### PR TITLE
[codex] add SOP run operational detail projection

### DIFF
--- a/apps/desktop/src/main/automation-store.ts
+++ b/apps/desktop/src/main/automation-store.ts
@@ -238,8 +238,8 @@ export function markRunStarted(runId: string, sessionId: string | null) {
     db.prepare('update automations set latest_run_status = ?, latest_run_id = ?, latest_session_id = ?, updated_at = ?, status = ? where id = ?')
       .run('running', runId, sessionId, now, 'running', run.automationId)
     if (run.kind === 'execution') {
-      db.prepare('update automation_work_items set status = ?, blocking_reason = null, updated_at = ? where automation_id = ? and status = ?')
-        .run('running', now, run.automationId, 'ready')
+      db.prepare('update automation_work_items set status = ?, run_id = ?, blocking_reason = null, updated_at = ? where automation_id = ? and status = ?')
+        .run('running', runId, now, run.automationId, 'ready')
     }
   })
   return getRun(runId)

--- a/apps/desktop/src/main/ipc/sop-handlers.ts
+++ b/apps/desktop/src/main/ipc/sop-handlers.ts
@@ -1,6 +1,7 @@
 import type { SopDraft } from '@open-cowork/shared'
 import {
   getSop,
+  getSopRunDetail,
   listSopDefinitions,
   runSopNow,
   saveAutomationRunAsSop,
@@ -110,5 +111,10 @@ export function registerSopHandlers(context: IpcHandlerContext) {
     assertString(sopId, 'SOP id')
     assertInputPayload(inputs)
     return runSopNow(sopId, inputs || {})
+  })
+
+  context.ipcMain.handle('sops:run-detail', async (_event, automationRunId: string) => {
+    assertString(automationRunId, 'Automation run id')
+    return getSopRunDetail(automationRunId)
   })
 }

