### PR TITLE
Surface runtime status IPC failures

### DIFF
--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -502,6 +502,21 @@ describe('App', () => {
     expect(api.runtime.status).toHaveBeenCalled()
   })
 
+  it('surfaces transient runtime status IPC failures without blocking the shell', async () => {
+    const { api } = installAppApi()
+    vi.mocked(api.runtime.status).mockRejectedValueOnce(new Error('ipc down'))
+
+    render(<App />)
+
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/Could not .*runtime status/)
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('ipc down'),
+      view: 'runtime',
+    }))
+  })
+
   it('creates and prompts a new session from the Home composer path', async () => {
     const user = userEvent.setup()
     const { api } = installAppApi()

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -134,7 +134,7 @@ export function App() {
     runtimeError,
     refreshRuntimeState,
     handleRuntimeRestart,
-  } = useRuntimeHealth(loadSessions)
+  } = useRuntimeHealth(loadSessions, reportAppError)
 
   const createAndActivateSession = useCallback(async (directory?: string): Promise<SessionInfo | null> => {
     try {

--- a/apps/desktop/src/renderer/hooks/useRuntimeHealth.ts
+++ b/apps/desktop/src/renderer/hooks/useRuntimeHealth.ts
@@ -8,12 +8,26 @@ type RuntimeHealth = {
   handleRuntimeRestart: () => Promise<void>
 }
 
-export function useRuntimeHealth(loadSessions: () => Promise<void>): RuntimeHealth {
+type RuntimeHealthErrorReporter = (notice: string, error: unknown, viewName: string) => void
+
+export function useRuntimeHealth(
+  loadSessions: () => Promise<void>,
+  reportError?: RuntimeHealthErrorReporter,
+): RuntimeHealth {
   const [runtimeReady, setRuntimeReady] = useState(false)
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
   // Flipped to true the first time the runtime is successfully ready.
   // Distinguishes "still booting" from "runtime dropped after success".
   const [runtimeWasReady, setRuntimeWasReady] = useState(false)
+
+  const reportRuntimeStatusError = useCallback((notice: string, err: unknown) => {
+    // A rejected status IPC can be a one-off bridge timing issue while
+    // the runtime itself remains healthy. Surface it through the app's
+    // notice/diagnostics channel, but do not convert it into authoritative
+    // runtime state. Successful status payloads and explicit restart
+    // failures below still own `runtimeReady` / `runtimeError`.
+    reportError?.(notice, err, 'runtime')
+  }, [reportError])
 
   const refreshRuntimeState = useCallback(async () => {
     return window.coworkApi.runtime.status().then(async (status) => {
@@ -23,8 +37,8 @@ export function useRuntimeHealth(loadSessions: () => Promise<void>): RuntimeHeal
         setRuntimeWasReady(true)
         await loadSessions()
       }
-    }).catch((err) => console.error('Failed to query runtime status:', err))
-  }, [loadSessions])
+    }).catch((err) => reportRuntimeStatusError('Could not query runtime status. Try restarting the app.', err))
+  }, [loadSessions, reportRuntimeStatusError])
 
   const handleRuntimeRestart = useCallback(async () => {
     try {
@@ -38,8 +52,9 @@ export function useRuntimeHealth(loadSessions: () => Promise<void>): RuntimeHeal
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Runtime restart failed.'
       setRuntimeError(message)
+      reportError?.('Runtime restart failed. Try again.', err, 'runtime')
     }
-  }, [loadSessions])
+  }, [loadSessions, reportError])
 
   // Poll runtime health so a mid-session drop surfaces as the offline banner
   // instead of silently hanging the next prompt. Polling is skipped while the
@@ -81,13 +96,16 @@ export function useRuntimeHealth(loadSessions: () => Promise<void>): RuntimeHeal
       if (status.ready) {
         void loadSessions()
       }
-    }).catch((err) => console.error('Failed to initialize runtime status:', err))
+    }).catch((err) => {
+      if (cancelled) return
+      reportRuntimeStatusError('Could not initialize runtime status. Try restarting the app.', err)
+    })
 
     return () => {
       cancelled = true
       unsub()
     }
-  }, [loadSessions])
+  }, [loadSessions, reportRuntimeStatusError])
 
   return {
     runtimeReady,


### PR DESCRIPTION
## Summary
- route runtime status initialization/query failures through the App error reporter
- show non-transient runtime status failures in loading/offline state instead of console-only logging
- cover runtime status IPC rejection in the App renderer test

## Validation
- pnpm --dir apps/desktop test:renderer -- App
- pnpm typecheck
- pnpm lint
- git diff --check