### PR TITLE
Split queue map helpers

### DIFF
--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -14,6 +14,11 @@ import {
   normalizeTaskTiming,
   nowIso,
 } from './event-task-timing.ts'
+import {
+  pushUniqueQueueValue,
+  shiftQueueValue,
+  spliceQueueValue,
+} from './queue-map.ts'
 
 export type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
 
@@ -70,36 +75,6 @@ const {
   queuedChildSessionsByParent,
   pendingSubmittedPromptBySession,
 } = hierarchyStore
-
-function pushQueue(map: Map<string, string[]>, parentSessionId: string, value: string) {
-  const current = map.get(parentSessionId) || []
-  if (!current.includes(value)) {
-    current.push(value)
-    map.set(parentSessionId, current)
-  }
-}
-
-function shiftQueue(map: Map<string, string[]>, parentSessionId: string) {
-  const current = map.get(parentSessionId) || []
-  const value = current.shift()
-  if (current.length > 0) map.set(parentSessionId, current)
-  else map.delete(parentSessionId)
-  return value
-}
-
-function spliceQueueValue<T extends string | QueuedChildSessionMeta>(
-  map: Map<string, T[]>,
-  parentSessionId: string,
-  matcher: (value: T) => boolean,
-) {
-  const current = map.get(parentSessionId) || []
-  const index = current.findIndex(matcher)
-  if (index < 0) return null
-  const [value] = current.splice(index, 1)
-  if (current.length > 0) map.set(parentSessionId, current)
-  else map.delete(parentSessionId)
-  return value ?? null
-}
 
 function isKnownSession(sessionId: string) {
   return parentSessions.has(sessionId) || sessionLineage.has(sessionId)
@@ -162,7 +137,7 @@ function takePendingTaskRunId(parentSessionId: string, hints?: BindingHints | nu
   const current = mapTaskRunsForParent(parentSessionId)
   if (current.length === 0) return null
   if (current.length === 1) {
-    return shiftQueue(pendingTaskRunsByParent, parentSessionId) || null
+    return shiftQueueValue(pendingTaskRunsByParent, parentSessionId) || null
   }
   const matchIndex = findBestIndexedMatch(
     current
@@ -296,7 +271,7 @@ export function registerTaskRun(taskRun: TaskRunMeta) {
   }
 
   if (!normalizedTaskRun.childSessionId) {
-    pushQueue(pendingTaskRunsByParent, parentQueueKey, normalizedTaskRun.id)
+    pushUniqueQueueValue(pendingTaskRunsByParent, parentQueueKey, normalizedTaskRun.id)
   }
 
   return taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun

--- a/apps/desktop/src/main/queue-map.ts
+++ b/apps/desktop/src/main/queue-map.ts
@@ -1,0 +1,34 @@
+export const pushUniqueQueueValue = <T>(
+  map: Map<string, T[]>,
+  key: string,
+  value: T,
+  isEqual: (left: T, right: T) => boolean = Object.is,
+) => {
+  const current = map.get(key) || []
+  if (!current.some((entry) => isEqual(entry, value))) {
+    current.push(value)
+    map.set(key, current)
+  }
+}
+
+export const shiftQueueValue = <T>(map: Map<string, T[]>, key: string) => {
+  const current = map.get(key) || []
+  const value = current.shift()
+  if (current.length > 0) map.set(key, current)
+  else map.delete(key)
+  return value
+}
+
+export const spliceQueueValue = <T>(
+  map: Map<string, T[]>,
+  key: string,
+  matcher: (value: T) => boolean,
+) => {
+  const current = map.get(key) || []
+  const index = current.findIndex(matcher)
+  if (index < 0) return null
+  const [value] = current.splice(index, 1)
+  if (current.length > 0) map.set(key, current)
+  else map.delete(key)
+  return value ?? null
+}

--- a/tests/queue-map.test.ts
+++ b/tests/queue-map.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  pushUniqueQueueValue,
+  shiftQueueValue,
+  spliceQueueValue,
+} from '../apps/desktop/src/main/queue-map.ts'
+
+test('pushUniqueQueueValue appends only new values for a key', () => {
+  const map = new Map<string, string[]>()
+
+  pushUniqueQueueValue(map, 'root', 'task-a')
+  pushUniqueQueueValue(map, 'root', 'task-a')
+  pushUniqueQueueValue(map, 'root', 'task-b')
+
+  assert.deepEqual(map.get('root'), ['task-a', 'task-b'])
+})
+
+test('pushUniqueQueueValue accepts custom equality for object queues', () => {
+  const map = new Map<string, Array<{ id: string; title: string }>>()
+
+  pushUniqueQueueValue(map, 'root', { id: 'child-a', title: 'First' }, (left, right) => left.id === right.id)
+  pushUniqueQueueValue(map, 'root', { id: 'child-a', title: 'Duplicate' }, (left, right) => left.id === right.id)
+
+  assert.deepEqual(map.get('root'), [{ id: 'child-a', title: 'First' }])
+})
+
+test('shiftQueueValue returns the oldest value and deletes empty queues', () => {
+  const map = new Map<string, string[]>([['root', ['task-a', 'task-b']]])
+
+  assert.equal(shiftQueueValue(map, 'root'), 'task-a')
+  assert.deepEqual(map.get('root'), ['task-b'])
+  assert.equal(shiftQueueValue(map, 'root'), 'task-b')
+  assert.equal(map.has('root'), false)
+})
+
+test('spliceQueueValue removes the matched value and keeps queue order', () => {
+  const map = new Map<string, string[]>([['root', ['task-a', 'task-b', 'task-c']]])
+
+  assert.equal(spliceQueueValue(map, 'root', (value) => value === 'task-b'), 'task-b')
+  assert.deepEqual(map.get('root'), ['task-a', 'task-c'])
+  assert.equal(spliceQueueValue(map, 'root', (value) => value === 'task-missing'), null)
+  assert.deepEqual(map.get('root'), ['task-a', 'task-c'])
+})


### PR DESCRIPTION
## Summary
- extract generic queue-map helpers from event-task-state
- keep event-task-state focused on session lineage and task binding policy
- add direct tests for queue insertion, shifting, matching, and custom equality

## Validation
- pnpm test -- tests/event-task-state.test.ts tests/queue-map.test.ts tests/event-runtime-handlers.test.ts tests/task-run-timing.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check