### PR TITLE
Surface capability credential load failures

### DIFF
--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -107,9 +107,13 @@ function renderCapabilitiesPage(overrides: {
   customMcps?: CustomMcpConfig[]
   customSkills?: CustomSkillConfig[]
   integrationCredentials?: Record<string, string>
+  integrationCredentialsError?: Error
+  settingsGetError?: Error
+  reportRendererError?: ReturnType<typeof vi.fn>
 } = {}) {
   useSessionStore.setState({
     currentSessionId: 'session-1',
+    globalErrors: [],
     sessions: [
       {
         id: 'session-1',
@@ -128,31 +132,38 @@ function renderCapabilitiesPage(overrides: {
   const listMcps = vi.fn(async () => overrides.customMcps ?? [customMcp])
   const listSkills = vi.fn(async () => overrides.customSkills ?? [customSkill])
   const listRuntimeTools = vi.fn(async () => runtimeTools)
-  const get = vi.fn(async () => ({
-    selectedProviderId: null,
-    selectedModelId: null,
-    providerCredentials: {},
-    integrationCredentials: {
-      charts: overrides.integrationCredentials ?? { apiKey: 'ck-stored' },
-    },
-    integrationEnabled: {},
-    enableBash: false,
-    enableFileWrite: false,
-    runtimeToolingBridgeEnabled: true,
-    automationLaunchAtLogin: false,
-    automationRunInBackground: false,
-    automationDesktopNotifications: true,
-    automationQuietHoursStart: null,
-    automationQuietHoursEnd: null,
-    defaultAutomationAutonomyPolicy: 'review-first',
-    defaultAutomationExecutionMode: 'scoped_execution',
-    effectiveProviderId: null,
-    effectiveModel: null,
-  }))
-  const getIntegrationCredentials = vi.fn(async () => overrides.integrationCredentials ?? { apiKey: 'ck-stored' })
+  const get = vi.fn(async () => {
+    if (overrides.settingsGetError) throw overrides.settingsGetError
+    return {
+      selectedProviderId: null,
+      selectedModelId: null,
+      providerCredentials: {},
+      integrationCredentials: {
+        charts: overrides.integrationCredentials ?? { apiKey: 'ck-stored' },
+      },
+      integrationEnabled: {},
+      enableBash: false,
+      enableFileWrite: false,
+      runtimeToolingBridgeEnabled: true,
+      automationLaunchAtLogin: false,
+      automationRunInBackground: false,
+      automationDesktopNotifications: true,
+      automationQuietHoursStart: null,
+      automationQuietHoursEnd: null,
+      defaultAutomationAutonomyPolicy: 'review-first',
+      defaultAutomationExecutionMode: 'scoped_execution',
+      effectiveProviderId: null,
+      effectiveModel: null,
+    }
+  })
+  const getIntegrationCredentials = vi.fn(async () => {
+    if (overrides.integrationCredentialsError) throw overrides.integrationCredentialsError
+    return overrides.integrationCredentials ?? { apiKey: 'ck-stored' }
+  })
   const set = vi.fn(async (updates) => ({ ...(await get()), ...updates }))
   const unsubscribeRuntimeReady = vi.fn()
   const runtimeReady = vi.fn(() => unsubscribeRuntimeReady)
+  const reportRendererError = overrides.reportRendererError || vi.fn()
 
   installRendererTestCoworkApi({
     capabilities: {
@@ -176,6 +187,9 @@ function renderCapabilitiesPage(overrides: {
       getIntegrationCredentials,
       set,
     },
+    diagnostics: {
+      reportRendererError,
+    },
     on: {
       runtimeReady,
     },
@@ -196,6 +210,7 @@ function renderCapabilitiesPage(overrides: {
     listSkills,
     listRuntimeTools,
     getIntegrationCredentials,
+    reportRendererError,
     settingsSet: set,
     runtimeReady,
     unsubscribeRuntimeReady,
@@ -261,6 +276,44 @@ describe('CapabilitiesPage', () => {
       name: 'charts-agent',
       toolIds: ['charts'],
       skillNames: [],
+    }))
+  })
+
+  it('surfaces stored integration credential load failures through the chat error channel and diagnostics', async () => {
+    const user = userEvent.setup()
+    const api = renderCapabilitiesPage({
+      integrationCredentialsError: new Error('keychain unavailable'),
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load stored integration credentials. Please try again.')
+    })
+    expect(api.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('keychain unavailable'),
+      view: 'capabilities',
+    }))
+  })
+
+  it('surfaces integration readiness failures and tolerates diagnostics failures', async () => {
+    const user = userEvent.setup()
+    const reportRendererError = vi.fn(() => {
+      throw new Error('diagnostics unavailable')
+    })
+    renderCapabilitiesPage({
+      settingsGetError: new Error('settings unavailable'),
+      reportRendererError,
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not verify integration credential readiness. Please try again.')
+    })
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('settings unavailable'),
+      view: 'capabilities',
     }))
   })
 

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -3,6 +3,23 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { CapabilityTool, RuntimeContextOptions } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
+import { useSessionStore } from '../../stores/session'
+
+function describeCapabilityError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportCapabilityError(error: unknown, scope: string) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${scope}: ${describeCapabilityError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'capabilities',
+    })
+  } catch {
+    // Diagnostics are best-effort from a capabilities recovery path.
+  }
+}
 
 export function StatBox({ label, value }: { label: string; value: string }) {
   return (
@@ -121,6 +138,7 @@ export function ToolCredentialsCard({
   const [saving, setSaving] = useState(false)
   const [savedAt, setSavedAt] = useState<number | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
 
   useEffect(() => {
     let cancelled = false
@@ -131,10 +149,12 @@ export function ToolCredentialsCard({
         setDrafts({})
       })
       .catch((err) => {
-        console.error('Failed to load stored integration credentials:', err)
+        if (cancelled) return
+        addGlobalError(t('capabilities.credentialsLoadFailed', 'Could not load stored integration credentials. Please try again.'))
+        reportCapabilityError(err, `Failed to load stored integration credentials for ${integrationId}`)
       })
     return () => { cancelled = true }
-  }, [integrationId])
+  }, [addGlobalError, integrationId])
 
   const dirty = Object.keys(drafts).some((key) => drafts[key] !== undefined && drafts[key] !== '')
 
@@ -245,6 +265,7 @@ export function ToolIntegrationToggleCard({
   const [localEnabled, setLocalEnabled] = useState<boolean | undefined>(enabled)
   const [hasStoredCredentials, setHasStoredCredentials] = useState(false)
   const mountedRef = useRef(true)
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
 
   useEffect(() => {
     setLocalEnabled(enabled)
@@ -258,10 +279,12 @@ export function ToolIntegrationToggleCard({
       const entries = settings.integrationCredentials?.[integrationId] || {}
       setHasStoredCredentials(Object.values(entries).some((value) => typeof value === 'string' && value.length > 0))
     }).catch((err) => {
-      console.error('Failed to load integration credential readiness:', err)
+      if (cancelled) return
+      addGlobalError(t('capabilities.credentialReadinessLoadFailed', 'Could not verify integration credential readiness. Please try again.'))
+      reportCapabilityError(err, `Failed to load integration credential readiness for ${integrationId}`)
     })
     return () => { cancelled = true }
-  }, [integrationId])
+  }, [addGlobalError, integrationId])
 
   useEffect(() => () => { mountedRef.current = false }, [])
 


### PR DESCRIPTION
## Summary
- route Capabilities stored integration credential load failures through the global error channel
- route integration credential readiness failures through the same user-visible recovery path
- report both paths to renderer diagnostics best-effort and cover them with renderer tests

## Validation
- pnpm --dir apps/desktop test:renderer -- CapabilitiesPage
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check