### PR TITLE
Split session engine cost handling

### DIFF
--- a/apps/desktop/src/main/session-engine-costs.ts
+++ b/apps/desktop/src/main/session-engine-costs.ts
@@ -1,0 +1,57 @@
+import type { SessionTokens } from '@open-cowork/shared'
+
+import {
+  withTaskRun,
+  type SessionViewState,
+} from '../lib/session-view-model.ts'
+import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
+
+type RuntimeCostEventData = NonNullable<RuntimeSessionEvent['data']>
+
+function normalizeCostTokens(tokens: RuntimeCostEventData['tokens']): SessionTokens {
+  return {
+    input: typeof tokens?.input === 'number' ? tokens.input : 0,
+    output: typeof tokens?.output === 'number' ? tokens.output : 0,
+    reasoning: typeof tokens?.reasoning === 'number' ? tokens.reasoning : 0,
+    cacheRead: typeof tokens?.cache?.read === 'number' ? tokens.cache.read : 0,
+    cacheWrite: typeof tokens?.cache?.write === 'number' ? tokens.cache.write : 0,
+  }
+}
+
+function addCostTokens(current: SessionTokens, delta: SessionTokens): SessionTokens {
+  return {
+    input: current.input + delta.input,
+    output: current.output + delta.output,
+    reasoning: current.reasoning + delta.reasoning,
+    cacheRead: current.cacheRead + delta.cacheRead,
+    cacheWrite: current.cacheWrite + delta.cacheWrite,
+  }
+}
+
+export function applyCostEventToSessionState(
+  current: SessionViewState,
+  data: RuntimeCostEventData,
+): SessionViewState {
+  const tokenDelta = normalizeCostTokens(data.tokens)
+  const sessionTokens = addCostTokens(current.sessionTokens, tokenDelta)
+  const cost = data.cost || 0
+  if (data.taskRunId) {
+    return {
+      ...current,
+      sessionCost: current.sessionCost + cost,
+      sessionTokens,
+      taskRuns: withTaskRun(current.taskRuns, data.taskRunId, (taskRun) => ({
+        ...taskRun,
+        sessionCost: taskRun.sessionCost + cost,
+        sessionTokens: addCostTokens(taskRun.sessionTokens, tokenDelta),
+      })),
+    }
+  }
+  return {
+    ...current,
+    sessionCost: current.sessionCost + cost,
+    lastInputTokens: tokenDelta.input > 0 ? tokenDelta.input : current.lastInputTokens,
+    contextState: tokenDelta.input > 0 ? 'measured' : current.contextState,
+    sessionTokens,
+  }
+}

--- a/apps/desktop/src/main/session-engine.ts
+++ b/apps/desktop/src/main/session-engine.ts
@@ -28,6 +28,7 @@ import type { SessionUsageSummary } from '@open-cowork/shared'
 import { buildSessionUsageSummary } from './session-usage-summary.ts'
 import { SessionCostEventTracker } from './session-cost-event-tracker.ts'
 import { createRootToolCall, getLatestHistoryEventAt } from './session-engine-helpers.ts'
+import { applyCostEventToSessionState } from './session-engine-costs.ts'
 
 export { MAX_SEEN_COST_EVENT_IDS_PER_SESSION } from './session-cost-event-tracker.ts'
 
