### PR TITLE
[codex] add channel review dispatch

### DIFF
--- a/apps/desktop/src/main/channel-delivery.ts
+++ b/apps/desktop/src/main/channel-delivery.ts
@@ -14,6 +14,10 @@ function notificationBody(item: ChannelInboundItem) {
       return 'Channel input is queued for supervised work.'
     case 'drafted':
       return 'Channel input created a draft reply.'
+    case 'dispatching':
+      return 'Channel input is being dispatched.'
+    case 'dispatched':
+      return 'Channel input was approved and dispatched.'
     case 'failed':
       return item.error || 'Channel input failed.'
     case 'received':

--- a/apps/desktop/src/main/channel-dispatch.ts
+++ b/apps/desktop/src/main/channel-dispatch.ts
@@ -1,0 +1,183 @@
+import type {
+  ChannelInboundItem,
+  CrewRunDetail,
+  CrewRunDraft,
+  SopRunLink,
+  SopTriggerType,
+} from '@open-cowork/shared'
+import {
+  claimChannelInboundItemForDispatch,
+  dismissChannelInboundItem,
+  getChannelInboundItem,
+  markChannelInboundItemDispatched,
+  markChannelInboundItemFailed,
+} from './channel-store.ts'
+import { startCrewRunWithOpenCode } from './crew-service.ts'
+import {
+  createOpenCodeCrewRuntimeDriver,
+  type CrewRuntimeExecutionDriver,
+} from './crew-runtime-execution.ts'
+import { log } from './logger.ts'
+import { finishOperationalQueueItem } from './operational-queue-store.ts'
+import { runSopForTrigger } from './sop-service.ts'
+
+const CHANNEL_EXECUTION_BODY_MAX_BYTES = 32 * 1024
+
+type ChannelDispatchDeps = {
+  reviewer?: string
+  publishAutomationUpdated?: () => void
+  runSopForTrigger?: typeof runSopForTrigger
+  startCrewRunWithOpenCode?: typeof startCrewRunWithOpenCode
+  createCrewRuntimeDriver?: () => CrewRuntimeExecutionDriver
+}
+
+function safeErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error || 'Unknown channel dispatch error')
+}
+
+function trimToUtf8Bytes(value: string, maxBytes: number) {
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return { text: value, truncated: false }
+  let end = value.length
+  while (end > 0 && Buffer.byteLength(value.slice(0, end), 'utf8') > maxBytes) {
+    end = Math.max(0, Math.floor(end * 0.9))
+  }
+  return { text: value.slice(0, end), truncated: true }
+}
+
+function channelTriggerType(item: ChannelInboundItem): SopTriggerType {
+  return item.provider === 'local_webhook' ? 'webhook' : 'inbox'
+}
+
+function buildChannelInputs(item: ChannelInboundItem) {
+  const body = trimToUtf8Bytes(item.body, CHANNEL_EXECUTION_BODY_MAX_BYTES)
+  return {
+    source: 'channel',
+    channel: {
+      id: item.channelId,
+      provider: item.provider,
+      sourceKey: item.source.sourceKey,
+      workspaceProfileId: item.workspaceProfileId,
+      allowedCapabilityIds: item.allowedCapabilityIds,
+    },
+    inbound: {
+      id: item.id,
+      sender: item.sender,
+      subject: item.subject,
+      externalMessageId: item.source.externalMessageId,
+      receivedAt: item.receivedAt,
+      body: body.text,
+      bodyTruncated: body.truncated,
+    },
+  }
+}
+
+function buildCrewRunDraft(item: ChannelInboundItem): CrewRunDraft {
+  const title = item.subject || `Channel item from ${item.sender}`
+  const body = trimToUtf8Bytes(item.body, CHANNEL_EXECUTION_BODY_MAX_BYTES)
+  return {
+    crewId: item.route.targetCrewId || '',
+    title,
+    workItemTitle: title,
+    workItemSource: 'channel',
+    workItemDescription: [
+      `Channel: ${item.provider}/${item.source.sourceKey}`,
+      `Sender: ${item.sender}`,
+      item.source.externalMessageId ? `External message: ${item.source.externalMessageId}` : null,
+      item.allowedCapabilityIds.length > 0 ? `Allowed capabilities: ${item.allowedCapabilityIds.join(', ')}` : null,
+      body.truncated ? `Body was truncated to ${CHANNEL_EXECUTION_BODY_MAX_BYTES} bytes for execution input.` : null,
+      '',
+      body.text,
+    ].filter((line): line is string => line !== null).join('\n'),
+  }
+}
+
+function isDispatchableChannelItem(item: ChannelInboundItem) {
+  if (item.status === 'dispatched' || item.status === 'dispatching') return false
+  if (item.route.activationMode !== 'run_sop' && item.route.activationMode !== 'run_crew') return false
+  return item.status === 'queued' || item.status === 'needs_user'
+}
+
+function isDismissibleChannelItem(item: ChannelInboundItem) {
+  return item.status === 'queued' || item.status === 'needs_user' || item.status === 'drafted'
+}
+
+function finishChannelQueueItem(item: ChannelInboundItem, status: 'completed' | 'failed', error?: string | null) {
+  if (!item.queueItemId) return
+  try {
+    finishOperationalQueueItem(item.queueItemId, status, { error })
+  } catch (finishError) {
+    log('channel', `Failed to mark channel queue item ${item.queueItemId} ${status}: ${safeErrorMessage(finishError)}`)
+  }
+}
+
+export async function approveChannelInboundItem(
+  itemId: string,
+  deps: ChannelDispatchDeps = {},
+): Promise<ChannelInboundItem | null> {
+  const item = getChannelInboundItem(itemId)
+  if (!item) return null
+  if (item.status === 'dispatched') return item
+  if (item.status === 'dispatching') return item
+  if (!isDispatchableChannelItem(item)) {
+    throw new Error('Channel item is not waiting for SOP or Crew approval.')
+  }
+
+  const reviewer = deps.reviewer || 'local-user'
+  const claimed = claimChannelInboundItemForDispatch(item.id, reviewer)
+  if (!claimed || claimed.status !== 'dispatching') {
+    return claimed
+  }
+  try {
+    if (claimed.route.activationMode === 'run_sop') {
+      const sopId = claimed.route.targetSopId
+      if (!sopId) throw new Error('Channel route is missing a SOP target.')
+      const runSop = deps.runSopForTrigger || runSopForTrigger
+      const link: SopRunLink = await runSop(
+        sopId,
+        channelTriggerType(claimed),
+        buildChannelInputs(claimed),
+        deps.publishAutomationUpdated || (() => {}),
+      )
+      const updated = markChannelInboundItemDispatched(claimed.id, {
+        runKind: 'sop',
+        runId: link.automationRunId,
+        approvedBy: reviewer,
+      })
+      finishChannelQueueItem(claimed, 'completed')
+      return updated
+    }
+
+    const crewId = claimed.route.targetCrewId
+    if (!crewId) throw new Error('Channel route is missing a Crew target.')
+    const startCrew = deps.startCrewRunWithOpenCode || startCrewRunWithOpenCode
+    const driver = (deps.createCrewRuntimeDriver || createOpenCodeCrewRuntimeDriver)()
+    const detail: CrewRunDetail = await startCrew(buildCrewRunDraft(claimed), driver)
+    const updated = markChannelInboundItemDispatched(claimed.id, {
+      runKind: 'crew',
+      runId: detail.run.id,
+      workItemId: detail.run.workItemId,
+      approvedBy: reviewer,
+    })
+    finishChannelQueueItem(claimed, 'completed')
+    return updated
+  } catch (error) {
+    const message = safeErrorMessage(error)
+    finishChannelQueueItem(claimed, 'failed', message)
+    return markChannelInboundItemFailed(claimed.id, message)
+  }
+}
+
+export function dismissChannelInboundReview(itemId: string, note?: string | null): ChannelInboundItem | null {
+  const item = getChannelInboundItem(itemId)
+  if (!item) return null
+  if (item.status === 'dispatched') throw new Error('Dispatched channel work cannot be dismissed.')
+  if (!isDismissibleChannelItem(item)) throw new Error('Channel item is not waiting for review.')
+  if (item.queueItemId) {
+    try {
+      finishOperationalQueueItem(item.queueItemId, 'cancelled', { error: note || 'Channel item dismissed by user.' })
+    } catch (error) {
+      log('channel', `Failed to cancel channel queue item ${item.queueItemId}: ${safeErrorMessage(error)}`)
+    }
+  }
+  return dismissChannelInboundItem(item.id, note)
+}

