### PR TITLE
[codex] add custom agent incident controls

### DIFF
--- a/apps/desktop/src/main/custom-agent-store.ts
+++ b/apps/desktop/src/main/custom-agent-store.ts
@@ -259,6 +259,15 @@ function assertValidCustomAgentName(name: string) {
   throw new Error('Custom agent id must use 1-64 lowercase letters, numbers, and single hyphens only.')
 }
 
+function assertSafeCustomAgentRemovalName(name: string) {
+  if (!name || name.includes('\0') || name.includes('/') || name.includes('\\') || name === '.' || name === '..') {
+    throw new Error('Custom agent id must be a single managed file name.')
+  }
+  if (Buffer.byteLength(name, 'utf8') > 256) {
+    throw new Error('Custom agent id is too large.')
+  }
+}
+
 function readManagedAgentMetadata(root: string, name: string): ManagedAgentMetadata {
   const path = agentMetaPath(root, name)
   try {
@@ -458,7 +467,7 @@ export function saveCustomAgent(agent: CustomAgentConfig, permission: Record<str
 }
 
 export function removeCustomAgent(target: ScopedArtifactRef) {
-  assertValidCustomAgentName(target.name)
+  assertSafeCustomAgentRemovalName(target.name)
   const root = ensureDirectory(agentsDirForTarget(target.scope, target.directory))
   rmSync(agentMarkdownPath(root, target.name, true), { force: true })
   rmSync(agentMarkdownPath(root, target.name, false), { force: true })

--- a/apps/desktop/src/main/governance-agent-controls.ts
+++ b/apps/desktop/src/main/governance-agent-controls.ts
@@ -1,0 +1,146 @@
+import type { CustomAgentConfig, RuntimeContextOptions, ScopedArtifactRef } from '@open-cowork/shared'
+import { getCustomAgentSummaries, normalizeCustomAgent, type CustomAgentSummary } from './custom-agents.ts'
+import {
+  customAgentGovernanceLifecycle,
+  customAgentGovernanceSubjectId,
+} from './governance-registry.ts'
+import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
+import { listCustomAgents, removeCustomAgent, saveCustomAgent } from './native-customizations.ts'
+
+const MAX_INCIDENT_REASON_BYTES = 16 * 1024
+
+export type GovernanceAgentIncidentControlRequest = {
+  subjectId: string
+  reason?: string | null
+  context?: RuntimeContextOptions
+}
+
+export type GovernanceAgentIncidentControlDependencies = {
+  buildCustomAgentPermission: (
+    agent: CustomAgentConfig,
+    options?: RuntimeContextOptions,
+  ) => Promise<Record<string, unknown>>
+  rebootRuntime: () => Promise<void>
+}
+
+type ResolvedCustomAgent = CustomAgentSummary & {
+  storageName: string
+}
+
+function boundedSubjectId(value: unknown) {
+  if (typeof value !== 'string') throw new Error('Agent subject id must be a string.')
+  const subjectId = value.trim()
+  if (!subjectId) throw new Error('Agent subject id is required.')
+  if (Buffer.byteLength(subjectId, 'utf8') > 1024) throw new Error('Agent subject id is too large.')
+  return subjectId
+}
+
+function boundedReason(value: unknown, fallback: string) {
+  if (value === undefined || value === null) return fallback
+  if (typeof value !== 'string') throw new Error('Agent incident reason must be a string.')
+  const reason = value.trim()
+  if (!reason) return fallback
+  if (Buffer.byteLength(reason, 'utf8') > MAX_INCIDENT_REASON_BYTES) {
+    throw new Error('Agent incident reason is too large.')
+  }
+  return reason
+}
+
+function agentTarget(agent: Pick<ResolvedCustomAgent, 'name' | 'scope' | 'directory' | 'storageName'>): ScopedArtifactRef {
+  return {
+    name: agent.storageName || agent.name,
+    scope: agent.scope || 'machine',
+    directory: agent.scope === 'project' ? agent.directory || null : null,
+  }
+}
+
+function runtimeContextForAgent(agent: Pick<CustomAgentSummary, 'scope' | 'directory'>): RuntimeContextOptions {
+  return {
+    directory: agent.scope === 'project' ? agent.directory || null : null,
+  }
+}
+
+async function findCustomAgentBySubjectId(
+  subjectId: string,
+  options?: RuntimeContextOptions,
+): Promise<ResolvedCustomAgent | null> {
+  const rawAgents = listCustomAgents(options)
+  const storageName = rawAgents
+    .find((agent) => customAgentGovernanceSubjectId(normalizeCustomAgent(agent)) === subjectId)
+    ?.name
+  const agents = await getCustomAgentSummaries(options)
+  const agent = agents.find((candidate) => customAgentGovernanceSubjectId(candidate) === subjectId)
+  return agent ? { ...agent, storageName: storageName || agent.name } : null
+}
+
+function auditAgentIncident(input: {
+  agent: CustomAgentSummary
+  action: 'pause_agent' | 'retire_agent'
+  reason: string
+  afterLifecycle: 'paused' | 'retired'
+}) {
+  recordGovernanceAuditEvent({
+    subjectKind: 'agent',
+    subjectId: customAgentGovernanceSubjectId(input.agent),
+    action: input.action,
+    beforeLifecycle: customAgentGovernanceLifecycle(input.agent),
+    afterLifecycle: input.afterLifecycle,
+    reason: input.reason,
+    metadata: {
+      agentName: input.agent.name,
+      scope: input.agent.scope || 'machine',
+      directory: input.agent.scope === 'project' ? input.agent.directory || null : null,
+    },
+  })
+}
+
+function assertControllableAgent(agent: ResolvedCustomAgent | null, subjectId: string): asserts agent is ResolvedCustomAgent {
+  if (!agent) throw new Error(`No custom agent found for governance subject ${subjectId}.`)
+}
+
+export async function pauseGovernanceAgent(
+  request: GovernanceAgentIncidentControlRequest,
+  dependencies: GovernanceAgentIncidentControlDependencies,
+) {
+  const subjectId = boundedSubjectId(request.subjectId)
+  const agent = await findCustomAgentBySubjectId(subjectId, request.context)
+  assertControllableAgent(agent, subjectId)
+  const beforeLifecycle = customAgentGovernanceLifecycle(agent)
+  if (beforeLifecycle === 'paused') throw new Error(`Agent ${agent.name} is already paused.`)
+  if (beforeLifecycle !== 'active') throw new Error(`Agent ${agent.name} cannot be paused from ${beforeLifecycle} state.`)
+
+  const reason = boundedReason(request.reason, 'Agent paused through governance incident control.')
+  const updated = normalizeCustomAgent({ ...agent, enabled: false })
+  const context = runtimeContextForAgent(agent)
+  saveCustomAgent(updated, await dependencies.buildCustomAgentPermission(updated, context))
+  auditAgentIncident({
+    agent,
+    action: 'pause_agent',
+    reason,
+    afterLifecycle: 'paused',
+  })
+  await dependencies.rebootRuntime()
+  return true
+}
+
+export async function retireGovernanceAgent(
+  request: GovernanceAgentIncidentControlRequest,
+  dependencies: GovernanceAgentIncidentControlDependencies,
+) {
+  const subjectId = boundedSubjectId(request.subjectId)
+  const agent = await findCustomAgentBySubjectId(subjectId, request.context)
+  assertControllableAgent(agent, subjectId)
+  const beforeLifecycle = customAgentGovernanceLifecycle(agent)
+  if (beforeLifecycle === 'retired') throw new Error(`Agent ${agent.name} is already retired.`)
+
+  const reason = boundedReason(request.reason, 'Agent retired through governance incident control.')
+  removeCustomAgent(agentTarget(agent))
+  auditAgentIncident({
+    agent,
+    action: 'retire_agent',
+    reason,
+    afterLifecycle: 'retired',
+  })
+  await dependencies.rebootRuntime()
+  return true
+}

--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -33,6 +33,12 @@ type GovernanceCustomAgentSummary = Omit<SharedCustomAgentSummary, 'scope'> & {
   scope?: SharedCustomAgentSummary['scope']
 }
 
+export type GovernanceCustomAgentIdentity = {
+  scope?: 'machine' | 'project' | null
+  directory?: string | null
+  name: string
+}
+
 const LOCAL_OWNER = {
   kind: 'user' as const,
   id: 'local-user',
@@ -53,7 +59,7 @@ function shortHash(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 12)
 }
 
-function customAgentSubjectId(agent: GovernanceCustomAgentSummary): string {
+export function customAgentGovernanceSubjectId(agent: GovernanceCustomAgentIdentity): string {
   if (agent.scope === 'project') {
     const directoryKey = shortHash(agent.directory || 'unknown-project')
     return `agent:project:${directoryKey}:${idSegment(agent.name)}`
@@ -141,7 +147,7 @@ function collectAgentDependencies(input: {
   return sortDependencies([...dependencies.values()])
 }
 
-function customAgentLifecycle(agent: GovernanceCustomAgentSummary): GovernanceLifecycleState {
+export function customAgentGovernanceLifecycle(agent: Pick<GovernanceCustomAgentSummary, 'enabled' | 'valid'>): GovernanceLifecycleState {
   if (!agent.valid) return 'draft'
   return agent.enabled ? 'active' : 'paused'
 }
@@ -186,13 +192,18 @@ function builtInAgentControls(agent: BuiltInAgentDetail): GovernanceIncidentCont
 }
 
 function customAgentControls(agent: GovernanceCustomAgentSummary): GovernanceIncidentControl[] {
+  const lifecycle = customAgentGovernanceLifecycle(agent)
   return [
     {
       kind: 'pause_agent',
-      label: agent.enabled ? 'Disable custom agent' : 'Custom agent already disabled',
-      available: agent.enabled,
+      label: lifecycle === 'active' ? 'Disable custom agent' : lifecycle === 'paused' ? 'Custom agent already disabled' : 'Custom agent not approved',
+      available: lifecycle === 'active',
       requiresConfirmation: false,
-      reason: agent.enabled ? null : 'The agent is already paused.',
+      reason: lifecycle === 'active'
+        ? null
+        : lifecycle === 'paused'
+          ? 'The agent is already paused.'
+          : 'Only active custom agents can be paused.',
     },
     {
       kind: 'retire_agent',
@@ -277,16 +288,16 @@ function buildCustomAgentSubject(
   return {
     schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
     subjectKind: 'agent',
-    subjectId: customAgentSubjectId(agent),
+    subjectId: customAgentGovernanceSubjectId(agent),
     name: agent.name,
     displayName: agent.name,
     description: agent.description,
     owner: LOCAL_OWNER,
-    lifecycle: customAgentLifecycle(agent),
+    lifecycle: customAgentGovernanceLifecycle(agent),
     scope: customAgentScope(agent),
     memoryBoundary: {
       kind: 'agent',
-      id: customAgentSubjectId(agent),
+      id: customAgentGovernanceSubjectId(agent),
       label: 'Agent-scoped OpenCode session context; no shared organization memory store is configured.',
     },
     evalSuiteId: null,

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -9,6 +9,11 @@ import { listCapabilityRiskMetadata } from '../operation-capability-risk.ts'
 import { getGovernanceRegistry } from '../governance-registry.ts'
 import { exportGovernanceAuditEvents } from '../governance-audit-export.ts'
 import { listGovernanceAuditEvents } from '../governance-audit-store.ts'
+import {
+  pauseGovernanceAgent,
+  retireGovernanceAgent,
+  type GovernanceAgentIncidentControlRequest,
+} from '../governance-agent-controls.ts'
 
 function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is Parameters<typeof listGovernanceAuditEvents>[0] {
   if (value === undefined) return
@@ -36,6 +41,53 @@ function assertOptionalGovernanceAuditExportOptions(value: unknown): asserts val
   if (options.format !== undefined && options.format !== 'ndjson' && options.format !== 'otel-json') {
     throw new Error('Governance audit export format is invalid.')
   }
+}
+
+function assertAgentIncidentControlRequest(value: unknown): asserts value is GovernanceAgentIncidentControlRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Agent incident request must be an object.')
+  }
+  const request = value as Record<string, unknown>
+  if (typeof request.subjectId !== 'string' || request.subjectId.trim().length === 0) {
+    throw new Error('Agent incident subject id is required.')
+  }
+  if (request.reason !== undefined && request.reason !== null && typeof request.reason !== 'string') {
+    throw new Error('Agent incident reason must be a string.')
+  }
+  if (request.context !== undefined) {
+    if (!request.context || typeof request.context !== 'object' || Array.isArray(request.context)) {
+      throw new Error('Agent incident context must be an object.')
+    }
+    const context = request.context as Record<string, unknown>
+    if (context.sessionId !== undefined && context.sessionId !== null && typeof context.sessionId !== 'string') {
+      throw new Error('Agent incident context session id must be a string.')
+    }
+    if (context.directory !== undefined && context.directory !== null && typeof context.directory !== 'string') {
+      throw new Error('Agent incident context directory must be a string.')
+    }
+  }
+}
+
+function resolveAgentIncidentControlRequest(
+  context: IpcHandlerContext,
+  request: GovernanceAgentIncidentControlRequest,
+): GovernanceAgentIncidentControlRequest {
+  if (!request.context) return request
+  const hasContext = Boolean(request.context.sessionId?.trim()) || Boolean(request.context.directory?.trim())
+  if (!hasContext) return { ...request, context: undefined }
+  const directory = context.resolveContextDirectory(request.context)
+  if (!directory) {
+    throw new Error('Agent incident context requires an active project directory.')
+  }
+  return {
+    ...request,
+    context: { directory },
+  }
+}
+
+async function rebootRuntimeForIncidentControl() {
+  const { rebootRuntime } = await import('../index.ts')
+  await rebootRuntime()
 }
 
 export function registerOperationHandlers(context: IpcHandlerContext) {
@@ -69,5 +121,21 @@ export function registerOperationHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('operations:export-governance-audit', async (_event, options?: unknown) => {
     assertOptionalGovernanceAuditExportOptions(options)
     return exportGovernanceAuditEvents(options)
+  })
+
+  context.ipcMain.handle('operations:pause-agent', async (_event, request: unknown) => {
+    assertAgentIncidentControlRequest(request)
+    return pauseGovernanceAgent(resolveAgentIncidentControlRequest(context, request), {
+      buildCustomAgentPermission: context.buildCustomAgentPermission,
+      rebootRuntime: rebootRuntimeForIncidentControl,
+    })
+  })
+
+  context.ipcMain.handle('operations:retire-agent', async (_event, request: unknown) => {
+    assertAgentIncidentControlRequest(request)
+    return retireGovernanceAgent(resolveAgentIncidentControlRequest(context, request), {
+      buildCustomAgentPermission: context.buildCustomAgentPermission,
+      rebootRuntime: rebootRuntimeForIncidentControl,
+    })
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -84,6 +84,8 @@ const PRELOAD_INVOKE_CHANNELS = [
   'operations:governance-registry',
   'operations:governance-audit-events',
   'operations:export-governance-audit',
+  'operations:pause-agent',
+  'operations:retire-agent',
   'channels:list',
   'channels:definitions',
   'channels:inbound-items',
@@ -325,6 +327,8 @@ const api: CoworkAPI = {
     governanceRegistry: () => invoke('operations:governance-registry'),
     governanceAuditEvents: (options) => invoke('operations:governance-audit-events', options),
     exportGovernanceAudit: (options) => invoke('operations:export-governance-audit', options),
+    pauseAgent: (request) => invoke('operations:pause-agent', request),
+    retireAgent: (request) => invoke('operations:retire-agent', request),
   },
   channels: {
     list: () => invoke('channels:list'),

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { COWORK_SOP_SCHEMA_VERSION } from '@open-cowork/shared'
@@ -341,7 +341,7 @@ describe('AutomationsPage', () => {
     expect(api.list).toHaveBeenCalledTimes(1)
     expect(api.automationUpdated).toHaveBeenCalledTimes(1)
 
-    await user.click(screen.getByRole('button', { name: /Weekly report/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Weekly report/ }))
     expect(await screen.findByRole('dialog', { name: 'Weekly report' })).toBeInTheDocument()
     expect(api.get).toHaveBeenCalledWith('auto-1')
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -117,15 +117,19 @@ map without changing OpenCode execution:
 - incident-control metadata that distinguishes actions available today from
   controls planned in later governance slices
 
-The first active incident controls are crew lifecycle controls. Admin surfaces
-can pause or retire a crew through the `crews` IPC namespace; paused or retired
-crews keep their history and registry entry but cannot start new runs. Each
-control writes a durable governance audit event with actor, action,
-before/after lifecycle state, subject id, and bounded metadata. Admin surfaces
-can query those events through the operations namespace. The export path emits
-a typed audit stream as deterministic NDJSON or OpenTelemetry-shaped JSON and
-covers governance incidents, crew traces, approvals, policy decisions, tool-call
-trace records, channel/automation deliveries, and outcome evaluations.
+The first active incident controls are crew lifecycle controls and custom-agent
+pause/retire controls. Admin surfaces can pause or retire a crew through the
+`crews` IPC namespace; paused or retired crews keep their history and registry
+entry but cannot start new runs. Admin surfaces can pause or retire a custom
+agent through the operations namespace; pausing disables the generated OpenCode
+agent config, while retiring removes the custom agent from user-managed runtime
+content. Each control writes a durable governance audit event with actor,
+action, before/after lifecycle state, subject id, and bounded metadata. Admin
+surfaces can query those events through the operations namespace. The export
+path emits a typed audit stream as deterministic NDJSON or
+OpenTelemetry-shaped JSON and covers governance incidents, crew traces,
+approvals, policy decisions, tool-call trace records, channel/automation
+deliveries, and outcome evaluations.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -148,6 +148,14 @@ export interface GovernanceAuditExportPayload {
   body: string
 }
 
+export interface GovernanceAgentIncidentControlRequest {
+  subjectId: string
+  reason?: string | null
+  context?: {
+    directory?: string | null
+  }
+}
+
 export type GovernanceAuditExportRecordPayload =
   | GovernanceAuditEvent
   | CoworkTraceEvent

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -131,6 +131,7 @@ import type {
   DreamRun,
 } from './improvements.js'
 import type {
+  GovernanceAgentIncidentControlRequest,
   GovernanceAuditEvent,
   GovernanceAuditExportFormat,
   GovernanceAuditExportPayload,
@@ -336,6 +337,8 @@ export interface CoworkAPI {
       limit?: number
       format?: GovernanceAuditExportFormat
     }) => Promise<GovernanceAuditExportPayload>
+    pauseAgent: (request: GovernanceAgentIncidentControlRequest) => Promise<boolean>
+    retireAgent: (request: GovernanceAgentIncidentControlRequest) => Promise<boolean>
   }
   channels: {
     list: () => Promise<ChannelListPayload>

--- a/tests/governance-agent-controls.test.ts
+++ b/tests/governance-agent-controls.test.ts
@@ -1,0 +1,156 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { CustomAgentConfig } from '../packages/shared/src/index.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  pauseGovernanceAgent,
+  retireGovernanceAgent,
+} from '../apps/desktop/src/main/governance-agent-controls.ts'
+import { customAgentGovernanceSubjectId } from '../apps/desktop/src/main/governance-registry.ts'
+import {
+  clearGovernanceAuditStoreCache,
+  listGovernanceAuditEvents,
+} from '../apps/desktop/src/main/governance-audit-store.ts'
+import {
+  listCustomAgents,
+  saveCustomAgent,
+} from '../apps/desktop/src/main/native-customizations.ts'
+import { getMachineAgentsDir } from '../apps/desktop/src/main/runtime-paths.ts'
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-agent-controls-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+function withAgentControlStore(name: string, fn: () => Promise<void>) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  return (async () => {
+    try {
+      process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+      clearConfigCaches()
+      clearGovernanceAuditStoreCache()
+      await fn()
+    } finally {
+      clearGovernanceAuditStoreCache()
+      clearConfigCaches()
+      if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+      else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+      rmSync(userDataDir, { recursive: true, force: true })
+    }
+  })()
+}
+
+function customAgent(overrides: Partial<CustomAgentConfig> = {}): CustomAgentConfig {
+  return {
+    scope: 'machine',
+    directory: null,
+    name: 'research-agent',
+    description: 'Researches operating questions.',
+    instructions: 'Use available context and produce a concise answer.',
+    skillNames: [],
+    toolIds: [],
+    enabled: true,
+    color: 'accent',
+    ...overrides,
+  }
+}
+
+test('pauseGovernanceAgent disables a custom agent, audits the lifecycle change, and reboots runtime', async () => withAgentControlStore('pause', async () => {
+  const agent = customAgent()
+  saveCustomAgent(agent, {})
+  const subjectId = customAgentGovernanceSubjectId(agent)
+  let permissionAgentEnabled: boolean | null = null
+  let rebootCount = 0
+
+  const result = await pauseGovernanceAgent({
+    subjectId,
+    reason: 'Security incident.',
+  }, {
+    buildCustomAgentPermission: async (updated) => {
+      permissionAgentEnabled = updated.enabled
+      return {}
+    },
+    rebootRuntime: async () => {
+      rebootCount += 1
+    },
+  })
+
+  assert.equal(result, true)
+  assert.equal(permissionAgentEnabled, false)
+  assert.equal(rebootCount, 1)
+  assert.equal(listCustomAgents().find((entry) => entry.name === agent.name)?.enabled, false)
+
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'agent', subjectId })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.action, 'pause_agent')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'active')
+  assert.equal(auditEvents[0]?.afterLifecycle, 'paused')
+  assert.equal(auditEvents[0]?.reason, 'Security incident.')
+}))
+
+test('retireGovernanceAgent removes a custom agent, audits retirement, and reboots runtime', async () => withAgentControlStore('retire', async () => {
+  const agent = customAgent({ name: 'retire-agent', enabled: false })
+  saveCustomAgent(agent, {})
+  const subjectId = customAgentGovernanceSubjectId(agent)
+  let rebootCount = 0
+
+  const result = await retireGovernanceAgent({
+    subjectId,
+    reason: 'Owner offboarded.',
+  }, {
+    buildCustomAgentPermission: async () => ({}),
+    rebootRuntime: async () => {
+      rebootCount += 1
+    },
+  })
+
+  assert.equal(result, true)
+  assert.equal(rebootCount, 1)
+  assert.equal(listCustomAgents().some((entry) => entry.name === agent.name), false)
+
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'agent', subjectId })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.action, 'retire_agent')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'paused')
+  assert.equal(auditEvents[0]?.afterLifecycle, 'retired')
+  assert.equal(auditEvents[0]?.reason, 'Owner offboarded.')
+}))
+
+test('retireGovernanceAgent removes invalid legacy custom agent filenames surfaced in the registry', async () => withAgentControlStore('retire-invalid', async () => {
+  const agentsDir = getMachineAgentsDir()
+  mkdirSync(agentsDir, { recursive: true })
+  const legacyAgentPath = join(agentsDir, 'Legacy Agent.md')
+  writeFileSync(legacyAgentPath, `---
+description: "Legacy manual file"
+mode: subagent
+permission: {}
+---
+
+Use available context.
+`)
+  const subjectId = customAgentGovernanceSubjectId({ name: 'legacy agent', scope: 'machine', directory: null })
+  let rebootCount = 0
+
+  const result = await retireGovernanceAgent({
+    subjectId,
+    reason: 'Remove invalid legacy agent.',
+  }, {
+    buildCustomAgentPermission: async () => ({}),
+    rebootRuntime: async () => {
+      rebootCount += 1
+    },
+  })
+
+  assert.equal(result, true)
+  assert.equal(rebootCount, 1)
+  assert.equal(existsSync(legacyAgentPath), false)
+
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'agent', subjectId })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.action, 'retire_agent')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'draft')
+  assert.equal(auditEvents[0]?.afterLifecycle, 'retired')
+}))

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -224,4 +224,6 @@ test('invalid custom agents stay visible as draft governance records', () => {
   assert.equal(agent?.name, 'broken-agent')
   assert.equal(agent?.lifecycle, 'draft')
   assert.equal(agent?.offboardingPath, 'Disable or remove the project custom agent from the Agents surface.')
+  assert.equal(agent?.incidentControls.some((control) => control.kind === 'pause_agent' && control.available), false)
+  assert.equal(agent?.incidentControls.some((control) => control.kind === 'retire_agent' && control.available), true)
 })

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -224,6 +224,38 @@ test('operations:export-governance-audit rejects malformed export formats at the
   )
 })
 
+test('operations:pause-agent rejects malformed incident-control requests at the IPC boundary', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerOperationHandlers(context)
+  const handler = handlers.get('operations:pause-agent')
+
+  assert.ok(handler, 'expected operations:pause-agent handler to be registered')
+  await assert.rejects(
+    () => handler({}, { subjectId: 'agent:machine:test', context: { directory: 123 } }),
+    /Agent incident context directory must be a string/,
+  )
+})
+
+test('operations:pause-agent resolves incident-control context through granted project directories', async () => {
+  const { context, handlers } = createBaseContext()
+  let requestedDirectory: string | null | undefined
+  context.resolveContextDirectory = (options) => {
+    requestedDirectory = options?.directory
+    return null
+  }
+
+  registerOperationHandlers(context)
+  const handler = handlers.get('operations:pause-agent')
+
+  assert.ok(handler, 'expected operations:pause-agent handler to be registered')
+  await assert.rejects(
+    () => handler({}, { subjectId: 'agent:project:abc123:legacy_agent', context: { directory: '/ungranted/project' } }),
+    /Agent incident context requires an active project directory/,
+  )
+  assert.equal(requestedDirectory, '/ungranted/project')
+})
+
 test('session:prompt clears pending prompt echo when dispatch fails', async () => {
   const { context, handlers } = createBaseContext()
   let promptCalled = false

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -130,6 +130,8 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('operations:governance-registry'), true)
   assert.equal(handlers.has('operations:governance-audit-events'), true)
   assert.equal(handlers.has('operations:export-governance-audit'), true)
+  assert.equal(handlers.has('operations:pause-agent'), true)
+  assert.equal(handlers.has('operations:retire-agent'), true)
   assert.equal(handlers.has('channels:list'), true)
   assert.equal(handlers.has('channels:definitions'), true)
   assert.equal(handlers.has('channels:inbound-items'), true)

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -240,17 +240,23 @@ test('custom agent builder selections round-trip through managed sidecar metadat
   }
 })
 
