### PR TITLE
Fix custom agent loadout persistence

### DIFF
--- a/apps/desktop/src/main/native-customizations.ts
+++ b/apps/desktop/src/main/native-customizations.ts
@@ -52,6 +52,20 @@ type ManagedAgentMetadata = {
   // inline in the JSON sidecar so runtime-project-overlay picks it up
   // for free along with the agent's .md + .opencowork.json pair.
   avatar?: string
+  // The Markdown `permission:` block remains the OpenCode-facing runtime
+  // contract. These UI selections are duplicated in the Open Cowork sidecar
+  // because some SDK-native tools (for example websearch/webfetch/bash) cannot
+  // be reliably reverse-mapped from permission keys without a live SDK tool
+  // catalog. Older files that lack these fields fall back to derivation below.
+  skillNames?: string[]
+  toolIds?: string[]
+  deniedToolPatterns?: string[]
+  model?: string | null
+  variant?: string | null
+  temperature?: number | null
+  top_p?: number | null
+  steps?: number | null
+  options?: Record<string, unknown> | null
 }
 
 type ManagedMcpMetadata = {
@@ -110,6 +124,16 @@ function mergeByName<T extends { name: string }>(items: T[]) {
     merged.set(item.name, item)
   }
   return Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function readStringArray(value: unknown) {
+  if (!Array.isArray(value)) return undefined
+  return Array.from(new Set(
+    value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  ))
 }
 
 function mcpMetaPathForTarget(scope: NativeConfigScope, directory?: string | null) {
@@ -512,6 +536,14 @@ function deriveToolIdsFromPermission(
     .filter((tool) => getConfiguredToolPatterns(tool).some((pattern) => patterns.has(pattern)))
     .map((tool) => tool.id)
 
+  // Back-compat for custom agents saved before we duplicated the exact
+  // builder selections into the Open Cowork sidecar. SDK-native tools
+  // such as `websearch` / `webfetch` are represented as direct permission
+  // keys, not MCP patterns, so there is nothing to reverse-map through
+  // configured tool metadata.
+  const nativeToolIds = Array.from(patterns)
+    .filter((pattern) => !pattern.startsWith('mcp__') && /^[a-z][a-z0-9_-]*$/.test(pattern))
+
   const customMcpIds = [
     ...readScopedMcps('machine'),
     ...(scope === 'project' && directory ? readScopedMcps('project', directory) : []),
@@ -519,7 +551,7 @@ function deriveToolIdsFromPermission(
     .filter((mcp) => Array.from(patterns).some((pattern) => pattern === `mcp__${mcp.name}__*` || pattern.startsWith(`mcp__${mcp.name}__`)))
     .map((mcp) => mcp.name)
 
-  return Array.from(new Set([...configuredToolIds, ...customMcpIds])).sort((a, b) => a.localeCompare(b))
+  return Array.from(new Set([...configuredToolIds, ...nativeToolIds, ...customMcpIds])).sort((a, b) => a.localeCompare(b))
 }
 
 // Deny entries written into the permission map by `buildCustomAgentPermission`
@@ -550,6 +582,17 @@ function readManagedAgentMetadata(root: string, name: string): ManagedAgentMetad
     return {
       color: typeof value.color === 'string' ? value.color as AgentColor : undefined,
       avatar: typeof value.avatar === 'string' && value.avatar.length > 0 ? value.avatar : undefined,
+      skillNames: readStringArray(value.skillNames),
+      toolIds: readStringArray(value.toolIds),
+      deniedToolPatterns: readStringArray(value.deniedToolPatterns),
+      model: typeof value.model === 'string' && value.model.trim() ? value.model.trim() : null,
+      variant: typeof value.variant === 'string' && value.variant.trim() ? value.variant.trim() : null,
+      temperature: typeof value.temperature === 'number' && Number.isFinite(value.temperature) ? value.temperature : null,
+      top_p: typeof value.top_p === 'number' && Number.isFinite(value.top_p) ? value.top_p : null,
+      steps: typeof value.steps === 'number' && Number.isFinite(value.steps) && value.steps > 0 ? Math.round(value.steps) : null,
+      options: value.options && typeof value.options === 'object' && !Array.isArray(value.options)
+        ? value.options as Record<string, unknown>
+        : null,
     }
   } catch (error) {
     log('error', `Custom agent metadata load failed for ${name}: ${error instanceof Error ? error.message : String(error)}`)
@@ -606,6 +649,9 @@ function readScopedAgents(scope: NativeConfigScope, directory?: string | null) {
     const derivedSkillNames = deriveSkillNamesFromPermission(permission)
     const derivedToolIds = deriveToolIdsFromPermission(permission, scope, directory)
     const derivedDenies = deriveDeniedToolPatternsFromPermission(permission)
+    const skillNames = metadata.skillNames ?? derivedSkillNames
+    const toolIds = metadata.toolIds ?? derivedToolIds
+    const deniedToolPatterns = metadata.deniedToolPatterns ?? derivedDenies
 
     agents.push({
       scope,
@@ -620,12 +666,18 @@ function readScopedAgents(scope: NativeConfigScope, directory?: string | null) {
       // validation downstream.
       description: typeof frontmatter.description === 'string' ? frontmatter.description : '',
       instructions: content.replace(/^---[\s\S]*?---\n?/, '').trim(),
-      skillNames: derivedSkillNames,
-      toolIds: derivedToolIds,
+      skillNames,
+      toolIds,
       enabled,
       color: metadata.color || 'accent',
       avatar: metadata.avatar || null,
-      ...(derivedDenies.length > 0 ? { deniedToolPatterns: derivedDenies } : {}),
+      model: metadata.model ?? null,
+      variant: metadata.variant ?? null,
+      temperature: metadata.temperature ?? null,
+      top_p: metadata.top_p ?? null,
+      steps: metadata.steps ?? null,
+      options: metadata.options ?? null,
+      ...(deniedToolPatterns.length > 0 ? { deniedToolPatterns } : {}),
     })
   }
 
@@ -781,7 +833,16 @@ export function saveCustomAgent(agent: CustomAgentConfig, permission: Record<str
   )
   writeJsonFile(agentMetaPath(root, agent.name), {
     color: agent.color,
+    skillNames: Array.from(new Set((agent.skillNames || []).map((name) => name.trim()).filter(Boolean))),
+    toolIds: Array.from(new Set((agent.toolIds || []).map((id) => id.trim()).filter(Boolean))),
+    deniedToolPatterns: Array.from(new Set((agent.deniedToolPatterns || []).map((pattern) => pattern.trim()).filter(Boolean))),
     ...(agent.avatar ? { avatar: agent.avatar } : {}),
+    ...(agent.model ? { model: agent.model } : {}),
+    ...(agent.variant ? { variant: agent.variant } : {}),
+    ...(typeof agent.temperature === 'number' && Number.isFinite(agent.temperature) ? { temperature: agent.temperature } : {}),
+    ...(typeof agent.top_p === 'number' && Number.isFinite(agent.top_p) ? { top_p: agent.top_p } : {}),
+    ...(typeof agent.steps === 'number' && Number.isFinite(agent.steps) && agent.steps > 0 ? { steps: Math.round(agent.steps) } : {}),
+    ...(agent.options && typeof agent.options === 'object' && Object.keys(agent.options).length > 0 ? { options: agent.options } : {}),
   })
   return true
 }

--- a/apps/desktop/src/main/update-check.ts
+++ b/apps/desktop/src/main/update-check.ts
@@ -1,11 +1,11 @@
 import semver from 'semver'
-import { getPublicAppConfig } from './config-loader.ts'
+import { getBranding } from './config-loader.ts'
 import { log } from './logger.ts'
 
 export type UpdateCheckResult =
   | { status: 'ok'; currentVersion: string; latestVersion: string; hasUpdate: boolean; releaseUrl: string }
-  | { status: 'error'; message: string }
-  | { status: 'disabled'; message: string }
+  | { status: 'error'; currentVersion: string; message: string }
+  | { status: 'disabled'; currentVersion: string; message: string }
 
 // Parse owner/repo from a GitHub URL. Returns null for anything that
 // isn't github.com — downstream forks on GitLab / internal hosts
@@ -53,62 +53,68 @@ async function getCurrentVersion(): Promise<string> {
 }
 
 export async function checkForUpdates(): Promise<UpdateCheckResult> {
-  const config = getPublicAppConfig()
-  const helpUrl = config.branding.helpUrl?.trim()
-  if (!helpUrl) {
-    return { status: 'disabled', message: 'No helpUrl configured — downstream builds set their own update endpoint.' }
-  }
-
-  const repo = parseGithubRepo(helpUrl)
-  if (!repo) {
-    return {
-      status: 'disabled',
-      message: 'Update check only supports GitHub-hosted releases. Downstream forks can wire their own endpoint.',
-    }
-  }
-
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  const current = await getCurrentVersion()
   try {
-    const response = await fetch(`https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/latest`, {
-      signal: controller.signal,
-      headers: {
-        // Identify the client so GitHub's unauthenticated rate limit
-        // bucket is at least attributable if a downstream user hits
-        // it. The 60/hr limit on anonymous requests is plenty for a
-        // user-initiated click.
-        'User-Agent': 'open-cowork-update-check',
-        'Accept': 'application/vnd.github+json',
-      },
-    })
-
-    if (response.status === 404) {
-      return { status: 'error', message: 'No releases published yet.' }
-    }
-    if (!response.ok) {
-      return { status: 'error', message: `GitHub API responded with ${response.status}.` }
-    }
-    const body = await response.json() as { tag_name?: string; html_url?: string }
-    if (!body.tag_name || !body.html_url) {
-      return { status: 'error', message: 'Malformed release payload.' }
+    const helpUrl = getBranding().helpUrl?.trim()
+    if (!helpUrl) {
+      return {
+        status: 'disabled',
+        currentVersion: current,
+        message: 'No helpUrl configured — downstream builds set their own update endpoint.',
+      }
     }
 
-    const current = await getCurrentVersion()
-    const hasUpdate = compareVersions(body.tag_name, current) > 0
+    const repo = parseGithubRepo(helpUrl)
+    if (!repo) {
+      return {
+        status: 'disabled',
+        currentVersion: current,
+        message: 'Update check only supports GitHub-hosted releases. Downstream forks can wire their own endpoint.',
+      }
+    }
 
-    log('app', `Update check: current=${current} latest=${body.tag_name} hasUpdate=${hasUpdate}`)
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    try {
+      const response = await fetch(`https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/latest`, {
+        signal: controller.signal,
+        headers: {
+          // Identify the client so GitHub's unauthenticated rate limit
+          // bucket is at least attributable if a downstream user hits
+          // it. The 60/hr limit on anonymous requests is plenty for a
+          // user-initiated click.
+          'User-Agent': 'open-cowork-update-check',
+          'Accept': 'application/vnd.github+json',
+        },
+      })
 
-    return {
-      status: 'ok',
-      currentVersion: current,
-      latestVersion: normalizeVersion(body.tag_name),
-      hasUpdate,
-      releaseUrl: body.html_url,
+      if (response.status === 404) {
+        return { status: 'error', currentVersion: current, message: 'No releases published yet.' }
+      }
+      if (!response.ok) {
+        return { status: 'error', currentVersion: current, message: `GitHub API responded with ${response.status}.` }
+      }
+      const body = await response.json() as { tag_name?: string; html_url?: string }
+      if (!body.tag_name || !body.html_url) {
+        return { status: 'error', currentVersion: current, message: 'Malformed release payload.' }
+      }
+
+      const hasUpdate = compareVersions(body.tag_name, current) > 0
+
+      log('app', `Update check: current=${current} latest=${body.tag_name} hasUpdate=${hasUpdate}`)
+
+      return {
+        status: 'ok',
+        currentVersion: current,
+        latestVersion: normalizeVersion(body.tag_name),
+        hasUpdate,
+        releaseUrl: body.html_url,
+      }
+    } finally {
+      clearTimeout(timeout)
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    return { status: 'error', message }
-  } finally {
-    clearTimeout(timeout)
+    return { status: 'error', currentVersion: current, message }
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1354,8 +1354,8 @@ export interface CoworkAPI {
     // known host; the renderer just doesn't surface an update hint.
     checkUpdates: () => Promise<
       | { status: 'ok'; currentVersion: string; latestVersion: string; hasUpdate: boolean; releaseUrl: string }
-      | { status: 'error'; message: string }
-      | { status: 'disabled'; message: string }
+      | { status: 'error'; currentVersion: string; message: string }
+      | { status: 'disabled'; currentVersion: string; message: string }
     >
     // Wipes user-data dir + sandbox workspaces and relaunches. Behind
     // a destructive confirmation token; call confirm.requestDestructive

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -128,6 +128,8 @@ permission:
     "chart-creator": allow
   "mcp__charts__*": allow
   "mcp__warehouse__run_query": ask
+  webfetch: allow
+  websearch: allow
 ---
 
 Work carefully.
@@ -137,9 +139,64 @@ Work carefully.
     const agent = listCustomAgents({ directory: projectRoot }).find((entry) => entry.name === 'insights')
     assert.ok(agent)
     assert.deepEqual(agent.skillNames, ['chart-creator'])
-    assert.deepEqual(agent.toolIds, ['charts', 'warehouse'])
+    assert.deepEqual(agent.toolIds, ['charts', 'warehouse', 'webfetch', 'websearch'])
     assert.equal(agent.color, 'accent')
   } finally {
+    rmSync(projectRoot, { recursive: true, force: true })
+  }
+})
+
+test('custom agent builder selections round-trip through managed sidecar metadata', () => {
+  const projectRoot = testTempDir('opencowork-native-agent-loadout-')
+
+  try {
+    saveCustomAgent(
+      {
+        scope: 'project',
+        directory: projectRoot,
+        name: 'researcher',
+        description: 'Researches a topic with native web tools.',
+        instructions: 'Use the selected tools and skills.',
+        skillNames: ['analyst', 'chart-creator'],
+        toolIds: ['websearch', 'webfetch'],
+        enabled: true,
+        color: 'info',
+        avatar: null,
+        model: 'openai/gpt-5.5',
+        variant: null,
+        temperature: 0.2,
+        top_p: null,
+        steps: 25,
+        options: { reasoningEffort: 'medium' },
+        deniedToolPatterns: ['mcp__github__delete_repo'],
+      },
+      {
+        skill: {
+          analyst: 'allow',
+          'chart-creator': 'allow',
+        },
+        websearch: 'allow',
+        webfetch: 'allow',
+        mcp__github__delete_repo: 'deny',
+      },
+    )
+
+    const agent = listCustomAgents({ directory: projectRoot }).find((entry) => entry.name === 'researcher')
+    assert.ok(agent)
+    assert.deepEqual(agent.skillNames, ['analyst', 'chart-creator'])
+    assert.deepEqual(agent.toolIds, ['websearch', 'webfetch'])
+    assert.deepEqual(agent.deniedToolPatterns, ['mcp__github__delete_repo'])
+    assert.equal(agent.model, 'openai/gpt-5.5')
+    assert.equal(agent.temperature, 0.2)
+    assert.equal(agent.steps, 25)
+    assert.deepEqual(agent.options, { reasoningEffort: 'medium' })
+
+    const metadataPath = join(projectRoot, '.opencowork', 'agents', 'researcher.opencowork.json')
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
+    assert.deepEqual(metadata.skillNames, ['analyst', 'chart-creator'])
+    assert.deepEqual(metadata.toolIds, ['websearch', 'webfetch'])
+  } finally {
+    removeCustomAgent({ scope: 'project', directory: projectRoot, name: 'researcher' })
     rmSync(projectRoot, { recursive: true, force: true })
   }
 })

--- a/tests/update-check-version.test.ts
+++ b/tests/update-check-version.test.ts
@@ -1,6 +1,16 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { compareVersions } from '../apps/desktop/src/main/update-check.ts'
+import { checkForUpdates, compareVersions } from '../apps/desktop/src/main/update-check.ts'
+
+async function withMockedFetch<T>(mock: typeof fetch, fn: () => Promise<T>): Promise<T> {
+  const previous = globalThis.fetch
+  globalThis.fetch = mock
+  try {
+    return await fn()
+  } finally {
+    globalThis.fetch = previous
+  }
+}
 
 test('compareVersions treats v-prefixed and bare versions identically', () => {
   assert.equal(compareVersions('v1.2.3', '1.2.3'), 0)
@@ -22,4 +32,40 @@ test('compareVersions follows semver prerelease ordering', () => {
 test('compareVersions handles missing segments gracefully', () => {
   assert.equal(compareVersions('1', '1.0.0'), 0)
   assert.equal(compareVersions('1.0', '1.0.1'), -1)
+})
+
+test('checkForUpdates reports a newer GitHub release', async () => {
+  await withMockedFetch(async (input) => {
+    assert.equal(
+      String(input),
+      'https://api.github.com/repos/joe-broadhead/open-cowork/releases/latest',
+    )
+    return new Response(JSON.stringify({
+      tag_name: 'v0.0.1',
+      html_url: 'https://github.com/joe-broadhead/open-cowork/releases/tag/v0.0.1',
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }, async () => {
+    assert.deepEqual(await checkForUpdates(), {
+      status: 'ok',
+      currentVersion: '0.0.0',
+      latestVersion: '0.0.1',
+      hasUpdate: true,
+      releaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases/tag/v0.0.1',
+    })
+  })
+})
+
+test('checkForUpdates still reports the current version when the network fails', async () => {
+  await withMockedFetch(async () => {
+    throw new Error('offline')
+  }, async () => {
+    assert.deepEqual(await checkForUpdates(), {
+      status: 'error',
+      currentVersion: '0.0.0',
+      message: 'offline',
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- persist custom-agent builder selections in the managed sidecar so tools, skills, denied patterns, and inference settings survive reopening and editing
- keep the OpenCode agent Markdown permission block as the runtime-facing contract, with backward-compatible derivation for older sidecarless agents
- tighten manual update checks so they avoid provider-catalog side effects and always return the current app version

## Validation

- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check
- pnpm build
- launched the built Electron app locally for manual testing
