### PR TITLE
Surface remaining renderer load failures

### DIFF
--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   AutomationDetail,
   AutomationDraft,
@@ -9,6 +9,7 @@ import type {
   AutomationSummary,
 } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
+import { useSessionStore } from '../../stores/session'
 import { AutomationsPage } from './AutomationsPage'
 
 function automation(overrides: Partial<AutomationSummary> = {}): AutomationSummary {
@@ -75,6 +76,8 @@ function renderAutomationsPage(options: {
   initialPayload?: AutomationListPayload
   selectedDetail?: AutomationDetail
   createdAutomation?: AutomationDetail
+  settingsGetError?: Error
+  reportRendererError?: ReturnType<typeof vi.fn>
 } = {}) {
   const currentPayload = options.initialPayload ?? payload({
     automations: [automation()],
@@ -95,6 +98,7 @@ function renderAutomationsPage(options: {
   const unsubscribeAutomationUpdated = vi.fn()
   const automationUpdated = vi.fn(() => unsubscribeAutomationUpdated)
   const onOpenThread = vi.fn()
+  const reportRendererError = options.reportRendererError || vi.fn()
 
   installRendererTestCoworkApi({
     automation: {
@@ -141,26 +145,32 @@ function renderAutomationsPage(options: {
     agents: {
       list: vi.fn(async () => []),
     },
+    diagnostics: {
+      reportRendererError,
+    },
     settings: {
-      get: vi.fn(async () => ({
-        selectedProviderId: null,
-        selectedModelId: null,
-        providerCredentials: {},
-        integrationCredentials: {},
-        integrationEnabled: {},
-        enableBash: false,
-        enableFileWrite: false,
-        runtimeToolingBridgeEnabled: true,
-        automationLaunchAtLogin: false,
-        automationRunInBackground: false,
-        automationDesktopNotifications: true,
-        automationQuietHoursStart: null,
-        automationQuietHoursEnd: null,
-        defaultAutomationAutonomyPolicy: 'review-first',
-        defaultAutomationExecutionMode: 'planning_only',
-        effectiveProviderId: null,
-        effectiveModel: null,
-      })),
+      get: vi.fn(async () => {
+        if (options.settingsGetError) throw options.settingsGetError
+        return {
+          selectedProviderId: null,
+          selectedModelId: null,
+          providerCredentials: {},
+          integrationCredentials: {},
+          integrationEnabled: {},
+          enableBash: false,
+          enableFileWrite: false,
+          runtimeToolingBridgeEnabled: true,
+          automationLaunchAtLogin: false,
+          automationRunInBackground: false,
+          automationDesktopNotifications: true,
+          automationQuietHoursStart: null,
+          automationQuietHoursEnd: null,
+          defaultAutomationAutonomyPolicy: 'review-first',
+          defaultAutomationExecutionMode: 'planning_only',
+          effectiveProviderId: null,
+          effectiveModel: null,
+        }
+      }),
     },
     on: {
       automationUpdated,
@@ -175,13 +185,41 @@ function renderAutomationsPage(options: {
     create,
     previewBrief,
     automationUpdated,
+    reportRendererError,
     unsubscribeAutomationUpdated,
     unmount: view.unmount,
     onOpenThread,
   }
 }
 
+beforeEach(() => {
+  vi.clearAllMocks()
+  useSessionStore.setState({
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+})
+
 describe('AutomationsPage', () => {
+  it('surfaces automation default load failures through the chat error channel and diagnostics', async () => {
+    const api = renderAutomationsPage({
+      settingsGetError: new Error('settings unavailable'),
+    })
+
+    expect(await screen.findByRole('heading', { name: 'Always-on work' })).toBeInTheDocument()
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load automation defaults. New automations will use standard defaults.')
+    })
+    expect(api.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('settings unavailable'),
+      view: 'automations',
+    }))
+  })
+
   it('loads the board, opens a card detail, runs preview, and cleans up the update listener', async () => {
     const user = userEvent.setup()
     const api = renderAutomationsPage()

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -7,6 +7,7 @@ import type {
   CustomAgentSummary,
 } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
+import { useSessionStore } from '../../stores/session'
 import { AutomationBoard } from './AutomationBoard'
 import { AutomationCardDetail } from './AutomationCardDetail'
 import { AutomationCreateWizard } from './AutomationCreateWizard'
@@ -31,6 +32,22 @@ type Props = {
   onOpenThread?: (sessionId: string) => void
 }
 
+function describeAutomationDefaultsError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportAutomationDefaultsError(error: unknown) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `Failed to load automation defaults: ${describeAutomationDefaultsError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'automations',
+    })
+  } catch {
+    // Diagnostics are best-effort from an automation defaults fallback.
+  }
+}
+
 export function AutomationsPage({ onOpenThread }: Props) {
   const [payload, setPayload] = useState<AutomationListPayload>({ automations: [], inbox: [], workItems: [], runs: [], deliveries: [] })
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null)
@@ -45,6 +62,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
   const [feedback, setFeedback] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
   const selectedAutomationIdRef = useRef<string | null>(null)
 
   const loadAgentOptions = useCallback(async (directory: string | null | undefined, selectedNames: string[]) => {
@@ -103,12 +121,14 @@ export function AutomationsPage({ onOpenThread }: Props) {
         executionMode: settings.defaultAutomationExecutionMode,
       }))
     }).catch((err) => {
-      console.error('Failed to load automation defaults:', err)
+      if (cancelled) return
+      addGlobalError(t('automations.defaultsLoadFailed', 'Could not load automation defaults. New automations will use standard defaults.'))
+      reportAutomationDefaultsError(err)
     })
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [addGlobalError])
 
   useEffect(() => {
     let cancelled = false

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SandboxStorageStats } from '@open-cowork/shared'
+import { useSessionStore } from '../../stores/session'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { StoragePanel } from './SettingsStoragePanel'
+
+const stats: SandboxStorageStats = {
+  root: '/tmp/open-cowork-test',
+  totalBytes: 0,
+  workspaceCount: 0,
+  referencedWorkspaceCount: 0,
+  unreferencedWorkspaceCount: 0,
+  staleWorkspaceCount: 0,
+  staleThresholdDays: 14,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useSessionStore.setState({
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+})
+
+describe('StoragePanel', () => {
+  it('surfaces diagnostics export failures through the chat error channel and diagnostics', async () => {
+    const user = userEvent.setup()
+    const reportRendererError = vi.fn()
+    installRendererTestCoworkApi({
+      app: {
+        checkUpdates: vi.fn(async () => ({
+          status: 'current',
+          currentVersion: '0.0.0',
+          latestVersion: '0.0.0',
+          releaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases/tag/v0.0.0',
+          hasUpdate: false,
+        })),
+        exportDiagnostics: vi.fn(async () => {
+          throw new Error('diagnostics unavailable')
+        }),
+      },
+      diagnostics: {
+        reportRendererError,
+      },
+    })
+
+    render(
+      <StoragePanel
+        stats={stats}
+        runningCleanup={null}
+        lastCleanup={null}
+        onCleanup={vi.fn(async () => undefined)}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Copy diagnostics to clipboard/ }))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not export diagnostics. Please try again.')
+    })
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('diagnostics unavailable'),
+      view: 'settings-storage',
+    }))
+    expect(screen.getByText('Could not build diagnostics — try again')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
@@ -6,6 +6,7 @@ import type {
 import { writeTextToClipboard } from '../../helpers/clipboard'
 import { confirmAppReset } from '../../helpers/destructive-actions'
 import { t } from '../../helpers/i18n'
+import { useSessionStore } from '../../stores/session'
 
 const sectionLabelCls = 'text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1'
 const panelCardCls = 'rounded-2xl border border-border-subtle p-4 flex flex-col gap-4'
@@ -34,6 +35,22 @@ function formatBytes(value: number) {
   return `${(value / 1024 ** 3).toFixed(2)} GB`
 }
 
+function describeStorageError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportStorageError(error: unknown, scope: string) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${scope}: ${describeStorageError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'settings-storage',
+    })
+  } catch {
+    // Diagnostics are best-effort from a storage recovery path.
+  }
+}
+
 export function StoragePanel({
   stats,
   runningCleanup,
@@ -49,6 +66,7 @@ export function StoragePanel({
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ kind: 'idle' })
   const [resetting, setResetting] = useState(false)
   const [currentVersion, setCurrentVersion] = useState<string | null>(null)
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
 
   // Resolve the current build's version on mount so we can surface it
   // next to the update-check button before the user clicks. Uses the
@@ -111,7 +129,8 @@ export function StoragePanel({
       setDiagnosticsStatus(copied ? 'copied' : 'error')
       setTimeout(() => setDiagnosticsStatus('idle'), 3_000)
     } catch (err) {
-      console.error('Failed to export diagnostics:', err)
+      addGlobalError(t('settings.storage.exportDiagnosticsFailed', 'Could not export diagnostics. Please try again.'))
+      reportStorageError(err, 'Failed to export diagnostics')
       setDiagnosticsStatus('error')
       setTimeout(() => setDiagnosticsStatus('idle'), 3_000)
     }


### PR DESCRIPTION
## Summary
- route automation default load failures through the global error channel and renderer diagnostics
- route diagnostics export failures through the same user-visible recovery path
- add renderer regression tests for both non-fatal failure paths

## Validation
- pnpm --dir apps/desktop test:renderer -- AutomationsPage SettingsStoragePanel
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check