### PR TITLE
[codex] apply reviewed eval-case improvement proposals

### DIFF
--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -18,6 +18,7 @@ import {
 import { createHash } from 'node:crypto'
 import {
   appendCoworkTraceEvent,
+  createEvalCase as createStoredEvalCase,
   createCoworkWorkItem,
   createCrewDefinition,
   createCrewRun,
@@ -239,6 +240,20 @@ export function getCrewDetail(crewId: string): CrewDetail | null {
     activeVersion,
     runs: listCrewRuns(crewId),
   }
+}
+
+export function createCrewEvalCase(input: {
+  suiteId: string
+  name: string
+  inputRef: string
+  expectedOutcome: string
+}) {
+  return requireCreated(createStoredEvalCase({
+    suiteId: boundedString(input.suiteId, 'Eval case suite id'),
+    name: boundedString(input.name, 'Eval case name'),
+    inputRef: boundedString(input.inputRef, 'Eval case input reference'),
+    expectedOutcome: boundedString(input.expectedOutcome, 'Eval case expected outcome'),
+  }), 'eval case')
 }
 
 function appendRunTrace(input: {

--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -60,6 +60,7 @@ import {
 } from './custom-agents.ts'
 import {
   createCrewFromDraft,
+  createCrewEvalCase,
   getCrewDetail,
   updateCrewFromDraft,
   validateCrewDefinitionDraft,
@@ -1255,6 +1256,43 @@ function applyApprovedSopProposal(proposal: ImprovementProposal) {
   updateSop(plan.sopId, plan.draft)
 }
 
+type PlannedEvalCaseProposalApply = {
+  suiteId: string
+  name: string
+  inputRef: string
+  expectedOutcome: string
+}
+
+function evalCaseDraftFromDiff(diff: ImprovementCandidateDiff): PlannedEvalCaseProposalApply {
+  const targetId = typeof diff.targetId === 'string' && diff.targetId.trim() ? diff.targetId.trim() : null
+  const payloadId = payloadString(diff.payload, 'id')
+  if (targetId || payloadId) {
+    throw new Error('Eval case create proposals must not target an existing eval case id.')
+  }
+  const suiteId = payloadString(diff.payload, 'suiteId')
+  if (!suiteId) throw new Error('Eval case proposal requires a suiteId.')
+  return {
+    suiteId,
+    name: payloadString(diff.payload, 'name') || diff.summary || 'Untitled eval case',
+    inputRef: payloadString(diff.payload, 'inputRef') || diff.summary || 'improvement-proposal',
+    expectedOutcome: payloadString(diff.payload, 'expectedOutcome') || diff.summary || 'Expected outcome proposed from governed learning.',
+  }
+}
+
+function planApprovedEvalCaseProposal(proposal: ImprovementProposal): PlannedEvalCaseProposalApply {
+  const evalCaseDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'eval_case')
+  if (proposal.candidateDiffs.length !== 1 || evalCaseDiffs.length !== 1) {
+    throw new Error('Eval case improvement proposals must contain exactly one eval case candidate diff.')
+  }
+  const diff = evalCaseDiffs[0]!
+  if (diff.operation !== 'create') throw new Error('Eval case update/delete proposals do not have a typed approval path yet.')
+  return evalCaseDraftFromDiff(diff)
+}
+
+function applyApprovedEvalCaseProposal(proposal: ImprovementProposal) {
+  createCrewEvalCase(planApprovedEvalCaseProposal(proposal))
+}
+
 type SkillProposalRef = {
   scope: 'machine'
   directory: null
@@ -1421,6 +1459,8 @@ function reviewImprovementProposal(id: string, status: Exclude<ImprovementPropos
         applyApprovedCrewProposal(proposal)
       } else if (proposal.targetType === 'sop') {
         applyApprovedSopProposal(proposal)
+      } else if (proposal.targetType === 'eval_case') {
+        applyApprovedEvalCaseProposal(proposal)
       } else if (proposal.targetType === 'skill') {
         applyApprovedSkillProposal(proposal)
       }

--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -339,6 +339,91 @@ const sopDeleteProposalQueue: ImprovementReviewQueue = {
   ],
 }
 
+const evalCaseProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...unsupportedProposalQueue.proposals[0]!,
+      id: 'proposal-eval-case',
+      targetType: 'eval_case',
+      targetId: null,
+      title: 'Create eval case',
+      candidateDiffs: [
+        {
+          ...unsupportedProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetType: 'eval_case',
+          targetId: null,
+          operation: 'create',
+          summary: 'Create eval case.',
+          payload: {
+            suiteId: 'suite-1',
+            name: 'Evidence coverage',
+            inputRef: 'trace://crew-run/evidence-coverage',
+            expectedOutcome: 'Material claims are backed by traceable evidence.',
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const evalCaseUpdateProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...evalCaseProposalQueue.proposals[0]!,
+      id: 'proposal-eval-case-update',
+      targetId: 'eval-case-1',
+      title: 'Update eval case',
+      candidateDiffs: [
+        {
+          ...evalCaseProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetId: 'eval-case-1',
+          operation: 'update',
+          summary: 'Update eval case.',
+          payload: {
+            id: 'eval-case-1',
+            suiteId: 'suite-1',
+            name: 'Evidence coverage update',
+            inputRef: 'trace://crew-run/evidence-coverage',
+            expectedOutcome: 'Updated expected outcome.',
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const evalCaseTargetedCreateProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...evalCaseProposalQueue.proposals[0]!,
+      id: 'proposal-eval-case-targeted-create',
+      targetId: 'eval-case-1',
+      title: 'Create targeted eval case',
+      candidateDiffs: [
+        {
+          ...evalCaseProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetId: 'eval-case-1',
+          operation: 'create',
+          summary: 'Create targeted eval case.',
+          payload: {
+            id: 'eval-case-1',
+            suiteId: 'suite-1',
+            name: 'Evidence coverage',
+            inputRef: 'trace://crew-run/evidence-coverage',
+            expectedOutcome: 'Material claims are backed by traceable evidence.',
+          },
+        },
+      ],
+    },
+  ],
+}
+
 describe('PulseImprovementInbox', () => {
   it('renders inspectable evidence, candidate diffs, memory provenance, and dream-run metadata', () => {
     render(<PulseImprovementInbox inbox={reviewQueue} actionId={null} onReview={vi.fn()} onUpdateProposal={vi.fn()} />)
@@ -474,6 +559,42 @@ describe('PulseImprovementInbox', () => {
     const user = userEvent.setup()
     const onReview = vi.fn()
     render(<PulseImprovementInbox inbox={sopDeleteProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.getByText('This proposal includes an operation that does not have a typed approval path yet. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).toBeDisabled()
+    await user.click(approve)
+    expect(onReview).not.toHaveBeenCalled()
+  })
+
+  it('offers approval for eval-case create proposals with a typed persistence path', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={evalCaseProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.queryByText('Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.')).not.toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).not.toBeDisabled()
+    await user.click(approve)
+    expect(onReview).toHaveBeenCalledWith('proposal-eval-case', 'approve-proposal')
+  })
+
+  it('does not offer approval for eval-case operations without an existing typed path', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={evalCaseUpdateProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.getByText('This proposal includes an operation that does not have a typed approval path yet. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).toBeDisabled()
+    await user.click(approve)
+    expect(onReview).not.toHaveBeenCalled()
+  })
+
+  it('does not offer approval for targeted eval-case create proposals', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={evalCaseTargetedCreateProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
 
     expect(screen.getByText('This proposal includes an operation that does not have a typed approval path yet. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
     const approve = screen.getByRole('button', { name: 'Approve' })

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -24,6 +24,12 @@ function proposalPayloadString(payload: Record<string, unknown>, key: string) {
   return typeof value === 'string' ? value : null
 }
 
+function diffTargetsExistingId(diff: Pick<ImprovementCandidateDiff, 'targetId' | 'payload'>) {
+  const targetId = typeof diff.targetId === 'string' ? diff.targetId.trim() : ''
+  const payloadId = proposalPayloadString(diff.payload, 'id')?.trim() || ''
+  return Boolean(targetId || payloadId)
+}
+
 export function improvementProposalApprovalBlockReason(
   proposal: Pick<ImprovementProposal, 'targetType' | 'candidateDiffs'>,
 ): ImprovementProposalApprovalBlockReason | null {
@@ -56,6 +62,14 @@ export function improvementProposalApprovalBlockReason(
     return sopDiffs.every((diff) => diff.operation === 'create' || diff.operation === 'update')
       ? null
       : 'operation'
+  }
+  if (proposal.targetType === 'eval_case') {
+    const evalCaseDiffs = proposal.candidateDiffs.filter((diff) => diff.targetType === 'eval_case')
+    if (evalCaseDiffs.length < 1) return 'target-type'
+    if (proposal.candidateDiffs.length !== 1 || evalCaseDiffs.length !== 1) return 'operation'
+    const evalCaseDiff = evalCaseDiffs[0]!
+    if (evalCaseDiff.operation !== 'create') return 'operation'
+    return diffTargetsExistingId(evalCaseDiff) ? 'operation' : null
   }
   return canApproveImprovementProposalTarget(proposal.targetType) ? null : 'target-type'
 }

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -41,7 +41,7 @@ import {
 } from '../apps/desktop/src/main/improvement-store.ts'
 import { listCustomAgents, listCustomSkills } from '../apps/desktop/src/main/native-customizations.ts'
 import { createCrewFromDraft, getCrewDetail, listCrewCatalog } from '../apps/desktop/src/main/crew-service.ts'
-import { clearCrewStoreCache } from '../apps/desktop/src/main/crew-store.ts'
+import { clearCrewStoreCache, createEvalSuite, listEvalCasesForSuite } from '../apps/desktop/src/main/crew-store.ts'
 import { clearAutomationStoreCache } from '../apps/desktop/src/main/automation-store.ts'
 import { getSop, listSopDefinitions } from '../apps/desktop/src/main/sop-service.ts'
 import { createSopDefinition } from '../apps/desktop/src/main/sop-store.ts'
@@ -734,6 +734,114 @@ test('SOP improvement proposal approval rejects mismatched payload and target id
   assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
   assert.equal(getSop(first.definition.id)?.definition.name, 'Primary SOP')
   assert.equal(getSop(second.definition.id)?.definition.name, 'Secondary SOP')
+}))
+
+test('approving eval-case improvement proposals applies through the eval case persistence service', () => withImprovementStore('proposal-eval-case-apply', () => {
+  const suite = createEvalSuite({
+    name: 'Research Crew Eval Suite',
+    description: 'Regression cases for research crew outputs.',
+    status: 'active',
+  })
+  assert.ok(suite)
+  const proposal = createImprovementProposal({
+    targetType: 'eval_case',
+    targetId: null,
+    title: 'Create evidence coverage eval case',
+    summary: 'A reviewed eval-case proposal should create a typed eval case.',
+    evidence: [evidence('trace-eval-case-create')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'eval_case',
+      targetId: null,
+      operation: 'create',
+      summary: 'Create eval case.',
+      afterHash: 'sha256:eval-create',
+      payload: {
+        suiteId: suite!.id,
+        name: 'Evidence coverage',
+        inputRef: 'trace://crew-run/evidence-coverage',
+        expectedOutcome: 'The final answer cites supporting tool calls or artifacts for material claims.',
+      },
+    })],
+  })
+
+  const approved = approveImprovementProposal(proposal.id, 'local-user')
+  const cases = listEvalCasesForSuite(suite!.id)
+  assert.equal(approved?.status, 'approved')
+  assert.equal(cases.length, 1)
+  assert.equal(cases[0]?.name, 'Evidence coverage')
+  assert.equal(cases[0]?.inputRef, 'trace://crew-run/evidence-coverage')
+  assert.equal(cases[0]?.expectedOutcome, 'The final answer cites supporting tool calls or artifacts for material claims.')
+}))
+
+test('eval-case improvement proposal approval rejects unsupported update operations', () => withImprovementStore('proposal-eval-case-update', () => {
+  const suite = createEvalSuite({
+    name: 'Update Eval Suite',
+    description: 'Suite used for unsupported update checks.',
+    status: 'active',
+  })
+  assert.ok(suite)
+  const proposal = createImprovementProposal({
+    targetType: 'eval_case',
+    targetId: 'eval-case-existing',
+    title: 'Update eval case',
+    summary: 'Eval case updates need a typed update path before approval.',
+    evidence: [evidence('trace-eval-case-update')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'eval_case',
+      targetId: 'eval-case-existing',
+      operation: 'update',
+      summary: 'Update eval case.',
+      payload: {
+        id: 'eval-case-existing',
+        suiteId: suite!.id,
+        name: 'Updated eval case',
+        inputRef: 'trace://crew-run/update',
+        expectedOutcome: 'Updated expected outcome.',
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /operation is not wired/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+  assert.deepEqual(listEvalCasesForSuite(suite!.id), [])
+}))
+
+test('eval-case improvement proposal approval rejects targeted creates', () => withImprovementStore('proposal-eval-case-targeted-create', () => {
+  const suite = createEvalSuite({
+    name: 'Targeted Eval Suite',
+    description: 'Suite used for targeted create checks.',
+    status: 'active',
+  })
+  assert.ok(suite)
+  const proposal = createImprovementProposal({
+    targetType: 'eval_case',
+    targetId: 'eval-case-target',
+    title: 'Create targeted eval case',
+    summary: 'Eval case creates must not pretend to update an existing case.',
+    evidence: [evidence('trace-eval-case-target')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'eval_case',
+      targetId: 'eval-case-target',
+      operation: 'create',
+      summary: 'Create eval case.',
+      payload: {
+        suiteId: suite!.id,
+        name: 'Targeted eval case',
+        inputRef: 'trace://crew-run/targeted',
+        expectedOutcome: 'Targeted creates are rejected.',
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /operation is not wired/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+  assert.deepEqual(listEvalCasesForSuite(suite!.id), [])
 }))
 
 test('approving machine agent improvement proposals applies through custom agent persistence', () => withImprovementStore('proposal-agent-apply', () => {


### PR DESCRIPTION
## Summary
- Apply approved eval-case improvement proposals through the existing crew eval-case creation path.
- Keep eval-case update/delete and targeted-create proposals blocked until a typed update/delete path exists.
- Add Pulse gating coverage so only supported eval-case create proposals expose approval.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-store.test.ts
- pnpm --dir apps/desktop test:renderer -- PulseImprovementInbox
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- pnpm lint:a11y --max-warnings=0
- git diff --check

Refs #247