### PR TITLE
Write generated runtime files atomically

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow, ipcMain, Menu, nativeImage, session as electronSession } from 'electron'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join, resolve } from 'path'
 import { setupIpcHandlers } from './ipc-handlers.ts'
 import { createApplicationMenuTemplate } from './app-menu.ts'
@@ -41,12 +40,12 @@ import { shouldScheduleRuntimeReconnect } from './runtime-reconnect-policy.ts'
 import { registerAppProtocolSchemes } from './app-protocol-schemes.ts'
 import { registerBrandingAssetProtocol } from './branding-assets.ts'
 import { registerChartFrameAssetProtocol } from './chart-frame-assets.ts'
-import { escapeHtml } from './html-escape.ts'
 import {
   attachPermissionGuards,
   attachWebContentsSecurityGuards,
   openExternalNavigation,
 } from './main-window-security.ts'
+import { resolveStartupSplashTemplatePath, writeStartupSplashFile } from './startup-splash.ts'
 
 import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
@@ -141,22 +140,14 @@ function expectedRendererEntryPath() {
   return join(__dirname, '../index.html')
 }
 
-function startupSplashTemplatePath() {
-  const builtSplash = join(__dirname, '../startup-splash.html')
-  if (existsSync(builtSplash)) return builtSplash
-  return join(__dirname, '../../public/startup-splash.html')
-}
-
 function startupSplashPath() {
-  const templatePath = startupSplashTemplatePath()
+  const templatePath = resolveStartupSplashTemplatePath(__dirname)
   try {
-    const brandName = escapeHtml(branding.name)
-    const html = readFileSync(templatePath, 'utf8').replaceAll('Open Cowork', () => brandName)
-    const outputDir = join(app.getPath('userData'), 'startup')
-    mkdirSync(outputDir, { recursive: true })
-    const outputPath = join(outputDir, 'startup-splash.html')
-    writeFileSync(outputPath, html)
-    return outputPath
+    return writeStartupSplashFile({
+      templatePath,
+      outputDir: join(app.getPath('userData'), 'startup'),
+      brandName: branding.name,
+    })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log('main', `Falling back to packaged startup splash: ${message}`)

--- a/apps/desktop/src/main/runtime-content.ts
+++ b/apps/desktop/src/main/runtime-content.ts
@@ -1,7 +1,8 @@
 import electron from 'electron'
-import { cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from 'fs'
+import { cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs'
 import { isAbsolute, join, relative, resolve } from 'path'
 import { getConfiguredSkillsFromConfig } from './config-loader.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
 import { log } from './logger.ts'
 import { getMachineSkillsDir, getManagedSkillsDir, getRuntimeHomeDir, getRuntimeSkillCatalogDir } from './runtime-paths.ts'
 import { syncProjectOverlayToRuntime } from './runtime-project-overlay.ts'
@@ -70,6 +71,10 @@ function copySkillDirectory(source: string, destination: string) {
       }
     },
   })
+}
+
+export function writeRuntimeAgentsFile(runtimeHome: string, agentsSrc: string) {
+  writeFileAtomic(join(runtimeHome, 'AGENTS.md'), readFileSync(agentsSrc, 'utf-8'), { mode: 0o600 })
 }
 
 // Root directories where bundled skill packages may live, in priority
@@ -142,7 +147,7 @@ export function copySkillsAndAgents(projectDirectory?: string | null) {
 
   const agentsSrc = join(runtimeConfigSrc, 'AGENTS.md')
   if (existsSync(agentsSrc)) {
-    writeFileSync(join(runtimeHome, 'AGENTS.md'), readFileSync(agentsSrc, 'utf-8'))
+    writeRuntimeAgentsFile(runtimeHome, agentsSrc)
   }
 
   const skillsDst = getManagedSkillsDir()

--- a/apps/desktop/src/main/startup-splash.ts
+++ b/apps/desktop/src/main/startup-splash.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { writeFileAtomic } from './fs-atomic.ts'
+import { escapeHtml } from './html-escape.ts'
+
+export function resolveStartupSplashTemplatePath(dirname: string) {
+  const builtSplash = join(dirname, '../startup-splash.html')
+  if (existsSync(builtSplash)) return builtSplash
+  return join(dirname, '../../public/startup-splash.html')
+}
+
+export function writeStartupSplashFile(options: {
+  templatePath: string
+  outputDir: string
+  brandName: string
+}) {
+  const brandName = escapeHtml(options.brandName)
+  const html = readFileSync(options.templatePath, 'utf8').replaceAll('Open Cowork', () => brandName)
+  const outputPath = join(options.outputDir, 'startup-splash.html')
+  writeFileAtomic(outputPath, html, { mode: 0o600 })
+  return outputPath
+}

--- a/tests/runtime-content.test.ts
+++ b/tests/runtime-content.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeRuntimeAgentsFile } from '../apps/desktop/src/main/runtime-content.ts'
+
+test('writeRuntimeAgentsFile writes the runtime AGENTS mirror privately', () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-runtime-agents-'))
+
+  try {
+    const sourcePath = join(root, 'AGENTS.md')
+    const runtimeHome = join(root, 'runtime-home')
+    writeFileSync(sourcePath, '# Runtime Instructions\n')
+
+    writeRuntimeAgentsFile(runtimeHome, sourcePath)
+
+    const outputPath = join(runtimeHome, 'AGENTS.md')
+    assert.equal(readFileSync(outputPath, 'utf-8'), '# Runtime Instructions\n')
+    assert.equal(statSync(outputPath).mode & 0o777, 0o600)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/tests/startup-splash.test.ts
+++ b/tests/startup-splash.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeStartupSplashFile } from '../apps/desktop/src/main/startup-splash.ts'
+
+test('writeStartupSplashFile writes escaped branded HTML privately', () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-startup-splash-'))
+
+  try {
+    const templatePath = join(root, 'template.html')
+    writeFileSync(templatePath, '<title>Open Cowork</title><h1>Open Cowork</h1>')
+
+    const outputPath = writeStartupSplashFile({
+      templatePath,
+      outputDir: join(root, 'user-data', 'startup'),
+      brandName: '<Acme & Co>',
+    })
+
+    assert.equal(
+      readFileSync(outputPath, 'utf-8'),
+      '<title>&lt;Acme &amp; Co&gt;</title><h1>&lt;Acme &amp; Co&gt;</h1>',
+    )
+    assert.equal(statSync(outputPath).mode & 0o777, 0o600)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- move startup splash generation into a testable helper that writes via writeFileAtomic with private permissions
- write the managed runtime AGENTS.md mirror atomically with private permissions
- add focused regression tests for both generated files

## Validation
- pnpm test -- --test-name-pattern="startup splash|runtime AGENTS"
- pnpm typecheck
- pnpm lint
- git diff --cached --check