### PR TITLE
Add signed update install capability guard

### DIFF
--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -30,6 +30,7 @@ import { getRuntimeInputDiagnostics } from '../runtime-input-diagnostics.ts'
 import { renderChartSpecToSvg } from '../chart-renderer.ts'
 import { saveChartArtifact } from '../chart-artifacts.ts'
 import { checkForUpdates } from '../update-check.ts'
+import { getUpdateInstallCapability } from '../update-service.ts'
 import { resetAppData } from '../app-reset.ts'
 import { readFileCheckedSync, readTextFileCheckedSync } from '../fs-read.ts'
 import { writeFileAtomic } from '../fs-atomic.ts'
@@ -341,6 +342,10 @@ export function registerAppHandlers(context: IpcHandlerContext) {
   // doesn't surface a "new version" hint — no false positives.
   context.ipcMain.handle('app:check-updates', async () => {
     return checkForUpdates()
+  })
+
+  context.ipcMain.handle('updates:install-capability', async () => {
+    return getUpdateInstallCapability()
   })
 
   // App-wide reset. Behind a destructive confirmation so a compromised

--- a/apps/desktop/src/main/update-check.ts
+++ b/apps/desktop/src/main/update-check.ts
@@ -10,7 +10,7 @@ export type UpdateCheckResult =
 // Parse owner/repo from a GitHub URL. Returns null for anything that
 // isn't github.com — downstream forks on GitLab / internal hosts
 // can extend this later; for now the upstream points at github.com.
-function parseGithubRepo(url: string): { owner: string; repo: string } | null {
+export function parseGithubRepo(url: string): { owner: string; repo: string } | null {
   try {
     const parsed = new URL(url)
     if (parsed.hostname !== 'github.com' && parsed.hostname !== 'www.github.com') return null
@@ -40,7 +40,7 @@ const FETCH_TIMEOUT_MS = 5000
 // we compare against the remote `tag_name`. We read it lazily because
 // the module can be imported from test contexts where `require` isn't
 // available.
-async function getCurrentVersion(): Promise<string> {
+export async function getCurrentVersion(): Promise<string> {
   try {
     // package.json is bundled inside the asar; Electron exposes it
     // via `app.getVersion()`. Dynamic import keeps the module

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -1,0 +1,60 @@
+import electron from 'electron'
+import type { UpdateInstallCapability, UpdateInstallUnsupportedReason } from '@open-cowork/shared'
+import { getBranding } from './config-loader.ts'
+import { getCurrentVersion, parseGithubRepo } from './update-check.ts'
+
+const electronApp = (electron as { app?: typeof import('electron').app }).app
+
+function manualReleaseUrlFromHelpUrl(helpUrl?: string | null): string | null {
+  const trimmed = helpUrl?.trim()
+  if (!trimmed) return null
+  const repo = parseGithubRepo(trimmed)
+  if (repo) return `https://github.com/${repo.owner}/${repo.repo}/releases`
+  return trimmed
+}
+
+function reasonCapability(input: {
+  isPackaged: boolean
+  platform: NodeJS.Platform
+  signedInstallEligible: boolean
+  feedConfigured: boolean
+}): UpdateInstallUnsupportedReason | null {
+  if (!input.isPackaged) return 'dev'
+  if (input.platform !== 'darwin') return 'platform'
+  if (!input.signedInstallEligible) return 'unsigned'
+  if (!input.feedConfigured) return 'missing-feed'
+  return null
+}
+
+export async function getUpdateInstallCapability(options?: {
+  isPackaged?: boolean
+  platform?: NodeJS.Platform
+  signedInstallEligible?: boolean
+  feedConfigured?: boolean
+  currentVersion?: string
+  manualReleaseUrl?: string | null
+}): Promise<UpdateInstallCapability> {
+  const currentVersion = options?.currentVersion ?? await getCurrentVersion()
+  const manualReleaseUrl = options && 'manualReleaseUrl' in options
+    ? options.manualReleaseUrl ?? null
+    : manualReleaseUrlFromHelpUrl(getBranding().helpUrl)
+  const reason = reasonCapability({
+    isPackaged: options?.isPackaged ?? (electronApp?.isPackaged === true),
+    platform: options?.platform ?? process.platform,
+    signedInstallEligible: options?.signedInstallEligible ?? false,
+    feedConfigured: options?.feedConfigured ?? false,
+  })
+  if (reason) {
+    return {
+      supported: false,
+      reason,
+      currentVersion,
+      manualReleaseUrl,
+    }
+  }
+  return {
+    supported: true,
+    currentVersion,
+    manualReleaseUrl,
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -68,6 +68,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'app:export-diagnostics',
   'app:check-updates',
   'app:reset',
+  'updates:install-capability',
   'automation:list',
   'automation:get',
   'automation:create',
@@ -237,6 +238,9 @@ const api: CoworkAPI = {
     exportDiagnostics: () => invoke('app:export-diagnostics'),
     checkUpdates: () => invoke('app:check-updates'),
     reset: (confirmationToken) => invoke('app:reset', confirmationToken),
+  },
+  updates: {
+    installCapability: () => invoke('updates:install-capability'),
   },
   automation: {
     list: () => invoke('automation:list'),

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
@@ -29,6 +29,30 @@ beforeEach(() => {
 })
 
 describe('StoragePanel', () => {
+  it('shows the manual update fallback when signed install is unsupported', async () => {
+    installRendererTestCoworkApi({
+      updates: {
+        installCapability: vi.fn(async () => ({
+          supported: false,
+          reason: 'unsigned',
+          currentVersion: '0.0.0',
+          manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+        })),
+      },
+    })
+
+    render(
+      <StoragePanel
+        stats={stats}
+        runningCleanup={null}
+        lastCleanup={null}
+        onCleanup={vi.fn(async () => undefined)}
+      />,
+    )
+
+    expect(await screen.findByText('This build is not signed for in-app update installation, so updates stay manual.')).toBeInTheDocument()
+  })
+
   it('surfaces diagnostics export failures through the chat error channel and diagnostics', async () => {
     const user = userEvent.setup()
     const reportRendererError = vi.fn()

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import type {
   SandboxCleanupResult,
   SandboxStorageStats,
+  UpdateInstallCapability,
 } from '@open-cowork/shared'
 import { writeTextToClipboard } from '../../helpers/clipboard'
 import { confirmAppReset } from '../../helpers/destructive-actions'
@@ -51,6 +52,24 @@ function reportStorageError(error: unknown, scope: string) {
   }
 }
 
+function describeInstallCapability(capability: UpdateInstallCapability) {
+  if (capability.supported) {
+    return t('settings.updates.installSupported', 'This signed macOS build is eligible for in-app update installation once install controls are enabled.')
+  }
+  switch (capability.reason) {
+    case 'dev':
+      return t('settings.updates.installUnsupportedDev', 'In-app installation is disabled while running from source. Use the manual release link for packaged builds.')
+    case 'platform':
+      return t('settings.updates.installUnsupportedPlatform', 'In-app installation is currently limited to signed macOS releases. Use the manual release link on this platform.')
+    case 'unsigned':
+      return t('settings.updates.installUnsupportedUnsigned', 'This build is not signed for in-app update installation, so updates stay manual.')
+    case 'missing-feed':
+      return t('settings.updates.installUnsupportedFeed', 'This build does not include signed update feed metadata, so updates stay manual.')
+    default:
+      return t('settings.updates.installUnsupportedGeneric', 'In-app installation is unavailable for this build. Use the manual release link.')
+  }
+}
+
 export function StoragePanel({
   stats,
   runningCleanup,
@@ -64,6 +83,7 @@ export function StoragePanel({
 }) {
   const [diagnosticsStatus, setDiagnosticsStatus] = useState<'idle' | 'working' | 'copied' | 'error'>('idle')
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ kind: 'idle' })
+  const [installCapability, setInstallCapability] = useState<UpdateInstallCapability | null>(null)
   const [resetting, setResetting] = useState(false)
   const [currentVersion, setCurrentVersion] = useState<string | null>(null)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
@@ -80,6 +100,13 @@ export function StoragePanel({
         if ('currentVersion' in result) setCurrentVersion(result.currentVersion)
       })
       .catch(() => { /* offline check is best-effort — version stays null */ })
+    window.coworkApi.updates.installCapability()
+      .then((capability) => {
+        if (cancelled) return
+        setInstallCapability(capability)
+        setCurrentVersion((current) => current || capability.currentVersion)
+      })
+      .catch(() => { /* capability hint is best-effort — manual check still works */ })
     return () => { cancelled = true }
   }, [])
 
@@ -237,6 +264,11 @@ export function StoragePanel({
         <div className="text-[11px] text-text-muted leading-relaxed">
           {t('settings.updates.description', "Queries the public GitHub Releases API for the latest published version. Read-only — there's no auto-download or auto-install.")}
         </div>
+        {installCapability ? (
+          <div className="rounded-xl border border-border-subtle bg-base px-3 py-2.5 text-[11px] leading-relaxed text-text-muted">
+            {describeInstallCapability(installCapability)}
+          </div>
+        ) : null}
         <button
           onClick={() => void handleCheckForUpdates()}
           disabled={updateStatus.kind === 'checking'}

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -43,6 +43,13 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
         providers: [],
         auth: { mode: 'none' },
       })),
+      checkUpdates: vi.fn(async () => ({
+        status: 'ok',
+        currentVersion: '0.0.0',
+        latestVersion: '0.0.0',
+        hasUpdate: false,
+        releaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases/tag/v0.0.0',
+      })),
     },
     agents: {
       list: vi.fn(async () => []),
@@ -131,6 +138,14 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       getProviderCredentials: vi.fn(async (providerId: string) => createDefaultSettings().providerCredentials[providerId] || {}),
       getIntegrationCredentials: vi.fn(async (integrationId: string) => createDefaultSettings().integrationCredentials[integrationId] || {}),
       set: vi.fn(async (updates) => createDefaultSettings(updates)),
+    },
+    updates: {
+      installCapability: vi.fn(async () => ({
+        supported: false,
+        reason: 'dev',
+        currentVersion: '0.0.0',
+        manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+      })),
     },
   }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -82,6 +82,9 @@ import type {
   SandboxStorageStats,
   SkillImportSelection,
 } from './workspace.js'
+import type {
+  UpdateInstallCapability,
+} from './updates.js'
 
 export * from './app-config.js'
 export * from './artifacts.js'
@@ -93,6 +96,7 @@ export * from './explorer.js'
 export * from './providers.js'
 export * from './runtime.js'
 export * from './session.js'
+export * from './updates.js'
 export * from './workspace.js'
 
 export type {
@@ -247,6 +251,9 @@ export interface CoworkAPI {
       removedPaths: string[]
       failedPaths?: Array<{ label: string; path: string; error: string }>
     }>
+  }
+  updates: {
+    installCapability: () => Promise<UpdateInstallCapability>
   }
   automation: {
     list: () => Promise<AutomationListPayload>

--- a/packages/shared/src/updates.ts
+++ b/packages/shared/src/updates.ts
@@ -1,0 +1,13 @@
+export type UpdateInstallUnsupportedReason =
+  | 'dev'
+  | 'unsigned'
+  | 'platform'
+  | 'missing-feed'
+  | 'unavailable'
+
+export interface UpdateInstallCapability {
+  supported: boolean
+  reason?: UpdateInstallUnsupportedReason
+  currentVersion: string
+  manualReleaseUrl: string | null
+}

--- a/tests/update-service.test.ts
+++ b/tests/update-service.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getUpdateInstallCapability } from '../apps/desktop/src/main/update-service.ts'
+
+test('update install capability disables install while running from source', async () => {
+  assert.deepEqual(await getUpdateInstallCapability({
+    isPackaged: false,
+    platform: 'darwin',
+    signedInstallEligible: true,
+    feedConfigured: true,
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  }), {
+    supported: false,
+    reason: 'dev',
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  })
+})
+
+test('update install capability is macOS-only for the first signed installer phase', async () => {
+  assert.deepEqual(await getUpdateInstallCapability({
+    isPackaged: true,
+    platform: 'linux',
+    signedInstallEligible: true,
+    feedConfigured: true,
+    currentVersion: '1.2.3',
+    manualReleaseUrl: null,
+  }), {
+    supported: false,
+    reason: 'platform',
+    currentVersion: '1.2.3',
+    manualReleaseUrl: null,
+  })
+})
+
+test('update install capability rejects unsigned packaged macOS builds', async () => {
+  assert.deepEqual(await getUpdateInstallCapability({
+    isPackaged: true,
+    platform: 'darwin',
+    signedInstallEligible: false,
+    feedConfigured: true,
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  }), {
+    supported: false,
+    reason: 'unsigned',
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  })
+})
+
+test('update install capability requires feed metadata after signing is eligible', async () => {
+  assert.deepEqual(await getUpdateInstallCapability({
+    isPackaged: true,
+    platform: 'darwin',
+    signedInstallEligible: true,
+    feedConfigured: false,
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  }), {
+    supported: false,
+    reason: 'missing-feed',
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  })
+})
+
+test('update install capability reports supported only for signed packaged macOS builds with feed metadata', async () => {
+  assert.deepEqual(await getUpdateInstallCapability({
+    isPackaged: true,
+    platform: 'darwin',
+    signedInstallEligible: true,
+    feedConfigured: true,
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  }), {
+    supported: true,
+    currentVersion: '1.2.3',
+    manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+  })
+})


### PR DESCRIPTION
## Summary
- add a typed update install capability contract and IPC route
- keep current builds on the manual update fallback unless signed macOS install eligibility and feed metadata are both present
- surface the unsupported reason in Settings so users understand why installation remains manual

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm --filter @open-cowork/desktop test:renderer -- SettingsStoragePanel
- pnpm build
- git diff --check

## Notes
This is the first safe slice of issue #40. It does not add a downloader or auto-install path; it only introduces the guarded capability model and UI fallback.