### PR TITLE
[codex] broaden governance audit export

### DIFF
--- a/apps/desktop/src/main/automation-store.ts
+++ b/apps/desktop/src/main/automation-store.ts
@@ -424,6 +424,11 @@ function getDeliveryRecord(deliveryId: string) {
   return row ? rowToDelivery(row) : null
 }
 
+export function listAutomationDeliveryRecordsForAudit() {
+  const rows = getDb().prepare('select * from automation_deliveries order by created_at asc, id asc').all() as DbRow[]
+  return rows.map(rowToDelivery)
+}
+
 function insertDeliveryRecord(db: DatabaseSync, id: string, input: DeliveryRecordInput, createdAt: string) {
   db.prepare(`
     insert into automation_deliveries (id, automation_id, run_id, provider, target, status, title, body, created_at)

--- a/apps/desktop/src/main/crew-store.ts
+++ b/apps/desktop/src/main/crew-store.ts
@@ -796,6 +796,23 @@ export function listCrewRuns(crewId: string) {
   return rows.map(rowToCrewRun)
 }
 
+export function listCrewRunsForAudit(options: { crewId?: string | null } = {}) {
+  const crewId = options.crewId ?? null
+  const rows = crewId !== null
+    ? getCrewDb().prepare(`
+      select *
+      from crew_runs
+      where crew_id = ?
+      order by created_at asc, id asc
+    `).all(crewId) as DbRow[]
+    : getCrewDb().prepare(`
+      select *
+      from crew_runs
+      order by created_at asc, id asc
+    `).all() as DbRow[]
+  return rows.map(rowToCrewRun)
+}
+
 export function getCrewRunByRootSessionId(rootSessionId: string) {
   const row = getCrewDb().prepare(`
     select *
@@ -1111,6 +1128,24 @@ export function listCrewApprovalsForRun(crewRunId: string) {
   return rows.map(rowToCrewApproval)
 }
 
+export function listCrewApprovalsForAudit(options: { crewId?: string | null } = {}) {
+  const crewId = options.crewId ?? null
+  const rows = crewId !== null
+    ? getCrewDb().prepare(`
+      select a.*
+      from crew_approvals a
+      join crew_runs r on r.id = a.crew_run_id
+      where r.crew_id = ?
+      order by a.requested_at asc, a.id asc
+    `).all(crewId) as DbRow[]
+    : getCrewDb().prepare(`
+      select *
+      from crew_approvals
+      order by requested_at asc, id asc
+    `).all() as DbRow[]
+  return rows.map(rowToCrewApproval)
+}
+
 export function resolveCrewApproval(id: string, status: Exclude<CrewApprovalStatus, 'requested'>, resolvedBy: string) {
   const existing = getCrewApproval(id)
   if (!existing) return null
@@ -1166,6 +1201,24 @@ export function listPolicyDecisionsForRun(runKind: CoworkRunKind, runId: string)
     where run_kind = ? and run_id = ?
     order by created_at asc, id asc
   `).all(runKind, runId) as DbRow[]
+  return rows.map(rowToPolicyDecision)
+}
+
+export function listPolicyDecisionsForAudit(options: { crewId?: string | null } = {}) {
+  const crewId = options.crewId ?? null
+  const rows = crewId !== null
+    ? getCrewDb().prepare(`
+      select p.*
+      from policy_decisions p
+      join crew_runs r on r.id = p.run_id and p.run_kind = 'crew'
+      where r.crew_id = ?
+      order by p.created_at asc, p.id asc
+    `).all(crewId) as DbRow[]
+    : getCrewDb().prepare(`
+      select *
+      from policy_decisions
+      order by created_at asc, id asc
+    `).all() as DbRow[]
   return rows.map(rowToPolicyDecision)
 }
 
@@ -1344,6 +1397,24 @@ export function listOutcomeEvaluationsForRun(crewRunId: string) {
   return rows.map(rowToOutcomeEvaluation)
 }
 
+export function listOutcomeEvaluationsForAudit(options: { crewId?: string | null } = {}) {
+  const crewId = options.crewId ?? null
+  const rows = crewId !== null
+    ? getCrewDb().prepare(`
+      select e.*
+      from outcome_evaluations e
+      join crew_runs r on r.id = e.crew_run_id
+      where r.crew_id = ?
+      order by e.created_at asc, e.id asc
+    `).all(crewId) as DbRow[]
+    : getCrewDb().prepare(`
+      select *
+      from outcome_evaluations
+      order by created_at asc, id asc
+    `).all() as DbRow[]
+  return rows.map(rowToOutcomeEvaluation)
+}
+
 function rowToTraceEvent(row: DbRow): CoworkTraceEvent {
   return createCoworkTraceEvent({
     id: String(row.id || ''),
@@ -1481,6 +1552,24 @@ export function listCoworkTraceEventsForRun(runId: string) {
     where run_id = ?
     order by sequence asc, created_at asc, id asc
   `).all(runId) as DbRow[]
+  return rows.map(rowToTraceEvent)
+}
+
+export function listCoworkTraceEventsForAudit(options: { crewId?: string | null } = {}) {
+  const crewId = options.crewId ?? null
+  const rows = crewId !== null
+    ? getCrewDb().prepare(`
+      select t.*
+      from crew_trace_events t
+      join crew_runs r on r.id = t.run_id
+      where r.crew_id = ?
+      order by t.created_at asc, t.sequence asc, t.id asc
+    `).all(crewId) as DbRow[]
+    : getCrewDb().prepare(`
+      select *
+      from crew_trace_events
+      order by created_at asc, sequence asc, id asc
+    `).all() as DbRow[]
   return rows.map(rowToTraceEvent)
 }
 

--- a/apps/desktop/src/main/governance-audit-export.ts
+++ b/apps/desktop/src/main/governance-audit-export.ts
@@ -1,0 +1,231 @@
+import {
+  COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+  serializeGovernanceAuditExportRecord,
+  serializeGovernanceAuditOtelExport,
+  toExportableCoworkTraceEvent,
+  toExportableGovernanceAuditEvent,
+  type AutomationDeliveryRecord,
+  type ChannelDeliveryRecord,
+  type CoworkRunKind,
+  type CoworkTraceEvent,
+  type CrewApproval,
+  type GovernanceAuditExportFormat,
+  type GovernanceAuditExportPayload,
+  type GovernanceAuditExportRecord,
+  type GovernanceSubjectKind,
+  type OutcomeEvaluation,
+  type PolicyDecision,
+} from '@open-cowork/shared'
+import { listAutomationDeliveryRecordsForAudit } from './automation-store.ts'
+import { listChannelDeliveryRecords } from './channel-store.ts'
+import {
+  listCoworkTraceEventsForAudit,
+  listCrewApprovalsForAudit,
+  listCrewRunsForAudit,
+  listOutcomeEvaluationsForAudit,
+  listPolicyDecisionsForAudit,
+} from './crew-store.ts'
+import { listGovernanceAuditEventsForExport } from './governance-audit-store.ts'
+
+const GOVERNANCE_AUDIT_EXPORT_BASENAME = 'open-cowork-governance-audit'
+
+export type GovernanceAuditExportOptions = {
+  subjectKind?: GovernanceSubjectKind
+  subjectId?: string
+  limit?: number
+  format?: GovernanceAuditExportFormat
+}
+
+function auditExportTimestamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+function normalizeExportLimit(value: number | undefined) {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(1, Math.trunc(value)) : null
+}
+
+function crewIdFromSubject(options: Pick<GovernanceAuditExportOptions, 'subjectKind' | 'subjectId'>): string | null | undefined {
+  if (!options.subjectKind) return undefined
+  if (options.subjectKind !== 'crew') return null
+  if (!options.subjectId?.startsWith('crew:')) return null
+  try {
+    const crewId = decodeURIComponent(options.subjectId.slice('crew:'.length))
+    return crewId.trim().length > 0 ? crewId : null
+  } catch {
+    return null
+  }
+}
+
+function crewSubjectId(crewId: string | null | undefined) {
+  return crewId ? `crew:${encodeURIComponent(crewId)}` : null
+}
+
+function sortAuditRecords(records: GovernanceAuditExportRecord[]) {
+  return records.slice().sort((left, right) => (
+    left.occurredAt.localeCompare(right.occurredAt)
+    || left.recordType.localeCompare(right.recordType)
+    || left.id.localeCompare(right.id)
+  ))
+}
+
+function incidentRecords(options: Pick<GovernanceAuditExportOptions, 'subjectKind' | 'subjectId'>): GovernanceAuditExportRecord[] {
+  return listGovernanceAuditEventsForExport(options).map((event) => ({
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    recordType: 'governance_incident',
+    id: event.id,
+    occurredAt: event.createdAt,
+    subjectKind: event.subjectKind,
+    subjectId: event.subjectId,
+    runKind: null,
+    runId: null,
+    payload: toExportableGovernanceAuditEvent(event),
+  }))
+}
+
+function traceRecord(event: CoworkTraceEvent, subjectId: string | null): GovernanceAuditExportRecord {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    recordType: 'crew_trace',
+    id: event.id,
+    occurredAt: event.createdAt,
+    subjectKind: subjectId ? 'crew' : null,
+    subjectId,
+    runKind: event.runKind,
+    runId: event.runId,
+    payload: toExportableCoworkTraceEvent(event),
+  }
+}
+
+function approvalRecord(approval: CrewApproval, subjectId: string | null): GovernanceAuditExportRecord {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    recordType: 'crew_approval',
+    id: approval.id,
+    occurredAt: approval.requestedAt,
+    subjectKind: subjectId ? 'crew' : null,
+    subjectId,
+    runKind: 'crew',
+    runId: approval.crewRunId,
+    payload: approval,
+  }
+}
+
+function policyDecisionRecord(decision: PolicyDecision, subjectId: string | null): GovernanceAuditExportRecord {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    recordType: 'policy_decision',
+    id: decision.id,
+    occurredAt: decision.createdAt,
+    subjectKind: subjectId ? 'crew' : null,
+    subjectId,
+    runKind: decision.runKind,
+    runId: decision.runId,
+    payload: decision,
+  }
+}
+
+function outcomeEvaluationRecord(evaluation: OutcomeEvaluation, subjectId: string | null): GovernanceAuditExportRecord {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    recordType: 'outcome_evaluation',
+    id: evaluation.id,
+    occurredAt: evaluation.createdAt,
+    subjectKind: subjectId ? 'crew' : null,
+    subjectId,
+    runKind: 'crew',
+    runId: evaluation.crewRunId,
+    payload: evaluation,
+  }
+}
+
+function automationDeliveryRecord(delivery: AutomationDeliveryRecord): GovernanceAuditExportRecord {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    recordType: 'automation_delivery',
+    id: delivery.id,
+    occurredAt: delivery.createdAt,
+    subjectKind: null,
+    subjectId: null,
+    runKind: 'automation',
+    runId: delivery.runId,
+    payload: delivery,
+  }
+}
+
+function channelDeliveryRecord(delivery: ChannelDeliveryRecord, crewRunSubjects: Map<string, string | null>): GovernanceAuditExportRecord {
+  const subjectId = delivery.runKind === 'crew' && delivery.runId ? crewRunSubjects.get(delivery.runId) || null : null
+  return {
+    schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+    recordType: 'channel_delivery',
+    id: delivery.id,
+    occurredAt: delivery.createdAt,
+    subjectKind: subjectId ? 'crew' : null,
+    subjectId,
+    runKind: delivery.runKind as CoworkRunKind | 'channel' | null,
+    runId: delivery.runId,
+    payload: delivery,
+  }
+}
+
+function collectProductAuditRecords(crewId: string | null | undefined): GovernanceAuditExportRecord[] {
+  if (crewId === null) return []
+  const crewRuns = listCrewRunsForAudit({ crewId })
+  const runSubjects = new Map(crewRuns.map((run) => [run.id, crewSubjectId(run.crewId)]))
+  const records: GovernanceAuditExportRecord[] = [
+    ...listCoworkTraceEventsForAudit({ crewId }).map((event) => traceRecord(event, runSubjects.get(event.runId) || null)),
+    ...listCrewApprovalsForAudit({ crewId }).map((approval) => approvalRecord(approval, runSubjects.get(approval.crewRunId) || null)),
+    ...listPolicyDecisionsForAudit({ crewId }).map((decision) => policyDecisionRecord(decision, decision.runKind === 'crew' ? runSubjects.get(decision.runId) || null : null)),
+    ...listOutcomeEvaluationsForAudit({ crewId }).map((evaluation) => outcomeEvaluationRecord(evaluation, runSubjects.get(evaluation.crewRunId) || null)),
+  ]
+  if (crewId !== undefined) {
+    const allowedRunIds = new Set(crewRuns.map((run) => run.id))
+    records.push(...listChannelDeliveryRecords()
+      .filter((delivery) => delivery.runKind === 'crew' && delivery.runId && allowedRunIds.has(delivery.runId))
+      .map((delivery) => channelDeliveryRecord(delivery, runSubjects)))
+    return records
+  }
+  records.push(
+    ...listAutomationDeliveryRecordsForAudit().map(automationDeliveryRecord),
+    ...listChannelDeliveryRecords().map((delivery) => channelDeliveryRecord(delivery, runSubjects)),
+  )
+  return records
+}
+
+export function collectGovernanceAuditExportRecords(options: GovernanceAuditExportOptions = {}): GovernanceAuditExportRecord[] {
+  const crewId = crewIdFromSubject(options)
+  const limit = normalizeExportLimit(options.limit)
+  const records = sortAuditRecords([
+    ...incidentRecords({ subjectKind: options.subjectKind, subjectId: options.subjectId }),
+    ...collectProductAuditRecords(crewId),
+  ])
+  return limit === null ? records : records.slice(0, limit)
+}
+
+export function exportGovernanceAuditEvents(options: GovernanceAuditExportOptions = {}): GovernanceAuditExportPayload {
+  const format = options.format || 'ndjson'
+  const records = collectGovernanceAuditExportRecords(options)
+  const exportedAt = new Date().toISOString()
+  if (format === 'ndjson') {
+    return {
+      schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+      format,
+      contentType: 'application/x-ndjson',
+      filename: `${GOVERNANCE_AUDIT_EXPORT_BASENAME}-${auditExportTimestamp(new Date(exportedAt))}.ndjson`,
+      exportedAt,
+      eventCount: records.length,
+      body: records.map(serializeGovernanceAuditExportRecord).join('\n'),
+    }
+  }
+  if (format === 'otel-json') {
+    return {
+      schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
+      format,
+      contentType: 'application/json',
+      filename: `${GOVERNANCE_AUDIT_EXPORT_BASENAME}-${auditExportTimestamp(new Date(exportedAt))}.otel.json`,
+      exportedAt,
+      eventCount: records.length,
+      body: serializeGovernanceAuditOtelExport(records),
+    }
+  }
+  throw new Error('Governance audit export format is invalid.')
+}

