### PR TITLE
[codex] apply reviewed skill improvement proposals

### DIFF
--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -16,6 +16,7 @@ import {
   type DreamRunDraft,
   type DreamRunStatus,
   type DreamRunStatusCounts,
+  type CustomSkillConfig,
   type ImprovementCandidateDiff,
   type ImprovementDiagnosticsSummary,
   type ImprovementEvidenceKind,
@@ -35,6 +36,11 @@ import {
   isImprovementProposalEnabledForScope,
   type ImprovementProposalPolicyScope,
 } from './improvement-policy.ts'
+import {
+  listCustomSkills,
+  removeCustomSkill,
+  saveCustomSkill,
+} from './native-customizations.ts'
 import { loadSettings } from './settings.ts'
 
 export const IMPROVEMENT_STORE_SCHEMA_VERSION = 1
@@ -518,10 +524,48 @@ function payloadString(payload: Record<string, unknown>, key: string) {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
+function payloadRawString(payload: Record<string, unknown>, key: string, label: string, maxBytes = MAX_JSON_BYTES) {
+  if (!(key in payload)) return null
+  const value = payload[key]
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  if (!value.trim()) return null
+  if (Buffer.byteLength(value, 'utf8') > maxBytes) throw new Error(`${label} is too large.`)
+  return value
+}
+
 function payloadStringArray(payload: Record<string, unknown>, key: string) {
   const value = payload[key]
   if (!Array.isArray(value)) return null
   return value.filter((entry): entry is string => typeof entry === 'string' && Boolean(entry.trim()))
+}
+
+function payloadStringArrayOrDefault(payload: Record<string, unknown>, key: string, fallback: string[]) {
+  if (!(key in payload)) return fallback
+  const value = payload[key]
+  if (!Array.isArray(value)) throw new Error(`${key} must be an array of strings.`)
+  return Array.from(new Set(value.map((entry) => boundedText(entry, key, 512)))).sort((a, b) => a.localeCompare(b))
+}
+
+function payloadSkillFilesOrDefault(
+  payload: Record<string, unknown>,
+  fallback: NonNullable<CustomSkillConfig['files']>,
+): NonNullable<CustomSkillConfig['files']> {
+  if (!('files' in payload)) return fallback
+  const value = payload.files
+  if (!Array.isArray(value)) throw new Error('Skill proposal files must be an array.')
+  return value.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Skill proposal file ${index + 1} must be an object.`)
+    }
+    const raw = entry as Record<string, unknown>
+    if (typeof raw.content !== 'string') {
+      throw new Error(`Skill proposal file ${index + 1} content must be a string.`)
+    }
+    return {
+      path: boundedText(raw.path, `Skill proposal file ${index + 1} path`, 1024),
+      content: raw.content,
+    }
+  })
 }
 
 export function createImprovementProposal(
@@ -670,6 +714,68 @@ function applyApprovedMemoryProposal(proposal: ImprovementProposal, reviewer: st
   if (appliedMemoryDiffs < 1) throw new Error('Memory improvement proposal has no memory candidate diff to apply.')
 }
 
+type SkillProposalRef = {
+  scope: 'machine'
+  directory: null
+  name: string
+}
+
+function skillProposalRef(diff: ImprovementCandidateDiff): SkillProposalRef {
+  const scope = payloadString(diff.payload, 'scope') || 'machine'
+  if (scope !== 'machine') {
+    throw new Error('Project-scoped skill improvement proposals need an explicit project grant before approval.')
+  }
+  return {
+    scope: 'machine',
+    directory: null,
+    name: payloadString(diff.payload, 'name') || diff.targetId || '',
+  }
+}
+
+function findCustomSkillByRef(ref: SkillProposalRef) {
+  return listCustomSkills()
+    .find((skill) => skill.scope === ref.scope && skill.name === ref.name) || null
+}
+
+function skillDraftFromDiff(diff: ImprovementCandidateDiff, ref: SkillProposalRef, existing: CustomSkillConfig | null): CustomSkillConfig {
+  const content = payloadRawString(diff.payload, 'content', 'Skill proposal content') || existing?.content || ''
+  if (!content) throw new Error('Skill improvement proposal requires SKILL.md content.')
+  return {
+    scope: ref.scope,
+    directory: ref.directory,
+    name: ref.name,
+    content,
+    files: payloadSkillFilesOrDefault(diff.payload, existing?.files || []),
+    toolIds: payloadStringArrayOrDefault(diff.payload, 'toolIds', existing?.toolIds || []),
+  }
+}
+
+function applyApprovedSkillProposal(proposal: ImprovementProposal) {
+  let appliedSkillDiffs = 0
+  for (const diff of proposal.candidateDiffs) {
+    if (diff.targetType !== 'skill') continue
+    appliedSkillDiffs += 1
+    const ref = skillProposalRef(diff)
+    if (!ref.name) throw new Error('Skill improvement proposal requires a target skill name.')
+    const existing = findCustomSkillByRef(ref)
+
+    if (diff.operation === 'delete') {
+      if (!existing) throw new Error('Skill delete proposal target does not exist.')
+      removeCustomSkill(ref)
+      continue
+    }
+    if (diff.operation === 'create' && existing) {
+      throw new Error('Skill create proposal target already exists.')
+    }
+    if (diff.operation === 'update' && !existing) {
+      throw new Error('Skill update proposal target does not exist.')
+    }
+
+    saveCustomSkill(skillDraftFromDiff(diff, ref, existing))
+  }
+  if (appliedSkillDiffs < 1) throw new Error('Skill improvement proposal has no skill candidate diff to apply.')
+}
+
 function reviewImprovementProposal(id: string, status: Exclude<ImprovementProposalStatus, 'proposed'>, reviewedBy: string, note?: string | null) {
   return withImprovementTransaction(() => {
     const proposal = getImprovementProposal(id)
@@ -684,6 +790,8 @@ function reviewImprovementProposal(id: string, status: Exclude<ImprovementPropos
       }
       if (proposal.targetType === 'memory') {
         applyApprovedMemoryProposal(proposal, reviewer, reviewNote)
+      } else if (proposal.targetType === 'skill') {
+        applyApprovedSkillProposal(proposal)
       }
     }
     const now = nowIso()

--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -720,6 +720,12 @@ type SkillProposalRef = {
   name: string
 }
 
+type PlannedSkillProposalApply = {
+  ref: SkillProposalRef
+  previous: CustomSkillConfig | null
+  next: CustomSkillConfig | null
+}
+
 function skillProposalRef(diff: ImprovementCandidateDiff): SkillProposalRef {
   const scope = payloadString(diff.payload, 'scope') || 'machine'
   if (scope !== 'machine') {
@@ -737,6 +743,19 @@ function findCustomSkillByRef(ref: SkillProposalRef) {
     .find((skill) => skill.scope === ref.scope && skill.name === ref.name) || null
 }
 
+function skillRefKey(ref: SkillProposalRef) {
+  return `${ref.scope}:${ref.name}`
+}
+
+function cloneCustomSkill(skill: CustomSkillConfig | null): CustomSkillConfig | null {
+  if (!skill) return null
+  return {
+    ...skill,
+    files: skill.files?.map((file) => ({ ...file })),
+    toolIds: skill.toolIds ? [...skill.toolIds] : undefined,
+  }
+}
+
 function skillDraftFromDiff(diff: ImprovementCandidateDiff, ref: SkillProposalRef, existing: CustomSkillConfig | null): CustomSkillConfig {
   const content = payloadRawString(diff.payload, 'content', 'Skill proposal content') || existing?.content || ''
   if (!content) throw new Error('Skill improvement proposal requires SKILL.md content.')
@@ -750,18 +769,27 @@ function skillDraftFromDiff(diff: ImprovementCandidateDiff, ref: SkillProposalRe
   }
 }
 
-function applyApprovedSkillProposal(proposal: ImprovementProposal) {
+function planApprovedSkillProposal(proposal: ImprovementProposal): PlannedSkillProposalApply[] {
   let appliedSkillDiffs = 0
+  const originalByKey = new Map<string, { ref: SkillProposalRef, skill: CustomSkillConfig | null }>()
+  const simulatedByKey = new Map<string, CustomSkillConfig | null>()
+
   for (const diff of proposal.candidateDiffs) {
     if (diff.targetType !== 'skill') continue
     appliedSkillDiffs += 1
     const ref = skillProposalRef(diff)
     if (!ref.name) throw new Error('Skill improvement proposal requires a target skill name.')
-    const existing = findCustomSkillByRef(ref)
+    const key = skillRefKey(ref)
+    if (!originalByKey.has(key)) {
+      const existing = cloneCustomSkill(findCustomSkillByRef(ref))
+      originalByKey.set(key, { ref, skill: existing })
+      simulatedByKey.set(key, cloneCustomSkill(existing))
+    }
+    const existing = simulatedByKey.get(key) || null
 
     if (diff.operation === 'delete') {
       if (!existing) throw new Error('Skill delete proposal target does not exist.')
-      removeCustomSkill(ref)
+      simulatedByKey.set(key, null)
       continue
     }
     if (diff.operation === 'create' && existing) {
@@ -771,9 +799,58 @@ function applyApprovedSkillProposal(proposal: ImprovementProposal) {
       throw new Error('Skill update proposal target does not exist.')
     }
 
-    saveCustomSkill(skillDraftFromDiff(diff, ref, existing))
+    simulatedByKey.set(key, skillDraftFromDiff(diff, ref, existing))
   }
   if (appliedSkillDiffs < 1) throw new Error('Skill improvement proposal has no skill candidate diff to apply.')
+
+  return Array.from(originalByKey.entries()).map(([key, original]) => ({
+    ref: original.ref,
+    previous: cloneCustomSkill(original.skill),
+    next: cloneCustomSkill(simulatedByKey.get(key) || null),
+  }))
+}
+
+function rollbackSkillProposalPlan(applied: PlannedSkillProposalApply[]) {
+  const rollbackErrors: string[] = []
+  for (const operation of [...applied].reverse()) {
+    try {
+      if (operation.previous) {
+        saveCustomSkill(operation.previous)
+      } else {
+        removeCustomSkill(operation.ref)
+      }
+    } catch (error) {
+      rollbackErrors.push(error instanceof Error ? error.message : String(error))
+    }
+  }
+  if (rollbackErrors.length > 0) {
+    throw new Error(`Skill improvement proposal rollback failed: ${rollbackErrors.join('; ')}`)
+  }
+}
+
+function applyApprovedSkillProposal(proposal: ImprovementProposal) {
+  const plan = planApprovedSkillProposal(proposal)
+  const applied: PlannedSkillProposalApply[] = []
+  try {
+    for (const operation of plan) {
+      if (operation.next) {
+        saveCustomSkill(operation.next)
+      } else if (operation.previous) {
+        removeCustomSkill(operation.ref)
+      }
+      applied.push(operation)
+    }
+  } catch (error) {
+    try {
+      rollbackSkillProposalPlan(applied)
+    } catch (rollbackError) {
+      throw new Error(
+        `Skill improvement proposal failed (${error instanceof Error ? error.message : String(error)}) and rollback was incomplete.`,
+        { cause: rollbackError },
+      )
+    }
+    throw error
+  }
 }
 
 function reviewImprovementProposal(id: string, status: Exclude<ImprovementProposalStatus, 'proposed'>, reviewedBy: string, note?: string | null) {

--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -7,7 +7,7 @@ import {
   COWORK_DREAM_RUN_SCHEMA_VERSION,
   COWORK_IMPROVEMENT_SCHEMA_VERSION,
   COWORK_MEMORY_SCHEMA_VERSION,
-  canApproveImprovementProposalTarget,
+  improvementProposalApprovalBlockReason,
   type AgentMemoryDraft,
   type AgentMemoryEntry,
   type AgentMemoryScopeKind,
@@ -862,8 +862,11 @@ function reviewImprovementProposal(id: string, status: Exclude<ImprovementPropos
     const reviewer = boundedText(reviewedBy, 'Improvement reviewer', 512)
     const reviewNote = optionalBoundedText(note, 'Improvement review note', 4096)
     if (status === 'approved') {
-      if (!canApproveImprovementProposalTarget(proposal.targetType)) {
+      const approvalBlockReason = improvementProposalApprovalBlockReason(proposal)
+      if (approvalBlockReason === 'target-type') {
         throw new Error(`Approval for ${proposal.targetType} improvement proposals is not wired to an existing persistence path yet.`)
+      } else if (approvalBlockReason === 'skill-scope') {
+        throw new Error('Project-scoped skill improvement proposals need an explicit project grant before approval.')
       }
       if (proposal.targetType === 'memory') {
         applyApprovedMemoryProposal(proposal, reviewer, reviewNote)

--- a/apps/desktop/src/main/ipc/improvement-handlers.ts
+++ b/apps/desktop/src/main/ipc/improvement-handlers.ts
@@ -85,7 +85,12 @@ export function registerImprovementHandlers(context: IpcHandlerContext) {
   })
 
   context.ipcMain.handle('improvements:proposal-approve', async (_event, id: unknown, note?: unknown) => {
-    return approveImprovementProposal(assertString(id, 'Improvement proposal id'), 'local-user', optionalNote(note))
+    const proposal = approveImprovementProposal(assertString(id, 'Improvement proposal id'), 'local-user', optionalNote(note))
+    if (proposal?.status === 'approved' && proposal.targetType === 'skill') {
+      const { rebootRuntime } = await import('../index.ts')
+      await rebootRuntime()
+    }
+    return proposal
   })
 
   context.ipcMain.handle('improvements:proposal-reject', async (_event, id: unknown, note?: unknown) => {

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -124,6 +124,33 @@ const unsupportedProposalQueue: ImprovementReviewQueue = {
   ],
 }
 
+const skillProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...unsupportedProposalQueue.proposals[0]!,
+      id: 'proposal-skill',
+      targetType: 'skill',
+      targetId: 'analyst-notes',
+      title: 'Update analyst notes skill',
+      candidateDiffs: [
+        {
+          ...unsupportedProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetType: 'skill',
+          targetId: 'analyst-notes',
+          summary: 'Update analyst notes skill.',
+          payload: {
+            scope: 'machine',
+            name: 'analyst-notes',
+            content: '---\nname: analyst-notes\ndescription: Analyst notes.\n---\n\nPrefer concise evidence notes.\n',
+          },
+        },
+      ],
+    },
+  ],
+}
+
 describe('PulseImprovementInbox', () => {
   it('renders inspectable evidence, candidate diffs, memory provenance, and dream-run metadata', () => {
     render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
@@ -193,6 +220,18 @@ describe('PulseImprovementInbox', () => {
     expect(approve).toBeDisabled()
     await user.click(approve)
     expect(onReview).not.toHaveBeenCalled()
+  })
+
+  it('offers approval for skill proposals with a typed persistence path', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={skillProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.queryByText('Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.')).not.toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).not.toBeDisabled()
+    await user.click(approve)
+    expect(onReview).toHaveBeenCalledWith('proposal-skill', 'approve-proposal')
   })
 
   it('clears the edit lock when the edited proposal leaves the visible inbox', async () => {

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -151,6 +151,31 @@ const skillProposalQueue: ImprovementReviewQueue = {
   ],
 }
 
+const projectSkillProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...skillProposalQueue.proposals[0]!,
+      id: 'proposal-project-skill',
+      targetId: 'project-notes',
+      title: 'Update project notes skill',
+      candidateDiffs: [
+        {
+          ...skillProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetId: 'project-notes',
+          payload: {
+            scope: 'project',
+            directory: '/tmp/project',
+            name: 'project-notes',
+            content: '---\nname: project-notes\ndescription: Project notes.\n---\n\nPrefer local project notes.\n',
+          },
+        },
+      ],
+    },
+  ],
+}
+
 describe('PulseImprovementInbox', () => {
   it('renders inspectable evidence, candidate diffs, memory provenance, and dream-run metadata', () => {
     render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
@@ -232,6 +257,18 @@ describe('PulseImprovementInbox', () => {
     expect(approve).not.toBeDisabled()
     await user.click(approve)
     expect(onReview).toHaveBeenCalledWith('proposal-skill', 'approve-proposal')
+  })
+
+  it('does not offer approval for project-scoped skill proposals until grants are wired', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={projectSkillProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.getByText('Project-scoped skill proposals need an explicit project grant before approval. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).toBeDisabled()
+    await user.click(approve)
+    expect(onReview).not.toHaveBeenCalled()
   })
 
   it('clears the edit lock when the edited proposal leaves the visible inbox', async () => {

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react'
-import { canApproveImprovementProposalTarget, type ImprovementProposalDraft, type ImprovementReviewQueue } from '@open-cowork/shared'
+import {
+  improvementProposalApprovalBlockReason,
+  type ImprovementProposalDraft,
+  type ImprovementReviewQueue,
+} from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
 import { DreamRunInspection, MemoryInspection, ProposalInspection } from './PulseImprovementInspection'
 import { PulseImprovementProposalEditor } from './PulseImprovementProposalEditor'
@@ -77,11 +81,17 @@ export function PulseImprovementInbox({ inbox, actionId, onReview, onUpdatePropo
   return (
     <div className="mt-4 space-y-3">
       {visibleProposals.map((proposal) => {
-        const canApproveProposal = canApproveImprovementProposalTarget(proposal.targetType)
-        const approvalUnavailableMessage = t(
-          'homepage.card.proposalApprovalUnavailable',
-          'Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.',
-        )
+        const approvalBlockReason = improvementProposalApprovalBlockReason(proposal)
+        const canApproveProposal = approvalBlockReason === null
+        const approvalUnavailableMessage = approvalBlockReason === 'skill-scope'
+          ? t(
+              'homepage.card.skillProposalApprovalUnavailable',
+              'Project-scoped skill proposals need an explicit project grant before approval. Reject, archive, or leave it queued for now.',
+            )
+          : t(
+              'homepage.card.proposalApprovalUnavailable',
+              'Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.',
+            )
         return (
           <div
             key={`proposal:${proposal.id}`}

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -17,6 +17,30 @@ export function canApproveImprovementProposalTarget(targetType: ImprovementPropo
   return APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES.includes(targetType)
 }
 
+export type ImprovementProposalApprovalBlockReason = 'target-type' | 'skill-scope'
+
+function proposalPayloadString(payload: Record<string, unknown>, key: string) {
+  const value = payload[key]
+  return typeof value === 'string' ? value : null
+}
+
+export function improvementProposalApprovalBlockReason(
+  proposal: Pick<ImprovementProposal, 'targetType' | 'candidateDiffs'>,
+): ImprovementProposalApprovalBlockReason | null {
+  if (!canApproveImprovementProposalTarget(proposal.targetType)) return 'target-type'
+  if (proposal.targetType !== 'skill') return null
+
+  const skillDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'skill')
+  if (skillDiffs.length < 1) return 'skill-scope'
+  return skillDiffs.every((diff) => (proposalPayloadString(diff.payload, 'scope') || 'machine') === 'machine')
+    ? null
+    : 'skill-scope'
+}
+
+export function canApproveImprovementProposal(proposal: Pick<ImprovementProposal, 'targetType' | 'candidateDiffs'>) {
+  return improvementProposalApprovalBlockReason(proposal) === null
+}
+
 export interface ImprovementSchemaVersionedRecord {
   schemaVersion: number
 }

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -11,7 +11,7 @@ export type ImprovementDiffOperation = 'create' | 'update' | 'delete'
 export type MemoryPrivacyClassification = 'public' | 'internal' | 'sensitive' | 'restricted'
 export type DreamRunStatus = 'running' | 'completed' | 'failed' | 'cancelled' | 'archived'
 
-export const APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES: readonly ImprovementProposalTargetType[] = ['memory']
+export const APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES: readonly ImprovementProposalTargetType[] = ['memory', 'skill']
 
 export function canApproveImprovementProposalTarget(targetType: ImprovementProposalTargetType) {
   return APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES.includes(targetType)

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -11,7 +11,7 @@ export type ImprovementDiffOperation = 'create' | 'update' | 'delete'
 export type MemoryPrivacyClassification = 'public' | 'internal' | 'sensitive' | 'restricted'
 export type DreamRunStatus = 'running' | 'completed' | 'failed' | 'cancelled' | 'archived'
 
-export const APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES: readonly ImprovementProposalTargetType[] = ['memory', 'skill']
+export const APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES: readonly ImprovementProposalTargetType[] = ['memory']
 
 export function canApproveImprovementProposalTarget(targetType: ImprovementProposalTargetType) {
   return APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES.includes(targetType)
@@ -27,14 +27,14 @@ function proposalPayloadString(payload: Record<string, unknown>, key: string) {
 export function improvementProposalApprovalBlockReason(
   proposal: Pick<ImprovementProposal, 'targetType' | 'candidateDiffs'>,
 ): ImprovementProposalApprovalBlockReason | null {
-  if (!canApproveImprovementProposalTarget(proposal.targetType)) return 'target-type'
-  if (proposal.targetType !== 'skill') return null
-
-  const skillDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'skill')
-  if (skillDiffs.length < 1) return 'skill-scope'
-  return skillDiffs.every((diff) => (proposalPayloadString(diff.payload, 'scope') || 'machine') === 'machine')
-    ? null
-    : 'skill-scope'
+  if (proposal.targetType === 'skill') {
+    const skillDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'skill')
+    if (skillDiffs.length < 1) return 'skill-scope'
+    return skillDiffs.every((diff) => (proposalPayloadString(diff.payload, 'scope') || 'machine') === 'machine')
+      ? null
+      : 'skill-scope'
+  }
+  return canApproveImprovementProposalTarget(proposal.targetType) ? null : 'target-type'
 }
 
 export function canApproveImprovementProposal(proposal: Pick<ImprovementProposal, 'targetType' | 'candidateDiffs'>) {

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -37,6 +37,7 @@ import {
   startDreamRun,
   updateImprovementProposal,
 } from '../apps/desktop/src/main/improvement-store.ts'
+import { listCustomSkills } from '../apps/desktop/src/main/native-customizations.ts'
 
 function uniqueUserDataDir(name: string) {
   return join(tmpdir(), `open-cowork-improvement-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
@@ -104,6 +105,10 @@ function memoryDiff(overrides: Partial<ImprovementCandidateDiff> = {}): Improvem
     },
     ...overrides,
   }
+}
+
+function skillContent(name: string, body = 'Use evidence-backed defaults when this skill is loaded.') {
+  return `---\nname: ${name}\ndescription: ${name} guidance.\n---\n\n${body}\n`
 }
 
 function settings(overrides: Partial<AppSettings> = {}): AppSettings {
@@ -323,6 +328,116 @@ test('unsupported improvement proposal targets cannot be marked approved without
   assert.throws(
     () => approveImprovementProposal(proposal.id, 'local-user'),
     /not wired to an existing persistence path/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+}))
