### PR TITLE
[codex] Close notification audio context on unmount

### DIFF
--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
@@ -1,0 +1,91 @@
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeNotification } from '@open-cowork/shared'
+import { installRendererTestCoworkApi } from '../test/setup'
+import { useOpenCodeEvents } from './useOpenCodeEvents'
+
+function Harness() {
+  useOpenCodeEvents()
+  return null
+}
+
+describe('useOpenCodeEvents', () => {
+  let notify: ((event: RuntimeNotification) => void) | null = null
+  let closeAudioContext: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    notify = null
+    closeAudioContext = vi.fn(async () => undefined)
+
+    class TestAudioContext {
+      currentTime = 0
+      destination = {}
+      close = closeAudioContext
+
+      createOscillator() {
+        return {
+          connect: vi.fn(),
+          frequency: { value: 0 },
+          start: vi.fn(),
+          stop: vi.fn(),
+          type: 'sine',
+        }
+      }
+
+      createGain() {
+        return {
+          connect: vi.fn(),
+          gain: {
+            value: 0,
+            exponentialRampToValueAtTime: vi.fn(),
+          },
+        }
+      }
+    }
+
+    Object.defineProperty(globalThis, 'AudioContext', {
+      configurable: true,
+      writable: true,
+      value: TestAudioContext,
+    })
+    Object.defineProperty(window, 'AudioContext', {
+      configurable: true,
+      writable: true,
+      value: TestAudioContext,
+    })
+
+    installRendererTestCoworkApi({
+      on: {
+        authExpired: vi.fn(() => vi.fn()),
+        authLogout: vi.fn(() => vi.fn()),
+        mcpStatus: vi.fn(() => vi.fn()),
+        notification: vi.fn((callback: (event: RuntimeNotification) => void) => {
+          notify = callback
+          return vi.fn()
+        }),
+        permissionRequest: vi.fn(() => vi.fn()),
+        sessionDeleted: vi.fn(() => vi.fn()),
+        sessionPatch: vi.fn(() => vi.fn()),
+        sessionUpdated: vi.fn(() => vi.fn()),
+        sessionView: vi.fn(() => vi.fn()),
+      },
+    })
+  })
+
+  it('closes the notification AudioContext after the final hook unmounts', () => {
+    const first = render(<Harness />)
+    const second = render(<Harness />)
+
+    act(() => {
+      notify?.({ type: 'done' })
+    })
+
+    expect(closeAudioContext).not.toHaveBeenCalled()
+
+    first.unmount()
+    expect(closeAudioContext).not.toHaveBeenCalled()
+
+    second.unmount()
+    expect(closeAudioContext).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
@@ -4,11 +4,28 @@ import type { SessionPatch } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
 
 let notifyCtx: AudioContext | null = null
+let activeHookMounts = 0
+
+function closeNotifyContext() {
+  const context = notifyCtx
+  notifyCtx = null
+  if (!context) return
+
+  try {
+    void context.close().catch(() => {
+      // Audio notifications are best-effort; cleanup failures should not
+      // interrupt renderer teardown.
+    })
+  } catch {
+    // Some browser runtimes can throw synchronously if close is unsupported.
+  }
+}
 
 export function useOpenCodeEvents() {
   const setMcpConnections = useSessionStore((s) => s.setMcpConnections)
 
   useEffect(() => {
+    activeHookMounts += 1
     const textBuffers = new Map<string, SessionPatch>()
     let frameHandle: number | null = null
 
@@ -190,6 +207,10 @@ export function useOpenCodeEvents() {
       unsubMcp()
       unsubAuth()
       unsubLogout()
+      activeHookMounts = Math.max(0, activeHookMounts - 1)
+      if (activeHookMounts === 0) {
+        closeNotifyContext()
+      }
     }
   }, [setMcpConnections])
 }


### PR DESCRIPTION
## Summary

- Close the module-level notification `AudioContext` when the last `useOpenCodeEvents` subscriber unmounts.
- Track active hook mounts so multiple subscribers do not close the shared context prematurely.
- Add a renderer regression test for the final-unmount cleanup behavior.

## Why

One audit finding called out that `useOpenCodeEvents` created a shared `AudioContext` for completion sounds but never closed it. This keeps renderer audio resources alive after the event hook is torn down.

## Validation

- `pnpm --dir apps/desktop test:renderer -- useOpenCodeEvents`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`
