### PR TITLE
Surface Mermaid render failures

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MermaidChart.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MermaidChart.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installRendererTestCoworkApi } from '../../test/setup'
 import { MermaidChart } from './MermaidChart'
 
 const mermaidMock = vi.hoisted(() => ({
@@ -42,12 +43,20 @@ describe('MermaidChart', () => {
   })
 
   it('shows a contained error state when Mermaid rejects a diagram', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const reportRendererError = vi.fn()
+    installRendererTestCoworkApi({
+      diagnostics: {
+        reportRendererError,
+      },
+    })
     mermaidMock.render.mockRejectedValueOnce(new Error('bad diagram'))
 
     render(<MermaidChart diagram="not mermaid" />)
 
     await screen.findByText('Mermaid error: bad diagram')
-    consoleError.mockRestore()
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('bad diagram'),
+      view: 'chat-mermaid',
+    }))
   })
 })

--- a/apps/desktop/src/renderer/components/chat/MermaidChart.tsx
+++ b/apps/desktop/src/renderer/components/chat/MermaidChart.tsx
@@ -46,6 +46,22 @@ function sanitizeMermaidSvg(svg: string) {
   })
 }
 
+function describeMermaidError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportMermaidError(error: unknown) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `Failed to render Mermaid diagram: ${describeMermaidError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'chat-mermaid',
+    })
+  } catch {
+    // Diagnostics reporting is best-effort; the chart already shows a local fallback.
+  }
+}
+
 export function MermaidChart({ diagram, title }: Props) {
   const viewportRef = useRef<HTMLDivElement>(null)
   const ref = useRef<HTMLDivElement>(null)
@@ -184,8 +200,8 @@ export function MermaidChart({ diagram, title }: Props) {
           }
         }
       } catch (err: unknown) {
-        console.error('[MermaidChart] Render error:', err)
         if (!cancelled) {
+          reportMermaidError(err)
           setError(err instanceof Error ? err.message : 'Failed to render Mermaid diagram')
         }
       }


### PR DESCRIPTION
## Summary
- report Mermaid render failures through the renderer diagnostics channel
- keep the local Mermaid fallback UI intact when diagram rendering fails
- update the Mermaid component test to assert diagnostics reporting instead of suppressing console output

## Validation
- pnpm --dir apps/desktop test:renderer -- MermaidChart
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check