### PR TITLE
Split session history projection utilities

### DIFF
--- a/apps/desktop/src/main/session-history-projection-utils.ts
+++ b/apps/desktop/src/main/session-history-projection-utils.ts
@@ -1,0 +1,42 @@
+import { resolveDisplayCostForModel } from './pricing-core.ts'
+import type {
+  NormalizedMessagePart,
+  NormalizedSessionMessage,
+} from './opencode-adapter.ts'
+
+export const toHistorySortTime = (value?: number, fallback = Date.now()) => {
+  const raw = typeof value === 'number' && Number.isFinite(value) ? value : fallback
+  return raw < 1_000_000_000_000 ? raw * 1000 : raw
+}
+
+export const collectHistoryTextParts = (parts: NormalizedMessagePart[]) => {
+  const textParts: NormalizedMessagePart[] = []
+  let fullText = ''
+
+  for (const part of parts) {
+    if (part.type !== 'text' || typeof part.text !== 'string' || part.text.length === 0) continue
+    textParts.push(part)
+    fullText += part.text
+  }
+
+  return { textParts, fullText }
+}
+
+export const createHistoryCostPayload = (cachedModelId: string, part: NormalizedMessagePart) => {
+  const tokens = part.tokens || { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
+  const cost = resolveDisplayCostForModel(cachedModelId, part.cost ?? undefined, tokens)
+  return {
+    cost,
+    tokens: {
+      input: tokens.input || 0,
+      output: tokens.output || 0,
+      reasoning: tokens.reasoning || 0,
+      cache: { read: tokens.cache?.read || 0, write: tokens.cache?.write || 0 },
+    },
+  }
+}
+
+export const getHistoryModelMeta = (message: NormalizedSessionMessage) => ({
+  providerId: message.info.model.providerId,
+  modelId: message.info.model.modelId,
+})

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -1,11 +1,9 @@
-import { resolveDisplayCostForModel } from './pricing-core.ts'
 import { isInternalCoworkMessage } from './internal-message-utils.ts'
 import {
   normalizeTodoItems,
   normalizeSessionMessages,
   normalizeSessionStatuses,
   type NormalizedMessagePart,
-  type NormalizedSessionMessage,
 } from './opencode-adapter.ts'
 import type { TodoItem } from '@open-cowork/shared'
 import {
@@ -19,6 +17,12 @@ import {
   findBestIndexedMatch,
   type BindingHints,
 } from './task-binding-score.ts'
+import {
+  collectHistoryTextParts,
+  createHistoryCostPayload,
+  getHistoryModelMeta,
+  toHistorySortTime,
+} from './session-history-projection-utils.ts'
 
 type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
 
@@ -102,10 +106,6 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   type InternalProjectedHistoryItem = ProjectedHistoryItem & { sortTime: number }
   const normalizedStatuses = normalizeSessionStatuses(statuses)
   const statusFor = (id: string) => normalizedStatuses[id] || { type: null }
-  const toSortTime = (value?: number) => {
-    const raw = typeof value === 'number' && Number.isFinite(value) ? value : Date.now()
-    return raw < 1_000_000_000_000 ? raw * 1000 : raw
-  }
   const children = (input.children || [])
     .slice()
     .sort((a, b) => (a?.time?.created || 0) - (b?.time?.created || 0))
@@ -126,38 +126,6 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       sortTime,
     })
   }
