### PR TITLE
Harden release readiness and renderer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Renderer component tests
+        run: pnpm test:renderer
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Renderer component tests
+        run: pnpm test:renderer
+
       - name: Performance gate
         run: pnpm perf:check
 
@@ -391,4 +394,5 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
+          prerelease: ${{ startsWith(github.ref_name, 'v0.') }}
           files: dist-artifacts/**/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Validate the repo:
 
 ```bash
 pnpm test
+pnpm test:renderer
 pnpm test:e2e
 pnpm typecheck
 pnpm lint
@@ -61,7 +62,9 @@ pnpm dev
   followed by `scripts/lint.mjs` for repo-specific checks (trailing
   whitespace, tabs, final newlines).
 - **Tests** run with Node's built-in runner via
-  `--experimental-strip-types`. No Jest / Vitest dependency.
+  `--experimental-strip-types` for main/shared/runtime coverage.
+  Renderer component tests run with Vitest + jsdom via
+  `pnpm test:renderer`.
 - **Perf gate**: `scripts/perf-benchmark.ts` compares against
   `benchmarks/perf-baseline.json`. Refresh the baseline intentionally
   with `pnpm perf:baseline` after major environment or workload changes.
@@ -109,6 +112,7 @@ Before opening a PR or checkpointing a large change, run:
 
 ```bash
 pnpm test
+pnpm test:renderer
 pnpm test:e2e
 pnpm typecheck
 pnpm lint

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "build:electron": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.preload.json --noEmit",
     "typecheck": "tsc --noEmit",
     "start": "electron .",
