### PR TITLE
[codex] add governed tool revocation

### DIFF
--- a/apps/desktop/src/main/agent-config.ts
+++ b/apps/desktop/src/main/agent-config.ts
@@ -84,6 +84,7 @@ export function buildOpenCoworkAgentConfig(options: {
   allToolPatterns: string[]
   allowToolPatterns?: string[]
   askToolPatterns?: string[]
+  deniedToolPatterns?: string[]
   managedSkillNames?: string[]
   availableSkillNames?: string[]
   bash?: PermissionAction
@@ -171,6 +172,7 @@ export function buildOpenCoworkAgentConfig(options: {
   const allowPatterns = Array.from(new Set([...(options.allowToolPatterns || []), ...globalAccess.allow]))
   const askPatterns = Array.from(new Set([...(options.askToolPatterns || []), ...globalAccess.ask]))
   const allToolPatterns = Array.from(new Set([...options.allToolPatterns, ...globalAccess.all]))
+  const deniedToolPatterns = Array.from(new Set(options.deniedToolPatterns || []))
   const appPermissions = getAppConfig().permissions
   const bash = options.bash || 'deny'
   const fileWrite = options.fileWrite || 'deny'
@@ -199,6 +201,7 @@ export function buildOpenCoworkAgentConfig(options: {
           allToolPatterns,
           allowPatterns,
           askPatterns,
+          deniedPatterns: deniedToolPatterns,
           externalDirectoryRules: managedExternalDirectoryRules,
           skillRules: globalSkillRules,
           web,
@@ -230,6 +233,7 @@ export function buildOpenCoworkAgentConfig(options: {
         permission: createPermissionConfig({
           allToolPatterns,
           allowPatterns,
+          deniedPatterns: deniedToolPatterns,
           externalDirectoryRules: managedExternalDirectoryRules,
           skillRules: globalSkillRules,
           web,
@@ -254,6 +258,7 @@ export function buildOpenCoworkAgentConfig(options: {
           allToolPatterns,
           allowPatterns,
           askPatterns,
+          deniedPatterns: deniedToolPatterns,
           externalDirectoryRules: managedExternalDirectoryRules,
           skillRules: globalSkillRules,
           web,
@@ -272,6 +277,7 @@ export function buildOpenCoworkAgentConfig(options: {
         color: 'accent',
         permission: createPermissionConfig({
           allToolPatterns,
+          deniedPatterns: deniedToolPatterns,
           externalDirectoryRules: managedExternalDirectoryRules,
           skillRules: globalSkillRules,
         }),
@@ -294,6 +300,7 @@ export function buildOpenCoworkAgentConfig(options: {
           allToolPatterns,
           allowPatterns,
           askPatterns,
+          deniedPatterns: deniedToolPatterns,
           externalDirectoryRules: managedExternalDirectoryRules,
           skillRules: globalSkillRules,
           web,
@@ -342,7 +349,7 @@ export function buildOpenCoworkAgentConfig(options: {
         allToolPatterns,
         allowPatterns: agent.allowPatterns,
         askPatterns: agent.askPatterns,
-        deniedPatterns: agent.deniedPatterns,
+        deniedPatterns: [...(agent.deniedPatterns || []), ...deniedToolPatterns],
         externalDirectoryRules: managedExternalDirectoryRules,
         skillRules: Object.fromEntries(agent.skillNames.map((skillName) => [skillName, 'allow' as const])),
         web: agentWeb,
@@ -376,6 +383,7 @@ export function buildOpenCoworkAgentConfig(options: {
         allToolPatterns,
         allowPatterns: agentAllowPatterns,
         askPatterns: agentAskPatterns,
+        deniedPatterns: deniedToolPatterns,
         externalDirectoryRules: managedExternalDirectoryRules,
         skillRules: Object.fromEntries(filteredSkillNames.map((skillName) => [skillName, 'allow' as const])),
         web: agentWeb,

--- a/apps/desktop/src/main/governance-audit-store.ts
+++ b/apps/desktop/src/main/governance-audit-store.ts
@@ -23,16 +23,17 @@ const MAX_METADATA_BYTES = 128 * 1024
 const DEFAULT_AUDIT_LIST_LIMIT = 500
 const AUDIT_KINDS = new Set<GovernanceAuditEventKind>(['incident_control'])
 const AUDIT_OUTCOMES = new Set<GovernanceAuditOutcome>(['succeeded', 'failed'])
-const SUBJECT_KINDS = new Set<GovernanceSubjectKind>(['agent', 'crew', 'memory'])
+const SUBJECT_KINDS = new Set<GovernanceSubjectKind>(['agent', 'crew', 'memory', 'tool'])
 const INCIDENT_ACTIONS = new Set<GovernanceIncidentControlKind>([
   'pause_agent',
   'retire_agent',
   'pause_crew',
   'retire_crew',
   'quarantine_memory',
+  'revoke_tool',
   'export_audit',
 ])
-const LIFECYCLE_STATES = new Set<GovernanceLifecycleState>(['draft', 'review', 'approved', 'active', 'paused', 'retired', 'quarantined'])
+const LIFECYCLE_STATES = new Set<GovernanceLifecycleState>(['draft', 'review', 'approved', 'active', 'paused', 'retired', 'quarantined', 'revoked'])
 
 type DbRow = Record<string, unknown>
 

--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -14,6 +14,7 @@ import type {
   GovernanceLifecycleState,
   GovernanceRegistryPayload,
   GovernanceRegistrySubject,
+  GovernanceRevokedTool,
   GovernanceScope,
   RuntimeContextOptions,
   SopListPayload,
@@ -32,6 +33,7 @@ import { listCrewCatalog } from './crew-service.ts'
 import { listChannelDefinitions } from './channel-store.ts'
 import { listSopDefinitions } from './sop-service.ts'
 import { listCustomMcps } from './native-customizations.ts'
+import { listApplicableRevokedGovernanceTools } from './governance-tool-policy.ts'
 
 export interface GovernanceRegistryBuildInput {
   builtinAgents: BuiltInAgentDetail[]
@@ -41,6 +43,7 @@ export interface GovernanceRegistryBuildInput {
   sopCatalog?: SopListPayload
   channels?: ChannelDefinition[]
   toolCredentialDependencies?: GovernanceToolCredentialDependency[]
+  revokedTools?: GovernanceRevokedTool[]
   generatedAt?: string
 }
 
@@ -122,10 +125,12 @@ function addDependency(
     dependencies.set(key, dependency)
     return
   }
+  const lifecycle = dependencyLifecycle(existing.lifecycle, dependency.lifecycle)
   dependencies.set(key, {
     ...existing,
     source: existing.source === 'direct' || dependency.source === 'direct' ? 'direct' : 'transitive',
     required: existing.required || dependency.required,
+    ...(lifecycle ? { lifecycle } : {}),
   })
 }
 
@@ -135,8 +140,21 @@ function createDependency(
   label: string,
   source: GovernanceDependencySource,
   required = true,
+  lifecycle?: GovernanceLifecycleState | null,
 ): GovernanceDependency {
-  return { kind, id, label, source, required }
+  return {
+    kind,
+    id,
+    label,
+    source,
+    required,
+    ...(lifecycle ? { lifecycle } : {}),
+  }
+}
+
+function dependencyLifecycle(existing?: GovernanceLifecycleState | null, next?: GovernanceLifecycleState | null) {
+  if (existing === 'revoked' || next === 'revoked') return 'revoked'
+  return existing || next || null
 }
 
 function createToolLabelMap(catalog: AgentCatalog): Map<string, string> {
@@ -169,11 +187,15 @@ function collectAgentDependencies(input: {
   skillLabels: Map<string, string>
   skillTools: Map<string, string[]>
   toolCredentials: Map<string, GovernanceDependency[]>
+  revokedTools: Map<string, GovernanceRevokedTool>
   supplemental?: GovernanceDependency[]
 }): GovernanceDependency[] {
   const dependencies = new Map<string, GovernanceDependency>()
   for (const toolId of input.toolIds) {
-    addDependency(dependencies, createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'direct'))
+    addDependency(
+      dependencies,
+      createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'direct', true, input.revokedTools.has(toolId) ? 'revoked' : null),
+    )
     for (const credential of input.toolCredentials.get(toolId) || []) {
       addDependency(dependencies, { ...credential, source: 'direct' })
     }
@@ -181,7 +203,10 @@ function collectAgentDependencies(input: {
   for (const skillName of input.skillNames) {
     addDependency(dependencies, createDependency('skill', skillName, input.skillLabels.get(skillName) || skillName, 'direct'))
     for (const toolId of input.skillTools.get(skillName) || []) {
-      addDependency(dependencies, createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'transitive'))
+      addDependency(
+        dependencies,
+        createDependency('tool', toolId, input.toolLabels.get(toolId) || toolId, 'transitive', true, input.revokedTools.has(toolId) ? 'revoked' : null),
+      )
       for (const credential of input.toolCredentials.get(toolId) || []) {
         addDependency(dependencies, { ...credential, source: 'transitive' })
       }
@@ -563,10 +588,12 @@ function buildDependencyIndex(subjects: GovernanceRegistrySubject[]): Governance
         continue
       }
       entry.subjectIds.add(subject.subjectId)
+      const lifecycle = dependencyLifecycle(entry.dependency.lifecycle, dependency.lifecycle)
       entry.dependency = {
         ...entry.dependency,
         source: entry.dependency.source === 'direct' || dependency.source === 'direct' ? 'direct' : 'transitive',
         required: entry.dependency.required || dependency.required,
+        ...(lifecycle ? { lifecycle } : {}),
       }
     }
   }
@@ -587,6 +614,7 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
   const skillLabels = createSkillLabelMap(input.agentCatalog)
   const skillTools = createSkillToolMap(input.agentCatalog)
   const toolCredentials = createToolCredentialMap(input.toolCredentialDependencies)
+  const revokedTools = new Map((input.revokedTools || []).map((tool) => [tool.toolId, tool]))
   const agentSupplementalDependencies = createAgentSupplementalDependencyMap({
     sops: input.sopCatalog,
     channels: input.channels,
@@ -601,6 +629,7 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
       skillLabels,
       skillTools,
       toolCredentials,
+      revokedTools,
       supplemental: agentSupplementalDependencies.get(agentNameKey(agent.name)),
     }))),
     ...input.customAgents.map((agent) => buildCustomAgentSubject(agent, collectAgentDependencies({
@@ -610,6 +639,7 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
       skillLabels,
       skillTools,
       toolCredentials,
+      revokedTools,
       supplemental: agentSupplementalDependencies.get(agentNameKey(agent.name)),
     }))),
   ]
@@ -655,5 +685,6 @@ export async function getGovernanceRegistry(options?: RuntimeContextOptions): Pr
       mcps: getConfiguredMcpsFromConfig(),
       customMcps: listCustomMcps(options),
     }),
+    revokedTools: listApplicableRevokedGovernanceTools(options),
   })
 }

--- a/apps/desktop/src/main/governance-tool-controls.ts
+++ b/apps/desktop/src/main/governance-tool-controls.ts
@@ -1,0 +1,69 @@
+import type { GovernanceRevokedTool, GovernanceToolIncidentControlRequest } from '@open-cowork/shared'
+import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
+import { saveRevokedGovernanceTool } from './governance-tool-policy-store.ts'
+import { resolveGovernanceToolControlTarget } from './governance-tool-policy.ts'
+
+const MAX_INCIDENT_REASON_BYTES = 16 * 1024
+const MAX_TOOL_ID_BYTES = 512
+
+export type GovernanceToolIncidentControlDependencies = {
+  rebootRuntime: () => Promise<void>
+}
+
+function boundedToolId(value: unknown) {
+  if (typeof value !== 'string') throw new Error('Tool incident id must be a string.')
+  const toolId = value.trim()
+  if (!toolId) throw new Error('Tool incident id is required.')
+  if (Buffer.byteLength(toolId, 'utf8') > MAX_TOOL_ID_BYTES) throw new Error('Tool incident id is too large.')
+  return toolId
+}
+
+function boundedReason(value: unknown, fallback: string) {
+  if (value === undefined || value === null) return fallback
+  if (typeof value !== 'string') throw new Error('Tool incident reason must be a string.')
+  const reason = value.trim()
+  if (!reason) return fallback
+  if (Buffer.byteLength(reason, 'utf8') > MAX_INCIDENT_REASON_BYTES) {
+    throw new Error('Tool incident reason is too large.')
+  }
+  return reason
+}
+
+export async function revokeGovernanceTool(
+  request: GovernanceToolIncidentControlRequest,
+  dependencies: GovernanceToolIncidentControlDependencies,
+): Promise<GovernanceRevokedTool> {
+  const toolId = boundedToolId(request.toolId)
+  const target = resolveGovernanceToolControlTarget(toolId, request.context)
+  if (!target) throw new Error(`No tool found for governance incident ${toolId}.`)
+
+  const reason = boundedReason(request.reason, 'Tool revoked through governance incident control.')
+  const revoked = saveRevokedGovernanceTool({
+    toolId: target.toolId,
+    label: target.label,
+    patterns: target.patterns,
+    source: target.source,
+    scope: target.scope,
+    directory: target.directory,
+    reason,
+    revokedBy: 'local-user',
+  })
+  recordGovernanceAuditEvent({
+    subjectKind: 'tool',
+    subjectId: `tool:${encodeURIComponent(target.toolId)}`,
+    action: 'revoke_tool',
+    beforeLifecycle: 'active',
+    afterLifecycle: 'revoked',
+    reason,
+    metadata: {
+      toolId: target.toolId,
+      label: target.label,
+      patterns: target.patterns,
+      source: target.source,
+      scope: target.scope,
+      directory: target.directory,
+    },
+  })
+  await dependencies.rebootRuntime()
+  return revoked
+}

--- a/apps/desktop/src/main/governance-tool-policy-store.ts
+++ b/apps/desktop/src/main/governance-tool-policy-store.ts
@@ -1,0 +1,195 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { GovernanceRevokedTool } from '@open-cowork/shared'
+import { COWORK_GOVERNANCE_SCHEMA_VERSION } from '@open-cowork/shared'
+import { getAppDataDir } from './config-loader.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
+
+const GOVERNANCE_TOOL_POLICY_FILENAME = 'governance-tool-policy.json'
+const MAX_TOOL_ID_BYTES = 512
+const MAX_LABEL_BYTES = 1024
+const MAX_REASON_BYTES = 16 * 1024
+const MAX_PATTERN_BYTES = 1024
+const MAX_DIRECTORY_BYTES = 4096
+const MAX_REVOKED_TOOL_COUNT = 512
+const MAX_PATTERN_COUNT = 128
+
+const TOOL_SOURCES = new Set(['configured', 'custom-mcp', 'native'])
+const TOOL_SCOPES = new Set(['system', 'machine', 'project'])
+
+let revokedToolCache: GovernanceRevokedTool[] | null = null
+
+function policyPath() {
+  return join(getAppDataDir(), GOVERNANCE_TOOL_POLICY_FILENAME)
+}
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function boundedString(value: unknown, label: string, maxBytes: number) {
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  const normalized = value.trim()
+  if (!normalized) throw new Error(`${label} is required.`)
+  if (Buffer.byteLength(normalized, 'utf8') > maxBytes) throw new Error(`${label} is too large.`)
+  return normalized
+}
+
+function optionalBoundedString(value: unknown, label: string, maxBytes: number) {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  const normalized = value.trim()
+  if (!normalized) return null
+  if (Buffer.byteLength(normalized, 'utf8') > maxBytes) throw new Error(`${label} is too large.`)
+  return normalized
+}
+
+function normalizePatterns(value: unknown) {
+  const raw = Array.isArray(value) ? value : []
+  const patterns = Array.from(new Set(raw
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean)))
+  if (patterns.length === 0) throw new Error('Revoked tool policy requires at least one permission pattern.')
+  if (patterns.length > MAX_PATTERN_COUNT) throw new Error('Revoked tool policy has too many permission patterns.')
+  for (const pattern of patterns) {
+    if (Buffer.byteLength(pattern, 'utf8') > MAX_PATTERN_BYTES) {
+      throw new Error('Revoked tool permission pattern is too large.')
+    }
+  }
+  return patterns
+}
+
+function normalizeRevokedTool(value: unknown): GovernanceRevokedTool | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const toolId = optionalBoundedString(record.toolId, 'Revoked tool id', MAX_TOOL_ID_BYTES)
+  if (!toolId) return null
+  const label = optionalBoundedString(record.label, 'Revoked tool label', MAX_LABEL_BYTES) || toolId
+  const patterns = normalizePatterns(record.patterns)
+  const source = typeof record.source === 'string' && TOOL_SOURCES.has(record.source)
+    ? record.source as GovernanceRevokedTool['source']
+    : 'configured'
+  const scope = typeof record.scope === 'string' && TOOL_SCOPES.has(record.scope)
+    ? record.scope as GovernanceRevokedTool['scope']
+    : 'system'
+  const directory = scope === 'project' ? optionalBoundedString(record.directory, 'Revoked tool directory', MAX_DIRECTORY_BYTES) : null
+  if (scope === 'project' && !directory) return null
+  const revokedAt = optionalBoundedString(record.revokedAt, 'Revoked tool timestamp', 128) || nowIso()
+  const revokedBy = optionalBoundedString(record.revokedBy, 'Revoked tool actor', 512) || 'local-user'
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    toolId,
+    label,
+    patterns,
+    source,
+    scope,
+    directory,
+    revokedAt,
+    revokedBy,
+    reason: optionalBoundedString(record.reason, 'Revoked tool reason', MAX_REASON_BYTES),
+  }
+}
+
+function readPolicyFile(): GovernanceRevokedTool[] {
+  const path = policyPath()
+  if (!existsSync(path)) return []
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown
+  const rawTools = parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>).revokedTools
+    : null
+  const entries = Array.isArray(rawTools)
+    ? rawTools.map(normalizeRevokedTool).filter((entry): entry is GovernanceRevokedTool => Boolean(entry))
+    : []
+  return entries.slice(0, MAX_REVOKED_TOOL_COUNT)
+}
+
+function writePolicyFile(entries: GovernanceRevokedTool[]) {
+  const sorted = [...entries].sort((left, right) => revokedToolKey(left).localeCompare(revokedToolKey(right)))
+  writeFileAtomic(policyPath(), `${JSON.stringify({
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    revokedTools: sorted,
+  }, null, 2)}\n`, { mode: 0o600 })
+  revokedToolCache = sorted
+}
+
+export function clearGovernanceToolPolicyCache() {
+  revokedToolCache = null
+}
+
+export function listRevokedGovernanceTools(): GovernanceRevokedTool[] {
+  if (!revokedToolCache) revokedToolCache = readPolicyFile()
+  return revokedToolCache.map((entry) => ({
+    ...entry,
+    patterns: [...entry.patterns],
+  }))
+}
+
+function revokedToolKey(input: {
+  toolId: string
+  source: GovernanceRevokedTool['source']
+  scope: GovernanceRevokedTool['scope']
+  directory?: string | null
+}) {
+  return [input.source, input.scope, input.directory || '', input.toolId].join('\u0000')
+}
+
+export function getRevokedGovernanceTool(
+  toolId: string,
+  options?: {
+    source?: GovernanceRevokedTool['source']
+    scope?: GovernanceRevokedTool['scope']
+    directory?: string | null
+  },
+) {
+  if (!options?.source || !options.scope) {
+    return listRevokedGovernanceTools().find((entry) => entry.toolId === toolId) || null
+  }
+  const key = revokedToolKey({
+    toolId,
+    source: options.source,
+    scope: options.scope,
+    directory: options.directory,
+  })
+  return listRevokedGovernanceTools().find((entry) => revokedToolKey(entry) === key) || null
+}
+
+export function saveRevokedGovernanceTool(input: {
+  toolId: string
+  label: string
+  patterns: string[]
+  source: GovernanceRevokedTool['source']
+  scope: GovernanceRevokedTool['scope']
+  directory?: string | null
+  reason?: string | null
+  revokedBy?: string | null
+}): GovernanceRevokedTool {
+  const toolId = boundedString(input.toolId, 'Revoked tool id', MAX_TOOL_ID_BYTES)
+  const source = TOOL_SOURCES.has(input.source) ? input.source : 'configured'
+  const scope = TOOL_SCOPES.has(input.scope) ? input.scope : 'system'
+  const directory = scope === 'project'
+    ? optionalBoundedString(input.directory, 'Revoked tool directory', MAX_DIRECTORY_BYTES)
+    : null
+  if (scope === 'project' && !directory) throw new Error('Project-scoped revoked tool policy requires a directory.')
+  const existing = getRevokedGovernanceTool(toolId, { source, scope, directory })
+  if (existing) throw new Error(`Tool ${toolId} is already revoked.`)
+  const entry: GovernanceRevokedTool = {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    toolId,
+    label: boundedString(input.label, 'Revoked tool label', MAX_LABEL_BYTES),
+    patterns: normalizePatterns(input.patterns),
+    source,
+    scope,
+    directory,
+    revokedAt: nowIso(),
+    revokedBy: optionalBoundedString(input.revokedBy, 'Revoked tool actor', 512) || 'local-user',
+    reason: optionalBoundedString(input.reason, 'Revoked tool reason', MAX_REASON_BYTES),
+  }
+  const entries = [...listRevokedGovernanceTools(), entry]
+  if (entries.length > MAX_REVOKED_TOOL_COUNT) throw new Error('Too many revoked tools are recorded.')
+  writePolicyFile(entries)
+  return {
+    ...entry,
+    patterns: [...entry.patterns],
+  }
+}

--- a/apps/desktop/src/main/governance-tool-policy.ts
+++ b/apps/desktop/src/main/governance-tool-policy.ts
@@ -1,0 +1,117 @@
+import type { CustomMcpConfig, RuntimeContextOptions } from '@open-cowork/shared'
+import {
+  expandMcpToolPermissionPatterns,
+  getConfiguredToolById,
+  getConfiguredToolPatterns,
+} from './config-loader.ts'
+import { listCustomMcps } from './native-customizations.ts'
+import { listRevokedGovernanceTools } from './governance-tool-policy-store.ts'
+import { nativeToolLabels } from './agent-tool-access.ts'
+import { resolveProjectDirectory } from './runtime-paths.ts'
+
+const NATIVE_TOOL_IDS = new Set([
+  'read',
+  'grep',
+  'glob',
+  'list',
+  'websearch',
+  'webfetch',
+  'codesearch',
+  'bash',
+  'edit',
+  'write',
+  'apply_patch',
+  'question',
+  'todowrite',
+])
+
+export type ResolvedToolControlTarget = {
+  toolId: string
+  label: string
+  patterns: string[]
+  source: 'configured' | 'custom-mcp' | 'native'
+  scope: 'system' | 'machine' | 'project'
+  directory: string | null
+}
+
+function customMcpLabel(mcp: CustomMcpConfig) {
+  const explicit = mcp.label?.trim()
+  if (explicit) return explicit
+  return mcp.name
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+    || mcp.name
+}
+
+function uniquePatterns(patterns: string[]) {
+  return Array.from(new Set(patterns.map((pattern) => pattern.trim()).filter(Boolean)))
+}
+
+export function resolveGovernanceToolControlTarget(
+  toolId: string,
+  options?: RuntimeContextOptions,
+): ResolvedToolControlTarget | null {
+  const configured = getConfiguredToolById(toolId)
+  if (configured) {
+    return {
+      toolId,
+      label: configured.name,
+      patterns: uniquePatterns(expandMcpToolPermissionPatterns(getConfiguredToolPatterns(configured))),
+      source: 'configured',
+      scope: 'system',
+      directory: null,
+    }
+  }
+
+  const custom = listCustomMcps(options).find((entry) => entry.name === toolId)
+  if (custom) {
+    return {
+      toolId,
+      label: customMcpLabel(custom),
+      patterns: uniquePatterns(expandMcpToolPermissionPatterns([`mcp__${custom.name}__*`])),
+      source: 'custom-mcp',
+      scope: custom.scope,
+      directory: custom.scope === 'project' ? custom.directory || null : null,
+    }
+  }
+
+  if (NATIVE_TOOL_IDS.has(toolId)) {
+    return {
+      toolId,
+      label: nativeToolLabels([toolId])[0] || toolId,
+      patterns: [toolId],
+      source: 'native',
+      scope: 'system',
+      directory: null,
+    }
+  }
+
+  return null
+}
+
+export function listRevokedToolPermissionPatterns(options?: RuntimeContextOptions): string[] {
+  const patterns = new Set<string>()
+  for (const revoked of listApplicableRevokedGovernanceTools(options)) {
+    for (const pattern of revoked.patterns) patterns.add(pattern)
+    const current = resolveGovernanceToolControlTarget(revoked.toolId, options)
+    for (const pattern of current?.patterns || []) patterns.add(pattern)
+  }
+  return [...patterns].sort((left, right) => left.localeCompare(right))
+}
+
+export function revokedToolAppliesToContext(
+  revoked: { scope?: string | null, directory?: string | null },
+  options?: RuntimeContextOptions,
+) {
+  if (revoked.scope !== 'project') return true
+  const revokedDirectory = resolveProjectDirectory(revoked.directory)
+  const contextDirectory = resolveProjectDirectory(options?.directory)
+  return Boolean(revokedDirectory && contextDirectory && revokedDirectory === contextDirectory)
+}
+
+export function listApplicableRevokedGovernanceTools(options?: RuntimeContextOptions) {
+  return listRevokedGovernanceTools()
+    .filter((revoked) => revokedToolAppliesToContext(revoked, options))
+}

--- a/apps/desktop/src/main/ipc/operation-handlers.ts
+++ b/apps/desktop/src/main/ipc/operation-handlers.ts
@@ -17,7 +17,10 @@ import {
 import {
   quarantineGovernanceMemory,
 } from '../governance-memory-controls.ts'
-import type { GovernanceMemoryIncidentControlRequest } from '@open-cowork/shared'
+import {
+  revokeGovernanceTool,
+} from '../governance-tool-controls.ts'
+import type { GovernanceMemoryIncidentControlRequest, GovernanceToolIncidentControlRequest } from '@open-cowork/shared'
 
 function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is Parameters<typeof listGovernanceAuditEvents>[0] {
   if (value === undefined) return
@@ -29,6 +32,7 @@ function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is 
     && options.subjectKind !== 'agent'
     && options.subjectKind !== 'crew'
     && options.subjectKind !== 'memory'
+    && options.subjectKind !== 'tool'
   ) {
     throw new Error('Governance audit subject kind is invalid.')
   }
@@ -40,6 +44,28 @@ function assertOptionalGovernanceAuditOptions(value: unknown): asserts value is 
   }
   if (options.limit !== undefined && (typeof options.limit !== 'number' || !Number.isFinite(options.limit))) {
     throw new Error('Governance audit limit must be a finite number.')
+  }
+}
+
+function assertToolIncidentControlRequest(value: unknown): asserts value is GovernanceToolIncidentControlRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Tool incident request must be an object.')
+  }
+  const request = value as Record<string, unknown>
+  if (typeof request.toolId !== 'string' || request.toolId.trim().length === 0) {
+    throw new Error('Tool incident id is required.')
+  }
+  if (request.reason !== undefined && request.reason !== null && typeof request.reason !== 'string') {
+    throw new Error('Tool incident reason must be a string.')
+  }
+  if (request.context !== undefined) {
+    if (!request.context || typeof request.context !== 'object' || Array.isArray(request.context)) {
+      throw new Error('Tool incident context must be an object.')
+    }
+    const context = request.context as Record<string, unknown>
+    if (context.directory !== undefined && context.directory !== null && typeof context.directory !== 'string') {
+      throw new Error('Tool incident context directory must be a string.')
+    }
   }
 }
 
@@ -107,6 +133,23 @@ function resolveAgentIncidentControlRequest(
   }
 }
 
+function resolveToolIncidentControlRequest(
+  context: IpcHandlerContext,
+  request: GovernanceToolIncidentControlRequest,
+): GovernanceToolIncidentControlRequest {
+  if (!request.context) return request
+  const hasContext = Boolean(request.context.directory?.trim())
+  if (!hasContext) return { ...request, context: undefined }
+  const directory = context.resolveContextDirectory(request.context)
+  if (!directory) {
+    throw new Error('Tool incident context requires an active project directory.')
+  }
+  return {
+    ...request,
+    context: { directory },
+  }
+}
+
 async function rebootRuntimeForIncidentControl() {
   const { rebootRuntime } = await import('../index.ts')
   await rebootRuntime()
@@ -164,5 +207,12 @@ export function registerOperationHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('operations:quarantine-memory', async (_event, request: unknown) => {
     assertMemoryIncidentControlRequest(request)
     return quarantineGovernanceMemory(request)
+  })
+
+  context.ipcMain.handle('operations:revoke-tool', async (_event, request: unknown) => {
+    assertToolIncidentControlRequest(request)
+    return revokeGovernanceTool(resolveToolIncidentControlRequest(context, request), {
+      rebootRuntime: rebootRuntimeForIncidentControl,
+    })
   })
 }

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -29,6 +29,7 @@ import { listEffectiveSkillsSync } from './effective-skills.ts'
 import { evaluateHttpMcpUrlResolved } from './mcp-url-policy.ts'
 import type { PermissionAction } from './permission-config.ts'
 import { getRuntimeSkillCatalogDir } from './runtime-paths.ts'
+import { listRevokedToolPermissionPatterns } from './governance-tool-policy.ts'
 
 type PlaceholderResolveOptions = {
   overrides?: Readonly<Record<string, string>>
@@ -407,10 +408,12 @@ function buildRuntimeConfigWithCustomMcps(
     ...configuredTools.flatMap((tool) => getConfiguredToolPatterns(tool)),
     ...customMcpPatterns,
   ]))
+  const deniedPatterns = listRevokedToolPermissionPatterns(contextOptions)
   const permission = buildCoworkRuntimePermissionConfig({
     managedSkillNames,
     allowPatterns: allowedPatterns,
     askPatterns,
+    deniedPatterns,
     bash: bashPolicy,
     fileWrite: fileWritePolicy,
     task: appPermissions.task,
@@ -424,6 +427,7 @@ function buildRuntimeConfigWithCustomMcps(
     allToolPatterns,
     allowToolPatterns: allowedPatterns,
     askToolPatterns: askPatterns,
+    deniedToolPatterns: deniedPatterns,
     managedSkillNames,
     availableSkillNames: managedSkillNames,
     bash: bashPolicy,

--- a/apps/desktop/src/main/runtime-permissions.ts
+++ b/apps/desktop/src/main/runtime-permissions.ts
@@ -9,6 +9,7 @@ export function buildCoworkRuntimePermissionConfig(options: {
   managedSkillNames: string[]
   allowPatterns: string[]
   askPatterns: string[]
+  deniedPatterns?: string[]
   bash: PermissionAction
   fileWrite: PermissionAction
   task: PermissionAction
@@ -24,6 +25,7 @@ export function buildCoworkRuntimePermissionConfig(options: {
     }),
     allowPatterns: options.allowPatterns,
     askPatterns: options.askPatterns,
+    deniedPatterns: options.deniedPatterns,
     question: 'deny',
     task: options.task,
     todoWrite: 'allow',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -87,6 +87,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'operations:pause-agent',
   'operations:retire-agent',
   'operations:quarantine-memory',
+  'operations:revoke-tool',
   'channels:list',
   'channels:definitions',
   'channels:inbound-items',
@@ -331,6 +332,7 @@ const api: CoworkAPI = {
     pauseAgent: (request) => invoke('operations:pause-agent', request),
     retireAgent: (request) => invoke('operations:retire-agent', request),
     quarantineMemory: (request) => invoke('operations:quarantine-memory', request),
+    revokeTool: (request) => invoke('operations:revoke-tool', request),
   },
   channels: {
     list: () => invoke('channels:list'),

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -273,6 +273,18 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       pauseAgent: vi.fn(async () => true),
       retireAgent: vi.fn(async () => true),
       quarantineMemory: vi.fn(async () => null),
+      revokeTool: vi.fn(async (request: { toolId: string, reason?: string | null }) => ({
+        schemaVersion: 1,
+        toolId: request.toolId,
+        label: request.toolId,
+        patterns: [request.toolId],
+        source: 'native',
+        scope: 'system',
+        directory: null,
+        revokedAt: new Date(0).toISOString(),
+        revokedBy: 'local-user',
+        reason: request.reason || null,
+      })),
     },
     improvements: {
       summary: vi.fn(async () => ({

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -119,18 +119,24 @@ map without changing OpenCode execution:
   controls planned in later governance slices
 
 The first active incident controls are crew lifecycle controls, custom-agent
-pause/retire controls, and governed-memory quarantine. Admin surfaces can pause
-or retire a crew through the `crews` IPC namespace; paused or retired crews keep
-their history and registry entry but cannot start new runs. Admin surfaces can
-pause or retire a custom agent through the operations namespace; pausing
-disables the generated OpenCode agent config, while retiring removes the custom
-agent from user-managed runtime content. Admin surfaces can also quarantine an
-approved memory entry through the operations namespace; quarantined memory stays
-inspectable and auditable but is excluded from future memory injection. Each
-control writes a durable governance audit event with actor, action,
-before/after lifecycle state, subject id, and bounded metadata. Admin surfaces
-can query those events through the operations namespace. The export path emits a
-typed audit stream as deterministic NDJSON or
+pause/retire controls, tool revocation, and governed-memory quarantine. Admin
+surfaces can pause or retire a crew through the `crews` IPC namespace; paused
+or retired crews keep their history and registry entry but cannot start new
+runs. Admin surfaces can pause or retire a custom agent through the operations
+namespace; pausing disables the generated OpenCode agent config, while retiring
+removes the custom agent from user-managed runtime content. Admin surfaces can
+revoke a tool through the operations namespace; Open Cowork records the
+revocation as governance policy, feeds deny patterns into the generated
+OpenCode permission config, reboots the managed runtime so the SDK sees the new
+policy, and marks matching tool dependencies as revoked in the registry.
+Project-scoped custom MCP revocations keep their project directory identity, so
+the deny policy only applies when building that project's runtime config.
+Admin surfaces can also quarantine an approved memory entry through the
+operations namespace; quarantined memory stays inspectable and auditable but is
+excluded from future memory injection. Each control writes a durable governance
+audit event with actor, action, before/after lifecycle state, subject id, and
+bounded metadata. Admin surfaces can query those events through the operations
+namespace. The export path emits a typed audit stream as deterministic NDJSON or
 OpenTelemetry-shaped JSON and covers governance incidents, crew traces,
 approvals, policy decisions, tool-call trace records, channel/automation
 deliveries, and outcome evaluations.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -6,8 +6,8 @@ export const COWORK_GOVERNANCE_SCHEMA_VERSION = 1
 export const COWORK_GOVERNANCE_AUDIT_SCHEMA_VERSION = 1
 export const COWORK_GOVERNANCE_AUDIT_EXPORT_SCHEMA_VERSION = 2
 
-export type GovernanceSubjectKind = 'agent' | 'crew' | 'memory'
-export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired' | 'quarantined'
+export type GovernanceSubjectKind = 'agent' | 'crew' | 'memory' | 'tool'
+export type GovernanceLifecycleState = 'draft' | 'review' | 'approved' | 'active' | 'paused' | 'retired' | 'quarantined' | 'revoked'
 export type GovernanceScopeKind = 'system' | 'machine' | 'project' | 'workspace_profile'
 export type GovernanceDependencyKind =
   | 'agent'
@@ -28,6 +28,7 @@ export type GovernanceIncidentControlKind =
   | 'pause_crew'
   | 'retire_crew'
   | 'quarantine_memory'
+  | 'revoke_tool'
   | 'export_audit'
 export type GovernanceAuditEventKind = 'incident_control'
 export type GovernanceAuditOutcome = 'succeeded' | 'failed'
@@ -60,6 +61,7 @@ export interface GovernanceDependency {
   label: string
   source: GovernanceDependencySource
   required: boolean
+  lifecycle?: GovernanceLifecycleState | null
 }
 
 export interface GovernanceMemoryBoundary {
@@ -160,6 +162,27 @@ export interface GovernanceAgentIncidentControlRequest {
 export interface GovernanceMemoryIncidentControlRequest {
   memoryId: string
   reason?: string | null
+}
+
+export interface GovernanceToolIncidentControlRequest {
+  toolId: string
+  reason?: string | null
+  context?: {
+    directory?: string | null
+  }
+}
+
+export interface GovernanceRevokedTool {
+  schemaVersion: number
+  toolId: string
+  label: string
+  patterns: string[]
+  source: 'configured' | 'custom-mcp' | 'native'
+  scope: GovernanceScopeKind
+  directory: string | null
+  revokedAt: string
+  revokedBy: string
+  reason: string | null
 }
 
 export type GovernanceAuditExportRecordPayload =

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -136,8 +136,10 @@ import type {
   GovernanceAuditExportFormat,
   GovernanceAuditExportPayload,
   GovernanceMemoryIncidentControlRequest,
+  GovernanceRevokedTool,
   GovernanceSubjectKind,
   GovernanceRegistryPayload,
+  GovernanceToolIncidentControlRequest,
 } from './governance.js'
 import type {
   CapabilityRiskMetadata,
@@ -341,6 +343,7 @@ export interface CoworkAPI {
     pauseAgent: (request: GovernanceAgentIncidentControlRequest) => Promise<boolean>
     retireAgent: (request: GovernanceAgentIncidentControlRequest) => Promise<boolean>
     quarantineMemory: (request: GovernanceMemoryIncidentControlRequest) => Promise<AgentMemoryEntry | null>
+    revokeTool: (request: GovernanceToolIncidentControlRequest) => Promise<GovernanceRevokedTool>
   }
   channels: {
     list: () => Promise<ChannelListPayload>

--- a/tests/governance-tool-controls.test.ts
+++ b/tests/governance-tool-controls.test.ts
@@ -1,0 +1,246 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { buildRuntimeConfig } from '../apps/desktop/src/main/runtime-config-builder.ts'
+import { closeLogger } from '../apps/desktop/src/main/logger.ts'
+import { getGovernanceRegistry } from '../apps/desktop/src/main/governance-registry.ts'
+import { exportGovernanceAuditEvents } from '../apps/desktop/src/main/governance-audit-export.ts'
+import {
+  clearGovernanceAuditStoreCache,
+  listGovernanceAuditEvents,
+} from '../apps/desktop/src/main/governance-audit-store.ts'
+import { revokeGovernanceTool } from '../apps/desktop/src/main/governance-tool-controls.ts'
+import { listRevokedToolPermissionPatterns } from '../apps/desktop/src/main/governance-tool-policy.ts'
+import {
+  clearGovernanceToolPolicyCache,
+  listRevokedGovernanceTools,
+} from '../apps/desktop/src/main/governance-tool-policy-store.ts'
+import { saveCustomMcp } from '../apps/desktop/src/main/native-customizations.ts'
+
+function uniqueUserDataDir(name: string) {
+  return mkdtempSync(join(tmpdir(), `open-cowork-tool-controls-${name}-`))
+}
+
+function writeToolConfig(configDir: string) {
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), `{
+  "providers": {
+    "available": ["test-provider"],
+    "defaultProvider": "test-provider",
+    "defaultModel": "fast",
+    "descriptors": {
+      "test-provider": {
+        "runtime": "builtin",
+        "name": "Test Provider",
+        "description": "Static test provider.",
+        "credentials": [],
+        "models": [{ "id": "fast", "name": "Fast" }]
+      }
+    }
+  },
+  "tools": [
+    {
+      "id": "warehouse",
+      "name": "Warehouse",
+      "icon": "database",
+      "description": "Query and export warehouse data.",
+      "kind": "mcp",
+      "namespace": "warehouse",
+      "patterns": ["mcp__warehouse__*"],
+      "allowPatterns": ["mcp__warehouse__query"],
+      "askPatterns": ["mcp__warehouse__export"]
+    }
+  ],
+  "skills": [
+    {
+      "name": "Analyst",
+      "description": "Analyze warehouse metrics.",
+      "badge": "Skill",
+      "sourceName": "analyst",
+      "toolIds": ["warehouse"]
+    }
+  ],
+  "agents": [
+    {
+      "name": "data-analyst",
+      "description": "Analyze business metrics.",
+      "instructions": "Use warehouse evidence.",
+      "skillNames": ["analyst"],
+      "toolIds": ["warehouse"],
+      "mode": "subagent"
+    }
+  ],
+  "permissions": {
+    "bash": "deny",
+    "fileWrite": "deny",
+    "task": "allow",
+    "web": "deny",
+    "webSearch": false
+  }
+}
+`)
+}
+
+function withToolControlStore(
+  name: string,
+  fn: (paths: { userDataDir: string, configDir: string }) => Promise<void>,
+) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  const configDir = join(userDataDir, 'config')
+  return (async () => {
+    try {
+      process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+      process.env.OPEN_COWORK_CONFIG_DIR = configDir
+      writeToolConfig(configDir)
+      clearConfigCaches()
+      clearGovernanceAuditStoreCache()
+      clearGovernanceToolPolicyCache()
+      await fn({ userDataDir, configDir })
+    } finally {
+      clearGovernanceToolPolicyCache()
+      clearGovernanceAuditStoreCache()
+      clearConfigCaches()
+      closeLogger()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+      else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+      if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+      else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+      rmSync(userDataDir, { recursive: true, force: true })
+    }
+  })()
+}
+
+test('revokeGovernanceTool records audit evidence and denies the tool in runtime permissions', async () => withToolControlStore('revoke-configured', async () => {
+  const beforeConfig = buildRuntimeConfig() as Record<string, any>
+  assert.equal(beforeConfig.permission['mcp__warehouse__query'], 'allow')
+  assert.equal(beforeConfig.permission['mcp__warehouse__export'], 'ask')
+  assert.equal(beforeConfig.agent.build.permission['mcp__warehouse__query'], 'allow')
+
+  let rebootCount = 0
+  const revoked = await revokeGovernanceTool({
+    toolId: 'warehouse',
+    reason: 'Compromised integration token.',
+  }, {
+    rebootRuntime: async () => {
+      rebootCount += 1
+    },
+  })
+
+  assert.equal(rebootCount, 1)
+  assert.equal(revoked.toolId, 'warehouse')
+  assert.equal(revoked.reason, 'Compromised integration token.')
+  assert.deepEqual(listRevokedGovernanceTools().map((tool) => tool.toolId), ['warehouse'])
+  assert.deepEqual(listRevokedToolPermissionPatterns(), [
+    'mcp__warehouse__*',
+    'mcp__warehouse__export',
+    'mcp__warehouse__query',
+    'warehouse_*',
+    'warehouse_export',
+    'warehouse_query',
+  ])
+
+  const afterConfig = buildRuntimeConfig() as Record<string, any>
+  assert.equal(afterConfig.permission['mcp__warehouse__*'], 'deny')
+  assert.equal(afterConfig.permission['warehouse_*'], 'deny')
+  assert.equal(afterConfig.permission['mcp__warehouse__query'], 'deny')
+  assert.equal(afterConfig.permission['mcp__warehouse__export'], 'deny')
+  assert.equal(afterConfig.agent.build.permission['mcp__warehouse__query'], 'deny')
+  assert.equal(afterConfig.agent['data-analyst'].permission['mcp__warehouse__query'], 'deny')
+
+  const registry = await getGovernanceRegistry()
+  const dependencyIndex = registry.dependencyIndex.find((entry) => entry.dependency.kind === 'tool' && entry.dependency.id === 'warehouse')
+  assert.equal(dependencyIndex?.dependency.lifecycle, 'revoked')
+  assert.equal(dependencyIndex?.subjectIds.some((subjectId) => subjectId.includes('data-analyst')), true)
+
+  const subjectId = 'tool:warehouse'
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'tool', subjectId })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.action, 'revoke_tool')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'active')
+  assert.equal(auditEvents[0]?.afterLifecycle, 'revoked')
+  assert.equal((auditEvents[0]?.metadata as Record<string, unknown>)?.toolId, 'warehouse')
+
+  const exported = exportGovernanceAuditEvents({ subjectKind: 'tool', subjectId })
+  const rows = exported.body.trim().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>)
+  assert.equal(rows.length, 1)
+  assert.equal(rows[0]?.recordType, 'governance_incident')
+  assert.equal((rows[0]?.payload as Record<string, unknown>)?.action, 'revoke_tool')
+}))
+
+test('revokeGovernanceTool resolves project custom MCPs through a granted context', async () => withToolControlStore('revoke-project-mcp', async ({ userDataDir }) => {
+  const projectDir = join(userDataDir, 'project')
+  const otherProjectDir = join(userDataDir, 'other-project')
+  mkdirSync(projectDir, { recursive: true })
+  mkdirSync(otherProjectDir, { recursive: true })
+  saveCustomMcp({
+    scope: 'project',
+    directory: projectDir,
+    name: 'analytics',
+    label: 'Analytics MCP',
+    description: 'Project-scoped analytical tools.',
+    type: 'http',
+    url: 'https://analytics.example.test/mcp',
+    permissionMode: 'allow',
+  })
+  saveCustomMcp({
+    scope: 'project',
+    directory: otherProjectDir,
+    name: 'analytics',
+    label: 'Other Analytics MCP',
+    description: 'Another project with the same MCP namespace.',
+    type: 'http',
+    url: 'https://other-analytics.example.test/mcp',
+    permissionMode: 'allow',
+  })
+
+  let rebootCount = 0
+  const revoked = await revokeGovernanceTool({
+    toolId: 'analytics',
+    context: { directory: projectDir },
+  }, {
+    rebootRuntime: async () => {
+      rebootCount += 1
+    },
+  })
+
+  assert.equal(rebootCount, 1)
+  assert.equal(revoked.label, 'Analytics MCP')
+  assert.equal(revoked.scope, 'project')
+  assert.equal(revoked.directory, projectDir)
+  assert.deepEqual(revoked.patterns, ['mcp__analytics__*', 'analytics_*'])
+  assert.deepEqual(listRevokedToolPermissionPatterns(), [])
+  assert.deepEqual(listRevokedToolPermissionPatterns({ directory: projectDir }), ['analytics_*', 'mcp__analytics__*'])
+  assert.deepEqual(listRevokedToolPermissionPatterns({ directory: otherProjectDir }), [])
+
+  const registry = await getGovernanceRegistry({ directory: projectDir })
+  assert.equal(
+    registry.dependencyIndex.some((entry) => entry.dependency.kind === 'tool' && entry.dependency.id === 'analytics'),
+    false,
+    'revoking a project MCP should not invent agent dependencies until an agent references it',
+  )
+}))
+
+test('revokeGovernanceTool refuses unknown tools without auditing or rebooting', async () => withToolControlStore('revoke-missing', async () => {
+  let rebootCount = 0
+  await assert.rejects(
+    () => revokeGovernanceTool({
+      toolId: 'missing-tool',
+      reason: 'No such tool.',
+    }, {
+      rebootRuntime: async () => {
+        rebootCount += 1
+      },
+    }),
+    /No tool found for governance incident missing-tool/,
+  )
+
+  assert.equal(rebootCount, 0)
+  assert.deepEqual(listRevokedGovernanceTools(), [])
+  assert.deepEqual(listGovernanceAuditEvents(), [])
+}))

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -269,6 +269,38 @@ test('operations:quarantine-memory rejects malformed incident-control requests a
   )
 })
 
+test('operations:revoke-tool rejects malformed incident-control requests at the IPC boundary', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerOperationHandlers(context)
+  const handler = handlers.get('operations:revoke-tool')
+
+  assert.ok(handler, 'expected operations:revoke-tool handler to be registered')
+  await assert.rejects(
+    () => handler({}, { toolId: 'charts', reason: 123 }),
+    /Tool incident reason must be a string/,
+  )
+})
+
+test('operations:revoke-tool resolves incident-control context through granted project directories', async () => {
+  const { context, handlers } = createBaseContext()
+  let requestedDirectory: string | null | undefined
+  context.resolveContextDirectory = (options) => {
+    requestedDirectory = options?.directory
+    return null
+  }
+
+  registerOperationHandlers(context)
+  const handler = handlers.get('operations:revoke-tool')
+
+  assert.ok(handler, 'expected operations:revoke-tool handler to be registered')
+  await assert.rejects(
+    () => handler({}, { toolId: 'warehouse', context: { directory: '/ungranted/project' } }),
+    /Tool incident context requires an active project directory/,
+  )
+  assert.equal(requestedDirectory, '/ungranted/project')
+})
+
 test('session:prompt clears pending prompt echo when dispatch fails', async () => {
   const { context, handlers } = createBaseContext()
   let promptCalled = false

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -133,6 +133,7 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('operations:pause-agent'), true)
   assert.equal(handlers.has('operations:retire-agent'), true)
   assert.equal(handlers.has('operations:quarantine-memory'), true)
+  assert.equal(handlers.has('operations:revoke-tool'), true)
   assert.equal(handlers.has('channels:list'), true)
   assert.equal(handlers.has('channels:definitions'), true)
   assert.equal(handlers.has('channels:inbound-items'), true)


### PR DESCRIPTION
## Summary
- add a durable governed-tool revocation policy store and incident-control IPC
- feed revoked tool permission patterns into generated OpenCode runtime and agent permission config
- mark revoked tool dependencies in the governance registry and audit/export stream
- document the active tool revocation control in operations docs

Refs #250

## Validation
- pnpm typecheck
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-tool-controls.test.ts tests/governance-registry.test.ts tests/governance-audit-store.test.ts tests/ipc-handler-registration.test.ts tests/ipc-handler-behavior.test.ts tests/runtime-config-builder.test.ts
- pnpm lint
- pnpm test
- pnpm test:renderer
- pnpm build
- uv run mkdocs build --strict
- git diff --check