### PR TITLE
Fix preview banner and audit edge cases

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,7 +21,7 @@
     "test:renderer": "pnpm --dir ../.. build:shared && vitest run --config vitest.renderer.config.ts",
     "test:coverage:renderer": "pnpm --dir ../.. build:shared && vitest run --config vitest.renderer.config.ts --coverage",
     "test:e2e": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && for test_file in tests/*.smoke.test.ts; do node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test \"$test_file\" || exit $?; done",
-    "test:e2e:packaged": "node --no-warnings --experimental-strip-types --test-timeout=120000 --test-force-exit --test-reporter=spec --test 'tests/*.packaged.test.ts'",
+    "test:e2e:packaged": "node --no-warnings --experimental-strip-types --test-timeout=240000 --test-force-exit --test-reporter=spec --test 'tests/*.packaged.test.ts'",
     "screenshots": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && node --no-warnings --experimental-strip-types tests/screenshots.ts",
     "dist": "node ../../scripts/desktop-dist.mjs",
     "dist:ci": "node ../../scripts/desktop-dist.mjs --mac zip --x64 --arm64 --publish never",

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -70,6 +70,9 @@ import { trackParentSession } from './event-task-state.ts'
 import { log } from './logger.ts'
 import type { OutputFormat } from '@opencode-ai/sdk/v2'
 import { executionBriefApprovalRevision } from './automation-brief-limits.ts'
+import { normalizeSingleQuestionAnswer } from './question-normalization.ts'
+import { dispatchRuntimeSessionEvent } from './session-event-dispatcher.ts'
+import { startSessionStatusReconciliation } from './session-status-reconciler.ts'
 
 let getMainWindow: (() => BrowserWindow | null) | null = null
 let schedulerTimer: NodeJS.Timeout | null = null
@@ -680,6 +683,7 @@ export async function cancelAutomationRun(runId: string) {
 export async function respondToAutomationInbox(itemId: string, response: string) {
   const item = getInboxItem(itemId)
   if (!item || !item.sessionId || !item.questionId) return false
+  const answer = normalizeSingleQuestionAnswer(response)
   const record = getSessionRecord(item.sessionId)
   if (!record) return false
   await ensureRuntimeContextDirectory(record.opencodeDirectory)
@@ -687,8 +691,19 @@ export async function respondToAutomationInbox(itemId: string, response: string)
   if (!client) return false
   await client.question.reply({
     requestID: item.questionId,
-    answers: [[response]],
+    answers: [[answer]],
   }, { throwOnError: true })
+  dispatchRuntimeSessionEvent(getMainWindow?.(), {
+    type: 'question_resolved',
+    sessionId: item.sessionId,
+    data: { type: 'question_resolved', id: item.questionId },
+  })
+  startSessionStatusReconciliation(item.sessionId, {
+    getMainWindow: () => getMainWindow?.() || null,
+    onIdle: (_win, reconciledSessionId) => {
+      void handleAutomationSessionIdle(reconciledSessionId)
+    },
+  })
   resolveInboxItem(itemId, 'resolved')
   maybeResumeRunAfterInboxResolution(item.automationId, item.runId)
   publishAutomationUpdated()

--- a/apps/desktop/src/main/directory-grants.ts
+++ b/apps/desktop/src/main/directory-grants.ts
@@ -45,3 +45,8 @@ export function normalizeProjectDirectory(directory: string) {
   }
   return realpathSync.native(resolved)
 }
+
+export function trustedRecordDirectoryMatches(candidate: string, stored?: string | null) {
+  if (!stored) return false
+  return resolve(stored) === candidate
+}

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -55,7 +55,7 @@ import { registerCustomContentHandlers } from './ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from './ipc/explorer-handlers.ts'
 import type { IpcHandlerContext } from './ipc/context.ts'
 import { clearPermissionsForSession, trackPermission } from './permission-tracker.ts'
-import { normalizeProjectDirectory, ProjectDirectoryGrantRegistry } from './directory-grants.ts'
+import { ProjectDirectoryGrantRegistry, trustedRecordDirectoryMatches } from './directory-grants.ts'
 import { resolveContainedArtifactPath } from './artifact-path-policy.ts'
 import { isTrustedRendererIpcUrl } from './main-window-lifecycle.ts'
 
@@ -139,23 +139,15 @@ export function setupIpcHandlers(ipcMain: IpcMain, getMainWindow: () => BrowserW
   const destructiveConfirmations = createDestructiveConfirmationManager()
   const capabilityToolMethodCache = new Map<string, { expiresAt: number; entries: CapabilityToolEntry[] }>()
   const approvedSkillImportDirectories = new Map<string, string>()
-  function sessionRecordDirectoryMatches(candidate: string, stored?: string | null) {
-    if (!stored) return false
-    try {
-      return normalizeProjectDirectory(stored) === candidate
-    } catch {
-      return resolve(stored) === candidate
-    }
-  }
 
   const projectDirectoryGrants = new ProjectDirectoryGrantRegistry((directory) => {
     const knownSession = listSessionRecords().find((record) => (
-      sessionRecordDirectoryMatches(directory, record.directory)
-      || sessionRecordDirectoryMatches(directory, record.opencodeDirectory)
+      trustedRecordDirectoryMatches(directory, record.directory)
+      || trustedRecordDirectoryMatches(directory, record.opencodeDirectory)
     ))
     if (knownSession) return 'session-record'
     const knownAutomation = listAutomationState().automations.find((automation) => (
-      sessionRecordDirectoryMatches(directory, automation.projectDirectory)
+      trustedRecordDirectoryMatches(directory, automation.projectDirectory)
     ))
     return knownAutomation ? 'automation-record' : null
   })

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -6,7 +6,6 @@ import { normalizeProviderListResponse, type ProviderLike } from '../provider-ut
 import { isSandboxWorkspaceDir } from '../runtime-paths.ts'
 import { removeParentSession } from '../events.ts'
 import { forgetSubmittedPrompt, rememberSubmittedPrompt, trackParentSession } from '../event-task-state.ts'
-import type { QuestionAnswer } from '@opencode-ai/sdk/v2'
 import { dispatchRuntimeSessionEvent, publishSessionView } from '../session-event-dispatcher.ts'
 import { sessionEngine } from '../session-engine.ts'
 import { startSessionStatusReconciliation, stopSessionStatusReconciliation } from '../session-status-reconciler.ts'
@@ -35,6 +34,7 @@ import { log } from '../logger.ts'
 import { ensureRuntimeContextDirectory } from '../runtime-context.ts'
 import { mergeSessionDiffsWithSynthetic } from '../session-diff-fallback.ts'
 import { readFileCheckedSync } from '../fs-read.ts'
+import { normalizeQuestionAnswers, normalizeQuestionRequestId } from '../question-normalization.ts'
 
 type PromptAttachmentInput = {
   mime: string
@@ -52,10 +52,6 @@ const MAX_PROMPT_AGENT_BYTES = 128
 const MAX_SESSION_ID_BYTES = 256
 const MAX_COMMAND_NAME_BYTES = 256
 const MAX_SESSION_TITLE_BYTES = 512
-const MAX_QUESTION_REQUEST_ID_BYTES = 256
-const MAX_QUESTION_ANSWERS = 32
-const MAX_QUESTION_ANSWER_CHOICES = 16
-const MAX_QUESTION_ANSWER_BYTES = 4 * 1024
 const MAX_FILE_SNIPPET_BYTES = 5 * 1024 * 1024
 const DATA_URL_PREFIX = 'data:'
 const MIME_TYPE_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*(?:;[a-z0-9_.+-]+=[a-z0-9_.+-]+)*$/i
@@ -128,26 +124,6 @@ function normalizeSessionTitle(value: unknown) {
   const title = requireBoundedString(value, 'Session title', MAX_SESSION_TITLE_BYTES).trim()
   if (!title) throw new Error('Session title is required')
   return title
-}
-
-function normalizeQuestionRequestId(value: unknown) {
-  const requestId = requireBoundedString(value, 'Question request id', MAX_QUESTION_REQUEST_ID_BYTES).trim()
-  if (!requestId) throw new Error('Question request id is required')
-  return requestId
-}
-
-function normalizeQuestionAnswers(value: unknown): QuestionAnswer[] {
-  if (!Array.isArray(value)) throw new Error('Question answers must be an array')
-  if (value.length > MAX_QUESTION_ANSWERS) throw new Error('Too many question answers')
-  return value.map((answer) => {
-    if (!Array.isArray(answer)) throw new Error('Question answer must be an array')
-    if (answer.length > MAX_QUESTION_ANSWER_CHOICES) throw new Error('Too many question answer choices')
-    return answer.map((choice) => {
-      const normalized = requireBoundedString(choice, 'Question answer choice', MAX_QUESTION_ANSWER_BYTES).trim()
-      if (!normalized) throw new Error('Question answer choice is required')
-      return normalized
-    })
-  })
 }
 
 function resolvePromptModel(settings: ReturnType<typeof getEffectiveSettings>, runtimeProvider?: ProviderLike | null) {

--- a/apps/desktop/src/main/mcp-stdio-policy.ts
+++ b/apps/desktop/src/main/mcp-stdio-policy.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'fs'
+import { existsSync, realpathSync, statSync } from 'fs'
 import { isAbsolute, relative, resolve } from 'path'
 import type { CustomMcpConfig } from '@open-cowork/shared'
 
@@ -40,7 +40,17 @@ function resolveProjectRelativePath(command: string, directory?: string | null) 
   const relativeToRoot = relative(root, candidate)
   if (relativeToRoot === '') return candidate
   if (relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) return null
-  return candidate
+  try {
+    const realRoot = realpathSync.native(root)
+    const realCandidate = realpathSync.native(candidate)
+    const relativeToRealRoot = relative(realRoot, realCandidate)
+    if (relativeToRealRoot === '' || relativeToRealRoot.startsWith('..') || isAbsolute(relativeToRealRoot)) {
+      return null
+    }
+    return realCandidate
+  } catch {
+    return candidate
+  }
 }
 
 // Shells that can eval arbitrary code via `-c`. Listed explicitly so a

--- a/apps/desktop/src/main/question-normalization.ts
+++ b/apps/desktop/src/main/question-normalization.ts
@@ -1,0 +1,45 @@
+import type { QuestionAnswer } from '@opencode-ai/sdk/v2'
+
+const MAX_QUESTION_REQUEST_ID_BYTES = 256
+const MAX_QUESTION_ANSWERS = 32
+const MAX_QUESTION_ANSWER_CHOICES = 16
+const MAX_QUESTION_ANSWER_BYTES = 4 * 1024
+
+function byteLength(value: string) {
+  return Buffer.byteLength(value, 'utf8')
+}
+
+function requireBoundedString(value: unknown, fieldName: string, maxBytes: number) {
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string`)
+  }
+  if (byteLength(value) > maxBytes) {
+    throw new Error(`${fieldName} exceeds ${maxBytes} bytes`)
+  }
+  return value
+}
+
+export function normalizeQuestionRequestId(value: unknown) {
+  const requestId = requireBoundedString(value, 'Question request id', MAX_QUESTION_REQUEST_ID_BYTES).trim()
+  if (!requestId) throw new Error('Question request id is required')
+  return requestId
+}
+
+export function normalizeQuestionAnswers(value: unknown): QuestionAnswer[] {
+  if (!Array.isArray(value)) throw new Error('Question answers must be an array')
+  if (value.length > MAX_QUESTION_ANSWERS) throw new Error('Too many question answers')
+  return value.map((answer) => {
+    if (!Array.isArray(answer)) throw new Error('Question answer must be an array')
+    if (answer.length > MAX_QUESTION_ANSWER_CHOICES) throw new Error('Too many question answer choices')
+    return answer.map((choice) => {
+      const normalized = requireBoundedString(choice, 'Question answer choice', MAX_QUESTION_ANSWER_BYTES).trim()
+      if (!normalized) throw new Error('Question answer choice is required')
+      return normalized
+    })
+  })
+}
+
+export function normalizeSingleQuestionAnswer(value: unknown) {
+  const answers = normalizeQuestionAnswers([[value]])
+  return answers[0]![0]!
+}

--- a/apps/desktop/src/main/runtime-mcp.ts
+++ b/apps/desktop/src/main/runtime-mcp.ts
@@ -287,7 +287,9 @@ export async function resolveCustomMcpRuntimeEntryForRuntime(
   // This is the last app-owned boundary before OpenCode receives the MCP
   // entry. Save/test handlers also validate URLs, but a hostname can
   // re-resolve between save and runtime boot. Re-run the DNS-aware policy
-  // here so tampered config files and DNS rebinding both fail closed.
+  // here so tampered config files and point-in-time private DNS resolutions
+  // are rejected before handoff. OpenCode owns the actual HTTP connection
+  // after registration; Open Cowork does not proxy or pin that transport.
   const verdict = await evaluateHttpMcpUrlResolved(custom.url, {
     ...options,
     allowPrivateNetwork: custom.allowPrivateNetwork,

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -552,14 +552,14 @@ export function App() {
     <div className="flex flex-col h-screen w-screen overflow-hidden bg-base">
       <TitleBar />
       {showPreviewNotice && metadata ? (
-        <div className="flex items-center gap-3 border-b border-amber-400/25 bg-amber-500/10 px-4 py-2 text-[12px] text-amber-100">
+        <div className="flex items-center gap-3 border-b border-amber-500/30 bg-amber-50 px-4 py-2 text-[12px] text-amber-950 dark:border-amber-400/25 dark:bg-amber-500/10 dark:text-amber-100">
           <span className="font-semibold">Public preview {metadata.version}</span>
-          <span className="min-w-0 flex-1 text-amber-100/80">
+          <span className="min-w-0 flex-1 text-amber-800 dark:text-amber-100/80">
             This v0.x build may change quickly. macOS preview artifacts can be unsigned until signing is configured.
           </span>
           <button
             type="button"
-            className="rounded border border-amber-300/30 px-2 py-1 text-[11px] text-amber-50 hover:bg-amber-200/10"
+            className="rounded border border-amber-600/30 px-2 py-1 text-[11px] text-amber-900 hover:bg-amber-200/50 dark:border-amber-300/30 dark:text-amber-50 dark:hover:bg-amber-200/10"
             onClick={() => {
               dismissPreview(metadata.version)
               setPreviewNoticeDismissed(true)

--- a/apps/desktop/tests/packaged-relaunch.packaged.test.ts
+++ b/apps/desktop/tests/packaged-relaunch.packaged.test.ts
@@ -4,15 +4,34 @@ import {
   cleanupSmokePaths,
   createSmokePaths,
   launchSmokeSession,
-  waitForAppShell,
   type SmokeSession,
 } from './smoke-helpers.ts'
 
 const packagedExecutablePath = process.env.OPEN_COWORK_PACKAGED_EXECUTABLE?.trim()
+const packagedRelaunchTimeoutMs = 240_000
+const packagedLaunchTimeoutMs = 90_000
+const packagedIpcTimeoutMs = 60_000
+
+async function withTimeout<T>(label: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
 
 test(
   'packaged app launches cleanly and preserves sessions across relaunch',
   {
+    timeout: packagedRelaunchTimeoutMs,
     skip: packagedExecutablePath
       ? false
       : 'OPEN_COWORK_PACKAGED_EXECUTABLE is not set; build/package first to run packaged smoke',
@@ -29,15 +48,25 @@ test(
     let secondLaunch: SmokeSession | null = null
 
     try {
-      firstLaunch = await launchSmokeSession(paths, { executablePath, appShellTimeoutMs: 90_000 })
-      await waitForAppShell(firstLaunch.page, 90_000)
+      firstLaunch = await launchSmokeSession(paths, {
+        executablePath,
+        appShellTimeoutMs: packagedLaunchTimeoutMs,
+      })
 
-      const initialSessions = await firstLaunch.page.evaluate(async () => window.coworkApi.session.list())
+      const initialSessions = await withTimeout(
+        'listing packaged sessions before relaunch',
+        firstLaunch.page.evaluate(async () => window.coworkApi.session.list()),
+        packagedIpcTimeoutMs,
+      )
       const initialIds = initialSessions.map((session) => session.id)
 
-      await firstLaunch.page.evaluate(async () => {
-        await window.coworkApi.session.create(null)
-      })
+      await withTimeout(
+        'creating packaged smoke session',
+        firstLaunch.page.evaluate(async () => {
+          await window.coworkApi.session.create(null)
+        }),
+        packagedIpcTimeoutMs,
+      )
 
       await firstLaunch.page.waitForFunction(
         async (beforeIds) => {
@@ -58,10 +87,16 @@ test(
       await firstLaunch.close()
       firstLaunch = null
 
-      secondLaunch = await launchSmokeSession(paths, { executablePath, appShellTimeoutMs: 90_000 })
-      await waitForAppShell(secondLaunch.page, 90_000)
+      secondLaunch = await launchSmokeSession(paths, {
+        executablePath,
+        appShellTimeoutMs: packagedLaunchTimeoutMs,
+      })
 
-      const afterRelaunch = await secondLaunch.page.evaluate(async () => window.coworkApi.session.list())
+      const afterRelaunch = await withTimeout(
+        'listing packaged sessions after relaunch',
+        secondLaunch.page.evaluate(async () => window.coworkApi.session.list()),
+        packagedIpcTimeoutMs,
+      )
       assert.ok(
         afterRelaunch.some((session) => session.id === createdSessionId),
         'expected created session to survive a packaged-app relaunch',

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -149,7 +149,10 @@ The `allowPrivateNetwork` flag on `CustomMcpConfig` is the only way to
 bypass the guard, and the UI surfaces a warning when it's set. The guard
 runs at save time (`custom:add-mcp`), test time (`custom:test-mcp`), and
 runtime registration, so public-looking hostnames that resolve into
-private networks are skipped before OpenCode receives the MCP entry.
+private networks at those policy checkpoints are skipped before OpenCode
+receives the MCP entry. After registration, OpenCode owns the actual
+HTTP connection; Open Cowork does not proxy or pin DNS for the runtime
+transport.
 
 ### stdio policy (stdio MCPs)
 
@@ -214,8 +217,10 @@ renderer:
 
 - `default-src 'none'`, `connect-src 'none'` in packaged builds —
   even arbitrary JS cannot exfiltrate over the network.
-- `sandbox` attribute on the iframe tag (allows scripts + same-origin
-  but blocks popups, forms, top-level navigation).
+- `sandbox="allow-scripts"` on the iframe tag. The chart frame can run
+  Vega scripts, but it intentionally does **not** get
+  `allow-same-origin`; its origin stays opaque, and popups, forms, and
+  top-level navigation remain blocked.
 - `frame-ancestors 'self'` — only the host renderer can embed the
   chart; blocks click-jacking from untrusted origins.
 - The chart-frame preload is empty — no `nodeIntegration`, no

--- a/tests/directory-grants.test.ts
+++ b/tests/directory-grants.test.ts
@@ -2,8 +2,8 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { ProjectDirectoryGrantRegistry } from '../apps/desktop/src/main/directory-grants.ts'
+import { join, resolve } from 'node:path'
+import { ProjectDirectoryGrantRegistry, trustedRecordDirectoryMatches } from '../apps/desktop/src/main/directory-grants.ts'
 
 test('project directory grants reject arbitrary renderer-supplied roots', () => {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-grant-'))
@@ -49,5 +49,25 @@ test('project directory grants allow main-owned session record directories', () 
     assert.equal(grants.resolve(root), trusted)
   } finally {
     rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('trusted record directory matching does not rebind through a later symlink replacement', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'open-cowork-record-rebind-'))
+  const original = join(parent, 'project')
+  const replacement = join(parent, 'replacement')
+  try {
+    mkdirSync(original)
+    mkdirSync(replacement)
+    const stored = resolve(original)
+
+    rmSync(original, { recursive: true, force: true })
+    symlinkSync(replacement, original)
+
+    const candidate = realpathSync.native(original)
+    assert.notEqual(candidate, stored)
+    assert.equal(trustedRecordDirectoryMatches(candidate, stored), false)
+  } finally {
+    rmSync(parent, { recursive: true, force: true })
   }
 })

--- a/tests/mcp-stdio-policy.test.ts
+++ b/tests/mcp-stdio-policy.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { validateCustomMcpStdioCommand } from '../apps/desktop/src/main/mcp-stdio-policy.ts'
@@ -78,6 +78,30 @@ test('rejects project-relative executables that escape via a shared-prefix sibli
       scope: 'project',
       directory: root,
       command: '../project-evil/bin/server.js',
+    }), /must stay inside the selected project/)
+  } finally {
+    rmSync(parent, { recursive: true, force: true })
+  }
+})
+
+test('rejects project-relative executables that escape through a symlink inside the project', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'opencowork-mcp-symlink-parent-'))
+  const root = join(parent, 'project')
+  const outside = join(parent, 'outside')
+  const scriptPath = join(outside, 'server.js')
+  const linkedPath = join(root, 'bin', 'linked-server.js')
+
+  try {
+    mkdirSync(join(root, 'bin'), { recursive: true })
+    mkdirSync(outside, { recursive: true })
+    writeFileSync(scriptPath, 'process.stdout.write("ok")', { flag: 'w' })
+    symlinkSync(scriptPath, linkedPath)
+
+    assert.throws(() => validateCustomMcpStdioCommand({
+      name: 'escaped-symlink-project',
+      scope: 'project',
+      directory: root,
+      command: './bin/linked-server.js',
     }), /must stay inside the selected project/)
   } finally {
     rmSync(parent, { recursive: true, force: true })

--- a/tests/question-normalization.test.ts
+++ b/tests/question-normalization.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  normalizeQuestionAnswers,
+  normalizeQuestionRequestId,
+  normalizeSingleQuestionAnswer,
+} from '../apps/desktop/src/main/question-normalization.ts'
+
+test('question normalization accepts bounded answer matrices', () => {
+  assert.deepEqual(normalizeQuestionAnswers([[' A ', 'B']]), [['A', 'B']])
+})
+
+test('question normalization rejects oversized answers', () => {
+  assert.throws(
+    () => normalizeSingleQuestionAnswer('x'.repeat(4 * 1024 + 1)),
+    /Question answer choice exceeds 4096 bytes/,
+  )
+})
+
+test('question normalization rejects empty choices and malformed request ids', () => {
+  assert.throws(() => normalizeQuestionAnswers([['   ']]), /Question answer choice is required/)
+  assert.throws(() => normalizeQuestionRequestId('   '), /Question request id is required/)
+})


### PR DESCRIPTION
## Summary

- Fix the v0.x public preview banner contrast in light mode so the warning and dismiss action stay legible.
- Harden project-relative stdio MCP command validation with realpath containment and prevent stale trusted directory records from rebinding to a different target.
- Share question-answer normalization between normal chat replies and automation inbox replies, then reconcile local question state after automation replies.
- Correct security docs/comments for chart iframe sandboxing and HTTP MCP DNS validation guarantees.

Fixes #69.

## Validation

- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/mcp-stdio-policy.test.ts tests/directory-grants.test.ts tests/question-normalization.test.ts tests/ipc-handler-behavior.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:renderer`
- `pnpm lint:a11y --max-warnings=0`
- `pnpm docs:build`
- `git diff --check`