### PR TITLE
[codex] surface governance execution-node readiness

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -11,6 +11,7 @@ import type {
   GovernanceDependencyIndexEntry,
   GovernanceDependencyKind,
   GovernanceDependencySource,
+  GovernanceExecutionNode,
   GovernanceIncidentControl,
   GovernanceLifecycleState,
   GovernanceRegistryPayload,
@@ -464,6 +465,59 @@ function evalSuiteGovernanceLifecycle(status: EvalSuite['status']): GovernanceLi
   return 'draft'
 }
 
+function buildLocalDesktopExecutionNode(lastSeenAt: string): GovernanceExecutionNode {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    id: 'execution-node:local-desktop',
+    kind: 'desktop',
+    label: 'Local desktop runtime',
+    status: 'active',
+    scope: {
+      kind: 'machine',
+      id: 'machine',
+      label: 'This device',
+      directory: null,
+    },
+    capabilities: [
+      {
+        kind: 'scheduling',
+        label: 'Durable local scheduling',
+        available: true,
+        reason: null,
+      },
+      {
+        kind: 'queue_recovery',
+        label: 'Queue recovery after app restart',
+        available: true,
+        reason: null,
+      },
+      {
+        kind: 'trigger_execution',
+        label: 'Channel and manual trigger dispatch',
+        available: true,
+        reason: null,
+      },
+      {
+        kind: 'cost_governance',
+        label: 'Run-level cost and token accounting',
+        available: true,
+        reason: null,
+      },
+      {
+        kind: 'background_execution',
+        label: 'Execution independent of this desktop app',
+        available: false,
+        reason: 'Requires a future managed worker or durable service plane.',
+      },
+    ],
+    limitations: [
+      'Scheduled and channel-triggered execution requires the desktop app and managed OpenCode runtime to be running.',
+      'No remote managed worker is registered for laptop-independent background execution yet.',
+    ],
+    lastSeenAt,
+  }
+}
+
 function buildBuiltInAgentSubject(
   agent: BuiltInAgentDetail,
   dependencies: GovernanceDependency[],
@@ -642,6 +696,7 @@ function buildDependencyIndex(subjects: GovernanceRegistrySubject[]): Governance
 }
 
 export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): GovernanceRegistryPayload {
+  const generatedAt = input.generatedAt || new Date().toISOString()
   const toolLabels = createToolLabelMap(input.agentCatalog)
   const skillLabels = createSkillLabelMap(input.agentCatalog)
   const skillTools = createSkillToolMap(input.agentCatalog)
@@ -695,10 +750,11 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
   ))
   return {
     schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
-    generatedAt: input.generatedAt || new Date().toISOString(),
+    generatedAt,
     organization: LOCAL_GOVERNANCE_ORGANIZATION,
     principals: listLocalGovernancePrincipals(),
     groups: listLocalGovernanceGroups(),
+    executionNodes: [buildLocalDesktopExecutionNode(generatedAt)],
     subjects,
     dependencyIndex: buildDependencyIndex(subjects),
   }

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -394,6 +394,23 @@ const governanceRegistry: GovernanceRegistryPayload = {
     displayName: 'Local administrators',
     roles: ['admin', 'owner', 'approver'],
   }],
