### PR TITLE
[codex] add governance eval hooks

### DIFF
--- a/apps/desktop/src/main/governance-registry.ts
+++ b/apps/desktop/src/main/governance-registry.ts
@@ -485,6 +485,25 @@ function evalSuiteGovernanceLifecycle(status: EvalSuite['status']): GovernanceLi
   return 'draft'
 }
 
+function baselineEvalSuiteId(subjectKind: 'agent' | 'crew', subjectId: string): string {
+  return `eval-suite:${subjectKind}:${idSegment(subjectId)}:baseline`
+}
+
+function baselineEvalSuiteDependency(input: {
+  subjectKind: 'agent' | 'crew'
+  subjectId: string
+  displayName: string
+}): GovernanceDependency {
+  return createDependency(
+    'eval_suite',
+    baselineEvalSuiteId(input.subjectKind, input.subjectId),
+    `${input.displayName} baseline eval hook`,
+    'direct',
+    false,
+    'review',
+  )
+}
+
 function memoryGovernanceSubjectId(entry: Pick<AgentMemoryEntry, 'id'>): string {
   return `memory:${idSegment(entry.id)}`
 }
@@ -751,10 +770,16 @@ function buildBuiltInAgentSubject(
   dependencies: GovernanceDependency[],
 ): GovernanceRegistrySubject {
   const displayName = agent.label || agent.name
+  const subjectId = builtInAgentSubjectId(agent)
+  const evalSuiteId = baselineEvalSuiteId('agent', subjectId)
+  const subjectDependencies = sortDependencies([
+    ...dependencies,
+    baselineEvalSuiteDependency({ subjectKind: 'agent', subjectId, displayName }),
+  ])
   return {
     schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
     subjectKind: 'agent',
-    subjectId: builtInAgentSubjectId(agent),
+    subjectId,
     name: agent.name,
     displayName,
     description: agent.description,
@@ -772,12 +797,12 @@ function buildBuiltInAgentSubject(
       id: agent.name,
       label: `${displayName} uses OpenCode session context; no shared organization memory boundary is attached.`,
     },
-    evalSuiteId: null,
+    evalSuiteId,
     offboardingPath: agent.source === 'opencode'
       ? 'Disable or retune through built-in agent overrides; do not delete OpenCode-owned runtime agents.'
       : 'Remove or disable the configured agent in Open Cowork configuration.',
-    credentialBindings: credentialBindingsFromDependencies(dependencies),
-    dependencies,
+    credentialBindings: credentialBindingsFromDependencies(subjectDependencies),
+    dependencies: subjectDependencies,
     incidentControls: builtInAgentControls(agent),
   }
 }
@@ -786,10 +811,16 @@ function buildCustomAgentSubject(
   agent: GovernanceCustomAgentSummary,
   dependencies: GovernanceDependency[],
 ): GovernanceRegistrySubject {
+  const subjectId = customAgentGovernanceSubjectId(agent)
+  const evalSuiteId = baselineEvalSuiteId('agent', subjectId)
+  const subjectDependencies = sortDependencies([
+    ...dependencies,
+    baselineEvalSuiteDependency({ subjectKind: 'agent', subjectId, displayName: agent.name }),
+  ])
   return {
     schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
     subjectKind: 'agent',
-    subjectId: customAgentGovernanceSubjectId(agent),
+    subjectId,
     name: agent.name,
     displayName: agent.name,
     description: agent.description,
@@ -802,12 +833,12 @@ function buildCustomAgentSubject(
       id: customAgentGovernanceSubjectId(agent),
       label: 'Agent-scoped OpenCode session context; no shared organization memory store is configured.',
     },
-    evalSuiteId: null,
+    evalSuiteId,
     offboardingPath: agent.scope === 'project'
       ? 'Disable or remove the project custom agent from the Agents surface.'
       : 'Disable or remove the machine custom agent from the Agents surface.',
-    credentialBindings: credentialBindingsFromDependencies(dependencies),
-    dependencies,
+    credentialBindings: credentialBindingsFromDependencies(subjectDependencies),
+    dependencies: subjectDependencies,
     incidentControls: customAgentControls(agent),
   }
 }
