### PR TITLE
Harden automation and IPC audit edges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
 
       - name: Audit full dependency graph (critical advisory)
         run: pnpm audit --audit-level critical
-        continue-on-error: true
 
       - name: Verify third-party notices
         run: |
@@ -156,13 +155,27 @@ jobs:
       - name: Install Linux packaging dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libarchive-tools rpm
+          sudo apt-get install -y libarchive-tools rpm xvfb
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Package Linux desktop app
         run: pnpm --dir apps/desktop dist:ci:linux
+
+      - name: Resolve Linux packaged executable
+        id: linux-packaged-executable
+        run: |
+          path="$(find apps/desktop/release -maxdepth 1 -type f -name "*.AppImage" -print -quit)"
+          test -n "$path" || (echo "Expected an AppImage in apps/desktop/release" && exit 1)
+          chmod +x "$path"
+          echo "path=$(realpath "$path")" >> "$GITHUB_OUTPUT"
+
+      - name: Run Linux packaged desktop smoke test
+        run: xvfb-run -a pnpm --dir apps/desktop test:e2e:packaged
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+          OPEN_COWORK_PACKAGED_EXECUTABLE: ${{ steps.linux-packaged-executable.outputs.path }}
 
       - name: Verify Linux artifacts exist
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,6 @@ jobs:
 
       - name: Audit full dependency graph (critical advisory)
         run: pnpm audit --audit-level critical
-        continue-on-error: true
 
       - name: Lint
         run: pnpm lint

--- a/apps/desktop/src/main/automation-brief-limits.ts
+++ b/apps/desktop/src/main/automation-brief-limits.ts
@@ -1,0 +1,123 @@
+import type { ExecutionBrief } from '@open-cowork/shared'
+
+export const AUTOMATION_BRIEF_LIMITS = {
+  text: 8 * 1024,
+  arrayItems: 32,
+  workItems: 128,
+  workItemId: 128,
+  workItemTitle: 512,
+  workItemDescription: 4 * 1024,
+  dependsOn: 32,
+  agentName: 128,
+  heartbeatText: 4 * 1024,
+} as const
+
+export function limitTextValue(value: string | null | undefined, maxLength = AUTOMATION_BRIEF_LIMITS.text) {
+  return (value || '').slice(0, maxLength)
+}
+
+export function limitTextArray(
+  values: string[] | null | undefined,
+  maxItems = AUTOMATION_BRIEF_LIMITS.arrayItems,
+  maxLength = AUTOMATION_BRIEF_LIMITS.text,
+) {
+  return (Array.isArray(values) ? values : [])
+    .filter((entry): entry is string => typeof entry === 'string')
+    .slice(0, maxItems)
+    .map((entry) => limitTextValue(entry, maxLength))
+}
+
+function shortStableHash(value: string) {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36).padStart(7, '0').slice(0, 7)
+}
+
+function appendIdSuffix(baseId: string, suffix: string) {
+  const maxPrefixLength = Math.max(1, AUTOMATION_BRIEF_LIMITS.workItemId - suffix.length - 1)
+  return `${baseId.slice(0, maxPrefixLength)}-${suffix}`
+}
+
+function uniqueWorkItemId(rawId: string, fallbackId: string, index: number, usedIds: Set<string>) {
+  const sourceId = rawId.trim() || fallbackId
+  const cappedId = limitTextValue(sourceId, AUTOMATION_BRIEF_LIMITS.workItemId).trim() || fallbackId
+  if (!usedIds.has(cappedId)) {
+    usedIds.add(cappedId)
+    return cappedId
+  }
+
+  const hashedId = appendIdSuffix(cappedId, shortStableHash(`${sourceId}:${index}`))
+  if (!usedIds.has(hashedId)) {
+    usedIds.add(hashedId)
+    return hashedId
+  }
+
+  let counter = 2
+  while (true) {
+    const candidate = appendIdSuffix(cappedId, `${shortStableHash(sourceId)}-${counter}`)
+    if (!usedIds.has(candidate)) {
+      usedIds.add(candidate)
+      return candidate
+    }
+    counter += 1
+  }
+}
+
+export function normalizeExecutionBriefForStorage(brief: ExecutionBrief): ExecutionBrief {
+  const workItems = Array.isArray(brief.workItems)
+    ? brief.workItems.slice(0, AUTOMATION_BRIEF_LIMITS.workItems)
+    : []
+  const usedWorkItemIds = new Set<string>()
+  const normalizedIds = workItems.map((item, index) => uniqueWorkItemId(
+    typeof item.id === 'string' ? item.id : '',
+    `work-item-${index + 1}`,
+    index,
+    usedWorkItemIds,
+  ))
+  const idByOriginal = new Map<string, string>()
+  const idByCapped = new Map<string, string>()
+  workItems.forEach((item, index) => {
+    const rawId = typeof item.id === 'string' ? item.id.trim() : ''
+    const cappedId = limitTextValue(rawId, AUTOMATION_BRIEF_LIMITS.workItemId).trim()
+    if (rawId && !idByOriginal.has(rawId)) idByOriginal.set(rawId, normalizedIds[index]!)
+    if (cappedId && !idByCapped.has(cappedId)) idByCapped.set(cappedId, normalizedIds[index]!)
+  })
+
+  return {
+    ...brief,
+    goal: limitTextValue(brief.goal),
+    deliverables: limitTextArray(brief.deliverables),
+    assumptions: limitTextArray(brief.assumptions),
+    missingContext: limitTextArray(brief.missingContext),
+    successCriteria: limitTextArray(brief.successCriteria),
+    recommendedAgents: limitTextArray(brief.recommendedAgents, AUTOMATION_BRIEF_LIMITS.arrayItems, AUTOMATION_BRIEF_LIMITS.agentName),
+    approvalBoundary: limitTextValue(brief.approvalBoundary),
+    workItems: workItems
+      .map((item, index) => ({
+        id: normalizedIds[index]!,
+        title: limitTextValue(item.title, AUTOMATION_BRIEF_LIMITS.workItemTitle).trim() || `Work item ${index + 1}`,
+        description: limitTextValue(item.description, AUTOMATION_BRIEF_LIMITS.workItemDescription),
+        ownerAgent: item.ownerAgent === null ? null : limitTextValue(item.ownerAgent, AUTOMATION_BRIEF_LIMITS.agentName).trim() || null,
+        dependsOn: (Array.isArray(item.dependsOn) ? item.dependsOn : [])
+          .filter((entry): entry is string => typeof entry === 'string')
+          .slice(0, AUTOMATION_BRIEF_LIMITS.dependsOn)
+          .map((entry) => {
+            const dependencyId = entry.trim()
+            return idByOriginal.get(dependencyId)
+              || idByCapped.get(limitTextValue(dependencyId, AUTOMATION_BRIEF_LIMITS.workItemId).trim())
+              || limitTextValue(dependencyId, AUTOMATION_BRIEF_LIMITS.workItemId).trim()
+          })
+          .filter(Boolean),
+      })),
+  }
+}
+
+export function executionBriefApprovalRevision(brief: ExecutionBrief | null | undefined) {
+  if (!brief?.approvedAt) return null
+  const normalized = normalizeExecutionBriefForStorage(brief)
+  const { approvedAt: _approvedAt, ...revision } = normalized
+  return JSON.stringify(revision)
+}

--- a/apps/desktop/src/main/automation-delivery.ts
+++ b/apps/desktop/src/main/automation-delivery.ts
@@ -1,36 +1,6 @@
-import type { AutomationDetail, AutomationRun, AppSettings } from '@open-cowork/shared'
+import type { AutomationDetail, AppSettings } from '@open-cowork/shared'
 import { createDeliveryRecord } from './automation-store.ts'
 import { sendAutomationDesktopNotification, shouldSendAutomationDesktopNotification } from './automation-notifications.ts'
