### PR TITLE
[codex] apply reviewed crew improvement proposals

### DIFF
--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -13,6 +13,7 @@ import {
   type AgentMemoryEntry,
   type AgentMemoryScopeKind,
   type AgentMemoryStatus,
+  type CrewDefinitionDraft,
   type DreamRun,
   type DreamRunDraft,
   type DreamRunStatus,
@@ -55,6 +56,12 @@ import {
   validateCustomAgent,
   type CustomAgentCatalog,
 } from './custom-agents.ts'
+import {
+  createCrewFromDraft,
+  getCrewDetail,
+  updateCrewFromDraft,
+  validateCrewDefinitionDraft,
+} from './crew-service.ts'
 
 export const IMPROVEMENT_STORE_SCHEMA_VERSION = 1
 
@@ -995,6 +1002,108 @@ function applyApprovedAgentProposal(proposal: ImprovementProposal) {
   }
 }
 
+type PlannedCrewProposalApply = {
+  operation: 'create' | 'update'
+  crewId: string | null
+  draft: CrewDefinitionDraft
+}
+
+function payloadCrewMembersOrDefault(
+  payload: Record<string, unknown>,
+  fallback: CrewDefinitionDraft['members'],
+): CrewDefinitionDraft['members'] {
+  if (!('members' in payload)) return fallback
+  const value = payload.members
+  if (!Array.isArray(value)) throw new Error('Crew proposal members must be an array.')
+  return value.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Crew proposal member ${index + 1} must be an object.`)
+    }
+    const record = entry as Record<string, unknown>
+    const required = 'required' in record ? payloadBooleanOrDefault(record, 'required', true) : undefined
+    return {
+      role: boundedText(record.role, `Crew proposal member ${index + 1} role`, 64) as CrewDefinitionDraft['members'][number]['role'],
+      agentName: boundedText(record.agentName, `Crew proposal member ${index + 1} agent name`, 128),
+      displayName: optionalBoundedText(record.displayName, `Crew proposal member ${index + 1} display name`, 256) || undefined,
+      description: optionalBoundedText(record.description, `Crew proposal member ${index + 1} description`, 2048) || undefined,
+      ...(required === undefined ? {} : { required }),
+    }
+  })
+}
+
+function crewDraftFromDetail(detail: NonNullable<ReturnType<typeof getCrewDetail>>): CrewDefinitionDraft {
+  const activeVersion = detail.activeVersion
+  if (!activeVersion) throw new Error(`Crew ${detail.definition.id} has no active version.`)
+  return {
+    name: detail.definition.name,
+    description: detail.definition.description,
+    members: activeVersion.members.map((member) => ({
+      role: member.role,
+      agentName: member.agentName,
+      displayName: member.displayName,
+      description: member.description,
+      required: member.required,
+    })),
+    workspaceProfileId: activeVersion.workspaceProfileId,
+    outcomeRubricId: activeVersion.outcomeRubricId,
+    evalSuiteId: activeVersion.evalSuiteId,
+    budgetCapUsd: activeVersion.budgetCapUsd,
+  }
+}
+
+function crewDraftFromDiff(diff: ImprovementCandidateDiff, existing: NonNullable<ReturnType<typeof getCrewDetail>> | null): CrewDefinitionDraft {
+  const fallback = existing ? crewDraftFromDetail(existing) : null
+  const draft = {
+    name: payloadString(diff.payload, 'name') || fallback?.name || diff.summary || 'Untitled crew',
+    description: payloadString(diff.payload, 'description') || fallback?.description || diff.summary || 'Crew proposed from governed learning.',
+    members: payloadCrewMembersOrDefault(diff.payload, fallback?.members || []),
+    workspaceProfileId: payloadNullableStringOrDefault(diff.payload, 'workspaceProfileId', fallback?.workspaceProfileId || null, 'Crew proposal workspace profile id'),
+    outcomeRubricId: payloadNullableStringOrDefault(diff.payload, 'outcomeRubricId', fallback?.outcomeRubricId || null, 'Crew proposal outcome rubric id'),
+    evalSuiteId: payloadNullableStringOrDefault(diff.payload, 'evalSuiteId', fallback?.evalSuiteId || null, 'Crew proposal eval suite id'),
+    budgetCapUsd: payloadNullableNumberOrDefault(diff.payload, 'budgetCapUsd', fallback?.budgetCapUsd ?? null, 'Crew proposal budget cap'),
+  }
+  validateCrewDefinitionDraft(draft)
+  return draft
+}
+
+function crewProposalTargetId(diff: ImprovementCandidateDiff) {
+  const targetId = typeof diff.targetId === 'string' && diff.targetId.trim() ? diff.targetId.trim() : null
+  const payloadId = payloadString(diff.payload, 'id')
+  if (targetId && payloadId && targetId !== payloadId) {
+    throw new Error('Crew proposal payload id must match the candidate target id.')
+  }
+  if (diff.operation === 'update' && !targetId) {
+    throw new Error('Crew update proposal requires a target crew id.')
+  }
+  return targetId || payloadId || ''
+}
+
+function planApprovedCrewProposal(proposal: ImprovementProposal): PlannedCrewProposalApply {
+  const crewDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'crew')
+  if (crewDiffs.length !== 1) throw new Error('Crew improvement proposals must contain exactly one crew candidate diff.')
+  const diff = crewDiffs[0]!
+  if (diff.operation === 'delete') throw new Error('Crew delete proposals do not have a typed approval path yet.')
+  const crewId = crewProposalTargetId(diff)
+  const existing = crewId ? getCrewDetail(crewId) : null
+  if (diff.operation === 'create' && existing) throw new Error('Crew create proposal target already exists.')
+  if (diff.operation === 'update' && !existing) throw new Error('Crew update proposal target does not exist.')
+  return {
+    operation: diff.operation,
+    crewId: crewId || null,
+    draft: crewDraftFromDiff(diff, existing),
+  }
+}
+
+function applyApprovedCrewProposal(proposal: ImprovementProposal) {
+  const plan = planApprovedCrewProposal(proposal)
+  if (plan.operation === 'create') {
+    createCrewFromDraft(plan.draft)
+    return
+  }
+  if (!plan.crewId) throw new Error('Crew update proposal requires a target crew id.')
+  updateCrewFromDraft(plan.crewId, plan.draft)
+}
+
 type SkillProposalRef = {
   scope: 'machine'
   directory: null
@@ -1146,6 +1255,8 @@ function reviewImprovementProposal(id: string, status: Exclude<ImprovementPropos
       const approvalBlockReason = improvementProposalApprovalBlockReason(proposal)
       if (approvalBlockReason === 'target-type') {
         throw new Error(`Approval for ${proposal.targetType} improvement proposals is not wired to an existing persistence path yet.`)
+      } else if (approvalBlockReason === 'operation') {
+        throw new Error(`Approval for this ${proposal.targetType} improvement proposal operation is not wired to an existing persistence path yet.`)
       } else if (approvalBlockReason === 'agent-scope') {
         throw new Error('Project-scoped agent improvement proposals need an explicit project grant before approval.')
       } else if (approvalBlockReason === 'skill-scope') {
@@ -1155,6 +1266,8 @@ function reviewImprovementProposal(id: string, status: Exclude<ImprovementPropos
         applyApprovedMemoryProposal(proposal, reviewer, reviewNote)
       } else if (proposal.targetType === 'agent') {
         applyApprovedAgentProposal(proposal)
+      } else if (proposal.targetType === 'crew') {
+        applyApprovedCrewProposal(proposal)
       } else if (proposal.targetType === 'skill') {
         applyApprovedSkillProposal(proposal)
       }

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -230,6 +230,62 @@ const projectSkillProposalQueue: ImprovementReviewQueue = {
   ],
 }
 
+const crewProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...unsupportedProposalQueue.proposals[0]!,
+      id: 'proposal-crew',
+      targetType: 'crew',
+      targetId: null,
+      title: 'Create reporting crew',
+      candidateDiffs: [
+        {
+          ...unsupportedProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetType: 'crew',
+          targetId: null,
+          summary: 'Create reporting crew.',
+          payload: {
+            name: 'Reporting Crew',
+            description: 'Prepares weekly reporting packages.',
+            members: [
+              { role: 'lead', agentName: 'build' },
+              { role: 'specialist', agentName: 'plan' },
+              { role: 'specialist', agentName: 'general' },
+              { role: 'evaluator', agentName: 'explore' },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const crewDeleteProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...crewProposalQueue.proposals[0]!,
+      id: 'proposal-crew-delete',
+      targetId: 'crew-1',
+      title: 'Delete reporting crew',
+      candidateDiffs: [
+        {
+          ...crewProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetId: 'crew-1',
+          operation: 'delete',
+          summary: 'Delete reporting crew.',
+          payload: {
+            id: 'crew-1',
+          },
+        },
+      ],
+    },
+  ],
+}
+
 describe('PulseImprovementInbox', () => {
   it('renders inspectable evidence, candidate diffs, memory provenance, and dream-run metadata', () => {
     render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
@@ -323,6 +379,30 @@ describe('PulseImprovementInbox', () => {
     expect(approve).not.toBeDisabled()
     await user.click(approve)
     expect(onReview).toHaveBeenCalledWith('proposal-agent', 'approve-proposal')
+  })
+
+  it('offers approval for crew create/update proposals with a typed persistence path', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={crewProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.queryByText('Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.')).not.toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).not.toBeDisabled()
+    await user.click(approve)
+    expect(onReview).toHaveBeenCalledWith('proposal-crew', 'approve-proposal')
+  })
+
+  it('does not offer approval for crew operations without an existing typed path', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={crewDeleteProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.getByText('This proposal includes an operation that does not have a typed approval path yet. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).toBeDisabled()
+    await user.click(approve)
+    expect(onReview).not.toHaveBeenCalled()
   })
 
   it('does not offer approval for project-scoped agent proposals until grants are wired', async () => {

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.tsx
@@ -93,6 +93,11 @@ export function PulseImprovementInbox({ inbox, actionId, onReview, onUpdatePropo
               'homepage.card.skillProposalApprovalUnavailable',
               'Project-scoped skill proposals need an explicit project grant before approval. Reject, archive, or leave it queued for now.',
             )
+          : approvalBlockReason === 'operation'
+          ? t(
+              'homepage.card.proposalOperationApprovalUnavailable',
+              'This proposal includes an operation that does not have a typed approval path yet. Reject, archive, or leave it queued for now.',
+            )
           : t(
               'homepage.card.proposalApprovalUnavailable',
               'Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.',

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -17,7 +17,7 @@ export function canApproveImprovementProposalTarget(targetType: ImprovementPropo
   return APPROVABLE_IMPROVEMENT_PROPOSAL_TARGET_TYPES.includes(targetType)
 }
 
-export type ImprovementProposalApprovalBlockReason = 'target-type' | 'agent-scope' | 'skill-scope'
+export type ImprovementProposalApprovalBlockReason = 'target-type' | 'operation' | 'agent-scope' | 'skill-scope'
 
 function proposalPayloadString(payload: Record<string, unknown>, key: string) {
   const value = payload[key]
@@ -40,6 +40,14 @@ export function improvementProposalApprovalBlockReason(
     return skillDiffs.every((diff) => (proposalPayloadString(diff.payload, 'scope') || 'machine') === 'machine')
       ? null
       : 'skill-scope'
+  }
+  if (proposal.targetType === 'crew') {
+    const crewDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'crew')
+    if (crewDiffs.length < 1) return 'target-type'
+    if (crewDiffs.length !== 1) return 'operation'
+    return crewDiffs.every((diff) => diff.operation === 'create' || diff.operation === 'update')
+      ? null
+      : 'operation'
   }
   return canApproveImprovementProposalTarget(proposal.targetType) ? null : 'target-type'
 }

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -9,6 +9,7 @@ import {
   type ImprovementCandidateDiff,
   type ImprovementEvidenceRef,
 } from '../packages/shared/src/improvements.ts'
+import type { CrewDefinitionDraft } from '../packages/shared/src/crews.ts'
 import type { AppSettings } from '../packages/shared/src/app-config.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
@@ -38,6 +39,8 @@ import {
   updateImprovementProposal,
 } from '../apps/desktop/src/main/improvement-store.ts'
 import { listCustomAgents, listCustomSkills } from '../apps/desktop/src/main/native-customizations.ts'
+import { createCrewFromDraft, getCrewDetail, listCrewCatalog } from '../apps/desktop/src/main/crew-service.ts'
+import { clearCrewStoreCache } from '../apps/desktop/src/main/crew-store.ts'
 
 function uniqueUserDataDir(name: string) {
   return join(tmpdir(), `open-cowork-improvement-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
@@ -48,6 +51,7 @@ function resetImprovementStore(userDataDir: string) {
   process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
   clearConfigCaches()
   clearImprovementStoreCache()
+  clearCrewStoreCache()
 }
 
 function withImprovementStore(name: string, fn: () => void) {
@@ -59,6 +63,7 @@ function withImprovementStore(name: string, fn: () => void) {
   } finally {
     closeLogger()
     clearImprovementStoreCache()
+    clearCrewStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -109,6 +114,39 @@ function memoryDiff(overrides: Partial<ImprovementCandidateDiff> = {}): Improvem
 
 function skillContent(name: string, body = 'Use evidence-backed defaults when this skill is loaded.') {
   return `---\nname: ${name}\ndescription: ${name} guidance.\n---\n\n${body}\n`
+}
+
+function crewMembers(): CrewDefinitionDraft['members'] {
+  return [
+    {
+      role: 'lead',
+      agentName: 'build',
+      displayName: 'Build Lead',
+      description: 'Coordinates the crew run.',
+      required: true,
+    },
+    {
+      role: 'specialist',
+      agentName: 'plan',
+      displayName: 'Planner',
+      description: 'Shapes the execution plan.',
+      required: true,
+    },
+    {
+      role: 'specialist',
+      agentName: 'general',
+      displayName: 'Generalist',
+      description: 'Handles broad implementation work.',
+      required: true,
+    },
+    {
+      role: 'evaluator',
+      agentName: 'explore',
+      displayName: 'Evaluator',
+      description: 'Checks the outcome against evidence.',
+      required: true,
+    },
+  ]
 }
 
 function settings(overrides: Partial<AppSettings> = {}): AppSettings {
@@ -330,6 +368,133 @@ test('unsupported improvement proposal targets cannot be marked approved without
     /not wired to an existing persistence path/,
   )
   assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+}))
+
+test('approving crew improvement proposals applies through the crew persistence service', () => withImprovementStore('proposal-crew-apply', () => {
+  const createProposal = createImprovementProposal({
+    targetType: 'crew',
+    targetId: null,
+    title: 'Create reporting crew',
+    summary: 'A reviewed crew proposal should create a typed crew definition.',
+    evidence: [evidence('trace-crew-create')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'crew',
+      targetId: null,
+      operation: 'create',
+      summary: 'Create reporting crew.',
+      afterHash: 'sha256:crew-create',
+      payload: {
+        name: 'Weekly Reporting Crew',
+        description: 'Prepares and evaluates weekly reporting packages.',
+        members: crewMembers(),
+        budgetCapUsd: 12,
+      },
+    })],
+  })
+
+  const approvedCreate = approveImprovementProposal(createProposal.id, 'local-user')
+  const created = listCrewCatalog().crews.find((crew) => crew.definition.name === 'Weekly Reporting Crew')
+  assert.equal(approvedCreate?.status, 'approved')
+  assert.ok(created)
+  assert.equal(created?.activeVersion?.members.length, 4)
+  assert.equal(created?.activeVersion?.budgetCapUsd, 12)
+
+  const updateProposal = createImprovementProposal({
+    targetType: 'crew',
+    targetId: created!.definition.id,
+    title: 'Update reporting crew',
+    summary: 'A reviewed crew update should create a new active crew version.',
+    evidence: [evidence('trace-crew-update')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'crew',
+      targetId: created!.definition.id,
+      operation: 'update',
+      summary: 'Update reporting crew.',
+      beforeHash: 'sha256:crew-create',
+      afterHash: 'sha256:crew-update',
+      payload: {
+        id: created!.definition.id,
+        name: 'Weekly Insights Crew',
+        description: 'Prepares, evaluates, and summarizes weekly insight packages.',
+        members: crewMembers().map((member, index) => index === 1 ? { ...member, required: false } : member),
+        budgetCapUsd: 25,
+      },
+    })],
+  })
+
+  approveImprovementProposal(updateProposal.id, 'local-user')
+  const updated = getCrewDetail(created!.definition.id)
+  assert.equal(updated?.definition.name, 'Weekly Insights Crew')
+  assert.equal(updated?.activeVersion?.version, 2)
+  assert.equal(updated?.activeVersion?.budgetCapUsd, 25)
+  assert.equal(updated?.activeVersion?.members.find((member) => member.agentName === 'plan')?.required, false)
+}))
+
+test('crew improvement proposal approval rejects unsupported delete operations', () => withImprovementStore('proposal-crew-delete', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'crew',
+    targetId: 'crew-to-delete',
+    title: 'Delete crew',
+    summary: 'Crew delete proposals need a typed retire/delete path before approval.',
+    evidence: [evidence('trace-crew-delete')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'crew',
+      targetId: 'crew-to-delete',
+      operation: 'delete',
+      summary: 'Delete crew.',
+      beforeHash: 'sha256:crew',
+      afterHash: null,
+      payload: {
+        id: 'crew-to-delete',
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /operation is not wired/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+}))
+
+test('crew improvement proposal approval rejects mismatched payload and target ids', () => withImprovementStore('proposal-crew-target-mismatch', () => {
+  const first = createCrewFromDraft({
+    name: 'Primary Crew',
+    description: 'Primary crew definition.',
+    members: crewMembers(),
+  })
+  const second = createCrewFromDraft({
+    name: 'Secondary Crew',
+    description: 'Secondary crew definition.',
+    members: crewMembers(),
+  })
+  const proposal = createImprovementProposal({
+    targetType: 'crew',
+    targetId: first.definition.id,
+    title: 'Update primary crew',
+    summary: 'Payload id mismatch should not update another crew.',
+    evidence: [evidence('trace-crew-mismatch')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'crew',
+      targetId: first.definition.id,
+      operation: 'update',
+      summary: 'Update primary crew.',
+      payload: {
+        id: second.definition.id,
+        name: 'Wrong Crew',
+        description: 'This should not be applied.',
+        members: crewMembers(),
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /payload id must match/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+  assert.equal(getCrewDetail(first.definition.id)?.definition.name, 'Primary Crew')
+  assert.equal(getCrewDetail(second.definition.id)?.definition.name, 'Secondary Crew')
 }))
 
 test('approving machine agent improvement proposals applies through custom agent persistence', () => withImprovementStore('proposal-agent-apply', () => {


### PR DESCRIPTION
## Summary
- wire crew-target improvement proposals into the existing crew create/update service paths
- keep crew delete/multi-diff proposals blocked because there is no typed retire/delete persistence path yet
- add operation-aware proposal approval gating for the review inbox
- cover crew create/update persistence and disabled unsupported operations in store and renderer tests

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-store.test.ts
- pnpm --dir apps/desktop test:renderer -- PulseImprovementInbox
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:renderer
- pnpm lint:a11y --max-warnings=0
- git diff --check