--- a/apps/desktop/src/main/governance-audit-store.ts
+++ b/apps/desktop/src/main/governance-audit-store.ts
@@ -4,14 +4,9 @@ import { chmodSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION,
-  COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
-  serializeGovernanceAuditEvent,
-  serializeGovernanceAuditOtelExport,
   type GovernanceAuditActor,
   type GovernanceAuditEvent,
   type GovernanceAuditEventDraft,
-  type GovernanceAuditExportFormat,
-  type GovernanceAuditExportPayload,
   type GovernanceAuditEventKind,
   type GovernanceAuditOutcome,
   type GovernanceIncidentControlKind,
@@ -26,7 +21,6 @@ const GOVERNANCE_AUDIT_SCHEMA_VERSION_KEY = 'schema_version'
 const MAX_TEXT_BYTES = 16 * 1024
 const MAX_METADATA_BYTES = 128 * 1024
 const DEFAULT_AUDIT_LIST_LIMIT = 500
-const GOVERNANCE_AUDIT_EXPORT_BASENAME = 'open-cowork-governance-audit'
 const AUDIT_KINDS = new Set<GovernanceAuditEventKind>(['incident_control'])
 const AUDIT_OUTCOMES = new Set<GovernanceAuditOutcome>(['succeeded', 'failed'])
 const SUBJECT_KINDS = new Set<GovernanceSubjectKind>(['agent', 'crew'])
@@ -342,43 +336,9 @@ export function listGovernanceAuditEvents(options: GovernanceAuditQueryOptions =
   })
 }
 
