### PR TITLE
[codex] inherit channel sandbox for routed runs

### DIFF
--- a/apps/desktop/src/main/automation-operational-queue.ts
+++ b/apps/desktop/src/main/automation-operational-queue.ts
@@ -55,12 +55,20 @@ function terminalOperationalStatus(status: AutomationRun['status']): Exclude<Ope
 
 export function enqueueAutomationOperationalQueueItem(automation: AutomationDetail, run: AutomationRun, options: {
   runKind?: 'automation' | 'sop'
+  workspaceProfileId?: string | null
+  channelId?: string | null
 } = {}) {
-  const workspaceProfileId = automationWorkspaceProfileId(automation, run.kind)
-  if (!getWorkspaceProfile(workspaceProfileId)) {
+  const workspaceProfileId = options.workspaceProfileId || automationWorkspaceProfileId(automation, run.kind)
+  const profile = getWorkspaceProfile(workspaceProfileId)
+  if (!profile) {
     throw new Error(`Workspace profile ${workspaceProfileId} does not exist.`)
   }
-  const writeCapable = writeCapableAutomationRun(automation, run.kind)
+  const externalSystemIds = profile.authority.externalSystems
+    .filter((system) => system.writeAllowed)
+    .map((system) => system.id)
+  const writeCapable = options.workspaceProfileId
+    ? Boolean(profile.authority.filesystem.writeAllowed || externalSystemIds.length > 0)
+    : writeCapableAutomationRun(automation, run.kind)
   return enqueueOperationalRun({
     runKind: options.runKind || 'automation',
     runId: run.id,
@@ -68,8 +76,9 @@ export function enqueueAutomationOperationalQueueItem(automation: AutomationDeta
     requestedAutonomy: requestedAutonomyForAutomation(automation, run.kind),
     globalMaxAutonomy: resolveOperationalAutonomyCeiling(automationGlobalMaxAutonomy(automation)),
     workspaceProfileId,
-    projectId: writeCapable ? automationQueueProjectId(automation) : null,
-    externalSystemIds: [],
+    projectId: writeCapable && !options.channelId ? automationQueueProjectId(automation) : null,
+    channelId: options.channelId || null,
+    externalSystemIds: options.workspaceProfileId ? externalSystemIds : [],
     writeCapable,
     caps: applyOperationalQueueSettings({
       maxParallel: 1,

--- a/apps/desktop/src/main/automation-run-starter.ts
+++ b/apps/desktop/src/main/automation-run-starter.ts
@@ -47,6 +47,8 @@ export interface StartAutomationRunOptions {
   sopTriggerType?: SopTriggerType | null
   sopInputs?: Record<string, unknown>
   sopRunContext?: SopRunStartContext | null
+  workspaceProfileId?: string | null
+  channelId?: string | null
 }
 
 function automationRunTitle(automation: AutomationDetail, kind: AutomationRunKind) {
@@ -211,6 +213,8 @@ export async function startAutomationRun(
   if (!run) throw new AutomationRunConflictError('Automation already has an active run.')
   enqueueAutomationOperationalQueueItem(automation, run, {
     runKind: sopRunLink ? 'sop' : 'automation',
+    workspaceProfileId: options.workspaceProfileId,
+    channelId: options.channelId,
   })
   const started = startAutomationOperationalQueueItem(run.id)
   if (!started || started.status !== 'running') {

--- a/apps/desktop/src/main/channel-dispatch.ts
+++ b/apps/desktop/src/main/channel-dispatch.ts
@@ -137,6 +137,10 @@ export async function approveChannelInboundItem(
         channelTriggerType(claimed),
         buildChannelInputs(claimed),
         deps.publishAutomationUpdated || (() => {}),
+        {
+          workspaceProfileId: claimed.workspaceProfileId,
+          channelId: claimed.channelId,
+        },
       )
       const updated = markChannelInboundItemDispatched(claimed.id, {
         runKind: 'sop',
@@ -151,7 +155,10 @@ export async function approveChannelInboundItem(
     if (!crewId) throw new Error('Channel route is missing a Crew target.')
     const startCrew = deps.startCrewRunWithOpenCode || startCrewRunWithOpenCode
     const driver = (deps.createCrewRuntimeDriver || createOpenCodeCrewRuntimeDriver)()
-    const detail: CrewRunDetail = await startCrew(buildCrewRunDraft(claimed), driver)
+    const detail: CrewRunDetail = await startCrew(buildCrewRunDraft(claimed), driver, {
+      workspaceProfileId: claimed.workspaceProfileId,
+      channelId: claimed.channelId,
+    })
     const updated = markChannelInboundItemDispatched(claimed.id, {
       runKind: 'crew',
       runId: detail.run.id,

--- a/apps/desktop/src/main/crew-operational-queue.ts
+++ b/apps/desktop/src/main/crew-operational-queue.ts
@@ -42,8 +42,11 @@ function terminalOperationalStatus(status: CrewRunStatus): Exclude<OperationalQu
   return null
 }
 
-export function enqueueCrewOperationalQueueItem(detail: CrewRunDetail) {
-  const workspaceProfileId = resolveCrewWorkspaceProfileId(detail.version.workspaceProfileId)
+export function enqueueCrewOperationalQueueItem(detail: CrewRunDetail, options: {
+  workspaceProfileId?: string | null
+  channelId?: string | null
+} = {}) {
+  const workspaceProfileId = resolveCrewWorkspaceProfileId(options.workspaceProfileId || detail.version.workspaceProfileId)
   const profile = getWorkspaceProfile(workspaceProfileId)
   const lead = detail.version.members.find((member) => member.role === 'lead')
   const externalSystemIds = profile?.authority.externalSystems
@@ -62,6 +65,7 @@ export function enqueueCrewOperationalQueueItem(detail: CrewRunDetail) {
     workspaceProfileId,
     agentName: lead?.agentName || null,
     crewId: detail.crew.id,
+    channelId: options.channelId || null,
     externalSystemIds,
     writeCapable,
     caps: applyOperationalQueueSettings({

--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -584,9 +584,13 @@ export async function dispatchRunnableCrewQueueItems(
 export async function startCrewRunWithOpenCode(
   draft: CrewRunDraft,
   driver: CrewRuntimeExecutionDriver,
+  options: { workspaceProfileId?: string | null; channelId?: string | null } = {},
 ): Promise<CrewRunDetail> {
   const runDetail = startCrewRun(draft, { initialStatus: 'queued' })
-  const queueItem = enqueueCrewOperationalQueueItem(runDetail)
+  const queueItem = enqueueCrewOperationalQueueItem(runDetail, {
+    workspaceProfileId: options.workspaceProfileId,
+    channelId: options.channelId,
+  })
   const started = startCrewOperationalQueueItem(runDetail.run.id)
   if (started?.status !== 'running') {
     updateCrewRunStatus(runDetail.run.id, 'queued', { summary: 'Waiting for operations queue capacity.' })

--- a/apps/desktop/src/main/sop-service.ts
+++ b/apps/desktop/src/main/sop-service.ts
@@ -340,6 +340,7 @@ export async function runSopForTrigger(
   triggerType: SopTriggerType,
   inputs: Record<string, unknown> = {},
   publishAutomationUpdated: () => void = () => {},
+  options: { workspaceProfileId?: string | null; channelId?: string | null } = {},
 ): Promise<SopRunLink> {
   const detail = getSopDetail(sopId)
   if (!detail?.activeVersion) throw new Error(`SOP ${sopId} has no active version.`)
@@ -356,6 +357,8 @@ export async function runSopForTrigger(
     run = await startAutomationRun(resolved.automationId, 'execution', publishAutomationUpdated, {
       title: `Run SOP: ${detail.definition.name}`,
       sopRunContext: resolved.context,
+      workspaceProfileId: options.workspaceProfileId,
+      channelId: options.channelId,
     })
   } catch (error) {
     publishAutomationUpdated()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,6 +269,9 @@ desktop notifications are enabled in Settings.
 Items routed to `run_sop` or `run_crew` are review-gated: Pulse must approve
 the inbound item before Open Cowork hands it to the existing SOP or Crew
 service, and the inbound audit record keeps the resulting run/work-item link.
+The linked SOP or Crew operational run inherits the channel workspace profile,
+which defaults to the read-only `channel-sandbox`, so channel-originated work
+keeps the channel isolation marker beyond the initial inbox review queue item.
 Once linked SOP or Crew work completes, Pulse can create a delivery draft from
 the run output. That draft links back to the inbound item, run, work item,
 artifacts, policy decisions, and approvals where those records exist.

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -260,6 +260,9 @@ Channel items configured for `run_sop` or `run_crew` still stop at Pulse for
 human review. Approving the item hands it to the existing SOP or Crew service
 and links the resulting run back to the inbound audit record; dismissing it
 cancels the review queue entry without triggering OpenCode execution.
+Channel-routed SOP and Crew runs inherit the selected channel workspace profile
+for their operational queue authority, defaulting to the read-only
+`channel-sandbox`.
 
 When linked SOP or Crew work completes, Pulse can project the run output into a
 channel delivery draft. The draft keeps the work-item/run link plus any recorded

--- a/tests/channel-dispatch.test.ts
+++ b/tests/channel-dispatch.test.ts
@@ -136,13 +136,17 @@ test('approving a channel SOP item dispatches through the SOP service and record
     publishAutomationUpdated: () => {
       published = true
     },
-    runSopForTrigger: async (sopId, triggerType, inputs, publishAutomationUpdated) => {
+    runSopForTrigger: async (sopId, triggerType, inputs, publishAutomationUpdated, options) => {
       publishAutomationUpdated()
       assert.equal(sopId, 'sop-weekly')
       assert.equal(triggerType, 'webhook')
       assert.equal(inputs.source, 'channel')
       assert.deepEqual((inputs.channel as { allowedCapabilityIds: string[] }).allowedCapabilityIds, ['skill:chart-creator'])
       assert.equal((inputs.inbound as { id: string }).id, item.id)
+      assert.deepEqual(options, {
+        workspaceProfileId: 'channel-sandbox',
+        channelId: channel.id,
+      })
       return sopLink()
     },
   })
@@ -220,11 +224,15 @@ test('approving a channel Crew item creates a channel-sourced work item', async 
       prompt: async () => {},
       evaluateOutcome: async () => ({ sessionId: 'eval-1', structured: null, text: '' }),
     }),
-    startCrewRunWithOpenCode: async (draft) => {
+    startCrewRunWithOpenCode: async (draft, _driver, options) => {
       assert.equal(draft.crewId, 'crew-research')
       assert.equal(draft.workItemTitle, 'Market scan')
       assert.equal(draft.workItemSource, 'channel')
       assert.match(draft.workItemDescription || '', /Sender: lead@example\.com/)
+      assert.deepEqual(options, {
+        workspaceProfileId: 'channel-sandbox',
+        channelId: channel.id,
+      })
       return crewDetail()
     },
   })

--- a/tests/operational-queue-store.test.ts
+++ b/tests/operational-queue-store.test.ts
@@ -3,7 +3,10 @@ import assert from 'node:assert/strict'
 import { rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { AutomationDetail, AutomationRun, CrewRunDetail } from '@open-cowork/shared'
+import { enqueueAutomationOperationalQueueItem } from '../apps/desktop/src/main/automation-operational-queue.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { enqueueCrewOperationalQueueItem } from '../apps/desktop/src/main/crew-operational-queue.ts'
 import {
   OPERATIONAL_QUEUE_STORE_SCHEMA_VERSION,
   blockOperationalQueueItem,
@@ -50,6 +53,110 @@ function withOperationalStore(name: string, fn: () => void) {
   }
 }
 
+function automationDetail(overrides: Partial<AutomationDetail> = {}): AutomationDetail {
+  return {
+    id: 'automation-1',
+    title: 'Channel SOP automation',
+    goal: 'Run a channel-sourced SOP.',
+    kind: 'managed-project',
+    status: 'ready',
+    schedule: { type: 'one_time', timezone: 'UTC', startAt: null },
+    heartbeatMinutes: 0,
+    retryPolicy: { maxRetries: 0, baseDelayMinutes: 5, maxDelayMinutes: 60 },
+    runPolicy: { dailyRunCap: 5, maxRunDurationMinutes: 60 },
+    executionMode: 'scoped_execution',
+    autonomyPolicy: 'mostly-autonomous',
+    projectDirectory: '/workspace/project',
+    preferredAgentNames: [],
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+    nextRunAt: null,
+    lastRunAt: null,
+    nextHeartbeatAt: null,
+    lastHeartbeatAt: null,
+    latestRunStatus: null,
+    latestRunId: null,
+    brief: null,
+    latestSessionId: null,
+    deliveries: [],
+    ...overrides,
+  }
+}
+
+function automationRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: 'automation-run-1',
+    automationId: 'automation-1',
+    sessionId: null,
+    kind: 'execution',
+    status: 'queued',
+    title: 'Run channel SOP',
+    summary: null,
+    error: null,
+    failureCode: null,
+    attempt: 1,
+    retryOfRunId: null,
+    nextRetryAt: null,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    startedAt: null,
+    finishedAt: null,
+    ...overrides,
+  }
+}
+
+function crewRunDetail(overrides: Partial<CrewRunDetail> = {}): CrewRunDetail {
+  return {
+    run: {
+      schemaVersion: 1,
+      id: 'crew-run-1',
+      crewId: 'crew-1',
+      crewVersionId: 'crew-version-1',
+      workItemId: 'work-1',
+      status: 'queued',
+      title: 'Channel crew run',
+      summary: null,
+      rootSessionId: null,
+      createdAt: '2026-05-11T00:00:00.000Z',
+      startedAt: null,
+      finishedAt: null,
+    },
+    crew: {
+      schemaVersion: 1,
+      id: 'crew-1',
+      name: 'Channel crew',
+      description: 'Handles channel work.',
+      status: 'active',
+      activeVersionId: 'crew-version-1',
+      createdAt: '2026-05-11T00:00:00.000Z',
+      updatedAt: '2026-05-11T00:00:00.000Z',
+    },
+    version: {
+      schemaVersion: 1,
+      id: 'crew-version-1',
+      crewId: 'crew-1',
+      version: 1,
+      members: [],
+      workspaceProfileId: 'project-workspace',
+      outcomeRubricId: null,
+      evalSuiteId: null,
+      certificationStatus: 'not_required',
+      certifiedAt: null,
+      budgetCapUsd: null,
+      workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
+      createdAt: '2026-05-11T00:00:00.000Z',
+      createdBy: 'local-user',
+    },
+    workItem: null,
+    nodes: [],
+    artifacts: [],
+    approvals: [],
+    policyDecisions: [],
+    evaluations: [],
+    traceEvents: [],
+    ...overrides,
+  }
+}
+
 test('operational queues serialize write-capable runs for the same project target', () => withOperationalStore('write-serialize', () => {
   const first = enqueueOperationalRun({
     runKind: 'agent',
@@ -84,6 +191,33 @@ test('operational queues serialize write-capable runs for the same project targe
   finishOperationalQueueItem(first.id, 'completed')
   assert.deepEqual(startRunnableOperationalQueueItems().map((item) => item.id), [second.id])
   assert.equal(getOperationalQueueItem(second.id)?.status, 'running')
+}))
+
+test('channel-triggered SOP runs inherit the channel sandbox queue authority', () => withOperationalStore('channel-sop-sandbox', () => {
+  const item = enqueueAutomationOperationalQueueItem(automationDetail(), automationRun(), {
+    runKind: 'sop',
+    workspaceProfileId: 'channel-sandbox',
+    channelId: 'channel-1',
+  })
+
+  assert.equal(item.runKind, 'sop')
+  assert.equal(item.workspaceProfileId, 'channel-sandbox')
+  assert.equal(item.authority.isolation.channelBound, true)
+  assert.equal(item.authority.filesystem.writeAllowed, false)
+  assert.deepEqual(item.queueKeys, [])
+}))
+
+test('channel-triggered Crew runs inherit the channel sandbox queue authority', () => withOperationalStore('channel-crew-sandbox', () => {
+  const item = enqueueCrewOperationalQueueItem(crewRunDetail(), {
+    workspaceProfileId: 'channel-sandbox',
+    channelId: 'channel-1',
+  })
+
+  assert.equal(item.runKind, 'crew')
+  assert.equal(item.workspaceProfileId, 'channel-sandbox')
+  assert.equal(item.authority.isolation.channelBound, true)
+  assert.equal(item.authority.filesystem.writeAllowed, false)
+  assert.deepEqual(item.queueKeys, [])
 }))
 
 test('operational queues allow read-only research fanout without serialization keys', () => withOperationalStore('read-fanout', () => {


### PR DESCRIPTION
## Summary
- Carry the selected channel workspace profile and channel id from approved channel dispatch into linked SOP and Crew operational runs.
- Keep channel-originated SOP/Crew queue authority channel-bound, defaulting to the read-only channel sandbox instead of recomputing from the automation or crew default.
- Document the inherited channel sandbox behavior for configuration and desktop app users.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/channel-dispatch.test.ts tests/operational-queue-store.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- uv run mkdocs build --strict
- git diff --check

Closes #249