### PR TITLE
[codex] run structured crew evaluator sessions

### DIFF
--- a/apps/desktop/src/main/crew-evaluation-contract.ts
+++ b/apps/desktop/src/main/crew-evaluation-contract.ts
@@ -1,0 +1,155 @@
+import type { OutcomeEvaluation, OutcomeEvaluationStatus } from '@open-cowork/shared'
+
+const CREW_EVALUATION_TYPE = 'open_cowork.crew_outcome_evaluation'
+const CONTRACT_VERSION = 1
+const STRUCTURED_OUTPUT_RETRY_COUNT = 2
+const MAX_EVALUATION_TEXT = 2_000
+const MAX_EVALUATION_EVIDENCE_EVENTS = 100
+const MAX_EVALUATION_TRACE_ID = 256
+
+type JsonRecord = Record<string, unknown>
+type JsonSchema = Record<string, unknown>
+
+type StructuredOutputFormat = {
+  type: 'json_schema'
+  schema: JsonSchema
+  retryCount: number
+}
+
+export type CrewOutcomeEvaluationResult = {
+  status: OutcomeEvaluationStatus
+  score: number
+  recommendation: OutcomeEvaluation['recommendation']
+  summary: string
+  evidenceTraceEventIds: string[]
+}
+
+const EVIDENCE_TRACE_EVENT_SCHEMA: JsonSchema = {
+  type: 'array',
+  minItems: 1,
+  maxItems: MAX_EVALUATION_EVIDENCE_EVENTS,
+  items: { type: 'string', maxLength: MAX_EVALUATION_TRACE_ID },
+}
+
+const CREW_EVALUATION_SCHEMA: JsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    type: { const: CREW_EVALUATION_TYPE },
+    version: { const: CONTRACT_VERSION },
+    status: {
+      type: 'string',
+      enum: ['passed', 'failed', 'needs_revision', 'needs_human'],
+    },
+    score: {
+      type: 'number',
+      minimum: 0,
+      maximum: 100,
+      description: 'Overall quality score on a 0-100 scale.',
+    },
+    recommendation: {
+      type: 'string',
+      enum: ['deliver', 'revise', 'escalate'],
+    },
+    summary: {
+      type: 'string',
+      maxLength: MAX_EVALUATION_TEXT,
+      description: 'Short evaluator rationale safe to show in the operations UI.',
+    },
+    evidenceTraceEventIds: EVIDENCE_TRACE_EVENT_SCHEMA,
+  },
+  required: ['type', 'version', 'status', 'score', 'recommendation', 'summary', 'evidenceTraceEventIds'],
+}
+
+function extractJsonPayload(text: string) {
+  const fenced = text.match(/```json\s*([\s\S]*?)```/i)
+  return fenced?.[1] || text
+}
+
+function parseJsonRecord(text: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(extractJsonPayload(text)) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as JsonRecord : null
+  } catch {
+    return null
+  }
+}
+
+function readString(value: unknown, maxLength = MAX_EVALUATION_TEXT) {
+  if (typeof value !== 'string') return ''
+  return value.trim().slice(0, maxLength)
+}
+
+function readEvidenceTraceEventIds(value: unknown) {
+  if (!Array.isArray(value)) return []
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const item of value) {
+    const id = readString(item, MAX_EVALUATION_TRACE_ID)
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
+    if (ids.length >= MAX_EVALUATION_EVIDENCE_EVENTS) break
+  }
+  return ids
+}
+
+function readStatus(value: unknown): OutcomeEvaluationStatus | null {
+  if (value === 'passed' || value === 'failed' || value === 'needs_revision' || value === 'needs_human') return value
+  return null
+}
+
+function readRecommendation(value: unknown): OutcomeEvaluation['recommendation'] | null {
+  if (value === 'deliver' || value === 'revise' || value === 'escalate') return value
+  return null
+}
+
+function coerceCrewOutcomeEvaluation(record: JsonRecord): CrewOutcomeEvaluationResult | null {
+  if (record.type !== CREW_EVALUATION_TYPE || record.version !== CONTRACT_VERSION) return null
+  const status = readStatus(record.status)
+  const recommendation = readRecommendation(record.recommendation)
+  const score = typeof record.score === 'number' && Number.isFinite(record.score) ? record.score : NaN
+  const evidenceTraceEventIds = readEvidenceTraceEventIds(record.evidenceTraceEventIds)
+  if (!status || !recommendation || !Number.isFinite(score) || score < 0 || score > 100 || evidenceTraceEventIds.length === 0) {
+    return null
+  }
+  return {
+    status,
+    score,
+    recommendation,
+    summary: readString(record.summary) || `${status} with recommendation ${recommendation}.`,
+    evidenceTraceEventIds,
+  }
+}
+
+export function crewOutcomeEvaluationOutputFormat(): StructuredOutputFormat {
+  return {
+    type: 'json_schema',
+    schema: CREW_EVALUATION_SCHEMA,
+    retryCount: STRUCTURED_OUTPUT_RETRY_COUNT,
+  }
+}
+
+export function crewOutcomeEvaluationSchemaHint() {
+  return [
+    '{',
+    `  "type": "${CREW_EVALUATION_TYPE}",`,
+    `  "version": ${CONTRACT_VERSION},`,
+    '  "status": "passed|failed|needs_revision|needs_human",',
+    '  "score": 0,',
+    '  "recommendation": "deliver|revise|escalate",',
+    '  "summary": "short evaluator rationale",',
+    '  "evidenceTraceEventIds": ["crew trace event id"]',
+    '}',
+  ].join('\n')
+}
+
+export function extractCrewOutcomeEvaluationFromStructured(value: unknown): CrewOutcomeEvaluationResult | null {
+  const record = value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null
+  return record ? coerceCrewOutcomeEvaluation(record) : null
+}
+
+export function extractCrewOutcomeEvaluationFromAssistantText(text: string): CrewOutcomeEvaluationResult | null {
+  const record = parseJsonRecord(text)
+  return record ? coerceCrewOutcomeEvaluation(record) : null
+}

