### PR TITLE
[codex] keep routing and policy proposals review-only

### DIFF
--- a/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
+++ b/apps/desktop/src/renderer/components/PulseImprovementInbox.test.tsx
@@ -124,6 +124,32 @@ const unsupportedProposalQueue: ImprovementReviewQueue = {
   ],
 }
 
+const unsupportedPolicyProposalQueue: ImprovementReviewQueue = {
+  memory: [],
+  dreamRuns: [],
+  proposals: [
+    {
+      ...unsupportedProposalQueue.proposals[0]!,
+      id: 'proposal-policy',
+      targetType: 'policy',
+      targetId: 'agent-build-risk-policy',
+      title: 'Tighten build policy',
+      candidateDiffs: [
+        {
+          ...unsupportedProposalQueue.proposals[0]!.candidateDiffs[0]!,
+          targetType: 'policy',
+          targetId: 'agent-build-risk-policy',
+          summary: 'Require review for high-risk build writes.',
+          payload: {
+            scope: 'agent:build',
+            permission: 'review_required',
+          },
+        },
+      ],
+    },
+  ],
+}
+
 const agentProposalQueue: ImprovementReviewQueue = {
   memory: [],
   dreamRuns: [],
@@ -487,6 +513,18 @@ describe('PulseImprovementInbox', () => {
     const user = userEvent.setup()
     const onReview = vi.fn()
     render(<PulseImprovementInbox inbox={unsupportedProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
+
+    expect(screen.getByText('Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
+    const approve = screen.getByRole('button', { name: 'Approve' })
+    expect(approve).toBeDisabled()
+    await user.click(approve)
+    expect(onReview).not.toHaveBeenCalled()
+  })
+
+  it('does not offer approval for policy proposals without a typed applicator', async () => {
+    const user = userEvent.setup()
+    const onReview = vi.fn()
+    render(<PulseImprovementInbox inbox={unsupportedPolicyProposalQueue} actionId={null} onReview={onReview} onUpdateProposal={vi.fn()} />)
 
     expect(screen.getByText('Approval for this proposal type is waiting for a typed persistence path. Reject, archive, or leave it queued for now.')).toBeInTheDocument()
     const approve = screen.getByRole('button', { name: 'Approve' })

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -71,6 +71,9 @@ export function improvementProposalApprovalBlockReason(
     if (evalCaseDiff.operation !== 'create') return 'operation'
     return diffTargetsExistingId(evalCaseDiff) ? 'operation' : null
   }
+  if (proposal.targetType === 'routing' || proposal.targetType === 'policy') {
+    return 'target-type'
+  }
   return canApproveImprovementProposalTarget(proposal.targetType) ? null : 'target-type'
 }
 

--- a/tests/improvement-store.test.ts
+++ b/tests/improvement-store.test.ts
@@ -425,6 +425,31 @@ test('unsupported improvement proposal targets cannot be marked approved without
   assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
 }))
 
+test('policy improvement proposals cannot be marked approved without an applicator', () => withImprovementStore('proposal-policy-target', () => {
+  const proposal = createImprovementProposal({
+    targetType: 'policy',
+    targetId: 'agent-build-risk-policy',
+    title: 'Tighten build policy',
+    summary: 'Policy changes must not be accepted without a typed persistence path.',
+    evidence: [evidence('eval-policy')],
+    candidateDiffs: [memoryDiff({
+      targetType: 'policy',
+      targetId: 'agent-build-risk-policy',
+      summary: 'Require review for high-risk build writes.',
+      payload: {
+        scope: 'agent:build',
+        permission: 'review_required',
+      },
+    })],
+  })
+
+  assert.throws(
+    () => approveImprovementProposal(proposal.id, 'local-user'),
+    /not wired to an existing persistence path/,
+  )
+  assert.equal(getImprovementProposal(proposal.id)?.status, 'proposed')
+}))
+
 test('approving crew improvement proposals applies through the crew persistence service', () => withImprovementStore('proposal-crew-apply', () => {
   const createProposal = createImprovementProposal({
     targetType: 'crew',


### PR DESCRIPTION
## Summary
- make routing and policy improvement proposal approval blocking explicit in the shared gate
- add backend coverage that policy proposals remain proposed without a typed applicator
- add Pulse coverage that policy proposals do not expose approval until a persistence path exists

Refs #247

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/improvement-store.test.ts
- pnpm --dir apps/desktop test:renderer -- PulseImprovementInbox
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- git diff --check