### PR TITLE
[codex] project SOP run evaluator results

### DIFF
--- a/apps/desktop/src/main/automation-store-db.ts
+++ b/apps/desktop/src/main/automation-store-db.ts
@@ -5,7 +5,7 @@ import { getAppDataDir } from './config-loader.ts'
 
 let automationDb: DatabaseSync | null = null
 let automationTransactionCounter = 0
-export const AUTOMATION_DB_SCHEMA_VERSION = 3
+export const AUTOMATION_DB_SCHEMA_VERSION = 4
 const AUTOMATION_SCHEMA_VERSION_KEY = 'schema_version'
 
 function getAutomationDbPath() {
@@ -203,9 +203,25 @@ export function getDb() {
         created_at text not null
       );
 
+      create table if not exists sop_run_evaluations (
+        id text primary key,
+        schema_version integer not null,
+        sop_id text not null,
+        sop_version_id text not null,
+        automation_id text not null,
+        automation_run_id text not null,
+        evaluator_agent_name text not null,
+        status text not null,
+        score real not null,
+        summary text not null,
+        recommendation text not null,
+        created_at text not null
+      );
+
       create index if not exists idx_sop_versions_sop_id on sop_versions(sop_id);
       create index if not exists idx_sop_run_links_sop_id on sop_run_links(sop_id);
       create index if not exists idx_sop_run_links_version_id on sop_run_links(sop_version_id);
+      create index if not exists idx_sop_run_evaluations_run on sop_run_evaluations(automation_run_id, created_at);
     `)
     const workItemsSql = db.prepare("select sql from sqlite_master where type = 'table' and name = 'automation_work_items'").get() as { sql?: string } | undefined
     if (!workItemsSql?.sql?.includes('primary key (automation_id, id)')) {

--- a/apps/desktop/src/main/sop-service.ts
+++ b/apps/desktop/src/main/sop-service.ts
@@ -35,6 +35,7 @@ import {
   getSopDetail,
   getSopRunLinkForAutomationRun,
   getSopVersion,
+  listSopRunEvaluationsForAutomationRun,
   listSops,
   updateSopDefinition,
 } from './sop-store.ts'
@@ -298,6 +299,7 @@ export function getSopRunDetail(automationRunId: string): SopRunDetail | null {
   const workItems = listRunWorkItems(run)
   const deliveries = listRunDeliveries(run)
   const artifacts = listRunArtifacts(run)
+  const evaluatorResults = listSopRunEvaluationsForAutomationRun(run.id)
   return {
     schemaVersion: COWORK_SOP_SCHEMA_VERSION,
     link,
@@ -315,7 +317,7 @@ export function getSopRunDetail(automationRunId: string): SopRunDetail | null {
     approvals: inbox.filter((item) => item.type === 'approval'),
     inbox,
     artifacts,
-    evaluatorResults: [],
+    evaluatorResults,
     failures: failuresForRun(run, inbox, deliveries),
   }
 }

--- a/apps/desktop/src/main/sop-store.ts
+++ b/apps/desktop/src/main/sop-store.ts
@@ -9,6 +9,7 @@ import type {
   SopListItem,
   SopListPayload,
   SopRequiredInput,
+  SopRunEvaluationResult,
   SopRunLink,
   SopStatus,
   SopTriggerType,
@@ -26,8 +27,11 @@ import {
 
 const TRIGGER_TYPES = new Set<SopTriggerType>(['manual', 'schedule', 'inbox', 'webhook'])
 const STEP_KINDS = new Set<SopWorkflowStep['kind']>(['plan', 'execute', 'approval', 'evaluate', 'deliver'])
+const EVALUATION_STATUSES = new Set<SopRunEvaluationResult['status']>(['passed', 'failed', 'needs_revision', 'needs_human'])
+const EVALUATION_RECOMMENDATIONS = new Set<SopRunEvaluationResult['recommendation']>(['deliver', 'revise', 'escalate'])
 const MAX_REQUIRED_INPUTS = 32
 const MAX_WORKFLOW_STEPS = 64
+const MAX_EVALUATION_SUMMARY_BYTES = 8 * 1024
 export const SOP_RUN_INPUT_SNAPSHOT_MAX_BYTES = 64 * 1024
 
 type SopDefinitionSource = {
@@ -40,6 +44,19 @@ type SopRunLinkDraft = {
   automationRunId: string
   triggerType: SopTriggerType
   inputs?: Record<string, unknown>
+}
+
+type SopRunEvaluationDraft = {
+  automationRunId: string
+  evaluatorAgentName: string
+  status: SopRunEvaluationResult['status']
+  score: number
+  summary: string
+  recommendation: SopRunEvaluationResult['recommendation']
+}
+
+function stringByteLength(value: string) {
+  return Buffer.byteLength(value, 'utf8')
 }
 
 function boundedText(value: unknown, fallback: string, max = 4_000) {
@@ -175,6 +192,22 @@ function rowToSopRunLink(row: DbRow): SopRunLink {
   }
 }
 
+function rowToSopRunEvaluation(row: DbRow): SopRunEvaluationResult {
+  return {
+    schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+    id: String(row.id),
+    status: EVALUATION_STATUSES.has(String(row.status) as SopRunEvaluationResult['status'])
+      ? String(row.status) as SopRunEvaluationResult['status']
+      : 'failed',
+    score: Number(row.score) || 0,
+    summary: String(row.summary || ''),
+    recommendation: EVALUATION_RECOMMENDATIONS.has(String(row.recommendation) as SopRunEvaluationResult['recommendation'])
+      ? String(row.recommendation) as SopRunEvaluationResult['recommendation']
+      : 'escalate',
+    createdAt: String(row.created_at),
+  }
+}
+
 function listSopVersions(sopId: string) {
   const rows = getDb().prepare('select * from sop_versions where sop_id = ? order by version desc').all(sopId) as DbRow[]
   return rows.map(rowToSopVersion)
@@ -273,6 +306,58 @@ export function linkSopRunToAutomationRunInTransaction(
   input: SopRunLinkDraft & { sopVersionId: string },
 ) {
   return insertSopRunLink(db, input)
+}
+
+export function recordSopRunEvaluation(input: SopRunEvaluationDraft) {
+  if (!EVALUATION_STATUSES.has(input.status)) throw new Error(`SOP evaluation status ${input.status} is not supported.`)
+  if (!EVALUATION_RECOMMENDATIONS.has(input.recommendation)) {
+    throw new Error(`SOP evaluation recommendation ${input.recommendation} is not supported.`)
+  }
+  if (!Number.isFinite(input.score) || input.score < 0 || input.score > 100) {
+    throw new Error('SOP evaluation score must be from 0 to 100.')
+  }
+  const evaluatorAgentName = boundedText(input.evaluatorAgentName, 'evaluator', 128) || 'evaluator'
+  const summary = boundedText(input.summary, '', MAX_EVALUATION_SUMMARY_BYTES)
+  if (!summary || stringByteLength(summary) > MAX_EVALUATION_SUMMARY_BYTES) {
+    throw new Error('SOP evaluation summary is required and must stay within size limits.')
+  }
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+  withTransaction((db) => {
+    const link = getSopRunLinkForAutomationRunFromDb(db, input.automationRunId)
+    if (!link) throw new Error(`Automation run ${input.automationRunId} is not linked to a SOP run.`)
+    db.prepare(`
+      insert into sop_run_evaluations (
+        id, schema_version, sop_id, sop_version_id, automation_id, automation_run_id,
+        evaluator_agent_name, status, score, summary, recommendation, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      COWORK_SOP_SCHEMA_VERSION,
+      link.sopId,
+      link.sopVersionId,
+      link.automationId,
+      link.automationRunId,
+      evaluatorAgentName,
+      input.status,
+      input.score,
+      summary,
+      input.recommendation,
+      now,
+    )
+  })
+  const row = getDb().prepare('select * from sop_run_evaluations where id = ?').get(id) as DbRow | undefined
+  return row ? rowToSopRunEvaluation(row) : null
+}
+
+export function listSopRunEvaluationsForAutomationRun(automationRunId: string) {
+  const rows = getDb().prepare(`
+    select *
+    from sop_run_evaluations
+    where automation_run_id = ?
+    order by created_at asc, id asc
+  `).all(automationRunId) as DbRow[]
+  return rows.map(rowToSopRunEvaluation)
 }
 
 export function createSopDefinition(

--- a/tests/sop-store.test.ts
+++ b/tests/sop-store.test.ts
@@ -29,7 +29,7 @@ import {
   updateSop,
 } from '../apps/desktop/src/main/sop-service.ts'
 import { getChartArtifactMetadataPath, getChartArtifactsRoot } from '../apps/desktop/src/main/chart-artifacts.ts'
-import { createSopDefinitionWithRunLink } from '../apps/desktop/src/main/sop-store.ts'
+import { createSopDefinitionWithRunLink, recordSopRunEvaluation } from '../apps/desktop/src/main/sop-store.ts'
 import { resolveSopRunContextForAutomationStart } from '../apps/desktop/src/main/sop-run-context.ts'
 
 const ONE_PX_PNG_BYTES = Buffer.from(
@@ -475,6 +475,15 @@ test('SOP run detail projects durable automation operations for the exact versio
   }), { mode: 0o600 })
   const postRunArtifactTime = new Date(Date.parse(failedRun!.finishedAt || failedRun!.createdAt) + 60_000)
   utimesSync(postRunChartPath, postRunArtifactTime, postRunArtifactTime)
