### PR TITLE
harden custom content and rendering edge cases

### DIFF
--- a/apps/desktop/src/lib/vega-spec.ts
+++ b/apps/desktop/src/lib/vega-spec.ts
@@ -23,8 +23,8 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 const TEMPORAL_POSITION_CHANNELS = ['x', 'y'] as const
-const SHORT_MONTH_OR_WEEKDAY_PATTERN = /\b(?:sun|mon|tue|wed|thu|fri|sat|jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)\b/i
-const EXPLICIT_YEAR_PATTERN = /\b\d{4}\b/
+const HUMAN_DATE_WORD_PATTERN = /\b(?:sun|sunday|mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\b/i
+const ISO_DATE_OR_DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2}(?:[Tt\s]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/
 
 function getInlineDataRows(spec: Record<string, unknown>): Array<Record<string, unknown>> | null {
   const data = asRecord(spec.data)
@@ -39,10 +39,11 @@ function getInlineDataRows(spec: Record<string, unknown>): Array<Record<string, 
   return rows.length > 0 ? rows : null
 }
 
-function isHumanDateLabelWithoutYear(value: string): boolean {
+function isHumanDateLabel(value: string): boolean {
   const trimmed = value.trim()
-  if (!trimmed || EXPLICIT_YEAR_PATTERN.test(trimmed)) return false
-  return /\d/.test(trimmed) && SHORT_MONTH_OR_WEEKDAY_PATTERN.test(trimmed)
+  if (!trimmed || ISO_DATE_OR_DATETIME_PATTERN.test(trimmed)) return false
+  if (!/\d/.test(trimmed)) return false
+  return HUMAN_DATE_WORD_PATTERN.test(trimmed)
 }
 
 function collectStringFieldValues(rows: Array<Record<string, unknown>>, field: string): string[] | null {
@@ -77,7 +78,7 @@ function normalizeTemporalLabelEncodings(spec: Record<string, unknown>): Record<
     if (!channelEncoding || !field || channelEncoding.type !== 'temporal') continue
 
     const values = collectStringFieldValues(rows, field)
-    if (!values || !values.every(isHumanDateLabelWithoutYear)) continue
+    if (!values || !values.every(isHumanDateLabel)) continue
 
     normalizedEncoding ||= { ...encoding }
     const normalizedChannel: Record<string, unknown> = {
@@ -92,9 +93,9 @@ function normalizeTemporalLabelEncodings(spec: Record<string, unknown>): Record<
 
   if (!normalizedEncoding) return spec
 
-  // Human labels like "Sun 3 May" are display categories, not stable
-  // timestamps. Leaving them temporal lets Vega-Lite infer sub-day ticks
-  // such as "12 PM", which is wrong for daily business charts.
+  // Human labels like "Sun 3 May" and "Apr 30, 2026" are display
+  // categories, not stable timestamps. Leaving them temporal lets Vega-Lite
+  // infer sub-day ticks such as "06 AM", which is wrong for daily charts.
   return {
     ...spec,
     encoding: normalizedEncoding,

--- a/apps/desktop/src/main/auth.ts
+++ b/apps/desktop/src/main/auth.ts
@@ -279,6 +279,9 @@ export async function loginWithGoogle(): Promise<AuthState> {
 
   return new Promise((resolve) => {
     let client: OAuth2Client | null = null
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    let finish = (state: AuthState) => resolve(state)
     const oauthState = crypto.randomUUID()
     const scopes = oauth.scopes?.length ? oauth.scopes : DEFAULT_GOOGLE_SCOPES
 
@@ -291,16 +294,14 @@ export async function loginWithGoogle(): Promise<AuthState> {
         if (returnedState !== oauthState) {
           res.writeHead(400, { 'Content-Type': 'text/html' })
           res.end('<html><body><h2>Login failed</h2><p>Invalid state parameter.</p></body></html>')
-          server.close()
-          resolve({ authenticated: false, email: null })
+          finish({ authenticated: false, email: null })
           return
         }
 
         if (!code) {
           res.writeHead(400, { 'Content-Type': 'text/html' })
           res.end('<html><body><h2>Login failed</h2><p>No authorization code received.</p></body></html>')
-          server.close()
-          resolve({ authenticated: false, email: null })
+          finish({ authenticated: false, email: null })
           return
         }
 
@@ -313,8 +314,7 @@ export async function loginWithGoogle(): Promise<AuthState> {
         if (!tokens.access_token || !tokens.refresh_token) {
           res.writeHead(400, { 'Content-Type': 'text/html' })
           res.end('<html><body><h2>Login failed</h2><p>Could not obtain tokens.</p></body></html>')
-          server.close()
-          resolve({ authenticated: false, email: null })
+          finish({ authenticated: false, email: null })
           return
         }
 
@@ -357,8 +357,7 @@ export async function loginWithGoogle(): Promise<AuthState> {
 
         res.writeHead(200, { 'Content-Type': 'text/html' })
         res.end(`<html><body style="font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#0a0a0a;color:#e0e0e0"><div style="text-align:center"><h2>Signed in as ${escapeHtml(email || 'user')}</h2><p>You can close this tab and return to ${escapeHtml(getBrandName())}.</p></div></body></html>`)
-        server.close()
-        resolve({ authenticated: true, email })
+        finish({ authenticated: true, email })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err || 'Unknown error')
         log('auth', `Login error: ${message}`)
@@ -367,9 +366,32 @@ export async function loginWithGoogle(): Promise<AuthState> {
         // the user's browser, so untrusted content (e.g., a garbled
         // error from the userinfo endpoint) could otherwise be HTML.
         res.end(`<html><body><h2>Login error</h2><p>${escapeHtml(message)}</p></body></html>`)
-        server.close()
-        resolve({ authenticated: false, email: null })
+        finish({ authenticated: false, email: null })
       }
+    })
+
+    finish = (state: AuthState) => {
+      if (settled) return
+      settled = true
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      if (server.listening) {
+        try {
+          server.close((error) => {
+            if (error) log('auth', `Login server close failed: ${error.message}`)
+          })
+        } catch (error) {
+          log('auth', `Login server close failed: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
+      resolve(state)
+    }
+
+    server.on('error', (error) => {
+      log('auth', `Login server error: ${error instanceof Error ? error.message : String(error)}`)
+      finish({ authenticated: false, email: null })
     })
 
     server.listen(0, '127.0.0.1', () => {
@@ -387,14 +409,12 @@ export async function loginWithGoogle(): Promise<AuthState> {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         log('auth', `Login server error: ${message}`)
-        server.close()
-        resolve({ authenticated: false, email: null })
+        finish({ authenticated: false, email: null })
       }
     })
 
-    setTimeout(() => {
-      server.close()
-      resolve({ authenticated: false, email: null })
+    timeout = setTimeout(() => {
+      finish({ authenticated: false, email: null })
     }, 120_000)
   })
 }

--- a/apps/desktop/src/main/custom-agent-store.ts
+++ b/apps/desktop/src/main/custom-agent-store.ts
@@ -3,11 +3,12 @@ import {
   join,
 } from 'path'
 import { type Dirent, readdirSync, rmSync } from 'fs'
-import type {
-  AgentColor,
-  CustomAgentConfig,
-  RuntimeContextOptions,
-  ScopedArtifactRef,
+import {
+  VALID_CUSTOM_AGENT_NAME,
+  type AgentColor,
+  type CustomAgentConfig,
+  type RuntimeContextOptions,
+  type ScopedArtifactRef,
 } from '@open-cowork/shared'
 import { getConfiguredToolPatterns, getConfiguredToolsFromConfig, getSidecarJsonSuffix } from './config-loader.ts'
 import {
@@ -27,6 +28,7 @@ import {
   ensureDirectory,
   mergeByName,
   readStringArray,
+  resolveContainedPath,
   targetDirectory,
   type JsonRecord,
 } from './custom-store-common.ts'
@@ -244,11 +246,17 @@ function deriveDeniedToolPatternsFromPermission(permission: unknown) {
 }
 
 function agentMetaPath(root: string, name: string) {
-  return join(root, `${name}${getSidecarJsonSuffix()}`)
+  return resolveContainedPath(root, `${name}${getSidecarJsonSuffix()}`, 'Custom agent metadata')
 }
 
 function agentMarkdownPath(root: string, name: string, enabled: boolean) {
-  return join(root, enabled ? `${name}.md` : `${name}.disabled.md`)
+  return resolveContainedPath(root, enabled ? `${name}.md` : `${name}.disabled.md`, 'Custom agent markdown')
+}
+
+function assertValidCustomAgentName(name: string) {
+  const trimmed = name.trim()
+  if (name === trimmed && VALID_CUSTOM_AGENT_NAME.test(trimmed)) return
+  throw new Error('Custom agent id must use 1-64 lowercase letters, numbers, and single hyphens only.')
 }
 
 function readManagedAgentMetadata(root: string, name: string): ManagedAgentMetadata {
@@ -426,9 +434,8 @@ export function syncCustomAgentRuntimeGuidance(context?: RuntimeContextOptions) 
 
 export function saveCustomAgent(agent: CustomAgentConfig, permission: Record<string, unknown>) {
   assertCustomAgentContentLimits(agent)
+  assertValidCustomAgentName(agent.name)
   const root = ensureDirectory(agentsDirForTarget(agent.scope, agent.directory))
-  rmSync(agentMarkdownPath(root, agent.name, true), { force: true })
-  rmSync(agentMarkdownPath(root, agent.name, false), { force: true })
   writeFileAtomic(
     agentMarkdownPath(root, agent.name, agent.enabled),
     serializeCustomAgentMarkdown(agent, permission),
@@ -446,10 +453,12 @@ export function saveCustomAgent(agent: CustomAgentConfig, permission: Record<str
     ...(typeof agent.steps === 'number' && Number.isFinite(agent.steps) && agent.steps > 0 ? { steps: Math.round(agent.steps) } : {}),
     ...(agent.options && typeof agent.options === 'object' && Object.keys(agent.options).length > 0 ? { options: agent.options } : {}),
   })
+  rmSync(agentMarkdownPath(root, agent.name, !agent.enabled), { force: true })
   return true
 }
 
 export function removeCustomAgent(target: ScopedArtifactRef) {
+  assertValidCustomAgentName(target.name)
   const root = ensureDirectory(agentsDirForTarget(target.scope, target.directory))
   rmSync(agentMarkdownPath(root, target.name, true), { force: true })
   rmSync(agentMarkdownPath(root, target.name, false), { force: true })

--- a/apps/desktop/src/main/custom-skill-store.ts
+++ b/apps/desktop/src/main/custom-skill-store.ts
@@ -1,10 +1,13 @@
 import {
   existsSync,
+  mkdtempSync,
   mkdirSync,
   readdirSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'fs'
+import { randomUUID } from 'crypto'
 import { basename, dirname, join, relative, resolve } from 'path'
 import type {
   CustomSkillConfig,
@@ -16,6 +19,7 @@ import { writeFileAtomic } from './fs-atomic.ts'
 import { readTextFileCheckedSync } from './fs-read.ts'
 import { resolveProjectDirectory } from './runtime-paths.ts'
 import {
+  assertValidOpenCodeSkillName,
   assertValidOpenCodeSkillBundle,
   extractSkillFrontmatterName,
   normalizeSkillBundleName,
@@ -30,6 +34,7 @@ import {
 import {
   ensureDirectory,
   mergeByName,
+  resolveContainedPath,
   skillsDirForTarget,
   targetDirectory,
 } from './custom-store-common.ts'
@@ -110,6 +115,43 @@ function canonicalizeManagedSkillContent(skillName: string, skillFile: string, r
   }
 
   return canonicalContent
+}
+
+function replaceSkillBundleDirectory(root: string, tempRoot: string) {
+  const parent = dirname(root)
+  const backupRoot = join(parent, `.${basename(root)}.backup-${randomUUID()}`)
+  let movedExisting = false
+
+  try {
+    if (existsSync(root)) {
+      renameSync(root, backupRoot)
+      movedExisting = true
+    }
+    renameSync(tempRoot, root)
+    if (movedExisting) {
+      try {
+        rmSync(backupRoot, { recursive: true, force: true })
+      } catch (cleanupError) {
+        log(
+          'warn',
+          `Custom skill backup cleanup failed for ${basename(root)}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+        )
+      }
+    }
+  } catch (error) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    if (movedExisting && !existsSync(root)) {
+      try {
+        renameSync(backupRoot, root)
+      } catch (rollbackError) {
+        log(
+          'error',
+          `Custom skill rollback failed for ${basename(root)}: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+        )
+      }
+    }
+    throw error
+  }
 }
 
 function readScopedSkills(scope: NativeConfigScope, directory?: string | null) {
@@ -281,7 +323,9 @@ export function getCustomSkill(name: string, context?: RuntimeContextOptions) {
 }
 
 export function saveCustomSkill(skill: CustomSkillConfig) {
-  const root = join(ensureDirectory(skillsDirForTarget(skill.scope, skill.directory)), skill.name)
+  assertValidOpenCodeSkillName(skill.name, 'Custom skill bundle')
+  const baseDir = ensureDirectory(skillsDirForTarget(skill.scope, skill.directory))
+  const root = resolveContainedPath(baseDir, skill.name, 'Custom skill bundle')
   const filesToWrite = skill.files || []
   // `toolIds` is stored inside SKILL.md frontmatter so the bundle stays
   // self-contained — no sidecar to drift. The form's selection wins over
@@ -293,31 +337,36 @@ export function saveCustomSkill(skill: CustomSkillConfig) {
   assertCustomSkillContent(contentToWrite)
   assertCustomSkillFiles(filesToWrite)
   assertValidOpenCodeSkillBundle({ name: skill.name, content: contentToWrite }, 'Custom skill bundle')
-  for (const file of filesToWrite) {
-    if (!isSafeRelativePath(file.path)) {
-      throw new Error(`Invalid skill file path: ${file.path}`)
-    }
-    const output = resolve(root, file.path)
-    const outputRelative = relative(root, output)
-    if (outputRelative.startsWith('..') || outputRelative.startsWith('/')) {
-      throw new Error(`Skill file escapes bundle root: ${file.path}`)
-    }
-  }
 
-  rmSync(root, { recursive: true, force: true })
-  mkdirSync(root, { recursive: true })
-  writeFileAtomic(join(root, 'SKILL.md'), contentToWrite)
+  const tempRoot = mkdtempSync(join(baseDir, `.${skill.name}.tmp-`))
+  try {
+    for (const file of filesToWrite) {
+      if (!isSafeRelativePath(file.path)) {
+        throw new Error(`Invalid skill file path: ${file.path}`)
+      }
+      resolveContainedPath(tempRoot, file.path, 'Custom skill file')
+    }
 
-  for (const file of filesToWrite) {
-    const output = resolve(root, file.path)
-    mkdirSync(dirname(output), { recursive: true })
-    writeFileAtomic(output, file.content)
+    writeFileAtomic(join(tempRoot, 'SKILL.md'), contentToWrite)
+
+    for (const file of filesToWrite) {
+      const output = resolveContainedPath(tempRoot, file.path, 'Custom skill file')
+      mkdirSync(dirname(output), { recursive: true })
+      writeFileAtomic(output, file.content)
+    }
+
+    replaceSkillBundleDirectory(root, tempRoot)
+  } catch (error) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    throw error
   }
 
   return true
 }
 
 export function removeCustomSkill(target: ScopedArtifactRef) {
-  rmSync(join(skillsDirForTarget(target.scope, target.directory), target.name), { recursive: true, force: true })
+  assertValidOpenCodeSkillName(target.name, 'Custom skill bundle')
+  const root = resolveContainedPath(skillsDirForTarget(target.scope, target.directory), target.name, 'Custom skill bundle')
+  rmSync(root, { recursive: true, force: true })
   return true
 }

--- a/apps/desktop/src/main/custom-store-common.ts
+++ b/apps/desktop/src/main/custom-store-common.ts
@@ -1,4 +1,5 @@
 import { mkdirSync } from 'fs'
+import { isAbsolute, relative, resolve } from 'path'
 import type { NativeConfigScope } from './runtime-paths.ts'
 import {
   getMachineAgentsDir,
@@ -16,6 +17,16 @@ export type JsonRecord = Record<string, unknown>
 export function ensureDirectory(path: string) {
   mkdirSync(path, { recursive: true })
   return path
+}
+
+export function resolveContainedPath(root: string, childPath: string, label: string) {
+  const resolvedRoot = resolve(root)
+  const resolvedChild = resolve(resolvedRoot, childPath)
+  const pathFromRoot = relative(resolvedRoot, resolvedChild)
+  if (!pathFromRoot || pathFromRoot.startsWith('..') || isAbsolute(pathFromRoot)) {
+    throw new Error(`${label} path escapes the managed directory.`)
+  }
+  return resolvedChild
 }
 
 export function targetDirectory(scope: NativeConfigScope, directory?: string | null) {

--- a/apps/desktop/src/main/skill-bundle-validation.ts
+++ b/apps/desktop/src/main/skill-bundle-validation.ts
@@ -1,4 +1,4 @@
-export const VALID_OPENCODE_SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+export const VALID_OPENCODE_SKILL_NAME = /^(?=.{1,64}$)[a-z0-9]+(?:-[a-z0-9]+)*$/
 const MAX_SKILL_DESCRIPTION_LENGTH = 1024
 
 function parseSkillFrontmatter(content: string) {
@@ -71,6 +71,12 @@ export function validateOpenCodeSkillBundle(input: {
   }
 
   return issues
+}
+
+export function assertValidOpenCodeSkillName(name: string, sourceLabel: string) {
+  const trimmed = name.trim()
+  if (name === trimmed && VALID_OPENCODE_SKILL_NAME.test(trimmed)) return
+  throw new Error(`${sourceLabel}: Skill bundle names must use 1-64 lowercase letters, numbers, and single hyphens only.`)
 }
 
 export function assertValidOpenCodeSkillBundle(input: {

--- a/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
@@ -10,7 +10,7 @@ function renderToolbar(overrides: Partial<Parameters<typeof ChatInputToolbar>[0]
     fileInputRef,
     modelButtonRef,
     modelLabel: 'Claude Sonnet',
-    currentDirectory: '/Users/joe/project',
+    currentDirectory: '/Users/example/project',
     agentMode: 'build',
     currentSessionId: 'ses_123',
     isGenerating: false,

--- a/apps/desktop/src/renderer/components/chat/MarkdownContent.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownContent.test.tsx
@@ -43,4 +43,18 @@ describe('MarkdownContent', () => {
     expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('copy me'))
     expect(button.getAttribute('aria-label')).toBe('Copy code')
   })
+
+  it('renders model-collapsed GFM tables after streaming has finished', async () => {
+    const text = '| Day | Date (2026) | Sessions | CVR | |---|---|---|---| | Sun | 26 Apr | 152,762 | 3.03% | | Mon | 27 Apr | 185,921 | 2.90% |'
+    const { container } = render(<MarkdownContent text={text} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('table')).not.toBeNull()
+    })
+
+    expect(container.querySelectorAll('thead th')).toHaveLength(4)
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2)
+    expect(container.textContent).toContain('152,762')
+    expect(container.textContent).not.toContain('|---|---')
+  })
 })

--- a/apps/desktop/src/renderer/components/chat/markdown-stream.ts
+++ b/apps/desktop/src/renderer/components/chat/markdown-stream.ts
@@ -93,6 +93,145 @@ function rewriteFence(line: string, char: '`' | '~', size: number, suffix = '') 
   return `${indent}${char.repeat(size)}${suffix}`
 }
 
+function countTableCells(row: string) {
+  const trimmed = row.trim()
+  if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) return null
+
+  let pipes = 0
+  let escaped = false
+  for (const char of trimmed) {
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+    if (char === '|') pipes += 1
+  }
+
+  return pipes >= 2 ? pipes - 1 : null
+}
+
+function readTableSeparatorRow(source: string) {
+  if (!source.startsWith('|')) return null
+
+  let cursor = 1
+  let cells = 0
+  let end = -1
+  while (cursor < source.length) {
+    const pipe = source.indexOf('|', cursor)
+    if (pipe < 0) break
+    const cell = source.slice(cursor, pipe).trim()
+    if (!/^:?-{3,}:?$/.test(cell)) break
+    cells += 1
+    end = pipe + 1
+    cursor = pipe + 1
+  }
+
+  if (cells === 0 || end < 0) return null
+  return {
+    cells,
+    row: source.slice(0, end).trim(),
+    rest: source.slice(end).trimStart(),
+  }
+}
+
+function readCollapsedTableRows(source: string, cells: number) {
+  const rows: string[] = []
+  let cursor = 0
+
+  while (cursor < source.length) {
+    while (cursor < source.length && /[ \t]/.test(source[cursor] ?? '')) cursor += 1
+    if (cursor >= source.length) break
+    if (source[cursor] !== '|') return null
+
+    let pipes = 0
+    let escaped = false
+    let end = -1
+    for (let index = cursor; index < source.length; index += 1) {
+      const char = source[index]
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char !== '|') continue
+      pipes += 1
+      if (pipes === cells + 1) {
+        end = index + 1
+        break
+      }
+    }
+
+    if (end < 0) return null
+    const row = source.slice(cursor, end).trim()
+    if (countTableCells(row) !== cells) return null
+    rows.push(row)
+    cursor = end
+  }
+
+  return rows.length > 0 ? rows : null
+}
+
+function normalizeCollapsedTableLine(line: string) {
+  const leading = line.match(/^\s*/)?.[0] ?? ''
+  const content = line.slice(leading.length)
+  if (!content.startsWith('|') || !content.includes('---')) return line
+
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] !== '|') continue
+    const separatorCandidate = content.slice(index + 1)
+    const whitespace = separatorCandidate.match(/^[ \t]+/)
+    if (!whitespace) continue
+    const rest = separatorCandidate.slice(whitespace[0].length)
+    const separator = readTableSeparatorRow(rest)
+    if (!separator) continue
+
+    const header = content.slice(0, index + 1).trim()
+    if (countTableCells(header) !== separator.cells) continue
+
+    const rows = readCollapsedTableRows(separator.rest, separator.cells)
+    if (!rows) return line
+
+    return [
+      header,
+      separator.row,
+      ...rows,
+    ].map((row) => `${leading}${row}`).join('\n')
+  }
+
+  return line
+}
+
+export function normalizeCollapsedMarkdownTables(text: string) {
+  if (!/\|\s*:?-{3,}:?/.test(text)) return text
+
+  const lines = text.split('\n')
+  let openFence: FenceMatch | null = null
+
+  return lines.map((line) => {
+    if (openFence) {
+      if (matchFenceClose(line, openFence.char, openFence.size)) {
+        openFence = null
+      }
+      return line
+    }
+
+    const fence = matchFenceOpen(line)
+    if (fence) {
+      openFence = fence
+      return line
+    }
+
+    return normalizeCollapsedTableLine(line)
+  }).join('\n')
+}
+
 export function normalizeFencedCodeBlocks(text: string) {
   if (!text || (!text.includes('```') && !text.includes('~~~'))) return text
 
@@ -144,7 +283,7 @@ export function normalizeFencedCodeBlocks(text: string) {
 }
 
 export function streamMarkdown(text: string, live: boolean): MarkdownBlock[] {
-  const normalized = normalizeFencedCodeBlocks(text)
+  const normalized = normalizeCollapsedMarkdownTables(normalizeFencedCodeBlocks(text))
   if (!live) return [{ raw: normalized, src: normalized, mode: 'full' }]
 
   const healed = heal(normalized)

--- a/mcps/charts/src/chart-utils.ts
+++ b/mcps/charts/src/chart-utils.ts
@@ -75,6 +75,7 @@ const MONTH_ALIASES = new Map<string, string>([
 
 type ChartRow = Record<string, unknown>
 type VegaEncoding = Record<string, unknown>
+const ISO_DATE_OR_DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2}(?:[Tt\s]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/
 
 function normalizeToken(value: unknown) {
   return String(value).trim().toLowerCase()
@@ -105,6 +106,7 @@ function uniqueInEncounterOrder(values: unknown[]) {
 function parseTemporalString(value: string) {
   const trimmed = value.trim()
   if (!/\d/.test(trimmed)) return null
+  if (!ISO_DATE_OR_DATETIME_PATTERN.test(trimmed)) return null
   const epoch = Date.parse(trimmed)
   return Number.isFinite(epoch) ? epoch : null
 }

--- a/packages/shared/src/agent-validation.ts
+++ b/packages/shared/src/agent-validation.ts
@@ -1,6 +1,6 @@
 import type { CustomAgentIssue } from './custom-content.js'
 
-export const VALID_CUSTOM_AGENT_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+export const VALID_CUSTOM_AGENT_NAME = /^(?=.{1,64}$)[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 export type CustomAgentDraftValidationInput = {
   name: string

--- a/tests/charts-axis-utils.test.ts
+++ b/tests/charts-axis-utils.test.ts
@@ -33,6 +33,17 @@ test('inferSequentialXAxisEncoding preserves true temporal fields', () => {
   assert.equal(encoding.type, 'temporal')
 })
 
+test('inferSequentialXAxisEncoding keeps human date labels as ordered categories', () => {
+  const encoding = inferSequentialXAxisEncoding([
+    { day: 'Apr 26, 2026', sales: 164821 },
+    { day: 'Apr 27, 2026', sales: 151204 },
+    { day: 'Apr 28, 2026', sales: 139842 },
+  ], 'day')
+
+  assert.equal(encoding.type, 'ordinal')
+  assert.deepEqual(encoding.sort, ['Apr 26, 2026', 'Apr 27, 2026', 'Apr 28, 2026'])
+})
+
 test('normalizeSeriesColorField rejects x/y fields as invalid series groups', () => {
   assert.equal(normalizeSeriesColorField('current', 'day', 'current'), undefined)
   assert.equal(normalizeSeriesColorField('day', 'day', 'current'), undefined)

--- a/tests/custom-skills.test.ts
+++ b/tests/custom-skills.test.ts
@@ -1,8 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
-import { listCustomSkills, readSkillBundleDirectory, saveCustomSkill } from '../apps/desktop/src/main/native-customizations.ts'
+import { listCustomSkills, readSkillBundleDirectory, removeCustomSkill, saveCustomSkill } from '../apps/desktop/src/main/native-customizations.ts'
 import { CUSTOM_SKILL_LIMITS } from '../apps/desktop/src/main/custom-content-limits.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { getMachineSkillsDir } from '../apps/desktop/src/main/runtime-paths.ts'
@@ -69,6 +69,32 @@ test('saveCustomSkill rejects bundles that do not meet OpenCode frontmatter requ
       files: [],
     })
   }, /Skill bundle names must use 1-64 lowercase letters, numbers, and single hyphens only|SKILL\.md must include a frontmatter description/)
+})
+
+test('removeCustomSkill rejects path-like names before deleting files', async () => {
+  const root = testTempDir('opencowork-skill-remove-policy-')
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  process.env.OPEN_COWORK_USER_DATA_DIR = join(root, 'user-data')
+  clearConfigCaches()
+
+  try {
+    const outsideDir = join(getMachineSkillsDir(), '..', 'outside')
+    mkdirSync(outsideDir, { recursive: true })
+    writeFileSync(join(outsideDir, 'marker.txt'), 'keep')
+
+    assert.throws(() => {
+      removeCustomSkill({ scope: 'machine', directory: null, name: '../outside' })
+    }, /Skill bundle names must use 1-64 lowercase letters/)
+
+    assert.equal(existsSync(join(outsideDir, 'marker.txt')), true)
+  } finally {
+    closeLogger()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(root, { recursive: true, force: true })
+  }
 })
 
 test('readSkillBundleDirectory rejects oversized supporting files', () => {

--- a/tests/markdown-stream.test.ts
+++ b/tests/markdown-stream.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { normalizeFencedCodeBlocks, streamMarkdown } from '../apps/desktop/src/renderer/components/chat/markdown-stream.ts'
+import { normalizeCollapsedMarkdownTables, normalizeFencedCodeBlocks, streamMarkdown } from '../apps/desktop/src/renderer/components/chat/markdown-stream.ts'
 
 test('normalizes nested fences inside a top-level code block', () => {
   const source = [
@@ -63,4 +63,51 @@ test('widens an incomplete outer fence during streaming when nested fences appea
 
   assert.equal(blocks.length, 1)
   assert.match(blocks[0]?.src ?? '', /^````julia/)
+})
+
+test('normalizes model-collapsed GFM tables before final rendering', () => {
+  const source = '| Day | Date (2026) | Sessions | CVR | |---|---|---|---| | Sun | 26 Apr | 152,762 | 3.03% | | Mon | 27 Apr | 185,921 | 2.90% |'
+  const normalized = normalizeCollapsedMarkdownTables(source)
+
+  assert.equal(normalized, [
+    '| Day | Date (2026) | Sessions | CVR |',
+    '|---|---|---|---|',
+    '| Sun | 26 Apr | 152,762 | 3.03% |',
+    '| Mon | 27 Apr | 185,921 | 2.90% |',
+  ].join('\n'))
+  assert.equal(streamMarkdown(source, false)[0]?.src, normalized)
+})
+
+test('normalizes collapsed table rows with empty cells without splitting them as row boundaries', () => {
+  const source = '| Metric | Current | Notes | |---|---|---| | Sessions | 906,321 | All days down YoY | | CVR | 2.79% | |'
+  const normalized = normalizeCollapsedMarkdownTables(source)
+
+  assert.equal(normalized, [
+    '| Metric | Current | Notes |',
+    '|---|---|---|',
+    '| Sessions | 906,321 | All days down YoY |',
+    '| CVR | 2.79% | |',
+  ].join('\n'))
+})
+
+test('normalizes collapsed table separators with padded cells', () => {
+  const source = '| Day | Sessions | | --- | ---: | | Sun | 10 | | Mon | 12 |'
+  const normalized = normalizeCollapsedMarkdownTables(source)
+
+  assert.equal(normalized, [
+    '| Day | Sessions |',
+    '| --- | ---: |',
+    '| Sun | 10 |',
+    '| Mon | 12 |',
+  ].join('\n'))
+})
+
+test('does not normalize collapsed-looking tables inside code fences', () => {
+  const source = [
+    '```md',
+    '| Day | Sessions | |---|---| | Sun | 10 |',
+    '```',
+  ].join('\n')
+
+  assert.equal(normalizeCollapsedMarkdownTables(source), source)
 })

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -240,6 +240,24 @@ test('custom agent builder selections round-trip through managed sidecar metadat
   }
 })
 
+test('removeCustomAgent rejects path-like names before deleting files', () => {
+  const projectRoot = testTempDir('opencowork-native-agent-remove-policy-')
+  const coworkDir = join(projectRoot, '.opencowork')
+  mkdirSync(coworkDir, { recursive: true })
+  const markerPath = join(coworkDir, 'outside.md')
+  writeFileSync(markerPath, 'keep')
+
+  try {
+    assert.throws(() => {
+      removeCustomAgent({ scope: 'project', directory: projectRoot, name: '../outside' })
+    }, /Custom agent id must use 1-64 lowercase letters/)
+
+    assert.equal(existsSync(markerPath), true)
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true })
+  }
+})
+
 test('runtime guidance is backfilled into existing native custom agent markdown without polluting editor instructions', () => {
   const projectRoot = testTempDir('opencowork-native-agent-guidance-')
   const agentsDir = join(projectRoot, '.opencowork', 'agents')

--- a/tests/vega-chart-utils.test.ts
+++ b/tests/vega-chart-utils.test.ts
@@ -50,6 +50,55 @@ test('normalizeVegaSpecSchema treats human daily labels as ordered categories', 
   assert.deepEqual(x.sort, ['Sun 3 May', 'Mon 4 May', 'Tue 5 May', 'Wed 6 May', 'Thu 7 May'])
 })
 
+test('normalizeVegaSpecSchema treats long human date labels as ordered categories', () => {
+  const spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+    data: {
+      values: [
+        { date: 'Apr 26, 2026', sessions: 164821 },
+        { date: 'Apr 27, 2026', sessions: 151204 },
+        { date: 'Apr 28, 2026', sessions: 139842 },
+        { date: 'Apr 29, 2026', sessions: 134998 },
+        { date: 'Apr 30, 2026', sessions: 127392 },
+      ],
+    },
+    mark: { type: 'line', point: true },
+    encoding: {
+      x: { field: 'date', type: 'temporal' },
+      y: { field: 'sessions', type: 'quantitative' },
+    },
+  }
+
+  const normalized = normalizeVegaSpecSchema(spec)
+  const x = (normalized.encoding as Record<string, any>).x
+
+  assert.equal(x.type, 'ordinal')
+  assert.deepEqual(x.sort, ['Apr 26, 2026', 'Apr 27, 2026', 'Apr 28, 2026', 'Apr 29, 2026', 'Apr 30, 2026'])
+})
+
+test('normalizeVegaSpecSchema treats full month date labels as ordered categories', () => {
+  const spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+    data: {
+      values: [
+        { date: 'April 26, 2026', sessions: 164821 },
+        { date: 'April 27, 2026', sessions: 151204 },
+      ],
+    },
+    mark: 'line',
+    encoding: {
+      x: { field: 'date', type: 'temporal' },
+      y: { field: 'sessions', type: 'quantitative' },
+    },
+  }
+
+  const normalized = normalizeVegaSpecSchema(spec)
+  const x = (normalized.encoding as Record<string, any>).x
+
+  assert.equal(x.type, 'ordinal')
+  assert.deepEqual(x.sort, ['April 26, 2026', 'April 27, 2026'])
+})
+
 test('normalizeVegaSpecSchema preserves real temporal date fields', () => {
   const spec = {
     $schema: 'https://vega.github.io/schema/vega-lite/v6.json',


### PR DESCRIPTION
## Summary
- harden custom skill and agent filesystem writes/removals with name validation, path containment, and safer replacement ordering
- make Google OAuth loopback login single-settle with timeout cleanup and server error handling
- normalize human date labels in Vega/Vega-Lite chart specs so daily charts do not render time-of-day axes
- repair model-collapsed GFM tables before markdown rendering, without touching code fences
- replace a local-user test fixture path with a generic example path

## Audit decisions
- Verified `pnpm --dir apps/desktop dist:ci` passes locally and confirmed both x64 and arm64 `app.asar` contain `/dist/main/index.js` and `/dist/preload/index.js`; the reported arm64 entrypoint blocker does not reproduce on current master.
- Left HTTP MCP per-request DNS pinning out of scope. Current code revalidates DNS at runtime registration and docs state Open Cowork does not proxy or pin OpenCode HTTP transport after handoff.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (924 tests)
- `pnpm test:renderer` (268 tests)
- `pnpm build`
- `pnpm perf:check`
- `pnpm docs:build`
- `pnpm audit --prod --audit-level high`
- `pnpm --dir apps/desktop dist:ci`
- `git diff --check`