### PR TITLE
[codex] Add selectable MCP credential fields

### DIFF
--- a/apps/desktop/src/main/runtime-mcp.ts
+++ b/apps/desktop/src/main/runtime-mcp.ts
@@ -1,6 +1,7 @@
 import electron from 'electron'
 import { existsSync } from 'fs'
 import { isAbsolute, join, resolve } from 'path'
+import { credentialFieldIsVisible } from '@open-cowork/shared'
 import type { CustomMcpConfig } from '@open-cowork/shared'
 import { getConfiguredMcpsFromConfig, type BundleMcp } from './config-loader.ts'
 import { getIntegrationCredentialValue, getEffectiveSettings, type CoworkSettings } from './settings.ts'
@@ -98,7 +99,14 @@ function getExplicitEnabledState(builtin: BundleMcp, settings: CoworkSettings): 
 // MCPs without a `credentials[]` block or without any `required: true`
 // entries are trivially credential-ready.
 function hasRequiredCredentials(builtin: BundleMcp, settings: CoworkSettings): boolean {
+  const credentialValues = Object.fromEntries(
+    (builtin.credentials || []).map((credential) => [
+      credential.key,
+      getIntegrationCredentialValue(settings, builtin.name, credential.key) || '',
+    ]),
+  )
   for (const credential of builtin.credentials || []) {
+    if (!credentialFieldIsVisible(credential, credentialValues)) continue
     if (credential.required === false) continue
     const value = getIntegrationCredentialValue(settings, builtin.name, credential.key)
     if (!value) return false

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -334,6 +334,115 @@ describe('CapabilitiesPage', () => {
     expect(apiKeyInput).toHaveValue('')
   })
 
+  it('renders select credentials and conditionally shows dependent credential fields without clearing hidden values', async () => {
+    const user = userEvent.setup()
+    const multiAuthTool: CapabilityTool = {
+      ...chartTool,
+      credentials: [
+        {
+          key: 'authMethod',
+          label: 'Authentication method',
+          description: 'How to authenticate with the chart service.',
+          type: 'select',
+          options: [
+            { label: 'API key', value: 'api_key', hint: 'Static API credentials' },
+            { label: 'SSO', value: 'sso', hint: 'Browser-based sign in' },
+          ],
+          required: true,
+        },
+        {
+          key: 'apiKey',
+          label: 'Charts API key',
+          description: 'Token for the chart service.',
+          secret: true,
+          required: true,
+          when: { key: 'authMethod', op: 'eq', value: 'api_key' },
+        },
+        {
+          key: 'ssoUser',
+          label: 'SSO email',
+          description: 'Email address for single sign-on.',
+          required: true,
+          when: { key: 'authMethod', op: 'eq', value: 'sso' },
+        },
+      ],
+    }
+    const api = renderCapabilitiesPage({
+      tools: [multiAuthTool, shellTool],
+      integrationCredentials: {
+        authMethod: 'api_key',
+        apiKey: 'ck-stored',
+        ssoUser: 'alice@example.com',
+      },
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+
+    const authMethod = await screen.findByLabelText(/Authentication method/)
+    expect(authMethod).toHaveValue('api_key')
+    expect(screen.getByText('Static API credentials')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Charts API key/)).toHaveValue('••••••••')
+    expect(screen.queryByLabelText(/SSO email/)).not.toBeInTheDocument()
+
+    await user.selectOptions(authMethod, 'sso')
+
+    expect(screen.queryByLabelText(/Charts API key/)).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/SSO email/)).toHaveValue('alice@example.com')
+    expect(screen.getByText('Browser-based sign in')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.settingsSet).toHaveBeenCalledWith({
+        integrationCredentials: {
+          charts: { authMethod: 'sso' },
+        },
+      })
+    })
+  })
+
+  it('renders radio credential options and saves the selected value', async () => {
+    const user = userEvent.setup()
+    const radioTool: CapabilityTool = {
+      ...chartTool,
+      credentials: [
+        {
+          key: 'runtimeMode',
+          label: 'Runtime mode',
+          description: 'Where the integration should run.',
+          type: 'radio',
+          options: [
+            { label: 'Local', value: 'local', hint: 'Run the bundled stdio server' },
+            { label: 'Remote', value: 'remote', hint: 'Connect to a hosted MCP server' },
+          ],
+          required: true,
+        },
+      ],
+    }
+    const api = renderCapabilitiesPage({
+      tools: [radioTool, shellTool],
+      integrationCredentials: { runtimeMode: 'local' },
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+
+    const local = await screen.findByRole('radio', { name: /Local/ })
+    const remote = screen.getByRole('radio', { name: /Remote/ })
+    expect(local).toBeChecked()
+    expect(remote).not.toBeChecked()
+
+    await user.click(remote)
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.settingsSet).toHaveBeenCalledWith({
+        integrationCredentials: {
+          charts: { runtimeMode: 'remote' },
+        },
+      })
+    })
+  })
+
   it('surfaces stored integration credential load failures through the chat error channel and diagnostics', async () => {
     const user = userEvent.setup()
     const api = renderCapabilitiesPage({

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { credentialFieldIsVisible } from '@open-cowork/shared'
 import type { CapabilityTool, RuntimeContextOptions } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import { useSessionStore } from '../../stores/session'
@@ -123,6 +124,21 @@ export function SkillBundleFileEntry({
   )
 }
 
+type ToolCredential = NonNullable<CapabilityTool['credentials']>[number]
+
+function credentialValueForConditions(
+  credentials: ToolCredential[],
+  stored: Record<string, string>,
+  drafts: Record<string, string>,
+) {
+  return Object.fromEntries(
+    credentials.map((credential) => [
+      credential.key,
+      drafts[credential.key] ?? stored[credential.key] ?? '',
+    ]),
+  )
+}
+
 // Per-MCP credential form surfaced in the Capabilities detail panel.
 // Reads only this integration's stored credential values and persists
 // through the shared settings path used by runtime env/header settings.
@@ -185,6 +201,11 @@ export function ToolCredentialsCard({
     }
   }
 
+  const conditionValues = credentialValueForConditions(credentials, stored, drafts)
+  const visibleCredentials = credentials.filter((credential) => (
+    credentialFieldIsVisible(credential, conditionValues)
+  ))
+
   return (
     <div className="rounded-xl border border-border-subtle bg-surface p-4">
       <div className="flex items-center justify-between gap-3 mb-3">
@@ -196,15 +217,84 @@ export function ToolCredentialsCard({
         ) : null}
       </div>
       <div className="flex flex-col gap-3">
-        {credentials.map((credential) => {
+        {visibleCredentials.map((credential) => {
           const storedValue = stored[credential.key] ?? ''
           const hasStored = Boolean(storedValue)
           const draft = drafts[credential.key]
+          const options = credential.options || []
+          const isChoiceField = (credential.type === 'select' || credential.type === 'radio') && options.length > 0
           const value = draft !== undefined
             ? draft
-            : credential.secret
+            : credential.secret && !isChoiceField
               ? (hasStored ? '••••••••' : '')
               : storedValue
+          const selectedOption = options.find((option) => option.value === value)
+          if (isChoiceField) {
+            if (credential.type === 'radio') {
+              return (
+                <fieldset key={credential.key} className="flex flex-col gap-1">
+                  <legend className="text-[11px] font-medium text-text-secondary">
+                    {credential.label}{credential.required ? <span className="text-red ms-1">*</span> : null}
+                  </legend>
+                  <div className="flex flex-col gap-2">
+                    {options.map((option) => (
+                      <label
+                        key={option.value}
+                        className="flex items-start gap-2 rounded-lg border border-border-subtle bg-elevated px-3 py-2"
+                      >
+                        <input
+                          type="radio"
+                          name={`${integrationId}-${credential.key}`}
+                          value={option.value}
+                          checked={value === option.value}
+                          onChange={(event) => {
+                            setDrafts((current) => ({ ...current, [credential.key]: event.target.value }))
+                          }}
+                          className="mt-0.5"
+                        />
+                        <span className="min-w-0">
+                          <span className="block text-[12px] font-medium text-text-secondary">{option.label}</span>
+                          {option.hint ? (
+                            <span className="block text-[10px] text-text-muted leading-relaxed">{option.hint}</span>
+                          ) : null}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                  {credential.description ? (
+                    <span className="text-[10px] text-text-muted leading-relaxed">{credential.description}</span>
+                  ) : null}
+                </fieldset>
+              )
+            }
+
+            return (
+              <label key={credential.key} className="flex flex-col gap-1">
+                <span className="text-[11px] font-medium text-text-secondary">
+                  {credential.label}{credential.required ? <span className="text-red ms-1">*</span> : null}
+                </span>
+                <select
+                  value={value}
+                  onChange={(event) => {
+                    setDrafts((current) => ({ ...current, [credential.key]: event.target.value }))
+                  }}
+                  className="px-3 py-2 rounded-lg text-[12px] bg-elevated border border-border-subtle text-text outline-none focus:border-border"
+                >
+                  <option value="">{credential.placeholder || t('capabilities.credentialsSelectPlaceholder', 'Select an option')}</option>
+                  {options.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+                {selectedOption?.hint ? (
+                  <span className="text-[10px] text-text-muted leading-relaxed">{selectedOption.hint}</span>
+                ) : null}
+                {credential.description ? (
+                  <span className="text-[10px] text-text-muted leading-relaxed">{credential.description}</span>
+                ) : null}
+              </label>
+            )
+          }
+
           return (
             <label key={credential.key} className="flex flex-col gap-1">
               <span className="text-[11px] font-medium text-text-secondary">

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -456,6 +456,63 @@ The same flag is available on user-added custom MCPs
   receives the env var can read the user's Google access token.
   Only enable it for MCPs your distribution trusts.
 
+### MCP credential fields
+
+Bundled MCPs can declare `credentials[]` metadata for the Capabilities
+detail panel. Each field persists to
+`integrationCredentials[mcpName][key]`; `envSettings` and
+`headerSettings` can then map those stored values into the spawned MCP.
+
+Text fields are the default. For discrete modes, set `type` to
+`"select"` or `"radio"` and provide `options[]`. Use `when` to hide a
+dependent field unless another credential has the expected value. Hidden
+fields are only hidden in the UI; their stored values are preserved and
+are not cleared when the selector changes.
+
+```json
+{
+  "mcps": [
+    {
+      "name": "my-mcp",
+      "type": "local",
+      "description": "Example MCP",
+      "authMode": "api_token",
+      "envSettings": [
+        { "env": "MY_MCP_AUTH_METHOD", "key": "authMethod" },
+        { "env": "MY_MCP_API_KEY", "key": "apiKey" },
+        { "env": "MY_MCP_SSO_USER", "key": "ssoUser" }
+      ],
+      "credentials": [
+        {
+          "key": "authMethod",
+          "label": "Authentication method",
+          "description": "How to authenticate with the service",
+          "type": "select",
+          "options": [
+            { "label": "API key", "value": "api_key", "hint": "Static API credentials" },
+            { "label": "SSO", "value": "sso", "hint": "Browser-based single sign-on" }
+          ],
+          "required": true
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "description": "Your API key",
+          "secret": true,
+          "when": { "key": "authMethod", "op": "eq", "value": "api_key" }
+        },
+        {
+          "key": "ssoUser",
+          "label": "SSO email",
+          "description": "Your login email address",
+          "when": { "key": "authMethod", "op": "eq", "value": "sso" }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ### Custom MCP approval mode
 
 User-added custom MCPs default to `permissionMode: "ask"`: agents can be

--- a/docs/custom-mcps.md
+++ b/docs/custom-mcps.md
@@ -98,6 +98,13 @@ For OAuth-backed HTTP MCPs, leave headers blank when the MCP expects
 OpenCode's browser-based OAuth flow. Save the MCP, reload the runtime,
 then authenticate from the MCP status panel.
 
+Bundled MCPs can also ship credential form metadata. Use a text field
+for free-form values, or `type: "select"` / `type: "radio"` with
+`options[]` when the MCP expects one of a fixed set of values. A field
+can declare `when: { "key": "...", "op": "eq" | "neq", "value": "..." }`
+to appear only for a selected mode. Changing modes does not delete
+hidden stored values; the next save only patches fields the user edited.
+
 ## Google-auth stdio MCPs
 
 Trusted local Google MCPs can opt into using the app's Google OAuth

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -298,9 +298,50 @@
         "placeholder": { "type": "string" },
         "secret": { "type": "boolean" },
         "required": { "type": "boolean" },
-        "env": { "type": "string" }
+        "env": { "type": "string" },
+        "type": { "type": "string", "enum": ["text", "select", "radio"] },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "label": { "type": "string" },
+              "value": { "type": "string" },
+              "hint": { "type": "string" }
+            },
+            "required": ["label", "value"]
+          }
+        },
+        "when": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key": { "type": "string" },
+            "op": { "type": "string", "enum": ["eq", "neq"] },
+            "value": { "type": "string" }
+          },
+          "required": ["key", "op", "value"]
+        }
       },
-      "required": ["key", "label", "description"]
+      "required": ["key", "label", "description"],
+      "allOf": [
+        {
+          "if": {
+            "required": ["type"],
+            "properties": {
+              "type": { "enum": ["select", "radio"] }
+            }
+          },
+          "then": {
+            "properties": {
+              "options": {}
+            },
+            "required": ["options"]
+          }
+        }
+      ]
     },
     "providerModelDescriptor": {
       "type": "object",

--- a/packages/shared/src/capabilities.ts
+++ b/packages/shared/src/capabilities.ts
@@ -30,6 +30,17 @@ export interface CapabilityTool {
     secret?: boolean
     required?: boolean
     env?: string
+    type?: 'text' | 'select' | 'radio'
+    options?: Array<{
+      label: string
+      value: string
+      hint?: string
+    }>
+    when?: {
+      key: string
+      op: 'eq' | 'neq'
+      value: string
+    }
   }>
   // The key the renderer uses when calling `settings.set(
   //   { integrationCredentials: { [integrationId]: { [key]: value } } })`.

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -1,3 +1,17 @@
+export type CredentialFieldType = 'text' | 'select' | 'radio'
+
+export interface CredentialFieldOption {
+  label: string
+  value: string
+  hint?: string
+}
+
+export interface CredentialFieldCondition {
+  key: string
+  op: 'eq' | 'neq'
+  value: string
+}
+
 export interface CredentialField {
   key: string
   label: string
@@ -7,6 +21,20 @@ export interface CredentialField {
   required?: boolean
   env?: string
   runtimeKey?: string
+  type?: CredentialFieldType
+  options?: CredentialFieldOption[]
+  when?: CredentialFieldCondition
+}
+
+export function credentialFieldIsVisible(
+  credential: Pick<CredentialField, 'when'>,
+  values: Record<string, string | null | undefined>,
+) {
+  if (!credential.when) return true
+  const actual = values[credential.when.key] ?? ''
+  return credential.when.op === 'eq'
+    ? actual === credential.when.value
+    : actual !== credential.when.value
 }
 
 // Per-model pricing + context info cached by the main process after

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -100,6 +100,79 @@ test('config loader lets downstreams disable native web search while keeping web
   }
 })
 
+test('config loader accepts select and radio credential metadata for bundled MCPs', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-mcp-credentials-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  writeFileSync(configPath, JSON.stringify({
+    mcps: [
+      {
+        name: 'multi-auth',
+        type: 'local',
+        description: 'Multi-mode auth MCP',
+        authMode: 'api_token',
+        command: ['node', '/tmp/multi-auth.js'],
+        envSettings: [
+          { env: 'AUTH_METHOD', key: 'authMethod' },
+          { env: 'API_KEY', key: 'apiKey' },
+          { env: 'RUNTIME_MODE', key: 'runtimeMode' },
+        ],
+        credentials: [
+          {
+            key: 'authMethod',
+            label: 'Authentication method',
+            description: 'How to authenticate with the service',
+            type: 'select',
+            options: [
+              { label: 'API key', value: 'api_key', hint: 'Static API credentials' },
+              { label: 'SSO', value: 'sso' },
+            ],
+            required: true,
+          },
+          {
+            key: 'apiKey',
+            label: 'API key',
+            description: 'Your API key',
+            secret: true,
+            when: { key: 'authMethod', op: 'eq', value: 'api_key' },
+          },
+          {
+            key: 'runtimeMode',
+            label: 'Runtime mode',
+            description: 'Where the MCP should run',
+            type: 'radio',
+            options: [
+              { label: 'Local', value: 'local' },
+              { label: 'Remote', value: 'remote', hint: 'Hosted MCP server' },
+            ],
+          },
+        ],
+      },
+    ],
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    assert.doesNotThrow(() => assertConfigValid())
+    const mcp = getConfiguredMcpsFromConfig().find((entry) => entry.name === 'multi-auth')
+    assert.equal(mcp?.credentials?.[0]?.type, 'select')
+    assert.equal(mcp?.credentials?.[0]?.options?.[0]?.value, 'api_key')
+    assert.deepEqual(mcp?.credentials?.[1]?.when, { key: 'authMethod', op: 'eq', value: 'api_key' })
+    assert.equal(mcp?.credentials?.[2]?.type, 'radio')
+  } finally {
+    if (previousOverride === undefined) {
+      delete process.env.OPEN_COWORK_CONFIG_PATH
+    } else {
+      process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    }
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('config loader accepts JSONC, file placeholders, and partial config directory overrides', () => {
   const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-dir-'))
   const configDir = join(tempRoot, 'downstream')

--- a/tests/runtime-mcp-opt-in.test.ts
+++ b/tests/runtime-mcp-opt-in.test.ts
@@ -152,6 +152,81 @@ test('evaluateBuiltInMcp — local MCP missing required credentials is skipped a
   })
 })
 
+test('evaluateBuiltInMcp — required conditional credentials only apply when their when clause matches', () => {
+  withConfigDir(baseConfig({}), () => {
+    const mcp: BundleMcp = {
+      name: 'multi-auth',
+      type: 'local',
+      description: 'Multi-mode auth MCP',
+      authMode: 'api_token',
+      command: ['node', '/tmp/multi-auth.js'],
+      credentials: [
+        {
+          key: 'authMethod',
+          label: 'Authentication method',
+          description: 'How to authenticate.',
+          type: 'select',
+          options: [
+            { label: 'API key', value: 'api_key' },
+            { label: 'SSO', value: 'sso' },
+          ],
+          required: true,
+        },
+        {
+          key: 'apiKey',
+          label: 'API key',
+          description: 'API token.',
+          required: true,
+          secret: true,
+          when: { key: 'authMethod', op: 'eq', value: 'api_key' },
+        },
+        {
+          key: 'ssoUser',
+          label: 'SSO email',
+          description: 'Single sign-on email.',
+          required: true,
+          when: { key: 'authMethod', op: 'eq', value: 'sso' },
+        },
+      ],
+      envSettings: [
+        { env: 'AUTH_METHOD', key: 'authMethod' },
+        { env: 'API_KEY', key: 'apiKey' },
+        { env: 'SSO_USER', key: 'ssoUser' },
+      ],
+    }
+    const ssoSettings: AppSettings = {
+      ...BASE_SETTINGS,
+      integrationCredentials: {
+        'multi-auth': {
+          authMethod: 'sso',
+          ssoUser: 'alice@example.com',
+        },
+      },
+    }
+
+    const ready = evaluateBuiltInMcp(mcp, ssoSettings)
+    assert.equal(ready.status, 'ready')
+    if (ready.status !== 'ready') return
+    assert.equal(ready.entry.type, 'local')
+    if (ready.entry.type !== 'local') return
+    assert.equal(ready.entry.environment?.AUTH_METHOD, 'sso')
+    assert.equal(ready.entry.environment?.SSO_USER, 'alice@example.com')
+    assert.equal(ready.entry.environment?.API_KEY, undefined)
+
+    const missingSso = evaluateBuiltInMcp(mcp, {
+      ...BASE_SETTINGS,
+      integrationCredentials: {
+        'multi-auth': {
+          authMethod: 'sso',
+        },
+      },
+    })
+    assert.equal(missingSso.status, 'skipped')
+    if (missingSso.status !== 'skipped') return
+    assert.equal(missingSso.reason, 'not-configured')
+  })
+})
+
 test('evaluateBuiltInMcp — OAuth MCP is skipped until the user explicitly enables it', () => {
   // Atlassian / Amplitude / etc. — bundled but the user may never
   // intend to use them. Previously showed up as `needs_auth` in the


### PR DESCRIPTION
Closes #233.

## Summary
- extend CredentialField metadata with text/select/radio types, options, and when conditions
- render selectable and conditional MCP credentials in the Capabilities detail panel while preserving hidden stored values
- make bundled MCP readiness respect visible required credentials only
- document MCP credential metadata and update config schema validation

## Validation
- pnpm test:renderer -- CapabilitiesPage.test.tsx
- node --no-warnings --experimental-strip-types --experimental-sqlite --test tests/config-elements.test.ts tests/runtime-mcp-opt-in.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm docs:build
- pnpm lint:a11y --max-warnings=0
- pnpm audit --prod --audit-level high
- pnpm audit --audit-level critical
- pnpm build
- git diff --check