### PR TITLE
Verify release tag signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,11 @@ jobs:
             exit 1
           fi
 
+      - name: Verify release tag signature
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/verify-release-tag-signature.mjs
+
       - name: Audit production dependencies
         run: pnpm audit --prod --audit-level high
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -57,6 +57,7 @@ Reference workflows in the repository root:
 - [ ] release workflows point at the correct package names and scripts
 - [ ] macOS and Linux packaging scripts still match Electron Builder config
 - [ ] release workflow is still tag-driven only
+- [ ] release tag will be an annotated signed tag and GitHub shows it as verified
 - [ ] signing/notarization configuration is present for the public release repo, or this is the explicitly documented unsigned `v0.x` public preview with `OPEN_COWORK_ALLOW_UNSIGNED_RELEASES` enabled for that tag only
 - [ ] if `OPEN_COWORK_ALLOW_UNSIGNED_RELEASES` was enabled for an unsigned preview tag, the repository variable is scheduled to be unset immediately after the GitHub Release publishes
 - [ ] the release repo or fork has the signing inputs expected by the release workflow (`MAC_CERTIFICATE_P12_BASE64`, `MAC_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`); a first `v*` tag intentionally fails without those inputs unless the unsigned preview override is enabled
@@ -70,14 +71,15 @@ Reference workflows in the repository root:
 
 ## Tagged release
 
-1. Create a version tag:
+1. Create a signed annotated version tag:
 
 ```bash
-git tag vX.Y.Z
+git tag -s vX.Y.Z -m "Open Cowork vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-2. Wait for the `Release` workflow to finish.
+2. Confirm GitHub shows the pushed tag as verified, then wait for the
+   `Release` workflow to finish.
 3. Verify the GitHub Release contains:
    - macOS zip artifacts
    - macOS dmg artifacts

--- a/scripts/verify-release-tag-signature.mjs
+++ b/scripts/verify-release-tag-signature.mjs
@@ -1,0 +1,113 @@
+const DEFAULT_API_BASE_URL = 'https://api.github.com'
+const GITHUB_API_VERSION = '2022-11-28'
+
+function fail(message) {
+  throw new Error(message)
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    fail(`${name} is required.`)
+  }
+  return value.trim()
+}
+
+export function validateReleaseTagPayload(input) {
+  const tagName = requiredString(input?.tagName, 'tagName')
+  const refPayload = input?.refPayload
+  const tagPayload = input?.tagPayload
+
+  if (!refPayload || typeof refPayload !== 'object') {
+    fail('GitHub tag ref payload is missing or invalid.')
+  }
+  if (!tagPayload || typeof tagPayload !== 'object') {
+    fail('GitHub annotated tag payload is missing or invalid.')
+  }
+
+  const expectedRef = `refs/tags/${tagName}`
+  if (refPayload.ref !== expectedRef) {
+    fail(`GitHub returned tag ref ${String(refPayload.ref || '')}, expected ${expectedRef}.`)
+  }
+
+  if (refPayload.object?.type !== 'tag') {
+    fail(`Release tag ${tagName} must be an annotated signed tag; lightweight tags are not accepted.`)
+  }
+
+  if (tagPayload.tag !== tagName) {
+    fail(`GitHub returned annotated tag ${String(tagPayload.tag || '')}, expected ${tagName}.`)
+  }
+
+  const verification = tagPayload.verification
+  if (!verification || typeof verification !== 'object') {
+    fail(`Release tag ${tagName} has no GitHub signature verification payload.`)
+  }
+
+  if (verification.verified !== true) {
+    const reason = typeof verification.reason === 'string' && verification.reason.length > 0
+      ? verification.reason
+      : 'unknown reason'
+    fail(`Release tag ${tagName} is not verified by GitHub signature verification: ${reason}.`)
+  }
+
+  return {
+    tagName,
+    tagSha: refPayload.object.sha,
+    targetSha: tagPayload.object?.sha,
+    reason: verification.reason || 'valid',
+  }
+}
+
+async function githubJson(path, token, apiBaseUrl = DEFAULT_API_BASE_URL) {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    },
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    fail(`GitHub API request failed (${response.status}) for ${path}: ${body.slice(0, 500)}`)
+  }
+
+  return response.json()
+}
+
+export async function verifyReleaseTagSignature(options) {
+  const repository = requiredString(options?.repository, 'repository')
+  const tagName = requiredString(options?.tagName, 'tagName')
+  const token = requiredString(options?.token, 'token')
+  const apiBaseUrl = options?.apiBaseUrl || DEFAULT_API_BASE_URL
+
+  const [owner, repo] = repository.split('/')
+  if (!owner || !repo || repository.split('/').length !== 2) {
+    fail(`repository must be in owner/name form, got ${repository}.`)
+  }
+
+  const repoPath = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
+  const refPayload = await githubJson(`${repoPath}/git/ref/tags/${encodeURIComponent(tagName)}`, token, apiBaseUrl)
+  const tagSha = refPayload?.object?.sha
+  if (typeof tagSha !== 'string' || tagSha.length === 0) {
+    fail(`GitHub tag ref for ${tagName} did not include an annotated tag SHA.`)
+  }
+  const tagPayload = await githubJson(`${repoPath}/git/tags/${encodeURIComponent(tagSha)}`, token, apiBaseUrl)
+  return validateReleaseTagPayload({ tagName, refPayload, tagPayload })
+}
+
+async function main() {
+  const result = await verifyReleaseTagSignature({
+    repository: process.env.GITHUB_REPOSITORY,
+    tagName: process.env.GITHUB_REF_NAME,
+    token: process.env.GITHUB_TOKEN,
+    apiBaseUrl: process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL,
+  })
+  process.stdout.write(`Verified signed release tag ${result.tagName} (${result.reason}).\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  })
+}

