### PR TITLE
harden managed OpenCode runtime wiring

### DIFF
--- a/apps/desktop/src/lib/session-view-messages.ts
+++ b/apps/desktop/src/lib/session-view-messages.ts
@@ -85,6 +85,7 @@ function moveLivePlaceholderStateToMessage(
     messageId: string
     segmentId: string
     role: 'user' | 'assistant'
+    content: string
     attachments?: MessageAttachment[]
     timestamp?: string | null
     providerId?: string | null
@@ -95,7 +96,7 @@ function moveLivePlaceholderStateToMessage(
     return state
   }
 
-  const liveMessageId = state.messageIds.find((messageId) => {
+  const liveMessageIds = state.messageIds.filter((messageId) => {
     const message = state.messageById[messageId]
     return Boolean(
       message
@@ -104,6 +105,13 @@ function moveLivePlaceholderStateToMessage(
       && message.id !== input.messageId,
     )
   })
+  const liveMessageId = input.role === 'user' && input.content.trim().length > 0
+    ? liveMessageIds.find((messageId) => {
+        const message = state.messageById[messageId]
+        if (!message) return false
+        return renderMessageSegments(buildMessageSegments(message, state.messagePartsById)) === input.content
+      }) || liveMessageIds[0]
+    : liveMessageIds[0]
 
   if (!liveMessageId) return state
 

--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -27,6 +27,10 @@ import {
 } from './task-run-utils.ts'
 
 const MAX_PENDING_TEXT_EVENTS = 500
+const MAX_TOTAL_PENDING_TEXT_EVENTS = 10_000
+const MAX_MESSAGE_ROLES_PER_SESSION = 2_000
+const MAX_TOTAL_MESSAGE_ROLES = 10_000
+const MISSING_SESSION_SCOPE_PREFIX = 'missing-session'
 
 export type PendingTextEvent = {
   mode: 'append' | 'replace'
@@ -40,19 +44,158 @@ export type PendingTextEvent = {
 
 type DispatchRuntimeEvent = (win: BrowserWindow, event: RuntimeSessionEvent) => void
 
+export type SessionScopedMessageState = {
+  messageRolesBySession: Map<string, Map<string, 'user' | 'assistant'>>
+  pendingTextEventsBySession: Map<string, Map<string, PendingTextEvent[]>>
+  totalPendingTextEvents: number
+  totalMessageRoles: number
+}
+
+export function createSessionScopedMessageState(): SessionScopedMessageState {
+  return {
+    messageRolesBySession: new Map(),
+    pendingTextEventsBySession: new Map(),
+    totalPendingTextEvents: 0,
+    totalMessageRoles: 0,
+  }
+}
+
+function messageSessionScope(sessionId: string | null | undefined, messageId: string) {
+  return sessionId || `${MISSING_SESSION_SCOPE_PREFIX}:${messageId}`
+}
+
+function getOrCreateSessionMap<T>(state: Map<string, Map<string, T>>, sessionScope: string) {
+  const existing = state.get(sessionScope)
+  if (existing) return existing
+  const created = new Map<string, T>()
+  state.set(sessionScope, created)
+  return created
+}
+
+function getMessageRole(
+  state: SessionScopedMessageState,
+  sessionId: string | null | undefined,
+  messageId: string,
+) {
+  return state.messageRolesBySession.get(messageSessionScope(sessionId, messageId))?.get(messageId)
+}
+
+function deleteMessageRole(
+  state: SessionScopedMessageState,
+  sessionScope: string,
+  scopedRoles: Map<string, 'user' | 'assistant'>,
+  messageId: string,
+) {
+  if (scopedRoles.delete(messageId)) state.totalMessageRoles = Math.max(0, state.totalMessageRoles - 1)
+  if (scopedRoles.size === 0) state.messageRolesBySession.delete(sessionScope)
+}
+
+function enforceMessageRoleBounds(state: SessionScopedMessageState) {
+  while (state.totalMessageRoles > MAX_TOTAL_MESSAGE_ROLES) {
+    const oldestScope = state.messageRolesBySession.keys().next().value
+    if (!oldestScope) {
+      state.totalMessageRoles = 0
+      break
+    }
+
+    const scopedRoles = state.messageRolesBySession.get(oldestScope)
+    const oldestMessageId = scopedRoles?.keys().next().value
+    if (!scopedRoles || !oldestMessageId) {
+      state.messageRolesBySession.delete(oldestScope)
+      continue
+    }
+
+    deleteMessageRole(state, oldestScope, scopedRoles, oldestMessageId)
+  }
+}
+
+function setMessageRole(
+  state: SessionScopedMessageState,
+  sessionId: string | null | undefined,
+  messageId: string,
+  role: 'user' | 'assistant',
+) {
+  const sessionScope = messageSessionScope(sessionId, messageId)
+  const scopedRoles = getOrCreateSessionMap(state.messageRolesBySession, sessionScope)
+  const alreadyTracked = scopedRoles.has(messageId)
+  scopedRoles.set(messageId, role)
+  if (!alreadyTracked) state.totalMessageRoles += 1
+  while (scopedRoles.size > MAX_MESSAGE_ROLES_PER_SESSION) {
+    const oldest = scopedRoles.keys().next().value
+    if (!oldest) break
+    deleteMessageRole(state, sessionScope, scopedRoles, oldest)
+  }
+  enforceMessageRoleBounds(state)
+}
+
+function deletePendingTextEvents(
+  state: SessionScopedMessageState,
+  sessionScope: string,
+  scopedPending: Map<string, PendingTextEvent[]>,
+  messageId: string,
+) {
+  const pending = scopedPending.get(messageId)
+  if (pending) {
+    state.totalPendingTextEvents = Math.max(0, state.totalPendingTextEvents - pending.length)
+  }
+  scopedPending.delete(messageId)
+  if (scopedPending.size === 0) state.pendingTextEventsBySession.delete(sessionScope)
+}
+
+function enforcePendingTextEventBounds(state: SessionScopedMessageState) {
+  while (state.totalPendingTextEvents > MAX_TOTAL_PENDING_TEXT_EVENTS) {
+    const oldestScope = state.pendingTextEventsBySession.keys().next().value
+    if (!oldestScope) {
+      state.totalPendingTextEvents = 0
+      break
+    }
+
+    const scopedPending = state.pendingTextEventsBySession.get(oldestScope)
+    const oldestMessageId = scopedPending?.keys().next().value
+    if (!scopedPending || !oldestMessageId) {
+      state.pendingTextEventsBySession.delete(oldestScope)
+      continue
+    }
+
+    deletePendingTextEvents(state, oldestScope, scopedPending, oldestMessageId)
+  }
+}
+
 function pushPendingTextEvent(
-  pendingTextEvents: Map<string, PendingTextEvent[]>,
+  state: SessionScopedMessageState,
+  sessionId: string | null | undefined,
   messageId: string,
   event: PendingTextEvent,
 ) {
-  const current = pendingTextEvents.get(messageId) || []
+  const sessionScope = messageSessionScope(sessionId, messageId)
+  const scopedPending = getOrCreateSessionMap(
+    state.pendingTextEventsBySession,
+    sessionScope,
+  )
+  const current = scopedPending.get(messageId) || []
   current.push(event)
-  pendingTextEvents.set(messageId, current)
-  while (pendingTextEvents.size > MAX_PENDING_TEXT_EVENTS) {
-    const oldest = pendingTextEvents.keys().next().value
+  state.totalPendingTextEvents += 1
+  scopedPending.set(messageId, current)
+  while (scopedPending.size > MAX_PENDING_TEXT_EVENTS) {
+    const oldest = scopedPending.keys().next().value
     if (!oldest) break
-    pendingTextEvents.delete(oldest)
+    deletePendingTextEvents(state, sessionScope, scopedPending, oldest)
   }
+  enforcePendingTextEventBounds(state)
+}
+
+export function sweepSessionScopedMessageState(state: SessionScopedMessageState) {
+  for (const [scope, roles] of state.messageRolesBySession.entries()) {
+    while (roles.size > MAX_MESSAGE_ROLES_PER_SESSION) {
+      const oldest = roles.keys().next().value
+      if (!oldest) break
+      deleteMessageRole(state, scope, roles, oldest)
+    }
+    if (roles.size === 0) state.messageRolesBySession.delete(scope)
+  }
+
+  enforceMessageRoleBounds(state)
+  enforcePendingTextEventBounds(state)
 }
 
 function dispatchTextPatch(
@@ -107,13 +250,16 @@ function emitTaskRun(win: BrowserWindow, taskRun: TaskRunMeta) {
 export function flushPendingTextEvents(
   win: BrowserWindow,
   dispatchRuntimeEvent: DispatchRuntimeEvent,
-  pendingTextEvents: Map<string, PendingTextEvent[]>,
+  state: SessionScopedMessageState,
+  sessionId: string | null | undefined,
   messageId: string,
   role: 'user' | 'assistant',
 ) {
-  const pending = pendingTextEvents.get(messageId)
-  if (!pending || pending.length === 0) return
-  pendingTextEvents.delete(messageId)
+  const scopedPending = state.pendingTextEventsBySession.get(messageSessionScope(sessionId, messageId))
+  const pending = scopedPending?.get(messageId)
+  if (!scopedPending || !pending || pending.length === 0) return
+  const sessionScope = messageSessionScope(sessionId, messageId)
+  deletePendingTextEvents(state, sessionScope, scopedPending, messageId)
   if (role === 'user') return
   for (const event of pending) {
     dispatchTextPatch(win, dispatchRuntimeEvent, {
@@ -132,13 +278,12 @@ export function handleMessageUpdatedEvent(
   win: BrowserWindow,
   dispatchRuntimeEvent: DispatchRuntimeEvent,
   properties: Record<string, unknown> | null | undefined,
-  messageRoles: Map<string, 'user' | 'assistant'>,
-  pendingTextEventsByMessageId: Map<string, PendingTextEvent[]>,
+  messageState: SessionScopedMessageState,
 ) {
   const info = normalizeSessionInfo(readRecordValue(properties, 'info'))
   if (info?.id && (info.role === 'user' || info.role === 'assistant')) {
-    messageRoles.set(info.id, info.role)
-    flushPendingTextEvents(win, dispatchRuntimeEvent, pendingTextEventsByMessageId, info.id, info.role)
+    setMessageRole(messageState, info.sessionID || null, info.id, info.role)
+    flushPendingTextEvents(win, dispatchRuntimeEvent, messageState, info.sessionID || null, info.id, info.role)
   }
   if (info?.sessionID) {
     registerSession(info.sessionID)
@@ -149,8 +294,7 @@ export function handleMessagePartDeltaEvent(
   win: BrowserWindow,
   dispatchRuntimeEvent: DispatchRuntimeEvent,
   properties: Record<string, unknown> | null | undefined,
-  messageRoles: Map<string, 'user' | 'assistant'>,
-  pendingTextEventsByMessageId: Map<string, PendingTextEvent[]>,
+  messageState: SessionScopedMessageState,
 ) {
   const messageId = readString(readRecordValue(properties, 'messageID'))
     || readString(readRecordValue(properties, 'messageId'))
@@ -172,10 +316,10 @@ export function handleMessagePartDeltaEvent(
     : null
 
   if (messageId) {
-    const role = messageRoles.get(messageId)
+    const role = getMessageRole(messageState, actualSessionId, messageId)
     if (role === 'user') return
     if (!role) {
-      pushPendingTextEvent(pendingTextEventsByMessageId, messageId, {
+      pushPendingTextEvent(messageState, actualSessionId, messageId, {
         mode: 'append',
         rootSessionId: sessionId,
         actualSessionId,
@@ -203,8 +347,7 @@ export function handleMessagePartUpdatedEvent(
   win: BrowserWindow,
   dispatchRuntimeEvent: DispatchRuntimeEvent,
   properties: Record<string, unknown> | null | undefined,
-  messageRoles: Map<string, 'user' | 'assistant'>,
-  pendingTextEventsByMessageId: Map<string, PendingTextEvent[]>,
+  messageState: SessionScopedMessageState,
   cachedModelId: string,
 ) {
   const part = normalizeMessagePart(readRecordValue(properties, 'part'))
@@ -220,7 +363,7 @@ export function handleMessagePartUpdatedEvent(
   const actualSessionId = readString(readRecordValue(properties, 'sessionID'))
     || readString(readRecordValue(properties, 'sessionId'))
     || null
-  const messageRole = messageId ? messageRoles.get(messageId) : undefined
+  const messageRole = messageId ? getMessageRole(messageState, actualSessionId, messageId) : undefined
   if (messageRole === 'user') return
 
   const rootSessionId = resolveRootSession(actualSessionId)
@@ -238,7 +381,7 @@ export function handleMessagePartUpdatedEvent(
       : null
 
     if (messageId && !messageRole) {
-      pushPendingTextEvent(pendingTextEventsByMessageId, messageId, {
+      pushPendingTextEvent(messageState, actualSessionId, messageId, {
         mode: 'replace',
         rootSessionId,
         actualSessionId,

--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -88,7 +88,7 @@ export function consumePendingPromptEcho(sessionId: string, content: string) {
   return hierarchyStore.consumePendingPromptEcho(sessionId, content)
 }
 
-export function sweepStaleTaskState(messageRoles: Map<string, 'user' | 'assistant'>) {
+export function sweepStaleTaskState(messageRoles?: Map<string, 'user' | 'assistant'>) {
   hierarchyStore.sweepStaleTaskState(messageRoles)
 }
 

--- a/apps/desktop/src/main/events.ts
+++ b/apps/desktop/src/main/events.ts
@@ -13,10 +13,11 @@ import {
   sweepStaleTaskState,
 } from './event-task-state.ts'
 import {
+  createSessionScopedMessageState,
   handleMessagePartDeltaEvent,
   handleMessagePartUpdatedEvent,
   handleMessageUpdatedEvent,
-  type PendingTextEvent,
+  sweepSessionScopedMessageState,
 } from './event-message-handlers.ts'
 import { handleRuntimeSideEffectEvent } from './event-runtime-handlers.ts'
 
@@ -39,10 +40,10 @@ export async function subscribeToEvents(
   log('events', `SSE stream connected${scopeLabel}`)
 
   const cachedModelId = getEffectiveSettings().effectiveModel || loadSettings().selectedModelId || ''
-  const messageRoles = new Map<string, 'user' | 'assistant'>()
-  const pendingTextEventsByMessageId = new Map<string, PendingTextEvent[]>()
+  const messageState = createSessionScopedMessageState()
   const sweepInterval = setInterval(() => {
-    sweepStaleTaskState(messageRoles)
+    sweepStaleTaskState()
+    sweepSessionScopedMessageState(messageState)
   }, 5 * 60 * 1000)
 
   // One-shot trace: log the first event per subscription so a silent stream
@@ -69,12 +70,12 @@ export async function subscribeToEvents(
       try {
         switch (data.type) {
           case 'message.updated': {
-            handleMessageUpdatedEvent(win, dispatchRuntimeEvent, data.properties, messageRoles, pendingTextEventsByMessageId)
+            handleMessageUpdatedEvent(win, dispatchRuntimeEvent, data.properties, messageState)
             break
           }
 
           case 'message.part.delta': {
-            handleMessagePartDeltaEvent(win, dispatchRuntimeEvent, data.properties, messageRoles, pendingTextEventsByMessageId)
+            handleMessagePartDeltaEvent(win, dispatchRuntimeEvent, data.properties, messageState)
             break
           }
 
@@ -83,8 +84,7 @@ export async function subscribeToEvents(
               win,
               dispatchRuntimeEvent,
               data.properties,
-              messageRoles,
-              pendingTextEventsByMessageId,
+              messageState,
               cachedModelId,
             )
             break

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -1,4 +1,5 @@
 import type { IpcHandlerContext } from './context.ts'
+import { randomUUID } from 'node:crypto'
 import { getEffectiveSettings, getProviderCredentialValue } from '../settings.ts'
 import { getProviderDescriptor } from '../config-loader.ts'
 import { getClient, getClientForDirectory, getRuntimeHomeDir } from '../runtime.ts'
@@ -191,8 +192,9 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
       // OpenCode absorbs this optimistic insert via
       // moveLivePlaceholderStateToMessage — otherwise the UI renders two
       // bubbles (the optimistic one and the server-confirmed one).
-      const optimisticMessageId = `${sessionId}:user:live`
-      const optimisticSegmentId = `${sessionId}:user:segment:live`
+      const optimisticPromptId = randomUUID()
+      const optimisticMessageId = `${sessionId}:${optimisticPromptId}:user:live`
+      const optimisticSegmentId = `${sessionId}:${optimisticPromptId}:user:segment:live`
       rememberSubmittedPrompt(sessionId, promptText)
       dispatchRuntimeSessionEvent(win, {
         type: 'text',

--- a/apps/desktop/src/main/runtime-environment.ts
+++ b/apps/desktop/src/main/runtime-environment.ts
@@ -5,6 +5,7 @@ import {
   OPEN_COWORK_MANAGED_RUNTIME_ENV,
   OPEN_COWORK_MANAGED_RUNTIME_VALUE,
 } from './runtime-process-cleanup.ts'
+import type { ManagedOpencodeServerAuth } from './runtime-managed-server.ts'
 
 type RuntimeEnvPaths = ReturnType<typeof getRuntimeEnvPaths>
 
@@ -72,6 +73,7 @@ export function buildManagedRuntimeEnvironment(input: {
   runtimePaths: RuntimeEnvPaths
   adcPath?: string | null
   enableNativeWebSearch?: boolean
+  serverAuth?: ManagedOpencodeServerAuth
 }) {
   const env: NodeJS.ProcessEnv = {}
   for (const [key, value] of Object.entries(input.currentEnv)) {
@@ -81,7 +83,12 @@ export function buildManagedRuntimeEnvironment(input: {
   applyManagedHomeEnvironment(env, input.runtimePaths)
   env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = '1'
   env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS = '1'
+  env.OPENCODE_DISABLE_EMBEDDED_WEB_UI = 'true'
   env[OPEN_COWORK_MANAGED_RUNTIME_ENV] = OPEN_COWORK_MANAGED_RUNTIME_VALUE
+  if (input.serverAuth) {
+    env.OPENCODE_SERVER_USERNAME = input.serverAuth.username
+    env.OPENCODE_SERVER_PASSWORD = input.serverAuth.password
+  }
   if (input.enableNativeWebSearch) env.OPENCODE_ENABLE_EXA = '1'
   if (input.adcPath) env.GOOGLE_APPLICATION_CREDENTIALS = input.adcPath
   return env

--- a/apps/desktop/src/main/runtime-managed-server.ts
+++ b/apps/desktop/src/main/runtime-managed-server.ts
@@ -1,5 +1,30 @@
 import type { ServerOptions as OpencodeServerOptions } from '@opencode-ai/sdk/v2/server'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+
+export const MANAGED_OPENCODE_SERVER_USERNAME = 'opencode'
+
+export type ManagedOpencodeServerAuth = {
+  username: string
+  password: string
+  authorizationHeader: string
+}
+
+export function buildManagedOpencodeAuthorizationHeader(input: { username: string; password: string }) {
+  return `Basic ${Buffer.from(`${input.username}:${input.password}`).toString('base64')}`
+}
+
+export function createManagedOpencodeServerAuth(): ManagedOpencodeServerAuth {
+  const password = randomBytes(32).toString('base64url')
+  return {
+    username: MANAGED_OPENCODE_SERVER_USERNAME,
+    password,
+    authorizationHeader: buildManagedOpencodeAuthorizationHeader({
+      username: MANAGED_OPENCODE_SERVER_USERNAME,
+      password,
+    }),
+  }
+}
 
 export function buildManagedOpencodeServerEnvironment(
   env: NodeJS.ProcessEnv,

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -2,6 +2,7 @@ import {
   createOpencodeClient,
   type Auth as OpencodeAuth,
   type OpencodeClient as V2OpencodeClient,
+  type OpencodeClientConfig,
 } from '@opencode-ai/sdk/v2'
 import type { ServerOptions as OpencodeServerOptions } from '@opencode-ai/sdk/v2/server'
 import type { ModelInfoSnapshot } from '@open-cowork/shared'
@@ -27,7 +28,11 @@ import { copySkillsAndAgents } from './runtime-content.ts'
 import { getOrCreateDirectoryClient } from './runtime-client-cache.ts'
 import { syncRuntimeHomeToolingBridge } from './runtime-home-bridge.ts'
 import { verifyRuntimeSkillCatalog } from './runtime-skill-verifier.ts'
-import { createManagedOpencodeServer } from './runtime-managed-server.ts'
+import {
+  createManagedOpencodeServer,
+  createManagedOpencodeServerAuth,
+  type ManagedOpencodeServerAuth,
+} from './runtime-managed-server.ts'
 import { buildManagedRuntimeEnvironment } from './runtime-environment.ts'
 import {
   cleanupOrphanedManagedOpencodeProcesses,
@@ -51,11 +56,12 @@ export {
 
 let client: V2OpencodeClient | null = null
 let serverUrl: string | null = null
+let serverAuth: ManagedOpencodeServerAuth | null = null
 let serverClose: (() => void) | null = null
 let tokenRefreshTimer: NodeJS.Timeout | null = null
 let startRuntimePromise: Promise<V2OpencodeClient> | null = null
 const directoryClients = new Map<string, V2OpencodeClient>()
-const MAX_DIRECTORY_CLIENTS = 50
+const MAX_DIRECTORY_CLIENTS = 10_000
 let activeProjectOverlayDirectory: string | null = null
 let onDirectoryClientCreated: ((directory: string, client: V2OpencodeClient) => void) | null = null
 let onDirectoryClientEvicted: ((directory: string, client: V2OpencodeClient) => void) | null = null
@@ -250,17 +256,34 @@ async function createManagedOpencode(options: OpencodeServerOptions, opencodeBin
   // anything to their shell. No-op when the user hasn't completed
   // Google sign-in, or when `auth.mode` isn't `google-oauth`.
   const adcPath = getAdcPathIfAvailable()
+  const auth = createManagedOpencodeServerAuth()
   const env = buildManagedRuntimeEnvironment({
     currentEnv: process.env,
     runtimePaths,
     adcPath,
     enableNativeWebSearch: shouldEnableNativeWebSearch(),
+    serverAuth: auth,
   })
   const server = await createManagedOpencodeServer({ ...options, env, opencodeBinPath })
-  const managedClient = createOpencodeClient({ baseUrl: server.url })
+  const managedClient = createOpencodeClient(buildManagedOpencodeClientConfig(server.url, auth))
   return {
     client: managedClient,
     server,
+    auth,
+  }
+}
+
+export function buildManagedOpencodeClientConfig(
+  baseUrl: string,
+  auth: ManagedOpencodeServerAuth,
+  directory?: string | null,
+): OpencodeClientConfig & { directory?: string } {
+  return {
+    baseUrl,
+    headers: {
+      Authorization: auth.authorizationHeader,
+    },
+    ...(directory ? { directory } : {}),
   }
 }
 
@@ -361,6 +384,7 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
 
       client = result.client
       serverUrl = result.server.url
+      serverAuth = result.auth
       serverClose = result.server.close
       await syncNativeProviderApiAuth(client)
       void verifyRuntimeSkillCatalog(client, getRuntimeHomeDir())
@@ -388,6 +412,7 @@ export async function startRuntime(projectDirectory?: string | null): Promise<V2
       cachedModelInfo = null
       client = null
       serverUrl = null
+      serverAuth = null
       serverClose = null
       currentRuntimePid = null
       directoryClients.clear()
@@ -417,14 +442,14 @@ export function getClientForDirectory(directory?: string | null): V2OpencodeClie
     cache: directoryClients,
     maxEntries: MAX_DIRECTORY_CLIENTS,
     createClient: (baseUrl, scopedDirectory) =>
-      createOpencodeClient({
-        baseUrl,
-        directory: scopedDirectory,
-      }),
+      createOpencodeClient(serverAuth
+        ? buildManagedOpencodeClientConfig(baseUrl, serverAuth, scopedDirectory)
+        : { baseUrl, directory: scopedDirectory }),
     onCreate: (scopedClient, scopedDirectory) => {
       onDirectoryClientCreated?.(scopedDirectory, scopedClient)
     },
     onEvict: (scopedClient, scopedDirectory) => {
+      log('runtime', `Evicting directory-scoped OpenCode client for ${scopedDirectory}`)
       onDirectoryClientEvicted?.(scopedDirectory, scopedClient)
     },
   })
@@ -468,6 +493,7 @@ export async function stopRuntime() {
   clearProjectOverlayCopies()
   client = null
   serverUrl = null
+  serverAuth = null
   cachedModelInfo = null
   activeProjectOverlayDirectory = null
 }

--- a/apps/desktop/src/main/session-task-state-store.ts
+++ b/apps/desktop/src/main/session-task-state-store.ts
@@ -299,7 +299,7 @@ export class SessionTaskStateStore {
     return content
   }
 
-  sweepStaleTaskState(messageRoles: Map<string, 'user' | 'assistant'>) {
+  sweepStaleTaskState(messageRoles?: Map<string, 'user' | 'assistant'>) {
     for (const [childSessionId, taskRunId] of this.childSessionToTaskRunId.entries()) {
       const taskRun = this.taskRuns.get(taskRunId)
       if (!taskRun || taskRun.childSessionId !== childSessionId) {
@@ -318,6 +318,8 @@ export class SessionTaskStateStore {
         this.queuedChildSessionsByParent.delete(parentSessionId)
       }
     }
+
+    if (!messageRoles) return
 
     while (messageRoles.size > 2000) {
       const oldest = messageRoles.keys().next().value

--- a/tests/event-message-handlers.test.ts
+++ b/tests/event-message-handlers.test.ts
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { BrowserWindow } from 'electron'
 import {
+  createSessionScopedMessageState,
   handleMessagePartDeltaEvent,
   handleMessageUpdatedEvent,
-  type PendingTextEvent,
 } from '../apps/desktop/src/main/event-message-handlers.ts'
 
 function createDispatchCollector() {
@@ -19,8 +19,7 @@ function createDispatchCollector() {
 
 test('message text deltas buffer until assistant role is known, then flush', () => {
   const win = {} as BrowserWindow
-  const messageRoles = new Map<string, 'user' | 'assistant'>()
-  const pending = new Map<string, PendingTextEvent[]>()
+  const messageState = createSessionScopedMessageState()
   const collector = createDispatchCollector()
 
   handleMessagePartDeltaEvent(
@@ -32,12 +31,12 @@ test('message text deltas buffer until assistant role is known, then flush', () 
       partID: 'part_1',
       delta: 'Hello',
     },
-    messageRoles,
-    pending,
+    messageState,
   )
 
   assert.equal(collector.events.length, 0)
-  assert.equal(pending.get('msg_1')?.length, 1)
+  assert.equal(messageState.pendingTextEventsBySession.get('sess_1')?.get('msg_1')?.length, 1)
+  assert.equal(messageState.totalPendingTextEvents, 1)
 
   handleMessageUpdatedEvent(
     win,
@@ -49,18 +48,17 @@ test('message text deltas buffer until assistant role is known, then flush', () 
         sessionID: 'sess_1',
       },
     },
-    messageRoles,
-    pending,
+    messageState,
   )
 
-  assert.equal(pending.has('msg_1'), false)
+  assert.equal(messageState.pendingTextEventsBySession.has('sess_1'), false)
+  assert.equal(messageState.totalPendingTextEvents, 0)
   assert.equal(collector.events.length, 1)
 })
 
 test('user-role message updates drop buffered text instead of dispatching it', () => {
   const win = {} as BrowserWindow
-  const messageRoles = new Map<string, 'user' | 'assistant'>()
-  const pending = new Map<string, PendingTextEvent[]>()
+  const messageState = createSessionScopedMessageState()
   const collector = createDispatchCollector()
 
   handleMessagePartDeltaEvent(
@@ -72,8 +70,7 @@ test('user-role message updates drop buffered text instead of dispatching it', (
       partID: 'part_1',
       delta: 'prompt echo',
     },
-    messageRoles,
-    pending,
+    messageState,
   )
 
   handleMessageUpdatedEvent(
@@ -86,10 +83,172 @@ test('user-role message updates drop buffered text instead of dispatching it', (
         sessionID: 'sess_1',
       },
     },
-    messageRoles,
-    pending,
+    messageState,
   )
 
-  assert.equal(pending.has('msg_user'), false)
+  assert.equal(messageState.pendingTextEventsBySession.has('sess_1'), false)
+  assert.equal(messageState.totalPendingTextEvents, 0)
   assert.equal(collector.events.length, 0)
+})
+
+test('pending text eviction is scoped per session', () => {
+  const win = {} as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+  const collector = createDispatchCollector()
+
+  handleMessagePartDeltaEvent(
+    win,
+    collector.dispatch,
+    {
+      messageID: 'msg_b',
+      sessionID: 'sess_b',
+      partID: 'part_b',
+      delta: 'preserve me',
+    },
+    messageState,
+  )
+
+  for (let index = 0; index < 505; index += 1) {
+    handleMessagePartDeltaEvent(
+      win,
+      collector.dispatch,
+      {
+        messageID: `msg_a_${index}`,
+        sessionID: 'sess_a',
+        partID: `part_a_${index}`,
+        delta: `noisy ${index}`,
+      },
+      messageState,
+    )
+  }
+
+  assert.equal(messageState.pendingTextEventsBySession.get('sess_b')?.get('msg_b')?.length, 1)
+  assert.equal(messageState.pendingTextEventsBySession.get('sess_a')?.size, 500)
+  assert.equal(messageState.totalPendingTextEvents, 501)
+  assert.equal(collector.events.length, 0)
+
+  handleMessageUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      info: {
+        id: 'msg_b',
+        role: 'assistant',
+        sessionID: 'sess_b',
+      },
+    },
+    messageState,
+  )
+
+  assert.equal(collector.events.length, 1)
+  assert.deepEqual(collector.events[0], {
+    type: 'text',
+    sessionId: 'sess_b',
+    data: {
+      type: 'text',
+      mode: 'append',
+      content: 'preserve me',
+      taskRunId: null,
+      sourceSessionId: 'sess_b',
+      messageId: 'msg_b',
+      partId: 'part_b',
+    },
+  })
+  assert.equal(messageState.totalPendingTextEvents, 500)
+})
+
+test('message roles without session ids do not affect session-scoped deltas', () => {
+  const win = {} as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+  const collector = createDispatchCollector()
+
+  handleMessageUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      info: {
+        id: 'shared-message-id',
+        role: 'user',
+      },
+    },
+    messageState,
+  )
+
+  handleMessagePartDeltaEvent(
+    win,
+    collector.dispatch,
+    {
+      messageID: 'shared-message-id',
+      sessionID: 'sess_with_scope',
+      partID: 'part_1',
+      delta: 'assistant text',
+    },
+    messageState,
+  )
+
+  assert.equal(collector.events.length, 0)
+  assert.equal(messageState.pendingTextEventsBySession.get('sess_with_scope')?.get('shared-message-id')?.length, 1)
+  assert.equal(messageState.totalPendingTextEvents, 1)
+})
+
+test('pending text buffers remain globally bounded across many sessions', () => {
+  const win = {} as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+  const collector = createDispatchCollector()
+
+  for (let index = 0; index < 10_025; index += 1) {
+    handleMessagePartDeltaEvent(
+      win,
+      collector.dispatch,
+      {
+        messageID: `pending_msg_${index}`,
+        sessionID: `pending_sess_${index}`,
+        partID: `pending_part_${index}`,
+        delta: `pending text ${index}`,
+      },
+      messageState,
+    )
+  }
+
+  const totalPendingMessages = Array.from(messageState.pendingTextEventsBySession.values())
+    .reduce((total, pendingByMessage) => total + pendingByMessage.size, 0)
+
+  assert.equal(totalPendingMessages, 10_000)
+  assert.equal(messageState.totalPendingTextEvents, 10_000)
+  assert.equal(messageState.pendingTextEventsBySession.has('pending_sess_0'), false)
+  assert.equal(messageState.pendingTextEventsBySession.has('pending_sess_24'), false)
+  assert.equal(messageState.pendingTextEventsBySession.has('pending_sess_25'), true)
+  assert.equal(messageState.pendingTextEventsBySession.has('pending_sess_10024'), true)
+  assert.equal(collector.events.length, 0)
+})
+
+test('message role cache remains globally bounded across many sessions', () => {
+  const win = {} as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+  const collector = createDispatchCollector()
+
+  for (let index = 0; index < 10_025; index += 1) {
+    handleMessageUpdatedEvent(
+      win,
+      collector.dispatch,
+      {
+        info: {
+          id: `msg_${index}`,
+          role: 'assistant',
+          sessionID: `sess_${index}`,
+        },
+      },
+      messageState,
+    )
+  }
+
+  const totalRoles = Array.from(messageState.messageRolesBySession.values())
+    .reduce((total, roles) => total + roles.size, 0)
+
+  assert.equal(totalRoles, 10_000)
+  assert.equal(messageState.totalMessageRoles, 10_000)
+  assert.equal(messageState.messageRolesBySession.has('sess_0'), false)
+  assert.equal(messageState.messageRolesBySession.has('sess_24'), false)
+  assert.equal(messageState.messageRolesBySession.has('sess_25'), true)
+  assert.equal(messageState.messageRolesBySession.has('sess_10024'), true)
 })

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { BrowserWindow } from 'electron'
 import { handleRuntimeSideEffectEvent } from '../apps/desktop/src/main/event-runtime-handlers.ts'
-import { handleMessagePartUpdatedEvent } from '../apps/desktop/src/main/event-message-handlers.ts'
+import {
+  createSessionScopedMessageState,
+  handleMessagePartUpdatedEvent,
+} from '../apps/desktop/src/main/event-message-handlers.ts'
 import {
   getTaskRun,
   registerSession,
@@ -352,8 +355,7 @@ test('child tool errors do not terminalize a still-running subagent task', () =>
         },
       },
     },
-    new Map([['message-1', 'assistant']]),
-    new Map(),
+    createSessionScopedMessageState(),
     'openai/gpt-5.5',
   )
 

--- a/tests/runtime-client-cache.test.ts
+++ b/tests/runtime-client-cache.test.ts
@@ -75,3 +75,30 @@ test('directory client cache reuses scoped clients and evicts the oldest entry',
   assert.equal(cache.has('/c'), true)
   assert.equal(third?.id.startsWith('client:/c:'), true)
 })
+
+test('directory client cache can retain more than fifty scoped clients without eviction', () => {
+  const cache = new Map<string, { id: string }>()
+  const baseClient = { id: 'base' }
+  const evicted: string[] = []
+
+  for (let index = 0; index < 60; index += 1) {
+    const directory = `/project-${index}`
+    const client = getOrCreateDirectoryClient({
+      baseClient,
+      serverUrl: 'http://127.0.0.1:8765',
+      directory,
+      runtimeHomeDir: '/runtime-home',
+      cache,
+      maxEntries: 10_000,
+      createClient: (_baseUrl, scopedDirectory) => ({ id: `client:${scopedDirectory}` }),
+      onEvict: (_client, scopedDirectory) => {
+        evicted.push(scopedDirectory)
+      },
+    })
+
+    assert.equal(client?.id, `client:${directory}`)
+  }
+
+  assert.equal(cache.size, 60)
+  assert.deepEqual(evicted, [])
+})

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict'
 import { PassThrough } from 'node:stream'
 import { buildManagedRuntimeEnvironment } from '../apps/desktop/src/main/runtime-environment.ts'
 import {
+  buildManagedOpencodeAuthorizationHeader,
   buildManagedOpencodeServerEnvironment,
+  createManagedOpencodeServerAuth,
   drainManagedOpencodeProcessOutput,
   parseManagedOpencodeServerStdoutChunk,
   resolveManagedOpencodeCommand,
@@ -49,6 +51,14 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
     runtimePaths,
     adcPath: '/tmp/open-cowork/adc.json',
     enableNativeWebSearch: true,
+    serverAuth: {
+      username: 'opencode',
+      password: 'runtime-password',
+      authorizationHeader: buildManagedOpencodeAuthorizationHeader({
+        username: 'opencode',
+        password: 'runtime-password',
+      }),
+    },
   })
 
   assert.equal(env.PATH, '/usr/bin:/bin')
@@ -76,6 +86,9 @@ test('managed runtime env keeps toolchain basics and drops arbitrary shell secre
   assert.equal(env.OPENCODE_ENABLE_EXA, '1')
   assert.equal(env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT, '1')
   assert.equal(env.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS, '1')
+  assert.equal(env.OPENCODE_DISABLE_EMBEDDED_WEB_UI, 'true')
+  assert.equal(env.OPENCODE_SERVER_USERNAME, 'opencode')
+  assert.equal(env.OPENCODE_SERVER_PASSWORD, 'runtime-password')
   assert.equal(env[OPEN_COWORK_MANAGED_RUNTIME_ENV], OPEN_COWORK_MANAGED_RUNTIME_VALUE)
 
   assert.equal(env.OPENAI_API_KEY, undefined)
@@ -97,6 +110,22 @@ test('managed runtime env drops inherited opencode binary overrides', () => {
 
   assert.equal(env.PATH, '/usr/bin:/bin')
   assert.equal(env.OPENCODE_BIN_PATH, undefined)
+})
+
+test('managed runtime server auth generates Basic auth without mutating the password', () => {
+  const auth = createManagedOpencodeServerAuth()
+
+  assert.equal(auth.username, 'opencode')
+  assert.equal(auth.password.length > 30, true)
+  assert.equal(
+    auth.authorizationHeader,
+    buildManagedOpencodeAuthorizationHeader({
+      username: auth.username,
+      password: auth.password,
+    }),
+  )
+  assert.equal(auth.authorizationHeader.startsWith('Basic '), true)
+  assert.equal(auth.authorizationHeader.includes(auth.password), false)
 })
 
 test('managed runtime env maps Windows home variables to the sandbox home', () => {

--- a/tests/runtime-managed-server.test.ts
+++ b/tests/runtime-managed-server.test.ts
@@ -6,8 +6,12 @@ import { join } from 'path'
 import { setTimeout as delay } from 'timers/promises'
 
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
-import { createManagedOpencodeServer } from '../apps/desktop/src/main/runtime-managed-server.ts'
 import {
+  buildManagedOpencodeAuthorizationHeader,
+  createManagedOpencodeServer,
+} from '../apps/desktop/src/main/runtime-managed-server.ts'
+import {
+  buildManagedOpencodeClientConfig,
   getActiveProjectOverlayDirectory,
   getClient,
   getModelInfo,
@@ -39,14 +43,21 @@ async function waitForProcessExit(pid: number) {
 test('managed opencode server resolves from stdout and closes the child process', async () => {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-runtime-server-'))
   const pidFile = join(root, 'pid')
+  const envFile = join(root, 'env')
   const executable = writeExecutable(root, 'fake-opencode', `
 printf '%s' "$$" > ${JSON.stringify(pidFile)}
+printf '%s\\n%s\\n%s\\n' "$OPENCODE_SERVER_USERNAME" "$OPENCODE_SERVER_PASSWORD" "$OPENCODE_DISABLE_EMBEDDED_WEB_UI" > ${JSON.stringify(envFile)}
 printf '%s\\n' 'opencode server listening on http://127.0.0.1:43210'
 while true; do sleep 1; done
 `)
 
   const server = await createManagedOpencodeServer({
-    env: { PATH: process.env.PATH || '' },
+    env: {
+      PATH: process.env.PATH || '',
+      OPENCODE_SERVER_USERNAME: 'opencode',
+      OPENCODE_SERVER_PASSWORD: 'runtime-password',
+      OPENCODE_DISABLE_EMBEDDED_WEB_UI: 'true',
+    },
     hostname: '127.0.0.1',
     opencodeBinPath: executable,
     port: 0,
@@ -57,6 +68,7 @@ while true; do sleep 1; done
     try {
       assert.equal(server.url, 'http://127.0.0.1:43210')
       assert.equal(existsSync(pidFile), true)
+      assert.equal(readFileSync(envFile, 'utf8'), 'opencode\nruntime-password\ntrue\n')
       const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10)
       assert.ok(childPid > 0)
       return childPid
@@ -100,6 +112,34 @@ test('runtime accessors remain inert before startup and after stop', async () =>
   assert.equal(getServerUrl(), null)
   assert.equal(getActiveProjectOverlayDirectory(), null)
   assert.deepEqual(await getModelInfoAsync(), getModelInfo())
+})
+
+test('managed OpenCode client config includes Basic auth for root and directory-scoped clients', () => {
+  const auth = {
+    username: 'opencode',
+    password: 'runtime-password',
+    authorizationHeader: buildManagedOpencodeAuthorizationHeader({
+      username: 'opencode',
+      password: 'runtime-password',
+    }),
+  }
+
+  const rootConfig = buildManagedOpencodeClientConfig('http://127.0.0.1:43210', auth)
+  const scopedConfig = buildManagedOpencodeClientConfig('http://127.0.0.1:43210', auth, '/project')
+
+  assert.deepEqual(rootConfig, {
+    baseUrl: 'http://127.0.0.1:43210',
+    headers: {
+      Authorization: 'Basic b3BlbmNvZGU6cnVudGltZS1wYXNzd29yZA==',
+    },
+  })
+  assert.deepEqual(scopedConfig, {
+    baseUrl: 'http://127.0.0.1:43210',
+    headers: {
+      Authorization: 'Basic b3BlbmNvZGU6cnVudGltZS1wYXNzd29yZA==',
+    },
+    directory: '/project',
+  })
 })
 
 test('runtime native web search env is enabled only when app permissions allow it', () => {

--- a/tests/session-store-reducer.test.ts
+++ b/tests/session-store-reducer.test.ts
@@ -377,6 +377,94 @@ test('real user ids absorb placeholder live user messages so the optimistic prom
   assert.equal(state.messageById['session-1:user:live'], undefined)
 })
 
+test('rapid optimistic user prompts keep unique placeholders before real messages arrive', () => {
+  const state = createEmptySessionViewState({ hydrated: true })
+
+  Object.assign(state, withMessageText(state, {
+    messageId: 'session-1:prompt-a:user:live',
+    role: 'user',
+    content: 'first prompt',
+    segmentId: 'session-1:prompt-a:user:segment:live',
+    replace: true,
+  }))
+  Object.assign(state, withMessageText(state, {
+    messageId: 'session-1:prompt-b:user:live',
+    role: 'user',
+    content: 'second prompt',
+    segmentId: 'session-1:prompt-b:user:segment:live',
+    replace: true,
+  }))
+
+  let messages = buildMessages(state.messageIds, state.messageById, state.messagePartsById)
+
+  assert.deepEqual(messages.map((message) => message.content), ['first prompt', 'second prompt'])
+  assert.equal(messages[0]?.id.endsWith(':user:live'), true)
+  assert.equal(messages[1]?.id.endsWith(':user:live'), true)
+
+  Object.assign(state, withMessageText(state, {
+    messageId: 'msg_real_user_1',
+    role: 'user',
+    content: 'first prompt',
+    segmentId: 'msg_real_user_1:part:0',
+    replace: true,
+  }))
+  Object.assign(state, withMessageText(state, {
+    messageId: 'msg_real_user_2',
+    role: 'user',
+    content: 'second prompt',
+    segmentId: 'msg_real_user_2:part:0',
+    replace: true,
+  }))
+
+  messages = buildMessages(state.messageIds, state.messageById, state.messagePartsById)
+
+  assert.deepEqual(messages.map((message) => message.id), ['msg_real_user_1', 'msg_real_user_2'])
+  assert.deepEqual(messages.map((message) => message.content), ['first prompt', 'second prompt'])
+  assert.equal(state.messageById['session-1:prompt-a:user:live'], undefined)
+  assert.equal(state.messageById['session-1:prompt-b:user:live'], undefined)
+})
+
+test('real user messages absorb the matching rapid prompt placeholder when confirmations arrive out of order', () => {
+  const state = createEmptySessionViewState({ hydrated: true })
+
+  Object.assign(state, withMessageText(state, {
+    messageId: 'session-1:prompt-a:user:live',
+    role: 'user',
+    content: 'first prompt',
+    segmentId: 'session-1:prompt-a:user:segment:live',
+    replace: true,
+  }))
+  Object.assign(state, withMessageText(state, {
+    messageId: 'session-1:prompt-b:user:live',
+    role: 'user',
+    content: 'second prompt',
+    segmentId: 'session-1:prompt-b:user:segment:live',
+    replace: true,
+  }))
+
+  Object.assign(state, withMessageText(state, {
+    messageId: 'msg_real_user_2',
+    role: 'user',
+    content: 'second prompt',
+    segmentId: 'msg_real_user_2:part:0',
+    replace: true,
+  }))
+  Object.assign(state, withMessageText(state, {
+    messageId: 'msg_real_user_1',
+    role: 'user',
+    content: 'first prompt',
+    segmentId: 'msg_real_user_1:part:0',
+    replace: true,
+  }))
+
+  const messages = buildMessages(state.messageIds, state.messageById, state.messagePartsById)
+
+  assert.deepEqual(messages.map((message) => message.id), ['msg_real_user_1', 'msg_real_user_2'])
+  assert.deepEqual(messages.map((message) => message.content), ['first prompt', 'second prompt'])
+  assert.equal(state.messageById['session-1:prompt-a:user:live'], undefined)
+  assert.equal(state.messageById['session-1:prompt-b:user:live'], undefined)
+})
+
 test('real assistant ids absorb placeholder live messages without leaving duplicates', () => {
   const state = createEmptySessionViewState({ hydrated: true })
 


### PR DESCRIPTION
## Summary
- run the managed local OpenCode server with per-boot Basic auth and disable the embedded web UI
- attach auth headers to both root and directory-scoped SDK clients without changing the OpenCode execution boundary
- isolate pending streaming text buffers by session so noisy sessions cannot evict another session's deltas
- generate unique optimistic prompt placeholders for rapid prompts while preserving the live-placeholder suffixes used by absorption
- raise the directory client cache cap and log if eviction ever occurs so directory SSE subscriptions are not silently dropped in normal use

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/runtime-environment.test.ts tests/runtime-managed-server.test.ts tests/runtime-client-cache.test.ts tests/event-message-handlers.test.ts tests/session-store-reducer.test.ts tests/event-runtime-handlers.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check

## Notes
- Preserves OpenCode as the execution runtime; Open Cowork continues to own only the managed spawn environment, SDK client wiring, event projection, and durable metadata.