### PR TITLE
[codex] add governed memory quarantine

### DIFF
--- a/apps/desktop/src/main/governance-audit-store.ts
+++ b/apps/desktop/src/main/governance-audit-store.ts
@@ -23,15 +23,16 @@ const MAX_METADATA_BYTES = 128 * 1024
 const DEFAULT_AUDIT_LIST_LIMIT = 500
 const AUDIT_KINDS = new Set<GovernanceAuditEventKind>(['incident_control'])
 const AUDIT_OUTCOMES = new Set<GovernanceAuditOutcome>(['succeeded', 'failed'])
-const SUBJECT_KINDS = new Set<GovernanceSubjectKind>(['agent', 'crew'])
+const SUBJECT_KINDS = new Set<GovernanceSubjectKind>(['agent', 'crew', 'memory'])
 const INCIDENT_ACTIONS = new Set<GovernanceIncidentControlKind>([
   'pause_agent',
   'retire_agent',
   'pause_crew',
   'retire_crew',
+  'quarantine_memory',
   'export_audit',
 ])
-const LIFECYCLE_STATES = new Set<GovernanceLifecycleState>(['draft', 'review', 'approved', 'active', 'paused', 'retired'])
+const LIFECYCLE_STATES = new Set<GovernanceLifecycleState>(['draft', 'review', 'approved', 'active', 'paused', 'retired', 'quarantined'])
 
 type DbRow = Record<string, unknown>
 

--- a/apps/desktop/src/main/governance-memory-controls.ts
+++ b/apps/desktop/src/main/governance-memory-controls.ts
@@ -1,0 +1,59 @@
+import type { GovernanceMemoryIncidentControlRequest } from '@open-cowork/shared'
+import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
+import {
+  getAgentMemoryEntry,
+  quarantineAgentMemoryEntry,
+} from './improvement-store.ts'
+
+const MAX_INCIDENT_REASON_BYTES = 16 * 1024
+
+function boundedMemoryId(value: unknown) {
+  if (typeof value !== 'string') throw new Error('Memory incident id must be a string.')
+  const memoryId = value.trim()
+  if (!memoryId) throw new Error('Memory incident id is required.')
+  if (Buffer.byteLength(memoryId, 'utf8') > 512) throw new Error('Memory incident id is too large.')
+  return memoryId
+}
+
+function boundedReason(value: unknown, fallback: string) {
+  if (value === undefined || value === null) return fallback
+  if (typeof value !== 'string') throw new Error('Memory incident reason must be a string.')
+  const reason = value.trim()
+  if (!reason) return fallback
+  if (Buffer.byteLength(reason, 'utf8') > MAX_INCIDENT_REASON_BYTES) {
+    throw new Error('Memory incident reason is too large.')
+  }
+  return reason
+}
+
+function memorySubjectId(memoryId: string) {
+  return `memory:${encodeURIComponent(memoryId)}`
+}
+
+export function quarantineGovernanceMemory(request: GovernanceMemoryIncidentControlRequest) {
+  const memoryId = boundedMemoryId(request.memoryId)
+  const entry = getAgentMemoryEntry(memoryId)
+  if (!entry) throw new Error(`No memory entry found for governance incident ${memoryId}.`)
+  if (entry.status === 'quarantined') throw new Error(`Memory ${memoryId} is already quarantined.`)
+  if (entry.status === 'archived') throw new Error(`Archived memory ${memoryId} cannot be quarantined.`)
+  if (entry.status !== 'approved') throw new Error(`Memory ${memoryId} cannot be quarantined from ${entry.status} state.`)
+
+  const reason = boundedReason(request.reason, 'Memory quarantined through governance incident control.')
+  const updated = quarantineAgentMemoryEntry(memoryId, 'local-user', reason)
+  recordGovernanceAuditEvent({
+    subjectKind: 'memory',
+    subjectId: memorySubjectId(memoryId),
+    action: 'quarantine_memory',
+    beforeLifecycle: 'approved',
+    afterLifecycle: 'quarantined',
+    reason,
+    metadata: {
+      memoryId,
+      scopeKind: entry.scopeKind,
+      scopeId: entry.scopeId,
+      privacy: entry.privacy,
+      sourceProposalId: entry.sourceProposalId,
+    },
+  })
+  return updated
+}

