### PR TITLE
[codex] add channel delivery outbox review

### DIFF
--- a/apps/desktop/src/main/channel-delivery.ts
+++ b/apps/desktop/src/main/channel-delivery.ts
@@ -1,6 +1,32 @@
-import type { AppSettings, ChannelInboundItem } from '@open-cowork/shared'
+import { randomUUID } from 'node:crypto'
+import type { AppSettings, ChannelDeliveryRecord, ChannelInboundItem } from '@open-cowork/shared'
 import { sendAutomationDesktopNotification, shouldSendAutomationDesktopNotification } from './automation-notifications.ts'
-import { createChannelDeliveryRecord } from './channel-store.ts'
+import {
+  cancelChannelDeliveryRecord,
+  claimChannelDeliveryForSend,
+  createChannelDeliveryRecord,
+  getChannelDeliveryRecord,
+  markChannelDeliveryDelivered,
+  markChannelDeliveryFailed,
+} from './channel-store.ts'
+import { evaluateHttpMcpUrlResolved, type McpDnsResolver } from './mcp-url-policy.ts'
+
+const WEBHOOK_DELIVERY_TIMEOUT_MS = 10_000
+const WEBHOOK_RESPONSE_ERROR_MAX_CHARS = 1_000
+
+type WebhookDeliveryPayload = ReturnType<typeof buildWebhookDeliveryPayload>
+
+type WebhookDeliveryResult = {
+  ok: boolean
+  status: number
+  body?: string
+}
+
+type ChannelDeliveryDeps = {
+  reviewer?: string
+  resolveHostname?: McpDnsResolver
+  sendWebhook?: (record: ChannelDeliveryRecord, payload: WebhookDeliveryPayload) => Promise<WebhookDeliveryResult>
+}
 
 function notificationTitle(item: ChannelInboundItem) {
   return item.subject || `Channel item from ${item.sender}`
@@ -34,6 +60,82 @@ function shouldNotifyForChannelItem(item: ChannelInboundItem) {
     || item.status === 'failed'
 }
 
+function safeErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error || 'Unknown channel delivery error')
+}
+
+function reviewableDelivery(record: ChannelDeliveryRecord) {
+  return record.status === 'draft' || record.status === 'approval_required'
+}
+
+function deliveryApprovalId(reviewer: string) {
+  return `channel-delivery:${reviewer}:${randomUUID()}`
+}
+
+function normalizedReviewer(value: string | undefined) {
+  const reviewer = (value || 'local-user').trim()
+  if (!reviewer) return 'local-user'
+  if (Buffer.byteLength(reviewer, 'utf8') > 128) throw new Error('Channel delivery reviewer is too large.')
+  return reviewer
+}
+
+function buildWebhookDeliveryPayload(record: ChannelDeliveryRecord, approvalId: string) {
+  return {
+    schemaVersion: 1,
+    deliveryId: record.id,
+    channelId: record.channelId,
+    inboundItemId: record.inboundItemId,
+    workItemId: record.workItemId,
+    runKind: record.runKind,
+    runId: record.runId,
+    title: record.title,
+    body: record.body,
+    artifactIds: record.artifactIds,
+    policyDecisionIds: record.policyDecisionIds,
+    approvalIds: [...record.approvalIds, approvalId],
+    draftFirst: record.draftFirst,
+    createdAt: record.createdAt,
+    approvedAt: new Date().toISOString(),
+  }
+}
+
+async function defaultWebhookSender(record: ChannelDeliveryRecord, payload: WebhookDeliveryPayload): Promise<WebhookDeliveryResult> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), WEBHOOK_DELIVERY_TIMEOUT_MS)
+  try {
+    const response = await fetch(record.target, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'user-agent': 'Open-Cowork-Channel-Delivery/1',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+      redirect: 'error',
+    })
+    let body: string | undefined
+    try {
+      body = (await response.text()).slice(0, WEBHOOK_RESPONSE_ERROR_MAX_CHARS)
+    } catch {
+      body = undefined
+    }
+    return { ok: response.ok, status: response.status, body }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function validateWebhookTarget(record: ChannelDeliveryRecord, deps: ChannelDeliveryDeps) {
+  const verdict = await evaluateHttpMcpUrlResolved(record.target, {
+    resolveHostname: deps.resolveHostname,
+    allowPrivateNetwork: false,
+  })
+  if (!verdict.ok) throw new Error(verdict.reason.replaceAll('MCP', 'channel delivery'))
+  if (verdict.url.protocol !== 'https:') {
+    throw new Error('Webhook delivery callbacks must use https URLs.')
+  }
+}
+
 export function deliverChannelDesktopNotification(input: {
   item: ChannelInboundItem
   settings: Pick<AppSettings, 'automationDesktopNotifications' | 'automationQuietHoursStart' | 'automationQuietHoursEnd'>
@@ -54,4 +156,37 @@ export function deliverChannelDesktopNotification(input: {
     draftFirst: false,
     error: delivered ? null : 'Desktop notifications are not supported.',
   })
+}
+
+export async function sendChannelDelivery(deliveryId: string, deps: ChannelDeliveryDeps = {}) {
+  const record = getChannelDeliveryRecord(deliveryId)
+  if (!record) return null
+  if (record.status === 'delivered') return record
+  if (record.status === 'sending') return record
+  if (!reviewableDelivery(record)) throw new Error('Channel delivery is not waiting for review.')
+  if (record.provider !== 'webhook') {
+    throw new Error(`${record.provider} delivery remains draft-only until that provider is configured.`)
+  }
+
+  const claimed = claimChannelDeliveryForSend(record.id)
+  if (!claimed || claimed.status !== 'sending') return claimed
+
+  try {
+    await validateWebhookTarget(claimed, deps)
+    const reviewer = normalizedReviewer(deps.reviewer)
+    const approvalId = deliveryApprovalId(reviewer)
+    const payload = buildWebhookDeliveryPayload(claimed, approvalId)
+    const result = await (deps.sendWebhook || defaultWebhookSender)(claimed, payload)
+    if (!result.ok) {
+      const detail = result.body ? `: ${result.body}` : ''
+      throw new Error(`Webhook callback returned HTTP ${result.status}${detail}`)
+    }
+    return markChannelDeliveryDelivered(claimed.id, approvalId)
+  } catch (error) {
+    return markChannelDeliveryFailed(claimed.id, safeErrorMessage(error))
+  }
+}
+
+export function cancelChannelDelivery(deliveryId: string, note?: string | null) {
+  return cancelChannelDeliveryRecord(deliveryId, note)
 }

--- a/apps/desktop/src/main/channel-store.ts
+++ b/apps/desktop/src/main/channel-store.ts
@@ -51,7 +51,7 @@ const CHANNEL_AUDIT_STATES = new Set<ChannelAuditState>([
 type ChannelInboundRunKind = Exclude<ChannelInboundItem['runKind'], null>
 const CHANNEL_INBOUND_RUN_KINDS = new Set<ChannelInboundRunKind>(['sop', 'crew'])
 const CHANNEL_DELIVERY_PROVIDERS = new Set<ChannelDeliveryProvider>(['desktop_notification', 'email', 'slack', 'teams', 'webhook'])
-const CHANNEL_DELIVERY_STATUSES = new Set<ChannelDeliveryStatus>(['draft', 'approval_required', 'delivered', 'failed'])
+const CHANNEL_DELIVERY_STATUSES = new Set<ChannelDeliveryStatus>(['draft', 'approval_required', 'sending', 'delivered', 'failed', 'cancelled'])
 type ChannelDeliveryRunKind = Exclude<ChannelDeliveryRecord['runKind'], null>
 const DELIVERY_RUN_KINDS = new Set<ChannelDeliveryRunKind>(['crew', 'sop', 'automation', 'channel'])
 
@@ -853,6 +853,7 @@ export function recordChannelInboundItem(draft: ChannelInboundDraft) {
   const sender = boundedText(draft.sender, 'Channel sender', 512)
   const subject = optionalBoundedText(draft.subject, 'Channel subject', 2048)
   const body = boundedText(draft.body, 'Channel body', MAX_BODY_BYTES)
+  const replyTarget = optionalBoundedText(draft.replyTarget, 'Channel reply target', 2048)
   const receivedAt = optionalBoundedText(draft.receivedAt, 'Channel received timestamp', 128) || nowIso()
   const source = {
     schemaVersion: COWORK_CHANNEL_SCHEMA_VERSION,
@@ -938,7 +939,7 @@ export function recordChannelInboundItem(draft: ChannelInboundDraft) {
         channelId: channel.id,
         inboundItemId: item.id,
         provider: channel.provider === 'local_webhook' ? 'webhook' : channel.provider,
-        target: sender,
+        target: replyTarget || sender,
         status: 'draft',
         title: subject || `Reply to ${sender}`,
         body: '',
@@ -1078,6 +1079,77 @@ export function getChannelDeliveryRecord(id: string) {
   const row = getChannelDb().prepare('select * from channel_delivery_records where id = ?')
     .get(boundedText(id, 'Channel delivery record id', 512)) as DbRow | undefined
   return row ? rowToDeliveryRecord(row) : null
+}
+
+export function claimChannelDeliveryForSend(id: string) {
+  const record = getChannelDeliveryRecord(id)
+  if (!record) return null
+  if (record.status === 'delivered' || record.status === 'sending') return record
+  if (record.status !== 'draft' && record.status !== 'approval_required') {
+    throw new Error('Only draft delivery records can be sent.')
+  }
+  const now = nowIso()
+  getChannelDb().prepare(`
+    update channel_delivery_records
+    set status = 'sending',
+        updated_at = ?,
+        error = null
+    where id = ?
+  `).run(now, record.id)
+  return getChannelDeliveryRecord(record.id)
+}
+
+export function markChannelDeliveryDelivered(id: string, approvalId: string) {
+  const record = getChannelDeliveryRecord(id)
+  if (!record) return null
+  if (record.status === 'delivered') return record
+  if (record.status !== 'draft' && record.status !== 'approval_required' && record.status !== 'sending') {
+    throw new Error('Only draft delivery records can be sent.')
+  }
+  const approvalIds = boundedStringArray([...record.approvalIds, approvalId], 'Channel delivery approval ids', { allowEmpty: true })
+  if (approvalIds.length === 0) throw new Error('Delivered channel records require an approval reference.')
+  const now = nowIso()
+  getChannelDb().prepare(`
+    update channel_delivery_records
+    set status = 'delivered',
+        approval_ids_json = ?,
+        updated_at = ?,
+        error = null
+    where id = ?
+  `).run(JSON.stringify(approvalIds), now, record.id)
+  return getChannelDeliveryRecord(record.id)
+}
+
+export function markChannelDeliveryFailed(id: string, error: string) {
+  const record = getChannelDeliveryRecord(id)
+  if (!record) return null
+  const now = nowIso()
+  getChannelDb().prepare(`
+    update channel_delivery_records
+    set status = 'failed',
+        updated_at = ?,
+        error = ?
+    where id = ?
+  `).run(now, optionalBoundedText(error, 'Channel delivery error', 4096), record.id)
+  return getChannelDeliveryRecord(record.id)
+}
+
+export function cancelChannelDeliveryRecord(id: string, note?: string | null) {
+  const record = getChannelDeliveryRecord(id)
+  if (!record) return null
+  if (record.status === 'delivered') throw new Error('Delivered channel records cannot be cancelled.')
+  if (record.status !== 'draft' && record.status !== 'approval_required') {
+    throw new Error('Only draft delivery records can be cancelled.')
+  }
+  const now = nowIso()
+  getChannelDb().prepare(`
+    update channel_delivery_records
+    set status = 'cancelled',
+        updated_at = ?,
+        error = ?
+    where id = ?
+  `).run(now, optionalBoundedText(note, 'Channel delivery cancellation note', 4096), record.id)
+  return getChannelDeliveryRecord(record.id)
 }
 
 export function listChannelDeliveryRecords() {

--- a/apps/desktop/src/main/channel-webhook-receiver.ts
+++ b/apps/desktop/src/main/channel-webhook-receiver.ts
@@ -195,6 +195,7 @@ async function handleLocalWebhookRequest(req: IncomingMessage, res: ServerRespon
       subject: payloadOptionalString(payload.subject, 'subject'),
       body: payloadString(payload.body, 'body'),
       externalMessageId: payloadOptionalString(payload.externalMessageId, 'externalMessageId'),
+      replyTarget: payloadOptionalString(payload.replyTarget, 'replyTarget'),
     })
     log('channel', `Recorded local webhook item ${item.id} for ${sourceKey} with status ${item.status}`)
     try {

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -11,6 +11,10 @@ import {
   approveChannelInboundItem,
   dismissChannelInboundReview,
 } from '../channel-dispatch.ts'
+import {
+  cancelChannelDelivery,
+  sendChannelDelivery,
+} from '../channel-delivery.ts'
 import { getLocalWebhookReceiverStatus } from '../channel-webhook-receiver.ts'
 import type { IpcHandlerContext } from './context.ts'
 
@@ -73,6 +77,17 @@ export function registerChannelHandlers(context: IpcHandlerContext) {
     return dismissChannelInboundReview(
       assertString(itemId, 'Channel inbound item id'),
       optionalString(note, 'Channel review note'),
+    )
+  })
+
+  context.ipcMain.handle('channels:send-delivery', async (_event, deliveryId) => {
+    return sendChannelDelivery(assertString(deliveryId, 'Channel delivery record id'))
+  })
+
+  context.ipcMain.handle('channels:cancel-delivery', async (_event, deliveryId, note) => {
+    return cancelChannelDelivery(
+      assertString(deliveryId, 'Channel delivery record id'),
+      optionalString(note, 'Channel delivery note'),
     )
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -91,6 +91,8 @@ const PRELOAD_INVOKE_CHANNELS = [
   'channels:rotate-local-webhook-token',
   'channels:approve-inbound-item',
   'channels:dismiss-inbound-item',
+  'channels:send-delivery',
+  'channels:cancel-delivery',
   'improvements:summary',
   'improvements:inbox',
   'improvements:memory-approve',
@@ -326,6 +328,8 @@ const api: CoworkAPI = {
     rotateLocalWebhookToken: (channelId) => invoke('channels:rotate-local-webhook-token', channelId),
     approveInboundItem: (itemId) => invoke('channels:approve-inbound-item', itemId),
     dismissInboundItem: (itemId, note) => invoke('channels:dismiss-inbound-item', itemId, note),
+    sendDelivery: (deliveryId) => invoke('channels:send-delivery', deliveryId),
+    cancelDelivery: (deliveryId, note) => invoke('channels:cancel-delivery', deliveryId, note),
   },
   improvements: {
     summary: () => invoke('improvements:summary'),

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -684,6 +684,8 @@ function installPulseApi(options: {
   localWebhookStatus?: LocalWebhookReceiverStatus
   approveInboundItem?: ReturnType<typeof vi.fn>
   dismissInboundItem?: ReturnType<typeof vi.fn>
+  sendDelivery?: ReturnType<typeof vi.fn>
+  cancelDelivery?: ReturnType<typeof vi.fn>
 } = {}) {
   const testChannelState = options.channelState ?? channelState
   const testLocalWebhookStatus = options.localWebhookStatus ?? localWebhookStatus
@@ -738,6 +740,8 @@ function installPulseApi(options: {
       rotateLocalWebhookToken: vi.fn(async () => null),
       approveInboundItem: options.approveInboundItem || vi.fn(async () => null),
       dismissInboundItem: options.dismissInboundItem || vi.fn(async () => null),
+      sendDelivery: options.sendDelivery || vi.fn(async () => null),
+      cancelDelivery: options.cancelDelivery || vi.fn(async () => null),
     },
     improvements: {
       summary: options.improvementSummary || vi.fn(async () => improvementSummary),
@@ -906,6 +910,34 @@ describe('PulsePage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Dismiss' }))
     await waitFor(() => expect(dismissInboundItem).toHaveBeenCalledWith('channel-item-1', 'Dismissed from Pulse.'))
+  })
+
+  it('reviews channel delivery drafts from Pulse', async () => {
+    const user = userEvent.setup()
+    const sendDelivery = vi.fn(async () => null)
+    const cancelDelivery = vi.fn(async () => null)
+    const api = installPulseApi({
+      sendDelivery,
+      cancelDelivery,
+      channelState: {
+        ...channelState,
+        deliveries: [{
+          ...channelState.deliveries[0]!,
+          provider: 'webhook',
+          target: 'https://callback.example/hooks/open-cowork',
+        }],
+      },
+    })
+
+    render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
+    await screen.findByText('Slack digest draft')
+
+    await user.click(screen.getByRole('button', { name: 'Send webhook' }))
+    await waitFor(() => expect(sendDelivery).toHaveBeenCalledWith('delivery-1'))
+    expect(api.channels.list).toHaveBeenCalledTimes(2)
+
+    await user.click(screen.getByRole('button', { name: 'Cancel draft' }))
+    await waitFor(() => expect(cancelDelivery).toHaveBeenCalledWith('delivery-1', 'Cancelled from Pulse.'))
   })
 
   it('updates Improvement Inbox proposals and refreshes diagnostics', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -159,8 +159,17 @@ function channelItemCanDispatch(item: ChannelInboundItem) {
 
 function deliveryTone(delivery: ChannelDeliveryRecord) {
   if (delivery.status === 'failed') return 'text-red'
-  if (delivery.status === 'draft' || delivery.status === 'approval_required') return 'text-amber'
+  if (delivery.status === 'cancelled') return 'text-text-muted'
+  if (delivery.status === 'draft' || delivery.status === 'approval_required' || delivery.status === 'sending') return 'text-amber'
   return 'text-accent'
+}
+
+function deliveryCanSend(delivery: ChannelDeliveryRecord) {
+  return delivery.provider === 'webhook' && (delivery.status === 'draft' || delivery.status === 'approval_required')
+}
+
+function deliveryCanCancel(delivery: ChannelDeliveryRecord) {
+  return delivery.status === 'draft' || delivery.status === 'approval_required'
 }
 
 export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => void; brandName: string }) {
@@ -303,7 +312,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     [channelState.inboundItems],
   )
   const draftChannelDeliveries = useMemo(
-    () => channelState.deliveries.filter((delivery) => delivery.status === 'draft' || delivery.status === 'approval_required'),
+    () => channelState.deliveries.filter((delivery) => delivery.status === 'draft' || delivery.status === 'approval_required' || delivery.status === 'sending'),
     [channelState.deliveries],
   )
   const channelSandboxQueueItems = useMemo(
@@ -489,6 +498,28 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
       try {
         window.coworkApi.diagnostics.reportRendererError({
           message: `Failed to review channel item ${item.id}: ${describePulseThreadError(error)}`,
+          stack: error instanceof Error ? error.stack : undefined,
+          view: 'pulse',
+        })
+      } catch {
+        // Diagnostics are best-effort from an action error handler.
+      }
+    } finally {
+      setChannelActionId(null)
+    }
+  }
+
+  async function reviewChannelDelivery(delivery: ChannelDeliveryRecord, action: 'send' | 'cancel') {
+    setChannelActionId(`${action}-delivery:${delivery.id}`)
+    try {
+      if (action === 'send') await window.coworkApi.channels.sendDelivery(delivery.id)
+      else await window.coworkApi.channels.cancelDelivery(delivery.id, 'Cancelled from Pulse.')
+      await refreshDiagnostics({ silent: true })
+    } catch (error) {
+      addGlobalError(t('pulse.channelDeliveryFailed', 'Could not update the delivery draft. Please try again.'))
+      try {
+        window.coworkApi.diagnostics.reportRendererError({
+          message: `Failed to review channel delivery ${delivery.id}: ${describePulseThreadError(error)}`,
           stack: error instanceof Error ? error.stack : undefined,
           view: 'pulse',
         })
@@ -839,6 +870,30 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                             <div className="mt-1 text-[11px] text-text-muted leading-relaxed">
                               {delivery.target} · {delivery.draftFirst ? t('homepage.channels.draftFirst', 'draft-first') : t('homepage.channels.direct', 'direct')} · {formatChannelTime(delivery.createdAt)}
                             </div>
+                            {deliveryCanSend(delivery) || deliveryCanCancel(delivery) ? (
+                              <div className="mt-3 flex flex-wrap gap-2">
+                                {deliveryCanSend(delivery) ? (
+                                  <button
+                                    type="button"
+                                    className="rounded-full bg-accent px-3 py-1.5 text-[11px] font-semibold text-base transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+                                    disabled={channelActionId !== null}
+                                    onClick={() => void reviewChannelDelivery(delivery, 'send')}
+                                  >
+                                    {channelActionId === `send-delivery:${delivery.id}` ? t('homepage.channels.sending', 'Sending...') : t('homepage.channels.sendWebhook', 'Send webhook')}
+                                  </button>
+                                ) : null}
+                                {deliveryCanCancel(delivery) ? (
+                                  <button
+                                    type="button"
+                                    className="rounded-full border border-border-subtle px-3 py-1.5 text-[11px] font-semibold text-text-secondary transition hover:border-red hover:text-red disabled:cursor-not-allowed disabled:opacity-60"
+                                    disabled={channelActionId !== null}
+                                    onClick={() => void reviewChannelDelivery(delivery, 'cancel')}
+                                  >
+                                    {channelActionId === `cancel-delivery:${delivery.id}` ? t('homepage.channels.cancelling', 'Cancelling...') : t('homepage.channels.cancelDraft', 'Cancel draft')}
+                                  </button>
+                                ) : null}
+                              </div>
+                            ) : null}
                           </div>
                         ))}
                       </div>

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -183,6 +183,10 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
         throw new Error('channels.createLocalWebhook not mocked')
       }),
       rotateLocalWebhookToken: vi.fn(async () => null),
+      approveInboundItem: vi.fn(async () => null),
+      dismissInboundItem: vi.fn(async () => null),
+      sendDelivery: vi.fn(async () => null),
+      cancelDelivery: vi.fn(async () => null),
     },
     clipboard: {
       writeText: vi.fn(async () => true),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,9 +269,12 @@ desktop notifications are enabled in Settings.
 Items routed to `run_sop` or `run_crew` are review-gated: Pulse must approve
 the inbound item before Open Cowork hands it to the existing SOP or Crew
 service, and the inbound audit record keeps the resulting run/work-item link.
-External channel delivery remains draft-first by default; direct sends should
-only be enabled by downstream channel integrations that add their own approval
-and audit policy.
+Webhook payloads may include `replyTarget` for a draft-first callback URL. The
+callback is never sent on receipt; Pulse must explicitly send the delivery
+draft, the URL must use HTTPS, and hostname resolution must pass the public
+network policy used for HTTP MCP endpoints. Slack, email, and Teams channel
+records remain draft-only until downstream provider integrations add their own
+approval and audit policy.
 
 ## Providers
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -85,7 +85,7 @@ Pulse mixes:
   capability metadata
 - channel ingress and delivery visibility: active channels, local webhook
   receiver state, recent inbound items, denied inputs, approve/dismiss actions
-  for channel-routed SOP or Crew work, and draft-first delivery records
+  for channel-routed SOP or Crew work, and reviewed delivery drafts
 - governed learning diagnostics for proposed memories, improvement proposals,
   dream runs, policy blocks, and review actions in the Improvement Inbox
 - recent performance metrics
@@ -260,3 +260,8 @@ Channel items configured for `run_sop` or `run_crew` still stop at Pulse for
 human review. Approving the item hands it to the existing SOP or Crew service
 and links the resulting run back to the inbound audit record; dismissing it
 cancels the review queue entry without triggering OpenCode execution.
+
+Delivery drafts are also reviewed from Pulse. Webhook drafts can be sent only
+after an explicit user action, and the target must pass the same public-network
+policy used for HTTP MCP endpoints plus an HTTPS-only check. Slack, email, and
+Teams records remain draft-only until a real provider integration is configured.

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -16,7 +16,7 @@ export type ChannelAuditState =
   | 'dismissed'
   | 'failed'
 export type ChannelDeliveryProvider = 'desktop_notification' | 'email' | 'slack' | 'teams' | 'webhook'
-export type ChannelDeliveryStatus = 'draft' | 'approval_required' | 'delivered' | 'failed'
+export type ChannelDeliveryStatus = 'draft' | 'approval_required' | 'sending' | 'delivered' | 'failed' | 'cancelled'
 
 export interface ChannelSchemaVersionedRecord {
   schemaVersion: number
@@ -121,6 +121,7 @@ export interface ChannelInboundDraft {
   subject?: string | null
   body: string
   externalMessageId?: string | null
+  replyTarget?: string | null
   receivedAt?: string | null
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -328,6 +328,8 @@ export interface CoworkAPI {
     rotateLocalWebhookToken: (channelId: string) => Promise<LocalWebhookChannelPairingResult | null>
     approveInboundItem: (itemId: string) => Promise<ChannelInboundItem | null>
     dismissInboundItem: (itemId: string, note?: string | null) => Promise<ChannelInboundItem | null>
+    sendDelivery: (deliveryId: string) => Promise<ChannelDeliveryRecord | null>
+    cancelDelivery: (deliveryId: string, note?: string | null) => Promise<ChannelDeliveryRecord | null>
   }
   improvements: {
     summary: () => Promise<ImprovementDiagnosticsSummary>

--- a/tests/channel-delivery.test.ts
+++ b/tests/channel-delivery.test.ts
@@ -8,9 +8,14 @@ import {
   clearChannelStoreCache,
   createChannelDefinition,
   listChannelDeliveryRecords,
+  getChannelInboundItem,
   recordChannelInboundItem,
 } from '../apps/desktop/src/main/channel-store.ts'
-import { deliverChannelDesktopNotification } from '../apps/desktop/src/main/channel-delivery.ts'
+import {
+  cancelChannelDelivery,
+  deliverChannelDesktopNotification,
+  sendChannelDelivery,
+} from '../apps/desktop/src/main/channel-delivery.ts'
 import { clearOperationalQueueStoreCache } from '../apps/desktop/src/main/operational-queue-store.ts'
 
 const notificationSettings = {
@@ -30,12 +35,12 @@ function resetStores(userDataDir: string) {
   clearOperationalQueueStoreCache()
 }
 
-function withChannelDeliveryStore(name: string, fn: () => void) {
+async function withChannelDeliveryStore(name: string, fn: () => void | Promise<void>) {
   const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
   const userDataDir = uniqueUserDataDir(name)
   try {
     resetStores(userDataDir)
-    fn()
+    await fn()
   } finally {
     clearChannelStoreCache()
     clearOperationalQueueStoreCache()
@@ -111,3 +116,156 @@ test('channel desktop notifications respect the shared notification toggle', () 
   assert.equal(delivery, null)
   assert.equal(listChannelDeliveryRecords().length, 0)
 }))
+
+test('channel webhook delivery sends draft-first callbacks only after explicit review', async () => {
+  await withChannelDeliveryStore('webhook-send', async () => {
+    const channel = createChannelDefinition({
+      provider: 'local_webhook',
+      name: 'Support webhook',
+      sourceKey: 'support',
+      senderAllowlist: ['ops@example.com'],
+      route: { activationMode: 'draft_reply' },
+    })
+    const item = recordChannelInboundItem({
+      channelId: channel.id,
+      sender: 'ops@example.com',
+      subject: 'Review this request',
+      body: 'Please review before routing.',
+      replyTarget: 'https://callback.example/hooks/open-cowork',
+    })
+    const delivery = listChannelDeliveryRecords()[0]
+    assert.ok(delivery)
+    assert.equal(item.status, 'drafted')
+    assert.equal(delivery.status, 'draft')
+    assert.equal(delivery.provider, 'webhook')
+    assert.equal(delivery.target, 'https://callback.example/hooks/open-cowork')
+
+    let sentPayload: { deliveryId?: string; approvalIds?: string[] } | null = null
+    const delivered = await sendChannelDelivery(delivery.id, {
+      resolveHostname: async () => [{ address: '93.184.216.34', family: 4 }],
+      sendWebhook: async (_record, payload) => {
+        sentPayload = payload
+        return { ok: true, status: 202 }
+      },
+    })
+
+    assert.equal(delivered?.status, 'delivered')
+    assert.equal(delivered?.approvalIds.length, 1)
+    assert.equal(sentPayload?.deliveryId, delivery.id)
+    assert.deepEqual(sentPayload?.approvalIds, delivered?.approvalIds)
+    assert.equal(getChannelInboundItem(item.id)?.status, 'drafted')
+  })
+})
+
+test('concurrent channel webhook delivery approvals send one callback', async () => {
+  await withChannelDeliveryStore('webhook-concurrent-send', async () => {
+    const channel = createChannelDefinition({
+      provider: 'local_webhook',
+      name: 'Support webhook',
+      sourceKey: 'support',
+      senderAllowlist: ['ops@example.com'],
+      route: { activationMode: 'draft_reply' },
+    })
+    recordChannelInboundItem({
+      channelId: channel.id,
+      sender: 'ops@example.com',
+      body: 'Send once.',
+      replyTarget: 'https://callback.example/hooks/open-cowork',
+    })
+    const delivery = listChannelDeliveryRecords()[0]
+    assert.ok(delivery)
+
+    let sendCalls = 0
+    let resolveSend: ((result: { ok: boolean; status: number }) => void) | null = null
+    const first = sendChannelDelivery(delivery.id, {
+      resolveHostname: async () => [{ address: '93.184.216.34', family: 4 }],
+      sendWebhook: async () => {
+        sendCalls += 1
+        return await new Promise((resolve) => {
+          resolveSend = resolve
+        })
+      },
+    })
+    const second = await sendChannelDelivery(delivery.id, {
+      resolveHostname: async () => [{ address: '93.184.216.34', family: 4 }],
+      sendWebhook: async () => {
+        sendCalls += 1
+        return { ok: true, status: 202 }
+      },
+    })
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    assert.equal(second?.status, 'sending')
+    assert.equal(sendCalls, 1)
+    assert.ok(resolveSend)
+    resolveSend({ ok: true, status: 202 })
+    const delivered = await first
+
+    assert.equal(delivered?.status, 'delivered')
+    assert.equal(sendCalls, 1)
+  })
+})
+
+test('channel webhook delivery failures are recorded without losing inbound work', async () => {
+  await withChannelDeliveryStore('webhook-failure', async () => {
+    const channel = createChannelDefinition({
+      provider: 'local_webhook',
+      name: 'Support webhook',
+      sourceKey: 'support',
+      senderAllowlist: ['ops@example.com'],
+      route: { activationMode: 'draft_reply' },
+    })
+    const item = recordChannelInboundItem({
+      channelId: channel.id,
+      sender: 'ops@example.com',
+      body: 'Send a callback.',
+      replyTarget: 'http://callback.example/hooks/open-cowork',
+    })
+    const delivery = listChannelDeliveryRecords()[0]
+    assert.ok(delivery)
+
+    const failed = await sendChannelDelivery(delivery.id, {
+      resolveHostname: async () => [{ address: '93.184.216.34', family: 4 }],
+      sendWebhook: async () => {
+        throw new Error('should not send blocked targets')
+      },
+    })
+
+    assert.equal(failed?.status, 'failed')
+    assert.match(failed?.error || '', /https URLs/)
+    assert.equal(getChannelInboundItem(item.id)?.status, 'drafted')
+  })
+})
+
+test('channel delivery drafts can be cancelled but unsupported providers stay draft-only', async () => {
+  await withChannelDeliveryStore('delivery-cancel', async () => {
+    const channel = createChannelDefinition({
+      provider: 'slack',
+      name: 'Customer Slack',
+      sourceKey: 'customer-slack',
+      senderAllowlist: ['customer@example.com'],
+      route: { activationMode: 'draft_reply' },
+    })
+    recordChannelInboundItem({
+      channelId: channel.id,
+      sender: 'customer@example.com',
+      body: 'Please draft a reply.',
+    })
+    const delivery = listChannelDeliveryRecords()[0]
+    assert.ok(delivery)
+
+    await assert.rejects(
+      () => sendChannelDelivery(delivery.id),
+      /draft-only/,
+    )
+    assert.equal(listChannelDeliveryRecords()[0]?.status, 'draft')
+
+    const cancelled = cancelChannelDelivery(delivery.id, 'No longer needed.')
+    assert.equal(cancelled?.status, 'cancelled')
+    assert.equal(cancelled?.error, 'No longer needed.')
+    assert.throws(
+      () => cancelChannelDelivery(delivery.id, 'again'),
+      /Only draft delivery records/,
+    )
+  })
+})

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -135,6 +135,8 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('channels:rotate-local-webhook-token'), true)
   assert.equal(handlers.has('channels:approve-inbound-item'), true)
   assert.equal(handlers.has('channels:dismiss-inbound-item'), true)
+  assert.equal(handlers.has('channels:send-delivery'), true)
+  assert.equal(handlers.has('channels:cancel-delivery'), true)
   assert.equal(handlers.has('improvements:summary'), true)
   assert.equal(handlers.has('improvements:inbox'), true)
   assert.equal(handlers.has('improvements:memory-approve'), true)


### PR DESCRIPTION
## Summary
- add reviewed channel delivery actions for Pulse outbox drafts
- allow webhook delivery drafts to send only after explicit user action, HTTPS URL validation, and public-network DNS policy checks
- keep email, Slack, and Teams delivery records draft-only until real provider integrations exist
- add a sending claim state so duplicate approvals cannot POST the same webhook twice
- support local webhook replyTarget values for draft-first callback destinations

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/channel-delivery.test.ts tests/channel-store.test.ts tests/ipc-handler-registration.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- --run src/renderer/components/PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm lint:a11y --max-warnings=0
- uv run mkdocs build --strict
- git diff --check

Roadmap: #249