### PR TITLE
[codex] add governance credential bindings

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -8,6 +8,7 @@ import type {
   CustomAgentSummary as SharedCustomAgentSummary,
   CustomMcpConfig,
   EvalSuite,
+  GovernanceCredentialBinding,
   GovernanceDependency,
   GovernanceDependencyIndexEntry,
   GovernanceDependencyKind,
@@ -117,6 +118,17 @@ function sortDependencies(dependencies: GovernanceDependency[]): GovernanceDepen
     || left.id.localeCompare(right.id)
     || left.source.localeCompare(right.source)
   ))
+}
+
+function credentialBindingsFromDependencies(dependencies: GovernanceDependency[]): GovernanceCredentialBinding[] {
+  return sortDependencies(dependencies.filter((dependency) => dependency.kind === 'credential'))
+    .map((dependency) => ({
+      id: dependency.id,
+      label: dependency.label,
+      source: dependency.source,
+      required: dependency.required,
+      ...(dependency.lifecycle ? { lifecycle: dependency.lifecycle } : {}),
+    }))
 }
 
 function addDependency(
@@ -617,6 +629,7 @@ function buildMemorySubject(entry: AgentMemoryEntry): GovernanceRegistrySubject 
     memoryBoundary: memoryBoundary(entry),
     evalSuiteId: null,
     offboardingPath: 'Quarantine unsafe approved memory, or archive memory through the governed improvement review workflow.',
+    credentialBindings: [],
     dependencies: [],
     incidentControls: memoryControls(entry),
   }
@@ -705,6 +718,7 @@ function buildBuiltInAgentSubject(
     offboardingPath: agent.source === 'opencode'
       ? 'Disable or retune through built-in agent overrides; do not delete OpenCode-owned runtime agents.'
       : 'Remove or disable the configured agent in Open Cowork configuration.',
+    credentialBindings: credentialBindingsFromDependencies(dependencies),
     dependencies,
     incidentControls: builtInAgentControls(agent),
   }
@@ -734,6 +748,7 @@ function buildCustomAgentSubject(
     offboardingPath: agent.scope === 'project'
       ? 'Disable or remove the project custom agent from the Agents surface.'
       : 'Disable or remove the machine custom agent from the Agents surface.',
+    credentialBindings: credentialBindingsFromDependencies(dependencies),
     dependencies,
     incidentControls: customAgentControls(agent),
   }
@@ -787,6 +802,7 @@ function buildCrewSubject(input: {
   for (const dependency of input.supplementalDependencies || []) {
     addDependency(dependencies, dependency)
   }
+  const sortedDependencies = sortDependencies([...dependencies.values()])
 
   const scope: GovernanceScope = activeVersion?.workspaceProfileId
     ? {
@@ -820,7 +836,8 @@ function buildCrewSubject(input: {
     },
     evalSuiteId: activeVersion?.evalSuiteId || null,
     offboardingPath: 'Pause or retire the crew before revoking its workspace profile, member agents, or eval suite.',
-    dependencies: sortDependencies([...dependencies.values()]),
+    credentialBindings: credentialBindingsFromDependencies(sortedDependencies),
+    dependencies: sortedDependencies,
     incidentControls: crewControls(definition.status),
   }
 }

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -427,6 +427,7 @@ const governanceRegistry: GovernanceRegistryPayload = {
       memoryBoundary: { kind: 'session', id: 'build', label: 'Session context' },
       evalSuiteId: null,
       offboardingPath: 'Disable through config.',
+      credentialBindings: [],
       dependencies: [{
         kind: 'tool',
         id: 'tool-github',
@@ -450,6 +451,7 @@ const governanceRegistry: GovernanceRegistryPayload = {
       memoryBoundary: { kind: 'crew', id: 'research', label: 'Crew traces and evals' },
       evalSuiteId: 'eval-suite-analytics',
       offboardingPath: 'Pause or retire the crew.',
+      credentialBindings: [],
       dependencies: [{
         kind: 'eval_suite',
         id: 'eval-suite-analytics',

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -112,6 +112,8 @@ map without changing OpenCode execution:
   membership, and role grants that policy decisions use today
 - agents and crews with owner, lifecycle, scope, memory boundary, and
   offboarding path
+- credential bindings derived from integration credential dependencies, without
+  exposing secret names or values
 - governed memory entries as registry subjects, with quarantine controls for
   approved memory
 - direct dependencies on member agents, tools, skills, memory entries,

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -92,6 +92,14 @@ export interface GovernanceDependency {
   lifecycle?: GovernanceLifecycleState | null
 }
 
+export interface GovernanceCredentialBinding {
+  id: string
+  label: string
+  source: GovernanceDependencySource
+  required: boolean
+  lifecycle?: GovernanceLifecycleState | null
+}
+
 export interface GovernanceMemoryBoundary {
   kind: GovernanceMemoryBoundaryKind
   id: string | null
@@ -140,6 +148,7 @@ export interface GovernanceRegistrySubject {
   memoryBoundary: GovernanceMemoryBoundary
   evalSuiteId: string | null
   offboardingPath: string
+  credentialBindings: GovernanceCredentialBinding[]
   dependencies: GovernanceDependency[]
   incidentControls: GovernanceIncidentControl[]
 }

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -379,11 +379,23 @@ test('governance registry exposes credential, SOP, and channel dependencies with
   assert.equal(hasDependency(agent, 'sop', 'sop-weekly-report', 'direct'), true)
   assert.equal(hasDependency(agent, 'channel', 'channel-analytics', 'transitive'), true)
   assert.equal(agent.dependencies.some((dependency) => dependency.label.includes('secret')), false)
+  assert.deepEqual(agent.credentialBindings, [{
+    id: 'integration:filesystem',
+    label: 'Filesystem integration credentials',
+    source: 'direct',
+    required: true,
+  }])
 
   const crew = payload.subjects.find((subject) => subject.subjectKind === 'crew' && subject.name === 'crew-analytics')
   assert.ok(crew)
   assert.equal(hasDependency(crew, 'credential', 'integration:filesystem', 'transitive'), true)
   assert.equal(hasDependency(crew, 'channel', 'channel-crew', 'direct'), true)
+  assert.deepEqual(crew.credentialBindings, [{
+    id: 'integration:filesystem',
+    label: 'Filesystem integration credentials',
+    source: 'transitive',
+    required: true,
+  }])
 
   const credentialIndex = payload.dependencyIndex.find(
     (entry) => entry.dependency.kind === 'credential' && entry.dependency.id === 'integration:filesystem',


### PR DESCRIPTION
## Summary
- add first-class credential bindings to governance registry subjects
- derive bindings from existing credential dependency projection without reading or exposing secret values
- cover direct agent and transitive crew credential bindings in registry tests and docs

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check

Part of #250.