### PR TITLE
Surface new thread failures

### DIFF
--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSessionStore } from '../../stores/session'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { NewThreadButton } from './NewThreadButton'
+
+function resetSessionStore() {
+  useSessionStore.setState({
+    sessions: [],
+    currentSessionId: null,
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetSessionStore()
+})
+
+describe('NewThreadButton', () => {
+  it('surfaces session creation failures through the chat error channel and diagnostics', async () => {
+    const user = userEvent.setup()
+    const create = vi.fn(async () => {
+      throw new Error('runtime unavailable')
+    })
+    const reportRendererError = vi.fn()
+    const api = installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError,
+      },
+      session: {
+        create,
+        activate: vi.fn(async () => undefined),
+      },
+    })
+
+    render(<NewThreadButton />)
+
+    await user.click(screen.getByRole('button', { name: 'New Thread' }))
+    await user.click(screen.getByRole('button', { name: /Blank thread/ }))
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(undefined)
+    })
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not create a new thread. Please try again.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('runtime unavailable'),
+      view: 'new-thread',
+    }))
+  })
+
+  it('surfaces project picker failures through the chat error channel and diagnostics', async () => {
+    const user = userEvent.setup()
+    const selectDirectory = vi.fn(async () => {
+      throw new Error('dialog unavailable')
+    })
+    const reportRendererError = vi.fn()
+    const api = installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError,
+      },
+      dialog: {
+        selectDirectory,
+      },
+      session: {
+        create: vi.fn(async () => {
+          throw new Error('should not create')
+        }),
+        activate: vi.fn(async () => undefined),
+      },
+    })
+
+    render(<NewThreadButton />)
+
+    await user.click(screen.getByRole('button', { name: 'New Thread' }))
+    await user.click(screen.getByRole('button', { name: /Open Project/ }))
+
+    await waitFor(() => {
+      expect(selectDirectory).toHaveBeenCalled()
+    })
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not open the project picker. Please try again.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('dialog unavailable'),
+      view: 'new-thread',
+    }))
+  })
+
+  it('keeps the recovery path intact when diagnostics reporting fails', async () => {
+    const user = userEvent.setup()
+    const create = vi.fn(async () => {
+      throw new Error('runtime unavailable')
+    })
+    installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError: vi.fn(() => {
+          throw new Error('diagnostics unavailable')
+        }),
+      },
+      session: {
+        create,
+        activate: vi.fn(async () => undefined),
+      },
+    })
+
+    render(<NewThreadButton />)
+
+    await user.click(screen.getByRole('button', { name: 'New Thread' }))
+    await user.click(screen.getByRole('button', { name: /Blank thread/ }))
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(undefined)
+    })
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not create a new thread. Please try again.')
+    expect(screen.queryByRole('button', { name: /Blank thread/ })).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
@@ -3,9 +3,28 @@ import { useSessionStore } from '../../stores/session'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
 import { t } from '../../helpers/i18n'
 
+function describeThreadError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportThreadError(error: unknown, view: string) {
+  const message = describeThreadError(error)
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${view}: ${message}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'new-thread',
+    })
+  } catch {
+    // Diagnostics are best-effort from an error handler; never let them
+    // mask the original user-facing recovery path.
+  }
+}
+
 export function NewThreadButton({ onClick }: { onClick?: () => void }) {
   const addSession = useSessionStore((s) => s.addSession)
   const setCurrentSession = useSessionStore((s) => s.setCurrentSession)
+  const addGlobalError = useSessionStore((s) => s.addGlobalError)
   const [showMenu, setShowMenu] = useState(false)
 
   const createThread = async (directory?: string) => {
@@ -16,7 +35,8 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
       await window.coworkApi.session.activate(session.id)
       onClick?.()
     } catch (err) {
-      console.error('Failed to create session:', err)
+      addGlobalError(t('newThread.createFailed', 'Could not create a new thread. Please try again.'))
+      reportThreadError(err, `Failed to create session${directory ? ` for ${directory}` : ''}`)
     }
     setShowMenu(false)
   }
@@ -56,9 +76,15 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
             <div className="border-t" style={{ borderColor: 'var(--color-border-subtle)' }} />
             <button
               onClick={async () => {
-                const dir = await window.coworkApi.dialog.selectDirectory()
-                if (dir) createThread(dir)
-                else setShowMenu(false)
+                try {
+                  const dir = await window.coworkApi.dialog.selectDirectory()
+                  if (dir) createThread(dir)
+                  else setShowMenu(false)
+                } catch (err) {
+                  addGlobalError(t('newThread.projectPickerFailed', 'Could not open the project picker. Please try again.'))
+                  reportThreadError(err, 'Failed to open project picker')
+                  setShowMenu(false)
+                }
               }}
               className="w-full text-start px-3 py-2.5 text-[12px] text-text hover:bg-surface-hover cursor-pointer transition-colors flex items-center gap-2.5"
             >


### PR DESCRIPTION
## Summary
- route new-thread session creation failures through the shared chat error channel
- report renderer diagnostics for failed thread creation and project picker failures
- add focused renderer coverage for both failure paths

## Validation
- pnpm --dir apps/desktop test:renderer -- NewThreadButton
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check