### PR TITLE
Split session interaction IPC handlers

### DIFF
--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -21,9 +21,7 @@ import {
 } from '../session-registry.ts'
 import { toIsoTimestamp } from '../task-run-utils.ts'
 import {
-  clearPermission,
   clearPermissionsForSession,
-  getPermissionSession,
 } from '../permission-tracker.ts'
 import { syncSessionView } from '../session-history-loader.ts'
 import { normalizeRuntimeCommands, normalizeSessionInfo, normalizeSessionMessages, normalizeShareUrl } from '../opencode-adapter.ts'
@@ -33,8 +31,8 @@ import { cleanupSandboxWorkspaceForSession } from '../sandbox-storage.ts'
 import { log } from '../logger.ts'
 import { ensureRuntimeContextDirectory } from '../runtime-context.ts'
 import { mergeSessionDiffsWithSynthetic } from '../session-diff-fallback.ts'
-import { normalizeQuestionAnswers, normalizeQuestionRequestId } from '../question-normalization.ts'
 import { registerSessionFileHandlers } from './session-file-handlers.ts'
+import { registerSessionInteractionHandlers } from './session-interaction-handlers.ts'
 import {
   normalizeCommandName,
   normalizePromptAgent,
@@ -43,18 +41,6 @@ import {
   normalizeSessionId,
   normalizeSessionTitle,
 } from './session-handler-validation.ts'
-
-function resolveQuestionLocally(context: IpcHandlerContext, sessionId: string, requestId: string) {
-  const win = context.getMainWindow()
-  dispatchRuntimeSessionEvent(win, {
-    type: 'question_resolved',
-    sessionId,
-    data: {
-      type: 'question_resolved',
-      id: requestId,
-    },
-  })
-}
 
 function resolvePromptModel(settings: ReturnType<typeof getEffectiveSettings>, runtimeProvider?: ProviderLike | null) {
   if (!settings.effectiveProviderId || !settings.effectiveModel) return null
@@ -638,69 +624,7 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('permission:respond', async (
-    _event,
-    permissionId: string,
-    allowed: boolean,
-    explicitSessionId?: string | null,
-  ) => {
-    const sessionId = explicitSessionId || getPermissionSession(permissionId)
-    if (!sessionId) throw new Error(`No session for permission ${permissionId}`)
-    const { client } = await context.getSessionV2Client(sessionId)
-
-    log('permission', `${allowed ? 'Approved' : 'Denied'} ${permissionId}`)
-    await client.permission.reply({
-      requestID: permissionId,
-      reply: allowed ? 'once' : 'reject',
-    }, {
-      throwOnError: true,
-    })
-    clearPermission(permissionId)
-    const resolvedSessionId = sessionEngine.resolveApproval(permissionId)
-    const win = context.getMainWindow()
-    if (resolvedSessionId && win && !win.isDestroyed()) {
-      dispatchRuntimeSessionEvent(win, {
-        type: 'approval_resolved',
-        sessionId: resolvedSessionId,
-        data: { type: 'approval_resolved', id: permissionId },
-      })
-    }
-  })
-
-  context.ipcMain.handle('question:reply', async (_event, sessionIdInput: unknown, requestIdInput: unknown, answersInput: unknown) => {
-    const sessionId = normalizeSessionId(sessionIdInput)
-    const requestId = normalizeQuestionRequestId(requestIdInput)
-    const answers = normalizeQuestionAnswers(answersInput)
-    const { client } = await context.getSessionV2Client(sessionId)
-    await client.question.reply({
-      requestID: requestId,
-      answers,
-    }, { throwOnError: true })
-    resolveQuestionLocally(context, sessionId, requestId)
-    startSessionStatusReconciliation(sessionId, {
-      getMainWindow: context.getMainWindow,
-      onIdle: (_win, reconciledSessionId) => {
-        context.reconcileIdleSession(reconciledSessionId)
-      },
-    })
-  })
-
-  context.ipcMain.handle('question:reject', async (_event, sessionIdInput: unknown, requestIdInput: unknown) => {
-    const sessionId = normalizeSessionId(sessionIdInput)
-    const requestId = normalizeQuestionRequestId(requestIdInput)
-    const { client } = await context.getSessionV2Client(sessionId)
-    await client.question.reject({
-      requestID: requestId,
-    }, { throwOnError: true })
-    resolveQuestionLocally(context, sessionId, requestId)
-    startSessionStatusReconciliation(sessionId, {
-      getMainWindow: context.getMainWindow,
-      onIdle: (_win, reconciledSessionId) => {
-        context.reconcileIdleSession(reconciledSessionId)
-      },
-    })
-  })
-
+  registerSessionInteractionHandlers(context)
   ipcCommandAndTodoHandlers(context)
 }
 

--- a/apps/desktop/src/main/ipc/session-interaction-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-interaction-handlers.ts
@@ -1,0 +1,85 @@
+import type { IpcHandlerContext } from './context.ts'
+import { normalizeSessionId } from './session-handler-validation.ts'
+import { normalizeQuestionAnswers, normalizeQuestionRequestId } from '../question-normalization.ts'
+import { clearPermission, getPermissionSession } from '../permission-tracker.ts'
+import { dispatchRuntimeSessionEvent } from '../session-event-dispatcher.ts'
+import { sessionEngine } from '../session-engine.ts'
+import { startSessionStatusReconciliation } from '../session-status-reconciler.ts'
+import { log } from '../logger.ts'
+
+function resolveQuestionLocally(context: IpcHandlerContext, sessionId: string, requestId: string) {
+  const win = context.getMainWindow()
+  dispatchRuntimeSessionEvent(win, {
+    type: 'question_resolved',
+    sessionId,
+    data: {
+      type: 'question_resolved',
+      id: requestId,
+    },
+  })
+}
+
+export function registerSessionInteractionHandlers(context: IpcHandlerContext) {
+  context.ipcMain.handle('permission:respond', async (
+    _event,
+    permissionId: string,
+    allowed: boolean,
+    explicitSessionId?: string | null,
+  ) => {
+    const sessionId = explicitSessionId || getPermissionSession(permissionId)
+    if (!sessionId) throw new Error(`No session for permission ${permissionId}`)
+    const { client } = await context.getSessionV2Client(sessionId)
+
+    log('permission', `${allowed ? 'Approved' : 'Denied'} ${permissionId}`)
+    await client.permission.reply({
+      requestID: permissionId,
+      reply: allowed ? 'once' : 'reject',
+    }, {
+      throwOnError: true,
+    })
+    clearPermission(permissionId)
+    const resolvedSessionId = sessionEngine.resolveApproval(permissionId)
+    const win = context.getMainWindow()
+    if (resolvedSessionId && win && !win.isDestroyed()) {
+      dispatchRuntimeSessionEvent(win, {
+        type: 'approval_resolved',
+        sessionId: resolvedSessionId,
+        data: { type: 'approval_resolved', id: permissionId },
+      })
+    }
+  })
+
+  context.ipcMain.handle('question:reply', async (_event, sessionIdInput: unknown, requestIdInput: unknown, answersInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
+    const requestId = normalizeQuestionRequestId(requestIdInput)
+    const answers = normalizeQuestionAnswers(answersInput)
+    const { client } = await context.getSessionV2Client(sessionId)
+    await client.question.reply({
+      requestID: requestId,
+      answers,
+    }, { throwOnError: true })
+    resolveQuestionLocally(context, sessionId, requestId)
+    startSessionStatusReconciliation(sessionId, {
+      getMainWindow: context.getMainWindow,
+      onIdle: (_win, reconciledSessionId) => {
+        context.reconcileIdleSession(reconciledSessionId)
+      },
+    })
+  })
+
+  context.ipcMain.handle('question:reject', async (_event, sessionIdInput: unknown, requestIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
+    const requestId = normalizeQuestionRequestId(requestIdInput)
+    const { client } = await context.getSessionV2Client(sessionId)
+    await client.question.reject({
+      requestID: requestId,
+    }, { throwOnError: true })
+    resolveQuestionLocally(context, sessionId, requestId)
+    startSessionStatusReconciliation(sessionId, {
+      getMainWindow: context.getMainWindow,
+      onIdle: (_win, reconciledSessionId) => {
+        context.reconcileIdleSession(reconciledSessionId)
+      },
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- move permission response and question reply/reject IPC registration into session-interaction-handlers
- keep the existing local question-resolution and approval-resolution behavior unchanged
- reduce session-handlers from 718 to 642 lines while leaving prompt/session lifecycle logic intact

## Validation
- pnpm typecheck
- pnpm test -- tests/ipc-handler-registration.test.ts tests/ipc-handler-behavior.test.ts
- pnpm lint
- pnpm test:renderer
- git diff --check