### PR TITLE
Split task binding score helper

### DIFF
--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -4,6 +4,10 @@ import {
   normalizeAgentName,
   normalizeTaskTitle,
 } from './task-run-utils.ts'
+import {
+  findBestIndexedMatch,
+  type BindingHints,
+} from './task-binding-score.ts'
 
 export type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
 
@@ -146,67 +150,6 @@ export function getImmediateParentSession(sessionId?: string | null): string | n
   const parent = sessionLineage.get(sessionId)
   if (!parent || parent === sessionId) return null
   return parent
-}
-
-type BindingHints = {
-  title?: string | null
-  agent?: string | null
-}
-
-function normalizeBindingHints(hints?: BindingHints | null) {
-  return {
-    title: normalizeTaskTitle(hints?.title) || null,
-    agent: normalizeAgentName(hints?.agent) || null,
-  }
-}
-
-function computeBindingScore(
-  candidate: { title?: string | null; agent?: string | null },
-  hints?: BindingHints | null,
-) {
-  const normalizedHints = normalizeBindingHints(hints)
-  if (!normalizedHints.title && !normalizedHints.agent) return 0
-
-  let score = 0
-  const candidateAgent = normalizeAgentName(candidate.agent) || null
-  const candidateTitle = normalizeTaskTitle(candidate.title) || null
-
-  if (normalizedHints.agent && candidateAgent && normalizedHints.agent === candidateAgent) {
-    score += 4
-  }
-
-  if (normalizedHints.title && candidateTitle) {
-    if (normalizedHints.title === candidateTitle) {
-      score += 3
-    }
-  }
-
-  return score
-}
-
-function findBestIndexedMatch<T extends { title?: string | null; agent?: string | null }>(
-  entries: T[],
-  hints?: BindingHints | null,
-) {
-  if (entries.length <= 1) return entries.length === 1 ? 0 : -1
-
-  let bestIndex = -1
-  let bestScore = 0
-  let ambiguous = false
-
-  for (const [index, entry] of entries.entries()) {
-    const score = computeBindingScore(entry, hints)
-    if (score > bestScore) {
-      bestScore = score
-      bestIndex = index
-      ambiguous = false
-    } else if (score > 0 && score === bestScore) {
-      ambiguous = true
-    }
-  }
-
-  if (bestIndex >= 0 && !ambiguous) return bestIndex
-  return -1
 }
 
 function takePendingTaskRunId(parentSessionId: string, hints?: BindingHints | null) {

--- a/apps/desktop/src/main/task-binding-score.ts
+++ b/apps/desktop/src/main/task-binding-score.ts
@@ -1,0 +1,65 @@
+import {
+  normalizeAgentName,
+  normalizeTaskTitle,
+} from './task-run-utils.ts'
+
+export type BindingHints = {
+  title?: string | null
+  agent?: string | null
+}
+
+function normalizeBindingHints(hints?: BindingHints | null) {
+  return {
+    title: normalizeTaskTitle(hints?.title) || null,
+    agent: normalizeAgentName(hints?.agent) || null,
+  }
+}
+
+export function computeBindingScore(
+  candidate: { title?: string | null; agent?: string | null },
+  hints?: BindingHints | null,
+) {
+  const normalizedHints = normalizeBindingHints(hints)
+  if (!normalizedHints.title && !normalizedHints.agent) return 0
+
+  let score = 0
+  const candidateAgent = normalizeAgentName(candidate.agent) || null
+  const candidateTitle = normalizeTaskTitle(candidate.title) || null
+
+  if (normalizedHints.agent && candidateAgent && normalizedHints.agent === candidateAgent) {
+    score += 4
+  }
+
+  if (normalizedHints.title && candidateTitle) {
+    if (normalizedHints.title === candidateTitle) {
+      score += 3
+    }
+  }
+
+  return score
+}
+
+export function findBestIndexedMatch<T extends { title?: string | null; agent?: string | null }>(
+  entries: T[],
+  hints?: BindingHints | null,
+) {
+  if (entries.length <= 1) return entries.length === 1 ? 0 : -1
+
+  let bestIndex = -1
+  let bestScore = 0
+  let ambiguous = false
+
+  for (const [index, entry] of entries.entries()) {
+    const score = computeBindingScore(entry, hints)
+    if (score > bestScore) {
+      bestScore = score
+      bestIndex = index
+      ambiguous = false
+    } else if (score > 0 && score === bestScore) {
+      ambiguous = true
+    }
+  }
+
+  if (bestIndex >= 0 && !ambiguous) return bestIndex
+  return -1
+}

--- a/tests/task-binding-score.test.ts
+++ b/tests/task-binding-score.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  computeBindingScore,
+  findBestIndexedMatch,
+} from '../apps/desktop/src/main/task-binding-score.ts'
+
+test('computeBindingScore rewards exact normalized agent and title matches', () => {
+  assert.equal(
+    computeBindingScore(
+      { title: 'Build chart pack', agent: 'charts' },
+      { title: 'Build chart pack', agent: 'Charts' },
+    ),
+    7,
+  )
+})
+
+test('computeBindingScore does not score partial title matches', () => {
+  assert.equal(
+    computeBindingScore(
+      { title: 'Prepare European forecast', agent: null },
+      { title: 'European forecast' },
+    ),
+    0,
+  )
+})
+
+test('findBestIndexedMatch returns the single entry even without hints', () => {
+  assert.equal(findBestIndexedMatch([{ title: 'Only task', agent: null }]), 0)
+})
+
+test('findBestIndexedMatch selects the strongest non-ambiguous candidate', () => {
+  const entries = [
+    { title: 'Prepare forecast', agent: 'analyst' },
+    { title: 'Build chart pack', agent: 'charts' },
+  ]
+
+  assert.equal(findBestIndexedMatch(entries, {
+    title: 'Build chart pack',
+    agent: 'charts',
+  }), 1)
+})
+
+test('findBestIndexedMatch refuses ambiguous matches', () => {
+  const entries = [
+    { title: 'Build chart pack', agent: 'charts' },
+    { title: 'Build chart pack', agent: 'charts' },
+  ]
+
+  assert.equal(findBestIndexedMatch(entries, {
+    title: 'Build chart pack',
+    agent: 'charts',
+  }), -1)
+})


### PR DESCRIPTION
## Summary
- move task binding score/index-selection policy out of event-task-state
- keep the mutable event task store unchanged while making the matching policy reusable
- add direct Node coverage for exact matching, partial-title rejection, singleton behavior, selection, and ambiguity

## Validation
- pnpm test -- tests/task-binding-score.test.ts tests/event-task-state.test.ts tests/event-runtime-handlers.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check