+
+test('approving machine skill improvement proposals applies through custom skill persistence', () => withImprovementStore('proposal-skill-apply', () => {
+  const createProposal = createImprovementProposal({
+    targetType: 'skill',
+    targetId: 'analyst-notes',
+    title: 'Create analyst notes skill',
+    summary: 'A reviewed skill proposal should write through the custom skill store.',
+    evidence: [evidence('trace-skill-create')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'skill',
+      targetId: 'analyst-notes',
+      operation: 'create',
+      summary: 'Create analyst notes skill.',
+      afterHash: 'sha256:skill-create',
+      payload: {
+        scope: 'machine',
+        name: 'analyst-notes',
+        content: skillContent('analyst-notes'),
+        toolIds: ['charts'],
+        files: [{ path: 'examples/report.md', content: '# Report example\n' }],
+      },
+    })],
+  })
+
+  const approvedCreate = approveImprovementProposal(createProposal.id, 'local-user')
+  const created = listCustomSkills().find((skill) => skill.name === 'analyst-notes')
+  assert.equal(approvedCreate?.status, 'approved')
+  assert.ok(created)
+  assert.equal(created?.scope, 'machine')
+  assert.deepEqual(created?.toolIds, ['charts'])
+  assert.equal(created?.files?.[0]?.path, 'examples/report.md')
+
+  const updateProposal = createImprovementProposal({
+    targetType: 'skill',
+    targetId: 'analyst-notes',
+    title: 'Update analyst notes skill',
+    summary: 'A reviewed update should replace the bundle atomically through the skill store.',
+    evidence: [evidence('trace-skill-update')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'skill',
+      targetId: 'analyst-notes',
+      operation: 'update',
+      summary: 'Update analyst notes skill body.',
+      beforeHash: 'sha256:skill-create',
+      afterHash: 'sha256:skill-update',
+      payload: {
+        scope: 'machine',
+        name: 'analyst-notes',
+        content: skillContent('analyst-notes', 'Prefer one chart and one source link per answer.'),
+        toolIds: ['charts', 'browser'],
+      },
+    })],
+  })
+
+  approveImprovementProposal(updateProposal.id, 'local-user')
+  const updated = listCustomSkills().find((skill) => skill.name === 'analyst-notes')
+  assert.match(updated?.content || '', /Prefer one chart/)
+  assert.deepEqual(updated?.toolIds, ['browser', 'charts'])
+
+  const deleteProposal = createImprovementProposal({
+    targetType: 'skill',
+    targetId: 'analyst-notes',
+    title: 'Archive analyst notes skill',
+    summary: 'A reviewed delete should remove the custom skill bundle.',
+    evidence: [evidence('trace-skill-delete')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'skill',
+      targetId: 'analyst-notes',
+      operation: 'delete',
+      summary: 'Remove analyst notes skill.',
+      beforeHash: 'sha256:skill-update',
+      afterHash: null,
+      payload: {
+        scope: 'machine',
+        name: 'analyst-notes',
+      },
+    })],
+  })
+
+  approveImprovementProposal(deleteProposal.id, 'local-user')
+  assert.equal(listCustomSkills().some((skill) => skill.name === 'analyst-notes'), false)
+}))
+
+test('skill improvement proposal approval rejects project scope until directory grants are wired', () => withImprovementStore('proposal-skill-project-scope', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'skill',
+    targetId: 'project-notes',
+    title: 'Create project skill',
+    summary: 'Project skill proposals need explicit project grant wiring.',
+    evidence: [evidence('trace-project-skill')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'skill',
+      targetId: 'project-notes',
+      operation: 'create',
+      summary: 'Create project scoped skill.',
+      payload: {
+        scope: 'project',
+        directory: '/tmp/project',
+        name: 'project-notes',
+        content: skillContent('project-notes'),
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /Project-scoped skill improvement proposals need an explicit project grant/,
   )
   assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
 }))

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -414,6 +414,47 @@ test('approving machine skill improvement proposals applies through custom skill
   assert.equal(listCustomSkills().some((skill) => skill.name === 'analyst-notes'), false)
 }))
 
