### PR TITLE
Write saved text exports atomically

### DIFF
--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -32,6 +32,7 @@ import { saveChartArtifact } from '../chart-artifacts.ts'
 import { checkForUpdates } from '../update-check.ts'
 import { resetAppData } from '../app-reset.ts'
 import { readFileCheckedSync, readTextFileCheckedSync } from '../fs-read.ts'
+import { writeFileAtomic } from '../fs-atomic.ts'
 import type {
   ChartSaveArtifactRequest,
   DestructiveConfirmationRequest,
@@ -50,6 +51,10 @@ async function loadAuthModule() {
 const electronShell = (electron as { shell?: typeof import('electron').shell }).shell
 const electronClipboard = (electron as { clipboard?: typeof import('electron').clipboard }).clipboard
 const electronApp = (electron as { app?: typeof import('electron').app }).app
+
+export function saveTextExportFile(filePath: string, content: string) {
+  writeFileAtomic(filePath, content, { mode: 0o600 })
+}
 
 export function registerAppHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('app:metadata', async () => {
@@ -307,7 +312,6 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     if (!safeDefaultFilename) throw new Error('Default filename is required.')
     const safeContent = normalizeBoundedString(content, 'Save content', MAX_SAVE_TEXT_BYTES)
     const { dialog } = await import('electron')
-    const fs = await import('fs')
     const result = await dialog.showSaveDialog({
       title: 'Save file',
       defaultPath: safeDefaultFilename,
@@ -316,7 +320,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     if (result.canceled || !result.filePath) return null
     const safeFilePath = resolveSafeSaveTextPath(result.filePath)
     try {
-      fs.writeFileSync(safeFilePath, safeContent, 'utf-8')
+      saveTextExportFile(safeFilePath, safeContent)
       return safeFilePath
     } catch (err) {
       log('error', `dialog:save-text write failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -1,11 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { CustomMcpConfig } from '@open-cowork/shared'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
-import { registerAppHandlers, resolveSafeSaveTextPath } from '../apps/desktop/src/main/ipc/app-handlers.ts'
+import { registerAppHandlers, resolveSafeSaveTextPath, saveTextExportFile } from '../apps/desktop/src/main/ipc/app-handlers.ts'
 import { registerArtifactHandlers } from '../apps/desktop/src/main/ipc/artifact-handlers.ts'
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
@@ -707,4 +707,17 @@ test('dialog:save-text path policy keeps exports as non-sensitive json files', (
     () => resolveSafeSaveTextPath('/Users/example/.ssh/config'),
     /sensitive configuration path/,
   )
+})
+
+test('dialog:save-text writes private export files atomically', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-save-text-'))
+  try {
+    const outputPath = join(tempRoot, 'agent.cowork-agent.json')
+    saveTextExportFile(outputPath, '{"ok":true}\n')
+
+    assert.equal(readFileSync(outputPath, 'utf-8'), '{"ok":true}\n')
+    assert.equal(statSync(outputPath).mode & 0o777, 0o600)
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary
- route dialog:save-text writes through writeFileAtomic with private 0600 permissions
- add a regression test for saved export file contents and mode

## Validation
- pnpm test -- --test-name-pattern="dialog:save-text"
- pnpm lint
- pnpm typecheck
- git diff --check