### PR TITLE
Added border shadow to dialogue

### DIFF
--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -61,9 +61,12 @@ body {
 }
 
 .theme-popover {
-  background: color-mix(in srgb, var(--color-base) 80%, var(--color-elevated) 20%);
-  border: 1px solid var(--color-border-subtle);
-  box-shadow: 0 18px 48px color-mix(in srgb, var(--color-base) 52%, transparent);
+  background: color-mix(in srgb, var(--color-elevated) 88%, var(--color-base) 12%);
+  border: 1px solid color-mix(in srgb, var(--color-border) 72%, var(--color-text) 18%);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-base) 36%, transparent),
+    0 10px 26px color-mix(in srgb, var(--color-base) 42%, transparent),
+    0 24px 64px color-mix(in srgb, var(--color-base) 34%, transparent);
 }
 
 .theme-chrome {


### PR DESCRIPTION
## Summary

- Increase the visual separation of shared popover surfaces, including the New Thread dropdown.
- This changed because the previous `.theme-popover` background, border, and shadow could blend into the surrounding UI in dark, light, or custom themes.
- Use existing theme variables to make the popover background more elevated, strengthen the border, and add layered dropdown shadows without hardcoded theme-specific colors.

## Validation

- [ ] `pnpm test`
- [ ] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] `pnpm perf:check` (if touched runtime, projection, or performance-sensitive code)
- [x] `git diff --check`
- [x] `pnpm --dir apps/desktop exec vitest run --config vitest.renderer.config.ts src/renderer/components/layout/Sidebar.test.tsx`

## User-visible impact

- [ ] No user-visible behavior change
- [x] UI change
- [ ] Runtime behavior change
- [ ] Packaging / release change
- [ ] Docs change

## Notes

- Risks, caveats, or follow-up work: visually check all `.theme-popover` users, especially the New Thread dropdown, command palette, thread context menu, and diff viewer modal, in light, dark, and custom themes.
- `pnpm --filter @open-cowork/desktop test:renderer -- Sidebar.test.tsx` loaded unrelated renderer tests and failed on missing `@dnd-kit/core` from `AutomationBoard`; the explicitly scoped sidebar test passed.