### PR TITLE
Cover automation approval and HTML helpers

### DIFF
--- a/tests/automation-service-approval.test.ts
+++ b/tests/automation-service-approval.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type { AutomationDetail, ExecutionBrief } from '@open-cowork/shared'
+import {
+  buildAutomationApprovalBody,
+  requiresManualApproval,
+} from '../apps/desktop/src/main/automation-service-approval.ts'
+
+function automationWithPolicy(autonomyPolicy: AutomationDetail['autonomyPolicy']) {
+  return { autonomyPolicy } as AutomationDetail
+}
+
+function brief(overrides: Partial<ExecutionBrief> = {}): ExecutionBrief {
+  return {
+    summary: 'Prepare the weekly brief.',
+    reasoning: 'The workflow has enough context.',
+    deliverables: ['Market summary', 'Action list'],
+    workItems: [],
+    recommendedAgents: ['researcher', 'writer'],
+    missingContext: [],
+    approvalBoundary: 'Approve before sending externally.',
+    ...overrides,
+  }
+}
+
+test('requiresManualApproval only gates review-first automations', () => {
+  assert.equal(requiresManualApproval(automationWithPolicy('review-first')), true)
+  assert.equal(requiresManualApproval(automationWithPolicy('autonomous')), false)
+})
+
+test('buildAutomationApprovalBody summarizes deliverables, agents, and approval boundary', () => {
+  assert.equal(
+    buildAutomationApprovalBody(brief()),
+    [
+      'The execution brief is ready.',
+      '',
+      'Deliverables: Market summary, Action list',
+      'Recommended agents: researcher, writer',
+      'Approval boundary: Approve before sending externally.',
+    ].join('\n'),
+  )
+})
+
+test('buildAutomationApprovalBody uses fallbacks and includes missing context', () => {
+  assert.equal(
+    buildAutomationApprovalBody(brief({
+      deliverables: [],
+      recommendedAgents: [],
+      missingContext: ['Confirm launch date.', 'Attach final budget.'],
+    })),
+    [
+      'The execution brief is ready.',
+      '',
+      'Deliverables: None specified.',
+      'Recommended agents: Use standard plan/build routing.',
+      'Approval boundary: Approve before sending externally.',
+      '',
+      'Missing context:',
+      'Confirm launch date.',
+      'Attach final budget.',
+    ].join('\n'),
+  )
+})

--- a/tests/html-escape.test.ts
+++ b/tests/html-escape.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { escapeHtml } from '../apps/desktop/src/main/html-escape.ts'
+
+test('escapeHtml escapes HTML-sensitive characters in main-process responses', () => {
+  assert.equal(
+    escapeHtml(`Signed in as <alice@example.com> & "Open Cowork's" user`),
+    'Signed in as &lt;alice@example.com&gt; &amp; &quot;Open Cowork&#39;s&quot; user',
+  )
+})
+
+test('escapeHtml stringifies non-string values before escaping', () => {
+  assert.equal(escapeHtml(null), 'null')
+  assert.equal(escapeHtml(42), '42')
+})


### PR DESCRIPTION
## Summary
- add focused tests for automation approval gating and approval inbox copy
- add HTML escaping coverage for main-process generated responses

## Validation
- pnpm test -- tests/automation-service-approval.test.ts tests/html-escape.test.ts
- pnpm lint
- pnpm typecheck
- git diff --check