### PR TITLE
[codex] queue automation runs before dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ release is planned for `v0.0.1`.
 - Crew runs now enter the durable operations queue before dispatching to
   OpenCode, so conflicting write-capable crew work waits instead of starting
   concurrently and queue authority/cost state stays visible in Pulse.
+- Automation and SOP-backed execution runs now enter the durable operations
+  queue before OpenCode dispatch, so project-scoped write runs wait on the
+  same target authority while planning/heartbeat work can continue to fan out.
 - Custom MCP guide plus clearer docs for signed update QA, MCP private-network
   trust boundaries, dynamic model catalogs, and automation behavior.
 

--- a/apps/desktop/src/main/automation-cancellation.ts
+++ b/apps/desktop/src/main/automation-cancellation.ts
@@ -1,4 +1,5 @@
 import { getRun, markRunCancelled } from './automation-store.ts'
+import { syncAutomationOperationalQueueStatus } from './automation-operational-queue.ts'
 import { log } from './logger.ts'
 import { getClientForDirectory } from './runtime.ts'
 import { ensureRuntimeContextDirectory } from './runtime-context.ts'
@@ -9,10 +10,16 @@ export async function cancelAutomationRunWithContext(
   publishAutomationUpdated: () => void,
 ) {
   const run = getRun(runId)
-  if (!run || !run.sessionId || run.status !== 'running') return false
+  if (!run) return false
+  if (run.status === 'queued') {
+    syncAutomationOperationalQueueStatus(markRunCancelled(runId, 'Queued automation run cancelled.'), 'Queued automation run cancelled.')
+    publishAutomationUpdated()
+    return true
+  }
+  if (!run.sessionId || run.status !== 'running') return false
   const record = getSessionRecord(run.sessionId)
   if (!record) {
-    markRunCancelled(runId, 'Automation run cancelled.')
+    syncAutomationOperationalQueueStatus(markRunCancelled(runId, 'Automation run cancelled.'), 'Automation run cancelled.')
     publishAutomationUpdated()
     return true
   }
@@ -23,7 +30,7 @@ export async function cancelAutomationRunWithContext(
   } catch (error) {
     log('error', `Failed to abort automation run ${run.id}: ${error instanceof Error ? error.message : String(error)}`)
   }
-  markRunCancelled(runId, 'Automation run cancelled.')
+  syncAutomationOperationalQueueStatus(markRunCancelled(runId, 'Automation run cancelled.'), 'Automation run cancelled.')
   publishAutomationUpdated()
   return true
 }

--- a/apps/desktop/src/main/automation-inbox-resolution.ts
+++ b/apps/desktop/src/main/automation-inbox-resolution.ts
@@ -3,6 +3,7 @@ import {
   listOpenInboxForAutomation,
   resumeRunFromNeedsUser,
 } from './automation-store.ts'
