### PR TITLE
Polish public preview release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Prebuilt binaries are published on [GitHub Releases](https://github.com/joe-broa
 > **Important**
 > The `v0.0.0` public preview is intentionally unsigned while Apple Developer validation is pending. The release workflow can publish unsigned `v0.x` artifacts only when the explicit preview override is enabled; macOS will warn on first launch in that mode.
 >
-> See Apple's [Gatekeeper guidance](https://support.apple.com/HT202491) for opening an unsigned preview build, or build locally.
+> To open the preview on macOS: right-click **Open Cowork.app**, choose **Open**, then choose **Open** again in the Gatekeeper dialog. See Apple's [Gatekeeper guidance](https://support.apple.com/HT202491) for details, or build locally.
 
 ## Quick start
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,8 +55,8 @@ Please allow time for triage, fix development, and coordinated release before pu
 
 These are targets, not contractual SLAs, but they set expectations for reporters:
 
-- Critical: acknowledgement within 2 business days; mitigation or release target within 7 days
-- High: acknowledgement within 3 business days; mitigation or release target within 14 days
+- Critical: acknowledgement target within 2 business days; initial assessment or mitigation plan within about 7 days
+- High: acknowledgement target within 3 business days; initial assessment or mitigation plan within about 14 days
 - Medium / Low: acknowledgement within 5 business days; fix scheduled through normal maintenance
 
 Business days are Monday-Friday in Europe/Amsterdam time, excluding local public holidays. If a response target passes without acknowledgement, re-contact the maintainer privately through GitHub with `[security-escalation]` in the subject.

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -68,11 +68,13 @@ function dashboardRangeOptions(): Array<{ key: DashboardTimeRangeKey; label: str
     { key: 'all', label: t('homepage.range.all', 'All time') },
   ]
 }
