### PR TITLE
[codex] Clarify automation control-plane queueing

### DIFF
--- a/apps/desktop/src/main/automation-control-plane-queue.ts
+++ b/apps/desktop/src/main/automation-control-plane-queue.ts
@@ -1,0 +1,26 @@
+import type { SerialRunner } from './promise-chain.ts'
+
+export type CoalescedControlPlaneTask = {
+  run(task: () => Promise<void>): Promise<boolean>
+  isPending(): boolean
+}
+
+export function createCoalescedControlPlaneTask(runSerially: SerialRunner): CoalescedControlPlaneTask {
+  let pending = false
+
+  return {
+    isPending() {
+      return pending
+    },
+    async run(task: () => Promise<void>) {
+      if (pending) return false
+      pending = true
+      try {
+        await runSerially(task)
+        return true
+      } finally {
+        pending = false
+      }
+    },
+  }
+}

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -64,11 +64,13 @@ import { normalizeSingleQuestionAnswer } from './question-normalization.ts'
 import { dispatchRuntimeSessionEvent } from './session-event-dispatcher.ts'
 import { startSessionStatusReconciliation } from './session-status-reconciler.ts'
 import { createPromiseChain } from './promise-chain.ts'
+import { createCoalescedControlPlaneTask } from './automation-control-plane-queue.ts'
 
 let getMainWindow: (() => BrowserWindow | null) | null = null
 let schedulerTimer: NodeJS.Timeout | null = null
-let schedulerInFlight = false, heartbeatInFlight = false
 const runAutomationControlPlaneSerially = createPromiseChain()
