### PR TITLE
[codex] surface governance eval-suite metadata

### DIFF
--- a/apps/desktop/src/main/crew-store.ts
+++ b/apps/desktop/src/main/crew-store.ts
@@ -1297,6 +1297,15 @@ export function getEvalSuite(id: string) {
   return row ? rowToEvalSuite(row) : null
 }
 
+export function listEvalSuites() {
+  const rows = getCrewDb().prepare(`
+    select *
+    from eval_suites
+    order by updated_at desc, created_at desc, id asc
+  `).all() as DbRow[]
+  return rows.map(rowToEvalSuite)
+}
+
 export function createEvalCase(input: {
   suiteId: string
   name: string

--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -6,6 +6,7 @@ import type {
   CrewListPayload,
   CustomAgentSummary as SharedCustomAgentSummary,
   CustomMcpConfig,
+  EvalSuite,
   GovernanceDependency,
   GovernanceDependencyIndexEntry,
   GovernanceDependencyKind,
@@ -22,6 +23,7 @@ import type {
 import { COWORK_GOVERNANCE_SCHEMA_VERSION } from '@open-cowork/shared'
 
 import { listBuiltInAgentDetails } from './built-in-agent-details.ts'
+import { listEvalSuites } from './crew-store.ts'
 import {
   getConfiguredMcpsFromConfig,
   getConfiguredToolsFromConfig,
@@ -49,6 +51,7 @@ export interface GovernanceRegistryBuildInput {
   customAgents: GovernanceCustomAgentSummary[]
   agentCatalog: AgentCatalog
   crewCatalog: CrewListPayload
+  evalSuites?: EvalSuite[]
   sopCatalog?: SopListPayload
   channels?: ChannelDefinition[]
   toolCredentialDependencies?: GovernanceToolCredentialDependency[]
@@ -451,6 +454,16 @@ function createCrewChannelDependencyMap(channels: ChannelDefinition[] = []): Map
   return dependenciesByCrew
 }
 
+function createEvalSuiteMap(evalSuites: EvalSuite[] = []): Map<string, EvalSuite> {
+  return new Map(evalSuites.map((suite) => [suite.id, suite]))
+}
+
+function evalSuiteGovernanceLifecycle(status: EvalSuite['status']): GovernanceLifecycleState {
+  if (status === 'active') return 'active'
+  if (status === 'archived') return 'retired'
+  return 'draft'
+}
+
 function buildBuiltInAgentSubject(
   agent: BuiltInAgentDetail,
   dependencies: GovernanceDependency[],
@@ -518,6 +531,7 @@ function buildCustomAgentSubject(
 function buildCrewSubject(input: {
   crew: CrewListPayload['crews'][number]
   agentSubjectsByName: Map<string, GovernanceRegistrySubject>
+  evalSuitesById?: Map<string, EvalSuite>
   supplementalDependencies?: GovernanceDependency[]
 }): GovernanceRegistrySubject {
   const { definition, activeVersion } = input.crew
@@ -541,7 +555,18 @@ function buildCrewSubject(input: {
     )
   }
   if (activeVersion?.evalSuiteId) {
-    addDependency(dependencies, createDependency('eval_suite', activeVersion.evalSuiteId, activeVersion.evalSuiteId, 'direct'))
+    const suite = input.evalSuitesById?.get(activeVersion.evalSuiteId)
+    addDependency(
+      dependencies,
+      createDependency(
+        'eval_suite',
+        activeVersion.evalSuiteId,
+        suite?.name || activeVersion.evalSuiteId,
+        'direct',
+        true,
+        suite ? evalSuiteGovernanceLifecycle(suite.status) : null,
+      ),
+    )
   }
   for (const dependency of input.supplementalDependencies || []) {
     addDependency(dependencies, dependency)
@@ -627,6 +652,7 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
     channels: input.channels,
   })
   const crewChannelDependencies = createCrewChannelDependencyMap(input.channels)
+  const evalSuitesById = createEvalSuiteMap(input.evalSuites)
 
   const agentSubjects = [
     ...input.builtinAgents.map((agent) => buildBuiltInAgentSubject(agent, collectAgentDependencies({
@@ -659,6 +685,7 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
   const crewSubjects = input.crewCatalog.crews.map((crew) => buildCrewSubject({
     crew,
     agentSubjectsByName,
+    evalSuitesById,
     supplementalDependencies: crewChannelDependencies.get(crew.definition.id),
   }))
   const subjects = [...agentSubjects, ...crewSubjects].sort((left, right) => (
@@ -688,6 +715,7 @@ export async function getGovernanceRegistry(options?: RuntimeContextOptions): Pr
     customAgents,
     agentCatalog,
     crewCatalog: listCrewCatalog(),
+    evalSuites: listEvalSuites(),
     sopCatalog: listSopDefinitions(),
     channels: listChannelDefinitions(),
     toolCredentialDependencies: buildGovernanceToolCredentialDependencies({

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -117,6 +117,9 @@ map without changing OpenCode execution:
 - transitive dependencies such as skill-linked tools, integration credentials
   needed by those tools, SOP/channel exposure for workflow agents, and crew
   member capabilities
+- eval-suite dependencies use the stored suite name and lifecycle state when
+  available, so admin views can distinguish active certification gates from
+  draft or retired suites
 - incident-control metadata that distinguishes actions available today from
   controls planned in later governance slices
 

--- a/tests/crew-store.test.ts
+++ b/tests/crew-store.test.ts
@@ -38,6 +38,7 @@ import {
   listCrewVersions,
   listCoworkTraceEventsForRun,
   listEvalCasesForSuite,
+  listEvalSuites,
   listOutcomeEvaluationsForRun,
   listOutcomeRubrics,
   listPolicyDecisionsForRun,
@@ -425,6 +426,7 @@ test('crew store persists eval suites, cases, rubrics, and outcome evaluations',
 
     assert.equal(rubric?.schemaVersion, COWORK_EVAL_SCHEMA_VERSION)
     assert.deepEqual(listOutcomeRubrics().map((entry) => entry.id), [rubric!.id])
+    assert.deepEqual(listEvalSuites().map((entry) => entry.id), [suite!.id])
     assert.deepEqual(listEvalCasesForSuite(suite!.id).map((entry) => entry.id), [evalCase!.id])
     assert.equal(evaluation?.status, 'passed')
     assert.deepEqual(evaluation?.evidenceTraceEventIds, ['trace-evidence'])

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -6,6 +6,7 @@ import type {
   ChannelDefinition,
   CrewListPayload,
   CustomAgentSummary,
+  EvalSuite,
   SopListPayload,
 } from '@open-cowork/shared'
 import {
@@ -136,6 +137,19 @@ function crewCatalog(overrides: Partial<CrewListPayload['crews'][number]> = {}):
         ...overrides,
       },
     ],
+  }
+}
+
+function evalSuite(overrides: Partial<EvalSuite> = {}): EvalSuite {
+  return {
+    schemaVersion: 1,
+    id: 'eval-suite-analytics',
+    name: 'Analytics certification',
+    description: 'Certifies analytics crew outputs.',
+    status: 'active',
+    createdAt: generatedAt,
+    updatedAt: generatedAt,
+    ...overrides,
   }
 }
 
@@ -422,6 +436,7 @@ test('governance registry projects crew member and transitive capability depende
     customAgents: [customAgent()],
     agentCatalog: catalog(),
     crewCatalog: crewCatalog(),
+    evalSuites: [evalSuite()],
     generatedAt,
   })
 
@@ -448,6 +463,9 @@ test('governance registry projects crew member and transitive capability depende
       'workspace_profile:project-workspace:direct',
     ],
   )
+  const evalSuiteDependency = crew.dependencies.find((dependency) => dependency.kind === 'eval_suite')
+  assert.equal(evalSuiteDependency?.label, 'Analytics certification')
+  assert.equal(evalSuiteDependency?.lifecycle, 'active')
 
   const workspaceIndex = payload.dependencyIndex.find(
     (entry) => entry.dependency.kind === 'workspace_profile' && entry.dependency.id === 'project-workspace',


### PR DESCRIPTION
## Summary
- add a local eval-suite listing API for governance registry builds
- label crew eval-suite dependencies with stored suite names and lifecycle states when available
- document the admin dependency-map behavior and cover it with store/registry tests

Part of #250.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts tests/crew-store.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check