### PR TITLE
[codex] expose governance incident actions in Pulse

### DIFF
--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -850,6 +850,12 @@ function installPulseApi(options: {
   archiveDreamRun?: ReturnType<typeof vi.fn>
   governanceRegistry?: ReturnType<typeof vi.fn>
   exportGovernanceAudit?: ReturnType<typeof vi.fn>
+  pauseCrew?: ReturnType<typeof vi.fn>
+  retireCrew?: ReturnType<typeof vi.fn>
+  pauseAgent?: ReturnType<typeof vi.fn>
+  retireAgent?: ReturnType<typeof vi.fn>
+  quarantineMemory?: ReturnType<typeof vi.fn>
+  revokeTool?: ReturnType<typeof vi.fn>
   channelState?: ChannelListPayload
   localWebhookStatus?: LocalWebhookReceiverStatus
   approveInboundItem?: ReturnType<typeof vi.fn>
@@ -909,6 +915,12 @@ function installPulseApi(options: {
         eventCount: 1,
         body: '{"recordType":"governance_incident"}',
       })),
+      pauseCrew: options.pauseCrew || vi.fn(async () => null),
+      retireCrew: options.retireCrew || vi.fn(async () => null),
+      pauseAgent: options.pauseAgent || vi.fn(async () => true),
+      retireAgent: options.retireAgent || vi.fn(async () => true),
+      quarantineMemory: options.quarantineMemory || vi.fn(async () => null),
+      revokeTool: options.revokeTool || vi.fn(async () => null),
     },
     channels: {
       list: vi.fn(async () => testChannelState),
@@ -1139,6 +1151,33 @@ describe('PulsePage', () => {
     await user.click(screen.getByRole('button', { name: 'Copy OTel JSON' }))
     await waitFor(() => expect(exportGovernanceAudit).toHaveBeenCalledWith({ format: 'otel-json' }))
     expect(api.clipboard.writeText).toHaveBeenLastCalledWith(expect.stringContaining('resourceLogs'))
+  })
+
+  it('runs governance incident controls from Pulse and refreshes the registry', async () => {
+    const user = userEvent.setup()
+    const pauseCrew = vi.fn(async () => null)
+    const governanceRegistryMock = vi.fn(async () => governanceRegistry)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const api = installPulseApi({
+      pauseCrew,
+      governanceRegistry: governanceRegistryMock,
+    })
+
+    try {
+      render(<PulsePage brandName="Open Cowork" onOpenThread={vi.fn()} />)
+      await screen.findByText('Governance incident controls')
+
+      await user.click(screen.getByRole('button', { name: 'Pause crew' }))
+
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Research crew'))
+      await waitFor(() => expect(pauseCrew).toHaveBeenCalledWith({
+        crewId: 'research',
+        reason: 'Triggered from Pulse governance operations.',
+      }))
+      expect(api.operations.governanceRegistry).toHaveBeenCalledTimes(2)
+    } finally {
+      confirmSpy.mockRestore()
+    }
   })
 
   it('reviews channel delivery drafts from Pulse', async () => {

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -5,6 +5,7 @@ import type {
   CapabilityRiskMetadata,
   GovernanceAuditExportFormat,
   GovernanceDependencyKind,
+  GovernanceIncidentControlKind,
   GovernanceRegistryPayload,
   GovernanceRegistrySubject,
   ImprovementProposalDraft,
@@ -160,22 +161,68 @@ function governanceDependencyLabel(kind: GovernanceDependencyKind) {
   }
 }
 
-function governanceSubjectLabel(subject: GovernanceRegistrySubject | undefined) {
-  if (!subject) return null
-  const kind = subject.subjectKind === 'crew'
+function governanceSubjectKindLabel(kind: GovernanceRegistrySubject['subjectKind']) {
+  return kind === 'crew'
     ? t('homepage.governance.subjectCrew', 'Crew')
-    : subject.subjectKind === 'memory'
+    : kind === 'memory'
       ? t('homepage.governance.subjectMemory', 'Memory')
-      : subject.subjectKind === 'tool'
+      : kind === 'tool'
         ? t('homepage.governance.subjectTool', 'Tool')
         : t('homepage.governance.subjectAgent', 'Agent')
-  return `${kind} · ${subject.displayName || subject.name}`
+}
+
+function governanceSubjectLabel(subject: GovernanceRegistrySubject | undefined) {
+  if (!subject) return null
+  return `${governanceSubjectKindLabel(subject.subjectKind)} · ${subject.displayName || subject.name}`
 }
 
 function formatGovernanceSubjectCount(count: number) {
   return count === 1
     ? t('homepage.governance.subjectCountSingular', '1 subject')
     : t('homepage.governance.subjectCountPlural', '{{count}} subjects', { count: formatInteger.format(count) })
+}
+
+type GovernanceIncidentActionSummary = {
+  key: string
+  kind: GovernanceIncidentControlKind
+  label: string
+  subjectId: string
+  subjectKind: GovernanceRegistrySubject['subjectKind']
+  subjectName: string
+  scopeLabel: string
+  directory: string | null
+  lifecycle: GovernanceRegistrySubject['lifecycle']
+  requiresConfirmation: boolean
+}
+
+function governanceIncidentSubjectLabel(action: Pick<GovernanceIncidentActionSummary, 'subjectKind' | 'subjectName'>) {
+  return `${governanceSubjectKindLabel(action.subjectKind)} · ${action.subjectName}`
+}
+
+function governanceIncidentActionRank(kind: GovernanceIncidentControlKind) {
+  switch (kind) {
+    case 'pause_agent':
+    case 'pause_crew':
+      return 0
+    case 'quarantine_memory':
+    case 'revoke_tool':
+      return 1
+    case 'retire_agent':
+    case 'retire_crew':
+      return 2
+    default:
+      return 3
+  }
+}
+
+function decodeGovernanceSubjectId(subject: Pick<GovernanceRegistrySubject, 'subjectId' | 'name'>, prefix: string) {
+  if (!subject.subjectId.startsWith(prefix)) return subject.name
+  try {
+    const decoded = decodeURIComponent(subject.subjectId.slice(prefix.length))
+    return decoded.trim() || subject.name
+  } catch {
+    return subject.name
+  }
 }
 
 function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null) {
@@ -211,6 +258,27 @@ function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null)
       || left.label.localeCompare(right.label)
     ))
     .slice(0, 4)
+  const incidentActions: GovernanceIncidentActionSummary[] = subjects
+    .flatMap((subject) => subject.incidentControls
+      .filter((control) => control.available && control.kind !== 'export_audit')
+      .map((control) => ({
+        key: `${subject.subjectId}:${control.kind}`,
+        kind: control.kind,
+        label: control.label,
+        subjectId: subject.subjectId,
+        subjectKind: subject.subjectKind,
+        subjectName: subject.displayName || subject.name,
+        scopeLabel: subject.scope.label,
+        directory: subject.scope.directory || null,
+        lifecycle: subject.lifecycle,
+        requiresConfirmation: control.requiresConfirmation,
+      })))
+    .sort((left, right) => (
+      governanceIncidentActionRank(left.kind) - governanceIncidentActionRank(right.kind)
+      || left.subjectName.localeCompare(right.subjectName)
+      || left.label.localeCompare(right.label)
+    ))
+    .slice(0, 5)
   const activeExecutionNodeCount = executionNodes.filter((node) => node.status === 'active').length
   const backgroundExecutionReady = executionNodes.some((node) => (
     node.status === 'active'
@@ -231,6 +299,7 @@ function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null)
     availableControls,
     dependencyHighlights,
     dependencyDetails,
+    incidentActions,
   }
 }
 