@@ -876,10 +907,19 @@ function buildCrewSubject(input: {
         directory: null,
       }
 
+  const subjectId = crewSubjectId(definition.id)
+  const evalSuiteId = activeVersion?.evalSuiteId || baselineEvalSuiteId('crew', subjectId)
+  const subjectDependencies = activeVersion?.evalSuiteId
+    ? sortedDependencies
+    : sortDependencies([
+        ...sortedDependencies,
+        baselineEvalSuiteDependency({ subjectKind: 'crew', subjectId, displayName: definition.name }),
+      ])
+
   return {
     schemaVersion: COWORK_GOVERNANCE_SCHEMA_VERSION,
     subjectKind: 'crew',
-    subjectId: crewSubjectId(definition.id),
+    subjectId,
     name: definition.id,
     displayName: definition.name,
     description: definition.description,
@@ -892,10 +932,10 @@ function buildCrewSubject(input: {
       id: definition.id,
       label: 'Crew runs keep durable traces, approvals, policy decisions, evals, and OpenCode child-session links.',
     },
-    evalSuiteId: activeVersion?.evalSuiteId || null,
+    evalSuiteId,
     offboardingPath: 'Pause or retire the crew before revoking its workspace profile, member agents, or eval suite.',
-    credentialBindings: credentialBindingsFromDependencies(sortedDependencies),
-    dependencies: sortedDependencies,
+    credentialBindings: credentialBindingsFromDependencies(subjectDependencies),
+    dependencies: subjectDependencies,
     incidentControls: crewControls(definition.status),
   }
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -129,6 +129,10 @@ map without changing OpenCode execution:
 - eval-suite dependencies use the stored suite name and lifecycle state when
   available, so admin views can distinguish active certification gates from
   draft or retired suites
+- agents and crews without a concrete stored certification suite still publish a
+  stable, non-required baseline eval hook in `review` state; this keeps the
+  governance contract explicit without pretending an executable suite already
+  exists
 - memory dependencies use the governed memory lifecycle, so quarantined memory
   remains visible in the map without being treated as an active requirement
 - execution-node readiness for the active local desktop runtime plus the

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -336,6 +336,7 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
   assert.equal(agent.owner.id, 'local-user')
   assert.deepEqual(agent.approvers.map((approver) => approver.id), ['local-user', 'local-admins'])
   assert.equal(agent.memoryBoundary.kind, 'agent')
+  assert.match(agent.evalSuiteId || '', /^eval-suite:agent:/)
   assert.equal(agent.incidentControls.some((control) => control.kind === 'retire_agent' && control.available), true)
   assert.deepEqual(
     agent.incidentControls.find((control) => control.kind === 'retire_agent')?.requiredRoles,
@@ -344,11 +345,15 @@ test('governance registry maps custom agent lifecycle, scope, and skill-linked t
   assert.deepEqual(
     agent.dependencies.map((dependency) => `${dependency.kind}:${dependency.id}:${dependency.source}`),
     [
+      `eval_suite:${agent.evalSuiteId}:direct`,
       'skill:analyst:direct',
       'tool:charts:transitive',
       'tool:filesystem:direct',
     ],
   )
+  const agentEvalDependency = agent.dependencies.find((dependency) => dependency.kind === 'eval_suite')
+  assert.equal(agentEvalDependency?.required, false)
+  assert.equal(agentEvalDependency?.lifecycle, 'review')
 
   const chartsIndex = payload.dependencyIndex.find((entry) => entry.dependency.kind === 'tool' && entry.dependency.id === 'charts')
   assert.deepEqual(chartsIndex?.subjectIds, [agent.subjectId])
@@ -663,6 +668,34 @@ test('governance registry projects crew member and transitive capability depende
     payload.subjects.find((subject) => subject.name === 'data-analyst')?.subjectId,
     crew.subjectId,
   ].sort())
+})
+
+test('governance registry gives crews without stored suites an explicit baseline eval hook', () => {
+  const crews = crewCatalog()
+  const crewEntry = crews.crews[0]
+  assert.ok(crewEntry?.activeVersion)
+  crewEntry.activeVersion = {
+    ...crewEntry.activeVersion,
+    evalSuiteId: null,
+    certificationStatus: 'not_required',
+    certifiedAt: null,
+  }
+  const payload = buildGovernanceRegistry({
+    builtinAgents: [builtInAgent()],
+    customAgents: [customAgent()],
+    agentCatalog: catalog(),
+    crewCatalog: crews,
+    secretStorageMode: 'encrypted',
+    generatedAt,
+  })
+
+  const crew = payload.subjects.find((subject) => subject.subjectKind === 'crew' && subject.name === 'crew-analytics')
+  assert.ok(crew)
+  assert.match(crew.evalSuiteId || '', /^eval-suite:crew:/)
+  const evalDependency = crew.dependencies.find((dependency) => dependency.kind === 'eval_suite')
+  assert.equal(evalDependency?.id, crew.evalSuiteId)
+  assert.equal(evalDependency?.required, false)
+  assert.equal(evalDependency?.lifecycle, 'review')
 })
 
 test('invalid custom agents stay visible as draft governance records', () => {


### PR DESCRIPTION
## Summary
- publish stable baseline eval-suite hooks for agent registry subjects
- give crews without a stored certification suite a non-required review-state eval hook
- document that these hooks make governance gaps explicit without adding an OpenCode-side eval runner

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/governance-registry.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --filter @open-cowork/desktop test:renderer -- PulsePage.test.tsx
- pnpm build
- uv run mkdocs build --strict
- git diff --check

Roadmap: #250