-function auditExportTimestamp(date = new Date()) {
-  return date.toISOString().replace(/[:.]/g, '-')
-}
-
-export function exportGovernanceAuditEvents(options: {
-  subjectKind?: GovernanceSubjectKind
-  subjectId?: string
-  limit?: number
-  format?: GovernanceAuditExportFormat
-} = {}): GovernanceAuditExportPayload {
-  const { format = 'ndjson', ...queryOptions } = options
-  const events = readGovernanceAuditEvents(queryOptions, {
+export function listGovernanceAuditEventsForExport(options: GovernanceAuditQueryOptions = {}): GovernanceAuditEvent[] {
+  return readGovernanceAuditEvents(options, {
     defaultLimit: null,
     maxLimit: null,
   })
-  const exportedAt = nowIso()
-  if (format === 'ndjson') {
-    return {
-      schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
-      format,
-      contentType: 'application/x-ndjson',
-      filename: `${GOVERNANCE_AUDIT_EXPORT_BASENAME}-${auditExportTimestamp(new Date(exportedAt))}.ndjson`,
-      exportedAt,
-      eventCount: events.length,
-      body: events.map(serializeGovernanceAuditEvent).join('\n'),
-    }
-  }
-  if (format === 'otel-json') {
-    return {
-      schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
-      format,
-      contentType: 'application/json',
-      filename: `${GOVERNANCE_AUDIT_EXPORT_BASENAME}-${auditExportTimestamp(new Date(exportedAt))}.otel.json`,
-      exportedAt,
-      eventCount: events.length,
-      body: serializeGovernanceAuditOtelExport(events),
-    }
-  }
-  throw new Error('Governance audit export format is invalid.')
 }

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -7,7 +7,8 @@ import {
 } from '../operational-queue-store.ts'
 import { listCapabilityRiskMetadata } from '../operation-capability-risk.ts'
 import { getGovernanceRegistry } from '../governance-registry.ts'
-import { exportGovernanceAuditEvents, listGovernanceAuditEvents } from '../governance-audit-store.ts'
+import { exportGovernanceAuditEvents } from '../governance-audit-export.ts'
+import { listGovernanceAuditEvents } from '../governance-audit-store.ts'
 
 function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is Parameters<typeof listGovernanceAuditEvents>[0] {
   if (value === undefined) return

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -122,10 +122,10 @@ can pause or retire a crew through the `crews` IPC namespace; paused or retired
 crews keep their history and registry entry but cannot start new runs. Each
 control writes a durable governance audit event with actor, action,
 before/after lifecycle state, subject id, and bounded metadata. Admin surfaces
-can query those events through the operations namespace and export the ledger as
-deterministic NDJSON or OpenTelemetry-shaped JSON. The current export covers
-governance incident-control events; broader trace, approval, policy, tool-call,
-delivery, and eval export will extend the same typed audit surface.
+can query those events through the operations namespace. The export path emits
+a typed audit stream as deterministic NDJSON or OpenTelemetry-shaped JSON and
+covers governance incidents, crew traces, approvals, policy decisions, tool-call
+trace records, channel/automation deliveries, and outcome evaluations.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -1,6 +1,10 @@
+import type { AutomationDeliveryRecord } from './automation.js'
+import type { ChannelDeliveryRecord } from './channels.js'
+import type { CoworkRunKind, CoworkTraceEvent, CrewApproval, OutcomeEvaluation, PolicyDecision } from './crews.js'
+
 export const COWORK_GOVERNANCE_SCHEMA_VERSION = 1
 export const COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION = 1
-export const COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION = 1
+export const COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION = 2
 
 export type GovernanceSubjectKind = 'agent' | 'crew'
 export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired'
@@ -27,6 +31,14 @@ export type GovernanceIncidentControlKind =
 export type GovernanceAuditEventKind = 'incident_control'
 export type GovernanceAuditOutcome = 'succeeded' | 'failed'
 export type GovernanceAuditExportFormat = 'ndjson' | 'otel-json'
+export type GovernanceAuditExportRecordType =
+  | 'governance_incident'
+  | 'crew_trace'
+  | 'crew_approval'
+  | 'policy_decision'
+  | 'outcome_evaluation'
+  | 'automation_delivery'
+  | 'channel_delivery'
 
 export interface GovernanceOwner {
   kind: GovernanceOwnerKind
@@ -136,6 +148,27 @@ export interface GovernanceAuditExportPayload {
   body: string
 }
 
+export type GovernanceAuditExportRecordPayload =
+  | GovernanceAuditEvent
+  | CoworkTraceEvent
+  | CrewApproval
+  | PolicyDecision
+  | OutcomeEvaluation
+  | AutomationDeliveryRecord
+  | ChannelDeliveryRecord
+
+export interface GovernanceAuditExportRecord {
+  schemaVersion: number
+  recordType: GovernanceAuditExportRecordType
+  id: string
+  occurredAt: string
+  subjectKind: GovernanceSubjectKind | null
+  subjectId: string | null
+  runKind: CoworkRunKind | 'channel' | null
+  runId: string | null
+  payload: GovernanceAuditExportRecordPayload
+}
+
 export type GovernanceAuditOtelValue =
   | { stringValue: string }
   | { intValue: number }
@@ -197,8 +230,22 @@ export function serializeGovernanceAuditEvent(event: GovernanceAuditEvent): stri
   })
 }
 
-function auditEventTimeUnixNano(event: GovernanceAuditEvent) {
-  const millis = Date.parse(event.createdAt)
+export function serializeGovernanceAuditExportRecord(record: GovernanceAuditExportRecord): string {
+  return JSON.stringify({
+    schemaVersion: record.schemaVersion,
+    recordType: record.recordType,
+    id: record.id,
+    occurredAt: record.occurredAt,
+    subjectKind: record.subjectKind,
+    subjectId: record.subjectId,
+    runKind: record.runKind,
+    runId: record.runId,
+    payload: record.payload,
+  })
+}
+
+function auditTimeUnixNano(isoTimestamp: string) {
+  const millis = Date.parse(isoTimestamp)
   const normalized = Number.isFinite(millis) ? Math.max(0, Math.trunc(millis)) : 0
   return `${normalized}000000`
 }
@@ -215,35 +262,36 @@ function otelOptionalStringAttribute(key: string, value: string | null): Governa
   return value ? [otelStringAttribute(key, value)] : []
 }
 
-export function toGovernanceAuditOtelLogRecord(event: GovernanceAuditEvent): GovernanceAuditOtelLogRecord {
-  const exportable = toExportableGovernanceAuditEvent(event)
-  const timeUnixNano = auditEventTimeUnixNano(exportable)
-  const metadataJson = JSON.stringify(exportable.metadata)
+function auditRecordStatus(record: GovernanceAuditExportRecord) {
+  if ('outcome' in record.payload) return record.payload.outcome
+  if ('status' in record.payload && typeof record.payload.status === 'string') return record.payload.status
+  return null
+}
+
+export function toGovernanceAuditOtelLogRecord(record: GovernanceAuditExportRecord): GovernanceAuditOtelLogRecord {
+  const timeUnixNano = auditTimeUnixNano(record.occurredAt)
+  const status = auditRecordStatus(record)
+  const payloadJson = JSON.stringify(record.payload)
   return {
     timeUnixNano,
     observedTimeUnixNano: timeUnixNano,
-    severityText: exportable.outcome === 'failed' ? 'ERROR' : 'INFO',
-    body: { stringValue: `open_cowork.governance.${exportable.action}.${exportable.outcome}` },
+    severityText: status === 'failed' || status === 'denied' ? 'ERROR' : 'INFO',
+    body: { stringValue: `open_cowork.audit.${record.recordType}${status ? `.${status}` : ''}` },
     attributes: [
-      otelIntAttribute('open_cowork.audit.schema_version', exportable.schemaVersion),
-      otelStringAttribute('open_cowork.audit.id', exportable.id),
-      otelStringAttribute('open_cowork.audit.kind', exportable.kind),
-      otelStringAttribute('open_cowork.audit.action', exportable.action),
-      otelStringAttribute('open_cowork.audit.outcome', exportable.outcome),
-      otelStringAttribute('open_cowork.governance.subject.kind', exportable.subjectKind),
-      otelStringAttribute('open_cowork.governance.subject.id', exportable.subjectId),
-      otelStringAttribute('open_cowork.governance.actor.kind', exportable.actor.kind),
-      otelStringAttribute('open_cowork.governance.actor.id', exportable.actor.id),
-      otelStringAttribute('open_cowork.governance.actor.display_name', exportable.actor.displayName),
-      ...otelOptionalStringAttribute('open_cowork.governance.lifecycle.before', exportable.beforeLifecycle),
-      ...otelOptionalStringAttribute('open_cowork.governance.lifecycle.after', exportable.afterLifecycle),
-      ...otelOptionalStringAttribute('open_cowork.audit.reason', exportable.reason),
-      otelStringAttribute('open_cowork.audit.metadata_json', metadataJson),
+      otelIntAttribute('open_cowork.audit.export_schema_version', record.schemaVersion),
+      otelStringAttribute('open_cowork.audit.record_type', record.recordType),
+      otelStringAttribute('open_cowork.audit.id', record.id),
+      ...otelOptionalStringAttribute('open_cowork.audit.status', status),
+      ...otelOptionalStringAttribute('open_cowork.governance.subject.kind', record.subjectKind),
+      ...otelOptionalStringAttribute('open_cowork.governance.subject.id', record.subjectId),
+      ...otelOptionalStringAttribute('open_cowork.audit.run.kind', record.runKind),
+      ...otelOptionalStringAttribute('open_cowork.audit.run.id', record.runId),
+      otelStringAttribute('open_cowork.audit.payload_json', payloadJson),
     ],
   }
 }
 
-export function toGovernanceAuditOtelExport(events: GovernanceAuditEvent[]): GovernanceAuditOtelExport {
+export function toGovernanceAuditOtelExport(records: GovernanceAuditExportRecord[]): GovernanceAuditOtelExport {
   return {
     schemaVersion: COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION,
     resourceLogs: [{
@@ -259,12 +307,12 @@ export function toGovernanceAuditOtelExport(events: GovernanceAuditEvent[]): Gov
           name: 'open-cowork.governance.audit',
           version: String(COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION),
         },
-        logRecords: events.map(toGovernanceAuditOtelLogRecord),
+        logRecords: records.map(toGovernanceAuditOtelLogRecord),
       }],
     }],
   }
 }
 
-export function serializeGovernanceAuditOtelExport(events: GovernanceAuditEvent[]): string {
-  return JSON.stringify(toGovernanceAuditOtelExport(events))
+export function serializeGovernanceAuditOtelExport(records: GovernanceAuditExportRecord[]): string {
+  return JSON.stringify(toGovernanceAuditOtelExport(records))
 }

--- a/tests/governance-audit-export.test.ts
+++ b/tests/governance-audit-export.test.ts
@@ -1,0 +1,284 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { clearAutomationStoreCache, createDeliveryRecord } from '../apps/desktop/src/main/automation-store.ts'
+import { clearChannelStoreCache, createChannelDefinition, createChannelDeliveryRecord } from '../apps/desktop/src/main/channel-store.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  appendCoworkTraceEvent,
+  clearCrewStoreCache,
+  createCrewApproval,
+  createCrewDefinition,
+  createCrewRun,
+  createCrewRunNode,
+  createCrewVersion,
+  createOutcomeRubric,
+  recordOutcomeEvaluation,
+  recordPolicyDecision,
+} from '../apps/desktop/src/main/crew-store.ts'
+import { exportGovernanceAuditEvents } from '../apps/desktop/src/main/governance-audit-export.ts'
+import { clearGovernanceAuditStoreCache, recordGovernanceAuditEvent } from '../apps/desktop/src/main/governance-audit-store.ts'
+import { createCoworkTraceEvent } from '../packages/shared/src/crews.ts'
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-governance-export-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+function withAuditExportStores(name: string, fn: () => void) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    clearConfigCaches()
+    clearGovernanceAuditStoreCache()
+    clearCrewStoreCache()
+    clearChannelStoreCache()
+    clearAutomationStoreCache()
+    fn()
+  } finally {
+    clearGovernanceAuditStoreCache()
+    clearCrewStoreCache()
+    clearChannelStoreCache()
+    clearAutomationStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+test('governance audit export covers incidents, traces, approvals, policy, deliveries, and evals', () => withAuditExportStores('records', () => {
+  const crew = createCrewDefinition({ name: 'Research Crew', description: 'Research team.' })!
+  const version = createCrewVersion({
+    crewId: crew.id,
+    members: [{
+      schemaVersion: 1,
+      id: 'lead',
+      role: 'lead',
+      agentName: 'lead-agent',
+      displayName: 'Lead',
+      description: 'Plans the work.',
+      required: true,
+    }],
+  })!
+  const run = createCrewRun({
+    crewId: crew.id,
+    crewVersionId: version.id,
+    title: 'Investigate a launch plan',
+  })!
+  const node = createCrewRunNode({
+    crewRunId: run.id,
+    kind: 'delegate',
+    title: 'Analyze launch data',
+    agentName: 'lead-agent',
+  })!
+  const trace = appendCoworkTraceEvent(createCoworkTraceEvent({
+    id: 'trace-tool-call',
+    sequence: 1,
+    runId: run.id,
+    runKind: 'crew',
+    source: 'opencode_event',
+    sourceEventId: 'evt-tool-call',
+    correlationId: null,
+    causationId: null,
+    sessionId: 'session-root',
+    parentSessionId: null,
+    actor: { kind: 'agent', id: 'lead-agent' },
+    nodeId: node.id,
+    artifactId: null,
+    approvalId: null,
+    policyDecisionId: null,
+    inputHash: null,
+    outputHash: null,
+    payloadRef: null,
+    payloadHash: null,
+    redactionState: 'none',
+    tokenUsage: null,
+    costUsd: null,
+    payload: { type: 'crew_run.tool_call', toolName: 'charts.create_line_chart' },
+    createdAt: new Date().toISOString(),
+  }))
+  const approval = createCrewApproval({
+    crewRunId: run.id,
+    nodeId: node.id,
+    title: 'Approve delivery',
+    body: 'Review before external delivery.',
+  })!
+  const policy = recordPolicyDecision({
+    runId: run.id,
+    runKind: 'crew',
+    nodeId: node.id,
+    status: 'approval_required',
+    reason: 'External delivery requires approval.',
+    capabilityId: 'delivery:external',
+  })!
+  const rubric = createOutcomeRubric({
+    name: 'Research quality',
+    description: 'Minimum bar.',
+    criteria: [{
+      schemaVersion: 1,
+      id: 'evidence',
+      label: 'Evidence',
+      description: 'Uses evidence.',
+      weight: 1,
+      passingScore: 80,
+    }],
+    passingScore: 80,
+  })!
+  const evaluation = recordOutcomeEvaluation({
+    crewRunId: run.id,
+    evaluatorAgentName: 'eval-agent',
+    rubricId: rubric.id,
+    status: 'passed',
+    score: 91,
+    evidenceTraceEventIds: [trace.id],
+    recommendation: 'deliver',
+  })!
+  const channel = createChannelDefinition({
+    provider: 'teams',
+    name: 'Launch Teams',
+    sourceKey: 'launch-teams',
+    senderAllowlist: ['ops@example.com'],
+    route: { activationMode: 'ask_user' },
+  })
+  const channelDelivery = createChannelDeliveryRecord({
+    channelId: channel.id,
+    provider: 'teams',
+    target: 'launch-channel',
+    status: 'draft',
+    title: 'Launch update',
+    body: 'Draft update.',
+    runKind: 'crew',
+    runId: run.id,
+    policyDecisionIds: [policy.id],
+    approvalIds: [approval.id],
+  })
+  const automationDelivery = createDeliveryRecord({
+    automationId: 'automation:daily-brief',
+    runId: 'automation-run-1',
+    provider: 'in_app',
+    target: 'pulse',
+    status: 'delivered',
+    title: 'Daily brief',
+    body: 'Ready.',
+  })!
+  const incident = recordGovernanceAuditEvent({
+    subjectKind: 'crew',
+    subjectId: `crew:${encodeURIComponent(crew.id)}`,
+    action: 'pause_crew',
+    beforeLifecycle: 'active',
+    afterLifecycle: 'paused',
+    reason: 'Operator pause.',
+  })
+
+  const exported = exportGovernanceAuditEvents({ format: 'ndjson' })
+  const rows = exported.body.split('\n').map((line) => JSON.parse(line) as {
+    recordType: string
+    id: string
+    subjectId: string | null
+    runId: string | null
+    payload: Record<string, unknown>
+  })
+  const byType = new Map(rows.map((row) => [row.recordType, row]))
+
+  assert.equal(exported.eventCount, 7)
+  assert.deepEqual([...byType.keys()].sort(), [
+    'automation_delivery',
+    'channel_delivery',
+    'crew_approval',
+    'crew_trace',
+    'governance_incident',
+    'outcome_evaluation',
+    'policy_decision',
+  ])
+  assert.equal(byType.get('crew_trace')?.id, trace.id)
+  assert.equal(byType.get('crew_trace')?.payload.payload && (byType.get('crew_trace')?.payload.payload as Record<string, unknown>).type, 'crew_run.tool_call')
+  assert.equal(byType.get('crew_approval')?.id, approval.id)
+  assert.equal(byType.get('policy_decision')?.id, policy.id)
+  assert.equal(byType.get('outcome_evaluation')?.id, evaluation.id)
+  assert.equal(byType.get('channel_delivery')?.id, channelDelivery.id)
+  assert.equal(byType.get('channel_delivery')?.subjectId, `crew:${encodeURIComponent(crew.id)}`)
+  assert.equal(byType.get('automation_delivery')?.id, automationDelivery.id)
+  assert.equal(byType.get('governance_incident')?.id, incident.id)
+
+  const otel = exportGovernanceAuditEvents({ format: 'otel-json' })
+  const otelBody = JSON.parse(otel.body) as {
+    resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: Array<{ body?: { stringValue?: string } }> }> }>
+  }
+  const bodies = (otelBody.resourceLogs?.[0]?.scopeLogs?.[0]?.logRecords || [])
+    .map((record) => record.body?.stringValue)
+  assert.equal(otel.eventCount, 7)
+  assert.ok(bodies.includes('open_cowork.audit.crew_trace'))
+  assert.ok(bodies.includes('open_cowork.audit.policy_decision.approval_required'))
+  assert.ok(bodies.includes('open_cowork.audit.channel_delivery.draft'))
+}))
+
+test('governance audit export rejects empty crew subject ids without broadening scope', () => withAuditExportStores('empty-crew-subject', () => {
+  const crew = createCrewDefinition({ name: 'Scoped Crew', description: 'Scoped team.' })!
+  const version = createCrewVersion({
+    crewId: crew.id,
+    members: [{
+      schemaVersion: 1,
+      id: 'lead',
+      role: 'lead',
+      agentName: 'lead-agent',
+      displayName: 'Lead',
+      description: 'Plans the work.',
+      required: true,
+    }],
+  })!
+  const run = createCrewRun({
+    crewId: crew.id,
+    crewVersionId: version.id,
+    title: 'Scoped run',
+  })!
+  const node = createCrewRunNode({
+    crewRunId: run.id,
+    kind: 'delegate',
+    title: 'Scoped task',
+    agentName: 'lead-agent',
+  })!
+  appendCoworkTraceEvent(createCoworkTraceEvent({
+    id: 'trace-scoped',
+    sequence: 1,
+    runId: run.id,
+    runKind: 'crew',
+    source: 'opencode_event',
+    sourceEventId: 'evt-scoped',
+    correlationId: null,
+    causationId: null,
+    sessionId: 'session-scoped',
+    parentSessionId: null,
+    actor: { kind: 'agent', id: 'lead-agent' },
+    nodeId: node.id,
+    artifactId: null,
+    approvalId: null,
+    policyDecisionId: null,
+    inputHash: null,
+    outputHash: null,
+    payloadRef: null,
+    payloadHash: null,
+    redactionState: 'none',
+    tokenUsage: null,
+    costUsd: null,
+    payload: { type: 'crew_run.tool_call', toolName: 'charts.create_line_chart' },
+    createdAt: new Date().toISOString(),
+  }))
+  recordGovernanceAuditEvent({
+    subjectKind: 'crew',
+    subjectId: `crew:${encodeURIComponent(crew.id)}`,
+    action: 'pause_crew',
+    beforeLifecycle: 'active',
+    afterLifecycle: 'paused',
+    reason: 'Operator pause.',
+  })
+
+  const unfiltered = exportGovernanceAuditEvents({ format: 'ndjson' })
+  assert.ok(unfiltered.eventCount > 0)
+
+  const malformed = exportGovernanceAuditEvents({ format: 'ndjson', subjectKind: 'crew', subjectId: 'crew:' })
+  assert.equal(malformed.eventCount, 0)
+  assert.equal(malformed.body, '')
+}))

