### PR TITLE
Expand coverage for renderer quick wins

### DIFF
--- a/apps/desktop/src/renderer/components/LoadingScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/LoadingScreen.test.tsx
@@ -1,0 +1,50 @@
+import { act, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { LoadingScreen } from './LoadingScreen'
+
+describe('LoadingScreen', () => {
+  it('renders stage-specific startup copy', () => {
+    const { rerender } = render(<LoadingScreen brandName="Open Cowork" stage="boot" />)
+    expect(screen.getByText('Open Cowork')).toBeInTheDocument()
+    expect(screen.getByText('Starting up...')).toBeInTheDocument()
+
+    rerender(<LoadingScreen brandName="Open Cowork" stage="auth" />)
+    expect(screen.getByText('Checking authentication...')).toBeInTheDocument()
+
+    rerender(<LoadingScreen brandName="Open Cowork" stage="config" />)
+    expect(screen.getByText('Loading workspace configuration...')).toBeInTheDocument()
+  })
+
+  it('progresses runtime loading copy as elapsed time grows', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-09T12:00:00.000Z'))
+
+    render(<LoadingScreen brandName="Open Cowork" stage="runtime" />)
+    expect(screen.getByText('Starting runtime...')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(3_000)
+    })
+    expect(screen.getByText('Connecting to runtime...')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(6_000)
+    })
+    expect(screen.getByText('Almost there...')).toBeInTheDocument()
+  })
+
+  it('surfaces runtime configuration errors with recovery guidance', () => {
+    render(
+      <LoadingScreen
+        brandName="Open Cowork"
+        stage="runtime"
+        errorMessage="Provider model is missing."
+      />,
+    )
+
+    expect(screen.getByText('Runtime configuration needs attention.')).toBeInTheDocument()
+    expect(screen.getByText('Open Cowork could not start the runtime')).toBeInTheDocument()
+    expect(screen.getByText('Provider model is missing.')).toBeInTheDocument()
+    expect(screen.getByText('Fix the invalid runtime or config input, then relaunch the app.')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/agents/AgentStaticPreview.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentStaticPreview.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { AgentCatalog, CustomAgentConfig } from '@open-cowork/shared'
+import { AgentStaticPreview } from './AgentStaticPreview'
+
+const catalog: AgentCatalog = {
+  reservedNames: [],
+  colors: ['accent', 'info'],
+  tools: [
+    {
+      id: 'charts',
+      name: 'Charts',
+      icon: 'chart',
+      description: 'Render charts.',
+      source: 'builtin',
+      supportsWrite: false,
+      patterns: ['mcp__charts__*'],
+    },
+  ],
+  skills: [
+    {
+      name: 'analyst',
+      label: 'Analyst',
+      description: 'Canonical data analysis workflow.',
+      source: 'builtin',
+      toolIds: ['charts'],
+    },
+  ],
+}
+
+function draft(overrides: Partial<CustomAgentConfig> = {}): CustomAgentConfig {
+  return {
+    scope: 'project',
+    directory: '/workspace',
+    name: 'data-analyst',
+    description: 'Analyze data.',
+    instructions: 'Read the analyst skill before answering.',
+    skillNames: ['analyst', 'missing-skill'],
+    toolIds: ['charts', 'missing-tool'],
+    enabled: true,
+    color: 'info',
+    avatar: null,
+    model: null,
+    variant: null,
+    temperature: null,
+    top_p: null,
+    steps: null,
+    options: null,
+    ...overrides,
+  }
+}
+
+describe('AgentStaticPreview', () => {
+  it('renders the compiled agent surface and missing reference warnings', () => {
+    render(<AgentStaticPreview draft={draft()} catalog={catalog} />)
+
+    expect(screen.getByText('Static preview')).toBeInTheDocument()
+    expect(screen.getByText('Read only scope')).toBeInTheDocument()
+    expect(screen.getByText('@data-analyst')).toBeInTheDocument()
+    expect(screen.getAllByText('1 of 2')).toHaveLength(2)
+    expect(screen.getByText('Missing tools: missing-tool')).toBeInTheDocument()
+    expect(screen.getByText('Missing skills: missing-skill')).toBeInTheDocument()
+    expect(screen.getByText('Read the analyst skill before answering.')).toBeInTheDocument()
+    expect(screen.getByText('mcp__charts__*')).toBeInTheDocument()
+    expect(screen.getByText('Canonical data analysis workflow.')).toBeInTheDocument()
+  })
+
+  it('omits optional sections when no tools or skills resolve', () => {
+    render(
+      <AgentStaticPreview
+        draft={draft({ toolIds: [], skillNames: [], scope: 'machine', directory: null })}
+        catalog={catalog}
+      />,
+    )
+
+    expect(screen.getByText('Read only scope')).toBeInTheDocument()
+    expect(screen.getAllByText('0 of 0')).toHaveLength(2)
+    expect(screen.queryByText('Tool patterns')).not.toBeInTheDocument()
+    expect(screen.queryByText('Skills available to load')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/agents/SkillLibraryTab.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/SkillLibraryTab.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentCatalog } from '@open-cowork/shared'
+import { SkillLibraryTab } from './SkillLibraryTab'
+
+const catalog: AgentCatalog = {
+  reservedNames: [],
+  colors: ['accent'],
+  tools: [
+    {
+      id: 'github',
+      name: 'GitHub',
+      icon: 'github',
+      description: 'Repository workflows.',
+      supportsWrite: true,
+      source: 'builtin',
+      patterns: ['mcp__github__*'],
+    },
+  ],
+  skills: [
+    {
+      name: 'repo-review',
+      label: 'Repo Review',
+      description: 'Review repository changes.',
+      source: 'builtin',
+      toolIds: ['github'],
+    },
+    {
+      name: 'custom-brief',
+      label: 'Custom Brief',
+      description: 'Prepare a custom brief.',
+      source: 'custom',
+      toolIds: [],
+    },
+  ],
+}
+
+describe('SkillLibraryTab', () => {
+  it('renders an empty-state prompt when no skills are available', () => {
+    render(
+      <SkillLibraryTab
+        catalog={{ ...catalog, skills: [] }}
+        selectedSkillNames={[]}
+        selectedToolIds={[]}
+        onToggle={() => undefined}
+        onAutoAttachTools={() => undefined}
+      />,
+    )
+
+    expect(screen.getByText('No skills available yet. Add a skill bundle from the Capabilities page.')).toBeInTheDocument()
+  })
+
+  it('toggles skills and offers to attach missing linked tools', () => {
+    const onToggle = vi.fn()
+    const onAutoAttachTools = vi.fn()
+    render(
+      <SkillLibraryTab
+        catalog={catalog}
+        selectedSkillNames={['repo-review', 'custom-brief']}
+        selectedToolIds={[]}
+        onToggle={onToggle}
+        onAutoAttachTools={onAutoAttachTools}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Repo Review/i }))
+    expect(onToggle).toHaveBeenCalledWith('repo-review')
+    expect(screen.getByText('Custom')).toBeInTheDocument()
+    expect(screen.getByText('Needs: GitHub')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add tools' }))
+    expect(onAutoAttachTools).toHaveBeenCalledWith(['github'])
+  })
+
+  it('does not fire toggles in read-only mode', () => {
+    const onToggle = vi.fn()
+    render(
+      <SkillLibraryTab
+        catalog={catalog}
+        selectedSkillNames={[]}
+        selectedToolIds={[]}
+        onToggle={onToggle}
+        onAutoAttachTools={() => undefined}
+        readOnly
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Repo Review/i }))
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/components/agents/ToolLibraryTab.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/ToolLibraryTab.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentCatalog } from '@open-cowork/shared'
+import { ToolLibraryTab } from './ToolLibraryTab'
+
+const catalog: AgentCatalog = {
+  reservedNames: [],
+  colors: ['accent'],
+  tools: [
+    {
+      id: 'github',
+      name: 'GitHub',
+      icon: 'github',
+      description: 'Repository workflows.',
+      supportsWrite: true,
+      source: 'builtin',
+      patterns: ['mcp__github__*'],
+    },
+    {
+      id: 'charts',
+      name: 'Charts',
+      icon: 'chart',
+      description: 'Chart rendering.',
+      supportsWrite: false,
+      source: 'builtin',
+      patterns: ['mcp__charts__*'],
+    },
+  ],
+  skills: [],
+}
+
+describe('ToolLibraryTab', () => {
+  it('renders an empty-state prompt when no tools are available', () => {
+    render(
+      <ToolLibraryTab
+        catalog={{ ...catalog, tools: [] }}
+        selectedToolIds={[]}
+        onToggle={() => undefined}
+        deniedToolPatterns={[]}
+        onToggleDeniedPattern={() => undefined}
+        projectDirectory={null}
+      />,
+    )
+
+    expect(screen.getByText('No tools available yet. Add an MCP from the Capabilities page.')).toBeInTheDocument()
+  })
+
+  it('renders write-capable marks and toggles selected tools', () => {
+    const onToggle = vi.fn()
+    render(
+      <ToolLibraryTab
+        catalog={catalog}
+        selectedToolIds={['github']}
+        onToggle={onToggle}
+        deniedToolPatterns={[]}
+        onToggleDeniedPattern={() => undefined}
+        projectDirectory={null}
+      />,
+    )
+
+    expect(screen.getByText('W')).toHaveAttribute('title', "This tool can write — adds to the agent's footprint")
+    fireEvent.click(screen.getByRole('button', { name: /Charts/i }))
+    expect(onToggle).toHaveBeenCalledWith('charts')
+  })
+
+  it('does not fire toggles in read-only mode', () => {
+    const onToggle = vi.fn()
+    render(
+      <ToolLibraryTab
+        catalog={catalog}
+        selectedToolIds={[]}
+        onToggle={onToggle}
+        deniedToolPatterns={[]}
+        onToggleDeniedPattern={() => undefined}
+        projectDirectory={null}
+        readOnly
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /GitHub/i }))
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/components/automations/AutomationDropConfirmDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationDropConfirmDialog.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AutomationDropConfirmDialog } from './AutomationDropConfirmDialog'
+
+describe('AutomationDropConfirmDialog', () => {
+  it('renders the drop action and dispatches cancel/confirm actions', () => {
+    const onCancel = vi.fn()
+    const onConfirm = vi.fn()
+
+    render(
+      <AutomationDropConfirmDialog
+        action={{
+          valid: true,
+          title: 'Archive automation',
+          message: 'Move this automation to archived.',
+          type: 'pause',
+          targetColumn: 'paused',
+          automationId: 'automation-1',
+          confirm: true,
+        }}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Archive automation' })).toBeInTheDocument()
+    expect(screen.getByText('Move this automation to archived.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AutomationHelpDrawer } from './AutomationHelpDrawer'
+
+describe('AutomationHelpDrawer', () => {
+  it('explains the automation lifecycle and closes from the header button', () => {
+    const onClose = vi.fn()
+    render(<AutomationHelpDrawer onClose={onClose} />)
+
+    expect(screen.getByRole('dialog', { name: 'Standing agent programs' })).toBeInTheDocument()
+    expect(screen.getByText('1. Enrich')).toBeInTheDocument()
+    expect(screen.getByText('2. Review')).toBeInTheDocument()
+    expect(screen.getByText('3. Execute')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close help' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/ElapsedClock.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ElapsedClock.test.tsx
@@ -1,0 +1,42 @@
+import { act, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ElapsedClock } from './ElapsedClock'
+
+describe('ElapsedClock', () => {
+  it('renders nothing without a valid start timestamp', () => {
+    const { container } = render(<ElapsedClock startedAt={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders finished durations with the default finished label', () => {
+    render(
+      <ElapsedClock
+        startedAt="2026-05-09T12:00:00.000Z"
+        finishedAt="2026-05-09T12:01:05.000Z"
+      />,
+    )
+
+    expect(screen.getByText('ran 1m 5s')).toHaveAttribute('title', 'Task duration')
+  })
+
+  it('ticks while running and respects custom running labels', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-09T12:00:05.000Z'))
+
+    render(
+      <ElapsedClock
+        startedAt="2026-05-09T12:00:00.000Z"
+        labelWhileRunning="working"
+      />,
+    )
+
+    expect(screen.getByText('working')).toHaveAttribute('title', 'Elapsed since the task started running')
+
+    act(() => {
+      vi.advanceTimersByTime(1_000)
+      vi.setSystemTime(new Date('2026-05-09T12:00:06.000Z'))
+    })
+
+    expect(screen.getByText('working')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/elapsed-clock-utils.test.ts
+++ b/apps/desktop/src/renderer/components/chat/elapsed-clock-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { formatElapsedMs, parseIsoToMs } from './elapsed-clock-utils'
+
+describe('formatElapsedMs', () => {
+  it('renders invalid and sub-minute durations safely', () => {
+    expect(formatElapsedMs(Number.NaN)).toBe('0s')
+    expect(formatElapsedMs(-1)).toBe('0s')
+    expect(formatElapsedMs(Number.POSITIVE_INFINITY)).toBe('0s')
+    expect(formatElapsedMs(999)).toBe('0s')
+    expect(formatElapsedMs(59_999)).toBe('59s')
+  })
+
+  it('renders minute and hour durations without rounding up', () => {
+    expect(formatElapsedMs(60_000)).toBe('1m 0s')
+    expect(formatElapsedMs(65_000)).toBe('1m 5s')
+    expect(formatElapsedMs(3_599_999)).toBe('59m 59s')
+    expect(formatElapsedMs(3_661_000)).toBe('1h 1m 1s')
+  })
+})
+
+describe('parseIsoToMs', () => {
+  it('returns null for missing or malformed timestamps', () => {
+    expect(parseIsoToMs(null)).toBeNull()
+    expect(parseIsoToMs(undefined)).toBeNull()
+    expect(parseIsoToMs('')).toBeNull()
+    expect(parseIsoToMs('not-a-date')).toBeNull()
+  })
+
+  it('parses ISO timestamps to epoch milliseconds', () => {
+    expect(parseIsoToMs('2026-05-09T12:34:56.000Z')).toBe(Date.parse('2026-05-09T12:34:56.000Z'))
+  })
+})

--- a/apps/desktop/src/renderer/components/layout/RuntimeOfflineBanner.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/RuntimeOfflineBanner.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { RuntimeOfflineBanner } from './RuntimeOfflineBanner'
+
+describe('RuntimeOfflineBanner', () => {
+  it('announces runtime failures and invokes the restart action', async () => {
+    const onRestart = vi.fn(async () => undefined)
+    render(<RuntimeOfflineBanner error="socket closed" onRestart={onRestart} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Runtime unavailable:')
+    expect(screen.getByText('socket closed')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() => expect(onRestart).toHaveBeenCalledTimes(1))
+  })
+
+  it('coalesces repeated restart clicks while a restart is in flight', async () => {
+    let resolveRestart!: () => void
+    const restartPromise = new Promise<void>((resolve) => {
+      resolveRestart = resolve
+    })
+    const onRestart = vi.fn(() => restartPromise)
+    render(<RuntimeOfflineBanner error="runtime crashed" onRestart={onRestart} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    await screen.findByRole('button', { name: 'Restarting…' })
+    fireEvent.click(screen.getByRole('button', { name: 'Restarting…' }))
+
+    expect(onRestart).toHaveBeenCalledTimes(1)
+    resolveRestart()
+
+    await screen.findByRole('button', { name: 'Try again' })
+  })
+})

--- a/apps/desktop/src/renderer/components/layout/StatusBar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/StatusBar.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { useSessionStore } from '../../stores/session'
+import { StatusBar } from './StatusBar'
+
+describe('StatusBar', () => {
+  it('renders active generation, context, MCP, and usage detail state', async () => {
+    installRendererTestCoworkApi({
+      settings: {
+        get: vi.fn(async () => ({
+          effectiveProviderId: 'openrouter',
+          effectiveModel: 'openrouter/anthropic/claude-sonnet-4',
+          selectedProviderId: null,
+          selectedModelId: null,
+        })),
+      },
+      model: {
+        info: vi.fn(async () => ({
+          contextLimits: {
+            'openrouter/anthropic/claude-sonnet-4': 100_000,
+          },
+        })),
+      },
+      on: {
+        runtimeReady: vi.fn(() => () => undefined),
+      },
+    })
+    useSessionStore.setState((state) => ({
+      mcpConnections: [
+        { name: 'charts', connected: true },
+        { name: 'github', connected: false },
+      ],
+      totalCost: 0.75,
+      currentView: {
+        ...state.currentView,
+        isGenerating: true,
+        activeAgent: 'data-analyst',
+        isAwaitingPermission: false,
+        isAwaitingQuestion: false,
+        sessionCost: 0.25,
+        sessionTokens: {
+          input: 1_500,
+          output: 250,
+          reasoning: 0,
+          cacheRead: 64,
+          cacheWrite: 32,
+        },
+        lastInputTokens: 90_000,
+        contextState: 'idle',
+        compactionCount: 2,
+        lastCompactedAt: '2026-05-09T12:00:00.000Z',
+      },
+    }))
+
+    render(<StatusBar />)
+
+    expect(screen.getByText('data analyst working...')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('openrouter/anthropic/claude sonnet 4')).toBeInTheDocument())
+    expect(screen.getByText('90% · compacting soon')).toBeInTheDocument()
+    expect(screen.getByText('1/2')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /1.8K tokens/i }))
+
+    expect(screen.getByText('Session Usage')).toBeInTheDocument()
+    expect(screen.getByText('Cache read')).toBeInTheDocument()
+    expect(screen.getByText('Cache write')).toBeInTheDocument()
+    expect(screen.getByText('Compactions')).toBeInTheDocument()
+    expect(screen.getByText('Total (all sessions)')).toBeInTheDocument()
+  })
+
+  it('prioritizes approval and question waiting states over ready', () => {
+    installRendererTestCoworkApi({
+      model: { info: vi.fn(async () => ({ contextLimits: {} })) },
+    })
+    const baseView = useSessionStore.getState().currentView
+
+    useSessionStore.setState({
+      currentView: {
+        ...baseView,
+        isGenerating: false,
+        isAwaitingPermission: true,
+        isAwaitingQuestion: true,
+        sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+      mcpConnections: [],
+    })
+    const { rerender } = render(<StatusBar />)
+    expect(screen.getByText('Awaiting approval')).toBeInTheDocument()
+
+    useSessionStore.setState({
+      currentView: {
+        ...baseView,
+        isGenerating: false,
+        isAwaitingPermission: false,
+        isAwaitingQuestion: true,
+        sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    })
+    rerender(<StatusBar />)
+    expect(screen.getByText('Awaiting answer')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/layout/TitleBar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/TitleBar.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useSessionStore } from '../../stores/session'
+import { TitleBar } from './TitleBar'
+
+describe('TitleBar', () => {
+  it('routes the sidebar button through the app-owned session store', () => {
+    const toggleSidebar = vi.fn()
+    useSessionStore.setState({ toggleSidebar })
+
+    render(<TitleBar />)
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle sidebar' }))
+
+    expect(toggleSidebar).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/components/layout/ViewErrorBoundary.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/ViewErrorBoundary.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { ViewErrorBoundary } from './ViewErrorBoundary'
+
+function BrokenView(): never {
+  throw new Error('render exploded')
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ViewErrorBoundary', () => {
+  it('renders a recovery panel, reports diagnostics, and lets the user go home', () => {
+    const reportRendererError = vi.fn()
+    installRendererTestCoworkApi({
+      diagnostics: { reportRendererError },
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const onBackHome = vi.fn()
+
+    render(
+      <ViewErrorBoundary resetKey="capabilities" onBackHome={onBackHome}>
+        <BrokenView />
+      </ViewErrorBoundary>,
+    )
+
+    expect(screen.getByText('This page failed to render.')).toBeInTheDocument()
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'render exploded',
+      view: 'capabilities',
+    }))
+    expect(consoleError).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to home' }))
+    expect(onBackHome).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets after navigation changes the reset key', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const { rerender } = render(
+      <ViewErrorBoundary resetKey="agents" onBackHome={() => undefined}>
+        <BrokenView />
+      </ViewErrorBoundary>,
+    )
+    expect(screen.getByText('This page failed to render.')).toBeInTheDocument()
+
+    rerender(
+      <ViewErrorBoundary resetKey="home" onBackHome={() => undefined}>
+        <div>Recovered page</div>
+      </ViewErrorBoundary>,
+    )
+
+    expect(screen.getByText('Recovered page')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/sidebar/SettingsAutomationPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsAutomationPanel.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { EffectiveAppSettings } from '@open-cowork/shared'
+import { AutomationSettingsPanel } from './SettingsAutomationPanel'
+
+function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSettings {
+  return {
+    selectedProviderId: null,
+    selectedModelId: null,
+    providerCredentials: {},
+    integrationCredentials: {},
+    integrationEnabled: {},
+    bashPermission: 'deny',
+    fileWritePermission: 'deny',
+    enableBash: false,
+    enableFileWrite: false,
+    runtimeToolingBridgeEnabled: true,
+    automationLaunchAtLogin: false,
+    automationRunInBackground: true,
+    automationDesktopNotifications: true,
+    automationQuietHoursStart: '22:00',
+    automationQuietHoursEnd: null,
+    defaultAutomationAutonomyPolicy: 'review-first',
+    defaultAutomationExecutionMode: 'planning_only',
+    effectiveProviderId: null,
+    effectiveModel: null,
+    ...overrides,
+  }
+}
+
+describe('AutomationSettingsPanel', () => {
+  it('renders automation toggles and emits precise setting patches', () => {
+    const update = vi.fn()
+    render(<AutomationSettingsPanel settings={settings()} update={update} />)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Launch at login' }))
+    fireEvent.click(screen.getByRole('switch', { name: 'Run in background' }))
+    fireEvent.click(screen.getByRole('switch', { name: 'Desktop notifications' }))
+
+    expect(update).toHaveBeenNthCalledWith(1, { automationLaunchAtLogin: true })
+    expect(update).toHaveBeenNthCalledWith(2, { automationRunInBackground: false })
+    expect(update).toHaveBeenNthCalledWith(3, { automationDesktopNotifications: false })
+  })
+
+  it('updates defaults and quiet-hour fields independently', () => {
+    const update = vi.fn()
+    render(<AutomationSettingsPanel settings={settings()} update={update} />)
+
+    fireEvent.change(screen.getByLabelText('Default autonomy'), {
+      target: { value: 'mostly-autonomous' },
+    })
+    fireEvent.change(screen.getByLabelText('Default execution mode'), {
+      target: { value: 'scoped_execution' },
+    })
+    fireEvent.change(screen.getByLabelText('Start'), {
+      target: { value: '' },
+    })
+    fireEvent.change(screen.getByLabelText('End'), {
+      target: { value: '07:30' },
+    })
+
+    expect(update).toHaveBeenNthCalledWith(1, { defaultAutomationAutonomyPolicy: 'mostly-autonomous' })
+    expect(update).toHaveBeenNthCalledWith(2, { defaultAutomationExecutionMode: 'scoped_execution' })
+    expect(update).toHaveBeenNthCalledWith(3, { automationQuietHoursStart: null })
+    expect(update).toHaveBeenNthCalledWith(4, { automationQuietHoursEnd: '07:30' })
+  })
+})

--- a/apps/desktop/src/renderer/helpers/agent-bundle.test.ts
+++ b/apps/desktop/src/renderer/helpers/agent-bundle.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CustomAgentSummary } from '@open-cowork/shared'
+import {
+  AGENT_BUNDLE_FORMAT,
+  bundleToAgentConfig,
+  decodeAgentBundle,
+  defaultBundleFilename,
+  encodeAgentBundle,
+  stringifyAgentBundle,
+} from './agent-bundle'
+
+function makeAgent(overrides: Partial<CustomAgentSummary> = {}): CustomAgentSummary {
+  return {
+    scope: 'machine',
+    directory: null,
+    name: 'data-analyst',
+    description: 'Analyze data and summarize findings.',
+    instructions: 'Use evidence before recommendations.',
+    skillNames: ['analyst'],
+    toolIds: ['charts'],
+    enabled: true,
+    color: 'info',
+    avatar: 'data:image/png;base64,avatar',
+    model: null,
+    variant: null,
+    temperature: 0.2,
+    top_p: null,
+    steps: 32,
+    options: null,
+    writeAccess: false,
+    valid: true,
+    issues: [],
+    ...overrides,
+  }
+}
+
+describe('agent bundle helpers', () => {
+  it('exports a portable bundle without install-specific state', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-09T12:00:00.000Z'))
+
+    const bundle = encodeAgentBundle(makeAgent({
+      scope: 'project',
+      directory: '/workspace',
+      valid: false,
+      issues: [{ code: 'invalid_name', message: 'bad name' }],
+    }))
+
+    expect(bundle).toMatchObject({
+      format: AGENT_BUNDLE_FORMAT,
+      name: 'data-analyst',
+      skillNames: ['analyst'],
+      toolIds: ['charts'],
+      exportedAt: '2026-05-09T12:00:00.000Z',
+    })
+    expect(bundle).not.toHaveProperty('scope')
+    expect(bundle).not.toHaveProperty('directory')
+    expect(bundle).not.toHaveProperty('issues')
+  })
+
+  it('decodes bundles with safe defaults and sanitizes invalid optional values', () => {
+    const result = decodeAgentBundle({
+      format: AGENT_BUNDLE_FORMAT,
+      name: ' imported-agent ',
+      description: 'Imported.',
+      instructions: 'Run the imported workflow.',
+      skillNames: ['analyst', 42],
+      toolIds: ['charts', null],
+      color: 'neon',
+      enabled: false,
+      temperature: 'hot',
+      options: [],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.bundle).toMatchObject({
+      name: 'imported-agent',
+      skillNames: ['analyst'],
+      toolIds: ['charts'],
+      color: 'accent',
+      enabled: false,
+      temperature: null,
+      options: null,
+    })
+  })
+
+  it('returns actionable decode errors for invalid bundle payloads', () => {
+    expect(decodeAgentBundle(null)).toMatchObject({ ok: false })
+    expect(decodeAgentBundle({ format: 'cowork-agent-v2' })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Unsupported bundle format'),
+    })
+    expect(decodeAgentBundle({ format: AGENT_BUNDLE_FORMAT, name: '', description: '', instructions: '' })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('name'),
+    })
+  })
+
+  it('round-trips through JSON and converts imported bundles into scoped agent configs', () => {
+    const bundle = encodeAgentBundle(makeAgent())
+    const raw = stringifyAgentBundle(bundle)
+    expect(raw.endsWith('\n')).toBe(true)
+
+    const decoded = decodeAgentBundle(JSON.parse(raw))
+    expect(decoded.ok).toBe(true)
+    if (!decoded.ok) return
+
+    expect(bundleToAgentConfig(decoded.bundle, { scope: 'machine', directory: '/ignored' })).toMatchObject({
+      scope: 'machine',
+      directory: null,
+      name: 'data-analyst',
+    })
+    expect(bundleToAgentConfig(decoded.bundle, { scope: 'project', directory: '/workspace' })).toMatchObject({
+      scope: 'project',
+      directory: '/workspace',
+      skillNames: ['analyst'],
+    })
+  })
+
+  it('builds safe default filenames from agent names', () => {
+    expect(defaultBundleFilename('Data Analyst')).toBe('data-analyst.cowork-agent.json')
+    expect(defaultBundleFilename('  $$ Weird Name !! ')).toBe('weird-name.cowork-agent.json')
+    expect(defaultBundleFilename('')).toBe('agent.cowork-agent.json')
+  })
+})

--- a/apps/desktop/src/renderer/helpers/destructive-actions.test.ts
+++ b/apps/desktop/src/renderer/helpers/destructive-actions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { installRendererTestCoworkApi } from '../test/setup'
+import {
+  confirmAgentRemoval,
+  confirmAppReset,
+  confirmMcpRemoval,
+  confirmSessionDelete,
+  confirmSkillRemoval,
+} from './destructive-actions'
+
+describe('renderer destructive-action helpers', () => {
+  it('delegates every destructive confirmation to the main-owned confirmation API', async () => {
+    const requestDestructive = vi.fn(async (request) => ({
+      token: `token:${request.action}`,
+      expiresAt: '2026-05-09T12:00:30.000Z',
+    }))
+    installRendererTestCoworkApi({
+      confirm: { requestDestructive },
+    })
+
+    await expect(confirmSessionDelete('session-1')).resolves.toMatchObject({ token: 'token:session.delete' })
+    await expect(confirmAgentRemoval({ name: 'analyst', scope: 'machine', directory: null })).resolves.toMatchObject({ token: 'token:agent.remove' })
+    await expect(confirmMcpRemoval({ name: 'github', scope: 'project', directory: '/repo' })).resolves.toMatchObject({ token: 'token:mcp.remove' })
+    await expect(confirmSkillRemoval({ name: 'chart-creator', scope: 'machine', directory: null })).resolves.toMatchObject({ token: 'token:skill.remove' })
+    await expect(confirmAppReset()).resolves.toMatchObject({ token: 'token:app.reset' })
+
+    expect(requestDestructive).toHaveBeenNthCalledWith(1, { action: 'session.delete', sessionId: 'session-1' })
+    expect(requestDestructive).toHaveBeenNthCalledWith(2, {
+      action: 'agent.remove',
+      target: { name: 'analyst', scope: 'machine', directory: null },
+    })
+    expect(requestDestructive).toHaveBeenNthCalledWith(3, {
+      action: 'mcp.remove',
+      target: { name: 'github', scope: 'project', directory: '/repo' },
+    })
+    expect(requestDestructive).toHaveBeenNthCalledWith(4, {
+      action: 'skill.remove',
+      target: { name: 'chart-creator', scope: 'machine', directory: null },
+    })
+    expect(requestDestructive).toHaveBeenNthCalledWith(5, { action: 'app.reset' })
+  })
+})

--- a/apps/desktop/src/renderer/helpers/image-downsampler.test.ts
+++ b/apps/desktop/src/renderer/helpers/image-downsampler.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { downsampleImageToDataUri } from './image-downsampler'
+
+const originalImage = globalThis.Image
+const originalCreateElement = document.createElement.bind(document)
+
+class LoadedTestImage {
+  naturalWidth = 800
+  naturalHeight = 400
+  onload: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  set src(_value: string) {
+    queueMicrotask(() => this.onload?.())
+  }
+}
+
+function installImageStub() {
+  Object.defineProperty(globalThis, 'Image', {
+    configurable: true,
+    writable: true,
+    value: LoadedTestImage,
+  })
+  Object.defineProperty(window, 'Image', {
+    configurable: true,
+    writable: true,
+    value: LoadedTestImage,
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  Object.defineProperty(globalThis, 'Image', {
+    configurable: true,
+    writable: true,
+    value: originalImage,
+  })
+  Object.defineProperty(window, 'Image', {
+    configurable: true,
+    writable: true,
+    value: originalImage,
+  })
+})
+
+describe('downsampleImageToDataUri', () => {
+  it('center-crops to a capped square and chooses jpeg for non-alpha images', async () => {
+    installImageStub()
+    const drawImage = vi.fn()
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({
+        drawImage,
+        imageSmoothingEnabled: false,
+        imageSmoothingQuality: 'low',
+      })),
+      toDataURL: vi.fn(() => 'data:image/jpeg;base64,DOWN'),
+    }
+    vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+      if (tagName === 'canvas') return canvas as unknown as HTMLCanvasElement
+      return originalCreateElement(tagName)
+    }) as typeof document.createElement)
+
+    await expect(downsampleImageToDataUri({ mime: 'image/jpeg', base64: 'SOURCE' }, 256))
+      .resolves.toBe('data:image/jpeg;base64,DOWN')
+
+    expect(canvas.width).toBe(256)
+    expect(canvas.height).toBe(256)
+    expect(drawImage).toHaveBeenCalledWith(expect.any(LoadedTestImage), 200, 0, 400, 400, 0, 0, 256, 256)
+    expect(canvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.9)
+  })
+
+  it('preserves alpha-friendly formats as png and never upscales small images', async () => {
+    installImageStub()
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({
+        drawImage: vi.fn(),
+        imageSmoothingEnabled: false,
+        imageSmoothingQuality: 'low',
+      })),
+      toDataURL: vi.fn(() => 'data:image/png;base64,DOWN'),
+    }
+    vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+      if (tagName === 'canvas') return canvas as unknown as HTMLCanvasElement
+      return originalCreateElement(tagName)
+    }) as typeof document.createElement)
+
+    await expect(downsampleImageToDataUri({ mime: 'image/png', base64: 'SOURCE' }, 1_000))
+      .resolves.toBe('data:image/png;base64,DOWN')
+
+    expect(canvas.width).toBe(800)
+    expect(canvas.height).toBe(800)
+    expect(canvas.toDataURL).toHaveBeenCalledWith('image/png', 0.9)
+  })
+
+  it('returns the original data URI when a canvas context is unavailable', async () => {
+    installImageStub()
+    vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+      if (tagName === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: vi.fn(() => null),
+        } as unknown as HTMLCanvasElement
+      }
+      return originalCreateElement(tagName)
+    }) as typeof document.createElement)
+
+    await expect(downsampleImageToDataUri({ mime: 'image/jpeg', base64: 'SOURCE' }, 256))
+      .resolves.toBe('data:image/jpeg;base64,SOURCE')
+  })
+})

--- a/tests/automation-record-actions.test.ts
+++ b/tests/automation-record-actions.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { AutomationDraft } from '../packages/shared/src/index.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  clearAutomationStoreCache,
+  getAutomationDetail,
+} from '../apps/desktop/src/main/automation-store.ts'
+import {
+  archiveAutomationRecordWithContext,
+  createAutomationRecordWithContext,
+  pauseAutomationRecordWithContext,
+  resumeAutomationRecordWithContext,
+  updateAutomationRecordWithContext,
+} from '../apps/desktop/src/main/automation-record-actions.ts'
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-automation-record-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+function resetAutomationStore(userDataDir: string) {
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+  clearAutomationStoreCache()
+}
+
+function makeDraft(overrides: Partial<AutomationDraft> = {}): AutomationDraft {
+  return {
+    title: 'Weekly data review',
+    goal: 'Review product analytics every Monday.',
+    kind: 'recurring',
+    schedule: {
+      type: 'weekly',
+      timezone: 'UTC',
+      dayOfWeek: 1,
+      runAtHour: 9,
+      runAtMinute: 0,
+    },
+    heartbeatMinutes: 15,
+    retryPolicy: {
+      maxRetries: 3,
+      baseDelayMinutes: 5,
+      maxDelayMinutes: 60,
+    },
+    runPolicy: {
+      dailyRunCap: 6,
+      maxRunDurationMinutes: 120,
+    },
+    executionMode: 'planning_only',
+    autonomyPolicy: 'review-first',
+    projectDirectory: null,
+    preferredAgentNames: ['data-analyst'],
+    ...overrides,
+  }
+}
+
+test('automation record action wrappers persist updates and publish after every mutation', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('actions')
+  let publishCount = 0
+  const publishAutomationUpdated = () => {
+    publishCount += 1
+  }
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const created = createAutomationRecordWithContext(makeDraft(), publishAutomationUpdated)
+    assert.equal(created.title, 'Weekly data review')
+    assert.equal(created.status, 'draft')
+
+    const updated = updateAutomationRecordWithContext(
+      created.id,
+      { title: 'Monday data review', preferredAgentNames: ['data-analyst', 'chart-creator'] },
+      publishAutomationUpdated,
+    )
+    assert.equal(updated?.title, 'Monday data review')
+    assert.deepEqual(updated?.preferredAgentNames, ['data-analyst', 'chart-creator'])
+
+    const paused = pauseAutomationRecordWithContext(created.id, publishAutomationUpdated)
+    assert.equal(paused?.status, 'paused')
+
+    const resumed = resumeAutomationRecordWithContext(created.id, publishAutomationUpdated)
+    assert.equal(resumed?.status, 'draft')
+
+    const archived = archiveAutomationRecordWithContext(created.id, publishAutomationUpdated)
+    assert.equal(archived?.status, 'archived')
+
+    const detail = getAutomationDetail(created.id)
+    assert.equal(detail?.title, 'Monday data review')
+    assert.equal(detail?.status, 'archived')
+    assert.deepEqual(detail?.preferredAgentNames, ['data-analyst', 'chart-creator'])
+    assert.equal(publishCount, 5)
+  } finally {
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add focused Vitest coverage for renderer zero-coverage quick wins: loading/runtime banners, elapsed clocks, destructive confirmation helpers, agent bundle helpers, image downsampling, title/status bars, automation dialog/drawer, automation settings, and agent workbench tabs
- add a Node test for automation record action wrappers so create/update/pause/resume/archive publish behavior is directly covered

## Coverage impact
- Renderer coverage: 67.4% lines / 63.4% functions / 53.6% branches -> 70.6% lines / 66.7% functions / 56.9% branches
- Node coverage: 85.0% lines / 80.2% functions / 69.6% branches -> 85.5% lines / 80.6% functions / 69.7% branches

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm test:coverage