+    "test:renderer": "pnpm --dir ../.. build:shared && vitest run --config vitest.renderer.config.ts",
     "test:e2e": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && for test_file in tests/*.smoke.test.ts; do node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test \"$test_file\"; done",
     "test:e2e:packaged": "node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test 'tests/*.packaged.test.ts'",
     "screenshots": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && node --no-warnings --experimental-strip-types tests/screenshots.ts",
@@ -54,17 +55,22 @@
   "devDependencies": {
     "@open-cowork/shared": "workspace:*",
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^6.0.1",
     "electron": "^41.3.0",
     "electron-builder": "^26.8.1",
+    "jsdom": "^29.1.0",
     "playwright-core": "^1.59.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vite-plugin-electron": "^0.29.0",
-    "vite-plugin-electron-renderer": "^0.14.0"
+    "vite-plugin-electron-renderer": "^0.14.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -44,6 +44,7 @@ import {
 } from './event-subscriptions.ts'
 import { primeShellEnvironment } from './shell-env.ts'
 import { listReadyGoogleAuthLocalMcpNames } from './runtime-mcp.ts'
+import { shouldScheduleRuntimeReconnect } from './runtime-reconnect-policy.ts'
 
 import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
@@ -51,7 +52,8 @@ import { telemetry } from './telemetry.ts'
 let mainWindow: BrowserWindow | null = null
 let runtimeStarted = false
 let reconnectTimer: NodeJS.Timeout | null = null
-let cleanupDone = false
+let startupCleanupDone = false
+let appCleanupStarted = false
 let runtimeProjectDirectory: string | null = null
 let mainWindowRecoveryTimer: NodeJS.Timeout | null = null
 let appIsQuitting = false
@@ -579,8 +581,8 @@ async function runBootRuntime(projectDirectory?: string | null) {
   if (runtimeStarted) return
   setRuntimeReady(false, null)
   try {
-    if (!cleanupDone) {
-      cleanupDone = true
+    if (!startupCleanupDone) {
+      startupCleanupDone = true
       const cleanup = pruneOldUnreferencedSandboxStorage()
       if (cleanup.removedWorkspaces > 0) {
         log('artifact', `Pruned ${cleanup.removedWorkspaces} stale sandbox workspace(s), freed ${cleanup.removedBytes} bytes`)
@@ -705,8 +707,11 @@ let reconnectDelay = 3000
 const MAX_RECONNECT_DELAY = 60000
 
 function scheduleReconnect() {
-  if (cleanupDone) return
-  if (reconnectTimer) return
+  if (!shouldScheduleRuntimeReconnect({
+    appCleanupStarted,
+    appIsQuitting,
+    reconnectTimerActive: Boolean(reconnectTimer),
+  })) return
   log('main', `Runtime disconnected — reconnecting in ${reconnectDelay / 1000}s...`)
   runtimeStarted = false
   setRuntimeReady(false)
@@ -731,8 +736,8 @@ function scheduleReconnect() {
 }
 
 async function performCleanup() {
-  if (cleanupDone) return
-  cleanupDone = true
+  if (appCleanupStarted) return
+  appCleanupStarted = true
 
   if (reconnectTimer) {
     clearTimeout(reconnectTimer)

--- a/apps/desktop/src/main/ipc/custom-content-handlers.ts
+++ b/apps/desktop/src/main/ipc/custom-content-handlers.ts
@@ -42,8 +42,8 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
         validateCustomMcpStdioCommand(mcp)
       }
       if (mcp.type === 'http' && mcp.url) {
-        const { evaluateHttpMcpUrl } = await import('../mcp-url-policy.ts')
-        const verdict = evaluateHttpMcpUrl(mcp.url, { allowPrivateNetwork: mcp.allowPrivateNetwork })
+        const { evaluateHttpMcpUrlResolved } = await import('../mcp-url-policy.ts')
+        const verdict = await evaluateHttpMcpUrlResolved(mcp.url, { allowPrivateNetwork: mcp.allowPrivateNetwork })
         if (!verdict.ok) {
           return { ok: false, methods: [], error: verdict.reason }
         }
@@ -89,8 +89,8 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
       validateCustomMcpStdioCommand(resolved)
     }
     if (resolved.type === 'http' && resolved.url) {
-      const { evaluateHttpMcpUrl } = await import('../mcp-url-policy.ts')
-      const verdict = evaluateHttpMcpUrl(resolved.url, { allowPrivateNetwork: resolved.allowPrivateNetwork })
+      const { evaluateHttpMcpUrlResolved } = await import('../mcp-url-policy.ts')
+      const verdict = await evaluateHttpMcpUrlResolved(resolved.url, { allowPrivateNetwork: resolved.allowPrivateNetwork })
       if (!verdict.ok) {
         throw new Error(`Cannot save MCP: ${verdict.reason}`)
       }

--- a/apps/desktop/src/main/mcp-url-policy.ts
+++ b/apps/desktop/src/main/mcp-url-policy.ts
@@ -12,49 +12,113 @@
 // the policy is opt-in via `CustomMcpConfig.allowPrivateNetwork`. The
 // default posture is "public internet only."
 
+import { lookup } from 'node:dns/promises'
+import { BlockList, isIP } from 'node:net'
+
 const LOOPBACK_HOSTS = new Set([
   'localhost',
   'ip6-localhost',
   'ip6-loopback',
 ])
 
-function isLoopbackV4(host: string) {
-  // 127.0.0.0/8
-  return /^127(?:\.\d{1,3}){3}$/.test(host)
+const loopbackBlocks = new BlockList()
+loopbackBlocks.addSubnet('127.0.0.0', 8, 'ipv4')
+loopbackBlocks.addAddress('::1', 'ipv6')
+
+const linkLocalBlocks = new BlockList()
+linkLocalBlocks.addSubnet('169.254.0.0', 16, 'ipv4')
+linkLocalBlocks.addSubnet('fe80::', 10, 'ipv6')
+
+const privateBlocks = new BlockList()
+privateBlocks.addSubnet('10.0.0.0', 8, 'ipv4')
+privateBlocks.addSubnet('172.16.0.0', 12, 'ipv4')
+privateBlocks.addSubnet('192.168.0.0', 16, 'ipv4')
+privateBlocks.addSubnet('fc00::', 7, 'ipv6')
+
+const nonRoutableBlocks = new BlockList()
+nonRoutableBlocks.addSubnet('0.0.0.0', 8, 'ipv4')
+nonRoutableBlocks.addAddress('::', 'ipv6')
+
+export type McpDnsResolver = (hostname: string) => Promise<Array<{ address: string; family?: number }>>
+
+type McpUrlPolicyOptions = {
+  allowPrivateNetwork?: boolean
 }
 
-function isRfc1918(host: string) {
-  // 10.0.0.0/8
-  if (/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true
-  // 172.16.0.0/12
-  const match172 = /^172\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/.exec(host)
-  if (match172) {
-    const second = Number(match172[1])
-    if (second >= 16 && second <= 31) return true
+type McpUrlResolutionOptions = McpUrlPolicyOptions & {
+  resolveHostname?: McpDnsResolver
+}
+
+type BlockedNetwork = {
+  kind: 'loopback' | 'link-local' | 'private' | 'non-routable'
+  address: string
+}
+
+function normalizeHostname(hostname: string) {
+  const lower = hostname.toLowerCase()
+  const withoutBrackets = lower.startsWith('[') && lower.endsWith(']')
+    ? lower.slice(1, -1)
+    : lower
+  const zoneIndex = withoutBrackets.indexOf('%')
+  return zoneIndex >= 0 ? withoutBrackets.slice(0, zoneIndex) : withoutBrackets
+}
+
+function ipv4MappedAddress(hostname: string) {
+  const match = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(hostname)
+  return match?.[1] || null
+}
+
+function blockListAddressType(address: string) {
+  const type = isIP(address)
+  if (type === 4) return 'ipv4'
+  if (type === 6) return 'ipv6'
+  return null
+}
+
+function classifyBlockedNetwork(hostname: string): BlockedNetwork | null {
+  if (LOOPBACK_HOSTS.has(hostname)) {
+    return { kind: 'loopback', address: hostname }
   }
-  // 192.168.0.0/16
-  if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)) return true
-  return false
+
+  const mapped = ipv4MappedAddress(hostname)
+  const address = mapped || hostname
+  const type = blockListAddressType(address)
+  if (!type) return null
+
+  if (loopbackBlocks.check(address, type)) {
+    return { kind: 'loopback', address }
+  }
+  if (linkLocalBlocks.check(address, type)) {
+    return { kind: 'link-local', address }
+  }
+  if (privateBlocks.check(address, type)) {
+    return { kind: 'private', address }
+  }
+  if (nonRoutableBlocks.check(address, type)) {
+    return { kind: 'non-routable', address }
+  }
+  return null
 }
 
-function isLinkLocalV4(host: string) {
-  // 169.254.0.0/16 — includes cloud metadata services (AWS IMDS,
-  // Azure IMDS at 169.254.169.254, GCP metadata). Prime SSRF target.
-  return /^169\.254\.\d{1,3}\.\d{1,3}$/.test(host)
+function rejectionReason(blocked: BlockedNetwork, source: 'literal' | 'resolved') {
+  const prefix = source === 'resolved'
+    ? `URL hostname resolves to a ${blocked.kind} address (${blocked.address}).`
+    : `URL targets a ${blocked.kind} address.`
+
+  if (blocked.kind === 'loopback') {
+    return `${prefix} Enable "Allow private network" on the MCP if this is intentional.`
+  }
+  if (blocked.kind === 'link-local') {
+    return `${prefix} Cloud metadata endpoints are blocked by default — enable "Allow private network" if you genuinely need it.`
+  }
+  if (blocked.kind === 'private') {
+    return `${prefix} Enable "Allow private network" on the MCP to use corporate-internal endpoints.`
+  }
+  return `${prefix} Enable "Allow private network" only if this local target is intentional.`
 }
 
-function isUniqueLocalV6(host: string) {
-  // fc00::/7
-  return /^f[cd][0-9a-f]{2}:/i.test(host)
-}
-
-function isLinkLocalV6(host: string) {
-  // fe80::/10
-  return /^fe[89ab][0-9a-f]:/i.test(host)
-}
-
-function isLoopbackV6(host: string) {
-  return host === '::1' || host === '0:0:0:0:0:0:0:1'
+async function defaultDnsResolver(hostname: string) {
+  return lookup(hostname, { all: true, verbatim: true })
 }
 
 export type McpUrlPolicyResult =
@@ -66,7 +130,7 @@ export type McpUrlPolicyResult =
 // whether to surface the reason to the user verbatim.
 export function evaluateHttpMcpUrl(
   rawUrl: string,
-  options?: { allowPrivateNetwork?: boolean },
+  options?: McpUrlPolicyOptions,
 ): McpUrlPolicyResult {
   if (!rawUrl || !rawUrl.trim()) {
     return { ok: false, reason: 'URL is required.' }
@@ -84,27 +148,55 @@ export function evaluateHttpMcpUrl(
   }
 
   // WHATWG URL preserves IPv6 brackets in hostname; strip them so the
-  // pattern matchers below see the bare address.
-  const rawHostname = url.hostname.toLowerCase()
-  const hostname = rawHostname.startsWith('[') && rawHostname.endsWith(']')
-    ? rawHostname.slice(1, -1)
-    : rawHostname
+  // policy matchers below see the bare address.
+  const hostname = normalizeHostname(url.hostname)
 
   if (options?.allowPrivateNetwork) {
     return { ok: true, url }
   }
 
-  if (LOOPBACK_HOSTS.has(hostname) || isLoopbackV4(hostname) || isLoopbackV6(hostname)) {
-    return { ok: false, reason: 'URL resolves to loopback. Enable "Allow private network" on the MCP if this is intentional.' }
-  }
-
-  if (isLinkLocalV4(hostname) || isLinkLocalV6(hostname)) {
-    return { ok: false, reason: 'URL targets a link-local address (169.254.*). Cloud metadata endpoints are blocked by default — enable "Allow private network" if you genuinely need it.' }
-  }
-
-  if (isRfc1918(hostname) || isUniqueLocalV6(hostname)) {
-    return { ok: false, reason: 'URL targets a private network (RFC1918). Enable "Allow private network" on the MCP to use corporate-internal endpoints.' }
+  const blocked = classifyBlockedNetwork(hostname)
+  if (blocked) {
+    return { ok: false, reason: rejectionReason(blocked, 'literal') }
   }
 
   return { ok: true, url }
+}
+
+export async function evaluateHttpMcpUrlResolved(
+  rawUrl: string,
+  options: McpUrlResolutionOptions = {},
+): Promise<McpUrlPolicyResult> {
+  const staticVerdict = evaluateHttpMcpUrl(rawUrl, options)
+  if (!staticVerdict.ok || options.allowPrivateNetwork) {
+    return staticVerdict
+  }
+
+  const hostname = normalizeHostname(staticVerdict.url.hostname)
+  if (blockListAddressType(hostname)) {
+    return staticVerdict
+  }
+
+  const resolver = options.resolveHostname || defaultDnsResolver
+  let records: Array<{ address: string; family?: number }>
+  try {
+    records = await resolver(hostname)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, reason: `Could not resolve MCP hostname "${hostname}": ${message}` }
+  }
+
+  if (records.length === 0) {
+    return { ok: false, reason: `Could not resolve MCP hostname "${hostname}".` }
+  }
+
+  for (const record of records) {
+    const address = normalizeHostname(record.address)
+    const blocked = classifyBlockedNetwork(address)
+    if (blocked) {
+      return { ok: false, reason: rejectionReason(blocked, 'resolved') }
+    }
+  }
+
+  return staticVerdict
 }

--- a/apps/desktop/src/main/native-customizations.ts
+++ b/apps/desktop/src/main/native-customizations.ts
@@ -57,6 +57,8 @@ type ManagedAgentMetadata = {
 type ManagedMcpMetadata = {
   label?: string
   description?: string
+  googleAuth?: boolean
+  allowPrivateNetwork?: boolean
 }
 
 function ensureDirectory(path: string) {
@@ -132,6 +134,8 @@ function readManagedMcpMetadata(
           return [name, {
             label: typeof record.label === 'string' ? record.label : undefined,
             description: typeof record.description === 'string' ? record.description : undefined,
+            googleAuth: record.googleAuth === true ? true : undefined,
+            allowPrivateNetwork: record.allowPrivateNetwork === true ? true : undefined,
           }]
         }),
     )
@@ -211,6 +215,8 @@ function parseCustomMcpEntry(
     name,
     label: metadata.label,
     description: metadata.description,
+    googleAuth: metadata.googleAuth,
+    allowPrivateNetwork: metadata.allowPrivateNetwork,
     type,
     command: type === 'stdio' ? commandArray[0] : undefined,
     args: type === 'stdio' ? commandArray.slice(1) : undefined,
@@ -678,11 +684,17 @@ export function saveCustomMcp(mcp: CustomMcpConfig) {
     const next = { ...current }
     const label = mcp.label?.trim() || undefined
     const description = mcp.description?.trim() || undefined
-    if (!label && !description) {
+    const metadata: ManagedMcpMetadata = {
+      label,
+      description,
+      googleAuth: mcp.googleAuth === true ? true : undefined,
+      allowPrivateNetwork: mcp.allowPrivateNetwork === true ? true : undefined,
+    }
+    if (!metadata.label && !metadata.description && !metadata.googleAuth && !metadata.allowPrivateNetwork) {
       delete next[mcp.name]
       return next
     }
-    next[mcp.name] = { label, description }
+    next[mcp.name] = metadata
     return next
   })
   return true

--- a/apps/desktop/src/main/opencode-adapter.ts
+++ b/apps/desktop/src/main/opencode-adapter.ts
@@ -1,4 +1,14 @@
 import type {
+  Event as SdkEvent,
+  GlobalEvent as SdkGlobalEvent,
+  McpStatus as SdkMcpStatus,
+  Message as SdkMessage,
+  Part as SdkPart,
+  Session as SdkSession,
+  SessionMessagesResponse as SdkSessionMessagesResponse,
+  SessionStatus as SdkSessionStatus,
+} from '@opencode-ai/sdk/v2'
+import type {
   ExplorerSymbol,
   FileContent,
   FileNode,
@@ -8,6 +18,8 @@ import type {
 } from '@open-cowork/shared'
 
 type JsonRecord = Record<string, unknown>
+type SdkSessionMessage = SdkSessionMessagesResponse extends Array<infer T> ? T : never
+type SdkRuntimeEventEnvelope = SdkEvent | SdkGlobalEvent | { payload: SdkEvent | SdkGlobalEvent }
 
 export type NormalizedTokens = {
   input: number
@@ -205,6 +217,8 @@ function normalizeToolState(value: unknown): NormalizedToolState {
   }
 }
 
+export function normalizeSessionInfo(value: SdkSession | SdkMessage): NormalizedSessionInfo | null
+export function normalizeSessionInfo(value: unknown): NormalizedSessionInfo | null
 export function normalizeSessionInfo(value: unknown): NormalizedSessionInfo | null {
   const record = asRecord(value)
   const id = readRecordString(record, ['id'])
@@ -236,14 +250,16 @@ export function normalizeSessionInfo(value: unknown): NormalizedSessionInfo | nu
       updated: readRecordNumber(time, ['updated']) || undefined,
     },
     model: {
-      providerId: readRecordString(model, ['providerID', 'providerId']),
-      modelId: readRecordString(model, ['modelID', 'modelId']),
+      providerId: readRecordString(model, ['providerID', 'providerId']) || readRecordString(record, ['providerID', 'providerId']),
+      modelId: readRecordString(model, ['modelID', 'modelId']) || readRecordString(record, ['modelID', 'modelId']),
     },
     summary,
     revertedMessageId,
   }
 }
 
+export function normalizeSessionMessage(value: SdkSessionMessage | SdkMessage): NormalizedSessionMessage | null
+export function normalizeSessionMessage(value: unknown): NormalizedSessionMessage | null
 export function normalizeSessionMessage(value: unknown): NormalizedSessionMessage | null {
   const record = asRecord(value)
   const mergedInfo = { ...record, ...asRecord(record.info) }
@@ -261,12 +277,16 @@ export function normalizeSessionMessage(value: unknown): NormalizedSessionMessag
   }
 }
 
+export function normalizeSessionMessages(value: SdkSessionMessagesResponse): NormalizedSessionMessage[]
+export function normalizeSessionMessages(value: unknown): NormalizedSessionMessage[]
 export function normalizeSessionMessages(value: unknown): NormalizedSessionMessage[] {
   return asArray(value)
     .map(normalizeSessionMessage)
     .filter((message): message is NormalizedSessionMessage => Boolean(message))
 }
 
+export function normalizeMessagePart(value: SdkPart): NormalizedMessagePart | null
+export function normalizeMessagePart(value: unknown): NormalizedMessagePart | null
 export function normalizeMessagePart(value: unknown): NormalizedMessagePart | null {
   const record = asRecord(value)
   const type = readRecordString(record, ['type'])
@@ -296,6 +316,8 @@ export function normalizeMessagePart(value: unknown): NormalizedMessagePart | nu
   }
 }
 
+export function normalizeRuntimeEventEnvelope(value: SdkRuntimeEventEnvelope): NormalizedRuntimeEventEnvelope | null
+export function normalizeRuntimeEventEnvelope(value: unknown): NormalizedRuntimeEventEnvelope | null
 export function normalizeRuntimeEventEnvelope(value: unknown): NormalizedRuntimeEventEnvelope | null {
   const envelope = asRecord(value)
   const payload = asRecord(envelope.payload)
@@ -317,6 +339,8 @@ export function normalizeRuntimeEventEnvelope(value: unknown): NormalizedRuntime
   }
 }
 
+export function normalizeSessionStatuses(value: Record<string, SdkSessionStatus>): Record<string, NormalizedSessionStatus>
+export function normalizeSessionStatuses(value: unknown): Record<string, NormalizedSessionStatus>
 export function normalizeSessionStatuses(value: unknown): Record<string, NormalizedSessionStatus> {
   const record = asRecord(value)
   return Object.fromEntries(
@@ -327,6 +351,8 @@ export function normalizeSessionStatuses(value: unknown): Record<string, Normali
   )
 }
 
+export function normalizeMcpStatusEntries(value: Record<string, SdkMcpStatus>): NormalizedMcpStatusEntry[]
+export function normalizeMcpStatusEntries(value: unknown): NormalizedMcpStatusEntry[]
 export function normalizeMcpStatusEntries(value: unknown): NormalizedMcpStatusEntry[] {
   const record = asRecord(value)
   return Object.entries(record).map(([name, status]) => {

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -1,5 +1,5 @@
 import type { AgentConfig, Config, ProviderConfig } from '@opencode-ai/sdk/v2'
-import type { ProviderModelDescriptor } from '@open-cowork/shared'
+import type { CustomMcpConfig, ProviderModelDescriptor } from '@open-cowork/shared'
 import {
   getAppConfig,
   getConfiguredMcpsFromConfig,
@@ -20,6 +20,7 @@ import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-cus
 import { validateCustomMcpStdioCommand } from './mcp-stdio-policy.ts'
 import { evaluateBuiltInMcp, resolveCustomMcpRuntimeEntry, type BuiltInMcpSkipReason } from './runtime-mcp.ts'
 import { listEffectiveSkillsSync } from './effective-skills.ts'
+import { evaluateHttpMcpUrlResolved } from './mcp-url-policy.ts'
 
 type PlaceholderResolveOptions = {
   overrides?: Readonly<Record<string, string>>
@@ -232,7 +233,7 @@ export function buildEffectiveProviderRuntimeConfig(
   return null
 }
 
-export function buildRuntimeConfig(projectDirectory?: string | null): Config {
+function buildRuntimeConfigWithCustomMcps(projectDirectory: string | null | undefined, customMcps: CustomMcpConfig[]): Config {
   const settings = getEffectiveSettings()
   const appConfig = getAppConfig()
   const providerId = settings.effectiveProviderId || appConfig.providers.defaultProvider || 'openrouter'
@@ -279,7 +280,6 @@ export function buildRuntimeConfig(projectDirectory?: string | null): Config {
   }
 
   const contextOptions = { directory: projectDirectory || null }
-  const customMcps = listCustomMcps(contextOptions)
   const customSkills = listCustomSkills(contextOptions)
   const customAgentsRaw = listCustomAgents(contextOptions)
   const availableSkills = listEffectiveSkillsSync(contextOptions).map((skill) => ({
@@ -409,4 +409,39 @@ export function buildRuntimeConfig(projectDirectory?: string | null): Config {
   log('runtime', `Config built: provider=${providerId} model=${modelStr}`)
 
   return config
+}
+
+async function listRuntimeEligibleCustomMcps(projectDirectory?: string | null) {
+  const contextOptions = { directory: projectDirectory || null }
+  const customMcps = listCustomMcps(contextOptions)
+  const eligible: CustomMcpConfig[] = []
+
+  for (const customMcp of customMcps) {
+    if (customMcp.type === 'http' && customMcp.url) {
+      const verdict = await evaluateHttpMcpUrlResolved(customMcp.url, {
+        allowPrivateNetwork: customMcp.allowPrivateNetwork,
+      })
+      if (!verdict.ok) {
+        log('mcp', `Skipping HTTP MCP ${customMcp.name}: ${verdict.reason}`)
+        continue
+      }
+    }
+    eligible.push(customMcp)
+  }
+
+  return eligible
+}
+
+export function buildRuntimeConfig(projectDirectory?: string | null): Config {
+  return buildRuntimeConfigWithCustomMcps(
+    projectDirectory,
+    listCustomMcps({ directory: projectDirectory || null }),
+  )
+}
+
+export async function buildRuntimeConfigForRuntime(projectDirectory?: string | null): Promise<Config> {
+  return buildRuntimeConfigWithCustomMcps(
+    projectDirectory,
+    await listRuntimeEligibleCustomMcps(projectDirectory),
+  )
 }

--- a/apps/desktop/src/main/runtime-reconnect-policy.ts
+++ b/apps/desktop/src/main/runtime-reconnect-policy.ts
@@ -1,0 +1,9 @@
+export type RuntimeReconnectState = {
+  appCleanupStarted: boolean
+  appIsQuitting: boolean
+  reconnectTimerActive: boolean
+}
+
+export function shouldScheduleRuntimeReconnect(state: RuntimeReconnectState) {
+  return !state.appCleanupStarted && !state.appIsQuitting && !state.reconnectTimerActive
+}

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -22,7 +22,7 @@ import { getAdcPathIfAvailable, getAuthState } from './auth.ts'
 import { getEffectiveSettings, getProviderCredentialValue } from './settings.ts'
 import { applyBundledOpencodeCliEnvironment } from './runtime-opencode-cli.ts'
 import { clearProjectOverlayCopies } from './runtime-project-overlay.ts'
-import { buildRuntimeConfig } from './runtime-config-builder.ts'
+import { buildRuntimeConfigForRuntime } from './runtime-config-builder.ts'
 import { copySkillsAndAgents } from './runtime-content.ts'
 import { getOrCreateDirectoryClient } from './runtime-client-cache.ts'
 import { syncRuntimeHomeToolingBridge } from './runtime-home-bridge.ts'
@@ -354,28 +354,28 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
     activeProjectOverlayDirectory = copySkillsAndAgents(projectDirectory)
 
     // Build config in memory — SDK passes it via OPENCODE_CONFIG_CONTENT env var
-    const config = buildRuntimeConfig(projectDirectory)
+    const config = await buildRuntimeConfigForRuntime(projectDirectory)
 
     // Set CWD to sandbox runtime home so OpenCode discovers AGENTS.md and skills there.
     // Session-specific project routing is handled by directory-scoped SDK clients.
     process.chdir(getRuntimeHomeDir())
 
     try {
-      const result = await withRuntimeEnvironment(() =>
-        createOpencode({
-          hostname: '127.0.0.1',
-          port: 0,
-          config: config as any,
-          // SDK defaults this to 5000ms, which is too aggressive on
-          // directory-switch reboots — the opencode binary is cold-loading
-          // MCPs + doing filesystem scans, and commonly takes 8-15s. When
-          // the timeout fires, the SDK tries to kill the child, but the
-          // child often survives the signal and becomes a zombie holding
-          // ~50MB RSS + MCP subprocesses. After several failed reboots
-          // the zombies can accumulate to multi-GB. Give it real room.
-          timeout: 30_000,
-        } as Parameters<typeof createOpencode>[0] & { timeout?: number }),
-      )
+      type CreateOpencodeOptions = Parameters<typeof createOpencode>[0] & { timeout?: number }
+      const opencodeOptions: CreateOpencodeOptions = {
+        hostname: '127.0.0.1',
+        port: 0,
+        config,
+        // SDK defaults this to 5000ms, which is too aggressive on
+        // directory-switch reboots — the opencode binary is cold-loading
+        // MCPs + doing filesystem scans, and commonly takes 8-15s. When
+        // the timeout fires, the SDK tries to kill the child, but the
+        // child often survives the signal and becomes a zombie holding
+        // ~50MB RSS + MCP subprocesses. After several failed reboots
+        // the zombies can accumulate to multi-GB. Give it real room.
+        timeout: 30_000,
+      }
+      const result = await withRuntimeEnvironment(() => createOpencode(opencodeOptions))
 
       client = result.client
       serverUrl = result.server.url

--- a/apps/desktop/src/renderer/components/CommandPalette.test.tsx
+++ b/apps/desktop/src/renderer/components/CommandPalette.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import type { BuiltInAgentDetail } from '@open-cowork/shared'
+import { CommandPalette } from './CommandPalette'
+
+const researchAgent: BuiltInAgentDetail = {
+  name: 'research',
+  label: 'Research Agent',
+  source: 'open-cowork',
+  mode: 'subagent',
+  hidden: false,
+  disabled: false,
+  color: 'info',
+  description: 'Researches a focused question.',
+  instructions: 'Research thoroughly.',
+  skills: [],
+  toolAccess: [],
+  nativeToolIds: [],
+  configuredToolIds: [],
+}
+
+describe('CommandPalette', () => {
+  it('loads runtime agents and inserts @-mentions through a selected agent action', async () => {
+    vi.mocked(window.coworkApi.app.builtinAgents).mockResolvedValue([researchAgent])
+    const onClose = vi.fn()
+    const onNavigate = vi.fn()
+    const onEnsureSession = vi.fn(async () => true)
+    const onInsertComposer = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CommandPalette
+        onClose={onClose}
+        onNavigate={onNavigate}
+        onCreateThread={vi.fn(async () => null)}
+        onEnsureSession={onEnsureSession}
+        onInsertComposer={onInsertComposer}
+        onSetAgentMode={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onToggleSearch={vi.fn()}
+      />,
+    )
+
+    await user.type(screen.getByPlaceholderText('Search actions, agents, and commands...'), 'research')
+    await user.click(await screen.findByText('Research Agent'))
+
+    await waitFor(() => expect(onEnsureSession).toHaveBeenCalledTimes(1))
+    expect(onNavigate).toHaveBeenCalledWith('chat')
+    expect(onInsertComposer).toHaveBeenCalledWith('@research ')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/ApprovalCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ApprovalCard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { ApprovalCard } from './ApprovalCard'
+import type { PendingApproval } from '../../stores/session'
+
+const approval: PendingApproval = {
+  id: 'permission-1',
+  sessionId: 'session-1',
+  tool: 'gmail_send_email',
+  input: {
+    to: 'user@example.com',
+    subject: 'Launch notes',
+  },
+  description: 'Send a message',
+  order: 0,
+}
+
+describe('ApprovalCard', () => {
+  it('summarizes risky tool actions and sends explicit allow/deny decisions', async () => {
+    const user = userEvent.setup()
+    render(<ApprovalCard approval={approval} />)
+
+    expect(screen.getByText('Send email')).toBeTruthy()
+    expect(screen.getByText(/To: user@example\.com.*Launch notes/)).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'Approve' }))
+    await user.click(screen.getByRole('button', { name: 'Deny' }))
+
+    await waitFor(() => expect(window.coworkApi.permission.respond).toHaveBeenCalledTimes(2))
+    expect(window.coworkApi.permission.respond).toHaveBeenNthCalledWith(1, 'permission-1', true, 'session-1')
+    expect(window.coworkApi.permission.respond).toHaveBeenNthCalledWith(2, 'permission-1', false, 'session-1')
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/ChatInputAttachments.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputAttachments.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { ChatInputAttachments } from './ChatInputAttachments'
+import type { Attachment } from './chat-input-types'
+
+const attachments: Attachment[] = [
+  {
+    filename: 'chart.png',
+    mime: 'image/png',
+    url: 'data:image/png;base64,abc',
+    preview: 'data:image/png;base64,abc',
+  },
+  {
+    filename: 'brief.pdf',
+    mime: 'application/pdf',
+    url: 'data:application/pdf;base64,abc',
+  },
+]
+
+describe('ChatInputAttachments', () => {
+  it('renders image previews, file chips, and removal callbacks by index', async () => {
+    const user = userEvent.setup()
+    const onRemove = vi.fn()
+
+    render(<ChatInputAttachments attachments={attachments} onRemove={onRemove} />)
+
+    expect(screen.getByAltText('chart.png').getAttribute('src')).toBe('data:image/png;base64,abc')
+    expect(screen.getByText('brief.pdf')).toBeTruthy()
+    expect(screen.getByText('pdf')).toBeTruthy()
+
+    const removeButtons = screen.getAllByRole('button')
+    await user.click(removeButtons[1])
+
+    expect(onRemove).toHaveBeenCalledWith(1)
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/MarkdownContent.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownContent.test.tsx
@@ -1,0 +1,46 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { MarkdownContent } from './MarkdownContent'
+
+function copyButton(container: HTMLElement) {
+  return waitFor(() => {
+    const button = container.querySelector('[data-slot="markdown-copy-button"]')
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('Expected rendered markdown code block to include a copy button.')
+    }
+    return button
+  })
+}
+
+describe('MarkdownContent', () => {
+  it('sanitizes untrusted markdown HTML and copies code through the app clipboard bridge', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <MarkdownContent text={'Hello <img src="x" onerror="alert(1)" />\n<script>alert(1)</script>\n\n```ts\nconst value = 42\n```'} />,
+    )
+
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('[onerror]')).toBeNull()
+    expect(container.textContent).toContain('Hello')
+
+    const button = await copyButton(container)
+    await user.click(button)
+
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(window.coworkApi.clipboard.writeText).mock.calls[0]?.[0]).toContain('const value = 42')
+    expect(button.getAttribute('aria-label')).toBe('Copied')
+  })
+
+  it('leaves the copy affordance unchanged when clipboard writing fails', async () => {
+    vi.mocked(window.coworkApi.clipboard.writeText).mockResolvedValueOnce(false)
+    const user = userEvent.setup()
+    const { container } = render(<MarkdownContent text={'```txt\ncopy me\n```'} />)
+
+    const button = await copyButton(container)
+    await user.click(button)
+
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('copy me'))
+    expect(button.getAttribute('aria-label')).toBe('Copy code')
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/MermaidChart.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MermaidChart.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MermaidChart } from './MermaidChart'
+
+const mermaidMock = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  render: vi.fn(),
+}))
+
+vi.mock('mermaid', () => ({
+  default: mermaidMock,
+}))
+
+describe('MermaidChart', () => {
+  beforeEach(() => {
+    mermaidMock.render.mockResolvedValue({
+      svg: '<svg width="120" height="80"><script>alert(1)</script><g onclick="alert(2)"><text>Safe chart</text></g></svg>',
+      bindFunctions: vi.fn(),
+    })
+  })
+
+  it('renders third-party Mermaid SVG through the SVG sanitizer', async () => {
+    const { container } = render(<MermaidChart diagram="graph TD; A-->B" title="Flow" />)
+
+    await waitFor(() => expect(mermaidMock.render).toHaveBeenCalledWith(expect.stringMatching(/^open-cowork-mermaid-/), 'graph TD; A-->B'))
+    await waitFor(() => {
+      if (!container.querySelector('svg')) throw new Error('Expected sanitized SVG to render.')
+    })
+
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('[onclick]')).toBeNull()
+    expect(container.textContent).toContain('Flow')
+    expect(screen.getByLabelText('Zoom in mermaid diagram')).toBeTruthy()
+  })
+
+  it('shows a contained error state when Mermaid rejects a diagram', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mermaidMock.render.mockRejectedValueOnce(new Error('bad diagram'))
+
+    render(<MermaidChart diagram="not mermaid" />)
+
+    await screen.findByText('Mermaid error: bad diagram')
+    consoleError.mockRestore()
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/VegaChart.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/VegaChart.test.tsx
@@ -1,0 +1,21 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { VegaChart } from './VegaChart'
+
+describe('VegaChart', () => {
+  it('loads charts in a sandboxed frame and surfaces frame startup failures', () => {
+    vi.useFakeTimers()
+    render(<VegaChart spec={{ mark: 'bar', data: { values: [{ x: 'A', y: 1 }] } }} />)
+
+    const iframe = screen.getByTitle('Generated chart')
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin')
+    expect(iframe.getAttribute('src')).toContain('chart-frame.html')
+
+    fireEvent.load(iframe)
+    act(() => {
+      vi.advanceTimersByTime(3_000)
+    })
+
+    expect(screen.getByText('Chart error: Chart frame did not initialize')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProviderAuthMethod } from '@open-cowork/shared'
+import { ProviderAuthControls } from './ProviderAuthControls'
+
+const browserMethod: ProviderAuthMethod = {
+  type: 'oauth',
+  label: 'ChatGPT',
+}
+
+describe('ProviderAuthControls', () => {
+  it('drives the OpenCode-native browser auth flow and verifies provider connection', async () => {
+    vi.mocked(window.coworkApi.provider.authMethods).mockResolvedValue({
+      openai: [browserMethod],
+    })
+    vi.mocked(window.coworkApi.provider.authorize).mockResolvedValue({
+      url: 'https://auth.example.test',
+      method: 'auto',
+      instructions: 'Finish in your browser.',
+    })
+    vi.mocked(window.coworkApi.provider.list).mockResolvedValue([
+      { id: 'openai', name: 'OpenAI', connected: true },
+    ])
+    const onBeforeAuthorize = vi.fn(async () => true)
+    const onAuthUpdated = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ProviderAuthControls
+        providerId="openai"
+        providerName="OpenAI"
+        connected={false}
+        onBeforeAuthorize={onBeforeAuthorize}
+        onAuthUpdated={onAuthUpdated}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Sign in with ChatGPT' }))
+
+    expect(onBeforeAuthorize).toHaveBeenCalledTimes(1)
+    expect(window.coworkApi.provider.authorize).toHaveBeenCalledWith('openai', 0, {})
+    expect(screen.getByText('Browser login opened. Complete the flow there, then return here and confirm so Open Cowork can verify the new login.')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: "I've finished signing in" }))
+
+    await waitFor(() => expect(onAuthUpdated).toHaveBeenCalledTimes(1))
+    expect(window.coworkApi.runtime.restart).not.toHaveBeenCalled()
+    expect(screen.getByText('Provider login completed.')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { CoworkAPI } from '@open-cowork/shared'
+
+type TestCoworkApi = {
+  [Group in keyof CoworkAPI]?: Record<string, unknown>
+}
+
+function installCoworkApi(overrides: TestCoworkApi = {}) {
+  const api: TestCoworkApi = {
+    app: {
+      builtinAgents: vi.fn(async () => []),
+      config: vi.fn(async () => ({
+        appId: 'com.opencowork.desktop',
+        name: 'Open Cowork',
+        helpUrl: 'https://github.com/joe-broadhead/open-cowork',
+        defaultModel: null,
+        providers: [],
+        auth: { mode: 'none' },
+      })),
+    },
+    agents: {
+      list: vi.fn(async () => []),
+      runtime: vi.fn(async () => []),
+    },
+    artifact: {
+      export: vi.fn(async () => null),
+      readAttachment: vi.fn(async () => ({
+        filename: 'chart.png',
+        mime: 'image/png',
+        url: 'data:image/png;base64,',
+      })),
+      reveal: vi.fn(async () => true),
+    },
+    chart: {
+      saveArtifact: vi.fn(async () => ({
+        id: 'artifact-1',
+        toolId: 'tool-call-1',
+        toolName: 'chart',
+        filename: 'chart.png',
+        filePath: '/tmp/chart.png',
+        order: 0,
+        mime: 'image/png',
+      })),
+    },
+    clipboard: {
+      writeText: vi.fn(async () => true),
+    },
+    command: {
+      list: vi.fn(async () => []),
+      run: vi.fn(async () => true),
+    },
+    dialog: {
+      selectDirectory: vi.fn(async () => null),
+    },
+    permission: {
+      respond: vi.fn(async () => undefined),
+    },
+    provider: {
+      authMethods: vi.fn(async () => ({})),
+      authorize: vi.fn(async () => null),
+      callback: vi.fn(async () => false),
+      list: vi.fn(async () => []),
+    },
+    runtime: {
+      restart: vi.fn(async () => ({
+        ready: true,
+        running: true,
+        sessions: 0,
+        uptimeMs: 0,
+      })),
+    },
+  }
+
+  for (const [key, value] of Object.entries(overrides) as Array<[keyof CoworkAPI, Record<string, unknown>]>) {
+    api[key] = {
+      ...(api[key] || {}),
+      ...value,
+    } as TestCoworkApi[typeof key]
+  }
+
+  Object.defineProperty(window, 'coworkApi', {
+    configurable: true,
+    writable: true,
+    value: api as CoworkAPI,
+  })
+
+  return window.coworkApi
+}
+
+class TestResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+class TestIntersectionObserver implements IntersectionObserver {
+  readonly root = null
+  readonly rootMargin = ''
+  readonly scrollMargin = ''
+  readonly thresholds = []
+  disconnect() {}
+  observe() {}
+  takeRecords() {
+    return []
+  }
+  unobserve() {}
+}
+
+class TestStorage implements Storage {
+  private readonly values = new Map<string, string>()
+
+  get length() {
+    return this.values.size
+  }
+
+  clear() {
+    this.values.clear()
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  configurable: true,
+  writable: true,
+  value: TestResizeObserver,
+})
+
+Object.defineProperty(globalThis, 'IntersectionObserver', {
+  configurable: true,
+  writable: true,
+  value: TestIntersectionObserver,
+})
+
+Object.defineProperty(window, 'matchMedia', {
+  configurable: true,
+  writable: true,
+  value: vi.fn((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+Object.defineProperty(navigator, 'clipboard', {
+  configurable: true,
+  writable: true,
+  value: {
+    writeText: vi.fn(async () => undefined),
+  },
+})
+
+const testLocalStorage = new TestStorage()
+const testSessionStorage = new TestStorage()
+
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  writable: true,
+  value: testLocalStorage,
+})
+
+Object.defineProperty(window, 'sessionStorage', {
+  configurable: true,
+  writable: true,
+  value: testSessionStorage,
+})
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  writable: true,
+  value: testLocalStorage,
+})
+
+Object.defineProperty(globalThis, 'sessionStorage', {
+  configurable: true,
+  writable: true,
+  value: testSessionStorage,
+})
+
+const svgGraphicsPrototype: object = typeof SVGGraphicsElement !== 'undefined'
+  ? SVGGraphicsElement.prototype
+  : SVGElement.prototype
+
+if (!('getBBox' in svgGraphicsPrototype)) {
+  Object.defineProperty(svgGraphicsPrototype, 'getBBox', {
+    configurable: true,
+    value: () => ({ x: 0, y: 0, width: 120, height: 80 }),
+  })
+}
+
+if (!HTMLElement.prototype.scrollIntoView) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: () => undefined,
+  })
+}
+
+beforeEach(() => {
+  installCoworkApi()
+  window.localStorage.clear()
+  window.sessionStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+export { installCoworkApi as installRendererTestCoworkApi }

--- a/apps/desktop/tests/custom-mcp-add.smoke.test.ts
+++ b/apps/desktop/tests/custom-mcp-add.smoke.test.ts
@@ -44,6 +44,7 @@ test('custom MCP add → list → remove round-trips through the IPC surface', a
     const probe = afterAdd.find((mcp: { name: string }) => mcp.name === probeName)
     assert.ok(probe, 'newly added MCP must appear in list')
     assert.equal((probe as { type: string }).type, 'http')
+    assert.equal((probe as { allowPrivateNetwork?: boolean }).allowPrivateNetwork, true)
 
     // SSRF guard rejects loopback URLs unless allowPrivateNetwork is set.
     // Try to add a second MCP without the opt-in; it must be rejected.

--- a/apps/desktop/vitest.renderer.config.ts
+++ b/apps/desktop/vitest.renderer.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost/',
+      },
+    },
+    include: ['src/renderer/**/*.test.{ts,tsx}'],
+    setupFiles: ['./src/renderer/test/setup.ts'],
+    clearMocks: true,
+    mockReset: false,
+    restoreMocks: false,
+  },
+})

