### PR TITLE
[codex] add governance secret vault metadata

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -24,6 +24,7 @@ import type {
   SopListPayload,
 } from '@open-cowork/shared'
 import { COWORK_GOVERNANCE_SCHEMA_VERSION } from '@open-cowork/shared'
+import type { SecretStorageMode } from './secure-storage-policy.ts'
 
 import { listBuiltInAgentDetails } from './built-in-agent-details.ts'
 import { listEvalSuites } from './crew-store.ts'
@@ -39,6 +40,7 @@ import { listChannelDefinitions } from './channel-store.ts'
 import { listSopDefinitions } from './sop-service.ts'
 import { listCustomMcps } from './native-customizations.ts'
 import { listAgentMemoryEntries } from './improvement-store.ts'
+import { buildGovernanceSecretVaults, LOCAL_SECRET_VAULT_ID } from './governance-secret-vaults.ts'
 import { listApplicableRevokedGovernanceTools } from './governance-tool-policy.ts'
 import {
   LOCAL_GOVERNANCE_APPROVERS,
@@ -49,6 +51,7 @@ import {
   listLocalGovernancePrincipals,
   requiredRolesForGovernanceIncident,
 } from './governance-policy.ts'
+import { getSettingsSecretStorageMode } from './settings.ts'
 
 export interface GovernanceRegistryBuildInput {
   builtinAgents: BuiltInAgentDetail[]
@@ -61,6 +64,7 @@ export interface GovernanceRegistryBuildInput {
   channels?: ChannelDefinition[]
   toolCredentialDependencies?: GovernanceToolCredentialDependency[]
   revokedTools?: GovernanceRevokedTool[]
+  secretStorageMode: SecretStorageMode
   generatedAt?: string
 }
 
@@ -127,6 +131,7 @@ function credentialBindingsFromDependencies(dependencies: GovernanceDependency[]
       label: dependency.label,
       source: dependency.source,
       required: dependency.required,
+      secretVaultId: LOCAL_SECRET_VAULT_ID,
       ...(dependency.lifecycle ? { lifecycle: dependency.lifecycle } : {}),
     }))
 }
@@ -997,6 +1002,10 @@ export function buildGovernanceRegistry(input: GovernanceRegistryBuildInput): Go
     organization: LOCAL_GOVERNANCE_ORGANIZATION,
     principals: listLocalGovernancePrincipals(),
     groups: listLocalGovernanceGroups(),
+    secretVaults: buildGovernanceSecretVaults({
+      secretStorageMode: input.secretStorageMode,
+      generatedAt,
+    }),
     executionNodes: [
       buildLocalDesktopExecutionNode(generatedAt),
       buildPlannedManagedWorkerExecutionNode(),
@@ -1027,5 +1036,6 @@ export async function getGovernanceRegistry(options?: RuntimeContextOptions): Pr
       customMcps: listCustomMcps(options),
     }),
     revokedTools: listApplicableRevokedGovernanceTools(options),
+    secretStorageMode: getSettingsSecretStorageMode(),
   })
 }

