### PR TITLE
[codex] add scheduled dream consolidation

### DIFF
--- a/apps/desktop/src/main/automation-service.ts
+++ b/apps/desktop/src/main/automation-service.ts
@@ -57,6 +57,7 @@ import {
 import { dispatchRunnableAutomationQueueItems, startAutomationRun } from './automation-run-starter.ts'
 import { syncAutomationOperationalQueueStatus } from './automation-operational-queue.ts'
 import { deliverAutomationDesktopUpdate } from './automation-delivery.ts'
+import { runScheduledDreamConsolidationTick } from './improvement-dream-scheduler.ts'
 import { ensureRuntimeContextDirectory } from './runtime-context.ts'
 import { getClientForDirectory } from './runtime.ts'
 import { loadSettings } from './settings.ts'
@@ -107,6 +108,10 @@ async function dispatchQueuedAutomationRuns() {
   }
 }
 
+async function maybeRunScheduledDreamConsolidation(now = new Date()) {
+  await runScheduledDreamConsolidationTick(now)
+}
+
 export function configureAutomationService(options: {
   getMainWindow: () => BrowserWindow | null
 }) {
@@ -132,6 +137,7 @@ export async function runAutomationServiceTick(now = new Date()) {
   await maybeEnforceRunTimeLimits(now)
   await maybeRunAutomationScheduler(now)
   await maybeRunHeartbeatReviews(now)
+  await maybeRunScheduledDreamConsolidation(now)
   await dispatchQueuedAutomationRuns()
 }
 

--- a/apps/desktop/src/main/improvement-dream-runner.ts
+++ b/apps/desktop/src/main/improvement-dream-runner.ts
@@ -53,6 +53,11 @@ export type DreamRuntimeDriver = {
   }>
 }
 
+type DreamConsolidationRunOptions = {
+  title: string
+  failWhenNoSourceMemories: boolean
+}
+
 function sha256Text(value: string) {
   return `sha256:${createHash('sha256').update(value).digest('hex')}`
 }
@@ -256,17 +261,20 @@ export function createOpenCodeDreamRuntimeDriver(): DreamRuntimeDriver {
   }
 }
 
