### PR TITLE
Split session engine event builders

### DIFF
--- a/apps/desktop/src/main/session-engine-events.ts
+++ b/apps/desktop/src/main/session-engine-events.ts
@@ -1,0 +1,68 @@
+import type {
+  PendingApproval,
+  PendingQuestion,
+  TaskRun,
+  ToolCall,
+} from '@open-cowork/shared'
+
+import type { upsertTaskRunList } from '../lib/session-view-model.ts'
+import { nowTs } from '../lib/session-view-model.ts'
+import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
+
+type RuntimeEventData = NonNullable<RuntimeSessionEvent['data']>
+type TaskRunUpdate = Parameters<typeof upsertTaskRunList>[1]
+
+export function normalizeToolStatus(status: unknown): ToolCall['status'] {
+  return status === 'running' || status === 'complete' || status === 'error'
+    ? status
+    : 'running'
+}
+
+function normalizeTaskStatus(status: unknown): TaskRun['status'] {
+  return status === 'queued' || status === 'running' || status === 'complete' || status === 'error'
+    ? status
+    : 'queued'
+}
+
+export function buildTaskRunUpdate(sessionId: string, data: RuntimeEventData): TaskRunUpdate {
+  return {
+    id: typeof data.id === 'string' ? data.id : `${sessionId}:task:${nowTs()}`,
+    title: typeof data.title === 'string' ? data.title : 'Task',
+    agent: data.agent,
+    status: normalizeTaskStatus(data.status),
+    sourceSessionId: data.sourceSessionId,
+    parentSessionId: typeof data.parentSessionId === 'string' ? data.parentSessionId : null,
+    startedAt: typeof data.startedAt === 'string' ? data.startedAt : null,
+    finishedAt: typeof data.finishedAt === 'string' ? data.finishedAt : null,
+  }
+}
+
+export function buildPendingApproval(sessionId: string, data: RuntimeEventData): Omit<PendingApproval, 'order'> {
+  return {
+    id: typeof data.id === 'string' ? data.id : `${sessionId}:approval:${nowTs()}`,
+    sessionId,
+    taskRunId: data.taskRunId || null,
+    tool: typeof data.tool === 'string' ? data.tool : 'permission',
+    input: data.input || {},
+    description: typeof data.description === 'string'
+      ? data.description
+      : typeof data.tool === 'string'
+        ? data.tool
+        : 'Permission requested',
+  }
+}
+
+export function buildPendingQuestion(sessionId: string, data: RuntimeEventData): PendingQuestion {
+  return {
+    id: typeof data.id === 'string' ? data.id : `${sessionId}:question:${nowTs()}`,
+    sessionId,
+    sourceSessionId: typeof data.sourceSessionId === 'string' ? data.sourceSessionId : null,
+    questions: Array.isArray(data.questions) ? data.questions as PendingQuestion['questions'] : [],
+    tool: data.tool && typeof data.tool === 'object'
+      ? {
+          messageId: String((data.tool as Record<string, unknown>).messageId || ''),
+          callId: String((data.tool as Record<string, unknown>).callId || ''),
+        }
+      : undefined,
+  }
+}

--- a/apps/desktop/src/main/session-engine.ts
+++ b/apps/desktop/src/main/session-engine.ts
@@ -29,6 +29,12 @@ import { buildSessionUsageSummary } from './session-usage-summary.ts'
 import { SessionCostEventTracker } from './session-cost-event-tracker.ts'
 import { createRootToolCall, getLatestHistoryEventAt } from './session-engine-helpers.ts'
 import { applyCostEventToSessionState } from './session-engine-costs.ts'
+import {
+  buildPendingApproval,
+  buildPendingQuestion,
+  buildTaskRunUpdate,
+  normalizeToolStatus,
+} from './session-engine-events.ts'
 
 export { MAX_SEEN_COST_EVENT_IDS_PER_SESSION } from './session-cost-event-tracker.ts'
 
