### PR TITLE
fix: preserve Mermaid chart labels

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MermaidChart.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MermaidChart.test.tsx
@@ -14,7 +14,7 @@ vi.mock('mermaid', () => ({
 describe('MermaidChart', () => {
   beforeEach(() => {
     mermaidMock.render.mockResolvedValue({
-      svg: '<svg width="120" height="80"><script>alert(1)</script><g onclick="alert(2)"><text>Safe chart</text></g></svg>',
+      svg: '<svg width="120" height="80"><script>alert(1)</script><foreignObject><div>Unsafe HTML label</div></foreignObject><g onclick="alert(2)"><text>Safe chart</text></g></svg>',
       bindFunctions: vi.fn(),
     })
   })
@@ -28,9 +28,17 @@ describe('MermaidChart', () => {
     })
 
     expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('foreignObject')).toBeNull()
     expect(container.querySelector('[onclick]')).toBeNull()
     expect(container.textContent).toContain('Flow')
+    expect(container.textContent).toContain('Safe chart')
     expect(screen.getByLabelText('Zoom in mermaid diagram')).toBeTruthy()
+    expect(mermaidMock.initialize).toHaveBeenCalledWith(expect.objectContaining({
+      htmlLabels: false,
+      flowchart: { htmlLabels: false },
+      secure: ['secure', 'securityLevel', 'startOnLoad', 'maxTextSize', 'suppressErrorRendering', 'maxEdges', 'htmlLabels'],
+      securityLevel: 'strict',
+    }))
   })
 
   it('shows a contained error state when Mermaid rejects a diagram', async () => {

--- a/apps/desktop/src/renderer/components/chat/MermaidChart.tsx
+++ b/apps/desktop/src/renderer/components/chat/MermaidChart.tsx
@@ -24,6 +24,16 @@ type MermaidTheme = {
 
 let mermaidModulePromise: Promise<{ default: typeof import('mermaid')['default'] }> | null = null
 
+const MERMAID_SECURE_CONFIG_KEYS = [
+  'secure',
+  'securityLevel',
+  'startOnLoad',
+  'maxTextSize',
+  'suppressErrorRendering',
+  'maxEdges',
+  'htmlLabels',
+]
+
 function loadMermaid() {
   mermaidModulePromise ||= import('mermaid') as Promise<{ default: typeof import('mermaid')['default'] }>
   return mermaidModulePromise
@@ -138,8 +148,13 @@ export function MermaidChart({ diagram, title }: Props) {
         mermaid.initialize({
           startOnLoad: false,
           securityLevel: 'strict',
+          htmlLabels: false,
+          secure: MERMAID_SECURE_CONFIG_KEYS,
           theme: 'base',
           themeVariables: chartTheme,
+          flowchart: {
+            htmlLabels: false,
+          },
         })
 
         const { svg, bindFunctions } = await mermaid.render(renderId, diagram)


### PR DESCRIPTION
## Summary
- disable Mermaid HTML labels at the root config level so SVG labels survive DOMPurify sanitization
- lock Mermaid security/html-label config against diagram overrides
- extend the renderer regression test to assert unsafe SVG content is stripped while SVG text labels remain visible

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- MermaidChart --run
- pnpm typecheck
- pnpm build
- git diff --check