### PR TITLE
Bugfix for the chat resizing when scrolling through previous chats

### DIFF
--- a/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useSessionStore } from '../../stores/session'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { ChatInput } from './ChatInput'
+
+const HISTORY_KEY = 'open-cowork-prompt-history'
+
+describe('ChatInput', () => {
+  it('resizes the textarea when navigating prompt history', async () => {
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => ({
+          appId: 'com.opencowork.desktop',
+          name: 'Open Cowork',
+          helpUrl: 'https://github.com/joe-broadhead/open-cowork',
+          defaultModel: null,
+          providers: { available: [] },
+          auth: { mode: 'none' },
+        })),
+      },
+      on: {
+        runtimeReady: vi.fn(() => () => undefined),
+      },
+    })
+    const longPrompt = ['first line', 'second line', 'third line', 'fourth line'].join('\n')
+    window.localStorage.setItem(HISTORY_KEY, JSON.stringify([longPrompt]))
+    useSessionStore.getState().setSessions([
+      {
+        id: 'session-1',
+        title: 'Session 1',
+        directory: '/tmp/project',
+        createdAt: '2026-04-29T00:00:00.000Z',
+        updatedAt: '2026-04-29T00:00:00.000Z',
+      },
+    ])
+    useSessionStore.getState().setCurrentSession('session-1')
+
+    render(<ChatInput />)
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    let scrollHeight = 240
+    Object.defineProperty(textarea, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    })
+
+    textarea.setSelectionRange(0, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+
+    await waitFor(() => expect(textarea).toHaveValue(longPrompt))
+    await waitFor(() => expect(textarea.style.height).toBe('180px'))
+
+    scrollHeight = 48
+    textarea.setSelectionRange(longPrompt.length, longPrompt.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+
+    await waitFor(() => expect(textarea).toHaveValue(''))
+    await waitFor(() => expect(textarea.style.height).toBe('48px'))
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.tsx
@@ -40,6 +40,12 @@ export function ChatInput() {
   const [inlinePicker, setInlinePicker] = useState<InlinePickerState | null>(null)
   const { navigate, recordPrompt } = usePromptHistory()
 
+  const resizeComposerTextarea = useCallback((element = textareaRef.current) => {
+    if (!element) return
+    element.style.height = 'auto'
+    element.style.height = Math.min(element.scrollHeight, 180) + 'px'
+  }, [])
+
   const refreshRuntimeSelection = useCallback(() => {
     Promise.all([window.coworkApi.settings.get(), window.coworkApi.app.config()]).then(([settings, config]) => {
       setCurrentModel(settings.effectiveModel || settings.selectedModelId || '')
@@ -160,10 +166,9 @@ export function ChatInput() {
       if (!textarea) return
       textarea.focus()
       textarea.setSelectionRange(nextCursor, nextCursor)
-      textarea.style.height = 'auto'
-      textarea.style.height = Math.min(textarea.scrollHeight, 180) + 'px'
+      resizeComposerTextarea(textarea)
     })
-  }, [inlinePicker, input])
+  }, [inlinePicker, input, resizeComposerTextarea])
 
   // Autofocus textarea when session changes
   useEffect(() => {
@@ -181,8 +186,7 @@ export function ChatInput() {
         if (typeof cursor === 'number') {
           element.setSelectionRange(cursor, cursor)
         }
-        element.style.height = 'auto'
-        element.style.height = Math.min(element.scrollHeight, 180) + 'px'
+        resizeComposerTextarea(element)
       })
     }
 
@@ -242,7 +246,7 @@ export function ChatInput() {
       window.removeEventListener(COMPOSER_INSERT_EVENT, handler as EventListener)
       window.removeEventListener(COMPOSER_COMPOSE_EVENT, composeHandler as EventListener)
     }
-  }, [])
+  }, [resizeComposerTextarea])
 
   // Global Shift+Tab to toggle agent mode — works even when textarea loses focus
   useEffect(() => {
@@ -326,6 +330,7 @@ export function ChatInput() {
       if (!next.handled) return
       e.preventDefault()
       setInput(next.value)
+      requestAnimationFrame(() => resizeComposerTextarea())
     }
 
     if (e.key === 'ArrowDown' && isAtEnd) {
@@ -333,6 +338,7 @@ export function ChatInput() {
       if (!next.handled) return
       e.preventDefault()
       setInput(next.value)
+      requestAnimationFrame(() => resizeComposerTextarea())
     }
   }
 
@@ -341,9 +347,7 @@ export function ChatInput() {
     const cursor = e.target.selectionStart ?? e.target.value.length
     const triggerState = detectInlineTrigger(e.target.value, cursor)
     setInlinePicker(triggerState ? { ...triggerState, selectedIndex: 0 } : null)
-    const el = e.target
-    el.style.height = 'auto'
-    el.style.height = Math.min(el.scrollHeight, 180) + 'px'
+    resizeComposerTextarea(e.target)
   }
 
   const handlePaste = async (e: React.ClipboardEvent) => {


### PR DESCRIPTION
## Summary

- Resize the chat composer when navigating prompt history with `ArrowUp` / `ArrowDown`.
- This changed because history navigation updated the controlled textarea value without running the autosize logic used for normal typing.
- Reuse the existing composer autosize behavior and preserve the current `180px` height cap.
- Add renderer coverage for long history entries resizing the composer and shrinking back for the saved draft.

## Validation

- [ ] `pnpm test`
- [x] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm perf:check` (if touched runtime, projection, or performance-sensitive code)
- [x] `git diff --check`
- [x] `pnpm --dir apps/desktop exec vitest run --config vitest.renderer.config.ts src/renderer/components/chat/ChatInput.test.tsx`
- [x] `pnpm --dir apps/desktop test:renderer`

## User-visible impact

- [ ] No user-visible behavior change
- [x] UI change
- [ ] Runtime behavior change
- [ ] Packaging / release change
- [ ] Docs change

## Notes

- Risks, caveats, or follow-up work: full `pnpm test` and `pnpm lint` were not run for this focused UI fix.
