### PR TITLE
Add configurable branding surfaces

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -55,6 +55,8 @@ let runtimeStarted = false
 let reconnectTimer: NodeJS.Timeout | null = null
 let startupCleanupDone = false
 let appCleanupStarted = false
+let appCleanupFinished = false
+let appCleanupPromise: Promise<void> | null = null
 let runtimeProjectDirectory: string | null = null
 let mainWindowRecoveryTimer: NodeJS.Timeout | null = null
 let appIsQuitting = false
@@ -737,29 +739,42 @@ function scheduleReconnect() {
 }
 
 async function performCleanup() {
-  if (appCleanupStarted) return
+  if (appCleanupPromise) return appCleanupPromise
   appCleanupStarted = true
 
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer)
-    reconnectTimer = null
-  }
-  if (mcpInterval) {
-    clearInterval(mcpInterval)
-    mcpInterval = null
-  }
+  appCleanupPromise = (async () => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    if (mcpInterval) {
+      clearInterval(mcpInterval)
+      mcpInterval = null
+    }
 
-  flushSessionRegistryWrites()
-  eventSubscriptions.reset()
+    flushSessionRegistryWrites()
+    eventSubscriptions.reset()
 
-  try {
-    await stopRuntime()
-  } catch (err: unknown) {
-    log('error', `Runtime shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
-  } finally {
-    stopAutomationService()
-    closeLogger()
-  }
+    try {
+      await stopRuntime()
+    } catch (err: unknown) {
+      log('error', `Runtime shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      stopAutomationService()
+      appCleanupFinished = true
+      closeLogger()
+    }
+  })()
+
+  return appCleanupPromise
+}
+
+function exitAfterCleanup(exitCode: number) {
+  appIsQuitting = true
+  void performCleanup().finally(() => {
+    appCleanupFinished = true
+    app.exit(exitCode)
+  })
 }
 
 app.whenReady().then(async () => {
@@ -907,24 +922,26 @@ app.on('window-all-closed', () => {
   }
 })
 
-app.on('before-quit', async () => {
+app.on('before-quit', (event) => {
   appIsQuitting = true
-  await performCleanup()
+  if (appCleanupFinished) return
+  event.preventDefault()
+  exitAfterCleanup(0)
 })
 
-app.on('will-quit', async () => {
+app.on('will-quit', (event) => {
   appIsQuitting = true
-  await performCleanup()
+  if (appCleanupFinished) return
+  event.preventDefault()
+  exitAfterCleanup(0)
 })
 
 process.on('SIGINT', () => {
-  appIsQuitting = true
-  void performCleanup().finally(() => app.exit(0))
+  exitAfterCleanup(0)
 })
 
 process.on('SIGTERM', () => {
-  appIsQuitting = true
-  void performCleanup().finally(() => app.exit(0))
+  exitAfterCleanup(0)
 })
 
 // Without these, an unhandled rejection in any background promise
@@ -950,7 +967,7 @@ function handleFatalError(kind: 'uncaughtException' | 'unhandledRejection', err:
     // still diagnosable.
     process.stderr.write(`[open-cowork] ${kind}: ${message}\n`)
   }
-  void performCleanup().finally(() => app.exit(1))
+  exitAfterCleanup(1)
 }
 
 process.on('uncaughtException', (err) => handleFatalError('uncaughtException', err))

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -539,6 +539,7 @@ export function App() {
             onViewChange={setView}
             searchRequestNonce={sidebarSearchNonce}
             settingsRequestNonce={sidebarSettingsNonce}
+            branding={config.branding.sidebar}
           />
         )}
         <main className="flex-1 flex flex-col min-h-0 min-w-0">
@@ -546,6 +547,7 @@ export function App() {
             {view === 'home' && (
               <HomePage
                 brandName={config.branding.name}
+                homeBranding={config.branding.home}
                 onStartThread={startThreadFromHome}
                 onOpenPulse={() => setView('pulse')}
                 onOpenThread={(sessionId) => void openExistingThread(sessionId)}

--- a/apps/desktop/src/renderer/components/HomePage.test.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { BuiltInAgentDetail } from '@open-cowork/shared'
+import { HomePage } from './HomePage'
+
+const researchAgent: BuiltInAgentDetail = {
+  name: 'research',
+  label: 'Research',
+  source: 'open-cowork',
+  mode: 'subagent',
+  hidden: false,
+  disabled: false,
+  color: 'info',
+  description: 'Researches a focused question.',
+  instructions: 'Research thoroughly.',
+  skills: [],
+  toolAccess: [],
+  nativeToolIds: [],
+  configuredToolIds: [],
+}
+
+describe('HomePage', () => {
+  it('keeps upstream Home copy as the default', async () => {
+    render(
+      <HomePage
+        brandName="Open Cowork"
+        onStartThread={vi.fn(async () => undefined)}
+        onOpenPulse={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('What shall we cowork on today?')).toBeTruthy()
+    expect(screen.getByText('Open Cowork · Ask anything, or @mention an agent')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Ask anything, or @mention an agent')).toBeTruthy()
+    await waitFor(() => expect(window.coworkApi.app.builtinAgents).toHaveBeenCalledTimes(1))
+  })
+
+  it('renders downstream-configured Home copy without changing agent suggestions', async () => {
+    vi.mocked(window.coworkApi.app.builtinAgents).mockResolvedValue([researchAgent])
+
+    render(
+      <HomePage
+        brandName="Acme Cowork"
+        homeBranding={{
+          greeting: 'What should {{brand}} work on today?',
+          subtitle: 'Ask a question or delegate to an approved agent.',
+          composerPlaceholder: 'Ask {{brand}} anything',
+          suggestionLabel: 'Start with',
+          statusReadyLabel: 'Online',
+        }}
+        onStartThread={vi.fn(async () => undefined)}
+        onOpenPulse={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('What should Acme Cowork work on today?')).toBeTruthy()
+    expect(screen.getByText('Ask a question or delegate to an approved agent.')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Ask Acme Cowork anything')).toBeTruthy()
+    expect(await screen.findByText('Start with')).toBeTruthy()
+    expect(screen.getByText('@Research')).toBeTruthy()
+    expect(screen.getByText('Online')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/renderer/components/HomePage.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.tsx
@@ -438,7 +438,7 @@ export function HomePage({ brandName, homeBranding, onStartThread, onOpenPulse, 
   const readyLabel = configuredCopy(homeBranding?.statusReadyLabel, 'home.statusStrip.ready', 'Ready', homeCopyVars)
 
   return (
-    <div className="relative flex-1 min-h-0 overflow-y-auto">
+    <div className="relative flex-1 min-h-0 overflow-y-auto" data-testid="home-view">
       <HomeBackdrop />
       <div className="relative max-w-[760px] mx-auto px-6 pt-[clamp(72px,13vh,142px)] pb-16 flex flex-col items-center">
         <HomeEyebrow brandName={brandName} />

--- a/apps/desktop/src/renderer/components/HomePage.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { BuiltInAgentDetail, SessionInfo } from '@open-cowork/shared'
+import type { BrandingHomeConfig, BuiltInAgentDetail, SessionInfo } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
 import { formatDate, t } from '../helpers/i18n'
 import { ChatInputAttachments } from './chat/ChatInputAttachments'
@@ -15,6 +15,7 @@ import type { Attachment } from './chat/chat-input-types'
 
 interface Props {
   brandName: string
+  homeBranding?: BrandingHomeConfig
   onStartThread: (text: string, attachments?: Attachment[]) => Promise<void>
   onOpenPulse: () => void
   onOpenThread: (sessionId: string) => void | Promise<void>
@@ -45,6 +46,25 @@ function formatAgentLabel(name: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ')
+}
+
+function interpolateCopy(value: string, vars?: Record<string, string | number>) {
+  if (!vars) return value
+  return value.replace(/\{\{([a-zA-Z0-9_]+)\}\}/g, (match, key) => {
+    const replacement = vars[key]
+    return replacement === undefined ? match : String(replacement)
+  })
+}
+
+function configuredCopy(
+  configured: string | undefined,
+  key: string,
+  fallback: string,
+  vars?: Record<string, string | number>,
+) {
+  const trimmed = configured?.trim()
+  if (trimmed) return interpolateCopy(trimmed, vars)
+  return t(key, fallback, vars)
 }
 
 function HomeBackdrop() {
@@ -249,15 +269,16 @@ function HomeComposer({ onSubmit, disabled, placeholder }: {
   )
 }
 
-function AgentSuggestions({ agents, onPick }: {
+function AgentSuggestions({ agents, onPick, label }: {
   agents: Array<{ id: string; label: string; description: string }>
   onPick: (agentId: string) => void
+  label: string
 }) {
   if (agents.length === 0) return null
   return (
     <div className="mt-6 flex items-center justify-center flex-wrap gap-2">
       <span className="text-[11px] uppercase text-text-muted">
-        {t('home.suggestions.title', 'Try')}
+        {label}
       </span>
       {agents.slice(0, MAX_SUGGESTIONS).map((agent) => (
         <button
@@ -310,7 +331,7 @@ function RecentThreads({ threads, onOpen }: {
   )
 }
 
-function StatusStrip({ onOpenPulse }: { onOpenPulse: () => void }) {
+function StatusStrip({ onOpenPulse, readyLabel }: { onOpenPulse: () => void; readyLabel: string }) {
   const mcpConnections = useSessionStore((s) => s.mcpConnections)
   const connected = mcpConnections.filter((conn) => conn.connected).length
   const total = mcpConnections.length
@@ -326,7 +347,7 @@ function StatusStrip({ onOpenPulse }: { onOpenPulse: () => void }) {
     >
       <span className="inline-flex items-center gap-1.5">
         <span className="w-1.5 h-1.5 rounded-full" style={{ background: total > 0 && connected === total ? 'var(--color-success)' : 'var(--color-warning)' }} />
-        {t('home.statusStrip.ready', 'Ready')}
+        {readyLabel}
       </span>
       <span className="opacity-40">·</span>
       <span>{t('home.statusStrip.mcps', '{{connected}}/{{total}} MCPs', { connected, total })}</span>
@@ -339,7 +360,7 @@ function StatusStrip({ onOpenPulse }: { onOpenPulse: () => void }) {
   )
 }
 
-export function HomePage({ brandName, onStartThread, onOpenPulse, onOpenThread }: Props) {
+export function HomePage({ brandName, homeBranding, onStartThread, onOpenPulse, onOpenThread }: Props) {
   const sessions = useSessionStore((s) => s.sessions)
   const [builtinAgents, setBuiltinAgents] = useState<BuiltInAgentDetail[]>([])
   const [submitting, setSubmitting] = useState(false)
@@ -399,31 +420,48 @@ export function HomePage({ brandName, onStartThread, onOpenPulse, onOpenThread }
     void onOpenThread(sessionId)
   }, [onOpenThread])
 
+  const homeCopyVars = { brand: brandName }
+  const greeting = configuredCopy(homeBranding?.greeting, GREETING_KEY, GREETING_FALLBACK, homeCopyVars)
+  const subtitle = configuredCopy(
+    homeBranding?.subtitle,
+    'home.subtitle',
+    '{{brand}} · Ask anything, or @mention an agent',
+    homeCopyVars,
+  )
+  const composerPlaceholder = configuredCopy(
+    homeBranding?.composerPlaceholder,
+    'home.composer.placeholder',
+    'Ask anything, or @mention an agent',
+    homeCopyVars,
+  )
+  const suggestionLabel = configuredCopy(homeBranding?.suggestionLabel, 'home.suggestions.title', 'Try', homeCopyVars)
+  const readyLabel = configuredCopy(homeBranding?.statusReadyLabel, 'home.statusStrip.ready', 'Ready', homeCopyVars)
+
   return (
     <div className="relative flex-1 min-h-0 overflow-y-auto">
       <HomeBackdrop />
       <div className="relative max-w-[760px] mx-auto px-6 pt-[clamp(72px,13vh,142px)] pb-16 flex flex-col items-center">
         <HomeEyebrow brandName={brandName} />
         <h1 className="text-[30px] sm:text-[38px] leading-[1.08] font-semibold text-text text-center">
-          {t(GREETING_KEY, GREETING_FALLBACK)}
+          {greeting}
         </h1>
         <p className="mt-3 text-[13px] text-text-muted text-center">
-          {t('home.subtitle', '{{brand}} · Ask anything, or @mention an agent', { brand: brandName })}
+          {subtitle}
         </p>
 
         <div className="w-full mt-9">
           <HomeComposer
             onSubmit={handleSubmit}
             disabled={submitting}
-            placeholder={t('home.composer.placeholder', 'Ask anything, or @mention an agent')}
+            placeholder={composerPlaceholder}
           />
         </div>
 
-        <AgentSuggestions agents={suggestedAgents} onPick={handlePickAgent} />
+        <AgentSuggestions agents={suggestedAgents} onPick={handlePickAgent} label={suggestionLabel} />
 
         <RecentThreads threads={recentThreads} onOpen={handleOpenThread} />
 
-        <StatusStrip onOpenPulse={onOpenPulse} />
+        <StatusStrip onOpenPulse={onOpenPulse} readyLabel={readyLabel} />
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { Sidebar } from './Sidebar'
+
+describe('Sidebar', () => {
+  it('keeps the upstream sidebar layout when no branding config is provided', () => {
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'New Thread' })).toBeTruthy()
+    expect(screen.getByText('Connections')).toBeTruthy()
+    expect(screen.queryByText('Acme AI')).toBeNull()
+  })
+
+  it('renders configured top and lower downstream branding surfaces', () => {
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'icon-text',
+            icon: 'AC',
+            title: 'Acme AI',
+            subtitle: 'Private workspace',
+            ariaLabel: 'Acme AI workspace',
+          },
+          lower: {
+            text: 'Acme internal build',
+            secondaryText: 'Support from Data Platform.',
+            linkLabel: 'Get help',
+            linkUrl: 'https://internal.acme.example/help',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Acme AI')).toBeTruthy()
+    expect(screen.getByText('Private workspace')).toBeTruthy()
+    expect(screen.getByText('Acme internal build')).toBeTruthy()
+    expect(screen.getByText('Support from Data Platform.')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Get help' })).toHaveAttribute('href', 'https://internal.acme.example/help')
+    expect(screen.getByText('Connections')).toBeTruthy()
+  })
+
+  it('supports icon-only, text-only, and logo-backed top branding variants', () => {
+    const { rerender } = render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'icon',
+            icon: 'AC',
+            ariaLabel: 'Acme AI workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: 'Acme AI workspace' })).toBeTruthy()
+    expect(screen.queryByText('Acme AI')).toBeNull()
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'text',
+            title: 'Acme AI',
+            subtitle: 'Private workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Acme AI')).toBeTruthy()
+    expect(screen.getByText('Private workspace')).toBeTruthy()
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'logo-text',
+            logoDataUrl: 'data:image/png;base64,AAAA',
+            title: 'Acme AI',
+          },
+        }}
+      />,
+    )
+
+    expect(document.querySelector('img[src="data:image/png;base64,AAAA"]')).toBeTruthy()
+    expect(screen.getByText('Acme AI')).toBeTruthy()
+  })
+
+  it('does not render unsafe downstream sidebar links', () => {
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          lower: {
+            text: 'Acme internal build',
+            linkLabel: 'Unsafe help',
+            linkUrl: 'http://internal.acme.example/help',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Acme internal build')).toBeTruthy()
+    expect(screen.queryByRole('link', { name: 'Unsafe help' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -100,6 +100,57 @@ describe('Sidebar', () => {
     expect(screen.getByText('Acme AI')).toBeTruthy()
   })
 
+  it('falls back instead of rendering an empty top-brand card for incompatible variants', () => {
+    const { rerender } = render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'text',
+            icon: 'AC',
+            ariaLabel: 'Acme AI workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: 'Acme AI workspace' })).toBeTruthy()
+    expect(screen.getByText('AC')).toBeTruthy()
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'logo',
+            title: 'Acme AI',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Acme AI')).toBeTruthy()
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'logo-text',
+            icon: 'AC',
+            ariaLabel: 'Acme AI workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: 'Acme AI workspace' })).toBeTruthy()
+    expect(screen.getByText('AC')).toBeTruthy()
+  })
+
   it('does not render unsafe downstream sidebar links', () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useState } from 'react'
+import type { BrandingSidebarConfig, BrandingSidebarLowerConfig, BrandingSidebarTopConfig } from '@open-cowork/shared'
 import { ThreadList } from '../sidebar/ThreadList'
 import { McpStatus } from '../sidebar/McpStatus'
 import { NewThreadButton } from '../sidebar/NewThreadButton'
@@ -9,17 +10,123 @@ interface Props {
   onViewChange: (view: 'home' | 'chat' | 'automations' | 'agents' | 'capabilities' | 'pulse') => void
   searchRequestNonce?: number
   settingsRequestNonce?: number
+  branding?: BrandingSidebarConfig
 }
 
 const SettingsPanel = lazy(() =>
   import('../sidebar/SettingsPanel').then((module) => ({ default: module.SettingsPanel })),
 )
 
+function safeLogoDataUrl(value: string | undefined) {
+  const trimmed = value?.trim()
+  if (!trimmed || trimmed.length > 65_536) return undefined
+  return /^data:image\/(?:png|jpeg|jpg|webp|gif);base64,[A-Za-z0-9+/=]+$/.test(trimmed) ? trimmed : undefined
+}
+
+function safeExternalHref(value: string | undefined) {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+  try {
+    const url = new URL(trimmed)
+    return url.protocol === 'https:' || url.protocol === 'mailto:' ? trimmed : null
+  } catch {
+    return null
+  }
+}
+
+function sidebarTopVariant(top: BrandingSidebarTopConfig) {
+  if (top.variant) return top.variant
+  if (safeLogoDataUrl(top.logoDataUrl)) return top.title || top.subtitle ? 'logo-text' : 'logo'
+  if (top.icon) return top.title || top.subtitle ? 'icon-text' : 'icon'
+  return 'text'
+}
+
+function SidebarBrandTop({ top }: { top?: BrandingSidebarTopConfig }) {
+  if (!top) return null
+
+  const title = top.title?.trim()
+  const subtitle = top.subtitle?.trim()
+  const icon = top.icon?.trim()
+  const logoDataUrl = safeLogoDataUrl(top.logoDataUrl)
+  const hasContent = Boolean(title || subtitle || icon || logoDataUrl)
+  if (!hasContent) return null
+
+  const variant = sidebarTopVariant(top)
+  const showLogo = Boolean(logoDataUrl && (variant === 'logo' || variant === 'logo-text'))
+  const showIcon = Boolean(!showLogo && icon && (variant === 'icon' || variant === 'icon-text'))
+  const showText = Boolean(title || subtitle) && (variant === 'text' || variant === 'icon-text' || variant === 'logo-text' || (!showLogo && !showIcon))
+  const iconOnly = !showText && (showLogo || showIcon)
+  const ariaLabel = top.ariaLabel?.trim() || title || subtitle || t('sidebar.branding', 'Brand')
+
+  return (
+    <div className="px-3 pt-3 pb-2">
+      <div
+        className={`flex min-h-10 items-center gap-2.5 rounded-lg border border-border-subtle px-2.5 py-2 text-text-secondary ${iconOnly ? 'justify-center' : ''}`}
+        style={{ background: 'color-mix(in srgb, var(--color-elevated) 42%, transparent)' }}
+        role={iconOnly ? 'img' : undefined}
+        aria-label={iconOnly ? ariaLabel : undefined}
+      >
+        {showLogo && (
+          <img
+            src={logoDataUrl}
+            alt=""
+            className="h-7 w-7 shrink-0 rounded-md object-contain"
+            draggable={false}
+          />
+        )}
+        {showIcon && (
+          <span
+            className="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-border-subtle text-[14px]"
+            style={{ background: 'color-mix(in srgb, var(--color-surface) 70%, transparent)' }}
+            aria-hidden={iconOnly ? undefined : 'true'}
+          >
+            {icon}
+          </span>
+        )}
+        {showText && (
+          <div className="min-w-0 flex-1">
+            {title && <div className="truncate text-[12px] font-medium text-text">{title}</div>}
+            {subtitle && <div className="mt-0.5 truncate text-[10px] text-text-muted">{subtitle}</div>}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SidebarLowerBranding({ lower }: { lower?: BrandingSidebarLowerConfig }) {
+  if (!lower) return null
+  const text = lower.text?.trim()
+  const secondaryText = lower.secondaryText?.trim()
+  const linkLabel = lower.linkLabel?.trim()
+  const linkUrl = safeExternalHref(lower.linkUrl)
+  if (!text && !secondaryText && !(linkLabel && linkUrl)) return null
+
+  return (
+    <div className="mb-2 rounded-md border border-border-subtle px-2 py-2 text-[11px] text-text-muted"
+      style={{ background: 'color-mix(in srgb, var(--color-elevated) 34%, transparent)' }}>
+      {text && <div className="truncate font-medium text-text-secondary">{text}</div>}
+      {secondaryText && <div className="mt-0.5 line-clamp-2 leading-snug">{secondaryText}</div>}
+      {linkLabel && linkUrl && (
+        <a
+          href={linkUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-1.5 inline-flex max-w-full text-[11px] text-text-secondary hover:text-text underline-offset-2 hover:underline"
+        >
+          <span className="truncate">{linkLabel}</span>
+        </a>
+      )}
+    </div>
+  )
+}
+
 export function Sidebar({
   currentView,
   onViewChange,
   searchRequestNonce = 0,
   settingsRequestNonce = 0,
+  branding,
 }: Props) {
   const [showSettings, setShowSettings] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -50,6 +157,7 @@ export function Sidebar({
         </Suspense>
       ) : (
         <>
+          <SidebarBrandTop top={branding?.top} />
           <div className="p-3 pb-1 flex gap-2">
             <div className="flex-1">
               <NewThreadButton onClick={() => onViewChange('chat')} />
@@ -143,6 +251,7 @@ export function Sidebar({
 
           {/* Connections */}
           <div className="border-t border-border-subtle px-2 py-2">
+            <SidebarLowerBranding lower={branding?.lower} />
             <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-widest text-text-muted">{t('sidebar.connections', 'Connections')}</div>
             <McpStatus />
           </div>

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -41,6 +41,40 @@ function sidebarTopVariant(top: BrandingSidebarTopConfig) {
   return 'text'
 }
 
+function renderableSidebarTopVariant(
+  preferred: NonNullable<BrandingSidebarTopConfig['variant']>,
+  options: {
+    hasLogo: boolean
+    hasIcon: boolean
+    hasText: boolean
+  },
+) {
+  const { hasLogo, hasIcon, hasText } = options
+  const firstRenderable = (...candidates: Array<NonNullable<BrandingSidebarTopConfig['variant']>>) =>
+    candidates.find((candidate) => {
+      if (candidate === 'logo') return hasLogo
+      if (candidate === 'icon') return hasIcon
+      if (candidate === 'text') return hasText
+      if (candidate === 'logo-text') return hasLogo && hasText
+      return hasIcon && hasText
+    }) || null
+
+  switch (preferred) {
+    case 'logo':
+      return firstRenderable('logo', 'icon', 'text')
+    case 'icon':
+      return firstRenderable('icon', 'logo', 'text')
+    case 'text':
+      return firstRenderable('text', 'logo', 'icon')
+    case 'logo-text':
+      return firstRenderable('logo-text', 'logo', 'text', 'icon')
+    case 'icon-text':
+      return firstRenderable('icon-text', 'icon', 'text', 'logo')
+    default:
+      return null
+  }
+}
+
 function SidebarBrandTop({ top }: { top?: BrandingSidebarTopConfig }) {
   if (!top) return null
 
@@ -48,13 +82,16 @@ function SidebarBrandTop({ top }: { top?: BrandingSidebarTopConfig }) {
   const subtitle = top.subtitle?.trim()
   const icon = top.icon?.trim()
   const logoDataUrl = safeLogoDataUrl(top.logoDataUrl)
-  const hasContent = Boolean(title || subtitle || icon || logoDataUrl)
-  if (!hasContent) return null
+  const hasText = Boolean(title || subtitle)
+  const hasIcon = Boolean(icon)
+  const hasLogo = Boolean(logoDataUrl)
+  if (!hasText && !hasIcon && !hasLogo) return null
 
-  const variant = sidebarTopVariant(top)
+  const variant = renderableSidebarTopVariant(sidebarTopVariant(top), { hasLogo, hasIcon, hasText })
+  if (!variant) return null
   const showLogo = Boolean(logoDataUrl && (variant === 'logo' || variant === 'logo-text'))
   const showIcon = Boolean(!showLogo && icon && (variant === 'icon' || variant === 'icon-text'))
-  const showText = Boolean(title || subtitle) && (variant === 'text' || variant === 'icon-text' || variant === 'logo-text' || (!showLogo && !showIcon))
+  const showText = hasText && (variant === 'text' || variant === 'icon-text' || variant === 'logo-text' || (!showLogo && !showIcon))
   const iconOnly = !showText && (showLogo || showIcon)
   const ariaLabel = top.ariaLabel?.trim() || title || subtitle || t('sidebar.branding', 'Brand')
 

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -59,14 +59,43 @@ export interface LaunchSmokeSessionOptions {
 
 const SMOKE_BRAND_NAME = 'Open Cowork Smoke'
 
+async function getAppShellDiagnostics(page: Page) {
+  try {
+    return await page.evaluate(async () => {
+      const runtimeStatus = await window.coworkApi?.runtime?.status?.().catch((error: unknown) => ({
+        error: error instanceof Error ? error.message : String(error),
+      }))
+      return {
+        url: window.location.href,
+        title: document.title,
+        hasRoot: Boolean(document.querySelector('#root')),
+        hasHomeView: Boolean(document.querySelector('[data-testid="home-view"]')),
+        hasCoworkApi: Boolean(window.coworkApi),
+        runtimeStatus,
+        bodyText: (document.body?.innerText || '').replace(/\s+/g, ' ').slice(0, 1_500),
+      }
+    })
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
 export async function waitForAppShell(page: Page, timeout = 15_000) {
-  await page.waitForFunction(() => Boolean(
-    document.querySelector('#root')
-    && typeof window.coworkApi?.app?.config === 'function'
-    && typeof window.coworkApi?.settings?.set === 'function'
-    && typeof window.coworkApi?.custom?.listMcps === 'function',
-  ), { timeout })
-  await page.getByRole('button', { name: 'Home', exact: true }).first().waitFor({ timeout })
+  try {
+    await page.waitForFunction(() => Boolean(
+      document.querySelector('#root')
+      && typeof window.coworkApi?.app?.config === 'function'
+      && typeof window.coworkApi?.settings?.set === 'function'
+      && typeof window.coworkApi?.custom?.listMcps === 'function',
+    ), { timeout })
+    await page.waitForFunction(() => Boolean(document.querySelector('[data-testid="home-view"]')), { timeout })
+  } catch (error) {
+    const diagnostics = await getAppShellDiagnostics(page)
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Timed out waiting for app shell: ${message}\nDiagnostics: ${JSON.stringify(diagnostics)}`, { cause: error })
+  }
 }
 
 function writeIsolatedConfig(tempRoot: string) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,12 +40,58 @@ Typical downstream changes:
 - data directory name
 - project namespace, if you intentionally want a different
   on-disk overlay directory than the upstream `.opencowork/`
+- optional sidebar and Home copy surfaces for downstream distributions
 
 > **Compatibility note:** the public GitHub repo is `open-cowork`, but
 > the upstream `appId` and `projectNamespace` intentionally keep the
 > historical `opencowork` form for bundle-ID and on-disk back-compat.
 > Change those only when you are deliberately creating a distinct
 > downstream distribution and are prepared to migrate app state.
+
+### Sidebar and Home surfaces
+
+Downstream builds can tune the first-run product surface without patching React
+components. These fields are optional; unset fields preserve upstream Open
+Cowork copy and layout.
+
+```jsonc
+{
+  "branding": {
+    "name": "Acme Cowork",
+    "sidebar": {
+      "top": {
+        "variant": "icon-text",
+        "icon": "AC",
+        "title": "Acme AI",
+        "subtitle": "Private workspace",
+        "ariaLabel": "Acme AI workspace"
+      },
+      "lower": {
+        "text": "Acme internal build",
+        "secondaryText": "Support from Data Platform.",
+        "linkLabel": "Get help",
+        "linkUrl": "https://internal.acme.example/cowork-help"
+      }
+    },
+    "home": {
+      "greeting": "What should {{brand}} work on today?",
+      "subtitle": "Ask a question or delegate to an approved agent.",
+      "composerPlaceholder": "Ask {{brand}} anything",
+      "suggestionLabel": "Start with",
+      "statusReadyLabel": "Online"
+    }
+  }
+}
+```
+
+`branding.sidebar.top.variant` accepts `icon`, `text`, `icon-text`, `logo`, or
+`logo-text`. Logo-backed variants use `logoDataUrl`, not filesystem paths or
+remote URLs. The schema only accepts compact `data:image/png|jpeg|jpg|webp|gif`
+base64 values so downstream branding cannot introduce arbitrary network loads,
+HTML, or SVG script surfaces.
+
+`branding.sidebar.lower.linkUrl` accepts only `https://` and `mailto:` links.
+The renderer re-checks that allowlist before rendering a link.
 
 ## Environment placeholders
 

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -187,7 +187,28 @@ provider, one internal MCP, and one internal skill would look like:
     "name": "Acme Cowork",
     "appId": "com.acme.cowork",
     "dataDirName": "acme-cowork",
-    "helpUrl": "https://internal.acme.example/cowork"
+    "helpUrl": "https://internal.acme.example/cowork",
+    "sidebar": {
+      "top": {
+        "variant": "icon-text",
+        "icon": "AC",
+        "title": "Acme AI",
+        "subtitle": "Private workspace"
+      },
+      "lower": {
+        "text": "Acme internal build",
+        "secondaryText": "Support from Data Platform.",
+        "linkLabel": "Get help",
+        "linkUrl": "https://internal.acme.example/cowork-help"
+      }
+    },
+    "home": {
+      "greeting": "What should {{brand}} work on today?",
+      "subtitle": "Ask a question or delegate to an approved agent.",
+      "composerPlaceholder": "Ask {{brand}} anything",
+      "suggestionLabel": "Start with",
+      "statusReadyLabel": "Online"
+    }
   },
   "providers": {
     "available": ["acme-gateway"],
@@ -251,6 +272,11 @@ The in-app brand name (window title, first-run copy, log prefixes) is
 driven separately by `branding.name` inside `open-cowork.config.json`
 or the downstream config overlay — see the Configuration section
 above.
+
+Downstream builds can also configure sidebar and Home copy under
+`branding.sidebar` and `branding.home`. Those fields only affect UI surfaces:
+they do not change OpenCode runtime providers, agents, permissions, MCPs, or
+skills.
 
 The repo name, bundle identifier, and project namespace are separate
 concerns. Upstream now uses the public repo name `open-cowork`, but

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -22,7 +22,9 @@
         "themes": {
           "type": "array",
           "items": { "$ref": "#/$defs/brandThemeDefinition" }
-        }
+        },
+        "sidebar": { "$ref": "#/$defs/brandingSidebar" },
+        "home": { "$ref": "#/$defs/brandingHome" }
       },
       "required": ["name", "appId", "dataDirName", "helpUrl"]
     },
@@ -187,6 +189,55 @@
   },
   "required": ["allowedEnvPlaceholders", "branding", "auth", "providers", "tools", "skills", "mcps", "agents", "permissions"],
   "$defs": {
+    "brandingSidebar": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "top": { "$ref": "#/$defs/brandingSidebarTop" },
+        "lower": { "$ref": "#/$defs/brandingSidebarLower" }
+      }
+    },
+    "brandingSidebarTop": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variant": { "type": "string", "enum": ["icon", "text", "icon-text", "logo", "logo-text"] },
+        "icon": { "type": "string", "maxLength": 16 },
+        "logoDataUrl": {
+          "type": "string",
+          "maxLength": 65536,
+          "pattern": "^data:image/(png|jpeg|jpg|webp|gif);base64,[A-Za-z0-9+/=]+$"
+        },
+        "title": { "type": "string", "maxLength": 48 },
+        "subtitle": { "type": "string", "maxLength": 96 },
+        "ariaLabel": { "type": "string", "maxLength": 96 }
+      }
+    },
+    "brandingSidebarLower": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": { "type": "string", "maxLength": 120 },
+        "secondaryText": { "type": "string", "maxLength": 160 },
+        "linkLabel": { "type": "string", "maxLength": 64 },
+        "linkUrl": {
+          "type": "string",
+          "maxLength": 2048,
+          "pattern": "^(https://|mailto:).+"
+        }
+      }
+    },
+    "brandingHome": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "greeting": { "type": "string", "maxLength": 120 },
+        "subtitle": { "type": "string", "maxLength": 180 },
+        "composerPlaceholder": { "type": "string", "maxLength": 120 },
+        "suggestionLabel": { "type": "string", "maxLength": 48 },
+        "statusReadyLabel": { "type": "string", "maxLength": 48 }
+      }
+    },
     "credentialField": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1125,6 +1125,37 @@ export interface BrandThemeDefinition {
   light?: BrandThemeTokens
 }
 
+export type BrandingSidebarTopVariant = 'icon' | 'text' | 'icon-text' | 'logo' | 'logo-text'
+
+export interface BrandingSidebarTopConfig {
+  variant?: BrandingSidebarTopVariant
+  icon?: string
+  logoDataUrl?: string
+  title?: string
+  subtitle?: string
+  ariaLabel?: string
+}
+
+export interface BrandingSidebarLowerConfig {
+  text?: string
+  secondaryText?: string
+  linkLabel?: string
+  linkUrl?: string
+}
+
+export interface BrandingSidebarConfig {
+  top?: BrandingSidebarTopConfig
+  lower?: BrandingSidebarLowerConfig
+}
+
+export interface BrandingHomeConfig {
+  greeting?: string
+  subtitle?: string
+  composerPlaceholder?: string
+  suggestionLabel?: string
+  statusReadyLabel?: string
+}
+
 export interface BrandingConfig {
   name: string
   appId: string
@@ -1142,6 +1173,10 @@ export interface BrandingConfig {
   // Extra themes appended to the built-in preset list. Downstream forks can
   // ship their own palette (e.g. "Nike Red") without touching source.
   themes?: BrandThemeDefinition[]
+  // Optional UI copy/brand surfaces for downstream distributions. These stay
+  // product-layer only and do not alter OpenCode runtime config or behavior.
+  sidebar?: BrandingSidebarConfig
+  home?: BrandingHomeConfig
 }
 
 export interface AgentStarterTemplate {

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -3,7 +3,71 @@ import test from 'node:test'
 import { readFileSync } from 'fs'
 import { validateResolvedConfig } from '../apps/desktop/src/main/config-schema.ts'
 
+function readRootConfig() {
+  return JSON.parse(readFileSync('open-cowork.config.json', 'utf-8'))
+}
+
+function cloneConfig() {
+  return JSON.parse(JSON.stringify(readRootConfig()))
+}
+
 test('root open-cowork.config.json validates against the public schema', () => {
-  const config = JSON.parse(readFileSync('open-cowork.config.json', 'utf-8'))
+  const config = readRootConfig()
   assert.doesNotThrow(() => validateResolvedConfig(config, 'open-cowork.config.json'))
+})
+
+test('branding sidebar and home overrides validate', () => {
+  const config = cloneConfig()
+  config.branding.sidebar = {
+    top: {
+      variant: 'icon-text',
+      icon: 'AC',
+      title: 'Acme AI',
+      subtitle: 'Private workspace',
+      ariaLabel: 'Acme AI workspace',
+    },
+    lower: {
+      text: 'Acme internal build',
+      secondaryText: 'Support is handled by the data platform team.',
+      linkLabel: 'Get help',
+      linkUrl: 'https://internal.acme.example/help',
+    },
+  }
+  config.branding.home = {
+    greeting: 'What should {{brand}} work on today?',
+    subtitle: 'Ask a question or delegate to an approved agent.',
+    composerPlaceholder: 'Ask {{brand}} anything',
+    suggestionLabel: 'Start with',
+    statusReadyLabel: 'Online',
+  }
+
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'branding config'))
+})
+
+test('branding rejects unknown sidebar keys', () => {
+  const config = cloneConfig()
+  config.branding.sidebar = {
+    top: {
+      title: 'Acme AI',
+      html: '<strong>not allowed</strong>',
+    },
+  }
+
+  assert.throws(() => validateResolvedConfig(config, 'branding config'), /branding\.sidebar\.top/)
+})
+
+test('branding rejects unsafe links and logo URLs', () => {
+  const config = cloneConfig()
+  config.branding.sidebar = {
+    top: {
+      variant: 'logo',
+      logoDataUrl: 'https://cdn.example.test/logo.png',
+    },
+    lower: {
+      linkLabel: 'Help',
+      linkUrl: 'http://internal.example.test/help',
+    },
+  }
+
+  assert.throws(() => validateResolvedConfig(config, 'branding config'), /branding\.sidebar/)
 })


### PR DESCRIPTION
## Summary
- add typed branding.sidebar and branding.home config surfaces for downstream builds
- render optional sidebar top branding, lower sidebar info, and Home/startup copy overrides with safe defaults
- document the new fields and add schema/renderer tests for defaults, configured branding, safe links, and layout variants

Closes #46.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm lint:a11y --max-warnings=0
- pnpm docs:build
- pnpm build
- pnpm test:e2e
- git diff --check