### PR TITLE
Cache renderer currency formatters

### DIFF
--- a/apps/desktop/src/renderer/helpers/i18n.ts
+++ b/apps/desktop/src/renderer/helpers/i18n.ts
@@ -151,6 +151,7 @@ export async function setLocale(locale: string | null) {
   // calls reflect the new locale immediately.
   numberFormatters.clear()
   compactFormatters.clear()
+  currencyFormatters.clear()
   dateFormatters.clear()
   await rebuildCatalog()
 }
@@ -194,6 +195,7 @@ export function t(key: string, fallback: string, vars?: Record<string, string | 
 // instantiate, and the chat / dashboard render paths are hot.
 const numberFormatters = new Map<string, Intl.NumberFormat>()
 const compactFormatters = new Map<string, Intl.NumberFormat>()
+const currencyFormatters = new Map<string, Intl.NumberFormat>()
 const dateFormatters = new Map<string, Intl.DateTimeFormat>()
 
 export function formatNumber(value: number): string {
@@ -234,7 +236,13 @@ export function formatDate(value: Date | string | number, options?: Intl.DateTim
 // default is USD to match the upstream pricing catalog.
 export function formatCurrency(value: number, currency: string = 'USD'): string {
   const locale = cachedLocale
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
+  const key = `${locale || '_default_'}:${currency}`
+  let formatter = currencyFormatters.get(key)
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, { style: 'currency', currency })
+    currencyFormatters.set(key, formatter)
+  }
+  return formatter.format(value)
 }
 
 // Auto-derived from the built-in catalog registry so adding a

--- a/tests/i18n-runtime.test.ts
+++ b/tests/i18n-runtime.test.ts
@@ -32,7 +32,7 @@ Object.defineProperty(globalThis, 'navigator', {
 })
 
 // Import after globals are stubbed — the runtime reads them at first use.
-const { setLocale, getLocale, t, configureI18n, getBuiltInLocales, formatNumber } = await import(
+const { setLocale, getLocale, t, configureI18n, getBuiltInLocales, formatCurrency, formatNumber } = await import(
   '../apps/desktop/src/renderer/helpers/i18n.ts'
 )
 
@@ -114,6 +114,15 @@ describe('i18n runtime', () => {
     await setLocale('en')
     const english = formatNumber(1234567)
     assert.equal(english, '1,234,567')
+  })
+
+  it('currency formatting respects active locale and currency', async () => {
+    await setLocale('fr')
+    const frenchEuro = formatCurrency(1234.5, 'EUR')
+    assert.ok(/1[\s\u00a0\u202f]234,50[\s\u00a0\u202f]€/.test(frenchEuro), `expected French EUR format, got: ${JSON.stringify(frenchEuro)}`)
+
+    await setLocale('en')
+    assert.equal(formatCurrency(1234.5, 'USD'), '$1,234.50')
   })
 
   it('reads user preference from localStorage at configure time, overriding system locale', async () => {


### PR DESCRIPTION
## Summary
- cache renderer currency Intl.NumberFormat instances by locale and currency
- clear the currency formatter cache on locale changes
- add i18n runtime coverage for locale-aware currency formatting

## Validation
- pnpm test -- --test-name-pattern=i18n
- pnpm lint
- pnpm typecheck
- git diff --check