### PR TITLE
Split session view task-run helpers

### DIFF
--- a/apps/desktop/src/lib/session-view-model.ts
+++ b/apps/desktop/src/lib/session-view-model.ts
@@ -8,7 +8,6 @@ import type {
   SessionTokens,
   SessionView,
   TaskRun,
-  TaskTranscriptSegment,
   TodoItem,
   ToolCall,
 } from '@open-cowork/shared'
@@ -33,7 +32,16 @@ import {
   type MessageStateShape,
 } from './session-view-messages.ts'
 import { nextSeq, observeSeq, nowTs } from './session-view-sequence.ts'
-import { mergeStreamingText, preferNewerStreamingText } from './session-view-text.ts'
+import {
+  deriveExecutionPlan,
+  ensureTaskRunTimingsForView,
+  renderTaskTranscript,
+  upsertTaskRunList,
+  withTaskRun,
+  withTaskTranscript,
+} from './session-view-task-runs.ts'
+import { cloneTokens, EMPTY_SESSION_TOKENS } from './session-view-tokens.ts'
+import { preferNewerStreamingText } from './session-view-text.ts'
 
 export { beginCompactionNotice, cloneCompactionNotice, finishCompactionNotice } from './session-view-compaction.ts'
 export {
@@ -44,17 +52,16 @@ export {
   withMessageText,
 } from './session-view-messages.ts'
 export { nextSeq, nowTs } from './session-view-sequence.ts'
+export {
+  createEmptyTaskRun,
+  upsertTaskRunList,
+  withTaskRun,
+  withTaskTranscript,
+} from './session-view-task-runs.ts'
 export { mergeStreamingText } from './session-view-text.ts'
+export { cloneTokens, EMPTY_SESSION_TOKENS } from './session-view-tokens.ts'
 
 export const MAX_WARM_SESSION_DETAILS = 12
-
-export const EMPTY_SESSION_TOKENS: SessionTokens = {
-  input: 0,
-  output: 0,
-  reasoning: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-}
 
 export type HistoryItem = {
   type?: string
@@ -129,134 +136,6 @@ export interface SessionViewState {
   lastEventAt: number
 }
 
-export function cloneTokens(tokens: SessionTokens): SessionTokens {
-  return {
-    input: tokens.input,
-    output: tokens.output,
-    reasoning: tokens.reasoning,
-    cacheRead: tokens.cacheRead,
-    cacheWrite: tokens.cacheWrite,
-  }
-}
-
-function appendTaskTranscript(existing: string, incoming: string, options?: { boundary?: boolean }) {
-  if (!incoming) return existing
-  if (!existing) return incoming
-
-  const boundary = options?.boundary
-    || /^(#{1,6}\s|[-*]\s|\d+\.\s|>|\n)/.test(incoming)
-  const separated = existing.endsWith('\n') || incoming.startsWith('\n')
-
-  if (!boundary) {
-    return mergeStreamingText(existing, incoming)
-  }
-
-  if (separated) {
-    return `${existing}${incoming}`
-  }
-
-  return `${existing}\n\n${incoming}`
-}
-
-function sortTaskTranscript(transcript: TaskTranscriptSegment[]) {
-  return transcript.slice().sort((a, b) => a.order - b.order)
-}
-
-function renderTaskTranscript(transcript: TaskTranscriptSegment[]) {
-  return sortTaskTranscript(transcript)
-    .map((segment) => segment.content)
-    .filter(Boolean)
-    .join('\n\n')
-}
-
-function appendTaskTranscriptSegment(
-  transcript: TaskTranscriptSegment[],
-  segmentId: string,
-  incoming: string,
-  options?: { boundary?: boolean; replace?: boolean },
-) {
-  if (!incoming) return transcript
-
-  const existing = transcript.find((segment) => segment.id === segmentId)
-  if (!existing) {
-    return [...transcript, { id: segmentId, content: incoming, order: nextSeq() }]
-  }
-
-  return transcript.map((segment) => segment.id === segmentId
-    ? {
-        ...segment,
-        content: options?.replace ? incoming : appendTaskTranscript(segment.content, incoming, options),
-      }
-    : segment)
-}
-
-export function withTaskTranscript(
-  taskRun: TaskRun,
-  segmentId: string,
-  incoming: string,
-  options?: { boundary?: boolean; replace?: boolean },
-) {
-  const transcript = appendTaskTranscriptSegment(taskRun.transcript, segmentId, incoming, options)
-  return {
-    ...taskRun,
-    transcript,
-    content: renderTaskTranscript(transcript),
-  }
-}
-
-export function createEmptyTaskRun(input: {
-  id: string
-  title?: string
-  agent?: string | null
-  status?: TaskRun['status']
-  sourceSessionId?: string | null
-  parentSessionId?: string | null
-  content?: string
-  transcript?: TaskTranscriptSegment[]
-  toolCalls?: ToolCall[]
-  compactions?: CompactionNotice[]
-  todos?: TodoItem[]
-  error?: string | null
-  sessionCost?: number
-  sessionTokens?: SessionTokens
-  order?: number
-  startedAt?: string | null
-  finishedAt?: string | null
-}): TaskRun {
-  const transcript = input.transcript
-    ? input.transcript
-    : input.content
-      ? [{ id: `${input.id}:initial`, content: input.content, order: nextSeq() }]
-      : []
-  observeSeq(input.order)
-  for (const segment of transcript) observeSeq(segment.order)
-  for (const tool of input.toolCalls || []) observeSeq(tool.order)
-  for (const notice of input.compactions || []) observeSeq(notice.order)
-
-  const status = input.status || 'queued'
-  const nowIso = new Date(nowTs()).toISOString()
-
-  return {
-    id: input.id,
-    title: input.title || 'Sub-Agent',
-    agent: input.agent || null,
-    status,
-    sourceSessionId: input.sourceSessionId || null,
-    parentSessionId: input.parentSessionId ?? null,
-    content: input.content || renderTaskTranscript(transcript),
-    transcript,
-    toolCalls: input.toolCalls || [],
-    compactions: (input.compactions || []).map(cloneCompactionNotice),
-    todos: input.todos || [],
-    error: input.error || null,
-    sessionCost: input.sessionCost || 0,
-    sessionTokens: cloneTokens(input.sessionTokens || EMPTY_SESSION_TOKENS),
-    order: input.order ?? nextSeq(),
-    startedAt: input.startedAt ?? (status === 'running' ? nowIso : null),
-    finishedAt: input.finishedAt ?? (status === 'complete' || status === 'error' ? nowIso : null),
-  }
-}
-
 function syncSessionSequence(state: SessionViewState) {
   for (const messageId of state.messageIds) {
     const message = state.messageById[messageId]
@@ -281,121 +160,6 @@ function syncSessionSequence(state: SessionViewState) {
   for (const notice of state.compactions) observeSeq(notice.order)
   for (const approval of state.pendingApprovals) observeSeq(approval.order)
   for (const error of state.errors) observeSeq(error.order)
-}
-
-export function upsertTaskRunList(taskRuns: TaskRun[], input: {
-  id: string
-  title?: string
-  agent?: string | null
-  status?: TaskRun['status']
-  sourceSessionId?: string | null
-  parentSessionId?: string | null
-  content?: string
-  transcript?: TaskTranscriptSegment[]
-  toolCalls?: ToolCall[]
-  compactions?: CompactionNotice[]
-  todos?: TodoItem[]
-  error?: string | null
-  sessionCost?: number
-  sessionTokens?: SessionTokens
-  order?: number
-  // Optional explicit anchors. Provided by the history replay path so
-  // rehydrated terminal tasks don't lose their duration — without them
-  // `createEmptyTaskRun` defaults both to null and the elapsed clock
-  // renders 0s.
-  startedAt?: string | null
-  finishedAt?: string | null
-}) {
-  const existing = taskRuns.find((taskRun) => taskRun.id === input.id)
-  if (!existing) {
-    return [...taskRuns, createEmptyTaskRun(input)]
-  }
-
-  return taskRuns.map((taskRun) => {
-    if (taskRun.id !== input.id) return taskRun
-    const incoming = input as TaskRun & { startedAt?: string | null; finishedAt?: string | null }
-    const nextStatus = input.status !== undefined ? input.status : taskRun.status
-    const nowIso = new Date(nowTs()).toISOString()
-    // Precedence: explicit caller-provided timestamp → existing task timestamp
-    // → derived from status transition. This keeps the clock stable across
-    // snapshots and lets callers override when they know better.
-    const startedAt = incoming.startedAt
-      ?? taskRun.startedAt
-      ?? (nextStatus === 'running' ? nowIso : null)
-    const finishedAt = incoming.finishedAt
-      ?? taskRun.finishedAt
-      ?? ((nextStatus === 'complete' || nextStatus === 'error') ? nowIso : null)
-    return {
-      ...taskRun,
-      ...(input.title !== undefined ? { title: input.title } : {}),
-      ...(input.agent !== undefined ? { agent: input.agent } : {}),
-      ...(input.status !== undefined ? { status: input.status } : {}),
-      ...(input.sourceSessionId !== undefined ? { sourceSessionId: input.sourceSessionId } : {}),
-      ...(input.parentSessionId !== undefined ? { parentSessionId: input.parentSessionId } : {}),
-      ...(input.content !== undefined ? { content: input.content } : {}),
-      ...(input.transcript !== undefined
-        ? {
-            transcript: input.transcript,
-            content: input.content !== undefined ? input.content : renderTaskTranscript(input.transcript),
-          }
-        : {}),
-      ...(input.toolCalls !== undefined ? { toolCalls: input.toolCalls } : {}),
-      ...(input.compactions !== undefined ? { compactions: input.compactions.map(cloneCompactionNotice) } : {}),
-      ...(input.todos !== undefined ? { todos: input.todos } : {}),
-      ...(input.error !== undefined ? { error: input.error } : {}),
-      ...(input.sessionCost !== undefined ? { sessionCost: input.sessionCost } : {}),
-      ...(input.sessionTokens !== undefined ? { sessionTokens: cloneTokens(input.sessionTokens) } : {}),
-      startedAt,
-      finishedAt,
-    }
-  })
-}
-
-export function withTaskRun(taskRuns: TaskRun[], taskRunId: string, updater: (taskRun: TaskRun) => TaskRun) {
-  const existing = taskRuns.find((taskRun) => taskRun.id === taskRunId) || createEmptyTaskRun({ id: taskRunId })
-  const next = updater(existing)
-  return upsertTaskRunList(taskRuns, next)
-}
-
-function deriveExecutionPlan(taskRuns: TaskRun[], busy: boolean): ExecutionPlanItem[] {
-  if (taskRuns.length === 0) return []
-
-  const orderedTaskRuns = taskRuns.slice().sort((a, b) => a.order - b.order)
-  const anyError = orderedTaskRuns.some((taskRun) => taskRun.status === 'error')
-  const allComplete = orderedTaskRuns.every((taskRun) => taskRun.status === 'complete')
-
-  const synthStatus = anyError
-    ? 'blocked'
-    : allComplete
-      ? (busy ? 'in_progress' : 'completed')
-      : 'pending'
-
-  return [
-    {
-      id: 'execution:launch',
-      content: `Launch ${orderedTaskRuns.length} sub-agent branch${orderedTaskRuns.length === 1 ? '' : 'es'}`,
-      status: 'completed',
-      priority: 'high',
-    },
-    ...orderedTaskRuns.map((taskRun) => ({
-      id: `execution:${taskRun.id}`,
-      content: taskRun.title,
-      status: taskRun.status === 'complete'
-        ? 'completed'
-        : taskRun.status === 'error'
-          ? 'blocked'
-          : taskRun.status === 'queued'
-            ? 'pending'
-            : 'in_progress',
-      priority: 'medium',
-    })),
-    {
-      id: 'execution:synthesize',
-      content: 'Synthesize the final answer',
-      status: synthStatus,
-      priority: 'high',
-    },
-  ]
 }
 
 export function createEmptySessionViewState(overrides: Partial<SessionViewState> = {}): SessionViewState {
@@ -461,35 +225,6 @@ export function pruneSessionDetailCache(
   }
 
   return changed ? next : sessionStateById
-}
-
-// Defensive backfill: guarantee task runs have stable timing anchors so
-// the renderer never mistakes an old terminal task for a still-live one.
-// - Running tasks without startedAt get the session's lastEventAt.
-// - Terminal tasks (complete / error) normalize missing startedAt or
-//   finishedAt to a shared timestamp so the elapsed clock stays bounded.
-function ensureTaskRunTimingsForView(taskRuns: TaskRun[], lastEventAt: number): TaskRun[] {
-  let patched = false
-  const sessionAnchor = lastEventAt > 0 ? new Date(lastEventAt).toISOString() : new Date(nowTs()).toISOString()
-  const next = taskRuns.map((taskRun) => {
-    if (taskRun.status === 'running') {
-      if (taskRun.startedAt) return taskRun
-      patched = true
-      return { ...taskRun, startedAt: sessionAnchor }
-    }
-
-    if (taskRun.status === 'complete' || taskRun.status === 'error') {
-      const startedAt = taskRun.startedAt ?? taskRun.finishedAt ?? sessionAnchor
-      const finishedAt = taskRun.finishedAt ?? startedAt
-      if (startedAt !== taskRun.startedAt || finishedAt !== taskRun.finishedAt) {
-        patched = true
-        return { ...taskRun, startedAt, finishedAt }
-      }
-    }
-
-    return taskRun
-  })
-  return patched ? next : taskRuns
 }
 
 export function deriveVisibleSessionPatch(

--- a/apps/desktop/src/lib/session-view-task-runs.ts
+++ b/apps/desktop/src/lib/session-view-task-runs.ts
@@ -1,0 +1,269 @@
+import type {
+  CompactionNotice,
+  ExecutionPlanItem,
+  SessionTokens,
+  TaskRun,
+  TaskTranscriptSegment,
+  ToolCall,
+} from '@open-cowork/shared'
+import { cloneCompactionNotice } from './session-view-compaction.ts'
+import { nextSeq, observeSeq, nowTs } from './session-view-sequence.ts'
+import { mergeStreamingText } from './session-view-text.ts'
+import { cloneTokens, EMPTY_SESSION_TOKENS } from './session-view-tokens.ts'
+
+function appendTaskTranscript(existing: string, incoming: string, options?: { boundary?: boolean }) {
+  if (!incoming) return existing
+  if (!existing) return incoming
+
+  const boundary = options?.boundary
+    || /^(#{1,6}\s|[-*]\s|\d+\.\s|>|\n)/.test(incoming)
+  const separated = existing.endsWith('\n') || incoming.startsWith('\n')
+
+  if (!boundary) {
+    return mergeStreamingText(existing, incoming)
+  }
+
+  if (separated) {
+    return `${existing}${incoming}`
+  }
+
+  return `${existing}\n\n${incoming}`
+}
+
+function sortTaskTranscript(transcript: TaskTranscriptSegment[]) {
+  return transcript.slice().sort((a, b) => a.order - b.order)
+}
+
+export function renderTaskTranscript(transcript: TaskTranscriptSegment[]) {
+  return sortTaskTranscript(transcript)
+    .map((segment) => segment.content)
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+function appendTaskTranscriptSegment(
+  transcript: TaskTranscriptSegment[],
+  segmentId: string,
+  incoming: string,
+  options?: { boundary?: boolean; replace?: boolean },
+) {
+  if (!incoming) return transcript
+
+  const existing = transcript.find((segment) => segment.id === segmentId)
+  if (!existing) {
+    return [...transcript, { id: segmentId, content: incoming, order: nextSeq() }]
+  }
+
+  return transcript.map((segment) => segment.id === segmentId
+    ? {
+        ...segment,
+        content: options?.replace ? incoming : appendTaskTranscript(segment.content, incoming, options),
+      }
+    : segment)
+}
+
+export function withTaskTranscript(
+  taskRun: TaskRun,
+  segmentId: string,
+  incoming: string,
+  options?: { boundary?: boolean; replace?: boolean },
+) {
+  const transcript = appendTaskTranscriptSegment(taskRun.transcript, segmentId, incoming, options)
+  return {
+    ...taskRun,
+    transcript,
+    content: renderTaskTranscript(transcript),
+  }
+}
+
+export function createEmptyTaskRun(input: {
+  id: string
+  title?: string
+  agent?: string | null
+  status?: TaskRun['status']
+  sourceSessionId?: string | null
+  parentSessionId?: string | null
+  content?: string
+  transcript?: TaskTranscriptSegment[]
+  toolCalls?: ToolCall[]
+  compactions?: CompactionNotice[]
+  todos?: TaskRun['todos']
+  error?: string | null
+  sessionCost?: number
+  sessionTokens?: SessionTokens
+  order?: number
+  startedAt?: string | null
+  finishedAt?: string | null
+}): TaskRun {
+  const transcript = input.transcript
+    ? input.transcript
+    : input.content
+      ? [{ id: `${input.id}:initial`, content: input.content, order: nextSeq() }]
+      : []
+  observeSeq(input.order)
+  for (const segment of transcript) observeSeq(segment.order)
+  for (const tool of input.toolCalls || []) observeSeq(tool.order)
+  for (const notice of input.compactions || []) observeSeq(notice.order)
+
+  const status = input.status || 'queued'
+  const nowIso = new Date(nowTs()).toISOString()
+
+  return {
+    id: input.id,
+    title: input.title || 'Sub-Agent',
+    agent: input.agent || null,
+    status,
+    sourceSessionId: input.sourceSessionId || null,
+    parentSessionId: input.parentSessionId ?? null,
+    content: input.content || renderTaskTranscript(transcript),
+    transcript,
+    toolCalls: input.toolCalls || [],
+    compactions: (input.compactions || []).map(cloneCompactionNotice),
+    todos: input.todos || [],
+    error: input.error || null,
+    sessionCost: input.sessionCost || 0,
+    sessionTokens: cloneTokens(input.sessionTokens || EMPTY_SESSION_TOKENS),
+    order: input.order ?? nextSeq(),
+    startedAt: input.startedAt ?? (status === 'running' ? nowIso : null),
+    finishedAt: input.finishedAt ?? (status === 'complete' || status === 'error' ? nowIso : null),
+  }
+}
+
+export function upsertTaskRunList(taskRuns: TaskRun[], input: {
+  id: string
+  title?: string
+  agent?: string | null
+  status?: TaskRun['status']
+  sourceSessionId?: string | null
+  parentSessionId?: string | null
+  content?: string
+  transcript?: TaskTranscriptSegment[]
+  toolCalls?: ToolCall[]
+  compactions?: CompactionNotice[]
+  todos?: TaskRun['todos']
+  error?: string | null
+  sessionCost?: number
+  sessionTokens?: SessionTokens
+  order?: number
+  // Optional explicit anchors. Provided by the history replay path so
+  // rehydrated terminal tasks don't lose their duration.
+  startedAt?: string | null
+  finishedAt?: string | null
+}) {
+  const existing = taskRuns.find((taskRun) => taskRun.id === input.id)
+  if (!existing) {
+    return [...taskRuns, createEmptyTaskRun(input)]
+  }
+
+  return taskRuns.map((taskRun) => {
+    if (taskRun.id !== input.id) return taskRun
+    const incoming = input as TaskRun & { startedAt?: string | null; finishedAt?: string | null }
+    const nextStatus = input.status !== undefined ? input.status : taskRun.status
+    const nowIso = new Date(nowTs()).toISOString()
+    // Precedence: explicit caller-provided timestamp, existing task
+    // timestamp, then derived from status transition. This keeps clocks
+    // stable across snapshots while allowing better caller knowledge.
+    const startedAt = incoming.startedAt
+      ?? taskRun.startedAt
+      ?? (nextStatus === 'running' ? nowIso : null)
+    const finishedAt = incoming.finishedAt
+      ?? taskRun.finishedAt
+      ?? ((nextStatus === 'complete' || nextStatus === 'error') ? nowIso : null)
+    return {
+      ...taskRun,
+      ...(input.title !== undefined ? { title: input.title } : {}),
+      ...(input.agent !== undefined ? { agent: input.agent } : {}),
+      ...(input.status !== undefined ? { status: input.status } : {}),
+      ...(input.sourceSessionId !== undefined ? { sourceSessionId: input.sourceSessionId } : {}),
+      ...(input.parentSessionId !== undefined ? { parentSessionId: input.parentSessionId } : {}),
+      ...(input.content !== undefined ? { content: input.content } : {}),
+      ...(input.transcript !== undefined
+        ? {
+            transcript: input.transcript,
+            content: input.content !== undefined ? input.content : renderTaskTranscript(input.transcript),
+          }
+        : {}),
+      ...(input.toolCalls !== undefined ? { toolCalls: input.toolCalls } : {}),
+      ...(input.compactions !== undefined ? { compactions: input.compactions.map(cloneCompactionNotice) } : {}),
+      ...(input.todos !== undefined ? { todos: input.todos } : {}),
+      ...(input.error !== undefined ? { error: input.error } : {}),
+      ...(input.sessionCost !== undefined ? { sessionCost: input.sessionCost } : {}),
+      ...(input.sessionTokens !== undefined ? { sessionTokens: cloneTokens(input.sessionTokens) } : {}),
+      startedAt,
+      finishedAt,
+    }
+  })
+}
+
+export function withTaskRun(taskRuns: TaskRun[], taskRunId: string, updater: (taskRun: TaskRun) => TaskRun) {
+  const existing = taskRuns.find((taskRun) => taskRun.id === taskRunId) || createEmptyTaskRun({ id: taskRunId })
+  const next = updater(existing)
+  return upsertTaskRunList(taskRuns, next)
+}
+
+export function deriveExecutionPlan(taskRuns: TaskRun[], busy: boolean): ExecutionPlanItem[] {
+  if (taskRuns.length === 0) return []
+
+  const orderedTaskRuns = taskRuns.slice().sort((a, b) => a.order - b.order)
+  const anyError = orderedTaskRuns.some((taskRun) => taskRun.status === 'error')
+  const allComplete = orderedTaskRuns.every((taskRun) => taskRun.status === 'complete')
+
+  const synthStatus = anyError
+    ? 'blocked'
+    : allComplete
+      ? (busy ? 'in_progress' : 'completed')
+      : 'pending'
+
+  return [
+    {
+      id: 'execution:launch',
+      content: `Launch ${orderedTaskRuns.length} sub-agent branch${orderedTaskRuns.length === 1 ? '' : 'es'}`,
+      status: 'completed',
+      priority: 'high',
+    },
+    ...orderedTaskRuns.map((taskRun) => ({
+      id: `execution:${taskRun.id}`,
+      content: taskRun.title,
+      status: taskRun.status === 'complete'
+        ? 'completed'
+        : taskRun.status === 'error'
+          ? 'blocked'
+          : taskRun.status === 'queued'
+            ? 'pending'
+            : 'in_progress',
+      priority: 'medium',
+    })),
+    {
+      id: 'execution:synthesize',
+      content: 'Synthesize the final answer',
+      status: synthStatus,
+      priority: 'high',
+    },
+  ]
+}
+
+export function ensureTaskRunTimingsForView(taskRuns: TaskRun[], lastEventAt: number): TaskRun[] {
+  // Defensive backfill: keep terminal task clocks bounded when older
+  // persisted/hydrated task records are missing timing anchors.
+  let patched = false
+  const sessionAnchor = lastEventAt > 0 ? new Date(lastEventAt).toISOString() : new Date(nowTs()).toISOString()
+  const next = taskRuns.map((taskRun) => {
+    if (taskRun.status === 'running') {
+      if (taskRun.startedAt) return taskRun
+      patched = true
+      return { ...taskRun, startedAt: sessionAnchor }
+    }
+
+    if (taskRun.status === 'complete' || taskRun.status === 'error') {
+      const startedAt = taskRun.startedAt ?? taskRun.finishedAt ?? sessionAnchor
+      const finishedAt = taskRun.finishedAt ?? startedAt
+      if (startedAt !== taskRun.startedAt || finishedAt !== taskRun.finishedAt) {
+        patched = true
+        return { ...taskRun, startedAt, finishedAt }
+      }
+    }
+
+    return taskRun
+  })
+  return patched ? next : taskRuns
+}

--- a/apps/desktop/src/lib/session-view-tokens.ts
+++ b/apps/desktop/src/lib/session-view-tokens.ts
@@ -1,0 +1,19 @@
+import type { SessionTokens } from '@open-cowork/shared'
+
+export const EMPTY_SESSION_TOKENS: SessionTokens = {
+  input: 0,
+  output: 0,
+  reasoning: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+}
+
+export function cloneTokens(tokens: SessionTokens): SessionTokens {
+  return {
+    input: tokens.input,
+    output: tokens.output,
+    reasoning: tokens.reasoning,
+    cacheRead: tokens.cacheRead,
+    cacheWrite: tokens.cacheWrite,
+  }
+}


### PR DESCRIPTION
## Summary
- extract task-run transcript/upsert/execution-plan helpers out of session-view-model
- extract reusable session token cloning constants into a tiny helper module
- preserve the existing session-view-model public exports so renderer/main imports do not change

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test -- --test-name-pattern='session view|task-run|session store|history replay|session engine'
- pnpm test:renderer
- git diff --check