### PR TITLE
Revamp automations into Kanban board

### DIFF
--- a/THIRD_PARTY_LICENSES/@dnd-kit__accessibility@3.1.1/LICENSE
+++ b/THIRD_PARTY_LICENSES/@dnd-kit__accessibility@3.1.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021, Claudéric Demers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD_PARTY_LICENSES/@dnd-kit__core@6.3.1/LICENSE
+++ b/THIRD_PARTY_LICENSES/@dnd-kit__core@6.3.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021, Claudéric Demers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD_PARTY_LICENSES/@dnd-kit__utilities@3.2.2/LICENSE
+++ b/THIRD_PARTY_LICENSES/@dnd-kit__utilities@3.2.2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021, Claudéric Demers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -13,6 +13,9 @@ Each package remains licensed under its own license terms. The table below is pr
 | @chevrotain/regexp-to-ast | 12.0.0 | Apache-2.0 | THIRD_PARTY_LICENSES/@chevrotain__regexp-to-ast@12.0.0/ | git://github.com/Chevrotain/chevrotain.git |
 | @chevrotain/types | 12.0.0 | Apache-2.0 | THIRD_PARTY_LICENSES/@chevrotain__types@12.0.0/ | git://github.com/Chevrotain/chevrotain.git |
 | @chevrotain/utils | 12.0.0 | Apache-2.0 | THIRD_PARTY_LICENSES/@chevrotain__utils@12.0.0/ | git://github.com/Chevrotain/chevrotain.git |