-
-  const collectTextParts = (parts: NormalizedMessagePart[]) => {
-    const textParts: NormalizedMessagePart[] = []
-    let fullText = ''
-
-    for (const part of parts) {
-      if (part.type !== 'text' || typeof part.text !== 'string' || part.text.length === 0) continue
-      textParts.push(part)
-      fullText += part.text
-    }
-
-    return { textParts, fullText }
-  }
-
-  const createCostPayload = (part: NormalizedMessagePart) => {
-    const tokens = part.tokens || { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
-    const cost = resolveDisplayCostForModel(cachedModelId, part.cost ?? undefined, tokens)
-    return {
-      cost,
-      tokens: {
-        input: tokens.input || 0,
-        output: tokens.output || 0,
-        reasoning: tokens.reasoning || 0,
-        cache: { read: tokens.cache?.read || 0, write: tokens.cache?.write || 0 },
-      },
-    }
-  }
-
-  const getModelMeta = (message: NormalizedSessionMessage) => ({
-    providerId: message.info.model.providerId,
-    modelId: message.info.model.modelId,
-  })
 
   const getTaskStatus = (childId?: string | null): TaskStatus => {
     if (!childId) return 'queued'
@@ -196,10 +164,10 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
   const timingFromChild = (child: ChildSessionRecord | null, status: TaskStatus) => {
     if (!child) return { startedAt: null, finishedAt: null }
-    const startedAt = child.time?.created ? toIsoTimestamp(toSortTime(child.time.created)) : null
+    const startedAt = child.time?.created ? toIsoTimestamp(toHistorySortTime(child.time.created)) : null
     const isTerminal = status === 'complete' || status === 'error'
     const finishedAt = isTerminal && child.time?.updated
-      ? toIsoTimestamp(toSortTime(child.time.updated))
+      ? toIsoTimestamp(toHistorySortTime(child.time.updated))
       : null
     return { startedAt, finishedAt }
   }
@@ -243,12 +211,12 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     if (!msg) continue
     const info = msg.info
     const parts = msg.parts
-    const tsMs = toSortTime(info.time.created || msg.time.created || Date.now())
+    const tsMs = toHistorySortTime(info.time.created || msg.time.created || Date.now())
     const ts = toIsoTimestamp(tsMs)
     const msgId = info.id || msg.id || crypto.randomUUID()
     const role = info.role || msg.role || 'assistant'
-    const modelMeta = getModelMeta(msg)
-    const { textParts, fullText } = collectTextParts(parts)
+    const modelMeta = getHistoryModelMeta(msg)
+    const { textParts, fullText } = collectHistoryTextParts(parts)
 
     if (fullText && !isInternalCoworkMessage(fullText)) {
       textParts.forEach((part, index: number) => {
@@ -348,7 +316,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
           id: part.id || crypto.randomUUID(),
           timestamp: ts,
           sequence: nextOrder(),
-          cost: createCostPayload(part),
+          cost: createHistoryCostPayload(cachedModelId, part),
         }, tsMs)
       }
     }
@@ -372,7 +340,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     if (matchedChildIds.has(child.id)) continue
     const taskId = `child:${child.id}`
     const agent = extractAgentName(child.title)
-    const sortTime = toSortTime(child.time?.created || Date.now())
+    const sortTime = toHistorySortTime(child.time?.created || Date.now())
     const childStatus = getTaskStatus(child.id)
     const timing = timingFromChild(child, childStatus)
     addTaskRun({
@@ -399,11 +367,11 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       if (!msg) continue
       const info = msg.info
       const parts = msg.parts
-      const tsMs = toSortTime(info.time.created || msg.time.created || Date.now())
+      const tsMs = toHistorySortTime(info.time.created || msg.time.created || Date.now())
       const ts = toIsoTimestamp(tsMs)
       const role = info.role || msg.role || 'assistant'
-      const modelMeta = getModelMeta(msg)
-      const { textParts, fullText } = collectTextParts(parts)
+      const modelMeta = getHistoryModelMeta(msg)
+      const { textParts, fullText } = collectHistoryTextParts(parts)
 
       for (const part of parts) {
         if (part.type === 'agent' && taskRunItem?.taskRun) {
@@ -517,7 +485,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
             timestamp: ts,
             sequence: nextOrder(),
             taskRunId: taskId,
-            cost: createCostPayload(part),
+            cost: createHistoryCostPayload(cachedModelId, part),
           }, tsMs)
         }
       }
@@ -533,7 +501,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     }
 
     if (normalizedChildTodos.length > 0) {
-      const todoSortTime = toSortTime(child.time?.updated || child.time?.created || Date.now())
+      const todoSortTime = toHistorySortTime(child.time?.updated || child.time?.created || Date.now())
       pushItem({
         type: 'task_todos',
         id: `${taskId}:todos`,

--- a/tests/session-history-projection-utils.test.ts
+++ b/tests/session-history-projection-utils.test.ts
@@ -1,0 +1,110 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type {
+  NormalizedMessagePart,
+  NormalizedSessionMessage,
+} from '../apps/desktop/src/main/opencode-adapter.ts'
+import {
+  collectHistoryTextParts,
+  createHistoryCostPayload,
+  getHistoryModelMeta,
+  toHistorySortTime,
+} from '../apps/desktop/src/main/session-history-projection-utils.ts'
+
+const part = (overrides: Partial<NormalizedMessagePart>): NormalizedMessagePart => ({
+  type: 'text',
+  id: null,
+  text: null,
+  tool: null,
+  callId: null,
+  title: null,
+  name: null,
+  agent: null,
+  description: null,
+  prompt: null,
+  raw: null,
+  auto: false,
+  overflow: false,
+  reason: null,
+  metadata: {},
+  attachments: [],
+  state: {
+    input: {},
+    output: null,
+    error: null,
+    attachments: [],
+    metadata: {},
+    title: null,
+    raw: null,
+    status: null,
+  },
+  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  cost: null,
+  ...overrides,
+})
+
+test('toHistorySortTime normalizes seconds while preserving millisecond timestamps', () => {
+  assert.equal(toHistorySortTime(1_713_714_000), 1_713_714_000_000)
+  assert.equal(toHistorySortTime(1_713_714_000_123), 1_713_714_000_123)
+  assert.equal(toHistorySortTime(Number.NaN, 123), 123_000)
+})
+
+test('collectHistoryTextParts returns only non-empty text parts and concatenates replay text', () => {
+  const first = part({ id: 'one', text: 'Hello ' })
+  const second = part({ id: 'two', text: 'world' })
+  const empty = part({ id: 'empty', text: '' })
+  const tool = part({ type: 'tool', id: 'tool', text: 'ignored' })
+
+  const result = collectHistoryTextParts([first, empty, tool, second])
+
+  assert.deepEqual(result.textParts.map((item) => item.id), ['one', 'two'])
+  assert.equal(result.fullText, 'Hello world')
+})
+
+test('createHistoryCostPayload preserves reported cost and normalizes token counters', () => {
+  const result = createHistoryCostPayload('unknown-model', part({
+    cost: 1.23,
+    tokens: {
+      input: 10,
+      output: 5,
+      reasoning: 2,
+      cache: { read: 3, write: 4 },
+    },
+  }))
+
+  assert.equal(result.cost, 1.23)
+  assert.deepEqual(result.tokens, {
+    input: 10,
+    output: 5,
+    reasoning: 2,
+    cache: { read: 3, write: 4 },
+  })
+})
+
+test('getHistoryModelMeta extracts renderer-safe provider and model ids', () => {
+  const message: NormalizedSessionMessage = {
+    id: 'msg-1',
+    role: 'assistant',
+    time: {},
+    info: {
+      id: 'msg-1',
+      title: null,
+      role: 'assistant',
+      parentID: null,
+      sessionID: null,
+      time: {},
+      model: {
+        providerId: 'openrouter',
+        modelId: 'anthropic/claude-sonnet-4',
+      },
+      summary: null,
+      revertedMessageId: null,
+    },
+    parts: [],
+  }
+
+  assert.deepEqual(getHistoryModelMeta(message), {
+    providerId: 'openrouter',
+    modelId: 'anthropic/claude-sonnet-4',
+  })
+})


### PR DESCRIPTION
## Summary
- extract pure history projection helpers for timestamp, text part, cost, and model metadata formatting
- keep session-history-projector focused on replay orchestration
- add direct coverage for the extracted helpers while preserving existing projector behavior

## Validation
- pnpm test -- tests/session-history-projector.test.ts tests/session-history-projection-utils.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check