### PR TITLE
[codex] add operations governance registry

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -1,0 +1,449 @@
+import { createHash } from 'node:crypto'
+import type {
+  AgentCatalog,
+  BuiltInAgentDetail,
+  CrewListPayload,
+  CustomAgentSummary as SharedCustomAgentSummary,
+  GovernanceDependency,
+  GovernanceDependencyIndexEntry,
+  GovernanceDependencyKind,
+  GovernanceDependencySource,
+  GovernanceIncidentControl,
+  GovernanceLifecycleState,
+  GovernanceRegistryPayload,
+  GovernanceRegistrySubject,
+  GovernanceScope,
+  RuntimeContextOptions,
+} from '@open-cowork/shared'
+import { COWORK_GOVERNANCE_SCHEMA_VERSION } from '@open-cowork/shared'
+
+import { listBuiltInAgentDetails } from './built-in-agent-details.ts'
+import { getCustomAgentCatalog, getCustomAgentSummaries } from './custom-agents.ts'
+import { listCrewCatalog } from './crew-service.ts'
+
+export interface GovernanceRegistryBuildInput {
+  builtinAgents: BuiltInAgentDetail[]
+  customAgents: GovernanceCustomAgentSummary[]
+  agentCatalog: AgentCatalog
+  crewCatalog: CrewListPayload
+  generatedAt?: string
+}
+
+type GovernanceCustomAgentSummary = Omit<SharedCustomAgentSummary, 'scope'> & {
+  scope?: SharedCustomAgentSummary['scope']
+}
+
+const LOCAL_OWNER = {
+  kind: 'user' as const,
+  id: 'local-user',
+  displayName: 'Local user',
+}
+
+const SYSTEM_OWNER = {
+  kind: 'system' as const,
+  id: 'open-cowork',
+  displayName: 'Open Cowork',
+}
+
+function idSegment(value: string): string {
+  return encodeURIComponent(value)
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12)
+}
+
+function customAgentSubjectId(agent: GovernanceCustomAgentSummary): string {
+  if (agent.scope === 'project') {
+    const directoryKey = shortHash(agent.directory || 'unknown-project')
+    return `agent:project:${directoryKey}:${idSegment(agent.name)}`
+  }
+  return `agent:machine:${idSegment(agent.name)}`
+}
+
+function builtInAgentSubjectId(agent: BuiltInAgentDetail): string {
+  return `agent:system:${idSegment(agent.name)}`
+}
+
+function crewSubjectId(crewId: string): string {
+  return `crew:${idSegment(crewId)}`
+}
+
+function dependencyKey(dependency: Pick<GovernanceDependency, 'kind' | 'id'>): string {
+  return `${dependency.kind}:${dependency.id}`
+}
+
+function sortDependencies(dependencies: GovernanceDependency[]): GovernanceDependency[] {
+  return [...dependencies].sort((left, right) => (
+    left.kind.localeCompare(right.kind)
+    || left.label.localeCompare(right.label)
+    || left.id.localeCompare(right.id)
+    || left.source.localeCompare(right.source)
+  ))
+}
+
+function addDependency(
+  dependencies: Map<string, GovernanceDependency>,
+  dependency: GovernanceDependency,
+) {
+  const key = dependencyKey(dependency)
+  const existing = dependencies.get(key)
+  if (!existing) {
+    dependencies.set(key, dependency)
+    return
+  }
+  dependencies.set(key, {
+    ...existing,
+    source: existing.source === 'direct' || dependency.source === 'direct' ? 'direct' : 'transitive',
+    required: existing.required || dependency.required,
+  })
+}
+
+function createDependency(
+  kind: GovernanceDependencyKind,
+  id: string,
+  label: string,
+  source: GovernanceDependencySource,
+  required = true,
+): GovernanceDependency {
+  return { kind, id, label, source, required }
+}
+
+function createToolLabelMap(catalog: AgentCatalog): Map<string, string> {
+  return new Map(catalog.tools.map((tool) => [tool.id, tool.name]))
+}
+
+function createSkillLabelMap(catalog: AgentCatalog): Map<string, string> {
+  return new Map(catalog.skills.map((skill) => [skill.name, skill.label || skill.name]))
+}
+
+function createSkillToolMap(catalog: AgentCatalog): Map<string, string[]> {
+  return new Map(catalog.skills.map((skill) => [skill.name, skill.toolIds || []]))
+}
+
+function collectAgentDependencies(input: {
+  toolIds: string[]
+  skillNames: string[]
+  toolLabels: Map<string, string>
+  skillLabels: Map<string, string>
+  skillTools: Map<string, string[]>
+}): GovernanceDependency[] {
+  const dependencies = new Map<string, GovernanceDependency>()
+  for (const toolId of input.toolIds) {
+    addDependency(dependencies, createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'direct'))
+  }
+  for (const skillName of input.skillNames) {
+    addDependency(dependencies, createDependency('skill', skillName, input.skillLabels.get(skillName) || skillName, 'direct'))
+    for (const toolId of input.skillTools.get(skillName) || []) {
+      addDependency(dependencies, createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'transitive'))
+    }
+  }
+  return sortDependencies([...dependencies.values()])
+}
+
+function customAgentLifecycle(agent: GovernanceCustomAgentSummary): GovernanceLifecycleState {
+  if (!agent.valid) return 'draft'
+  return agent.enabled ? 'active' : 'paused'
+}
+
+function customAgentScope(agent: GovernanceCustomAgentSummary): GovernanceScope {
+  if (agent.scope === 'project') {
+    const directory = agent.directory || null
+    return {
+      kind: 'project',
+      id: directory ? `project:${shortHash(directory)}` : 'project:unbound',
+      label: directory || 'Project scope',
+      directory,
+    }
+  }
+  return {
+    kind: 'machine',
+    id: 'machine',
+    label: 'This device',
+    directory: null,
+  }
+}
+
+function builtInAgentControls(agent: BuiltInAgentDetail): GovernanceIncidentControl[] {
+  return [
+    {
+      kind: 'pause_agent',
+      label: 'Disable through built-in agent override',
+      available: false,
+      requiresConfirmation: true,
+      reason: agent.source === 'opencode'
+        ? 'OpenCode-owned built-in agents require config overrides rather than a local destructive action.'
+        : 'Configured built-ins are controlled by Open Cowork configuration.',
+    },
+    {
+      kind: 'retire_agent',
+      label: 'Retire built-in agent',
+      available: false,
+      requiresConfirmation: true,
+      reason: 'Built-in agents are part of the configured runtime contract and cannot be deleted from user data.',
+    },
+  ]
+}
+
+function customAgentControls(agent: GovernanceCustomAgentSummary): GovernanceIncidentControl[] {
+  return [
+    {
+      kind: 'pause_agent',
+      label: agent.enabled ? 'Disable custom agent' : 'Custom agent already disabled',
+      available: agent.enabled,
+      requiresConfirmation: false,
+      reason: agent.enabled ? null : 'The agent is already paused.',
+    },
+    {
+      kind: 'retire_agent',
+      label: 'Remove custom agent',
+      available: true,
+      requiresConfirmation: true,
+      reason: null,
+    },
+  ]
+}
+
+function crewControls(lifecycle: GovernanceLifecycleState): GovernanceIncidentControl[] {
+  const retired = lifecycle === 'retired'
+  return [
+    {
+      kind: 'pause_crew',
+      label: retired ? 'Crew retired' : 'Pause crew',
+      available: false,
+      requiresConfirmation: true,
+      reason: retired
+        ? 'The crew is already retired.'
+        : 'Crew lifecycle metadata exists; the admin action surface lands in a later governance slice.',
+    },
+    {
+      kind: 'retire_crew',
+      label: retired ? 'Crew retired' : 'Retire crew',
+      available: false,
+      requiresConfirmation: true,
+      reason: retired
+        ? 'The crew is already retired.'
+        : 'Crew lifecycle metadata exists; the admin action surface lands in a later governance slice.',
+    },
+    {
+      kind: 'export_audit',
+      label: 'Export crew run trace',
+      available: true,
+      requiresConfirmation: false,
+      reason: null,
+    },
+  ]
+}
+
+function buildBuiltInAgentSubject(
+  agent: BuiltInAgentDetail,
+  dependencies: GovernanceDependency[],
+): GovernanceRegistrySubject {
+  const displayName = agent.label || agent.name
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    subjectKind: 'agent',
+    subjectId: builtInAgentSubjectId(agent),
+    name: agent.name,
+    displayName,
+    description: agent.description,
+    owner: SYSTEM_OWNER,
+    lifecycle: agent.disabled ? 'paused' : 'active',
+    scope: {
+      kind: 'system',
+      id: 'open-cowork-runtime',
+      label: agent.source === 'opencode' ? 'OpenCode runtime' : 'Open Cowork runtime config',
+      directory: null,
+    },
+    memoryBoundary: {
+      kind: 'session',
+      id: agent.name,
+      label: `${displayName} uses OpenCode session context; no shared organization memory boundary is attached.`,
+    },
+    evalSuiteId: null,
+    offboardingPath: agent.source === 'opencode'
+      ? 'Disable or retune through built-in agent overrides; do not delete OpenCode-owned runtime agents.'
+      : 'Remove or disable the configured agent in Open Cowork configuration.',
+    dependencies,
+    incidentControls: builtInAgentControls(agent),
+  }
+}
+
+function buildCustomAgentSubject(
+  agent: GovernanceCustomAgentSummary,
+  dependencies: GovernanceDependency[],
+): GovernanceRegistrySubject {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    subjectKind: 'agent',
+    subjectId: customAgentSubjectId(agent),
+    name: agent.name,
+    displayName: agent.name,
+    description: agent.description,
+    owner: LOCAL_OWNER,
+    lifecycle: customAgentLifecycle(agent),
+    scope: customAgentScope(agent),
+    memoryBoundary: {
+      kind: 'agent',
+      id: customAgentSubjectId(agent),
+      label: 'Agent-scoped OpenCode session context; no shared organization memory store is configured.',
+    },
+    evalSuiteId: null,
+    offboardingPath: agent.scope === 'project'
+      ? 'Disable or remove the project custom agent from the Agents surface.'
+      : 'Disable or remove the machine custom agent from the Agents surface.',
+    dependencies,
+    incidentControls: customAgentControls(agent),
+  }
+}
+
+function buildCrewSubject(input: {
+  crew: CrewListPayload['crews'][number]
+  agentSubjectsByName: Map<string, GovernanceRegistrySubject>
+}): GovernanceRegistrySubject {
+  const { definition, activeVersion } = input.crew
+  const dependencies = new Map<string, GovernanceDependency>()
+  for (const member of activeVersion?.members || []) {
+    addDependency(dependencies, createDependency('agent', member.agentName, member.displayName || member.agentName, 'direct'))
+    const agentSubject = input.agentSubjectsByName.get(member.agentName)
+    if (!agentSubject) continue
+    for (const dependency of agentSubject.dependencies) {
+      if (dependency.kind !== 'tool' && dependency.kind !== 'skill' && dependency.kind !== 'credential') continue
+      addDependency(dependencies, {
+        ...dependency,
+        source: 'transitive',
+      })
+    }
+  }
+  if (activeVersion?.workspaceProfileId) {
+    addDependency(
+      dependencies,
+      createDependency('workspace_profile', activeVersion.workspaceProfileId, activeVersion.workspaceProfileId, 'direct'),
+    )
+  }
+  if (activeVersion?.evalSuiteId) {
+    addDependency(dependencies, createDependency('eval_suite', activeVersion.evalSuiteId, activeVersion.evalSuiteId, 'direct'))
+  }
+
+  const scope: GovernanceScope = activeVersion?.workspaceProfileId
+    ? {
+        kind: 'workspace_profile',
+        id: activeVersion.workspaceProfileId,
+        label: activeVersion.workspaceProfileId,
+        directory: null,
+      }
+    : {
+        kind: 'machine',
+        id: 'machine',
+        label: 'This device',
+        directory: null,
+      }
+
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    subjectKind: 'crew',
+    subjectId: crewSubjectId(definition.id),
+    name: definition.id,
+    displayName: definition.name,
+    description: definition.description,
+    owner: LOCAL_OWNER,
+    lifecycle: definition.status,
+    scope,
+    memoryBoundary: {
+      kind: 'crew',
+      id: definition.id,
+      label: 'Crew runs keep durable traces, approvals, policy decisions, evals, and OpenCode child-session links.',
+    },
+    evalSuiteId: activeVersion?.evalSuiteId || null,
+    offboardingPath: 'Pause or retire the crew before revoking its workspace profile, member agents, or eval suite.',
+    dependencies: sortDependencies([...dependencies.values()]),
+    incidentControls: crewControls(definition.status),
+  }
+}
+
+function buildDependencyIndex(subjects: GovernanceRegistrySubject[]): GovernanceDependencyIndexEntry[] {
+  const entries = new Map<string, { dependency: GovernanceDependency, subjectIds: Set<string> }>()
+  for (const subject of subjects) {
+    for (const dependency of subject.dependencies) {
+      const key = dependencyKey(dependency)
+      const entry = entries.get(key)
+      if (!entry) {
+        entries.set(key, { dependency, subjectIds: new Set([subject.subjectId]) })
+        continue
+      }
+      entry.subjectIds.add(subject.subjectId)
+      entry.dependency = {
+        ...entry.dependency,
+        source: entry.dependency.source === 'direct' || dependency.source === 'direct' ? 'direct' : 'transitive',
+        required: entry.dependency.required || dependency.required,
+      }
+    }
+  }
+  return [...entries.values()]
+    .map((entry) => ({
+      dependency: entry.dependency,
+      subjectIds: [...entry.subjectIds].sort(),
+    }))
+    .sort((left, right) => (
+      left.dependency.kind.localeCompare(right.dependency.kind)
+      || left.dependency.label.localeCompare(right.dependency.label)
+      || left.dependency.id.localeCompare(right.dependency.id)
+    ))
+}
+
+export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): GovernanceRegistryPayload {
+  const toolLabels = createToolLabelMap(input.agentCatalog)
+  const skillLabels = createSkillLabelMap(input.agentCatalog)
+  const skillTools = createSkillToolMap(input.agentCatalog)
+
+  const agentSubjects = [
+    ...input.builtinAgents.map((agent) => buildBuiltInAgentSubject(agent, collectAgentDependencies({
+      toolIds: [...agent.nativeToolIds, ...agent.configuredToolIds],
+      skillNames: agent.skills,
+      toolLabels,
+      skillLabels,
+      skillTools,
+    }))),
+    ...input.customAgents.map((agent) => buildCustomAgentSubject(agent, collectAgentDependencies({
+      toolIds: agent.toolIds,
+      skillNames: agent.skillNames,
+      toolLabels,
+      skillLabels,
+      skillTools,
+    }))),
+  ]
+
+  const agentSubjectsByName = new Map<string, GovernanceRegistrySubject>()
+  for (const subject of agentSubjects) {
+    agentSubjectsByName.set(subject.name, subject)
+  }
+
+  const crewSubjects = input.crewCatalog.crews.map((crew) => buildCrewSubject({
+    crew,
+    agentSubjectsByName,
+  }))
+  const subjects = [...agentSubjects, ...crewSubjects].sort((left, right) => (
+    left.subjectKind.localeCompare(right.subjectKind)
+    || left.displayName.localeCompare(right.displayName)
+    || left.subjectId.localeCompare(right.subjectId)
+  ))
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    generatedAt: input.generatedAt || new Date().toISOString(),
+    subjects,
+    dependencyIndex: buildDependencyIndex(subjects),
+  }
+}
+
+export async function getGovernanceRegistry(options?: RuntimeContextOptions): Promise<GovernanceRegistryPayload> {
+  const [agentCatalog, customAgents] = await Promise.all([
+    getCustomAgentCatalog(options),
+    getCustomAgentSummaries(options),
+  ])
+  return buildGovernanceRegistry({
+    builtinAgents: listBuiltInAgentDetails(),
+    customAgents,
+    agentCatalog,
+    crewCatalog: listCrewCatalog(),
+  })
+}

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -6,6 +6,7 @@ import {
   recoverInterruptedOperationalQueueItems,
 } from '../operational-queue-store.ts'
 import { listCapabilityRiskMetadata } from '../operation-capability-risk.ts'
