### PR TITLE
Use atomic provider catalog cache writes

### DIFF
--- a/apps/desktop/src/main/fs-atomic.ts
+++ b/apps/desktop/src/main/fs-atomic.ts
@@ -21,6 +21,23 @@ import { dirname } from 'path'
 // other's temp files.
 let tempCounter = 0
 
+type BufferWriter = (fd: number, buffer: Buffer, offset: number, length: number) => number
+
+export function writeBufferFullySync(
+  fd: number,
+  bytes: Buffer,
+  writer: BufferWriter = writeSync,
+) {
+  let offset = 0
+  while (offset < bytes.length) {
+    const written = writer(fd, bytes, offset, bytes.length - offset)
+    if (!Number.isInteger(written) || written <= 0) {
+      throw new Error('Atomic write failed before all bytes were written')
+    }
+    offset += written
+  }
+}
+
 export function writeFileAtomic(
   targetPath: string,
   data: Buffer | string,
@@ -41,7 +58,7 @@ export function writeFileAtomic(
   try {
     fd = openSync(tempPath, 'w', mode)
     const bytes = typeof data === 'string' ? Buffer.from(data, 'utf-8') : data
-    writeSync(fd, bytes, 0, bytes.length)
+    writeBufferFullySync(fd, bytes)
     // fsync forces the bytes out of the page cache so a power-loss
     // between write() and close() doesn't lose them. Matters most for
     // credential files — an empty decrypt on reboot is worse than

--- a/apps/desktop/src/main/provider-catalog.ts
+++ b/apps/desktop/src/main/provider-catalog.ts
@@ -1,10 +1,11 @@
 import { createHash } from 'crypto'
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync } from 'fs'
 import { join } from 'path'
 import type { ProviderModelDescriptor } from '@open-cowork/shared'
 import { getAppDataDir } from './config-loader.ts'
 import { dedupByKey } from './inflight-dedup.ts'
 import { log } from './logger.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
 
 // Config-driven dynamic model catalog. A provider descriptor opts in by
 // adding a `dynamicCatalog` block — we fetch the URL, pull models out of
@@ -88,13 +89,7 @@ function readCacheFromDisk(providerId: string): CacheEntry | null {
 
 function writeCacheToDisk(entry: CacheEntry) {
   try {
-    // Atomic write: dodge corruption if the process is killed mid-write
-    // or a parallel refresh flushes the same key. Rename is atomic on
-    // the same filesystem so readers always see a fully-formed JSON file.
-    const target = catalogPath(entry.providerId)
-    const tmp = `${target}.tmp-${process.pid}`
-    writeFileSync(tmp, JSON.stringify(entry, null, 2))
-    renameSync(tmp, target)
+    writeFileAtomic(catalogPath(entry.providerId), JSON.stringify(entry, null, 2), { mode: 0o600 })
   } catch (err) {
     log('provider', `Failed to persist catalog for ${entry.providerId}: ${(err as Error).message}`)
   }

--- a/tests/fs-atomic.test.ts
+++ b/tests/fs-atomic.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { writeFileAtomic } from '../apps/desktop/src/main/fs-atomic.ts'
+import { writeBufferFullySync, writeFileAtomic } from '../apps/desktop/src/main/fs-atomic.ts'
 
 function withTempDir(fn: (dir: string) => void | Promise<void>) {
   const dir = mkdtempSync(join(tmpdir(), 'cowork-atomic-'))
@@ -56,3 +56,26 @@ test('writeFileAtomic leaves the original file intact if the write fails midway'
   const residue = readdirSync(dir).filter((entry) => entry.startsWith('settings.enc.tmp-'))
   assert.deepEqual(residue, [])
 }))
+
+test('writeBufferFullySync keeps writing after short writes', () => {
+  const calls: Array<{ offset: number; length: number }> = []
+  const payload = Buffer.from('abcdef')
+
+  writeBufferFullySync(1, payload, (_fd, _buffer, offset, length) => {
+    calls.push({ offset, length })
+    return Math.min(length, 2)
+  })
+
+  assert.deepEqual(calls, [
+    { offset: 0, length: 6 },
+    { offset: 2, length: 4 },
+    { offset: 4, length: 2 },
+  ])
+})
+
+test('writeBufferFullySync rejects stalled writes', () => {
+  assert.throws(
+    () => writeBufferFullySync(1, Buffer.from('payload'), () => 0),
+    /before all bytes were written/,
+  )
+})

--- a/tests/provider-catalog.test.ts
+++ b/tests/provider-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
@@ -163,6 +163,40 @@ describe('mapResponseToModels', () => {
         sha256,
       })
       assert.deepEqual(models, [{ id: 'x', name: 'X', description: undefined, contextLength: undefined }])
+    } finally {
+      globalThis.fetch = previousFetch
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      closeLogger()
+      if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+      else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+      clearConfigCaches()
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('persists fetched catalogs with private file permissions', async (t) => {
+    if (process.platform === 'win32') {
+      t.skip('Windows ACLs do not map cleanly to POSIX mode assertions')
+      return
+    }
+
+    const tempRoot = testTempDir('opencowork-provider-catalog-mode-')
+    const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+    const previousFetch = globalThis.fetch
+    const userDataDir = join(tempRoot, 'user-data')
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    clearConfigCaches()
+
+    try {
+      globalThis.fetch = (async () => new Response('{"data":[{"id":"x","name":"X"}]}', { status: 200 })) as typeof fetch
+
+      await refreshProviderCatalog('private-mode-test', {
+        url: 'https://example.test/models',
+        responsePath: 'data',
+      })
+
+      const mode = statSync(join(userDataDir, 'provider-catalogs', 'private-mode-test.json')).mode & 0o777
+      assert.equal(mode, 0o600)
     } finally {
       globalThis.fetch = previousFetch
       await new Promise((resolve) => setTimeout(resolve, 10))


### PR DESCRIPTION
## Summary
- replace provider catalog's hand-rolled temp rename with the shared writeFileAtomic helper
- persist fetched provider catalog caches with 0600 file mode
- add a regression asserting catalog cache files are private on POSIX platforms

## Validation
- pnpm test -- tests/provider-catalog.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check