-export async function runManualDreamConsolidation(
+async function runDreamConsolidation(
+  options: DreamConsolidationRunOptions,
   driver: DreamRuntimeDriver = createOpenCodeDreamRuntimeDriver(),
-): Promise<DreamRun> {
+): Promise<DreamRun | null> {
   const existingRun = getRunningDreamRun()
   if (existingRun) return existingRun
 
   const sourceMemories = selectDreamSourceMemories()
+  if (sourceMemories.length === 0 && !options.failWhenNoSourceMemories) return null
+
   const prompt = buildDreamPrompt(sourceMemories)
   const settings = getEffectiveSettings()
   const run = startDreamRun({
-    title: 'Manual memory consolidation',
+    title: options.title,
     modelId: settings.effectiveModel || null,
     instructions: prompt,
     sourceMemoryEntryIds: sourceMemories.map((memory) => memory.id),
@@ -305,4 +313,22 @@ export async function runManualDreamConsolidation(
   } catch (error) {
     return failDreamRun(run.id, error instanceof Error ? error.message : String(error))!
   }
+}
+
+export async function runManualDreamConsolidation(
+  driver: DreamRuntimeDriver = createOpenCodeDreamRuntimeDriver(),
+): Promise<DreamRun> {
+  return (await runDreamConsolidation({
+    title: 'Manual memory consolidation',
+    failWhenNoSourceMemories: true,
+  }, driver))!
+}
+
+export async function runScheduledDreamConsolidation(
+  driver: DreamRuntimeDriver = createOpenCodeDreamRuntimeDriver(),
+): Promise<DreamRun | null> {
+  return runDreamConsolidation({
+    title: 'Scheduled memory consolidation',
+    failWhenNoSourceMemories: false,
+  }, driver)
 }

--- a/apps/desktop/src/main/improvement-dream-scheduler.ts
+++ b/apps/desktop/src/main/improvement-dream-scheduler.ts
@@ -1,0 +1,54 @@
+import type { AppSettings, DreamRun } from '@open-cowork/shared'
+import {
+  getLatestDreamRun,
+  getRunningDreamRun,
+} from './improvement-store.ts'
+import { runScheduledDreamConsolidation, type DreamRuntimeDriver } from './improvement-dream-runner.ts'
+import { loadSettings } from './settings.ts'
+import { log } from './logger.ts'
+
+const MIN_DREAM_CONSOLIDATION_INTERVAL_HOURS = 24
+const MAX_DREAM_CONSOLIDATION_INTERVAL_HOURS = 720
+
+function clampIntervalHours(value: number) {
+  if (!Number.isFinite(value)) return 168
+  return Math.max(
+    MIN_DREAM_CONSOLIDATION_INTERVAL_HOURS,
+    Math.min(MAX_DREAM_CONSOLIDATION_INTERVAL_HOURS, Math.floor(value)),
+  )
+}
+
+function parseRunStartedAt(run: DreamRun | null) {
+  if (!run) return null
+  const timestamp = Date.parse(run.startedAt)
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+export function isScheduledDreamConsolidationDue(
+  settings: AppSettings,
+  latestRun: DreamRun | null,
+  now = new Date(),
+) {
+  if (!settings.improvementProposalsEnabled) return false
+  if (!settings.dreamConsolidationScheduleEnabled) return false
+  const latestStartedAt = parseRunStartedAt(latestRun)
+  if (!latestStartedAt) return true
+  const intervalMs = clampIntervalHours(settings.dreamConsolidationIntervalHours) * 60 * 60 * 1000
+  return now.getTime() - latestStartedAt >= intervalMs
+}
+
+export async function runScheduledDreamConsolidationTick(
+  now = new Date(),
+  driver?: DreamRuntimeDriver,
+  settings: AppSettings = loadSettings(),
+) {
+  if (getRunningDreamRun()) return null
+  const latestRun = getLatestDreamRun()
+  if (!isScheduledDreamConsolidationDue(settings, latestRun, now)) return null
+  try {
+    return await runScheduledDreamConsolidation(driver)
+  } catch (error) {
+    log('improvement', `Scheduled dream consolidation failed: ${error instanceof Error ? error.message : String(error)}`)
+    return null
+  }
+}

--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -770,6 +770,16 @@ export function getRunningDreamRun() {
   return row ? rowToDreamRun(row) : null
 }
 
+export function getLatestDreamRun() {
+  const row = getImprovementDb().prepare(`
+    select *
+    from dream_runs
+    order by started_at desc, id asc
+    limit 1
+  `).get() as DbRow | undefined
+  return row ? rowToDreamRun(row) : null
+}
+
 export function completeDreamRun(
   id: string,
   options: {

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -27,7 +27,7 @@ export type { AgentColor }
 
 let settingsCache: AppSettings | null = null
 
-export const SETTINGS_SCHEMA_VERSION = 4
+export const SETTINGS_SCHEMA_VERSION = 5
 
 type NativePermissionDefault = RuntimePermissionPolicy
 const MAX_SETTINGS_MAP_ENTRIES = 64
@@ -145,6 +145,8 @@ function createDefaults(): AppSettings {
     improvementProposalsDisabledAgents: {},
     improvementProposalsDisabledProjects: {},
     improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: false,
+    dreamConsolidationIntervalHours: 168,
   }
 }
 
@@ -286,6 +288,9 @@ function normalizeSettingsUpdate(settings: Partial<AppSettings>) {
   if (settings.improvementProposalsDisabledAgents !== undefined) update.improvementProposalsDisabledAgents = normalizeBoolMap(settings.improvementProposalsDisabledAgents)
   if (settings.improvementProposalsDisabledProjects !== undefined) update.improvementProposalsDisabledProjects = normalizeBoolMap(settings.improvementProposalsDisabledProjects)
   if (settings.improvementProposalsDisabledCrews !== undefined) update.improvementProposalsDisabledCrews = normalizeBoolMap(settings.improvementProposalsDisabledCrews)
+  if (typeof settings.dreamConsolidationScheduleEnabled === 'boolean') update.dreamConsolidationScheduleEnabled = settings.dreamConsolidationScheduleEnabled
+  const dreamConsolidationIntervalHours = normalizeInteger(settings.dreamConsolidationIntervalHours, 24, 720)
+  if (dreamConsolidationIntervalHours !== undefined) update.dreamConsolidationIntervalHours = dreamConsolidationIntervalHours
   return update
 }
 
@@ -350,6 +355,8 @@ function migrateLegacySettings(raw: any): AppSettings {
     improvementProposalsDisabledAgents: normalizeBoolMap(raw?.improvementProposalsDisabledAgents),
     improvementProposalsDisabledProjects: normalizeBoolMap(raw?.improvementProposalsDisabledProjects),
     improvementProposalsDisabledCrews: normalizeBoolMap(raw?.improvementProposalsDisabledCrews),
+    dreamConsolidationScheduleEnabled: raw?.dreamConsolidationScheduleEnabled === true,
+    dreamConsolidationIntervalHours: normalizeInteger(raw?.dreamConsolidationIntervalHours, 24, 720) || defaults.dreamConsolidationIntervalHours,
   }
 
   const legacyProviderCredentials = next.providerCredentials['google-vertex']

--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -266,6 +266,8 @@ const completeSettings: EffectiveAppSettings = {
   improvementProposalsDisabledAgents: {},
   improvementProposalsDisabledProjects: {},
   improvementProposalsDisabledCrews: {},
+  dreamConsolidationScheduleEnabled: false,
+  dreamConsolidationIntervalHours: 168,
   effectiveProviderId: 'openrouter',
   effectiveModel: 'anthropic/claude-sonnet-4',
 }

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -62,6 +62,8 @@ const baseSettings: EffectiveAppSettings = {
   improvementProposalsDisabledAgents: {},
   improvementProposalsDisabledProjects: {},
   improvementProposalsDisabledCrews: {},
+  dreamConsolidationScheduleEnabled: false,
+  dreamConsolidationIntervalHours: 168,
   effectiveProviderId: 'openrouter',
   effectiveModel: 'gpt-4.1',
 }

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -34,6 +34,8 @@ function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSe
     improvementProposalsDisabledAgents: {},
     improvementProposalsDisabledProjects: {},
     improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: false,
+    dreamConsolidationIntervalHours: 168,
     effectiveProviderId: 'openrouter',
     effectiveModel: 'anthropic/claude-sonnet-4',
     ...overrides,

--- a/apps/desktop/src/renderer/components/sidebar/SettingsAutomationPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsAutomationPanel.test.tsx
@@ -31,6 +31,8 @@ function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSe
     improvementProposalsDisabledAgents: {},
     improvementProposalsDisabledProjects: {},
     improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: false,
+    dreamConsolidationIntervalHours: 168,
     effectiveProviderId: null,
     effectiveModel: null,
     ...overrides,
@@ -70,6 +72,19 @@ describe('AutomationSettingsPanel', () => {
     expect(update).toHaveBeenNthCalledWith(2, { improvementProposalsDisabledAgents: { build: true, researcher: true } })
     expect(update).toHaveBeenNthCalledWith(3, { improvementProposalsDisabledProjects: { '/workspace/acme': true } })
     expect(update).toHaveBeenNthCalledWith(4, { improvementProposalsDisabledCrews: { 'growth-review': true } })
+  })
+
+  it('updates scheduled dream consolidation independently', () => {
+    const update = vi.fn()
+    render(<AutomationSettingsPanel settings={settings()} update={update} />)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Scheduled consolidation' }))
+    fireEvent.change(screen.getByLabelText('Interval (hours)'), {
+      target: { value: '12' },
+    })
+
+    expect(update).toHaveBeenNthCalledWith(1, { dreamConsolidationScheduleEnabled: true })
+    expect(update).toHaveBeenNthCalledWith(2, { dreamConsolidationIntervalHours: 24 })
   })
 
   it('updates defaults and quiet-hour fields independently', () => {

--- a/apps/desktop/src/renderer/components/sidebar/SettingsAutomationPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsAutomationPanel.tsx
@@ -264,6 +264,49 @@ export function AutomationSettingsPanel({
             />
           </button>
         </div>
+        <div className="mt-4 grid grid-cols-[1fr_auto] items-center gap-4 rounded-md border border-border-subtle p-3 max-[720px]:grid-cols-1">
+          <div>
+            <div className="text-[12px] font-semibold text-text">{t('settings.automations.dreamScheduleTitle', 'Scheduled consolidation')}</div>
+            <div className="mt-1 text-[11px] text-text-muted">
+              {t('settings.automations.dreamScheduleDescription', 'Let Open Cowork periodically ask OpenCode to propose memory cleanups. Outputs still land in the Improvement Inbox for review.')}
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.dreamConsolidationScheduleEnabled}
+            aria-label={t('settings.automations.dreamScheduleTitle', 'Scheduled consolidation')}
+            onClick={() => update({ dreamConsolidationScheduleEnabled: !settings.dreamConsolidationScheduleEnabled })}
+            className="relative h-5 w-10 shrink-0 cursor-pointer rounded-full transition-colors"
+            style={{ background: settings.dreamConsolidationScheduleEnabled ? 'var(--color-accent)' : 'var(--color-border)' }}
+          >
+            <div
+              className="absolute top-[3px] h-3.5 w-3.5 rounded-full border border-border-subtle transition-all"
+              style={{
+                left: settings.dreamConsolidationScheduleEnabled ? 20 : 3,
+                background: 'color-mix(in srgb, var(--color-elevated) 92%, var(--color-base) 8%)',
+              }}
+            />
+          </button>
+          <label className="col-span-2 flex max-w-[220px] flex-col gap-2 max-[720px]:col-span-1">
+            <span className={fieldLabelCls}>{t('settings.automations.dreamIntervalHours', 'Interval (hours)')}</span>
+            <input
+              type="number"
+              min={24}
+              max={720}
+              value={settings.dreamConsolidationIntervalHours}
+              onChange={(event) => update({
+                dreamConsolidationIntervalHours: updateIntegerSetting(
+                  event.target.value,
+                  settings.dreamConsolidationIntervalHours,
+                  24,
+                  720,
+                ),
+              })}
+              className={inputCls}
+            />
+          </label>
+        </div>
         <div className="grid grid-cols-3 gap-4 max-[980px]:grid-cols-1">
           <label className="flex flex-col gap-2">
             <span className={fieldLabelCls}>{t('settings.automations.disabledLearningAgents', 'Disabled agents')}</span>

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EffectiveAppSettings, PublicAppConfig } from '@open-cowork/shared'
@@ -34,6 +34,8 @@ function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSe
     improvementProposalsDisabledAgents: {},
     improvementProposalsDisabledProjects: {},
     improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: false,
+    dreamConsolidationIntervalHours: 168,
     effectiveProviderId: 'openrouter',
     effectiveModel: 'anthropic/claude-sonnet-4',
     ...overrides,
@@ -272,6 +274,8 @@ describe('SettingsPanel', () => {
     await user.type(screen.getByLabelText('Disabled agents'), 'data-analyst')
     await user.type(screen.getByLabelText('Disabled projects'), '/workspace/acme')
     await user.type(screen.getByLabelText('Disabled crews'), 'growth-review')
+    await user.click(screen.getByRole('switch', { name: 'Scheduled consolidation' }))
+    fireEvent.change(screen.getByLabelText('Interval (hours)'), { target: { value: '48' } })
     await user.click(screen.getByRole('button', { name: 'Save Changes' }))
 
     await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1))
@@ -280,6 +284,8 @@ describe('SettingsPanel', () => {
       improvementProposalsDisabledAgents: { 'data-analyst': true },
       improvementProposalsDisabledProjects: { '/workspace/acme': true },
       improvementProposalsDisabledCrews: { 'growth-review': true },
+      dreamConsolidationScheduleEnabled: true,
+      dreamConsolidationIntervalHours: 48,
     })
   })
 

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -179,6 +179,8 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
         improvementProposalsDisabledAgents: settings.improvementProposalsDisabledAgents,
         improvementProposalsDisabledProjects: settings.improvementProposalsDisabledProjects,
         improvementProposalsDisabledCrews: settings.improvementProposalsDisabledCrews,
+        dreamConsolidationScheduleEnabled: settings.dreamConsolidationScheduleEnabled,
+        dreamConsolidationIntervalHours: settings.dreamConsolidationIntervalHours,
       })
       dirtyProviderCredentialKeys.current = {}
       let next = savedSettings

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -35,6 +35,8 @@ function createDefaultSettings(overrides: Partial<EffectiveAppSettings> = {}): E
     improvementProposalsDisabledAgents: {},
     improvementProposalsDisabledProjects: {},
     improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: false,
+    dreamConsolidationIntervalHours: 168,
     effectiveProviderId: null,
     effectiveModel: null,
     ...overrides,

--- a/packages/shared/src/app-config.ts
+++ b/packages/shared/src/app-config.ts
@@ -166,6 +166,8 @@ export interface AppSettings {
   improvementProposalsDisabledAgents: Record<string, boolean>
   improvementProposalsDisabledProjects: Record<string, boolean>
   improvementProposalsDisabledCrews: Record<string, boolean>
+  dreamConsolidationScheduleEnabled: boolean
+  dreamConsolidationIntervalHours: number
 }
 
 export interface EffectiveAppSettings extends AppSettings {

--- a/tests/improvement-dream-scheduler.test.ts
+++ b/tests/improvement-dream-scheduler.test.ts
@@ -1,0 +1,213 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { AppSettings, AgentMemoryDraft, ImprovementEvidenceRef } from '../packages/shared/src/index.ts'
+import {
+  COWORK_IMPROVEMENT_SCHEMA_VERSION,
+} from '../packages/shared/src/improvements.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { closeLogger } from '../apps/desktop/src/main/logger.ts'
+import {
+  approveAgentMemoryEntry,
+  clearImprovementStoreCache,
+  createAgentMemoryProposal,
+  failDreamRun,
+  getLatestDreamRun,
+  getImprovementProposal,
+  startDreamRun,
+} from '../apps/desktop/src/main/improvement-store.ts'
+import {
+  isScheduledDreamConsolidationDue,
+  runScheduledDreamConsolidationTick,
+} from '../apps/desktop/src/main/improvement-dream-scheduler.ts'
+import type { DreamRuntimeDriver } from '../apps/desktop/src/main/improvement-dream-runner.ts'
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-dream-scheduler-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+async function withImprovementStore(name: string, fn: () => Promise<void>) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    closeLogger()
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    clearConfigCaches()
+    clearImprovementStoreCache()
+    await fn()
+  } finally {
+    closeLogger()
+    clearImprovementStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    selectedProviderId: null,
+    selectedModelId: null,
+    providerCredentials: {},
+    integrationCredentials: {},
+    integrationEnabled: {},
+    bashPermission: 'deny',
+    fileWritePermission: 'deny',
+    enableBash: false,
+    enableFileWrite: false,
+    runtimeToolingBridgeEnabled: true,
+    automationLaunchAtLogin: false,
+    automationRunInBackground: true,
+    automationDesktopNotifications: true,
+    automationQuietHoursStart: '22:00',
+    automationQuietHoursEnd: '07:00',
+    defaultAutomationAutonomyPolicy: 'review-first',
+    defaultAutomationExecutionMode: 'planning_only',
+    operationalMaxAutonomy: 'supervised',
+    operationalWriteMaxParallel: 1,
+    operationalMaxRunDurationMinutes: 120,
+    operationalMaxCostUsd: null,
+    operationalMaxRetries: 10,
+    improvementProposalsEnabled: true,
+    improvementProposalsDisabledAgents: {},
+    improvementProposalsDisabledProjects: {},
+    improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: true,
+    dreamConsolidationIntervalHours: 24,
+    ...overrides,
+  }
+}
+
+function evidence(id = 'trace-1'): ImprovementEvidenceRef {
+  return {
+    schemaVersion: COWORK_IMPROVEMENT_SCHEMA_VERSION,
+    kind: 'trace',
+    id,
+    label: `Trace ${id}`,
+    uri: null,
+    hash: `sha256:${id}`,
+  }
+}
+
+function memoryDraft(overrides: Partial<AgentMemoryDraft> = {}): AgentMemoryDraft {
+  return {
+    scopeKind: 'machine',
+    scopeId: null,
+    title: 'Use concise validation notes',
+    summary: 'Keep validation notes concise.',
+    body: 'Roadmap handoffs should name the validation commands and keep notes concise.',
+    tags: ['validation'],
+    privacy: 'internal',
+    provenance: [evidence()],
+    ...overrides,
+  }
+}
+
+function driverForMemory(memoryId: string): DreamRuntimeDriver {
+  return {
+    async consolidate() {
+      return {
+        sessionId: 'scheduled-dream-session',
+        structured: {
+          type: 'open_cowork.dream_consolidation',
+          version: 1,
+          summary: 'Consolidate validation guidance.',
+          candidates: [{
+            operation: 'update',
+            sourceMemoryEntryId: memoryId,
+            title: 'Use concise validation notes',
+            summary: 'Keep validation notes concise and source-backed.',
+            body: 'Roadmap handoffs should name validation commands and keep notes concise.',
+            tags: ['validation'],
+            privacy: 'internal',
+          }],
+        },
+        text: '',
+      }
+    },
+  }
+}
+
+test('scheduled dream consolidation due checks respect policy and interval', () => {
+  const now = new Date('2026-05-10T12:00:00.000Z')
+  const staleRun = {
+    startedAt: '2026-05-09T11:00:00.000Z',
+  } as Parameters<typeof isScheduledDreamConsolidationDue>[1]
+  const recentRun = {
+    startedAt: '2026-05-10T11:30:00.000Z',
+  } as Parameters<typeof isScheduledDreamConsolidationDue>[1]
+
+  assert.equal(isScheduledDreamConsolidationDue(settings(), null, now), true)
+  assert.equal(isScheduledDreamConsolidationDue(settings({ dreamConsolidationScheduleEnabled: false }), null, now), false)
+  assert.equal(isScheduledDreamConsolidationDue(settings({ improvementProposalsEnabled: false }), null, now), false)
+  assert.equal(isScheduledDreamConsolidationDue(settings(), recentRun, now), false)
+  assert.equal(isScheduledDreamConsolidationDue(settings(), staleRun, now), true)
+})
+
+test('scheduled dream consolidation runs through the shared dream runner when due', async () => {
+  await withImprovementStore('scheduled-run', async () => {
+    const memory = createAgentMemoryProposal(memoryDraft())
+    approveAgentMemoryEntry(memory.id, 'reviewer')
+
+    const run = await runScheduledDreamConsolidationTick(
+      new Date('2026-05-10T12:00:00.000Z'),
+      driverForMemory(memory.id),
+      settings(),
+    )
+    const proposal = getImprovementProposal(run?.candidateProposalIds[0] || '')
+
+    assert.equal(run?.status, 'completed')
+    assert.equal(run?.title, 'Scheduled memory consolidation')
+    assert.equal(proposal?.status, 'proposed')
+    assert.equal(proposal?.targetId, memory.id)
+  })
+})
+
+test('scheduled dream consolidation skips safely when not due or no memory exists', async () => {
+  await withImprovementStore('scheduled-skip', async () => {
+    let called = false
+    const memory = createAgentMemoryProposal(memoryDraft())
+    approveAgentMemoryEntry(memory.id, 'reviewer')
+    const recent = startDreamRun({
+      title: 'Recent consolidation',
+      instructions: 'Recently attempted.',
+      sourceMemoryEntryIds: [memory.id],
+    })
+    failDreamRun(recent.id, 'Provider unavailable.')
+
+    const notDue = await runScheduledDreamConsolidationTick(
+      new Date(Date.parse(recent.startedAt) + 60 * 60 * 1000),
+      {
+        async consolidate() {
+          called = true
+          throw new Error('not used')
+        },
+      },
+      settings(),
+    )
+
+    assert.equal(notDue, null)
+    assert.equal(called, false)
+  })
+
+  await withImprovementStore('scheduled-empty', async () => {
+    let called = false
+    const skipped = await runScheduledDreamConsolidationTick(
+      new Date('2026-05-10T12:00:00.000Z'),
+      {
+        async consolidate() {
+          called = true
+          throw new Error('not used')
+        },
+      },
+      settings(),
+    )
+
+    assert.equal(skipped, null)
+    assert.equal(called, false)
+    assert.equal(getLatestDreamRun(), null)
+  })
+})

--- a/tests/improvement-policy.test.ts
+++ b/tests/improvement-policy.test.ts
@@ -34,6 +34,8 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     improvementProposalsDisabledAgents: {},
     improvementProposalsDisabledProjects: {},
     improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: false,
+    dreamConsolidationIntervalHours: 168,
     ...overrides,
   }
 }

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -134,6 +134,8 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     improvementProposalsDisabledAgents: {},
     improvementProposalsDisabledProjects: {},
     improvementProposalsDisabledCrews: {},