--- a/apps/desktop/src/main/improvement-store.ts
+++ b/apps/desktop/src/main/improvement-store.ts
@@ -25,6 +25,7 @@ import {
   type ImprovementDiagnosticsSummary,
   type ImprovementEvidenceKind,
   type ImprovementEvidenceRef,
+  type ImprovementMemoryStatusCounts,
   type ImprovementPolicyDiagnostics,
   type ImprovementProposal,
   type ImprovementProposalDraft,
@@ -87,7 +88,7 @@ const DEFAULT_REVIEW_QUEUE_LIMIT = 25
 const MAX_REVIEW_QUEUE_LIMIT = 100
 
 const MEMORY_SCOPE_KINDS = new Set<AgentMemoryScopeKind>(['machine', 'project', 'agent', 'crew'])
-const MEMORY_STATUSES = new Set<AgentMemoryStatus>(['proposed', 'approved', 'rejected', 'archived'])
+const MEMORY_STATUSES = new Set<AgentMemoryStatus>(['proposed', 'approved', 'rejected', 'archived', 'quarantined'])
 const PRIVACY_CLASSIFICATIONS = new Set<MemoryPrivacyClassification>(['public', 'internal', 'sensitive', 'restricted'])
 const EVIDENCE_KINDS = new Set<ImprovementEvidenceKind>(['run', 'artifact', 'eval', 'trace', 'thread', 'session', 'sop', 'crew'])
 const PROPOSAL_TARGET_TYPES = new Set<ImprovementProposalTargetType>(['memory', 'agent', 'skill', 'sop', 'crew', 'eval_case', 'routing', 'policy'])
@@ -112,6 +113,13 @@ function emptyImprovementStatusCounts(): ImprovementStatusCounts {
     approved: 0,
     rejected: 0,
     archived: 0,
+  }
+}
+
+function emptyImprovementMemoryStatusCounts(): ImprovementMemoryStatusCounts {
+  return {
+    ...emptyImprovementStatusCounts(),
+    quarantined: 0,
   }
 }
 
