### PR TITLE
Type Google OAuth userinfo email parsing

### DIFF
--- a/apps/desktop/src/main/auth.ts
+++ b/apps/desktop/src/main/auth.ts
@@ -37,6 +37,14 @@ type GoogleOAuthConfig = {
   clientSecret?: string
 }
 
+export function normalizeGoogleUserInfoEmail(data: unknown) {
+  if (!data || typeof data !== 'object') return null
+  const email = (data as { email?: unknown }).email
+  if (typeof email !== 'string') return null
+  const trimmed = email.trim()
+  return trimmed || null
+}
+
 function getTokenPath() {
   const dir = getAppDataDir()
   mkdirSync(dir, { recursive: true })
@@ -314,7 +322,7 @@ export async function loginWithGoogle(): Promise<AuthState> {
         let email: string | null = null
         try {
           const userInfo = await client.request({ url: 'https://www.googleapis.com/oauth2/v2/userinfo' })
-          email = (userInfo.data as any)?.email || null
+          email = normalizeGoogleUserInfoEmail(userInfo.data)
         } catch {
           // Email lookup is optional for local auth state.
         }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -117,3 +117,12 @@ test('Google OAuth state stays authenticated with expired access token but does 
     assert.equal(auth.getCachedAccessToken(), null)
   })
 })
+
+test('Google OAuth userinfo email normalization accepts only non-empty strings', async () => {
+  const auth = await importFreshAuthModule('userinfo-email')
+
+  assert.equal(auth.normalizeGoogleUserInfoEmail({ email: ' user@example.com ' }), 'user@example.com')
+  assert.equal(auth.normalizeGoogleUserInfoEmail({ email: '   ' }), null)
+  assert.equal(auth.normalizeGoogleUserInfoEmail({ email: 42 }), null)
+  assert.equal(auth.normalizeGoogleUserInfoEmail(null), null)
+})


### PR DESCRIPTION
## Summary
- replace the OAuth userinfo email unsafe cast with an unknown-safe normalizer
- trim and reject malformed or empty email values before storing auth state
- add direct coverage for accepted and rejected userinfo payloads

## Validation
- pnpm test -- tests/auth.test.ts
- pnpm lint
- pnpm typecheck
- git diff --check