### PR TITLE
Cap retained log files

### DIFF
--- a/apps/desktop/src/main/logger.ts
+++ b/apps/desktop/src/main/logger.ts
@@ -6,12 +6,19 @@ import { sanitizeLogMessage } from './log-sanitizer.ts'
 let logPath: string | null = null
 let logStream: ReturnType<typeof createWriteStream> | null = null
 const LOG_RETENTION_DAYS = 14
+const LOG_MAX_TOTAL_BYTES = 512 * 1024 * 1024 // 512 MB
 // Per-file rotation cap. A streaming LLM chat can generate tens of MB
 // of debug chatter in a day; without a cap, a user who leaves the app
 // open for a week can fill their disk. On rotation we bump the current
 // file to `<name>.1` and start fresh — simple one-deep rotation, no
-// accumulation beyond the retention window.
+// accumulation beyond the retention window and total-size cap.
 const LOG_ROTATE_BYTES = 100 * 1024 * 1024 // 100 MB
+
+interface LogPruneOptions {
+  nowMs?: number
+  retentionDays?: number
+  maxTotalBytes?: number
+}
 
 function escapeRegex(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -19,20 +26,47 @@ function escapeRegex(value: string) {
 
 function isKnownLogFile(file: string) {
   const prefixes = Array.from(new Set([getLogFilePrefix(), 'cowork', 'open-cowork']))
-  return prefixes.some((prefix) => new RegExp(`^${escapeRegex(prefix)}-\\d{4}-\\d{2}-\\d{2}\\.log$`).test(file))
+  return prefixes.some((prefix) => new RegExp(`^${escapeRegex(prefix)}-\\d{4}-\\d{2}-\\d{2}\\.log(?:\\.\\d+)?$`).test(file))
 }
 
-function pruneOldLogs(dir: string) {
-  const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000
+export function pruneLogDirectory(dir: string, options: LogPruneOptions = {}) {
+  const nowMs = options.nowMs ?? Date.now()
+  const retentionDays = options.retentionDays ?? LOG_RETENTION_DAYS
+  const maxTotalBytes = options.maxTotalBytes ?? LOG_MAX_TOTAL_BYTES
+  const cutoff = nowMs - retentionDays * 24 * 60 * 60 * 1000
+  const retained: Array<{ file: string; path: string; mtimeMs: number; size: number }> = []
+
   for (const file of readdirSync(dir)) {
     if (!isKnownLogFile(file)) continue
     const path = join(dir, file)
     try {
-      if (statSync(path).mtimeMs < cutoff) {
+      const stat = statSync(path)
+      if (!stat.isFile()) continue
+      if (stat.mtimeMs < cutoff) {
         unlinkSync(path)
+      } else {
+        retained.push({ file, path, mtimeMs: stat.mtimeMs, size: stat.size })
       }
     } catch {
       // Ignore log-prune races and continue scanning other files.
+    }
+  }
+
+  if (!Number.isFinite(maxTotalBytes) || maxTotalBytes < 0) return
+
+  retained.sort((a, b) => {
+    const mtimeCompare = b.mtimeMs - a.mtimeMs
+    return mtimeCompare || a.file.localeCompare(b.file)
+  })
+
+  let total = 0
+  for (const entry of retained) {
+    total += entry.size
+    if (total <= maxTotalBytes) continue
+    try {
+      unlinkSync(entry.path)
+    } catch {
+      // Ignore log-prune races and continue enforcing the cap.
     }
   }
 }
@@ -41,7 +75,7 @@ function getLogPath(): string {
   if (logPath) return logPath
   const dir = join(getAppDataDir(), 'logs')
   mkdirSync(dir, { recursive: true })
-  pruneOldLogs(dir)
+  pruneLogDirectory(dir)
   const date = new Date().toISOString().split('T')[0]
   logPath = join(dir, `${getLogFilePrefix()}-${date}.log`)
   return logPath

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pruneLogDirectory } from '../apps/desktop/src/main/logger.ts'
+
+function withTempDir(fn: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), 'open-cowork-logger-'))
+  try {
+    fn(dir)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function writeLog(dir: string, file: string, size: number, mtime: string) {
+  const path = join(dir, file)
+  writeFileSync(path, Buffer.alloc(size, 'x'))
+  const date = new Date(mtime)
+  utimesSync(path, date, date)
+  return path
+}
+
+test('log pruning includes rotated archives in retention cleanup', () => withTempDir((dir) => {
+  const oldArchive = writeLog(dir, 'cowork-2026-04-01.log.1', 4, '2026-04-01T00:00:00.000Z')
+  const recentArchive = writeLog(dir, 'cowork-2026-05-06.log.1', 4, '2026-05-06T00:00:00.000Z')
+
+  pruneLogDirectory(dir, {
+    nowMs: Date.parse('2026-05-07T00:00:00.000Z'),
+    retentionDays: 14,
+    maxTotalBytes: Number.POSITIVE_INFINITY,
+  })
+
+  assert.equal(existsSync(oldArchive), false)
+  assert.equal(existsSync(recentArchive), true)
+}))
+
+test('log pruning enforces a total retained size cap by removing oldest files first', () => withTempDir((dir) => {
+  const newest = writeLog(dir, 'open-cowork-2026-05-06.log', 3, '2026-05-06T00:00:00.000Z')
+  const middle = writeLog(dir, 'open-cowork-2026-05-05.log.1', 4, '2026-05-05T00:00:00.000Z')
+  const oldest = writeLog(dir, 'open-cowork-2026-05-04.log', 4, '2026-05-04T00:00:00.000Z')
+  const unrelated = writeLog(dir, 'other.log', 20, '2026-05-01T00:00:00.000Z')
+
+  pruneLogDirectory(dir, {
+    nowMs: Date.parse('2026-05-07T00:00:00.000Z'),
+    retentionDays: 14,
+    maxTotalBytes: 8,
+  })
+
+  assert.equal(existsSync(newest), true)
+  assert.equal(existsSync(middle), true)
+  assert.equal(existsSync(oldest), false)
+  assert.equal(existsSync(unrelated), true)
+}))


### PR DESCRIPTION
## Summary
- include rotated log archives in retention pruning
- add a total retained log-size cap so old logs cannot grow without bound
- add deterministic logger pruning tests for archive retention and size-cap eviction

## Validation
- pnpm test -- tests/logger.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check