### PR TITLE
Surface global action failures

### DIFF
--- a/apps/desktop/src/renderer/hooks/useAppGlobalEvents.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useAppGlobalEvents.test.tsx
@@ -1,0 +1,174 @@
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppView } from '../app-types'
+import { useSessionStore } from '../stores/session'
+import { installRendererTestCoworkApi } from '../test/setup'
+import { useAppGlobalEvents } from './useAppGlobalEvents'
+
+type MenuActionCallback = (action: 'new-thread' | 'command-palette' | 'search' | 'toggle-sidebar' | 'export') => void
+
+function resetSessionStore() {
+  useSessionStore.setState({
+    sessions: [],
+    currentSessionId: null,
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+  useSessionStore.getState().setSessions([
+    {
+      id: 'session-1',
+      title: 'Session 1',
+      directory: '/tmp/project',
+      createdAt: '2026-05-08T00:00:00.000Z',
+      updatedAt: '2026-05-08T00:00:00.000Z',
+    },
+  ])
+  useSessionStore.getState().setCurrentSession('session-1')
+}
+
+function installGlobalEventsApi(options: {
+  revert?: ReturnType<typeof vi.fn>
+  unrevert?: ReturnType<typeof vi.fn>
+  exportSession?: ReturnType<typeof vi.fn>
+  reportRendererError?: ReturnType<typeof vi.fn>
+  onMenuAction?: (callback: MenuActionCallback) => void
+} = {}) {
+  return installRendererTestCoworkApi({
+    diagnostics: {
+      reportRendererError: options.reportRendererError || vi.fn(),
+    },
+    session: {
+      activate: vi.fn(async () => ({
+        messages: [],
+        toolCalls: [],
+        taskRuns: [],
+        compactions: [],
+        pendingApprovals: [],
+        pendingQuestions: [],
+        errors: [],
+        todos: [],
+        executionPlan: [],
+        sessionCost: 0,
+        sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+        lastInputTokens: 0,
+        contextState: 'idle',
+        compactionCount: 0,
+        lastCompactedAt: null,
+        activeAgent: null,
+        lastItemWasTool: false,
+        revision: 0,
+        lastEventAt: 0,
+        isGenerating: false,
+        isAwaitingPermission: false,
+        isAwaitingQuestion: false,
+      })),
+      revert: options.revert || vi.fn(async () => true),
+      unrevert: options.unrevert || vi.fn(async () => true),
+      export: options.exportSession || vi.fn(async () => null),
+    },
+    on: {
+      menuAction: vi.fn((callback: MenuActionCallback) => {
+        options.onMenuAction?.(callback)
+        return vi.fn()
+      }),
+      menuNavigate: vi.fn(() => vi.fn()),
+    },
+  })
+}
+
+function Harness({ view = 'chat' }: { view?: AppView }) {
+  useAppGlobalEvents({
+    runtimeReady: true,
+    view,
+    currentSessionId: 'session-1',
+    toggleSidebar: vi.fn(),
+    createAndActivateSession: vi.fn(async () => null),
+    openSidebarSearch: vi.fn(),
+    openSidebarSettings: vi.fn(),
+    setView: vi.fn(),
+    setAuthenticated: vi.fn(),
+    setShowCommandPalette: vi.fn(),
+  })
+  return null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetSessionStore()
+})
+
+describe('useAppGlobalEvents', () => {
+  it('surfaces failed keyboard session reverts through the chat error channel and diagnostics', async () => {
+    const revert = vi.fn(async () => {
+      throw new Error('runtime rejected revert')
+    })
+    const reportRendererError = vi.fn()
+    const api = installGlobalEventsApi({ revert, reportRendererError })
+    render(<Harness />)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true }))
+
+    await waitFor(() => {
+      expect(revert).toHaveBeenCalledWith('session-1')
+    })
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not revert this session. Please try again.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('runtime rejected revert'),
+      view: 'global-actions',
+    }))
+  })
+
+  it('surfaces false unrevert responses and keeps diagnostics best-effort', async () => {
+    const unrevert = vi.fn(async () => false)
+    installGlobalEventsApi({
+      unrevert,
+      reportRendererError: vi.fn(() => {
+        throw new Error('diagnostics unavailable')
+      }),
+    })
+    render(<Harness />)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', shiftKey: true, metaKey: true }))
+
+    await waitFor(() => {
+      expect(unrevert).toHaveBeenCalledWith('session-1')
+    })
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not unrevert this session. Please try again.')
+  })
+
+  it('surfaces failed menu exports through the chat error channel and diagnostics', async () => {
+    let menuAction: MenuActionCallback | null = null
+    const exportSession = vi.fn(async () => {
+      throw new Error('export failed')
+    })
+    const reportRendererError = vi.fn()
+    const api = installGlobalEventsApi({
+      exportSession,
+      reportRendererError,
+      onMenuAction: (callback) => {
+        menuAction = callback
+      },
+    })
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(menuAction).not.toBeNull()
+    })
+    const callback = menuAction as MenuActionCallback | null
+    if (!callback) throw new Error('menu action callback was not registered')
+    callback('export')
+
+    await waitFor(() => {
+      expect(exportSession).toHaveBeenCalledWith('session-1')
+    })
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not export this thread. Please try again.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('export failed'),
+      view: 'global-actions',
+    }))
+  })
+})

