### PR TITLE
[codex] expose governance audit export in Pulse

### DIFF
--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -811,6 +811,7 @@ function installPulseApi(options: {
   startDreamRun?: ReturnType<typeof vi.fn>
   archiveDreamRun?: ReturnType<typeof vi.fn>
   governanceRegistry?: ReturnType<typeof vi.fn>
+  exportGovernanceAudit?: ReturnType<typeof vi.fn>
   channelState?: ChannelListPayload
   localWebhookStatus?: LocalWebhookReceiverStatus
   approveInboundItem?: ReturnType<typeof vi.fn>
@@ -861,6 +862,15 @@ function installPulseApi(options: {
       queueAlerts: options.queueAlerts || vi.fn(async () => queueAlerts),
       capabilityRisks: vi.fn(async () => capabilityRisks),
       governanceRegistry: options.governanceRegistry || vi.fn(async () => governanceRegistry),
+      exportGovernanceAudit: options.exportGovernanceAudit || vi.fn(async () => ({
+        schemaVersion: 2,
+        format: 'ndjson',
+        contentType: 'application/x-ndjson',
+        filename: 'open-cowork-governance-audit.ndjson',
+        exportedAt: '2026-05-07T00:00:00.000Z',
+        eventCount: 1,
+        body: '{"recordType":"governance_incident"}',
+      })),
     },
     channels: {
       list: vi.fn(async () => testChannelState),
@@ -1050,6 +1060,36 @@ describe('PulsePage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Dismiss' }))
     await waitFor(() => expect(dismissInboundItem).toHaveBeenCalledWith('channel-item-1', 'Dismissed from Pulse.'))
+  })
+
+  it('copies governance audit exports from Pulse', async () => {
+    const user = userEvent.setup()
+    const exportGovernanceAudit = vi.fn(async ({ format }: { format: 'ndjson' | 'otel-json' }) => ({
+      schemaVersion: 2,
+      format,
+      contentType: format === 'otel-json' ? 'application/json' : 'application/x-ndjson',
+      filename: format === 'otel-json'
+        ? 'open-cowork-governance-audit.otel.json'
+        : 'open-cowork-governance-audit.ndjson',
+      exportedAt: '2026-05-07T00:00:00.000Z',
+      eventCount: 1,
+      body: format === 'otel-json'
+        ? '{"resourceLogs":[]}'
+        : '{"recordType":"governance_incident"}',
+    }))
+    const api = installPulseApi({ exportGovernanceAudit })
+
+    render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
+    await screen.findByText('Governance map')
+
+    await user.click(screen.getByRole('button', { name: 'Copy audit NDJSON' }))
+    await waitFor(() => expect(exportGovernanceAudit).toHaveBeenCalledWith({ format: 'ndjson' }))
+    expect(api.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('governance_incident'))
+    expect(await screen.findByText('Copied')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Copy OTel JSON' }))
+    await waitFor(() => expect(exportGovernanceAudit).toHaveBeenCalledWith({ format: 'otel-json' }))
+    expect(api.clipboard.writeText).toHaveBeenLastCalledWith(expect.stringContaining('resourceLogs'))
   })
 
   it('reviews channel delivery drafts from Pulse', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type {
   ChannelDeliveryRecord,
   ChannelInboundItem,
   CapabilityRiskMetadata,
+  GovernanceAuditExportFormat,
   GovernanceDependencyKind,
   GovernanceRegistryPayload,
   ImprovementProposalDraft,
@@ -10,6 +11,7 @@ import type {
 } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
 import { loadSessionMessages } from '../helpers/loadSessionMessages'
+import { writeTextToClipboard } from '../helpers/clipboard'
 import { formatCost } from '../helpers/format'
 import { t } from '../helpers/i18n'
 import {
@@ -52,6 +54,18 @@ function reportPulseThreadError(error: unknown, directory?: string) {
     })
   } catch {
     // Diagnostics are best-effort from an action error handler.
+  }
+}
+
+function reportPulseActionError(error: unknown, scope: string) {
+  try {
+    window.coworkApi?.diagnostics?.reportRendererError?.({
+      message: `${scope}: ${describePulseThreadError(error)}`,
+      stack: error instanceof Error ? error.stack : undefined,
+      view: 'pulse',
+    })
+  } catch {
+    // Diagnostics are best-effort from action error handlers.
   }
 }
 
@@ -262,6 +276,16 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
   } = usePulseDiagnostics()
   const [improvementActionId, setImprovementActionId] = useState<string | null>(null)
   const [channelActionId, setChannelActionId] = useState<string | null>(null)