--- a/apps/desktop/src/main/governance-secret-vaults.ts
+++ b/apps/desktop/src/main/governance-secret-vaults.ts
@@ -1,0 +1,78 @@
+import {
+  COWORK_GOVERNANCE_SCHEMA_VERSION,
+  type GovernanceSecretVault,
+  type GovernanceSecretVaultStatus,
+} from '@open-cowork/shared'
+import type { SecretStorageMode } from './secure-storage-policy.ts'
+
+export const LOCAL_SECRET_VAULT_ID = 'secret-vault:local-os'
+export const MANAGED_EXTERNAL_SECRET_VAULT_ID = 'secret-vault:managed-external'
+
+function localVaultStatus(mode: SecretStorageMode): GovernanceSecretVaultStatus {
+  return mode === 'encrypted' ? 'active' : 'unavailable'
+}
+
+function localVaultLimitations(mode: SecretStorageMode): string[] {
+  if (mode === 'encrypted') {
+    return [
+      'Credentials are protected by the operating-system account on this device.',
+      'No organization-wide external secret vault is configured yet.',
+    ]
+  }
+  if (mode === 'plaintext') {
+    return [
+      'Development mode is using the plaintext settings fallback because OS-backed safeStorage is unavailable.',
+      'Do not treat this device as an active governance secret vault for production credentials.',
+    ]
+  }
+  return [
+    'OS-backed safeStorage is unavailable, so packaged builds refuse to persist credentials.',
+    'Configure the platform keychain, libsecret, or DPAPI before relying on local credential bindings.',
+  ]
+}
+
+export function buildGovernanceSecretVaults(options: {
+  secretStorageMode: SecretStorageMode
+  generatedAt: string
+}): GovernanceSecretVault[] {
+  const localStatus = localVaultStatus(options.secretStorageMode)
+  return [
+    {
+      schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+      id: LOCAL_SECRET_VAULT_ID,
+      kind: 'local_os',
+      label: 'Local OS credential vault',
+      status: localStatus,
+      scope: {
+        kind: 'machine',
+        id: 'machine',
+        label: 'This device',
+        directory: null,
+      },
+      storageMode: options.secretStorageMode,
+      storedSecretKinds: ['provider_credentials', 'integration_credentials', 'oauth_tokens'],
+      limitations: localVaultLimitations(options.secretStorageMode),
+      lastVerifiedAt: localStatus === 'active' ? options.generatedAt : null,
+    },
+    {
+      schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
+      id: MANAGED_EXTERNAL_SECRET_VAULT_ID,
+      kind: 'managed_external',
+      label: 'Managed external secret vault',
+      status: 'planned',
+      scope: {
+        kind: 'system',
+        id: 'managed-secret-vault',
+        label: 'Future organization vault',
+        directory: null,
+      },
+      storageMode: 'external',
+      storedSecretKinds: ['provider_credentials', 'integration_credentials', 'oauth_tokens'],
+      limitations: [
+        'This is a roadmap integration point; no external vault provider is connected yet.',
+        'Credential bindings currently resolve to the local OS credential vault only.',
+      ],
+      lastVerifiedAt: null,
+    },
+  ]
+}

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -424,6 +424,10 @@ function getSecretStorageMode() {
   })
 }
 