+    dreamConsolidationScheduleEnabled: false,
+    dreamConsolidationIntervalHours: 168,
     ...overrides,
   }
 }

--- a/tests/runtime-mcp-google-auth.test.ts
+++ b/tests/runtime-mcp-google-auth.test.ts
@@ -35,6 +35,8 @@ const BASE_SETTINGS: AppSettings = {
   improvementProposalsDisabledAgents: {},
   improvementProposalsDisabledProjects: {},
   improvementProposalsDisabledCrews: {},
+  dreamConsolidationScheduleEnabled: false,
+  dreamConsolidationIntervalHours: 168,
 }
 
 function makeStdioMcp(overrides: Partial<CustomMcpConfig> = {}): CustomMcpConfig {

--- a/tests/runtime-mcp-opt-in.test.ts
+++ b/tests/runtime-mcp-opt-in.test.ts
@@ -39,6 +39,8 @@ const BASE_SETTINGS: AppSettings = {
   improvementProposalsDisabledAgents: {},
   improvementProposalsDisabledProjects: {},
   improvementProposalsDisabledCrews: {},
+  dreamConsolidationScheduleEnabled: false,
+  dreamConsolidationIntervalHours: 168,
 }
 
 function withConfigDir(configJson: Record<string, unknown>, fn: () => void) {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -161,6 +161,8 @@ test('saveSettings normalizes renderer updates before persistence', async () => 
       improvementProposalsDisabledCrews: {
         'growth-review': true,
       },
+      dreamConsolidationScheduleEnabled: true,
+      dreamConsolidationIntervalHours: 12,
       providerCredentials: {
         openrouter: {
           apiKey: 'valid-key',
@@ -184,6 +186,8 @@ test('saveSettings normalizes renderer updates before persistence', async () => 
     assert.deepEqual(after.improvementProposalsDisabledAgents, { build: true })
     assert.deepEqual(after.improvementProposalsDisabledProjects, { '/workspace/acme': true })
     assert.deepEqual(after.improvementProposalsDisabledCrews, { 'growth-review': true })
+    assert.equal(after.dreamConsolidationScheduleEnabled, true)
+    assert.equal(after.dreamConsolidationIntervalHours, 24)
     assert.equal(after.providerCredentials.openrouter.apiKey, 'valid-key')
     assert.equal(after.providerCredentials.openrouter.oversized, undefined)
     assert.equal(after.unexpectedTopLevel, undefined)


### PR DESCRIPTION
## Summary
- add settings for opt-in scheduled governed memory consolidation
- reuse the OpenCode-backed dream runner for scheduled runs while keeping outputs review-first
- hook the scheduler into the existing automation service tick and skip safely when no approved memory exists
- add scheduler, settings, and renderer persistence coverage

Refs #247

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-dream-scheduler.test.ts tests/improvement-dream-runner.test.ts tests/improvement-store.test.ts tests/settings.test.ts
- pnpm test:renderer
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm lint:a11y --max-warnings=0
- pnpm build
- pnpm docs:build
- pnpm test:e2e
- git diff --check