--- a/apps/desktop/src/main/crew-runtime-execution.ts
+++ b/apps/desktop/src/main/crew-runtime-execution.ts
@@ -1,6 +1,7 @@
+import type { OutputFormat } from '@opencode-ai/sdk/v2'
 import { getEffectiveSettings } from './settings.ts'
 import { getClientForDirectory, getRuntimeHomeDir } from './runtime.ts'
-import { normalizeSessionInfo } from './opencode-adapter.ts'
+import { normalizeSessionInfo, normalizeSessionMessages } from './opencode-adapter.ts'
 import { toIsoTimestamp } from './task-run-utils.ts'
 import { trackParentSession } from './event-task-state.ts'
 import {
@@ -19,6 +20,16 @@ export type CrewRuntimeSession = {
 export type CrewRuntimeExecutionDriver = {
   createRootSession: (input: { title: string; agentName: string }) => Promise<CrewRuntimeSession>
   prompt: (input: { sessionId: string; agentName: string; prompt: string }) => Promise<void>
+  evaluateOutcome: (input: {
+    title: string
+    agentName: string
+    prompt: string
+    format: OutputFormat
+  }) => Promise<{
+    sessionId: string
+    structured: unknown
+    text: string
+  }>
 }
 
 export function createOpenCodeCrewRuntimeDriver(): CrewRuntimeExecutionDriver {
@@ -74,6 +85,59 @@ export function createOpenCodeCrewRuntimeDriver(): CrewRuntimeExecutionDriver {
       })
       if (record) getThreadIndexService().upsertThreadFromSessionRecord(record)
       log('crew', `Submitted crew prompt to ${shortSessionId(input.sessionId)} as ${input.agentName}`)
+    },
+
+    async evaluateOutcome(input) {
+      const client = getRuntimeClient()
+      const settings = getEffectiveSettings()
+      const result = await client.session.create({}, { throwOnError: true })
+      const session = normalizeSessionInfo(result.data)
+      if (!session) throw new Error('Runtime returned an invalid evaluator session payload')
+
+      const title = `Crew evaluator: ${input.title}`
+      try {
+        await client.session.update({ sessionID: session.id, title })
+      } catch (error) {
+        log('crew', `Could not title crew evaluator session ${shortSessionId(session.id)}: ${error instanceof Error ? error.message : String(error)}`)
+      }
+
+      trackParentSession(session.id)
+      const record = upsertSessionRecord(toSessionRecord({
+        id: session.id,
+        title,
+        createdAt: toIsoTimestamp(session.time.created),
+        updatedAt: toIsoTimestamp(session.time.updated || session.time.created),
+        opencodeDirectory: directory,
+        providerId: settings.effectiveProviderId || null,
+        modelId: settings.effectiveModel || null,
+        kind: 'interactive',
+      }))
+      if (record) getThreadIndexService().upsertThreadFromSessionRecord(record)
+
+      await client.session.promptAsync({
+        sessionID: session.id,
+        parts: [{ type: 'text', text: input.prompt }],
+        agent: input.agentName,
+        format: input.format,
+      }, {
+        throwOnError: true,
+      })
+
+      const messages = normalizeSessionMessages((await client.session.messages({ sessionID: session.id }, { throwOnError: true })).data)
+      const assistant = [...messages].reverse().find((message) => message.role === 'assistant') || null
+      const text = assistant?.parts
+        .filter((part) => part.type === 'text' && typeof part.text === 'string')
+        .map((part) => part.text?.trim() || '')
+        .filter(Boolean)
+        .join('\n\n') || ''
+      const updated = updateSessionRecord(session.id, { updatedAt: new Date().toISOString() })
+      if (updated) getThreadIndexService().upsertThreadFromSessionRecord(updated)
+      log('crew', `Recorded crew evaluator output from ${shortSessionId(session.id)} as ${input.agentName}`)
+      return {
+        sessionId: session.id,
+        structured: assistant?.structured,
+        text,
+      }
     },
   }
 }

