### PR TITLE
Fix sandboxed chart frame initialization

### DIFF
--- a/apps/desktop/src/lib/chart-frame-assets.ts
+++ b/apps/desktop/src/lib/chart-frame-assets.ts
@@ -1,0 +1,7 @@
+export const CHART_FRAME_ASSET_PROTOCOL = 'open-cowork-chart'
+export const CHART_FRAME_ASSET_HOST = 'frame'
+
+export function chartFrameAssetUrl(assetPath: string) {
+  const normalized = assetPath.replace(/^\.?\//, '').replace(/\\/g, '/')
+  return `${CHART_FRAME_ASSET_PROTOCOL}://${CHART_FRAME_ASSET_HOST}/${normalized}`
+}

--- a/apps/desktop/src/main/app-protocol-schemes.ts
+++ b/apps/desktop/src/main/app-protocol-schemes.ts
@@ -1,0 +1,32 @@
+import electron from 'electron'
+import type { CustomScheme } from 'electron'
+import { BRANDING_ASSET_PROTOCOL } from './branding-assets.ts'
+import { CHART_FRAME_ASSET_PROTOCOL } from '../lib/chart-frame-assets.ts'
+
+const electronProtocol = (electron as { protocol?: typeof import('electron').protocol }).protocol
+
+export const APP_PROTOCOL_SCHEMES: CustomScheme[] = [
+  {
+    scheme: BRANDING_ASSET_PROTOCOL,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: false,
+    },
+  },
+  {
+    scheme: CHART_FRAME_ASSET_PROTOCOL,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+    },
+  },
+]
+
+export function registerAppProtocolSchemes() {
+  if (!electronProtocol) return
+  electronProtocol.registerSchemesAsPrivileged(APP_PROTOCOL_SCHEMES)
+}

--- a/apps/desktop/src/main/branding-assets.ts
+++ b/apps/desktop/src/main/branding-assets.ts
@@ -86,18 +86,3 @@ export function registerBrandingAssetProtocol() {
     }
   })
 }
-
-export function registerBrandingAssetScheme() {
-  if (!electronProtocol) return
-  electronProtocol.registerSchemesAsPrivileged([
-    {
-      scheme: BRANDING_ASSET_PROTOCOL,
-      privileges: {
-        standard: true,
-        secure: true,
-        supportFetchAPI: true,
-        corsEnabled: false,
-      },
-    },
-  ])
-}

--- a/apps/desktop/src/main/chart-frame-assets.ts
+++ b/apps/desktop/src/main/chart-frame-assets.ts
@@ -88,18 +88,3 @@ export function registerChartFrameAssetProtocol() {
     }
   })
 }
-
-export function registerChartFrameAssetScheme() {
-  if (!electronProtocol) return
-  electronProtocol.registerSchemesAsPrivileged([
-    {
-      scheme: CHART_FRAME_ASSET_PROTOCOL,
-      privileges: {
-        standard: true,
-        secure: true,
-        supportFetchAPI: true,
-        corsEnabled: true,
-      },
-    },
-  ])
-}

