### PR TITLE
Harden chat composer error handling

### DIFF
--- a/apps/desktop/src/renderer/components/HomePage.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.tsx
@@ -211,7 +211,7 @@ function HomeComposer({ onSubmit, disabled, placeholder }: {
     >
       <ChatInputAttachments
         attachments={attachments}
-        onRemove={(index) => setAttachments((prev) => prev.filter((_, currentIndex) => currentIndex !== index))}
+        onRemove={(id) => setAttachments((prev) => prev.filter((attachment) => attachment.id !== id))}
       />
       <div
         className="w-full rounded-[18px] px-4 py-3 flex items-end gap-3 transition-colors"

--- a/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
@@ -6,6 +6,27 @@ import { ChatInput } from './ChatInput'
 
 const HISTORY_KEY = 'open-cowork-prompt-history'
 
+function seedCurrentSession() {
+  useSessionStore.setState({
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+  useSessionStore.getState().setSessions([
+    {
+      id: 'session-1',
+      title: 'Session 1',
+      directory: '/tmp/project',
+      createdAt: '2026-04-29T00:00:00.000Z',
+      updatedAt: '2026-04-29T00:00:00.000Z',
+    },
+  ])
+  useSessionStore.getState().setCurrentSession('session-1')
+}
+
 describe('ChatInput', () => {
   it('resizes the textarea when navigating prompt history', async () => {
     installRendererTestCoworkApi({
@@ -25,16 +46,7 @@ describe('ChatInput', () => {
     })
     const longPrompt = ['first line', 'second line', 'third line', 'fourth line'].join('\n')
     window.localStorage.setItem(HISTORY_KEY, JSON.stringify([longPrompt]))
-    useSessionStore.getState().setSessions([
-      {
-        id: 'session-1',
-        title: 'Session 1',
-        directory: '/tmp/project',
-        createdAt: '2026-04-29T00:00:00.000Z',
-        updatedAt: '2026-04-29T00:00:00.000Z',
-      },
-    ])
-    useSessionStore.getState().setCurrentSession('session-1')
+    seedCurrentSession()
 
     render(<ChatInput />)
 
@@ -57,5 +69,52 @@ describe('ChatInput', () => {
 
     await waitFor(() => expect(textarea).toHaveValue(''))
     await waitFor(() => expect(textarea.style.height).toBe('48px'))
+  })
+
+  it('surfaces prompt IPC failures through the chat error channel and diagnostics', async () => {
+    const prompt = vi.fn(async () => {
+      throw new Error('provider offline')
+    })
+    const reportRendererError = vi.fn()
+    const api = installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => ({
+          appId: 'com.opencowork.desktop',
+          name: 'Open Cowork',
+          helpUrl: 'https://github.com/joe-broadhead/open-cowork',
+          defaultModel: null,
+          providers: { available: [] },
+          auth: { mode: 'none' },
+        })),
+      },
+      diagnostics: {
+        reportRendererError,
+      },
+      on: {
+        runtimeReady: vi.fn(() => () => undefined),
+      },
+      session: {
+        prompt,
+      },
+    })
+    seedCurrentSession()
+
+    render(<ChatInput />)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Summarize this' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => expect(prompt).toHaveBeenCalledWith(
+      'session-1',
+      'Summarize this',
+      undefined,
+      'build',
+    ))
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not send the prompt. Please try again.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('provider offline'),
+      view: 'chat',
+    }))
   })
 })

