### PR TITLE
Add Linux perf baseline selection

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,9 +7,13 @@ Open Cowork now ships a local synthetic benchmark runner so session-engine chang
 - `pnpm perf:bench`
   Runs the benchmark suite and prints the current numbers.
 - `pnpm perf:baseline`
-  Runs the suite and rewrites [perf-baseline.json](perf-baseline.json).
+  Runs the suite and rewrites the environment-specific baseline for the
+  current platform, architecture, and Node major version.
 - `pnpm perf:check`
-  Runs the suite and compares the current results against the checked-in baseline.
+  Runs the suite and compares the current results against the checked-in
+  environment-specific baseline when one exists, falling back first to the
+  nearest same-platform/architecture baseline and then to
+  [perf-baseline.json](perf-baseline.json).
 
 ## Coverage
 
@@ -23,5 +27,9 @@ The current suite measures:
 ## Usage Notes
 
 - Run `pnpm perf:check` on an otherwise idle machine or at least not in parallel with `test`, `typecheck`, or `build`.
+- Baselines are environment-specific. CI uses `perf-baseline.linux-x64-node22.json`;
+  local runs prefer a matching `perf-baseline.<platform>-<arch>-node<major>.json`
+  before falling back to another baseline from the same platform and architecture,
+  then the generic fallback.
 - The baseline is machine-specific enough that it should be refreshed intentionally after major local environment changes.
 - If the architecture changes enough that the workload is no longer representative, update the fixture generator in [scripts/perf-benchmark.ts](../scripts/perf-benchmark.ts) before refreshing the baseline.

--- a/benchmarks/perf-baseline.linux-x64-node22.json
+++ b/benchmarks/perf-baseline.linux-x64-node22.json
@@ -1,0 +1,53 @@
+{
+  "generatedAt": "2026-05-07T20:00:01.181Z",
+  "environment": {
+    "platform": "linux",
+    "arch": "x64",
+    "node": "v22.12.0"
+  },
+  "suiteRuns": 5,
+  "regressionThresholds": {
+    "avgMultiplier": 1.2,
+    "p95Multiplier": 1.25,
+    "avgAbsoluteFloorMs": 0.4,
+    "p95AbsoluteFloorMs": 0.8
+  },
+  "benchmarks": [
+    {
+      "name": "history.project.large",
+      "iterations": 10,
+      "minMs": 0.92,
+      "maxMs": 3.55,
+      "avgMs": 1.16,
+      "p50Ms": 1.16,
+      "p95Ms": 1.7
+    },
+    {
+      "name": "engine.hydrate.large",
+      "iterations": 24,
+      "minMs": 0.82,
+      "maxMs": 4.63,
+      "avgMs": 0.87,
+      "p50Ms": 0.87,
+      "p95Ms": 0.94
+    },
+    {
+      "name": "engine.view.large",
+      "iterations": 30,
+      "minMs": 0.01,
+      "maxMs": 0.14,
+      "avgMs": 0.02,
+      "p50Ms": 0.02,
+      "p95Ms": 0.03
+    },
+    {
+      "name": "engine.stream.mixed",
+      "iterations": 20,
+      "minMs": 1.35,
+      "maxMs": 2.74,
+      "avgMs": 1.5,
+      "p50Ms": 1.5,
+      "p95Ms": 1.85
+    }
+  ]
+}

--- a/scripts/perf-benchmark.ts
+++ b/scripts/perf-benchmark.ts
@@ -1,13 +1,14 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { baselinePathForEnvironment, selectBaselinePath } from './perf/baseline.ts'
 import { compareReports, hasComparableEnvironment } from './perf/compare.ts'
 import { aggregateReports, formatLine } from './perf/report.ts'
 import { runSessionBenchmarks } from './perf/suite.ts'
 import type { BenchmarkReport } from './perf/types.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const BASELINE_PATH = resolve(__dirname, '../benchmarks/perf-baseline.json')
