### PR TITLE
Write project overlay manifest atomically

### DIFF
--- a/apps/desktop/src/main/runtime-project-overlay.ts
+++ b/apps/desktop/src/main/runtime-project-overlay.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
 import {
@@ -10,6 +10,7 @@ import {
   getRuntimeHomeDir,
 } from './runtime-paths.ts'
 import { getProjectNamespace, getSidecarJsonSuffix } from './config-loader.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
 
 function agentOverlayFileSuffixes() {
   return ['.md', '.disabled.md', getSidecarJsonSuffix()]
@@ -81,7 +82,7 @@ function readProjectOverlayManifest(): ProjectOverlayManifest {
 function writeProjectOverlayManifest(manifest: ProjectOverlayManifest) {
   const manifestPath = getProjectOverlayManifestPath()
   mkdirSync(dirname(manifestPath), { recursive: true })
-  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  writeFileAtomic(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 })
 }
 
 export function clearProjectOverlayCopies() {

--- a/tests/runtime-project-overlay.test.ts
+++ b/tests/runtime-project-overlay.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
 import { mkdir } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { clearConfigCaches, getSidecarJsonSuffix } from '../apps/desktop/src/main/config-loader.ts'
+import { clearConfigCaches, getProjectNamespace, getSidecarJsonSuffix } from '../apps/desktop/src/main/config-loader.ts'
 import {
   clearProjectOverlayCopies,
   projectHasOverlayContent,
@@ -15,6 +15,7 @@ import {
   getMachineSkillsDir,
   getProjectCoworkAgentsDir,
   getProjectCoworkSkillsDir,
+  getRuntimeEnvPaths,
 } from '../apps/desktop/src/main/runtime-paths.ts'
 
 function skillContent(label: string) {
@@ -58,6 +59,10 @@ test('project overlay copies project-scoped skills and agents then restores mach
     assert.equal(projectHasOverlayContent(join(root, 'empty-project')), false)
 
     assert.equal(syncProjectOverlayToRuntime(projectDir), projectDir)
+    const manifestPath = join(getRuntimeEnvPaths().configHome, 'opencode', `.${getProjectNamespace()}-project-overlay.json`)
+    const manifestContent = readFileSync(manifestPath, 'utf-8')
+    assert.match(manifestContent, /project/)
+    assert.equal(statSync(manifestPath).mode & 0o777, 0o600)
     assert.match(readFileSync(join(machineSkillDir, 'SKILL.md'), 'utf-8'), /project skill/)
     assert.match(readFileSync(join(machineAgentDir, 'brief-writer.md'), 'utf-8'), /project agent/)
     assert.match(readFileSync(join(machineAgentDir, sidecarName), 'utf-8'), /green/)


### PR DESCRIPTION
## Summary
- write the runtime project-overlay manifest through writeFileAtomic with private 0600 permissions
- assert the overlay recovery manifest is written privately in the project overlay regression test

## Validation
- pnpm test -- --test-name-pattern="project overlay"
- pnpm lint
- pnpm typecheck
- git diff --check