### PR TITLE
[codex] add channel desktop notification delivery

### DIFF
--- a/apps/desktop/src/main/channel-delivery.ts
+++ b/apps/desktop/src/main/channel-delivery.ts
@@ -1,0 +1,53 @@
+import type { AppSettings, ChannelInboundItem } from '@open-cowork/shared'
+import { sendAutomationDesktopNotification, shouldSendAutomationDesktopNotification } from './automation-notifications.ts'
+import { createChannelDeliveryRecord } from './channel-store.ts'
+
+function notificationTitle(item: ChannelInboundItem) {
+  return item.subject || `Channel item from ${item.sender}`
+}
+
+function notificationBody(item: ChannelInboundItem) {
+  switch (item.status) {
+    case 'needs_user':
+      return 'Channel input needs review before work continues.'
+    case 'queued':
+      return 'Channel input is queued for supervised work.'
+    case 'drafted':
+      return 'Channel input created a draft reply.'
+    case 'failed':
+      return item.error || 'Channel input failed.'
+    case 'received':
+      return 'Channel input was received.'
+    case 'denied':
+      return item.error || 'Channel input was denied.'
+  }
+}
+
+function shouldNotifyForChannelItem(item: ChannelInboundItem) {
+  return item.status === 'needs_user'
+    || item.status === 'queued'
+    || item.status === 'drafted'
+    || item.status === 'failed'
+}
+
+export function deliverChannelDesktopNotification(input: {
+  item: ChannelInboundItem
+  settings: Pick<AppSettings, 'automationDesktopNotifications' | 'automationQuietHoursStart' | 'automationQuietHoursEnd'>
+}) {
+  if (!shouldNotifyForChannelItem(input.item)) return null
+  if (!shouldSendAutomationDesktopNotification(input.settings)) return null
+  const title = notificationTitle(input.item)
+  const body = notificationBody(input.item)
+  const delivered = sendAutomationDesktopNotification({ title, body })
+  return createChannelDeliveryRecord({
+    channelId: input.item.channelId,
+    inboundItemId: input.item.id,
+    provider: 'desktop_notification',
+    target: 'system-notification',
+    status: delivered ? 'delivered' : 'failed',
+    title,
+    body,
+    draftFirst: false,
+    error: delivered ? null : 'Desktop notifications are not supported.',
+  })
+}

--- a/apps/desktop/src/main/channel-store.ts
+++ b/apps/desktop/src/main/channel-store.ts
@@ -45,7 +45,7 @@ const CHANNEL_AUDIT_STATES = new Set<ChannelAuditState>([
   'queued_for_review',
   'failed',
 ])
-const CHANNEL_DELIVERY_PROVIDERS = new Set<ChannelDeliveryProvider>(['email', 'slack', 'teams', 'webhook'])
+const CHANNEL_DELIVERY_PROVIDERS = new Set<ChannelDeliveryProvider>(['desktop_notification', 'email', 'slack', 'teams', 'webhook'])
 const CHANNEL_DELIVERY_STATUSES = new Set<ChannelDeliveryStatus>(['draft', 'approval_required', 'delivered', 'failed'])
 type ChannelDeliveryRunKind = Exclude<ChannelDeliveryRecord['runKind'], null>
 const DELIVERY_RUN_KINDS = new Set<ChannelDeliveryRunKind>(['crew', 'sop', 'automation', 'channel'])

--- a/apps/desktop/src/main/channel-webhook-receiver.ts
+++ b/apps/desktop/src/main/channel-webhook-receiver.ts
@@ -5,12 +5,14 @@ import {
   type LocalWebhookReceiverStatus,
 } from '@open-cowork/shared'
 import { getAppConfig } from './config-loader.ts'
+import { deliverChannelDesktopNotification } from './channel-delivery.ts'
 import {
   listLocalWebhookPairings,
   recordChannelInboundItem,
   verifyLocalWebhookPairingToken,
 } from './channel-store.ts'
 import { log } from './logger.ts'
+import { loadSettings } from './settings.ts'
 
 export type LocalWebhookReceiverConfig = {
   enabled?: boolean
@@ -195,6 +197,12 @@ async function handleLocalWebhookRequest(req: IncomingMessage, res: ServerRespon
       externalMessageId: payloadOptionalString(payload.externalMessageId, 'externalMessageId'),
     })
     log('channel', `Recorded local webhook item ${item.id} for ${sourceKey} with status ${item.status}`)
