### PR TITLE
[codex] auto-run crew outcome evaluation

### DIFF
--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -27,6 +27,7 @@ import {
   getCrewDefinition,
   getCoworkWorkItem,
   getCrewRun,
+  getCrewRunByRootSessionId,
   getCrewVersion,
   getOutcomeRubric,
   listCoworkTraceEventsForRun,
@@ -57,6 +58,7 @@ const MAX_CREW_STRING_BYTES = 16 * 1024
 const MAX_EVALUATION_EVIDENCE_EVENTS = 100
 const MAX_EVALUATION_TRACE_PROMPT_EVENTS = 80
 const FIXED_CREW_WORKFLOW = ['plan', 'delegate', 'join', 'evaluate', 'deliver'] as const
+const inFlightRootEvaluationRunIds = new Set<string>()
 const DEFAULT_CREW_OUTCOME_RUBRIC = {
   name: 'Research crew outcome rubric',
   description: 'Checks whether the crew output is correct, evidence-backed, and useful enough to deliver.',
@@ -553,6 +555,28 @@ export async function evaluateCrewRunWithOpenCode(
   const updated = getCrewRunDetail(runId)
   if (!updated) throw new Error(`Crew run ${runId} disappeared after evaluation dispatch.`)
   return updated
+}
+
+export async function evaluateCrewRunForRootSessionIdle(
+  rootSessionId: string,
+  driver: CrewRuntimeExecutionDriver,
+): Promise<CrewRunDetail | null> {
+  const run = getCrewRunByRootSessionId(boundedString(rootSessionId, 'Crew root session id'))
+  if (!run) return null
+  const detail = getCrewRunDetail(run.id)
+  if (!detail) return null
+  if (detail.run.status !== 'evaluating') return detail
+  if (detail.evaluations.length > 0) return detail
+  if (inFlightRootEvaluationRunIds.has(detail.run.id)) return detail
+  const readyForEvaluation = detail.traceEvents.some((event) => event.payload?.type === 'crew_run.ready_for_evaluation')
+  if (!readyForEvaluation) return detail
+
+  inFlightRootEvaluationRunIds.add(detail.run.id)
+  try {
+    return await evaluateCrewRunWithOpenCode(detail.run.id, driver)
+  } finally {
+    inFlightRootEvaluationRunIds.delete(detail.run.id)
+  }
 }
 
 export function recordCrewOutcomeEvaluation(input: {

--- a/apps/desktop/src/main/event-runtime-handlers.ts
+++ b/apps/desktop/src/main/event-runtime-handlers.ts
@@ -28,6 +28,8 @@ import {
   handleAutomationSessionError,
   handleAutomationSessionIdle,
 } from './automation-service.ts'
+import { evaluateCrewRunForRootSessionIdle } from './crew-service.ts'
+import { createOpenCodeCrewRuntimeDriver } from './crew-runtime-execution.ts'
 import {
   ensureTaskRunForChild,
   forgetSubmittedPrompt,
@@ -54,7 +56,7 @@ import type { PermissionRequest } from '@open-cowork/shared'
 
 type DispatchRuntimeEvent = (win: BrowserWindow, event: RuntimeSessionEvent) => void
 
-function runAutomationSideEffect(scope: string, task: () => void | Promise<unknown>) {
+function runRuntimeSideEffect(scope: string, task: () => void | Promise<unknown>) {
   void Promise.resolve().then(task).catch((err) => {
     const message = err instanceof Error ? err.message : String(err)
     log('error', `${scope} failed: ${message}`)
@@ -208,7 +210,7 @@ export function handleRuntimeSideEffectEvent(input: {
           sourceSessionId: actualSessionId,
         },
       })
-      runAutomationSideEffect('automation question prompt handling', () => handleAutomationQuestionAsked({
+      runRuntimeSideEffect('automation question prompt handling', () => handleAutomationQuestionAsked({
         sessionId: rootSessionId,
         questionId,
         header: questions[0]?.header || 'Automation needs input',
@@ -233,7 +235,7 @@ export function handleRuntimeSideEffectEvent(input: {
           sourceSessionId: actualSessionId,
         },
       })
-      runAutomationSideEffect('automation question resolution handling', () => handleAutomationQuestionResolved(requestId, {
+      runRuntimeSideEffect('automation question resolution handling', () => handleAutomationQuestionResolved(requestId, {
         resume: type === 'question.replied',
       }))
 
@@ -289,7 +291,9 @@ export function handleRuntimeSideEffectEvent(input: {
           if (isTrackedParentSession(rootSessionId)) {
             untrackParentSession(rootSessionId)
           }
-          runAutomationSideEffect('automation idle handling', () => handleAutomationSessionIdle(rootSessionId))
+          runRuntimeSideEffect('automation idle handling', () => handleAutomationSessionIdle(rootSessionId))
+          runRuntimeSideEffect('crew idle evaluation handling', () =>
+            evaluateCrewRunForRootSessionIdle(rootSessionId, createOpenCodeCrewRuntimeDriver()))
         } else {
           const taskRun = ensureTaskRunForChild(rootSessionId, actualSessionId)
           if (taskRun) {
@@ -464,7 +468,7 @@ export function handleRuntimeSideEffectEvent(input: {
         sessionId: rootSessionId,
         data: { type: 'error', message, taskRunId, sourceSessionId: actualSessionId },
       })
-      runAutomationSideEffect('automation session error handling', () => handleAutomationSessionError(rootSessionId, message))
+      runRuntimeSideEffect('automation session error handling', () => handleAutomationSessionError(rootSessionId, message))
       return true
     }
 

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -11,15 +11,19 @@ import {
 } from '../apps/desktop/src/main/crew-store.ts'
 import {
   createCrewFromDraft,
+  evaluateCrewRunForRootSessionIdle,
   evaluateCrewRunWithOpenCode,
   executeCrewRunWithOpenCode,
   getCrewDetail,
+  getCrewRunDetail,
   listCrewCatalog,
   recordCrewOutcomeEvaluation,
   startCrewRun,
   startCrewRunWithOpenCode,
   validateCrewDefinitionDraft,
 } from '../apps/desktop/src/main/crew-service.ts'
+import type { CrewRuntimeExecutionDriver } from '../apps/desktop/src/main/crew-runtime-execution.ts'
+import { projectCrewRuntimeEvent } from '../apps/desktop/src/main/crew-runtime-projector.ts'
 
 function uniqueUserDataDir(name: string) {
   return mkdtempSync(join(tmpdir(), `open-cowork-crew-service-${name}-`))
@@ -323,6 +327,72 @@ test('crew service runs a structured evaluator session and records the outcome',
     ])
     assert.equal(evaluated.traceEvents.at(-1)?.sessionId, 'evaluator-session-1')
     assert.equal(evaluated.traceEvents.at(-1)?.payload?.discardedEvidenceTraceEventCount, 1)
+  })
+})
+
+test('crew service auto-runs evaluation once when the root session reaches ready-for-evaluation', async () => {
+  await withCrewStoreAsync('auto-evaluate', async () => {
+    const crew = createCrewFromDraft(draft())
+    const dispatched = await startCrewRunWithOpenCode({
+      crewId: crew.definition.id,
+      title: 'Analyze the weekly market',
+    }, {
+      async createRootSession() {
+        return { id: 'root-session-auto' }
+      },
+      async prompt() {},
+      async evaluateOutcome() {
+        throw new Error('not used')
+      },
+    })
+
+    projectCrewRuntimeEvent({
+      type: 'done',
+      sessionId: 'root-session-auto',
+      data: { type: 'done' },
+    })
+
+    const ready = getCrewRunDetail(dispatched.run.id)
+    assert.equal(ready?.run.status, 'evaluating')
+    assert.equal(ready?.traceEvents.at(-1)?.payload?.type, 'crew_run.ready_for_evaluation')
+
+    let evaluateCalls = 0
+    const driver: CrewRuntimeExecutionDriver = {
+      async createRootSession() {
+        throw new Error('not used')
+      },
+      async prompt() {
+        throw new Error('not used')
+      },
+      async evaluateOutcome() {
+        evaluateCalls += 1
+        const evidenceId = getCrewRunDetail(dispatched.run.id)?.traceEvents.find((event) => event.source !== 'cowork_eval')?.id
+        assert.ok(evidenceId)
+        return {
+          sessionId: 'evaluator-session-auto',
+          text: '',
+          structured: {
+            type: 'open_cowork.crew_outcome_evaluation',
+            version: 1,
+            status: 'passed',
+            score: 88,
+            recommendation: 'deliver',
+            summary: 'Ready after automatic evaluation.',
+            evidenceTraceEventIds: [evidenceId],
+          },
+        }
+      },
+    }
+
+    const evaluated = await evaluateCrewRunForRootSessionIdle('root-session-auto', driver)
+    assert.equal(evaluateCalls, 1)
+    assert.equal(evaluated?.run.status, 'completed')
+    assert.equal(evaluated?.evaluations[0]?.score, 88)
+    assert.equal(evaluated?.traceEvents.at(-1)?.payload?.type, 'crew_run.evaluation_recorded')
+
+    const second = await evaluateCrewRunForRootSessionIdle('root-session-auto', driver)
+    assert.equal(evaluateCalls, 1)
+    assert.equal(second?.run.status, 'completed')
   })
 })
 


### PR DESCRIPTION
## Summary

- Auto-runs the existing structured crew evaluator when a root crew session reaches the ready-for-evaluation state.
- Gates the hook on the durable crew run status plus the crew_run.ready_for_evaluation trace event.
- Prevents duplicate evaluator dispatches for already evaluated or in-flight runs.
- Keeps the manual crews:evaluate path intact.

## Why

This closes the #245 lifecycle gap where the crew runtime projector could move a run to evaluating, but the evaluator only ran after a manual UI action. The Minimum Lovable Crew flow now advances from root completion into outcome evaluation without adding a second runtime.

## Validation

- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/crew-service.test.ts tests/crew-runtime-projector.test.ts tests/event-runtime-handlers.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check