### PR TITLE
[codex] add planned managed worker governance node

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -688,6 +688,59 @@ function buildLocalDesktopExecutionNode(lastSeenAt: string): GovernanceExecution
   }
 }
 
+function buildPlannedManagedWorkerExecutionNode(): GovernanceExecutionNode {
+  return {
+    schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+    id: 'execution-node:managed-worker',
+    kind: 'managed_worker',
+    label: 'Managed worker plane',
+    status: 'planned',
+    scope: {
+      kind: 'system',
+      id: 'managed-worker-plane',
+      label: 'Future managed service plane',
+      directory: null,
+    },
+    capabilities: [
+      {
+        kind: 'background_execution',
+        label: 'Execution independent of this desktop app',
+        available: false,
+        reason: 'No managed worker is registered yet.',
+      },
+      {
+        kind: 'scheduling',
+        label: 'Server-side scheduling',
+        available: false,
+        reason: 'Scheduled work is currently coordinated by the desktop runtime.',
+      },
+      {
+        kind: 'queue_recovery',
+        label: 'Server-side queue recovery',
+        available: false,
+        reason: 'Queue recovery is currently local to this device.',
+      },
+      {
+        kind: 'trigger_execution',
+        label: 'Remote trigger dispatch',
+        available: false,
+        reason: 'Channel and manual triggers still dispatch through the local desktop runtime.',
+      },
+      {
+        kind: 'cost_governance',
+        label: 'Organization-wide worker cost governance',
+        available: false,
+        reason: 'Cost governance is currently recorded at local run boundaries.',
+      },
+    ],
+    limitations: [
+      'This node is a roadmap placeholder, not an active execution backend.',
+      'Do not route OpenCode execution here until a managed worker or durable service plane is implemented.',
+    ],
+    lastSeenAt: null,
+  }
+}
+
 function buildBuiltInAgentSubject(
   agent: BuiltInAgentDetail,
   dependencies: GovernanceDependency[],
@@ -944,7 +997,10 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
     organization: LOCAL_GOVERNANCE_ORGANIZATION,
     principals: listLocalGovernancePrincipals(),
     groups: listLocalGovernanceGroups(),
-    executionNodes: [buildLocalDesktopExecutionNode(generatedAt)],
+    executionNodes: [
+      buildLocalDesktopExecutionNode(generatedAt),
+      buildPlannedManagedWorkerExecutionNode(),
+    ],
     subjects,
     dependencyIndex: buildDependencyIndex(subjects),
   }

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -395,23 +395,38 @@ const governanceRegistry: GovernanceRegistryPayload = {
     displayName: 'Local administrators',
     roles: ['admin', 'owner', 'approver'],
   }],
