### PR TITLE
[codex] surface governance map in Pulse

### DIFF
--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -9,6 +9,7 @@ import type {
   CustomAgentSummary,
   DashboardSummary,
   EffectiveAppSettings,
+  GovernanceRegistryPayload,
   ImprovementDiagnosticsSummary,
   ImprovementReviewQueue,
   CapabilityRiskMetadata,
@@ -370,6 +371,130 @@ const capabilityRisks: CapabilityRiskMetadata[] = [
   },
 ]
 
+const governanceRegistry: GovernanceRegistryPayload = {
+  schemaVersion: 1,
+  generatedAt: '2026-05-07T00:00:00.000Z',
+  organization: {
+    schemaVersion: 1,
+    id: 'local-organization',
+    tenantId: 'local',
+    displayName: 'Acme Local Ops',
+    mode: 'local',
+  },
+  principals: [{
+    kind: 'user',
+    id: 'local-user',
+    displayName: 'Local operator',
+    roles: ['admin', 'owner', 'approver'],
+    groupIds: ['local-admins'],
+  }],
+  groups: [{
+    kind: 'group',
+    id: 'local-admins',
+    displayName: 'Local administrators',
+    roles: ['admin', 'owner', 'approver'],
+  }],
+  subjects: [
+    {
+      schemaVersion: 1,
+      subjectKind: 'agent',
+      subjectId: 'agent:system:build',
+      name: 'build',
+      displayName: 'Build',
+      description: 'Builds changes',
+      owner: { kind: 'system', id: 'open-cowork', displayName: 'Open Cowork' },
+      approvers: [{ kind: 'group', id: 'local-admins', displayName: 'Local administrators' }],
+      lifecycle: 'active',
+      scope: { kind: 'system', id: 'runtime', label: 'Runtime', directory: null },
+      memoryBoundary: { kind: 'session', id: 'build', label: 'Session context' },
+      evalSuiteId: null,
+      offboardingPath: 'Disable through config.',
+      dependencies: [{
+        kind: 'tool',
+        id: 'tool-github',
+        label: 'GitHub',
+        source: 'direct',
+        required: true,
+      }],
+      incidentControls: [],
+    },
+    {
+      schemaVersion: 1,
+      subjectKind: 'crew',
+      subjectId: 'crew:research',
+      name: 'research',
+      displayName: 'Research crew',
+      description: 'Runs research jobs',
+      owner: { kind: 'user', id: 'local-user', displayName: 'Local operator' },
+      approvers: [{ kind: 'group', id: 'local-admins', displayName: 'Local administrators' }],
+      lifecycle: 'active',
+      scope: { kind: 'workspace_profile', id: 'workspace:research', label: 'Research workspace', directory: null },
+      memoryBoundary: { kind: 'crew', id: 'research', label: 'Crew traces and evals' },
+      evalSuiteId: 'eval-suite-analytics',
+      offboardingPath: 'Pause or retire the crew.',
+      dependencies: [{
+        kind: 'eval_suite',
+        id: 'eval-suite-analytics',
+        label: 'Analytics certification',
+        source: 'direct',
+        required: true,
+        lifecycle: 'active',
+      }],
+      incidentControls: [
+        {
+          kind: 'pause_crew',
+          label: 'Pause crew',
+          available: true,
+          requiresConfirmation: true,
+          requiredRoles: ['admin', 'owner', 'approver'],
+          reason: null,
+        },
+        {
+          kind: 'export_audit',
+          label: 'Export crew run trace',
+          available: true,
+          requiresConfirmation: false,
+          requiredRoles: ['admin', 'approver', 'viewer'],
+          reason: null,
+        },
+      ],
+    },
+  ],
+  dependencyIndex: [
+    {
+      dependency: {
+        kind: 'tool',
+        id: 'tool-github',
+        label: 'GitHub',
+        source: 'direct',
+        required: true,
+      },
+      subjectIds: ['agent:system:build'],
+    },
+    {
+      dependency: {
+        kind: 'credential',
+        id: 'integration:github',
+        label: 'GitHub integration credentials',
+        source: 'direct',
+        required: true,
+      },
+      subjectIds: ['agent:system:build'],
+    },
+    {
+      dependency: {
+        kind: 'eval_suite',
+        id: 'eval-suite-analytics',
+        label: 'Analytics certification',
+        source: 'direct',
+        required: true,
+        lifecycle: 'active',
+      },
+      subjectIds: ['crew:research'],
+    },
+  ],
+}
+
 const channelState: ChannelListPayload = {
   channels: [
     {
@@ -685,6 +810,7 @@ function installPulseApi(options: {
   rejectMemory?: ReturnType<typeof vi.fn>
   startDreamRun?: ReturnType<typeof vi.fn>
   archiveDreamRun?: ReturnType<typeof vi.fn>
+  governanceRegistry?: ReturnType<typeof vi.fn>
   channelState?: ChannelListPayload
   localWebhookStatus?: LocalWebhookReceiverStatus
   approveInboundItem?: ReturnType<typeof vi.fn>
@@ -734,6 +860,7 @@ function installPulseApi(options: {
       queueItems: vi.fn(async () => queueItems),
       queueAlerts: options.queueAlerts || vi.fn(async () => queueAlerts),
       capabilityRisks: vi.fn(async () => capabilityRisks),
+      governanceRegistry: options.governanceRegistry || vi.fn(async () => governanceRegistry),
     },
     channels: {
       list: vi.fn(async () => testChannelState),
@@ -852,6 +979,11 @@ describe('PulsePage', () => {
     expect(screen.getByText('Bash')).toBeInTheDocument()
     expect(screen.getAllByText('Skills')).toHaveLength(1)
     expect(screen.getByText('High risk caps').parentElement?.textContent).toContain('2')
+    expect(screen.getByText('Governance map')).toBeInTheDocument()
+    expect(screen.getByText('Acme Local Ops')).toBeInTheDocument()
+    expect(screen.getByText(/1 principal · 1 group/)).toBeInTheDocument()
+    expect(screen.getByText('Credentials · 1')).toBeInTheDocument()
+    expect(screen.getByText('Eval gates · 1')).toBeInTheDocument()
     expect(screen.getByText('Channel inbox and delivery')).toBeInTheDocument()
     expect(screen.getByText('Ops webhook · SOP')).toBeInTheDocument()
     expect(screen.getByText('Weekly support digest')).toBeInTheDocument()
@@ -872,6 +1004,7 @@ describe('PulsePage', () => {
     expect(api.operations.queueAlerts).toHaveBeenCalledTimes(1)
     expect(api.operations.queueItems).toHaveBeenCalledTimes(1)
     expect(api.operations.capabilityRisks).toHaveBeenCalledTimes(1)
+    expect(api.operations.governanceRegistry).toHaveBeenCalledTimes(1)
     expect(api.channels.list).toHaveBeenCalledTimes(1)
     expect(api.channels.localWebhookStatus).toHaveBeenCalledTimes(1)
     expect(api.improvements.summary).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -3,6 +3,8 @@ import type {
   ChannelDeliveryRecord,
   ChannelInboundItem,
   CapabilityRiskMetadata,
+  GovernanceDependencyKind,
+  GovernanceRegistryPayload,
   ImprovementProposalDraft,
   OperationalQueueItem,
 } from '@open-cowork/shared'
@@ -118,6 +120,59 @@ function describeRiskSummary(risks: CapabilityRiskMetadata[]) {
   return { high, write, approval }
 }
 
+function governanceDependencyLabel(kind: GovernanceDependencyKind) {
+  switch (kind) {
+    case 'credential':
+      return t('homepage.governance.credentials', 'Credentials')
+    case 'eval_suite':
+      return t('homepage.governance.evalSuites', 'Eval suites')
+    case 'channel':
+      return t('homepage.governance.channels', 'Channels')
+    case 'sop':
+      return t('homepage.governance.sops', 'SOPs')
+    case 'workspace_profile':
+      return t('homepage.governance.workspaces', 'Workspaces')
+    case 'memory':
+      return t('homepage.governance.memory', 'Memory')
+    case 'skill':
+      return t('homepage.governance.skills', 'Skills')
+    case 'tool':
+      return t('homepage.governance.tools', 'Tools')
+    case 'agent':
+      return t('homepage.governance.agents', 'Agents')
+    default:
+      return kind
+  }
+}
+
+function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null) {
+  const subjects = registry?.subjects || []
+  const dependencies = registry?.dependencyIndex || []
+  const availableControls = subjects.reduce((count, subject) => (
+    count + subject.incidentControls.filter((control) => control.available).length
+  ), 0)
+  const dependencyKinds = new Map<GovernanceDependencyKind, number>()
+  for (const entry of dependencies) {
+    dependencyKinds.set(entry.dependency.kind, (dependencyKinds.get(entry.dependency.kind) || 0) + 1)
+  }
+  const dependencyHighlights = [...dependencyKinds.entries()]
+    .sort((left, right) => right[1] - left[1] || governanceDependencyLabel(left[0]).localeCompare(governanceDependencyLabel(right[0])))
+    .slice(0, 5)
+    .map(([kind, count]) => `${governanceDependencyLabel(kind)} · ${formatInteger.format(count)}`)
+
+  return {
+    organizationLabel: registry?.organization.displayName || t('homepage.governance.localOrg', 'Local organization'),
+    principalCount: registry?.principals.length || 0,
+    groupCount: registry?.groups.length || 0,
+    agentCount: subjects.filter((subject) => subject.subjectKind === 'agent').length,
+    crewCount: subjects.filter((subject) => subject.subjectKind === 'crew').length,
+    dependencyCount: dependencies.length,
+    evalSuiteCount: dependencies.filter((entry) => entry.dependency.kind === 'eval_suite').length,
+    availableControls,
+    dependencyHighlights,
+  }
+}
+
 function formatChannelProvider(provider: string) {
   return provider
     .split(/[_-]/g)
@@ -198,6 +253,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     queueItems,
     queueAlerts,
     capabilityRisks,
+    governanceRegistry,
     channelState,
     localWebhookStatus,
     improvementSummary,
@@ -301,6 +357,10 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
   const riskSummary = useMemo(
     () => describeRiskSummary(capabilityRisks),
     [capabilityRisks],
+  )
+  const governanceSummary = useMemo(
+    () => summarizeGovernanceRegistry(governanceRegistry),
+    [governanceRegistry],
   )
   const highRiskCapabilityLabels = useMemo(
     () => capabilityRisks
@@ -732,6 +792,46 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                       ]}
                     />
                     <div className="mt-4 space-y-3">
+                      <div
+                        className="rounded-2xl bg-surface px-4 py-3"
+                        style={{ boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-text) 4%, transparent)' }}
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted">{t('homepage.governance.eyebrow', 'Governance map')}</div>
+                            <div className="mt-1 text-[12px] font-semibold text-text truncate">{governanceSummary.organizationLabel}</div>
+                          </div>
+                          <div className="shrink-0 text-right text-[10px] uppercase tracking-[0.14em] text-text-muted">
+                            {formatInteger.format(governanceSummary.principalCount)} {governanceSummary.principalCount === 1 ? t('homepage.governance.principal', 'principal') : t('homepage.governance.principals', 'principals')}
+                            {' · '}
+                            {formatInteger.format(governanceSummary.groupCount)} {governanceSummary.groupCount === 1 ? t('homepage.governance.group', 'group') : t('homepage.governance.groups', 'groups')}
+                          </div>
+                        </div>
+                        <div className="mt-3 grid grid-cols-4 gap-2 max-[860px]:grid-cols-2">
+                          {[
+                            { label: t('homepage.governance.agents', 'Agents'), value: formatInteger.format(governanceSummary.agentCount) },
+                            { label: t('homepage.governance.crews', 'Crews'), value: formatInteger.format(governanceSummary.crewCount) },
+                            { label: t('homepage.governance.dependencies', 'Dependencies'), value: formatInteger.format(governanceSummary.dependencyCount) },
+                            { label: t('homepage.governance.controls', 'Controls'), value: formatInteger.format(governanceSummary.availableControls) },
+                          ].map((stat) => (
+                            <div key={stat.label} className="rounded-xl border border-border-subtle px-2.5 py-2">
+                              <div className="text-[9px] uppercase tracking-[0.08em] text-text-muted">{stat.label}</div>
+                              <div className="mt-1 text-[11px] font-semibold text-text">{stat.value}</div>
+                            </div>
+                          ))}
+                        </div>
+                        <div className="mt-3">
+                          <TagRail
+                            items={[
+                              ...governanceSummary.dependencyHighlights,
+                              ...(governanceSummary.evalSuiteCount > 0
+                                ? [`${t('homepage.governance.evalGates', 'Eval gates')} · ${formatInteger.format(governanceSummary.evalSuiteCount)}`]
+                                : []),
+                            ].slice(0, 6)}
+                            emptyLabel={t('homepage.governance.empty', 'No governed dependencies registered yet.')}
+                          />
+                        </div>
+                      </div>
                       {visibleQueueItems.map((item) => (
                         <div
                           key={item.id}

--- a/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
+++ b/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
@@ -3,6 +3,7 @@ import type {
   ChannelListPayload,
   DashboardSummary,
   DashboardTimeRangeKey,
+  GovernanceRegistryPayload,
   ImprovementDiagnosticsSummary,
   ImprovementReviewQueue,
   CapabilityRiskMetadata,
@@ -30,6 +31,7 @@ export function usePulseDiagnostics() {
   const [capabilityRisks, setCapabilityRisks] = useState<CapabilityRiskMetadata[]>([])
   const [channelState, setChannelState] = useState<ChannelListPayload>({ channels: [], inboundItems: [], deliveries: [] })
   const [localWebhookStatus, setLocalWebhookStatus] = useState<LocalWebhookReceiverStatus | null>(null)
+  const [governanceRegistry, setGovernanceRegistry] = useState<GovernanceRegistryPayload | null>(null)
   const [improvementSummary, setImprovementSummary] = useState<ImprovementDiagnosticsSummary | null>(null)
   const [improvementInbox, setImprovementInbox] = useState<ImprovementReviewQueue | null>(null)
 
@@ -69,6 +71,7 @@ export function usePulseDiagnostics() {
       queueItemsResult,
       queueAlertsResult,
       capabilityRisksResult,
+      governanceRegistryResult,
       channelStateResult,
       localWebhookStatusResult,
       improvementSummaryResult,
@@ -89,6 +92,7 @@ export function usePulseDiagnostics() {
       window.coworkApi.operations.queueItems(),
       window.coworkApi.operations.queueAlerts(),
       window.coworkApi.operations.capabilityRisks(),
+      window.coworkApi.operations.governanceRegistry(),
       window.coworkApi.channels.list(),
       window.coworkApi.channels.localWebhookStatus(),
       window.coworkApi.improvements.summary(),
@@ -131,6 +135,7 @@ export function usePulseDiagnostics() {
     setQueueItems(queueItemsResult.status === 'fulfilled' ? queueItemsResult.value : [])
     setQueueAlerts(queueAlertsResult.status === 'fulfilled' ? queueAlertsResult.value : [])
     setCapabilityRisks(capabilityRisksResult.status === 'fulfilled' ? capabilityRisksResult.value : [])
+    setGovernanceRegistry(governanceRegistryResult.status === 'fulfilled' ? governanceRegistryResult.value : null)
     setChannelState(channelStateResult.status === 'fulfilled' ? channelStateResult.value : { channels: [], inboundItems: [], deliveries: [] })
     setLocalWebhookStatus(localWebhookStatusResult.status === 'fulfilled' ? localWebhookStatusResult.value : null)
     setImprovementSummary(improvementSummaryResult.status === 'fulfilled' ? improvementSummaryResult.value : null)
@@ -207,6 +212,7 @@ export function usePulseDiagnostics() {
     queueItems,
     queueAlerts,
     capabilityRisks,
+    governanceRegistry,
     channelState,
     localWebhookStatus,
     improvementSummary,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -156,6 +156,10 @@ stream as deterministic NDJSON or OpenTelemetry-shaped JSON and covers
 governance incidents, crew traces, approvals, policy decisions, tool-call trace
 records, channel/automation deliveries, and outcome evaluations.
 
+Pulse summarizes this registry in its Operations card, including the active
+local organization, governed agent and crew counts, dependency breadth, eval
+gates, and available incident controls.
+
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.
 


### PR DESCRIPTION
## Summary
- load the governance registry through Pulse diagnostics
- show a compact governance map in the Operations card with organization, agents, crews, dependencies, eval gates, and available incident controls
- cover the new Pulse surface with renderer tests and document the operations behavior

Part of #250.

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check