--- a/tests/release-tag-verifier.test.ts
+++ b/tests/release-tag-verifier.test.ts
@@ -1,0 +1,139 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  validateReleaseTagPayload,
+  verifyReleaseTagSignature,
+} from '../scripts/verify-release-tag-signature.mjs'
+
+function refPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    ref: 'refs/tags/v1.2.3',
+    object: {
+      type: 'tag',
+      sha: 'tag-object-sha',
+    },
+    ...overrides,
+  }
+}
+
+function tagPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    tag: 'v1.2.3',
+    object: {
+      type: 'commit',
+      sha: 'target-commit-sha',
+    },
+    verification: {
+      verified: true,
+      reason: 'valid',
+    },
+    ...overrides,
+  }
+}
+
+test('release tag verifier accepts annotated tags GitHub marks verified', () => {
+  const result = validateReleaseTagPayload({
+    tagName: 'v1.2.3',
+    refPayload: refPayload(),
+    tagPayload: tagPayload(),
+  })
+
+  assert.deepEqual(result, {
+    tagName: 'v1.2.3',
+    tagSha: 'tag-object-sha',
+    targetSha: 'target-commit-sha',
+    reason: 'valid',
+  })
+})
+
+test('release tag verifier rejects lightweight tags', () => {
+  assert.throws(
+    () => validateReleaseTagPayload({
+      tagName: 'v1.2.3',
+      refPayload: refPayload({ object: { type: 'commit', sha: 'target-commit-sha' } }),
+      tagPayload: tagPayload(),
+    }),
+    /must be an annotated signed tag/,
+  )
+})
+
+test('release tag verifier rejects mismatched tag refs', () => {
+  assert.throws(
+    () => validateReleaseTagPayload({
+      tagName: 'v1.2.3',
+      refPayload: refPayload({ ref: 'refs/tags/v9.9.9' }),
+      tagPayload: tagPayload(),
+    }),
+    /expected refs\/tags\/v1\.2\.3/,
+  )
+})
+
+test('release tag verifier rejects unverified annotated tags', () => {
+  assert.throws(
+    () => validateReleaseTagPayload({
+      tagName: 'v1.2.3',
+      refPayload: refPayload(),
+      tagPayload: tagPayload({ verification: { verified: false, reason: 'unsigned' } }),
+    }),
+    /not verified by GitHub signature verification: unsigned/,
+  )
+})
+
+test('release tag verifier rejects annotated tags without GitHub verification payloads', () => {
+  assert.throws(
+    () => validateReleaseTagPayload({
+      tagName: 'v1.2.3',
+      refPayload: refPayload(),
+      tagPayload: tagPayload({ verification: undefined }),
+    }),
+    /has no GitHub signature verification payload/,
+  )
+})
+
+test('release tag verifier fetches and validates the GitHub tag object', async () => {
+  const originalFetch = globalThis.fetch
+  const seenPaths: string[] = []
+  globalThis.fetch = (async (url) => {
+    const path = String(url).replace('https://github.test', '')
+    seenPaths.push(path)
+    if (path === '/repos/joe-broadhead/open-cowork/git/ref/tags/v1.2.3') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => refPayload(),
+        text: async () => JSON.stringify(refPayload()),
+      } as Response
+    }
+    if (path === '/repos/joe-broadhead/open-cowork/git/tags/tag-object-sha') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => tagPayload(),
+        text: async () => JSON.stringify(tagPayload()),
+      } as Response
+    }
+    return {
+      ok: false,
+      status: 404,
+      json: async () => ({ message: 'not found' }),
+      text: async () => 'not found',
+    } as Response
+  }) as typeof fetch
+
+  try {
+    const result = await verifyReleaseTagSignature({
+      repository: 'joe-broadhead/open-cowork',
+      tagName: 'v1.2.3',
+      token: 'github-token',
+      apiBaseUrl: 'https://github.test',
+    })
+
+    assert.equal(result.tagSha, 'tag-object-sha')
+    assert.deepEqual(seenPaths, [
+      '/repos/joe-broadhead/open-cowork/git/ref/tags/v1.2.3',
+      '/repos/joe-broadhead/open-cowork/git/tags/tag-object-sha',
+    ])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})


### PR DESCRIPTION
## Summary
- add a release preflight verifier for GitHub-verified annotated signed tags
- reject lightweight or unverified release tags before packaging begins
- document signed tag creation in the release checklist

## Validation
- pnpm test -- tests/release-tag-verifier.test.ts
- pnpm typecheck
- pnpm lint
- pnpm docs:build
- git diff --check