+  const [governanceExportStatus, setGovernanceExportStatus] = useState<'idle' | 'working-ndjson' | 'working-otel-json' | 'copied' | 'empty' | 'error'>('idle')
+  const governanceExportResetTimerRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (governanceExportResetTimerRef.current !== null) {
+        window.clearTimeout(governanceExportResetTimerRef.current)
+      }
+    }
+  }, [])
 
   const busyCount = busySessions.size
   const connectedMcpCount = mcpConnections.filter((entry) => entry.connected).length
@@ -558,6 +582,41 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     }
   }
 
+  async function copyGovernanceAudit(format: GovernanceAuditExportFormat) {
+    clearGovernanceExportResetTimer()
+    setGovernanceExportStatus(format === 'otel-json' ? 'working-otel-json' : 'working-ndjson')
+    try {
+      const payload = await window.coworkApi.operations.exportGovernanceAudit({ format })
+      if (!payload.body) {
+        setGovernanceExportStatus('empty')
+        scheduleGovernanceExportStatusReset()
+        return
+      }
+      const copied = await writeTextToClipboard(payload.body)
+      setGovernanceExportStatus(copied ? 'copied' : 'error')
+      scheduleGovernanceExportStatusReset()
+    } catch (error) {
+      addGlobalError(t('pulse.governanceExportFailed', 'Could not export the governance audit. Please try again.'))
+      reportPulseActionError(error, 'Failed to export governance audit')
+      setGovernanceExportStatus('error')
+      scheduleGovernanceExportStatusReset()
+    }
+  }
+
+  function clearGovernanceExportResetTimer() {
+    if (governanceExportResetTimerRef.current === null) return
+    window.clearTimeout(governanceExportResetTimerRef.current)
+    governanceExportResetTimerRef.current = null
+  }
+
+  function scheduleGovernanceExportStatusReset() {
+    clearGovernanceExportResetTimer()
+    governanceExportResetTimerRef.current = window.setTimeout(() => {
+      governanceExportResetTimerRef.current = null
+      setGovernanceExportStatus('idle')
+    }, 3_000)
+  }
+
   async function reviewChannelItem(item: ChannelInboundItem, action: 'approve' | 'dismiss') {
     setChannelActionId(`${action}:${item.id}`)
     try {
@@ -830,6 +889,41 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                             ].slice(0, 6)}
                             emptyLabel={t('homepage.governance.empty', 'No governed dependencies registered yet.')}
                           />
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            className="rounded-full border border-border-subtle px-3 py-1.5 text-[11px] font-semibold text-text-secondary transition-colors hover:bg-surface-hover disabled:cursor-wait disabled:opacity-60"
+                            disabled={governanceExportStatus === 'working-ndjson' || governanceExportStatus === 'working-otel-json'}
+                            onClick={() => void copyGovernanceAudit('ndjson')}
+                          >
+                            {governanceExportStatus === 'working-ndjson'
+                              ? t('homepage.governance.exportPreparing', 'Preparing...')
+                              : t('homepage.governance.copyNdjson', 'Copy audit NDJSON')}
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-full border border-border-subtle px-3 py-1.5 text-[11px] font-semibold text-text-secondary transition-colors hover:bg-surface-hover disabled:cursor-wait disabled:opacity-60"
+                            disabled={governanceExportStatus === 'working-ndjson' || governanceExportStatus === 'working-otel-json'}
+                            onClick={() => void copyGovernanceAudit('otel-json')}
+                          >
+                            {governanceExportStatus === 'working-otel-json'
+                              ? t('homepage.governance.exportPreparing', 'Preparing...')
+                              : t('homepage.governance.copyOtel', 'Copy OTel JSON')}
+                          </button>
+                          {governanceExportStatus === 'copied' ? (
+                            <span className="inline-flex items-center px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-accent">
+                              {t('homepage.governance.exportCopied', 'Copied')}
+                            </span>
+                          ) : governanceExportStatus === 'empty' ? (
+                            <span className="inline-flex items-center px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">
+                              {t('homepage.governance.exportEmpty', 'No records')}
+                            </span>
+                          ) : governanceExportStatus === 'error' ? (
+                            <span className="inline-flex items-center px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-red">
+                              {t('homepage.governance.exportFailed', 'Export failed')}
+                            </span>
+                          ) : null}
                         </div>
                       </div>
                       {visibleQueueItems.map((item) => (

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,7 +158,9 @@ records, channel/automation deliveries, and outcome evaluations.
 
 Pulse summarizes this registry in its Operations card, including the active
 local organization, governed agent and crew counts, dependency breadth, eval
-gates, and available incident controls.
+gates, and available incident controls. Operators can also copy the audit
+stream from Pulse as NDJSON for review or OTel-shaped JSON for telemetry
+pipelines.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.


### PR DESCRIPTION
## Summary
- add Pulse actions to copy governance audit exports as NDJSON or OTel-shaped JSON
- surface export status and renderer diagnostics for failures
- cover the Pulse export interaction and document the operator workflow

Part of #250.

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check