### PR TITLE
Harden audit trust boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,15 +166,13 @@ jobs:
       - name: Resolve Linux packaged executable
         id: linux-packaged-executable
         run: |
-          path="$(find apps/desktop/release -maxdepth 1 -type f -name "*.AppImage" -print -quit)"
-          test -n "$path" || (echo "Expected an AppImage in apps/desktop/release" && exit 1)
-          chmod +x "$path"
+          path="$(find apps/desktop/release/linux-unpacked -maxdepth 1 -type f \( -name "open-cowork" -o -name "Open Cowork" \) -perm -111 -print -quit)"
+          test -n "$path" || (echo "Expected a packaged Linux executable in apps/desktop/release/linux-unpacked" && exit 1)
           echo "path=$(realpath "$path")" >> "$GITHUB_OUTPUT"
 
       - name: Run Linux packaged desktop smoke test
         run: xvfb-run -a pnpm --dir apps/desktop test:e2e:packaged
         env:
-          APPIMAGE_EXTRACT_AND_RUN: "1"
           OPEN_COWORK_PACKAGED_EXECUTABLE: ${{ steps.linux-packaged-executable.outputs.path }}
 
       - name: Verify Linux artifacts exist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,18 @@ jobs:
       - name: Resolve Linux packaged executable
         id: linux-packaged-executable
         run: |
