### PR TITLE
Document current transitive advisory overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ release is planned for `v0.0.1`.
 
 ## [Unreleased]
 
+### Security
+
+- Raised the transitive `hono` override floor to `>=4.12.16` and added an
+  `ip-address >=10.1.1` override so the dependency graph stays above the
+  latest Hono and SOCKS parser advisory floors.
+
 ## [0.0.0] - 2026-04-28
 
 ### Added

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -314,8 +314,11 @@ are documented in `docs/packaging-and-releases.md`.
 
 - `pnpm audit --prod --audit-level high` runs as part of the CI gate.
 - Root `pnpm.overrides` entries are intentional:
-  - `hono@<4.12.14` is forced to `>=4.12.14` to keep the transitive
-    `@modelcontextprotocol/sdk` web stack above GHSA-458j-xx4x-4375.
+  - `hono@<4.12.16` is forced to `>=4.12.16` to keep the transitive
+    `@modelcontextprotocol/sdk` web stack above the GHSA-458j-xx4x-4375
+    advisory floor and subsequent patch releases in the same line.
+  - `ip-address@<=10.1.0` is forced to `>=10.1.1` to keep Electron
+    Builder's transitive `socks` stack above GHSA-v2v4-37r5-5v8g.
   - `mermaid>uuid` is pinned to `^14.0.0` so Mermaid's transitive UUID
     dependency stays on the current major used by the rest of the bundle.
   - `electron-builder-squirrel-windows` is pinned while the package graph


### PR DESCRIPTION
## Summary
- update the security model to match the current pnpm override floors for hono and ip-address
- add an Unreleased security note for the latest transitive advisory override changes

## Validation
- pnpm lint
- pnpm docs:build
- git diff --check