@@ -525,6 +533,9 @@ function reviewMemoryEntry(id: string, status: Exclude<AgentMemoryStatus, 'propo
     const entry = getAgentMemoryEntry(id)
     if (!entry) return null
     if (entry.status === 'archived' && status !== 'archived') throw new Error('Archived memory entries cannot be reviewed.')
+    if (entry.status === 'quarantined' && status !== 'archived' && status !== 'quarantined') {
+      throw new Error('Quarantined memory entries cannot be reviewed.')
+    }
     const reviewer = boundedText(reviewedBy, 'Memory reviewer', 512)
     if (status === 'approved' && entry.provenance.length < 1) {
       throw new Error('Approved memory requires provenance evidence.')
@@ -549,6 +560,24 @@ export function rejectAgentMemoryEntry(id: string, rejectedBy: string, note?: st
 
 export function archiveAgentMemoryEntry(id: string, archivedBy: string, note?: string | null) {
   return reviewMemoryEntry(id, 'archived', archivedBy, note)
+}
+
+export function quarantineAgentMemoryEntry(id: string, quarantinedBy: string, note?: string | null) {
+  return withImprovementTransaction(() => {
+    const entry = getAgentMemoryEntry(id)
+    if (!entry) return null
+    if (entry.status === 'quarantined') throw new Error('Memory entry is already quarantined.')
+    if (entry.status === 'archived') throw new Error('Archived memory entries cannot be quarantined.')
+    if (entry.status !== 'approved') throw new Error(`Memory entries can only be quarantined from approved state, not ${entry.status}.`)
+    const reviewer = boundedText(quarantinedBy, 'Memory reviewer', 512)
+    const now = nowIso()
+    getImprovementDb().prepare(`
+      update agent_memory_entries
+      set status = ?, updated_at = ?, reviewed_at = ?, reviewed_by = ?, review_note = ?
+      where id = ?
+    `).run('quarantined', now, now, reviewer, optionalBoundedText(note, 'Memory review note', 4096), id)
+    return getAgentMemoryEntry(id)
+  })
 }
 
 function payloadString(payload: Record<string, unknown>, key: string) {
@@ -1664,7 +1693,7 @@ export function buildImprovementDiagnosticsSummary(
   policy: ImprovementPolicyDiagnostics,
 ): ImprovementDiagnosticsSummary {
   const db = getImprovementDb()
-  const memory = emptyImprovementStatusCounts()
+  const memory = emptyImprovementMemoryStatusCounts()
   const memoryRows = db.prepare(`
     select status, count(*) as count
     from agent_memory_entries

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -14,13 +14,22 @@ import {
   retireGovernanceAgent,
   type GovernanceAgentIncidentControlRequest,
 } from '../governance-agent-controls.ts'
+import {
+  quarantineGovernanceMemory,
+} from '../governance-memory-controls.ts'
+import type { GovernanceMemoryIncidentControlRequest } from '@open-cowork/shared'
 
 function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is Parameters<typeof listGovernanceAuditEvents>[0] {
   if (value === undefined) return
   if (value === null) throw new Error('Governance audit options must be an object.')
   if (typeof value !== 'object' || Array.isArray(value)) throw new Error('Governance audit options must be an object.')
   const options = value as Record<string, unknown>
-  if (options.subjectKind !== undefined && options.subjectKind !== 'agent' && options.subjectKind !== 'crew') {
+  if (
+    options.subjectKind !== undefined
+    && options.subjectKind !== 'agent'
+    && options.subjectKind !== 'crew'
+    && options.subjectKind !== 'memory'
+  ) {
     throw new Error('Governance audit subject kind is invalid.')
   }
   if (options.subjectId !== undefined && typeof options.subjectId !== 'string') {
@@ -65,6 +74,19 @@ function assertAgentIncidentControlRequest(value: unknown): asserts value is Gov
     if (context.directory !== undefined && context.directory !== null && typeof context.directory !== 'string') {
       throw new Error('Agent incident context directory must be a string.')
     }
+  }
+}
+
+function assertMemoryIncidentControlRequest(value: unknown): asserts value is GovernanceMemoryIncidentControlRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Memory incident request must be an object.')
+  }
+  const request = value as Record<string, unknown>
+  if (typeof request.memoryId !== 'string' || request.memoryId.trim().length === 0) {
+    throw new Error('Memory incident id is required.')
+  }
+  if (request.reason !== undefined && request.reason !== null && typeof request.reason !== 'string') {
+    throw new Error('Memory incident reason must be a string.')
   }
 }
 
@@ -137,5 +159,10 @@ export function registerOperationHandlers(context: IpcHandlerContext) {
       buildCustomAgentPermission: context.buildCustomAgentPermission,
       rebootRuntime: rebootRuntimeForIncidentControl,
     })
+  })
+
+  context.ipcMain.handle('operations:quarantine-memory', async (_event, request: unknown) => {
+    assertMemoryIncidentControlRequest(request)
+    return quarantineGovernanceMemory(request)
   })
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -86,6 +86,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'operations:export-governance-audit',
   'operations:pause-agent',
   'operations:retire-agent',
+  'operations:quarantine-memory',
   'channels:list',
   'channels:definitions',
   'channels:inbound-items',
@@ -329,6 +330,7 @@ const api: CoworkAPI = {
     exportGovernanceAudit: (options) => invoke('operations:export-governance-audit', options),
     pauseAgent: (request) => invoke('operations:pause-agent', request),
     retireAgent: (request) => invoke('operations:retire-agent', request),
+    quarantineMemory: (request) => invoke('operations:quarantine-memory', request),
   },
   channels: {
     list: () => invoke('channels:list'),

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -533,6 +533,7 @@ const improvementSummary: ImprovementDiagnosticsSummary = {
     approved: 3,
     rejected: 0,
     archived: 0,
+    quarantined: 0,
     approvedRestrictedCount: 1,
     injection: {
       consideredCount: 3,

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -259,6 +259,20 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       queueItems: vi.fn(async () => []),
       queueAlerts: vi.fn(async () => []),
       capabilityRisks: vi.fn(async () => []),
+      governanceRegistry: vi.fn(async () => ({ schemaVersion: 1, generatedAt: new Date().toISOString(), subjects: [], dependencyIndex: [] })),
+      governanceAuditEvents: vi.fn(async () => []),
+      exportGovernanceAudit: vi.fn(async () => ({
+        schemaVersion: 2,
+        format: 'ndjson',
+        contentType: 'application/x-ndjson',
+        filename: 'open-cowork-governance-audit.ndjson',
+        exportedAt: new Date().toISOString(),
+        eventCount: 0,
+        body: '',
+      })),
+      pauseAgent: vi.fn(async () => true),
+      retireAgent: vi.fn(async () => true),
+      quarantineMemory: vi.fn(async () => null),
     },
     improvements: {
       summary: vi.fn(async () => ({
@@ -267,6 +281,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
           approved: 0,
           rejected: 0,
           archived: 0,
+          quarantined: 0,
           approvedRestrictedCount: 0,
           injection: {
             consideredCount: 0,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -118,16 +118,19 @@ map without changing OpenCode execution:
 - incident-control metadata that distinguishes actions available today from
   controls planned in later governance slices
 
-The first active incident controls are crew lifecycle controls and custom-agent
-pause/retire controls. Admin surfaces can pause or retire a crew through the
-`crews` IPC namespace; paused or retired crews keep their history and registry
-entry but cannot start new runs. Admin surfaces can pause or retire a custom
-agent through the operations namespace; pausing disables the generated OpenCode
-agent config, while retiring removes the custom agent from user-managed runtime
-content. Each control writes a durable governance audit event with actor,
-action, before/after lifecycle state, subject id, and bounded metadata. Admin
-surfaces can query those events through the operations namespace. The export
-path emits a typed audit stream as deterministic NDJSON or
+The first active incident controls are crew lifecycle controls, custom-agent
+pause/retire controls, and governed-memory quarantine. Admin surfaces can pause
+or retire a crew through the `crews` IPC namespace; paused or retired crews keep
+their history and registry entry but cannot start new runs. Admin surfaces can
+pause or retire a custom agent through the operations namespace; pausing
+disables the generated OpenCode agent config, while retiring removes the custom
+agent from user-managed runtime content. Admin surfaces can also quarantine an
+approved memory entry through the operations namespace; quarantined memory stays
+inspectable and auditable but is excluded from future memory injection. Each
+control writes a durable governance audit event with actor, action,
+before/after lifecycle state, subject id, and bounded metadata. Admin surfaces
+can query those events through the operations namespace. The export path emits a
+typed audit stream as deterministic NDJSON or
 OpenTelemetry-shaped JSON and covers governance incidents, crew traces,
 approvals, policy decisions, tool-call trace records, channel/automation
 deliveries, and outcome evaluations.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -6,8 +6,8 @@ export const COWORK_GOVERNANCE_SCHEMA_VERSION = 1
 export const COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION = 1
 export const COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION = 2
 
-export type GovernanceSubjectKind = 'agent' | 'crew'
-export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired'
+export type GovernanceSubjectKind = 'agent' | 'crew' | 'memory'
+export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired' | 'quarantined'
 export type GovernanceScopeKind = 'system' | 'machine' | 'project' | 'workspace_profile'
 export type GovernanceDependencyKind =
   | 'agent'
@@ -27,6 +27,7 @@ export type GovernanceIncidentControlKind =
   | 'retire_agent'
   | 'pause_crew'
   | 'retire_crew'
+  | 'quarantine_memory'
   | 'export_audit'
 export type GovernanceAuditEventKind = 'incident_control'
 export type GovernanceAuditOutcome = 'succeeded' | 'failed'
@@ -154,6 +155,11 @@ export interface GovernanceAgentIncidentControlRequest {
   context?: {
     directory?: string | null
   }
+}
+
+export interface GovernanceMemoryIncidentControlRequest {
+  memoryId: string
+  reason?: string | null
 }
 
 export type GovernanceAuditExportRecordPayload =

--- a/packages/shared/src/improvements.ts
+++ b/packages/shared/src/improvements.ts
@@ -3,7 +3,7 @@ export const COWORK_IMPROVEMENT_SCHEMA_VERSION = 1
 export const COWORK_DREAM_RUN_SCHEMA_VERSION = 1
 
 export type AgentMemoryScopeKind = 'machine' | 'project' | 'agent' | 'crew'
-export type AgentMemoryStatus = 'proposed' | 'approved' | 'rejected' | 'archived'
+export type AgentMemoryStatus = 'proposed' | 'approved' | 'rejected' | 'archived' | 'quarantined'
 export type ImprovementProposalStatus = 'proposed' | 'approved' | 'rejected' | 'archived'
 export type ImprovementProposalTargetType = 'memory' | 'agent' | 'skill' | 'sop' | 'crew' | 'eval_case' | 'routing' | 'policy'
 export type ImprovementEvidenceKind = 'run' | 'artifact' | 'eval' | 'trace' | 'thread' | 'session' | 'sop' | 'crew'
@@ -210,6 +210,10 @@ export interface ImprovementStatusCounts {
   archived: number
 }
 
+export interface ImprovementMemoryStatusCounts extends ImprovementStatusCounts {
+  quarantined: number
+}
+
 export interface DreamRunStatusCounts {
   running: number
   completed: number
@@ -226,7 +230,7 @@ export interface ImprovementPolicyDiagnostics {
 }
 
 export interface ImprovementDiagnosticsSummary {
-  memory: ImprovementStatusCounts & {
+  memory: ImprovementMemoryStatusCounts & {
     approvedRestrictedCount: number
     injection: MemoryInjectionDiagnostics
   }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -135,6 +135,7 @@ import type {
   GovernanceAuditEvent,
   GovernanceAuditExportFormat,
   GovernanceAuditExportPayload,
+  GovernanceMemoryIncidentControlRequest,
   GovernanceSubjectKind,
   GovernanceRegistryPayload,
 } from './governance.js'
@@ -339,6 +340,7 @@ export interface CoworkAPI {
     }) => Promise<GovernanceAuditExportPayload>
     pauseAgent: (request: GovernanceAgentIncidentControlRequest) => Promise<boolean>
     retireAgent: (request: GovernanceAgentIncidentControlRequest) => Promise<boolean>
+    quarantineMemory: (request: GovernanceMemoryIncidentControlRequest) => Promise<AgentMemoryEntry | null>
   }
   channels: {
     list: () => Promise<ChannelListPayload>

--- a/tests/governance-memory-controls.test.ts
+++ b/tests/governance-memory-controls.test.ts
@@ -1,0 +1,130 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  COWORK_IMPROVEMENT_SCHEMA_VERSION,
+  type AgentMemoryDraft,
+  type ImprovementEvidenceRef,
+} from '../packages/shared/src/improvements.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { closeLogger } from '../apps/desktop/src/main/logger.ts'
+import { exportGovernanceAuditEvents } from '../apps/desktop/src/main/governance-audit-export.ts'
+import {
+  clearGovernanceAuditStoreCache,
+  listGovernanceAuditEvents,
+} from '../apps/desktop/src/main/governance-audit-store.ts'
+import {
+  approveAgentMemoryEntry,
+  buildImprovementDiagnosticsSummary,
+  buildMemoryInjectionPlan,
+  clearImprovementStoreCache,
+  createAgentMemoryProposal,
+  getAgentMemoryEntry,
+} from '../apps/desktop/src/main/improvement-store.ts'
+import { quarantineGovernanceMemory } from '../apps/desktop/src/main/governance-memory-controls.ts'
+
+function uniqueUserDataDir(name: string) {
+  return join(tmpdir(), `open-cowork-memory-control-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+}
+
+function withMemoryControlStore(name: string, fn: () => void) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    closeLogger()
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    clearConfigCaches()
+    clearImprovementStoreCache()
+    clearGovernanceAuditStoreCache()
+    fn()
+  } finally {
+    closeLogger()
+    clearImprovementStoreCache()
+    clearGovernanceAuditStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+function evidence(id = 'trace-1'): ImprovementEvidenceRef {
+  return {
+    schemaVersion: COWORK_IMPROVEMENT_SCHEMA_VERSION,
+    kind: 'trace',
+    id,
+    label: `Trace ${id}`,
+    uri: null,
+    hash: `sha256:${id}`,
+  }
+}
+
+function memoryDraft(overrides: Partial<AgentMemoryDraft> = {}): AgentMemoryDraft {
+  return {
+    scopeKind: 'machine',
+    scopeId: null,
+    title: 'Sensitive operating lesson',
+    summary: 'A reviewed lesson that may need incident quarantine.',
+    body: 'Prefer concise operating summaries when evidence is strong.',
+    tags: ['incident', 'memory'],
+    privacy: 'internal',
+    provenance: [evidence()],
+    ...overrides,
+  }
+}
+
+const policyDiagnostics = {
+  proposalsEnabled: true,
+  disabledAgentCount: 0,
+  disabledProjectCount: 0,
+  disabledCrewCount: 0,
+}
+
+test('quarantineGovernanceMemory removes approved memory from injection and records audit evidence', () => withMemoryControlStore('quarantine-approved', () => {
+  const proposed = createAgentMemoryProposal(memoryDraft())
+  approveAgentMemoryEntry(proposed.id, 'reviewer', 'Evidence checked.')
+  assert.equal(buildMemoryInjectionPlan([{ scopeKind: 'machine' }]).entries.length, 1)
+
+  const quarantined = quarantineGovernanceMemory({
+    memoryId: proposed.id,
+    reason: 'Potentially unsafe lesson.',
+  })
+
+  assert.equal(quarantined?.status, 'quarantined')
+  assert.equal(quarantined?.reviewedBy, 'local-user')
+  assert.equal(quarantined?.reviewNote, 'Potentially unsafe lesson.')
+  assert.deepEqual(buildMemoryInjectionPlan([{ scopeKind: 'machine' }]).entries, [])
+
+  const summary = buildImprovementDiagnosticsSummary(policyDiagnostics)
+  assert.equal(summary.memory.approved, 0)
+  assert.equal(summary.memory.quarantined, 1)
+  assert.equal(summary.memory.injection.consideredCount, 0)
+
+  const subjectId = `memory:${encodeURIComponent(proposed.id)}`
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'memory', subjectId })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.action, 'quarantine_memory')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'approved')
+  assert.equal(auditEvents[0]?.afterLifecycle, 'quarantined')
+  assert.equal(auditEvents[0]?.reason, 'Potentially unsafe lesson.')
+  assert.equal(auditEvents[0]?.metadata.memoryId, proposed.id)
+
+  const exported = exportGovernanceAuditEvents({ subjectKind: 'memory', subjectId })
+  const rows = exported.body.split('\n').map((line) => JSON.parse(line) as Record<string, unknown>)
+  assert.equal(exported.eventCount, 1)
+  assert.equal(rows[0]?.subjectKind, 'memory')
+  assert.equal((rows[0]?.payload as Record<string, unknown>)?.action, 'quarantine_memory')
+}))
+
+test('quarantineGovernanceMemory refuses non-approved memory without mutating or auditing', () => withMemoryControlStore('quarantine-proposed', () => {
+  const proposed = createAgentMemoryProposal(memoryDraft({ title: 'Unreviewed lesson' }))
+
+  assert.throws(
+    () => quarantineGovernanceMemory({ memoryId: proposed.id, reason: 'Too early.' }),
+    /cannot be quarantined from proposed state/,
+  )
+  assert.equal(getAgentMemoryEntry(proposed.id)?.status, 'proposed')
+  assert.equal(listGovernanceAuditEvents().length, 0)
+}))

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -256,6 +256,19 @@ test('operations:pause-agent resolves incident-control context through granted p
   assert.equal(requestedDirectory, '/ungranted/project')
 })
 