+export function getSettingsSecretStorageMode() {
+  return getSecretStorageMode()
+}
+
 function applyAutomationLaunchAtLogin(settings: AppSettings) {
   try {
     electronApp?.setLoginItemSettings?.({ openAtLogin: settings.automationLaunchAtLogin })

--- a/apps/desktop/src/renderer/components/PulsePage.test.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.test.tsx
@@ -395,6 +395,32 @@ const governanceRegistry: GovernanceRegistryPayload = {
     displayName: 'Local administrators',
     roles: ['admin', 'owner', 'approver'],
   }],
+  secretVaults: [
+    {
+      schemaVersion: 1,
+      id: 'secret-vault:local-os',
+      kind: 'local_os',
+      label: 'Local OS credential vault',
+      status: 'active',
+      scope: { kind: 'machine', id: 'machine', label: 'This device', directory: null },
+      storageMode: 'encrypted',
+      storedSecretKinds: ['provider_credentials', 'integration_credentials', 'oauth_tokens'],
+      limitations: ['Protected by this operating-system account.'],
+      lastVerifiedAt: '2026-05-07T00:00:00.000Z',
+    },
+    {
+      schemaVersion: 1,
+      id: 'secret-vault:managed-external',
+      kind: 'managed_external',
+      label: 'Managed external secret vault',
+      status: 'planned',
+      scope: { kind: 'system', id: 'managed-secret-vault', label: 'Future organization vault', directory: null },
+      storageMode: 'external',
+      storedSecretKinds: ['provider_credentials', 'integration_credentials', 'oauth_tokens'],
+      limitations: ['Roadmap integration point.'],
+      lastVerifiedAt: null,
+    },
+  ],
   executionNodes: [
     {
       schemaVersion: 1,
@@ -1080,6 +1106,7 @@ describe('PulsePage', () => {
     expect(screen.getByText('Governance map')).toBeInTheDocument()
     expect(screen.getByText('Acme Local Ops')).toBeInTheDocument()
     expect(screen.getByText(/1 principal · 1 group/)).toBeInTheDocument()
+    expect(screen.getByText('Vaults').parentElement?.textContent).toContain('1/2')
     expect(screen.getByText('Nodes').parentElement?.textContent).toContain('1/2')
     expect(screen.getByText('Credentials · 1')).toBeInTheDocument()
     expect(screen.getByText('Channels · 1')).toBeInTheDocument()
@@ -1093,6 +1120,7 @@ describe('PulsePage', () => {
     expect(screen.getAllByText('Agent · Build').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Crew · Research crew').length).toBeGreaterThan(0)
     expect(screen.getByText('Background workers planned')).toBeInTheDocument()
+    expect(screen.getByText('Local vault active')).toBeInTheDocument()
     expect(screen.getByText('Recent governance incidents')).toBeInTheDocument()
     expect(screen.getByText('Pause Crew')).toBeInTheDocument()
     expect(screen.getByText(/Ops freeze while the certification gate is refreshed/)).toBeInTheDocument()

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -243,6 +243,7 @@ function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null)
   const subjects = registry?.subjects || []
   const dependencies = registry?.dependencyIndex || []
   const executionNodes = registry?.executionNodes || []
+  const secretVaults = registry?.secretVaults || []
   const subjectsById = new Map(subjects.map((subject) => [subject.subjectId, subject]))
   const availableControls = subjects.reduce((count, subject) => (
     count + subject.incidentControls.filter((control) => control.available).length
@@ -294,6 +295,7 @@ function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null)
     ))
     .slice(0, 5)
   const activeExecutionNodeCount = executionNodes.filter((node) => node.status === 'active').length
+  const activeSecretVaultCount = secretVaults.filter((vault) => vault.status === 'active').length
   const backgroundExecutionReady = executionNodes.some((node) => (
     node.status === 'active'
     && node.capabilities.some((capability) => capability.kind === 'background_execution' && capability.available)
@@ -303,6 +305,8 @@ function summarizeGovernanceRegistry(registry: GovernanceRegistryPayload | null)
     organizationLabel: registry?.organization.displayName || t('homepage.governance.localOrg', 'Local organization'),
     principalCount: registry?.principals.length || 0,
     groupCount: registry?.groups.length || 0,
+    secretVaultCount: secretVaults.length,
+    activeSecretVaultCount,
     executionNodeCount: executionNodes.length,
     activeExecutionNodeCount,
     backgroundExecutionReady,
@@ -1070,12 +1074,18 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                             {formatInteger.format(governanceSummary.groupCount)} {governanceSummary.groupCount === 1 ? t('homepage.governance.group', 'group') : t('homepage.governance.groups', 'groups')}
                           </div>
                         </div>
-                        <div className="mt-3 grid grid-cols-5 gap-2 max-[980px]:grid-cols-2">
+                        <div className="mt-3 grid grid-cols-6 gap-2 max-[980px]:grid-cols-2">
                           {[
                             { label: t('homepage.governance.agents', 'Agents'), value: formatInteger.format(governanceSummary.agentCount) },
                             { label: t('homepage.governance.crews', 'Crews'), value: formatInteger.format(governanceSummary.crewCount) },
                             { label: t('homepage.governance.dependencies', 'Dependencies'), value: formatInteger.format(governanceSummary.dependencyCount) },
                             { label: t('homepage.governance.controls', 'Controls'), value: formatInteger.format(governanceSummary.availableControls) },
+                            {
+                              label: t('homepage.governance.secretVaults', 'Vaults'),
+                              value: governanceSummary.secretVaultCount > 0
+                                ? `${formatInteger.format(governanceSummary.activeSecretVaultCount)}/${formatInteger.format(governanceSummary.secretVaultCount)}`
+                                : '0',
+                            },
                             {
                               label: t('homepage.governance.nodes', 'Nodes'),
                               value: governanceSummary.executionNodeCount > 0
@@ -1103,7 +1113,14 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                                       : t('homepage.governance.backgroundPlanned', 'Background workers planned'),
                                   ]
                                 : []),
-                            ].slice(0, 7)}
+                              ...(governanceSummary.secretVaultCount > 0
+                                ? [
+                                    governanceSummary.activeSecretVaultCount > 0
+                                      ? t('homepage.governance.vaultReady', 'Local vault active')
+                                      : t('homepage.governance.vaultUnavailable', 'Credential vault unavailable'),
+                                  ]
+                                : []),
+                            ].slice(0, 8)}
                             emptyLabel={t('homepage.governance.empty', 'No governed dependencies registered yet.')}
                           />
                         </div>

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,7 +113,11 @@ map without changing OpenCode execution:
 - agents and crews with owner, lifecycle, scope, memory boundary, and
   offboarding path
 - credential bindings derived from integration credential dependencies, without
-  exposing secret names or values
+  exposing secret names or values; each binding points at an explicit
+  governance secret-vault record
+- secret-vault integration metadata for the local OS-backed credential vault
+  and the planned managed external vault, so admin views can distinguish
+  active local protection from future organization-vault work
 - governed memory entries as registry subjects, with quarantine controls for
   approved memory
 - direct dependencies on member agents, tools, skills, memory entries,
@@ -171,7 +175,8 @@ records, channel/automation deliveries, and outcome evaluations.
 
 Pulse summarizes this registry in its Operations card, including the active
 local organization, governed agent and crew counts, dependency breadth, eval
-gates, execution-node readiness, and available incident controls. It also lists
+gates, secret-vault readiness, execution-node readiness, and available incident
+controls. It also lists
 the highest-impact dependency links with the affected governed subjects, so an
 operator can see which agents or crews rely on a tool, memory, credential,
 channel, SOP, or eval gate without exporting the raw registry first. Available

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -24,6 +24,10 @@ export type GovernanceOwnerKind = 'user' | 'group' | 'system'
 export type GovernanceRole = 'admin' | 'owner' | 'approver' | 'viewer'
 export type GovernanceOrganizationMode = 'local' | 'managed'
 export type GovernanceMemoryBoundaryKind = 'none' | 'session' | 'agent' | 'crew' | 'workspace'
+export type GovernanceSecretVaultKind = 'local_os' | 'managed_external'
+export type GovernanceSecretVaultStatus = 'active' | 'planned' | 'unavailable'
+export type GovernanceSecretVaultStorageMode = 'encrypted' | 'plaintext' | 'unavailable' | 'external'
+export type GovernanceSecretKind = 'provider_credentials' | 'integration_credentials' | 'oauth_tokens'
 export type GovernanceExecutionNodeKind = 'desktop' | 'managed_worker'
 export type GovernanceExecutionNodeStatus = 'active' | 'planned' | 'unavailable'
 export type GovernanceExecutionCapabilityKind =
@@ -97,7 +101,21 @@ export interface GovernanceCredentialBinding {
   label: string
   source: GovernanceDependencySource
   required: boolean
+  secretVaultId: string
   lifecycle?: GovernanceLifecycleState | null
+}
+
+export interface GovernanceSecretVault {
+  schemaVersion: number
+  id: string
+  kind: GovernanceSecretVaultKind
+  label: string
+  status: GovernanceSecretVaultStatus
+  scope: GovernanceScope
+  storageMode: GovernanceSecretVaultStorageMode
+  storedSecretKinds: GovernanceSecretKind[]
+  limitations: string[]
+  lastVerifiedAt: string | null
 }
 
 export interface GovernanceMemoryBoundary {
@@ -164,6 +182,7 @@ export interface GovernanceRegistryPayload {
   organization: GovernanceOrganization
   principals: GovernancePrincipal[]
   groups: GovernanceGroup[]
+  secretVaults: GovernanceSecretVault[]
   executionNodes: GovernanceExecutionNode[]
   subjects: GovernanceRegistrySubject[]
   dependencyIndex: GovernanceDependencyIndexEntry[]

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -291,6 +291,7 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
     customAgents: [customAgent({ enabled: false })],
     agentCatalog: catalog(),
     crewCatalog: { crews: [] },
+    secretStorageMode: 'encrypted',
     generatedAt,
   })
 
@@ -305,6 +306,15 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
   assert.deepEqual(payload.executionNodes.map((node) => `${node.id}:${node.kind}:${node.status}:${node.scope.kind}`), [
     'execution-node:local-desktop:desktop:active:machine',
     'execution-node:managed-worker:managed_worker:planned:system',
+  ])
+  assert.deepEqual(payload.secretVaults.map((vault) => `${vault.id}:${vault.kind}:${vault.status}:${vault.storageMode}`), [
+    'secret-vault:local-os:local_os:active:encrypted',
+    'secret-vault:managed-external:managed_external:planned:external',
+  ])
+  assert.deepEqual(payload.secretVaults[0]?.storedSecretKinds, [
+    'provider_credentials',
+    'integration_credentials',
+    'oauth_tokens',
   ])
   const localNode = payload.executionNodes[0]
   assert.ok(localNode)
@@ -376,6 +386,7 @@ test('governance registry exposes credential, SOP, and channel dependencies with
         },
       },
     ],
+    secretStorageMode: 'encrypted',
     generatedAt,
   })
 
@@ -390,6 +401,7 @@ test('governance registry exposes credential, SOP, and channel dependencies with
     label: 'Filesystem integration credentials',
     source: 'direct',
     required: true,
+    secretVaultId: 'secret-vault:local-os',
   }])
 
   const crew = payload.subjects.find((subject) => subject.subjectKind === 'crew' && subject.name === 'crew-analytics')
