### PR TITLE
[codex] map governed memory in governance registry

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -752,7 +752,12 @@ function buildCrewSubject(input: {
     const agentSubject = input.agentSubjectsByName.get(agentNameKey(member.agentName))
     if (!agentSubject) continue
     for (const dependency of agentSubject.dependencies) {
-      if (dependency.kind !== 'tool' && dependency.kind !== 'skill' && dependency.kind !== 'credential') continue
+      if (
+        dependency.kind !== 'tool'
+        && dependency.kind !== 'skill'
+        && dependency.kind !== 'credential'
+        && dependency.kind !== 'memory'
+      ) continue
       addDependency(dependencies, {
         ...dependency,
         source: 'transitive',

--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import type {
   AgentCatalog,
+  AgentMemoryEntry,
   BuiltInAgentDetail,
   ChannelDefinition,
   CrewListPayload,
@@ -36,6 +37,7 @@ import { listCrewCatalog } from './crew-service.ts'
 import { listChannelDefinitions } from './channel-store.ts'
 import { listSopDefinitions } from './sop-service.ts'
 import { listCustomMcps } from './native-customizations.ts'
+import { listAgentMemoryEntries } from './improvement-store.ts'
 import { listApplicableRevokedGovernanceTools } from './governance-tool-policy.ts'
 import {
   LOCAL_GOVERNANCE_APPROVERS,
@@ -53,6 +55,7 @@ export interface GovernanceRegistryBuildInput {
   agentCatalog: AgentCatalog
   crewCatalog: CrewListPayload
   evalSuites?: EvalSuite[]
+  memoryEntries?: AgentMemoryEntry[]
   sopCatalog?: SopListPayload
   channels?: ChannelDefinition[]
   toolCredentialDependencies?: GovernanceToolCredentialDependency[]
@@ -465,6 +468,160 @@ function evalSuiteGovernanceLifecycle(status: EvalSuite['status']): GovernanceLi
   return 'draft'
 }
 
+function memoryGovernanceSubjectId(entry: Pick<AgentMemoryEntry, 'id'>): string {
+  return `memory:${idSegment(entry.id)}`
+}
+
+function memoryGovernanceLifecycle(entry: Pick<AgentMemoryEntry, 'status'>): GovernanceLifecycleState {
+  if (entry.status === 'proposed') return 'review'
+  if (entry.status === 'approved') return 'approved'
+  if (entry.status === 'quarantined') return 'quarantined'
+  return 'retired'
+}
+
+function memoryDependency(entry: AgentMemoryEntry): GovernanceDependency {
+  const lifecycle = memoryGovernanceLifecycle(entry)
+  return createDependency(
+    'memory',
+    memoryGovernanceSubjectId(entry),
+    entry.title || entry.summary || entry.id,
+    'direct',
+    entry.status === 'approved',
+    lifecycle,
+  )
+}
+
+function memoryEntryCanBeRuntimeDependency(entry: AgentMemoryEntry): boolean {
+  return entry.status === 'approved' || entry.status === 'quarantined'
+}
+
+function memoryMatchesAgent(entry: AgentMemoryEntry, agent: GovernanceCustomAgentSummary | BuiltInAgentDetail): boolean {
+  if (!memoryEntryCanBeRuntimeDependency(entry)) return false
+  if (entry.scopeKind === 'agent') return agentNameKey(entry.scopeId) === agentNameKey(agent.name)
+  if ('scope' in agent && entry.scopeKind === 'project') {
+    return agent.scope === 'project' && Boolean(agent.directory) && entry.scopeId === agent.directory
+  }
+  return false
+}
+
+function memoryMatchesCrew(entry: AgentMemoryEntry, crew: CrewListPayload['crews'][number]): boolean {
+  return memoryEntryCanBeRuntimeDependency(entry)
+    && entry.scopeKind === 'crew'
+    && entry.scopeId === crew.definition.id
+}
+
+function agentMemoryDependencies(
+  agent: GovernanceCustomAgentSummary | BuiltInAgentDetail,
+  memoryEntries: AgentMemoryEntry[] = [],
+): GovernanceDependency[] {
+  return memoryEntries
+    .filter((entry) => memoryMatchesAgent(entry, agent))
+    .map(memoryDependency)
+}
+
+function crewMemoryDependencies(
+  crew: CrewListPayload['crews'][number],
+  memoryEntries: AgentMemoryEntry[] = [],
+): GovernanceDependency[] {
+  return memoryEntries
+    .filter((entry) => memoryMatchesCrew(entry, crew))
+    .map(memoryDependency)
+}
+
+function memoryScope(entry: AgentMemoryEntry): GovernanceScope {
+  if (entry.scopeKind === 'project') {
+    const directory = entry.scopeId || null
+    return {
+      kind: 'project',
+      id: directory ? `project:${shortHash(directory)}` : 'project:unbound',
+      label: directory || 'Project memory',
+      directory,
+    }
+  }
+  const labelPrefix = entry.scopeKind === 'agent'
+    ? 'Agent memory'
+    : entry.scopeKind === 'crew'
+      ? 'Crew memory'
+      : 'Machine memory'
+  return {
+    kind: 'machine',
+    id: `memory:${entry.scopeKind}:${entry.scopeId ? idSegment(entry.scopeId) : '*'}`,
+    label: entry.scopeId ? `${labelPrefix}: ${entry.scopeId}` : labelPrefix,
+    directory: null,
+  }
+}
+
+function memoryBoundary(entry: AgentMemoryEntry) {
+  if (entry.scopeKind === 'agent') {
+    return {
+      kind: 'agent' as const,
+      id: entry.scopeId,
+      label: entry.scopeId
+        ? `Available to the ${entry.scopeId} agent memory scope.`
+        : 'Available to an agent memory scope.',
+    }
+  }
+  if (entry.scopeKind === 'crew') {
+    return {
+      kind: 'crew' as const,
+      id: entry.scopeId,
+      label: entry.scopeId
+        ? `Available to the ${entry.scopeId} crew memory scope.`
+        : 'Available to a crew memory scope.',
+    }
+  }
+  if (entry.scopeKind === 'project') {
+    return {
+      kind: 'workspace' as const,
+      id: entry.scopeId,
+      label: entry.scopeId
+        ? `Available inside project memory scope ${entry.scopeId}.`
+        : 'Available inside a project memory scope.',
+    }
+  }
+  return {
+    kind: 'none' as const,
+    id: null,
+    label: 'Machine-scoped governed learning memory.',
+  }
+}
+
+function memoryControls(entry: AgentMemoryEntry): GovernanceIncidentControl[] {
+  const lifecycle = memoryGovernanceLifecycle(entry)
+  return [{
+    kind: 'quarantine_memory',
+    label: lifecycle === 'approved' ? 'Quarantine memory' : lifecycle === 'quarantined' ? 'Memory quarantined' : 'Memory not approved',
+    available: lifecycle === 'approved',
+    requiresConfirmation: true,
+    requiredRoles: requiredRolesForGovernanceIncident('quarantine_memory'),
+    reason: lifecycle === 'approved'
+      ? null
+      : lifecycle === 'quarantined'
+        ? 'The memory entry is already quarantined.'
+        : 'Only approved memory can be quarantined.',
+  }]
+}
+
+function buildMemorySubject(entry: AgentMemoryEntry): GovernanceRegistrySubject {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    subjectKind: 'memory',
+    subjectId: memoryGovernanceSubjectId(entry),
+    name: entry.id,
+    displayName: entry.title || entry.id,
+    description: entry.summary || entry.title || 'Governed learning memory entry.',
+    owner: LOCAL_GOVERNANCE_OWNER,
+    approvers: LOCAL_GOVERNANCE_APPROVERS,
+    lifecycle: memoryGovernanceLifecycle(entry),
+    scope: memoryScope(entry),
+    memoryBoundary: memoryBoundary(entry),
+    evalSuiteId: null,
+    offboardingPath: 'Quarantine unsafe approved memory, or archive memory through the governed improvement review workflow.',
+    dependencies: [],
+    incidentControls: memoryControls(entry),
+  }
+}
+
 function buildLocalDesktopExecutionNode(lastSeenAt: string): GovernanceExecutionNode {
   return {
     schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
@@ -708,6 +865,7 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
   })
   const crewChannelDependencies = createCrewChannelDependencyMap(input.channels)
   const evalSuitesById = createEvalSuiteMap(input.evalSuites)
+  const memoryEntries = input.memoryEntries || []
 
   const agentSubjects = [
     ...input.builtinAgents.map((agent) => buildBuiltInAgentSubject(agent, collectAgentDependencies({
@@ -718,7 +876,10 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
       skillTools,
       toolCredentials,
       revokedTools,
-      supplemental: agentSupplementalDependencies.get(agentNameKey(agent.name)),
+      supplemental: [
+        ...(agentSupplementalDependencies.get(agentNameKey(agent.name)) || []),
+        ...agentMemoryDependencies(agent, memoryEntries),
+      ],
     }))),
     ...input.customAgents.map((agent) => buildCustomAgentSubject(agent, collectAgentDependencies({
       toolIds: agent.toolIds,
@@ -728,7 +889,10 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
       skillTools,
       toolCredentials,
       revokedTools,
-      supplemental: agentSupplementalDependencies.get(agentNameKey(agent.name)),
+      supplemental: [
+        ...(agentSupplementalDependencies.get(agentNameKey(agent.name)) || []),
+        ...agentMemoryDependencies(agent, memoryEntries),
+      ],
     }))),
   ]
 
@@ -741,9 +905,13 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
     crew,
     agentSubjectsByName,
     evalSuitesById,
-    supplementalDependencies: crewChannelDependencies.get(crew.definition.id),
+    supplementalDependencies: [
+      ...(crewChannelDependencies.get(crew.definition.id) || []),
+      ...crewMemoryDependencies(crew, memoryEntries),
+    ],
   }))
-  const subjects = [...agentSubjects, ...crewSubjects].sort((left, right) => (
+  const memorySubjects = memoryEntries.map(buildMemorySubject)
+  const subjects = [...agentSubjects, ...crewSubjects, ...memorySubjects].sort((left, right) => (
     left.subjectKind.localeCompare(right.subjectKind)
     || left.displayName.localeCompare(right.displayName)
     || left.subjectId.localeCompare(right.subjectId)
@@ -772,6 +940,7 @@ export async function getGovernanceRegistry(options?: RuntimeContextOptions): Pr
     agentCatalog,
     crewCatalog: listCrewCatalog(),
     evalSuites: listEvalSuites(),
+    memoryEntries: listAgentMemoryEntries(),
     sopCatalog: listSopDefinitions(),
     channels: listChannelDefinitions(),
     toolCredentialDependencies: buildGovernanceToolCredentialDependencies({

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -509,6 +509,17 @@ const governanceRegistry: GovernanceRegistryPayload = {
       },
       subjectIds: ['crew:research'],
     },
+    {
+      dependency: {
+        kind: 'memory',
+        id: 'memory:memory-analyst',
+        label: 'Analyst memory',
+        source: 'direct',
+        required: true,
+        lifecycle: 'approved',
+      },
+      subjectIds: ['agent:system:build'],
+    },
   ],
 }
 
@@ -1012,6 +1023,7 @@ describe('PulsePage', () => {
     expect(screen.getByText('Nodes').parentElement?.textContent).toContain('1/1')
     expect(screen.getByText('Credentials · 1')).toBeInTheDocument()
     expect(screen.getByText('Eval gates · 1')).toBeInTheDocument()
+    expect(screen.getByText('Memory · 1')).toBeInTheDocument()
     expect(screen.getByText('Background workers planned')).toBeInTheDocument()
     expect(screen.getByText('Channel inbox and delivery')).toBeInTheDocument()
     expect(screen.getByText('Ops webhook · SOP')).toBeInTheDocument()

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -112,14 +112,19 @@ map without changing OpenCode execution:
   membership, and role grants that policy decisions use today
 - agents and crews with owner, lifecycle, scope, memory boundary, and
   offboarding path
-- direct dependencies on member agents, tools, skills, workspace profiles,
-  SOPs, channel routes, integration credentials, and eval suites
+- governed memory entries as registry subjects, with quarantine controls for
+  approved memory
+- direct dependencies on member agents, tools, skills, memory entries,
+  workspace profiles, SOPs, channel routes, integration credentials, and eval
+  suites
 - transitive dependencies such as skill-linked tools, integration credentials
   needed by those tools, SOP/channel exposure for workflow agents, and crew
   member capabilities
 - eval-suite dependencies use the stored suite name and lifecycle state when
   available, so admin views can distinguish active certification gates from
   draft or retired suites
+- memory dependencies use the governed memory lifecycle, so quarantined memory
+  remains visible in the map without being treated as an active requirement
 - execution-node readiness for the local desktop runtime, including which
   scheduling, queue recovery, trigger, cost-governance, and background
   execution capabilities are available today

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -442,6 +442,10 @@ test('governance registry maps governed memory subjects and agent or crew depend
   const crew = payload.subjects.find((subject) => subject.subjectId === 'crew:crew-analytics')
   assert.ok(crew)
   assert.equal(hasDependency(crew, 'memory', 'memory:memory-crew-analytics'), true)
+  assert.equal(hasDependency(crew, 'memory', 'memory:memory-agent-analyst', 'transitive'), true)
+  assert.equal(hasDependency(crew, 'memory', 'memory:memory-project-acme', 'transitive'), true)
+  assert.equal(hasDependency(crew, 'memory', 'memory:memory-quarantined', 'transitive'), true)
+  assert.equal(hasDependency(crew, 'memory', 'memory:memory-proposed'), false)
 
   const memorySubject = payload.subjects.find((subject) => subject.subjectId === 'memory:memory-agent-analyst')
   assert.ok(memorySubject)
@@ -457,7 +461,7 @@ test('governance registry maps governed memory subjects and agent or crew depend
   assert.equal(quarantinedSubject.incidentControls.find((control) => control.kind === 'quarantine_memory')?.available, false)
 
   const memoryIndex = payload.dependencyIndex.find((entry) => entry.dependency.kind === 'memory' && entry.dependency.id === 'memory:memory-agent-analyst')
-  assert.deepEqual(memoryIndex?.subjectIds, [analyst.subjectId])
+  assert.deepEqual(memoryIndex?.subjectIds.sort(), [analyst.subjectId, crew.subjectId].sort())
 })
 
 test('governance credential dependencies are derived from configured MCP credential surfaces', () => {

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import type {
   AgentCatalog,
+  AgentMemoryEntry,
   BuiltInAgentDetail,
   ChannelDefinition,
   CrewListPayload,
@@ -89,6 +90,37 @@ function customAgent(overrides: Partial<CustomAgentSummary> = {}): CustomAgentSu
     writeAccess: true,
     valid: true,
     issues: [],
+    ...overrides,
+  }
+}
+
+function memoryEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry {
+  return {
+    schemaVersion: 1,
+    id: 'memory-agent-analyst',
+    scopeKind: 'agent',
+    scopeId: 'data-analyst',
+    status: 'approved',
+    title: 'Analyst reporting memory',
+    body: 'Prefer concise evidence notes in reporting.',
+    summary: 'Use concise evidence notes.',
+    tags: ['reporting'],
+    privacy: 'internal',
+    provenance: [{
+      schemaVersion: 1,
+      kind: 'trace',
+      id: 'trace-1',
+      label: 'Trace evidence',
+      uri: null,
+      hash: 'sha256:trace-1',
+    }],
+    sourceProposalId: 'proposal-memory-1',
+    contentHash: 'sha256:memory-1',
+    createdAt: generatedAt,
+    updatedAt: generatedAt,
+    reviewedAt: generatedAt,
+    reviewedBy: 'local-user',
+    reviewNote: 'Evidence checked.',
     ...overrides,
   }
 }
@@ -361,6 +393,71 @@ test('governance registry exposes credential, SOP, and channel dependencies with
     agent.subjectId,
     crew.subjectId,
   ].sort())
+})
+
+test('governance registry maps governed memory subjects and agent or crew dependencies', () => {
+  const agentMemory = memoryEntry()
+  const projectMemory = memoryEntry({
+    id: 'memory-project-acme',
+    scopeKind: 'project',
+    scopeId: '/workspace/acme',
+    title: 'Project reporting convention',
+    summary: 'Mention the current sprint in project reports.',
+  })
+  const crewMemory = memoryEntry({
+    id: 'memory-crew-analytics',
+    scopeKind: 'crew',
+    scopeId: 'crew-analytics',
+    title: 'Crew delivery lesson',
+    summary: 'Always include evaluator pass notes.',
+  })
+  const quarantinedMemory = memoryEntry({
+    id: 'memory-quarantined',
+    status: 'quarantined',
+    title: 'Quarantined lesson',
+    summary: 'Do not inject this lesson.',
+  })
+  const proposedMemory = memoryEntry({
+    id: 'memory-proposed',
+    status: 'proposed',
+    title: 'Proposed lesson',
+    summary: 'Not approved yet.',
+  })
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [builtInAgent()],
+    customAgents: [customAgent()],
+    agentCatalog: catalog(),
+    crewCatalog: crewCatalog(),
+    memoryEntries: [agentMemory, projectMemory, crewMemory, quarantinedMemory, proposedMemory],
+    generatedAt,
+  })
+
+  const analyst = payload.subjects.find((subject) => subject.name === 'data-analyst')
+  assert.ok(analyst)
+  assert.equal(hasDependency(analyst, 'memory', 'memory:memory-agent-analyst'), true)
+  assert.equal(hasDependency(analyst, 'memory', 'memory:memory-project-acme'), true)
+  assert.equal(hasDependency(analyst, 'memory', 'memory:memory-quarantined'), true)
+  assert.equal(hasDependency(analyst, 'memory', 'memory:memory-proposed'), false)
+
+  const crew = payload.subjects.find((subject) => subject.subjectId === 'crew:crew-analytics')
+  assert.ok(crew)
+  assert.equal(hasDependency(crew, 'memory', 'memory:memory-crew-analytics'), true)
+
+  const memorySubject = payload.subjects.find((subject) => subject.subjectId === 'memory:memory-agent-analyst')
+  assert.ok(memorySubject)
+  assert.equal(memorySubject.subjectKind, 'memory')
+  assert.equal(memorySubject.lifecycle, 'approved')
+  assert.equal(memorySubject.scope.label, 'Agent memory: data-analyst')
+  assert.equal(memorySubject.memoryBoundary.kind, 'agent')
+  assert.equal(memorySubject.incidentControls.find((control) => control.kind === 'quarantine_memory')?.available, true)
+
+  const quarantinedSubject = payload.subjects.find((subject) => subject.subjectId === 'memory:memory-quarantined')
+  assert.ok(quarantinedSubject)
+  assert.equal(quarantinedSubject.lifecycle, 'quarantined')
+  assert.equal(quarantinedSubject.incidentControls.find((control) => control.kind === 'quarantine_memory')?.available, false)
+
+  const memoryIndex = payload.dependencyIndex.find((entry) => entry.dependency.kind === 'memory' && entry.dependency.id === 'memory:memory-agent-analyst')
+  assert.deepEqual(memoryIndex?.subjectIds, [analyst.subjectId])
 })
 
 test('governance credential dependencies are derived from configured MCP credential surfaces', () => {


### PR DESCRIPTION
## Summary
- project governed memory entries as governance registry subjects with lifecycle and quarantine controls
- link approved/quarantined agent, project, and crew-scoped memory as agent/crew dependencies while leaving proposed memory unlinked
- surface memory dependency highlights in Pulse and document the governance map behavior

Part of #250.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check