+    try {
+      deliverChannelDesktopNotification({ item, settings: loadSettings() })
+    } catch (notificationError) {
+      const message = notificationError instanceof Error ? notificationError.message : String(notificationError)
+      log('error', `Failed to deliver local webhook notification for ${item.id}: ${message}`)
+    }
     respondJson(res, 202, {
       ok: true,
       itemId: item.id,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,6 +263,9 @@ The desktop Settings > Channels surface creates local webhook pairings without
 editing the JSON config. A pairing binds a local source key to a sender
 allowlist, activation mode (`ignore`, `draft_reply`, `ask_user`, `run_sop`, or
 `run_crew`), a channel-bound workspace profile, and optional capability IDs.
+Accepted local webhook items that need review, create drafts, or enter the
+operations queue also record a desktop-notification delivery attempt when
+desktop notifications are enabled in Settings.
 External channel delivery remains draft-first by default; direct sends should
 only be enabled by downstream channel integrations that add their own approval
 and audit policy.

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -12,7 +12,7 @@ export type ChannelAuditState =
   | 'user_review_required'
   | 'queued_for_review'
   | 'failed'
-export type ChannelDeliveryProvider = 'email' | 'slack' | 'teams' | 'webhook'
+export type ChannelDeliveryProvider = 'desktop_notification' | 'email' | 'slack' | 'teams' | 'webhook'
 export type ChannelDeliveryStatus = 'draft' | 'approval_required' | 'delivered' | 'failed'
 
 export interface ChannelSchemaVersionedRecord {

--- a/tests/channel-delivery.test.ts
+++ b/tests/channel-delivery.test.ts
@@ -1,0 +1,113 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  clearChannelStoreCache,
+  createChannelDefinition,
+  listChannelDeliveryRecords,
+  recordChannelInboundItem,
+} from '../apps/desktop/src/main/channel-store.ts'
+import { deliverChannelDesktopNotification } from '../apps/desktop/src/main/channel-delivery.ts'
+import { clearOperationalQueueStoreCache } from '../apps/desktop/src/main/operational-queue-store.ts'
+
+const notificationSettings = {
+  automationDesktopNotifications: true,
+  automationQuietHoursStart: null,
+  automationQuietHoursEnd: null,
+}
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-channel-delivery-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+function resetStores(userDataDir: string) {
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+  clearChannelStoreCache()
+  clearOperationalQueueStoreCache()
+}
+
+function withChannelDeliveryStore(name: string, fn: () => void) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    resetStores(userDataDir)
+    fn()
+  } finally {
+    clearChannelStoreCache()
+    clearOperationalQueueStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+test('channel desktop notifications are recorded as delivery attempts without completing channel work', () => withChannelDeliveryStore('desktop-notification', () => {
+  const channel = createChannelDefinition({
+    provider: 'local_webhook',
+    name: 'Support webhook',
+    sourceKey: 'support',
+    senderAllowlist: ['ops@example.com'],
+    route: { activationMode: 'ask_user' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'ops@example.com',
+    subject: 'Review this request',
+    body: 'Please review before routing.',
+  })
+
+  const delivery = deliverChannelDesktopNotification({ item, settings: notificationSettings })
+  const deliveries = listChannelDeliveryRecords()
+
+  assert.ok(delivery)
+  assert.equal(delivery.provider, 'desktop_notification')
+  assert.equal(delivery.channelId, channel.id)
+  assert.equal(delivery.inboundItemId, item.id)
+  assert.equal(delivery.target, 'system-notification')
+  assert.equal(delivery.title, 'Review this request')
+  assert.equal(delivery.draftFirst, false)
+  assert.match(delivery.status, /^(delivered|failed)$/)
+  assert.equal(deliveries.length, 1)
+  assert.equal(deliveries[0]?.id, delivery.id)
+  assert.equal(item.status, 'needs_user')
+  const denied = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'attacker@example.net',
+    body: 'Do not notify denied senders.',
+  })
+  assert.equal(denied.status, 'denied')
+  assert.equal(deliverChannelDesktopNotification({ item: denied, settings: notificationSettings }), null)
+  assert.equal(listChannelDeliveryRecords().length, 1)
+}))
+
+test('channel desktop notifications respect the shared notification toggle', () => withChannelDeliveryStore('desktop-notification-disabled', () => {
+  const channel = createChannelDefinition({
+    provider: 'local_webhook',
+    name: 'Support webhook',
+    sourceKey: 'support',
+    senderAllowlist: ['ops@example.com'],
+    route: { activationMode: 'ask_user' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'ops@example.com',
+    subject: 'Review this request',
+    body: 'Please review before routing.',
+  })
+
+  const delivery = deliverChannelDesktopNotification({
+    item,
+    settings: {
+      ...notificationSettings,
+      automationDesktopNotifications: false,
+    },
+  })
+
+  assert.equal(delivery, null)
+  assert.equal(listChannelDeliveryRecords().length, 0)
+}))


### PR DESCRIPTION
## Summary
- add desktop_notification as a durable channel delivery provider
- record desktop notification attempts for accepted local webhook items that need review, create drafts, queue work, or fail
- keep denied/ignored inputs from generating notifications, and keep notification failures isolated from webhook acceptance
- document the channel notification behavior

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/channel-delivery.test.ts tests/channel-webhook-receiver.test.ts tests/channel-store.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- uv run mkdocs build --strict
- git diff --check

Part of #249.