### PR TITLE
Make packaged runtime self-contained

### DIFF
--- a/apps/desktop/src/main/runtime-mcp.ts
+++ b/apps/desktop/src/main/runtime-mcp.ts
@@ -28,6 +28,24 @@ function mcpPath(name: string) {
   return resourcePath('mcps', name, 'dist', 'index.js')
 }
 
+export function resolveBundledMcpNodeCommand(scriptPath: string, options: {
+  isPackaged?: boolean
+  executablePath?: string
+} = {}): { command: string[]; environment: Record<string, string> } {
+  const isPackaged = options.isPackaged ?? Boolean(electronApp?.isPackaged)
+  if (!isPackaged) {
+    return { command: ['node', scriptPath], environment: {} }
+  }
+
+  // Packaged users should not need a system Node install. Electron can run
+  // as Node for child scripts when ELECTRON_RUN_AS_NODE is set, and
+  // OpenCode passes this environment block to the spawned MCP process.
+  return {
+    command: [options.executablePath || process.execPath, scriptPath],
+    environment: { ELECTRON_RUN_AS_NODE: '1' },
+  }
+}
+
 export type ResolvedRuntimeMcpEntry =
   | {
     type: 'local'
@@ -166,11 +184,14 @@ function googleAuthEnv(mcpName: string, googleAuth: boolean | undefined): Record
 
 function buildBuiltInMcpEntry(builtin: BundleMcp, settings: CoworkSettings): ResolvedRuntimeMcpEntry | null {
   if (builtin.type === 'local') {
+    const nodeCommand = builtin.command
+      ? { command: builtin.command, environment: {} }
+      : resolveBundledMcpNodeCommand(mcpPath(builtin.packageName || builtin.name))
     const entry: ResolvedRuntimeMcpEntry = {
       type: 'local',
-      command: builtin.command || ['node', mcpPath(builtin.packageName || builtin.name)],
+      command: nodeCommand.command,
     }
-    const env: Record<string, string> = {}
+    const env: Record<string, string> = { ...nodeCommand.environment }
 
     for (const envSetting of builtin.envSettings || []) {
       const value = getIntegrationCredentialValue(settings, builtin.name, envSetting.key)

--- a/apps/desktop/src/main/runtime-opencode-cli.ts
+++ b/apps/desktop/src/main/runtime-opencode-cli.ts
@@ -69,38 +69,40 @@ export function getBundledOpencodeVersion(): string | null {
   }
 }
 
+function prependPathEntry(entry: string, entries: string[]) {
+  return [entry, ...entries.filter((candidate) => candidate !== entry)].join(delimiter)
+}
+
 export function applyBundledOpencodeCliEnvironment() {
   const wrapper = resolveBundledOpencodeWrapperPath()
   const binary = resolveBundledOpencodeBinaryPath()
 
-  // The wrapper is mandatory. Without it there's nothing on PATH for the
-  // SDK's createOpencode() to spawn, and the app cannot start.
-  if (!wrapper) {
-    if (electronApp?.isPackaged) {
-      throw new Error('Bundled OpenCode CLI is missing from the packaged app')
-    }
+  const currentPath = process.env.PATH || ''
+  const pathEntries = currentPath.split(delimiter).filter(Boolean)
+
+  // Prefer the platform-native binary package (for example
+  // `opencode-darwin-arm64`) over the `opencode-ai/bin/opencode` wrapper.
+  // The SDK starts the runtime with `cross-spawn('opencode')`; in packaged
+  // desktop apps that must resolve to a self-contained executable. The
+  // wrapper is a Node script with `#!/usr/bin/env node`, and end-user
+  // machines cannot be expected to have a system `node` on PATH.
+  if (binary) {
+    const binaryDir = dirname(binary)
+    process.env.PATH = prependPathEntry(binaryDir, pathEntries)
+    process.env.OPENCODE_BIN_PATH = binary
     return
   }
 
-  const currentPath = process.env.PATH || ''
-  const wrapperDir = dirname(wrapper)
-  const pathEntries = currentPath.split(delimiter).filter(Boolean)
-  if (!pathEntries.includes(wrapperDir)) {
-    process.env.PATH = [wrapperDir, ...pathEntries].join(delimiter)
+  // Development fallback: pnpm may place the optional native package under
+  // opencode-ai's nested dependencies where top-level resolution cannot see
+  // it, but the wrapper can still walk relative node_modules and find it.
+  if (wrapper) {
+    const wrapperDir = dirname(wrapper)
+    process.env.PATH = prependPathEntry(wrapperDir, pathEntries)
+    return
   }
 
-  // The platform-specific binary package (e.g. `opencode-darwin-arm64`) is
-  // the wrapper's fast path and is required for packaged builds — the
-  // bundled asar layout flattens pnpm's nested node_modules, so the wrapper
-  // can't always find the binary on its own. In dev under pnpm workspaces
-  // the optional platform package lives one directory deeper inside
-  // opencode-ai's own node_modules, which the top-level require.resolve
-  // doesn't reach — but the wrapper itself can still resolve it at runtime
-  // via its own relative-path walk, so we skip the env override rather
-  // than bail entirely.
-  if (binary) {
-    process.env.OPENCODE_BIN_PATH = binary
-  } else if (electronApp?.isPackaged) {
+  if (electronApp?.isPackaged) {
     throw new Error('Bundled OpenCode CLI is missing from the packaged app')
   }
 }

--- a/apps/desktop/src/main/runtime-opencode-cli.ts
+++ b/apps/desktop/src/main/runtime-opencode-cli.ts
@@ -73,12 +73,13 @@ function prependPathEntry(entry: string, entries: string[]) {
   return [entry, ...entries.filter((candidate) => candidate !== entry)].join(delimiter)
 }
 
-export function applyBundledOpencodeCliEnvironment() {
-  const wrapper = resolveBundledOpencodeWrapperPath()
-  const binary = resolveBundledOpencodeBinaryPath()
-
-  const currentPath = process.env.PATH || ''
-  const pathEntries = currentPath.split(delimiter).filter(Boolean)
+export function resolveBundledOpencodeCliEnvironment(options: {
+  binary: string | null
+  currentPath?: string
+  isPackaged: boolean
+  wrapper: string | null
+}): { opencodeBinPath?: string; path?: string } {
+  const pathEntries = (options.currentPath || '').split(delimiter).filter(Boolean)
 
   // Prefer the platform-native binary package (for example
   // `opencode-darwin-arm64`) over the `opencode-ai/bin/opencode` wrapper.
@@ -86,23 +87,43 @@ export function applyBundledOpencodeCliEnvironment() {
   // desktop apps that must resolve to a self-contained executable. The
   // wrapper is a Node script with `#!/usr/bin/env node`, and end-user
   // machines cannot be expected to have a system `node` on PATH.
-  if (binary) {
-    const binaryDir = dirname(binary)
-    process.env.PATH = prependPathEntry(binaryDir, pathEntries)
-    process.env.OPENCODE_BIN_PATH = binary
-    return
+  if (options.binary) {
+    const binaryDir = dirname(options.binary)
+    return {
+      opencodeBinPath: options.binary,
+      path: prependPathEntry(binaryDir, pathEntries),
+    }
+  }
+
+  if (options.isPackaged) {
+    throw new Error('Bundled OpenCode native CLI is missing from the packaged app')
   }
 
   // Development fallback: pnpm may place the optional native package under
   // opencode-ai's nested dependencies where top-level resolution cannot see
   // it, but the wrapper can still walk relative node_modules and find it.
-  if (wrapper) {
-    const wrapperDir = dirname(wrapper)
-    process.env.PATH = prependPathEntry(wrapperDir, pathEntries)
-    return
+  if (options.wrapper) {
+    const wrapperDir = dirname(options.wrapper)
+    return {
+      path: prependPathEntry(wrapperDir, pathEntries),
+    }
   }
 
-  if (electronApp?.isPackaged) {
-    throw new Error('Bundled OpenCode CLI is missing from the packaged app')
-  }
+  return {}
+}
+
+export function applyBundledOpencodeCliEnvironment() {
+  const wrapper = resolveBundledOpencodeWrapperPath()
+  const binary = resolveBundledOpencodeBinaryPath()
+
+  const currentPath = process.env.PATH || ''
+  const env = resolveBundledOpencodeCliEnvironment({
+    binary,
+    currentPath,
+    isPackaged: Boolean(electronApp?.isPackaged),
+    wrapper,
+  })
+
+  if (env.path) process.env.PATH = env.path
+  if (env.opencodeBinPath) process.env.OPENCODE_BIN_PATH = env.opencodeBinPath
 }

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -209,7 +209,7 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 //   - GOOGLE_APPLICATION_CREDENTIALS: our app-scoped ADC path so the
 //     subprocess uses the app's OAuth session, not any ADC that might
 //     be sitting in the user's real home.
-//   - PATH: the bundled `opencode` wrapper dir is prepended in
+//   - PATH: the bundled native `opencode` binary dir is prepended in
 //     `applyBundledOpencodeCliEnvironment()` (runtime-opencode-cli.ts),
 //     so the SDK's `cross-spawn('opencode')` binds to our copy, not a
 //     user-installed one on PATH.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,6 +293,20 @@ Agents package:
 
 Built-in and custom agents compile into OpenCode-native agent definitions.
 
+## Naming and storage namespaces
+
+The public repository, packages, docs, and GitHub URLs use `open-cowork`.
+The upstream bundle identifier and project overlay namespace intentionally
+retain the historical `opencowork` form:
+
+- `com.opencowork.desktop` for the desktop bundle id
+- `.opencowork/` for project-local overlay state
+- `opencowork.*` for a few legacy renderer storage keys
+
+That split is deliberate compatibility policy, not drift. Changing those
+values creates a distinct downstream distribution and requires an explicit
+state-migration plan.
+
 ## Sandbox artifacts
 
 Sandbox workspaces are real Cowork-managed directories under private app control.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,6 +328,11 @@ The upstream core ships:
 
 User-added MCPs are stored separately from the shipped config.
 
+The bundled `skills` MCP receives `OPEN_COWORK_CUSTOM_SKILLS_DIR` from
+the app when it is spawned. That value must be an absolute app-managed
+directory, not a filesystem root, the user's home directory, or a
+downstream-controlled override.
+
 ### Reusing the app's Google OAuth session for Google MCPs
 
 When `auth.mode` is `google-oauth` and the user has signed in, the app

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -94,7 +94,9 @@ the active config.
 | `OPEN_COWORK_CHART_TIMEOUT_MS` | Main-process chart render timeout. Clamped to `[250, 10000]` ms. | `1500` |
 
 `OPEN_COWORK_CUSTOM_SKILLS_DIR` is set by the app itself when spawning the
-bundled `skills` MCP and is not intended for downstream use.
+bundled `skills` MCP and is not intended for downstream use. The skills
+MCP rejects relative paths, filesystem roots, and the user's home
+directory; keep custom skill storage inside the app-managed runtime home.
 
 ## Skills overlay
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -58,6 +58,7 @@ Reference workflows in the repository root:
 - [ ] release workflow is still tag-driven only
 - [ ] signing/notarization configuration is present for the public release repo, or this is the explicitly documented unsigned `v0.0.0` public preview with `OPEN_COWORK_ALLOW_UNSIGNED_RELEASES` enabled for that tag only
 - [ ] the release repo or fork has the signing inputs expected by the release workflow (`MAC_CERTIFICATE_P12_BASE64`, `MAC_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`); a first `v*` tag intentionally fails without those inputs unless the unsigned preview override is enabled
+- [ ] Linux artifacts are either signed with the current release policy or explicitly documented as unsigned and verified through `SHA256SUMS.txt` plus GitHub provenance
 - [ ] release assets still include `SHA256SUMS.txt`, `THIRD_PARTY_NOTICES.md`, SBOMs, and provenance attestation
 - [ ] docs drift is acceptable for this release: the published Pages site tracks `master`, not immutable versioned docs; decide on versioned docs before v0.2.0
 - [ ] every `[Unreleased]` changelog bullet has been checked against the app before moving it into the tagged release section

--- a/mcps/charts/package.json
+++ b/mcps/charts/package.json
@@ -2,7 +2,13 @@
   "name": "@open-cowork/mcp-charts",
   "version": "0.0.0",
   "description": "Open Cowork chart rendering MCP server",
+  "author": "Joe Broadhead",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joe-broadhead/open-cowork.git",
+    "directory": "mcps/charts"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/mcps/skills/README.md
+++ b/mcps/skills/README.md
@@ -11,6 +11,8 @@ through this MCP.
 
 `OPEN_COWORK_CUSTOM_SKILLS_DIR` must point at the directory where custom
 skill bundles are stored. The server creates the directory when it starts.
+The path must be absolute and app-managed; filesystem roots, the user's
+home directory, and relative paths are rejected at startup.
 
 ## Security Model
 

--- a/mcps/skills/package.json
+++ b/mcps/skills/package.json
@@ -2,7 +2,13 @@
   "name": "@open-cowork/mcp-skills",
   "version": "0.0.0",
   "description": "Open Cowork skill bundle MCP server",
+  "author": "Joe Broadhead",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joe-broadhead/open-cowork.git",
+    "directory": "mcps/skills"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/mcps/skills/src/index.ts
+++ b/mcps/skills/src/index.ts
@@ -1,5 +1,6 @@
 import { closeSync, fstatSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
-import { dirname, join, relative, resolve } from 'path'
+import { homedir } from 'os'
+import { dirname, isAbsolute, join, parse, relative, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
@@ -16,11 +17,27 @@ const skillFileSchema = z.object({
 })
 
 function skillsRoot() {
-  const root = process.env.OPEN_COWORK_CUSTOM_SKILLS_DIR?.trim()
-  if (!root) {
+  const root = resolveSafeSkillsRoot(process.env.OPEN_COWORK_CUSTOM_SKILLS_DIR)
+  mkdirSync(root, { recursive: true })
+  return root
+}
+
+export function resolveSafeSkillsRoot(value?: string) {
+  const raw = value?.trim()
+  if (!raw) {
     throw new Error('OPEN_COWORK_CUSTOM_SKILLS_DIR is not configured')
   }
-  mkdirSync(root, { recursive: true })
+  if (!isAbsolute(raw)) {
+    throw new Error('OPEN_COWORK_CUSTOM_SKILLS_DIR must be an absolute app-managed directory')
+  }
+
+  const root = resolve(raw)
+  if (root === parse(root).root) {
+    throw new Error('OPEN_COWORK_CUSTOM_SKILLS_DIR cannot point at a filesystem root')
+  }
+  if (root === resolve(homedir())) {
+    throw new Error('OPEN_COWORK_CUSTOM_SKILLS_DIR cannot point at the user home directory')
+  }
   return root
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,7 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "description": "Shared Open Cowork preload and renderer types",
+  "author": "Joe Broadhead",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joe-broadhead/open-cowork.git",
+    "directory": "packages/shared"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/runtime-mcp-opt-in.test.ts
+++ b/tests/runtime-mcp-opt-in.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { evaluateBuiltInMcp } from '../apps/desktop/src/main/runtime-mcp.ts'
+import { evaluateBuiltInMcp, resolveBundledMcpNodeCommand } from '../apps/desktop/src/main/runtime-mcp.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import type { AppSettings } from '../packages/shared/src/index.ts'
 import type { BundleMcp } from '../apps/desktop/src/main/config-loader.ts'
@@ -88,6 +88,24 @@ test('evaluateBuiltInMcp — local MCP with required credentials present is read
     assert.equal(result.entry.type, 'local')
     if (result.entry.type !== 'local') return
     assert.equal(result.entry.environment?.PERPLEXITY_API_KEY, 'sk-test')
+  })
+})
+
+test('resolveBundledMcpNodeCommand uses Electron as Node in packaged builds', () => {
+  assert.deepEqual(resolveBundledMcpNodeCommand('/tmp/charts.js', {
+    isPackaged: false,
+    executablePath: '/Applications/Open Cowork.app/Contents/MacOS/Open Cowork',
+  }), {
+    command: ['node', '/tmp/charts.js'],
+    environment: {},
+  })
+
+  assert.deepEqual(resolveBundledMcpNodeCommand('/tmp/charts.js', {
+    isPackaged: true,
+    executablePath: '/Applications/Open Cowork.app/Contents/MacOS/Open Cowork',
+  }), {
+    command: ['/Applications/Open Cowork.app/Contents/MacOS/Open Cowork', '/tmp/charts.js'],
+    environment: { ELECTRON_RUN_AS_NODE: '1' },
   })
 })
 

--- a/tests/runtime-opencode-cli.test.ts
+++ b/tests/runtime-opencode-cli.test.ts
@@ -15,8 +15,11 @@ test('applyBundledOpencodeCliEnvironment exposes a usable bundled OpenCode binar
     if (typeof binary === 'string' && binary.length > 0) {
       assert.equal(existsSync(binary), true)
       const pathEntries = (process.env.PATH || '').split(delimiter).filter(Boolean)
-      assert.equal(pathEntries.includes(dirname(binary)), false)
-      assert.ok(pathEntries.some((entry) => entry.includes('opencode-ai')))
+      assert.equal(pathEntries[0], dirname(binary))
+
+      process.env.PATH = ['/usr/local/bin', dirname(binary), '/usr/bin'].join(delimiter)
+      applyBundledOpencodeCliEnvironment()
+      assert.equal((process.env.PATH || '').split(delimiter).filter(Boolean)[0], dirname(binary))
     }
   } finally {
     if (previousPath === undefined) delete process.env.PATH

--- a/tests/runtime-opencode-cli.test.ts
+++ b/tests/runtime-opencode-cli.test.ts
@@ -2,7 +2,10 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { existsSync } from 'fs'
 import { delimiter, dirname } from 'path'
-import { applyBundledOpencodeCliEnvironment } from '../apps/desktop/src/main/runtime-opencode-cli.ts'
+import {
+  applyBundledOpencodeCliEnvironment,
+  resolveBundledOpencodeCliEnvironment,
+} from '../apps/desktop/src/main/runtime-opencode-cli.ts'
 
 test('applyBundledOpencodeCliEnvironment exposes a usable bundled OpenCode binary path', () => {
   const previousPath = process.env.PATH
@@ -27,4 +30,44 @@ test('applyBundledOpencodeCliEnvironment exposes a usable bundled OpenCode binar
     if (previousBin === undefined) delete process.env.OPENCODE_BIN_PATH
     else process.env.OPENCODE_BIN_PATH = previousBin
   }
+})
+
+test('resolveBundledOpencodeCliEnvironment prefers the native binary', () => {
+  const env = resolveBundledOpencodeCliEnvironment({
+    binary: '/app/node_modules/opencode-darwin-arm64/bin/opencode',
+    currentPath: ['/usr/local/bin', '/app/node_modules/opencode-darwin-arm64/bin', '/usr/bin'].join(delimiter),
+    isPackaged: true,
+    wrapper: '/app/node_modules/opencode-ai/bin/opencode',
+  })
+
+  assert.equal(env.opencodeBinPath, '/app/node_modules/opencode-darwin-arm64/bin/opencode')
+  assert.equal(
+    env.path?.split(delimiter).filter(Boolean)[0],
+    '/app/node_modules/opencode-darwin-arm64/bin',
+  )
+})
+
+test('resolveBundledOpencodeCliEnvironment refuses wrapper fallback in packaged builds', () => {
+  assert.throws(
+    () =>
+      resolveBundledOpencodeCliEnvironment({
+        binary: null,
+        currentPath: '/usr/bin',
+        isPackaged: true,
+        wrapper: '/app/node_modules/opencode-ai/bin/opencode',
+      }),
+    /Bundled OpenCode native CLI is missing/,
+  )
+})
+
+test('resolveBundledOpencodeCliEnvironment allows wrapper fallback in development', () => {
+  const env = resolveBundledOpencodeCliEnvironment({
+    binary: null,
+    currentPath: '/usr/bin',
+    isPackaged: false,
+    wrapper: '/repo/node_modules/opencode-ai/bin/opencode',
+  })
+
+  assert.equal(env.opencodeBinPath, undefined)
+  assert.equal(env.path?.split(delimiter).filter(Boolean)[0], '/repo/node_modules/opencode-ai/bin')
 })

--- a/tests/skills-mcp-path-policy.test.ts
+++ b/tests/skills-mcp-path-policy.test.ts
@@ -1,6 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { isSafeRelativePath } from '../mcps/skills/src/index.ts'
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import { isSafeRelativePath, resolveSafeSkillsRoot } from '../mcps/skills/src/index.ts'
 
 test('skills MCP path policy accepts ordinary relative bundle files', () => {
   assert.equal(isSafeRelativePath('references/example.md'), true)
@@ -17,4 +19,14 @@ test('skills MCP path policy rejects empty segments and Windows traversal', () =
   for (const path of ['', 'references//example.md', 'references\\..\\secret.md']) {
     assert.equal(isSafeRelativePath(path), false, path)
   }
+})
+
+test('skills MCP root policy rejects broad filesystem roots', () => {
+  assert.throws(() => resolveSafeSkillsRoot(undefined), /not configured/)
+  assert.throws(() => resolveSafeSkillsRoot('relative/skills'), /absolute/)
+  assert.throws(() => resolveSafeSkillsRoot(resolve('/')), /filesystem root/)
+  assert.throws(() => resolveSafeSkillsRoot(homedir()), /home directory/)
+
+  const safeRoot = resolve(homedir(), '.config', 'open-cowork', 'runtime-home', '.config', 'opencode', 'skills')
+  assert.equal(resolveSafeSkillsRoot(safeRoot), safeRoot)
 })


### PR DESCRIPTION
## Summary

- Prefer the bundled native OpenCode binary in packaged builds so clean user machines do not need a system node or user-installed opencode.
- Run bundled local MCPs through Electron's Node runtime in packaged builds using ELECTRON_RUN_AS_NODE=1, while preserving normal node execution in development and explicit downstream/custom MCP commands.
- Close release-audit hygiene gaps: document the open-cowork/opencowork namespace policy, add package metadata, clarify Linux signing posture, and reject unsafe custom-skill root directories.

## Why

The packaged app previously could resolve the opencode-ai/bin/opencode Node wrapper or launch bundled MCPs with node, which works on developer machines but can fail for non-technical users without Node on PATH. This keeps runtime ownership with OpenCode while making the Open Cowork packaged resource launch path self-contained.

## Validation

- pnpm test - 569 passing
- pnpm typecheck
- pnpm lint
- git diff --check
- uv run mkdocs build --strict
- pnpm --dir apps/desktop dist:ci
- packaged smoke passed after rebuilding the app