### PR TITLE
Harden audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,12 @@ jobs:
 
       - name: Verify third-party notices
         run: |
-          pnpm notices
+          node scripts/generate-third-party-notices.mjs --skip-license-output
           git diff --exit-code THIRD_PARTY_NOTICES.md || {
             echo "::error::THIRD_PARTY_NOTICES.md is stale. Run 'pnpm notices' and commit the result."
             exit 1
           }
+          node scripts/verify-third-party-license-files.mjs
 
       - name: Lint
         run: pnpm lint

--- a/apps/desktop/src/main/chart-artifacts.ts
+++ b/apps/desktop/src/main/chart-artifacts.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { join, resolve, sep } from 'path'
 import type { ChartArtifactSource, ChartSaveArtifactRequest, SessionArtifact } from '@open-cowork/shared'
 import { getAppDataDir } from './config-loader.ts'
 import { log } from './logger.ts'
@@ -10,13 +10,68 @@ import { log } from './logger.ts'
 // project mode. Per-session root keeps them namespaced and easy to
 // clean alongside the session.
 export function getChartArtifactsRoot(sessionId: string): string {
-  return join(getAppDataDir(), 'chart-artifacts', sessionId)
+  const base = resolve(getAppDataDir(), 'chart-artifacts')
+  const safeSessionId = sanitizePathSegment(sessionId, 'sessionId', 160)
+  const root = resolve(base, safeSessionId)
+  if (root !== base && !root.startsWith(`${base}${sep}`)) {
+    throw new Error('Chart artifact session root escaped the artifact directory.')
+  }
+  return root
 }
 
 const DATA_URL_PREFIX = 'data:image/png;base64,'
+const MAX_CHART_ARTIFACT_BYTES = 16 * 1024 * 1024
+const MAX_CHART_ARTIFACT_METADATA_BYTES = 1024 * 1024
+
+function stringByteLength(value: string) {
+  return Buffer.byteLength(value, 'utf8')
+}
+
+function sanitizePathSegment(value: unknown, label: string, maxBytes: number) {
+  if (typeof value !== 'string') {
+    throw new Error(`Chart artifact ${label} must be a string.`)
+  }
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new Error(`Chart artifact ${label} is required.`)
+  }
+  if (stringByteLength(trimmed) > maxBytes) {
+    throw new Error(`Chart artifact ${label} is too large.`)
+  }
+  const safe = trimmed.replace(/[^a-zA-Z0-9_-]+/g, '-').slice(0, maxBytes)
+  if (!safe || safe === '.' || safe === '..') {
+    throw new Error(`Chart artifact ${label} could not be normalized safely.`)
+  }
+  return safe
+}
+
+function decodeBoundedPngDataUrl(dataUrl: unknown) {
+  if (typeof dataUrl !== 'string' || !dataUrl.startsWith(DATA_URL_PREFIX)) {
+    throw new Error('Chart artifact payload must be a base64-encoded PNG data URL.')
+  }
+  const base64 = dataUrl.slice(DATA_URL_PREFIX.length).trim()
+  if (!base64) {
+    throw new Error('Chart artifact payload was empty after decode.')
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(base64)) {
+    throw new Error('Chart artifact payload must be valid base64.')
+  }
+  const estimatedBytes = Math.floor((base64.length * 3) / 4)
+  if (estimatedBytes > MAX_CHART_ARTIFACT_BYTES + 2) {
+    throw new Error('Chart artifact payload is too large.')
+  }
+  const bytes = Buffer.from(base64, 'base64')
+  if (bytes.length === 0) {
+    throw new Error('Chart artifact payload was empty after decode.')
+  }
+  if (bytes.length > MAX_CHART_ARTIFACT_BYTES) {
+    throw new Error('Chart artifact payload is too large.')
+  }
+  return bytes
+}
 
 function sanitizeToolCallId(toolCallId: string) {
-  return toolCallId.replace(/[^a-zA-Z0-9_-]+/g, '-').slice(0, 64) || 'chart'
+  return sanitizePathSegment(toolCallId, 'toolCallId', 64)
 }
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
@@ -59,15 +114,8 @@ export function saveChartArtifact(request: ChartSaveArtifactRequest): SessionArt
   if (!request.sessionId || !request.toolCallId || !request.toolName) {
     throw new Error('Chart artifact save requires sessionId, toolCallId, and toolName.')
   }
-  if (!request.dataUrl?.startsWith(DATA_URL_PREFIX)) {
-    throw new Error('Chart artifact payload must be a base64-encoded PNG data URL.')
-  }
 
