### PR TITLE
Surface task abort failures

### DIFF
--- a/apps/desktop/src/renderer/components/chat/TaskDrillIn.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/TaskDrillIn.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { TaskRun } from '../../stores/session'
+import { useSessionStore, type TaskRun } from '../../stores/session'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { TaskDrillIn } from './TaskDrillIn'
 
@@ -117,10 +117,22 @@ function createTask(overrides: Partial<TaskRun> = {}): TaskRun {
   }
 }
 
-function installTaskApi() {
+function resetSessionStore() {
+  useSessionStore.setState({
+    globalErrors: [],
+  })
+}
+
+function installTaskApi(options: {
+  abortTask?: ReturnType<typeof vi.fn>
+  reportRendererError?: ReturnType<typeof vi.fn>
+} = {}) {
   return installRendererTestCoworkApi({
+    diagnostics: {
+      reportRendererError: options.reportRendererError || vi.fn(),
+    },
     session: {
-      abortTask: vi.fn(async () => true),
+      abortTask: options.abortTask || vi.fn(async () => true),
     },
   })
 }
@@ -128,6 +140,7 @@ function installTaskApi() {
 beforeEach(() => {
   vi.clearAllMocks()
   installTaskApi()
+  resetSessionStore()
   window.localStorage.clear()
 })
 
@@ -166,6 +179,37 @@ describe('TaskDrillIn', () => {
 
     await user.click(screen.getByRole('button', { name: 'Close drawer' }))
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces abort failures through the chat error channel and diagnostics', async () => {
+    const user = userEvent.setup()
+    const abortTask = vi.fn(async () => {
+      throw new Error('runtime rejected abort')
+    })
+    const reportRendererError = vi.fn()
+    const api = installTaskApi({ abortTask, reportRendererError })
+    const rootTask = createTask()
+
+    render(
+      <TaskDrillIn
+        rootTask={rootTask}
+        allTaskRuns={[rootTask]}
+        agentVisuals={{ 'code-reviewer': { color: 'blue', avatar: null } }}
+        rootSessionId="root-session"
+        onClose={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Abort this task' }))
+
+    await waitFor(() => {
+      expect(api.session.abortTask).toHaveBeenCalledWith('root-session', 'child-session-1234567890')
+    })
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not abort this task. Please try again.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('runtime rejected abort'),
+      view: 'task-drill-in',
+    }))
   })
 
   it('supports nested task drill-in navigation and returning to the parent task', async () => {

--- a/apps/desktop/src/renderer/components/chat/TaskDrillIn.tsx
+++ b/apps/desktop/src/renderer/components/chat/TaskDrillIn.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
-import type { TaskRun } from '../../stores/session'
+import { useSessionStore, type TaskRun } from '../../stores/session'
 import { t } from '../../helpers/i18n'
 import { AgentAvatar } from '../agents/AgentAvatar'
 import { agentTone } from '../agents/agent-builder-utils'
@@ -57,6 +57,23 @@ function formatSessionId(id: string | null | undefined) {
   return `${id.slice(0, 8)}…${id.slice(-6)}`
 }
 
+function describeAbortError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportTaskAbortError(rootSessionId: string, taskSessionId: string, error: unknown, addGlobalError: (message: string) => void) {
+  addGlobalError(t('taskDrillIn.abortFailed', 'Could not abort this task. Please try again.'))
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `Failed to abort task ${taskSessionId} from ${rootSessionId}: ${describeAbortError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'task-drill-in',
+    })
+  } catch {
+    // Diagnostics reporting must never make the abort failure worse.
+  }
+}
+
 export const TaskDrillIn = memo(function TaskDrillIn({
   rootTask,
   allTaskRuns,
@@ -65,6 +82,7 @@ export const TaskDrillIn = memo(function TaskDrillIn({
   onClose,
 }: Props) {
   const [abortInFlight, setAbortInFlight] = useState(false)
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
   // Focus history stack. Entry 0 is the root; pushing a nested task navigates
   // deeper, popping (via back) returns to the parent.
   const [focusStack, setFocusStack] = useState<string[]>([rootTask.id])
@@ -111,11 +129,11 @@ export const TaskDrillIn = memo(function TaskDrillIn({
     try {
       await window.coworkApi.session.abortTask(rootSessionId, focused.sourceSessionId)
     } catch (err) {
-      console.error('Failed to abort task:', err)
+      reportTaskAbortError(rootSessionId, focused.sourceSessionId, err, addGlobalError)
     } finally {
       setAbortInFlight(false)
     }
-  }, [rootSessionId, focused.sourceSessionId])
+  }, [rootSessionId, focused.sourceSessionId, addGlobalError])
 
   const canAbort = Boolean(
     rootSessionId && focused.sourceSessionId && (focused.status === 'running' || focused.status === 'queued'),


### PR DESCRIPTION
## Summary
- route failed task-abort IPC calls from Task Drill-In through the global chat error channel
- report abort failure diagnostics with task/root session context
- add a renderer regression test for rejected task-abort IPC

## Validation
- pnpm --dir apps/desktop test:renderer -- TaskDrillIn
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check