+  const evaluation = recordSopRunEvaluation({
+    automationRunId: startedRun!.id,
+    evaluatorAgentName: 'qa-evaluator',
+    status: 'needs_revision',
+    score: 72,
+    summary: 'The output needs a tighter evidence note before delivery.',
+    recommendation: 'revise',
+  })
+  assert.ok(evaluation)
   saveAutomationBrief(startedRun!.automationId, {
     version: 2,
     status: 'ready',
@@ -539,9 +548,26 @@ test('SOP run detail projects durable automation operations for the exact versio
   assert.equal(detail?.approvals[0]?.id, approval?.id)
   assert.ok(detail?.inbox.some((item) => item.id === failure?.id))
   assert.deepEqual(detail?.workItems, [])
-  assert.deepEqual(detail?.evaluatorResults, [])
+  assert.equal(detail?.evaluatorResults.length, 1)
+  assert.equal(detail?.evaluatorResults[0]?.id, evaluation?.id)
+  assert.equal(detail?.evaluatorResults[0]?.status, 'needs_revision')
+  assert.equal(detail?.evaluatorResults[0]?.score, 72)
+  assert.equal(detail?.evaluatorResults[0]?.summary, 'The output needs a tighter evidence note before delivery.')
+  assert.equal(detail?.evaluatorResults[0]?.recommendation, 'revise')
   assert.deepEqual(detail?.failures.map((entry) => entry.source).sort(), ['delivery', 'inbox', 'run'])
   assert.equal(getSopRunDetail('not-linked'), null)
+}))
+
+test('SOP evaluation results require an exact SOP run link', () => withAutomationStore('evaluation-link-guard', () => {
+  const { run } = createCompletedAutomationRun()
+  assert.throws(() => recordSopRunEvaluation({
+    automationRunId: run.id,
+    evaluatorAgentName: 'qa-evaluator',
+    status: 'passed',
+    score: 91,
+    summary: 'Looks good.',
+    recommendation: 'deliver',
+  }), /not linked to a SOP run/)
 }))
 
 test('manual SOP runs preserve the backing automation active-run guard', () => withAutomationStore('run-now-active-guard', () => {
@@ -558,6 +584,6 @@ test('automation database schema includes SOP tables and records the current ver
   const tables = db.prepare("select name from sqlite_master where type = 'table' and name like 'sop_%' order by name").all() as Array<{ name?: string }>
   const meta = db.prepare('select value from automation_meta where key = ?').get('schema_version') as { value?: string } | undefined
 
-  assert.deepEqual(tables.map((row) => row.name), ['sop_definitions', 'sop_run_links', 'sop_versions'])
+  assert.deepEqual(tables.map((row) => row.name), ['sop_definitions', 'sop_run_evaluations', 'sop_run_links', 'sop_versions'])
   assert.equal(Number(meta?.value), AUTOMATION_DB_SCHEMA_VERSION)
 }))


### PR DESCRIPTION
## Summary
- Add a durable SOP run evaluator-results ledger keyed to exact SOP-linked automation runs.
- Project recorded SOP evaluator status, score, summary, and recommendation into SopRunDetail evaluator results.
- Bump the automation DB schema and cover linked-run projection plus unlinked-run rejection.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/sop-store.test.ts
- pnpm test
- pnpm typecheck
- pnpm lint
- git diff --check