--- a/apps/desktop/src/main/sop-service.ts
+++ b/apps/desktop/src/main/sop-service.ts
@@ -1,8 +1,13 @@
 import type {
+  AutomationDeliveryRecord,
   AutomationDetail,
+  AutomationInboxItem,
   AutomationRun,
+  AutomationWorkItem,
   ExecutionBrief,
   SopDraft,
+  SopRunDetail,
+  SopRunFailure,
   SopRunLink,
   SopTriggerType,
   SopWorkflowStep,
@@ -13,10 +18,18 @@ import {
   getAutomationDetail,
   getRun,
 } from './automation-store.ts'
+import { getDb } from './automation-store-db.ts'
+import {
+  rowToDelivery,
+  rowToInbox,
+  rowToWorkItem,
+  type DbRow,
+} from './automation-store-model.ts'
 import {
   createSopDefinitionWithRunLink,
   getSopDetail,
   getSopRunLinkForAutomationRun,
+  getSopVersion,
   linkAutomationRunToSopVersion,
   listSops,
   updateSopDefinition,
@@ -121,6 +134,106 @@ export function listSopDefinitions() {
 
 export function getSop(sopId: string) {
   return getSopDetail(sopId)
+}
+
+function listRunInboxItems(run: AutomationRun): AutomationInboxItem[] {
+  const rows = getDb().prepare(`
+    select *
+    from automation_inbox
+    where run_id = ?
+    order by updated_at desc, id desc
+  `).all(run.id) as DbRow[]
+  return rows.map(rowToInbox)
+}
+
+function listRunWorkItems(run: AutomationRun): AutomationWorkItem[] {
+  const rows = getDb().prepare(`
+    select *
+    from automation_work_items
+    where run_id = ?
+    order by updated_at desc, id desc
+  `).all(run.id) as DbRow[]
+  return rows.map(rowToWorkItem)
+}
+
+function listRunDeliveries(run: AutomationRun): AutomationDeliveryRecord[] {
+  const rows = getDb().prepare(`
+    select *
+    from automation_deliveries
+    where run_id = ?
+    order by created_at desc, id desc
+  `).all(run.id) as DbRow[]
+  return rows.map(rowToDelivery)
+}
+
+function failuresForRun(run: AutomationRun, inbox: AutomationInboxItem[], deliveries: AutomationDeliveryRecord[]): SopRunFailure[] {
+  const failures: SopRunFailure[] = []
+  if (run.status === 'failed' || run.error) {
+    failures.push({
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      source: 'run',
+      id: run.id,
+      title: run.failureCode || 'run_failed',
+      message: run.error || 'Run failed without a recorded error message.',
+      createdAt: run.finishedAt || run.startedAt || run.createdAt,
+    })
+  }
+  for (const item of inbox) {
+    if (item.type !== 'failure') continue
+    failures.push({
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      source: 'inbox',
+      id: item.id,
+      title: item.title,
+      message: item.body,
+      createdAt: item.createdAt,
+    })
+  }
+  for (const delivery of deliveries) {
+    if (delivery.status !== 'failed') continue
+    failures.push({
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      source: 'delivery',
+      id: delivery.id,
+      title: delivery.title,
+      message: delivery.body,
+      createdAt: delivery.createdAt,
+    })
+  }
+  return failures.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+}
+
+export function getSopRunDetail(automationRunId: string): SopRunDetail | null {
+  const link = getSopRunLinkForAutomationRun(automationRunId)
+  if (!link) return null
+  const version = getSopVersion(link.sopVersionId)
+  const sop = getSopDetail(link.sopId)
+  const automation = getAutomationDetail(link.automationId)
+  const run = getRun(link.automationRunId)
+  if (!version || !sop || !automation || !run) return null
+  const inbox = listRunInboxItems(run)
+  const workItems = listRunWorkItems(run)
+  const deliveries = listRunDeliveries(run)
+  return {
+    schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+    link,
+    definition: sop.definition,
+    version,
+    automation,
+    run,
+    inputs: link.inputs,
+    outputs: {
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      summary: run.summary,
+      deliveries,
+    },
+    workItems,
+    approvals: inbox.filter((item) => item.type === 'approval'),
+    inbox,
+    artifacts: [],
+    evaluatorResults: [],
+    failures: failuresForRun(run, inbox, deliveries),
+  }
 }
 
 export function saveAutomationRunAsSop(runId: string) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -108,6 +108,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'sops:save-from-automation-run',
   'sops:update',
   'sops:run-now',
+  'sops:run-detail',
   'threads:search',
   'threads:facets',
   'threads:tags:list',
@@ -324,6 +325,7 @@ const api: CoworkAPI = {
     saveFromAutomationRun: (runId) => invoke('sops:save-from-automation-run', runId),
     update: (sopId, draft) => invoke('sops:update', sopId, draft),
     runNow: (sopId, inputs) => invoke('sops:run-now', sopId, inputs),
+    runDetail: (automationRunId) => invoke('sops:run-detail', automationRunId),
   },
   threads: {
     search: (query) => invoke('threads:search', query),

--- a/apps/desktop/src/renderer/components/automations/AutomationCardDetail.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCardDetail.test.tsx
@@ -1,7 +1,8 @@
 import type { ComponentProps } from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
+import { COWORK_SOP_SCHEMA_VERSION } from '@open-cowork/shared'
 import type {
   AutomationDeliveryRecord,
   AutomationDetail,
@@ -9,6 +10,7 @@ import type {
   AutomationRun,
   AutomationWorkItem,
   ExecutionBrief,
+  SopRunDetail,
 } from '@open-cowork/shared'
 import { AutomationCardDetail } from './AutomationCardDetail'
 
@@ -141,6 +143,92 @@ function delivery(overrides: Partial<AutomationDeliveryRecord> = {}): Automation
     title: 'Report ready',
     body: 'The weekly report is ready.',
     createdAt: '2026-01-01T02:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function sopRunDetail(overrides: Partial<SopRunDetail> = {}): SopRunDetail {
+  const baseAutomation = automation()
+  const baseRun = run()
+  return {
+    schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+    link: {
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      id: 'sop-run-link-1',
+      sopId: 'sop-1',
+      sopVersionId: 'sop-version-2',
+      automationId: baseAutomation.id,
+      automationRunId: baseRun.id,
+      triggerType: 'manual',
+      inputs: { requester: 'qa-user', priority: 'high' },
+      createdAt: '2026-01-01T00:00:00.000Z',
+    },
+    definition: {
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      id: 'sop-1',
+      name: 'Weekly report SOP',
+      description: 'Reusable weekly report process.',
+      status: 'active',
+      activeVersionId: 'sop-version-2',
+      sourceAutomationId: baseAutomation.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    version: {
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      id: 'sop-version-2',
+      sopId: 'sop-1',
+      version: 2,
+      sourceAutomationId: baseAutomation.id,
+      sourceRunId: baseRun.id,
+      triggerTypes: ['manual'],
+      requiredInputs: [],
+      workflow: [],
+      approvalPolicy: {
+        schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+        reviewFirst: true,
+        approvalBoundary: 'Review before delivery.',
+      },
+      retryPolicy: {
+        maxRetries: 3,
+        baseDelayMinutes: 5,
+        maxDelayMinutes: 60,
+      },
+      runPolicy: {
+        dailyRunCap: 6,
+        maxRunDurationMinutes: 120,
+      },
+      deliveryPolicy: {
+        schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+        provider: 'in_app',
+        target: 'automation-inbox',
+        draftFirst: true,
+      },
+      outcomeRubricId: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      createdBy: null,
+    },
+    automation: baseAutomation,
+    run: baseRun,
+    inputs: { requester: 'qa-user', priority: 'high' },
+    outputs: {
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      summary: 'Delivered the report.',
+      deliveries: [delivery()],
+    },
+    workItems: [workItem()],
+    approvals: [inboxItem()],
+    inbox: [inboxItem()],
+    artifacts: [],
+    evaluatorResults: [],
+    failures: [{
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      source: 'delivery',
+      id: 'failure-1',
+      title: 'Delivery failed',
+      message: 'Delivery target rejected the payload.',
+      createdAt: '2026-01-01T02:00:00.000Z',
+    }],
     ...overrides,
   }
 }
@@ -309,5 +397,27 @@ describe('AutomationCardDetail', () => {
     await user.click(screen.getAllByRole('button', { name: 'Save as SOP' })[1]!)
 
     expect(props.onSaveAsSop).toHaveBeenCalledWith('completed-run')
+  })
+
+  it('shows SOP run operational detail alongside automation history', async () => {
+    const user = userEvent.setup()
+    renderDetail({
+      runs: [run()],
+      sopRunDetailsByRunId: {
+        'run-1': sopRunDetail(),
+      },
+    })
+
+    await user.click(screen.getByRole('button', { name: 'History' }))
+
+    const detailCard = screen.getByLabelText('SOP run detail for Execute report')
+    expect(within(detailCard).getByText('SOP v2')).toBeInTheDocument()
+    expect(within(detailCard).getByText('manual trigger')).toBeInTheDocument()
+    expect(within(detailCard).getByText(/requester: qa-user/)).toBeInTheDocument()
+    expect(within(detailCard).getByText(/priority: high/)).toBeInTheDocument()
+    expect(within(detailCard).getByText(/Delivery target rejected the payload/)).toBeInTheDocument()
+    expect(within(detailCard).getByText('Work')).toBeInTheDocument()
+    expect(within(detailCard).getByText('Approvals')).toBeInTheDocument()
+    expect(within(detailCard).getByText('Deliveries')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
@@ -6,6 +6,7 @@ import type {
   AutomationInboxItem,
   AutomationRun,
   AutomationWorkItem,
+  SopRunDetail,
 } from '@open-cowork/shared'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
@@ -34,6 +35,7 @@ type Props = {
   workItems: AutomationWorkItem[]
   runs: AutomationRun[]
   deliveries: AutomationDeliveryRecord[]
+  sopRunDetailsByRunId?: Record<string, SopRunDetail>
   agentOptions: AutomationAgentOption[]
   onClose: () => void
   onOpenThread?: (sessionId: string) => void
@@ -68,12 +70,19 @@ function tabLabel(tab: DetailTab) {
   return 'Settings'
 }
 
+function inputSummary(inputs: Record<string, unknown>) {
+  const entries = Object.entries(inputs).filter(([, value]) => value !== undefined && value !== null && value !== '')
+  if (entries.length === 0) return 'No recorded inputs'
+  return entries.slice(0, 4).map(([key, value]) => `${key}: ${typeof value === 'string' ? value : JSON.stringify(value)}`).join(' · ')
+}
+
 export function AutomationCardDetail({
   automation,
   inbox,
   workItems,
   runs,
   deliveries,
+  sopRunDetailsByRunId = {},
   agentOptions,
   onClose,
   onOpenThread,
@@ -332,31 +341,64 @@ export function AutomationCardDetail({
               <div className="space-y-3">
                 {runs.length === 0 ? (
                   <div className="text-[12px] text-text-muted">No runs yet.</div>
-                ) : runs.map((run) => (
-                  <div key={run.id} className="rounded-xl border border-border px-3 py-3">
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="text-[12px] font-medium text-text">{run.title}</div>
-                      <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{run.status}</span>
+                ) : runs.map((run) => {
+                  const sopRunDetail = sopRunDetailsByRunId[run.id]
+                  const evaluationDetail = !sopRunDetail || sopRunDetail.failures.length === 0
+                    ? 'quality'
+                    : sopRunDetail.failures.length === 1
+                      ? '1 failure'
+                      : `${sopRunDetail.failures.length} failures`
+                  return (
+                    <div key={run.id} className="rounded-xl border border-border px-3 py-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="text-[12px] font-medium text-text">{run.title}</div>
+                        <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{run.status}</span>
+                      </div>
+                      <div className="mt-1 text-[11px] text-text-muted">{formatTimestamp(run.createdAt)} · attempt {run.attempt}{run.nextRetryAt ? ` · retrying ${formatTimestamp(run.nextRetryAt)}` : ''}</div>
+                      {run.summary ? <div className="mt-2 whitespace-pre-wrap text-[12px] text-text-secondary">{run.summary}</div> : null}
+                      {run.error ? <div className="mt-2 text-[12px]" style={{ color: 'var(--color-red)' }}>{run.error}</div> : null}
+                      {sopRunDetail ? (
+                        <div className="mt-3 rounded-lg border border-border-subtle bg-elevated px-3 py-3" aria-label={`SOP run detail for ${run.title}`}>
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-text-muted">SOP v{sopRunDetail.version.version}</div>
+                            <div className="text-[11px] text-text-muted">{sopRunDetail.link.triggerType} trigger</div>
+                          </div>
+                          <div className="mt-2 text-[12px] leading-5 text-text-secondary">{inputSummary(sopRunDetail.inputs)}</div>
+                          <div className="mt-3 grid grid-cols-2 gap-2 md:grid-cols-5">
+                            <SummaryCard label="Work" value={String(sopRunDetail.workItems.length)} detail="items" compact />
+                            <SummaryCard label="Approvals" value={String(sopRunDetail.approvals.length)} detail="gates" compact />
+                            <SummaryCard label="Deliveries" value={String(sopRunDetail.outputs.deliveries.length)} detail="outputs" compact />
+                            <SummaryCard label="Artifacts" value={String(sopRunDetail.artifacts.length)} detail="files" compact />
+                            <SummaryCard label="Evals" value={String(sopRunDetail.evaluatorResults.length)} detail={evaluationDetail} compact />
+                          </div>
+                          {sopRunDetail.failures.length > 0 ? (
+                            <div className="mt-3 space-y-2">
+                              {sopRunDetail.failures.slice(0, 3).map((failure) => (
+                                <div key={`${failure.source}:${failure.id}`} className="text-[11px]" style={{ color: 'var(--color-red)' }}>
+                                  {failure.source}: {failure.message}
+                                </div>
+                              ))}
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : null}
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {run.status === 'running' ? (
+                          <button type="button" onClick={() => void onCancelRun(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Cancel run</button>
+                        ) : null}
+                        {run.status === 'failed' || run.status === 'cancelled' ? (
+                          <button type="button" disabled={isArchived || hasActiveRun} onClick={() => void onRetryRun(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer disabled:opacity-50">Retry run</button>
+                        ) : null}
+                        {run.status === 'completed' ? (
+                          <button type="button" onClick={() => void onSaveAsSop(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Save as SOP</button>
+                        ) : null}
+                        {run.sessionId && onOpenThread ? (
+                          <button type="button" onClick={() => onOpenThread(run.sessionId!)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Open thread</button>
+                        ) : null}
+                      </div>
                     </div>
-                    <div className="mt-1 text-[11px] text-text-muted">{formatTimestamp(run.createdAt)} · attempt {run.attempt}{run.nextRetryAt ? ` · retrying ${formatTimestamp(run.nextRetryAt)}` : ''}</div>
-                    {run.summary ? <div className="mt-2 whitespace-pre-wrap text-[12px] text-text-secondary">{run.summary}</div> : null}
-                    {run.error ? <div className="mt-2 text-[12px]" style={{ color: 'var(--color-red)' }}>{run.error}</div> : null}
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      {run.status === 'running' ? (
-                        <button type="button" onClick={() => void onCancelRun(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Cancel run</button>
-                      ) : null}
-                      {run.status === 'failed' || run.status === 'cancelled' ? (
-                        <button type="button" disabled={isArchived || hasActiveRun} onClick={() => void onRetryRun(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer disabled:opacity-50">Retry run</button>
-                      ) : null}
-                      {run.status === 'completed' ? (
-                        <button type="button" onClick={() => void onSaveAsSop(run.id)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Save as SOP</button>
-                      ) : null}
-                      {run.sessionId && onOpenThread ? (
-                        <button type="button" onClick={() => onOpenThread(run.sessionId!)} className="rounded-xl border border-border px-3 py-2 text-[11px] cursor-pointer">Open thread</button>
-                      ) : null}
-                    </div>
-                  </div>
-                ))}
+                  )
+                })}
               </div>
             </DetailSection>
           ) : null}

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -6,6 +6,7 @@ import type {
   BuiltInAgentDetail,
   CustomAgentSummary,
   SopListPayload,
+  SopRunDetail,
 } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import { useSessionStore } from '../../stores/session'
@@ -61,11 +62,24 @@ function reportAutomationSopsError(error: unknown) {
   }
 }
 
+function reportAutomationSopRunDetailError(error: unknown) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `Failed to load SOP run detail: ${describeAutomationDefaultsError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'automations',
+    })
+  } catch {
+    // Diagnostics are best-effort when historical SOP run detail is unavailable.
+  }
+}
+
 export function AutomationsPage({ onOpenThread }: Props) {
   const [payload, setPayload] = useState<AutomationListPayload>({ automations: [], inbox: [], workItems: [], runs: [], deliveries: [] })
   const [sopPayload, setSopPayload] = useState<SopListPayload>({ sops: [] })
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null)
   const [selectedAutomation, setSelectedAutomation] = useState<AutomationDetail | null>(null)
+  const [selectedSopRunDetailsByRunId, setSelectedSopRunDetailsByRunId] = useState<Record<string, SopRunDetail>>({})
   const [selectedAgentOptions, setSelectedAgentOptions] = useState<AutomationAgentOption[]>([])
   const [draftDefaults, setDraftDefaults] = useState<DraftState>(() => createDefaultDraft())
   const [wizardDefaults, setWizardDefaults] = useState<DraftState>(() => createDefaultDraft())
@@ -159,6 +173,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
     let cancelled = false
     if (!selectedAutomation) {
       setSelectedAgentOptions([])
+      setSelectedSopRunDetailsByRunId({})
       return () => {
         cancelled = true
       }
@@ -187,6 +202,30 @@ export function AutomationsPage({ onOpenThread }: Props) {
   const selectedWorkItems = useMemo(() => payload.workItems.filter((item) => item.automationId === selectedAutomationId), [payload.workItems, selectedAutomationId])
   const selectedRuns = useMemo(() => payload.runs.filter((item) => item.automationId === selectedAutomationId), [payload.runs, selectedAutomationId])
   const selectedDeliveries = useMemo(() => payload.deliveries.filter((item) => item.automationId === selectedAutomationId), [payload.deliveries, selectedAutomationId])
+
+  useEffect(() => {
+    let cancelled = false
+    if (selectedRuns.length === 0) {
+      setSelectedSopRunDetailsByRunId({})
+      return () => {
+        cancelled = true
+      }
+    }
+    void Promise.all(selectedRuns.map(async (run): Promise<[string, SopRunDetail | null]> => {
+      try {
+        return [run.id, await window.coworkApi.sops.runDetail(run.id)]
+      } catch (err) {
+        reportAutomationSopRunDetailError(err)
+        return [run.id, null]
+      }
+    })).then((entries) => {
+      if (cancelled) return
+      setSelectedSopRunDetailsByRunId(Object.fromEntries(entries.filter((entry): entry is [string, SopRunDetail] => Boolean(entry[1]))))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedRuns])
 
   const executeDropAction = async (action: Extract<AutomationDropAction, { valid: true }>) => {
     setFeedback(null)
@@ -360,6 +399,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
           workItems={selectedWorkItems}
           runs={selectedRuns}
           deliveries={selectedDeliveries}
+          sopRunDetailsByRunId={selectedSopRunDetailsByRunId}
           agentOptions={selectedAgentOptions}
           onClose={() => {
             setSelectedAutomationId(null)

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -113,6 +113,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       runNow: vi.fn(async () => {
         throw new Error('sops.runNow not mocked')
       }),
+      runDetail: vi.fn(async () => null),
     },
     artifact: {
       cleanup: vi.fn(async (mode) => ({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -66,6 +66,7 @@ import type {
   SopDetail,
   SopDraft,
   SopListPayload,
+  SopRunDetail,
   SopRunLink,
 } from './sops.js'
 import type {
@@ -311,6 +312,7 @@ export interface CoworkAPI {
     saveFromAutomationRun: (runId: string) => Promise<SopDetail>
     update: (sopId: string, draft: SopDraft) => Promise<SopDetail>
     runNow: (sopId: string, inputs?: Record<string, unknown>) => Promise<SopRunLink>
+    runDetail: (automationRunId: string) => Promise<SopRunDetail | null>
   }
   crews: {
     list: () => Promise<CrewListPayload>

--- a/packages/shared/src/sops.ts
+++ b/packages/shared/src/sops.ts
@@ -1,7 +1,12 @@
 import type {
   AutomationDeliveryProvider,
+  AutomationDeliveryRecord,
+  AutomationDetail,
+  AutomationInboxItem,
+  AutomationRun,
   AutomationRetryPolicy,
   AutomationRunPolicy,
+  AutomationWorkItem,
 } from './automation.js'
 
 export const COWORK_SOP_SCHEMA_VERSION = 1
@@ -107,4 +112,51 @@ export interface SopDetail {
   versions: SopVersion[]
   activeVersion: SopVersion | null
   runLinks: SopRunLink[]
+}
+
+export interface SopRunArtifact extends SopSchemaVersionedRecord {
+  id: string
+  title: string
+  mime: string
+  uri: string
+  hash: string | null
+  createdAt: string
+}
+
+export interface SopRunEvaluationResult extends SopSchemaVersionedRecord {
+  id: string
+  status: 'passed' | 'failed' | 'needs_revision' | 'needs_human'
+  score: number
+  summary: string
+  recommendation: 'deliver' | 'revise' | 'escalate'
+  createdAt: string
+}
+
+export interface SopRunFailure extends SopSchemaVersionedRecord {
+  source: 'run' | 'inbox' | 'delivery'
+  id: string
+  title: string
+  message: string
+  createdAt: string
+}
+
+export interface SopRunOutput extends SopSchemaVersionedRecord {
+  summary: string | null
+  deliveries: AutomationDeliveryRecord[]
+}
+
+export interface SopRunDetail extends SopSchemaVersionedRecord {
+  link: SopRunLink
+  definition: SopDefinition
+  version: SopVersion
+  automation: AutomationDetail
+  run: AutomationRun
+  inputs: Record<string, unknown>
+  outputs: SopRunOutput
+  workItems: AutomationWorkItem[]
+  approvals: AutomationInboxItem[]
+  inbox: AutomationInboxItem[]
+  artifacts: SopRunArtifact[]
+  evaluatorResults: SopRunEvaluationResult[]
+  failures: SopRunFailure[]
 }

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -118,6 +118,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('sops:list'), true)
   assert.equal(handlers.has('sops:save-from-automation-run'), true)
   assert.equal(handlers.has('sops:run-now'), true)
+  assert.equal(handlers.has('sops:run-detail'), true)
   assert.equal(handlers.has('threads:tags:apply'), true)
   assert.equal(handlers.has('threads:smart-filters:create'), true)
   assert.equal(handlers.has('threads:suggestions:accept'), true)

--- a/tests/sop-store.test.ts
+++ b/tests/sop-store.test.ts
@@ -8,14 +8,19 @@ import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import {
   clearAutomationStoreCache,
   createAutomation,
+  createDeliveryRecord,
   createAutomationRun,
+  createInboxItem,
   getRun,
   markRunCompleted,
+  markRunFailed,
+  markRunStarted,
   saveAutomationBrief,
 } from '../apps/desktop/src/main/automation-store.ts'
 import { AUTOMATION_DB_SCHEMA_VERSION, getDb } from '../apps/desktop/src/main/automation-store-db.ts'
 import {
   getSop,
+  getSopRunDetail,
   listSopDefinitions,
   runSopNow,
   saveAutomationRunAsSop,
@@ -93,6 +98,7 @@ function createCompletedAutomationRun(summary = 'Report prepared and ready for r
   })
   const run = createAutomationRun(automation.id, 'execution', 'Execute weekly report')
   assert.ok(run)
+  markRunStarted(run!.id, 'session-completed-run')
   markRunCompleted(run!.id, summary)
   return { automation, run: getRun(run!.id)! }
 }
@@ -262,6 +268,107 @@ test('manual SOP runs create automation runs linked to the active SOP version', 
     detail?.runLinks.map((entry) => entry.sopVersionId).sort(),
     [v1.activeVersion?.id, v2.activeVersion?.id].sort(),
   )
+}))
+
+test('SOP run detail projects durable automation operations for the exact version', () => withAutomationStore('run-detail', () => {
+  const { run } = createCompletedAutomationRun()
+  const sop = saveAutomationRunAsSop(run.id)
+  const link = runSopNow(sop.definition.id, { requester: 'qa-user', priority: 'high' })
+  const startedRun = getRun(link.automationRunId)
+  assert.ok(startedRun)
+  markRunStarted(startedRun!.id, 'session-run-detail')
+
+  const approval = createInboxItem({
+    automationId: startedRun!.automationId,
+    runId: startedRun!.id,
+    type: 'approval',
+    title: 'Approve delivery',
+    body: 'Review the SOP output before delivery.',
+    promoteAutomationStatus: false,
+  })
+  const failure = createInboxItem({
+    automationId: startedRun!.automationId,
+    runId: startedRun!.id,
+    type: 'failure',
+    title: 'Delivery failed',
+    body: 'The delivery target rejected the payload.',
+    promoteAutomationStatus: false,
+  })
+  const delivery = createDeliveryRecord({
+    automationId: startedRun!.automationId,
+    runId: startedRun!.id,
+    provider: 'in_app',
+    target: 'automation-inbox',
+    status: 'failed',
+    title: 'SOP delivery',
+    body: 'Delivery failed after execution.',
+  })
+  markRunFailed(startedRun!.id, 'Run exceeded its duration cap.', null, {
+    retryable: false,
+    failureCode: 'run_timeout',
+  })
+  saveAutomationBrief(startedRun!.automationId, {
+    version: 2,
+    status: 'ready',
+    goal: 'Prepare a refreshed report.',
+    deliverables: ['Refreshed report'],
+    assumptions: ['Newer brief should not rewrite old SOP run detail.'],
+    missingContext: [],
+    successCriteria: ['Readable summary'],
+    recommendedAgents: ['research'],
+    workItems: [
+      {
+        id: 'research-market',
+        title: 'Research market movement',
+        description: 'Collect competitor and trend changes.',
+        ownerAgent: 'research',
+        dependsOn: [],
+      },
+      {
+        id: 'chart-market',
+        title: 'Chart market movement',
+        description: 'Create the delivery chart.',
+        ownerAgent: 'charts',
+        dependsOn: ['research-market'],
+      },
+      {
+        id: 'newer-run-only',
+        title: 'Newer run only',
+        description: 'This work item belongs to a later run.',
+        ownerAgent: 'research',
+        dependsOn: [],
+      },
+    ],
+    approvalBoundary: 'Approve before sending anything externally.',
+    generatedAt: new Date().toISOString(),
+    approvedAt: new Date().toISOString(),
+  })
+  const newerRun = createAutomationRun(startedRun!.automationId, 'execution', 'Execute refreshed report')
+  assert.ok(newerRun)
+  markRunStarted(newerRun!.id, 'session-newer-run')
+
+  const sourceDetail = getSopRunDetail(run.id)
+  assert.ok(sourceDetail)
+  assert.equal(sourceDetail?.run.id, run.id)
+  assert.equal(sourceDetail?.workItems.length, 2)
+  assert.deepEqual(sourceDetail?.workItems.map((item) => item.id).sort(), ['chart-market', 'research-market'])
+  assert.equal(sourceDetail?.workItems.some((item) => item.id === 'newer-run-only'), false)
+
+  const detail = getSopRunDetail(startedRun!.id)
+  assert.ok(detail)
+  assert.equal(detail?.link.sopVersionId, sop.activeVersion?.id)
+  assert.equal(detail?.version.id, sop.activeVersion?.id)
+  assert.equal(detail?.run.id, startedRun!.id)
+  assert.equal(detail?.inputs.requester, 'qa-user')
+  assert.equal(detail?.outputs.summary, null)
+  assert.equal(detail?.outputs.deliveries[0]?.id, delivery?.id)
+  assert.equal(detail?.approvals[0]?.id, approval?.id)
+  assert.ok(detail?.inbox.some((item) => item.id === failure?.id))
+  assert.deepEqual(detail?.workItems, [])
+  assert.deepEqual(detail?.artifacts, [])
+  assert.deepEqual(detail?.evaluatorResults, [])
+  assert.deepEqual(detail?.failures.map((entry) => entry.source).sort(), ['delivery', 'inbox', 'run'])
+  assert.equal(getSopRunDetail('not-linked'), null)
 }))
 
 test('manual SOP runs preserve the backing automation active-run guard', () => withAutomationStore('run-now-active-guard', () => {


### PR DESCRIPTION
## Summary
- add a typed SOP run detail IPC projection for exact SOP version, inputs, automation run, work items, approvals, deliveries, and failures
- show linked SOP run operational detail inside automation history
- cover the store projection, IPC registration, preload mock, and renderer history card

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/sop-store.test.ts tests/ipc-handler-registration.test.ts
- pnpm --dir apps/desktop test:renderer -- AutomationCardDetail AutomationsPage
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check