--- a/docs/first-contribution.md
+++ b/docs/first-contribution.md
@@ -44,14 +44,23 @@ please PR" is the fastest path to a green merge.
 ```bash
 pnpm typecheck    # TypeScript strict mode across all workspaces
 pnpm test         # repo unit/integration test suite
+pnpm test:renderer # Vitest/jsdom renderer component suite
 pnpm lint         # ESLint + security rules + repo-specific checks
 pnpm perf:check   # Regression gate against benchmarks/perf-baseline.json
 ```
 
-All four run on every PR in CI, so pushing green locally saves a
+All five run on every PR in CI, so pushing green locally saves a
 round trip. If `perf:check` regresses and the regression is known-
 acceptable (e.g. you added a new benchmark case), refresh the
 baseline with `pnpm perf:baseline` and commit the updated JSON.
+
+## Renderer component tests
+
+Renderer component tests live next to the components under
+`apps/desktop/src/renderer/**/*.test.tsx` and run with
+`pnpm test:renderer`. Use them for branchy UI behavior, unsafe
+content rendering, permission/auth controls, and component-level
+regressions that do not need a full Electron process.
 
 ## Playwright smoke tests
 
@@ -102,7 +111,7 @@ If you're landing a change that touches a release-visible surface
 (build scripts, CI, changelog, docs), run through the checklist:
 
 ```bash
-pnpm typecheck && pnpm lint && pnpm test && pnpm perf:check && python -m pip install -r docs/requirements.txt && mkdocs build --strict
+pnpm typecheck && pnpm lint && pnpm test && pnpm test:renderer && pnpm perf:check && python -m pip install -r docs/requirements.txt && mkdocs build --strict
 ```
 
 That covers the main repository quality gates. Release tags also run

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,6 +24,7 @@ ready to merge unless it survives:
 - `pnpm lint:a11y --max-warnings=0`
 - `git diff --check`
 - `pnpm test`
