### PR TITLE
Add signed macOS update feed metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,8 @@ jobs:
           APP_PRODUCT_NAME: Open Cowork
           APP_ID: com.opencowork.desktop
           APP_ARTIFACT_PREFIX: Open-Cowork
+          OPEN_COWORK_SIGNED_UPDATE_INSTALL_ELIGIBLE: true
+          OPEN_COWORK_UPDATE_FEED_CONFIGURED: true
 
       - name: Build macOS release artifacts (unsigned preview override)
         if: steps.signing.outputs.mode == 'unsigned'
@@ -210,7 +212,20 @@ jobs:
           done < <(find apps/desktop/release -type f -name "*.dmg" -print0)
           test "$dmg_count" -gt 0
 
-      - name: Upload macOS artifacts
+      - name: Upload signed macOS artifacts
+        if: steps.signing.outputs.mode == 'signed'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-macos
+          if-no-files-found: error
+          path: |
+            apps/desktop/release/*.zip
+            apps/desktop/release/*.dmg
+            apps/desktop/release/*.blockmap
+            apps/desktop/release/latest-mac.yml
+
+      - name: Upload unsigned macOS artifacts
+        if: steps.signing.outputs.mode == 'unsigned'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-macos
@@ -300,10 +315,17 @@ jobs:
 
       - name: Verify release artifacts
         run: |
+          signing_mode="${{ needs.build-macos.outputs.signing-mode }}"
           test -d dist-artifacts/release-macos
           test -d dist-artifacts/release-linux
           find dist-artifacts/release-macos -type f \( -name '*.dmg' -o -name '*.zip' \) | grep -q .
           find dist-artifacts/release-linux -type f \( -name '*.AppImage' -o -name '*.deb' \) | grep -q .
+          if [ "$signing_mode" = "signed" ]; then
+            test -s dist-artifacts/release-macos/latest-mac.yml
+          elif [ -e dist-artifacts/release-macos/latest-mac.yml ]; then
+            echo "::error::Unsigned macOS preview artifacts must not publish latest-mac.yml feed metadata."
+            exit 1
+          fi
 
       - name: Enforce Linux signing policy
         run: |
@@ -422,6 +444,12 @@ jobs:
             dist-artifacts/THIRD_PARTY_LICENSES/**/*
             dist-artifacts/sbom.cdx.json
             dist-artifacts/sbom.spdx.json
+
+      - name: Attest signed macOS update feed metadata
+        if: needs.build-macos.outputs.signing-mode == 'signed'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist-artifacts/release-macos/latest-mac.yml
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -1,9 +1,17 @@
 import electron from 'electron'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import type { UpdateInstallCapability, UpdateInstallUnsupportedReason } from '@open-cowork/shared'
 import { getBranding } from './config-loader.ts'
 import { getCurrentVersion, parseGithubRepo } from './update-check.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