--- a/apps/desktop/src/renderer/hooks/useAppGlobalEvents.ts
+++ b/apps/desktop/src/renderer/hooks/useAppGlobalEvents.ts
@@ -2,6 +2,7 @@ import { useEffect, type Dispatch, type SetStateAction } from 'react'
 import type { SessionInfo } from '@open-cowork/shared'
 
 import type { AppView } from '../app-types'
+import { t } from '../helpers/i18n'
 import { loadSessionMessages } from '../helpers/loadSessionMessages'
 import { useSessionStore } from '../stores/session'
 
@@ -16,6 +17,69 @@ type UseAppGlobalEventsOptions = {
   setView: (view: AppView) => void
   setAuthenticated: (authenticated: boolean) => void
   setShowCommandPalette: Dispatch<SetStateAction<boolean>>
+}
+
+function describeGlobalActionError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportGlobalActionError(userMessage: string, diagnosticMessage: string, error: unknown) {
+  useSessionStore.getState().addGlobalError(userMessage)
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${diagnosticMessage}: ${describeGlobalActionError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'global-actions',
+    })
+  } catch {
+    // Diagnostics are best-effort from action error handlers.
+  }
+}
+
+async function revertCurrentSession(sessionId: string) {
+  const userMessage = t('globalActions.revertFailed', 'Could not revert this session. Please try again.')
+  try {
+    const ok = await window.coworkApi.session.revert(sessionId)
+    if (!ok) {
+      reportGlobalActionError(userMessage, `Failed to revert session ${sessionId}`, new Error('session.revert returned false'))
+      return
+    }
+    await loadSessionMessages(sessionId, { force: true })
+  } catch (err) {
+    reportGlobalActionError(userMessage, `Failed to revert session ${sessionId}`, err)
+  }
+}
+
+async function unrevertCurrentSession(sessionId: string) {
+  const userMessage = t('globalActions.unrevertFailed', 'Could not unrevert this session. Please try again.')
+  try {
+    const ok = await window.coworkApi.session.unrevert(sessionId)
+    if (!ok) {
+      reportGlobalActionError(userMessage, `Failed to unrevert session ${sessionId}`, new Error('session.unrevert returned false'))
+      return
+    }
+    await loadSessionMessages(sessionId, { force: true })
+  } catch (err) {
+    reportGlobalActionError(userMessage, `Failed to unrevert session ${sessionId}`, err)
+  }
+}
+
+async function exportCurrentSession(sessionId: string) {
+  try {
+    const md = await window.coworkApi.session.export(sessionId)
+    if (!md) return
+    const blob = new Blob([md], { type: 'text/markdown' })
+    const anchor = document.createElement('a')
+    anchor.href = URL.createObjectURL(blob)
+    anchor.download = 'thread.md'
+    anchor.click()
+  } catch (err) {
+    reportGlobalActionError(
+      t('globalActions.exportFailed', 'Could not export this thread. Please try again.'),
+      `Failed to export session ${sessionId}`,
+      err,
+    )
+  }
 }
 
 export function useAppGlobalEvents({
@@ -54,9 +118,7 @@ export function useAppGlobalEvents({
         const sid = useSessionStore.getState().currentSessionId
         if (sid && !useSessionStore.getState().currentView.isGenerating) {
           e.preventDefault()
-          window.coworkApi.session.revert(sid).then((ok: boolean) => {
-            if (ok) loadSessionMessages(sid, { force: true })
-          }).catch((err) => console.error('Failed to revert session:', err))
+          void revertCurrentSession(sid)
         }
       }
 
@@ -64,9 +126,7 @@ export function useAppGlobalEvents({
         const sid = useSessionStore.getState().currentSessionId
         if (sid && !useSessionStore.getState().currentView.isGenerating) {
           e.preventDefault()
-          window.coworkApi.session.unrevert(sid).then((ok: boolean) => {
-            if (ok) loadSessionMessages(sid, { force: true })
-          }).catch((err) => console.error('Failed to unrevert session:', err))
+          void unrevertCurrentSession(sid)
         }
       }
 
@@ -120,14 +180,7 @@ export function useAppGlobalEvents({
       } else if (action === 'export') {
         const sid = useSessionStore.getState().currentSessionId
         if (sid) {
-          window.coworkApi.session.export(sid).then((md) => {
-            if (!md) return
-            const blob = new Blob([md], { type: 'text/markdown' })
-            const anchor = document.createElement('a')
-            anchor.href = URL.createObjectURL(blob)
-            anchor.download = 'thread.md'
-            anchor.click()
-          }).catch((err) => console.error('Failed to export session:', err))
+          void exportCurrentSession(sid)
         }
       }
     })


### PR DESCRIPTION
## Summary
- route keyboard revert/unrevert failures through the shared chat error channel
- route menu export failures through the same error and diagnostics path
- add renderer coverage for rejected IPC, false return values, and diagnostics failures

## Validation
- pnpm --dir apps/desktop test:renderer -- useAppGlobalEvents
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check