### PR TITLE
Use exact task metadata binding

### DIFF
--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -178,11 +178,6 @@ function computeBindingScore(
   if (normalizedHints.title && candidateTitle) {
     if (normalizedHints.title === candidateTitle) {
       score += 3
-    } else if (
-      normalizedHints.title.includes(candidateTitle)
-      || candidateTitle.includes(normalizedHints.title)
-    ) {
-      score += 2
     }
   }
 

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -217,7 +217,6 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     if (partAgent && childAgent && partAgent === childAgent) score += 4
     if (partTitle && childTitle) {
       if (partTitle === childTitle) score += 3
-      else if (partTitle.includes(childTitle) || childTitle.includes(partTitle)) score += 2
     }
     return score
   }
@@ -241,7 +240,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       }
     }
     if (best && !ambiguous) return best
-    return available[0] || null
+    return null
   }
 
   for (const rawMsg of rootMessages) {

--- a/tests/event-task-state.test.ts
+++ b/tests/event-task-state.test.ts
@@ -158,6 +158,37 @@ test('binds same-parent sibling child sessions by metadata instead of raw FIFO',
   assert.equal(boundA?.childSessionId, 'child-a')
 })
 
+test('does not bind same-parent sibling sessions from partial task titles', () => {
+  trackParentSession('root-session')
+
+  registerTaskRun({
+    id: 'task-a',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'Prepare European forecast',
+    agent: null,
+    childSessionId: null,
+    status: 'queued',
+  })
+  registerTaskRun({
+    id: 'task-b',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'Build chart pack',
+    agent: null,
+    childSessionId: null,
+    status: 'queued',
+  })
+
+  const bound = queueOrBindChildSession('root-session', 'child-partial', {
+    title: 'European forecast',
+  })
+
+  assert.equal(bound, null)
+  assert.equal(getTaskRun('task-a')?.childSessionId, null)
+  assert.equal(getTaskRun('task-b')?.childSessionId, null)
+})
+
 test('registerTaskRun binds queued same-parent child sessions by metadata when sessions arrive first', () => {
   trackParentSession('root-session')
 

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -209,3 +209,47 @@ test('history projector binds simultaneous same-parent child sessions by task me
   assert.equal(taskTexts.find((item) => item.content === 'child-market result')?.taskRunId, 'child:child-market')
   assert.equal(taskTexts.find((item) => item.content === 'child-sports result')?.taskRunId, 'child:child-sports')
 })
+
+test('history projector does not reorder child sessions from partial task titles', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-5',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-msg-5', role: 'assistant', time: { created: 1 } },
+      parts: [
+        { id: 'subtask-market', type: 'subtask', description: 'Summarize market lineage in detail' },
+        { id: 'subtask-sports', type: 'subtask', description: 'Summarize sports lineage' },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      { id: 'child-sports', title: 'Summarize sports lineage', parentSessionId: 'root-5', time: { created: 2, updated: 5 } },
+      { id: 'child-market', title: 'Summarize market lineage', parentSessionId: 'root-5', time: { created: 3, updated: 6 } },
+    ],
+    statuses: {
+      'root-5': { type: 'idle' },
+      'child-sports': { type: 'idle' },
+      'child-market': { type: 'idle' },
+    },
+    loadChildSnapshot: async (childId) => ({
+      messages: [{
+        info: { id: `${childId}-msg`, role: 'assistant', time: { created: childId === 'child-sports' ? 4 : 5 } },
+        parts: [
+          { id: `${childId}-text`, type: 'text', text: `${childId} result` },
+          { id: `${childId}-finish`, type: 'step-finish', reason: 'stop', tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } } },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const taskRuns = items.filter((item) => item.type === 'task_run').map((item) => item.taskRun).filter(Boolean)
+  assert.deepEqual(
+    taskRuns.map((taskRun) => ({ source: taskRun?.sourceSessionId, title: taskRun?.title })),
+    [
+      { source: null, title: 'Summarize market lineage in detail' },
+      { source: 'child-sports', title: 'Summarize sports lineage' },
+      { source: 'child-market', title: 'Summarize market lineage' },
+    ],
+  )
+})


### PR DESCRIPTION
## Summary
- remove partial-title substring scoring from live task-run binding
- remove partial-title substring scoring from history replay child binding
- add regressions proving partial titles do not bind or reorder child sessions

## Validation
- pnpm test -- tests/event-task-state.test.ts tests/session-history-projector.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- git diff --check