### PR TITLE
Split managed runtime environment helpers

### DIFF
--- a/apps/desktop/src/main/runtime-environment.ts
+++ b/apps/desktop/src/main/runtime-environment.ts
@@ -1,0 +1,88 @@
+import { win32 } from 'path'
+
+import type { getRuntimeEnvPaths } from './runtime-paths.ts'
+import {
+  OPEN_COWORK_MANAGED_RUNTIME_ENV,
+  OPEN_COWORK_MANAGED_RUNTIME_VALUE,
+} from './runtime-process-cleanup.ts'
+
+type RuntimeEnvPaths = ReturnType<typeof getRuntimeEnvPaths>
+
+const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
+  'APPDATA',
+  'ALL_PROXY',
+  'COMSPEC',
+  'ComSpec',
+  'CURL_CA_BUNDLE',
+  'GIT_SSL_CAINFO',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'LANG',
+  'LOCALAPPDATA',
+  'LOGNAME',
+  'NODE_EXTRA_CA_CERTS',
+  'NO_PROXY',
+  'PATH',
+  'PATHEXT',
+  'REQUESTS_CA_BUNDLE',
+  'SHELL',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
+  'SystemRoot',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'TZ',
+  'USER',
+  'USERNAME',
+  'WINDIR',
+  'all_proxy',
+  'https_proxy',
+  'http_proxy',
+  'no_proxy',
+])
+
+function shouldPassRuntimeEnvKey(key: string) {
+  return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.toLowerCase() === 'path' || key.toLowerCase() === 'comspec' || key.startsWith('LC_')
+}
+
+function applyManagedHomeEnvironment(env: NodeJS.ProcessEnv, runtimePaths: RuntimeEnvPaths) {
+  env.HOME = runtimePaths.home
+  env.XDG_CONFIG_HOME = runtimePaths.configHome
+  env.XDG_DATA_HOME = runtimePaths.dataHome
+  env.XDG_CACHE_HOME = runtimePaths.cacheHome
+  env.XDG_STATE_HOME = runtimePaths.stateHome
+  env.USERPROFILE = runtimePaths.home
+  env.APPDATA = runtimePaths.configHome
+  env.LOCALAPPDATA = runtimePaths.dataHome
+
+  const parsed = win32.parse(runtimePaths.home)
+  if (/^[a-zA-Z]:\\$/.test(parsed.root)) {
+    env.HOMEDRIVE = parsed.root.slice(0, 2)
+    env.HOMEPATH = runtimePaths.home.slice(2) || '\\'
+  } else {
+    delete env.HOMEDRIVE
+    delete env.HOMEPATH
+  }
+}
+
+export function buildManagedRuntimeEnvironment(input: {
+  currentEnv: NodeJS.ProcessEnv
+  runtimePaths: RuntimeEnvPaths
+  adcPath?: string | null
+  enableNativeWebSearch?: boolean
+}) {
+  const env: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(input.currentEnv)) {
+    if (value !== undefined && shouldPassRuntimeEnvKey(key)) env[key] = value
+  }
+
+  applyManagedHomeEnvironment(env, input.runtimePaths)
+  env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = '1'
+  env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS = '1'
+  env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE
+  if (input.enableNativeWebSearch) env.OPENCODE_ENABLE_EXA = '1'
+  if (input.adcPath) env.GOOGLE_APPLICATION_CREDENTIALS = input.adcPath
+  return env
+}

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -7,7 +7,7 @@ import type { ServerOptions as OpencodeServerOptions } from '@opencode-ai/sdk/v2
 import type { ModelInfoSnapshot } from '@open-cowork/shared'
 import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from 'fs'
 import { homedir } from 'os'