@@ -323,6 +392,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
   } = usePulseDiagnostics()
   const [improvementActionId, setImprovementActionId] = useState<string | null>(null)
   const [channelActionId, setChannelActionId] = useState<string | null>(null)
+  const [governanceActionId, setGovernanceActionId] = useState<string | null>(null)
   const [governanceExportStatus, setGovernanceExportStatus] = useState<'idle' | 'working-ndjson' | 'working-otel-json' | 'copied' | 'empty' | 'error'>('idle')
   const governanceExportResetTimerRef = useRef<number | null>(null)
 
@@ -647,6 +717,71 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
       reportPulseActionError(error, 'Failed to export governance audit')
       setGovernanceExportStatus('error')
       scheduleGovernanceExportStatusReset()
+    }
+  }
+
+  async function runGovernanceIncidentControl(action: GovernanceIncidentActionSummary) {
+    if (action.requiresConfirmation) {
+      const confirmed = window.confirm(t(
+        'pulse.governanceControlConfirm',
+        'Run {{action}} for {{subject}}? This writes a governance audit event and may change runtime access.',
+        { action: action.label.toLowerCase(), subject: action.subjectName },
+      ))
+      if (!confirmed) return
+    }
+
+    setGovernanceActionId(action.key)
+    const reason = t('pulse.governanceControlReason', 'Triggered from Pulse governance operations.')
+    try {
+      switch (action.kind) {
+        case 'pause_agent':
+          await window.coworkApi.operations.pauseAgent({
+            subjectId: action.subjectId,
+            reason,
+            context: action.directory ? { directory: action.directory } : undefined,
+          })
+          break
+        case 'retire_agent':
+          await window.coworkApi.operations.retireAgent({
+            subjectId: action.subjectId,
+            reason,
+            context: action.directory ? { directory: action.directory } : undefined,
+          })
+          break
+        case 'pause_crew':
+          await window.coworkApi.operations.pauseCrew({
+            crewId: decodeGovernanceSubjectId({ subjectId: action.subjectId, name: action.subjectName }, 'crew:'),
+            reason,
+          })
+          break
+        case 'retire_crew':
+          await window.coworkApi.operations.retireCrew({
+            crewId: decodeGovernanceSubjectId({ subjectId: action.subjectId, name: action.subjectName }, 'crew:'),
+            reason,
+          })
+          break
+        case 'quarantine_memory':
+          await window.coworkApi.operations.quarantineMemory({
+            memoryId: decodeGovernanceSubjectId({ subjectId: action.subjectId, name: action.subjectName }, 'memory:'),
+            reason,
+          })
+          break
+        case 'revoke_tool':
+          await window.coworkApi.operations.revokeTool({
+            toolId: decodeGovernanceSubjectId({ subjectId: action.subjectId, name: action.subjectName }, 'tool:'),
+            reason,
+            context: action.directory ? { directory: action.directory } : undefined,
+          })
+          break
+        default:
+          throw new Error(`Unsupported governance incident control ${action.kind}.`)
+      }
+      await refreshDiagnostics({ silent: true })
+    } catch (error) {
+      addGlobalError(t('pulse.governanceControlFailed', 'Could not run the governance incident control. Please try again.'))
+      reportPulseActionError(error, `Failed to run governance incident control ${action.kind}`)
+    } finally {
+      setGovernanceActionId(null)
     }
   }
 
