### PR TITLE
Validate signed update capability in packaged smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,7 @@ jobs:
         run: pnpm --dir apps/desktop test:e2e:packaged
         env:
           OPEN_COWORK_PACKAGED_EXECUTABLE: ${{ steps.packaged-executable.outputs.path }}
+          OPEN_COWORK_EXPECT_SIGNED_UPDATE_INSTALL: ${{ steps.signing.outputs.mode == 'signed' }}
 
       - name: Verify macOS signing and notarization
         if: steps.signing.outputs.mode == 'signed'

--- a/apps/desktop/tests/packaged-relaunch.packaged.test.ts
+++ b/apps/desktop/tests/packaged-relaunch.packaged.test.ts
@@ -8,9 +8,17 @@ import {
 } from './smoke-helpers.ts'
 
 const packagedExecutablePath = process.env.OPEN_COWORK_PACKAGED_EXECUTABLE?.trim()
+const expectSignedUpdateInstall = process.env.OPEN_COWORK_EXPECT_SIGNED_UPDATE_INSTALL?.toLowerCase() === 'true'
 const packagedRelaunchTimeoutMs = 240_000
 const packagedLaunchTimeoutMs = 90_000
 const packagedIpcTimeoutMs = 60_000
+const updateInstallUnsupportedReasons = new Set([
+  'dev',
+  'unsigned',
+  'platform',
+  'missing-feed',
+  'unavailable',
+])
 
 async function withTimeout<T>(label: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timeout: NodeJS.Timeout | undefined
@@ -52,6 +60,33 @@ test(
         executablePath,
         appShellTimeoutMs: packagedLaunchTimeoutMs,
       })
+
+      const updateInstallCapability = await withTimeout(
+        'checking packaged update install capability',
+        firstLaunch.page.evaluate(async () => window.coworkApi.updates.installCapability()),
+        packagedIpcTimeoutMs,
+      )
+      assert.equal(
+        typeof updateInstallCapability.currentVersion,
+        'string',
+        'expected packaged update capability to include the running app version',
+      )
+      assert.equal(
+        updateInstallCapability.currentVersion.length > 0,
+        true,
+        'expected packaged update capability version to be non-empty',
+      )
+      if (expectSignedUpdateInstall) {
+        assert.equal(updateInstallCapability.supported, true, 'expected signed packaged macOS build to advertise in-app update install support')
+        assert.equal(updateInstallCapability.reason, undefined)
+      } else {
+        assert.equal(updateInstallCapability.supported, false, 'expected unsigned or unsupported packaged build to keep in-app update install disabled')
+        assert.equal(
+          updateInstallUnsupportedReasons.has(String(updateInstallCapability.reason)),
+          true,
+          `expected a known update install unsupported reason, got ${String(updateInstallCapability.reason)}`,
+        )
+      }
 
       const initialSessions = await withTimeout(
         'listing packaged sessions before relaunch',

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -135,8 +135,8 @@ artifacts. A tagged release now does one of two things:
 
 - builds signed/notarized-capable macOS artifacts when the required
   secrets are present, embeds signed-update capability metadata in the
-  packaged app, uploads `latest-mac.yml`, then publishes the GitHub
-  Release
+  packaged app, verifies the packaged Settings updater capability,
+  uploads `latest-mac.yml`, then publishes the GitHub Release
 - fails unless the `OPEN_COWORK_ALLOW_UNSIGNED_RELEASES` repository
   variable is explicitly enabled for a preview-only unsigned `v0.x`
   build; in that mode the workflow can publish a GitHub Release, and the
@@ -146,6 +146,21 @@ artifacts. A tagged release now does one of two things:
 
 That keeps public production releases honest while still leaving a
 deliberate escape hatch for the initial unsigned public preview.
+
+For signed macOS releases, the packaged smoke test runs with
+`OPEN_COWORK_EXPECT_SIGNED_UPDATE_INSTALL=true` and calls the renderer's
+typed `updates.installCapability()` API. The smoke does not download or
+install an update; it only proves the signed build advertises in-app
+installation support. Unsigned preview and non-macOS package smoke runs
+keep that expectation unset, so the same test proves Settings stays on
+the manual-update fallback.
+
+Before announcing a signed public tag, run one manual staging update from
+version `N` to `N+1`: install the previous signed build, open Settings,
+check for updates, download the new signed update, restart to install,
+and confirm the relaunched app reports the new version. This manual
+exercise is intentionally outside CI because it uses a real published
+feed and real signed artifacts.
 
 ### Signing gate inputs
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -63,6 +63,8 @@ Reference workflows in the repository root:
 - [ ] the release repo or fork has the signing inputs expected by the release workflow (`MAC_CERTIFICATE_P12_BASE64`, `MAC_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`); a first `v*` tag intentionally fails without those inputs unless the unsigned preview override is enabled
 - [ ] Linux artifacts are either signed with the current release policy or explicitly documented as unsigned and verified through `SHA256SUMS.txt` plus GitHub provenance
 - [ ] release assets still include `SHA256SUMS.txt`, `THIRD_PARTY_NOTICES.md`, `THIRD_PARTY_LICENSES/`, SBOMs, and provenance attestation
+- [ ] signed macOS releases include `latest-mac.yml`; unsigned preview releases do not include signed update feed metadata
+- [ ] for signed macOS releases, Settings reports in-app update installation as supported in the packaged smoke run
 - [ ] docs drift is acceptable for this release: the published Pages site tracks `master`, not immutable versioned docs; decide on versioned docs before v0.2.0
 - [ ] every `[Unreleased]` changelog bullet has been checked against the app before moving it into the tagged release section
 - [ ] `CHANGELOG.md`: rename the `[Unreleased]` heading to `[X.Y.Z] - YYYY-MM-DD` with the tag version (without the leading `v`) and tag date, then add a fresh empty `[Unreleased]` section above it for the next cycle
@@ -83,10 +85,16 @@ git push origin vX.Y.Z
 3. Verify the GitHub Release contains:
    - macOS zip artifacts
    - macOS dmg artifacts
+   - `latest-mac.yml` for signed macOS releases only
    - Linux AppImage artifacts
    - Linux deb artifacts
    - `SHA256SUMS.txt`
 4. Smoke-test at least one macOS build and one Linux build.
+5. For signed macOS releases, run a staging update check from version
+   `N` to `N+1`: install the previous signed build, open Settings, check
+   for updates, download the new signed update, restart to install, and
+   confirm the app relaunches on the new version. Do not perform this
+   self-update test for unsigned preview artifacts.
 
 ## After release
 


### PR DESCRIPTION
## Summary
- make packaged smoke assert update install capability without downloading or installing
- pass the signed-update expectation from release.yml only for signed macOS release builds
- document signed updater validation and the manual N-to-N+1 release QA path

## Validation
- OPEN_COWORK_PACKAGED_EXECUTABLE=... pnpm --dir apps/desktop test:e2e:packaged (rerun with local-port privileges after sandbox denied 127.0.0.1 listen)
- pnpm typecheck
- pnpm lint
- uv run mkdocs build --strict
- git diff --check
- pnpm test