--- a/apps/desktop/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.tsx
@@ -14,6 +14,23 @@ import {
 import { useChatRuntimeSelection, useComposerExternalEvents, useMentionableAgents } from './useChatInputRuntime'
 import { usePromptHistory } from './usePromptHistory'
 
+function describeComposerError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportComposerError(userMessage: string, diagnosticMessage: string, error: unknown, addGlobalError: (message: string) => void) {
+  addGlobalError(userMessage)
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${diagnosticMessage}: ${describeComposerError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'chat',
+    })
+  } catch {
+    // Diagnostics reporting must never make a user-facing error worse.
+  }
+}
+
 export function ChatInput() {
   const [input, setInput] = useState('')
   const [attachments, setAttachments] = useState<Attachment[]>([])
@@ -28,6 +45,7 @@ export function ChatInput() {
   const isGenerating = useSessionStore((s) => s.currentView.isGenerating)
   const isAwaitingPermission = useSessionStore((s) => s.currentView.isAwaitingPermission)
   const isAwaitingQuestion = useSessionStore((s) => s.currentView.isAwaitingQuestion)
+  const addGlobalError = useSessionStore((s) => s.addGlobalError)
   const agentMode = useSessionStore((s) => s.agentMode)
   const setAgentMode = useSessionStore((s) => s.setAgentMode)
   const [showModelMenu, setShowModelMenu] = useState(false)
@@ -77,9 +95,14 @@ export function ChatInput() {
         directInvocation.agent || agentMode,
       )
     } catch (err) {
-      console.error('Prompt failed:', err)
+      reportComposerError(
+        t('chat.promptFailed', 'Could not send the prompt. Please try again.'),
+        'Prompt failed',
+        err,
+        addGlobalError,
+      )
     }
-  }, [input, attachments, currentSessionId, agentMode, specialistAgents])
+  }, [input, attachments, currentSessionId, agentMode, specialistAgents, addGlobalError])
 
   const inlineSuggestions = useMemo(() => {
     if (!inlinePicker) return []
@@ -162,9 +185,14 @@ export function ChatInput() {
     try {
       await window.coworkApi.session.abort(currentSessionId)
     } catch (err) {
-      console.error('Abort failed:', err)
+      reportComposerError(
+        t('chat.abortFailed', 'Could not stop generation. Please try again.'),
+        'Abort failed',
+        err,
+        addGlobalError,
+      )
     }
-  }, [currentSessionId])
+  }, [currentSessionId, addGlobalError])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (inlinePicker && inlineSuggestions.length > 0) {
@@ -282,7 +310,7 @@ export function ChatInput() {
       <div className="max-w-[900px] mx-auto">
         <ChatInputAttachments
           attachments={attachments}
-          onRemove={(index) => setAttachments((prev) => prev.filter((_, currentIndex) => currentIndex !== index))}
+          onRemove={(id) => setAttachments((prev) => prev.filter((attachment) => attachment.id !== id))}
         />
 
         {/* Codex-style input card. The drag/drop handlers are a
@@ -384,7 +412,12 @@ export function ChatInput() {
             await window.coworkApi.settings.set({ selectedModelId: modelId })
           } catch (error) {
             setCurrentModel(previousModel)
-            console.error('Failed to save selected model:', error)
+            reportComposerError(
+              t('chat.modelSaveFailed', 'Could not save the selected model. Please try again.'),
+              'Failed to save selected model',
+              error,
+              addGlobalError,
+            )
           }
         }}
       />

--- a/apps/desktop/src/renderer/components/chat/ChatInputAttachments.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputAttachments.test.tsx
@@ -6,12 +6,14 @@ import type { Attachment } from './chat-input-types'
 
 const attachments: Attachment[] = [
   {
+    id: 'attachment-chart',
     filename: 'chart.png',
     mime: 'image/png',
     url: 'data:image/png;base64,abc',
     preview: 'data:image/png;base64,abc',
   },
   {
+    id: 'attachment-brief',
     filename: 'brief.pdf',
     mime: 'application/pdf',
     url: 'data:application/pdf;base64,abc',
@@ -19,7 +21,7 @@ const attachments: Attachment[] = [
 ]
 
 describe('ChatInputAttachments', () => {
-  it('renders image previews, file chips, and removal callbacks by index', async () => {
+  it('renders image previews, file chips, and removal callbacks by stable attachment id', async () => {
     const user = userEvent.setup()
     const onRemove = vi.fn()
 
@@ -29,9 +31,8 @@ describe('ChatInputAttachments', () => {
     expect(screen.getByText('brief.pdf')).toBeTruthy()
     expect(screen.getByText('pdf')).toBeTruthy()
 
-    const removeButtons = screen.getAllByRole('button')
-    await user.click(removeButtons[1])
+    await user.click(screen.getByRole('button', { name: 'Remove brief.pdf' }))
 
-    expect(onRemove).toHaveBeenCalledWith(1)
+    expect(onRemove).toHaveBeenCalledWith('attachment-brief')
   })
 })

--- a/apps/desktop/src/renderer/components/chat/ChatInputAttachments.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputAttachments.tsx
@@ -2,7 +2,7 @@ import type { Attachment } from './chat-input-types'
 
 type ChatInputAttachmentsProps = {
   attachments: Attachment[]
-  onRemove: (index: number) => void
+  onRemove: (id: string) => void
 }
 
 export function ChatInputAttachments({ attachments, onRemove }: ChatInputAttachmentsProps) {
@@ -10,8 +10,8 @@ export function ChatInputAttachments({ attachments, onRemove }: ChatInputAttachm
 
   return (
     <div className="flex gap-2 mb-2.5 flex-wrap">
-      {attachments.map((attachment, index) => (
-        <div key={`${attachment.filename}:${index}`} className="relative group/att">
+      {attachments.map((attachment) => (
+        <div key={attachment.id} className="relative group/att">
           {attachment.preview ? (
             <img
               src={attachment.preview}
@@ -32,7 +32,9 @@ export function ChatInputAttachments({ attachments, onRemove }: ChatInputAttachm
             </div>
           )}
           <button
-            onClick={() => onRemove(index)}
+            type="button"
+            onClick={() => onRemove(attachment.id)}
+            aria-label={`Remove ${attachment.filename}`}
             className="absolute -top-2 -end-2 w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold opacity-0 group-hover/att:opacity-100 cursor-pointer transition-opacity"
             style={{ background: 'var(--color-red)', color: 'var(--color-accent-foreground)' }}
           >

--- a/apps/desktop/src/renderer/components/chat/chat-input-types.ts
+++ b/apps/desktop/src/renderer/components/chat/chat-input-types.ts
@@ -13,6 +13,7 @@ export type InlinePickerState = {
 }
 
 export interface Attachment {
+  id: string
   mime: string
   url: string
   filename: string

--- a/apps/desktop/src/renderer/components/chat/chat-input-utils.ts
+++ b/apps/desktop/src/renderer/components/chat/chat-input-utils.ts
@@ -3,6 +3,22 @@ export { compactDescription } from '../../helpers/format.ts'
 
 const HISTORY_KEY = 'open-cowork-prompt-history'
 const MAX_HISTORY = 10
+let attachmentIdCounter = 0
+
+export function createAttachmentId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  attachmentIdCounter += 1
+  return `attachment-${Date.now().toString(36)}-${attachmentIdCounter.toString(36)}`
+}
+
+export function ensureAttachmentId(attachment: Omit<Attachment, 'id'> & { id?: string }): Attachment {
+  return {
+    ...attachment,
+    id: attachment.id || createAttachmentId(),
+  }
+}
 
 export function resolveDirectAgentInvocation(
   rawInput: string,
@@ -76,12 +92,12 @@ export async function filesToAttachments(files: FileList | File[]): Promise<Atta
   for (const file of Array.from(files)) {
     if (file.size > 20 * 1024 * 1024) continue
     const url = await fileToDataUrl(file)
-    attachments.push({
+    attachments.push(ensureAttachmentId({
       mime: file.type,
       url,
       filename: file.name,
       preview: file.type.startsWith('image/') ? url : undefined,
-    })
+    }))
   }
   return attachments
 }

--- a/apps/desktop/src/renderer/components/chat/composer-events.ts
+++ b/apps/desktop/src/renderer/components/chat/composer-events.ts
@@ -1,5 +1,6 @@
 import type { ChartArtifactSource, SessionArtifactAttachment } from '@open-cowork/shared'
 import type { Attachment } from './chat-input-types'
+import { ensureAttachmentId } from './chat-input-utils.ts'
 
 export const COMPOSER_INSERT_EVENT = 'open-cowork:composer-insert'
 export const COMPOSER_COMPOSE_EVENT = 'open-cowork:composer-compose'
@@ -11,12 +12,12 @@ export type ComposerComposeDetail = {
 }
 
 export function attachmentFromArtifact(payload: SessionArtifactAttachment): Attachment {
-  return {
+  return ensureAttachmentId({
     mime: payload.mime,
     url: payload.url,
     filename: payload.filename,
     preview: payload.mime.startsWith('image/') ? payload.url : undefined,
-  }
+  })
 }
 
 export function dispatchComposerCompose(detail: ComposerComposeDetail) {

--- a/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
+++ b/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
@@ -1,6 +1,6 @@
 import { type Dispatch, type RefObject, type SetStateAction, useEffect, useState } from 'react'
 import type { Attachment, InlinePickerState, MentionableAgent } from './chat-input-types'
-import { formatAgentLabel } from './chat-input-utils'
+import { ensureAttachmentId, formatAgentLabel } from './chat-input-utils.ts'
 import { COMPOSER_COMPOSE_EVENT, COMPOSER_INSERT_EVENT, type ComposerComposeDetail } from './composer-events'
 
 type ModelCatalog = Record<string, Array<{ id: string; label: string; featured?: boolean }>>
@@ -143,6 +143,7 @@ export function useComposerExternalEvents({
           && typeof attachment.mime === 'string'
           && typeof attachment.url === 'string'
           && typeof attachment.filename === 'string')
+          .map((attachment) => ensureAttachmentId(attachment))
         : []
       const replaceText = customEvent.detail?.replaceText === true
 

--- a/tests/composer-events.test.ts
+++ b/tests/composer-events.test.ts
@@ -9,12 +9,11 @@ test('attachmentFromArtifact marks image payloads as previewable composer attach
     filename: 'chart.png',
   })
 
-  assert.deepEqual(attachment, {
-    mime: 'image/png',
-    url: 'data:image/png;base64,abc123',
-    filename: 'chart.png',
-    preview: 'data:image/png;base64,abc123',
-  })
+  assert.match(attachment.id, /^[-a-zA-Z0-9]+$/)
+  assert.equal(attachment.mime, 'image/png')
+  assert.equal(attachment.url, 'data:image/png;base64,abc123')
+  assert.equal(attachment.filename, 'chart.png')
+  assert.equal(attachment.preview, 'data:image/png;base64,abc123')
 })
 
 test('buildChartRerenderPrompt includes format, title, and exact spec JSON', () => {


### PR DESCRIPTION
## Summary
- surface chat composer prompt/abort/model-save IPC failures through the existing global error and diagnostics channels
- give pending composer attachments stable generated ids and remove them by id instead of render index
- update composer event and attachment tests for stable attachment identity

## Validation
- pnpm test
- pnpm test:renderer
- pnpm typecheck
- pnpm lint
- git diff --check