+test('operations:quarantine-memory rejects malformed incident-control requests at the IPC boundary', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerOperationHandlers(context)
+  const handler = handlers.get('operations:quarantine-memory')
+
+  assert.ok(handler, 'expected operations:quarantine-memory handler to be registered')
+  await assert.rejects(
+    () => handler({}, { memoryId: 'memory-1', reason: 123 }),
+    /Memory incident reason must be a string/,
+  )
+})
+
 test('session:prompt clears pending prompt echo when dispatch fails', async () => {
   const { context, handlers } = createBaseContext()
   let promptCalled = false

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -132,6 +132,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('operations:export-governance-audit'), true)
   assert.equal(handlers.has('operations:pause-agent'), true)
   assert.equal(handlers.has('operations:retire-agent'), true)
+  assert.equal(handlers.has('operations:quarantine-memory'), true)
   assert.equal(handlers.has('channels:list'), true)
   assert.equal(handlers.has('channels:definitions'), true)
   assert.equal(handlers.has('channels:inbound-items'), true)


### PR DESCRIPTION
## Summary\n- add a governed-memory quarantine incident control for approved memory entries\n- exclude quarantined memory from future memory injection while keeping it inspectable and counted in diagnostics\n- record/export quarantine events through the governance audit stream and operations IPC namespace\n- document the control in operations docs\n\n## Validation\n- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-memory-controls.test.ts tests/governance-audit-store.test.ts tests/ipc-handler-registration.test.ts tests/ipc-handler-behavior.test.ts tests/improvement-store.test.ts\n- pnpm typecheck\n- pnpm lint\n- pnpm test\n- pnpm test:renderer\n- pnpm build\n- uv run mkdocs build --strict\n- git diff --cached --check\n\nRefs #250