### PR TITLE
Harden automation board and runtime boundaries

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "start": "electron .",
     "test:renderer": "pnpm --dir ../.. build:shared && vitest run --config vitest.renderer.config.ts",
     "test:coverage:renderer": "pnpm --dir ../.. build:shared && vitest run --config vitest.renderer.config.ts --coverage",
-    "test:e2e": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && for test_file in tests/*.smoke.test.ts; do node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test \"$test_file\"; done",
+    "test:e2e": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && for test_file in tests/*.smoke.test.ts; do node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test \"$test_file\" || exit $?; done",
     "test:e2e:packaged": "node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test 'tests/*.packaged.test.ts'",
     "screenshots": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && node --no-warnings --experimental-strip-types tests/screenshots.ts",
     "dist": "node ../../scripts/desktop-dist.mjs",

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -15,6 +15,7 @@ import {
   countAutomationWorkRunAttemptsForDay,
   createAutomation,
   createAutomationRun,
+  createAutomationRunWhenNoActive,
   createInboxItem,
   getActiveRunForAutomation,
   getAutomationDetail,
@@ -301,7 +302,7 @@ async function startRun(
   if (activeRun) {
     throw new AutomationRunConflictError(`Automation already has an active ${activeRun.kind} run.`)
   }
-  const run = createAutomationRun(
+  const run = createAutomationRunWhenNoActive(
     automationId,
     kind,
     options.title || (
@@ -316,7 +317,7 @@ async function startRun(
       retryOfRunId: options.retryOfRunId,
     },
   )
-  if (!run) throw new Error('Failed to create automation run')
+  if (!run) throw new AutomationRunConflictError('Automation already has an active run.')
   const prompt = kind === 'enrichment'
     ? createAutomationEnrichmentPrompt(automation)
     : kind === 'execution'

--- a/apps/desktop/src/main/automation-store.ts
+++ b/apps/desktop/src/main/automation-store.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from 'node:sqlite'
-import { mkdirSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import type {
   AutomationAutonomyPolicy,
@@ -73,6 +73,14 @@ function getAutomationDbPath() {
   const dir = getAppDataDir()
   mkdirSync(dir, { recursive: true })
   return join(dir, 'automation.sqlite')
+}
+
+function ensureAutomationDbFileModes(dbPath = getAutomationDbPath()) {
+  if (process.platform === 'win32') return
+  for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (!existsSync(path)) continue
+    chmodSync(path, 0o600)
+  }
 }
 
 function parseJson<T>(value: unknown, fallback: T): T {
@@ -167,7 +175,8 @@ function ensureColumn(db: DatabaseSync, table: string, column: string, definitio
 
 function getDb() {
   if (automationDb) return automationDb
-  const db = new DatabaseSync(getAutomationDbPath())
+  const dbPath = getAutomationDbPath()
+  const db = new DatabaseSync(dbPath)
   db.exec('pragma journal_mode = WAL;')
   db.exec(`
     create table if not exists automations (
@@ -303,6 +312,7 @@ function getDb() {
   ensureColumn(db, 'automation_runs', 'retry_of_run_id', 'text')
   ensureColumn(db, 'automation_runs', 'next_retry_at', 'text')
   ensureColumn(db, 'automation_runs', 'failure_code', 'text')
+  ensureAutomationDbFileModes(dbPath)
   automationDb = db
   return db
 }
@@ -314,12 +324,14 @@ function withTransaction<T>(callback: (db: DatabaseSync) => T): T {
   try {
     const result = callback(db)
     db.exec(`release savepoint ${savepoint}`)
+    ensureAutomationDbFileModes()
     return result
   } catch (error) {
     try {
       db.exec(`rollback to savepoint ${savepoint}`)
     } finally {
       db.exec(`release savepoint ${savepoint}`)
+      ensureAutomationDbFileModes()
     }
     throw error
   }
@@ -685,28 +697,13 @@ export function createAutomationRun(
 ) {
   const id = crypto.randomUUID()
   withTransaction((db) => {
-    const now = new Date().toISOString()
-    const automation = getAutomationRow(automationId)
-    const schedule = automation ? parseJson<AutomationSchedule>(automation.schedule_json, { type: 'weekly', timezone: 'UTC' }) : null
-    const nextStatus = kind === 'heartbeat'
-      ? (automation?.status as AutomationStatus | undefined) || 'draft'
-      : 'running'
-    const nextRunAt = automation && kind !== 'heartbeat' && automation.next_run_at && automation.next_run_at <= now && schedule
-      ? computeNextAutomationRunAt(schedule, new Date(now))
-      : automation?.next_run_at || null
-    db.prepare(`
-      insert into automation_runs (
-        id, automation_id, session_id, kind, status, title, summary, error, failure_code, attempt, retry_of_run_id, next_retry_at, created_at, started_at, finished_at
-      ) values (?, ?, null, ?, ?, ?, null, null, null, ?, ?, null, ?, null, null)
-    `).run(id, automationId, kind, 'queued', title, options.attempt || 1, options.retryOfRunId || null, now)
-    db.prepare('update automations set latest_run_id = ?, latest_run_status = ?, updated_at = ?, status = ?, next_run_at = ? where id = ?')
-      .run(id, 'queued', now, nextStatus, nextRunAt, automationId)
+    insertAutomationRun(db, id, automationId, kind, title, options)
   })
   return getRun(id)
 }
 
-export function getActiveRunForAutomation(automationId: string) {
-  const row = getDb().prepare(`
+function getActiveRunRowForAutomation(db: DatabaseSync, automationId: string) {
+  return db.prepare(`
     select *
     from automation_runs
     where automation_id = ?
@@ -714,6 +711,52 @@ export function getActiveRunForAutomation(automationId: string) {
     order by created_at desc
     limit 1
   `).get(automationId) as DbRow | undefined
+}
+
+function insertAutomationRun(
+  db: DatabaseSync,
+  id: string,
+  automationId: string,
+  kind: AutomationRunKind,
+  title: string,
+  options: { attempt?: number, retryOfRunId?: string | null } = {},
+) {
+  const now = new Date().toISOString()
+  const automation = getAutomationRow(automationId)
+  const schedule = automation ? parseJson<AutomationSchedule>(automation.schedule_json, { type: 'weekly', timezone: 'UTC' }) : null
+  const nextStatus = kind === 'heartbeat'
+    ? (automation?.status as AutomationStatus | undefined) || 'draft'
+    : 'running'
+  const nextRunAt = automation && kind !== 'heartbeat' && automation.next_run_at && automation.next_run_at <= now && schedule
+    ? computeNextAutomationRunAt(schedule, new Date(now))
+    : automation?.next_run_at || null
+  db.prepare(`
+    insert into automation_runs (
+      id, automation_id, session_id, kind, status, title, summary, error, failure_code, attempt, retry_of_run_id, next_retry_at, created_at, started_at, finished_at
+    ) values (?, ?, null, ?, ?, ?, null, null, null, ?, ?, null, ?, null, null)
+  `).run(id, automationId, kind, 'queued', title, options.attempt || 1, options.retryOfRunId || null, now)
+  db.prepare('update automations set latest_run_id = ?, latest_run_status = ?, updated_at = ?, status = ?, next_run_at = ? where id = ?')
+    .run(id, 'queued', now, nextStatus, nextRunAt, automationId)
+}
+
+export function createAutomationRunWhenNoActive(
+  automationId: string,
+  kind: AutomationRunKind,
+  title: string,
+  options: { attempt?: number, retryOfRunId?: string | null } = {},
+) {
+  const id = crypto.randomUUID()
+  let created = false
+  withTransaction((db) => {
+    if (kind !== 'heartbeat' && getActiveRunRowForAutomation(db, automationId)) return
+    insertAutomationRun(db, id, automationId, kind, title, options)
+    created = true
+  })
+  return created ? getRun(id) : null
+}
+
+export function getActiveRunForAutomation(automationId: string) {
+  const row = getActiveRunRowForAutomation(getDb(), automationId)
   return row ? rowToRun(row) : null
 }
 

--- a/apps/desktop/src/main/chart-artifacts.ts
+++ b/apps/desktop/src/main/chart-artifacts.ts
@@ -1,7 +1,8 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs'
 import { join, resolve, sep } from 'path'
 import type { ChartArtifactSource, ChartSaveArtifactRequest, SessionArtifact } from '@open-cowork/shared'
 import { getAppDataDir } from './config-loader.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
 import { log } from './logger.ts'
 
 // Charts are captured client-side (vega-embed's `view.toImageURL`) and
@@ -128,7 +129,7 @@ export function saveChartArtifact(request: ChartSaveArtifactRequest): SessionArt
   // duplicate events) overwrites rather than accumulating duplicates.
   const filename = `chart-${sanitizeToolCallId(request.toolCallId)}.png`
   const filePath = join(root, filename)
-  writeFileSync(filePath, bytes)
+  writeFileAtomic(filePath, bytes, { mode: 0o600 })
   const metadataPath = getChartArtifactMetadataPath(filePath)
   if (chart) {
     const metadata = JSON.stringify(chart)
@@ -136,7 +137,7 @@ export function saveChartArtifact(request: ChartSaveArtifactRequest): SessionArt
       rmSync(filePath, { force: true })
       throw new Error('Chart artifact metadata is too large.')
     }
-    writeFileSync(metadataPath, metadata)
+    writeFileAtomic(metadataPath, metadata, { mode: 0o600 })
   } else {
     rmSync(metadataPath, { force: true })
   }

--- a/apps/desktop/src/main/content-security-policy.ts
+++ b/apps/desktop/src/main/content-security-policy.ts
@@ -60,8 +60,9 @@ export const PACKAGED_CONTENT_SECURITY_POLICY = buildContentSecurityPolicy()
 //   1. `default-src 'none'` + `connect-src 'none'` in packaged builds
 //      — even if an attacker-controlled spec turns into arbitrary JS,
 //      it cannot exfiltrate over the network.
-//   2. `sandbox` attribute on the frame tag (allows scripts + same-origin
-//      but blocks popups, forms, navigation, and top-level redirects).
+//   2. `sandbox` attribute on the frame tag allows scripts only. It
+//      intentionally omits `allow-same-origin`, so arbitrary chart JS
+//      stays in an opaque origin and cannot reach parent renderer state.
 //   3. `frame-ancestors 'self'` — only the host renderer can embed it,
 //      blocking click-jacking from untrusted origins.
 //   4. `validateInlineChartSpec` runs before static rendering and inside

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -5,7 +5,7 @@ import { getClient, getClientForDirectory, getRuntimeHomeDir } from '../runtime.
 import { normalizeProviderListResponse, type ProviderLike } from '../provider-utils.ts'
 import { isSandboxWorkspaceDir } from '../runtime-paths.ts'
 import { removeParentSession } from '../events.ts'
-import { rememberSubmittedPrompt, trackParentSession } from '../event-task-state.ts'
+import { forgetSubmittedPrompt, rememberSubmittedPrompt, trackParentSession } from '../event-task-state.ts'
 import type { QuestionAnswer } from '@opencode-ai/sdk/v2'
 import { dispatchRuntimeSessionEvent, publishSessionView } from '../session-event-dispatcher.ts'
 import { sessionEngine } from '../session-engine.ts'
@@ -358,6 +358,7 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
         },
       })
     } catch (err) {
+      forgetSubmittedPrompt(sessionId)
       const win = context.getMainWindow()
       const message = err instanceof Error
         ? err.message

--- a/apps/desktop/src/main/mcp-url-policy.ts
+++ b/apps/desktop/src/main/mcp-url-policy.ts
@@ -37,7 +37,17 @@ privateBlocks.addSubnet('fc00::', 7, 'ipv6')
 
 const nonRoutableBlocks = new BlockList()
 nonRoutableBlocks.addSubnet('0.0.0.0', 8, 'ipv4')
+nonRoutableBlocks.addSubnet('100.64.0.0', 10, 'ipv4')
+nonRoutableBlocks.addSubnet('192.0.0.0', 24, 'ipv4')
+nonRoutableBlocks.addSubnet('192.0.2.0', 24, 'ipv4')
+nonRoutableBlocks.addSubnet('198.18.0.0', 15, 'ipv4')
+nonRoutableBlocks.addSubnet('198.51.100.0', 24, 'ipv4')
+nonRoutableBlocks.addSubnet('203.0.113.0', 24, 'ipv4')
+nonRoutableBlocks.addSubnet('224.0.0.0', 4, 'ipv4')
+nonRoutableBlocks.addSubnet('240.0.0.0', 4, 'ipv4')
 nonRoutableBlocks.addAddress('::', 'ipv6')
+nonRoutableBlocks.addSubnet('2001:db8::', 32, 'ipv6')
+nonRoutableBlocks.addSubnet('ff00::', 8, 'ipv6')
 
 export type McpDnsResolver = (hostname: string) => Promise<Array<{ address: string; family?: number }>>
 

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { AutomationListPayload, AutomationRun, AutomationSummary } from '@open-cowork/shared'
 import { AutomationBoard } from './AutomationBoard'
@@ -165,11 +165,55 @@ describe('AutomationBoard', () => {
         onDropAutomation={vi.fn()}
         onNewAutomation={vi.fn()}
         onLearnMore={vi.fn()}
+        showArchived={false}
+        onShowArchivedChange={vi.fn()}
       />,
     )
 
     expect(screen.getByText('1 active')).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Backlog' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Setup' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Weekly report/ })).toBeInTheDocument()
+  })
+
+  it('hides archived automations until the board toggle is enabled', () => {
+    const onShowArchivedChange = vi.fn()
+    const data = payload({
+      automations: [
+        automation({ id: 'active', title: 'Active automation', status: 'draft' }),
+        automation({ id: 'archived', title: 'Archived automation', status: 'archived' }),
+      ],
+    })
+
+    const { rerender } = render(
+      <AutomationBoard
+        payload={data}
+        selectedAutomationId={null}
+        onSelectAutomation={vi.fn()}
+        onDropAutomation={vi.fn()}
+        onNewAutomation={vi.fn()}
+        onLearnMore={vi.fn()}
+        showArchived={false}
+        onShowArchivedChange={onShowArchivedChange}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /Active automation/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Archived automation/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Show archived (1)' }))
+    expect(onShowArchivedChange).toHaveBeenCalledWith(true)
+
+    rerender(
+      <AutomationBoard
+        payload={data}
+        selectedAutomationId={null}
+        onSelectAutomation={vi.fn()}
+        onDropAutomation={vi.fn()}
+        onNewAutomation={vi.fn()}
+        onLearnMore={vi.fn()}
+        showArchived
+        onShowArchivedChange={onShowArchivedChange}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /Archived automation/ })).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type CSSProperties } from 'react'
 import {
   DndContext,
   DragOverlay,
@@ -30,7 +30,26 @@ type Props = {
   onDropAutomation: (automationId: string, targetColumn: AutomationColumnId) => void
   onNewAutomation: (templateId?: string) => void
   onLearnMore: () => void
+  showArchived: boolean
+  onShowArchivedChange: (showArchived: boolean) => void
   feedback?: string | null
+}
+
+const BOARD_STYLE = {
+  '--automation-card-width': '280px',
+} as CSSProperties
+
+function filterBoardPayload(payload: AutomationListPayload, showArchived: boolean): AutomationListPayload {
+  if (showArchived) return payload
+  const automations = payload.automations.filter((automation) => automation.status !== 'archived')
+  const visibleAutomationIds = new Set(automations.map((automation) => automation.id))
+  return {
+    automations,
+    inbox: payload.inbox.filter((item) => visibleAutomationIds.has(item.automationId)),
+    workItems: payload.workItems.filter((item) => visibleAutomationIds.has(item.automationId)),
+    runs: payload.runs.filter((item) => visibleAutomationIds.has(item.automationId)),
+    deliveries: payload.deliveries.filter((item) => visibleAutomationIds.has(item.automationId)),
+  }
 }
 
 function AutomationColumnView({
@@ -46,7 +65,7 @@ function AutomationColumnView({
   return (
     <section
       ref={setNodeRef}
-      className="flex h-full min-h-[520px] w-[280px] shrink-0 flex-col rounded-2xl border border-border-subtle"
+      className="flex h-full min-h-[520px] w-[var(--automation-card-width)] shrink-0 flex-col rounded-2xl border border-border-subtle"
       style={{
         background: isOver ? 'color-mix(in srgb, var(--color-accent) 8%, var(--color-elevated))' : 'var(--color-elevated)',
       }}
@@ -132,17 +151,21 @@ export function AutomationBoard({
   onDropAutomation,
   onNewAutomation,
   onLearnMore,
+  showArchived,
+  onShowArchivedChange,
   feedback,
 }: Props) {
   const [activeCardId, setActiveCardId] = useState<string | null>(null)
-  const columns = useMemo(() => buildAutomationBoard(payload), [payload])
-  const stats = useMemo(() => summarizeAutomationBoard(payload), [payload])
+  const visiblePayload = useMemo(() => filterBoardPayload(payload, showArchived), [payload, showArchived])
+  const columns = useMemo(() => buildAutomationBoard(visiblePayload), [visiblePayload])
+  const stats = useMemo(() => summarizeAutomationBoard(visiblePayload), [visiblePayload])
+  const archivedCount = useMemo(() => payload.automations.filter((automation) => automation.status === 'archived').length, [payload.automations])
   const cardById = useMemo(() => {
-    return new Map(payload.automations.map((automation) => [
+    return new Map(visiblePayload.automations.map((automation) => [
       automation.id,
-      buildAutomationCardModel(payload, automation),
+      buildAutomationCardModel(visiblePayload, automation),
     ]))
-  }, [payload])
+  }, [visiblePayload])
   const activeCard = activeCardId ? cardById.get(activeCardId) || null : null
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -165,7 +188,7 @@ export function AutomationBoard({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col" style={BOARD_STYLE}>
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap gap-2 text-[12px] text-text-secondary">
           <span className="rounded-full border border-border px-3 py-1">{stats.active} active</span>
@@ -174,6 +197,16 @@ export function AutomationBoard({
           <span className="rounded-full border border-border px-3 py-1">{stats.delivered} delivered</span>
         </div>
         <div className="flex gap-2">
+          {archivedCount > 0 ? (
+            <button
+              type="button"
+              onClick={() => onShowArchivedChange(!showArchived)}
+              aria-pressed={showArchived}
+              className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer"
+            >
+              {showArchived ? 'Hide archived' : `Show archived (${archivedCount})`}
+            </button>
+          ) : null}
           <button type="button" onClick={onLearnMore} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">
             Learn more
           </button>
@@ -192,6 +225,11 @@ export function AutomationBoard({
           {feedback}
         </div>
       ) : null}
+      {visiblePayload.automations.length === 0 && archivedCount > 0 ? (
+        <div className="mb-3 rounded-xl border border-border-subtle px-4 py-2 text-[12px] text-text-secondary" role="status">
+          Archived automations are hidden. Use Show archived to inspect them.
+        </div>
+      ) : null}
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={() => setActiveCardId(null)}>
         <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto pb-3" aria-label="Automation lifecycle board">
           {columns.map((column) => (
@@ -205,7 +243,7 @@ export function AutomationBoard({
         </div>
         <DragOverlay>
           {activeCard ? (
-            <div className="w-[280px]">
+            <div className="w-[var(--automation-card-width)]">
               <AutomationCard card={activeCard} selected={false} onSelect={() => undefined} dragDisabled />
             </div>
           ) : null}

--- a/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
@@ -25,7 +25,7 @@ function statusTone(card: AutomationCardModel) {
 export function AutomationCard({ card, selected, onSelect, dragDisabled = false }: Props) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: card.automation.id,
-    disabled: dragDisabled || card.automation.status === 'archived',
+    disabled: dragDisabled,
     data: { type: 'automation-card' },
   })
   const progress = progressPercent(card.workProgress.completed, card.workProgress.total)

--- a/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
@@ -184,7 +184,9 @@ export function AutomationCardDetail({
             {activeRun ? (
               <button type="button" onClick={() => void onCancelRun(activeRun.id)} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Cancel run</button>
             ) : null}
-            {automation.status === 'paused' ? (
+            {isArchived ? (
+              <button type="button" onClick={() => void onResume()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Restore</button>
+            ) : automation.status === 'paused' ? (
               <button type="button" onClick={() => void onResume()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Resume</button>
             ) : (
               <button type="button" disabled={isArchived} onClick={() => void onPause()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">Pause</button>

--- a/apps/desktop/src/renderer/components/automations/AutomationDropConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationDropConfirmDialog.tsx
@@ -1,0 +1,37 @@
+import { useRef } from 'react'
+import { ModalBackdrop } from '../layout/ModalBackdrop'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import type { AutomationDropAction } from './automation-board-support'
+
+type Props = {
+  action: Extract<AutomationDropAction, { valid: true }>
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export function AutomationDropConfirmDialog({ action, onCancel, onConfirm }: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(dialogRef, { onEscape: onCancel })
+  return (
+    <>
+      <ModalBackdrop onDismiss={onCancel} />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-drop-confirm-title"
+        className="fixed left-1/2 top-[28vh] z-50 w-[420px] max-w-[92vw] -translate-x-1/2 rounded-2xl border border-border-subtle p-5 shadow-2xl"
+        style={{ background: 'var(--color-base)' }}
+      >
+        <h2 id="automation-drop-confirm-title" className="text-[16px] font-semibold text-text">{action.title}</h2>
+        <p className="mt-2 text-[13px] leading-6 text-text-secondary">{action.message}</p>
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Cancel</button>
+          <button type="button" onClick={onConfirm} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>
+            Confirm
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.tsx
@@ -1,0 +1,50 @@
+import { useRef } from 'react'
+import { ModalBackdrop } from '../layout/ModalBackdrop'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+
+type Props = {
+  onClose: () => void
+}
+
+export function AutomationHelpDrawer({ onClose }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(panelRef, { onEscape: onClose })
+  return (
+    <>
+      <ModalBackdrop onDismiss={onClose} className="fixed inset-0 z-40 bg-black/30" />
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-help-title"
+        className="fixed bottom-0 right-0 top-0 z-50 flex w-[460px] max-w-full flex-col border-l border-border-subtle shadow-2xl"
+        style={{ background: 'var(--color-base)' }}
+      >
+        <div className="border-b border-border-subtle px-5 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">How it works</div>
+              <h2 id="automation-help-title" className="mt-1 text-[20px] font-semibold text-text">Standing agent programs</h2>
+            </div>
+            <button type="button" onClick={onClose} aria-label="Close help" className="text-[22px] leading-none text-text-muted hover:text-text cursor-pointer">x</button>
+          </div>
+        </div>
+        <div className="space-y-4 overflow-y-auto p-5">
+          {[
+            ['1. Enrich', 'Cowork routes the raw ask through OpenCode plan and turns it into an execution-ready brief.'],
+            ['2. Review', 'Approvals, missing context, and failures become Inbox items so the automation pauses instead of guessing.'],
+            ['3. Execute', 'Approved work runs through OpenCode build and specialist subagents, then lands as in-app delivery.'],
+          ].map(([title, body]) => (
+            <div key={title} className="rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>
+              <div className="text-[13px] font-semibold text-text">{title}</div>
+              <div className="mt-2 text-[12px] leading-6 text-text-secondary">{body}</div>
+            </div>
+          ))}
+          <div className="rounded-2xl border border-border-subtle p-4 text-[12px] leading-6 text-text-secondary">
+            Drag a card to another lifecycle column when the board offers a valid shortcut. Risky actions ask for confirmation before Cowork calls the existing automation action.
+          </div>
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -6,12 +6,12 @@ import type {
   BuiltInAgentDetail,
   CustomAgentSummary,
 } from '@open-cowork/shared'
-import { ModalBackdrop } from '../layout/ModalBackdrop'
-import { useFocusTrap } from '../../hooks/useFocusTrap'
 import { t } from '../../helpers/i18n'
 import { AutomationBoard } from './AutomationBoard'
 import { AutomationCardDetail } from './AutomationCardDetail'
 import { AutomationCreateWizard } from './AutomationCreateWizard'
+import { AutomationDropConfirmDialog } from './AutomationDropConfirmDialog'
+import { AutomationHelpDrawer } from './AutomationHelpDrawer'
 import {
   buildAutomationCardModel,
   resolveAutomationDropAction,
@@ -31,84 +31,6 @@ type Props = {
   onOpenThread?: (sessionId: string) => void
 }
 
-function HelpDrawer({ onClose }: { onClose: () => void }) {
-  const panelRef = useRef<HTMLDivElement>(null)
-  useFocusTrap(panelRef, { onEscape: onClose })
-  return (
-    <>
-      <ModalBackdrop onDismiss={onClose} className="fixed inset-0 z-40 bg-black/30" />
-      <aside
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="automation-help-title"
-        className="fixed bottom-0 right-0 top-0 z-50 flex w-[460px] max-w-full flex-col border-l border-border-subtle shadow-2xl"
-        style={{ background: 'var(--color-base)' }}
-      >
-        <div className="border-b border-border-subtle px-5 py-4">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">How it works</div>
-              <h2 id="automation-help-title" className="mt-1 text-[20px] font-semibold text-text">Standing agent programs</h2>
-            </div>
-            <button type="button" onClick={onClose} aria-label="Close help" className="text-[22px] leading-none text-text-muted hover:text-text cursor-pointer">×</button>
-          </div>
-        </div>
-        <div className="space-y-4 overflow-y-auto p-5">
-          {[
-            ['1. Enrich', 'Cowork routes the raw ask through OpenCode plan and turns it into an execution-ready brief.'],
-            ['2. Review', 'Approvals, missing context, and failures become Inbox items so the automation pauses instead of guessing.'],
-            ['3. Execute', 'Approved work runs through OpenCode build and specialist subagents, then lands as in-app delivery.'],
-          ].map(([title, body]) => (
-            <div key={title} className="rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>
-              <div className="text-[13px] font-semibold text-text">{title}</div>
-              <div className="mt-2 text-[12px] leading-6 text-text-secondary">{body}</div>
-            </div>
-          ))}
-          <div className="rounded-2xl border border-border-subtle p-4 text-[12px] leading-6 text-text-secondary">
-            Drag a card to another lifecycle column when the board offers a valid shortcut. Risky actions ask for confirmation before Cowork calls the existing automation action.
-          </div>
-        </div>
-      </aside>
-    </>
-  )
-}
-
-function ConfirmDropDialog({
-  action,
-  onCancel,
-  onConfirm,
-}: {
-  action: Extract<AutomationDropAction, { valid: true }>
-  onCancel: () => void
-  onConfirm: () => void
-}) {
-  const dialogRef = useRef<HTMLDivElement>(null)
-  useFocusTrap(dialogRef, { onEscape: onCancel })
-  return (
-    <>
-      <ModalBackdrop onDismiss={onCancel} />
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="automation-drop-confirm-title"
-        className="fixed left-1/2 top-[28vh] z-50 w-[420px] max-w-[92vw] -translate-x-1/2 rounded-2xl border border-border-subtle p-5 shadow-2xl"
-        style={{ background: 'var(--color-base)' }}
-      >
-        <h2 id="automation-drop-confirm-title" className="text-[16px] font-semibold text-text">{action.title}</h2>
-        <p className="mt-2 text-[13px] leading-6 text-text-secondary">{action.message}</p>
-        <div className="mt-5 flex justify-end gap-2">
-          <button type="button" onClick={onCancel} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">Cancel</button>
-          <button type="button" onClick={onConfirm} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>
-            Confirm
-          </button>
-        </div>
-      </div>
-    </>
-  )
-}
-
 export function AutomationsPage({ onOpenThread }: Props) {
   const [payload, setPayload] = useState<AutomationListPayload>({ automations: [], inbox: [], workItems: [], runs: [], deliveries: [] })
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null)
@@ -118,6 +40,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
   const [wizardDefaults, setWizardDefaults] = useState<DraftState>(() => createDefaultDraft())
   const [wizardOpen, setWizardOpen] = useState(false)
   const [helpOpen, setHelpOpen] = useState(false)
+  const [showArchived, setShowArchived] = useState(false)
   const [pendingDropAction, setPendingDropAction] = useState<Extract<AutomationDropAction, { valid: true }> | null>(null)
   const [feedback, setFeedback] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -313,6 +236,8 @@ export function AutomationsPage({ onOpenThread }: Props) {
         onDropAutomation={handleDropAutomation}
         onNewAutomation={openWizard}
         onLearnMore={() => setHelpOpen(true)}
+        showArchived={showArchived}
+        onShowArchivedChange={setShowArchived}
         feedback={feedback}
       />
 
@@ -325,7 +250,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
         />
       ) : null}
 
-      {helpOpen ? <HelpDrawer onClose={() => setHelpOpen(false)} /> : null}
+      {helpOpen ? <AutomationHelpDrawer onClose={() => setHelpOpen(false)} /> : null}
 
       {selectedAutomation ? (
         <AutomationCardDetail
@@ -355,7 +280,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
       ) : null}
 
       {pendingDropAction ? (
-        <ConfirmDropDialog
+        <AutomationDropConfirmDialog
           action={pendingDropAction}
           onCancel={() => setPendingDropAction(null)}
           onConfirm={() => {

--- a/apps/desktop/src/renderer/components/automations/automation-board-support.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-board-support.ts
@@ -75,7 +75,7 @@ export type AutomationColumn = {
 export const AUTOMATION_COLUMNS: Array<Omit<AutomationColumn, 'cards'>> = [
   {
     id: 'draft',
-    title: 'Backlog',
+    title: 'Setup',
     description: 'New programs that still need an execution brief.',
   },
   {

--- a/apps/desktop/src/renderer/components/chat/VegaChart.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/VegaChart.test.tsx
@@ -8,7 +8,7 @@ describe('VegaChart', () => {
     render(<VegaChart spec={{ mark: 'bar', data: { values: [{ x: 'A', y: 1 }] } }} />)
 
     const iframe = screen.getByTitle('Generated chart')
-    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin')
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts')
     expect(iframe.getAttribute('src')).toContain('chart-frame.html')
 
     fireEvent.load(iframe)

--- a/apps/desktop/src/renderer/components/chat/VegaChart.tsx
+++ b/apps/desktop/src/renderer/components/chat/VegaChart.tsx
@@ -82,13 +82,7 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
     return makeInteractiveVegaSpecResponsive(themed)
   }, [chartTheme, spec])
   const frameSrc = useMemo(() => new URL('./chart-frame.html', window.location.href).toString(), [])
-  const frameOrigin = useMemo(() => {
-    try {
-      return new URL(frameSrc, window.location.href).origin
-    } catch {
-      return window.location.origin
-    }
-  }, [frameSrc])
+  const frameOrigin = 'null'
 
   const canCapture = Boolean(sessionId && toolCallId && toolName)
   const chartSource = useMemo<ChartArtifactSource | null>(() => {
@@ -114,13 +108,11 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
 
     captureRequestIdRef.current += 1
     const requestId = captureRequestIdRef.current
-    const iframeSrc = iframeRef.current.src || ''
-    let targetOrigin = window.location.origin
-    try {
-      if (iframeSrc) targetOrigin = new URL(iframeSrc, window.location.href).origin
-    } catch {
-      /* fall back */
-    }
+    // The chart iframe intentionally omits `allow-same-origin`, so its
+    // sandboxed origin is opaque. Opaque targets can only receive
+    // postMessage with "*"; the destination is still scoped to this
+    // iframe's contentWindow, and replies are source-checked below.
+    const targetOrigin = '*'
     iframeRef.current.contentWindow.postMessage({
       type: 'capture-chart',
       requestId,
@@ -214,18 +206,9 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
     setError(null)
     setFrameHeight(DEFAULT_FRAME_HEIGHT)
 
-    // Post to the frame's own origin rather than `"*"` so a compromised
-    // or hijacked cross-origin listener inside the iframe can't intercept
-    // the spec. In Electron packaged builds the frame is served via
-    // `file://`; in dev it's the vite dev server. `iframeRef.src` holds
-    // either URL and we can derive the target origin from it.
-    const iframeSrc = iframeRef.current.src || ''
-    let targetOrigin = window.location.origin
-    try {
-      if (iframeSrc) targetOrigin = new URL(iframeSrc, window.location.href).origin
-    } catch {
-      // Non-URL src (e.g. data:); fall back to the renderer's own origin.
-    }
+    // The sandboxed frame has an opaque origin; see the capture path
+    // above for why targetOrigin must be "*".
+    const targetOrigin = '*'
     iframeRef.current.contentWindow.postMessage({
       type: 'render-chart',
       requestId,
@@ -287,7 +270,7 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
         ref={iframeRef}
         title={t('chart.generatedChart', 'Generated chart')}
         src={frameSrc}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts"
         className="block w-full border-0 bg-transparent"
         style={{ height: `${frameHeight}px` }}
         onLoad={() => {

--- a/apps/desktop/tests/automations-page.smoke.test.ts
+++ b/apps/desktop/tests/automations-page.smoke.test.ts
@@ -40,7 +40,7 @@ test('automations page creates and renders an automation', async () => {
       'Build a weekly market and performance report for leadership.',
     )
 
-    await page.getByRole('heading', { name: 'Backlog', exact: true }).waitFor()
+    await page.getByRole('heading', { name: 'Setup', exact: true }).waitFor()
     await page.getByRole('button', { name: /Weekly market report/ }).waitFor()
     await page.getByRole('dialog', { name: /Weekly market report/ }).waitFor()
     await page.getByText('Run policy', { exact: true }).waitFor()
@@ -143,6 +143,43 @@ test('automation creation persists preferred specialists', async () => {
     })
 
     assert.deepEqual(payload.automations[0]?.preferredAgentNames, ['general', 'explore'])
+  } finally {
+    await cleanup()
+  }
+})
+
+test('archived automations are hidden until requested and can be restored', async () => {
+  const { page, cleanup } = await launchSmokeApp()
+
+  try {
+    await waitForAppShell(page)
+    await page.getByRole('button', { name: 'Automations', exact: true }).click()
+
+    await createWeeklyAutomation(
+      page,
+      'Archive recovery check',
+      'Verify archived automations are not lost from the board.',
+    )
+    await page.getByRole('dialog', { name: /Archive recovery check/ }).waitFor()
+    await page.getByRole('button', { name: 'Archive', exact: true }).click()
+    await page.getByRole('button', { name: 'Restore', exact: true }).waitFor()
+    await page.getByRole('button', { name: 'Close automation details' }).click()
+
+    await page.getByRole('button', { name: 'Show archived (1)', exact: true }).waitFor()
+    assert.equal(await page.getByRole('button', { name: /Archive recovery check/ }).count(), 0)
+
+    await page.getByRole('button', { name: 'Show archived (1)', exact: true }).click()
+    await page.getByRole('button', { name: /Archive recovery check/ }).waitFor()
+    await page.getByRole('button', { name: /Archive recovery check/ }).click()
+    await page.getByRole('button', { name: 'Restore', exact: true }).click()
+    await page.getByRole('button', { name: 'Pause', exact: true }).waitFor()
+
+    const payload = await page.evaluate(async () => {
+      return window.coworkApi.automation.list()
+    })
+
+    assert.equal(payload.automations[0]?.title, 'Archive recovery check')
+    assert.notEqual(payload.automations[0]?.status, 'archived')
   } finally {
     await cleanup()
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,12 @@ The default upstream config is organized into:
 - `skills`
 - `mcps`
 - `agents`
+- `agentStarterTemplates`
+- `builtInAgents`
 - `permissions`
+- `compaction`
+- `i18n`
+- `telemetry`
 
 ## Branding
 
@@ -518,6 +523,32 @@ tuned or silenced via `builtInAgents`:
 `disable: true` removes the agent from the runtime entirely — it will
 no longer appear in the UI or accept delegations. Any inference field
 can be set independently; unset fields keep Cowork's defaults.
+
+### Agent starter templates
+
+`agentStarterTemplates` controls the quick-start cards shown in the agent
+builder. Templates are UI scaffolding only: creating or editing an agent
+still writes a normal OpenCode-native configured agent. Downstream builds
+can replace the upstream examples with company-specific roles, skills, and
+tool presets without forking the renderer.
+
+```json
+{
+  "agentStarterTemplates": [
+    {
+      "id": "internal-analyst",
+      "label": "Internal analyst",
+      "description": "Reviews internal reports and prepares a concise brief.",
+      "color": "info",
+      "instructions": "Use approved internal MCPs and cite sources.",
+      "toolIds": ["internal-reports"],
+      "skillNames": ["analysis"],
+      "temperature": 0.2,
+      "steps": 30
+    }
+  ]
+}
+```
 
 ## Compaction
 

--- a/tests/automation-store.test.ts
+++ b/tests/automation-store.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { rmSync } from 'node:fs'
+import { existsSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
@@ -10,6 +10,7 @@ import {
   createAutomation,
   createDeliveryRecord,
   createAutomationRun,
+  createAutomationRunWhenNoActive,
   createInboxItem,
   getAutomationDetail,
   getRun,
@@ -142,6 +143,103 @@ test('automation store persists automations, briefs, inbox items, and runs toget
     )
     assert.equal(payload.inbox[0]?.title, 'Review ready')
     assert.equal(payload.deliveries[0]?.title, 'Weekly report delivered')
+  } finally {
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('automation store keeps SQLite files private', { skip: process.platform === 'win32' }, () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('private-mode')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    createAutomation({
+      title: 'Private database mode',
+      goal: 'Persist user-authored automation state with private permissions.',
+      kind: 'recurring',
+      schedule: {
+        type: 'weekly',
+        timezone: 'UTC',
+        dayOfWeek: 1,
+        runAtHour: 9,
+        runAtMinute: 0,
+      },
+      heartbeatMinutes: 15,
+      retryPolicy: {
+        maxRetries: 3,
+        baseDelayMinutes: 5,
+        maxDelayMinutes: 60,
+      },
+      runPolicy: {
+        dailyRunCap: 6,
+        maxRunDurationMinutes: 120,
+      },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: null,
+      preferredAgentNames: [],
+    })
+
+    const dbPath = join(userDataDir, 'automation.sqlite')
+    assert.equal(statSync(dbPath).mode & 0o777, 0o600)
+    for (const sidecar of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+      if (existsSync(sidecar)) {
+        assert.equal(statSync(sidecar).mode & 0o777, 0o600)
+      }
+    }
+  } finally {
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('createAutomationRunWhenNoActive atomically refuses duplicate work runs', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('active-run-guard')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const automation = createAutomation({
+      title: 'Duplicate guard',
+      goal: 'Never create two active work runs for the same automation.',
+      kind: 'recurring',
+      schedule: {
+        type: 'weekly',
+        timezone: 'UTC',
+        dayOfWeek: 1,
+        runAtHour: 9,
+        runAtMinute: 0,
+      },
+      heartbeatMinutes: 15,
+      retryPolicy: {
+        maxRetries: 3,
+        baseDelayMinutes: 5,
+        maxDelayMinutes: 60,
+      },
+      runPolicy: {
+        dailyRunCap: 6,
+        maxRunDurationMinutes: 120,
+      },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: null,
+      preferredAgentNames: [],
+    })
+
+    const first = createAutomationRunWhenNoActive(automation.id, 'execution', 'Execute first')
+    assert.ok(first)
+    assert.equal(createAutomationRunWhenNoActive(automation.id, 'execution', 'Execute duplicate'), null)
+    assert.ok(createAutomationRunWhenNoActive(automation.id, 'heartbeat', 'Heartbeat still allowed'))
   } finally {
     clearAutomationStoreCache()
     clearConfigCaches()

--- a/tests/chart-artifacts.test.ts
+++ b/tests/chart-artifacts.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs'
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { saveChartArtifact, getChartArtifactsRoot, readChartArtifactSource } from '../apps/desktop/src/main/chart-artifacts.ts'
@@ -35,6 +35,30 @@ test('saveChartArtifact writes a base64 PNG to a per-session root', () => {
 
     const root = getChartArtifactsRoot(sessionId)
     assert.ok(artifact.filePath.startsWith(root + '/'))
+  } finally {
+    cleanup(sessionId)
+  }
+})
+
+test('saveChartArtifact writes private file permissions', { skip: process.platform === 'win32' }, () => {
+  const sessionId = 'sess-test-private-mode-' + Date.now()
+  try {
+    const artifact = saveChartArtifact({
+      sessionId,
+      toolCallId: 'tool-private',
+      toolName: 'render_chart',
+      dataUrl: ONE_PX_PNG,
+      chart: {
+        format: 'vega-lite',
+        spec: {
+          mark: 'bar',
+          data: { values: [{ label: 'A', value: 1 }] },
+        },
+      },
+    })
+
+    assert.equal(statSync(artifact.filePath).mode & 0o777, 0o600)
+    assert.equal(statSync(artifact.filePath.replace(/\.png$/i, '.json')).mode & 0o777, 0o600)
   } finally {
     cleanup(sessionId)
   }

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -8,6 +8,7 @@ import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-ha
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { registerAutomationHandlers } from '../apps/desktop/src/main/ipc/automation-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
+import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { stopSessionStatusReconciliation } from '../apps/desktop/src/main/session-status-reconciler.ts'
 
@@ -123,6 +124,42 @@ test('session:prompt rejects too many attachments before runtime dispatch', asyn
     /Prompt attachments exceed 10 files/,
   )
   assert.equal(clientRequested, false)
+})
+
+test('session:prompt clears pending prompt echo when dispatch fails', async () => {
+  const { context, handlers } = createBaseContext()
+  let promptCalled = false
+  context.getSessionClient = async () => ({
+    client: {
+      provider: {
+        list: async () => ({
+          data: [],
+        }),
+        auth: async () => ({ data: {} }),
+      },
+      session: {
+        promptAsync: async () => {
+          promptCalled = true
+          throw new Error('dispatch failed')
+        },
+      },
+    } as any,
+    record: null,
+  })
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('session:prompt')
+
+  assert.ok(handler, 'expected session:prompt handler to be registered')
+  await assert.rejects(
+    () => handler({}, 'session-prompt-failure', 'hello from optimistic prompt'),
+    /dispatch failed/i,
+  )
+  assert.equal(promptCalled, true)
+  assert.equal(
+    consumePendingPromptEcho('session-prompt-failure', 'hello from optimistic prompt'),
+    'hello from optimistic prompt',
+  )
 })
 
 test('session:create rejects renderer-supplied project directories without a native-picker grant', async () => {

--- a/tests/mcp-url-policy.test.ts
+++ b/tests/mcp-url-policy.test.ts
@@ -28,6 +28,22 @@ test('evaluateHttpMcpUrl rejects RFC1918 private ranges by default', () => {
   }
 })
 
+test('evaluateHttpMcpUrl rejects special-use non-public ranges by default', () => {
+  for (const url of [
+    'http://100.64.0.1/',
+    'http://198.18.0.1/',
+    'http://224.0.0.1/',
+    'http://240.0.0.1/',
+    'http://192.0.2.1/',
+    'http://198.51.100.1/',
+    'http://203.0.113.1/',
+  ]) {
+    const result = evaluateHttpMcpUrl(url)
+    assert.equal(result.ok, false, `expected reject for ${url}`)
+    if (result.ok === false) assert.match(result.reason, /non-routable/i)
+  }
+})
+
 test('evaluateHttpMcpUrl accepts private ranges when allowPrivateNetwork is true', () => {
   for (const url of ['http://localhost:3000', 'http://10.0.0.1/', 'http://192.168.1.1/']) {
     const result = evaluateHttpMcpUrl(url, { allowPrivateNetwork: true })
@@ -56,6 +72,8 @@ test('evaluateHttpMcpUrl rejects IPv6 loopback + link-local + ULA', () => {
   assert.equal(evaluateHttpMcpUrl('http://[::1]/').ok, false)
   assert.equal(evaluateHttpMcpUrl('http://[fe80::1]/').ok, false)
   assert.equal(evaluateHttpMcpUrl('http://[fd00::1]/').ok, false)
+  assert.equal(evaluateHttpMcpUrl('http://[2001:db8::1]/').ok, false)
+  assert.equal(evaluateHttpMcpUrl('http://[ff02::1]/').ok, false)
 })
 
 test('evaluateHttpMcpUrl rejects IPv6 zone-id link-local inputs', () => {
@@ -82,7 +100,7 @@ test('evaluateHttpMcpUrlResolved accepts public DNS answers', async () => {
 })
 
 test('evaluateHttpMcpUrlResolved rejects public-looking hostnames resolving to private networks', async () => {
-  for (const address of ['127.0.0.1', '10.0.0.5', '169.254.169.254', 'fd00::1']) {
+  for (const address of ['127.0.0.1', '10.0.0.5', '169.254.169.254', '100.64.0.8', '198.18.0.1', '224.0.0.1', 'fd00::1', '2001:db8::1', 'ff02::1']) {
     const result = await evaluateHttpMcpUrlResolved('https://mcp.example.com/api', {
       resolveHostname: async () => [{ address }],
     })

--- a/tests/vega-chart-message-utils.test.ts
+++ b/tests/vega-chart-message-utils.test.ts
@@ -40,6 +40,13 @@ test('shouldHandleChartFrameMessage only accepts messages from the matching ifra
     eventOrigin: 'file://',
     expectedOrigin: 'null',
   }), true)
+
+  assert.equal(shouldHandleChartFrameMessage({
+    frameWindow: owningFrame,
+    eventSource: owningFrame,
+    eventOrigin: 'null',
+    expectedOrigin: 'null',
+  }), true)
 })
 
 test('shouldHandleChartFrameMessage rejects opaque origins for non-file frames', () => {


### PR DESCRIPTION
## Summary

- Adds archived automation recovery to the Kanban board, renames the draft lane to `Setup`, moves small automation dialogs out of `AutomationsPage`, and keeps board card width centralized.
- Hardens audit-proven runtime boundaries: e2e smoke loop now exits on the first failed file, chart artifacts use atomic private writes, automation SQLite files are chmodded private, active automation work-run creation gets an atomic duplicate guard, MCP HTTP URL policy blocks more special-use ranges, prompt failure clears stale optimistic prompt state, and the Vega chart iframe now runs without same-origin privileges.
- Documents `agentStarterTemplates` and completes the configuration top-level section list.

## Review Notes

I reviewed the supplied audit items against the current tree. Proven and addressed: false-green `test:e2e`, chart artifact write policy, automation DB file modes, active-run duplicate guard, special-use MCP URL ranges, stale optimistic prompt state, chart iframe same-origin isolation, archived automation recovery, and config docs drift.

Refuted or deferred: the stale `Backlog` renderer test already passes as `Setup`; automation draft validation is already enforced in main IPC; the Hono override is still active via `@modelcontextprotocol/sdk`; Linux packaged smoke, SBOM cross-checking, and large-file splits remain valid roadmap work outside this focused hardening PR.

## Validation

- `pnpm lint`
- `pnpm lint:a11y --max-warnings=0`
- `pnpm typecheck`
- `pnpm test` (679 tests)
- `pnpm --dir apps/desktop test:renderer` (26 tests)
- `pnpm test:e2e`
- `pnpm perf:check`
- `pnpm audit --prod --audit-level high`
- `uv run mkdocs build --strict`
- `git diff --check`