### PR TITLE
Disclose runtime tooling bridge during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Release artifacts are published on [GitHub Releases](https://github.com/joe-broa
 
 1. Download a release for your platform, or run from source.
 2. Launch **Open Cowork**.
-3. Complete first-run setup by choosing a provider and model.
+3. Complete first-run setup by choosing a provider, model, and whether the managed runtime can reuse standard developer config such as Git, SSH, cloud, Docker, and Kubernetes settings.
 4. Connect a provider: OpenRouter API key, or OpenAI/Codex via ChatGPT Plus/Pro or API key.
 5. Start a thread:
    - **Project thread** for real filesystem work in a chosen directory.

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -122,4 +122,48 @@ describe('SetupScreen', () => {
     await waitFor(() => expect(screen.getByPlaceholderText('team-...')).toHaveValue('team-from-disk'))
     expect(apiKeyInput).toHaveValue('sk-or-user-edit')
   })
+
+  it('discloses and persists the developer config bridge choice during first-run setup', async () => {
+    const user = userEvent.setup()
+    const set = vi.fn(async () => settings())
+    const restart = vi.fn(async () => ({ ready: true, error: null }))
+    const onComplete = vi.fn()
+    installRendererTestCoworkApi({
+      settings: {
+        get: vi.fn(async () => settings({ runtimeToolingBridgeEnabled: true })),
+        getProviderCredentials: vi.fn(async () => ({ apiKey: 'sk-or-scoped' })),
+        set,
+      },
+      runtime: {
+        restart,
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providers}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={onComplete}
+      />,
+    )
+
+    const bridgeToggle = await screen.findByRole('checkbox', { name: /Developer config bridge/ })
+    expect(bridgeToggle).toBeChecked()
+
+    await user.click(bridgeToggle)
+    await user.click(screen.getByRole('button', { name: 'Get Started' }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    expect(restart).toHaveBeenCalledTimes(1)
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      selectedProviderId: 'openrouter',
+      selectedModelId: 'anthropic/claude-sonnet-4',
+      runtimeToolingBridgeEnabled: false,
+      providerCredentials: {
+        openrouter: expect.objectContaining({ apiKey: 'sk-or-scoped' }),
+      },
+    }))
+  })
 })

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -24,6 +24,7 @@ export function SetupScreen({
   const [providerId, setProviderId] = useState<string | null>(defaultProviderId)
   const [modelId, setModelId] = useState(defaultModelId || '')
   const [providerCredentials, setProviderCredentials] = useState<Record<string, Record<string, string>>>({})
+  const [runtimeToolingBridgeEnabled, setRuntimeToolingBridgeEnabled] = useState(true)
   const [loadedCredentialProviders, setLoadedCredentialProviders] = useState<Set<string>>(() => new Set())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -67,6 +68,7 @@ export function SetupScreen({
         setProviderId(initialProviderId)
         setModelId(initialModelId)
       }
+      setRuntimeToolingBridgeEnabled(settings.runtimeToolingBridgeEnabled !== false)
       if (initialProviderId) {
         mergeLoadedProviderCredentials(initialProviderId, initialCredentials)
         setLoadedCredentialProviders((current) => new Set(current).add(initialProviderId))
@@ -133,6 +135,7 @@ export function SetupScreen({
       await window.coworkApi.settings.set({
         selectedProviderId: providerId,
         selectedModelId: nextModelId,
+        runtimeToolingBridgeEnabled,
         providerCredentials: {
           [providerId]: selectedCredentials,
         },
@@ -284,6 +287,28 @@ export function SetupScreen({
           {error ? (
             <p className="text-[12px] text-center" style={{ color: 'var(--color-red)' }}>{error}</p>
           ) : null}
+
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="setup-runtime-tooling-bridge" className="mt-1 flex items-start gap-3 rounded-xl border border-border-subtle bg-elevated px-3.5 py-3 cursor-pointer">
+            <input
+              id="setup-runtime-tooling-bridge"
+              type="checkbox"
+              checked={runtimeToolingBridgeEnabled}
+              onChange={(event) => setRuntimeToolingBridgeEnabled(event.target.checked)}
+              className="mt-0.5"
+            />
+            <span className="flex min-w-0 flex-col gap-1">
+              <span className="text-[12px] font-semibold text-text">
+                {t('setup.toolingBridgeTitle', 'Developer config bridge')}
+              </span>
+              <span className="text-[10px] leading-relaxed text-text-muted">
+                {t(
+                  'setup.toolingBridgeDescription',
+                  'Let the managed OpenCode runtime reuse standard Git, SSH, package-manager, cloud, Docker, and Kubernetes config from your home directory. Turn this off for a stricter isolated runtime HOME; you can change it later in Settings.',
+                )}
+              </span>
+            </span>
+          </label>
 
           <button
             onClick={handleContinue}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,8 +62,14 @@ On first launch, Open Cowork asks you to choose:
 - a provider
 - a model
 - any required provider credentials
+- whether the managed runtime can reuse standard developer config
+  such as Git, SSH, package-manager, cloud, Docker, and Kubernetes
+  settings
 
 The app then boots the OpenCode runtime with your selected configuration.
+The developer config bridge is enabled by default for normal project
+workflows, but you can turn it off during setup or later in Settings ->
+Permissions for a stricter isolated runtime home.
 
 ### Default providers
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -192,9 +192,10 @@ set of standard tooling paths such as Git, npm/pnpm/yarn, SSH, GitHub
 CLI, Docker, Kubernetes, AWS, Azure, and Google Cloud config into that
 runtime home. Those bridged files are a deliberate trust boundary:
 tools invoked by OpenCode may read the linked developer-tool config.
-Users can disable this bridge in Settings → Permissions → Developer
-config bridge; disabling it removes the curated symlinks from the
-managed runtime home on the next runtime restart.
+Users can disable this bridge during first-run setup or later in
+Settings → Permissions → Developer config bridge; disabling it removes
+the curated symlinks from the managed runtime home on the next runtime
+restart.
 
 The OpenCode server process also receives a curated environment, not the
 user's full login shell environment. Open Cowork preserves toolchain basics


### PR DESCRIPTION
## Summary
- add first-run setup disclosure for the developer config bridge trust boundary
- persist the user's runtime tooling bridge choice from setup
- update onboarding/security docs to match the new setup choice

## Validation
- pnpm test:renderer -- SetupScreen
- pnpm typecheck
- pnpm lint
- pnpm lint:a11y --max-warnings=0
- pnpm test
- uv run mkdocs build --strict
- git diff --check