### PR TITLE
Split custom MCP form helpers

### DIFF
--- a/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomMcpForm.tsx
@@ -2,19 +2,18 @@ import { useEffect, useMemo, useState } from 'react'
 import type { CustomMcpConfig, CustomMcpTestResult, CustomSkillConfig } from '@open-cowork/shared'
 import { getBrandName } from '../../helpers/brand'
 import { t } from '../../helpers/i18n'
-import { PluginIcon } from './PluginIcon'
-
-const inputClass = 'w-full px-3 py-2 rounded-lg text-[12px] bg-elevated border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-border'
-const VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
-
-type KeyValueDraft = { id: string; key: string; value: string }
-
-let nextKeyValueDraftId = 0
-
-function createKeyValueDraft(key = '', value = ''): KeyValueDraft {
-  nextKeyValueDraftId += 1
-  return { id: `custom-mcp-field-${nextKeyValueDraftId}`, key, value }
-}
+import { LinkedSkillsCard, McpPreviewCard, ToolApprovalsCard } from './CustomMcpFormCards'
+import {
+  buildCustomMcpDraft,
+  collectCustomMcpIssues,
+  createKeyValueDraft,
+  createKeyValueDraftsFromRecord,
+  customMcpInputClass as inputClass,
+  linkedSkillNamesForMcp,
+  nextSkillToolIdsForMcp,
+  type KeyValueDraft,
+  toggleStringSelection,
+} from './custom-mcp-form-support'
 
 export function CustomMcpForm({
   onSave,
@@ -45,14 +44,10 @@ export function CustomMcpForm({
   const [args, setArgs] = useState((existing?.args || []).join(' '))
   const [url, setUrl] = useState(existing?.url || '')
   const [envPairs, setEnvPairs] = useState<KeyValueDraft[]>(() => (
-    existing?.env && Object.keys(existing.env).length > 0
-      ? Object.entries(existing.env).map(([key, value]) => createKeyValueDraft(key, value))
-      : [createKeyValueDraft()]
+    createKeyValueDraftsFromRecord(existing?.env)
   ))
   const [headerPairs, setHeaderPairs] = useState<KeyValueDraft[]>(() => (
-    existing?.headers && Object.keys(existing.headers).length > 0
-      ? Object.entries(existing.headers).map(([key, value]) => createKeyValueDraft(key, value))
-      : [createKeyValueDraft()]
+    createKeyValueDraftsFromRecord(existing?.headers)
   ))
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -129,11 +124,7 @@ export function CustomMcpForm({
         // wiring. Without this, the picker would look empty even when
         // skills are already linked.
         if (existing?.name) {
-          setLinkedSkillNames(
-            (skills || [])
-              .filter((skill) => (skill.toolIds || []).includes(existing.name))
-              .map((skill) => skill.name),
-          )
+          setLinkedSkillNames(linkedSkillNamesForMcp(skills || [], existing.name))
         }
       })
       .catch(() => setAvailableSkills([]))
@@ -146,58 +137,34 @@ export function CustomMcpForm({
   }, [])
 
   const draft = useMemo<CustomMcpConfig>(() => {
-    const mcp: CustomMcpConfig = {
+    return buildCustomMcpDraft({
       scope,
-      directory: scope === 'project' ? projectTargetDirectory || null : null,
-      name: name.trim(),
-      label: label.trim() || undefined,
-      description: description.trim() || undefined,
+      projectTargetDirectory,
+      name,
+      label,
+      description,
       type,
-    }
-
-    if (type === 'stdio') {
-      mcp.command = command.trim()
-      mcp.args = args.trim() ? args.trim().split(/\s+/).filter(Boolean) : []
-      const env: Record<string, string> = {}
-      for (const { key, value } of envPairs) {
-        if (key.trim()) env[key.trim()] = value
-      }
-      if (Object.keys(env).length > 0) mcp.env = env
-      if (googleAuthEnabled && authModeAvailable) mcp.googleAuth = true
-    } else {
-      mcp.url = url.trim()
-      const headers: Record<string, string> = {}
-      for (const { key, value } of headerPairs) {
-        if (key.trim()) headers[key.trim()] = value
-      }
-      if (Object.keys(headers).length > 0) mcp.headers = headers
-      if (allowPrivateNetwork) mcp.allowPrivateNetwork = true
-    }
-    if (permissionMode === 'allow') mcp.permissionMode = 'allow'
-
-    return mcp
+      command,
+      args,
+      url,
+      envPairs,
+      headerPairs,
+      googleAuthEnabled,
+      authModeAvailable,
+      allowPrivateNetwork,
+      permissionMode,
+    })
   }, [allowPrivateNetwork, args, authModeAvailable, command, description, envPairs, googleAuthEnabled, headerPairs, label, name, permissionMode, projectTargetDirectory, scope, type, url])
 
   const issues = useMemo(() => {
-    const next: string[] = []
-    if (!draft.name) {
-      next.push('Add an MCP id so the runtime can register it.')
-    } else if (!VALID_NAME.test(draft.name)) {
-      next.push('Use alphanumeric characters, hyphens, or underscores only for the MCP id.')
-    }
-    if (draft.name && !isEditing && existingNames.includes(draft.name)) {
-      next.push(`A custom MCP named "${draft.name}" already exists.`)
-    }
-    if (scope === 'project' && !projectTargetDirectory) {
-      next.push('Choose a project directory for this project-scoped MCP.')
-    }
-    if (type === 'stdio' && !draft.command?.trim()) {
-      next.push('Add the stdio command that starts this MCP server.')
-    }
-    if (type === 'http' && !draft.url?.trim()) {
-      next.push('Add the HTTP or SSE endpoint URL for this MCP server.')
-    }
-    return next
+    return collectCustomMcpIssues({
+      draft,
+      isEditing,
+      existingNames,
+      scope,
+      projectTargetDirectory,
+      type,
+    })
   }, [draft.command, draft.name, draft.url, existingNames, isEditing, projectTargetDirectory, scope, type])
 
   const chooseProjectDirectory = async () => {
@@ -233,12 +200,9 @@ export function CustomMcpForm({
     const desired = new Set(linkedSkillNames)
     for (const skill of availableSkills) {
       const currentToolIds = skill.toolIds || []
-      const currentlyLinked = currentToolIds.includes(mcpId)
       const shouldBeLinked = desired.has(skill.name)
-      if (currentlyLinked === shouldBeLinked) continue
-      const nextToolIds = shouldBeLinked
-        ? Array.from(new Set([...currentToolIds, mcpId]))
-        : currentToolIds.filter((id) => id !== mcpId)
+      const nextToolIds = nextSkillToolIdsForMcp({ currentToolIds, mcpId, shouldBeLinked })
+      if (!nextToolIds) continue
       await window.coworkApi.custom.addSkill({ ...skill, toolIds: nextToolIds })
     }
 
@@ -247,11 +211,7 @@ export function CustomMcpForm({
   }
 
   const toggleLinkedSkill = (skillName: string) => {
-    setLinkedSkillNames((current) => (
-      current.includes(skillName)
-        ? current.filter((entry) => entry !== skillName)
-        : [...current, skillName]
-    ))
+    setLinkedSkillNames((current) => toggleStringSelection(current, skillName))
   }
 
   return (
@@ -475,161 +435,29 @@ export function CustomMcpForm({
               )}
             </div>
 
-            <div className="rounded-xl border border-border-subtle bg-surface p-5">
-              <div className="mb-3">
-                <div className="text-[14px] font-semibold text-text">{t('mcpForm.toolApprovals', 'Tool approvals')}</div>
-                <div className="text-[11px] text-text-muted mt-1">
-                  Choose how assigned agents should handle this MCP&apos;s tool calls.
-                </div>
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                <button
-                  type="button"
-                  aria-pressed={permissionMode === 'ask'}
-                  onClick={() => setPermissionMode('ask')}
-                  className="rounded-lg border px-3 py-3 text-left cursor-pointer transition-colors"
-                  style={{
-                    borderColor: permissionMode === 'ask'
-                      ? 'color-mix(in srgb, var(--color-accent) 45%, var(--color-border-subtle))'
-                      : 'var(--color-border-subtle)',
-                    background: permissionMode === 'ask'
-                      ? 'color-mix(in srgb, var(--color-accent) 9%, var(--color-elevated))'
-                      : 'var(--color-elevated)',
-                  }}
-                >
-                  <span className="block text-[12px] font-medium text-text">{t('mcpForm.approvalAsk', 'Ask before tool calls')}</span>
-                  <span className="mt-1 block text-[10px] leading-relaxed text-text-muted">
-                    OpenCode asks for approval before an assigned agent uses this MCP.
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  aria-pressed={permissionMode === 'allow'}
-                  onClick={() => setPermissionMode('allow')}
-                  className="rounded-lg border px-3 py-3 text-left cursor-pointer transition-colors"
-                  style={{
-                    borderColor: permissionMode === 'allow'
-                      ? 'color-mix(in srgb, var(--color-amber) 45%, var(--color-border-subtle))'
-                      : 'var(--color-border-subtle)',
-                    background: permissionMode === 'allow'
-                      ? 'color-mix(in srgb, var(--color-amber) 7%, var(--color-elevated))'
-                      : 'var(--color-elevated)',
-                  }}
-                >
-                  <span className="block text-[12px] font-medium text-text">{t('mcpForm.approvalAllow', 'Trusted, auto-approve')}</span>
-                  <span className="mt-1 block text-[10px] leading-relaxed text-text-muted">
-                    Assigned agents can call this MCP without approval prompts. Use only for MCPs you control or trust.
-                  </span>
-                </button>
-              </div>
-            </div>
+            <ToolApprovalsCard
+              permissionMode={permissionMode}
+              onPermissionModeChange={setPermissionMode}
+            />
 
-            <div className="rounded-xl border border-border-subtle bg-surface p-5">
-              <div className="mb-3">
-                <div className="text-[14px] font-semibold text-text">{t('mcpForm.linkedSkills', 'Linked skills')}</div>
-                <div className="text-[11px] text-text-muted mt-1">
-                  Pre-wire this MCP into custom skills that should request it automatically.
-                  {getBrandName()} writes this MCP&apos;s id into each selected skill&apos;s
-                  SKILL.md frontmatter <span className="font-mono">toolIds</span>.
-                </div>
-              </div>
-              {availableSkills.length > 0 ? (
-                <div className="flex flex-wrap gap-1.5">
-                  {availableSkills.map((skill) => {
-                    const selected = linkedSkillNames.includes(skill.name)
-                    return (
-                      <button
-                        key={skill.name}
-                        type="button"
-                        onClick={() => toggleLinkedSkill(skill.name)}
-                        className="inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-[11px] border cursor-pointer transition-colors"
-                        style={{
-                          color: selected ? 'var(--color-accent)' : 'var(--color-text-secondary)',
-                          background: selected
-                            ? 'color-mix(in srgb, var(--color-accent) 12%, transparent)'
-                            : 'var(--color-elevated)',
-                          borderColor: selected
-                            ? 'color-mix(in srgb, var(--color-accent) 40%, transparent)'
-                            : 'var(--color-border-subtle)',
-                        }}
-                      >
-                        <PluginIcon icon={skill.name} size={14} />
-                        {skill.name}
-                      </button>
-                    )
-                  })}
-                </div>
-              ) : (
-                <div className="text-[11px] text-text-muted italic">
-                  No custom skills discovered yet. Add a skill bundle from the Capabilities page
-                  and it will show up here.
-                </div>
-              )}
-            </div>
+            <LinkedSkillsCard
+              availableSkills={availableSkills}
+              linkedSkillNames={linkedSkillNames}
+              onToggleSkill={toggleLinkedSkill}
+            />
           </div>
 
           <div className="xl:sticky xl:top-6 self-start flex flex-col gap-4">
-            <div className="rounded-xl border border-border-subtle bg-surface p-4">
-              <div className="text-[12px] font-semibold text-text mb-3">{t('mcpForm.preview', 'MCP preview')}</div>
-              <div className="rounded-xl border border-border-subtle bg-elevated p-4 mb-4">
-                <div className="text-[11px] text-text-secondary mb-1">{t('mcpForm.displayName', 'Display name')}</div>
-                <div className="text-[13px] font-medium text-text">{label.trim() || name.trim() || 'New MCP'}</div>
-                <div className="mt-3 text-[11px] text-text-secondary mb-1">{t('mcpForm.runtimeNamespace', 'Runtime namespace')}</div>
-                <div className="text-[12px] text-text">{name.trim() || 'not-set'}</div>
-                <div className="mt-3 text-[11px] text-text-secondary mb-1">{t('mcpForm.permissionPrefix', 'Permission prefix')}</div>
-                <div className="text-[11px] text-text-muted font-mono">{name.trim() ? `mcp__${name.trim()}__*` : 'Set an MCP id to generate this.'}</div>
-              </div>
-
-              <div className="flex flex-col gap-3 text-[11px] text-text-muted">
-                <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
-                  <div className="text-text-secondary mb-1">{t('mcpForm.connectionSummary', 'Connection summary')}</div>
-                  <div>{type === 'stdio' ? 'Starts a local MCP server process.' : 'Connects to a remote MCP endpoint.'}</div>
-                </div>
-
-                <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
-                  <div className="text-text-secondary mb-1">{t('mcpForm.approvalSummary', 'Approval summary')}</div>
-                  <div>
-                    {permissionMode === 'allow'
-                      ? 'Trusted MCP. Assigned agents can use its tools automatically.'
-                      : 'OpenCode will ask before assigned agents use its tools.'}
-                  </div>
-                </div>
-
-                <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
-                  <div className="flex items-center justify-between gap-3 mb-2">
-                    <div className="text-text-secondary">{t('mcpForm.connectivityTest', 'Connectivity test')}</div>
-                    <button
-                      onClick={() => void handleTest()}
-                      disabled={testing || issues.length > 0}
-                      className="px-2.5 py-1 rounded-md text-[10px] border border-border-subtle text-accent disabled:opacity-40 cursor-pointer"
-                    >
-                      {testing ? 'Testing…' : 'Test MCP'}
-                    </button>
-                  </div>
-                  {testResult ? (
-                    testResult.ok ? (
-                      <div className="flex flex-col gap-2">
-                        <div className="text-[11px]" style={{ color: 'var(--color-green)' }}>
-                          Connected successfully. Found {testResult.methods.length} {testResult.methods.length === 1 ? 'method' : 'methods'}.
-                        </div>
-                        {testResult.methods.slice(0, 6).map((method) => (
-                          <div key={method.id} className="text-[10px] text-text-muted">
-                            <span className="text-text-secondary">{method.id}</span>
-                            {method.description ? ` · ${method.description}` : ''}
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="text-[11px]" style={{ color: 'var(--color-amber)' }}>
-                        {testResult.error || t('mcpForm.couldNotConnect', 'Could not connect to this MCP.')}
-                      </div>
-                    )
-                  ) : (
-                    <div>{t('mcpForm.runTestHint', 'Run a test before saving to confirm the server responds and exposes methods.')}</div>
-                  )}
-                </div>
-              </div>
-            </div>
+            <McpPreviewCard
+              label={label}
+              name={name}
+              type={type}
+              permissionMode={permissionMode}
+              testResult={testResult}
+              testing={testing}
+              hasIssues={issues.length > 0}
+              onTest={() => void handleTest()}
+            />
           </div>
         </div>
 

--- a/apps/desktop/src/renderer/components/plugins/CustomMcpFormCards.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomMcpFormCards.tsx
@@ -1,0 +1,207 @@
+import type { CustomMcpTestResult, CustomSkillConfig } from '@open-cowork/shared'
+import { getBrandName } from '../../helpers/brand'
+import { t } from '../../helpers/i18n'
+import { PluginIcon } from './PluginIcon'
+import type { CustomMcpFormType, CustomMcpPermissionMode } from './custom-mcp-form-support'
+
+export function ToolApprovalsCard({
+  permissionMode,
+  onPermissionModeChange,
+}: {
+  permissionMode: CustomMcpPermissionMode
+  onPermissionModeChange: (mode: CustomMcpPermissionMode) => void
+}) {
+  return (
+    <div className="rounded-xl border border-border-subtle bg-surface p-5">
+      <div className="mb-3">
+        <div className="text-[14px] font-semibold text-text">{t('mcpForm.toolApprovals', 'Tool approvals')}</div>
+        <div className="text-[11px] text-text-muted mt-1">
+          Choose how assigned agents should handle this MCP&apos;s tool calls.
+        </div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <button
+          type="button"
+          aria-pressed={permissionMode === 'ask'}
+          onClick={() => onPermissionModeChange('ask')}
+          className="rounded-lg border px-3 py-3 text-left cursor-pointer transition-colors"
+          style={{
+            borderColor: permissionMode === 'ask'
+              ? 'color-mix(in srgb, var(--color-accent) 45%, var(--color-border-subtle))'
+              : 'var(--color-border-subtle)',
+            background: permissionMode === 'ask'
+              ? 'color-mix(in srgb, var(--color-accent) 9%, var(--color-elevated))'
+              : 'var(--color-elevated)',
+          }}
+        >
+          <span className="block text-[12px] font-medium text-text">{t('mcpForm.approvalAsk', 'Ask before tool calls')}</span>
+          <span className="mt-1 block text-[10px] leading-relaxed text-text-muted">
+            OpenCode asks for approval before an assigned agent uses this MCP.
+          </span>
+        </button>
+        <button
+          type="button"
+          aria-pressed={permissionMode === 'allow'}
+          onClick={() => onPermissionModeChange('allow')}
+          className="rounded-lg border px-3 py-3 text-left cursor-pointer transition-colors"
+          style={{
+            borderColor: permissionMode === 'allow'
+              ? 'color-mix(in srgb, var(--color-amber) 45%, var(--color-border-subtle))'
+              : 'var(--color-border-subtle)',
+            background: permissionMode === 'allow'
+              ? 'color-mix(in srgb, var(--color-amber) 7%, var(--color-elevated))'
+              : 'var(--color-elevated)',
+          }}
+        >
+          <span className="block text-[12px] font-medium text-text">{t('mcpForm.approvalAllow', 'Trusted, auto-approve')}</span>
+          <span className="mt-1 block text-[10px] leading-relaxed text-text-muted">
+            Assigned agents can call this MCP without approval prompts. Use only for MCPs you control or trust.
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function LinkedSkillsCard({
+  availableSkills,
+  linkedSkillNames,
+  onToggleSkill,
+}: {
+  availableSkills: readonly CustomSkillConfig[]
+  linkedSkillNames: readonly string[]
+  onToggleSkill: (skillName: string) => void
+}) {
+  return (
+    <div className="rounded-xl border border-border-subtle bg-surface p-5">
+      <div className="mb-3">
+        <div className="text-[14px] font-semibold text-text">{t('mcpForm.linkedSkills', 'Linked skills')}</div>
+        <div className="text-[11px] text-text-muted mt-1">
+          Pre-wire this MCP into custom skills that should request it automatically.
+          {getBrandName()} writes this MCP&apos;s id into each selected skill&apos;s
+          SKILL.md frontmatter <span className="font-mono">toolIds</span>.
+        </div>
+      </div>
+      {availableSkills.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {availableSkills.map((skill) => {
+            const selected = linkedSkillNames.includes(skill.name)
+            return (
+              <button
+                key={skill.name}
+                type="button"
+                onClick={() => onToggleSkill(skill.name)}
+                className="inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-[11px] border cursor-pointer transition-colors"
+                style={{
+                  color: selected ? 'var(--color-accent)' : 'var(--color-text-secondary)',
+                  background: selected
+                    ? 'color-mix(in srgb, var(--color-accent) 12%, transparent)'
+                    : 'var(--color-elevated)',
+                  borderColor: selected
+                    ? 'color-mix(in srgb, var(--color-accent) 40%, transparent)'
+                    : 'var(--color-border-subtle)',
+                }}
+              >
+                <PluginIcon icon={skill.name} size={14} />
+                {skill.name}
+              </button>
+            )
+          })}
+        </div>
+      ) : (
+        <div className="text-[11px] text-text-muted italic">
+          No custom skills discovered yet. Add a skill bundle from the Capabilities page
+          and it will show up here.
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function McpPreviewCard({
+  label,
+  name,
+  type,
+  permissionMode,
+  testResult,
+  testing,
+  hasIssues,
+  onTest,
+}: {
+  label: string
+  name: string
+  type: CustomMcpFormType
+  permissionMode: CustomMcpPermissionMode
+  testResult: CustomMcpTestResult | null
+  testing: boolean
+  hasIssues: boolean
+  onTest: () => void
+}) {
+  const displayName = label.trim() || name.trim() || 'New MCP'
+  const namespace = name.trim() || 'not-set'
+  const permissionPrefix = name.trim() ? `mcp__${name.trim()}__*` : 'Set an MCP id to generate this.'
+
+  return (
+    <div className="rounded-xl border border-border-subtle bg-surface p-4">
+      <div className="text-[12px] font-semibold text-text mb-3">{t('mcpForm.preview', 'MCP preview')}</div>
+      <div className="rounded-xl border border-border-subtle bg-elevated p-4 mb-4">
+        <div className="text-[11px] text-text-secondary mb-1">{t('mcpForm.displayName', 'Display name')}</div>
+        <div className="text-[13px] font-medium text-text">{displayName}</div>
+        <div className="mt-3 text-[11px] text-text-secondary mb-1">{t('mcpForm.runtimeNamespace', 'Runtime namespace')}</div>
+        <div className="text-[12px] text-text">{namespace}</div>
+        <div className="mt-3 text-[11px] text-text-secondary mb-1">{t('mcpForm.permissionPrefix', 'Permission prefix')}</div>
+        <div className="text-[11px] text-text-muted font-mono">{permissionPrefix}</div>
+      </div>
+
+      <div className="flex flex-col gap-3 text-[11px] text-text-muted">
+        <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
+          <div className="text-text-secondary mb-1">{t('mcpForm.connectionSummary', 'Connection summary')}</div>
+          <div>{type === 'stdio' ? 'Starts a local MCP server process.' : 'Connects to a remote MCP endpoint.'}</div>
+        </div>
+
+        <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
+          <div className="text-text-secondary mb-1">{t('mcpForm.approvalSummary', 'Approval summary')}</div>
+          <div>
+            {permissionMode === 'allow'
+              ? 'Trusted MCP. Assigned agents can use its tools automatically.'
+              : 'OpenCode will ask before assigned agents use its tools.'}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-border-subtle bg-elevated px-3.5 py-3">
+          <div className="flex items-center justify-between gap-3 mb-2">
+            <div className="text-text-secondary">{t('mcpForm.connectivityTest', 'Connectivity test')}</div>
+            <button
+              onClick={onTest}
+              disabled={testing || hasIssues}
+              className="px-2.5 py-1 rounded-md text-[10px] border border-border-subtle text-accent disabled:opacity-40 cursor-pointer"
+            >
+              {testing ? 'Testing…' : 'Test MCP'}
+            </button>
+          </div>
+          {testResult ? (
+            testResult.ok ? (
+              <div className="flex flex-col gap-2">
+                <div className="text-[11px]" style={{ color: 'var(--color-green)' }}>
+                  Connected successfully. Found {testResult.methods.length} {testResult.methods.length === 1 ? 'method' : 'methods'}.
+                </div>
+                {testResult.methods.slice(0, 6).map((method) => (
+                  <div key={method.id} className="text-[10px] text-text-muted">
+                    <span className="text-text-secondary">{method.id}</span>
+                    {method.description ? ` · ${method.description}` : ''}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-[11px]" style={{ color: 'var(--color-amber)' }}>
+                {testResult.error || t('mcpForm.couldNotConnect', 'Could not connect to this MCP.')}
+              </div>
+            )
+          ) : (
+            <div>{t('mcpForm.runTestHint', 'Run a test before saving to confirm the server responds and exposes methods.')}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/plugins/custom-mcp-form-support.ts
+++ b/apps/desktop/src/renderer/components/plugins/custom-mcp-form-support.ts
@@ -1,0 +1,152 @@
+import type { CustomMcpConfig, CustomSkillConfig } from '@open-cowork/shared'
+
+export const customMcpInputClass = 'w-full px-3 py-2 rounded-lg text-[12px] bg-elevated border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-border'
+export const CUSTOM_MCP_VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
+
+export type CustomMcpFormType = 'stdio' | 'http'
+export type CustomMcpFormScope = 'machine' | 'project'
+export type CustomMcpPermissionMode = 'ask' | 'allow'
+export type KeyValueDraft = { id: string; key: string; value: string }
+
+let nextKeyValueDraftId = 0
+
+export function createKeyValueDraft(key = '', value = ''): KeyValueDraft {
+  nextKeyValueDraftId += 1
+  return { id: `custom-mcp-field-${nextKeyValueDraftId}`, key, value }
+}
+
+export function createKeyValueDraftsFromRecord(record?: Record<string, string>): KeyValueDraft[] {
+  const entries = Object.entries(record || {})
+  if (entries.length === 0) return [createKeyValueDraft()]
+  return entries.map(([key, value]) => createKeyValueDraft(key, value))
+}
+
+export function buildCustomMcpDraft({
+  scope,
+  projectTargetDirectory,
+  name,
+  label,
+  description,
+  type,
+  command,
+  args,
+  url,
+  envPairs,
+  headerPairs,
+  googleAuthEnabled,
+  authModeAvailable,
+  allowPrivateNetwork,
+  permissionMode,
+}: {
+  scope: CustomMcpFormScope
+  projectTargetDirectory: string | null
+  name: string
+  label: string
+  description: string
+  type: CustomMcpFormType
+  command: string
+  args: string
+  url: string
+  envPairs: readonly KeyValueDraft[]
+  headerPairs: readonly KeyValueDraft[]
+  googleAuthEnabled: boolean
+  authModeAvailable: boolean
+  allowPrivateNetwork: boolean
+  permissionMode: CustomMcpPermissionMode
+}): CustomMcpConfig {
+  const mcp: CustomMcpConfig = {
+    scope,
+    directory: scope === 'project' ? projectTargetDirectory || null : null,
+    name: name.trim(),
+    label: label.trim() || undefined,
+    description: description.trim() || undefined,
+    type,
+  }
+
+  if (type === 'stdio') {
+    mcp.command = command.trim()
+    mcp.args = args.trim() ? args.trim().split(/\s+/).filter(Boolean) : []
+    const env = keyValueDraftsToRecord(envPairs)
+    if (Object.keys(env).length > 0) mcp.env = env
+    if (googleAuthEnabled && authModeAvailable) mcp.googleAuth = true
+  } else {
+    mcp.url = url.trim()
+    const headers = keyValueDraftsToRecord(headerPairs)
+    if (Object.keys(headers).length > 0) mcp.headers = headers
+    if (allowPrivateNetwork) mcp.allowPrivateNetwork = true
+  }
+
+  if (permissionMode === 'allow') mcp.permissionMode = 'allow'
+  return mcp
+}
+
+function keyValueDraftsToRecord(pairs: readonly KeyValueDraft[]): Record<string, string> {
+  const record: Record<string, string> = {}
+  for (const { key, value } of pairs) {
+    if (key.trim()) record[key.trim()] = value
+  }
+  return record
+}
+
+export function collectCustomMcpIssues({
+  draft,
+  isEditing,
+  existingNames,
+  scope,
+  projectTargetDirectory,
+  type,
+}: {
+  draft: CustomMcpConfig
+  isEditing: boolean
+  existingNames: readonly string[]
+  scope: CustomMcpFormScope
+  projectTargetDirectory: string | null
+  type: CustomMcpFormType
+}): string[] {
+  const next: string[] = []
+  if (!draft.name) {
+    next.push('Add an MCP id so the runtime can register it.')
+  } else if (!CUSTOM_MCP_VALID_NAME.test(draft.name)) {
+    next.push('Use alphanumeric characters, hyphens, or underscores only for the MCP id.')
+  }
+  if (draft.name && !isEditing && existingNames.includes(draft.name)) {
+    next.push(`A custom MCP named "${draft.name}" already exists.`)
+  }
+  if (scope === 'project' && !projectTargetDirectory) {
+    next.push('Choose a project directory for this project-scoped MCP.')
+  }
+  if (type === 'stdio' && !draft.command?.trim()) {
+    next.push('Add the stdio command that starts this MCP server.')
+  }
+  if (type === 'http' && !draft.url?.trim()) {
+    next.push('Add the HTTP or SSE endpoint URL for this MCP server.')
+  }
+  return next
+}
+
+export function linkedSkillNamesForMcp(skills: readonly CustomSkillConfig[], mcpName: string): string[] {
+  return skills
+    .filter((skill) => (skill.toolIds || []).includes(mcpName))
+    .map((skill) => skill.name)
+}
+
+export function toggleStringSelection(current: readonly string[], value: string): string[] {
+  return current.includes(value)
+    ? current.filter((entry) => entry !== value)
+    : [...current, value]
+}
+
+export function nextSkillToolIdsForMcp({
+  currentToolIds,
+  mcpId,
+  shouldBeLinked,
+}: {
+  currentToolIds: readonly string[]
+  mcpId: string
+  shouldBeLinked: boolean
+}): string[] | null {
+  const currentlyLinked = currentToolIds.includes(mcpId)
+  if (currentlyLinked === shouldBeLinked) return null
+  if (shouldBeLinked) return Array.from(new Set([...currentToolIds, mcpId]))
+  return currentToolIds.filter((id) => id !== mcpId)
+}

--- a/tests/custom-mcp-form-support.test.ts
+++ b/tests/custom-mcp-form-support.test.ts
@@ -1,0 +1,225 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { CustomSkillConfig } from '../packages/shared/src/index.ts'
+import {
+  buildCustomMcpDraft,
+  collectCustomMcpIssues,
+  createKeyValueDraft,
+  createKeyValueDraftsFromRecord,
+  linkedSkillNamesForMcp,
+  nextSkillToolIdsForMcp,
+  toggleStringSelection,
+} from '../apps/desktop/src/renderer/components/plugins/custom-mcp-form-support.ts'
+
+function makeSkill(name: string, toolIds: string[] = []): CustomSkillConfig {
+  return {
+    scope: 'machine',
+    directory: null,
+    name,
+    content: `# ${name}`,
+    files: [],
+    toolIds,
+  }
+}
+
+describe('createKeyValueDraftsFromRecord', () => {
+  it('keeps one blank row for empty records and stable row ids for entries', () => {
+    const empty = createKeyValueDraftsFromRecord()
+    assert.equal(empty.length, 1)
+    assert.equal(empty[0]?.key, '')
+    assert.equal(empty[0]?.value, '')
+    assert.match(empty[0]?.id || '', /^custom-mcp-field-/)
+
+    const filled = createKeyValueDraftsFromRecord({ TOKEN: 'secret', REGION: 'eu' })
+    assert.deepEqual(
+      filled.map(({ key, value }) => ({ key, value })),
+      [
+        { key: 'TOKEN', value: 'secret' },
+        { key: 'REGION', value: 'eu' },
+      ],
+    )
+    assert.notEqual(filled[0]?.id, filled[1]?.id)
+  })
+})
+
+describe('buildCustomMcpDraft', () => {
+  it('normalizes stdio drafts without exposing project directories for machine scope', () => {
+    const draft = buildCustomMcpDraft({
+      scope: 'machine',
+      projectTargetDirectory: '/ignored',
+      name: ' github ',
+      label: ' GitHub ',
+      description: ' Developer platform ',
+      type: 'stdio',
+      command: ' npx ',
+      args: ' -y   @modelcontextprotocol/server-github ',
+      url: '',
+      envPairs: [
+        createKeyValueDraft(' GITHUB_TOKEN ', 'abc'),
+        createKeyValueDraft('', 'ignored'),
+      ],
+      headerPairs: [createKeyValueDraft('Authorization', 'ignored')],
+      googleAuthEnabled: true,
+      authModeAvailable: true,
+      allowPrivateNetwork: true,
+      permissionMode: 'allow',
+    })
+
+    assert.equal(draft.scope, 'machine')
+    assert.equal(draft.directory, null)
+    assert.equal(draft.name, 'github')
+    assert.equal(draft.label, 'GitHub')
+    assert.equal(draft.description, 'Developer platform')
+    assert.equal(draft.command, 'npx')
+    assert.deepEqual(draft.args, ['-y', '@modelcontextprotocol/server-github'])
+    assert.deepEqual(draft.env, { GITHUB_TOKEN: 'abc' })
+    assert.equal(draft.googleAuth, true)
+    assert.equal(draft.permissionMode, 'allow')
+    assert.equal(draft.allowPrivateNetwork, undefined)
+    assert.equal(draft.headers, undefined)
+  })
+
+  it('normalizes HTTP drafts with headers and private-network opt-in', () => {
+    const draft = buildCustomMcpDraft({
+      scope: 'project',
+      projectTargetDirectory: '/repo',
+      name: 'jira',
+      label: '',
+      description: '',
+      type: 'http',
+      command: 'ignored',
+      args: 'ignored',
+      url: ' https://mcp.example.test/sse ',
+      envPairs: [createKeyValueDraft('IGNORED', 'yes')],
+      headerPairs: [createKeyValueDraft(' Authorization ', 'Bearer token')],
+      googleAuthEnabled: true,
+      authModeAvailable: true,
+      allowPrivateNetwork: true,
+      permissionMode: 'ask',
+    })
+
+    assert.equal(draft.scope, 'project')
+    assert.equal(draft.directory, '/repo')
+    assert.equal(draft.label, undefined)
+    assert.equal(draft.description, undefined)
+    assert.equal(draft.url, 'https://mcp.example.test/sse')
+    assert.deepEqual(draft.headers, { Authorization: 'Bearer token' })
+    assert.equal(draft.allowPrivateNetwork, true)
+    assert.equal(draft.command, undefined)
+    assert.equal(draft.env, undefined)
+    assert.equal(draft.googleAuth, undefined)
+    assert.equal(draft.permissionMode, undefined)
+  })
+})
+
+describe('collectCustomMcpIssues', () => {
+  it('reports the same save blockers as the form', () => {
+    const draft = buildCustomMcpDraft({
+      scope: 'project',
+      projectTargetDirectory: null,
+      name: 'bad name',
+      label: '',
+      description: '',
+      type: 'stdio',
+      command: '',
+      args: '',
+      url: '',
+      envPairs: [],
+      headerPairs: [],
+      googleAuthEnabled: false,
+      authModeAvailable: false,
+      allowPrivateNetwork: false,
+      permissionMode: 'ask',
+    })
+
+    assert.deepEqual(collectCustomMcpIssues({
+      draft,
+      isEditing: false,
+      existingNames: ['github'],
+      scope: 'project',
+      projectTargetDirectory: null,
+      type: 'stdio',
+    }), [
+      'Use alphanumeric characters, hyphens, or underscores only for the MCP id.',
+      'Choose a project directory for this project-scoped MCP.',
+      'Add the stdio command that starts this MCP server.',
+    ])
+  })
+
+  it('blocks duplicate names only while creating', () => {
+    const draft = buildCustomMcpDraft({
+      scope: 'machine',
+      projectTargetDirectory: null,
+      name: 'github',
+      label: '',
+      description: '',
+      type: 'http',
+      command: '',
+      args: '',
+      url: '',
+      envPairs: [],
+      headerPairs: [],
+      googleAuthEnabled: false,
+      authModeAvailable: false,
+      allowPrivateNetwork: false,
+      permissionMode: 'ask',
+    })
+
+    const createIssues = collectCustomMcpIssues({
+      draft,
+      isEditing: false,
+      existingNames: ['github'],
+      scope: 'machine',
+      projectTargetDirectory: null,
+      type: 'http',
+    })
+    assert.match(createIssues.join('\n'), /already exists/)
+
+    const editIssues = collectCustomMcpIssues({
+      draft,
+      isEditing: true,
+      existingNames: ['github'],
+      scope: 'machine',
+      projectTargetDirectory: null,
+      type: 'http',
+    })
+    assert.doesNotMatch(editIssues.join('\n'), /already exists/)
+  })
+})
+
+describe('skill link helpers', () => {
+  it('derives linked skills and toggles selected names', () => {
+    const skills = [
+      makeSkill('research', ['github']),
+      makeSkill('charts', ['other']),
+      makeSkill('docs', ['github', 'other']),
+    ]
+
+    assert.deepEqual(linkedSkillNamesForMcp(skills, 'github'), ['research', 'docs'])
+    assert.deepEqual(toggleStringSelection(['research'], 'charts'), ['research', 'charts'])
+    assert.deepEqual(toggleStringSelection(['research', 'charts'], 'research'), ['charts'])
+  })
+
+  it('returns null when a skill toolIds list already matches the requested link state', () => {
+    assert.equal(nextSkillToolIdsForMcp({
+      currentToolIds: ['github'],
+      mcpId: 'github',
+      shouldBeLinked: true,
+    }), null)
+    assert.deepEqual(nextSkillToolIdsForMcp({
+      currentToolIds: ['github', 'github', 'other'],
+      mcpId: 'github',
+      shouldBeLinked: true,
+    }), null)
+    assert.deepEqual(nextSkillToolIdsForMcp({
+      currentToolIds: ['other'],
+      mcpId: 'github',
+      shouldBeLinked: true,
+    }), ['other', 'github'])
+    assert.deepEqual(nextSkillToolIdsForMcp({
+      currentToolIds: ['github', 'other'],
+      mcpId: 'github',
+      shouldBeLinked: false,
+    }), ['other'])
+  })
+})


### PR DESCRIPTION
## Summary
- split CustomMcpForm sidebar cards into focused renderer components
- move custom MCP draft construction, validation, and skill-link helpers into a pure support module
- add direct node:test coverage for the extracted MCP form helpers

## Validation
- node --no-warnings --experimental-strip-types --test tests/custom-mcp-form-support.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- CustomMcpForm
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- pnpm perf:check
- git diff --check