### PR TITLE
Split session command IPC handlers

### DIFF
--- a/apps/desktop/src/main/ipc/session-command-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-command-handlers.ts
@@ -1,0 +1,47 @@
+import type { IpcHandlerContext } from './context.ts'
+import { normalizeCommandName, normalizeSessionId } from './session-handler-validation.ts'
+import { trackParentSession } from '../event-task-state.ts'
+import { shortSessionId } from '../log-sanitizer.ts'
+import { normalizeRuntimeCommands } from '../opencode-adapter.ts'
+import { getClient } from '../runtime.ts'
+import { touchSessionRecord } from '../session-registry.ts'
+
+export function registerSessionCommandHandlers(context: IpcHandlerContext) {
+  context.ipcMain.handle('command:list', async () => {
+    const client = getClient()
+    if (!client) return []
+    try {
+      const result = await client.command.list()
+      return normalizeRuntimeCommands(result.data)
+    } catch (err) {
+      context.logHandlerError('command:list', err)
+      return []
+    }
+  })
+
+  context.ipcMain.handle('command:run', async (_event, sessionIdInput: unknown, commandNameInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
+    const commandName = normalizeCommandName(commandNameInput)
+    const { client } = await context.getSessionClient(sessionId)
+    try {
+      trackParentSession(sessionId)
+      await client.session.command({ sessionID: sessionId, command: commandName })
+      touchSessionRecord(sessionId)
+      return true
+    } catch (err) {
+      context.logHandlerError(`command:run ${shortSessionId(sessionId)}:${commandName}`, err)
+      return false
+    }
+  })
+
+  context.ipcMain.handle('session:todo', async (_event, sessionId: string) => {
+    const { client } = await context.getSessionClient(sessionId)
+    try {
+      const result = await client.session.todo({ sessionID: sessionId })
+      return result.data || []
+    } catch (err) {
+      context.logHandlerError(`session:todo ${shortSessionId(sessionId)}`, err)
+      return []
+    }
+  })
+}

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -24,17 +24,17 @@ import {
   clearPermissionsForSession,
 } from '../permission-tracker.ts'
 import { syncSessionView } from '../session-history-loader.ts'
-import { normalizeRuntimeCommands, normalizeSessionInfo, normalizeSessionMessages, normalizeShareUrl } from '../opencode-adapter.ts'
+import { normalizeSessionInfo, normalizeSessionMessages, normalizeShareUrl } from '../opencode-adapter.ts'
 import { shortSessionId } from '../log-sanitizer.ts'
 import { isInternalCoworkMessage } from '../internal-message-utils.ts'
 import { cleanupSandboxWorkspaceForSession } from '../sandbox-storage.ts'
 import { log } from '../logger.ts'
 import { ensureRuntimeContextDirectory } from '../runtime-context.ts'
 import { mergeSessionDiffsWithSynthetic } from '../session-diff-fallback.ts'
+import { registerSessionCommandHandlers } from './session-command-handlers.ts'
 import { registerSessionFileHandlers } from './session-file-handlers.ts'
 import { registerSessionInteractionHandlers } from './session-interaction-handlers.ts'
 import {
-  normalizeCommandName,
   normalizePromptAgent,
   normalizePromptAttachments,
   normalizePromptText,
@@ -557,32 +557,7 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
 
   registerSessionFileHandlers(context)
 
-  context.ipcMain.handle('command:list', async () => {
-    const client = getClient()
-    if (!client) return []
-    try {
-      const result = await client.command.list()
-      return normalizeRuntimeCommands(result.data)
-    } catch (err) {
-      context.logHandlerError('command:list', err)
-      return []
-    }
-  })
-
-  context.ipcMain.handle('command:run', async (_event, sessionIdInput: unknown, commandNameInput: unknown) => {
-    const sessionId = normalizeSessionId(sessionIdInput)
-    const commandName = normalizeCommandName(commandNameInput)
-    const { client } = await context.getSessionClient(sessionId)
-    try {
-      trackParentSession(sessionId)
-      await client.session.command({ sessionID: sessionId, command: commandName })
-      touchSessionRecord(sessionId)
-      return true
-    } catch (err) {
-      context.logHandlerError(`command:run ${shortSessionId(sessionId)}:${commandName}`, err)
-      return false
-    }
-  })
+  registerSessionCommandHandlers(context)
 
   context.ipcMain.handle('session:rename', async (_event, sessionIdInput: unknown, titleInput: unknown) => {
     const sessionId = normalizeSessionId(sessionIdInput)
@@ -625,18 +600,4 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
   })
 
   registerSessionInteractionHandlers(context)
-  ipcCommandAndTodoHandlers(context)
-}
-
-function ipcCommandAndTodoHandlers(context: IpcHandlerContext) {
-  context.ipcMain.handle('session:todo', async (_event, sessionId: string) => {
-    const { client } = await context.getSessionClient(sessionId)
-    try {
-      const result = await client.session.todo({ sessionID: sessionId })
-      return result.data || []
-    } catch (err) {
-      context.logHandlerError(`session:todo ${shortSessionId(sessionId)}`, err)
-      return []
-    }
-  })
 }

--- a/apps/desktop/tests/home-page.smoke.test.ts
+++ b/apps/desktop/tests/home-page.smoke.test.ts
@@ -8,7 +8,7 @@ import { launchSmokeApp } from './smoke-helpers.ts'
 // diagnostic dashboard that used to live here moved to PulsePage and
 // is covered by `pulse-page.smoke.test.ts`.
 
-test('home renders the greeting, composer, and status strip', async () => {
+test('home renders the greeting, composer, status strip, and no dashboard pills', async () => {
   const { page, cleanup } = await launchSmokeApp()
   try {
     // Greeting is a single stable line now (we tried rotating and it
@@ -35,15 +35,6 @@ test('home renders the greeting, composer, and status strip', async () => {
     // Status strip at the bottom links to Pulse. Copy can change but
     // the "Pulse" anchor should remain stable.
     await page.getByRole('button', { name: /Pulse/i }).first().waitFor({ timeout: 5_000 })
-  } finally {
-    await cleanup()
-  }
-})
-
-test('home does not surface the diagnostic dashboard pills', async () => {
-  const { page, cleanup } = await launchSmokeApp()
-  try {
-    await page.waitForSelector('h1', { timeout: 30_000 })
 
     // These headings used to live on Home and now only live on Pulse.
     // If they reappear on Home, the redesign regressed.


### PR DESCRIPTION
## Summary
- move command:list, command:run, and session:todo IPC registration into session-command-handlers
- keep OpenCode command/todo SDK calls and session touch behavior unchanged
- reduce session-handlers from 642 to 603 lines after the previous splits

## Validation
- pnpm typecheck
- pnpm test -- tests/ipc-handler-registration.test.ts tests/ipc-handler-behavior.test.ts
- pnpm lint
- pnpm test:renderer
- git diff --check