### PR TITLE
Extract session task state store

### DIFF
--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -1,125 +1,28 @@
+import type { BindingHints } from './task-binding-score.ts'
 import {
-  chooseTaskTitle,
-  isPlaceholderTaskTitle,
-  normalizeAgentName,
-  normalizeTaskTitle,
-} from './task-run-utils.ts'
-import {
-  findBestIndexedMatch,
-  type BindingHints,
-} from './task-binding-score.ts'
-import {
-  applyTaskTimingTransition,
-  isTerminalTaskStatus,
-  normalizeTaskTiming,
-  nowIso,
-} from './event-task-timing.ts'
-import {
-  pushUniqueQueueValue,
-  shiftQueueValue,
-  spliceQueueValue,
-} from './queue-map.ts'
+  SessionTaskStateStore,
+  type TaskRunMeta,
+  type TaskStatus,
+} from './session-task-state-store.ts'
 
-export type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
+export type { TaskRunMeta, TaskStatus }
 
-export type TaskRunMeta = {
-  id: string
-  rootSessionId: string
-  parentSessionId: string | null
-  title: string
-  agent: string | null
-  childSessionId: string | null
-  status: TaskStatus
-  startedAt?: string | null
-  finishedAt?: string | null
-}
-
-// parentSessions + sessionLineage are local caches fed from the SDK's own
-// session.created / session.updated events. They exist so resolveRootSession()
-// can traverse a session tree synchronously inside event handlers without
-// calling client.session.get() per event. OpenCode remains the source of
-// truth; these are memoized views of data the SDK already handed us.
-type QueuedChildSessionMeta = {
-  id: string
-  title: string | null
-  agent: string | null
-}
-
-class SessionHierarchyStore {
-  readonly parentSessions = new Set<string>()
-  readonly sessionLineage = new Map<string, string>()
-  readonly taskRuns = new Map<string, TaskRunMeta>()
-  readonly childSessionToTaskRunId = new Map<string, string>()
-  readonly pendingTaskRunsByParent = new Map<string, string[]>()
-  readonly queuedChildSessionsByParent = new Map<string, QueuedChildSessionMeta[]>()
-  readonly pendingSubmittedPromptBySession = new Map<string, string>()
-
-  reset() {
-    this.parentSessions.clear()
-    this.sessionLineage.clear()
-    this.taskRuns.clear()
-    this.childSessionToTaskRunId.clear()
-    this.pendingTaskRunsByParent.clear()
-    this.queuedChildSessionsByParent.clear()
-    this.pendingSubmittedPromptBySession.clear()
-  }
-}
-
-const hierarchyStore = new SessionHierarchyStore()
-const {
-  parentSessions,
-  sessionLineage,
-  taskRuns,
-  childSessionToTaskRunId,
-  pendingTaskRunsByParent,
-  queuedChildSessionsByParent,
-  pendingSubmittedPromptBySession,
-} = hierarchyStore
-
-function isKnownSession(sessionId: string) {
-  return parentSessions.has(sessionId) || sessionLineage.has(sessionId)
-}
+const hierarchyStore = new SessionTaskStateStore()
 
 export function trackParentSession(sessionId: string) {
-  parentSessions.add(sessionId)
-  sessionLineage.set(sessionId, sessionId)
+  hierarchyStore.trackParentSession(sessionId)
 }
 
 export function isTrackedParentSession(sessionId: string) {
-  return parentSessions.has(sessionId)
+  return hierarchyStore.isTrackedParentSession(sessionId)
 }
 
 export function untrackParentSession(sessionId: string) {
-  parentSessions.delete(sessionId)
+  hierarchyStore.untrackParentSession(sessionId)
 }
 
 export function registerSession(sessionId?: string | null, parentId?: string | null) {
-  if (!sessionId) return
-  if (!parentId) {
-    if (!sessionLineage.has(sessionId)) {
-      sessionLineage.set(sessionId, sessionId)
-    }
-    return
-  }
-  if (wouldCreateLineageCycle(sessionId, parentId)) {
-    sessionLineage.set(sessionId, sessionId)
-    return
-  }
-  sessionLineage.set(sessionId, parentId)
-}
-
-function wouldCreateLineageCycle(sessionId: string, parentId: string) {
-  let current: string | undefined = parentId
-  const seen = new Set<string>()
-  while (current) {
-    if (current === sessionId) return true
-    if (seen.has(current)) return true
-    seen.add(current)
-    const next = sessionLineage.get(current)
-    if (!next || next === current) return false
-    current = next
-  }
-  return false
+  hierarchyStore.registerSession(sessionId, parentId)
 }
 
 // Returns the immediate parent session id for a child session, or null if