@@ -977,6 +1112,41 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                                     {dependency.subjectLabels.join(' · ')}
                                   </div>
                                 ) : null}
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
+                        {governanceSummary.incidentActions.length > 0 ? (
+                          <div className="mt-3 space-y-2" aria-label={t('homepage.governance.incidentControls', 'Governance incident controls')}>
+                            <div className="text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                              {t('homepage.governance.incidentControls', 'Governance incident controls')}
+                            </div>
+                            {governanceSummary.incidentActions.map((action) => (
+                              <div
+                                key={action.key}
+                                className="flex items-center justify-between gap-3 rounded-xl border border-border-subtle px-3 py-2"
+                                style={{
+                                  background: 'color-mix(in srgb, var(--color-surface) 76%, transparent)',
+                                }}
+                              >
+                                <div className="min-w-0">
+                                  <div className="text-[10px] uppercase tracking-[0.1em] text-text-muted">
+                                    {governanceIncidentSubjectLabel(action)}
+                                  </div>
+                                  <div className="mt-1 text-[12px] font-semibold text-text truncate">
+                                    {action.scopeLabel} · {action.lifecycle}
+                                  </div>
+                                </div>
+                                <button
+                                  type="button"
+                                  className="shrink-0 rounded-full border border-border-subtle px-3 py-1.5 text-[11px] font-semibold text-text-secondary transition-colors hover:bg-surface-hover disabled:cursor-wait disabled:opacity-60"
+                                  disabled={governanceActionId !== null}
+                                  onClick={() => void runGovernanceIncidentControl(action)}
+                                >
+                                  {governanceActionId === action.key
+                                    ? t('homepage.governance.controlWorking', 'Running...')
+                                    : action.label}
+                                </button>
                               </div>
                             ))}
                           </div>

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -287,6 +287,8 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       })),
       pauseAgent: vi.fn(async () => true),
       retireAgent: vi.fn(async () => true),
+      pauseCrew: vi.fn(async () => null),
+      retireCrew: vi.fn(async () => null),
       quarantineMemory: vi.fn(async () => null),
       revokeTool: vi.fn(async (request: { toolId: string, reason?: string | null }) => ({
         schemaVersion: 1,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -171,7 +171,9 @@ local organization, governed agent and crew counts, dependency breadth, eval
 gates, execution-node readiness, and available incident controls. It also lists
 the highest-impact dependency links with the affected governed subjects, so an
 operator can see which agents or crews rely on a tool, memory, credential,
-channel, SOP, or eval gate without exporting the raw registry first. Operators
+channel, SOP, or eval gate without exporting the raw registry first. Available
+incident controls can be run from Pulse with confirmation, using the same
+operations IPC methods and audit trail as the lower-level admin APIs. Operators
 can also copy the audit stream from Pulse as NDJSON for review or OTel-shaped
 JSON for telemetry pipelines.
 


### PR DESCRIPTION
## Summary
- surface the top available governance incident controls in the Pulse Operations card
- confirm risky actions, call the existing operations IPC controls, and refresh the governance registry afterward
- cover the Pulse action flow with a renderer test and document the admin surface

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check

Part of #250.