### PR TITLE
Fix clipboard writes in sandboxed renderer

### DIFF
--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -29,6 +29,7 @@ async function loadAuthModule() {
 }
 
 const electronShell = (electron as { shell?: typeof import('electron').shell }).shell
+const electronClipboard = (electron as { clipboard?: typeof import('electron').clipboard }).clipboard
 const MAX_PROVIDER_ID_LENGTH = 128
 const MAX_PROVIDER_AUTH_METHOD_INDEX = 1_000
 const MAX_PROVIDER_AUTH_INPUTS = 20
@@ -37,6 +38,7 @@ const MAX_PROVIDER_AUTH_INPUT_VALUE_LENGTH = 8 * 1024
 const MAX_PROVIDER_AUTH_CODE_LENGTH = 16 * 1024
 const MAX_PROVIDER_AUTH_URL_LENGTH = 8 * 1024
 const MAX_PROVIDER_AUTH_INSTRUCTIONS_LENGTH = 4 * 1024
+const MAX_CLIPBOARD_TEXT_LENGTH = 2 * 1024 * 1024
 
 export async function ensureRuntimeAfterAuthLogin(input: {
   authenticated: boolean
@@ -239,6 +241,19 @@ export function registerAppHandlers(context: IpcHandlerContext) {
       }
     }
     return state
+  })
+
+  context.ipcMain.handle('clipboard:write-text', async (_event, textInput: unknown) => {
+    if (typeof textInput !== 'string') return false
+    if (!textInput || textInput.length > MAX_CLIPBOARD_TEXT_LENGTH) return false
+    if (!electronClipboard) return false
+    try {
+      electronClipboard.writeText(textInput)
+      return true
+    } catch (err) {
+      log('clipboard', `Failed to write clipboard text: ${err instanceof Error ? err.message : String(err)}`)
+      return false
+    }
   })
 
   context.ipcMain.handle('app:config', async () => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -49,6 +49,9 @@ const api: CoworkAPI = {
   confirm: {
     requestDestructive: (request) => ipcRenderer.invoke('confirm:request-destructive', request),
   },
+  clipboard: {
+    writeText: (text) => ipcRenderer.invoke('clipboard:write-text', text),
+  },
   tools: {
     list: (options) => ipcRenderer.invoke('tool:list', options),
   },

--- a/apps/desktop/src/renderer/components/chat/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownContent.tsx
@@ -3,6 +3,7 @@ import DOMPurify from 'dompurify'
 import morphdom from 'morphdom'
 import { marked } from 'marked'
 import { streamMarkdown } from './markdown-stream'
+import { writeTextToClipboard } from '../../helpers/clipboard'
 
 type CacheEntry = {
   html: string
@@ -194,7 +195,8 @@ export function MarkdownContent({
       if (!(button instanceof HTMLButtonElement)) return
       const content = extractCodeText(button)
       if (!content) return
-      await navigator.clipboard.writeText(content)
+      const copied = await writeTextToClipboard(content)
+      if (!copied) return
       setCopyButtonState(button, true)
       window.setTimeout(() => {
         setCopyButtonState(button, false)

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -22,6 +22,7 @@ import {
   UI_FONT_OPTIONS,
 } from '../../helpers/theme'
 import { confirmAppReset } from '../../helpers/destructive-actions'
+import { writeTextToClipboard } from '../../helpers/clipboard'
 import { ProviderAuthControls } from '../provider/ProviderAuthControls'
 
 function ThemePreviewCard({
@@ -809,8 +810,8 @@ function StoragePanel({
         setDiagnosticsStatus('error')
         return
       }
-      await navigator.clipboard.writeText(bundle)
-      setDiagnosticsStatus('copied')
+      const copied = await writeTextToClipboard(bundle)
+      setDiagnosticsStatus(copied ? 'copied' : 'error')
       setTimeout(() => setDiagnosticsStatus('idle'), 3_000)
     } catch (err) {
       console.error('Failed to export diagnostics:', err)

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -5,6 +5,7 @@ import { loadSessionMessages } from '../../helpers/loadSessionMessages'
 import { DiffViewer } from '../chat/DiffViewer'
 import { confirmSessionDelete } from '../../helpers/destructive-actions'
 import { t } from '../../helpers/i18n'
+import { writeTextToClipboard } from '../../helpers/clipboard'
 
 // Kick in virtualization only above this count. Below it, plain
 // rendering is a wash (~8ms mount for 50 rows) and avoids the
@@ -283,10 +284,10 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
           <button onClick={async () => {
             const url = await window.coworkApi.session.share(menuId)
             if (url) {
-              navigator.clipboard.writeText(url)
+              const copied = await writeTextToClipboard(url)
               // Brief visual feedback
               const btn = document.activeElement as HTMLElement
-              if (btn) btn.textContent = t('thread.linkCopied', 'Link copied!')
+              if (btn) btn.textContent = copied ? t('thread.linkCopied', 'Link copied!') : t('thread.linkCopyFailed', 'Copy failed')
               setTimeout(() => setMenuId(null), 800)
             } else {
               setMenuId(null)

--- a/apps/desktop/src/renderer/helpers/clipboard.ts
+++ b/apps/desktop/src/renderer/helpers/clipboard.ts
@@ -1,0 +1,14 @@
+export async function writeTextToClipboard(text: string) {
+  if (!text) return false
+
+  try {
+    if (window.coworkApi?.clipboard?.writeText) {
+      return window.coworkApi.clipboard.writeText(text)
+    }
+
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/tests/clipboard.smoke.test.ts
+++ b/apps/desktop/tests/clipboard.smoke.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { launchSmokeApp } from './smoke-helpers.ts'
+
+test('clipboard writes go through the preload and main IPC bridge', async () => {
+  const { app, page, cleanup } = await launchSmokeApp()
+  const previousText = await app.evaluate(({ clipboard }) => clipboard.readText())
+  try {
+    await page.waitForFunction(() => typeof window.coworkApi?.clipboard?.writeText === 'function')
+
+    const copied = await page.evaluate(async () => {
+      return window.coworkApi.clipboard.writeText('Open Cowork clipboard smoke')
+    })
+
+    assert.equal(copied, true)
+  } finally {
+    await app.evaluate(({ clipboard }, text) => {
+      clipboard.writeText(text)
+    }, previousText)
+    await cleanup()
+  }
+})

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -286,11 +286,34 @@ async function closeCdpSmokeApp(browser: Browser, port: number) {
 }
 
 async function closeSmokeApp(app: ElectronApplication) {
-  await app.close()
+  const processHandle = app.process()
+  let closed = false
+
+  const closePromise = app.close().then(() => {
+    closed = true
+  }).catch(() => {
+    // If Electron is already gone or wedged during shutdown, the
+    // process fallback below gives the smoke harness a bounded exit.
+  })
+
+  await Promise.race([closePromise, delay(10_000)])
+
+  if (!closed && processHandle && !processHandle.killed) {
+    processHandle.kill('SIGTERM')
+    await Promise.race([
+      new Promise<void>((resolveExit) => processHandle.once('exit', () => resolveExit())),
+      delay(5_000),
+    ])
+  }
+
+  if (!closed && processHandle && !processHandle.killed) {
+    processHandle.kill('SIGKILL')
+  }
+
   // Runtime reboot tests can leave the bundled opencode child exiting
   // slightly after Electron closes. Give the OS a moment to release
   // the temp tree before cleanup or relaunch.
-  await new Promise((done) => setTimeout(done, 1_000))
+  await delay(1_000)
 }
 
 async function bootstrapSmokeSettings(page: Page, appShellTimeoutMs = 30_000) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1302,6 +1302,9 @@ export interface CoworkAPI {
   confirm: {
     requestDestructive: (request: DestructiveConfirmationRequest) => Promise<DestructiveConfirmationGrant>
   }
+  clipboard: {
+    writeText: (text: string) => Promise<boolean>
+  }
   model: {
     info: () => Promise<ModelInfoSnapshot>
   }


### PR DESCRIPTION
## Summary
- route renderer clipboard writes through a typed Electron preload/main bridge
- replace direct code-snippet, diagnostics, and share-link clipboard writes
- add a clipboard smoke test that restores the previous clipboard contents

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --dir apps/desktop build
- node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test tests/clipboard.smoke.test.ts