+- `pnpm test:renderer`
 - `pnpm typecheck`
 - `pnpm perf:check`
 - `mkdocs build --strict`

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -14,6 +14,7 @@ Reference workflows in the repository root:
 ### Repository quality
 
 - [ ] `pnpm test`
+- [ ] `pnpm test:renderer`
 - [ ] `pnpm typecheck`
 - [ ] `pnpm lint`
 - [ ] `pnpm perf:check`

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -122,8 +122,9 @@ policies:
 
 ### URL policy (HTTP MCPs)
 
-`evaluateHttpMcpUrl` in `apps/desktop/src/main/mcp-url-policy.ts`
-rejects:
+`evaluateHttpMcpUrl` / `evaluateHttpMcpUrlResolved` in
+`apps/desktop/src/main/mcp-url-policy.ts` reject literal and
+DNS-resolved targets for:
 
 - Non-`http`/`https` schemes.
 - Loopback (`127.0.0.0/8`, `::1`, `localhost`) — blocks tunnels to
@@ -134,9 +135,10 @@ rejects:
   and IPv6 ULAs (`fc00::/7`) — blocks corporate-internal pivot.
 
 The `allowPrivateNetwork` flag on `CustomMcpConfig` is the only way to
-bypass the guard, and the UI surfaces a warning when it's set. This
-closes SSRF vectors both at save time (`custom:add-mcp`) and at
-test time (`custom:test-mcp`).
+bypass the guard, and the UI surfaces a warning when it's set. The guard
+runs at save time (`custom:add-mcp`), test time (`custom:test-mcp`), and
+runtime registration, so public-looking hostnames that resolve into
+private networks are skipped before OpenCode receives the MCP entry.
 
 ### stdio policy (stdio MCPs)
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lint": "eslint . --max-warnings 0 && node scripts/lint.mjs",
     "lint:a11y": "eslint --config eslint.a11y.config.mjs 'apps/desktop/src/renderer/**/*.tsx'",
     "test": "pnpm --filter @open-cowork/shared build && node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/*.test.ts",
