### PR TITLE
[codex] add channel pairing settings surface

### DIFF
--- a/apps/desktop/src/renderer/components/sidebar/SettingsChannelsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsChannelsPanel.test.tsx
@@ -1,0 +1,296 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ChannelDefinition,
+  CrewListPayload,
+  LocalWebhookChannelPairing,
+  LocalWebhookChannelPairingResult,
+  LocalWebhookReceiverStatus,
+  SopListPayload,
+  WorkspaceProfile,
+} from '@open-cowork/shared'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { ChannelsPanel } from './SettingsChannelsPanel'
+
+const now = '2026-05-11T12:00:00.000Z'
+
+const channelWorkspaceProfile: WorkspaceProfile = {
+  schemaVersion: 1,
+  id: 'channel-sandbox',
+  kind: 'channel_sandbox',
+  name: 'Channel sandbox',
+  description: 'Channel-bound sandbox',
+  authority: {
+    schemaVersion: 1,
+    filesystem: {
+      mode: 'sandbox',
+      roots: [],
+      writeAllowed: true,
+    },
+    externalSystems: [],
+    cleanup: {
+      retentionDays: 14,
+      deletesUnreferencedArtifacts: true,
+    },
+    isolation: {
+      projectBound: false,
+      channelBound: true,
+      highRiskIsolated: false,
+    },
+  },
+  createdAt: now,
+  updatedAt: now,
+}
+
+const receiverStatus: LocalWebhookReceiverStatus = {
+  schemaVersion: 1,
+  enabled: true,
+  listening: true,
+  host: '127.0.0.1',
+  port: 49152,
+  url: 'http://127.0.0.1:49152/channels/local-webhook/:sourceKey',
+  pairedChannels: 0,
+  lastError: null,
+}
+
+function channel(overrides: Partial<ChannelDefinition> = {}): ChannelDefinition {
+  return {
+    schemaVersion: 1,
+    id: 'channel-1',
+    provider: 'local_webhook',
+    name: 'Support inbox',
+    description: 'Support messages',
+    sourceKey: 'support-inbox',
+    enabled: true,
+    senderAllowlist: ['ops@example.com'],
+    allowedCapabilityIds: ['support.reply'],
+    route: {
+      schemaVersion: 1,
+      activationMode: 'ask_user',
+      targetSopId: null,
+      targetCrewId: null,
+    },
+    workspaceProfileId: 'channel-sandbox',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+const sopPayload: SopListPayload = {
+  sops: [
+    {
+      definition: {
+        schemaVersion: 1,
+        id: 'sop-1',
+        name: 'Support triage',
+        description: 'Triage inbound support',
+        status: 'active',
+        activeVersionId: 'sop-version-1',
+        sourceAutomationId: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      activeVersion: null,
+    },
+  ],
+}
+
+const crewPayload: CrewListPayload = {
+  crews: [
+    {
+      definition: {
+        schemaVersion: 1,
+        id: 'crew-1',
+        name: 'Response crew',
+        description: 'Draft channel responses',
+        status: 'active',
+        activeVersionId: 'crew-version-1',
+        createdAt: now,
+        updatedAt: now,
+      },
+      activeVersion: null,
+      latestRun: null,
+    },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+describe('ChannelsPanel', () => {
+  it('creates a local webhook pairing with explicit sender, route, capability, and workspace scope', async () => {
+    const user = userEvent.setup()
+    const createdChannel = channel({
+      route: {
+        schemaVersion: 1,
+        activationMode: 'run_sop',
+        targetSopId: 'sop-1',
+        targetCrewId: null,
+      },
+    })
+    const createLocalWebhook = vi.fn(async (): Promise<LocalWebhookChannelPairingResult> => ({
+      channel: createdChannel,
+      pairing: {
+        schemaVersion: 1,
+        channelId: createdChannel.id,
+        sourceKey: createdChannel.sourceKey,
+        tokenPrefix: 'ocw_wh_abcd',
+        createdAt: now,
+        rotatedAt: now,
+      },
+      token: 'ocw_wh_abcd_secret',
+    }))
+    installRendererTestCoworkApi({
+      channels: {
+        localWebhookStatus: vi.fn(async () => receiverStatus),
+        definitions: vi.fn(async () => []),
+        localWebhookPairings: vi.fn(async () => []),
+        createLocalWebhook,
+      },
+      sops: {
+        list: vi.fn(async () => sopPayload),
+      },
+      crews: {
+        list: vi.fn(async () => crewPayload),
+      },
+    })
+
+    render(<ChannelsPanel workspaceProfiles={[channelWorkspaceProfile]} />)
+
+    await screen.findByText('Receiver status')
+    await user.type(screen.getByLabelText('Name'), 'Support inbox')
+    expect(screen.getByLabelText('Source key')).toHaveValue('support-inbox')
+    await user.type(screen.getByLabelText('Sender allowlist'), 'ops@example.com\n*@trusted.example')
+    await user.selectOptions(screen.getByLabelText('Activation mode'), 'run_sop')
+    await user.selectOptions(screen.getByLabelText('Target SOP'), 'sop-1')
+    await user.type(screen.getByLabelText('Allowed capability IDs'), 'support.reply\nsupport.lookup')
+    await user.click(screen.getByRole('button', { name: 'Create pairing' }))
+
+    await waitFor(() => expect(createLocalWebhook).toHaveBeenCalledTimes(1))
+    expect(createLocalWebhook).toHaveBeenCalledWith({
+      name: 'Support inbox',
+      description: null,
+      sourceKey: 'support-inbox',
+      enabled: true,
+      senderAllowlist: ['ops@example.com', '*@trusted.example'],
+      allowedCapabilityIds: ['support.reply', 'support.lookup'],
+      route: {
+        activationMode: 'run_sop',
+        targetSopId: 'sop-1',
+        targetCrewId: null,
+      },
+      workspaceProfileId: 'channel-sandbox',
+    })
+    expect(await screen.findByText('ocw_wh_abcd_secret')).toBeInTheDocument()
+    expect(screen.getByText('http://127.0.0.1:49152/channels/local-webhook/support-inbox')).toBeInTheDocument()
+  })
+
+  it('does not let a stale initial refresh overwrite state loaded after creating a pairing', async () => {
+    const user = userEvent.setup()
+    const initialStatus = deferred<LocalWebhookReceiverStatus>()
+    const createdChannel = channel()
+    const createdPairing: LocalWebhookChannelPairing = {
+      schemaVersion: 1,
+      channelId: createdChannel.id,
+      sourceKey: createdChannel.sourceKey,
+      tokenPrefix: 'ocw_wh_abcd',
+      createdAt: now,
+      rotatedAt: now,
+    }
+    const createLocalWebhook = vi.fn(async (): Promise<LocalWebhookChannelPairingResult> => ({
+      channel: createdChannel,
+      pairing: createdPairing,
+      token: 'ocw_wh_abcd_secret',
+    }))
+    const localWebhookStatus = vi.fn()
+      .mockImplementationOnce(() => initialStatus.promise)
+      .mockResolvedValue(receiverStatus)
+    installRendererTestCoworkApi({
+      channels: {
+        localWebhookStatus,
+        definitions: vi.fn()
+          .mockResolvedValueOnce([])
+          .mockResolvedValue([createdChannel]),
+        localWebhookPairings: vi.fn()
+          .mockResolvedValueOnce([])
+          .mockResolvedValue([createdPairing]),
+        createLocalWebhook,
+      },
+      sops: {
+        list: vi.fn(async () => ({ sops: [] })),
+      },
+      crews: {
+        list: vi.fn(async () => ({ crews: [] })),
+      },
+    })
+
+    render(<ChannelsPanel workspaceProfiles={[channelWorkspaceProfile]} />)
+
+    await user.type(screen.getByLabelText('Name'), 'Support inbox')
+    await user.type(screen.getByLabelText('Sender allowlist'), 'ops@example.com')
+    await user.click(screen.getByRole('button', { name: 'Create pairing' }))
+
+    await waitFor(() => expect(createLocalWebhook).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('Support inbox')).toBeInTheDocument()
+
+    initialStatus.resolve(receiverStatus)
+    await waitFor(() => expect(localWebhookStatus).toHaveBeenCalledTimes(2))
+    expect(screen.getByText('Support inbox')).toBeInTheDocument()
+    expect(screen.queryByText('No local webhook pairings yet.')).not.toBeInTheDocument()
+  })
+
+  it('rotates an existing local webhook token and reveals only the new token', async () => {
+    const user = userEvent.setup()
+    const existingChannel = channel()
+    const existingPairing: LocalWebhookChannelPairing = {
+      schemaVersion: 1,
+      channelId: existingChannel.id,
+      sourceKey: existingChannel.sourceKey,
+      tokenPrefix: 'ocw_wh_old',
+      createdAt: now,
+      rotatedAt: now,
+    }
+    const rotateLocalWebhookToken = vi.fn(async (): Promise<LocalWebhookChannelPairingResult> => ({
+      channel: existingChannel,
+      pairing: {
+        ...existingPairing,
+        tokenPrefix: 'ocw_wh_new',
+      },
+      token: 'ocw_wh_new_secret',
+    }))
+    installRendererTestCoworkApi({
+      channels: {
+        localWebhookStatus: vi.fn(async () => ({ ...receiverStatus, pairedChannels: 1 })),
+        definitions: vi.fn(async () => [existingChannel]),
+        localWebhookPairings: vi.fn(async () => [existingPairing]),
+        rotateLocalWebhookToken,
+      },
+      sops: {
+        list: vi.fn(async () => ({ sops: [] })),
+      },
+      crews: {
+        list: vi.fn(async () => ({ crews: [] })),
+      },
+    })
+
+    render(<ChannelsPanel workspaceProfiles={[channelWorkspaceProfile]} />)
+
+    await screen.findByText('Support inbox')
+    expect(screen.queryByText('ocw_wh_new_secret')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Rotate token' }))
+
+    await waitFor(() => expect(rotateLocalWebhookToken).toHaveBeenCalledWith('channel-1'))
+    expect(await screen.findByText('ocw_wh_new_secret')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/sidebar/SettingsChannelsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsChannelsPanel.tsx
@@ -1,0 +1,611 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type {
+  ChannelActivationMode,
+  ChannelDefinition,
+  LocalWebhookChannelPairing,
+  LocalWebhookChannelPairingResult,
+  LocalWebhookReceiverStatus,
+  SopListItem,
+  CrewListItem,
+  WorkspaceProfile,
+} from '@open-cowork/shared'
+import { writeTextToClipboard } from '../../helpers/clipboard'
+import { t } from '../../helpers/i18n'
+import { useSessionStore } from '../../stores/session'
+import {
+  fieldLabelCls,
+  inputCls,
+  panelCardCls,
+  sectionLabelCls,
+} from './settings-panel-styles'
+
+const CHANNEL_SANDBOX_PROFILE_ID = 'channel-sandbox'
+const textareaCls = `${inputCls} min-h-[74px] resize-y leading-relaxed`
+
+type ChannelFormState = {
+  name: string
+  description: string
+  sourceKey: string
+  senderAllowlist: string
+  activationMode: ChannelActivationMode
+  targetSopId: string
+  targetCrewId: string
+  allowedCapabilityIds: string
+  workspaceProfileId: string
+}
+
+type RevealedToken = {
+  channelId: string
+  sourceKey: string
+  token: string
+  endpoint: string | null
+}
+
+type ChannelPanelData = {
+  status: LocalWebhookReceiverStatus
+  channels: ChannelDefinition[]
+  pairings: LocalWebhookChannelPairing[]
+  sops: SopListItem[]
+  crews: CrewListItem[]
+}
+
+async function fetchChannelPanelData(): Promise<ChannelPanelData> {
+  const [
+    status,
+    channels,
+    pairings,
+    sops,
+    crews,
+  ] = await Promise.all([
+    window.coworkApi.channels.localWebhookStatus(),
+    window.coworkApi.channels.definitions(),
+    window.coworkApi.channels.localWebhookPairings(),
+    window.coworkApi.sops.list(),
+    window.coworkApi.crews.list(),
+  ])
+  return {
+    status,
+    channels,
+    pairings,
+    sops: sops.sops,
+    crews: crews.crews,
+  }
+}
+
+function parseList(value: string) {
+  return [...new Set(value
+    .split(/[\n,]/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean))]
+}
+
+function sourceKeyFromName(value: string) {
+  return value.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+}
+
+function receiverEndpoint(status: LocalWebhookReceiverStatus | null, sourceKey: string) {
+  if (!status?.url) return null
+  return status.url.replace(':sourceKey', encodeURIComponent(sourceKey))
+}
+
+function defaultWorkspaceProfileId(workspaceProfiles: WorkspaceProfile[]) {
+  const channelProfile = workspaceProfiles.find((profile) => profile.id === CHANNEL_SANDBOX_PROFILE_ID)
+    || workspaceProfiles.find((profile) => profile.kind === 'channel_sandbox')
+    || workspaceProfiles.find((profile) => profile.authority.isolation.channelBound)
+  return channelProfile?.id || CHANNEL_SANDBOX_PROFILE_ID
+}
+
+function emptyForm(workspaceProfiles: WorkspaceProfile[]): ChannelFormState {
+  return {
+    name: '',
+    description: '',
+    sourceKey: '',
+    senderAllowlist: '',
+    activationMode: 'ask_user',
+    targetSopId: '',
+    targetCrewId: '',
+    allowedCapabilityIds: '',
+    workspaceProfileId: defaultWorkspaceProfileId(workspaceProfiles),
+  }
+}
+
+function describeChannelError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function reportChannelsError(error: unknown, scope: string) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${scope}: ${describeChannelError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'settings-channels',
+    })
+  } catch {
+    // Diagnostics are best-effort from a settings recovery path.
+  }
+}
+
+function StatusPill({ tone, children }: { tone: 'green' | 'amber' | 'muted'; children: string }) {
+  const color = tone === 'green'
+    ? 'var(--color-green)'
+    : tone === 'amber'
+      ? 'var(--color-orange)'
+      : 'var(--color-text-muted)'
+  return (
+    <span
+      className="inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em]"
+      style={{
+        color,
+        borderColor: `color-mix(in srgb, ${color} 35%, transparent)`,
+        background: `color-mix(in srgb, ${color} 9%, transparent)`,
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+function ChannelStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-border-subtle bg-surface px-3 py-3">
+      <div className="text-[10px] uppercase tracking-[0.08em] text-text-muted">{label}</div>
+      <div className="mt-1.5 break-words text-[13px] font-medium text-text">{value}</div>
+    </div>
+  )
+}
+
+function describeActivationMode(mode: ChannelActivationMode) {
+  switch (mode) {
+    case 'ignore':
+      return t('settings.channels.mode.ignore', 'Ignore')
+    case 'draft_reply':
+      return t('settings.channels.mode.draftReply', 'Draft reply')
+    case 'ask_user':
+      return t('settings.channels.mode.askUser', 'Ask user')
+    case 'run_sop':
+      return t('settings.channels.mode.runSop', 'Run SOP')
+    case 'run_crew':
+      return t('settings.channels.mode.runCrew', 'Run Crew')
+  }
+}
+
+function PairingCard({
+  pairing,
+  channel,
+  status,
+  rotating,
+  onRotate,
+}: {
+  pairing: LocalWebhookChannelPairing
+  channel: ChannelDefinition | undefined
+  status: LocalWebhookReceiverStatus | null
+  rotating: boolean
+  onRotate: (channelId: string) => void
+}) {
+  const endpoint = receiverEndpoint(status, pairing.sourceKey)
+  return (
+    <div className="rounded-2xl border border-border-subtle bg-surface px-4 py-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[12px] font-semibold text-text">{channel?.name || pairing.sourceKey}</div>
+          <div className="mt-1 text-[11px] text-text-muted">
+            {pairing.sourceKey} · {t('settings.channels.tokenPrefix', 'token')} {pairing.tokenPrefix}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => onRotate(pairing.channelId)}
+          disabled={rotating}
+          className="rounded-xl border border-border-subtle px-3 py-2 text-[11px] font-semibold text-text-secondary transition-colors hover:border-accent/40 hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {rotating ? t('settings.channels.rotating', 'Rotating...') : t('settings.channels.rotateToken', 'Rotate token')}
+        </button>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-3 max-[980px]:grid-cols-1">
+        <ChannelStat label={t('settings.channels.route', 'Route')} value={channel ? describeActivationMode(channel.route.activationMode) : t('common.unknown', 'Unknown')} />
+        <ChannelStat label={t('settings.channels.workspace', 'Workspace')} value={channel?.workspaceProfileId || CHANNEL_SANDBOX_PROFILE_ID} />
+      </div>
+      {endpoint ? (
+        <div className="mt-3 break-all rounded-xl border border-border-subtle bg-base px-3 py-2 font-mono text-[10px] text-text-muted">
+          {endpoint}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function ChannelsPanel({ workspaceProfiles }: { workspaceProfiles: WorkspaceProfile[] }) {
+  const [status, setStatus] = useState<LocalWebhookReceiverStatus | null>(null)
+  const [channels, setChannels] = useState<ChannelDefinition[]>([])
+  const [pairings, setPairings] = useState<LocalWebhookChannelPairing[]>([])
+  const [sops, setSops] = useState<SopListItem[]>([])
+  const [crews, setCrews] = useState<CrewListItem[]>([])
+  const [form, setForm] = useState<ChannelFormState>(() => emptyForm(workspaceProfiles))
+  const [loading, setLoading] = useState(true)
+  const [working, setWorking] = useState(false)
+  const [rotatingChannelId, setRotatingChannelId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [token, setToken] = useState<RevealedToken | null>(null)
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
+  const refreshVersionRef = useRef(0)
+
+  const channelWorkspaceProfiles = useMemo(
+    () => workspaceProfiles.filter((profile) => profile.authority.isolation.channelBound),
+    [workspaceProfiles],
+  )
+  const channelsById = useMemo(() => new Map(channels.map((channel) => [channel.id, channel])), [channels])
+  const localWebhookChannels = useMemo(
+    () => channels.filter((channel) => channel.provider === 'local_webhook'),
+    [channels],
+  )
+
+  useEffect(() => {
+    setForm((current) => {
+      if (current.workspaceProfileId && (
+        current.workspaceProfileId === CHANNEL_SANDBOX_PROFILE_ID
+        || channelWorkspaceProfiles.some((profile) => profile.id === current.workspaceProfileId)
+      )) {
+        return current
+      }
+      return { ...current, workspaceProfileId: defaultWorkspaceProfileId(workspaceProfiles) }
+    })
+  }, [channelWorkspaceProfiles, workspaceProfiles])
+
+  const load = useCallback(async () => {
+    const refreshVersion = refreshVersionRef.current + 1
+    refreshVersionRef.current = refreshVersion
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await fetchChannelPanelData()
+      if (refreshVersionRef.current !== refreshVersion) return
+      setStatus(data.status)
+      setChannels(data.channels)
+      setPairings(data.pairings)
+      setSops(data.sops)
+      setCrews(data.crews)
+    } catch (err) {
+      if (refreshVersionRef.current !== refreshVersion) return
+      addGlobalError(t('settings.channels.loadFailed', 'Could not load channel settings. Please try again.'))
+      reportChannelsError(err, 'Failed to load channel settings')
+      setError(describeChannelError(err))
+    } finally {
+      if (refreshVersionRef.current === refreshVersion) setLoading(false)
+    }
+  }, [addGlobalError])
+
+  useEffect(() => {
+    void load()
+    return () => {
+      refreshVersionRef.current += 1
+    }
+  }, [load])
+
+  const updateForm = (patch: Partial<ChannelFormState>) => {
+    setForm((current) => ({ ...current, ...patch }))
+  }
+
+  const updateName = (value: string) => {
+    setForm((current) => ({
+      ...current,
+      name: value,
+      sourceKey: current.sourceKey && current.sourceKey !== sourceKeyFromName(current.name)
+        ? current.sourceKey
+        : sourceKeyFromName(value),
+    }))
+  }
+
+  const createWebhook = async () => {
+    setWorking(true)
+    setError(null)
+    setCopyStatus('idle')
+    try {
+      const result = await window.coworkApi.channels.createLocalWebhook({
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        sourceKey: form.sourceKey.trim(),
+        enabled: true,
+        senderAllowlist: parseList(form.senderAllowlist),
+        allowedCapabilityIds: parseList(form.allowedCapabilityIds),
+        route: {
+          activationMode: form.activationMode,
+          targetSopId: form.activationMode === 'run_sop' ? form.targetSopId || null : null,
+          targetCrewId: form.activationMode === 'run_crew' ? form.targetCrewId || null : null,
+        },
+        workspaceProfileId: form.workspaceProfileId || CHANNEL_SANDBOX_PROFILE_ID,
+      })
+      setToken({
+        channelId: result.channel.id,
+        sourceKey: result.channel.sourceKey,
+        token: result.token,
+        endpoint: receiverEndpoint(status, result.channel.sourceKey),
+      })
+      setForm(emptyForm(workspaceProfiles))
+      await load()
+    } catch (err) {
+      setError(describeChannelError(err))
+      reportChannelsError(err, 'Failed to create local webhook channel')
+    } finally {
+      setWorking(false)
+    }
+  }
+
+  const rotateToken = async (channelId: string) => {
+    setRotatingChannelId(channelId)
+    setError(null)
+    setCopyStatus('idle')
+    try {
+      const result: LocalWebhookChannelPairingResult | null = await window.coworkApi.channels.rotateLocalWebhookToken(channelId)
+      if (!result) {
+        setError(t('settings.channels.rotateMissing', 'Channel token could not be rotated.'))
+        return
+      }
+      setToken({
+        channelId: result.channel.id,
+        sourceKey: result.channel.sourceKey,
+        token: result.token,
+        endpoint: receiverEndpoint(status, result.channel.sourceKey),
+      })
+      await load()
+    } catch (err) {
+      setError(describeChannelError(err))
+      reportChannelsError(err, 'Failed to rotate local webhook token')
+    } finally {
+      setRotatingChannelId(null)
+    }
+  }
+
+  const copyToken = async () => {
+    if (!token) return
+    const copied = await writeTextToClipboard(token.token)
+    setCopyStatus(copied ? 'copied' : 'failed')
+  }
+
+  const receiverTone = status?.listening ? 'green' : status?.enabled ? 'amber' : 'muted'
+  const receiverText = status?.listening
+    ? t('settings.channels.receiverListening', 'Listening')
+    : status?.enabled
+      ? t('settings.channels.receiverStarting', 'Enabled')
+      : t('settings.channels.receiverDisabled', 'Disabled')
+  const endpointPreview = form.sourceKey.trim() ? receiverEndpoint(status, form.sourceKey) : status?.url || null
+  const canCreate = Boolean(form.name.trim()
+    && form.sourceKey.trim()
+    && parseList(form.senderAllowlist).length > 0
+    && (form.activationMode !== 'run_sop' || form.targetSopId)
+    && (form.activationMode !== 'run_crew' || form.targetCrewId))
+
+  return (
+    <div className="flex flex-col gap-5">
+      <span className={sectionLabelCls}>{t('settings.channels.receiverHeader', 'Local Webhook Receiver')}</span>
+      <div className={panelCardCls}>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="text-[12px] font-semibold text-text">{t('settings.channels.receiverTitle', 'Receiver status')}</div>
+            <div className="mt-1 text-[11px] text-text-muted leading-relaxed">
+              {status?.lastError || t('settings.channels.receiverDescription', 'Inbound items are accepted only from paired source keys and allowlisted senders.')}
+            </div>
+          </div>
+          <StatusPill tone={receiverTone}>{receiverText}</StatusPill>
+        </div>
+        <div className="grid grid-cols-3 gap-3 max-[980px]:grid-cols-1">
+          <ChannelStat label={t('settings.channels.host', 'Host')} value={status ? `${status.host}:${status.port || '-'}` : '-'} />
+          <ChannelStat label={t('settings.channels.paired', 'Paired channels')} value={String(status?.pairedChannels ?? pairings.length)} />
+          <ChannelStat label={t('settings.channels.localChannels', 'Local channels')} value={String(localWebhookChannels.length)} />
+        </div>
+      </div>
+
+      <span className={sectionLabelCls}>{t('settings.channels.createHeader', 'New Pairing')}</span>
+      <div className={panelCardCls}>
+        <div className="grid grid-cols-2 gap-4 max-[980px]:grid-cols-1">
+          <label className="flex flex-col gap-2">
+            <span className={fieldLabelCls}>{t('settings.channels.name', 'Name')}</span>
+            <input
+              value={form.name}
+              onChange={(event) => updateName(event.target.value)}
+              className={inputCls}
+              placeholder={t('settings.channels.namePlaceholder', 'Support inbox')}
+            />
+          </label>
+          <label className="flex flex-col gap-2">
+            <span className={fieldLabelCls}>{t('settings.channels.sourceKey', 'Source key')}</span>
+            <input
+              value={form.sourceKey}
+              onChange={(event) => updateForm({ sourceKey: event.target.value })}
+              className={inputCls}
+              placeholder={t('settings.channels.sourceKeyPlaceholder', 'support-inbox')}
+            />
+          </label>
+        </div>
+
+        <label className="flex flex-col gap-2">
+          <span className={fieldLabelCls}>{t('settings.channels.description', 'Description')}</span>
+          <input
+            value={form.description}
+            onChange={(event) => updateForm({ description: event.target.value })}
+            className={inputCls}
+            placeholder={t('settings.channels.descriptionPlaceholder', 'Inbound customer messages')}
+          />
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className={fieldLabelCls}>{t('settings.channels.senderAllowlist', 'Sender allowlist')}</span>
+          <textarea
+            value={form.senderAllowlist}
+            onChange={(event) => updateForm({ senderAllowlist: event.target.value })}
+            className={textareaCls}
+            placeholder={t('settings.channels.senderAllowlistPlaceholder', 'ops@example.com\n*@trusted.example')}
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-4 max-[980px]:grid-cols-1">
+          <label className="flex flex-col gap-2">
+            <span className={fieldLabelCls}>{t('settings.channels.activationMode', 'Activation mode')}</span>
+            <select
+              value={form.activationMode}
+              onChange={(event) => updateForm({ activationMode: event.target.value as ChannelActivationMode })}
+              className={inputCls}
+            >
+              <option value="ignore">{describeActivationMode('ignore')}</option>
+              <option value="draft_reply">{describeActivationMode('draft_reply')}</option>
+              <option value="ask_user">{describeActivationMode('ask_user')}</option>
+              <option value="run_sop">{describeActivationMode('run_sop')}</option>
+              <option value="run_crew">{describeActivationMode('run_crew')}</option>
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-2">
+            <span className={fieldLabelCls}>{t('settings.channels.workspaceProfile', 'Workspace profile')}</span>
+            <select
+              value={form.workspaceProfileId}
+              onChange={(event) => updateForm({ workspaceProfileId: event.target.value })}
+              className={inputCls}
+            >
+              {channelWorkspaceProfiles.length === 0 ? (
+                <option value={CHANNEL_SANDBOX_PROFILE_ID}>{CHANNEL_SANDBOX_PROFILE_ID}</option>
+              ) : channelWorkspaceProfiles.map((profile) => (
+                <option key={profile.id} value={profile.id}>{profile.name}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {form.activationMode === 'run_sop' ? (
+          <label className="flex flex-col gap-2">
+            <span className={fieldLabelCls}>{t('settings.channels.targetSop', 'Target SOP')}</span>
+            <select
+              value={form.targetSopId}
+              onChange={(event) => updateForm({ targetSopId: event.target.value })}
+              className={inputCls}
+            >
+              <option value="">{t('settings.channels.chooseSop', 'Choose SOP')}</option>
+              {sops.map((entry) => (
+                <option key={entry.definition.id} value={entry.definition.id}>
+                  {entry.definition.name} · {entry.definition.status}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        {form.activationMode === 'run_crew' ? (
+          <label className="flex flex-col gap-2">
+            <span className={fieldLabelCls}>{t('settings.channels.targetCrew', 'Target Crew')}</span>
+            <select
+              value={form.targetCrewId}
+              onChange={(event) => updateForm({ targetCrewId: event.target.value })}
+              className={inputCls}
+            >
+              <option value="">{t('settings.channels.chooseCrew', 'Choose Crew')}</option>
+              {crews.map((entry) => (
+                <option key={entry.definition.id} value={entry.definition.id}>
+                  {entry.definition.name} · {entry.definition.status}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        <label className="flex flex-col gap-2">
+          <span className={fieldLabelCls}>{t('settings.channels.allowedCapabilities', 'Allowed capability IDs')}</span>
+          <textarea
+            value={form.allowedCapabilityIds}
+            onChange={(event) => updateForm({ allowedCapabilityIds: event.target.value })}
+            className={textareaCls}
+            placeholder={t('settings.channels.allowedCapabilitiesPlaceholder', 'capability-id-one\ncapability-id-two')}
+          />
+        </label>
+
+        {endpointPreview ? (
+          <div className="break-all rounded-xl border border-border-subtle bg-base px-3 py-2 font-mono text-[10px] text-text-muted">
+            {endpointPreview}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="text-[11px] text-text-muted">
+            {loading ? t('settings.channels.loading', 'Loading channel state...') : t('settings.channels.createHint', 'New local webhook channels start enabled and require bearer token pairing.')}
+          </div>
+          <button
+            type="button"
+            onClick={createWebhook}
+            disabled={!canCreate || working}
+            className="rounded-xl px-4 py-2 text-[12px] font-semibold transition-all disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              background: 'var(--color-accent)',
+              color: 'var(--color-accent-foreground)',
+            }}
+          >
+            {working ? t('settings.channels.creating', 'Creating...') : t('settings.channels.createPairing', 'Create pairing')}
+          </button>
+        </div>
+      </div>
+
+      {token ? (
+        <div className={panelCardCls}>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-[12px] font-semibold text-text">{t('settings.channels.tokenReady', 'Pairing token ready')}</div>
+              <div className="mt-1 text-[11px] text-text-muted">
+                {token.sourceKey}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={copyToken}
+              className="rounded-xl border border-border-subtle px-3 py-2 text-[11px] font-semibold text-text-secondary transition-colors hover:border-accent/40 hover:text-text"
+            >
+              {copyStatus === 'copied'
+                ? t('settings.channels.copied', 'Copied')
+                : copyStatus === 'failed'
+                  ? t('settings.channels.copyFailed', 'Copy failed')
+                  : t('settings.channels.copyToken', 'Copy token')}
+            </button>
+          </div>
+          <div className="break-all rounded-xl border border-border-subtle bg-base px-3 py-2 font-mono text-[10px] text-text">
+            {token.token}
+          </div>
+          {token.endpoint ? (
+            <div className="break-all rounded-xl border border-border-subtle bg-base px-3 py-2 font-mono text-[10px] text-text-muted">
+              {token.endpoint}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-2xl border px-4 py-3 text-[12px]" style={{
+          color: 'var(--color-red)',
+          borderColor: 'color-mix(in srgb, var(--color-red) 32%, transparent)',
+          background: 'color-mix(in srgb, var(--color-red) 8%, transparent)',
+        }}>
+          {error}
+        </div>
+      ) : null}
+
+      <span className={sectionLabelCls}>{t('settings.channels.pairingsHeader', 'Existing Pairings')}</span>
+      {pairings.length === 0 ? (
+        <div className={panelCardCls}>
+          <div className="text-[12px] text-text-muted">{t('settings.channels.emptyPairings', 'No local webhook pairings yet.')}</div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3">
+          {pairings.map((pairing) => (
+            <PairingCard
+              key={pairing.channelId}
+              pairing={pairing}
+              channel={channelsById.get(pairing.channelId)}
+              status={status}
+              rotating={rotatingChannelId === pairing.channelId}
+              onRotate={rotateToken}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -16,12 +16,13 @@ import { useSessionStore } from '../../stores/session'
 import { mergeFetchedProviderCredentials, stripMaskedProviderCredentials } from '../provider/credential-merge'
 import { AppearancePreview } from './SettingsAppearancePanel'
 import { AutomationSettingsPanel } from './SettingsAutomationPanel'
+import { ChannelsPanel } from './SettingsChannelsPanel'
 import { LanguagePicker } from './SettingsLanguagePicker'
 import { ModelsPanel } from './SettingsModelsPanel'
 import { PermissionsPanel } from './SettingsPermissionsPanel'
 import { StoragePanel } from './SettingsStoragePanel'
 
-type SettingsTab = 'appearance' | 'models' | 'permissions' | 'automations' | 'storage'
+type SettingsTab = 'appearance' | 'models' | 'permissions' | 'automations' | 'channels' | 'storage'
 
 function describeSettingsPanelError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
@@ -143,6 +144,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
         { id: 'models' as const, label: t('settings.tab.models', 'Models'), description: t('settings.tab.modelsDescription', 'Provider, model, and credentials') },
         { id: 'permissions' as const, label: t('settings.tab.permissions', 'Permissions'), description: t('settings.tab.permissionsDescription', 'Local tool access') },
         { id: 'automations' as const, label: t('settings.tab.automations', 'Automations'), description: t('settings.tab.automationsDescription', 'Schedule, notifications, and defaults') },
+        { id: 'channels' as const, label: t('settings.tab.channels', 'Channels'), description: t('settings.tab.channelsDescription', 'Webhook pairing and routing') },
         { id: 'storage' as const, label: t('settings.tab.storage', 'Storage'), description: t('settings.tab.storageDescription', 'Sandbox artifacts and cleanup') },
       ],
     [],
@@ -308,6 +310,9 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
             )}
             {tab === 'automations' && (
               <AutomationSettingsPanel settings={settings} update={update} />
+            )}
+            {tab === 'channels' && (
+              <ChannelsPanel workspaceProfiles={workspaceProfiles} />
             )}
             {tab === 'storage' && (
               <StoragePanel

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,6 +259,14 @@ or `localhost`). A `port` of `0` lets the OS choose an available port. Each
 local webhook channel still requires its own pairing token, and the token is
 shown only when it is created or rotated.
 
+The desktop Settings > Channels surface creates local webhook pairings without
+editing the JSON config. A pairing binds a local source key to a sender
+allowlist, activation mode (`ignore`, `draft_reply`, `ask_user`, `run_sop`, or
+`run_crew`), a channel-bound workspace profile, and optional capability IDs.
+External channel delivery remains draft-first by default; direct sends should
+only be enabled by downstream channel integrations that add their own approval
+and audit policy.
+
 ## Providers
 
 `providers` defines:

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -22,7 +22,7 @@ flowchart TD
     Agents["Agents<br/>built-in + custom"]
     Caps["Capabilities<br/>tools · skills · MCPs"]
     Pulse["Pulse<br/>runtime · usage · perf · inventory"]
-    Settings["Settings<br/>appearance · models · permissions · storage"]
+    Settings["Settings<br/>appearance · models · permissions · channels · storage"]
 
     Home -->|submit prompt| Chat
     Home -->|history search| Threads
@@ -41,7 +41,7 @@ Home is the landing surface; submitting a prompt routes to Chat in one
 motion. Threads is the full-history workspace for search, facets, tags,
 and saved filters. Pulse, Capabilities, Agents, Crews, and Automations each present a
 dedicated operational surface; Settings holds appearance, models,
-permissions, and storage.
+permissions, channel pairing, and storage.
 
 ## Home
 
@@ -239,6 +239,8 @@ Settings currently cover:
   and retry ceilings
 - permissions — local tool access (bash, file write) and the developer
   config bridge into the managed OpenCode runtime
+- channels — local webhook receiver status, paired source keys, sender
+  allowlists, activation routes, and one-time token rotation
 - storage — sandbox artifacts and cleanup
 
 The Models tab is where providers and credentials are managed, and is
@@ -248,3 +250,8 @@ typically the first stop on a fresh install:
 
 The Storage section reports sandbox usage and provides cleanup
 controls for old or unused sandbox workspaces.
+
+The Channels section creates local webhook pairings against channel-bound
+workspace profiles. Each pairing records a source key, sender allowlist,
+activation mode, optional SOP or Crew route, and optional capability scope.
+Pairing tokens are only revealed when created or rotated.


### PR DESCRIPTION
## Summary
- add a Settings > Channels panel for local webhook receiver status, source-key pairing creation, sender allowlists, activation routing, channel-bound workspace selection, capability scopes, and token rotation
- reveal local webhook tokens only from create/rotate responses and refresh channel state after each mutation
- document the Settings channel pairing surface in the desktop app and configuration guides

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --filter @open-cowork/desktop test:renderer -- --run src/renderer/components/sidebar/SettingsChannelsPanel.test.tsx
- pnpm lint:a11y --max-warnings=0
- uv run mkdocs build --strict
- git diff --check

Part of #249.