### PR TITLE
Harden smoke test waits

### DIFF
--- a/apps/desktop/tests/agent-chart-regression.smoke.test.ts
+++ b/apps/desktop/tests/agent-chart-regression.smoke.test.ts
@@ -1,18 +1,38 @@
 import assert from 'node:assert/strict'
 import { randomUUID } from 'node:crypto'
 import test from 'node:test'
-import { launchSmokeApp, waitForAppShell } from './smoke-helpers.ts'
+import { launchSmokeApp, waitForAppShell, waitForRuntimeReady } from './smoke-helpers.ts'
 
-async function waitForRuntimeReady(page: Parameters<typeof waitForAppShell>[0], timeout = 20_000) {
-  await page.evaluate(async (maxWaitMs) => {
-    const startedAt = Date.now()
-    while (Date.now() - startedAt < maxWaitMs) {
-      const status = await window.coworkApi.runtime.status()
-      if (status.ready) return
-      await new Promise((resolve) => setTimeout(resolve, 250))
+async function waitForRuntimeAgent(page: Parameters<typeof waitForAppShell>[0], name: string, timeout = 15_000) {
+  await page.evaluate(() => {
+    const state = window as unknown as {
+      __openCoworkRuntimeAgentNames?: string[]
+      __openCoworkRuntimeAgentProbeInFlight?: boolean
     }
-    throw new Error('Timed out waiting for runtime to become ready')
-  }, timeout)
+    state.__openCoworkRuntimeAgentNames = []
+    state.__openCoworkRuntimeAgentProbeInFlight = false
+  })
+  await page.waitForFunction((agentName) => {
+    const state = window as unknown as {
+      __openCoworkRuntimeAgentNames?: string[]
+      __openCoworkRuntimeAgentProbeInFlight?: boolean
+    }
+    if (state.__openCoworkRuntimeAgentProbeInFlight) {
+      return state.__openCoworkRuntimeAgentNames?.includes(agentName) === true
+    }
+    state.__openCoworkRuntimeAgentProbeInFlight = true
+    void window.coworkApi.agents.runtime()
+      .then((runtimeAgents) => {
+        state.__openCoworkRuntimeAgentNames = runtimeAgents.map((agent) => agent.name)
+      })
+      .catch(() => {
+        state.__openCoworkRuntimeAgentNames = []
+      })
+      .finally(() => {
+        state.__openCoworkRuntimeAgentProbeInFlight = false
+      })
+    return state.__openCoworkRuntimeAgentNames?.includes(agentName) === true
+  }, name, { timeout })
 }
 
 test('chart specialist survives runtime rebuild and chart rendering still works', async () => {
@@ -23,6 +43,7 @@ test('chart specialist survives runtime rebuild and chart rendering still works'
   try {
     await waitForAppShell(page)
     await waitForRuntimeReady(page)
+    await waitForRuntimeAgent(page, 'charts')
 
     const before = await page.evaluate(async () => {
       const [skills, runtimeAgents] = await Promise.all([
@@ -54,6 +75,7 @@ test('chart specialist survives runtime rebuild and chart rendering still works'
     created = true
 
     await waitForRuntimeReady(page)
+    await waitForRuntimeAgent(page, agentName)
 
     const after = await page.evaluate(async (name) => {
       const [skills, customAgents, runtimeAgents, svg] = await Promise.all([

--- a/apps/desktop/tests/navigation-wiring.smoke.test.ts
+++ b/apps/desktop/tests/navigation-wiring.smoke.test.ts
@@ -12,7 +12,7 @@ test('home recent-thread CTA routes through the real session activation path', a
   try {
     await waitForAppShell(page, 30_000)
 
-    await page.evaluate(async ({ sourceTitle, targetTitle, marker }) => {
+    const sourceId = await page.evaluate(async ({ sourceTitle, marker }) => {
       const source = await window.coworkApi.session.create()
       await window.coworkApi.session.rename(source.id, sourceTitle)
       await window.coworkApi.session.activate(source.id)
@@ -24,19 +24,51 @@ test('home recent-thread CTA routes through the real session activation path', a
         // observably different from the empty target thread.
       }
 
-      for (let attempt = 0; attempt < 20; attempt += 1) {
-        const view = await window.coworkApi.session.activate(source.id, { force: true })
-        if (view.messages.some((message) => message.content.includes(marker))) break
-        await new Promise((resolve) => window.setTimeout(resolve, 200))
-      }
-
-      const target = await window.coworkApi.session.create()
-      await window.coworkApi.session.rename(target.id, targetTitle)
+      return source.id
     }, {
       sourceTitle: RECENT_SOURCE_TITLE,
-      targetTitle: RECENT_TARGET_TITLE,
       marker: RECENT_THREAD_MARKER,
     })
+
+    await page.waitForFunction(({ id, marker }) => {
+      const state = window as unknown as {
+        __openCoworkRecentThreadProbe?: {
+          id: string
+          marker: string
+          found: boolean
+          inFlight: boolean
+        }
+      }
+      const current = state.__openCoworkRecentThreadProbe
+      if (!current || current.id !== id || current.marker !== marker) {
+        state.__openCoworkRecentThreadProbe = { id, marker, found: false, inFlight: false }
+      }
+      if (state.__openCoworkRecentThreadProbe.inFlight) {
+        return state.__openCoworkRecentThreadProbe.found
+      }
+      state.__openCoworkRecentThreadProbe.inFlight = true
+      void window.coworkApi.session.activate(id, { force: true })
+        .then((view) => {
+          state.__openCoworkRecentThreadProbe = {
+            id,
+            marker,
+            found: view.messages.some((message) => message.content.includes(marker)),
+            inFlight: false,
+          }
+        })
+        .catch(() => {
+          state.__openCoworkRecentThreadProbe = { id, marker, found: false, inFlight: false }
+        })
+      return state.__openCoworkRecentThreadProbe?.found === true
+    }, {
+      id: sourceId,
+      marker: RECENT_THREAD_MARKER,
+    }, { timeout: 15_000 })
+
+    await page.evaluate(async (targetTitle) => {
+      const target = await window.coworkApi.session.create()
+      await window.coworkApi.session.rename(target.id, targetTitle)
+    }, RECENT_TARGET_TITLE)
 
     await page.reload()
     await waitForAppShell(page, 30_000)

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -98,6 +98,42 @@ export async function waitForAppShell(page: Page, timeout = 15_000) {
   }
 }
 
+export async function waitForRuntimeReady(page: Page, timeout = 20_000) {
+  try {
+    await page.evaluate(() => {
+      const state = window as unknown as {
+        __openCoworkRuntimeReady?: boolean
+        __openCoworkRuntimeReadyProbeInFlight?: boolean
+      }
+      state.__openCoworkRuntimeReady = false
+      state.__openCoworkRuntimeReadyProbeInFlight = false
+    })
+    await page.waitForFunction(() => {
+      const state = window as unknown as {
+        __openCoworkRuntimeReady?: boolean
+        __openCoworkRuntimeReadyProbeInFlight?: boolean
+      }
+      if (state.__openCoworkRuntimeReadyProbeInFlight) return state.__openCoworkRuntimeReady === true
+      state.__openCoworkRuntimeReadyProbeInFlight = true
+      void window.coworkApi?.runtime?.status?.()
+        .then((status) => {
+          state.__openCoworkRuntimeReady = Boolean(status?.ready)
+        })
+        .catch(() => {
+          state.__openCoworkRuntimeReady = false
+        })
+        .finally(() => {
+          state.__openCoworkRuntimeReadyProbeInFlight = false
+        })
+      return state.__openCoworkRuntimeReady === true
+    }, undefined, { timeout })
+  } catch (error) {
+    const diagnostics = await getAppShellDiagnostics(page)
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Timed out waiting for runtime readiness: ${message}\nDiagnostics: ${JSON.stringify(diagnostics)}`, { cause: error })
+  }
+}
+
 function writeIsolatedConfig(tempRoot: string) {
   // Borrow upstream's config but rebrand dataDirName so the test install
   // can't collide with a developer's real Open Cowork state on disk.


### PR DESCRIPTION
## Summary
- replace in-page sleep loops in navigation smoke coverage with Playwright condition polling
- move runtime readiness waiting into a shared smoke helper with diagnostics on timeout
- wait for runtime agent registration explicitly before chart-agent assertions

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm --dir apps/desktop test:e2e
- node ../../scripts/run-desktop-smoke-tests.mjs --pattern tests/agent-chart-regression.smoke.test.ts --timeout=120000 --retries=1
- node ../../scripts/run-desktop-smoke-tests.mjs --pattern tests/navigation-wiring.smoke.test.ts --timeout=120000 --retries=1
- git diff --check