-          path="$(find apps/desktop/release/linux-unpacked -maxdepth 1 -type f \( -name "open-cowork" -o -name "Open Cowork" \) -perm -111 -print -quit)"
+          find apps/desktop/release/linux-unpacked -maxdepth 1 -type f -perm -111 -printf '%f\n'
+          path=""
+          for candidate in apps/desktop/release/linux-unpacked/*; do
+            test -f "$candidate" || continue
+            test -x "$candidate" || continue
+            base="$(basename "$candidate")"
+            case "$base" in
+              chrome-sandbox|chrome_crashpad_handler|*.so|*.so.*) continue ;;
+            esac
+            path="$candidate"
+            break
+          done
           test -n "$path" || (echo "Expected a packaged Linux executable in apps/desktop/release/linux-unpacked" && exit 1)
           echo "path=$(realpath "$path")" >> "$GITHUB_OUTPUT"
 

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -73,11 +73,13 @@ import { executionBriefApprovalRevision } from './automation-brief-limits.ts'
 import { normalizeSingleQuestionAnswer } from './question-normalization.ts'
 import { dispatchRuntimeSessionEvent } from './session-event-dispatcher.ts'
 import { startSessionStatusReconciliation } from './session-status-reconciler.ts'
+import { createPromiseChain } from './promise-chain.ts'
 
 let getMainWindow: (() => BrowserWindow | null) | null = null
 let schedulerTimer: NodeJS.Timeout | null = null
 let schedulerInFlight = false
 let heartbeatInFlight = false
+const runAutomationControlPlaneSerially = createPromiseChain()
 
 function getRetryRootRunId(run: AutomationRun) {
   return run.retryOfRunId || run.id
@@ -425,55 +427,59 @@ async function maybeRunDueAutomations(now = new Date()) {
 async function maybeRunAutomationScheduler(now = new Date()) {
   if (schedulerInFlight) return
   schedulerInFlight = true
-  try {
-    await maybeRunDueRetries(now)
-    await maybeRunDueAutomations(now)
-  } finally {
-    schedulerInFlight = false
-    publishAutomationUpdated()
-  }
+  await runAutomationControlPlaneSerially(async () => {
+    try {
+      await maybeRunDueRetries(now)
+      await maybeRunDueAutomations(now)
+    } finally {
+      schedulerInFlight = false
+      publishAutomationUpdated()
+    }
+  })
 }
 
 async function maybeRunHeartbeatReviews(now = new Date()) {
   if (heartbeatInFlight) return
   heartbeatInFlight = true
-  const due = listDueHeartbeats(now)
-  try {
-    for (const automation of due) {
-      const detail = getAutomationDetail(automation.id)
-      if (!detail) continue
-      const openInbox = listOpenInboxForAutomation(automation.id)
-      if (detail.status === 'needs_user') {
-        const heartbeatRun = createAutomationRun(automation.id, 'heartbeat', `Heartbeat ${automation.title}`)
-        if (!heartbeatRun) continue
-        const summary = openInbox.length > 0
-          ? `Waiting on user input or approval (${openInbox.length} open item${openInbox.length === 1 ? '' : 's'}).`
-          : 'Waiting on user input.'
-        if (openInbox.length === 0) {
-          createInboxItem({
-            automationId: automation.id,
-            runId: heartbeatRun.id,
-            type: 'info',
-            title: 'Automation waiting for input',
-            body: 'This automation is paused until the missing context or approval is provided.',
-          })
+  await runAutomationControlPlaneSerially(async () => {
+    const due = listDueHeartbeats(now)
+    try {
+      for (const automation of due) {
+        const detail = getAutomationDetail(automation.id)
+        if (!detail) continue
+        const openInbox = listOpenInboxForAutomation(automation.id)
+        if (detail.status === 'needs_user') {
+          const heartbeatRun = createAutomationRun(automation.id, 'heartbeat', `Heartbeat ${automation.title}`)
+          if (!heartbeatRun) continue
+          const summary = openInbox.length > 0
+            ? `Waiting on user input or approval (${openInbox.length} open item${openInbox.length === 1 ? '' : 's'}).`
+            : 'Waiting on user input.'
+          if (openInbox.length === 0) {
+            createInboxItem({
+              automationId: automation.id,
+              runId: heartbeatRun.id,
+              type: 'info',
+              title: 'Automation waiting for input',
+              body: 'This automation is paused until the missing context or approval is provided.',
+            })
+          }
+          markHeartbeatCompleted(heartbeatRun.id, summary)
+          continue
         }
-        markHeartbeatCompleted(heartbeatRun.id, summary)
-        continue
+        try {
+          await startRun(automation.id, 'heartbeat')
+        } catch (error) {
+          if (error instanceof AutomationRunConflictError) continue
+          const message = error instanceof Error ? error.message : String(error)
+          log('error', `Failed to start automation heartbeat ${automation.id}: ${message}`)
+          const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
+          maybeReportFailedRun(automation.id, failedRun, 'Automation heartbeat failed to start', message)
+        }
       }
-      try {
-        await startRun(automation.id, 'heartbeat')
-      } catch (error) {
-        if (error instanceof AutomationRunConflictError) continue
-        const message = error instanceof Error ? error.message : String(error)
-        log('error', `Failed to start automation heartbeat ${automation.id}: ${message}`)
-        const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
-        maybeReportFailedRun(automation.id, failedRun, 'Automation heartbeat failed to start', message)
-      }
+    } finally {
+      heartbeatInFlight = false
     }
-  } finally {
-    heartbeatInFlight = false
-  }
+  })
 }
 
 async function maybeEnforceRunTimeLimits(now = new Date()) {

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -149,6 +149,7 @@ export type ConfiguredProviderDescriptor = {
     descriptionField?: string
     contextLengthField?: string
     authHeader?: string
+    sha256?: string
     cacheTtlMinutes?: number
   }
 }

--- a/apps/desktop/src/main/custom-skill-integrity.ts
+++ b/apps/desktop/src/main/custom-skill-integrity.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'crypto'
+import type { CustomSkillConfig } from '@open-cowork/shared'
+
+export function computeCustomSkillBundleDigest(skill: CustomSkillConfig) {
+  const hash = createHash('sha256')
+  hash.update('SKILL.md')
+  hash.update('\0')
+  hash.update(skill.content || '')
+
+  const files = [...(skill.files || [])].sort((left, right) => left.path.localeCompare(right.path))
+  for (const file of files) {
+    hash.update('\0')
+    hash.update(file.path)
+    hash.update('\0')
+    hash.update(file.content)
+  }
+
+  return hash.digest('hex')
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -39,6 +39,7 @@ import {
   needsMainWindowRecovery,
   pickRecoverableMainWindow,
   rendererUrlLooksWrong,
+  rendererUrlMatchesDevServer,
   shouldRecoverMainWindowFromDidFailLoad,
 } from './main-window-lifecycle.ts'
 import {
@@ -111,7 +112,7 @@ function openExternalNavigation(url: string) {
 }
 
 function rendererNavigationIsAllowed(contents: WebContents, url: string) {
-  if (process.env.VITE_DEV_SERVER_URL && url.startsWith(process.env.VITE_DEV_SERVER_URL)) return true
+  if (process.env.VITE_DEV_SERVER_URL && rendererUrlMatchesDevServer(url, process.env.VITE_DEV_SERVER_URL)) return true
   const currentUrl = contents.getURL()
   if (currentUrl && url === currentUrl) return true
   if (isExpectedPackagedRendererFile(url, expectedRendererEntryPath())) return true

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -1,7 +1,15 @@
 import electron from 'electron'
 import { basename, extname } from 'node:path'
 import type { IpcHandlerContext } from './context.ts'
-import { getEffectiveSettings, maskEffectiveSettingsCredentials, saveSettings, isSetupComplete, type CoworkSettings } from '../settings.ts'
+import {
+  getEffectiveSettings,
+  getIntegrationCredentials,
+  getProviderCredentials,
+  maskEffectiveSettingsCredentials,
+  saveSettings,
+  isSetupComplete,
+  type CoworkSettings,
+} from '../settings.ts'
 import { getClient, getModelInfoAsync } from '../runtime.ts'
 import { normalizeProviderListResponse } from '../provider-utils.ts'
 import { getConfigError, getProviderDynamicCatalog, getPublicAppConfig, invalidatePublicConfigCache, resolveProviderDefaultModel } from '../config-loader.ts'
@@ -42,6 +50,7 @@ const MAX_PROVIDER_AUTH_INPUT_VALUE_LENGTH = 8 * 1024
 const MAX_PROVIDER_AUTH_CODE_LENGTH = 16 * 1024
 const MAX_PROVIDER_AUTH_URL_LENGTH = 8 * 1024
 const MAX_PROVIDER_AUTH_INSTRUCTIONS_LENGTH = 4 * 1024
+const MAX_CREDENTIAL_SCOPE_ID_BYTES = 256
 const MAX_CLIPBOARD_TEXT_LENGTH = 2 * 1024 * 1024
 const MAX_SAVE_TEXT_BYTES = 2 * 1024 * 1024
 const MAX_SAVE_TEXT_FILENAME_BYTES = 512
@@ -94,6 +103,12 @@ function normalizeBoundedString(value: unknown, label: string, maxBytes: number)
   if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
   if (stringByteLength(value) > maxBytes) throw new Error(`${label} is too large.`)
   return value
+}
+
+function normalizeCredentialScopeId(value: unknown, label: string): string {
+  const normalized = normalizeBoundedString(value, `${label} id`, MAX_CREDENTIAL_SCOPE_ID_BYTES).trim()
+  if (!normalized) throw new Error(`${label} id is invalid.`)
+  return normalized
 }
 
 function pathContainsSensitiveDir(filePath: string) {
@@ -388,11 +403,16 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     return maskEffectiveSettingsCredentials(getEffectiveSettings())
   })
 
-  context.ipcMain.handle('settings:get-with-credentials', async () => {
-    // Explicit opt-in for the credential editor surfaces (SetupScreen,
-    // SettingsPanel → Models tab) that need the real values to prefill
-    // their forms. Any other caller should use `settings:get`.
-    return getEffectiveSettings()
+  context.ipcMain.handle('settings:get-provider-credentials', async (_event, providerId: unknown) => {
+    // Scoped opt-in for provider credential editor surfaces. Avoid
+    // returning every stored provider and integration secret to any
+    // renderer code that only needs one credential bag.
+    return getProviderCredentials(normalizeCredentialScopeId(providerId, 'Provider'))
+  })
+
+  context.ipcMain.handle('settings:get-integration-credentials', async (_event, integrationId: unknown) => {
+    // Same scoped read for integration/MCP credential editors.
+    return getIntegrationCredentials(normalizeCredentialScopeId(integrationId, 'Integration'))
   })
 
   context.ipcMain.handle('settings:set', async (_event, updates: Partial<CoworkSettings>) => {
@@ -419,7 +439,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
       }
     }
 
-    return result
+    return maskEffectiveSettingsCredentials(result)
   })
 
   context.ipcMain.handle('model:info', async () => {

--- a/apps/desktop/src/main/ipc/custom-content-handlers.ts
+++ b/apps/desktop/src/main/ipc/custom-content-handlers.ts
@@ -9,6 +9,7 @@ import { log } from '../logger.ts'
 import { getBrandName } from '../config-loader.ts'
 import { VALID_OPENCODE_SKILL_NAME } from '../skill-bundle-validation.ts'
 import { assertCustomMcpContentLimits, assertCustomSkillContent } from '../custom-content-limits.ts'
+import { computeCustomSkillBundleDigest } from '../custom-skill-integrity.ts'
 
 const VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
@@ -29,6 +30,12 @@ function resolveCustomContext(context: IpcHandlerContext, options?: RuntimeConte
     ...options,
     directory: context.resolveContextDirectory(options),
   }
+}
+
+function logUnsignedSkillBundle(action: 'add' | 'import', skill: CustomSkillConfig) {
+  const digest = computeCustomSkillBundleDigest(skill)
+  log('audit', `skill.${action} unsigned name=${skill.name} scope=${skill.scope} sha256=${digest}`)
+  log('warn', `Saved unsigned custom skill bundle ${skill.name}; only use skill bundles from sources you trust.`)
 }
 
 export function registerCustomContentHandlers(context: IpcHandlerContext) {
@@ -99,6 +106,9 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     }
     try {
       saveCustomMcp(resolved)
+      if (resolved.allowPrivateNetwork === true) {
+        log('audit', `mcp.allowPrivateNetwork enabled name=${resolved.name} scope=${resolved.scope || 'machine'}`)
+      }
       log('custom', `Added MCP: ${resolved.name} (${resolved.type})`)
       const { rebootRuntime } = await import('../index.ts')
       await rebootRuntime()
@@ -134,8 +144,10 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('custom:add-skill', async (_event, skill: CustomSkillConfig) => {
     validateSkillName(skill.name)
     assertCustomSkillContent(skill.content || '')
-    saveCustomSkill(context.resolveScopedTarget(skill) as CustomSkillConfig)
-    log('custom', `Added skill: ${skill.name}`)
+    const resolved = context.resolveScopedTarget(skill) as CustomSkillConfig
+    saveCustomSkill(resolved)
+    logUnsignedSkillBundle('add', resolved)
+    log('custom', `Added skill: ${resolved.name}`)
     const { rebootRuntime } = await import('../index.ts')
     await rebootRuntime()
     return true
@@ -169,6 +181,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
       throw new Error(`A custom skill bundle named "${imported.name}" already exists.`)
     }
     saveCustomSkill(imported)
+    logUnsignedSkillBundle('import', imported)
     log('custom', `Imported skill directory: ${imported.name}`)
     const { rebootRuntime } = await import('../index.ts')
     await rebootRuntime()

--- a/apps/desktop/src/main/main-window-lifecycle.ts
+++ b/apps/desktop/src/main/main-window-lifecycle.ts
@@ -9,7 +9,7 @@ type WindowLike = {
 export function rendererUrlLooksWrong(url: string, devServerUrl?: string | null) {
   if (!url) return true
   if (devServerUrl) {
-    return !url.startsWith(devServerUrl)
+    return !rendererUrlMatchesDevServer(url, devServerUrl)
   }
   return url.endsWith('.js') || url.includes('/assets/') || !url.endsWith('/index.html')
 }

--- a/apps/desktop/src/main/provider-catalog.ts
+++ b/apps/desktop/src/main/provider-catalog.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import type { ProviderModelDescriptor } from '@open-cowork/shared'
@@ -30,6 +31,9 @@ export type ProviderDynamicCatalog = {
   // Optional bearer token header; the value may reference an allowed env
   // placeholder via `{env:NAME}` elsewhere in the config pipeline.
   authHeader?: string
+  // Optional hex-encoded SHA-256 of the response body. Downstream
+  // distributions can pin catalogs they do not fully control.
+  sha256?: string
   cacheTtlMinutes?: number
 }
 
@@ -161,10 +165,17 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: numbe
 function isAllowedCatalogUrl(url: string): boolean {
   try {
     const parsed = new URL(url)
-    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+    return parsed.protocol === 'https:'
   } catch {
     return false
   }
+}
+
+function responseHashMatches(text: string, expectedSha256?: string) {
+  if (!expectedSha256) return true
+  if (!/^[a-f0-9]{64}$/i.test(expectedSha256)) return false
+  const actual = createHash('sha256').update(text).digest('hex')
+  return actual.toLowerCase() === expectedSha256.toLowerCase()
 }
 
 async function readBodyWithLimit(response: Response): Promise<string | null> {
@@ -217,6 +228,10 @@ async function fetchCatalog(
     const text = await readBodyWithLimit(response)
     if (text === null) {
       log('provider', `Catalog ${providerId} fetch aborted: response exceeded ${MAX_RESPONSE_BYTES} bytes`)
+      return null
+    }
+    if (!responseHashMatches(text, catalog.sha256)) {
+      log('provider', `Catalog ${providerId} fetch rejected: SHA-256 mismatch`)
       return null
     }
     let body: unknown

--- a/apps/desktop/src/main/runtime-content.ts
+++ b/apps/desktop/src/main/runtime-content.ts
@@ -130,9 +130,10 @@ export function findBundledSkillDir(root: string, skillName: string): string | n
 //
 // AGENTS.md and project-overlay copying are separate concerns: OpenCode
 // reads AGENTS.md from cwd, while buildRuntimeConfig points OpenCode at the
-// prepared skill catalog via `skills.paths`. Because `withRuntimeEnvironment`
-// points XDG_CONFIG_HOME at `runtime-home/.config`, the compatibility mirror
-// in `getMachineSkillsDir()` is still app-isolated and safe to populate.
+// prepared skill catalog via `skills.paths`. Because the managed OpenCode
+// server is launched with XDG_CONFIG_HOME pointing at `runtime-home/.config`,
+// the compatibility mirror in `getMachineSkillsDir()` is still app-isolated
+// and safe to populate.
 export function copySkillsAndAgents(projectDirectory?: string | null) {
   const runtimeHome = getRuntimeHomeDir()
   const runtimeConfigSrc = app.isPackaged

--- a/apps/desktop/src/main/runtime-opencode-cli.ts
+++ b/apps/desktop/src/main/runtime-opencode-cli.ts
@@ -83,8 +83,8 @@ export function resolveBundledOpencodeCliEnvironment(options: {
 
   // Prefer the platform-native binary package (for example
   // `opencode-darwin-arm64`) over the `opencode-ai/bin/opencode` wrapper.
-  // The managed runtime launcher uses OPENCODE_BIN_PATH when available;
-  // in packaged desktop apps that must be a self-contained executable.
+  // The managed runtime launcher receives this resolved binary path directly;
+  // in packaged desktop apps it must be a self-contained executable.
   // The wrapper is a Node script with `#!/usr/bin/env node`, and end-user
   // machines cannot be expected to have a system `node` on PATH.
   if (options.binary) {
@@ -125,6 +125,5 @@ export function applyBundledOpencodeCliEnvironment() {
   })
 
   if (env.path) process.env.PATH = env.path
-  if (env.opencodeBinPath) process.env.OPENCODE_BIN_PATH = env.opencodeBinPath
   return env
 }

--- a/apps/desktop/src/main/runtime-opencode-cli.ts
+++ b/apps/desktop/src/main/runtime-opencode-cli.ts
@@ -83,7 +83,7 @@ export function resolveBundledOpencodeCliEnvironment(options: {
 
   // Prefer the platform-native binary package (for example
   // `opencode-darwin-arm64`) over the `opencode-ai/bin/opencode` wrapper.
-  // The SDK starts the runtime with `cross-spawn('opencode')`; in packaged
+  // The managed runtime launcher starts `opencode` from PATH; in packaged
   // desktop apps that must resolve to a self-contained executable. The
   // wrapper is a Node script with `#!/usr/bin/env node`, and end-user
   // machines cannot be expected to have a system `node` on PATH.

--- a/apps/desktop/src/main/runtime-opencode-cli.ts
+++ b/apps/desktop/src/main/runtime-opencode-cli.ts
@@ -83,9 +83,9 @@ export function resolveBundledOpencodeCliEnvironment(options: {
 
   // Prefer the platform-native binary package (for example
   // `opencode-darwin-arm64`) over the `opencode-ai/bin/opencode` wrapper.
-  // The managed runtime launcher starts `opencode` from PATH; in packaged
-  // desktop apps that must resolve to a self-contained executable. The
-  // wrapper is a Node script with `#!/usr/bin/env node`, and end-user
+  // The managed runtime launcher uses OPENCODE_BIN_PATH when available;
+  // in packaged desktop apps that must be a self-contained executable.
+  // The wrapper is a Node script with `#!/usr/bin/env node`, and end-user
   // machines cannot be expected to have a system `node` on PATH.
   if (options.binary) {
     const binaryDir = dirname(options.binary)

--- a/apps/desktop/src/main/runtime-opencode-cli.ts
+++ b/apps/desktop/src/main/runtime-opencode-cli.ts
@@ -126,4 +126,5 @@ export function applyBundledOpencodeCliEnvironment() {
 
   if (env.path) process.env.PATH = env.path
   if (env.opencodeBinPath) process.env.OPENCODE_BIN_PATH = env.opencodeBinPath
+  return env
 }

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -234,6 +234,7 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'APPDATA',
   'ALL_PROXY',
+  'COMSPEC',
   'ComSpec',
   'HTTPS_PROXY',
   'HTTP_PROXY',
@@ -261,7 +262,7 @@ const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
 ])
 
 function shouldPassRuntimeEnvKey(key: string) {
-  return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.toLowerCase() === 'path' || key.startsWith('LC_')
+  return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.toLowerCase() === 'path' || key.toLowerCase() === 'comspec' || key.startsWith('LC_')
 }
 
 function applyManagedHomeEnvironment(env: NodeJS.ProcessEnv, runtimePaths: ReturnType<typeof getRuntimeEnvPaths>) {
@@ -319,6 +320,22 @@ export function resolveManagedOpencodeCommand(env: NodeJS.ProcessEnv) {
   return explicitBinary || 'opencode'
 }
 
+export function resolveManagedOpencodeSpawn(
+  env: NodeJS.ProcessEnv,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+) {
+  const explicitBinary = env.OPENCODE_BIN_PATH?.trim()
+  if (explicitBinary) return { command: explicitBinary, args }
+  if (platform === 'win32') {
+    return {
+      command: env.ComSpec?.trim() || env.COMSPEC?.trim() || 'cmd.exe',
+      args: ['/d', '/s', '/c', 'opencode', ...args],
+    }
+  }
+  return { command: 'opencode', args }
+}
+
 function stopManagedOpencodeProcess(proc: ChildProcess) {
   if (proc.exitCode !== null || proc.signalCode !== null) return
   if (process.platform === 'win32' && proc.pid) {
@@ -358,7 +375,8 @@ async function createManagedOpencodeServer(options: OpencodeServerOptions & { en
   const args = ['serve', `--hostname=${resolved.hostname}`, `--port=${resolved.port}`]
   if (resolved.config?.logLevel) args.push(`--log-level=${resolved.config.logLevel}`)
 
-  const proc = spawn(resolveManagedOpencodeCommand(resolved.env), args, {
+  const spawnPlan = resolveManagedOpencodeSpawn(resolved.env, args)
+  const proc = spawn(spawnPlan.command, spawnPlan.args, {
     env: buildManagedOpencodeServerEnvironment(resolved.env, resolved.config),
     windowsHide: true,
   })

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -211,10 +211,10 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 //   - GOOGLE_APPLICATION_CREDENTIALS: our app-scoped ADC path so the
 //     subprocess uses the app's OAuth session, not any ADC that might
 //     be sitting in the user's real home.
-//   - PATH: the bundled native `opencode` binary dir is prepended in
-//     `applyBundledOpencodeCliEnvironment()` (runtime-opencode-cli.ts),
-//     so the managed server launcher binds to our copy, not a user-installed
-//     one on PATH.
+//   - OPENCODE_BIN_PATH / PATH: `applyBundledOpencodeCliEnvironment()`
+//     points OPENCODE_BIN_PATH at the bundled native binary and prepends
+//     its directory to PATH. The managed server launcher uses that explicit
+//     binary path when available, avoiding a user-installed PATH hit.
 //
 // What we redirect:
 //   - HOME: OpenCode still performs home-relative compatibility
@@ -298,6 +298,11 @@ export function buildManagedOpencodeServerEnvironment(
   }
 }
 
+export function resolveManagedOpencodeCommand(env: NodeJS.ProcessEnv) {
+  const explicitBinary = env.OPENCODE_BIN_PATH?.trim()
+  return explicitBinary || 'opencode'
+}
+
 function stopManagedOpencodeProcess(proc: ChildProcess) {
   if (proc.exitCode !== null || proc.signalCode !== null) return
   if (process.platform === 'win32' && proc.pid) {
@@ -337,7 +342,7 @@ async function createManagedOpencodeServer(options: OpencodeServerOptions & { en
   const args = ['serve', `--hostname=${resolved.hostname}`, `--port=${resolved.port}`]
   if (resolved.config?.logLevel) args.push(`--log-level=${resolved.config.logLevel}`)
 
-  const proc = spawn('opencode', args, {
+  const proc = spawn(resolveManagedOpencodeCommand(resolved.env), args, {
     env: buildManagedOpencodeServerEnvironment(resolved.env, resolved.config),
     windowsHide: true,
   })

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -8,7 +8,7 @@ import type { ModelInfoSnapshot } from '@open-cowork/shared'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from 'fs'
 import { homedir } from 'os'
-import { dirname, join, resolve } from 'path'
+import { dirname, join, resolve, win32 } from 'path'
 import {
   getAppConfig,
   getAppDataDir,
@@ -264,6 +264,26 @@ function shouldPassRuntimeEnvKey(key: string) {
   return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.toLowerCase() === 'path' || key.startsWith('LC_')
 }
 
+function applyManagedHomeEnvironment(env: NodeJS.ProcessEnv, runtimePaths: ReturnType<typeof getRuntimeEnvPaths>) {
+  env.HOME = runtimePaths.home
+  env.XDG_CONFIG_HOME = runtimePaths.configHome
+  env.XDG_DATA_HOME = runtimePaths.dataHome
+  env.XDG_CACHE_HOME = runtimePaths.cacheHome
+  env.XDG_STATE_HOME = runtimePaths.stateHome
+  env.USERPROFILE = runtimePaths.home
+  env.APPDATA = runtimePaths.configHome
+  env.LOCALAPPDATA = runtimePaths.dataHome
+
+  const parsed = win32.parse(runtimePaths.home)
+  if (/^[a-zA-Z]:\\$/.test(parsed.root)) {
+    env.HOMEDRIVE = parsed.root.slice(0, 2)
+    env.HOMEPATH = runtimePaths.home.slice(2) || '\\'
+  } else {
+    delete env.HOMEDRIVE
+    delete env.HOMEPATH
+  }
+}
+
 export function buildManagedRuntimeEnvironment(input: {
   currentEnv: NodeJS.ProcessEnv
   runtimePaths: ReturnType<typeof getRuntimeEnvPaths>
@@ -275,11 +295,7 @@ export function buildManagedRuntimeEnvironment(input: {
     if (value !== undefined && shouldPassRuntimeEnvKey(key)) env[key] = value
   }
 
-  env.HOME = input.runtimePaths.home
-  env.XDG_CONFIG_HOME = input.runtimePaths.configHome
-  env.XDG_DATA_HOME = input.runtimePaths.dataHome
-  env.XDG_CACHE_HOME = input.runtimePaths.cacheHome
-  env.XDG_STATE_HOME = input.runtimePaths.stateHome
+  applyManagedHomeEnvironment(env, input.runtimePaths)
   env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = '1'
   env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS = '1'
   env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -372,8 +372,6 @@ export function parseManagedOpencodeServerStdoutChunk(
     }
   }
 
-  const partialUrl = extractManagedOpencodeServerUrl(nextBuffer.replace(/\r$/, ''))
-  if (partialUrl) return { buffer: nextBuffer, url: partialUrl }
   return { buffer: nextBuffer }
 }
 

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -211,10 +211,10 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 //   - GOOGLE_APPLICATION_CREDENTIALS: our app-scoped ADC path so the
 //     subprocess uses the app's OAuth session, not any ADC that might
 //     be sitting in the user's real home.
-//   - OPENCODE_BIN_PATH / PATH: `applyBundledOpencodeCliEnvironment()`
-//     points OPENCODE_BIN_PATH at the bundled native binary and prepends
-//     its directory to PATH. The managed server launcher uses that explicit
-//     binary path when available, avoiding a user-installed PATH hit.
+//   - Bundled OpenCode binary / PATH: `applyBundledOpencodeCliEnvironment()`
+//     resolves the bundled native binary and prepends its directory to PATH.
+//     The managed server launcher receives that app-owned binary path as a
+//     separate argument when available, avoiding a user-installed PATH hit.
 //
 // What we redirect:
 //   - HOME: OpenCode still performs home-relative compatibility
@@ -295,7 +295,6 @@ export function buildManagedRuntimeEnvironment(input: {
   runtimePaths: ReturnType<typeof getRuntimeEnvPaths>
   adcPath?: string | null
   enableNativeWebSearch?: boolean
-  opencodeBinPath?: string | null
 }) {
   const env: NodeJS.ProcessEnv = {}
   for (const [key, value] of Object.entries(input.currentEnv)) {
@@ -308,7 +307,6 @@ export function buildManagedRuntimeEnvironment(input: {
   env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE
   if (input.enableNativeWebSearch) env.OPENCODE_ENABLE_EXA = '1'
   if (input.adcPath) env.GOOGLE_APPLICATION_CREDENTIALS = input.adcPath
-  if (input.opencodeBinPath?.trim()) env.OPENCODE_BIN_PATH = input.opencodeBinPath.trim()
   return env
 }
 
@@ -322,8 +320,8 @@ export function buildManagedOpencodeServerEnvironment(
   }
 }
 
-export function resolveManagedOpencodeCommand(env: NodeJS.ProcessEnv) {
-  const explicitBinary = env.OPENCODE_BIN_PATH?.trim()
+export function resolveManagedOpencodeCommand(opencodeBinPath?: string | null) {
+  const explicitBinary = opencodeBinPath?.trim()
   return explicitBinary || 'opencode'
 }
 
@@ -331,9 +329,10 @@ export function resolveManagedOpencodeSpawn(
   env: NodeJS.ProcessEnv,
   args: string[],
   platform: NodeJS.Platform = process.platform,
+  opencodeBinPath?: string | null,
 ) {
-  const explicitBinary = env.OPENCODE_BIN_PATH?.trim()
-  if (explicitBinary) return { command: explicitBinary, args }
+  const explicitBinary = resolveManagedOpencodeCommand(opencodeBinPath)
+  if (explicitBinary !== 'opencode') return { command: explicitBinary, args }
   if (platform === 'win32') {
     return {
       command: env.ComSpec?.trim() || env.COMSPEC?.trim() || 'cmd.exe',
@@ -407,7 +406,7 @@ function bindManagedOpencodeAbort(proc: ChildProcess, signal?: AbortSignal, onAb
   return clear
 }
 
-async function createManagedOpencodeServer(options: OpencodeServerOptions & { env: NodeJS.ProcessEnv }) {
+async function createManagedOpencodeServer(options: OpencodeServerOptions & { env: NodeJS.ProcessEnv; opencodeBinPath?: string | null }) {
   const resolved = {
     hostname: '127.0.0.1',
     port: 4096,
@@ -417,7 +416,7 @@ async function createManagedOpencodeServer(options: OpencodeServerOptions & { en
   const args = ['serve', `--hostname=${resolved.hostname}`, `--port=${resolved.port}`]
   if (resolved.config?.logLevel) args.push(`--log-level=${resolved.config.logLevel}`)
 
-  const spawnPlan = resolveManagedOpencodeSpawn(resolved.env, args)
+  const spawnPlan = resolveManagedOpencodeSpawn(resolved.env, args, process.platform, resolved.opencodeBinPath)
   const proc = spawn(spawnPlan.command, spawnPlan.args, {
     env: buildManagedOpencodeServerEnvironment(resolved.env, resolved.config),
     windowsHide: true,
@@ -499,9 +498,8 @@ async function createManagedOpencode(options: OpencodeServerOptions, opencodeBin
     runtimePaths,
     adcPath,
     enableNativeWebSearch: shouldEnableNativeWebSearch(),
-    opencodeBinPath,
   })
-  const server = await createManagedOpencodeServer({ ...options, env })
+  const server = await createManagedOpencodeServer({ ...options, env, opencodeBinPath })
   const managedClient = createOpencodeClient({ baseUrl: server.url })
   return {
     client: managedClient,

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -246,6 +246,8 @@ const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'PATH',
   'PATHEXT',
   'SHELL',
+  'SSH_AGENT_PID',
+  'SSH_AUTH_SOCK',
   'SystemRoot',
   'TEMP',
   'TERM',

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -260,7 +260,7 @@ const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
 ])
 
 function shouldPassRuntimeEnvKey(key: string) {
-  return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.startsWith('LC_')
+  return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.toLowerCase() === 'path' || key.startsWith('LC_')
 }
 
 export function buildManagedRuntimeEnvironment(input: {

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -224,43 +224,77 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 //     curated set of developer-tool config paths into that sandbox so
 //     git / ssh / npm keep behaving like the user's normal shell.
 //
-// We already merge the user's login-shell PATH and environment before
-// starting the server, so runtime subprocesses still inherit the shell
-// toolchain they need. The thing we are intentionally severing is
-// OpenCode's access to the real home directory as a discovery root.
+// The SDK currently launches `opencode` with `{ ...process.env }`. Keep
+// that SDK-native launch path, but temporarily replace `process.env` with
+// a curated managed environment while `createOpencode()` spawns the
+// server. This preserves the shell toolchain (`PATH`) without forwarding
+// arbitrary exported API keys or git/SSH override variables into the
+// managed runtime.
+const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
+  'APPDATA',
+  'ComSpec',
+  'LANG',
+  'LOCALAPPDATA',
+  'LOGNAME',
+  'OPENCODE_BIN_PATH',
+  'PATH',
+  'PATHEXT',
+  'SHELL',
+  'SystemRoot',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'TZ',
+  'USER',
+  'USERNAME',
+  'WINDIR',
+])
+
+function shouldPassRuntimeEnvKey(key: string) {
+  return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.startsWith('LC_')
+}
+
+export function buildManagedRuntimeEnvironment(input: {
+  currentEnv: NodeJS.ProcessEnv
+  runtimePaths: ReturnType<typeof getRuntimeEnvPaths>
+  adcPath?: string | null
+  enableNativeWebSearch?: boolean
+}) {
+  const env: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(input.currentEnv)) {
+    if (value !== undefined && shouldPassRuntimeEnvKey(key)) env[key] = value
+  }
+
+  env.HOME = input.runtimePaths.home
+  env.XDG_CONFIG_HOME = input.runtimePaths.configHome
+  env.XDG_DATA_HOME = input.runtimePaths.dataHome
+  env.XDG_CACHE_HOME = input.runtimePaths.cacheHome
+  env.XDG_STATE_HOME = input.runtimePaths.stateHome
+  env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = '1'
+  env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS = '1'
+  env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE
+  if (input.enableNativeWebSearch) env.OPENCODE_ENABLE_EXA = '1'
+  if (input.adcPath) env.GOOGLE_APPLICATION_CREDENTIALS = input.adcPath
+  return env
+}
+
+function replaceProcessEnvironment(next: NodeJS.ProcessEnv) {
+  const previous = { ...process.env }
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key]
+  }
+  Object.assign(process.env, next)
+  return () => {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    Object.assign(process.env, previous)
+  }
+}
+
 async function withRuntimeEnvironment<T>(fn: () => Promise<T>) {
   const runtimePaths = getRuntimeEnvPaths()
-  const previous = {
-    HOME: process.env.HOME,
-    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
-    XDG_DATA_HOME: process.env.XDG_DATA_HOME,
-    XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
-    XDG_STATE_HOME: process.env.XDG_STATE_HOME,
-    GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
-    OPENCODE_ENABLE_EXA: process.env.OPENCODE_ENABLE_EXA,
-    OPENCODE_DISABLE_CLAUDE_CODE_PROMPT: process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT,
-    OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: process.env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS,
-    [OPEN_COWORK_MANAGED_RUNTIME_ENV]: process.env[OPEN_COWORK_MANAGED_RUNTIME_ENV],
-  }
-
-  process.env.HOME = runtimePaths.home
-  process.env.XDG_CONFIG_HOME = runtimePaths.configHome
-  process.env.XDG_DATA_HOME = runtimePaths.dataHome
-  process.env.XDG_CACHE_HOME = runtimePaths.cacheHome
-  process.env.XDG_STATE_HOME = runtimePaths.stateHome
-  // Keep Claude Code itself available for OpenCode-native subscription
-  // auth, but disable Claude compatibility prompt/skill discovery so the
-  // runtime cannot read unmanaged `~/.claude` prompts or skills outside
-  // our sandbox.
-  process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = '1'
-  process.env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS = '1'
-  process.env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE
-  if (shouldEnableNativeWebSearch()) {
-    process.env.OPENCODE_ENABLE_EXA = '1'
-  } else {
-    delete process.env.OPENCODE_ENABLE_EXA
-  }
-
   // Forward the app-level Google OAuth session as ADC to the OpenCode
   // subprocess. Any in-process provider that uses `google-auth-library`
   // (notably `@ai-sdk/google-vertex`) auto-discovers this env var and
@@ -268,20 +302,17 @@ async function withRuntimeEnvironment<T>(fn: () => Promise<T>) {
   // anything to their shell. No-op when the user hasn't completed
   // Google sign-in, or when `auth.mode` isn't `google-oauth`.
   const adcPath = getAdcPathIfAvailable()
-  if (adcPath) {
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = adcPath
-  }
+  const restore = replaceProcessEnvironment(buildManagedRuntimeEnvironment({
+    currentEnv: process.env,
+    runtimePaths,
+    adcPath,
+    enableNativeWebSearch: shouldEnableNativeWebSearch(),
+  }))
 
   try {
     return await fn()
   } finally {
-    for (const [key, value] of Object.entries(previous)) {
-      if (value === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = value
-      }
-    }
+    restore()
   }
 }
 

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -245,15 +245,12 @@ const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'LOGNAME',
   'NODE_EXTRA_CA_CERTS',
   'NO_PROXY',
-  'OPENCODE_BIN_PATH',
   'PATH',
   'PATHEXT',
   'REQUESTS_CA_BUNDLE',
   'SHELL',
   'SSL_CERT_DIR',
   'SSL_CERT_FILE',
-  'SSH_AGENT_PID',
-  'SSH_AUTH_SOCK',
   'SystemRoot',
   'TEMP',
   'TERM',
@@ -298,6 +295,7 @@ export function buildManagedRuntimeEnvironment(input: {
   runtimePaths: ReturnType<typeof getRuntimeEnvPaths>
   adcPath?: string | null
   enableNativeWebSearch?: boolean
+  opencodeBinPath?: string | null
 }) {
   const env: NodeJS.ProcessEnv = {}
   for (const [key, value] of Object.entries(input.currentEnv)) {
@@ -310,6 +308,7 @@ export function buildManagedRuntimeEnvironment(input: {
   env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE
   if (input.enableNativeWebSearch) env.OPENCODE_ENABLE_EXA = '1'
   if (input.adcPath) env.GOOGLE_APPLICATION_CREDENTIALS = input.adcPath
+  if (input.opencodeBinPath?.trim()) env.OPENCODE_BIN_PATH = input.opencodeBinPath.trim()
   return env
 }
 
@@ -486,7 +485,7 @@ async function createManagedOpencodeServer(options: OpencodeServerOptions & { en
   }
 }
 
-async function createManagedOpencode(options: OpencodeServerOptions) {
+async function createManagedOpencode(options: OpencodeServerOptions, opencodeBinPath?: string | null) {
   const runtimePaths = getRuntimeEnvPaths()
   // Forward the app-level Google OAuth session as ADC to the OpenCode
   // subprocess. Any in-process provider that uses `google-auth-library`
@@ -500,6 +499,7 @@ async function createManagedOpencode(options: OpencodeServerOptions) {
     runtimePaths,
     adcPath,
     enableNativeWebSearch: shouldEnableNativeWebSearch(),
+    opencodeBinPath,
   })
   const server = await createManagedOpencodeServer({ ...options, env })
   const managedClient = createOpencodeClient({ baseUrl: server.url })
@@ -552,7 +552,7 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
     syncRuntimeHomeToolingBridge({
       enabled: getEffectiveSettings().runtimeToolingBridgeEnabled,
     })
-    applyBundledOpencodeCliEnvironment()
+    const bundledOpencodeEnv = applyBundledOpencodeCliEnvironment()
 
     if (!orphanCleanupComplete) {
       await cleanupOrphanedManagedOpencodeProcesses().catch((error) => {
@@ -602,7 +602,7 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
         // the zombies can accumulate to multi-GB. Give it real room.
         timeout: 30_000,
       }
-      const result = await createManagedOpencode(opencodeOptions)
+      const result = await createManagedOpencode(opencodeOptions, bundledOpencodeEnv.opencodeBinPath)
 
       client = result.client
       serverUrl = result.server.url

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -232,10 +232,14 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 // managed runtime.
 const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'APPDATA',
+  'ALL_PROXY',
   'ComSpec',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
   'LANG',
   'LOCALAPPDATA',
   'LOGNAME',
+  'NO_PROXY',
   'OPENCODE_BIN_PATH',
   'PATH',
   'PATHEXT',
@@ -249,6 +253,10 @@ const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'USER',
   'USERNAME',
   'WINDIR',
+  'all_proxy',
+  'https_proxy',
+  'http_proxy',
+  'no_proxy',
 ])
 
 function shouldPassRuntimeEnvKey(key: string) {

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1,10 +1,11 @@
 import {
-  createOpencode,
   createOpencodeClient,
   type Auth as OpencodeAuth,
   type OpencodeClient as V2OpencodeClient,
 } from '@opencode-ai/sdk/v2'
+import type { ServerOptions as OpencodeServerOptions } from '@opencode-ai/sdk/v2/server'
 import type { ModelInfoSnapshot } from '@open-cowork/shared'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join, resolve } from 'path'
@@ -212,8 +213,8 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 //     be sitting in the user's real home.
 //   - PATH: the bundled native `opencode` binary dir is prepended in
 //     `applyBundledOpencodeCliEnvironment()` (runtime-opencode-cli.ts),
-//     so the SDK's `cross-spawn('opencode')` binds to our copy, not a
-//     user-installed one on PATH.
+//     so the managed server launcher binds to our copy, not a user-installed
+//     one on PATH.
 //
 // What we redirect:
 //   - HOME: OpenCode still performs home-relative compatibility
@@ -224,14 +225,12 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 //     curated set of developer-tool config paths into that sandbox so
 //     git / ssh / npm keep behaving like the user's normal shell.
 //
-// The SDK currently launches `opencode` with `{ ...process.env }`. Keep
-// that SDK-native launch path, but replace `process.env` only for the
-// synchronous call stack where `createOpencode()` spawns the server, then
-// restore it before awaiting runtime readiness. This preserves the shell
-// toolchain (`PATH`) without forwarding arbitrary exported API keys or
-// git/SSH override variables into the managed runtime, and without letting
-// unrelated main-process work observe the curated environment while the
-// runtime is still booting.
+// The SDK's server helper currently launches `opencode` with
+// `{ ...process.env }` and does not expose an env option. Keep OpenCode
+// itself as the runtime and keep SDK v2 as the API boundary, but own this
+// small spawn adapter so the child receives an explicit curated env. This
+// avoids both broad secret forwarding and any temporary mutation of the
+// Electron main process environment.
 const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'APPDATA',
   'ALL_PROXY',
@@ -289,34 +288,124 @@ export function buildManagedRuntimeEnvironment(input: {
   return env
 }
 
-function replaceProcessEnvironment(next: NodeJS.ProcessEnv) {
-  const previous = { ...process.env }
-  for (const key of Object.keys(process.env)) {
-    delete process.env[key]
-  }
-  Object.assign(process.env, next)
-  return () => {
-    for (const key of Object.keys(process.env)) {
-      delete process.env[key]
-    }
-    Object.assign(process.env, previous)
+export function buildManagedOpencodeServerEnvironment(
+  env: NodeJS.ProcessEnv,
+  config: OpencodeServerOptions['config'],
+) {
+  return {
+    ...env,
+    OPENCODE_CONFIG_CONTENT: JSON.stringify(config ?? {}),
   }
 }
 
-export function callWithRuntimeEnvironmentForSpawn<T>(env: NodeJS.ProcessEnv, fn: () => Promise<T>) {
-  const restore = replaceProcessEnvironment(env)
-  try {
-    // In @opencode-ai/sdk 1.14.x the child process is spawned
-    // synchronously before `createOpencode()` returns its pending promise.
-    // Restore immediately so other IPC handlers never run under the
-    // managed runtime env while the server continues booting.
-    return fn()
-  } finally {
-    restore()
+function stopManagedOpencodeProcess(proc: ChildProcess) {
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+  if (process.platform === 'win32' && proc.pid) {
+    const out = spawnSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { windowsHide: true })
+    if (!out.error && out.status === 0) return
+  }
+  proc.kill()
+}
+
+function bindManagedOpencodeAbort(proc: ChildProcess, signal?: AbortSignal, onAbort?: () => void) {
+  if (!signal) return () => undefined
+  const clear = () => {
+    signal.removeEventListener('abort', abort)
+    proc.off('exit', clear)
+    proc.off('error', clear)
+  }
+  const abort = () => {
+    clear()
+    stopManagedOpencodeProcess(proc)
+    onAbort?.()
+  }
+
+  signal.addEventListener('abort', abort, { once: true })
+  proc.on('exit', clear)
+  proc.on('error', clear)
+  if (signal.aborted) abort()
+  return clear
+}
+
+async function createManagedOpencodeServer(options: OpencodeServerOptions & { env: NodeJS.ProcessEnv }) {
+  const resolved = {
+    hostname: '127.0.0.1',
+    port: 4096,
+    timeout: 5000,
+    ...options,
+  }
+  const args = ['serve', `--hostname=${resolved.hostname}`, `--port=${resolved.port}`]
+  if (resolved.config?.logLevel) args.push(`--log-level=${resolved.config.logLevel}`)
+
+  const proc = spawn('opencode', args, {
+    env: buildManagedOpencodeServerEnvironment(resolved.env, resolved.config),
+    windowsHide: true,
+  })
+
+  let clear: () => void = () => undefined
+  const url = await new Promise<string>((resolveUrl, reject) => {
+    const id = setTimeout(() => {
+      clear()
+      stopManagedOpencodeProcess(proc)
+      reject(new Error(`Timeout waiting for server to start after ${resolved.timeout}ms`))
+    }, resolved.timeout)
+    let output = ''
+    let resolvedUrl = false
+
+    proc.stdout?.on('data', (chunk) => {
+      if (resolvedUrl) return
+      output += chunk.toString()
+      const lines = output.split('\n')
+      for (const line of lines) {
+        if (line.startsWith('opencode server listening')) {
+          const match = line.match(/on\s+(https?:\/\/[^\s]+)/)
+          if (!match) {
+            clear()
+            stopManagedOpencodeProcess(proc)
+            clearTimeout(id)
+            reject(new Error(`Failed to parse server url from output: ${line}`))
+            return
+          }
+          clearTimeout(id)
+          resolvedUrl = true
+          resolveUrl(match[1])
+          return
+        }
+      }
+    })
+
+    proc.stderr?.on('data', (chunk) => {
+      output += chunk.toString()
+    })
+
+    proc.on('exit', (code) => {
+      clearTimeout(id)
+      let message = `Server exited with code ${code}`
+      if (output.trim()) message += `\nServer output: ${output}`
+      reject(new Error(message))
+    })
+
+    proc.on('error', (error) => {
+      clearTimeout(id)
+      reject(error)
+    })
+
+    clear = bindManagedOpencodeAbort(proc, resolved.signal, () => {
+      clearTimeout(id)
+      reject(resolved.signal?.reason)
+    })
+  })
+
+  return {
+    url,
+    close() {
+      clear()
+      stopManagedOpencodeProcess(proc)
+    },
   }
 }
 
-function createOpencodeWithRuntimeEnvironment(options: Parameters<typeof createOpencode>[0]) {
+async function createManagedOpencode(options: OpencodeServerOptions) {
   const runtimePaths = getRuntimeEnvPaths()
   // Forward the app-level Google OAuth session as ADC to the OpenCode
   // subprocess. Any in-process provider that uses `google-auth-library`
@@ -331,7 +420,12 @@ function createOpencodeWithRuntimeEnvironment(options: Parameters<typeof createO
     adcPath,
     enableNativeWebSearch: shouldEnableNativeWebSearch(),
   })
-  return callWithRuntimeEnvironmentForSpawn(env, () => createOpencode(options))
+  const server = await createManagedOpencodeServer({ ...options, env })
+  const managedClient = createOpencodeClient({ baseUrl: server.url })
+  return {
+    client: managedClient,
+    server,
+  }
 }
 
 export function shouldEnableNativeWebSearch() {
@@ -413,7 +507,7 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
     process.chdir(getRuntimeHomeDir())
 
     try {
-      type CreateOpencodeOptions = Parameters<typeof createOpencode>[0] & { timeout?: number }
+      type CreateOpencodeOptions = OpencodeServerOptions & { timeout?: number }
       const opencodeOptions: CreateOpencodeOptions = {
         hostname: '127.0.0.1',
         port: 0,
@@ -427,7 +521,7 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
         // the zombies can accumulate to multi-GB. Give it real room.
         timeout: 30_000,
       }
-      const result = await createOpencodeWithRuntimeEnvironment(opencodeOptions)
+      const result = await createManagedOpencode(opencodeOptions)
 
       client = result.client
       serverUrl = result.server.url

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -422,54 +422,73 @@ async function createManagedOpencodeServer(options: OpencodeServerOptions & { en
 
   let clear: () => void = () => undefined
   const url = await new Promise<string>((resolveUrl, reject) => {
-    const id = setTimeout(() => {
-      clear()
-      stopManagedOpencodeProcess(proc)
-      reject(new Error(`Timeout waiting for server to start after ${resolved.timeout}ms`))
-    }, resolved.timeout)
     let output = ''
     let stdoutBuffer = ''
-    let resolvedUrl = false
+    let startupSettled = false
 
-    proc.stdout?.on('data', (chunk) => {
-      if (resolvedUrl) return
+    function cleanupStartupListeners() {
+      proc.stdout?.off('data', onStdoutData)
+      proc.stderr?.off('data', onStderrData)
+      proc.off('exit', onExit)
+      proc.off('error', onError)
+    }
+
+    function settleStartup(callback: () => void) {
+      if (startupSettled) return
+      startupSettled = true
+      clearTimeout(id)
+      cleanupStartupListeners()
+      callback()
+    }
+
+    function rejectStartup(error: Error, stopProcess = false) {
+      settleStartup(() => reject(error))
+      clear()
+      if (stopProcess) stopManagedOpencodeProcess(proc)
+    }
+
+    const id = setTimeout(() => {
+      rejectStartup(new Error(`Timeout waiting for server to start after ${resolved.timeout}ms`), true)
+    }, resolved.timeout)
+
+    function onStdoutData(chunk: Buffer) {
+      if (startupSettled) return
       const text = chunk.toString()
       output += text
       const parsed = parseManagedOpencodeServerStdoutChunk(stdoutBuffer, text)
       stdoutBuffer = parsed.buffer
       if (parsed.error) {
-        clear()
-        stopManagedOpencodeProcess(proc)
-        clearTimeout(id)
-        reject(new Error(parsed.error))
+        rejectStartup(new Error(parsed.error), true)
         return
       }
       if (parsed.url) {
-        clearTimeout(id)
-        resolvedUrl = true
-        resolveUrl(parsed.url)
+        const startupUrl = parsed.url
+        settleStartup(() => resolveUrl(startupUrl))
       }
-    })
+    }
 
-    proc.stderr?.on('data', (chunk) => {
+    function onStderrData(chunk: Buffer) {
+      if (startupSettled) return
       output += chunk.toString()
-    })
+    }
 
-    proc.on('exit', (code) => {
-      clearTimeout(id)
+    function onExit(code: number | null) {
       let message = `Server exited with code ${code}`
       if (output.trim()) message += `\nServer output: ${output}`
-      reject(new Error(message))
-    })
+      rejectStartup(new Error(message))
+    }
 
-    proc.on('error', (error) => {
-      clearTimeout(id)
-      reject(error)
-    })
+    function onError(error: Error) {
+      rejectStartup(error)
+    }
+
+    proc.stdout?.on('data', onStdoutData)
+    proc.stderr?.on('data', onStderrData)
+    proc.on('exit', onExit)
+    proc.on('error', onError)
 
     clear = bindManagedOpencodeAbort(proc, resolved.signal, () => {
-      clearTimeout(id)
-      reject(resolved.signal?.reason)
+      settleStartup(() => reject(resolved.signal?.reason))
     })
   })
 

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -236,16 +236,22 @@ const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'ALL_PROXY',
   'COMSPEC',
   'ComSpec',
+  'CURL_CA_BUNDLE',
+  'GIT_SSL_CAINFO',
   'HTTPS_PROXY',
   'HTTP_PROXY',
   'LANG',
   'LOCALAPPDATA',
   'LOGNAME',
+  'NODE_EXTRA_CA_CERTS',
   'NO_PROXY',
   'OPENCODE_BIN_PATH',
   'PATH',
   'PATHEXT',
+  'REQUESTS_CA_BUNDLE',
   'SHELL',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
   'SSH_AGENT_PID',
   'SSH_AUTH_SOCK',
   'SystemRoot',
@@ -338,6 +344,41 @@ export function resolveManagedOpencodeSpawn(
   return { command: 'opencode', args }
 }
 
+const OPENCODE_SERVER_LISTENING_PREFIX = 'opencode server listening'
+
+export interface ManagedOpencodeServerStdoutParseResult {
+  buffer: string
+  url?: string
+  error?: string
+}
+
+function extractManagedOpencodeServerUrl(line: string) {
+  if (!line.startsWith(OPENCODE_SERVER_LISTENING_PREFIX)) return null
+  return line.match(/on\s+(https?:\/\/[^\s]+)/)?.[1] || null
+}
+
+export function parseManagedOpencodeServerStdoutChunk(
+  buffer: string,
+  chunk: string,
+): ManagedOpencodeServerStdoutParseResult {
+  const text = buffer + chunk
+  const lines = text.split('\n')
+  const nextBuffer = lines.pop() ?? ''
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '')
+    const url = extractManagedOpencodeServerUrl(line)
+    if (url) return { buffer: nextBuffer, url }
+    if (line.startsWith(OPENCODE_SERVER_LISTENING_PREFIX)) {
+      return { buffer: nextBuffer, error: `Failed to parse server url from output: ${line}` }
+    }
+  }
+
+  const partialUrl = extractManagedOpencodeServerUrl(nextBuffer.replace(/\r$/, ''))
+  if (partialUrl) return { buffer: nextBuffer, url: partialUrl }
+  return { buffer: nextBuffer }
+}
+
 function stopManagedOpencodeProcess(proc: ChildProcess) {
   if (proc.exitCode !== null || proc.signalCode !== null) return
   if (process.platform === 'win32' && proc.pid) {
@@ -391,27 +432,26 @@ async function createManagedOpencodeServer(options: OpencodeServerOptions & { en
       reject(new Error(`Timeout waiting for server to start after ${resolved.timeout}ms`))
     }, resolved.timeout)
     let output = ''
+    let stdoutBuffer = ''
     let resolvedUrl = false
 
     proc.stdout?.on('data', (chunk) => {
       if (resolvedUrl) return
-      output += chunk.toString()
-      const lines = output.split('\n')
-      for (const line of lines) {
-        if (line.startsWith('opencode server listening')) {
-          const match = line.match(/on\s+(https?:\/\/[^\s]+)/)
-          if (!match) {
-            clear()
-            stopManagedOpencodeProcess(proc)
-            clearTimeout(id)
-            reject(new Error(`Failed to parse server url from output: ${line}`))
-            return
-          }
-          clearTimeout(id)
-          resolvedUrl = true
-          resolveUrl(match[1])
-          return
-        }
+      const text = chunk.toString()
+      output += text
+      const parsed = parseManagedOpencodeServerStdoutChunk(stdoutBuffer, text)
+      stdoutBuffer = parsed.buffer
+      if (parsed.error) {
+        clear()
+        stopManagedOpencodeProcess(proc)
+        clearTimeout(id)
+        reject(new Error(parsed.error))
+        return
+      }
+      if (parsed.url) {
+        clearTimeout(id)
+        resolvedUrl = true
+        resolveUrl(parsed.url)
       }
     })
 

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -384,6 +384,19 @@ function stopManagedOpencodeProcess(proc: ChildProcess) {
   proc.kill()
 }
 
+export interface ManagedProcessOutputStreams {
+  stdout?: { resume(): unknown } | null
+  stderr?: { resume(): unknown } | null
+}
+
+export function drainManagedOpencodeProcessOutput(proc: ManagedProcessOutputStreams) {
+  // Startup parsing stops once the server URL is known, but the child
+  // keeps its stdout/stderr pipes. Keep draining them without retaining
+  // logs so noisy runtime output cannot fill the pipe buffer.
+  proc.stdout?.resume()
+  proc.stderr?.resume()
+}
+
 function bindManagedOpencodeAbort(proc: ChildProcess, signal?: AbortSignal, onAbort?: () => void) {
   if (!signal) return () => undefined
   const clear = () => {
@@ -463,7 +476,10 @@ async function createManagedOpencodeServer(options: OpencodeServerOptions & { en
       }
       if (parsed.url) {
         const startupUrl = parsed.url
-        settleStartup(() => resolveUrl(startupUrl))
+        settleStartup(() => {
+          drainManagedOpencodeProcessOutput(proc)
+          resolveUrl(startupUrl)
+        })
       }
     }
 

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -225,11 +225,13 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 //     git / ssh / npm keep behaving like the user's normal shell.
 //
 // The SDK currently launches `opencode` with `{ ...process.env }`. Keep
-// that SDK-native launch path, but temporarily replace `process.env` with
-// a curated managed environment while `createOpencode()` spawns the
-// server. This preserves the shell toolchain (`PATH`) without forwarding
-// arbitrary exported API keys or git/SSH override variables into the
-// managed runtime.
+// that SDK-native launch path, but replace `process.env` only for the
+// synchronous call stack where `createOpencode()` spawns the server, then
+// restore it before awaiting runtime readiness. This preserves the shell
+// toolchain (`PATH`) without forwarding arbitrary exported API keys or
+// git/SSH override variables into the managed runtime, and without letting
+// unrelated main-process work observe the curated environment while the
+// runtime is still booting.
 const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
   'APPDATA',
   'ALL_PROXY',
@@ -301,7 +303,20 @@ function replaceProcessEnvironment(next: NodeJS.ProcessEnv) {
   }
 }
 
-async function withRuntimeEnvironment<T>(fn: () => Promise<T>) {
+export function callWithRuntimeEnvironmentForSpawn<T>(env: NodeJS.ProcessEnv, fn: () => Promise<T>) {
+  const restore = replaceProcessEnvironment(env)
+  try {
+    // In @opencode-ai/sdk 1.14.x the child process is spawned
+    // synchronously before `createOpencode()` returns its pending promise.
+    // Restore immediately so other IPC handlers never run under the
+    // managed runtime env while the server continues booting.
+    return fn()
+  } finally {
+    restore()
+  }
+}
+
+function createOpencodeWithRuntimeEnvironment(options: Parameters<typeof createOpencode>[0]) {
   const runtimePaths = getRuntimeEnvPaths()
   // Forward the app-level Google OAuth session as ADC to the OpenCode
   // subprocess. Any in-process provider that uses `google-auth-library`
@@ -310,18 +325,13 @@ async function withRuntimeEnvironment<T>(fn: () => Promise<T>) {
   // anything to their shell. No-op when the user hasn't completed
   // Google sign-in, or when `auth.mode` isn't `google-oauth`.
   const adcPath = getAdcPathIfAvailable()
-  const restore = replaceProcessEnvironment(buildManagedRuntimeEnvironment({
+  const env = buildManagedRuntimeEnvironment({
     currentEnv: process.env,
     runtimePaths,
     adcPath,
     enableNativeWebSearch: shouldEnableNativeWebSearch(),
-  }))
-
-  try {
-    return await fn()
-  } finally {
-    restore()
-  }
+  })
+  return callWithRuntimeEnvironmentForSpawn(env, () => createOpencode(options))
 }
 
 export function shouldEnableNativeWebSearch() {
@@ -417,7 +427,7 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
         // the zombies can accumulate to multi-GB. Give it real room.
         timeout: 30_000,
       }
-      const result = await withRuntimeEnvironment(() => createOpencode(opencodeOptions))
+      const result = await createOpencodeWithRuntimeEnvironment(opencodeOptions)
 
       client = result.client
       serverUrl = result.server.url

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -369,7 +369,7 @@ export function saveSettings(settings: Partial<AppSettings>) {
   // Strip mask sentinels so a caller that round-tripped `settings:get`
   // (which returns masked credentials) can't accidentally overwrite
   // real keys with the mask string. Safe because the real value can
-  // only have been preserved through `settings:get-with-credentials`.
+  // only have been preserved through the scoped credential IPCs.
   const merged: AppSettings = {
     ...current,
     ...updates,
@@ -408,6 +408,16 @@ export function getProviderCredentialValue(settings: AppSettings, providerId: st
 export function getIntegrationCredentialValue(settings: AppSettings, integrationId: string, key: string) {
   const value = settings.integrationCredentials?.[integrationId]?.[key]
   return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function getProviderCredentials(providerId: string) {
+  const credentials = loadSettings().providerCredentials[providerId] || {}
+  return { ...credentials }
+}
+
+export function getIntegrationCredentials(integrationId: string) {
+  const credentials = loadSettings().integrationCredentials[integrationId] || {}
+  return { ...credentials }
 }
 
 export function isSetupComplete(settings = loadSettings()) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -68,7 +68,8 @@ const api: CoworkAPI = {
   },
   settings: {
     get: () => ipcRenderer.invoke('settings:get'),
-    getWithCredentials: () => ipcRenderer.invoke('settings:get-with-credentials'),
+    getProviderCredentials: (providerId) => ipcRenderer.invoke('settings:get-provider-credentials', providerId),
+    getIntegrationCredentials: (integrationId) => ipcRenderer.invoke('settings:get-integration-credentials', integrationId),
     set: (updates) => ipcRenderer.invoke('settings:set', updates),
   },
   mcp: {

--- a/apps/desktop/src/renderer/chart-frame.ts
+++ b/apps/desktop/src/renderer/chart-frame.ts
@@ -196,6 +196,14 @@ window.addEventListener('unhandledrejection', (event) => {
   })
 })
 
+document.addEventListener('securitypolicyviolation', (event) => {
+  postToParent({
+    type: 'chart-error',
+    requestId: -1,
+    message: `Chart frame blocked ${event.violatedDirective || 'a CSP directive'}`,
+  })
+})
+
 window.addEventListener('beforeunload', () => {
   activeChartResizeObserver?.disconnect()
   activeChartResizeObserver = null

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import type { EffectiveAppSettings, ProviderDescriptor } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../test/setup'
@@ -27,6 +28,14 @@ function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSe
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
 const providers: ProviderDescriptor[] = [
   {
     id: 'openrouter',
@@ -41,6 +50,14 @@ const providers: ProviderDescriptor[] = [
         placeholder: 'sk-or-...',
         secret: true,
         required: true,
+      },
+      {
+        key: 'teamId',
+        label: 'Team ID',
+        description: 'Optional team identifier',
+        placeholder: 'team-...',
+        secret: false,
+        required: false,
       },
     ],
     models: [
@@ -75,5 +92,34 @@ describe('SetupScreen', () => {
     await waitFor(() => expect(apiKeyInput).toHaveValue('sk-or-scoped'))
     expect(get).toHaveBeenCalledTimes(1)
     expect(getProviderCredentials).toHaveBeenCalledWith('openrouter')
+  })
+
+  it('does not overwrite setup credential edits when scoped credential loading resolves late', async () => {
+    const credentialLoad = deferred<Record<string, string>>()
+    const user = userEvent.setup()
+    installRendererTestCoworkApi({
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(() => credentialLoad.promise),
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providers}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={vi.fn()}
+      />,
+    )
+
+    const apiKeyInput = await screen.findByPlaceholderText('sk-or-...')
+    await user.type(apiKeyInput, 'sk-or-user-edit')
+
+    credentialLoad.resolve({ apiKey: 'sk-or-from-disk', teamId: 'team-from-disk' })
+
+    await waitFor(() => expect(screen.getByPlaceholderText('team-...')).toHaveValue('team-from-disk'))
+    expect(apiKeyInput).toHaveValue('sk-or-user-edit')
   })
 })

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { EffectiveAppSettings, ProviderDescriptor } from '@open-cowork/shared'
+import { installRendererTestCoworkApi } from '../test/setup'
+import { SetupScreen } from './SetupScreen'
+
+function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSettings {
+  return {
+    selectedProviderId: 'openrouter',
+    selectedModelId: 'anthropic/claude-sonnet-4',
+    providerCredentials: {},
+    integrationCredentials: {},
+    integrationEnabled: {},
+    enableBash: false,
+    enableFileWrite: false,
+    runtimeToolingBridgeEnabled: true,
+    automationLaunchAtLogin: false,
+    automationRunInBackground: false,
+    automationDesktopNotifications: true,
+    automationQuietHoursStart: null,
+    automationQuietHoursEnd: null,
+    defaultAutomationAutonomyPolicy: 'review-first',
+    defaultAutomationExecutionMode: 'scoped_execution',
+    effectiveProviderId: 'openrouter',
+    effectiveModel: 'anthropic/claude-sonnet-4',
+    ...overrides,
+  }
+}
+
+const providers: ProviderDescriptor[] = [
+  {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    description: 'OpenRouter models',
+    connected: false,
+    credentials: [
+      {
+        key: 'apiKey',
+        label: 'API key',
+        description: 'OpenRouter API key',
+        placeholder: 'sk-or-...',
+        secret: true,
+        required: true,
+      },
+    ],
+    models: [
+      { id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' },
+    ],
+    defaultModel: 'anthropic/claude-sonnet-4',
+  },
+]
+
+describe('SetupScreen', () => {
+  it('loads selected-provider credentials through the scoped credential IPC', async () => {
+    const get = vi.fn(async () => settings())
+    const getProviderCredentials = vi.fn(async () => ({ apiKey: 'sk-or-scoped' }))
+    installRendererTestCoworkApi({
+      settings: {
+        get,
+        getProviderCredentials,
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providers}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={vi.fn()}
+      />,
+    )
+
+    const apiKeyInput = await screen.findByPlaceholderText('sk-or-...')
+    await waitFor(() => expect(apiKeyInput).toHaveValue('sk-or-scoped'))
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(getProviderCredentials).toHaveBeenCalledWith('openrouter')
+  })
+})

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -23,14 +23,15 @@ export function SetupScreen({
   const [providerId, setProviderId] = useState<string | null>(defaultProviderId)
   const [modelId, setModelId] = useState(defaultModelId || '')
   const [providerCredentials, setProviderCredentials] = useState<Record<string, Record<string, string>>>({})
+  const [loadedCredentialProviders, setLoadedCredentialProviders] = useState<Set<string>>(() => new Set())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    // SetupScreen is a credential-editor surface — it prefills existing
-    // values and lets the user append to them, so it needs the real
-    // strings rather than the masked defaults returned by settings.get().
-    window.coworkApi.settings.getWithCredentials().then((settings) => {
+    // Settings are loaded masked by default. The setup form requests only
+    // the selected provider's credential bag below.
+    let cancelled = false
+    window.coworkApi.settings.get().then(async (settings) => {
       const initialProviderId = providers.some((provider) => provider.id === settings.selectedProviderId)
         ? settings.selectedProviderId
         : settings.effectiveProviderId || defaultProviderId
@@ -38,12 +39,18 @@ export function SetupScreen({
       const initialModelId = initialProvider?.models.some((model) => model.id === settings.selectedModelId)
         ? settings.selectedModelId || ''
         : settings.effectiveModel || initialProvider?.defaultModel || defaultModelId || initialProvider?.models[0]?.id || ''
+      const initialCredentials = initialProviderId
+        ? await window.coworkApi.settings.getProviderCredentials(initialProviderId)
+        : {}
+      if (cancelled) return
       setProviderId(initialProviderId)
       setModelId(initialModelId)
-      setProviderCredentials(settings.providerCredentials || {})
+      setProviderCredentials(initialProviderId ? { [initialProviderId]: initialCredentials } : {})
+      setLoadedCredentialProviders(initialProviderId ? new Set([initialProviderId]) : new Set())
     }).catch((err) => {
       console.error('Failed to load setup settings:', err)
     })
+    return () => { cancelled = true }
   }, [defaultModelId, defaultProviderId, providers])
 
   const selectedProvider = useMemo(
@@ -57,6 +64,19 @@ export function SetupScreen({
       setModelId(selectedProvider.defaultModel || selectedProvider.models[0]?.id || defaultModelId || '')
     }
   }, [selectedProvider, modelId, defaultModelId])
+
+  useEffect(() => {
+    if (!providerId || loadedCredentialProviders.has(providerId)) return
+    let cancelled = false
+    window.coworkApi.settings.getProviderCredentials(providerId).then((credentials) => {
+      if (cancelled) return
+      setProviderCredentials((current) => ({ ...current, [providerId]: credentials }))
+      setLoadedCredentialProviders((current) => new Set(current).add(providerId))
+    }).catch((err) => {
+      console.error('Failed to load provider credentials:', err)
+    })
+    return () => { cancelled = true }
+  }, [loadedCredentialProviders, providerId])
 
   const selectedCredentials = providerId ? (providerCredentials[providerId] || {}) : {}
   const requiredCredentials = selectedProvider?.credentials.filter((credential) => credential.required !== false) || []

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ProviderDescriptor } from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
+import { mergeFetchedProviderCredentials } from './provider/credential-merge'
 import { ProviderAuthControls } from './provider/ProviderAuthControls'
 
 interface Props {
@@ -26,6 +27,25 @@ export function SetupScreen({
   const [loadedCredentialProviders, setLoadedCredentialProviders] = useState<Set<string>>(() => new Set())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const dirtyProviderCredentialKeys = useRef<Record<string, Set<string>>>({})
+  const providerSelectionEdited = useRef(false)
+
+  const markProviderCredentialDirty = (nextProviderId: string, key: string) => {
+    const keys = dirtyProviderCredentialKeys.current[nextProviderId] || new Set<string>()
+    keys.add(key)
+    dirtyProviderCredentialKeys.current[nextProviderId] = keys
+  }
+
+  const mergeLoadedProviderCredentials = (nextProviderId: string, credentials: Record<string, string>) => {
+    setProviderCredentials((current) => ({
+      ...current,
+      [nextProviderId]: mergeFetchedProviderCredentials(
+        current[nextProviderId],
+        credentials,
+        dirtyProviderCredentialKeys.current[nextProviderId],
+      ),
+    }))
+  }
 
   useEffect(() => {
     // Settings are loaded masked by default. The setup form requests only
@@ -43,10 +63,14 @@ export function SetupScreen({
         ? await window.coworkApi.settings.getProviderCredentials(initialProviderId)
         : {}
       if (cancelled) return
-      setProviderId(initialProviderId)
-      setModelId(initialModelId)
-      setProviderCredentials(initialProviderId ? { [initialProviderId]: initialCredentials } : {})
-      setLoadedCredentialProviders(initialProviderId ? new Set([initialProviderId]) : new Set())
+      if (!providerSelectionEdited.current) {
+        setProviderId(initialProviderId)
+        setModelId(initialModelId)
+      }
+      if (initialProviderId) {
+        mergeLoadedProviderCredentials(initialProviderId, initialCredentials)
+        setLoadedCredentialProviders((current) => new Set(current).add(initialProviderId))
+      }
     }).catch((err) => {
       console.error('Failed to load setup settings:', err)
     })
@@ -70,7 +94,7 @@ export function SetupScreen({
     let cancelled = false
     window.coworkApi.settings.getProviderCredentials(providerId).then((credentials) => {
       if (cancelled) return
-      setProviderCredentials((current) => ({ ...current, [providerId]: credentials }))
+      mergeLoadedProviderCredentials(providerId, credentials)
       setLoadedCredentialProviders((current) => new Set(current).add(providerId))
     }).catch((err) => {
       console.error('Failed to load provider credentials:', err)
@@ -88,6 +112,7 @@ export function SetupScreen({
 
   const updateCredential = (key: string, value: string) => {
     if (!providerId) return
+    markProviderCredentialDirty(providerId, key)
     setProviderCredentials((current) => ({
       ...current,
       [providerId]: {
@@ -161,6 +186,7 @@ export function SetupScreen({
             <button
               key={provider.id}
               onClick={() => {
+                providerSelectionEdited.current = true
                 setProviderId(provider.id)
                 setModelId(provider.defaultModel || provider.models[0]?.id || '')
               }}

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.tsx
@@ -183,7 +183,7 @@ function SkillBundleFileEntry({
 }
 
 // Per-MCP credential form surfaced in the Capabilities detail panel.
-// Reads the currently stored (masked) values from `settings.getWithCredentials`,
+// Reads only this integration's currently stored credential values,
 // lets the user overwrite them, and persists through `settings.set` —
 // the same bag (`integrationCredentials[mcpName][key]`) that
 // `envSettings` / `headerSettings` read from at runtime. No shell env
@@ -204,10 +204,9 @@ function ToolCredentialsCard({
 
   useEffect(() => {
     let cancelled = false
-    window.coworkApi.settings.getWithCredentials()
-      .then((settings) => {
+    window.coworkApi.settings.getIntegrationCredentials(integrationId)
+      .then((current) => {
         if (cancelled) return
-        const current = settings.integrationCredentials?.[integrationId] || {}
         setStored(current)
         setDrafts({})
       })
@@ -237,8 +236,8 @@ function ToolCredentialsCard({
           [integrationId]: patch,
         },
       })
-      const refreshed = await window.coworkApi.settings.getWithCredentials()
-      setStored(refreshed.integrationCredentials?.[integrationId] || {})
+      const refreshed = await window.coworkApi.settings.getIntegrationCredentials(integrationId)
+      setStored(refreshed)
       setDrafts({})
       setSavedAt(Date.now())
     } catch (error) {

--- a/apps/desktop/src/renderer/components/plugins/CustomMcpForm.test.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomMcpForm.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CustomMcpForm } from './CustomMcpForm'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('CustomMcpForm', () => {
+  it('requires explicit confirmation before allowing private network MCP URLs', async () => {
+    const onSave = vi.fn()
+    const onCancel = vi.fn()
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<CustomMcpForm onSave={onSave} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'HTTP / SSE (remote)' }))
+    const checkbox = await screen.findByLabelText(/Allow private network/)
+    fireEvent.click(checkbox)
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect(checkbox).not.toBeChecked()
+
+    confirm.mockReturnValue(true)
+    fireEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+  })
+})

--- a/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
@@ -75,6 +75,18 @@ export function CustomMcpForm({
     existing?.permissionMode === 'allow' ? 'allow' : 'ask',
   )
 
+  const handleAllowPrivateNetworkChange = (checked: boolean) => {
+    if (!checked) {
+      setAllowPrivateNetwork(false)
+      return
+    }
+    const confirmed = window.confirm(t(
+      'mcpForm.allowPrivateNetworkConfirm',
+      'Allow this MCP to reach localhost and private network addresses? Only enable this for endpoints you control or trust.',
+    ))
+    if (confirmed) setAllowPrivateNetwork(true)
+  }
+
   useEffect(() => {
     if (projectDirectory) {
       setProjectTargetDirectory(projectDirectory)
@@ -437,7 +449,7 @@ export function CustomMcpForm({
                       id="mcp-allow-private-network"
                       type="checkbox"
                       checked={allowPrivateNetwork}
-                      onChange={(event) => setAllowPrivateNetwork(event.target.checked)}
+                      onChange={(event) => handleAllowPrivateNetworkChange(event.target.checked)}
                       className="mt-0.5"
                     />
                     <div className="flex flex-col gap-0.5">

--- a/apps/desktop/src/renderer/components/plugins/CustomSkillForm.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomSkillForm.tsx
@@ -184,6 +184,11 @@ export function CustomSkillForm({
     try {
       const selection = await window.coworkApi.custom.selectSkillDirectoryImport()
       if (!selection) return
+      const confirmed = window.confirm(t(
+        'skillForm.unsignedImportConfirm',
+        'Import this unsigned skill bundle? Skill bundles change agent behavior and may request tool access. Only continue if you trust the source.',
+      ))
+      if (!confirmed) return
       await window.coworkApi.custom.importSkillDirectory(selection.token, {
         name,
         scope,

--- a/apps/desktop/src/renderer/components/provider/credential-merge.ts
+++ b/apps/desktop/src/renderer/components/provider/credential-merge.ts
@@ -1,5 +1,7 @@
 export type ProviderCredentialBag = Record<string, string>
 
+const CREDENTIAL_MASK = '••••••••'
+
 export function mergeFetchedProviderCredentials(
   current: ProviderCredentialBag | undefined,
   fetched: ProviderCredentialBag,
@@ -10,6 +12,21 @@ export function mergeFetchedProviderCredentials(
   for (const key of dirtyKeys) {
     const value = current?.[key]
     if (value !== undefined) next[key] = value
+  }
+  return next
+}
+
+export function stripMaskedProviderCredentials(
+  credentials: Record<string, ProviderCredentialBag>,
+): Record<string, ProviderCredentialBag> {
+  const next: Record<string, ProviderCredentialBag> = {}
+  for (const [providerId, values] of Object.entries(credentials)) {
+    const clean: ProviderCredentialBag = {}
+    for (const [key, value] of Object.entries(values)) {
+      if (value === CREDENTIAL_MASK) continue
+      clean[key] = value
+    }
+    next[providerId] = clean
   }
   return next
 }

--- a/apps/desktop/src/renderer/components/provider/credential-merge.ts
+++ b/apps/desktop/src/renderer/components/provider/credential-merge.ts
@@ -1,0 +1,15 @@
+export type ProviderCredentialBag = Record<string, string>
+
+export function mergeFetchedProviderCredentials(
+  current: ProviderCredentialBag | undefined,
+  fetched: ProviderCredentialBag,
+  dirtyKeys: ReadonlySet<string> | undefined,
+): ProviderCredentialBag {
+  if (!dirtyKeys?.size) return fetched
+  const next: ProviderCredentialBag = { ...fetched }
+  for (const key of dirtyKeys) {
+    const value = current?.[key]
+    if (value !== undefined) next[key] = value
+  }
+  return next
+}

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -135,4 +135,45 @@ describe('SettingsPanel', () => {
     await waitFor(() => expect(screen.getByPlaceholderText('team-...')).toHaveValue('team-from-disk'))
     expect(apiKeyInput).toHaveValue('sk-or-user-edit')
   })
+
+  it('does not bind masked credential sentinels to editable inputs', async () => {
+    const credentialLoad = deferred<Record<string, string>>()
+    const user = userEvent.setup()
+    const settingsSet = vi.fn(async (updates: Partial<EffectiveAppSettings>) => settings(updates))
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      settings: {
+        get: vi.fn(async () => settings({
+          providerCredentials: {
+            openrouter: {
+              apiKey: '••••••••',
+              teamId: '••••••••',
+            },
+          },
+        })),
+        getProviderCredentials: vi.fn(() => credentialLoad.promise),
+        set: settingsSet,
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await user.click(screen.getByRole('button', { name: /Models/ }))
+
+    const apiKeyInput = await screen.findByPlaceholderText('sk-or-...')
+    expect(apiKeyInput).toHaveValue('')
+
+    await user.type(apiKeyInput, 'sk-or-replacement')
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1))
+    expect(settingsSet.mock.calls[0]?.[0].providerCredentials).toEqual({
+      openrouter: {
+        apiKey: 'sk-or-replacement',
+      },
+    })
+  })
 })

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -1,7 +1,88 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
+import type { EffectiveAppSettings, PublicAppConfig } from '@open-cowork/shared'
+import { installRendererTestCoworkApi } from '../../test/setup'
 import { SettingsPanel } from './SettingsPanel'
+
+function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSettings {
+  return {
+    selectedProviderId: 'openrouter',
+    selectedModelId: 'anthropic/claude-sonnet-4',
+    providerCredentials: {},
+    integrationCredentials: {},
+    integrationEnabled: {},
+    enableBash: false,
+    enableFileWrite: false,
+    runtimeToolingBridgeEnabled: true,
+    automationLaunchAtLogin: false,
+    automationRunInBackground: false,
+    automationDesktopNotifications: true,
+    automationQuietHoursStart: null,
+    automationQuietHoursEnd: null,
+    defaultAutomationAutonomyPolicy: 'review-first',
+    defaultAutomationExecutionMode: 'scoped_execution',
+    effectiveProviderId: 'openrouter',
+    effectiveModel: 'anthropic/claude-sonnet-4',
+    ...overrides,
+  }
+}
+
+const config: PublicAppConfig = {
+  branding: {
+    name: 'Open Cowork',
+    appId: 'com.opencowork.desktop',
+    dataDirName: 'Open Cowork',
+    helpUrl: 'https://github.com/joe-broadhead/open-cowork',
+  },
+  auth: {
+    mode: 'none',
+    enabled: false,
+  },
+  providers: {
+    defaultProvider: 'openrouter',
+    defaultModel: 'anthropic/claude-sonnet-4',
+    available: [
+      {
+        id: 'openrouter',
+        name: 'OpenRouter',
+        description: 'OpenRouter models',
+        connected: false,
+        credentials: [
+          {
+            key: 'apiKey',
+            label: 'API key',
+            description: 'OpenRouter API key',
+            placeholder: 'sk-or-...',
+            secret: true,
+            required: true,
+          },
+          {
+            key: 'teamId',
+            label: 'Team ID',
+            description: 'Optional team identifier',
+            placeholder: 'team-...',
+            secret: false,
+            required: false,
+          },
+        ],
+        models: [
+          { id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' },
+        ],
+        defaultModel: 'anthropic/claude-sonnet-4',
+      },
+    ],
+  },
+  agentStarterTemplates: [],
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
 
 describe('SettingsPanel', () => {
   it('persists the developer config bridge permission toggle', async () => {
@@ -27,5 +108,31 @@ describe('SettingsPanel', () => {
       enableFileWrite: false,
       runtimeToolingBridgeEnabled: false,
     })
+  })
+
+  it('does not overwrite credential edits when scoped provider credentials resolve late', async () => {
+    const credentialLoad = deferred<Record<string, string>>()
+    const user = userEvent.setup()
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(() => credentialLoad.promise),
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await user.click(screen.getByRole('button', { name: /Models/ }))
+    const apiKeyInput = await screen.findByPlaceholderText('sk-or-...')
+    await user.type(apiKeyInput, 'sk-or-user-edit')
+
+    credentialLoad.resolve({ apiKey: 'sk-or-from-disk', teamId: 'team-from-disk' })
+
+    await waitFor(() => expect(screen.getByPlaceholderText('team-...')).toHaveValue('team-from-disk'))
+    expect(apiKeyInput).toHaveValue('sk-or-user-edit')
   })
 })

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -1017,11 +1017,10 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
   useEffect(() => {
     // Fast close-reopen cycles can land these resolves into an unmounted
     // component; guard with a cancelled flag so we don't setState on a
-    // disposed instance. Uses getWithCredentials because the Models tab
-    // edits the API-key form — a masked load would overwrite real keys
-    // with the sentinel on save.
+    // disposed instance. The default settings load is masked; the Models
+    // tab fetches only the active provider's real credential bag below.
     let cancelled = false
-    Promise.all([window.coworkApi.settings.getWithCredentials(), window.coworkApi.app.config(), window.coworkApi.artifact.storageStats()])
+    Promise.all([window.coworkApi.settings.get(), window.coworkApi.app.config(), window.coworkApi.artifact.storageStats()])
       .then(([nextSettings, nextConfig, nextStorage]) => {
         if (cancelled) return
         setSettings(nextSettings)
@@ -1034,6 +1033,28 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
       })
     return () => { cancelled = true }
   }, [])
+
+  useEffect(() => {
+    const providerId = settings?.effectiveProviderId
+    if (!providerId) return
+    let cancelled = false
+    window.coworkApi.settings.getProviderCredentials(providerId).then((credentials) => {
+      if (cancelled) return
+      setSettings((current) => {
+        if (!current || current.effectiveProviderId !== providerId) return current
+        return {
+          ...current,
+          providerCredentials: {
+            ...current.providerCredentials,
+            [providerId]: credentials,
+          },
+        }
+      })
+    }).catch((err) => {
+      console.error('Failed to load provider credentials:', err)
+    })
+    return () => { cancelled = true }
+  }, [settings?.effectiveProviderId])
 
   const tabs = useMemo(
     () => [
@@ -1051,7 +1072,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
     const { showSaved = true } = options
     setSaveError(null)
     try {
-      const next = await window.coworkApi.settings.set({
+      const savedSettings = await window.coworkApi.settings.set({
         selectedProviderId: settings.selectedProviderId,
         selectedModelId: settings.selectedModelId,
         providerCredentials: settings.providerCredentials,
@@ -1067,6 +1088,20 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
         defaultAutomationAutonomyPolicy: settings.defaultAutomationAutonomyPolicy,
         defaultAutomationExecutionMode: settings.defaultAutomationExecutionMode,
       })
+      let next = savedSettings
+      if (savedSettings.effectiveProviderId) {
+        try {
+          next = {
+            ...savedSettings,
+            providerCredentials: {
+              ...savedSettings.providerCredentials,
+              [savedSettings.effectiveProviderId]: await window.coworkApi.settings.getProviderCredentials(savedSettings.effectiveProviderId),
+            },
+          }
+        } catch (error) {
+          console.error('Failed to reload provider credentials after saving settings:', error)
+        }
+      }
       setSettings(next)
       if (showSaved) {
         setSaved(true)

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../helpers/theme'
 import { confirmAppReset } from '../../helpers/destructive-actions'
 import { writeTextToClipboard } from '../../helpers/clipboard'
-import { mergeFetchedProviderCredentials } from '../provider/credential-merge'
+import { mergeFetchedProviderCredentials, stripMaskedProviderCredentials } from '../provider/credential-merge'
 import { ProviderAuthControls } from '../provider/ProviderAuthControls'
 
 function ThemePreviewCard({
@@ -509,6 +509,14 @@ function ModelsPanel({
 
     </div>
   )
+}
+
+function stripMaskedSettingsCredentials(settings: EffectiveAppSettings): EffectiveAppSettings {
+  return {
+    ...settings,
+    providerCredentials: stripMaskedProviderCredentials(settings.providerCredentials),
+    integrationCredentials: stripMaskedProviderCredentials(settings.integrationCredentials),
+  }
 }
 
 function PermissionsPanel({
@@ -1031,7 +1039,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
     Promise.all([window.coworkApi.settings.get(), window.coworkApi.app.config(), window.coworkApi.artifact.storageStats()])
       .then(([nextSettings, nextConfig, nextStorage]) => {
         if (cancelled) return
-        setSettings(nextSettings)
+        setSettings(stripMaskedSettingsCredentials(nextSettings))
         setConfig(nextConfig)
         setStorageStats(nextStorage)
       })

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
 import type {
   AutomationAutonomyPolicy,
   AutomationExecutionMode,
@@ -23,6 +23,7 @@ import {
 } from '../../helpers/theme'
 import { confirmAppReset } from '../../helpers/destructive-actions'
 import { writeTextToClipboard } from '../../helpers/clipboard'
+import { mergeFetchedProviderCredentials } from '../provider/credential-merge'
 import { ProviderAuthControls } from '../provider/ProviderAuthControls'
 
 function ThemePreviewCard({
@@ -1013,6 +1014,13 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
   const [storageStats, setStorageStats] = useState<SandboxStorageStats | null>(null)
   const [runningCleanup, setRunningCleanup] = useState<SandboxCleanupResult['mode'] | null>(null)
   const [lastCleanup, setLastCleanup] = useState<SandboxCleanupResult | null>(null)
+  const dirtyProviderCredentialKeys = useRef<Record<string, Set<string>>>({})
+
+  const markProviderCredentialDirty = (providerId: string, key: string) => {
+    const keys = dirtyProviderCredentialKeys.current[providerId] || new Set<string>()
+    keys.add(key)
+    dirtyProviderCredentialKeys.current[providerId] = keys
+  }
 
   useEffect(() => {
     // Fast close-reopen cycles can land these resolves into an unmounted
@@ -1046,7 +1054,11 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
           ...current,
           providerCredentials: {
             ...current.providerCredentials,
-            [providerId]: credentials,
+            [providerId]: mergeFetchedProviderCredentials(
+              current.providerCredentials[providerId],
+              credentials,
+              dirtyProviderCredentialKeys.current[providerId],
+            ),
           },
         }
       })
@@ -1088,6 +1100,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
         defaultAutomationAutonomyPolicy: settings.defaultAutomationAutonomyPolicy,
         defaultAutomationExecutionMode: settings.defaultAutomationExecutionMode,
       })
+      dirtyProviderCredentialKeys.current = {}
       let next = savedSettings
       if (savedSettings.effectiveProviderId) {
         try {
@@ -1139,6 +1152,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
   }
 
   const updateProviderCredential = (providerId: string, key: string, value: string) => {
+    markProviderCredentialDirty(providerId, key)
     setSettings((current) => {
       if (!current) return current
       return {

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -89,6 +89,23 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       list: vi.fn(async () => []),
       run: vi.fn(async () => true),
     },
+    custom: {
+      addSkill: vi.fn(async () => true),
+      addMcp: vi.fn(async () => true),
+      importSkillDirectory: vi.fn(async () => ({
+        name: 'imported-skill',
+        path: '/tmp/imported-skill',
+        directory: null,
+        scope: 'machine',
+        toolIds: [],
+      })),
+      listMcps: vi.fn(async () => []),
+      listSkills: vi.fn(async () => []),
+      removeMcp: vi.fn(async () => true),
+      removeSkill: vi.fn(async () => true),
+      selectSkillDirectoryImport: vi.fn(async () => null),
+      testMcp: vi.fn(async () => ({ ok: true, methods: [], error: null })),
+    },
     dialog: {
       selectDirectory: vi.fn(async () => null),
     },
@@ -111,7 +128,8 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
     },
     settings: {
       get: vi.fn(async () => createDefaultSettings()),
-      getWithCredentials: vi.fn(async () => createDefaultSettings()),
+      getProviderCredentials: vi.fn(async (providerId: string) => createDefaultSettings().providerCredentials[providerId] || {}),
+      getIntegrationCredentials: vi.fn(async (integrationId: string) => createDefaultSettings().integrationCredentials[integrationId] || {}),
       set: vi.fn(async (updates) => createDefaultSettings(updates)),
     },
   }

--- a/apps/desktop/tests/settings-round-trip.smoke.test.ts
+++ b/apps/desktop/tests/settings-round-trip.smoke.test.ts
@@ -55,9 +55,9 @@ test('settings round-trip survives a full reload through safeStorage + disk', as
 
     // Credentials come back through a separate IPC so the plain
     // settings:get doesn't leak them to every renderer consumer.
-    const withCreds = await page.evaluate(async () => window.coworkApi.settings.getWithCredentials())
+    const providerCredentials = await page.evaluate(async () => window.coworkApi.settings.getProviderCredentials('openrouter'))
     assert.equal(
-      withCreds.providerCredentials?.openrouter?.apiKey,
+      providerCredentials.apiKey,
       'roundtrip-key',
       'safeStorage-encrypted credential must decrypt back to the original value',
     )

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -304,7 +304,6 @@ async function closeCdpSmokeApp(browser: Browser, port: number) {
 
   for (let attempts = 0; attempts < 20; attempts += 1) {
     if (!(await isCdpAvailable(port))) {
-      await stopSpawnedSmokeProcess(child)
       await delay(1_000)
       return
     }

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -349,14 +349,15 @@ async function bootstrapSmokeSettings(page: Page, appShellTimeoutMs = 30_000) {
   const setupComplete = await page.evaluate(async () => {
     const [config, settings] = await Promise.all([
       window.coworkApi.app.config(),
-      window.coworkApi.settings.getWithCredentials(),
+      window.coworkApi.settings.get(),
     ])
     if (!settings.effectiveProviderId || !settings.effectiveModel) return false
     const provider = config.providers.available.find((entry) => entry.id === settings.effectiveProviderId)
     if (!provider) return false
+    const providerCredentials = await window.coworkApi.settings.getProviderCredentials(provider.id)
     return provider.credentials.every((credential) => {
       if (credential.required === false) return true
-      const value = settings.providerCredentials?.[provider.id]?.[credential.key]
+      const value = providerCredentials[credential.key]
       return typeof value === 'string' && value.trim().length > 0
     })
   })

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -220,6 +220,22 @@ async function delay(ms: number) {
   await new Promise((done) => setTimeout(done, ms))
 }
 
+async function withSmokeTimeout<T>(label: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
 async function getAvailablePort() {
   const server = createServer()
   await new Promise<void>((resolveListen, rejectListen) => {
@@ -259,11 +275,17 @@ function runCommand(command: string, args: string[], timeoutMs = 10_000) {
 }
 
 async function isCdpAvailable(port: number) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 1_000)
   try {
-    const response = await fetch(`http://127.0.0.1:${port}/json/version`)
+    const response = await fetch(`http://127.0.0.1:${port}/json/version`, {
+      signal: controller.signal,
+    })
     return response.ok
   } catch {
     return false
+  } finally {
+    clearTimeout(timeout)
   }
 }
 
@@ -291,13 +313,13 @@ async function waitForCdpPage(browser: Browser, timeoutMs = 30_000) {
 async function closeCdpSmokeApp(browser: Browser, port: number) {
   try {
     const cdpSession = await browser.newBrowserCDPSession()
-    await cdpSession.send('Browser.close')
+    await withSmokeTimeout('closing packaged app over CDP', cdpSession.send('Browser.close'), 2_000)
   } catch {
     // Fall through to the normal Playwright close/disconnect path.
   }
 
   try {
-    await browser.close()
+    await withSmokeTimeout('closing packaged browser connection', browser.close(), 5_000)
   } catch {
     // The process may already be gone after Browser.close reaches CDP.
   }
@@ -329,13 +351,13 @@ async function stopSpawnedSmokeProcess(child: ChildProcess) {
 async function closeSpawnedCdpSmokeApp(browser: Browser, child: ChildProcess, port: number) {
   try {
     const cdpSession = await browser.newBrowserCDPSession()
-    await cdpSession.send('Browser.close')
+    await withSmokeTimeout('closing spawned packaged app over CDP', cdpSession.send('Browser.close'), 2_000)
   } catch {
     // Fall through to direct process cleanup below.
   }
 
   try {
-    await browser.close()
+    await withSmokeTimeout('closing spawned packaged browser connection', browser.close(), 5_000)
   } catch {
     // The browser may already be gone after Browser.close reaches CDP.
   }

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { spawn, type ChildProcess } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
 import { createServer, type AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
@@ -304,6 +304,7 @@ async function closeCdpSmokeApp(browser: Browser, port: number) {
 
   for (let attempts = 0; attempts < 20; attempts += 1) {
     if (!(await isCdpAvailable(port))) {
+      await stopSpawnedSmokeProcess(child)
       await delay(1_000)
       return
     }
@@ -311,6 +312,44 @@ async function closeCdpSmokeApp(browser: Browser, port: number) {
   }
 
   await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
+  await delay(1_000)
+}
+
+async function stopSpawnedSmokeProcess(child: ChildProcess) {
+  if (child.killed || child.exitCode !== null || child.signalCode !== null) return
+  child.kill('SIGTERM')
+  await Promise.race([
+    new Promise<void>((resolveExit) => child.once('exit', () => resolveExit())),
+    delay(5_000),
+  ])
+  if (!child.killed && child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL')
+  }
+}
+
+async function closeSpawnedCdpSmokeApp(browser: Browser, child: ChildProcess, port: number) {
+  try {
+    const cdpSession = await browser.newBrowserCDPSession()
+    await cdpSession.send('Browser.close')
+  } catch {
+    // Fall through to direct process cleanup below.
+  }
+
+  try {
+    await browser.close()
+  } catch {
+    // The browser may already be gone after Browser.close reaches CDP.
+  }
+
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    if (!(await isCdpAvailable(port))) {
+      await delay(1_000)
+      return
+    }
+    await delay(250)
+  }
+
+  await stopSpawnedSmokeProcess(child)
   await delay(1_000)
 }
 
@@ -435,6 +474,60 @@ export async function launchSmokeSession(
       }
     } catch (error) {
       if (browser) await closeCdpSmokeApp(browser, port)
+      throw error
+    }
+  }
+
+  if (options?.executablePath && process.platform === 'linux') {
+    const port = await getAvailablePort()
+    const childArgs = [
+      `--remote-debugging-port=${port}`,
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+    ]
+    const child = spawn(options.executablePath, childArgs, {
+      cwd: desktopAppDir,
+      env: getSmokeEnvironment(paths),
+      stdio: 'ignore',
+    })
+    let clearEarlyExit: () => void = () => undefined
+    const earlyExit = new Promise<never>((_resolve, reject) => {
+      const onError = (error: Error) => reject(error)
+      const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+        reject(new Error(`Packaged app exited before CDP was available: ${signal || code}`))
+      }
+      child.once('error', onError)
+      child.once('exit', onExit)
+      clearEarlyExit = () => {
+        child.off('error', onError)
+        child.off('exit', onExit)
+      }
+    })
+
+    let browser: Browser | null = null
+    try {
+      await Promise.race([waitForCdp(port), earlyExit])
+      clearEarlyExit()
+      browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`)
+      const page = await waitForCdpPage(browser)
+      await page.waitForFunction(() => Boolean(
+        document.querySelector('#root')
+        && typeof window.coworkApi?.app?.config === 'function'
+        && typeof window.coworkApi?.settings?.get === 'function',
+      ))
+      await bootstrapSmokeSettings(page, appShellTimeoutMs)
+
+      return {
+        page,
+        async close() {
+          if (browser) await closeSpawnedCdpSmokeApp(browser, child, port)
+          else await stopSpawnedSmokeProcess(child)
+        },
+      }
+    } catch (error) {
+      clearEarlyExit()
+      if (browser) await closeSpawnedCdpSmokeApp(browser, child, port)
+      else await stopSpawnedSmokeProcess(child)
       throw error
     }
   }

--- a/apps/desktop/vitest.renderer.config.ts
+++ b/apps/desktop/vitest.renderer.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
         // Baseline ratchet for the current component-test suite.
         // Keep just below measured coverage and raise as stateful
         // renderer screens gain direct tests.
-        lines: 16,
-        branches: 9,
-        functions: 12,
-        statements: 15,
+        lines: 19,
+        branches: 13,
+        functions: 15,
+        statements: 18,
       },
     },
   },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,7 +275,7 @@ directly; the app does not implement provider-specific login logic.
 ### Dynamic model catalogs
 
 Any provider descriptor may declare a `dynamicCatalog` block to pull its
-model list from an HTTP endpoint at runtime. The hardcoded `models[]`
+model list from an HTTPS endpoint at runtime. The hardcoded `models[]`
 entries stay pinned at the top of the picker as **Featured** models; the
 dynamic list is overlaid beneath them, deduplicated by id.
 
@@ -297,6 +297,7 @@ dynamic list is overlaid beneath them, deduplicated by id.
           "nameField": "name",
           "descriptionField": "description",
           "contextLengthField": "context_length",
+          "sha256": "optional 64-character response hash",
           "cacheTtlMinutes": 60
         }
       }
@@ -305,7 +306,10 @@ dynamic list is overlaid beneath them, deduplicated by id.
 }
 ```
 
-- `url` — JSON endpoint to fetch.
+- `url` — HTTPS JSON endpoint to fetch. Plain HTTP dynamic catalogs are
+  rejected so model metadata cannot be rewritten in transit.
+- `sha256` — optional SHA-256 hash of the exact response body. Use it
+  when distributing catalogs from a static endpoint or release asset.
 - `responsePath` — dotted path to the model array in the response body
   (`"data"` for OpenRouter, omit if the body itself is an array).
 - `idField` / `nameField` / `descriptionField` / `contextLengthField` —

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -196,6 +196,14 @@ Users can disable this bridge in Settings → Permissions → Developer
 config bridge; disabling it removes the curated symlinks from the
 managed runtime home on the next runtime restart.
 
+The OpenCode server process also receives a curated environment, not the
+user's full login shell environment. Open Cowork preserves toolchain basics
+such as `PATH`, locale, temp-directory, and managed OpenCode variables, then
+sets Cowork-owned `HOME`/XDG paths and the app-scoped Google ADC path when
+available. Arbitrary exported secrets and command overrides such as
+`OPENAI_API_KEY`, cloud session tokens, `GIT_SSH_COMMAND`, and
+`SSH_AUTH_SOCK` are not forwarded into the managed runtime.
+
 Provider authentication has one separate, intentional bridge. OpenCode
 owns provider login flows, so Open Cowork links OpenCode's native
 `auth.json` into the managed runtime data directory instead of copying

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -199,11 +199,11 @@ managed runtime home on the next runtime restart.
 The OpenCode server process also receives a curated environment, not the
 user's full login shell environment. Open Cowork preserves toolchain basics
 such as `PATH`, locale, temp-directory, proxy variables, custom CA trust-store
-variables, SSH-agent sockets, and managed OpenCode variables, then sets
-Cowork-owned `HOME`/XDG paths and the app-scoped Google ADC path when
-available. Arbitrary exported secrets and command overrides such as
-`OPENAI_API_KEY`, cloud session tokens, and `GIT_SSH_COMMAND` are not forwarded
-into the managed runtime.
+variables, and app-managed OpenCode variables, then sets Cowork-owned
+`HOME`/XDG paths and the app-scoped Google ADC path when available. Arbitrary
+exported secrets, SSH-agent sockets, and command overrides such as
+`OPENAI_API_KEY`, cloud session tokens, `SSH_AUTH_SOCK`, and `GIT_SSH_COMMAND`
+are not forwarded into the managed runtime.
 
 Provider authentication has one separate, intentional bridge. OpenCode
 owns provider login flows, so Open Cowork links OpenCode's native

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -198,11 +198,12 @@ managed runtime home on the next runtime restart.
 
 The OpenCode server process also receives a curated environment, not the
 user's full login shell environment. Open Cowork preserves toolchain basics
-such as `PATH`, locale, temp-directory, and managed OpenCode variables, then
-sets Cowork-owned `HOME`/XDG paths and the app-scoped Google ADC path when
+such as `PATH`, locale, temp-directory, proxy variables, custom CA trust-store
+variables, SSH-agent sockets, and managed OpenCode variables, then sets
+Cowork-owned `HOME`/XDG paths and the app-scoped Google ADC path when
 available. Arbitrary exported secrets and command overrides such as
-`OPENAI_API_KEY`, cloud session tokens, `GIT_SSH_COMMAND`, and
-`SSH_AUTH_SOCK` are not forwarded into the managed runtime.
+`OPENAI_API_KEY`, cloud session tokens, and `GIT_SSH_COMMAND` are not forwarded
+into the managed runtime.
 
 Provider authentication has one separate, intentional bridge. OpenCode
 owns provider login flows, so Open Cowork links OpenCode's native

--- a/docs/skills-and-mcps.md
+++ b/docs/skills-and-mcps.md
@@ -78,6 +78,12 @@ A skill bundle is a folder. It must contain a `SKILL.md` with frontmatter
 and may contain supporting files. OpenCode loads it; Open Cowork only
 decides which bundles are available.
 
+Custom skill bundles are code-adjacent trust decisions: they change agent
+behavior and can request tool access through frontmatter. Open Cowork validates
+bundle shape, caps supporting files, warns before importing a directory, and
+writes a SHA-256 digest to the audit log for every user-saved bundle, but v0.x
+does not require detached signatures. Only import skills from sources you trust.
+
 ### Anatomy
 
 ```text

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -373,13 +373,14 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "url": { "type": "string" },
+            "url": { "type": "string", "pattern": "^https://.+" },
             "responsePath": { "type": "string" },
             "idField": { "type": "string" },
             "nameField": { "type": "string" },
             "descriptionField": { "type": "string" },
             "contextLengthField": { "type": "string" },
             "authHeader": { "type": "string" },
+            "sha256": { "type": "string", "pattern": "^[A-Fa-f0-9]{64}$" },
             "cacheTtlMinutes": { "type": "number" }
           },
           "required": ["url"]

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1320,9 +1320,10 @@ export interface CoworkAPI {
     // Returns credentials masked ('••••••••' for set values). Safe default
     // for any consumer that only needs non-secret fields.
     get: () => Promise<EffectiveAppSettings>
-    // Returns unmasked credentials. Only the credential editor surfaces
-    // (SetupScreen, SettingsPanel → Models) should call this.
-    getWithCredentials: () => Promise<EffectiveAppSettings>
+    // Scoped unmasked reads for credential editor surfaces. The renderer
+    // never receives the full effective settings object with every secret.
+    getProviderCredentials: (providerId: string) => Promise<Record<string, string>>
+    getIntegrationCredentials: (integrationId: string) => Promise<Record<string, string>>
     set: (updates: Partial<AppSettings>) => Promise<EffectiveAppSettings>
   }
   mcp: {

--- a/tests/chart-spec-safety.test.ts
+++ b/tests/chart-spec-safety.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  MAX_CHART_ARRAY_ITEMS,
+  MAX_CHART_DEPTH,
+  MAX_CHART_SPEC_BYTES,
+  validateInlineChartSpec,
+} from '../apps/desktop/src/lib/chart-spec-safety.ts'
+
+test('validateInlineChartSpec accepts bounded inline data specs', () => {
+  assert.doesNotThrow(() => validateInlineChartSpec({
+    data: { values: [{ category: 'A', value: 1 }] },
+    mark: 'bar',
+    encoding: {
+      x: { field: 'category', type: 'nominal' },
+      y: { field: 'value', type: 'quantitative' },
+    },
+  }))
+})
+
+test('validateInlineChartSpec rejects external resource references and image marks', () => {
+  assert.throws(
+    () => validateInlineChartSpec({ data: { url: 'https://example.test/data.csv' }, mark: 'bar' }),
+    /url=.*not allowed/,
+  )
+  assert.throws(
+    () => validateInlineChartSpec({ data: { values: [] }, mark: 'image' }),
+    /image marks are not allowed/,
+  )
+  assert.throws(
+    () => validateInlineChartSpec({ data: { values: [] }, mark: { type: 'image' } }),
+    /image marks are not allowed/,
+  )
+})
+
+test('validateInlineChartSpec rejects oversized chart specs', () => {
+  assert.throws(
+    () => validateInlineChartSpec({ data: { values: [{ text: 'x'.repeat(MAX_CHART_SPEC_BYTES) }] }, mark: 'text' }),
+    /spec exceeds/,
+  )
+  assert.throws(
+    () => validateInlineChartSpec({ data: { values: Array.from({ length: MAX_CHART_ARRAY_ITEMS + 1 }, () => null) }, mark: 'point' }),
+    /total array items/,
+  )
+
+  let nested: Record<string, unknown> = { value: 1 }
+  for (let index = 0; index < MAX_CHART_DEPTH + 1; index += 1) {
+    nested = { nested }
+  }
+  assert.throws(() => validateInlineChartSpec(nested), /maximum depth/)
+})

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -155,3 +155,19 @@ test('telemetry schema rejects unknown keys and non-https endpoints', () => {
 
   assert.throws(() => validateResolvedConfig(config, 'telemetry config'), /telemetry/)
 })
+
+test('provider dynamic catalogs require https URLs and valid SHA-256 pins', () => {
+  const config = cloneConfig()
+  config.providers.descriptors.openrouter.dynamicCatalog = {
+    url: 'http://models.example.test/catalog.json',
+    sha256: 'not-a-sha',
+  }
+
+  assert.throws(() => validateResolvedConfig(config, 'provider catalog config'), /providers/)
+
+  config.providers.descriptors.openrouter.dynamicCatalog = {
+    url: 'https://models.example.test/catalog.json',
+    sha256: 'a'.repeat(64),
+  }
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'provider catalog config'))
+})

--- a/tests/custom-skill-integrity.test.ts
+++ b/tests/custom-skill-integrity.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { computeCustomSkillBundleDigest } from '../apps/desktop/src/main/custom-skill-integrity.ts'
+
+test('custom skill bundle digest is stable across supporting file order', () => {
+  const baseSkill = {
+    scope: 'machine' as const,
+    name: 'research-helper',
+    content: '---\nname: research-helper\ndescription: Research helper.\n---\n# Research Helper\n',
+    files: [
+      { path: 'examples/a.md', content: 'A' },
+      { path: 'references/b.md', content: 'B' },
+    ],
+  }
+
+  const digest = computeCustomSkillBundleDigest(baseSkill)
+  assert.match(digest, /^[a-f0-9]{64}$/)
+  assert.equal(computeCustomSkillBundleDigest({
+    ...baseSkill,
+    files: [...baseSkill.files].reverse(),
+  }), digest)
+  assert.notEqual(computeCustomSkillBundleDigest({
+    ...baseSkill,
+    files: [
+      { path: 'examples/a.md', content: 'A' },
+      { path: 'references/b.md', content: 'changed' },
+    ],
+  }), digest)
+})

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -73,6 +73,9 @@ test('IPC handler modules register their core channels', () => {
 
   assert.equal(handlers.has('auth:status'), true)
   assert.equal(handlers.has('settings:set'), true)
+  assert.equal(handlers.has('settings:get-provider-credentials'), true)
+  assert.equal(handlers.has('settings:get-integration-credentials'), true)
+  assert.equal(handlers.has('settings:get-with-credentials'), false)
   assert.equal(handlers.has('provider:auth-methods'), true)
   assert.equal(handlers.has('provider:oauth-authorize'), true)
   assert.equal(handlers.has('provider:oauth-callback'), true)

--- a/tests/main-window-lifecycle.test.ts
+++ b/tests/main-window-lifecycle.test.ts
@@ -22,6 +22,7 @@ test('rendererUrlLooksWrong accepts the expected shell URL and rejects asset URL
   assert.equal(rendererUrlLooksWrong('file:///tmp/index.html'), false)
   assert.equal(rendererUrlLooksWrong('file:///tmp/assets/chunk.js'), true)
   assert.equal(rendererUrlLooksWrong('http://127.0.0.1:5173', 'http://127.0.0.1:5173'), false)
+  assert.equal(rendererUrlLooksWrong('http://127.0.0.1:51730', 'http://127.0.0.1:5173'), true)
   assert.equal(rendererUrlLooksWrong('http://127.0.0.1:4173', 'http://127.0.0.1:5173'), true)
 })
 

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -1,6 +1,17 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { mapResponseToModels } from '../apps/desktop/src/main/provider-catalog.ts'
+import { createHash } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { closeLogger } from '../apps/desktop/src/main/logger.ts'
+import { mapResponseToModels, refreshProviderCatalog } from '../apps/desktop/src/main/provider-catalog.ts'
+
+function testTempDir(prefix: string) {
+  const parent = join(process.cwd(), '.open-cowork-test')
+  mkdirSync(parent, { recursive: true })
+  return mkdtempSync(join(parent, prefix))
+}
 
 describe('mapResponseToModels', () => {
   it('returns empty for non-object bodies', () => {
@@ -111,5 +122,55 @@ describe('mapResponseToModels', () => {
     const body = { data: [{ id: 'a', name: 'A', context_length: Number.POSITIVE_INFINITY }] }
     const result = mapResponseToModels(body, { url: 'x', responsePath: 'data' })
     assert.equal(result[0].contextLength, undefined)
+  })
+
+  it('fetches dynamic catalogs only over HTTPS and verifies optional SHA-256 pins', async () => {
+    const tempRoot = testTempDir('opencowork-provider-catalog-')
+    const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+    const previousFetch = globalThis.fetch
+    process.env.OPEN_COWORK_USER_DATA_DIR = join(tempRoot, 'user-data')
+    clearConfigCaches()
+
+    try {
+      let calls = 0
+      globalThis.fetch = (async () => {
+        calls += 1
+        return new Response('{"data":[{"id":"x","name":"X"}]}', { status: 200 })
+      }) as typeof fetch
+
+      assert.deepEqual(
+        await refreshProviderCatalog('http-catalog-test', { url: 'http://example.test/models', responsePath: 'data' }),
+        [],
+      )
+      assert.equal(calls, 0)
+
+      assert.deepEqual(
+        await refreshProviderCatalog('hash-mismatch-test', {
+          url: 'https://example.test/models',
+          responsePath: 'data',
+          sha256: '0'.repeat(64),
+        }),
+        [],
+      )
+
+      const body = '{"data":[{"id":"x","name":"X"}]}'
+      const sha256 = createHash('sha256').update(body).digest('hex')
+      globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch
+
+      const models = await refreshProviderCatalog('hash-match-test', {
+        url: 'https://example.test/models',
+        responsePath: 'data',
+        sha256,
+      })
+      assert.deepEqual(models, [{ id: 'x', name: 'X', description: undefined, contextLength: undefined }])
+    } finally {
+      globalThis.fetch = previousFetch
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      closeLogger()
+      if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+      else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+      clearConfigCaches()
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime.ts'
+import { buildManagedRuntimeEnvironment, callWithRuntimeEnvironmentForSpawn } from '../apps/desktop/src/main/runtime.ts'
 import { OPEN_COWORK_MANAGED_RUNTIME_ENV, OPEN_COWORK_MANAGED_RUNTIME_VALUE } from '../apps/desktop/src/main/runtime-process-cleanup.ts'
 
 const runtimePaths = {
@@ -54,4 +54,41 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.GIT_SSH_COMMAND, undefined)
   assert.equal(env.AWS_SESSION_TOKEN, undefined)
   assert.equal(env.SSH_AUTH_SOCK, undefined)
+})
+
+test('managed runtime env is restored before async runtime startup settles', async () => {
+  const originalEnv = { ...process.env }
+  process.env.OPEN_COWORK_USER_DATA_DIR = '/tmp/open-cowork/user-data'
+  process.env.PATH = '/usr/bin:/bin'
+  let resolveStartup!: (value: string) => void
+
+  try {
+    const startup = callWithRuntimeEnvironmentForSpawn(
+      {
+        PATH: '/managed/bin',
+        HOME: runtimePaths.home,
+        [OPEN_COWORK_MANAGED_RUNTIME_ENV]: OPEN_COWORK_MANAGED_RUNTIME_VALUE,
+      },
+      () => {
+        assert.equal(process.env.PATH, '/managed/bin')
+        assert.equal(process.env.OPEN_COWORK_USER_DATA_DIR, undefined)
+        return new Promise<string>((resolve) => {
+          resolveStartup = resolve
+        })
+      },
+    )
+
+    assert.equal(process.env.OPEN_COWORK_USER_DATA_DIR, '/tmp/open-cowork/user-data')
+    assert.equal(process.env.PATH, '/usr/bin:/bin')
+
+    resolveStartup('ready')
+    assert.equal(await startup, 'ready')
+    assert.equal(process.env.OPEN_COWORK_USER_DATA_DIR, '/tmp/open-cowork/user-data')
+    assert.equal(process.env.PATH, '/usr/bin:/bin')
+  } finally {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    Object.assign(process.env, originalEnv)
+  }
 })

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   buildManagedOpencodeServerEnvironment,
   buildManagedRuntimeEnvironment,
+  parseManagedOpencodeServerStdoutChunk,
   resolveManagedOpencodeCommand,
   resolveManagedOpencodeSpawn,
 } from '../apps/desktop/src/main/runtime.ts'
@@ -23,6 +24,12 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
       Path: 'C:\\Windows\\System32;C:\\Windows',
       LANG: 'en_US.UTF-8',
       LC_CTYPE: 'UTF-8',
+      NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-node.pem',
+      SSL_CERT_FILE: '/etc/ssl/corp.pem',
+      SSL_CERT_DIR: '/etc/ssl/certs',
+      REQUESTS_CA_BUNDLE: '/etc/ssl/python.pem',
+      CURL_CA_BUNDLE: '/etc/ssl/curl.pem',
+      GIT_SSL_CAINFO: '/etc/ssl/git.pem',
       HTTPS_PROXY: 'http://proxy.example:8080',
       HTTP_PROXY: 'http://proxy.example:8080',
       NO_PROXY: 'localhost,127.0.0.1',
@@ -46,6 +53,12 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.Path, 'C:\\Windows\\System32;C:\\Windows')
   assert.equal(env.LANG, 'en_US.UTF-8')
   assert.equal(env.LC_CTYPE, 'UTF-8')
+  assert.equal(env.NODE_EXTRA_CA_CERTS, '/etc/ssl/corp-node.pem')
+  assert.equal(env.SSL_CERT_FILE, '/etc/ssl/corp.pem')
+  assert.equal(env.SSL_CERT_DIR, '/etc/ssl/certs')
+  assert.equal(env.REQUESTS_CA_BUNDLE, '/etc/ssl/python.pem')
+  assert.equal(env.CURL_CA_BUNDLE, '/etc/ssl/curl.pem')
+  assert.equal(env.GIT_SSL_CAINFO, '/etc/ssl/git.pem')
   assert.equal(env.HTTPS_PROXY, 'http://proxy.example:8080')
   assert.equal(env.HTTP_PROXY, 'http://proxy.example:8080')
   assert.equal(env.NO_PROXY, 'localhost,127.0.0.1')
@@ -176,4 +189,35 @@ test('managed runtime spawn keeps non-Windows wrapper fallback direct', () => {
     command: 'opencode',
     args: ['serve'],
   })
+})
+
+test('managed runtime server stdout parser buffers split startup lines', () => {
+  const first = parseManagedOpencodeServerStdoutChunk('', 'debug\nopencode server listening')
+  assert.deepEqual(first, { buffer: 'opencode server listening' })
+
+  const second = parseManagedOpencodeServerStdoutChunk(first.buffer, ' on http://127.0.0.1:4096\n')
+  assert.deepEqual(second, {
+    buffer: '',
+    url: 'http://127.0.0.1:4096',
+  })
+})
+
+test('managed runtime server stdout parser resolves unterminated startup lines', () => {
+  assert.deepEqual(
+    parseManagedOpencodeServerStdoutChunk('', 'opencode server listening on http://127.0.0.1:4096'),
+    {
+      buffer: 'opencode server listening on http://127.0.0.1:4096',
+      url: 'http://127.0.0.1:4096',
+    },
+  )
+})
+
+test('managed runtime server stdout parser rejects malformed complete startup lines', () => {
+  assert.deepEqual(
+    parseManagedOpencodeServerStdoutChunk('', 'opencode server listening\n'),
+    {
+      buffer: '',
+      error: 'Failed to parse server url from output: opencode server listening',
+    },
+  )
 })

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -42,11 +42,12 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
       AWS_SESSION_TOKEN: 'aws-secret',
       SSH_AUTH_SOCK: '/tmp/agent.sock',
       SSH_AGENT_PID: '12345',
-      OPENCODE_BIN_PATH: '/Applications/Open Cowork.app/Contents/Resources/opencode',
+      OPENCODE_BIN_PATH: '/tmp/untrusted-opencode',
     },
     runtimePaths,
     adcPath: '/tmp/open-cowork/adc.json',
     enableNativeWebSearch: true,
+    opencodeBinPath: '/Applications/Open Cowork.app/Contents/Resources/opencode',
   })
 
   assert.equal(env.PATH, '/usr/bin:/bin')
@@ -63,8 +64,6 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.HTTP_PROXY, 'http://proxy.example:8080')
   assert.equal(env.NO_PROXY, 'localhost,127.0.0.1')
   assert.equal(env.all_proxy, 'socks5://proxy.example:1080')
-  assert.equal(env.SSH_AUTH_SOCK, '/tmp/agent.sock')
-  assert.equal(env.SSH_AGENT_PID, '12345')
   assert.equal(env.OPENCODE_BIN_PATH, '/Applications/Open Cowork.app/Contents/Resources/opencode')
   assert.equal(env.HOME, runtimePaths.home)
   assert.equal(env.USERPROFILE, runtimePaths.home)
@@ -82,6 +81,21 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.OPENAI_API_KEY, undefined)
   assert.equal(env.GIT_SSH_COMMAND, undefined)
   assert.equal(env.AWS_SESSION_TOKEN, undefined)
+  assert.equal(env.SSH_AUTH_SOCK, undefined)
+  assert.equal(env.SSH_AGENT_PID, undefined)
+})
+
+test('managed runtime env drops inherited opencode binary overrides', () => {
+  const env = buildManagedRuntimeEnvironment({
+    currentEnv: {
+      PATH: '/usr/bin:/bin',
+      OPENCODE_BIN_PATH: '/tmp/untrusted-opencode',
+    },
+    runtimePaths,
+  })
+
+  assert.equal(env.PATH, '/usr/bin:/bin')
+  assert.equal(env.OPENCODE_BIN_PATH, undefined)
 })
 
 test('managed runtime env maps Windows home variables to the sandbox home', () => {

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime.ts'
+import { OPEN_COWORK_MANAGED_RUNTIME_ENV, OPEN_COWORK_MANAGED_RUNTIME_VALUE } from '../apps/desktop/src/main/runtime-process-cleanup.ts'
+
+const runtimePaths = {
+  home: '/tmp/open-cowork/runtime-home',
+  configHome: '/tmp/open-cowork/runtime-home/.config',
+  dataHome: '/tmp/open-cowork/runtime-home/.local/share',
+  cacheHome: '/tmp/open-cowork/runtime-home/.cache',
+  stateHome: '/tmp/open-cowork/runtime-home/.local/state',
+}
+
+test('managed runtime env keeps toolchain basics and drops arbitrary shell secrets', () => {
+  const env = buildManagedRuntimeEnvironment({
+    currentEnv: {
+      PATH: '/usr/bin:/bin',
+      LANG: 'en_US.UTF-8',
+      LC_CTYPE: 'UTF-8',
+      OPENAI_API_KEY: 'sk-secret',
+      GIT_SSH_COMMAND: 'ssh -i /tmp/attacker-key',
+      AWS_SESSION_TOKEN: 'aws-secret',
+      SSH_AUTH_SOCK: '/tmp/agent.sock',
+      OPENCODE_BIN_PATH: '/Applications/Open Cowork.app/Contents/Resources/opencode',
+    },
+    runtimePaths,
+    adcPath: '/tmp/open-cowork/adc.json',
+    enableNativeWebSearch: true,
+  })
+
+  assert.equal(env.PATH, '/usr/bin:/bin')
+  assert.equal(env.LANG, 'en_US.UTF-8')
+  assert.equal(env.LC_CTYPE, 'UTF-8')
+  assert.equal(env.OPENCODE_BIN_PATH, '/Applications/Open Cowork.app/Contents/Resources/opencode')
+  assert.equal(env.HOME, runtimePaths.home)
+  assert.equal(env.XDG_CONFIG_HOME, runtimePaths.configHome)
+  assert.equal(env.GOOGLE_APPLICATION_CREDENTIALS, '/tmp/open-cowork/adc.json')
+  assert.equal(env.OPENCODE_ENABLE_EXA, '1')
+  assert.equal(env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT, '1')
+  assert.equal(env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS, '1')
+  assert.equal(env[OPEN_COWORK_MANAGED_RUNTIME_ENV], OPEN_COWORK_MANAGED_RUNTIME_VALUE)
+
+  assert.equal(env.OPENAI_API_KEY, undefined)
+  assert.equal(env.GIT_SSH_COMMAND, undefined)
+  assert.equal(env.AWS_SESSION_TOKEN, undefined)
+  assert.equal(env.SSH_AUTH_SOCK, undefined)
+})

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -34,6 +34,7 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
       GIT_SSH_COMMAND: 'ssh -i /tmp/attacker-key',
       AWS_SESSION_TOKEN: 'aws-secret',
       SSH_AUTH_SOCK: '/tmp/agent.sock',
+      SSH_AGENT_PID: '12345',
       OPENCODE_BIN_PATH: '/Applications/Open Cowork.app/Contents/Resources/opencode',
     },
     runtimePaths,
@@ -49,6 +50,8 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.HTTP_PROXY, 'http://proxy.example:8080')
   assert.equal(env.NO_PROXY, 'localhost,127.0.0.1')
   assert.equal(env.all_proxy, 'socks5://proxy.example:1080')
+  assert.equal(env.SSH_AUTH_SOCK, '/tmp/agent.sock')
+  assert.equal(env.SSH_AGENT_PID, '12345')
   assert.equal(env.OPENCODE_BIN_PATH, '/Applications/Open Cowork.app/Contents/Resources/opencode')
   assert.equal(env.HOME, runtimePaths.home)
   assert.equal(env.USERPROFILE, runtimePaths.home)
@@ -66,7 +69,6 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.OPENAI_API_KEY, undefined)
   assert.equal(env.GIT_SSH_COMMAND, undefined)
   assert.equal(env.AWS_SESSION_TOKEN, undefined)
-  assert.equal(env.SSH_AUTH_SOCK, undefined)
 })
 
 test('managed runtime env maps Windows home variables to the sandbox home', () => {

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -216,14 +216,26 @@ test('managed runtime server stdout parser buffers split startup lines', () => {
   })
 })
 
-test('managed runtime server stdout parser resolves unterminated startup lines', () => {
+test('managed runtime server stdout parser waits for newline before resolving startup lines', () => {
   assert.deepEqual(
     parseManagedOpencodeServerStdoutChunk('', 'opencode server listening on http://127.0.0.1:4096'),
     {
       buffer: 'opencode server listening on http://127.0.0.1:4096',
-      url: 'http://127.0.0.1:4096',
     },
   )
+})
+
+test('managed runtime server stdout parser buffers startup URLs split across chunks', () => {
+  const first = parseManagedOpencodeServerStdoutChunk('', 'opencode server listening on http://127.0.0.1:')
+  assert.deepEqual(first, {
+    buffer: 'opencode server listening on http://127.0.0.1:',
+  })
+
+  const second = parseManagedOpencodeServerStdoutChunk(first.buffer, '4096\n')
+  assert.deepEqual(second, {
+    buffer: '',
+    url: 'http://127.0.0.1:4096',
+  })
 })
 
 test('managed runtime server stdout parser rejects malformed complete startup lines', () => {

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -17,6 +17,10 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
       PATH: '/usr/bin:/bin',
       LANG: 'en_US.UTF-8',
       LC_CTYPE: 'UTF-8',
+      HTTPS_PROXY: 'http://proxy.example:8080',
+      HTTP_PROXY: 'http://proxy.example:8080',
+      NO_PROXY: 'localhost,127.0.0.1',
+      all_proxy: 'socks5://proxy.example:1080',
       OPENAI_API_KEY: 'sk-secret',
       GIT_SSH_COMMAND: 'ssh -i /tmp/attacker-key',
       AWS_SESSION_TOKEN: 'aws-secret',
@@ -31,6 +35,10 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.PATH, '/usr/bin:/bin')
   assert.equal(env.LANG, 'en_US.UTF-8')
   assert.equal(env.LC_CTYPE, 'UTF-8')
+  assert.equal(env.HTTPS_PROXY, 'http://proxy.example:8080')
+  assert.equal(env.HTTP_PROXY, 'http://proxy.example:8080')
+  assert.equal(env.NO_PROXY, 'localhost,127.0.0.1')
+  assert.equal(env.all_proxy, 'socks5://proxy.example:1080')
   assert.equal(env.OPENCODE_BIN_PATH, '/Applications/Open Cowork.app/Contents/Resources/opencode')
   assert.equal(env.HOME, runtimePaths.home)
   assert.equal(env.XDG_CONFIG_HOME, runtimePaths.configHome)

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { buildManagedOpencodeServerEnvironment, buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime.ts'
+import { buildManagedOpencodeServerEnvironment, buildManagedRuntimeEnvironment, resolveManagedOpencodeCommand } from '../apps/desktop/src/main/runtime.ts'
 import { OPEN_COWORK_MANAGED_RUNTIME_ENV, OPEN_COWORK_MANAGED_RUNTIME_VALUE } from '../apps/desktop/src/main/runtime-process-cleanup.ts'
 
 const runtimePaths = {
@@ -86,4 +86,13 @@ test('managed runtime server env is explicit and does not mutate main process en
     }
     Object.assign(process.env, originalEnv)
   }
+})
+
+test('managed runtime server prefers the explicit bundled OpenCode binary', () => {
+  assert.equal(
+    resolveManagedOpencodeCommand({ OPENCODE_BIN_PATH: '/app/resources/opencode/bin/opencode' }),
+    '/app/resources/opencode/bin/opencode',
+  )
+  assert.equal(resolveManagedOpencodeCommand({ OPENCODE_BIN_PATH: '   ' }), 'opencode')
+  assert.equal(resolveManagedOpencodeCommand({}), 'opencode')
 })

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -15,6 +15,7 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   const env = buildManagedRuntimeEnvironment({
     currentEnv: {
       PATH: '/usr/bin:/bin',
+      Path: 'C:\\Windows\\System32;C:\\Windows',
       LANG: 'en_US.UTF-8',
       LC_CTYPE: 'UTF-8',
       HTTPS_PROXY: 'http://proxy.example:8080',
@@ -33,6 +34,7 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   })
 
   assert.equal(env.PATH, '/usr/bin:/bin')
+  assert.equal(env.Path, 'C:\\Windows\\System32;C:\\Windows')
   assert.equal(env.LANG, 'en_US.UTF-8')
   assert.equal(env.LC_CTYPE, 'UTF-8')
   assert.equal(env.HTTPS_PROXY, 'http://proxy.example:8080')

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,6 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { buildManagedOpencodeServerEnvironment, buildManagedRuntimeEnvironment, resolveManagedOpencodeCommand } from '../apps/desktop/src/main/runtime.ts'
+import {
+  buildManagedOpencodeServerEnvironment,
+  buildManagedRuntimeEnvironment,
+  resolveManagedOpencodeCommand,
+  resolveManagedOpencodeSpawn,
+} from '../apps/desktop/src/main/runtime.ts'
 import { OPEN_COWORK_MANAGED_RUNTIME_ENV, OPEN_COWORK_MANAGED_RUNTIME_VALUE } from '../apps/desktop/src/main/runtime-process-cleanup.ts'
 
 const runtimePaths = {
@@ -76,6 +81,7 @@ test('managed runtime env maps Windows home variables to the sandbox home', () =
   const env = buildManagedRuntimeEnvironment({
     currentEnv: {
       Path: 'C:\\Windows\\System32;C:\\Windows',
+      COMSPEC: 'C:\\Windows\\System32\\cmd.exe',
       USERPROFILE: 'C:\\Users\\Joe',
       HOMEDRIVE: 'C:',
       HOMEPATH: '\\Users\\Joe',
@@ -86,6 +92,7 @@ test('managed runtime env maps Windows home variables to the sandbox home', () =
   })
 
   assert.equal(env.Path, 'C:\\Windows\\System32;C:\\Windows')
+  assert.equal(env.COMSPEC, 'C:\\Windows\\System32\\cmd.exe')
   assert.equal(env.HOME, windowsRuntimePaths.home)
   assert.equal(env.USERPROFILE, windowsRuntimePaths.home)
   assert.equal(env.HOMEDRIVE, 'C:')
@@ -133,4 +140,38 @@ test('managed runtime server prefers the explicit bundled OpenCode binary', () =
   )
   assert.equal(resolveManagedOpencodeCommand({ OPENCODE_BIN_PATH: '   ' }), 'opencode')
   assert.equal(resolveManagedOpencodeCommand({}), 'opencode')
+})
+
+test('managed runtime spawn launches explicit binaries directly', () => {
+  const args = ['serve', '--hostname=127.0.0.1', '--port=4096']
+  const spawnPlan = resolveManagedOpencodeSpawn(
+    { OPENCODE_BIN_PATH: 'C:\\Program Files\\Open Cowork\\resources\\opencode.exe', ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    args,
+    'win32',
+  )
+
+  assert.deepEqual(spawnPlan, {
+    command: 'C:\\Program Files\\Open Cowork\\resources\\opencode.exe',
+    args,
+  })
+})
+
+test('managed runtime spawn uses cmd.exe for the Windows wrapper fallback', () => {
+  const spawnPlan = resolveManagedOpencodeSpawn(
+    { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    ['serve', '--hostname=127.0.0.1', '--port=4096'],
+    'win32',
+  )
+
+  assert.deepEqual(spawnPlan, {
+    command: 'C:\\Windows\\System32\\cmd.exe',
+    args: ['/d', '/s', '/c', 'opencode', 'serve', '--hostname=127.0.0.1', '--port=4096'],
+  })
+})
+
+test('managed runtime spawn keeps non-Windows wrapper fallback direct', () => {
+  assert.deepEqual(resolveManagedOpencodeSpawn({}, ['serve'], 'linux'), {
+    command: 'opencode',
+    args: ['serve'],
+  })
 })

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,8 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { PassThrough } from 'node:stream'
 import {
   buildManagedOpencodeServerEnvironment,
   buildManagedRuntimeEnvironment,
+  drainManagedOpencodeProcessOutput,
   parseManagedOpencodeServerStdoutChunk,
   resolveManagedOpencodeCommand,
   resolveManagedOpencodeSpawn,
@@ -246,4 +248,19 @@ test('managed runtime server stdout parser rejects malformed complete startup li
       error: 'Failed to parse server url from output: opencode server listening',
     },
   )
+})
+
+test('managed runtime drains stdio after startup parsing is detached', () => {
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+  assert.equal(stdout.readableFlowing, null)
+  assert.equal(stderr.readableFlowing, null)
+
+  drainManagedOpencodeProcessOutput({
+    stdout,
+    stderr,
+  })
+
+  assert.equal(stdout.readableFlowing, true)
+  assert.equal(stderr.readableFlowing, true)
 })

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { buildManagedRuntimeEnvironment, callWithRuntimeEnvironmentForSpawn } from '../apps/desktop/src/main/runtime.ts'
+import { buildManagedOpencodeServerEnvironment, buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime.ts'
 import { OPEN_COWORK_MANAGED_RUNTIME_ENV, OPEN_COWORK_MANAGED_RUNTIME_VALUE } from '../apps/desktop/src/main/runtime-process-cleanup.ts'
 
 const runtimePaths = {
@@ -56,33 +56,28 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.SSH_AUTH_SOCK, undefined)
 })
 
-test('managed runtime env is restored before async runtime startup settles', async () => {
+test('managed runtime server env is explicit and does not mutate main process env', () => {
   const originalEnv = { ...process.env }
   process.env.OPEN_COWORK_USER_DATA_DIR = '/tmp/open-cowork/user-data'
   process.env.PATH = '/usr/bin:/bin'
-  let resolveStartup!: (value: string) => void
 
   try {
-    const startup = callWithRuntimeEnvironmentForSpawn(
+    const serverEnv = buildManagedOpencodeServerEnvironment(
       {
         PATH: '/managed/bin',
         HOME: runtimePaths.home,
         [OPEN_COWORK_MANAGED_RUNTIME_ENV]: OPEN_COWORK_MANAGED_RUNTIME_VALUE,
       },
-      () => {
-        assert.equal(process.env.PATH, '/managed/bin')
-        assert.equal(process.env.OPEN_COWORK_USER_DATA_DIR, undefined)
-        return new Promise<string>((resolve) => {
-          resolveStartup = resolve
-        })
+      {
+        logLevel: 'debug',
       },
     )
 
-    assert.equal(process.env.OPEN_COWORK_USER_DATA_DIR, '/tmp/open-cowork/user-data')
-    assert.equal(process.env.PATH, '/usr/bin:/bin')
-
-    resolveStartup('ready')
-    assert.equal(await startup, 'ready')
+    assert.equal(serverEnv.PATH, '/managed/bin')
+    assert.equal(serverEnv.HOME, runtimePaths.home)
+    assert.equal(serverEnv[OPEN_COWORK_MANAGED_RUNTIME_ENV], OPEN_COWORK_MANAGED_RUNTIME_VALUE)
+    assert.match(serverEnv.OPENCODE_CONFIG_CONTENT || '', /"logLevel":"debug"/)
+    assert.equal(serverEnv.OPEN_COWORK_USER_DATA_DIR, undefined)
     assert.equal(process.env.OPEN_COWORK_USER_DATA_DIR, '/tmp/open-cowork/user-data')
     assert.equal(process.env.PATH, '/usr/bin:/bin')
   } finally {

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -22,6 +22,9 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
       HTTP_PROXY: 'http://proxy.example:8080',
       NO_PROXY: 'localhost,127.0.0.1',
       all_proxy: 'socks5://proxy.example:1080',
+      APPDATA: 'C:\\Users\\Joe\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\Joe\\AppData\\Local',
+      USERPROFILE: 'C:\\Users\\Joe',
       OPENAI_API_KEY: 'sk-secret',
       GIT_SSH_COMMAND: 'ssh -i /tmp/attacker-key',
       AWS_SESSION_TOKEN: 'aws-secret',
@@ -43,6 +46,11 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.all_proxy, 'socks5://proxy.example:1080')
   assert.equal(env.OPENCODE_BIN_PATH, '/Applications/Open Cowork.app/Contents/Resources/opencode')
   assert.equal(env.HOME, runtimePaths.home)
+  assert.equal(env.USERPROFILE, runtimePaths.home)
+  assert.equal(env.APPDATA, runtimePaths.configHome)
+  assert.equal(env.LOCALAPPDATA, runtimePaths.dataHome)
+  assert.equal(env.HOMEDRIVE, undefined)
+  assert.equal(env.HOMEPATH, undefined)
   assert.equal(env.XDG_CONFIG_HOME, runtimePaths.configHome)
   assert.equal(env.GOOGLE_APPLICATION_CREDENTIALS, '/tmp/open-cowork/adc.json')
   assert.equal(env.OPENCODE_ENABLE_EXA, '1')
@@ -54,6 +62,36 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.GIT_SSH_COMMAND, undefined)
   assert.equal(env.AWS_SESSION_TOKEN, undefined)
   assert.equal(env.SSH_AUTH_SOCK, undefined)
+})
+
+test('managed runtime env maps Windows home variables to the sandbox home', () => {
+  const windowsRuntimePaths = {
+    home: 'C:\\Users\\Joe\\AppData\\Roaming\\Open Cowork\\runtime-home',
+    configHome: 'C:\\Users\\Joe\\AppData\\Roaming\\Open Cowork\\runtime-home\\.config',
+    dataHome: 'C:\\Users\\Joe\\AppData\\Roaming\\Open Cowork\\runtime-home\\.local\\share',
+    cacheHome: 'C:\\Users\\Joe\\AppData\\Roaming\\Open Cowork\\runtime-home\\.cache',
+    stateHome: 'C:\\Users\\Joe\\AppData\\Roaming\\Open Cowork\\runtime-home\\.local\\state',
+  }
+
+  const env = buildManagedRuntimeEnvironment({
+    currentEnv: {
+      Path: 'C:\\Windows\\System32;C:\\Windows',
+      USERPROFILE: 'C:\\Users\\Joe',
+      HOMEDRIVE: 'C:',
+      HOMEPATH: '\\Users\\Joe',
+      APPDATA: 'C:\\Users\\Joe\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\Joe\\AppData\\Local',
+    },
+    runtimePaths: windowsRuntimePaths,
+  })
+
+  assert.equal(env.Path, 'C:\\Windows\\System32;C:\\Windows')
+  assert.equal(env.HOME, windowsRuntimePaths.home)
+  assert.equal(env.USERPROFILE, windowsRuntimePaths.home)
+  assert.equal(env.HOMEDRIVE, 'C:')
+  assert.equal(env.HOMEPATH, '\\Users\\Joe\\AppData\\Roaming\\Open Cowork\\runtime-home')
+  assert.equal(env.APPDATA, windowsRuntimePaths.configHome)
+  assert.equal(env.LOCALAPPDATA, windowsRuntimePaths.dataHome)
 })
 
 test('managed runtime server env is explicit and does not mutate main process env', () => {

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -47,7 +47,6 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
     runtimePaths,
     adcPath: '/tmp/open-cowork/adc.json',
     enableNativeWebSearch: true,
-    opencodeBinPath: '/Applications/Open Cowork.app/Contents/Resources/opencode',
   })
 
   assert.equal(env.PATH, '/usr/bin:/bin')
@@ -64,7 +63,6 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.HTTP_PROXY, 'http://proxy.example:8080')
   assert.equal(env.NO_PROXY, 'localhost,127.0.0.1')
   assert.equal(env.all_proxy, 'socks5://proxy.example:1080')
-  assert.equal(env.OPENCODE_BIN_PATH, '/Applications/Open Cowork.app/Contents/Resources/opencode')
   assert.equal(env.HOME, runtimePaths.home)
   assert.equal(env.USERPROFILE, runtimePaths.home)
   assert.equal(env.APPDATA, runtimePaths.configHome)
@@ -83,6 +81,7 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.AWS_SESSION_TOKEN, undefined)
   assert.equal(env.SSH_AUTH_SOCK, undefined)
   assert.equal(env.SSH_AGENT_PID, undefined)
+  assert.equal(env.OPENCODE_BIN_PATH, undefined)
 })
 
 test('managed runtime env drops inherited opencode binary overrides', () => {
@@ -164,19 +163,20 @@ test('managed runtime server env is explicit and does not mutate main process en
 
 test('managed runtime server prefers the explicit bundled OpenCode binary', () => {
   assert.equal(
-    resolveManagedOpencodeCommand({ OPENCODE_BIN_PATH: '/app/resources/opencode/bin/opencode' }),
+    resolveManagedOpencodeCommand('/app/resources/opencode/bin/opencode'),
     '/app/resources/opencode/bin/opencode',
   )
-  assert.equal(resolveManagedOpencodeCommand({ OPENCODE_BIN_PATH: '   ' }), 'opencode')
-  assert.equal(resolveManagedOpencodeCommand({}), 'opencode')
+  assert.equal(resolveManagedOpencodeCommand('   '), 'opencode')
+  assert.equal(resolveManagedOpencodeCommand(null), 'opencode')
 })
 
 test('managed runtime spawn launches explicit binaries directly', () => {
   const args = ['serve', '--hostname=127.0.0.1', '--port=4096']
   const spawnPlan = resolveManagedOpencodeSpawn(
-    { OPENCODE_BIN_PATH: 'C:\\Program Files\\Open Cowork\\resources\\opencode.exe', ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    { OPENCODE_BIN_PATH: 'C:\\untrusted\\opencode.exe', ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
     args,
     'win32',
+    'C:\\Program Files\\Open Cowork\\resources\\opencode.exe',
   )
 
   assert.deepEqual(spawnPlan, {

--- a/tests/runtime-opencode-cli.test.ts
+++ b/tests/runtime-opencode-cli.test.ts
@@ -7,15 +7,17 @@ import {
   resolveBundledOpencodeCliEnvironment,
 } from '../apps/desktop/src/main/runtime-opencode-cli.ts'
 
-test('applyBundledOpencodeCliEnvironment exposes a usable bundled OpenCode binary path', () => {
+test('applyBundledOpencodeCliEnvironment returns a usable bundled OpenCode binary path without trusting inherited overrides', () => {
   const previousPath = process.env.PATH
   const previousBin = process.env.OPENCODE_BIN_PATH
 
   try {
-    assert.doesNotThrow(() => applyBundledOpencodeCliEnvironment())
+    process.env.OPENCODE_BIN_PATH = '/tmp/user-controlled-opencode'
+    const env = applyBundledOpencodeCliEnvironment()
 
-    const binary = process.env.OPENCODE_BIN_PATH
+    const binary = env.opencodeBinPath
     if (typeof binary === 'string' && binary.length > 0) {
+      assert.equal(process.env.OPENCODE_BIN_PATH, '/tmp/user-controlled-opencode')
       assert.equal(existsSync(binary), true)
       const pathEntries = (process.env.PATH || '').split(delimiter).filter(Boolean)
       assert.equal(pathEntries[0], dirname(binary))

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -167,6 +167,52 @@ test('saveSettings normalizes renderer updates before persistence', async () => 
   }
 })
 
+test('credential reads are scoped while default effective settings can be masked', async () => {
+  const tempRoot = testTempDir('opencowork-settings-scoped-credentials-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeEmptyConfig(configDir)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const {
+      CREDENTIAL_MASK,
+      getEffectiveSettings,
+      getIntegrationCredentials,
+      getProviderCredentials,
+      maskEffectiveSettingsCredentials,
+      saveSettings,
+    } = await importFreshSettingsModule('scoped-credentials')
+    saveSettings({
+      providerCredentials: {
+        openrouter: { apiKey: 'provider-secret' },
+        databricks: { token: 'other-provider-secret' },
+      },
+      integrationCredentials: {
+        github: { token: 'integration-secret' },
+      },
+    })
+
+    const masked = maskEffectiveSettingsCredentials(getEffectiveSettings())
+    assert.equal(masked.providerCredentials.openrouter.apiKey, CREDENTIAL_MASK)
+    assert.equal(masked.integrationCredentials.github.token, CREDENTIAL_MASK)
+    assert.deepEqual(getProviderCredentials('openrouter'), { apiKey: 'provider-secret' })
+    assert.deepEqual(getIntegrationCredentials('github'), { token: 'integration-secret' })
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('legacy settings without native toggles inherit downstream ask defaults', async () => {
   const tempRoot = testTempDir('opencowork-settings-legacy-ask-defaults-')
   const configDir = join(tempRoot, 'downstream')


### PR DESCRIPTION
## Summary
- replace broad renderer credential reads with scoped provider/integration credential IPC and masked settings:set responses
- harden dynamic provider catalogs with HTTPS-only fetches and optional SHA-256 response pins
- curate the managed OpenCode runtime environment, add MCP private-network confirmation/audit logging, unsigned custom-skill digest logging, and chart-frame CSP/spec hardening
- serialize automation scheduler/heartbeat work and raise the renderer coverage ratchet

## Validation
- pnpm typecheck
- pnpm lint
- pnpm lint:a11y --max-warnings=0
- pnpm test
- pnpm test:renderer
- pnpm test:e2e
- pnpm test:coverage
- pnpm test:coverage:renderer
- pnpm perf:check
- pnpm build
- pnpm audit --prod --audit-level high
- pnpm docs:build
- git diff --check