### PR TITLE
Add provider-level default models

### DIFF
--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -108,6 +108,7 @@ export type BuiltInAgentOverrideConfig = {
 export type CustomProviderRuntimeConfig = {
   npm: string
   name: string
+  defaultModel?: string
   options?: Record<string, unknown>
   models: Record<string, Record<string, unknown>>
   credentials?: CredentialField[]
@@ -131,6 +132,7 @@ export type ConfiguredProviderDescriptor = {
   runtime?: 'builtin' | 'custom'
   name: string
   description: string
+  defaultModel?: string
   options?: Record<string, unknown>
   credentials: CredentialField[]
   models: ProviderModelDescriptor[]
@@ -682,17 +684,55 @@ function mergeDescriptorModels(
   return [...featured, ...overlay]
 }
 
+export function normalizeProviderModelId(providerId: string, modelId: string) {
+  const trimmed = modelId.trim()
+  const prefix = `${providerId}/`
+  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed
+}
+
+function resolveModelFromCurrentCatalog(
+  providerId: string,
+  models: ProviderModelDescriptor[],
+  modelId: string | null | undefined,
+) {
+  if (!modelId?.trim()) return null
+  const normalized = normalizeProviderModelId(providerId, modelId)
+  if (models.length === 0) return normalized
+  return models.find((model) => model.id === modelId || model.id === normalized)?.id || null
+}
+
+export function resolveProviderDefaultModel(
+  providerId: string,
+  models: ProviderModelDescriptor[],
+  runtimeDefaultModel?: string | null,
+) {
+  const config = getAppConfig()
+  const descriptorDefault = config.providers.descriptors?.[providerId]?.defaultModel
+  const customDefault = config.providers.custom?.[providerId]?.defaultModel
+  const globalDefault = providerId === config.providers.defaultProvider ? config.providers.defaultModel : null
+  const candidates = [descriptorDefault, customDefault, globalDefault, runtimeDefaultModel]
+
+  for (const candidate of candidates) {
+    const resolved = resolveModelFromCurrentCatalog(providerId, models, candidate)
+    if (resolved) return resolved
+  }
+  return undefined
+}
+
 export function getProviderDescriptors(): ProviderDescriptor[] {
   const config = getAppConfig()
   return config.providers.available.map((providerId) => {
     const builtin = config.providers.descriptors?.[providerId]
     if (builtin) {
+      const models = mergeDescriptorModels(providerId, builtin, invalidatePublicConfigCache)
+      const defaultModel = resolveProviderDefaultModel(providerId, models)
       return {
         id: providerId,
         name: builtin.name,
         description: builtin.description,
         credentials: builtin.credentials || [],
-        models: mergeDescriptorModels(providerId, builtin, invalidatePublicConfigCache),
+        models,
+        ...(defaultModel ? { defaultModel } : {}),
       }
     }
 
@@ -707,15 +747,18 @@ export function getProviderDescriptors(): ProviderDescriptor[] {
       }
     }
 
+    const models = Object.entries(custom.models || {}).map(([id, info]) => ({
+      id,
+      name: typeof info?.name === 'string' ? info.name : id,
+    }))
+    const defaultModel = resolveProviderDefaultModel(providerId, models)
     return {
       id: providerId,
       name: custom.name,
       description: custom.description || `${custom.name} custom provider`,
       credentials: custom.credentials || [],
-      models: Object.entries(custom.models || {}).map(([id, info]) => ({
-        id,
-        name: typeof info?.name === 'string' ? info.name : id,
-      })),
+      models,
+      ...(defaultModel ? { defaultModel } : {}),
     }
   })
 }

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -710,7 +710,7 @@ export function resolveProviderDefaultModel(
   const descriptorDefault = config.providers.descriptors?.[providerId]?.defaultModel
   const customDefault = config.providers.custom?.[providerId]?.defaultModel
   const globalDefault = providerId === config.providers.defaultProvider ? config.providers.defaultModel : null
-  const candidates = [descriptorDefault, customDefault, globalDefault, runtimeDefaultModel]
+  const candidates = [descriptorDefault, customDefault, runtimeDefaultModel, globalDefault]
 
   for (const candidate of candidates) {
     const resolved = resolveModelFromCurrentCatalog(providerId, models, candidate)

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -705,17 +705,23 @@ export function resolveProviderDefaultModel(
   providerId: string,
   models: ProviderModelDescriptor[],
   runtimeDefaultModel?: string | null,
+  options: { runtimeCatalogKnown?: boolean } = {},
 ) {
   const config = getAppConfig()
   const descriptorDefault = config.providers.descriptors?.[providerId]?.defaultModel
   const customDefault = config.providers.custom?.[providerId]?.defaultModel
   const globalDefault = providerId === config.providers.defaultProvider ? config.providers.defaultModel : null
-  const candidates = [descriptorDefault, customDefault, runtimeDefaultModel, globalDefault]
+  const descriptorResolved = resolveModelFromCurrentCatalog(providerId, models, descriptorDefault)
+  if (descriptorResolved) return descriptorResolved
+  const customResolved = resolveModelFromCurrentCatalog(providerId, models, customDefault)
+  if (customResolved) return customResolved
 
-  for (const candidate of candidates) {
-    const resolved = resolveModelFromCurrentCatalog(providerId, models, candidate)
-    if (resolved) return resolved
-  }
+  const runtimeModels = options.runtimeCatalogKnown === false ? [] : models
+  const runtimeResolved = resolveModelFromCurrentCatalog(providerId, runtimeModels, runtimeDefaultModel)
+  if (runtimeResolved) return runtimeResolved
+
+  const globalResolved = resolveModelFromCurrentCatalog(providerId, models, globalDefault)
+  if (globalResolved) return globalResolved
   return undefined
 }
 

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -3,7 +3,7 @@ import type { IpcHandlerContext } from './context.ts'
 import { getEffectiveSettings, maskEffectiveSettingsCredentials, saveSettings, isSetupComplete, type CoworkSettings } from '../settings.ts'
 import { getClient, getModelInfoAsync } from '../runtime.ts'
 import { normalizeProviderListResponse } from '../provider-utils.ts'
-import { getConfigError, getProviderDynamicCatalog, getPublicAppConfig, invalidatePublicConfigCache } from '../config-loader.ts'
+import { getConfigError, getProviderDynamicCatalog, getPublicAppConfig, invalidatePublicConfigCache, resolveProviderDefaultModel } from '../config-loader.ts'
 import { refreshProviderCatalog } from '../provider-catalog.ts'
 import { buildDiagnosticsBundle } from '../diagnostics-export.ts'
 import { getRuntimeStatus } from '../runtime-status.ts'
@@ -20,6 +20,7 @@ import type {
   ChartSaveArtifactRequest,
   DestructiveConfirmationRequest,
   ProviderAuthAuthorization,
+  ProviderDescriptor,
   ProviderModelDescriptor,
   PublicAppConfig,
   RuntimeProviderDescriptor,
@@ -146,7 +147,18 @@ function runtimeModelToDescriptor(modelId: string, rawModel: unknown): ProviderM
   }
 }
 
-function mergeRuntimeProviderModels(
+function providerWithoutDefaultModel(provider: ProviderDescriptor): ProviderDescriptor {
+  return {
+    id: provider.id,
+    name: provider.name,
+    description: provider.description,
+    credentials: provider.credentials,
+    models: provider.models,
+    ...(provider.connected !== undefined ? { connected: provider.connected } : {}),
+  }
+}
+
+export function mergeRuntimeProviderModels(
   config: PublicAppConfig,
   runtimeProviders: RuntimeProviderDescriptor[],
 ): PublicAppConfig {
@@ -164,23 +176,38 @@ function mergeRuntimeProviderModels(
       available: config.providers.available.map((provider) => {
         const runtimeProvider = runtimeById.get(provider.id)
         if (!runtimeProvider) return provider
-        const metadata = {
-          ...(runtimeProvider.defaultModel ? { defaultModel: runtimeProvider.defaultModel } : {}),
-          ...(typeof runtimeProvider.connected === 'boolean' ? { connected: runtimeProvider.connected } : {}),
+        const providerBase = providerWithoutDefaultModel(provider)
+        const connected = typeof runtimeProvider.connected === 'boolean' ? runtimeProvider.connected : undefined
+        if (!runtimeProvider.models) {
+          const defaultModel = resolveProviderDefaultModel(provider.id, provider.models, runtimeProvider.defaultModel)
+          return {
+            ...providerBase,
+            ...(defaultModel ? { defaultModel } : {}),
+            ...(connected !== undefined ? { connected } : {}),
+          }
         }
-        if (!runtimeProvider.models) return { ...provider, ...metadata }
         const runtimeModels = Object.entries(runtimeProvider.models)
           .map(([modelId, rawModel]) => runtimeModelToDescriptor(modelId, rawModel))
           .sort((a, b) => a.name.localeCompare(b.name))
-        if (runtimeModels.length === 0) return { ...provider, ...metadata }
+        if (runtimeModels.length === 0) {
+          const defaultModel = resolveProviderDefaultModel(provider.id, provider.models, runtimeProvider.defaultModel)
+          return {
+            ...providerBase,
+            ...(defaultModel ? { defaultModel } : {}),
+            ...(connected !== undefined ? { connected } : {}),
+          }
+        }
         const configuredIds = new Set(provider.models.map((model) => model.id))
+        const models = [
+          ...provider.models,
+          ...runtimeModels.filter((model) => !configuredIds.has(model.id)),
+        ]
+        const defaultModel = resolveProviderDefaultModel(provider.id, models, runtimeProvider.defaultModel)
         return {
-          ...provider,
-          ...metadata,
-          models: [
-            ...provider.models,
-            ...runtimeModels.filter((model) => !configuredIds.has(model.id)),
-          ],
+          ...providerBase,
+          ...(defaultModel ? { defaultModel } : {}),
+          ...(connected !== undefined ? { connected } : {}),
+          models,
         }
       }),
     },

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -179,7 +179,9 @@ export function mergeRuntimeProviderModels(
         const providerBase = providerWithoutDefaultModel(provider)
         const connected = typeof runtimeProvider.connected === 'boolean' ? runtimeProvider.connected : undefined
         if (!runtimeProvider.models) {
-          const defaultModel = resolveProviderDefaultModel(provider.id, provider.models, runtimeProvider.defaultModel)
+          const defaultModel = resolveProviderDefaultModel(provider.id, provider.models, runtimeProvider.defaultModel, {
+            runtimeCatalogKnown: false,
+          })
           return {
             ...providerBase,
             ...(defaultModel ? { defaultModel } : {}),

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -6,7 +6,13 @@ import type {
   AppSettings,
   EffectiveAppSettings,
 } from '@open-cowork/shared'
-import { getAppConfig, getAppDataDir, getProviderDescriptor, getPublicAppConfig } from './config-loader.ts'
+import {
+  getAppConfig,
+  getAppDataDir,
+  getProviderDescriptor,
+  getPublicAppConfig,
+  normalizeProviderModelId,
+} from './config-loader.ts'
 import { log } from './logger.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
 import { resolveSecretStorageMode } from './secure-storage-policy.ts'
@@ -25,12 +31,31 @@ export function nativePermissionEnabledByDefault(policy: NativePermissionDefault
   return policy !== 'deny'
 }
 
+function resolveProviderModelSelection(
+  providerId: string | null,
+  providerModels: Array<{ id: string }> | undefined,
+  modelId: string | null | undefined,
+) {
+  const trimmed = modelId?.trim()
+  if (!trimmed) return null
+  if (!providerId) return trimmed
+
+  const normalized = normalizeProviderModelId(providerId, trimmed)
+  if (!providerModels?.length) {
+    return !trimmed.includes('/') || trimmed.startsWith(`${providerId}/`) ? normalized : null
+  }
+
+  return providerModels.find((model) => model.id === trimmed || model.id === normalized)?.id || null
+}
+
 function createDefaults(): AppSettings {
   const config = getPublicAppConfig()
   const appConfig = getAppConfig()
+  const defaultProvider = config.providers.defaultProvider
+  const defaultProviderDescriptor = config.providers.available.find((provider) => provider.id === defaultProvider)
   return {
-    selectedProviderId: config.providers.defaultProvider,
-    selectedModelId: config.providers.defaultModel,
+    selectedProviderId: defaultProvider,
+    selectedModelId: defaultProviderDescriptor?.defaultModel || config.providers.defaultModel,
     providerCredentials: {},
     integrationCredentials: {},
     integrationEnabled: {},
@@ -356,23 +381,12 @@ export function getEffectiveSettings(settings = loadSettings()): EffectiveAppSet
     : null
   const providerId = selectedProvider?.id || configuredDefaultProvider
   const provider = getProviderDescriptor(providerId)
-  const hasConfiguredModelList = Boolean(provider?.models?.length)
-  const selectedModelBelongsToProvider = !settings.selectedModelId
-    || !settings.selectedModelId.includes('/')
-    || (providerId ? settings.selectedModelId.startsWith(`${providerId}/`) : false)
-  const validDefaultModel = config.providers.defaultModel
-    && provider?.models?.some((model) => model.id === config.providers.defaultModel)
-      ? config.providers.defaultModel
-      : null
-  const validSelectedModel = settings.selectedModelId
-    && (
-      hasConfiguredModelList
-        ? provider?.models?.some((model) => model.id === settings.selectedModelId)
-        : selectedModelBelongsToProvider
-    )
-      ? settings.selectedModelId
-      : null
-  const fallbackModel = validDefaultModel || provider?.models?.[0]?.id || (hasConfiguredModelList ? config.providers.defaultModel : '')
+  const providerDefaultModel = provider?.defaultModel || (
+    providerId === configuredDefaultProvider ? config.providers.defaultModel : null
+  )
+  const validDefaultModel = resolveProviderModelSelection(providerId, provider?.models, providerDefaultModel)
+  const validSelectedModel = resolveProviderModelSelection(providerId, provider?.models, settings.selectedModelId)
+  const fallbackModel = validDefaultModel || provider?.models?.[0]?.id || ''
   const selectedModelId = validSelectedModel || fallbackModel
 
   return {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,6 +281,7 @@ dynamic list is overlaid beneath them, deduplicated by id.
       "openrouter": {
         "name": "OpenRouter",
         "credentials": [ ... ],
+        "defaultModel": "anthropic/claude-sonnet-4",
         "models": [
           { "id": "anthropic/claude-sonnet-4", "name": "Claude Sonnet 4" }
         ],
@@ -308,6 +309,12 @@ dynamic list is overlaid beneath them, deduplicated by id.
 - `authHeader` — optional `Authorization` header value (use config
   placeholders if you need to reference a secret via `{env:NAME}`).
 - `cacheTtlMinutes` — refresh window for the disk cache. Defaults to 60.
+- `defaultModel` — optional provider-local default. When a user switches
+  to this provider, Open Cowork picks this model if it exists in the
+  current configured, cached, or runtime model catalog. If it is absent
+  at that moment, the app silently falls back to OpenCode's runtime
+  default, the app-wide `providers.defaultModel`, or the first available
+  model.
 
 Fetches are best-effort: network failures fall back to the last cached
 catalog, and cache misses fall back to the hardcoded `models[]` alone, so
@@ -317,8 +324,9 @@ button on the Models tab lets users force a refetch.
 For upstream releases, the featured OpenRouter model ids in
 `open-cowork.config.json` are checked during the release audit. If a provider
 renames or retires a featured id between releases, the dynamic catalog can still
-surface the live provider list when configured, but `defaultModel` and the
-featured list should be updated before the next tagged release.
+surface the live provider list when configured, but provider-local
+`defaultModel`, app-wide `providers.defaultModel`, and the featured list
+should be updated before the next tagged release.
 
 Any provider with a public "list models" endpoint can be wired up the
 same way — OpenRouter is just an example. Downstream distributions can

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -220,19 +220,21 @@ provider, one internal MCP, and one internal skill would look like:
         "runtime": "custom",
         "name": "Acme Gateway",
         "description": "Internal LLM gateway.",
+        "defaultModel": "acme-large",
         "credentials": []
       }
     },
     "custom": {
       "acme-gateway": {
         "name": "Acme Gateway",
+        "defaultModel": "acme-large",
         "options": {
           "baseURL": "{env:ACME_GATEWAY_URL}",
           "apiKey": "{env:ACME_GATEWAY_KEY}"
         },
-        "models": [
-          { "id": "acme-large", "name": "Acme Large" }
-        ]
+        "models": {
+          "acme-large": { "name": "Acme Large" }
+        }
       }
     },
     "defaultProvider": "acme-gateway",

--- a/open-cowork.config.json
+++ b/open-cowork.config.json
@@ -19,6 +19,7 @@
         "runtime": "builtin",
         "name": "OpenRouter",
         "description": "Use OpenRouter to access models through a single API key.",
+        "defaultModel": "anthropic/claude-sonnet-4",
         "credentials": [
           {
             "key": "apiKey",

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -87,6 +87,7 @@
               "npm": { "type": "string" },
               "name": { "type": "string" },
               "description": { "type": "string" },
+              "defaultModel": { "type": "string" },
               "options": {
                 "type": "object",
                 "additionalProperties": true
@@ -351,6 +352,7 @@
         },
         "name": { "type": "string" },
         "description": { "type": "string" },
+        "defaultModel": { "type": "string" },
         "options": {
           "type": "object",
           "additionalProperties": true

--- a/tests/app-handlers.test.ts
+++ b/tests/app-handlers.test.ts
@@ -127,3 +127,49 @@ test('mergeRuntimeProviderModels drops provider defaults absent from the live ru
     rmSync(tempRoot, { recursive: true, force: true })
   }
 })
+
+test('mergeRuntimeProviderModels prefers OpenCode live defaults over app-wide defaults', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-provider-runtime-default-precedence-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  writeFileSync(configPath, JSON.stringify({
+    providers: {
+      available: ['acme-provider'],
+      defaultProvider: 'acme-provider',
+      defaultModel: 'app-wide',
+      descriptors: {
+        'acme-provider': {
+          runtime: 'builtin',
+          name: 'Acme Provider',
+          description: 'Acme provider',
+          defaultModel: 'stale-local',
+          credentials: [],
+          models: [
+            { id: 'app-wide', name: 'App Wide' },
+          ],
+        },
+      },
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    const merged = mergeRuntimeProviderModels(getPublicAppConfig(), [{
+      id: 'acme-provider',
+      models: {
+        'app-wide': { name: 'App Wide' },
+        live: { name: 'Live' },
+      },
+      defaultModel: 'live',
+    }])
+    assert.equal(merged.providers.available[0]?.defaultModel, 'live')
+  } finally {
+    if (previousOverride === undefined) delete process.env.OPEN_COWORK_CONFIG_PATH
+    else process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/tests/app-handlers.test.ts
+++ b/tests/app-handlers.test.ts
@@ -173,3 +173,46 @@ test('mergeRuntimeProviderModels prefers OpenCode live defaults over app-wide de
     rmSync(tempRoot, { recursive: true, force: true })
   }
 })
+
+test('mergeRuntimeProviderModels preserves OpenCode defaults when the runtime omits the model list', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-provider-runtime-default-no-models-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  writeFileSync(configPath, JSON.stringify({
+    providers: {
+      available: ['acme-provider'],
+      defaultProvider: 'acme-provider',
+      defaultModel: 'static-model',
+      descriptors: {
+        'acme-provider': {
+          runtime: 'builtin',
+          name: 'Acme Provider',
+          description: 'Acme provider',
+          credentials: [],
+          models: [
+            { id: 'static-model', name: 'Static Model' },
+          ],
+        },
+      },
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    const merged = mergeRuntimeProviderModels(getPublicAppConfig(), [{
+      id: 'acme-provider',
+      defaultModel: 'runtime-owned-model',
+      connected: true,
+    }])
+    assert.equal(merged.providers.available[0]?.defaultModel, 'runtime-owned-model')
+    assert.equal(merged.providers.available[0]?.connected, true)
+  } finally {
+    if (previousOverride === undefined) delete process.env.OPEN_COWORK_CONFIG_PATH
+    else process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/tests/app-handlers.test.ts
+++ b/tests/app-handlers.test.ts
@@ -1,6 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { ensureRuntimeAfterAuthLogin } from '../apps/desktop/src/main/ipc/app-handlers.ts'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ensureRuntimeAfterAuthLogin, mergeRuntimeProviderModels } from '../apps/desktop/src/main/ipc/app-handlers.ts'
+import { clearConfigCaches, getPublicAppConfig } from '../apps/desktop/src/main/config-loader.ts'
 
 test('ensureRuntimeAfterAuthLogin reboots an active runtime after successful sign-in', async () => {
   const calls: string[] = []
@@ -66,4 +70,60 @@ test('ensureRuntimeAfterAuthLogin does nothing for incomplete or failed auth flo
   })
 
   assert.deepEqual(calls, [])
+})
+
+test('mergeRuntimeProviderModels drops provider defaults absent from the live runtime catalog', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-provider-runtime-default-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  writeFileSync(configPath, JSON.stringify({
+    providers: {
+      available: ['acme-provider'],
+      defaultProvider: 'acme-provider',
+      defaultModel: null,
+      descriptors: {
+        'acme-provider': {
+          runtime: 'builtin',
+          name: 'Acme Provider',
+          description: 'Acme provider',
+          defaultModel: 'stale-default',
+          credentials: [],
+          models: [],
+        },
+      },
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    const config = getPublicAppConfig()
+    assert.equal(config.providers.available[0]?.defaultModel, 'stale-default')
+
+    const merged = mergeRuntimeProviderModels(config, [{
+      id: 'acme-provider',
+      models: {
+        live: { name: 'Live' },
+      },
+      connected: true,
+    }])
+    assert.equal(merged.providers.available[0]?.defaultModel, undefined)
+    assert.equal(merged.providers.available[0]?.connected, true)
+
+    const withRuntimeDefault = mergeRuntimeProviderModels(config, [{
+      id: 'acme-provider',
+      models: {
+        live: { name: 'Live' },
+      },
+      defaultModel: 'live',
+    }])
+    assert.equal(withRuntimeDefault.providers.available[0]?.defaultModel, 'live')
+  } finally {
+    if (previousOverride === undefined) delete process.env.OPEN_COWORK_CONFIG_PATH
+    else process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
 })

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -30,7 +30,9 @@ test('open core ships with built-in tools, skills, mcps, and agents configured b
   assert.equal(mcps.map((mcp) => mcp.name).join(','), 'charts,skills')
   assert.equal(agents.map((agent) => agent.name).join(','), 'charts,skill-builder,research')
   assert.equal(getConfiguredToolAskPatterns(tools.find((tool) => tool.id === 'skills')!).includes('mcp__skills__save_skill_bundle'), true)
-  assert.equal(getProviderDescriptors().map((provider) => provider.id).join(','), 'openrouter,openai')
+  const providers = getProviderDescriptors()
+  assert.equal(providers.map((provider) => provider.id).join(','), 'openrouter,openai')
+  assert.equal(providers.find((provider) => provider.id === 'openrouter')?.defaultModel, 'anthropic/claude-sonnet-4')
   assert.equal(getAppConfig().permissions.bash, 'ask')
   assert.equal(getAppConfig().permissions.fileWrite, 'ask')
   assert.equal(getAppConfig().permissions.webSearch, true)
@@ -223,6 +225,104 @@ test('config loader accepts downstream model price and context overrides', () =>
     assert.equal(fallbacks.pricing['claude-sonnet-4'].inputPer1M, 3)
     assert.equal(fallbacks.contextLimits['github-copilot/claude-sonnet-4'], 200000)
     assert.equal(fallbacks.contextLimits['claude-sonnet-4'], 200000)
+  } finally {
+    if (previousOverride === undefined) {
+      delete process.env.OPEN_COWORK_CONFIG_PATH
+    } else {
+      process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    }
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('config loader exposes provider-local default models when present in the configured catalog', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-provider-default-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  writeFileSync(configPath, JSON.stringify({
+    providers: {
+      available: ['acme-gateway', 'internal-gateway'],
+      defaultProvider: 'acme-gateway',
+      defaultModel: 'fallback-large',
+      descriptors: {
+        'acme-gateway': {
+          runtime: 'builtin',
+          name: 'Acme Gateway',
+          description: 'Acme model gateway',
+          defaultModel: 'acme-large',
+          credentials: [],
+          models: [
+            { id: 'fallback-large', name: 'Fallback Large' },
+            { id: 'acme-large', name: 'Acme Large' },
+          ],
+        },
+      },
+      custom: {
+        'internal-gateway': {
+          npm: '@acme/opencode-provider',
+          name: 'Internal Gateway',
+          defaultModel: 'internal-balanced',
+          models: {
+            'internal-balanced': { name: 'Internal Balanced' },
+            'internal-fast': { name: 'Internal Fast' },
+          },
+        },
+      },
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    assert.doesNotThrow(() => assertConfigValid())
+    const providers = getProviderDescriptors()
+    assert.equal(providers.find((provider) => provider.id === 'acme-gateway')?.defaultModel, 'acme-large')
+    assert.equal(providers.find((provider) => provider.id === 'internal-gateway')?.defaultModel, 'internal-balanced')
+  } finally {
+    if (previousOverride === undefined) {
+      delete process.env.OPEN_COWORK_CONFIG_PATH
+    } else {
+      process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    }
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('config loader silently ignores provider-local defaults absent from the current catalog', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-provider-default-missing-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  writeFileSync(configPath, JSON.stringify({
+    providers: {
+      available: ['acme-gateway'],
+      defaultProvider: 'acme-gateway',
+      defaultModel: null,
+      descriptors: {
+        'acme-gateway': {
+          runtime: 'builtin',
+          name: 'Acme Gateway',
+          description: 'Acme model gateway',
+          defaultModel: 'missing-model',
+          credentials: [],
+          models: [
+            { id: 'acme-large', name: 'Acme Large' },
+          ],
+        },
+      },
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    assert.doesNotThrow(() => assertConfigValid())
+    assert.equal(getProviderDescriptors().find((provider) => provider.id === 'acme-gateway')?.defaultModel, undefined)
   } finally {
     if (previousOverride === undefined) {
       delete process.env.OPEN_COWORK_CONFIG_PATH

--- a/tests/runtime-config-builder.test.ts
+++ b/tests/runtime-config-builder.test.ts
@@ -242,6 +242,54 @@ test('buildProviderRuntimeConfig preserves configured custom provider options', 
   assert.equal(providerConfig.options.workspace, 'analytics')
 })
 
+test('buildRuntimeConfig uses a custom provider local default when the saved model is stale', () => {
+  const tempRoot = testTempDir('opencowork-runtime-provider-default-')
+  const configDir = join(tempRoot, 'downstream')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const originalSettings = loadSettings()
+
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.json'), JSON.stringify({
+    providers: {
+      available: ['acme-provider'],
+      defaultProvider: 'acme-provider',
+      defaultModel: null,
+      custom: {
+        'acme-provider': {
+          npm: '@acme/opencode-provider',
+          name: 'Acme Provider',
+          defaultModel: 'balanced',
+          models: {
+            fast: { name: 'Fast' },
+            balanced: { name: 'Balanced' },
+          },
+        },
+      },
+    },
+  }))
+
+  try {
+    process.env.OPEN_COWORK_CONFIG_DIR = configDir
+    clearConfigCaches()
+    saveSettings({
+      selectedProviderId: 'acme-provider',
+      selectedModelId: 'other-provider/old-model',
+      providerCredentials: {},
+    })
+
+    const runtimeConfig = buildRuntimeConfig() as Record<string, any>
+    assert.equal(runtimeConfig.model, 'acme-provider/balanced')
+    assert.equal(runtimeConfig.small_model, 'acme-provider/fast')
+    assert.equal(runtimeConfig.provider['acme-provider'].npm, '@acme/opencode-provider')
+  } finally {
+    saveSettings(originalSettings)
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('buildRuntimeConfig registers project-scoped custom agents in config.agent so the primary can delegate to them', () => {
   const projectRoot = testTempDir('opencowork-custom-agent-')
   const originalSettings = loadSettings()

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -29,6 +29,41 @@ function writeEmptyConfig(configDir: string) {
   writeFileSync(join(configDir, 'config.jsonc'), '{}\n')
 }
 
+function writeProviderDefaultConfig(configDir: string, internalDefaultModel = 'internal-balanced') {
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({
+    providers: {
+      available: ['acme-gateway', 'internal-gateway'],
+      defaultProvider: 'acme-gateway',
+      defaultModel: 'fallback-large',
+      descriptors: {
+        'acme-gateway': {
+          runtime: 'builtin',
+          name: 'Acme Gateway',
+          description: 'Acme model gateway',
+          defaultModel: 'acme-large',
+          credentials: [],
+          models: [
+            { id: 'fallback-large', name: 'Fallback Large' },
+            { id: 'acme-large', name: 'Acme Large' },
+          ],
+        },
+        'internal-gateway': {
+          runtime: 'builtin',
+          name: 'Internal Gateway',
+          description: 'Internal model gateway',
+          defaultModel: internalDefaultModel,
+          credentials: [],
+          models: [
+            { id: 'internal-fast', name: 'Internal Fast' },
+            { id: 'internal-balanced', name: 'Internal Balanced' },
+          ],
+        },
+      },
+    },
+  }))
+}
+
 async function importFreshSettingsModule(label: string) {
   return import(`../apps/desktop/src/main/settings.ts?${label}-${Date.now()}`)
 }
@@ -109,6 +144,132 @@ test('legacy settings without native toggles inherit downstream ask defaults', a
     const settings = loadSettings()
     assert.equal(settings.enableBash, true)
     assert.equal(settings.enableFileWrite, true)
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('fresh settings initialize to the default provider local default model', async () => {
+  const tempRoot = testTempDir('opencowork-settings-provider-default-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeProviderDefaultConfig(configDir)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, getEffectiveSettings } = await importFreshSettingsModule('fresh-provider-default')
+    const settings = loadSettings()
+    const effective = getEffectiveSettings(settings)
+    assert.equal(settings.selectedProviderId, 'acme-gateway')
+    assert.equal(settings.selectedModelId, 'acme-large')
+    assert.equal(effective.effectiveProviderId, 'acme-gateway')
+    assert.equal(effective.effectiveModel, 'acme-large')
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('effective settings use a selected provider local default when the saved model belongs to another provider', async () => {
+  const tempRoot = testTempDir('opencowork-settings-provider-switch-default-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeProviderDefaultConfig(configDir)
+  mkdirSync(userDataDir, { recursive: true })
+  writeFileSync(join(userDataDir, 'settings.json'), JSON.stringify({
+    selectedProviderId: 'internal-gateway',
+    selectedModelId: 'acme-large',
+  }))
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, getEffectiveSettings } = await importFreshSettingsModule('provider-switch-default')
+    const effective = getEffectiveSettings(loadSettings())
+    assert.equal(effective.effectiveProviderId, 'internal-gateway')
+    assert.equal(effective.effectiveModel, 'internal-balanced')
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('effective settings accept provider-prefixed model ids for configured provider catalogs', async () => {
+  const tempRoot = testTempDir('opencowork-settings-prefixed-provider-model-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeProviderDefaultConfig(configDir)
+  mkdirSync(userDataDir, { recursive: true })
+  writeFileSync(join(userDataDir, 'settings.json'), JSON.stringify({
+    selectedProviderId: 'internal-gateway',
+    selectedModelId: 'internal-gateway/internal-fast',
+  }))
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, getEffectiveSettings } = await importFreshSettingsModule('prefixed-provider-model')
+    const effective = getEffectiveSettings(loadSettings())
+    assert.equal(effective.effectiveProviderId, 'internal-gateway')
+    assert.equal(effective.effectiveModel, 'internal-fast')
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('effective settings fall back to the first provider model when the provider local default is unavailable', async () => {
+  const tempRoot = testTempDir('opencowork-settings-provider-default-missing-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeProviderDefaultConfig(configDir, 'missing-model')
+  mkdirSync(userDataDir, { recursive: true })
+  writeFileSync(join(userDataDir, 'settings.json'), JSON.stringify({
+    selectedProviderId: 'internal-gateway',
+    selectedModelId: 'acme-large',
+  }))
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, getEffectiveSettings } = await importFreshSettingsModule('provider-default-missing')
+    const effective = getEffectiveSettings(loadSettings())
+    assert.equal(effective.effectiveProviderId, 'internal-gateway')
+    assert.equal(effective.effectiveModel, 'internal-fast')
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir


### PR DESCRIPTION
## Summary
- Add provider-local `defaultModel` support for configured descriptors and custom providers.
- Resolve defaults through the current configured, cached, and runtime model catalog while preserving OpenCode SDK ownership of execution.
- Normalize provider-prefixed model ids and silently fall back when a provider default is unavailable.
- Document the config field and add schema coverage for downstream distributions.

## Validation
- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/app-handlers.test.ts tests/config-elements.test.ts tests/settings.test.ts tests/runtime-config-builder.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- Earlier before the final stale-default hardening patch: `pnpm test:renderer`, `pnpm docs:build`, `pnpm test:e2e`