### PR TITLE
[codex] add dream run review actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ release is planned for `v0.0.1`.
   proposal, dream-run, and policy counts.
 - Improvement Inbox review actions in Pulse for proposed memories and
   improvement proposals, backed by typed IPC and durable store coverage.
+- Improvement Inbox controls for dream runs so users can cancel running
+  consolidation work or archive failed runs after review.
 - Pulse operations visibility for durable queue items, run authority, queue
   alerts, and derived high-risk/write-capable capability metadata.
 - Crew runs now enter the durable operations queue before dispatching to

--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -53,7 +53,7 @@ const PRIVACY_CLASSIFICATIONS = new Set<MemoryPrivacyClassification>(['public', 
 const EVIDENCE_KINDS = new Set<ImprovementEvidenceKind>(['run', 'artifact', 'eval', 'trace', 'thread', 'session', 'sop', 'crew'])
 const PROPOSAL_TARGET_TYPES = new Set<ImprovementProposalTargetType>(['memory', 'agent', 'skill', 'sop', 'crew', 'eval_case', 'routing', 'policy'])
 const PROPOSAL_STATUSES = new Set<ImprovementProposalStatus>(['proposed', 'approved', 'rejected', 'archived'])
-const DREAM_RUN_STATUSES = new Set<DreamRunStatus>(['running', 'completed', 'failed', 'cancelled'])
+const DREAM_RUN_STATUSES = new Set<DreamRunStatus>(['running', 'completed', 'failed', 'cancelled', 'archived'])
 
 export class ImprovementProposalPolicyDisabledError extends Error {
   constructor() {
@@ -82,6 +82,7 @@ function emptyDreamRunStatusCounts(): DreamRunStatusCounts {
     completed: 0,
     failed: 0,
     cancelled: 0,
+    archived: 0,
   }
 }
 
@@ -589,10 +590,10 @@ export function listImprovementReviewQueue(options: { limit?: number } = {}): Im
   const dreamRows = db.prepare(`
     select *
     from dream_runs
-    where status in (?, ?)
+    where status in (?, ?, ?)
     order by updated_at desc, id asc
     limit ?
-  `).all('running', 'failed', limit) as DbRow[]
+  `).all('running', 'failed', 'cancelled', limit) as DbRow[]
 
   return {
     memory: memoryRows.map(rowToMemoryEntry),
@@ -801,6 +802,23 @@ export function cancelDreamRun(id: string, note = 'Dream run cancelled.') {
     where id = ?
   `).run('cancelled', boundedText(note, 'Dream cancellation note', 4096), now, now, id)
   return getDreamRun(id)
+}
+
+export function archiveDreamRun(id: string, note = 'Dream run archived.') {
+  return withImprovementTransaction(() => {
+    const run = getDreamRun(id)
+    if (!run) return null
+    if (run.status === 'running') throw new Error('Running dream runs must be cancelled before archiving.')
+    if (run.status === 'completed') throw new Error('Completed dream runs are retained as governed learning history.')
+    if (run.status === 'archived') return run
+    const now = nowIso()
+    getImprovementDb().prepare(`
+      update dream_runs
+      set status = ?, error = coalesce(error, ?), updated_at = ?
+      where id = ?
+    `).run('archived', boundedText(note, 'Dream archive note', 4096), now, id)
+    return getDreamRun(id)
+  })
 }
 
 export function buildMemoryInjectionPlan(

--- a/apps/desktop/src/main/ipc/improvement-handlers.ts
+++ b/apps/desktop/src/main/ipc/improvement-handlers.ts
@@ -3,8 +3,10 @@ import {
   approveAgentMemoryEntry,
   approveImprovementProposal,
   archiveAgentMemoryEntry,
+  archiveDreamRun,
   archiveImprovementProposal,
   buildImprovementDiagnosticsSummary,
+  cancelDreamRun,
   listImprovementReviewQueue,
   rejectAgentMemoryEntry,
   rejectImprovementProposal,
@@ -91,5 +93,13 @@ export function registerImprovementHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('improvements:proposal-archive', async (_event, id: unknown, note?: unknown) => {
     return archiveImprovementProposal(assertString(id, 'Improvement proposal id'), 'local-user', optionalNote(note))
+  })
+
+  context.ipcMain.handle('improvements:dream-cancel', async (_event, id: unknown, note?: unknown) => {
+    return cancelDreamRun(assertString(id, 'Dream run id'), optionalNote(note) || undefined)
+  })
+
+  context.ipcMain.handle('improvements:dream-archive', async (_event, id: unknown, note?: unknown) => {
+    return archiveDreamRun(assertString(id, 'Dream run id'), optionalNote(note) || undefined)
   })
 }

--- a/apps/desktop/src/main/ipc/thread-handlers.ts
+++ b/apps/desktop/src/main/ipc/thread-handlers.ts
@@ -42,19 +42,17 @@ export function registerThreadHandlers(context: IpcHandlerContext) {
     return threads().deleteTag(tagId)
   })
 
-  context.ipcMain.handle('threads:tags:apply', async (_event, sessionIds: unknown, tagIds: unknown) => (
-    threads().applyTags(
-      requireStringArray(sessionIds, 'sessionIds'),
-      requireStringArray(tagIds, 'tagIds', THREAD_FILTER_MAX_VALUES),
-    )
-  ))
+  context.ipcMain.handle('threads:tags:apply', async (_event, sessionIds: unknown, tagIds: unknown) => {
+    const normalizedSessionIds = requireStringArray(sessionIds, 'sessionIds')
+    const normalizedTagIds = requireStringArray(tagIds, 'tagIds', THREAD_FILTER_MAX_VALUES)
+    return threads().applyTags(normalizedSessionIds, normalizedTagIds)
+  })
 
-  context.ipcMain.handle('threads:tags:remove', async (_event, sessionIds: unknown, tagIds: unknown) => (
-    threads().removeTags(
-      requireStringArray(sessionIds, 'sessionIds'),
-      requireStringArray(tagIds, 'tagIds', THREAD_FILTER_MAX_VALUES),
-    )
-  ))
+  context.ipcMain.handle('threads:tags:remove', async (_event, sessionIds: unknown, tagIds: unknown) => {
+    const normalizedSessionIds = requireStringArray(sessionIds, 'sessionIds')
+    const normalizedTagIds = requireStringArray(tagIds, 'tagIds', THREAD_FILTER_MAX_VALUES)
+    return threads().removeTags(normalizedSessionIds, normalizedTagIds)
+  })
 
   context.ipcMain.handle('threads:smart-filters:list', async () => (
     threads().listSmartFilters()
@@ -94,6 +92,7 @@ export function registerThreadHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('threads:reindex', async (_event, sessionIds?: unknown) => {
     if (sessionIds === undefined || sessionIds === null) return threads().reindex()
-    return threads().reindex(requireStringArray(sessionIds, 'sessionIds'))
+    const normalizedSessionIds = requireStringArray(sessionIds, 'sessionIds')
+    return threads().reindex(normalizedSessionIds)
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -90,6 +90,8 @@ const PRELOAD_INVOKE_CHANNELS = [
   'improvements:proposal-approve',
   'improvements:proposal-reject',
   'improvements:proposal-archive',
+  'improvements:dream-cancel',
+  'improvements:dream-archive',
   'updates:install-capability',
   'updates:check-installable',
   'updates:download',
@@ -312,6 +314,8 @@ const api: CoworkAPI = {
     approveProposal: (id, note) => invoke('improvements:proposal-approve', id, note),
     rejectProposal: (id, note) => invoke('improvements:proposal-reject', id, note),
     archiveProposal: (id, note) => invoke('improvements:proposal-archive', id, note),
+    cancelDreamRun: (id, note) => invoke('improvements:dream-cancel', id, note),
+    archiveDreamRun: (id, note) => invoke('improvements:dream-archive', id, note),
   },
   updates: {
     installCapability: () => invoke('updates:install-capability'),

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
@@ -7,6 +7,8 @@ export type PulseImprovementReviewAction =
   | 'approve-proposal'
   | 'reject-proposal'
   | 'archive-proposal'
+  | 'cancel-dream'
+  | 'archive-dream'
 
 interface PulseImprovementInboxProps {
   inbox: ImprovementReviewQueue | null
@@ -137,6 +139,25 @@ export function PulseImprovementInbox({ inbox, actionId, onReview }: PulseImprov
           </div>
           <div className="mt-2 text-[12px] font-medium text-text">{run.title}</div>
           {run.error ? <div className="mt-1 line-clamp-2 text-[11px] text-text-secondary leading-relaxed">{run.error}</div> : null}
+          <div className="mt-3 flex flex-wrap gap-2">
+            {run.status === 'running' ? (
+              <ReviewButton
+                actionId={`cancel-dream:${run.id}`}
+                currentActionId={actionId}
+                label={t('homepage.card.cancel', 'Cancel')}
+                onClick={() => onReview(run.id, 'cancel-dream')}
+              />
+            ) : null}
+            {run.status === 'failed' || run.status === 'cancelled' ? (
+              <ReviewButton
+                actionId={`archive-dream:${run.id}`}
+                currentActionId={actionId}
+                label={t('homepage.card.archive', 'Archive')}
+                tone="muted"
+                onClick={() => onReview(run.id, 'archive-dream')}
+              />
+            ) : null}
+          </div>
         </div>
       ))}
     </div>

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -392,6 +392,7 @@ const improvementSummary: ImprovementDiagnosticsSummary = {
     completed: 2,
     failed: 1,
     cancelled: 0,
+    archived: 0,
   },
   policy: {
     proposalsEnabled: true,
@@ -519,6 +520,7 @@ function installPulseApi(options: {
   improvementInbox?: ReturnType<typeof vi.fn>
   approveProposal?: ReturnType<typeof vi.fn>
   rejectMemory?: ReturnType<typeof vi.fn>
+  archiveDreamRun?: ReturnType<typeof vi.fn>
 } = {}) {
   return installRendererTestCoworkApi({
     runtime: {
@@ -570,6 +572,8 @@ function installPulseApi(options: {
       approveProposal: options.approveProposal || vi.fn(async () => null),
       rejectProposal: vi.fn(async () => null),
       archiveProposal: vi.fn(async () => null),
+      cancelDreamRun: vi.fn(async () => null),
+      archiveDreamRun: options.archiveDreamRun || vi.fn(async () => null),
     },
     session: {
       create: options.createSession || vi.fn(async (directory?: string) => ({
@@ -681,7 +685,8 @@ describe('PulsePage', () => {
     const user = userEvent.setup()
     const approveProposal = vi.fn(async () => null)
     const rejectMemory = vi.fn(async () => null)
-    const api = installPulseApi({ approveProposal, rejectMemory })
+    const archiveDreamRun = vi.fn(async () => null)
+    const api = installPulseApi({ approveProposal, rejectMemory, archiveDreamRun })
 
     render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
     await screen.findByText('Tighten analyst memory')
@@ -695,6 +700,9 @@ describe('PulsePage', () => {
     const rejectButtons = screen.getAllByRole('button', { name: 'Reject' })
     await user.click(rejectButtons[1]!)
     await waitFor(() => expect(rejectMemory).toHaveBeenCalledWith('memory-1'))
+
+    await user.click(screen.getAllByRole('button', { name: 'Archive' }).at(-1)!)
+    await waitFor(() => expect(archiveDreamRun).toHaveBeenCalledWith('dream-1'))
   })
 
   it('opens recent threads through the existing session-loading path', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -331,7 +331,9 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
       else if (action === 'reject-memory') await window.coworkApi.improvements.rejectMemory(id)
       else if (action === 'approve-proposal') await window.coworkApi.improvements.approveProposal(id)
       else if (action === 'reject-proposal') await window.coworkApi.improvements.rejectProposal(id)
-      else await window.coworkApi.improvements.archiveProposal(id)
+      else if (action === 'archive-proposal') await window.coworkApi.improvements.archiveProposal(id)
+      else if (action === 'cancel-dream') await window.coworkApi.improvements.cancelDreamRun(id)
+      else await window.coworkApi.improvements.archiveDreamRun(id)
       await refreshDiagnostics({ silent: true })
     } catch (error) {
       addGlobalError(t('pulse.improvementReviewFailed', 'Could not update the Improvement Inbox item. Please try again.'))
@@ -588,7 +590,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                       items={[
                         { label: t('homepage.card.pendingImprovements', 'Pending review'), value: formatInteger.format(pendingImprovementItems), tone: pendingImprovementItems > 0 ? 'accent' : undefined },
                         { label: t('homepage.card.approvedMemory', 'Approved memory'), value: formatInteger.format(improvementSummary?.memory.approved || 0) },
-                        { label: t('homepage.card.dreamRuns', 'Dream runs'), value: formatInteger.format((improvementSummary?.dreamRuns.running || 0) + (improvementSummary?.dreamRuns.completed || 0) + (improvementSummary?.dreamRuns.failed || 0) + (improvementSummary?.dreamRuns.cancelled || 0)) },
+                        { label: t('homepage.card.dreamRuns', 'Dream runs'), value: formatInteger.format((improvementSummary?.dreamRuns.running || 0) + (improvementSummary?.dreamRuns.completed || 0) + (improvementSummary?.dreamRuns.failed || 0) + (improvementSummary?.dreamRuns.cancelled || 0) + (improvementSummary?.dreamRuns.archived || 0)) },
                         { label: t('homepage.card.policyBlocks', 'Policy blocks'), value: formatInteger.format(learningDisabledScopes) },
                       ]}
                     />

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -259,6 +259,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
           completed: 0,
           failed: 0,
           cancelled: 0,
+          archived: 0,
         },
         policy: {
           proposalsEnabled: true,
@@ -279,6 +280,8 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       approveProposal: vi.fn(async () => null),
       rejectProposal: vi.fn(async () => null),
       archiveProposal: vi.fn(async () => null),
+      cancelDreamRun: vi.fn(async () => null),
+      archiveDreamRun: vi.fn(async () => null),
     },
     settings: {
       get: vi.fn(async () => createDefaultSettings()),

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -9,7 +9,7 @@ export type ImprovementProposalTargetType = 'memory' | 'agent' | 'skill' | 'sop'
 export type ImprovementEvidenceKind = 'run' | 'artifact' | 'eval' | 'trace' | 'thread' | 'session' | 'sop' | 'crew'
 export type ImprovementDiffOperation = 'create' | 'update' | 'delete'
 export type MemoryPrivacyClassification = 'public' | 'internal' | 'sensitive' | 'restricted'
-export type DreamRunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
+export type DreamRunStatus = 'running' | 'completed' | 'failed' | 'cancelled' | 'archived'
 
 export interface ImprovementSchemaVersionedRecord {
   schemaVersion: number
@@ -145,6 +145,7 @@ export interface DreamRunStatusCounts {
   completed: number
   failed: number
   cancelled: number
+  archived: number
 }
 
 export interface ImprovementPolicyDiagnostics {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -118,6 +118,7 @@ import type {
   ImprovementProposalDraft,
   ImprovementReviewQueue,
   AgentMemoryEntry,
+  DreamRun,
 } from './improvements.js'
 import type {
   CapabilityRiskMetadata,
@@ -315,6 +316,8 @@ export interface CoworkAPI {
     approveProposal: (id: string, note?: string) => Promise<ImprovementProposal | null>
     rejectProposal: (id: string, note?: string) => Promise<ImprovementProposal | null>
     archiveProposal: (id: string, note?: string) => Promise<ImprovementProposal | null>
+    cancelDreamRun: (id: string, note?: string) => Promise<DreamRun | null>
+    archiveDreamRun: (id: string, note?: string) => Promise<DreamRun | null>
   }
   updates: {
     installCapability: () => Promise<UpdateInstallCapability>

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -14,10 +14,12 @@ import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
 import {
   IMPROVEMENT_STORE_SCHEMA_VERSION,
+  archiveDreamRun,
   approveAgentMemoryEntry,
   approveImprovementProposal,
   buildImprovementDiagnosticsSummary,
   buildMemoryInjectionPlan,
+  cancelDreamRun,
   clearImprovementStoreCache,
   completeDreamRun,
   createAgentMemoryProposal,
@@ -339,11 +341,23 @@ test('improvement review queue lists pending items and edits proposed diffs befo
     instructions: 'Look for duplicates.',
     sourceMemoryEntryIds: [memory.id],
   })
+  const failedDream = startDreamRun({
+    title: 'Failed consolidation',
+    instructions: 'Leave failed output inspectable.',
+    sourceMemoryEntryIds: [memory.id],
+  })
+  failDreamRun(failedDream.id, 'Provider unavailable.')
+  const cancelledDream = startDreamRun({
+    title: 'Cancelled consolidation',
+    instructions: 'Leave cancelled output dismissable.',
+    sourceMemoryEntryIds: [memory.id],
+  })
+  cancelDreamRun(cancelledDream.id, 'Reviewer stopped the run.')
 
   const queue = listImprovementReviewQueue()
   assert.deepEqual(queue.memory.map((entry) => entry.id), [memory.id])
   assert.deepEqual(queue.proposals.map((entry) => entry.id), [proposal.id])
-  assert.deepEqual(queue.dreamRuns.map((entry) => entry.id), [dream.id])
+  assert.deepEqual(new Set(queue.dreamRuns.map((entry) => entry.id)), new Set([dream.id, failedDream.id, cancelledDream.id]))
 
   const edited = updateImprovementProposal(proposal.id, {
     targetType: 'memory',
@@ -432,6 +446,47 @@ test('failed dream runs remain inspectable without changing source memory', () =
   assert.deepEqual(getDreamRun(dream.id)?.sourceMemoryEntryIds, [memory.id])
   assert.equal(afterFailure?.contentHash, beforeFailure?.contentHash)
   assert.equal(afterFailure?.status, beforeFailure?.status)
+}))
+
+test('dream runs can be cancelled or archived without mutating source memory', () => withImprovementStore('dream-review', () => {
+  const memory = createAgentMemoryProposal(memoryDraft())
+  approveAgentMemoryEntry(memory.id, 'local-user')
+  const beforeReview = getAgentMemoryEntry(memory.id)
+
+  const running = startDreamRun({
+    title: 'Running consolidation',
+    instructions: 'Collect candidates only.',
+    sourceMemoryEntryIds: [memory.id],
+  })
+  const cancelled = cancelDreamRun(running.id, 'User stopped the consolidation.')
+  assert.equal(cancelled?.status, 'cancelled')
+  assert.equal(cancelled?.error, 'User stopped the consolidation.')
+
+  const failed = startDreamRun({
+    title: 'Failed consolidation',
+    instructions: 'Collect candidates only.',
+    sourceMemoryEntryIds: [memory.id],
+  })
+  failDreamRun(failed.id, 'Provider unavailable.')
+  const archived = archiveDreamRun(failed.id, 'Dismissed after review.')
+  const afterReview = getAgentMemoryEntry(memory.id)
+
+  assert.equal(archived?.status, 'archived')
+  assert.equal(archived?.error, 'Provider unavailable.')
+  assert.equal(afterReview?.contentHash, beforeReview?.contentHash)
+  assert.equal(afterReview?.status, beforeReview?.status)
+  assert.throws(() => archiveDreamRun(startDreamRun({
+    title: 'Still running',
+    instructions: 'Do not archive active work.',
+    sourceMemoryEntryIds: [memory.id],
+  }).id), /Running dream runs must be cancelled before archiving/)
+  const completed = startDreamRun({
+    title: 'Completed consolidation',
+    instructions: 'Keep completed learning history.',
+    sourceMemoryEntryIds: [memory.id],
+  })
+  completeDreamRun(completed.id)
+  assert.throws(() => archiveDreamRun(completed.id), /Completed dream runs are retained/)
 }))
 
 test('improvement diagnostics summarize policy, review queues, and memory injection', () => withImprovementStore('diagnostics-summary', () => {

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -128,6 +128,8 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('improvements:memory-approve'), true)
   assert.equal(handlers.has('improvements:proposal-update'), true)
   assert.equal(handlers.has('improvements:proposal-approve'), true)
+  assert.equal(handlers.has('improvements:dream-cancel'), true)
+  assert.equal(handlers.has('improvements:dream-archive'), true)
   assert.equal(handlers.has('sops:list'), true)
   assert.equal(handlers.has('sops:save-from-automation-run'), true)
   assert.equal(handlers.has('sops:run-now'), true)


### PR DESCRIPTION
## Summary
- add typed Improvement Inbox actions for cancelling running dream runs and archiving failed or cancelled dream runs after review
- persist archived dream-run status in the governed learning store and diagnostics, while retaining completed dream runs as learning history
- route the actions through shared CoworkAPI types, preload allowlist, IPC handlers, and Pulse refresh behavior

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-store.test.ts tests/ipc-handler-registration.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm build
- pnpm docs:build
- pnpm test:e2e
- git diff --check

Refs #247