### PR TITLE
Split automation retry orchestration

### DIFF
--- a/apps/desktop/src/main/automation-retry.ts
+++ b/apps/desktop/src/main/automation-retry.ts
@@ -1,0 +1,45 @@
+import type { AutomationRun } from '@open-cowork/shared'
+
+import {
+  clearPendingRetriesForChain,
+  getActiveRunForAutomation,
+  getAutomationDetail,
+  getNextRetryAttemptForChain,
+  getRun,
+} from './automation-store.ts'
+import { getRetryRootRunId } from './automation-service-reporting.ts'
+import { AutomationRunStartError } from './automation-service-errors.ts'
+import { startAutomationRun } from './automation-run-starter.ts'
+
+export async function retryAutomationRunWithContext(
+  runId: string,
+  publishAutomationUpdated: () => void,
+): Promise<AutomationRun | null> {
+  const run = getRun(runId)
+  if (!run || run.status === 'running') return null
+  const automation = getAutomationDetail(run.automationId)
+  if (!automation) return null
+  if (automation.status === 'archived') {
+    throw new Error('Archived automations cannot be started.')
+  }
+  const activeRun = getActiveRunForAutomation(run.automationId)
+  if (activeRun) {
+    throw new Error(`Automation already has an active ${activeRun.kind} run.`)
+  }
+  const retryRootRunId = getRetryRootRunId(run)
+  const nextAttempt = getNextRetryAttemptForChain(retryRootRunId)
+  try {
+    const started = await startAutomationRun(run.automationId, run.kind, publishAutomationUpdated, {
+      attempt: nextAttempt,
+      retryOfRunId: retryRootRunId,
+      title: `${run.title} (retry ${nextAttempt})`,
+    })
+    if (started) clearPendingRetriesForChain(retryRootRunId, started.id)
+    return started
+  } catch (error) {
+    if (error instanceof AutomationRunStartError && error.runId) {
+      clearPendingRetriesForChain(retryRootRunId, error.runId)
+    }
+    throw error
+  }
+}

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -6,13 +6,10 @@ import type {
   ExecutionBrief,
 } from '@open-cowork/shared'
 import {
-  clearPendingRetriesForChain,
   createAutomation,
   createInboxItem,
-  getActiveRunForAutomation,
   getAutomationDetail,
   getInboxItem,
-  getNextRetryAttemptForChain,
   getRun,
   listAutomationState,
   listOpenInboxForAutomation,
@@ -35,11 +32,11 @@ import { AutomationRunConflictError, AutomationRunStartError } from './automatio
 import { buildAutomationApprovalBody, requiresManualApproval } from './automation-service-approval.ts'
 import {
   buildRetryScheduledBody,
-  getRetryRootRunId,
   maybeOpenFailureCircuit,
   maybeReportFailedRun,
   processAutomationRunFailure,
 } from './automation-service-reporting.ts'
+import { retryAutomationRunWithContext } from './automation-retry.ts'
 import { runAutomationHeartbeatReviews } from './automation-heartbeat.ts'
 import { runAutomationScheduler } from './automation-scheduler.ts'
 import { enforceAutomationRunTimeLimits } from './automation-timeouts.ts'
@@ -201,33 +198,7 @@ export async function runAutomationNow(automationId: string): Promise<Automation
 }
 
 export async function retryAutomationRun(runId: string): Promise<AutomationRun | null> {
-  const run = getRun(runId)
-  if (!run || run.status === 'running') return null
-  const automation = getAutomationDetail(run.automationId)
-  if (!automation) return null
-  if (automation.status === 'archived') {
-    throw new Error('Archived automations cannot be started.')
-  }
-  const activeRun = getActiveRunForAutomation(run.automationId)
-  if (activeRun) {
-    throw new Error(`Automation already has an active ${activeRun.kind} run.`)
-  }
-  const retryRootRunId = getRetryRootRunId(run)
-  const nextAttempt = getNextRetryAttemptForChain(retryRootRunId)
-  try {
-    const started = await startAutomationRun(run.automationId, run.kind, publishAutomationUpdated, {
-      attempt: nextAttempt,
-      retryOfRunId: retryRootRunId,
-      title: `${run.title} (retry ${nextAttempt})`,
-    })
-    if (started) clearPendingRetriesForChain(retryRootRunId, started.id)
-    return started
-  } catch (error) {
-    if (error instanceof AutomationRunStartError && error.runId) {
-      clearPendingRetriesForChain(retryRootRunId, error.runId)
-    }
-    throw error
-  }
+  return retryAutomationRunWithContext(runId, publishAutomationUpdated)
 }
 
 export async function cancelAutomationRun(runId: string) {


### PR DESCRIPTION
## Summary
- move manual automation retry orchestration into automation-retry.ts
- keep automation-service as the public API delegate while reducing orchestration bulk
- preserve existing retry root, attempt numbering, conflict cleanup, and publish callback behavior

## Validation
- pnpm test -- tests/automation-service.test.ts tests/automation-control-plane-queue.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check