### PR TITLE
chore: update OpenCode runtime readiness

### DIFF
--- a/.github/workflows/monthly-maintenance.yml
+++ b/.github/workflows/monthly-maintenance.yml
@@ -49,26 +49,27 @@ jobs:
         run: pnpm outdated || true
         continue-on-error: true
 
-      - name: Typecheck with pinned SDK
+      - name: Typecheck with pinned OpenCode packages
         run: pnpm typecheck
 
-      - name: Test with pinned SDK
+      - name: Test with pinned OpenCode packages
         run: pnpm test
 
-      # Opt-in compatibility probe. Reinstalls with the latest
-      # @opencode-ai/sdk and runs typecheck + tests against it. This
-      # step is allowed to fail because breaking SDK changes don't
-      # mean our release is broken — they're a signal to update or
-      # pin with a knowing note in CHANGELOG.
-      - name: Probe compatibility with latest opencode-ai/sdk
+      # Opt-in compatibility probe. Reinstalls with the latest paired
+      # @opencode-ai/sdk client and opencode-ai runtime package, then
+      # runs typecheck + tests against them. This step is allowed to
+      # fail because upstream package drift doesn't mean our release is
+      # broken — it's a signal to update both packages together or pin
+      # with a knowing note in CHANGELOG.
+      - name: Probe compatibility with latest OpenCode packages
         id: sdk-probe
         continue-on-error: true
         run: |
-          pnpm --filter @open-cowork/desktop add @opencode-ai/sdk@latest
+          pnpm --filter @open-cowork/desktop add @opencode-ai/sdk@latest opencode-ai@latest
           pnpm typecheck
           pnpm test
 
       - name: Mark SDK probe status
         if: steps.sdk-probe.outcome == 'failure'
         run: |
-          echo "::warning title=SDK drift::latest @opencode-ai/sdk breaks typecheck or tests. Review before release."
+          echo "::warning title=OpenCode drift::latest paired OpenCode packages break typecheck or tests. Review before release."

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Use it as a personal OpenCode cockpit, an internal AI workbench for your company
 
 ## Built on OpenCode
 
