### PR TITLE
[codex] add governance audit ledger

### DIFF
--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -52,6 +52,7 @@ import {
   updateCrewRunNodeStatus,
   withCrewTransaction,
 } from './crew-store.ts'
+import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
 import {
   crewOutcomeEvaluationOutputFormat,
   crewOutcomeEvaluationSchemaHint,
@@ -233,6 +234,20 @@ function setCrewLifecycleStatus(crewId: string, status: CrewLifecycleStatus): Cr
     if (!updated) throw new Error(`Failed to update crew ${id}.`)
     const detail = getCrewDetail(id)
     if (!detail) throw new Error(`Failed to load crew ${id}.`)
+    recordGovernanceAuditEvent({
+      subjectKind: 'crew',
+      subjectId: `crew:${encodeURIComponent(id)}`,
+      action: status === 'paused' ? 'pause_crew' : 'retire_crew',
+      beforeLifecycle: current.status,
+      afterLifecycle: status,
+      reason: status === 'paused'
+        ? 'Crew paused through governance incident control.'
+        : 'Crew retired through governance incident control.',
+      metadata: {
+        crewId: id,
+        crewName: current.name,
+      },
+    })
     return detail
   })
 }

--- a/apps/desktop/src/main/governance-audit-store.ts
+++ b/apps/desktop/src/main/governance-audit-store.ts
@@ -1,0 +1,310 @@
+import { randomUUID } from 'node:crypto'
+import { DatabaseSync } from 'node:sqlite'
+import { chmodSync, existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION,
+  type GovernanceAuditActor,
+  type GovernanceAuditEvent,
+  type GovernanceAuditEventDraft,
+  type GovernanceAuditEventKind,
+  type GovernanceAuditOutcome,
+  type GovernanceIncidentControlKind,
+  type GovernanceLifecycleState,
+  type GovernanceSubjectKind,
+} from '@open-cowork/shared'
+import { getAppDataDir } from './config-loader.ts'
+
+export const GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION = 1
+
+const GOVERNANCE_AUDIT_SCHEMA_VERSION_KEY = 'schema_version'
+const MAX_TEXT_BYTES = 16 * 1024
+const MAX_METADATA_BYTES = 128 * 1024
+const MAX_AUDIT_EVENTS = 500
+const AUDIT_KINDS = new Set<GovernanceAuditEventKind>(['incident_control'])
+const AUDIT_OUTCOMES = new Set<GovernanceAuditOutcome>(['succeeded', 'failed'])
+const SUBJECT_KINDS = new Set<GovernanceSubjectKind>(['agent', 'crew'])
+const INCIDENT_ACTIONS = new Set<GovernanceIncidentControlKind>([
+  'pause_agent',
+  'retire_agent',
+  'pause_crew',
+  'retire_crew',
+  'export_audit',
+])
+const LIFECYCLE_STATES = new Set<GovernanceLifecycleState>(['draft', 'review', 'approved', 'active', 'paused', 'retired'])
+
+type DbRow = Record<string, unknown>
+
+let governanceAuditDb: DatabaseSync | null = null
+let governanceAuditTransactionCounter = 0
+
+function getGovernanceAuditDbPath() {
+  const dir = getAppDataDir()
+  mkdirSync(dir, { recursive: true })
+  return join(dir, 'governance-audit.sqlite')
+}
+
+function ensureGovernanceAuditDbFileModes(dbPath = getGovernanceAuditDbPath()) {
+  if (process.platform === 'win32') return
+  for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (!existsSync(path)) continue
+    chmodSync(path, 0o600)
+  }
+}
+
+function readSchemaVersion(db: DatabaseSync) {
+  const row = db.prepare('select value from governance_audit_meta where key = ?')
+    .get(GOVERNANCE_AUDIT_SCHEMA_VERSION_KEY) as { value?: string } | undefined
+  const version = Number(row?.value || 0)
+  return Number.isInteger(version) && version >= 0 ? version : 0
+}
+
+function assertSupportedSchemaVersion(db: DatabaseSync) {
+  const version = readSchemaVersion(db)
+  if (version > GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION) {
+    throw new Error(`Governance audit schema version ${version} is newer than supported version ${GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION}.`)
+  }
+}
+
+function recordSchemaVersion(db: DatabaseSync) {
+  db.prepare(`
+    insert into governance_audit_meta (key, value)
+    values (?, ?)
+    on conflict(key) do update set value = excluded.value
+  `).run(GOVERNANCE_AUDIT_SCHEMA_VERSION_KEY, String(GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION))
+}
+
+export function getGovernanceAuditDb() {
+  if (governanceAuditDb) return governanceAuditDb
+  const dbPath = getGovernanceAuditDbPath()
+  const db = new DatabaseSync(dbPath)
+  try {
+    db.exec('pragma journal_mode = WAL;')
+    db.exec(`
+      create table if not exists governance_audit_meta (
+        key text primary key,
+        value text not null
+      );
+    `)
+    assertSupportedSchemaVersion(db)
+    db.exec(`
+      create table if not exists governance_audit_events (
+        sequence integer primary key autoincrement,
+        id text not null unique,
+        schema_version integer not null,
+        kind text not null,
+        subject_kind text not null,
+        subject_id text not null,
+        action text not null,
+        outcome text not null,
+        actor_kind text not null,
+        actor_id text not null,
+        actor_display_name text not null,
+        reason text,
+        before_lifecycle text,
+        after_lifecycle text,
+        metadata_json text not null,
+        created_at text not null
+      );
+
+      create index if not exists idx_governance_audit_created
+        on governance_audit_events (sequence desc);
+
+      create index if not exists idx_governance_audit_subject
+        on governance_audit_events (subject_kind, subject_id, sequence desc);
+    `)
+    recordSchemaVersion(db)
+    ensureGovernanceAuditDbFileModes(dbPath)
+    governanceAuditDb = db
+    return db
+  } catch (error) {
+    db.close()
+    throw error
+  }
+}
+
+export function clearGovernanceAuditStoreCache() {
+  if (governanceAuditDb) {
+    governanceAuditDb.close()
+    governanceAuditDb = null
+  }
+  governanceAuditTransactionCounter = 0
+}
+
+function withGovernanceAuditTransaction<T>(fn: () => T): T {
+  const db = getGovernanceAuditDb()
+  const savepoint = `governance_audit_tx_${++governanceAuditTransactionCounter}`
+  db.exec(`savepoint ${savepoint}`)
+  try {
+    const result = fn()
+    db.exec(`release ${savepoint}`)
+    return result
+  } catch (error) {
+    db.exec(`rollback to ${savepoint}`)
+    db.exec(`release ${savepoint}`)
+    throw error
+  }
+}
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function boundedText(value: unknown, label: string, maxBytes = MAX_TEXT_BYTES) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (Buffer.byteLength(normalized, 'utf8') > maxBytes) throw new Error(`${label} is too large.`)
+  return normalized
+}
+
+function optionalBoundedText(value: unknown, label: string, maxBytes = MAX_TEXT_BYTES) {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  const normalized = value.trim()
+  if (!normalized) return null
+  if (Buffer.byteLength(normalized, 'utf8') > maxBytes) throw new Error(`${label} is too large.`)
+  return normalized
+}
+
+function lifecycleState(value: unknown, label: string) {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string' || !LIFECYCLE_STATES.has(value as GovernanceLifecycleState)) {
+    throw new Error(`${label} is invalid.`)
+  }
+  return value as GovernanceLifecycleState
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== 'string' || !value.trim()) return fallback
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+function normalizeActor(actor: GovernanceAuditEventDraft['actor']): GovernanceAuditActor {
+  const kind = actor?.kind === 'system' || actor?.kind === 'group' || actor?.kind === 'user' ? actor.kind : 'user'
+  const id = optionalBoundedText(actor?.id, 'Governance audit actor id') || 'local-user'
+  const displayName = optionalBoundedText(actor?.displayName, 'Governance audit actor display name') || (kind === 'system' ? 'Open Cowork' : 'Local user')
+  return { kind, id, displayName }
+}
+
+function normalizeMetadata(metadata: unknown) {
+  const value = metadata && typeof metadata === 'object' && !Array.isArray(metadata) ? metadata as Record<string, unknown> : {}
+  let raw: string | undefined
+  try {
+    raw = JSON.stringify(value)
+  } catch {
+    throw new Error('Governance audit metadata must be JSON-serializable.')
+  }
+  if (raw === undefined) throw new Error('Governance audit metadata must be JSON-serializable.')
+  if (Buffer.byteLength(raw, 'utf8') > MAX_METADATA_BYTES) throw new Error('Governance audit metadata is too large.')
+  return raw
+}
+
+function eventFromRow(row: DbRow): GovernanceAuditEvent {
+  return {
+    schemaVersion: Number(row.schema_version || COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION),
+    id: String(row.id || ''),
+    kind: String(row.kind || 'incident_control') as GovernanceAuditEventKind,
+    subjectKind: String(row.subject_kind || 'agent') as GovernanceSubjectKind,
+    subjectId: String(row.subject_id || ''),
+    action: String(row.action || 'export_audit') as GovernanceIncidentControlKind,
+    outcome: String(row.outcome || 'succeeded') as GovernanceAuditOutcome,
+    actor: {
+      kind: String(row.actor_kind || 'user') as GovernanceAuditActor['kind'],
+      id: String(row.actor_id || ''),
+      displayName: String(row.actor_display_name || ''),
+    },
+    reason: row.reason === null || row.reason === undefined ? null : String(row.reason),
+    beforeLifecycle: row.before_lifecycle === null || row.before_lifecycle === undefined ? null : String(row.before_lifecycle) as GovernanceLifecycleState,
+    afterLifecycle: row.after_lifecycle === null || row.after_lifecycle === undefined ? null : String(row.after_lifecycle) as GovernanceLifecycleState,
+    metadata: parseJson<Record<string, unknown>>(row.metadata_json, {}),
+    createdAt: String(row.created_at || ''),
+  }
+}
+
+export function recordGovernanceAuditEvent(input: GovernanceAuditEventDraft): GovernanceAuditEvent {
+  const subjectKind = input.subjectKind
+  if (!SUBJECT_KINDS.has(subjectKind)) throw new Error('Governance audit subject kind is invalid.')
+  const action = input.action
+  if (!INCIDENT_ACTIONS.has(action)) throw new Error('Governance audit action is invalid.')
+  const outcome = input.outcome || 'succeeded'
+  if (!AUDIT_OUTCOMES.has(outcome)) throw new Error('Governance audit outcome is invalid.')
+  const kind = 'incident_control' satisfies GovernanceAuditEventKind
+  if (!AUDIT_KINDS.has(kind)) throw new Error('Governance audit kind is invalid.')
+  const actor = normalizeActor(input.actor)
+  const metadataJson = normalizeMetadata(input.metadata)
+  const event: GovernanceAuditEvent = {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION,
+    id: randomUUID(),
+    kind,
+    subjectKind,
+    subjectId: boundedText(input.subjectId, 'Governance audit subject id'),
+    action,
+    outcome,
+    actor,
+    reason: optionalBoundedText(input.reason, 'Governance audit reason'),
+    beforeLifecycle: lifecycleState(input.beforeLifecycle, 'Governance audit before lifecycle'),
+    afterLifecycle: lifecycleState(input.afterLifecycle, 'Governance audit after lifecycle'),
+    metadata: parseJson<Record<string, unknown>>(metadataJson, {}),
+    createdAt: nowIso(),
+  }
+  return withGovernanceAuditTransaction(() => {
+    getGovernanceAuditDb().prepare(`
+      insert into governance_audit_events (
+        id, schema_version, kind, subject_kind, subject_id, action, outcome,
+        actor_kind, actor_id, actor_display_name, reason,
+        before_lifecycle, after_lifecycle, metadata_json, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      event.id,
+      event.schemaVersion,
+      event.kind,
+      event.subjectKind,
+      event.subjectId,
+      event.action,
+      event.outcome,
+      event.actor.kind,
+      event.actor.id,
+      event.actor.displayName,
+      event.reason,
+      event.beforeLifecycle,
+      event.afterLifecycle,
+      metadataJson,
+      event.createdAt,
+    )
+    return event
+  })
+}
+
+export function listGovernanceAuditEvents(options: {
+  subjectKind?: GovernanceSubjectKind
+  subjectId?: string
+  limit?: number
+} = {}): GovernanceAuditEvent[] {
+  const requestedLimit = typeof options.limit === 'number' && Number.isFinite(options.limit) ? options.limit : MAX_AUDIT_EVENTS
+  const limit = Math.max(1, Math.min(Math.trunc(requestedLimit), MAX_AUDIT_EVENTS))
+  if ((options.subjectKind && !options.subjectId) || (!options.subjectKind && options.subjectId)) {
+    throw new Error('Governance audit subject filters require both kind and id.')
+  }
+  const hasSubjectFilter = Boolean(options.subjectKind && options.subjectId)
+  if (hasSubjectFilter) {
+    const subjectKind = options.subjectKind!
+    const subjectId = boundedText(options.subjectId, 'Governance audit subject id')
+    if (!SUBJECT_KINDS.has(subjectKind)) throw new Error('Governance audit subject kind is invalid.')
+    return (getGovernanceAuditDb().prepare(`
+      select * from governance_audit_events
+      where subject_kind = ? and subject_id = ?
+      order by sequence desc
+      limit ?
+    `).all(subjectKind, subjectId, limit) as DbRow[])
+      .map(eventFromRow)
+  }
+  return (getGovernanceAuditDb().prepare(`
+    select * from governance_audit_events
+    order by sequence desc
+    limit ?
+  `).all(limit) as DbRow[]).map(eventFromRow)
+}

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -7,6 +7,26 @@ import {
 } from '../operational-queue-store.ts'
 import { listCapabilityRiskMetadata } from '../operation-capability-risk.ts'
 import { getGovernanceRegistry } from '../governance-registry.ts'
+import { listGovernanceAuditEvents } from '../governance-audit-store.ts'
+
+function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is Parameters<typeof listGovernanceAuditEvents>[0] {
+  if (value === undefined) return
+  if (value === null) throw new Error('Governance audit options must be an object.')
+  if (typeof value !== 'object' || Array.isArray(value)) throw new Error('Governance audit options must be an object.')
+  const options = value as Record<string, unknown>
+  if (options.subjectKind !== undefined && options.subjectKind !== 'agent' && options.subjectKind !== 'crew') {
+    throw new Error('Governance audit subject kind is invalid.')
+  }
+  if (options.subjectId !== undefined && typeof options.subjectId !== 'string') {
+    throw new Error('Governance audit subject id must be a string.')
+  }
+  if ((options.subjectKind && !options.subjectId) || (!options.subjectKind && options.subjectId)) {
+    throw new Error('Governance audit subject filters require both kind and id.')
+  }
+  if (options.limit !== undefined && (typeof options.limit !== 'number' || !Number.isFinite(options.limit))) {
+    throw new Error('Governance audit limit must be a finite number.')
+  }
+}
 
 export function registerOperationHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('operations:workspace-profiles', async () => {
@@ -29,5 +49,10 @@ export function registerOperationHandlers(context: IpcHandlerContext) {
 
   context.ipcMain.handle('operations:governance-registry', async () => {
     return getGovernanceRegistry()
+  })
+
+  context.ipcMain.handle('operations:governance-audit-events', async (_event, options?: unknown) => {
+    assertOptionalGovernanceAuditOptions(options)
+    return listGovernanceAuditEvents(options)
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -82,6 +82,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'operations:queue-alerts',
   'operations:capability-risks',
   'operations:governance-registry',
+  'operations:governance-audit-events',
   'channels:list',
   'channels:definitions',
   'channels:inbound-items',
@@ -321,6 +322,7 @@ const api: CoworkAPI = {
     queueAlerts: () => invoke('operations:queue-alerts'),
     capabilityRisks: () => invoke('operations:capability-risks'),
     governanceRegistry: () => invoke('operations:governance-registry'),
+    governanceAuditEvents: (options) => invoke('operations:governance-audit-events', options),
   },
   channels: {
     list: () => invoke('channels:list'),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -119,7 +119,11 @@ map without changing OpenCode execution:
 
 The first active incident controls are crew lifecycle controls. Admin surfaces
 can pause or retire a crew through the `crews` IPC namespace; paused or retired
-crews keep their history and registry entry but cannot start new runs.
+crews keep their history and registry entry but cannot start new runs. Each
+control writes a durable governance audit event with actor, action,
+before/after lifecycle state, subject id, and bounded metadata. Admin surfaces
+can query those events through the operations namespace before broader audit
+and OpenTelemetry export land.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -1,4 +1,5 @@
 export const COWORK_GOVERNANCE_SCHEMA_VERSION = 1
+export const COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION = 1
 
 export type GovernanceSubjectKind = 'agent' | 'crew'
 export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired'
@@ -22,6 +23,8 @@ export type GovernanceIncidentControlKind =
   | 'pause_crew'
   | 'retire_crew'
   | 'export_audit'
+export type GovernanceAuditEventKind = 'incident_control'
+export type GovernanceAuditOutcome = 'succeeded' | 'failed'
 
 export interface GovernanceOwner {
   kind: GovernanceOwnerKind
@@ -85,4 +88,38 @@ export interface GovernanceRegistryPayload {
   generatedAt: string
   subjects: GovernanceRegistrySubject[]
   dependencyIndex: GovernanceDependencyIndexEntry[]
+}
+
+export interface GovernanceAuditActor {
+  kind: GovernanceOwnerKind
+  id: string
+  displayName: string
+}
+
+export interface GovernanceAuditEvent {
+  schemaVersion: number
+  id: string
+  kind: GovernanceAuditEventKind
+  subjectKind: GovernanceSubjectKind
+  subjectId: string
+  action: GovernanceIncidentControlKind
+  outcome: GovernanceAuditOutcome
+  actor: GovernanceAuditActor
+  reason: string | null
+  beforeLifecycle: GovernanceLifecycleState | null
+  afterLifecycle: GovernanceLifecycleState | null
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
+export interface GovernanceAuditEventDraft {
+  subjectKind: GovernanceSubjectKind
+  subjectId: string
+  action: GovernanceIncidentControlKind
+  outcome?: GovernanceAuditOutcome
+  actor?: Partial<GovernanceAuditActor> | null
+  reason?: string | null
+  beforeLifecycle?: GovernanceLifecycleState | null
+  afterLifecycle?: GovernanceLifecycleState | null
+  metadata?: Record<string, unknown> | null
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -131,6 +131,8 @@ import type {
   DreamRun,
 } from './improvements.js'
 import type {
+  GovernanceAuditEvent,
+  GovernanceSubjectKind,
   GovernanceRegistryPayload,
 } from './governance.js'
 import type {
@@ -321,6 +323,11 @@ export interface CoworkAPI {
     queueAlerts: () => Promise<OperationalQueueAlert[]>
     capabilityRisks: () => Promise<CapabilityRiskMetadata[]>
     governanceRegistry: () => Promise<GovernanceRegistryPayload>
+    governanceAuditEvents: (options?: {
+      subjectKind?: GovernanceSubjectKind
+      subjectId?: string
+      limit?: number
+    }) => Promise<GovernanceAuditEvent[]>
   }
   channels: {
     list: () => Promise<ChannelListPayload>

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -19,6 +19,10 @@ import {
   getOperationalQueueItemForRun,
 } from '../apps/desktop/src/main/operational-queue-store.ts'
 import {
+  clearGovernanceAuditStoreCache,
+  listGovernanceAuditEvents,
+} from '../apps/desktop/src/main/governance-audit-store.ts'
+import {
   createCrewFromDraft,
   certifyCrewVersion,
   evaluateCrewRunForRootSessionIdle,
@@ -48,6 +52,7 @@ function resetCrewStore(userDataDir: string) {
   clearConfigCaches()
   clearCrewStoreCache()
   clearOperationalQueueStoreCache()
+  clearGovernanceAuditStoreCache()
 }
 
 function draft(overrides: Partial<CrewDefinitionDraft> = {}): CrewDefinitionDraft {
@@ -104,6 +109,7 @@ function withCrewStore<T>(name: string, callback: () => T): T {
   } finally {
     clearCrewStoreCache()
     clearOperationalQueueStoreCache()
+    clearGovernanceAuditStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -120,6 +126,7 @@ async function withCrewStoreAsync<T>(name: string, callback: () => Promise<T>): 
   } finally {
     clearCrewStoreCache()
     clearOperationalQueueStoreCache()
+    clearGovernanceAuditStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
@@ -170,6 +177,14 @@ test('crew incident controls pause and retire crews before new runs start', () =
     title: 'Run while retired',
   }), /Crew is retired/)
   assert.throws(() => pauseCrew(created.definition.id), /retired and cannot be reactivated/)
+
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'crew', subjectId: `crew:${encodeURIComponent(created.definition.id)}` })
+  assert.deepEqual(auditEvents.map((event) => event.action), ['retire_crew', 'pause_crew'])
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'paused')
+  assert.equal(auditEvents[0]?.afterLifecycle, 'retired')
+  assert.equal(auditEvents[1]?.beforeLifecycle, 'draft')
+  assert.equal(auditEvents[1]?.afterLifecycle, 'paused')
+  assert.equal(auditEvents[0]?.metadata.crewName, 'Research Crew')
 }))
 
 test('crew service saves edits as new crew versions without rewriting run history', () => withCrewStore('version-edit', () => {

--- a/tests/governance-audit-store.test.ts
+++ b/tests/governance-audit-store.test.ts
@@ -1,0 +1,100 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  clearGovernanceAuditStoreCache,
+  getGovernanceAuditDb,
+  GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION,
+  listGovernanceAuditEvents,
+  recordGovernanceAuditEvent,
+} from '../apps/desktop/src/main/governance-audit-store.ts'
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-governance-audit-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+function withGovernanceAuditStore(name: string, fn: () => void) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    clearConfigCaches()
+    clearGovernanceAuditStoreCache()
+    fn()
+  } finally {
+    clearGovernanceAuditStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+test('governance audit store records incident controls and filters by subject', () => withGovernanceAuditStore('record-filter', () => {
+  const first = recordGovernanceAuditEvent({
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    action: 'pause_crew',
+    beforeLifecycle: 'active',
+    afterLifecycle: 'paused',
+    reason: 'Manual pause.',
+    metadata: { crewId: 'research' },
+  })
+  recordGovernanceAuditEvent({
+    subjectKind: 'agent',
+    subjectId: 'agent:machine:data-analyst',
+    action: 'pause_agent',
+    beforeLifecycle: 'active',
+    afterLifecycle: 'paused',
+  })
+
+  const crewEvents = listGovernanceAuditEvents({ subjectKind: 'crew', subjectId: 'crew:research' })
+  assert.equal(crewEvents.length, 1)
+  assert.equal(crewEvents[0]?.id, first.id)
+  assert.equal(crewEvents[0]?.actor.id, 'local-user')
+  assert.equal(crewEvents[0]?.outcome, 'succeeded')
+  assert.equal(crewEvents[0]?.metadata.crewId, 'research')
+  assert.equal(listGovernanceAuditEvents().length, 2)
+}))
+
+test('governance audit store caps result count and stores schema version', () => withGovernanceAuditStore('limit-schema', () => {
+  for (let index = 0; index < 5; index += 1) {
+    recordGovernanceAuditEvent({
+      subjectKind: 'crew',
+      subjectId: `crew:${index}`,
+      action: 'retire_crew',
+      beforeLifecycle: 'paused',
+      afterLifecycle: 'retired',
+    })
+  }
+
+  const limited = listGovernanceAuditEvents({ limit: 2 })
+  assert.equal(limited.length, 2)
+  const row = getGovernanceAuditDb().prepare('select value from governance_audit_meta where key = ?')
+    .get('schema_version') as { value?: string } | undefined
+  assert.equal(Number(row?.value), GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION)
+}))
+
+test('governance audit store rejects oversized metadata', () => withGovernanceAuditStore('bounds', () => {
+  assert.throws(() => recordGovernanceAuditEvent({
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    action: 'pause_crew',
+    metadata: { value: 'x'.repeat(129 * 1024) },
+  }), /metadata is too large/)
+
+  const cyclic: Record<string, unknown> = {}
+  cyclic.self = cyclic
+  assert.throws(() => recordGovernanceAuditEvent({
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    action: 'pause_crew',
+    metadata: cyclic,
+  }), /JSON-serializable/)
+
+  assert.throws(() => listGovernanceAuditEvents({ subjectKind: 'crew' }), /require both kind and id/)
+  assert.equal(listGovernanceAuditEvents({ limit: Number.NaN }).length, 0)
+}))

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -12,6 +12,7 @@ import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/cust
 import { registerAutomationHandlers } from '../apps/desktop/src/main/ipc/automation-handlers.ts'
 import { registerSopHandlers } from '../apps/desktop/src/main/ipc/sop-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
+import { registerOperationHandlers } from '../apps/desktop/src/main/ipc/operation-handlers.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
@@ -195,6 +196,19 @@ test('session:prompt rejects non-data attachment URLs before runtime dispatch', 
     /URL must be a base64 data URL/,
   )
   assert.equal(clientRequested, false)
+})
+
+test('operations:governance-audit-events rejects null options at the IPC boundary', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerOperationHandlers(context)
+  const handler = handlers.get('operations:governance-audit-events')
+
+  assert.ok(handler, 'expected operations:governance-audit-events handler to be registered')
+  await assert.rejects(
+    () => handler({}, null),
+    /Governance audit options must be an object/,
+  )
 })
 
 test('session:prompt clears pending prompt echo when dispatch fails', async () => {

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -128,6 +128,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('operations:queue-alerts'), true)
   assert.equal(handlers.has('operations:capability-risks'), true)
   assert.equal(handlers.has('operations:governance-registry'), true)
+  assert.equal(handlers.has('operations:governance-audit-events'), true)
   assert.equal(handlers.has('channels:list'), true)
   assert.equal(handlers.has('channels:definitions'), true)
   assert.equal(handlers.has('channels:inbound-items'), true)


### PR DESCRIPTION
## Summary
- add a durable governance audit ledger for incident-control events
- record crew pause/retire controls with actor, action, subject, before/after lifecycle, reason, and bounded metadata
- expose audit event reads through the typed operations IPC/preload surface
- document the audit ledger as the next org-governance control-plane slice

Refs #250.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-audit-store.test.ts tests/crew-service.test.ts tests/ipc-handler-registration.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:renderer
- pnpm docs:build
- git diff --check