--- a/apps/desktop/src/main/chart-frame-assets.ts
+++ b/apps/desktop/src/main/chart-frame-assets.ts
@@ -1,0 +1,105 @@
+import electron from 'electron'
+import { existsSync, realpathSync, statSync } from 'fs'
+import { extname, isAbsolute, normalize, relative, resolve } from 'path'
+import { pathToFileURL } from 'url'
+import {
+  CHART_FRAME_ASSET_HOST,
+  CHART_FRAME_ASSET_PROTOCOL,
+} from '../lib/chart-frame-assets.ts'
+
+const electronNet = (electron as { net?: typeof import('electron').net }).net
+const electronProtocol = (electron as { protocol?: typeof import('electron').protocol }).protocol
+const SUPPORTED_CHART_FRAME_ASSET_EXTENSIONS = new Set(['.js', '.css', '.map'])
+
+function getRendererDistRoot() {
+  return resolve(__dirname, '..')
+}
+
+function isPathInside(parent: string, child: string) {
+  const rel = relative(parent, child)
+  return rel === '' || (rel && !rel.startsWith('..') && !isAbsolute(rel))
+}
+
+function normalizeChartFrameAssetPath(assetPath: string | undefined) {
+  const trimmed = assetPath?.trim()
+  if (!trimmed) return null
+  if (trimmed.length > 512) return null
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null
+  if (isAbsolute(trimmed) || trimmed.startsWith('/') || trimmed.startsWith('\\')) return null
+
+  const normalized = normalize(trimmed).replace(/\\/g, '/')
+  if (!normalized.startsWith('assets/')) return null
+  if (normalized === 'assets' || normalized.startsWith('../') || normalized.includes('/../')) return null
+
+  const ext = extname(normalized).toLowerCase()
+  if (!SUPPORTED_CHART_FRAME_ASSET_EXTENSIONS.has(ext)) return null
+  return normalized
+}
+
+export function resolveChartFrameAssetFile(assetPath: string | undefined, root = getRendererDistRoot()) {
+  const normalized = normalizeChartFrameAssetPath(assetPath)
+  if (!normalized) return null
+  const rootPath = resolve(root)
+  const resolved = resolve(rootPath, normalized)
+  if (!isPathInside(rootPath, resolved)) return null
+  if (!existsSync(resolved)) return null
+  try {
+    const realRoot = realpathSync.native(rootPath)
+    const realFile = realpathSync.native(resolved)
+    if (!isPathInside(realRoot, realFile)) return null
+    if (!statSync(realFile).isFile()) return null
+    return realFile
+  } catch {
+    return null
+  }
+}
+
+function contentTypeForPath(filePath: string) {
+  const ext = extname(filePath).toLowerCase()
+  if (ext === '.js') return 'text/javascript; charset=utf-8'
+  if (ext === '.css') return 'text/css; charset=utf-8'
+  if (ext === '.map') return 'application/json; charset=utf-8'
+  return 'application/octet-stream'
+}
+
+export function registerChartFrameAssetProtocol() {
+  if (!electronProtocol || !electronNet) return
+  electronProtocol.handle(CHART_FRAME_ASSET_PROTOCOL, async (request) => {
+    try {
+      const url = new URL(request.url)
+      if (url.hostname !== CHART_FRAME_ASSET_HOST) return new Response(null, { status: 404 })
+      const assetPath = decodeURIComponent(url.pathname.replace(/^\/+/, ''))
+      const file = resolveChartFrameAssetFile(assetPath)
+      if (!file) return new Response(null, { status: 404 })
+      const response = await electronNet.fetch(pathToFileURL(file).toString())
+      const headers = new Headers(response.headers)
+      headers.set('Content-Type', contentTypeForPath(file))
+      // Chart-frame module scripts are loaded from an opaque sandboxed file
+      // frame. CORS must allow the opaque `null` origin, but the protocol only
+      // serves immutable bundled chart chunks from the renderer dist.
+      headers.set('Access-Control-Allow-Origin', '*')
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      })
+    } catch {
+      return new Response(null, { status: 404 })
+    }
+  })
+}
+
+export function registerChartFrameAssetScheme() {
+  if (!electronProtocol) return
+  electronProtocol.registerSchemesAsPrivileged([
+    {
+      scheme: CHART_FRAME_ASSET_PROTOCOL,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+  ])
+}

--- a/apps/desktop/src/main/content-security-policy.ts
+++ b/apps/desktop/src/main/content-security-policy.ts
@@ -1,4 +1,5 @@
 import type { Session } from 'electron'
+import { CHART_FRAME_ASSET_PROTOCOL } from '../lib/chart-frame-assets.ts'
 
 type ContentSecurityPolicyOptions = {
   devServerUrl?: string | null
@@ -71,15 +72,19 @@ export const PACKAGED_CONTENT_SECURITY_POLICY = buildContentSecurityPolicy()
 //      oversized specs, excessive array items, and excessive object depth
 //      so specs can only reference bounded inline values the caller
 //      already had.
-//   5. The chart-frame preload is a no-op — no `nodeIntegration`, no
+//   5. Packaged module chunks load through the app-owned
+//      `open-cowork-chart:` protocol because Chromium blocks opaque
+//      sandboxed file frames from loading sibling `file://` module
+//      chunks. The protocol serves only bundled chart-frame assets.
+//   6. The chart-frame preload is a no-op — no `nodeIntegration`, no
 //      `coworkApi`, so even arbitrary eval has no filesystem, IPC, or
 //      Electron-specific escape hatches.
-//   6. `postMessage` handlers in the parent check `event.origin` and
+//   7. `postMessage` handlers in the parent check `event.origin` and
 //      `event.source === iframe.contentWindow` before trusting the
 //      payload (see `VegaChart.tsx`).
 export function buildChartFrameContentSecurityPolicy(options: ContentSecurityPolicyOptions = {}) {
   const devServerOrigin = normalizeDevServerOrigin(options.devServerUrl)
-  const scriptSrc = new Set(["'self'", "'unsafe-eval'"])
+  const scriptSrc = new Set(["'self'", "'unsafe-eval'", `${CHART_FRAME_ASSET_PROTOCOL}:`])
   const styleSrc = new Set(["'self'", "'unsafe-inline'"])
   const connectSrc = new Set<string>()
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -49,11 +49,13 @@ import { primeShellEnvironment } from './shell-env.ts'
 import { listReadyGoogleAuthLocalMcpNames } from './runtime-mcp.ts'
 import { shouldScheduleRuntimeReconnect } from './runtime-reconnect-policy.ts'
 import { registerBrandingAssetProtocol, registerBrandingAssetScheme } from './branding-assets.ts'
+import { registerChartFrameAssetProtocol, registerChartFrameAssetScheme } from './chart-frame-assets.ts'
 
 import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
 
 registerBrandingAssetScheme()
+registerChartFrameAssetScheme()
 
 let mainWindow: BrowserWindow | null = null
 let runtimeStarted = false
@@ -859,6 +861,7 @@ app.whenReady().then(async () => {
   configureAutomationService({ getMainWindow })
   startAutomationService()
   registerBrandingAssetProtocol()
+  registerChartFrameAssetProtocol()
   attachContentSecurityPolicy(electronSession.defaultSession, {
     devServerUrl: process.env.VITE_DEV_SERVER_URL,
   })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -48,14 +48,14 @@ import {
 import { primeShellEnvironment } from './shell-env.ts'
 import { listReadyGoogleAuthLocalMcpNames } from './runtime-mcp.ts'
 import { shouldScheduleRuntimeReconnect } from './runtime-reconnect-policy.ts'
-import { registerBrandingAssetProtocol, registerBrandingAssetScheme } from './branding-assets.ts'
-import { registerChartFrameAssetProtocol, registerChartFrameAssetScheme } from './chart-frame-assets.ts'
+import { registerAppProtocolSchemes } from './app-protocol-schemes.ts'
+import { registerBrandingAssetProtocol } from './branding-assets.ts'
+import { registerChartFrameAssetProtocol } from './chart-frame-assets.ts'
 
 import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
 
-registerBrandingAssetScheme()
-registerChartFrameAssetScheme()
+registerAppProtocolSchemes()
 
 let mainWindow: BrowserWindow | null = null
 let runtimeStarted = false

--- a/apps/desktop/src/renderer/chart-frame.ts
+++ b/apps/desktop/src/renderer/chart-frame.ts
@@ -14,6 +14,10 @@ type ChartCaptureMessage = {
   scale?: number
 }
 
+type ChartPingMessage = {
+  type: 'chart-frame-ping'
+}
+
 type ChartResponseMessage =
   | { type: 'chart-frame-ready' }
   | { type: 'chart-ready'; requestId: number; height: number }
@@ -161,8 +165,13 @@ async function captureChart(message: ChartCaptureMessage) {
 
 window.addEventListener('message', (event) => {
   if (!shouldHandleParentMessage(event)) return
-  const data = event.data as ChartRenderMessage | ChartCaptureMessage | undefined
-  if (!data || typeof data.requestId !== 'number') return
+  const data = event.data as ChartRenderMessage | ChartCaptureMessage | ChartPingMessage | undefined
+  if (!data || typeof data !== 'object') return
+  if (data.type === 'chart-frame-ping') {
+    postToParent({ type: 'chart-frame-ready' })
+    return
+  }
+  if (typeof data.requestId !== 'number') return
   if (data.type === 'render-chart' && (data as ChartRenderMessage).spec) {
     void renderChart(data as ChartRenderMessage)
     return

--- a/apps/desktop/src/renderer/components/chat/VegaChart.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/VegaChart.test.tsx
@@ -18,4 +18,28 @@ describe('VegaChart', () => {
 
     expect(screen.getByText('Chart error: Chart frame did not initialize')).toBeTruthy()
   })
+
+  it('pings the chart frame after load so a missed one-shot ready message can recover', () => {
+    vi.useFakeTimers()
+    render(<VegaChart spec={{ mark: 'bar', data: { values: [{ x: 'A', y: 1 }] } }} />)
+
+    const iframe = screen.getByTitle('Generated chart') as HTMLIFrameElement
+    const frameWindow = iframe.contentWindow
+    expect(frameWindow).toBeTruthy()
+    const postMessage = vi.spyOn(frameWindow!, 'postMessage')
+
+    fireEvent.load(iframe)
+    expect(postMessage).toHaveBeenCalledWith({ type: 'chart-frame-ping' }, '*')
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'chart-frame-ready' },
+        origin: 'null',
+        source: frameWindow,
+      }))
+      vi.advanceTimersByTime(3_000)
+    })
+
+    expect(screen.queryByText('Chart error: Chart frame did not initialize')).toBeNull()
+  })
 })

--- a/apps/desktop/src/renderer/components/chat/VegaChart.tsx
+++ b/apps/desktop/src/renderer/components/chat/VegaChart.tsx
@@ -32,6 +32,7 @@ type ChartFrameMessage =
 
 const DEFAULT_FRAME_HEIGHT = 360
 const FRAME_READY_TIMEOUT_MS = 3_000
+const FRAME_READY_PING_INTERVAL_MS = 250
 
 export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId, toolName, taskRunId }: Props) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