-
-type DeliveryInput = {
-  automation: AutomationDetail
-  run: AutomationRun
-  summary: string
-}
-
-type DeliveryProvider = {
-  provider: 'in_app'
-  deliver(input: DeliveryInput): ReturnType<typeof createDeliveryRecord>
-}
-
-const inAppProvider: DeliveryProvider = {
-  provider: 'in_app',
-  deliver(input) {
-    return createDeliveryRecord({
-      automationId: input.automation.id,
-      runId: input.run.id,
-      provider: 'in_app',
-      target: 'automation-inbox',
-      status: 'delivered',
-      title: `${input.automation.title} output ready`,
-      body: input.summary,
-    })
-  },
-}
-
-export function deliverAutomationRunResult(input: DeliveryInput) {
-  return [inAppProvider.deliver(input)].filter(Boolean)
-}
 
 export function deliverAutomationDesktopUpdate(input: {
   automation: AutomationDetail

--- a/apps/desktop/src/main/automation-prompt-contract.ts
+++ b/apps/desktop/src/main/automation-prompt-contract.ts
@@ -1,4 +1,10 @@
 import type { ExecutionBrief } from '@open-cowork/shared'
+import {
+  AUTOMATION_BRIEF_LIMITS,
+  limitTextArray,
+  limitTextValue,
+  normalizeExecutionBriefForStorage,
+} from './automation-brief-limits.ts'
 
 const EXECUTION_BRIEF_TYPE = 'open_cowork.execution_brief'
 const HEARTBEAT_DECISION_TYPE = 'open_cowork.heartbeat_decision'
@@ -20,16 +26,18 @@ export type AutomationHeartbeatDecision = {
   userMessage: string | null
 }
 
-function readString(value: unknown) {
-  return typeof value === 'string' ? value : ''
+function readString(value: unknown, maxLength = AUTOMATION_BRIEF_LIMITS.text) {
+  return typeof value === 'string' ? limitTextValue(value, maxLength) : ''
 }
 
-function readOptionalString(value: unknown) {
-  return typeof value === 'string' ? value : null
+function readOptionalString(value: unknown, maxLength = AUTOMATION_BRIEF_LIMITS.text) {
+  return typeof value === 'string' ? limitTextValue(value, maxLength) : null
 }
 
-function readStringArray(value: unknown) {
-  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+function readStringArray(value: unknown, maxItems = AUTOMATION_BRIEF_LIMITS.arrayItems, maxLength = AUTOMATION_BRIEF_LIMITS.text) {
+  return Array.isArray(value)
+    ? limitTextArray(value.filter((entry): entry is string => typeof entry === 'string'), maxItems, maxLength)
+    : []
 }
 
 function extractJsonPayload(text: string) {
@@ -52,7 +60,8 @@ function hasContractEnvelope(record: JsonRecord, type: string) {
 
 const STRING_ARRAY_SCHEMA: JsonSchema = {
   type: 'array',
-  items: { type: 'string' },
+  maxItems: AUTOMATION_BRIEF_LIMITS.arrayItems,
+  items: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.text },
 }
 
 const EXECUTION_BRIEF_SCHEMA: JsonSchema = {
@@ -61,24 +70,29 @@ const EXECUTION_BRIEF_SCHEMA: JsonSchema = {
   properties: {
     type: { const: EXECUTION_BRIEF_TYPE },
     version: { const: CONTRACT_VERSION },
-    goal: { type: 'string', description: 'The overall automation goal.' },
+    goal: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.text, description: 'The overall automation goal.' },
     deliverables: STRING_ARRAY_SCHEMA,
     assumptions: STRING_ARRAY_SCHEMA,
     missingContext: STRING_ARRAY_SCHEMA,
     successCriteria: STRING_ARRAY_SCHEMA,
     recommendedAgents: STRING_ARRAY_SCHEMA,
-    approvalBoundary: { type: 'string' },
+    approvalBoundary: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.text },
     workItems: {
       type: 'array',
+      maxItems: AUTOMATION_BRIEF_LIMITS.workItems,
       items: {
         type: 'object',
         additionalProperties: false,
         properties: {
-          id: { type: 'string' },
-          title: { type: 'string' },
-          description: { type: 'string' },
-          ownerAgent: { type: ['string', 'null'] },
-          dependsOn: STRING_ARRAY_SCHEMA,
+          id: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.workItemId },
+          title: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.workItemTitle },
+          description: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.workItemDescription },
+          ownerAgent: { type: ['string', 'null'], maxLength: AUTOMATION_BRIEF_LIMITS.agentName },
+          dependsOn: {
+            type: 'array',
+            maxItems: AUTOMATION_BRIEF_LIMITS.dependsOn,
+            items: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.workItemId },
+          },
         },
         required: ['id', 'title', 'description', 'ownerAgent', 'dependsOn'],
       },
@@ -104,13 +118,13 @@ const HEARTBEAT_DECISION_SCHEMA: JsonSchema = {
   properties: {
     type: { const: HEARTBEAT_DECISION_TYPE },
     version: { const: CONTRACT_VERSION },
-    summary: { type: 'string' },
+    summary: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.heartbeatText },
     action: {
       type: 'string',
       enum: ['noop', 'request_user', 'refresh_brief', 'run_execution'],
     },
-    reason: { type: 'string' },
-    userMessage: { type: ['string', 'null'] },
+    reason: { type: 'string', maxLength: AUTOMATION_BRIEF_LIMITS.heartbeatText },
+    userMessage: { type: ['string', 'null'], maxLength: AUTOMATION_BRIEF_LIMITS.heartbeatText },
   },
   required: ['type', 'version', 'summary', 'action', 'reason', 'userMessage'],
 }
@@ -142,21 +156,22 @@ function coerceExecutionBriefRecord(parsed: JsonRecord): ExecutionBrief | null {
   const missingContext = readStringArray(parsed.missingContext)
   const workItems = Array.isArray(parsed.workItems)
     ? parsed.workItems
+      .slice(0, AUTOMATION_BRIEF_LIMITS.workItems)
       .map((entry, index) => {
         if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
         const record = entry as JsonRecord
         return {
-          id: readString(record.id).trim() || `work-item-${index + 1}`,
-          title: readString(record.title).trim() || `Work item ${index + 1}`,
-          description: readString(record.description),
-          ownerAgent: readOptionalString(record.ownerAgent),
-          dependsOn: readStringArray(record.dependsOn),
+          id: readString(record.id, AUTOMATION_BRIEF_LIMITS.workItemId).trim() || `work-item-${index + 1}`,
+          title: readString(record.title, AUTOMATION_BRIEF_LIMITS.workItemTitle).trim() || `Work item ${index + 1}`,
+          description: readString(record.description, AUTOMATION_BRIEF_LIMITS.workItemDescription),
+          ownerAgent: readOptionalString(record.ownerAgent, AUTOMATION_BRIEF_LIMITS.agentName),
+          dependsOn: readStringArray(record.dependsOn, AUTOMATION_BRIEF_LIMITS.dependsOn, AUTOMATION_BRIEF_LIMITS.workItemId),
         }
       })
       .filter((entry): entry is ExecutionBrief['workItems'][number] => Boolean(entry))
     : []
 
-  return {
+  return normalizeExecutionBriefForStorage({
     version: CONTRACT_VERSION,
     status: missingContext.length > 0 ? 'needs_user' : 'ready',
     goal,
@@ -168,7 +183,7 @@ function coerceExecutionBriefRecord(parsed: JsonRecord): ExecutionBrief | null {
     approvalBoundary: readString(parsed.approvalBoundary).trim() || 'Approve the brief before execution.',
     workItems,
     generatedAt: new Date().toISOString(),
-  }
+  })
 }
 
 function coerceHeartbeatDecisionRecord(parsed: JsonRecord): AutomationHeartbeatDecision | null {
@@ -181,9 +196,9 @@ function coerceHeartbeatDecisionRecord(parsed: JsonRecord): AutomationHeartbeatD
     return null
   }
 
-  const summary = readString(parsed.summary).trim() || readString(parsed.reason).trim() || 'Heartbeat review completed.'
-  const reason = readString(parsed.reason).trim() || summary
-  const userMessage = readOptionalString(parsed.userMessage)?.trim() || null
+  const summary = readString(parsed.summary, AUTOMATION_BRIEF_LIMITS.heartbeatText).trim() || readString(parsed.reason, AUTOMATION_BRIEF_LIMITS.heartbeatText).trim() || 'Heartbeat review completed.'
+  const reason = readString(parsed.reason, AUTOMATION_BRIEF_LIMITS.heartbeatText).trim() || summary
+  const userMessage = readOptionalString(parsed.userMessage, AUTOMATION_BRIEF_LIMITS.heartbeatText)?.trim() || null
   return {
     summary,
     action,

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -31,6 +31,7 @@ import {
   markHeartbeatCompleted,
   markRunCancelled,
   markRunCompleted,
+  markRunCompletedWithDeliveryRecord,
   markRunFailed,
   markRunNeedsUser,
   markRunStarted,
@@ -58,7 +59,7 @@ import {
   extractHeartbeatDecisionFromMessages,
   summarizeAutomationMessages,
 } from './automation-run-output.ts'
-import { deliverAutomationDesktopUpdate, deliverAutomationRunResult } from './automation-delivery.ts'
+import { deliverAutomationDesktopUpdate } from './automation-delivery.ts'
 import { ensureRuntimeContextDirectory } from './runtime-context.ts'
 import { getClientForDirectory, getRuntimeHomeDir } from './runtime.ts'
 import { getEffectiveSettings, loadSettings } from './settings.ts'
@@ -68,6 +69,7 @@ import { toSessionRecord, upsertSessionRecord, getSessionRecord } from './sessio
 import { trackParentSession } from './event-task-state.ts'
 import { log } from './logger.ts'
 import type { OutputFormat } from '@opencode-ai/sdk/v2'
+import { executionBriefApprovalRevision } from './automation-brief-limits.ts'
 
 let getMainWindow: (() => BrowserWindow | null) | null = null
 let schedulerTimer: NodeJS.Timeout | null = null
@@ -273,7 +275,7 @@ async function createAutomationSession(options: {
   })
   upsertSessionRecord(sessionRecord)
   trackParentSession(session.id)
-  attachRunSession(options.runId, session.id)
+  attachRunSession(options.runId, options.automationId, session.id)
   markRunStarted(options.runId, session.id)
   publishAutomationUpdated()
   await client.session.promptAsync({
@@ -757,8 +759,17 @@ export async function handleAutomationSessionIdle(sessionId: string) {
     }
 
     if (decision.action === 'run_execution') {
+      const approvedRevision = executionBriefApprovalRevision(automation.brief)
       const openInbox = listOpenInboxForAutomation(record.automationId)
-      if (automation.brief?.approvedAt && openInbox.length === 0 && automation.status !== 'paused' && automation.status !== 'archived') {
+      const latestAutomation = getAutomationDetail(record.automationId)
+      if (
+        approvedRevision
+        && latestAutomation
+        && executionBriefApprovalRevision(latestAutomation.brief) === approvedRevision
+        && openInbox.length === 0
+        && latestAutomation.status !== 'paused'
+        && latestAutomation.status !== 'archived'
+      ) {
         markHeartbeatCompleted(run.id, `${completionSummary} Execution queued.`)
         try {
           await startRun(record.automationId, 'execution')
@@ -881,11 +892,18 @@ export async function handleAutomationSessionIdle(sessionId: string) {
     return
   }
 
-  markRunCompleted(run.id, summary, sessionId)
   const automation = getAutomationDetail(record.automationId)
-  const completedRun = getRun(run.id)
+  const completed = automation
+    ? markRunCompletedWithDeliveryRecord(run.id, summary, sessionId, {
+        provider: 'in_app',
+        target: 'automation-inbox',
+        status: 'delivered',
+        title: `${automation.title} output ready`,
+        body: summary,
+      })
+    : { run: markRunCompleted(run.id, summary, sessionId), delivery: null }
+  const completedRun = completed.run
   if (automation && completedRun?.status === 'completed') {
-    deliverAutomationRunResult({ automation, run: completedRun, summary })
     createInboxItem({
       automationId: record.automationId,
       runId: run.id,

--- a/apps/desktop/src/main/automation-store.ts
+++ b/apps/desktop/src/main/automation-store.ts
@@ -23,6 +23,7 @@ import type {
 } from '@open-cowork/shared'
 import { getAppDataDir } from './config-loader.ts'
 import { computeNextAutomationRunAt } from './automation-schedule.ts'
+import { normalizeExecutionBriefForStorage } from './automation-brief-limits.ts'
 
 type DbRow = Record<string, unknown>
 
@@ -621,14 +622,15 @@ export function resumeAutomationStatus(automationId: string) {
 }
 
 export function saveAutomationBrief(automationId: string, brief: ExecutionBrief) {
+  const boundedBrief = normalizeExecutionBriefForStorage(brief)
   withTransaction((db) => {
     const now = new Date().toISOString()
     db.prepare(`
       insert into automation_briefs (automation_id, brief_json, updated_at)
       values (?, ?, ?)
       on conflict(automation_id) do update set brief_json = excluded.brief_json, updated_at = excluded.updated_at
-    `).run(automationId, JSON.stringify(brief), now)
-    const status: AutomationStatus = brief.status === 'needs_user' ? 'needs_user' : brief.status === 'ready' ? 'ready' : 'draft'
+    `).run(automationId, JSON.stringify(boundedBrief), now)
+    const status: AutomationStatus = boundedBrief.status === 'needs_user' ? 'needs_user' : boundedBrief.status === 'ready' ? 'ready' : 'draft'
     const automation = getAutomationRow(automationId)
     db.prepare('update automations set status = ?, updated_at = ?, next_heartbeat_at = ? where id = ?')
       .run(status, now, automation ? nextHeartbeatAt(automation.heartbeat_minutes, new Date(now)) : null, automationId)
@@ -647,10 +649,10 @@ export function saveAutomationBrief(automationId: string, brief: ExecutionBrief)
         updated_at = excluded.updated_at
     `)
     const seenIds = new Set<string>()
-    for (const item of brief.workItems) {
+    for (const item of boundedBrief.workItems) {
       seenIds.add(item.id)
       const existingItem = existingItems.get(item.id)
-      const nextStatus = brief.status === 'ready'
+      const nextStatus = boundedBrief.status === 'ready'
         ? (existingItem?.status === 'completed' || existingItem?.status === 'running' || existingItem?.status === 'failed'
             ? existingItem.status
             : 'ready')
@@ -940,28 +942,32 @@ export function markRunCompleted(runId: string, summary: string | null, sessionI
   const run = getRun(runId)
   if (!run) return null
   withTransaction((db) => {
-    const now = new Date().toISOString()
-    const retryRootRunId = run.retryOfRunId || run.id
-    db.prepare('update automation_runs set status = ?, summary = ?, error = null, failure_code = null, session_id = coalesce(?, session_id), finished_at = ? where id = ?')
-      .run('completed', summary, sessionId || null, now, runId)
-    clearPendingRetriesForChain(retryRootRunId)
-    const row = getAutomationRow(run.automationId)
-    if (row) {
-      const schedule = parseJson<AutomationSchedule>(row.schedule_json, { type: 'weekly', timezone: 'UTC' })
-      if (run.kind === 'execution') {
-        db.prepare('update automations set latest_run_status = ?, latest_session_id = coalesce(?, latest_session_id), updated_at = ?, status = ?, last_run_at = ?, next_run_at = ?, next_heartbeat_at = ? where id = ?')
-          .run('completed', sessionId || null, now, 'completed', now, computeNextAutomationRunAt(schedule, new Date(now)), nextHeartbeatAt(row.heartbeat_minutes, new Date(now)), run.automationId)
-      } else {
-        db.prepare('update automations set latest_run_status = ?, latest_session_id = coalesce(?, latest_session_id), updated_at = ?, status = ?, next_heartbeat_at = ? where id = ?')
-          .run('completed', sessionId || null, now, 'ready', nextHeartbeatAt(row.heartbeat_minutes, new Date(now)), run.automationId)
-      }
-    }
-    if (run.kind === 'execution') {
-      db.prepare('update automation_work_items set status = ?, blocking_reason = null, updated_at = ? where automation_id = ? and status in (\'ready\', \'running\')')
-        .run('completed', now, run.automationId)
-    }
+    markRunCompletedInTransaction(db, run, summary, sessionId)
   })
   return getRun(runId)
+}
+
+function markRunCompletedInTransaction(db: DatabaseSync, run: AutomationRun, summary: string | null, sessionId?: string | null) {
+  const now = new Date().toISOString()
+  const retryRootRunId = run.retryOfRunId || run.id
+  db.prepare('update automation_runs set status = ?, summary = ?, error = null, failure_code = null, session_id = coalesce(?, session_id), finished_at = ? where id = ?')
+    .run('completed', summary, sessionId || null, now, run.id)
+  clearPendingRetriesForChain(retryRootRunId)
+  const row = getAutomationRow(run.automationId)
+  if (row) {
+    const schedule = parseJson<AutomationSchedule>(row.schedule_json, { type: 'weekly', timezone: 'UTC' })
+    if (run.kind === 'execution') {
+      db.prepare('update automations set latest_run_status = ?, latest_session_id = coalesce(?, latest_session_id), updated_at = ?, status = ?, last_run_at = ?, next_run_at = ?, next_heartbeat_at = ? where id = ?')
+        .run('completed', sessionId || null, now, 'completed', now, computeNextAutomationRunAt(schedule, new Date(now)), nextHeartbeatAt(row.heartbeat_minutes, new Date(now)), run.automationId)
+    } else {
+      db.prepare('update automations set latest_run_status = ?, latest_session_id = coalesce(?, latest_session_id), updated_at = ?, status = ?, next_heartbeat_at = ? where id = ?')
+        .run('completed', sessionId || null, now, 'ready', nextHeartbeatAt(row.heartbeat_minutes, new Date(now)), run.automationId)
+    }
+  }
+  if (run.kind === 'execution') {
+    db.prepare('update automation_work_items set status = ?, blocking_reason = null, updated_at = ? where automation_id = ? and status in (\'ready\', \'running\')')
+      .run('completed', now, run.automationId)
+  }
 }
 
 export function markRunFailed(
@@ -1074,9 +1080,12 @@ export function listInboxForSession(sessionId: string) {
   return (getDb().prepare('select * from automation_inbox where session_id = ? and status = ?').all(sessionId, 'open') as DbRow[]).map(rowToInbox)
 }
 
-export function attachRunSession(runId: string, sessionId: string) {
+export function attachRunSession(runId: string, automationId: string, sessionId: string) {
   const run = getRun(runId)
   if (!run) return null
+  if (run.automationId !== automationId) {
+    throw new Error('Automation run does not belong to the requested automation.')
+  }
   withTransaction((db) => {
     const now = new Date().toISOString()
     db.prepare('update automation_runs set session_id = ?, started_at = coalesce(started_at, ?) where id = ?').run(sessionId, now, runId)
@@ -1085,7 +1094,7 @@ export function attachRunSession(runId: string, sessionId: string) {
   return getRun(runId)
 }
 
-export function createDeliveryRecord(input: {
+type DeliveryRecordInput = {
   automationId: string
   runId?: string | null
   provider: AutomationDeliveryRecord['provider']
@@ -1093,13 +1102,48 @@ export function createDeliveryRecord(input: {
   status: AutomationDeliveryRecord['status']
   title: string
   body: string
-}) {
-  const id = crypto.randomUUID()
-  const createdAt = new Date().toISOString()
-  getDb().prepare(`
+}
+
+function getDeliveryRecord(deliveryId: string) {
+  const row = getDb().prepare('select * from automation_deliveries where id = ?').get(deliveryId) as DbRow | undefined
+  return row ? rowToDelivery(row) : null
+}
+
+function insertDeliveryRecord(db: DatabaseSync, id: string, input: DeliveryRecordInput, createdAt: string) {
+  db.prepare(`
     insert into automation_deliveries (id, automation_id, run_id, provider, target, status, title, body, created_at)
     values (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(id, input.automationId, input.runId || null, input.provider, input.target, input.status, input.title, input.body, createdAt)
-  const row = getDb().prepare('select * from automation_deliveries where id = ?').get(id) as DbRow | undefined
-  return row ? rowToDelivery(row) : null
+}
+
+export function createDeliveryRecord(input: DeliveryRecordInput) {
+  const id = crypto.randomUUID()
+  withTransaction((db) => {
+    insertDeliveryRecord(db, id, input, new Date().toISOString())
+  })
+  return getDeliveryRecord(id)
+}
+
+export function markRunCompletedWithDeliveryRecord(
+  runId: string,
+  summary: string | null,
+  sessionId: string | null | undefined,
+  delivery: Omit<DeliveryRecordInput, 'automationId' | 'runId'>,
+) {
+  const run = getRun(runId)
+  if (!run) return { run: null, delivery: null }
+  const deliveryId = crypto.randomUUID()
+  withTransaction((db) => {
+    const now = new Date().toISOString()
+    markRunCompletedInTransaction(db, run, summary, sessionId)
+    insertDeliveryRecord(db, deliveryId, {
+      automationId: run.automationId,
+      runId: run.id,
+      ...delivery,
+    }, now)
+  })
+  return {
+    run: getRun(runId),
+    delivery: getDeliveryRecord(deliveryId),
+  }
 }

--- a/apps/desktop/src/main/custom-content-limits.ts
+++ b/apps/desktop/src/main/custom-content-limits.ts
@@ -17,6 +17,19 @@ export const CUSTOM_SKILL_LIMITS = {
   pathDepth: 6,
 } as const
 
+export const CUSTOM_MCP_LIMITS = {
+  labelBytes: 256,
+  descriptionBytes: 2 * 1024,
+  commandBytes: 1024,
+  argBytes: 4 * 1024,
+  args: 64,
+  env: 64,
+  headers: 64,
+  keyBytes: 256,
+  valueBytes: 8 * 1024,
+  urlBytes: 4 * 1024,
+} as const
+
 export type CustomContentLimitIssue = {
   code: string
   message: string
@@ -37,8 +50,18 @@ type CustomSkillFileInput = {
   content: string
 }
 
-export function textBytes(value: string | null | undefined) {
-  return Buffer.byteLength(value || '', 'utf8')
+type CustomMcpLimitInput = {
+  label?: string | null
+  description?: string | null
+  command?: string | null
+  args?: string[] | null
+  env?: Record<string, string> | null
+  url?: string | null
+  headers?: Record<string, string> | null
+}
+
+export function textBytes(value: unknown) {
+  return Buffer.byteLength(typeof value === 'string' ? value : '', 'utf8')
 }
 
 function jsonDepth(value: unknown, seen = new WeakSet<object>()): number {
@@ -176,5 +199,49 @@ export function validateCustomSkillFiles(files: CustomSkillFileInput[] = []): Cu
 
 export function assertCustomSkillFiles(files: CustomSkillFileInput[] = []) {
   const issue = validateCustomSkillFiles(files)[0]
+  if (issue) throw new Error(issue.message)
+}
+
+function validateStringRecord(
+  issues: CustomContentLimitIssue[],
+  value: Record<string, string> | null | undefined,
+  label: string,
+  maxEntries: number,
+) {
+  const entries = Object.entries(value || {})
+  pushCountIssue(issues, `${label.toLowerCase()}_too_many_entries`, label, entries.length, maxEntries)
+  for (const [key, entryValue] of entries) {
+    pushBytesIssue(issues, `${label.toLowerCase()}_key_too_large`, `${label} key`, textBytes(key), CUSTOM_MCP_LIMITS.keyBytes)
+    if (typeof entryValue !== 'string') {
+      issues.push({
+        code: `${label.toLowerCase()}_value_invalid`,
+        message: `${label} values must be strings.`,
+      })
+    } else {
+      pushBytesIssue(issues, `${label.toLowerCase()}_value_too_large`, `${label} value`, textBytes(entryValue), CUSTOM_MCP_LIMITS.valueBytes)
+    }
+  }
+}
+
+export function validateCustomMcpContentLimits(mcp: CustomMcpLimitInput): CustomContentLimitIssue[] {
+  const issues: CustomContentLimitIssue[] = []
+  pushBytesIssue(issues, 'mcp_label_too_large', 'MCP label', textBytes(mcp.label), CUSTOM_MCP_LIMITS.labelBytes)
+  pushBytesIssue(issues, 'mcp_description_too_large', 'MCP description', textBytes(mcp.description), CUSTOM_MCP_LIMITS.descriptionBytes)
+  pushBytesIssue(issues, 'mcp_command_too_large', 'MCP command', textBytes(mcp.command), CUSTOM_MCP_LIMITS.commandBytes)
+  pushBytesIssue(issues, 'mcp_url_too_large', 'MCP URL', textBytes(mcp.url), CUSTOM_MCP_LIMITS.urlBytes)
+
+  const args = Array.isArray(mcp.args) ? mcp.args : []
+  pushCountIssue(issues, 'mcp_too_many_args', 'MCP args', args.length, CUSTOM_MCP_LIMITS.args)
+  for (const arg of args) {
+    pushBytesIssue(issues, 'mcp_arg_too_large', 'MCP argument', textBytes(arg), CUSTOM_MCP_LIMITS.argBytes)
+  }
+
+  validateStringRecord(issues, mcp.env, 'MCP env', CUSTOM_MCP_LIMITS.env)
+  validateStringRecord(issues, mcp.headers, 'MCP headers', CUSTOM_MCP_LIMITS.headers)
+  return issues
+}
+
+export function assertCustomMcpContentLimits(mcp: CustomMcpLimitInput) {
+  const issue = validateCustomMcpContentLimits(mcp)[0]
   if (issue) throw new Error(issue.message)
 }

--- a/apps/desktop/src/main/ipc/custom-content-handlers.ts
+++ b/apps/desktop/src/main/ipc/custom-content-handlers.ts
@@ -8,7 +8,7 @@ import { resolveCustomMcpRuntimeEntryForRuntime } from '../runtime-mcp.ts'
 import { log } from '../logger.ts'
 import { getBrandName } from '../config-loader.ts'
 import { VALID_OPENCODE_SKILL_NAME } from '../skill-bundle-validation.ts'
-import { assertCustomSkillContent } from '../custom-content-limits.ts'
+import { assertCustomMcpContentLimits, assertCustomSkillContent } from '../custom-content-limits.ts'
 
 const VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
@@ -38,6 +38,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('custom:test-mcp', async (_event, mcp: CustomMcpConfig): Promise<CustomMcpTestResult> => {
     try {
+      assertCustomMcpContentLimits(mcp)
       if (mcp.type === 'stdio') {
         validateCustomMcpStdioCommand(mcp)
       }
@@ -84,6 +85,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('custom:add-mcp', async (_event, mcp: CustomMcpConfig) => {
     validateName(mcp.name, 'MCP')
+    assertCustomMcpContentLimits(mcp)
     const resolved = context.resolveScopedTarget(mcp) as CustomMcpConfig
     if (resolved.type === 'stdio') {
       validateCustomMcpStdioCommand(resolved)

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -34,6 +34,7 @@ import { cleanupSandboxWorkspaceForSession } from '../sandbox-storage.ts'
 import { log } from '../logger.ts'
 import { ensureRuntimeContextDirectory } from '../runtime-context.ts'
 import { mergeSessionDiffsWithSynthetic } from '../session-diff-fallback.ts'
+import { readFileCheckedSync } from '../fs-read.ts'
 
 type PromptAttachmentInput = {
   mime: string
@@ -55,6 +56,7 @@ const MAX_QUESTION_REQUEST_ID_BYTES = 256
 const MAX_QUESTION_ANSWERS = 32
 const MAX_QUESTION_ANSWER_CHOICES = 16
 const MAX_QUESTION_ANSWER_BYTES = 4 * 1024
+const MAX_FILE_SNIPPET_BYTES = 5 * 1024 * 1024
 const DATA_URL_PREFIX = 'data:'
 const MIME_TYPE_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*(?:;[a-z0-9_.+-]+=[a-z0-9_.+-]+)*$/i
 const DATA_URL_RE = /^data:([^,;]+(?:;[^,;=]+=[^,;]+)*);base64,[A-Za-z0-9+/]*={0,2}$/i
@@ -710,25 +712,34 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
 
     const root = record.opencodeDirectory || getRuntimeHomeDir()
     const { resolve } = await import('path')
-    const { existsSync, readFileSync, realpathSync, statSync } = await import('fs')
+    const { realpathSync } = await import('fs')
 
     const absoluteRoot = resolve(root)
     const absolutePath = resolve(absoluteRoot, filePath)
-    // Existence check before realpath so symlink-to-nowhere fails
-    // cleanly with a typed error instead of a raw ENOENT from
-    // realpathSync.
-    if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
-      throw new Error('File is not available for snippet read.')
-    }
     // Dereference symlinks on BOTH sides. Prefix-matching the
     // un-resolved path lets a symlink inside the project dir (e.g.
     // `link -> /etc/passwd`) bypass the containment check; realpath
     // collapses the symlink so the prefix check is semantically
     // meaningful.
-    const realRoot = realpathSync.native(absoluteRoot)
-    const realPath = realpathSync.native(absolutePath)
+    let realRoot: string
+    let realPath: string
+    try {
+      realRoot = realpathSync.native(absoluteRoot)
+      realPath = realpathSync.native(absolutePath)
+    } catch (err) {
+      throw new Error('File is not available for snippet read.', { cause: err })
+    }
     if (!(realPath === realRoot || realPath.startsWith(`${realRoot}/`))) {
       throw new Error('File snippet path escapes the session directory.')
+    }
+    let bytes: Buffer
+    try {
+      ({ bytes } = readFileCheckedSync(realPath, { maxBytes: MAX_FILE_SNIPPET_BYTES }))
+    } catch (err) {
+      if (err instanceof Error && err.name === 'FileTooLargeError') {
+        throw new Error('File is too large for snippet read.', { cause: err })
+      }
+      throw new Error('File is not available for snippet read.', { cause: err })
     }
 
     // Cap the range so a pathological request (huge file, wide gap)
@@ -738,10 +749,10 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     const safeStart = Math.max(1, Math.floor(startLine))
     const safeEnd = Math.max(safeStart, Math.min(Math.floor(endLine), safeStart + MAX_LINES - 1))
 
-    // Read from the resolved-real path so a symlink target swap
-    // between our check and the read can't smuggle a different file
-    // through. realPath was validated to live inside realRoot above.
-    const contents = readFileSync(realPath, 'utf-8')
+    if (bytes.includes(0)) {
+      throw new Error('Binary files are not available for snippet read.')
+    }
+    const contents = bytes.toString('utf-8')
     const lines = contents.split('\n')
     return lines.slice(safeStart - 1, safeEnd)
   })

--- a/apps/desktop/src/main/log-sanitizer.ts
+++ b/apps/desktop/src/main/log-sanitizer.ts
@@ -8,6 +8,8 @@ const TOKEN_PATTERNS = [
   /\bya29\.[0-9A-Za-z._-]+\b/g,
   // Generic JWT (any issuer — Google refresh, Azure, Auth0, etc.).
   /\beyJ[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\b/g,
+  // Generic Authorization headers users may paste from curl examples.
+  /\bAuthorization:\s*Bearer\s+\S+/gi,
   // GitHub classic personal access tokens (`ghp_`) + fine-grained (`ghu_`,
   // `ghs_`, `ghr_`, `gho_`) and the newer `github_pat_` format.
   /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,

--- a/apps/desktop/src/main/native-customizations.ts
+++ b/apps/desktop/src/main/native-customizations.ts
@@ -45,6 +45,7 @@ import {
 import {
   CUSTOM_SKILL_LIMITS,
   assertCustomAgentContentLimits,
+  assertCustomMcpContentLimits,
   assertCustomSkillContent,
   assertCustomSkillFiles,
   textBytes,
@@ -768,6 +769,7 @@ export function listCustomMcps(context?: RuntimeContextOptions) {
 }
 
 export function saveCustomMcp(mcp: CustomMcpConfig) {
+  assertCustomMcpContentLimits(mcp)
   updateScopedMcpConfig(mcp.scope, mcp.directory, (current) => ({
     ...current,
     [mcp.name]: serializeCustomMcp(mcp),

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -100,10 +100,7 @@ function buildCredentialEnvOverrides(
     const value = getProviderCredentialValue(settings, providerId, credential.key)
     if (value) {
       overrides[credential.env] = value
-      const fp = value.length <= 10
-        ? `len=${value.length}`
-        : `len=${value.length} ${value.slice(0, 4)}…${value.slice(-4)}`
-      mapped.push(`${credential.env}=<${fp}>`)
+      mapped.push(`${credential.env}=<len=${value.length} redacted>`)
     } else {
       missing.push(`${credential.env} (key=${credential.key})`)
     }

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -26,6 +26,10 @@ export type { AgentColor }
 let settingsCache: AppSettings | null = null
 
 type NativePermissionDefault = 'allow' | 'ask' | 'deny'
+const MAX_SETTINGS_MAP_ENTRIES = 64
+const MAX_SETTINGS_KEY_BYTES = 256
+const MAX_SETTINGS_VALUE_BYTES = 64 * 1024
+const QUIET_HOURS_RE = /^([01]\d|2[0-3]):[0-5]\d$/
 
 export function nativePermissionEnabledByDefault(policy: NativePermissionDefault) {
   return policy !== 'deny'
@@ -76,7 +80,10 @@ function normalizeBoolMap(value: unknown): Record<string, boolean> {
   if (!value || typeof value !== 'object') return {}
   const next: Record<string, boolean> = {}
   for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof raw === 'boolean') next[key] = raw
+    if (Object.keys(next).length >= MAX_SETTINGS_MAP_ENTRIES) break
+    if (typeof raw === 'boolean' && Buffer.byteLength(key, 'utf8') <= MAX_SETTINGS_KEY_BYTES) {
+      next[key] = raw
+    }
   }
   return next
 }
@@ -85,7 +92,14 @@ function normalizeStringMap(value: unknown) {
   if (!value || typeof value !== 'object') return {}
   const next: Record<string, string> = {}
   for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof raw === 'string') next[key] = raw
+    if (Object.keys(next).length >= MAX_SETTINGS_MAP_ENTRIES) break
+    if (
+      typeof raw === 'string'
+      && Buffer.byteLength(key, 'utf8') <= MAX_SETTINGS_KEY_BYTES
+      && Buffer.byteLength(raw, 'utf8') <= MAX_SETTINGS_VALUE_BYTES
+    ) {
+      next[key] = raw
+    }
   }
   return next
 }
@@ -94,9 +108,47 @@ function normalizeNestedStringMap(value: unknown) {
   if (!value || typeof value !== 'object') return {}
   const next: Record<string, Record<string, string>> = {}
   for (const [outerKey, raw] of Object.entries(value as Record<string, unknown>)) {
-    next[outerKey] = normalizeStringMap(raw)
+    if (Object.keys(next).length >= MAX_SETTINGS_MAP_ENTRIES) break
+    if (Buffer.byteLength(outerKey, 'utf8') <= MAX_SETTINGS_KEY_BYTES) {
+      next[outerKey] = normalizeStringMap(raw)
+    }
   }
   return next
+}
+
+function normalizeQuietHours(value: unknown) {
+  if (value === null) return null
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return QUIET_HOURS_RE.test(trimmed) ? trimmed : undefined
+}
+
+function normalizeSettingsUpdate(settings: Partial<AppSettings>) {
+  const update: Partial<AppSettings> = {}
+  if (typeof settings.selectedProviderId === 'string' && Buffer.byteLength(settings.selectedProviderId, 'utf8') <= MAX_SETTINGS_KEY_BYTES) update.selectedProviderId = settings.selectedProviderId
+  if (settings.selectedProviderId === null) update.selectedProviderId = null
+  if (typeof settings.selectedModelId === 'string' && Buffer.byteLength(settings.selectedModelId, 'utf8') <= MAX_SETTINGS_KEY_BYTES) update.selectedModelId = settings.selectedModelId
+  if (settings.selectedModelId === null) update.selectedModelId = null
+  if (settings.providerCredentials !== undefined) update.providerCredentials = normalizeNestedStringMap(settings.providerCredentials)
+  if (settings.integrationCredentials !== undefined) update.integrationCredentials = normalizeNestedStringMap(settings.integrationCredentials)
+  if (settings.integrationEnabled !== undefined) update.integrationEnabled = normalizeBoolMap(settings.integrationEnabled)
+  if (typeof settings.enableBash === 'boolean') update.enableBash = settings.enableBash
+  if (typeof settings.enableFileWrite === 'boolean') update.enableFileWrite = settings.enableFileWrite
+  if (typeof settings.runtimeToolingBridgeEnabled === 'boolean') update.runtimeToolingBridgeEnabled = settings.runtimeToolingBridgeEnabled
+  if (typeof settings.automationLaunchAtLogin === 'boolean') update.automationLaunchAtLogin = settings.automationLaunchAtLogin
+  if (typeof settings.automationRunInBackground === 'boolean') update.automationRunInBackground = settings.automationRunInBackground
+  if (typeof settings.automationDesktopNotifications === 'boolean') update.automationDesktopNotifications = settings.automationDesktopNotifications
+  const quietHoursStart = normalizeQuietHours(settings.automationQuietHoursStart)
+  const quietHoursEnd = normalizeQuietHours(settings.automationQuietHoursEnd)
+  if (quietHoursStart !== undefined) update.automationQuietHoursStart = quietHoursStart
+  if (quietHoursEnd !== undefined) update.automationQuietHoursEnd = quietHoursEnd
+  if (settings.defaultAutomationAutonomyPolicy === 'review-first' || settings.defaultAutomationAutonomyPolicy === 'mostly-autonomous') {
+    update.defaultAutomationAutonomyPolicy = settings.defaultAutomationAutonomyPolicy
+  }
+  if (settings.defaultAutomationExecutionMode === 'planning_only' || settings.defaultAutomationExecutionMode === 'scoped_execution') {
+    update.defaultAutomationExecutionMode = settings.defaultAutomationExecutionMode
+  }
+  return update
 }
 
 function migrateLegacySettings(raw: any): AppSettings {
@@ -313,16 +365,17 @@ export function loadSettings(): AppSettings {
 
 export function saveSettings(settings: Partial<AppSettings>) {
   const current = settingsCache || loadSettings()
+  const updates = normalizeSettingsUpdate(settings)
   // Strip mask sentinels so a caller that round-tripped `settings:get`
   // (which returns masked credentials) can't accidentally overwrite
   // real keys with the mask string. Safe because the real value can
   // only have been preserved through `settings:get-with-credentials`.
   const merged: AppSettings = {
     ...current,
-    ...settings,
-    providerCredentials: mergeNestedStringMaps(current.providerCredentials, stripMaskedValues(settings.providerCredentials)),
-    integrationCredentials: mergeNestedStringMaps(current.integrationCredentials, stripMaskedValues(settings.integrationCredentials)),
-    integrationEnabled: { ...current.integrationEnabled, ...(settings.integrationEnabled || {}) },
+    ...updates,
+    providerCredentials: mergeNestedStringMaps(current.providerCredentials, stripMaskedValues(updates.providerCredentials)),
+    integrationCredentials: mergeNestedStringMaps(current.integrationCredentials, stripMaskedValues(updates.integrationCredentials)),
+    integrationEnabled: { ...current.integrationEnabled, ...(updates.integrationEnabled || {}) },
   }
 
   const json = JSON.stringify(merged)

--- a/tests/automation-prompts.test.ts
+++ b/tests/automation-prompts.test.ts
@@ -231,6 +231,77 @@ test('extractBriefFromStructured parses a structured execution brief payload', (
   assert.equal(brief?.status, 'ready')
 })
 
+test('extractBriefFromStructured preserves unique capped work item ids and dependency references', () => {
+  const sharedPrefix = 'x'.repeat(128)
+  const firstRawId = `${sharedPrefix}-first`
+  const secondRawId = `${sharedPrefix}-second`
+  const brief = extractBriefFromStructured({
+    type: 'open_cowork.execution_brief',
+    version: 1,
+    goal: 'Build a weekly report',
+    deliverables: ['Markdown report'],
+    assumptions: [],
+    missingContext: [],
+    successCriteria: [],
+    recommendedAgents: ['research'],
+    approvalBoundary: 'Approve before sending.',
+    workItems: [
+      {
+        id: firstRawId,
+        title: 'Collect data',
+        description: 'Gather the latest weekly metrics.',
+        ownerAgent: 'research',
+        dependsOn: [],
+      },
+      {
+        id: secondRawId,
+        title: 'Write report',
+        description: 'Draft the report after data collection.',
+        ownerAgent: 'writer',
+        dependsOn: [firstRawId],
+      },
+    ],
+  })
+
+  const firstId = brief?.workItems[0]?.id
+  const secondId = brief?.workItems[1]?.id
+  assert.ok(firstId)
+  assert.ok(secondId)
+  assert.notEqual(firstId, secondId)
+  assert.ok(firstId.length <= 128)
+  assert.ok(secondId.length <= 128)
+  assert.deepEqual(brief?.workItems[1]?.dependsOn, [firstId])
+})
+
+test('extractBriefFromStructured caps automation brief volume before persistence', () => {
+  const brief = extractBriefFromStructured({
+    type: 'open_cowork.execution_brief',
+    version: 1,
+    goal: 'x'.repeat(9 * 1024),
+    deliverables: Array.from({ length: 40 }, (_, index) => `deliverable-${index}`),
+    assumptions: [],
+    missingContext: [],
+    successCriteria: [],
+    recommendedAgents: [],
+    approvalBoundary: 'Approve before sending.',
+    workItems: Array.from({ length: 140 }, (_, index) => ({
+      id: `item-${index}`,
+      title: 'x'.repeat(600),
+      description: 'x'.repeat(5 * 1024),
+      ownerAgent: 'research',
+      dependsOn: Array.from({ length: 40 }, (_entry, depIndex) => `dep-${depIndex}`),
+    })),
+  })
+
+  assert.ok(brief)
+  assert.equal(brief?.goal.length, 8 * 1024)
+  assert.equal(brief?.deliverables.length, 32)
+  assert.equal(brief?.workItems.length, 128)
+  assert.equal(brief?.workItems[0]?.title.length, 512)
+  assert.equal(brief?.workItems[0]?.description.length, 4 * 1024)
+  assert.equal(brief?.workItems[0]?.dependsOn.length, 32)
+})
+
 test('extractHeartbeatDecisionFromAssistantText rejects unknown contract envelopes', () => {
   const decision = extractHeartbeatDecisionFromAssistantText(JSON.stringify({
     type: 'unexpected.contract',

--- a/tests/automation-store.test.ts
+++ b/tests/automation-store.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import {
   clearAutomationStoreCache,
+  attachRunSession,
   countAutomationWorkRunAttemptsForDay,
   createAutomation,
   createDeliveryRecord,
@@ -20,6 +21,7 @@ import {
   markHeartbeatCompleted,
   markRunCancelled,
   markRunCompleted,
+  markRunCompletedWithDeliveryRecord,
   markRunFailed,
   markRunStarted,
   resumeAutomationStatus,
@@ -143,6 +145,99 @@ test('automation store persists automations, briefs, inbox items, and runs toget
     )
     assert.equal(payload.inbox[0]?.title, 'Review ready')
     assert.equal(payload.deliveries[0]?.title, 'Weekly report delivered')
+  } finally {
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('automation store completes an execution run and creates its delivery atomically', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('complete-deliver')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const automation = createAutomation({
+      title: 'Atomic delivery',
+      goal: 'Complete and deliver together.',
+      kind: 'recurring',
+      schedule: { type: 'weekly', timezone: 'UTC', dayOfWeek: 1, runAtHour: 9, runAtMinute: 0 },
+      heartbeatMinutes: 15,
+      retryPolicy: { maxRetries: 3, baseDelayMinutes: 5, maxDelayMinutes: 60 },
+      runPolicy: { dailyRunCap: 6, maxRunDurationMinutes: 120 },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: null,
+      preferredAgentNames: [],
+    })
+    const run = createAutomationRun(automation.id, 'execution', 'Execute atomic delivery')
+    assert.ok(run)
+
+    const result = markRunCompletedWithDeliveryRecord(run.id, 'Done.', 'session-atomic', {
+      provider: 'in_app',
+      target: 'automation-inbox',
+      status: 'delivered',
+      title: 'Atomic delivery ready',
+      body: 'Done.',
+    })
+
+    assert.equal(result.run?.status, 'completed')
+    assert.equal(result.delivery?.runId, run.id)
+    assert.equal(getAutomationDetail(automation.id)?.deliveries.length, 1)
+  } finally {
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('automation store rejects attaching a session to a run from another automation', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('attach-cross-automation')
+
+  try {
+    resetAutomationStore(userDataDir)
+    const first = createAutomation({
+      title: 'First automation',
+      goal: 'Own its own run.',
+      kind: 'recurring',
+      schedule: { type: 'weekly', timezone: 'UTC', dayOfWeek: 1, runAtHour: 9, runAtMinute: 0 },
+      heartbeatMinutes: 15,
+      retryPolicy: { maxRetries: 3, baseDelayMinutes: 5, maxDelayMinutes: 60 },
+      runPolicy: { dailyRunCap: 6, maxRunDurationMinutes: 120 },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: null,
+      preferredAgentNames: [],
+    })
+    const second = createAutomation({
+      title: 'Second automation',
+      goal: 'Must not claim the first run.',
+      kind: 'recurring',
+      schedule: { type: 'weekly', timezone: 'UTC', dayOfWeek: 2, runAtHour: 9, runAtMinute: 0 },
+      heartbeatMinutes: 15,
+      retryPolicy: { maxRetries: 3, baseDelayMinutes: 5, maxDelayMinutes: 60 },
+      runPolicy: { dailyRunCap: 6, maxRunDurationMinutes: 120 },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: null,
+      preferredAgentNames: [],
+    })
+    const run = createAutomationRun(first.id, 'execution', 'Run for first automation')
+    assert.ok(run)
+
+    assert.throws(
+      () => attachRunSession(run.id, second.id, 'wrong-session'),
+      /does not belong/,
+    )
+    assert.equal(getRun(run.id)?.sessionId, null)
+    assert.equal(attachRunSession(run.id, first.id, 'right-session')?.sessionId, 'right-session')
   } finally {
     clearAutomationStoreCache()
     clearConfigCaches()

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -1,5 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type { CustomMcpConfig } from '@open-cowork/shared'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
 import { registerAppHandlers, resolveSafeSaveTextPath } from '../apps/desktop/src/main/ipc/app-handlers.ts'
@@ -11,6 +14,7 @@ import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { stopSessionStatusReconciliation } from '../apps/desktop/src/main/session-status-reconciler.ts'
+import { clearSessionRegistryCache, toSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
 
 function createBaseContext() {
   const handlers = new Map<string, (...args: any[]) => any>()
@@ -391,6 +395,38 @@ test('question:reply clears the answered request locally so queued questions adv
   } finally {
     stopSessionStatusReconciliation(sessionId)
     sessionEngine.removeSession(sessionId)
+  }
+})
+
+test('session:file-snippet rejects oversized files before reading snippet contents', async () => {
+  const { context, handlers } = createBaseContext()
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-snippet-'))
+  try {
+    writeFileSync(join(root, 'large.txt'), Buffer.alloc(5 * 1024 * 1024 + 1, 'a'))
+    upsertSessionRecord(toSessionRecord({
+      id: 'session-large-snippet',
+      title: 'Large snippet',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      opencodeDirectory: root,
+    }))
+
+    registerSessionHandlers(context)
+    const handler = handlers.get('session:file-snippet')
+
+    assert.ok(handler, 'expected session:file-snippet handler to be registered')
+    await assert.rejects(
+      () => handler({}, {
+        sessionId: 'session-large-snippet',
+        filePath: 'large.txt',
+        startLine: 1,
+        endLine: 2,
+      }),
+      /too large/,
+    )
+  } finally {
+    clearSessionRegistryCache()
+    rmSync(root, { recursive: true, force: true })
   }
 })
 

--- a/tests/log-sanitizer.test.ts
+++ b/tests/log-sanitizer.test.ts
@@ -47,6 +47,12 @@ test('sanitizeForExport still applies token redaction', () => {
   assert.ok(!exported.includes('dev'))
 })
 
+test('sanitizeForExport redacts generic bearer authorization headers', () => {
+  const exported = sanitizeForExport('curl -H "Authorization: Bearer opaque-token-from-docs" https://api.example.test')
+  assert.ok(!exported.includes('opaque-token-from-docs'))
+  assert.match(exported, /\[REDACTED_TOKEN\]/)
+})
+
 test('sanitizeLogMessage redacts cloud connection strings and keyed high-entropy values', () => {
   const googleSecret = ['GOC', 'SPX', '-abcdefghijklmnopqrstuvwxyz1234567890'].join('')
   const genericSecret = 'abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -112,6 +112,28 @@ test('custom MCP auth opt-ins round-trip through managed sidecar metadata', () =
   }
 })
 
+test('custom MCP definitions reject unbounded renderer payloads', () => {
+  const projectRoot = testTempDir('opencowork-native-mcp-limits-')
+
+  try {
+    assert.throws(
+      () => saveCustomMcp({
+        scope: 'project',
+        directory: projectRoot,
+        name: 'huge-mcp',
+        label: 'Huge MCP',
+        description: 'x'.repeat(3 * 1024),
+        type: 'http',
+        url: 'https://example.test/mcp',
+      }),
+      /MCP description is too large/,
+    )
+    assert.equal(listCustomMcps({ directory: projectRoot }).some((entry) => entry.name === 'huge-mcp'), false)
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true })
+  }
+})
+
 test('custom agents derive tool and skill selections from native markdown permissions without a sidecar', () => {
   const projectRoot = testTempDir('opencowork-native-agents-')
   const agentsDir = join(projectRoot, '.opencowork', 'agents')

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -122,6 +122,51 @@ test('default public config initializes native permission toggles enabled', asyn
   }
 })
 
+test('saveSettings normalizes renderer updates before persistence', async () => {
+  const tempRoot = testTempDir('opencowork-settings-normalize-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeEmptyConfig(configDir)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, saveSettings } = await importFreshSettingsModule('normalize-updates')
+    const before = loadSettings()
+    saveSettings({
+      enableBash: false,
+      automationQuietHoursStart: '99:99',
+      defaultAutomationAutonomyPolicy: 'invalid',
+      providerCredentials: {
+        openrouter: {
+          apiKey: 'valid-key',
+          oversized: 'x'.repeat(65 * 1024),
+        },
+      },
+      unexpectedTopLevel: 'should not persist',
+    } as any)
+
+    const after = loadSettings() as any
+    assert.equal(after.enableBash, false)
+    assert.equal(after.automationQuietHoursStart, before.automationQuietHoursStart)
+    assert.equal(after.defaultAutomationAutonomyPolicy, before.defaultAutomationAutonomyPolicy)
+    assert.equal(after.providerCredentials.openrouter.apiKey, 'valid-key')
+    assert.equal(after.providerCredentials.openrouter.oversized, undefined)
+    assert.equal(after.unexpectedTopLevel, undefined)
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('legacy settings without native toggles inherit downstream ask defaults', async () => {
   const tempRoot = testTempDir('opencowork-settings-legacy-ask-defaults-')
   const configDir = join(tempRoot, 'downstream')


### PR DESCRIPTION
## Summary

Hardens the proved findings from the latest audit set without changing OpenCode runtime ownership or versioning.

- makes automation execution completion and in-app delivery insertion atomic, and validates run/session attachment against the owning automation
- adds bounded, normalized automation brief persistence plus structured-output schema caps and stale-approved-brief protection before heartbeat-triggered execution
- normalizes renderer-provided settings updates at the main-process boundary, including credential maps, integration maps, enum fields, booleans, and quiet hours
- adds hard caps for custom MCP labels, descriptions, command args, env, headers, URLs, and descriptions before testing or saving
- rejects oversized/binary session file snippets before reading, expands generic bearer-token log redaction, and removes credential prefix/suffix logging
- wires Linux packaged smoke coverage into CI and makes critical audit gates fail closed in CI/release

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:a11y --max-warnings=0`
- `pnpm test` (691 tests)
- `pnpm test:renderer` (26 tests)
- `pnpm test:e2e`
- `pnpm build`
- `pnpm docs:build`
- `pnpm perf:check` (rerun solo after a parallel-load false failure)
- `pnpm audit --prod --audit-level high`
- `pnpm audit --audit-level critical`
- targeted rerun: `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/ipc-handler-behavior.test.ts`
- `git diff --check`

## Notes

I left versioning unchanged because v0.0.0 is intentionally being re-released. I also did not tackle broad renderer coverage, large component splits, private CodeQL visibility, or signing governance in this PR; those are either already tracked as product/release work or outside the code diff needed for these proved hardening findings.