-const DASHBOARD_RANGE_STORAGE_KEY = 'opencowork.dashboardRange.v1'
+const DASHBOARD_RANGE_STORAGE_KEY = 'open-cowork.dashboardRange.v1'
+const LEGACY_DASHBOARD_RANGE_STORAGE_KEY = 'opencowork.dashboardRange.v1'
 
 function readStoredRange(): DashboardTimeRangeKey {
   try {
     const stored = window.localStorage.getItem(DASHBOARD_RANGE_STORAGE_KEY)
+      || window.localStorage.getItem(LEGACY_DASHBOARD_RANGE_STORAGE_KEY)
     if (stored && DASHBOARD_RANGE_KEYS.includes(stored as DashboardTimeRangeKey)) {
       return stored as DashboardTimeRangeKey
     }
@@ -416,6 +418,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
   useEffect(() => {
     try {
       window.localStorage.setItem(DASHBOARD_RANGE_STORAGE_KEY, dashboardRange)
+      window.localStorage.removeItem(LEGACY_DASHBOARD_RANGE_STORAGE_KEY)
     } catch {
       /* Quota / disabled storage — non-fatal, selection just won't persist. */
     }

--- a/apps/desktop/src/renderer/components/chat/TaskDrillIn.tsx
+++ b/apps/desktop/src/renderer/components/chat/TaskDrillIn.tsx
@@ -41,12 +41,14 @@ interface Props {
   onClose: () => void
 }
 
-const TASK_DRILL_IN_LAYOUT_STORAGE_KEY = 'opencowork.task-drill-in.layout.v1'
+const TASK_DRILL_IN_LAYOUT_STORAGE_KEY = 'open-cowork.task-drill-in.layout.v1'
+const LEGACY_TASK_DRILL_IN_LAYOUT_STORAGE_KEY = 'opencowork.task-drill-in.layout.v1'
 
 function readStoredLayoutPreference(): { customWidth: number } | null {
   if (typeof window === 'undefined') return null
   try {
     const raw = window.localStorage.getItem(TASK_DRILL_IN_LAYOUT_STORAGE_KEY)
+      || window.localStorage.getItem(LEGACY_TASK_DRILL_IN_LAYOUT_STORAGE_KEY)
     if (!raw) return null
     const parsed = JSON.parse(raw) as { customWidth?: number }
     const customWidth = typeof parsed.customWidth === 'number' && Number.isFinite(parsed.customWidth)
@@ -125,6 +127,7 @@ export const TaskDrillIn = memo(function TaskDrillIn({
       window.localStorage.setItem(TASK_DRILL_IN_LAYOUT_STORAGE_KEY, JSON.stringify({
         customWidth,
       }))
+      window.localStorage.removeItem(LEGACY_TASK_DRILL_IN_LAYOUT_STORAGE_KEY)
     } catch {
       /* localStorage unavailable — non-fatal */
     }

--- a/apps/desktop/src/renderer/helpers/i18n.ts
+++ b/apps/desktop/src/renderer/helpers/i18n.ts
@@ -17,7 +17,8 @@ import { BUILT_IN_CATALOGS, type LocaleCatalog } from './i18n-catalogs/index.ts'
 // empty; the fallback is the source of truth for the English
 // baseline.
 
-const LANGUAGE_STORAGE_KEY = 'opencowork.locale.v1'
+const LANGUAGE_STORAGE_KEY = 'open-cowork.locale.v1'
+const LEGACY_LANGUAGE_STORAGE_KEY = 'opencowork.locale.v1'
 
 let cachedCatalog: Record<string, string> = {}
 let cachedLocale: string | undefined
@@ -51,6 +52,7 @@ function lookupBuiltInCatalog(locale: string | undefined): LocaleCatalog | undef
 function detectPreferredLocale(): string | undefined {
   try {
     const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY)
+      || window.localStorage.getItem(LEGACY_LANGUAGE_STORAGE_KEY)
     if (stored && stored.trim()) return stored
   } catch {
     /* localStorage unavailable — fall through */
@@ -103,8 +105,10 @@ export function setLocale(locale: string | null) {
   try {
     if (locale) {
       window.localStorage.setItem(LANGUAGE_STORAGE_KEY, locale)
+      window.localStorage.removeItem(LEGACY_LANGUAGE_STORAGE_KEY)
     } else {
       window.localStorage.removeItem(LANGUAGE_STORAGE_KEY)
+      window.localStorage.removeItem(LEGACY_LANGUAGE_STORAGE_KEY)
     }
   } catch {
     /* non-fatal */

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,11 +301,14 @@ retain the historical `opencowork` form:
 
 - `com.opencowork.desktop` for the desktop bundle id
 - `.opencowork/` for project-local overlay state
-- `opencowork.*` for a few legacy renderer storage keys
 
 That split is deliberate compatibility policy, not drift. Changing those
 values creates a distinct downstream distribution and requires an explicit
 state-migration plan.
+
+Renderer-only preference keys use the public `open-cowork.*` prefix.
+The app reads the earlier `opencowork.*` keys during v0.x migrations and
+rewrites them to the public prefix on the next preference save.
 
 ## Sandbox artifacts
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,62 @@
+# Contributing
+
+Open Cowork is a product layer on top of OpenCode. Contributions should
+preserve that split: OpenCode owns execution, sessions, MCP calls,
+approvals, and agent runtime behavior; Open Cowork owns composition,
+configuration, UI, packaging, and product ergonomics.
+
+## Setup
+
+Requirements:
+
+- Node `>=22`
+- pnpm `>=10`
+- Python `>=3.11` for docs work
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Run the desktop app:
+
+```bash
+pnpm dev
+```
+
+## Validation
+
+Before opening a pull request, run the relevant subset of:
+
+```bash
+pnpm test
+pnpm test:e2e
+pnpm typecheck
+pnpm lint
+pnpm perf:check
+git diff --check
+```
+
+Build docs with:
+
+```bash
+python -m pip install -r docs/requirements.txt
+mkdocs build --strict
+```
+
+## Pull Requests
+
+The repository uses a single `master` line. Create a short-lived branch
+for each change, open a pull request back to `master`, and keep the
+branch focused enough that it can be squash-merged or rebased cleanly.
+
+Good pull requests explain:
+
+- what changed
+- why it changed
+- how it was validated
+- any remaining caveats
+
+The full contributor guide also lives at the repository root:
+[`CONTRIBUTING.md`](https://github.com/joe-broadhead/open-cowork/blob/master/CONTRIBUTING.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 <p class="subtitle">A desktop AI workspace built on OpenCode. Configurable, brandable, automation-ready, and engineered like a public product — not a demo.</p>
 
-[Get started in 5 minutes :material-arrow-right:](getting-started.md){ .md-button .md-button--primary }
+[Get started :material-arrow-right:](getting-started.md){ .md-button .md-button--primary }
 [Why this exists :material-arrow-right:](architecture.md){ .md-button }
 
 <div class="cowork-stats" markdown>
@@ -184,9 +184,9 @@ own branding, providers, skills, and automations.
 
     ---
 
-    Signed macOS artifacts, SHA256 checksums, CycloneDX + SPDX SBOMs,
-    SHA-pinned actions. Monthly maintenance probes the OpenCode SDK
-    against typecheck and tests.
+    Signed macOS artifacts once signing is configured, SHA256 checksums,
+    CycloneDX + SPDX SBOMs, SHA-pinned actions. Monthly maintenance
+    probes the OpenCode SDK against typecheck and tests.
 
     [:octicons-arrow-right-24: Packaging and Releases](packaging-and-releases.md)
 

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -93,9 +93,13 @@ the GitHub build provenance attestation above.
 The Vite 8 / Rolldown build currently emits a small set of known
 warnings in local and CI builds:
 
-- React plugin guidance about the future `@vitejs/plugin-react-oxc`
+- `resolve.alias` entries with `customResolver` are deprecated and will
+  need a Vite 9-compatible replacement in the Electron renderer plugin
   path.
-- Rolldown compatibility warnings from `vite-plugin-electron` options.
+- Rolldown reports `freeze` as an invalid output option through the
+  current Vite/plugin compatibility layer.
+- Electron Builder may surface Node's `DEP0190` warning from an
+  upstream shell invocation.
 - A large lazy Mermaid vendor chunk.
 
 These warnings are reviewed and accepted for v0.0.0. They do not affect

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,7 @@ nav:
       - Troubleshooting: troubleshooting.md
   - Project:
       - Roadmap: roadmap.md
-      - Contributing: https://github.com/joe-broadhead/open-cowork/blob/master/CONTRIBUTING.md
+      - Contributing: contributing.md
       - First Contribution: first-contribution.md
 
 extra:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,15 @@
   "type": "module",
   "packageManager": "pnpm@10.32.1",
   "description": "Desktop workspace for OpenCode sessions, agents, tools, skills, and automations",
+  "keywords": [
+    "electron",
+    "opencode",
+    "ai-agents",
+    "desktop-app",
+    "mcp",
+    "automations",
+    "typescript"
+  ],
   "author": "Joe Broadhead",
   "license": "MIT",
   "homepage": "https://github.com/joe-broadhead/open-cowork",

--- a/scripts/desktop-dist.mjs
+++ b/scripts/desktop-dist.mjs
@@ -13,6 +13,12 @@ const branding = {
   APP_MAINTAINER: process.env.APP_MAINTAINER || 'Open Cowork Maintainers <joe-broadhead@users.noreply.github.com>',
 }
 
+function cleanReleaseOutput() {
+  const releaseDir = join(process.cwd(), 'release')
+  process.stdout.write(`[desktop-dist] removing stale release output at ${releaseDir}\n`)
+  rmSync(releaseDir, { force: true, recursive: true })
+}
+
 function createBuilderConfig() {
   const sourcePath = join(process.cwd(), 'electron-builder.yml')
   const generatedPath = join(process.cwd(), '.electron-builder.generated.yml')
@@ -50,6 +56,7 @@ const builderArgs = process.argv.slice(2)
 const builderConfigPath = createBuilderConfig()
 
 try {
+  cleanReleaseOutput()
   await runStep('pnpm', ['--dir', '../..', 'build:shared'])
   await runStep('pnpm', ['build'])
   await runStep('pnpm', ['build:electron'])

--- a/tests/i18n-runtime.test.ts
+++ b/tests/i18n-runtime.test.ts
@@ -71,10 +71,11 @@ describe('i18n runtime', () => {
 
   it('persists user locale selection in localStorage', () => {
     setLocale('de')
-    assert.equal(storage.get('opencowork.locale.v1'), 'de')
+    assert.equal(storage.get('open-cowork.locale.v1'), 'de')
+    assert.equal(storage.has('opencowork.locale.v1'), false)
 
     setLocale(null)
-    assert.equal(storage.has('opencowork.locale.v1'), false)
+    assert.equal(storage.has('open-cowork.locale.v1'), false)
   })
 
   it('falls back to English inline default when a catalog key is missing', () => {
@@ -105,6 +106,14 @@ describe('i18n runtime', () => {
   })
 
   it('reads user preference from localStorage at configure time, overriding system locale', () => {
+    storage.set('open-cowork.locale.v1', 'pt')
+    storage.set('opencowork.locale.v1', 'ja')
+    navLanguage = 'en-US'
+    configureI18n(undefined)
+    assert.equal(getLocale(), 'pt')
+  })
+
+  it('reads legacy user preference from localStorage during migration', () => {
     storage.set('opencowork.locale.v1', 'ja')
     navLanguage = 'en-US'
     configureI18n(undefined)


### PR DESCRIPTION
## Summary
- clarify unsigned v0.0.0 macOS preview install wording and signing expectations
- document accepted build warnings and clean stale local release output before packaging
- add local MkDocs contributing page and package keywords
- migrate renderer preference keys to open-cowork.* while reading legacy opencowork.* keys

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- uv run mkdocs build --strict
- git diff --check
- pnpm --dir apps/desktop dist:ci
- OPEN_COWORK_PACKAGED_EXECUTABLE=apps/desktop/release/mac-arm64/Open Cowork.app/Contents/MacOS/Open Cowork pnpm --dir apps/desktop test:e2e:packaged