--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -6,6 +6,7 @@ import {
   type CrewListPayload,
   type CrewMember,
   type CrewMemberDraft,
+  type CoworkTraceEvent,
   type OutcomeEvaluation,
   type OutcomeEvaluationStatus,
   type CrewRunDetail,
@@ -42,11 +43,19 @@ import {
   updateCrewRunNodeStatus,
   withCrewTransaction,
 } from './crew-store.ts'
+import {
+  crewOutcomeEvaluationOutputFormat,
+  crewOutcomeEvaluationSchemaHint,
+  extractCrewOutcomeEvaluationFromAssistantText,
+  extractCrewOutcomeEvaluationFromStructured,
+  type CrewOutcomeEvaluationResult,
+} from './crew-evaluation-contract.ts'
 import type { CrewRuntimeExecutionDriver } from './crew-runtime-execution.ts'
 
 const MAX_CREW_MEMBERS = 25
 const MAX_CREW_STRING_BYTES = 16 * 1024
 const MAX_EVALUATION_EVIDENCE_EVENTS = 100
+const MAX_EVALUATION_TRACE_PROMPT_EVENTS = 80
 const FIXED_CREW_WORKFLOW = ['plan', 'delegate', 'join', 'evaluate', 'deliver'] as const
 const DEFAULT_CREW_OUTCOME_RUBRIC = {
   name: 'Research crew outcome rubric',
@@ -295,6 +304,93 @@ function buildCrewLeadPrompt(detail: CrewRunDetail) {
   ].join('\n')
 }
 
+function summarizeTraceEventForEvaluation(detail: CrewRunDetail, event: CoworkTraceEvent) {
+  const node = event.nodeId ? detail.nodes.find((item) => item.id === event.nodeId) : null
+  const payloadType = typeof event.payload?.type === 'string' ? event.payload.type : 'unknown'
+  const payloadSummary = {
+    type: payloadType,
+    agentName: typeof event.payload?.agentName === 'string' ? event.payload.agentName : undefined,
+    status: typeof event.payload?.status === 'string' ? event.payload.status : undefined,
+    title: typeof event.payload?.title === 'string' ? event.payload.title : undefined,
+    uri: typeof event.payload?.uri === 'string' ? event.payload.uri : undefined,
+    message: typeof event.payload?.message === 'string' ? event.payload.message.slice(0, 240) : undefined,
+  }
+  return {
+    id: event.id,
+    sequence: event.sequence,
+    source: event.source,
+    actor: event.actor,
+    sessionId: event.sessionId,
+    node: node ? {
+      id: node.id,
+      kind: node.kind,
+      status: node.status,
+      agentName: node.agentName,
+      title: node.title,
+    } : null,
+    payload: Object.fromEntries(Object.entries(payloadSummary).filter(([, value]) => value !== undefined)),
+  }
+}
+
+function buildCrewEvaluationPrompt(detail: CrewRunDetail) {
+  const evaluator = detail.version.members.find((member) => member.role === 'evaluator')
+  const rubric = detail.version.outcomeRubricId ? getOutcomeRubric(detail.version.outcomeRubricId) : null
+  const evidenceEvents = detail.traceEvents
+    .filter((event) => event.source !== 'cowork_eval')
+    .slice(0, MAX_EVALUATION_TRACE_PROMPT_EVENTS)
+    .map((event) => summarizeTraceEventForEvaluation(detail, event))
+  const artifactLines = detail.artifacts.map((artifact) => `- ${artifact.title} (${artifact.mime}) ${artifact.uri}`).join('\n')
+  const approvalLines = detail.approvals.map((approval) => `- ${approval.title}: ${approval.status}`).join('\n')
+  const rubricLines = rubric
+    ? [
+        `${rubric.name}: ${rubric.description}`,
+        `Overall passing score: ${rubric.passingScore}`,
+        ...rubric.criteria.map((criterion) => `- ${criterion.label} (${Math.round(criterion.weight * 100)}%, pass ${criterion.passingScore}): ${criterion.description}`),
+      ].join('\n')
+    : 'Default expectation: score correctness, evidence quality, and usefulness on a 0-100 scale.'
+
+  return [
+    `You are the evaluator agent for Open Cowork crew run "${detail.run.title}".`,
+    '',
+    'OpenCode owns execution. Open Cowork is asking you to evaluate the product-level outcome from trace evidence only.',
+    'Do not rely on hidden reasoning from the producing agent. Use the trace event ids, artifacts, approvals, and visible outcome signals below.',
+    '',
+    `Evaluator agent: ${evaluator?.agentName || 'unknown'}`,
+    `Crew: ${detail.crew.name}`,
+    detail.workItem ? `Work item: ${detail.workItem.title}\n${detail.workItem.description}` : `Run title: ${detail.run.title}`,
+    '',
+    'Rubric:',
+    rubricLines,
+    '',
+    'Artifacts:',
+    artifactLines || '- none recorded',
+    '',
+    'Approvals:',
+    approvalLines || '- none recorded',
+    '',
+    'Trace evidence JSON:',
+    JSON.stringify(evidenceEvents, null, 2),
+    '',
+    'Return only the structured JSON object requested by the runtime. evidenceTraceEventIds must contain ids from the trace evidence JSON above.',
+    'Use recommendation "deliver" only when the result is ready for user delivery. Use "revise" for bounded specialist/lead revision. Use "escalate" when a human needs to decide.',
+    '',
+    'Schema:',
+    crewOutcomeEvaluationSchemaHint(),
+  ].join('\n')
+}
+
+function normalizeEvaluatorEvidence(
+  detail: CrewRunDetail,
+  result: CrewOutcomeEvaluationResult,
+) {
+  const allowed = new Set(detail.traceEvents.filter((event) => event.source !== 'cowork_eval').map((event) => event.id))
+  const filtered = result.evidenceTraceEventIds.filter((id) => allowed.has(id)).slice(0, MAX_EVALUATION_EVIDENCE_EVENTS)
+  return {
+    evidenceTraceEventIds: filtered.length > 0 ? filtered : [...allowed].slice(0, MAX_EVALUATION_EVIDENCE_EVENTS),
+    discardedEvidenceTraceEventIds: result.evidenceTraceEventIds.filter((id) => !allowed.has(id)),
+  }
+}
+
 export async function executeCrewRunWithOpenCode(
   runId: string,
   driver: CrewRuntimeExecutionDriver,
@@ -376,6 +472,89 @@ export async function startCrewRunWithOpenCode(
   return executeCrewRunWithOpenCode(runDetail.run.id, driver)
 }
 
+export async function evaluateCrewRunWithOpenCode(
+  runId: string,
+  driver: CrewRuntimeExecutionDriver,
+): Promise<CrewRunDetail> {
+  const detail = getCrewRunDetail(runId)
+  if (!detail) throw new Error(`Crew run ${runId} does not exist.`)
+  const evaluator = detail.version.members.find((member) => member.role === 'evaluator')
+  const evaluateNode = detail.nodes.find((node) => node.kind === 'evaluate')
+  if (!evaluator || !evaluateNode) throw new Error('Crew run has no evaluator node.')
+  const evidenceEvents = detail.traceEvents.filter((event) => event.source !== 'cowork_eval')
+  if (evidenceEvents.length === 0) throw new Error('Crew run has no trace evidence to evaluate.')
+
+  let sequence = nextTraceSequence(runId)
+  let sessionId: string | null = null
+  updateCrewRunStatus(runId, 'evaluating')
+  updateCrewRunNodeStatus(evaluateNode.id, 'running')
+
+  try {
+    const prompt = buildCrewEvaluationPrompt(detail)
+    const output = await driver.evaluateOutcome({
+      title: detail.run.title,
+      agentName: evaluator.agentName,
+      prompt,
+      format: crewOutcomeEvaluationOutputFormat(),
+    })
+    sessionId = output.sessionId
+    updateCrewRunNodeStatus(evaluateNode.id, 'running', { sessionId })
+    appendRunTrace({
+      runId,
+      sequence: sequence++,
+      nodeId: evaluateNode.id,
+      source: 'cowork_eval',
+      sessionId,
+      actor: { kind: 'agent', id: evaluator.agentName },
+      inputHash: sha256Text(prompt),
+      payload: {
+        type: 'crew_run.evaluation_prompt_submitted',
+        evaluatorAgentName: evaluator.agentName,
+        evidenceTraceEventCount: evidenceEvents.length,
+      },
+    })
+
+    const parsed = extractCrewOutcomeEvaluationFromStructured(output.structured)
+      || extractCrewOutcomeEvaluationFromAssistantText(output.text)
+    if (!parsed) {
+      throw new Error('Evaluator did not return a valid crew outcome evaluation.')
+    }
+
+    const evidence = normalizeEvaluatorEvidence(detail, parsed)
+    return recordCrewOutcomeEvaluation({
+      runId,
+      evaluatorAgentName: evaluator.agentName,
+      status: parsed.status,
+      score: parsed.score,
+      evidenceTraceEventIds: evidence.evidenceTraceEventIds,
+      recommendation: parsed.recommendation,
+      summary: parsed.summary,
+      sessionId,
+      discardedEvidenceTraceEventIds: evidence.discardedEvidenceTraceEventIds,
+    })
+  } catch (error) {
+    const message = safeErrorMessage(error)
+    updateCrewRunNodeStatus(evaluateNode.id, 'failed', { sessionId })
+    updateCrewRunStatus(runId, 'blocked', { summary: `Crew evaluation failed: ${message}` })
+    appendRunTrace({
+      runId,
+      sequence,
+      nodeId: evaluateNode.id,
+      source: 'cowork_eval',
+      sessionId,
+      actor: { kind: 'agent', id: evaluator.agentName },
+      payload: {
+        type: 'crew_run.evaluation_failed',
+        message,
+      },
+    })
+  }
+
+  const updated = getCrewRunDetail(runId)
+  if (!updated) throw new Error(`Crew run ${runId} disappeared after evaluation dispatch.`)
+  return updated
+}
+
 export function recordCrewOutcomeEvaluation(input: {
   runId: string
   evaluatorAgentName?: string | null
@@ -383,6 +562,9 @@ export function recordCrewOutcomeEvaluation(input: {
   score: number
   evidenceTraceEventIds?: string[]
   recommendation: OutcomeEvaluation['recommendation']
+  summary?: string | null
+  sessionId?: string | null
+  discardedEvidenceTraceEventIds?: string[]
 }): CrewRunDetail {
   return withCrewTransaction(() => {
     const detail = getCrewRunDetail(input.runId)
@@ -416,14 +598,15 @@ export function recordCrewOutcomeEvaluation(input: {
     if (deliverNode && passedForDelivery) updateCrewRunNodeStatus(deliverNode.id, 'completed')
     updateCrewRunStatus(detail.run.id, passedForDelivery ? 'completed' : 'blocked', {
       summary: passedForDelivery
-        ? `Evaluator ${evaluatorAgentName} passed the run with score ${Math.round(input.score)}.`
-        : `Evaluator ${evaluatorAgentName} requested ${input.recommendation} with score ${Math.round(input.score)}.`,
+        ? `Evaluator ${evaluatorAgentName} passed the run with score ${Math.round(input.score)}.${input.summary ? ` ${input.summary}` : ''}`
+        : `Evaluator ${evaluatorAgentName} requested ${input.recommendation} with score ${Math.round(input.score)}.${input.summary ? ` ${input.summary}` : ''}`,
     })
     appendRunTrace({
       runId: detail.run.id,
       sequence: nextTraceSequence(detail.run.id),
       nodeId: evaluateNode?.id || null,
       source: 'cowork_eval',
+      sessionId: input.sessionId ?? null,
       actor: { kind: 'agent', id: evaluatorAgentName },
       inputHash: sha256Text(JSON.stringify({ rubricId, evidenceTraceEventIds })),
       outputHash: sha256Text(JSON.stringify({
@@ -440,6 +623,8 @@ export function recordCrewOutcomeEvaluation(input: {
         score: evaluation.score,
         recommendation: evaluation.recommendation,
         evidenceTraceEventCount: evidenceTraceEventIds.length,
+        discardedEvidenceTraceEventCount: input.discardedEvidenceTraceEventIds?.length || 0,
+        summary: input.summary || null,
       },
     })
 

--- a/apps/desktop/src/main/ipc/crew-handlers.ts
+++ b/apps/desktop/src/main/ipc/crew-handlers.ts
@@ -1,6 +1,7 @@
 import type { CrewDefinitionDraft, CrewRunDraft } from '@open-cowork/shared'
 import {
   createCrewFromDraft,
+  evaluateCrewRunWithOpenCode,
   getCrewDetail,
   getCrewRunDetail,
   listCrewCatalog,
@@ -79,5 +80,10 @@ export function registerCrewHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('crews:run-detail', async (_event, runId: string) => {
     assertString(runId, 'Crew run id')
     return getCrewRunDetail(runId)
+  })
+
+  context.ipcMain.handle('crews:evaluate', async (_event, runId: string) => {
+    assertString(runId, 'Crew run id')
+    return evaluateCrewRunWithOpenCode(runId, createOpenCodeCrewRuntimeDriver())
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -100,6 +100,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'crews:create',
   'crews:run',
   'crews:run-detail',
+  'crews:evaluate',
   'threads:search',
   'threads:facets',
   'threads:tags:list',
@@ -306,6 +307,7 @@ const api: CoworkAPI = {
     create: (draft) => invoke('crews:create', draft),
     run: (draft) => invoke('crews:run', draft),
     runDetail: (runId) => invoke('crews:run-detail', runId),
+    evaluate: (runId) => invoke('crews:evaluate', runId),
   },
   threads: {
     search: (query) => invoke('threads:search', query),

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -188,6 +188,7 @@ describe('CrewsPage', () => {
         list: vi.fn(async () => payload()),
         get: vi.fn(async () => detail),
         runDetail: vi.fn(async () => runDetail),
+        evaluate: vi.fn(async () => runDetail),
       },
     })
 
@@ -216,6 +217,7 @@ describe('CrewsPage', () => {
         create,
         run: runCrew,
         runDetail: vi.fn(async () => null),
+        evaluate: vi.fn(async () => runDetail),
       },
     })
 
@@ -245,6 +247,7 @@ describe('CrewsPage', () => {
         list: vi.fn(async () => payload()),
         get: vi.fn(async () => detail),
         runDetail: vi.fn(async () => runDetail),
+        evaluate: vi.fn(async () => runDetail),
       },
       dialog: {
         saveText,
@@ -259,5 +262,27 @@ describe('CrewsPage', () => {
     expect(saveText.mock.calls[0]?.[0]).toBe('research-crew-demo-run-trace.ndjson')
     expect(saveText.mock.calls[0]?.[1]).toContain('"id":"trace-1"')
     expect(saveText.mock.calls[0]?.[1]).toContain('"type":"crew_run.tool_call"')
+  })
+
+  it('runs the evaluator for the selected crew run', async () => {
+    const user = userEvent.setup()
+    const evaluate = vi.fn(async () => ({
+      ...runDetail,
+      run: { ...runDetail.run, status: 'completed' as const },
+    }))
+    installRendererTestCoworkApi({
+      crews: {
+        list: vi.fn(async () => payload()),
+        get: vi.fn(async () => detail),
+        runDetail: vi.fn(async () => runDetail),
+        evaluate,
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Run evaluator' }))
+
+    await waitFor(() => expect(evaluate).toHaveBeenCalledWith(run.id))
   })
 })

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
@@ -390,6 +390,21 @@ export function CrewsPage() {
     }
   }
 
+  const evaluateRun = async () => {
+    if (!runDetail) return
+    setBusy(true)
+    setError(null)
+    try {
+      const evaluated = await window.coworkApi.crews.evaluate(runDetail.run.id)
+      setRunDetail(evaluated)
+      await load(evaluated.crew.id, evaluated.run.id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to run crew evaluator.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-base">
       <header className="border-b border-border-subtle px-6 py-5">
@@ -495,6 +510,14 @@ export function CrewsPage() {
                         </div>
                       </div>
                       <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => void evaluateRun()}
+                          disabled={busy || runDetail.traceEvents.length === 0 || runDetail.run.status === 'completed'}
+                          className="rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[12px] font-medium text-text hover:bg-surface-hover disabled:opacity-50"
+                        >
+                          Run evaluator
+                        </button>
                         <button
                           type="button"
                           onClick={() => void exportTrace()}

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -93,6 +93,9 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
         throw new Error('crews.run not mocked')
       }),
       runDetail: vi.fn(async () => null),
+      evaluate: vi.fn(async () => {
+        throw new Error('crews.evaluate not mocked')
+      }),
     },
     artifact: {
       cleanup: vi.fn(async (mode) => ({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -304,6 +304,7 @@ export interface CoworkAPI {
     create: (draft: CrewDefinitionDraft) => Promise<CrewDetail>
     run: (draft: CrewRunDraft) => Promise<CrewRunDetail>
     runDetail: (runId: string) => Promise<CrewRunDetail | null>
+    evaluate: (runId: string) => Promise<CrewRunDetail>
   }
   threads: {
     search: (query?: ThreadSearchQuery) => Promise<ThreadSearchResult>

--- a/tests/crew-evaluation-contract.test.ts
+++ b/tests/crew-evaluation-contract.test.ts
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  crewOutcomeEvaluationOutputFormat,
+  extractCrewOutcomeEvaluationFromAssistantText,
+  extractCrewOutcomeEvaluationFromStructured,
+} from '../apps/desktop/src/main/crew-evaluation-contract.ts'
+
+test('crew evaluation output format requests a bounded json schema payload', () => {
+  const format = crewOutcomeEvaluationOutputFormat()
+
+  assert.equal(format.type, 'json_schema')
+  assert.equal(format.retryCount, 2)
+  assert.equal((format.schema.properties as Record<string, unknown>).score instanceof Object, true)
+  assert.deepEqual(format.schema.required, [
+    'type',
+    'version',
+    'status',
+    'score',
+    'recommendation',
+    'summary',
+    'evidenceTraceEventIds',
+  ])
+})
+
+test('extractCrewOutcomeEvaluationFromStructured parses a valid evaluator payload', () => {
+  const evaluation = extractCrewOutcomeEvaluationFromStructured({
+    type: 'open_cowork.crew_outcome_evaluation',
+    version: 1,
+    status: 'passed',
+    score: 92,
+    recommendation: 'deliver',
+    summary: 'Evidence is sufficient.',
+    evidenceTraceEventIds: ['trace-1', 'trace-2'],
+  })
+
+  assert.equal(evaluation?.status, 'passed')
+  assert.equal(evaluation?.score, 92)
+  assert.equal(evaluation?.recommendation, 'deliver')
+  assert.deepEqual(evaluation?.evidenceTraceEventIds, ['trace-1', 'trace-2'])
+})
+
+test('extractCrewOutcomeEvaluationFromStructured rejects invalid scores and missing evidence', () => {
+  assert.equal(extractCrewOutcomeEvaluationFromStructured({
+    type: 'open_cowork.crew_outcome_evaluation',
+    version: 1,
+    status: 'passed',
+    score: 101,
+    recommendation: 'deliver',
+    summary: 'Too high.',
+    evidenceTraceEventIds: ['trace-1'],
+  }), null)
+
+  assert.equal(extractCrewOutcomeEvaluationFromStructured({
+    type: 'open_cowork.crew_outcome_evaluation',
+    version: 1,
+    status: 'passed',
+    score: 90,
+    recommendation: 'deliver',
+    summary: 'No evidence.',
+    evidenceTraceEventIds: [],
+  }), null)
+})
+
+test('extractCrewOutcomeEvaluationFromAssistantText accepts fenced json fallback', () => {
+  const evaluation = extractCrewOutcomeEvaluationFromAssistantText([
+    '```json',
+    '{',
+    '  "type": "open_cowork.crew_outcome_evaluation",',
+    '  "version": 1,',
+    '  "status": "needs_revision",',
+    '  "score": 67,',
+    '  "recommendation": "revise",',
+    '  "summary": "Needs clearer artifact evidence.",',
+    '  "evidenceTraceEventIds": ["trace-1"]',
+    '}',
+    '```',
+  ].join('\n'))
+
+  assert.equal(evaluation?.status, 'needs_revision')
+  assert.equal(evaluation?.recommendation, 'revise')
+})

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../apps/desktop/src/main/crew-store.ts'
 import {
   createCrewFromDraft,
+  evaluateCrewRunWithOpenCode,
   executeCrewRunWithOpenCode,
   getCrewDetail,
   listCrewCatalog,
@@ -215,6 +216,9 @@ test('crew service dispatches the lead run through an OpenCode execution driver'
       async prompt(input) {
         prompts.push(input)
       },
+      async evaluateOutcome() {
+        throw new Error('not used')
+      },
     })
 
     const planNode = runDetail.nodes.find((node) => node.kind === 'plan')
@@ -252,6 +256,9 @@ test('crew service records execution dispatch failures in the durable run', asyn
       async prompt() {
         throw new Error('provider unavailable')
       },
+      async evaluateOutcome() {
+        throw new Error('not used')
+      },
     })
 
     const planNode = failed.nodes.find((node) => node.kind === 'plan')
@@ -261,5 +268,93 @@ test('crew service records execution dispatch failures in the durable run', asyn
     assert.equal(planNode?.status, 'failed')
     assert.equal(planNode?.sessionId, 'root-session-2')
     assert.equal(failed.traceEvents.at(-1)?.payload?.type, 'crew_run.execution_failed')
+  })
+})
+
+test('crew service runs a structured evaluator session and records the outcome', async () => {
+  await withCrewStoreAsync('evaluate-structured', async () => {
+    const crew = createCrewFromDraft(draft())
+    const runDetail = startCrewRun({
+      crewId: crew.definition.id,
+      title: 'Analyze the weekly market',
+    })
+    const evaluatorPrompts: Array<{ agentName: string; prompt: string; format: unknown }> = []
+    const evaluated = await evaluateCrewRunWithOpenCode(runDetail.run.id, {
+      async createRootSession() {
+        throw new Error('not used')
+      },
+      async prompt() {
+        throw new Error('not used')
+      },
+      async evaluateOutcome(input) {
+        evaluatorPrompts.push(input)
+        return {
+          sessionId: 'evaluator-session-1',
+          text: 'ignored fallback',
+          structured: {
+            type: 'open_cowork.crew_outcome_evaluation',
+            version: 1,
+            status: 'passed',
+            score: 94,
+            recommendation: 'deliver',
+            summary: 'Ready to deliver.',
+            evidenceTraceEventIds: [runDetail.traceEvents[0]!.id, 'hallucinated-trace-id'],
+          },
+        }
+      },
+    })
+
+    const evaluateNode = evaluated.nodes.find((node) => node.kind === 'evaluate')
+    const deliverNode = evaluated.nodes.find((node) => node.kind === 'deliver')
+    assert.equal(evaluatorPrompts.length, 1)
+    assert.equal(evaluatorPrompts[0]?.agentName, 'evaluator')
+    assert.match(evaluatorPrompts[0]?.prompt || '', /trace evidence/i)
+    assert.match(evaluatorPrompts[0]?.prompt || '', new RegExp(runDetail.traceEvents[0]!.id))
+    assert.equal(evaluated.run.status, 'completed')
+    assert.equal(evaluateNode?.status, 'completed')
+    assert.equal(evaluateNode?.sessionId, 'evaluator-session-1')
+    assert.equal(deliverNode?.status, 'completed')
+    assert.equal(evaluated.evaluations.length, 1)
+    assert.equal(evaluated.evaluations[0]?.score, 94)
+    assert.deepEqual(evaluated.evaluations[0]?.evidenceTraceEventIds, [runDetail.traceEvents[0]!.id])
+    assert.deepEqual(evaluated.traceEvents.map((event) => event.payload?.type).slice(-2), [
+      'crew_run.evaluation_prompt_submitted',
+      'crew_run.evaluation_recorded',
+    ])
+    assert.equal(evaluated.traceEvents.at(-1)?.sessionId, 'evaluator-session-1')
+    assert.equal(evaluated.traceEvents.at(-1)?.payload?.discardedEvidenceTraceEventCount, 1)
+  })
+})
+
+test('crew service blocks the run when evaluator output is invalid', async () => {
+  await withCrewStoreAsync('evaluate-invalid', async () => {
+    const crew = createCrewFromDraft(draft())
+    const runDetail = startCrewRun({
+      crewId: crew.definition.id,
+      title: 'Analyze the weekly market',
+    })
+    const evaluated = await evaluateCrewRunWithOpenCode(runDetail.run.id, {
+      async createRootSession() {
+        throw new Error('not used')
+      },
+      async prompt() {
+        throw new Error('not used')
+      },
+      async evaluateOutcome() {
+        return {
+          sessionId: 'evaluator-session-invalid',
+          structured: { bad: true },
+          text: 'not json',
+        }
+      },
+    })
+
+    const evaluateNode = evaluated.nodes.find((node) => node.kind === 'evaluate')
+    assert.equal(evaluated.run.status, 'blocked')
+    assert.match(evaluated.run.summary || '', /valid crew outcome evaluation/)
+    assert.equal(evaluateNode?.status, 'failed')
+    assert.equal(evaluateNode?.sessionId, 'evaluator-session-invalid')
+    assert.equal(evaluated.evaluations.length, 0)
+    assert.equal(evaluated.traceEvents.at(-1)?.payload?.type, 'crew_run.evaluation_failed')
   })
 })

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -110,6 +110,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('crews:list'), true)
   assert.equal(handlers.has('crews:create'), true)
   assert.equal(handlers.has('crews:run'), true)
+  assert.equal(handlers.has('crews:evaluate'), true)
   assert.equal(handlers.has('threads:tags:apply'), true)
   assert.equal(handlers.has('threads:smart-filters:create'), true)
   assert.equal(handlers.has('threads:suggestions:accept'), true)


### PR DESCRIPTION
## Summary
- add a versioned structured-output contract for crew outcome evaluations
- run evaluator agents through the existing OpenCode runtime driver and persist the result as Cowork outcome evaluation + trace state
- expose a Crew UI action and IPC bridge for running the evaluator on a selected run

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/crew-evaluation-contract.test.ts tests/crew-service.test.ts tests/ipc-handler-registration.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- --run apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check