+    "test:renderer": "pnpm --filter @open-cowork/desktop test:renderer",
     "test:e2e": "pnpm --filter @open-cowork/desktop test:e2e",
     "test:e2e:packaged": "pnpm --filter @open-cowork/desktop test:e2e:packaged",
     "screenshots": "pnpm --filter @open-cowork/desktop screenshots",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,15 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -137,6 +146,9 @@ importers:
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      jsdom:
+        specifier: ^29.1.0
+        version: 29.1.0
       playwright-core:
         specifier: ^1.59.1
         version: 1.59.1
@@ -155,6 +167,9 @@ importers:
       vite-plugin-electron-renderer:
         specifier: ^0.14.0
         version: 0.14.6
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1))
 
   mcps/charts:
     dependencies:
@@ -205,11 +220,45 @@ packages:
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@chevrotain/cst-dts-gen@12.0.0':
     resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
@@ -225,6 +274,42 @@ packages:
 
   '@chevrotain/utils@12.0.0':
     resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -474,6 +559,15 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
@@ -660,6 +754,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -767,11 +864,46 @@ packages:
   '@tanstack/virtual-core@3.14.0':
     resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -868,6 +1000,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1015,6 +1150,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -1075,6 +1239,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1091,6 +1259,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1119,6 +1290,10 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1169,6 +1344,9 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -1236,6 +1414,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1343,6 +1525,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -1373,6 +1558,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1545,6 +1737,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1568,6 +1764,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1627,6 +1826,12 @@ packages:
     engines: {node: '>=8'}
     os: [darwin]
     hasBin: true
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dompurify@3.4.1:
     resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