-import { dirname, join, resolve, win32 } from 'path'
+import { dirname, join, resolve } from 'path'
 import {
   getAppConfig,
   getAppDataDir,
@@ -28,16 +28,16 @@ import { getOrCreateDirectoryClient } from './runtime-client-cache.ts'
 import { syncRuntimeHomeToolingBridge } from './runtime-home-bridge.ts'
 import { verifyRuntimeSkillCatalog } from './runtime-skill-verifier.ts'
 import { createManagedOpencodeServer } from './runtime-managed-server.ts'
+import { buildManagedRuntimeEnvironment } from './runtime-environment.ts'
 import {
   cleanupOrphanedManagedOpencodeProcesses,
-  OPEN_COWORK_MANAGED_RUNTIME_ENV,
-  OPEN_COWORK_MANAGED_RUNTIME_VALUE,
   registerTrackedManagedRuntimePid,
   resolveListeningPid,
   terminateManagedRuntimePid,
 } from './runtime-process-cleanup.ts'
 
 export { getRuntimeHomeDir } from './runtime-paths.ts'
+export { buildManagedRuntimeEnvironment } from './runtime-environment.ts'
 export {
   buildManagedOpencodeServerEnvironment,
   createManagedOpencodeServer,
@@ -241,85 +241,6 @@ async function syncNativeProviderApiAuth(c: V2OpencodeClient) {
 // small spawn adapter so the child receives an explicit curated env. This
 // avoids both broad secret forwarding and any temporary mutation of the
 // Electron main process environment.
-const RUNTIME_ENV_PASSTHROUGH_KEYS = new Set([
-  'APPDATA',
-  'ALL_PROXY',
-  'COMSPEC',
-  'ComSpec',
-  'CURL_CA_BUNDLE',
-  'GIT_SSL_CAINFO',
-  'HTTPS_PROXY',
-  'HTTP_PROXY',
-  'LANG',
-  'LOCALAPPDATA',
-  'LOGNAME',
-  'NODE_EXTRA_CA_CERTS',
-  'NO_PROXY',
-  'PATH',
-  'PATHEXT',
-  'REQUESTS_CA_BUNDLE',
-  'SHELL',
-  'SSL_CERT_DIR',
-  'SSL_CERT_FILE',
-  'SystemRoot',
-  'TEMP',
-  'TERM',
-  'TMP',
-  'TMPDIR',
-  'TZ',
-  'USER',
-  'USERNAME',
-  'WINDIR',
-  'all_proxy',
-  'https_proxy',
-  'http_proxy',
-  'no_proxy',
-])
-
-function shouldPassRuntimeEnvKey(key: string) {
-  return RUNTIME_ENV_PASSTHROUGH_KEYS.has(key) || key.toLowerCase() === 'path' || key.toLowerCase() === 'comspec' || key.startsWith('LC_')
-}
-
-function applyManagedHomeEnvironment(env: NodeJS.ProcessEnv, runtimePaths: ReturnType<typeof getRuntimeEnvPaths>) {
-  env.HOME = runtimePaths.home
-  env.XDG_CONFIG_HOME = runtimePaths.configHome
-  env.XDG_DATA_HOME = runtimePaths.dataHome
-  env.XDG_CACHE_HOME = runtimePaths.cacheHome
-  env.XDG_STATE_HOME = runtimePaths.stateHome
-  env.USERPROFILE = runtimePaths.home
-  env.APPDATA = runtimePaths.configHome
-  env.LOCALAPPDATA = runtimePaths.dataHome
-
-  const parsed = win32.parse(runtimePaths.home)
-  if (/^[a-zA-Z]:\\$/.test(parsed.root)) {
-    env.HOMEDRIVE = parsed.root.slice(0, 2)
-    env.HOMEPATH = runtimePaths.home.slice(2) || '\\'
-  } else {
-    delete env.HOMEDRIVE
-    delete env.HOMEPATH
-  }
-}
-
-export function buildManagedRuntimeEnvironment(input: {
-  currentEnv: NodeJS.ProcessEnv
-  runtimePaths: ReturnType<typeof getRuntimeEnvPaths>
-  adcPath?: string | null
-  enableNativeWebSearch?: boolean
-}) {
-  const env: NodeJS.ProcessEnv = {}
-  for (const [key, value] of Object.entries(input.currentEnv)) {
-    if (value !== undefined && shouldPassRuntimeEnvKey(key)) env[key] = value
-  }
-
-  applyManagedHomeEnvironment(env, input.runtimePaths)
-  env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = '1'
-  env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS = '1'
-  env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE
-  if (input.enableNativeWebSearch) env.OPENCODE_ENABLE_EXA = '1'
-  if (input.adcPath) env.GOOGLE_APPLICATION_CREDENTIALS = input.adcPath
-  return env
-}
-
 async function createManagedOpencode(options: OpencodeServerOptions, opencodeBinPath?: string | null) {
   const runtimePaths = getRuntimeEnvPaths()
   // Forward the app-level Google OAuth session as ADC to the OpenCode

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { PassThrough } from 'node:stream'
-import { buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime.ts'
+import { buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime-environment.ts'
 import {
   buildManagedOpencodeServerEnvironment,
   drainManagedOpencodeProcessOutput,


### PR DESCRIPTION
## Summary
- move the managed OpenCode child-process environment builder into runtime-environment.ts
- keep runtime.ts exporting the helper for compatibility while reducing runtime lifecycle module size
- point environment tests at the pure helper module directly

## Validation
- pnpm test -- tests/runtime-environment.test.ts tests/runtime-managed-server.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check