### PR TITLE
Split session engine helpers

### DIFF
--- a/apps/desktop/src/main/session-engine-helpers.ts
+++ b/apps/desktop/src/main/session-engine-helpers.ts
@@ -1,0 +1,30 @@
+import type { ToolCall } from '@open-cowork/shared'
+import {
+  nextSeq,
+  type HistoryItem,
+} from '../lib/session-view-model.ts'
+
+export function getLatestHistoryEventAt(items: HistoryItem[]) {
+  let latest = 0
+  for (const item of items) {
+    const timestamp = Date.parse(item.timestamp)
+    if (Number.isFinite(timestamp) && timestamp > latest) {
+      latest = timestamp
+    }
+  }
+  return latest
+}
+
+export function createRootToolCall(id: string, update: Partial<ToolCall>): ToolCall {
+  return {
+    id,
+    name: (update.name as string) || 'tool',
+    input: (update.input as Record<string, unknown>) || {},
+    status: (update.status as ToolCall['status']) || 'running',
+    output: update.output,
+    attachments: update.attachments,
+    agent: update.agent || null,
+    sourceSessionId: update.sourceSessionId || null,
+    order: nextSeq(),
+  }
+}

--- a/apps/desktop/src/main/session-engine.ts
+++ b/apps/desktop/src/main/session-engine.ts
@@ -4,7 +4,6 @@ import type {
   SessionError,
   SessionView,
   TodoItem,
-  ToolCall,
 } from '@open-cowork/shared'
 import {
   MAX_WARM_SESSION_DETAILS,
@@ -28,6 +27,7 @@ import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
 import type { SessionUsageSummary } from '@open-cowork/shared'
 import { buildSessionUsageSummary } from './session-usage-summary.ts'
 import { SessionCostEventTracker } from './session-cost-event-tracker.ts'
+import { createRootToolCall, getLatestHistoryEventAt } from './session-engine-helpers.ts'
 
 export { MAX_SEEN_COST_EVENT_IDS_PER_SESSION } from './session-cost-event-tracker.ts'
 
@@ -37,31 +37,6 @@ type CachedSessionView = {
   busy: boolean
   awaitingPermission: boolean
   view: SessionView
-}
-
-function getLatestHistoryEventAt(items: HistoryItem[]) {
-  let latest = 0
-  for (const item of items) {
-    const timestamp = Date.parse(item.timestamp)
-    if (Number.isFinite(timestamp) && timestamp > latest) {
-      latest = timestamp
-    }
-  }
-  return latest
-}
-
-function createRootToolCall(id: string, update: Partial<ToolCall>): ToolCall {
-  return {
-    id,
-    name: (update.name as string) || 'tool',
-    input: (update.input as Record<string, unknown>) || {},
-    status: (update.status as ToolCall['status']) || 'running',
-    output: update.output,
-    attachments: update.attachments,
-    agent: update.agent || null,
-    sourceSessionId: update.sourceSessionId || null,
-    order: nextSeq(),
-  }
 }
 
 export class SessionEngine {

--- a/tests/session-engine-helpers.test.ts
+++ b/tests/session-engine-helpers.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createRootToolCall, getLatestHistoryEventAt } from '../apps/desktop/src/main/session-engine-helpers.ts'
+
+test('getLatestHistoryEventAt returns the newest finite history timestamp', () => {
+  const latest = getLatestHistoryEventAt([
+    { id: 'a', role: 'assistant', text: 'older', timestamp: '2026-01-01T10:00:00.000Z' },
+    { id: 'b', role: 'assistant', text: 'invalid', timestamp: 'not-a-date' },
+    { id: 'c', role: 'user', text: 'newer', timestamp: '2026-01-01T10:05:00.000Z' },
+  ])
+
+  assert.equal(latest, Date.parse('2026-01-01T10:05:00.000Z'))
+})
+
+test('createRootToolCall fills safe defaults and preserves supplied metadata', () => {
+  const tool = createRootToolCall('tool-1', {
+    name: 'write',
+    input: { file: 'README.md' },
+    status: 'complete',
+    output: 'done',
+    agent: 'build',
+    sourceSessionId: 'child-1',
+  })
+
+  assert.equal(tool.id, 'tool-1')
+  assert.equal(tool.name, 'write')
+  assert.deepEqual(tool.input, { file: 'README.md' })
+  assert.equal(tool.status, 'complete')
+  assert.equal(tool.output, 'done')
+  assert.equal(tool.agent, 'build')
+  assert.equal(tool.sourceSessionId, 'child-1')
+  assert.ok(Number.isFinite(tool.order))
+})
+
+test('createRootToolCall falls back to a running generic tool shape', () => {
+  const tool = createRootToolCall('tool-2', {})
+
+  assert.equal(tool.name, 'tool')
+  assert.deepEqual(tool.input, {})
+  assert.equal(tool.status, 'running')
+  assert.equal(tool.agent, null)
+  assert.equal(tool.sourceSessionId, null)
+})


### PR DESCRIPTION
## Summary
- move session-engine history timestamp and root tool-call helpers into a dedicated module
- add direct helper coverage for timestamp filtering and tool-call defaults
- reduce session-engine without changing event projection behavior

## Validation
- pnpm test -- tests/session-engine-helpers.test.ts tests/session-engine.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check