@@ -39,6 +40,7 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
   const captureRequestIdRef = useRef(0)
   const capturedForSpecRef = useRef<string | null>(null)
   const frameReadyTimeoutRef = useRef<number | null>(null)
+  const frameReadyPingIntervalRef = useRef<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [themeVersion, setThemeVersion] = useState(0)
   const [frameLoaded, setFrameLoaded] = useState(false)
@@ -139,6 +141,10 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
           window.clearTimeout(frameReadyTimeoutRef.current)
           frameReadyTimeoutRef.current = null
         }
+        if (frameReadyPingIntervalRef.current) {
+          window.clearInterval(frameReadyPingIntervalRef.current)
+          frameReadyPingIntervalRef.current = null
+        }
         setFrameReady(true)
         return
       }
@@ -194,6 +200,9 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
       window.removeEventListener('message', handleMessage)
       if (frameReadyTimeoutRef.current) {
         window.clearTimeout(frameReadyTimeoutRef.current)
+      }
+      if (frameReadyPingIntervalRef.current) {
+        window.clearInterval(frameReadyPingIntervalRef.current)
       }
     }
   }, [canCapture, chartSource, frameOrigin, registerChartArtifact, sessionId, specSignature, taskRunId, toolCallId, toolName])
@@ -280,7 +289,19 @@ export function VegaChart({ spec, chartFormat, chartTitle, sessionId, toolCallId
           if (frameReadyTimeoutRef.current) {
             window.clearTimeout(frameReadyTimeoutRef.current)
           }
+          if (frameReadyPingIntervalRef.current) {
+            window.clearInterval(frameReadyPingIntervalRef.current)
+          }
+          const pingFrame = () => {
+            iframeRef.current?.contentWindow?.postMessage({ type: 'chart-frame-ping' }, '*')
+          }
+          pingFrame()
+          frameReadyPingIntervalRef.current = window.setInterval(pingFrame, FRAME_READY_PING_INTERVAL_MS)
           frameReadyTimeoutRef.current = window.setTimeout(() => {
+            if (frameReadyPingIntervalRef.current) {
+              window.clearInterval(frameReadyPingIntervalRef.current)
+              frameReadyPingIntervalRef.current = null
+            }
             setError('Chart frame did not initialize')
           }, FRAME_READY_TIMEOUT_MS)
         }}