+import { syncAutomationOperationalQueueStatus } from './automation-operational-queue.ts'
 
 export function hasBlockingInboxItems(automationId: string) {
   return listOpenInboxForAutomation(automationId).some((item) =>
@@ -14,5 +15,5 @@ export function maybeResumeRunAfterInboxResolution(automationId: string, runId: 
   const automation = getAutomationDetail(automationId)
   if (!automation || automation.status === 'paused' || automation.status === 'archived') return
   if (hasBlockingInboxItems(automationId)) return
-  resumeRunFromNeedsUser(runId)
+  syncAutomationOperationalQueueStatus(resumeRunFromNeedsUser(runId))
 }

--- a/apps/desktop/src/main/automation-manual-actions.ts
+++ b/apps/desktop/src/main/automation-manual-actions.ts
@@ -12,6 +12,7 @@ import {
   resolveInboxItem,
   saveAutomationBrief,
 } from './automation-store.ts'
+import { syncAutomationOperationalQueueStatus } from './automation-operational-queue.ts'
 import { startAutomationRun } from './automation-run-starter.ts'
 
 export async function previewAutomationBriefWithContext(
@@ -41,7 +42,7 @@ export function approveAutomationBriefWithContext(
     if (item.runId) {
       const run = getRun(item.runId)
       if (run?.automationId === automationId && run.kind === 'enrichment' && run.status === 'needs_user') {
-        markRunCompleted(item.runId, 'Execution brief approved.', item.sessionId)
+        syncAutomationOperationalQueueStatus(markRunCompleted(item.runId, 'Execution brief approved.', item.sessionId), 'Execution brief approved.')
       }
     }
     resolveInboxItem(item.id, 'resolved')

--- a/apps/desktop/src/main/automation-operational-queue.ts
+++ b/apps/desktop/src/main/automation-operational-queue.ts
@@ -1,0 +1,111 @@
+import type {
+  AutomationDetail,
+  AutomationRun,
+  AutomationRunKind,
+  AutonomyLevel,
+  OperationalQueueItem,
+} from '@open-cowork/shared'
+import {
+  blockOperationalQueueItem,
+  enqueueOperationalRun,
+  finishOperationalQueueItem,
+  getOperationalQueueItemForRun,
+  getWorkspaceProfile,
+  listOperationalQueueItems,
+  resumeBlockedOperationalQueueItem,
+  startOperationalQueueItem,
+} from './operational-queue-store.ts'
+
+const AUTOMATION_WORKSPACE_PROFILE_ID = 'automation-workspace'
+const PROJECT_WORKSPACE_PROFILE_ID = 'project-workspace'
+
+function automationWorkspaceProfileId(automation: AutomationDetail, kind: AutomationRunKind) {
+  if (kind === 'execution' && automation.executionMode === 'scoped_execution') return PROJECT_WORKSPACE_PROFILE_ID
+  return AUTOMATION_WORKSPACE_PROFILE_ID
+}
+
+function requestedAutonomyForAutomation(automation: AutomationDetail, kind: AutomationRunKind): AutonomyLevel {
+  if (kind === 'heartbeat') return 'observe'
+  if (kind === 'enrichment') return 'draft'
+  return automation.autonomyPolicy === 'mostly-autonomous' ? 'supervised' : 'approve'
+}
+
+function writeCapableAutomationRun(automation: AutomationDetail, kind: AutomationRunKind) {
+  return kind === 'execution' && automation.executionMode === 'scoped_execution'
+}
+
+function automationQueueProjectId(automation: AutomationDetail) {
+  return automation.projectDirectory || `automation:${automation.id}`
+}
+
+function automationGlobalMaxAutonomy(automation: AutomationDetail): AutonomyLevel {
+  return automation.autonomyPolicy === 'mostly-autonomous' ? 'supervised' : 'approve'
+}
+
+function terminalOperationalStatus(status: AutomationRun['status']): Exclude<OperationalQueueItem['status'], 'queued' | 'running' | 'blocked'> | null {
+  if (status === 'completed') return 'completed'
+  if (status === 'failed') return 'failed'
+  if (status === 'cancelled') return 'cancelled'
+  return null
+}
+
+export function enqueueAutomationOperationalQueueItem(automation: AutomationDetail, run: AutomationRun, options: {
+  runKind?: 'automation' | 'sop'
+} = {}) {
+  const workspaceProfileId = automationWorkspaceProfileId(automation, run.kind)
+  if (!getWorkspaceProfile(workspaceProfileId)) {
+    throw new Error(`Workspace profile ${workspaceProfileId} does not exist.`)
+  }
+  const writeCapable = writeCapableAutomationRun(automation, run.kind)
+  return enqueueOperationalRun({
+    runKind: options.runKind || 'automation',
+    runId: run.id,
+    title: run.title,
+    requestedAutonomy: requestedAutonomyForAutomation(automation, run.kind),
+    globalMaxAutonomy: automationGlobalMaxAutonomy(automation),
+    workspaceProfileId,
+    projectId: writeCapable ? automationQueueProjectId(automation) : null,
+    externalSystemIds: [],
+    writeCapable,
+    caps: {
+      maxParallel: 1,
+      maxRunDurationMinutes: automation.runPolicy.maxRunDurationMinutes,
+      maxCostUsd: null,
+      maxRetries: automation.retryPolicy.maxRetries,
+    },
+  })
+}
+
+export function getAutomationOperationalQueueItem(runId: string) {
+  return getOperationalQueueItemForRun('automation', runId) || getOperationalQueueItemForRun('sop', runId)
+}
+
+export function listQueuedAutomationOperationalQueueItems() {
+  return listOperationalQueueItems()
+    .filter((item) => (item.runKind === 'automation' || item.runKind === 'sop') && item.status === 'queued')
+}
+
+export function startAutomationOperationalQueueItem(runId: string) {
+  const item = getAutomationOperationalQueueItem(runId)
+  if (!item) return null
+  return startOperationalQueueItem(item.id)
+}
+
+export function syncAutomationOperationalQueueStatus(run: AutomationRun | null, summary?: string | null) {
+  if (!run) return null
+  const item = getAutomationOperationalQueueItem(run.id)
+  if (!item) return null
+  const terminal = terminalOperationalStatus(run.status)
+  if (terminal) {
+    return finishOperationalQueueItem(item.id, terminal, {
+      error: terminal === 'failed' || terminal === 'cancelled' ? summary || run.error : null,
+    })
+  }
+  if (run.status === 'needs_user') {
+    return blockOperationalQueueItem(item.id, summary || run.summary || 'Automation run is waiting for user input.')
+  }
+  if (run.status === 'running' && item.status === 'blocked') {
+    return resumeBlockedOperationalQueueItem(item.id)
+  }
+  return getAutomationOperationalQueueItem(run.id)
+}

--- a/apps/desktop/src/main/automation-run-starter.ts
+++ b/apps/desktop/src/main/automation-run-starter.ts
@@ -1,4 +1,4 @@
-import type { AutomationRunKind, ExecutionBrief, SopTriggerType } from '@open-cowork/shared'
+import type { AutomationDetail, AutomationRun, AutomationRunKind, ExecutionBrief, SopTriggerType } from '@open-cowork/shared'
 import {
   clearPendingRetriesForChain,
   countConsecutiveFailedWorkRuns,
@@ -32,6 +32,13 @@ import {
   createAutomationHeartbeatPrompt,
 } from './automation-prompts.ts'
 import { type SopRunStartContext, resolveSopRunContextForAutomationStart } from './sop-run-context.ts'
+import {
+  enqueueAutomationOperationalQueueItem,
+  listQueuedAutomationOperationalQueueItems,
+  startAutomationOperationalQueueItem,
+  syncAutomationOperationalQueueStatus,
+} from './automation-operational-queue.ts'
+import { log } from './logger.ts'
 
 export interface StartAutomationRunOptions {
   attempt?: number
@@ -40,6 +47,128 @@ export interface StartAutomationRunOptions {
   sopTriggerType?: SopTriggerType | null
   sopInputs?: Record<string, unknown>
   sopRunContext?: SopRunStartContext | null
+}
+
+function automationRunTitle(automation: AutomationDetail, kind: AutomationRunKind) {
+  return kind === 'enrichment'
+    ? `Enrich ${automation.title}`
+    : kind === 'execution'
+      ? `Execute ${automation.title}`
+      : `Heartbeat ${automation.title}`
+}
+
+function buildAutomationPromptAndFormat(automation: AutomationDetail, kind: AutomationRunKind) {
+  const prompt = kind === 'enrichment'
+    ? createAutomationEnrichmentPrompt(automation)
+    : kind === 'execution'
+      ? createAutomationExecutionPrompt(automation, automation.brief as ExecutionBrief)
+      : createAutomationHeartbeatPrompt({
+        automation,
+        openInbox: listOpenInboxForAutomation(automation.id),
+        recentRuns: listAutomationState().runs.filter((entry) => entry.automationId === automation.id).slice(0, 5),
+      })
+  const format = kind === 'enrichment'
+    ? createAutomationEnrichmentFormat()
+    : kind === 'heartbeat'
+      ? createAutomationHeartbeatFormat()
+      : undefined
+  return { prompt, format }
+}
+
+function recordAutomationRunStartFailure(run: AutomationRun, error: unknown) {
+  const failureMessage = error instanceof Error ? error.message : String(error)
+  const disposition = classifyAutomationFailure(failureMessage)
+  const failedRun = markRunFailed(run.id, failureMessage, undefined, {
+    retryable: disposition.retryable,
+    failureCode: disposition.code,
+  })
+  syncAutomationOperationalQueueStatus(failedRun, failureMessage)
+  if (failedRun) {
+    const consecutiveFailures = countConsecutiveFailedWorkRuns(run.automationId)
+    const shouldPause = failedRun.kind !== 'heartbeat' && (!disposition.retryable || consecutiveFailures >= AUTOMATION_CONSECUTIVE_FAILURE_LIMIT)
+    if (shouldPause) {
+      clearPendingRetriesForChain(failedRun.retryOfRunId || failedRun.id)
+      updateAutomationStatus(run.automationId, 'paused')
+    }
+  }
+  return new AutomationRunStartError(failureMessage, {
+    runId: failedRun?.id,
+    retryScheduled: Boolean(getRun(failedRun?.id || '')?.nextRetryAt),
+  })
+}
+
+async function dispatchAutomationRunThroughOpenCode(
+  automation: AutomationDetail,
+  run: AutomationRun,
+  publishAutomationUpdated: () => void,
+) {
+  const { prompt, format } = buildAutomationPromptAndFormat(automation, run.kind)
+  try {
+    await createAutomationSession({
+      automationId: automation.id,
+      runId: run.id,
+      title: run.title,
+      directory: automation.projectDirectory,
+      agent: agentForAutomationRun(run.kind),
+      prompt,
+      format,
+    }, publishAutomationUpdated)
+    return getRun(run.id)
+  } catch (error) {
+    throw recordAutomationRunStartFailure(run, error)
+  }
+}
+
+export async function dispatchRunnableAutomationQueueItems(
+  publishAutomationUpdated: () => void,
+  limit = 5,
+) {
+  const dispatched: AutomationRun[] = []
+  const dispatchLimit = Math.max(1, Math.min(100, Math.floor(limit)))
+  let attemptedDispatches = 0
+  const queued = listQueuedAutomationOperationalQueueItems()
+  for (const item of queued) {
+    if (attemptedDispatches >= dispatchLimit) break
+    const run = getRun(item.runId)
+    if (!run) {
+      syncAutomationOperationalQueueStatus({
+        id: item.runId,
+        automationId: 'unknown',
+        sessionId: null,
+        kind: 'execution',
+        status: 'failed',
+        title: item.title,
+        summary: null,
+        error: 'Automation run is missing.',
+        attempt: 1,
+        retryOfRunId: null,
+        nextRetryAt: null,
+        createdAt: item.createdAt,
+        startedAt: null,
+        finishedAt: null,
+      }, 'Automation run is missing.')
+      continue
+    }
+    const automation = getAutomationDetail(run.automationId)
+    if (!automation) {
+      syncAutomationOperationalQueueStatus(markRunFailed(run.id, 'Automation record is missing.', undefined, {
+        retryable: false,
+        failureCode: 'configuration_invalid',
+      }), 'Automation record is missing.')
+      continue
+    }
+    const started = startAutomationOperationalQueueItem(run.id)
+    if (!started || started.status !== 'running') continue
+    attemptedDispatches += 1
+    try {
+      const startedRun = await dispatchAutomationRunThroughOpenCode(automation, run, publishAutomationUpdated)
+      if (startedRun) dispatched.push(startedRun)
+    } catch (error) {
+      log('error', `Failed to dispatch queued automation run ${run.id}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+  if (dispatched.length > 0) publishAutomationUpdated()
+  return dispatched
 }
 
 export async function startAutomationRun(
@@ -72,13 +201,7 @@ export async function startAutomationRun(
   const run = createAutomationRunWhenNoActive(
     automationId,
     kind,
-    options.title || (
-      kind === 'enrichment'
-        ? `Enrich ${automation.title}`
-        : kind === 'execution'
-          ? `Execute ${automation.title}`
-          : `Heartbeat ${automation.title}`
-    ),
+    options.title || automationRunTitle(automation, kind),
     {
       attempt: options.attempt,
       retryOfRunId: options.retryOfRunId,
@@ -86,49 +209,15 @@ export async function startAutomationRun(
     },
   )
   if (!run) throw new AutomationRunConflictError('Automation already has an active run.')
-  const prompt = kind === 'enrichment'
-    ? createAutomationEnrichmentPrompt(automation)
-    : kind === 'execution'
-      ? createAutomationExecutionPrompt(automation, automation.brief as ExecutionBrief)
-      : createAutomationHeartbeatPrompt({
-        automation,
-        openInbox: listOpenInboxForAutomation(automationId),
-        recentRuns: listAutomationState().runs.filter((entry) => entry.automationId === automationId).slice(0, 5),
-      })
-  const format = kind === 'enrichment'
-    ? createAutomationEnrichmentFormat()
-    : kind === 'heartbeat'
-      ? createAutomationHeartbeatFormat()
-      : undefined
-  try {
-    await createAutomationSession({
-      automationId,
-      runId: run.id,
-      title: run.title,
-      directory: automation.projectDirectory,
-      agent: agentForAutomationRun(kind),
-      prompt,
-      format,
-    }, publishAutomationUpdated)
-  } catch (error) {
-    const failureMessage = error instanceof Error ? error.message : String(error)
-    const disposition = classifyAutomationFailure(failureMessage)
-    const failedRun = markRunFailed(run.id, failureMessage, undefined, {
-      retryable: disposition.retryable,
-      failureCode: disposition.code,
-    })
-    if (failedRun) {
-      const consecutiveFailures = countConsecutiveFailedWorkRuns(automationId)
-      const shouldPause = failedRun.kind !== 'heartbeat' && (!disposition.retryable || consecutiveFailures >= AUTOMATION_CONSECUTIVE_FAILURE_LIMIT)
-      if (shouldPause) {
-        clearPendingRetriesForChain(failedRun.retryOfRunId || failedRun.id)
-        updateAutomationStatus(automationId, 'paused')
-      }
-    }
-    throw new AutomationRunStartError(error instanceof Error ? error.message : String(error), {
-      runId: failedRun?.id,
-      retryScheduled: Boolean(getRun(failedRun?.id || '')?.nextRetryAt),
-    })
+  enqueueAutomationOperationalQueueItem(automation, run, {
+    runKind: sopRunLink ? 'sop' : 'automation',
+  })
+  const started = startAutomationOperationalQueueItem(run.id)
+  if (!started || started.status !== 'running') {
+    publishAutomationUpdated()
+    return getRun(run.id)
   }
-  return getRun(run.id)
+  const startedRun = await dispatchAutomationRunThroughOpenCode(automation, run, publishAutomationUpdated)
+  syncAutomationOperationalQueueStatus(startedRun)
+  return startedRun
 }

--- a/apps/desktop/src/main/automation-service-reporting.ts
+++ b/apps/desktop/src/main/automation-service-reporting.ts
@@ -15,6 +15,7 @@ import {
   updateAutomationStatus,
 } from './automation-store.ts'
 import { loadSettings } from './settings.ts'
+import { syncAutomationOperationalQueueStatus } from './automation-operational-queue.ts'
 
 export function getRetryRootRunId(run: AutomationRun) {
   return run.retryOfRunId || run.id
@@ -108,6 +109,7 @@ export function processAutomationRunFailure(input: {
     retryable: disposition.retryable,
     failureCode: disposition.code,
   })
+  syncAutomationOperationalQueueStatus(failedRun, input.message)
   const consecutiveFailures = countConsecutiveFailedWorkRuns(input.automationId)
   const circuitReason = input.run.kind === 'heartbeat'
     ? null

--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -54,7 +54,8 @@ import {
   extractHeartbeatDecisionFromMessages,
   summarizeAutomationMessages,
 } from './automation-run-output.ts'
-import { startAutomationRun } from './automation-run-starter.ts'
+import { dispatchRunnableAutomationQueueItems, startAutomationRun } from './automation-run-starter.ts'
+import { syncAutomationOperationalQueueStatus } from './automation-operational-queue.ts'
 import { deliverAutomationDesktopUpdate } from './automation-delivery.ts'
 import { ensureRuntimeContextDirectory } from './runtime-context.ts'
 import { getClientForDirectory } from './runtime.ts'
@@ -66,6 +67,7 @@ import { dispatchRuntimeSessionEvent } from './session-event-dispatcher.ts'
 import { startSessionStatusReconciliation } from './session-status-reconciler.ts'
 import { createPromiseChain } from './promise-chain.ts'
 import { createCoalescedControlPlaneTask } from './automation-control-plane-queue.ts'
+import { log } from './logger.ts'
 
 let getMainWindow: (() => BrowserWindow | null) | null = null
 let schedulerTimer: NodeJS.Timeout | null = null
@@ -97,6 +99,14 @@ async function maybeEnforceRunTimeLimits(now = new Date()) {
   await enforceAutomationRunTimeLimits(now, handleAutomationSessionError, publishAutomationUpdated)
 }
 
+async function dispatchQueuedAutomationRuns() {
+  try {
+    await dispatchRunnableAutomationQueueItems(publishAutomationUpdated)
+  } catch (error) {
+    log('error', `Failed to dispatch queued automation runs: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
 export function configureAutomationService(options: {
   getMainWindow: () => BrowserWindow | null
 }) {
@@ -122,6 +132,7 @@ export async function runAutomationServiceTick(now = new Date()) {
   await maybeEnforceRunTimeLimits(now)
   await maybeRunAutomationScheduler(now)
   await maybeRunHeartbeatReviews(now)
+  await dispatchQueuedAutomationRuns()
 }
 
 export function listAutomations(): AutomationListPayload {
@@ -169,7 +180,9 @@ export async function retryAutomationRun(runId: string): Promise<AutomationRun |
 }
 
 export async function cancelAutomationRun(runId: string) {
-  return cancelAutomationRunWithContext(runId, publishAutomationUpdated)
+  const cancelled = await cancelAutomationRunWithContext(runId, publishAutomationUpdated)
+  if (cancelled) await dispatchQueuedAutomationRuns()
+  return cancelled
 }
 
 export async function respondToAutomationInbox(itemId: string, response: string) {
@@ -219,8 +232,9 @@ export async function handleAutomationSessionIdle(sessionId: string) {
     const automation = getAutomationDetail(record.automationId)
     const decision = extractHeartbeatDecisionFromMessages(messages)
     if (!automation || !decision) {
-      markHeartbeatCompleted(run.id, summary)
+      syncAutomationOperationalQueueStatus(markHeartbeatCompleted(run.id, summary), summary)
       publishAutomationUpdated()
+      await dispatchQueuedAutomationRuns()
       return
     }
 
@@ -241,13 +255,15 @@ export async function handleAutomationSessionIdle(sessionId: string) {
         title: 'Automation needs input',
         body: decision.userMessage || decision.reason || completionSummary,
       })
-      markHeartbeatCompleted(run.id, completionSummary)
+      syncAutomationOperationalQueueStatus(markHeartbeatCompleted(run.id, completionSummary), completionSummary)
       publishAutomationUpdated()
+      await dispatchQueuedAutomationRuns()
       return
     }
 
     if (decision.action === 'refresh_brief') {
-      markHeartbeatCompleted(run.id, `${completionSummary} Brief refresh queued.`)
+      const heartbeatSummary = `${completionSummary} Brief refresh queued.`
+      syncAutomationOperationalQueueStatus(markHeartbeatCompleted(run.id, heartbeatSummary), heartbeatSummary)
       if (automation.status !== 'paused' && automation.status !== 'archived') {
         try {
           await startAutomationRun(record.automationId, 'enrichment', publishAutomationUpdated)
@@ -277,7 +293,8 @@ export async function handleAutomationSessionIdle(sessionId: string) {
         && latestAutomation.status !== 'paused'
         && latestAutomation.status !== 'archived'
       ) {
-        markHeartbeatCompleted(run.id, `${completionSummary} Execution queued.`)
+        const heartbeatSummary = `${completionSummary} Execution queued.`
+        syncAutomationOperationalQueueStatus(markHeartbeatCompleted(run.id, heartbeatSummary), heartbeatSummary)
         try {
           await startAutomationRun(record.automationId, 'execution', publishAutomationUpdated)
         } catch (error) {
@@ -290,14 +307,16 @@ export async function handleAutomationSessionIdle(sessionId: string) {
           maybeReportFailedRun(record.automationId, failedRun, 'Automation execution could not start', message, sessionId)
         }
       } else {
-        markHeartbeatCompleted(run.id, `${completionSummary} Execution was not queued because input or approval is still pending.`)
+        const heartbeatSummary = `${completionSummary} Execution was not queued because input or approval is still pending.`
+        syncAutomationOperationalQueueStatus(markHeartbeatCompleted(run.id, heartbeatSummary), heartbeatSummary)
       }
       publishAutomationUpdated()
       return
     }
 
-    markHeartbeatCompleted(run.id, completionSummary)
+    syncAutomationOperationalQueueStatus(markHeartbeatCompleted(run.id, completionSummary), completionSummary)
     publishAutomationUpdated()
+    await dispatchQueuedAutomationRuns()
     return
   }
   if (run.kind === 'enrichment') {
@@ -312,6 +331,7 @@ export async function handleAutomationSessionIdle(sessionId: string) {
         retryable: disposition.retryable,
         failureCode: disposition.code,
       })
+      syncAutomationOperationalQueueStatus(failedRun, failureMessage)
       maybeOpenFailureCircuit({
         automationId: record.automationId,
         run: failedRun,
@@ -324,13 +344,15 @@ export async function handleAutomationSessionIdle(sessionId: string) {
         circuitReason: disposition.retryable ? null : disposition.reason,
       })
       publishAutomationUpdated()
+      await dispatchQueuedAutomationRuns()
       return
     }
     const automation = getAutomationDetail(record.automationId)
     if (!automation) return
     saveAutomationBrief(record.automationId, brief)
     if (brief.status === 'needs_user') {
-      markRunNeedsUser(run.id, 'Waiting for clarification before execution can begin.')
+      const needsUserSummary = 'Waiting for clarification before execution can begin.'
+      syncAutomationOperationalQueueStatus(markRunNeedsUser(run.id, needsUserSummary), needsUserSummary)
       if (brief.missingContext.length > 0) {
         createInboxItem({
           automationId: record.automationId,
@@ -373,7 +395,8 @@ export async function handleAutomationSessionIdle(sessionId: string) {
             body: buildAutomationApprovalBody(brief),
           })
         }
-        markRunNeedsUser(run.id, 'Execution brief is ready for approval.')
+        const needsUserSummary = 'Execution brief is ready for approval.'
+        syncAutomationOperationalQueueStatus(markRunNeedsUser(run.id, needsUserSummary), needsUserSummary)
       } else {
         const approvedBrief: ExecutionBrief = {
           ...brief,
@@ -381,7 +404,8 @@ export async function handleAutomationSessionIdle(sessionId: string) {
           status: 'ready',
         }
         saveAutomationBrief(record.automationId, approvedBrief)
-        markRunCompleted(run.id, 'Execution brief auto-approved and ready for execution.', sessionId)
+        const completedSummary = 'Execution brief auto-approved and ready for execution.'
+        syncAutomationOperationalQueueStatus(markRunCompleted(run.id, completedSummary, sessionId), completedSummary)
         try {
           await startAutomationRun(record.automationId, 'execution', publishAutomationUpdated)
         } catch (error) {
@@ -410,6 +434,7 @@ export async function handleAutomationSessionIdle(sessionId: string) {
       })
     : { run: markRunCompleted(run.id, summary, sessionId), delivery: null }
   const completedRun = completed.run
+  syncAutomationOperationalQueueStatus(completedRun, summary)
   if (automation && completedRun?.status === 'completed') {
     createInboxItem({
       automationId: record.automationId,
@@ -428,6 +453,7 @@ export async function handleAutomationSessionIdle(sessionId: string) {
       body: summary,
     })
   }
+  await dispatchQueuedAutomationRuns()
   publishAutomationUpdated()
 }
 
@@ -444,6 +470,7 @@ export function handleAutomationSessionError(sessionId: string, message: string)
     sessionId,
   })
   publishAutomationUpdated()
+  void dispatchQueuedAutomationRuns()
 }
 
 export function handleAutomationQuestionAsked(input: {
@@ -477,7 +504,7 @@ export function handleAutomationQuestionAsked(input: {
       body: input.question,
     })
   }
-  markRunNeedsUser(record.runId, input.question)
+  syncAutomationOperationalQueueStatus(markRunNeedsUser(record.runId, input.question), input.question)
   publishAutomationUpdated()
 }
 

--- a/apps/desktop/src/main/operational-queue-store.ts
+++ b/apps/desktop/src/main/operational-queue-store.ts
@@ -533,6 +533,16 @@ export function blockOperationalQueueItem(id: string, reason: string) {
   return getOperationalQueueItem(id)
 }
 
+export function resumeBlockedOperationalQueueItem(id: string) {
+  const now = nowIso()
+  getOperationalQueueDb().prepare(`
+    update operational_queue_items
+    set status = ?, started_at = coalesce(started_at, ?), updated_at = ?, error = null
+    where id = ? and status = ?
+  `).run('running', now, now, id, 'blocked')
+  return getOperationalQueueItem(id)
+}
+
 export function retryOperationalQueueItem(id: string) {
   return withOperationalTransaction(() => {
     const item = getOperationalQueueItem(id)

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -60,6 +60,14 @@ The execution path still goes through OpenCode-native agents:
 Open Cowork adds the durable scheduling, approval, retry, and visibility layer
 around that flow.
 
+Automation runs now also claim operations queue authority before dispatching to
+OpenCode. Planning and heartbeat runs are queued as low-risk coordination work,
+while scoped execution runs claim their project workspace key. That means two
+write-capable automation or SOP-backed runs cannot mutate the same project at
+the same time unless queue policy explicitly permits more parallelism. Waiting
+runs stay durable and visible in Pulse instead of becoming hidden in-memory
+work.
+
 Completed automation runs can also be saved as **SOPs**. A SOP is a reusable,
 versioned process definition derived from a successful run: it preserves the
 brief shape, work graph, approval boundary, retry/run policy, and delivery

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -133,6 +133,8 @@ The current upstream surface includes:
 - heartbeat supervision for due or blocked work
 - inbox items for clarification, approval, and failure handling
 - durable work items, runs, and in-app deliveries
+- operations queue authority for automation and SOP-backed execution runs,
+  including serialized project-scoped writes and visible queue caps
 - optional preferred specialists that bias routing without replacing the `plan` / `build` flow
 
 Once an automation exists it gets a dedicated detail surface for

--- a/tests/automation-service.test.ts
+++ b/tests/automation-service.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../apps/desktop/src/main/automation-store.ts'
 import {
   approveAutomationBrief,
+  cancelAutomationRun,
   handleAutomationQuestionAsked,
   handleAutomationQuestionResolved,
   handleAutomationSessionIdle,
@@ -38,6 +39,14 @@ import {
   getSopRunDetail,
   saveAutomationRunAsSop,
 } from '../apps/desktop/src/main/sop-service.ts'
+import {
+  clearOperationalQueueStoreCache,
+  enqueueOperationalRun,
+  finishOperationalQueueItem,
+  getOperationalQueueItemForRun,
+  startOperationalQueueItem,
+} from '../apps/desktop/src/main/operational-queue-store.ts'
+import { dispatchRunnableAutomationQueueItems } from '../apps/desktop/src/main/automation-run-starter.ts'
 import { clearSessionRegistryCache, toSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
 
@@ -50,7 +59,52 @@ function resetAutomationStore(userDataDir: string) {
   process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
   clearConfigCaches()
   clearAutomationStoreCache()
+  clearOperationalQueueStoreCache()
   clearSessionRegistryCache()
+}
+
+function createScopedExecutionAutomation(title: string, projectDirectory = '/Users/example/project') {
+  const automation = createAutomation({
+    title,
+    goal: `Execute ${title}.`,
+    kind: 'recurring',
+    schedule: {
+      type: 'weekly',
+      timezone: 'UTC',
+      dayOfWeek: 1,
+      runAtHour: 9,
+      runAtMinute: 0,
+    },
+    heartbeatMinutes: 15,
+    retryPolicy: {
+      maxRetries: 3,
+      baseDelayMinutes: 5,
+      maxDelayMinutes: 60,
+    },
+    runPolicy: {
+      dailyRunCap: 6,
+      maxRunDurationMinutes: 120,
+    },
+    executionMode: 'scoped_execution',
+    autonomyPolicy: 'review-first',
+    projectDirectory,
+    preferredAgentNames: [],
+  })
+  saveAutomationBrief(automation.id, {
+    version: 1,
+    status: 'ready',
+    goal: automation.goal,
+    deliverables: ['Report'],
+    assumptions: [],
+    missingContext: [],
+    successCriteria: ['Ready'],
+    recommendedAgents: ['research'],
+    workItems: [],
+    approvalBoundary: 'Approve before delivery.',
+    generatedAt: new Date().toISOString(),
+    approvedAt: new Date().toISOString(),
+  })
+  return automation
 }
 
 test('runAutomationNow rejects when an automation already has an active run', async () => {
@@ -114,6 +168,203 @@ test('runAutomationNow rejects when an automation already has an active run', as
     closeLogger()
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('runAutomationNow queues scoped execution when the project target is already active', async () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('operational-queue-wait')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const projectDirectory = '/Users/example/project'
+    const blocker = enqueueOperationalRun({
+      runKind: 'agent',
+      runId: 'active-writer',
+      title: 'Active writer',
+      requestedAutonomy: 'supervised',
+      globalMaxAutonomy: 'supervised',
+      workspaceProfileId: 'project-workspace',
+      projectId: projectDirectory,
+      writeCapable: true,
+      caps: { maxParallel: 1 },
+    })
+    assert.equal(startOperationalQueueItem(blocker.id)?.status, 'running')
+
+    const automation = createScopedExecutionAutomation('Queued project execution', projectDirectory)
+    const queuedRun = await runAutomationNow(automation.id)
+
+    assert.equal(queuedRun?.status, 'queued')
+    const queueItem = getOperationalQueueItemForRun('automation', queuedRun!.id)
+    assert.equal(queueItem?.status, 'queued')
+    assert.deepEqual(queueItem?.queueKeys, [`project:${projectDirectory}`])
+    assert.equal(queueItem?.workspaceProfileId, 'project-workspace')
+    assert.equal(queueItem?.effectiveAutonomy, 'approve')
+  } finally {
+    closeLogger()
+    clearSessionRegistryCache()
+    clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('queued automation dispatches after its project queue key is released', async () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('operational-queue-dispatch')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const projectDirectory = '/Users/example/project'
+    const blocker = enqueueOperationalRun({
+      runKind: 'agent',
+      runId: 'active-writer',
+      title: 'Active writer',
+      requestedAutonomy: 'supervised',
+      globalMaxAutonomy: 'supervised',
+      workspaceProfileId: 'project-workspace',
+      projectId: projectDirectory,
+      writeCapable: true,
+      caps: { maxParallel: 1 },
+    })
+    assert.equal(startOperationalQueueItem(blocker.id)?.status, 'running')
+
+    const automation = createScopedExecutionAutomation('Dispatch after writer', projectDirectory)
+    const queuedRun = await runAutomationNow(automation.id)
+    assert.equal(queuedRun?.status, 'queued')
+
+    finishOperationalQueueItem(blocker.id, 'completed')
+    await dispatchRunnableAutomationQueueItems(() => {})
+
+    const failedRun = getRun(queuedRun!.id)
+    assert.equal(failedRun?.status, 'failed')
+    assert.match(failedRun?.error || '', /runtime not started/i)
+    const queueItem = getOperationalQueueItemForRun('automation', queuedRun!.id)
+    assert.equal(queueItem?.status, 'failed')
+    assert.match(queueItem?.error || '', /runtime not started/i)
+    closeLogger()
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  } finally {
+    closeLogger()
+    clearSessionRegistryCache()
+    clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('queued automation runs can be cancelled before OpenCode dispatch', async () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('operational-queue-cancel')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const projectDirectory = '/Users/example/project'
+    const blocker = enqueueOperationalRun({
+      runKind: 'agent',
+      runId: 'active-writer',
+      title: 'Active writer',
+      requestedAutonomy: 'supervised',
+      globalMaxAutonomy: 'supervised',
+      workspaceProfileId: 'project-workspace',
+      projectId: projectDirectory,
+      writeCapable: true,
+      caps: { maxParallel: 1 },
+    })
+    assert.equal(startOperationalQueueItem(blocker.id)?.status, 'running')
+
+    const automation = createScopedExecutionAutomation('Cancel queued execution', projectDirectory)
+    const queuedRun = await runAutomationNow(automation.id)
+    assert.equal(queuedRun?.status, 'queued')
+
+    assert.equal(await cancelAutomationRun(queuedRun!.id), true)
+    const cancelledRun = getRun(queuedRun!.id)
+    assert.equal(cancelledRun?.status, 'cancelled')
+    const queueItem = getOperationalQueueItemForRun('automation', queuedRun!.id)
+    assert.equal(queueItem?.status, 'cancelled')
+    assert.match(queueItem?.error || '', /cancelled/i)
+  } finally {
+    closeLogger()
+    clearSessionRegistryCache()
+    clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('automation queue dispatch skips blocked head items before applying the start cap', async () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('operational-queue-skip-blocked')
+
+  try {
+    resetAutomationStore(userDataDir)
+
+    const blockedProject = '/Users/example/project-a'
+    const runnableProject = '/Users/example/project-b'
+    const blockedWriter = enqueueOperationalRun({
+      runKind: 'agent',
+      runId: 'active-writer-a',
+      title: 'Active writer A',
+      requestedAutonomy: 'supervised',
+      globalMaxAutonomy: 'supervised',
+      workspaceProfileId: 'project-workspace',
+      projectId: blockedProject,
+      writeCapable: true,
+      caps: { maxParallel: 1 },
+    })
+    const releasedWriter = enqueueOperationalRun({
+      runKind: 'agent',
+      runId: 'active-writer-b',
+      title: 'Active writer B',
+      requestedAutonomy: 'supervised',
+      globalMaxAutonomy: 'supervised',
+      workspaceProfileId: 'project-workspace',
+      projectId: runnableProject,
+      writeCapable: true,
+      caps: { maxParallel: 1 },
+    })
+    assert.equal(startOperationalQueueItem(blockedWriter.id)?.status, 'running')
+    assert.equal(startOperationalQueueItem(releasedWriter.id)?.status, 'running')
+
+    const blockedAutomation = createScopedExecutionAutomation('Blocked queued execution', blockedProject)
+    const blockedRun = await runAutomationNow(blockedAutomation.id)
+    assert.equal(blockedRun?.status, 'queued')
+
+    const runnableAutomation = createScopedExecutionAutomation('Runnable queued execution', runnableProject)
+    const runnableRun = await runAutomationNow(runnableAutomation.id)
+    assert.equal(runnableRun?.status, 'queued')
+
+    finishOperationalQueueItem(releasedWriter.id, 'completed')
+    await dispatchRunnableAutomationQueueItems(() => {}, 1)
+
+    assert.equal(getRun(blockedRun!.id)?.status, 'queued')
+    assert.equal(getOperationalQueueItemForRun('automation', blockedRun!.id)?.status, 'queued')
+    assert.equal(getRun(runnableRun!.id)?.status, 'failed')
+    assert.match(getOperationalQueueItemForRun('automation', runnableRun!.id)?.error || '', /runtime not started/i)
+    closeLogger()
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  } finally {
+    closeLogger()
+    clearSessionRegistryCache()
+    clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -188,10 +439,14 @@ test('runAutomationNow links active SOP versions before starting execution', asy
     assert.equal(detail?.link.triggerType, 'manual')
     assert.equal(detail?.inputs.source, 'automation_run_now')
     assert.equal(detail?.inputs['project-directory'], '/Users/example/project')
+    const queueItem = getOperationalQueueItemForRun('sop', startedRun!.id)
+    assert.equal(queueItem?.status, 'failed')
+    assert.equal(queueItem?.runKind, 'sop')
   } finally {
     closeLogger()
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -273,6 +528,7 @@ test('approving an enrichment brief completes the parked approval run', () => {
     closeLogger()
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -375,6 +631,7 @@ test('automation question resolution resumes the active run before idle completi
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -447,6 +704,7 @@ test('scheduler skips stale due automations that already have an active run with
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -528,6 +786,7 @@ test('scheduler links due SOP-backed execution runs with schedule trigger', asyn
     closeLogger()
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -595,6 +854,7 @@ test('runAutomationNow rejects when the daily work-run attempt cap is exhausted'
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -663,6 +923,7 @@ test('archived automations reject preview and run-now actions', async () => {
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -751,6 +1012,7 @@ test('manual retry supersedes existing scheduled retries for the whole chain and
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -830,6 +1092,7 @@ test('manual retry from an older failed ancestor keeps attempt numbering monoton
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -900,6 +1163,7 @@ test('manual retry blocked by the daily run cap keeps the scheduled retry armed'
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -980,6 +1244,7 @@ test('deterministic automation session failures pause the automation and do not 
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -1050,6 +1315,7 @@ test('runAutomationServiceTick fails active runs that exceed the max run duratio
   } finally {
     clearSessionRegistryCache()
     clearAutomationStoreCache()
+    clearOperationalQueueStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir

--- a/tests/operational-queue-store.test.ts
+++ b/tests/operational-queue-store.test.ts
@@ -17,6 +17,7 @@ import {
   listOperationalQueueItems,
   listWorkspaceProfiles,
   recordOperationalQueueItemCost,
+  resumeBlockedOperationalQueueItem,
   resolveEffectiveAutonomy,
   retryOperationalQueueItem,
   startOperationalQueueItem,
@@ -195,6 +196,28 @@ test('blocked operational items keep their queue keys occupied until resolved', 
   assert.equal(startOperationalQueueItem(first.id)?.status, 'running')
   assert.equal(blockOperationalQueueItem(first.id, 'Waiting for approval.')?.status, 'blocked')
   assert.equal(startOperationalQueueItem(second.id)?.status, 'queued')
+}))
+
+test('blocked operational items can resume without losing their started timestamp', () => withOperationalStore('blocked-resume', () => {
+  const item = enqueueOperationalRun({
+    runKind: 'automation',
+    runId: 'automation-blocked-1',
+    title: 'Automation waiting for approval',
+    requestedAutonomy: 'approve',
+    workspaceProfileId: 'project-workspace',
+    projectId: '/workspace/acme',
+    writeCapable: true,
+  })
+
+  const started = startOperationalQueueItem(item.id)
+  assert.equal(started?.status, 'running')
+  assert.ok(started?.startedAt)
+  assert.equal(blockOperationalQueueItem(item.id, 'Waiting for approval.')?.status, 'blocked')
+
+  const resumed = resumeBlockedOperationalQueueItem(item.id)
+  assert.equal(resumed?.status, 'running')
+  assert.equal(resumed?.startedAt, started?.startedAt)
+  assert.equal(resumed?.error, null)
 }))
 
 test('operational queue state survives store reopen', () => withOperationalStore('survives-restart', () => {


### PR DESCRIPTION
## Summary
- route automation and SOP-backed execution starts through the durable operations queue before OpenCode dispatch
- serialize scoped execution runs by project workspace authority while keeping planning and heartbeat work fanout-friendly
- sync automation queue items on start failures, user-blocked states, resumes, cancellation, runtime failures, and completion
- document the automation queue authority behavior and add regression coverage

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/automation-service.test.ts tests/operational-queue-store.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm build
- uv run mkdocs build --strict
- git diff --check