+  executionNodes: [{
+    schemaVersion: 1,
+    id: 'execution-node:local-desktop',
+    kind: 'desktop',
+    label: 'Local desktop runtime',
+    status: 'active',
+    scope: { kind: 'machine', id: 'machine', label: 'This device', directory: null },
+    capabilities: [
+      { kind: 'scheduling', label: 'Durable local scheduling', available: true, reason: null },
+      { kind: 'queue_recovery', label: 'Queue recovery after app restart', available: true, reason: null },
+      { kind: 'trigger_execution', label: 'Channel and manual trigger dispatch', available: true, reason: null },
+      { kind: 'cost_governance', label: 'Run-level cost and token accounting', available: true, reason: null },
+      { kind: 'background_execution', label: 'Execution independent of this desktop app', available: false, reason: 'Requires a future managed worker.' },
+    ],
+    limitations: ['Requires the desktop app to be running.'],
+    lastSeenAt: '2026-05-07T00:00:00.000Z',
+  }],
   subjects: [
     {
       schemaVersion: 1,
@@ -992,8 +1009,10 @@ describe('PulsePage', () => {
     expect(screen.getByText('Governance map')).toBeInTheDocument()
     expect(screen.getByText('Acme Local Ops')).toBeInTheDocument()
     expect(screen.getByText(/1 principal · 1 group/)).toBeInTheDocument()
+    expect(screen.getByText('Nodes').parentElement?.textContent).toContain('1/1')
     expect(screen.getByText('Credentials · 1')).toBeInTheDocument()
     expect(screen.getByText('Eval gates · 1')).toBeInTheDocument()
+    expect(screen.getByText('Background workers planned')).toBeInTheDocument()
     expect(screen.getByText('Channel inbox and delivery')).toBeInTheDocument()
     expect(screen.getByText('Ops webhook · SOP')).toBeInTheDocument()
     expect(screen.getByText('Weekly support digest')).toBeInTheDocument()

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -162,6 +162,7 @@ function governanceDependencyLabel(kind: GovernanceDependencyKind) {
 function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null) {
   const subjects = registry?.subjects || []
   const dependencies = registry?.dependencyIndex || []
+  const executionNodes = registry?.executionNodes || []
   const availableControls = subjects.reduce((count, subject) => (
     count + subject.incidentControls.filter((control) => control.available).length
   ), 0)
@@ -173,11 +174,19 @@ function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null)
     .sort((left, right) => right[1] - left[1] || governanceDependencyLabel(left[0]).localeCompare(governanceDependencyLabel(right[0])))
     .slice(0, 5)
     .map(([kind, count]) => `${governanceDependencyLabel(kind)} · ${formatInteger.format(count)}`)
+  const activeExecutionNodeCount = executionNodes.filter((node) => node.status === 'active').length
+  const backgroundExecutionReady = executionNodes.some((node) => (
+    node.status === 'active'
+    && node.capabilities.some((capability) => capability.kind === 'background_execution' && capability.available)
+  ))
 
   return {
     organizationLabel: registry?.organization.displayName || t('homepage.governance.localOrg', 'Local organization'),
     principalCount: registry?.principals.length || 0,
     groupCount: registry?.groups.length || 0,
+    executionNodeCount: executionNodes.length,
+    activeExecutionNodeCount,
+    backgroundExecutionReady,
     agentCount: subjects.filter((subject) => subject.subjectKind === 'agent').length,
     crewCount: subjects.filter((subject) => subject.subjectKind === 'crew').length,
     dependencyCount: dependencies.length,
@@ -866,12 +875,18 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                             {formatInteger.format(governanceSummary.groupCount)} {governanceSummary.groupCount === 1 ? t('homepage.governance.group', 'group') : t('homepage.governance.groups', 'groups')}
                           </div>
                         </div>
-                        <div className="mt-3 grid grid-cols-4 gap-2 max-[860px]:grid-cols-2">
+                        <div className="mt-3 grid grid-cols-5 gap-2 max-[980px]:grid-cols-2">
                           {[
                             { label: t('homepage.governance.agents', 'Agents'), value: formatInteger.format(governanceSummary.agentCount) },
                             { label: t('homepage.governance.crews', 'Crews'), value: formatInteger.format(governanceSummary.crewCount) },
                             { label: t('homepage.governance.dependencies', 'Dependencies'), value: formatInteger.format(governanceSummary.dependencyCount) },
                             { label: t('homepage.governance.controls', 'Controls'), value: formatInteger.format(governanceSummary.availableControls) },
+                            {
+                              label: t('homepage.governance.nodes', 'Nodes'),
+                              value: governanceSummary.executionNodeCount > 0
+                                ? `${formatInteger.format(governanceSummary.activeExecutionNodeCount)}/${formatInteger.format(governanceSummary.executionNodeCount)}`
+                                : '0',
+                            },
                           ].map((stat) => (
                             <div key={stat.label} className="rounded-xl border border-border-subtle px-2.5 py-2">
                               <div className="text-[9px] uppercase tracking-[0.08em] text-text-muted">{stat.label}</div>
@@ -886,7 +901,14 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                               ...(governanceSummary.evalSuiteCount > 0
                                 ? [`${t('homepage.governance.evalGates', 'Eval gates')} · ${formatInteger.format(governanceSummary.evalSuiteCount)}`]
                                 : []),
-                            ].slice(0, 6)}
+                              ...(governanceSummary.executionNodeCount > 0
+                                ? [
+                                    governanceSummary.backgroundExecutionReady
+                                      ? t('homepage.governance.backgroundReady', 'Background execution ready')
+                                      : t('homepage.governance.backgroundPlanned', 'Background workers planned'),
+                                  ]
+                                : []),
+                            ].slice(0, 7)}
                             emptyLabel={t('homepage.governance.empty', 'No governed dependencies registered yet.')}
                           />
                         </div>

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -271,6 +271,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
         },
         principals: [],
         groups: [],
+        executionNodes: [],
         subjects: [],
         dependencyIndex: [],
       })),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -120,6 +120,9 @@ map without changing OpenCode execution:
 - eval-suite dependencies use the stored suite name and lifecycle state when
   available, so admin views can distinguish active certification gates from
   draft or retired suites
