### PR TITLE
[codex] add governance incident-control RBAC

### DIFF
--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -14,6 +14,7 @@ import {
   type CrewRunDraft,
   type TraceActor,
   type TraceEventSource,
+  type GovernancePrincipal,
   createCoworkTraceEvent,
 } from '@open-cowork/shared'
 import { createHash } from 'node:crypto'
@@ -53,6 +54,11 @@ import {
   withCrewTransaction,
 } from './crew-store.ts'
 import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
+import {
+  LOCAL_GOVERNANCE_OWNER,
+  assertGovernanceIncidentControlAllowed,
+  decideGovernanceIncidentControl,
+} from './governance-policy.ts'
 import {
   crewOutcomeEvaluationOutputFormat,
   crewOutcomeEvaluationSchemaHint,
@@ -105,6 +111,10 @@ const DEFAULT_CREW_OUTCOME_RUBRIC = {
       passingScore: 80,
     },
   ],
+}
+
+export type CrewIncidentControlOptions = {
+  actor?: GovernancePrincipal | null
 }
 
 function boundedString(value: unknown, label: string) {
@@ -218,13 +228,48 @@ export function updateCrewFromDraft(crewId: string, draft: CrewDefinitionDraft):
   })
 }
 
-function setCrewLifecycleStatus(crewId: string, status: CrewLifecycleStatus): CrewDetail {
+function setCrewLifecycleStatus(
+  crewId: string,
+  status: CrewLifecycleStatus,
+  options: CrewIncidentControlOptions = {},
+): CrewDetail {
   const id = boundedString(crewId, 'Crew id')
   return withCrewTransaction(() => {
     const current = getCrewDefinition(id)
     if (!current) throw new Error(`Crew ${id} does not exist.`)
     if (current.status === 'retired' && status !== 'retired') {
       throw new Error(`Crew ${id} is retired and cannot be reactivated.`)
+    }
+    const action = status === 'paused' ? 'pause_crew' : 'retire_crew'
+    const reason = status === 'paused'
+      ? 'Crew paused through governance incident control.'
+      : 'Crew retired through governance incident control.'
+    const subjectId = `crew:${encodeURIComponent(id)}`
+    const policyDecision = decideGovernanceIncidentControl({
+      actor: options.actor,
+      action,
+      subjectKind: 'crew',
+      subjectId,
+      owner: LOCAL_GOVERNANCE_OWNER,
+      approvers: [LOCAL_GOVERNANCE_OWNER],
+    })
+    if (policyDecision.outcome === 'denied') {
+      recordGovernanceAuditEvent({
+        subjectKind: 'crew',
+        subjectId,
+        action,
+        outcome: 'failed',
+        actor: policyDecision.actor,
+        beforeLifecycle: current.status,
+        afterLifecycle: null,
+        reason: policyDecision.reason,
+        metadata: {
+          crewId: id,
+          crewName: current.name,
+          policyDecision,
+        },
+      })
+      assertGovernanceIncidentControlAllowed(policyDecision)
     }
     const updated = updateCrewDefinitionMetadata(id, {
       name: current.name,
@@ -236,28 +281,28 @@ function setCrewLifecycleStatus(crewId: string, status: CrewLifecycleStatus): Cr
     if (!detail) throw new Error(`Failed to load crew ${id}.`)
     recordGovernanceAuditEvent({
       subjectKind: 'crew',
-      subjectId: `crew:${encodeURIComponent(id)}`,
-      action: status === 'paused' ? 'pause_crew' : 'retire_crew',
+      subjectId,
+      action,
+      actor: policyDecision.actor,
       beforeLifecycle: current.status,
       afterLifecycle: status,
-      reason: status === 'paused'
-        ? 'Crew paused through governance incident control.'
-        : 'Crew retired through governance incident control.',
+      reason,
       metadata: {
         crewId: id,
         crewName: current.name,
+        policyDecision,
       },
     })
     return detail
   })
 }
 
-export function pauseCrew(crewId: string): CrewDetail {
-  return setCrewLifecycleStatus(crewId, 'paused')
+export function pauseCrew(crewId: string, options?: CrewIncidentControlOptions): CrewDetail {
+  return setCrewLifecycleStatus(crewId, 'paused', options)
 }
 
-export function retireCrew(crewId: string): CrewDetail {
-  return setCrewLifecycleStatus(crewId, 'retired')
+export function retireCrew(crewId: string, options?: CrewIncidentControlOptions): CrewDetail {
+  return setCrewLifecycleStatus(crewId, 'retired', options)
 }
 
 export function listCrewCatalog(): CrewListPayload {

--- a/apps/desktop/src/main/governance-agent-controls.ts
+++ b/apps/desktop/src/main/governance-agent-controls.ts
@@ -1,4 +1,4 @@
-import type { CustomAgentConfig, RuntimeContextOptions, ScopedArtifactRef } from '@open-cowork/shared'
+import type { CustomAgentConfig, GovernancePrincipal, RuntimeContextOptions, ScopedArtifactRef } from '@open-cowork/shared'
 import { getCustomAgentSummaries, normalizeCustomAgent, type CustomAgentSummary } from './custom-agents.ts'
 import {
   customAgentGovernanceLifecycle,
@@ -6,6 +6,12 @@ import {
 } from './governance-registry.ts'
 import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
 import { listCustomAgents, removeCustomAgent, saveCustomAgent } from './native-customizations.ts'
+import {
+  LOCAL_GOVERNANCE_OWNER,
+  assertGovernanceIncidentControlAllowed,
+  decideGovernanceIncidentControl,
+  type GovernanceIncidentPolicyDecision,
+} from './governance-policy.ts'
 
 const MAX_INCIDENT_REASON_BYTES = 16 * 1024
 
@@ -21,6 +27,7 @@ export type GovernanceAgentIncidentControlDependencies = {
     options?: RuntimeContextOptions,
   ) => Promise<Record<string, unknown>>
   rebootRuntime: () => Promise<void>
+  actor?: GovernancePrincipal | null
 }
 
 type ResolvedCustomAgent = CustomAgentSummary & {
@@ -78,11 +85,14 @@ function auditAgentIncident(input: {
   action: 'pause_agent' | 'retire_agent'
   reason: string
   afterLifecycle: 'paused' | 'retired'
+  policyDecision: GovernanceIncidentPolicyDecision
 }) {
+  const subjectId = customAgentGovernanceSubjectId(input.agent)
   recordGovernanceAuditEvent({
     subjectKind: 'agent',
-    subjectId: customAgentGovernanceSubjectId(input.agent),
+    subjectId,
     action: input.action,
+    actor: input.policyDecision.actor,
     beforeLifecycle: customAgentGovernanceLifecycle(input.agent),
     afterLifecycle: input.afterLifecycle,
     reason: input.reason,
@@ -90,8 +100,45 @@ function auditAgentIncident(input: {
       agentName: input.agent.name,
       scope: input.agent.scope || 'machine',
       directory: input.agent.scope === 'project' ? input.agent.directory || null : null,
+      policyDecision: input.policyDecision,
     },
   })
+}
+
+function authorizeAgentIncident(input: {
+  agent: CustomAgentSummary
+  action: 'pause_agent' | 'retire_agent'
+  actor?: GovernancePrincipal | null
+}) {
+  const subjectId = customAgentGovernanceSubjectId(input.agent)
+  const policyDecision = decideGovernanceIncidentControl({
+    actor: input.actor,
+    action: input.action,
+    subjectKind: 'agent',
+    subjectId,
+    owner: LOCAL_GOVERNANCE_OWNER,
+    approvers: [LOCAL_GOVERNANCE_OWNER],
+  })
+  if (policyDecision.outcome === 'denied') {
+    recordGovernanceAuditEvent({
+      subjectKind: 'agent',
+      subjectId,
+      action: input.action,
+      outcome: 'failed',
+      actor: policyDecision.actor,
+      beforeLifecycle: customAgentGovernanceLifecycle(input.agent),
+      afterLifecycle: null,
+      reason: policyDecision.reason,
+      metadata: {
+        agentName: input.agent.name,
+        scope: input.agent.scope || 'machine',
+        directory: input.agent.scope === 'project' ? input.agent.directory || null : null,
+        policyDecision,
+      },
+    })
+    assertGovernanceIncidentControlAllowed(policyDecision)
+  }
+  return policyDecision
 }
 
 function assertControllableAgent(agent: ResolvedCustomAgent | null, subjectId: string): asserts agent is ResolvedCustomAgent {
@@ -110,6 +157,11 @@ export async function pauseGovernanceAgent(
   if (beforeLifecycle !== 'active') throw new Error(`Agent ${agent.name} cannot be paused from ${beforeLifecycle} state.`)
 
   const reason = boundedReason(request.reason, 'Agent paused through governance incident control.')
+  const policyDecision = authorizeAgentIncident({
+    agent,
+    action: 'pause_agent',
+    actor: dependencies.actor,
+  })
   const updated = normalizeCustomAgent({ ...agent, enabled: false })
   const context = runtimeContextForAgent(agent)
   saveCustomAgent(updated, await dependencies.buildCustomAgentPermission(updated, context))
@@ -118,6 +170,7 @@ export async function pauseGovernanceAgent(
     action: 'pause_agent',
     reason,
     afterLifecycle: 'paused',
+    policyDecision,
   })
   await dependencies.rebootRuntime()
   return true
@@ -134,12 +187,18 @@ export async function retireGovernanceAgent(
   if (beforeLifecycle === 'retired') throw new Error(`Agent ${agent.name} is already retired.`)
 
   const reason = boundedReason(request.reason, 'Agent retired through governance incident control.')
+  const policyDecision = authorizeAgentIncident({
+    agent,
+    action: 'retire_agent',
+    actor: dependencies.actor,
+  })
   removeCustomAgent(agentTarget(agent))
   auditAgentIncident({
     agent,
     action: 'retire_agent',
     reason,
     afterLifecycle: 'retired',
+    policyDecision,
   })
   await dependencies.rebootRuntime()
   return true

--- a/apps/desktop/src/main/governance-memory-controls.ts
+++ b/apps/desktop/src/main/governance-memory-controls.ts
@@ -1,11 +1,20 @@
-import type { GovernanceMemoryIncidentControlRequest } from '@open-cowork/shared'
+import type { GovernanceMemoryIncidentControlRequest, GovernancePrincipal } from '@open-cowork/shared'
 import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
+import {
+  LOCAL_GOVERNANCE_OWNER,
+  assertGovernanceIncidentControlAllowed,
+  decideGovernanceIncidentControl,
+} from './governance-policy.ts'
 import {
   getAgentMemoryEntry,
   quarantineAgentMemoryEntry,
 } from './improvement-store.ts'
 
 const MAX_INCIDENT_REASON_BYTES = 16 * 1024
+
+export type GovernanceMemoryIncidentControlDependencies = {
+  actor?: GovernancePrincipal | null
+}
 
 function boundedMemoryId(value: unknown) {
   if (typeof value !== 'string') throw new Error('Memory incident id must be a string.')
@@ -30,7 +39,10 @@ function memorySubjectId(memoryId: string) {
   return `memory:${encodeURIComponent(memoryId)}`
 }
 
-export function quarantineGovernanceMemory(request: GovernanceMemoryIncidentControlRequest) {
+export function quarantineGovernanceMemory(
+  request: GovernanceMemoryIncidentControlRequest,
+  dependencies: GovernanceMemoryIncidentControlDependencies = {},
+) {
   const memoryId = boundedMemoryId(request.memoryId)
   const entry = getAgentMemoryEntry(memoryId)
   if (!entry) throw new Error(`No memory entry found for governance incident ${memoryId}.`)
@@ -39,11 +51,43 @@ export function quarantineGovernanceMemory(request: GovernanceMemoryIncidentCont
   if (entry.status !== 'approved') throw new Error(`Memory ${memoryId} cannot be quarantined from ${entry.status} state.`)
 
   const reason = boundedReason(request.reason, 'Memory quarantined through governance incident control.')
-  const updated = quarantineAgentMemoryEntry(memoryId, 'local-user', reason)
+  const subjectId = memorySubjectId(memoryId)
+  const policyDecision = decideGovernanceIncidentControl({
+    actor: dependencies.actor,
+    action: 'quarantine_memory',
+    subjectKind: 'memory',
+    subjectId,
+    owner: LOCAL_GOVERNANCE_OWNER,
+    approvers: [LOCAL_GOVERNANCE_OWNER],
+  })
+  if (policyDecision.outcome === 'denied') {
+    recordGovernanceAuditEvent({
+      subjectKind: 'memory',
+      subjectId,
+      action: 'quarantine_memory',
+      outcome: 'failed',
+      actor: policyDecision.actor,
+      beforeLifecycle: 'approved',
+      afterLifecycle: null,
+      reason: policyDecision.reason,
+      metadata: {
+        memoryId,
+        scopeKind: entry.scopeKind,
+        scopeId: entry.scopeId,
+        privacy: entry.privacy,
+        sourceProposalId: entry.sourceProposalId,
+        policyDecision,
+      },
+    })
+    assertGovernanceIncidentControlAllowed(policyDecision)
+  }
+
+  const updated = quarantineAgentMemoryEntry(memoryId, policyDecision.actor.id, reason)
   recordGovernanceAuditEvent({
     subjectKind: 'memory',
-    subjectId: memorySubjectId(memoryId),
+    subjectId,
     action: 'quarantine_memory',
+    actor: policyDecision.actor,
     beforeLifecycle: 'approved',
     afterLifecycle: 'quarantined',
     reason,
@@ -53,6 +97,7 @@ export function quarantineGovernanceMemory(request: GovernanceMemoryIncidentCont
       scopeId: entry.scopeId,
       privacy: entry.privacy,
       sourceProposalId: entry.sourceProposalId,
+      policyDecision,
     },
   })
   return updated

--- a/apps/desktop/src/main/governance-policy.ts
+++ b/apps/desktop/src/main/governance-policy.ts
@@ -1,0 +1,114 @@
+import type {
+  GovernanceAuditActor,
+  GovernanceIncidentControlKind,
+  GovernanceOwner,
+  GovernancePrincipal,
+  GovernanceRole,
+  GovernanceSubjectKind,
+} from '@open-cowork/shared'
+import { COWORK_GOVERNANCE_SCHEMA_VERSION } from '@open-cowork/shared'
+
+const INCIDENT_CONTROL_ROLES: Record<GovernanceIncidentControlKind, GovernanceRole[]> = {
+  pause_agent: ['admin', 'owner', 'approver'],
+  retire_agent: ['admin', 'owner', 'approver'],
+  pause_crew: ['admin', 'owner', 'approver'],
+  retire_crew: ['admin', 'owner', 'approver'],
+  quarantine_memory: ['admin', 'owner', 'approver'],
+  revoke_tool: ['admin', 'approver'],
+  export_audit: ['admin', 'approver', 'viewer'],
+}
+
+export type GovernanceIncidentPolicyOutcome = 'allowed' | 'denied'
+
+export interface GovernanceIncidentPolicyDecision {
+  schemaVersion: number
+  subjectKind: GovernanceSubjectKind
+  subjectId: string
+  action: GovernanceIncidentControlKind
+  outcome: GovernanceIncidentPolicyOutcome
+  reason: string
+  requiredRoles: GovernanceRole[]
+  actor: GovernanceAuditActor
+  actorRoles: GovernanceRole[]
+}
+
+export const LOCAL_GOVERNANCE_OWNER: GovernanceOwner = {
+  kind: 'user',
+  id: 'local-user',
+  displayName: 'Local user',
+}
+
+export const SYSTEM_GOVERNANCE_OWNER: GovernanceOwner = {
+  kind: 'system',
+  id: 'open-cowork',
+  displayName: 'Open Cowork',
+}
+
+export const LOCAL_GOVERNANCE_PRINCIPAL: GovernancePrincipal = {
+  ...LOCAL_GOVERNANCE_OWNER,
+  roles: ['admin', 'approver', 'owner'],
+  groupIds: [],
+}
+
+export function governancePrincipalToAuditActor(principal: GovernancePrincipal): GovernanceAuditActor {
+  return {
+    kind: principal.kind,
+    id: principal.id,
+    displayName: principal.displayName,
+  }
+}
+
+function hasRole(principal: GovernancePrincipal, role: GovernanceRole) {
+  return principal.roles.includes(role)
+}
+
+function ownsSubject(principal: GovernancePrincipal, owner?: GovernanceOwner | null) {
+  if (!owner) return false
+  return principal.kind === owner.kind && principal.id === owner.id
+}
+
+function approvesSubject(principal: GovernancePrincipal, approvers: GovernanceOwner[] = []) {
+  return approvers.some((approver) => (
+    principal.kind === approver.kind && principal.id === approver.id
+  ))
+}
+
+export function requiredRolesForGovernanceIncident(action: GovernanceIncidentControlKind): GovernanceRole[] {
+  return [...INCIDENT_CONTROL_ROLES[action]]
+}
+
+export function decideGovernanceIncidentControl(input: {
+  actor?: GovernancePrincipal | null
+  action: GovernanceIncidentControlKind
+  subjectKind: GovernanceSubjectKind
+  subjectId: string
+  owner?: GovernanceOwner | null
+  approvers?: GovernanceOwner[]
+}): GovernanceIncidentPolicyDecision {
+  const actor = input.actor || LOCAL_GOVERNANCE_PRINCIPAL
+  const requiredRoles = requiredRolesForGovernanceIncident(input.action)
+  const allowed = hasRole(actor, 'admin')
+    || (requiredRoles.includes('approver') && (hasRole(actor, 'approver') || approvesSubject(actor, input.approvers)))
+    || (requiredRoles.includes('owner') && ownsSubject(actor, input.owner))
+    || (requiredRoles.includes('viewer') && hasRole(actor, 'viewer'))
+
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    subjectKind: input.subjectKind,
+    subjectId: input.subjectId,
+    action: input.action,
+    outcome: allowed ? 'allowed' : 'denied',
+    reason: allowed
+      ? 'Actor is authorized for this governance incident control.'
+      : `Actor ${actor.id} is not authorized to ${input.action.replace(/_/g, ' ')}.`,
+    requiredRoles,
+    actor: governancePrincipalToAuditActor(actor),
+    actorRoles: [...actor.roles],
+  }
+}
+
+export function assertGovernanceIncidentControlAllowed(
+  decision: GovernanceIncidentPolicyDecision,
+) {
+  if (decision.outcome === 'denied') throw new Error(decision.reason)
+}

--- a/apps/desktop/src/main/governance-policy.ts
+++ b/apps/desktop/src/main/governance-policy.ts
@@ -62,15 +62,18 @@ function hasRole(principal: GovernancePrincipal, role: GovernanceRole) {
   return principal.roles.includes(role)
 }
 
-function ownsSubject(principal: GovernancePrincipal, owner?: GovernanceOwner | null) {
+function principalMatchesOwner(principal: GovernancePrincipal, owner?: GovernanceOwner | null) {
   if (!owner) return false
-  return principal.kind === owner.kind && principal.id === owner.id
+  if (principal.kind === owner.kind && principal.id === owner.id) return true
+  return owner.kind === 'group' && principal.groupIds.includes(owner.id)
+}
+
+function ownsSubject(principal: GovernancePrincipal, owner?: GovernanceOwner | null) {
+  return principalMatchesOwner(principal, owner)
 }
 
 function approvesSubject(principal: GovernancePrincipal, approvers: GovernanceOwner[] = []) {
-  return approvers.some((approver) => (
-    principal.kind === approver.kind && principal.id === approver.id
-  ))
+  return approvers.some((approver) => principalMatchesOwner(principal, approver))
 }
 
 export function requiredRolesForGovernanceIncident(action: GovernanceIncidentControlKind): GovernanceRole[] {

--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -34,6 +34,11 @@ import { listChannelDefinitions } from './channel-store.ts'
 import { listSopDefinitions } from './sop-service.ts'
 import { listCustomMcps } from './native-customizations.ts'
 import { listApplicableRevokedGovernanceTools } from './governance-tool-policy.ts'
+import {
+  LOCAL_GOVERNANCE_OWNER,
+  SYSTEM_GOVERNANCE_OWNER,
+  requiredRolesForGovernanceIncident,
+} from './governance-policy.ts'
 
 export interface GovernanceRegistryBuildInput {
   builtinAgents: BuiltInAgentDetail[]
@@ -60,18 +65,6 @@ export type GovernanceCustomAgentIdentity = {
 export type GovernanceToolCredentialDependency = {
   toolId: string
   dependency: GovernanceDependency
-}
-
-const LOCAL_OWNER = {
-  kind: 'user' as const,
-  id: 'local-user',
-  displayName: 'Local user',
-}
-
-const SYSTEM_OWNER = {
-  kind: 'system' as const,
-  id: 'open-cowork',
-  displayName: 'Open Cowork',
 }
 
 function idSegment(value: string): string {
@@ -327,6 +320,7 @@ function builtInAgentControls(agent: BuiltInAgentDetail): GovernanceIncidentCont
       label: 'Disable through built-in agent override',
       available: false,
       requiresConfirmation: true,
+      requiredRoles: requiredRolesForGovernanceIncident('pause_agent'),
       reason: agent.source === 'opencode'
         ? 'OpenCode-owned built-in agents require config overrides rather than a local destructive action.'
         : 'Configured built-ins are controlled by Open Cowork configuration.',
@@ -336,6 +330,7 @@ function builtInAgentControls(agent: BuiltInAgentDetail): GovernanceIncidentCont
       label: 'Retire built-in agent',
       available: false,
       requiresConfirmation: true,
+      requiredRoles: requiredRolesForGovernanceIncident('retire_agent'),
       reason: 'Built-in agents are part of the configured runtime contract and cannot be deleted from user data.',
     },
   ]
@@ -349,6 +344,7 @@ function customAgentControls(agent: GovernanceCustomAgentSummary): GovernanceInc
       label: lifecycle === 'active' ? 'Disable custom agent' : lifecycle === 'paused' ? 'Custom agent already disabled' : 'Custom agent not approved',
       available: lifecycle === 'active',
       requiresConfirmation: false,
+      requiredRoles: requiredRolesForGovernanceIncident('pause_agent'),
       reason: lifecycle === 'active'
         ? null
         : lifecycle === 'paused'
@@ -360,6 +356,7 @@ function customAgentControls(agent: GovernanceCustomAgentSummary): GovernanceInc
       label: 'Remove custom agent',
       available: true,
       requiresConfirmation: true,
+      requiredRoles: requiredRolesForGovernanceIncident('retire_agent'),
       reason: null,
     },
   ]
@@ -374,6 +371,7 @@ function crewControls(lifecycle: GovernanceLifecycleState): GovernanceIncidentCo
       label: retired ? 'Crew retired' : paused ? 'Crew paused' : 'Pause crew',
       available: !retired && !paused,
       requiresConfirmation: true,
+      requiredRoles: requiredRolesForGovernanceIncident('pause_crew'),
       reason: retired
         ? 'The crew is already retired.'
         : paused
@@ -385,6 +383,7 @@ function crewControls(lifecycle: GovernanceLifecycleState): GovernanceIncidentCo
       label: retired ? 'Crew retired' : 'Retire crew',
       available: !retired,
       requiresConfirmation: true,
+      requiredRoles: requiredRolesForGovernanceIncident('retire_crew'),
       reason: retired ? 'The crew is already retired.' : null,
     },
     {
@@ -392,6 +391,7 @@ function crewControls(lifecycle: GovernanceLifecycleState): GovernanceIncidentCo
       label: 'Export crew run trace',
       available: true,
       requiresConfirmation: false,
+      requiredRoles: requiredRolesForGovernanceIncident('export_audit'),
       reason: null,
     },
   ]
@@ -459,7 +459,8 @@ function buildBuiltInAgentSubject(
     name: agent.name,
     displayName,
     description: agent.description,
-    owner: SYSTEM_OWNER,
+    owner: SYSTEM_GOVERNANCE_OWNER,
+    approvers: [LOCAL_GOVERNANCE_OWNER],
     lifecycle: agent.disabled ? 'paused' : 'active',
     scope: {
       kind: 'system',
@@ -492,7 +493,8 @@ function buildCustomAgentSubject(
     name: agent.name,
     displayName: agent.name,
     description: agent.description,
-    owner: LOCAL_OWNER,
+    owner: LOCAL_GOVERNANCE_OWNER,
+    approvers: [LOCAL_GOVERNANCE_OWNER],
     lifecycle: customAgentGovernanceLifecycle(agent),
     scope: customAgentScope(agent),
     memoryBoundary: {
@@ -562,7 +564,8 @@ function buildCrewSubject(input: {
     name: definition.id,
     displayName: definition.name,
     description: definition.description,
-    owner: LOCAL_OWNER,
+    owner: LOCAL_GOVERNANCE_OWNER,
+    approvers: [LOCAL_GOVERNANCE_OWNER],
     lifecycle: definition.status,
     scope,
     memoryBoundary: {

--- a/apps/desktop/src/main/governance-tool-controls.ts
+++ b/apps/desktop/src/main/governance-tool-controls.ts
@@ -1,13 +1,19 @@
-import type { GovernanceRevokedTool, GovernanceToolIncidentControlRequest } from '@open-cowork/shared'
+import type { GovernancePrincipal, GovernanceRevokedTool, GovernanceToolIncidentControlRequest } from '@open-cowork/shared'
 import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
 import { saveRevokedGovernanceTool } from './governance-tool-policy-store.ts'
 import { resolveGovernanceToolControlTarget } from './governance-tool-policy.ts'
+import {
+  LOCAL_GOVERNANCE_OWNER,
+  assertGovernanceIncidentControlAllowed,
+  decideGovernanceIncidentControl,
+} from './governance-policy.ts'
 
 const MAX_INCIDENT_REASON_BYTES = 16 * 1024
 const MAX_TOOL_ID_BYTES = 512
 
 export type GovernanceToolIncidentControlDependencies = {
   rebootRuntime: () => Promise<void>
+  actor?: GovernancePrincipal | null
 }
 
 function boundedToolId(value: unknown) {
@@ -38,6 +44,38 @@ export async function revokeGovernanceTool(
   if (!target) throw new Error(`No tool found for governance incident ${toolId}.`)
 
   const reason = boundedReason(request.reason, 'Tool revoked through governance incident control.')
+  const subjectId = `tool:${encodeURIComponent(target.toolId)}`
+  const policyDecision = decideGovernanceIncidentControl({
+    actor: dependencies.actor,
+    action: 'revoke_tool',
+    subjectKind: 'tool',
+    subjectId,
+    owner: LOCAL_GOVERNANCE_OWNER,
+    approvers: [LOCAL_GOVERNANCE_OWNER],
+  })
+  if (policyDecision.outcome === 'denied') {
+    recordGovernanceAuditEvent({
+      subjectKind: 'tool',
+      subjectId,
+      action: 'revoke_tool',
+      outcome: 'failed',
+      actor: policyDecision.actor,
+      beforeLifecycle: 'active',
+      afterLifecycle: null,
+      reason: policyDecision.reason,
+      metadata: {
+        toolId: target.toolId,
+        label: target.label,
+        patterns: target.patterns,
+        source: target.source,
+        scope: target.scope,
+        directory: target.directory,
+        policyDecision,
+      },
+    })
+    assertGovernanceIncidentControlAllowed(policyDecision)
+  }
+
   const revoked = saveRevokedGovernanceTool({
     toolId: target.toolId,
     label: target.label,
@@ -46,12 +84,13 @@ export async function revokeGovernanceTool(
     scope: target.scope,
     directory: target.directory,
     reason,
-    revokedBy: 'local-user',
+    revokedBy: policyDecision.actor.id,
   })
   recordGovernanceAuditEvent({
     subjectKind: 'tool',
-    subjectId: `tool:${encodeURIComponent(target.toolId)}`,
+    subjectId,
     action: 'revoke_tool',
+    actor: policyDecision.actor,
     beforeLifecycle: 'active',
     afterLifecycle: 'revoked',
     reason,
@@ -62,6 +101,7 @@ export async function revokeGovernanceTool(
       source: target.source,
       scope: target.scope,
       directory: target.directory,
+      policyDecision,
     },
   })
   await dependencies.rebootRuntime()

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -119,27 +119,35 @@ map without changing OpenCode execution:
   controls planned in later governance slices
 
 The first active incident controls are crew lifecycle controls, custom-agent
-pause/retire controls, tool revocation, and governed-memory quarantine. Admin
-surfaces can pause or retire a crew through the `crews` IPC namespace; paused
-or retired crews keep their history and registry entry but cannot start new
-runs. Admin surfaces can pause or retire a custom agent through the operations
-namespace; pausing disables the generated OpenCode agent config, while retiring
-removes the custom agent from user-managed runtime content. Admin surfaces can
-revoke a tool through the operations namespace; Open Cowork records the
-revocation as governance policy, feeds deny patterns into the generated
-OpenCode permission config, reboots the managed runtime so the SDK sees the new
-policy, and marks matching tool dependencies as revoked in the registry.
-Project-scoped custom MCP revocations keep their project directory identity, so
-the deny policy only applies when building that project's runtime config.
-Admin surfaces can also quarantine an approved memory entry through the
+pause/retire controls, tool revocation, and governed-memory quarantine. Each
+control is checked by a local governance policy before any mutation. The default
+desktop actor is the local admin principal, while the registry also exposes
+owner, approver, and viewer role requirements so future organization surfaces
+can render the same policy. Denied controls write a failed governance audit
+event and leave the subject unchanged.
+
+Admin surfaces can pause or retire a crew through the `crews` IPC namespace;
+paused or retired crews keep their history and registry entry but cannot start
+new runs. Admin surfaces can pause or retire a custom agent through the
+operations namespace; pausing disables the generated OpenCode agent config,
+while retiring removes the custom agent from user-managed runtime content.
+Admin surfaces can revoke a tool through the operations namespace; Open Cowork
+records the revocation as governance policy, feeds deny patterns into the
+generated OpenCode permission config, reboots the managed runtime so the SDK
+sees the new policy, and marks matching tool dependencies as revoked in the
+registry. Project-scoped custom MCP revocations keep their project directory
+identity, so the deny policy only applies when building that project's runtime
+config. Admin surfaces can also quarantine an approved memory entry through the
 operations namespace; quarantined memory stays inspectable and auditable but is
-excluded from future memory injection. Each control writes a durable governance
-audit event with actor, action, before/after lifecycle state, subject id, and
-bounded metadata. Admin surfaces can query those events through the operations
-namespace. The export path emits a typed audit stream as deterministic NDJSON or
-OpenTelemetry-shaped JSON and covers governance incidents, crew traces,
-approvals, policy decisions, tool-call trace records, channel/automation
-deliveries, and outcome evaluations.
+excluded from future memory injection.
+
+Each control writes a durable governance audit event with actor, action,
+before/after lifecycle state, subject id, bounded metadata, and the policy
+decision that allowed or denied the action. Admin surfaces can query those
+events through the operations namespace. The export path emits a typed audit
+stream as deterministic NDJSON or OpenTelemetry-shaped JSON and covers
+governance incidents, crew traces, approvals, policy decisions, tool-call trace
+records, channel/automation deliveries, and outcome evaluations.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -21,6 +21,7 @@ export type GovernanceDependencyKind =
   | 'workspace_profile'
 export type GovernanceDependencySource = 'direct' | 'transitive'
 export type GovernanceOwnerKind = 'user' | 'group' | 'system'
+export type GovernanceRole = 'admin' | 'owner' | 'approver' | 'viewer'
 export type GovernanceMemoryBoundaryKind = 'none' | 'session' | 'agent' | 'crew' | 'workspace'
 export type GovernanceIncidentControlKind =
   | 'pause_agent'
@@ -46,6 +47,11 @@ export interface GovernanceOwner {
   kind: GovernanceOwnerKind
   id: string
   displayName: string
+}
+
+export interface GovernancePrincipal extends GovernanceOwner {
+  roles: GovernanceRole[]
+  groupIds: string[]
 }
 
 export interface GovernanceScope {
@@ -75,6 +81,7 @@ export interface GovernanceIncidentControl {
   label: string
   available: boolean
   requiresConfirmation: boolean
+  requiredRoles?: GovernanceRole[]
   reason?: string | null
 }
 
@@ -86,6 +93,7 @@ export interface GovernanceRegistrySubject {
   displayName: string
   description: string
   owner: GovernanceOwner
+  approvers: GovernanceOwner[]
   lifecycle: GovernanceLifecycleState
   scope: GovernanceScope
   memoryBoundary: GovernanceMemoryBoundary

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createCoworkTraceEvent, type CoworkTraceEventInput, type CrewDefinitionDraft } from '../packages/shared/src/crews.ts'
+import type { GovernancePrincipal } from '../packages/shared/src/governance.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import {
   clearCrewStoreCache,
@@ -69,6 +70,14 @@ function draft(overrides: Partial<CrewDefinitionDraft> = {}): CrewDefinitionDraf
     budgetCapUsd: 4,
     ...overrides,
   }
+}
+
+const viewer: GovernancePrincipal = {
+  kind: 'user',
+  id: 'viewer',
+  displayName: 'Viewer',
+  roles: ['viewer'],
+  groupIds: [],
 }
 
 function traceInput(runId: string, id = 'certification-trace'): CoworkTraceEventInput {
@@ -185,6 +194,23 @@ test('crew incident controls pause and retire crews before new runs start', () =
   assert.equal(auditEvents[1]?.beforeLifecycle, 'draft')
   assert.equal(auditEvents[1]?.afterLifecycle, 'paused')
   assert.equal(auditEvents[0]?.metadata.crewName, 'Research Crew')
+}))
+
+test('crew incident controls record denied audit before mutating for unauthorized actors', () => withCrewStore('lifecycle-denied', () => {
+  const created = createCrewFromDraft(draft())
+
+  assert.throws(
+    () => pauseCrew(created.definition.id, { actor: viewer }),
+    /not authorized to pause crew/,
+  )
+
+  assert.equal(getCrewDetail(created.definition.id)?.definition.status, 'draft')
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'crew', subjectId: `crew:${encodeURIComponent(created.definition.id)}` })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.outcome, 'failed')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'draft')
+  assert.equal(auditEvents[0]?.afterLifecycle, null)
+  assert.equal((auditEvents[0]?.metadata.policyDecision as Record<string, unknown>)?.outcome, 'denied')
 }))
 
 test('crew service saves edits as new crew versions without rewriting run history', () => withCrewStore('version-edit', () => {

--- a/tests/governance-agent-controls.test.ts
+++ b/tests/governance-agent-controls.test.ts
@@ -1,9 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { CustomAgentConfig } from '../packages/shared/src/index.ts'
+import type { CustomAgentConfig, GovernancePrincipal } from '../packages/shared/src/index.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import {
   pauseGovernanceAgent,
@@ -21,7 +21,7 @@ import {
 import { getMachineAgentsDir } from '../apps/desktop/src/main/runtime-paths.ts'
 
 function uniqueUserDataDir(name: string) {
-  return join(tmpdir(), `open-cowork-agent-controls-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  return mkdtempSync(join(tmpdir(), `open-cowork-agent-controls-${name}-`))
 }
 
 function withAgentControlStore(name: string, fn: () => Promise<void>) {
@@ -58,6 +58,14 @@ function customAgent(overrides: Partial<CustomAgentConfig> = {}): CustomAgentCon
   }
 }
 
+const viewer: GovernancePrincipal = {
+  kind: 'user',
+  id: 'viewer',
+  displayName: 'Viewer',
+  roles: ['viewer'],
+  groupIds: [],
+}
+
 test('pauseGovernanceAgent disables a custom agent, audits the lifecycle change, and reboots runtime', async () => withAgentControlStore('pause', async () => {
   const agent = customAgent()
   saveCustomAgent(agent, {})
@@ -89,6 +97,42 @@ test('pauseGovernanceAgent disables a custom agent, audits the lifecycle change,
   assert.equal(auditEvents[0]?.beforeLifecycle, 'active')
   assert.equal(auditEvents[0]?.afterLifecycle, 'paused')
   assert.equal(auditEvents[0]?.reason, 'Security incident.')
+}))
+
+test('pauseGovernanceAgent records a denied audit event before mutating for unauthorized actors', async () => withAgentControlStore('pause-denied', async () => {
+  const agent = customAgent({ name: 'denied-agent' })
+  saveCustomAgent(agent, {})
+  const subjectId = customAgentGovernanceSubjectId(agent)
+  let permissionBuildCount = 0
+  let rebootCount = 0
+
+  await assert.rejects(
+    () => pauseGovernanceAgent({
+      subjectId,
+      reason: 'Unauthorized pause.',
+    }, {
+      actor: viewer,
+      buildCustomAgentPermission: async () => {
+        permissionBuildCount += 1
+        return {}
+      },
+      rebootRuntime: async () => {
+        rebootCount += 1
+      },
+    }),
+    /not authorized to pause agent/,
+  )
+
+  assert.equal(permissionBuildCount, 0)
+  assert.equal(rebootCount, 0)
+  assert.equal(listCustomAgents().find((entry) => entry.name === agent.name)?.enabled, true)
+
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'agent', subjectId })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.outcome, 'failed')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'active')
+  assert.equal(auditEvents[0]?.afterLifecycle, null)
+  assert.equal((auditEvents[0]?.metadata.policyDecision as Record<string, unknown>)?.outcome, 'denied')
 }))
 
 test('retireGovernanceAgent removes a custom agent, audits retirement, and reboots runtime', async () => withAgentControlStore('retire', async () => {

--- a/tests/governance-memory-controls.test.ts
+++ b/tests/governance-memory-controls.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { rmSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -8,6 +8,7 @@ import {
   type AgentMemoryDraft,
   type ImprovementEvidenceRef,
 } from '../packages/shared/src/improvements.ts'
+import type { GovernancePrincipal } from '../packages/shared/src/governance.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
 import { exportGovernanceAuditEvents } from '../apps/desktop/src/main/governance-audit-export.ts'
@@ -26,7 +27,7 @@ import {
 import { quarantineGovernanceMemory } from '../apps/desktop/src/main/governance-memory-controls.ts'
 
 function uniqueUserDataDir(name: string) {
-  return join(tmpdir(), `open-cowork-memory-control-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  return mkdtempSync(join(tmpdir(), `open-cowork-memory-control-${name}-`))
 }
 
 function withMemoryControlStore(name: string, fn: () => void) {
@@ -82,6 +83,14 @@ const policyDiagnostics = {
   disabledCrewCount: 0,
 }
 
+const viewer: GovernancePrincipal = {
+  kind: 'user',
+  id: 'viewer',
+  displayName: 'Viewer',
+  roles: ['viewer'],
+  groupIds: [],
+}
+
 test('quarantineGovernanceMemory removes approved memory from injection and records audit evidence', () => withMemoryControlStore('quarantine-approved', () => {
   const proposed = createAgentMemoryProposal(memoryDraft())
   approveAgentMemoryEntry(proposed.id, 'reviewer', 'Evidence checked.')
@@ -127,4 +136,28 @@ test('quarantineGovernanceMemory refuses non-approved memory without mutating or
   )
   assert.equal(getAgentMemoryEntry(proposed.id)?.status, 'proposed')
   assert.equal(listGovernanceAuditEvents().length, 0)
+}))
+
+test('quarantineGovernanceMemory records denied audit before mutating for unauthorized actors', () => withMemoryControlStore('quarantine-denied', () => {
+  const proposed = createAgentMemoryProposal(memoryDraft({ title: 'Approved sensitive lesson' }))
+  approveAgentMemoryEntry(proposed.id, 'reviewer', 'Evidence checked.')
+
+  assert.throws(
+    () => quarantineGovernanceMemory({
+      memoryId: proposed.id,
+      reason: 'Unauthorized quarantine.',
+    }, {
+      actor: viewer,
+    }),
+    /not authorized to quarantine memory/,
+  )
+
+  assert.equal(getAgentMemoryEntry(proposed.id)?.status, 'approved')
+  const subjectId = `memory:${encodeURIComponent(proposed.id)}`
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'memory', subjectId })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.outcome, 'failed')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'approved')
+  assert.equal(auditEvents[0]?.afterLifecycle, null)
+  assert.equal((auditEvents[0]?.metadata.policyDecision as Record<string, unknown>)?.outcome, 'denied')
 }))

--- a/tests/governance-policy.test.ts
+++ b/tests/governance-policy.test.ts
@@ -97,6 +97,52 @@ test('subject owners and approvers can run matching owner-scoped controls', () =
   }).outcome, 'allowed')
 })
 
+test('subject group owners and approvers authorize matching user principals', () => {
+  const groupMember: GovernancePrincipal = {
+    kind: 'user',
+    id: 'analyst-1',
+    displayName: 'Analyst 1',
+    roles: ['viewer'],
+    groupIds: ['security'],
+  }
+  const securityGroup: GovernanceOwner = {
+    kind: 'group',
+    id: 'security',
+    displayName: 'Security',
+  }
+
+  assert.equal(decideGovernanceIncidentControl({
+    actor: groupMember,
+    action: 'pause_agent',
+    subjectKind: 'agent',
+    subjectId: 'agent:machine:data-analyst',
+    owner: securityGroup,
+    approvers: [],
+  }).outcome, 'allowed')
+
+  assert.equal(decideGovernanceIncidentControl({
+    actor: groupMember,
+    action: 'revoke_tool',
+    subjectKind: 'tool',
+    subjectId: 'tool:warehouse',
+    owner,
+    approvers: [securityGroup],
+  }).outcome, 'allowed')
+
+  assert.equal(decideGovernanceIncidentControl({
+    actor: groupMember,
+    action: 'revoke_tool',
+    subjectKind: 'tool',
+    subjectId: 'tool:warehouse',
+    owner,
+    approvers: [{
+      kind: 'group',
+      id: 'finance',
+      displayName: 'Finance',
+    }],
+  }).outcome, 'denied')
+})
+
 test('incident controls expose stable required roles', () => {
   assert.deepEqual(requiredRolesForGovernanceIncident('pause_agent'), ['admin', 'owner', 'approver'])
   assert.deepEqual(requiredRolesForGovernanceIncident('revoke_tool'), ['admin', 'approver'])

--- a/tests/governance-policy.test.ts
+++ b/tests/governance-policy.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type { GovernanceOwner, GovernancePrincipal } from '../packages/shared/src/governance.ts'
+import {
+  LOCAL_GOVERNANCE_PRINCIPAL,
+  decideGovernanceIncidentControl,
+  requiredRolesForGovernanceIncident,
+} from '../apps/desktop/src/main/governance-policy.ts'
+
+const owner: GovernanceOwner = {
+  kind: 'user',
+  id: 'owner-1',
+  displayName: 'Owner 1',
+}
+
+const viewer: GovernancePrincipal = {
+  kind: 'user',
+  id: 'viewer-1',
+  displayName: 'Viewer 1',
+  roles: ['viewer'],
+  groupIds: [],
+}
+
+test('default local governance principal can run incident controls', () => {
+  const decision = decideGovernanceIncidentControl({
+    action: 'revoke_tool',
+    subjectKind: 'tool',
+    subjectId: 'tool:warehouse',
+    owner,
+    approvers: [],
+  })
+
+  assert.equal(decision.outcome, 'allowed')
+  assert.equal(decision.actor.id, LOCAL_GOVERNANCE_PRINCIPAL.id)
+  assert.deepEqual(decision.requiredRoles, ['admin', 'approver'])
+})
+
+test('viewer role can export audit but cannot mutate incidents', () => {
+  assert.equal(decideGovernanceIncidentControl({
+    actor: viewer,
+    action: 'export_audit',
+    subjectKind: 'crew',
+    subjectId: 'crew:analytics',
+    owner,
+    approvers: [],
+  }).outcome, 'allowed')
+
+  assert.equal(decideGovernanceIncidentControl({
+    actor: viewer,
+    action: 'pause_agent',
+    subjectKind: 'agent',
+    subjectId: 'agent:machine:data-analyst',
+    owner,
+    approvers: [],
+  }).outcome, 'denied')
+})
+
+test('subject owners and approvers can run matching owner-scoped controls', () => {
+  const subjectOwner: GovernancePrincipal = {
+    ...owner,
+    roles: ['viewer'],
+    groupIds: [],
+  }
+  const subjectApprover: GovernancePrincipal = {
+    kind: 'user',
+    id: 'approver-1',
+    displayName: 'Approver 1',
+    roles: ['viewer'],
+    groupIds: [],
+  }
+
+  assert.equal(decideGovernanceIncidentControl({
+    actor: subjectOwner,
+    action: 'pause_agent',
+    subjectKind: 'agent',
+    subjectId: 'agent:machine:data-analyst',
+    owner,
+    approvers: [],
+  }).outcome, 'allowed')
+
+  assert.equal(decideGovernanceIncidentControl({
+    actor: subjectOwner,
+    action: 'pause_agent',
+    subjectKind: 'agent',
+    subjectId: 'agent:machine:data-analyst',
+    owner: { ...owner, id: 'different-owner' },
+    approvers: [],
+  }).outcome, 'denied')
+
+  assert.equal(decideGovernanceIncidentControl({
+    actor: subjectApprover,
+    action: 'retire_crew',
+    subjectKind: 'crew',
+    subjectId: 'crew:analytics',
+    owner,
+    approvers: [subjectApprover],
+  }).outcome, 'allowed')
+})
+
+test('incident controls expose stable required roles', () => {
+  assert.deepEqual(requiredRolesForGovernanceIncident('pause_agent'), ['admin', 'owner', 'approver'])
+  assert.deepEqual(requiredRolesForGovernanceIncident('revoke_tool'), ['admin', 'approver'])
+  assert.deepEqual(requiredRolesForGovernanceIncident('export_audit'), ['admin', 'approver', 'viewer'])
+})

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -254,8 +254,13 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
   assert.equal(agent.scope.kind, 'project')
   assert.equal(agent.scope.directory, '/workspace/acme')
   assert.equal(agent.owner.id, 'local-user')
+  assert.deepEqual(agent.approvers.map((approver) => approver.id), ['local-user'])
   assert.equal(agent.memoryBoundary.kind, 'agent')
   assert.equal(agent.incidentControls.some((control) => control.kind === 'retire_agent' && control.available), true)
+  assert.deepEqual(
+    agent.incidentControls.find((control) => control.kind === 'retire_agent')?.requiredRoles,
+    ['admin', 'owner', 'approver'],
+  )
   assert.deepEqual(
     agent.dependencies.map((dependency) => `${dependency.kind}:${dependency.id}:${dependency.source}`),
     [
@@ -416,8 +421,13 @@ test('governance registry projects crew member and transitive capability depende
   assert.equal(crew.lifecycle, 'active')
   assert.equal(crew.scope.kind, 'workspace_profile')
   assert.equal(crew.evalSuiteId, 'eval-suite-analytics')
+  assert.deepEqual(crew.approvers.map((approver) => approver.id), ['local-user'])
   assert.equal(crew.incidentControls.some((control) => control.kind === 'pause_crew' && control.available), true)
   assert.equal(crew.incidentControls.some((control) => control.kind === 'retire_crew' && control.available), true)
+  assert.deepEqual(
+    crew.incidentControls.find((control) => control.kind === 'export_audit')?.requiredRoles,
+    ['admin', 'approver', 'viewer'],
+  )
   assert.deepEqual(
     crew.dependencies.map((dependency) => `${dependency.kind}:${dependency.id}:${dependency.source}`),
     [

--- a/tests/governance-tool-controls.test.ts
+++ b/tests/governance-tool-controls.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { GovernancePrincipal } from '../packages/shared/src/governance.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { buildRuntimeConfig } from '../apps/desktop/src/main/runtime-config-builder.ts'
 import { closeLogger } from '../apps/desktop/src/main/logger.ts'
@@ -22,6 +23,14 @@ import { saveCustomMcp } from '../apps/desktop/src/main/native-customizations.ts
 
 function uniqueUserDataDir(name: string) {
   return mkdtempSync(join(tmpdir(), `open-cowork-tool-controls-${name}-`))
+}
+
+const viewer: GovernancePrincipal = {
+  kind: 'user',
+  id: 'viewer',
+  displayName: 'Viewer',
+  roles: ['viewer'],
+  groupIds: [],
 }
 
 function writeToolConfig(configDir: string) {
@@ -224,6 +233,34 @@ test('revokeGovernanceTool resolves project custom MCPs through a granted contex
     false,
     'revoking a project MCP should not invent agent dependencies until an agent references it',
   )
+}))
+
+test('revokeGovernanceTool records denied audit before mutating for unauthorized actors', async () => withToolControlStore('revoke-denied', async () => {
+  let rebootCount = 0
+
+  await assert.rejects(
+    () => revokeGovernanceTool({
+      toolId: 'warehouse',
+      reason: 'Unauthorized revoke.',
+    }, {
+      actor: viewer,
+      rebootRuntime: async () => {
+        rebootCount += 1
+      },
+    }),
+    /not authorized to revoke tool/,
+  )
+
+  assert.equal(rebootCount, 0)
+  assert.deepEqual(listRevokedGovernanceTools(), [])
+  assert.deepEqual(listRevokedToolPermissionPatterns(), [])
+
+  const auditEvents = listGovernanceAuditEvents({ subjectKind: 'tool', subjectId: 'tool:warehouse' })
+  assert.equal(auditEvents.length, 1)
+  assert.equal(auditEvents[0]?.outcome, 'failed')
+  assert.equal(auditEvents[0]?.beforeLifecycle, 'active')
+  assert.equal(auditEvents[0]?.afterLifecycle, null)
+  assert.equal((auditEvents[0]?.metadata.policyDecision as Record<string, unknown>)?.outcome, 'denied')
 }))
 
 test('revokeGovernanceTool refuses unknown tools without auditing or rebooting', async () => withToolControlStore('revoke-missing', async () => {


### PR DESCRIPTION
## Summary
- add a shared governance principal/role model and registry-required roles/approvers
- authorize crew, custom-agent, memory, and tool incident controls before mutation
- record failed audit events for denied controls and include policy decisions in audit metadata
- document the local governance policy surface for future organization controls

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-policy.test.ts tests/governance-agent-controls.test.ts tests/governance-memory-controls.test.ts tests/governance-tool-controls.test.ts tests/crew-service.test.ts tests/governance-registry.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:renderer
- pnpm build
- uv run mkdocs build --strict
- pnpm test:e2e
- git diff --check

Closes part of #250.