### PR TITLE
[codex] prune stale managed skill mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ release is planned for `v0.0.1`.
 - Fixed path and persistence edge cases around chart artifacts, directory grant
   rebinding, saved text exports, runtime generated files, and session file
   snippets.
+- Fixed stale generated skill mirrors so downstream builds that remove bundled
+  skills stop advertising those skills after restart without deleting
+  user-authored custom skills.
 
 ## [0.0.0] - 2026-04-28
 

--- a/apps/desktop/src/main/custom-skill-store.ts
+++ b/apps/desktop/src/main/custom-skill-store.ts
@@ -39,6 +39,7 @@ import {
   targetDirectory,
 } from './custom-store-common.ts'
 import type { NativeConfigScope } from './runtime-paths.ts'
+import { readManagedSkillMirrorNames } from './runtime-skill-mirror.ts'
 
 type SkillFileReadState = {
   files: Array<{ path: string; content: string }>
@@ -157,10 +158,14 @@ function replaceSkillBundleDirectory(root: string, tempRoot: string) {
 function readScopedSkills(scope: NativeConfigScope, directory?: string | null) {
   const root = ensureDirectory(skillsDirForTarget(scope, directory))
   const entries = readdirSync(root, { withFileTypes: true })
+  const generatedMachineMirrors = scope === 'machine'
+    ? readManagedSkillMirrorNames(root)
+    : new Set<string>()
   const skills: CustomSkillConfig[] = []
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue
+    if (generatedMachineMirrors.has(entry.name)) continue
     const skillRoot = join(root, entry.name)
 
     const skillFile = join(skillRoot, 'SKILL.md')

--- a/apps/desktop/src/main/custom-skill-store.ts
+++ b/apps/desktop/src/main/custom-skill-store.ts
@@ -39,7 +39,7 @@ import {
   targetDirectory,
 } from './custom-store-common.ts'
 import type { NativeConfigScope } from './runtime-paths.ts'
-import { readManagedSkillMirrorNames } from './runtime-skill-mirror.ts'
+import { readCurrentManagedSkillMirrorNames } from './runtime-skill-mirror.ts'
 
 type SkillFileReadState = {
   files: Array<{ path: string; content: string }>
@@ -159,7 +159,7 @@ function readScopedSkills(scope: NativeConfigScope, directory?: string | null) {
   const root = ensureDirectory(skillsDirForTarget(scope, directory))
   const entries = readdirSync(root, { withFileTypes: true })
   const generatedMachineMirrors = scope === 'machine'
-    ? readManagedSkillMirrorNames(root)
+    ? readCurrentManagedSkillMirrorNames(root)
     : new Set<string>()
   const skills: CustomSkillConfig[] = []
 

--- a/apps/desktop/src/main/runtime-content.ts
+++ b/apps/desktop/src/main/runtime-content.ts
@@ -88,12 +88,6 @@ function runtimeConfigSourceDir() {
     : join(process.cwd(), 'runtime-config')
 }
 
-function findFirstBundledSkillSource(skillSourceRoots: string[], skillName: string) {
-  return skillSourceRoots
-    .map((root) => findBundledSkillDir(root, skillName))
-    .find((candidate) => candidate && existsSync(candidate)) || null
-}
-
 // Root directories where bundled skill packages may live, in priority
 // order. Exported so the effective-skills catalog can resolve the same
 // paths as `copySkillsAndAgents` — otherwise the Capabilities UI's
@@ -174,7 +168,6 @@ export function copySkillsAndAgents(projectDirectory?: string | null) {
     discoverableSkillsDir: discoverableSkillsDst,
     previousManagedSkillsDir: skillsDst,
     configuredSkillNames,
-    findBundledSkillSource: (skillName) => findFirstBundledSkillSource(skillSourceRoots, skillName),
   })
   rmSync(skillsDst, { recursive: true, force: true })
   rmSync(runtimeSkillCatalog, { recursive: true, force: true })

--- a/apps/desktop/src/main/runtime-content.ts
+++ b/apps/desktop/src/main/runtime-content.ts
@@ -5,6 +5,7 @@ import { getConfiguredSkillsFromConfig } from './config-loader.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
 import { log } from './logger.ts'
 import { getMachineSkillsDir, getManagedSkillsDir, getRuntimeHomeDir, getRuntimeSkillCatalogDir } from './runtime-paths.ts'
+import { pruneManagedSkillMirror, writeManagedSkillMirrorNames } from './runtime-skill-mirror.ts'
 import { syncProjectOverlayToRuntime } from './runtime-project-overlay.ts'
 import { buildRuntimeSkillCatalog } from './runtime-skill-catalog.ts'
 import { syncCustomAgentRuntimeGuidance } from './native-customizations.ts'
@@ -78,6 +79,21 @@ export function writeRuntimeAgentsFile(runtimeHome: string, agentsSrc: string) {
   writeFileAtomic(join(runtimeHome, 'AGENTS.md'), readFileSync(agentsSrc, 'utf-8'), { mode: 0o600 })
 }
 
+function runtimeConfigSourceDir() {
+  if (app?.isPackaged) return join(process.resourcesPath, 'runtime-config')
+  if (app?.getAppPath) return join(app.getAppPath(), 'runtime-config')
+  const repoDesktopRuntimeConfig = join(process.cwd(), 'apps', 'desktop', 'runtime-config')
+  return existsSync(repoDesktopRuntimeConfig)
+    ? repoDesktopRuntimeConfig
+    : join(process.cwd(), 'runtime-config')
+}
+
+function findFirstBundledSkillSource(skillSourceRoots: string[], skillName: string) {
+  return skillSourceRoots
+    .map((root) => findBundledSkillDir(root, skillName))
+    .find((candidate) => candidate && existsSync(candidate)) || null
+}
+
 // Root directories where bundled skill packages may live, in priority
 // order. Exported so the effective-skills catalog can resolve the same
 // paths as `copySkillsAndAgents` — otherwise the Capabilities UI's
@@ -142,9 +158,7 @@ export function findBundledSkillDir(root: string, skillName: string): string | n
 // and safe to populate.
 export function copySkillsAndAgents(projectDirectory?: string | null) {
   const runtimeHome = getRuntimeHomeDir()
-  const runtimeConfigSrc = app.isPackaged
-    ? join(process.resourcesPath, 'runtime-config')
-    : join(app.getAppPath(), 'runtime-config')
+  const runtimeConfigSrc = runtimeConfigSourceDir()
 
   const agentsSrc = join(runtimeConfigSrc, 'AGENTS.md')
   if (existsSync(agentsSrc)) {
@@ -154,6 +168,14 @@ export function copySkillsAndAgents(projectDirectory?: string | null) {
   const skillsDst = getManagedSkillsDir()
   const discoverableSkillsDst = getMachineSkillsDir()
   const runtimeSkillCatalog = getRuntimeSkillCatalogDir()
+  const skillSourceRoots = getBundledSkillRoots()
+  const configuredSkillNames = new Set(getConfiguredSkillsFromConfig().map((skill) => skill.sourceName))
+  pruneManagedSkillMirror({
+    discoverableSkillsDir: discoverableSkillsDst,
+    previousManagedSkillsDir: skillsDst,
+    configuredSkillNames,
+    findBundledSkillSource: (skillName) => findFirstBundledSkillSource(skillSourceRoots, skillName),
+  })
   rmSync(skillsDst, { recursive: true, force: true })
   rmSync(runtimeSkillCatalog, { recursive: true, force: true })
   mkdirSync(skillsDst, { recursive: true })
@@ -169,8 +191,8 @@ export function copySkillsAndAgents(projectDirectory?: string | null) {
     rmSync(legacyCwdSkills, { recursive: true, force: true })
   }
 
-  const skillSourceRoots = getBundledSkillRoots()
-  for (const skillName of Array.from(new Set(getConfiguredSkillsFromConfig().map((skill) => skill.sourceName)))) {
+  const copiedSkillNames: string[] = []
+  for (const skillName of Array.from(configuredSkillNames)) {
     const destination = join(skillsDst, skillName)
     const source = skillSourceRoots
       .map((root) => findBundledSkillDir(root, skillName))
@@ -189,7 +211,9 @@ export function copySkillsAndAgents(projectDirectory?: string | null) {
     // from ~/.config/opencode/skills.
     const discoverableDestination = join(discoverableSkillsDst, skillName)
     copySkillDirectory(source, discoverableDestination)
+    copiedSkillNames.push(skillName)
   }
+  writeManagedSkillMirrorNames(discoverableSkillsDst, copiedSkillNames)
 
   syncCustomAgentRuntimeGuidance({ directory: projectDirectory || undefined })
   const activeOverlayDirectory = syncProjectOverlayToRuntime(projectDirectory)

--- a/apps/desktop/src/main/runtime-skill-mirror.ts
+++ b/apps/desktop/src/main/runtime-skill-mirror.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto'
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'fs'
 import { join, relative } from 'path'
+import { readFileCheckedSync } from './fs-read.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
 import { log } from './logger.ts'
 
@@ -66,6 +67,20 @@ export function readManagedSkillMirrorNames(root: string): Set<string> {
   return new Set(normalizeSkillNames(names))
 }
 
+export function readCurrentManagedSkillMirrorNames(root: string): Set<string> {
+  const registry = readManagedSkillMirrorRegistry(root)
+  if (!registry?.skills?.length) return new Set()
+
+  const names = new Set<string>()
+  for (const skill of registry.skills) {
+    const currentFingerprint = fingerprintDirectory(join(root, skill.name))
+    if (currentFingerprint && currentFingerprint === skill.fingerprint) {
+      names.add(skill.name)
+    }
+  }
+  return names
+}
+
 export function writeManagedSkillMirrorNames(root: string, skillNames: string[]) {
   mkdirSync(root, { recursive: true })
   const names = normalizeSkillNames(skillNames)
@@ -119,7 +134,7 @@ function fingerprintDirectory(root: string) {
 
       hash.update(relative(root, path).replace(/\\/g, '/'))
       hash.update('\0')
-      hash.update(readFileSync(path))
+      hash.update(readFileCheckedSync(path).bytes)
       hash.update('\0')
       fileCount += 1
     }
@@ -139,9 +154,8 @@ export function pruneManagedSkillMirror(input: {
   discoverableSkillsDir: string
   previousManagedSkillsDir: string
   configuredSkillNames: Set<string>
-  findBundledSkillSource: (skillName: string) => string | null
 }) {
-  const { discoverableSkillsDir, previousManagedSkillsDir, configuredSkillNames, findBundledSkillSource } = input
+  const { discoverableSkillsDir, previousManagedSkillsDir, configuredSkillNames } = input
   if (!existsSync(discoverableSkillsDir)) return []
 
   const registry = readManagedSkillMirrorRegistry(discoverableSkillsDir)
@@ -156,7 +170,6 @@ export function pruneManagedSkillMirror(input: {
 
     const skillRoot = join(discoverableSkillsDir, entry.name)
     const previousManagedRoot = join(previousManagedSkillsDir, entry.name)
-    const bundledSource = findBundledSkillSource(entry.name)
     const currentFingerprint = registryFingerprints.has(entry.name)
       ? fingerprintDirectory(skillRoot)
       : null
@@ -166,11 +179,8 @@ export function pruneManagedSkillMirror(input: {
     )
     const generatedByPreviousMirror = existsSync(previousManagedRoot)
       && directoriesHaveSameContent(previousManagedRoot, skillRoot)
-    const generatedByBundledSource = bundledSource
-      ? directoriesHaveSameContent(bundledSource, skillRoot)
-      : false
 
-    if (!generatedByRegistry && !generatedByPreviousMirror && !generatedByBundledSource) {
+    if (!generatedByRegistry && !generatedByPreviousMirror) {
       continue
     }
 

--- a/apps/desktop/src/main/runtime-skill-mirror.ts
+++ b/apps/desktop/src/main/runtime-skill-mirror.ts
@@ -1,0 +1,186 @@
+import { createHash } from 'crypto'
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'fs'
+import { join, relative } from 'path'
+import { writeFileAtomic } from './fs-atomic.ts'
+import { log } from './logger.ts'
+
+const MANAGED_SKILL_MIRROR_REGISTRY = '.open-cowork-managed-skills.json'
+const MANAGED_SKILL_MIRROR_SCHEMA_VERSION = 1
+
+type ManagedSkillMirrorRegistry = {
+  schemaVersion: number
+  updatedAt: string
+  skillNames?: string[]
+  skills?: Array<{
+    name: string
+    fingerprint: string
+  }>
+}
+
+function registryPath(root: string) {
+  return join(root, MANAGED_SKILL_MIRROR_REGISTRY)
+}
+
+function normalizeSkillNames(value: unknown) {
+  if (!Array.isArray(value)) return []
+  return Array.from(new Set(
+    value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  )).sort((a, b) => a.localeCompare(b))
+}
+
+function readManagedSkillMirrorRegistry(root: string): ManagedSkillMirrorRegistry | null {
+  try {
+    const raw = JSON.parse(readFileSync(registryPath(root), 'utf-8')) as Partial<ManagedSkillMirrorRegistry>
+    return {
+      schemaVersion: typeof raw.schemaVersion === 'number' ? raw.schemaVersion : 0,
+      updatedAt: typeof raw.updatedAt === 'string' ? raw.updatedAt : '',
+      skillNames: normalizeSkillNames(raw.skillNames),
+      skills: Array.isArray(raw.skills)
+        ? raw.skills
+          .filter((entry): entry is { name: string; fingerprint: string } => (
+            typeof entry?.name === 'string'
+            && entry.name.trim().length > 0
+            && typeof entry.fingerprint === 'string'
+            && entry.fingerprint.trim().length > 0
+          ))
+          .map((entry) => ({ name: entry.name.trim(), fingerprint: entry.fingerprint.trim() }))
+          .sort((a, b) => a.name.localeCompare(b.name))
+        : [],
+    }
+  } catch {
+    return null
+  }
+}
+
+export function readManagedSkillMirrorNames(root: string): Set<string> {
+  const registry = readManagedSkillMirrorRegistry(root)
+  if (!registry) {
+    return new Set()
+  }
+  const names = registry.skills?.length
+    ? registry.skills.map((skill) => skill.name)
+    : registry.skillNames || []
+  return new Set(normalizeSkillNames(names))
+}
+
+export function writeManagedSkillMirrorNames(root: string, skillNames: string[]) {
+  mkdirSync(root, { recursive: true })
+  const names = normalizeSkillNames(skillNames)
+  const registry: ManagedSkillMirrorRegistry = {
+    schemaVersion: MANAGED_SKILL_MIRROR_SCHEMA_VERSION,
+    updatedAt: new Date().toISOString(),
+    skills: names
+      .map((name) => {
+        const fingerprint = fingerprintDirectory(join(root, name))
+        return fingerprint ? { name, fingerprint } : null
+      })
+      .filter((entry): entry is { name: string; fingerprint: string } => Boolean(entry)),
+  }
+  writeFileAtomic(registryPath(root), `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 })
+}
+
+function fingerprintDirectory(root: string) {
+  if (!existsSync(root)) return null
+
+  try {
+    if (!statSync(root).isDirectory()) return null
+  } catch {
+    return null
+  }
+
+  const hash = createHash('sha256')
+  let fileCount = 0
+
+  const visit = (current: string): boolean => {
+    let entries
+    try {
+      entries = readdirSync(current, { withFileTypes: true })
+    } catch {
+      return false
+    }
+
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const path = join(current, entry.name)
+      let stats
+      try {
+        stats = lstatSync(path)
+      } catch {
+        return false
+      }
+      if (stats.isSymbolicLink()) return false
+      if (stats.isDirectory()) {
+        if (!visit(path)) return false
+        continue
+      }
+      if (!stats.isFile()) continue
+
+      hash.update(relative(root, path).replace(/\\/g, '/'))
+      hash.update('\0')
+      hash.update(readFileSync(path))
+      hash.update('\0')
+      fileCount += 1
+    }
+    return true
+  }
+
+  return visit(root) ? `${fileCount}:${hash.digest('hex')}` : null
+}
+
+function directoriesHaveSameContent(left: string, right: string) {
+  const leftFingerprint = fingerprintDirectory(left)
+  if (!leftFingerprint) return false
+  return leftFingerprint === fingerprintDirectory(right)
+}
+
+export function pruneManagedSkillMirror(input: {
+  discoverableSkillsDir: string
+  previousManagedSkillsDir: string
+  configuredSkillNames: Set<string>
+  findBundledSkillSource: (skillName: string) => string | null
+}) {
+  const { discoverableSkillsDir, previousManagedSkillsDir, configuredSkillNames, findBundledSkillSource } = input
+  if (!existsSync(discoverableSkillsDir)) return []
+
+  const registry = readManagedSkillMirrorRegistry(discoverableSkillsDir)
+  const registryFingerprints = new Map(
+    (registry?.skills || []).map((entry) => [entry.name, entry.fingerprint] as const),
+  )
+  const pruned: string[] = []
+
+  for (const entry of readdirSync(discoverableSkillsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    if (configuredSkillNames.has(entry.name)) continue
+
+    const skillRoot = join(discoverableSkillsDir, entry.name)
+    const previousManagedRoot = join(previousManagedSkillsDir, entry.name)
+    const bundledSource = findBundledSkillSource(entry.name)
+    const currentFingerprint = registryFingerprints.has(entry.name)
+      ? fingerprintDirectory(skillRoot)
+      : null
+    const generatedByRegistry = Boolean(
+      currentFingerprint
+      && registryFingerprints.get(entry.name) === currentFingerprint,
+    )
+    const generatedByPreviousMirror = existsSync(previousManagedRoot)
+      && directoriesHaveSameContent(previousManagedRoot, skillRoot)
+    const generatedByBundledSource = bundledSource
+      ? directoriesHaveSameContent(bundledSource, skillRoot)
+      : false
+
+    if (!generatedByRegistry && !generatedByPreviousMirror && !generatedByBundledSource) {
+      continue
+    }
+
+    rmSync(skillRoot, { recursive: true, force: true })
+    pruned.push(entry.name)
+  }
+
+  if (pruned.length > 0) {
+    log('runtime', `Pruned stale managed skill mirror(s): ${pruned.sort((a, b) => a.localeCompare(b)).join(', ')}`)
+  }
+
+  return pruned
+}

--- a/tests/custom-skills.test.ts
+++ b/tests/custom-skills.test.ts
@@ -7,6 +7,7 @@ import { CUSTOM_SKILL_LIMITS } from '../apps/desktop/src/main/custom-content-lim
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { getMachineSkillsDir } from '../apps/desktop/src/main/runtime-paths.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
+import { writeManagedSkillMirrorNames } from '../apps/desktop/src/main/runtime-skill-mirror.ts'
 
 function testTempDir(prefix: string) {
   const parent = join(process.cwd(), '.open-cowork-test')
@@ -179,6 +180,38 @@ test('listCustomSkills skips bundles with too-deep supporting file paths', async
 
     const skills = listCustomSkills()
     assert.deepEqual(skills.map((skill) => skill.name), ['valid-skill'])
+  } finally {
+    closeLogger()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('listCustomSkills keeps edited machine skills even when the managed mirror registry is stale', async () => {
+  const root = testTempDir('opencowork-skill-list-registry-')
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  process.env.OPEN_COWORK_USER_DATA_DIR = join(root, 'user-data')
+  clearConfigCaches()
+
+  try {
+    saveCustomSkill({
+      scope: 'machine',
+      directory: null,
+      name: 'stale-generated',
+      content: '---\nname: stale-generated\ndescription: "Generated skill"\n---\n# Generated Skill',
+      files: [],
+    })
+    writeManagedSkillMirrorNames(getMachineSkillsDir(), ['stale-generated'])
+    writeFileSync(
+      join(getMachineSkillsDir(), 'stale-generated', 'SKILL.md'),
+      '---\nname: stale-generated\ndescription: "User edited skill"\n---\n# User Edited Skill',
+    )
+
+    const skills = listCustomSkills()
+    assert.equal(skills.some((skill) => skill.name === 'stale-generated'), true)
   } finally {
     closeLogger()
     await new Promise((resolve) => setTimeout(resolve, 20))

--- a/tests/runtime-content.test.ts
+++ b/tests/runtime-content.test.ts
@@ -143,3 +143,42 @@ test('copySkillsAndAgents preserves edited skill mirrors even when an old regist
     rmSync(root, { recursive: true, force: true })
   }
 })
+
+test('copySkillsAndAgents preserves custom skills that only match unconfigured bundled content', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-skill-mirror-template-'))
+  const configDir = join(root, 'config')
+  const downstreamRoot = join(root, 'downstream')
+  const downstreamSkills = join(downstreamRoot, 'skills')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousDownstreamRoot = process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  mkdirSync(configDir, { recursive: true })
+  mkdirSync(downstreamSkills, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({ skills: [] }, null, 2))
+  writeSkillBundle(downstreamSkills, 'template-skill', 'Template source')
+
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_DOWNSTREAM_ROOT = downstreamRoot
+  process.env.OPEN_COWORK_USER_DATA_DIR = join(root, 'user-data')
+  clearConfigCaches()
+
+  try {
+    writeSkillBundle(getMachineSkillsDir(), 'template-skill', 'Template source')
+
+    copySkillsAndAgents()
+
+    assert.equal(existsSync(join(getMachineSkillsDir(), 'template-skill', 'SKILL.md')), true)
+    assert.equal(listCustomSkills().some((skill) => skill.name === 'template-skill'), true)
+  } finally {
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousDownstreamRoot === undefined) delete process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+    else process.env.OPEN_COWORK_DOWNSTREAM_ROOT = previousDownstreamRoot
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/tests/runtime-content.test.ts
+++ b/tests/runtime-content.test.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { writeRuntimeAgentsFile } from '../apps/desktop/src/main/runtime-content.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { listEffectiveSkillsSync } from '../apps/desktop/src/main/effective-skills.ts'
+import { listCustomSkills } from '../apps/desktop/src/main/native-customizations.ts'
+import { getMachineSkillsDir, getManagedSkillsDir } from '../apps/desktop/src/main/runtime-paths.ts'
+import { copySkillsAndAgents, writeRuntimeAgentsFile } from '../apps/desktop/src/main/runtime-content.ts'
+import { writeManagedSkillMirrorNames } from '../apps/desktop/src/main/runtime-skill-mirror.ts'
 
 test('writeRuntimeAgentsFile writes the runtime AGENTS mirror privately', () => {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-runtime-agents-'))
@@ -19,6 +24,122 @@ test('writeRuntimeAgentsFile writes the runtime AGENTS mirror privately', () => 
     assert.equal(readFileSync(outputPath, 'utf-8'), '# Runtime Instructions\n')
     assert.equal(statSync(outputPath).mode & 0o777, 0o600)
   } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function writeSkillBundle(root: string, name: string, description: string) {
+  const directory = join(root, name)
+  mkdirSync(directory, { recursive: true })
+  writeFileSync(
+    join(directory, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${description}\n---\n# ${description}\n`,
+  )
+  writeFileSync(join(directory, 'notes.md'), `${description}\n`)
+}
+
+test('copySkillsAndAgents prunes stale generated skill mirrors without deleting user custom skills', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-skill-mirror-'))
+  const configDir = join(root, 'config')
+  const downstreamRoot = join(root, 'downstream')
+  const downstreamSkills = join(downstreamRoot, 'skills')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousDownstreamRoot = process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  mkdirSync(configDir, { recursive: true })
+  mkdirSync(downstreamSkills, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({
+    skills: [
+      {
+        name: 'Keep Skill',
+        description: 'Still configured.',
+        badge: 'Skill',
+        sourceName: 'keep-skill',
+        toolIds: [],
+      },
+    ],
+  }, null, 2))
+  writeSkillBundle(downstreamSkills, 'keep-skill', 'Still configured')
+  writeSkillBundle(downstreamSkills, 'stale-skill', 'Removed from config')
+
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_DOWNSTREAM_ROOT = downstreamRoot
+  process.env.OPEN_COWORK_USER_DATA_DIR = join(root, 'user-data')
+  clearConfigCaches()
+
+  try {
+    writeSkillBundle(getMachineSkillsDir(), 'stale-skill', 'Removed from config')
+    writeSkillBundle(getManagedSkillsDir(), 'stale-skill', 'Removed from config')
+    writeSkillBundle(getMachineSkillsDir(), 'user-skill', 'User-authored custom skill')
+
+    copySkillsAndAgents()
+
+    assert.equal(existsSync(join(getMachineSkillsDir(), 'keep-skill', 'SKILL.md')), true)
+    assert.equal(existsSync(join(getMachineSkillsDir(), 'stale-skill')), false)
+    assert.equal(existsSync(join(getMachineSkillsDir(), 'user-skill', 'SKILL.md')), true)
+
+    const customSkillNames = listCustomSkills().map((skill) => skill.name)
+    assert.deepEqual(customSkillNames, ['user-skill'])
+
+    const effectiveSkillNames = listEffectiveSkillsSync().map((skill) => skill.name)
+    assert.equal(effectiveSkillNames.includes('keep-skill'), true)
+    assert.equal(effectiveSkillNames.includes('user-skill'), true)
+    assert.equal(effectiveSkillNames.includes('stale-skill'), false)
+  } finally {
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousDownstreamRoot === undefined) delete process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+    else process.env.OPEN_COWORK_DOWNSTREAM_ROOT = previousDownstreamRoot
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('copySkillsAndAgents preserves edited skill mirrors even when an old registry named them', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-skill-mirror-edit-'))
+  const configDir = join(root, 'config')
+  const downstreamRoot = join(root, 'downstream')
+  const downstreamSkills = join(downstreamRoot, 'skills')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousDownstreamRoot = process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  mkdirSync(configDir, { recursive: true })
+  mkdirSync(downstreamSkills, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({ skills: [] }, null, 2))
+  writeSkillBundle(downstreamSkills, 'stale-skill', 'Generated source')
+
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_DOWNSTREAM_ROOT = downstreamRoot
+  process.env.OPEN_COWORK_USER_DATA_DIR = join(root, 'user-data')
+  clearConfigCaches()
+
+  try {
+    writeSkillBundle(getMachineSkillsDir(), 'stale-skill', 'Generated source')
+    writeManagedSkillMirrorNames(getMachineSkillsDir(), ['stale-skill'])
+    writeSkillBundle(getManagedSkillsDir(), 'stale-skill', 'Generated source')
+    writeFileSync(
+      join(getMachineSkillsDir(), 'stale-skill', 'SKILL.md'),
+      '---\nname: stale-skill\ndescription: User edited skill\n---\n# User edited skill\n',
+    )
+
+    copySkillsAndAgents()
+
+    assert.equal(existsSync(join(getMachineSkillsDir(), 'stale-skill', 'SKILL.md')), true)
+    assert.equal(listCustomSkills().some((skill) => skill.name === 'stale-skill'), true)
+  } finally {
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousDownstreamRoot === undefined) delete process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+    else process.env.OPEN_COWORK_DOWNSTREAM_ROOT = previousDownstreamRoot
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
     rmSync(root, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary
- add a managed skill mirror registry with per-bundle fingerprints for generated OpenCode-compatible skill mirrors
- prune stale generated mirrors when downstream configured skills shrink, while preserving user-authored or edited machine custom skills
- skip current generated mirrors in custom skill enumeration so bundled skills do not reappear as user custom skills

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/runtime-content.test.ts tests/effective-skills.test.ts tests/custom-skills.test.ts tests/runtime-config-builder.test.ts tests/capability-catalog.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- git diff --check

Fixes #274