### PR TITLE
Patch/startup fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ site/
 .env.local
 .env.*.local
 .venv-docs/
-local/
 
 # OS
 .DS_Store
@@ -35,7 +34,7 @@ Thumbs.db
 .idea/
 .claude/
 .opencode/
-.codex
+.codex/
 *.swp
 *.swo
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ site/
 .env.local
 .env.*.local
 .venv-docs/
+local/
 
 # OS
 .DS_Store
@@ -34,6 +35,7 @@ Thumbs.db
 .idea/
 .claude/
 .opencode/
+.codex
 *.swp
 *.swo
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ node -v
 # Expected: v22.12.0 or newer
 
 corepack enable
-corepack prepare pnpm@10 --activate
+corepack prepare pnpm@10.32.1 --activate
 pnpm -v
 ```
 
@@ -195,17 +195,14 @@ pnpm -v
 pnpm install
 ```
 
-### Build shared package
-
-```bash
-pnpm build:shared
-```
-
 ### Run the desktop app
 
 ```bash
 pnpm dev
 ```
+
+`pnpm dev` builds the shared workspace package before launching the
+desktop app, so fresh clones do not need a separate bootstrap command.
 
 ### Core validation
 

--- a/README.md
+++ b/README.md
@@ -178,10 +178,27 @@ Prebuilt binaries are published on [GitHub Releases](https://github.com/joe-broa
 - pnpm `>=10`
 - Python `>=3.11` for docs builds
 
+### Verify Node and install pnpm via Corepack
+
+```bash
+node -v
+# Expected: v22.12.0 or newer
+
+corepack enable
+corepack prepare pnpm@10 --activate
+pnpm -v
+```
+
 ### Install dependencies
 
 ```bash
 pnpm install
+```
+
+### Build shared package
+
+```bash
+pnpm build:shared
 ```
 
 ### Run the desktop app

--- a/apps/desktop/src/main/custom-agents-utils.ts
+++ b/apps/desktop/src/main/custom-agents-utils.ts
@@ -54,7 +54,7 @@ export type NormalizedCustomAgent = Omit<CustomAgentLike, 'scope' | 'directory'>
 }
 
 export type CustomAgentCatalogState = {
-  customMcps?: Array<{ name: string; label?: string; description?: string }>
+  customMcps?: Array<{ name: string; label?: string; description?: string; permissionMode?: 'ask' | 'allow' }>
   customSkills: CustomSkillLike[]
   customAgents: CustomAgentLike[]
   [key: string]: unknown
@@ -228,7 +228,7 @@ export function buildCustomAgentCatalog(input: {
   builtinSkills?: ConfiguredSkill[]
   runtimeTools?: Array<{ id: string; description: string }>
   availableSkills?: CustomAgentCatalogSkill[]
-  customMcps: Array<{ name: string; label?: string; description?: string }>
+  customMcps: Array<{ name: string; label?: string; description?: string; permissionMode?: 'ask' | 'allow' }>
   customSkills: CustomSkillLike[]
   state: CustomAgentCatalogState
 }): CustomAgentCatalog {
@@ -261,6 +261,7 @@ export function buildCustomAgentCatalog(input: {
   for (const mcp of input.customMcps || []) {
     if (!mcp.name) continue
     const mcpPatterns = expandMcpToolPermissionPatterns([`mcp__${mcp.name}__*`])
+    const permissionMode = mcp.permissionMode === 'allow' ? 'allow' : 'ask'
     tools.set(mcp.name, {
       id: mcp.name,
       name: mcp.label?.trim() || humanize(mcp.name),
@@ -269,8 +270,8 @@ export function buildCustomAgentCatalog(input: {
       supportsWrite: true,
       source: 'custom',
       patterns: mcpPatterns,
-      allowPatterns: [],
-      askPatterns: mcpPatterns,
+      allowPatterns: permissionMode === 'allow' ? mcpPatterns : [],
+      askPatterns: permissionMode === 'ask' ? mcpPatterns : [],
     })
   }
 

--- a/apps/desktop/src/main/native-customizations.ts
+++ b/apps/desktop/src/main/native-customizations.ts
@@ -73,6 +73,7 @@ type ManagedMcpMetadata = {
   description?: string
   googleAuth?: boolean
   allowPrivateNetwork?: boolean
+  permissionMode?: 'allow'
 }
 
 function ensureDirectory(path: string) {
@@ -160,6 +161,7 @@ function readManagedMcpMetadata(
             description: typeof record.description === 'string' ? record.description : undefined,
             googleAuth: record.googleAuth === true ? true : undefined,
             allowPrivateNetwork: record.allowPrivateNetwork === true ? true : undefined,
+            permissionMode: record.permissionMode === 'allow' ? 'allow' : undefined,
           }]
         }),
     )
@@ -241,6 +243,7 @@ function parseCustomMcpEntry(
     description: metadata.description,
     googleAuth: metadata.googleAuth,
     allowPrivateNetwork: metadata.allowPrivateNetwork,
+    permissionMode: metadata.permissionMode,
     type,
     command: type === 'stdio' ? commandArray[0] : undefined,
     args: type === 'stdio' ? commandArray.slice(1) : undefined,
@@ -741,8 +744,9 @@ export function saveCustomMcp(mcp: CustomMcpConfig) {
       description,
       googleAuth: mcp.googleAuth === true ? true : undefined,
       allowPrivateNetwork: mcp.allowPrivateNetwork === true ? true : undefined,
+      permissionMode: mcp.permissionMode === 'allow' ? 'allow' : undefined,
     }
-    if (!metadata.label && !metadata.description && !metadata.googleAuth && !metadata.allowPrivateNetwork) {
+    if (!metadata.label && !metadata.description && !metadata.googleAuth && !metadata.allowPrivateNetwork && !metadata.permissionMode) {
       delete next[mcp.name]
       return next
     }

--- a/apps/desktop/src/main/runtime-project-overlay.ts
+++ b/apps/desktop/src/main/runtime-project-overlay.ts
@@ -1,5 +1,5 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
-import { join, resolve } from 'path'
+import { dirname, join, resolve } from 'path'
 import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
 import {
   getMachineAgentsDir,
@@ -79,7 +79,9 @@ function readProjectOverlayManifest(): ProjectOverlayManifest {
 }
 
 function writeProjectOverlayManifest(manifest: ProjectOverlayManifest) {
-  writeFileSync(getProjectOverlayManifestPath(), `${JSON.stringify(manifest, null, 2)}\n`)
+  const manifestPath = getProjectOverlayManifestPath()
+  mkdirSync(dirname(manifestPath), { recursive: true })
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
 }
 
 export function clearProjectOverlayCopies() {

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -120,8 +120,8 @@ export function SetupScreen({
   }
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen w-screen" style={{ background: 'var(--color-base)' }}>
-      <div className="flex flex-col items-center gap-6 max-w-md w-full px-6">
+    <div className="h-screen w-screen overflow-y-auto" style={{ background: 'var(--color-base)' }}>
+      <div className="mx-auto w-full max-w-2xl px-6 py-8">
         <div className="flex flex-col items-center gap-2">
           <div className="w-12 h-12 rounded-2xl bg-surface border border-border flex items-center justify-center">
             <span className="text-lg font-bold text-accent">O</span>
@@ -131,12 +131,12 @@ export function SetupScreen({
               ? t('setup.welcomeUser', 'Welcome, {{name}}', { name: email.split('@')[0] })
               : t('setup.welcomeGeneric', 'Welcome to {{brandName}}', { brandName })}
           </h1>
-          <p className="text-[13px] text-text-muted text-center">
+          <p className="text-[13px] text-text-muted text-center max-w-2xl">
             {t('setup.description', 'Choose the provider and model this {{brandName}} build should use by default.', { brandName })}
           </p>
         </div>
 
-        <div className="w-full flex flex-col gap-2">
+        <div className="mt-6 w-full flex flex-col gap-3">
           {providers.map((provider) => (
             <button
               key={provider.id}
@@ -156,95 +156,102 @@ export function SetupScreen({
               <div className="text-[11px] text-text-muted mt-0.5">{provider.description}</div>
             </button>
           ))}
-        </div>
 
-        {selectedProvider && (
-          <div className="w-full flex flex-col gap-3">
-            <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1">{t('settings.models.authentication', 'Authentication')}</span>
-            <ProviderAuthControls
-              providerId={providerId}
-              providerName={selectedProvider.name}
-              connected={selectedProvider.connected}
-              disabled={!providerId || saving}
-              onBeforeAuthorize={async () => persistSelectionAndRestart(undefined, { allowMissingModel: true })}
-              onAuthUpdated={async () => {
-                const authModelId = selectedProvider.defaultModel || modelId
-                setModelId(authModelId)
-              }}
-            />
-            {selectedProvider.credentials.length > 0 ? (
-              <div className="flex flex-col gap-2.5 rounded-xl border border-border-subtle p-3.5" style={{ background: 'var(--color-elevated)' }}>
-                {selectedProvider.credentials.map((credential) => (
-                  <label key={credential.key} className="flex flex-col gap-1">
-                    <span className="text-[11px] text-text-muted font-medium">{credential.label}</span>
-                    <input
-                      type={credential.secret ? 'password' : 'text'}
-                      value={selectedCredentials[credential.key] || ''}
-                      onChange={(event) => updateCredential(credential.key, event.target.value)}
-                      placeholder={credential.placeholder}
-                      className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
-                    />
-                    <span className="text-[10px] text-text-muted">{credential.description}</span>
-                  </label>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        )}
-
-        {selectedProvider ? (
-          <div className="w-full flex flex-col gap-3">
-            <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1">{t('setup.model', 'Model')}</span>
-            {selectedProvider.models.length > 0 ? (
-              <div className="flex flex-col gap-1">
-                {selectedProvider.models.map((model) => (
-                  <button
-                    key={model.id}
-                    onClick={() => setModelId(model.id)}
-                    className="flex items-center justify-between px-3.5 py-2.5 rounded-lg text-start cursor-pointer transition-all border"
-                    style={{
-                      background: modelId === model.id ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : 'transparent',
-                      borderColor: modelId === model.id ? 'var(--color-accent)' : 'transparent',
-                    }}
-                  >
-                    <span className="text-[12px]" style={{ color: modelId === model.id ? 'var(--color-accent)' : 'var(--color-text-secondary)' }}>{model.name}</span>
-                    {model.description ? <span className="text-[10px] text-text-muted">{model.description}</span> : null}
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <input
-                type="text"
-                value={modelId}
-                onChange={(event) => setModelId(event.target.value)}
-                placeholder={t('setup.modelIdPlaceholder', 'Model ID')}
-                className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
+          {selectedProvider && (
+            <>
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1 mt-3">{t('settings.models.authentication', 'Authentication')}</span>
+              <ProviderAuthControls
+                providerId={providerId}
+                providerName={selectedProvider.name}
+                connected={selectedProvider.connected}
+                disabled={!providerId || saving}
+                onBeforeAuthorize={async () => persistSelectionAndRestart(undefined, { allowMissingModel: true })}
+                onAuthUpdated={async () => {
+                  const authModelId = selectedProvider.defaultModel || modelId
+                  setModelId(authModelId)
+                }}
               />
-            )}
-            {selectedProvider.models.length === 0 ? (
-              <span className="text-[10px] text-text-muted px-1">
-                {t('setup.runtimeModelsHint', 'This provider uses OpenCode\'s live model catalog after the runtime starts.')}
-              </span>
-            ) : null}
-          </div>
-        ) : null}
+              {selectedProvider.credentials.length > 0 ? (
+                <div className="flex flex-col gap-2.5 rounded-xl border border-border-subtle p-3.5" style={{ background: 'var(--color-elevated)' }}>
+                  {selectedProvider.credentials.map((credential) => (
+                    <label key={credential.key} className="flex flex-col gap-1">
+                      <span className="text-[11px] text-text-muted font-medium">{credential.label}</span>
+                      <input
+                        type={credential.secret ? 'password' : 'text'}
+                        value={selectedCredentials[credential.key] || ''}
+                        onChange={(event) => updateCredential(credential.key, event.target.value)}
+                        placeholder={credential.placeholder}
+                        className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
+                      />
+                      <span className="text-[10px] text-text-muted">{credential.description}</span>
+                    </label>
+                  ))}
+                </div>
+              ) : null}
 
-        {error ? (
-          <p className="text-[12px] text-center" style={{ color: 'var(--color-red)' }}>{error}</p>
-        ) : null}
+              <div className="w-full flex flex-col gap-3 mt-2">
+                <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1">{t('setup.model', 'Model')}</span>
+                {selectedProvider.models.length > 0 ? (
+                  <div className="flex flex-col gap-1">
+                    {selectedProvider.models.map((model) => (
+                      <button
+                        key={model.id}
+                        onClick={() => setModelId(model.id)}
+                        className="flex flex-col items-start gap-1 px-3.5 py-2.5 rounded-lg text-start cursor-pointer transition-all border"
+                        style={{
+                          background: modelId === model.id ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : 'transparent',
+                          borderColor: modelId === model.id ? 'var(--color-accent)' : 'transparent',
+                        }}
+                      >
+                        <span
+                          className="text-[12px] font-medium leading-snug w-full"
+                          style={{ color: modelId === model.id ? 'var(--color-accent)' : 'var(--color-text-secondary)' }}
+                        >
+                          {model.name}
+                        </span>
+                        {model.description ? (
+                          <span className="text-[10px] text-text-muted leading-relaxed w-full line-clamp-2">
+                            {model.description}
+                          </span>
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <input
+                    type="text"
+                    value={modelId}
+                    onChange={(event) => setModelId(event.target.value)}
+                    placeholder={t('setup.modelIdPlaceholder', 'Model ID')}
+                    className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
+                  />
+                )}
+                {selectedProvider.models.length === 0 ? (
+                  <span className="text-[10px] text-text-muted px-1">
+                    {t('setup.runtimeModelsHint', 'This provider uses OpenCode\'s live model catalog after the runtime starts.')}
+                  </span>
+                ) : null}
+              </div>
+            </>
+          )}
 
-        <button
-          onClick={handleContinue}
-          disabled={!canContinue || saving}
-          className="w-full py-2.5 rounded-xl text-[13px] font-semibold cursor-pointer transition-all"
-          style={{
-            background: canContinue ? 'var(--color-accent)' : 'var(--color-surface-hover)',
-            color: canContinue ? 'var(--color-accent-foreground)' : 'var(--color-text-muted)',
-            opacity: saving ? 0.6 : 1,
-          }}
-        >
-          {saving ? t('common.loading', 'Setting up...') : t('setup.continue', 'Get Started')}
-        </button>
+          {error ? (
+            <p className="text-[12px] text-center" style={{ color: 'var(--color-red)' }}>{error}</p>
+          ) : null}
+
+          <button
+            onClick={handleContinue}
+            disabled={!canContinue || saving}
+            className="w-full py-2.5 rounded-xl text-[13px] font-semibold cursor-pointer transition-all mt-2"
+            style={{
+              background: canContinue ? 'var(--color-accent)' : 'var(--color-surface-hover)',
+              color: canContinue ? 'var(--color-accent-foreground)' : 'var(--color-text-muted)',
+              opacity: saving ? 0.6 : 1,
+            }}
+          >
+            {saving ? t('common.loading', 'Setting up...') : t('setup.continue', 'Get Started')}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
@@ -68,6 +68,12 @@ export function CustomMcpForm({
   // RFC1918 ranges — required for on-prem company MCPs but must be
   // an explicit user decision.
   const [allowPrivateNetwork, setAllowPrivateNetwork] = useState(Boolean(existing?.allowPrivateNetwork))
+  // Custom MCP tools default to OpenCode approval prompts. Trusted MCPs
+  // can opt into allow-mode so agents assigned that MCP can call its
+  // methods without prompting every time.
+  const [permissionMode, setPermissionMode] = useState<'ask' | 'allow'>(
+    existing?.permissionMode === 'allow' ? 'allow' : 'ask',
+  )
 
   useEffect(() => {
     if (projectDirectory) {
@@ -146,9 +152,10 @@ export function CustomMcpForm({
       if (Object.keys(headers).length > 0) mcp.headers = headers
       if (allowPrivateNetwork) mcp.allowPrivateNetwork = true
     }
+    if (permissionMode === 'allow') mcp.permissionMode = 'allow'
 
     return mcp
-  }, [allowPrivateNetwork, args, authModeAvailable, command, description, envPairs, googleAuthEnabled, headerPairs, label, name, projectTargetDirectory, scope, type, url])
+  }, [allowPrivateNetwork, args, authModeAvailable, command, description, envPairs, googleAuthEnabled, headerPairs, label, name, permissionMode, projectTargetDirectory, scope, type, url])
 
   const issues = useMemo(() => {
     const next: string[] = []
@@ -449,6 +456,55 @@ export function CustomMcpForm({
 
             <div className="rounded-xl border border-border-subtle bg-surface p-5">
               <div className="mb-3">
+                <div className="text-[14px] font-semibold text-text">{t('mcpForm.toolApprovals', 'Tool approvals')}</div>
+                <div className="text-[11px] text-text-muted mt-1">
+                  Choose how assigned agents should handle this MCP&apos;s tool calls.
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  aria-pressed={permissionMode === 'ask'}
+                  onClick={() => setPermissionMode('ask')}
+                  className="rounded-lg border px-3 py-3 text-left cursor-pointer transition-colors"
+                  style={{
+                    borderColor: permissionMode === 'ask'
+                      ? 'color-mix(in srgb, var(--color-accent) 45%, var(--color-border-subtle))'
+                      : 'var(--color-border-subtle)',
+                    background: permissionMode === 'ask'
+                      ? 'color-mix(in srgb, var(--color-accent) 9%, var(--color-elevated))'
+                      : 'var(--color-elevated)',
+                  }}
+                >
+                  <span className="block text-[12px] font-medium text-text">{t('mcpForm.approvalAsk', 'Ask before tool calls')}</span>
+                  <span className="mt-1 block text-[10px] leading-relaxed text-text-muted">
+                    OpenCode asks for approval before an assigned agent uses this MCP.
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={permissionMode === 'allow'}
+                  onClick={() => setPermissionMode('allow')}
+                  className="rounded-lg border px-3 py-3 text-left cursor-pointer transition-colors"
+                  style={{
+                    borderColor: permissionMode === 'allow'
+                      ? 'color-mix(in srgb, var(--color-amber) 45%, var(--color-border-subtle))'
+                      : 'var(--color-border-subtle)',
+                    background: permissionMode === 'allow'
+                      ? 'color-mix(in srgb, var(--color-amber) 7%, var(--color-elevated))'
+                      : 'var(--color-elevated)',
+                  }}
+                >
+                  <span className="block text-[12px] font-medium text-text">{t('mcpForm.approvalAllow', 'Trusted, auto-approve')}</span>
+                  <span className="mt-1 block text-[10px] leading-relaxed text-text-muted">
+                    Assigned agents can call this MCP without approval prompts. Use only for MCPs you control or trust.
+                  </span>
+                </button>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border-subtle bg-surface p-5">
+              <div className="mb-3">
                 <div className="text-[14px] font-semibold text-text">{t('mcpForm.linkedSkills', 'Linked skills')}</div>
                 <div className="text-[11px] text-text-muted mt-1">
                   Pre-wire this MCP into custom skills that should request it automatically.
@@ -507,6 +563,15 @@ export function CustomMcpForm({
                 <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
                   <div className="text-text-secondary mb-1">{t('mcpForm.connectionSummary', 'Connection summary')}</div>
                   <div>{type === 'stdio' ? 'Starts a local MCP server process.' : 'Connects to a remote MCP endpoint.'}</div>
+                </div>
+
+                <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
+                  <div className="text-text-secondary mb-1">{t('mcpForm.approvalSummary', 'Approval summary')}</div>
+                  <div>
+                    {permissionMode === 'allow'
+                      ? 'Trusted MCP. Assigned agents can use its tools automatically.'
+                      : 'OpenCode will ask before assigned agents use its tools.'}
+                  </div>
                 </div>
 
                 <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -409,12 +409,15 @@ export async function launchSmokeSession(
     }
   }
 
-  const launchArgs = options?.executablePath ? [] : ['.']
+  const launchArgs: string[] = []
   if (process.platform === 'linux') {
     // CI/sandboxed Linux environments (including some containerized dev
     // runners) can block Chromium's namespace sandbox setup, which causes
     // Electron to abort before smoke tests even boot the app shell.
     launchArgs.push('--no-sandbox', '--disable-setuid-sandbox')
+  }
+  if (!options?.executablePath) {
+    launchArgs.push('.')
   }
 
   const app = await electron.launch({

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -409,10 +409,18 @@ export async function launchSmokeSession(
     }
   }
 
+  const launchArgs = options?.executablePath ? [] : ['.']
+  if (process.platform === 'linux') {
+    // CI/sandboxed Linux environments (including some containerized dev
+    // runners) can block Chromium's namespace sandbox setup, which causes
+    // Electron to abort before smoke tests even boot the app shell.
+    launchArgs.push('--no-sandbox', '--disable-setuid-sandbox')
+  }
+
   const app = await electron.launch({
     cwd: desktopAppDir,
     executablePath: options?.executablePath,
-    args: options?.executablePath ? [] : ['.'],
+    args: launchArgs,
     env: getSmokeEnvironment(paths),
   })
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -373,6 +373,19 @@ The same flag is available on user-added custom MCPs
   receives the env var can read the user's Google access token.
   Only enable it for MCPs your distribution trusts.
 
+### Custom MCP approval mode
+
+User-added custom MCPs default to `permissionMode: "ask"`: agents can be
+assigned the MCP, but OpenCode still asks before each tool call. For MCPs
+you control or trust, the Capabilities UI can mark the MCP as trusted.
+That persists `permissionMode: "allow"` in Open Cowork's
+`mcp.open-cowork.json` sidecar metadata and generates OpenCode-native
+allow patterns for agents that include the MCP.
+
+Leave the default for third-party or newly-tested MCPs. `permissionMode`
+does not bypass agent-specific denied method patterns, so maintainers can
+still block destructive methods even on a trusted MCP.
+
 ## Agents
 
 `agents` defines built-in product agents.

--- a/docs/first-contribution.md
+++ b/docs/first-contribution.md
@@ -8,7 +8,7 @@ a small change. Five minutes end-to-end.
 You need:
 
 - Node `>= 22.12` (tracked in `.nvmrc`).
-- pnpm `>= 10` (`brew install pnpm` or the pnpm install script).
+- pnpm `>= 10` (install via Corepack).
 - macOS or Linux. Windows isn't supported yet.
 
 No API keys required to run the dev server. Actual LLM calls need
@@ -20,6 +20,11 @@ entered through the in-app Settings panel.
 ```bash
 git clone https://github.com/joe-broadhead/open-cowork.git
 cd open-cowork
+node -v
+# Expected: v22.12.0 or newer
+corepack enable
+corepack prepare pnpm@10 --activate
+pnpm -v
 pnpm install
 pnpm dev
 ```

--- a/docs/first-contribution.md
+++ b/docs/first-contribution.md
@@ -23,15 +23,16 @@ cd open-cowork
 node -v
 # Expected: v22.12.0 or newer
 corepack enable
-corepack prepare pnpm@10 --activate
+corepack prepare pnpm@10.32.1 --activate
 pnpm -v
 pnpm install
 pnpm dev
 ```
 
-The Vite dev server boots, Electron wraps it, and the app opens.
-HMR picks up renderer changes immediately. Main-process changes
-need a full relaunch (kill `pnpm dev`, start again).
+The root `pnpm dev` command builds the shared workspace package, boots
+the Vite dev server, wraps it with Electron, and opens the app. HMR
+picks up renderer changes immediately. Main-process changes need a full
+relaunch (kill `pnpm dev`, start again).
 
 ## Find something to work on
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ node -v
 # Expected: v22.12.0 or newer
 
 corepack enable
-corepack prepare pnpm@10 --activate
+corepack prepare pnpm@10.32.1 --activate
 pnpm -v
 ```
 
@@ -23,19 +23,15 @@ pnpm -v
 
 ```bash
 pnpm install
-pnpm build:shared
 pnpm test
 pnpm typecheck
 pnpm dev
 ```
 
-If `pnpm dev` fails because `@open-cowork/shared` cannot be resolved or
-`packages/shared/dist/` is missing, run:
-
-```bash
-pnpm build:shared
-pnpm dev
-```
+The root `pnpm dev` command builds `@open-cowork/shared` before
+launching the desktop app. If you launch the desktop workspace directly
+and see a missing `packages/shared/dist/` error, run `pnpm build:shared`
+from the repo root first.
 
 ## Install from a release artifact
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,12 +6,34 @@
 - pnpm `>=10`
 - Python `>=3.11` for documentation work
 
+## Verify toolchain first
+
+Before installing dependencies, verify Node and install `pnpm` via Corepack:
+
+```bash
+node -v
+# Expected: v22.12.0 or newer
+
+corepack enable
+corepack prepare pnpm@10 --activate
+pnpm -v
+```
+
 ## Install from source
 
 ```bash
 pnpm install
+pnpm build:shared
 pnpm test
 pnpm typecheck
+pnpm dev
+```
+
+If `pnpm dev` fails because `@open-cowork/shared` cannot be resolved or
+`packages/shared/dist/` is missing, run:
+
+```bash
+pnpm build:shared
 pnpm dev
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,6 +159,11 @@ own branding, providers, skills, and automations.
 === ":material-source-branch: Build from source"
 
     ```bash
+    node -v
+    # Expected: v22.12.0 or newer
+    corepack enable
+    corepack prepare pnpm@10 --activate
+    pnpm -v
     pnpm install
     pnpm dev          # hot-reload Electron + Vite
     pnpm build        # full build (shared + MCPs + desktop)

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,10 +162,10 @@ own branding, providers, skills, and automations.
     node -v
     # Expected: v22.12.0 or newer
     corepack enable
-    corepack prepare pnpm@10 --activate
+    corepack prepare pnpm@10.32.1 --activate
     pnpm -v
     pnpm install
-    pnpm dev          # hot-reload Electron + Vite
+    pnpm dev          # builds shared, then hot-reloads Electron + Vite
     pnpm build        # full build (shared + MCPs + desktop)
     ```
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -153,6 +153,16 @@ trusting that package publisher and whatever version resolution selects.
 Prefer pinned package specs such as `some-package@1.2.3` for repeatable
 MCP configuration.
 
+### MCP tool approvals
+
+User-added custom MCPs are ask-first by default. Assigning a custom MCP to
+an agent exposes the MCP namespace to that agent, but OpenCode still
+raises approval requests before tool calls. The only exception is an
+explicit user trust decision in Settings → Capabilities, persisted as
+`permissionMode: "allow"` in Open Cowork's MCP sidecar metadata. That
+trust flag generates OpenCode-native allow rules for assigned agents, and
+agent-specific denied method patterns still win last.
+
 ### Runtime isolation
 
 OpenCode spawns each MCP as its own subprocess. Each MCP sees only the

--- a/docs/skills-and-mcps.md
+++ b/docs/skills-and-mcps.md
@@ -151,6 +151,14 @@ through Settings → Capabilities. They are validated by:
 - `mcp-stdio-policy.ts` — for stdio MCPs (rejects shell metacharacters,
   `..` segments, and redirection operators in the command).
 
+Custom MCPs default to approval prompts when an agent uses their tools.
+For MCPs you control or otherwise trust, Settings → Capabilities can mark
+the MCP as **Trusted, auto-approve**. That stores
+`permissionMode: "allow"` in the Open Cowork sidecar metadata, which
+generates OpenCode-native allow permissions for agents that have been
+assigned the MCP. Agent-specific denied method patterns still override
+that trust setting.
+
 See [Security Model](security-model.md#mcp-sandbox-boundaries) for the
 full policy.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,6 +76,31 @@ doesn't unblock it, check `pnpm test` locally against
 `tests/mcp-url-policy.test.ts` to confirm the policy evaluates the
 URL shape correctly.
 
+## `pnpm dev` fails with missing `packages/shared/dist/`
+
+If startup fails with errors around `@open-cowork/shared` or a missing
+`packages/shared/dist/` directory, the shared workspace package has not
+been built yet.
+
+Fix sequence:
+
+1. Verify Node is `v22.12.0+` and that `pnpm` is installed via Corepack:
+   ```bash
+   node -v
+   corepack enable
+   corepack prepare pnpm@10 --activate
+   pnpm -v
+   ```
+2. Reinstall workspace dependencies:
+   ```bash
+   pnpm install
+   ```
+3. Build the shared package explicitly, then restart dev:
+   ```bash
+   pnpm build:shared
+   pnpm dev
+   ```
+
 ## Settings reset on reboot
 
 Credentials are persisted via Electron's `safeStorage`, which uses

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,7 +88,7 @@ Fix sequence:
    ```bash
    node -v
    corepack enable
-   corepack prepare pnpm@10 --activate
+   corepack prepare pnpm@10.32.1 --activate
    pnpm -v
    ```
 2. Reinstall workspace dependencies:
@@ -100,6 +100,10 @@ Fix sequence:
    pnpm build:shared
    pnpm dev
    ```
+
+The root `pnpm dev` command performs this shared build automatically.
+This manual step is mainly for direct `apps/desktop` workspace launches
+or interrupted installs.
 
 ## Settings reset on reboot
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "onlyBuiltDependencies": [
       "@googleworkspace/cli",
       "electron",
-      "esbuild"
+      "electron-winstaller",
+      "esbuild",
+      "opencode-ai"
     ],
     "overrides": {
       "electron-builder-squirrel-windows": "26.8.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/joe-broadhead/open-cowork/issues"
   },
   "scripts": {
-    "dev": "pnpm --filter @open-cowork/desktop dev",
+    "dev": "pnpm --filter @open-cowork/shared build && pnpm --filter @open-cowork/desktop dev",
     "build": "pnpm --filter @open-cowork/shared build && pnpm --filter ./mcps/charts build && pnpm --filter ./mcps/skills build && pnpm --filter @open-cowork/desktop build",
     "build:desktop": "pnpm --filter @open-cowork/desktop build",
     "build:mcps": "pnpm --filter ./mcps/charts build && pnpm --filter ./mcps/skills build",
@@ -56,7 +56,6 @@
     "onlyBuiltDependencies": [
       "@googleworkspace/cli",
       "electron",
-      "electron-winstaller",
       "esbuild",
       "opencode-ai"
     ],

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -759,6 +759,8 @@ export function isMcpAuthRequiredStatus(status?: string | null) {
     && (MCP_AUTH_REQUIRED_STATUSES as readonly string[]).includes(status)
 }
 
+export type CustomMcpPermissionMode = 'ask' | 'allow'
+
 export interface CustomMcpConfig {
   scope: 'machine' | 'project'
   directory?: string | null
@@ -786,6 +788,12 @@ export interface CustomMcpConfig {
   // exfil channels. Downstream installs with legit corporate-internal
   // MCPs flip this per-MCP; the UI surfaces a warning when it's set.
   allowPrivateNetwork?: boolean
+  // Agent permission posture for this custom MCP. Missing/`ask` means
+  // assigned agents can see the MCP but OpenCode still asks before tool
+  // calls. `allow` is an explicit trust decision: selected agents receive
+  // allow patterns for this MCP's methods, while denied method patterns
+  // still override it.
+  permissionMode?: CustomMcpPermissionMode
 }
 
 export interface CustomMcpTestResult {

--- a/tests/custom-agents.test.ts
+++ b/tests/custom-agents.test.ts
@@ -255,3 +255,57 @@ test('custom MCP tools default to ask-only access', () => {
   assert.deepEqual(warehouse?.allowPatterns, [])
   assert.deepEqual(warehouse?.askPatterns, ['mcp__warehouse__*', 'warehouse_*'])
 })
+
+test('trusted custom MCP tools become allow access', () => {
+  const catalog = buildCustomAgentCatalog({
+    builtinTools: builtinTools as any,
+    builtinSkills: builtinSkills as any,
+    customMcps: [
+      {
+        name: 'warehouse',
+        label: 'Warehouse',
+        description: 'Custom warehouse MCP',
+        permissionMode: 'allow',
+      },
+    ],
+    customSkills: [],
+    state: baseSettings,
+  })
+
+  const warehouse = catalog.tools.find((tool) => tool.id === 'warehouse')
+  assert.deepEqual(warehouse?.allowPatterns, ['mcp__warehouse__*', 'warehouse_*'])
+  assert.deepEqual(warehouse?.askPatterns, [])
+})
+
+test('runtime custom agents inherit trusted custom MCP allow patterns', () => {
+  const runtimeAgents = buildRuntimeCustomAgents({
+    state: {
+      ...baseSettings,
+      customMcps: [
+        {
+          name: 'nova',
+          label: 'Nova',
+          description: 'Data analysis MCP',
+          permissionMode: 'allow',
+        },
+      ],
+      customAgents: [
+        {
+          name: 'data-analyst',
+          description: 'Analyze business metrics',
+          instructions: 'Use Nova for metric lookup.',
+          skillNames: [],
+          toolIds: ['nova'],
+          enabled: true,
+          color: 'accent' as const,
+        },
+      ],
+    },
+    builtinTools: builtinTools as any,
+    builtinSkills: builtinSkills as any,
+  })
+
+  assert.equal(runtimeAgents.length, 1)
+  assert.deepEqual(runtimeAgents[0]?.allowPatterns, ['mcp__nova__*', 'nova_*'])
+  assert.deepEqual(runtimeAgents[0]?.askPatterns, [])
+})

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -45,6 +45,7 @@ test('project-scoped MCP edits preserve JSONC comments and unrelated keys', () =
       type: 'http',
       url: 'https://warehouse.example.test/mcp',
       allowPrivateNetwork: true,
+      permissionMode: 'allow',
     })
 
     let updated = readFileSync(configPath, 'utf-8')
@@ -56,10 +57,12 @@ test('project-scoped MCP edits preserve JSONC comments and unrelated keys', () =
     const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
     assert.equal(metadata.warehouse.description, 'Warehouse MCP')
     assert.equal(metadata.warehouse.allowPrivateNetwork, true)
+    assert.equal(metadata.warehouse.permissionMode, 'allow')
 
     const savedMcp = listCustomMcps({ directory: projectRoot }).find((entry) => entry.name === 'warehouse')
     assert.ok(savedMcp)
     assert.equal(savedMcp.allowPrivateNetwork, true)
+    assert.equal(savedMcp.permissionMode, 'allow')
 
     removeCustomMcp({
       scope: 'project',
@@ -91,15 +94,18 @@ test('custom MCP auth opt-ins round-trip through managed sidecar metadata', () =
       command: 'node',
       args: ['server.js'],
       googleAuth: true,
+      permissionMode: 'allow',
     })
 
     const savedMcp = listCustomMcps({ directory: projectRoot }).find((entry) => entry.name === 'workspace')
     assert.ok(savedMcp)
     assert.equal(savedMcp.googleAuth, true)
+    assert.equal(savedMcp.permissionMode, 'allow')
 
     const metadataPath = join(projectRoot, '.opencowork', 'mcp.open-cowork.json')
     const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
     assert.equal(metadata.workspace.googleAuth, true)
+    assert.equal(metadata.workspace.permissionMode, 'allow')
   } finally {
     removeCustomMcp({ scope: 'project', directory: projectRoot, name: 'workspace' })
     rmSync(projectRoot, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- Rebased the collaborator startup fixes onto current master so the PR now contains only the real remaining delta.
- Harden project overlay manifest writes by creating the OpenCode config directory before writing the overlay manifest.
- Improve first-run setup ergonomics by making the setup screen scrollable and placing provider authentication before model selection.
- Make root `pnpm dev` bootstrap `@open-cowork/shared` before launching the desktop app, then align README/docs troubleshooting around that behavior.
- Keep Linux smoke tests stable in sandboxed CI/dev environments with Electron sandbox flags.
- Allow `opencode-ai` package build scripts so packaged runtime binary installation remains deterministic.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:renderer`
- [x] `pnpm test` — 586 tests passed
- [x] `pnpm test:e2e`
- [x] `uv run mkdocs build --strict`
- [x] `git diff --check`

## User-visible impact

- [x] UI change — setup/auth flow is easier to understand on first run
- [x] Runtime/dev workflow change — root `pnpm dev` now builds shared first
- [x] CI/dev reliability change — Linux smoke launch flags
- [x] Docs change

## Notes

The original PR branch had a noisy history because several older commits were already merged through other PRs. This branch has now been rebased onto current `master`; GitHub checks are rerunning against the cleaned branch.