### PR TITLE
Fix chart frame handshake in packaged app

### DIFF
--- a/apps/desktop/src/renderer/chart-frame-message-origin.test.ts
+++ b/apps/desktop/src/renderer/chart-frame-message-origin.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isOpaqueMessageOrigin, resolveParentTargetOrigin } from './chart-frame-message-origin'
+
+describe('resolveParentTargetOrigin', () => {
+  it('uses the concrete referrer origin in dev server frames', () => {
+    expect(resolveParentTargetOrigin('http://localhost:5173/chart-frame.html')).toBe('http://localhost:5173')
+  })
+
+  it('falls back to wildcard when the packaged frame referrer is stripped', () => {
+    expect(resolveParentTargetOrigin('')).toBe('*')
+  })
+
+  it('falls back to wildcard for file referrers with opaque origins', () => {
+    expect(resolveParentTargetOrigin('file:///Applications/Open%20Cowork.app/Contents/Resources/app.asar/dist/chart-frame.html')).toBe('*')
+  })
+
+  it('falls back to wildcard for invalid referrers', () => {
+    expect(resolveParentTargetOrigin('not a url')).toBe('*')
+  })
+})
+
+describe('isOpaqueMessageOrigin', () => {
+  it('recognizes opaque sandbox and file origins', () => {
+    expect(isOpaqueMessageOrigin('null')).toBe(true)
+    expect(isOpaqueMessageOrigin('file://')).toBe(true)
+    expect(isOpaqueMessageOrigin('http://localhost:5173')).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/chart-frame-message-origin.ts
+++ b/apps/desktop/src/renderer/chart-frame-message-origin.ts
@@ -1,0 +1,20 @@
+export function isOpaqueMessageOrigin(origin: string) {
+  return origin === 'null' || origin === 'file://'
+}
+
+function isConcreteTargetOrigin(origin: string) {
+  return Boolean(origin && !isOpaqueMessageOrigin(origin))
+}
+
+export function resolveParentTargetOrigin(referrer: string) {
+  try {
+    if (referrer) {
+      const origin = new URL(referrer).origin
+      if (isConcreteTargetOrigin(origin)) return origin
+    }
+  } catch {
+    // Invalid or stripped referrers fall through to the opaque-frame path.
+  }
+
+  return '*'
+}

--- a/apps/desktop/src/renderer/chart-frame.ts
+++ b/apps/desktop/src/renderer/chart-frame.ts
@@ -1,5 +1,6 @@
 import embed, { type Result as VegaEmbedResult } from 'vega-embed'
 import { validateInlineChartSpec } from '../lib/chart-spec-safety'
+import { isOpaqueMessageOrigin, resolveParentTargetOrigin } from './chart-frame-message-origin.ts'
 
 type ChartRenderMessage = {
   type: 'render-chart'
@@ -44,16 +45,12 @@ function createRestrictedVegaLoader() {
 }
 
 function postToParent(message: ChartResponseMessage) {
-  // Use `document.referrer` when available (packaged app: `file://`; dev:
-  // `http://localhost:5173`) so the parent origin is explicit rather than
-  // "any listener, anywhere". Falls back to the frame's own origin which
-  // in Electron same-origin iframes matches the parent. `"*"` is never
-  // used — it would let an injected cross-origin listener read the chart
-  // response payload.
-  const parentOrigin = document.referrer
-    ? new URL(document.referrer).origin
-    : window.location.origin
-  window.parent.postMessage(message, parentOrigin)
+  // Use a concrete referrer origin when Chromium provides one. Packaged
+  // `file://` navigations can strip the referrer, and this sandboxed frame's
+  // own origin is opaque, so `"*"` is the only deliverable target in that
+  // case. Delivery is still scoped to `window.parent`; the parent validates
+  // `event.source === iframe.contentWindow` before trusting the payload.
+  window.parent.postMessage(message, resolveParentTargetOrigin(document.referrer))
 }
 
 function expectedParentOrigin() {
@@ -66,14 +63,10 @@ function expectedParentOrigin() {
   }
 }
 
-function isOpaqueFileOrigin(origin: string) {
-  return origin === 'null' || origin === 'file://'
-}
-
 function parentOriginMatches(eventOrigin: string) {
   const expectedOrigin = expectedParentOrigin()
   return eventOrigin === expectedOrigin
-    || (isOpaqueFileOrigin(eventOrigin) && isOpaqueFileOrigin(expectedOrigin))
+    || (isOpaqueMessageOrigin(eventOrigin) && isOpaqueMessageOrigin(expectedOrigin))
 }
 
 function shouldHandleParentMessage(event: MessageEvent) {

--- a/apps/desktop/src/renderer/components/chat/vega-chart-message-utils.test.ts
+++ b/apps/desktop/src/renderer/components/chat/vega-chart-message-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { shouldHandleChartFrameMessage } from './vega-chart-message-utils'
+
+describe('shouldHandleChartFrameMessage', () => {
+  it('accepts messages from the chart frame when both origins are opaque variants', () => {
+    expect(shouldHandleChartFrameMessage({
+      frameWindow: window,
+      eventSource: window,
+      eventOrigin: 'null',
+      expectedOrigin: 'file://',
+    })).toBe(true)
+
+    expect(shouldHandleChartFrameMessage({
+      frameWindow: window,
+      eventSource: window,
+      eventOrigin: 'file://',
+      expectedOrigin: 'null',
+    })).toBe(true)
+  })
+
+  it('rejects messages from other sources or concrete origins', () => {
+    expect(shouldHandleChartFrameMessage({
+      frameWindow: window,
+      eventSource: null,
+      eventOrigin: 'null',
+      expectedOrigin: 'null',
+    })).toBe(false)
+
+    expect(shouldHandleChartFrameMessage({
+      frameWindow: window,
+      eventSource: window,
+      eventOrigin: 'https://example.test',
+      expectedOrigin: 'null',
+    })).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/vega-chart-message-utils.ts
+++ b/apps/desktop/src/renderer/components/chat/vega-chart-message-utils.ts
@@ -1,10 +1,8 @@
-function isOpaqueFileOrigin(origin: string) {
-  return origin === 'null' || origin === 'file://'
-}
+import { isOpaqueMessageOrigin } from '../../chart-frame-message-origin.ts'
 
 function originMatches(eventOrigin: string, expectedOrigin: string) {
   if (eventOrigin === expectedOrigin) return true
-  return isOpaqueFileOrigin(eventOrigin) && isOpaqueFileOrigin(expectedOrigin)
+  return isOpaqueMessageOrigin(eventOrigin) && isOpaqueMessageOrigin(expectedOrigin)
 }
 
 export function shouldHandleChartFrameMessage(options: {


### PR DESCRIPTION
## Summary

Fixes #74.

This updates the chart iframe handshake so packaged `file://` builds can receive the initial `chart-frame-ready` message from the sandboxed chart frame.

## Root Cause

The chart iframe intentionally runs with `sandbox="allow-scripts"` and without `allow-same-origin`, which gives it an opaque origin. In packaged Electron builds, Chromium can strip the `file://` referrer for the iframe navigation. The old child-to-parent `postMessage` fallback used `window.location.origin`, which is not a deliverable parent target for the opaque sandboxed frame, so the browser silently dropped the handshake and the parent timed out with `Chart frame did not initialize`.

## Changes

- Add a small chart-frame message-origin helper.
- Use a concrete referrer origin when available.
- Fall back to `'*'` for stripped/opaque packaged-frame cases.
- Preserve the iframe sandbox; this does not add `allow-same-origin`.
- Reuse the same opaque-origin helper in the parent message gate.
- Add renderer tests for dev-server origins, packaged `file://` fallback behavior, invalid referrers, and opaque-origin parent message validation.

## Validation

- `pnpm --dir apps/desktop test:renderer -- src/renderer/chart-frame-message-origin.test.ts src/renderer/components/chat/vega-chart-message-utils.test.ts src/renderer/components/chat/VegaChart.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`