### PR TITLE
[codex] expose local governance directory

### DIFF
--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -55,6 +55,7 @@ import {
 } from './crew-store.ts'
 import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
 import {
+  LOCAL_GOVERNANCE_APPROVERS,
   LOCAL_GOVERNANCE_OWNER,
   assertGovernanceIncidentControlAllowed,
   decideGovernanceIncidentControl,
@@ -251,7 +252,7 @@ function setCrewLifecycleStatus(
       subjectKind: 'crew',
       subjectId,
       owner: LOCAL_GOVERNANCE_OWNER,
-      approvers: [LOCAL_GOVERNANCE_OWNER],
+      approvers: LOCAL_GOVERNANCE_APPROVERS,
     })
     if (policyDecision.outcome === 'denied') {
       recordGovernanceAuditEvent({

--- a/apps/desktop/src/main/governance-agent-controls.ts
+++ b/apps/desktop/src/main/governance-agent-controls.ts
@@ -7,6 +7,7 @@ import {
 import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
 import { listCustomAgents, removeCustomAgent, saveCustomAgent } from './native-customizations.ts'
 import {
+  LOCAL_GOVERNANCE_APPROVERS,
   LOCAL_GOVERNANCE_OWNER,
   assertGovernanceIncidentControlAllowed,
   decideGovernanceIncidentControl,
@@ -117,7 +118,7 @@ function authorizeAgentIncident(input: {
     subjectKind: 'agent',
     subjectId,
     owner: LOCAL_GOVERNANCE_OWNER,
-    approvers: [LOCAL_GOVERNANCE_OWNER],
+    approvers: LOCAL_GOVERNANCE_APPROVERS,
   })
   if (policyDecision.outcome === 'denied') {
     recordGovernanceAuditEvent({

--- a/apps/desktop/src/main/governance-memory-controls.ts
+++ b/apps/desktop/src/main/governance-memory-controls.ts
@@ -1,6 +1,7 @@
 import type { GovernanceMemoryIncidentControlRequest, GovernancePrincipal } from '@open-cowork/shared'
 import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
 import {
+  LOCAL_GOVERNANCE_APPROVERS,
   LOCAL_GOVERNANCE_OWNER,
   assertGovernanceIncidentControlAllowed,
   decideGovernanceIncidentControl,
@@ -58,7 +59,7 @@ export function quarantineGovernanceMemory(
     subjectKind: 'memory',
     subjectId,
     owner: LOCAL_GOVERNANCE_OWNER,
-    approvers: [LOCAL_GOVERNANCE_OWNER],
+    approvers: LOCAL_GOVERNANCE_APPROVERS,
   })
   if (policyDecision.outcome === 'denied') {
     recordGovernanceAuditEvent({

--- a/apps/desktop/src/main/governance-policy.ts
+++ b/apps/desktop/src/main/governance-policy.ts
@@ -1,6 +1,8 @@
 import type {
   GovernanceAuditActor,
+  GovernanceGroup,
   GovernanceIncidentControlKind,
+  GovernanceOrganization,
   GovernanceOwner,
   GovernancePrincipal,
   GovernanceRole,
@@ -38,6 +40,21 @@ export const LOCAL_GOVERNANCE_OWNER: GovernanceOwner = {
   displayName: 'Local user',
 }
 
+export const LOCAL_GOVERNANCE_ORGANIZATION: GovernanceOrganization = {
+  schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+  id: 'local-organization',
+  tenantId: 'local-tenant',
+  displayName: 'Local Open Cowork',
+  mode: 'local',
+}
+
+export const LOCAL_GOVERNANCE_ADMIN_GROUP: GovernanceGroup = {
+  kind: 'group',
+  id: 'local-admins',
+  displayName: 'Local administrators',
+  roles: ['admin', 'owner', 'approver'],
+}
+
 export const SYSTEM_GOVERNANCE_OWNER: GovernanceOwner = {
   kind: 'system',
   id: 'open-cowork',
@@ -47,7 +64,27 @@ export const SYSTEM_GOVERNANCE_OWNER: GovernanceOwner = {
 export const LOCAL_GOVERNANCE_PRINCIPAL: GovernancePrincipal = {
   ...LOCAL_GOVERNANCE_OWNER,
   roles: ['admin', 'approver', 'owner'],
-  groupIds: [],
+  groupIds: [LOCAL_GOVERNANCE_ADMIN_GROUP.id],
+}
+
+export const LOCAL_GOVERNANCE_APPROVERS: GovernanceOwner[] = [
+  LOCAL_GOVERNANCE_OWNER,
+  LOCAL_GOVERNANCE_ADMIN_GROUP,
+]
+
+export function listLocalGovernancePrincipals(): GovernancePrincipal[] {
+  return [{
+    ...LOCAL_GOVERNANCE_PRINCIPAL,
+    roles: [...LOCAL_GOVERNANCE_PRINCIPAL.roles],
+    groupIds: [...LOCAL_GOVERNANCE_PRINCIPAL.groupIds],
+  }]
+}
+
+export function listLocalGovernanceGroups(): GovernanceGroup[] {
+  return [{
+    ...LOCAL_GOVERNANCE_ADMIN_GROUP,
+    roles: [...LOCAL_GOVERNANCE_ADMIN_GROUP.roles],
+  }]
 }
 
 export function governancePrincipalToAuditActor(principal: GovernancePrincipal): GovernanceAuditActor {

--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -35,8 +35,12 @@ import { listSopDefinitions } from './sop-service.ts'
 import { listCustomMcps } from './native-customizations.ts'
 import { listApplicableRevokedGovernanceTools } from './governance-tool-policy.ts'
 import {
+  LOCAL_GOVERNANCE_APPROVERS,
+  LOCAL_GOVERNANCE_ORGANIZATION,
   LOCAL_GOVERNANCE_OWNER,
   SYSTEM_GOVERNANCE_OWNER,
+  listLocalGovernanceGroups,
+  listLocalGovernancePrincipals,
   requiredRolesForGovernanceIncident,
 } from './governance-policy.ts'
 
@@ -460,7 +464,7 @@ function buildBuiltInAgentSubject(
     displayName,
     description: agent.description,
     owner: SYSTEM_GOVERNANCE_OWNER,
-    approvers: [LOCAL_GOVERNANCE_OWNER],
+    approvers: LOCAL_GOVERNANCE_APPROVERS,
     lifecycle: agent.disabled ? 'paused' : 'active',
     scope: {
       kind: 'system',
@@ -494,7 +498,7 @@ function buildCustomAgentSubject(
     displayName: agent.name,
     description: agent.description,
     owner: LOCAL_GOVERNANCE_OWNER,
-    approvers: [LOCAL_GOVERNANCE_OWNER],
+    approvers: LOCAL_GOVERNANCE_APPROVERS,
     lifecycle: customAgentGovernanceLifecycle(agent),
     scope: customAgentScope(agent),
     memoryBoundary: {
@@ -565,7 +569,7 @@ function buildCrewSubject(input: {
     displayName: definition.name,
     description: definition.description,
     owner: LOCAL_GOVERNANCE_OWNER,
-    approvers: [LOCAL_GOVERNANCE_OWNER],
+    approvers: LOCAL_GOVERNANCE_APPROVERS,
     lifecycle: definition.status,
     scope,
     memoryBoundary: {
@@ -665,6 +669,9 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
   return {
     schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
     generatedAt: input.generatedAt || new Date().toISOString(),
+    organization: LOCAL_GOVERNANCE_ORGANIZATION,
+    principals: listLocalGovernancePrincipals(),
+    groups: listLocalGovernanceGroups(),
     subjects,
     dependencyIndex: buildDependencyIndex(subjects),
   }

--- a/apps/desktop/src/main/governance-tool-controls.ts
+++ b/apps/desktop/src/main/governance-tool-controls.ts
@@ -3,6 +3,7 @@ import { recordGovernanceAuditEvent } from './governance-audit-store.ts'
 import { saveRevokedGovernanceTool } from './governance-tool-policy-store.ts'
 import { resolveGovernanceToolControlTarget } from './governance-tool-policy.ts'
 import {
+  LOCAL_GOVERNANCE_APPROVERS,
   LOCAL_GOVERNANCE_OWNER,
   assertGovernanceIncidentControlAllowed,
   decideGovernanceIncidentControl,
@@ -51,7 +52,7 @@ export async function revokeGovernanceTool(
     subjectKind: 'tool',
     subjectId,
     owner: LOCAL_GOVERNANCE_OWNER,
-    approvers: [LOCAL_GOVERNANCE_OWNER],
+    approvers: LOCAL_GOVERNANCE_APPROVERS,
   })
   if (policyDecision.outcome === 'denied') {
     recordGovernanceAuditEvent({

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -259,7 +259,21 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       queueItems: vi.fn(async () => []),
       queueAlerts: vi.fn(async () => []),
       capabilityRisks: vi.fn(async () => []),
-      governanceRegistry: vi.fn(async () => ({ schemaVersion: 1, generatedAt: new Date().toISOString(), subjects: [], dependencyIndex: [] })),
+      governanceRegistry: vi.fn(async () => ({
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        organization: {
+          schemaVersion: 1,
+          id: 'local-organization',
+          tenantId: 'local-tenant',
+          displayName: 'Local Open Cowork',
+          mode: 'local',
+        },
+        principals: [],
+        groups: [],
+        subjects: [],
+        dependencyIndex: [],
+      })),
       governanceAuditEvents: vi.fn(async () => []),
       exportGovernanceAudit: vi.fn(async () => ({
         schemaVersion: 2,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -108,6 +108,8 @@ The desktop operations namespace exposes a read-only governance registry for
 admin surfaces. It projects existing Open Cowork metadata into one dependency
 map without changing OpenCode execution:
 
+- the local organization/tenant identity plus the local user principal, group
+  membership, and role grants that policy decisions use today
 - agents and crews with owner, lifecycle, scope, memory boundary, and
   offboarding path
 - direct dependencies on member agents, tools, skills, workspace profiles,
@@ -123,8 +125,10 @@ pause/retire controls, tool revocation, and governed-memory quarantine. Each
 control is checked by a local governance policy before any mutation. The default
 desktop actor is the local admin principal, while the registry also exposes
 owner, approver, and viewer role requirements so future organization surfaces
-can render the same policy. Denied controls write a failed governance audit
-event and leave the subject unchanged.
+can render the same policy. The local admin principal belongs to the local
+administrators group, and group owners/approvers authorize matching members in
+the same way direct user owners/approvers do. Denied controls write a failed
+governance audit event and leave the subject unchanged.
 
 Admin surfaces can pause or retire a crew through the `crews` IPC namespace;
 paused or retired crews keep their history and registry entry but cannot start

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -22,6 +22,7 @@ export type GovernanceDependencyKind =
 export type GovernanceDependencySource = 'direct' | 'transitive'
 export type GovernanceOwnerKind = 'user' | 'group' | 'system'
 export type GovernanceRole = 'admin' | 'owner' | 'approver' | 'viewer'
+export type GovernanceOrganizationMode = 'local' | 'managed'
 export type GovernanceMemoryBoundaryKind = 'none' | 'session' | 'agent' | 'crew' | 'workspace'
 export type GovernanceIncidentControlKind =
   | 'pause_agent'
@@ -52,6 +53,19 @@ export interface GovernanceOwner {
 export interface GovernancePrincipal extends GovernanceOwner {
   roles: GovernanceRole[]
   groupIds: string[]
+}
+
+export interface GovernanceGroup extends GovernanceOwner {
+  kind: 'group'
+  roles: GovernanceRole[]
+}
+
+export interface GovernanceOrganization {
+  schemaVersion: number
+  id: string
+  tenantId: string
+  displayName: string
+  mode: GovernanceOrganizationMode
 }
 
 export interface GovernanceScope {
@@ -111,6 +125,9 @@ export interface GovernanceDependencyIndexEntry {
 export interface GovernanceRegistryPayload {
   schemaVersion: number
   generatedAt: string
+  organization: GovernanceOrganization
+  principals: GovernancePrincipal[]
+  groups: GovernanceGroup[]
   subjects: GovernanceRegistrySubject[]
   dependencyIndex: GovernanceDependencyIndexEntry[]
 }

--- a/tests/governance-policy.test.ts
+++ b/tests/governance-policy.test.ts
@@ -2,8 +2,12 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import type { GovernanceOwner, GovernancePrincipal } from '../packages/shared/src/governance.ts'
 import {
+  LOCAL_GOVERNANCE_ADMIN_GROUP,
+  LOCAL_GOVERNANCE_ORGANIZATION,
   LOCAL_GOVERNANCE_PRINCIPAL,
   decideGovernanceIncidentControl,
+  listLocalGovernanceGroups,
+  listLocalGovernancePrincipals,
   requiredRolesForGovernanceIncident,
 } from '../apps/desktop/src/main/governance-policy.ts'
 
@@ -33,6 +37,14 @@ test('default local governance principal can run incident controls', () => {
   assert.equal(decision.outcome, 'allowed')
   assert.equal(decision.actor.id, LOCAL_GOVERNANCE_PRINCIPAL.id)
   assert.deepEqual(decision.requiredRoles, ['admin', 'approver'])
+})
+
+test('local governance directory exposes the desktop organization, principal, and admin group', () => {
+  assert.equal(LOCAL_GOVERNANCE_ORGANIZATION.mode, 'local')
+  assert.equal(LOCAL_GOVERNANCE_ORGANIZATION.tenantId, 'local-tenant')
+  assert.deepEqual(LOCAL_GOVERNANCE_PRINCIPAL.groupIds, [LOCAL_GOVERNANCE_ADMIN_GROUP.id])
+  assert.deepEqual(listLocalGovernancePrincipals(), [LOCAL_GOVERNANCE_PRINCIPAL])
+  assert.deepEqual(listLocalGovernanceGroups(), [LOCAL_GOVERNANCE_ADMIN_GROUP])
 })
 
 test('viewer role can export audit but cannot mutate incidents', () => {

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -248,13 +248,22 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
     generatedAt,
   })
 
+  assert.equal(payload.organization.mode, 'local')
+  assert.equal(payload.organization.tenantId, 'local-tenant')
+  assert.deepEqual(payload.principals.map((principal) => `${principal.id}:${principal.roles.join(',')}:${principal.groupIds.join(',')}`), [
+    'local-user:admin,approver,owner:local-admins',
+  ])
+  assert.deepEqual(payload.groups.map((group) => `${group.id}:${group.roles.join(',')}`), [
+    'local-admins:admin,owner,approver',
+  ])
+
   const agent = payload.subjects.find((subject) => subject.name === 'data-analyst')
   assert.ok(agent)
   assert.equal(agent.lifecycle, 'paused')
   assert.equal(agent.scope.kind, 'project')
   assert.equal(agent.scope.directory, '/workspace/acme')
   assert.equal(agent.owner.id, 'local-user')
-  assert.deepEqual(agent.approvers.map((approver) => approver.id), ['local-user'])
+  assert.deepEqual(agent.approvers.map((approver) => approver.id), ['local-user', 'local-admins'])
   assert.equal(agent.memoryBoundary.kind, 'agent')
   assert.equal(agent.incidentControls.some((control) => control.kind === 'retire_agent' && control.available), true)
   assert.deepEqual(
@@ -421,7 +430,7 @@ test('governance registry projects crew member and transitive capability depende
   assert.equal(crew.lifecycle, 'active')
   assert.equal(crew.scope.kind, 'workspace_profile')
   assert.equal(crew.evalSuiteId, 'eval-suite-analytics')
-  assert.deepEqual(crew.approvers.map((approver) => approver.id), ['local-user'])
+  assert.deepEqual(crew.approvers.map((approver) => approver.id), ['local-user', 'local-admins'])
   assert.equal(crew.incidentControls.some((control) => control.kind === 'pause_crew' && control.available), true)
   assert.equal(crew.incidentControls.some((control) => control.kind === 'retire_crew' && control.available), true)
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- add typed local organization/tenant, principal, and group metadata to the governance registry payload
- route local incident-control approvers through a shared local administrators group as well as the direct local user
- document the local directory and group owner/approver behavior for future admin surfaces

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-policy.test.ts tests/governance-registry.test.ts tests/governance-agent-controls.test.ts tests/governance-memory-controls.test.ts tests/governance-tool-controls.test.ts tests/crew-service.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check

Part of #250.