### PR TITLE
[codex] Show non-secret credential values

### DIFF
--- a/THIRD_PARTY_LICENSES/fast-uri@3.1.2/LICENSE
+++ b/THIRD_PARTY_LICENSES/fast-uri@3.1.2/LICENSE
@@ -1,8 +1,6 @@
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
-Copyright (c) 2021-present The Fastify team
+Copyright (c) 2021-present The Fastify team <https://github.com/fastify/fastify#team>
 All rights reserved.
-
-The Fastify team members are listed at https://github.com/fastify/fastify#team.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `73b0736968c60fd6c554a4be66ce4c1a13a8be1d6600c2980eb489561c750040`
+- pnpm lockfile SHA-256: `45273409612b1f7d147b5f7257755ecd79d33a47b3c1ea5ab7940fed3ace330a`
 - Production package entries: 433
 
 Each package remains licensed under its own license terms. The table below is provided for attribution and review; bundled license files are emitted under `THIRD_PARTY_LICENSES/`.
@@ -181,7 +181,7 @@ Each package remains licensed under its own license terms. The table below is pr
 | extend | 3.0.2 | MIT | THIRD_PARTY_LICENSES/extend@3.0.2/ | https://github.com/justmoon/node-extend.git |
 | fast-deep-equal | 3.1.3 | MIT | THIRD_PARTY_LICENSES/fast-deep-equal@3.1.3/ | git+https://github.com/epoberezkin/fast-deep-equal.git |
 | fast-json-patch | 3.1.1 | MIT | THIRD_PARTY_LICENSES/fast-json-patch@3.1.1/ | git://github.com/Starcounter-Jack/JSON-Patch.git |
-| fast-uri | 3.1.0 | BSD-3-Clause | THIRD_PARTY_LICENSES/fast-uri@3.1.0/ | git+https://github.com/fastify/fast-uri.git |
+| fast-uri | 3.1.2 | BSD-3-Clause | THIRD_PARTY_LICENSES/fast-uri@3.1.2/ | git+https://github.com/fastify/fast-uri.git |
 | fetch-blob | 3.2.0 | MIT | THIRD_PARTY_LICENSES/fetch-blob@3.2.0/ | https://github.com/node-fetch/fetch-blob.git |
 | finalhandler | 2.1.1 | MIT | THIRD_PARTY_LICENSES/finalhandler@2.1.1/ | pillarjs/finalhandler |
 | formdata-polyfill | 4.0.10 | MIT | THIRD_PARTY_LICENSES/formdata-polyfill@4.0.10/ | git+https://jimmywarting@github.com/jimmywarting/FormData.git |

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -126,7 +126,10 @@ function renderCapabilitiesPage(overrides: {
   })
 
   const tools = vi.fn(async () => overrides.tools ?? [chartTool, shellTool])
-  const tool = vi.fn(async () => chartTool)
+  const tool = vi.fn(async (id: string) => {
+    const availableTools = overrides.tools ?? [chartTool, shellTool]
+    return availableTools.find((entry) => entry.id === id) ?? chartTool
+  })
   const skills = vi.fn(async () => overrides.skills ?? [researchSkill])
   const skillBundleFile = vi.fn(async () => 'Reference note')
   const listMcps = vi.fn(async () => overrides.customMcps ?? [customMcp])
@@ -279,6 +282,56 @@ describe('CapabilitiesPage', () => {
       toolIds: ['charts'],
       skillNames: [],
     }))
+  })
+
+  it('shows stored non-secret credentials while keeping secret values masked until edited', async () => {
+    const user = userEvent.setup()
+    const mixedCredentialTool: CapabilityTool = {
+      ...chartTool,
+      credentials: [
+        ...(chartTool.credentials ?? []),
+        {
+          key: 'username',
+          label: 'Username',
+          description: 'Account username for chart API access.',
+          placeholder: 'name@example.com',
+          secret: false,
+        },
+        {
+          key: 'accountRegion',
+          label: 'Account region',
+          description: 'Region slug used by the chart API.',
+          placeholder: 'us',
+        },
+      ],
+    }
+    renderCapabilitiesPage({
+      tools: [mixedCredentialTool, shellTool],
+      integrationCredentials: {
+        apiKey: 'ck-stored',
+        username: 'alice@example.com',
+        accountRegion: 'eu',
+      },
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+
+    const apiKeyInput = await screen.findByLabelText(/Charts API key/)
+    const usernameInput = screen.getByLabelText(/Username/)
+    const accountRegionInput = screen.getByLabelText(/Account region/)
+
+    expect(apiKeyInput).toHaveAttribute('type', 'password')
+    expect(apiKeyInput).toHaveValue('••••••••')
+    expect(usernameInput).toHaveAttribute('type', 'text')
+    expect(usernameInput).toHaveValue('alice@example.com')
+    expect(accountRegionInput).toHaveAttribute('type', 'text')
+    expect(accountRegionInput).toHaveValue('eu')
+
+    await user.click(usernameInput)
+    expect(usernameInput).toHaveValue('alice@example.com')
+
+    await user.click(apiKeyInput)
+    expect(apiKeyInput).toHaveValue('')
   })
 
   it('surfaces stored integration credential load failures through the chat error channel and diagnostics', async () => {

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -197,9 +197,14 @@ export function ToolCredentialsCard({
       </div>
       <div className="flex flex-col gap-3">
         {credentials.map((credential) => {
-          const hasStored = Boolean(stored[credential.key])
+          const storedValue = stored[credential.key] ?? ''
+          const hasStored = Boolean(storedValue)
           const draft = drafts[credential.key]
-          const value = draft !== undefined ? draft : (hasStored ? '••••••••' : '')
+          const value = draft !== undefined
+            ? draft
+            : credential.secret
+              ? (hasStored ? '••••••••' : '')
+              : storedValue
           return (
             <label key={credential.key} className="flex flex-col gap-1">
               <span className="text-[11px] font-medium text-text-secondary">
@@ -210,7 +215,7 @@ export function ToolCredentialsCard({
                 value={value}
                 placeholder={credential.placeholder || ''}
                 onFocus={(event) => {
-                  if (draft === undefined && hasStored) {
+                  if (credential.secret && draft === undefined && hasStored) {
                     setDrafts((current) => ({ ...current, [credential.key]: '' }))
                     event.currentTarget.value = ''
                   }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     ],
     "overrides": {
       "electron-builder-squirrel-windows": "26.8.1",
+      "fast-uri@<=3.1.0": ">=3.1.1",
       "hono@<4.12.16": ">=4.12.16",
       "ip-address@<=10.1.0": ">=10.1.1",
       "mermaid>uuid": "^14.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   electron-builder-squirrel-windows: 26.8.1
+  fast-uri@<=3.1.0: '>=3.1.1'
   hono@<4.12.16: '>=4.12.16'
   ip-address@<=10.1.0: '>=10.1.1'
   mermaid>uuid: ^14.0.0
@@ -2127,8 +2128,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -5276,7 +5277,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6392,7 +6393,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fd-slicer@1.1.0:
     dependencies:


### PR DESCRIPTION
Closes #234.

## Summary
- render stored non-secret capability credentials as plain text
- keep stored secret capability credentials masked until the user focuses them for editing
- add renderer regression coverage for mixed secret and non-secret credential fields

## Validation
- pnpm test:renderer -- CapabilitiesPage.test.tsx
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check