### PR TITLE
[codex] validate SOP run eligibility before execution

### DIFF
--- a/apps/desktop/src/main/sop-service.ts
+++ b/apps/desktop/src/main/sop-service.ts
@@ -26,6 +26,7 @@ import {
   type DbRow,
 } from './automation-store-model.ts'
 import {
+  assertSopRunInputSnapshotSize,
   createSopDefinitionWithRunLink,
   getSopDetail,
   getSopRunLinkForAutomationRun,
@@ -36,6 +37,26 @@ import {
 } from './sop-store.ts'
 
 const RUN_PROVENANCE_SUMMARY_MAX_CHARS = 4_000
+
+function inputValueIsPresent(value: unknown) {
+  if (value === null || value === undefined) return false
+  if (typeof value === 'string') return value.trim().length > 0
+  if (Array.isArray(value)) return value.length > 0
+  return true
+}
+
+function assertSopRunEligible(detail: NonNullable<ReturnType<typeof getSopDetail>>, inputs: Record<string, unknown>) {
+  if (detail.definition.status !== 'active') throw new Error('Only active SOPs can be run.')
+  const activeVersion = detail.activeVersion
+  if (!activeVersion) throw new Error(`SOP ${detail.definition.id} has no active version.`)
+  const missingInputs = activeVersion.requiredInputs
+    .filter((input) => input.required && !inputValueIsPresent(inputs[input.id]))
+    .map((input) => input.label || input.id)
+  if (missingInputs.length > 0) {
+    throw new Error(`Missing required SOP input${missingInputs.length === 1 ? '' : 's'}: ${missingInputs.join(', ')}`)
+  }
+  assertSopRunInputSnapshotSize(inputs)
+}
 
 function step(id: string, kind: SopWorkflowStep['kind'], title: string, options: {
   agentName?: string | null
@@ -267,6 +288,7 @@ export function updateSop(sopId: string, draft: SopDraft) {
 export function runSopNow(sopId: string, inputs: Record<string, unknown> = {}): SopRunLink {
   const detail = getSopDetail(sopId)
   if (!detail?.activeVersion) throw new Error(`SOP ${sopId} has no active version.`)
+  assertSopRunEligible(detail, inputs)
   const automationId = detail.activeVersion.sourceAutomationId || detail.definition.sourceAutomationId
   if (!automationId) throw new Error('SOP has no backing automation to execute.')
   if (!detail.activeVersion.triggerTypes.includes('manual')) {

--- a/apps/desktop/src/main/sop-store.ts
+++ b/apps/desktop/src/main/sop-store.ts
@@ -28,7 +28,7 @@ const TRIGGER_TYPES = new Set<SopTriggerType>(['manual', 'schedule', 'inbox', 'w
 const STEP_KINDS = new Set<SopWorkflowStep['kind']>(['plan', 'execute', 'approval', 'evaluate', 'deliver'])
 const MAX_REQUIRED_INPUTS = 32
 const MAX_WORKFLOW_STEPS = 64
-const MAX_INPUT_SNAPSHOT_BYTES = 64 * 1024
+export const SOP_RUN_INPUT_SNAPSHOT_MAX_BYTES = 64 * 1024
 
 type SopDefinitionSource = {
   automationId?: string | null
@@ -251,7 +251,7 @@ function insertSopRunLink(
     throw new Error(`SOP version ${version.id} does not allow ${triggerType} triggers.`)
   }
   const inputs = input.inputs || {}
-  assertInputSnapshotSize(inputs)
+  assertSopRunInputSnapshotSize(inputs)
   const id = crypto.randomUUID()
   const now = new Date().toISOString()
   db.prepare(`
@@ -350,9 +350,9 @@ export function listSops(): SopListPayload {
   return { sops }
 }
 
-function assertInputSnapshotSize(inputs: Record<string, unknown>) {
+export function assertSopRunInputSnapshotSize(inputs: Record<string, unknown>) {
   const bytes = Buffer.byteLength(JSON.stringify(inputs), 'utf8')
-  if (bytes > MAX_INPUT_SNAPSHOT_BYTES) throw new Error('SOP run inputs are too large.')
+  if (bytes > SOP_RUN_INPUT_SNAPSHOT_MAX_BYTES) throw new Error('SOP run inputs are too large.')
 }
 
 export function linkAutomationRunToSopVersion(input: {

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -97,7 +97,15 @@ function sopPayload(overrides: Partial<SopListPayload> = {}): SopListPayload {
           sourceAutomationId: 'auto-1',
           sourceRunId: 'run-1',
           triggerTypes: ['manual', 'schedule'],
-          requiredInputs: [],
+          requiredInputs: [
+            {
+              schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+              id: 'project-directory',
+              label: 'Project directory',
+              description: 'Directory to run the SOP against.',
+              required: true,
+            },
+          ],
           workflow: [],
           approvalPolicy: {
             schemaVersion: COWORK_SOP_SCHEMA_VERSION,
@@ -361,8 +369,22 @@ describe('AutomationsPage', () => {
     await user.click(screen.getByRole('button', { name: 'Run SOP' }))
 
     await waitFor(() => expect(api.sopsRunNow).toHaveBeenCalledWith('sop-1', expect.objectContaining({
+      'project-directory': '/work/project',
       source: 'automation_page',
     })))
+  })
+
+  it('does not queue manual SOP runs when required inputs cannot be inferred', async () => {
+    renderAutomationsPage({
+      initialPayload: payload({
+        automations: [automation({ id: 'other-automation' })],
+      }),
+      initialSops: sopPayload(),
+    })
+
+    expect(await screen.findByRole('region', { name: 'Reusable SOPs' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Run SOP' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Run SOP' })).toHaveAttribute('title', 'Missing required inputs: Project directory')
   })
 
   it('keeps automations available when reusable SOPs fail to load', async () => {

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -387,6 +387,24 @@ describe('AutomationsPage', () => {
     expect(screen.getByRole('button', { name: 'Run SOP' })).toHaveAttribute('title', 'Missing required inputs: Project directory')
   })
 
+  it('does not queue manual SOP runs for paused SOP definitions', async () => {
+    const pausedSops = sopPayload()
+    pausedSops.sops[0] = {
+      ...pausedSops.sops[0]!,
+      definition: {
+        ...pausedSops.sops[0]!.definition,
+        status: 'paused',
+      },
+    }
+    renderAutomationsPage({
+      initialSops: pausedSops,
+    })
+
+    expect(await screen.findByRole('region', { name: 'Reusable SOPs' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Run SOP' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Run SOP' })).toHaveAttribute('title', 'SOP is paused')
+  })
+
   it('keeps automations available when reusable SOPs fail to load', async () => {
     const api = renderAutomationsPage({
       sopsListError: new Error('sop database unavailable'),

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -3,8 +3,10 @@ import type {
   AutomationDetail,
   AutomationDraft,
   AutomationListPayload,
+  AutomationSummary,
   BuiltInAgentDetail,
   CustomAgentSummary,
+  SopListItem,
   SopListPayload,
   SopRunDetail,
 } from '@open-cowork/shared'
@@ -71,6 +73,45 @@ function reportAutomationSopRunDetailError(error: unknown) {
     })
   } catch {
     // Diagnostics are best-effort when historical SOP run detail is unavailable.
+  }
+}
+
+function requiredInputIsPresent(value: unknown) {
+  if (value === null || value === undefined) return false
+  if (typeof value === 'string') return value.trim().length > 0
+  if (Array.isArray(value)) return value.length > 0
+  return true
+}
+
+function inferSopRunInputs(sop: SopListItem, automations: AutomationSummary[]) {
+  const inputs: Record<string, unknown> = {}
+  const sourceAutomationId = sop.activeVersion?.sourceAutomationId || sop.definition.sourceAutomationId
+  const sourceAutomation = sourceAutomationId
+    ? automations.find((automation) => automation.id === sourceAutomationId)
+    : null
+  const missingRequiredInputs: string[] = []
+
+  for (const input of sop.activeVersion?.requiredInputs || []) {
+    if (input.id === 'project-directory' && sourceAutomation?.projectDirectory) {
+      inputs[input.id] = sourceAutomation.projectDirectory
+    }
+    if (input.required && !requiredInputIsPresent(inputs[input.id])) {
+      missingRequiredInputs.push(input.label || input.id)
+    }
+  }
+
+  return { inputs, missingRequiredInputs }
+}
+
+function buildSopRunPayload(sop: SopListItem, automations: AutomationSummary[]) {
+  const { inputs, missingRequiredInputs } = inferSopRunInputs(sop, automations)
+  return {
+    inputs: {
+      ...inputs,
+      source: 'automation_page',
+      requestedAt: new Date().toISOString(),
+    },
+    missingRequiredInputs,
   }
 }
 
@@ -307,14 +348,16 @@ export function AutomationsPage({ onOpenThread }: Props) {
     }
   }
 
-  const runSop = async (sopId: string) => {
+  const runSop = async (sop: SopListItem) => {
     setError(null)
     setFeedback(null)
+    const { inputs, missingRequiredInputs } = buildSopRunPayload(sop, payload.automations)
+    if (missingRequiredInputs.length > 0) {
+      setError(`SOP requires input${missingRequiredInputs.length === 1 ? '' : 's'} this view cannot infer: ${missingRequiredInputs.join(', ')}.`)
+      return
+    }
     try {
-      await window.coworkApi.sops.runNow(sopId, {
-        source: 'automation_page',
-        requestedAt: new Date().toISOString(),
-      })
+      await window.coworkApi.sops.runNow(sop.definition.id, inputs)
       setFeedback('SOP run queued.')
       await refresh(selectedAutomationId)
     } catch (err) {
@@ -350,21 +393,39 @@ export function AutomationsPage({ onOpenThread }: Props) {
             </div>
           </div>
           <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-            {sopPayload.sops.map(({ definition, activeVersion }) => (
-              <div key={definition.id} className="rounded-xl border border-border px-3 py-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate text-[13px] font-medium text-text">{definition.name}</div>
-                    <div className="mt-1 line-clamp-2 text-[11px] leading-5 text-text-muted">{definition.description}</div>
+            {sopPayload.sops.map((sop) => {
+              const { definition, activeVersion } = sop
+              const canRunManually = Boolean(activeVersion?.triggerTypes.includes('manual'))
+              const missingInputs = inferSopRunInputs(sop, payload.automations).missingRequiredInputs
+              return (
+                <div key={definition.id} className="rounded-xl border border-border px-3 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-[13px] font-medium text-text">{definition.name}</div>
+                      <div className="mt-1 line-clamp-2 text-[11px] leading-5 text-text-muted">{definition.description}</div>
+                    </div>
+                    <span className="shrink-0 text-[10px] uppercase tracking-[0.14em] text-text-muted">v{activeVersion?.version ?? '-'}</span>
                   </div>
-                  <span className="shrink-0 text-[10px] uppercase tracking-[0.14em] text-text-muted">v{activeVersion?.version ?? '-'}</span>
+                  <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <div className="text-[11px] text-text-muted">{activeVersion?.triggerTypes.join(', ') || 'No triggers'}</div>
+                      {missingInputs.length > 0 ? (
+                        <div className="mt-1 text-[10px] text-text-muted">Needs {missingInputs.join(', ')}</div>
+                      ) : null}
+                    </div>
+                    <button
+                      type="button"
+                      disabled={!canRunManually || missingInputs.length > 0}
+                      title={missingInputs.length > 0 ? `Missing required inputs: ${missingInputs.join(', ')}` : undefined}
+                      onClick={() => void runSop(sop)}
+                      className="rounded-xl border border-border px-3 py-1.5 text-[11px] cursor-pointer disabled:opacity-50"
+                    >
+                      Run SOP
+                    </button>
+                  </div>
                 </div>
-                <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-                  <div className="text-[11px] text-text-muted">{activeVersion?.triggerTypes.join(', ') || 'No triggers'}</div>
-                  <button type="button" disabled={!activeVersion?.triggerTypes.includes('manual')} onClick={() => void runSop(definition.id)} className="rounded-xl border border-border px-3 py-1.5 text-[11px] cursor-pointer disabled:opacity-50">Run SOP</button>
-                </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </section>
       ) : null}

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -397,6 +397,11 @@ export function AutomationsPage({ onOpenThread }: Props) {
               const { definition, activeVersion } = sop
               const canRunManually = Boolean(activeVersion?.triggerTypes.includes('manual'))
               const missingInputs = inferSopRunInputs(sop, payload.automations).missingRequiredInputs
+              const runUnavailableReasons = [
+                ...(definition.status === 'active' ? [] : [`SOP is ${definition.status}`]),
+                ...(canRunManually ? [] : ['Manual trigger is not enabled']),
+                ...(missingInputs.length > 0 ? [`Missing required inputs: ${missingInputs.join(', ')}`] : []),
+              ]
               return (
                 <div key={definition.id} className="rounded-xl border border-border px-3 py-3">
                   <div className="flex items-start justify-between gap-3">
@@ -415,8 +420,8 @@ export function AutomationsPage({ onOpenThread }: Props) {
                     </div>
                     <button
                       type="button"
-                      disabled={!canRunManually || missingInputs.length > 0}
-                      title={missingInputs.length > 0 ? `Missing required inputs: ${missingInputs.join(', ')}` : undefined}
+                      disabled={runUnavailableReasons.length > 0}
+                      title={runUnavailableReasons.length > 0 ? runUnavailableReasons.join('; ') : undefined}
                       onClick={() => void runSop(sop)}
                       className="rounded-xl border border-border px-3 py-1.5 text-[11px] cursor-pointer disabled:opacity-50"
                     >

--- a/tests/sop-store.test.ts
+++ b/tests/sop-store.test.ts
@@ -253,7 +253,7 @@ test('manual SOP runs create automation runs linked to the active SOP version', 
   const { run } = createCompletedAutomationRun()
   const v1 = saveAutomationRunAsSop(run.id)
   const v2 = updateSop(v1.definition.id, draftFromSop(v1))
-  const link = runSopNow(v2.definition.id, { requester: 'local-user' })
+  const link = runSopNow(v2.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
   const startedRun = getRun(link.automationRunId)
 
   assert.ok(startedRun)
@@ -261,6 +261,7 @@ test('manual SOP runs create automation runs linked to the active SOP version', 
   assert.equal(startedRun?.status, 'queued')
   assert.equal(link.sopVersionId, v2.activeVersion?.id)
   assert.equal(link.inputs.requester, 'local-user')
+  assert.equal(link.inputs['project-directory'], '/Users/example/project')
 
   const detail = getSop(v2.definition.id)
   assert.equal(detail?.runLinks.length, 2)
@@ -270,10 +271,34 @@ test('manual SOP runs create automation runs linked to the active SOP version', 
   )
 }))
 
+test('manual SOP runs validate active status and required inputs before creating automation runs', () => withAutomationStore('run-now-eligibility', () => {
+  const { run } = createCompletedAutomationRun()
+  const sop = saveAutomationRunAsSop(run.id)
+  const runCountBefore = (getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count
+
+  assert.throws(() => runSopNow(sop.definition.id, {}), /Missing required SOP input: Project directory/)
+  assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, runCountBefore)
+
+  getDb().prepare('update sop_definitions set status = ? where id = ?').run('paused', sop.definition.id)
+  assert.throws(() => runSopNow(sop.definition.id, { 'project-directory': '/Users/example/project' }), /Only active SOPs/)
+  assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, runCountBefore)
+  getDb().prepare('update sop_definitions set status = ? where id = ?').run('active', sop.definition.id)
+
+  assert.throws(() => runSopNow(sop.definition.id, {
+    'project-directory': '/Users/example/project',
+    oversized: 'x'.repeat(100_000),
+  }), /SOP run inputs are too large/)
+  assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, runCountBefore)
+
+  const link = runSopNow(sop.definition.id, { 'project-directory': '/Users/example/project' })
+  assert.equal(link.inputs['project-directory'], '/Users/example/project')
+  assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, Number(runCountBefore) + 1)
+}))
+
 test('SOP run detail projects durable automation operations for the exact version', () => withAutomationStore('run-detail', () => {
   const { run } = createCompletedAutomationRun()
   const sop = saveAutomationRunAsSop(run.id)
-  const link = runSopNow(sop.definition.id, { requester: 'qa-user', priority: 'high' })
+  const link = runSopNow(sop.definition.id, { requester: 'qa-user', priority: 'high', 'project-directory': '/Users/example/project' })
   const startedRun = getRun(link.automationRunId)
   assert.ok(startedRun)
   markRunStarted(startedRun!.id, 'session-run-detail')
@@ -360,6 +385,7 @@ test('SOP run detail projects durable automation operations for the exact versio
   assert.equal(detail?.version.id, sop.activeVersion?.id)
   assert.equal(detail?.run.id, startedRun!.id)
   assert.equal(detail?.inputs.requester, 'qa-user')
+  assert.equal(detail?.inputs['project-directory'], '/Users/example/project')
   assert.equal(detail?.outputs.summary, null)
   assert.equal(detail?.outputs.deliveries[0]?.id, delivery?.id)
   assert.equal(detail?.approvals[0]?.id, approval?.id)
@@ -375,9 +401,9 @@ test('manual SOP runs preserve the backing automation active-run guard', () => w
   const { run } = createCompletedAutomationRun()
   const sop = saveAutomationRunAsSop(run.id)
 
-  const first = runSopNow(sop.definition.id, { requester: 'local-user' })
+  const first = runSopNow(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
   assert.ok(first)
-  assert.throws(() => runSopNow(sop.definition.id, { requester: 'local-user' }), /already has an active run/)
+  assert.throws(() => runSopNow(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' }), /already has an active run/)
 }))
 
 test('automation database schema includes SOP tables and records the current version', () => withAutomationStore('schema', () => {


### PR DESCRIPTION
Summary:
- validate active SOP status, required inputs, and input snapshot size before creating backing automation runs
- keep the store-level input size guard as the durable invariant
- infer project-directory for reusable SOPs from the source automation in the automation page, and disable runs when required inputs cannot be inferred
- add node and renderer regression tests for non-mutating failures and UI run readiness

Validation:
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/sop-store.test.ts
- pnpm --dir apps/desktop test:renderer -- AutomationsPage
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check