### PR TITLE
Split provider IPC handlers

### DIFF
--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -5,16 +5,11 @@ import {
   MAX_CLIPBOARD_TEXT_LENGTH,
   MAX_SAVE_TEXT_BYTES,
   MAX_SAVE_TEXT_FILENAME_BYTES,
-  mergeRuntimeProviderModels,
   normalizeBoundedString,
   normalizeCredentialScopeId,
-  normalizeProviderAuthCode,
-  normalizeProviderAuthorization,
-  normalizeProviderAuthInputs,
-  normalizeProviderAuthMethod,
-  resolveKnownProviderId,
   resolveSafeSaveTextPath,
 } from './app-handler-support.ts'
+import { getPublicAppConfigWithRuntimeModels, registerProviderHandlers } from './provider-handlers.ts'
 import {
   getEffectiveSettings,
   getIntegrationCredentials,
@@ -25,9 +20,7 @@ import {
   type CoworkSettings,
 } from '../settings.ts'
 import { getClient, getModelInfoAsync } from '../runtime.ts'
-import { normalizeProviderListResponse } from '../provider-utils.ts'
-import { getConfigError, getProviderDynamicCatalog, getPublicAppConfig, invalidatePublicConfigCache } from '../config-loader.ts'
-import { refreshProviderCatalog } from '../provider-catalog.ts'
+import { getConfigError } from '../config-loader.ts'
 import { buildDiagnosticsBundle } from '../diagnostics-export.ts'
 import { getRuntimeStatus } from '../runtime-status.ts'
 import { getPerfSnapshot } from '../perf-metrics.ts'
@@ -57,23 +50,6 @@ async function loadAuthModule() {
 const electronShell = (electron as { shell?: typeof import('electron').shell }).shell
 const electronClipboard = (electron as { clipboard?: typeof import('electron').clipboard }).clipboard
 const electronApp = (electron as { app?: typeof import('electron').app }).app
-
-async function listRuntimeProviders() {
-  const client = getClient()
-  if (!client) return []
-  const result = await client.provider.list()
-  return normalizeProviderListResponse(result.data)
-}
-
-async function getPublicAppConfigWithRuntimeModels() {
-  const config = getPublicAppConfig()
-  try {
-    return mergeRuntimeProviderModels(config, await listRuntimeProviders())
-  } catch (err) {
-    log('provider', `Could not merge runtime provider models: ${err instanceof Error ? err.message : String(err)}`)
-    return config
-  }
-}
 
 export function registerAppHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('app:metadata', async () => {
@@ -170,18 +146,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('app:refresh-provider-catalog', async (_event, providerId: string) => {
-    const catalog = getProviderDynamicCatalog(providerId)
-    if (!catalog) return []
-    try {
-      const models = await refreshProviderCatalog(providerId, catalog)
-      invalidatePublicConfigCache()
-      return models
-    } catch (err) {
-      context.logHandlerError(`app:refresh-provider-catalog ${providerId}`, err)
-      return []
-    }
-  })
+  registerProviderHandlers(context, electronShell)
 
   context.ipcMain.handle('settings:get', async () => {
     // Default surface returns credentials masked so the raw API keys
@@ -231,82 +196,6 @@ export function registerAppHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('model:info', async () => {
     return getModelInfoAsync()
-  })
-
-  context.ipcMain.handle('provider:list', async () => {
-    try {
-      const data = await listRuntimeProviders()
-      log('provider', `Listed ${data.length} providers: ${data.map((provider) => `${provider.id || provider.name}(${Object.keys(provider.models || {}).length} models)`).join(', ')}`)
-      return data
-    } catch (err) {
-      context.logHandlerError('provider:list', err)
-      return []
-    }
-  })
-
-  context.ipcMain.handle('provider:auth-methods', async () => {
-    const client = getClient()
-    if (!client) return {}
-    try {
-      const result = await client.provider.auth()
-      return result.data || {}
-    } catch (err) {
-      context.logHandlerError('provider:auth-methods', err)
-      return {}
-    }
-  })
-
-  context.ipcMain.handle('provider:oauth-authorize', async (_event, providerIdInput: unknown, methodInput: unknown, inputsInput?: unknown) => {
-    const providerId = resolveKnownProviderId(providerIdInput)
-    const method = normalizeProviderAuthMethod(methodInput)
-    const inputs = normalizeProviderAuthInputs(inputsInput)
-    const client = getClient()
-    if (!client) throw new Error('OpenCode runtime is not running. Save your provider settings first, then try provider login again.')
-    try {
-      const result = await client.provider.oauth.authorize({
-        providerID: providerId,
-        method,
-        inputs,
-      })
-      const authorization = normalizeProviderAuthorization(result.data)
-      if (authorization?.url) {
-        try {
-          const parsed = new URL(authorization.url)
-          if (!['http:', 'https:'].includes(parsed.protocol)) {
-            throw new Error(`Unsupported auth URL protocol: ${parsed.protocol}`)
-          }
-          if (!electronShell) throw new Error('Electron shell API is unavailable')
-          await electronShell.openExternal(authorization.url)
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err)
-          log('security', `Blocked provider auth URL for ${providerId}: ${message}`)
-          throw new Error('Provider auth URL was blocked because it was not a valid http(s) URL.', { cause: err })
-        }
-      }
-      return authorization
-    } catch (err) {
-      context.logHandlerError(`provider:oauth-authorize ${providerId}`, err)
-      throw err
-    }
-  })
-
-  context.ipcMain.handle('provider:oauth-callback', async (_event, providerIdInput: unknown, methodInput: unknown, codeInput?: unknown) => {
-    const providerId = resolveKnownProviderId(providerIdInput)
-    const method = normalizeProviderAuthMethod(methodInput)
-    const code = normalizeProviderAuthCode(codeInput)
-    const client = getClient()
-    if (!client) throw new Error('OpenCode runtime is not running. Save your provider settings first, then try provider login again.')
-    try {
-      const result = await client.provider.oauth.callback({
-        providerID: providerId,
-        method,
-        code,
-      })
-      return Boolean(result.data)
-    } catch (err) {
-      context.logHandlerError(`provider:oauth-callback ${providerId}`, err)
-      throw err
-    }
   })
 
   context.ipcMain.handle('runtime:status', async () => {

--- a/apps/desktop/src/main/ipc/provider-handlers.ts
+++ b/apps/desktop/src/main/ipc/provider-handlers.ts
@@ -1,0 +1,124 @@
+import type { IpcHandlerContext } from './context.ts'
+import {
+  mergeRuntimeProviderModels,
+  normalizeProviderAuthCode,
+  normalizeProviderAuthorization,
+  normalizeProviderAuthInputs,
+  normalizeProviderAuthMethod,
+  resolveKnownProviderId,
+} from './app-handler-support.ts'
+import { getProviderDynamicCatalog, getPublicAppConfig, invalidatePublicConfigCache } from '../config-loader.ts'
+import { log } from '../logger.ts'
+import { refreshProviderCatalog } from '../provider-catalog.ts'
+import { normalizeProviderListResponse } from '../provider-utils.ts'
+import { getClient } from '../runtime.ts'
+
+type ElectronShell = typeof import('electron').shell
+
+async function listRuntimeProviders() {
+  const client = getClient()
+  if (!client) return []
+  const result = await client.provider.list()
+  return normalizeProviderListResponse(result.data)
+}
+
+export async function getPublicAppConfigWithRuntimeModels() {
+  const config = getPublicAppConfig()
+  try {
+    return mergeRuntimeProviderModels(config, await listRuntimeProviders())
+  } catch (err) {
+    log('provider', `Could not merge runtime provider models: ${err instanceof Error ? err.message : String(err)}`)
+    return config
+  }
+}
+
+export function registerProviderHandlers(context: IpcHandlerContext, electronShell: ElectronShell | undefined) {
+  context.ipcMain.handle('app:refresh-provider-catalog', async (_event, providerId: string) => {
+    const catalog = getProviderDynamicCatalog(providerId)
+    if (!catalog) return []
+    try {
+      const models = await refreshProviderCatalog(providerId, catalog)
+      invalidatePublicConfigCache()
+      return models
+    } catch (err) {
+      context.logHandlerError(`app:refresh-provider-catalog ${providerId}`, err)
+      return []
+    }
+  })
+
+  context.ipcMain.handle('provider:list', async () => {
+    try {
+      const data = await listRuntimeProviders()
+      log('provider', `Listed ${data.length} providers: ${data.map((provider) => `${provider.id || provider.name}(${Object.keys(provider.models || {}).length} models)`).join(', ')}`)
+      return data
+    } catch (err) {
+      context.logHandlerError('provider:list', err)
+      return []
+    }
+  })
+
+  context.ipcMain.handle('provider:auth-methods', async () => {
+    const client = getClient()
+    if (!client) return {}
+    try {
+      const result = await client.provider.auth()
+      return result.data || {}
+    } catch (err) {
+      context.logHandlerError('provider:auth-methods', err)
+      return {}
+    }
+  })
+
+  context.ipcMain.handle('provider:oauth-authorize', async (_event, providerIdInput: unknown, methodInput: unknown, inputsInput?: unknown) => {
+    const providerId = resolveKnownProviderId(providerIdInput)
+    const method = normalizeProviderAuthMethod(methodInput)
+    const inputs = normalizeProviderAuthInputs(inputsInput)
+    const client = getClient()
+    if (!client) throw new Error('OpenCode runtime is not running. Save your provider settings first, then try provider login again.')
+    try {
+      const result = await client.provider.oauth.authorize({
+        providerID: providerId,
+        method,
+        inputs,
+      })
+      const authorization = normalizeProviderAuthorization(result.data)
+      if (authorization?.url) {
+        try {
+          const parsed = new URL(authorization.url)
+          if (!['http:', 'https:'].includes(parsed.protocol)) {
+            throw new Error(`Unsupported auth URL protocol: ${parsed.protocol}`)
+          }
+          if (!electronShell) throw new Error('Electron shell API is unavailable')
+          await electronShell.openExternal(authorization.url)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          log('security', `Blocked provider auth URL for ${providerId}: ${message}`)
+          throw new Error('Provider auth URL was blocked because it was not a valid http(s) URL.', { cause: err })
+        }
+      }
+      return authorization
+    } catch (err) {
+      context.logHandlerError(`provider:oauth-authorize ${providerId}`, err)
+      throw err
+    }
+  })
+
+  context.ipcMain.handle('provider:oauth-callback', async (_event, providerIdInput: unknown, methodInput: unknown, codeInput?: unknown) => {
+    const providerId = resolveKnownProviderId(providerIdInput)
+    const method = normalizeProviderAuthMethod(methodInput)
+    const code = normalizeProviderAuthCode(codeInput)
+    const client = getClient()
+    if (!client) throw new Error('OpenCode runtime is not running. Save your provider settings first, then try provider login again.')
+    try {
+      const result = await client.provider.oauth.callback({
+        providerID: providerId,
+        method,
+        code,
+      })
+      return Boolean(result.data)
+    } catch (err) {
+      context.logHandlerError(`provider:oauth-callback ${providerId}`, err)
+      throw err
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- extract provider catalog and OAuth IPC registration from app-handlers into provider-handlers
- keep existing channel names and provider config merge behavior unchanged
- reduce app-handlers from 512 to 401 lines while leaving app/auth/settings/dialog/reset handlers in place

## Validation
- pnpm typecheck
- pnpm test -- tests/app-handlers.test.ts tests/ipc-handler-registration.test.ts tests/ipc-handler-behavior.test.ts
- pnpm lint
- pnpm test:renderer
- git diff --check