### PR TITLE
[codex] wire crew runs into operations queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ release is planned for `v0.0.1`.
   improvement proposals, backed by typed IPC and durable store coverage.
 - Pulse operations visibility for durable queue items, run authority, queue
   alerts, and derived high-risk/write-capable capability metadata.
+- Crew runs now enter the durable operations queue before dispatching to
+  OpenCode, so conflicting write-capable crew work waits instead of starting
+  concurrently and queue authority/cost state stays visible in Pulse.
 - Custom MCP guide plus clearer docs for signed update QA, MCP private-network
   trust boundaries, dynamic model catalogs, and automation behavior.
 

--- a/apps/desktop/src/main/crew-operational-queue.ts
+++ b/apps/desktop/src/main/crew-operational-queue.ts
@@ -1,0 +1,109 @@
+import type {
+  AutonomyLevel,
+  CrewRunDetail,
+  CrewRunStatus,
+  OperationalQueueItem,
+} from '@open-cowork/shared'
+import {
+  blockOperationalQueueItem,
+  enqueueOperationalRun,
+  finishOperationalQueueItem,
+  getOperationalQueueItemForRun,
+  getWorkspaceProfile,
+  listOperationalQueueItems,
+  recordOperationalQueueItemCost,
+  startOperationalQueueItem,
+} from './operational-queue-store.ts'
+import { listCoworkTraceEventsForRun } from './crew-store.ts'
+
+const DEFAULT_CREW_WORKSPACE_PROFILE_ID = 'personal-sandbox'
+const DEFAULT_CREW_AUTONOMY: AutonomyLevel = 'supervised'
+
+function resolveCrewWorkspaceProfileId(requestedId: string | null | undefined) {
+  if (requestedId && getWorkspaceProfile(requestedId)) return requestedId
+  return DEFAULT_CREW_WORKSPACE_PROFILE_ID
+}
+
+function crewQueueCostUsd(runId: string) {
+  return listCoworkTraceEventsForRun(runId).reduce((total, event) => {
+    const cost = typeof event.costUsd === 'number' && Number.isFinite(event.costUsd) ? event.costUsd : 0
+    return total + cost
+  }, 0)
+}
+
+function terminalOperationalStatus(status: CrewRunStatus): Exclude<OperationalQueueItem['status'], 'queued' | 'running' | 'blocked'> | null {
+  if (status === 'completed') return 'completed'
+  if (status === 'failed') return 'failed'
+  if (status === 'cancelled') return 'cancelled'
+  return null
+}
+
+export function enqueueCrewOperationalQueueItem(detail: CrewRunDetail) {
+  const workspaceProfileId = resolveCrewWorkspaceProfileId(detail.version.workspaceProfileId)
+  const profile = getWorkspaceProfile(workspaceProfileId)
+  const lead = detail.version.members.find((member) => member.role === 'lead')
+  const externalSystemIds = profile?.authority.externalSystems
+    .filter((system) => system.writeAllowed)
+    .map((system) => system.id) || []
+  const writeCapable = Boolean(
+    profile?.authority.filesystem.writeAllowed
+      || externalSystemIds.length > 0,
+  )
+  return enqueueOperationalRun({
+    runKind: 'crew',
+    runId: detail.run.id,
+    title: detail.run.title,
+    requestedAutonomy: DEFAULT_CREW_AUTONOMY,
+    globalMaxAutonomy: DEFAULT_CREW_AUTONOMY,
+    workspaceProfileId,
+    agentName: lead?.agentName || null,
+    crewId: detail.crew.id,
+    externalSystemIds,
+    writeCapable,
+    caps: {
+      maxParallel: 1,
+      maxRunDurationMinutes: 60,
+      maxCostUsd: detail.version.budgetCapUsd,
+      maxRetries: 0,
+    },
+  })
+}
+
+export function getCrewOperationalQueueItem(runId: string) {
+  return getOperationalQueueItemForRun('crew', runId)
+}
+
+export function listQueuedCrewOperationalQueueItems() {
+  return listOperationalQueueItems().filter((item) => item.runKind === 'crew' && item.status === 'queued')
+}
+
+export function startCrewOperationalQueueItem(runId: string) {
+  const item = getCrewOperationalQueueItem(runId)
+  if (!item) return null
+  return startOperationalQueueItem(item.id)
+}
+
+export function recordCrewOperationalQueueCost(runId: string) {
+  const item = getCrewOperationalQueueItem(runId)
+  if (!item || item.status !== 'running') return item
+  return recordOperationalQueueItemCost(item.id, crewQueueCostUsd(runId))
+}
+
+export function syncCrewOperationalQueueStatus(runId: string, status: CrewRunStatus, summary?: string | null) {
+  const item = getCrewOperationalQueueItem(runId)
+  if (!item) return null
+  if (item.status === 'running') {
+    recordOperationalQueueItemCost(item.id, crewQueueCostUsd(runId))
+  }
+  const terminal = terminalOperationalStatus(status)
+  if (terminal) {
+    return finishOperationalQueueItem(item.id, terminal, {
+      costUsd: crewQueueCostUsd(runId),
+      error: terminal === 'failed' || terminal === 'cancelled' ? summary : null,
+    })
+  }
+  if (status === 'blocked') {
+    return blockOperationalQueueItem(item.id, summary || 'Crew run is blocked and requires attention.')
+  }
+  return getCrewOperationalQueueItem(runId)
+}