@@ -1698,6 +1903,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1716,6 +1925,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1812,6 +2024,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1827,6 +2042,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -2115,6 +2334,10 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -2167,6 +2390,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -2273,6 +2500,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2346,9 +2576,21 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.0:
+    resolution: {integrity: sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
@@ -2523,9 +2765,17 @@ packages:
   lowlight@3.3.0:
     resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2595,6 +2845,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2720,6 +2973,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2828,6 +3085,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2928,6 +3188,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3006,6 +3269,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -3056,6 +3323,9 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
@@ -3069,6 +3339,10 @@ packages:
   read-binary-file-arch@1.0.6:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3183,6 +3457,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -3253,6 +3531,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3285,6 +3566,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
@@ -3292,6 +3576,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3332,6 +3619,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -3348,6 +3639,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
@@ -3370,6 +3664,9 @@ packages:
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -3377,6 +3674,17 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -3392,6 +3700,14 @@ packages:
   topojson-client@3.1.0:
     resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
     hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3464,6 +3780,10 @@ packages:
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3697,6 +4017,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -3717,12 +4078,28 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3755,6 +4132,11 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -3770,9 +4152,16 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3841,12 +4230,48 @@ snapshots:
 
   7zip-bin@5.2.0: {}
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
   '@braintree/sanitize-url@7.1.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@chevrotain/cst-dts-gen@12.0.0':
     dependencies:
@@ -3862,6 +4287,30 @@ snapshots:
   '@chevrotain/types@12.0.0': {}
 
   '@chevrotain/utils@12.0.0': {}
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -4089,6 +4538,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@exodus/bytes@1.15.0': {}
+
   '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
@@ -4242,6 +4693,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -4322,10 +4775,46 @@ snapshots:
 
   '@tanstack/virtual-core@3.14.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -4333,6 +4822,11 @@ snapshots:
       '@types/keyv': 3.1.4
       '@types/node': 25.6.0
       '@types/responselike': 1.0.3
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -4454,6 +4948,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -4631,6 +5127,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xmldom/xmldom@0.8.13': {}
 
   abbrev@4.0.0: {}
@@ -4685,6 +5222,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   app-builder-bin@5.0.0-alpha.12: {}
@@ -4734,6 +5273,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -4779,6 +5322,8 @@ snapshots:
   assert-plus@1.0.0:
     optional: true
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astral-regex@2.0.0:
@@ -4809,6 +5354,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bignumber.js@9.3.1: {}
 
@@ -4915,6 +5464,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -5004,6 +5555,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -5037,6 +5590,13 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
 
@@ -5234,6 +5794,13 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -5257,6 +5824,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -5330,6 +5899,10 @@ snapshots:
       smart-buffer: 4.2.0
       verror: 1.10.1
     optional: true
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dompurify@3.4.1:
     optionalDependencies:
@@ -5434,6 +6007,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@8.0.0: {}
+
   env-paths@2.2.1: {}
 
   err-code@2.0.3: {}
@@ -5498,6 +6073,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5653,6 +6230,10 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -5662,6 +6243,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -6078,6 +6661,12 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -6133,6 +6722,8 @@ snapshots:
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -6235,6 +6826,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -6298,9 +6891,37 @@ snapshots:
 
   jose@6.2.2: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-bigint@1.0.0:
     dependencies:
@@ -6454,9 +7075,13 @@ snapshots:
       devlop: 1.1.0
       highlight.js: 11.11.1
 
+  lru-cache@11.3.5: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -6627,6 +7252,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -6865,6 +7492,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -6977,6 +7606,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7077,6 +7708,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-data-parser@0.1.0: {}
@@ -7137,6 +7772,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proc-log@6.1.0: {}
 
   progress@2.0.3: {}
@@ -7186,6 +7827,8 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
+  react-is@17.0.2: {}
+
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       '@types/hast': 3.0.4
@@ -7211,6 +7854,11 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -7394,6 +8042,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver-compare@1.0.0:
@@ -7493,6 +8145,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-update-notifier@2.0.0:
@@ -7523,9 +8177,13 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7586,6 +8244,10 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -7605,6 +8267,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@4.2.4: {}
 
@@ -7632,12 +8296,22 @@ snapshots:
     dependencies:
       semver: 5.7.2
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
 
   tmp-promise@3.0.3:
     dependencies:
@@ -7650,6 +8324,14 @@ snapshots:
   topojson-client@3.1.0:
     dependencies:
       commander: 2.20.3
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -7729,6 +8411,8 @@ snapshots:
   undici-types@7.19.2: {}
 
   undici@6.25.0: {}
+
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -8089,6 +8773,34 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      jsdom: 29.1.0
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -8106,9 +8818,25 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -8163,6 +8891,11 @@ snapshots:
     dependencies:
       isexe: 4.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
@@ -8179,7 +8912,11 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'fs'
+import { validateResolvedConfig } from '../apps/desktop/src/main/config-schema.ts'
+
+test('root open-cowork.config.json validates against the public schema', () => {
+  const config = JSON.parse(readFileSync('open-cowork.config.json', 'utf-8'))
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'open-cowork.config.json'))
+})

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -153,7 +153,7 @@ test('custom:test-mcp reports OAuth guidance for remote MCP auth errors', async 
   const mcp: CustomMcpConfig = {
     name: 'nova',
     type: 'http',
-    url: 'https://example.com/mcp',
+    url: 'https://93.184.216.34/mcp',
     scope: 'machine',
     directory: null,
   }

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -1,11 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'fs'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
 import { registerAppHandlers } from '../apps/desktop/src/main/ipc/app-handlers.ts'
 import { registerArtifactHandlers } from '../apps/desktop/src/main/ipc/artifact-handlers.ts'
+import { registerAutomationHandlers } from '../apps/desktop/src/main/ipc/automation-handlers.ts'
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCatalogHandlers } from '../apps/desktop/src/main/ipc/catalog-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
+import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
 
 function createTestContext() {
   const handlers = new Map<string, unknown>()
@@ -54,9 +57,12 @@ test('IPC handler modules register their core channels', () => {
 
   registerAppHandlers(context)
   registerArtifactHandlers(context)
+  registerAutomationHandlers(context)
   registerSessionHandlers(context)
   registerCatalogHandlers(context)
   registerCustomContentHandlers(context)
+  registerExplorerHandlers(context)
+  context.ipcMain.handle('confirm:request-destructive', async () => ({ token: 'test' }))
 
   // One-way fire-and-forget channels (renderer uses `send`) must also
   // be registered. Guards against regressions like the renderer panic
@@ -77,6 +83,37 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('capabilities:tools'), true)
   assert.equal(handlers.has('custom:add-mcp'), true)
   assert.equal(handlers.has('custom:import-skill-directory'), true)
+})
+
+test('preload invoke/send channels match registered main-process IPC channels', () => {
+  const { context, handlers, listeners } = createTestContext()
+
+  registerAppHandlers(context)
+  registerArtifactHandlers(context)
+  registerAutomationHandlers(context)
+  registerSessionHandlers(context)
+  registerCatalogHandlers(context)
+  registerCustomContentHandlers(context)
+  registerExplorerHandlers(context)
+  context.ipcMain.handle('confirm:request-destructive', async () => ({ token: 'test' }))
+
+  const preloadSource = readFileSync('apps/desktop/src/preload/index.ts', 'utf-8')
+  const exposedInvokes = new Set(
+    Array.from(preloadSource.matchAll(/ipcRenderer\.invoke\('([^']+)'/g), (match) => match[1]),
+  )
+  const exposedSends = new Set(
+    Array.from(preloadSource.matchAll(/ipcRenderer\.send\('([^']+)'/g), (match) => match[1]),
+  )
+
+  const missingInvokeHandlers = [...exposedInvokes].filter((channel) => !handlers.has(channel)).sort()
+  const unexposedInvokeHandlers = [...handlers.keys()].filter((channel) => !exposedInvokes.has(channel)).sort()
+  const missingSendListeners = [...exposedSends].filter((channel) => !listeners.has(channel)).sort()
+  const unexposedSendListeners = [...listeners.keys()].filter((channel) => !exposedSends.has(channel)).sort()
+
+  assert.deepEqual(missingInvokeHandlers, [])
+  assert.deepEqual(unexposedInvokeHandlers, [])
+  assert.deepEqual(missingSendListeners, [])
+  assert.deepEqual(unexposedSendListeners, [])
 })
 
 test('provider auth IPC fails closed for malformed renderer input before runtime access', async () => {

--- a/tests/mcp-url-policy.test.ts
+++ b/tests/mcp-url-policy.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { evaluateHttpMcpUrl } from '../apps/desktop/src/main/mcp-url-policy.ts'
+import { evaluateHttpMcpUrl, evaluateHttpMcpUrlResolved } from '../apps/desktop/src/main/mcp-url-policy.ts'
 
 test('evaluateHttpMcpUrl accepts public internet URLs by default', () => {
   const result = evaluateHttpMcpUrl('https://api.example.com/mcp')
@@ -64,4 +64,44 @@ test('evaluateHttpMcpUrl rejects malformed URLs with a clear reason', () => {
 test('evaluateHttpMcpUrl rejects empty input', () => {
   const result = evaluateHttpMcpUrl('')
   assert.equal(result.ok, false)
+})
+
+test('evaluateHttpMcpUrlResolved accepts public DNS answers', async () => {
+  const result = await evaluateHttpMcpUrlResolved('https://api.example.com/mcp', {
+    resolveHostname: async () => [{ address: '93.184.216.34', family: 4 }],
+  })
+  assert.equal(result.ok, true)
+})
+
+test('evaluateHttpMcpUrlResolved rejects public-looking hostnames resolving to private networks', async () => {
+  for (const address of ['127.0.0.1', '10.0.0.5', '169.254.169.254', 'fd00::1']) {
+    const result = await evaluateHttpMcpUrlResolved('https://mcp.example.com/api', {
+      resolveHostname: async () => [{ address }],
+    })
+    assert.equal(result.ok, false, `expected reject for resolved ${address}`)
+    if (result.ok === false) assert.match(result.reason, /resolves/i)
+  }
+})
+
+test('evaluateHttpMcpUrlResolved skips DNS checks when private networks are explicitly allowed', async () => {
+  let resolverCalled = false
+  const result = await evaluateHttpMcpUrlResolved('https://mcp.example.com/api', {
+    allowPrivateNetwork: true,
+    resolveHostname: async () => {
+      resolverCalled = true
+      return [{ address: '127.0.0.1', family: 4 }]
+    },
+  })
+  assert.equal(result.ok, true)
+  assert.equal(resolverCalled, false)
+})
+
+test('evaluateHttpMcpUrlResolved fails closed on DNS resolution errors', async () => {
+  const result = await evaluateHttpMcpUrlResolved('https://missing.example.test/api', {
+    resolveHostname: async () => {
+      throw new Error('ENOTFOUND')
+    },
+  })
+  assert.equal(result.ok, false)
+  if (result.ok === false) assert.match(result.reason, /Could not resolve/i)
 })

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import {
+  listCustomMcps,
   listCustomAgents,
   removeCustomMcp,
   saveCustomMcp,
@@ -43,6 +44,7 @@ test('project-scoped MCP edits preserve JSONC comments and unrelated keys', () =
       description: 'Warehouse MCP',
       type: 'http',
       url: 'https://warehouse.example.test/mcp',
+      allowPrivateNetwork: true,
     })
 
     let updated = readFileSync(configPath, 'utf-8')
@@ -51,7 +53,13 @@ test('project-scoped MCP edits preserve JSONC comments and unrelated keys', () =
     assert.match(updated, /"existing"/)
     assert.match(updated, /"warehouse"/)
     assert.doesNotMatch(updated, /Warehouse MCP/)
-    assert.equal(JSON.parse(readFileSync(metadataPath, 'utf-8')).warehouse.description, 'Warehouse MCP')
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
+    assert.equal(metadata.warehouse.description, 'Warehouse MCP')
+    assert.equal(metadata.warehouse.allowPrivateNetwork, true)
+
+    const savedMcp = listCustomMcps({ directory: projectRoot }).find((entry) => entry.name === 'warehouse')
+    assert.ok(savedMcp)
+    assert.equal(savedMcp.allowPrivateNetwork, true)
 
     removeCustomMcp({
       scope: 'project',
@@ -66,6 +74,34 @@ test('project-scoped MCP edits preserve JSONC comments and unrelated keys', () =
     assert.doesNotMatch(updated, /"warehouse"/)
     assert.equal(existsSync(metadataPath), false)
   } finally {
+    rmSync(projectRoot, { recursive: true, force: true })
+  }
+})
+
+test('custom MCP auth opt-ins round-trip through managed sidecar metadata', () => {
+  const projectRoot = testTempDir('opencowork-native-mcp-flags-')
+
+  try {
+    saveCustomMcp({
+      scope: 'project',
+      directory: projectRoot,
+      name: 'workspace',
+      label: 'Workspace',
+      type: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      googleAuth: true,
+    })
+
+    const savedMcp = listCustomMcps({ directory: projectRoot }).find((entry) => entry.name === 'workspace')
+    assert.ok(savedMcp)
+    assert.equal(savedMcp.googleAuth, true)
+
+    const metadataPath = join(projectRoot, '.opencowork', 'mcp.open-cowork.json')
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
+    assert.equal(metadata.workspace.googleAuth, true)
+  } finally {
+    removeCustomMcp({ scope: 'project', directory: projectRoot, name: 'workspace' })
     rmSync(projectRoot, { recursive: true, force: true })
   }
 })

--- a/tests/opencode-adapter.test.ts
+++ b/tests/opencode-adapter.test.ts
@@ -1,10 +1,21 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import type {
+  Event as SdkEvent,
+  McpStatus as SdkMcpStatus,
+  Message as SdkMessage,
+  Part as SdkPart,
+  Session as SdkSession,
+  SessionMessagesResponse as SdkSessionMessagesResponse,
+  SessionStatus as SdkSessionStatus,
+} from '@opencode-ai/sdk/v2'
 import {
   normalizeMcpStatusEntries,
   normalizeRuntimeCommands,
   normalizeRuntimeEventEnvelope,
+  normalizeSessionInfo,
   normalizeSessionMessages,
+  normalizeSessionStatuses,
   normalizeShareUrl,
 } from '../apps/desktop/src/main/opencode-adapter.ts'
 
@@ -161,4 +172,79 @@ test('normalizeShareUrl supports string and nested share payloads', () => {
     normalizeShareUrl({ share: { url: 'https://example.com/share/2' } }),
     'https://example.com/share/2',
   )
+})
+
+test('opencode adapter accepts current SDK session, message, part, status, and event types', () => {
+  const session = {
+    id: 'ses_sdk',
+    slug: 'sdk',
+    projectID: 'proj',
+    directory: '/tmp/project',
+    title: 'SDK session',
+    version: '1.14.25',
+    time: { created: 1, updated: 2 },
+    summary: { additions: 3, deletions: 1, files: 2 },
+  } satisfies SdkSession
+
+  const assistantMessage = {
+    id: 'msg_sdk',
+    sessionID: 'ses_sdk',
+    role: 'assistant',
+    time: { created: 3, completed: 4 },
+    parentID: 'msg_parent',
+    modelID: 'gpt-5.5',
+    providerID: 'openai',
+    mode: 'build',
+    agent: 'build',
+    path: { cwd: '/tmp/project', root: '/tmp/project' },
+    cost: 0.01,
+    tokens: {
+      input: 10,
+      output: 20,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    structured: { ok: true },
+  } satisfies Extract<SdkMessage, { role: 'assistant' }>
+
+  const textPart = {
+    id: 'part_sdk',
+    sessionID: 'ses_sdk',
+    messageID: 'msg_sdk',
+    type: 'text',
+    text: 'hello from sdk',
+  } satisfies SdkPart
+
+  const messages = [{
+    info: assistantMessage,
+    parts: [textPart],
+  }] satisfies SdkSessionMessagesResponse
+
+  const event = {
+    type: 'message.part.updated',
+    properties: {
+      sessionID: 'ses_sdk',
+      part: textPart,
+      time: 5,
+    },
+  } satisfies SdkEvent
+
+  const mcpStatuses = {
+    charts: { status: 'connected' },
+    blocked: { status: 'failed', error: 'Non-200 status code (403)' },
+  } satisfies Record<string, SdkMcpStatus>
+
+  const sessionStatuses = {
+    ses_sdk: { type: 'busy' },
+  } satisfies Record<string, SdkSessionStatus>
+
+  assert.equal(normalizeSessionInfo(session)?.id, 'ses_sdk')
+  assert.deepEqual(normalizeSessionInfo(assistantMessage)?.model, {
+    providerId: 'openai',
+    modelId: 'gpt-5.5',
+  })
+  assert.equal(normalizeSessionMessages(messages)[0]?.parts[0]?.text, 'hello from sdk')
+  assert.equal(normalizeRuntimeEventEnvelope(event)?.type, 'message.part.updated')
+  assert.deepEqual(normalizeSessionStatuses(sessionStatuses), { ses_sdk: { type: 'busy' } })
+  assert.equal(normalizeMcpStatusEntries(mcpStatuses)[1]?.rawStatus, 'auth_required')
 })

--- a/tests/runtime-reconnect-policy.test.ts
+++ b/tests/runtime-reconnect-policy.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { shouldScheduleRuntimeReconnect } from '../apps/desktop/src/main/runtime-reconnect-policy.ts'
+
+test('runtime reconnect remains enabled after startup cleanup', () => {
+  assert.equal(shouldScheduleRuntimeReconnect({
+    appCleanupStarted: false,
+    appIsQuitting: false,
+    reconnectTimerActive: false,
+  }), true)
+})
+
+test('runtime reconnect is blocked only by shutdown or an active reconnect timer', () => {
+  assert.equal(shouldScheduleRuntimeReconnect({
+    appCleanupStarted: true,
+    appIsQuitting: false,
+    reconnectTimerActive: false,
+  }), false)
+  assert.equal(shouldScheduleRuntimeReconnect({
+    appCleanupStarted: false,
+    appIsQuitting: true,
+    reconnectTimerActive: false,
+  }), false)
+  assert.equal(shouldScheduleRuntimeReconnect({
+    appCleanupStarted: false,
+    appIsQuitting: false,
+    reconnectTimerActive: true,
+  }), false)
+})


### PR DESCRIPTION
## Summary
- add a Vitest/jsdom renderer component test stack and gate it in CI/release preflight
- harden release readiness gaps: runtime reconnect policy, DNS-aware HTTP MCP validation, MCP opt-in metadata persistence, SDK-typed OpenCode adapter checks, config schema and IPC contract tests
- update contributor, operations, release, and security docs for the new gates and MCP DNS policy

## Review notes
- Renderer tests are isolated from the Electron/Vite app config so they do not inherit Electron plugins or packaging behavior.
- HTTP MCP DNS checks fail closed unless the user explicitly enables allowPrivateNetwork.
- v0.x GitHub Releases are marked prerelease automatically.

## Validation
- pnpm test:renderer
- pnpm typecheck
- pnpm lint
- pnpm lint:a11y --max-warnings=0
- pnpm test
- pnpm docs:build
- pnpm audit --prod --audit-level high
- pnpm perf:check
- pnpm test:e2e
- pnpm notices
- git diff --check