--- a/apps/desktop/src/main/channel-store.ts
+++ b/apps/desktop/src/main/channel-store.ts
@@ -25,7 +25,7 @@ import {
 import { getAppDataDir } from './config-loader.ts'
 import { enqueueOperationalRun, getWorkspaceProfile } from './operational-queue-store.ts'
 
-export const CHANNEL_STORE_SCHEMA_VERSION = 1
+export const CHANNEL_STORE_SCHEMA_VERSION = 2
 export const CHANNEL_SANDBOX_WORKSPACE_PROFILE_ID = 'channel-sandbox'
 const LOCAL_WEBHOOK_TOKEN_PREFIX = 'ocw_wh_'
 
@@ -35,7 +35,7 @@ const MAX_BODY_BYTES = 256 * 1024
 const MAX_JSON_BYTES = 128 * 1024
 const CHANNEL_PROVIDERS = new Set<ChannelProvider>(['local_webhook', 'email', 'slack', 'teams'])
 const CHANNEL_ACTIVATION_MODES = new Set<ChannelActivationMode>(['ignore', 'draft_reply', 'ask_user', 'run_sop', 'run_crew'])
-const CHANNEL_INBOUND_STATUSES = new Set<ChannelInboundStatus>(['denied', 'received', 'drafted', 'needs_user', 'queued', 'failed'])
+const CHANNEL_INBOUND_STATUSES = new Set<ChannelInboundStatus>(['denied', 'received', 'drafted', 'needs_user', 'queued', 'dispatching', 'dispatched', 'failed'])
 const CHANNEL_AUDIT_STATES = new Set<ChannelAuditState>([
   'denied_unknown_sender',
   'denied_channel_disabled',
@@ -43,8 +43,13 @@ const CHANNEL_AUDIT_STATES = new Set<ChannelAuditState>([
   'draft_created',
   'user_review_required',
   'queued_for_review',
+  'execution_dispatching',
+  'execution_dispatched',
+  'dismissed',
   'failed',
 ])
+type ChannelInboundRunKind = Exclude<ChannelInboundItem['runKind'], null>
+const CHANNEL_INBOUND_RUN_KINDS = new Set<ChannelInboundRunKind>(['sop', 'crew'])
 const CHANNEL_DELIVERY_PROVIDERS = new Set<ChannelDeliveryProvider>(['desktop_notification', 'email', 'slack', 'teams', 'webhook'])
 const CHANNEL_DELIVERY_STATUSES = new Set<ChannelDeliveryStatus>(['draft', 'approval_required', 'delivered', 'failed'])
 type ChannelDeliveryRunKind = Exclude<ChannelDeliveryRecord['runKind'], null>
@@ -89,6 +94,26 @@ function assertSupportedSchemaVersion(db: DatabaseSync) {
   if (version > CHANNEL_STORE_SCHEMA_VERSION) {
     throw new Error(`Channel store schema version ${version} is newer than supported version ${CHANNEL_STORE_SCHEMA_VERSION}.`)
   }
+}
+
+function channelInboundItemColumns(db: DatabaseSync) {
+  const rows = db.prepare('pragma table_info(channel_inbound_items)').all() as Array<{ name?: unknown }>
+  return new Set(rows.map((row) => String(row.name || '')))
+}
+
+function addChannelInboundColumnIfMissing(db: DatabaseSync, columns: Set<string>, columnName: string, definition: string) {
+  if (columns.has(columnName)) return
+  db.exec(`alter table channel_inbound_items add column ${columnName} ${definition}`)
+}
+
+function migrateChannelDb(db: DatabaseSync) {
+  const columns = channelInboundItemColumns(db)
+  addChannelInboundColumnIfMissing(db, columns, 'work_item_id', 'text')
+  addChannelInboundColumnIfMissing(db, columns, 'routed_run_kind', 'text')
+  addChannelInboundColumnIfMissing(db, columns, 'routed_run_id', 'text')
+  addChannelInboundColumnIfMissing(db, columns, 'approved_at', 'text')
+  addChannelInboundColumnIfMissing(db, columns, 'approved_by', 'text')
+  addChannelInboundColumnIfMissing(db, columns, 'review_note', 'text')
 }
 
 export function getChannelDb() {
@@ -186,6 +211,7 @@ export function getChannelDb() {
         foreign key(channel_id) references channel_definitions(id)
       );
     `)
+    migrateChannelDb(db)
     recordSchemaVersion(db)
     ensureChannelDbFileModes(dbPath)
     channelDb = db
@@ -442,6 +468,14 @@ function rowToInboundItem(row: DbRow): ChannelInboundItem {
     workspaceProfileId: String(row.workspace_profile_id || CHANNEL_SANDBOX_WORKSPACE_PROFILE_ID),
     queueItemId: typeof row.queue_item_id === 'string' ? row.queue_item_id : null,
     deliveryRecordId: typeof row.delivery_record_id === 'string' ? row.delivery_record_id : null,
+    workItemId: typeof row.work_item_id === 'string' ? row.work_item_id : null,
+    runKind: CHANNEL_INBOUND_RUN_KINDS.has(String(row.routed_run_kind) as ChannelInboundRunKind)
+      ? String(row.routed_run_kind) as ChannelInboundRunKind
+      : null,
+    runId: typeof row.routed_run_id === 'string' ? row.routed_run_id : null,
+    approvedAt: typeof row.approved_at === 'string' ? row.approved_at : null,
+    approvedBy: typeof row.approved_by === 'string' ? row.approved_by : null,
+    reviewNote: typeof row.review_note === 'string' ? row.review_note : null,
     receivedAt: String(row.received_at || ''),
     updatedAt: String(row.updated_at || ''),
     error: typeof row.error === 'string' ? row.error : null,
@@ -724,6 +758,12 @@ function updateInboundItemLinks(id: string, fields: {
   auditState?: ChannelAuditState
   queueItemId?: string | null
   deliveryRecordId?: string | null
+  workItemId?: string | null
+  runKind?: ChannelInboundItem['runKind']
+  runId?: string | null
+  approvedAt?: string | null
+  approvedBy?: string | null
+  reviewNote?: string | null
   error?: string | null
 }) {
   const current = getChannelInboundItem(id)
@@ -731,18 +771,80 @@ function updateInboundItemLinks(id: string, fields: {
   const now = nowIso()
   getChannelDb().prepare(`
     update channel_inbound_items
-    set status = ?, audit_state = ?, queue_item_id = ?, delivery_record_id = ?, updated_at = ?, error = ?
+    set status = ?, audit_state = ?, queue_item_id = ?, delivery_record_id = ?,
+      work_item_id = ?, routed_run_kind = ?, routed_run_id = ?,
+      approved_at = ?, approved_by = ?, review_note = ?, updated_at = ?, error = ?
     where id = ?
   `).run(
     fields.status || current.status,
     fields.auditState || current.auditState,
     fields.queueItemId === undefined ? current.queueItemId : fields.queueItemId,
     fields.deliveryRecordId === undefined ? current.deliveryRecordId : fields.deliveryRecordId,
+    fields.workItemId === undefined ? current.workItemId : fields.workItemId,
+    fields.runKind === undefined ? current.runKind : fields.runKind,
+    fields.runId === undefined ? current.runId : fields.runId,
+    fields.approvedAt === undefined ? current.approvedAt : fields.approvedAt,
+    fields.approvedBy === undefined ? current.approvedBy : fields.approvedBy,
+    fields.reviewNote === undefined ? current.reviewNote : fields.reviewNote,
     now,
     fields.error === undefined ? current.error : fields.error,
     id,
   )
   return getChannelInboundItem(id)
+}
+
+export function markChannelInboundItemDispatched(id: string, fields: {
+  runKind: ChannelInboundRunKind
+  runId: string
+  workItemId?: string | null
+  approvedBy: string
+  reviewNote?: string | null
+}) {
+  const runKind = assertKnown(CHANNEL_INBOUND_RUN_KINDS, fields.runKind, 'Channel inbound run kind')
+  return updateInboundItemLinks(id, {
+    status: 'dispatched',
+    auditState: 'execution_dispatched',
+    runKind,
+    runId: boundedText(fields.runId, 'Channel inbound routed run id', 512),
+    workItemId: optionalBoundedText(fields.workItemId, 'Channel inbound work item id', 512),
+    approvedAt: nowIso(),
+    approvedBy: boundedText(fields.approvedBy, 'Channel reviewer', 512),
+    reviewNote: optionalBoundedText(fields.reviewNote, 'Channel review note', 2048),
+    error: null,
+  })
+}
+
+export function claimChannelInboundItemForDispatch(id: string, reviewer: string) {
+  const current = getChannelInboundItem(id)
+  if (!current) return null
+  if (current.status !== 'queued' && current.status !== 'needs_user') return current
+  return updateInboundItemLinks(id, {
+    status: 'dispatching',
+    auditState: 'execution_dispatching',
+    approvedAt: nowIso(),
+    approvedBy: boundedText(reviewer, 'Channel reviewer', 512),
+    error: null,
+  })
+}
+
+export function markChannelInboundItemFailed(id: string, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  return updateInboundItemLinks(id, {
+    status: 'failed',
+    auditState: 'failed',
+    error: message,
+  })
+}
+
+export function dismissChannelInboundItem(id: string, note?: string | null) {
+  return updateInboundItemLinks(id, {
+    status: 'denied',
+    auditState: 'dismissed',
+    reviewNote: optionalBoundedText(note, 'Channel review note', 2048),
+    approvedAt: nowIso(),
+    approvedBy: 'local-user',
+    error: null,
+  })
 }
 
 export function recordChannelInboundItem(draft: ChannelInboundDraft) {

--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -863,7 +863,7 @@ export function startCrewRun(
       ? createCoworkWorkItem({
         title: workItemTitle || title,
         description: workItemDescription || workItemTitle || title,
-        source: 'manual',
+        source: draft.workItemSource || 'manual',
         status: 'running',
       })
       : null

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -7,10 +7,30 @@ import {
   listLocalWebhookPairings,
   rotateLocalWebhookPairingToken,
 } from '../channel-store.ts'
+import {
+  approveChannelInboundItem,
+  dismissChannelInboundReview,
+} from '../channel-dispatch.ts'
 import { getLocalWebhookReceiverStatus } from '../channel-webhook-receiver.ts'
 import type { IpcHandlerContext } from './context.ts'
 
+function assertString(value: unknown, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} must be a string.`)
+  if (Buffer.byteLength(value, 'utf8') > 16 * 1024) throw new Error(`${label} is too large.`)
+  return value.trim()
+}
+
+function optionalString(value: unknown, label: string) {
+  if (value === undefined || value === null) return null
+  return assertString(value, label)
+}
+
 export function registerChannelHandlers(context: IpcHandlerContext) {
+  const publishAutomationUpdated = () => {
+    const win = context.getMainWindow()
+    if (win && !win.isDestroyed()) win.webContents.send('automation:updated')
+  }
+
   context.ipcMain.handle('channels:list', async () => {
     return listChannelState()
   })
@@ -41,5 +61,18 @@ export function registerChannelHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('channels:rotate-local-webhook-token', async (_event, channelId) => {
     return rotateLocalWebhookPairingToken(channelId)
+  })
+
+  context.ipcMain.handle('channels:approve-inbound-item', async (_event, itemId) => {
+    return approveChannelInboundItem(assertString(itemId, 'Channel inbound item id'), {
+      publishAutomationUpdated,
+    })
+  })
+
+  context.ipcMain.handle('channels:dismiss-inbound-item', async (_event, itemId, note) => {
+    return dismissChannelInboundReview(
+      assertString(itemId, 'Channel inbound item id'),
+      optionalString(note, 'Channel review note'),
+    )
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -89,6 +89,8 @@ const PRELOAD_INVOKE_CHANNELS = [
   'channels:local-webhook-pairings',
   'channels:create-local-webhook',
   'channels:rotate-local-webhook-token',
+  'channels:approve-inbound-item',
+  'channels:dismiss-inbound-item',
   'improvements:summary',
   'improvements:inbox',
   'improvements:memory-approve',
@@ -322,6 +324,8 @@ const api: CoworkAPI = {
     localWebhookPairings: () => invoke('channels:local-webhook-pairings'),
     createLocalWebhook: (draft) => invoke('channels:create-local-webhook', draft),
     rotateLocalWebhookToken: (channelId) => invoke('channels:rotate-local-webhook-token', channelId),
+    approveInboundItem: (itemId) => invoke('channels:approve-inbound-item', itemId),
+    dismissInboundItem: (itemId, note) => invoke('channels:dismiss-inbound-item', itemId, note),
   },
   improvements: {
     summary: () => invoke('improvements:summary'),

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -440,6 +440,12 @@ const channelState: ChannelListPayload = {
       workspaceProfileId: 'channel-sandbox',
       queueItemId: 'queue-channel-1',
       deliveryRecordId: 'delivery-1',
+      workItemId: null,
+      runKind: null,
+      runId: null,
+      approvedAt: null,
+      approvedBy: null,
+      reviewNote: null,
       receivedAt: '2026-05-07T00:00:00.000Z',
       updatedAt: '2026-05-07T00:00:01.000Z',
       error: null,
@@ -470,6 +476,12 @@ const channelState: ChannelListPayload = {
       workspaceProfileId: 'channel-sandbox',
       queueItemId: null,
       deliveryRecordId: null,
+      workItemId: null,
+      runKind: null,
+      runId: null,
+      approvedAt: null,
+      approvedBy: null,
+      reviewNote: null,
       receivedAt: '2026-05-07T00:01:00.000Z',
       updatedAt: '2026-05-07T00:01:00.000Z',
       error: null,
@@ -670,6 +682,8 @@ function installPulseApi(options: {
   archiveDreamRun?: ReturnType<typeof vi.fn>
   channelState?: ChannelListPayload
   localWebhookStatus?: LocalWebhookReceiverStatus
+  approveInboundItem?: ReturnType<typeof vi.fn>
+  dismissInboundItem?: ReturnType<typeof vi.fn>
 } = {}) {
   const testChannelState = options.channelState ?? channelState
   const testLocalWebhookStatus = options.localWebhookStatus ?? localWebhookStatus
@@ -722,6 +736,8 @@ function installPulseApi(options: {
       localWebhookPairings: vi.fn(async () => []),
       createLocalWebhook: vi.fn(),
       rotateLocalWebhookToken: vi.fn(async () => null),
+      approveInboundItem: options.approveInboundItem || vi.fn(async () => null),
+      dismissInboundItem: options.dismissInboundItem || vi.fn(async () => null),
     },
     improvements: {
       summary: options.improvementSummary || vi.fn(async () => improvementSummary),
@@ -873,6 +889,23 @@ describe('PulsePage', () => {
 
     await user.click(screen.getAllByRole('button', { name: 'Archive' }).at(-1)!)
     await waitFor(() => expect(archiveDreamRun).toHaveBeenCalledWith('dream-1'))
+  })
+
+  it('approves and dismisses channel review items from Pulse', async () => {
+    const user = userEvent.setup()
+    const approveInboundItem = vi.fn(async () => null)
+    const dismissInboundItem = vi.fn(async () => null)
+    const api = installPulseApi({ approveInboundItem, dismissInboundItem })
+
+    render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
+    await screen.findByText('Weekly support digest')
+
+    await user.click(screen.getByRole('button', { name: 'Approve run' }))
+    await waitFor(() => expect(approveInboundItem).toHaveBeenCalledWith('channel-item-1'))
+    expect(api.channels.list).toHaveBeenCalledTimes(2)
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }))
+    await waitFor(() => expect(dismissInboundItem).toHaveBeenCalledWith('channel-item-1', 'Dismissed from Pulse.'))
   })
 
   it('updates Improvement Inbox proposals and refreshes diagnostics', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -148,8 +148,13 @@ function formatChannelTime(value: string) {
 
 function channelItemTone(item: ChannelInboundItem) {
   if (item.status === 'denied' || item.status === 'failed') return 'text-red'
-  if (item.status === 'queued' || item.status === 'needs_user' || item.status === 'drafted') return 'text-amber'
+  if (item.status === 'queued' || item.status === 'needs_user' || item.status === 'drafted' || item.status === 'dispatching') return 'text-amber'
   return 'text-accent'
+}
+
+function channelItemCanDispatch(item: ChannelInboundItem) {
+  return (item.route.activationMode === 'run_sop' || item.route.activationMode === 'run_crew')
+    && (item.status === 'queued' || item.status === 'needs_user')
 }
 
 function deliveryTone(delivery: ChannelDeliveryRecord) {
@@ -180,6 +185,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     refreshDiagnostics,
   } = usePulseDiagnostics()
   const [improvementActionId, setImprovementActionId] = useState<string | null>(null)
+  const [channelActionId, setChannelActionId] = useState<string | null>(null)
 
   const busyCount = busySessions.size
   const connectedMcpCount = mcpConnections.filter((entry) => entry.connected).length
@@ -472,6 +478,28 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     }
   }
 
+  async function reviewChannelItem(item: ChannelInboundItem, action: 'approve' | 'dismiss') {
+    setChannelActionId(`${action}:${item.id}`)
+    try {
+      if (action === 'approve') await window.coworkApi.channels.approveInboundItem(item.id)
+      else await window.coworkApi.channels.dismissInboundItem(item.id, 'Dismissed from Pulse.')
+      await refreshDiagnostics({ silent: true })
+    } catch (error) {
+      addGlobalError(t('pulse.channelReviewFailed', 'Could not update the channel item. Please try again.'))
+      try {
+        window.coworkApi.diagnostics.reportRendererError({
+          message: `Failed to review channel item ${item.id}: ${describePulseThreadError(error)}`,
+          stack: error instanceof Error ? error.stack : undefined,
+          view: 'pulse',
+        })
+      } catch {
+        // Diagnostics are best-effort from an action error handler.
+      }
+    } finally {
+      setChannelActionId(null)
+    }
+  }
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div
@@ -755,6 +783,31 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                           <div className="mt-1 text-[11px] text-text-muted leading-relaxed">
                             {item.sender} · {formatChannelRoute(item.route.activationMode)} · {formatChannelTime(item.receivedAt)}
                           </div>
+                          {item.runKind && item.runId ? (
+                            <div className="mt-2 text-[10px] uppercase tracking-[0.14em] text-text-muted">
+                              {item.runKind} · {item.runId}
+                            </div>
+                          ) : null}
+                          {channelItemCanDispatch(item) ? (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              <button
+                                type="button"
+                                className="rounded-full bg-accent px-3 py-1.5 text-[11px] font-semibold text-base transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+                                disabled={channelActionId !== null}
+                                onClick={() => void reviewChannelItem(item, 'approve')}
+                              >
+                                {channelActionId === `approve:${item.id}` ? t('homepage.channels.approving', 'Approving...') : t('homepage.channels.approveRun', 'Approve run')}
+                              </button>
+                              <button
+                                type="button"
+                                className="rounded-full border border-border-subtle px-3 py-1.5 text-[11px] font-semibold text-text-secondary transition hover:border-red hover:text-red disabled:cursor-not-allowed disabled:opacity-60"
+                                disabled={channelActionId !== null}
+                                onClick={() => void reviewChannelItem(item, 'dismiss')}
+                              >
+                                {channelActionId === `dismiss:${item.id}` ? t('homepage.channels.dismissing', 'Dismissing...') : t('homepage.channels.dismiss', 'Dismiss')}
+                              </button>
+                            </div>
+                          ) : null}
                         </div>
                       ))}
                       {visibleChannelItems.length === 0 ? (

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,9 @@ allowlist, activation mode (`ignore`, `draft_reply`, `ask_user`, `run_sop`, or
 Accepted local webhook items that need review, create drafts, or enter the
 operations queue also record a desktop-notification delivery attempt when
 desktop notifications are enabled in Settings.
+Items routed to `run_sop` or `run_crew` are review-gated: Pulse must approve
+the inbound item before Open Cowork hands it to the existing SOP or Crew
+service, and the inbound audit record keeps the resulting run/work-item link.
 External channel delivery remains draft-first by default; direct sends should
 only be enabled by downstream channel integrations that add their own approval
 and audit policy.

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -84,8 +84,8 @@ Pulse mixes:
   and external-system authority, queue caps, serialization keys, and high-risk
   capability metadata
 - channel ingress and delivery visibility: active channels, local webhook
-  receiver state, recent inbound items, denied inputs, and draft-first delivery
-  records
+  receiver state, recent inbound items, denied inputs, approve/dismiss actions
+  for channel-routed SOP or Crew work, and draft-first delivery records
 - governed learning diagnostics for proposed memories, improvement proposals,
   dream runs, policy blocks, and review actions in the Improvement Inbox
 - recent performance metrics
@@ -255,3 +255,8 @@ The Channels section creates local webhook pairings against channel-bound
 workspace profiles. Each pairing records a source key, sender allowlist,
 activation mode, optional SOP or Crew route, and optional capability scope.
 Pairing tokens are only revealed when created or rotated.
+
+Channel items configured for `run_sop` or `run_crew` still stop at Pulse for
+human review. Approving the item hands it to the existing SOP or Crew service
+and links the resulting run back to the inbound audit record; dismissing it
+cancels the review queue entry without triggering OpenCode execution.

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -3,7 +3,7 @@ export const COWORK_CHANNEL_DELIVERY_SCHEMA_VERSION = 1
 
 export type ChannelProvider = 'local_webhook' | 'email' | 'slack' | 'teams'
 export type ChannelActivationMode = 'ignore' | 'draft_reply' | 'ask_user' | 'run_sop' | 'run_crew'
-export type ChannelInboundStatus = 'denied' | 'received' | 'drafted' | 'needs_user' | 'queued' | 'failed'
+export type ChannelInboundStatus = 'denied' | 'received' | 'drafted' | 'needs_user' | 'queued' | 'dispatching' | 'dispatched' | 'failed'
 export type ChannelAuditState =
   | 'denied_unknown_sender'
   | 'denied_channel_disabled'
@@ -11,6 +11,9 @@ export type ChannelAuditState =
   | 'draft_created'
   | 'user_review_required'
   | 'queued_for_review'
+  | 'execution_dispatching'
+  | 'execution_dispatched'
+  | 'dismissed'
   | 'failed'
 export type ChannelDeliveryProvider = 'desktop_notification' | 'email' | 'slack' | 'teams' | 'webhook'
 export type ChannelDeliveryStatus = 'draft' | 'approval_required' | 'delivered' | 'failed'
@@ -101,6 +104,12 @@ export interface ChannelInboundItem extends ChannelSchemaVersionedRecord {
   workspaceProfileId: string
   queueItemId: string | null
   deliveryRecordId: string | null
+  workItemId: string | null
+  runKind: 'sop' | 'crew' | null
+  runId: string | null
+  approvedAt: string | null
+  approvedBy: string | null
+  reviewNote: string | null
   receivedAt: string
   updatedAt: string
   error: string | null

--- a/packages/shared/src/crews.ts
+++ b/packages/shared/src/crews.ts
@@ -230,6 +230,7 @@ export interface CrewRunDraft {
   title: string
   workItemTitle?: string | null
   workItemDescription?: string | null
+  workItemSource?: CoworkWorkItem['source']
 }
 
 export interface TraceActor {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -326,6 +326,8 @@ export interface CoworkAPI {
     localWebhookPairings: () => Promise<LocalWebhookChannelPairing[]>
     createLocalWebhook: (draft: Omit<ChannelDefinitionDraft, 'provider'>) => Promise<LocalWebhookChannelPairingResult>
     rotateLocalWebhookToken: (channelId: string) => Promise<LocalWebhookChannelPairingResult | null>
+    approveInboundItem: (itemId: string) => Promise<ChannelInboundItem | null>
+    dismissInboundItem: (itemId: string, note?: string | null) => Promise<ChannelInboundItem | null>
   }
   improvements: {
     summary: () => Promise<ImprovementDiagnosticsSummary>

--- a/tests/channel-dispatch.test.ts
+++ b/tests/channel-dispatch.test.ts
@@ -1,0 +1,317 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { CrewRunDetail, SopRunLink } from '@open-cowork/shared'
+import {
+  approveChannelInboundItem,
+  dismissChannelInboundReview,
+} from '../apps/desktop/src/main/channel-dispatch.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  clearChannelStoreCache,
+  createChannelDefinition,
+  getChannelInboundItem,
+  recordChannelInboundItem,
+} from '../apps/desktop/src/main/channel-store.ts'
+import {
+  clearOperationalQueueStoreCache,
+  getOperationalQueueItem,
+  listOperationalQueueItems,
+} from '../apps/desktop/src/main/operational-queue-store.ts'
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-channel-dispatch-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+async function withChannelDispatchStore(name: string, fn: () => Promise<void>) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    clearConfigCaches()
+    clearChannelStoreCache()
+    clearOperationalQueueStoreCache()
+    await fn()
+  } finally {
+    clearChannelStoreCache()
+    clearOperationalQueueStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+function sopLink(overrides: Partial<SopRunLink> = {}): SopRunLink {
+  return {
+    schemaVersion: 1,
+    id: 'sop-link-1',
+    sopId: 'sop-weekly',
+    sopVersionId: 'sop-version-1',
+    automationId: 'automation-1',
+    automationRunId: 'automation-run-1',
+    triggerType: 'webhook',
+    inputs: {},
+    createdAt: '2026-05-11T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function crewDetail(overrides: Partial<CrewRunDetail> = {}): CrewRunDetail {
+  return {
+    run: {
+      schemaVersion: 1,
+      id: 'crew-run-1',
+      crewId: 'crew-research',
+      crewVersionId: 'crew-version-1',
+      workItemId: 'work-channel-1',
+      status: 'queued',
+      title: 'Channel crew run',
+      summary: null,
+      rootSessionId: null,
+      createdAt: '2026-05-11T00:00:00.000Z',
+      startedAt: null,
+      finishedAt: null,
+    },
+    crew: {
+      schemaVersion: 1,
+      id: 'crew-research',
+      name: 'Research crew',
+      description: 'Researches inbound work.',
+      status: 'active',
+      activeVersionId: 'crew-version-1',
+      createdAt: '2026-05-11T00:00:00.000Z',
+      updatedAt: '2026-05-11T00:00:00.000Z',
+    },
+    version: {
+      schemaVersion: 1,
+      id: 'crew-version-1',
+      crewId: 'crew-research',
+      version: 1,
+      members: [],
+      workspaceProfileId: null,
+      outcomeRubricId: null,
+      evalSuiteId: null,
+      certificationStatus: 'not_required',
+      certifiedAt: null,
+      budgetCapUsd: null,
+      workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
+      createdAt: '2026-05-11T00:00:00.000Z',
+      createdBy: 'local-user',
+    },
+    workItem: null,
+    nodes: [],
+    artifacts: [],
+    approvals: [],
+    policyDecisions: [],
+    evaluations: [],
+    traceEvents: [],
+    ...overrides,
+  }
+}
+
+test('approving a channel SOP item dispatches through the SOP service and records the run link', async () => withChannelDispatchStore('sop', async () => {
+  const channel = createChannelDefinition({
+    provider: 'local_webhook',
+    name: 'Ops webhook',
+    sourceKey: 'ops',
+    senderAllowlist: ['ops@example.com'],
+    allowedCapabilityIds: ['skill:chart-creator'],
+    route: { activationMode: 'run_sop', targetSopId: 'sop-weekly' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'ops@example.com',
+    subject: 'Weekly digest',
+    body: 'Prepare the weekly support digest.',
+    externalMessageId: 'msg-1',
+  })
+  const queueItem = listOperationalQueueItems()[0]
+  assert.ok(queueItem)
+
+  let published = false
+  const approved = await approveChannelInboundItem(item.id, {
+    publishAutomationUpdated: () => {
+      published = true
+    },
+    runSopForTrigger: async (sopId, triggerType, inputs, publishAutomationUpdated) => {
+      publishAutomationUpdated()
+      assert.equal(sopId, 'sop-weekly')
+      assert.equal(triggerType, 'webhook')
+      assert.equal(inputs.source, 'channel')
+      assert.deepEqual((inputs.channel as { allowedCapabilityIds: string[] }).allowedCapabilityIds, ['skill:chart-creator'])
+      assert.equal((inputs.inbound as { id: string }).id, item.id)
+      return sopLink()
+    },
+  })
+
+  assert.equal(published, true)
+  assert.equal(approved?.status, 'dispatched')
+  assert.equal(approved?.auditState, 'execution_dispatched')
+  assert.equal(approved?.runKind, 'sop')
+  assert.equal(approved?.runId, 'automation-run-1')
+  assert.equal(approved?.approvedBy, 'local-user')
+  assert.ok(approved?.approvedAt)
+  assert.equal(getOperationalQueueItem(queueItem.id)?.status, 'completed')
+}))
+
+test('concurrent channel approvals claim once before dispatch awaits', async () => withChannelDispatchStore('concurrent', async () => {
+  const channel = createChannelDefinition({
+    provider: 'local_webhook',
+    name: 'Ops webhook',
+    sourceKey: 'ops',
+    senderAllowlist: ['ops@example.com'],
+    route: { activationMode: 'run_sop', targetSopId: 'sop-weekly' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'ops@example.com',
+    body: 'Run the SOP once.',
+  })
+
+  let runCalls = 0
+  let resolveRun: ((link: SopRunLink) => void) | null = null
+  const first = approveChannelInboundItem(item.id, {
+    runSopForTrigger: async () => {
+      runCalls += 1
+      return await new Promise<SopRunLink>((resolve) => {
+        resolveRun = resolve
+      })
+    },
+  })
+  const second = await approveChannelInboundItem(item.id, {
+    runSopForTrigger: async () => {
+      runCalls += 1
+      return sopLink({ automationRunId: 'duplicate-run' })
+    },
+  })
+
+  assert.equal(second?.status, 'dispatching')
+  assert.equal(runCalls, 1)
+  assert.ok(resolveRun)
+  resolveRun(sopLink())
+  const completed = await first
+
+  assert.equal(completed?.status, 'dispatched')
+  assert.equal(completed?.runId, 'automation-run-1')
+  assert.equal(runCalls, 1)
+}))
+
+test('approving a channel Crew item creates a channel-sourced work item', async () => withChannelDispatchStore('crew', async () => {
+  const channel = createChannelDefinition({
+    provider: 'email',
+    name: 'Research inbox',
+    sourceKey: 'research',
+    senderAllowlist: ['lead@example.com'],
+    route: { activationMode: 'run_crew', targetCrewId: 'crew-research' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'lead@example.com',
+    subject: 'Market scan',
+    body: 'Run a concise market scan.',
+  })
+
+  const approved = await approveChannelInboundItem(item.id, {
+    createCrewRuntimeDriver: () => ({
+      createRootSession: async () => ({ id: 'session-1' }),
+      prompt: async () => {},
+      evaluateOutcome: async () => ({ sessionId: 'eval-1', structured: null, text: '' }),
+    }),
+    startCrewRunWithOpenCode: async (draft) => {
+      assert.equal(draft.crewId, 'crew-research')
+      assert.equal(draft.workItemTitle, 'Market scan')
+      assert.equal(draft.workItemSource, 'channel')
+      assert.match(draft.workItemDescription || '', /Sender: lead@example\.com/)
+      return crewDetail()
+    },
+  })
+
+  assert.equal(approved?.status, 'dispatched')
+  assert.equal(approved?.auditState, 'execution_dispatched')
+  assert.equal(approved?.runKind, 'crew')
+  assert.equal(approved?.runId, 'crew-run-1')
+  assert.equal(approved?.workItemId, 'work-channel-1')
+}))
+
+test('failed channel dispatch is recorded without losing the inbound item', async () => withChannelDispatchStore('failure', async () => {
+  const channel = createChannelDefinition({
+    provider: 'local_webhook',
+    name: 'Ops webhook',
+    sourceKey: 'ops',
+    senderAllowlist: ['ops@example.com'],
+    route: { activationMode: 'run_sop', targetSopId: 'sop-weekly' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'ops@example.com',
+    body: 'Run the SOP.',
+  })
+  const queueItem = listOperationalQueueItems()[0]
+  assert.ok(queueItem)
+
+  const failed = await approveChannelInboundItem(item.id, {
+    runSopForTrigger: async () => {
+      throw new Error('SOP backing automation needs an approved execution brief before it can run.')
+    },
+  })
+
+  assert.equal(failed?.status, 'failed')
+  assert.equal(failed?.auditState, 'failed')
+  assert.match(failed?.error || '', /approved execution brief/)
+  assert.equal(getOperationalQueueItem(queueItem.id)?.status, 'failed')
+  assert.equal(getChannelInboundItem(item.id)?.id, item.id)
+}))
+
+test('dismissing a queued channel item cancels review queue state', async () => withChannelDispatchStore('dismiss', async () => {
+  const channel = createChannelDefinition({
+    provider: 'local_webhook',
+    name: 'Ops webhook',
+    sourceKey: 'ops',
+    senderAllowlist: ['ops@example.com'],
+    route: { activationMode: 'run_crew', targetCrewId: 'crew-research' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'ops@example.com',
+    body: 'Do not run this.',
+  })
+  const queueItem = listOperationalQueueItems()[0]
+  assert.ok(queueItem)
+
+  const dismissed = dismissChannelInboundReview(item.id, 'Not useful.')
+
+  assert.equal(dismissed?.status, 'denied')
+  assert.equal(dismissed?.auditState, 'dismissed')
+  assert.equal(dismissed?.reviewNote, 'Not useful.')
+  assert.equal(getOperationalQueueItem(queueItem.id)?.status, 'cancelled')
+}))
+
+test('dismiss refuses failed channel items without erasing diagnostics', async () => withChannelDispatchStore('dismiss-failed', async () => {
+  const channel = createChannelDefinition({
+    provider: 'local_webhook',
+    name: 'Ops webhook',
+    sourceKey: 'ops',
+    senderAllowlist: ['ops@example.com'],
+    route: { activationMode: 'run_sop', targetSopId: 'sop-weekly' },
+  })
+  const item = recordChannelInboundItem({
+    channelId: channel.id,
+    sender: 'ops@example.com',
+    body: 'Run the SOP.',
+  })
+  const failed = await approveChannelInboundItem(item.id, {
+    runSopForTrigger: async () => {
+      throw new Error('dispatch failed')
+    },
+  })
+
+  assert.equal(failed?.status, 'failed')
+  assert.throws(() => dismissChannelInboundReview(item.id, 'hide failure'), /not waiting for review/)
+  const current = getChannelInboundItem(item.id)
+  assert.equal(current?.status, 'failed')
+  assert.equal(current?.auditState, 'failed')
+  assert.equal(current?.error, 'dispatch failed')
+}))

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -133,6 +133,8 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('channels:local-webhook-pairings'), true)
   assert.equal(handlers.has('channels:create-local-webhook'), true)
   assert.equal(handlers.has('channels:rotate-local-webhook-token'), true)
+  assert.equal(handlers.has('channels:approve-inbound-item'), true)
+  assert.equal(handlers.has('channels:dismiss-inbound-item'), true)
   assert.equal(handlers.has('improvements:summary'), true)
   assert.equal(handlers.has('improvements:inbox'), true)
   assert.equal(handlers.has('improvements:memory-approve'), true)


### PR DESCRIPTION
## Summary
- add review-gated channel dispatch APIs for inbound SOP/Crew routes
- link approved channel items to dispatched SOP/Crew run ids and channel work items
- add Pulse approve/dismiss controls for queued channel work
- keep channel queue entries auditable on approval, failure, and dismissal

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/channel-dispatch.test.ts tests/channel-store.test.ts tests/channel-webhook-receiver.test.ts tests/ipc-handler-registration.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:renderer
- pnpm lint:a11y --max-warnings=0
- uv run mkdocs build --strict
- git diff --check