### PR TITLE
Surface settings load failures

### DIFF
--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EffectiveAppSettings, PublicAppConfig } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
+import { useSessionStore } from '../../stores/session'
 import { SettingsPanel } from './SettingsPanel'
 
 function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSettings {
@@ -84,7 +85,107 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
+beforeEach(() => {
+  vi.clearAllMocks()
+  useSessionStore.setState({
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+})
+
 describe('SettingsPanel', () => {
+  it('surfaces initial settings load failures through the chat error channel and diagnostics', async () => {
+    const reportRendererError = vi.fn()
+    installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError,
+      },
+      settings: {
+        get: vi.fn(async () => {
+          throw new Error('settings unavailable')
+        }),
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load settings. Please try again.')
+    })
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('settings unavailable'),
+      view: 'settings',
+    }))
+  })
+
+  it('surfaces provider credential load failures through the chat error channel and diagnostics', async () => {
+    const reportRendererError = vi.fn()
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      diagnostics: {
+        reportRendererError,
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(async () => {
+          throw new Error('keychain unavailable')
+        }),
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load provider credentials. Please try again.')
+    })
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('keychain unavailable'),
+      view: 'settings',
+    }))
+  })
+
+  it('surfaces provider credential reload failures after saving settings', async () => {
+    const user = userEvent.setup()
+    const reportRendererError = vi.fn()
+    const getProviderCredentials = vi.fn()
+      .mockResolvedValueOnce({ apiKey: 'sk-or-initial' })
+      .mockRejectedValueOnce(new Error('reload unavailable'))
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      diagnostics: {
+        reportRendererError,
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials,
+        set: vi.fn(async (updates: Partial<EffectiveAppSettings>) => settings(updates)),
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await waitFor(() => expect(getProviderCredentials).toHaveBeenCalledTimes(1))
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Settings saved, but provider credentials could not be reloaded. Please reopen Settings.')
+    })
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('reload unavailable'),
+      view: 'settings',
+    }))
+  })
+
   it('persists the developer config bridge permission toggle', async () => {
     const settingsSet = vi.mocked(window.coworkApi.settings.set)
     const user = userEvent.setup()

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -11,6 +11,7 @@ import {
   saveAppearancePreferences,
   type AppearancePreferences,
 } from '../../helpers/theme'
+import { useSessionStore } from '../../stores/session'
 import { mergeFetchedProviderCredentials, stripMaskedProviderCredentials } from '../provider/credential-merge'
 import { AppearancePreview } from './SettingsAppearancePanel'
 import { AutomationSettingsPanel } from './SettingsAutomationPanel'
@@ -20,6 +21,22 @@ import { PermissionsPanel } from './SettingsPermissionsPanel'
 import { StoragePanel } from './SettingsStoragePanel'
 
 type SettingsTab = 'appearance' | 'models' | 'permissions' | 'automations' | 'storage'
+
+function describeSettingsPanelError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportSettingsPanelError(error: unknown, scope: string) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${scope}: ${describeSettingsPanelError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'settings',
+    })
+  } catch {
+    // Diagnostics are best-effort from a settings recovery path.
+  }
+}
 
 function stripMaskedSettingsCredentials(settings: EffectiveAppSettings): EffectiveAppSettings {
   return {
@@ -39,6 +56,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
   const [storageStats, setStorageStats] = useState<SandboxStorageStats | null>(null)
   const [runningCleanup, setRunningCleanup] = useState<SandboxCleanupResult['mode'] | null>(null)
   const [lastCleanup, setLastCleanup] = useState<SandboxCleanupResult | null>(null)
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
   const dirtyProviderCredentialKeys = useRef<Record<string, Set<string>>>({})
 
   const markProviderCredentialDirty = (providerId: string, key: string) => {
@@ -62,10 +80,11 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
       })
       .catch((err) => {
         if (cancelled) return
-        console.error('Failed to load settings panel:', err)
+        addGlobalError(t('settings.loadFailed', 'Could not load settings. Please try again.'))
+        reportSettingsPanelError(err, 'Failed to load settings panel')
       })
     return () => { cancelled = true }
-  }, [])
+  }, [addGlobalError])
 
   useEffect(() => {
     const providerId = settings?.effectiveProviderId
@@ -88,10 +107,12 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
         }
       })
     }).catch((err) => {
-      console.error('Failed to load provider credentials:', err)
+      if (cancelled) return
+      addGlobalError(t('settings.providerCredentialsLoadFailed', 'Could not load provider credentials. Please try again.'))
+      reportSettingsPanelError(err, `Failed to load provider credentials for ${providerId}`)
     })
     return () => { cancelled = true }
-  }, [settings?.effectiveProviderId])
+  }, [addGlobalError, settings?.effectiveProviderId])
 
   const tabs = useMemo(
     () => [
@@ -137,7 +158,8 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
             },
           }
         } catch (error) {
-          console.error('Failed to reload provider credentials after saving settings:', error)
+          addGlobalError(t('settings.providerCredentialsReloadFailed', 'Settings saved, but provider credentials could not be reloaded. Please reopen Settings.'))
+          reportSettingsPanelError(error, `Failed to reload provider credentials after saving settings for ${savedSettings.effectiveProviderId}`)
         }
       }
       setSettings(next)


### PR DESCRIPTION
## Summary
- route Settings panel load failures through the global error channel and diagnostics
- route scoped provider credential load failures through the same recovery path
- surface post-save provider credential refresh failures instead of silently logging them
- cover all three paths with renderer regression tests

## Validation
- pnpm --dir apps/desktop test:renderer -- SettingsPanel
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check