### PR TITLE
Cap session cost-event dedupe memory

### DIFF
--- a/apps/desktop/src/main/session-engine.ts
+++ b/apps/desktop/src/main/session-engine.ts
@@ -36,6 +36,8 @@ type CachedSessionView = {
   view: SessionView
 }
 
+export const MAX_SEEN_COST_EVENT_IDS_PER_SESSION = 1_000
+
 function getLatestHistoryEventAt(items: HistoryItem[]) {
   let latest = 0
   for (const item of items) {
@@ -181,6 +183,11 @@ export class SessionEngine {
     const seen = this.seenCostEventIdsBySession.get(sessionId) || new Set<string>()
     if (seen.has(eventId)) return false
     seen.add(eventId)
+    while (seen.size > MAX_SEEN_COST_EVENT_IDS_PER_SESSION) {
+      const oldest = seen.values().next().value
+      if (typeof oldest !== 'string') break
+      seen.delete(oldest)
+    }
     this.seenCostEventIdsBySession.set(sessionId, seen)
     return true
   }

--- a/tests/session-engine.test.ts
+++ b/tests/session-engine.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { SessionEngine } from '../apps/desktop/src/main/session-engine.ts'
+import { MAX_SEEN_COST_EVENT_IDS_PER_SESSION, SessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { MAX_WARM_SESSION_DETAILS } from '../apps/desktop/src/lib/session-view-model.ts'
 
 function apply(engine: SessionEngine, sessionId: string, data: Record<string, unknown>) {
@@ -177,6 +177,54 @@ test('session engine dedupes repeated streamed cost updates for the same part', 
   const view = engine.getSessionView(sessionId)
   assert.equal(view.sessionCost, 0.26)
   assert.equal(view.sessionTokens.input, 1000)
+})
+
+test('session engine bounds remembered streamed cost event ids per session', () => {
+  const engine = new SessionEngine()
+  const sessionId = 'session-cost-cap'
+  engine.activateSession(sessionId)
+
+  for (let index = 0; index <= MAX_SEEN_COST_EVENT_IDS_PER_SESSION; index += 1) {
+    apply(engine, sessionId, {
+      type: 'cost',
+      id: `cost-${index}`,
+      cost: 1,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    })
+  }
+
+  assert.equal(engine.getSessionView(sessionId).sessionCost, MAX_SEEN_COST_EVENT_IDS_PER_SESSION + 1)
+
+  apply(engine, sessionId, {
+    type: 'cost',
+    id: 'cost-0',
+    cost: 1,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  })
+  apply(engine, sessionId, {
+    type: 'cost',
+    id: `cost-${MAX_SEEN_COST_EVENT_IDS_PER_SESSION}`,
+    cost: 1,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  })
+
+  const view = engine.getSessionView(sessionId)
+  assert.equal(view.sessionCost, MAX_SEEN_COST_EVENT_IDS_PER_SESSION + 2)
 })
 
 test('tool calls and transcript segments share the same sequence space so a sub-agent timeline stays in order', () => {


### PR DESCRIPTION
## Summary
- cap remembered streamed cost event IDs per session at 1,000 entries
- evict the oldest remembered cost IDs once the per-session cap is exceeded
- add a regression test proving old IDs are evicted while recent IDs still dedupe

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check