### PR TITLE
Split event task timing helpers

### DIFF
--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -8,6 +8,12 @@ import {
   findBestIndexedMatch,
   type BindingHints,
 } from './task-binding-score.ts'
+import {
+  applyTaskTimingTransition,
+  isTerminalTaskStatus,
+  normalizeTaskTiming,
+  nowIso,
+} from './event-task-timing.ts'
 
 export type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
 
@@ -190,40 +196,6 @@ function mapTaskRunsForParent(parentSessionId: string) {
   return pendingTaskRunsByParent.get(parentSessionId) || []
 }
 
-function nowIso() {
-  return new Date().toISOString()
-}
-
-function isTerminalStatus(status: TaskStatus) {
-  return status === 'complete' || status === 'error'
-}
-
-function normalizeTaskTiming(taskRun: TaskRunMeta): TaskRunMeta {
-  const startedAt = taskRun.startedAt ?? nowIso()
-  const finishedAt = taskRun.finishedAt ?? (isTerminalStatus(taskRun.status) ? nowIso() : null)
-  return { ...taskRun, startedAt, finishedAt }
-}
-
-function applyTaskTimingTransition(existing: TaskRunMeta, patch: Partial<TaskRunMeta>): TaskRunMeta {
-  const nextStatus = patch.status ?? existing.status
-  const timestamp = nowIso()
-  const startedAt = patch.startedAt
-    ?? existing.startedAt
-    ?? timestamp
-  const finishedAt = patch.finishedAt !== undefined
-    ? patch.finishedAt
-    : isTerminalStatus(nextStatus)
-      ? (existing.finishedAt ?? timestamp)
-      : null
-
-  return {
-    ...existing,
-    ...patch,
-    startedAt,
-    finishedAt,
-  }
-}
-
 export function resolveRootSession(sessionId?: string | null) {
   if (!sessionId) return undefined
 
@@ -269,7 +241,7 @@ export function bindTaskRunToChild(taskRunId: string, childSessionId: string) {
             ? 'running'
             : existingTaskRun.status
       const timestamp = nowIso()
-      const finishedAt = isTerminalStatus(mergedStatus)
+      const finishedAt = isTerminalTaskStatus(mergedStatus)
         ? (existingTaskRun.finishedAt || incomingTaskRun.finishedAt || timestamp)
         : null
       const mergedTaskRun: TaskRunMeta = {

--- a/apps/desktop/src/main/event-task-timing.ts
+++ b/apps/desktop/src/main/event-task-timing.ts
@@ -1,0 +1,43 @@
+import type {
+  TaskRunMeta,
+  TaskStatus,
+} from './event-task-state.ts'
+
+export const nowIso = () => new Date().toISOString()
+
+export const isTerminalTaskStatus = (status: TaskStatus) => {
+  return status === 'complete' || status === 'error'
+}
+
+export const normalizeTaskTiming = (
+  taskRun: TaskRunMeta,
+  getTimestamp: () => string = nowIso,
+): TaskRunMeta => {
+  const startedAt = taskRun.startedAt ?? getTimestamp()
+  const finishedAt = taskRun.finishedAt ?? (isTerminalTaskStatus(taskRun.status) ? getTimestamp() : null)
+  return { ...taskRun, startedAt, finishedAt }
+}
+
+export const applyTaskTimingTransition = (
+  existing: TaskRunMeta,
+  patch: Partial<TaskRunMeta>,
+  getTimestamp: () => string = nowIso,
+): TaskRunMeta => {
+  const nextStatus = patch.status ?? existing.status
+  const timestamp = getTimestamp()
+  const startedAt = patch.startedAt
+    ?? existing.startedAt
+    ?? timestamp
+  const finishedAt = patch.finishedAt !== undefined
+    ? patch.finishedAt
+    : isTerminalTaskStatus(nextStatus)
+      ? (existing.finishedAt ?? timestamp)
+      : null
+
+  return {
+    ...existing,
+    ...patch,
+    startedAt,
+    finishedAt,
+  }
+}

--- a/tests/event-task-timing.test.ts
+++ b/tests/event-task-timing.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type { TaskRunMeta } from '../apps/desktop/src/main/event-task-state.ts'
+import {
+  applyTaskTimingTransition,
+  isTerminalTaskStatus,
+  normalizeTaskTiming,
+} from '../apps/desktop/src/main/event-task-timing.ts'
+
+const taskRun = (overrides: Partial<TaskRunMeta> = {}): TaskRunMeta => ({
+  id: 'task-1',
+  rootSessionId: 'root-session',
+  parentSessionId: 'root-session',
+  title: 'Research',
+  agent: 'research',
+  childSessionId: null,
+  status: 'queued',
+  ...overrides,
+})
+
+test('isTerminalTaskStatus recognizes complete and error states only', () => {
+  assert.equal(isTerminalTaskStatus('queued'), false)
+  assert.equal(isTerminalTaskStatus('running'), false)
+  assert.equal(isTerminalTaskStatus('complete'), true)
+  assert.equal(isTerminalTaskStatus('error'), true)
+})
+
+test('normalizeTaskTiming anchors live tasks and only finishes terminal tasks', () => {
+  const running = normalizeTaskTiming(taskRun({ status: 'running' }), () => '2026-05-08T00:00:00.000Z')
+  assert.equal(running.startedAt, '2026-05-08T00:00:00.000Z')
+  assert.equal(running.finishedAt, null)
+
+  const terminalTimes = ['2026-05-08T00:00:01.000Z', '2026-05-08T00:00:02.000Z']
+  let index = 0
+  const complete = normalizeTaskTiming(taskRun({ status: 'complete' }), () => terminalTimes[index++] || 'fallback')
+  assert.equal(complete.startedAt, '2026-05-08T00:00:01.000Z')
+  assert.equal(complete.finishedAt, '2026-05-08T00:00:02.000Z')
+})
+
+test('normalizeTaskTiming preserves caller-supplied anchors', () => {
+  const normalized = normalizeTaskTiming(taskRun({
+    status: 'complete',
+    startedAt: '2026-05-08T00:00:00.000Z',
+    finishedAt: '2026-05-08T00:00:05.000Z',
+  }), () => 'unused')
+
+  assert.equal(normalized.startedAt, '2026-05-08T00:00:00.000Z')
+  assert.equal(normalized.finishedAt, '2026-05-08T00:00:05.000Z')
+})
+
+test('applyTaskTimingTransition preserves start time and clamps terminal finish time', () => {
+  const existing = taskRun({
+    status: 'running',
+    startedAt: '2026-05-08T00:00:00.000Z',
+    finishedAt: null,
+  })
+
+  const complete = applyTaskTimingTransition(
+    existing,
+    { status: 'complete' },
+    () => '2026-05-08T00:00:07.000Z',
+  )
+
+  assert.equal(complete.startedAt, '2026-05-08T00:00:00.000Z')
+  assert.equal(complete.finishedAt, '2026-05-08T00:00:07.000Z')
+})
+
+test('applyTaskTimingTransition clears stale finish time when a task returns to running', () => {
+  const existing = taskRun({
+    status: 'complete',
+    startedAt: '2026-05-08T00:00:00.000Z',
+    finishedAt: '2026-05-08T00:00:07.000Z',
+  })
+
+  const running = applyTaskTimingTransition(existing, { status: 'running' }, () => 'unused')
+
+  assert.equal(running.startedAt, '2026-05-08T00:00:00.000Z')
+  assert.equal(running.finishedAt, null)
+})


### PR DESCRIPTION
## Summary
- extract event task timestamp normalization and status transition helpers
- keep event-task-state focused on session/task binding state
- add direct tests for terminal status and timestamp transition behavior

## Validation
- pnpm test -- tests/event-task-state.test.ts tests/event-task-timing.test.ts tests/task-run-timing.test.ts tests/event-runtime-handlers.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check