### PR TITLE
Split session history task binding helpers

### DIFF
--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -13,18 +13,20 @@ import {
   normalizeAgentName,
   toIsoTimestamp,
 } from './task-run-utils.ts'
-import {
-  findBestIndexedMatch,
-  type BindingHints,
-} from './task-binding-score.ts'
+import { findBestIndexedMatch } from './task-binding-score.ts'
 import {
   collectHistoryTextParts,
   createHistoryCostPayload,
   getHistoryModelMeta,
   toHistorySortTime,
 } from './session-history-projection-utils.ts'
-
-type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
+import {
+  bindingHintsForSubtask,
+  childBindingCandidates,
+  timingFromChild,
+  type ChildSessionRecord,
+  type TaskStatus,
+} from './session-history-task-binding.ts'
 
 type TaskRunSnapshot = {
   title: string
@@ -79,16 +81,6 @@ export type ProjectedHistoryItem = {
     overflow: boolean
     sourceSessionId?: string | null
   }
-}
-
-type ChildSessionRecord = {
-  id: string
-  title?: string
-  time?: {
-    created?: number
-    updated?: number
-  }
-  parentSessionId?: string | null
 }
 
 type ProjectSessionHistoryInput = {
@@ -160,39 +152,6 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     out.push(item)
     taskRunItems.set(taskRun.id, item)
     return item
-  }
-
-  const timingFromChild = (child: ChildSessionRecord | null, status: TaskStatus) => {
-    if (!child) return { startedAt: null, finishedAt: null }
-    const startedAt = child.time?.created ? toIsoTimestamp(toHistorySortTime(child.time.created)) : null
-    const isTerminal = status === 'complete' || status === 'error'
-    const finishedAt = isTerminal && child.time?.updated
-      ? toIsoTimestamp(toHistorySortTime(child.time.updated))
-      : null
-    return { startedAt, finishedAt }
-  }
-
-  const bindingHintsForSubtask = (part: NormalizedMessagePart): BindingHints => {
-    const agent = normalizeAgentName(part.agent)
-      || extractAgentName(part.description, part.title, part.prompt, part.raw)
-      || null
-    return {
-      agent,
-      title: chooseTaskTitle(
-        agent,
-        part.description,
-        part.title,
-        part.prompt,
-        part.raw,
-      ),
-    }
-  }
-
-  const childBindingCandidates = (candidateChildren: ChildSessionRecord[]) => {
-    return candidateChildren.map((child) => ({
-      title: child.title,
-      agent: extractAgentName(child.title),
-    }))
   }
 
   const takeDirectChildForSubtask = (part: NormalizedMessagePart) => {

--- a/apps/desktop/src/main/session-history-task-binding.ts
+++ b/apps/desktop/src/main/session-history-task-binding.ts
@@ -1,0 +1,54 @@
+import type { NormalizedMessagePart } from './opencode-adapter.ts'
+import type { BindingHints } from './task-binding-score.ts'
+import {
+  chooseTaskTitle,
+  extractAgentName,
+  normalizeAgentName,
+  toIsoTimestamp,
+} from './task-run-utils.ts'
+import { toHistorySortTime } from './session-history-projection-utils.ts'
+
+export type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
+
+export type ChildSessionRecord = {
+  id: string
+  title?: string
+  time?: {
+    created?: number
+    updated?: number
+  }
+  parentSessionId?: string | null
+}
+
+export function timingFromChild(child: ChildSessionRecord | null, status: TaskStatus) {
+  if (!child) return { startedAt: null, finishedAt: null }
+  const startedAt = child.time?.created ? toIsoTimestamp(toHistorySortTime(child.time.created)) : null
+  const isTerminal = status === 'complete' || status === 'error'
+  const finishedAt = isTerminal && child.time?.updated
+    ? toIsoTimestamp(toHistorySortTime(child.time.updated))
+    : null
+  return { startedAt, finishedAt }
+}
+
+export function bindingHintsForSubtask(part: NormalizedMessagePart): BindingHints {
+  const agent = normalizeAgentName(part.agent)
+    || extractAgentName(part.description, part.title, part.prompt, part.raw)
+    || null
+  return {
+    agent,
+    title: chooseTaskTitle(
+      agent,
+      part.description,
+      part.title,
+      part.prompt,
+      part.raw,
+    ),
+  }
+}
+
+export function childBindingCandidates(candidateChildren: ChildSessionRecord[]) {
+  return candidateChildren.map((child) => ({
+    title: child.title,
+    agent: extractAgentName(child.title),
+  }))
+}

--- a/tests/session-history-task-binding.test.ts
+++ b/tests/session-history-task-binding.test.ts
@@ -1,0 +1,89 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import type { NormalizedMessagePart } from '../apps/desktop/src/main/opencode-adapter.ts'
+import {
+  bindingHintsForSubtask,
+  childBindingCandidates,
+  timingFromChild,
+} from '../apps/desktop/src/main/session-history-task-binding.ts'
+
+function subtaskPart(fields: Partial<NormalizedMessagePart>): NormalizedMessagePart {
+  return {
+    type: 'subtask',
+    id: 'part-1',
+    text: null,
+    tool: null,
+    callId: null,
+    title: null,
+    name: null,
+    agent: null,
+    description: null,
+    prompt: null,
+    raw: null,
+    auto: false,
+    overflow: false,
+    reason: null,
+    metadata: {},
+    attachments: [],
+    state: {
+      input: {},
+      output: null,
+      error: null,
+      title: null,
+      raw: null,
+      metadata: {},
+      attachments: [],
+    },
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    cost: null,
+    ...fields,
+  }
+}
+
+test('timingFromChild carries start time and only closes terminal task runs', () => {
+  const child = {
+    id: 'child-1',
+    time: {
+      created: Date.parse('2026-01-01T10:00:00.000Z'),
+      updated: Date.parse('2026-01-01T10:05:00.000Z'),
+    },
+  }
+
+  assert.deepEqual(timingFromChild(child, 'running'), {
+    startedAt: '2026-01-01T10:00:00.000Z',
+    finishedAt: null,
+  })
+  assert.deepEqual(timingFromChild(child, 'complete'), {
+    startedAt: '2026-01-01T10:00:00.000Z',
+    finishedAt: '2026-01-01T10:05:00.000Z',
+  })
+})
+
+test('bindingHintsForSubtask normalizes explicit agent and title metadata', () => {
+  const hints = bindingHintsForSubtask(subtaskPart({
+    agent: '@Build-Agent',
+    description: '@Build-Agent: Fix the flaky smoke test',
+    title: 'Sub-agent task',
+  }))
+
+  assert.deepEqual(hints, {
+    agent: 'build-agent',
+    title: 'Fix the flaky smoke test',
+  })
+})
+
+test('childBindingCandidates exposes titles and normalized agent hints', () => {
+  assert.deepEqual(childBindingCandidates([
+    { id: 'child-1', title: '@explore: Inspect runtime startup' },
+    { id: 'child-2', title: 'General follow-up' },
+  ]), [
+    { title: '@explore: Inspect runtime startup', agent: 'explore' },
+    { title: 'General follow-up', agent: null },
+  ])
+})


### PR DESCRIPTION
## Summary
- move child-session timing and subtask binding helpers out of session-history-projector
- keep projector replay flow unchanged while reducing nested helper state
- add direct tests for timing and binding helper behavior

## Validation
- pnpm test -- tests/session-history-task-binding.test.ts tests/session-history-projector.test.ts tests/task-binding-score.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check