### PR TITLE
[codex] guard improvement proposal approvals

### DIFF
--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -7,6 +7,7 @@ import {
   COWORK_DREAM_RUN_SCHEMA_VERSION,
   COWORK_IMPROVEMENT_SCHEMA_VERSION,
   COWORK_MEMORY_SCHEMA_VERSION,
+  canApproveImprovementProposalTarget,
   type AgentMemoryDraft,
   type AgentMemoryEntry,
   type AgentMemoryScopeKind,
@@ -677,8 +678,13 @@ function reviewImprovementProposal(id: string, status: Exclude<ImprovementPropos
     if (proposal.status !== 'proposed' && status !== 'archived') throw new Error('Only proposed improvement proposals can be reviewed.')
     const reviewer = boundedText(reviewedBy, 'Improvement reviewer', 512)
     const reviewNote = optionalBoundedText(note, 'Improvement review note', 4096)
-    if (status === 'approved' && proposal.targetType === 'memory') {
-      applyApprovedMemoryProposal(proposal, reviewer, reviewNote)
+    if (status === 'approved') {
+      if (!canApproveImprovementProposalTarget(proposal.targetType)) {
+        throw new Error(`Approval for ${proposal.targetType} improvement proposals is not wired to an existing persistence path yet.`)
+      }
+      if (proposal.targetType === 'memory') {
+        applyApprovedMemoryProposal(proposal, reviewer, reviewNote)
+      }
     }
     const now = nowIso()
     getImprovementDb().prepare(`

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -99,6 +99,31 @@ const reviewQueue: ImprovementReviewQueue = {
   ],
 }
 
+const unsupportedProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...reviewQueue.proposals[0]!,
+      id: 'proposal-agent',
+      targetType: 'agent',
+      targetId: 'analyst',
+      title: 'Tune analyst agent',
+      candidateDiffs: [
+        {
+          ...reviewQueue.proposals[0]!.candidateDiffs[0]!,
+          targetType: 'agent',
+          targetId: 'analyst',
+          summary: 'Update analyst instructions.',
+          payload: {
+            instructions: 'Prefer concise evidence notes.',
+          },
+        },
+      ],
+    },
+  ],
+}
+
 describe('PulseImprovementInbox', () => {
   it('renders inspectable evidence, candidate diffs, memory provenance, and dream-run metadata', () => {
     render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
@@ -156,6 +181,18 @@ describe('PulseImprovementInbox', () => {
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(screen.getAllByRole('button', { name: 'Approve' })[0]).not.toBeDisabled()
+  })
+
+  it('does not offer approval for proposal targets without a typed applicator', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={unsupportedProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.getByText('Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).toBeDisabled()
+    await user.click(approve)
+    expect(onReview).not.toHaveBeenCalled()
   })
 
   it('clears the edit lock when the edited proposal leaves the visible inbox', async () => {

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { ImprovementProposalDraft, ImprovementReviewQueue } from '@open-cowork/shared'
+import { canApproveImprovementProposalTarget, type ImprovementProposalDraft, type ImprovementReviewQueue } from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
 import { DreamRunInspection, MemoryInspection, ProposalInspection } from './PulseImprovementInspection'
 import { PulseImprovementProposalEditor } from './PulseImprovementProposalEditor'
@@ -28,6 +28,7 @@ function ReviewButton({
   label,
   tone = 'neutral',
   disabled = false,
+  title,
   onClick,
 }: {
   actionId: string
@@ -35,6 +36,7 @@ function ReviewButton({
   label: string
   tone?: 'accent' | 'muted' | 'neutral'
   disabled?: boolean
+  title?: string
   onClick: () => void
 }) {
   const isCurrentAction = currentActionId === actionId
@@ -49,6 +51,7 @@ function ReviewButton({
       onClick={onClick}
       disabled={disabled || currentActionId !== null}
       aria-busy={isCurrentAction}
+      title={title}
       className={`rounded-full border border-border-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] disabled:opacity-50 ${toneClass}`}
     >
       {label}
@@ -73,54 +76,67 @@ export function PulseImprovementInbox({ inbox, actionId, onReview, onUpdatePropo
 
   return (
     <div className="mt-4 space-y-3">
-      {visibleProposals.map((proposal) => (
-        <div
-          key={`proposal:${proposal.id}`}
-          className="rounded-2xl bg-surface px-4 py-3"
-          style={itemShellStyle}
-        >
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-[10px] uppercase tracking-[0.14em] text-accent">{t('homepage.card.improvementProposal', 'Improvement proposal')}</span>
-            <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{proposal.targetType.replace(/_/g, ' ')}</span>
+      {visibleProposals.map((proposal) => {
+        const canApproveProposal = canApproveImprovementProposalTarget(proposal.targetType)
+        const approvalUnavailableMessage = t(
+          'homepage.card.proposalApprovalUnavailable',
+          'Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.',
+        )
+        return (
+          <div
+            key={`proposal:${proposal.id}`}
+            className="rounded-2xl bg-surface px-4 py-3"
+            style={itemShellStyle}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-[10px] uppercase tracking-[0.14em] text-accent">{t('homepage.card.improvementProposal', 'Improvement proposal')}</span>
+              <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{proposal.targetType.replace(/_/g, ' ')}</span>
+            </div>
+            <div className="mt-2 text-[12px] font-medium text-text">{proposal.title}</div>
+            <div className="mt-1 line-clamp-2 text-[11px] text-text-secondary leading-relaxed">{proposal.summary}</div>
+            {!canApproveProposal ? (
+              <div className="mt-2 rounded-xl border border-border-subtle bg-surface-elevated px-3 py-2 text-[11px] leading-relaxed text-text-muted">
+                {approvalUnavailableMessage}
+              </div>
+            ) : null}
+            <ProposalInspection proposal={proposal} />
+            <PulseImprovementProposalEditor
+              proposal={proposal}
+              actionId={actionId}
+              editing={editingProposalId === proposal.id}
+              editDisabled={actionId !== null || (editingProposalId !== null && editingProposalId !== proposal.id)}
+              onEditingChange={(editing) => setEditingProposalId(editing ? proposal.id : null)}
+              onUpdate={onUpdateProposal}
+            />
+            <div className="mt-3 flex flex-wrap gap-2">
+              <ReviewButton
+                actionId={`approve-proposal:${proposal.id}`}
+                currentActionId={actionId}
+                label={t('homepage.card.approve', 'Approve')}
+                tone="accent"
+                disabled={editingProposalId !== null || !canApproveProposal}
+                title={!canApproveProposal ? approvalUnavailableMessage : undefined}
+                onClick={() => onReview(proposal.id, 'approve-proposal')}
+              />
+              <ReviewButton
+                actionId={`reject-proposal:${proposal.id}`}
+                currentActionId={actionId}
+                label={t('homepage.card.reject', 'Reject')}
+                disabled={editingProposalId !== null}
+                onClick={() => onReview(proposal.id, 'reject-proposal')}
+              />
+              <ReviewButton
+                actionId={`archive-proposal:${proposal.id}`}
+                currentActionId={actionId}
+                label={t('homepage.card.archive', 'Archive')}
+                tone="muted"
+                disabled={editingProposalId !== null}
+                onClick={() => onReview(proposal.id, 'archive-proposal')}
+              />
+            </div>
           </div>
-          <div className="mt-2 text-[12px] font-medium text-text">{proposal.title}</div>
-          <div className="mt-1 line-clamp-2 text-[11px] text-text-secondary leading-relaxed">{proposal.summary}</div>
-          <ProposalInspection proposal={proposal} />
-          <PulseImprovementProposalEditor
-            proposal={proposal}
-            actionId={actionId}
-            editing={editingProposalId === proposal.id}
-            editDisabled={actionId !== null || (editingProposalId !== null && editingProposalId !== proposal.id)}
-            onEditingChange={(editing) => setEditingProposalId(editing ? proposal.id : null)}
-            onUpdate={onUpdateProposal}
-          />
-          <div className="mt-3 flex flex-wrap gap-2">
-            <ReviewButton
-              actionId={`approve-proposal:${proposal.id}`}
-              currentActionId={actionId}
-              label={t('homepage.card.approve', 'Approve')}
-              tone="accent"
-              disabled={editingProposalId !== null}
-              onClick={() => onReview(proposal.id, 'approve-proposal')}
-            />
-            <ReviewButton
-              actionId={`reject-proposal:${proposal.id}`}
-              currentActionId={actionId}
-              label={t('homepage.card.reject', 'Reject')}
-              disabled={editingProposalId !== null}
-              onClick={() => onReview(proposal.id, 'reject-proposal')}
-            />
-            <ReviewButton
-              actionId={`archive-proposal:${proposal.id}`}
-              currentActionId={actionId}
-              label={t('homepage.card.archive', 'Archive')}
-              tone="muted"
-              disabled={editingProposalId !== null}
-              onClick={() => onReview(proposal.id, 'archive-proposal')}
-            />
-          </div>
-        </div>
-      ))}
+        )
+      })}
 
       {pendingMemories.slice(0, 2).map((memory) => (
         <div

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -11,6 +11,12 @@ export type ImprovementDiffOperation = 'create' | 'update' | 'delete'
 export type MemoryPrivacyClassification = 'public' | 'internal' | 'sensitive' | 'restricted'
 export type DreamRunStatus = 'running' | 'completed' | 'failed' | 'cancelled' | 'archived'
 
+export const APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES: readonly ImprovementProposalTargetType[] = ['memory']
+
+export function canApproveImprovementProposalTarget(targetType: ImprovementProposalTargetType) {
+  return APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES.includes(targetType)
+}
+
 export interface ImprovementSchemaVersionedRecord {
   schemaVersion: number
 }

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -305,6 +305,28 @@ test('memory improvement proposal approval rejects proposals without memory diff
   assert.equal(listAgentMemoryEntries().length, 0)
 }))
 
+test('unsupported improvement proposal targets cannot be marked approved without an applicator', () => withImprovementStore('proposal-unsupported-target', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'agent',
+    targetId: 'analyst',
+    title: 'Tune analyst agent',
+    summary: 'Agent profile changes must not be accepted without a typed persistence path.',
+    evidence: [evidence('eval-agent')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'agent',
+      targetId: 'analyst',
+      summary: 'Update analyst instructions.',
+      payload: { instructions: 'Prefer concise evidence notes.' },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /not wired to an existing persistence path/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+}))
+
 test('memory update proposal approval rejects stale target ids', () => withImprovementStore('proposal-stale-memory-update', () => {
   const proposal = createImprovementProposal({
     targetType: 'memory',


### PR DESCRIPTION
## Summary
- add a shared approvable-target helper for governed improvement proposals
- prevent non-wired proposal targets from being marked approved without a persistence applicator
- show Pulse reviewers that non-memory proposal targets can be rejected, archived, or left queued but not approved yet

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-store.test.ts
- pnpm --dir apps/desktop test:renderer -- PulseImprovementInbox
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- git diff --check