@@ -401,6 +413,7 @@ test('governance registry exposes credential, SOP, and channel dependencies with
     label: 'Filesystem integration credentials',
     source: 'transitive',
     required: true,
+    secretVaultId: 'secret-vault:local-os',
   }])
 
   const credentialIndex = payload.dependencyIndex.find(
@@ -411,6 +424,45 @@ test('governance registry exposes credential, SOP, and channel dependencies with
     agent.subjectId,
     crew.subjectId,
   ].sort())
+})
+
+test('governance registry marks unavailable local secret vaults without dropping bindings', () => {
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [],
+    customAgents: [customAgent()],
+    agentCatalog: catalog(),
+    crewCatalog: { crews: [] },
+    toolCredentialDependencies: [
+      {
+        toolId: 'filesystem',
+        dependency: {
+          kind: 'credential',
+          id: 'integration:filesystem',
+          label: 'Filesystem integration credentials',
+          source: 'direct',
+          required: true,
+        },
+      },
+    ],
+    secretStorageMode: 'unavailable',
+    generatedAt,
+  })
+
+  const localVault = payload.secretVaults.find((vault) => vault.id === 'secret-vault:local-os')
+  assert.ok(localVault)
+  assert.equal(localVault.status, 'unavailable')
+  assert.equal(localVault.storageMode, 'unavailable')
+  assert.match(localVault.limitations.join(' '), /refuse to persist credentials/i)
+
+  const agent = payload.subjects.find((subject) => subject.name === 'data-analyst')
+  assert.ok(agent)
+  assert.deepEqual(agent.credentialBindings, [{
+    id: 'integration:filesystem',
+    label: 'Filesystem integration credentials',
+    source: 'direct',
+    required: true,
+    secretVaultId: 'secret-vault:local-os',
+  }])
 })
 
 test('governance registry maps governed memory subjects and agent or crew dependencies', () => {
@@ -447,6 +499,7 @@ test('governance registry maps governed memory subjects and agent or crew depend
     agentCatalog: catalog(),
     crewCatalog: crewCatalog(),
     memoryEntries: [agentMemory, projectMemory, crewMemory, quarantinedMemory, proposedMemory],
+    secretStorageMode: 'encrypted',
     generatedAt,
   })
 
@@ -549,6 +602,7 @@ test('governance registry matches SOP exposure to mixed-case configured agent na
     crewCatalog: { crews: [] },
     sopCatalog: sopCatalog('reportagent'),
     channels: [channel()],
+    secretStorageMode: 'encrypted',
     generatedAt,
   })
 
@@ -565,6 +619,7 @@ test('governance registry projects crew member and transitive capability depende
     agentCatalog: catalog(),
     crewCatalog: crewCatalog(),
     evalSuites: [evalSuite()],
+    secretStorageMode: 'encrypted',
     generatedAt,
   })
 
@@ -620,6 +675,7 @@ test('invalid custom agents stay visible as draft governance records', () => {
     })],
     agentCatalog: catalog(),
     crewCatalog: { crews: [] },
+    secretStorageMode: 'encrypted',
     generatedAt,
   })
 


### PR DESCRIPTION
## Summary
- add typed governance secret-vault records for the local OS credential vault and planned managed external vault
- link credential bindings to the local governance secret vault without exposing secret names or values
- surface vault readiness in Pulse governance operations and document the registry contract

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- uv run mkdocs build --strict
- git diff --check