### PR TITLE
Split automation scheduler orchestration

### DIFF
--- a/apps/desktop/src/main/automation-scheduler.ts
+++ b/apps/desktop/src/main/automation-scheduler.ts
@@ -1,0 +1,76 @@
+import {
+  clearPendingRetriesForChain,
+  getActiveRunForAutomation,
+  getAutomationDetail,
+  getNextRetryAttemptForChain,
+  getRun,
+  listDueAutomations,
+  listDueRetryRuns,
+} from './automation-store.ts'
+import { startAutomationRun } from './automation-run-starter.ts'
+import { AutomationRunConflictError, AutomationRunStartError } from './automation-service-errors.ts'
+import {
+  getRetryRootRunId,
+  hasRemainingWorkRunBudget,
+  maybeReportFailedRun,
+} from './automation-service-reporting.ts'
+import { log } from './logger.ts'
+
+export type AutomationUpdatePublisher = () => void
+
+async function maybeRunDueRetries(now: Date, publishAutomationUpdated: AutomationUpdatePublisher) {
+  const dueRetries = listDueRetryRuns(now)
+  const processedRoots = new Set<string>()
+  for (const run of dueRetries) {
+    const retryRootRunId = getRetryRootRunId(run)
+    if (processedRoots.has(retryRootRunId)) continue
+    processedRoots.add(retryRootRunId)
+    const detail = getAutomationDetail(run.automationId)
+    if (!detail || detail.status === 'paused' || detail.status === 'archived') continue
+    if (getActiveRunForAutomation(run.automationId)) continue
+    if (!hasRemainingWorkRunBudget(detail, now)) continue
+    clearPendingRetriesForChain(retryRootRunId)
+    const nextAttempt = getNextRetryAttemptForChain(retryRootRunId)
+    try {
+      await startAutomationRun(run.automationId, run.kind, publishAutomationUpdated, {
+        attempt: nextAttempt,
+        retryOfRunId: retryRootRunId,
+        title: `${run.title} (retry ${nextAttempt})`,
+      })
+    } catch (error) {
+      if (error instanceof AutomationRunConflictError) continue
+      const message = error instanceof Error ? error.message : String(error)
+      log('error', `Failed to start retry for automation ${run.automationId}: ${message}`)
+      if (error instanceof AutomationRunStartError && error.retryScheduled) continue
+      const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
+      maybeReportFailedRun(run.automationId, failedRun, 'Automation retry failed to start', message)
+    }
+  }
+}
+
+async function maybeRunDueAutomations(now: Date, publishAutomationUpdated: AutomationUpdatePublisher) {
+  const due = listDueAutomations(now)
+  for (const automation of due) {
+    if (automation.status === 'paused' || automation.status === 'archived' || automation.status === 'needs_user' || automation.status === 'running') continue
+    const detail = getAutomationDetail(automation.id)
+    if (!detail) continue
+    if (!hasRemainingWorkRunBudget(detail, now)) continue
+    if (getActiveRunForAutomation(automation.id)) continue
+    const shouldEnrich = !detail.brief || !detail.brief.approvedAt || detail.status === 'draft'
+    try {
+      await startAutomationRun(automation.id, shouldEnrich ? 'enrichment' : 'execution', publishAutomationUpdated)
+    } catch (error) {
+      if (error instanceof AutomationRunConflictError) continue
+      const message = error instanceof Error ? error.message : String(error)
+      log('error', `Failed to start automation ${automation.id}: ${message}`)
+      if (error instanceof AutomationRunStartError && error.retryScheduled) continue
+      const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
+      maybeReportFailedRun(automation.id, failedRun, 'Automation could not start', message)
+    }
+  }
+}
+
+export async function runAutomationScheduler(now: Date, publishAutomationUpdated: AutomationUpdatePublisher) {
+  await maybeRunDueRetries(now, publishAutomationUpdated)
+  await maybeRunDueAutomations(now, publishAutomationUpdated)
+}

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -17,9 +17,7 @@ import {
   getRun,
   listActiveAutomationRuns,
   listAutomationState,
-  listDueAutomations,
   listDueHeartbeats,
-  listDueRetryRuns,
   listOpenInboxForAutomation,
   markHeartbeatCompleted,
   markRunCancelled,
@@ -41,11 +39,11 @@ import { buildAutomationApprovalBody, requiresManualApproval } from './automatio
 import {
   buildRetryScheduledBody,
   getRetryRootRunId,
-  hasRemainingWorkRunBudget,
   maybeOpenFailureCircuit,
   maybeReportFailedRun,
   processAutomationRunFailure,
 } from './automation-service-reporting.ts'
+import { runAutomationScheduler } from './automation-scheduler.ts'
 import { maybeResumeRunAfterInboxResolution } from './automation-inbox-resolution.ts'
 import {
   extractExecutionBriefFromMessages,
@@ -76,63 +74,10 @@ function publishAutomationUpdated() {
   if (win && !win.isDestroyed()) win.webContents.send('automation:updated')
 }
 
-async function maybeRunDueRetries(now = new Date()) {
-  const dueRetries = listDueRetryRuns(now)
-  const processedRoots = new Set<string>()
-  for (const run of dueRetries) {
-    const retryRootRunId = getRetryRootRunId(run)
-    if (processedRoots.has(retryRootRunId)) continue
-    processedRoots.add(retryRootRunId)
-    const detail = getAutomationDetail(run.automationId)
-    if (!detail || detail.status === 'paused' || detail.status === 'archived') continue
-    if (getActiveRunForAutomation(run.automationId)) continue
-    if (!hasRemainingWorkRunBudget(detail, now)) continue
-    clearPendingRetriesForChain(retryRootRunId)
-    const nextAttempt = getNextRetryAttemptForChain(retryRootRunId)
-    try {
-      await startAutomationRun(run.automationId, run.kind, publishAutomationUpdated, {
-        attempt: nextAttempt,
-        retryOfRunId: retryRootRunId,
-        title: `${run.title} (retry ${nextAttempt})`,
-      })
-    } catch (error) {
-      if (error instanceof AutomationRunConflictError) continue
-      const message = error instanceof Error ? error.message : String(error)
-      log('error', `Failed to start retry for automation ${run.automationId}: ${message}`)
-      if (error instanceof AutomationRunStartError && error.retryScheduled) continue
-      const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
-      maybeReportFailedRun(run.automationId, failedRun, 'Automation retry failed to start', message)
-    }
-  }
-}
-
-async function maybeRunDueAutomations(now = new Date()) {
-  const due = listDueAutomations(now)
-  for (const automation of due) {
-    if (automation.status === 'paused' || automation.status === 'archived' || automation.status === 'needs_user' || automation.status === 'running') continue
-    const detail = getAutomationDetail(automation.id)
-    if (!detail) continue
-    if (!hasRemainingWorkRunBudget(detail, now)) continue
-    if (getActiveRunForAutomation(automation.id)) continue
-    const shouldEnrich = !detail.brief || !detail.brief.approvedAt || detail.status === 'draft'
-    try {
-      await startAutomationRun(automation.id, shouldEnrich ? 'enrichment' : 'execution', publishAutomationUpdated)
-    } catch (error) {
-      if (error instanceof AutomationRunConflictError) continue
-      const message = error instanceof Error ? error.message : String(error)
-      log('error', `Failed to start automation ${automation.id}: ${message}`)
-      if (error instanceof AutomationRunStartError && error.retryScheduled) continue
-      const failedRun = error instanceof AutomationRunStartError && error.runId ? getRun(error.runId) : null
-      maybeReportFailedRun(automation.id, failedRun, 'Automation could not start', message)
-    }
-  }
-}
-
 async function maybeRunAutomationScheduler(now = new Date()) {
   await runSchedulerTick.run(async () => {
     try {
-      await maybeRunDueRetries(now)
-      await maybeRunDueAutomations(now)
+      await runAutomationScheduler(now, publishAutomationUpdated)
     } finally {
       publishAutomationUpdated()
     }


### PR DESCRIPTION
## Summary
- move due automation and retry startup orchestration into a dedicated automation scheduler module
- keep service-level control-plane coalescing and update publishing in automation-service
- reduce automation-service surface without changing scheduler behavior

## Validation
- pnpm test -- tests/automation-service.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check