### PR TITLE
[codex] project crew runs from OpenCode events

### DIFF
--- a/apps/desktop/src/main/crew-runtime-projector.ts
+++ b/apps/desktop/src/main/crew-runtime-projector.ts
@@ -1,5 +1,12 @@
 import { createHash } from 'node:crypto'
-import { createCoworkTraceEvent, type CrewRun, type CrewRunNode, type CrewRunNodeStatus, type TraceTokenUsage } from '@open-cowork/shared'
+import {
+  createCoworkTraceEvent,
+  type CrewRun,
+  type CrewRunNode,
+  type CrewRunNodeStatus,
+  type CrewRunStatus,
+  type TraceTokenUsage,
+} from '@open-cowork/shared'
 import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
 import {
   appendCoworkTraceEventIfNew,
@@ -93,6 +100,11 @@ function runtimeStatusToNodeStatus(status: unknown): CrewRunNodeStatus {
 
 function findPlanNode(nodes: CrewRunNode[]) {
   return nodes.find((node) => node.kind === 'plan') || null
+}
+
+function nextRunStatusFromNodes(runId: string, fallback: CrewRunStatus): CrewRunStatus {
+  const nodes = listCrewRunNodes(runId)
+  return nodes.some((node) => node.status === 'failed' || node.status === 'blocked') ? 'blocked' : fallback
 }
 
 function findRunNodeForTask(run: CrewRun, data: RuntimeEventData): CrewRunNode | null {
@@ -198,7 +210,7 @@ function projectTaskRun(run: CrewRun, data: RuntimeEventData) {
     agentName,
     sessionId: sourceSessionId,
   })
-  updateCrewRunStatus(run.id, status === 'failed' ? 'blocked' : 'running')
+  updateCrewRunStatus(run.id, nextRunStatusFromNodes(run.id, 'running'))
 
   traceBase({
     run,
@@ -331,7 +343,7 @@ function projectApprovalResolved(run: CrewRun, data: RuntimeEventData) {
   if (approval?.nodeId) {
     updateCrewRunNodeRuntimeState(approval.nodeId, { status: data.status === 'denied' ? 'failed' : 'running' })
   }
-  updateCrewRunStatus(run.id, 'running')
+  updateCrewRunStatus(run.id, nextRunStatusFromNodes(run.id, 'running'))
   traceBase({
     run,
     id: traceId([run.id, 'approval_resolved', approvalSourceId]),

--- a/apps/desktop/src/main/crew-runtime-projector.ts
+++ b/apps/desktop/src/main/crew-runtime-projector.ts
@@ -1,0 +1,468 @@
+import { createHash } from 'node:crypto'
+import { createCoworkTraceEvent, type CrewRun, type CrewRunNode, type CrewRunNodeStatus, type TraceTokenUsage } from '@open-cowork/shared'
+import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
+import {
+  appendCoworkTraceEventIfNew,
+  createCrewApproval,
+  createCrewArtifact,
+  createCrewRunNode,
+  getCrewApproval,
+  getCrewRunByRootSessionId,
+  listCoworkTraceEventsForRun,
+  listCrewRunNodes,
+  nextCoworkTraceSequence,
+  resolveCrewApproval,
+  updateCrewRunNodeRuntimeState,
+  updateCrewRunStatus,
+} from './crew-store.ts'
+
+const MAX_TRACE_TEXT_BYTES = 4096
+
+type RuntimeEventData = NonNullable<RuntimeSessionEvent['data']>
+
+function eventType(event: RuntimeSessionEvent) {
+  return String(event.data?.type || event.type || '')
+}
+
+function boundedText(value: unknown, fallback = '') {
+  if (typeof value !== 'string') return fallback
+  const trimmed = value.trim()
+  if (!trimmed) return fallback
+  if (Buffer.byteLength(trimmed, 'utf8') <= MAX_TRACE_TEXT_BYTES) return trimmed
+  return `${Buffer.from(trimmed, 'utf8').subarray(0, MAX_TRACE_TEXT_BYTES).toString('utf8')}...`
+}
+
+function stableStringify(value: unknown): string {
+  const seen = new WeakSet<object>()
+  return JSON.stringify(value, (_key, current) => {
+    if (!current || typeof current !== 'object') return current
+    if (seen.has(current)) return '[Circular]'
+    seen.add(current)
+    if (Array.isArray(current)) return current
+    return Object.fromEntries(Object.keys(current).sort().map((key) => [key, (current as Record<string, unknown>)[key]]))
+  }) || ''
+}
+
+function sha256(value: unknown) {
+  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`
+}
+
+function traceId(parts: Array<string | null | undefined>) {
+  return `crew-trace-${createHash('sha256').update(parts.filter(Boolean).join(':')).digest('hex').slice(0, 32)}`
+}
+
+function scopedId(prefix: string, runId: string, sourceId: string) {
+  return `${prefix}-${createHash('sha256').update(`${runId}:${sourceId}`).digest('hex').slice(0, 32)}`
+}
+
+function readTaskRunTraceNodeId(runId: string, taskRunId: string | null | undefined) {
+  if (!taskRunId) return null
+  for (const trace of listCoworkTraceEventsForRun(runId)) {
+    if (trace.payload?.type !== 'crew_run.task_run') continue
+    if (trace.payload.taskRunId !== taskRunId) continue
+    if (trace.nodeId) return trace.nodeId
+  }
+  return null
+}
+
+function runtimeTaskRunId(data: RuntimeEventData) {
+  if (data.type === 'task_run' && typeof data.id === 'string' && data.id) return data.id
+  if (typeof data.taskRunId === 'string' && data.taskRunId) return data.taskRunId
+  if (typeof data.id === 'string' && data.id) return data.id
+  return null
+}
+
+function runtimeStatusToNodeStatus(status: unknown): CrewRunNodeStatus {
+  switch (status) {
+    case 'complete':
+    case 'completed':
+    case 'success':
+      return 'completed'
+    case 'error':
+    case 'failed':
+      return 'failed'
+    case 'blocked':
+    case 'waiting':
+      return 'blocked'
+    case 'queued':
+      return 'queued'
+    default:
+      return 'running'
+  }
+}
+
+function findPlanNode(nodes: CrewRunNode[]) {
+  return nodes.find((node) => node.kind === 'plan') || null
+}
+
+function findRunNodeForTask(run: CrewRun, data: RuntimeEventData): CrewRunNode | null {
+  const nodes = listCrewRunNodes(run.id)
+  const taskRunId = runtimeTaskRunId(data)
+  const tracedNodeId = readTaskRunTraceNodeId(run.id, taskRunId)
+  if (tracedNodeId) {
+    const node = nodes.find((candidate) => candidate.id === tracedNodeId)
+    if (node) return node
+  }
+
+  const sourceSessionId = typeof data.sourceSessionId === 'string' && data.sourceSessionId ? data.sourceSessionId : null
+  if (sourceSessionId) {
+    const bySession = nodes.find((candidate) => candidate.sessionId === sourceSessionId)
+    if (bySession) return bySession
+  }
+
+  const agentName = typeof data.agent === 'string' && data.agent ? data.agent : null
+  if (agentName) {
+    const byAgent = nodes.find((candidate) =>
+      candidate.agentName === agentName
+      && (candidate.status === 'queued' || candidate.status === 'running' || candidate.status === 'blocked')
+      && (!sourceSessionId || !candidate.sessionId),
+    )
+    if (byAgent) return byAgent
+  }
+
+  const plan = findPlanNode(nodes)
+  const title = boundedText(data.title, agentName ? `Delegate to ${agentName}` : 'Delegated OpenCode task')
+  return createCrewRunNode({
+    crewRunId: run.id,
+    kind: 'delegate',
+    title,
+    agentName,
+    sessionId: sourceSessionId,
+    parentNodeId: plan?.id || null,
+    status: runtimeStatusToNodeStatus(data.status),
+  })
+}
+
+function traceBase(input: {
+  run: CrewRun
+  id: string
+  payloadType: string
+  sourceEventId: string | null
+  sessionId?: string | null
+  parentSessionId?: string | null
+  actorId?: string | null
+  nodeId?: string | null
+  approvalId?: string | null
+  artifactId?: string | null
+  inputHash?: string | null
+  outputHash?: string | null
+  payloadHash?: string | null
+  payload: Record<string, unknown>
+  tokenUsage?: TraceTokenUsage | null
+  costUsd?: number | null
+}) {
+  appendCoworkTraceEventIfNew(createCoworkTraceEvent({
+    id: input.id,
+    sequence: nextCoworkTraceSequence(input.run.id),
+    runId: input.run.id,
+    runKind: 'crew',
+    source: 'opencode_event',
+    sourceEventId: input.sourceEventId,
+    correlationId: input.run.id,
+    causationId: null,
+    sessionId: input.sessionId ?? input.run.rootSessionId,
+    parentSessionId: input.parentSessionId ?? null,
+    actor: { kind: input.actorId ? 'agent' : 'opencode', id: input.actorId || 'opencode' },
+    nodeId: input.nodeId || null,
+    artifactId: input.artifactId || null,
+    approvalId: input.approvalId || null,
+    policyDecisionId: null,
+    inputHash: input.inputHash ?? null,
+    outputHash: input.outputHash ?? null,
+    payloadRef: null,
+    payloadHash: input.payloadHash ?? null,
+    redactionState: 'none',
+    tokenUsage: input.tokenUsage ?? null,
+    costUsd: input.costUsd ?? null,
+    payload: {
+      type: input.payloadType,
+      ...input.payload,
+    },
+    createdAt: new Date().toISOString(),
+  }))
+}
+
+function projectTaskRun(run: CrewRun, data: RuntimeEventData) {
+  const taskRunId = typeof data.id === 'string' && data.id ? data.id : null
+  if (!taskRunId) return
+  const node = findRunNodeForTask(run, data)
+  if (!node) return
+
+  const status = runtimeStatusToNodeStatus(data.status)
+  const sourceSessionId = typeof data.sourceSessionId === 'string' && data.sourceSessionId ? data.sourceSessionId : null
+  const agentName = typeof data.agent === 'string' && data.agent ? data.agent : node.agentName
+  const title = boundedText(data.title, node.title)
+  updateCrewRunNodeRuntimeState(node.id, {
+    status,
+    title,
+    agentName,
+    sessionId: sourceSessionId,
+  })
+  updateCrewRunStatus(run.id, status === 'failed' ? 'blocked' : 'running')
+
+  traceBase({
+    run,
+    id: traceId([run.id, 'task_run', taskRunId, String(data.status || 'running')]),
+    payloadType: 'crew_run.task_run',
+    sourceEventId: taskRunId,
+    sessionId: sourceSessionId || run.rootSessionId,
+    parentSessionId: typeof data.parentSessionId === 'string' ? data.parentSessionId : run.rootSessionId,
+    actorId: agentName,
+    nodeId: node.id,
+    payload: {
+      taskRunId,
+      title,
+      agentName,
+      status: String(data.status || 'running'),
+      sourceSessionId,
+    },
+  })
+}
+
+function projectToolCall(run: CrewRun, data: RuntimeEventData) {
+  const toolCallId = typeof data.id === 'string' && data.id ? data.id : null
+  if (!toolCallId) return
+  const node = findRunNodeForTask(run, data)
+  const sourceSessionId = typeof data.sourceSessionId === 'string' && data.sourceSessionId ? data.sourceSessionId : null
+  const agentName = typeof data.agent === 'string' && data.agent ? data.agent : node?.agentName || null
+  const toolName = boundedText(data.name, 'tool')
+  const attachments = Array.isArray(data.attachments) ? data.attachments : []
+
+  traceBase({
+    run,
+    id: traceId([run.id, 'tool_call', toolCallId, String(data.status || 'unknown')]),
+    payloadType: 'crew_run.tool_call',
+    sourceEventId: toolCallId,
+    sessionId: sourceSessionId || run.rootSessionId,
+    actorId: agentName,
+    nodeId: node?.id || null,
+    inputHash: data.input ? sha256(data.input) : null,
+    outputHash: data.output !== undefined ? sha256(data.output) : null,
+    payload: {
+      toolCallId,
+      toolName,
+      status: String(data.status || 'unknown'),
+      taskRunId: typeof data.taskRunId === 'string' ? data.taskRunId : null,
+      sourceSessionId,
+      attachmentCount: attachments.length,
+    },
+  })
+
+  attachments.forEach((attachment, index) => {
+    if (!attachment || typeof attachment !== 'object') return
+    const record = attachment as unknown as Record<string, unknown>
+    const uri = typeof record.url === 'string' ? record.url : ''
+    const mime = typeof record.mime === 'string' ? record.mime : 'application/octet-stream'
+    if (!uri) return
+    const title = boundedText(record.filename, `${toolName} artifact ${index + 1}`)
+    const artifact = createCrewArtifact({
+      id: scopedId('crew-artifact', run.id, `${toolCallId}:${index}:${uri}`),
+      crewRunId: run.id,
+      nodeId: node?.id || null,
+      title,
+      mime,
+      uri,
+      hash: sha256({ uri, mime, title }),
+    })
+    if (!artifact) return
+    traceBase({
+      run,
+      id: traceId([run.id, 'artifact', artifact.id]),
+      payloadType: 'crew_run.artifact_recorded',
+      sourceEventId: `${toolCallId}:artifact:${index}`,
+      sessionId: sourceSessionId || run.rootSessionId,
+      actorId: agentName,
+      nodeId: node?.id || null,
+      artifactId: artifact.id,
+      payloadHash: artifact.hash,
+      payload: {
+        artifactId: artifact.id,
+        title: artifact.title,
+        mime: artifact.mime,
+        sourceToolCallId: toolCallId,
+      },
+    })
+  })
+}
+
+function projectApproval(run: CrewRun, data: RuntimeEventData) {
+  const approvalSourceId = typeof data.id === 'string' && data.id ? data.id : null
+  if (!approvalSourceId) return
+  const node = findRunNodeForTask(run, data)
+  const approvalId = scopedId('crew-approval', run.id, approvalSourceId)
+  const title = boundedText(data.tool, 'Approval required')
+  const body = boundedText(data.description, title)
+  const approval = createCrewApproval({
+    id: approvalId,
+    crewRunId: run.id,
+    nodeId: node?.id || null,
+    title,
+    body,
+  })
+  if (node) updateCrewRunNodeRuntimeState(node.id, { status: 'blocked' })
+  updateCrewRunStatus(run.id, 'blocked')
+  traceBase({
+    run,
+    id: traceId([run.id, 'approval', approvalSourceId]),
+    payloadType: 'crew_run.approval_requested',
+    sourceEventId: approvalSourceId,
+    sessionId: typeof data.sourceSessionId === 'string' ? data.sourceSessionId : run.rootSessionId,
+    actorId: node?.agentName || null,
+    nodeId: node?.id || null,
+    approvalId: approval?.id || approvalId,
+    inputHash: data.input ? sha256(data.input) : null,
+    payload: {
+      approvalId,
+      title,
+      sourceApprovalId: approvalSourceId,
+      taskRunId: typeof data.taskRunId === 'string' ? data.taskRunId : null,
+    },
+  })
+}
+
+function projectApprovalResolved(run: CrewRun, data: RuntimeEventData) {
+  const approvalSourceId = typeof data.id === 'string' && data.id ? data.id : null
+  if (!approvalSourceId) return
+  const approvalId = scopedId('crew-approval', run.id, approvalSourceId)
+  const approval = getCrewApproval(approvalId)
+  if (approval?.status === 'requested') {
+    resolveCrewApproval(approvalId, data.status === 'denied' ? 'denied' : 'approved', 'opencode')
+  }
+  if (approval?.nodeId) {
+    updateCrewRunNodeRuntimeState(approval.nodeId, { status: data.status === 'denied' ? 'failed' : 'running' })
+  }
+  updateCrewRunStatus(run.id, 'running')
+  traceBase({
+    run,
+    id: traceId([run.id, 'approval_resolved', approvalSourceId]),
+    payloadType: 'crew_run.approval_resolved',
+    sourceEventId: approvalSourceId,
+    approvalId,
+    payload: {
+      approvalId,
+      status: data.status === 'denied' ? 'denied' : 'approved',
+      sourceApprovalId: approvalSourceId,
+    },
+  })
+}
+
+function projectQuestion(run: CrewRun, data: RuntimeEventData, resolved: boolean) {
+  const questionId = typeof data.id === 'string' && data.id ? data.id : null
+  if (!questionId) return
+  updateCrewRunStatus(run.id, resolved ? 'running' : 'blocked')
+  traceBase({
+    run,
+    id: traceId([run.id, resolved ? 'question_resolved' : 'question_asked', questionId]),
+    payloadType: resolved ? 'crew_run.question_resolved' : 'crew_run.question_asked',
+    sourceEventId: questionId,
+    payload: {
+      questionId,
+      questionCount: Array.isArray(data.questions) ? data.questions.length : null,
+    },
+  })
+}
+
+function projectCost(run: CrewRun, data: RuntimeEventData) {
+  const eventId = typeof data.id === 'string' && data.id ? data.id : traceId([run.id, 'cost', String(data.cost || 0)])
+  const tokens = data.tokens || {}
+  traceBase({
+    run,
+    id: traceId([run.id, 'cost', eventId]),
+    payloadType: 'crew_run.cost',
+    sourceEventId: eventId,
+    sessionId: typeof data.sourceSessionId === 'string' ? data.sourceSessionId : run.rootSessionId,
+    actorId: typeof data.agent === 'string' ? data.agent : null,
+    tokenUsage: {
+      input: Number(tokens.input || 0),
+      output: Number(tokens.output || 0),
+      reasoning: Number(tokens.reasoning || 0),
+      cacheRead: Number(tokens.cache?.read || 0),
+      cacheWrite: Number(tokens.cache?.write || 0),
+    },
+    costUsd: typeof data.cost === 'number' && Number.isFinite(data.cost) ? data.cost : null,
+    payload: {
+      taskRunId: typeof data.taskRunId === 'string' ? data.taskRunId : null,
+      sourceSessionId: typeof data.sourceSessionId === 'string' ? data.sourceSessionId : null,
+    },
+  })
+}
+
+function projectDone(run: CrewRun, data: RuntimeEventData) {
+  const nodes = listCrewRunNodes(run.id)
+  for (const node of nodes) {
+    if (node.status === 'failed' || node.status === 'completed' || node.status === 'skipped') continue
+    const unobservedAgentNode = (node.kind === 'delegate' || node.kind === 'evaluate') && node.status === 'queued' && !node.sessionId
+    updateCrewRunNodeRuntimeState(node.id, { status: unobservedAgentNode ? 'skipped' : 'completed' })
+  }
+  updateCrewRunStatus(run.id, 'completed')
+  traceBase({
+    run,
+    id: traceId([run.id, 'done', run.rootSessionId || run.id]),
+    payloadType: 'crew_run.completed',
+    sourceEventId: typeof data.id === 'string' ? data.id : null,
+    payload: {
+      rootSessionId: run.rootSessionId,
+      synthetic: Boolean(data.synthetic),
+    },
+  })
+}
+
+function projectError(run: CrewRun, data: RuntimeEventData) {
+  const node = findRunNodeForTask(run, data)
+  if (node) updateCrewRunNodeRuntimeState(node.id, { status: 'failed' })
+  const message = boundedText(data.message, 'OpenCode session failed')
+  const sourceSessionId = typeof data.sourceSessionId === 'string' && data.sourceSessionId ? data.sourceSessionId : null
+  const branchError = Boolean(data.taskRunId) || Boolean(sourceSessionId && sourceSessionId !== run.rootSessionId)
+  updateCrewRunStatus(run.id, branchError ? 'blocked' : 'failed', { summary: message })
+  traceBase({
+    run,
+    id: traceId([run.id, 'error', typeof data.taskRunId === 'string' ? data.taskRunId : run.rootSessionId || run.id]),
+    payloadType: branchError ? 'crew_run.branch_failed' : 'crew_run.failed',
+    sourceEventId: typeof data.taskRunId === 'string' ? data.taskRunId : null,
+    sessionId: sourceSessionId || run.rootSessionId,
+    actorId: node?.agentName || null,
+    nodeId: node?.id || null,
+    payload: {
+      message,
+      taskRunId: typeof data.taskRunId === 'string' ? data.taskRunId : null,
+    },
+  })
+}
+
+export function projectCrewRuntimeEvent(event: RuntimeSessionEvent) {
+  if (!event.sessionId || !event.data) return
+  const run = getCrewRunByRootSessionId(event.sessionId)
+  if (!run) return
+
+  switch (eventType(event)) {
+    case 'task_run':
+      projectTaskRun(run, event.data)
+      return
+    case 'tool_call':
+      projectToolCall(run, event.data)
+      return
+    case 'approval':
+      projectApproval(run, event.data)
+      return
+    case 'approval_resolved':
+      projectApprovalResolved(run, event.data)
+      return
+    case 'question_asked':
+      projectQuestion(run, event.data, false)
+      return
+    case 'question_resolved':
+      projectQuestion(run, event.data, true)
+      return
+    case 'cost':
+      projectCost(run, event.data)
+      return
+    case 'done':
+      projectDone(run, event.data)
+      return
+    case 'error':
+      projectError(run, event.data)
+      return
+    default:
+      return
+  }
+}

--- a/apps/desktop/src/main/crew-store.ts
+++ b/apps/desktop/src/main/crew-store.ts
@@ -708,6 +708,17 @@ export function listCrewRuns(crewId: string) {
   return rows.map(rowToCrewRun)
 }
 
+export function getCrewRunByRootSessionId(rootSessionId: string) {
+  const row = getCrewDb().prepare(`
+    select *
+    from crew_runs
+    where root_session_id = ?
+    order by created_at desc, id asc
+    limit 1
+  `).get(rootSessionId) as DbRow | undefined
+  return row ? rowToCrewRun(row) : null
+}
+
 export function updateCrewRunStatus(
   runId: string,
   status: CrewRunStatus,
@@ -813,6 +824,46 @@ export function updateCrewRunNodeStatus(
   return getCrewRunNode(nodeId)
 }
 
+export function updateCrewRunNodeRuntimeState(
+  nodeId: string,
+  patch: {
+    status?: CrewRunNodeStatus
+    title?: string | null
+    agentName?: string | null
+    sessionId?: string | null
+  },
+) {
+  const existing = getCrewRunNode(nodeId)
+  if (!existing) return null
+  const nextStatus = patch.status || existing.status
+  const now = nowIso()
+  const startedAt = existing.startedAt || (nextStatus !== 'queued' ? now : null)
+  const finishedAt = terminalCrewRunNodeStatus(nextStatus) ? (existing.finishedAt || now) : null
+  const title = patch.title ? requiredText(patch.title, 'Crew run node title') : null
+  const agentName = patch.agentName?.trim() || null
+  withCrewTransaction((db) => {
+    db.prepare(`
+      update crew_run_nodes
+      set status = ?,
+        title = coalesce(?, title),
+        agent_name = coalesce(?, agent_name),
+        session_id = coalesce(?, session_id),
+        started_at = ?,
+        finished_at = ?
+      where id = ?
+    `).run(
+      nextStatus,
+      title,
+      agentName,
+      patch.sessionId ?? null,
+      startedAt,
+      finishedAt,
+      nodeId,
+    )
+  })
+  return getCrewRunNode(nodeId)
+}
+
 export function createCoworkWorkItem(input: {
   title: string
   description: string
@@ -866,6 +917,7 @@ export function updateCoworkWorkItemStatus(id: string, status: CoworkWorkItem['s
 }
 
 export function createCrewArtifact(input: {
+  id?: string
   crewRunId: string
   nodeId?: string | null
   title: string
@@ -873,7 +925,14 @@ export function createCrewArtifact(input: {
   uri: string
   hash?: string | null
 }) {
-  const id = crypto.randomUUID()
+  const id = input.id || crypto.randomUUID()
+  const existing = getCrewArtifact(id)
+  if (existing) {
+    if (existing.crewRunId !== input.crewRunId) {
+      throw new Error(`Crew artifact ${id} belongs to a different crew run.`)
+    }
+    return existing
+  }
   const now = nowIso()
   withCrewTransaction((db) => {
     assertCrewRunExists(db, input.crewRunId)
@@ -913,12 +972,20 @@ export function listCrewArtifactsForRun(crewRunId: string) {
 }
 
 export function createCrewApproval(input: {
+  id?: string
   crewRunId: string
   nodeId?: string | null
   title: string
   body: string
 }) {
-  const id = crypto.randomUUID()
+  const id = input.id || crypto.randomUUID()
+  const existing = getCrewApproval(id)
+  if (existing) {
+    if (existing.crewRunId !== input.crewRunId) {
+      throw new Error(`Crew approval ${id} belongs to a different crew run.`)
+    }
+    return existing
+  }
   const now = nowIso()
   withCrewTransaction((db) => {
     assertCrewRunExists(db, input.crewRunId)
@@ -1254,6 +1321,58 @@ export function appendCoworkTraceEvent(event: CoworkTraceEvent) {
     )
   })
   return event
+}
+
+export function appendCoworkTraceEventIfNew(event: CoworkTraceEvent) {
+  if (event.schemaVersion !== COWORK_TRACE_EVENT_SCHEMA_VERSION) {
+    throw new Error(`Unsupported trace event schema version ${event.schemaVersion}.`)
+  }
+
+  withCrewTransaction((db) => {
+    db.prepare(`
+      insert or ignore into crew_trace_events (
+        id, schema_version, sequence, run_id, run_kind, source, source_event_id,
+        correlation_id, causation_id, session_id, parent_session_id,
+        actor_kind, actor_id, node_id, artifact_id, approval_id,
+        policy_decision_id, input_hash, output_hash, payload_ref, payload_hash,
+        redaction_state, token_usage_json, cost_usd, payload_json, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      event.id,
+      event.schemaVersion,
+      event.sequence,
+      event.runId,
+      event.runKind,
+      event.source,
+      event.sourceEventId,
+      event.correlationId,
+      event.causationId,
+      event.sessionId,
+      event.parentSessionId,
+      event.actor.kind,
+      event.actor.id,
+      event.nodeId,
+      event.artifactId,
+      event.approvalId,
+      event.policyDecisionId,
+      event.inputHash,
+      event.outputHash,
+      event.payloadRef,
+      event.payloadHash,
+      event.redactionState,
+      event.tokenUsage ? JSON.stringify(event.tokenUsage) : null,
+      event.costUsd,
+      event.payload ? JSON.stringify(event.payload) : null,
+      event.createdAt,
+    )
+  })
+  return event
+}
+
+export function nextCoworkTraceSequence(runId: string) {
+  const row = getCrewDb().prepare('select max(sequence) as sequence from crew_trace_events where run_id = ?')
+    .get(runId) as { sequence?: number | null } | undefined
+  return Number(row?.sequence || 0) + 1
 }
 
 export function listCoworkTraceEventsForRun(runId: string) {

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -3,6 +3,7 @@ import type { MessageAttachment, RuntimeNotification, SessionPatch, TodoItem } f
 import { log } from './logger.ts'
 import { shortSessionId } from './log-sanitizer.ts'
 import { incrementPerfCounter, measureAsyncPerf, measurePerf, observePerf } from './perf-metrics.ts'
+import { projectCrewRuntimeEvent } from './crew-runtime-projector.ts'
 import { sessionEngine } from './session-engine.ts'
 import { getThreadIndexService } from './thread-index-service.ts'
 
@@ -288,6 +289,12 @@ export function dispatchRuntimeSessionEvent(
 ) {
   const eventType = getEventType(event)
   sessionEngine.applyStreamEvent(event)
+  try {
+    projectCrewRuntimeEvent(event)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || 'Unknown error')
+    log('error', `Crew runtime projection failed: ${message}`)
+  }
   if (event.sessionId) {
     getThreadIndexService().scheduleThreadMetadataRefresh(event.sessionId)
   }

--- a/tests/crew-runtime-projector.test.ts
+++ b/tests/crew-runtime-projector.test.ts
@@ -1,0 +1,320 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { CrewDefinitionDraft } from '../packages/shared/src/crews.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  clearCrewStoreCache,
+  getCrewRun,
+  listCoworkTraceEventsForRun,
+  listCrewApprovalsForRun,
+  listCrewArtifactsForRun,
+  listCrewRunNodes,
+  updateCrewRunNodeStatus,
+  updateCrewRunStatus,
+} from '../apps/desktop/src/main/crew-store.ts'
+import { projectCrewRuntimeEvent } from '../apps/desktop/src/main/crew-runtime-projector.ts'
+import { createCrewFromDraft, startCrewRun } from '../apps/desktop/src/main/crew-service.ts'
+
+function uniqueUserDataDir(name: string) {
+  return mkdtempSync(join(tmpdir(), `open-cowork-crew-projector-${name}-`))
+}
+
+function resetCrewStore(userDataDir: string) {
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+  clearCrewStoreCache()
+}
+
+function withCrewStore<T>(name: string, callback: () => T): T {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    resetCrewStore(userDataDir)
+    return callback()
+  } finally {
+    clearCrewStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+function draft(): CrewDefinitionDraft {
+  return {
+    name: 'Research Crew',
+    description: 'Lead, specialists, and evaluator.',
+    members: [
+      { role: 'lead', agentName: 'research-lead', displayName: 'Research Lead' },
+      { role: 'specialist', agentName: 'analyst', displayName: 'Analyst' },
+      { role: 'specialist', agentName: 'charts', displayName: 'Charts' },
+      { role: 'evaluator', agentName: 'evaluator', displayName: 'Evaluator' },
+    ],
+    workspaceProfileId: 'workspace-default',
+    outcomeRubricId: 'rubric-default',
+    budgetCapUsd: 4,
+  }
+}
+
+function startRootedCrewRun() {
+  const crew = createCrewFromDraft(draft())
+  const detail = startCrewRun({
+    crewId: crew.definition.id,
+    title: 'Analyze the weekly market',
+    workItemTitle: 'Weekly market research',
+  })
+  updateCrewRunStatus(detail.run.id, 'running', { rootSessionId: 'root-session' })
+  const plan = listCrewRunNodes(detail.run.id).find((node) => node.kind === 'plan')
+  assert.ok(plan)
+  updateCrewRunNodeStatus(plan.id, 'running', { sessionId: 'root-session' })
+  return detail.run.id
+}
+
+test('crew runtime projector maps OpenCode task runs onto configured crew nodes', () => withCrewStore('task-run', () => {
+  const crew = createCrewFromDraft(draft())
+  const detail = startCrewRun({
+    crewId: crew.definition.id,
+    title: 'Analyze the weekly market',
+    workItemTitle: 'Weekly market research',
+  })
+  updateCrewRunStatus(detail.run.id, 'running', { rootSessionId: 'root-session' })
+  const plan = listCrewRunNodes(detail.run.id).find((node) => node.kind === 'plan')
+  assert.ok(plan)
+  updateCrewRunNodeStatus(plan.id, 'running', { sessionId: 'root-session' })
+
+  projectCrewRuntimeEvent({
+    type: 'task_run',
+    sessionId: 'root-session',
+    data: {
+      type: 'task_run',
+      id: 'task-analyst',
+      title: 'Analyze conversion metrics',
+      agent: 'analyst',
+      status: 'running',
+      sourceSessionId: 'child-analyst',
+      parentSessionId: 'root-session',
+    },
+  })
+
+  let analyst = listCrewRunNodes(detail.run.id).find((node) => node.agentName === 'analyst')
+  assert.equal(analyst?.status, 'running')
+  assert.equal(analyst?.sessionId, 'child-analyst')
+
+  projectCrewRuntimeEvent({
+    type: 'task_run',
+    sessionId: 'root-session',
+    data: {
+      type: 'task_run',
+      id: 'task-analyst',
+      title: 'Analyze conversion metrics',
+      agent: 'analyst',
+      status: 'complete',
+      sourceSessionId: 'child-analyst',
+      parentSessionId: 'root-session',
+    },
+  })
+
+  analyst = listCrewRunNodes(detail.run.id).find((node) => node.agentName === 'analyst')
+  assert.equal(analyst?.status, 'completed')
+  const traces = listCoworkTraceEventsForRun(detail.run.id).filter((event) => event.payload?.type === 'crew_run.task_run')
+  assert.equal(traces.length, 2)
+  assert.equal(traces[0]?.nodeId, analyst?.id)
+  assert.equal(traces[0]?.payload?.taskRunId, 'task-analyst')
+}))
+
+test('crew runtime projector traces tool calls without persisting raw tool payloads', () => withCrewStore('tool-call', () => {
+  const crew = createCrewFromDraft(draft())
+  const detail = startCrewRun({
+    crewId: crew.definition.id,
+    title: 'Analyze the weekly market',
+  })
+  updateCrewRunStatus(detail.run.id, 'running', { rootSessionId: 'root-session' })
+
+  projectCrewRuntimeEvent({
+    type: 'task_run',
+    sessionId: 'root-session',
+    data: {
+      type: 'task_run',
+      id: 'task-charts',
+      title: 'Build charts',
+      agent: 'charts',
+      status: 'running',
+      sourceSessionId: 'child-charts',
+      parentSessionId: 'root-session',
+    },
+  })
+
+  const toolEvent = {
+    type: 'tool_call',
+    sessionId: 'root-session',
+    data: {
+      type: 'tool_call',
+      id: 'tool-1',
+      name: 'chart.create',
+      input: { rows: [{ date: '2026-05-01', sessions: 123 }] },
+      status: 'completed',
+      output: { html: '<div>chart</div>' },
+      agent: 'charts',
+      taskRunId: 'task-charts',
+      sourceSessionId: 'child-charts',
+      attachments: [{ mime: 'text/html', url: 'artifact://chart-1', filename: 'chart.html' }],
+    },
+  } as const
+  projectCrewRuntimeEvent(toolEvent)
+  projectCrewRuntimeEvent(toolEvent)
+
+  const traces = listCoworkTraceEventsForRun(detail.run.id).filter((event) => event.payload?.type === 'crew_run.tool_call')
+  assert.equal(traces.length, 1)
+  assert.equal(traces[0]?.inputHash?.startsWith('sha256:'), true)
+  assert.equal(traces[0]?.outputHash?.startsWith('sha256:'), true)
+  assert.equal(Object.hasOwn(traces[0]?.payload || {}, 'input'), false)
+  assert.equal(Object.hasOwn(traces[0]?.payload || {}, 'output'), false)
+  assert.equal(traces[0]?.payload?.attachmentCount, 1)
+
+  const artifacts = listCrewArtifactsForRun(detail.run.id)
+  assert.equal(artifacts.length, 1)
+  assert.equal(artifacts[0]?.title, 'chart.html')
+  assert.equal(artifacts[0]?.uri, 'artifact://chart-1')
+}))
+
+test('crew runtime projector records approvals idempotently and unblocks on resolution', () => withCrewStore('approval', () => {
+  const crew = createCrewFromDraft(draft())
+  const detail = startCrewRun({
+    crewId: crew.definition.id,
+    title: 'Analyze the weekly market',
+  })
+  updateCrewRunStatus(detail.run.id, 'running', { rootSessionId: 'root-session' })
+
+  projectCrewRuntimeEvent({
+    type: 'task_run',
+    sessionId: 'root-session',
+    data: {
+      type: 'task_run',
+      id: 'task-analyst',
+      title: 'Analyze private files',
+      agent: 'analyst',
+      status: 'running',
+      sourceSessionId: 'child-analyst',
+      parentSessionId: 'root-session',
+    },
+  })
+
+  const approvalEvent = {
+    type: 'approval',
+    sessionId: 'root-session',
+    data: {
+      type: 'approval',
+      id: 'approval-1',
+      taskRunId: 'task-analyst',
+      tool: 'bash',
+      input: { cmd: 'cat private.csv' },
+      description: 'Analyst: bash',
+      sourceSessionId: 'child-analyst',
+    },
+  } as const
+  projectCrewRuntimeEvent(approvalEvent)
+  projectCrewRuntimeEvent(approvalEvent)
+
+  let approvals = listCrewApprovalsForRun(detail.run.id)
+  assert.equal(approvals.length, 1)
+  assert.equal(approvals[0]?.status, 'requested')
+  assert.equal(listCrewRunNodes(detail.run.id).find((node) => node.agentName === 'analyst')?.status, 'blocked')
+
+  projectCrewRuntimeEvent({
+    type: 'approval_resolved',
+    sessionId: 'root-session',
+    data: {
+      type: 'approval_resolved',
+      id: 'approval-1',
+      status: 'approved',
+    },
+  })
+
+  approvals = listCrewApprovalsForRun(detail.run.id)
+  assert.equal(approvals[0]?.status, 'approved')
+  assert.equal(listCrewRunNodes(detail.run.id).find((node) => node.agentName === 'analyst')?.status, 'running')
+  assert.equal(listCoworkTraceEventsForRun(detail.run.id).filter((event) => event.payload?.type === 'crew_run.approval_requested').length, 1)
+  assert.equal(listCoworkTraceEventsForRun(detail.run.id).filter((event) => event.payload?.type === 'crew_run.approval_resolved').length, 1)
+}))
+
+test('crew runtime projector keeps a ten-agent run inspectable from product graph state', () => withCrewStore('ten-agent', () => {
+  const runId = startRootedCrewRun()
+  for (let index = 0; index < 10; index += 1) {
+    projectCrewRuntimeEvent({
+      type: 'task_run',
+      sessionId: 'root-session',
+      data: {
+        type: 'task_run',
+        id: `task-${index}`,
+        title: `Specialist branch ${index}`,
+        agent: `specialist-${index}`,
+        status: 'running',
+        sourceSessionId: `child-${index}`,
+        parentSessionId: 'root-session',
+      },
+    })
+  }
+
+  const dynamicNodes = listCrewRunNodes(runId).filter((node) => node.agentName?.startsWith('specialist-'))
+  assert.equal(dynamicNodes.length, 10)
+  assert.equal(dynamicNodes.every((node) => node.status === 'running' && node.sessionId?.startsWith('child-')), true)
+  assert.equal(listCoworkTraceEventsForRun(runId).filter((event) => event.payload?.type === 'crew_run.task_run').length, 10)
+}))
+
+test('crew runtime projector completes the crew run from root done events', () => withCrewStore('done', () => {
+  const crew = createCrewFromDraft(draft())
+  const detail = startCrewRun({
+    crewId: crew.definition.id,
+    title: 'Analyze the weekly market',
+  })
+  updateCrewRunStatus(detail.run.id, 'running', { rootSessionId: 'root-session' })
+
+  projectCrewRuntimeEvent({
+    type: 'done',
+    sessionId: 'root-session',
+    data: { type: 'done' },
+  })
+
+  const nodes = listCrewRunNodes(detail.run.id)
+  assert.equal(nodes.find((node) => node.kind === 'plan')?.status, 'completed')
+  assert.equal(nodes.find((node) => node.kind === 'join')?.status, 'completed')
+  assert.equal(nodes.find((node) => node.kind === 'deliver')?.status, 'completed')
+  assert.equal(nodes.filter((node) => node.kind === 'delegate' || node.kind === 'evaluate').every((node) => node.status === 'skipped'), true)
+  assert.equal(getCrewRun(detail.run.id)?.status, 'completed')
+  assert.equal(listCoworkTraceEventsForRun(detail.run.id).at(-1)?.payload?.type, 'crew_run.completed')
+}))
+
+test('crew runtime projector treats child-session errors as blockers instead of root run crashes', () => withCrewStore('branch-error', () => {
+  const runId = startRootedCrewRun()
+  projectCrewRuntimeEvent({
+    type: 'task_run',
+    sessionId: 'root-session',
+    data: {
+      type: 'task_run',
+      id: 'task-analyst',
+      title: 'Analyze source data',
+      agent: 'analyst',
+      status: 'running',
+      sourceSessionId: 'child-analyst',
+      parentSessionId: 'root-session',
+    },
+  })
+
+  projectCrewRuntimeEvent({
+    type: 'error',
+    sessionId: 'root-session',
+    data: {
+      type: 'error',
+      message: 'CSV parse failed',
+      taskRunId: 'task-analyst',
+      sourceSessionId: 'child-analyst',
+    },
+  })
+
+  assert.equal(getCrewRun(runId)?.status, 'blocked')
+  assert.equal(listCrewRunNodes(runId).find((node) => node.agentName === 'analyst')?.status, 'failed')
+  assert.equal(listCoworkTraceEventsForRun(runId).at(-1)?.payload?.type, 'crew_run.branch_failed')
+}))

--- a/tests/crew-runtime-projector.test.ts
+++ b/tests/crew-runtime-projector.test.ts
@@ -240,6 +240,55 @@ test('crew runtime projector records approvals idempotently and unblocks on reso
   assert.equal(listCoworkTraceEventsForRun(detail.run.id).filter((event) => event.payload?.type === 'crew_run.approval_resolved').length, 1)
 }))
 
+test('crew runtime projector keeps a denied approval blocked instead of reopening the run', () => withCrewStore('approval-denied', () => {
+  const crew = createCrewFromDraft(draft())
+  const detail = startCrewRun({
+    crewId: crew.definition.id,
+    title: 'Analyze the weekly market',
+  })
+  updateCrewRunStatus(detail.run.id, 'running', { rootSessionId: 'root-session' })
+
+  projectCrewRuntimeEvent({
+    type: 'task_run',
+    sessionId: 'root-session',
+    data: {
+      type: 'task_run',
+      id: 'task-analyst',
+      title: 'Analyze private files',
+      agent: 'analyst',
+      status: 'running',
+      sourceSessionId: 'child-analyst',
+      parentSessionId: 'root-session',
+    },
+  })
+  projectCrewRuntimeEvent({
+    type: 'approval',
+    sessionId: 'root-session',
+    data: {
+      type: 'approval',
+      id: 'approval-denied',
+      taskRunId: 'task-analyst',
+      tool: 'bash',
+      input: { cmd: 'cat private.csv' },
+      description: 'Analyst: bash',
+      sourceSessionId: 'child-analyst',
+    },
+  })
+  projectCrewRuntimeEvent({
+    type: 'approval_resolved',
+    sessionId: 'root-session',
+    data: {
+      type: 'approval_resolved',
+      id: 'approval-denied',
+      status: 'denied',
+    },
+  })
+
+  assert.equal(getCrewRun(detail.run.id)?.status, 'blocked')
+  assert.equal(listCrewRunNodes(detail.run.id).find((node) => node.agentName === 'analyst')?.status, 'failed')
+  assert.equal(listCrewApprovalsForRun(detail.run.id)[0]?.status, 'denied')
+}))
+
 test('crew runtime projector keeps a ten-agent run inspectable from product graph state', () => withCrewStore('ten-agent', () => {
   const runId = startRootedCrewRun()
   for (let index = 0; index < 10; index += 1) {
@@ -317,4 +366,20 @@ test('crew runtime projector treats child-session errors as blockers instead of 
   assert.equal(getCrewRun(runId)?.status, 'blocked')
   assert.equal(listCrewRunNodes(runId).find((node) => node.agentName === 'analyst')?.status, 'failed')
   assert.equal(listCoworkTraceEventsForRun(runId).at(-1)?.payload?.type, 'crew_run.branch_failed')
+
+  projectCrewRuntimeEvent({
+    type: 'task_run',
+    sessionId: 'root-session',
+    data: {
+      type: 'task_run',
+      id: 'task-charts',
+      title: 'Build charts',
+      agent: 'charts',
+      status: 'complete',
+      sourceSessionId: 'child-charts',
+      parentSessionId: 'root-session',
+    },
+  })
+
+  assert.equal(getCrewRun(runId)?.status, 'blocked')
 }))


### PR DESCRIPTION
## Summary
- add a Crew runtime projector that observes normalized OpenCode runtime events and projects them into Crew run nodes and trace events
- persist idempotent Crew approvals/artifacts from runtime events without storing raw tool inputs or outputs in trace payloads
- keep branch failures as visible blockers while reserving Crew run failure for root OpenCode errors

## Roadmap
- Advances #245 by making Crew runs inspectable from product trace/graph state over OpenCode-native execution
- Preserves the #243 boundary: OpenCode executes; Open Cowork projects accountable product state

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/crew-runtime-projector.test.ts tests/crew-store.test.ts tests/crew-service.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --filter @open-cowork/desktop test:renderer -- --run
- pnpm test:e2e
- git diff --check