### PR TITLE
Harden release readiness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Audit production dependencies
         run: pnpm audit --prod --audit-level high
 
+      - name: Audit full dependency graph (critical advisory)
+        run: pnpm audit --audit-level critical
+        continue-on-error: true
+
       - name: Verify third-party notices
         run: |
           pnpm notices

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Docs
 on:
   push:
     branches: [master]
+  # GitHub's `public` event fires when the repository visibility changes
+  # from private to public, which lets the docs deploy after launch.
   public:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,10 @@ jobs:
       - name: Audit production dependencies
         run: pnpm audit --prod --audit-level high
 
+      - name: Audit full dependency graph (critical advisory)
+        run: pnpm audit --audit-level critical
+        continue-on-error: true
+
       - name: Lint
         run: pnpm lint
 

--- a/apps/desktop/runtime-config/README.md
+++ b/apps/desktop/runtime-config/README.md
@@ -1,0 +1,3 @@
+# Runtime Config Resources
+
+This directory contains runtime configuration resources bundled into the desktop app. Downstream builds can add or replace files here when customizing OpenCode runtime composition.

--- a/apps/desktop/src/main/auth.ts
+++ b/apps/desktop/src/main/auth.ts
@@ -30,6 +30,11 @@ const DEFAULT_GOOGLE_SCOPES = [
 
 let cachedClient: OAuth2Client | null = null
 
+type GoogleOAuthConfig = {
+  clientId: string
+  clientSecret?: string
+}
+
 function getTokenPath() {
   const dir = getAppDataDir()
   mkdirSync(dir, { recursive: true })
@@ -97,8 +102,16 @@ function getOAuth2Client() {
     throw new Error('Google OAuth is not configured')
   }
   if (cachedClient) return cachedClient
-  cachedClient = new OAuth2Client(oauth.clientId, oauth.clientSecret || '', 'http://127.0.0.1:0')
+  cachedClient = createGoogleOAuthClient(oauth)
   return cachedClient
+}
+
+function createGoogleOAuthClient(oauth: GoogleOAuthConfig, redirectUri?: string) {
+  return new OAuth2Client({
+    clientId: oauth.clientId,
+    clientSecret: oauth.clientSecret || '',
+    ...(redirectUri ? { redirectUri } : {}),
+  })
 }
 
 function loadTokens(): StoredTokens | null {
@@ -255,7 +268,7 @@ export async function loginWithGoogle(): Promise<AuthState> {
   }
 
   return new Promise((resolve) => {
-    const client = new OAuth2Client(oauth.clientId, oauth.clientSecret || '', '')
+    let client: OAuth2Client | null = null
     const oauthState = crypto.randomUUID()
     const scopes = oauth.scopes?.length ? oauth.scopes : DEFAULT_GOOGLE_SCOPES
 
@@ -282,7 +295,9 @@ export async function loginWithGoogle(): Promise<AuthState> {
         }
 
         const redirectUri = `http://127.0.0.1:${getServerPort(server)}`
-        ;(client as any)._redirectUri = redirectUri
+        if (!client) {
+          throw new Error('OAuth callback received before the login client was initialized.')
+        }
         const { tokens } = await client.getToken({ code, redirect_uri: redirectUri })
 
         if (!tokens.access_token || !tokens.refresh_token) {
@@ -350,6 +365,7 @@ export async function loginWithGoogle(): Promise<AuthState> {
     server.listen(0, '127.0.0.1', () => {
       try {
         const redirectUri = `http://127.0.0.1:${getServerPort(server)}`
+        client = createGoogleOAuthClient(oauth, redirectUri)
         const authUrl = client.generateAuthUrl({
           access_type: 'offline',
           scope: scopes,

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1,6 +1,6 @@
 import {
   createOpencode,
-  createOpencodeClient as createV2OpencodeClient,
+  createOpencodeClient,
   type Auth as OpencodeAuth,
   type OpencodeClient as V2OpencodeClient,
 } from '@opencode-ai/sdk/v2'
@@ -436,7 +436,7 @@ export function getClientForDirectory(directory?: string | null): V2OpencodeClie
     cache: directoryClients,
     maxEntries: MAX_DIRECTORY_CLIENTS,
     createClient: (baseUrl, scopedDirectory) =>
-      createV2OpencodeClient({
+      createOpencodeClient({
         baseUrl,
         directory: scopedDirectory,
       }),

--- a/apps/desktop/vitest.renderer.config.ts
+++ b/apps/desktop/vitest.renderer.config.ts
@@ -27,12 +27,13 @@ export default defineConfig({
         'src/renderer/index.tsx',
       ],
       thresholds: {
-        // Advisory ratchet for the current component-test baseline.
-        // Raise these as stateful renderer screens gain direct tests.
-        lines: 5,
-        branches: 1,
-        functions: 1,
-        statements: 5,
+        // Baseline ratchet for the current component-test suite.
+        // Keep just below measured coverage and raise as stateful
+        // renderer screens gain direct tests.
+        lines: 12,
+        branches: 6,
+        functions: 9,
+        statements: 11,
       },
     },
   },

--- a/branding/README.md
+++ b/branding/README.md
@@ -1,0 +1,3 @@
+# Branding Assets
+
+This directory is reserved for downstream branding assets referenced by `open-cowork.config.json`, such as sidebar logos. Only configured image assets are copied into packaged builds.

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -19,6 +19,12 @@ Current release targets:
 - `.deb`
 - `x64`
 
+### Windows
+
+Windows packaging is not part of the v0.x preview release matrix. Add a
+Windows Electron Builder target, signing policy, and smoke test before
+claiming Windows support for a stable release.
+
 ## Local packaging
 
 From the repository root:

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "scripts": {
     "dev": "pnpm --filter @open-cowork/shared build && pnpm --filter @open-cowork/desktop dev",
-    "build": "pnpm --filter @open-cowork/shared build && pnpm --filter ./mcps/charts build && pnpm --filter ./mcps/skills build && pnpm --filter @open-cowork/desktop build",
+    "build": "pnpm --filter @open-cowork/shared build && pnpm build:mcps && pnpm --filter @open-cowork/desktop build",
     "build:desktop": "pnpm --filter @open-cowork/desktop build",
-    "build:mcps": "pnpm --filter ./mcps/charts build && pnpm --filter ./mcps/skills build",
+    "build:mcps": "pnpm --filter './mcps/*' build",
     "build:shared": "pnpm --filter @open-cowork/shared build",
     "docs:build": "mkdocs build --strict",
     "docs:serve": "mkdocs serve",

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -39,6 +39,9 @@ const secretScanAllowlist = new Set([
   'scripts/lint.mjs',
   'tests/log-sanitizer.test.ts',
 ])
+const privateSdkAccessAllowlist = new Set([
+  'scripts/lint.mjs',
+])
 const ignoredFiles = new Set([
   'docs/javascripts/vendor/mermaid.min.js',
 ])
@@ -49,6 +52,13 @@ const secretPatterns = [
   { name: 'API key', pattern: /\bsk-(?:or-|ant-)?[A-Za-z0-9_-]{20,}\b/ },
   { name: 'Azure connection string', pattern: /\bDefaultEndpointsProtocol=https?;AccountName=[^;\s]+;AccountKey=[^;\s]+/i },
   { name: 'keyed high-entropy secret', pattern: /\b(?:api[_-]?key|token|secret|password|client[_-]?secret)\s*[:=]\s*['"]?[A-Za-z0-9+/=_-]{32,}/i },
+]
+const privateSdkAccessPatterns = [
+  {
+    name: 'google-auth-library private redirectUri mutation',
+    pattern: /\._redirectUri\b/,
+    guidance: 'Use OAuth2ClientOptions.redirectUri or GetTokenOptions.redirect_uri instead.',
+  },
 ]
 
 function visit(dir) {
@@ -95,6 +105,16 @@ function lintFile(fullPath) {
     && !consoleLogAllowlist.has(relPath)
     && /\bconsole\.log\s*\(/.test(content)) {
     errors.push(`${relPath}: console.log is forbidden outside the main logger`)
+  }
+
+  if (shouldLintStyle
+    && (ext === '.ts' || ext === '.tsx' || ext === '.js' || ext === '.jsx' || ext === '.mjs')
+    && !privateSdkAccessAllowlist.has(relPath)) {
+    for (const { name, pattern, guidance } of privateSdkAccessPatterns) {
+      if (pattern.test(content)) {
+        errors.push(`${relPath}: forbidden ${name}. ${guidance}`)
+      }
+    }
   }
 
   if (shouldScanSecrets && !secretScanAllowlist.has(relPath)) {

--- a/tests/opencode-adapter.test.ts
+++ b/tests/opencode-adapter.test.ts
@@ -181,7 +181,7 @@ test('opencode adapter accepts current SDK session, message, part, status, and e
     projectID: 'proj',
     directory: '/tmp/project',
     title: 'SDK session',
-    version: '1.14.25',
+    version: '1.14.29',
     time: { created: 1, updated: 2 },
     summary: { additions: 3, deletions: 1, files: 2 },
   } satisfies SdkSession


### PR DESCRIPTION
## Summary
- make MCP builds discover workspace MCP packages via a wildcard filter
- add advisory critical full-graph audits to CI and release preflight
- document runtime-config/branding staging dirs and v0.x Windows packaging posture
- remove stale OpenCode v2 client aliasing
- replace Google OAuth private-field mutation with public OAuth2 client options
- ratchet renderer coverage thresholds to the current measured baseline

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:coverage:renderer
- pnpm build
- pnpm docs:build
- pnpm audit --audit-level critical
- git diff --check