### PR TITLE
Keep reset from recreating user data logs

### DIFF
--- a/apps/desktop/src/main/app-reset.ts
+++ b/apps/desktop/src/main/app-reset.ts
@@ -1,10 +1,15 @@
 import electron from 'electron'
-import { rmSync } from 'fs'
+import { existsSync, rmSync } from 'fs'
 import { getAppDataDir } from './config-loader.ts'
 import { getSandboxRootDir } from './runtime-paths.ts'
 import { log } from './logger.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
+
+export type ResetAppDataResult = {
+  removedPaths: string[]
+  failedPaths: Array<{ label: string; path: string; error: string }>
+}
 
 // Full app-state wipe. Called behind a destructive-confirmation
 // token so a prompt-injected renderer can't trigger it. Removes:
@@ -22,8 +27,9 @@ const electronApp = (electron as { app?: typeof import('electron').app }).app
 // After deletion we relaunch the app so the user lands in the
 // first-run flow with a fresh state. Relaunch + quit is the standard
 // Electron recipe; the main process exits, a new one starts.
-export function resetAppData(): { removedPaths: string[] } {
+export function resetAppData(): ResetAppDataResult {
   const removedPaths: string[] = []
+  const failedPaths: ResetAppDataResult['failedPaths'] = []
 
   const appDataDir = getAppDataDir()
   const sandboxRoot = getSandboxRootDir()
@@ -37,10 +43,14 @@ export function resetAppData(): { removedPaths: string[] } {
     try {
       rmSync(target.path, { recursive: true, force: true })
       removedPaths.push(target.path)
-      log('app', `Reset wiped ${target.label}: ${target.path}`)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      log('error', `Reset failed to remove ${target.label} at ${target.path}: ${message}`)
+      failedPaths.push({ label: target.label, path: target.path, error: message })
+      if (existsSync(appDataDir)) {
+        log('error', `Reset failed to remove ${target.label} at ${target.path}: ${message}`)
+      } else {
+        process.stderr.write(`[app] Reset failed to remove ${target.label} at ${target.path}: ${message}\n`)
+      }
       // Continue with the remaining targets — partial reset is better
       // than no reset when one path is locked (e.g. a stale logfile
       // handle on Windows).
@@ -60,5 +70,5 @@ export function resetAppData(): { removedPaths: string[] } {
     }, 200)
   }
 
-  return { removedPaths }
+  return { removedPaths, failedPaths }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -891,7 +891,10 @@ export interface CoworkAPI {
     // Wipes user-data dir + sandbox workspaces and relaunches. Behind
     // a destructive confirmation token; call confirm.requestDestructive
     // with `{ action: 'app.reset' }` first to get the token.
-    reset: (confirmationToken: string) => Promise<{ removedPaths: string[] }>
+    reset: (confirmationToken: string) => Promise<{
+      removedPaths: string[]
+      failedPaths?: Array<{ label: string; path: string; error: string }>
+    }>
   }
   automation: {
     list: () => Promise<AutomationListPayload>

--- a/tests/app-reset.test.ts
+++ b/tests/app-reset.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+test('resetAppData wipes user data and sandbox roots from explicit test directories', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-reset-'))
+  const userDataDir = join(root, 'user-data')
+  const sandboxDir = join(root, 'sandbox')
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const previousSandboxDir = process.env.OPEN_COWORK_SANDBOX_DIR
+
+  try {
+    mkdirSync(userDataDir, { recursive: true })
+    mkdirSync(sandboxDir, { recursive: true })
+    writeFileSync(join(userDataDir, 'settings.enc'), 'secret settings')
+    writeFileSync(join(sandboxDir, 'workspace.txt'), 'sandbox content')
+
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    process.env.OPEN_COWORK_SANDBOX_DIR = sandboxDir
+
+    const { resetAppData } = await import('../apps/desktop/src/main/app-reset.ts')
+    const result = resetAppData()
+
+    assert.deepEqual(new Set(result.removedPaths), new Set([userDataDir, sandboxDir]))
+    assert.deepEqual(result.failedPaths, [])
+    assert.equal(existsSync(userDataDir), false)
+    assert.equal(existsSync(sandboxDir), false)
+  } finally {
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    if (previousSandboxDir === undefined) delete process.env.OPEN_COWORK_SANDBOX_DIR
+    else process.env.OPEN_COWORK_SANDBOX_DIR = previousSandboxDir
+    rmSync(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- stop resetAppData from writing success logs after the user-data directory has been removed
- avoid recreating user-data/logs during destructive reset cleanup
- add a regression test that wipes explicit test user-data and sandbox roots

## Validation
- pnpm test -- tests/app-reset.test.ts
- pnpm lint
- pnpm typecheck
- git diff --check