### PR TITLE
Refactor OpenCode adapter normalizers

### DIFF
--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -4,9 +4,8 @@ import { dispatchRuntimeSessionEvent } from './session-event-dispatcher.ts'
 import {
   normalizeMessagePart,
   normalizeSessionInfo,
-  readRecordValue,
-  readString,
 } from './opencode-adapter.ts'
+import { readRecordValue, readString } from './normalizer-utils.ts'
 import { resolveDisplayCost } from './pricing.ts'
 import {
   ensureTaskRunForChild,

--- a/apps/desktop/src/main/event-runtime-handlers.ts
+++ b/apps/desktop/src/main/event-runtime-handlers.ts
@@ -4,11 +4,13 @@ import { log } from './logger.ts'
 import {
   normalizeSessionInfo,
   normalizeTodoItems,
+} from './opencode-adapter.ts'
+import {
   asRecord,
   readRecordArray,
   readRecordValue,
   readString,
-} from './opencode-adapter.ts'
+} from './normalizer-utils.ts'
 import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
 import { dispatchRuntimeSessionEvent, dropSessionFromDispatcherQueues } from './session-event-dispatcher.ts'
 import { shortSessionId } from './log-sanitizer.ts'

--- a/apps/desktop/src/main/explorer-normalizers.ts
+++ b/apps/desktop/src/main/explorer-normalizers.ts
@@ -1,0 +1,158 @@
+import type {
+  ExplorerSymbol,
+  FileContent,
+  FileNode,
+  FileStatus,
+  TextMatch,
+} from '@open-cowork/shared'
+import {
+  asArray,
+  asRecord,
+  readNumber,
+  readRecordNumber,
+  readRecordString,
+} from './normalizer-utils.ts'
+
+// Explorer normalizers (SDK find.* + file.*)
+//
+// Keep renderer callers off snake_case (`line_number`), URI tuples, and
+// optional-everywhere SDK shapes. One place to update when SDK file/find
+// response types drift.
+
+export function normalizeFileNode(value: unknown): FileNode | null {
+  const record = asRecord(value)
+  const name = readRecordString(record, ['name'])
+  const path = readRecordString(record, ['path'])
+  const absolute = readRecordString(record, ['absolute'])
+  const type = readRecordString(record, ['type'])
+  if (!name || !path || !absolute) return null
+  if (type !== 'file' && type !== 'directory') return null
+  return {
+    name,
+    path,
+    absolute,
+    type,
+    ignored: record.ignored === true,
+  }
+}
+
+export function normalizeFileNodes(value: unknown): FileNode[] {
+  return asArray(value)
+    .map(normalizeFileNode)
+    .filter((node): node is FileNode => node !== null)
+}
+
+export function normalizeFileContent(value: unknown): FileContent | null {
+  const record = asRecord(value)
+  const type = readRecordString(record, ['type'])
+  if (type !== 'text' && type !== 'binary') return null
+  const content = typeof record.content === 'string' ? record.content : ''
+  return {
+    type,
+    content,
+    diff: readRecordString(record, ['diff']),
+    // `patch` can be an object on v2; flatten to the reconstructed unified
+    // diff string when possible, otherwise fall back to the string form.
+    patch: readRecordString(record, ['patch']) ?? flattenPatch(record.patch),
+    encoding: readRecordString(record, ['encoding']),
+  }
+}
+
+function flattenPatch(value: unknown): string | null {
+  const record = asRecord(value)
+  if (Object.keys(record).length === 0) return null
+  const hunks = asArray(record.hunks)
+  if (hunks.length === 0) return null
+  const out: string[] = []
+  for (const hunk of hunks) {
+    const h = asRecord(hunk)
+    const oldStart = readRecordNumber(h, ['oldStart']) ?? 0
+    const oldLines = readRecordNumber(h, ['oldLines']) ?? 0
+    const newStart = readRecordNumber(h, ['newStart']) ?? 0
+    const newLines = readRecordNumber(h, ['newLines']) ?? 0
+    out.push(`@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`)
+    for (const line of asArray(h.lines)) {
+      if (typeof line === 'string') out.push(line)
+    }
+  }
+  return out.join('\n')
+}
+
+export function normalizeFileStatus(value: unknown): FileStatus | null {
+  const record = asRecord(value)
+  const path = readRecordString(record, ['path'])
+  if (!path) return null
+  const status = readRecordString(record, ['status'])
+  if (status !== 'added' && status !== 'deleted' && status !== 'modified') return null
+  return {
+    path,
+    added: readRecordNumber(record, ['added']) ?? 0,
+    removed: readRecordNumber(record, ['removed']) ?? 0,
+    status,
+  }
+}
+
+export function normalizeFileStatuses(value: unknown): FileStatus[] {
+  return asArray(value)
+    .map(normalizeFileStatus)
+    .filter((entry): entry is FileStatus => entry !== null)
+}
+
+function normalizeRangePos(value: unknown) {
+  const record = asRecord(value)
+  return {
+    line: readNumber(record.line) ?? 0,
+    col: readRecordNumber(record, ['col', 'character', 'column']) ?? 0,
+  }
+}
+
+export function normalizeExplorerSymbol(value: unknown): ExplorerSymbol | null {
+  const record = asRecord(value)
+  const name = readRecordString(record, ['name'])
+  if (!name) return null
+  const location = asRecord(record.location)
+  const uri = readRecordString(location, ['uri']) || ''
+  const path = uri.startsWith('file://') ? uri.slice('file://'.length) : uri
+  const range = asRecord(location.range)
+  return {
+    name,
+    kind: readRecordNumber(record, ['kind']) ?? 0,
+    path,
+    range: {
+      start: normalizeRangePos(range.start),
+      end: normalizeRangePos(range.end),
+    },
+  }
+}
+
+export function normalizeExplorerSymbols(value: unknown): ExplorerSymbol[] {
+  return asArray(value)
+    .map(normalizeExplorerSymbol)
+    .filter((entry): entry is ExplorerSymbol => entry !== null)
+}
+
+export function normalizeTextMatch(value: unknown): TextMatch | null {
+  const record = asRecord(value)
+  const pathRec = asRecord(record.path)
+  const path = readRecordString(pathRec, ['text'])
+  if (!path) return null
+  const linesRec = asRecord(record.lines)
+  const lineText = readRecordString(linesRec, ['text']) ?? ''
+  const lineNumber = readRecordNumber(record, ['line_number', 'lineNumber']) ?? 0
+  const submatches = asArray(record.submatches).flatMap((entry) => {
+    const sub = asRecord(entry)
+    const match = asRecord(sub.match)
+    const text = readRecordString(match, ['text'])
+    const start = readRecordNumber(sub, ['start'])
+    const end = readRecordNumber(sub, ['end'])
+    if (text === null || start === null || end === null) return []
+    return [{ text, start, end }]
+  })
+  return { path, lineNumber, lineText, submatches }
+}
+
+export function normalizeTextMatches(value: unknown): TextMatch[] {
+  return asArray(value)
+    .map(normalizeTextMatch)
+    .filter((entry): entry is TextMatch => entry !== null)
+}

