### PR TITLE
[codex] add Improvement Inbox proposal editing

### DIFF
--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import type { ImprovementReviewQueue } from '@open-cowork/shared'
 import { PulseImprovementInbox } from './PulseImprovementInbox'
@@ -100,7 +101,7 @@ const reviewQueue: ImprovementReviewQueue = {
 
 describe('PulseImprovementInbox', () => {
   it('renders inspectable evidence, candidate diffs, memory provenance, and dream-run metadata', () => {
-    render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} />)
+    render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
 
     expect(screen.getByText('Inspect evidence and diffs')).toBeInTheDocument()
     expect(screen.getByText('1 evidence / 1 diff')).toBeInTheDocument()
@@ -117,5 +118,55 @@ describe('PulseImprovementInbox', () => {
     expect(screen.getByText('1 memory / 1 proposal')).toBeInTheDocument()
     expect(screen.getByText('openrouter/example')).toBeInTheDocument()
     expect(screen.getByText('proposal-1')).toBeInTheDocument()
+  })
+
+  it('saves edited memory proposal drafts through the update handler', async () => {
+    const user = userEvent.setup()
+    const updateProposal = vi.fn(async () => true)
+    render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={updateProposal} />)
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.clear(screen.getByLabelText('Memory body'))
+    await user.type(screen.getByLabelText('Memory body'), 'Use concise evidence notes with one source link per claim.')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(updateProposal).toHaveBeenCalledTimes(1)
+    expect(updateProposal).toHaveBeenCalledWith('proposal-1', expect.objectContaining({
+      title: 'Tighten analyst memory',
+      summary: 'Candidate improvement from evaluated work.',
+      candidateDiffs: [
+        expect.objectContaining({
+          afterHash: null,
+          payload: expect.objectContaining({
+            body: 'Use concise evidence notes with one source link per claim.',
+          }),
+        }),
+      ],
+    }))
+  })
+
+  it('pauses review actions while an edit is open', async () => {
+    const user = userEvent.setup()
+    render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getAllByRole('button', { name: 'Approve' })[0]).toBeDisabled()
+    expect(screen.getAllByRole('button', { name: 'Reject' })[0]).toBeDisabled()
+    expect(screen.getAllByRole('button', { name: 'Archive' })[0]).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getAllByRole('button', { name: 'Approve' })[0]).not.toBeDisabled()
+  })
+
+  it('clears the edit lock when the edited proposal leaves the visible inbox', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getAllByRole('button', { name: 'Approve' })[0]).toBeDisabled()
+
+    rerender(<PulseImprovementInbox inbox={{ ...reviewQueue, proposals: [] }} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Approve' })).not.toBeDisabled())
   })
 })

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
@@ -1,6 +1,8 @@
-import type { ImprovementReviewQueue } from '@open-cowork/shared'
+import { useEffect, useState } from 'react'
+import type { ImprovementProposalDraft, ImprovementReviewQueue } from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
 import { DreamRunInspection, MemoryInspection, ProposalInspection } from './PulseImprovementInspection'
+import { PulseImprovementProposalEditor } from './PulseImprovementProposalEditor'
 
 export type PulseImprovementReviewAction =
   | 'approve-memory'
@@ -15,6 +17,7 @@ interface PulseImprovementInboxProps {
   inbox: ImprovementReviewQueue | null
   actionId: string | null
   onReview: (id: string, action: PulseImprovementReviewAction) => void
+  onUpdateProposal: (id: string, draft: ImprovementProposalDraft) => Promise<boolean>
 }
 
 const itemShellStyle = { boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-text) 4%, transparent)' }
