### PR TITLE
wire reasoning variants and chart axis normalization

### DIFF
--- a/apps/desktop/src/lib/vega-spec.ts
+++ b/apps/desktop/src/lib/vega-spec.ts
@@ -17,15 +17,100 @@ export function isFullVegaSpec(spec: Record<string, unknown>): boolean {
   return schema.includes('/vega/v') && !schema.includes('/vega-lite/')
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+const TEMPORAL_POSITION_CHANNELS = ['x', 'y'] as const
+const SHORT_MONTH_OR_WEEKDAY_PATTERN = /\b(?:sun|mon|tue|wed|thu|fri|sat|jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)\b/i
+const EXPLICIT_YEAR_PATTERN = /\b\d{4}\b/
+
+function getInlineDataRows(spec: Record<string, unknown>): Array<Record<string, unknown>> | null {
+  const data = asRecord(spec.data)
+  if (!Array.isArray(data?.values)) return null
+
+  const rows: Array<Record<string, unknown>> = []
+  for (const row of data.values) {
+    const rowRecord = asRecord(row)
+    if (rowRecord) rows.push(rowRecord)
+  }
+
+  return rows.length > 0 ? rows : null
+}
+
+function isHumanDateLabelWithoutYear(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed || EXPLICIT_YEAR_PATTERN.test(trimmed)) return false
+  return /\d/.test(trimmed) && SHORT_MONTH_OR_WEEKDAY_PATTERN.test(trimmed)
+}
+
+function collectStringFieldValues(rows: Array<Record<string, unknown>>, field: string): string[] | null {
+  const values: string[] = []
+
+  for (const row of rows) {
+    const value = row[field]
+    if (value == null) continue
+    if (typeof value !== 'string') return null
+    values.push(value)
+  }
+
+  return values.length > 0 ? values : null
+}
+
+function buildEncounterOrderSort(values: string[]): string[] {
+  return Array.from(new Set(values))
+}
+
+function normalizeTemporalLabelEncodings(spec: Record<string, unknown>): Record<string, unknown> {
+  if (isFullVegaSpec(spec)) return spec
+
+  const rows = getInlineDataRows(spec)
+  const encoding = asRecord(spec.encoding)
+  if (!rows || !encoding) return spec
+
+  let normalizedEncoding: Record<string, unknown> | null = null
+
+  for (const channel of TEMPORAL_POSITION_CHANNELS) {
+    const channelEncoding = asRecord(encoding[channel])
+    const field = typeof channelEncoding?.field === 'string' ? channelEncoding.field : null
+    if (!channelEncoding || !field || channelEncoding.type !== 'temporal') continue
+
+    const values = collectStringFieldValues(rows, field)
+    if (!values || !values.every(isHumanDateLabelWithoutYear)) continue
+
+    normalizedEncoding ||= { ...encoding }
+    const normalizedChannel: Record<string, unknown> = {
+      ...channelEncoding,
+      type: 'ordinal',
+    }
+    if (!('sort' in normalizedChannel)) {
+      normalizedChannel.sort = buildEncounterOrderSort(values)
+    }
+    normalizedEncoding[channel] = normalizedChannel
+  }
+
+  if (!normalizedEncoding) return spec
+
+  // Human labels like "Sun 3 May" are display categories, not stable
+  // timestamps. Leaving them temporal lets Vega-Lite infer sub-day ticks
+  // such as "12 PM", which is wrong for daily business charts.
+  return {
+    ...spec,
+    encoding: normalizedEncoding,
+  }
+}
+
 export function normalizeVegaSpecSchema(spec: Record<string, unknown>): Record<string, unknown> {
   const schema = typeof spec?.$schema === 'string' ? spec.$schema : ''
   if (!schema.includes('/vega-lite/')) return spec
 
   const normalizedSchema = schema.replace(/\/vega-lite\/v\d+(?:\.\d+)?\.json$/, '/vega-lite/v6.json')
-  if (normalizedSchema === schema) return spec
+  const normalizedSpec = normalizeTemporalLabelEncodings(spec)
+  if (normalizedSchema === schema) return normalizedSpec
 
   return {
-    ...spec,
+    ...normalizedSpec,
     $schema: normalizedSchema,
   }
 }
@@ -36,11 +121,6 @@ function isResponsiveVegaLiteCandidate(spec: Record<string, unknown>) {
     return false
   }
   return true
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-  return value as Record<string, unknown>
 }
 
 function getDiscreteValueCount(spec: Record<string, unknown>, channel: string) {

--- a/apps/desktop/src/main/ipc/app-handler-support.ts
+++ b/apps/desktop/src/main/ipc/app-handler-support.ts
@@ -149,6 +149,14 @@ export function normalizeProviderAuthorization(raw: unknown): ProviderAuthAuthor
 function runtimeModelToDescriptor(modelId: string, rawModel: unknown): ProviderModelDescriptor {
   const model = asRecord(rawModel)
   const limit = asRecord(model?.limit)
+  const capabilities = asRecord(model?.capabilities)
+  const variants = asRecord(model?.variants)
+  const enabledVariants = variants
+    ? Object.entries(variants)
+        .filter(([, config]) => asRecord(config)?.disabled !== true)
+        .map(([variant]) => variant)
+        .sort((a, b) => a.localeCompare(b))
+    : []
   const context = typeof limit?.context === 'number' && Number.isFinite(limit.context)
     ? limit.context
     : undefined
@@ -156,6 +164,8 @@ function runtimeModelToDescriptor(modelId: string, rawModel: unknown): ProviderM
     id: modelId,
     name: typeof model?.name === 'string' && model.name.trim() ? model.name : modelId,
     ...(context ? { contextLength: context } : {}),
+    ...(capabilities?.reasoning === true ? { reasoning: true } : {}),
+    ...(enabledVariants.length > 0 ? { variants: enabledVariants } : {}),
   }
 }
 
@@ -168,6 +178,24 @@ function providerWithoutDefaultModel(provider: ProviderDescriptor): ProviderDesc
     models: provider.models,
     ...(provider.connected !== undefined ? { connected: provider.connected } : {}),
   }
+}
+
+function mergeConfiguredModelRuntimeMetadata(
+  configuredModel: ProviderModelDescriptor,
+  runtimeModel: ProviderModelDescriptor | undefined,
+): ProviderModelDescriptor {
+  if (!runtimeModel) return configuredModel
+  const merged: ProviderModelDescriptor = {
+    ...runtimeModel,
+    ...configuredModel,
+  }
+  if (runtimeModel.reasoning) {
+    merged.reasoning = true
+  }
+  if (runtimeModel.variants?.length) {
+    merged.variants = runtimeModel.variants
+  }
+  return merged
 }
 
 export function mergeRuntimeProviderModels(
@@ -212,8 +240,9 @@ export function mergeRuntimeProviderModels(
           }
         }
         const configuredIds = new Set(provider.models.map((model) => model.id))