-Open Cowork exists because [OpenCode](https://github.com/sst/opencode) already does the hard part brilliantly.
+Open Cowork exists because [OpenCode](https://github.com/anomalyco/opencode) already does the hard part brilliantly.
 
 OpenCode is the open source AI coding agent that powers execution: models, sessions, tools, context, and agentic coding workflows.
+
+Open Cowork is an independent project built on top of OpenCode. It is not built by, sponsored by, or affiliated with the OpenCode team.
 
 Open Cowork is the desktop product layer around it.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ Each package remains licensed under its own license terms. The table below is pr
 | @iconify/utils | 3.1.0 | MIT | https://github.com/iconify/iconify.git |
 | @mermaid-js/parser | 1.1.0 | MIT | https://github.com/mermaid-js/mermaid.git |
 | @modelcontextprotocol/sdk | 1.29.0 | MIT | git+https://github.com/modelcontextprotocol/typescript-sdk.git |
-| @opencode-ai/sdk | 1.14.25 | MIT | https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.25.tgz |
+| @opencode-ai/sdk | 1.14.28 | MIT | https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.28.tgz |
 | @tanstack/react-virtual | 3.13.24 | MIT | git+https://github.com/TanStack/virtual.git |
 | @tanstack/virtual-core | 3.14.0 | MIT | git+https://github.com/TanStack/virtual.git |
 | @types/d3 | 7.4.3 | MIT | https://github.com/DefinitelyTyped/DefinitelyTyped.git |
@@ -299,19 +299,19 @@ Each package remains licensed under its own license terms. The table below is pr
 | object-inspect | 1.13.4 | MIT | git://github.com/inspect-js/object-inspect.git |
 | on-finished | 2.4.1 | MIT | jshttp/on-finished |
 | once | 1.4.0 | ISC | git://github.com/isaacs/once |
-| opencode-ai | 1.14.25 | MIT | https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.14.25.tgz |
-| opencode-darwin-arm64 | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.14.25.tgz |
-| opencode-darwin-x64 | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.14.25.tgz |
-| opencode-darwin-x64-baseline | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.14.25.tgz |
-| opencode-linux-arm64 | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.14.25.tgz |
-| opencode-linux-arm64-musl | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.14.25.tgz |
-| opencode-linux-x64 | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.14.25.tgz |
-| opencode-linux-x64-baseline | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.14.25.tgz |
-| opencode-linux-x64-baseline-musl | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.14.25.tgz |
-| opencode-linux-x64-musl | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.14.25.tgz |
-| opencode-windows-arm64 | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.14.25.tgz |
-| opencode-windows-x64 | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.14.25.tgz |
-| opencode-windows-x64-baseline | 1.14.25 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.14.25.tgz |
+| opencode-ai | 1.14.28 | MIT | https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.14.28.tgz |
+| opencode-darwin-arm64 | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.14.28.tgz |
+| opencode-darwin-x64 | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.14.28.tgz |
+| opencode-darwin-x64-baseline | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.14.28.tgz |
+| opencode-linux-arm64 | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.14.28.tgz |
+| opencode-linux-arm64-musl | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.14.28.tgz |
+| opencode-linux-x64 | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.14.28.tgz |
+| opencode-linux-x64-baseline | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.14.28.tgz |
+| opencode-linux-x64-baseline-musl | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.14.28.tgz |
+| opencode-linux-x64-musl | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.14.28.tgz |
+| opencode-windows-arm64 | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.14.28.tgz |
+| opencode-windows-x64 | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.14.28.tgz |
+| opencode-windows-x64-baseline | 1.14.28 | MIT (opencode-ai companion package) | https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.14.28.tgz |
 | package-manager-detector | 1.6.0 | MIT | git+https://github.com/antfu-collective/package-manager-detector.git |
 | parse-entities | 4.0.2 | MIT | wooorm/parse-entities |
 | parse5 | 7.3.0 | MIT | git://github.com/inikulin/parse5.git |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@opencode-ai/sdk": "1.14.25",
+    "@opencode-ai/sdk": "1.14.28",
     "@tanstack/react-virtual": "^3.13.24",
     "ajv": "^8.20.0",
     "dompurify": "^3.4.0",
@@ -37,7 +37,7 @@
     "marked": "^18.0.0",
     "mermaid": "^11.14.0",
     "morphdom": "^2.7.8",
-    "opencode-ai": "1.14.25",
+    "opencode-ai": "1.14.28",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -34,6 +34,7 @@ import { syncReadableSkillMirror } from './runtime-skill-catalog.ts'
 import { attachContentSecurityPolicy } from './content-security-policy.ts'
 import { listCustomMcps } from './native-customizations.ts'
 import {
+  isExpectedPackagedRendererFile,
   needsMainWindowRecovery,
   pickRecoverableMainWindow,
   rendererUrlLooksWrong,
@@ -107,7 +108,7 @@ function rendererNavigationIsAllowed(contents: WebContents, url: string) {
   if (process.env.VITE_DEV_SERVER_URL && url.startsWith(process.env.VITE_DEV_SERVER_URL)) return true
   const currentUrl = contents.getURL()
   if (currentUrl && url === currentUrl) return true
-  if (url.startsWith('file://') && currentUrl.startsWith('file://')) return true
+  if (isExpectedPackagedRendererFile(url, expectedRendererEntryPath())) return true
   return false
 }
 

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -53,6 +53,18 @@ function byteLength(value: string) {
   return Buffer.byteLength(value, 'utf8')
 }
 
+function resolveQuestionLocally(context: IpcHandlerContext, sessionId: string, requestId: string) {
+  const win = context.getMainWindow()
+  dispatchRuntimeSessionEvent(win, {
+    type: 'question_resolved',
+    sessionId,
+    data: {
+      type: 'question_resolved',
+      id: requestId,
+    },
+  })
+}
+
 function requireBoundedString(value: unknown, fieldName: string, maxBytes: number) {
   if (typeof value !== 'string') {
     throw new Error(`${fieldName} must be a string`)
@@ -766,6 +778,7 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
       requestID: requestId,
       answers: answers as QuestionAnswer[],
     }, { throwOnError: true })
+    resolveQuestionLocally(context, sessionId, requestId)
     startSessionStatusReconciliation(sessionId, {
       getMainWindow: context.getMainWindow,
       onIdle: (_win, reconciledSessionId) => {
@@ -779,6 +792,7 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     await client.question.reject({
       requestID: requestId,
     }, { throwOnError: true })
+    resolveQuestionLocally(context, sessionId, requestId)
     startSessionStatusReconciliation(sessionId, {
       getMainWindow: context.getMainWindow,
       onIdle: (_win, reconciledSessionId) => {

--- a/apps/desktop/src/main/main-window-lifecycle.ts
+++ b/apps/desktop/src/main/main-window-lifecycle.ts
@@ -1,3 +1,6 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+
 type WindowLike = {
   isDestroyed(): boolean
   isVisible(): boolean
@@ -9,6 +12,16 @@ export function rendererUrlLooksWrong(url: string, devServerUrl?: string | null)
     return !url.startsWith(devServerUrl)
   }
   return url.endsWith('.js') || url.includes('/assets/') || !url.endsWith('/index.html')
+}
+
+export function isExpectedPackagedRendererFile(url: string, expectedRendererPath: string) {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'file:') return false
+    return resolve(fileURLToPath(parsed)) === resolve(expectedRendererPath)
+  } catch {
+    return false
+  }
 }
 
 export function pickRecoverableMainWindow<T extends WindowLike>(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ owns its own subprocess for sessions and MCP tool calls.
 Open Cowork embeds the OpenCode SDK v2 API surface from the
 `@opencode-ai/sdk` package. The current pinned package version is
 tracked in `apps/desktop/package.json` — at the time of writing,
-`@opencode-ai/sdk: 1.14.25`. The packaged desktop app ships the
+`@opencode-ai/sdk: 1.14.28`. The packaged desktop app ships the
 OpenCode CLI binary alongside the Electron bundle (see
 `runtime-opencode-cli.ts`).
 
@@ -365,7 +365,7 @@ load-bearing and easy to regress:
 This repo pins `opencode-ai` (the runtime) and
 `@opencode-ai/sdk` (the client) explicitly in
 `apps/desktop/package.json`. Current pairs as of this
-writing: `opencode-ai: 1.14.25`, `@opencode-ai/sdk: 1.14.25`.
+writing: `opencode-ai: 1.14.28`, `@opencode-ai/sdk: 1.14.28`.
 
 Why the pin is load-bearing:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -191,7 +191,8 @@ own branding, providers, skills, and automations.
 
     Signed macOS artifacts once signing is configured, SHA256 checksums,
     CycloneDX + SPDX SBOMs, SHA-pinned actions. Monthly maintenance
-    probes the OpenCode SDK against typecheck and tests.
+    probes paired OpenCode SDK/runtime updates against typecheck and
+    tests.
 
     [:octicons-arrow-right-24: Packaging and Releases](packaging-and-releases.md)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -90,10 +90,17 @@ That monthly window includes:
 
 - Dependabot PRs for npm dependencies
 - Dependabot PRs for GitHub Actions SHA bumps
-- the monthly maintenance workflow's audit and SDK drift checks
+- the monthly maintenance workflow's audit and paired OpenCode package
+  drift checks
 
 This keeps the repository healthy while leaving day-to-day CI focused on
 real product changes.
+
+OpenCode runtime drift is checked by probing the latest paired
+`@opencode-ai/sdk` and `opencode-ai` packages together. Treat a failure
+there as an upstream compatibility signal: either bump both packages in
+one release branch and rerun the full suite, or keep the current pins
+with an explicit release note.
 
 ## Recommended operator routine
 

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -62,7 +62,8 @@ The repository includes:
 
 - `monthly-maintenance.yml`
   - runs on the first day of each month
-  - checks dependency audit state, outdated packages, and SDK drift
+  - checks dependency audit state, outdated packages, and paired
+    OpenCode SDK/runtime drift
   - exists to catch maintenance issues without a noisy nightly signal
 
 ## Verify a download

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -171,6 +171,16 @@ when `googleAuth: true`), never the user's full shell env. Tool
 responses are typed at the runtime boundary; a misbehaving MCP cannot
 inject arbitrary IPC events into Open Cowork's renderer.
 
+The managed OpenCode runtime runs with a Cowork-owned runtime `HOME` so
+OpenCode does not discover unmanaged machine-local agents, skills, or
+state. To keep developer workflows usable, Open Cowork bridges a curated
+set of standard tooling paths such as Git, npm/pnpm/yarn, SSH, GitHub
+CLI, Docker, Kubernetes, AWS, Azure, and Google Cloud config into that
+runtime home. Those bridged files are a deliberate trust boundary:
+tools invoked by OpenCode may read the linked developer-tool config, but
+OpenCode provider state and Cowork-managed skills stay inside the
+runtime sandbox.
+
 ## Chart frame isolation
 
 Chart rendering uses Vega, which compiles its specs with `new Function()`
@@ -279,8 +289,9 @@ are documented in `docs/packaging-and-releases.md`.
 - Renderer bundles are split per-feature so a CVE in a heavy, rarely
   loaded dependency (e.g. a Vega module) does not block a patch
   release of the shell.
-- Monthly maintenance watches the OpenCode SDK for shape changes that
-  could affect our event projector.
+- Monthly maintenance watches paired OpenCode SDK/runtime package
+  updates for shape changes that could affect our event projector or
+  packaged runtime.
 
 ## Reporting a vulnerability
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       '@opencode-ai/sdk':
-        specifier: 1.14.25
-        version: 1.14.25
+        specifier: 1.14.28
+        version: 1.14.28
       '@tanstack/react-virtual':
         specifier: ^3.13.24
         version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -71,8 +71,8 @@ importers:
         specifier: ^2.7.8
         version: 2.7.8
       opencode-ai:
-        specifier: 1.14.25
-        version: 1.14.25
+        specifier: 1.14.28
+        version: 1.14.28
       react:
         specifier: ^19.1.0
         version: 19.2.5
@@ -643,8 +643,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@opencode-ai/sdk@1.14.25':
-    resolution: {integrity: sha512-YSb+77OgIylwnk9aLoIyfr7FOx3MDD1ASEy2cUbOGTnhNqcR7S2sZAWLgkNWBBOkIH4tG6ouOckcG8lg12a3Tg==}
+  '@opencode-ai/sdk@1.14.28':
+    resolution: {integrity: sha512-qRFJfD+Zdz3jHHSupW4F6Io1ZFrQ6gCRFlG50O6kEU9xRxrBpK0wGvP+Y5VwwvD/gH9WKMHYinlQpDVI9/lgJQ==}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -3095,67 +3095,67 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  opencode-ai@1.14.25:
-    resolution: {integrity: sha512-xlcuGQWsaN/BZ1Bo9+Pk7X7zMYz2BMnzkKFzZMn/Q9D7SEvdVx+ycjK5Wf8Wq/7niv0t1nFkAQZ85T3tCRWVxg==}
+  opencode-ai@1.14.28:
+    resolution: {integrity: sha512-ZPukJNvujSVa+LVoXvj2ciUV57UcnuxmMtzpFQBYd6fbhjeT1vMC6jCurO/5mIp76fiPmGM7ilzRXVeY6bIwPw==}
     hasBin: true
 
-  opencode-darwin-arm64@1.14.25:
-    resolution: {integrity: sha512-hOTygBfFPAJeo1nGHLi4bqHoJQSQBRNZsKTsyhmflUlGkb+VuXGlxs7PpcN5yPitbnB+EUySEOaJmTlcZf73yg==}
+  opencode-darwin-arm64@1.14.28:
+    resolution: {integrity: sha512-Gu2vZYACAeoewfPhgJDAaScwRo1K5YZq7tVpPKw2rpul34OpOPLk4oB4Pmr539iWiagK+DLuUxnbJIbRRYCS5g==}
     cpu: [arm64]
     os: [darwin]
 
-  opencode-darwin-x64-baseline@1.14.25:
-    resolution: {integrity: sha512-Cqedwl6GIUAbZModPvKNMcLFG95ROSqamDomx89VjwTX68Lg8GjdOqGWO4A66XfohBemMtEyigbgE6fMcFM0vA==}
+  opencode-darwin-x64-baseline@1.14.28:
+    resolution: {integrity: sha512-/KsZkZh5oh6urHWwIHJudS6sedBil59E/4o7/7TuxPy/pOdRlSlSWVkMJd20AmqM4G/qILF/GthXy3D2+f99Tg==}
     cpu: [x64]
     os: [darwin]
 
-  opencode-darwin-x64@1.14.25:
-    resolution: {integrity: sha512-34FTz0Yh2FY+E+TzQHQVPO1w2jXMkLDt/hdlluqBrFdwBxJRKCvrHv+RGPDJJrYiFjyr9GGJfNYQJmxRfrGEdg==}
+  opencode-darwin-x64@1.14.28:
+    resolution: {integrity: sha512-D6BnAXlSdQDRtZgAg6OxWT6CEzbbONnlYof9hdPbaIIaNyBLjqK+Er2O1rrbiXFhSbs7YHBiDoGd+nNUymx4Ng==}
     cpu: [x64]
     os: [darwin]
 
-  opencode-linux-arm64-musl@1.14.25:
-    resolution: {integrity: sha512-aRAzikWpeXZrTfqdR0Nnqta3IV9NQgmTP7r81tMQOw5vNEyuHeBXGPoXnaV0U/8WDqhp7msIOpAd9qQ/kfm8gw==}
+  opencode-linux-arm64-musl@1.14.28:
+    resolution: {integrity: sha512-7R1GHqSg/UuT9r77GF2skh8r66WkZcphmDWAWaV2dmptJlxEJeV9I2jbE2i8Ctp4BzPUexFqfSoBA82S9Dcf+A==}
     cpu: [arm64]
     os: [linux]
 
-  opencode-linux-arm64@1.14.25:
-    resolution: {integrity: sha512-PdeyTRE10OwAPTpLVmKE3hSGncxxeHJC7iN1FVf+yRFBzp9SPYe5mlP7+O4ETj/J2j64peftuI0RYz44R9oisw==}
+  opencode-linux-arm64@1.14.28:
+    resolution: {integrity: sha512-jdTrs4YpPGFGZOMLuiaSfOUzkjAA+lnIEaW6HYLvaey3WsBnu3S4utaBhXURincp20H1JPQcahDOe+jjGZH7xw==}
     cpu: [arm64]
     os: [linux]
 
-  opencode-linux-x64-baseline-musl@1.14.25:
-    resolution: {integrity: sha512-6geh3YcHJmEI946pBODj96s9mFuC/kI5MXftC07k2+o61H2ehL22QA5k6vc1T/DiH09HHvXZpFpe4YjbehCfXg==}
+  opencode-linux-x64-baseline-musl@1.14.28:
+    resolution: {integrity: sha512-GKxZXj8/Mbutfs1DW4v0/rEWcAQrD/RUI9kV9VhMoNA8vUt0nuA3H9UvbFXh9EJj2C+RBSPLlMGal++oCH4c4w==}
     cpu: [x64]
     os: [linux]
 
-  opencode-linux-x64-baseline@1.14.25:
-    resolution: {integrity: sha512-/Mp8uGLzM1TIxU7MLnQZb9Xi79k78SibezxQhRzXUABCKbi2fDwIlX1Pi0UfjnBapIVknaRO8VML284nIhV9Lw==}
+  opencode-linux-x64-baseline@1.14.28:
+    resolution: {integrity: sha512-Dtl+xjEAKaWNk2l3iC9ebwi79BkChHIdtx97ksZKTLjAeR424Zh3vnjuWjpMYk9YAnesVlwL8y4kHs2Y736Zpw==}
     cpu: [x64]
     os: [linux]
 
-  opencode-linux-x64-musl@1.14.25:
-    resolution: {integrity: sha512-5Z/S5lCbdiT96fcT6aFpetGen8NaHrFNne/2QLYrHYfI2fIzT2uvtIT9c4MyBpN7Mx1TSHeq0Wol5b7D4QLznA==}
+  opencode-linux-x64-musl@1.14.28:
+    resolution: {integrity: sha512-XyzWl35L8N6El/hxAM28bDUHLCY0aujMtprDTCYXVckeNxBkN3idM4EfdLtJaUHkE6bqMr+m6wXQl4oYDoOtpg==}
     cpu: [x64]
     os: [linux]
 
-  opencode-linux-x64@1.14.25:
-    resolution: {integrity: sha512-gUTRsniZv91V4VO1eYa7QThDMVQkqClI2yiyhrN7L0xF95Oi4xzbYFvYdWbkmvaO85MKLaNsFNgdyYHEqhQ4wg==}
+  opencode-linux-x64@1.14.28:
+    resolution: {integrity: sha512-XnpQrud15bvUBvOI58tOGUBTrwqKHl6bYQ3eoy5HhGa2spUnRv3B/HU8QiS6QuNbmkPxRPR+vuTGtBYQvtRGPw==}
     cpu: [x64]
     os: [linux]
 
-  opencode-windows-arm64@1.14.25:
-    resolution: {integrity: sha512-HeJxvqJdsbGxTKna9zMaaEhDgSvKJDJofC9qLGEledYxH9HUVHd9CFUmuYpO7KKcQZvClcAEJWRu0DOhUKTHDA==}
+  opencode-windows-arm64@1.14.28:
+    resolution: {integrity: sha512-emR1oEoLe6soASahJNX6IwR9x8rJkbwBXDnXNTWQcGdSxKBMD4/cLkq84k/5zqLfB7dbUChTw7eFz7u8Sa5VQw==}
     cpu: [arm64]
     os: [win32]
 
-  opencode-windows-x64-baseline@1.14.25:
-    resolution: {integrity: sha512-HPtLBjM5Ox5saLGM9UQ9jyfeebgKL6C/zMte0TX7RBkib/D0lv8fwGC7fnBXbUUzGaLlLz0yixVlvllragfViw==}
+  opencode-windows-x64-baseline@1.14.28:
+    resolution: {integrity: sha512-ARKHTThHezib44QPLiivYI8c71iNE9iNDubwV5XxUhM2FtzMJkZGma+EgbcCsXwY5r0lAsarzzDMqYB0YfCZ1A==}
     cpu: [x64]
     os: [win32]
 
-  opencode-windows-x64@1.14.25:
-    resolution: {integrity: sha512-o2LjSo2/2meUlUD37oYX8H9KQUu9z8wRiyS0jAahnlgIQwmHHJ//FLgoPPxrnTqhk+eM7/lv24wckxJ8T7y12g==}
+  opencode-windows-x64@1.14.28:
+    resolution: {integrity: sha512-tEpblIEdmlJ7npo5Bq+1O7uup9jCOyqnnA63t+3JQiNQ1et3UTjNb5ruAjb7sudUer6i5MlQCwNXBjitjuU4Kg==}
     cpu: [x64]
     os: [win32]
 
@@ -4632,7 +4632,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@opencode-ai/sdk@1.14.25':
+  '@opencode-ai/sdk@1.14.28':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -7616,55 +7616,55 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  opencode-ai@1.14.25:
+  opencode-ai@1.14.28:
     optionalDependencies:
-      opencode-darwin-arm64: 1.14.25
-      opencode-darwin-x64: 1.14.25
-      opencode-darwin-x64-baseline: 1.14.25
-      opencode-linux-arm64: 1.14.25
-      opencode-linux-arm64-musl: 1.14.25
-      opencode-linux-x64: 1.14.25
-      opencode-linux-x64-baseline: 1.14.25
-      opencode-linux-x64-baseline-musl: 1.14.25
-      opencode-linux-x64-musl: 1.14.25
-      opencode-windows-arm64: 1.14.25
-      opencode-windows-x64: 1.14.25
-      opencode-windows-x64-baseline: 1.14.25
+      opencode-darwin-arm64: 1.14.28
+      opencode-darwin-x64: 1.14.28
+      opencode-darwin-x64-baseline: 1.14.28
+      opencode-linux-arm64: 1.14.28
+      opencode-linux-arm64-musl: 1.14.28
+      opencode-linux-x64: 1.14.28
+      opencode-linux-x64-baseline: 1.14.28
+      opencode-linux-x64-baseline-musl: 1.14.28
+      opencode-linux-x64-musl: 1.14.28
+      opencode-windows-arm64: 1.14.28
+      opencode-windows-x64: 1.14.28
+      opencode-windows-x64-baseline: 1.14.28
 
-  opencode-darwin-arm64@1.14.25:
+  opencode-darwin-arm64@1.14.28:
     optional: true
 
-  opencode-darwin-x64-baseline@1.14.25:
+  opencode-darwin-x64-baseline@1.14.28:
     optional: true
 
-  opencode-darwin-x64@1.14.25:
+  opencode-darwin-x64@1.14.28:
     optional: true
 
-  opencode-linux-arm64-musl@1.14.25:
+  opencode-linux-arm64-musl@1.14.28:
     optional: true
 
-  opencode-linux-arm64@1.14.25:
+  opencode-linux-arm64@1.14.28:
     optional: true
 
-  opencode-linux-x64-baseline-musl@1.14.25:
+  opencode-linux-x64-baseline-musl@1.14.28:
     optional: true
 
-  opencode-linux-x64-baseline@1.14.25:
+  opencode-linux-x64-baseline@1.14.28:
     optional: true
 
-  opencode-linux-x64-musl@1.14.25:
+  opencode-linux-x64-musl@1.14.28:
     optional: true
 
-  opencode-linux-x64@1.14.25:
+  opencode-linux-x64@1.14.28:
     optional: true
 
-  opencode-windows-arm64@1.14.25:
+  opencode-windows-arm64@1.14.28:
     optional: true
 
-  opencode-windows-x64-baseline@1.14.25:
+  opencode-windows-x64-baseline@1.14.28:
     optional: true
 
-  opencode-windows-x64@1.14.25:
+  opencode-windows-x64@1.14.28:
     optional: true
 
   optionator@0.9.4:

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -4,6 +4,8 @@ import type { CustomMcpConfig } from '@open-cowork/shared'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
+import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
+import { stopSessionStatusReconciliation } from '../apps/desktop/src/main/session-status-reconciler.ts'
 
 function createBaseContext() {
   const handlers = new Map<string, (...args: any[]) => any>()
@@ -146,6 +148,142 @@ test('permission:respond can answer a reopened approval using the hydrated sessi
     requestID: 'perm-1',
     reply: 'once',
   }])
+})
+
+test('question:reply clears the answered request locally so queued questions advance', async () => {
+  const { context, handlers } = createBaseContext()
+  const sessionId = 'question-ipc-reply-session'
+  const replies: Array<Record<string, unknown>> = []
+  const sentViews: unknown[] = []
+
+  sessionEngine.removeSession(sessionId)
+  try {
+    sessionEngine.activateSession(sessionId)
+    sessionEngine.applyStreamEvent({ sessionId, data: { type: 'busy' } })
+    sessionEngine.applyStreamEvent({
+      sessionId,
+      data: {
+        type: 'question_asked',
+        id: 'question-1',
+        questions: [{
+          header: 'First',
+          question: 'Pick the first answer',
+          options: [{ label: 'A', description: 'Alpha' }],
+        }],
+      },
+    })
+    sessionEngine.applyStreamEvent({
+      sessionId,
+      data: {
+        type: 'question_asked',
+        id: 'question-2',
+        questions: [{
+          header: 'Second',
+          question: 'Pick the second answer',
+          options: [{ label: 'B', description: 'Beta' }],
+        }],
+      },
+    })
+
+    context.getMainWindow = () => ({
+      isDestroyed: () => false,
+      webContents: {
+        id: 101,
+        send: (channel: string, payload: unknown) => {
+          if (channel === 'session:view') sentViews.push(payload)
+        },
+      },
+    } as any)
+    context.getSessionV2Client = async () => ({
+      client: {
+        question: {
+          reply: async (payload: Record<string, unknown>) => {
+            replies.push(payload)
+          },
+        },
+      } as any,
+      record: null,
+    })
+
+    registerSessionHandlers(context)
+    const handler = handlers.get('question:reply')
+    assert.ok(handler, 'expected question:reply handler to be registered')
+
+    await handler({}, sessionId, 'question-1', [['A']])
+
+    const view = sessionEngine.getSessionView(sessionId)
+    assert.deepEqual(replies, [{
+      requestID: 'question-1',
+      answers: [['A']],
+    }])
+    assert.equal(view.pendingQuestions.length, 1)
+    assert.equal(view.pendingQuestions[0]?.id, 'question-2')
+    assert.equal(view.isAwaitingQuestion, true)
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    assert.equal(sentViews.length > 0, true)
+  } finally {
+    stopSessionStatusReconciliation(sessionId)
+    sessionEngine.removeSession(sessionId)
+  }
+})
+
+test('question:reject clears the rejected request locally', async () => {
+  const { context, handlers } = createBaseContext()
+  const sessionId = 'question-ipc-reject-session'
+  const rejects: Array<Record<string, unknown>> = []
+
+  sessionEngine.removeSession(sessionId)
+  try {
+    sessionEngine.activateSession(sessionId)
+    sessionEngine.applyStreamEvent({ sessionId, data: { type: 'busy' } })
+    sessionEngine.applyStreamEvent({
+      sessionId,
+      data: {
+        type: 'question_asked',
+        id: 'question-reject',
+        questions: [{
+          header: 'Reject',
+          question: 'Should this be dismissed?',
+          options: [{ label: 'Dismiss', description: 'Dismiss it' }],
+        }],
+      },
+    })
+
+    context.getMainWindow = () => ({
+      isDestroyed: () => false,
+      webContents: {
+        id: 102,
+        send: () => {},
+      },
+    } as any)
+    context.getSessionV2Client = async () => ({
+      client: {
+        question: {
+          reject: async (payload: Record<string, unknown>) => {
+            rejects.push(payload)
+          },
+        },
+      } as any,
+      record: null,
+    })
+
+    registerSessionHandlers(context)
+    const handler = handlers.get('question:reject')
+    assert.ok(handler, 'expected question:reject handler to be registered')
+
+    await handler({}, sessionId, 'question-reject')
+
+    const view = sessionEngine.getSessionView(sessionId)
+    assert.deepEqual(rejects, [{ requestID: 'question-reject' }])
+    assert.equal(view.pendingQuestions.length, 0)
+    assert.equal(view.isAwaitingQuestion, false)
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  } finally {
+    stopSessionStatusReconciliation(sessionId)
+    sessionEngine.removeSession(sessionId)
+  }
 })
 
 test('custom:test-mcp reports OAuth guidance for remote MCP auth errors', async () => {

--- a/tests/main-window-lifecycle.test.ts
+++ b/tests/main-window-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  isExpectedPackagedRendererFile,
   needsMainWindowRecovery,
   pickRecoverableMainWindow,
   rendererUrlLooksWrong,
@@ -20,6 +21,26 @@ test('rendererUrlLooksWrong accepts the expected shell URL and rejects asset URL
   assert.equal(rendererUrlLooksWrong('file:///tmp/assets/chunk.js'), true)
   assert.equal(rendererUrlLooksWrong('http://127.0.0.1:5173', 'http://127.0.0.1:5173'), false)
   assert.equal(rendererUrlLooksWrong('http://127.0.0.1:4173', 'http://127.0.0.1:5173'), true)
+})
+
+test('isExpectedPackagedRendererFile only allows the packaged renderer entry', () => {
+  const expected = '/Applications/Open Cowork.app/Contents/Resources/app.asar/dist/index.html'
+  assert.equal(
+    isExpectedPackagedRendererFile('file:///Applications/Open%20Cowork.app/Contents/Resources/app.asar/dist/index.html', expected),
+    true,
+  )
+  assert.equal(
+    isExpectedPackagedRendererFile('file:///Applications/Open%20Cowork.app/Contents/Resources/app.asar/dist/chart-frame.html', expected),
+    false,
+  )
+  assert.equal(
+    isExpectedPackagedRendererFile('file:///Users/example/.ssh/config', expected),
+    false,
+  )
+  assert.equal(
+    isExpectedPackagedRendererFile('https://example.com/index.html', expected),
+    false,
+  )
 })
 
 test('pickRecoverableMainWindow keeps a live current window and falls back when needed', () => {


### PR DESCRIPTION
## Summary
- bump bundled OpenCode SDK/runtime packages to 1.14.28 and update docs/notices
- check SDK and runtime drift together in monthly maintenance
- harden packaged file:// navigation and document runtime HOME trust boundary
- resolve pending OpenCode questions locally after reply/reject so later queued questions surface reliably

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm lint:a11y --max-warnings=0
- pnpm audit --prod --audit-level high
- pnpm perf:check
- uv run mkdocs build --strict
- pnpm build
- pnpm test:e2e
- pnpm --dir apps/desktop dist:ci
- packaged app launched locally from apps/desktop/release/mac-arm64/Open Cowork.app