### PR TITLE
Version automation SQLite schema

### DIFF
--- a/apps/desktop/src/main/automation-store-db.ts
+++ b/apps/desktop/src/main/automation-store-db.ts
@@ -5,6 +5,8 @@ import { getAppDataDir } from './config-loader.ts'
 
 let automationDb: DatabaseSync | null = null
 let automationTransactionCounter = 0
+export const AUTOMATION_DB_SCHEMA_VERSION = 2
+const AUTOMATION_SCHEMA_VERSION_KEY = 'schema_version'
 
 function getAutomationDbPath() {
   const dir = getAppDataDir()
@@ -26,110 +28,100 @@ function ensureColumn(db: DatabaseSync, table: string, column: string, definitio
   db.exec(`alter table ${table} add column ${column} ${definition}`)
 }
 
+function ensureSchemaVersionTable(db: DatabaseSync) {
+  db.exec(`
+    create table if not exists automation_meta (
+      key text primary key,
+      value text not null
+    );
+  `)
+}
+
+function readAutomationSchemaVersion(db: DatabaseSync) {
+  const row = db.prepare('select value from automation_meta where key = ?')
+    .get(AUTOMATION_SCHEMA_VERSION_KEY) as { value?: string } | undefined
+  const version = Number(row?.value || 0)
+  return Number.isInteger(version) && version >= 0 ? version : 0
+}
+
+function assertSupportedAutomationSchemaVersion(db: DatabaseSync) {
+  const version = readAutomationSchemaVersion(db)
+  if (version > AUTOMATION_DB_SCHEMA_VERSION) {
+    throw new Error(`Automation database schema version ${version} is newer than supported version ${AUTOMATION_DB_SCHEMA_VERSION}.`)
+  }
+}
+
+function recordAutomationSchemaVersion(db: DatabaseSync) {
+  db.prepare(`
+    insert into automation_meta (key, value)
+    values (?, ?)
+    on conflict(key) do update set value = excluded.value
+  `).run(AUTOMATION_SCHEMA_VERSION_KEY, String(AUTOMATION_DB_SCHEMA_VERSION))
+}
+
 export function getDb() {
   if (automationDb) return automationDb
   const dbPath = getAutomationDbPath()
   const db = new DatabaseSync(dbPath)
-  db.exec('pragma journal_mode = WAL;')
-  db.exec(`
-    create table if not exists automations (
-      id text primary key,
-      title text not null,
-      goal text not null,
-      kind text not null,
-      status text not null,
-      paused_from_status text,
-      schedule_json text not null,
-      heartbeat_minutes integer not null,
-      retry_max_attempts integer not null default 3,
-      retry_base_delay_minutes integer not null default 5,
-      retry_max_delay_minutes integer not null default 60,
-      run_daily_run_cap integer not null default 6,
-      run_max_duration_minutes integer not null default 120,
-      execution_mode text not null,
-      autonomy_policy text not null,
-      project_directory text,
-      preferred_agents_json text not null default '[]',
-      created_at text not null,
-      updated_at text not null,
-      next_run_at text,
-      last_run_at text,
-      next_heartbeat_at text,
-      last_heartbeat_at text,
-      latest_run_id text,
-      latest_run_status text,
-      latest_session_id text
-    );
-
-    create table if not exists automation_briefs (
-      automation_id text primary key,
-      brief_json text not null,
-      updated_at text not null
-    );
-
-    create table if not exists automation_runs (
-      id text primary key,
-      automation_id text not null,
-      session_id text,
-      kind text not null,
-      status text not null,
-      title text not null,
-      summary text,
-      error text,
-      failure_code text,
-      attempt integer not null default 1,
-      retry_of_run_id text,
-      next_retry_at text,
-      created_at text not null,
-      started_at text,
-      finished_at text
-    );
-
-    create table if not exists automation_work_items (
-      id text not null,
-      automation_id text not null,
-      run_id text,
-      title text not null,
-      description text not null,
-      status text not null,
-      blocking_reason text,
-      owner_agent text,
-      depends_on_json text not null,
-      created_at text not null,
-      updated_at text not null,
-      primary key (automation_id, id)
-    );
-
-    create table if not exists automation_inbox (
-      id text primary key,
-      automation_id text not null,
-      run_id text,
-      session_id text,
-      question_id text,
-      type text not null,
-      status text not null,
-      title text not null,
-      body text not null,
-      created_at text not null,
-      updated_at text not null
-    );
-
-    create table if not exists automation_deliveries (
-      id text primary key,
-      automation_id text not null,
-      run_id text,
-      provider text not null,
-      target text not null,
-      status text not null,
-      title text not null,
-      body text not null,
-      created_at text not null
-    );
-  `)
-  const workItemsSql = db.prepare("select sql from sqlite_master where type = 'table' and name = 'automation_work_items'").get() as { sql?: string } | undefined
-  if (!workItemsSql?.sql?.includes('primary key (automation_id, id)')) {
+  try {
+    db.exec('pragma journal_mode = WAL;')
+    ensureSchemaVersionTable(db)
+    assertSupportedAutomationSchemaVersion(db)
     db.exec(`
-      create table automation_work_items_v2 (
+      create table if not exists automations (
+        id text primary key,
+        title text not null,
+        goal text not null,
+        kind text not null,
+        status text not null,
+        paused_from_status text,
+        schedule_json text not null,
+        heartbeat_minutes integer not null,
+        retry_max_attempts integer not null default 3,
+        retry_base_delay_minutes integer not null default 5,
+        retry_max_delay_minutes integer not null default 60,
+        run_daily_run_cap integer not null default 6,
+        run_max_duration_minutes integer not null default 120,
+        execution_mode text not null,
+        autonomy_policy text not null,
+        project_directory text,
+        preferred_agents_json text not null default '[]',
+        created_at text not null,
+        updated_at text not null,
+        next_run_at text,
+        last_run_at text,
+        next_heartbeat_at text,
+        last_heartbeat_at text,
+        latest_run_id text,
+        latest_run_status text,
+        latest_session_id text
+      );
+
+      create table if not exists automation_briefs (
+        automation_id text primary key,
+        brief_json text not null,
+        updated_at text not null
+      );
+
+      create table if not exists automation_runs (
+        id text primary key,
+        automation_id text not null,
+        session_id text,
+        kind text not null,
+        status text not null,
+        title text not null,
+        summary text,
+        error text,
+        failure_code text,
+        attempt integer not null default 1,
+        retry_of_run_id text,
+        next_retry_at text,
+        created_at text not null,
+        started_at text,
+        finished_at text
+      );
+
+      create table if not exists automation_work_items (
         id text not null,
         automation_id text not null,
         run_id text,
@@ -143,31 +135,80 @@ export function getDb() {
         updated_at text not null,
         primary key (automation_id, id)
       );
-      insert into automation_work_items_v2 (
-        id, automation_id, run_id, title, description, status, blocking_reason, owner_agent, depends_on_json, created_at, updated_at
-      )
-      select id, automation_id, run_id, title, description, status, blocking_reason, owner_agent, depends_on_json, created_at, updated_at
-      from automation_work_items;
-      drop table automation_work_items;
-      alter table automation_work_items_v2 rename to automation_work_items;
+
+      create table if not exists automation_inbox (
+        id text primary key,
+        automation_id text not null,
+        run_id text,
+        session_id text,
+        question_id text,
+        type text not null,
+        status text not null,
+        title text not null,
+        body text not null,
+        created_at text not null,
+        updated_at text not null
+      );
+
+      create table if not exists automation_deliveries (
+        id text primary key,
+        automation_id text not null,
+        run_id text,
+        provider text not null,
+        target text not null,
+        status text not null,
+        title text not null,
+        body text not null,
+        created_at text not null
+      );
     `)
+    const workItemsSql = db.prepare("select sql from sqlite_master where type = 'table' and name = 'automation_work_items'").get() as { sql?: string } | undefined
+    if (!workItemsSql?.sql?.includes('primary key (automation_id, id)')) {
+      db.exec(`
+        create table automation_work_items_v2 (
+          id text not null,
+          automation_id text not null,
+          run_id text,
+          title text not null,
+          description text not null,
+          status text not null,
+          blocking_reason text,
+          owner_agent text,
+          depends_on_json text not null,
+          created_at text not null,
+          updated_at text not null,
+          primary key (automation_id, id)
+        );
+        insert into automation_work_items_v2 (
+          id, automation_id, run_id, title, description, status, blocking_reason, owner_agent, depends_on_json, created_at, updated_at
+        )
+        select id, automation_id, run_id, title, description, status, blocking_reason, owner_agent, depends_on_json, created_at, updated_at
+        from automation_work_items;
+        drop table automation_work_items;
+        alter table automation_work_items_v2 rename to automation_work_items;
+      `)
+    }
+    ensureColumn(db, 'automations', 'paused_from_status', 'text')
+    ensureColumn(db, 'automations', 'next_heartbeat_at', 'text')
+    ensureColumn(db, 'automations', 'last_heartbeat_at', 'text')
+    ensureColumn(db, 'automations', 'retry_max_attempts', 'integer not null default 3')
+    ensureColumn(db, 'automations', 'retry_base_delay_minutes', 'integer not null default 5')
+    ensureColumn(db, 'automations', 'retry_max_delay_minutes', 'integer not null default 60')
+    ensureColumn(db, 'automations', 'run_daily_run_cap', 'integer not null default 6')
+    ensureColumn(db, 'automations', 'run_max_duration_minutes', 'integer not null default 120')
+    ensureColumn(db, 'automations', 'preferred_agents_json', `text not null default '[]'`)
+    ensureColumn(db, 'automation_runs', 'attempt', 'integer not null default 1')
+    ensureColumn(db, 'automation_runs', 'retry_of_run_id', 'text')
+    ensureColumn(db, 'automation_runs', 'next_retry_at', 'text')
+    ensureColumn(db, 'automation_runs', 'failure_code', 'text')
+    recordAutomationSchemaVersion(db)
+    ensureAutomationDbFileModes(dbPath)
+    automationDb = db
+    return db
+  } catch (error) {
+    db.close()
+    throw error
   }
-  ensureColumn(db, 'automations', 'paused_from_status', 'text')
-  ensureColumn(db, 'automations', 'next_heartbeat_at', 'text')
-  ensureColumn(db, 'automations', 'last_heartbeat_at', 'text')
-  ensureColumn(db, 'automations', 'retry_max_attempts', 'integer not null default 3')
-  ensureColumn(db, 'automations', 'retry_base_delay_minutes', 'integer not null default 5')
-  ensureColumn(db, 'automations', 'retry_max_delay_minutes', 'integer not null default 60')
-  ensureColumn(db, 'automations', 'run_daily_run_cap', 'integer not null default 6')
-  ensureColumn(db, 'automations', 'run_max_duration_minutes', 'integer not null default 120')
-  ensureColumn(db, 'automations', 'preferred_agents_json', `text not null default '[]'`)
-  ensureColumn(db, 'automation_runs', 'attempt', 'integer not null default 1')
-  ensureColumn(db, 'automation_runs', 'retry_of_run_id', 'text')
-  ensureColumn(db, 'automation_runs', 'next_retry_at', 'text')
-  ensureColumn(db, 'automation_runs', 'failure_code', 'text')
-  ensureAutomationDbFileModes(dbPath)
-  automationDb = db
-  return db
 }
 
 export function withTransaction<T>(callback: (db: DatabaseSync) => T): T {

--- a/tests/automation-store.test.ts
+++ b/tests/automation-store.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { existsSync, rmSync, statSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { existsSync, mkdirSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
@@ -31,7 +32,7 @@ import {
   updateAutomation,
   updateAutomationStatus,
 } from '../apps/desktop/src/main/automation-store.ts'
-import { getDb } from '../apps/desktop/src/main/automation-store-db.ts'
+import { AUTOMATION_DB_SCHEMA_VERSION, getDb } from '../apps/desktop/src/main/automation-store-db.ts'
 
 function uniqueUserDataDir(name: string) {
   return join(tmpdir(), `open-cowork-automation-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
@@ -402,6 +403,59 @@ test('automation store keeps SQLite files private', { skip: process.platform ===
         assert.equal(statSync(sidecar).mode & 0o777, 0o600)
       }
     }
+  } finally {
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('automation store records an explicit SQLite schema version', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('schema-version')
+
+  try {
+    resetAutomationStore(userDataDir)
+    const row = getDb().prepare('select value from automation_meta where key = ?')
+      .get('schema_version') as { value?: string } | undefined
+    assert.equal(Number(row?.value), AUTOMATION_DB_SCHEMA_VERSION)
+  } finally {
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('automation store rejects databases from a newer schema version', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('future-schema-version')
+  const dbPath = join(userDataDir, 'automation.sqlite')
+
+  try {
+    mkdirSync(userDataDir, { recursive: true })
+    const db = new DatabaseSync(dbPath)
+    try {
+      db.exec(`
+        create table automation_meta (
+          key text primary key,
+          value text not null
+        );
+      `)
+      db.prepare('insert into automation_meta (key, value) values (?, ?)')
+        .run('schema_version', String(AUTOMATION_DB_SCHEMA_VERSION + 1))
+    } finally {
+      db.close()
+    }
+
+    resetAutomationStore(userDataDir)
+    assert.throws(
+      () => getDb(),
+      /newer than supported/,
+    )
   } finally {
     clearAutomationStoreCache()
     clearConfigCaches()


### PR DESCRIPTION
## Summary
- record the automation SQLite schema version in an automation_meta table
- fail closed when opening a database created by a newer schema before migrations mutate it
- add regression coverage for schema-version persistence and future-version rejection

## Validation
- pnpm test -- tests/automation-store.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check