### PR TITLE
Split runtime event normalizers

### DIFF
--- a/apps/desktop/src/main/event-runtime-handlers.ts
+++ b/apps/desktop/src/main/event-runtime-handlers.ts
@@ -11,6 +11,11 @@ import {
   readRecordValue,
   readString,
 } from './normalizer-utils.ts'
+import {
+  extractRuntimeErrorMessage,
+  normalizePermissionEvent,
+  readRuntimeSessionId,
+} from './runtime-event-normalizers.ts'
 import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
 import { dispatchRuntimeSessionEvent, dropSessionFromDispatcherQueues } from './session-event-dispatcher.ts'
 import { shortSessionId } from './log-sanitizer.ts'
@@ -49,104 +54,11 @@ import type { PermissionRequest } from '@open-cowork/shared'
 
 type DispatchRuntimeEvent = (win: BrowserWindow, event: RuntimeSessionEvent) => void
 
-function readFirstString(record: Record<string, unknown> | null | undefined, keys: string[]) {
-  for (const key of keys) {
-    const value = readString(readRecordValue(record, key))
-    if (value) return value
-  }
-  return null
-}
-
-function readRuntimeSessionId(properties: Record<string, unknown> | null | undefined) {
-  return readFirstString(properties, ['sessionID', 'sessionId'])
-}
-
 function runAutomationSideEffect(scope: string, task: () => void | Promise<unknown>) {
   void Promise.resolve().then(task).catch((err) => {
     const message = err instanceof Error ? err.message : String(err)
     log('error', `${scope} failed: ${message}`)
   })
-}
-
-function extractRuntimeErrorMessage(
-  properties: Record<string, unknown> | null | undefined,
-  error: Record<string, unknown> | null | undefined,
-) {
-  const nestedError = asRecord(readRecordValue(error, 'error'))
-  const data = asRecord(readRecordValue(error, 'data'))
-  const nestedData = asRecord(readRecordValue(nestedError, 'data'))
-  const response = asRecord(readRecordValue(error, 'response'))
-  const responseBody = asRecord(readRecordValue(response, 'body'))
-
-  const resolved = readFirstString(error, ['message'])
-    || readFirstString(nestedError, ['message'])
-    || readFirstString(data, ['message', 'error'])
-    || readFirstString(nestedData, ['message', 'error'])
-    || readFirstString(responseBody, ['message', 'error'])
-    || readFirstString(properties, ['message'])
-    || readFirstString(error, ['name', 'type', 'code'])
-    || readFirstString(nestedError, ['name', 'type', 'status', 'code'])
-  if (resolved) return resolved
-
-  // Fall back to stringifying the payload so a runtime-surfaced error with
-  // an unfamiliar shape still reaches the user with actionable detail.
-  // "An error occurred" on its own is not useful when debugging which of
-  // 300+ OpenRouter models failed.
-  try {
-    const payload = error && Object.keys(error).length > 0
-      ? error
-      : properties && Object.keys(properties).length > 0
-        ? properties
-        : null
-    if (payload) {
-      const serialized = JSON.stringify(payload)
-      if (serialized && serialized !== '{}') return serialized
-    }
-  } catch {
-    // ignore serialization errors
-  }
-  return 'An error occurred'
-}
-
-function readNestedRecord(
-  record: Record<string, unknown> | null | undefined,
-  keys: string[],
-) {
-  for (const key of keys) {
-    const nested = asRecord(readRecordValue(record, key))
-    if (Object.keys(nested).length > 0) return nested
-  }
-  return null
-}
-
-function normalizePermissionEvent(properties: Record<string, unknown> | null | undefined) {
-  const permission = readNestedRecord(properties, ['permission', 'info', 'request'])
-  const id = readFirstString(permission, ['id', 'requestID', 'requestId'])
-    || readFirstString(properties, ['id', 'requestID', 'requestId'])
-  const sessionId = readFirstString(permission, ['sessionID', 'sessionId'])
-    || readFirstString(properties, ['sessionID', 'sessionId'])
-  const permissionType = readFirstString(permission, ['type', 'permission'])
-    || readFirstString(properties, ['type', 'permission'])
-    || 'permission'
-  const title = readFirstString(permission, ['title', 'tool', 'name'])
-    || readFirstString(properties, ['title', 'tool', 'name'])
-    || permissionType
-  const metadata = asRecord(readRecordValue(permission, 'metadata'))
-  const outerMetadata = asRecord(readRecordValue(properties, 'metadata'))
-  const nestedInput = asRecord(readRecordValue(permission, 'input'))
-  const outerInput = asRecord(readRecordValue(properties, 'input'))
-  let input = outerInput
-  if (Object.keys(nestedInput).length > 0) input = nestedInput
-  if (Object.keys(outerMetadata).length > 0) input = outerMetadata
-  if (Object.keys(metadata).length > 0) input = metadata
-
-  return {
-    id,
-    sessionId,
-    permissionType,
-    title,
-    input,
-  }
 }
 
 function emitTaskRun(win: BrowserWindow, taskRun: TaskRunMeta) {

--- a/apps/desktop/src/main/runtime-event-normalizers.ts
+++ b/apps/desktop/src/main/runtime-event-normalizers.ts
@@ -1,0 +1,98 @@
+import {
+  asRecord,
+  readRecordValue,
+  readString,
+} from './normalizer-utils.ts'
+
+export function readFirstString(record: Record<string, unknown> | null | undefined, keys: string[]) {
+  for (const key of keys) {
+    const value = readString(readRecordValue(record, key))
+    if (value) return value
+  }
+  return null
+}
+
+export function readRuntimeSessionId(properties: Record<string, unknown> | null | undefined) {
+  return readFirstString(properties, ['sessionID', 'sessionId'])
+}
+
+export function extractRuntimeErrorMessage(
+  properties: Record<string, unknown> | null | undefined,
+  error: Record<string, unknown> | null | undefined,
+) {
+  const nestedError = asRecord(readRecordValue(error, 'error'))
+  const data = asRecord(readRecordValue(error, 'data'))
+  const nestedData = asRecord(readRecordValue(nestedError, 'data'))
+  const response = asRecord(readRecordValue(error, 'response'))
+  const responseBody = asRecord(readRecordValue(response, 'body'))
+
+  const resolved = readFirstString(error, ['message'])
+    || readFirstString(nestedError, ['message'])
+    || readFirstString(data, ['message', 'error'])
+    || readFirstString(nestedData, ['message', 'error'])
+    || readFirstString(responseBody, ['message', 'error'])
+    || readFirstString(properties, ['message'])
+    || readFirstString(error, ['name', 'type', 'code'])
+    || readFirstString(nestedError, ['name', 'type', 'status', 'code'])
+  if (resolved) return resolved
+
+  // Fall back to stringifying the payload so a runtime-surfaced error with
+  // an unfamiliar shape still reaches the user with actionable detail.
+  // "An error occurred" on its own is not useful when debugging which of
+  // 300+ OpenRouter models failed.
+  try {
+    const payload = error && Object.keys(error).length > 0
+      ? error
+      : properties && Object.keys(properties).length > 0
+        ? properties
+        : null
+    if (payload) {
+      const serialized = JSON.stringify(payload)
+      if (serialized && serialized !== '{}') return serialized
+    }
+  } catch {
+    // ignore serialization errors
+  }
+  return 'An error occurred'
+}
+
+function readNestedRecord(
+  record: Record<string, unknown> | null | undefined,
+  keys: string[],
+) {
+  for (const key of keys) {
+    const nested = asRecord(readRecordValue(record, key))
+    if (Object.keys(nested).length > 0) return nested
+  }
+  return null
+}
+
+export function normalizePermissionEvent(properties: Record<string, unknown> | null | undefined) {
+  const permission = readNestedRecord(properties, ['permission', 'info', 'request'])
+  const id = readFirstString(permission, ['id', 'requestID', 'requestId'])
+    || readFirstString(properties, ['id', 'requestID', 'requestId'])
+  const sessionId = readFirstString(permission, ['sessionID', 'sessionId'])
+    || readFirstString(properties, ['sessionID', 'sessionId'])
+  const permissionType = readFirstString(permission, ['type', 'permission'])
+    || readFirstString(properties, ['type', 'permission'])
+    || 'permission'
+  const title = readFirstString(permission, ['title', 'tool', 'name'])
+    || readFirstString(properties, ['title', 'tool', 'name'])
+    || permissionType
+  const metadata = asRecord(readRecordValue(permission, 'metadata'))
+  const outerMetadata = asRecord(readRecordValue(properties, 'metadata'))
+  const nestedInput = asRecord(readRecordValue(permission, 'input'))
+  const outerInput = asRecord(readRecordValue(properties, 'input'))
+  let input = outerInput
+  if (Object.keys(nestedInput).length > 0) input = nestedInput
+  if (Object.keys(outerMetadata).length > 0) input = outerMetadata
+  if (Object.keys(metadata).length > 0) input = metadata
+
+  return {
+    id,
+    sessionId,
+    permissionType,
+    title,
+    input,
+  }
+}

--- a/tests/runtime-event-normalizers.test.ts
+++ b/tests/runtime-event-normalizers.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  extractRuntimeErrorMessage,
+  normalizePermissionEvent,
+  readRuntimeSessionId,
+} from '../apps/desktop/src/main/runtime-event-normalizers.ts'
+
+test('readRuntimeSessionId accepts SDK sessionID and camelCase sessionId fields', () => {
+  assert.equal(readRuntimeSessionId({ sessionID: 'session-a' }), 'session-a')
+  assert.equal(readRuntimeSessionId({ sessionId: 'session-b' }), 'session-b')
+  assert.equal(readRuntimeSessionId({}), null)
+})
+
+test('normalizePermissionEvent merges nested permission payloads with top-level request ids', () => {
+  assert.deepEqual(normalizePermissionEvent({
+    id: 'perm-1',
+    sessionID: 'root-session',
+    permission: {
+      permission: 'bash',
+      title: 'Run shell command',
+      metadata: { command: 'pwd' },
+    },
+  }), {
+    id: 'perm-1',
+    sessionId: 'root-session',
+    permissionType: 'bash',
+    title: 'Run shell command',
+    input: { command: 'pwd' },
+  })
+})
+
+test('normalizePermissionEvent prefers nested metadata over input and outer metadata', () => {
+  assert.deepEqual(normalizePermissionEvent({
+    input: { value: 'outer-input' },
+    metadata: { value: 'outer-metadata' },
+    permission: {
+      id: 'perm-2',
+      sessionID: 'root-session',
+      type: 'tool',
+      input: { value: 'nested-input' },
+      metadata: { value: 'nested-metadata' },
+    },
+  }), {
+    id: 'perm-2',
+    sessionId: 'root-session',
+    permissionType: 'tool',
+    title: 'tool',
+    input: { value: 'nested-metadata' },
+  })
+})
+
+test('extractRuntimeErrorMessage reads common nested provider error shapes', () => {
+  assert.equal(extractRuntimeErrorMessage({}, {
+    error: {
+      data: { message: 'provider rejected model' },
+    },
+  }), 'provider rejected model')
+
+  assert.equal(extractRuntimeErrorMessage({}, {
+    response: {
+      body: { error: 'rate limited' },
+    },
+  }), 'rate limited')
+})
+
+test('extractRuntimeErrorMessage stringifies unfamiliar payloads before falling back to a generic message', () => {
+  const message = extractRuntimeErrorMessage({}, {
+    provider_shape: 'unknown',
+    nested: { hint: 'inspect this' },
+  })
+
+  assert.notEqual(message, 'An error occurred')
+  assert.ok(message.includes('provider_shape'))
+})


### PR DESCRIPTION
## Summary
- move runtime event payload normalization out of event-runtime-handlers
- keep the dispatcher focused on side effects and event routing
- add direct Node coverage for session id, permission, and runtime error payload normalization

## Validation
- pnpm test -- tests/runtime-event-normalizers.test.ts tests/event-runtime-handlers.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check