### PR TITLE
[codex] Clarify runtime permission controls

### DIFF
--- a/apps/desktop/src/main/config-public.ts
+++ b/apps/desktop/src/main/config-public.ts
@@ -171,6 +171,10 @@ export function buildPublicAppConfig(
       defaultProvider: config.providers.defaultProvider,
       defaultModel: config.providers.defaultModel,
     },
+    permissions: {
+      bash: config.permissions.bash,
+      fileWrite: config.permissions.fileWrite,
+    },
     agentStarterTemplates: config.agentStarterTemplates || [],
     // Pass through the i18n overlay if present — renderer code reads
     // `config.i18n` via the public-config IPC. Absent block is treated

--- a/apps/desktop/src/main/ipc/provider-handlers.ts
+++ b/apps/desktop/src/main/ipc/provider-handlers.ts
@@ -121,4 +121,18 @@ export function registerProviderHandlers(context: IpcHandlerContext, electronShe
       throw err
     }
   })
+
+  context.ipcMain.handle('provider:auth-remove', async (_event, providerIdInput: unknown) => {
+    const providerId = resolveKnownProviderId(providerIdInput)
+    const client = getClient()
+    if (!client) throw new Error('OpenCode runtime is not running. Start the runtime, then try provider sign-out again.')
+    try {
+      await client.auth.remove({ providerID: providerId }, { throwOnError: true })
+      log('provider', `Removed OpenCode-native auth for ${providerId}`)
+      return true
+    } catch (err) {
+      context.logHandlerError(`provider:auth-remove ${providerId}`, err)
+      throw err
+    }
+  })
 }

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -232,8 +232,12 @@ export function buildEffectiveProviderRuntimeConfig(
   return null
 }
 