--- a/tests/governance-audit-store.test.ts
+++ b/tests/governance-audit-store.test.ts
@@ -4,9 +4,9 @@ import { rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { exportGovernanceAuditEvents } from '../apps/desktop/src/main/governance-audit-export.ts'
 import {
   clearGovernanceAuditStoreCache,
-  exportGovernanceAuditEvents,
   getGovernanceAuditDb,
   GOVERNANCE_AUDIT_STORE_SCHEMA_VERSION,
   listGovernanceAuditEvents,
@@ -132,21 +132,18 @@ test('governance audit store exports deterministic NDJSON and OTel JSON', () => 
   assert.equal(ndjson.contentType, 'application/x-ndjson')
   assert.equal(ndjson.eventCount, 2)
   assert.match(ndjson.filename, /^open-cowork-governance-audit-.*\.ndjson$/)
-  assert.deepEqual(ndjsonRows.map((row) => row.action), ['retire_crew', 'pause_crew'])
+  assert.deepEqual(ndjsonRows.map((row) => row.recordType), ['governance_incident', 'governance_incident'])
+  assert.deepEqual(ndjsonRows.map((row) => (row.payload as Record<string, unknown>).action), ['pause_crew', 'retire_crew'])
   assert.deepEqual(Object.keys(ndjsonRows[0] || {}), [
     'schemaVersion',
+    'recordType',
     'id',
-    'kind',
+    'occurredAt',
     'subjectKind',
     'subjectId',
-    'action',
-    'outcome',
-    'actor',
-    'reason',
-    'beforeLifecycle',
-    'afterLifecycle',
-    'metadata',
-    'createdAt',
+    'runKind',
+    'runId',
+    'payload',
   ])
 
   const otel = exportGovernanceAuditEvents({
@@ -177,9 +174,11 @@ test('governance audit store exports deterministic NDJSON and OTel JSON', () => 
   assert.match(otel.filename, /^open-cowork-governance-audit-.*\.otel\.json$/)
   assert.equal(logRecords.length, 2)
   assert.equal(logRecords[0]?.severityText, 'INFO')
-  assert.equal(logRecords[0]?.body?.stringValue, 'open_cowork.governance.retire_crew.succeeded')
+  assert.equal(logRecords[0]?.body?.stringValue, 'open_cowork.audit.governance_incident.succeeded')
   assert.equal(firstAttributes.get('open_cowork.governance.subject.id'), 'crew:research')
-  assert.equal(firstAttributes.get('open_cowork.audit.metadata_json'), '{"crewId":"research","ticket":"INC-123"}')
+  const firstPayload = JSON.parse(String(firstAttributes.get('open_cowork.audit.payload_json'))) as { action?: string; metadata?: Record<string, unknown> }
+  assert.equal(firstPayload.action, 'pause_crew')
+  assert.equal(firstPayload.metadata?.crewId, 'research')
 }))
 
 test('governance audit store rejects oversized metadata', () => withGovernanceAuditStore('bounds', () => {


### PR DESCRIPTION
## Summary
- add typed governance audit export records for incidents, crew traces, approvals, policy decisions, outcome evaluations, automation deliveries, and channel deliveries
- move export aggregation out of the incident ledger store while keeping the list API capped for UI use
- update operations docs and add coverage for NDJSON + OpenTelemetry-shaped JSON export

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm docs:build
- git diff --check