### PR TITLE
Split session cost event tracking

### DIFF
--- a/apps/desktop/src/main/session-cost-event-tracker.ts
+++ b/apps/desktop/src/main/session-cost-event-tracker.ts
@@ -1,0 +1,23 @@
+export const MAX_SEEN_COST_EVENT_IDS_PER_SESSION = 1_000
+
+export class SessionCostEventTracker {
+  private seenEventIdsBySession = new Map<string, Set<string>>()
+
+  mark(sessionId: string, eventId?: string | null) {
+    if (!eventId) return true
+    const seen = this.seenEventIdsBySession.get(sessionId) || new Set<string>()
+    if (seen.has(eventId)) return false
+    seen.add(eventId)
+    while (seen.size > MAX_SEEN_COST_EVENT_IDS_PER_SESSION) {
+      const oldest = seen.values().next().value
+      if (typeof oldest !== 'string') break
+      seen.delete(oldest)
+    }
+    this.seenEventIdsBySession.set(sessionId, seen)
+    return true
+  }
+
+  forgetSession(sessionId: string) {
+    this.seenEventIdsBySession.delete(sessionId)
+  }
+}

--- a/apps/desktop/src/main/session-engine.ts
+++ b/apps/desktop/src/main/session-engine.ts
@@ -27,6 +27,9 @@ import {
 import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
 import type { SessionUsageSummary } from '@open-cowork/shared'
 import { buildSessionUsageSummary } from './session-usage-summary.ts'
+import { SessionCostEventTracker } from './session-cost-event-tracker.ts'
+
+export { MAX_SEEN_COST_EVENT_IDS_PER_SESSION } from './session-cost-event-tracker.ts'
 
 type CachedSessionView = {
   revision: number
@@ -35,8 +38,6 @@ type CachedSessionView = {
   awaitingPermission: boolean
   view: SessionView
 }
-
-export const MAX_SEEN_COST_EVENT_IDS_PER_SESSION = 1_000
 
 function getLatestHistoryEventAt(items: HistoryItem[]) {
   let latest = 0
@@ -69,7 +70,7 @@ export class SessionEngine {
   private awaitingPermissionSessions = new Set<string>()
   private currentSessionId: string | null = null
   private viewCacheById = new Map<string, CachedSessionView>()
-  private seenCostEventIdsBySession = new Map<string, Set<string>>()
+  private costEventTracker = new SessionCostEventTracker()
 
   private invalidateView(sessionId: string) {
     this.viewCacheById.delete(sessionId)
@@ -170,26 +171,12 @@ export class SessionEngine {
     delete next[sessionId]
     this.sessionStateById = next
     this.invalidateView(sessionId)
-    this.seenCostEventIdsBySession.delete(sessionId)
+    this.costEventTracker.forgetSession(sessionId)
     this.busySessions.delete(sessionId)
     this.awaitingPermissionSessions.delete(sessionId)
     if (this.currentSessionId === sessionId) {
       this.currentSessionId = null
     }
-  }
-
-  private markCostEvent(sessionId: string, eventId?: string | null) {
-    if (!eventId) return true
-    const seen = this.seenCostEventIdsBySession.get(sessionId) || new Set<string>()
-    if (seen.has(eventId)) return false
-    seen.add(eventId)
-    while (seen.size > MAX_SEEN_COST_EVENT_IDS_PER_SESSION) {
-      const oldest = seen.values().next().value
-      if (typeof oldest !== 'string') break
-      seen.delete(oldest)
-    }
-    this.seenCostEventIdsBySession.set(sessionId, seen)
-    return true
   }
 
   addApproval(approval: Omit<PendingApproval, 'order'>) {
@@ -355,7 +342,7 @@ export class SessionEngine {
         }))
         break
       case 'cost':
-        if (!this.markCostEvent(sessionId, typeof data.id === 'string' ? data.id : null)) {
+        if (!this.costEventTracker.mark(sessionId, typeof data.id === 'string' ? data.id : null)) {
           break
         }
         this.updateSessionState(sessionId, (current) => {

--- a/tests/session-cost-event-tracker.test.ts
+++ b/tests/session-cost-event-tracker.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  MAX_SEEN_COST_EVENT_IDS_PER_SESSION,
+  SessionCostEventTracker,
+} from '../apps/desktop/src/main/session-cost-event-tracker.ts'
+
+test('session cost event tracker treats missing ids as non-deduped events', () => {
+  const tracker = new SessionCostEventTracker()
+
+  assert.equal(tracker.mark('session-a'), true)
+  assert.equal(tracker.mark('session-a', null), true)
+})
+
+test('session cost event tracker dedupes event ids per session', () => {
+  const tracker = new SessionCostEventTracker()
+
+  assert.equal(tracker.mark('session-a', 'cost-1'), true)
+  assert.equal(tracker.mark('session-a', 'cost-1'), false)
+  assert.equal(tracker.mark('session-b', 'cost-1'), true)
+})
+
+test('session cost event tracker bounds remembered ids and evicts the oldest', () => {
+  const tracker = new SessionCostEventTracker()
+
+  for (let index = 0; index <= MAX_SEEN_COST_EVENT_IDS_PER_SESSION; index += 1) {
+    assert.equal(tracker.mark('session-a', `cost-${index}`), true)
+  }
+
+  assert.equal(tracker.mark('session-a', 'cost-0'), true)
+  assert.equal(tracker.mark('session-a', `cost-${MAX_SEEN_COST_EVENT_IDS_PER_SESSION}`), false)
+})
+
+test('session cost event tracker can forget all ids for a session', () => {
+  const tracker = new SessionCostEventTracker()
+
+  assert.equal(tracker.mark('session-a', 'cost-1'), true)
+  assert.equal(tracker.mark('session-a', 'cost-1'), false)
+
+  tracker.forgetSession('session-a')
+
+  assert.equal(tracker.mark('session-a', 'cost-1'), true)
+})


### PR DESCRIPTION
## Summary
- extract streamed cost-event dedupe state from SessionEngine into SessionCostEventTracker
- keep the existing SessionEngine export for the cost-event cap so current callers remain stable
- add direct Node tests for missing ids, per-session dedupe, bounded eviction, and session cleanup

## Validation
- pnpm test -- tests/session-cost-event-tracker.test.ts tests/session-engine.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check