### PR TITLE
Raise renderer coverage ratchet

### DIFF
--- a/apps/desktop/vitest.renderer.config.ts
+++ b/apps/desktop/vitest.renderer.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
         // Baseline ratchet for the current component-test suite.
         // Keep just below measured coverage and raise as stateful
         // renderer screens gain direct tests.
-        lines: 19,
-        branches: 13,
-        functions: 15,
-        statements: 18,
+        lines: 65,
+        branches: 51,
+        functions: 62,
+        statements: 61,
       },
     },
   },


### PR DESCRIPTION
## Summary
- raise renderer Vitest coverage thresholds from the old preview floor to the current measured suite level
- keep thresholds just below observed renderer coverage so regressions fail CI without requiring unrelated new tests

## Validation
- pnpm test:coverage:renderer
- pnpm lint
- pnpm typecheck
- git diff --check