### PR TITLE
Surface session activation failures

### DIFF
--- a/apps/desktop/src/renderer/helpers/loadSessionMessages.test.ts
+++ b/apps/desktop/src/renderer/helpers/loadSessionMessages.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { installRendererTestCoworkApi } from '../test/setup'
+import { useSessionStore } from '../stores/session'
+import { switchToSession } from './loadSessionMessages'
+
+function resetSessionStore() {
+  useSessionStore.setState({
+    sessions: [
+      {
+        id: 'session-1',
+        title: 'Session 1',
+        directory: '/tmp/project',
+        createdAt: '2026-05-08T00:00:00.000Z',
+        updatedAt: '2026-05-08T00:00:00.000Z',
+      },
+    ],
+    currentSessionId: null,
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+}
+
+describe('switchToSession', () => {
+  it('surfaces activation failures through the chat error channel and diagnostics', async () => {
+    const activate = vi.fn(async () => {
+      throw new Error('activation ipc failed')
+    })
+    const reportRendererError = vi.fn()
+    const api = installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError,
+      },
+      session: {
+        activate,
+      },
+    })
+    resetSessionStore()
+
+    await switchToSession('session-1')
+
+    expect(activate).toHaveBeenCalledWith('session-1', undefined)
+    expect(useSessionStore.getState().currentSessionId).toBe('session-1')
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load this thread. Try reopening it.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('activation ipc failed'),
+      view: 'chat',
+    }))
+  })
+})

--- a/apps/desktop/src/renderer/helpers/loadSessionMessages.ts
+++ b/apps/desktop/src/renderer/helpers/loadSessionMessages.ts
@@ -1,4 +1,23 @@
 import { useSessionStore } from '../stores/session'
+import { t } from './i18n'
+
+function describeSessionLoadError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportSessionLoadError(sessionId: string, error: unknown) {
+  const message = t('session.loadFailed', 'Could not load this thread. Try reopening it.')
+  useSessionStore.getState().addGlobalError(message)
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `Failed to load session ${sessionId}: ${describeSessionLoadError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'chat',
+    })
+  } catch {
+    // Diagnostics reporting must never make navigation failure worse.
+  }
+}
 
 // When the user clicks through sessions quickly (A → B → A), each call
 // kicks off an activate IPC + view hydrate. The store keys views by
@@ -21,7 +40,7 @@ export async function switchToSession(sessionId: string, options?: { force?: boo
     store.setSessionView(sessionId, view)
   } catch (err) {
     if (myToken !== activateToken) return
-    console.error('[switchToSession] Failed to load messages:', err)
+    reportSessionLoadError(sessionId, err)
   }
 }
 


### PR DESCRIPTION
## Summary
- route failed session activation / history hydration through the chat global error channel instead of console-only logging
- report failed activation details to renderer diagnostics without disrupting navigation
- add a renderer regression test for failed session activation

## Validation
- pnpm --dir apps/desktop test:renderer -- loadSessionMessages
- pnpm test:renderer
- pnpm typecheck
- pnpm lint
- node --no-warnings --experimental-strip-types --test tests/provider-catalog.test.ts
- pnpm test (first run hit an unrelated provider-catalog flake; direct file rerun and immediate full rerun passed)
- git diff --check