### PR TITLE
[codex] expose crew trace export api

### DIFF
--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -24,6 +24,7 @@ import {
   createCrewRunNode,
   createCrewVersion,
   createOutcomeRubric,
+  exportCoworkTraceEventsForRun,
   getCrewDefinition,
   getCoworkWorkItem,
   getCrewRun,
@@ -770,4 +771,10 @@ export function getCrewRunDetail(runId: string): CrewRunDetail | null {
     evaluations: listOutcomeEvaluationsForRun(run.id),
     traceEvents: listCoworkTraceEventsForRun(run.id),
   }
+}
+
+export function exportCrewRunTraceNdjson(runId: string): string {
+  const id = boundedString(runId, 'Crew run id')
+  if (!getCrewRun(id)) throw new Error(`Crew run ${id} does not exist.`)
+  return exportCoworkTraceEventsForRun(id)
 }

--- a/apps/desktop/src/main/ipc/crew-handlers.ts
+++ b/apps/desktop/src/main/ipc/crew-handlers.ts
@@ -2,6 +2,7 @@ import type { CrewDefinitionDraft, CrewRunDraft } from '@open-cowork/shared'
 import {
   createCrewFromDraft,
   evaluateCrewRunWithOpenCode,
+  exportCrewRunTraceNdjson,
   getCrewDetail,
   getCrewRunDetail,
   listCrewCatalog,
@@ -85,5 +86,10 @@ export function registerCrewHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('crews:evaluate', async (_event, runId: string) => {
     assertString(runId, 'Crew run id')
     return evaluateCrewRunWithOpenCode(runId, createOpenCodeCrewRuntimeDriver())
+  })
+
+  context.ipcMain.handle('crews:export-trace', async (_event, runId: string) => {
+    assertString(runId, 'Crew run id')
+    return exportCrewRunTraceNdjson(runId)
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -101,6 +101,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'crews:run',
   'crews:run-detail',
   'crews:evaluate',
+  'crews:export-trace',
   'threads:search',
   'threads:facets',
   'threads:tags:list',
@@ -308,6 +309,7 @@ const api: CoworkAPI = {
     run: (draft) => invoke('crews:run', draft),
     runDetail: (runId) => invoke('crews:run-detail', runId),
     evaluate: (runId) => invoke('crews:evaluate', runId),
+    exportTrace: (runId) => invoke('crews:export-trace', runId),
   },
   threads: {
     search: (query) => invoke('threads:search', query),

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -181,6 +181,11 @@ function payload(): CrewListPayload {
   }
 }
 
+const traceNdjson = [
+  '{"schemaVersion":1,"id":"trace-1","payload":{"type":"crew_run.created"}}',
+  '{"schemaVersion":1,"id":"trace-2","payload":{"type":"crew_run.tool_call","toolName":"web_search"}}',
+].join('\n')
+
 describe('CrewsPage', () => {
   it('loads crew detail and renders operational run panels from trace state', async () => {
     installRendererTestCoworkApi({
@@ -189,6 +194,7 @@ describe('CrewsPage', () => {
         get: vi.fn(async () => detail),
         runDetail: vi.fn(async () => runDetail),
         evaluate: vi.fn(async () => runDetail),
+        exportTrace: vi.fn(async () => traceNdjson),
       },
     })
 
@@ -218,6 +224,7 @@ describe('CrewsPage', () => {
         run: runCrew,
         runDetail: vi.fn(async () => null),
         evaluate: vi.fn(async () => runDetail),
+        exportTrace: vi.fn(async () => traceNdjson),
       },
     })
 
@@ -242,12 +249,14 @@ describe('CrewsPage', () => {
   it('exports trace events as deterministic NDJSON through the save dialog', async () => {
     const user = userEvent.setup()
     const saveText = vi.fn(async (_defaultFilename: string, _content: string) => '/tmp/crew-trace.ndjson')
+    const exportTrace = vi.fn(async () => traceNdjson)
     installRendererTestCoworkApi({
       crews: {
         list: vi.fn(async () => payload()),
         get: vi.fn(async () => detail),
         runDetail: vi.fn(async () => runDetail),
         evaluate: vi.fn(async () => runDetail),
+        exportTrace,
       },
       dialog: {
         saveText,
@@ -259,6 +268,7 @@ describe('CrewsPage', () => {
     await user.click(await screen.findByRole('button', { name: 'Export trace' }))
 
     await waitFor(() => expect(saveText).toHaveBeenCalledTimes(1))
+    expect(exportTrace).toHaveBeenCalledWith(run.id)
     expect(saveText.mock.calls[0]?.[0]).toBe('research-crew-demo-run-trace.ndjson')
     expect(saveText.mock.calls[0]?.[1]).toContain('"id":"trace-1"')
     expect(saveText.mock.calls[0]?.[1]).toContain('"type":"crew_run.tool_call"')
@@ -276,6 +286,7 @@ describe('CrewsPage', () => {
         get: vi.fn(async () => detail),
         runDetail: vi.fn(async () => runDetail),
         evaluate,
+        exportTrace: vi.fn(async () => traceNdjson),
       },
     })
 

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { serializeCoworkTraceEvent, sortCoworkTraceEvents, type CrewDetail, type CrewListItem, type CrewRunDetail } from '@open-cowork/shared'
+import type { CrewDetail, CrewListItem, CrewRunDetail } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import {
   nodeLabelForTrace,
@@ -381,8 +381,8 @@ export function CrewsPage() {
     setBusy(true)
     setError(null)
     try {
-      const content = sortCoworkTraceEvents(runDetail.traceEvents).map(serializeCoworkTraceEvent).join('\n')
-      await window.coworkApi.dialog.saveText(`${runDetail.run.title.replace(/[^a-z0-9-]+/gi, '-').toLowerCase()}-trace.ndjson`, `${content}\n`)
+      const content = await window.coworkApi.crews.exportTrace(runDetail.run.id)
+      await window.coworkApi.dialog.saveText(`${runDetail.run.title.replace(/[^a-z0-9-]+/gi, '-').toLowerCase()}-trace.ndjson`, content ? `${content}\n` : '')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to export crew trace.')
     } finally {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -305,6 +305,7 @@ export interface CoworkAPI {
     run: (draft: CrewRunDraft) => Promise<CrewRunDetail>
     runDetail: (runId: string) => Promise<CrewRunDetail | null>
     evaluate: (runId: string) => Promise<CrewRunDetail>
+    exportTrace: (runId: string) => Promise<string>
   }
   threads: {
     search: (query?: ThreadSearchQuery) => Promise<ThreadSearchResult>

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -14,6 +14,7 @@ import {
   evaluateCrewRunForRootSessionIdle,
   evaluateCrewRunWithOpenCode,
   executeCrewRunWithOpenCode,
+  exportCrewRunTraceNdjson,
   getCrewDetail,
   getCrewRunDetail,
   listCrewCatalog,
@@ -175,6 +176,22 @@ test('crew service records evaluator pass results as durable evals and trace eve
   assert.deepEqual(evaluated.evaluations[0]?.evidenceTraceEventIds, [runDetail.traceEvents[0]!.id])
   assert.equal(evaluated.traceEvents.at(-1)?.source, 'cowork_eval')
   assert.equal(evaluated.traceEvents.at(-1)?.payload?.type, 'crew_run.evaluation_recorded')
+}))
+
+test('crew service exports run traces from the durable ledger as NDJSON', () => withCrewStore('trace-export', () => {
+  const crew = createCrewFromDraft(draft())
+  const runDetail = startCrewRun({
+    crewId: crew.definition.id,
+    title: 'Analyze the weekly market',
+  })
+
+  const exported = exportCrewRunTraceNdjson(runDetail.run.id)
+  const rows = exported.split('\n').map((line) => JSON.parse(line) as Record<string, unknown>)
+
+  assert.deepEqual(rows.map((row) => row.id), runDetail.traceEvents.map((event) => event.id))
+  assert.deepEqual(rows.map((row) => row.sequence), runDetail.traceEvents.map((event) => event.sequence))
+  assert.equal((rows[0]?.payload as Record<string, unknown> | undefined)?.type, 'crew_run.created')
+  assert.throws(() => exportCrewRunTraceNdjson('missing-run'), /Crew run missing-run does not exist/)
 }))
 
 test('crew service blocks delivery when evaluator requests revision or escalation', () => withCrewStore('evaluation-block', () => {

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -111,6 +111,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('crews:create'), true)
   assert.equal(handlers.has('crews:run'), true)
   assert.equal(handlers.has('crews:evaluate'), true)
+  assert.equal(handlers.has('crews:export-trace'), true)
   assert.equal(handlers.has('threads:tags:apply'), true)
   assert.equal(handlers.has('threads:smart-filters:create'), true)
   assert.equal(handlers.has('threads:suggestions:accept'), true)


### PR DESCRIPTION
## Summary

- Adds a typed crews:export-trace IPC/API surface for Crew Run trace export.
- Produces NDJSON from the durable main-process crew trace ledger instead of rebuilding export content in the renderer.
- Updates the Crews page to save the main-owned export payload.
- Extends IPC parity, service, store-backed export, and renderer tests.

## Why

This tightens the #245 trace export acceptance path. The export now has an explicit product contract over durable trace state, with deterministic ordering and redaction handled by the existing trace serializer.

## Validation

- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/crew-service.test.ts tests/crew-store.test.ts tests/ipc-handler-registration.test.ts
- pnpm test:renderer
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check