### PR TITLE
Split runtime MCP status polling

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,7 +10,7 @@ import {
   stopRuntime,
 } from './runtime.ts'
 import { isSandboxWorkspaceDir } from './runtime-paths.ts'
-import { subscribeToEvents, getMcpStatus } from './events.ts'
+import { subscribeToEvents } from './events.ts'
 import { flushSessionRegistryWrites } from './session-registry.ts'
 import { assertConfigValid, getAppConfig, getBranding } from './config-loader.ts'
 import { applySettingsSideEffects, isSetupComplete, loadSettings } from './settings.ts'
@@ -34,7 +34,7 @@ import {
   createRuntimeEventSubscriptionManager,
 } from './event-subscriptions.ts'
 import { primeShellEnvironment } from './shell-env.ts'
-import { createStartupMcpRecovery } from './runtime-mcp-recovery.ts'
+import { restartRuntimeMcpStatusPolling } from './runtime-mcp-status-polling.ts'
 import { shouldScheduleRuntimeReconnect } from './runtime-reconnect-policy.ts'
 import { registerAppProtocolSchemes } from './app-protocol-schemes.ts'
 import { registerBrandingAssetProtocol } from './branding-assets.ts'
@@ -497,31 +497,13 @@ async function runBootRuntime(projectDirectory?: string | null) {
 
     eventSubscriptions.ensure(getRuntimeHomeDir(), client)
 
-    const {
-      recoverDisconnectedGoogleAuthMcps,
-      recoverFailedLocalMcps,
-    } = createStartupMcpRecovery({ client, runtimeProjectDirectory })
-
-    const pollMcp = async () => {
-      try {
-        const statuses = await getMcpStatus(client)
-        await recoverDisconnectedGoogleAuthMcps(statuses)
-        await recoverFailedLocalMcps(statuses)
-        const currentWindow = getMainWindow()
-        if (currentWindow && !currentWindow.isDestroyed()) {
-          currentWindow.webContents.send('mcp:status', statuses)
-        }
-      } catch (err: unknown) {
-        log('error', `MCP status poll failed: ${err instanceof Error ? err.message : String(err)}`)
-        // Runtime might have died — trigger reconnect
-        scheduleReconnect()
-      }
-    }
-    // Kick off the first MCP poll right away so the home page's MCP pill
-    // populates on first paint instead of waiting for the recurring tick.
-    void pollMcp()
-    if (mcpInterval) clearInterval(mcpInterval)
-    mcpInterval = setInterval(pollMcp, 10_000)
+    mcpInterval = restartRuntimeMcpStatusPolling({
+      client,
+      runtimeProjectDirectory,
+      currentInterval: mcpInterval,
+      getMainWindow,
+      scheduleReconnect,
+    })
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Failed to start runtime'
     log('error', `Failed to start runtime: ${message}`)

--- a/apps/desktop/src/main/runtime-mcp-status-polling.ts
+++ b/apps/desktop/src/main/runtime-mcp-status-polling.ts
@@ -1,0 +1,44 @@
+import type { BrowserWindow } from 'electron'
+import type { OpencodeClient } from '@opencode-ai/sdk/v2'
+
+import { getMcpStatus } from './events.ts'
+import { log } from './logger.ts'
+import { createStartupMcpRecovery } from './runtime-mcp-recovery.ts'
+
+export function restartRuntimeMcpStatusPolling(options: {
+  client: OpencodeClient
+  runtimeProjectDirectory: string | null
+  currentInterval: NodeJS.Timeout | null
+  getMainWindow: () => BrowserWindow | null
+  scheduleReconnect: () => void
+  intervalMs?: number
+}) {
+  const {
+    recoverDisconnectedGoogleAuthMcps,
+    recoverFailedLocalMcps,
+  } = createStartupMcpRecovery({
+    client: options.client,
+    runtimeProjectDirectory: options.runtimeProjectDirectory,
+  })
+
+  const pollMcp = async () => {
+    try {
+      const statuses = await getMcpStatus(options.client)
+      await recoverDisconnectedGoogleAuthMcps(statuses)
+      await recoverFailedLocalMcps(statuses)
+      const currentWindow = options.getMainWindow()
+      if (currentWindow && !currentWindow.isDestroyed()) {
+        currentWindow.webContents.send('mcp:status', statuses)
+      }
+    } catch (err: unknown) {
+      log('error', `MCP status poll failed: ${err instanceof Error ? err.message : String(err)}`)
+      options.scheduleReconnect()
+    }
+  }
+
+  // Kick off the first MCP poll right away so the home page's MCP pill
+  // populates on first paint instead of waiting for the recurring tick.
+  void pollMcp()
+  if (options.currentInterval) clearInterval(options.currentInterval)
+  return setInterval(pollMcp, options.intervalMs ?? 10_000)
+}

--- a/tests/runtime-mcp-status-polling.test.ts
+++ b/tests/runtime-mcp-status-polling.test.ts
@@ -1,0 +1,83 @@
+import type { BrowserWindow } from 'electron'
+import type { OpencodeClient } from '@opencode-ai/sdk/v2'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { restartRuntimeMcpStatusPolling } from '../apps/desktop/src/main/runtime-mcp-status-polling.ts'
+
+function createFakeMcpClient(status: () => Promise<{ data: unknown }>): OpencodeClient {
+  return {
+    mcp: {
+      status,
+      connect: async () => ({}),
+    },
+  } as unknown as OpencodeClient
+}
+
+async function flushPoll() {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+test('runtime MCP status polling publishes the immediate status payload', async () => {
+  const sent: Array<{ channel: string; payload: unknown }> = []
+  const interval = restartRuntimeMcpStatusPolling({
+    client: createFakeMcpClient(async () => ({
+      data: {
+        charts: { status: 'connected' },
+      },
+    })),
+    runtimeProjectDirectory: null,
+    currentInterval: null,
+    getMainWindow: () => ({
+      isDestroyed: () => false,
+      webContents: {
+        send: (channel: string, payload: unknown) => {
+          sent.push({ channel, payload })
+        },
+      },
+    }) as unknown as BrowserWindow,
+    scheduleReconnect: () => assert.fail('reconnect should not be scheduled for a healthy poll'),
+  })
+
+  try {
+    await flushPoll()
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0]?.channel, 'mcp:status')
+    assert.deepEqual(sent[0]?.payload, [
+      { name: 'charts', connected: true, rawStatus: 'connected' },
+    ])
+  } finally {
+    clearInterval(interval)
+  }
+})
+
+test('runtime MCP status polling schedules reconnect when publishing fails', async () => {
+  let reconnects = 0
+  const interval = restartRuntimeMcpStatusPolling({
+    client: createFakeMcpClient(async () => ({
+      data: {
+        charts: { status: 'connected' },
+      },
+    })),
+    runtimeProjectDirectory: null,
+    currentInterval: null,
+    getMainWindow: () => ({
+      isDestroyed: () => false,
+      webContents: {
+        send: () => {
+          throw new Error('renderer unavailable')
+        },
+      },
+    }) as unknown as BrowserWindow,
+    scheduleReconnect: () => {
+      reconnects += 1
+    },
+  })
+
+  try {
+    await flushPoll()
+    assert.equal(reconnects, 1)
+  } finally {
+    clearInterval(interval)
+  }
+})


### PR DESCRIPTION
## Summary
- move runtime MCP status polling and startup recovery wiring out of main index
- keep index responsible for boot orchestration while delegating MCP status publishing
- add node tests for immediate MCP status publish and reconnect scheduling on publish failure

## Validation
- pnpm test -- tests/runtime-mcp-status-polling.test.ts tests/events.test.ts tests/runtime-mcp-recovery.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm build
- pnpm perf:check
- git diff --check