-  const base64 = request.dataUrl.slice(DATA_URL_PREFIX.length)
-  const bytes = Buffer.from(base64, 'base64')
-  if (bytes.length === 0) {
-    throw new Error('Chart artifact payload was empty after decode.')
-  }
+  const bytes = decodeBoundedPngDataUrl(request.dataUrl)
   const chart = request.chart ? normalizeChartArtifactSource(request.chart) : null
   if (request.chart && !chart) {
     throw new Error('Chart artifact metadata must include a valid vega or vega-lite spec.')
@@ -83,7 +131,12 @@ export function saveChartArtifact(request: ChartSaveArtifactRequest): SessionArt
   writeFileSync(filePath, bytes)
   const metadataPath = getChartArtifactMetadataPath(filePath)
   if (chart) {
-    writeFileSync(metadataPath, JSON.stringify(chart))
+    const metadata = JSON.stringify(chart)
+    if (stringByteLength(metadata) > MAX_CHART_ARTIFACT_METADATA_BYTES) {
+      rmSync(filePath, { force: true })
+      throw new Error('Chart artifact metadata is too large.')
+    }
+    writeFileSync(metadataPath, metadata)
   } else {
     rmSync(metadataPath, { force: true })
   }

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import type { BrowserWindow, IpcMain } from 'electron'
+import type { BrowserWindow, IpcMain, IpcMainEvent, IpcMainInvokeEvent } from 'electron'
 import type {
   CapabilityTool,
   CapabilityToolEntry,
@@ -13,7 +13,8 @@ import { isMcpAuthRequiredStatus } from '@open-cowork/shared'
 import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp'
-import { resolve } from 'path'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
 import { getChartArtifactsRoot } from './chart-artifacts.ts'
 import {
   getClient,
@@ -56,9 +57,36 @@ import type { IpcHandlerContext } from './ipc/context.ts'
 import { clearPermissionsForSession, trackPermission } from './permission-tracker.ts'
 import { normalizeProjectDirectory, ProjectDirectoryGrantRegistry } from './directory-grants.ts'
 import { resolveContainedArtifactPath } from './artifact-path-policy.ts'
+import { isTrustedRendererIpcUrl } from './main-window-lifecycle.ts'
 
 import { RUNTIME_TOOL_CACHE_TTL_MS, runtimeToolCache } from './runtime-tool-cache.ts'
 export { invalidateRuntimeToolCache } from './runtime-tool-cache.ts'
+
+type IpcSenderEvent = IpcMainEvent | IpcMainInvokeEvent
+
+function currentModuleDirname() {
+  return typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
+}
+
+function expectedRendererEntryPath() {
+  return join(currentModuleDirname(), '../index.html')
+}
+
+export function isTrustedIpcSenderUrl(rawUrl: string, devServerUrl = process.env.VITE_DEV_SERVER_URL) {
+  return isTrustedRendererIpcUrl({
+    rawUrl,
+    devServerUrl,
+    expectedRendererPath: expectedRendererEntryPath(),
+  })
+}
+
+function assertTrustedIpcSender(event: IpcSenderEvent, channel: string) {
+  const senderFrame = (event as { senderFrame?: { url?: unknown } | null }).senderFrame
+  const senderUrl = typeof senderFrame?.url === 'string' ? senderFrame.url : ''
+  if (isTrustedIpcSenderUrl(senderUrl)) return
+  log('security', `Rejected IPC ${channel} from untrusted sender frame: ${senderUrl || 'unknown'}`)
+  throw new Error('Rejected IPC request from untrusted renderer frame.')
+}
 
 export function setupIpcHandlers(ipcMain: IpcMain, getMainWindow: () => BrowserWindow | null) {
   setSessionHistoryRefreshHandler(async (sessionId: string) => {
@@ -89,6 +117,7 @@ export function setupIpcHandlers(ipcMain: IpcMain, getMainWindow: () => BrowserW
       return ipcMain.handle(channel, async (...args) => {
         const start = performance.now()
         try {
+          assertTrustedIpcSender(args[0], channel)
           return await listener(...args)
         } finally {
           observePerf(`ipc.${channel}`, performance.now() - start, { slowThresholdMs: 500 })
@@ -99,7 +128,10 @@ export function setupIpcHandlers(ipcMain: IpcMain, getMainWindow: () => BrowserW
       // Fire-and-forget channels (renderer uses `ipcRenderer.send`) skip
       // the perf histograms because there's no reply to time — they're
       // one-way notifications by design.
-      return ipcMain.on(channel, listener)
+      return ipcMain.on(channel, (event, ...args) => {
+        assertTrustedIpcSender(event, channel)
+        return listener(event, ...args)
+      })
     },
   } satisfies Pick<IpcMain, 'handle' | 'on'>
 

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -1,4 +1,5 @@
 import electron from 'electron'
+import { basename, extname } from 'node:path'
 import type { IpcHandlerContext } from './context.ts'
 import { getEffectiveSettings, maskEffectiveSettingsCredentials, saveSettings, isSetupComplete, type CoworkSettings } from '../settings.ts'
 import { getClient, getModelInfoAsync } from '../runtime.ts'
@@ -44,6 +45,27 @@ const MAX_PROVIDER_AUTH_INSTRUCTIONS_LENGTH = 4 * 1024
 const MAX_CLIPBOARD_TEXT_LENGTH = 2 * 1024 * 1024
 const MAX_SAVE_TEXT_BYTES = 2 * 1024 * 1024
 const MAX_SAVE_TEXT_FILENAME_BYTES = 512
+const SENSITIVE_SAVE_TEXT_BASENAMES = new Set([
+  '.bash_profile',
+  '.bashrc',
+  '.profile',
+  '.ssh_config',
+  '.zprofile',
+  '.zshenv',
+  '.zshrc',
+  'authorized_keys',
+  'config',
+  'known_hosts',
+])
+const SENSITIVE_SAVE_TEXT_DIRS = new Set([
+  '.aws',
+  '.azure',
+  '.config/gcloud',
+  '.docker',
+  '.gnupg',
+  '.kube',
+  '.ssh',
+])
 
 export async function ensureRuntimeAfterAuthLogin(input: {
   authenticated: boolean
@@ -72,6 +94,24 @@ function normalizeBoundedString(value: unknown, label: string, maxBytes: number)
   if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
   if (stringByteLength(value) > maxBytes) throw new Error(`${label} is too large.`)
   return value
+}
+
+function pathContainsSensitiveDir(filePath: string) {
+  const normalized = filePath.replaceAll('\\', '/').toLowerCase()
+  return Array.from(SENSITIVE_SAVE_TEXT_DIRS).some((dir) => normalized.includes(`/${dir}/`))
+}
+
+export function resolveSafeSaveTextPath(filePath: string) {
+  const extension = extname(filePath)
+  const targetPath = extension ? filePath : `${filePath}.json`
+  if (extname(targetPath).toLowerCase() !== '.json') {
+    throw new Error('Saved text exports must use a .json extension.')
+  }
+  const lowerBasename = basename(targetPath).toLowerCase()
+  if (SENSITIVE_SAVE_TEXT_BASENAMES.has(lowerBasename) || pathContainsSensitiveDir(targetPath)) {
+    throw new Error('Refusing to save exported text into a sensitive configuration path.')
+  }
+  return targetPath
 }
 
 function resolveKnownProviderId(providerId: unknown): string {
@@ -578,9 +618,10 @@ export function registerAppHandlers(context: IpcHandlerContext) {
       filters: [{ name: 'JSON', extensions: ['json'] }],
     })
     if (result.canceled || !result.filePath) return null
+    const safeFilePath = resolveSafeSaveTextPath(result.filePath)
     try {
-      fs.writeFileSync(result.filePath, safeContent, 'utf-8')
-      return result.filePath
+      fs.writeFileSync(safeFilePath, safeContent, 'utf-8')
+      return safeFilePath
     } catch (err) {
       log('error', `dialog:save-text write failed: ${err instanceof Error ? err.message : String(err)}`)
       return null

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -48,6 +48,13 @@ const MAX_PROMPT_ATTACHMENTS_TOTAL_BYTES = 60 * 1024 * 1024
 const MAX_PROMPT_ATTACHMENT_MIME_BYTES = 256
 const MAX_PROMPT_ATTACHMENT_FILENAME_BYTES = 512
 const MAX_PROMPT_AGENT_BYTES = 128
+const MAX_SESSION_ID_BYTES = 256
+const MAX_COMMAND_NAME_BYTES = 256
+const MAX_SESSION_TITLE_BYTES = 512
+const MAX_QUESTION_REQUEST_ID_BYTES = 256
+const MAX_QUESTION_ANSWERS = 32
+const MAX_QUESTION_ANSWER_CHOICES = 16
+const MAX_QUESTION_ANSWER_BYTES = 4 * 1024
 
 function byteLength(value: string) {
   return Buffer.byteLength(value, 'utf8')
@@ -82,6 +89,44 @@ function normalizePromptText(text: unknown) {
 function normalizePromptAgent(agent: unknown) {
   if (agent == null || agent === '') return 'build'
   return requireBoundedString(agent, 'Prompt agent', MAX_PROMPT_AGENT_BYTES)
+}
+
+function normalizeSessionId(value: unknown) {
+  const sessionId = requireBoundedString(value, 'Session id', MAX_SESSION_ID_BYTES).trim()
+  if (!sessionId) throw new Error('Session id is required')
+  return sessionId
+}
+
+function normalizeCommandName(value: unknown) {
+  const commandName = requireBoundedString(value, 'Command name', MAX_COMMAND_NAME_BYTES).trim()
+  if (!commandName) throw new Error('Command name is required')
+  return commandName
+}
+
+function normalizeSessionTitle(value: unknown) {
+  const title = requireBoundedString(value, 'Session title', MAX_SESSION_TITLE_BYTES).trim()
+  if (!title) throw new Error('Session title is required')
+  return title
+}
+
+function normalizeQuestionRequestId(value: unknown) {
+  const requestId = requireBoundedString(value, 'Question request id', MAX_QUESTION_REQUEST_ID_BYTES).trim()
+  if (!requestId) throw new Error('Question request id is required')
+  return requestId
+}
+
+function normalizeQuestionAnswers(value: unknown): QuestionAnswer[] {
+  if (!Array.isArray(value)) throw new Error('Question answers must be an array')
+  if (value.length > MAX_QUESTION_ANSWERS) throw new Error('Too many question answers')
+  return value.map((answer) => {
+    if (!Array.isArray(answer)) throw new Error('Question answer must be an array')
+    if (answer.length > MAX_QUESTION_ANSWER_CHOICES) throw new Error('Too many question answer choices')
+    return answer.map((choice) => {
+      const normalized = requireBoundedString(choice, 'Question answer choice', MAX_QUESTION_ANSWER_BYTES).trim()
+      if (!normalized) throw new Error('Question answer choice is required')
+      return normalized
+    })
+  })
 }
 
 function resolvePromptModel(settings: ReturnType<typeof getEffectiveSettings>, runtimeProvider?: ProviderLike | null) {
@@ -692,7 +737,9 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('command:run', async (_event, sessionId: string, commandName: string) => {
+  context.ipcMain.handle('command:run', async (_event, sessionIdInput: unknown, commandNameInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
+    const commandName = normalizeCommandName(commandNameInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       trackParentSession(sessionId)
@@ -705,7 +752,9 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:rename', async (_event, sessionId: string, title: string) => {
+  context.ipcMain.handle('session:rename', async (_event, sessionIdInput: unknown, titleInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
+    const title = normalizeSessionTitle(titleInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       await client.session.update({ sessionID: sessionId, title })
@@ -772,11 +821,14 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('question:reply', async (_event, sessionId: string, requestId: string, answers: string[][]) => {
+  context.ipcMain.handle('question:reply', async (_event, sessionIdInput: unknown, requestIdInput: unknown, answersInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
+    const requestId = normalizeQuestionRequestId(requestIdInput)
+    const answers = normalizeQuestionAnswers(answersInput)
     const { client } = await context.getSessionV2Client(sessionId)
     await client.question.reply({
       requestID: requestId,
-      answers: answers as QuestionAnswer[],
+      answers,
     }, { throwOnError: true })
     resolveQuestionLocally(context, sessionId, requestId)
     startSessionStatusReconciliation(sessionId, {
@@ -787,7 +839,9 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     })
   })
 
-  context.ipcMain.handle('question:reject', async (_event, sessionId: string, requestId: string) => {
+  context.ipcMain.handle('question:reject', async (_event, sessionIdInput: unknown, requestIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
+    const requestId = normalizeQuestionRequestId(requestIdInput)
     const { client } = await context.getSessionV2Client(sessionId)
     await client.question.reject({
       requestID: requestId,

--- a/apps/desktop/src/main/main-window-lifecycle.ts
+++ b/apps/desktop/src/main/main-window-lifecycle.ts
@@ -24,6 +24,28 @@ export function isExpectedPackagedRendererFile(url: string, expectedRendererPath
   }
 }
 
+export function rendererUrlMatchesDevServer(rawUrl: string, devServerUrl: string) {
+  try {
+    const parsed = new URL(rawUrl)
+    const expected = new URL(devServerUrl)
+    if (parsed.origin !== expected.origin) return false
+    const expectedPath = expected.pathname.endsWith('/') ? expected.pathname : `${expected.pathname}/`
+    return parsed.pathname === expected.pathname || parsed.pathname.startsWith(expectedPath)
+  } catch {
+    return false
+  }
+}
+
+export function isTrustedRendererIpcUrl(options: {
+  rawUrl: string
+  devServerUrl?: string | null
+  expectedRendererPath: string
+}) {
+  if (!options.rawUrl) return false
+  if (options.devServerUrl && rendererUrlMatchesDevServer(options.rawUrl, options.devServerUrl)) return true
+  return isExpectedPackagedRendererFile(options.rawUrl, options.expectedRendererPath)
+}
+
 export function pickRecoverableMainWindow<T extends WindowLike>(
   currentWindow: T | null,
   allWindows: readonly T[],

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -265,6 +265,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
             <input
               value={draft.title}
               onChange={(event) => updateDraft({ title: event.target.value })}
+              aria-label={t('automations.titleLabel', 'Automation title')}
               placeholder={t('automations.titlePlaceholder', 'Weekly market report')}
               className="rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent"
             />
@@ -272,41 +273,42 @@ export function AutomationsPage({ onOpenThread }: Props) {
               value={draft.goal}
               onChange={(event) => updateDraft({ goal: event.target.value })}
               rows={5}
+              aria-label={t('automations.goalLabel', 'Automation goal')}
               placeholder={t('automations.goalPlaceholder', 'Build a weekly analysis and market research report and keep it ready for review every Monday morning.')}
               className="rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent resize-y"
             />
             <div className="grid grid-cols-2 gap-2">
-              <select value={draft.kind} onChange={(event) => updateDraft({ kind: event.target.value as AutomationKind })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
+              <select value={draft.kind} onChange={(event) => updateDraft({ kind: event.target.value as AutomationKind })} aria-label={t('automations.kindLabel', 'Automation type')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
                 <option value="recurring">Recurring program</option>
                 <option value="managed-project">Managed project</option>
               </select>
-              <select value={draft.scheduleType} onChange={(event) => updateDraft({ scheduleType: event.target.value as AutomationScheduleType })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
+              <select value={draft.scheduleType} onChange={(event) => updateDraft({ scheduleType: event.target.value as AutomationScheduleType })} aria-label={t('automations.scheduleTypeLabel', 'Schedule type')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
                 <option value="weekly">Weekly</option>
                 <option value="daily">Daily</option>
                 <option value="monthly">Monthly</option>
                 <option value="one_time">One-time</option>
               </select>
             </div>
-            <input value={draft.timezone} onChange={(event) => updateDraft({ timezone: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Europe/Amsterdam" />
+            <input value={draft.timezone} onChange={(event) => updateDraft({ timezone: event.target.value })} aria-label={t('automations.timezoneLabel', 'Timezone')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Europe/Amsterdam" />
             <div className="grid grid-cols-2 gap-2">
-              <input value={draft.runAtHour} onChange={(event) => updateDraft({ runAtHour: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Hour" />
-              <input value={draft.runAtMinute} onChange={(event) => updateDraft({ runAtMinute: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Minute" />
+              <input value={draft.runAtHour} onChange={(event) => updateDraft({ runAtHour: event.target.value })} aria-label={t('automations.runAtHourLabel', 'Run hour')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Hour" />
+              <input value={draft.runAtMinute} onChange={(event) => updateDraft({ runAtMinute: event.target.value })} aria-label={t('automations.runAtMinuteLabel', 'Run minute')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Minute" />
             </div>
             {draft.scheduleType === 'weekly' && (
-              <input value={draft.dayOfWeek} onChange={(event) => updateDraft({ dayOfWeek: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Day of week (0-6)" />
+              <input value={draft.dayOfWeek} onChange={(event) => updateDraft({ dayOfWeek: event.target.value })} aria-label={t('automations.dayOfWeekLabel', 'Day of week')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Day of week (0-6)" />
             )}
             {draft.scheduleType === 'monthly' && (
-              <input value={draft.dayOfMonth} onChange={(event) => updateDraft({ dayOfMonth: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Day of month (1-31)" />
+              <input value={draft.dayOfMonth} onChange={(event) => updateDraft({ dayOfMonth: event.target.value })} aria-label={t('automations.dayOfMonthLabel', 'Day of month')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Day of month (1-31)" />
             )}
             {draft.scheduleType === 'one_time' && (
-              <input value={draft.startAt} onChange={(event) => updateDraft({ startAt: event.target.value })} type="datetime-local" className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" />
+              <input value={draft.startAt} onChange={(event) => updateDraft({ startAt: event.target.value })} type="datetime-local" aria-label={t('automations.startAtLabel', 'Start date and time')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" />
             )}
             <div className="grid grid-cols-2 gap-2">
-              <select value={draft.executionMode} onChange={(event) => updateDraft({ executionMode: event.target.value as AutomationExecutionMode })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
+              <select value={draft.executionMode} onChange={(event) => updateDraft({ executionMode: event.target.value as AutomationExecutionMode })} aria-label={t('automations.executionModeLabel', 'Execution mode')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
                 <option value="planning_only">Planning only</option>
                 <option value="scoped_execution">Scoped execution</option>
               </select>
-              <select value={draft.autonomyPolicy} onChange={(event) => updateDraft({ autonomyPolicy: event.target.value as AutomationAutonomyPolicy })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
+              <select value={draft.autonomyPolicy} onChange={(event) => updateDraft({ autonomyPolicy: event.target.value as AutomationAutonomyPolicy })} aria-label={t('automations.autonomyPolicyLabel', 'Autonomy policy')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
                 <option value="review-first">Review first</option>
                 <option value="mostly-autonomous">Mostly autonomous</option>
               </select>
@@ -315,6 +317,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
               <input
                 value={draft.projectDirectory}
                 readOnly
+                aria-label={t('automations.projectDirectoryLabel', 'Project directory')}
                 className="flex-1 rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent"
                 placeholder="Optional project directory"
               />
@@ -357,15 +360,15 @@ export function AutomationsPage({ onOpenThread }: Props) {
                 Scoped execution needs a project directory so the agent team has an explicit workspace boundary.
               </div>
             ) : null}
-            <input value={draft.heartbeatMinutes} onChange={(event) => updateDraft({ heartbeatMinutes: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Heartbeat minutes" />
+            <input value={draft.heartbeatMinutes} onChange={(event) => updateDraft({ heartbeatMinutes: event.target.value })} aria-label={t('automations.heartbeatMinutesLabel', 'Heartbeat minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Heartbeat minutes" />
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-              <input value={draft.maxRetries} onChange={(event) => updateDraft({ maxRetries: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max retries" />
-              <input value={draft.retryBaseDelayMinutes} onChange={(event) => updateDraft({ retryBaseDelayMinutes: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Base retry delay (min)" />
-              <input value={draft.retryMaxDelayMinutes} onChange={(event) => updateDraft({ retryMaxDelayMinutes: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max retry delay (min)" />
+              <input value={draft.maxRetries} onChange={(event) => updateDraft({ maxRetries: event.target.value })} aria-label={t('automations.maxRetriesLabel', 'Maximum retries')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max retries" />
+              <input value={draft.retryBaseDelayMinutes} onChange={(event) => updateDraft({ retryBaseDelayMinutes: event.target.value })} aria-label={t('automations.retryBaseDelayLabel', 'Base retry delay in minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Base retry delay (min)" />
+              <input value={draft.retryMaxDelayMinutes} onChange={(event) => updateDraft({ retryMaxDelayMinutes: event.target.value })} aria-label={t('automations.retryMaxDelayLabel', 'Maximum retry delay in minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max retry delay (min)" />
             </div>
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-              <input value={draft.dailyRunCap} onChange={(event) => updateDraft({ dailyRunCap: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder={dailyRunAttemptCapPlaceholder()} />
-              <input value={draft.maxRunDurationMinutes} onChange={(event) => updateDraft({ maxRunDurationMinutes: event.target.value })} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max run duration (min)" />
+              <input value={draft.dailyRunCap} onChange={(event) => updateDraft({ dailyRunCap: event.target.value })} aria-label={t('automations.dailyRunCapLabel', 'Daily run attempt cap')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder={dailyRunAttemptCapPlaceholder()} />
+              <input value={draft.maxRunDurationMinutes} onChange={(event) => updateDraft({ maxRunDurationMinutes: event.target.value })} aria-label={t('automations.maxRunDurationLabel', 'Maximum run duration in minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max run duration (min)" />
             </div>
             <button
               type="button"

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -255,6 +255,8 @@ export function Sidebar({
             </div>
             <button
               onClick={() => setShowSearch(!showSearch)}
+              aria-label={t('sidebar.searchTitle', 'Search threads (⌘K)')}
+              aria-expanded={showSearch}
               className={`w-9 h-9 flex items-center justify-center rounded-lg border border-border-subtle transition-colors cursor-pointer ${showSearch ? 'bg-surface-active text-text' : 'text-text-muted hover:bg-surface-hover hover:text-text-secondary'}`}
               title={t('sidebar.searchTitle', 'Search threads (⌘K)')}
             >
@@ -273,6 +275,7 @@ export function Sidebar({
                 value={searchQuery}
                 onChange={e => setSearchQuery(e.target.value)}
                 onKeyDown={e => { if (e.key === 'Escape') { setShowSearch(false); setSearchQuery('') } }}
+                aria-label={t('sidebar.search', 'Search threads...')}
                 placeholder={t('sidebar.search', 'Search threads...')}
                 className="w-full px-3 py-1.5 rounded-lg text-[12px] bg-elevated border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-border"
               />
@@ -281,6 +284,7 @@ export function Sidebar({
 
           <div className="px-2 pt-2 pb-1">
             <button onClick={() => onViewChange('home')}
+              aria-current={currentView === 'home' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'home' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M2 5.5 6.5 2 11 5.5V11a.75.75 0 0 1-.75.75H2.75A.75.75 0 0 1 2 11V5.5Z" />
@@ -289,6 +293,7 @@ export function Sidebar({
               {t('sidebar.home', 'Home')}
             </button>
             <button onClick={() => onViewChange('agents')}
+              aria-current={currentView === 'agents' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'agents' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="4" cy="4" r="1.5" />
@@ -299,6 +304,7 @@ export function Sidebar({
               {t('sidebar.agents', 'Agents')}
             </button>
             <button onClick={() => onViewChange('automations')}
+              aria-current={currentView === 'automations' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'automations' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="2" y="2" width="3" height="3" rx="0.6" />
@@ -312,6 +318,7 @@ export function Sidebar({
               {t('sidebar.automations', 'Automations')}
             </button>
             <button onClick={() => onViewChange('capabilities')}
+              aria-current={currentView === 'capabilities' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'capabilities' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="3.25" cy="3.25" r="1.25" />
@@ -324,6 +331,7 @@ export function Sidebar({
               {t('sidebar.capabilities', 'Capabilities')}
             </button>
             <button onClick={() => onViewChange('pulse')}
+              aria-current={currentView === 'pulse' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'pulse' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M1.5 6.5h2.3l1.2-3 2 6 1.2-3h3.3" />

--- a/apps/desktop/src/renderer/components/layout/TitleBar.tsx
+++ b/apps/desktop/src/renderer/components/layout/TitleBar.tsx
@@ -1,4 +1,5 @@
 import { useSessionStore } from '../../stores/session'
+import { t } from '../../helpers/i18n'
 
 export function TitleBar() {
   const toggleSidebar = useSessionStore((s) => s.toggleSidebar)
@@ -8,6 +9,7 @@ export function TitleBar() {
       <div className="flex items-center pl-[72px] gap-1.5">
         <button
           onClick={toggleSidebar}
+          aria-label={t('titleBar.toggleSidebar', 'Toggle sidebar')}
           className="no-drag flex items-center justify-center w-6 h-6 rounded-md text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -109,14 +109,26 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
     setMenuId(null)
   }
 
+  const openMenuAt = (xInput: number, yInput: number, sessionId: string) => {
+    // Clamp so the menu doesn't go off-screen
+    const y = Math.min(yInput, window.innerHeight - 140)
+    const x = Math.min(xInput, window.innerWidth - 170)
+    setMenuPos({ x, y })
+    setMenuId(menuId === sessionId ? null : sessionId)
+  }
+
   const openMenu = (e: React.MouseEvent, sessionId: string) => {
     e.preventDefault()
     e.stopPropagation()
-    // Clamp so the menu doesn't go off-screen
-    const y = Math.min(e.clientY, window.innerHeight - 140)
-    const x = Math.min(e.clientX, window.innerWidth - 170)
-    setMenuPos({ x, y })
-    setMenuId(menuId === sessionId ? null : sessionId)
+    openMenuAt(e.clientX, e.clientY, sessionId)
+  }
+
+  const openMenuFromKeyboard = (e: React.KeyboardEvent<HTMLElement>, sessionId: string) => {
+    if (e.key !== 'ContextMenu' && !(e.shiftKey && e.key === 'F10')) return
+    e.preventDefault()
+    e.stopPropagation()
+    const rect = e.currentTarget.getBoundingClientRect()
+    openMenuAt(rect.right - 12, rect.top + 12, sessionId)
   }
 
   const renderRow = (session: typeof filtered[number]) => {
@@ -137,6 +149,7 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
             ) : (
               <button onClick={() => handleSelect(session.id)}
                 onContextMenu={(e) => openMenu(e, session.id)}
+                onKeyDown={(e) => openMenuFromKeyboard(e, session.id)}
                 className={`w-full text-start px-3 py-[7px] rounded-md text-[13px] truncate transition-colors cursor-pointer flex items-center justify-between gap-1 ${isActive ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
                 <span className="truncate flex-1">
                   <span className="flex items-center gap-1.5">
@@ -205,8 +218,8 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
                     via the row's onContextMenu handler — native
                     "context-menu key" / Shift+F10 path works because
                     the outer button owns that listener. */}
-                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                 <span onClick={(e) => openMenu(e, session.id)}
+                  aria-hidden="true"
                   className="opacity-0 group-hover:opacity-100 shrink-0 w-5 h-5 flex items-center justify-center rounded text-text-muted hover:text-text-secondary transition-opacity cursor-pointer">
                   <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="6" cy="3" r="1"/><circle cx="6" cy="6" r="1"/><circle cx="6" cy="9" r="1"/></svg>
                 </span>

--- a/apps/desktop/src/renderer/stores/session.ts
+++ b/apps/desktop/src/renderer/stores/session.ts
@@ -207,6 +207,8 @@ export const useSessionStore = create<SessionStore>((set) => ({
   removeSession: (id) => set((state) => {
     const sessionStateById = { ...state.sessionStateById }
     delete sessionStateById[id]
+    const chartArtifactsBySession = { ...state.chartArtifactsBySession }
+    delete chartArtifactsBySession[id]
 
     // Drop the id from the status Sets too — otherwise a session that was
     // busy / awaiting-permission / awaiting-question at delete time leaves
@@ -229,6 +231,7 @@ export const useSessionStore = create<SessionStore>((set) => ({
       busySessions: nextBusy,
       awaitingPermissionSessions: nextAwaitingPermission,
       awaitingQuestionSessions: nextAwaitingQuestion,
+      chartArtifactsBySession,
     }
 
     if (state.currentSessionId === id) {

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 const rootDir = process.cwd()
 const outputPath = join(rootDir, 'THIRD_PARTY_NOTICES.md')
 const licenseOutputDir = join(rootDir, 'THIRD_PARTY_LICENSES')
+const skipLicenseOutput = process.argv.includes('--skip-license-output')
 const noticeFileNames = ['NOTICE', 'NOTICE.md', 'NOTICE.txt']
 const licenseFileNames = ['LICENSE', 'LICENSE.md', 'LICENSE.txt', 'license', 'license.md', 'license.txt']
 
@@ -164,14 +165,16 @@ if (packagesWithNotices.length > 0) {
   }
 }
 
-rmSync(licenseOutputDir, { recursive: true, force: true })
-mkdirSync(licenseOutputDir, { recursive: true })
-for (const item of sortedPackages) {
-  if (item.licenseFiles.length === 0) continue
-  const dir = join(licenseOutputDir, packageLicenseDirName(item.name, item.version))
-  mkdirSync(dir, { recursive: true })
-  for (const license of item.licenseFiles) {
-    writeFileSync(join(dir, license.file), `${license.text}\n`)
+if (!skipLicenseOutput) {
+  rmSync(licenseOutputDir, { recursive: true, force: true })
+  mkdirSync(licenseOutputDir, { recursive: true })
+  for (const item of sortedPackages) {
+    if (item.licenseFiles.length === 0) continue
+    const dir = join(licenseOutputDir, packageLicenseDirName(item.name, item.version))
+    mkdirSync(dir, { recursive: true })
+    for (const license of item.licenseFiles) {
+      writeFileSync(join(dir, license.file), `${license.text}\n`)
+    }
   }
 }
 

--- a/scripts/verify-third-party-license-files.mjs
+++ b/scripts/verify-third-party-license-files.mjs
@@ -1,0 +1,35 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const rootDir = process.cwd()
+const noticesPath = join(rootDir, 'THIRD_PARTY_NOTICES.md')
+const licenseDir = join(rootDir, 'THIRD_PARTY_LICENSES')
+const notices = readFileSync(noticesPath, 'utf8')
+const referencedDirs = Array.from(notices.matchAll(/THIRD_PARTY_LICENSES\/([^)\s|]+)\//g))
+  .map((match) => match[1])
+  .filter(Boolean)
+
+const missing = []
+const empty = []
+for (const dirName of referencedDirs) {
+  const dir = join(licenseDir, dirName)
+  if (!existsSync(dir)) {
+    missing.push(`THIRD_PARTY_LICENSES/${dirName}/`)
+    continue
+  }
+  const files = readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+  if (files.length === 0) {
+    empty.push(`THIRD_PARTY_LICENSES/${dirName}/`)
+  }
+}
+
+if (missing.length > 0 || empty.length > 0) {
+  for (const path of missing) {
+    console.error(`Missing bundled license directory referenced by THIRD_PARTY_NOTICES.md: ${path}`)
+  }
+  for (const path of empty) {
+    console.error(`Bundled license directory has no files: ${path}`)
+  }
+  process.exit(1)
+}

--- a/tests/chart-artifacts.test.ts
+++ b/tests/chart-artifacts.test.ts
@@ -90,6 +90,40 @@ test('saveChartArtifact sanitizes unsafe characters in tool-call ids', () => {
   }
 })
 
+test('saveChartArtifact sanitizes unsafe characters in session ids', () => {
+  const unsafeSessionId = '../sess-test-escape-' + Date.now()
+  const root = getChartArtifactsRoot(unsafeSessionId)
+  try {
+    const artifact = saveChartArtifact({
+      sessionId: unsafeSessionId,
+      toolCallId: 'tool-safe',
+      toolName: 'render_chart',
+      dataUrl: ONE_PX_PNG,
+    })
+    assert.ok(!root.includes('..'))
+    assert.ok(artifact.filePath.startsWith(root + '/'))
+    assert.ok(!artifact.filePath.includes('/../'))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('saveChartArtifact rejects oversized PNG payloads before writing', () => {
+  const sessionId = 'sess-test-large-' + Date.now()
+  try {
+    const oversized = 'data:image/png;base64,' + 'A'.repeat(Math.ceil((16 * 1024 * 1024 * 4) / 3) + 32)
+    assert.throws(() => saveChartArtifact({
+      sessionId,
+      toolCallId: 'tool-large',
+      toolName: 'render_chart',
+      dataUrl: oversized,
+    }), /payload is too large/)
+    assert.equal(existsSync(getChartArtifactsRoot(sessionId)), false)
+  } finally {
+    cleanup(sessionId)
+  }
+})
+
 test('saveChartArtifact persists chart metadata for rerender flows', () => {
   const sessionId = 'sess-test-chart-meta-' + Date.now()
   try {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import type { CustomMcpConfig } from '@open-cowork/shared'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
-import { registerAppHandlers } from '../apps/desktop/src/main/ipc/app-handlers.ts'
+import { registerAppHandlers, resolveSafeSaveTextPath } from '../apps/desktop/src/main/ipc/app-handlers.ts'
 import { registerArtifactHandlers } from '../apps/desktop/src/main/ipc/artifact-handlers.ts'
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
@@ -334,6 +334,63 @@ test('question:reply clears the answered request locally so queued questions adv
   }
 })
 
+test('question:reply rejects malformed answers before runtime dispatch', async () => {
+  const { context, handlers } = createBaseContext()
+  let clientRequested = false
+  context.getSessionV2Client = async () => {
+    clientRequested = true
+    throw new Error('runtime should not be reached')
+  }
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('question:reply')
+  assert.ok(handler, 'expected question:reply handler to be registered')
+
+  await assert.rejects(
+    () => handler({}, 'session-question-bounds', 'question-1', 'not-an-array'),
+    /Question answers must be an array/,
+  )
+  assert.equal(clientRequested, false)
+})
+
+test('command:run rejects oversized command names before runtime dispatch', async () => {
+  const { context, handlers } = createBaseContext()
+  let clientRequested = false
+  context.getSessionClient = async () => {
+    clientRequested = true
+    throw new Error('runtime should not be reached')
+  }
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('command:run')
+  assert.ok(handler, 'expected command:run handler to be registered')
+
+  await assert.rejects(
+    () => handler({}, 'session-command-bounds', 'x'.repeat(257)),
+    /Command name exceeds 256 bytes/,
+  )
+  assert.equal(clientRequested, false)
+})
+
+test('session:rename rejects empty titles before runtime dispatch', async () => {
+  const { context, handlers } = createBaseContext()
+  let clientRequested = false
+  context.getSessionClient = async () => {
+    clientRequested = true
+    throw new Error('runtime should not be reached')
+  }
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('session:rename')
+  assert.ok(handler, 'expected session:rename handler to be registered')
+
+  await assert.rejects(
+    () => handler({}, 'session-rename-bounds', '   '),
+    /Session title is required/,
+  )
+  assert.equal(clientRequested, false)
+})
+
 test('question:reject clears the rejected request locally', async () => {
   const { context, handlers } = createBaseContext()
   const sessionId = 'question-ipc-reject-session'
@@ -540,5 +597,18 @@ test('dialog:save-text rejects oversized renderer content before opening a save 
   await assert.rejects(
     () => handler({}, 'agent.cowork-agent.json', 'x'.repeat((2 * 1024 * 1024) + 1)),
     /Save content is too large/,
+  )
+})
+
+test('dialog:save-text path policy keeps exports as non-sensitive json files', () => {
+  assert.equal(resolveSafeSaveTextPath('/tmp/agent'), '/tmp/agent.json')
+  assert.equal(resolveSafeSaveTextPath('/tmp/agent.cowork-agent.json'), '/tmp/agent.cowork-agent.json')
+  assert.throws(
+    () => resolveSafeSaveTextPath('/tmp/agent.md'),
+    /must use a \.json extension/,
+  )
+  assert.throws(
+    () => resolveSafeSaveTextPath('/Users/example/.ssh/config'),
+    /sensitive configuration path/,
   )
 })

--- a/tests/main-window-lifecycle.test.ts
+++ b/tests/main-window-lifecycle.test.ts
@@ -2,9 +2,11 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   isExpectedPackagedRendererFile,
+  isTrustedRendererIpcUrl,
   needsMainWindowRecovery,
   pickRecoverableMainWindow,
   rendererUrlLooksWrong,
+  rendererUrlMatchesDevServer,
   shouldRecoverMainWindowFromDidFailLoad,
 } from '../apps/desktop/src/main/main-window-lifecycle.ts'
 
@@ -41,6 +43,34 @@ test('isExpectedPackagedRendererFile only allows the packaged renderer entry', (
     isExpectedPackagedRendererFile('https://example.com/index.html', expected),
     false,
   )
+})
+
+test('rendererUrlMatchesDevServer requires the exact dev-server origin', () => {
+  assert.equal(rendererUrlMatchesDevServer('http://127.0.0.1:5173', 'http://127.0.0.1:5173'), true)
+  assert.equal(rendererUrlMatchesDevServer('http://127.0.0.1:5173/src/App.tsx', 'http://127.0.0.1:5173'), true)
+  assert.equal(rendererUrlMatchesDevServer('http://127.0.0.1:51730', 'http://127.0.0.1:5173'), false)
+  assert.equal(rendererUrlMatchesDevServer('https://example.com', 'http://127.0.0.1:5173'), false)
+})
+
+test('isTrustedRendererIpcUrl accepts only packaged renderer or configured dev shell', () => {
+  const expected = '/Applications/Open Cowork.app/Contents/Resources/app.asar/dist/index.html'
+  assert.equal(isTrustedRendererIpcUrl({
+    rawUrl: 'file:///Applications/Open%20Cowork.app/Contents/Resources/app.asar/dist/index.html',
+    expectedRendererPath: expected,
+  }), true)
+  assert.equal(isTrustedRendererIpcUrl({
+    rawUrl: 'file:///Applications/Open%20Cowork.app/Contents/Resources/app.asar/dist/startup-splash.html',
+    expectedRendererPath: expected,
+  }), false)
+  assert.equal(isTrustedRendererIpcUrl({
+    rawUrl: 'http://127.0.0.1:5173',
+    devServerUrl: 'http://127.0.0.1:5173',
+    expectedRendererPath: expected,
+  }), true)
+  assert.equal(isTrustedRendererIpcUrl({
+    rawUrl: 'https://example.com/index.html',
+    expectedRendererPath: expected,
+  }), false)
 })
 
 test('pickRecoverableMainWindow keeps a live current window and falls back when needed', () => {

--- a/tests/session-store-reducer.test.ts
+++ b/tests/session-store-reducer.test.ts
@@ -169,6 +169,49 @@ test('renderer live permission requests do not advance the session event clock',
   assert.equal(state.sessionStateById['session-1']?.lastEventAt, 200)
 })
 
+test('renderer store drops chart artifacts when a session is removed', () => {
+  useSessionStore.setState({
+    sessions: [{
+      id: 'session-with-chart',
+      title: 'Chart session',
+      createdAt: '2026-05-04T00:00:00.000Z',
+      updatedAt: '2026-05-04T00:00:00.000Z',
+    }],
+    currentSessionId: null,
+    currentView: deriveVisibleSessionPatch(createEmptySessionViewState(), null, new Set<string>(), new Set<string>()),
+    globalErrors: [],
+    mcpConnections: [],
+    agentMode: 'build',
+    totalCost: 0,
+    sidebarCollapsed: false,
+    busySessions: new Set<string>(),
+    awaitingPermissionSessions: new Set<string>(),
+    awaitingQuestionSessions: new Set<string>(),
+    sessionStateById: {
+      'session-with-chart': createEmptySessionViewState(),
+    },
+    chartArtifactsBySession: {
+      'session-with-chart': [{
+        id: 'artifact-1',
+        toolId: 'tool-1',
+        toolName: 'render_chart',
+        filePath: '/tmp/chart.png',
+        filename: 'chart.png',
+        order: 1,
+        taskRunId: null,
+        mime: 'image/png',
+      }],
+    },
+  })
+
+  useSessionStore.getState().removeSession('session-with-chart')
+
+  const state = useSessionStore.getState()
+  assert.equal(state.sessions.length, 0)
+  assert.deepEqual(state.chartArtifactsBySession, {})
+  assert.equal(state.sessionStateById['session-with-chart'], undefined)
+})
+
 test('session view snapshots do not wipe newer locally streamed text', () => {
   const existing = createEmptySessionViewState({
     hydrated: true,


### PR DESCRIPTION
## Summary

Hardens the concrete findings proven from the external audits without changing the v0.0.0 preview version/signing posture.

- Bounds and normalizes chart artifact saves so renderer-provided session IDs cannot escape the chart artifact root, and PNG/metadata payloads have explicit caps.
- Adds central IPC sender-frame validation so `ipcMain.handle` and `ipcMain.on` only accept the packaged renderer entry or configured dev renderer origin.
- Adds bounds and shape validation for session command, rename, and question response IPC inputs before dispatching to OpenCode SDK calls.
- Tightens JSON export writes to keep `dialog:save-text` outputs as `.json` and reject sensitive config paths.
- Fixes smaller hygiene/a11y items: third-party license directory freshness in CI, chart artifact store cleanup on session deletion, automations form accessible names, sidebar `aria-current`, and keyboard access to the thread context menu.

## Validation

- Targeted: `chart-artifacts.test.ts`, `ipc-handler-behavior.test.ts`, `session-store-reducer.test.ts`, `main-window-lifecycle.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:a11y --max-warnings=0`
- `pnpm test` — 674 tests passing
- `pnpm test:renderer` — 22 tests passing
- `pnpm build`
- `pnpm test:e2e`
- `pnpm perf:check`
- `pnpm audit --prod --audit-level high`
- `pnpm docs:build`
- `pnpm notices`
- `git diff --check`

## Notes

Version/date/signing findings from the audits are intentionally not changed here because v0.0.0 is being re-released as the explicit preview build.