--- a/apps/desktop/src/main/crew-runtime-projector.ts
+++ b/apps/desktop/src/main/crew-runtime-projector.ts
@@ -23,6 +23,13 @@ import {
   updateCrewRunNodeRuntimeState,
   updateCrewRunStatus,
 } from './crew-store.ts'
+import {
+  recordCrewOperationalQueueCost,
+  syncCrewOperationalQueueStatus,
+} from './crew-operational-queue.ts'
+import { dispatchRunnableCrewQueueItems } from './crew-service.ts'
+import { createOpenCodeCrewRuntimeDriver } from './crew-runtime-execution.ts'
+import { log } from './logger.ts'
 
 const MAX_TRACE_TEXT_BYTES = 4096
 
@@ -398,6 +405,7 @@ function projectCost(run: CrewRun, data: RuntimeEventData) {
       sourceSessionId: typeof data.sourceSessionId === 'string' ? data.sourceSessionId : null,
     },
   })
+  recordCrewOperationalQueueCost(run.id)
 }
 
 function projectDone(run: CrewRun, data: RuntimeEventData) {
@@ -442,6 +450,7 @@ function projectDone(run: CrewRun, data: RuntimeEventData) {
     updateCrewRunNodeRuntimeState(node.id, { status: unobservedAgentNode ? 'skipped' : 'completed' })
   }
   updateCrewRunStatus(run.id, 'completed')
+  syncCrewOperationalQueueStatus(run.id, 'completed')
   traceBase({
     run,
     id: traceId([run.id, 'done', run.rootSessionId || run.id]),
@@ -461,6 +470,12 @@ function projectError(run: CrewRun, data: RuntimeEventData) {
   const sourceSessionId = typeof data.sourceSessionId === 'string' && data.sourceSessionId ? data.sourceSessionId : null
   const branchError = Boolean(data.taskRunId) || Boolean(sourceSessionId && sourceSessionId !== run.rootSessionId)
   updateCrewRunStatus(run.id, branchError ? 'blocked' : 'failed', { summary: message })
+  syncCrewOperationalQueueStatus(run.id, branchError ? 'blocked' : 'failed', message)
+  if (!branchError) {
+    void dispatchRunnableCrewQueueItems(createOpenCodeCrewRuntimeDriver()).catch((error) => {
+      log('crew', `Could not dispatch queued crew runs after runtime failure: ${error instanceof Error ? error.message : String(error)}`)
+    })
+  }
   traceBase({
     run,
     id: traceId([run.id, 'error', typeof data.taskRunId === 'string' ? data.taskRunId : run.rootSessionId || run.id]),

--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -58,6 +58,12 @@ import {
   type CrewOutcomeEvaluationResult,
 } from './crew-evaluation-contract.ts'
 import { recordCrewEvaluationRemediation } from './crew-evaluation-remediation.ts'
+import {
+  enqueueCrewOperationalQueueItem,
+  listQueuedCrewOperationalQueueItems,
+  startCrewOperationalQueueItem,
+  syncCrewOperationalQueueStatus,
+} from './crew-operational-queue.ts'
 import type { CrewRuntimeExecutionDriver } from './crew-runtime-execution.ts'
 
 const MAX_CREW_MEMBERS = 25
@@ -314,6 +320,27 @@ function requireCreated<T>(value: T | null, label: string): T {
   return value
 }
 
+function appendOperationalQueueTrace(input: {
+  runId: string
+  crewId: string
+  queueItemId: string
+  queueKeys: string[]
+  effectiveAutonomy: string
+  waiting: boolean
+}) {
+  appendRunTrace({
+    runId: input.runId,
+    sequence: nextTraceSequence(input.runId),
+    actorId: input.crewId,
+    payload: {
+      type: input.waiting ? 'crew_run.operational_queue_waiting' : 'crew_run.operational_queue_started',
+      queueItemId: input.queueItemId,
+      queueKeys: input.queueKeys,
+      effectiveAutonomy: input.effectiveAutonomy,
+    },
+  })
+}
+
 function buildCrewLeadPrompt(detail: CrewRunDetail) {
   const lead = detail.version.members.find((member) => member.role === 'lead')
   const specialists = detail.version.members.filter((member) => member.role === 'specialist')
@@ -504,6 +531,7 @@ export async function executeCrewRunWithOpenCode(
         message,
       },
     })
+    syncCrewOperationalQueueStatus(runId, 'failed', `Crew execution failed: ${message}`)
   }
 
   const updated = getCrewRunDetail(runId)
@@ -511,12 +539,67 @@ export async function executeCrewRunWithOpenCode(
   return updated
 }
 
+export async function dispatchRunnableCrewQueueItems(
+  driver: CrewRuntimeExecutionDriver,
+  limit = 5,
+): Promise<CrewRunDetail[]> {
+  const dispatched: CrewRunDetail[] = []
+  for (const item of listQueuedCrewOperationalQueueItems()) {
+    if (dispatched.length >= limit) break
+    const detail = getCrewRunDetail(item.runId)
+    if (!detail) {
+      syncCrewOperationalQueueStatus(item.runId, 'cancelled', 'Crew run no longer exists.')
+      continue
+    }
+    const started = startCrewOperationalQueueItem(item.runId)
+    if (started?.status !== 'running') continue
+    appendOperationalQueueTrace({
+      runId: detail.run.id,
+      crewId: detail.crew.id,
+      queueItemId: started.id,
+      queueKeys: started.queueKeys,
+      effectiveAutonomy: started.effectiveAutonomy,
+      waiting: false,
+    })
+    dispatched.push(await executeCrewRunWithOpenCode(item.runId, driver))
+  }
+  return dispatched
+}
+
 export async function startCrewRunWithOpenCode(
   draft: CrewRunDraft,
   driver: CrewRuntimeExecutionDriver,
 ): Promise<CrewRunDetail> {
-  const runDetail = startCrewRun(draft)
-  return executeCrewRunWithOpenCode(runDetail.run.id, driver)
+  const runDetail = startCrewRun(draft, { initialStatus: 'queued' })
+  const queueItem = enqueueCrewOperationalQueueItem(runDetail)
+  const started = startCrewOperationalQueueItem(runDetail.run.id)
+  if (started?.status !== 'running') {
+    updateCrewRunStatus(runDetail.run.id, 'queued', { summary: 'Waiting for operations queue capacity.' })
+    appendOperationalQueueTrace({
+      runId: runDetail.run.id,
+      crewId: runDetail.crew.id,
+      queueItemId: queueItem.id,
+      queueKeys: queueItem.queueKeys,
+      effectiveAutonomy: queueItem.effectiveAutonomy,
+      waiting: true,
+    })
+    const queued = getCrewRunDetail(runDetail.run.id)
+    if (!queued) throw new Error(`Crew run ${runDetail.run.id} disappeared after queueing.`)
+    return queued
+  }
+  appendOperationalQueueTrace({
+    runId: runDetail.run.id,
+    crewId: runDetail.crew.id,
+    queueItemId: started.id,
+    queueKeys: started.queueKeys,
+    effectiveAutonomy: started.effectiveAutonomy,
+    waiting: false,
+  })
+  const dispatched = await executeCrewRunWithOpenCode(runDetail.run.id, driver)
+  if (dispatched.run.status === 'completed' || dispatched.run.status === 'failed' || dispatched.run.status === 'cancelled') {
+    await dispatchRunnableCrewQueueItems(driver)
+  }
+  return dispatched
 }
 
 export async function evaluateCrewRunWithOpenCode(
@@ -571,7 +654,7 @@ export async function evaluateCrewRunWithOpenCode(
       }
 
       const evidence = normalizeEvaluatorEvidence(detail, parsed)
-      return recordCrewOutcomeEvaluation({
+      const updated = recordCrewOutcomeEvaluation({
         runId,
         evaluatorAgentName: evaluator.agentName,
         status: parsed.status,
@@ -582,10 +665,15 @@ export async function evaluateCrewRunWithOpenCode(
         sessionId,
         discardedEvidenceTraceEventIds: evidence.discardedEvidenceTraceEventIds,
       })
+      if (updated.run.status === 'completed' || updated.run.status === 'failed' || updated.run.status === 'cancelled') {
+        await dispatchRunnableCrewQueueItems(driver)
+      }
+      return updated
     } catch (error) {
       const message = safeErrorMessage(error)
       updateCrewRunNodeStatus(evaluateNode.id, 'failed', { sessionId })
       updateCrewRunStatus(runId, 'blocked', { summary: `Crew evaluation failed: ${message}` })
+      syncCrewOperationalQueueStatus(runId, 'blocked', `Crew evaluation failed: ${message}`)
       appendRunTrace({
         runId,
         sequence,
@@ -635,7 +723,7 @@ export function recordCrewOutcomeEvaluation(input: {
   sessionId?: string | null
   discardedEvidenceTraceEventIds?: string[]
 }): CrewRunDetail {
-  return withCrewTransaction(() => {
+  const updated = withCrewTransaction(() => {
     const detail = getCrewRunDetail(input.runId)
     if (!detail) throw new Error(`Crew run ${input.runId} does not exist.`)
     const evaluator = detail.version.members.find((member) => member.role === 'evaluator')
@@ -729,13 +817,18 @@ export function recordCrewOutcomeEvaluation(input: {
       sequence,
     })
 
-    const updated = getCrewRunDetail(detail.run.id)
-    if (!updated) throw new Error(`Crew run ${detail.run.id} disappeared after recording evaluation.`)
-    return updated
+    const nextDetail = getCrewRunDetail(detail.run.id)
+    if (!nextDetail) throw new Error(`Crew run ${detail.run.id} disappeared after recording evaluation.`)
+    return nextDetail
   })
+  syncCrewOperationalQueueStatus(updated.run.id, updated.run.status, updated.run.summary)
+  return updated
 }
 
-export function startCrewRun(draft: CrewRunDraft): CrewRunDetail {
+export function startCrewRun(
+  draft: CrewRunDraft,
+  options: { initialStatus?: 'queued' | 'planning' } = {},
+): CrewRunDetail {
   const crewId = boundedString(draft.crewId, 'Crew id')
   const title = boundedString(draft.title, 'Crew run title')
   const detail = getCrewDetail(crewId)
@@ -800,7 +893,8 @@ export function startCrewRun(draft: CrewRunDraft): CrewRunDetail {
       parentNodeId: evaluate.id,
     }), 'crew deliver node')
 
-    const updatedRun = updateCrewRunStatus(run.id, 'planning')
+    const initialStatus = options.initialStatus || 'planning'
+    const updatedRun = initialStatus === 'planning' ? updateCrewRunStatus(run.id, 'planning') : run
     appendRunTrace({
       runId: run.id,
       sequence: sequence++,

--- a/apps/desktop/src/main/operational-queue-store.ts
+++ b/apps/desktop/src/main/operational-queue-store.ts
@@ -439,6 +439,13 @@ export function getOperationalQueueItem(id: string) {
   return row ? rowToQueueItem(row) : null
 }
 
+export function getOperationalQueueItemForRun(runKind: OperationalQueueItem['runKind'], runId: string) {
+  if (!RUN_KINDS.has(runKind)) throw new Error(`Operational run kind ${runKind} is not supported.`)
+  const row = getOperationalQueueDb().prepare('select * from operational_queue_items where run_kind = ? and run_id = ?')
+    .get(runKind, boundedText(runId, 'Operational run id', 512)) as DbRow | undefined
+  return row ? rowToQueueItem(row) : null
+}
+
 export function listOperationalQueueItems() {
   const rows = getOperationalQueueDb().prepare('select * from operational_queue_items order by created_at asc, rowid asc').all() as DbRow[]
   return rows.map(rowToQueueItem)
@@ -455,11 +462,37 @@ function hasQueueCapacity(active: OperationalQueueItem[], item: OperationalQueue
   return true
 }
 
+function queueItemsConflict(left: OperationalQueueItem, right: OperationalQueueItem) {
+  if (left.queueKeys.length === 0 || right.queueKeys.length === 0) return false
+  return left.queueKeys.some((key) => right.queueKeys.includes(key))
+}
+
+export function startOperationalQueueItem(id: string) {
+  return withOperationalTransaction(() => {
+    const ordered = listOperationalQueueItems()
+    const itemIndex = ordered.findIndex((item) => item.id === id)
+    const item = itemIndex >= 0 ? ordered[itemIndex] : null
+    if (!item || item.status !== 'queued') return item
+    const active = ordered.filter((candidate) => candidate.status === 'running' || candidate.status === 'blocked')
+    const earlierQueuedConflict = ordered
+      .slice(0, itemIndex)
+      .some((candidate) => candidate.status === 'queued' && queueItemsConflict(candidate, item))
+    if (earlierQueuedConflict || !hasQueueCapacity(active, item)) return item
+    const now = nowIso()
+    getOperationalQueueDb().prepare(`
+      update operational_queue_items
+      set status = ?, started_at = coalesce(started_at, ?), updated_at = ?, attempt = attempt + 1
+      where id = ? and status = ?
+    `).run('running', now, now, item.id, 'queued')
+    return getOperationalQueueItem(item.id)
+  })
+}
+
 export function startRunnableOperationalQueueItems(limit = 100) {
   return withOperationalTransaction(() => {
     const startLimit = boundedInteger(limit, 100, 1, 1000)
     const started: OperationalQueueItem[] = []
-    const running = listOperationalQueueItems().filter((item) => item.status === 'running')
+    const running = listOperationalQueueItems().filter((item) => item.status === 'running' || item.status === 'blocked')
     const active = [...running]
     const queued = listOperationalQueueItems().filter((item) => item.status === 'queued')
     const now = nowIso()
@@ -524,8 +557,8 @@ export function finishOperationalQueueItem(id: string, status: Exclude<Operation
   getOperationalQueueDb().prepare(`
     update operational_queue_items
     set status = ?, finished_at = ?, updated_at = ?, error = ?, cost_usd = coalesce(?, cost_usd)
-    where id = ? and status = ?
-  `).run(status, now, now, optionalBoundedText(options.error, 'Operational queue error', 4096), costUsd, id, 'running')
+    where id = ? and status in ('queued', 'running', 'blocked')
+  `).run(status, now, now, optionalBoundedText(options.error, 'Operational queue error', 4096), costUsd, id)
   return getOperationalQueueItem(id)
 }
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -2,11 +2,12 @@
 
 ## Main sections
 
-The desktop app is centered around seven areas:
+The desktop app is centered around eight areas:
 - `Home` — welcoming landing surface
 - `Chat` — where OpenCode sessions run
 - `Threads` — searchable history, metadata facets, user tags, and saved filters
 - `Automations` — the durable schedule / inbox / run control plane
+- `Crews` — supervised multi-agent runs with trace, queue, and eval visibility
 - `Agents` — manage built-in and custom agents
 - `Capabilities` — browse tools, skills, and MCPs
 - `Pulse` — diagnostic workspace dashboard
@@ -17,6 +18,7 @@ flowchart TD
     Chat["Chat<br/>session UI · streamed events · approvals"]
     Threads["Threads<br/>search · facets · tags · filters"]
     Auto["Automations<br/>list · inbox · work items · runs · deliveries"]
+    Crews["Crews<br/>lead · specialists · evaluator · queue"]
     Agents["Agents<br/>built-in + custom"]
     Caps["Capabilities<br/>tools · skills · MCPs"]
     Pulse["Pulse<br/>runtime · usage · perf · inventory"]
@@ -29,6 +31,7 @@ flowchart TD
     Chat -->|@agent| Agents
     Chat -->|tool calls| Caps
     Auto -->|run links| Chat
+    Crews -->|root sessions| Chat
     Pulse -->|capability counts| Caps
     Pulse -->|agent inventory| Agents
     Pulse -.linked from sidebar.-> Settings
@@ -36,7 +39,7 @@ flowchart TD
 
 Home is the landing surface; submitting a prompt routes to Chat in one
 motion. Threads is the full-history workspace for search, facets, tags,
-and saved filters. Pulse, Capabilities, Agents, and Automations each present a
+and saved filters. Pulse, Capabilities, Agents, Crews, and Automations each present a
 dedicated operational surface; Settings holds appearance, models,
 permissions, and storage.
 
@@ -136,6 +139,25 @@ Once an automation exists it gets a dedicated detail surface for
 brief, run timeline, reliability, and run policy:
 
 ![Automation detail with execution brief, run timeline, reliability, and run policy panels](assets/auto/automations-detail.png)
+
+## Crews
+
+Crews are supervised multi-agent product runs. A crew version defines a lead,
+specialists, an evaluator, a workspace profile, and an optional budget cap.
+When a crew run starts, Open Cowork records the durable product run, enters it
+into the operations queue, and only then dispatches the lead through OpenCode.
+
+That queue integration keeps the runtime boundary intact:
+- OpenCode still owns sessions, task delegation, tools, questions, approvals,
+  and streamed events.
+- Open Cowork owns run metadata, queue state, authority visibility, trace
+  records, evaluator handoff, and cost/budget diagnostics.
+
+Write-capable crew runs targeting the same crew, lead-agent, or external-system authority wait in
+the durable queue instead of dispatching concurrently. When an evaluator passes
+a run, the queue item is completed and the next compatible queued crew can
+dispatch. Pulse shows the queue item, effective autonomy, filesystem/external
+authority, duration/cost caps, and any stuck or blocked alerts.
 
 ## Project vs sandbox threads
 

--- a/tests/crew-runtime-projector.test.ts
+++ b/tests/crew-runtime-projector.test.ts
@@ -16,7 +16,9 @@ import {
   updateCrewRunStatus,
 } from '../apps/desktop/src/main/crew-store.ts'
 import { projectCrewRuntimeEvent } from '../apps/desktop/src/main/crew-runtime-projector.ts'
-import { createCrewFromDraft, recordCrewOutcomeEvaluation, startCrewRun } from '../apps/desktop/src/main/crew-service.ts'
+import { createCrewFromDraft, recordCrewOutcomeEvaluation, startCrewRun, startCrewRunWithOpenCode } from '../apps/desktop/src/main/crew-service.ts'
+import type { CrewRuntimeExecutionDriver } from '../apps/desktop/src/main/crew-runtime-execution.ts'
+import { clearOperationalQueueStoreCache, getOperationalQueueItemForRun } from '../apps/desktop/src/main/operational-queue-store.ts'
 
 function uniqueUserDataDir(name: string) {
   return mkdtempSync(join(tmpdir(), `open-cowork-crew-projector-${name}-`))
@@ -26,6 +28,7 @@ function resetCrewStore(userDataDir: string) {
   process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
   clearConfigCaches()
   clearCrewStoreCache()
+  clearOperationalQueueStoreCache()
 }
 
 function withCrewStore<T>(name: string, callback: () => T): T {
@@ -36,6 +39,7 @@ function withCrewStore<T>(name: string, callback: () => T): T {
     return callback()
   } finally {
     clearCrewStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -43,7 +47,23 @@ function withCrewStore<T>(name: string, callback: () => T): T {
   }
 }
 
-function draft(): CrewDefinitionDraft {
+async function withCrewStoreAsync<T>(name: string, callback: () => Promise<T>): Promise<T> {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    resetCrewStore(userDataDir)
+    return await callback()
+  } finally {
+    clearCrewStoreCache()
+    clearOperationalQueueStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+function draft(overrides: Partial<CrewDefinitionDraft> = {}): CrewDefinitionDraft {
   return {
     name: 'Research Crew',
     description: 'Lead, specialists, and evaluator.',
@@ -55,6 +75,7 @@ function draft(): CrewDefinitionDraft {
     ],
     workspaceProfileId: 'workspace-default',
     budgetCapUsd: 4,
+    ...overrides,
   }
 }
 
@@ -443,3 +464,43 @@ test('crew runtime projector treats child-session errors as blockers instead of 
 
   assert.equal(getCrewRun(runId)?.status, 'blocked')
 }))
+
+test('crew runtime projector drains queued crew work after root runtime failures', async () => {
+  await withCrewStoreAsync('root-error-drain', async () => {
+    const crew = createCrewFromDraft(draft({ workspaceProfileId: 'project-workspace' }))
+    let createRootCalls = 0
+    const driver: CrewRuntimeExecutionDriver = {
+      async createRootSession() {
+        createRootCalls += 1
+        return { id: `root-session-${createRootCalls}` }
+      },
+      async prompt() {},
+      async evaluateOutcome() {
+        throw new Error('not used')
+      },
+    }
+
+    const first = await startCrewRunWithOpenCode({
+      crewId: crew.definition.id,
+      title: 'Run that will fail',
+    }, driver)
+    const second = await startCrewRunWithOpenCode({
+      crewId: crew.definition.id,
+      title: 'Queued behind failure',
+    }, driver)
+    assert.equal(first.run.status, 'running')
+    assert.equal(second.run.status, 'queued')
+
+    projectCrewRuntimeEvent({
+      type: 'error',
+      sessionId: first.run.rootSessionId || '',
+      data: { type: 'error', message: 'root session failed' },
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(getCrewRun(first.run.id)?.status, 'failed')
+    assert.equal(getOperationalQueueItemForRun('crew', first.run.id)?.status, 'failed')
+    assert.equal(getCrewRun(second.run.id)?.status, 'failed')
+    assert.equal(getOperationalQueueItemForRun('crew', second.run.id)?.status, 'failed')
+  })
+})

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -15,6 +15,10 @@ import {
   recordOutcomeEvaluation,
 } from '../apps/desktop/src/main/crew-store.ts'
 import {
+  clearOperationalQueueStoreCache,
+  getOperationalQueueItemForRun,
+} from '../apps/desktop/src/main/operational-queue-store.ts'
+import {
   createCrewFromDraft,
   certifyCrewVersion,
   evaluateCrewRunForRootSessionIdle,
@@ -41,6 +45,7 @@ function resetCrewStore(userDataDir: string) {
   process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
   clearConfigCaches()
   clearCrewStoreCache()
+  clearOperationalQueueStoreCache()
 }
 
 function draft(overrides: Partial<CrewDefinitionDraft> = {}): CrewDefinitionDraft {
@@ -96,6 +101,7 @@ function withCrewStore<T>(name: string, callback: () => T): T {
     return callback()
   } finally {
     clearCrewStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -111,6 +117,7 @@ async function withCrewStoreAsync<T>(name: string, callback: () => Promise<T>): 
     return await callback()
   } finally {
     clearCrewStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -451,7 +458,7 @@ test('crew service escalates to a human after the bounded revision budget is exh
 
 test('crew service dispatches the lead run through an OpenCode execution driver', async () => {
   await withCrewStoreAsync('execute', async () => {
-    const crew = createCrewFromDraft(draft())
+    const crew = createCrewFromDraft(draft({ workspaceProfileId: 'project-workspace' }))
     const prompts: Array<{ sessionId: string; agentName: string; prompt: string }> = []
     const runDetail = await startCrewRunWithOpenCode({
       crewId: crew.definition.id,
@@ -473,8 +480,14 @@ test('crew service dispatches the lead run through an OpenCode execution driver'
     })
 
     const planNode = runDetail.nodes.find((node) => node.kind === 'plan')
+    const queueItem = getOperationalQueueItemForRun('crew', runDetail.run.id)
     assert.equal(runDetail.run.status, 'running')
     assert.equal(runDetail.run.rootSessionId, 'root-session-1')
+    assert.equal(queueItem?.status, 'running')
+    assert.equal(queueItem?.runKind, 'crew')
+    assert.equal(queueItem?.workspaceProfileId, 'project-workspace')
+    assert.equal(queueItem?.caps.maxCostUsd, 4)
+    assert.deepEqual(queueItem?.queueKeys.includes(`crew:${crew.definition.id}`), true)
     assert.equal(planNode?.status, 'running')
     assert.equal(planNode?.sessionId, 'root-session-1')
     assert.equal(prompts.length, 1)
@@ -489,7 +502,71 @@ test('crew service dispatches the lead run through an OpenCode execution driver'
       'crew_run.session_created',
       'crew_run.prompt_submitted',
     ])
+    assert.equal(runDetail.traceEvents.some((event) => event.payload?.type === 'crew_run.operational_queue_started'), true)
     assert.equal(runDetail.traceEvents.at(-1)?.inputHash?.startsWith('sha256:'), true)
+
+    const completed = recordCrewOutcomeEvaluation({
+      runId: runDetail.run.id,
+      status: 'passed',
+      score: 91,
+      evidenceTraceEventIds: [runDetail.traceEvents[0]!.id],
+      recommendation: 'deliver',
+    })
+    assert.equal(completed.run.status, 'completed')
+    assert.equal(getOperationalQueueItemForRun('crew', runDetail.run.id)?.status, 'completed')
+  })
+})
+
+test('crew service leaves conflicting write-capable runs queued instead of dispatching them concurrently', async () => {
+  await withCrewStoreAsync('queue-conflict', async () => {
+    const crew = createCrewFromDraft(draft({ workspaceProfileId: 'project-workspace' }))
+    let createRootCalls = 0
+    let firstEvidenceTraceId = ''
+    const driver: CrewRuntimeExecutionDriver = {
+      async createRootSession() {
+        createRootCalls += 1
+        return { id: `root-session-${createRootCalls}` }
+      },
+      async prompt() {},
+      async evaluateOutcome() {
+        return {
+          sessionId: 'evaluator-session-queue',
+          text: '',
+          structured: {
+            type: 'open_cowork.crew_outcome_evaluation',
+            version: 1,
+            status: 'passed',
+            score: 90,
+            recommendation: 'deliver',
+            summary: 'Ready to unblock queued work.',
+            evidenceTraceEventIds: [firstEvidenceTraceId],
+          },
+        }
+      },
+    }
+
+    const first = await startCrewRunWithOpenCode({
+      crewId: crew.definition.id,
+      title: 'Analyze market A',
+    }, driver)
+    const second = await startCrewRunWithOpenCode({
+      crewId: crew.definition.id,
+      title: 'Analyze market B',
+    }, driver)
+    firstEvidenceTraceId = first.traceEvents[0]!.id
+
+    assert.equal(createRootCalls, 1)
+    assert.equal(first.run.status, 'running')
+    assert.equal(second.run.status, 'queued')
+    assert.equal(getOperationalQueueItemForRun('crew', first.run.id)?.status, 'running')
+    assert.equal(getOperationalQueueItemForRun('crew', second.run.id)?.status, 'queued')
+    assert.equal(second.traceEvents.at(-1)?.payload?.type, 'crew_run.operational_queue_waiting')
+
+    await evaluateCrewRunWithOpenCode(first.run.id, driver)
+    assert.equal(createRootCalls, 2)
+    assert.equal(getOperationalQueueItemForRun('crew', first.run.id)?.status, 'completed')
+    assert.equal(getOperationalQueueItemForRun('crew', second.run.id)?.status, 'running')
+    assert.equal(getCrewRunDetail(second.run.id)?.run.status, 'running')
   })
 })
 
@@ -513,8 +590,10 @@ test('crew service records execution dispatch failures in the durable run', asyn
     })
 
     const planNode = failed.nodes.find((node) => node.kind === 'plan')
+    const queueItem = getOperationalQueueItemForRun('crew', initial.run.id)
     assert.equal(failed.run.status, 'failed')
     assert.equal(failed.run.rootSessionId, 'root-session-2')
+    assert.equal(queueItem, null)
     assert.match(failed.run.summary || '', /provider unavailable/)
     assert.equal(planNode?.status, 'failed')
     assert.equal(planNode?.sessionId, 'root-session-2')

--- a/tests/operational-queue-store.test.ts
+++ b/tests/operational-queue-store.test.ts
@@ -19,6 +19,7 @@ import {
   recordOperationalQueueItemCost,
   resolveEffectiveAutonomy,
   retryOperationalQueueItem,
+  startOperationalQueueItem,
   startRunnableOperationalQueueItems,
 } from '../apps/desktop/src/main/operational-queue-store.ts'
 
@@ -144,6 +145,56 @@ test('operational queues honor explicit parallelism caps for shared write target
 
   assert.deepEqual(startRunnableOperationalQueueItems().map((item) => item.id), [first.id, second.id])
   assert.equal(getOperationalQueueItem(third.id)?.status, 'queued')
+}))
+
+test('starting one operational item does not accidentally claim unrelated queued runs', () => withOperationalStore('start-one', () => {
+  const first = enqueueOperationalRun({
+    runKind: 'crew',
+    runId: 'crew-specific-1',
+    title: 'Specific crew run',
+    requestedAutonomy: 'supervised',
+    workspaceProfileId: 'project-workspace',
+    crewId: 'crew-specific',
+    writeCapable: true,
+  })
+  const second = enqueueOperationalRun({
+    runKind: 'crew',
+    runId: 'crew-specific-2',
+    title: 'Second crew run',
+    requestedAutonomy: 'supervised',
+    workspaceProfileId: 'project-workspace',
+    crewId: 'crew-other',
+    writeCapable: true,
+  })
+
+  assert.equal(startOperationalQueueItem(second.id)?.status, 'running')
+  assert.equal(getOperationalQueueItem(first.id)?.status, 'queued')
+  assert.equal(getOperationalQueueItem(second.id)?.status, 'running')
+}))
+
+test('blocked operational items keep their queue keys occupied until resolved', () => withOperationalStore('blocked-occupies', () => {
+  const first = enqueueOperationalRun({
+    runKind: 'crew',
+    runId: 'crew-blocked-1',
+    title: 'Blocked crew run',
+    requestedAutonomy: 'supervised',
+    workspaceProfileId: 'project-workspace',
+    crewId: 'crew-blocked',
+    writeCapable: true,
+  })
+  const second = enqueueOperationalRun({
+    runKind: 'crew',
+    runId: 'crew-blocked-2',
+    title: 'Next crew run',
+    requestedAutonomy: 'supervised',
+    workspaceProfileId: 'project-workspace',
+    crewId: 'crew-blocked',
+    writeCapable: true,
+  })
+
+  assert.equal(startOperationalQueueItem(first.id)?.status, 'running')
+  assert.equal(blockOperationalQueueItem(first.id, 'Waiting for approval.')?.status, 'blocked')
+  assert.equal(startOperationalQueueItem(second.id)?.status, 'queued')
 }))
 
 test('operational queue state survives store reopen', () => withOperationalStore('survives-restart', () => {


### PR DESCRIPTION
## Summary
- enqueue crew runs into the durable operations queue before dispatching the lead OpenCode session
- keep conflicting write-capable crew runs queued, keep blocked items occupying queue keys, and drain compatible queued crew work after evaluator completion
- sync crew queue cost/status from crew runtime projection and outcome evaluation
- document the crew queue behavior and add focused queue/crew tests

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/operational-queue-store.test.ts tests/crew-service.test.ts tests/crew-runtime-projector.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm build
- uv run mkdocs build --strict
- git diff --check

Closes part of #248.