-  executionNodes: [{
-    schemaVersion: 1,
-    id: 'execution-node:local-desktop',
-    kind: 'desktop',
-    label: 'Local desktop runtime',
-    status: 'active',
-    scope: { kind: 'machine', id: 'machine', label: 'This device', directory: null },
-    capabilities: [
-      { kind: 'scheduling', label: 'Durable local scheduling', available: true, reason: null },
-      { kind: 'queue_recovery', label: 'Queue recovery after app restart', available: true, reason: null },
-      { kind: 'trigger_execution', label: 'Channel and manual trigger dispatch', available: true, reason: null },
-      { kind: 'cost_governance', label: 'Run-level cost and token accounting', available: true, reason: null },
-      { kind: 'background_execution', label: 'Execution independent of this desktop app', available: false, reason: 'Requires a future managed worker.' },
-    ],
-    limitations: ['Requires the desktop app to be running.'],
-    lastSeenAt: '2026-05-07T00:00:00.000Z',
-  }],
+  executionNodes: [
+    {
+      schemaVersion: 1,
+      id: 'execution-node:local-desktop',
+      kind: 'desktop',
+      label: 'Local desktop runtime',
+      status: 'active',
+      scope: { kind: 'machine', id: 'machine', label: 'This device', directory: null },
+      capabilities: [
+        { kind: 'scheduling', label: 'Durable local scheduling', available: true, reason: null },
+        { kind: 'queue_recovery', label: 'Queue recovery after app restart', available: true, reason: null },
+        { kind: 'trigger_execution', label: 'Channel and manual trigger dispatch', available: true, reason: null },
+        { kind: 'cost_governance', label: 'Run-level cost and token accounting', available: true, reason: null },
+        { kind: 'background_execution', label: 'Execution independent of this desktop app', available: false, reason: 'Requires a future managed worker.' },
+      ],
+      limitations: ['Requires the desktop app to be running.'],
+      lastSeenAt: '2026-05-07T00:00:00.000Z',
+    },
+    {
+      schemaVersion: 1,
+      id: 'execution-node:managed-worker',
+      kind: 'managed_worker',
+      label: 'Managed worker plane',
+      status: 'planned',
+      scope: { kind: 'system', id: 'managed-worker-plane', label: 'Future managed service plane', directory: null },
+      capabilities: [
+        { kind: 'background_execution', label: 'Execution independent of this desktop app', available: false, reason: 'No managed worker is registered yet.' },
+      ],
+      limitations: ['This node is a roadmap placeholder, not an active execution backend.'],
+      lastSeenAt: null,
+    },
+  ],
   subjects: [
     {
       schemaVersion: 1,
@@ -1065,7 +1080,7 @@ describe('PulsePage', () => {
     expect(screen.getByText('Governance map')).toBeInTheDocument()
     expect(screen.getByText('Acme Local Ops')).toBeInTheDocument()
     expect(screen.getByText(/1 principal · 1 group/)).toBeInTheDocument()
-    expect(screen.getByText('Nodes').parentElement?.textContent).toContain('1/1')
+    expect(screen.getByText('Nodes').parentElement?.textContent).toContain('1/2')
     expect(screen.getByText('Credentials · 1')).toBeInTheDocument()
     expect(screen.getByText('Channels · 1')).toBeInTheDocument()
     expect(screen.getByText('Eval gates · 1')).toBeInTheDocument()

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -127,9 +127,10 @@ map without changing OpenCode execution:
   draft or retired suites
 - memory dependencies use the governed memory lifecycle, so quarantined memory
   remains visible in the map without being treated as an active requirement
-- execution-node readiness for the local desktop runtime, including which
-  scheduling, queue recovery, trigger, cost-governance, and background
-  execution capabilities are available today
+- execution-node readiness for the active local desktop runtime plus the
+  planned managed-worker service plane, including which scheduling, queue
+  recovery, trigger, cost-governance, and background execution capabilities are
+  available today
 - incident-control metadata that distinguishes actions available today from
   controls planned in later governance slices
 

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -304,6 +304,7 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
   ])
   assert.deepEqual(payload.executionNodes.map((node) => `${node.id}:${node.kind}:${node.status}:${node.scope.kind}`), [
     'execution-node:local-desktop:desktop:active:machine',
+    'execution-node:managed-worker:managed_worker:planned:system',
   ])
   const localNode = payload.executionNodes[0]
   assert.ok(localNode)
@@ -311,6 +312,11 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
   assert.equal(localNode.capabilities.find((capability) => capability.kind === 'scheduling')?.available, true)
   assert.equal(localNode.capabilities.find((capability) => capability.kind === 'background_execution')?.available, false)
   assert.match(localNode.limitations.join(' '), /desktop app/)
+  const managedNode = payload.executionNodes[1]
+  assert.ok(managedNode)
+  assert.equal(managedNode.lastSeenAt, null)
+  assert.equal(managedNode.capabilities.find((capability) => capability.kind === 'background_execution')?.available, false)
+  assert.match(managedNode.limitations.join(' '), /roadmap placeholder/)
 
   const agent = payload.subjects.find((subject) => subject.name === 'data-analyst')
   assert.ok(agent)


### PR DESCRIPTION
## Summary
- add a planned managed-worker execution node to the governance registry
- keep execution unchanged by marking every managed-worker capability unavailable with explicit roadmap limitations
- update Pulse readiness fixture/docs to distinguish the active local desktop node from the planned service plane

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check

Part of #250.