### PR TITLE
Split public config projection helpers

### DIFF
--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -2,15 +2,19 @@ import electron from 'electron'
 import { cpSync, existsSync, mkdirSync, readFileSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join, resolve } from 'path'
-import type { BrandingConfig, ProviderDescriptor, ProviderModelDescriptor, PublicAppConfig } from '@open-cowork/shared'
-import { getCachedProviderCatalog, scheduleBackgroundRefresh } from './provider-catalog.ts'
+import type { ProviderModelDescriptor, PublicAppConfig } from '@open-cowork/shared'
+import {
+  buildConfiguredModelFallbacks,
+  buildProviderDescriptors,
+  buildPublicAppConfig,
+  findProviderDescriptor,
+  getProviderDynamicCatalogFromConfig,
+  resolveProviderDefaultModel as resolveProviderDefaultModelForConfig,
+} from './config-public.ts'
 import { validateConfigLayerInput, validateResolvedConfig } from './config-schema.ts'
 import { jsonConfigCandidates, readJsoncFile } from './jsonc.ts'
-import { modelInfoKeys } from './model-info-utils.ts'
-import { brandingAssetUrl } from './branding-assets.ts'
 import { DEFAULT_CONFIG } from './config-types.ts'
 import type {
-  ConfiguredProviderDescriptor,
   ConfiguredTool,
   ModelFallbackInfo,
   OpenCoworkConfig,
@@ -31,6 +35,8 @@ export type {
   ModelFallbackInfo,
   OpenCoworkConfig,
 } from './config-types.ts'
+
+export { normalizeProviderModelId } from './config-public.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
 
@@ -419,113 +425,17 @@ export function getAppDataDir() {
   return preferredDir
 }
 
-// Merge the descriptor's hardcoded `models[]` (marked featured) with the
-// latest cached dynamic catalog. Hardcoded entries take priority on
-// duplicate ids — the descriptor name wins, and the `featured` flag flags
-// it for pinning in the picker. The fetch itself is kicked off in the
-// background so subsequent reads eventually pick up fresh data.
-function mergeDescriptorModels(
-  providerId: string,
-  descriptor: ConfiguredProviderDescriptor,
-  invalidateCache: () => void,
-): ProviderModelDescriptor[] {
-  const featured: ProviderModelDescriptor[] = (descriptor.models || []).map((model) => ({
-    ...model,
-    featured: true,
-  }))
-  if (!descriptor.dynamicCatalog) return featured
-
-  const dynamic = getCachedProviderCatalog(providerId)
-  scheduleBackgroundRefresh(providerId, descriptor.dynamicCatalog, invalidateCache)
-
-  const seen = new Set(featured.map((entry) => entry.id))
-  const overlay = dynamic.filter((entry) => !seen.has(entry.id))
-  return [...featured, ...overlay]
-}
-
-export function normalizeProviderModelId(providerId: string, modelId: string) {
-  const trimmed = modelId.trim()
-  const prefix = `${providerId}/`
-  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed
-}
-
-function resolveModelFromCurrentCatalog(
-  providerId: string,
-  models: ProviderModelDescriptor[],
-  modelId: string | null | undefined,
-) {
-  if (!modelId?.trim()) return null
-  const normalized = normalizeProviderModelId(providerId, modelId)
-  if (models.length === 0) return normalized
-  return models.find((model) => model.id === modelId || model.id === normalized)?.id || null
-}
-
 export function resolveProviderDefaultModel(
   providerId: string,
   models: ProviderModelDescriptor[],
   runtimeDefaultModel?: string | null,
   options: { runtimeCatalogKnown?: boolean } = {},
 ) {
-  const config = getAppConfig()
-  const descriptorDefault = config.providers.descriptors?.[providerId]?.defaultModel
-  const customDefault = config.providers.custom?.[providerId]?.defaultModel
-  const globalDefault = providerId === config.providers.defaultProvider ? config.providers.defaultModel : null
-  const descriptorResolved = resolveModelFromCurrentCatalog(providerId, models, descriptorDefault)
-  if (descriptorResolved) return descriptorResolved
-  const customResolved = resolveModelFromCurrentCatalog(providerId, models, customDefault)
-  if (customResolved) return customResolved
-
-  const runtimeModels = options.runtimeCatalogKnown === false ? [] : models
-  const runtimeResolved = resolveModelFromCurrentCatalog(providerId, runtimeModels, runtimeDefaultModel)
-  if (runtimeResolved) return runtimeResolved
-
-  const globalResolved = resolveModelFromCurrentCatalog(providerId, models, globalDefault)
-  if (globalResolved) return globalResolved
-  return undefined
+  return resolveProviderDefaultModelForConfig(getAppConfig(), providerId, models, runtimeDefaultModel, options)
 }
 
-export function getProviderDescriptors(): ProviderDescriptor[] {
-  const config = getAppConfig()
-  return config.providers.available.map((providerId) => {
-    const builtin = config.providers.descriptors?.[providerId]
-    if (builtin) {
-      const models = mergeDescriptorModels(providerId, builtin, invalidatePublicConfigCache)
-      const defaultModel = resolveProviderDefaultModel(providerId, models)
-      return {
-        id: providerId,
-        name: builtin.name,
-        description: builtin.description,
-        credentials: builtin.credentials || [],
-        models,
-        ...(defaultModel ? { defaultModel } : {}),
-      }
-    }
-
-    const custom = config.providers.custom?.[providerId]
-    if (!custom) {
-      return {
-        id: providerId,
-        name: providerId,
-        description: 'Custom provider',
-        credentials: [],
-        models: [],
-      }
-    }
-
-    const models = Object.entries(custom.models || {}).map(([id, info]) => ({
-      id,
-      name: typeof info?.name === 'string' ? info.name : id,
-    }))
-    const defaultModel = resolveProviderDefaultModel(providerId, models)
-    return {
-      id: providerId,
-      name: custom.name,
-      description: custom.description || `${custom.name} custom provider`,
-      credentials: custom.credentials || [],
-      models,
-      ...(defaultModel ? { defaultModel } : {}),
-    }
-  })
+export function getProviderDescriptors() {
+  return buildProviderDescriptors(getAppConfig(), invalidatePublicConfigCache)
 }
 
 export function invalidatePublicConfigCache() {
@@ -533,33 +443,11 @@ export function invalidatePublicConfigCache() {
 }
 
 export function getProviderDynamicCatalog(providerId: string) {
-  const config = getAppConfig()
-  return config.providers.descriptors?.[providerId]?.dynamicCatalog || null
+  return getProviderDynamicCatalogFromConfig(getAppConfig(), providerId)
 }
 
 export function getProviderDescriptor(providerId: string | null | undefined) {
-  if (!providerId) return null
-  return getProviderDescriptors().find((provider) => provider.id === providerId) || null
-}
-
-function resolvePublicBranding(branding: BrandingConfig): BrandingConfig {
-  const top = branding.sidebar?.top
-  if (!top?.logoAsset) return branding
-
-  const logoUrl = brandingAssetUrl(top.logoAsset)
-  const nextTop = {
-    ...top,
-    ...(logoUrl
-      ? { logoUrl, logoDataUrl: undefined }
-      : {}),
-  }
-  return {
-    ...branding,
-    sidebar: {
-      ...branding.sidebar,
-      top: nextTop,
-    },
-  }
+  return findProviderDescriptor(getProviderDescriptors(), providerId)
 }
 
 export function getPublicAppConfig(): PublicAppConfig {
@@ -567,24 +455,7 @@ export function getPublicAppConfig(): PublicAppConfig {
   // getAppConfig() returns the fully loaded, already-expanded runtime config.
   // Keep the public view derived from that source of truth rather than
   // re-running placeholder resolution in a second code path.
-  const config = getAppConfig()
-  publicConfigCache = {
-    branding: resolvePublicBranding(config.branding),
-    auth: {
-      mode: config.auth.mode,
-      enabled: config.auth.mode !== 'none',
-    },
-    providers: {
-      available: getProviderDescriptors(),
-      defaultProvider: config.providers.defaultProvider,
-      defaultModel: config.providers.defaultModel,
-    },
-    agentStarterTemplates: config.agentStarterTemplates || [],
-    // Pass through the i18n overlay if present — renderer code reads
-    // `config.i18n` via the public-config IPC. Absent block is treated
-    // as "use inline English + host locale."
-    ...(config.i18n ? { i18n: config.i18n } : {}),
-  }
+  publicConfigCache = buildPublicAppConfig(getAppConfig(), getProviderDescriptors())
   return publicConfigCache
 }
 
@@ -656,55 +527,5 @@ export function resolveCustomProviderConfig(providerId: string) {
 }
 
 export function getConfiguredModelFallbacks(): ModelFallbackInfo {
-  const pricing: ModelFallbackInfo['pricing'] = {}
-  const contextLimits: ModelFallbackInfo['contextLimits'] = {}
-
-  const addModelInfo = (providerId: string | undefined, modelId: string, rawModel: unknown) => {
-    const model = rawModel as Record<string, any>
-    const cost = model?.cost
-    if (cost && typeof cost === 'object') {
-      const inputPer1M = typeof cost.input === 'number' ? cost.input : 0
-      const outputPer1M = typeof cost.output === 'number' ? cost.output : 0
-      const cachePer1M = typeof cost.cache_read === 'number' ? cost.cache_read : undefined
-      const cacheWritePer1M = typeof cost.cache_write === 'number' ? cost.cache_write : undefined
-      if (inputPer1M > 0 || outputPer1M > 0 || (cachePer1M || 0) > 0 || (cacheWritePer1M || 0) > 0) {
-        const modelPricing = {
-          inputPer1M,
-          outputPer1M,
-          ...(cachePer1M !== undefined ? { cachePer1M } : {}),
-          ...(cacheWritePer1M !== undefined ? { cacheWritePer1M } : {}),
-        }
-        for (const key of modelInfoKeys(providerId, modelId)) {
-          pricing[key] = modelPricing
-        }
-      }
-    }
-
-    const context = model?.limit?.context
-    if (typeof context === 'number' && context > 0) {
-      for (const key of modelInfoKeys(providerId, modelId)) {
-        contextLimits[key] = context
-      }
-    }
-  }
-
-  const config = getAppConfig()
-
-  for (const [providerId, descriptor] of Object.entries(config.providers.descriptors || {})) {
-    for (const model of descriptor.models || []) {
-      addModelInfo(providerId, model.id, model)
-    }
-  }
-
-  for (const [providerId, provider] of Object.entries(config.providers.custom || {})) {
-    for (const [modelId, rawModel] of Object.entries(provider.models || {})) {
-      addModelInfo(providerId, modelId, rawModel)
-    }
-  }
-
-  for (const [modelId, modelInfo] of Object.entries(config.providers.modelInfo || {})) {
-    addModelInfo(undefined, modelId, modelInfo)
-  }
-
-  return { pricing, contextLimits }
+  return buildConfiguredModelFallbacks(getAppConfig())
 }

--- a/apps/desktop/src/main/config-public.ts
+++ b/apps/desktop/src/main/config-public.ts
@@ -1,0 +1,232 @@
+import type {
+  BrandingConfig,
+  ProviderDescriptor,
+  ProviderModelDescriptor,
+  PublicAppConfig,
+} from '@open-cowork/shared'
+import { brandingAssetUrl } from './branding-assets.ts'
+import type {
+  ConfiguredProviderDescriptor,
+  ModelFallbackInfo,
+  OpenCoworkConfig,
+} from './config-types.ts'
+import { modelInfoKeys } from './model-info-utils.ts'
+import { getCachedProviderCatalog, scheduleBackgroundRefresh } from './provider-catalog.ts'
+
+// Merge the descriptor's hardcoded `models[]` (marked featured) with the
+// latest cached dynamic catalog. Hardcoded entries take priority on
+// duplicate ids — the descriptor name wins, and the `featured` flag flags
+// it for pinning in the picker. The fetch itself is kicked off in the
+// background so subsequent reads eventually pick up fresh data.
+function mergeDescriptorModels(
+  providerId: string,
+  descriptor: ConfiguredProviderDescriptor,
+  invalidateCache: () => void,
+): ProviderModelDescriptor[] {
+  const featured: ProviderModelDescriptor[] = (descriptor.models || []).map((model) => ({
+    ...model,
+    featured: true,
+  }))
+  if (!descriptor.dynamicCatalog) return featured
+
+  const dynamic = getCachedProviderCatalog(providerId)
+  scheduleBackgroundRefresh(providerId, descriptor.dynamicCatalog, invalidateCache)
+
+  const seen = new Set(featured.map((entry) => entry.id))
+  const overlay = dynamic.filter((entry) => !seen.has(entry.id))
+  return [...featured, ...overlay]
+}
+
+export function normalizeProviderModelId(providerId: string, modelId: string) {
+  const trimmed = modelId.trim()
+  const prefix = `${providerId}/`
+  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed
+}
+
+function resolveModelFromCurrentCatalog(
+  providerId: string,
+  models: ProviderModelDescriptor[],
+  modelId: string | null | undefined,
+) {
+  if (!modelId?.trim()) return null
+  const normalized = normalizeProviderModelId(providerId, modelId)
+  if (models.length === 0) return normalized
+  return models.find((model) => model.id === modelId || model.id === normalized)?.id || null
+}
+
+export function resolveProviderDefaultModel(
+  config: OpenCoworkConfig,
+  providerId: string,
+  models: ProviderModelDescriptor[],
+  runtimeDefaultModel?: string | null,
+  options: { runtimeCatalogKnown?: boolean } = {},
+) {
+  const descriptorDefault = config.providers.descriptors?.[providerId]?.defaultModel
+  const customDefault = config.providers.custom?.[providerId]?.defaultModel
+  const globalDefault = providerId === config.providers.defaultProvider ? config.providers.defaultModel : null
+  const descriptorResolved = resolveModelFromCurrentCatalog(providerId, models, descriptorDefault)
+  if (descriptorResolved) return descriptorResolved
+  const customResolved = resolveModelFromCurrentCatalog(providerId, models, customDefault)
+  if (customResolved) return customResolved
+
+  const runtimeModels = options.runtimeCatalogKnown === false ? [] : models
+  const runtimeResolved = resolveModelFromCurrentCatalog(providerId, runtimeModels, runtimeDefaultModel)
+  if (runtimeResolved) return runtimeResolved
+
+  const globalResolved = resolveModelFromCurrentCatalog(providerId, models, globalDefault)
+  if (globalResolved) return globalResolved
+  return undefined
+}
+
+export function buildProviderDescriptors(
+  config: OpenCoworkConfig,
+  invalidateCache: () => void,
+): ProviderDescriptor[] {
+  return config.providers.available.map((providerId) => {
+    const builtin = config.providers.descriptors?.[providerId]
+    if (builtin) {
+      const models = mergeDescriptorModels(providerId, builtin, invalidateCache)
+      const defaultModel = resolveProviderDefaultModel(config, providerId, models)
+      return {
+        id: providerId,
+        name: builtin.name,
+        description: builtin.description,
+        credentials: builtin.credentials || [],
+        models,
+        ...(defaultModel ? { defaultModel } : {}),
+      }
+    }
+
+    const custom = config.providers.custom?.[providerId]
+    if (!custom) {
+      return {
+        id: providerId,
+        name: providerId,
+        description: 'Custom provider',
+        credentials: [],
+        models: [],
+      }
+    }
+
+    const models = Object.entries(custom.models || {}).map(([id, info]) => ({
+      id,
+      name: typeof info?.name === 'string' ? info.name : id,
+    }))
+    const defaultModel = resolveProviderDefaultModel(config, providerId, models)
+    return {
+      id: providerId,
+      name: custom.name,
+      description: custom.description || `${custom.name} custom provider`,
+      credentials: custom.credentials || [],
+      models,
+      ...(defaultModel ? { defaultModel } : {}),
+    }
+  })
+}
+
+export function getProviderDynamicCatalogFromConfig(config: OpenCoworkConfig, providerId: string) {
+  return config.providers.descriptors?.[providerId]?.dynamicCatalog || null
+}
+
+export function findProviderDescriptor(
+  providers: ProviderDescriptor[],
+  providerId: string | null | undefined,
+) {
+  if (!providerId) return null
+  return providers.find((provider) => provider.id === providerId) || null
+}
+
+function resolvePublicBranding(branding: BrandingConfig): BrandingConfig {
+  const top = branding.sidebar?.top
+  if (!top?.logoAsset) return branding
+
+  const logoUrl = brandingAssetUrl(top.logoAsset)
+  const nextTop = {
+    ...top,
+    ...(logoUrl
+      ? { logoUrl, logoDataUrl: undefined }
+      : {}),
+  }
+  return {
+    ...branding,
+    sidebar: {
+      ...branding.sidebar,
+      top: nextTop,
+    },
+  }
+}
+
+export function buildPublicAppConfig(
+  config: OpenCoworkConfig,
+  providers: ProviderDescriptor[],
+): PublicAppConfig {
+  return {
+    branding: resolvePublicBranding(config.branding),
+    auth: {
+      mode: config.auth.mode,
+      enabled: config.auth.mode !== 'none',
+    },
+    providers: {
+      available: providers,
+      defaultProvider: config.providers.defaultProvider,
+      defaultModel: config.providers.defaultModel,
+    },
+    agentStarterTemplates: config.agentStarterTemplates || [],
+    // Pass through the i18n overlay if present — renderer code reads
+    // `config.i18n` via the public-config IPC. Absent block is treated
+    // as "use inline English + host locale."
+    ...(config.i18n ? { i18n: config.i18n } : {}),
+  }
+}
+
+export function buildConfiguredModelFallbacks(config: OpenCoworkConfig): ModelFallbackInfo {
+  const pricing: ModelFallbackInfo['pricing'] = {}
+  const contextLimits: ModelFallbackInfo['contextLimits'] = {}
+
+  const addModelInfo = (providerId: string | undefined, modelId: string, rawModel: unknown) => {
+    const model = rawModel as Record<string, any>
+    const cost = model?.cost
+    if (cost && typeof cost === 'object') {
+      const inputPer1M = typeof cost.input === 'number' ? cost.input : 0
+      const outputPer1M = typeof cost.output === 'number' ? cost.output : 0
+      const cachePer1M = typeof cost.cache_read === 'number' ? cost.cache_read : undefined
+      const cacheWritePer1M = typeof cost.cache_write === 'number' ? cost.cache_write : undefined
+      if (inputPer1M > 0 || outputPer1M > 0 || (cachePer1M || 0) > 0 || (cacheWritePer1M || 0) > 0) {
+        const modelPricing = {
+          inputPer1M,
+          outputPer1M,
+          ...(cachePer1M !== undefined ? { cachePer1M } : {}),
+          ...(cacheWritePer1M !== undefined ? { cacheWritePer1M } : {}),
+        }
+        for (const key of modelInfoKeys(providerId, modelId)) {
+          pricing[key] = modelPricing
+        }
+      }
+    }
+
+    const context = model?.limit?.context
+    if (typeof context === 'number' && context > 0) {
+      for (const key of modelInfoKeys(providerId, modelId)) {
+        contextLimits[key] = context
+      }
+    }
+  }
+
+  for (const [providerId, descriptor] of Object.entries(config.providers.descriptors || {})) {
+    for (const model of descriptor.models || []) {
+      addModelInfo(providerId, model.id, model)
+    }
+  }
+
+  for (const [providerId, provider] of Object.entries(config.providers.custom || {})) {
+    for (const [modelId, rawModel] of Object.entries(provider.models || {})) {
+      addModelInfo(providerId, modelId, rawModel)
+    }
+  }
+
+  for (const [modelId, modelInfo] of Object.entries(config.providers.modelInfo || {})) {
+    addModelInfo(undefined, modelId, modelInfo)
+  }
+
+  return { pricing, contextLimits }
+}


### PR DESCRIPTION
## Summary
- move provider descriptor projection, public config projection, and model fallback projection into config-public.ts
- keep config-loader.ts as the cache/merge/load API wrapper so existing callers keep their imports
- reduce config-loader.ts from 710 to 531 lines without changing merge order or runtime behavior

## Validation
- pnpm typecheck
- pnpm test -- tests/config-elements.test.ts tests/app-handlers.test.ts tests/runtime-config-builder.test.ts tests/provider-catalog.test.ts
- pnpm lint
- pnpm test:renderer
- git diff --check