### PR TITLE
Split agent builder draft helpers

### DIFF
--- a/apps/desktop/src/renderer/components/agents/AgentBuilderPage.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentBuilderPage.tsx
@@ -1,19 +1,15 @@
 import { useEffect, useMemo, useState } from 'react'
 import type {
   AgentCatalog,
-  AgentColor,
-  BuiltInAgentDetail,
   CustomAgentConfig,
-  CustomAgentSummary,
-  RuntimeAgentDescriptor,
 } from '@open-cowork/shared'
 import { AgentCard } from './AgentCard'
-import { getBrandName } from '../../helpers/brand'
 import { t } from '../../helpers/i18n'
 import { AgentStaticPreview } from './AgentStaticPreview'
 import { SkillLibraryTab } from './SkillLibraryTab'
 import { ToolLibraryTab } from './ToolLibraryTab'
 import { InstructionsTab } from './InstructionsTab'
+import { buildInitialAgentDraft, type BuilderTarget } from './agent-builder-drafts'
 import {
   augmentCatalogForBuiltIn,
   linkedSkillNamesForTool,
@@ -21,12 +17,6 @@ import {
 } from './agent-builder-utils'
 
 type WorkbenchTab = 'skills' | 'tools' | 'instructions' | 'inference'
-
-type BuilderTarget =
-  | { kind: 'new'; seed?: Partial<CustomAgentConfig> | null }
-  | { kind: 'custom'; agent: CustomAgentSummary }
-  | { kind: 'builtin'; agent: BuiltInAgentDetail }
-  | { kind: 'runtime'; agent: RuntimeAgentDescriptor }
 
 type Props = {
   target: BuilderTarget
@@ -36,107 +26,6 @@ type Props = {
   onCancel: () => void
   onSaved: () => void
   onOpenCapabilities: () => void
-}
-
-function blankDraft(seed?: Partial<CustomAgentConfig> | null): CustomAgentConfig {
-  return {
-    scope: seed?.scope || 'machine',
-    directory: seed?.scope === 'project' ? seed.directory || null : null,
-    name: seed?.name || '',
-    description: seed?.description || '',
-    instructions: seed?.instructions || '',
-    skillNames: Array.from(new Set(seed?.skillNames || [])),
-    toolIds: Array.from(new Set(seed?.toolIds || [])),
-    enabled: seed?.enabled ?? true,
-    color: seed?.color || 'accent',
-    avatar: seed?.avatar ?? null,
-    model: seed?.model ?? null,
-    variant: seed?.variant ?? null,
-    temperature: seed?.temperature ?? null,
-    top_p: seed?.top_p ?? null,
-    steps: seed?.steps ?? null,
-    options: seed?.options ?? null,
-    deniedToolPatterns: Array.from(new Set(seed?.deniedToolPatterns || [])),
-  }
-}
-
-function draftFromCustom(agent: CustomAgentSummary): CustomAgentConfig {
-  return {
-    scope: agent.scope,
-    directory: agent.directory ?? null,
-    name: agent.name,
-    description: agent.description,
-    instructions: agent.instructions,
-    skillNames: [...agent.skillNames],
-    toolIds: [...agent.toolIds],
-    enabled: agent.enabled,
-    color: agent.color,
-    avatar: agent.avatar ?? null,
-    model: agent.model ?? null,
-    variant: agent.variant ?? null,
-    temperature: agent.temperature ?? null,
-    top_p: agent.top_p ?? null,
-    steps: agent.steps ?? null,
-    options: agent.options ?? null,
-    deniedToolPatterns: [...(agent.deniedToolPatterns || [])],
-  }
-}
-
-function draftFromBuiltIn(agent: BuiltInAgentDetail): CustomAgentConfig {
-  // Built-ins expose tools across three overlapping arrays — `nativeToolIds`
-  // (OpenCode built-ins like websearch / webfetch / bash), `configuredToolIds`
-  // (Cowork-registered MCPs), and `toolAccess` (free-form labels). Merge
-  // the first two so the loadout reflects everything the agent can call.
-  // Natives that aren't in the catalog are rendered via a synthetic-entry
-  // overlay in `augmentCatalogForBuiltIn`.
-  //
-  // Built-ins whose `source` is `opencode` have an empty `instructions`
-  // string because OpenCode owns their system prompt internally. Showing
-  // the generic "No instructions yet — add guidance" placeholder would
-  // be misleading for read-only built-ins, so we substitute an accurate
-  // note about who owns the prompt.
-  const instructions = agent.instructions.trim()
-    ? agent.instructions
-    : agent.source === 'opencode'
-      ? `This agent uses OpenCode's native built-in prompt and behavior. ${getBrandName()} only shapes its tool access, visibility, and UI metadata — the instructions aren't editable here.`
-      : agent.instructions
-  return {
-    scope: 'machine',
-    directory: null,
-    name: agent.name,
-    description: agent.description,
-    instructions,
-    skillNames: [...agent.skills],
-    toolIds: Array.from(new Set([...agent.nativeToolIds, ...agent.configuredToolIds])),
-    enabled: !agent.disabled,
-    color: (agent.color as AgentColor) || 'accent',
-    model: agent.model ?? null,
-    variant: agent.variant ?? null,
-    temperature: agent.temperature ?? null,
-    top_p: agent.top_p ?? null,
-    steps: agent.steps ?? null,
-    options: agent.options ?? null,
-  }
-}
-
-function draftFromRuntime(agent: RuntimeAgentDescriptor): CustomAgentConfig {
-  return {
-    scope: 'machine',
-    directory: null,
-    name: agent.name,
-    description: agent.description || '',
-    instructions: '',
-    skillNames: [],
-    toolIds: [],
-    enabled: !agent.disabled,
-    color: (agent.color as AgentColor) || 'accent',
-    model: agent.model ?? null,
-    variant: null,
-    temperature: null,
-    top_p: null,
-    steps: null,
-    options: null,
-  }
 }
 
 // Single page serving all three agent types. For built-in and runtime
@@ -155,10 +44,7 @@ export function AgentBuilderPage({
   const typeLabel = target.kind === 'builtin' ? 'Built-in' : target.kind === 'runtime' ? 'Runtime' : 'Custom'
 
   const initialDraft = useMemo(() => {
-    if (target.kind === 'new') return blankDraft(target.seed)
-    if (target.kind === 'custom') return draftFromCustom(target.agent)
-    if (target.kind === 'builtin') return draftFromBuiltIn(target.agent)
-    return draftFromRuntime(target.agent)
+    return buildInitialAgentDraft(target)
   }, [target])
 
   // For built-in agents, overlay the catalog with synthetic entries for

--- a/apps/desktop/src/renderer/components/agents/agent-builder-drafts.ts
+++ b/apps/desktop/src/renderer/components/agents/agent-builder-drafts.ts
@@ -1,0 +1,114 @@
+import type {
+  AgentColor,
+  BuiltInAgentDetail,
+  CustomAgentConfig,
+  CustomAgentSummary,
+  RuntimeAgentDescriptor,
+} from '@open-cowork/shared'
+import { getBrandName } from '../../helpers/brand.ts'
+
+export type BuilderTarget =
+  | { kind: 'new'; seed?: Partial<CustomAgentConfig> | null }
+  | { kind: 'custom'; agent: CustomAgentSummary }
+  | { kind: 'builtin'; agent: BuiltInAgentDetail }
+  | { kind: 'runtime'; agent: RuntimeAgentDescriptor }
+
+export function blankAgentDraft(seed?: Partial<CustomAgentConfig> | null): CustomAgentConfig {
+  return {
+    scope: seed?.scope || 'machine',
+    directory: seed?.scope === 'project' ? seed.directory || null : null,
+    name: seed?.name || '',
+    description: seed?.description || '',
+    instructions: seed?.instructions || '',
+    skillNames: Array.from(new Set(seed?.skillNames || [])),
+    toolIds: Array.from(new Set(seed?.toolIds || [])),
+    enabled: seed?.enabled ?? true,
+    color: seed?.color || 'accent',
+    avatar: seed?.avatar ?? null,
+    model: seed?.model ?? null,
+    variant: seed?.variant ?? null,
+    temperature: seed?.temperature ?? null,
+    top_p: seed?.top_p ?? null,
+    steps: seed?.steps ?? null,
+    options: seed?.options ?? null,
+    deniedToolPatterns: Array.from(new Set(seed?.deniedToolPatterns || [])),
+  }
+}
+
+export function draftFromCustomAgent(agent: CustomAgentSummary): CustomAgentConfig {
+  return {
+    scope: agent.scope,
+    directory: agent.directory ?? null,
+    name: agent.name,
+    description: agent.description,
+    instructions: agent.instructions,
+    skillNames: [...agent.skillNames],
+    toolIds: [...agent.toolIds],
+    enabled: agent.enabled,
+    color: agent.color,
+    avatar: agent.avatar ?? null,
+    model: agent.model ?? null,
+    variant: agent.variant ?? null,
+    temperature: agent.temperature ?? null,
+    top_p: agent.top_p ?? null,
+    steps: agent.steps ?? null,
+    options: agent.options ?? null,
+    deniedToolPatterns: [...(agent.deniedToolPatterns || [])],
+  }
+}
+
+export function draftFromBuiltInAgent(agent: BuiltInAgentDetail): CustomAgentConfig {
+  // Built-ins expose tools across overlapping arrays. Merge the native
+  // OpenCode tool ids and Cowork-configured MCP ids so the loadout mirrors
+  // the effective agent surface shown elsewhere in the catalog.
+  const instructions = agent.instructions.trim()
+    ? agent.instructions
+    : agent.source === 'opencode'
+      ? `This agent uses OpenCode's native built-in prompt and behavior. ${getBrandName()} only shapes its tool access, visibility, and UI metadata — the instructions aren't editable here.`
+      : agent.instructions
+
+  return {
+    scope: 'machine',
+    directory: null,
+    name: agent.name,
+    description: agent.description,
+    instructions,
+    skillNames: [...agent.skills],
+    toolIds: Array.from(new Set([...agent.nativeToolIds, ...agent.configuredToolIds])),
+    enabled: !agent.disabled,
+    color: (agent.color as AgentColor) || 'accent',
+    model: agent.model ?? null,
+    variant: agent.variant ?? null,
+    temperature: agent.temperature ?? null,
+    top_p: agent.top_p ?? null,
+    steps: agent.steps ?? null,
+    options: agent.options ?? null,
+  }
+}
+
+export function draftFromRuntimeAgent(agent: RuntimeAgentDescriptor): CustomAgentConfig {
+  return {
+    scope: 'machine',
+    directory: null,
+    name: agent.name,
+    description: agent.description || '',
+    instructions: '',
+    skillNames: [],
+    toolIds: [],
+    enabled: !agent.disabled,
+    color: (agent.color as AgentColor) || 'accent',
+    model: agent.model ?? null,
+    variant: null,
+    temperature: null,
+    top_p: null,
+    steps: null,
+    options: null,
+  }
+}
+
+export function buildInitialAgentDraft(target: BuilderTarget): CustomAgentConfig {
+  if (target.kind === 'new') return blankAgentDraft(target.seed)
+  if (target.kind === 'custom') return draftFromCustomAgent(target.agent)
+  if (target.kind === 'builtin') return draftFromBuiltInAgent(target.agent)
+  return draftFromRuntimeAgent(target.agent)
+}

--- a/tests/agent-builder-drafts.test.ts
+++ b/tests/agent-builder-drafts.test.ts
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type {
+  BuiltInAgentDetail,
+  CustomAgentSummary,
+  RuntimeAgentDescriptor,
+} from '../packages/shared/src/index.ts'
+import {
+  blankAgentDraft,
+  buildInitialAgentDraft,
+  draftFromBuiltInAgent,
+  draftFromCustomAgent,
+  draftFromRuntimeAgent,
+} from '../apps/desktop/src/renderer/components/agents/agent-builder-drafts.ts'
+
+function makeCustomAgent(overrides?: Partial<CustomAgentSummary>): CustomAgentSummary {
+  return {
+    scope: 'project',
+    directory: '/project',
+    name: 'custom-agent',
+    description: 'Custom description',
+    instructions: 'Do the custom work',
+    skillNames: ['analysis'],
+    toolIds: ['postgres'],
+    enabled: true,
+    color: 'info',
+    avatar: 'CA',
+    model: 'provider/model',
+    variant: 'large',
+    temperature: 0.2,
+    top_p: 0.9,
+    steps: 25,
+    options: { reasoning: 'medium' },
+    deniedToolPatterns: ['mcp__postgres__write'],
+    writeAccess: false,
+    valid: true,
+    issues: [],
+    ...overrides,
+  }
+}
+
+function makeBuiltInAgent(overrides?: Partial<BuiltInAgentDetail>): BuiltInAgentDetail {
+  return {
+    name: 'plan',
+    label: 'Plan',
+    source: 'open-cowork',
+    mode: 'primary',
+    hidden: false,
+    disabled: false,
+    color: 'accent',
+    description: 'Plan work',
+    instructions: 'Plan carefully',
+    skills: ['planning'],
+    toolAccess: ['read'],
+    nativeToolIds: ['read', 'bash'],
+    configuredToolIds: ['charts', 'read'],
+    avatar: null,
+    model: null,
+    variant: null,
+    temperature: null,
+    top_p: null,
+    steps: null,
+    options: null,
+    ...overrides,
+  }
+}
+
+function makeRuntimeAgent(overrides?: Partial<RuntimeAgentDescriptor>): RuntimeAgentDescriptor {
+  return {
+    name: 'runtime-agent',
+    description: 'Registered by runtime',
+    model: 'runtime/model',
+    color: 'success',
+    disabled: false,
+    ...overrides,
+  }
+}
+
+describe('blankAgentDraft', () => {
+  it('dedupes seeded references and keeps project directories only for project scope', () => {
+    const draft = blankAgentDraft({
+      scope: 'project',
+      directory: '/repo',
+      skillNames: ['charts', 'charts'],
+      toolIds: ['read', 'read'],
+      deniedToolPatterns: ['mcp__x__write', 'mcp__x__write'],
+    })
+
+    assert.equal(draft.scope, 'project')
+    assert.equal(draft.directory, '/repo')
+    assert.deepEqual(draft.skillNames, ['charts'])
+    assert.deepEqual(draft.toolIds, ['read'])
+    assert.deepEqual(draft.deniedToolPatterns, ['mcp__x__write'])
+
+    assert.equal(blankAgentDraft({ scope: 'machine', directory: '/ignored' }).directory, null)
+  })
+})
+
+describe('draftFromCustomAgent', () => {
+  it('copies persisted custom-agent fields into an editable draft', () => {
+    const draft = draftFromCustomAgent(makeCustomAgent())
+
+    assert.equal(draft.name, 'custom-agent')
+    assert.equal(draft.scope, 'project')
+    assert.equal(draft.directory, '/project')
+    assert.deepEqual(draft.skillNames, ['analysis'])
+    assert.deepEqual(draft.toolIds, ['postgres'])
+    assert.deepEqual(draft.deniedToolPatterns, ['mcp__postgres__write'])
+    assert.equal(draft.model, 'provider/model')
+  })
+})
+
+describe('draftFromBuiltInAgent', () => {
+  it('merges native and configured tools without duplicates', () => {
+    const draft = draftFromBuiltInAgent(makeBuiltInAgent())
+
+    assert.deepEqual(draft.toolIds, ['read', 'bash', 'charts'])
+    assert.deepEqual(draft.skillNames, ['planning'])
+    assert.equal(draft.enabled, true)
+  })
+
+  it('describes OpenCode-owned prompts when native built-ins expose no instructions', () => {
+    const draft = draftFromBuiltInAgent(makeBuiltInAgent({
+      source: 'opencode',
+      instructions: '',
+      name: 'build',
+    }))
+
+    assert.match(draft.instructions, /OpenCode's native built-in prompt/)
+    assert.match(draft.instructions, /Open Cowork/)
+  })
+})
+
+describe('draftFromRuntimeAgent', () => {
+  it('normalizes runtime descriptors into read-only draft shape', () => {
+    const draft = draftFromRuntimeAgent(makeRuntimeAgent({ disabled: true, description: null }))
+
+    assert.equal(draft.name, 'runtime-agent')
+    assert.equal(draft.description, '')
+    assert.equal(draft.enabled, false)
+    assert.equal(draft.model, 'runtime/model')
+    assert.deepEqual(draft.skillNames, [])
+    assert.deepEqual(draft.toolIds, [])
+  })
+})
+
+describe('buildInitialAgentDraft', () => {
+  it('dispatches draft creation by target kind', () => {
+    assert.equal(buildInitialAgentDraft({ kind: 'new', seed: { name: 'seeded' } }).name, 'seeded')
+    assert.equal(buildInitialAgentDraft({ kind: 'custom', agent: makeCustomAgent({ name: 'custom' }) }).name, 'custom')
+    assert.equal(buildInitialAgentDraft({ kind: 'builtin', agent: makeBuiltInAgent({ name: 'builtin' }) }).name, 'builtin')
+    assert.equal(buildInitialAgentDraft({ kind: 'runtime', agent: makeRuntimeAgent({ name: 'runtime' }) }).name, 'runtime')
+  })
+})


### PR DESCRIPTION
## Summary
- move agent-builder draft construction into agent-builder-drafts.ts
- add focused unit coverage for new/custom/built-in/runtime draft normalization
- keep AgentBuilderPage focused on UI state, catalog overlays, validation, and save flow

## Validation
- node --no-warnings --experimental-strip-types --test tests/agent-builder-drafts.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- AgentBuilder
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- pnpm perf:check
- git diff --check