### PR TITLE
Surface setup load failures

### DIFF
--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EffectiveAppSettings, ProviderDescriptor } from '@open-cowork/shared'
+import { useSessionStore } from '../stores/session'
 import { installRendererTestCoworkApi } from '../test/setup'
 import { SetupScreen } from './SetupScreen'
 
@@ -67,6 +68,24 @@ const providers: ProviderDescriptor[] = [
   },
 ]
 
+function resetSessionStore() {
+  useSessionStore.setState({
+    sessions: [],
+    currentSessionId: null,
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetSessionStore()
+})
+
 describe('SetupScreen', () => {
   it('loads selected-provider credentials through the scoped credential IPC', async () => {
     const get = vi.fn(async () => settings())
@@ -92,6 +111,70 @@ describe('SetupScreen', () => {
     await waitFor(() => expect(apiKeyInput).toHaveValue('sk-or-scoped'))
     expect(get).toHaveBeenCalledTimes(1)
     expect(getProviderCredentials).toHaveBeenCalledWith('openrouter')
+  })
+
+  it('surfaces initial setup settings load failures through the chat error channel and diagnostics', async () => {
+    const get = vi.fn(async () => {
+      throw new Error('settings unavailable')
+    })
+    const reportRendererError = vi.fn()
+    const api = installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError,
+      },
+      settings: {
+        get,
+        getProviderCredentials: vi.fn(async () => ({})),
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providers}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load setup settings. Please try again.')
+    })
+    expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('settings unavailable'),
+      view: 'setup',
+    }))
+  })
+
+  it('surfaces selected-provider credential load failures and tolerates diagnostics failures', async () => {
+    installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError: vi.fn(() => {
+          throw new Error('diagnostics unavailable')
+        }),
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(async () => {
+          throw new Error('credentials unavailable')
+        }),
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providers}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load provider credentials. Please try again.')
+    })
   })
 
   it('does not overwrite setup credential edits when scoped credential loading resolves late', async () => {

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -3,6 +3,7 @@ import type { ProviderDescriptor } from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
 import { mergeFetchedProviderCredentials } from './provider/credential-merge'
 import { ProviderAuthControls } from './provider/ProviderAuthControls'
+import { useSessionStore } from '../stores/session'
 
 interface Props {
   brandName: string
@@ -11,6 +12,22 @@ interface Props {
   defaultProviderId: string | null
   defaultModelId: string | null
   onComplete: () => void
+}
+
+function describeSetupLoadError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportSetupLoadError(error: unknown, scope: string) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${scope}: ${describeSetupLoadError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'setup',
+    })
+  } catch {
+    // Diagnostics are best-effort from a setup recovery path.
+  }
 }
 
 export function SetupScreen({
@@ -28,6 +45,7 @@ export function SetupScreen({
   const [loadedCredentialProviders, setLoadedCredentialProviders] = useState<Set<string>>(() => new Set())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const addGlobalError = useSessionStore((s) => s.addGlobalError)
   const dirtyProviderCredentialKeys = useRef<Record<string, Set<string>>>({})
   const providerSelectionEdited = useRef(false)
 
@@ -74,10 +92,12 @@ export function SetupScreen({
         setLoadedCredentialProviders((current) => new Set(current).add(initialProviderId))
       }
     }).catch((err) => {
-      console.error('Failed to load setup settings:', err)
+      if (cancelled) return
+      addGlobalError(t('setup.loadFailed', 'Could not load setup settings. Please try again.'))
+      reportSetupLoadError(err, 'Failed to load setup settings')
     })
     return () => { cancelled = true }
-  }, [defaultModelId, defaultProviderId, providers])
+  }, [addGlobalError, defaultModelId, defaultProviderId, providers])
 
   const selectedProvider = useMemo(
     () => providers.find((provider) => provider.id === providerId) || null,
@@ -99,10 +119,12 @@ export function SetupScreen({
       mergeLoadedProviderCredentials(providerId, credentials)
       setLoadedCredentialProviders((current) => new Set(current).add(providerId))
     }).catch((err) => {
-      console.error('Failed to load provider credentials:', err)
+      if (cancelled) return
+      addGlobalError(t('setup.credentialsLoadFailed', 'Could not load provider credentials. Please try again.'))
+      reportSetupLoadError(err, `Failed to load provider credentials for ${providerId}`)
     })
     return () => { cancelled = true }
-  }, [loadedCredentialProviders, providerId])
+  }, [addGlobalError, loadedCredentialProviders, providerId])
 
   const selectedCredentials = providerId ? (providerCredentials[providerId] || {}) : {}
   const requiredCredentials = selectedProvider?.credentials.filter((credential) => credential.required !== false) || []


### PR DESCRIPTION
## Summary
- route first-run setup settings load failures through the global error channel
- route selected-provider credential load failures through the same user-visible recovery path
- report setup load failures to renderer diagnostics best-effort, without letting diagnostics failures mask recovery

## Validation
- pnpm --dir apps/desktop test:renderer -- SetupScreen
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check