### PR TITLE
Use modern platform hints for shortcuts

### DIFF
--- a/apps/desktop/src/renderer/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/components/CommandPalette.tsx
@@ -9,6 +9,7 @@ import { t } from '../helpers/i18n'
 import { ModalBackdrop } from './layout/ModalBackdrop'
 import {
   buildCommandPaletteItems,
+  getShortcutPlatform,
   SECTION_ORDER,
   type PaletteItem,
   type RuntimeCommand,
@@ -71,7 +72,7 @@ export function CommandPalette({
       commands,
       builtinAgents,
       customAgents,
-      platform: typeof navigator !== 'undefined' ? navigator.platform : '',
+      platform: getShortcutPlatform(),
       onNavigate,
       onCreateThread,
       onEnsureSession,

--- a/apps/desktop/src/renderer/components/command-palette-items.ts
+++ b/apps/desktop/src/renderer/components/command-palette-items.ts
@@ -33,7 +33,20 @@ export type PaletteItem = {
 
 export const SECTION_ORDER: PaletteSection[] = ['Go To', 'Create', 'Modes', 'Commands', 'Agents']
 
-export function formatShortcutLabel(shortcut: string, platform = typeof navigator !== 'undefined' ? navigator.platform : '') {
+type NavigatorPlatformSource = {
+  platform?: string
+  userAgentData?: {
+    platform?: string
+  }
+}
+
+export function getShortcutPlatform(source: NavigatorPlatformSource | undefined = typeof navigator !== 'undefined' ? navigator as NavigatorPlatformSource : undefined) {
+  const userAgentPlatform = source?.userAgentData?.platform?.trim()
+  if (userAgentPlatform) return userAgentPlatform
+  return source?.platform || ''
+}
+
+export function formatShortcutLabel(shortcut: string, platform = getShortcutPlatform()) {
   const isMac = platform.toLowerCase().includes('mac')
   return shortcut
     .replace('CmdOrCtrl', isMac ? 'Cmd' : 'Ctrl')

--- a/tests/command-palette-items.test.ts
+++ b/tests/command-palette-items.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import type { BuiltInAgentDetail, CustomAgentSummary, SessionInfo } from '@open-cowork/shared'
-import { buildCommandPaletteItems, formatShortcutLabel } from '../apps/desktop/src/renderer/components/command-palette-items.ts'
+import { buildCommandPaletteItems, formatShortcutLabel, getShortcutPlatform } from '../apps/desktop/src/renderer/components/command-palette-items.ts'
 
 function createCallbacks() {
   const calls: Array<{ type: string; value?: string }> = []
@@ -49,6 +49,15 @@ function createCallbacks() {
 test('formatShortcutLabel adapts CmdOrCtrl for mac and non-mac labels', () => {
   assert.equal(formatShortcutLabel('CmdOrCtrl+Shift+P', 'MacIntel'), 'Cmd + Shift + P')
   assert.equal(formatShortcutLabel('CmdOrCtrl+Shift+P', 'Linux x86_64'), 'Ctrl + Shift + P')
+})
+
+test('getShortcutPlatform prefers userAgentData and falls back to legacy platform', () => {
+  assert.equal(getShortcutPlatform({
+    userAgentData: { platform: 'macOS' },
+    platform: 'Linux x86_64',
+  }), 'macOS')
+  assert.equal(getShortcutPlatform({ platform: 'MacIntel' }), 'MacIntel')
+  assert.equal(getShortcutPlatform({}), '')
 })
 
 test('buildCommandPaletteItems filters runtime commands and exposes valid agents only', async () => {


### PR DESCRIPTION
## Summary
- prefer navigator.userAgentData.platform for command palette shortcut labels
- keep navigator.platform as a compatibility fallback in one helper
- add command-palette unit coverage for userAgentData and fallback behavior

## Validation
- pnpm test -- --test-name-pattern=command-palette
- pnpm lint
- pnpm typecheck
- git diff --check