### PR TITLE
Harden audit-proved release edges

### DIFF
--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -600,10 +600,16 @@ export function approveAutomationBrief(automationId: string) {
   }
   const updated = saveAutomationBrief(automationId, approvedBrief)
   for (const item of listOpenInboxForAutomation(automationId, 'approval')) {
+    if (item.runId) {
+      const run = getRun(item.runId)
+      if (run?.automationId === automationId && run.kind === 'enrichment' && run.status === 'needs_user') {
+        markRunCompleted(item.runId, 'Execution brief approved.', item.sessionId)
+      }
+    }
     resolveInboxItem(item.id, 'resolved')
   }
   publishAutomationUpdated()
-  return updated
+  return getAutomationDetail(automationId) || updated
 }
 
 export async function runAutomationNow(automationId: string): Promise<AutomationRun | null> {

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -566,9 +566,9 @@ export function getAppConfig(): OpenCoworkConfig {
     const baseForPaths = getBaseConfigForPathResolution()
     const layerPaths = uniquePaths([
       firstExistingConfigPath(getBundledConfigCandidates()),
-      firstExistingConfigPath(getUserConfigCandidates(baseForPaths.branding.dataDirName)),
       firstExistingConfigPath(getOverrideConfigCandidates()),
       firstExistingConfigPath(getCustomDirConfigCandidates()),
+      firstExistingConfigPath(getUserConfigCandidates(baseForPaths.branding.dataDirName)),
       firstExistingConfigPath(getManagedConfigCandidates(baseForPaths.branding.dataDirName)),
     ])
 

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -55,6 +55,9 @@ const MAX_QUESTION_REQUEST_ID_BYTES = 256
 const MAX_QUESTION_ANSWERS = 32
 const MAX_QUESTION_ANSWER_CHOICES = 16
 const MAX_QUESTION_ANSWER_BYTES = 4 * 1024
+const DATA_URL_PREFIX = 'data:'
+const MIME_TYPE_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*(?:;[a-z0-9_.+-]+=[a-z0-9_.+-]+)*$/i
+const DATA_URL_RE = /^data:([^,;]+(?:;[^,;=]+=[^,;]+)*);base64,[A-Za-z0-9+/]*={0,2}$/i
 
 function byteLength(value: string) {
   return Buffer.byteLength(value, 'utf8')
@@ -89,6 +92,22 @@ function normalizePromptText(text: unknown) {
 function normalizePromptAgent(agent: unknown) {
   if (agent == null || agent === '') return 'build'
   return requireBoundedString(agent, 'Prompt agent', MAX_PROMPT_AGENT_BYTES)
+}
+
+function assertPromptAttachmentDataUrl(url: string, mime: string, index: number) {
+  if (!MIME_TYPE_RE.test(mime)) {
+    throw new Error(`Prompt attachment ${index + 1} MIME type is invalid`)
+  }
+  if (!url.startsWith(DATA_URL_PREFIX)) {
+    throw new Error(`Prompt attachment ${index + 1} URL must be a base64 data URL`)
+  }
+  const match = DATA_URL_RE.exec(url)
+  if (!match) {
+    throw new Error(`Prompt attachment ${index + 1} URL must be a base64 data URL`)
+  }
+  if (match[1]?.toLowerCase() !== mime.toLowerCase()) {
+    throw new Error(`Prompt attachment ${index + 1} data URL MIME type must match its declared MIME type`)
+  }
 }
 
 function normalizeSessionId(value: unknown) {
@@ -238,6 +257,7 @@ function normalizePromptAttachments(attachments: unknown): PromptAttachmentInput
     const filename = record.filename == null
       ? undefined
       : requireBoundedString(record.filename, `Prompt attachment ${index + 1} filename`, MAX_PROMPT_ATTACHMENT_FILENAME_BYTES)
+    assertPromptAttachmentDataUrl(url, mime, index)
 
     totalBytes += byteLength(mime) + byteLength(url) + (filename ? byteLength(filename) : 0)
     if (totalBytes > MAX_PROMPT_ATTACHMENTS_TOTAL_BYTES) {

--- a/mcps/skills/src/index.ts
+++ b/mcps/skills/src/index.ts
@@ -1,4 +1,4 @@
-import { closeSync, fstatSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { closeSync, fstatSync, mkdirSync, openSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, isAbsolute, join, parse, relative, resolve } from 'path'
 import { pathToFileURL } from 'url'
@@ -22,6 +22,18 @@ function skillsRoot() {
   return root
 }
 
+export function isSafeSkillBundleName(value: string) {
+  const trimmed = value.trim()
+  if (trimmed.length < 1 || trimmed.length > 64) return false
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(trimmed)) return false
+  return !trimmed.includes('--')
+}
+
+const skillBundleNameSchema = z.string()
+  .min(1)
+  .max(64)
+  .refine(isSafeSkillBundleName, 'Use lowercase letters, numbers, and single hyphens only')
+
 export function resolveSafeSkillsRoot(value?: string) {
   const raw = value?.trim()
   if (!raw) {
@@ -42,7 +54,11 @@ export function resolveSafeSkillsRoot(value?: string) {
 }
 
 function skillDir(name: string) {
-  return join(skillsRoot(), name)
+  const trimmed = name.trim()
+  if (!isSafeSkillBundleName(trimmed)) {
+    throw new Error('Skill bundle name must be a lowercase path segment using letters, numbers, and single hyphens')
+  }
+  return join(skillsRoot(), trimmed)
 }
 
 export function isSafeRelativePath(value: string) {
@@ -91,6 +107,7 @@ function readTextFileCheckedSync(path: string) {
 }
 
 function readSkillBundle(name: string) {
+  if (!isSafeSkillBundleName(name)) return null
   const root = skillDir(name)
   const skillFile = join(root, 'SKILL.md')
   let content: string
@@ -106,13 +123,9 @@ function readSkillBundle(name: string) {
   }
 }
 
-function saveSkillBundle(name: string, skillContent: string, files: Array<{ path: string; content: string }>) {
+export function saveSkillBundle(name: string, skillContent: string, files: Array<{ path: string; content: string }>) {
   const root = skillDir(name)
-  rmSync(root, { recursive: true, force: true })
-  mkdirSync(root, { recursive: true })
-  writeFileSync(join(root, 'SKILL.md'), skillContent)
-
-  for (const file of files) {
+  const validatedFiles = files.map((file) => {
     if (!isSafeRelativePath(file.path)) {
       throw new Error(`Invalid skill file path: ${file.path}`)
     }
@@ -121,8 +134,30 @@ function saveSkillBundle(name: string, skillContent: string, files: Array<{ path
     if (outputRelative.startsWith('..') || outputRelative.startsWith('/')) {
       throw new Error(`Skill file escapes bundle root: ${file.path}`)
     }
-    mkdirSync(dirname(output), { recursive: true })
-    writeFileSync(output, file.content)
+    return { ...file, outputRelative }
+  })
+
+  const tempRoot = `${root}.tmp-${process.pid}-${Date.now()}`
+  rmSync(tempRoot, { recursive: true, force: true })
+  mkdirSync(tempRoot, { recursive: true })
+
+  try {
+    writeFileSync(join(tempRoot, 'SKILL.md'), skillContent)
+    for (const file of validatedFiles) {
+      const output = resolve(tempRoot, file.outputRelative)
+      const outputRelative = relative(tempRoot, output)
+      if (outputRelative.startsWith('..') || outputRelative.startsWith('/')) {
+        throw new Error(`Skill file escapes bundle root: ${file.path}`)
+      }
+      mkdirSync(dirname(output), { recursive: true })
+      writeFileSync(output, file.content)
+    }
+
+    rmSync(root, { recursive: true, force: true })
+    renameSync(tempRoot, root)
+  } catch (err) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    throw err
   }
 }
 
@@ -156,7 +191,7 @@ server.tool(
   'get_skill_bundle',
   'Read one custom OpenCode skill bundle, including SKILL.md and any extra files.',
   {
-    name: z.string().describe('Skill bundle directory name'),
+    name: skillBundleNameSchema.describe('Skill bundle directory name'),
   },
   async ({ name }) => {
     const bundle = readSkillBundle(name)
@@ -177,7 +212,7 @@ server.tool(
   'save_skill_bundle',
   'Create or update a custom OpenCode skill bundle in Open Cowork.',
   {
-    name: z.string().describe('Skill bundle directory name'),
+    name: skillBundleNameSchema.describe('Skill bundle directory name'),
     skill_md: z.string().describe('The contents of SKILL.md'),
     files: z.array(skillFileSchema).optional().default([]).describe('Optional extra files in the skill bundle'),
   },
@@ -200,7 +235,7 @@ server.tool(
   'delete_skill_bundle',
   'Delete a custom OpenCode skill bundle from Open Cowork.',
   {
-    name: z.string().describe('Skill bundle directory name'),
+    name: skillBundleNameSchema.describe('Skill bundle directory name'),
   },
   async ({ name }) => {
     rmSync(skillDir(name), { recursive: true, force: true })

--- a/tests/automation-service.test.ts
+++ b/tests/automation-service.test.ts
@@ -9,17 +9,22 @@ import {
   clearAutomationStoreCache,
   createAutomation,
   createAutomationRun,
+  createAutomationRunWhenNoActive,
+  createInboxItem,
+  getActiveRunForAutomation,
   getAutomationDetail,
   getRun,
   listDueRetryRuns,
   listAutomationState,
   markRunCompleted,
   markRunFailed,
+  markRunNeedsUser,
   markRunStarted,
   saveAutomationBrief,
   updateAutomationStatus,
 } from '../apps/desktop/src/main/automation-store.ts'
 import {
+  approveAutomationBrief,
   handleAutomationQuestionAsked,
   handleAutomationQuestionResolved,
   handleAutomationSessionIdle,
@@ -99,6 +104,86 @@ test('runAutomationNow rejects when an automation already has an active run', as
       () => runAutomationNow(automation.id),
       /already has an active execution run/i,
     )
+  } finally {
+    clearSessionRegistryCache()
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('approving an enrichment brief completes the parked approval run', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('approve-enrichment')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const automation = createAutomation({
+      title: 'Manual approval',
+      goal: 'Approve the brief and then allow execution.',
+      kind: 'recurring',
+      schedule: {
+        type: 'weekly',
+        timezone: 'UTC',
+        dayOfWeek: 1,
+        runAtHour: 9,
+        runAtMinute: 0,
+      },
+      heartbeatMinutes: 15,
+      retryPolicy: {
+        maxRetries: 3,
+        baseDelayMinutes: 5,
+        maxDelayMinutes: 60,
+      },
+      runPolicy: {
+        dailyRunCap: 6,
+        maxRunDurationMinutes: 120,
+      },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: null,
+      preferredAgentNames: [],
+    })
+
+    saveAutomationBrief(automation.id, {
+      version: 1,
+      status: 'needs_approval',
+      goal: automation.goal,
+      deliverables: ['Report'],
+      assumptions: [],
+      missingContext: [],
+      successCriteria: ['Ready'],
+      recommendedAgents: ['research'],
+      workItems: [],
+      approvalBoundary: 'Approve before delivery.',
+      generatedAt: new Date().toISOString(),
+      approvedAt: null,
+    })
+
+    const run = createAutomationRun(automation.id, 'enrichment', 'Prepare execution brief')
+    assert.ok(run)
+    markRunStarted(run.id, 'session-approval')
+    markRunNeedsUser(run.id, 'Execution brief is ready for approval.')
+    createInboxItem({
+      automationId: automation.id,
+      runId: run.id,
+      sessionId: 'session-approval',
+      type: 'approval',
+      title: 'Approve brief',
+      body: 'The execution brief is ready.',
+    })
+
+    const approved = approveAutomationBrief(automation.id)
+
+    assert.equal(approved?.brief?.status, 'ready')
+    assert.ok(approved?.brief?.approvedAt)
+    assert.equal(getRun(run.id)?.status, 'completed')
+    assert.equal(getActiveRunForAutomation(automation.id), null)
+    assert.equal(listAutomationState().inbox.filter((item) => item.automationId === automation.id && item.status === 'open').length, 0)
+    assert.ok(createAutomationRunWhenNoActive(automation.id, 'execution', 'Execute approved brief'))
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -145,6 +145,66 @@ test('config loader accepts JSONC, file placeholders, and partial config directo
   }
 })
 
+test('config loader applies per-user config after downstream env layers', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-merge-order-'))
+  const tempHome = join(tempRoot, 'home')
+  const configDir = join(tempRoot, 'downstream')
+  const userConfigDir = join(tempHome, '.config', 'merge-order-data')
+  const previousHome = process.env.HOME
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousDownstreamRoot = process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  mkdirSync(configDir, { recursive: true })
+  mkdirSync(userConfigDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.json'), JSON.stringify({
+    branding: {
+      dataDirName: 'merge-order-data',
+      helpUrl: 'https://downstream.example/help',
+    },
+  }))
+  writeFileSync(join(userConfigDir, 'config.json'), JSON.stringify({
+    branding: {
+      helpUrl: 'https://user.example/help',
+    },
+  }))
+
+  process.env.HOME = tempHome
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  delete process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+  delete process.env.OPEN_COWORK_CONFIG_PATH
+  clearConfigCaches()
+
+  try {
+    assert.doesNotThrow(() => assertConfigValid())
+    assert.equal(getAppConfig().branding.dataDirName, 'merge-order-data')
+    assert.equal(getAppConfig().branding.helpUrl, 'https://user.example/help')
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME
+    } else {
+      process.env.HOME = previousHome
+    }
+    if (previousConfigDir === undefined) {
+      delete process.env.OPEN_COWORK_CONFIG_DIR
+    } else {
+      process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    }
+    if (previousDownstreamRoot === undefined) {
+      delete process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+    } else {
+      process.env.OPEN_COWORK_DOWNSTREAM_ROOT = previousDownstreamRoot
+    }
+    if (previousOverride === undefined) {
+      delete process.env.OPEN_COWORK_CONFIG_PATH
+    } else {
+      process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    }
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('public branding keeps logoDataUrl fallback when logoAsset cannot resolve', () => {
   const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-branding-fallback-'))
   const configPath = join(tempRoot, 'open-cowork.config.json')

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -126,6 +126,29 @@ test('session:prompt rejects too many attachments before runtime dispatch', asyn
   assert.equal(clientRequested, false)
 })
 
+test('session:prompt rejects non-data attachment URLs before runtime dispatch', async () => {
+  const { context, handlers } = createBaseContext()
+  let clientRequested = false
+  context.getSessionClient = async () => {
+    clientRequested = true
+    throw new Error('runtime should not be reached')
+  }
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('session:prompt')
+
+  assert.ok(handler, 'expected session:prompt handler to be registered')
+  await assert.rejects(
+    () => handler({}, 'session-1', 'hello', [{
+      mime: 'image/png',
+      url: 'file:///Users/example/private.png',
+      filename: 'private.png',
+    }]),
+    /URL must be a base64 data URL/,
+  )
+  assert.equal(clientRequested, false)
+})
+
 test('session:prompt clears pending prompt echo when dispatch fails', async () => {
   const { context, handlers } = createBaseContext()
   let promptCalled = false

--- a/tests/skills-mcp-path-policy.test.ts
+++ b/tests/skills-mcp-path-policy.test.ts
@@ -1,8 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { homedir } from 'node:os'
-import { resolve } from 'node:path'
-import { isSafeRelativePath, resolveSafeSkillsRoot } from '../mcps/skills/src/index.ts'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { isSafeRelativePath, isSafeSkillBundleName, resolveSafeSkillsRoot, saveSkillBundle } from '../mcps/skills/src/index.ts'
 
 test('skills MCP path policy accepts ordinary relative bundle files', () => {
   assert.equal(isSafeRelativePath('references/example.md'), true)
@@ -18,6 +19,39 @@ test('skills MCP path policy rejects traversal and absolute paths', () => {
 test('skills MCP path policy rejects empty segments and Windows traversal', () => {
   for (const path of ['', 'references//example.md', 'references\\..\\secret.md']) {
     assert.equal(isSafeRelativePath(path), false, path)
+  }
+})
+
+test('skills MCP bundle name policy accepts only lowercase path segments', () => {
+  assert.equal(isSafeSkillBundleName('data-analyst'), true)
+  assert.equal(isSafeSkillBundleName('skill1'), true)
+
+  for (const name of ['', '../secret', 'Bad_Skill', '-bad', 'bad-', 'bad--name', 'a'.repeat(65)]) {
+    assert.equal(isSafeSkillBundleName(name), false, name)
+  }
+})
+
+test('skills MCP validates bundle files before replacing an existing bundle', () => {
+  const previousRoot = process.env.OPEN_COWORK_CUSTOM_SKILLS_DIR
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-skills-mcp-'))
+
+  try {
+    process.env.OPEN_COWORK_CUSTOM_SKILLS_DIR = root
+    saveSkillBundle('safe-skill', '# Existing\n', [])
+
+    assert.throws(
+      () => saveSkillBundle('safe-skill', '# Replacement\n', [{ path: '../escape.md', content: 'bad' }]),
+      /Invalid skill file path/,
+    )
+
+    assert.equal(readFileSync(join(root, 'safe-skill', 'SKILL.md'), 'utf-8'), '# Existing\n')
+  } finally {
+    if (previousRoot === undefined) {
+      delete process.env.OPEN_COWORK_CUSTOM_SKILLS_DIR
+    } else {
+      process.env.OPEN_COWORK_CUSTOM_SKILLS_DIR = previousRoot
+    }
+    rmSync(root, { recursive: true, force: true })
   }
 })
 


### PR DESCRIPTION
## Summary
- complete parked automation enrichment runs when a manual brief approval resolves, so approved automations can start execution
- align config precedence with the public downstream docs: bundled -> env/downstream -> per-user -> managed
- harden Skills MCP bundle writes with safe bundle names, preflight file validation, and temp-dir replacement
- reject non-base64 data attachment URLs at the `session:prompt` IPC boundary

## Notes
- I checked the audit claims about `events.ts` interval cleanup and log sanitizer coverage; the interval is already cleared in `finally`, and `tests/log-sanitizer.test.ts` already covers env-backed secrets, token patterns, and export path scrubbing.

## Validation
- `node --test tests/automation-service.test.ts`
- `node --test tests/config-elements.test.ts`
- `node --test tests/skills-mcp-path-policy.test.ts`
- `node --test tests/ipc-handler-behavior.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:renderer`
- `pnpm audit --prod --audit-level high`
- `pnpm perf:check`
- `pnpm docs:build`
- `pnpm test:e2e`
- `git diff --check`