### PR TITLE
[codex] recover interrupted operational queue runs

### DIFF
--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -3,6 +3,7 @@ import {
   buildOperationalQueueAlerts,
   listOperationalQueueItems,
   listWorkspaceProfiles,
+  recoverInterruptedOperationalQueueItems,
 } from '../operational-queue-store.ts'
 import { listCapabilityRiskMetadata } from '../operation-capability-risk.ts'
 
@@ -12,10 +13,12 @@ export function registerOperationHandlers(context: IpcHandlerContext) {
   })
 
   context.ipcMain.handle('operations:queue-items', async () => {
+    recoverInterruptedOperationalQueueItems()
     return listOperationalQueueItems()
   })
 
   context.ipcMain.handle('operations:queue-alerts', async () => {
+    recoverInterruptedOperationalQueueItems()
     return buildOperationalQueueAlerts()
   })
 

--- a/apps/desktop/src/main/operational-queue-store.ts
+++ b/apps/desktop/src/main/operational-queue-store.ts
@@ -27,6 +27,8 @@ const RUN_KINDS = new Set<OperationalQueueItem['runKind']>(['agent', 'crew', 'au
 const QUEUE_KINDS = new Set<OperationalQueueKind>(['agent', 'crew', 'project', 'channel', 'external_system'])
 const QUEUE_STATUSES = new Set<OperationalQueueStatus>(['queued', 'running', 'blocked', 'completed', 'failed', 'cancelled'])
 const WORKSPACE_PROFILE_KINDS = new Set<WorkspaceProfileKind>(['personal_sandbox', 'project_workspace', 'automation_workspace', 'channel_sandbox', 'high_risk_isolated'])
+const OPERATIONAL_QUEUE_PROCESS_STARTED_AT = nowIso()
+const INTERRUPTED_RUN_MESSAGE = 'Open Cowork restarted before this run reported a terminal state. Inspect the backing run before resuming or retrying.'
 
 type DbRow = Record<string, unknown>
 
@@ -449,6 +451,35 @@ export function getOperationalQueueItemForRun(runKind: OperationalQueueItem['run
 export function listOperationalQueueItems() {
   const rows = getOperationalQueueDb().prepare('select * from operational_queue_items order by created_at asc, rowid asc').all() as DbRow[]
   return rows.map(rowToQueueItem)
+}
+
+export function recoverInterruptedOperationalQueueItems(options: {
+  processStartedAt?: string
+  now?: string
+} = {}) {
+  return withOperationalTransaction(() => {
+    const processStartedMs = Date.parse(options.processStartedAt || OPERATIONAL_QUEUE_PROCESS_STARTED_AT)
+    if (!Number.isFinite(processStartedMs)) return []
+    const now = options.now || nowIso()
+    const interrupted = listOperationalQueueItems().filter((item) => {
+      if (item.status !== 'running') return false
+      const startedMs = item.startedAt ? Date.parse(item.startedAt) : Number.NaN
+      const updatedMs = Date.parse(item.updatedAt)
+      const startedBeforeBoot = !Number.isFinite(startedMs) || startedMs < processStartedMs
+      const untouchedSinceBoot = !Number.isFinite(updatedMs) || updatedMs < processStartedMs
+      return startedBeforeBoot && untouchedSinceBoot
+    })
+    for (const item of interrupted) {
+      getOperationalQueueDb().prepare(`
+        update operational_queue_items
+        set status = ?, updated_at = ?, error = coalesce(error, ?)
+        where id = ? and status = ?
+      `).run('blocked', now, INTERRUPTED_RUN_MESSAGE, item.id, 'running')
+    }
+    return interrupted
+      .map((item) => getOperationalQueueItem(item.id))
+      .filter((item): item is OperationalQueueItem => item !== null)
+  })
 }
 
 function hasQueueCapacity(active: OperationalQueueItem[], item: OperationalQueueItem) {

--- a/tests/operational-queue-store.test.ts
+++ b/tests/operational-queue-store.test.ts
@@ -17,6 +17,7 @@ import {
   listOperationalQueueItems,
   listWorkspaceProfiles,
   recordOperationalQueueItemCost,
+  recoverInterruptedOperationalQueueItems,
   resumeBlockedOperationalQueueItem,
   resolveEffectiveAutonomy,
   retryOperationalQueueItem,
@@ -235,6 +236,72 @@ test('operational queue state survives store reopen', () => withOperationalStore
 
   assert.equal(getOperationalQueueItem(queued.id)?.status, 'queued')
   assert.equal(listOperationalQueueItems().length, 1)
+}))
+
+test('operational queue recovery blocks pre-boot running items with an explicit restart message', () => withOperationalStore('restart-recovery', () => {
+  const item = enqueueOperationalRun({
+    runKind: 'crew',
+    runId: 'interrupted-crew-run',
+    title: 'Interrupted crew run',
+    requestedAutonomy: 'supervised',
+    workspaceProfileId: 'project-workspace',
+    crewId: 'crew-restart',
+    projectId: '/workspace/acme',
+    writeCapable: true,
+  })
+  assert.equal(startOperationalQueueItem(item.id)?.status, 'running')
+  getOperationalQueueDb().prepare(`
+    update operational_queue_items
+    set started_at = ?, updated_at = ?
+    where id = ?
+  `).run('2026-05-10T00:00:00.000Z', '2026-05-10T00:00:00.000Z', item.id)
+
+  const recovered = recoverInterruptedOperationalQueueItems({
+    processStartedAt: '2026-05-10T00:01:00.000Z',
+    now: '2026-05-10T00:02:00.000Z',
+  })
+
+  assert.deepEqual(recovered.map((entry) => entry.id), [item.id])
+  const blocked = getOperationalQueueItem(item.id)
+  assert.equal(blocked?.status, 'blocked')
+  assert.match(blocked?.error || '', /restarted before this run reported a terminal state/i)
+  const alerts = buildOperationalQueueAlerts('2026-05-10T00:03:00.000Z')
+  assert.equal(alerts[0]?.kind, 'blocked_run')
+  assert.equal(alerts[0]?.queueItemId, item.id)
+
+  const resumed = resumeBlockedOperationalQueueItem(item.id)
+  assert.equal(resumed?.status, 'running')
+  recoverInterruptedOperationalQueueItems({
+    processStartedAt: '2026-05-10T00:01:00.000Z',
+    now: '2026-05-10T00:04:00.000Z',
+  })
+  assert.equal(getOperationalQueueItem(item.id)?.status, 'running')
+}))
+
+test('operational queue recovery leaves current-process running items alone', () => withOperationalStore('restart-recovery-current', () => {
+  const item = enqueueOperationalRun({
+    runKind: 'automation',
+    runId: 'current-process-run',
+    title: 'Current process run',
+    requestedAutonomy: 'approve',
+    workspaceProfileId: 'automation-workspace',
+    projectId: '/workspace/acme',
+    writeCapable: true,
+  })
+  assert.equal(startOperationalQueueItem(item.id)?.status, 'running')
+  getOperationalQueueDb().prepare(`
+    update operational_queue_items
+    set started_at = ?, updated_at = ?
+    where id = ?
+  `).run('2026-05-10T00:02:00.000Z', '2026-05-10T00:02:00.000Z', item.id)
+
+  const recovered = recoverInterruptedOperationalQueueItems({
+    processStartedAt: '2026-05-10T00:01:00.000Z',
+    now: '2026-05-10T00:03:00.000Z',
+  })
+
+  assert.deepEqual(recovered, [])
+  assert.equal(getOperationalQueueItem(item.id)?.status, 'running')
 }))
 
 test('workspace profiles expose filesystem, external authority, cleanup, and retention', () => withOperationalStore('profiles', () => {


### PR DESCRIPTION
Refs #248

## Summary
- detect operational queue items that were running before the current app process started
- move interrupted items to blocked with an explicit restart recovery message when operations queue state is read
- keep current-process running items untouched
- surface recovered items through the existing blocked-run alert path in Pulse

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/operational-queue-store.test.ts tests/ipc-handler-registration.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- git diff --check