+- execution-node readiness for the local desktop runtime, including which
+  scheduling, queue recovery, trigger, cost-governance, and background
+  execution capabilities are available today
 - incident-control metadata that distinguishes actions available today from
   controls planned in later governance slices
 
@@ -158,9 +161,9 @@ records, channel/automation deliveries, and outcome evaluations.
 
 Pulse summarizes this registry in its Operations card, including the active
 local organization, governed agent and crew counts, dependency breadth, eval
-gates, and available incident controls. Operators can also copy the audit
-stream from Pulse as NDJSON for review or OTel-shaped JSON for telemetry
-pipelines.
+gates, execution-node readiness, and available incident controls. Operators can
+also copy the audit stream from Pulse as NDJSON for review or OTel-shaped JSON
+for telemetry pipelines.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -24,6 +24,14 @@ export type GovernanceOwnerKind = 'user' | 'group' | 'system'
 export type GovernanceRole = 'admin' | 'owner' | 'approver' | 'viewer'
 export type GovernanceOrganizationMode = 'local' | 'managed'
 export type GovernanceMemoryBoundaryKind = 'none' | 'session' | 'agent' | 'crew' | 'workspace'
+export type GovernanceExecutionNodeKind = 'desktop' | 'managed_worker'
+export type GovernanceExecutionNodeStatus = 'active' | 'planned' | 'unavailable'
+export type GovernanceExecutionCapabilityKind =
+  | 'background_execution'
+  | 'cost_governance'
+  | 'queue_recovery'
+  | 'scheduling'
+  | 'trigger_execution'
 export type GovernanceIncidentControlKind =
   | 'pause_agent'
   | 'retire_agent'
@@ -90,6 +98,25 @@ export interface GovernanceMemoryBoundary {
   label: string
 }
 
+export interface GovernanceExecutionCapability {
+  kind: GovernanceExecutionCapabilityKind
+  label: string
+  available: boolean
+  reason?: string | null
+}
+
+export interface GovernanceExecutionNode {
+  schemaVersion: number
+  id: string
+  kind: GovernanceExecutionNodeKind
+  label: string
+  status: GovernanceExecutionNodeStatus
+  scope: GovernanceScope
+  capabilities: GovernanceExecutionCapability[]
+  limitations: string[]
+  lastSeenAt: string | null
+}
+
 export interface GovernanceIncidentControl {
   kind: GovernanceIncidentControlKind
   label: string
@@ -128,6 +155,7 @@ export interface GovernanceRegistryPayload {
   organization: GovernanceOrganization
   principals: GovernancePrincipal[]
   groups: GovernanceGroup[]
+  executionNodes: GovernanceExecutionNode[]
   subjects: GovernanceRegistrySubject[]
   dependencyIndex: GovernanceDependencyIndexEntry[]
 }

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -270,6 +270,15 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
   assert.deepEqual(payload.groups.map((group) => `${group.id}:${group.roles.join(',')}`), [
     'local-admins:admin,owner,approver',
   ])
+  assert.deepEqual(payload.executionNodes.map((node) => `${node.id}:${node.kind}:${node.status}:${node.scope.kind}`), [
+    'execution-node:local-desktop:desktop:active:machine',
+  ])
+  const localNode = payload.executionNodes[0]
+  assert.ok(localNode)
+  assert.equal(localNode.lastSeenAt, generatedAt)
+  assert.equal(localNode.capabilities.find((capability) => capability.kind === 'scheduling')?.available, true)
+  assert.equal(localNode.capabilities.find((capability) => capability.kind === 'background_execution')?.available, false)
+  assert.match(localNode.limitations.join(' '), /desktop app/)
 
   const agent = payload.subjects.find((subject) => subject.name === 'data-analyst')
   assert.ok(agent)


### PR DESCRIPTION
## Summary
- add execution-node readiness metadata to the governance registry
- model the current local desktop runtime truthfully: local scheduling/recovery are available, laptop-independent background execution is planned
- surface node readiness in Pulse and document the admin-facing execution-plane view

Part of #250.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check