+| @dnd-kit/accessibility | 3.1.1 | MIT | THIRD_PARTY_LICENSES/@dnd-kit__accessibility@3.1.1/ | git+https://github.com/clauderic/dnd-kit.git |
+| @dnd-kit/core | 6.3.1 | MIT | THIRD_PARTY_LICENSES/@dnd-kit__core@6.3.1/ | git+https://github.com/clauderic/dnd-kit.git |
+| @dnd-kit/utilities | 3.2.2 | MIT | THIRD_PARTY_LICENSES/@dnd-kit__utilities@3.2.2/ | git+https://github.com/clauderic/dnd-kit.git |
 | @hono/node-server | 1.19.13 | MIT | THIRD_PARTY_LICENSES/@hono__node-server@1.19.13/ | https://github.com/honojs/node-server.git |
 | @iconify/types | 2.0.0 | MIT | THIRD_PARTY_LICENSES/@iconify__types@2.0.0/ | https://github.com/iconify/iconify.git |
 | @iconify/utils | 3.1.0 | MIT | THIRD_PARTY_LICENSES/@iconify__utils@3.1.0/ | https://github.com/iconify/iconify.git |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,7 @@
     "dist:ci:linux": "node ../../scripts/desktop-dist.mjs --linux AppImage deb --x64 --publish never"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "1.14.33",
     "@tanstack/react-virtual": "^3.13.24",

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AutomationListPayload, AutomationRun, AutomationSummary } from '@open-cowork/shared'
+import { AutomationBoard } from './AutomationBoard'
+import {
+  buildAutomationBoard,
+  buildAutomationCardModel,
+  resolveAutomationDropAction,
+} from './automation-board-support'
+
+function automation(overrides: Partial<AutomationSummary>): AutomationSummary {
+  return {
+    id: overrides.id || 'auto-1',
+    title: overrides.title || 'Weekly report',
+    goal: overrides.goal || 'Keep a weekly report ready for review.',
+    kind: overrides.kind || 'recurring',
+    status: overrides.status || 'draft',
+    schedule: overrides.schedule || {
+      type: 'weekly',
+      timezone: 'UTC',
+      dayOfWeek: 1,
+      runAtHour: 9,
+      runAtMinute: 0,
+    },
+    heartbeatMinutes: overrides.heartbeatMinutes ?? 15,
+    retryPolicy: overrides.retryPolicy || {
+      maxRetries: 3,
+      baseDelayMinutes: 5,
+      maxDelayMinutes: 60,
+    },
+    runPolicy: overrides.runPolicy || {
+      dailyRunCap: 6,
+      maxRunDurationMinutes: 120,
+    },
+    executionMode: overrides.executionMode || 'planning_only',
+    autonomyPolicy: overrides.autonomyPolicy || 'review-first',
+    projectDirectory: overrides.projectDirectory ?? null,
+    preferredAgentNames: overrides.preferredAgentNames || [],
+    createdAt: overrides.createdAt || '2026-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt || '2026-01-01T00:00:00.000Z',
+    nextRunAt: overrides.nextRunAt ?? null,
+    lastRunAt: overrides.lastRunAt ?? null,
+    nextHeartbeatAt: overrides.nextHeartbeatAt ?? null,
+    lastHeartbeatAt: overrides.lastHeartbeatAt ?? null,
+    latestRunStatus: overrides.latestRunStatus ?? null,
+    latestRunId: overrides.latestRunId ?? null,
+  }
+}
+
+function run(overrides: Partial<AutomationRun>): AutomationRun {
+  return {
+    id: overrides.id || 'run-1',
+    automationId: overrides.automationId || 'auto-1',
+    sessionId: overrides.sessionId ?? null,
+    kind: overrides.kind || 'execution',
+    status: overrides.status || 'running',
+    title: overrides.title || 'Execute report',
+    summary: overrides.summary ?? null,
+    error: overrides.error ?? null,
+    failureCode: overrides.failureCode ?? null,
+    attempt: overrides.attempt ?? 1,
+    retryOfRunId: overrides.retryOfRunId ?? null,
+    nextRetryAt: overrides.nextRetryAt ?? null,
+    createdAt: overrides.createdAt || '2026-01-01T01:00:00.000Z',
+    startedAt: overrides.startedAt ?? null,
+    finishedAt: overrides.finishedAt ?? null,
+  }
+}
+
+function payload(overrides: Partial<AutomationListPayload> = {}): AutomationListPayload {
+  return {
+    automations: [],
+    inbox: [],
+    workItems: [],
+    runs: [],
+    deliveries: [],
+    ...overrides,
+  }
+}
+
+describe('AutomationBoard support', () => {
+  it('groups automations into lifecycle columns by priority', () => {
+    const data = payload({
+      automations: [
+        automation({ id: 'draft', title: 'Draft task', status: 'draft' }),
+        automation({ id: 'planning', title: 'Planning task', status: 'running' }),
+        automation({ id: 'review', title: 'Review task', status: 'needs_user' }),
+        automation({ id: 'ready', title: 'Ready task', status: 'ready' }),
+        automation({ id: 'delivered', title: 'Delivered task', status: 'completed' }),
+        automation({ id: 'paused', title: 'Paused task', status: 'paused' }),
+      ],
+      inbox: [{
+        id: 'inbox-1',
+        automationId: 'review',
+        runId: null,
+        sessionId: null,
+        questionId: null,
+        type: 'approval',
+        status: 'open',
+        title: 'Approve',
+        body: 'Approve the brief.',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }],
+      runs: [run({ automationId: 'planning', kind: 'enrichment' })],
+      deliveries: [{
+        id: 'delivery-1',
+        automationId: 'delivered',
+        runId: null,
+        provider: 'in_app',
+        target: 'automation-inbox',
+        status: 'delivered',
+        title: 'Output ready',
+        body: 'Done.',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }],
+    })
+
+    const board = buildAutomationBoard(data)
+
+    expect(board.find((column) => column.id === 'draft')?.cards.map((card) => card.automation.id)).toEqual(['draft'])
+    expect(board.find((column) => column.id === 'planning')?.cards.map((card) => card.automation.id)).toEqual(['planning'])
+    expect(board.find((column) => column.id === 'needs-review')?.cards.map((card) => card.automation.id)).toEqual(['review'])
+    expect(board.find((column) => column.id === 'ready-running')?.cards.map((card) => card.automation.id)).toEqual(['ready'])
+    expect(board.find((column) => column.id === 'delivered')?.cards.map((card) => card.automation.id)).toEqual(['delivered'])
+    expect(board.find((column) => column.id === 'paused')?.cards.map((card) => card.automation.id)).toEqual(['paused'])
+  })
+
+  it('maps supported drops to existing automation actions', () => {
+    const draftPayload = payload({ automations: [automation({ id: 'draft', status: 'draft' })] })
+    const draftAction = resolveAutomationDropAction(buildAutomationCardModel(draftPayload, draftPayload.automations[0]!), 'planning')
+    expect(draftAction).toMatchObject({ valid: true, type: 'previewBrief', confirm: false })
+
+    const reviewPayload = payload({
+      automations: [automation({ id: 'review', status: 'needs_user' })],
+      inbox: [{
+        id: 'approval',
+        automationId: 'review',
+        runId: null,
+        sessionId: null,
+        questionId: null,
+        type: 'approval',
+        status: 'open',
+        title: 'Approve',
+        body: 'Approve.',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    })
+    const approveAction = resolveAutomationDropAction(buildAutomationCardModel(reviewPayload, reviewPayload.automations[0]!), 'ready-running')
+    expect(approveAction).toMatchObject({ valid: true, type: 'approveBrief', confirm: true })
+
+    const invalidAction = resolveAutomationDropAction(buildAutomationCardModel(draftPayload, draftPayload.automations[0]!), 'delivered')
+    expect(invalidAction.valid).toBe(false)
+  })
+})
+
+describe('AutomationBoard', () => {
+  it('renders stats, columns, and cards', () => {
+    render(
+      <AutomationBoard
+        payload={payload({ automations: [automation({ title: 'Weekly report' })] })}
+        selectedAutomationId={null}
+        onSelectAutomation={vi.fn()}
+        onDropAutomation={vi.fn()}
+        onNewAutomation={vi.fn()}
+        onLearnMore={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('1 active')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Backlog' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Weekly report/ })).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import type { AutomationListPayload } from '@open-cowork/shared'
+import { AutomationCard } from './AutomationCard'
+import {
+  AUTOMATION_COLUMNS,
+  buildAutomationBoard,
+  buildAutomationCardModel,
+  summarizeAutomationBoard,
+  type AutomationColumn,
+  type AutomationColumnId,
+} from './automation-board-support'
+import { AUTOMATION_TEMPLATES } from './automations-page-support'
+
+type Props = {
+  payload: AutomationListPayload
+  selectedAutomationId: string | null
+  onSelectAutomation: (automationId: string) => void
+  onDropAutomation: (automationId: string, targetColumn: AutomationColumnId) => void
+  onNewAutomation: (templateId?: string) => void
+  onLearnMore: () => void
+  feedback?: string | null
+}
+
+function AutomationColumnView({
+  column,
+  selectedAutomationId,
+  onSelectAutomation,
+}: {
+  column: AutomationColumn
+  selectedAutomationId: string | null
+  onSelectAutomation: (automationId: string) => void
+}) {
+  const { isOver, setNodeRef } = useDroppable({ id: column.id })
+  return (
+    <section
+      ref={setNodeRef}
+      className="flex h-full min-h-[520px] w-[280px] shrink-0 flex-col rounded-2xl border border-border-subtle"
+      style={{
+        background: isOver ? 'color-mix(in srgb, var(--color-accent) 8%, var(--color-elevated))' : 'var(--color-elevated)',
+      }}
+      aria-label={`${column.title} automations`}
+    >
+      <div className="border-b border-border-subtle px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-[13px] font-semibold text-text">{column.title}</h2>
+          <span className="rounded-full border border-border px-2 py-0.5 text-[10px] text-text-muted">{column.cards.length}</span>
+        </div>
+        <p className="mt-1 min-h-8 text-[11px] leading-4 text-text-muted">{column.description}</p>
+      </div>
+      <div className="flex-1 space-y-3 overflow-y-auto p-3">
+        {column.cards.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border-subtle px-3 py-8 text-center text-[11px] leading-5 text-text-muted">
+            Drop a supported automation here or use a card action.
+          </div>
+        ) : column.cards.map((card) => (
+          <AutomationCard
+            key={card.automation.id}
+            card={card}
+            selected={selectedAutomationId === card.automation.id}
+            onSelect={onSelectAutomation}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function EmptyBoard({
+  onNewAutomation,
+  onLearnMore,
+}: {
+  onNewAutomation: (templateId?: string) => void
+  onLearnMore: () => void
+}) {
+  return (
+    <div className="grid min-h-[520px] gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+      <div className="rounded-3xl border border-border-subtle p-6" style={{ background: 'var(--color-elevated)' }}>
+        <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">Automations</div>
+        <h2 className="mt-2 text-[28px] font-semibold text-text">Turn repeatable work into a standing agent program</h2>
+        <p className="mt-3 text-[14px] leading-7 text-text-secondary">
+          Start with a small recurring task. Cowork plans it, asks for review when needed, and runs the approved work through OpenCode.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => onNewAutomation()}
+            className="rounded-xl px-4 py-2 text-[13px] font-medium cursor-pointer"
+            style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}
+          >
+            New automation
+          </button>
+          <button type="button" onClick={onLearnMore} className="rounded-xl border border-border px-4 py-2 text-[13px] cursor-pointer">
+            Learn more
+          </button>
+        </div>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {AUTOMATION_TEMPLATES.map((template) => (
+          <button
+            key={template.id}
+            type="button"
+            onClick={() => onNewAutomation(template.id)}
+            className="rounded-2xl border border-dashed border-border-subtle p-4 text-left transition-colors hover:bg-surface-hover cursor-pointer"
+            style={{ background: 'color-mix(in srgb, var(--color-elevated) 72%, transparent)' }}
+          >
+            <div className="text-[11px] uppercase tracking-[0.16em] text-text-muted">Template</div>
+            <div className="mt-2 text-[15px] font-semibold text-text">{template.label}</div>
+            <p className="mt-2 text-[12px] leading-6 text-text-secondary">{template.description}</p>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function AutomationBoard({
+  payload,
+  selectedAutomationId,
+  onSelectAutomation,
+  onDropAutomation,
+  onNewAutomation,
+  onLearnMore,
+  feedback,
+}: Props) {
+  const [activeCardId, setActiveCardId] = useState<string | null>(null)
+  const columns = useMemo(() => buildAutomationBoard(payload), [payload])
+  const stats = useMemo(() => summarizeAutomationBoard(payload), [payload])
+  const cardById = useMemo(() => {
+    return new Map(payload.automations.map((automation) => [
+      automation.id,
+      buildAutomationCardModel(payload, automation),
+    ]))
+  }, [payload])
+  const activeCard = activeCardId ? cardById.get(activeCardId) || null : null
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor),
+  )
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveCardId(String(event.active.id))
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveCardId(null)
+    const targetColumn = event.over?.id
+    if (!targetColumn || !AUTOMATION_COLUMNS.some((column) => column.id === targetColumn)) return
+    onDropAutomation(String(event.active.id), targetColumn as AutomationColumnId)
+  }
+
+  if (payload.automations.length === 0) {
+    return <EmptyBoard onNewAutomation={onNewAutomation} onLearnMore={onLearnMore} />
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2 text-[12px] text-text-secondary">
+          <span className="rounded-full border border-border px-3 py-1">{stats.active} active</span>
+          <span className="rounded-full border border-border px-3 py-1">{stats.needsReview} need review</span>
+          <span className="rounded-full border border-border px-3 py-1">{stats.running} running</span>
+          <span className="rounded-full border border-border px-3 py-1">{stats.delivered} delivered</span>
+        </div>
+        <div className="flex gap-2">
+          <button type="button" onClick={onLearnMore} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">
+            Learn more
+          </button>
+          <button
+            type="button"
+            onClick={() => onNewAutomation()}
+            className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer"
+            style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}
+          >
+            New Automation
+          </button>
+        </div>
+      </div>
+      {feedback ? (
+        <div className="mb-3 rounded-xl border border-border-subtle px-4 py-2 text-[12px] text-text-secondary" role="status">
+          {feedback}
+        </div>
+      ) : null}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={() => setActiveCardId(null)}>
+        <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto pb-3" aria-label="Automation lifecycle board">
+          {columns.map((column) => (
+            <AutomationColumnView
+              key={column.id}
+              column={column}
+              selectedAutomationId={selectedAutomationId}
+              onSelectAutomation={onSelectAutomation}
+            />
+          ))}
+        </div>
+        <DragOverlay>
+          {activeCard ? (
+            <div className="w-[280px]">
+              <AutomationCard card={activeCard} selected={false} onSelect={() => undefined} dragDisabled />
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
@@ -1,0 +1,102 @@
+import { useDraggable } from '@dnd-kit/core'
+import type { AutomationCardModel } from './automation-board-support'
+import { formatStatus } from './automations-page-support'
+
+type Props = {
+  card: AutomationCardModel
+  selected: boolean
+  onSelect: (automationId: string) => void
+  dragDisabled?: boolean
+}
+
+function progressPercent(completed: number, total: number) {
+  if (total <= 0) return 0
+  return Math.max(0, Math.min(100, Math.round((completed / total) * 100)))
+}
+
+function statusTone(card: AutomationCardModel) {
+  if (card.automation.status === 'failed' || card.inbox.some((item) => item.type === 'failure')) return 'var(--color-red)'
+  if (card.hasBlockingInbox) return 'var(--color-warning)'
+  if (card.activeRun) return 'var(--color-accent)'
+  if (card.columnId === 'delivered') return 'var(--color-green)'
+  return 'var(--color-text-muted)'
+}
+
+export function AutomationCard({ card, selected, onSelect, dragDisabled = false }: Props) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: card.automation.id,
+    disabled: dragDisabled || card.automation.status === 'archived',
+    data: { type: 'automation-card' },
+  })
+  const progress = progressPercent(card.workProgress.completed, card.workProgress.total)
+  const tone = statusTone(card)
+  const style = {
+    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+    opacity: isDragging ? 0.55 : 1,
+    borderColor: selected ? 'var(--color-accent)' : 'var(--color-border-subtle)',
+    boxShadow: selected ? '0 0 0 1px var(--color-accent)' : undefined,
+  }
+
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      onClick={() => onSelect(card.automation.id)}
+      className="group w-full rounded-xl border p-3 text-left transition-colors hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-accent cursor-pointer"
+      style={style}
+      aria-label={`${card.automation.title}, ${formatStatus(card.automation.status)}, ${card.scheduleLabel}`}
+      {...attributes}
+      {...listeners}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: tone }} />
+          <span className="truncate text-[10px] uppercase tracking-[0.14em] text-text-muted">
+            {card.automation.kind === 'managed-project' ? 'project' : 'recurring'}
+          </span>
+        </div>
+        <span className="shrink-0 rounded-full border border-border px-2 py-0.5 text-[10px] text-text-muted">
+          {formatStatus(card.automation.status)}
+        </span>
+      </div>
+
+      <div className="mt-3 line-clamp-2 text-[13px] font-semibold leading-5 text-text">{card.automation.title}</div>
+      <div className="mt-1 line-clamp-2 text-[11px] leading-5 text-text-secondary">{card.automation.goal}</div>
+      <div className="mt-3 text-[11px] text-text-muted">{card.scheduleLabel}</div>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {card.inboxCount > 0 ? (
+          <span className="rounded-full px-2 py-0.5 text-[10px]" style={{ background: 'color-mix(in srgb, var(--color-warning) 14%, transparent)', color: 'var(--color-warning)' }}>
+            {card.inboxCount} inbox
+          </span>
+        ) : null}
+        {card.activeRun ? (
+          <span className="rounded-full px-2 py-0.5 text-[10px]" style={{ background: 'color-mix(in srgb, var(--color-accent) 14%, transparent)', color: 'var(--color-accent)' }}>
+            {card.activeRun.kind}
+          </span>
+        ) : null}
+        {card.latestRun?.nextRetryAt ? (
+          <span className="rounded-full px-2 py-0.5 text-[10px]" style={{ background: 'color-mix(in srgb, var(--color-red) 12%, transparent)', color: 'var(--color-red)' }}>
+            retry queued
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-3">
+        <div className="flex items-center justify-between text-[10px] text-text-muted">
+          <span>{card.workProgress.total > 0 ? `${card.workProgress.completed}/${card.workProgress.total} items` : 'No work items yet'}</span>
+          <span className="truncate ps-2">{card.latestActivityLabel}</span>
+        </div>
+        <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-surface-active">
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${progress}%`,
+              background: tone,
+            }}
+          />
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
@@ -1,0 +1,404 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import type {
+  AutomationDeliveryRecord,
+  AutomationDetail,
+  AutomationDraft,
+  AutomationInboxItem,
+  AutomationRun,
+  AutomationWorkItem,
+} from '@open-cowork/shared'
+import { ModalBackdrop } from '../layout/ModalBackdrop'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import {
+  AgentTeamSelector,
+  dailyRunAttemptCapLabel,
+  dailyRunAttemptCapPlaceholder,
+  deriveNextAction,
+  deriveReliabilityState,
+  describeRunPolicy,
+  DetailGroup,
+  DetailSection,
+  formatSchedule,
+  formatStatus,
+  formatTimestamp,
+  latestRunSummary,
+  resolveAgentLabels,
+  SummaryCard,
+  summarizeWorkItems,
+  type AutomationAgentOption,
+} from './automations-page-support'
+
+type DetailTab = 'now' | 'brief' | 'work' | 'history' | 'settings'
+
+type Props = {
+  automation: AutomationDetail
+  inbox: AutomationInboxItem[]
+  workItems: AutomationWorkItem[]
+  runs: AutomationRun[]
+  deliveries: AutomationDeliveryRecord[]
+  agentOptions: AutomationAgentOption[]
+  onClose: () => void
+  onOpenThread?: (sessionId: string) => void
+  onPatch: (patch: Partial<AutomationDraft>) => Promise<void>
+  onPreviewBrief: () => Promise<void>
+  onApproveBrief: () => Promise<void>
+  onRunNow: () => Promise<void>
+  onPause: () => Promise<void>
+  onResume: () => Promise<void>
+  onArchive: () => Promise<void>
+  onCancelRun: (runId: string) => Promise<void>
+  onRetryRun: (runId: string) => Promise<void>
+  onInboxRespond: (itemId: string, response: string) => Promise<void>
+  onInboxDismiss: (itemId: string) => Promise<void>
+}
+
+function PanelField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="block">
+      <span className="text-[11px] uppercase tracking-[0.14em] text-text-muted">{label}</span>
+      <div className="mt-2">{children}</div>
+    </label>
+  )
+}
+
+function tabLabel(tab: DetailTab) {
+  if (tab === 'now') return 'Now'
+  if (tab === 'brief') return 'Brief'
+  if (tab === 'work') return 'Work'
+  if (tab === 'history') return 'History'
+  return 'Settings'
+}
+
+export function AutomationCardDetail({
+  automation,
+  inbox,
+  workItems,
+  runs,
+  deliveries,
+  agentOptions,
+  onClose,
+  onOpenThread,
+  onPatch,
+  onPreviewBrief,
+  onApproveBrief,
+  onRunNow,
+  onPause,
+  onResume,
+  onArchive,
+  onCancelRun,
+  onRetryRun,
+  onInboxRespond,
+  onInboxDismiss,
+}: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const [tab, setTab] = useState<DetailTab>('now')
+  const [edit, setEdit] = useState({
+    title: automation.title,
+    goal: automation.goal,
+    projectDirectory: automation.projectDirectory,
+    preferredAgentNames: automation.preferredAgentNames,
+    runPolicy: automation.runPolicy,
+  })
+  const [replies, setReplies] = useState<Record<string, string>>({})
+  const [saving, setSaving] = useState(false)
+  useFocusTrap(panelRef, { onEscape: onClose })
+
+  useEffect(() => {
+    setEdit({
+      title: automation.title,
+      goal: automation.goal,
+      projectDirectory: automation.projectDirectory,
+      preferredAgentNames: automation.preferredAgentNames,
+      runPolicy: automation.runPolicy,
+    })
+  }, [automation.id, automation.title, automation.goal, automation.projectDirectory, automation.preferredAgentNames, automation.runPolicy])
+
+  useEffect(() => {
+    setTab('now')
+  }, [automation.id])
+
+  const activeRun = useMemo(() => runs.find((run) => run.status === 'queued' || run.status === 'running') || null, [runs])
+  const latestRun = runs[0] || null
+  const latestDelivery = deliveries[0] || null
+  const backlog = useMemo(() => summarizeWorkItems(workItems), [workItems])
+  const nextAction = useMemo(() => deriveNextAction({ automation, inbox, activeRun, latestRun, latestDelivery }), [automation, inbox, activeRun, latestRun, latestDelivery])
+  const reliability = useMemo(() => deriveReliabilityState({ automation, inbox, activeRun, latestRun }), [automation, inbox, activeRun, latestRun])
+  const preferredAgentLabels = useMemo(() => resolveAgentLabels(automation.preferredAgentNames, agentOptions), [automation.preferredAgentNames, agentOptions])
+  const isArchived = automation.status === 'archived'
+  const hasActiveRun = Boolean(activeRun)
+  const canRun = !isArchived && !hasActiveRun && Boolean(automation.brief?.approvedAt)
+
+  const saveEdits = async () => {
+    setSaving(true)
+    try {
+      await onPatch({
+        title: edit.title,
+        goal: edit.goal,
+        projectDirectory: edit.projectDirectory,
+        preferredAgentNames: edit.preferredAgentNames,
+        runPolicy: edit.runPolicy,
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <ModalBackdrop onDismiss={onClose} className="fixed inset-0 z-40 bg-black/30" />
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-detail-title"
+        className="fixed bottom-0 right-0 top-0 z-50 flex w-[760px] max-w-full flex-col border-l border-border-subtle shadow-2xl"
+        style={{ background: 'var(--color-base)' }}
+      >
+        <div className="border-b border-border-subtle px-5 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">{automation.kind === 'managed-project' ? 'Managed project' : 'Recurring program'}</div>
+              <h2 id="automation-detail-title" className="mt-1 text-[24px] font-semibold text-text">{automation.title}</h2>
+              <p className="mt-2 max-w-2xl text-[13px] leading-6 text-text-secondary">{automation.goal}</p>
+              <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-muted">
+                <span>{formatStatus(automation.status)}</span>
+                <span>{formatSchedule(automation.schedule)}</span>
+                <span>{automation.executionMode === 'scoped_execution' ? 'Scoped execution' : 'Planning only'}</span>
+                <span>{automation.autonomyPolicy}</span>
+                {preferredAgentLabels.length > 0 ? <span>Team {preferredAgentLabels.join(', ')}</span> : null}
+              </div>
+            </div>
+            <button type="button" onClick={onClose} aria-label="Close automation details" className="text-[22px] leading-none text-text-muted hover:text-text cursor-pointer">×</button>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {automation.status === 'draft' || !automation.brief ? (
+              <button type="button" disabled={hasActiveRun || isArchived} onClick={() => void onPreviewBrief()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">Preview brief</button>
+            ) : null}
+            {inbox.some((item) => item.type === 'approval') ? (
+              <button type="button" disabled={isArchived} onClick={() => void onApproveBrief()} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer disabled:opacity-50" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>Approve brief</button>
+            ) : null}
+            {canRun ? (
+              <button type="button" onClick={() => void onRunNow()} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>Run now</button>
+            ) : null}
+            {activeRun ? (
+              <button type="button" onClick={() => void onCancelRun(activeRun.id)} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Cancel run</button>
+            ) : null}
+            {automation.status === 'paused' ? (
+              <button type="button" onClick={() => void onResume()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Resume</button>
+            ) : (
+              <button type="button" disabled={isArchived} onClick={() => void onPause()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">Pause</button>
+            )}
+            <button type="button" disabled={hasActiveRun || isArchived} onClick={() => void onArchive()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">Archive</button>
+          </div>
+        </div>
+
+        <div className="flex gap-2 overflow-x-auto border-b border-border-subtle px-5 py-3">
+          {(['now', 'brief', 'work', 'history', 'settings'] as DetailTab[]).map((entry) => (
+            <button
+              key={entry}
+              type="button"
+              onClick={() => setTab(entry)}
+              className="rounded-full border px-3 py-1.5 text-[11px] cursor-pointer"
+              style={{
+                borderColor: tab === entry ? 'var(--color-accent)' : 'var(--color-border)',
+                color: tab === entry ? 'var(--color-accent)' : 'var(--color-text-muted)',
+              }}
+            >
+              {tabLabel(entry)}
+            </button>
+          ))}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-5">
+          {tab === 'now' ? (
+            <div className="space-y-5">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <SummaryCard label="Next step" value={nextAction} detail={activeRun ? `Active run: ${activeRun.title}` : latestRunSummary(latestRun)} accent />
+                <SummaryCard label="Reliability" value={reliability.value} detail={reliability.detail} compact />
+                <SummaryCard label="Run policy" value={dailyRunAttemptCapLabel(automation.runPolicy.dailyRunCap)} detail={describeRunPolicy(automation, latestRun)} compact />
+              </div>
+              <DetailSection title="Attention">
+                {inbox.length === 0 ? (
+                  <div className="text-[12px] text-text-muted">No open inbox items.</div>
+                ) : (
+                  <div className="space-y-3">
+                    {inbox.map((item) => (
+                      <div key={item.id} className="rounded-xl border border-border px-3 py-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="text-[12px] font-medium text-text">{item.title}</div>
+                          <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{item.type}</span>
+                        </div>
+                        <div className="mt-1 whitespace-pre-wrap text-[12px] text-text-secondary">{item.body}</div>
+                        {item.questionId ? (
+                          <div className="mt-3 flex gap-2">
+                            <input
+                              value={replies[item.id] || ''}
+                              onChange={(event) => setReplies((current) => ({ ...current, [item.id]: event.target.value }))}
+                              placeholder="Reply to continue"
+                              className="min-w-0 flex-1 rounded-xl border border-border bg-transparent px-3 py-2 text-[12px]"
+                            />
+                            <button type="button" onClick={() => void onInboxRespond(item.id, replies[item.id] || '')} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>
+                              Send
+                            </button>
+                          </div>
+                        ) : null}
+                        {item.type === 'approval' ? (
+                          <button type="button" disabled={isArchived} onClick={() => void onApproveBrief()} className="mt-3 rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer disabled:opacity-50" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>
+                            Approve brief
+                          </button>
+                        ) : null}
+                        <button type="button" onClick={() => void onInboxDismiss(item.id)} className="mt-3 text-[11px] text-text-muted underline cursor-pointer">Dismiss</button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </DetailSection>
+              {latestDelivery ? (
+                <DetailSection title="Latest delivery">
+                  <div className="text-[12px] font-medium text-text">{latestDelivery.title}</div>
+                  <div className="mt-1 text-[11px] text-text-muted">{latestDelivery.provider} · {formatTimestamp(latestDelivery.createdAt)}</div>
+                  <div className="mt-2 whitespace-pre-wrap text-[12px] leading-6 text-text-secondary">{latestDelivery.body}</div>
+                </DetailSection>
+              ) : null}
+            </div>
+          ) : null}
+
+          {tab === 'brief' ? (
+            <DetailSection
+              title="Execution brief"
+              action={automation.latestSessionId && onOpenThread ? (
+                <button type="button" onClick={() => onOpenThread(automation.latestSessionId!)} className="text-[11px] text-text-muted underline cursor-pointer">Open linked thread</button>
+              ) : undefined}
+            >
+              {automation.brief ? (
+                <div className="space-y-4 text-[12px]">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <DetailGroup label="Deliverables" values={automation.brief.deliverables} empty="No deliverables specified yet" />
+                    <DetailGroup label="Recommended agents" values={automation.brief.recommendedAgents} empty="Use standard plan/build routing" />
+                    <DetailGroup label="Preferred specialists" values={preferredAgentLabels} empty="No preferred specialist team configured" />
+                    <DetailGroup label="Assumptions" values={automation.brief.assumptions} />
+                    <DetailGroup label="Success criteria" values={automation.brief.successCriteria} />
+                    <DetailGroup label="Missing context" values={automation.brief.missingContext} empty="No missing context" />
+                  </div>
+                  <div>
+                    <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Approval boundary</div>
+                    <div className="mt-2 text-[12px] leading-6 text-text-secondary">{automation.brief.approvalBoundary}</div>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-[12px] text-text-muted">No execution brief yet. Preview the brief to route this through the plan agent.</div>
+              )}
+            </DetailSection>
+          ) : null}
+
+          {tab === 'work' ? (
+            <DetailSection title="Work items">
+              <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+                <SummaryCard label="Total" value={String(backlog.total)} detail="Items in this brief" />
+                <SummaryCard label="Completed" value={String(backlog.completed)} detail="Finished work" />
+                <SummaryCard label="Ready" value={String(backlog.ready + backlog.running)} detail="Ready or running" />
+                <SummaryCard label="Blocked" value={String(backlog.blocked + backlog.failed)} detail="Blocked or failed" />
+              </div>
+              <div className="space-y-3">
+                {workItems.length === 0 ? (
+                  <div className="text-[12px] text-text-muted">Work items appear after enrichment.</div>
+                ) : workItems.map((item) => (
+                  <div key={item.id} className="rounded-xl border border-border px-3 py-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-[12px] font-medium text-text">{item.title}</div>
+                      <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{item.status}</span>
+                    </div>
+                    <div className="mt-1 text-[12px] leading-6 text-text-secondary">{item.description}</div>
+                    <div className="mt-2 text-[11px] text-text-muted">
+                      {item.ownerAgent ? `Owner: ${item.ownerAgent}` : 'Owner decided at runtime'}
+                      {item.dependsOn.length > 0 ? ` · depends on ${item.dependsOn.join(', ')}` : ''}
+                      {item.blockingReason ? ` · ${item.blockingReason}` : ''}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </DetailSection>
+          ) : null}
+
+          {tab === 'history' ? (
+            <DetailSection title="Run timeline">
+              <div className="space-y-3">
+                {runs.length === 0 ? (
+                  <div className="text-[12px] text-text-muted">No runs yet.</div>
+                ) : runs.map((run) => (
+                  <div key={run.id} className="rounded-xl border border-border px-3 py-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-[12px] font-medium text-text">{run.title}</div>
+                      <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{run.status}</span>
+                    </div>
+                    <div className="mt-1 text-[11px] text-text-muted">{formatTimestamp(run.createdAt)} · attempt {run.attempt}{run.nextRetryAt ? ` · retrying ${formatTimestamp(run.nextRetryAt)}` : ''}</div>
+                    {run.summary ? <div className="mt-2 whitespace-pre-wrap text-[12px] text-text-secondary">{run.summary}</div> : null}
+                    {run.error ? <div className="mt-2 text-[12px]" style={{ color: 'var(--color-red)' }}>{run.error}</div> : null}
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {run.status === 'running' ? (
+                        <button type="button" onClick={() => void onCancelRun(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Cancel run</button>
+                      ) : null}
+                      {run.status === 'failed' || run.status === 'cancelled' ? (
+                        <button type="button" disabled={isArchived || hasActiveRun} onClick={() => void onRetryRun(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer disabled:opacity-50">Retry run</button>
+                      ) : null}
+                      {run.sessionId && onOpenThread ? (
+                        <button type="button" onClick={() => onOpenThread(run.sessionId!)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Open thread</button>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </DetailSection>
+          ) : null}
+
+          {tab === 'settings' ? (
+            <DetailSection title="Quick settings">
+              <div className="grid gap-3 md:grid-cols-2">
+                <PanelField label="Title">
+                  <input value={edit.title} onChange={(event) => setEdit((current) => ({ ...current, title: event.target.value }))} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                </PanelField>
+                <PanelField label="Project directory">
+                  <div className="flex gap-2">
+                    <input value={edit.projectDirectory || ''} readOnly className="min-w-0 flex-1 rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="Optional project directory" />
+                    <button type="button" onClick={async () => {
+                      const selected = await window.coworkApi.dialog.selectDirectory()
+                      if (selected) setEdit((current) => ({ ...current, projectDirectory: selected }))
+                    }} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Browse</button>
+                    {edit.projectDirectory ? (
+                      <button type="button" onClick={() => setEdit((current) => ({ ...current, projectDirectory: null }))} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Clear</button>
+                    ) : null}
+                  </div>
+                </PanelField>
+                <PanelField label="Goal">
+                  <textarea value={edit.goal} onChange={(event) => setEdit((current) => ({ ...current, goal: event.target.value }))} rows={5} className="w-full resize-y rounded-xl border border-border bg-transparent px-3 py-2 text-[13px] md:col-span-2" />
+                </PanelField>
+                <PanelField label="Daily run cap">
+                  <input type="number" min={1} value={edit.runPolicy.dailyRunCap} onChange={(event) => setEdit((current) => ({
+                    ...current,
+                    runPolicy: { ...current.runPolicy, dailyRunCap: Math.max(1, Number.parseInt(event.target.value, 10) || 1) },
+                  }))} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder={dailyRunAttemptCapPlaceholder()} />
+                </PanelField>
+                <PanelField label="Max run duration minutes">
+                  <input type="number" min={1} value={edit.runPolicy.maxRunDurationMinutes} onChange={(event) => setEdit((current) => ({
+                    ...current,
+                    runPolicy: { ...current.runPolicy, maxRunDurationMinutes: Math.max(1, Number.parseInt(event.target.value, 10) || 1) },
+                  }))} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                </PanelField>
+              </div>
+              <div className="mt-4">
+                <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Preferred specialists</div>
+                <div className="mt-2">
+                  <AgentTeamSelector options={agentOptions} value={edit.preferredAgentNames} onChange={(preferredAgentNames) => setEdit((current) => ({ ...current, preferredAgentNames }))} />
+                </div>
+              </div>
+              <button type="button" onClick={() => void saveEdits()} disabled={saving} className="mt-4 rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">
+                {saving ? 'Saving…' : 'Save edits'}
+              </button>
+            </DetailSection>
+          ) : null}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useRef, useState } from 'react'
+import { ModalBackdrop } from '../layout/ModalBackdrop'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import {
+  AgentTeamSelector,
+  AUTOMATION_TEMPLATES,
+  createDefaultDraft,
+  dailyRunAttemptCapPlaceholder,
+  draftToPayload,
+  type AutomationAgentOption,
+  type DraftState,
+} from './automations-page-support'
+import type { AutomationAutonomyPolicy, AutomationExecutionMode, AutomationKind, AutomationScheduleType } from '@open-cowork/shared'
+
+type Props = {
+  defaults: DraftState
+  onCreate: (draft: DraftState) => Promise<void>
+  onClose: () => void
+  loadAgentOptions: (directory: string | null | undefined, selectedNames: string[]) => Promise<AutomationAgentOption[]>
+}
+
+const STEPS = ['What & Why', 'When & How', 'Review & Create']
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="text-[11px] uppercase tracking-[0.14em] text-text-muted">{label}</span>
+      <div className="mt-2">{children}</div>
+    </label>
+  )
+}
+
+function SegmentedButton({
+  selected,
+  title,
+  detail,
+  onClick,
+}: {
+  selected: boolean
+  title: string
+  detail: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-xl border px-3 py-3 text-left transition-colors cursor-pointer"
+      style={{
+        borderColor: selected ? 'var(--color-accent)' : 'var(--color-border)',
+        background: selected ? 'color-mix(in srgb, var(--color-accent) 10%, transparent)' : 'transparent',
+      }}
+    >
+      <div className="text-[13px] font-semibold text-text">{title}</div>
+      <div className="mt-1 text-[11px] leading-5 text-text-secondary">{detail}</div>
+    </button>
+  )
+}
+
+function validateWizardDraft(draft: DraftState) {
+  if (!draft.title.trim()) return 'Automation title is required.'
+  if (!draft.goal.trim()) return 'Automation goal is required.'
+  if (draft.executionMode === 'scoped_execution' && !draft.projectDirectory.trim()) {
+    return 'Scoped execution automations require a project directory.'
+  }
+  if (draft.scheduleType === 'one_time' && !draft.startAt.trim()) {
+    return 'One-time automations require a start date and time.'
+  }
+  try {
+    draftToPayload(draft)
+  } catch {
+    return 'Check the schedule fields before creating this automation.'
+  }
+  return null
+}
+
+export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentOptions }: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const [step, setStep] = useState(0)
+  const [draft, setDraft] = useState<DraftState>(() => ({ ...createDefaultDraft(), ...defaults }))
+  const [agentOptions, setAgentOptions] = useState<AutomationAgentOption[]>([])
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  useFocusTrap(dialogRef, { onEscape: saving ? undefined : onClose })
+
+  useEffect(() => {
+    let cancelled = false
+    void loadAgentOptions(draft.projectDirectory, draft.preferredAgentNames).then((options) => {
+      if (!cancelled) setAgentOptions(options)
+    }).catch(() => {
+      if (!cancelled) setAgentOptions([])
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [draft.projectDirectory, draft.preferredAgentNames, loadAgentOptions])
+
+  const updateDraft = (patch: Partial<DraftState>) => setDraft((current) => ({ ...current, ...patch }))
+  const goNext = () => {
+    setError(null)
+    if (step === 0 && (!draft.title.trim() || !draft.goal.trim())) {
+      setError('Add a title and goal before choosing schedule details.')
+      return
+    }
+    if (step === 1 && draft.executionMode === 'scoped_execution' && !draft.projectDirectory.trim()) {
+      setError('Scoped execution automations require a project directory.')
+      return
+    }
+    setStep((current) => Math.min(STEPS.length - 1, current + 1))
+  }
+  const submit = async () => {
+    const validation = validateWizardDraft(draft)
+    if (validation) {
+      setError(validation)
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await onCreate(draft)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create automation.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <ModalBackdrop onDismiss={saving ? () => undefined : onClose} className="fixed inset-0 z-50 bg-black/50" />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-wizard-title"
+        className="fixed left-1/2 top-[5vh] z-50 flex max-h-[90vh] w-[760px] max-w-[94vw] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border border-border-subtle shadow-2xl"
+        style={{ background: 'var(--color-base)' }}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-border-subtle px-5 py-4">
+          <div>
+            <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">New automation</div>
+            <h2 id="automation-wizard-title" className="mt-1 text-[18px] font-semibold text-text">{STEPS[step]}</h2>
+          </div>
+          <button type="button" onClick={onClose} disabled={saving} aria-label="Close wizard" className="text-[22px] leading-none text-text-muted hover:text-text cursor-pointer disabled:opacity-50">×</button>
+        </div>
+
+        <div className="flex gap-2 border-b border-border-subtle px-5 py-3">
+          {STEPS.map((label, index) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => setStep(index)}
+              className="rounded-full border px-3 py-1 text-[11px] cursor-pointer"
+              style={{
+                borderColor: index === step ? 'var(--color-accent)' : 'var(--color-border)',
+                color: index === step ? 'var(--color-accent)' : 'var(--color-text-muted)',
+              }}
+            >
+              {index + 1}. {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+          {error ? (
+            <div className="mb-4 rounded-xl border border-border-subtle px-4 py-3 text-[12px]" style={{ color: 'var(--color-red)', background: 'color-mix(in srgb, var(--color-red) 8%, transparent)' }} role="alert">
+              {error}
+            </div>
+          ) : null}
+
+          {step === 0 ? (
+            <div className="space-y-5">
+              <div className="grid gap-3 sm:grid-cols-2">
+                {AUTOMATION_TEMPLATES.map((template) => (
+                  <button
+                    key={template.id}
+                    type="button"
+                    onClick={() => setDraft((current) => template.apply(current))}
+                    className="rounded-xl border border-border px-4 py-3 text-left transition-colors hover:bg-surface-hover cursor-pointer"
+                    title={template.description}
+                  >
+                    <div className="text-[13px] font-semibold text-text">{template.label}</div>
+                    <div className="mt-1 text-[11px] leading-5 text-text-secondary">{template.description}</div>
+                  </button>
+                ))}
+              </div>
+              <Field label="Title">
+                <input autoFocus value={draft.title} onChange={(event) => updateDraft({ title: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="Weekly market report" />
+              </Field>
+              <Field label="Goal">
+                <textarea value={draft.goal} onChange={(event) => updateDraft({ goal: event.target.value })} rows={6} className="w-full resize-y rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="Describe the repeated outcome Cowork should keep moving." />
+              </Field>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <SegmentedButton selected={draft.kind === 'recurring'} title="Recurring program" detail="Repeats on a schedule and produces a regular output." onClick={() => updateDraft({ kind: 'recurring' as AutomationKind })} />
+                <SegmentedButton selected={draft.kind === 'managed-project'} title="Managed project" detail="Keeps a standing body of work planned and moving." onClick={() => updateDraft({ kind: 'managed-project' as AutomationKind })} />
+              </div>
+            </div>
+          ) : null}
+
+          {step === 1 ? (
+            <div className="space-y-5">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Field label="Schedule">
+                  <select value={draft.scheduleType} onChange={(event) => updateDraft({ scheduleType: event.target.value as AutomationScheduleType })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]">
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                    <option value="monthly">Monthly</option>
+                    <option value="one_time">One-time</option>
+                  </select>
+                </Field>
+                <Field label="Timezone">
+                  <input value={draft.timezone} onChange={(event) => updateDraft({ timezone: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                </Field>
+                <Field label="Run hour">
+                  <input value={draft.runAtHour} onChange={(event) => updateDraft({ runAtHour: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="9" />
+                </Field>
+                <Field label="Run minute">
+                  <input value={draft.runAtMinute} onChange={(event) => updateDraft({ runAtMinute: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="0" />
+                </Field>
+                {draft.scheduleType === 'weekly' ? (
+                  <Field label="Day of week">
+                    <input value={draft.dayOfWeek} onChange={(event) => updateDraft({ dayOfWeek: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="1" />
+                  </Field>
+                ) : null}
+                {draft.scheduleType === 'monthly' ? (
+                  <Field label="Day of month">
+                    <input value={draft.dayOfMonth} onChange={(event) => updateDraft({ dayOfMonth: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="1" />
+                  </Field>
+                ) : null}
+                {draft.scheduleType === 'one_time' ? (
+                  <Field label="Start date and time">
+                    <input type="datetime-local" value={draft.startAt} onChange={(event) => updateDraft({ startAt: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                  </Field>
+                ) : null}
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <SegmentedButton selected={draft.autonomyPolicy === 'review-first'} title="Review first" detail="Cowork asks before executing a new brief." onClick={() => updateDraft({ autonomyPolicy: 'review-first' as AutomationAutonomyPolicy })} />
+                <SegmentedButton selected={draft.autonomyPolicy === 'mostly-autonomous'} title="Mostly autonomous" detail="Cowork can continue after planning when no review is needed." onClick={() => updateDraft({ autonomyPolicy: 'mostly-autonomous' as AutomationAutonomyPolicy })} />
+                <SegmentedButton selected={draft.executionMode === 'planning_only'} title="Planning only" detail="Good for research, briefs, and inbox-ready output." onClick={() => updateDraft({ executionMode: 'planning_only' as AutomationExecutionMode })} />
+                <SegmentedButton selected={draft.executionMode === 'scoped_execution'} title="Scoped execution" detail="Runs against an explicit project directory." onClick={() => updateDraft({ executionMode: 'scoped_execution' as AutomationExecutionMode })} />
+              </div>
+              {draft.executionMode === 'scoped_execution' ? (
+                <Field label="Project directory">
+                  <div className="flex gap-2">
+                    <input value={draft.projectDirectory} readOnly className="min-w-0 flex-1 rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="Choose a project directory" />
+                    <button type="button" onClick={async () => {
+                      const selected = await window.coworkApi.dialog.selectDirectory()
+                      if (selected) updateDraft({ projectDirectory: selected })
+                    }} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">
+                      Browse
+                    </button>
+                    {draft.projectDirectory ? (
+                      <button type="button" onClick={() => updateDraft({ projectDirectory: '' })} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">
+                        Clear
+                      </button>
+                    ) : null}
+                  </div>
+                </Field>
+              ) : null}
+            </div>
+          ) : null}
+
+          {step === 2 ? (
+            <div className="space-y-5">
+              <div className="rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>
+                <div className="text-[15px] font-semibold text-text">{draft.title || 'Untitled automation'}</div>
+                <p className="mt-2 text-[12px] leading-6 text-text-secondary">{draft.goal || 'No goal yet.'}</p>
+                <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-muted">
+                  <span>{draft.kind === 'managed-project' ? 'Managed project' : 'Recurring program'}</span>
+                  <span>{draft.scheduleType}</span>
+                  <span>{draft.autonomyPolicy}</span>
+                  <span>{draft.executionMode === 'scoped_execution' ? 'Scoped execution' : 'Planning only'}</span>
+                </div>
+              </div>
+              <button type="button" onClick={() => setAdvancedOpen((current) => !current)} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">
+                {advancedOpen ? 'Hide advanced settings' : 'Show advanced settings'}
+              </button>
+              {advancedOpen ? (
+                <div className="space-y-4 rounded-2xl border border-border-subtle p-4">
+                  <div>
+                    <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Preferred specialists</div>
+                    <div className="mt-2">
+                      <AgentTeamSelector
+                        options={agentOptions}
+                        value={draft.preferredAgentNames}
+                        onChange={(preferredAgentNames) => updateDraft({ preferredAgentNames })}
+                        emptyLabel="No specialist agents are available yet. Cowork will use default routing."
+                      />
+                    </div>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <Field label="Heartbeat minutes">
+                      <input value={draft.heartbeatMinutes} onChange={(event) => updateDraft({ heartbeatMinutes: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                    </Field>
+                    <Field label="Max retries">
+                      <input value={draft.maxRetries} onChange={(event) => updateDraft({ maxRetries: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                    </Field>
+                    <Field label="Base retry delay">
+                      <input value={draft.retryBaseDelayMinutes} onChange={(event) => updateDraft({ retryBaseDelayMinutes: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                    </Field>
+                    <Field label="Max retry delay">
+                      <input value={draft.retryMaxDelayMinutes} onChange={(event) => updateDraft({ retryMaxDelayMinutes: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                    </Field>
+                    <Field label="Daily run cap">
+                      <input value={draft.dailyRunCap} onChange={(event) => updateDraft({ dailyRunCap: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder={dailyRunAttemptCapPlaceholder()} />
+                    </Field>
+                    <Field label="Max run duration">
+                      <input value={draft.maxRunDurationMinutes} onChange={(event) => updateDraft({ maxRunDurationMinutes: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" />
+                    </Field>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex items-center justify-between gap-3 border-t border-border-subtle px-5 py-4">
+          <button type="button" onClick={onClose} disabled={saving} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">
+            Cancel
+          </button>
+          <div className="flex gap-2">
+            <button type="button" onClick={() => setStep((current) => Math.max(0, current - 1))} disabled={step === 0 || saving} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">
+              Back
+            </button>
+            {step < STEPS.length - 1 ? (
+              <button type="button" onClick={goNext} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>
+                Continue
+              </button>
+            ) : (
+              <button type="button" onClick={() => void submit()} disabled={saving} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer disabled:opacity-50" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>
+                {saving ? 'Creating…' : 'Create automation'}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -1,37 +1,28 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type {
-  AutomationAutonomyPolicy,
   AutomationDetail,
   AutomationDraft,
-  AutomationExecutionMode,
-  AutomationKind,
   AutomationListPayload,
-  AutomationScheduleType,
   BuiltInAgentDetail,
   CustomAgentSummary,
 } from '@open-cowork/shared'
+import { ModalBackdrop } from '../layout/ModalBackdrop'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
 import { t } from '../../helpers/i18n'
+import { AutomationBoard } from './AutomationBoard'
+import { AutomationCardDetail } from './AutomationCardDetail'
+import { AutomationCreateWizard } from './AutomationCreateWizard'
 import {
-  AgentTeamSelector,
+  buildAutomationCardModel,
+  resolveAutomationDropAction,
+  type AutomationColumnId,
+  type AutomationDropAction,
+} from './automation-board-support'
+import {
   AUTOMATION_TEMPLATES,
   buildAutomationAgentOptions,
   createDefaultDraft,
-  dailyRunAttemptCapLabel,
-  dailyRunAttemptCapPlaceholder,
-  deriveNextAction,
-  deriveReliabilityState,
-  describeRunPolicy,
-  DetailGroup,
-  DetailSection,
   draftToPayload,
-  formatSchedule,
-  formatStatus,
-  formatTimestamp,
-  latestRunSummary,
-  pluralize,
-  resolveAgentLabels,
-  summarizeWorkItems,
-  SummaryCard,
   type AutomationAgentOption,
   type DraftState,
 } from './automations-page-support'
@@ -40,17 +31,98 @@ type Props = {
   onOpenThread?: (sessionId: string) => void
 }
 
+function HelpDrawer({ onClose }: { onClose: () => void }) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(panelRef, { onEscape: onClose })
+  return (
+    <>
+      <ModalBackdrop onDismiss={onClose} className="fixed inset-0 z-40 bg-black/30" />
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-help-title"
+        className="fixed bottom-0 right-0 top-0 z-50 flex w-[460px] max-w-full flex-col border-l border-border-subtle shadow-2xl"
+        style={{ background: 'var(--color-base)' }}
+      >
+        <div className="border-b border-border-subtle px-5 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">How it works</div>
+              <h2 id="automation-help-title" className="mt-1 text-[20px] font-semibold text-text">Standing agent programs</h2>
+            </div>
+            <button type="button" onClick={onClose} aria-label="Close help" className="text-[22px] leading-none text-text-muted hover:text-text cursor-pointer">×</button>
+          </div>
+        </div>
+        <div className="space-y-4 overflow-y-auto p-5">
+          {[
+            ['1. Enrich', 'Cowork routes the raw ask through OpenCode plan and turns it into an execution-ready brief.'],
+            ['2. Review', 'Approvals, missing context, and failures become Inbox items so the automation pauses instead of guessing.'],
+            ['3. Execute', 'Approved work runs through OpenCode build and specialist subagents, then lands as in-app delivery.'],
+          ].map(([title, body]) => (
+            <div key={title} className="rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>
+              <div className="text-[13px] font-semibold text-text">{title}</div>
+              <div className="mt-2 text-[12px] leading-6 text-text-secondary">{body}</div>
+            </div>
+          ))}
+          <div className="rounded-2xl border border-border-subtle p-4 text-[12px] leading-6 text-text-secondary">
+            Drag a card to another lifecycle column when the board offers a valid shortcut. Risky actions ask for confirmation before Cowork calls the existing automation action.
+          </div>
+        </div>
+      </aside>
+    </>
+  )
+}
+
+function ConfirmDropDialog({
+  action,
+  onCancel,
+  onConfirm,
+}: {
+  action: Extract<AutomationDropAction, { valid: true }>
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(dialogRef, { onEscape: onCancel })
+  return (
+    <>
+      <ModalBackdrop onDismiss={onCancel} />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-drop-confirm-title"
+        className="fixed left-1/2 top-[28vh] z-50 w-[420px] max-w-[92vw] -translate-x-1/2 rounded-2xl border border-border-subtle p-5 shadow-2xl"
+        style={{ background: 'var(--color-base)' }}
+      >
+        <h2 id="automation-drop-confirm-title" className="text-[16px] font-semibold text-text">{action.title}</h2>
+        <p className="mt-2 text-[13px] leading-6 text-text-secondary">{action.message}</p>
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Cancel</button>
+          <button type="button" onClick={onConfirm} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>
+            Confirm
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}
+
 export function AutomationsPage({ onOpenThread }: Props) {
   const [payload, setPayload] = useState<AutomationListPayload>({ automations: [], inbox: [], workItems: [], runs: [], deliveries: [] })
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null)
   const [selectedAutomation, setSelectedAutomation] = useState<AutomationDetail | null>(null)
-  const [draftDefaults, setDraftDefaults] = useState<DraftState>(() => createDefaultDraft())
-  const [draft, setDraft] = useState<DraftState>(() => createDefaultDraft())
-  const [draftAgentOptions, setDraftAgentOptions] = useState<AutomationAgentOption[]>([])
   const [selectedAgentOptions, setSelectedAgentOptions] = useState<AutomationAgentOption[]>([])
+  const [draftDefaults, setDraftDefaults] = useState<DraftState>(() => createDefaultDraft())
+  const [wizardDefaults, setWizardDefaults] = useState<DraftState>(() => createDefaultDraft())
+  const [wizardOpen, setWizardOpen] = useState(false)
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [pendingDropAction, setPendingDropAction] = useState<Extract<AutomationDropAction, { valid: true }> | null>(null)
+  const [feedback, setFeedback] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [inboxReplies, setInboxReplies] = useState<Record<string, string>>({})
+  const selectedAutomationIdRef = useRef<string | null>(null)
 
   const loadAgentOptions = useCallback(async (directory: string | null | undefined, selectedNames: string[]) => {
     const context = directory?.trim() ? { directory: directory.trim() } : undefined
@@ -65,13 +137,20 @@ export function AutomationsPage({ onOpenThread }: Props) {
     })
   }, [])
 
+  useEffect(() => {
+    selectedAutomationIdRef.current = selectedAutomationId
+  }, [selectedAutomationId])
+
   const refresh = useCallback(async (preferredAutomationId?: string | null) => {
     setLoading(true)
     setError(null)
     try {
       const nextPayload = await window.coworkApi.automation.list()
       setPayload(nextPayload)
-      const resolvedId = preferredAutomationId ?? selectedAutomationId ?? nextPayload.automations[0]?.id ?? null
+      const candidateId = preferredAutomationId === undefined ? selectedAutomationIdRef.current : preferredAutomationId
+      const resolvedId = candidateId && nextPayload.automations.some((automation) => automation.id === candidateId)
+        ? candidateId
+        : null
       setSelectedAutomationId(resolvedId)
       setSelectedAutomation(resolvedId ? await window.coworkApi.automation.get(resolvedId) : null)
     } catch (err) {
@@ -79,10 +158,10 @@ export function AutomationsPage({ onOpenThread }: Props) {
     } finally {
       setLoading(false)
     }
-  }, [selectedAutomationId])
+  }, [])
 
   useEffect(() => {
-    void refresh()
+    void refresh(null)
     return window.coworkApi.on.automationUpdated(() => {
       void refresh()
     })
@@ -92,14 +171,11 @@ export function AutomationsPage({ onOpenThread }: Props) {
     let cancelled = false
     void window.coworkApi.settings.get().then((settings) => {
       if (cancelled) return
-      const defaults = createDefaultDraft({
+      setDraftDefaults(createDefaultDraft({
         autonomyPolicy: settings.defaultAutomationAutonomyPolicy,
         executionMode: settings.defaultAutomationExecutionMode,
-      })
-      setDraftDefaults(defaults)
-      setDraft((current) => ({
-        ...defaults,
-        ...current,
+      }))
+      setWizardDefaults(createDefaultDraft({
         autonomyPolicy: settings.defaultAutomationAutonomyPolicy,
         executionMode: settings.defaultAutomationExecutionMode,
       }))
@@ -110,18 +186,6 @@ export function AutomationsPage({ onOpenThread }: Props) {
       cancelled = true
     }
   }, [])
-
-  useEffect(() => {
-    let cancelled = false
-    void loadAgentOptions(draft.projectDirectory, draft.preferredAgentNames).then((options) => {
-      if (!cancelled) setDraftAgentOptions(options)
-    }).catch(() => {
-      if (!cancelled) setDraftAgentOptions([])
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [draft.projectDirectory, draft.preferredAgentNames, loadAgentOptions])
 
   useEffect(() => {
     let cancelled = false
@@ -139,764 +203,168 @@ export function AutomationsPage({ onOpenThread }: Props) {
     return () => {
       cancelled = true
     }
-  }, [selectedAutomation?.projectDirectory, selectedAutomation?.preferredAgentNames, loadAgentOptions])
+  }, [selectedAutomation, loadAgentOptions])
 
-  const automationInbox = useMemo(
-    () => payload.inbox.filter((item) => item.automationId === selectedAutomationId),
-    [payload.inbox, selectedAutomationId],
-  )
-  const automationWorkItems = useMemo(
-    () => payload.workItems.filter((item) => item.automationId === selectedAutomationId),
-    [payload.workItems, selectedAutomationId],
-  )
-  const automationRuns = useMemo(
-    () => payload.runs.filter((item) => item.automationId === selectedAutomationId),
-    [payload.runs, selectedAutomationId],
-  )
-  const automationDeliveries = useMemo(
-    () => payload.deliveries.filter((item) => item.automationId === selectedAutomationId),
-    [payload.deliveries, selectedAutomationId],
-  )
-  const activeRun = useMemo(
-    () => automationRuns.find((run) => run.status === 'queued' || run.status === 'running') || null,
-    [automationRuns],
-  )
-  const latestRun = automationRuns[0] || null
-  const latestDelivery = automationDeliveries[0] || null
-  const backlog = useMemo(
-    () => summarizeWorkItems(automationWorkItems),
-    [automationWorkItems],
-  )
-  const overview = useMemo(() => {
-    const activeAutomations = payload.automations.filter((automation) => automation.status !== 'archived').length
-    const runningRuns = payload.runs.filter((run) => run.status === 'queued' || run.status === 'running').length
-    const failedRuns = payload.runs.filter((run) => run.status === 'failed').length
-    const latestActivity = payload.runs[0] || null
-    return {
-      totalAutomations: payload.automations.length,
-      activeAutomations,
-      inboxCount: payload.inbox.length,
-      runningRuns,
-      failedRuns,
-      deliveryCount: payload.deliveries.length,
-      latestActivity,
-    }
-  }, [payload])
-  const selectedNextAction = useMemo(
-    () => selectedAutomation
-      ? deriveNextAction({
-        automation: selectedAutomation,
-        inbox: automationInbox,
-        activeRun,
-        latestRun,
-        latestDelivery,
-      })
-      : '',
-    [selectedAutomation, automationInbox, activeRun, latestRun, latestDelivery],
-  )
-  const selectedPreferredAgentLabels = useMemo(
-    () => selectedAutomation ? resolveAgentLabels(selectedAutomation.preferredAgentNames, selectedAgentOptions) : [],
-    [selectedAutomation, selectedAgentOptions],
-  )
-  const reliability = useMemo(
-    () => selectedAutomation
-      ? deriveReliabilityState({
-        automation: selectedAutomation,
-        inbox: automationInbox,
-        activeRun,
-        latestRun,
-      })
-      : null,
-    [selectedAutomation, automationInbox, activeRun, latestRun],
-  )
-  const hasActiveRun = Boolean(activeRun)
-  const isArchived = selectedAutomation?.status === 'archived'
-  const controlsLocked = hasActiveRun || isArchived
-
-  const submitDraft = async () => {
+  const selectAutomation = async (automationId: string) => {
+    setError(null)
     try {
-      const created = await window.coworkApi.automation.create(draftToPayload(draft))
-      setDraft(draftDefaults)
-      await refresh(created.id)
+      setSelectedAutomationId(automationId)
+      setSelectedAutomation(await window.coworkApi.automation.get(automationId))
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create automation.')
+      setError(err instanceof Error ? err.message : 'Failed to open automation.')
     }
+  }
+
+  const selectedInbox = useMemo(() => payload.inbox.filter((item) => item.automationId === selectedAutomationId), [payload.inbox, selectedAutomationId])
+  const selectedWorkItems = useMemo(() => payload.workItems.filter((item) => item.automationId === selectedAutomationId), [payload.workItems, selectedAutomationId])
+  const selectedRuns = useMemo(() => payload.runs.filter((item) => item.automationId === selectedAutomationId), [payload.runs, selectedAutomationId])
+  const selectedDeliveries = useMemo(() => payload.deliveries.filter((item) => item.automationId === selectedAutomationId), [payload.deliveries, selectedAutomationId])
+
+  const executeDropAction = async (action: Extract<AutomationDropAction, { valid: true }>) => {
+    setFeedback(null)
+    setError(null)
+    try {
+      if (action.type === 'previewBrief') await window.coworkApi.automation.previewBrief(action.automationId)
+      if (action.type === 'approveBrief') await window.coworkApi.automation.approveBrief(action.automationId)
+      if (action.type === 'runNow') await window.coworkApi.automation.runNow(action.automationId)
+      if (action.type === 'pause') await window.coworkApi.automation.pause(action.automationId)
+      if (action.type === 'resume') await window.coworkApi.automation.resume(action.automationId)
+      setFeedback(action.message)
+      await refresh(action.automationId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to move automation.')
+    }
+  }
+
+  const handleDropAutomation = (automationId: string, targetColumn: AutomationColumnId) => {
+    const automation = payload.automations.find((entry) => entry.id === automationId)
+    if (!automation) return
+    const action = resolveAutomationDropAction(buildAutomationCardModel(payload, automation), targetColumn)
+    if (!action.valid) {
+      setFeedback(action.message)
+      return
+    }
+    if (action.confirm) {
+      setPendingDropAction(action)
+      return
+    }
+    void executeDropAction(action)
+  }
+
+  const createAutomation = async (draft: DraftState) => {
+    const created = await window.coworkApi.automation.create(draftToPayload(draft))
+    await refresh(created.id)
+  }
+
+  const openWizard = (templateId?: string) => {
+    const template = templateId ? AUTOMATION_TEMPLATES.find((entry) => entry.id === templateId) : null
+    setWizardDefaults(template ? template.apply(draftDefaults) : draftDefaults)
+    setWizardOpen(true)
   }
 
   const patchSelected = async (patch: Partial<AutomationDraft>) => {
     if (!selectedAutomationId) return
+    setError(null)
+    setFeedback(null)
     try {
       const updated = await window.coworkApi.automation.update(selectedAutomationId, patch)
       await refresh(updated?.id || selectedAutomationId)
+      setFeedback('Automation settings saved.')
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update automation.')
+      setError(err instanceof Error ? err.message : 'Failed to save automation settings.')
     }
   }
 
-  const updateDraft = (patch: Partial<DraftState>) => setDraft((current) => ({ ...current, ...patch }))
+  const runAndRefresh = async (callback: () => Promise<unknown>) => {
+    if (!selectedAutomationId) return
+    setError(null)
+    setFeedback(null)
+    try {
+      await callback()
+      await refresh(selectedAutomationId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Automation action failed.')
+    }
+  }
 
   return (
-    <div className="flex min-h-0 flex-1">
-      <aside className="w-[340px] shrink-0 border-r border-border-subtle p-4 overflow-y-auto">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">{t('automations.label', 'Automations')}</div>
-            <h1 className="mt-1 text-[20px] font-semibold text-text">{t('automations.title', 'Always-on work')}</h1>
-          </div>
-          {loading ? <span className="text-[11px] text-text-muted">{t('common.loading', 'Loading…')}</span> : null}
+    <div className="flex min-h-0 flex-1 flex-col p-5">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">{t('automations.label', 'Automations')}</div>
+          <h1 className="mt-1 text-[24px] font-semibold text-text">{t('automations.title', 'Always-on work')}</h1>
+          <p className="mt-2 max-w-2xl text-[13px] leading-6 text-text-secondary">
+            See every standing agent program by lifecycle stage. Drag supported cards to trigger existing actions, or open a card for focused details.
+          </p>
         </div>
+        {loading ? <div className="text-[11px] text-text-muted">{t('common.loading', 'Loading…')}</div> : null}
+      </div>
 
-        <div className="mt-5 rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>
-          <div className="text-[13px] font-semibold text-text">{t('automations.create', 'New automation')}</div>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {AUTOMATION_TEMPLATES.map((template) => (
-              <button
-                key={template.id}
-                type="button"
-                onClick={() => setDraft((current) => template.apply(current))}
-                className="rounded-full border border-border px-3 py-1.5 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover cursor-pointer"
-                title={template.description}
-              >
-                {template.label}
-              </button>
-            ))}
-          </div>
-          <div className="mt-3 flex flex-col gap-3">
-            <input
-              value={draft.title}
-              onChange={(event) => updateDraft({ title: event.target.value })}
-              aria-label={t('automations.titleLabel', 'Automation title')}
-              placeholder={t('automations.titlePlaceholder', 'Weekly market report')}
-              className="rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent"
-            />
-            <textarea
-              value={draft.goal}
-              onChange={(event) => updateDraft({ goal: event.target.value })}
-              rows={5}
-              aria-label={t('automations.goalLabel', 'Automation goal')}
-              placeholder={t('automations.goalPlaceholder', 'Build a weekly analysis and market research report and keep it ready for review every Monday morning.')}
-              className="rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent resize-y"
-            />
-            <div className="grid grid-cols-2 gap-2">
-              <select value={draft.kind} onChange={(event) => updateDraft({ kind: event.target.value as AutomationKind })} aria-label={t('automations.kindLabel', 'Automation type')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
-                <option value="recurring">Recurring program</option>
-                <option value="managed-project">Managed project</option>
-              </select>
-              <select value={draft.scheduleType} onChange={(event) => updateDraft({ scheduleType: event.target.value as AutomationScheduleType })} aria-label={t('automations.scheduleTypeLabel', 'Schedule type')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
-                <option value="weekly">Weekly</option>
-                <option value="daily">Daily</option>
-                <option value="monthly">Monthly</option>
-                <option value="one_time">One-time</option>
-              </select>
-            </div>
-            <input value={draft.timezone} onChange={(event) => updateDraft({ timezone: event.target.value })} aria-label={t('automations.timezoneLabel', 'Timezone')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Europe/Amsterdam" />
-            <div className="grid grid-cols-2 gap-2">
-              <input value={draft.runAtHour} onChange={(event) => updateDraft({ runAtHour: event.target.value })} aria-label={t('automations.runAtHourLabel', 'Run hour')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Hour" />
-              <input value={draft.runAtMinute} onChange={(event) => updateDraft({ runAtMinute: event.target.value })} aria-label={t('automations.runAtMinuteLabel', 'Run minute')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Minute" />
-            </div>
-            {draft.scheduleType === 'weekly' && (
-              <input value={draft.dayOfWeek} onChange={(event) => updateDraft({ dayOfWeek: event.target.value })} aria-label={t('automations.dayOfWeekLabel', 'Day of week')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Day of week (0-6)" />
-            )}
-            {draft.scheduleType === 'monthly' && (
-              <input value={draft.dayOfMonth} onChange={(event) => updateDraft({ dayOfMonth: event.target.value })} aria-label={t('automations.dayOfMonthLabel', 'Day of month')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Day of month (1-31)" />
-            )}
-            {draft.scheduleType === 'one_time' && (
-              <input value={draft.startAt} onChange={(event) => updateDraft({ startAt: event.target.value })} type="datetime-local" aria-label={t('automations.startAtLabel', 'Start date and time')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" />
-            )}
-            <div className="grid grid-cols-2 gap-2">
-              <select value={draft.executionMode} onChange={(event) => updateDraft({ executionMode: event.target.value as AutomationExecutionMode })} aria-label={t('automations.executionModeLabel', 'Execution mode')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
-                <option value="planning_only">Planning only</option>
-                <option value="scoped_execution">Scoped execution</option>
-              </select>
-              <select value={draft.autonomyPolicy} onChange={(event) => updateDraft({ autonomyPolicy: event.target.value as AutomationAutonomyPolicy })} aria-label={t('automations.autonomyPolicyLabel', 'Autonomy policy')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent">
-                <option value="review-first">Review first</option>
-                <option value="mostly-autonomous">Mostly autonomous</option>
-              </select>
-            </div>
-            <div className="flex gap-2">
-              <input
-                value={draft.projectDirectory}
-                readOnly
-                aria-label={t('automations.projectDirectoryLabel', 'Project directory')}
-                className="flex-1 rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent"
-                placeholder="Optional project directory"
-              />
-              <button
-                type="button"
-                onClick={async () => {
-                  const selected = await window.coworkApi.dialog.selectDirectory()
-                  if (selected) updateDraft({ projectDirectory: selected })
-                }}
-                className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer"
-              >
-                Browse
-              </button>
-              {draft.projectDirectory ? (
-                <button
-                  type="button"
-                  onClick={() => updateDraft({ projectDirectory: '' })}
-                  className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer"
-                >
-                  Clear
-                </button>
-              ) : null}
-            </div>
-            <div>
-              <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Preferred specialists</div>
-              <div className="mt-2">
-                <AgentTeamSelector
-                  options={draftAgentOptions}
-                  value={draft.preferredAgentNames}
-                  onChange={(preferredAgentNames) => updateDraft({ preferredAgentNames })}
-                  emptyLabel="No specialist agents are available yet. You can still create the automation and let Cowork use its default routing."
-                />
-              </div>
-              <div className="mt-2 text-[11px] text-text-muted">
-                These agents stay preferred during enrichment and execution, but Cowork still uses plan/build as the primary automation flow.
-              </div>
-            </div>
-            {draft.executionMode === 'scoped_execution' && !draft.projectDirectory.trim() ? (
-              <div className="text-[11px]" style={{ color: 'var(--color-warning)' }}>
-                Scoped execution needs a project directory so the agent team has an explicit workspace boundary.
-              </div>
-            ) : null}
-            <input value={draft.heartbeatMinutes} onChange={(event) => updateDraft({ heartbeatMinutes: event.target.value })} aria-label={t('automations.heartbeatMinutesLabel', 'Heartbeat minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Heartbeat minutes" />
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-              <input value={draft.maxRetries} onChange={(event) => updateDraft({ maxRetries: event.target.value })} aria-label={t('automations.maxRetriesLabel', 'Maximum retries')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max retries" />
-              <input value={draft.retryBaseDelayMinutes} onChange={(event) => updateDraft({ retryBaseDelayMinutes: event.target.value })} aria-label={t('automations.retryBaseDelayLabel', 'Base retry delay in minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Base retry delay (min)" />
-              <input value={draft.retryMaxDelayMinutes} onChange={(event) => updateDraft({ retryMaxDelayMinutes: event.target.value })} aria-label={t('automations.retryMaxDelayLabel', 'Maximum retry delay in minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max retry delay (min)" />
-            </div>
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-              <input value={draft.dailyRunCap} onChange={(event) => updateDraft({ dailyRunCap: event.target.value })} aria-label={t('automations.dailyRunCapLabel', 'Daily run attempt cap')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder={dailyRunAttemptCapPlaceholder()} />
-              <input value={draft.maxRunDurationMinutes} onChange={(event) => updateDraft({ maxRunDurationMinutes: event.target.value })} aria-label={t('automations.maxRunDurationLabel', 'Maximum run duration in minutes')} className="rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent" placeholder="Max run duration (min)" />
-            </div>
-            <button
-              type="button"
-              onClick={() => void submitDraft()}
-              className="rounded-xl px-3 py-2 text-[13px] font-medium cursor-pointer"
-              style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}
-            >
-              {t('automations.createAction', 'Create automation')}
-            </button>
-          </div>
+      {error ? (
+        <div className="mb-4 rounded-2xl border border-border-subtle px-4 py-3 text-[12px]" style={{ background: 'color-mix(in srgb, var(--color-red) 8%, transparent)', color: 'var(--color-red)' }} role="alert">
+          {error}
         </div>
+      ) : null}
 
-        <div className="mt-5 flex flex-col gap-2">
-          {payload.automations.map((automation) => (
-            <button
-              key={automation.id}
-              type="button"
-              onClick={() => {
-                setSelectedAutomationId(automation.id)
-                void window.coworkApi.automation.get(automation.id).then(setSelectedAutomation)
-              }}
-              className={`rounded-2xl border px-4 py-3 text-start transition-colors cursor-pointer ${selectedAutomationId === automation.id ? 'bg-surface-active' : 'hover:bg-surface-hover'}`}
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="truncate text-[13px] font-semibold text-text">{automation.title}</div>
-                  <div className="mt-1 text-[11px] text-text-muted truncate">{automation.goal}</div>
-                </div>
-                <span className="shrink-0 rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.14em]" style={{ background: 'color-mix(in srgb, var(--color-accent) 12%, transparent)', color: 'var(--color-accent)' }}>
-                  {formatStatus(automation.status)}
-                </span>
-              </div>
-              <div className="mt-2 text-[10px] text-text-muted">
-                {formatSchedule(automation.schedule)}
-                {automation.nextRunAt ? ` · next ${new Date(automation.nextRunAt).toLocaleString()}` : ''}
-              </div>
-            </button>
-          ))}
-        </div>
-      </aside>
+      <AutomationBoard
+        payload={payload}
+        selectedAutomationId={selectedAutomationId}
+        onSelectAutomation={(automationId) => void selectAutomation(automationId)}
+        onDropAutomation={handleDropAutomation}
+        onNewAutomation={openWizard}
+        onLearnMore={() => setHelpOpen(true)}
+        feedback={feedback}
+      />
 
-      <section className="min-w-0 flex-1 overflow-y-auto p-5">
-        {error ? (
-          <div className="mb-4 rounded-2xl border border-border-subtle px-4 py-3 text-[12px]" style={{ background: 'color-mix(in srgb, var(--color-red) 8%, transparent)', color: 'var(--color-red)' }}>
-            {error}
-          </div>
-        ) : null}
+      {wizardOpen ? (
+        <AutomationCreateWizard
+          defaults={wizardDefaults}
+          onClose={() => setWizardOpen(false)}
+          onCreate={createAutomation}
+          loadAgentOptions={loadAgentOptions}
+        />
+      ) : null}
 
-        {!selectedAutomation ? (
-          <div className="space-y-5">
-            <div className="rounded-3xl border border-border-subtle p-6" style={{ background: 'var(--color-elevated)' }}>
-              <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
-                <div>
-                  <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">Automation overview</div>
-                  <h2 className="mt-2 text-[28px] font-semibold text-text">Turn repeatable work into a standing agent program</h2>
-                  <p className="mt-3 max-w-3xl text-[14px] leading-7 text-text-secondary">
-                    Automations wake up on schedule, enrich raw asks into execution-ready briefs, ask for clarification when context is missing,
-                    and route approved work into the Cowork agent team.
-                  </p>
-                  <div className="mt-4 flex flex-wrap gap-3">
-                    <button
-                      type="button"
-                      onClick={() => setDraft((current) => AUTOMATION_TEMPLATES[0]!.apply(current))}
-                      className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer"
-                      style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}
-                    >
-                      Load weekly report template
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setDraft((current) => AUTOMATION_TEMPLATES[1]!.apply(current))}
-                      className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer"
-                    >
-                      Load managed project template
-                    </button>
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <SummaryCard
-                    label="Active automations"
-                    value={String(overview.activeAutomations)}
-                    detail={overview.totalAutomations === 0 ? 'No standing programs yet' : `${overview.totalAutomations} total configured`}
-                    accent
-                  />
-                  <SummaryCard
-                    label="Open inbox"
-                    value={String(overview.inboxCount)}
-                    detail={overview.inboxCount > 0 ? 'Approvals and clarifications waiting on you' : 'No user action is currently required'}
-                  />
-                  <SummaryCard
-                    label="Live runs"
-                    value={String(overview.runningRuns)}
-                    detail={overview.runningRuns > 0 ? 'Queued or running automation work' : 'Nothing is currently executing'}
-                  />
-                  <SummaryCard
-                    label="Deliveries"
-                    value={String(overview.deliveryCount)}
-                    detail={overview.deliveryCount > 0 ? `${overview.failedRuns} failed run${overview.failedRuns === 1 ? '' : 's'} recorded` : 'Nothing has been delivered yet'}
-                  />
-                </div>
-              </div>
-            </div>
+      {helpOpen ? <HelpDrawer onClose={() => setHelpOpen(false)} /> : null}
 
-            <div className="grid grid-cols-1 gap-5 xl:grid-cols-[1.15fr_0.85fr]">
-              <DetailSection title="Start with a template">
-                <div className="grid gap-3 lg:grid-cols-2">
-                  {AUTOMATION_TEMPLATES.map((template) => (
-                    <button
-                      key={`overview-${template.id}`}
-                      type="button"
-                      onClick={() => setDraft((current) => template.apply(current))}
-                      className="rounded-2xl border border-border px-4 py-4 text-left transition-colors hover:bg-surface-hover cursor-pointer"
-                    >
-                      <div className="text-[13px] font-semibold text-text">{template.label}</div>
-                      <div className="mt-2 text-[12px] leading-6 text-text-secondary">{template.description}</div>
-                      <div className="mt-3 text-[11px] text-text-muted">Loads the draft on the left so you can adjust the schedule, autonomy, and retry policy.</div>
-                    </button>
-                  ))}
-                </div>
-              </DetailSection>
+      {selectedAutomation ? (
+        <AutomationCardDetail
+          automation={selectedAutomation}
+          inbox={selectedInbox}
+          workItems={selectedWorkItems}
+          runs={selectedRuns}
+          deliveries={selectedDeliveries}
+          agentOptions={selectedAgentOptions}
+          onClose={() => {
+            setSelectedAutomationId(null)
+            setSelectedAutomation(null)
+          }}
+          onOpenThread={onOpenThread}
+          onPatch={patchSelected}
+          onPreviewBrief={() => runAndRefresh(() => window.coworkApi.automation.previewBrief(selectedAutomation.id))}
+          onApproveBrief={() => runAndRefresh(() => window.coworkApi.automation.approveBrief(selectedAutomation.id))}
+          onRunNow={() => runAndRefresh(() => window.coworkApi.automation.runNow(selectedAutomation.id))}
+          onPause={() => runAndRefresh(() => window.coworkApi.automation.pause(selectedAutomation.id))}
+          onResume={() => runAndRefresh(() => window.coworkApi.automation.resume(selectedAutomation.id))}
+          onArchive={() => runAndRefresh(() => window.coworkApi.automation.archive(selectedAutomation.id))}
+          onCancelRun={(runId) => runAndRefresh(() => window.coworkApi.automation.cancelRun(runId))}
+          onRetryRun={(runId) => runAndRefresh(() => window.coworkApi.automation.retryRun(runId))}
+          onInboxRespond={(itemId, response) => runAndRefresh(() => window.coworkApi.automation.inboxRespond(itemId, response))}
+          onInboxDismiss={(itemId) => runAndRefresh(() => window.coworkApi.automation.inboxDismiss(itemId))}
+        />
+      ) : null}
 
-              <DetailSection title="How it works">
-                <div className="space-y-3">
-                  {[
-                    ['1. Enrich', 'Cowork routes the raw ask through the plan agent and attached specialists until the brief is execution-ready.'],
-                    ['2. Ask when blocked', 'Missing context and review gates become inbox items so automations stop instead of guessing.'],
-                    ['3. Execute and deliver', 'Approved work runs through build and specialist subagents, then lands as run output and delivery records.'],
-                  ].map(([label, detail]) => (
-                    <div key={label} className="rounded-2xl border border-border px-4 py-3">
-                      <div className="text-[13px] font-semibold text-text">{label}</div>
-                      <div className="mt-1 text-[12px] leading-6 text-text-secondary">{detail}</div>
-                    </div>
-                  ))}
-                </div>
-              </DetailSection>
-            </div>
-
-            <div className="grid grid-cols-1 gap-5 xl:grid-cols-[1.05fr_0.95fr]">
-              <DetailSection title="Recent automation activity">
-                {overview.latestActivity ? (
-                  <div className="space-y-3">
-                    {payload.runs.slice(0, 5).map((run) => (
-                      <div key={run.id} className="rounded-xl border border-border px-4 py-3">
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="text-[12px] font-medium text-text">{run.title}</div>
-                          <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{run.status}</span>
-                        </div>
-                        <div className="mt-1 text-[11px] text-text-muted">
-                          {formatTimestamp(run.createdAt)} · attempt {run.attempt}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="text-[12px] text-text-muted">
-                    No automation activity yet. Create the first recurring report or managed project and the right side will turn into an operations view.
-                  </div>
-                )}
-              </DetailSection>
-
-              <DetailSection title="Good first use cases">
-                <div className="space-y-3">
-                  {[
-                    'Build a weekly market + performance report every Monday and keep it ready for review.',
-                    'Maintain a project roadmap, enrich the next tasks, and keep execution-ready work moving.',
-                    'Run a recurring research sweep that produces a brief, charts, and linked run history.',
-                  ].map((example) => (
-                    <div key={example} className="rounded-xl border border-border px-4 py-3 text-[12px] leading-6 text-text-secondary">
-                      {example}
-                    </div>
-                  ))}
-                </div>
-              </DetailSection>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-5">
-            <div className="rounded-3xl border border-border-subtle p-5" style={{ background: 'var(--color-elevated)' }}>
-              <div className="flex flex-wrap items-start justify-between gap-4">
-                <div>
-                  <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">{selectedAutomation.kind === 'recurring' ? 'Recurring program' : 'Managed project'}</div>
-                  <h2 className="mt-1 text-[26px] font-semibold text-text">{selectedAutomation.title}</h2>
-                  <p className="mt-2 max-w-3xl text-[13px] leading-6 text-text-secondary">{selectedAutomation.goal}</p>
-                  <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-muted">
-                    <span>{formatSchedule(selectedAutomation.schedule)}</span>
-                    <span>Heartbeat {selectedAutomation.heartbeatMinutes}m</span>
-                    <span>Retries {selectedAutomation.retryPolicy.maxRetries}x ({selectedAutomation.retryPolicy.baseDelayMinutes}m → {selectedAutomation.retryPolicy.maxDelayMinutes}m)</span>
-                    <span>Run cap {dailyRunAttemptCapLabel(selectedAutomation.runPolicy.dailyRunCap)} · {selectedAutomation.runPolicy.maxRunDurationMinutes}m max</span>
-                    {selectedAutomation.nextHeartbeatAt ? <span>Next heartbeat {formatTimestamp(selectedAutomation.nextHeartbeatAt)}</span> : null}
-                    <span>{selectedAutomation.executionMode === 'planning_only' ? 'Planning only' : 'Scoped execution'}</span>
-                    <span>{selectedAutomation.autonomyPolicy}</span>
-                    <span>In-app delivery</span>
-                    {selectedPreferredAgentLabels.length > 0 ? <span>Team {selectedPreferredAgentLabels.join(', ')}</span> : null}
-                  </div>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  <button type="button" disabled={controlsLocked} onClick={() => void window.coworkApi.automation.previewBrief(selectedAutomation.id).then(() => refresh(selectedAutomation.id))} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">Preview brief</button>
-                  <button type="button" disabled={isArchived} onClick={() => void window.coworkApi.automation.approveBrief(selectedAutomation.id).then(() => refresh(selectedAutomation.id))} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">Approve brief</button>
-                  <button type="button" disabled={controlsLocked} onClick={() => void window.coworkApi.automation.runNow(selectedAutomation.id).then(() => refresh(selectedAutomation.id))} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>Run now</button>
-                  {selectedAutomation.status === 'paused' ? (
-                    <button type="button" disabled={isArchived} onClick={() => void window.coworkApi.automation.resume(selectedAutomation.id).then(() => refresh(selectedAutomation.id))} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">Resume</button>
-                  ) : (
-                    <button type="button" disabled={isArchived} onClick={() => void window.coworkApi.automation.pause(selectedAutomation.id).then(() => refresh(selectedAutomation.id))} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">Pause</button>
-                  )}
-                  <button type="button" disabled={hasActiveRun || isArchived} onClick={() => void window.coworkApi.automation.archive(selectedAutomation.id).then(() => refresh())} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">Archive</button>
-                </div>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-              <SummaryCard
-                label="Status"
-                value={formatStatus(selectedAutomation.status)}
-                detail={selectedAutomation.brief?.approvedAt ? 'Execution brief approved and reusable' : 'Still moving toward an execution-ready brief'}
-                accent
-              />
-              <SummaryCard
-                label="Reliability"
-                value={reliability?.value || 'Healthy'}
-                detail={reliability?.detail || 'No reliability issues detected.'}
-                compact
-              />
-              <SummaryCard
-                label="Next step"
-                value={selectedNextAction}
-                detail={activeRun ? `Active run: ${activeRun.title}` : latestRun ? latestRunSummary(latestRun) : 'No runs yet'}
-                compact
-              />
-              <SummaryCard
-                label="Backlog"
-                value={backlog.total > 0 ? `${backlog.completed}/${backlog.total}` : '0'}
-                detail={backlog.total > 0
-                  ? `${pluralize(backlog.ready + backlog.running, 'ready item')} · ${pluralize(backlog.blocked + backlog.failed, 'blocked item')}`
-                  : 'Work items appear after enrichment'}
-              />
-              <SummaryCard
-                label="Run policy"
-                value={`${selectedAutomation.runPolicy.dailyRunCap}/day`}
-                detail={describeRunPolicy(selectedAutomation, latestRun)}
-              />
-              <SummaryCard
-                label="Delivery"
-                value="In-app"
-                detail={latestDelivery
-                  ? `Latest via ${latestDelivery.provider} on ${formatTimestamp(latestDelivery.createdAt)}`
-                  : 'Outputs land in the automation inbox and delivery ledger.'}
-                compact
-              />
-            </div>
-
-            <div className="grid grid-cols-1 gap-5 xl:grid-cols-[1.1fr_0.9fr]">
-              <DetailSection
-                title="Execution brief"
-                action={selectedAutomation.latestSessionId && onOpenThread ? (
-                  <button type="button" onClick={() => onOpenThread(selectedAutomation.latestSessionId!)} className="text-[11px] text-text-muted underline cursor-pointer">
-                    Open linked thread
-                  </button>
-                ) : undefined}
-              >
-                {selectedAutomation.brief ? (
-                  <div className="space-y-4 text-[12px]">
-                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                      <DetailGroup label="Deliverables" values={selectedAutomation.brief.deliverables} empty="No deliverables specified yet" />
-                      <DetailGroup label="Recommended agents" values={selectedAutomation.brief.recommendedAgents} empty="Use standard plan/build routing" />
-                    </div>
-                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                      <DetailGroup label="Preferred specialists" values={selectedPreferredAgentLabels} empty="No preferred specialist team configured" />
-                      <DetailGroup label="Assumptions" values={selectedAutomation.brief.assumptions} />
-                    </div>
-                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                      <DetailGroup label="Success criteria" values={selectedAutomation.brief.successCriteria} />
-                      <div />
-                    </div>
-                    <DetailGroup label="Missing context" values={selectedAutomation.brief.missingContext} empty="No missing context" />
-                    <div>
-                      <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Approval boundary</div>
-                      <div className="mt-2 text-[12px] leading-6 text-text-secondary">{selectedAutomation.brief.approvalBoundary}</div>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="text-[12px] text-text-muted">No execution brief yet. Run Preview brief to enrich this task through the plan agent.</div>
-                )}
-              </DetailSection>
-
-              <DetailSection title="Inbox">
-                <div className="space-y-3">
-                  {automationInbox.length === 0 ? (
-                    <div className="text-[12px] text-text-muted">No open inbox items.</div>
-                  ) : automationInbox.map((item) => (
-                    <div key={item.id} className="rounded-xl border border-border px-3 py-3">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="text-[12px] font-medium text-text">{item.title}</div>
-                        <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{item.type}</span>
-                      </div>
-                      <div className="mt-1 text-[12px] text-text-secondary whitespace-pre-wrap">{item.body}</div>
-                      {item.questionId ? (
-                        <div className="mt-3 flex gap-2">
-                          <input
-                            value={inboxReplies[item.id] || ''}
-                            onChange={(event) => setInboxReplies((current) => ({ ...current, [item.id]: event.target.value }))}
-                            placeholder="Reply to continue"
-                            className="flex-1 rounded-xl border border-border px-3 py-2 text-[12px] bg-transparent"
-                          />
-                          <button
-                            type="button"
-                            onClick={() => void window.coworkApi.automation.inboxRespond(item.id, inboxReplies[item.id] || '').then(() => refresh(selectedAutomation.id))}
-                            className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer"
-                            style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}
-                          >
-                            Send
-                          </button>
-                        </div>
-                      ) : null}
-                      {item.type === 'approval' ? (
-                        <button
-                          type="button"
-                          disabled={selectedAutomation.status === 'archived'}
-                          onClick={() => void window.coworkApi.automation.approveBrief(selectedAutomation.id).then(() => refresh(selectedAutomation.id))}
-                          className="mt-3 rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                          style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}
-                        >
-                          Approve brief
-                        </button>
-                      ) : null}
-                      <button type="button" onClick={() => void window.coworkApi.automation.inboxDismiss(item.id).then(() => refresh(selectedAutomation.id))} className="mt-3 text-[11px] text-text-muted underline cursor-pointer">Dismiss</button>
-                    </div>
-                  ))}
-                </div>
-              </DetailSection>
-            </div>
-
-            <div className="grid grid-cols-1 gap-5 xl:grid-cols-[0.95fr_1.05fr]">
-              <DetailSection title="Backlog">
-                <div className="mb-4 grid grid-cols-2 gap-3 lg:grid-cols-4">
-                  <SummaryCard label="Total" value={String(backlog.total)} detail="Items in this brief revision" />
-                  <SummaryCard label="Completed" value={String(backlog.completed)} detail="Work already finished" />
-                  <SummaryCard label="Ready now" value={String(backlog.ready + backlog.running)} detail="Execution-ready or in-flight" />
-                  <SummaryCard label="Blocked" value={String(backlog.blocked + backlog.failed)} detail="Waiting on context, review, or recovery" />
-                </div>
-                <div className="space-y-3">
-                  {automationWorkItems.length === 0 ? (
-                    <div className="text-[12px] text-text-muted">No work items yet.</div>
-                  ) : automationWorkItems.map((item) => (
-                    <div key={item.id} className="rounded-xl border border-border px-3 py-3">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="text-[12px] font-medium text-text">{item.title}</div>
-                        <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{item.status}</span>
-                      </div>
-                      <div className="mt-1 text-[12px] text-text-secondary">{item.description}</div>
-                      <div className="mt-2 text-[11px] text-text-muted">
-                        {item.ownerAgent ? `Owner: ${item.ownerAgent}` : 'Owner decided at runtime'}
-                        {item.dependsOn.length > 0 ? ` · depends on ${item.dependsOn.join(', ')}` : ''}
-                        {item.blockingReason ? ` · ${item.blockingReason}` : ''}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </DetailSection>
-
-              <DetailSection title="Run timeline">
-                <div className="space-y-3">
-                  {automationRuns.length === 0 ? (
-                    <div className="text-[12px] text-text-muted">No runs yet.</div>
-                  ) : automationRuns.map((run) => (
-                    <div key={run.id} className="rounded-xl border border-border px-3 py-3">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="text-[12px] font-medium text-text">{run.title}</div>
-                        <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{run.status}</span>
-                      </div>
-                      <div className="mt-1 text-[11px] text-text-muted">
-                        {formatTimestamp(run.createdAt)} · attempt {run.attempt}
-                        {run.nextRetryAt ? ` · retrying ${formatTimestamp(run.nextRetryAt)}` : ''}
-                      </div>
-                      {run.summary ? <div className="mt-2 text-[12px] text-text-secondary whitespace-pre-wrap">{run.summary}</div> : null}
-                      {run.error ? <div className="mt-2 text-[12px]" style={{ color: 'var(--color-red)' }}>{run.error}</div> : null}
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {run.status === 'running' ? (
-                          <button
-                            type="button"
-                            onClick={() => void window.coworkApi.automation.cancelRun(run.id).then(() => refresh(selectedAutomation.id))}
-                            className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer"
-                          >
-                            Cancel run
-                          </button>
-                        ) : null}
-                        {(run.status === 'failed' || run.status === 'cancelled') ? (
-                          <button
-                            type="button"
-                            disabled={isArchived || hasActiveRun}
-                            onClick={() => void window.coworkApi.automation.retryRun(run.id).then(() => refresh(selectedAutomation.id))}
-                            className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            Retry run
-                          </button>
-                        ) : null}
-                      </div>
-                      {run.sessionId && onOpenThread ? (
-                        <button type="button" onClick={() => onOpenThread(run.sessionId!)} className="mt-2 text-[11px] text-text-muted underline cursor-pointer">
-                          Open run thread
-                        </button>
-                      ) : null}
-                    </div>
-                  ))}
-                </div>
-              </DetailSection>
-            </div>
-
-            <div className="grid grid-cols-1 gap-5 xl:grid-cols-[0.95fr_1.05fr]">
-              <DetailSection title="Deliveries">
-                <div className="space-y-3">
-                  {automationDeliveries.length === 0 ? (
-                    <div className="text-[12px] text-text-muted">No deliveries yet.</div>
-                  ) : automationDeliveries.map((delivery) => (
-                    <div key={delivery.id} className="rounded-xl border border-border px-3 py-3">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="text-[12px] font-medium text-text">{delivery.title}</div>
-                        <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{delivery.provider} · {delivery.status}</span>
-                      </div>
-                      <div className="mt-1 text-[11px] text-text-muted">{formatTimestamp(delivery.createdAt)} · {delivery.target}</div>
-                      <div className="mt-2 text-[12px] text-text-secondary whitespace-pre-wrap">{delivery.body}</div>
-                    </div>
-                  ))}
-                </div>
-              </DetailSection>
-
-              <DetailSection title="Quick edits">
-                <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                  <input
-                    value={selectedAutomation.title}
-                    onChange={(event) => setSelectedAutomation((current) => current ? { ...current, title: event.target.value } : current)}
-                    className="rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent"
-                  />
-                  <div className="flex gap-2">
-                    <input
-                      value={selectedAutomation.projectDirectory || ''}
-                      readOnly
-                      className="min-w-0 flex-1 rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent"
-                      placeholder="Optional project directory"
-                    />
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        const selected = await window.coworkApi.dialog.selectDirectory()
-                        if (selected) setSelectedAutomation((current) => current ? { ...current, projectDirectory: selected } : current)
-                      }}
-                      className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer"
-                    >
-                      Browse
-                    </button>
-                    {selectedAutomation.projectDirectory ? (
-                      <button
-                        type="button"
-                        onClick={() => setSelectedAutomation((current) => current ? { ...current, projectDirectory: null } : current)}
-                        className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer"
-                      >
-                        Clear
-                      </button>
-                    ) : null}
-                  </div>
-                  <textarea
-                    value={selectedAutomation.goal}
-                    onChange={(event) => setSelectedAutomation((current) => current ? { ...current, goal: event.target.value } : current)}
-                    rows={4}
-                    className="lg:col-span-2 rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent resize-y"
-                  />
-                  <input
-                    type="number"
-                    min={1}
-                    value={selectedAutomation.runPolicy.dailyRunCap}
-                    onChange={(event) => setSelectedAutomation((current) => current
-                      ? {
-                        ...current,
-                        runPolicy: {
-                          ...current.runPolicy,
-                          dailyRunCap: Math.max(1, Number.parseInt(event.target.value, 10) || 1),
-                        },
-                      }
-                      : current)}
-                    className="rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent"
-                    placeholder={dailyRunAttemptCapPlaceholder()}
-                  />
-                  <input
-                    type="number"
-                    min={1}
-                    value={selectedAutomation.runPolicy.maxRunDurationMinutes}
-                    onChange={(event) => setSelectedAutomation((current) => current
-                      ? {
-                        ...current,
-                        runPolicy: {
-                          ...current.runPolicy,
-                          maxRunDurationMinutes: Math.max(1, Number.parseInt(event.target.value, 10) || 1),
-                        },
-                      }
-                      : current)}
-                    className="rounded-xl border border-border px-3 py-2 text-[13px] bg-transparent"
-                    placeholder="Max run duration (min)"
-                  />
-                </div>
-                <div className="mt-4">
-                  <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Preferred specialists</div>
-                  <div className="mt-2">
-                    <AgentTeamSelector
-                      options={selectedAgentOptions}
-                      value={selectedAutomation.preferredAgentNames}
-                      onChange={(preferredAgentNames) => setSelectedAutomation((current) => current ? { ...current, preferredAgentNames } : current)}
-                    />
-                  </div>
-                </div>
-                <div className="mt-3">
-                  <button
-                    type="button"
-                    onClick={() => void patchSelected({
-                      title: selectedAutomation.title,
-                      goal: selectedAutomation.goal,
-                      projectDirectory: selectedAutomation.projectDirectory,
-                      preferredAgentNames: selectedAutomation.preferredAgentNames,
-                      runPolicy: selectedAutomation.runPolicy,
-                    })}
-                    className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer"
-                  >
-                    Save edits
-                  </button>
-                </div>
-              </DetailSection>
-            </div>
-          </div>
-        )}
-      </section>
+      {pendingDropAction ? (
+        <ConfirmDropDialog
+          action={pendingDropAction}
+          onCancel={() => setPendingDropAction(null)}
+          onConfirm={() => {
+            const action = pendingDropAction
+            setPendingDropAction(null)
+            void executeDropAction(action)
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/components/automations/automation-board-support.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-board-support.ts
@@ -1,0 +1,275 @@
+import type {
+  AutomationDeliveryRecord,
+  AutomationInboxItem,
+  AutomationListPayload,
+  AutomationRun,
+  AutomationSummary,
+  AutomationWorkItem,
+} from '@open-cowork/shared'
+import { formatSchedule, formatStatus, formatTimestamp, summarizeWorkItems } from './automations-page-support'
+
+export type AutomationColumnId =
+  | 'draft'
+  | 'planning'
+  | 'needs-review'
+  | 'ready-running'
+  | 'delivered'
+  | 'paused'
+
+export type AutomationDropActionType =
+  | 'previewBrief'
+  | 'approveBrief'
+  | 'runNow'
+  | 'pause'
+  | 'resume'
+
+export type AutomationDropAction =
+  | {
+      valid: true
+      automationId: string
+      type: AutomationDropActionType
+      targetColumn: AutomationColumnId
+      title: string
+      message: string
+      confirm: boolean
+    }
+  | {
+      valid: false
+      automationId: string
+      targetColumn: AutomationColumnId
+      message: string
+    }
+
+export type AutomationCardModel = {
+  automation: AutomationSummary
+  columnId: AutomationColumnId
+  inbox: AutomationInboxItem[]
+  workItems: AutomationWorkItem[]
+  runs: AutomationRun[]
+  deliveries: AutomationDeliveryRecord[]
+  activeRun: AutomationRun | null
+  latestRun: AutomationRun | null
+  latestDelivery: AutomationDeliveryRecord | null
+  inboxCount: number
+  hasApproval: boolean
+  hasBlockingInbox: boolean
+  workProgress: {
+    total: number
+    completed: number
+    ready: number
+    running: number
+    blocked: number
+    failed: number
+  }
+  scheduleLabel: string
+  latestActivityLabel: string
+}
+
+export type AutomationColumn = {
+  id: AutomationColumnId
+  title: string
+  description: string
+  cards: AutomationCardModel[]
+}
+
+export const AUTOMATION_COLUMNS: Array<Omit<AutomationColumn, 'cards'>> = [
+  {
+    id: 'draft',
+    title: 'Backlog',
+    description: 'New programs that still need an execution brief.',
+  },
+  {
+    id: 'planning',
+    title: 'Planning',
+    description: 'Cowork is enriching or supervising the work.',
+  },
+  {
+    id: 'needs-review',
+    title: 'Needs Review',
+    description: 'Approvals, clarifications, or failures need attention.',
+  },
+  {
+    id: 'ready-running',
+    title: 'Ready / Running',
+    description: 'Approved work that is ready or executing.',
+  },
+  {
+    id: 'delivered',
+    title: 'Delivered',
+    description: 'Recent output is ready to review.',
+  },
+  {
+    id: 'paused',
+    title: 'Paused',
+    description: 'Paused, failed, or archived programs.',
+  },
+]
+
+const COLUMN_TITLES = new Map(AUTOMATION_COLUMNS.map((column) => [column.id, column.title]))
+
+function byAutomationId<T extends { automationId: string }>(items: T[], automationId: string) {
+  return items.filter((item) => item.automationId === automationId)
+}
+
+function latest<T extends { createdAt: string }>(items: T[]) {
+  return items[0] || null
+}
+
+function getActiveRun(runs: AutomationRun[]) {
+  return runs.find((run) => run.status === 'queued' || run.status === 'running') || null
+}
+
+function hasBlockingInboxItem(items: AutomationInboxItem[]) {
+  return items.some((item) => item.type === 'approval' || item.type === 'clarification' || item.type === 'failure')
+}
+
+function resolveColumn(input: {
+  automation: AutomationSummary
+  inbox: AutomationInboxItem[]
+  activeRun: AutomationRun | null
+  latestRun: AutomationRun | null
+  latestDelivery: AutomationDeliveryRecord | null
+}): AutomationColumnId {
+  const { automation, inbox, activeRun, latestRun, latestDelivery } = input
+  if (automation.status === 'paused' || automation.status === 'failed' || automation.status === 'archived') return 'paused'
+  if (automation.status === 'needs_user' || hasBlockingInboxItem(inbox)) return 'needs-review'
+  if (activeRun?.kind === 'enrichment' || activeRun?.kind === 'heartbeat' || automation.status === 'enriching') return 'planning'
+  if (automation.status === 'ready' || automation.status === 'running' || activeRun?.kind === 'execution') return 'ready-running'
+  if (automation.status === 'completed' || latestDelivery || latestRun?.status === 'completed') return 'delivered'
+  return 'draft'
+}
+
+export function buildAutomationCardModel(payload: AutomationListPayload, automation: AutomationSummary): AutomationCardModel {
+  const inbox = byAutomationId(payload.inbox, automation.id)
+  const workItems = byAutomationId(payload.workItems, automation.id)
+  const runs = byAutomationId(payload.runs, automation.id)
+  const deliveries = byAutomationId(payload.deliveries, automation.id)
+  const activeRun = getActiveRun(runs)
+  const latestRun = latest(runs)
+  const latestDelivery = latest(deliveries)
+  const columnId = resolveColumn({ automation, inbox, activeRun, latestRun, latestDelivery })
+  return {
+    automation,
+    columnId,
+    inbox,
+    workItems,
+    runs,
+    deliveries,
+    activeRun,
+    latestRun,
+    latestDelivery,
+    inboxCount: inbox.length,
+    hasApproval: inbox.some((item) => item.type === 'approval'),
+    hasBlockingInbox: hasBlockingInboxItem(inbox),
+    workProgress: summarizeWorkItems(workItems),
+    scheduleLabel: formatSchedule(automation.schedule),
+    latestActivityLabel: latestRun
+      ? `${formatStatus(latestRun.status)} ${latestRun.kind} · ${formatTimestamp(latestRun.createdAt, '')}`
+      : automation.nextRunAt
+        ? `Next ${formatTimestamp(automation.nextRunAt, '')}`
+        : 'No runs yet',
+  }
+}
+
+export function buildAutomationBoard(payload: AutomationListPayload): AutomationColumn[] {
+  const cards = payload.automations.map((automation) => buildAutomationCardModel(payload, automation))
+  return AUTOMATION_COLUMNS.map((column) => ({
+    ...column,
+    cards: cards.filter((card) => card.columnId === column.id),
+  }))
+}
+
+export function summarizeAutomationBoard(payload: AutomationListPayload) {
+  const cards = payload.automations.map((automation) => buildAutomationCardModel(payload, automation))
+  return {
+    active: cards.filter((card) => card.automation.status !== 'archived').length,
+    needsReview: cards.filter((card) => card.columnId === 'needs-review').length,
+    running: cards.filter((card) => card.activeRun).length,
+    delivered: cards.filter((card) => card.columnId === 'delivered').length,
+  }
+}
+
+export function resolveAutomationDropAction(
+  card: AutomationCardModel,
+  targetColumn: AutomationColumnId,
+): AutomationDropAction {
+  const automationId = card.automation.id
+  const targetTitle = COLUMN_TITLES.get(targetColumn) || 'that column'
+  if (targetColumn === card.columnId) {
+    return {
+      valid: false,
+      automationId,
+      targetColumn,
+      message: `${card.automation.title} is already in ${targetTitle}.`,
+    }
+  }
+  if (card.automation.status === 'archived') {
+    return {
+      valid: false,
+      automationId,
+      targetColumn,
+      message: 'Archived automations cannot be moved. Create a new automation if you want to run this program again.',
+    }
+  }
+  if (targetColumn === 'planning' && card.columnId === 'draft') {
+    return {
+      valid: true,
+      automationId,
+      targetColumn,
+      type: 'previewBrief',
+      title: 'Preview execution brief',
+      message: `Start planning ${card.automation.title} by asking OpenCode plan to create an execution brief.`,
+      confirm: false,
+    }
+  }
+  if (targetColumn === 'ready-running' && card.columnId === 'needs-review' && card.hasApproval) {
+    return {
+      valid: true,
+      automationId,
+      targetColumn,
+      type: 'approveBrief',
+      title: 'Approve execution brief',
+      message: `Approve the brief for ${card.automation.title} so it can move into ready work.`,
+      confirm: true,
+    }
+  }
+  if (targetColumn === 'ready-running' && card.columnId === 'delivered') {
+    return {
+      valid: true,
+      automationId,
+      targetColumn,
+      type: 'runNow',
+      title: 'Run automation now',
+      message: `Start a new execution run for ${card.automation.title}.`,
+      confirm: true,
+    }
+  }
+  if (targetColumn === 'ready-running' && card.automation.status === 'paused') {
+    return {
+      valid: true,
+      automationId,
+      targetColumn,
+      type: 'resume',
+      title: 'Resume automation',
+      message: `Resume ${card.automation.title} so scheduled work can continue.`,
+      confirm: true,
+    }
+  }
+  if (targetColumn === 'paused' && card.automation.status !== 'paused') {
+    return {
+      valid: true,
+      automationId,
+      targetColumn,
+      type: 'pause',
+      title: 'Pause automation',
+      message: `Pause ${card.automation.title}. Active or scheduled work will stop until you resume it.`,
+      confirm: true,
+    }
+  }
+  return {
+    valid: false,
+    automationId,
+    targetColumn,
+    message: `That move is not a direct lifecycle action. Open the card and use the focused action buttons for ${targetTitle}.`,
+  }
+}

--- a/apps/desktop/tests/automations-page.smoke.test.ts
+++ b/apps/desktop/tests/automations-page.smoke.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import type { Page } from 'playwright-core'
 import { launchSmokeApp, waitForAppShell } from './smoke-helpers.ts'
 
 test('automations page shows an overview landing state before any automation exists', async () => {
@@ -10,12 +11,21 @@ test('automations page shows an overview landing state before any automation exi
     await page.getByRole('button', { name: 'Automations', exact: true }).click()
 
     await page.getByRole('heading', { name: 'Turn repeatable work into a standing agent program', exact: true }).waitFor()
-    await page.getByText('How it works', { exact: true }).waitFor()
-    await page.getByText('Recent automation activity', { exact: true }).waitFor()
+    await page.getByRole('button', { name: /New automation/i }).waitFor()
+    await page.getByRole('button', { name: /Weekly report/ }).first().waitFor()
   } finally {
     await cleanup()
   }
 })
+
+async function createWeeklyAutomation(page: Page, title: string, goal: string) {
+  await page.getByRole('button', { name: /New automation/i }).first().click()
+  await page.getByLabel('Title').fill(title)
+  await page.getByLabel('Goal').fill(goal)
+  await page.getByRole('button', { name: 'Continue', exact: true }).click()
+  await page.getByRole('button', { name: 'Continue', exact: true }).click()
+  await page.getByRole('button', { name: 'Create automation', exact: true }).click()
+}
 
 test('automations page creates and renders an automation', async () => {
   const { page, cleanup } = await launchSmokeApp()
@@ -24,17 +34,15 @@ test('automations page creates and renders an automation', async () => {
     await waitForAppShell(page)
     await page.getByRole('button', { name: 'Automations', exact: true }).click()
 
-    await page.getByPlaceholder('Weekly market report').fill('Weekly market report')
-    await page.getByPlaceholder('Build a weekly analysis and market research report and keep it ready for review every Monday morning.').fill(
+    await createWeeklyAutomation(
+      page,
+      'Weekly market report',
       'Build a weekly market and performance report for leadership.',
     )
-    await page.getByRole('button', { name: 'Create automation', exact: true }).click()
 
-    await page.getByRole('heading', { name: 'Weekly market report', exact: true }).waitFor()
-    await page.getByText('Execution brief', { exact: true }).waitFor()
-    await page.getByText('Run timeline', { exact: true }).waitFor()
-    await page.getByText('Quick edits', { exact: true }).waitFor()
-    await page.getByText('Reliability', { exact: true }).waitFor()
+    await page.getByRole('heading', { name: 'Backlog', exact: true }).waitFor()
+    await page.getByRole('button', { name: /Weekly market report/ }).waitFor()
+    await page.getByRole('dialog', { name: /Weekly market report/ }).waitFor()
     await page.getByText('Run policy', { exact: true }).waitFor()
 
     const payload = await page.evaluate(async () => {
@@ -60,18 +68,19 @@ test('automation templates prefill the draft and scoped execution requires a pro
     await waitForAppShell(page)
     await page.getByRole('button', { name: 'Automations', exact: true }).click()
 
-    await page.getByRole('button', { name: 'Managed project', exact: true }).click()
+    await page.getByRole('button', { name: /New automation/i }).first().click()
+    await page.getByRole('dialog', { name: /What & Why/i }).getByRole('button', { name: /Managed project/ }).first().click()
 
-    assert.equal(await page.locator('input').first().inputValue(), 'Managed product roadmap')
+    assert.equal(await page.getByLabel('Title').inputValue(), 'Managed product roadmap')
     assert.equal(
-      await page.locator('textarea').first().inputValue(),
+      await page.getByLabel('Goal').inputValue(),
       'Maintain a clear roadmap for this project, enrich the next execution-ready tasks, and keep progress moving forward without guessing when context is missing.',
     )
 
-    await page.locator('select').nth(2).selectOption('scoped_execution')
-    await page.getByText('Scoped execution needs a project directory so the agent team has an explicit workspace boundary.').waitFor()
+    await page.getByRole('button', { name: 'Continue', exact: true }).click()
+    await page.getByRole('button', { name: /Scoped execution/ }).click()
+    await page.getByRole('button', { name: 'Continue', exact: true }).click()
 
-    await page.getByRole('button', { name: 'Create automation', exact: true }).click()
     await page.getByText('Scoped execution automations require a project directory.').waitFor()
   } finally {
     await cleanup()
@@ -92,15 +101,20 @@ test('automation draft resets to the saved automation defaults after create', as
 
     await page.getByRole('button', { name: 'Automations', exact: true }).click()
 
-    await page.getByPlaceholder('Weekly market report').fill('Default reset check')
-    await page.getByPlaceholder('Build a weekly analysis and market research report and keep it ready for review every Monday morning.').fill(
+    await createWeeklyAutomation(
+      page,
+      'Default reset check',
       'Verify the create form resets using the saved automation defaults.',
     )
-    await page.getByRole('button', { name: 'Create automation', exact: true }).click()
-    await page.getByRole('heading', { name: 'Default reset check', exact: true }).waitFor()
+    await page.getByRole('dialog', { name: /Default reset check/ }).waitFor()
+    await page.getByRole('button', { name: 'Close automation details' }).click()
 
-    assert.equal(await page.locator('select').nth(2).inputValue(), 'planning_only')
-    assert.equal(await page.locator('select').nth(3).inputValue(), 'mostly-autonomous')
+    await page.getByRole('button', { name: /New automation/i }).first().click()
+    await page.getByLabel('Title').fill('Defaults snapshot')
+    await page.getByLabel('Goal').fill('Check defaults after create.')
+    await page.getByRole('button', { name: 'Continue', exact: true }).click()
+    await page.getByRole('button', { name: /Mostly autonomous/ }).waitFor()
+    await page.getByRole('button', { name: /Planning only/ }).waitFor()
   } finally {
     await cleanup()
   }
@@ -113,14 +127,16 @@ test('automation creation persists preferred specialists', async () => {
     await waitForAppShell(page)
     await page.getByRole('button', { name: 'Automations', exact: true }).click()
 
+    await page.getByRole('button', { name: /New automation/i }).first().click()
+    await page.getByLabel('Title').fill('Specialist team check')
+    await page.getByLabel('Goal').fill('Verify the selected specialist team persists through automation creation.')
+    await page.getByRole('button', { name: 'Continue', exact: true }).click()
+    await page.getByRole('button', { name: 'Continue', exact: true }).click()
+    await page.getByRole('button', { name: 'Show advanced settings', exact: true }).click()
     await page.getByRole('button', { name: /General/i }).click()
     await page.getByRole('button', { name: /Explore/i }).click()
-    await page.getByPlaceholder('Weekly market report').fill('Specialist team check')
-    await page.getByPlaceholder('Build a weekly analysis and market research report and keep it ready for review every Monday morning.').fill(
-      'Verify the selected specialist team persists through automation creation.',
-    )
     await page.getByRole('button', { name: 'Create automation', exact: true }).click()
-    await page.getByRole('heading', { name: 'Specialist team check', exact: true }).waitFor()
+    await page.getByRole('dialog', { name: /Specialist team check/ }).waitFor()
 
     const payload = await page.evaluate(async () => {
       return window.coworkApi.automation.list()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.2)
@@ -322,6 +325,22 @@ packages:
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
@@ -4316,6 +4335,24 @@ snapshots:
     dependencies:
       ajv: 6.15.0
       ajv-keywords: 3.5.2(ajv@6.15.0)
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@electron/asar@3.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

Reworks the Automations surface into a lifecycle Kanban board while keeping the automation backend, store, service, IPC handlers, and OpenCode execution path unchanged.

- Adds a board with Backlog, Planning, Needs Review, Ready / Running, Delivered, and Paused columns.
- Adds drag-and-drop shortcuts through existing automation actions only: preview brief, approve brief, run now, pause, and resume.
- Adds a three-step creation wizard with templates, review summary, scoped execution handling, and advanced settings.
- Adds a focused card detail drawer for current action, brief, work items, run history, quick settings, inbox replies, and contextual controls.
- Adds renderer coverage for board grouping/drop action mapping and updates the Automations Electron smoke flow.
- Adds `@dnd-kit/core` and refreshed third-party notices/license files.

## Review Notes

This is intentionally a UI/UX reorganization. It does not introduce a parallel automation runtime and does not change the OpenCode SDK execution boundary.

## Validation

- `pnpm lint`
- `pnpm lint:a11y --max-warnings=0`
- `pnpm typecheck`
- `pnpm test` — 674 passed
- `pnpm test:renderer` — 25 passed
- `pnpm test:e2e` — passed full Electron smoke suite
- `pnpm --dir apps/desktop build`
- `pnpm perf:check`
- `pnpm audit --prod --audit-level high`
- `pnpm notices`
- `git diff --check`