### PR TITLE
Write runtime skill catalog files atomically

### DIFF
--- a/apps/desktop/src/main/runtime-skill-catalog.ts
+++ b/apps/desktop/src/main/runtime-skill-catalog.ts
@@ -1,10 +1,11 @@
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, rmSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import type { RuntimeContextOptions } from '@open-cowork/shared'
 import { getProjectOverlayDirName } from './config-loader.ts'
 import { getEffectiveSkillBundleSync, listEffectiveSkillsSync } from './effective-skills.ts'
 import { log } from './logger.ts'
 import { getRuntimeHomeDir, getRuntimeSkillCatalogDir } from './runtime-paths.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
 
 export type RuntimeSkillBundle = {
   name: string
@@ -128,16 +129,16 @@ export function buildRuntimeSkillContent(skillName: string, content: string, fil
   return embedSupportingFiles(withMirrorSection, files)
 }
 
-function writeBundle(root: string, bundle: RuntimeSkillBundle, skillContent: string, options?: { includeFiles?: boolean }) {
+export function writeRuntimeSkillBundle(root: string, bundle: RuntimeSkillBundle, skillContent: string, options?: { includeFiles?: boolean }) {
   const skillRoot = join(root, bundle.name)
   rmSync(skillRoot, { recursive: true, force: true })
   mkdirSync(skillRoot, { recursive: true })
-  writeFileSync(join(skillRoot, 'SKILL.md'), skillContent, 'utf-8')
+  writeFileAtomic(join(skillRoot, 'SKILL.md'), skillContent, { mode: 0o600 })
   if (options?.includeFiles !== false) {
     for (const file of bundle.files) {
       const output = join(skillRoot, normalizeBundlePath(file.path))
       mkdirSync(dirname(output), { recursive: true })
-      writeFileSync(output, file.content, 'utf-8')
+      writeFileAtomic(output, file.content, { mode: 0o600 })
     }
   }
 }
@@ -169,7 +170,7 @@ export function syncReadableSkillMirror(directory?: string | null, context?: Run
     rmSync(root, { recursive: true, force: true })
     mkdirSync(root, { recursive: true })
     for (const bundle of listContextBundles(context)) {
-      writeBundle(root, bundle, bundle.content)
+      writeRuntimeSkillBundle(root, bundle, bundle.content)
     }
     return root
   } catch (error) {
@@ -185,7 +186,7 @@ export function buildRuntimeSkillCatalog(context?: RuntimeContextOptions) {
 
   const bundles = listContextBundles(context)
   for (const bundle of bundles) {
-    writeBundle(catalogRoot, bundle, buildRuntimeSkillContent(bundle.name, bundle.content, bundle.files), { includeFiles: false })
+    writeRuntimeSkillBundle(catalogRoot, bundle, buildRuntimeSkillContent(bundle.name, bundle.content, bundle.files), { includeFiles: false })
   }
 
   syncReadableSkillMirror(null, undefined)

--- a/tests/runtime-skill-catalog.test.ts
+++ b/tests/runtime-skill-catalog.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   buildReadableSkillMirrorRelativePath,
   buildRuntimeSkillContent,
+  writeRuntimeSkillBundle,
 } from '../apps/desktop/src/main/runtime-skill-catalog.ts'
 
 test('buildReadableSkillMirrorRelativePath points into the project overlay skill mirror', () => {
@@ -63,4 +67,29 @@ test('buildRuntimeSkillContent rewrites stale shared-skill suffix paths to the l
   assert.ok(!rewritten.includes('../../shared/analyst/assets/evidence-block.md'))
   assert.match(rewritten, /`\.opencowork\/skill-bundles\/analyst\/references\/workflow\.md`/)
   assert.match(rewritten, /`\.opencowork\/skill-bundles\/analyst\/assets\/evidence-block\.md`/)
+})
+
+test('writeRuntimeSkillBundle writes private generated skill files', () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-runtime-skill-catalog-'))
+
+  try {
+    writeRuntimeSkillBundle(root, {
+      name: 'analyst',
+      content: '# Analyst',
+      files: [{ path: 'references/workflow.md', content: '# workflow' }],
+    }, '# Runtime Analyst\n')
+
+    const skillDirs = readdirSync(root, { withFileTypes: true }).filter((entry) => entry.isDirectory())
+    assert.ok(skillDirs.length > 0, 'expected runtime skill catalog to contain generated skill bundles')
+
+    const skillPath = join(root, skillDirs[0]!.name, 'SKILL.md')
+    assert.equal(readFileSync(skillPath, 'utf-8'), '# Runtime Analyst\n')
+    assert.equal(statSync(skillPath).mode & 0o777, 0o600)
+
+    const supportingFilePath = join(root, skillDirs[0]!.name, 'references', 'workflow.md')
+    assert.equal(readFileSync(supportingFilePath, 'utf-8'), '# workflow')
+    assert.equal(statSync(supportingFilePath).mode & 0o777, 0o600)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary
- write generated runtime skill catalog and readable mirror files through writeFileAtomic with private 0600 permissions
- expose the bundle writer for targeted tests and assert generated SKILL.md/supporting files are private

## Validation
- pnpm test -- --test-name-pattern="runtime skill"
- pnpm lint
- pnpm typecheck
- git diff --check