### PR TITLE
[codex] add governance audit export

### DIFF
--- a/apps/desktop/src/main/governance-audit-store.ts
+++ b/apps/desktop/src/main/governance-audit-store.ts
@@ -4,9 +4,14 @@ import { chmodSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION,
+  COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+  serializeGovernanceAuditEvent,
+  serializeGovernanceAuditOtelExport,
   type GovernanceAuditActor,
   type GovernanceAuditEvent,
   type GovernanceAuditEventDraft,
+  type GovernanceAuditExportFormat,
+  type GovernanceAuditExportPayload,
   type GovernanceAuditEventKind,
   type GovernanceAuditOutcome,
   type GovernanceIncidentControlKind,
@@ -20,7 +25,8 @@ export const GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION = 1
 const GOVERNANCE_AUDIT_SCHEMA_VERSION_KEY = 'schema_version'
 const MAX_TEXT_BYTES = 16 * 1024
 const MAX_METADATA_BYTES = 128 * 1024
-const MAX_AUDIT_EVENTS = 500
+const DEFAULT_AUDIT_LIST_LIMIT = 500
+const GOVERNANCE_AUDIT_EXPORT_BASENAME = 'open-cowork-governance-audit'
 const AUDIT_KINDS = new Set<GovernanceAuditEventKind>(['incident_control'])
 const AUDIT_OUTCOMES = new Set<GovernanceAuditOutcome>(['succeeded', 'failed'])
 const SUBJECT_KINDS = new Set<GovernanceSubjectKind>(['agent', 'crew'])
@@ -279,13 +285,29 @@ export function recordGovernanceAuditEvent(input: GovernanceAuditEventDraft): Go
   })
 }
 