+import { getGovernanceRegistry } from '../governance-registry.ts'
 
 export function registerOperationHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('operations:workspace-profiles', async () => {
@@ -24,5 +25,9 @@ export function registerOperationHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('operations:capability-risks', async () => {
     return listCapabilityRiskMetadata()
+  })
+
+  context.ipcMain.handle('operations:governance-registry', async () => {
+    return getGovernanceRegistry()
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -81,6 +81,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'operations:queue-items',
   'operations:queue-alerts',
   'operations:capability-risks',
+  'operations:governance-registry',
   'channels:list',
   'channels:definitions',
   'channels:inbound-items',
@@ -317,6 +318,7 @@ const api: CoworkAPI = {
     queueItems: () => invoke('operations:queue-items'),
     queueAlerts: () => invoke('operations:queue-alerts'),
     capabilityRisks: () => invoke('operations:capability-risks'),
+    governanceRegistry: () => invoke('operations:governance-registry'),
   },
   channels: {
     list: () => invoke('channels:list'),

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -83,6 +83,10 @@ Pulse mixes:
 - operational queue visibility: running/queued work, queue alerts, filesystem
   and external-system authority, queue caps, serialization keys, and high-risk
   capability metadata
+- governance registry visibility for agents and crews: owners, lifecycle
+  state, scope, memory boundary, eval suite hooks, offboarding paths, incident
+  controls, and the dependency map across tools, skills, workspace profiles,
+  and eval suites
 - channel ingress and delivery visibility: active channels, local webhook
   receiver state, recent inbound items, denied inputs, approve/dismiss actions
   for channel-routed SOP or Crew work, and reviewed delivery drafts

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -102,6 +102,24 @@ there as an upstream compatibility signal: either bump both packages in
 one release branch and rerun the full suite, or keep the current pins
 with an explicit release note.
 
+## Product Operations Registry
+
+The desktop operations namespace exposes a read-only governance registry for
+admin surfaces. It projects existing Open Cowork metadata into one dependency
+map without changing OpenCode execution:
+
+- agents and crews with owner, lifecycle, scope, memory boundary, and
+  offboarding path
+- direct dependencies on member agents, tools, skills, workspace profiles, and
+  eval suites
+- transitive dependencies such as skill-linked tools and crew member
+  capabilities
+- incident-control metadata that distinguishes actions available today from
+  controls planned in later governance slices
+
+Use the registry as the control-plane inventory for Pulse and future admin
+views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.
+
 ## Recommended operator routine
 
 If you are responsible for keeping the repository release-ready:

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -1,0 +1,88 @@
+export const COWORK_GOVERNANCE_SCHEMA_VERSION = 1
+
+export type GovernanceSubjectKind = 'agent' | 'crew'
+export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired'
+export type GovernanceScopeKind = 'system' | 'machine' | 'project' | 'workspace_profile'
+export type GovernanceDependencyKind =
+  | 'agent'
+  | 'tool'
+  | 'skill'
+  | 'memory'
+  | 'credential'
+  | 'channel'
+  | 'sop'
+  | 'eval_suite'
+  | 'workspace_profile'
+export type GovernanceDependencySource = 'direct' | 'transitive'
+export type GovernanceOwnerKind = 'user' | 'group' | 'system'
+export type GovernanceMemoryBoundaryKind = 'none' | 'session' | 'agent' | 'crew' | 'workspace'
+export type GovernanceIncidentControlKind =
+  | 'pause_agent'
+  | 'retire_agent'
+  | 'pause_crew'
+  | 'retire_crew'
+  | 'export_audit'
+
+export interface GovernanceOwner {
+  kind: GovernanceOwnerKind
+  id: string
+  displayName: string
+}
+
+export interface GovernanceScope {
+  kind: GovernanceScopeKind
+  id: string
+  label: string
+  directory?: string | null
+}
+
+export interface GovernanceDependency {
+  kind: GovernanceDependencyKind
+  id: string
+  label: string
+  source: GovernanceDependencySource
+  required: boolean
+}
+
+export interface GovernanceMemoryBoundary {
+  kind: GovernanceMemoryBoundaryKind
+  id: string | null
+  label: string
+}
+
+export interface GovernanceIncidentControl {
+  kind: GovernanceIncidentControlKind
+  label: string
+  available: boolean
+  requiresConfirmation: boolean
+  reason?: string | null
+}
+
+export interface GovernanceRegistrySubject {
+  schemaVersion: number
+  subjectKind: GovernanceSubjectKind
+  subjectId: string
+  name: string
+  displayName: string
+  description: string
+  owner: GovernanceOwner
+  lifecycle: GovernanceLifecycleState
+  scope: GovernanceScope
+  memoryBoundary: GovernanceMemoryBoundary
+  evalSuiteId: string | null
+  offboardingPath: string
+  dependencies: GovernanceDependency[]
+  incidentControls: GovernanceIncidentControl[]
+}
+
+export interface GovernanceDependencyIndexEntry {
+  dependency: GovernanceDependency
+  subjectIds: string[]
+}
+
+export interface GovernanceRegistryPayload {
+  schemaVersion: number
+  generatedAt: string
+  subjects: GovernanceRegistrySubject[]
+  dependencyIndex: GovernanceDependencyIndexEntry[]
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -131,6 +131,9 @@ import type {
   DreamRun,
 } from './improvements.js'
 import type {
+  GovernanceRegistryPayload,
+} from './governance.js'
+import type {
   CapabilityRiskMetadata,
   OperationalQueueAlert,
   OperationalQueueItem,
@@ -147,6 +150,7 @@ export * from './custom-content.js'
 export * from './destructive-actions.js'
 export * from './events.js'
 export * from './explorer.js'
+export * from './governance.js'
 export * from './improvements.js'
 export * from './operations.js'
 export * from './providers.js'
@@ -316,6 +320,7 @@ export interface CoworkAPI {
     queueItems: () => Promise<OperationalQueueItem[]>
     queueAlerts: () => Promise<OperationalQueueAlert[]>
     capabilityRisks: () => Promise<CapabilityRiskMetadata[]>
+    governanceRegistry: () => Promise<GovernanceRegistryPayload>
   }
   channels: {
     list: () => Promise<ChannelListPayload>

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -1,0 +1,225 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type {
+  AgentCatalog,
+  BuiltInAgentDetail,
+  CrewListPayload,
+  CustomAgentSummary,
+} from '@open-cowork/shared'
+import { buildGovernanceRegistry } from '../apps/desktop/src/main/governance-registry.ts'
+
+const generatedAt = '2026-05-11T12:00:00.000Z'
+
+function catalog(): AgentCatalog {
+  return {
+    tools: [
+      {
+        id: 'charts',
+        name: 'Charts',
+        icon: 'bar-chart',
+        description: 'Create charts.',
+        supportsWrite: false,
+        source: 'builtin',
+        patterns: ['mcp__charts__*'],
+      },
+      {
+        id: 'filesystem',
+        name: 'Filesystem',
+        icon: 'folder',
+        description: 'Read and write project files.',
+        supportsWrite: true,
+        source: 'builtin',
+        patterns: ['write', 'edit'],
+      },
+    ],
+    skills: [
+      {
+        name: 'analyst',
+        label: 'Analyst',
+        description: 'Analyze metrics.',
+        source: 'custom',
+        origin: 'custom',
+        scope: 'project',
+        location: '/workspace/acme/.opencode/skill/analyst',
+        toolIds: ['charts'],
+      },
+    ],
+    reservedNames: ['build', 'plan'],
+    colors: ['primary', 'accent', 'success', 'warning', 'info', 'secondary'],
+  }
+}
+
+function builtInAgent(overrides: Partial<BuiltInAgentDetail> = {}): BuiltInAgentDetail {
+  return {
+    name: 'build',
+    label: 'Build',
+    source: 'opencode',
+    mode: 'primary',
+    surface: 'chat',
+    hidden: false,
+    disabled: false,
+    color: 'primary',
+    description: 'Default builder.',
+    instructions: '',
+    skills: [],
+    toolAccess: ['Filesystem'],
+    nativeToolIds: ['filesystem'],
+    configuredToolIds: [],
+    ...overrides,
+  }
+}
+
+function customAgent(overrides: Partial<CustomAgentSummary> = {}): CustomAgentSummary {
+  return {
+    scope: 'project',
+    directory: '/workspace/acme',
+    name: 'data-analyst',
+    description: 'Analyzes business metrics.',
+    instructions: 'Use the analyst skill.',
+    skillNames: ['analyst'],
+    toolIds: ['filesystem'],
+    enabled: true,
+    color: 'accent',
+    writeAccess: true,
+    valid: true,
+    issues: [],
+    ...overrides,
+  }
+}
+
+function crewCatalog(overrides: Partial<CrewListPayload['crews'][number]> = {}): CrewListPayload {
+  return {
+    crews: [
+      {
+        definition: {
+          schemaVersion: 1,
+          id: 'crew-analytics',
+          name: 'Analytics crew',
+          description: 'Handles weekly analytics.',
+          status: 'active',
+          activeVersionId: 'crew-version-1',
+          createdAt: generatedAt,
+          updatedAt: generatedAt,
+        },
+        activeVersion: {
+          schemaVersion: 1,
+          id: 'crew-version-1',
+          crewId: 'crew-analytics',
+          version: 1,
+          members: [
+            {
+              schemaVersion: 1,
+              id: 'member-1',
+              role: 'lead',
+              agentName: 'data-analyst',
+              displayName: 'Data Analyst',
+              description: 'Analyze the metrics.',
+              required: true,
+            },
+          ],
+          workspaceProfileId: 'project-workspace',
+          outcomeRubricId: null,
+          evalSuiteId: 'eval-suite-analytics',
+          certificationStatus: 'required',
+          certifiedAt: null,
+          budgetCapUsd: 5,
+          workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
+          createdAt: generatedAt,
+          createdBy: 'local-user',
+        },
+        latestRun: null,
+        ...overrides,
+      },
+    ],
+  }
+}
+
+test('governance registry maps custom agent lifecycle, scope, and skill-linked tools', () => {
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [builtInAgent()],
+    customAgents: [customAgent({ enabled: false })],
+    agentCatalog: catalog(),
+    crewCatalog: { crews: [] },
+    generatedAt,
+  })
+
+  const agent = payload.subjects.find((subject) => subject.name === 'data-analyst')
+  assert.ok(agent)
+  assert.equal(agent.lifecycle, 'paused')
+  assert.equal(agent.scope.kind, 'project')
+  assert.equal(agent.scope.directory, '/workspace/acme')
+  assert.equal(agent.owner.id, 'local-user')
+  assert.equal(agent.memoryBoundary.kind, 'agent')
+  assert.equal(agent.incidentControls.some((control) => control.kind === 'retire_agent' && control.available), true)
+  assert.deepEqual(
+    agent.dependencies.map((dependency) => `${dependency.kind}:${dependency.id}:${dependency.source}`),
+    [
+      'skill:analyst:direct',
+      'tool:charts:transitive',
+      'tool:filesystem:direct',
+    ],
+  )
+
+  const chartsIndex = payload.dependencyIndex.find((entry) => entry.dependency.kind === 'tool' && entry.dependency.id === 'charts')
+  assert.deepEqual(chartsIndex?.subjectIds, [agent.subjectId])
+})
+
+test('governance registry projects crew member and transitive capability dependencies', () => {
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [builtInAgent()],
+    customAgents: [customAgent()],
+    agentCatalog: catalog(),
+    crewCatalog: crewCatalog(),
+    generatedAt,
+  })
+
+  const crew = payload.subjects.find((subject) => subject.subjectKind === 'crew' && subject.name === 'crew-analytics')
+  assert.ok(crew)
+  assert.equal(crew.lifecycle, 'active')
+  assert.equal(crew.scope.kind, 'workspace_profile')
+  assert.equal(crew.evalSuiteId, 'eval-suite-analytics')
+  assert.deepEqual(
+    crew.dependencies.map((dependency) => `${dependency.kind}:${dependency.id}:${dependency.source}`),
+    [
+      'agent:data-analyst:direct',
+      'eval_suite:eval-suite-analytics:direct',
+      'skill:analyst:transitive',
+      'tool:charts:transitive',
+      'tool:filesystem:transitive',
+      'workspace_profile:project-workspace:direct',
+    ],
+  )
+
+  const workspaceIndex = payload.dependencyIndex.find(
+    (entry) => entry.dependency.kind === 'workspace_profile' && entry.dependency.id === 'project-workspace',
+  )
+  assert.deepEqual(workspaceIndex?.subjectIds, [crew.subjectId])
+
+  const filesystemIndex = payload.dependencyIndex.find(
+    (entry) => entry.dependency.kind === 'tool' && entry.dependency.id === 'filesystem',
+  )
+  assert.deepEqual(filesystemIndex?.subjectIds.sort(), [
+    payload.subjects.find((subject) => subject.name === 'build')?.subjectId,
+    payload.subjects.find((subject) => subject.name === 'data-analyst')?.subjectId,
+    crew.subjectId,
+  ].sort())
+})
+
+test('invalid custom agents stay visible as draft governance records', () => {
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [],
+    customAgents: [customAgent({
+      name: 'broken-agent',
+      valid: false,
+      issues: [{ code: 'missing_instructions', message: 'Instructions are required.' }],
+    })],
+    agentCatalog: catalog(),
+    crewCatalog: { crews: [] },
+    generatedAt,
+  })
+
+  const agent = payload.subjects[0]
+  assert.equal(agent?.name, 'broken-agent')
+  assert.equal(agent?.lifecycle, 'draft')
+  assert.equal(agent?.offboardingPath, 'Disable or remove the project custom agent from the Agents surface.')
+})

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -125,6 +125,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('operations:queue-items'), true)
   assert.equal(handlers.has('operations:queue-alerts'), true)
   assert.equal(handlers.has('operations:capability-risks'), true)
+  assert.equal(handlers.has('operations:governance-registry'), true)
   assert.equal(handlers.has('channels:list'), true)
   assert.equal(handlers.has('channels:definitions'), true)
   assert.equal(handlers.has('channels:inbound-items'), true)


### PR DESCRIPTION
## Summary
- add a typed governance registry payload under the existing operations namespace
- project built-in agents, custom agents, and crews into owner/lifecycle/scope/memory/offboarding records
- build a dependency index across agents, tools, skills, workspace profiles, and eval suites for future Pulse/admin surfaces
- document the read-only operations registry as a control-plane inventory, not an OpenCode execution replacement

Refs #250.

## Validation
- pnpm typecheck
- pnpm lint
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts tests/ipc-handler-registration.test.ts
- pnpm test
- pnpm test:renderer
- pnpm docs:build
- git diff --check