--- a/apps/desktop/src/main/ipc/explorer-handlers.ts
+++ b/apps/desktop/src/main/ipc/explorer-handlers.ts
@@ -16,7 +16,7 @@ import {
   normalizeFileNodes,
   normalizeFileStatuses,
   normalizeTextMatches,
-} from '../opencode-adapter.ts'
+} from '../explorer-normalizers.ts'
 
 // Explorer calls are project-scoped. Returning `null` when the runtime isn't
 // up lets each handler serve a stable empty response instead of throwing.

--- a/apps/desktop/src/main/model-info-utils.ts
+++ b/apps/desktop/src/main/model-info-utils.ts
@@ -1,5 +1,5 @@
 import type { ModelInfoSnapshot } from '@open-cowork/shared'
-import { asRecord } from './opencode-adapter.ts'
+import { asRecord } from './normalizer-utils.ts'
 
 // Merge normalized provider/model data from `client.provider.list()` with
 // the configured fallbacks (pricing + context limits pulled from the local

--- a/apps/desktop/src/main/normalizer-utils.ts
+++ b/apps/desktop/src/main/normalizer-utils.ts
@@ -1,0 +1,47 @@
+export type JsonRecord = Record<string, unknown>
+
+export function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonRecord
+    : {}
+}
+
+export function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : []
+}
+
+export function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+export function readNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export function readBoolean(value: unknown): boolean {
+  return value === true
+}
+
+export function readRecordString(record: JsonRecord, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = readString(record[key])
+    if (value) return value
+  }
+  return null
+}
+
+export function readRecordNumber(record: JsonRecord, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = readNumber(record[key])
+    if (value !== null) return value
+  }
+  return null
+}
+
+export function readRecordArray(record: unknown, key: string): unknown[] {
+  return asArray(asRecord(record)[key])
+}
+
+export function readRecordValue(record: unknown, key: string): unknown {
+  return asRecord(record)[key]
+}

--- a/apps/desktop/src/main/opencode-adapter.ts
+++ b/apps/desktop/src/main/opencode-adapter.ts
@@ -9,15 +9,18 @@ import type {
   SessionStatus as SdkSessionStatus,
 } from '@opencode-ai/sdk/v2'
 import type {
-  ExplorerSymbol,
-  FileContent,
-  FileNode,
-  FileStatus,
-  TextMatch,
   TodoItem,
 } from '@open-cowork/shared'
