### PR TITLE
[codex] add typed SOP trigger IPC

### DIFF
--- a/apps/desktop/src/main/ipc/sop-handlers.ts
+++ b/apps/desktop/src/main/ipc/sop-handlers.ts
@@ -1,8 +1,9 @@
-import type { SopDraft } from '@open-cowork/shared'
+import type { SopDraft, SopTriggerType } from '@open-cowork/shared'
 import {
   getSop,
   getSopRunDetail,
   listSopDefinitions,
+  runSopForTrigger,
   runSopNow,
   saveAutomationRunAsSop,
   updateSop,
@@ -86,6 +87,12 @@ function assertInputPayload(value: unknown): asserts value is Record<string, unk
   assertJsonPayloadSize(value, 'SOP inputs', MAX_SOP_INPUT_BYTES)
 }
 
+function assertSopTriggerType(value: unknown): asserts value is SopTriggerType {
+  if (typeof value !== 'string' || !TRIGGERS.has(value)) {
+    throw new Error('SOP trigger type is invalid.')
+  }
+}
+
 export function registerSopHandlers(context: IpcHandlerContext) {
   const publishAutomationUpdated = () => {
     const win = context.getMainWindow()
@@ -116,6 +123,13 @@ export function registerSopHandlers(context: IpcHandlerContext) {
     assertString(sopId, 'SOP id')
     assertInputPayload(inputs)
     return runSopNow(sopId, inputs || {}, publishAutomationUpdated)
+  })
+
+  context.ipcMain.handle('sops:run-trigger', async (_event, sopId: string, triggerType: SopTriggerType, inputs?: Record<string, unknown>) => {
+    assertString(sopId, 'SOP id')
+    assertSopTriggerType(triggerType)
+    assertInputPayload(inputs)
+    return runSopForTrigger(sopId, triggerType, inputs || {}, publishAutomationUpdated)
   })
 
   context.ipcMain.handle('sops:run-detail', async (_event, automationRunId: string) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -108,6 +108,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'sops:save-from-automation-run',
   'sops:update',
   'sops:run-now',
+  'sops:run-trigger',
   'sops:run-detail',
   'threads:search',
   'threads:facets',
@@ -325,6 +326,7 @@ const api: CoworkAPI = {
     saveFromAutomationRun: (runId) => invoke('sops:save-from-automation-run', runId),
     update: (sopId, draft) => invoke('sops:update', sopId, draft),
     runNow: (sopId, inputs) => invoke('sops:run-now', sopId, inputs),
+    runForTrigger: (sopId, triggerType, inputs) => invoke('sops:run-trigger', sopId, triggerType, inputs),
     runDetail: (automationRunId) => invoke('sops:run-detail', automationRunId),
   },
   threads: {

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -239,6 +239,9 @@ function renderAutomationsPage(options: {
     sops: {
       list: sopsList,
       runNow: sopsRunNow,
+      runForTrigger: vi.fn(async () => {
+        throw new Error('sops.runForTrigger not mocked')
+      }),
     },
     diagnostics: {
       reportRendererError,

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -113,6 +113,9 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       runNow: vi.fn(async () => {
         throw new Error('sops.runNow not mocked')
       }),
+      runForTrigger: vi.fn(async () => {
+        throw new Error('sops.runForTrigger not mocked')
+      }),
       runDetail: vi.fn(async () => null),
     },
     artifact: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -68,6 +68,7 @@ import type {
   SopListPayload,
   SopRunDetail,
   SopRunLink,
+  SopTriggerType,
 } from './sops.js'
 import type {
   DestructiveConfirmationGrant,
@@ -312,6 +313,7 @@ export interface CoworkAPI {
     saveFromAutomationRun: (runId: string) => Promise<SopDetail>
     update: (sopId: string, draft: SopDraft) => Promise<SopDetail>
     runNow: (sopId: string, inputs?: Record<string, unknown>) => Promise<SopRunLink>
+    runForTrigger: (sopId: string, triggerType: SopTriggerType, inputs?: Record<string, unknown>) => Promise<SopRunLink>
     runDetail: (automationRunId: string) => Promise<SopRunDetail | null>
   }
   crews: {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -10,6 +10,7 @@ import { registerArtifactHandlers } from '../apps/desktop/src/main/ipc/artifact-
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { registerAutomationHandlers } from '../apps/desktop/src/main/ipc/automation-handlers.ts'
+import { registerSopHandlers } from '../apps/desktop/src/main/ipc/sop-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
@@ -841,6 +842,23 @@ test('automation:create rejects malformed policy objects before persistence', as
       preferredAgentNames: [],
     }),
     /Automation retryPolicy is required/,
+  )
+})
+
+test('sops:run-trigger rejects malformed trigger payloads before SOP lookup', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerSopHandlers(context)
+  const handler = handlers.get('sops:run-trigger')
+
+  assert.ok(handler, 'expected sops:run-trigger handler to be registered')
+  await assert.rejects(
+    () => handler({}, 'sop-1', 'side-channel', {}),
+    /SOP trigger type is invalid/,
+  )
+  await assert.rejects(
+    () => handler({}, 'sop-1', 'inbox', []),
+    /SOP inputs must be an object/,
   )
 })
 

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -118,6 +118,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('sops:list'), true)
   assert.equal(handlers.has('sops:save-from-automation-run'), true)
   assert.equal(handlers.has('sops:run-now'), true)
+  assert.equal(handlers.has('sops:run-trigger'), true)
   assert.equal(handlers.has('sops:run-detail'), true)
   assert.equal(handlers.has('threads:tags:apply'), true)
   assert.equal(handlers.has('threads:smart-filters:create'), true)


### PR DESCRIPTION
## Summary
- add a typed sops.runForTrigger IPC/preload API for manual, schedule, inbox, and future webhook SOP entry points
- validate trigger type and input payload shape at the main-process handler boundary before dispatching into the existing automation-backed SOP runner
- keep sops.runNow as the current manual convenience path and update renderer test mocks/registration coverage

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/ipc-handler-registration.test.ts tests/ipc-handler-behavior.test.ts tests/sop-store.test.ts
- pnpm typecheck
- pnpm lint
- pnpm --dir apps/desktop exec vitest run --config vitest.renderer.config.ts src/renderer/components/automations/AutomationsPage.test.tsx
- git diff --check