@@ -127,154 +30,23 @@ function wouldCreateLineageCycle(sessionId: string, parentId: string) {
 // the orchestration UI to render two-level nesting — a task's parent
 // session tells us which other task (if any) spawned it.
 export function getImmediateParentSession(sessionId?: string | null): string | null {
-  if (!sessionId) return null
-  const parent = sessionLineage.get(sessionId)
-  if (!parent || parent === sessionId) return null
-  return parent
-}
-
-function takePendingTaskRunId(parentSessionId: string, hints?: BindingHints | null) {
-  const current = mapTaskRunsForParent(parentSessionId)
-  if (current.length === 0) return null
-  if (current.length === 1) {
-    return shiftQueueValue(pendingTaskRunsByParent, parentSessionId) || null
-  }
-  const matchIndex = findBestIndexedMatch(
-    current
-      .map((taskRunId) => taskRuns.get(taskRunId))
-      .filter((taskRun): taskRun is TaskRunMeta => Boolean(taskRun)),
-    hints,
-  )
-  if (matchIndex < 0) return null
-  const matchId = current[matchIndex] || null
-  if (!matchId) return null
-  return spliceQueueValue(pendingTaskRunsByParent, parentSessionId, (value) => value === matchId)
-}
-
-function takeQueuedChildSession(
-  parentSessionId: string,
-  hints?: BindingHints | null,
-) {
-  const current = queuedChildSessionsByParent.get(parentSessionId) || []
-  if (current.length === 0) return null
-  if (current.length === 1) {
-    return spliceQueueValue(queuedChildSessionsByParent, parentSessionId, () => true)
-  }
-  const matchIndex = findBestIndexedMatch(current, hints)
-  if (matchIndex < 0) return null
-  const matchId = current[matchIndex]?.id
-  if (!matchId) return null
-  return spliceQueueValue(queuedChildSessionsByParent, parentSessionId, (value) => value.id === matchId)
-}
-
-function mapTaskRunsForParent(parentSessionId: string) {
-  return pendingTaskRunsByParent.get(parentSessionId) || []
+  return hierarchyStore.getImmediateParentSession(sessionId)
 }
 
 export function resolveRootSession(sessionId?: string | null) {
-  if (!sessionId) return undefined
-
-  let current = sessionId
-  const seen = new Set<string>()
-
-  while (true) {
-    const next = sessionLineage.get(current)
-    if (!next) return current
-    if (next === current) return current
-    if (seen.has(current)) return current
-    seen.add(current)
-    current = next
-  }
+  return hierarchyStore.resolveRootSession(sessionId)
 }
 
 export function findFallbackTaskRun(rootSessionId: string, parentSessionId: string, agent?: string | null) {
-  const candidates = Array.from(taskRuns.values()).filter((taskRun) => {
-    return taskRun.rootSessionId === rootSessionId
-      && taskRun.parentSessionId === parentSessionId
-      && taskRun.id.startsWith('child:')
-      && (taskRun.status === 'queued' || taskRun.status === 'running')
-      && (!agent || taskRun.agent === agent || !taskRun.agent)
-  })
-
-  return candidates.length === 1 ? candidates[0] : null
+  return hierarchyStore.findFallbackTaskRun(rootSessionId, parentSessionId, agent)
 }
 
 export function bindTaskRunToChild(taskRunId: string, childSessionId: string) {
-  const existingTaskRunId = childSessionToTaskRunId.get(childSessionId)
-  const childParentSessionId = getImmediateParentSession(childSessionId)
-  if (existingTaskRunId && existingTaskRunId !== taskRunId) {
-    const existingTaskRun = taskRuns.get(existingTaskRunId)
-    const incomingTaskRun = taskRuns.get(taskRunId)
-
-    if (existingTaskRun && incomingTaskRun) {
-      const mergedAgent = incomingTaskRun.agent || existingTaskRun.agent
-      const mergedStatus = incomingTaskRun.status === 'error'
-        ? 'error'
-        : incomingTaskRun.status === 'complete'
-          ? 'complete'
-          : incomingTaskRun.status === 'running'
-            ? 'running'
-            : existingTaskRun.status
-      const timestamp = nowIso()
-      const finishedAt = isTerminalTaskStatus(mergedStatus)
-        ? (existingTaskRun.finishedAt || incomingTaskRun.finishedAt || timestamp)
-        : null
-      const mergedTaskRun: TaskRunMeta = {
-        ...existingTaskRun,
-        rootSessionId: incomingTaskRun.rootSessionId || existingTaskRun.rootSessionId,
-        parentSessionId: childParentSessionId
-          || incomingTaskRun.parentSessionId
-          || existingTaskRun.parentSessionId
-          || existingTaskRun.rootSessionId,
-        title: chooseTaskTitle(
-          mergedAgent,
-          !isPlaceholderTaskTitle(existingTaskRun.title, existingTaskRun.agent) ? existingTaskRun.title : null,
-          incomingTaskRun.title,
-        ),
-        agent: mergedAgent,
-        childSessionId,
-        status: mergedStatus,
-        startedAt: existingTaskRun.startedAt || incomingTaskRun.startedAt || timestamp,
-        finishedAt,
-      }
-
-      taskRuns.set(existingTaskRunId, mergedTaskRun)
-      taskRuns.delete(taskRunId)
-      childSessionToTaskRunId.set(childSessionId, existingTaskRunId)
-      return mergedTaskRun
-    }
-  }
-
-  const taskRun = taskRuns.get(taskRunId)
-  if (!taskRun) return null
-  taskRun.childSessionId = childSessionId
-  taskRun.parentSessionId = childParentSessionId || taskRun.parentSessionId || taskRun.rootSessionId
-  childSessionToTaskRunId.set(childSessionId, taskRunId)
-  return taskRun
+  return hierarchyStore.bindTaskRunToChild(taskRunId, childSessionId)
 }
 
 export function registerTaskRun(taskRun: TaskRunMeta) {
-  const normalizedTaskRun: TaskRunMeta = normalizeTaskTiming({
-    ...taskRun,
-    parentSessionId: taskRun.parentSessionId || taskRun.rootSessionId,
-  })
-  taskRuns.set(normalizedTaskRun.id, normalizedTaskRun)
-  const parentQueueKey = normalizedTaskRun.parentSessionId || normalizedTaskRun.rootSessionId
-
-  const queuedChild = takeQueuedChildSession(parentQueueKey, {
-    agent: normalizedTaskRun.agent,
-    title: normalizedTaskRun.title,
-  })
-  if (queuedChild) {
-    const bound = bindTaskRunToChild(normalizedTaskRun.id, queuedChild.id)
-    return bound || taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun
-  }
-
-  if (!normalizedTaskRun.childSessionId) {
-    pushUniqueQueueValue(pendingTaskRunsByParent, parentQueueKey, normalizedTaskRun.id)
-  }
-
-  return taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun
+  return hierarchyStore.registerTaskRun(taskRun)
 }
 
 export function queueOrBindChildSession(
@@ -282,22 +54,7 @@ export function queueOrBindChildSession(
   childSessionId: string,
   hints?: BindingHints | null,
 ) {
-  if (!parentSessionId) return null
-  const pendingTaskRunId = takePendingTaskRunId(parentSessionId, hints)
-  if (pendingTaskRunId) {
-    return bindTaskRunToChild(pendingTaskRunId, childSessionId)
-  }
-
-  const queuedChild: QueuedChildSessionMeta = {
-    id: childSessionId,
-    title: normalizeTaskTitle(hints?.title) || null,
-    agent: normalizeAgentName(hints?.agent) || null,
-  }
-  const current = queuedChildSessionsByParent.get(parentSessionId) || []
-  if (!current.some((entry) => entry.id === childSessionId)) {
-    queuedChildSessionsByParent.set(parentSessionId, [...current, queuedChild])
-  }
-  return null
+  return hierarchyStore.queueOrBindChildSession(parentSessionId, childSessionId, hints)
 }
 
 export function ensureTaskRunForChild(
@@ -306,171 +63,43 @@ export function ensureTaskRunForChild(
   agent?: string | null,
   parentSessionId?: string | null,
 ) {
-  const existingTaskRunId = childSessionToTaskRunId.get(childSessionId)
-  if (existingTaskRunId) return taskRuns.get(existingTaskRunId) || null
-
-  const immediateParentSessionId = parentSessionId || getImmediateParentSession(childSessionId) || rootSessionId
-  const fallback: TaskRunMeta = {
-    id: `child:${childSessionId}`,
-    rootSessionId,
-    parentSessionId: immediateParentSessionId,
-    title: chooseTaskTitle(agent),
-    agent: agent || null,
-    childSessionId,
-    status: 'queued',
-    startedAt: nowIso(),
-    finishedAt: null,
-  }
-  taskRuns.set(fallback.id, fallback)
-  childSessionToTaskRunId.set(childSessionId, fallback.id)
-  return fallback
+  return hierarchyStore.ensureTaskRunForChild(rootSessionId, childSessionId, agent, parentSessionId)
 }
 
 export function updateTaskRun(taskRunId: string, patch: Partial<TaskRunMeta>) {
-  const existing = taskRuns.get(taskRunId)
-  if (!existing) return null
-  const next = applyTaskTimingTransition(existing, patch)
-  taskRuns.set(taskRunId, next)
-  if (next.childSessionId) {
-    childSessionToTaskRunId.set(next.childSessionId, next.id)
-  }
-  return next
+  return hierarchyStore.updateTaskRun(taskRunId, patch)
 }
 
 export function getTaskRun(taskRunId: string | null | undefined) {
-  if (!taskRunId) return null
-  return taskRuns.get(taskRunId) || null
+  return hierarchyStore.getTaskRun(taskRunId)
 }
 
 export function getTaskRunIdForChild(sessionId: string | null | undefined) {
-  if (!sessionId) return null
-  return childSessionToTaskRunId.get(sessionId) || null
+  return hierarchyStore.getTaskRunIdForChild(sessionId)
 }
 
 export function rememberSubmittedPrompt(sessionId: string, text: string) {
-  if (!sessionId || !text) return
-  pendingSubmittedPromptBySession.set(sessionId, text)
+  hierarchyStore.rememberSubmittedPrompt(sessionId, text)
 }
 
 export function forgetSubmittedPrompt(sessionId: string) {
-  pendingSubmittedPromptBySession.delete(sessionId)
+  hierarchyStore.forgetSubmittedPrompt(sessionId)
 }
 
 export function consumePendingPromptEcho(sessionId: string, content: string) {
-  const pending = pendingSubmittedPromptBySession.get(sessionId)
-  if (!pending || !content) return content
-  if (content === pending) {
-    pendingSubmittedPromptBySession.delete(sessionId)
-    return ''
-  }
-  if (pending.startsWith(content)) {
-    pendingSubmittedPromptBySession.set(sessionId, pending.slice(content.length))
-    return ''
-  }
-  if (content.startsWith(pending)) {
-    pendingSubmittedPromptBySession.delete(sessionId)
-    return content.slice(pending.length)
-  }
-  return content
+  return hierarchyStore.consumePendingPromptEcho(sessionId, content)
 }
 
 export function sweepStaleTaskState(messageRoles: Map<string, 'user' | 'assistant'>) {
-  for (const [childSessionId, taskRunId] of childSessionToTaskRunId.entries()) {
-    const taskRun = taskRuns.get(taskRunId)
-    if (!taskRun || taskRun.childSessionId !== childSessionId) {
-      childSessionToTaskRunId.delete(childSessionId)
-    }
-  }
-
-  for (const [parentSessionId] of pendingTaskRunsByParent.entries()) {
-    if (!isKnownSession(parentSessionId)) {
-      pendingTaskRunsByParent.delete(parentSessionId)
-    }
-  }
-
-  for (const [parentSessionId] of queuedChildSessionsByParent.entries()) {
-    if (!isKnownSession(parentSessionId)) {
-      queuedChildSessionsByParent.delete(parentSessionId)
-    }
-  }
-
-  while (messageRoles.size > 2000) {
-    const oldest = messageRoles.keys().next().value
-    if (!oldest) break
-    messageRoles.delete(oldest)
-  }
-}
-
-// Drop any lineage rows that pointed at `sessionId` as their parent.
-// Without this pass, deleting a root session leaves orphaned child rows
-// in `sessionLineage` whose resolveRootSession walks would still end at
-// the deleted id — making the cache disagree with OpenCode's own view
-// until a full runtime reboot.
-function collectDescendantSessions(sessionId: string) {
-  const descendants: string[] = []
-  const queue = [sessionId]
-  while (queue.length > 0) {
-    const currentParentId = queue.shift()
-    if (!currentParentId) continue
-    for (const [childId, parentId] of sessionLineage.entries()) {
-      if (parentId !== currentParentId || childId === currentParentId) continue
-      descendants.push(childId)
-      queue.push(childId)
-    }
-  }
-  return descendants
-}
-
-function deleteTaskRunsForSessions(sessionIds: string[]) {
-  const targetIds = new Set(sessionIds)
-  for (const sessionId of targetIds) {
-    childSessionToTaskRunId.delete(sessionId)
-  }
-  for (const [taskRunId, taskRun] of taskRuns.entries()) {
-    const childSessionId = taskRun.childSessionId
-    if (
-      (childSessionId && targetIds.has(childSessionId))
-      || (taskRunId.startsWith('child:') && targetIds.has(taskRunId.slice('child:'.length)))
-    ) {
-      taskRuns.delete(taskRunId)
-    }
-  }
-}
-
-function removeDescendantLineage(sessionId: string) {
-  const descendants = collectDescendantSessions(sessionId)
-  deleteTaskRunsForSessions(descendants)
-  for (const childId of descendants) {
-    sessionLineage.delete(childId)
-    pendingTaskRunsByParent.delete(childId)
-    queuedChildSessionsByParent.delete(childId)
-    pendingSubmittedPromptBySession.delete(childId)
-  }
+  hierarchyStore.sweepStaleTaskState(messageRoles)
 }
 
 export function removeParentSessionState(sessionId: string) {
-  parentSessions.delete(sessionId)
-  sessionLineage.delete(sessionId)
-  pendingTaskRunsByParent.delete(sessionId)
-  queuedChildSessionsByParent.delete(sessionId)
-  pendingSubmittedPromptBySession.delete(sessionId)
-  deleteTaskRunsForSessions([sessionId])
-  for (const [taskRunId, taskRun] of taskRuns.entries()) {
-    if (taskRun.rootSessionId === sessionId) taskRuns.delete(taskRunId)
-  }
-  removeDescendantLineage(sessionId)
+  hierarchyStore.removeParentSessionState(sessionId)
 }
 
 export function removeSessionState(sessionId: string, parentId?: string | null) {
-  deleteTaskRunsForSessions([sessionId])
-  sessionLineage.delete(sessionId)
-  pendingTaskRunsByParent.delete(sessionId)
-  queuedChildSessionsByParent.delete(sessionId)
-  pendingSubmittedPromptBySession.delete(sessionId)
-  removeDescendantLineage(sessionId)
-  if (!parentId) {
-    parentSessions.delete(sessionId)
-  }
+  hierarchyStore.removeSessionState(sessionId, parentId)
 }
 
 export function resetEventTaskState() {

--- a/apps/desktop/src/main/session-task-state-store.ts
+++ b/apps/desktop/src/main/session-task-state-store.ts
@@ -1,0 +1,452 @@
+import {
+  chooseTaskTitle,
+  isPlaceholderTaskTitle,
+  normalizeAgentName,
+  normalizeTaskTitle,
+} from './task-run-utils.ts'
+import {
+  findBestIndexedMatch,
+  type BindingHints,
+} from './task-binding-score.ts'
+import {
+  applyTaskTimingTransition,
+  isTerminalTaskStatus,
+  normalizeTaskTiming,
+  nowIso,
+} from './event-task-timing.ts'
+import {
+  pushUniqueQueueValue,
+  shiftQueueValue,
+  spliceQueueValue,
+} from './queue-map.ts'
+
+export type TaskStatus = 'queued' | 'running' | 'complete' | 'error'
+
+export type TaskRunMeta = {
+  id: string
+  rootSessionId: string
+  parentSessionId: string | null
+  title: string
+  agent: string | null
+  childSessionId: string | null
+  status: TaskStatus
+  startedAt?: string | null
+  finishedAt?: string | null
+}
+
+type QueuedChildSessionMeta = {
+  id: string
+  title: string | null
+  agent: string | null
+}
+
+// Local cache fed by OpenCode session/task events. OpenCode remains the
+// source of truth; this store only keeps enough indexed state for synchronous
+// event projection without calling the SDK from every event handler.
+export class SessionTaskStateStore {
+  private readonly parentSessions = new Set<string>()
+  private readonly sessionLineage = new Map<string, string>()
+  private readonly taskRuns = new Map<string, TaskRunMeta>()
+  private readonly childSessionToTaskRunId = new Map<string, string>()
+  private readonly pendingTaskRunsByParent = new Map<string, string[]>()
+  private readonly queuedChildSessionsByParent = new Map<string, QueuedChildSessionMeta[]>()
+  private readonly pendingSubmittedPromptBySession = new Map<string, string>()
+
+  reset() {
+    this.parentSessions.clear()
+    this.sessionLineage.clear()
+    this.taskRuns.clear()
+    this.childSessionToTaskRunId.clear()
+    this.pendingTaskRunsByParent.clear()
+    this.queuedChildSessionsByParent.clear()
+    this.pendingSubmittedPromptBySession.clear()
+  }
+
+  trackParentSession(sessionId: string) {
+    this.parentSessions.add(sessionId)
+    this.sessionLineage.set(sessionId, sessionId)
+  }
+
+  isTrackedParentSession(sessionId: string) {
+    return this.parentSessions.has(sessionId)
+  }
+
+  untrackParentSession(sessionId: string) {
+    this.parentSessions.delete(sessionId)
+  }
+
+  registerSession(sessionId?: string | null, parentId?: string | null) {
+    if (!sessionId) return
+    if (!parentId) {
+      if (!this.sessionLineage.has(sessionId)) {
+        this.sessionLineage.set(sessionId, sessionId)
+      }
+      return
+    }
+    if (this.wouldCreateLineageCycle(sessionId, parentId)) {
+      this.sessionLineage.set(sessionId, sessionId)
+      return
+    }
+    this.sessionLineage.set(sessionId, parentId)
+  }
+
+  getImmediateParentSession(sessionId?: string | null): string | null {
+    if (!sessionId) return null
+    const parent = this.sessionLineage.get(sessionId)
+    if (!parent || parent === sessionId) return null
+    return parent
+  }
+
+  resolveRootSession(sessionId?: string | null) {
+    if (!sessionId) return undefined
+
+    let current = sessionId
+    const seen = new Set<string>()
+
+    while (true) {
+      const next = this.sessionLineage.get(current)
+      if (!next) return current
+      if (next === current) return current
+      if (seen.has(current)) return current
+      seen.add(current)
+      current = next
+    }
+  }
+
+  findFallbackTaskRun(rootSessionId: string, parentSessionId: string, agent?: string | null) {
+    const candidates = Array.from(this.taskRuns.values()).filter((taskRun) => {
+      return taskRun.rootSessionId === rootSessionId
+        && taskRun.parentSessionId === parentSessionId
+        && taskRun.id.startsWith('child:')
+        && (taskRun.status === 'queued' || taskRun.status === 'running')
+        && (!agent || taskRun.agent === agent || !taskRun.agent)
+    })
+
+    return candidates.length === 1 ? candidates[0] : null
+  }
+
+  bindTaskRunToChild(taskRunId: string, childSessionId: string) {
+    const existingTaskRunId = this.childSessionToTaskRunId.get(childSessionId)
+    const childParentSessionId = this.getImmediateParentSession(childSessionId)
+    if (existingTaskRunId && existingTaskRunId !== taskRunId) {
+      const existingTaskRun = this.taskRuns.get(existingTaskRunId)
+      const incomingTaskRun = this.taskRuns.get(taskRunId)
+
+      if (existingTaskRun && incomingTaskRun) {
+        const mergedAgent = incomingTaskRun.agent || existingTaskRun.agent
+        const mergedStatus = incomingTaskRun.status === 'error'
+          ? 'error'
+          : incomingTaskRun.status === 'complete'
+            ? 'complete'
+            : incomingTaskRun.status === 'running'
+              ? 'running'
+              : existingTaskRun.status
+        const timestamp = nowIso()
+        const finishedAt = isTerminalTaskStatus(mergedStatus)
+          ? (existingTaskRun.finishedAt || incomingTaskRun.finishedAt || timestamp)
+          : null
+        const mergedTaskRun: TaskRunMeta = {
+          ...existingTaskRun,
+          rootSessionId: incomingTaskRun.rootSessionId || existingTaskRun.rootSessionId,
+          parentSessionId: childParentSessionId
+            || incomingTaskRun.parentSessionId
+            || existingTaskRun.parentSessionId
+            || existingTaskRun.rootSessionId,
+          title: chooseTaskTitle(
+            mergedAgent,
+            !isPlaceholderTaskTitle(existingTaskRun.title, existingTaskRun.agent) ? existingTaskRun.title : null,
+            incomingTaskRun.title,
+          ),
+          agent: mergedAgent,
+          childSessionId,
+          status: mergedStatus,
+          startedAt: existingTaskRun.startedAt || incomingTaskRun.startedAt || timestamp,
+          finishedAt,
+        }
+
+        this.taskRuns.set(existingTaskRunId, mergedTaskRun)
+        this.taskRuns.delete(taskRunId)
+        this.childSessionToTaskRunId.set(childSessionId, existingTaskRunId)
+        return mergedTaskRun
+      }
+    }
+
+    const taskRun = this.taskRuns.get(taskRunId)
+    if (!taskRun) return null
+    taskRun.childSessionId = childSessionId
+    taskRun.parentSessionId = childParentSessionId || taskRun.parentSessionId || taskRun.rootSessionId
+    this.childSessionToTaskRunId.set(childSessionId, taskRunId)
+    return taskRun
+  }
+
+  registerTaskRun(taskRun: TaskRunMeta) {
+    const normalizedTaskRun: TaskRunMeta = normalizeTaskTiming({
+      ...taskRun,
+      parentSessionId: taskRun.parentSessionId || taskRun.rootSessionId,
+    })
+    this.taskRuns.set(normalizedTaskRun.id, normalizedTaskRun)
+    const parentQueueKey = normalizedTaskRun.parentSessionId || normalizedTaskRun.rootSessionId
+
+    const queuedChild = this.takeQueuedChildSession(parentQueueKey, {
+      agent: normalizedTaskRun.agent,
+      title: normalizedTaskRun.title,
+    })
+    if (queuedChild) {
+      const bound = this.bindTaskRunToChild(normalizedTaskRun.id, queuedChild.id)
+      return bound || this.taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun
+    }
+
+    if (!normalizedTaskRun.childSessionId) {
+      pushUniqueQueueValue(this.pendingTaskRunsByParent, parentQueueKey, normalizedTaskRun.id)
+    }
+
+    return this.taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun
+  }
+
+  queueOrBindChildSession(
+    parentSessionId: string | null | undefined,
+    childSessionId: string,
+    hints?: BindingHints | null,
+  ) {
+    if (!parentSessionId) return null
+    const pendingTaskRunId = this.takePendingTaskRunId(parentSessionId, hints)
+    if (pendingTaskRunId) {
+      return this.bindTaskRunToChild(pendingTaskRunId, childSessionId)
+    }
+
+    const queuedChild: QueuedChildSessionMeta = {
+      id: childSessionId,
+      title: normalizeTaskTitle(hints?.title) || null,
+      agent: normalizeAgentName(hints?.agent) || null,
+    }
+    const current = this.queuedChildSessionsByParent.get(parentSessionId) || []
+    if (!current.some((entry) => entry.id === childSessionId)) {
+      this.queuedChildSessionsByParent.set(parentSessionId, [...current, queuedChild])
+    }
+    return null
+  }
+
+  ensureTaskRunForChild(
+    rootSessionId: string,
+    childSessionId: string,
+    agent?: string | null,
+    parentSessionId?: string | null,
+  ) {
+    const existingTaskRunId = this.childSessionToTaskRunId.get(childSessionId)
+    if (existingTaskRunId) return this.taskRuns.get(existingTaskRunId) || null
+
+    const immediateParentSessionId = parentSessionId || this.getImmediateParentSession(childSessionId) || rootSessionId
+    const fallback: TaskRunMeta = {
+      id: `child:${childSessionId}`,
+      rootSessionId,
+      parentSessionId: immediateParentSessionId,
+      title: chooseTaskTitle(agent),
+      agent: agent || null,
+      childSessionId,
+      status: 'queued',
+      startedAt: nowIso(),
+      finishedAt: null,
+    }
+    this.taskRuns.set(fallback.id, fallback)
+    this.childSessionToTaskRunId.set(childSessionId, fallback.id)
+    return fallback
+  }
+
+  updateTaskRun(taskRunId: string, patch: Partial<TaskRunMeta>) {
+    const existing = this.taskRuns.get(taskRunId)
+    if (!existing) return null
+    const next = applyTaskTimingTransition(existing, patch)
+    this.taskRuns.set(taskRunId, next)
+    if (next.childSessionId) {
+      this.childSessionToTaskRunId.set(next.childSessionId, next.id)
+    }
+    return next
+  }
+
+  getTaskRun(taskRunId: string | null | undefined) {
+    if (!taskRunId) return null
+    return this.taskRuns.get(taskRunId) || null
+  }
+
+  getTaskRunIdForChild(sessionId: string | null | undefined) {
+    if (!sessionId) return null
+    return this.childSessionToTaskRunId.get(sessionId) || null
+  }
+
+  rememberSubmittedPrompt(sessionId: string, text: string) {
+    if (!sessionId || !text) return
+    this.pendingSubmittedPromptBySession.set(sessionId, text)
+  }
+
+  forgetSubmittedPrompt(sessionId: string) {
+    this.pendingSubmittedPromptBySession.delete(sessionId)
+  }
+
+  consumePendingPromptEcho(sessionId: string, content: string) {
+    const pending = this.pendingSubmittedPromptBySession.get(sessionId)
+    if (!pending || !content) return content
+    if (content === pending) {
+      this.pendingSubmittedPromptBySession.delete(sessionId)
+      return ''
+    }
+    if (pending.startsWith(content)) {
+      this.pendingSubmittedPromptBySession.set(sessionId, pending.slice(content.length))
+      return ''
+    }
+    if (content.startsWith(pending)) {
+      this.pendingSubmittedPromptBySession.delete(sessionId)
+      return content.slice(pending.length)
+    }
+    return content
+  }
+
+  sweepStaleTaskState(messageRoles: Map<string, 'user' | 'assistant'>) {
+    for (const [childSessionId, taskRunId] of this.childSessionToTaskRunId.entries()) {
+      const taskRun = this.taskRuns.get(taskRunId)
+      if (!taskRun || taskRun.childSessionId !== childSessionId) {
+        this.childSessionToTaskRunId.delete(childSessionId)
+      }
+    }
+
+    for (const [parentSessionId] of this.pendingTaskRunsByParent.entries()) {
+      if (!this.isKnownSession(parentSessionId)) {
+        this.pendingTaskRunsByParent.delete(parentSessionId)
+      }
+    }
+
+    for (const [parentSessionId] of this.queuedChildSessionsByParent.entries()) {
+      if (!this.isKnownSession(parentSessionId)) {
+        this.queuedChildSessionsByParent.delete(parentSessionId)
+      }
+    }
+
+    while (messageRoles.size > 2000) {
+      const oldest = messageRoles.keys().next().value
+      if (!oldest) break
+      messageRoles.delete(oldest)
+    }
+  }
+
+  removeParentSessionState(sessionId: string) {
+    this.parentSessions.delete(sessionId)
+    this.sessionLineage.delete(sessionId)
+    this.pendingTaskRunsByParent.delete(sessionId)
+    this.queuedChildSessionsByParent.delete(sessionId)
+    this.pendingSubmittedPromptBySession.delete(sessionId)
+    this.deleteTaskRunsForSessions([sessionId])
+    for (const [taskRunId, taskRun] of this.taskRuns.entries()) {
+      if (taskRun.rootSessionId === sessionId) this.taskRuns.delete(taskRunId)
+    }
+    this.removeDescendantLineage(sessionId)
+  }
+
+  removeSessionState(sessionId: string, parentId?: string | null) {
+    this.deleteTaskRunsForSessions([sessionId])
+    this.sessionLineage.delete(sessionId)
+    this.pendingTaskRunsByParent.delete(sessionId)
+    this.queuedChildSessionsByParent.delete(sessionId)
+    this.pendingSubmittedPromptBySession.delete(sessionId)
+    this.removeDescendantLineage(sessionId)
+    if (!parentId) {
+      this.parentSessions.delete(sessionId)
+    }
+  }
+
+  private isKnownSession(sessionId: string) {
+    return this.parentSessions.has(sessionId) || this.sessionLineage.has(sessionId)
+  }
+
+  private wouldCreateLineageCycle(sessionId: string, parentId: string) {
+    let current: string | undefined = parentId
+    const seen = new Set<string>()
+    while (current) {
+      if (current === sessionId) return true
+      if (seen.has(current)) return true
+      seen.add(current)
+      const next = this.sessionLineage.get(current)
+      if (!next || next === current) return false
+      current = next
+    }
+    return false
+  }
+
+  private takePendingTaskRunId(parentSessionId: string, hints?: BindingHints | null) {
+    const current = this.mapTaskRunsForParent(parentSessionId)
+    if (current.length === 0) return null
+    if (current.length === 1) {
+      return shiftQueueValue(this.pendingTaskRunsByParent, parentSessionId) || null
+    }
+    const matchIndex = findBestIndexedMatch(
+      current
+        .map((taskRunId) => this.taskRuns.get(taskRunId))
+        .filter((taskRun): taskRun is TaskRunMeta => Boolean(taskRun)),
+      hints,
+    )
+    if (matchIndex < 0) return null
+    const matchId = current[matchIndex] || null
+    if (!matchId) return null
+    return spliceQueueValue(this.pendingTaskRunsByParent, parentSessionId, (value) => value === matchId)
+  }
+
+  private takeQueuedChildSession(
+    parentSessionId: string,
+    hints?: BindingHints | null,
+  ) {
+    const current = this.queuedChildSessionsByParent.get(parentSessionId) || []
+    if (current.length === 0) return null
+    if (current.length === 1) {
+      return spliceQueueValue(this.queuedChildSessionsByParent, parentSessionId, () => true)
+    }
+    const matchIndex = findBestIndexedMatch(current, hints)
+    if (matchIndex < 0) return null
+    const matchId = current[matchIndex]?.id
+    if (!matchId) return null
+    return spliceQueueValue(this.queuedChildSessionsByParent, parentSessionId, (value) => value.id === matchId)
+  }
+
+  private mapTaskRunsForParent(parentSessionId: string) {
+    return this.pendingTaskRunsByParent.get(parentSessionId) || []
+  }
+
+  private collectDescendantSessions(sessionId: string) {
+    const descendants: string[] = []
+    const queue = [sessionId]
+    while (queue.length > 0) {
+      const currentParentId = queue.shift()
+      if (!currentParentId) continue
+      for (const [childId, parentId] of this.sessionLineage.entries()) {
+        if (parentId !== currentParentId || childId === currentParentId) continue
+        descendants.push(childId)
+        queue.push(childId)
+      }
+    }
+    return descendants
+  }
+
+  private deleteTaskRunsForSessions(sessionIds: string[]) {
+    const targetIds = new Set(sessionIds)
+    for (const sessionId of targetIds) {
+      this.childSessionToTaskRunId.delete(sessionId)
+    }
+    for (const [taskRunId, taskRun] of this.taskRuns.entries()) {
+      const childSessionId = taskRun.childSessionId
+      if (
+        (childSessionId && targetIds.has(childSessionId))
+        || (taskRunId.startsWith('child:') && targetIds.has(taskRunId.slice('child:'.length)))
+      ) {
+        this.taskRuns.delete(taskRunId)
+      }
+    }
+  }
+
+  private removeDescendantLineage(sessionId: string) {
+    const descendants = this.collectDescendantSessions(sessionId)
+    this.deleteTaskRunsForSessions(descendants)
+    for (const childId of descendants) {
+      this.sessionLineage.delete(childId)
+      this.pendingTaskRunsByParent.delete(childId)
+      this.queuedChildSessionsByParent.delete(childId)
+      this.pendingSubmittedPromptBySession.delete(childId)
+    }
+  }
+}

--- a/tests/event-task-state.test.ts
+++ b/tests/event-task-state.test.ts
@@ -16,6 +16,7 @@ import {
   untrackParentSession,
   updateTaskRun,
 } from '../apps/desktop/src/main/event-task-state.ts'
+import { SessionTaskStateStore } from '../apps/desktop/src/main/session-task-state-store.ts'
 
 test.afterEach(() => {
   resetEventTaskState()
@@ -236,6 +237,26 @@ test('removeSessionState drops descendant task runs for deleted nested session t
 
   assert.equal(getTaskRun('child:child-session'), null)
   assert.equal(getTaskRun('child:grandchild-session'), null)
+})
+
+test('SessionTaskStateStore keeps hierarchy indexes isolated per instance', () => {
+  const first = new SessionTaskStateStore()
+  const second = new SessionTaskStateStore()
+
+  first.trackParentSession('root-session')
+  first.registerSession('child-session', 'root-session')
+  first.ensureTaskRunForChild('root-session', 'child-session', 'research')
+  first.rememberSubmittedPrompt('child-session', 'pending echo')
+
+  assert.equal(first.resolveRootSession('child-session'), 'root-session')
+  assert.equal(first.getTaskRun('child:child-session')?.childSessionId, 'child-session')
+  assert.equal(second.resolveRootSession('child-session'), 'child-session')
+  assert.equal(second.getTaskRun('child:child-session'), null)
+
+  first.removeSessionState('child-session', 'root-session')
+
+  assert.equal(first.getTaskRun('child:child-session'), null)
+  assert.equal(first.consumePendingPromptEcho('child-session', 'pending echo'), 'pending echo')
 })
 
 test('consumes pending prompt echo incrementally', () => {


### PR DESCRIPTION
## Summary
- move session/task hierarchy indexes and mutation methods into a dedicated SessionTaskStateStore
- keep event-task-state.ts as the stable facade for existing event/session callers
- add a direct store isolation and cleanup invariant test

## Validation
- pnpm test -- tests/event-task-state.test.ts tests/event-runtime-handlers.test.ts tests/ipc-handler-behavior.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check