### PR TITLE
Surface Pulse thread failures

### DIFF
--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -272,6 +272,9 @@ function resetSessionStore() {
 function installPulseApi(options: {
   dashboardSummary?: () => Promise<DashboardSummary>
   selectDirectory?: () => Promise<string | null>
+  createSession?: ReturnType<typeof vi.fn>
+  activateSession?: ReturnType<typeof vi.fn>
+  reportRendererError?: ReturnType<typeof vi.fn>
 } = {}) {
   return installRendererTestCoworkApi({
     runtime: {
@@ -306,16 +309,17 @@ function installPulseApi(options: {
     },
     diagnostics: {
       perf: vi.fn(async () => perfSnapshot),
+      reportRendererError: options.reportRendererError || vi.fn(),
     },
     session: {
-      create: vi.fn(async (directory?: string) => ({
+      create: options.createSession || vi.fn(async (directory?: string) => ({
         id: directory ? 'session-directory' : 'session-new',
         title: directory ? 'Directory thread' : 'New thread',
         directory: directory ?? null,
         createdAt: '2026-05-07T00:00:00.000Z',
         updatedAt: '2026-05-07T00:00:00.000Z',
       })),
-      activate: vi.fn(async () => ({
+      activate: options.activateSession || vi.fn(async () => ({
         messages: [],
         toolCalls: [],
         taskRuns: [],
@@ -421,6 +425,49 @@ describe('PulsePage', () => {
     expect(api.session.activate).toHaveBeenLastCalledWith('session-directory')
     expect(useSessionStore.getState().currentSessionId).toBe('session-directory')
     expect(onOpenThread).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces thread creation failures through the chat error channel and diagnostics', async () => {
+    const user = userEvent.setup()
+    const createSession = vi.fn(async () => {
+      throw new Error('runtime offline')
+    })
+    const reportRendererError = vi.fn()
+    const api = installPulseApi({ createSession, reportRendererError })
+
+    render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
+    await screen.findByText('Ready')
+
+    await user.click(screen.getByRole('button', { name: /New thread/ }))
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith(undefined))
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not create a thread from Pulse. Please try again.')
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('runtime offline'),
+      view: 'pulse',
+    }))
+  })
+
+  it('clears a partially selected thread when Pulse activation fails', async () => {
+    const user = userEvent.setup()
+    const activateSession = vi.fn(async () => {
+      throw new Error('activation failed')
+    })
+    installPulseApi({
+      activateSession,
+      reportRendererError: vi.fn(() => {
+        throw new Error('diagnostics unavailable')
+      }),
+    })
+
+    render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
+    await screen.findByText('Ready')
+
+    await user.click(screen.getByRole('button', { name: /New thread/ }))
+
+    await waitFor(() => expect(activateSession).toHaveBeenCalledWith('session-new'))
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not create a thread from Pulse. Please try again.')
+    expect(useSessionStore.getState().currentSessionId).toBeNull()
   })
 
   it('persists range changes and surfaces dashboard load failures', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -29,9 +29,26 @@ import {
 import { PulseSidebar } from './PulseSidebar.tsx'
 import { usePulseDiagnostics } from './usePulseDiagnostics.ts'
 
+function describePulseThreadError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportPulseThreadError(error: unknown, directory?: string) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `Failed to create Pulse thread${directory ? ` for ${directory}` : ''}: ${describePulseThreadError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'pulse',
+    })
+  } catch {
+    // Diagnostics are best-effort from an action error handler.
+  }
+}
+
 export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => void; brandName: string }) {
   const addSession = useSessionStore((s) => s.addSession)
   const setCurrentSession = useSessionStore((s) => s.setCurrentSession)
+  const addGlobalError = useSessionStore((s) => s.addGlobalError)
   const busySessions = useSessionStore((s) => s.busySessions)
   const mcpConnections = useSessionStore((s) => s.mcpConnections)
   const {
@@ -169,7 +186,8 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
       await window.coworkApi.session.activate(session.id)
       onOpenThread()
     } catch (err) {
-      console.error('Failed to create thread:', err)
+      addGlobalError(t('pulse.createThreadFailed', 'Could not create a thread from Pulse. Please try again.'))
+      reportPulseThreadError(err, directory)
       if (sessionId) setCurrentSession(null)
     }
   }


### PR DESCRIPTION
## Summary
- route Pulse action-card thread creation and activation failures through the shared chat error channel
- report Pulse thread creation diagnostics without letting diagnostics failures break recovery
- add renderer coverage for create rejection, activation rejection, and cleanup of partially selected sessions

## Validation
- pnpm --dir apps/desktop test:renderer -- PulsePage
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check