### PR TITLE
Use stable renderer list keys

### DIFF
--- a/apps/desktop/src/renderer/components/agents/AgentAttributeBar.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentAttributeBar.tsx
@@ -25,11 +25,12 @@ export function AgentAttributeBar({ value, label, icon, tone = 'var(--color-acce
       </span>
       <span className="w-[78px] uppercase tracking-[0.08em]">{label}</span>
       <span className="flex items-center gap-[3px]">
-        {Array.from({ length: SEGMENTS }).map((_, index) => {
-          const isOn = index < filled
+        {Array.from({ length: SEGMENTS }).map((_, segmentOffset) => {
+          const segmentNumber = segmentOffset + 1
+          const isOn = segmentOffset < filled
           return (
             <span
-              key={index}
+              key={`segment-${segmentNumber}`}
               className="inline-block w-[10px] h-[6px] rounded-sm"
               style={{
                 background: isOn

--- a/apps/desktop/src/renderer/components/chat/ChatView.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatView.tsx
@@ -281,10 +281,7 @@ export function ChatView() {
     return expandedTaskGroups[key] ?? true
   }
 
-  const renderTimelineItem = (
-    item: TimelineItem,
-    index: number,
-  ): ReactNode => {
+  const renderTimelineItem = (item: TimelineItem): ReactNode => {
     switch (item.kind) {
       case 'message':
         return (
@@ -295,7 +292,7 @@ export function ChatView() {
           />
         )
       case 'tools':
-        return <ToolTrace key={`trace-${item.data[0]?.id || index}`} tools={item.data} />
+        return <ToolTrace key={`trace-${item.data[0]?.id || 'empty'}`} tools={item.data} />
       case 'task':
         return (
           <MissionControl
@@ -311,7 +308,7 @@ export function ChatView() {
       case 'task_group':
         return (
           <MissionControl
-            key={`task-group-${item.data[0]?.id || index}`}
+            key={`task-group-${taskGroupKey(item.data) || 'empty'}`}
             taskRuns={item.data}
             agentVisuals={agentVisuals}
             expanded={isTaskGroupExpanded(item.data)}
@@ -457,7 +454,7 @@ export function ChatView() {
                     }}
                   >
                     <div className="mx-auto px-6" style={{ maxWidth: transcriptMaxWidth }}>
-                      <div className="py-[5px]">{renderTimelineItem(item, vRow.index)}</div>
+                      <div className="py-[5px]">{renderTimelineItem(item)}</div>
                     </div>
                   </div>
                 )
@@ -470,7 +467,7 @@ export function ChatView() {
             </div>
           ) : (
             <div className="mx-auto px-6 py-4 flex flex-col gap-2.5" style={{ maxWidth: transcriptMaxWidth }}>
-              {timeline.map((item, i) => renderTimelineItem(item, i))}
+              {timeline.map((item) => renderTimelineItem(item))}
               {isGenerating && <ThinkingIndicator />}
             </div>
           )}

--- a/apps/desktop/src/renderer/components/chat/DiffViewer.tsx
+++ b/apps/desktop/src/renderer/components/chat/DiffViewer.tsx
@@ -21,6 +21,20 @@ type ViewMode = 'unified' | 'split'
 // lines" affordance so the user can scroll past the churn.
 const HUNK_GAP_THRESHOLD = 4
 
+function keyFragment(value: string) {
+  return `${value.length}:${value.slice(0, 64)}:${value.slice(-64)}`
+}
+
+function diffRowKey(row: DiffRow) {
+  return `${row.kind}:${row.oldLine ?? '-'}:${row.newLine ?? '-'}:${keyFragment(row.content)}`
+}
+
+function diffHunkKey(hunk: DiffHunk) {
+  const firstRow = hunk.rows[0] ? diffRowKey(hunk.rows[0]) : 'empty'
+  const lastRow = hunk.rows[hunk.rows.length - 1] ? diffRowKey(hunk.rows[hunk.rows.length - 1]!) : 'empty'
+  return `${hunk.header}:${hunk.rows.length}:${firstRow}:${lastRow}`
+}
+
 interface Props {
   sessionId: string
   // When present, scopes the diff to changes introduced by a single message
@@ -195,7 +209,7 @@ const DiffFileRow = memo(function DiffFileRow({
                 const gap = prev ? computeHunkGap(prev, hunk) : null
                 const gapBig = gap && gap.hiddenLines >= HUNK_GAP_THRESHOLD
                 return (
-                  <div key={i}>
+                  <div key={diffHunkKey(hunk)}>
                     {gapBig ? (
                       <HunkGapRow
                         sessionId={sessionId}
@@ -235,17 +249,17 @@ function UnifiedHunkBlock({ hunk }: { hunk: DiffHunk }) {
         {hunk.header}
       </div>
       <div>
-        {pairs.map((entry, i) => {
+        {pairs.map((entry) => {
           if (entry.kind === 'pair') {
             const wordDiff = diffWordsInLinePair(entry.remove.content, entry.add.content)
             return (
-              <div key={i}>
+              <div key={`pair:${diffRowKey(entry.remove)}:${diffRowKey(entry.add)}`}>
                 <UnifiedRow row={entry.remove} segments={wordDiff.removedSegments} />
                 <UnifiedRow row={entry.add} segments={wordDiff.addedSegments} />
               </div>
             )
           }
-          return <UnifiedRow key={i} row={entry.row} />
+          return <UnifiedRow key={`single:${diffRowKey(entry.row)}`} row={entry.row} />
         })}
       </div>
     </div>
@@ -287,8 +301,11 @@ function SplitHunkBlock({ hunk }: { hunk: DiffHunk }) {
         {hunk.header}
       </div>
       <div>
-        {columns.map((entry, i) => (
-          <SplitRowPair key={i} entry={entry} />
+        {columns.map((entry) => (
+          <SplitRowPair
+            key={`split:${entry.left ? diffRowKey(entry.left) : 'blank'}:${entry.right ? diffRowKey(entry.right) : 'blank'}`}
+            entry={entry}
+          />
         ))}
       </div>
     </div>
@@ -382,15 +399,18 @@ function LineNumberCell({ value }: { value: number | null }) {
 }
 
 function renderSegments(segments: WordDiffSegment[], ownedKind: 'remove' | 'add' | 'context') {
-  return segments.map((segment, i) => {
-    if (segment.kind === 'same') return <span key={i}>{segment.text}</span>
+  let offset = 0
+  return segments.map((segment) => {
+    const key = `${segment.kind}:${offset}:${keyFragment(segment.text)}`
+    offset += segment.text.length
+    if (segment.kind === 'same') return <span key={key}>{segment.text}</span>
     // Only render our own side's changed segments as emphasized — the
     // cross-side segment is ignored so we don't leak highlight onto
     // an incorrect side.
     if (ownedKind === 'remove' && segment.kind === 'removed') {
       return (
         <span
-          key={i}
+          key={key}
           style={{
             background: 'color-mix(in srgb, var(--color-red) 24%, transparent)',
             fontWeight: 600,
@@ -403,7 +423,7 @@ function renderSegments(segments: WordDiffSegment[], ownedKind: 'remove' | 'add'
     if (ownedKind === 'add' && segment.kind === 'added') {
       return (
         <span
-          key={i}
+          key={key}
           style={{
             background: 'color-mix(in srgb, var(--color-green) 24%, transparent)',
             fontWeight: 600,
@@ -515,14 +535,18 @@ function HunkGapRow({
   if (expanded && snippet) {
     return (
       <div>
-        {snippet.map((content, i) => (
-          <div key={i} className="flex">
-            <LineNumberCell value={gap.startOldLine + i} />
-            <LineNumberCell value={gap.startNewLine + i} />
-            <span className="shrink-0 text-center select-none" style={{ width: MARKER_COL }}> </span>
-            <span className="whitespace-pre pr-4" style={{ color: 'var(--color-text-secondary)' }}>{content}</span>
-          </div>
-        ))}
+        {snippet.map((content, snippetOffset) => {
+          const oldLine = gap.startOldLine + snippetOffset
+          const newLine = gap.startNewLine + snippetOffset
+          return (
+            <div key={`snippet:${oldLine}:${newLine}`} className="flex">
+              <LineNumberCell value={oldLine} />
+              <LineNumberCell value={newLine} />
+              <span className="shrink-0 text-center select-none" style={{ width: MARKER_COL }}> </span>
+              <span className="whitespace-pre pr-4" style={{ color: 'var(--color-text-secondary)' }}>{content}</span>
+            </div>
+          )
+        })}
         <button
           onClick={() => setExpanded(false)}
           className="w-full text-center text-[10px] py-1 text-text-muted hover:text-text cursor-pointer"

--- a/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
@@ -4,16 +4,36 @@ import { MessageActions } from './MessageActions'
 
 import type { Message } from '../../stores/session'
 
+type Attachment = import('../../stores/session').MessageAttachment
+
+function keyFragment(value: string) {
+  return `${value.length}:${value.slice(0, 48)}:${value.slice(-48)}`
+}
+
+function attachmentRenderKey(prefix: string, attachment: Attachment, seen: Map<string, number>) {
+  const base = [
+    prefix,
+    attachment.filename || 'unnamed',
+    attachment.mime,
+    keyFragment(attachment.url),
+  ].join(':')
+  const occurrence = seen.get(base) || 0
+  seen.set(base, occurrence + 1)
+  return occurrence === 0 ? base : `${base}:${occurrence + 1}`
+}
+
 function AttachmentGrid({ attachments }: { attachments: import('../../stores/session').MessageAttachment[] }) {
   const images = attachments.filter(a => a.mime.startsWith('image/'))
   const files = attachments.filter(a => !a.mime.startsWith('image/'))
+  const imageKeys = new Map<string, number>()
+  const fileKeys = new Map<string, number>()
 
   return (
     <div className="flex flex-col gap-2">
       {images.length > 0 && (
         <div className={`grid gap-1.5 ${images.length === 1 ? 'grid-cols-1' : images.length === 2 ? 'grid-cols-2' : 'grid-cols-3'}`}>
-          {images.map((img, i) => (
-            <img key={i} src={img.url} alt={img.filename}
+          {images.map((img) => (
+            <img key={attachmentRenderKey('image', img, imageKeys)} src={img.url} alt={img.filename}
               className="rounded-lg object-cover w-full border border-white/10"
               style={{ maxHeight: images.length === 1 ? 300 : 160 }} />
           ))}
@@ -21,8 +41,8 @@ function AttachmentGrid({ attachments }: { attachments: import('../../stores/ses
       )}
       {files.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
-          {files.map((f, i) => (
-            <div key={i} className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px]"
+          {files.map((f) => (
+            <div key={attachmentRenderKey('file', f, fileKeys)} className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px]"
               style={{ background: 'var(--color-surface-active)', color: 'var(--color-text-secondary)' }}>
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><path d="M7 1H3a1 1 0 00-1 1v8a1 1 0 001 1h6a1 1 0 001-1V4L7 1z"/><polyline points="7,1 7,4 10,4"/></svg>
               {f.filename}

--- a/apps/desktop/src/renderer/components/chat/ToolTrace.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolTrace.tsx
@@ -27,6 +27,23 @@ function cachedChart(tool: ToolCall) {
   return parsed
 }
 
+type ToolAttachment = NonNullable<ToolCall['attachments']>[number]
+
+function keyFragment(value: string) {
+  return `${value.length}:${value.slice(0, 48)}:${value.slice(-48)}`
+}
+
+function toolAttachmentKey(attachment: ToolAttachment, seen: Map<string, number>) {
+  const base = [
+    attachment.filename || 'attachment',
+    attachment.mime || 'unknown',
+    keyFragment(attachment.url),
+  ].join(':')
+  const occurrence = seen.get(base) || 0
+  seen.set(base, occurrence + 1)
+  return occurrence === 0 ? base : `${base}:${occurrence + 1}`
+}
+
 interface Props {
   tools: ToolCall[]
   compact?: boolean
@@ -267,10 +284,11 @@ export function ToolTrace({ tools, compact = false }: Props) {
         }
         // Image attachments always visible
         if (tool.attachments?.some(a => a.mime?.startsWith('image/'))) {
+          const imageAttachmentKeys = new Map<string, number>()
           return (
             <div key={`att-${tool.id}`}>
-              {tool.attachments.filter(a => a.mime?.startsWith('image/')).map((att, i) => (
-                <div key={i} className="mt-1 mb-1">
+              {tool.attachments.filter(a => a.mime?.startsWith('image/')).map((att) => (
+                <div key={toolAttachmentKey(att, imageAttachmentKeys)} className="mt-1 mb-1">
                   <img src={att.url} alt={att.filename || 'attachment'} className="rounded-lg max-w-full border border-border-subtle" style={{ maxHeight: 400 }} />
                 </div>
               ))}

--- a/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
@@ -7,6 +7,15 @@ import { PluginIcon } from './PluginIcon'
 const inputClass = 'w-full px-3 py-2 rounded-lg text-[12px] bg-elevated border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-border'
 const VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
+type KeyValueDraft = { id: string; key: string; value: string }
+
+let nextKeyValueDraftId = 0
+
+function createKeyValueDraft(key = '', value = ''): KeyValueDraft {
+  nextKeyValueDraftId += 1
+  return { id: `custom-mcp-field-${nextKeyValueDraftId}`, key, value }
+}
+
 export function CustomMcpForm({
   onSave,
   onCancel,
@@ -35,16 +44,16 @@ export function CustomMcpForm({
   const [command, setCommand] = useState(existing?.command || '')
   const [args, setArgs] = useState((existing?.args || []).join(' '))
   const [url, setUrl] = useState(existing?.url || '')
-  const [envPairs, setEnvPairs] = useState<Array<{ key: string; value: string }>>(
+  const [envPairs, setEnvPairs] = useState<KeyValueDraft[]>(() => (
     existing?.env && Object.keys(existing.env).length > 0
-      ? Object.entries(existing.env).map(([key, value]) => ({ key, value }))
-      : [{ key: '', value: '' }],
-  )
-  const [headerPairs, setHeaderPairs] = useState<Array<{ key: string; value: string }>>(
+      ? Object.entries(existing.env).map(([key, value]) => createKeyValueDraft(key, value))
+      : [createKeyValueDraft()]
+  ))
+  const [headerPairs, setHeaderPairs] = useState<KeyValueDraft[]>(() => (
     existing?.headers && Object.keys(existing.headers).length > 0
-      ? Object.entries(existing.headers).map(([key, value]) => ({ key, value }))
-      : [{ key: '', value: '' }],
-  )
+      ? Object.entries(existing.headers).map(([key, value]) => createKeyValueDraft(key, value))
+      : [createKeyValueDraft()]
+  ))
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
   const [existingNames, setExistingNames] = useState<string[]>([])
@@ -381,13 +390,13 @@ export function CustomMcpForm({
                   </label>
                   <div className="flex flex-col gap-2">
                     <span className="text-[11px] text-text-muted">{t('mcpForm.envVars', 'Environment variables')}</span>
-                    {envPairs.map((pair, index) => (
-                      <div key={index} className="flex gap-2">
-                        <input type="text" value={pair.key} onChange={(e) => { const next = [...envPairs]; next[index].key = e.target.value; setEnvPairs(next) }} placeholder="GITHUB_TOKEN" className={`${inputClass} flex-1`} />
-                        <input type="password" value={pair.value} onChange={(e) => { const next = [...envPairs]; next[index].value = e.target.value; setEnvPairs(next) }} placeholder={t('mcpForm.envValuePlaceholder', 'value')} className={`${inputClass} flex-1`} />
+                    {envPairs.map((pair) => (
+                      <div key={pair.id} className="flex gap-2">
+                        <input type="text" value={pair.key} onChange={(e) => setEnvPairs((current) => current.map((entry) => entry.id === pair.id ? { ...entry, key: e.target.value } : entry))} placeholder="GITHUB_TOKEN" className={`${inputClass} flex-1`} />
+                        <input type="password" value={pair.value} onChange={(e) => setEnvPairs((current) => current.map((entry) => entry.id === pair.id ? { ...entry, value: e.target.value } : entry))} placeholder={t('mcpForm.envValuePlaceholder', 'value')} className={`${inputClass} flex-1`} />
                       </div>
                     ))}
-                    <button onClick={() => setEnvPairs([...envPairs, { key: '', value: '' }])} className="text-[11px] text-accent cursor-pointer text-start">+ Add variable</button>
+                    <button onClick={() => setEnvPairs((current) => [...current, createKeyValueDraft()])} className="text-[11px] text-accent cursor-pointer text-start">+ Add variable</button>
                   </div>
                   {authModeAvailable ? (
                     // Label + checkbox are explicitly paired via htmlFor/id;
@@ -422,13 +431,13 @@ export function CustomMcpForm({
                   </label>
                   <div className="flex flex-col gap-2">
                     <span className="text-[11px] text-text-muted">{t('mcpForm.headers', 'Headers')}</span>
-                    {headerPairs.map((pair, index) => (
-                      <div key={index} className="flex gap-2">
-                        <input type="text" value={pair.key} onChange={(e) => { const next = [...headerPairs]; next[index].key = e.target.value; setHeaderPairs(next) }} placeholder="Authorization" className={`${inputClass} flex-1`} />
-                        <input type="password" value={pair.value} onChange={(e) => { const next = [...headerPairs]; next[index].value = e.target.value; setHeaderPairs(next) }} placeholder="Bearer ..." className={`${inputClass} flex-1`} />
+                    {headerPairs.map((pair) => (
+                      <div key={pair.id} className="flex gap-2">
+                        <input type="text" value={pair.key} onChange={(e) => setHeaderPairs((current) => current.map((entry) => entry.id === pair.id ? { ...entry, key: e.target.value } : entry))} placeholder="Authorization" className={`${inputClass} flex-1`} />
+                        <input type="password" value={pair.value} onChange={(e) => setHeaderPairs((current) => current.map((entry) => entry.id === pair.id ? { ...entry, value: e.target.value } : entry))} placeholder="Bearer ..." className={`${inputClass} flex-1`} />
                       </div>
                     ))}
-                    <button onClick={() => setHeaderPairs([...headerPairs, { key: '', value: '' }])} className="text-[11px] text-accent cursor-pointer text-start">+ Add header</button>
+                    <button onClick={() => setHeaderPairs((current) => [...current, createKeyValueDraft()])} className="text-[11px] text-accent cursor-pointer text-start">+ Add header</button>
                     <div className="text-[10px] text-text-muted">
                       Leave headers blank for remote MCPs that use OpenCode&apos;s browser-based OAuth flow. After
                       saving, authenticate the MCP from the status panel once the runtime reloads.

--- a/apps/desktop/src/renderer/components/plugins/CustomSkillForm.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomSkillForm.tsx
@@ -17,6 +17,15 @@ function isSafeRelativePath(value: string) {
 
 const VALID_SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
+type SkillFileDraft = { id: string; path: string; content: string }
+
+let nextSkillFileDraftId = 0
+
+function createSkillFileDraft(path = '', content = ''): SkillFileDraft {
+  nextSkillFileDraftId += 1
+  return { id: `custom-skill-file-${nextSkillFileDraftId}`, path, content }
+}
+
 const DEFAULT_SKILL_CONTENT = `---
 name: my-skill
 description: "Describe what this skill does and when to use it."
@@ -62,7 +71,9 @@ export function CustomSkillForm({
   )
   const [name, setName] = useState(existing?.name || '')
   const [content, setContent] = useState(existing?.content || DEFAULT_SKILL_CONTENT)
-  const [files, setFiles] = useState<Array<{ path: string; content: string }>>(existing?.files?.map((file) => ({ ...file })) || [])
+  const [files, setFiles] = useState<SkillFileDraft[]>(() => (
+    existing?.files?.map((file) => createSkillFileDraft(file.path, file.content)) || []
+  ))
   // Ids of tools this skill needs. Persisted into SKILL.md frontmatter
   // on save; loaded back from frontmatter when the form is used to edit
   // an existing skill. The agent builder reads this list via the
@@ -370,7 +381,7 @@ export function CustomSkillForm({
                   <div className="text-[11px] text-text-muted mt-1">Add optional references, examples, templates, or helper files inside this bundle.</div>
                 </div>
                 <button
-                  onClick={() => setFiles((current) => [...current, { path: '', content: '' }])}
+                  onClick={() => setFiles((current) => [...current, createSkillFileDraft()])}
                   className="text-[11px] text-accent cursor-pointer"
                 >
                   + Add file
@@ -380,11 +391,11 @@ export function CustomSkillForm({
               {files.length > 0 ? (
                 <div className="flex flex-col gap-3">
                   {files.map((file, index) => (
-                    <div key={index} className="rounded-xl border border-border-subtle bg-elevated p-3">
+                    <div key={file.id} className="rounded-xl border border-border-subtle bg-elevated p-3">
                       <div className="flex items-center justify-between gap-3 mb-2">
                         <div className="text-[11px] text-text-secondary">File {index + 1}</div>
                         <button
-                          onClick={() => setFiles((current) => current.filter((_, entryIndex) => entryIndex !== index))}
+                          onClick={() => setFiles((current) => current.filter((entry) => entry.id !== file.id))}
                           className="text-[11px] text-text-muted hover:text-red cursor-pointer"
                         >
                           Remove
@@ -394,13 +405,13 @@ export function CustomSkillForm({
                         <input
                           type="text"
                           value={file.path}
-                          onChange={(event) => setFiles((current) => current.map((entry, entryIndex) => entryIndex === index ? { ...entry, path: event.target.value } : entry))}
+                          onChange={(event) => setFiles((current) => current.map((entry) => entry.id === file.id ? { ...entry, path: event.target.value } : entry))}
                           placeholder="references/example.md"
                           className="w-full px-3 py-2 rounded-lg text-[12px] bg-surface border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-border"
                         />
                         <textarea
                           value={file.content}
-                          onChange={(event) => setFiles((current) => current.map((entry, entryIndex) => entryIndex === index ? { ...entry, content: event.target.value } : entry))}
+                          onChange={(event) => setFiles((current) => current.map((entry) => entry.id === file.id ? { ...entry, content: event.target.value } : entry))}
                           rows={8}
                           placeholder={t('skillForm.fileContents', 'File contents')}
                           className="w-full min-h-[180px] px-3 py-2 rounded-lg text-[11px] font-mono bg-surface border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-border resize-y leading-relaxed"
@@ -439,7 +450,7 @@ export function CustomSkillForm({
                   {populatedFiles.length > 0 ? (
                     <div className="flex flex-col gap-1">
                       {populatedFiles.map((file) => (
-                        <div key={file.path || file.content} className="text-[10px] text-text-muted">{file.path || 'Unnamed file'}</div>
+                        <div key={file.id} className="text-[10px] text-text-muted">{file.path || 'Unnamed file'}</div>
                       ))}
                     </div>
                   ) : (


### PR DESCRIPTION
## Summary
- replace index-based React keys in mutable renderer lists with stable content/local ids
- keep editable MCP env/header rows and skill bundle file rows stable across add/remove edits
- avoid full data URLs or long diff lines in keys by using bounded key fragments

## Validation
- pnpm typecheck
- pnpm --dir apps/desktop exec vitest run --config vitest.renderer.config.ts src/renderer/components/chat/MessageBubble.test.tsx src/renderer/components/chat/DiffViewer.test.tsx src/renderer/components/chat/ToolTrace.test.tsx src/renderer/components/plugins/CustomMcpForm.test.tsx src/renderer/components/sidebar/SettingsPanel.test.tsx
- pnpm lint
- pnpm test:renderer
- git diff --check
- rg -n "key=\{i\}|key=\{index\}|key=\{[^}]*Index|key=\{[^}]*index|key=\{[^}]*i\}" apps/desktop/src/renderer/components