@@ -320,46 +321,7 @@ export class SessionEngine {
         if (!this.costEventTracker.mark(sessionId, typeof data.id === 'string' ? data.id : null)) {
           break
         }
-        this.updateSessionState(sessionId, (current) => {
-          const tokens = data.tokens || { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
-          const inputTokens = typeof tokens.input === 'number' ? tokens.input : 0
-          const outputTokens = typeof tokens.output === 'number' ? tokens.output : 0
-          const reasoningTokens = typeof tokens.reasoning === 'number' ? tokens.reasoning : 0
-          const cacheReadTokens = typeof tokens.cache?.read === 'number' ? tokens.cache.read : 0
-          const cacheWriteTokens = typeof tokens.cache?.write === 'number' ? tokens.cache.write : 0
-          const sessionTokens = {
-            input: current.sessionTokens.input + inputTokens,
-            output: current.sessionTokens.output + outputTokens,
-            reasoning: current.sessionTokens.reasoning + reasoningTokens,
-            cacheRead: current.sessionTokens.cacheRead + cacheReadTokens,
-            cacheWrite: current.sessionTokens.cacheWrite + cacheWriteTokens,
-          }
-          if (data.taskRunId) {
-            return {
-              ...current,
-              sessionCost: current.sessionCost + (data.cost || 0),
-              sessionTokens,
-              taskRuns: withTaskRun(current.taskRuns, data.taskRunId, (taskRun) => ({
-                ...taskRun,
-                sessionCost: taskRun.sessionCost + (data.cost || 0),
-                sessionTokens: {
-                  input: taskRun.sessionTokens.input + inputTokens,
-                  output: taskRun.sessionTokens.output + outputTokens,
-                  reasoning: taskRun.sessionTokens.reasoning + reasoningTokens,
-                  cacheRead: taskRun.sessionTokens.cacheRead + cacheReadTokens,
-                  cacheWrite: taskRun.sessionTokens.cacheWrite + cacheWriteTokens,
-                },
-              })),
-            }
-          }
-          return {
-            ...current,
-            sessionCost: current.sessionCost + (data.cost || 0),
-            lastInputTokens: inputTokens > 0 ? inputTokens : current.lastInputTokens,
-            contextState: inputTokens > 0 ? 'measured' : current.contextState,
-            sessionTokens,
-          }
-        })
+        this.updateSessionState(sessionId, (current) => applyCostEventToSessionState(current, data))
         break
       case 'agent':
         this.updateSessionState(sessionId, (current) => ({

--- a/tests/session-engine-costs.test.ts
+++ b/tests/session-engine-costs.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createEmptySessionViewState,
+  createEmptyTaskRun,
+} from '../apps/desktop/src/lib/session-view-model.ts'
+import { applyCostEventToSessionState } from '../apps/desktop/src/main/session-engine-costs.ts'
+
+test('applyCostEventToSessionState updates root session cost and measured context', () => {
+  const current = createEmptySessionViewState({
+    sessionCost: 0.25,
+    lastInputTokens: 12,
+    contextState: 'idle',
+  })
+  const next = applyCostEventToSessionState(current, {
+    type: 'cost',
+    cost: 0.75,
+    tokens: {
+      input: 100,
+      output: 40,
+      reasoning: 10,
+      cache: { read: 5, write: 2 },
+    },
+  })
+
+  assert.equal(next.sessionCost, 1)
+  assert.equal(next.lastInputTokens, 100)
+  assert.equal(next.contextState, 'measured')
+  assert.deepEqual(next.sessionTokens, {
+    input: 100,
+    output: 40,
+    reasoning: 10,
+    cacheRead: 5,
+    cacheWrite: 2,
+  })
+  assert.deepEqual(current.sessionTokens, {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  })
+})
+
+test('applyCostEventToSessionState adds task-run cost without changing root input context', () => {
+  const taskRun = createEmptyTaskRun({
+    id: 'task-1',
+    title: 'Research',
+    agent: 'explore',
+    status: 'running',
+    sessionCost: 0.1,
+  })
+  const current = createEmptySessionViewState({
+    taskRuns: [taskRun],
+    sessionCost: 0.1,
+    lastInputTokens: 8,
+    contextState: 'idle',
+  })
+  const next = applyCostEventToSessionState(current, {
+    type: 'cost',
+    taskRunId: 'task-1',
+    cost: 0.4,
+    tokens: {
+      input: 12,
+      output: 6,
+      reasoning: 3,
+      cache: { read: 2, write: 1 },
+    },
+  })
+
+  assert.equal(next.sessionCost, 0.5)
+  assert.equal(next.lastInputTokens, 8)
+  assert.equal(next.contextState, 'idle')
+  assert.deepEqual(next.sessionTokens, {
+    input: 12,
+    output: 6,
+    reasoning: 3,
+    cacheRead: 2,
+    cacheWrite: 1,
+  })
+  assert.equal(next.taskRuns[0]?.sessionCost, 0.5)
+  assert.deepEqual(next.taskRuns[0]?.sessionTokens, {
+    input: 12,
+    output: 6,
+    reasoning: 3,
+    cacheRead: 2,
+    cacheWrite: 1,
+  })
+})


### PR DESCRIPTION
## Summary
- move streamed cost-token arithmetic out of session-engine into a focused helper
- preserve root-session versus task-run cost semantics in the event dispatcher
- add direct tests for root and task-run cost updates

## Validation
- pnpm test -- tests/session-engine-costs.test.ts tests/session-engine.test.ts tests/session-view-model.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check