+test('skill improvement proposal approval validates every diff before writing skill bundles', () => withImprovementStore('proposal-skill-apply-atomic', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'skill',
+    targetId: 'analyst-notes',
+    title: 'Create duplicate skill diffs',
+    summary: 'Conflicting diffs should not leave partial skill files on disk.',
+    evidence: [evidence('trace-skill-conflict')],
+    candidateDiffs: [
+      memoryDiff({
+        targetType: 'skill',
+        targetId: 'analyst-notes',
+        operation: 'create',
+        summary: 'Create analyst notes skill.',
+        payload: {
+          scope: 'machine',
+          name: 'analyst-notes',
+          content: skillContent('analyst-notes'),
+        },
+      }),
+      memoryDiff({
+        targetType: 'skill',
+        targetId: 'analyst-notes',
+        operation: 'create',
+        summary: 'Create the same skill again.',
+        payload: {
+          scope: 'machine',
+          name: 'analyst-notes',
+          content: skillContent('analyst-notes', 'Duplicate content.'),
+        },
+      }),
+    ],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /already exists/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+  assert.equal(listCustomSkills().some((skill) => skill.name === 'analyst-notes'), false)
+}))
+
 test('skill improvement proposal approval rejects project scope until directory grants are wired', () => withImprovementStore('proposal-skill-project-scope', () => {
   const proposal = createImprovementProposal({
     targetType: 'skill',


### PR DESCRIPTION
## Summary
- allow reviewed machine-scope skill proposals to create, update, and delete custom skills through the existing custom skill store
- keep project-scoped skill proposals blocked until they can be tied to an explicit project grant
- reboot the managed OpenCode runtime after an approved skill proposal changes persisted skill content
- extend Pulse coverage so skill proposals are approvable while unsupported target types stay blocked

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-store.test.ts
- pnpm --dir apps/desktop test:renderer -- PulseImprovementInbox
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- git diff --check