--- a/apps/desktop/tests/chart-render.smoke.test.ts
+++ b/apps/desktop/tests/chart-render.smoke.test.ts
@@ -50,6 +50,65 @@ test('chart renderer round-trips through preload and main IPC', async () => {
     })
 
     assert.match(blocked || '', /only supports local inline specs/i)
+
+    const frameResult = await page.evaluate(async () => {
+      const iframe = document.createElement('iframe')
+      iframe.sandbox.add('allow-scripts')
+      iframe.src = new URL('./chart-frame.html', window.location.href).toString()
+      document.body.appendChild(iframe)
+
+      return await new Promise<{ ok: true; height: number } | { ok: false; message: string }>((resolveFrame) => {
+        let settled = false
+        let requestSent = false
+        const finish = (result: { ok: true; height: number } | { ok: false; message: string }) => {
+          if (settled) return
+          settled = true
+          window.clearInterval(pingInterval)
+          window.clearTimeout(timeout)
+          window.removeEventListener('message', onMessage)
+          iframe.remove()
+          resolveFrame(result)
+        }
+        const renderSpec = {
+          $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+          data: { values: [{ category: 'A', value: 1 }] },
+          mark: 'bar',
+          encoding: {
+            x: { field: 'category', type: 'nominal' },
+            y: { field: 'value', type: 'quantitative' },
+          },
+        }
+        const onMessage = (event: MessageEvent) => {
+          if (event.source !== iframe.contentWindow) return
+          const data = event.data
+          if (!data || typeof data !== 'object') return
+          if (data.type === 'chart-frame-ready' && !requestSent) {
+            requestSent = true
+            iframe.contentWindow?.postMessage({ type: 'render-chart', requestId: 1, spec: renderSpec }, '*')
+            return
+          }
+          if (data.type === 'chart-ready' && data.requestId === 1) {
+            finish({ ok: true, height: Number(data.height) || 0 })
+            return
+          }
+          if (data.type === 'chart-error') {
+            finish({ ok: false, message: String(data.message || 'chart frame error') })
+          }
+        }
+        window.addEventListener('message', onMessage)
+        const pingInterval = window.setInterval(() => {
+          iframe.contentWindow?.postMessage({ type: 'chart-frame-ping' }, '*')
+        }, 100)
+        const timeout = window.setTimeout(() => {
+          finish({ ok: false, message: 'chart frame did not initialize' })
+        }, 5_000)
+      })
+    })
+
+    assert.equal(frameResult.ok, true, frameResult.ok ? undefined : frameResult.message)
+    if (frameResult.ok) {
+      assert.ok(frameResult.height > 0)
+    }
   } finally {
     await cleanup()
   }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import electron from 'vite-plugin-electron'
 import { resolve } from 'path'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import type { Plugin, ResolvedConfig } from 'vite'