+const BASELINE_DIR = resolve(__dirname, '../benchmarks')
 
 function writeStdout(line = '') {
   process.stdout.write(`${line}\n`)
@@ -39,13 +40,16 @@ async function main() {
   printReport(report)
 
   if (shouldWrite) {
-    mkdirSync(dirname(BASELINE_PATH), { recursive: true })
-    writeFileSync(BASELINE_PATH, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
-    writeStdout(`\nWrote baseline to ${BASELINE_PATH}`)
+    const baselinePath = baselinePathForEnvironment(BASELINE_DIR, report.environment)
+    mkdirSync(dirname(baselinePath), { recursive: true })
+    writeFileSync(baselinePath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+    writeStdout(`\nWrote baseline to ${baselinePath}`)
   }
 
   if (shouldCheck) {
-    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as BenchmarkReport
+    const baselinePath = selectBaselinePath(BASELINE_DIR, report.environment)
+    const baseline = JSON.parse(readFileSync(baselinePath, 'utf8')) as BenchmarkReport
+    writeStdout(`\nUsing perf baseline ${baselinePath}`)
     if (!hasComparableEnvironment(report, baseline)) {
       writeStdout(
         `\nPerf baseline environment differs (${baseline.environment.platform}/${baseline.environment.arch} ${baseline.environment.node}); using cross-environment absolute floors.`,

--- a/scripts/perf/baseline.ts
+++ b/scripts/perf/baseline.ts
@@ -1,0 +1,58 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { BenchmarkReport } from './types.ts'
+
+type BenchmarkEnvironment = BenchmarkReport['environment']
+
+function nodeMajor(version: string) {
+  const match = /^v?(\d+)/.exec(version)
+  return match ? Number(match[1]) : null
+}
+
+function safeSegment(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'unknown'
+}
+
+function platformArchPrefix(environment: BenchmarkEnvironment) {
+  return `perf-baseline.${safeSegment(environment.platform)}-${safeSegment(environment.arch)}-node`
+}
+
+export function baselineFilenameForEnvironment(environment: BenchmarkEnvironment) {
+  const major = nodeMajor(environment.node)
+  const nodeSegment = major === null ? 'node-unknown' : `node${major}`
+  return `perf-baseline.${safeSegment(environment.platform)}-${safeSegment(environment.arch)}-${nodeSegment}.json`
+}
+
+export function baselinePathForEnvironment(baselineDir: string, environment: BenchmarkEnvironment) {
+  return resolve(baselineDir, baselineFilenameForEnvironment(environment))
+}
+
+export function selectBaselinePath(baselineDir: string, environment: BenchmarkEnvironment) {
+  const environmentPath = baselinePathForEnvironment(baselineDir, environment)
+  if (existsSync(environmentPath)) return environmentPath
+
+  const currentMajor = nodeMajor(environment.node)
+  const prefix = platformArchPrefix(environment)
+  let files: string[]
+  try {
+    files = readdirSync(baselineDir)
+  } catch {
+    files = []
+  }
+  const samePlatformArch = files.flatMap((file) => {
+    if (!file.startsWith(prefix) || !file.endsWith('.json')) return []
+    const match = /^(.+)-node(\d+)\.json$/.exec(file)
+    return [{ file, major: match ? Number(match[2]) : null }]
+  })
+
+  const [nearest] = samePlatformArch.sort((a, b) => {
+    if (currentMajor !== null && a.major !== null && b.major !== null) {
+      const distance = Math.abs(a.major - currentMajor) - Math.abs(b.major - currentMajor)
+      if (distance !== 0) return distance
+    }
+    return (b.major ?? -1) - (a.major ?? -1) || a.file.localeCompare(b.file)
+  })
+  if (nearest) return resolve(baselineDir, nearest.file)
+
+  return resolve(baselineDir, 'perf-baseline.json')
+}

--- a/tests/perf-baseline.test.ts
+++ b/tests/perf-baseline.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  baselineFilenameForEnvironment,
+  baselinePathForEnvironment,
+  selectBaselinePath,
+} from '../scripts/perf/baseline.ts'
+
+const linuxNode22 = {
+  platform: 'linux',
+  arch: 'x64',
+  node: 'v22.12.0',
+}
+
+const linuxNode24 = {
+  platform: 'linux',
+  arch: 'x64',
+  node: 'v24.1.0',
+}
+
+test('baselineFilenameForEnvironment includes platform, arch, and Node major', () => {
+  assert.equal(
+    baselineFilenameForEnvironment(linuxNode22),
+    'perf-baseline.linux-x64-node22.json',
+  )
+})
+
+test('selectBaselinePath prefers a matching environment baseline', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'perf-baseline-'))
+  try {
+    const expected = baselinePathForEnvironment(dir, linuxNode22)
+    writeFileSync(expected, '{}\n')
+    assert.equal(selectBaselinePath(dir, linuxNode22), expected)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('selectBaselinePath prefers same platform and arch before generic fallback', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'perf-baseline-'))
+  try {
+    const generic = join(dir, 'perf-baseline.json')
+    const linuxNode22Path = baselinePathForEnvironment(dir, linuxNode22)
+    writeFileSync(generic, '{}\n')
+    writeFileSync(linuxNode22Path, '{}\n')
+    assert.equal(selectBaselinePath(dir, linuxNode24), linuxNode22Path)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('selectBaselinePath chooses the nearest same-platform Node major', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'perf-baseline-'))
+  try {
+    const linuxNode20Path = baselinePathForEnvironment(dir, { ...linuxNode22, node: 'v20.11.0' })
+    const linuxNode22Path = baselinePathForEnvironment(dir, linuxNode22)
+    writeFileSync(linuxNode20Path, '{}\n')
+    writeFileSync(linuxNode22Path, '{}\n')
+    assert.equal(selectBaselinePath(dir, linuxNode24), linuxNode22Path)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('selectBaselinePath falls back to the generic baseline', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'perf-baseline-'))
+  try {
+    assert.equal(selectBaselinePath(dir, linuxNode22), join(dir, 'perf-baseline.json'))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add environment-specific perf baseline selection before falling back to the generic baseline
- check in a Linux/x64 Node 22 baseline from the passing GitHub Actions validate run
- document the baseline naming/selection behavior and cover it with unit tests

## CI source
- Linux baseline values came from PR #161 validate job 74897119403 in run 25518827458.

## Validation
- node --no-warnings --experimental-strip-types --test tests/perf-baseline.test.ts
- pnpm perf:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check