### PR TITLE
Warn before saving unsigned skill bundles

### DIFF
--- a/apps/desktop/src/renderer/components/plugins/CustomSkillForm.test.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomSkillForm.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { CustomSkillForm } from './CustomSkillForm'
+
+function installCustomSkillFormApi(overrides: {
+  addSkill?: ReturnType<typeof vi.fn>
+  importSkillDirectory?: ReturnType<typeof vi.fn>
+  selectSkillDirectoryImport?: ReturnType<typeof vi.fn>
+} = {}) {
+  return installRendererTestCoworkApi({
+    capabilities: {
+      tools: vi.fn(async () => []),
+    },
+    custom: {
+      listSkills: vi.fn(async () => []),
+      addSkill: overrides.addSkill || vi.fn(async () => true),
+      selectSkillDirectoryImport: overrides.selectSkillDirectoryImport || vi.fn(async () => null),
+      importSkillDirectory: overrides.importSkillDirectory || vi.fn(async () => ({
+        name: 'imported-skill',
+        path: '/tmp/imported-skill',
+        directory: null,
+        scope: 'machine',
+        toolIds: [],
+      })),
+    },
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('CustomSkillForm', () => {
+  it('shows an explicit unsigned skill trust warning', () => {
+    installCustomSkillFormApi()
+
+    render(<CustomSkillForm onSave={vi.fn()} onCancel={vi.fn()} />)
+
+    const note = screen.getByRole('note')
+    expect(note).toHaveTextContent('Unsigned skill bundle')
+    expect(note).toHaveTextContent('Only save or import bundles you wrote or trust')
+  })
+
+  it('requires confirmation before saving a new unsigned skill bundle', () => {
+    const addSkill = vi.fn(async () => true)
+    installCustomSkillFormApi({ addSkill })
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<CustomSkillForm onSave={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. code-review, data-pipeline'), {
+      target: { value: 'trusted-skill' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add skill' }))
+
+    expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Save this unsigned skill bundle'))
+    expect(addSkill).not.toHaveBeenCalled()
+  })
+
+  it('saves a new skill after the unsigned skill warning is accepted', async () => {
+    const addSkill = vi.fn(async () => true)
+    const onSave = vi.fn()
+    installCustomSkillFormApi({ addSkill })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<CustomSkillForm onSave={onSave} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. code-review, data-pipeline'), {
+      target: { value: 'trusted-skill' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add skill' }))
+
+    await waitFor(() => {
+      expect(addSkill).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'trusted-skill',
+        scope: 'machine',
+      }))
+    })
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not import a directory when the unsigned skill warning is declined', async () => {
+    const importSkillDirectory = vi.fn(async () => ({
+      name: 'imported-skill',
+      path: '/tmp/imported-skill',
+      directory: null,
+      scope: 'machine',
+      toolIds: [],
+    }))
+    installCustomSkillFormApi({
+      importSkillDirectory,
+      selectSkillDirectoryImport: vi.fn(async () => ({
+        token: 'selection-token',
+        directory: '/tmp/imported-skill',
+      })),
+    })
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<CustomSkillForm onSave={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import directory' }))
+
+    await waitFor(() => {
+      expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Import this unsigned skill bundle'))
+    })
+    expect(importSkillDirectory).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/components/plugins/CustomSkillForm.tsx
+++ b/apps/desktop/src/renderer/components/plugins/CustomSkillForm.tsx
@@ -5,8 +5,17 @@ import { t } from '../../helpers/i18n'
 import { PluginIcon } from './PluginIcon'
 
 function extractFrontmatterField(content: string, field: string) {
-  const match = content.match(new RegExp(`^---\\n[\\s\\S]*?\\n${field}:\\s*["']?(.+?)["']?\\s*(?:\\n|$)`, 'm'))
-  return match?.[1]?.trim() || ''
+  const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  if (!frontmatter) return ''
+  const line = frontmatter[1]
+    .split(/\r?\n/)
+    .find((candidate) => candidate.trimStart().startsWith(`${field}:`))
+  if (!line) return ''
+  return line
+    .slice(line.indexOf(':') + 1)
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .trim()
 }
 
 function isSafeRelativePath(value: string) {
@@ -166,6 +175,13 @@ export function CustomSkillForm({
 
   const handleSave = async () => {
     if (issues.length > 0) return
+    if (!isEditing) {
+      const confirmed = window.confirm(t(
+        'skillForm.unsignedSaveConfirm',
+        'Save this unsigned skill bundle? Custom skills change agent instructions and can request tool access. Only save skills you wrote or trust.',
+      ))
+      if (!confirmed) return
+    }
     setSaving(true)
     await window.coworkApi.custom.addSkill({
       scope,
@@ -269,6 +285,25 @@ export function CustomSkillForm({
             {importError}
           </div>
         ) : null}
+
+        <div
+          role="note"
+          className="mb-4 rounded-xl border px-4 py-3"
+          style={{
+            borderColor: 'color-mix(in srgb, var(--color-amber) 35%, var(--color-border-subtle))',
+            background: 'color-mix(in srgb, var(--color-amber) 6%, var(--color-surface))',
+          }}
+        >
+          <div className="text-[12px] font-medium text-text mb-1">
+            {t('skillForm.trustWarningTitle', 'Unsigned skill bundle')}
+          </div>
+          <div className="text-[11px] text-text-muted leading-relaxed">
+            {t(
+              'skillForm.trustWarningBody',
+              'Custom skills are loaded into the OpenCode runtime as instructions and may ask agents to use tools. Only save or import bundles you wrote or trust.',
+            )}
+          </div>
+        </div>
 
         <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-5">
           <div className="flex flex-col gap-5">


### PR DESCRIPTION
## Summary
- add a persistent trust warning to the custom skill bundle form
- require explicit confirmation before saving a new unsigned skill bundle
- keep directory imports behind the existing unsigned import confirmation
- fix frontmatter field parsing so first-line fields in SKILL.md are recognized
- add renderer tests for trust warning, declined save, accepted save, and declined import

## Validation
- pnpm --dir apps/desktop test:renderer -- CustomSkillForm
- pnpm test:renderer
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check