### PR TITLE
Version persisted settings state

### DIFF
--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -25,11 +25,20 @@ export type { AgentColor }
 
 let settingsCache: AppSettings | null = null
 
+export const SETTINGS_SCHEMA_VERSION = 1
+
 type NativePermissionDefault = 'allow' | 'ask' | 'deny'
 const MAX_SETTINGS_MAP_ENTRIES = 64
 const MAX_SETTINGS_KEY_BYTES = 256
 const MAX_SETTINGS_VALUE_BYTES = 64 * 1024
 const QUIET_HOURS_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+
+class UnsupportedSettingsSchemaVersionError extends Error {
+  constructor(version: number) {
+    super(`Settings schema version ${version} is newer than supported version ${SETTINGS_SCHEMA_VERSION}.`)
+    this.name = 'UnsupportedSettingsSchemaVersionError'
+  }
+}
 
 export function nativePermissionEnabledByDefault(policy: NativePermissionDefault) {
   return policy !== 'deny'
@@ -58,6 +67,7 @@ function createDefaults(): AppSettings {
   const defaultProvider = config.providers.defaultProvider
   const defaultProviderDescriptor = config.providers.available.find((provider) => provider.id === defaultProvider)
   return {
+    _schemaVersion: SETTINGS_SCHEMA_VERSION,
     selectedProviderId: defaultProvider,
     selectedModelId: defaultProviderDescriptor?.defaultModel || config.providers.defaultModel,
     providerCredentials: {},
@@ -74,6 +84,24 @@ function createDefaults(): AppSettings {
     defaultAutomationAutonomyPolicy: 'review-first',
     defaultAutomationExecutionMode: 'planning_only',
   }
+}
+
+function readSettingsSchemaVersion(raw: unknown) {
+  if (!raw || typeof raw !== 'object') return 0
+  const value = (raw as { _schemaVersion?: unknown })._schemaVersion
+  if (typeof value !== 'number') return 0
+  return Number.isInteger(value) && value >= 0 ? value : 0
+}
+
+function assertSupportedSettingsSchemaVersion(raw: unknown) {
+  const version = readSettingsSchemaVersion(raw)
+  if (version > SETTINGS_SCHEMA_VERSION) {
+    throw new UnsupportedSettingsSchemaVersionError(version)
+  }
+}
+
+function isUnsupportedSettingsSchemaVersionError(error: unknown) {
+  return error instanceof UnsupportedSettingsSchemaVersionError
 }
 
 function normalizeBoolMap(value: unknown): Record<string, boolean> {
@@ -152,9 +180,11 @@ function normalizeSettingsUpdate(settings: Partial<AppSettings>) {
 }
 
 function migrateLegacySettings(raw: any): AppSettings {
+  assertSupportedSettingsSchemaVersion(raw)
   const defaults = createDefaults()
   const next: AppSettings = {
     ...defaults,
+    _schemaVersion: SETTINGS_SCHEMA_VERSION,
     selectedProviderId: typeof raw?.selectedProviderId === 'string'
       ? raw.selectedProviderId
       : typeof raw?.provider === 'string'
@@ -340,6 +370,7 @@ export function loadSettings(): AppSettings {
       settingsCache = result
       return result
     } catch (err: unknown) {
+      if (isUnsupportedSettingsSchemaVersionError(err)) throw err
       log('error', `Settings load failed: ${err instanceof Error ? err.message : String(err)}`)
     }
   }
@@ -354,6 +385,7 @@ export function loadSettings(): AppSettings {
         saveSettings(result)
         return result
       } catch (err: unknown) {
+        if (isUnsupportedSettingsSchemaVersionError(err)) throw err
         log('error', `Settings legacy load failed: ${err instanceof Error ? err.message : String(err)}`)
       }
     }
@@ -373,6 +405,7 @@ export function saveSettings(settings: Partial<AppSettings>) {
   const merged: AppSettings = {
     ...current,
     ...updates,
+    _schemaVersion: SETTINGS_SCHEMA_VERSION,
     providerCredentials: mergeNestedStringMaps(current.providerCredentials, stripMaskedValues(updates.providerCredentials)),
     integrationCredentials: mergeNestedStringMaps(current.integrationCredentials, stripMaskedValues(updates.integrationCredentials)),
     integrationEnabled: { ...current.integrationEnabled, ...(updates.integrationEnabled || {}) },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -709,6 +709,9 @@ export interface PublicAppConfig {
 }
 
 export interface AppSettings {
+  // Persisted settings schema version. Missing means a legacy settings
+  // payload and is migrated by the main process on load.
+  _schemaVersion?: number
   selectedProviderId: string | null
   selectedModelId: string | null
   providerCredentials: Record<string, Record<string, string>>

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 
@@ -157,6 +157,69 @@ test('saveSettings normalizes renderer updates before persistence', async () => 
     assert.equal(after.providerCredentials.openrouter.apiKey, 'valid-key')
     assert.equal(after.providerCredentials.openrouter.oversized, undefined)
     assert.equal(after.unexpectedTopLevel, undefined)
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('saveSettings records an explicit persisted schema version', async () => {
+  const tempRoot = testTempDir('opencowork-settings-schema-version-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeEmptyConfig(configDir)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, saveSettings, SETTINGS_SCHEMA_VERSION } = await importFreshSettingsModule('schema-version')
+    assert.equal(loadSettings()._schemaVersion, SETTINGS_SCHEMA_VERSION)
+    saveSettings({ enableBash: false })
+    const persisted = JSON.parse(readFileSync(join(userDataDir, 'settings.json'), 'utf-8'))
+    assert.equal(persisted._schemaVersion, SETTINGS_SCHEMA_VERSION)
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('loadSettings rejects settings from a newer schema version', async () => {
+  const tempRoot = testTempDir('opencowork-settings-future-schema-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeEmptyConfig(configDir)
+  mkdirSync(userDataDir, { recursive: true })
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { SETTINGS_SCHEMA_VERSION } = await importFreshSettingsModule('future-schema-constant')
+    writeFileSync(join(userDataDir, 'settings.json'), JSON.stringify({
+      _schemaVersion: SETTINGS_SCHEMA_VERSION + 1,
+      selectedProviderId: 'openrouter',
+      selectedModelId: 'openrouter/auto',
+    }))
+    const { loadSettings } = await importFreshSettingsModule('future-schema-load')
+    assert.throws(
+      () => loadSettings(),
+      /newer than supported/,
+    )
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir


### PR DESCRIPTION
## Summary
- add an explicit persisted settings schema version
- preserve legacy settings migration while rejecting future-version settings files before fallback/default overwrite
- add regression tests for persisted schema-version writes and future-version rejection

## Validation
- pnpm test -- tests/settings.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check