### PR TITLE
Expand renderer control coverage

### DIFF
--- a/apps/desktop/src/renderer/components/agents/AgentBuilderPrimitives.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentBuilderPrimitives.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { CustomAgentConfig } from '@open-cowork/shared'
+import { InferenceTab, ScopeRow, WorkbenchTabs } from './AgentBuilderPrimitives'
+
+const draft: CustomAgentConfig = {
+  scope: 'machine',
+  name: 'analyst',
+  description: 'Analyze metrics.',
+  instructions: 'Use canonical metrics.',
+  skillNames: ['analyst'],
+  toolIds: ['warehouse'],
+  enabled: true,
+  color: 'accent',
+  model: null,
+  variant: null,
+  temperature: null,
+  steps: null,
+}
+
+describe('AgentBuilderPrimitives', () => {
+  it('switches workbench tabs', () => {
+    const onChange = vi.fn()
+    render(<WorkbenchTabs tab="instructions" onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Capabilities' }))
+
+    expect(onChange).toHaveBeenCalledWith('capabilities')
+    expect(screen.getByRole('button', { name: 'Instructions' })).toHaveStyle({
+      color: 'var(--color-text)',
+    })
+  })
+
+  it('changes scope and prompts for project directories', () => {
+    const onScopeChange = vi.fn()
+    const onChooseDirectory = vi.fn()
+    const { rerender } = render(
+      <ScopeRow
+        draft={draft}
+        projectTargetDirectory={null}
+        onScopeChange={onScopeChange}
+        onChooseDirectory={onChooseDirectory}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Project' }))
+    expect(onScopeChange).toHaveBeenCalledWith('project')
+
+    rerender(
+      <ScopeRow
+        draft={{ ...draft, scope: 'project' }}
+        projectTargetDirectory={null}
+        onScopeChange={onScopeChange}
+        onChooseDirectory={onChooseDirectory}
+      />,
+    )
+    expect(screen.getByText('Choose a project directory')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Choose directory' }))
+    expect(onChooseDirectory).toHaveBeenCalledTimes(1)
+  })
+
+  it('normalizes inference updates', () => {
+    const onChange = vi.fn()
+    render(<InferenceTab draft={{ ...draft, variant: 'reasoning' }} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('openrouter/anthropic/claude-sonnet-4'), {
+      target: { value: 'openrouter/anthropic/claude-sonnet-4' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('reasoning'), {
+      target: { value: '' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('0.0 – 2.0'), {
+      target: { value: '0.7' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('20'), {
+      target: { value: '4.6' },
+    })
+
+    expect(onChange).toHaveBeenCalledWith({ model: 'openrouter/anthropic/claude-sonnet-4' })
+    expect(onChange).toHaveBeenCalledWith({ variant: null })
+    expect(onChange).toHaveBeenCalledWith({ temperature: 0.7 })
+    expect(onChange).toHaveBeenCalledWith({ steps: 5 })
+  })
+
+  it('ignores invalid numeric inference values', () => {
+    const onChange = vi.fn()
+    render(<InferenceTab draft={{ ...draft, temperature: 1, steps: 3 }} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('0.0 – 2.0'), {
+      target: { value: '' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('20'), {
+      target: { value: '0' },
+    })
+
+    expect(onChange).toHaveBeenCalledWith({ temperature: null })
+    expect(onChange).toHaveBeenCalledWith({ steps: null })
+  })
+})

--- a/apps/desktop/src/renderer/components/agents/InstructionsTab.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/InstructionsTab.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { InstructionsTab } from './InstructionsTab'
+
+describe('InstructionsTab', () => {
+  it('edits instructions and reports character count', () => {
+    const onChange = vi.fn()
+    render(<InstructionsTab value="Existing guidance" onChange={onChange} />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'Updated guidance' },
+    })
+
+    expect(onChange).toHaveBeenCalledWith('Updated guidance')
+    expect(screen.getByText('17 chars')).toBeInTheDocument()
+  })
+
+  it('prepends selected starter snippets', () => {
+    const onChange = vi.fn()
+    render(<InstructionsTab value="Existing guidance" onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Snippet' }))
+    fireEvent.click(screen.getByRole('button', { name: /Be concise/i }))
+
+    expect(onChange).toHaveBeenCalledWith(expect.stringContaining('Existing guidance'))
+    expect(onChange.mock.calls[0][0]).toMatch(/^Answer in 3/)
+  })
+
+  it('switches between edit and markdown preview states', () => {
+    render(<InstructionsTab value="# Analyst\n\n- Check sources" onChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
+    expect(screen.getByText(/Analyst/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toContain('Analyst')
+  })
+
+  it('hides snippets in read-only mode and warns on long prompts', () => {
+    render(<InstructionsTab value={'x'.repeat(2001)} onChange={vi.fn()} readOnly />)
+
+    expect(screen.queryByRole('button', { name: '+ Snippet' })).not.toBeInTheDocument()
+    expect(screen.getByText('Long prompts burn tokens — consider trimming')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/agents/McpRestrictionPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/McpRestrictionPanel.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentCatalog, CustomMcpConfig } from '@open-cowork/shared'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { McpRestrictionPanel } from './McpRestrictionPanel'
+
+const catalog: AgentCatalog = {
+  tools: [
+    {
+      id: 'warehouse',
+      name: 'Warehouse',
+      icon: 'db',
+      description: 'Query governed warehouse data.',
+      supportsWrite: false,
+      source: 'custom',
+      patterns: ['mcp__warehouse__*'],
+    },
+    {
+      id: 'bash',
+      name: 'Bash',
+      icon: 'code',
+      description: 'Run shell commands.',
+      supportsWrite: true,
+      source: 'builtin',
+      patterns: ['bash'],
+    },
+  ],
+  skills: [],
+  reservedNames: [],
+  colors: ['accent'],
+}
+
+const warehouseMcp: CustomMcpConfig = {
+  scope: 'project',
+  directory: '/repo',
+  name: 'warehouse',
+  label: 'Warehouse',
+  description: 'Query governed warehouse data.',
+  type: 'http',
+  url: 'https://warehouse.example/mcp',
+}
+
+describe('McpRestrictionPanel', () => {
+  it('renders nothing without selected custom MCP tools', () => {
+    const { container } = render(
+      <McpRestrictionPanel
+        catalog={catalog}
+        selectedToolIds={['bash']}
+        deniedToolPatterns={[]}
+        projectDirectory={null}
+        onTogglePattern={vi.fn()}
+      />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('introspects custom MCP methods and toggles method restrictions', async () => {
+    const onTogglePattern = vi.fn()
+    const listMcps = vi.fn(async () => [warehouseMcp])
+    const testMcp = vi.fn(async () => ({
+      ok: true,
+      methods: [
+        { id: 'query', description: 'Run a query' },
+        { id: 'delete_dataset', description: 'Delete a dataset' },
+      ],
+      error: null,
+    }))
+    installRendererTestCoworkApi({ custom: { listMcps, testMcp } })
+
+    render(
+      <McpRestrictionPanel
+        catalog={catalog}
+        selectedToolIds={['warehouse']}
+        deniedToolPatterns={['mcp__warehouse__delete_dataset']}
+        projectDirectory="/repo"
+        onTogglePattern={onTogglePattern}
+      />,
+    )
+
+    await waitFor(() => expect(listMcps).toHaveBeenCalledWith({ directory: '/repo' }))
+    fireEvent.click(screen.getByRole('button', { name: /Warehouse/i }))
+
+    expect(await screen.findByText('query')).toBeInTheDocument()
+    expect(testMcp).toHaveBeenCalledWith(warehouseMcp)
+
+    fireEvent.click(screen.getByLabelText(/Run a query/i))
+    expect(onTogglePattern).toHaveBeenCalledWith('mcp__warehouse__query')
+
+    fireEvent.click(screen.getByLabelText(/Delete a dataset/i))
+    expect(onTogglePattern).toHaveBeenCalledWith('mcp__warehouse__delete_dataset')
+  })
+
+  it('falls back to manual restriction entry when introspection fails', async () => {
+    const onTogglePattern = vi.fn()
+    const listMcps = vi.fn(async () => [warehouseMcp])
+    installRendererTestCoworkApi({
+      custom: {
+        listMcps,
+        testMcp: vi.fn(async () => ({
+          ok: false,
+          methods: [],
+          error: 'OAuth required',
+        })),
+      },
+    })
+
+    render(
+      <McpRestrictionPanel
+        catalog={catalog}
+        selectedToolIds={['warehouse']}
+        deniedToolPatterns={['mcp__warehouse__old_method']}
+        projectDirectory="/repo"
+        onTogglePattern={onTogglePattern}
+      />,
+    )
+
+    await waitFor(() => expect(listMcps).toHaveBeenCalledWith({ directory: '/repo' }))
+    fireEvent.click(screen.getByRole('button', { name: /Warehouse/i }))
+    expect(await screen.findByText(/OAuth required/)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. delete_repo'), {
+      target: { value: 'drop_table' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Block' }))
+    expect(onTogglePattern).toHaveBeenCalledWith('mcp__warehouse__drop_table')
+
+    fireEvent.click(screen.getByTitle('Click to remove this restriction'))
+    expect(onTogglePattern).toHaveBeenCalledWith('mcp__warehouse__old_method')
+  })
+
+  it('reports missing MCP configuration and supports retry', async () => {
+    const testMcp = vi.fn()
+    installRendererTestCoworkApi({
+      custom: {
+        listMcps: vi.fn(async () => []),
+        testMcp,
+      },
+    })
+
+    render(
+      <McpRestrictionPanel
+        catalog={catalog}
+        selectedToolIds={['warehouse']}
+        deniedToolPatterns={[]}
+        projectDirectory={null}
+        onTogglePattern={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Warehouse/i }))
+    expect(await screen.findByText(/MCP config not found/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(testMcp).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitySelectionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitySelectionCard.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { CapabilitySkill, CapabilityTool } from '@open-cowork/shared'
+import { SkillSelectionCard, ToolSelectionCard } from './CapabilitySelectionCard'
+
+const tool: CapabilityTool = {
+  id: 'warehouse.query',
+  name: 'Warehouse Query',
+  icon: 'db',
+  description: 'Run bounded analytical queries.',
+  kind: 'mcp',
+  source: 'custom',
+  origin: 'custom',
+  scope: 'project',
+  namespace: 'warehouse',
+  patterns: ['mcp__warehouse__query'],
+  availableTools: [
+    { id: 'query', description: 'Query data' },
+    { id: 'schema', description: 'Inspect schema' },
+  ],
+  agentNames: ['Analyst', 'BI Engineer'],
+}
+
+const skill: CapabilitySkill = {
+  name: 'analyst',
+  label: 'Analyst',
+  description: 'Resolve canonical metrics before querying.',
+  source: 'builtin',
+  origin: 'open-cowork',
+  scope: 'machine',
+  toolIds: ['warehouse.query'],
+  agentNames: ['Analyst'],
+}
+
+describe('CapabilitySelectionCard', () => {
+  it('renders tool metadata, linked skills, and opens the tool', () => {
+    const onOpen = vi.fn()
+    render(
+      <ToolSelectionCard
+        tool={tool}
+        methodsCount={2}
+        isCustom
+        linkedSkills={[skill]}
+        onOpen={onOpen}
+      />,
+    )
+
+    expect(screen.getByText('Warehouse Query')).toBeInTheDocument()
+    expect(screen.getByText('MCP')).toBeInTheDocument()
+    expect(screen.getByText('Custom')).toBeInTheDocument()
+    expect(screen.getByText('Analyst')).toBeInTheDocument()
+    expect(screen.getByText('Project')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Warehouse Query/i }))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders custom tool removal without opening the card', () => {
+    const onOpen = vi.fn()
+    const onRemove = vi.fn()
+    render(
+      <ToolSelectionCard
+        tool={tool}
+        methodsCount={2}
+        isCustom
+        linkedSkills={[]}
+        onOpen={onOpen}
+        onRemove={onRemove}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(onRemove).toHaveBeenCalledTimes(1)
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('renders skill metadata, linked tools, and custom removal', () => {
+    const onOpen = vi.fn()
+    const onRemove = vi.fn()
+    render(
+      <SkillSelectionCard
+        skill={{ ...skill, source: 'custom', origin: 'custom', scope: 'project' }}
+        isCustom
+        linkedTools={[{ id: tool.id, name: tool.name }]}
+        onOpen={onOpen}
+        onRemove={onRemove}
+      />,
+    )
+
+    expect(screen.getByText('Analyst')).toBeInTheDocument()
+    expect(screen.getByText('Custom')).toBeInTheDocument()
+    expect(screen.getByText('Project')).toBeInTheDocument()
+    expect(screen.getByText('Warehouse Query')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Resolve canonical metrics/i }))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/ChatInputInlinePicker.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputInlinePicker.test.tsx
@@ -1,0 +1,81 @@
+import { createRef } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ChatInputInlinePicker } from './ChatInputInlinePicker'
+import type { InlinePickerState, MentionableAgent } from './chat-input-types'
+
+const picker: InlinePickerState = {
+  trigger: '@',
+  query: 'ana',
+  start: 0,
+  end: 4,
+  selectedIndex: 1,
+}
+
+const suggestions: MentionableAgent[] = [
+  {
+    id: 'explore',
+    label: 'Explore',
+    description: 'Reads code and explains structure.',
+  },
+  {
+    id: 'analyst',
+    label: 'Analyst',
+    description: 'Investigates data and summarizes insights with enough detail to be compacted.',
+  },
+]
+
+describe('ChatInputInlinePicker', () => {
+  it('renders nothing when the picker is inactive', () => {
+    const { container } = render(
+      <ChatInputInlinePicker
+        picker={null}
+        suggestions={suggestions}
+        pickerRef={createRef<HTMLDivElement>()}
+        left={100}
+        top={300}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders agent suggestions and reports selection', () => {
+    const onSelect = vi.fn()
+    render(
+      <ChatInputInlinePicker
+        picker={picker}
+        suggestions={suggestions}
+        pickerRef={createRef<HTMLDivElement>()}
+        left={100}
+        top={300}
+        onSelect={onSelect}
+      />,
+    )
+
+    expect(screen.getByText('Sub-Agents')).toBeInTheDocument()
+    expect(screen.getByText('Explore')).toBeInTheDocument()
+    expect(screen.getByText('@analyst')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Analyst/i }))
+    expect(onSelect).toHaveBeenCalledWith(suggestions[1])
+  })
+
+  it('clamps the menu position inside the viewport and shows empty state', () => {
+    const { container } = render(
+      <ChatInputInlinePicker
+        picker={{ ...picker, query: 'missing' }}
+        suggestions={[]}
+        pickerRef={createRef<HTMLDivElement>()}
+        left={10_000}
+        top={80}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    const menu = container.firstElementChild as HTMLElement
+    expect(menu.style.left).toBe('752px')
+    expect(screen.getByText('No agents match “missing”.')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
@@ -1,0 +1,88 @@
+import { createRef } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ChatInputToolbar } from './ChatInputToolbar'
+
+function renderToolbar(overrides: Partial<Parameters<typeof ChatInputToolbar>[0]> = {}) {
+  const fileInputRef = createRef<HTMLInputElement>()
+  const modelButtonRef = createRef<HTMLButtonElement>()
+  const props: Parameters<typeof ChatInputToolbar>[0] = {
+    fileInputRef,
+    modelButtonRef,
+    modelLabel: 'Claude Sonnet',
+    currentDirectory: '/Users/joe/project',
+    agentMode: 'build',
+    currentSessionId: 'ses_123',
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+    canSend: true,
+    onAddFiles: vi.fn(),
+    onToggleModelMenu: vi.fn(),
+    onToggleAgentMode: vi.fn(),
+    onFork: vi.fn(),
+    onStop: vi.fn(),
+    onSubmit: vi.fn(),
+    ...overrides,
+  }
+
+  return {
+    ...render(<ChatInputToolbar {...props} />),
+    props,
+  }
+}
+
+describe('ChatInputToolbar', () => {
+  it('opens the hidden file input and forwards selected files', () => {
+    const { container, props } = renderToolbar()
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const clickSpy = vi.spyOn(input, 'click')
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' })
+
+    fireEvent.click(screen.getByTitle('Attach file'))
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [file],
+    })
+    fireEvent.change(input)
+    expect(props.onAddFiles).toHaveBeenCalledWith([file])
+  })
+
+  it('handles model, agent mode, fork, and submit controls', () => {
+    const { props } = renderToolbar()
+
+    fireEvent.click(screen.getByRole('button', { name: /Claude Sonnet/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Build/i }))
+    fireEvent.click(screen.getByTitle('Fork thread'))
+    fireEvent.click(screen.getAllByRole('button').at(-1)!)
+
+    expect(props.onToggleModelMenu).toHaveBeenCalledTimes(1)
+    expect(props.onToggleAgentMode).toHaveBeenCalledTimes(1)
+    expect(props.onFork).toHaveBeenCalledTimes(1)
+    expect(props.onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes stop actions while generating', () => {
+    const { props } = renderToolbar({ isGenerating: true })
+
+    fireEvent.click(screen.getByTitle('Stop generating (Esc)'))
+    fireEvent.click(screen.getAllByRole('button').at(-1)!)
+
+    expect(props.onStop).toHaveBeenCalledTimes(2)
+    expect(props.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('shows waiting states and disables submit when it cannot send', () => {
+    renderToolbar({
+      canSend: false,
+      isAwaitingPermission: true,
+      isAwaitingQuestion: true,
+    })
+
+    expect(screen.getByText('Awaiting approval')).toBeInTheDocument()
+    expect(screen.getByText('Awaiting answer')).toBeInTheDocument()
+    expect(screen.getAllByRole('button').at(-1)).toBeDisabled()
+  })
+})

--- a/apps/desktop/src/renderer/components/plugins/PluginIcon.test.tsx
+++ b/apps/desktop/src/renderer/components/plugins/PluginIcon.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { PluginIcon } from './PluginIcon'
+
+describe('PluginIcon', () => {
+  it('renders known provider glyphs at the requested size', () => {
+    const { container } = render(<PluginIcon icon="github" size={48} />)
+
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper).toHaveStyle({ width: '48px', height: '48px' })
+    expect(wrapper.querySelector('svg')).toBeTruthy()
+  })
+
+  it.each([
+    'google',
+    'nova',
+    'atlassian',
+    'amplitude',
+    'charts',
+    'github',
+    'perplexity',
+    'github-mcp',
+    'google-sheets',
+    'google-docs',
+    'google-slides',
+    'google-drive',
+    'gmail',
+    'google-gmail',
+    'google-calendar',
+    'google-chat',
+    'google-people',
+    'google-forms',
+    'google-keep',
+    'google-tasks',
+    'google-appscript',
+    'search',
+    'code',
+  ])('renders the %s icon renderer', (icon) => {
+    const { container } = render(<PluginIcon icon={icon} />)
+
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+
+  it('renders two-character custom icons literally', () => {
+    render(<PluginIcon icon="db" />)
+
+    expect(screen.getByText('db')).toBeInTheDocument()
+  })
+
+  it('falls back to the uppercase initial for long unknown icons', () => {
+    render(<PluginIcon icon="warehouse" size={30} />)
+
+    expect(screen.getByText('W')).toHaveStyle({ fontSize: '12px' })
+  })
+})

--- a/apps/desktop/src/renderer/components/sidebar/McpStatus.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/McpStatus.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { useSessionStore } from '../../stores/session'
+import { McpStatus } from './McpStatus'
+
+function setConnections() {
+  useSessionStore.setState({
+    mcpConnections: [
+      { name: 'charts', connected: true },
+      { name: 'github', connected: false, rawStatus: 'disconnected' },
+      { name: 'google-drive', connected: false, rawStatus: 'auth_required' },
+    ],
+  })
+}
+
+describe('McpStatus', () => {
+  it('renders nothing without MCP connections', () => {
+    useSessionStore.setState({ mcpConnections: [] })
+
+    const { container } = render(<McpStatus />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('summarizes and expands MCP connection state', () => {
+    setConnections()
+    render(<McpStatus />)
+
+    expect(screen.getByRole('button', { name: /1 2 3 connections/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /3 connections/i }))
+    expect(screen.getByText('charts')).toBeInTheDocument()
+    expect(screen.getByText('github')).toBeInTheDocument()
+    expect(screen.getByText('auth required')).toBeInTheDocument()
+  })
+
+  it('uses connect for disconnected MCPs and auth for auth-required MCPs', async () => {
+    const connect = vi.fn(async () => undefined)
+    const auth = vi.fn(async () => true)
+    installRendererTestCoworkApi({ mcp: { connect, auth } })
+    setConnections()
+    render(<McpStatus />)
+
+    fireEvent.click(screen.getByRole('button', { name: /3 connections/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Re-auth' }))
+
+    await waitFor(() => {
+      expect(connect).toHaveBeenCalledWith('github')
+      expect(auth).toHaveBeenCalledWith('google-drive')
+    })
+  })
+
+  it('clears reconnecting state after failed reconnect attempts', async () => {
+    const connect = vi.fn(async () => {
+      throw new Error('offline')
+    })
+    installRendererTestCoworkApi({ mcp: { connect } })
+    useSessionStore.setState({
+      mcpConnections: [{ name: 'github', connected: false, rawStatus: 'disconnected' }],
+    })
+    render(<McpStatus />)
+
+    fireEvent.click(screen.getByRole('button', { name: /1 connections/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByRole('button', { name: 'Retry' })).toBeEnabled()
+  })
+})

--- a/apps/desktop/src/renderer/helpers/chart-colors.test.ts
+++ b/apps/desktop/src/renderer/helpers/chart-colors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  contrastRatio,
+  ensureReadableTextColor,
+  parseCssColor,
+  pickReadableTextColor,
+  relativeLuminance,
+} from './chart-colors'
+
+describe('chart color helpers', () => {
+  it('parses supported hex colors', () => {
+    expect(parseCssColor('#0f8')).toEqual({ r: 0, g: 255, b: 136, a: 1 })
+    expect(parseCssColor('#0f8c')).toEqual({ r: 0, g: 255, b: 136, a: 0.8 })
+    expect(parseCssColor('#003366')).toEqual({ r: 0, g: 51, b: 102, a: 1 })
+
+    const parsed = parseCssColor('#00336680')
+    expect(parsed).toMatchObject({ r: 0, g: 51, b: 102 })
+    expect(parsed?.a).toBeCloseTo(0.502, 3)
+  })
+
+  it('parses and clamps rgb colors', () => {
+    expect(parseCssColor('rgb(300, -20, 12.6)')).toEqual({ r: 255, g: 0, b: 12.6, a: 1 })
+    expect(parseCssColor('rgba(8, 16, 32, 1.4)')).toEqual({ r: 8, g: 16, b: 32, a: 1 })
+    expect(parseCssColor('rgba(8, 16, 32, -0.2)')).toEqual({ r: 8, g: 16, b: 32, a: 0 })
+  })
+
+  it('rejects invalid or unsupported color values', () => {
+    expect(parseCssColor(null)).toBeNull()
+    expect(parseCssColor('')).toBeNull()
+    expect(parseCssColor('blue')).toBeNull()
+    expect(parseCssColor('#12')).toBeNull()
+    expect(parseCssColor('rgba(10, bad, 20, 1)')).toBeNull()
+  })
+
+  it('computes luminance and contrast ratios', () => {
+    expect(relativeLuminance(parseCssColor('#000000'))).toBeCloseTo(0)
+    expect(relativeLuminance(parseCssColor('#ffffff'))).toBeCloseTo(1)
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21)
+    expect(contrastRatio('not-a-color', '#ffffff')).toBeNull()
+  })
+
+  it('selects readable text colors and preserves readable preferences', () => {
+    expect(pickReadableTextColor('#ffffff', '#eeeeee', '#111111')).toBe('#111111')
+    expect(pickReadableTextColor('#111111', '#eeeeee', '#111111')).toBe('#eeeeee')
+    expect(pickReadableTextColor('not-a-color', '#eeeeee', '#111111')).toBe('#eeeeee')
+
+    expect(ensureReadableTextColor('#000000', '#ffffff', '#eeeeee', '#111111')).toBe('#000000')
+    expect(ensureReadableTextColor('#777777', '#777777', '#eeeeee', '#111111')).toBe('#eeeeee')
+  })
+})

--- a/apps/desktop/src/renderer/stores/session.test.ts
+++ b/apps/desktop/src/renderer/stores/session.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SessionArtifact, SessionView } from '@open-cowork/shared'
+import type { Session } from './session'
+import {
+  createEmptySessionViewState,
+  deriveVisibleSessionPatch,
+  type SessionViewState,
+} from '../../lib/session-view-model'
+import { useSessionStore } from './session'
+
+function resetStore() {
+  useSessionStore.setState(useSessionStore.getInitialState(), true)
+}
+
+function session(id: string, title = id): Session {
+  return {
+    id,
+    title,
+    directory: '/repo',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+function view(overrides: Partial<SessionView> = {}): SessionView {
+  const state = createEmptySessionViewState(overrides as Partial<SessionViewState>)
+  const busySessions = overrides.isGenerating || overrides.isAwaitingPermission || overrides.isAwaitingQuestion
+    ? new Set(['ses_1'])
+    : new Set<string>()
+  const awaitingPermissionSessions = overrides.isAwaitingPermission ? new Set(['ses_1']) : new Set<string>()
+  return {
+    ...deriveVisibleSessionPatch(state, 'ses_1', busySessions, awaitingPermissionSessions),
+    ...overrides,
+  }
+}
+
+describe('useSessionStore', () => {
+  beforeEach(() => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000000')
+    resetStore()
+  })
+
+  it('manages session list metadata without erasing stable parent links', () => {
+    const store = useSessionStore.getState()
+
+    store.setSessions([session('one', 'One')])
+    useSessionStore.getState().addSession(session('two', 'Two'))
+    useSessionStore.getState().renameSession('one', 'Renamed')
+    useSessionStore.getState().applySessionMetadata({
+      id: 'two',
+      title: 'Fork',
+      parentSessionId: 'parent',
+      changeSummary: { additions: 2, deletions: 1, files: 1 },
+      revertedMessageId: 'msg_1',
+    })
+    useSessionStore.getState().applySessionMetadata({
+      id: 'two',
+      title: null,
+      parentSessionId: null,
+      changeSummary: null,
+      revertedMessageId: null,
+    })
+
+    expect(useSessionStore.getState().sessions).toEqual([
+      {
+        ...session('two', 'Fork'),
+        parentSessionId: 'parent',
+        changeSummary: null,
+        revertedMessageId: null,
+      },
+      session('one', 'Renamed'),
+    ])
+  })
+
+  it('projects full session views into busy and awaiting indexes', () => {
+    const store = useSessionStore.getState()
+
+    store.setCurrentSession('ses_1')
+    useSessionStore.getState().setSessionView('ses_1', view({
+      isGenerating: true,
+      isAwaitingPermission: true,
+      sessionCost: 1.25,
+    }))
+
+    expect(useSessionStore.getState().busySessions.has('ses_1')).toBe(true)
+    expect(useSessionStore.getState().awaitingPermissionSessions.has('ses_1')).toBe(true)
+    expect(useSessionStore.getState().totalCost).toBe(1.25)
+    expect(useSessionStore.getState().currentView.isAwaitingPermission).toBe(true)
+
+    useSessionStore.getState().setSessionView('ses_1', view({
+      isGenerating: true,
+      isAwaitingPermission: false,
+      sessionCost: 2,
+    }))
+
+    expect(useSessionStore.getState().currentView.isGenerating).toBe(true)
+
+    useSessionStore.getState().setSessionView('ses_1', view({
+      isGenerating: false,
+      isAwaitingPermission: false,
+      sessionCost: 2,
+    }))
+
+    expect(useSessionStore.getState().busySessions.has('ses_1')).toBe(false)
+    expect(useSessionStore.getState().awaitingPermissionSessions.has('ses_1')).toBe(false)
+    expect(useSessionStore.getState().totalCost).toBe(2)
+  })
+
+  it('applies message and task text patches to the visible session', () => {
+    const store = useSessionStore.getState()
+    store.setCurrentSession('ses_1')
+
+    useSessionStore.getState().applySessionPatch({
+      type: 'message_text',
+      sessionId: 'ses_1',
+      messageId: 'msg_1',
+      segmentId: 'seg_1',
+      content: 'Hello',
+      mode: 'append',
+      role: 'assistant',
+      eventAt: 10,
+    })
+    useSessionStore.getState().applySessionPatch({
+      type: 'message_text',
+      sessionId: 'ses_1',
+      messageId: 'msg_1',
+      segmentId: 'seg_1',
+      content: 'Hello world',
+      mode: 'replace',
+      role: 'assistant',
+      eventAt: 20,
+    })
+    useSessionStore.getState().applySessionPatch({
+      type: 'task_text',
+      sessionId: 'ses_1',
+      taskRunId: 'task_1',
+      segmentId: 'task_seg',
+      content: 'Working',
+      mode: 'append',
+      eventAt: 30,
+    })
+
+    const state = useSessionStore.getState()
+    expect(state.currentView.messages[0]?.content).toBe('Hello world')
+    expect(state.currentView.taskRuns[0]?.id).toBe('task_1')
+    expect(state.currentView.taskRuns[0]?.transcript[0]?.content).toBe('Working')
+    expect(state.currentView.lastItemWasTool).toBe(true)
+  })
+
+  it('deduplicates pending approvals and sets awaiting state', () => {
+    const approval = {
+      id: 'approval_1',
+      sessionId: 'ses_1',
+      tool: 'bash',
+      input: { command: 'pwd' },
+      description: 'Run pwd',
+    }
+
+    useSessionStore.getState().setCurrentSession('ses_1')
+    useSessionStore.getState().addPendingApproval(approval)
+    useSessionStore.getState().addPendingApproval({ ...approval, description: 'Run pwd again' })
+
+    const state = useSessionStore.getState()
+    expect(state.awaitingPermissionSessions.has('ses_1')).toBe(true)
+    expect(state.busySessions.has('ses_1')).toBe(true)
+    expect(state.currentView.pendingApprovals).toHaveLength(1)
+    expect(state.currentView.pendingApprovals[0]?.description).toBe('Run pwd again')
+  })
+
+  it('removes session state, status indexes, and chart artifacts together', () => {
+    const artifact: SessionArtifact = {
+      id: 'artifact-1',
+      toolId: 'tool-1',
+      toolName: 'chart',
+      filename: 'chart.png',
+      filePath: '/tmp/chart.png',
+      order: 0,
+      mime: 'image/png',
+    }
+
+    useSessionStore.getState().setSessions([session('ses_1')])
+    useSessionStore.getState().setCurrentSession('ses_1')
+    useSessionStore.getState().setSessionView('ses_1', view({ isAwaitingQuestion: true }))
+    useSessionStore.getState().registerChartArtifact('ses_1', artifact)
+    useSessionStore.getState().removeSession('ses_1')
+
+    const state = useSessionStore.getState()
+    expect(state.sessions).toEqual([])
+    expect(state.currentSessionId).toBeNull()
+    expect(state.sessionStateById.ses_1).toBeUndefined()
+    expect(state.awaitingQuestionSessions.has('ses_1')).toBe(false)
+    expect(state.chartArtifactsBySession.ses_1).toBeUndefined()
+  })
+
+  it('maps MCP status, tracks global errors, toggles sidebar, and dedupes chart artifacts', () => {
+    const artifact: SessionArtifact = {
+      id: 'artifact-1',
+      toolId: 'tool-1',
+      toolName: 'chart',
+      filename: 'chart.png',
+      filePath: '/tmp/chart.png',
+      order: 0,
+      mime: 'image/png',
+    }
+
+    useSessionStore.getState().setMcpConnections([
+      { name: 'charts', connected: true },
+      { name: 'github', connected: false, rawStatus: 'auth_required', error: 'login' },
+    ])
+    useSessionStore.getState().addGlobalError('Boom')
+    useSessionStore.getState().toggleSidebar()
+    useSessionStore.getState().registerChartArtifact('ses_1', artifact)
+    useSessionStore.getState().registerChartArtifact('ses_1', { ...artifact, id: 'artifact-2' })
+
+    const state = useSessionStore.getState()
+    expect(state.mcpConnections).toEqual([
+      { name: 'charts', connected: true, rawStatus: undefined, error: undefined },
+      { name: 'github', connected: false, rawStatus: 'auth_required', error: 'login' },
+    ])
+    expect(state.globalErrors).toEqual([{
+      id: '00000000-0000-4000-8000-000000000000',
+      sessionId: null,
+      message: 'Boom',
+      order: expect.any(Number),
+    }])
+    expect(state.sidebarCollapsed).toBe(true)
+    expect(state.chartArtifactsBySession.ses_1).toEqual([{ ...artifact, id: 'artifact-2' }])
+  })
+})

--- a/tests/runtime-managed-server.test.ts
+++ b/tests/runtime-managed-server.test.ts
@@ -50,7 +50,7 @@ while true; do sleep 1; done
     hostname: '127.0.0.1',
     opencodeBinPath: executable,
     port: 0,
-    timeout: 1000,
+    timeout: 5000,
   })
 
   const pid = (() => {


### PR DESCRIPTION
## Summary
- add focused renderer tests for agent builder controls, capability selection cards, chat input controls, plugin icons, MCP status, chart colors, and the session store
- raise practical coverage over previously thin control surfaces without changing production renderer behavior
- stabilize the managed runtime server coverage test by giving the successful startup path more room under coverage instrumentation

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm test:coverage
- git diff --check