+        const runtimeModelById = new Map(runtimeModels.map((model) => [model.id, model]))
         const models = [
-          ...provider.models,
+          ...provider.models.map((model) => mergeConfiguredModelRuntimeMetadata(model, runtimeModelById.get(model.id))),
           ...runtimeModels.filter((model) => !configuredIds.has(model.id)),
         ]
         const defaultModel = resolveProviderDefaultModel(provider.id, models, runtimeProvider.defaultModel)

--- a/apps/desktop/src/main/ipc/session-handler-validation.ts
+++ b/apps/desktop/src/main/ipc/session-handler-validation.ts
@@ -4,6 +4,10 @@ type PromptAttachmentInput = {
   filename?: string
 }
 
+export type PromptOptionsInput = {
+  variant?: string
+}
+
 const MAX_PROMPT_TEXT_BYTES = 1_000_000
 const MAX_PROMPT_ATTACHMENTS = 10
 const MAX_PROMPT_ATTACHMENT_URL_BYTES = 30 * 1024 * 1024
@@ -11,6 +15,7 @@ const MAX_PROMPT_ATTACHMENTS_TOTAL_BYTES = 60 * 1024 * 1024
 const MAX_PROMPT_ATTACHMENT_MIME_BYTES = 256
 const MAX_PROMPT_ATTACHMENT_FILENAME_BYTES = 512
 const MAX_PROMPT_AGENT_BYTES = 128
+const MAX_PROMPT_VARIANT_BYTES = 128
 const MAX_SESSION_ID_BYTES = 256
 const MAX_COMMAND_NAME_BYTES = 256
 const MAX_SESSION_TITLE_BYTES = 512
@@ -56,6 +61,18 @@ export function normalizePromptText(text: unknown) {
 export function normalizePromptAgent(agent: unknown) {
   if (agent == null || agent === '') return 'build'
   return requireBoundedString(agent, 'Prompt agent', MAX_PROMPT_AGENT_BYTES)
+}
+
+export function normalizePromptOptions(options: unknown): PromptOptionsInput {
+  if (options == null) return {}
+  if (typeof options !== 'object' || Array.isArray(options)) {
+    throw new Error('Prompt options must be an object')
+  }
+  const record = options as Record<string, unknown>
+  const variant = record.variant == null || record.variant === ''
+    ? undefined
+    : requireBoundedString(record.variant, 'Prompt reasoning variant', MAX_PROMPT_VARIANT_BYTES).trim()
+  return variant ? { variant } : {}
 }
 
 export function normalizeSessionId(value: unknown) {

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -31,6 +31,7 @@ import { registerSessionInteractionHandlers } from './session-interaction-handle
 import {
   normalizePromptAgent,
   normalizePromptAttachments,
+  normalizePromptOptions,
   normalizePromptText,
 } from './session-handler-validation.ts'
 
@@ -55,6 +56,34 @@ function resolvePromptModel(settings: ReturnType<typeof getEffectiveSettings>, r
     providerID: settings.effectiveProviderId,
     modelID,
   }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function resolvePromptVariant(
+  requestedVariant: string | undefined,
+  promptModel: ReturnType<typeof resolvePromptModel>,
+  runtimeProvider?: ProviderLike | null,
+) {
+  if (!requestedVariant || !promptModel) return null
+  const runtimeModels = runtimeProvider?.models || null
+  if (!runtimeModels) return null
+  const rawModel = runtimeModels[promptModel.modelID]
+    || runtimeModels[`${promptModel.providerID}/${promptModel.modelID}`]
+  const variants = asRecord(asRecord(rawModel)?.variants)
+  if (!variants || !Object.prototype.hasOwnProperty.call(variants, requestedVariant)) {
+    log('provider', `Ignoring unavailable model variant ${promptModel.providerID}/${promptModel.modelID}:${requestedVariant}`)
+    return null
+  }
+  if (asRecord(variants[requestedVariant])?.disabled === true) {
+    log('provider', `Ignoring disabled model variant ${promptModel.providerID}/${promptModel.modelID}:${requestedVariant}`)
+    return null
+  }
+  return requestedVariant
 }
 
 type ProviderAuthMethodLike = {
@@ -162,10 +191,11 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
         }
   })
 
