### PR TITLE
Patch to include mcp build

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ pnpm install
 pnpm dev
 ```
 
-`pnpm dev` builds the shared workspace package before launching the
-desktop app, so fresh clones do not need a separate bootstrap command.
+`pnpm dev` builds the shared workspace package and bundled MCP servers
+before launching the desktop app, so fresh clones do not need a separate
+bootstrap command.
 
 ### Core validation
 

--- a/docs/first-contribution.md
+++ b/docs/first-contribution.md
@@ -29,10 +29,11 @@ pnpm install
 pnpm dev
 ```
 
-The root `pnpm dev` command builds the shared workspace package, boots
-the Vite dev server, wraps it with Electron, and opens the app. HMR
-picks up renderer changes immediately. Main-process changes need a full
-relaunch (kill `pnpm dev`, start again).
+The root `pnpm dev` command builds the shared workspace package and
+bundled MCP servers, boots the Vite dev server, wraps it with Electron,
+and opens the app. HMR picks up renderer changes immediately.
+Main-process changes need a full relaunch (kill `pnpm dev`, start
+again).
 
 ## Find something to work on
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,9 +28,10 @@ pnpm typecheck
 pnpm dev
 ```
 
-The root `pnpm dev` command builds `@open-cowork/shared` before
-launching the desktop app. If you launch the desktop workspace directly
-and see a missing `packages/shared/dist/` error, run `pnpm build:shared`
+The root `pnpm dev` command builds `@open-cowork/shared` and the bundled
+MCP servers before launching the desktop app. If you launch the desktop
+workspace directly and see missing `packages/shared/dist/` or
+`mcps/*/dist/` errors, run `pnpm build:shared` and `pnpm build:mcps`
 from the repo root first.
 
 ## Install from a release artifact

--- a/docs/index.md
+++ b/docs/index.md
@@ -165,7 +165,7 @@ own branding, providers, skills, and automations.
     corepack prepare pnpm@10.32.1 --activate
     pnpm -v
     pnpm install
-    pnpm dev          # builds shared, then hot-reloads Electron + Vite
+    pnpm dev          # builds shared + MCPs, then hot-reloads Electron + Vite
     pnpm build        # full build (shared + MCPs + desktop)
     ```
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/joe-broadhead/open-cowork/issues"
   },
   "scripts": {
-    "dev": "pnpm --filter @open-cowork/shared build && pnpm --filter @open-cowork/desktop dev",
+    "dev": "pnpm --filter @open-cowork/shared build && pnpm build:mcps && pnpm --filter @open-cowork/desktop dev",
     "build": "pnpm --filter @open-cowork/shared build && pnpm build:mcps && pnpm --filter @open-cowork/desktop build",
     "build:desktop": "pnpm --filter @open-cowork/desktop build",
     "build:mcps": "pnpm --filter './mcps/*' build",


### PR DESCRIPTION
## Summary

- Build bundled MCP servers as part of the root `pnpm dev` startup path.
- Keep source-run documentation aligned with the dev bootstrap so fresh clones generate `mcps/*/dist/index.js` before OpenCode tries to spawn the built-in `charts` and `skills` MCPs.
- This fixes local dev sessions where Open Cowork starts successfully but no MCP-backed tools are available because the bundled MCP `dist` files do not exist yet.

## Validation

- [ ] `pnpm test`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm perf:check` (if touched runtime, projection, or performance-sensitive code)
- [x] `git diff --check`
- [x] `pnpm build:mcps`
- [x] `pnpm --filter @open-cowork/shared build`

## User-visible impact

- [ ] No user-visible behavior change
- [ ] UI change
- [x] Runtime behavior change
- [ ] Packaging / release change
- [x] Docs change

## Notes

- Risks, caveats, or follow-up work:
- Root `pnpm dev` now does a small MCP build before launching Electron, so startup does a little more bootstrap work but avoids a broken tool catalog on fresh checkouts.
- The MCP build output remains ignored by git; it is generated locally before runtime startup.