@@ -251,9 +257,7 @@ export class SessionEngine {
       case 'tool_call':
         this.updateSessionState(sessionId, (current) => {
           const toolId = typeof data.id === 'string' ? data.id : `${sessionId}:tool:${nowTs()}`
-          const toolStatus = data.status === 'running' || data.status === 'complete' || data.status === 'error'
-            ? data.status
-            : 'running'
+          const toolStatus = normalizeToolStatus(data.status)
           const toolName = typeof data.name === 'string' ? data.name : undefined
           if (data.taskRunId) {
             return {
@@ -302,18 +306,7 @@ export class SessionEngine {
       case 'task_run':
         this.updateSessionState(sessionId, (current) => ({
           ...current,
-          taskRuns: upsertTaskRunList(current.taskRuns, {
-            id: typeof data.id === 'string' ? data.id : `${sessionId}:task:${nowTs()}`,
-            title: typeof data.title === 'string' ? data.title : 'Task',
-            agent: data.agent,
-            status: data.status === 'queued' || data.status === 'running' || data.status === 'complete' || data.status === 'error'
-              ? data.status
-              : 'queued',
-            sourceSessionId: data.sourceSessionId,
-            parentSessionId: typeof data.parentSessionId === 'string' ? data.parentSessionId : null,
-            startedAt: typeof data.startedAt === 'string' ? data.startedAt : null,
-            finishedAt: typeof data.finishedAt === 'string' ? data.finishedAt : null,
-          }),
+          taskRuns: upsertTaskRunList(current.taskRuns, buildTaskRunUpdate(sessionId, data)),
           lastItemWasTool: true,
         }))
         break
@@ -458,33 +451,11 @@ export class SessionEngine {
         })
         break
       case 'approval':
-        this.addApproval({
-          id: typeof data.id === 'string' ? data.id : `${sessionId}:approval:${nowTs()}`,
-          sessionId,
-          taskRunId: data.taskRunId || null,
-          tool: typeof data.tool === 'string' ? data.tool : 'permission',
-          input: data.input || {},
-          description: typeof data.description === 'string'
-            ? data.description
-            : typeof data.tool === 'string'
-              ? data.tool
-              : 'Permission requested',
-        })
+        this.addApproval(buildPendingApproval(sessionId, data))
         break
       case 'question_asked':
         this.updateSessionState(sessionId, (current) => {
-          const nextQuestion: PendingQuestion = {
-            id: typeof data.id === 'string' ? data.id : `${sessionId}:question:${nowTs()}`,
-            sessionId,
-            sourceSessionId: typeof data.sourceSessionId === 'string' ? data.sourceSessionId : null,
-            questions: Array.isArray(data.questions) ? data.questions as PendingQuestion['questions'] : [],
-            tool: data.tool && typeof data.tool === 'object'
-              ? {
-                  messageId: String((data.tool as Record<string, unknown>).messageId || ''),
-                  callId: String((data.tool as Record<string, unknown>).callId || ''),
-                }
-              : undefined,
-          }
+          const nextQuestion = buildPendingQuestion(sessionId, data)
           return {
             ...current,
             pendingQuestions: current.pendingQuestions.some((question) => question.id === nextQuestion.id)

--- a/tests/session-engine-events.test.ts
+++ b/tests/session-engine-events.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildPendingApproval,
+  buildPendingQuestion,
+  buildTaskRunUpdate,
+  normalizeToolStatus,
+} from '../apps/desktop/src/main/session-engine-events.ts'
+
+test('normalizeToolStatus accepts only runtime tool terminal states', () => {
+  assert.equal(normalizeToolStatus('running'), 'running')
+  assert.equal(normalizeToolStatus('complete'), 'complete')
+  assert.equal(normalizeToolStatus('error'), 'error')
+  assert.equal(normalizeToolStatus('queued'), 'running')
+  assert.equal(normalizeToolStatus(null), 'running')
+})
+
+test('buildTaskRunUpdate normalizes task run payloads from streamed events', () => {
+  assert.deepEqual(buildTaskRunUpdate('session-1', {
+    type: 'task_run',
+    id: 'task-1',
+    title: 'Explore repo',
+    agent: 'explore',
+    status: 'complete',
+    sourceSessionId: 'child-1',
+    parentSessionId: 'session-1',
+    startedAt: '2026-01-01T10:00:00.000Z',
+    finishedAt: '2026-01-01T10:05:00.000Z',
+  }), {
+    id: 'task-1',
+    title: 'Explore repo',
+    agent: 'explore',
+    status: 'complete',
+    sourceSessionId: 'child-1',
+    parentSessionId: 'session-1',
+    startedAt: '2026-01-01T10:00:00.000Z',
+    finishedAt: '2026-01-01T10:05:00.000Z',
+  })
+})
+
+test('buildTaskRunUpdate falls back for malformed optional task fields', () => {
+  const update = buildTaskRunUpdate('session-1', {
+    type: 'task_run',
+    status: 'unknown',
+    parentSessionId: 12,
+    startedAt: false,
+    finishedAt: {},
+  })
+
+  assert.match(update.id, /^session-1:task:\d+$/)
+  assert.equal(update.title, 'Task')
+  assert.equal(update.status, 'queued')
+  assert.equal(update.parentSessionId, null)
+  assert.equal(update.startedAt, null)
+  assert.equal(update.finishedAt, null)
+})
+
+test('buildPendingApproval uses explicit descriptions and permission fallbacks', () => {
+  assert.deepEqual(buildPendingApproval('session-1', {
+    type: 'approval',
+    id: 'approval-1',
+    taskRunId: 'task-1',
+    tool: 'bash',
+    input: { command: 'pwd' },
+    description: 'Run pwd',
+  }), {
+    id: 'approval-1',
+    sessionId: 'session-1',
+    taskRunId: 'task-1',
+    tool: 'bash',
+    input: { command: 'pwd' },
+    description: 'Run pwd',
+  })
+
+  const fallback = buildPendingApproval('session-1', { type: 'approval' })
+  assert.match(fallback.id, /^session-1:approval:\d+$/)
+  assert.equal(fallback.tool, 'permission')
+  assert.deepEqual(fallback.input, {})
+  assert.equal(fallback.description, 'Permission requested')
+})
+
+test('buildPendingQuestion preserves question prompts and normalized tool identity', () => {
+  assert.deepEqual(buildPendingQuestion('session-1', {
+    type: 'question_asked',
+    id: 'question-1',
+    sourceSessionId: 'child-1',
+    questions: [{
+      header: 'Scope',
+      question: 'What should change?',
+      options: [{ label: 'Tests', description: 'Focus tests' }],
+    }],
+    tool: {
+      messageId: 'message-1',
+      callId: 'call-1',
+    },
+  }), {
+    id: 'question-1',
+    sessionId: 'session-1',
+    sourceSessionId: 'child-1',
+    questions: [{
+      header: 'Scope',
+      question: 'What should change?',
+      options: [{ label: 'Tests', description: 'Focus tests' }],
+    }],
+    tool: {
+      messageId: 'message-1',
+      callId: 'call-1',
+    },
+  })
+})


### PR DESCRIPTION
## Summary
- move streamed event payload builders out of session-engine into session-engine-events
- keep the session engine switch focused on state transitions while preserving task/approval/question normalization
- add direct tests for status normalization and event payload fallbacks

## Validation
- pnpm test -- tests/session-engine-events.test.ts tests/session-engine.test.ts tests/session-engine-costs.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check