### PR TITLE
Split managed runtime server helpers

### DIFF
--- a/apps/desktop/src/main/runtime-managed-server.ts
+++ b/apps/desktop/src/main/runtime-managed-server.ts
@@ -1,0 +1,209 @@
+import type { ServerOptions as OpencodeServerOptions } from '@opencode-ai/sdk/v2/server'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+
+export function buildManagedOpencodeServerEnvironment(
+  env: NodeJS.ProcessEnv,
+  config: OpencodeServerOptions['config'],
+) {
+  return {
+    ...env,
+    OPENCODE_CONFIG_CONTENT: JSON.stringify(config ?? {}),
+  }
+}
+
+export function resolveManagedOpencodeCommand(opencodeBinPath?: string | null) {
+  const explicitBinary = opencodeBinPath?.trim()
+  return explicitBinary || 'opencode'
+}
+
+export function resolveManagedOpencodeSpawn(
+  env: NodeJS.ProcessEnv,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  opencodeBinPath?: string | null,
+) {
+  const explicitBinary = resolveManagedOpencodeCommand(opencodeBinPath)
+  if (explicitBinary !== 'opencode') return { command: explicitBinary, args }
+  if (platform === 'win32') {
+    return {
+      command: env.ComSpec?.trim() || env.COMSPEC?.trim() || 'cmd.exe',
+      args: ['/d', '/s', '/c', 'opencode', ...args],
+    }
+  }
+  return { command: 'opencode', args }
+}
+
+const OPENCODE_SERVER_LISTENING_PREFIX = 'opencode server listening'
+
+export interface ManagedOpencodeServerStdoutParseResult {
+  buffer: string
+  url?: string
+  error?: string
+}
+
+function extractManagedOpencodeServerUrl(line: string) {
+  if (!line.startsWith(OPENCODE_SERVER_LISTENING_PREFIX)) return null
+  return line.match(/on\s+(https?:\/\/[^\s]+)/)?.[1] || null
+}
+
+export function parseManagedOpencodeServerStdoutChunk(
+  buffer: string,
+  chunk: string,
+): ManagedOpencodeServerStdoutParseResult {
+  const text = buffer + chunk
+  const lines = text.split('\n')
+  const nextBuffer = lines.pop() ?? ''
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '')
+    const url = extractManagedOpencodeServerUrl(line)
+    if (url) return { buffer: nextBuffer, url }
+    if (line.startsWith(OPENCODE_SERVER_LISTENING_PREFIX)) {
+      return { buffer: nextBuffer, error: `Failed to parse server url from output: ${line}` }
+    }
+  }
+
+  return { buffer: nextBuffer }
+}
+
+function stopManagedOpencodeProcess(proc: ChildProcess) {
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+  if (process.platform === 'win32' && proc.pid) {
+    const out = spawnSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { windowsHide: true })
+    if (!out.error && out.status === 0) return
+  }
+  proc.kill()
+}
+
+export interface ManagedProcessOutputStreams {
+  stdout?: { resume(): unknown } | null
+  stderr?: { resume(): unknown } | null
+}
+
+export function drainManagedOpencodeProcessOutput(proc: ManagedProcessOutputStreams) {
+  // Startup parsing stops once the server URL is known, but the child
+  // keeps its stdout/stderr pipes. Keep draining them without retaining
+  // logs so noisy runtime output cannot fill the pipe buffer.
+  proc.stdout?.resume()
+  proc.stderr?.resume()
+}
+
+function bindManagedOpencodeAbort(proc: ChildProcess, signal?: AbortSignal, onAbort?: () => void) {
+  if (!signal) return () => undefined
+  const clear = () => {
+    signal.removeEventListener('abort', abort)
+    proc.off('exit', clear)
+    proc.off('error', clear)
+  }
+  const abort = () => {
+    clear()
+    stopManagedOpencodeProcess(proc)
+    onAbort?.()
+  }
+
+  signal.addEventListener('abort', abort, { once: true })
+  proc.on('exit', clear)
+  proc.on('error', clear)
+  if (signal.aborted) abort()
+  return clear
+}
+
+export async function createManagedOpencodeServer(options: OpencodeServerOptions & { env: NodeJS.ProcessEnv; opencodeBinPath?: string | null }) {
+  const resolved = {
+    hostname: '127.0.0.1',
+    port: 4096,
+    timeout: 5000,
+    ...options,
+  }
+  const args = ['serve', `--hostname=${resolved.hostname}`, `--port=${resolved.port}`]
+  if (resolved.config?.logLevel) args.push(`--log-level=${resolved.config.logLevel}`)
+
+  const spawnPlan = resolveManagedOpencodeSpawn(resolved.env, args, process.platform, resolved.opencodeBinPath)
+  const proc = spawn(spawnPlan.command, spawnPlan.args, {
+    env: buildManagedOpencodeServerEnvironment(resolved.env, resolved.config),
+    windowsHide: true,
+  })
+
+  let clear: () => void = () => undefined
+  const url = await new Promise<string>((resolveUrl, reject) => {
+    let output = ''
+    let stdoutBuffer = ''
+    let startupSettled = false
+
+    function cleanupStartupListeners() {
+      proc.stdout?.off('data', onStdoutData)
+      proc.stderr?.off('data', onStderrData)
+      proc.off('exit', onExit)
+      proc.off('error', onError)
+    }
+
+    function settleStartup(callback: () => void) {
+      if (startupSettled) return
+      startupSettled = true
+      clearTimeout(id)
+      cleanupStartupListeners()
+      callback()
+    }
+
+    function rejectStartup(error: Error, stopProcess = false) {
+      settleStartup(() => reject(error))
+      clear()
+      if (stopProcess) stopManagedOpencodeProcess(proc)
+    }
+
+    const id = setTimeout(() => {
+      rejectStartup(new Error(`Timeout waiting for server to start after ${resolved.timeout}ms`), true)
+    }, resolved.timeout)
+
+    function onStdoutData(chunk: Buffer) {
+      if (startupSettled) return
+      const text = chunk.toString()
+      output += text
+      const parsed = parseManagedOpencodeServerStdoutChunk(stdoutBuffer, text)
+      stdoutBuffer = parsed.buffer
+      if (parsed.error) {
+        rejectStartup(new Error(parsed.error), true)
+        return
+      }
+      if (parsed.url) {
+        const startupUrl = parsed.url
+        settleStartup(() => {
+          drainManagedOpencodeProcessOutput(proc)
+          resolveUrl(startupUrl)
+        })
+      }
+    }
+
+    function onStderrData(chunk: Buffer) {
+      if (startupSettled) return
+      output += chunk.toString()
+    }
+
+    function onExit(code: number | null) {
+      let message = `Server exited with code ${code}`
+      if (output.trim()) message += `\nServer output: ${output}`
+      rejectStartup(new Error(message))
+    }
+
+    function onError(error: Error) {
+      rejectStartup(error)
+    }
+
+    proc.stdout?.on('data', onStdoutData)
+    proc.stderr?.on('data', onStderrData)
+    proc.on('exit', onExit)
+    proc.on('error', onError)
+
+    clear = bindManagedOpencodeAbort(proc, resolved.signal, () => {
+      settleStartup(() => reject(resolved.signal?.reason))
+    })
+  })
+
+  return {
+    url,
+    close() {
+      clear()
+      stopManagedOpencodeProcess(proc)
+    },
+  }
+}

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -5,7 +5,6 @@ import {
 } from '@opencode-ai/sdk/v2'
 import type { ServerOptions as OpencodeServerOptions } from '@opencode-ai/sdk/v2/server'
 import type { ModelInfoSnapshot } from '@open-cowork/shared'
