### PR TITLE
Feature: Configurable Sidebar top-branding media controls

### DIFF
--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -98,7 +98,7 @@ describe('Sidebar', () => {
 
     expect(document.querySelector('img[src="open-cowork-asset://branding/acme-logo.svg"]')).toHaveStyle({
       height: '28px',
-      width: 'auto',
+      width: '28px',
     })
     expect(screen.getByText('Acme AI')).toBeTruthy()
   })

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -96,8 +96,102 @@ describe('Sidebar', () => {
       />,
     )
 
-    expect(document.querySelector('img[src="open-cowork-asset://branding/acme-logo.svg"]')).toBeTruthy()
+    expect(document.querySelector('img[src="open-cowork-asset://branding/acme-logo.svg"]')).toHaveStyle({
+      height: '28px',
+      width: 'auto',
+    })
     expect(screen.getByText('Acme AI')).toBeTruthy()
+  })
+
+  it('applies configured top branding media size, fit, and icon-only alignment', () => {
+    const { rerender } = render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'logo',
+            logoUrl: 'open-cowork-asset://branding/acme-logo.svg',
+            mediaSize: 40,
+            mediaFit: 'horizontal',
+            mediaAlign: 'end',
+            ariaLabel: 'Acme AI workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: 'Acme AI workspace' })).toHaveClass('justify-end')
+    expect(document.querySelector('img[src="open-cowork-asset://branding/acme-logo.svg"]')).toHaveStyle({
+      width: '40px',
+      height: 'auto',
+      maxHeight: '40px',
+    })
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'logo',
+            logoUrl: 'open-cowork-asset://branding/acme-logo.svg',
+            mediaSize: 36,
+            mediaFit: 'vertical',
+            mediaAlign: 'start',
+            ariaLabel: 'Acme AI workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: 'Acme AI workspace' })).toHaveClass('justify-start')
+    expect(document.querySelector('img[src="open-cowork-asset://branding/acme-logo.svg"]')).toHaveStyle({
+      height: '36px',
+      width: 'auto',
+    })
+  })
+
+  it('clamps direct top branding media sizes to renderer-safe bounds', () => {
+    const { rerender } = render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'icon',
+            icon: 'AC',
+            mediaSize: 8,
+            ariaLabel: 'Acme AI workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('AC')).toHaveStyle({
+      width: '16px',
+      height: '16px',
+    })
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        branding={{
+          top: {
+            variant: 'icon',
+            icon: 'AC',
+            mediaSize: 120,
+            ariaLabel: 'Acme AI workspace',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('AC')).toHaveStyle({
+      width: '96px',
+      height: '96px',
+    })
   })
 
   it('keeps legacy logo data URLs as a fallback', () => {

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useState, type CSSProperties } from 'react'
 import type { BrandingSidebarConfig, BrandingSidebarLowerConfig, BrandingSidebarTopConfig } from '@open-cowork/shared'
 import { ThreadList } from '../sidebar/ThreadList'
 import { McpStatus } from '../sidebar/McpStatus'
@@ -90,6 +90,30 @@ function renderableSidebarTopVariant(
   }
 }
 