+const updateInstallCapabilityResourceName = 'open-cowork-update-capability.json'
+
+interface UpdateInstallCapabilityResource {
+  signedInstallEligible: boolean
+  feedConfigured: boolean
+}
 
 function manualReleaseUrlFromHelpUrl(helpUrl?: string | null): string | null {
   const trimmed = helpUrl?.trim()
@@ -26,6 +34,32 @@ function reasonCapability(input: {
   return null
 }
 
+function normalizeEmbeddedCapability(value: unknown): UpdateInstallCapabilityResource | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  if (record.schemaVersion !== 1) return null
+  return {
+    signedInstallEligible: record.signedInstallEligible === true,
+    feedConfigured: record.feedConfigured === true,
+  }
+}
+
+function readEmbeddedUpdateInstallCapability(resourcePath?: string | null): UpdateInstallCapabilityResource {
+  const defaultResourcePath = typeof process.resourcesPath === 'string'
+    ? join(process.resourcesPath, updateInstallCapabilityResourceName)
+    : null
+  const resolvedPath = resourcePath === undefined ? defaultResourcePath : resourcePath
+  if (!resolvedPath || !existsSync(resolvedPath)) {
+    return { signedInstallEligible: false, feedConfigured: false }
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(resolvedPath, 'utf8')) as unknown
+    return normalizeEmbeddedCapability(parsed) || { signedInstallEligible: false, feedConfigured: false }
+  } catch {
+    return { signedInstallEligible: false, feedConfigured: false }
+  }
+}
+
 export async function getUpdateInstallCapability(options?: {
   isPackaged?: boolean
   platform?: NodeJS.Platform
@@ -33,7 +67,9 @@ export async function getUpdateInstallCapability(options?: {
   feedConfigured?: boolean
   currentVersion?: string
   manualReleaseUrl?: string | null
+  resourcePath?: string | null
 }): Promise<UpdateInstallCapability> {
+  const embedded = readEmbeddedUpdateInstallCapability(options?.resourcePath)
   const currentVersion = options?.currentVersion ?? await getCurrentVersion()
   const manualReleaseUrl = options && 'manualReleaseUrl' in options
     ? options.manualReleaseUrl ?? null
@@ -41,8 +77,8 @@ export async function getUpdateInstallCapability(options?: {
   const reason = reasonCapability({
     isPackaged: options?.isPackaged ?? (electronApp?.isPackaged === true),
     platform: options?.platform ?? process.platform,
-    signedInstallEligible: options?.signedInstallEligible ?? false,
-    feedConfigured: options?.feedConfigured ?? false,
+    signedInstallEligible: options?.signedInstallEligible ?? embedded.signedInstallEligible,
+    feedConfigured: options?.feedConfigured ?? embedded.feedConfigured,
   })
   if (reason) {
     return {

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -64,6 +64,8 @@ The repository includes:
   - builds release artifacts for macOS and Linux
   - creates GitHub Releases automatically for version tags
   - publishes `SHA256SUMS.txt`
+  - publishes `latest-mac.yml` only for signed/notarized macOS release
+    artifacts, so unsigned preview builds stay on the manual update path
   - attaches GitHub build provenance attestation metadata
 
 - `monthly-maintenance.yml`
@@ -132,12 +134,15 @@ The release workflow no longer silently publishes unsigned macOS
 artifacts. A tagged release now does one of two things:
 
 - builds signed/notarized-capable macOS artifacts when the required
-  secrets are present, then publishes the GitHub Release
+  secrets are present, embeds signed-update capability metadata in the
+  packaged app, uploads `latest-mac.yml`, then publishes the GitHub
+  Release
 - fails unless the `OPEN_COWORK_ALLOW_UNSIGNED_RELEASES` repository
   variable is explicitly enabled for a preview-only unsigned `v0.x`
   build; in that mode the workflow can publish a GitHub Release, and the
   release notes / README must clearly mark the artifacts as unsigned
-  public-preview builds
+  public-preview builds. Unsigned preview builds intentionally omit
+  `latest-mac.yml`, so Settings keeps showing the manual update fallback.
 
 That keeps public production releases honest while still leaving a
 deliberate escape hatch for the initial unsigned public preview.

--- a/scripts/desktop-after-pack.mjs
+++ b/scripts/desktop-after-pack.mjs
@@ -1,9 +1,10 @@
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const virtualStoreDir = join(repoRoot, 'node_modules', '.pnpm')
+export const updateInstallCapabilityResourceName = 'open-cowork-update-capability.json'
 const platformPrefixes = {
   darwin: 'opencode-darwin-',
   linux: 'opencode-linux-',
@@ -96,6 +97,29 @@ export function listInstalledOpencodePackages(platformName, archName, options = 
   return Array.from(packagesByName.values())
 }
 
+function isTruthyEnv(value) {
+  return value === '1' || value === 'true'
+}
+
+export function buildUpdateInstallCapabilityResource(context, env = process.env) {
+  if (context.electronPlatformName !== 'darwin') return null
+  const signedInstallEligible = isTruthyEnv(env.OPEN_COWORK_SIGNED_UPDATE_INSTALL_ELIGIBLE)
+  const feedConfigured = isTruthyEnv(env.OPEN_COWORK_UPDATE_FEED_CONFIGURED)
+  if (!signedInstallEligible && !feedConfigured) return null
+  return {
+    schemaVersion: 1,
+    signedInstallEligible,
+    feedConfigured,
+  }
+}
+
+export function writeUpdateInstallCapabilityResource(context, resourcesDir, env = process.env) {
+  const marker = buildUpdateInstallCapabilityResource(context, env)
+  if (!marker) return false
+  writeFileSync(join(resourcesDir, updateInstallCapabilityResourceName), `${JSON.stringify(marker, null, 2)}\n`, { mode: 0o644 })
+  return true
+}
+
 export function createDesktopAfterPack(options = {}) {
   return async function afterPack(context) {
     const targetArch = getTargetArchName(context.arch)
@@ -110,7 +134,10 @@ export function createDesktopAfterPack(options = {}) {
       )
     }
 
-    const targetModulesDir = join(getResourcesDir(context), 'app.asar.unpacked', 'node_modules')
+    const resourcesDir = getResourcesDir(context)
+    writeUpdateInstallCapabilityResource(context, resourcesDir)
+
+    const targetModulesDir = join(resourcesDir, 'app.asar.unpacked', 'node_modules')
     mkdirSync(targetModulesDir, { recursive: true })
 
     for (const entry of packages) {

--- a/tests/desktop-after-pack.test.ts
+++ b/tests/desktop-after-pack.test.ts
@@ -4,12 +4,15 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
+  buildUpdateInstallCapabilityResource,
   createDesktopAfterPack,
   getPackageName,
   getPackageVersion,
   getTargetArchName,
   listInstalledOpencodePackages,
   packageTargetsArch,
+  updateInstallCapabilityResourceName,
+  writeUpdateInstallCapabilityResource,
 } from '../scripts/desktop-after-pack.mjs'
 
 function makeNativePackage(virtualStoreDir: string, packageName: string, version = '1.2.3') {
@@ -75,6 +78,42 @@ test('desktop-after-pack copies native OpenCode packages into app.asar.unpacked'
     assert.equal(existsSync(join(copiedPackage, 'bin', 'opencode')), true)
     assert.equal(readFileSync(join(copiedPackage, 'bin', 'opencode'), 'utf8'), 'binary')
     assert.equal(JSON.parse(readFileSync(join(copiedPackage, 'package.json'), 'utf8')).version, '1.2.3')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('desktop-after-pack writes signed macOS update capability metadata only when enabled', () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-after-pack-'))
+  try {
+    const resourcesDir = join(root, 'resources')
+    mkdirSync(resourcesDir, { recursive: true })
+
+    assert.equal(buildUpdateInstallCapabilityResource(
+      { electronPlatformName: 'linux' },
+      {
+        OPEN_COWORK_SIGNED_UPDATE_INSTALL_ELIGIBLE: 'true',
+        OPEN_COWORK_UPDATE_FEED_CONFIGURED: 'true',
+      },
+    ), null)
+    assert.equal(writeUpdateInstallCapabilityResource({ electronPlatformName: 'darwin' }, resourcesDir, {}), false)
+
+    assert.equal(writeUpdateInstallCapabilityResource(
+      { electronPlatformName: 'darwin' },
+      resourcesDir,
+      {
+        OPEN_COWORK_SIGNED_UPDATE_INSTALL_ELIGIBLE: 'true',
+        OPEN_COWORK_UPDATE_FEED_CONFIGURED: 'true',
+      },
+    ), true)
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(resourcesDir, updateInstallCapabilityResourceName), 'utf8')),
+      {
+        schemaVersion: 1,
+        signedInstallEligible: true,
+        feedConfigured: true,
+      },
+    )
   } finally {
     rmSync(root, { recursive: true, force: true })
   }

--- a/tests/update-service.test.ts
+++ b/tests/update-service.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { getUpdateInstallCapability } from '../apps/desktop/src/main/update-service.ts'
 
 test('update install capability disables install while running from source', async () => {
@@ -79,4 +82,53 @@ test('update install capability reports supported only for signed packaged macOS
     currentVersion: '1.2.3',
     manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
   })
+})
+
+test('update install capability reads signed feed eligibility from packaged resources', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-update-service-'))
+  try {
+    const markerPath = join(root, 'open-cowork-update-capability.json')
+    writeFileSync(markerPath, `${JSON.stringify({
+      schemaVersion: 1,
+      signedInstallEligible: true,
+      feedConfigured: true,
+    })}\n`)
+
+    assert.deepEqual(await getUpdateInstallCapability({
+      isPackaged: true,
+      platform: 'darwin',
+      currentVersion: '1.2.3',
+      manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+      resourcePath: markerPath,
+    }), {
+      supported: true,
+      currentVersion: '1.2.3',
+      manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+    })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('update install capability ignores malformed packaged resource markers', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-update-service-'))
+  try {
+    const markerPath = join(root, 'open-cowork-update-capability.json')
+    writeFileSync(markerPath, '{"schemaVersion":2,"signedInstallEligible":true,"feedConfigured":true}\n')
+
+    assert.deepEqual(await getUpdateInstallCapability({
+      isPackaged: true,
+      platform: 'darwin',
+      currentVersion: '1.2.3',
+      manualReleaseUrl: null,
+      resourcePath: markerPath,
+    }), {
+      supported: false,
+      reason: 'unsigned',
+      currentVersion: '1.2.3',
+      manualReleaseUrl: null,
+    })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary
- embed a non-secret signed update-install capability marker in packaged macOS apps only when the signed feed is intentionally enabled
- have Settings/update capability detection read that packaged marker before exposing install support
- publish and attest latest-mac.yml only for signed macOS releases, while unsigned previews omit feed metadata

## Validation
- pnpm test
- pnpm typecheck
- git diff --check
- pnpm lint
- uv run mkdocs build --strict
- pnpm build
- OPEN_COWORK_SIGNED_UPDATE_INSTALL_ELIGIBLE=true OPEN_COWORK_UPDATE_FEED_CONFIGURED=true pnpm --dir apps/desktop dist:ci
- OPEN_COWORK_PACKAGED_EXECUTABLE=... pnpm --dir apps/desktop test:e2e:packaged