+const runSchedulerTick = createCoalescedControlPlaneTask(runAutomationControlPlaneSerially)
+const runHeartbeatTick = createCoalescedControlPlaneTask(runAutomationControlPlaneSerially)
 function publishAutomationUpdated() {
   const win = getMainWindow?.()
   if (win && !win.isDestroyed()) win.webContents.send('automation:updated')
@@ -127,59 +129,50 @@ async function maybeRunDueAutomations(now = new Date()) {
 }
 
 async function maybeRunAutomationScheduler(now = new Date()) {
-  if (schedulerInFlight) return
-  schedulerInFlight = true
-  await runAutomationControlPlaneSerially(async () => {
+  await runSchedulerTick.run(async () => {
     try {
       await maybeRunDueRetries(now)
       await maybeRunDueAutomations(now)
     } finally {
-      schedulerInFlight = false
       publishAutomationUpdated()
     }
   })
 }
 
 async function maybeRunHeartbeatReviews(now = new Date()) {
-  if (heartbeatInFlight) return
-  heartbeatInFlight = true
-  await runAutomationControlPlaneSerially(async () => {
+  await runHeartbeatTick.run(async () => {
     const due = listDueHeartbeats(now)
-    try {
-      for (const automation of due) {
-        const detail = getAutomationDetail(automation.id)
-        if (!detail) continue
-        const openInbox = listOpenInboxForAutomation(automation.id)
-        if (detail.status === 'needs_user') {
-          const heartbeatRun = createAutomationRun(automation.id, 'heartbeat', `Heartbeat ${automation.title}`)
-          if (!heartbeatRun) continue
-          const summary = openInbox.length > 0
-            ? `Waiting on user input or approval (${openInbox.length} open item${openInbox.length === 1 ? '' : 's'}).`
-            : 'Waiting on user input.'
-          if (openInbox.length === 0) {
-            createInboxItem({
-              automationId: automation.id,
-              runId: heartbeatRun.id,
-              type: 'info',
-              title: 'Automation waiting for input',
-              body: 'This automation is paused until the missing context or approval is provided.',
-            })
-          }
-          markHeartbeatCompleted(heartbeatRun.id, summary)
-          continue
+    for (const automation of due) {
+      const detail = getAutomationDetail(automation.id)
+      if (!detail) continue
+      const openInbox = listOpenInboxForAutomation(automation.id)
+      if (detail.status === 'needs_user') {
+        const heartbeatRun = createAutomationRun(automation.id, 'heartbeat', `Heartbeat ${automation.title}`)
+        if (!heartbeatRun) continue
+        const summary = openInbox.length > 0
+          ? `Waiting on user input or approval (${openInbox.length} open item${openInbox.length === 1 ? '' : 's'}).`
+          : 'Waiting on user input.'
+        if (openInbox.length === 0) {
+          createInboxItem({
+            automationId: automation.id,
+            runId: heartbeatRun.id,
+            type: 'info',
+            title: 'Automation waiting for input',
+            body: 'This automation is paused until the missing context or approval is provided.',
+          })
         }
-        try {
-          await startAutomationRun(automation.id, 'heartbeat', publishAutomationUpdated)
-        } catch (error) {
-          if (error instanceof AutomationRunConflictError) continue
-          const message = error instanceof Error ? error.message : String(error)
-          log('error', `Failed to start automation heartbeat ${automation.id}: ${message}`)
-          const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
-          maybeReportFailedRun(automation.id, failedRun, 'Automation heartbeat failed to start', message)
-        }
+        markHeartbeatCompleted(heartbeatRun.id, summary)
+        continue
       }
-    } finally {
-      heartbeatInFlight = false
+      try {
+        await startAutomationRun(automation.id, 'heartbeat', publishAutomationUpdated)
+      } catch (error) {
+        if (error instanceof AutomationRunConflictError) continue
+        const message = error instanceof Error ? error.message : String(error)
+        log('error', `Failed to start automation heartbeat ${automation.id}: ${message}`)
+        const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
+        maybeReportFailedRun(automation.id, failedRun, 'Automation heartbeat failed to start', message)
+      }
     }
   })
 }

--- a/tests/automation-control-plane-queue.test.ts
+++ b/tests/automation-control-plane-queue.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createCoalescedControlPlaneTask } from '../apps/desktop/src/main/automation-control-plane-queue.ts'
+import { createPromiseChain } from '../apps/desktop/src/main/promise-chain.ts'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((next) => { resolve = next })
+  return { promise, resolve }
+}
+
+test('coalesced control-plane task drops duplicate ticks while one is pending', async () => {
+  const release = deferred()
+  const task = createCoalescedControlPlaneTask(createPromiseChain())
+  const events: string[] = []
+
+  const first = task.run(async () => {
+    events.push('first:start')
+    await release.promise
+    events.push('first:end')
+  })
+  await Promise.resolve()
+
+  const duplicate = await task.run(async () => {
+    events.push('duplicate')
+  })
+  assert.equal(duplicate, false)
+  assert.equal(task.isPending(), true)
+
+  release.resolve()
+  assert.equal(await first, true)
+  assert.equal(task.isPending(), false)
+  assert.deepEqual(events, ['first:start', 'first:end'])
+})
+
+test('coalesced control-plane tasks share the serial runner across task kinds', async () => {
+  const release = deferred()
+  const runSerially = createPromiseChain()
+  const scheduler = createCoalescedControlPlaneTask(runSerially)
+  const heartbeat = createCoalescedControlPlaneTask(runSerially)
+  const events: string[] = []
+
+  const first = scheduler.run(async () => {
+    events.push('scheduler:start')
+    await release.promise
+    events.push('scheduler:end')
+  })
+  await Promise.resolve()
+
+  const second = heartbeat.run(async () => {
+    events.push('heartbeat')
+  })
+  await Promise.resolve()
+  assert.deepEqual(events, ['scheduler:start'])
+
+  release.resolve()
+  assert.equal(await first, true)
+  assert.equal(await second, true)
+  assert.deepEqual(events, ['scheduler:start', 'scheduler:end', 'heartbeat'])
+})
+
+test('coalesced control-plane task clears pending state after failures', async () => {
+  const task = createCoalescedControlPlaneTask(createPromiseChain())
+
+  await assert.rejects(
+    task.run(async () => {
+      throw new Error('boom')
+    }),
+    /boom/,
+  )
+  assert.equal(task.isPending(), false)
+
+  const ran = await task.run(async () => {})
+  assert.equal(ran, true)
+})


### PR DESCRIPTION
## Summary
- move automation scheduler/heartbeat coalescing into a small control-plane queue helper
- keep scheduler and heartbeat tasks serialized through the existing promise chain
- remove ad hoc scheduler/heartbeat boolean state from automation-service
- add regression tests for duplicate coalescing, cross-kind serialization, and failure recovery

## Validation
- node --no-warnings --experimental-strip-types --test tests/automation-control-plane-queue.test.ts
- pnpm typecheck
- pnpm lint
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/automation-service.test.ts tests/automation-store.test.ts tests/automation-control-plane-queue.test.ts
- pnpm test
- pnpm build
- git diff --check