@@ -24,12 +27,14 @@ function ReviewButton({
   currentActionId,
   label,
   tone = 'neutral',
+  disabled = false,
   onClick,
 }: {
   actionId: string
   currentActionId: string | null
   label: string
   tone?: 'accent' | 'muted' | 'neutral'
+  disabled?: boolean
   onClick: () => void
 }) {
   const isCurrentAction = currentActionId === actionId
@@ -42,7 +47,7 @@ function ReviewButton({
     <button
       type="button"
       onClick={onClick}
-      disabled={currentActionId !== null}
+      disabled={disabled || currentActionId !== null}
       aria-busy={isCurrentAction}
       className={`rounded-full border border-border-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] disabled:opacity-50 ${toneClass}`}
     >
@@ -51,15 +56,24 @@ function ReviewButton({
   )
 }
 
-export function PulseImprovementInbox({ inbox, actionId, onReview }: PulseImprovementInboxProps) {
+export function PulseImprovementInbox({ inbox, actionId, onReview, onUpdateProposal }: PulseImprovementInboxProps) {
+  const [editingProposalId, setEditingProposalId] = useState<string | null>(null)
   const pendingMemories = inbox?.memory || []
   const pendingProposals = inbox?.proposals || []
+  const visibleProposals = pendingProposals.slice(0, 3)
   const attentionDreamRuns = inbox?.dreamRuns || []
+
+  useEffect(() => {
+    if (editingProposalId && !pendingProposals.slice(0, 3).some((proposal) => proposal.id === editingProposalId)) {
+      setEditingProposalId(null)
+    }
+  }, [editingProposalId, pendingProposals])
+
   if (!inbox || (pendingMemories.length === 0 && pendingProposals.length === 0 && attentionDreamRuns.length === 0)) return null
 
   return (
     <div className="mt-4 space-y-3">
-      {pendingProposals.slice(0, 3).map((proposal) => (
+      {visibleProposals.map((proposal) => (
         <div
           key={`proposal:${proposal.id}`}
           className="rounded-2xl bg-surface px-4 py-3"
@@ -72,18 +86,28 @@ export function PulseImprovementInbox({ inbox, actionId, onReview }: PulseImprov
           <div className="mt-2 text-[12px] font-medium text-text">{proposal.title}</div>
           <div className="mt-1 line-clamp-2 text-[11px] text-text-secondary leading-relaxed">{proposal.summary}</div>
           <ProposalInspection proposal={proposal} />
+          <PulseImprovementProposalEditor
+            proposal={proposal}
+            actionId={actionId}
+            editing={editingProposalId === proposal.id}
+            editDisabled={actionId !== null || (editingProposalId !== null && editingProposalId !== proposal.id)}
+            onEditingChange={(editing) => setEditingProposalId(editing ? proposal.id : null)}
+            onUpdate={onUpdateProposal}
+          />
           <div className="mt-3 flex flex-wrap gap-2">
             <ReviewButton
               actionId={`approve-proposal:${proposal.id}`}
               currentActionId={actionId}
               label={t('homepage.card.approve', 'Approve')}
               tone="accent"
+              disabled={editingProposalId !== null}
               onClick={() => onReview(proposal.id, 'approve-proposal')}
             />
             <ReviewButton
               actionId={`reject-proposal:${proposal.id}`}
               currentActionId={actionId}
               label={t('homepage.card.reject', 'Reject')}
+              disabled={editingProposalId !== null}
               onClick={() => onReview(proposal.id, 'reject-proposal')}
             />
             <ReviewButton
@@ -91,6 +115,7 @@ export function PulseImprovementInbox({ inbox, actionId, onReview }: PulseImprov
               currentActionId={actionId}
               label={t('homepage.card.archive', 'Archive')}
               tone="muted"
+              disabled={editingProposalId !== null}
               onClick={() => onReview(proposal.id, 'archive-proposal')}
             />
           </div>
@@ -116,12 +141,14 @@ export function PulseImprovementInbox({ inbox, actionId, onReview }: PulseImprov
               currentActionId={actionId}
               label={t('homepage.card.approve', 'Approve')}
               tone="accent"
+              disabled={editingProposalId !== null}
               onClick={() => onReview(memory.id, 'approve-memory')}
             />
             <ReviewButton
               actionId={`reject-memory:${memory.id}`}
               currentActionId={actionId}
               label={t('homepage.card.reject', 'Reject')}
+              disabled={editingProposalId !== null}
               onClick={() => onReview(memory.id, 'reject-memory')}
             />
           </div>
@@ -149,6 +176,7 @@ export function PulseImprovementInbox({ inbox, actionId, onReview }: PulseImprov
                 actionId={`cancel-dream:${run.id}`}
                 currentActionId={actionId}
                 label={t('homepage.card.cancel', 'Cancel')}
+                disabled={editingProposalId !== null}
                 onClick={() => onReview(run.id, 'cancel-dream')}
               />
             ) : null}
@@ -158,6 +186,7 @@ export function PulseImprovementInbox({ inbox, actionId, onReview }: PulseImprov
                 currentActionId={actionId}
                 label={t('homepage.card.archive', 'Archive')}
                 tone="muted"
+                disabled={editingProposalId !== null}
                 onClick={() => onReview(run.id, 'archive-dream')}
               />
             ) : null}

--- a/apps/desktop/src/renderer/components/PulseImprovementProposalEditor.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementProposalEditor.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { ImprovementCandidateDiff, ImprovementProposal, ImprovementProposalDraft } from '@open-cowork/shared'
+import { t } from '../helpers/i18n'
+
+interface ProposalEditorState {
+  title: string
+  summary: string
+  memoryTitle: string
+  memorySummary: string
+  memoryBody: string
+}
+
+interface PulseImprovementProposalEditorProps {
+  proposal: ImprovementProposal
+  actionId: string | null
+  editing: boolean
+  editDisabled: boolean
+  onEditingChange: (editing: boolean) => void
+  onUpdate: (id: string, draft: ImprovementProposalDraft) => Promise<boolean>
+}
+
+function payloadText(diff: ImprovementCandidateDiff | null, key: string) {
+  if (!diff) return ''
+  const value = diff.payload[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function editableMemoryDiffIndex(proposal: ImprovementProposal) {
+  return proposal.candidateDiffs.findIndex((diff) => (
+    diff.targetType === 'memory' && diff.operation !== 'delete'
+  ))
+}
+
+function editorStateFromProposal(proposal: ImprovementProposal): ProposalEditorState {
+  const diff = proposal.candidateDiffs[editableMemoryDiffIndex(proposal)] || null
+  return {
+    title: proposal.title,
+    summary: proposal.summary,
+    memoryTitle: payloadText(diff, 'title') || proposal.title,
+    memorySummary: payloadText(diff, 'summary') || diff?.summary || proposal.summary,
+    memoryBody: payloadText(diff, 'body'),
+  }
+}
+
+function buildDraft(proposal: ImprovementProposal, state: ProposalEditorState): ImprovementProposalDraft {
+  const memoryDiffIndex = editableMemoryDiffIndex(proposal)
+  const candidateDiffs = proposal.candidateDiffs.map((diff, index) => {
+    if (index !== memoryDiffIndex) return diff
+    return {
+      ...diff,
+      summary: state.memorySummary.trim() || diff.summary,
+      afterHash: null,
+      payload: {
+        ...diff.payload,
+        title: state.memoryTitle.trim(),
+        summary: state.memorySummary.trim(),
+        body: state.memoryBody,
+      },
+    }
+  })
+  return {
+    targetType: proposal.targetType,
+    targetId: proposal.targetId,
+    title: state.title.trim(),
+    summary: state.summary.trim(),
+    evidence: proposal.evidence,
+    candidateDiffs,
+  }
+}
+
+function hasChanges(proposal: ImprovementProposal, state: ProposalEditorState) {
+  const original = editorStateFromProposal(proposal)
+  return original.title !== state.title
+    || original.summary !== state.summary
+    || original.memoryTitle !== state.memoryTitle
+    || original.memorySummary !== state.memorySummary
+    || original.memoryBody !== state.memoryBody
+}
+
+export function PulseImprovementProposalEditor({
+  proposal,
+  actionId,
+  editing,
+  editDisabled,
+  onEditingChange,
+  onUpdate,
+}: PulseImprovementProposalEditorProps) {
+  const [state, setState] = useState<ProposalEditorState>(() => editorStateFromProposal(proposal))
+  const memoryDiffIndex = useMemo(() => editableMemoryDiffIndex(proposal), [proposal])
+  const hasEditableMemoryDiff = memoryDiffIndex >= 0
+  const isSaving = actionId === `update-proposal:${proposal.id}`
+  const isBusy = actionId !== null
+  const canSave = state.title.trim().length > 0
+    && state.summary.trim().length > 0
+    && (!hasEditableMemoryDiff || (
+      state.memoryTitle.trim().length > 0
+      && state.memorySummary.trim().length > 0
+      && state.memoryBody.trim().length > 0
+    ))
+    && hasChanges(proposal, state)
+    && !isBusy
+
+  useEffect(() => {
+    if (!editing) setState(editorStateFromProposal(proposal))
+  }, [editing, proposal])
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => onEditingChange(true)}
+        disabled={editDisabled}
+        className="rounded-full border border-border-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-secondary hover:border-border-strong disabled:opacity-50"
+      >
+        {t('homepage.card.editProposal', 'Edit')}
+      </button>
+    )
+  }
+
+  async function save() {
+    if (!canSave) return
+    const saved = await onUpdate(proposal.id, buildDraft(proposal, state))
+    if (saved) onEditingChange(false)
+  }
+
+  return (
+    <form
+      className="mt-3 rounded-2xl border border-border-subtle bg-bg px-3 py-3"
+      onSubmit={(event) => {
+        event.preventDefault()
+        void save()
+      }}
+    >
+      <div className="grid grid-cols-2 gap-3 max-[720px]:grid-cols-1">
+        <label className="block">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{t('homepage.card.proposalTitle', 'Proposal title')}</span>
+          <input
+            value={state.title}
+            onChange={(event) => setState((current) => ({ ...current, title: event.target.value }))}
+            disabled={isBusy}
+            className="mt-1 w-full rounded-xl border border-border-subtle bg-surface px-3 py-2 text-[12px] text-text outline-none focus:border-accent disabled:opacity-60"
+          />
+        </label>
+        <label className="block">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{t('homepage.card.proposalSummary', 'Proposal summary')}</span>
+          <textarea
+            value={state.summary}
+            onChange={(event) => setState((current) => ({ ...current, summary: event.target.value }))}
+            disabled={isBusy}
+            rows={3}
+            className="mt-1 w-full resize-y rounded-xl border border-border-subtle bg-surface px-3 py-2 text-[12px] text-text outline-none focus:border-accent disabled:opacity-60"
+          />
+        </label>
+      </div>
+      {hasEditableMemoryDiff ? (
+        <div className="mt-3 space-y-3 rounded-2xl bg-surface px-3 py-3">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-green">
+            {t('homepage.card.memoryDraft', 'Candidate memory draft')}
+          </div>
+          <div className="grid grid-cols-2 gap-3 max-[720px]:grid-cols-1">
+            <label className="block">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{t('homepage.card.memoryTitle', 'Memory title')}</span>
+              <input
+                value={state.memoryTitle}
+                onChange={(event) => setState((current) => ({ ...current, memoryTitle: event.target.value }))}
+                disabled={isBusy}
+                className="mt-1 w-full rounded-xl border border-border-subtle bg-bg px-3 py-2 text-[12px] text-text outline-none focus:border-accent disabled:opacity-60"
+              />
+            </label>
+            <label className="block">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{t('homepage.card.memorySummary', 'Memory summary')}</span>
+              <input
+                value={state.memorySummary}
+                onChange={(event) => setState((current) => ({ ...current, memorySummary: event.target.value }))}
+                disabled={isBusy}
+                className="mt-1 w-full rounded-xl border border-border-subtle bg-bg px-3 py-2 text-[12px] text-text outline-none focus:border-accent disabled:opacity-60"
+              />
+            </label>
+          </div>
+          <label className="block">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{t('homepage.card.memoryBody', 'Memory body')}</span>
+            <textarea
+              value={state.memoryBody}
+              onChange={(event) => setState((current) => ({ ...current, memoryBody: event.target.value }))}
+              disabled={isBusy}
+              rows={5}
+              className="mt-1 w-full resize-y rounded-xl border border-border-subtle bg-bg px-3 py-2 text-[12px] text-text outline-none focus:border-accent disabled:opacity-60"
+            />
+          </label>
+        </div>
+      ) : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="submit"
+          disabled={!canSave}
+          aria-busy={isSaving}
+          className="rounded-full border border-border-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-accent hover:border-accent disabled:opacity-50"
+        >
+          {t('homepage.card.saveProposal', 'Save')}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setState(editorStateFromProposal(proposal))
+            onEditingChange(false)
+          }}
+          disabled={isBusy}
+          className="rounded-full border border-border-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted hover:border-border-strong disabled:opacity-50"
+        >
+          {t('homepage.card.cancelEdit', 'Cancel')}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -520,6 +520,7 @@ function installPulseApi(options: {
   queueAlerts?: ReturnType<typeof vi.fn>
   improvementSummary?: ReturnType<typeof vi.fn>
   improvementInbox?: ReturnType<typeof vi.fn>
+  updateProposal?: ReturnType<typeof vi.fn>
   approveProposal?: ReturnType<typeof vi.fn>
   rejectMemory?: ReturnType<typeof vi.fn>
   startDreamRun?: ReturnType<typeof vi.fn>
@@ -571,7 +572,7 @@ function installPulseApi(options: {
       approveMemory: vi.fn(async () => null),
       rejectMemory: options.rejectMemory || vi.fn(async () => null),
       archiveMemory: vi.fn(async () => null),
-      updateProposal: vi.fn(async () => null),
+      updateProposal: options.updateProposal || vi.fn(async () => null),
       approveProposal: options.approveProposal || vi.fn(async () => null),
       rejectProposal: vi.fn(async () => null),
       archiveProposal: vi.fn(async () => null),
@@ -707,6 +708,26 @@ describe('PulsePage', () => {
 
     await user.click(screen.getAllByRole('button', { name: 'Archive' }).at(-1)!)
     await waitFor(() => expect(archiveDreamRun).toHaveBeenCalledWith('dream-1'))
+  })
+
+  it('updates Improvement Inbox proposals and refreshes diagnostics', async () => {
+    const user = userEvent.setup()
+    const updateProposal = vi.fn(async () => null)
+    const api = installPulseApi({ updateProposal })
+
+    render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
+    await screen.findByText('Tighten analyst memory')
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.clear(screen.getByLabelText('Proposal summary'))
+    await user.type(screen.getByLabelText('Proposal summary'), 'Edited proposal summary.')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(updateProposal).toHaveBeenCalledWith('proposal-1', expect.objectContaining({
+      summary: 'Edited proposal summary.',
+    })))
+    expect(api.improvements.summary).toHaveBeenCalledTimes(2)
+    expect(api.improvements.inbox).toHaveBeenCalledTimes(2)
   })
 
   it('starts a manual dream consolidation from the learning card', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import type {
   CapabilityRiskMetadata,
+  ImprovementProposalDraft,
   OperationalQueueItem,
 } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
@@ -355,6 +356,29 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     }
   }
 
+  async function updateImprovementProposal(id: string, draft: ImprovementProposalDraft) {
+    setImprovementActionId(`update-proposal:${id}`)
+    try {
+      await window.coworkApi.improvements.updateProposal(id, draft)
+      await refreshDiagnostics({ silent: true })
+      return true
+    } catch (error) {
+      addGlobalError(t('pulse.improvementUpdateFailed', 'Could not save the Improvement Inbox proposal. Please try again.'))
+      try {
+        window.coworkApi.diagnostics.reportRendererError({
+          message: `Failed to update improvement proposal ${id}: ${describePulseThreadError(error)}`,
+          stack: error instanceof Error ? error.stack : undefined,
+          view: 'pulse',
+        })
+      } catch {
+        // Diagnostics are best-effort from an action error handler.
+      }
+      return false
+    } finally {
+      setImprovementActionId(null)
+    }
+  }
+
   async function startDreamRun() {
     setImprovementActionId('start-dream:manual')
     try {
@@ -649,6 +673,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                       inbox={improvementInbox}
                       actionId={improvementActionId}
                       onReview={(id, action) => void reviewImprovement(id, action)}
+                      onUpdateProposal={updateImprovementProposal}
                     />
                     <div
                       className="mt-4 rounded-2xl bg-surface px-4 py-3 text-[12px] text-text-secondary leading-relaxed"


### PR DESCRIPTION
Refs #247

## Summary
- add inline Improvement Inbox proposal editing before approval
- preserve the typed ImprovementProposalDraft path through the existing updateProposal IPC
- allow memory-target proposals to edit candidate memory title, summary, and body before approval
- clear edited candidate afterHash values instead of preserving stale model hashes
- disable review actions while a proposal edit is open

## Validation
- pnpm test:renderer -- PulseImprovementInbox PulsePage
- pnpm typecheck
- pnpm lint
- pnpm lint:a11y --max-warnings=0
- pnpm test (rerun passed after one transient provider-catalog full-suite failure; isolated provider-catalog also passed)
- pnpm build
- git diff --check