+import { chartFrameAssetUrl } from './src/lib/chart-frame-assets'
 
 function packageNameFromId(id: string) {
   const normalized = id.replace(/\\/g, '/')
@@ -12,6 +15,39 @@ function packageNameFromId(id: string) {
   const parts = normalized.slice(nodeModulesIndex + marker.length).split('/')
   if (!parts[0]) return null
   return parts[0].startsWith('@') ? `${parts[0]}/${parts[1] || ''}` : parts[0]
+}
+
+function chartFrameAssetProtocolPlugin(): Plugin {
+  let config: ResolvedConfig
+  let shouldRewriteChartFrame = false
+
+  return {
+    name: 'chart-frame-asset-protocol',
+    apply: 'build',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig
+      const input = resolvedConfig.build.rollupOptions.input
+      shouldRewriteChartFrame = Boolean(input && typeof input === 'object' && !Array.isArray(input) && 'chartFrame' in input)
+    },
+    closeBundle() {
+      if (!shouldRewriteChartFrame) return
+      const chartFrameHtmlPath = resolve(config.root, config.build.outDir, 'chart-frame.html')
+      if (!existsSync(chartFrameHtmlPath)) {
+        this.error('Expected chart-frame.html to be emitted by the renderer build')
+        return
+      }
+      const source = readFileSync(chartFrameHtmlPath, 'utf8')
+      const rewritten = source.replace(
+        /(<script\b[^>]*\bsrc=")(\.\/assets\/chartFrame-[^"]+\.js)(")/,
+        (_match, prefix: string, assetPath: string, suffix: string) => `${prefix}${chartFrameAssetUrl(assetPath)}${suffix}`,
+      )
+      if (rewritten === source) {
+        this.error('Expected chart-frame.html to contain a bundled chartFrame module script')
+        return
+      }
+      writeFileSync(chartFrameHtmlPath, rewritten)
+    },
+  }
 }
 
 export default defineConfig({
@@ -50,6 +86,7 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
+    chartFrameAssetProtocolPlugin(),
     electron([
       {
         entry: 'src/main/index.ts',

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import electron from 'vite-plugin-electron'
 import { resolve } from 'path'
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import type { Plugin, ResolvedConfig } from 'vite'
 import { chartFrameAssetUrl } from './src/lib/chart-frame-assets'
 
@@ -32,11 +32,13 @@ function chartFrameAssetProtocolPlugin(): Plugin {
     closeBundle() {
       if (!shouldRewriteChartFrame) return
       const chartFrameHtmlPath = resolve(config.root, config.build.outDir, 'chart-frame.html')
-      if (!existsSync(chartFrameHtmlPath)) {
-        this.error('Expected chart-frame.html to be emitted by the renderer build')
+      let source: string
+      try {
+        source = readFileSync(chartFrameHtmlPath, 'utf8')
+      } catch (error) {
+        this.error(`Expected chart-frame.html to be emitted by the renderer build: ${error instanceof Error ? error.message : String(error)}`)
         return
       }
-      const source = readFileSync(chartFrameHtmlPath, 'utf8')
       const rewritten = source.replace(
         /(<script\b[^>]*\bsrc=")(\.\/assets\/chartFrame-[^"]+\.js)(")/,
         (_match, prefix: string, assetPath: string, suffix: string) => `${prefix}${chartFrameAssetUrl(assetPath)}${suffix}`,

--- a/tests/app-protocol-schemes.test.ts
+++ b/tests/app-protocol-schemes.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BRANDING_ASSET_PROTOCOL } from '../apps/desktop/src/main/branding-assets.ts'
+import { CHART_FRAME_ASSET_PROTOCOL } from '../apps/desktop/src/lib/chart-frame-assets.ts'
+import { APP_PROTOCOL_SCHEMES } from '../apps/desktop/src/main/app-protocol-schemes.ts'
+
+test('app protocol schemes are registered as one privileged scheme list', () => {
+  const schemes = new Map(APP_PROTOCOL_SCHEMES.map((entry) => [entry.scheme, entry.privileges]))
+
+  assert.deepEqual(Array.from(schemes.keys()).sort(), [
+    BRANDING_ASSET_PROTOCOL,
+    CHART_FRAME_ASSET_PROTOCOL,
+  ].sort())
+
+  assert.equal(schemes.get(BRANDING_ASSET_PROTOCOL)?.standard, true)
+  assert.equal(schemes.get(BRANDING_ASSET_PROTOCOL)?.secure, true)
+  assert.equal(schemes.get(BRANDING_ASSET_PROTOCOL)?.supportFetchAPI, true)
+  assert.equal(schemes.get(BRANDING_ASSET_PROTOCOL)?.corsEnabled, false)
+
+  assert.equal(schemes.get(CHART_FRAME_ASSET_PROTOCOL)?.standard, true)
+  assert.equal(schemes.get(CHART_FRAME_ASSET_PROTOCOL)?.secure, true)
+  assert.equal(schemes.get(CHART_FRAME_ASSET_PROTOCOL)?.supportFetchAPI, true)
+  assert.equal(schemes.get(CHART_FRAME_ASSET_PROTOCOL)?.corsEnabled, true)
+})

--- a/tests/chart-frame-assets.test.ts
+++ b/tests/chart-frame-assets.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdirSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { chartFrameAssetUrl } from '../apps/desktop/src/lib/chart-frame-assets.ts'
+import { resolveChartFrameAssetFile } from '../apps/desktop/src/main/chart-frame-assets.ts'
+
+test('chartFrameAssetUrl points bundled chart chunks at the app-owned protocol', () => {
+  assert.equal(
+    chartFrameAssetUrl('./assets/chartFrame-abc123.js'),
+    'open-cowork-chart://frame/assets/chartFrame-abc123.js',
+  )
+})
+
+test('resolveChartFrameAssetFile only serves contained renderer asset files', () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-chart-assets-'))
+  const outside = mkdtempSync(join(tmpdir(), 'open-cowork-chart-outside-'))
+  try {
+    mkdirSync(join(root, 'assets'), { recursive: true })
+    const chunk = join(root, 'assets', 'chartFrame-test.js')
+    writeFileSync(chunk, 'export {}')
+    const secret = join(outside, 'secret.js')
+    writeFileSync(secret, 'export const secret = true')
+    symlinkSync(secret, join(root, 'assets', 'linked.js'))
+
+    assert.equal(resolveChartFrameAssetFile('assets/chartFrame-test.js', root), realpathSync.native(chunk))
+    assert.equal(resolveChartFrameAssetFile('../assets/chartFrame-test.js', root), null)
+    assert.equal(resolveChartFrameAssetFile('chart-frame.html', root), null)
+    assert.equal(resolveChartFrameAssetFile('assets/chartFrame-test.html', root), null)
+    assert.equal(resolveChartFrameAssetFile('assets/linked.js', root), null)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  }
+})

--- a/tests/content-security-policy.test.ts
+++ b/tests/content-security-policy.test.ts
@@ -38,7 +38,7 @@ test('index.html does not ship a meta CSP (main process attaches the authoritati
 test('chart frame CSP allows only local scripts with eval and no network egress in packaged mode', () => {
   const policy = buildChartFrameContentSecurityPolicy()
 
-  assert.match(policy, /script-src 'self' 'unsafe-eval'/)
+  assert.match(policy, /script-src 'self' 'unsafe-eval' open-cowork-chart:/)
   assert.doesNotMatch(policy, /script-src[^;]*'unsafe-inline'/)
   assert.match(policy, /connect-src 'none'/)
   assert.match(policy, /img-src 'self' data: blob:/)


### PR DESCRIPTION
## Summary
- route packaged chart-frame JS chunks through an app-owned open-cowork-chart protocol so opaque sandboxed iframes can initialize
- keep the chart iframe sandbox opaque and add a ready-ping recovery path for missed startup messages
- add unit and smoke coverage for chart-frame asset containment, CSP, initialization, and rendering

## Root cause
The built chart iframe was sandboxed with allow-scripts only, so Chromium assigned it an opaque origin. That frame then tried to load sibling file:// module chunks from dist/assets, which Chromium blocks for opaque sandboxed file frames. The parent timed out waiting for chart-frame-ready.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- tests/chart-frame-assets.test.ts tests/content-security-policy.test.ts
- pnpm test:renderer
- pnpm test:e2e
- pnpm perf:check
- git diff --check
- pnpm --dir apps/desktop build