### PR TITLE
Add chat message row semantics

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MessageBubble.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageBubble.test.tsx
@@ -115,6 +115,7 @@ describe('MessageBubble', () => {
     )
 
     expect(screen.getByText('Review this chart')).toBeInTheDocument()
+    expect(screen.getByRole('article', { name: 'User message' })).toBeInTheDocument()
     expect(screen.getByRole('img', { name: 'chart.png' })).toHaveAttribute('src', 'data:image/png;base64,abc')
     expect(screen.getByText('notes.txt')).toBeInTheDocument()
   })
@@ -152,6 +153,7 @@ describe('MessageBubble', () => {
 
     render(<MessageBubble message={assistantMessage} streaming />)
 
+    expect(screen.getByRole('article', { name: 'Assistant message' })).toBeInTheDocument()
     expect(screen.getByTestId('markdown-content')).toHaveTextContent('Done with changes streaming')
 
     await user.click(screen.getByRole('button', { name: 'Branch here' }))

--- a/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react'
 import { MarkdownContent } from './MarkdownContent'
 import { MessageActions } from './MessageActions'
+import { t } from '../../helpers/i18n'
 
 import type { Message } from '../../stores/session'
 
@@ -66,7 +67,7 @@ export const MessageBubble = memo(function MessageBubble({
 
   if (isUser) {
     return (
-      <div className="group flex flex-col items-end">
+      <article aria-label={t('chat.userMessageAriaLabel', 'User message')} className="group flex flex-col items-end">
         <div className="max-w-[80%] flex flex-col gap-2">
           {hasAttachments && <AttachmentGrid attachments={message.attachments!} />}
           {message.content && message.content !== 'Sent attachments' && (
@@ -83,16 +84,16 @@ export const MessageBubble = memo(function MessageBubble({
           )}
         </div>
         <MessageActions message={message} placement="right" />
-      </div>
+      </article>
     )
   }
 
   return (
-    <div className="group flex flex-col items-start">
+    <article aria-label={t('chat.assistantMessageAriaLabel', 'Assistant message')} className="group flex flex-col items-start">
       <div className="max-w-[90%]">
         <MarkdownContent text={message.content} streaming={streaming} />
       </div>
       <MessageActions message={message} placement="left" />
-    </div>
+    </article>
   )
 }, (prev, next) => prev.message === next.message && prev.streaming === next.streaming)


### PR DESCRIPTION
## Summary
- render user and assistant message bubbles as labeled article rows inside the chat transcript
- extend MessageBubble tests to assert the transcript row semantics for both roles

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- MessageBubble.test.tsx
- pnpm lint:a11y --max-warnings=0
- pnpm lint
- pnpm typecheck
- git diff --check