-import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join, resolve, win32 } from 'path'
@@ -28,6 +27,7 @@ import { copySkillsAndAgents } from './runtime-content.ts'
 import { getOrCreateDirectoryClient } from './runtime-client-cache.ts'
 import { syncRuntimeHomeToolingBridge } from './runtime-home-bridge.ts'
 import { verifyRuntimeSkillCatalog } from './runtime-skill-verifier.ts'
+import { createManagedOpencodeServer } from './runtime-managed-server.ts'
 import {
   cleanupOrphanedManagedOpencodeProcesses,
   OPEN_COWORK_MANAGED_RUNTIME_ENV,
@@ -38,6 +38,16 @@ import {
 } from './runtime-process-cleanup.ts'
 
 export { getRuntimeHomeDir } from './runtime-paths.ts'
+export {
+  buildManagedOpencodeServerEnvironment,
+  createManagedOpencodeServer,
+  drainManagedOpencodeProcessOutput,
+  parseManagedOpencodeServerStdoutChunk,
+  resolveManagedOpencodeCommand,
+  resolveManagedOpencodeSpawn,
+  type ManagedOpencodeServerStdoutParseResult,
+  type ManagedProcessOutputStreams,
+} from './runtime-managed-server.ts'
 
 let client: V2OpencodeClient | null = null
 let serverUrl: string | null = null
@@ -308,213 +318,6 @@ export function buildManagedRuntimeEnvironment(input: {
   if (input.enableNativeWebSearch) env.OPENCODE_ENABLE_EXA = '1'
   if (input.adcPath) env.GOOGLE_APPLICATION_CREDENTIALS = input.adcPath
   return env
-}
-
-export function buildManagedOpencodeServerEnvironment(
-  env: NodeJS.ProcessEnv,
-  config: OpencodeServerOptions['config'],
-) {
-  return {
-    ...env,
-    OPENCODE_CONFIG_CONTENT: JSON.stringify(config ?? {}),
-  }
-}
-
-export function resolveManagedOpencodeCommand(opencodeBinPath?: string | null) {
-  const explicitBinary = opencodeBinPath?.trim()
-  return explicitBinary || 'opencode'
-}
-
-export function resolveManagedOpencodeSpawn(
-  env: NodeJS.ProcessEnv,
-  args: string[],
-  platform: NodeJS.Platform = process.platform,
-  opencodeBinPath?: string | null,
-) {
-  const explicitBinary = resolveManagedOpencodeCommand(opencodeBinPath)
-  if (explicitBinary !== 'opencode') return { command: explicitBinary, args }
-  if (platform === 'win32') {
-    return {
-      command: env.ComSpec?.trim() || env.COMSPEC?.trim() || 'cmd.exe',
-      args: ['/d', '/s', '/c', 'opencode', ...args],
-    }
-  }
-  return { command: 'opencode', args }
-}
-
-const OPENCODE_SERVER_LISTENING_PREFIX = 'opencode server listening'
-
-export interface ManagedOpencodeServerStdoutParseResult {
-  buffer: string
-  url?: string
-  error?: string
-}
-
-function extractManagedOpencodeServerUrl(line: string) {
-  if (!line.startsWith(OPENCODE_SERVER_LISTENING_PREFIX)) return null
-  return line.match(/on\s+(https?:\/\/[^\s]+)/)?.[1] || null
-}
-
-export function parseManagedOpencodeServerStdoutChunk(
-  buffer: string,
-  chunk: string,
-): ManagedOpencodeServerStdoutParseResult {
-  const text = buffer + chunk
-  const lines = text.split('\n')
-  const nextBuffer = lines.pop() ?? ''
-
-  for (const rawLine of lines) {
-    const line = rawLine.replace(/\r$/, '')
-    const url = extractManagedOpencodeServerUrl(line)
-    if (url) return { buffer: nextBuffer, url }
-    if (line.startsWith(OPENCODE_SERVER_LISTENING_PREFIX)) {
-      return { buffer: nextBuffer, error: `Failed to parse server url from output: ${line}` }
-    }
-  }
-
-  return { buffer: nextBuffer }
-}
-
-function stopManagedOpencodeProcess(proc: ChildProcess) {
-  if (proc.exitCode !== null || proc.signalCode !== null) return
-  if (process.platform === 'win32' && proc.pid) {
-    const out = spawnSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { windowsHide: true })
-    if (!out.error && out.status === 0) return
-  }
-  proc.kill()
-}
-
-export interface ManagedProcessOutputStreams {
-  stdout?: { resume(): unknown } | null
-  stderr?: { resume(): unknown } | null
-}
-
-export function drainManagedOpencodeProcessOutput(proc: ManagedProcessOutputStreams) {
-  // Startup parsing stops once the server URL is known, but the child
-  // keeps its stdout/stderr pipes. Keep draining them without retaining
-  // logs so noisy runtime output cannot fill the pipe buffer.
-  proc.stdout?.resume()
-  proc.stderr?.resume()
-}
-
-function bindManagedOpencodeAbort(proc: ChildProcess, signal?: AbortSignal, onAbort?: () => void) {
-  if (!signal) return () => undefined
-  const clear = () => {
-    signal.removeEventListener('abort', abort)
-    proc.off('exit', clear)
-    proc.off('error', clear)
-  }
-  const abort = () => {
-    clear()
-    stopManagedOpencodeProcess(proc)
-    onAbort?.()
-  }
-
-  signal.addEventListener('abort', abort, { once: true })
-  proc.on('exit', clear)
-  proc.on('error', clear)
-  if (signal.aborted) abort()
-  return clear
-}
-
-export async function createManagedOpencodeServer(options: OpencodeServerOptions & { env: NodeJS.ProcessEnv; opencodeBinPath?: string | null }) {
-  const resolved = {
-    hostname: '127.0.0.1',
-    port: 4096,
-    timeout: 5000,
-    ...options,
-  }
-  const args = ['serve', `--hostname=${resolved.hostname}`, `--port=${resolved.port}`]
-  if (resolved.config?.logLevel) args.push(`--log-level=${resolved.config.logLevel}`)
-
-  const spawnPlan = resolveManagedOpencodeSpawn(resolved.env, args, process.platform, resolved.opencodeBinPath)
-  const proc = spawn(spawnPlan.command, spawnPlan.args, {
-    env: buildManagedOpencodeServerEnvironment(resolved.env, resolved.config),
-    windowsHide: true,
-  })
-
-  let clear: () => void = () => undefined
-  const url = await new Promise<string>((resolveUrl, reject) => {
-    let output = ''
-    let stdoutBuffer = ''
-    let startupSettled = false
-
-    function cleanupStartupListeners() {
-      proc.stdout?.off('data', onStdoutData)
-      proc.stderr?.off('data', onStderrData)
-      proc.off('exit', onExit)
-      proc.off('error', onError)
-    }
-
-    function settleStartup(callback: () => void) {
-      if (startupSettled) return
-      startupSettled = true
-      clearTimeout(id)
-      cleanupStartupListeners()
-      callback()
-    }
-
-    function rejectStartup(error: Error, stopProcess = false) {
-      settleStartup(() => reject(error))
-      clear()
-      if (stopProcess) stopManagedOpencodeProcess(proc)
-    }
-
-    const id = setTimeout(() => {
-      rejectStartup(new Error(`Timeout waiting for server to start after ${resolved.timeout}ms`), true)
-    }, resolved.timeout)
-
-    function onStdoutData(chunk: Buffer) {
-      if (startupSettled) return
-      const text = chunk.toString()
-      output += text
-      const parsed = parseManagedOpencodeServerStdoutChunk(stdoutBuffer, text)
-      stdoutBuffer = parsed.buffer
-      if (parsed.error) {
-        rejectStartup(new Error(parsed.error), true)
-        return
-      }
-      if (parsed.url) {
-        const startupUrl = parsed.url
-        settleStartup(() => {
-          drainManagedOpencodeProcessOutput(proc)
-          resolveUrl(startupUrl)
-        })
-      }
-    }
-
-    function onStderrData(chunk: Buffer) {
-      if (startupSettled) return
-      output += chunk.toString()
-    }
-
-    function onExit(code: number | null) {
-      let message = `Server exited with code ${code}`
-      if (output.trim()) message += `\nServer output: ${output}`
-      rejectStartup(new Error(message))
-    }
-
-    function onError(error: Error) {
-      rejectStartup(error)
-    }
-
-    proc.stdout?.on('data', onStdoutData)
-    proc.stderr?.on('data', onStderrData)
-    proc.on('exit', onExit)
-    proc.on('error', onError)
-
-    clear = bindManagedOpencodeAbort(proc, resolved.signal, () => {
-      settleStartup(() => reject(resolved.signal?.reason))
-    })
-  })
-
-  return {
-    url,
-    close() {
-      clear()
-      stopManagedOpencodeProcess(proc)
-    },
-  }
 }
 
 async function createManagedOpencode(options: OpencodeServerOptions, opencodeBinPath?: string | null) {

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,14 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { PassThrough } from 'node:stream'
+import { buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime.ts'
 import {
   buildManagedOpencodeServerEnvironment,
-  buildManagedRuntimeEnvironment,
   drainManagedOpencodeProcessOutput,
   parseManagedOpencodeServerStdoutChunk,
   resolveManagedOpencodeCommand,
   resolveManagedOpencodeSpawn,
-} from '../apps/desktop/src/main/runtime.ts'
+} from '../apps/desktop/src/main/runtime-managed-server.ts'
 import { OPEN_COWORK_MANAGED_RUNTIME_ENV, OPEN_COWORK_MANAGED_RUNTIME_VALUE } from '../apps/desktop/src/main/runtime-process-cleanup.ts'
 
 const runtimePaths = {

--- a/tests/runtime-managed-server.test.ts
+++ b/tests/runtime-managed-server.test.ts
@@ -5,8 +5,8 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { setTimeout as delay } from 'timers/promises'
 
+import { createManagedOpencodeServer } from '../apps/desktop/src/main/runtime-managed-server.ts'
 import {
-  createManagedOpencodeServer,
   getActiveProjectOverlayDirectory,
   getClient,
   getModelInfo,


### PR DESCRIPTION
## Summary
- Move the low-level OpenCode server spawn/parser/close helpers out of runtime.ts into runtime-managed-server.ts.
- Keep runtime.ts lifecycle behavior and public re-exports stable for existing callers.
- Point focused runtime-server tests at the new module while preserving runtime accessor coverage.

## Validation
- node --no-warnings --experimental-strip-types --test tests/runtime-environment.test.ts tests/runtime-managed-server.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- git diff --check