-function applyUserToggle(defaultPolicy: PermissionAction, enabled: boolean): PermissionAction {
-  return enabled ? defaultPolicy : 'deny'
+function applyUserPermissionPolicy(
+  defaultPolicy: PermissionAction,
+  selectedPolicy: PermissionAction | undefined,
+  legacyEnabled: boolean,
+): PermissionAction {
+  return legacyEnabled ? selectedPolicy || defaultPolicy : 'deny'
 }
 
 function webSearchPolicy(web: PermissionAction, enabled: boolean): PermissionAction {
@@ -248,8 +252,8 @@ function buildRuntimeConfigWithCustomMcps(
   const settings = getEffectiveSettings()
   const appConfig = getAppConfig()
   const appPermissions = appConfig.permissions
-  const bashPolicy = applyUserToggle(appPermissions.bash, settings.enableBash)
-  const fileWritePolicy = applyUserToggle(appPermissions.fileWrite, settings.enableFileWrite)
+  const bashPolicy = applyUserPermissionPolicy(appPermissions.bash, settings.bashPermission, settings.enableBash)
+  const fileWritePolicy = applyUserPermissionPolicy(appPermissions.fileWrite, settings.fileWritePermission, settings.enableFileWrite)
   const webPolicy = appPermissions.web
   const effectiveWebSearchPolicy = webSearchPolicy(webPolicy, appPermissions.webSearch)
   const providerId = settings.effectiveProviderId || appConfig.providers.defaultProvider || 'openrouter'

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -5,6 +5,7 @@ import type {
   AgentColor,
   AppSettings,
   EffectiveAppSettings,
+  RuntimePermissionPolicy,
 } from '@open-cowork/shared'
 import {
   getAppConfig,
@@ -25,13 +26,18 @@ export type { AgentColor }
 
 let settingsCache: AppSettings | null = null
 
-export const SETTINGS_SCHEMA_VERSION = 1
+export const SETTINGS_SCHEMA_VERSION = 2
 
-type NativePermissionDefault = 'allow' | 'ask' | 'deny'
+type NativePermissionDefault = RuntimePermissionPolicy
 const MAX_SETTINGS_MAP_ENTRIES = 64
 const MAX_SETTINGS_KEY_BYTES = 256
 const MAX_SETTINGS_VALUE_BYTES = 64 * 1024
 const QUIET_HOURS_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+const PERMISSION_POLICY_RANK: Record<RuntimePermissionPolicy, number> = {
+  deny: 0,
+  ask: 1,
+  allow: 2,
+}
 
 class UnsupportedSettingsSchemaVersionError extends Error {
   constructor(version: number) {
@@ -42,6 +48,47 @@ class UnsupportedSettingsSchemaVersionError extends Error {
 
 export function nativePermissionEnabledByDefault(policy: NativePermissionDefault) {
   return policy !== 'deny'
+}
+
+function isRuntimePermissionPolicy(value: unknown): value is RuntimePermissionPolicy {
+  return value === 'allow' || value === 'ask' || value === 'deny'
+}
+
+function clampRuntimePermissionPolicy(
+  requested: RuntimePermissionPolicy,
+  maximum: RuntimePermissionPolicy,
+): RuntimePermissionPolicy {
+  return PERMISSION_POLICY_RANK[requested] <= PERMISSION_POLICY_RANK[maximum]
+    ? requested
+    : maximum
+}
+
+function defaultRuntimePermissionPolicy(maximum: RuntimePermissionPolicy): RuntimePermissionPolicy {
+  // Keep fresh installs conservative even when a build allows users to opt
+  // into no-prompt execution from Settings.
+  return maximum === 'deny' ? 'deny' : 'ask'
+}
+
+function normalizeRuntimePermissionPolicy(
+  requested: unknown,
+  maximum: RuntimePermissionPolicy,
+): RuntimePermissionPolicy | undefined {
+  return isRuntimePermissionPolicy(requested)
+    ? clampRuntimePermissionPolicy(requested, maximum)
+    : undefined
+}
+
+function migrateRuntimePermissionPolicy(
+  requested: unknown,
+  legacyEnabled: unknown,
+  maximum: RuntimePermissionPolicy,
+  fallback: RuntimePermissionPolicy,
+): RuntimePermissionPolicy {
+  const normalized = normalizeRuntimePermissionPolicy(requested, maximum)
+  if (normalized) return normalized
+  if (legacyEnabled === false) return 'deny'
+  if (legacyEnabled === true) return clampRuntimePermissionPolicy('ask', maximum)
+  return fallback
 }
 
 function resolveProviderModelSelection(
@@ -66,6 +113,8 @@ function createDefaults(): AppSettings {
   const appConfig = getAppConfig()
   const defaultProvider = config.providers.defaultProvider
   const defaultProviderDescriptor = config.providers.available.find((provider) => provider.id === defaultProvider)
+  const bashPermission = defaultRuntimePermissionPolicy(appConfig.permissions.bash)
+  const fileWritePermission = defaultRuntimePermissionPolicy(appConfig.permissions.fileWrite)
   return {
     _schemaVersion: SETTINGS_SCHEMA_VERSION,
     selectedProviderId: defaultProvider,
@@ -73,8 +122,10 @@ function createDefaults(): AppSettings {
     providerCredentials: {},
     integrationCredentials: {},
     integrationEnabled: {},
-    enableBash: nativePermissionEnabledByDefault(appConfig.permissions.bash),
-    enableFileWrite: nativePermissionEnabledByDefault(appConfig.permissions.fileWrite),
+    bashPermission,
+    fileWritePermission,
+    enableBash: nativePermissionEnabledByDefault(bashPermission),
+    enableFileWrite: nativePermissionEnabledByDefault(fileWritePermission),
     runtimeToolingBridgeEnabled: true,
     automationLaunchAtLogin: false,
     automationRunInBackground: false,
@@ -153,6 +204,7 @@ function normalizeQuietHours(value: unknown) {
 
 function normalizeSettingsUpdate(settings: Partial<AppSettings>) {
   const update: Partial<AppSettings> = {}
+  const appPermissions = getAppConfig().permissions
   if (typeof settings.selectedProviderId === 'string' && Buffer.byteLength(settings.selectedProviderId, 'utf8') <= MAX_SETTINGS_KEY_BYTES) update.selectedProviderId = settings.selectedProviderId
   if (settings.selectedProviderId === null) update.selectedProviderId = null
   if (typeof settings.selectedModelId === 'string' && Buffer.byteLength(settings.selectedModelId, 'utf8') <= MAX_SETTINGS_KEY_BYTES) update.selectedModelId = settings.selectedModelId
@@ -160,8 +212,26 @@ function normalizeSettingsUpdate(settings: Partial<AppSettings>) {
   if (settings.providerCredentials !== undefined) update.providerCredentials = normalizeNestedStringMap(settings.providerCredentials)
   if (settings.integrationCredentials !== undefined) update.integrationCredentials = normalizeNestedStringMap(settings.integrationCredentials)
   if (settings.integrationEnabled !== undefined) update.integrationEnabled = normalizeBoolMap(settings.integrationEnabled)
-  if (typeof settings.enableBash === 'boolean') update.enableBash = settings.enableBash
-  if (typeof settings.enableFileWrite === 'boolean') update.enableFileWrite = settings.enableFileWrite
+  const bashPermission = normalizeRuntimePermissionPolicy(settings.bashPermission, appPermissions.bash)
+  if (bashPermission) {
+    update.bashPermission = bashPermission
+    update.enableBash = bashPermission !== 'deny'
+  } else if (typeof settings.enableBash === 'boolean') {
+    update.enableBash = settings.enableBash
+    update.bashPermission = settings.enableBash
+      ? defaultRuntimePermissionPolicy(appPermissions.bash)
+      : 'deny'
+  }
+  const fileWritePermission = normalizeRuntimePermissionPolicy(settings.fileWritePermission, appPermissions.fileWrite)
+  if (fileWritePermission) {
+    update.fileWritePermission = fileWritePermission
+    update.enableFileWrite = fileWritePermission !== 'deny'
+  } else if (typeof settings.enableFileWrite === 'boolean') {
+    update.enableFileWrite = settings.enableFileWrite
+    update.fileWritePermission = settings.enableFileWrite
+      ? defaultRuntimePermissionPolicy(appPermissions.fileWrite)
+      : 'deny'
+  }
   if (typeof settings.runtimeToolingBridgeEnabled === 'boolean') update.runtimeToolingBridgeEnabled = settings.runtimeToolingBridgeEnabled
   if (typeof settings.automationLaunchAtLogin === 'boolean') update.automationLaunchAtLogin = settings.automationLaunchAtLogin
   if (typeof settings.automationRunInBackground === 'boolean') update.automationRunInBackground = settings.automationRunInBackground
@@ -182,6 +252,19 @@ function normalizeSettingsUpdate(settings: Partial<AppSettings>) {
 function migrateLegacySettings(raw: any): AppSettings {
   assertSupportedSettingsSchemaVersion(raw)
   const defaults = createDefaults()
+  const appPermissions = getAppConfig().permissions
+  const bashPermission = migrateRuntimePermissionPolicy(
+    raw?.bashPermission,
+    raw?.enableBash,
+    appPermissions.bash,
+    defaults.bashPermission,
+  )
+  const fileWritePermission = migrateRuntimePermissionPolicy(
+    raw?.fileWritePermission,
+    raw?.enableFileWrite,
+    appPermissions.fileWrite,
+    defaults.fileWritePermission,
+  )
   const next: AppSettings = {
     ...defaults,
     _schemaVersion: SETTINGS_SCHEMA_VERSION,
@@ -198,8 +281,10 @@ function migrateLegacySettings(raw: any): AppSettings {
     providerCredentials: normalizeNestedStringMap(raw?.providerCredentials),
     integrationCredentials: normalizeNestedStringMap(raw?.integrationCredentials),
     integrationEnabled: normalizeBoolMap(raw?.integrationEnabled),
-    enableBash: typeof raw?.enableBash === 'boolean' ? raw.enableBash : defaults.enableBash,
-    enableFileWrite: typeof raw?.enableFileWrite === 'boolean' ? raw.enableFileWrite : defaults.enableFileWrite,
+    bashPermission,
+    fileWritePermission,
+    enableBash: bashPermission !== 'deny',
+    enableFileWrite: fileWritePermission !== 'deny',
     runtimeToolingBridgeEnabled: raw?.runtimeToolingBridgeEnabled !== false,
     automationLaunchAtLogin: raw?.automationLaunchAtLogin === true,
     automationRunInBackground: raw?.automationRunInBackground === true,
@@ -471,6 +556,7 @@ export function isSetupComplete(settings = loadSettings()) {
 
 export function getEffectiveSettings(settings = loadSettings()): EffectiveAppSettings {
   const config = getPublicAppConfig()
+  const appPermissions = getAppConfig().permissions
   const configuredDefaultProvider = config.providers.defaultProvider
   const selectedProvider = settings.selectedProviderId
     ? getProviderDescriptor(settings.selectedProviderId)
@@ -484,9 +570,21 @@ export function getEffectiveSettings(settings = loadSettings()): EffectiveAppSet
   const validSelectedModel = resolveProviderModelSelection(providerId, provider?.models, settings.selectedModelId)
   const fallbackModel = validDefaultModel || provider?.models?.[0]?.id || ''
   const selectedModelId = validSelectedModel || fallbackModel
+  const bashPermission = clampRuntimePermissionPolicy(
+    settings.enableBash === false ? 'deny' : settings.bashPermission,
+    appPermissions.bash,
+  )
+  const fileWritePermission = clampRuntimePermissionPolicy(
+    settings.enableFileWrite === false ? 'deny' : settings.fileWritePermission,
+    appPermissions.fileWrite,
+  )
 
   return {
     ...settings,
+    bashPermission,
+    fileWritePermission,
+    enableBash: bashPermission !== 'deny',
+    enableFileWrite: fileWritePermission !== 'deny',
     effectiveProviderId: providerId,
     effectiveModel: selectedModelId,
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -64,6 +64,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'provider:auth-methods',
   'provider:oauth-authorize',
   'provider:oauth-callback',
+  'provider:auth-remove',
   'runtime:status',
   'runtime:restart',
   'diagnostics:perf',
@@ -230,6 +231,7 @@ const api: CoworkAPI = {
     authMethods: () => invoke('provider:auth-methods'),
     authorize: (providerId, method, inputs) => invoke('provider:oauth-authorize', providerId, method, inputs),
     callback: (providerId, method, code) => invoke('provider:oauth-callback', providerId, method, code),
+    logout: (providerId) => invoke('provider:auth-remove', providerId),
   },
   runtime: {
     status: () => invoke('runtime:status'),

--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -239,6 +239,8 @@ const completeSettings: EffectiveAppSettings = {
   },
   integrationCredentials: {},
   integrationEnabled: {},
+  bashPermission: 'deny',
+  fileWritePermission: 'deny',
   enableBash: false,
   enableFileWrite: false,
   runtimeToolingBridgeEnabled: true,
@@ -291,6 +293,10 @@ const config: PublicAppConfig = {
         ],
       },
     ],
+  },
+  permissions: {
+    bash: 'allow',
+    fileWrite: 'allow',
   },
   agentStarterTemplates: [],
   i18n: {

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -36,6 +36,8 @@ const baseSettings: EffectiveAppSettings = {
   providerCredentials: {},
   integrationCredentials: {},
   integrationEnabled: {},
+  bashPermission: 'deny',
+  fileWritePermission: 'deny',
   enableBash: false,
   enableFileWrite: false,
   runtimeToolingBridgeEnabled: true,

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -13,6 +13,8 @@ function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSe
     providerCredentials: {},
     integrationCredentials: {},
     integrationEnabled: {},
+    bashPermission: 'deny',
+    fileWritePermission: 'deny',
     enableBash: false,
     enableFileWrite: false,
     runtimeToolingBridgeEnabled: true,

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -157,6 +157,8 @@ function renderAutomationsPage(options: {
           providerCredentials: {},
           integrationCredentials: {},
           integrationEnabled: {},
+          bashPermission: 'deny',
+          fileWritePermission: 'deny',
           enableBash: false,
           enableFileWrite: false,
           runtimeToolingBridgeEnabled: true,

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -142,6 +142,8 @@ function renderCapabilitiesPage(overrides: {
         charts: overrides.integrationCredentials ?? { apiKey: 'ck-stored' },
       },
       integrationEnabled: {},
+      bashPermission: 'deny',
+      fileWritePermission: 'deny',
       enableBash: false,
       enableFileWrite: false,
       runtimeToolingBridgeEnabled: true,

--- a/apps/desktop/src/renderer/components/chat/SessionInspector.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionInspector.test.tsx
@@ -159,6 +159,8 @@ function installInspectorApi() {
         providerCredentials: {},
         integrationCredentials: {},
         integrationEnabled: {},
+        bashPermission: 'deny',
+        fileWritePermission: 'deny',
         enableBash: false,
         enableFileWrite: false,
         runtimeToolingBridgeEnabled: true,

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
@@ -48,4 +48,27 @@ describe('ProviderAuthControls', () => {
     expect(window.coworkApi.runtime.restart).not.toHaveBeenCalled()
     expect(screen.getByText('Provider login completed.')).toBeTruthy()
   })
+
+  it('can clear stale OpenCode-native provider auth before a fresh login', async () => {
+    vi.mocked(window.coworkApi.provider.authMethods).mockResolvedValue({
+      openai: [browserMethod],
+    })
+    const onAuthUpdated = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ProviderAuthControls
+        providerId="openai"
+        providerName="OpenAI"
+        connected
+        onAuthUpdated={onAuthUpdated}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Forget login' }))
+
+    await waitFor(() => expect(window.coworkApi.provider.logout).toHaveBeenCalledWith('openai'))
+    expect(onAuthUpdated).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Provider login removed. Sign in again to refresh the token.')).toBeTruthy()
+  })
 })

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
@@ -203,6 +203,25 @@ export function ProviderAuthControls({
     }
   }
 
+  const forgetProviderLogin = async () => {
+    if (!providerId) return
+    setAuthorizing(-1)
+    setStatus(null)
+    try {
+      await window.coworkApi.provider.logout(providerId)
+      setPending(null)
+      setPendingBrowserLogin(false)
+      setCode('')
+      setStatus(t('providerAuth.removed', 'Provider login removed. Sign in again to refresh the token.'))
+      await onAuthUpdated?.()
+      void loadMethods()
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : String(err))
+    } finally {
+      setAuthorizing(null)
+    }
+  }
+
   const entries = oauthMethods
 
   return (
@@ -220,8 +239,16 @@ export function ProviderAuthControls({
           </div>
         ) : null}
         {connected === true ? (
-          <div className="rounded-xl border border-border-subtle px-3 py-2 text-[11px] leading-relaxed" style={{ color: 'var(--color-green)', background: 'var(--color-surface)' }}>
-            {t('providerAuth.connectedStatus', 'OpenCode reports this provider is signed in.')}
+          <div className="rounded-xl border border-border-subtle px-3 py-2 text-[11px] leading-relaxed flex items-center justify-between gap-3" style={{ color: 'var(--color-green)', background: 'var(--color-surface)' }}>
+            <span>{t('providerAuth.connectedStatus', 'OpenCode reports this provider is signed in.')}</span>
+            <button
+              type="button"
+              onClick={forgetProviderLogin}
+              disabled={authorizing !== null}
+              className="shrink-0 px-2 py-1 rounded-lg border border-border-subtle text-[11px] font-semibold text-text hover:bg-surface-hover cursor-pointer disabled:opacity-60 disabled:cursor-wait"
+            >
+              {t('providerAuth.forgetLogin', 'Forget login')}
+            </button>
           </div>
         ) : null}
         {!loading && entries.length === 0 ? (

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EffectiveAppSettings, PublicAppConfig } from '@open-cowork/shared'
@@ -13,6 +13,8 @@ function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSe
     providerCredentials: {},
     integrationCredentials: {},
     integrationEnabled: {},
+    bashPermission: 'deny',
+    fileWritePermission: 'deny',
     enableBash: false,
     enableFileWrite: false,
     runtimeToolingBridgeEnabled: true,
@@ -73,6 +75,10 @@ const config: PublicAppConfig = {
         defaultModel: 'anthropic/claude-sonnet-4',
       },
     ],
+  },
+  permissions: {
+    bash: 'allow',
+    fileWrite: 'allow',
   },
   agentStarterTemplates: [],
 }
@@ -186,7 +192,7 @@ describe('SettingsPanel', () => {
     }))
   })
 
-  it('persists the developer config bridge permission toggle', async () => {
+  it('persists explicit developer permission modes', async () => {
     const settingsSet = vi.mocked(window.coworkApi.settings.set)
     const user = userEvent.setup()
 
@@ -194,6 +200,9 @@ describe('SettingsPanel', () => {
 
     await screen.findByText('Settings')
     await user.click(screen.getByRole('button', { name: /Permissions/ }))
+
+    await user.click(within(screen.getByRole('group', { name: 'Shell commands' })).getByRole('button', { name: 'Allow' }))
+    await user.click(within(screen.getByRole('group', { name: 'File editing' })).getByRole('button', { name: 'Allow' }))
 
     const toolingBridge = await screen.findByRole('switch', { name: 'Developer config bridge' })
     expect(toolingBridge).toHaveAttribute('aria-checked', 'true')
@@ -205,8 +214,10 @@ describe('SettingsPanel', () => {
 
     await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1))
     expect(settingsSet.mock.calls[0]?.[0]).toMatchObject({
-      enableBash: false,
-      enableFileWrite: false,
+      bashPermission: 'allow',
+      fileWritePermission: 'allow',
+      enableBash: true,
+      enableFileWrite: true,
       runtimeToolingBridgeEnabled: false,
     })
   })

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -145,6 +145,8 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
         selectedModelId: settings.selectedModelId,
         providerCredentials: settings.providerCredentials,
         integrationCredentials: settings.integrationCredentials,
+        bashPermission: settings.bashPermission,
+        fileWritePermission: settings.fileWritePermission,
         enableBash: settings.enableBash,
         enableFileWrite: settings.enableFileWrite,
         runtimeToolingBridgeEnabled: settings.runtimeToolingBridgeEnabled,
@@ -278,7 +280,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
               />
             )}
             {tab === 'permissions' && (
-              <PermissionsPanel settings={settings} update={update} />
+              <PermissionsPanel permissions={config.permissions} settings={settings} update={update} />
             )}
             {tab === 'automations' && (
               <AutomationSettingsPanel settings={settings} update={update} />

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPermissionsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPermissionsPanel.tsx
@@ -1,65 +1,116 @@
-import type { EffectiveAppSettings } from '@open-cowork/shared'
+import type { EffectiveAppSettings, PublicAppConfig, RuntimePermissionPolicy } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import {
   panelCardCls,
   sectionLabelCls,
 } from './settings-panel-styles'
 
+const PERMISSION_RANK: Record<RuntimePermissionPolicy, number> = {
+  deny: 0,
+  ask: 1,
+  allow: 2,
+}
+
+const PERMISSION_OPTIONS: Array<{ value: RuntimePermissionPolicy; label: string; description: string }> = [
+  { value: 'deny', label: 'Off', description: 'Block the tool.' },
+  { value: 'ask', label: 'Ask', description: 'Prompt before each side effect.' },
+  { value: 'allow', label: 'Allow', description: 'Run without repeated prompts.' },
+]
+
+function canSelectPermission(value: RuntimePermissionPolicy, maximum: RuntimePermissionPolicy) {
+  return PERMISSION_RANK[value] <= PERMISSION_RANK[maximum]
+}
+
 export function PermissionsPanel({
+  permissions,
   settings,
   update,
 }: {
+  permissions: PublicAppConfig['permissions']
   settings: EffectiveAppSettings
   update: (patch: Partial<EffectiveAppSettings>) => void
 }) {
+  const permissionRows = [
+    {
+      key: 'bashPermission' as const,
+      legacyKey: 'enableBash' as const,
+      maximum: permissions.bash,
+      title: t('settings.permissions.bashTitle', 'Shell commands'),
+      description: t('settings.permissions.bashDescription', 'Choose whether agents can run terminal commands in the active workspace, and whether each command needs approval.'),
+    },
+    {
+      key: 'fileWritePermission' as const,
+      legacyKey: 'enableFileWrite' as const,
+      maximum: permissions.fileWrite,
+      title: t('settings.permissions.fileWriteTitle', 'File editing'),
+      description: t('settings.permissions.fileWriteDescription', 'Choose whether agents can create or modify local workspace files, and whether each edit needs approval.'),
+    },
+  ]
+
   return (
     <div className="flex flex-col gap-5">
       <span className={sectionLabelCls}>{t('settings.permissions.header', 'Developer Tools')}</span>
       <div className={panelCardCls}>
-        {[
-          {
-            key: 'enableBash' as const,
-            title: t('settings.permissions.bashTitle', 'Shell commands'),
-            description: t('settings.permissions.bashDescription', 'Allow agents to run terminal commands inside the active workspace.'),
-          },
-          {
-            key: 'enableFileWrite' as const,
-            title: t('settings.permissions.fileWriteTitle', 'File editing'),
-            description: t('settings.permissions.fileWriteDescription', 'Allow agents to create and modify files in the local workspace.'),
-          },
-          {
-            key: 'runtimeToolingBridgeEnabled' as const,
-            title: t('settings.permissions.toolingBridgeTitle', 'Developer config bridge'),
-            description: t('settings.permissions.toolingBridgeDescription', 'Expose standard Git, SSH, package-manager, cloud, Docker, and Kubernetes config to the managed OpenCode runtime. Disable this for a stricter runtime HOME.'),
-          },
-        ].map((toggle) => {
-          const enabled = settings[toggle.key]
+        {permissionRows.map((row) => {
+          const selected = settings[row.key]
           return (
-            <div key={toggle.key} className="flex items-center justify-between gap-4">
-              <div>
-                <div className="text-[12px] font-semibold text-text">{toggle.title}</div>
-                <div className="text-[11px] text-text-muted mt-1">{toggle.description}</div>
+            <div key={row.key} className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <div className="text-[12px] font-semibold text-text">{row.title}</div>
+                <div className="text-[11px] text-text-muted mt-1 leading-relaxed">{row.description}</div>
               </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={enabled}
-                aria-label={toggle.title}
-                onClick={() => update({ [toggle.key]: !enabled } as Partial<EffectiveAppSettings>)}
-                className="w-10 h-5 rounded-full transition-colors relative shrink-0 cursor-pointer"
-                style={{ background: enabled ? 'var(--color-accent)' : 'var(--color-border)' }}
-              >
-                <div
-                  className="w-3.5 h-3.5 rounded-full absolute top-[3px] transition-all border border-border-subtle"
-                  style={{
-                    left: enabled ? 20 : 3,
-                    background: 'color-mix(in srgb, var(--color-elevated) 92%, var(--color-base) 8%)',
-                  }}
-                />
-              </button>
+              <div role="group" aria-label={row.title} className="shrink-0 grid grid-cols-3 rounded-xl border border-border-subtle overflow-hidden">
+                {PERMISSION_OPTIONS.map((option) => {
+                  const allowed = canSelectPermission(option.value, row.maximum)
+                  const active = selected === option.value
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      disabled={!allowed}
+                      title={allowed ? option.description : t('settings.permissions.maximumHint', 'This build limits {{tool}} to {{mode}}.', { tool: row.title, mode: row.maximum })}
+                      aria-pressed={active}
+                      onClick={() => update({
+                        [row.key]: option.value,
+                        [row.legacyKey]: option.value !== 'deny',
+                      } as Partial<EffectiveAppSettings>)}
+                      className="px-3 py-1.5 text-[11px] font-semibold transition-colors disabled:opacity-35 disabled:cursor-not-allowed cursor-pointer"
+                      style={{
+                        background: active ? 'var(--color-accent)' : 'transparent',
+                        color: active ? 'var(--color-accent-foreground)' : 'var(--color-text-muted)',
+                      }}
+                    >
+                      {t(`settings.permissions.mode.${option.value}`, option.label)}
+                    </button>
+                  )
+                })}
+              </div>
             </div>
           )
         })}
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <div className="text-[12px] font-semibold text-text">{t('settings.permissions.toolingBridgeTitle', 'Developer config bridge')}</div>
+            <div className="text-[11px] text-text-muted mt-1">{t('settings.permissions.toolingBridgeDescription', 'Expose standard Git, SSH, package-manager, cloud, Docker, and Kubernetes config to the managed OpenCode runtime. Disable this for a stricter runtime HOME.')}</div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.runtimeToolingBridgeEnabled}
+            aria-label={t('settings.permissions.toolingBridgeTitle', 'Developer config bridge')}
+            onClick={() => update({ runtimeToolingBridgeEnabled: !settings.runtimeToolingBridgeEnabled })}
+            className="w-10 h-5 rounded-full transition-colors relative shrink-0 cursor-pointer"
+            style={{ background: settings.runtimeToolingBridgeEnabled ? 'var(--color-accent)' : 'var(--color-border)' }}
+          >
+            <div
+              className="w-3.5 h-3.5 rounded-full absolute top-[3px] transition-all border border-border-subtle"
+              style={{
+                left: settings.runtimeToolingBridgeEnabled ? 20 : 3,
+                background: 'color-mix(in srgb, var(--color-elevated) 92%, var(--color-base) 8%)',
+              }}
+            />
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -14,6 +14,8 @@ function createDefaultSettings(overrides: Partial<EffectiveAppSettings> = {}): E
     providerCredentials: {},
     integrationCredentials: {},
     integrationEnabled: {},
+    bashPermission: 'deny',
+    fileWritePermission: 'deny',
     enableBash: false,
     enableFileWrite: false,
     runtimeToolingBridgeEnabled: true,
@@ -40,6 +42,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
         name: 'Open Cowork',
         helpUrl: 'https://github.com/joe-broadhead/open-cowork',
         defaultModel: null,
+        permissions: { bash: 'allow', fileWrite: 'allow' },
         providers: [],
         auth: { mode: 'none' },
       })),
@@ -124,6 +127,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       authorize: vi.fn(async () => null),
       callback: vi.fn(async () => false),
       list: vi.fn(async () => []),
+      logout: vi.fn(async () => true),
     },
     runtime: {
       restart: vi.fn(async () => ({

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -597,8 +597,8 @@ trim a long exploratory session.
 ```json
 {
   "permissions": {
-    "bash": "ask",
-    "fileWrite": "ask",
+    "bash": "allow",
+    "fileWrite": "allow",
     "task": "allow",
     "web": "allow",
     "webSearch": true
@@ -607,10 +607,12 @@ trim a long exploratory session.
 ```
 
 - `bash` and `fileWrite` are app-level maximum policies. The default
-  `ask` means users can enable shell commands and file edits in Settings,
-  and OpenCode still asks before side-effecting actions. Downstream builds
-  that must be read-only can set either value to `deny`, which makes the
-  corresponding Settings toggle unable to grant that capability.
+  upstream maximum is `allow`, which lets users choose **Off**, **Ask**,
+  or **Allow** in Settings. Fresh Open Cowork profiles still default to
+  **Ask** so side-effecting shell/file actions require confirmation until
+  the user explicitly opts into **Allow**. Downstream builds can set either
+  value to `ask` or `deny` to remove the no-prompt option or make the
+  corresponding Settings control unable to grant that capability.
 - `web` controls OpenCode's native `webfetch` and `codesearch`
   permissions.
 - `webSearch` controls OpenCode's native `websearch` permission and

--- a/open-cowork.config.json
+++ b/open-cowork.config.json
@@ -166,8 +166,8 @@
     }
   ],
   "permissions": {
-    "bash": "ask",
-    "fileWrite": "ask",
+    "bash": "allow",
+    "fileWrite": "allow",
     "task": "allow",
     "web": "allow",
     "webSearch": true

--- a/packages/shared/src/app-config.ts
+++ b/packages/shared/src/app-config.ts
@@ -112,6 +112,8 @@ export interface AppMetadata {
   preview: boolean
 }
 
+export type RuntimePermissionPolicy = 'allow' | 'ask' | 'deny'
+
 export interface PublicAppConfig {
   branding: BrandingConfig
   auth: {
@@ -122,6 +124,10 @@ export interface PublicAppConfig {
     available: ProviderDescriptor[]
     defaultProvider: string | null
     defaultModel: string | null
+  }
+  permissions: {
+    bash: RuntimePermissionPolicy
+    fileWrite: RuntimePermissionPolicy
   }
   agentStarterTemplates: AgentStarterTemplate[]
   i18n?: AppI18nConfig
@@ -134,6 +140,10 @@ export interface AppSettings {
   providerCredentials: Record<string, Record<string, string>>
   integrationCredentials: Record<string, Record<string, string>>
   integrationEnabled: Record<string, boolean>
+  bashPermission: RuntimePermissionPolicy
+  fileWritePermission: RuntimePermissionPolicy
+  // Back-compat booleans retained for older renderer payloads and settings
+  // migrations. New UI should use bashPermission/fileWritePermission.
   enableBash: boolean
   enableFileWrite: boolean
   runtimeToolingBridgeEnabled: boolean

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -212,6 +212,7 @@ export interface CoworkAPI {
       inputs?: Record<string, string>,
     ) => Promise<ProviderAuthAuthorization | null>
     callback: (providerId: string, method: number, code?: string) => Promise<boolean>
+    logout: (providerId: string) => Promise<boolean>
   }
   runtime: {
     status: () => Promise<RuntimeStatus>

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -33,8 +33,8 @@ test('open core ships with built-in tools, skills, mcps, and agents configured b
   const providers = getProviderDescriptors()
   assert.equal(providers.map((provider) => provider.id).join(','), 'openrouter,openai')
   assert.equal(providers.find((provider) => provider.id === 'openrouter')?.defaultModel, 'anthropic/claude-sonnet-4')
-  assert.equal(getAppConfig().permissions.bash, 'ask')
-  assert.equal(getAppConfig().permissions.fileWrite, 'ask')
+  assert.equal(getAppConfig().permissions.bash, 'allow')
+  assert.equal(getAppConfig().permissions.fileWrite, 'allow')
   assert.equal(getAppConfig().permissions.webSearch, true)
 })
 

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -91,6 +91,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('provider:auth-methods'), true)
   assert.equal(handlers.has('provider:oauth-authorize'), true)
   assert.equal(handlers.has('provider:oauth-callback'), true)
+  assert.equal(handlers.has('provider:auth-remove'), true)
   assert.equal(handlers.has('artifact:export'), true)
   assert.equal(handlers.has('artifact:read-attachment'), true)
   assert.equal(handlers.has('session:prompt'), true)

--- a/tests/runtime-config-builder.test.ts
+++ b/tests/runtime-config-builder.test.ts
@@ -77,6 +77,8 @@ test('buildRuntimeConfig resolves env-backed custom providers and project custom
   saveSettings({
     selectedProviderId: 'test-provider',
     selectedModelId: 'fast',
+    bashPermission: 'allow',
+    fileWritePermission: 'deny',
     enableBash: true,
     enableFileWrite: false,
   })
@@ -189,14 +191,14 @@ test('buildRuntimeConfig treats disabled bash and file-write toggles as hard den
   clearConfigCaches()
 
   try {
-    saveSettings({ enableBash: false, enableFileWrite: false })
+    saveSettings({ bashPermission: 'deny', fileWritePermission: 'deny' })
     const disabledConfig = buildRuntimeConfig() as Record<string, any>
     assert.equal(disabledConfig.permission.bash, 'deny')
     assert.equal(disabledConfig.permission.write, 'deny')
     assert.equal(disabledConfig.permission.edit, 'deny')
     assert.equal(disabledConfig.permission.apply_patch, 'deny')
 
-    saveSettings({ enableBash: true, enableFileWrite: true })
+    saveSettings({ bashPermission: 'ask', fileWritePermission: 'ask' })
     const enabledConfig = buildRuntimeConfig() as Record<string, any>
     assert.equal(enabledConfig.permission.bash, 'ask')
     assert.equal(enabledConfig.permission.write, 'ask')
@@ -232,6 +234,9 @@ test('buildProviderRuntimeConfig preserves configured custom provider options', 
       effectiveModel: 'fast',
       providerCredentials: {},
       integrationCredentials: {},
+      integrationEnabled: {},
+      bashPermission: 'deny',
+      fileWritePermission: 'deny',
       enableBash: false,
       enableFileWrite: false,
     },

--- a/tests/runtime-mcp-google-auth.test.ts
+++ b/tests/runtime-mcp-google-auth.test.ts
@@ -14,6 +14,8 @@ const BASE_SETTINGS: AppSettings = {
   providerCredentials: {},
   integrationCredentials: {},
   integrationEnabled: {},
+  bashPermission: 'deny',
+  fileWritePermission: 'deny',
   enableBash: false,
   enableFileWrite: false,
   runtimeToolingBridgeEnabled: true,

--- a/tests/runtime-mcp-opt-in.test.ts
+++ b/tests/runtime-mcp-opt-in.test.ts
@@ -18,6 +18,8 @@ const BASE_SETTINGS: AppSettings = {
   providerCredentials: {},
   integrationCredentials: {},
   integrationEnabled: {},
+  bashPermission: 'deny',
+  fileWritePermission: 'deny',
   enableBash: false,
   enableFileWrite: false,
   runtimeToolingBridgeEnabled: true,

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -83,6 +83,8 @@ test('native permission ask defaults initialize fresh profiles with toggles enab
   try {
     const { loadSettings } = await importFreshSettingsModule('fresh-ask-defaults')
     const settings = loadSettings()
+    assert.equal(settings.bashPermission, 'ask')
+    assert.equal(settings.fileWritePermission, 'ask')
     assert.equal(settings.enableBash, true)
     assert.equal(settings.enableFileWrite, true)
   } finally {
@@ -110,6 +112,8 @@ test('default public config initializes native permission toggles enabled', asyn
   try {
     const { loadSettings } = await importFreshSettingsModule('fresh-public-defaults')
     const settings = loadSettings()
+    assert.equal(settings.bashPermission, 'ask')
+    assert.equal(settings.fileWritePermission, 'ask')
     assert.equal(settings.enableBash, true)
     assert.equal(settings.enableFileWrite, true)
   } finally {
@@ -151,12 +155,47 @@ test('saveSettings normalizes renderer updates before persistence', async () => 
     } as any)
 
     const after = loadSettings() as any
+    assert.equal(after.bashPermission, 'deny')
     assert.equal(after.enableBash, false)
     assert.equal(after.automationQuietHoursStart, before.automationQuietHoursStart)
     assert.equal(after.defaultAutomationAutonomyPolicy, before.defaultAutomationAutonomyPolicy)
     assert.equal(after.providerCredentials.openrouter.apiKey, 'valid-key')
     assert.equal(after.providerCredentials.openrouter.oversized, undefined)
     assert.equal(after.unexpectedTopLevel, undefined)
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('saveSettings persists explicit native permission modes and clamps to downstream maximums', async () => {
+  const tempRoot = testTempDir('opencowork-settings-permission-modes-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeAskPermissionConfig(configDir)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, saveSettings } = await importFreshSettingsModule('permission-modes')
+    saveSettings({
+      bashPermission: 'allow',
+      fileWritePermission: 'deny',
+    })
+
+    const after = loadSettings()
+    assert.equal(after.bashPermission, 'ask')
+    assert.equal(after.enableBash, true)
+    assert.equal(after.fileWritePermission, 'deny')
+    assert.equal(after.enableFileWrite, false)
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
@@ -296,6 +335,8 @@ test('legacy settings without native toggles inherit downstream ask defaults', a
   try {
     const { loadSettings } = await importFreshSettingsModule('legacy-ask-defaults')
     const settings = loadSettings()
+    assert.equal(settings.bashPermission, 'ask')
+    assert.equal(settings.fileWritePermission, 'ask')
     assert.equal(settings.enableBash, true)
     assert.equal(settings.enableFileWrite, true)
   } finally {


### PR DESCRIPTION
## Summary

This PR fixes the runtime permission UX that made shell and file-write settings look like hard allow toggles even though they only enabled OpenCode's `ask` policy.

- Adds explicit `Off`, `Ask`, and `Allow` modes for shell commands and file editing.
- Keeps fresh and migrated profiles conservative by defaulting enabled legacy settings to `Ask`.
- Exposes downstream permission maximums to the renderer so builds can cap the available modes.
- Adds a provider `Forget login` action so stale OpenCode-native auth, such as an invalidated OpenAI/Codex token, can be cleared before signing in again.

## Root Cause

The settings UI presented `enableBash` and `enableFileWrite` as “Allow agents…” switches, but the bundled config capped both permissions at `ask`. Users could enable permission requests, but OpenCode still correctly prompted before side-effecting actions.

Separately, OpenCode reported the stored OpenAI auth token as invalidated. OpenRouter still worked because its API-key auth path synced successfully.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 875 passing
- `pnpm test:renderer` — 146 passing
- `pnpm lint:a11y --max-warnings=0`
- `uv run mkdocs build --strict`
- `pnpm build`
- `git diff --check`

## Notes

The untracked `audits/` folder is intentionally excluded from this PR.
