### PR TITLE
Run unit tests on macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run Node unit tests
+        run: pnpm test
+
+      - name: Run renderer component tests
+        run: pnpm test:renderer
+
       - name: Run desktop smoke tests
         run: pnpm test:e2e
 


### PR DESCRIPTION
## Summary
- Add Node unit tests to the macOS CI path before desktop smoke tests.
- Add renderer component tests to the same macOS path so platform-sensitive renderer behavior is not only checked on Linux.

## Validation
- pnpm test:renderer
- git diff --check

Note: pnpm test already passed locally on the current tree while validating the preceding runtime split; this PR wires that same command into the macOS runner.