### PR TITLE
Fix code scanning alerts

### DIFF
--- a/apps/desktop/src/main/artifact-attachments.ts
+++ b/apps/desktop/src/main/artifact-attachments.ts
@@ -1,7 +1,7 @@
 import { basename, extname } from 'path'
-import { readFileSync, statSync } from 'fs'
 import type { SessionArtifactAttachment } from '@open-cowork/shared'
 import { readChartArtifactSource } from './chart-artifacts.ts'
+import { readFileCheckedSync } from './fs-read.ts'
 
 export const MAX_COMPOSER_ATTACHMENT_BYTES = 20 * 1024 * 1024
 
@@ -30,13 +30,9 @@ export function inferArtifactMime(source: string): string {
 }
 
 export function buildArtifactAttachmentPayload(source: string): SessionArtifactAttachment {
-  const stats = statSync(source)
-  if (stats.size > MAX_COMPOSER_ATTACHMENT_BYTES) {
-    throw new Error('Artifact is too large to attach to the thread.')
-  }
+  const { bytes } = readFileCheckedSync(source, { maxBytes: MAX_COMPOSER_ATTACHMENT_BYTES })
 
   const mime = inferArtifactMime(source)
-  const bytes = readFileSync(source)
   return {
     mime,
     url: `data:${mime};base64,${bytes.toString('base64')}`,

--- a/apps/desktop/src/main/capability-catalog.ts
+++ b/apps/desktop/src/main/capability-catalog.ts
@@ -22,8 +22,11 @@ function humanize(value: string) {
 }
 
 function namespaceFromPattern(pattern: string) {
-  const match = pattern.match(/^mcp__([^_]+(?:-[^_]+)*)__/)
-  return match?.[1] || null
+  if (!pattern.startsWith('mcp__')) return null
+  const end = pattern.indexOf('__', 'mcp__'.length)
+  if (end <= 'mcp__'.length) return null
+  const namespace = pattern.slice('mcp__'.length, end)
+  return /^[a-zA-Z0-9-]+$/.test(namespace) ? namespace : null
 }
 
 function listRuntimeEligibleCustomAgents(

--- a/apps/desktop/src/main/diagnostics-export.ts
+++ b/apps/desktop/src/main/diagnostics-export.ts
@@ -1,4 +1,4 @@
-import { closeSync, openSync, readSync, statSync } from 'fs'
+import { closeSync, fstatSync, openSync, readSync } from 'fs'
 import { getPublicAppConfig } from './config-loader.ts'
 import { getLogFilePath } from './logger.ts'
 import { getPerfSnapshot } from './perf-metrics.ts'
@@ -21,21 +21,22 @@ const LOG_TAIL_MAX_BYTES = 512 * 1024
 function tailLogFile(path: string, lines: number, maxBytes: number): string {
   try {
     if (!path) return '(no log file configured)'
-    const stat = statSync(path)
-    const readBytes = Math.min(stat.size, maxBytes)
-    // Read the tail without loading the whole file into memory.
-    const buffer = Buffer.alloc(readBytes)
     const fd = openSync(path, 'r')
     try {
+      const stat = fstatSync(fd)
+      if (!stat.isFile()) return '(log path is not a file)'
+      const readBytes = Math.min(stat.size, maxBytes)
+      // Read the tail without loading the whole file into memory.
+      const buffer = Buffer.alloc(readBytes)
       readSync(fd, buffer, 0, readBytes, Math.max(0, stat.size - readBytes))
+      const text = buffer.toString('utf-8')
+      const split = text.split('\n')
+      // Drop the first partial line if we started mid-line.
+      const usable = stat.size > maxBytes ? split.slice(1) : split
+      return usable.slice(-lines).join('\n')
     } finally {
       closeSync(fd)
     }
-    const text = buffer.toString('utf-8')
-    const split = text.split('\n')
-    // Drop the first partial line if we started mid-line.
-    const usable = stat.size > maxBytes ? split.slice(1) : split
-    return usable.slice(-lines).join('\n')
   } catch (err) {
     return `(could not read log: ${(err as Error).message})`
   }

--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -245,7 +245,7 @@ function applyTaskTimingTransition(existing: TaskRunMeta, patch: Partial<TaskRun
 }
 
 export function resolveRootSession(sessionId?: string | null) {
-  if (!sessionId) return sessionId ?? undefined
+  if (!sessionId) return undefined
 
   let current = sessionId
   const seen = new Set<string>()

--- a/apps/desktop/src/main/fs-read.ts
+++ b/apps/desktop/src/main/fs-read.ts
@@ -1,0 +1,33 @@
+import { closeSync, fstatSync, openSync, readFileSync } from 'fs'
+
+export function readFileCheckedSync(
+  path: string,
+  options?: { maxBytes?: number },
+): { bytes: Buffer; size: number } {
+  // This opens an existing file read-only; it never creates temp files.
+  // Descriptor validation below is what closes the stat/read TOCTOU gap.
+  // codeql[js/insecure-temporary-file]
+  const fd = openSync(path, 'r')
+  try {
+    const stats = fstatSync(fd)
+    if (!stats.isFile()) {
+      throw new Error('Path is not a regular file.')
+    }
+    if (typeof options?.maxBytes === 'number' && stats.size > options.maxBytes) {
+      const error = new Error(`File is too large: ${stats.size} bytes exceeds ${options.maxBytes} bytes.`)
+      error.name = 'FileTooLargeError'
+      throw error
+    }
+    return { bytes: readFileSync(fd), size: stats.size }
+  } finally {
+    closeSync(fd)
+  }
+}
+
+export function readTextFileCheckedSync(
+  path: string,
+  options?: { maxBytes?: number },
+): { content: string; size: number } {
+  const { bytes, size } = readFileCheckedSync(path, options)
+  return { content: bytes.toString('utf-8'), size }
+}

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -15,6 +15,7 @@ import { renderChartSpecToSvg } from '../chart-renderer.ts'
 import { saveChartArtifact } from '../chart-artifacts.ts'
 import { checkForUpdates } from '../update-check.ts'
 import { resetAppData } from '../app-reset.ts'
+import { readFileCheckedSync, readTextFileCheckedSync } from '../fs-read.ts'
 import type {
   ChartSaveArtifactRequest,
   DestructiveConfirmationRequest,
@@ -468,14 +469,8 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     if (result.canceled || result.filePaths.length === 0) return null
     const path = result.filePaths[0]!
     try {
-      const fs = await import('fs')
-      const stats = fs.statSync(path)
       const MAX_BYTES = 8 * 1024 * 1024
-      if (stats.size > MAX_BYTES) {
-        log('error', `dialog:select-image rejected ${stats.size}B — over ${MAX_BYTES}B cap`)
-        return null
-      }
-      const buffer = fs.readFileSync(path)
+      const { bytes } = readFileCheckedSync(path, { maxBytes: MAX_BYTES })
       const ext = path.toLowerCase().split('.').pop() || ''
       const mime = ext === 'jpg' || ext === 'jpeg'
         ? 'image/jpeg'
@@ -484,7 +479,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
           : ext === 'gif'
             ? 'image/gif'
             : 'image/png'
-      return { mime, base64: buffer.toString('base64') }
+      return { mime, base64: bytes.toString('base64') }
     } catch (err) {
       log('error', `dialog:select-image read failed: ${err instanceof Error ? err.message : String(err)}`)
       return null
@@ -505,14 +500,8 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     if (result.canceled || result.filePaths.length === 0) return null
     const path = result.filePaths[0]!
     try {
-      const fs = await import('fs')
-      const stats = fs.statSync(path)
       const MAX_BYTES = 2 * 1024 * 1024
-      if (stats.size > MAX_BYTES) {
-        log('error', `dialog:open-json rejected ${stats.size}B — over ${MAX_BYTES}B cap`)
-        return null
-      }
-      const raw = fs.readFileSync(path, 'utf-8')
+      const { content: raw } = readTextFileCheckedSync(path, { maxBytes: MAX_BYTES })
       const content = JSON.parse(raw)
       const filename = path.split(/[\\/]/).pop() || 'file.json'
       return { content, filename }

--- a/apps/desktop/src/main/jsonc.ts
+++ b/apps/desktop/src/main/jsonc.ts
@@ -1,5 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync } from 'fs'
 import { dirname, extname } from 'path'
+import { writeFileAtomic } from './fs-atomic.ts'
+import { readTextFileCheckedSync } from './fs-read.ts'
 
 export type JsonObject = Record<string, unknown>
 
@@ -119,15 +121,21 @@ export function parseJsoncText<T extends JsonObject = JsonObject>(raw: string): 
 }
 
 export function readJsoncFile<T extends JsonObject = JsonObject>(path: string): T {
-  if (!existsSync(path)) return {} as T
-  const raw = readFileSync(path, 'utf-8').trim()
+  let raw: string
+  try {
+    raw = readTextFileCheckedSync(path).content.trim()
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return {} as T
+    throw error
+  }
   if (!raw) return {} as T
   return parseJsoncText<T>(raw)
 }
 
 export function writeJsonFile(path: string, value: JsonObject) {
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`)
+  writeFileAtomic(path, `${JSON.stringify(value, null, 2)}\n`)
 }
 
 export function jsonConfigCandidates(path: string) {
@@ -386,14 +394,25 @@ export function writeTopLevelObjectPropertyFile(
   value: JsonObject | null,
 ) {
   const path = resolveExistingJsonConfigPath(preferredPath)
-  if (!existsSync(path) || !readFileSync(path, 'utf-8').trim()) {
+  let raw: string
+  try {
+    raw = readTextFileCheckedSync(path).content
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') {
+      raw = ''
+    } else {
+      throw error
+    }
+  }
+
+  if (!raw.trim()) {
     if (value === null) return path
     writeJsonFile(path, { [key]: value })
     return path
   }
 
-  const raw = readFileSync(path, 'utf-8')
   const next = updateTopLevelObjectPropertyInJsonc(raw, key, value)
-  writeFileSync(path, next.endsWith('\n') ? next : `${next}\n`)
+  writeFileAtomic(path, next.endsWith('\n') ? next : `${next}\n`)
   return path
 }

--- a/apps/desktop/src/main/native-customizations.ts
+++ b/apps/desktop/src/main/native-customizations.ts
@@ -2,10 +2,8 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
-  readFileSync,
   rmSync,
   statSync,
-  writeFileSync,
 } from 'fs'
 import { basename, dirname, join, relative, resolve } from 'path'
 import type {
@@ -24,6 +22,8 @@ import {
   writeTopLevelObjectPropertyFile,
 } from './jsonc.ts'
 import { log } from './logger.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
+import { readTextFileCheckedSync } from './fs-read.ts'
 import {
   getMachineAgentsDir,
   getMachineOpencodeDir,
@@ -122,7 +122,6 @@ function readManagedMcpMetadata(
   directory?: string | null,
 ): Record<string, ManagedMcpMetadata> {
   const path = mcpMetaPathForTarget(scope, directory)
-  if (!existsSync(path)) return {}
   try {
     const value = readJsoncFile<JsonRecord>(path)
     return Object.fromEntries(
@@ -259,21 +258,26 @@ function updateScopedMcpConfig(
 
 function listFiles(root: string, current = root): Array<{ path: string; content: string }> {
   const files: Array<{ path: string; content: string }> = []
-  if (!existsSync(current)) return files
+  let entries
+  try {
+    entries = readdirSync(current, { withFileTypes: true })
+  } catch {
+    return files
+  }
 
-  for (const entry of readdirSync(current)) {
-    const fullPath = join(current, entry)
-    const stats = statSync(fullPath)
-    if (stats.isDirectory()) {
+  for (const entry of entries) {
+    const fullPath = join(current, entry.name)
+    if (entry.isDirectory()) {
       files.push(...listFiles(root, fullPath))
       continue
     }
+    if (!entry.isFile()) continue
 
     const filePath = relative(root, fullPath).replace(/\\/g, '/')
     if (filePath === 'SKILL.md') continue
     files.push({
       path: filePath,
-      content: readFileSync(fullPath, 'utf-8'),
+      content: readTextFileCheckedSync(fullPath).content,
     })
   }
 
@@ -292,7 +296,7 @@ function canonicalizeManagedSkillContent(skillName: string, skillFile: string, r
   }
 
   try {
-    writeFileSync(skillFile, canonicalContent)
+    writeFileAtomic(skillFile, canonicalContent)
   } catch (error) {
     log(
       'error',
@@ -305,29 +309,28 @@ function canonicalizeManagedSkillContent(skillName: string, skillFile: string, r
 
 function readScopedSkills(scope: NativeConfigScope, directory?: string | null) {
   const root = ensureDirectory(skillsDirForTarget(scope, directory))
-  const entries = existsSync(root) ? readdirSync(root) : []
+  const entries = readdirSync(root, { withFileTypes: true })
   const skills: CustomSkillConfig[] = []
 
   for (const entry of entries) {
-    const skillRoot = join(root, entry)
-    let stats
+    if (!entry.isDirectory()) continue
+    const skillRoot = join(root, entry.name)
+
+    const skillFile = join(skillRoot, 'SKILL.md')
+    let rawContent: string
     try {
-      stats = statSync(skillRoot)
+      rawContent = readTextFileCheckedSync(skillFile).content
     } catch {
       continue
     }
-    if (!stats.isDirectory()) continue
 
-    const skillFile = join(skillRoot, 'SKILL.md')
-    if (!existsSync(skillFile)) continue
-
-    const content = canonicalizeManagedSkillContent(entry, skillFile, readFileSync(skillFile, 'utf-8'))
+    const content = canonicalizeManagedSkillContent(entry.name, skillFile, rawContent)
     const toolIds = parseToolIdsFromFrontmatter(content)
 
     skills.push({
       scope,
       directory: scope === 'project' ? targetDirectory(scope, directory) : null,
-      name: entry,
+      name: entry.name,
       content,
       files: listFiles(skillRoot),
       ...(toolIds.length > 0 ? { toolIds } : {}),
@@ -536,7 +539,6 @@ function agentMarkdownPath(root: string, name: string, enabled: boolean) {
 
 function readManagedAgentMetadata(root: string, name: string): ManagedAgentMetadata {
   const path = agentMetaPath(root, name)
-  if (!existsSync(path)) return {}
   try {
     const value = readJsoncFile<JsonRecord>(path)
     return {
@@ -574,25 +576,24 @@ function serializeCustomAgentMarkdown(agent: CustomAgentConfig, permission: Reco
 
 function readScopedAgents(scope: NativeConfigScope, directory?: string | null) {
   const root = ensureDirectory(agentsDirForTarget(scope, directory))
-  const entries = existsSync(root) ? readdirSync(root) : []
+  const entries = readdirSync(root, { withFileTypes: true })
   const agents: CustomAgentConfig[] = []
 
   for (const entry of entries) {
-    if (!entry.endsWith('.md') && !entry.endsWith('.disabled.md')) continue
-    if (entry.endsWith(getSidecarJsonSuffix())) continue
+    if (!entry.isFile()) continue
+    if (!entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')) continue
+    if (entry.name.endsWith(getSidecarJsonSuffix())) continue
 
-    const fullPath = join(root, entry)
-    let stats
+    const fullPath = join(root, entry.name)
+    let content: string
     try {
-      stats = statSync(fullPath)
+      content = readTextFileCheckedSync(fullPath).content
     } catch {
       continue
     }
-    if (!stats.isFile()) continue
 
-    const enabled = entry.endsWith('.md') && !entry.endsWith('.disabled.md')
-    const name = basename(entry, enabled ? '.md' : '.disabled.md')
-    const content = readFileSync(fullPath, 'utf-8')
+    const enabled = entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')
+    const name = basename(entry.name, enabled ? '.md' : '.disabled.md')
     const metadata = readManagedAgentMetadata(root, name)
     const frontmatter = parseFrontmatter(content)
     const permission = frontmatter.permission
@@ -632,11 +633,12 @@ export function readSkillBundleDirectory(directory: string, target: ScopedArtifa
   }
 
   const skillFile = join(root, 'SKILL.md')
-  if (!existsSync(skillFile) || !statSync(skillFile).isFile()) {
+  let rawContent: string
+  try {
+    rawContent = readTextFileCheckedSync(skillFile).content
+  } catch {
     throw new Error('The selected directory does not contain a SKILL.md file.')
   }
-
-  const rawContent = readFileSync(skillFile, 'utf-8')
   const importedName = normalizeSkillBundleName(
     extractSkillFrontmatterName(rawContent)
       || basename(root),
@@ -725,7 +727,7 @@ export function saveCustomSkill(skill: CustomSkillConfig) {
     ? writeToolIdsIntoFrontmatter(contentToWrite, skill.toolIds)
     : contentToWrite
   assertValidOpenCodeSkillBundle({ name: skill.name, content: contentToWrite }, 'Custom skill bundle')
-  writeFileSync(join(root, 'SKILL.md'), contentToWrite)
+  writeFileAtomic(join(root, 'SKILL.md'), contentToWrite)
 
   for (const file of skill.files || []) {
     if (!isSafeRelativePath(file.path)) {
@@ -737,7 +739,7 @@ export function saveCustomSkill(skill: CustomSkillConfig) {
       throw new Error(`Skill file escapes bundle root: ${file.path}`)
     }
     mkdirSync(dirname(output), { recursive: true })
-    writeFileSync(output, file.content)
+    writeFileAtomic(output, file.content)
   }
 
   return true
@@ -761,7 +763,7 @@ export function saveCustomAgent(agent: CustomAgentConfig, permission: Record<str
   const root = ensureDirectory(agentsDirForTarget(agent.scope, agent.directory))
   rmSync(agentMarkdownPath(root, agent.name, true), { force: true })
   rmSync(agentMarkdownPath(root, agent.name, false), { force: true })
-  writeFileSync(
+  writeFileAtomic(
     agentMarkdownPath(root, agent.name, agent.enabled),
     serializeCustomAgentMarkdown(agent, permission),
   )

--- a/apps/desktop/src/main/session-diff-fallback.ts
+++ b/apps/desktop/src/main/session-diff-fallback.ts
@@ -4,8 +4,8 @@ import type {
   SessionView,
   ToolCall,
 } from '@open-cowork/shared'
-import { existsSync, readFileSync, statSync } from 'fs'
 import { relative, resolve } from 'path'
+import { readTextFileCheckedSync } from './fs-read.ts'
 
 const WRITE_LIKE_TOOLS = new Set(['write', 'edit', 'multi_edit', 'str_replace', 'apply_patch'])
 const MAX_SYNTHETIC_DIFF_BYTES = 256 * 1024
@@ -69,29 +69,12 @@ function buildAddedFilePatch(contents: string) {
 function buildSyntheticDiff(rootDir: string, candidate: SessionArtifactCandidate): SessionFileDiff | null {
   const absolutePath = resolve(candidate.filePath)
   if (!isContainedPath(rootDir, absolutePath)) return null
-  if (!existsSync(absolutePath)) return null
-  let stats
-  try {
-    stats = statSync(absolutePath)
-  } catch {
-    return null
-  }
-  if (!stats.isFile()) return null
-
-  if (stats.size > MAX_SYNTHETIC_DIFF_BYTES) {
-    return {
-      file: toDisplayPath(rootDir, absolutePath),
-      patch: '',
-      additions: 0,
-      deletions: 0,
-      status: 'added',
-    }
-  }
-
   let contents: string
   try {
-    contents = readFileSync(absolutePath, 'utf8')
-  } catch {
+    const file = readTextFileCheckedSync(absolutePath, { maxBytes: MAX_SYNTHETIC_DIFF_BYTES })
+    contents = file.content
+  } catch (error) {
+    if ((error as Error).name !== 'FileTooLargeError') return null
     return {
       file: toDisplayPath(rootDir, absolutePath),
       patch: '',

--- a/apps/desktop/src/renderer/chart-frame.ts
+++ b/apps/desktop/src/renderer/chart-frame.ts
@@ -56,6 +56,30 @@ function postToParent(message: ChartResponseMessage) {
   window.parent.postMessage(message, parentOrigin)
 }
 
+function expectedParentOrigin() {
+  try {
+    return document.referrer
+      ? new URL(document.referrer).origin
+      : window.location.origin
+  } catch {
+    return window.location.origin
+  }
+}
+
+function isOpaqueFileOrigin(origin: string) {
+  return origin === 'null' || origin === 'file://'
+}
+
+function parentOriginMatches(eventOrigin: string) {
+  const expectedOrigin = expectedParentOrigin()
+  return eventOrigin === expectedOrigin
+    || (isOpaqueFileOrigin(eventOrigin) && isOpaqueFileOrigin(expectedOrigin))
+}
+
+function shouldHandleParentMessage(event: MessageEvent) {
+  return event.source === window.parent && parentOriginMatches(event.origin)
+}
+
 function measureChartHeight() {
   if (!root) return 0
   const svg = root.querySelector('svg')
@@ -143,6 +167,7 @@ async function captureChart(message: ChartCaptureMessage) {
 }
 
 window.addEventListener('message', (event) => {
+  if (!shouldHandleParentMessage(event)) return
   const data = event.data as ChartRenderMessage | ChartCaptureMessage | undefined
   if (!data || typeof data.requestId !== 'number') return
   if (data.type === 'render-chart' && (data as ChartRenderMessage).spec) {

--- a/mcps/skills/src/index.ts
+++ b/mcps/skills/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
+import { closeSync, fstatSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { dirname, join, relative, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -36,34 +36,55 @@ export function isSafeRelativePath(value: string) {
 
 function listBundleFiles(root: string, current = root): Array<{ path: string; content: string }> {
   const files: Array<{ path: string; content: string }> = []
-  if (!existsSync(current)) return files
+  let entries
+  try {
+    entries = readdirSync(current, { withFileTypes: true })
+  } catch {
+    return files
+  }
 
-  for (const entry of readdirSync(current)) {
-    const fullPath = join(current, entry)
-    const stats = statSync(fullPath)
-    if (stats.isDirectory()) {
+  for (const entry of entries) {
+    const fullPath = join(current, entry.name)
+    if (entry.isDirectory()) {
       files.push(...listBundleFiles(root, fullPath))
       continue
     }
+    if (!entry.isFile()) continue
 
     const filePath = relative(root, fullPath).replace(/\\/g, '/')
     if (filePath === 'SKILL.md') continue
     files.push({
       path: filePath,
-      content: readFileSync(fullPath, 'utf-8'),
+      content: readTextFileCheckedSync(fullPath),
     })
   }
 
   return files.sort((a, b) => a.path.localeCompare(b.path))
 }
 
+function readTextFileCheckedSync(path: string) {
+  const fd = openSync(path, 'r')
+  try {
+    const stats = fstatSync(fd)
+    if (!stats.isFile()) throw new Error('Path is not a regular file.')
+    return readFileSync(fd, 'utf-8')
+  } finally {
+    closeSync(fd)
+  }
+}
+
 function readSkillBundle(name: string) {
   const root = skillDir(name)
   const skillFile = join(root, 'SKILL.md')
-  if (!existsSync(skillFile)) return null
+  let content: string
+  try {
+    content = readTextFileCheckedSync(skillFile)
+  } catch {
+    return null
+  }
   return {
     name,
-    content: readFileSync(skillFile, 'utf-8'),
+    content,
     files: listBundleFiles(root),
   }
 }
@@ -95,13 +116,13 @@ server.tool(
   async () => {
     const root = skillsRoot()
     const bundles = readdirSync(root)
-      .filter((entry) => existsSync(join(root, entry, 'SKILL.md')))
-      .sort()
-      .map((name) => {
-        const bundle = readSkillBundle(name)
+      .map((entry) => readSkillBundle(entry))
+      .filter((bundle): bundle is NonNullable<ReturnType<typeof readSkillBundle>> => bundle !== null)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((bundle) => {
         return {
-          name,
-          fileCount: bundle?.files.length || 0,
+          name: bundle.name,
+          fileCount: bundle.files.length,
         }
       })
 

--- a/tests/artifact-attachments.test.ts
+++ b/tests/artifact-attachments.test.ts
@@ -1,6 +1,5 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { tmpdir } from 'node:os'
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { buildArtifactAttachmentPayload, inferArtifactMime } from '../apps/desktop/src/main/artifact-attachments.ts'
@@ -8,6 +7,12 @@ import { saveChartArtifact } from '../apps/desktop/src/main/chart-artifacts.ts'
 
 const ONE_PX_PNG =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+function testTempDir(prefix: string) {
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  return mkdtempSync(join(parent, prefix))
+}
 
 test('inferArtifactMime recognizes common chart and text artifact extensions', () => {
   assert.equal(inferArtifactMime('/tmp/chart.png'), 'image/png')
@@ -17,7 +22,7 @@ test('inferArtifactMime recognizes common chart and text artifact extensions', (
 })
 
 test('buildArtifactAttachmentPayload returns a data-url attachment for generic artifacts', () => {
-  const root = mkdtempSync(join(tmpdir(), 'artifact-attachment-'))
+  const root = testTempDir('artifact-attachment-')
   try {
     const filePath = join(root, 'summary.txt')
     writeFileSync(filePath, 'hello world', 'utf-8')

--- a/tests/capability-catalog.test.ts
+++ b/tests/capability-catalog.test.ts
@@ -1,7 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { getCapabilityTool, listCapabilitySkills, listCapabilityTools } from '../apps/desktop/src/main/capability-catalog.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
@@ -23,7 +22,9 @@ test('built-in capabilities expose discoverable metadata without source parsing'
 })
 
 test('capability skills exclude invalid custom bundles that the OpenCode runtime would not discover', async () => {
-  const tempUserData = join(tmpdir(), `opencowork-capability-skills-${Date.now()}`)
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  const tempUserData = mkdtempSync(join(parent, 'opencowork-capability-skills-'))
   const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
 
   process.env.OPEN_COWORK_USER_DATA_DIR = tempUserData

--- a/tests/custom-skills.test.ts
+++ b/tests/custom-skills.test.ts
@@ -1,12 +1,17 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
 import { join } from 'path'
 import { readSkillBundleDirectory, saveCustomSkill } from '../apps/desktop/src/main/custom-skills.ts'
 
+function testTempDir(prefix: string) {
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  return mkdtempSync(join(parent, prefix))
+}
+
 test('readSkillBundleDirectory loads SKILL.md and supporting files from a bundle directory', () => {
-  const root = mkdtempSync(join(tmpdir(), 'opencowork-skill-bundle-'))
+  const root = testTempDir('opencowork-skill-bundle-')
   const bundle = join(root, 'Chart Creator')
   mkdirSync(join(bundle, 'references'), { recursive: true })
   writeFileSync(join(bundle, 'SKILL.md'), '---\nname: Chart Creator\ndescription: "Build charts"\n---\n# Chart Creator')
@@ -32,7 +37,7 @@ test('readSkillBundleDirectory loads SKILL.md and supporting files from a bundle
 })
 
 test('readSkillBundleDirectory canonicalizes the imported frontmatter name to the saved bundle id', () => {
-  const root = mkdtempSync(join(tmpdir(), 'opencowork-skill-bundle-'))
+  const root = testTempDir('opencowork-skill-bundle-')
   const bundle = join(root, 'Chart Creator')
   mkdirSync(bundle, { recursive: true })
   writeFileSync(join(bundle, 'SKILL.md'), '---\nname: Chart Creator\ndescription: "Build charts"\n---\n# Chart Creator')

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -1,7 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   listCustomAgents,
@@ -11,8 +10,14 @@ import {
   removeCustomAgent,
 } from '../apps/desktop/src/main/native-customizations.ts'
 
+function testTempDir(prefix: string) {
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  return mkdtempSync(join(parent, prefix))
+}
+
 test('project-scoped MCP edits preserve JSONC comments and unrelated keys', () => {
-  const projectRoot = mkdtempSync(join(tmpdir(), 'opencowork-native-config-'))
+  const projectRoot = testTempDir('opencowork-native-config-')
   const configPath = join(projectRoot, '.opencowork', 'config.jsonc')
   const metadataPath = join(projectRoot, '.opencowork', 'mcp.open-cowork.json')
   mkdirSync(join(projectRoot, '.opencowork'), { recursive: true })
@@ -66,7 +71,7 @@ test('project-scoped MCP edits preserve JSONC comments and unrelated keys', () =
 })
 
 test('custom agents derive tool and skill selections from native markdown permissions without a sidecar', () => {
-  const projectRoot = mkdtempSync(join(tmpdir(), 'opencowork-native-agents-'))
+  const projectRoot = testTempDir('opencowork-native-agents-')
   const agentsDir = join(projectRoot, '.opencowork', 'agents')
   const configPath = join(projectRoot, '.opencowork', 'config.json')
 
@@ -104,7 +109,7 @@ Work carefully.
 })
 
 test('custom agent avatars round-trip through the managed sidecar metadata', () => {
-  const projectRoot = mkdtempSync(join(tmpdir(), 'opencowork-native-agent-avatar-'))
+  const projectRoot = testTempDir('opencowork-native-agent-avatar-')
 
   try {
     saveCustomAgent(

--- a/tests/runtime-config-builder.test.ts
+++ b/tests/runtime-config-builder.test.ts
@@ -1,7 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
-import { tmpdir } from 'os'
 import { join } from 'path'
 import { buildProviderRuntimeConfig, buildRuntimeConfig } from '../apps/desktop/src/main/runtime-config-builder.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
@@ -9,8 +8,14 @@ import { loadSettings, saveSettings } from '../apps/desktop/src/main/settings.ts
 import { removeCustomAgent, removeCustomMcp, saveCustomAgent, saveCustomMcp } from '../apps/desktop/src/main/native-customizations.ts'
 import { getMachineSkillsDir } from '../apps/desktop/src/main/runtime-paths.ts'
 
+function testTempDir(prefix: string) {
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  return mkdtempSync(join(parent, prefix))
+}
+
 test('buildRuntimeConfig resolves env-backed custom providers and project custom MCP permissions', () => {
-  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-runtime-config-'))
+  const tempRoot = testTempDir('opencowork-runtime-config-')
   const configDir = join(tempRoot, 'downstream')
   const projectRoot = join(tempRoot, 'project')
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
@@ -132,7 +137,7 @@ test('buildProviderRuntimeConfig preserves configured custom provider options', 
 })
 
 test('buildRuntimeConfig registers project-scoped custom agents in config.agent so the primary can delegate to them', () => {
-  const projectRoot = mkdtempSync(join(tmpdir(), 'opencowork-custom-agent-'))
+  const projectRoot = testTempDir('opencowork-custom-agent-')
   const originalSettings = loadSettings()
 
   saveCustomAgent(
@@ -166,7 +171,7 @@ test('buildRuntimeConfig registers project-scoped custom agents in config.agent 
 })
 
 test('buildRuntimeConfig only advertises skills that match OpenCode bundle rules', () => {
-  const tempUserData = mkdtempSync(join(tmpdir(), 'opencowork-runtime-skills-'))
+  const tempUserData = testTempDir('opencowork-runtime-skills-')
   const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
 
   process.env.OPEN_COWORK_USER_DATA_DIR = tempUserData
@@ -189,10 +194,11 @@ test('buildRuntimeConfig only advertises skills that match OpenCode bundle rules
 })
 
 test('buildRuntimeConfig gives the charts agent explicit access to the managed chart skill directory', () => {
-  const runtimeConfig = buildRuntimeConfig('/tmp/open-cowork-charts-project') as Record<string, any>
+  const projectRoot = join(process.cwd(), '.open-cowork-test', 'open-cowork-charts-project')
+  const runtimeConfig = buildRuntimeConfig(projectRoot) as Record<string, any>
 
   assert.equal(
-    runtimeConfig.agent?.charts?.permission?.external_directory?.['/tmp/open-cowork-charts-project/.opencowork/skill-bundles/chart-creator/*'],
+    runtimeConfig.agent?.charts?.permission?.external_directory?.[`${projectRoot}/.opencowork/skill-bundles/chart-creator/*`],
     'allow',
   )
   assert.equal(
@@ -202,7 +208,7 @@ test('buildRuntimeConfig gives the charts agent explicit access to the managed c
 })
 
 test('buildRuntimeConfig still registers custom agents whose app-owned skills need frontmatter healing', () => {
-  const tempUserData = mkdtempSync(join(tmpdir(), 'opencowork-runtime-skill-heal-'))
+  const tempUserData = testTempDir('opencowork-runtime-skill-heal-')
   const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
 
   process.env.OPEN_COWORK_USER_DATA_DIR = tempUserData
@@ -260,7 +266,7 @@ test('buildProviderRuntimeConfig bridges custom provider credentials into env pl
   // bridge that was missing before: custom providers ignored credentials
   // entirely and only saw `process.env`, which broke the Settings UI for
   // GUI-launched apps.
-  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-cred-bridge-'))
+  const tempRoot = testTempDir('opencowork-cred-bridge-')
   const configDir = join(tempRoot, 'downstream')
   mkdirSync(configDir, { recursive: true })
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
@@ -324,7 +330,7 @@ test('buildRuntimeConfig does NOT fall back to process.env for custom provider c
   // resolves to empty string — never to a matching shell env var. A
   // stale `DATABRICKS_TOKEN` sitting in a teammate's shell must not
   // get picked up silently in place of the user's Settings entry.
-  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-cred-noenvleak-'))
+  const tempRoot = testTempDir('opencowork-cred-noenvleak-')
   const configDir = join(tempRoot, 'downstream')
   mkdirSync(configDir, { recursive: true })
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
@@ -384,7 +390,7 @@ test('buildRuntimeConfig mixes credential-scoped and non-credential placeholders
   //   - `baseUrl` NOT in credentials[] (the shell export is a
   //     legitimate escape hatch for power users tweaking endpoints).
   // Asserts the two rules coexist in the same provider.
-  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-mixed-placeholders-'))
+  const tempRoot = testTempDir('opencowork-mixed-placeholders-')
   const configDir = join(tempRoot, 'downstream')
   mkdirSync(configDir, { recursive: true })
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
@@ -494,7 +500,7 @@ test('buildRuntimeConfig provisions selected built-in providers with stored cred
 })
 
 test('buildRuntimeConfig supports OpenCode-native providers without required app-stored API keys', () => {
-  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-runtime-native-provider-'))
+  const tempRoot = testTempDir('opencowork-runtime-native-provider-')
   const configDir = join(tempRoot, 'downstream')
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
   const originalSettings = loadSettings()
@@ -666,7 +672,7 @@ test('buildRuntimeConfig accepts already-prefixed direct built-in model ids with
 })
 
 test('buildRuntimeConfig supports downstream OpenCode-native providers with runtime-owned model catalogs', () => {
-  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-runtime-builtin-provider-'))
+  const tempRoot = testTempDir('opencowork-runtime-builtin-provider-')
   const configDir = join(tempRoot, 'downstream')
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
   const originalSettings = loadSettings()

--- a/tests/sandbox-storage.test.ts
+++ b/tests/sandbox-storage.test.ts
@@ -1,13 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { cleanupSandboxStorage, cleanupSandboxWorkspaceForSession, getSandboxStorageStats } from '../apps/desktop/src/main/sandbox-storage.ts'
 import { flushSessionRegistryWrites, removeSessionRecord, toSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
 
 function uniqueSandboxRoot(name: string) {
-  return join(tmpdir(), `open-cowork-sandbox-test-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  return mkdtempSync(join(parent, `sandbox-storage-${name}-`))
 }
 
 function writeWorkspaceFile(directory: string, filename: string, content: string) {

--- a/tests/session-diff-fallback.test.ts
+++ b/tests/session-diff-fallback.test.ts
@@ -1,14 +1,19 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
-import { tmpdir } from 'os'
 import type { SessionView, ToolCall } from '@open-cowork/shared'
 import {
   buildSyntheticSessionDiffs,
   mergeSessionDiffsWithSynthetic,
   summarizeSessionDiffs,
 } from '../apps/desktop/src/main/session-diff-fallback.ts'
+
+function testTempDir(prefix: string) {
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  return mkdtempSync(join(parent, prefix))
+}
 
 function createEmptyView(toolCalls: ToolCall[]): SessionView {
   return {
@@ -38,7 +43,7 @@ function createEmptyView(toolCalls: ToolCall[]): SessionView {
 }
 
 test('buildSyntheticSessionDiffs turns write artifacts into added-file diffs', () => {
-  const root = mkdtempSync(join(tmpdir(), 'open-cowork-diff-'))
+  const root = testTempDir('open-cowork-diff-')
   try {
     const reportPath = join(root, 'report.md')
     writeFileSync(reportPath, '# Report\n\nHello\n')
@@ -66,8 +71,8 @@ test('buildSyntheticSessionDiffs turns write artifacts into added-file diffs', (
 })
 
 test('buildSyntheticSessionDiffs ignores write artifacts outside the session root', () => {
-  const root = mkdtempSync(join(tmpdir(), 'open-cowork-diff-root-'))
-  const outside = mkdtempSync(join(tmpdir(), 'open-cowork-diff-outside-'))
+  const root = testTempDir('open-cowork-diff-root-')
+  const outside = testTempDir('open-cowork-diff-outside-')
   try {
     const outsidePath = join(outside, 'secret.txt')
     writeFileSync(outsidePath, 'nope\n')
@@ -90,7 +95,7 @@ test('buildSyntheticSessionDiffs ignores write artifacts outside the session roo
 })
 
 test('mergeSessionDiffsWithSynthetic appends write-only files without duplicating SDK diffs', () => {
-  const root = mkdtempSync(join(tmpdir(), 'open-cowork-diff-merge-'))
+  const root = testTempDir('open-cowork-diff-merge-')
   try {
     const reportPath = join(root, 'report.md')
     writeFileSync(reportPath, '# Report\n')


### PR DESCRIPTION
## Summary
- replace TOCTOU-prone stat/read pairs with descriptor-checked reads and atomic JSON/customization writes
- add explicit chart-frame postMessage origin validation
- remove ReDoS/trivial-conditional/insecure-temp-file findings

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check