### PR TITLE
[codex] apply reviewed SOP improvement proposals

### DIFF
--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -7,6 +7,7 @@ import {
   COWORK_DREAM_RUN_SCHEMA_VERSION,
   COWORK_IMPROVEMENT_SCHEMA_VERSION,
   COWORK_MEMORY_SCHEMA_VERSION,
+  COWORK_SOP_SCHEMA_VERSION,
   improvementProposalApprovalBlockReason,
   type AgentColor,
   type AgentMemoryDraft,
@@ -33,6 +34,7 @@ import {
   type ImprovementStatusCounts,
   type MemoryInjectionPlan,
   type MemoryPrivacyClassification,
+  type SopDraft,
 } from '@open-cowork/shared'
 import { getAppDataDir } from './config-loader.ts'
 import {
@@ -62,6 +64,15 @@ import {
   updateCrewFromDraft,
   validateCrewDefinitionDraft,
 } from './crew-service.ts'
+import {
+  createSop,
+  getSop,
+  updateSop,
+} from './sop-service.ts'
+import {
+  sanitizeRetryPolicy,
+  sanitizeRunPolicy,
+} from './automation-store-model.ts'
 
 export const IMPROVEMENT_STORE_SCHEMA_VERSION = 1
 
@@ -605,6 +616,35 @@ function payloadNullableJsonObjectOrDefault(
   return JSON.parse(JSON.stringify(value)) as Record<string, unknown>
 }
 
+function payloadJsonObjectOrDefault<T extends object>(
+  payload: Record<string, unknown>,
+  key: string,
+  fallback: T,
+  label: string,
+): T {
+  if (!(key in payload)) {
+    if (!fallback || typeof fallback !== 'object' || Array.isArray(fallback)) throw new Error(`${label} fallback must be an object.`)
+    return JSON.parse(JSON.stringify(fallback)) as T
+  }
+  const value = payload[key]
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} must be an object.`)
+  assertJsonSize(value, label)
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function payloadJsonArrayOrDefault<T>(
+  payload: Record<string, unknown>,
+  key: string,
+  fallback: T[],
+  label: string,
+): T[] {
+  if (!(key in payload)) return JSON.parse(JSON.stringify(fallback)) as T[]
+  const value = payload[key]
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array.`)
+  assertJsonSize(value, label)
+  return JSON.parse(JSON.stringify(value)) as T[]
+}
+
 function payloadSkillFilesOrDefault(
   payload: Record<string, unknown>,
   fallback: NonNullable<CustomSkillConfig['files']>,
@@ -1104,6 +1144,117 @@ function applyApprovedCrewProposal(proposal: ImprovementProposal) {
   updateCrewFromDraft(plan.crewId, plan.draft)
 }
 
+type PlannedSopProposalApply = {
+  operation: 'create' | 'update'
+  sopId: string | null
+  draft: SopDraft
+}
+
+const DEFAULT_SOP_APPROVAL_POLICY: NonNullable<SopDraft['approvalPolicy']> = {
+  schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+  reviewFirst: true,
+  approvalBoundary: null,
+}
+
+const DEFAULT_SOP_DELIVERY_POLICY: NonNullable<SopDraft['deliveryPolicy']> = {
+  schemaVersion: COWORK_SOP_SCHEMA_VERSION,
+  provider: 'in_app',
+  target: 'automation-inbox',
+  draftFirst: true,
+}
+
+const SOP_TRIGGER_TYPES = new Set<SopDraft['triggerTypes'][number]>(['manual', 'schedule', 'inbox', 'webhook'])
+
+function payloadSopTriggerTypesOrDefault(payload: Record<string, unknown>, fallback: SopDraft['triggerTypes']) {
+  if (!('triggerTypes' in payload)) return fallback
+  const value = payload.triggerTypes
+  if (!Array.isArray(value)) throw new Error('SOP proposal triggerTypes must be an array.')
+  assertJsonSize(value, 'SOP proposal triggerTypes')
+  const triggerTypes = Array.from(new Set(value.map((entry, index) => {
+    if (typeof entry !== 'string') throw new Error(`SOP proposal trigger type ${index + 1} must be a string.`)
+    const triggerType = entry.trim()
+    if (!SOP_TRIGGER_TYPES.has(triggerType as SopDraft['triggerTypes'][number])) {
+      throw new Error(`SOP proposal trigger type ${index + 1} is invalid.`)
+    }
+    return triggerType as SopDraft['triggerTypes'][number]
+  })))
+  if (triggerTypes.length < 1) throw new Error('SOP proposal triggerTypes must include at least one trigger.')
+  return triggerTypes
+}
+
+function sopDraftFromDetail(detail: NonNullable<ReturnType<typeof getSop>>): SopDraft {
+  const activeVersion = detail.activeVersion
+  if (!activeVersion) throw new Error(`SOP ${detail.definition.id} has no active version.`)
+  return {
+    name: detail.definition.name,
+    description: detail.definition.description,
+    triggerTypes: [...activeVersion.triggerTypes],
+    requiredInputs: activeVersion.requiredInputs.map((input) => ({ ...input })),
+    workflow: activeVersion.workflow.map((step) => ({ ...step })),
+    approvalPolicy: { ...activeVersion.approvalPolicy },
+    retryPolicy: { ...activeVersion.retryPolicy },
+    runPolicy: { ...activeVersion.runPolicy },
+    deliveryPolicy: { ...activeVersion.deliveryPolicy },
+    outcomeRubricId: activeVersion.outcomeRubricId,
+  }
+}
+
+function sopDraftFromDiff(diff: ImprovementCandidateDiff, existing: NonNullable<ReturnType<typeof getSop>> | null): SopDraft {
+  const fallback = existing ? sopDraftFromDetail(existing) : null
+  return {
+    name: payloadString(diff.payload, 'name') || fallback?.name || diff.summary || 'Untitled SOP',
+    description: payloadString(diff.payload, 'description') || fallback?.description || diff.summary || 'SOP proposed from governed learning.',
+    triggerTypes: payloadSopTriggerTypesOrDefault(diff.payload, fallback?.triggerTypes || ['manual']),
+    requiredInputs: payloadJsonArrayOrDefault(diff.payload, 'requiredInputs', fallback?.requiredInputs || [], 'SOP proposal requiredInputs'),
+    workflow: payloadJsonArrayOrDefault(diff.payload, 'workflow', fallback?.workflow || [], 'SOP proposal workflow'),
+    approvalPolicy: payloadJsonObjectOrDefault(diff.payload, 'approvalPolicy', fallback?.approvalPolicy || DEFAULT_SOP_APPROVAL_POLICY, 'SOP proposal approvalPolicy'),
+    retryPolicy: sanitizeRetryPolicy(payloadJsonObjectOrDefault(diff.payload, 'retryPolicy', fallback?.retryPolicy || {}, 'SOP proposal retryPolicy')),
+    runPolicy: sanitizeRunPolicy(payloadJsonObjectOrDefault(diff.payload, 'runPolicy', fallback?.runPolicy || {}, 'SOP proposal runPolicy')),
+    deliveryPolicy: payloadJsonObjectOrDefault(diff.payload, 'deliveryPolicy', fallback?.deliveryPolicy || DEFAULT_SOP_DELIVERY_POLICY, 'SOP proposal deliveryPolicy'),
+    outcomeRubricId: payloadNullableStringOrDefault(diff.payload, 'outcomeRubricId', fallback?.outcomeRubricId || null, 'SOP proposal outcome rubric id'),
+  }
+}
+
+function sopProposalTargetId(diff: ImprovementCandidateDiff) {
+  const targetId = typeof diff.targetId === 'string' && diff.targetId.trim() ? diff.targetId.trim() : null
+  const payloadId = payloadString(diff.payload, 'id')
+  if (targetId && payloadId && targetId !== payloadId) {
+    throw new Error('SOP proposal payload id must match the candidate target id.')
+  }
+  if (diff.operation === 'update' && !targetId) {
+    throw new Error('SOP update proposal requires a target SOP id.')
+  }
+  return targetId || payloadId || ''
+}
+
+function planApprovedSopProposal(proposal: ImprovementProposal): PlannedSopProposalApply {
+  const sopDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'sop')
+  if (proposal.candidateDiffs.length !== 1 || sopDiffs.length !== 1) {
+    throw new Error('SOP improvement proposals must contain exactly one SOP candidate diff.')
+  }
+  const diff = sopDiffs[0]!
+  if (diff.operation === 'delete') throw new Error('SOP delete proposals do not have a typed approval path yet.')
+  const sopId = sopProposalTargetId(diff)
+  const existing = sopId ? getSop(sopId) : null
+  if (diff.operation === 'create' && existing) throw new Error('SOP create proposal target already exists.')
+  if (diff.operation === 'update' && !existing) throw new Error('SOP update proposal target does not exist.')
+  return {
+    operation: diff.operation,
+    sopId: sopId || null,
+    draft: sopDraftFromDiff(diff, existing),
+  }
+}
+
+function applyApprovedSopProposal(proposal: ImprovementProposal) {
+  const plan = planApprovedSopProposal(proposal)
+  if (plan.operation === 'create') {
+    createSop(plan.draft)
+    return
+  }
+  if (!plan.sopId) throw new Error('SOP update proposal requires a target SOP id.')
+  updateSop(plan.sopId, plan.draft)
+}
+
 type SkillProposalRef = {
   scope: 'machine'
   directory: null
@@ -1268,6 +1419,8 @@ function reviewImprovementProposal(id: string, status: Exclude<ImprovementPropos
         applyApprovedAgentProposal(proposal)
       } else if (proposal.targetType === 'crew') {
         applyApprovedCrewProposal(proposal)
+      } else if (proposal.targetType === 'sop') {
+        applyApprovedSopProposal(proposal)
       } else if (proposal.targetType === 'skill') {
         applyApprovedSkillProposal(proposal)
       }

--- a/apps/desktop/src/main/sop-service.ts
+++ b/apps/desktop/src/main/sop-service.ts
@@ -30,6 +30,7 @@ import {
   type DbRow,
 } from './automation-store-model.ts'
 import {
+  createSopDefinition,
   createSopDefinitionWithRunLink,
   getSopDetail,
   getSopRunLinkForAutomationRun,
@@ -139,6 +140,10 @@ export function listSopDefinitions() {
 
 export function getSop(sopId: string) {
   return getSopDetail(sopId)
+}
+
+export function createSop(draft: SopDraft) {
+  return createSopDefinition(draft, { createdBy: 'local-user' })
 }
 
 function listRunInboxItems(run: AutomationRun): AutomationInboxItem[] {

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -286,6 +286,59 @@ const crewDeleteProposalQueue: ImprovementReviewQueue = {
   ],
 }
 
+const sopProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...unsupportedProposalQueue.proposals[0]!,
+      id: 'proposal-sop',
+      targetType: 'sop',
+      targetId: null,
+      title: 'Create reporting SOP',
+      candidateDiffs: [
+        {
+          ...unsupportedProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetType: 'sop',
+          targetId: null,
+          summary: 'Create reporting SOP.',
+          payload: {
+            name: 'Reporting SOP',
+            description: 'Prepares weekly reporting packages.',
+            triggerTypes: ['manual'],
+            retryPolicy: { maxRetries: 1, baseDelayMinutes: 30, maxDelayMinutes: 120 },
+            runPolicy: { dailyRunCap: 1, maxRunDurationMinutes: 60 },
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const sopDeleteProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...sopProposalQueue.proposals[0]!,
+      id: 'proposal-sop-delete',
+      targetId: 'sop-1',
+      title: 'Delete reporting SOP',
+      candidateDiffs: [
+        {
+          ...sopProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetId: 'sop-1',
+          operation: 'delete',
+          summary: 'Delete reporting SOP.',
+          payload: {
+            id: 'sop-1',
+          },
+        },
+      ],
+    },
+  ],
+}
+
 describe('PulseImprovementInbox', () => {
   it('renders inspectable evidence, candidate diffs, memory provenance, and dream-run metadata', () => {
     render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
@@ -397,6 +450,30 @@ describe('PulseImprovementInbox', () => {
     const user = userEvent.setup()
     const onReview = vi.fn()
     render(<PulseImprovementInbox inbox={crewDeleteProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.getByText('This proposal includes an operation that does not have a typed approval path yet. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).toBeDisabled()
+    await user.click(approve)
+    expect(onReview).not.toHaveBeenCalled()
+  })
+
+  it('offers approval for SOP create/update proposals with a typed persistence path', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={sopProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.queryByText('Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.')).not.toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).not.toBeDisabled()
+    await user.click(approve)
+    expect(onReview).toHaveBeenCalledWith('proposal-sop', 'approve-proposal')
+  })
+
+  it('does not offer approval for SOP operations without an existing typed path', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={sopDeleteProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
 
     expect(screen.getByText('This proposal includes an operation that does not have a typed approval path yet. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
     const approve = screen.getByRole('button', { name: 'Approve' })

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -49,6 +49,14 @@ export function improvementProposalApprovalBlockReason(
       ? null
       : 'operation'
   }
+  if (proposal.targetType === 'sop') {
+    const sopDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'sop')
+    if (sopDiffs.length < 1) return 'target-type'
+    if (proposal.candidateDiffs.length !== 1 || sopDiffs.length !== 1) return 'operation'
+    return sopDiffs.every((diff) => diff.operation === 'create' || diff.operation === 'update')
+      ? null
+      : 'operation'
+  }
   return canApproveImprovementProposalTarget(proposal.targetType) ? null : 'target-type'
 }
 

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -10,6 +10,7 @@ import {
   type ImprovementEvidenceRef,
 } from '../packages/shared/src/improvements.ts'
 import type { CrewDefinitionDraft } from '../packages/shared/src/crews.ts'
+import type { SopDraft } from '../packages/shared/src/sops.ts'
 import type { AppSettings } from '../packages/shared/src/app-config.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
@@ -41,6 +42,9 @@ import {
 import { listCustomAgents, listCustomSkills } from '../apps/desktop/src/main/native-customizations.ts'
 import { createCrewFromDraft, getCrewDetail, listCrewCatalog } from '../apps/desktop/src/main/crew-service.ts'
 import { clearCrewStoreCache } from '../apps/desktop/src/main/crew-store.ts'
+import { clearAutomationStoreCache } from '../apps/desktop/src/main/automation-store.ts'
+import { getSop, listSopDefinitions } from '../apps/desktop/src/main/sop-service.ts'
+import { createSopDefinition } from '../apps/desktop/src/main/sop-store.ts'
 
 function uniqueUserDataDir(name: string) {
   return join(tmpdir(), `open-cowork-improvement-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
@@ -52,6 +56,7 @@ function resetImprovementStore(userDataDir: string) {
   clearConfigCaches()
   clearImprovementStoreCache()
   clearCrewStoreCache()
+  clearAutomationStoreCache()
 }
 
 function withImprovementStore(name: string, fn: () => void) {
@@ -64,6 +69,7 @@ function withImprovementStore(name: string, fn: () => void) {
     closeLogger()
     clearImprovementStoreCache()
     clearCrewStoreCache()
+    clearAutomationStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -147,6 +153,55 @@ function crewMembers(): CrewDefinitionDraft['members'] {
       required: true,
     },
   ]
+}
+
+function sopDraft(overrides: Partial<SopDraft> = {}): SopDraft {
+  return {
+    name: 'Weekly Reporting SOP',
+    description: 'Prepares a weekly reporting package.',
+    triggerTypes: ['manual'],
+    requiredInputs: [{
+      schemaVersion: 1,
+      id: 'report-owner',
+      label: 'Report owner',
+      description: 'The person accountable for the report.',
+      required: true,
+    }],
+    workflow: [{
+      schemaVersion: 1,
+      id: 'execute-report',
+      kind: 'execute',
+      title: 'Prepare report',
+      agentName: 'build',
+      approvalRequired: false,
+    }],
+    approvalPolicy: {
+      schemaVersion: 1,
+      reviewFirst: true,
+      approvalBoundary: 'Review before delivery.',
+    },
+    retryPolicy: {
+      maxRetries: 1,
+      baseDelayMinutes: 30,
+      maxDelayMinutes: 120,
+    },
+    runPolicy: {
+      dailyRunCap: 1,
+      maxRunDurationMinutes: 60,
+    },
+    deliveryPolicy: {
+      schemaVersion: 1,
+      provider: 'in_app',
+      target: 'automation-inbox',
+      draftFirst: true,
+    },
+    outcomeRubricId: null,
+    ...overrides,
+  }
+}
+
+function sopPayload(overrides: Partial<SopDraft> = {}): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(sopDraft(overrides))) as Record<string, unknown>
 }
 
 function settings(overrides: Partial<AppSettings> = {}): AppSettings {
@@ -495,6 +550,190 @@ test('crew improvement proposal approval rejects mismatched payload and target i
   assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
   assert.equal(getCrewDetail(first.definition.id)?.definition.name, 'Primary Crew')
   assert.equal(getCrewDetail(second.definition.id)?.definition.name, 'Secondary Crew')
+}))
+
+test('approving SOP improvement proposals applies through the SOP persistence service', () => withImprovementStore('proposal-sop-apply', () => {
+  const createProposal = createImprovementProposal({
+    targetType: 'sop',
+    targetId: null,
+    title: 'Create weekly SOP',
+    summary: 'A reviewed SOP proposal should create a typed SOP definition.',
+    evidence: [evidence('trace-sop-create')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'sop',
+      targetId: null,
+      operation: 'create',
+      summary: 'Create weekly SOP.',
+      afterHash: 'sha256:sop-create',
+      payload: sopPayload({
+        name: 'Weekly Reporting SOP',
+        description: 'Prepares and reviews weekly reporting packages.',
+      }),
+    })],
+  })
+
+  const approvedCreate = approveImprovementProposal(createProposal.id, 'local-user')
+  const created = listSopDefinitions().sops.find((sop) => sop.definition.name === 'Weekly Reporting SOP')
+  assert.equal(approvedCreate?.status, 'approved')
+  assert.ok(created)
+  assert.equal(created?.activeVersion?.triggerTypes.includes('manual'), true)
+  assert.equal(created?.activeVersion?.runPolicy.maxRunDurationMinutes, 60)
+
+  const updateProposal = createImprovementProposal({
+    targetType: 'sop',
+    targetId: created!.definition.id,
+    title: 'Update weekly SOP',
+    summary: 'A reviewed SOP update should create a new active SOP version.',
+    evidence: [evidence('trace-sop-update')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'sop',
+      targetId: created!.definition.id,
+      operation: 'update',
+      summary: 'Update weekly SOP.',
+      beforeHash: 'sha256:sop-create',
+      afterHash: 'sha256:sop-update',
+      payload: {
+        id: created!.definition.id,
+        ...sopDraft({
+          name: 'Weekly Insights SOP',
+          description: 'Prepares, reviews, and delivers weekly insight packages.',
+          runPolicy: {
+            dailyRunCap: 2,
+            maxRunDurationMinutes: 90,
+          },
+        }),
+      },
+    })],
+  })
+
+  approveImprovementProposal(updateProposal.id, 'local-user')
+  const updated = getSop(created!.definition.id)
+  assert.equal(updated?.definition.name, 'Weekly Insights SOP')
+  assert.equal(updated?.activeVersion?.version, 2)
+  assert.equal(updated?.activeVersion?.runPolicy.dailyRunCap, 2)
+  assert.equal(updated?.activeVersion?.runPolicy.maxRunDurationMinutes, 90)
+}))
+
+test('SOP improvement proposal approval rejects unsupported delete operations', () => withImprovementStore('proposal-sop-delete', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'sop',
+    targetId: 'sop-to-delete',
+    title: 'Delete SOP',
+    summary: 'SOP delete proposals need a typed retire/delete path before approval.',
+    evidence: [evidence('trace-sop-delete')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'sop',
+      targetId: 'sop-to-delete',
+      operation: 'delete',
+      summary: 'Delete SOP.',
+      beforeHash: 'sha256:sop',
+      afterHash: null,
+      payload: {
+        id: 'sop-to-delete',
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /operation is not wired/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+}))
+
+test('SOP improvement proposal approval rejects mixed multi-diff payloads', () => withImprovementStore('proposal-sop-mixed-diffs', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'sop',
+    targetId: null,
+    title: 'Create SOP and memory',
+    summary: 'SOP approvals must not apply unrelated candidate diffs.',
+    evidence: [evidence('trace-sop-mixed')],
+    candidateDiffs: [
+      memoryDiff({
+        targetType: 'sop',
+        targetId: null,
+        operation: 'create',
+        summary: 'Create SOP.',
+        payload: sopPayload({ name: 'Mixed SOP' }),
+      }),
+      memoryDiff({
+        targetType: 'memory',
+        targetId: null,
+        operation: 'create',
+        summary: 'Create unrelated memory.',
+        payload: {
+          body: 'This memory must not be applied through SOP approval.',
+        },
+      }),
+    ],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /operation is not wired/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+  assert.equal(listSopDefinitions().sops.some((sop) => sop.definition.name === 'Mixed SOP'), false)
+}))
+
+test('SOP improvement proposal approval rejects invalid trigger types before persistence', () => withImprovementStore('proposal-sop-invalid-trigger', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'sop',
+    targetId: null,
+    title: 'Create SOP with invalid trigger',
+    summary: 'Invalid trigger types should not be normalized into another trigger.',
+    evidence: [evidence('trace-sop-trigger')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'sop',
+      targetId: null,
+      operation: 'create',
+      summary: 'Create SOP.',
+      payload: {
+        ...sopDraft({ name: 'Invalid Trigger SOP' }),
+        triggerTypes: ['manual', 'email'],
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /trigger type 2 is invalid/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+  assert.equal(listSopDefinitions().sops.some((sop) => sop.definition.name === 'Invalid Trigger SOP'), false)
+}))
+
+test('SOP improvement proposal approval rejects mismatched payload and target ids', () => withImprovementStore('proposal-sop-target-mismatch', () => {
+  const first = createSopDefinition(sopDraft({ name: 'Primary SOP', description: 'Primary SOP definition.' }))
+  const second = createSopDefinition(sopDraft({ name: 'Secondary SOP', description: 'Secondary SOP definition.' }))
+  const proposal = createImprovementProposal({
+    targetType: 'sop',
+    targetId: first.definition.id,
+    title: 'Update primary SOP',
+    summary: 'Payload id mismatch should not update another SOP.',
+    evidence: [evidence('trace-sop-mismatch')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'sop',
+      targetId: first.definition.id,
+      operation: 'update',
+      summary: 'Update primary SOP.',
+      payload: {
+        id: second.definition.id,
+        ...sopDraft({
+          name: 'Wrong SOP',
+          description: 'This should not be applied.',
+        }),
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /payload id must match/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+  assert.equal(getSop(first.definition.id)?.definition.name, 'Primary SOP')
+  assert.equal(getSop(second.definition.id)?.definition.name, 'Secondary SOP')
 }))
 
 test('approving machine agent improvement proposals applies through custom agent persistence', () => withImprovementStore('proposal-agent-apply', () => {


### PR DESCRIPTION
## Summary
- Apply approved SOP improvement proposals through the existing SOP service/versioning path for create and update operations.
- Keep SOP delete and mixed multi-diff proposals blocked until there is a typed retire/delete path.
- Validate SOP target ids and trigger types before persistence, with regression coverage for mismatches and invalid payloads.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-store.test.ts
- pnpm --dir apps/desktop test:renderer -- PulseImprovementInbox
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:renderer
- pnpm build
- pnpm lint:a11y --max-warnings=0
- git diff --check

Refs #247