### PR TITLE
Split automation page support modules

### DIFF
--- a/apps/desktop/src/renderer/components/automations/AutomationAgentTeamSelector.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationAgentTeamSelector.tsx
@@ -1,0 +1,41 @@
+import type { AutomationAgentOption } from './automation-view-model'
+
+export function AutomationAgentTeamSelector({
+  options,
+  value,
+  onChange,
+  emptyLabel = 'No specialist agents are available in this context yet.',
+}: {
+  options: AutomationAgentOption[]
+  value: string[]
+  onChange: (next: string[]) => void
+  emptyLabel?: string
+}) {
+  if (options.length === 0) {
+    return <div className="text-[12px] text-text-muted">{emptyLabel}</div>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option) => {
+        const selected = value.includes(option.id)
+        return (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => onChange(selected ? value.filter((entry) => entry !== option.id) : [...value, option.id])}
+            className="rounded-full border px-3 py-1.5 text-left transition-colors cursor-pointer"
+            style={{
+              borderColor: selected ? 'var(--color-accent)' : 'var(--color-border)',
+              background: selected ? 'color-mix(in srgb, var(--color-accent) 12%, var(--color-elevated))' : 'transparent',
+            }}
+            title={option.description}
+          >
+            <span className="text-[11px] font-medium text-text">{option.label}</span>
+            <span className="ml-2 text-[10px] uppercase tracking-[0.14em] text-text-muted">{option.source}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
@@ -21,7 +21,7 @@ import {
   type AutomationColumn,
   type AutomationColumnId,
 } from './automation-board-support'
-import { AUTOMATION_TEMPLATES } from './automations-page-support'
+import { AUTOMATION_TEMPLATES } from './automation-view-model'
 
 type Props = {
   payload: AutomationListPayload

--- a/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
@@ -1,6 +1,6 @@
 import { useDraggable } from '@dnd-kit/core'
 import type { AutomationCardModel } from './automation-board-support'
-import { formatStatus } from './automations-page-support'
+import { formatStatus } from './automation-view-model'
 
 type Props = {
   card: AutomationCardModel

--- a/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
@@ -9,24 +9,22 @@ import type {
 } from '@open-cowork/shared'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { AutomationAgentTeamSelector } from './AutomationAgentTeamSelector'
+import { DetailGroup, DetailSection, SummaryCard } from './AutomationDetailPrimitives'
 import {
-  AgentTeamSelector,
   dailyRunAttemptCapLabel,
   dailyRunAttemptCapPlaceholder,
   deriveNextAction,
   deriveReliabilityState,
   describeRunPolicy,
-  DetailGroup,
-  DetailSection,
   formatSchedule,
   formatStatus,
   formatTimestamp,
   latestRunSummary,
   resolveAgentLabels,
-  SummaryCard,
   summarizeWorkItems,
   type AutomationAgentOption,
-} from './automations-page-support'
+} from './automation-view-model'
 
 type DetailTab = 'now' | 'brief' | 'work' | 'history' | 'settings'
 
@@ -391,7 +389,7 @@ export function AutomationCardDetail({
               <div className="mt-4">
                 <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Preferred specialists</div>
                 <div className="mt-2">
-                  <AgentTeamSelector options={agentOptions} value={edit.preferredAgentNames} onChange={(preferredAgentNames) => setEdit((current) => ({ ...current, preferredAgentNames }))} />
+                  <AutomationAgentTeamSelector options={agentOptions} value={edit.preferredAgentNames} onChange={(preferredAgentNames) => setEdit((current) => ({ ...current, preferredAgentNames }))} />
                 </div>
               </div>
               <button type="button" onClick={() => void saveEdits()} disabled={saving} className="mt-4 rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">

--- a/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { AutomationCreateWizard } from './AutomationCreateWizard'
-import { createDefaultDraft, type AutomationAgentOption, type DraftState } from './automations-page-support'
+import { createDefaultDraft, type AutomationAgentOption, type DraftState } from './automation-view-model'
 
 function draft(overrides: Partial<DraftState> = {}) {
   return {

--- a/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { AutomationAgentTeamSelector } from './AutomationAgentTeamSelector'
 import {
-  AgentTeamSelector,
   AUTOMATION_TEMPLATES,
   createDefaultDraft,
   dailyRunAttemptCapPlaceholder,
   draftToPayload,
   type AutomationAgentOption,
   type DraftState,
-} from './automations-page-support'
+} from './automation-view-model'
 import type { AutomationAutonomyPolicy, AutomationExecutionMode, AutomationKind, AutomationScheduleType } from '@open-cowork/shared'
 
 type Props = {
@@ -282,7 +282,7 @@ export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentO
                   <div>
                     <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Preferred specialists</div>
                     <div className="mt-2">
-                      <AgentTeamSelector
+                      <AutomationAgentTeamSelector
                         options={agentOptions}
                         value={draft.preferredAgentNames}
                         onChange={(preferredAgentNames) => updateDraft({ preferredAgentNames })}

--- a/apps/desktop/src/renderer/components/automations/AutomationDetailPrimitives.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationDetailPrimitives.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react'
+
+export function SummaryCard({
+  label,
+  value,
+  detail,
+  accent = false,
+  compact = false,
+}: {
+  label: string
+  value: string
+  detail: string
+  accent?: boolean
+  compact?: boolean
+}) {
+  return (
+    <div
+      className="rounded-2xl border border-border-subtle p-4"
+      style={{ background: accent ? 'color-mix(in srgb, var(--color-accent) 10%, var(--color-elevated))' : 'var(--color-elevated)' }}
+    >
+      <div className="text-[10px] uppercase tracking-[0.16em] text-text-muted">{label}</div>
+      <div className={`mt-2 font-semibold text-text ${compact ? 'text-[15px] leading-6' : 'text-[22px]'} `}>{value}</div>
+      <div className="mt-1 text-[12px] leading-5 text-text-secondary">{detail}</div>
+    </div>
+  )
+}
+
+export function DetailSection({
+  title,
+  action,
+  children,
+}: {
+  title: string
+  action?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <div className="rounded-2xl border border-border-subtle p-5" style={{ background: 'var(--color-elevated)' }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-[15px] font-semibold text-text">{title}</div>
+        {action}
+      </div>
+      <div className="mt-4">{children}</div>
+    </div>
+  )
+}
+
+export function DetailGroup({
+  label,
+  values,
+  empty = 'None',
+}: {
+  label: string
+  values: string[]
+  empty?: string
+}) {
+  return (
+    <div>
+      <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">{label}</div>
+      {values.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {values.map((value) => (
+            <span key={`${label}-${value}`} className="rounded-full border border-border px-2.5 py-1 text-[11px] text-text-secondary">
+              {value}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 text-[12px] text-text-muted">{empty}</div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -25,7 +25,7 @@ import {
   draftToPayload,
   type AutomationAgentOption,
   type DraftState,
-} from './automations-page-support'
+} from './automation-view-model'
 
 type Props = {
   onOpenThread?: (sessionId: string) => void

--- a/apps/desktop/src/renderer/components/automations/automation-board-support.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-board-support.ts
@@ -6,7 +6,7 @@ import type {
   AutomationSummary,
   AutomationWorkItem,
 } from '@open-cowork/shared'
-import { formatSchedule, formatStatus, formatTimestamp, summarizeWorkItems } from './automations-page-support'
+import { formatSchedule, formatStatus, formatTimestamp, summarizeWorkItems } from './automation-view-model'
 
 export type AutomationColumnId =
   | 'draft'

--- a/apps/desktop/src/renderer/components/automations/automation-view-model.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-view-model.ts
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react'
 import type {
   AutomationAutonomyPolicy,
   AutomationDeliveryRecord,
@@ -243,78 +242,6 @@ export function deriveNextAction(input: {
   return 'Review the latest run summary'
 }
 
-export function SummaryCard({
-  label,
-  value,
-  detail,
-  accent = false,
-  compact = false,
-}: {
-  label: string
-  value: string
-  detail: string
-  accent?: boolean
-  compact?: boolean
-}) {
-  return (
-    <div
-      className="rounded-2xl border border-border-subtle p-4"
-      style={{ background: accent ? 'color-mix(in srgb, var(--color-accent) 10%, var(--color-elevated))' : 'var(--color-elevated)' }}
-    >
-      <div className="text-[10px] uppercase tracking-[0.16em] text-text-muted">{label}</div>
-      <div className={`mt-2 font-semibold text-text ${compact ? 'text-[15px] leading-6' : 'text-[22px]'} `}>{value}</div>
-      <div className="mt-1 text-[12px] leading-5 text-text-secondary">{detail}</div>
-    </div>
-  )
-}
-
-export function DetailSection({
-  title,
-  action,
-  children,
-}: {
-  title: string
-  action?: ReactNode
-  children: ReactNode
-}) {
-  return (
-    <div className="rounded-2xl border border-border-subtle p-5" style={{ background: 'var(--color-elevated)' }}>
-      <div className="flex items-center justify-between gap-3">
-        <div className="text-[15px] font-semibold text-text">{title}</div>
-        {action}
-      </div>
-      <div className="mt-4">{children}</div>
-    </div>
-  )
-}
-
-export function DetailGroup({
-  label,
-  values,
-  empty = 'None',
-}: {
-  label: string
-  values: string[]
-  empty?: string
-}) {
-  return (
-    <div>
-      <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">{label}</div>
-      {values.length > 0 ? (
-        <div className="mt-2 flex flex-wrap gap-2">
-          {values.map((value) => (
-            <span key={`${label}-${value}`} className="rounded-full border border-border px-2.5 py-1 text-[11px] text-text-secondary">
-              {value}
-            </span>
-          ))}
-        </div>
-      ) : (
-        <div className="mt-2 text-[12px] text-text-muted">{empty}</div>
-      )}
-    </div>
-  )
-}
-
 export function buildAutomationAgentOptions(input: {
   builtinAgents: BuiltInAgentDetail[]
   customAgents: CustomAgentSummary[]
@@ -355,46 +282,6 @@ export function buildAutomationAgentOptions(input: {
 export function resolveAgentLabels(names: string[], options: AutomationAgentOption[]) {
   const labels = new Map(options.map((option) => [option.id, option.label.replace(/\s+\(unavailable\)$/i, '')]))
   return names.map((name) => labels.get(name) || formatAgentLabel(name))
-}
-
-export function AgentTeamSelector({
-  options,
-  value,
-  onChange,
-  emptyLabel = 'No specialist agents are available in this context yet.',
-}: {
-  options: AutomationAgentOption[]
-  value: string[]
-  onChange: (next: string[]) => void
-  emptyLabel?: string
-}) {
-  if (options.length === 0) {
-    return <div className="text-[12px] text-text-muted">{emptyLabel}</div>
-  }
-
-  return (
-    <div className="flex flex-wrap gap-2">
-      {options.map((option) => {
-        const selected = value.includes(option.id)
-        return (
-          <button
-            key={option.id}
-            type="button"
-            onClick={() => onChange(selected ? value.filter((entry) => entry !== option.id) : [...value, option.id])}
-            className="rounded-full border px-3 py-1.5 text-left transition-colors cursor-pointer"
-            style={{
-              borderColor: selected ? 'var(--color-accent)' : 'var(--color-border)',
-              background: selected ? 'color-mix(in srgb, var(--color-accent) 12%, var(--color-elevated))' : 'transparent',
-            }}
-            title={option.description}
-          >
-            <span className="text-[11px] font-medium text-text">{option.label}</span>
-            <span className="ml-2 text-[10px] uppercase tracking-[0.14em] text-text-muted">{option.source}</span>
-          </button>
-        )
-      })}
-    </div>
-  )
 }
 
 export function draftToPayload(draft: DraftState): AutomationDraft {


### PR DESCRIPTION
## Summary
- move pure automation board/detail helpers into `automation-view-model.ts`
- extract reusable detail cards/groups into `AutomationDetailPrimitives.tsx`
- extract the agent team selector into `AutomationAgentTeamSelector.tsx`
- remove the mixed JSX/helper `automations-page-support.tsx` module

## Validation
- pnpm test:renderer
- pnpm typecheck
- pnpm lint
- pnpm test:e2e
- git diff --check