-  context.ipcMain.handle('session:prompt', async (_event, sessionId: string, text: unknown, attachments?: unknown, agent?: unknown) => {
+  context.ipcMain.handle('session:prompt', async (_event, sessionId: string, text: unknown, attachments?: unknown, agent?: unknown, options?: unknown) => {
     const promptText = normalizePromptText(text)
     const promptAttachments = normalizePromptAttachments(attachments)
     const requestedAgent = normalizePromptAgent(agent)
+    const promptOptions = normalizePromptOptions(options)
     const { client } = await context.getSessionClient(sessionId)
     const settings = getEffectiveSettings()
     const parts: Array<
@@ -217,11 +247,13 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
       const runtimeProvider = await getSelectedRuntimeProvider(client, settings.effectiveProviderId)
       await assertSelectedProviderReadyForPrompt(client, settings, runtimeProvider)
       const promptModel = resolvePromptModel(settings, runtimeProvider)
+      const promptVariant = resolvePromptVariant(promptOptions.variant, promptModel, runtimeProvider)
 
       await client.session.promptAsync({
         sessionID: sessionId,
         parts,
         ...(promptModel ? { model: promptModel } : {}),
+        ...(promptVariant ? { variant: promptVariant } : {}),
         agent: requestedAgent,
       }, {
         throwOnError: true,

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -125,6 +125,10 @@ function buildDescriptorModelRuntimeConfig(
       {
         id: model.id,
         name: model.name,
+        ...(model.reasoning ? { reasoning: true } : {}),
+        ...(model.variants?.length
+          ? { variants: Object.fromEntries(model.variants.map((variant) => [variant, {}])) }
+          : {}),
       },
     ]),
   )

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -172,7 +172,7 @@ const api: CoworkAPI = {
   session: {
     create: (directory?) => invoke('session:create', directory),
     activate: (sessionId, options) => invoke('session:activate', sessionId, options),
-    prompt: (sessionId, text, attachments, agent) => invoke('session:prompt', sessionId, text, attachments, agent),
+    prompt: (sessionId, text, attachments, agent, options) => invoke('session:prompt', sessionId, text, attachments, agent, options),
     list: () => invoke('session:list'),
     get: (id) => invoke('session:get', id),
     abort: (sessionId) => invoke('session:abort', sessionId),

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, lazy, Suspense } from 'react'
-import type { AppMetadata, CustomAgentConfig, EffectiveAppSettings, PublicAppConfig, SessionInfo } from '@open-cowork/shared'
+import type { AppMetadata, CustomAgentConfig, EffectiveAppSettings, PublicAppConfig, SessionInfo, SessionPromptOptions } from '@open-cowork/shared'
 import { Sidebar } from './components/layout/Sidebar'
 import { TitleBar } from './components/layout/TitleBar'
 import { StatusBar } from './components/layout/StatusBar'
@@ -180,6 +180,7 @@ export function App() {
     text: string,
     attachments?: Array<{ mime: string; url: string; filename: string }>,
     agent?: string,
+    options?: SessionPromptOptions,
   ) => {
     const session = await createAndActivateSession()
     if (!session) return
@@ -197,7 +198,12 @@ export function App() {
       // if the user didn't type anything — they can always edit the
       // thread after.
       const promptText = text.trim() || (files ? 'Describe this image.' : text)
-      await window.coworkApi.session.prompt(session.id, promptText, files, agent || useSessionStore.getState().agentMode)
+      const promptAgent = agent || useSessionStore.getState().agentMode
+      if (options) {
+        await window.coworkApi.session.prompt(session.id, promptText, files, promptAgent, options)
+      } else {
+        await window.coworkApi.session.prompt(session.id, promptText, files, promptAgent)
+      }
     } catch (err) {
       reportAppError('Could not send the Home prompt. Try again from the thread.', err, 'home')
     }

--- a/apps/desktop/src/renderer/components/HomePage.test.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.test.tsx
@@ -109,7 +109,7 @@ function installHomeRuntime(overrides: Parameters<typeof installRendererTestCowo
 }
 
 function createStartThreadMock() {
-  return vi.fn(async (_text: string, _attachments?: Attachment[], _agent?: string) => undefined)
+  return vi.fn(async (_text: string, _attachments?: Attachment[], _agent?: string, _options?: unknown) => undefined)
 }
 
 describe('HomePage', () => {
@@ -230,6 +230,58 @@ describe('HomePage', () => {
 
     await waitFor(() => {
       expect(onStartThread).toHaveBeenCalledWith('Map the market', [], 'research')
+    })
+  })
+
+  it('forwards selected reasoning variants through the Home composer prompt options', async () => {
+    const user = userEvent.setup()
+    const onStartThread = createStartThreadMock()
+    installHomeRuntime({
+      app: {
+        config: vi.fn(async () => ({
+          ...providerConfig,
+          providers: {
+            ...providerConfig.providers,
+            available: [{
+              ...providerConfig.providers.available[0],
+              models: [
+                {
+                  id: 'anthropic/claude-sonnet-4',
+                  name: 'Claude Sonnet 4',
+                  featured: true,
+                  reasoning: true,
+                  variants: ['low', 'xhigh'],
+                },
+              ],
+            }],
+          },
+        })),
+      },
+    })
+
+    render(
+      <HomePage
+        brandName="Open Cowork"
+        onStartThread={onStartThread}
+        onOpenPulse={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: /Think Auto/i }))
+    await user.click(await screen.findByRole('option', { name: /XHigh/i }))
+    expect(screen.getByRole('button', { name: /Think XHigh/i })).toBeTruthy()
+
+    await user.type(screen.getByPlaceholderText('Ask anything, or @mention an agent'), 'Analyze this with more reasoning')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(onStartThread).toHaveBeenCalledWith(
+        'Analyze this with more reasoning',
+        [],
+        'build',
+        { variant: 'xhigh' },
+      )
     })
   })
 

--- a/apps/desktop/src/renderer/components/HomePage.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.tsx
@@ -1,17 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { BrandingHomeConfig, SessionInfo } from '@open-cowork/shared'
+import type { BrandingHomeConfig, SessionInfo, SessionPromptOptions } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
 import { formatDate, t } from '../helpers/i18n'
 import { ChatInputAttachments } from './chat/ChatInputAttachments'
 import { ChatInputInlinePicker } from './chat/ChatInputInlinePicker'
 import { ChatInputModelMenu } from './chat/ChatInputModelMenu'
+import { ChatInputReasoningMenu, formatReasoningVariantLabel } from './chat/ChatInputReasoningMenu'
 import { ChatInputToolbar } from './chat/ChatInputToolbar'
 import {
   detectInlineTrigger,
   filesToAttachments,
   resolveDirectAgentInvocation,
 } from './chat/chat-input-utils'
-import { useChatRuntimeSelection, useMentionableAgents } from './chat/useChatInputRuntime'
+import { useChatRuntimeSelection, useMentionableAgents, useReasoningVariantSelection } from './chat/useChatInputRuntime'
 import type { Attachment, InlinePickerState, MentionableAgent } from './chat/chat-input-types'
 
 // Home is the welcoming landing surface. We deliberately moved the
@@ -24,7 +25,7 @@ import type { Attachment, InlinePickerState, MentionableAgent } from './chat/cha
 interface Props {
   brandName: string
   homeBranding?: BrandingHomeConfig
-  onStartThread: (text: string, attachments?: Attachment[], agent?: string) => Promise<void>
+  onStartThread: (text: string, attachments?: Attachment[], agent?: string, options?: SessionPromptOptions) => Promise<void>
   onOpenPulse: () => void
   onOpenThread: (sessionId: string) => void | Promise<void>
 }
@@ -127,7 +128,7 @@ function ChevronRightIcon() {
 }
 
 function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefillAgent }: {
-  onSubmit: (text: string, attachments: Attachment[], agent?: string) => void | Promise<void>
+  onSubmit: (text: string, attachments: Attachment[], agent?: string, options?: SessionPromptOptions) => void | Promise<void>
   disabled: boolean
   placeholder: string
   specialistAgents: MentionableAgent[]
@@ -137,16 +138,19 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
   const [attachments, setAttachments] = useState<Attachment[]>([])
   const [dragOver, setDragOver] = useState(false)
   const [showModelMenu, setShowModelMenu] = useState(false)
+  const [showReasoningMenu, setShowReasoningMenu] = useState(false)
   const [inlinePicker, setInlinePicker] = useState<InlinePickerState | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const inputChromeRef = useRef<HTMLDivElement>(null)
   const inlinePickerRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const modelBtnRef = useRef<HTMLButtonElement>(null)
+  const reasoningBtnRef = useRef<HTMLButtonElement>(null)
   const agentMode = useSessionStore((s) => s.agentMode)
   const setAgentMode = useSessionStore((s) => s.setAgentMode)
   const addGlobalError = useSessionStore((s) => s.addGlobalError)
   const { currentModel, setCurrentModel, provider, availableModels } = useChatRuntimeSelection()
+  const reasoningSelection = useReasoningVariantSelection(provider, currentModel, availableModels)
 
   useEffect(() => {
     // Autofocus on mount — the composer is the primary action on Home,
@@ -195,8 +199,13 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
     setAttachments([])
     setInlinePicker(null)
     autosize()
-    await onSubmit(promptText, currentAttachments, directInvocation.agent || agentMode)
-  }, [text, attachments, disabled, onSubmit, specialistAgents, agentMode])
+    const promptAgent = directInvocation.agent || agentMode
+    if (reasoningSelection.promptOptions) {
+      await onSubmit(promptText, currentAttachments, promptAgent, reasoningSelection.promptOptions)
+    } else {
+      await onSubmit(promptText, currentAttachments, promptAgent)
+    }
+  }, [text, attachments, disabled, onSubmit, specialistAgents, agentMode, reasoningSelection.promptOptions])
 
   const inlineSuggestions = useMemo(() => {
     if (!inlinePicker) return []
@@ -405,7 +414,10 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
         <ChatInputToolbar
           fileInputRef={fileInputRef}
           modelButtonRef={modelBtnRef}
+          reasoningButtonRef={reasoningBtnRef}
           modelLabel={currentModelLabel}
+          reasoningLabel={formatReasoningVariantLabel(reasoningSelection.reasoningVariant)}
+          showReasoningControl={reasoningSelection.supportsReasoning}
           currentDirectory={null}
           agentMode={agentMode}
           currentSessionId={null}
@@ -416,7 +428,13 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
           onAddFiles={addFiles}
           onToggleModelMenu={() => {
             setInlinePicker(null)
+            setShowReasoningMenu(false)
             setShowModelMenu(!showModelMenu)
+          }}
+          onToggleReasoningMenu={() => {
+            setInlinePicker(null)
+            setShowModelMenu(false)
+            setShowReasoningMenu(!showReasoningMenu)
           }}
           onToggleAgentMode={() => setAgentMode(agentMode === 'build' ? 'plan' : 'build')}
           onFork={() => undefined}
@@ -458,6 +476,14 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
             }
           }
         }}
+      />
+      <ChatInputReasoningMenu
+        visible={showReasoningMenu}
+        anchorRect={reasoningBtnRef.current?.getBoundingClientRect() || null}
+        variants={reasoningSelection.reasoningVariants}
+        currentVariant={reasoningSelection.reasoningVariant}
+        onClose={() => setShowReasoningMenu(false)}
+        onSelect={reasoningSelection.setReasoningVariant}
       />
     </div>
   )
