### PR TITLE
[codex] surface recent governance incidents in Pulse

### DIFF
--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -9,6 +9,7 @@ import type {
   CustomAgentSummary,
   DashboardSummary,
   EffectiveAppSettings,
+  GovernanceAuditEvent,
   GovernanceRegistryPayload,
   ImprovementDiagnosticsSummary,
   ImprovementReviewQueue,
@@ -533,6 +534,24 @@ const governanceRegistry: GovernanceRegistryPayload = {
   ],
 }
 
+const governanceAuditEvents: GovernanceAuditEvent[] = [
+  {
+    schemaVersion: 1,
+    id: 'audit-1',
+    kind: 'incident_control',
+    subjectKind: 'crew',
+    subjectId: 'crew:research',
+    action: 'pause_crew',
+    outcome: 'succeeded',
+    actor: { kind: 'user', id: 'local-user', displayName: 'Local operator' },
+    reason: 'Ops freeze while the certification gate is refreshed.',
+    beforeLifecycle: 'active',
+    afterLifecycle: 'paused',
+    metadata: {},
+    createdAt: '2026-05-07T00:05:00.000Z',
+  },
+]
+
 const channelState: ChannelListPayload = {
   channels: [
     {
@@ -849,6 +868,7 @@ function installPulseApi(options: {
   startDreamRun?: ReturnType<typeof vi.fn>
   archiveDreamRun?: ReturnType<typeof vi.fn>
   governanceRegistry?: ReturnType<typeof vi.fn>
+  governanceAuditEvents?: ReturnType<typeof vi.fn>
   exportGovernanceAudit?: ReturnType<typeof vi.fn>
   pauseCrew?: ReturnType<typeof vi.fn>
   retireCrew?: ReturnType<typeof vi.fn>
@@ -906,6 +926,7 @@ function installPulseApi(options: {
       queueAlerts: options.queueAlerts || vi.fn(async () => queueAlerts),
       capabilityRisks: vi.fn(async () => capabilityRisks),
       governanceRegistry: options.governanceRegistry || vi.fn(async () => governanceRegistry),
+      governanceAuditEvents: options.governanceAuditEvents || vi.fn(async () => governanceAuditEvents),
       exportGovernanceAudit: options.exportGovernanceAudit || vi.fn(async () => ({
         schemaVersion: 2,
         format: 'ndjson',
@@ -1055,6 +1076,9 @@ describe('PulsePage', () => {
     expect(screen.getAllByText('Agent · Build').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Crew · Research crew').length).toBeGreaterThan(0)
     expect(screen.getByText('Background workers planned')).toBeInTheDocument()
+    expect(screen.getByText('Recent governance incidents')).toBeInTheDocument()
+    expect(screen.getByText('Pause Crew')).toBeInTheDocument()
+    expect(screen.getByText(/Ops freeze while the certification gate is refreshed/)).toBeInTheDocument()
     expect(screen.getByText('Channel inbox and delivery')).toBeInTheDocument()
     expect(screen.getByText('Ops webhook · SOP')).toBeInTheDocument()
     expect(screen.getByText('Weekly support digest')).toBeInTheDocument()
@@ -1076,6 +1100,7 @@ describe('PulsePage', () => {
     expect(api.operations.queueItems).toHaveBeenCalledTimes(1)
     expect(api.operations.capabilityRisks).toHaveBeenCalledTimes(1)
     expect(api.operations.governanceRegistry).toHaveBeenCalledTimes(1)
+    expect(api.operations.governanceAuditEvents).toHaveBeenCalledWith({ limit: 5 })
     expect(api.channels.list).toHaveBeenCalledTimes(1)
     expect(api.channels.localWebhookStatus).toHaveBeenCalledTimes(1)
     expect(api.improvements.summary).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -3,6 +3,7 @@ import type {
   ChannelDeliveryRecord,
   ChannelInboundItem,
   CapabilityRiskMetadata,
+  GovernanceAuditEvent,
   GovernanceAuditExportFormat,
   GovernanceDependencyKind,
   GovernanceIncidentControlKind,
@@ -225,6 +226,19 @@ function decodeGovernanceSubjectId(subject: Pick<GovernanceRegistrySubject, 'sub
   }
 }
 
+function formatGovernanceAuditAction(action: string) {
+  return action
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatGovernanceAuditSubject(event: Pick<GovernanceAuditEvent, 'subjectKind' | 'subjectId'>, subjectLabelsById: Map<string, string>) {
+  const subjectLabel = subjectLabelsById.get(event.subjectId) || event.subjectId
+  return `${formatGovernanceAuditAction(event.subjectKind)} · ${subjectLabel}`
+}
+
 function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null) {
   const subjects = registry?.subjects || []
   const dependencies = registry?.dependencyIndex || []
@@ -384,6 +398,7 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
     queueAlerts,
     capabilityRisks,
     governanceRegistry,
+    governanceAuditEvents,
     channelState,
     localWebhookStatus,
     improvementSummary,
@@ -501,6 +516,13 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
   )
   const governanceSummary = useMemo(
     () => summarizeGovernanceRegistry(governanceRegistry),
+    [governanceRegistry],
+  )
+  const governanceSubjectLabelsById = useMemo(
+    () => new Map((governanceRegistry?.subjects || []).map((subject) => [
+      subject.subjectId,
+      governanceSubjectLabel(subject) || subject.subjectId,
+    ])),
     [governanceRegistry],
   )
   const highRiskCapabilityLabels = useMemo(
@@ -1147,6 +1169,41 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                                     ? t('homepage.governance.controlWorking', 'Running...')
                                     : action.label}
                                 </button>
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
+                        {governanceAuditEvents.length > 0 ? (
+                          <div className="mt-3 space-y-2" aria-label={t('homepage.governance.recentIncidents', 'Recent governance incidents')}>
+                            <div className="text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                              {t('homepage.governance.recentIncidents', 'Recent governance incidents')}
+                            </div>
+                            {governanceAuditEvents.slice(0, 3).map((event) => (
+                              <div
+                                key={event.id}
+                                className="rounded-xl border border-border-subtle px-3 py-2"
+                                style={{
+                                  background: 'color-mix(in srgb, var(--color-surface) 76%, transparent)',
+                                }}
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="min-w-0">
+                                    <div className="truncate text-[10px] uppercase tracking-[0.1em] text-text-muted">
+                                      {formatGovernanceAuditSubject(event, governanceSubjectLabelsById)}
+                                    </div>
+                                    <div className="mt-1 text-[12px] font-semibold text-text truncate">
+                                      {formatGovernanceAuditAction(event.action)}
+                                    </div>
+                                  </div>
+                                  <div className={`shrink-0 text-[10px] font-semibold uppercase tracking-[0.1em] ${event.outcome === 'failed' ? 'text-red' : 'text-accent'}`}>
+                                    {event.outcome}
+                                  </div>
+                                </div>
+                                <div className="mt-1.5 text-[11px] text-text-secondary truncate">
+                                  {event.reason || t('homepage.governance.noIncidentReason', 'No incident reason recorded.')}
+                                  {' · '}
+                                  {formatChannelTime(event.createdAt)}
+                                </div>
                               </div>
                             ))}
                           </div>

--- a/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
+++ b/apps/desktop/src/renderer/components/usePulseDiagnostics.ts
@@ -3,6 +3,7 @@ import type {
   ChannelListPayload,
   DashboardSummary,
   DashboardTimeRangeKey,
+  GovernanceAuditEvent,
   GovernanceRegistryPayload,
   ImprovementDiagnosticsSummary,
   ImprovementReviewQueue,
@@ -32,6 +33,7 @@ export function usePulseDiagnostics() {
   const [channelState, setChannelState] = useState<ChannelListPayload>({ channels: [], inboundItems: [], deliveries: [] })
   const [localWebhookStatus, setLocalWebhookStatus] = useState<LocalWebhookReceiverStatus | null>(null)
   const [governanceRegistry, setGovernanceRegistry] = useState<GovernanceRegistryPayload | null>(null)
+  const [governanceAuditEvents, setGovernanceAuditEvents] = useState<GovernanceAuditEvent[]>([])
   const [improvementSummary, setImprovementSummary] = useState<ImprovementDiagnosticsSummary | null>(null)
   const [improvementInbox, setImprovementInbox] = useState<ImprovementReviewQueue | null>(null)
 
@@ -72,6 +74,7 @@ export function usePulseDiagnostics() {
       queueAlertsResult,
       capabilityRisksResult,
       governanceRegistryResult,
+      governanceAuditEventsResult,
       channelStateResult,
       localWebhookStatusResult,
       improvementSummaryResult,
@@ -93,6 +96,7 @@ export function usePulseDiagnostics() {
       window.coworkApi.operations.queueAlerts(),
       window.coworkApi.operations.capabilityRisks(),
       window.coworkApi.operations.governanceRegistry(),
+      window.coworkApi.operations.governanceAuditEvents({ limit: 5 }),
       window.coworkApi.channels.list(),
       window.coworkApi.channels.localWebhookStatus(),
       window.coworkApi.improvements.summary(),
@@ -136,6 +140,7 @@ export function usePulseDiagnostics() {
     setQueueAlerts(queueAlertsResult.status === 'fulfilled' ? queueAlertsResult.value : [])
     setCapabilityRisks(capabilityRisksResult.status === 'fulfilled' ? capabilityRisksResult.value : [])
     setGovernanceRegistry(governanceRegistryResult.status === 'fulfilled' ? governanceRegistryResult.value : null)
+    setGovernanceAuditEvents(governanceAuditEventsResult.status === 'fulfilled' ? governanceAuditEventsResult.value : [])
     setChannelState(channelStateResult.status === 'fulfilled' ? channelStateResult.value : { channels: [], inboundItems: [], deliveries: [] })
     setLocalWebhookStatus(localWebhookStatusResult.status === 'fulfilled' ? localWebhookStatusResult.value : null)
     setImprovementSummary(improvementSummaryResult.status === 'fulfilled' ? improvementSummaryResult.value : null)
@@ -213,6 +218,7 @@ export function usePulseDiagnostics() {
     queueAlerts,
     capabilityRisks,
     governanceRegistry,
+    governanceAuditEvents,
     channelState,
     localWebhookStatus,
     improvementSummary,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -174,8 +174,8 @@ operator can see which agents or crews rely on a tool, memory, credential,
 channel, SOP, or eval gate without exporting the raw registry first. Available
 incident controls can be run from Pulse with confirmation, using the same
 operations IPC methods and audit trail as the lower-level admin APIs. Operators
-can also copy the audit stream from Pulse as NDJSON for review or OTel-shaped
-JSON for telemetry pipelines.
+can review the most recent incident outcomes in Pulse, or copy the full audit
+stream as NDJSON for review or OTel-shaped JSON for telemetry pipelines.
 
 Use the registry as the control-plane inventory for Pulse and future admin
 views. Execution still flows through OpenCode sessions, tools, skills, and MCPs.


### PR DESCRIPTION
## Summary
- load recent governance audit events into Pulse diagnostics
- show recent incident outcomes in the Operations card without exporting the full audit stream
- cover the feed with Pulse renderer test coverage and docs

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check

Part of #250.