-test('removeCustomAgent rejects path-like names before deleting files', () => {
+test('removeCustomAgent removes contained legacy names while rejecting path-like names', () => {
   const projectRoot = testTempDir('opencowork-native-agent-remove-policy-')
   const coworkDir = join(projectRoot, '.opencowork')
-  mkdirSync(coworkDir, { recursive: true })
+  const agentsDir = join(coworkDir, 'agents')
+  mkdirSync(agentsDir, { recursive: true })
   const markerPath = join(coworkDir, 'outside.md')
+  const legacyAgentPath = join(agentsDir, 'Legacy Agent.md')
   writeFileSync(markerPath, 'keep')
+  writeFileSync(legacyAgentPath, 'remove')
 
   try {
+    removeCustomAgent({ scope: 'project', directory: projectRoot, name: 'Legacy Agent' })
+    assert.equal(existsSync(legacyAgentPath), false)
+
     assert.throws(() => {
       removeCustomAgent({ scope: 'project', directory: projectRoot, name: '../outside' })
-    }, /Custom agent id must use 1-64 lowercase letters/)
+    }, /Custom agent id must be a single managed file name/)
 
     assert.equal(existsSync(markerPath), true)
   } finally {


### PR DESCRIPTION
## Summary
- add governance incident controls to pause or retire custom agents by registry subject id
- wire operations IPC/preload/shared API for agent pause/retire and reboot runtime after changes
- audit agent lifecycle controls and tighten registry control availability for draft/paused agents

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-agent-controls.test.ts tests/governance-registry.test.ts tests/governance-audit-store.test.ts tests/ipc-handler-registration.test.ts tests/ipc-handler-behavior.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:renderer
- pnpm docs:build
- git diff --check