### PR TITLE
[codex] link SOP triggers to automation execution runs

### DIFF
--- a/apps/desktop/src/main/automation-manual-actions.ts
+++ b/apps/desktop/src/main/automation-manual-actions.ts
@@ -60,7 +60,13 @@ export async function runAutomationNowWithContext(
     await previewAutomationBriefWithContext(automationId, publishAutomationUpdated)
     return null
   }
-  const run = await startAutomationRun(automationId, 'execution', publishAutomationUpdated)
+  const run = await startAutomationRun(automationId, 'execution', publishAutomationUpdated, {
+    sopTriggerType: 'manual',
+    sopInputs: {
+      source: 'automation_run_now',
+      requestedAt: new Date().toISOString(),
+    },
+  })
   publishAutomationUpdated()
   return run
 }

--- a/apps/desktop/src/main/automation-run-starter.ts
+++ b/apps/desktop/src/main/automation-run-starter.ts
@@ -1,4 +1,4 @@
-import type { AutomationRunKind, ExecutionBrief } from '@open-cowork/shared'
+import type { AutomationRunKind, ExecutionBrief, SopTriggerType } from '@open-cowork/shared'
 import {
   clearPendingRetriesForChain,
   countConsecutiveFailedWorkRuns,
@@ -31,11 +31,14 @@ import {
   createAutomationHeartbeatFormat,
   createAutomationHeartbeatPrompt,
 } from './automation-prompts.ts'
+import { resolveSopRunContextForAutomationStart } from './sop-run-context.ts'
 
 export interface StartAutomationRunOptions {
   attempt?: number
   retryOfRunId?: string | null
   title?: string
+  sopTriggerType?: SopTriggerType | null
+  sopInputs?: Record<string, unknown>
 }
 
 export async function startAutomationRun(
@@ -56,6 +59,13 @@ export async function startAutomationRun(
   if (activeRun) {
     throw new AutomationRunConflictError(`Automation already has an active ${activeRun.kind} run.`)
   }
+  const sopRunLink = resolveSopRunContextForAutomationStart({
+    automation,
+    kind,
+    triggerType: options.sopTriggerType,
+    retryOfRunId: options.retryOfRunId,
+    inputs: options.sopInputs,
+  })
   const run = createAutomationRunWhenNoActive(
     automationId,
     kind,
@@ -69,6 +79,7 @@ export async function startAutomationRun(
     {
       attempt: options.attempt,
       retryOfRunId: options.retryOfRunId,
+      sopRunLink,
     },
   )
   if (!run) throw new AutomationRunConflictError('Automation already has an active run.')

--- a/apps/desktop/src/main/automation-scheduler.ts
+++ b/apps/desktop/src/main/automation-scheduler.ts
@@ -58,7 +58,15 @@ async function maybeRunDueAutomations(now: Date, publishAutomationUpdated: Autom
     if (getActiveRunForAutomation(automation.id)) continue
     const shouldEnrich = !detail.brief || !detail.brief.approvedAt || detail.status === 'draft'
     try {
-      await startAutomationRun(automation.id, shouldEnrich ? 'enrichment' : 'execution', publishAutomationUpdated)
+      await startAutomationRun(automation.id, shouldEnrich ? 'enrichment' : 'execution', publishAutomationUpdated, shouldEnrich
+        ? {}
+        : {
+            sopTriggerType: 'schedule',
+            sopInputs: {
+              source: 'automation_schedule',
+              scheduledFor: automation.nextRunAt || now.toISOString(),
+            },
+          })
     } catch (error) {
       if (error instanceof AutomationRunConflictError) continue
       const message = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/main/automation-store.ts
+++ b/apps/desktop/src/main/automation-store.ts
@@ -6,6 +6,7 @@ import type {
   AutomationRunKind,
   AutomationSchedule,
   AutomationStatus,
+  SopTriggerType,
 } from '@open-cowork/shared'
 import { computeNextAutomationRunAt } from './automation-schedule.ts'
 import { getDb, withTransaction } from './automation-store-db.ts'
@@ -22,6 +23,14 @@ import {
   type DbRow,
 } from './automation-store-model.ts'
 import { getAutomationDetail, getAutomationRow } from './automation-store-automations.ts'
+import { linkSopRunToAutomationRunInTransaction } from './sop-store.ts'
+
+type AutomationRunCreateOptions = {
+  attempt?: number
+  retryOfRunId?: string | null
+  sopRunLink?: { sopVersionId: string, triggerType: SopTriggerType, inputs?: Record<string, unknown> } | null
+}
+
 export { clearAutomationStoreCache } from './automation-store-db.ts'
 export {
   AUTOMATION_LIST_INBOX_PER_AUTOMATION_LIMIT,
@@ -47,7 +56,7 @@ export function createAutomationRun(
   automationId: string,
   kind: AutomationRunKind,
   title: string,
-  options: { attempt?: number, retryOfRunId?: string | null } = {},
+  options: AutomationRunCreateOptions = {},
 ) {
   const id = crypto.randomUUID()
   withTransaction((db) => {
@@ -73,7 +82,7 @@ function insertAutomationRun(
   automationId: string,
   kind: AutomationRunKind,
   title: string,
-  options: { attempt?: number, retryOfRunId?: string | null } = {},
+  options: AutomationRunCreateOptions = {},
 ) {
   const now = new Date().toISOString()
   const automation = getAutomationRow(automationId)
@@ -91,13 +100,21 @@ function insertAutomationRun(
   `).run(id, automationId, kind, 'queued', title, options.attempt || 1, options.retryOfRunId || null, now)
   db.prepare('update automations set latest_run_id = ?, latest_run_status = ?, updated_at = ?, status = ?, next_run_at = ? where id = ?')
     .run(id, 'queued', now, nextStatus, nextRunAt, automationId)
+  if (options.sopRunLink) {
+    linkSopRunToAutomationRunInTransaction(db, {
+      sopVersionId: options.sopRunLink.sopVersionId,
+      automationRunId: id,
+      triggerType: options.sopRunLink.triggerType,
+      inputs: options.sopRunLink.inputs,
+    })
+  }
 }
 
 export function createAutomationRunWhenNoActive(
   automationId: string,
   kind: AutomationRunKind,
   title: string,
-  options: { attempt?: number, retryOfRunId?: string | null } = {},
+  options: AutomationRunCreateOptions = {},
 ) {
   const id = crypto.randomUUID()
   let created = false

--- a/apps/desktop/src/main/sop-run-context.ts
+++ b/apps/desktop/src/main/sop-run-context.ts
@@ -1,0 +1,87 @@
+import type {
+  AutomationDetail,
+  AutomationRunKind,
+  SopListItem,
+  SopRunLink,
+  SopTriggerType,
+} from '@open-cowork/shared'
+import {
+  assertSopRunInputSnapshotSize,
+  getLatestActiveSopForAutomation,
+  getSopRunLinkForAutomationRun,
+} from './sop-store.ts'
+
+export type SopRunStartContext = {
+  sopVersionId: string
+  triggerType: SopTriggerType
+  inputs: Record<string, unknown>
+}
+
+function inputValueIsPresent(value: unknown) {
+  if (value === null || value === undefined) return false
+  if (typeof value === 'string') return value.trim().length > 0
+  if (Array.isArray(value)) return value.length > 0
+  return true
+}
+
+function inputsForSopRun(
+  sop: SopListItem,
+  automation: AutomationDetail,
+  seedInputs: Record<string, unknown>,
+) {
+  const inputs = { ...seedInputs }
+  const missingInputs: string[] = []
+  for (const input of sop.activeVersion?.requiredInputs || []) {
+    if (input.id === 'project-directory' && !inputValueIsPresent(inputs[input.id]) && automation.projectDirectory) {
+      inputs[input.id] = automation.projectDirectory
+    }
+    if (input.required && !inputValueIsPresent(inputs[input.id])) {
+      missingInputs.push(input.label || input.id)
+    }
+  }
+  if (missingInputs.length > 0) {
+    throw new Error(`Missing required SOP input${missingInputs.length === 1 ? '' : 's'}: ${missingInputs.join(', ')}`)
+  }
+  assertSopRunInputSnapshotSize(inputs)
+  return inputs
+}
+
+function retrySopContext(previousLink: SopRunLink | null): SopRunStartContext | null {
+  if (!previousLink) return null
+  return {
+    sopVersionId: previousLink.sopVersionId,
+    triggerType: previousLink.triggerType,
+    inputs: previousLink.inputs,
+  }
+}
+
+export function resolveSopRunContextForAutomationStart(options: {
+  automation: AutomationDetail
+  kind: AutomationRunKind
+  triggerType?: SopTriggerType | null
+  retryOfRunId?: string | null
+  inputs?: Record<string, unknown>
+}): SopRunStartContext | null {
+  if (options.kind !== 'execution') return null
+  const retryContext = retrySopContext(options.retryOfRunId ? getSopRunLinkForAutomationRun(options.retryOfRunId) : null)
+  if (retryContext) return retryContext
+
+  const triggerType = options.triggerType || null
+  if (!triggerType) return null
+  const sop = getLatestActiveSopForAutomation(options.automation.id)
+  if (!sop?.activeVersion) return null
+  if (!sop.activeVersion.triggerTypes.includes(triggerType)) return null
+
+  let inputs: Record<string, unknown>
+  try {
+    inputs = inputsForSopRun(sop, options.automation, options.inputs || {})
+  } catch {
+    return null
+  }
+
+  return {
+    sopVersionId: sop.activeVersion.id,
+    triggerType,
+    inputs,
+  }
+}

--- a/apps/desktop/src/main/sop-service.ts
+++ b/apps/desktop/src/main/sop-service.ts
@@ -31,7 +31,6 @@ import {
   getSopDetail,
   getSopRunLinkForAutomationRun,
   getSopVersion,
-  linkAutomationRunToSopVersion,
   listSops,
   updateSopDefinition,
 } from './sop-store.ts'
@@ -294,12 +293,15 @@ export function runSopNow(sopId: string, inputs: Record<string, unknown> = {}): 
   if (!detail.activeVersion.triggerTypes.includes('manual')) {
     throw new Error('SOP does not allow manual runs.')
   }
-  const run = createAutomationRunWhenNoActive(automationId, 'execution', `Run SOP: ${detail.definition.name}`)
-  if (!run) throw new Error('SOP backing automation already has an active run.')
-  return linkAutomationRunToSopVersion({
-    sopVersionId: detail.activeVersion.id,
-    automationRunId: run.id,
-    triggerType: 'manual',
-    inputs,
+  const run = createAutomationRunWhenNoActive(automationId, 'execution', `Run SOP: ${detail.definition.name}`, {
+    sopRunLink: {
+      sopVersionId: detail.activeVersion.id,
+      triggerType: 'manual',
+      inputs,
+    },
   })
+  if (!run) throw new Error('SOP backing automation already has an active run.')
+  const link = getSopRunLinkForAutomationRun(run.id)
+  if (!link) throw new Error('SOP run link was not created.')
+  return link
 }

--- a/apps/desktop/src/main/sop-store.ts
+++ b/apps/desktop/src/main/sop-store.ts
@@ -268,6 +268,13 @@ function insertSopRunLink(
   return link
 }
 
+export function linkSopRunToAutomationRunInTransaction(
+  db: ReturnType<typeof getDb>,
+  input: SopRunLinkDraft & { sopVersionId: string },
+) {
+  return insertSopRunLink(db, input)
+}
+
 export function createSopDefinition(
   draft: SopDraft,
   source: SopDefinitionSource = {},
@@ -338,6 +345,23 @@ export function getSopDetail(sopId: string): SopDetail | null {
     activeVersion: definition.activeVersionId ? versions.find((version) => version.id === definition.activeVersionId) || null : null,
     runLinks: listSopRunLinks(sopId),
   }
+}
+
+export function getLatestActiveSopForAutomation(automationId: string): SopListItem | null {
+  const row = getDb().prepare(`
+    select *
+    from sop_definitions
+    where source_automation_id = ?
+      and status = 'active'
+      and active_version_id is not null
+    order by updated_at desc, created_at desc, id desc
+    limit 1
+  `).get(automationId) as DbRow | undefined
+  if (!row) return null
+  const definition = rowToSopDefinition(row)
+  const activeVersion = definition.activeVersionId ? getSopVersion(definition.activeVersionId) : null
+  if (!activeVersion) return null
+  return { definition, activeVersion }
 }
 
 export function listSops(): SopListPayload {

--- a/tests/automation-service.test.ts
+++ b/tests/automation-service.test.ts
@@ -34,13 +34,19 @@ import {
   runAutomationServiceTick,
   runAutomationNow,
 } from '../apps/desktop/src/main/automation-service.ts'
+import {
+  getSopRunDetail,
+  saveAutomationRunAsSop,
+} from '../apps/desktop/src/main/sop-service.ts'
 import { clearSessionRegistryCache, toSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
+import { closeLogger } from '../apps/desktop/src/main/logger.ts'
 
 function uniqueUserDataDir(name: string) {
   return join(tmpdir(), `open-cowork-automation-service-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
 }
 
 function resetAutomationStore(userDataDir: string) {
+  closeLogger()
   process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
   clearConfigCaches()
   clearAutomationStoreCache()
@@ -105,6 +111,85 @@ test('runAutomationNow rejects when an automation already has an active run', as
       /already has an active execution run/i,
     )
   } finally {
+    closeLogger()
+    clearSessionRegistryCache()
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('runAutomationNow links active SOP versions before starting execution', async () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('manual-sop-link')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const automation = createAutomation({
+      title: 'Manual SOP execution',
+      goal: 'Execute the reusable SOP through the automation action.',
+      kind: 'recurring',
+      schedule: {
+        type: 'weekly',
+        timezone: 'UTC',
+        dayOfWeek: 1,
+        runAtHour: 9,
+        runAtMinute: 0,
+      },
+      heartbeatMinutes: 15,
+      retryPolicy: {
+        maxRetries: 3,
+        baseDelayMinutes: 5,
+        maxDelayMinutes: 60,
+      },
+      runPolicy: {
+        dailyRunCap: 6,
+        maxRunDurationMinutes: 120,
+      },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: '/Users/example/project',
+      preferredAgentNames: [],
+    })
+
+    saveAutomationBrief(automation.id, {
+      version: 1,
+      status: 'ready',
+      goal: automation.goal,
+      deliverables: ['Report'],
+      assumptions: [],
+      missingContext: [],
+      successCriteria: ['Ready'],
+      recommendedAgents: ['research'],
+      workItems: [],
+      approvalBoundary: 'Approve before delivery.',
+      generatedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+    })
+    const sourceRun = createAutomationRun(automation.id, 'execution', 'Source successful run')
+    assert.ok(sourceRun)
+    markRunStarted(sourceRun!.id, 'session-source')
+    markRunCompleted(sourceRun!.id, 'Source run completed.')
+    const sop = saveAutomationRunAsSop(sourceRun!.id)
+
+    await assert.rejects(
+      () => runAutomationNow(automation.id),
+      /runtime not started/i,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    const startedRun = listAutomationState().runs.find((entry) => entry.id !== sourceRun!.id && entry.automationId === automation.id)
+    assert.ok(startedRun)
+    const detail = getSopRunDetail(startedRun!.id)
+    assert.equal(detail?.version.id, sop.activeVersion?.id)
+    assert.equal(detail?.link.triggerType, 'manual')
+    assert.equal(detail?.inputs.source, 'automation_run_now')
+    assert.equal(detail?.inputs['project-directory'], '/Users/example/project')
+  } finally {
+    closeLogger()
     clearSessionRegistryCache()
     clearAutomationStoreCache()
     clearConfigCaches()
@@ -185,6 +270,7 @@ test('approving an enrichment brief completes the parked approval run', () => {
     assert.equal(listAutomationState().inbox.filter((item) => item.automationId === automation.id && item.status === 'open').length, 0)
     assert.ok(createAutomationRunWhenNoActive(automation.id, 'execution', 'Execute approved brief'))
   } finally {
+    closeLogger()
     clearSessionRegistryCache()
     clearAutomationStoreCache()
     clearConfigCaches()
@@ -359,6 +445,87 @@ test('scheduler skips stale due automations that already have an active run with
     assert.equal(getRun(run.id)?.status, 'running')
     assert.equal(listAutomationState().inbox.filter((item) => item.automationId === automation.id && item.type === 'failure').length, 0)
   } finally {
+    clearSessionRegistryCache()
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('scheduler links due SOP-backed execution runs with schedule trigger', async () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('scheduler-sop-link')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const automation = createAutomation({
+      title: 'Scheduled SOP execution',
+      goal: 'Run a saved SOP from the scheduler.',
+      kind: 'recurring',
+      schedule: {
+        type: 'weekly',
+        timezone: 'UTC',
+        dayOfWeek: 1,
+        runAtHour: 9,
+        runAtMinute: 0,
+      },
+      heartbeatMinutes: 15,
+      retryPolicy: {
+        maxRetries: 3,
+        baseDelayMinutes: 5,
+        maxDelayMinutes: 60,
+      },
+      runPolicy: {
+        dailyRunCap: 6,
+        maxRunDurationMinutes: 120,
+      },
+      executionMode: 'planning_only',
+      autonomyPolicy: 'review-first',
+      projectDirectory: '/Users/example/project',
+      preferredAgentNames: [],
+    })
+
+    saveAutomationBrief(automation.id, {
+      version: 1,
+      status: 'ready',
+      goal: automation.goal,
+      deliverables: ['Report'],
+      assumptions: [],
+      missingContext: [],
+      successCriteria: ['Ready'],
+      recommendedAgents: ['research'],
+      workItems: [],
+      approvalBoundary: 'Approve before delivery.',
+      generatedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+    })
+    const sourceRun = createAutomationRun(automation.id, 'execution', 'Source successful run')
+    assert.ok(sourceRun)
+    markRunStarted(sourceRun!.id, 'session-source')
+    markRunCompleted(sourceRun!.id, 'Source run completed.')
+    const sop = saveAutomationRunAsSop(sourceRun!.id)
+
+    const db = new DatabaseSync(join(userDataDir, 'automation.sqlite'))
+    db.prepare('update automations set status = ?, next_run_at = ? where id = ?')
+      .run('ready', '2026-01-01T09:00:00.000Z', automation.id)
+    db.close()
+
+    await runAutomationServiceTick(new Date('2026-01-01T09:05:00.000Z'))
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    const startedRun = listAutomationState().runs.find((entry) => entry.id !== sourceRun!.id && entry.automationId === automation.id)
+    assert.ok(startedRun)
+    const detail = getSopRunDetail(startedRun!.id)
+    assert.equal(detail?.version.id, sop.activeVersion?.id)
+    assert.equal(detail?.link.triggerType, 'schedule')
+    assert.equal(detail?.inputs.source, 'automation_schedule')
+    assert.equal(detail?.inputs.scheduledFor, '2026-01-01T09:00:00.000Z')
+    assert.equal(detail?.inputs['project-directory'], '/Users/example/project')
+  } finally {
+    closeLogger()
     clearSessionRegistryCache()
     clearAutomationStoreCache()
     clearConfigCaches()

--- a/tests/sop-store.test.ts
+++ b/tests/sop-store.test.ts
@@ -5,11 +5,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { COWORK_SOP_SCHEMA_VERSION, type SopDraft } from '../packages/shared/src/sops.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { closeLogger } from '../apps/desktop/src/main/logger.ts'
 import {
   clearAutomationStoreCache,
   createAutomation,
   createDeliveryRecord,
   createAutomationRun,
+  createAutomationRunWhenNoActive,
   createInboxItem,
   getRun,
   markRunCompleted,
@@ -27,12 +29,14 @@ import {
   updateSop,
 } from '../apps/desktop/src/main/sop-service.ts'
 import { createSopDefinitionWithRunLink } from '../apps/desktop/src/main/sop-store.ts'
+import { resolveSopRunContextForAutomationStart } from '../apps/desktop/src/main/sop-run-context.ts'
 
 function uniqueUserDataDir(name: string) {
   return join(tmpdir(), `open-cowork-sop-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
 }
 
 function resetAutomationStore(userDataDir: string) {
+  closeLogger()
   process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
   clearConfigCaches()
   clearAutomationStoreCache()
@@ -45,6 +49,7 @@ function withAutomationStore(name: string, fn: () => void) {
     resetAutomationStore(userDataDir)
     fn()
   } finally {
+    closeLogger()
     clearAutomationStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
@@ -293,6 +298,102 @@ test('manual SOP runs validate active status and required inputs before creating
   const link = runSopNow(sop.definition.id, { 'project-directory': '/Users/example/project' })
   assert.equal(link.inputs['project-directory'], '/Users/example/project')
   assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, Number(runCountBefore) + 1)
+}))
+
+test('automation service starts can resolve active SOP trigger context', () => withAutomationStore('start-context', () => {
+  const { automation, run } = createCompletedAutomationRun()
+  const sop = saveAutomationRunAsSop(run.id)
+  const context = resolveSopRunContextForAutomationStart({
+    automation,
+    kind: 'execution',
+    triggerType: 'schedule',
+    inputs: {
+      source: 'automation_schedule',
+      scheduledFor: '2026-05-11T09:00:00.000Z',
+    },
+  })
+
+  assert.equal(context?.sopVersionId, sop.activeVersion?.id)
+  assert.equal(context?.triggerType, 'schedule')
+  assert.equal(context?.inputs.source, 'automation_schedule')
+  assert.equal(context?.inputs['project-directory'], '/Users/example/project')
+}))
+
+test('automation service starts skip SOP links when required inputs are unavailable', () => withAutomationStore('start-context-missing-input', () => {
+  const { automation, run } = createCompletedAutomationRun()
+  const sop = saveAutomationRunAsSop(run.id)
+  updateSop(sop.definition.id, {
+    ...draftFromSop(sop),
+    requiredInputs: [
+      ...(sop.activeVersion?.requiredInputs || []),
+      {
+        schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+        id: 'report-owner',
+        label: 'Report owner',
+        description: 'Required reviewer that the automation service cannot infer.',
+        required: true,
+      },
+    ],
+  })
+
+  const context = resolveSopRunContextForAutomationStart({
+    automation,
+    kind: 'execution',
+    triggerType: 'schedule',
+    inputs: {
+      source: 'automation_schedule',
+      scheduledFor: '2026-05-11T09:00:00.000Z',
+    },
+  })
+  assert.equal(context, null)
+
+  const started = createAutomationRunWhenNoActive(automation.id, 'execution', 'Execute scheduled automation', {
+    sopRunLink: context,
+  })
+  assert.ok(started)
+  assert.equal(getSopRunDetail(started!.id), null)
+}))
+
+test('automation run creation can atomically link a scheduled SOP run', () => withAutomationStore('atomic-start-link', () => {
+  const { automation, run } = createCompletedAutomationRun()
+  const sop = saveAutomationRunAsSop(run.id)
+  const context = resolveSopRunContextForAutomationStart({
+    automation,
+    kind: 'execution',
+    triggerType: 'schedule',
+    inputs: { source: 'automation_schedule' },
+  })
+  assert.ok(context)
+
+  const started = createAutomationRunWhenNoActive(automation.id, 'execution', 'Execute scheduled SOP', {
+    sopRunLink: context,
+  })
+  assert.ok(started)
+
+  const detail = getSopRunDetail(started!.id)
+  assert.equal(detail?.version.id, sop.activeVersion?.id)
+  assert.equal(detail?.link.triggerType, 'schedule')
+  assert.equal(detail?.inputs.source, 'automation_schedule')
+  assert.equal(detail?.inputs['project-directory'], '/Users/example/project')
+}))
+
+test('retry SOP runs inherit the original SOP version even after edits', () => withAutomationStore('retry-context', () => {
+  const { automation, run } = createCompletedAutomationRun()
+  const sop = saveAutomationRunAsSop(run.id)
+  const first = runSopNow(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
+  markRunFailed(first.automationRunId, 'Temporary runtime failure', undefined, { retryable: true })
+  const edited = updateSop(sop.definition.id, draftFromSop(sop))
+
+  const context = resolveSopRunContextForAutomationStart({
+    automation,
+    kind: 'execution',
+    retryOfRunId: first.automationRunId,
+  })
+
+  assert.equal(context?.sopVersionId, sop.activeVersion?.id)
+  assert.notEqual(context?.sopVersionId, edited.activeVersion?.id)
+  assert.equal(context?.triggerType, 'manual')
+  assert.equal(context?.inputs.requester, 'local-user')
 }))
 
 test('SOP run detail projects durable automation operations for the exact version', () => withAutomationStore('run-detail', () => {


### PR DESCRIPTION
## Summary
- link manual and scheduled automation execution runs to the latest active SOP version when the trigger is supported
- create SOP run links atomically inside automation run creation, including direct SOP runs
- preserve the original SOP version, trigger, and inputs when retrying SOP-backed automation runs
- add targeted service and store coverage for manual, scheduled, atomic, and retry paths

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint
- git diff --check