+const BRAND_MEDIA_SIZE_DEFAULT = 28
+const BRAND_MEDIA_SIZE_MIN = 16
+const BRAND_MEDIA_SIZE_MAX = 96
+
+function sidebarBrandMediaSize(value: number | undefined) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return BRAND_MEDIA_SIZE_DEFAULT
+  return Math.min(BRAND_MEDIA_SIZE_MAX, Math.max(BRAND_MEDIA_SIZE_MIN, Math.round(value)))
+}
+
+function sidebarBrandMediaFit(value: BrandingSidebarTopConfig['mediaFit']) {
+  return value === 'horizontal' ? 'horizontal' : 'vertical'
+}
+
+function sidebarBrandMediaAlign(value: BrandingSidebarTopConfig['mediaAlign'], iconOnly: boolean) {
+  if (value === 'start' || value === 'center' || value === 'end') return value
+  return iconOnly ? 'center' : 'start'
+}
+
+function sidebarBrandJustifyClass(align: 'start' | 'center' | 'end') {
+  if (align === 'center') return 'justify-center'
+  if (align === 'end') return 'justify-end'
+  return 'justify-start'
+}
+
 function SidebarBrandTop({ top }: { top?: BrandingSidebarTopConfig }) {
   if (!top) return null
 
@@ -109,11 +133,22 @@ function SidebarBrandTop({ top }: { top?: BrandingSidebarTopConfig }) {
   const showText = hasText && (variant === 'text' || variant === 'icon-text' || variant === 'logo-text' || (!showLogo && !showIcon))
   const iconOnly = !showText && (showLogo || showIcon)
   const ariaLabel = top.ariaLabel?.trim() || title || subtitle || t('sidebar.branding', 'Brand')
+  const mediaSize = sidebarBrandMediaSize(top.mediaSize)
+  const mediaFit = sidebarBrandMediaFit(top.mediaFit)
+  const mediaAlign = sidebarBrandMediaAlign(top.mediaAlign, iconOnly)
+  const logoStyle: CSSProperties = mediaFit === 'horizontal'
+    ? { width: mediaSize, height: 'auto', maxHeight: mediaSize }
+    : { height: mediaSize, width: 'auto', maxWidth: '100%' }
+  const iconStyle: CSSProperties = {
+    width: mediaSize,
+    height: mediaSize,
+    background: 'color-mix(in srgb, var(--color-surface) 70%, transparent)',
+  }
 
   return (
     <div className="px-3 pt-3 pb-2">
       <div
-        className={`flex min-h-10 items-center gap-2.5 rounded-lg border border-border-subtle px-2.5 py-2 text-text-secondary ${iconOnly ? 'justify-center' : ''}`}
+        className={`flex min-h-10 items-center gap-2.5 rounded-lg border border-border-subtle px-2.5 py-2 text-text-secondary ${iconOnly ? sidebarBrandJustifyClass(mediaAlign) : ''}`}
         style={{ background: 'color-mix(in srgb, var(--color-elevated) 42%, transparent)' }}
         role={iconOnly ? 'img' : undefined}
         aria-label={iconOnly ? ariaLabel : undefined}
@@ -122,14 +157,15 @@ function SidebarBrandTop({ top }: { top?: BrandingSidebarTopConfig }) {
           <img
             src={logoUrl}
             alt=""
-            className="h-7 w-7 shrink-0 rounded-md object-contain"
+            className={`shrink-0 rounded-md object-contain ${!iconOnly ? 'self-center' : ''}`}
+            style={logoStyle}
             draggable={false}
           />
         )}
         {showIcon && (
           <span
-            className="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-border-subtle text-[14px]"
-            style={{ background: 'color-mix(in srgb, var(--color-surface) 70%, transparent)' }}
+            className={`grid shrink-0 place-items-center rounded-md border border-border-subtle text-[14px] ${!iconOnly ? 'self-center' : ''}`}
+            style={iconStyle}
             aria-hidden={iconOnly ? undefined : 'true'}
           >
             {icon}

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -100,7 +100,8 @@ function sidebarBrandMediaSize(value: number | undefined) {
 }
 
 function sidebarBrandMediaFit(value: BrandingSidebarTopConfig['mediaFit']) {
-  return value === 'horizontal' ? 'horizontal' : 'vertical'
+  if (value === 'horizontal' || value === 'vertical') return value
+  return 'bounded'
 }
 
 function sidebarBrandMediaAlign(value: BrandingSidebarTopConfig['mediaAlign'], iconOnly: boolean) {
@@ -138,7 +139,9 @@ function SidebarBrandTop({ top }: { top?: BrandingSidebarTopConfig }) {
   const mediaAlign = sidebarBrandMediaAlign(top.mediaAlign, iconOnly)
   const logoStyle: CSSProperties = mediaFit === 'horizontal'
     ? { width: mediaSize, height: 'auto', maxHeight: mediaSize }
-    : { height: mediaSize, width: 'auto', maxWidth: '100%' }
+    : mediaFit === 'vertical'
+      ? { height: mediaSize, width: 'auto', maxWidth: '100%' }
+      : { width: mediaSize, height: mediaSize }
   const iconStyle: CSSProperties = {
     width: mediaSize,
     height: mediaSize,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,10 +98,11 @@ config blobs.
 
 `branding.sidebar.top.mediaSize` controls the logo/icon media size in pixels
 and defaults to `28`. Values must be between `16` and `96`. `mediaFit` accepts
-`vertical` or `horizontal`: use `vertical` for square or tall marks whose height
-should define the sidebar presence, and `horizontal` for wide wordmarks whose
-width should be fixed. `mediaAlign` accepts `start`, `center`, or `end` and
-controls icon/logo placement for icon-only or logo-only branding.
+`vertical` or `horizontal`: leave it unset to preserve the legacy square
+bounding box, use `vertical` for square or tall marks whose height should define
+the sidebar presence, and use `horizontal` for wide wordmarks whose width should
+be fixed. `mediaAlign` accepts `start`, `center`, or `end` and controls
+icon/logo placement for icon-only or logo-only branding.
 
 `branding.sidebar.lower.linkUrl` accepts only `https://` and `mailto:` links.
 The renderer re-checks that allowlist before rendering a link.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,9 @@ Cowork copy and layout.
       "top": {
         "variant": "logo-text",
         "logoAsset": "branding/acme-logo.svg",
+        "mediaSize": 36,
+        "mediaFit": "vertical",
+        "mediaAlign": "center",
         "title": "Acme AI",
         "subtitle": "Private workspace",
         "ariaLabel": "Acme AI workspace"
@@ -92,6 +95,13 @@ URLs, missing files, and non-image extensions before exposing the asset to the
 renderer. Legacy `logoDataUrl` values are still accepted as a compatibility
 fallback, but new downstream builds should ship image assets instead of base64
 config blobs.
+
+`branding.sidebar.top.mediaSize` controls the logo/icon media size in pixels
+and defaults to `28`. Values must be between `16` and `96`. `mediaFit` accepts
+`vertical` or `horizontal`: use `vertical` for square or tall marks whose height
+should define the sidebar presence, and `horizontal` for wide wordmarks whose
+width should be fixed. `mediaAlign` accepts `start`, `center`, or `end` and
+controls icon/logo placement for icon-only or logo-only branding.
 
 `branding.sidebar.lower.linkUrl` accepts only `https://` and `mailto:` links.
 The renderer re-checks that allowlist before rendering a link.

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -286,8 +286,9 @@ remote URLs, and unsupported extensions.
 
 Sidebar top branding can also tune the rendered media with
 `branding.sidebar.top.mediaSize` (`16`-`96` pixels, default `28`),
-`mediaFit` (`vertical` or `horizontal`), and `mediaAlign` (`start`, `center`,
-or `end` for icon-only or logo-only placement).
+`mediaFit` (`vertical` or `horizontal`; unset keeps the legacy square bounding
+box), and `mediaAlign` (`start`, `center`, or `end` for icon-only or logo-only
+placement).
 
 The repo name, bundle identifier, and project namespace are separate
 concerns. Upstream now uses the public repo name `open-cowork`, but

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -192,6 +192,9 @@ provider, one internal MCP, and one internal skill would look like:
       "top": {
         "variant": "logo-text",
         "logoAsset": "branding/acme-logo.svg",
+        "mediaSize": 36,
+        "mediaFit": "vertical",
+        "mediaAlign": "center",
         "title": "Acme AI",
         "subtitle": "Private workspace"
       },
@@ -280,6 +283,11 @@ skills. For logo-backed sidebar variants, place image files under the repo-level
 `branding/` directory and reference them with `branding.sidebar.top.logoAsset`,
 for example `branding/acme-logo.svg`. The app rejects absolute paths, traversal,
 remote URLs, and unsupported extensions.
+
+Sidebar top branding can also tune the rendered media with
+`branding.sidebar.top.mediaSize` (`16`-`96` pixels, default `28`),
+`mediaFit` (`vertical` or `horizontal`), and `mediaAlign` (`start`, `center`,
+or `end` for icon-only or logo-only placement).
 
 The repo name, bundle identifier, and project namespace are separate
 concerns. Upstream now uses the public repo name `open-cowork`, but

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -249,6 +249,13 @@
           "maxLength": 65536,
           "pattern": "^data:image/(png|jpeg|jpg|webp|gif);base64,[A-Za-z0-9+/=]+$"
         },
+        "mediaSize": {
+          "type": "integer",
+          "minimum": 16,
+          "maximum": 96
+        },
+        "mediaFit": { "type": "string", "enum": ["vertical", "horizontal"] },
+        "mediaAlign": { "type": "string", "enum": ["start", "center", "end"] },
         "title": { "type": "string", "maxLength": 48 },
         "subtitle": { "type": "string", "maxLength": 96 },
         "ariaLabel": { "type": "string", "maxLength": 96 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1126,6 +1126,8 @@ export interface BrandThemeDefinition {
 }
 
 export type BrandingSidebarTopVariant = 'icon' | 'text' | 'icon-text' | 'logo' | 'logo-text'
+export type BrandingSidebarMediaFit = 'vertical' | 'horizontal'
+export type BrandingSidebarMediaAlign = 'start' | 'center' | 'end'
 
 export interface BrandingSidebarTopConfig {
   variant?: BrandingSidebarTopVariant
@@ -1133,6 +1135,9 @@ export interface BrandingSidebarTopConfig {
   logoAsset?: string
   logoUrl?: string
   logoDataUrl?: string
+  mediaSize?: number
+  mediaFit?: BrandingSidebarMediaFit
+  mediaAlign?: BrandingSidebarMediaAlign
   title?: string
   subtitle?: string
   ariaLabel?: string

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -22,6 +22,9 @@ test('branding sidebar and home overrides validate', () => {
     top: {
       variant: 'icon-text',
       icon: 'AC',
+      mediaSize: 36,
+      mediaFit: 'vertical',
+      mediaAlign: 'center',
       title: 'Acme AI',
       subtitle: 'Private workspace',
       ariaLabel: 'Acme AI workspace',
@@ -102,6 +105,23 @@ test('branding rejects unsafe logo asset paths', () => {
     }
 
     assert.throws(() => validateResolvedConfig(config, 'branding config'), /branding\.sidebar\.top\.logoAsset/)
+  }
+})
+
+test('branding rejects invalid sidebar top media controls', () => {
+  for (const top of [
+    { variant: 'logo', mediaSize: 15 },
+    { variant: 'logo', mediaSize: 97 },
+    { variant: 'logo', mediaSize: 28.5 },
+    { variant: 'logo', mediaFit: 'stretch' },
+    { variant: 'logo', mediaAlign: 'left' },
+  ]) {
+    const config = cloneConfig()
+    config.branding.sidebar = {
+      top,
+    }
+
+    assert.throws(() => validateResolvedConfig(config, 'branding config'), /branding\.sidebar\.top/)
   }
 })
 


### PR DESCRIPTION
## Summary

- Add configurable sidebar top-branding media controls for downstream builds.
- Extend the public branding config with `mediaSize`, `mediaFit`, and `mediaAlign` so logo/icon rendering is no longer fixed to a 28x28 box.
- Preserve the existing default appearance while allowing vertical or horizontal media fitting and icon/logo-only alignment.
- Document the new config fields in the configuration and downstream customization docs.

## Validation

- [ ] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] `pnpm perf:check` (if touched runtime, projection, or performance-sensitive code)
- [x] `git diff --check`
- [x] `pnpm --filter @open-cowork/desktop test:renderer -- Sidebar`

## User-visible impact

- [ ] No user-visible behavior change
- [x] UI change
- [ ] Runtime behavior change
- [ ] Packaging / release change
- [x] Docs change

## Notes

- Risks, caveats, or follow-up work:
- Existing configs keep the current 28px branding media default.
- `mediaSize` is schema-bounded to `16`-`96` pixels, and the renderer clamps direct prop values defensively.
- `mediaAlign` currently affects icon/logo-only placement; text-bearing variants keep the existing readable row layout.