### PR TITLE
[codex] surface channel delivery state in Pulse

### DIFF
--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -5,12 +5,14 @@ import type {
   BuiltInAgentDetail,
   CapabilitySkill,
   CapabilityTool,
+  ChannelListPayload,
   CustomAgentSummary,
   DashboardSummary,
   EffectiveAppSettings,
   ImprovementDiagnosticsSummary,
   ImprovementReviewQueue,
   CapabilityRiskMetadata,
+  LocalWebhookReceiverStatus,
   OperationalQueueAlert,
   OperationalQueueItem,
   PerfSnapshot,
@@ -368,6 +370,147 @@ const capabilityRisks: CapabilityRiskMetadata[] = [
   },
 ]
 
+const channelState: ChannelListPayload = {
+  channels: [
+    {
+      schemaVersion: 1,
+      id: 'channel-ops',
+      provider: 'local_webhook',
+      name: 'Ops webhook',
+      description: 'Routes trusted operational messages.',
+      sourceKey: 'ops',
+      enabled: true,
+      senderAllowlist: ['ops@example.com'],
+      allowedCapabilityIds: ['skill:chart-creator'],
+      route: {
+        schemaVersion: 1,
+        activationMode: 'run_sop',
+        targetSopId: 'sop-weekly-digest',
+        targetCrewId: null,
+      },
+      workspaceProfileId: 'channel-sandbox',
+      createdAt: '2026-05-07T00:00:00.000Z',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    },
+    {
+      schemaVersion: 1,
+      id: 'channel-triage',
+      provider: 'email',
+      name: 'Triage inbox',
+      description: null,
+      sourceKey: 'triage',
+      enabled: false,
+      senderAllowlist: ['triage@example.com'],
+      allowedCapabilityIds: [],
+      route: {
+        schemaVersion: 1,
+        activationMode: 'draft_reply',
+        targetSopId: null,
+        targetCrewId: null,
+      },
+      workspaceProfileId: 'default',
+      createdAt: '2026-05-07T00:00:00.000Z',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    },
+  ],
+  inboundItems: [
+    {
+      schemaVersion: 1,
+      id: 'channel-item-1',
+      channelId: 'channel-ops',
+      provider: 'local_webhook',
+      source: {
+        schemaVersion: 1,
+        provider: 'local_webhook',
+        sourceKey: 'ops',
+        externalMessageId: 'msg-1',
+      },
+      sender: 'ops@example.com',
+      subject: 'Weekly support digest',
+      body: 'Summarize support pressure.',
+      route: {
+        schemaVersion: 1,
+        activationMode: 'run_sop',
+        targetSopId: 'sop-weekly-digest',
+        targetCrewId: null,
+      },
+      status: 'queued',
+      auditState: 'queued_for_review',
+      allowedCapabilityIds: ['skill:chart-creator'],
+      workspaceProfileId: 'channel-sandbox',
+      queueItemId: 'queue-channel-1',
+      deliveryRecordId: 'delivery-1',
+      receivedAt: '2026-05-07T00:00:00.000Z',
+      updatedAt: '2026-05-07T00:00:01.000Z',
+      error: null,
+    },
+    {
+      schemaVersion: 1,
+      id: 'channel-item-2',
+      channelId: 'channel-ops',
+      provider: 'local_webhook',
+      source: {
+        schemaVersion: 1,
+        provider: 'local_webhook',
+        sourceKey: 'ops',
+        externalMessageId: 'msg-2',
+      },
+      sender: 'unknown@example.net',
+      subject: 'Untrusted sender',
+      body: 'Should be blocked.',
+      route: {
+        schemaVersion: 1,
+        activationMode: 'ignore',
+        targetSopId: null,
+        targetCrewId: null,
+      },
+      status: 'denied',
+      auditState: 'denied_unknown_sender',
+      allowedCapabilityIds: [],
+      workspaceProfileId: 'channel-sandbox',
+      queueItemId: null,
+      deliveryRecordId: null,
+      receivedAt: '2026-05-07T00:01:00.000Z',
+      updatedAt: '2026-05-07T00:01:00.000Z',
+      error: null,
+    },
+  ],
+  deliveries: [
+    {
+      schemaVersion: 1,
+      id: 'delivery-1',
+      channelId: 'channel-ops',
+      inboundItemId: 'channel-item-1',
+      provider: 'slack',
+      target: '#ops',
+      status: 'draft',
+      title: 'Slack digest draft',
+      body: 'Draft support digest.',
+      draftFirst: true,
+      workItemId: 'work-1',
+      runKind: 'sop',
+      runId: 'sop-run-1',
+      artifactIds: [],
+      policyDecisionIds: [],
+      approvalIds: [],
+      createdAt: '2026-05-07T00:02:00.000Z',
+      updatedAt: '2026-05-07T00:02:00.000Z',
+      error: null,
+    },
+  ],
+}
+
+const localWebhookStatus: LocalWebhookReceiverStatus = {
+  schemaVersion: 1,
+  enabled: true,
+  listening: true,
+  host: '127.0.0.1',
+  port: 64200,
+  url: 'http://127.0.0.1:64200',
+  pairedChannels: 1,
+  lastError: null,
+}
+
 const improvementSummary: ImprovementDiagnosticsSummary = {
   memory: {
     proposed: 1,
@@ -525,7 +668,11 @@ function installPulseApi(options: {
   rejectMemory?: ReturnType<typeof vi.fn>
   startDreamRun?: ReturnType<typeof vi.fn>
   archiveDreamRun?: ReturnType<typeof vi.fn>
+  channelState?: ChannelListPayload
+  localWebhookStatus?: LocalWebhookReceiverStatus
 } = {}) {
+  const testChannelState = options.channelState ?? channelState
+  const testLocalWebhookStatus = options.localWebhookStatus ?? localWebhookStatus
   return installRendererTestCoworkApi({
     runtime: {
       status: vi.fn(async () => ({ ready: true })),
@@ -565,6 +712,16 @@ function installPulseApi(options: {
       queueItems: vi.fn(async () => queueItems),
       queueAlerts: options.queueAlerts || vi.fn(async () => queueAlerts),
       capabilityRisks: vi.fn(async () => capabilityRisks),
+    },
+    channels: {
+      list: vi.fn(async () => testChannelState),
+      definitions: vi.fn(async () => testChannelState.channels),
+      inboundItems: vi.fn(async () => testChannelState.inboundItems),
+      deliveries: vi.fn(async () => testChannelState.deliveries),
+      localWebhookStatus: vi.fn(async () => testLocalWebhookStatus),
+      localWebhookPairings: vi.fn(async () => []),
+      createLocalWebhook: vi.fn(),
+      rotateLocalWebhookToken: vi.fn(async () => null),
     },
     improvements: {
       summary: options.improvementSummary || vi.fn(async () => improvementSummary),
@@ -668,6 +825,12 @@ describe('PulsePage', () => {
     expect(screen.getByText('Bash')).toBeInTheDocument()
     expect(screen.getAllByText('Skills')).toHaveLength(1)
     expect(screen.getByText('High risk caps').parentElement?.textContent).toContain('2')
+    expect(screen.getByText('Channel inbox and delivery')).toBeInTheDocument()
+    expect(screen.getByText('Ops webhook · SOP')).toBeInTheDocument()
+    expect(screen.getByText('Weekly support digest')).toBeInTheDocument()
+    expect(screen.getByText(/unknown@example\.net/)).toBeInTheDocument()
+    expect(screen.getByText('Slack digest draft')).toBeInTheDocument()
+    expect(screen.getByText('Listening')).toBeInTheDocument()
     expect(screen.getByText('Governed improvements')).toBeInTheDocument()
     expect(screen.getByText('Tighten analyst memory')).toBeInTheDocument()
     expect(screen.getByText('Prefer concise evidence notes')).toBeInTheDocument()
@@ -682,6 +845,8 @@ describe('PulsePage', () => {
     expect(api.operations.queueAlerts).toHaveBeenCalledTimes(1)
     expect(api.operations.queueItems).toHaveBeenCalledTimes(1)
     expect(api.operations.capabilityRisks).toHaveBeenCalledTimes(1)
+    expect(api.channels.list).toHaveBeenCalledTimes(1)
+    expect(api.channels.localWebhookStatus).toHaveBeenCalledTimes(1)
     expect(api.improvements.summary).toHaveBeenCalledTimes(1)
     expect(api.improvements.inbox).toHaveBeenCalledTimes(1)
   })

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react'
 import type {
+  ChannelDeliveryRecord,
+  ChannelInboundItem,
   CapabilityRiskMetadata,
   ImprovementProposalDraft,
   OperationalQueueItem,
@@ -116,6 +118,46 @@ function describeRiskSummary(risks: CapabilityRiskMetadata[]) {
   return { high, write, approval }
 }
 
+function formatChannelProvider(provider: string) {
+  return provider
+    .split(/[_-]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatChannelRoute(mode: string) {
+  switch (mode) {
+    case 'draft_reply':
+      return t('homepage.channels.routeDraft', 'Draft')
+    case 'ask_user':
+      return t('homepage.channels.routeAskUser', 'Review')
+    case 'run_sop':
+      return t('homepage.channels.routeSop', 'SOP')
+    case 'run_crew':
+      return t('homepage.channels.routeCrew', 'Crew')
+    default:
+      return t('homepage.channels.routeIgnore', 'Ignore')
+  }
+}
+
+function formatChannelTime(value: string) {
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date.toLocaleString() : value
+}
+
+function channelItemTone(item: ChannelInboundItem) {
+  if (item.status === 'denied' || item.status === 'failed') return 'text-red'
+  if (item.status === 'queued' || item.status === 'needs_user' || item.status === 'drafted') return 'text-amber'
+  return 'text-accent'
+}
+
+function deliveryTone(delivery: ChannelDeliveryRecord) {
+  if (delivery.status === 'failed') return 'text-red'
+  if (delivery.status === 'draft' || delivery.status === 'approval_required') return 'text-amber'
+  return 'text-accent'
+}
+
 export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => void; brandName: string }) {
   const addSession = useSessionStore((s) => s.addSession)
   const setCurrentSession = useSessionStore((s) => s.setCurrentSession)
@@ -131,6 +173,8 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     queueItems,
     queueAlerts,
     capabilityRisks,
+    channelState,
+    localWebhookStatus,
     improvementSummary,
     improvementInbox,
     refreshDiagnostics,
@@ -239,6 +283,34 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
       .filter((label, index, labels) => labels.indexOf(label) === index)
       .slice(0, 5),
     [capabilityRisks],
+  )
+  const activeChannels = useMemo(
+    () => channelState.channels.filter((channel) => channel.enabled),
+    [channelState.channels],
+  )
+  const channelItemsNeedingReview = useMemo(
+    () => channelState.inboundItems.filter((item) => item.status === 'needs_user' || item.status === 'queued' || item.status === 'drafted'),
+    [channelState.inboundItems],
+  )
+  const deniedChannelItems = useMemo(
+    () => channelState.inboundItems.filter((item) => item.status === 'denied' || item.status === 'failed'),
+    [channelState.inboundItems],
+  )
+  const draftChannelDeliveries = useMemo(
+    () => channelState.deliveries.filter((delivery) => delivery.status === 'draft' || delivery.status === 'approval_required'),
+    [channelState.deliveries],
+  )
+  const channelSandboxQueueItems = useMemo(
+    () => queueItems.filter((item) => item.authority.isolation.channelBound),
+    [queueItems],
+  )
+  const visibleChannelItems = useMemo(
+    () => channelState.inboundItems.slice(0, 3),
+    [channelState.inboundItems],
+  )
+  const visibleChannelDeliveries = useMemo(
+    () => draftChannelDeliveries.slice(0, 3),
+    [draftChannelDeliveries],
   )
   const learningDisabledScopes = improvementSummary
     ? improvementSummary.policy.disabledAgentCount + improvementSummary.policy.disabledProjectCount + improvementSummary.policy.disabledCrewCount
@@ -632,6 +704,92 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                         </div>
                       ) : null}
                     </div>
+                  </MetricCard>
+
+                  <MetricCard icon={<CircuitIcon />} eyebrow={t('homepage.channels.eyebrow', 'Channels')} title={t('homepage.channels.title', 'Channel inbox and delivery')}>
+                    <StatGrid
+                      items={[
+                        { label: t('homepage.channels.activeChannels', 'Active channels'), value: formatInteger.format(activeChannels.length), tone: activeChannels.length > 0 ? 'accent' : undefined },
+                        { label: t('homepage.channels.inboundItems', 'Inbound items'), value: formatInteger.format(channelState.inboundItems.length) },
+                        { label: t('homepage.channels.needsReview', 'Needs review'), value: formatInteger.format(channelItemsNeedingReview.length), tone: channelItemsNeedingReview.length > 0 ? 'accent' : undefined },
+                        { label: t('homepage.channels.deliveryDrafts', 'Delivery drafts'), value: formatInteger.format(draftChannelDeliveries.length), tone: draftChannelDeliveries.length > 0 ? 'accent' : undefined },
+                      ]}
+                    />
+                    <div className="mt-4 space-y-3">
+                      <Row
+                        label={t('homepage.channels.localWebhook', 'Local webhook')}
+                        value={localWebhookStatus?.listening
+                          ? t('homepage.channels.listening', 'Listening')
+                          : localWebhookStatus?.enabled
+                            ? t('homepage.channels.notListening', 'Not listening')
+                            : t('homepage.channels.disabled', 'Disabled')}
+                        tone={localWebhookStatus?.listening ? 'accent' : 'muted'}
+                      />
+                      <Row label={t('homepage.channels.pairedChannels', 'Paired channels')} value={formatInteger.format(localWebhookStatus?.pairedChannels || 0)} />
+                      <Row label={t('homepage.channels.deniedItems', 'Denied / failed')} value={formatInteger.format(deniedChannelItems.length)} tone={deniedChannelItems.length > 0 ? 'accent' : undefined} />
+                      <Row label={t('homepage.channels.channelSandboxQueue', 'Channel sandbox queue')} value={formatInteger.format(channelSandboxQueueItems.length)} />
+                    </div>
+
+                    <div className="mt-4">
+                      <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted mb-2">{t('homepage.channels.configured', 'Configured channels')}</div>
+                      <TagRail
+                        items={channelState.channels.slice(0, 6).map((channel) => `${channel.name} · ${formatChannelRoute(channel.route.activationMode)}`)}
+                        emptyLabel={t('homepage.channels.noChannels', 'No channels configured yet.')}
+                      />
+                    </div>
+
+                    <div className="mt-4 space-y-3">
+                      {visibleChannelItems.map((item) => (
+                        <div
+                          key={item.id}
+                          className="rounded-2xl bg-surface px-4 py-3"
+                          style={{ boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-text) 4%, transparent)' }}
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{formatChannelProvider(item.provider)}</span>
+                            <span className={`text-[10px] font-semibold uppercase tracking-[0.14em] ${channelItemTone(item)}`}>
+                              {item.status.replace(/_/g, ' ')}
+                            </span>
+                          </div>
+                          <div className="mt-2 text-[12px] font-semibold text-text truncate">{item.subject || item.sender}</div>
+                          <div className="mt-1 text-[11px] text-text-muted leading-relaxed">
+                            {item.sender} · {formatChannelRoute(item.route.activationMode)} · {formatChannelTime(item.receivedAt)}
+                          </div>
+                        </div>
+                      ))}
+                      {visibleChannelItems.length === 0 ? (
+                        <div
+                          className="rounded-2xl bg-surface px-4 py-3 text-[12px] text-text-secondary leading-relaxed"
+                          style={{ boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-text) 4%, transparent)' }}
+                        >
+                          {t('homepage.channels.noInbound', 'No channel inbox items recorded yet.')}
+                        </div>
+                      ) : null}
+                    </div>
+
+                    {visibleChannelDeliveries.length > 0 ? (
+                      <div className="mt-4 space-y-3">
+                        <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{t('homepage.channels.deliveryOutbox', 'Delivery outbox')}</div>
+                        {visibleChannelDeliveries.map((delivery) => (
+                          <div
+                            key={delivery.id}
+                            className="rounded-2xl bg-surface px-4 py-3"
+                            style={{ boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-text) 4%, transparent)' }}
+                          >
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{formatChannelProvider(delivery.provider)}</span>
+                              <span className={`text-[10px] font-semibold uppercase tracking-[0.14em] ${deliveryTone(delivery)}`}>
+                                {delivery.status.replace(/_/g, ' ')}
+                              </span>
+                            </div>
+                            <div className="mt-2 text-[12px] font-semibold text-text truncate">{delivery.title}</div>
+                            <div className="mt-1 text-[11px] text-text-muted leading-relaxed">
+                              {delivery.target} · {delivery.draftFirst ? t('homepage.channels.draftFirst', 'draft-first') : t('homepage.channels.direct', 'direct')} · {formatChannelTime(delivery.createdAt)}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
                   </MetricCard>
 
                   <MetricCard icon={<LayersIcon />} eyebrow={t('homepage.card.learningEyebrow', 'Learning')} title={t('homepage.card.learning', 'Governed improvements')}>

--- a/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
+++ b/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import type {
+  ChannelListPayload,
   DashboardSummary,
   DashboardTimeRangeKey,
   ImprovementDiagnosticsSummary,
   ImprovementReviewQueue,
   CapabilityRiskMetadata,
+  LocalWebhookReceiverStatus,
   OperationalQueueAlert,
   OperationalQueueItem,
 } from '@open-cowork/shared'
@@ -26,6 +28,8 @@ export function usePulseDiagnostics() {
   const [queueItems, setQueueItems] = useState<OperationalQueueItem[]>([])
   const [queueAlerts, setQueueAlerts] = useState<OperationalQueueAlert[]>([])
   const [capabilityRisks, setCapabilityRisks] = useState<CapabilityRiskMetadata[]>([])
+  const [channelState, setChannelState] = useState<ChannelListPayload>({ channels: [], inboundItems: [], deliveries: [] })
+  const [localWebhookStatus, setLocalWebhookStatus] = useState<LocalWebhookReceiverStatus | null>(null)
   const [improvementSummary, setImprovementSummary] = useState<ImprovementDiagnosticsSummary | null>(null)
   const [improvementInbox, setImprovementInbox] = useState<ImprovementReviewQueue | null>(null)
 
@@ -65,6 +69,8 @@ export function usePulseDiagnostics() {
       queueItemsResult,
       queueAlertsResult,
       capabilityRisksResult,
+      channelStateResult,
+      localWebhookStatusResult,
       improvementSummaryResult,
       improvementInboxResult,
     ] = await Promise.allSettled([
@@ -83,6 +89,8 @@ export function usePulseDiagnostics() {
       window.coworkApi.operations.queueItems(),
       window.coworkApi.operations.queueAlerts(),
       window.coworkApi.operations.capabilityRisks(),
+      window.coworkApi.channels.list(),
+      window.coworkApi.channels.localWebhookStatus(),
       window.coworkApi.improvements.summary(),
       window.coworkApi.improvements.inbox(),
     ])
@@ -123,6 +131,8 @@ export function usePulseDiagnostics() {
     setQueueItems(queueItemsResult.status === 'fulfilled' ? queueItemsResult.value : [])
     setQueueAlerts(queueAlertsResult.status === 'fulfilled' ? queueAlertsResult.value : [])
     setCapabilityRisks(capabilityRisksResult.status === 'fulfilled' ? capabilityRisksResult.value : [])
+    setChannelState(channelStateResult.status === 'fulfilled' ? channelStateResult.value : { channels: [], inboundItems: [], deliveries: [] })
+    setLocalWebhookStatus(localWebhookStatusResult.status === 'fulfilled' ? localWebhookStatusResult.value : null)
     setImprovementSummary(improvementSummaryResult.status === 'fulfilled' ? improvementSummaryResult.value : null)
     setImprovementInbox(improvementInboxResult.status === 'fulfilled' ? improvementInboxResult.value : null)
   }, [dashboardRange])
@@ -197,6 +207,8 @@ export function usePulseDiagnostics() {
     queueItems,
     queueAlerts,
     capabilityRisks,
+    channelState,
+    localWebhookStatus,
     improvementSummary,
     improvementInbox,
     refreshDiagnostics,

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -163,6 +163,27 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
         mime: 'image/png',
       })),
     },
+    channels: {
+      list: vi.fn(async () => ({ channels: [], inboundItems: [], deliveries: [] })),
+      definitions: vi.fn(async () => []),
+      inboundItems: vi.fn(async () => []),
+      deliveries: vi.fn(async () => []),
+      localWebhookStatus: vi.fn(async () => ({
+        schemaVersion: 1,
+        enabled: false,
+        listening: false,
+        host: '127.0.0.1',
+        port: null,
+        url: null,
+        pairedChannels: 0,
+        lastError: null,
+      })),
+      localWebhookPairings: vi.fn(async () => []),
+      createLocalWebhook: vi.fn(async () => {
+        throw new Error('channels.createLocalWebhook not mocked')
+      }),
+      rotateLocalWebhookToken: vi.fn(async () => null),
+    },
     clipboard: {
       writeText: vi.fn(async () => true),
     },

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -83,6 +83,9 @@ Pulse mixes:
 - operational queue visibility: running/queued work, queue alerts, filesystem
   and external-system authority, queue caps, serialization keys, and high-risk
   capability metadata
+- channel ingress and delivery visibility: active channels, local webhook
+  receiver state, recent inbound items, denied inputs, and draft-first delivery
+  records
 - governed learning diagnostics for proposed memories, improvement proposals,
   dream runs, policy blocks, and review actions in the Improvement Inbox
 - recent performance metrics


### PR DESCRIPTION
Summary:
- add channel state and local webhook status to Pulse diagnostics
- surface active channels, inbound items, denied inputs, channel queue count, and draft delivery outbox in Pulse
- update renderer test mocks, Pulse coverage, and desktop docs for the new visibility surface

Validation:
- pnpm --filter @open-cowork/desktop test:renderer -- --run src/renderer/components/PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- uv run mkdocs build --strict
- git diff --check

Refs #249