-export function listGovernanceAuditEvents(options: {
+type GovernanceAuditQueryOptions = {
   subjectKind?: GovernanceSubjectKind
   subjectId?: string
   limit?: number
-} = {}): GovernanceAuditEvent[] {
-  const requestedLimit = typeof options.limit === 'number' && Number.isFinite(options.limit) ? options.limit : MAX_AUDIT_EVENTS
-  const limit = Math.max(1, Math.min(Math.trunc(requestedLimit), MAX_AUDIT_EVENTS))
+}
+
+function resolveAuditLimit(
+  value: number | undefined,
+  defaults: { defaultLimit: number | null; maxLimit: number | null },
+) {
+  const requestedLimit = typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : defaults.defaultLimit
+  if (requestedLimit === null) return null
+  const normalized = Math.max(1, Math.trunc(requestedLimit))
+  return defaults.maxLimit === null ? normalized : Math.min(normalized, defaults.maxLimit)
+}
+
+function readGovernanceAuditEvents(
+  options: GovernanceAuditQueryOptions,
+  limits: { defaultLimit: number | null; maxLimit: number | null },
+): GovernanceAuditEvent[] {
+  const limit = resolveAuditLimit(options.limit, limits)
   if ((options.subjectKind && !options.subjectId) || (!options.subjectKind && options.subjectId)) {
     throw new Error('Governance audit subject filters require both kind and id.')
   }
@@ -294,17 +316,69 @@ export function listGovernanceAuditEvents(options: {
     const subjectKind = options.subjectKind!
     const subjectId = boundedText(options.subjectId, 'Governance audit subject id')
     if (!SUBJECT_KINDS.has(subjectKind)) throw new Error('Governance audit subject kind is invalid.')
-    return (getGovernanceAuditDb().prepare(`
+    const sql = `
       select * from governance_audit_events
       where subject_kind = ? and subject_id = ?
       order by sequence desc
-      limit ?
-    `).all(subjectKind, subjectId, limit) as DbRow[])
+      ${limit === null ? '' : 'limit ?'}
+    `
+    const args = limit === null ? [subjectKind, subjectId] : [subjectKind, subjectId, limit]
+    return (getGovernanceAuditDb().prepare(sql).all(...args) as DbRow[])
       .map(eventFromRow)
   }
-  return (getGovernanceAuditDb().prepare(`
+  const sql = `
     select * from governance_audit_events
     order by sequence desc
-    limit ?
-  `).all(limit) as DbRow[]).map(eventFromRow)
+    ${limit === null ? '' : 'limit ?'}
+  `
+  const args = limit === null ? [] : [limit]
+  return (getGovernanceAuditDb().prepare(sql).all(...args) as DbRow[]).map(eventFromRow)
+}
+
+export function listGovernanceAuditEvents(options: GovernanceAuditQueryOptions = {}): GovernanceAuditEvent[] {
+  return readGovernanceAuditEvents(options, {
+    defaultLimit: DEFAULT_AUDIT_LIST_LIMIT,
+    maxLimit: DEFAULT_AUDIT_LIST_LIMIT,
+  })
+}
+
+function auditExportTimestamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+export function exportGovernanceAuditEvents(options: {
+  subjectKind?: GovernanceSubjectKind
+  subjectId?: string
+  limit?: number
+  format?: GovernanceAuditExportFormat
+} = {}): GovernanceAuditExportPayload {
+  const { format = 'ndjson', ...queryOptions } = options
+  const events = readGovernanceAuditEvents(queryOptions, {
+    defaultLimit: null,
+    maxLimit: null,
+  })
+  const exportedAt = nowIso()
+  if (format === 'ndjson') {
+    return {
+      schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+      format,
+      contentType: 'application/x-ndjson',
+      filename: `${GOVERNANCE_AUDIT_EXPORT_BASENAME}-${auditExportTimestamp(new Date(exportedAt))}.ndjson`,
+      exportedAt,
+      eventCount: events.length,
+      body: events.map(serializeGovernanceAuditEvent).join('\n'),
+    }
+  }
+  if (format === 'otel-json') {
+    return {
+      schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+      format,
+      contentType: 'application/json',
+      filename: `${GOVERNANCE_AUDIT_EXPORT_BASENAME}-${auditExportTimestamp(new Date(exportedAt))}.otel.json`,
+      exportedAt,
+      eventCount: events.length,
+      body: serializeGovernanceAuditOtelExport(events),
+    }
+  }
+  throw new Error('Governance audit export format is invalid.')
 }

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -7,7 +7,7 @@ import {
 } from '../operational-queue-store.ts'
 import { listCapabilityRiskMetadata } from '../operation-capability-risk.ts'
 import { getGovernanceRegistry } from '../governance-registry.ts'
-import { listGovernanceAuditEvents } from '../governance-audit-store.ts'
+import { exportGovernanceAuditEvents, listGovernanceAuditEvents } from '../governance-audit-store.ts'
 
 function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is Parameters<typeof listGovernanceAuditEvents>[0] {
   if (value === undefined) return
@@ -25,6 +25,15 @@ function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is 
   }
   if (options.limit !== undefined && (typeof options.limit !== 'number' || !Number.isFinite(options.limit))) {
     throw new Error('Governance audit limit must be a finite number.')
+  }
+}
+
+function assertOptionalGovernanceAuditExportOptions(value: unknown): asserts value is Parameters<typeof exportGovernanceAuditEvents>[0] {
+  assertOptionalGovernanceAuditOptions(value)
+  if (value === undefined) return
+  const options = value as Record<string, unknown>
+  if (options.format !== undefined && options.format !== 'ndjson' && options.format !== 'otel-json') {
+    throw new Error('Governance audit export format is invalid.')
   }
 }
 
@@ -54,5 +63,10 @@ export function registerOperationHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('operations:governance-audit-events', async (_event, options?: unknown) => {
     assertOptionalGovernanceAuditOptions(options)
     return listGovernanceAuditEvents(options)
+  })
+
+  context.ipcMain.handle('operations:export-governance-audit', async (_event, options?: unknown) => {
+    assertOptionalGovernanceAuditExportOptions(options)
+    return exportGovernanceAuditEvents(options)
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -83,6 +83,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'operations:capability-risks',
   'operations:governance-registry',
   'operations:governance-audit-events',
+  'operations:export-governance-audit',
   'channels:list',
   'channels:definitions',
   'channels:inbound-items',
@@ -323,6 +324,7 @@ const api: CoworkAPI = {
     capabilityRisks: () => invoke('operations:capability-risks'),
     governanceRegistry: () => invoke('operations:governance-registry'),
     governanceAuditEvents: (options) => invoke('operations:governance-audit-events', options),
+    exportGovernanceAudit: (options) => invoke('operations:export-governance-audit', options),
   },
   channels: {
     list: () => invoke('channels:list'),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -122,8 +122,10 @@ can pause or retire a crew through the `crews` IPC namespace; paused or retired
 crews keep their history and registry entry but cannot start new runs. Each
 control writes a durable governance audit event with actor, action,
 before/after lifecycle state, subject id, and bounded metadata. Admin surfaces
-can query those events through the operations namespace before broader audit
-and OpenTelemetry export land.
+can query those events through the operations namespace and export the ledger as
+deterministic NDJSON or OpenTelemetry-shaped JSON. The current export covers
+governance incident-control events; broader trace, approval, policy, tool-call,
+delivery, and eval export will extend the same typed audit surface.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -1,5 +1,6 @@
 export const COWORK_GOVERNANCE_SCHEMA_VERSION = 1
 export const COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION = 1
+export const COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION = 1
 
 export type GovernanceSubjectKind = 'agent' | 'crew'
 export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired'
@@ -25,6 +26,7 @@ export type GovernanceIncidentControlKind =
   | 'export_audit'
 export type GovernanceAuditEventKind = 'incident_control'
 export type GovernanceAuditOutcome = 'succeeded' | 'failed'
+export type GovernanceAuditExportFormat = 'ndjson' | 'otel-json'
 
 export interface GovernanceOwner {
   kind: GovernanceOwnerKind
@@ -122,4 +124,147 @@ export interface GovernanceAuditEventDraft {
   beforeLifecycle?: GovernanceLifecycleState | null
   afterLifecycle?: GovernanceLifecycleState | null
   metadata?: Record<string, unknown> | null
+}
+
+export interface GovernanceAuditExportPayload {
+  schemaVersion: number
+  format: GovernanceAuditExportFormat
+  contentType: string
+  filename: string
+  exportedAt: string
+  eventCount: number
+  body: string
+}
+
+export type GovernanceAuditOtelValue =
+  | { stringValue: string }
+  | { intValue: number }
+  | { boolValue: boolean }
+
+export interface GovernanceAuditOtelAttribute {
+  key: string
+  value: GovernanceAuditOtelValue
+}
+
+export interface GovernanceAuditOtelLogRecord {
+  timeUnixNano: string
+  observedTimeUnixNano: string
+  severityText: 'INFO' | 'ERROR'
+  body: { stringValue: string }
+  attributes: GovernanceAuditOtelAttribute[]
+}
+
+export interface GovernanceAuditOtelExport {
+  schemaVersion: number
+  resourceLogs: Array<{
+    resource: {
+      attributes: GovernanceAuditOtelAttribute[]
+    }
+    scopeLogs: Array<{
+      scope: {
+        name: string
+        version: string
+      }
+      logRecords: GovernanceAuditOtelLogRecord[]
+    }>
+  }>
+}
+
+export function toExportableGovernanceAuditEvent(event: GovernanceAuditEvent): GovernanceAuditEvent {
+  return {
+    ...event,
+    actor: { ...event.actor },
+    metadata: { ...event.metadata },
+  }
+}
+
+export function serializeGovernanceAuditEvent(event: GovernanceAuditEvent): string {
+  const exportable = toExportableGovernanceAuditEvent(event)
+  return JSON.stringify({
+    schemaVersion: exportable.schemaVersion,
+    id: exportable.id,
+    kind: exportable.kind,
+    subjectKind: exportable.subjectKind,
+    subjectId: exportable.subjectId,
+    action: exportable.action,
+    outcome: exportable.outcome,
+    actor: exportable.actor,
+    reason: exportable.reason,
+    beforeLifecycle: exportable.beforeLifecycle,
+    afterLifecycle: exportable.afterLifecycle,
+    metadata: exportable.metadata,
+    createdAt: exportable.createdAt,
+  })
+}
+
+function auditEventTimeUnixNano(event: GovernanceAuditEvent) {
+  const millis = Date.parse(event.createdAt)
+  const normalized = Number.isFinite(millis) ? Math.max(0, Math.trunc(millis)) : 0
+  return `${normalized}000000`
+}
+
+function otelStringAttribute(key: string, value: string): GovernanceAuditOtelAttribute {
+  return { key, value: { stringValue: value } }
+}
+
+function otelIntAttribute(key: string, value: number): GovernanceAuditOtelAttribute {
+  return { key, value: { intValue: value } }
+}
+
+function otelOptionalStringAttribute(key: string, value: string | null): GovernanceAuditOtelAttribute[] {
+  return value ? [otelStringAttribute(key, value)] : []
+}
+
+export function toGovernanceAuditOtelLogRecord(event: GovernanceAuditEvent): GovernanceAuditOtelLogRecord {
+  const exportable = toExportableGovernanceAuditEvent(event)
+  const timeUnixNano = auditEventTimeUnixNano(exportable)
+  const metadataJson = JSON.stringify(exportable.metadata)
+  return {
+    timeUnixNano,
+    observedTimeUnixNano: timeUnixNano,
+    severityText: exportable.outcome === 'failed' ? 'ERROR' : 'INFO',
+    body: { stringValue: `open_cowork.governance.${exportable.action}.${exportable.outcome}` },
+    attributes: [
+      otelIntAttribute('open_cowork.audit.schema_version', exportable.schemaVersion),
+      otelStringAttribute('open_cowork.audit.id', exportable.id),
+      otelStringAttribute('open_cowork.audit.kind', exportable.kind),
+      otelStringAttribute('open_cowork.audit.action', exportable.action),
+      otelStringAttribute('open_cowork.audit.outcome', exportable.outcome),
+      otelStringAttribute('open_cowork.governance.subject.kind', exportable.subjectKind),
+      otelStringAttribute('open_cowork.governance.subject.id', exportable.subjectId),
+      otelStringAttribute('open_cowork.governance.actor.kind', exportable.actor.kind),
+      otelStringAttribute('open_cowork.governance.actor.id', exportable.actor.id),
+      otelStringAttribute('open_cowork.governance.actor.display_name', exportable.actor.displayName),
+      ...otelOptionalStringAttribute('open_cowork.governance.lifecycle.before', exportable.beforeLifecycle),
+      ...otelOptionalStringAttribute('open_cowork.governance.lifecycle.after', exportable.afterLifecycle),
+      ...otelOptionalStringAttribute('open_cowork.audit.reason', exportable.reason),
+      otelStringAttribute('open_cowork.audit.metadata_json', metadataJson),
+    ],
+  }
+}
+
+export function toGovernanceAuditOtelExport(events: GovernanceAuditEvent[]): GovernanceAuditOtelExport {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    resourceLogs: [{
+      resource: {
+        attributes: [
+          otelStringAttribute('service.name', 'open-cowork'),
+          otelStringAttribute('service.namespace', 'open-cowork'),
+          otelStringAttribute('telemetry.sdk.language', 'javascript'),
+        ],
+      },
+      scopeLogs: [{
+        scope: {
+          name: 'open-cowork.governance.audit',
+          version: String(COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION),
+        },
+        logRecords: events.map(toGovernanceAuditOtelLogRecord),
+      }],
+    }],
+  }
+}
+
+export function serializeGovernanceAuditOtelExport(events: GovernanceAuditEvent[]): string {
+  return JSON.stringify(toGovernanceAuditOtelExport(events))
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -132,6 +132,8 @@ import type {
 } from './improvements.js'
 import type {
   GovernanceAuditEvent,
+  GovernanceAuditExportFormat,
+  GovernanceAuditExportPayload,
   GovernanceSubjectKind,
   GovernanceRegistryPayload,
 } from './governance.js'
@@ -328,6 +330,12 @@ export interface CoworkAPI {
       subjectId?: string
       limit?: number
     }) => Promise<GovernanceAuditEvent[]>
+    exportGovernanceAudit: (options?: {
+      subjectKind?: GovernanceSubjectKind
+      subjectId?: string
+      limit?: number
+      format?: GovernanceAuditExportFormat
+    }) => Promise<GovernanceAuditExportPayload>
   }
   channels: {
     list: () => Promise<ChannelListPayload>

--- a/tests/governance-audit-store.test.ts
+++ b/tests/governance-audit-store.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import {
   clearGovernanceAuditStoreCache,
+  exportGovernanceAuditEvents,
   getGovernanceAuditDb,
   GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION,
   listGovernanceAuditEvents,
@@ -78,6 +79,109 @@ test('governance audit store caps result count and stores schema version', () =>
   assert.equal(Number(row?.value), GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION)
 }))
 
+test('governance audit export includes full history by default', () => withGovernanceAuditStore('export-full-history', () => {
+  for (let index = 0; index < 505; index += 1) {
+    recordGovernanceAuditEvent({
+      subjectKind: 'crew',
+      subjectId: `crew:${index}`,
+      action: 'pause_crew',
+      beforeLifecycle: 'active',
+      afterLifecycle: 'paused',
+    })
+  }
+
+  const listed = listGovernanceAuditEvents()
+  assert.equal(listed.length, 500)
+
+  const exported = exportGovernanceAuditEvents()
+  assert.equal(exported.eventCount, 505)
+  assert.equal(exported.body.split('\n').length, 505)
+
+  const explicitlyLimited = exportGovernanceAuditEvents({ limit: 3 })
+  assert.equal(explicitlyLimited.eventCount, 3)
+  assert.equal(explicitlyLimited.body.split('\n').length, 3)
+}))
+
+test('governance audit store exports deterministic NDJSON and OTel JSON', () => withGovernanceAuditStore('export', () => {
+  recordGovernanceAuditEvent({
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    action: 'pause_crew',
+    beforeLifecycle: 'active',
+    afterLifecycle: 'paused',
+    metadata: { crewId: 'research' },
+  })
+  recordGovernanceAuditEvent({
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    action: 'retire_crew',
+    beforeLifecycle: 'paused',
+    afterLifecycle: 'retired',
+    reason: 'Decommissioned.',
+    metadata: { crewId: 'research', ticket: 'INC-123' },
+  })
+
+  const ndjson = exportGovernanceAuditEvents({
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    format: 'ndjson',
+  })
+  const ndjsonRows = ndjson.body.split('\n').map((line) => JSON.parse(line) as Record<string, unknown>)
+
+  assert.equal(ndjson.format, 'ndjson')
+  assert.equal(ndjson.contentType, 'application/x-ndjson')
+  assert.equal(ndjson.eventCount, 2)
+  assert.match(ndjson.filename, /^open-cowork-governance-audit-.*\.ndjson$/)
+  assert.deepEqual(ndjsonRows.map((row) => row.action), ['retire_crew', 'pause_crew'])
+  assert.deepEqual(Object.keys(ndjsonRows[0] || {}), [
+    'schemaVersion',
+    'id',
+    'kind',
+    'subjectKind',
+    'subjectId',
+    'action',
+    'outcome',
+    'actor',
+    'reason',
+    'beforeLifecycle',
+    'afterLifecycle',
+    'metadata',
+    'createdAt',
+  ])
+
+  const otel = exportGovernanceAuditEvents({
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    format: 'otel-json',
+  })
+  const otelBody = JSON.parse(otel.body) as {
+    resourceLogs?: Array<{
+      scopeLogs?: Array<{
+        logRecords?: Array<{
+          severityText?: string
+          body?: { stringValue?: string }
+          attributes?: Array<{ key?: string; value?: { stringValue?: string; intValue?: number } }>
+        }>
+      }>
+    }>
+  }
+  const logRecords = otelBody.resourceLogs?.[0]?.scopeLogs?.[0]?.logRecords || []
+  const firstAttributes = new Map((logRecords[0]?.attributes || []).map((attribute) => [
+    attribute.key,
+    attribute.value?.stringValue ?? attribute.value?.intValue,
+  ]))
+
+  assert.equal(otel.format, 'otel-json')
+  assert.equal(otel.contentType, 'application/json')
+  assert.equal(otel.eventCount, 2)
+  assert.match(otel.filename, /^open-cowork-governance-audit-.*\.otel\.json$/)
+  assert.equal(logRecords.length, 2)
+  assert.equal(logRecords[0]?.severityText, 'INFO')
+  assert.equal(logRecords[0]?.body?.stringValue, 'open_cowork.governance.retire_crew.succeeded')
+  assert.equal(firstAttributes.get('open_cowork.governance.subject.id'), 'crew:research')
+  assert.equal(firstAttributes.get('open_cowork.audit.metadata_json'), '{"crewId":"research","ticket":"INC-123"}')
+}))
+
 test('governance audit store rejects oversized metadata', () => withGovernanceAuditStore('bounds', () => {
   assert.throws(() => recordGovernanceAuditEvent({
     subjectKind: 'crew',
@@ -97,4 +201,5 @@ test('governance audit store rejects oversized metadata', () => withGovernanceAu
 
   assert.throws(() => listGovernanceAuditEvents({ subjectKind: 'crew' }), /require both kind and id/)
   assert.equal(listGovernanceAuditEvents({ limit: Number.NaN }).length, 0)
+  assert.throws(() => exportGovernanceAuditEvents({ format: 'xml' as never }), /format is invalid/)
 }))

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -211,6 +211,19 @@ test('operations:governance-audit-events rejects null options at the IPC boundar
   )
 })
 
+test('operations:export-governance-audit rejects malformed export formats at the IPC boundary', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerOperationHandlers(context)
+  const handler = handlers.get('operations:export-governance-audit')
+
+  assert.ok(handler, 'expected operations:export-governance-audit handler to be registered')
+  await assert.rejects(
+    () => handler({}, { format: 'xml' }),
+    /Governance audit export format is invalid/,
+  )
+})
+
 test('session:prompt clears pending prompt echo when dispatch fails', async () => {
   const { context, handlers } = createBaseContext()
   let promptCalled = false

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -129,6 +129,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('operations:capability-risks'), true)
   assert.equal(handlers.has('operations:governance-registry'), true)
   assert.equal(handlers.has('operations:governance-audit-events'), true)
+  assert.equal(handlers.has('operations:export-governance-audit'), true)
   assert.equal(handlers.has('channels:list'), true)
   assert.equal(handlers.has('channels:definitions'), true)
   assert.equal(handlers.has('channels:inbound-items'), true)


### PR DESCRIPTION
## Summary
- add deterministic NDJSON export for governance audit events
- add an OpenTelemetry-shaped JSON log export projection for governance audit events
- expose audit export through the typed operations IPC/preload surface
- document the export as the next #250 org-governance slice

Refs #250.

## Validation
- pnpm typecheck
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-audit-store.test.ts tests/ipc-handler-behavior.test.ts tests/ipc-handler-registration.test.ts
- pnpm lint
- pnpm test
- pnpm test:renderer
- pnpm docs:build
- git diff --check