### PR TITLE
[codex] extend governance dependency map

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -2,8 +2,10 @@ import { createHash } from 'node:crypto'
 import type {
   AgentCatalog,
   BuiltInAgentDetail,
+  ChannelDefinition,
   CrewListPayload,
   CustomAgentSummary as SharedCustomAgentSummary,
+  CustomMcpConfig,
   GovernanceDependency,
   GovernanceDependencyIndexEntry,
   GovernanceDependencyKind,
@@ -14,18 +16,31 @@ import type {
   GovernanceRegistrySubject,
   GovernanceScope,
   RuntimeContextOptions,
+  SopListPayload,
 } from '@open-cowork/shared'
 import { COWORK_GOVERNANCE_SCHEMA_VERSION } from '@open-cowork/shared'
 
 import { listBuiltInAgentDetails } from './built-in-agent-details.ts'
+import {
+  getConfiguredMcpsFromConfig,
+  getConfiguredToolsFromConfig,
+  getConfiguredToolPatterns,
+} from './config-loader.ts'
+import type { BundleMcp, ConfiguredTool } from './config-types.ts'
 import { getCustomAgentCatalog, getCustomAgentSummaries } from './custom-agents.ts'
 import { listCrewCatalog } from './crew-service.ts'
+import { listChannelDefinitions } from './channel-store.ts'
+import { listSopDefinitions } from './sop-service.ts'
+import { listCustomMcps } from './native-customizations.ts'
 
 export interface GovernanceRegistryBuildInput {
   builtinAgents: BuiltInAgentDetail[]
   customAgents: GovernanceCustomAgentSummary[]
   agentCatalog: AgentCatalog
   crewCatalog: CrewListPayload
+  sopCatalog?: SopListPayload
+  channels?: ChannelDefinition[]
+  toolCredentialDependencies?: GovernanceToolCredentialDependency[]
   generatedAt?: string
 }
 
@@ -37,6 +52,11 @@ export type GovernanceCustomAgentIdentity = {
   scope?: 'machine' | 'project' | null
   directory?: string | null
   name: string
+}
+
+export type GovernanceToolCredentialDependency = {
+  toolId: string
+  dependency: GovernanceDependency
 }
 
 const LOCAL_OWNER = {
@@ -77,6 +97,10 @@ function crewSubjectId(crewId: string): string {
 
 function dependencyKey(dependency: Pick<GovernanceDependency, 'kind' | 'id'>): string {
   return `${dependency.kind}:${dependency.id}`
+}
+
+function agentNameKey(name: string | null | undefined): string {
+  return name?.trim().toLowerCase() || ''
 }
 
 function sortDependencies(dependencies: GovernanceDependency[]): GovernanceDependency[] {
@@ -127,24 +151,125 @@ function createSkillToolMap(catalog: AgentCatalog): Map<string, string[]> {
   return new Map(catalog.skills.map((skill) => [skill.name, skill.toolIds || []]))
 }
 
+function createToolCredentialMap(entries: GovernanceToolCredentialDependency[] = []): Map<string, GovernanceDependency[]> {
+  const map = new Map<string, GovernanceDependency[]>()
+  for (const entry of entries) {
+    if (!entry.toolId || !entry.dependency.id) continue
+    const current = map.get(entry.toolId) || []
+    current.push(entry.dependency)
+    map.set(entry.toolId, current)
+  }
+  return map
+}
+
 function collectAgentDependencies(input: {
   toolIds: string[]
   skillNames: string[]
   toolLabels: Map<string, string>
   skillLabels: Map<string, string>
   skillTools: Map<string, string[]>
+  toolCredentials: Map<string, GovernanceDependency[]>
+  supplemental?: GovernanceDependency[]
 }): GovernanceDependency[] {
   const dependencies = new Map<string, GovernanceDependency>()
   for (const toolId of input.toolIds) {
     addDependency(dependencies, createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'direct'))
+    for (const credential of input.toolCredentials.get(toolId) || []) {
+      addDependency(dependencies, { ...credential, source: 'direct' })
+    }
   }
   for (const skillName of input.skillNames) {
     addDependency(dependencies, createDependency('skill', skillName, input.skillLabels.get(skillName) || skillName, 'direct'))
     for (const toolId of input.skillTools.get(skillName) || []) {
       addDependency(dependencies, createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'transitive'))
+      for (const credential of input.toolCredentials.get(toolId) || []) {
+        addDependency(dependencies, { ...credential, source: 'transitive' })
+      }
     }
   }
+  for (const dependency of input.supplemental || []) {
+    addDependency(dependencies, dependency)
+  }
   return sortDependencies([...dependencies.values()])
+}
+
+function namespaceFromPattern(pattern: string): string | null {
+  const match = pattern.match(/^mcp__([a-z0-9][a-z0-9_-]*)__[^/]+$/i)
+  return match?.[1] || null
+}
+
+function namespaceForConfiguredTool(tool: ConfiguredTool): string | null {
+  if (tool.namespace) return tool.namespace
+  for (const pattern of getConfiguredToolPatterns(tool)) {
+    const namespace = namespaceFromPattern(pattern)
+    if (namespace) return namespace
+  }
+  return null
+}
+
+function builtInMcpCredentialDependency(mcp: BundleMcp): GovernanceDependency | null {
+  const credentialFields = mcp.credentials || []
+  const hasCredentialSurface = mcp.authMode !== 'none'
+    || credentialFields.length > 0
+    || Boolean(mcp.googleAuth)
+    || Boolean(mcp.envSettings?.length)
+    || Boolean(mcp.headerSettings?.length)
+  if (!hasCredentialSurface) return null
+  return createDependency(
+    'credential',
+    `integration:${mcp.name}`,
+    `${mcp.name} integration credentials`,
+    'direct',
+    mcp.authMode !== 'none'
+      || credentialFields.some((credential) => credential.required !== false)
+      || Boolean(mcp.googleAuth)
+      || Boolean(mcp.envSettings?.length)
+      || Boolean(mcp.headerSettings?.length),
+  )
+}
+
+function customMcpCredentialDependency(mcp: CustomMcpConfig): GovernanceDependency | null {
+  const hasCredentialSurface = Boolean(mcp.googleAuth)
+    || Object.keys(mcp.env || {}).length > 0
+    || Object.keys(mcp.headers || {}).length > 0
+  if (!hasCredentialSurface) return null
+  return createDependency(
+    'credential',
+    `custom-mcp:${mcp.scope}:${mcp.name}`,
+    `${mcp.label || mcp.name} custom MCP credentials`,
+    'direct',
+    true,
+  )
+}
+
+export function buildGovernanceToolCredentialDependencies(input: {
+  tools: ConfiguredTool[]
+  mcps: BundleMcp[]
+  customMcps?: CustomMcpConfig[]
+}): GovernanceToolCredentialDependency[] {
+  const builtinMcpsByName = new Map(input.mcps.map((mcp) => [mcp.name, mcp]))
+  const customMcpsByName = new Map((input.customMcps || []).map((mcp) => [mcp.name, mcp]))
+  const entries: GovernanceToolCredentialDependency[] = []
+  for (const tool of input.tools) {
+    const namespace = namespaceForConfiguredTool(tool)
+    if (!namespace) continue
+    const builtin = builtinMcpsByName.get(namespace)
+    const custom = customMcpsByName.get(namespace)
+    const dependency = builtin
+      ? builtInMcpCredentialDependency(builtin)
+      : custom
+        ? customMcpCredentialDependency(custom)
+        : null
+    if (dependency) entries.push({ toolId: tool.id, dependency })
+  }
+  for (const custom of input.customMcps || []) {
+    const dependency = customMcpCredentialDependency(custom)
+    if (dependency) entries.push({ toolId: custom.name, dependency })
+  }
+  return entries.sort((left, right) => (
+    left.toolId.localeCompare(right.toolId)
+    || left.dependency.id.localeCompare(right.dependency.id)
+  ))
 }
 
 export function customAgentGovernanceLifecycle(agent: Pick<GovernanceCustomAgentSummary, 'enabled' | 'valid'>): GovernanceLifecycleState {
@@ -247,6 +372,56 @@ function crewControls(lifecycle: GovernanceLifecycleState): GovernanceIncidentCo
   ]
 }
 
+function createAgentSupplementalDependencyMap(input: {
+  sops?: SopListPayload
+  channels?: ChannelDefinition[]
+}): Map<string, GovernanceDependency[]> {
+  const dependenciesByAgent = new Map<string, GovernanceDependency[]>()
+  const activeSops = input.sops?.sops || []
+  const channelsBySop = new Map<string, ChannelDefinition[]>()
+  for (const channel of input.channels || []) {
+    if (channel.route.activationMode !== 'run_sop' || !channel.route.targetSopId) continue
+    const channels = channelsBySop.get(channel.route.targetSopId) || []
+    channels.push(channel)
+    channelsBySop.set(channel.route.targetSopId, channels)
+  }
+
+  const addForAgent = (agentName: string | null | undefined, dependency: GovernanceDependency) => {
+    const normalized = agentNameKey(agentName)
+    if (!normalized) return
+    const current = dependenciesByAgent.get(normalized) || []
+    current.push(dependency)
+    dependenciesByAgent.set(normalized, current)
+  }
+
+  for (const sop of activeSops) {
+    if (!sop.activeVersion || sop.definition.status === 'retired') continue
+    const sopDependency = createDependency('sop', sop.definition.id, sop.definition.name, 'direct', false)
+    const channelDependencies = (channelsBySop.get(sop.definition.id) || []).map((channel) => (
+      createDependency('channel', channel.id, channel.name, 'transitive', false)
+    ))
+    for (const step of sop.activeVersion.workflow) {
+      addForAgent(step.agentName, sopDependency)
+      for (const channelDependency of channelDependencies) {
+        addForAgent(step.agentName, channelDependency)
+      }
+    }
+  }
+
+  return dependenciesByAgent
+}
+
+function createCrewChannelDependencyMap(channels: ChannelDefinition[] = []): Map<string, GovernanceDependency[]> {
+  const dependenciesByCrew = new Map<string, GovernanceDependency[]>()
+  for (const channel of channels) {
+    if (channel.route.activationMode !== 'run_crew' || !channel.route.targetCrewId) continue
+    const current = dependenciesByCrew.get(channel.route.targetCrewId) || []
+    current.push(createDependency('channel', channel.id, channel.name, 'direct', false))
+    dependenciesByCrew.set(channel.route.targetCrewId, current)
+  }
+  return dependenciesByCrew
+}
+
 function buildBuiltInAgentSubject(
   agent: BuiltInAgentDetail,
   dependencies: GovernanceDependency[],
@@ -312,12 +487,13 @@ function buildCustomAgentSubject(
 function buildCrewSubject(input: {
   crew: CrewListPayload['crews'][number]
   agentSubjectsByName: Map<string, GovernanceRegistrySubject>
+  supplementalDependencies?: GovernanceDependency[]
 }): GovernanceRegistrySubject {
   const { definition, activeVersion } = input.crew
   const dependencies = new Map<string, GovernanceDependency>()
   for (const member of activeVersion?.members || []) {
     addDependency(dependencies, createDependency('agent', member.agentName, member.displayName || member.agentName, 'direct'))
-    const agentSubject = input.agentSubjectsByName.get(member.agentName)
+    const agentSubject = input.agentSubjectsByName.get(agentNameKey(member.agentName))
     if (!agentSubject) continue
     for (const dependency of agentSubject.dependencies) {
       if (dependency.kind !== 'tool' && dependency.kind !== 'skill' && dependency.kind !== 'credential') continue
@@ -335,6 +511,9 @@ function buildCrewSubject(input: {
   }
   if (activeVersion?.evalSuiteId) {
     addDependency(dependencies, createDependency('eval_suite', activeVersion.evalSuiteId, activeVersion.evalSuiteId, 'direct'))
+  }
+  for (const dependency of input.supplementalDependencies || []) {
+    addDependency(dependencies, dependency)
   }
 
   const scope: GovernanceScope = activeVersion?.workspaceProfileId
@@ -407,6 +586,12 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
   const toolLabels = createToolLabelMap(input.agentCatalog)
   const skillLabels = createSkillLabelMap(input.agentCatalog)
   const skillTools = createSkillToolMap(input.agentCatalog)
+  const toolCredentials = createToolCredentialMap(input.toolCredentialDependencies)
+  const agentSupplementalDependencies = createAgentSupplementalDependencyMap({
+    sops: input.sopCatalog,
+    channels: input.channels,
+  })
+  const crewChannelDependencies = createCrewChannelDependencyMap(input.channels)
 
   const agentSubjects = [
     ...input.builtinAgents.map((agent) => buildBuiltInAgentSubject(agent, collectAgentDependencies({
@@ -415,6 +600,8 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
       toolLabels,
       skillLabels,
       skillTools,
+      toolCredentials,
+      supplemental: agentSupplementalDependencies.get(agentNameKey(agent.name)),
     }))),
     ...input.customAgents.map((agent) => buildCustomAgentSubject(agent, collectAgentDependencies({
       toolIds: agent.toolIds,
@@ -422,17 +609,20 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
       toolLabels,
       skillLabels,
       skillTools,
+      toolCredentials,
+      supplemental: agentSupplementalDependencies.get(agentNameKey(agent.name)),
     }))),
   ]
 
   const agentSubjectsByName = new Map<string, GovernanceRegistrySubject>()
   for (const subject of agentSubjects) {
-    agentSubjectsByName.set(subject.name, subject)
+    agentSubjectsByName.set(agentNameKey(subject.name), subject)
   }
 
   const crewSubjects = input.crewCatalog.crews.map((crew) => buildCrewSubject({
     crew,
     agentSubjectsByName,
+    supplementalDependencies: crewChannelDependencies.get(crew.definition.id),
   }))
   const subjects = [...agentSubjects, ...crewSubjects].sort((left, right) => (
     left.subjectKind.localeCompare(right.subjectKind)
@@ -452,10 +642,18 @@ export async function getGovernanceRegistry(options?: RuntimeContextOptions): Pr
     getCustomAgentCatalog(options),
     getCustomAgentSummaries(options),
   ])
+  const configuredTools = getConfiguredToolsFromConfig()
   return buildGovernanceRegistry({
     builtinAgents: listBuiltInAgentDetails(),
     customAgents,
     agentCatalog,
     crewCatalog: listCrewCatalog(),
+    sopCatalog: listSopDefinitions(),
+    channels: listChannelDefinitions(),
+    toolCredentialDependencies: buildGovernanceToolCredentialDependencies({
+      tools: configuredTools,
+      mcps: getConfiguredMcpsFromConfig(),
+      customMcps: listCustomMcps(options),
+    }),
   })
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -110,10 +110,11 @@ map without changing OpenCode execution:
 
 - agents and crews with owner, lifecycle, scope, memory boundary, and
   offboarding path
-- direct dependencies on member agents, tools, skills, workspace profiles, and
-  eval suites
-- transitive dependencies such as skill-linked tools and crew member
-  capabilities
+- direct dependencies on member agents, tools, skills, workspace profiles,
+  SOPs, channel routes, integration credentials, and eval suites
+- transitive dependencies such as skill-linked tools, integration credentials
+  needed by those tools, SOP/channel exposure for workflow agents, and crew
+  member capabilities
 - incident-control metadata that distinguishes actions available today from
   controls planned in later governance slices
 

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -3,10 +3,15 @@ import assert from 'node:assert/strict'
 import type {
   AgentCatalog,
   BuiltInAgentDetail,
+  ChannelDefinition,
   CrewListPayload,
   CustomAgentSummary,
+  SopListPayload,
 } from '@open-cowork/shared'
-import { buildGovernanceRegistry } from '../apps/desktop/src/main/governance-registry.ts'
+import {
+  buildGovernanceRegistry,
+  buildGovernanceToolCredentialDependencies,
+} from '../apps/desktop/src/main/governance-registry.ts'
 
 const generatedAt = '2026-05-11T12:00:00.000Z'
 
@@ -134,6 +139,106 @@ function crewCatalog(overrides: Partial<CrewListPayload['crews'][number]> = {}):
   }
 }
 
+function sopCatalog(agentName = 'data-analyst'): SopListPayload {
+  return {
+    sops: [
+      {
+        definition: {
+          schemaVersion: 1,
+          id: 'sop-weekly-report',
+          name: 'Weekly report SOP',
+          description: 'Prepare weekly analytics.',
+          status: 'active',
+          activeVersionId: 'sop-version-1',
+          sourceAutomationId: null,
+          createdAt: generatedAt,
+          updatedAt: generatedAt,
+        },
+        activeVersion: {
+          schemaVersion: 1,
+          id: 'sop-version-1',
+          sopId: 'sop-weekly-report',
+          version: 1,
+          sourceAutomationId: null,
+          sourceRunId: null,
+          triggerTypes: ['manual', 'webhook'],
+          requiredInputs: [],
+          workflow: [
+            {
+              schemaVersion: 1,
+              id: 'execute',
+              kind: 'execute',
+              title: 'Analyze the numbers',
+              agentName,
+              approvalRequired: true,
+            },
+          ],
+          approvalPolicy: {
+            schemaVersion: 1,
+            reviewFirst: true,
+            approvalBoundary: 'Review before delivery.',
+          },
+          retryPolicy: {
+            maxRetries: 2,
+            baseDelayMinutes: 1,
+            maxDelayMinutes: 5,
+          },
+          runPolicy: {
+            maxRunDurationMinutes: 30,
+            dailyRunCap: 5,
+          },
+          deliveryPolicy: {
+            schemaVersion: 1,
+            provider: 'in_app',
+            target: 'automation-inbox',
+            draftFirst: true,
+          },
+          outcomeRubricId: 'rubric-weekly-report',
+          createdAt: generatedAt,
+          createdBy: 'local-user',
+        },
+      },
+    ],
+  }
+}
+
+function channel(overrides: Partial<ChannelDefinition> = {}): ChannelDefinition {
+  return {
+    schemaVersion: 1,
+    id: 'channel-analytics',
+    provider: 'local_webhook',
+    name: 'Analytics webhook',
+    description: 'Inbound analytics requests.',
+    sourceKey: 'analytics',
+    enabled: true,
+    senderAllowlist: ['ops@example.com'],
+    allowedCapabilityIds: ['charts'],
+    route: {
+      schemaVersion: 1,
+      activationMode: 'run_sop',
+      targetSopId: 'sop-weekly-report',
+      targetCrewId: null,
+    },
+    workspaceProfileId: 'channel-sandbox',
+    createdAt: generatedAt,
+    updatedAt: generatedAt,
+    ...overrides,
+  }
+}
+
+function hasDependency(
+  subject: NonNullable<ReturnType<typeof buildGovernanceRegistry>['subjects'][number]>,
+  kind: string,
+  id: string,
+  source?: string,
+) {
+  return subject.dependencies.some((dependency) => (
+    dependency.kind === kind
+    && dependency.id === id
+    && (source === undefined || dependency.source === source)
+  ))
+}
+
 test('governance registry maps custom agent lifecycle, scope, and skill-linked tools', () => {
   const payload = buildGovernanceRegistry({
     builtinAgents: [builtInAgent()],
@@ -162,6 +267,139 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
 
   const chartsIndex = payload.dependencyIndex.find((entry) => entry.dependency.kind === 'tool' && entry.dependency.id === 'charts')
   assert.deepEqual(chartsIndex?.subjectIds, [agent.subjectId])
+})
+
+test('governance registry exposes credential, SOP, and channel dependencies without secret values', () => {
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [builtInAgent()],
+    customAgents: [customAgent()],
+    agentCatalog: catalog(),
+    crewCatalog: crewCatalog(),
+    sopCatalog: sopCatalog(),
+    channels: [
+      channel(),
+      channel({
+        id: 'channel-crew',
+        name: 'Crew webhook',
+        route: {
+          schemaVersion: 1,
+          activationMode: 'run_crew',
+          targetSopId: null,
+          targetCrewId: 'crew-analytics',
+        },
+      }),
+    ],
+    toolCredentialDependencies: [
+      {
+        toolId: 'filesystem',
+        dependency: {
+          kind: 'credential',
+          id: 'integration:filesystem',
+          label: 'Filesystem integration credentials',
+          source: 'direct',
+          required: true,
+        },
+      },
+    ],
+    generatedAt,
+  })
+
+  const agent = payload.subjects.find((subject) => subject.name === 'data-analyst')
+  assert.ok(agent)
+  assert.equal(hasDependency(agent, 'credential', 'integration:filesystem', 'direct'), true)
+  assert.equal(hasDependency(agent, 'sop', 'sop-weekly-report', 'direct'), true)
+  assert.equal(hasDependency(agent, 'channel', 'channel-analytics', 'transitive'), true)
+  assert.equal(agent.dependencies.some((dependency) => dependency.label.includes('secret')), false)
+
+  const crew = payload.subjects.find((subject) => subject.subjectKind === 'crew' && subject.name === 'crew-analytics')
+  assert.ok(crew)
+  assert.equal(hasDependency(crew, 'credential', 'integration:filesystem', 'transitive'), true)
+  assert.equal(hasDependency(crew, 'channel', 'channel-crew', 'direct'), true)
+
+  const credentialIndex = payload.dependencyIndex.find(
+    (entry) => entry.dependency.kind === 'credential' && entry.dependency.id === 'integration:filesystem',
+  )
+  assert.deepEqual(credentialIndex?.subjectIds.sort(), [
+    payload.subjects.find((subject) => subject.name === 'build')?.subjectId,
+    agent.subjectId,
+    crew.subjectId,
+  ].sort())
+})
+
+test('governance credential dependencies are derived from configured MCP credential surfaces', () => {
+  const entries = buildGovernanceToolCredentialDependencies({
+    tools: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        description: 'GitHub MCP.',
+        kind: 'mcp',
+        namespace: 'github',
+        patterns: ['mcp__github__*'],
+      },
+      {
+        id: 'charts',
+        name: 'Charts',
+        description: 'Charts MCP.',
+        kind: 'mcp',
+        namespace: 'charts',
+        patterns: ['mcp__charts__*'],
+      },
+    ],
+    mcps: [
+      {
+        name: 'github',
+        type: 'remote',
+        description: 'GitHub MCP.',
+        authMode: 'api_token',
+        url: 'https://example.com/mcp',
+        headerSettings: [{ header: 'Authorization', key: 'token', prefix: 'Bearer ' }],
+        credentials: [
+          {
+            key: 'token',
+            label: 'Token',
+            description: 'Personal access token.',
+            secret: true,
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'charts',
+        type: 'local',
+        description: 'Charts MCP.',
+        authMode: 'none',
+      },
+    ],
+  })
+
+  assert.deepEqual(entries.map((entry) => `${entry.toolId}:${entry.dependency.id}:${entry.dependency.required}`), [
+    'github:integration:github:true',
+  ])
+})
+
+test('governance registry matches SOP exposure to mixed-case configured agent names', () => {
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [
+      builtInAgent({
+        name: 'ReportAgent',
+        label: 'Report Agent',
+        nativeToolIds: [],
+        configuredToolIds: [],
+      }),
+    ],
+    customAgents: [],
+    agentCatalog: catalog(),
+    crewCatalog: { crews: [] },
+    sopCatalog: sopCatalog('reportagent'),
+    channels: [channel()],
+    generatedAt,
+  })
+
+  const agent = payload.subjects.find((subject) => subject.name === 'ReportAgent')
+  assert.ok(agent)
+  assert.equal(hasDependency(agent, 'sop', 'sop-weekly-report', 'direct'), true)
+  assert.equal(hasDependency(agent, 'channel', 'channel-analytics', 'transitive'), true)
 })
 
 test('governance registry projects crew member and transitive capability dependencies', () => {


### PR DESCRIPTION
## Summary
- extend the operations governance registry to include credential dependencies for MCP-backed tools without exposing secret values
- add SOP/channel exposure dependencies for workflow agents and channel-routed crews
- document the expanded control-plane inventory in operations docs

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts
- pnpm typecheck
- pnpm test
- pnpm lint
- uv run mkdocs build --strict
- git diff --check

Refs #250