### PR TITLE
[codex] start SOP trigger runs through automation runner

### DIFF
--- a/apps/desktop/src/main/automation-run-starter.ts
+++ b/apps/desktop/src/main/automation-run-starter.ts
@@ -31,7 +31,7 @@ import {
   createAutomationHeartbeatFormat,
   createAutomationHeartbeatPrompt,
 } from './automation-prompts.ts'
-import { resolveSopRunContextForAutomationStart } from './sop-run-context.ts'
+import { type SopRunStartContext, resolveSopRunContextForAutomationStart } from './sop-run-context.ts'
 
 export interface StartAutomationRunOptions {
   attempt?: number
@@ -39,6 +39,7 @@ export interface StartAutomationRunOptions {
   title?: string
   sopTriggerType?: SopTriggerType | null
   sopInputs?: Record<string, unknown>
+  sopRunContext?: SopRunStartContext | null
 }
 
 export async function startAutomationRun(
@@ -59,13 +60,15 @@ export async function startAutomationRun(
   if (activeRun) {
     throw new AutomationRunConflictError(`Automation already has an active ${activeRun.kind} run.`)
   }
-  const sopRunLink = resolveSopRunContextForAutomationStart({
-    automation,
-    kind,
-    triggerType: options.sopTriggerType,
-    retryOfRunId: options.retryOfRunId,
-    inputs: options.sopInputs,
-  })
+  const sopRunLink = kind === 'execution' && options.sopRunContext
+    ? options.sopRunContext
+    : resolveSopRunContextForAutomationStart({
+      automation,
+      kind,
+      triggerType: options.sopTriggerType,
+      retryOfRunId: options.retryOfRunId,
+      inputs: options.sopInputs,
+    })
   const run = createAutomationRunWhenNoActive(
     automationId,
     kind,

--- a/apps/desktop/src/main/ipc/sop-handlers.ts
+++ b/apps/desktop/src/main/ipc/sop-handlers.ts
@@ -87,6 +87,11 @@ function assertInputPayload(value: unknown): asserts value is Record<string, unk
 }
 
 export function registerSopHandlers(context: IpcHandlerContext) {
+  const publishAutomationUpdated = () => {
+    const win = context.getMainWindow()
+    if (win && !win.isDestroyed()) win.webContents.send('automation:updated')
+  }
+
   context.ipcMain.handle('sops:list', async () => {
     return listSopDefinitions()
   })
@@ -110,7 +115,7 @@ export function registerSopHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('sops:run-now', async (_event, sopId: string, inputs?: Record<string, unknown>) => {
     assertString(sopId, 'SOP id')
     assertInputPayload(inputs)
-    return runSopNow(sopId, inputs || {})
+    return runSopNow(sopId, inputs || {}, publishAutomationUpdated)
   })
 
   context.ipcMain.handle('sops:run-detail', async (_event, automationRunId: string) => {

--- a/apps/desktop/src/main/sop-run-context.ts
+++ b/apps/desktop/src/main/sop-run-context.ts
@@ -7,14 +7,21 @@ import type {
 } from '@open-cowork/shared'
 import {
   assertSopRunInputSnapshotSize,
+  getSopDetail,
   getLatestActiveSopForAutomation,
   getSopRunLinkForAutomationRun,
 } from './sop-store.ts'
+import { getAutomationDetail } from './automation-store.ts'
 
 export type SopRunStartContext = {
   sopVersionId: string
   triggerType: SopTriggerType
   inputs: Record<string, unknown>
+}
+
+export type ResolvedSopRunStartContext = {
+  automationId: string
+  context: SopRunStartContext
 }
 
 function inputValueIsPresent(value: unknown) {
@@ -25,7 +32,7 @@ function inputValueIsPresent(value: unknown) {
 }
 
 function inputsForSopRun(
-  sop: SopListItem,
+  sop: Pick<SopListItem, 'activeVersion'>,
   automation: AutomationDetail,
   seedInputs: Record<string, unknown>,
 ) {
@@ -44,6 +51,32 @@ function inputsForSopRun(
   }
   assertSopRunInputSnapshotSize(inputs)
   return inputs
+}
+
+export function resolveSopRunContextForSopTrigger(options: {
+  sopId: string
+  triggerType: SopTriggerType
+  inputs?: Record<string, unknown>
+}): ResolvedSopRunStartContext {
+  const sop = getSopDetail(options.sopId)
+  if (!sop?.activeVersion) throw new Error(`SOP ${options.sopId} has no active version.`)
+  if (sop.definition.status !== 'active') throw new Error('Only active SOPs can be run.')
+  if (!sop.activeVersion.triggerTypes.includes(options.triggerType)) {
+    throw new Error(`SOP does not allow ${options.triggerType} runs.`)
+  }
+  const automationId = sop.activeVersion.sourceAutomationId || sop.definition.sourceAutomationId
+  if (!automationId) throw new Error('SOP has no backing automation to execute.')
+  const automation = getAutomationDetail(automationId)
+  if (!automation) throw new Error(`SOP backing automation ${automationId} does not exist.`)
+  const inputs = inputsForSopRun(sop, automation, options.inputs || {})
+  return {
+    automationId,
+    context: {
+      sopVersionId: sop.activeVersion.id,
+      triggerType: options.triggerType,
+      inputs,
+    },
+  }
 }
 
 function retrySopContext(previousLink: SopRunLink | null): SopRunStartContext | null {

--- a/apps/desktop/src/main/sop-service.ts
+++ b/apps/desktop/src/main/sop-service.ts
@@ -17,10 +17,10 @@ import { COWORK_SOP_SCHEMA_VERSION } from '@open-cowork/shared'
 import { readdirSync, statSync } from 'fs'
 import { join } from 'path'
 import {
-  createAutomationRunWhenNoActive,
   getAutomationDetail,
   getRun,
 } from './automation-store.ts'
+import { startAutomationRun } from './automation-run-starter.ts'
 import { getChartArtifactsRoot, readChartArtifactSource } from './chart-artifacts.ts'
 import { getDb } from './automation-store-db.ts'
 import {
@@ -30,7 +30,6 @@ import {
   type DbRow,
 } from './automation-store-model.ts'
 import {
-  assertSopRunInputSnapshotSize,
   createSopDefinitionWithRunLink,
   getSopDetail,
   getSopRunLinkForAutomationRun,
@@ -39,28 +38,9 @@ import {
   listSops,
   updateSopDefinition,
 } from './sop-store.ts'
+import { resolveSopRunContextForSopTrigger } from './sop-run-context.ts'
 
 const RUN_PROVENANCE_SUMMARY_MAX_CHARS = 4_000
-
-function inputValueIsPresent(value: unknown) {
-  if (value === null || value === undefined) return false
-  if (typeof value === 'string') return value.trim().length > 0
-  if (Array.isArray(value)) return value.length > 0
-  return true
-}
-
-function assertSopRunEligible(detail: NonNullable<ReturnType<typeof getSopDetail>>, inputs: Record<string, unknown>) {
-  if (detail.definition.status !== 'active') throw new Error('Only active SOPs can be run.')
-  const activeVersion = detail.activeVersion
-  if (!activeVersion) throw new Error(`SOP ${detail.definition.id} has no active version.`)
-  const missingInputs = activeVersion.requiredInputs
-    .filter((input) => input.required && !inputValueIsPresent(inputs[input.id]))
-    .map((input) => input.label || input.id)
-  if (missingInputs.length > 0) {
-    throw new Error(`Missing required SOP input${missingInputs.length === 1 ? '' : 's'}: ${missingInputs.join(', ')}`)
-  }
-  assertSopRunInputSnapshotSize(inputs)
-}
 
 function step(id: string, kind: SopWorkflowStep['kind'], title: string, options: {
   agentName?: string | null
@@ -350,24 +330,42 @@ export function updateSop(sopId: string, draft: SopDraft) {
   return detail
 }
 
-export function runSopNow(sopId: string, inputs: Record<string, unknown> = {}): SopRunLink {
+export async function runSopForTrigger(
+  sopId: string,
+  triggerType: SopTriggerType,
+  inputs: Record<string, unknown> = {},
+  publishAutomationUpdated: () => void = () => {},
+): Promise<SopRunLink> {
   const detail = getSopDetail(sopId)
   if (!detail?.activeVersion) throw new Error(`SOP ${sopId} has no active version.`)
-  assertSopRunEligible(detail, inputs)
-  const automationId = detail.activeVersion.sourceAutomationId || detail.definition.sourceAutomationId
-  if (!automationId) throw new Error('SOP has no backing automation to execute.')
-  if (!detail.activeVersion.triggerTypes.includes('manual')) {
-    throw new Error('SOP does not allow manual runs.')
+  if (detail.definition.status !== 'active') throw new Error('Only active SOPs can be run.')
+  if (!detail.activeVersion.triggerTypes.includes(triggerType)) {
+    throw new Error(`SOP does not allow ${triggerType} runs.`)
   }
-  const run = createAutomationRunWhenNoActive(automationId, 'execution', `Run SOP: ${detail.definition.name}`, {
-    sopRunLink: {
-      sopVersionId: detail.activeVersion.id,
-      triggerType: 'manual',
-      inputs,
-    },
-  })
+  const resolved = resolveSopRunContextForSopTrigger({ sopId, triggerType, inputs })
+  const automation = getAutomationDetail(resolved.automationId)
+  if (!automation) throw new Error(`SOP backing automation ${resolved.automationId} does not exist.`)
+  if (!automation.brief?.approvedAt) throw new Error('SOP backing automation needs an approved execution brief before it can run.')
+  let run: Awaited<ReturnType<typeof startAutomationRun>>
+  try {
+    run = await startAutomationRun(resolved.automationId, 'execution', publishAutomationUpdated, {
+      title: `Run SOP: ${detail.definition.name}`,
+      sopRunContext: resolved.context,
+    })
+  } catch (error) {
+    publishAutomationUpdated()
+    throw error
+  }
   if (!run) throw new Error('SOP backing automation already has an active run.')
   const link = getSopRunLinkForAutomationRun(run.id)
   if (!link) throw new Error('SOP run link was not created.')
   return link
+}
+
+export function runSopNow(
+  sopId: string,
+  inputs: Record<string, unknown> = {},
+  publishAutomationUpdated: () => void = () => {},
+): Promise<SopRunLink> {
+  return runSopForTrigger(sopId, 'manual', inputs, publishAutomationUpdated)
 }

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -144,6 +144,7 @@ function renderAutomationsPage(options: {
   createdAutomation?: AutomationDetail
   settingsGetError?: Error
   sopsListError?: Error
+  sopsRunNowError?: Error
   reportRendererError?: ReturnType<typeof vi.fn>
 } = {}) {
   const currentPayload = options.initialPayload ?? payload({
@@ -167,19 +168,26 @@ function renderAutomationsPage(options: {
     if (options.sopsListError) throw options.sopsListError
     return currentSops
   })
-  const sopsRunNow = vi.fn(async () => ({
-    schemaVersion: COWORK_SOP_SCHEMA_VERSION,
-    id: 'sop-run-link-1',
-    sopId: 'sop-1',
-    sopVersionId: 'sop-version-1',
-    automationId: 'auto-1',
-    automationRunId: 'run-sop-1',
-    triggerType: 'manual' as const,
-    inputs: {},
-    createdAt: '2026-05-06T11:00:00.000Z',
-  }))
+  const sopsRunNow = vi.fn(async () => {
+    if (options.sopsRunNowError) throw options.sopsRunNowError
+    return {
+      schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+      id: 'sop-run-link-1',
+      sopId: 'sop-1',
+      sopVersionId: 'sop-version-1',
+      automationId: 'auto-1',
+      automationRunId: 'run-sop-1',
+      triggerType: 'manual' as const,
+      inputs: {},
+      createdAt: '2026-05-06T11:00:00.000Z',
+    }
+  })
   const unsubscribeAutomationUpdated = vi.fn()
-  const automationUpdated = vi.fn(() => unsubscribeAutomationUpdated)
+  let automationUpdatedHandler: (() => void) | null = null
+  const automationUpdated = vi.fn((handler: () => void) => {
+    automationUpdatedHandler = handler
+    return unsubscribeAutomationUpdated
+  })
   const onOpenThread = vi.fn()
   const reportRendererError = options.reportRendererError || vi.fn()
 
@@ -278,6 +286,7 @@ function renderAutomationsPage(options: {
     automationUpdated,
     reportRendererError,
     unsubscribeAutomationUpdated,
+    triggerAutomationUpdated: () => automationUpdatedHandler?.(),
     unmount: view.unmount,
     onOpenThread,
   }
@@ -372,6 +381,23 @@ describe('AutomationsPage', () => {
       'project-directory': '/work/project',
       source: 'automation_page',
     })))
+  })
+
+  it('refreshes automations after a SOP run start failure', async () => {
+    const user = userEvent.setup()
+    const api = renderAutomationsPage({
+      initialSops: sopPayload(),
+      sopsRunNowError: new Error('Runtime not started'),
+    })
+
+    expect(await screen.findByRole('region', { name: 'Reusable SOPs' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Run SOP' }))
+
+    expect(await screen.findByText('Runtime not started')).toBeInTheDocument()
+    await waitFor(() => expect(api.list).toHaveBeenCalledTimes(2))
+    api.triggerAutomationUpdated()
+    await waitFor(() => expect(api.list).toHaveBeenCalledTimes(3))
+    expect(screen.getByText('Runtime not started')).toBeInTheDocument()
   })
 
   it('does not queue manual SOP runs when required inputs cannot be inferred', async () => {

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -151,9 +151,12 @@ export function AutomationsPage({ onOpenThread }: Props) {
     selectedAutomationIdRef.current = selectedAutomationId
   }, [selectedAutomationId])
 
-  const refresh = useCallback(async (preferredAutomationId?: string | null) => {
+  const refresh = useCallback(async (
+    preferredAutomationId?: string | null,
+    options: { clearError?: boolean } = {},
+  ) => {
     setLoading(true)
-    setError(null)
+    if (options.clearError !== false) setError(null)
     try {
       const [automationResult, sopResult] = await Promise.allSettled([
         window.coworkApi.automation.list(),
@@ -184,7 +187,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
   useEffect(() => {
     void refresh(null)
     return window.coworkApi.on.automationUpdated(() => {
-      void refresh()
+      void refresh(undefined, { clearError: false })
     })
   }, [refresh])
 
@@ -361,7 +364,9 @@ export function AutomationsPage({ onOpenThread }: Props) {
       setFeedback('SOP run queued.')
       await refresh(selectedAutomationId)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to run SOP.')
+      const message = err instanceof Error ? err.message : 'Failed to run SOP.'
+      await refresh(selectedAutomationId, { clearError: false })
+      setError(message)
     }
   }
 

--- a/tests/sop-store.test.ts
+++ b/tests/sop-store.test.ts
@@ -14,6 +14,7 @@ import {
   createAutomationRunWhenNoActive,
   createInboxItem,
   getRun,
+  listAutomationState,
   markRunCompleted,
   markRunFailed,
   markRunStarted,
@@ -24,13 +25,17 @@ import {
   getSop,
   getSopRunDetail,
   listSopDefinitions,
+  runSopForTrigger,
   runSopNow,
   saveAutomationRunAsSop,
   updateSop,
 } from '../apps/desktop/src/main/sop-service.ts'
 import { getChartArtifactMetadataPath, getChartArtifactsRoot } from '../apps/desktop/src/main/chart-artifacts.ts'
 import { createSopDefinitionWithRunLink, recordSopRunEvaluation } from '../apps/desktop/src/main/sop-store.ts'
-import { resolveSopRunContextForAutomationStart } from '../apps/desktop/src/main/sop-run-context.ts'
+import {
+  resolveSopRunContextForAutomationStart,
+  resolveSopRunContextForSopTrigger,
+} from '../apps/desktop/src/main/sop-run-context.ts'
 
 const ONE_PX_PNG_BYTES = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
@@ -54,6 +59,22 @@ function withAutomationStore(name: string, fn: () => void) {
   try {
     resetAutomationStore(userDataDir)
     fn()
+  } finally {
+    closeLogger()
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+async function withAutomationStoreAsync(name: string, fn: () => Promise<void>) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    resetAutomationStore(userDataDir)
+    await fn()
   } finally {
     closeLogger()
     clearAutomationStoreCache()
@@ -174,6 +195,17 @@ function draftFromSop(detail: NonNullable<ReturnType<typeof getSop>>): SopDraft 
   }
 }
 
+function createLinkedSopRun(sopId: string, inputs: Record<string, unknown>, triggerType: 'manual' | 'schedule' | 'inbox' | 'webhook' = 'manual') {
+  const resolved = resolveSopRunContextForSopTrigger({ sopId, triggerType, inputs })
+  const run = createAutomationRunWhenNoActive(resolved.automationId, 'execution', `Test SOP ${triggerType}`, {
+    sopRunLink: resolved.context,
+  })
+  if (!run) throw new Error('SOP backing automation already has an active run.')
+  const detail = getSopRunDetail(run!.id)
+  assert.ok(detail)
+  return detail.link
+}
+
 test('successful automation runs can be saved as versioned SOPs with exact run provenance', () => withAutomationStore('save-run', () => {
   const { automation, run } = createCompletedAutomationRun()
   const detail = saveAutomationRunAsSop(run.id)
@@ -264,7 +296,7 @@ test('manual SOP runs create automation runs linked to the active SOP version', 
   const { run } = createCompletedAutomationRun()
   const v1 = saveAutomationRunAsSop(run.id)
   const v2 = updateSop(v1.definition.id, draftFromSop(v1))
-  const link = runSopNow(v2.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
+  const link = createLinkedSopRun(v2.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
   const startedRun = getRun(link.automationRunId)
 
   assert.ok(startedRun)
@@ -282,27 +314,80 @@ test('manual SOP runs create automation runs linked to the active SOP version', 
   )
 }))
 
+test('SOP trigger entry points start execution through the automation runner', async () => withAutomationStoreAsync('trigger-entrypoints', async () => {
+  const { run } = createCompletedAutomationRun()
+  const sop = saveAutomationRunAsSop(run.id)
+  const active = updateSop(sop.definition.id, {
+    ...draftFromSop(sop),
+    triggerTypes: ['manual', 'inbox', 'webhook'],
+  })
+  const triggers = [
+    ['manual', 'automation_page'],
+    ['inbox', 'automation_inbox'],
+    ['webhook', 'automation_webhook'],
+  ] as const
+
+  for (const [triggerType, source] of triggers) {
+    const existingRunIds = new Set(listAutomationState().runs.map((entry) => entry.id))
+    const start = triggerType === 'manual'
+      ? () => runSopNow(active.definition.id, { source })
+      : () => runSopForTrigger(active.definition.id, triggerType, { source })
+    await assert.rejects(start, /Runtime not started/)
+    const startedRun = listAutomationState().runs.find((entry) => !existingRunIds.has(entry.id))
+    assert.ok(startedRun)
+    const detail = getSopRunDetail(startedRun!.id)
+    assert.equal(startedRun?.status, 'failed')
+    assert.equal(detail?.version.id, active.activeVersion?.id)
+    assert.equal(detail?.link.triggerType, triggerType)
+    assert.equal(detail?.inputs.source, source)
+    assert.equal(detail?.inputs['project-directory'], '/Users/example/project')
+  }
+}))
+
 test('manual SOP runs validate active status and required inputs before creating automation runs', () => withAutomationStore('run-now-eligibility', () => {
   const { run } = createCompletedAutomationRun()
   const sop = saveAutomationRunAsSop(run.id)
+  const runnableSop = updateSop(sop.definition.id, {
+    ...draftFromSop(sop),
+    requiredInputs: [
+      ...(sop.activeVersion?.requiredInputs || []),
+      {
+        schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+        id: 'report-owner',
+        label: 'Report owner',
+        description: 'Required reviewer that cannot be inferred from the backing automation.',
+        required: true,
+      },
+    ],
+  })
   const runCountBefore = (getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count
 
-  assert.throws(() => runSopNow(sop.definition.id, {}), /Missing required SOP input: Project directory/)
+  assert.throws(() => resolveSopRunContextForSopTrigger({ sopId: runnableSop.definition.id, triggerType: 'manual', inputs: {} }), /Missing required SOP input: Report owner/)
   assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, runCountBefore)
 
-  getDb().prepare('update sop_definitions set status = ? where id = ?').run('paused', sop.definition.id)
-  assert.throws(() => runSopNow(sop.definition.id, { 'project-directory': '/Users/example/project' }), /Only active SOPs/)
+  getDb().prepare('update sop_definitions set status = ? where id = ?').run('paused', runnableSop.definition.id)
+  assert.throws(() => resolveSopRunContextForSopTrigger({
+    sopId: runnableSop.definition.id,
+    triggerType: 'manual',
+    inputs: { 'project-directory': '/Users/example/project', 'report-owner': 'qa' },
+  }), /Only active SOPs/)
   assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, runCountBefore)
-  getDb().prepare('update sop_definitions set status = ? where id = ?').run('active', sop.definition.id)
+  getDb().prepare('update sop_definitions set status = ? where id = ?').run('active', runnableSop.definition.id)
 
-  assert.throws(() => runSopNow(sop.definition.id, {
-    'project-directory': '/Users/example/project',
-    oversized: 'x'.repeat(100_000),
+  assert.throws(() => resolveSopRunContextForSopTrigger({
+    sopId: runnableSop.definition.id,
+    triggerType: 'manual',
+    inputs: {
+      'project-directory': '/Users/example/project',
+      'report-owner': 'qa',
+      oversized: 'x'.repeat(100_000),
+    },
   }), /SOP run inputs are too large/)
   assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, runCountBefore)
 
-  const link = runSopNow(sop.definition.id, { 'project-directory': '/Users/example/project' })
+  const link = createLinkedSopRun(runnableSop.definition.id, { 'project-directory': '/Users/example/project', 'report-owner': 'qa' })
   assert.equal(link.inputs['project-directory'], '/Users/example/project')
+  assert.equal(link.inputs['report-owner'], 'qa')
   assert.equal((getDb().prepare('select count(*) as count from automation_runs').get() as { count?: number }).count, Number(runCountBefore) + 1)
 }))
 
@@ -386,7 +471,7 @@ test('automation run creation can atomically link a scheduled SOP run', () => wi
 test('retry SOP runs inherit the original SOP version even after edits', () => withAutomationStore('retry-context', () => {
   const { automation, run } = createCompletedAutomationRun()
   const sop = saveAutomationRunAsSop(run.id)
-  const first = runSopNow(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
+  const first = createLinkedSopRun(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
   markRunFailed(first.automationRunId, 'Temporary runtime failure', undefined, { retryable: true })
   const edited = updateSop(sop.definition.id, draftFromSop(sop))
 
@@ -405,7 +490,7 @@ test('retry SOP runs inherit the original SOP version even after edits', () => w
 test('SOP run detail projects durable automation operations for the exact version', () => withAutomationStore('run-detail', () => {
   const { run } = createCompletedAutomationRun()
   const sop = saveAutomationRunAsSop(run.id)
-  const link = runSopNow(sop.definition.id, { requester: 'qa-user', priority: 'high', 'project-directory': '/Users/example/project' })
+  const link = createLinkedSopRun(sop.definition.id, { requester: 'qa-user', priority: 'high', 'project-directory': '/Users/example/project' })
   const startedRun = getRun(link.automationRunId)
   assert.ok(startedRun)
   const runningRun = markRunStarted(startedRun!.id, 'session-run-detail')
@@ -574,9 +659,9 @@ test('manual SOP runs preserve the backing automation active-run guard', () => w
   const { run } = createCompletedAutomationRun()
   const sop = saveAutomationRunAsSop(run.id)
 
-  const first = runSopNow(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
+  const first = createLinkedSopRun(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' })
   assert.ok(first)
-  assert.throws(() => runSopNow(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' }), /already has an active run/)
+  assert.throws(() => createLinkedSopRun(sop.definition.id, { requester: 'local-user', 'project-directory': '/Users/example/project' }), /already has an active run/)
 }))
 
 test('automation database schema includes SOP tables and records the current version', () => withAutomationStore('schema', () => {


### PR DESCRIPTION
## Summary
- route direct SOP trigger starts through the existing automation runner instead of only creating a queued run record
- add explicit SOP trigger context resolution for manual, inbox, and future webhook starts while preserving scheduled/retry context resolution
- refresh automation state and preserve visible errors when a SOP start mutates durable state but fails during runtime startup

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/sop-store.test.ts tests/ipc-handler-registration.test.ts
- pnpm --dir apps/desktop exec vitest run --config vitest.renderer.config.ts src/renderer/components/automations/AutomationsPage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:renderer
- git diff --check