### PR TITLE
[codex] surface operational workspace profiles

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -31,6 +31,7 @@ import { registerAutomationHandlers } from './ipc/automation-handlers.ts'
 import { registerSessionHandlers } from './ipc/session-handlers.ts'
 import { registerCatalogHandlers } from './ipc/catalog-handlers.ts'
 import { registerCrewHandlers } from './ipc/crew-handlers.ts'
+import { registerOperationHandlers } from './ipc/operation-handlers.ts'
 import { registerSopHandlers } from './ipc/sop-handlers.ts'
 import { registerCustomContentHandlers } from './ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from './ipc/explorer-handlers.ts'
@@ -362,6 +363,7 @@ export function setupIpcHandlers(ipcMain: IpcMain, getMainWindow: () => BrowserW
   registerArtifactHandlers(context)
   registerAutomationHandlers(context)
   registerCrewHandlers(context)
+  registerOperationHandlers(context)
   registerSopHandlers(context)
 
   registerThreadHandlers(context)

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -1,0 +1,15 @@
+import type { IpcHandlerContext } from './context.ts'
+import {
+  buildOperationalQueueAlerts,
+  listWorkspaceProfiles,
+} from '../operational-queue-store.ts'
+
+export function registerOperationHandlers(context: IpcHandlerContext) {
+  context.ipcMain.handle('operations:workspace-profiles', async () => {
+    return listWorkspaceProfiles()
+  })
+
+  context.ipcMain.handle('operations:queue-alerts', async () => {
+    return buildOperationalQueueAlerts()
+  })
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -77,6 +77,8 @@ const PRELOAD_INVOKE_CHANNELS = [
   'app:export-diagnostics',
   'app:check-updates',
   'app:reset',
+  'operations:workspace-profiles',
+  'operations:queue-alerts',
   'updates:install-capability',
   'updates:check-installable',
   'updates:download',
@@ -282,6 +284,10 @@ const api: CoworkAPI = {
     exportDiagnostics: () => invoke('app:export-diagnostics'),
     checkUpdates: () => invoke('app:check-updates'),
     reset: (confirmationToken) => invoke('app:reset', confirmationToken),
+  },
+  operations: {
+    workspaceProfiles: () => invoke('operations:workspace-profiles'),
+    queueAlerts: () => invoke('operations:queue-alerts'),
   },
   updates: {
     installCapability: () => invoke('updates:install-capability'),

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -8,6 +8,7 @@ import type {
   CustomAgentSummary,
   DashboardSummary,
   EffectiveAppSettings,
+  OperationalQueueAlert,
   PerfSnapshot,
   RuntimeInputDiagnostics,
   SessionInfo,
@@ -250,6 +251,17 @@ const skills: CapabilitySkill[] = [
   },
 ]
 
+const queueAlerts: OperationalQueueAlert[] = [
+  {
+    schemaVersion: 1,
+    queueItemId: 'queue-1',
+    severity: 'critical',
+    kind: 'budget_exceeded',
+    message: 'Run exceeded $5.00 queue budget cap.',
+    createdAt: '2026-05-07T00:00:00.000Z',
+  },
+]
+
 function resetSessionStore() {
   useSessionStore.setState({
     sessions: [],
@@ -277,6 +289,7 @@ function installPulseApi(options: {
   createSession?: ReturnType<typeof vi.fn>
   activateSession?: ReturnType<typeof vi.fn>
   reportRendererError?: ReturnType<typeof vi.fn>
+  queueAlerts?: ReturnType<typeof vi.fn>
 } = {}) {
   return installRendererTestCoworkApi({
     runtime: {
@@ -312,6 +325,9 @@ function installPulseApi(options: {
     diagnostics: {
       perf: vi.fn(async () => perfSnapshot),
       reportRendererError: options.reportRendererError || vi.fn(),
+    },
+    operations: {
+      queueAlerts: options.queueAlerts || vi.fn(async () => queueAlerts),
     },
     session: {
       create: options.createSession || vi.fn(async (directory?: string) => ({
@@ -386,12 +402,14 @@ describe('PulsePage', () => {
     expect(screen.getAllByText('Researcher').length).toBeGreaterThan(0)
     expect(screen.getByText('reasoning: medium')).toBeInTheDocument()
     expect(screen.getByText('apiKey')).toBeInTheDocument()
+    expect(screen.getByText('Run exceeded $5.00 queue budget cap.')).toBeInTheDocument()
     expect(screen.getByText(/1 session\(s\) couldn't be reconstructed/)).toBeInTheDocument()
     expect(screen.getByText(/Still loading 2 older session\(s\)/)).toBeInTheDocument()
 
     expect(api.app.dashboardSummary).toHaveBeenCalledWith('last7d')
     expect(api.runtime.status).toHaveBeenCalledTimes(1)
     expect(api.diagnostics.perf).toHaveBeenCalledTimes(1)
+    expect(api.operations.queueAlerts).toHaveBeenCalledTimes(1)
   })
 
   it('opens recent threads through the existing session-loading path', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -57,6 +57,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     setDashboardRange,
     dashboardSummary,
     dashboardError,
+    queueAlerts,
     refreshDiagnostics,
   } = usePulseDiagnostics()
 
@@ -128,6 +129,14 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
   const leadAgent = useMemo(
     () => visibleBuiltinAgents.find((agent) => agent.mode === 'primary') || null,
     [visibleBuiltinAgents],
+  )
+  const criticalQueueAlerts = useMemo(
+    () => queueAlerts.filter((alert) => alert.severity === 'critical'),
+    [queueAlerts],
+  )
+  const warningQueueAlerts = useMemo(
+    () => queueAlerts.filter((alert) => alert.severity === 'warning'),
+    [queueAlerts],
   )
 
   const historyLoadMetric = metricByName(diagnostics.perf, 'session.history.load')
@@ -354,6 +363,43 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                         {t('homepage.card.agentUsageEmpty', 'No sub-agent delegations in {{window}}. Once a primary agent dispatches work to Research / Explore / Writer / any custom specialist, their cost and token usage rolls up here.', { window: dashboardSummary?.range.label?.toLowerCase() || t('homepage.card.selectedWindow', 'the selected window') })}
                       </div>
                     )}
+                  </MetricCard>
+
+                  <MetricCard icon={<DatabaseIcon />} eyebrow={t('homepage.card.operationsEyebrow', 'Operations')} title={t('homepage.card.operations', 'Queues and authority')}>
+                    <StatGrid
+                      items={[
+                        { label: t('homepage.card.queueAlerts', 'Queue alerts'), value: formatInteger.format(queueAlerts.length), tone: queueAlerts.length > 0 ? 'accent' : undefined },
+                        { label: t('homepage.card.criticalAlerts', 'Critical'), value: formatInteger.format(criticalQueueAlerts.length) },
+                        { label: t('homepage.card.warningAlerts', 'Warnings'), value: formatInteger.format(warningQueueAlerts.length) },
+                        { label: t('homepage.card.busyRightNow', 'Busy right now'), value: formatInteger.format(busyCount) },
+                      ]}
+                    />
+                    <div className="mt-4 space-y-3">
+                      {queueAlerts.length > 0 ? (
+                        queueAlerts.slice(0, 3).map((alert) => (
+                          <div
+                            key={`${alert.queueItemId}:${alert.kind}:${alert.createdAt}`}
+                            className="rounded-2xl bg-surface px-4 py-3"
+                            style={{ boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-text) 4%, transparent)' }}
+                          >
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{alert.kind.replace(/_/g, ' ')}</span>
+                              <span className={alert.severity === 'critical' ? 'text-[10px] font-semibold uppercase tracking-[0.14em] text-red' : 'text-[10px] font-semibold uppercase tracking-[0.14em] text-amber'}>
+                                {alert.severity}
+                              </span>
+                            </div>
+                            <div className="mt-2 text-[12px] text-text-secondary leading-relaxed">{alert.message}</div>
+                          </div>
+                        ))
+                      ) : (
+                        <div
+                          className="rounded-2xl bg-surface px-4 py-3 text-[12px] text-text-secondary leading-relaxed"
+                          style={{ boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-text) 4%, transparent)' }}
+                        >
+                          {t('homepage.card.operationsHealthy', 'No stuck, blocked, or over-budget operational runs are waiting for attention.')}
+                        </div>
+                      )}
+                    </div>
                   </MetricCard>
 
                   <MetricCard icon={<LightningIcon />} eyebrow={t('homepage.card.perfEyebrow', 'Performance')} title={t('homepage.card.perf', 'Hydration and patch flow')}>

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -157,6 +157,35 @@ describe('SettingsPanel', () => {
     }))
   })
 
+  it('keeps Settings usable when workspace profile metadata is unavailable', async () => {
+    const reportRendererError = vi.fn()
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      diagnostics: {
+        reportRendererError,
+      },
+      operations: {
+        workspaceProfiles: vi.fn(async () => {
+          throw new Error('operations store unavailable')
+        }),
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    expect(await screen.findByText('Settings')).toBeInTheDocument()
+    expect(useSessionStore.getState().globalErrors).toEqual([])
+    expect(reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('operations store unavailable'),
+      view: 'settings',
+    }))
+  })
+
   it('surfaces provider credential reload failures after saving settings', async () => {
     const user = userEvent.setup()
     const reportRendererError = vi.fn()

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import type {
   PublicAppConfig,
   SandboxCleanupResult,
   SandboxStorageStats,
+  WorkspaceProfile,
 } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import {
@@ -54,6 +55,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
   const [tab, setTab] = useState<SettingsTab>('appearance')
   const [appearance, setAppearance] = useState<AppearancePreferences>(getAppearancePreferences())
   const [storageStats, setStorageStats] = useState<SandboxStorageStats | null>(null)
+  const [workspaceProfiles, setWorkspaceProfiles] = useState<WorkspaceProfile[]>([])
   const [runningCleanup, setRunningCleanup] = useState<SandboxCleanupResult['mode'] | null>(null)
   const [lastCleanup, setLastCleanup] = useState<SandboxCleanupResult | null>(null)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
@@ -72,12 +74,23 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
     // disposed instance. The default settings load is masked; the Models
     // tab fetches only the active provider's real credential bag below.
     let cancelled = false
-    Promise.all([window.coworkApi.settings.get(), window.coworkApi.app.config(), window.coworkApi.artifact.storageStats()])
-      .then(([nextSettings, nextConfig, nextStorage]) => {
+    const workspaceProfilesPromise = window.coworkApi.operations.workspaceProfiles()
+      .catch((err) => {
+        reportSettingsPanelError(err, 'Failed to load workspace profiles')
+        return []
+      })
+    Promise.all([
+      window.coworkApi.settings.get(),
+      window.coworkApi.app.config(),
+      window.coworkApi.artifact.storageStats(),
+      workspaceProfilesPromise,
+    ])
+      .then(([nextSettings, nextConfig, nextStorage, nextWorkspaceProfiles]) => {
         if (cancelled) return
         setSettings(stripMaskedSettingsCredentials(nextSettings))
         setConfig(nextConfig)
         setStorageStats(nextStorage)
+        setWorkspaceProfiles(nextWorkspaceProfiles)
       })
       .catch((err) => {
         if (cancelled) return
@@ -290,6 +303,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
                 stats={storageStats}
                 runningCleanup={runningCleanup}
                 lastCleanup={lastCleanup}
+                workspaceProfiles={workspaceProfiles}
                 onCleanup={runCleanup}
               />
             )}

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { SandboxStorageStats, UpdateInstallEvent, UpdateInstallStatus } from '@open-cowork/shared'
+import type { SandboxStorageStats, UpdateInstallEvent, UpdateInstallStatus, WorkspaceProfile } from '@open-cowork/shared'
 import { useSessionStore } from '../../stores/session'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { StoragePanel } from './SettingsStoragePanel'
@@ -15,6 +15,34 @@ const stats: SandboxStorageStats = {
   unreferencedWorkspaceCount: 0,
   staleWorkspaceCount: 0,
   staleThresholdDays: 14,
+}
+
+const workspaceProfile: WorkspaceProfile = {
+  schemaVersion: 1,
+  id: 'project-workspace',
+  kind: 'project_workspace',
+  name: 'Project workspace',
+  description: 'Project-bound work using explicit filesystem grants.',
+  authority: {
+    schemaVersion: 1,
+    filesystem: {
+      mode: 'project',
+      roots: ['<project grant>'],
+      writeAllowed: true,
+    },
+    externalSystems: [],
+    cleanup: {
+      retentionDays: 90,
+      deletesUnreferencedArtifacts: false,
+    },
+    isolation: {
+      projectBound: true,
+      channelBound: false,
+      highRiskIsolated: false,
+    },
+  },
+  createdAt: '2026-05-10T00:00:00.000Z',
+  updatedAt: '2026-05-10T00:00:00.000Z',
 }
 
 beforeEach(() => {
@@ -48,6 +76,7 @@ describe('StoragePanel', () => {
         stats={stats}
         runningCleanup={null}
         lastCleanup={null}
+        workspaceProfiles={[]}
         onCleanup={vi.fn(async () => undefined)}
       />,
     )
@@ -106,6 +135,7 @@ describe('StoragePanel', () => {
         stats={stats}
         runningCleanup={null}
         lastCleanup={null}
+        workspaceProfiles={[]}
         onCleanup={vi.fn(async () => undefined)}
       />,
     )
@@ -169,6 +199,7 @@ describe('StoragePanel', () => {
         stats={stats}
         runningCleanup={null}
         lastCleanup={null}
+        workspaceProfiles={[]}
         onCleanup={vi.fn(async () => undefined)}
       />,
     )
@@ -189,6 +220,7 @@ describe('StoragePanel', () => {
         stats={stats}
         runningCleanup={null}
         lastCleanup={null}
+        workspaceProfiles={[]}
         onCleanup={vi.fn(async () => undefined)}
       />,
     )
@@ -223,6 +255,7 @@ describe('StoragePanel', () => {
         stats={stats}
         runningCleanup={null}
         lastCleanup={null}
+        workspaceProfiles={[]}
         onCleanup={vi.fn(async () => undefined)}
       />,
     )
@@ -237,5 +270,24 @@ describe('StoragePanel', () => {
       view: 'settings-storage',
     }))
     expect(screen.getByText('Could not build diagnostics — try again')).toBeInTheDocument()
+  })
+
+  it('shows workspace authority and retention profiles', () => {
+    render(
+      <StoragePanel
+        stats={stats}
+        runningCleanup={null}
+        lastCleanup={null}
+        workspaceProfiles={[workspaceProfile]}
+        onCleanup={vi.fn(async () => undefined)}
+      />,
+    )
+
+    expect(screen.getByText('Workspace Profiles')).toBeInTheDocument()
+    expect(screen.getByText('Project workspace')).toBeInTheDocument()
+    expect(screen.getByText('Project-bound')).toBeInTheDocument()
+    expect(screen.getByText('Project grant')).toBeInTheDocument()
+    expect(screen.getByText('90 days')).toBeInTheDocument()
+    expect(screen.getByText('Keep artifacts')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type {
   SandboxCleanupResult,
   SandboxStorageStats,
+  WorkspaceProfile,
 } from '@open-cowork/shared'
 import { writeTextToClipboard } from '../../helpers/clipboard'
 import { confirmAppReset } from '../../helpers/destructive-actions'
@@ -32,6 +33,76 @@ function describeStorageError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
 }
 
+function describeFilesystemMode(mode: WorkspaceProfile['authority']['filesystem']['mode']) {
+  switch (mode) {
+    case 'none':
+      return t('settings.workspaceProfiles.filesystemNone', 'No filesystem')
+    case 'sandbox':
+      return t('settings.workspaceProfiles.filesystemSandbox', 'Sandbox')
+    case 'project':
+      return t('settings.workspaceProfiles.filesystemProject', 'Project grant')
+    case 'external':
+      return t('settings.workspaceProfiles.filesystemExternal', 'External')
+  }
+}
+
+function describeIsolation(profile: WorkspaceProfile) {
+  const parts = []
+  if (profile.authority.isolation.projectBound) parts.push(t('settings.workspaceProfiles.projectBound', 'Project-bound'))
+  if (profile.authority.isolation.channelBound) parts.push(t('settings.workspaceProfiles.channelBound', 'Channel-bound'))
+  if (profile.authority.isolation.highRiskIsolated) parts.push(t('settings.workspaceProfiles.highRisk', 'High-risk isolated'))
+  if (parts.length === 0) parts.push(t('settings.workspaceProfiles.generalSandbox', 'General sandbox'))
+  return parts.join(' · ')
+}
+
+function WorkspaceProfileCard({ profile }: { profile: WorkspaceProfile }) {
+  const externalWriteCount = profile.authority.externalSystems.filter((system) => system.writeAllowed).length
+  const externalSummary = profile.authority.externalSystems.length === 0
+    ? t('settings.workspaceProfiles.noExternalSystems', 'No external systems')
+    : t('settings.workspaceProfiles.externalSystems', '{{count}} external systems · {{writes}} write-capable', {
+        count: String(profile.authority.externalSystems.length),
+        writes: String(externalWriteCount),
+      })
+  const filesystemRoots = profile.authority.filesystem.roots.length > 0
+    ? profile.authority.filesystem.roots.join(' · ')
+    : t('settings.workspaceProfiles.noFilesystemRoots', 'No filesystem roots')
+
+  return (
+    <div className="rounded-2xl border border-border-subtle bg-surface px-4 py-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[12px] font-semibold text-text">{profile.name}</div>
+          <div className="mt-1 text-[11px] text-text-muted leading-relaxed">{profile.description}</div>
+        </div>
+        <div className="rounded-full border border-border-subtle px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-text-muted">
+          {describeIsolation(profile)}
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <StorageStat label={t('settings.workspaceProfiles.filesystem', 'Filesystem')} value={describeFilesystemMode(profile.authority.filesystem.mode)} />
+        <StorageStat
+          label={t('settings.workspaceProfiles.writeAccess', 'Writes')}
+          value={profile.authority.filesystem.writeAllowed ? t('common.enabled', 'Enabled') : t('common.disabled', 'Disabled')}
+        />
+        <StorageStat
+          label={t('settings.workspaceProfiles.retention', 'Retention')}
+          value={t('settings.storage.retentionDays', '{{days}} days', { days: String(profile.authority.cleanup.retentionDays) })}
+        />
+        <StorageStat
+          label={t('settings.workspaceProfiles.cleanup', 'Cleanup')}
+          value={profile.authority.cleanup.deletesUnreferencedArtifacts ? t('settings.workspaceProfiles.autoPrune', 'Auto-prune') : t('settings.workspaceProfiles.keepArtifacts', 'Keep artifacts')}
+        />
+      </div>
+      <div className="mt-3 text-[11px] text-text-muted leading-relaxed">
+        {externalSummary}
+      </div>
+      <div className="mt-2 break-words text-[10px] text-text-muted leading-relaxed">
+        {filesystemRoots}
+      </div>
+    </div>
+  )
+}
+
 function reportStorageError(error: unknown, scope: string) {
   try {
     window.coworkApi?.diagnostics?.reportRendererError?.({
@@ -48,11 +119,13 @@ export function StoragePanel({
   stats,
   runningCleanup,
   lastCleanup,
+  workspaceProfiles,
   onCleanup,
 }: {
   stats: SandboxStorageStats | null
   runningCleanup: SandboxCleanupResult['mode'] | null
   lastCleanup: SandboxCleanupResult | null
+  workspaceProfiles: WorkspaceProfile[]
   onCleanup: (mode: SandboxCleanupResult['mode']) => Promise<void>
 }) {
   const [diagnosticsStatus, setDiagnosticsStatus] = useState<'idle' | 'working' | 'copied' | 'error'>('idle')
@@ -143,6 +216,19 @@ export function StoragePanel({
           {t('settings.storage.sandboxNote', 'Sandbox threads write into a private Cowork workspace under {{root}}. Older unreferenced workspaces are pruned automatically, and you can run cleanup manually here.', { root: stats.root })}
         </div>
       </div>
+
+      <span className={sectionLabelCls}>{t('settings.workspaceProfiles.header', 'Workspace Profiles')}</span>
+      {workspaceProfiles.length === 0 ? (
+        <div className={panelCardCls}>
+          <div className="text-[12px] text-text-muted">{t('settings.workspaceProfiles.empty', 'No workspace profiles are available yet.')}</div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3">
+          {workspaceProfiles.map((profile) => (
+            <WorkspaceProfileCard key={profile.id} profile={profile} />
+          ))}
+        </div>
+      )}
 
       <div className={panelCardCls}>
         <div className="text-[12px] font-semibold text-text">{t('settings.storage.cleanup', 'Cleanup')}</div>

--- a/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
+++ b/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import type {
   DashboardSummary,
   DashboardTimeRangeKey,
+  OperationalQueueAlert,
 } from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
 import { getModelContextLimit } from '../helpers/model-info'
@@ -18,6 +19,7 @@ export function usePulseDiagnostics() {
   const [dashboardRange, setDashboardRange] = useState<DashboardTimeRangeKey>(readStoredRange)
   const [dashboardSummary, setDashboardSummary] = useState<DashboardSummary | null>(null)
   const [dashboardError, setDashboardError] = useState<string | null>(null)
+  const [queueAlerts, setQueueAlerts] = useState<OperationalQueueAlert[]>([])
 
   // Persist filter selection so the user's "All time" pick survives a
   // relaunch. Session-independent; one preference per install.
@@ -52,6 +54,7 @@ export function usePulseDiagnostics() {
       perfResult,
       dashboardSummaryResult,
       runtimeInputsResult,
+      queueAlertsResult,
     ] = await Promise.allSettled([
       window.coworkApi.runtime.status(),
       window.coworkApi.settings.get(),
@@ -65,6 +68,7 @@ export function usePulseDiagnostics() {
       window.coworkApi.diagnostics.perf(),
       window.coworkApi.app.dashboardSummary(dashboardRange),
       window.coworkApi.app.runtimeInputs(),
+      window.coworkApi.operations.queueAlerts(),
     ])
 
     const settings = settingsResult.status === 'fulfilled' ? settingsResult.value : null
@@ -100,6 +104,7 @@ export function usePulseDiagnostics() {
       const reason = dashboardSummaryResult.reason
       setDashboardError(reason instanceof Error ? reason.message : t('homepage.warning.dashboardLoadFailed', 'Could not load dashboard totals.'))
     }
+    setQueueAlerts(queueAlertsResult.status === 'fulfilled' ? queueAlertsResult.value : [])
   }, [dashboardRange])
 
   useEffect(() => {
@@ -169,6 +174,7 @@ export function usePulseDiagnostics() {
     setDashboardRange,
     dashboardSummary,
     dashboardError,
+    queueAlerts,
     refreshDiagnostics,
   }
 }

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -217,6 +217,10 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       })),
       reportRendererError: vi.fn(),
     },
+    operations: {
+      workspaceProfiles: vi.fn(async () => []),
+      queueAlerts: vi.fn(async () => []),
+    },
     settings: {
       get: vi.fn(async () => createDefaultSettings()),
       getProviderCredentials: vi.fn(async (providerId: string) => createDefaultSettings().providerCredentials[providerId] || {}),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -112,6 +112,10 @@ import type {
   UpdateInstallEvent,
   UpdateInstallStatus,
 } from './updates.js'
+import type {
+  OperationalQueueAlert,
+  WorkspaceProfile,
+} from './operations.js'
 
 export * from './app-config.js'
 export * from './agent-validation.js'
@@ -285,6 +289,10 @@ export interface CoworkAPI {
       removedPaths: string[]
       failedPaths?: Array<{ label: string; path: string; error: string }>
     }>
+  }
+  operations: {
+    workspaceProfiles: () => Promise<WorkspaceProfile[]>
+    queueAlerts: () => Promise<OperationalQueueAlert[]>
   }
   updates: {
     installCapability: () => Promise<UpdateInstallCapability>

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -8,6 +8,7 @@ import { registerAutomationHandlers } from '../apps/desktop/src/main/ipc/automat
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCatalogHandlers } from '../apps/desktop/src/main/ipc/catalog-handlers.ts'
 import { registerCrewHandlers } from '../apps/desktop/src/main/ipc/crew-handlers.ts'
+import { registerOperationHandlers } from '../apps/desktop/src/main/ipc/operation-handlers.ts'
 import { registerSopHandlers } from '../apps/desktop/src/main/ipc/sop-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
@@ -73,6 +74,7 @@ test('IPC handler modules register their core channels', () => {
   registerArtifactHandlers(context)
   registerAutomationHandlers(context)
   registerCrewHandlers(context)
+  registerOperationHandlers(context)
   registerSopHandlers(context)
   registerSessionHandlers(context)
   registerCatalogHandlers(context)
@@ -115,6 +117,8 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('crews:run'), true)
   assert.equal(handlers.has('crews:evaluate'), true)
   assert.equal(handlers.has('crews:export-trace'), true)
+  assert.equal(handlers.has('operations:workspace-profiles'), true)
+  assert.equal(handlers.has('operations:queue-alerts'), true)
   assert.equal(handlers.has('sops:list'), true)
   assert.equal(handlers.has('sops:save-from-automation-run'), true)
   assert.equal(handlers.has('sops:run-now'), true)
@@ -132,6 +136,7 @@ test('preload invoke/send channels match registered main-process IPC channels', 
   registerArtifactHandlers(context)
   registerAutomationHandlers(context)
   registerCrewHandlers(context)
+  registerOperationHandlers(context)
   registerSopHandlers(context)
   registerSessionHandlers(context)
   registerCatalogHandlers(context)


### PR DESCRIPTION
## Summary
- add a typed operations IPC namespace for workspace profiles and operational queue alerts
- surface queue alerts in Pulse so stuck, blocked, or over-budget runs are visible
- show workspace profile authority, filesystem scope, and cleanup retention in Settings storage

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --dir apps/desktop test:renderer -- src/renderer/components/PulsePage.test.tsx src/renderer/components/sidebar/SettingsStoragePanel.test.tsx src/renderer/components/sidebar/SettingsPanel.test.tsx
- node --no-warnings --experimental-strip-types --test tests/ipc-handler-registration.test.ts
- git diff --check

Refs #248