### PR TITLE
Harden replay and provider diagnostics

### DIFF
--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -156,19 +156,13 @@ export function buildProviderRuntimeConfig(
   })
 
   // Diagnostic breadcrumb so "token rejected" errors can be distinguished
-  // from "host URL mangled" — without leaking credentials. `baseURL` is
-  // logged verbatim (it's a public endpoint); secrets are reported as a
-  // fingerprint — length plus first/last 4 chars — enough to spot a
-  // truncated / trailing-newline / wrong-token case without exposing the
-  // full value.
-  const fingerprint = (value: string) => (
-    value.length <= 10
-      ? `<len ${value.length}>`
-      : `<len ${value.length} ${value.slice(0, 4)}…${value.slice(-4)}>`
-  )
+  // from "host URL mangled" without leaking credential prefixes/suffixes.
+  // `baseURL` is logged verbatim because it is a public endpoint; every
+  // other string option is reduced to length-only metadata.
+  const redactedLength = (value: string) => `<len=${value.length} redacted>`
   const optionsShape = Object.entries(options).map(([key, value]) => {
     if (key === 'baseURL' && typeof value === 'string') return `${key}=${value}`
-    if (typeof value === 'string') return `${key}=${fingerprint(value)}`
+    if (typeof value === 'string') return `${key}=${redactedLength(value)}`
     return `${key}=<${typeof value}>`
   })
   log('runtime', `provider=${providerId} options {${optionsShape.join(', ')}}`)

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -1,11 +1,13 @@
 import { resolveDisplayCostForModel } from './pricing-core.ts'
 import { isInternalCoworkMessage } from './internal-message-utils.ts'
 import {
+  normalizeTodoItems,
   normalizeSessionMessages,
   normalizeSessionStatuses,
   type NormalizedMessagePart,
   type NormalizedSessionMessage,
 } from './opencode-adapter.ts'
+import type { TodoItem } from '@open-cowork/shared'
 import {
   chooseTaskTitle,
   extractAgentName,
@@ -45,7 +47,7 @@ export type ProjectedHistoryItem = {
   modelId?: string | null
   taskRunId?: string
   taskRun?: TaskRunSnapshot
-  todos?: any[]
+  todos?: TodoItem[]
   tool?: {
     name: string
     input: Record<string, unknown>
@@ -360,14 +362,17 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   }
 
   if (rootTodos.length > 0) {
-    const todosTs = Date.now()
-    pushItem({
-      type: 'todos',
-      id: `todos:${sessionId}`,
-      timestamp: toIsoTimestamp(todosTs),
-      sequence: nextOrder(),
-      todos: rootTodos,
-    }, todosTs)
+    const todos = normalizeTodoItems(rootTodos)
+    if (todos.length > 0) {
+      const todosTs = Date.now()
+      pushItem({
+        type: 'todos',
+        id: `todos:${sessionId}`,
+        timestamp: toIsoTimestamp(todosTs),
+        sequence: nextOrder(),
+        todos,
+      }, todosTs)
+    }
   }
 
   for (const child of children) {
@@ -392,6 +397,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
   for (const [taskId, child] of childByTaskId.entries()) {
     const { messages: childMessages, todos: childTodos } = await loadChildSnapshot(child.id)
+    const normalizedChildTodos = normalizeTodoItems(childTodos)
     const taskRunItem = taskRunItems.get(taskId)
     let childHasTerminalStop = false
 
@@ -533,7 +539,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       taskRunItem.taskRun.finishedAt = timing.finishedAt
     }
 
-    if (childTodos.length > 0) {
+    if (normalizedChildTodos.length > 0) {
       const todoSortTime = toSortTime(child.time?.updated || child.time?.created || Date.now())
       pushItem({
         type: 'task_todos',
@@ -541,7 +547,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         timestamp: toIsoTimestamp(todoSortTime),
         sequence: nextOrder(),
         taskRunId: taskId,
-        todos: childTodos,
+        todos: normalizedChildTodos,
       }, todoSortTime)
     }
   }

--- a/tests/runtime-config-builder.test.ts
+++ b/tests/runtime-config-builder.test.ts
@@ -454,19 +454,35 @@ test('buildProviderRuntimeConfig bridges custom provider credentials into env pl
   clearConfigCaches()
 
   // Settings holds the token the user actually entered in the UI.
+  const storedToken = 'ui-token-fresh-sensitive-tail'
   saveSettings({
     providerCredentials: {
-      'bridge-provider': { token: 'ui-token-fresh' },
+      'bridge-provider': { token: storedToken },
     },
   })
 
   try {
-    const runtimeConfig = buildRuntimeConfig() as Record<string, any>
+    const capturedLogs: string[] = []
+    const originalConsoleLog = console.log
+    let runtimeConfig: Record<string, any> | null = null
+    try {
+      console.log = (...args: unknown[]) => {
+        capturedLogs.push(args.map(String).join(' '))
+      }
+      runtimeConfig = buildRuntimeConfig() as Record<string, any>
+    } finally {
+      console.log = originalConsoleLog
+    }
+    assert.ok(runtimeConfig)
     assert.equal(
       runtimeConfig.provider['bridge-provider'].options.apiKey,
-      'ui-token-fresh',
+      storedToken,
       'stored credential must win over process.env',
     )
+    const runtimeLogs = capturedLogs.join('\n')
+    assert.match(runtimeLogs, new RegExp(`apiKey=<len=${storedToken.length} redacted>`))
+    assert.doesNotMatch(runtimeLogs, /ui-token/)
+    assert.doesNotMatch(runtimeLogs, /tail/)
   } finally {
     saveSettings(originalSettings)
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -253,3 +253,48 @@ test('history projector does not reorder child sessions from partial task titles
     ],
   )
 })
+
+test('history projector normalizes replayed todo snapshots', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-todos',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [],
+    rootTodos: [
+      { id: 'root-todo-1', content: 'Review docs', status: 'pending', priority: 'high', ignored: true },
+      { content: 'Missing priority', status: 'pending' },
+      'not-a-todo',
+    ],
+    children: [
+      { id: 'child-todos', title: 'Review docs child', parentSessionId: 'root-todos', time: { created: 2, updated: 3 } },
+    ],
+    statuses: {
+      'root-todos': { type: 'idle' },
+      'child-todos': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({
+      messages: [],
+      todos: [
+        { id: 'child-todo-1', content: 'Summarize notes', status: 'in_progress', priority: 'medium' },
+        { content: 'Missing status', priority: 'low' },
+      ],
+    }),
+  })
+
+  const rootTodos = items.find((item) => item.type === 'todos')?.todos
+  assert.equal(rootTodos?.length, 1)
+  assert.deepEqual(rootTodos?.[0], {
+    id: 'root-todo-1',
+    content: 'Review docs',
+    status: 'pending',
+    priority: 'high',
+  })
+
+  const childTodos = items.find((item) => item.type === 'task_todos')?.todos
+  assert.equal(childTodos?.length, 1)
+  assert.deepEqual(childTodos?.[0], {
+    id: 'child-todo-1',
+    content: 'Summarize notes',
+    status: 'in_progress',
+    priority: 'medium',
+  })
+})


### PR DESCRIPTION
## Summary
- normalize root and child todo snapshots during session history replay
- replace the loose projected todo shape with the shared TodoItem contract
- redact custom provider string diagnostics to length-only metadata instead of prefix/suffix fingerprints
- add regression tests for malformed replayed todos and provider log redaction

## Validation
- pnpm test -- tests/runtime-config-builder.test.ts tests/session-history-projector.test.ts
- pnpm test -- tests/session-history-projector.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check