+import {
+  asArray,
+  asRecord,
+  readBoolean,
+  readRecordNumber,
+  readRecordString,
+  readString,
+  type JsonRecord,
+} from './normalizer-utils.ts'
 
-type JsonRecord = Record<string, unknown>
 type SdkSessionMessage = SdkSessionMessagesResponse extends Array<infer T> ? T : never
 type SdkRuntimeEventEnvelope = SdkEvent | SdkGlobalEvent | { payload: SdkEvent | SdkGlobalEvent }
 
@@ -125,36 +128,6 @@ export type NormalizedRuntimeCommand = {
   source?: string
 }
 
-export function asRecord(value: unknown): JsonRecord {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? value as JsonRecord
-    : {}
-}
-
-function asArray(value: unknown): unknown[] {
-  return Array.isArray(value) ? value : []
-}
-
-export function readString(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null
-}
-
-function readNumber(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
-}
-
-function readBoolean(value: unknown): boolean {
-  return value === true
-}
-
-function readRecordString(record: JsonRecord, keys: string[]): string | null {
-  for (const key of keys) {
-    const value = readString(record[key])
-    if (value) return value
-  }
-  return null
-}
-
 function readMcpStatusError(record: JsonRecord): string | null {
   const parts = ['error', 'message', 'error_description']
     .map((key) => readString(record[key]))
@@ -166,14 +139,6 @@ function isLikelyMcpAuthFailure(status: string | null, error: string | null) {
   if (status !== 'failed') return false
   return /missing authorization header|invalid_token|unauthorized|forbidden|oauth|non-200 status code \(40[13]\)|\b40[13]\b/i
     .test(error || '')
-}
-
-function readRecordNumber(record: JsonRecord, keys: string[]): number | null {
-  for (const key of keys) {
-    const value = readNumber(record[key])
-    if (value !== null) return value
-  }
-  return null
 }
 
 function normalizeTokens(value: unknown): NormalizedTokens {
@@ -392,14 +357,6 @@ export function normalizeShareUrl(value: unknown): string | null {
   return readRecordString(share, ['url']) || readRecordString(record, ['url'])
 }
 
-export function readRecordArray(record: unknown, key: string): unknown[] {
-  return asArray(asRecord(record)[key])
-}
-
-export function readRecordValue(record: unknown, key: string): unknown {
-  return asRecord(record)[key]
-}
-
 export function normalizeTodoItems(value: unknown): TodoItem[] {
   return asArray(value).flatMap((entry) => {
     const record = asRecord(entry)
@@ -410,146 +367,4 @@ export function normalizeTodoItems(value: unknown): TodoItem[] {
     const id = readRecordString(record, ['id']) || undefined
     return [{ content, status, priority, id }]
   })
-}
-
-// ── Explorer normalizers (SDK find.* + file.*) ────────────────────────────
-// Keep renderer callers off snake_case (`line_number`), URI tuples, and
-// optional-everywhere SDK shapes. One place to update when SDK types drift.
-
-export function normalizeFileNode(value: unknown): FileNode | null {
-  const record = asRecord(value)
-  const name = readRecordString(record, ['name'])
-  const path = readRecordString(record, ['path'])
-  const absolute = readRecordString(record, ['absolute'])
-  const type = readRecordString(record, ['type'])
-  if (!name || !path || !absolute) return null
-  if (type !== 'file' && type !== 'directory') return null
-  return {
-    name,
-    path,
-    absolute,
-    type,
-    ignored: record.ignored === true,
-  }
-}
-
-export function normalizeFileNodes(value: unknown): FileNode[] {
-  return asArray(value)
-    .map(normalizeFileNode)
-    .filter((node): node is FileNode => node !== null)
-}
-
-export function normalizeFileContent(value: unknown): FileContent | null {
-  const record = asRecord(value)
-  const type = readRecordString(record, ['type'])
-  if (type !== 'text' && type !== 'binary') return null
-  const content = typeof record.content === 'string' ? record.content : ''
-  return {
-    type,
-    content,
-    diff: readRecordString(record, ['diff']),
-    // `patch` can be an object on v2; flatten to the reconstructed unified
-    // diff string when possible, otherwise fall back to the string form.
-    patch: readRecordString(record, ['patch']) ?? flattenPatch(record.patch),
-    encoding: readRecordString(record, ['encoding']),
-  }
-}
-
-function flattenPatch(value: unknown): string | null {
-  const record = asRecord(value)
-  if (Object.keys(record).length === 0) return null
-  const hunks = asArray(record.hunks)
-  if (hunks.length === 0) return null
-  const out: string[] = []
-  for (const hunk of hunks) {
-    const h = asRecord(hunk)
-    const oldStart = readRecordNumber(h, ['oldStart']) ?? 0
-    const oldLines = readRecordNumber(h, ['oldLines']) ?? 0
-    const newStart = readRecordNumber(h, ['newStart']) ?? 0
-    const newLines = readRecordNumber(h, ['newLines']) ?? 0
-    out.push(`@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`)
-    for (const line of asArray(h.lines)) {
-      if (typeof line === 'string') out.push(line)
-    }
-  }
-  return out.join('\n')
-}
-
-export function normalizeFileStatus(value: unknown): FileStatus | null {
-  const record = asRecord(value)
-  const path = readRecordString(record, ['path'])
-  if (!path) return null
-  const status = readRecordString(record, ['status'])
-  if (status !== 'added' && status !== 'deleted' && status !== 'modified') return null
-  return {
-    path,
-    added: readRecordNumber(record, ['added']) ?? 0,
-    removed: readRecordNumber(record, ['removed']) ?? 0,
-    status,
-  }
-}
-
-export function normalizeFileStatuses(value: unknown): FileStatus[] {
-  return asArray(value)
-    .map(normalizeFileStatus)
-    .filter((entry): entry is FileStatus => entry !== null)
-}
-
-function normalizeRangePos(value: unknown) {
-  const record = asRecord(value)
-  return {
-    line: readRecordNumber(record, ['line']) ?? 0,
-    col: readRecordNumber(record, ['col', 'character', 'column']) ?? 0,
-  }
-}
-
-export function normalizeExplorerSymbol(value: unknown): ExplorerSymbol | null {
-  const record = asRecord(value)
-  const name = readRecordString(record, ['name'])
-  if (!name) return null
-  const location = asRecord(record.location)
-  const uri = readRecordString(location, ['uri']) || ''
-  const path = uri.startsWith('file://') ? uri.slice('file://'.length) : uri
-  const range = asRecord(location.range)
-  return {
-    name,
-    kind: readRecordNumber(record, ['kind']) ?? 0,
-    path,
-    range: {
-      start: normalizeRangePos(range.start),
-      end: normalizeRangePos(range.end),
-    },
-  }
-}
-
-export function normalizeExplorerSymbols(value: unknown): ExplorerSymbol[] {
-  return asArray(value)
-    .map(normalizeExplorerSymbol)
-    .filter((entry): entry is ExplorerSymbol => entry !== null)
-}
-
-export function normalizeTextMatch(value: unknown): TextMatch | null {
-  const record = asRecord(value)
-  const pathRec = asRecord(record.path)
-  const path = readRecordString(pathRec, ['text'])
-  if (!path) return null
-  const linesRec = asRecord(record.lines)
-  const lineText = readRecordString(linesRec, ['text']) ?? ''
-  const lineNumber = readRecordNumber(record, ['line_number', 'lineNumber']) ?? 0
-  const submatches = asArray(record.submatches).flatMap((entry) => {
-    const sub = asRecord(entry)
-    const match = asRecord(sub.match)
-    const text = readRecordString(match, ['text'])
-    const start = readRecordNumber(sub, ['start'])
-    const end = readRecordNumber(sub, ['end'])
-    if (text === null || start === null || end === null) return []
-    return [{ text, start, end }]
-  })
-  return { path, lineNumber, lineText, submatches }
-}
-
-export function normalizeTextMatches(value: unknown): TextMatch[] {
-  return asArray(value)
-    .map(normalizeTextMatch)
-    .filter((entry): entry is TextMatch => entry !== null)
 }

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -7,11 +7,13 @@ import {
   normalizeSessionInfo,
   normalizeSessionMessages,
   normalizeSessionStatuses,
+} from './opencode-adapter.ts'
+import {
   asRecord,
   readRecordArray,
   readRecordValue,
   readString,
-} from './opencode-adapter.ts'
+} from './normalizer-utils.ts'
 import { projectSessionHistory } from './session-history-projector.ts'
 import { log } from './logger.ts'
 import { shortSessionId } from './log-sanitizer.ts'

--- a/tests/explorer-normalizers.test.ts
+++ b/tests/explorer-normalizers.test.ts
@@ -6,7 +6,7 @@ import {
   normalizeFileNodes,
   normalizeFileStatuses,
   normalizeTextMatches,
-} from '../apps/desktop/src/main/opencode-adapter.ts'
+} from '../apps/desktop/src/main/explorer-normalizers.ts'
 
 describe('normalizeFileNodes', () => {
   it('returns [] for non-array input', () => {


### PR DESCRIPTION
## Summary
- split generic record-reader helpers out of the OpenCode adapter
- move explorer/file normalization into a dedicated main-process module
- keep renderer-facing normalized payload shapes unchanged while reducing adapter scope

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- targeted adapter/history tests
- git diff --check