@@ -575,11 +601,15 @@ export function HomePage({ brandName, homeBranding, onStartThread, onOpenPulse, 
     [sessions],
   )
 
-  const handleSubmit = useCallback(async (text: string, attachments: Attachment[], agent?: string) => {
+  const handleSubmit = useCallback(async (text: string, attachments: Attachment[], agent?: string, options?: SessionPromptOptions) => {
     if (submitting) return
     setSubmitting(true)
     try {
-      await onStartThread(text, attachments, agent)
+      if (options) {
+        await onStartThread(text, attachments, agent, options)
+      } else {
+        await onStartThread(text, attachments, agent)
+      }
     } finally {
       setSubmitting(false)
     }

--- a/apps/desktop/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.tsx
@@ -4,6 +4,7 @@ import { t } from '../../helpers/i18n'
 import { ChatInputAttachments } from './ChatInputAttachments'
 import { ChatInputInlinePicker } from './ChatInputInlinePicker'
 import { ChatInputModelMenu } from './ChatInputModelMenu'
+import { ChatInputReasoningMenu, formatReasoningVariantLabel } from './ChatInputReasoningMenu'
 import { ChatInputToolbar } from './ChatInputToolbar'
 import type { Attachment, InlinePickerState, MentionableAgent } from './chat-input-types'
 import {
@@ -11,7 +12,7 @@ import {
   filesToAttachments,
   resolveDirectAgentInvocation,
 } from './chat-input-utils'
-import { useChatRuntimeSelection, useComposerExternalEvents, useMentionableAgents } from './useChatInputRuntime'
+import { useChatRuntimeSelection, useComposerExternalEvents, useMentionableAgents, useReasoningVariantSelection } from './useChatInputRuntime'
 import { usePromptHistory } from './usePromptHistory'
 
 function describeComposerError(error: unknown) {
@@ -40,6 +41,7 @@ export function ChatInput() {
   const inlinePickerRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const modelBtnRef = useRef<HTMLButtonElement>(null)
+  const reasoningBtnRef = useRef<HTMLButtonElement>(null)
   const currentSessionId = useSessionStore((s) => s.currentSessionId)
   const sessions = useSessionStore((s) => s.sessions)
   const isGenerating = useSessionStore((s) => s.currentView.isGenerating)
@@ -49,6 +51,7 @@ export function ChatInput() {
   const agentMode = useSessionStore((s) => s.agentMode)
   const setAgentMode = useSessionStore((s) => s.setAgentMode)
   const [showModelMenu, setShowModelMenu] = useState(false)
+  const [showReasoningMenu, setShowReasoningMenu] = useState(false)
   const [inlinePicker, setInlinePicker] = useState<InlinePickerState | null>(null)
   const { navigate, recordPrompt } = usePromptHistory()
   const currentProjectDirectory = useMemo(
@@ -56,6 +59,7 @@ export function ChatInput() {
     [currentSessionId, sessions],
   )
   const { currentModel, setCurrentModel, provider, availableModels } = useChatRuntimeSelection()
+  const reasoningSelection = useReasoningVariantSelection(provider, currentModel, availableModels)
   const specialistAgents = useMentionableAgents(currentProjectDirectory)
 
   const resizeComposerTextarea = useCallback((element = textareaRef.current) => {
@@ -88,12 +92,13 @@ export function ChatInput() {
       if (!promptText && files.length === 0) {
         return
       }
-      await window.coworkApi.session.prompt(
-        currentSessionId,
-        promptText || 'Describe this image.',
-        files.length > 0 ? files : undefined,
-        directInvocation.agent || agentMode,
-      )
+      const message = promptText || 'Describe this image.'
+      const promptAgent = directInvocation.agent || agentMode
+      if (reasoningSelection.promptOptions) {
+        await window.coworkApi.session.prompt(currentSessionId, message, files.length > 0 ? files : undefined, promptAgent, reasoningSelection.promptOptions)
+      } else {
+        await window.coworkApi.session.prompt(currentSessionId, message, files.length > 0 ? files : undefined, promptAgent)
+      }
     } catch (err) {
       reportComposerError(
         t('chat.promptFailed', 'Could not send the prompt. Please try again.'),
@@ -102,7 +107,7 @@ export function ChatInput() {
         addGlobalError,
       )
     }
-  }, [input, attachments, currentSessionId, agentMode, specialistAgents, addGlobalError])
+  }, [input, attachments, currentSessionId, agentMode, specialistAgents, addGlobalError, reasoningSelection.promptOptions])
 
   const inlineSuggestions = useMemo(() => {
     if (!inlinePicker) return []
@@ -359,7 +364,10 @@ export function ChatInput() {
           <ChatInputToolbar
             fileInputRef={fileInputRef}
             modelButtonRef={modelBtnRef}
+            reasoningButtonRef={reasoningBtnRef}
             modelLabel={currentModelLabel}
+            reasoningLabel={formatReasoningVariantLabel(reasoningSelection.reasoningVariant)}
+            showReasoningControl={reasoningSelection.supportsReasoning}
             currentDirectory={currentProjectDirectory}
             agentMode={agentMode}
             currentSessionId={currentSessionId || null}
@@ -370,7 +378,13 @@ export function ChatInput() {
             onAddFiles={addFiles}
             onToggleModelMenu={() => {
               setInlinePicker(null)
+              setShowReasoningMenu(false)
               setShowModelMenu(!showModelMenu)
+            }}
+            onToggleReasoningMenu={() => {
+              setInlinePicker(null)
+              setShowModelMenu(false)
+              setShowReasoningMenu(!showReasoningMenu)
             }}
             onToggleAgentMode={() => setAgentMode(agentMode === 'build' ? 'plan' : 'build')}
             onFork={async () => {
@@ -420,6 +434,14 @@ export function ChatInput() {
             )
           }
         }}
+      />
+      <ChatInputReasoningMenu
+        visible={showReasoningMenu}
+        anchorRect={reasoningBtnRef.current?.getBoundingClientRect() || null}
+        variants={reasoningSelection.reasoningVariants}
+        currentVariant={reasoningSelection.reasoningVariant}
+        onClose={() => setShowReasoningMenu(false)}
+        onSelect={reasoningSelection.setReasoningVariant}
       />
     </div>
   )

--- a/apps/desktop/src/renderer/components/chat/ChatInputModelMenu.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputModelMenu.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
 import { t } from '../../helpers/i18n'
-
-export type ChatInputModelEntry = {
-  id: string
-  label: string
-  featured?: boolean
-}
+import type { ChatInputModelEntry } from './chat-input-types'
 
 type ChatInputModelMenuProps = {
   visible: boolean

--- a/apps/desktop/src/renderer/components/chat/ChatInputReasoningMenu.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputReasoningMenu.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ModalBackdrop } from '../layout/ModalBackdrop'
+import { t } from '../../helpers/i18n'
+
+type ChatInputReasoningMenuProps = {
+  visible: boolean
+  anchorRect: DOMRect | null
+  variants: string[]
+  currentVariant: string | null
+  onClose: () => void
+  onSelect: (variant: string | null) => void
+}
+
+const MENU_WIDTH = 240
+
+const VARIANT_LABELS: Record<string, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'XHigh',
+  reasoning: 'Reasoning',
+  thinking: 'Thinking',
+}
+
+export function formatReasoningVariantLabel(variant: string | null | undefined) {
+  if (!variant) return t('chat.reasoningAuto', 'Auto')
+  const normalized = variant.trim()
+  return VARIANT_LABELS[normalized.toLowerCase()]
+    || normalized
+      .replace(/[-_]+/g, ' ')
+      .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+export function ChatInputReasoningMenu({
+  visible,
+  anchorRect,
+  variants,
+  currentVariant,
+  onClose,
+  onSelect,
+}: ChatInputReasoningMenuProps) {
+  const options = useMemo(() => [null, ...variants], [variants])
+  const [highlightIndex, setHighlightIndex] = useState(0)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!visible) return
+    const activeIndex = Math.max(0, options.findIndex((variant) => variant === (currentVariant || null)))
+    setHighlightIndex(activeIndex)
+    requestAnimationFrame(() => menuRef.current?.focus())
+  }, [currentVariant, options, visible])
+
+  if (!visible || !anchorRect) return null
+
+  const desiredHeight = Math.min(320, options.length * 48 + 42)
+  const above = anchorRect.top - desiredHeight - 4
+  const below = anchorRect.bottom + 4
+  const top = Math.max(
+    8,
+    Math.min(above >= 8 ? above : below, window.innerHeight - desiredHeight - 8),
+  )
+  const left = Math.min(
+    anchorRect.left,
+    Math.max(8, window.innerWidth - MENU_WIDTH - 8),
+  )
+
+  function handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHighlightIndex((current) => (current + 1) % options.length)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHighlightIndex((current) => (current - 1 + options.length) % options.length)
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setHighlightIndex(0)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setHighlightIndex(options.length - 1)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      onSelect(options[highlightIndex])
+      onClose()
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+    }
+  }
+
+  return (
+    <>
+      <ModalBackdrop onDismiss={onClose} className="fixed inset-0 z-40" />
+      <div
+        ref={menuRef}
+        className="fixed z-50 rounded-xl border shadow-xl overflow-hidden"
+        role="listbox"
+        tabIndex={-1}
+        aria-label={t('chat.reasoningSelect', 'Select reasoning mode')}
+        onKeyDown={handleKeyDown}
+        style={{
+          background: 'var(--color-base)',
+          borderColor: 'var(--color-border)',
+          width: MENU_WIDTH,
+          maxHeight: desiredHeight,
+          left,
+          top,
+        }}
+      >
+        <div
+          className="px-3 py-2 text-[11px] text-text-muted font-medium border-b"
+          style={{ borderColor: 'var(--color-border-subtle)' }}
+        >
+          {t('chat.reasoning', 'Reasoning')}
+        </div>
+        <div className="py-1">
+          {options.map((variant, index) => {
+            const isActive = (currentVariant || null) === variant
+            const isHighlighted = highlightIndex === index
+            const label = formatReasoningVariantLabel(variant)
+            const description = variant
+              ? t('chat.reasoningVariantDescription', 'Use the model variant reported by OpenCode.')
+              : t('chat.reasoningAutoDescription', 'Use the model default.')
+            return (
+              <button
+                key={variant || 'auto'}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                onClick={() => {
+                  onSelect(variant)
+                  onClose()
+                }}
+                className="w-full text-start px-3 py-2 text-[12px] cursor-pointer transition-colors flex items-center justify-between gap-2 hover:bg-surface-hover"
+                style={{
+                  color: 'var(--color-text)',
+                  background: isHighlighted
+                    ? 'var(--color-surface-hover)'
+                    : isActive
+                      ? 'color-mix(in srgb, var(--color-accent) 10%, transparent)'
+                      : 'transparent',
+                }}
+              >
+                <span className="min-w-0">
+                  <span className="block font-medium truncate">{label}</span>
+                  <span className="block text-[10px] text-text-muted truncate">{description}</span>
+                </span>
+                {isActive ? (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="var(--color-text)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+                    <polyline points="3,7.5 6,10.5 11,4" />
+                  </svg>
+                ) : null}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
@@ -64,6 +64,22 @@ describe('ChatInputToolbar', () => {
     expect(props.onSubmit).toHaveBeenCalledTimes(1)
   })
 
+  it('opens the reasoning selector when a model exposes variants', () => {
+    const reasoningButtonRef = createRef<HTMLButtonElement>()
+    const onToggleReasoningMenu = vi.fn()
+
+    renderToolbar({
+      reasoningButtonRef,
+      reasoningLabel: 'XHigh',
+      showReasoningControl: true,
+      onToggleReasoningMenu,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Think XHigh/i }))
+
+    expect(onToggleReasoningMenu).toHaveBeenCalledTimes(1)
+  })
+
   it('routes stop actions while generating', () => {
     const { props } = renderToolbar({ isGenerating: true })
 

--- a/apps/desktop/src/renderer/components/chat/ChatInputToolbar.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputToolbar.tsx
@@ -4,7 +4,10 @@ import { t } from '../../helpers/i18n'
 type ChatInputToolbarProps = {
   fileInputRef: RefObject<HTMLInputElement | null>
   modelButtonRef: RefObject<HTMLButtonElement | null>
+  reasoningButtonRef?: RefObject<HTMLButtonElement | null>
   modelLabel: string
+  reasoningLabel?: string
+  showReasoningControl?: boolean
   currentDirectory: string | null
   agentMode: 'build' | 'plan'
   currentSessionId: string | null
@@ -14,6 +17,7 @@ type ChatInputToolbarProps = {
   canSend: boolean
   onAddFiles: (files: FileList | File[]) => Promise<void> | void
   onToggleModelMenu: () => void
+  onToggleReasoningMenu?: () => void
   onToggleAgentMode: () => void
   onFork: () => Promise<void> | void
   onStop: () => Promise<void> | void
@@ -23,7 +27,10 @@ type ChatInputToolbarProps = {
 export function ChatInputToolbar({
   fileInputRef,
   modelButtonRef,
+  reasoningButtonRef,
   modelLabel,
+  reasoningLabel,
+  showReasoningControl = false,
   currentDirectory,
   agentMode,
   currentSessionId,
@@ -33,6 +40,7 @@ export function ChatInputToolbar({
   canSend,
   onAddFiles,
   onToggleModelMenu,
+  onToggleReasoningMenu,
   onToggleAgentMode,
   onFork,
   onStop,
@@ -76,6 +84,20 @@ export function ChatInputToolbar({
             </svg>
           </button>
         </div>
+
+        {showReasoningControl && onToggleReasoningMenu ? (
+          <button
+            ref={reasoningButtonRef}
+            onClick={onToggleReasoningMenu}
+            className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer flex items-center gap-1"
+            title={t('chat.reasoningDescription', 'Reasoning mode for models that expose OpenCode variants')}
+          >
+            {t('chat.reasoningChip', 'Think')} {reasoningLabel || t('chat.reasoningAuto', 'Auto')}
+            <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.2">
+              <polyline points="2,3 4,5.5 6,3" />
+            </svg>
+          </button>
+        ) : null}
 
         {currentDirectory ? (
           <span

--- a/apps/desktop/src/renderer/components/chat/chat-input-types.ts
+++ b/apps/desktop/src/renderer/components/chat/chat-input-types.ts
@@ -4,6 +4,14 @@ export interface MentionableAgent {
   description: string
 }
 
+export type ChatInputModelEntry = {
+  id: string
+  label: string
+  featured?: boolean
+  reasoning?: boolean
+  variants?: string[]
+}
+
 export type InlinePickerState = {
   trigger: '@'
   query: string

--- a/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
+++ b/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
@@ -1,11 +1,11 @@
-import { type Dispatch, type RefObject, type SetStateAction, useEffect, useState } from 'react'
+import { type Dispatch, type RefObject, type SetStateAction, useEffect, useMemo, useState } from 'react'
 import { t } from '../../helpers/i18n'
 import { useSessionStore } from '../../stores/session'
-import type { Attachment, InlinePickerState, MentionableAgent } from './chat-input-types'
+import type { Attachment, ChatInputModelEntry, InlinePickerState, MentionableAgent } from './chat-input-types'
 import { ensureAttachmentId, formatAgentLabel } from './chat-input-utils.ts'
 import { COMPOSER_COMPOSE_EVENT, COMPOSER_INSERT_EVENT, type ComposerComposeDetail } from './composer-events'
 
-type ModelCatalog = Record<string, Array<{ id: string; label: string; featured?: boolean }>>
+type ModelCatalog = Record<string, ChatInputModelEntry[]>
 
 type ResizeComposerTextarea = (element?: HTMLTextAreaElement | null) => void
 
@@ -41,7 +41,13 @@ export function useChatRuntimeSelection() {
         setAvailableModels(Object.fromEntries(
           config.providers.available.map((entry) => [
             entry.id,
-            entry.models.map((model) => ({ id: model.id, label: model.name, featured: model.featured })),
+            entry.models.map((model) => ({
+              id: model.id,
+              label: model.name,
+              featured: model.featured,
+              reasoning: model.reasoning,
+              variants: model.variants,
+            })),
           ]),
         ))
       }).catch((err) => {
@@ -64,6 +70,41 @@ export function useChatRuntimeSelection() {
     setCurrentModel,
     provider,
     availableModels,
+  }
+}
+
+export function useReasoningVariantSelection(provider: string, currentModel: string, availableModels: ModelCatalog) {
+  const reasoningVariant = useSessionStore((s) => s.reasoningVariant)
+  const setReasoningVariant = useSessionStore((s) => s.setReasoningVariant)
+  const currentModelEntry = useMemo(
+    () => (availableModels[provider] || []).find((model) => model.id === currentModel) || null,
+    [availableModels, currentModel, provider],
+  )
+  const reasoningVariants = useMemo(
+    () => Array.from(new Set(currentModelEntry?.variants || [])).filter(Boolean),
+    [currentModelEntry],
+  )
+  const activeReasoningVariant = reasoningVariant && reasoningVariants.includes(reasoningVariant)
+    ? reasoningVariant
+    : null
+  const supportsReasoning = reasoningVariants.length > 0
+  const promptOptions = useMemo(
+    () => activeReasoningVariant ? { variant: activeReasoningVariant } : undefined,
+    [activeReasoningVariant],
+  )
+
+  useEffect(() => {
+    if (reasoningVariant && !reasoningVariants.includes(reasoningVariant)) {
+      setReasoningVariant(null)
+    }
+  }, [reasoningVariant, reasoningVariants, setReasoningVariant])
+
+  return {
+    supportsReasoning,
+    reasoningVariants,
+    reasoningVariant: activeReasoningVariant,
+    setReasoningVariant,
+    promptOptions,
   }
 }
 

--- a/apps/desktop/src/renderer/stores/session.ts
+++ b/apps/desktop/src/renderer/stores/session.ts
@@ -76,6 +76,9 @@ interface SessionStore {
   agentMode: 'build' | 'plan'
   setAgentMode: (mode: 'build' | 'plan') => void
 
+  reasoningVariant: string | null
+  setReasoningVariant: (variant: string | null) => void
+
   totalCost: number
 
   sidebarCollapsed: boolean
@@ -358,6 +361,8 @@ export const useSessionStore = create<SessionStore>((set) => ({
 
   agentMode: 'build',
   setAgentMode: (mode) => set({ agentMode: mode }),
+  reasoningVariant: null,
+  setReasoningVariant: (variant) => set({ reasoningVariant: variant }),
   totalCost: 0,
 
   sidebarCollapsed: false,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,6 +17,7 @@ import type {
   SessionChildInfo,
   SessionFileDiff,
   SessionInfo,
+  SessionPromptOptions,
   SessionPatch,
   SessionView,
   TodoItem,
@@ -129,7 +130,7 @@ export interface CoworkAPI {
   session: {
     create: (directory?: string) => Promise<SessionInfo>
     activate: (sessionId: string, options?: { force?: boolean }) => Promise<SessionView>
-    prompt: (sessionId: string, text: string, attachments?: Array<{ mime: string; url: string; filename?: string }>, agent?: string) => Promise<void>
+    prompt: (sessionId: string, text: string, attachments?: Array<{ mime: string; url: string; filename?: string }>, agent?: string, options?: SessionPromptOptions) => Promise<void>
     list: () => Promise<SessionInfo[]>
     get: (id: string) => Promise<SessionInfo | null>
     abort: (sessionId: string) => Promise<void>

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -56,6 +56,8 @@ export interface ProviderModelDescriptor {
   id: string
   name: string
   description?: string
+  reasoning?: boolean
+  variants?: string[]
   limit?: {
     context?: number
     output?: number

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -36,6 +36,10 @@ export interface SessionInfo {
   revertedMessageId?: string | null
 }
 
+export interface SessionPromptOptions {
+  variant?: string | null
+}
+
 export interface SessionChildInfo {
   id: string
   title?: string

--- a/tests/app-handlers.test.ts
+++ b/tests/app-handlers.test.ts
@@ -216,3 +216,61 @@ test('mergeRuntimeProviderModels preserves OpenCode defaults when the runtime om
     rmSync(tempRoot, { recursive: true, force: true })
   }
 })
+
+test('mergeRuntimeProviderModels exposes OpenCode reasoning model metadata', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-provider-runtime-reasoning-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+
+  writeFileSync(configPath, JSON.stringify({
+    providers: {
+      available: ['acme-provider'],
+      defaultProvider: 'acme-provider',
+      defaultModel: null,
+      descriptors: {
+        'acme-provider': {
+          runtime: 'builtin',
+          name: 'Acme Provider',
+          description: 'Acme provider',
+          credentials: [],
+          models: [
+            { id: 'live', name: 'Configured Live', featured: true },
+          ],
+        },
+      },
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    const merged = mergeRuntimeProviderModels(getPublicAppConfig(), [{
+      id: 'acme-provider',
+      models: {
+        live: {
+          name: 'Live Reasoning',
+          capabilities: { reasoning: true },
+          variants: {
+            xhigh: {},
+            low: {},
+            disabled: { disabled: true },
+          },
+        },
+      },
+      defaultModel: 'live',
+      connected: true,
+    }])
+    const model = merged.providers.available[0]?.models.find((entry) => entry.id === 'live')
+
+    assert.equal(model?.reasoning, true)
+    assert.deepEqual(model?.variants, ['low', 'xhigh'])
+    assert.equal(model?.name, 'Configured Live')
+    assert.equal(model?.featured, true)
+  } finally {
+    if (previousOverride === undefined) delete process.env.OPEN_COWORK_CONFIG_PATH
+    else process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -11,6 +11,7 @@ import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-ha
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { registerAutomationHandlers } from '../apps/desktop/src/main/ipc/automation-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { stopSessionStatusReconciliation } from '../apps/desktop/src/main/session-status-reconciler.ts'
@@ -59,6 +60,47 @@ function createBaseContext() {
   }
 
   return { context, handlers, errors }
+}
+
+function withPromptProviderConfig() {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-prompt-provider-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+  const providerId = 'acme-provider'
+  const modelId = 'live-model'
+
+  writeFileSync(configPath, JSON.stringify({
+    providers: {
+      available: [providerId],
+      defaultProvider: providerId,
+      defaultModel: modelId,
+      descriptors: {
+        [providerId]: {
+          runtime: 'builtin',
+          name: 'Acme Provider',
+          description: 'Acme provider',
+          credentials: [],
+          models: [
+            { id: modelId, name: 'Live Model' },
+          ],
+        },
+      },
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  return {
+    providerId,
+    modelId,
+    cleanup() {
+      if (previousOverride === undefined) delete process.env.OPEN_COWORK_CONFIG_PATH
+      else process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+      clearConfigCaches()
+      rmSync(tempRoot, { recursive: true, force: true })
+    },
+  }
 }
 
 test('session:delete refuses to delete without a valid destructive confirmation', async () => {
@@ -188,6 +230,124 @@ test('session:prompt clears pending prompt echo when dispatch fails', async () =
     consumePendingPromptEcho('session-prompt-failure', 'hello from optimistic prompt'),
     'hello from optimistic prompt',
   )
+})
+
+test('session:prompt forwards an OpenCode model variant when the runtime catalog exposes it', async () => {
+  const { providerId, modelId, cleanup } = withPromptProviderConfig()
+  const { context, handlers } = createBaseContext()
+  const sessionId = 'session-prompt-variant'
+  const promptPayloads: Array<Record<string, unknown>> = []
+
+  sessionEngine.removeSession(sessionId)
+  try {
+    context.getSessionClient = async () => ({
+      client: {
+        provider: {
+          list: async () => ({
+            data: {
+              all: [{
+                id: providerId,
+                name: 'Acme Provider',
+                models: {
+                  [modelId]: {
+                    name: 'Live Model',
+                    variants: {
+                      xhigh: {},
+                      low: {},
+                    },
+                  },
+                },
+              }],
+              default: { [providerId]: modelId },
+              connected: [providerId],
+            },
+          }),
+          auth: async () => ({ data: {} }),
+        },
+        session: {
+          promptAsync: async (payload: Record<string, unknown>) => {
+            promptPayloads.push(payload)
+          },
+        },
+      } as any,
+      record: null,
+    })
+
+    registerSessionHandlers(context)
+    const handler = handlers.get('session:prompt')
+    assert.ok(handler, 'expected session:prompt handler to be registered')
+
+    await handler({}, sessionId, 'analyze with more reasoning', undefined, 'build', { variant: 'xhigh' })
+
+    assert.equal(promptPayloads.length, 1)
+    assert.equal(promptPayloads[0]?.variant, 'xhigh')
+    assert.deepEqual(promptPayloads[0]?.model, {
+      providerID: providerId,
+      modelID: modelId,
+    })
+  } finally {
+    consumePendingPromptEcho(sessionId, 'analyze with more reasoning')
+    stopSessionStatusReconciliation(sessionId)
+    sessionEngine.removeSession(sessionId)
+    cleanup()
+  }
+})
+
+test('session:prompt ignores disabled model variants before runtime dispatch', async () => {
+  const { providerId, modelId, cleanup } = withPromptProviderConfig()
+  const { context, handlers } = createBaseContext()
+  const sessionId = 'session-prompt-invalid-variant'
+  const promptPayloads: Array<Record<string, unknown>> = []
+
+  sessionEngine.removeSession(sessionId)
+  try {
+    context.getSessionClient = async () => ({
+      client: {
+        provider: {
+          list: async () => ({
+            data: {
+              all: [{
+                id: providerId,
+                name: 'Acme Provider',
+                models: {
+                  [modelId]: {
+                    name: 'Live Model',
+                    variants: {
+                      low: {},
+                      xhigh: { disabled: true },
+                    },
+                  },
+                },
+              }],
+              default: { [providerId]: modelId },
+              connected: [providerId],
+            },
+          }),
+          auth: async () => ({ data: {} }),
+        },
+        session: {
+          promptAsync: async (payload: Record<string, unknown>) => {
+            promptPayloads.push(payload)
+          },
+        },
+      } as any,
+      record: null,
+    })
+
+    registerSessionHandlers(context)
+    const handler = handlers.get('session:prompt')
+    assert.ok(handler, 'expected session:prompt handler to be registered')
+
+    await handler({}, sessionId, 'try a stale reasoning variant', undefined, 'build', { variant: 'xhigh' })
+
+    assert.equal(promptPayloads.length, 1)
+    assert.equal('variant' in promptPayloads[0]!, false)
+  } finally {
+    consumePendingPromptEcho(sessionId, 'try a stale reasoning variant')
+    stopSessionStatusReconciliation(sessionId)
+    sessionEngine.removeSession(sessionId)
+    cleanup()
+  }
 })
 
 test('session:create rejects renderer-supplied project directories without a native-picker grant', async () => {

--- a/tests/vega-chart-utils.test.ts
+++ b/tests/vega-chart-utils.test.ts
@@ -24,6 +24,55 @@ test('normalizeVegaSpecSchema leaves full vega specs untouched', () => {
   assert.equal(isFullVegaSpec(spec), true)
 })
 
+test('normalizeVegaSpecSchema treats human daily labels as ordered categories', () => {
+  const spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+    data: {
+      values: [
+        { session_date: 'Sun 3 May', sessions: 145898 },
+        { session_date: 'Mon 4 May', sessions: 155270 },
+        { session_date: 'Tue 5 May', sessions: 126579 },
+        { session_date: 'Wed 6 May', sessions: 120673 },
+        { session_date: 'Thu 7 May', sessions: 133894 },
+      ],
+    },
+    mark: { type: 'line', point: true },
+    encoding: {
+      x: { field: 'session_date', type: 'temporal' },
+      y: { field: 'sessions', type: 'quantitative' },
+    },
+  }
+
+  const normalized = normalizeVegaSpecSchema(spec)
+  const x = (normalized.encoding as Record<string, any>).x
+
+  assert.equal(x.type, 'ordinal')
+  assert.deepEqual(x.sort, ['Sun 3 May', 'Mon 4 May', 'Tue 5 May', 'Wed 6 May', 'Thu 7 May'])
+})
+
+test('normalizeVegaSpecSchema preserves real temporal date fields', () => {
+  const spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+    data: {
+      values: [
+        { session_date: '2026-05-03', sessions: 145898 },
+        { session_date: '2026-05-04', sessions: 155270 },
+      ],
+    },
+    mark: { type: 'line', point: true },
+    encoding: {
+      x: { field: 'session_date', type: 'temporal' },
+      y: { field: 'sessions', type: 'quantitative' },
+    },
+  }
+
+  const normalized = normalizeVegaSpecSchema(spec)
+  const x = (normalized.encoding as Record<string, any>).x
+
+  assert.equal(x.type, 'temporal')
+  assert.equal('sort' in x, false)
+})
+
 test('applyVegaTheme preserves explicit chart dimensions for static rendering', () => {
   const spec = {
     $schema: 'https://vega.github.io/schema/vega-lite/v6.json',


### PR DESCRIPTION
## Summary
- expose OpenCode SDK model reasoning variants in provider metadata and pass selected variants through `session.promptAsync`
- add the shared reasoning selector to Home and in-thread composers, including keyboard support and IPC validation
- normalize human date labels in Vega-Lite temporal axes so daily charts render ordered day labels instead of inferred time ticks

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:renderer
- pnpm test
- pnpm build
- git diff --check