### PR TITLE
[codex] add crew run operational detail view

### DIFF
--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -67,41 +67,112 @@ const runDetail: CrewRunDetail = {
   version,
   workItem: null,
   nodes: [
-    { schemaVersion: 1, id: 'node-plan', crewRunId: run.id, sequence: 1, kind: 'plan', status: 'queued', agentName: 'plan', sessionId: null, parentNodeId: null, title: 'Plan work', startedAt: null, finishedAt: null },
-    { schemaVersion: 1, id: 'node-delegate', crewRunId: run.id, sequence: 2, kind: 'delegate', status: 'queued', agentName: 'explore', sessionId: null, parentNodeId: 'node-plan', title: 'Delegate to Explorer', startedAt: null, finishedAt: null },
+    { schemaVersion: 1, id: 'node-plan', crewRunId: run.id, sequence: 1, kind: 'plan', status: 'running', agentName: 'plan', sessionId: 'session-root', parentNodeId: null, title: 'Plan work', startedAt: null, finishedAt: null },
+    { schemaVersion: 1, id: 'node-delegate', crewRunId: run.id, sequence: 2, kind: 'delegate', status: 'blocked', agentName: 'explore', sessionId: 'session-child', parentNodeId: 'node-plan', title: 'Delegate to Explorer', startedAt: null, finishedAt: null },
     { schemaVersion: 1, id: 'node-join', crewRunId: run.id, sequence: 3, kind: 'join', status: 'queued', agentName: null, sessionId: null, parentNodeId: 'node-plan', title: 'Join specialist outputs', startedAt: null, finishedAt: null },
   ],
-  artifacts: [],
-  approvals: [],
-  policyDecisions: [],
-  evaluations: [],
-  traceEvents: [{
+  artifacts: [{
     schemaVersion: 1,
-    id: 'trace-1',
-    sequence: 1,
+    id: 'artifact-1',
+    crewRunId: run.id,
+    nodeId: 'node-delegate',
+    title: 'Research notes',
+    mime: 'text/markdown',
+    uri: 'artifact://research-notes',
+    hash: 'sha256:artifact',
+    createdAt: '2026-05-10T00:02:00.000Z',
+  }],
+  approvals: [{
+    schemaVersion: 1,
+    id: 'approval-1',
+    crewRunId: run.id,
+    nodeId: 'node-delegate',
+    status: 'requested',
+    title: 'Approve external lookup',
+    body: 'Explorer needs approval before continuing.',
+    requestedAt: '2026-05-10T00:02:10.000Z',
+    resolvedAt: null,
+    resolvedBy: null,
+  }],
+  policyDecisions: [{
+    schemaVersion: 1,
+    id: 'policy-1',
     runId: run.id,
     runKind: 'crew',
-    source: 'cowork_worker',
-    sourceEventId: null,
-    correlationId: run.id,
-    causationId: null,
-    sessionId: null,
-    parentSessionId: null,
-    actor: { kind: 'crew', id: crew.id },
-    nodeId: null,
-    artifactId: null,
-    approvalId: null,
-    policyDecisionId: null,
-    inputHash: null,
-    outputHash: null,
-    payloadRef: null,
-    payloadHash: null,
-    redactionState: 'none',
-    tokenUsage: null,
-    costUsd: null,
-    payload: { type: 'crew_run.created' },
-    createdAt: '2026-05-10T00:01:00.000Z',
+    nodeId: 'node-delegate',
+    status: 'approval_required',
+    reason: 'External read needs review.',
+    capabilityId: 'web',
+    createdAt: '2026-05-10T00:02:05.000Z',
   }],
+  evaluations: [{
+    schemaVersion: 1,
+    id: 'eval-1',
+    crewRunId: run.id,
+    evaluatorAgentName: 'general',
+    rubricId: 'rubric-1',
+    status: 'needs_revision',
+    score: 72,
+    evidenceTraceEventIds: ['trace-1'],
+    recommendation: 'revise',
+    createdAt: '2026-05-10T00:03:00.000Z',
+  }],
+  traceEvents: [
+    {
+      schemaVersion: 1,
+      id: 'trace-1',
+      sequence: 1,
+      runId: run.id,
+      runKind: 'crew',
+      source: 'cowork_worker',
+      sourceEventId: null,
+      correlationId: run.id,
+      causationId: null,
+      sessionId: null,
+      parentSessionId: null,
+      actor: { kind: 'crew', id: crew.id },
+      nodeId: null,
+      artifactId: null,
+      approvalId: null,
+      policyDecisionId: null,
+      inputHash: null,
+      outputHash: null,
+      payloadRef: null,
+      payloadHash: null,
+      redactionState: 'none',
+      tokenUsage: null,
+      costUsd: null,
+      payload: { type: 'crew_run.created' },
+      createdAt: '2026-05-10T00:01:00.000Z',
+    },
+    {
+      schemaVersion: 1,
+      id: 'trace-2',
+      sequence: 2,
+      runId: run.id,
+      runKind: 'crew',
+      source: 'opencode_event',
+      sourceEventId: 'tool-1',
+      correlationId: run.id,
+      causationId: null,
+      sessionId: 'session-child',
+      parentSessionId: 'session-root',
+      actor: { kind: 'agent', id: 'explore' },
+      nodeId: 'node-delegate',
+      artifactId: null,
+      approvalId: null,
+      policyDecisionId: null,
+      inputHash: 'sha256:input',
+      outputHash: 'sha256:output',
+      payloadRef: null,
+      payloadHash: null,
+      redactionState: 'none',
+      tokenUsage: { input: 10, output: 20, reasoning: 5, cacheRead: 0, cacheWrite: 0 },
+      costUsd: 0.12,
+      payload: { type: 'crew_run.tool_call', toolName: 'web_search', status: 'completed' },
+      createdAt: '2026-05-10T00:02:00.000Z',
+    },
+  ],
 }
 
 function payload(): CrewListPayload {
@@ -111,7 +182,7 @@ function payload(): CrewListPayload {
 }
 
 describe('CrewsPage', () => {
-  it('loads crew detail and renders run nodes plus trace timeline', async () => {
+  it('loads crew detail and renders operational run panels from trace state', async () => {
     installRendererTestCoworkApi({
       crews: {
         list: vi.fn(async () => payload()),
@@ -126,6 +197,12 @@ describe('CrewsPage', () => {
     expect(screen.getByText('Plan work')).toBeInTheDocument()
     expect(screen.getByText('Delegate to Explorer')).toBeInTheDocument()
     expect(screen.getByText('crew_run.created')).toBeInTheDocument()
+    expect(screen.getByText('Authority')).toBeInTheDocument()
+    expect(screen.getByText('Needs attention')).toBeInTheDocument()
+    expect(screen.getAllByText('Approve external lookup').length).toBeGreaterThan(0)
+    expect(screen.getByText('Research notes')).toBeInTheDocument()
+    expect(screen.getByText('web_search')).toBeInTheDocument()
+    expect(screen.getByText('Quality gate')).toBeInTheDocument()
   })
 
   it('creates the research crew and starts the MVP run', async () => {
@@ -158,5 +235,29 @@ describe('CrewsPage', () => {
       crewId: crew.id,
       title: 'Research crew demo run',
     })))
+  })
+
+  it('exports trace events as deterministic NDJSON through the save dialog', async () => {
+    const user = userEvent.setup()
+    const saveText = vi.fn(async (_defaultFilename: string, _content: string) => '/tmp/crew-trace.ndjson')
+    installRendererTestCoworkApi({
+      crews: {
+        list: vi.fn(async () => payload()),
+        get: vi.fn(async () => detail),
+        runDetail: vi.fn(async () => runDetail),
+      },
+      dialog: {
+        saveText,
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Export trace' }))
+
+    await waitFor(() => expect(saveText).toHaveBeenCalledTimes(1))
+    expect(saveText.mock.calls[0]?.[0]).toBe('research-crew-demo-run-trace.ndjson')
+    expect(saveText.mock.calls[0]?.[1]).toContain('"id":"trace-1"')
+    expect(saveText.mock.calls[0]?.[1]).toContain('"type":"crew_run.tool_call"')
   })
 })

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { CrewDetail, CrewListItem, CrewRunDetail } from '@open-cowork/shared'
+import { serializeCoworkTraceEvent, sortCoworkTraceEvents, type CrewDetail, type CrewListItem, type CrewRunDetail } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
+import {
+  nodeLabelForTrace,
+  nodeOperationalDetails,
+  summarizeCrewRun,
+  tracePayloadType,
+  traceToolName,
+} from './crew-run-detail-utils'
 
 const RESEARCH_CREW_MEMBERS = [
   { role: 'lead' as const, agentName: 'plan', displayName: 'Planner', description: 'Decomposes the work and keeps the run scoped.' },
@@ -14,6 +21,31 @@ function formatTime(value: string | null) {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function formatMoney(value: number) {
+  if (!value) return '$0.00'
+  return value < 0.01 ? '<$0.01' : `$${value.toFixed(2)}`
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat().format(value)
+}
+
+function statusTone(status: string) {
+  if (status === 'completed' || status === 'passed' || status === 'allowed' || status === 'approved') return 'border-emerald-400/30 bg-emerald-500/10 text-emerald-200'
+  if (status === 'failed' || status === 'denied' || status === 'needs_human') return 'border-red-400/30 bg-red-500/10 text-red-100'
+  if (status === 'blocked' || status === 'requested' || status === 'needs_revision' || status === 'approval_required') return 'border-amber-400/30 bg-amber-500/10 text-amber-100'
+  if (status === 'running' || status === 'evaluating' || status === 'planning') return 'border-cyan-400/30 bg-cyan-500/10 text-cyan-100'
+  return 'border-border-subtle bg-elevated text-text-secondary'
+}
+
+function StatusPill({ value }: { value: string }) {
+  return (
+    <span className={`inline-flex rounded border px-2 py-1 text-[10px] font-semibold uppercase tracking-widest ${statusTone(value)}`}>
+      {value.replaceAll('_', ' ')}
+    </span>
+  )
 }
 
 function CrewCard({ item, selected, onSelect }: { item: CrewListItem; selected: boolean; onSelect: () => void }) {
@@ -42,17 +74,186 @@ function CrewCard({ item, selected, onSelect }: { item: CrewListItem; selected: 
   )
 }
 
-function NodeLane({ detail }: { detail: CrewRunDetail }) {
+function MetricTile({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <div className="grid gap-2 lg:grid-cols-6">
-      {detail.nodes.map((node) => (
-        <div key={node.id} className="min-h-[116px] rounded-lg border border-border-subtle bg-elevated px-3 py-3">
+    <div className="rounded-md border border-border-subtle bg-elevated px-3 py-2">
+      <div className="text-[17px] font-semibold text-text">{value}</div>
+      <div className="mt-1 text-[10px] uppercase tracking-widest text-text-muted">{label}</div>
+      {hint ? <div className="mt-1 text-[11px] text-text-muted">{hint}</div> : null}
+    </div>
+  )
+}
+
+function RunOverview({ detail }: { detail: CrewRunDetail }) {
+  const summary = summarizeCrewRun(detail)
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <MetricTile label="Agents active" value={String(summary.activeAgents)} hint={`${summary.completedNodes} nodes complete`} />
+      <MetricTile label="Blockers" value={String(summary.blockedAgents)} hint={summary.pendingApprovals ? `${summary.pendingApprovals} approvals waiting` : 'No pending approvals'} />
+      <MetricTile label="Tool calls" value={String(summary.toolCallCount)} hint={`${summary.artifactCount} artifacts`} />
+      <MetricTile label="Cost" value={formatMoney(summary.totalCostUsd)} hint={summary.hasTokenUsage ? `${formatNumber(summary.tokenTotal)} tokens` : 'No token events yet'} />
+    </div>
+  )
+}
+
+function AuthorityPanel({ detail }: { detail: CrewRunDetail }) {
+  const decisions = detail.policyDecisions
+  const version = detail.version
+  return (
+    <div className="rounded-lg border border-border-subtle bg-surface p-5">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-widest text-text-muted">Authority</div>
+          <div className="mt-1 text-[13px] text-text-secondary">Workspace, budget, policy, and root OpenCode session for this run.</div>
+        </div>
+        <StatusPill value={detail.run.status} />
+      </div>
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+        <MetricTile label="Workspace" value={version.workspaceProfileId || 'Default'} hint="Crew workspace profile" />
+        <MetricTile label="Budget cap" value={version.budgetCapUsd ? formatMoney(version.budgetCapUsd) : 'None'} hint="Run cost guardrail" />
+        <MetricTile label="Policy decisions" value={String(decisions.length)} hint={decisions.length ? decisions.map((decision) => decision.status.replaceAll('_', ' ')).join(', ') : 'No decisions yet'} />
+        <MetricTile label="Root session" value={detail.run.rootSessionId ? detail.run.rootSessionId.slice(0, 8) : 'Pending'} hint="OpenCode execution source" />
+      </div>
+    </div>
+  )
+}
+
+function BlockerPanel({ detail }: { detail: CrewRunDetail }) {
+  const summary = summarizeCrewRun(detail)
+  if (summary.blockerLabels.length === 0) {
+    return (
+      <div className="rounded-lg border border-border-subtle bg-surface p-4 text-[13px] text-text-secondary">
+        No active blockers. Approval requests, failed nodes, and failed evals will appear here.
+      </div>
+    )
+  }
+  return (
+    <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 p-4">
+      <div className="text-[12px] font-semibold uppercase tracking-widest text-amber-100">Needs attention</div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {summary.blockerLabels.map((label) => (
+          <span key={label} className="rounded-full border border-amber-300/30 px-3 py-1 text-[12px] text-amber-50">{label}</span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function NodeSwimlanes({ detail }: { detail: CrewRunDetail }) {
+  const nodes = nodeOperationalDetails(detail)
+  return (
+    <div className="grid gap-3 xl:grid-cols-3">
+      {nodes.map(({ node, events, toolCalls, artifacts, approvals, evaluations }) => (
+        <div key={node.id} className="min-h-[154px] rounded-lg border border-border-subtle bg-elevated px-3 py-3">
           <div className="text-[10px] font-semibold uppercase tracking-widest text-accent">{node.kind}</div>
-          <div className="mt-2 text-[13px] font-semibold text-text">{node.title}</div>
+          <div className="mt-2 text-[14px] font-semibold text-text">{node.title}</div>
           <div className="mt-1 text-[12px] text-text-secondary">{node.agentName || 'System step'}</div>
-          <div className="mt-3 inline-flex rounded border border-border-subtle px-2 py-1 text-[11px] text-text-muted">{node.status}</div>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <StatusPill value={node.status} />
+            {node.sessionId ? <span className="text-[11px] text-text-muted">session {node.sessionId.slice(0, 8)}</span> : null}
+          </div>
+          <div className="mt-4 grid grid-cols-4 gap-2 text-center">
+            <MetricTile label="Events" value={String(events.length)} />
+            <MetricTile label="Tools" value={String(toolCalls.length)} />
+            <MetricTile label="Files" value={String(artifacts.length)} />
+            <MetricTile label="Gates" value={String(approvals.length + evaluations.length)} />
+          </div>
         </div>
       ))}
+    </div>
+  )
+}
+
+function ToolCallsPanel({ detail }: { detail: CrewRunDetail }) {
+  const toolCalls = detail.traceEvents.filter((event) => tracePayloadType(event) === 'crew_run.tool_call')
+  return (
+    <div className="rounded-lg border border-border-subtle bg-surface p-5">
+      <div className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-text-muted">Tool calls</div>
+      {toolCalls.length === 0 ? <div className="text-[13px] text-text-secondary">No tool calls recorded yet.</div> : null}
+      <div className="space-y-2">
+        {toolCalls.map((event) => (
+          <div key={event.id} className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border-subtle bg-elevated px-3 py-2">
+            <div>
+              <div className="text-[13px] font-semibold text-text">{traceToolName(event)}</div>
+              <div className="mt-1 text-[11px] text-text-muted">{nodeLabelForTrace(detail, event)} · {formatTime(event.createdAt)}</div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {event.inputHash ? <span className="text-[10px] text-text-muted">input hashed</span> : null}
+              {event.outputHash ? <span className="text-[10px] text-text-muted">output hashed</span> : null}
+              <StatusPill value={typeof event.payload?.status === 'string' ? event.payload.status : 'recorded'} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ApprovalsArtifactsPanel({ detail }: { detail: CrewRunDetail }) {
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      <div className="rounded-lg border border-border-subtle bg-surface p-5">
+        <div className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-text-muted">Approvals</div>
+        {detail.approvals.length === 0 ? <div className="text-[13px] text-text-secondary">No approval gates recorded yet.</div> : null}
+        <div className="space-y-2">
+          {detail.approvals.map((approval) => (
+            <div key={approval.id} className="rounded-md border border-border-subtle bg-elevated px-3 py-2">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-[13px] font-semibold text-text">{approval.title}</div>
+                  <div className="mt-1 text-[11px] text-text-muted">{formatTime(approval.requestedAt)}</div>
+                </div>
+                <StatusPill value={approval.status} />
+              </div>
+              <div className="mt-2 line-clamp-2 text-[12px] text-text-secondary">{approval.body}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="rounded-lg border border-border-subtle bg-surface p-5">
+        <div className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-text-muted">Artifacts</div>
+        {detail.artifacts.length === 0 ? <div className="text-[13px] text-text-secondary">No artifacts recorded yet.</div> : null}
+        <div className="space-y-2">
+          {detail.artifacts.map((artifact) => (
+            <div key={artifact.id} className="rounded-md border border-border-subtle bg-elevated px-3 py-2">
+              <div className="text-[13px] font-semibold text-text">{artifact.title}</div>
+              <div className="mt-1 text-[11px] text-text-muted">{artifact.mime} · {artifact.hash ? 'hashed' : 'no hash'} · {formatTime(artifact.createdAt)}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EvaluationPanel({ detail }: { detail: CrewRunDetail }) {
+  return (
+    <div className="rounded-lg border border-border-subtle bg-surface p-5">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[12px] font-semibold uppercase tracking-widest text-text-muted">Quality gate</div>
+          <div className="mt-1 text-[13px] text-text-secondary">Evaluator outcomes and evidence links for this crew run.</div>
+        </div>
+        <span className="text-[12px] text-text-muted">{summarizeCrewRun(detail).qualityLabel}</span>
+      </div>
+      {detail.evaluations.length === 0 ? <div className="text-[13px] text-text-secondary">No evaluator result recorded yet.</div> : null}
+      <div className="space-y-2">
+        {detail.evaluations.map((evaluation) => (
+          <div key={evaluation.id} className="rounded-md border border-border-subtle bg-elevated px-3 py-2">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="text-[13px] font-semibold text-text">{evaluation.evaluatorAgentName}</div>
+                <div className="mt-1 text-[11px] text-text-muted">{evaluation.evidenceTraceEventIds.length} evidence events · {formatTime(evaluation.createdAt)}</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] font-semibold text-text">{Math.round(evaluation.score)}</span>
+                <StatusPill value={evaluation.status} />
+              </div>
+            </div>
+            <div className="mt-2 text-[12px] text-text-secondary">Recommendation: {evaluation.recommendation}</div>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }
@@ -63,11 +264,17 @@ function TraceTimeline({ detail }: { detail: CrewRunDetail }) {
       {detail.traceEvents.map((event) => (
         <div key={event.id} className="rounded-md border border-border-subtle bg-surface px-3 py-2">
           <div className="flex items-center justify-between gap-3">
-            <div className="text-[12px] font-semibold text-text">{String(event.payload?.type || event.source)}</div>
+            <div className="text-[12px] font-semibold text-text">{tracePayloadType(event)}</div>
             <div className="text-[10px] uppercase tracking-widest text-text-muted">#{event.sequence}</div>
           </div>
           <div className="mt-1 text-[11px] text-text-muted">
-            {event.nodeId ? `Node ${event.nodeId.slice(0, 8)}` : 'Run'} · {formatTime(event.createdAt)}
+            {nodeLabelForTrace(detail, event)} · {event.actor.kind}:{event.actor.id} · {formatTime(event.createdAt)}
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-text-muted">
+            {event.inputHash ? <span>input {event.inputHash.slice(0, 18)}...</span> : null}
+            {event.outputHash ? <span>output {event.outputHash.slice(0, 18)}...</span> : null}
+            {event.tokenUsage ? <span>{formatNumber(event.tokenUsage.input + event.tokenUsage.output + event.tokenUsage.reasoning + event.tokenUsage.cacheRead + event.tokenUsage.cacheWrite)} tokens</span> : null}
+            {event.costUsd ? <span>{formatMoney(event.costUsd)}</span> : null}
           </div>
         </div>
       ))}
@@ -80,6 +287,7 @@ export function CrewsPage() {
   const [selectedCrewId, setSelectedCrewId] = useState<string | null>(null)
   const [detail, setDetail] = useState<CrewDetail | null>(null)
   const [runDetail, setRunDetail] = useState<CrewRunDetail | null>(null)
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -89,7 +297,7 @@ export function CrewsPage() {
     [crews, selectedCrewId],
   )
 
-  const load = useCallback(async (nextCrewId?: string | null) => {
+  const load = useCallback(async (nextCrewId?: string | null, nextRunId?: string | null) => {
     setLoading(true)
     setError(null)
     try {
@@ -100,11 +308,13 @@ export function CrewsPage() {
       if (crewId) {
         const nextDetail = await window.coworkApi.crews.get(crewId)
         setDetail(nextDetail)
-        const latestRunId = nextDetail?.runs[0]?.id || null
+        const latestRunId = nextRunId || nextDetail?.runs[0]?.id || null
+        setSelectedRunId(latestRunId)
         setRunDetail(latestRunId ? await window.coworkApi.crews.runDetail(latestRunId) : null)
       } else {
         setDetail(null)
         setRunDetail(null)
+        setSelectedRunId(null)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load crews.')
@@ -147,9 +357,34 @@ export function CrewsPage() {
         workItemDescription: 'Plan, branch to specialists, join, evaluate, and deliver.',
       })
       setRunDetail(nextRun)
-      await load(detail.definition.id)
+      setSelectedRunId(nextRun.run.id)
+      await load(detail.definition.id, nextRun.run.id)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to start crew run.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const selectRun = async (runId: string) => {
+    setSelectedRunId(runId)
+    setError(null)
+    try {
+      setRunDetail(await window.coworkApi.crews.runDetail(runId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load crew run.')
+    }
+  }
+
+  const exportTrace = async () => {
+    if (!runDetail) return
+    setBusy(true)
+    setError(null)
+    try {
+      const content = sortCoworkTraceEvents(runDetail.traceEvents).map(serializeCoworkTraceEvent).join('\n')
+      await window.coworkApi.dialog.saveText(`${runDetail.run.title.replace(/[^a-z0-9-]+/gi, '-').toLowerCase()}-trace.ndjson`, `${content}\n`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to export crew trace.')
     } finally {
       setBusy(false)
     }
@@ -253,15 +488,54 @@ export function CrewsPage() {
                   <div className="rounded-lg border border-border-subtle bg-surface p-5">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div>
-                        <div className="text-[11px] uppercase tracking-widest text-text-muted">Latest run</div>
+                        <div className="text-[11px] uppercase tracking-widest text-text-muted">Selected run</div>
                         <h3 className="mt-1 text-[17px] font-semibold text-text">{runDetail.run.title}</h3>
+                        <div className="mt-1 text-[12px] text-text-muted">
+                          Started {formatTime(runDetail.run.startedAt)} · Finished {formatTime(runDetail.run.finishedAt)}
+                        </div>
                       </div>
-                      <span className="rounded border border-border-subtle px-3 py-1 text-[12px] text-text-secondary">{runDetail.run.status}</span>
-                    </div>
-                    <div className="mt-4">
-                      <NodeLane detail={runDetail} />
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => void exportTrace()}
+                          disabled={busy || runDetail.traceEvents.length === 0}
+                          className="rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[12px] font-medium text-text hover:bg-surface-hover disabled:opacity-50"
+                        >
+                          Export trace
+                        </button>
+                        <StatusPill value={runDetail.run.status} />
+                      </div>
                     </div>
                   </div>
+                  <RunOverview detail={runDetail} />
+                  <BlockerPanel detail={runDetail} />
+                  {detail.runs.length > 1 ? (
+                    <div className="rounded-lg border border-border-subtle bg-surface p-4">
+                      <div className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-text-muted">Runs</div>
+                      <div className="flex flex-wrap gap-2">
+                        {detail.runs.map((run) => (
+                          <button
+                            key={run.id}
+                            type="button"
+                            onClick={() => void selectRun(run.id)}
+                            aria-current={selectedRunId === run.id ? 'true' : undefined}
+                            className={`rounded-md border px-3 py-2 text-left text-[12px] ${selectedRunId === run.id ? 'border-accent bg-accent/10 text-text' : 'border-border-subtle bg-elevated text-text-secondary hover:bg-surface-hover'}`}
+                          >
+                            <div className="font-semibold">{run.title}</div>
+                            <div className="mt-1 text-[10px] uppercase tracking-widest text-text-muted">{run.status}</div>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  <AuthorityPanel detail={runDetail} />
+                  <div className="rounded-lg border border-border-subtle bg-surface p-5">
+                    <div className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-text-muted">Specialist swimlanes</div>
+                    <NodeSwimlanes detail={runDetail} />
+                  </div>
+                  <ToolCallsPanel detail={runDetail} />
+                  <ApprovalsArtifactsPanel detail={runDetail} />
+                  <EvaluationPanel detail={runDetail} />
                   <div className="rounded-lg border border-border-subtle bg-elevated p-5">
                     <div className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-text-muted">Trace timeline</div>
                     <TraceTimeline detail={runDetail} />

--- a/apps/desktop/src/renderer/components/crews/crew-run-detail-utils.ts
+++ b/apps/desktop/src/renderer/components/crews/crew-run-detail-utils.ts
@@ -1,0 +1,107 @@
+import type {
+  CoworkTraceEvent,
+  CrewApproval,
+  CrewArtifact,
+  CrewRunDetail,
+  CrewRunNode,
+  OutcomeEvaluation,
+  PolicyDecision,
+} from '@open-cowork/shared'
+
+export type CrewRunOperationalSummary = {
+  activeAgents: number
+  blockedAgents: number
+  completedNodes: number
+  failedNodes: number
+  pendingApprovals: number
+  artifactCount: number
+  toolCallCount: number
+  traceCount: number
+  totalCostUsd: number
+  tokenTotal: number
+  hasTokenUsage: boolean
+  qualityLabel: string
+  blockerLabels: string[]
+}
+
+export type NodeOperationalDetail = {
+  node: CrewRunNode
+  events: CoworkTraceEvent[]
+  toolCalls: CoworkTraceEvent[]
+  artifacts: CrewArtifact[]
+  approvals: CrewApproval[]
+  evaluations: OutcomeEvaluation[]
+  policyDecisions: PolicyDecision[]
+}
+
+const BLOCKING_EVAL_STATUSES = new Set(['failed', 'needs_revision', 'needs_human'])
+
+export function tracePayloadType(event: CoworkTraceEvent) {
+  return typeof event.payload?.type === 'string' && event.payload.type ? event.payload.type : event.source
+}
+
+export function traceToolName(event: CoworkTraceEvent) {
+  return typeof event.payload?.toolName === 'string' && event.payload.toolName ? event.payload.toolName : 'Tool call'
+}
+
+export function summarizeCrewRun(detail: CrewRunDetail): CrewRunOperationalSummary {
+  const pendingApprovals = detail.approvals.filter((approval) => approval.status === 'requested').length
+  const toolCalls = detail.traceEvents.filter((event) => tracePayloadType(event) === 'crew_run.tool_call')
+  const blockedNodes = detail.nodes.filter((node) => node.status === 'blocked' || node.status === 'failed')
+  const blockingEvaluations = detail.evaluations.filter((evaluation) => BLOCKING_EVAL_STATUSES.has(evaluation.status))
+  const cost = detail.traceEvents.reduce((sum, event) => sum + (typeof event.costUsd === 'number' ? event.costUsd : 0), 0)
+  const tokenTotal = detail.traceEvents.reduce((sum, event) => {
+    if (!event.tokenUsage) return sum
+    return sum
+      + event.tokenUsage.input
+      + event.tokenUsage.output
+      + event.tokenUsage.reasoning
+      + event.tokenUsage.cacheRead
+      + event.tokenUsage.cacheWrite
+  }, 0)
+  const blockerLabels = [
+    ...blockedNodes.map((node) => `${node.title} ${node.status}`),
+    ...detail.approvals.filter((approval) => approval.status === 'requested').map((approval) => approval.title),
+    ...blockingEvaluations.map((evaluation) => `Evaluation ${evaluation.status}`),
+  ]
+
+  return {
+    activeAgents: detail.nodes.filter((node) => node.status === 'running' || node.status === 'queued').length,
+    blockedAgents: blockedNodes.length + pendingApprovals + blockingEvaluations.length,
+    completedNodes: detail.nodes.filter((node) => node.status === 'completed').length,
+    failedNodes: detail.nodes.filter((node) => node.status === 'failed').length,
+    pendingApprovals,
+    artifactCount: detail.artifacts.length,
+    toolCallCount: toolCalls.length,
+    traceCount: detail.traceEvents.length,
+    totalCostUsd: cost,
+    tokenTotal,
+    hasTokenUsage: detail.traceEvents.some((event) => Boolean(event.tokenUsage)),
+    qualityLabel: qualityLabel(detail.evaluations),
+    blockerLabels,
+  }
+}
+
+export function nodeOperationalDetails(detail: CrewRunDetail): NodeOperationalDetail[] {
+  return detail.nodes.map((node) => ({
+    node,
+    events: detail.traceEvents.filter((event) => event.nodeId === node.id),
+    toolCalls: detail.traceEvents.filter((event) => event.nodeId === node.id && tracePayloadType(event) === 'crew_run.tool_call'),
+    artifacts: detail.artifacts.filter((artifact) => artifact.nodeId === node.id),
+    approvals: detail.approvals.filter((approval) => approval.nodeId === node.id),
+    evaluations: detail.evaluations.filter((evaluation) => node.kind === 'evaluate' && evaluation.evaluatorAgentName === node.agentName),
+    policyDecisions: detail.policyDecisions.filter((decision) => decision.nodeId === node.id),
+  }))
+}
+
+export function nodeLabelForTrace(detail: CrewRunDetail, event: CoworkTraceEvent) {
+  if (!event.nodeId) return 'Run'
+  return detail.nodes.find((node) => node.id === event.nodeId)?.title || event.nodeId.slice(0, 8)
+}
+
+function qualityLabel(evaluations: OutcomeEvaluation[]) {
+  if (evaluations.length === 0) return 'No eval yet'
+  const latest = evaluations[evaluations.length - 1]
+  if (!latest) return 'No eval yet'
+  return `${latest.status.replaceAll('_', ' ')} · ${Math.round(latest.score)}`
+}

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -160,6 +160,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
     },
     dialog: {
       selectDirectory: vi.fn(async () => null),
+      saveText: vi.fn(async () => null),
     },
     permission: {
       respond: vi.fn(async () => undefined),


### PR DESCRIPTION
## Summary

- expands the Crews page run detail into an operational view over existing Cowork run state
- surfaces blockers, authority, specialist swimlanes, tool calls, approvals, artifacts, evaluator results, token/cost totals, and the trace timeline
- adds deterministic NDJSON trace export through the existing save-text dialog

## Validation

- pnpm --filter @open-cowork/desktop test:renderer -- --run apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check