### PR TITLE
Add gated fleet registry table views

### DIFF
--- a/apps/desktop/src/main/capability-catalog.ts
+++ b/apps/desktop/src/main/capability-catalog.ts
@@ -1,4 +1,11 @@
-import type { CapabilitySkill, CapabilitySkillBundle, CapabilityTool, CapabilityToolEntry, RuntimeContextOptions } from '@open-cowork/shared'
+import {
+  credentialFieldIsVisible,
+  type CapabilitySkill,
+  type CapabilitySkillBundle,
+  type CapabilityTool,
+  type CapabilityToolEntry,
+  type RuntimeContextOptions,
+} from '@open-cowork/shared'
 import {
   getConfiguredAgentsFromConfig,
   getConfiguredMcpsFromConfig,
@@ -9,7 +16,7 @@ import {
 import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
 import { summarizeCustomAgents, type CustomAgentCatalogSkill } from './custom-agents-utils.ts'
 import { getEffectiveSkillBundle, listEffectiveSkills, listEffectiveSkillsSync } from './effective-skills.ts'
-import { getEffectiveSettings } from './settings.ts'
+import { getEffectiveSettings, getIntegrationCredentialValue } from './settings.ts'
 
 function humanize(value: string) {
   return value
@@ -25,6 +32,24 @@ function namespaceFromPattern(pattern: string) {
   if (end <= 'mcp__'.length) return null
   const namespace = pattern.slice('mcp__'.length, end)
   return /^[a-zA-Z0-9-]+$/.test(namespace) ? namespace : null
+}
+
+function hasRequiredIntegrationCredentials(
+  integrationId: string,
+  credentials: NonNullable<CapabilityTool['credentials']>,
+  settings: ReturnType<typeof getEffectiveSettings>,
+) {
+  const credentialValues = Object.fromEntries(
+    credentials.map((credential) => [
+      credential.key,
+      getIntegrationCredentialValue(settings, integrationId, credential.key) || '',
+    ]),
+  )
+  return credentials.every((credential) => {
+    if (!credentialFieldIsVisible(credential, credentialValues)) return true
+    if (credential.required === false) return true
+    return Boolean(getIntegrationCredentialValue(settings, integrationId, credential.key))
+  })
 }
 
 function listRuntimeEligibleCustomAgents(
@@ -95,12 +120,16 @@ export function listCapabilityTools(context?: RuntimeContextOptions): Capability
   // position the Enable toggle without a second IPC. Reads `Partial`
   // because older settings files may be missing the field; the map
   // defaults to {} in that case.
-  const enabledOverrides = getEffectiveSettings().integrationEnabled || {}
+  const effectiveSettings = getEffectiveSettings()
+  const enabledOverrides = effectiveSettings.integrationEnabled || {}
 
   const configured = getConfiguredToolsFromConfig().map((tool) => {
     const patterns = getConfiguredToolPatterns(tool)
     const namespace = tool.namespace || patterns.map(namespaceFromPattern).find(Boolean) || null
     const backingMcp = namespace ? mcpByNamespace.get(namespace) : undefined
+    const credentialReady = backingMcp?.authMode === 'api_token'
+      ? hasRequiredIntegrationCredentials(backingMcp.name, backingMcp.credentials || [], effectiveSettings)
+      : undefined
 
     return {
       id: tool.id,
@@ -126,6 +155,7 @@ export function listCapabilityTools(context?: RuntimeContextOptions): Capability
           integrationId: backingMcp.name,
           authMode: backingMcp.authMode,
           enabled: enabledOverrides[backingMcp.name],
+          ...(credentialReady !== undefined ? { credentialReady } : {}),
           ...(backingMcp.credentials && backingMcp.credentials.length > 0
             ? { credentials: backingMcp.credentials }
             : {}),

--- a/apps/desktop/src/renderer/components/agents/AgentsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentsPage.test.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { AgentsPage } from './AgentsPage'
+import { FLEET_REGISTRY_FEATURE_GATE_KEY } from '../fleet/fleet-registry-model'
 
 const catalog: AgentCatalog = {
   reservedNames: ['build'],
@@ -215,5 +216,45 @@ describe('AgentsPage', () => {
     await user.click(screen.getAllByRole('button', { name: 'Test' })[0]!)
 
     expect(api.onTestAgent).toHaveBeenCalledWith('market-analyst', '/workspace/acme')
+  })
+
+  it('renders the gated registry table with quick filters and disabled unsupported bulk actions', async () => {
+    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    renderAgentsPage()
+
+    await screen.findByText('market-analyst')
+    await user.click(screen.getByRole('button', { name: 'table' }))
+
+    expect(screen.getByRole('table', { name: 'Agent registry table' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'market-analyst' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Build' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Custom only' }))
+    expect(screen.getByRole('button', { name: 'market-analyst' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Build' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Select market-analyst'))
+    const tagButton = screen.getByRole('button', { name: 'Tag selected' })
+    expect(tagButton).toBeDisabled()
+    expect(tagButton).toHaveAttribute('title', expect.stringContaining('not persisted'))
+  })
+
+  it('defaults gated large inventories to table mode', async () => {
+    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    const manyAgents = Array.from({ length: 24 }, (_, index) => ({
+      ...customAgent,
+      name: `agent-${index + 1}`,
+      description: `Agent ${index + 1}`,
+    }))
+
+    renderAgentsPage({
+      customAgents: manyAgents,
+      builtInAgents: [],
+      runtimeAgents: [],
+    })
+
+    expect(await screen.findByRole('table', { name: 'Agent registry table' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'agent-1' })).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/components/agents/AgentsPage.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentsPage.tsx
@@ -16,6 +16,14 @@ import {
 import { confirmAgentRemoval } from '../../helpers/destructive-actions'
 import { t } from '../../helpers/i18n'
 import { useSessionStore } from '../../stores/session'
+import { FleetRegistryTable, FleetRegistryViewToggle } from '../fleet/FleetRegistryTable'
+import {
+  buildAgentRegistryItems,
+  filterFleetRegistryItems,
+  isFleetRegistryViewsEnabled,
+  sortFleetRegistryItems,
+} from '../fleet/fleet-registry-model'
+import { useFleetRegistryPreferences } from '../fleet/useFleetRegistryPreferences'
 import {
   bundleToAgentConfig,
   decodeAgentBundle,
@@ -103,6 +111,30 @@ export function AgentsPage({
     for (const agent of customs) known.add(agent.name)
     return runtimeAgents.filter((agent) => !known.has(agent.name))
   }, [builtinDetails, customs, runtimeAgents])
+  const registryEnabled = isFleetRegistryViewsEnabled()
+  const registryItems = useMemo(() => buildAgentRegistryItems({
+    customAgents: customs,
+    builtInAgents: builtinDetails,
+    runtimeAgents: runtimeUnknown,
+  }), [builtinDetails, customs, runtimeUnknown])
+  const registryPreferences = useFleetRegistryPreferences('agents', registryItems.length)
+  const sourceFilteredRegistryItems = useMemo(
+    () => registryItems.filter((item) => {
+      if (filter === 'all') return true
+      return item.metadata?.agentKind === filter
+    }),
+    [filter, registryItems],
+  )
+  const visibleRegistryItems = useMemo(
+    () => sortFleetRegistryItems(
+      filterFleetRegistryItems(sourceFilteredRegistryItems, {
+        query: search,
+        quickFilter: registryPreferences.quickFilter,
+      }),
+      registryPreferences.sort,
+    ),
+    [registryPreferences.quickFilter, registryPreferences.sort, search, sourceFilteredRegistryItems],
+  )
 
   const filteredCustoms = useMemo(() => (
     customs.filter((agent) => matchesSearch(search, agent.name, agent.description, agent.instructions, ...agent.skillNames, ...agent.toolIds))
@@ -212,6 +244,14 @@ export function AgentsPage({
     setSelected({ kind: 'custom', name: targetName })
   }
 
+  const openRegistryItem = (item: (typeof registryItems)[number]) => {
+    const agentKind = item.metadata?.agentKind
+    const agentName = typeof item.metadata?.agentName === 'string' ? item.metadata.agentName : item.name
+    if (agentKind === 'custom' || agentKind === 'builtin' || agentKind === 'runtime') {
+      setSelected({ kind: agentKind, name: agentName })
+    }
+  }
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-[1200px] mx-auto px-8 py-8">
@@ -248,6 +288,12 @@ export function AgentsPage({
               </button>
             ))}
           </div>
+          {registryEnabled ? (
+            <FleetRegistryViewToggle
+              viewMode={registryPreferences.viewMode}
+              onViewModeChange={registryPreferences.setViewMode}
+            />
+          ) : null}
           <button
             onClick={onImportAgent}
             className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-[12px] font-medium hover:bg-surface-hover cursor-pointer border border-border-subtle text-text-secondary"
@@ -274,76 +320,93 @@ export function AgentsPage({
           </button>
         </div>
 
-        {showCustoms && (
-          <ListSection
-            label="Custom agents"
-            sublabel="Built by you — edit, enable, or delete from the card."
-            emptyState={customs.length === 0
-              ? 'No custom agents yet. Click “New agent” to build your first specialist.'
-              : 'No custom agents matched your search.'}
-            empty={filteredCustoms.length === 0}
-          >
-            {filteredCustoms.map((agent) => (
-              <CustomSelectionCard
-                key={agent.name}
-                agent={agent}
-                catalog={catalog}
-                onOpen={() => setSelected({ kind: 'custom', name: agent.name })}
-                onTest={onTestAgent ? () => onTestAgent(
-                  agent.name,
-                  agent.scope === 'project' ? agent.directory || projectDirectory : projectDirectory,
-                ) : undefined}
-                onExport={() => onExportAgent(agent)}
-                onDelete={async () => {
-                  const target = {
-                    name: agent.name,
-                    scope: agent.scope,
-                    directory: agent.directory || null,
-                  } as const
-                  const confirmation = await confirmAgentRemoval(target)
-                  if (!confirmation) return
-                  const ok = await window.coworkApi.agents.remove(target, confirmation.token)
-                  if (ok) refresh()
-                }}
-              />
-            ))}
-          </ListSection>
-        )}
+        {registryEnabled && registryPreferences.viewMode === 'table' ? (
+          <FleetRegistryTable
+            surfaceLabel="Agent"
+            items={visibleRegistryItems}
+            totalCount={registryItems.length}
+            quickFilter={registryPreferences.quickFilter}
+            sort={registryPreferences.sort}
+            onQuickFilterChange={registryPreferences.setQuickFilter}
+            onSortChange={registryPreferences.setSort}
+            onOpenItem={openRegistryItem}
+            onBulkAction={() => undefined}
+            emptyMessage="No agents match the current registry filters."
+          />
+        ) : (
+          <>
+            {showCustoms && (
+              <ListSection
+                label="Custom agents"
+                sublabel="Built by you — edit, enable, or delete from the card."
+                emptyState={customs.length === 0
+                  ? 'No custom agents yet. Click “New agent” to build your first specialist.'
+                  : 'No custom agents matched your search.'}
+                empty={filteredCustoms.length === 0}
+              >
+                {filteredCustoms.map((agent) => (
+                  <CustomSelectionCard
+                    key={agent.name}
+                    agent={agent}
+                    catalog={catalog}
+                    onOpen={() => setSelected({ kind: 'custom', name: agent.name })}
+                    onTest={onTestAgent ? () => onTestAgent(
+                      agent.name,
+                      agent.scope === 'project' ? agent.directory || projectDirectory : projectDirectory,
+                    ) : undefined}
+                    onExport={() => onExportAgent(agent)}
+                    onDelete={async () => {
+                      const target = {
+                        name: agent.name,
+                        scope: agent.scope,
+                        directory: agent.directory || null,
+                      } as const
+                      const confirmation = await confirmAgentRemoval(target)
+                      if (!confirmation) return
+                      const ok = await window.coworkApi.agents.remove(target, confirmation.token)
+                      if (ok) refresh()
+                    }}
+                  />
+                ))}
+              </ListSection>
+            )}
 
-        {showBuiltIns && (
-          <ListSection
-            label="Built-in agents"
-            sublabel="OpenCode's built-ins plus the focused agents Cowork ships on top."
-            emptyState="No built-ins matched your search."
-            empty={filteredBuiltIns.length === 0}
-          >
-            {filteredBuiltIns.map((agent) => (
-              <BuiltInSelectionCard
-                key={agent.name}
-                agent={agent}
-                onOpen={() => setSelected({ kind: 'builtin', name: agent.name })}
-                onTest={onTestAgent ? () => onTestAgent(agent.name, projectDirectory) : undefined}
-              />
-            ))}
-          </ListSection>
-        )}
+            {showBuiltIns && (
+              <ListSection
+                label="Built-in agents"
+                sublabel="OpenCode's built-ins plus the focused agents Cowork ships on top."
+                emptyState="No built-ins matched your search."
+                empty={filteredBuiltIns.length === 0}
+              >
+                {filteredBuiltIns.map((agent) => (
+                  <BuiltInSelectionCard
+                    key={agent.name}
+                    agent={agent}
+                    onOpen={() => setSelected({ kind: 'builtin', name: agent.name })}
+                    onTest={onTestAgent ? () => onTestAgent(agent.name, projectDirectory) : undefined}
+                  />
+                ))}
+              </ListSection>
+            )}
 
-        {showRuntime && (
-          <ListSection
-            label="Runtime-registered agents"
-            sublabel="Agents registered by an SDK plugin that bypass Cowork's catalog."
-            emptyState="No runtime agents matched your search."
-            empty={filteredRuntime.length === 0}
-          >
-            {filteredRuntime.map((agent) => (
-              <RuntimeSelectionCard
-                key={agent.name}
-                agent={agent}
-                onOpen={() => setSelected({ kind: 'runtime', name: agent.name })}
-                onTest={onTestAgent ? () => onTestAgent(agent.name, projectDirectory) : undefined}
-              />
-            ))}
-          </ListSection>
+            {showRuntime && (
+              <ListSection
+                label="Runtime-registered agents"
+                sublabel="Agents registered by an SDK plugin that bypass Cowork's catalog."
+                emptyState="No runtime agents matched your search."
+                empty={filteredRuntime.length === 0}
+              >
+                {filteredRuntime.map((agent) => (
+                  <RuntimeSelectionCard
+                    key={agent.name}
+                    agent={agent}
+                    onOpen={() => setSelected({ kind: 'runtime', name: agent.name })}
+                    onTest={onTestAgent ? () => onTestAgent(agent.name, projectDirectory) : undefined}
+                  />
+                ))}
+              </ListSection>
+            )}
+          </>
         )}
       </div>
 

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
@@ -226,8 +226,10 @@ describe('AutomationBoard', () => {
         payload={payload({
           automations: [
             automation({ id: 'ready', title: 'Ready automation', status: 'ready' }),
+            automation({ id: 'running', title: 'Running automation', status: 'running' }),
             automation({ id: 'completed', title: 'Completed automation', status: 'completed' }),
           ],
+          runs: [run({ automationId: 'running', status: 'running' })],
         })}
         selectedAutomationId={null}
         onSelectAutomation={vi.fn()}
@@ -245,11 +247,15 @@ describe('AutomationBoard', () => {
 
     fireEvent.click(screen.getByLabelText('Select Ready automation'))
     expect(screen.getByRole('button', { name: 'Pause selected' })).toBeEnabled()
-    expect(screen.getByRole('button', { name: 'Archive selected' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Archive selected' })).toBeEnabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Pause selected' }))
     expect(onBulkAction).toHaveBeenCalledWith(expect.objectContaining({ kind: 'pause' }), [
       expect.objectContaining({ id: 'ready' }),
     ])
+
+    fireEvent.click(screen.getByLabelText('Select Ready automation'))
+    fireEvent.click(screen.getByLabelText('Select Running automation'))
+    expect(screen.getByRole('button', { name: 'Archive selected' })).toBeDisabled()
   })
 })

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
@@ -7,6 +7,7 @@ import {
   buildAutomationCardModel,
   resolveAutomationDropAction,
 } from './automation-board-support'
+import { FLEET_REGISTRY_FEATURE_GATE_KEY } from '../fleet/fleet-registry-model'
 
 function automation(overrides: Partial<AutomationSummary>): AutomationSummary {
   return {
@@ -215,5 +216,40 @@ describe('AutomationBoard', () => {
       />,
     )
     expect(screen.getByRole('button', { name: /Archived automation/ })).toBeInTheDocument()
+  })
+
+  it('renders the gated registry table and enables only backed bulk actions', () => {
+    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    const onBulkAction = vi.fn()
+    render(
+      <AutomationBoard
+        payload={payload({
+          automations: [
+            automation({ id: 'ready', title: 'Ready automation', status: 'ready' }),
+            automation({ id: 'completed', title: 'Completed automation', status: 'completed' }),
+          ],
+        })}
+        selectedAutomationId={null}
+        onSelectAutomation={vi.fn()}
+        onDropAutomation={vi.fn()}
+        onNewAutomation={vi.fn()}
+        onLearnMore={vi.fn()}
+        showArchived={false}
+        onShowArchivedChange={vi.fn()}
+        onBulkAction={onBulkAction}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'table' }))
+    expect(screen.getByRole('table', { name: 'Automation registry table' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Select Ready automation'))
+    expect(screen.getByRole('button', { name: 'Pause selected' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Archive selected' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause selected' }))
+    expect(onBulkAction).toHaveBeenCalledWith(expect.objectContaining({ kind: 'pause' }), [
+      expect.objectContaining({ id: 'ready' }),
+    ])
   })
 })

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
@@ -11,7 +11,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core'
-import type { AutomationListPayload } from '@open-cowork/shared'
+import type { AutomationListPayload, FleetBulkAction, FleetRegistryItem } from '@open-cowork/shared'
 import { AutomationCard } from './AutomationCard'
 import {
   AUTOMATION_COLUMNS,
@@ -22,6 +22,14 @@ import {
   type AutomationColumnId,
 } from './automation-board-support'
 import { AUTOMATION_TEMPLATES } from './automation-view-model'
+import { FleetRegistryTable, FleetRegistryViewToggle } from '../fleet/FleetRegistryTable'
+import {
+  buildAutomationRegistryItems,
+  filterFleetRegistryItems,
+  isFleetRegistryViewsEnabled,
+  sortFleetRegistryItems,
+} from '../fleet/fleet-registry-model'
+import { useFleetRegistryPreferences } from '../fleet/useFleetRegistryPreferences'
 
 type Props = {
   payload: AutomationListPayload
@@ -33,6 +41,7 @@ type Props = {
   showArchived: boolean
   onShowArchivedChange: (showArchived: boolean) => void
   feedback?: string | null
+  onBulkAction?: (action: FleetBulkAction, items: FleetRegistryItem[]) => void | Promise<void>
 }
 
 const BOARD_STYLE = {
@@ -154,11 +163,26 @@ export function AutomationBoard({
   showArchived,
   onShowArchivedChange,
   feedback,
+  onBulkAction,
 }: Props) {
   const [activeCardId, setActiveCardId] = useState<string | null>(null)
+  const [registrySearch, setRegistrySearch] = useState('')
   const visiblePayload = useMemo(() => filterBoardPayload(payload, showArchived), [payload, showArchived])
   const columns = useMemo(() => buildAutomationBoard(visiblePayload), [visiblePayload])
   const stats = useMemo(() => summarizeAutomationBoard(visiblePayload), [visiblePayload])
+  const registryEnabled = isFleetRegistryViewsEnabled()
+  const registryItems = useMemo(() => buildAutomationRegistryItems(visiblePayload), [visiblePayload])
+  const registryPreferences = useFleetRegistryPreferences('automations', registryItems.length)
+  const visibleRegistryItems = useMemo(
+    () => sortFleetRegistryItems(
+      filterFleetRegistryItems(registryItems, {
+        query: registrySearch,
+        quickFilter: registryPreferences.quickFilter,
+      }),
+      registryPreferences.sort,
+    ),
+    [registryItems, registryPreferences.quickFilter, registryPreferences.sort, registrySearch],
+  )
   const archivedCount = useMemo(() => payload.automations.filter((automation) => automation.status === 'archived').length, [payload.automations])
   const cardById = useMemo(() => {
     return new Map(visiblePayload.automations.map((automation) => [
@@ -197,6 +221,12 @@ export function AutomationBoard({
           <span className="rounded-full border border-border px-3 py-1">{stats.delivered} delivered</span>
         </div>
         <div className="flex gap-2">
+          {registryEnabled ? (
+            <FleetRegistryViewToggle
+              viewMode={registryPreferences.viewMode}
+              onViewModeChange={registryPreferences.setViewMode}
+            />
+          ) : null}
           {archivedCount > 0 ? (
             <button
               type="button"
@@ -230,25 +260,49 @@ export function AutomationBoard({
           Archived automations are hidden. Use Show archived to inspect them.
         </div>
       ) : null}
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={() => setActiveCardId(null)}>
-        <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto pb-3" aria-label="Automation lifecycle board">
-          {columns.map((column) => (
-            <AutomationColumnView
-              key={column.id}
-              column={column}
-              selectedAutomationId={selectedAutomationId}
-              onSelectAutomation={onSelectAutomation}
-            />
-          ))}
+      {registryEnabled && registryPreferences.viewMode === 'table' ? (
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto">
+          <input
+            type="text"
+            value={registrySearch}
+            onChange={(event) => setRegistrySearch(event.target.value)}
+            placeholder="Search automations, agents, goals, runs, or review items..."
+            className="w-full rounded-lg border border-border-subtle bg-elevated px-3 py-2 text-[12px] text-text placeholder:text-text-muted outline-none focus:border-border"
+          />
+          <FleetRegistryTable
+            surfaceLabel="Automation"
+            items={visibleRegistryItems}
+            totalCount={registryItems.length}
+            quickFilter={registryPreferences.quickFilter}
+            sort={registryPreferences.sort}
+            onQuickFilterChange={registryPreferences.setQuickFilter}
+            onSortChange={registryPreferences.setSort}
+            onOpenItem={(item) => onSelectAutomation(item.id)}
+            onBulkAction={onBulkAction}
+            emptyMessage="No automations match the current registry filters."
+          />
         </div>
-        <DragOverlay>
-          {activeCard ? (
-            <div className="w-[var(--automation-card-width)]">
-              <AutomationCard card={activeCard} selected={false} onSelect={() => undefined} dragDisabled />
-            </div>
-          ) : null}
-        </DragOverlay>
-      </DndContext>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={() => setActiveCardId(null)}>
+          <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto pb-3" aria-label="Automation lifecycle board">
+            {columns.map((column) => (
+              <AutomationColumnView
+                key={column.id}
+                column={column}
+                selectedAutomationId={selectedAutomationId}
+                onSelectAutomation={onSelectAutomation}
+              />
+            ))}
+          </div>
+          <DragOverlay>
+            {activeCard ? (
+              <div className="w-[var(--automation-card-width)]">
+                <AutomationCard card={activeCard} selected={false} onSelect={() => undefined} dragDisabled />
+              </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -6,6 +6,8 @@ import type {
   AutomationSummary,
   BuiltInAgentDetail,
   CustomAgentSummary,
+  FleetBulkAction,
+  FleetRegistryItem,
   SopListItem,
   SopListPayload,
   SopRunDetail,
@@ -370,6 +372,25 @@ export function AutomationsPage({ onOpenThread }: Props) {
     }
   }
 
+  const runAutomationBulkAction = async (action: FleetBulkAction, items: FleetRegistryItem[]) => {
+    const automationIds = items.map((item) => item.id)
+    if (automationIds.length === 0) return
+    if (action.requiresConfirmation && !window.confirm(`${action.label} for ${automationIds.length} automation${automationIds.length === 1 ? '' : 's'}?`)) return
+    setFeedback(null)
+    setError(null)
+    try {
+      for (const automationId of automationIds) {
+        if (action.kind === 'pause') await window.coworkApi.automation.pause(automationId)
+        else if (action.kind === 'resume') await window.coworkApi.automation.resume(automationId)
+        else if (action.kind === 'archive') await window.coworkApi.automation.archive(automationId)
+      }
+      await refresh(selectedAutomationIdRef.current)
+      setFeedback(`${action.label.replace(' selected', '')} completed for ${automationIds.length} automation${automationIds.length === 1 ? '' : 's'}.`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Automation bulk action failed.')
+    }
+  }
+
   return (
     <div className="flex min-h-0 flex-1 flex-col p-5">
       <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
@@ -450,6 +471,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
         showArchived={showArchived}
         onShowArchivedChange={setShowArchived}
         feedback={feedback}
+        onBulkAction={runAutomationBulkAction}
       />
 
       {wizardOpen ? (

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -12,6 +12,7 @@ import type {
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { useSessionStore } from '../../stores/session'
 import { CapabilitiesPage } from './CapabilitiesPage'
+import { FLEET_REGISTRY_FEATURE_GATE_KEY } from '../fleet/fleet-registry-model'
 
 const chartTool: CapabilityTool = {
   id: 'charts',
@@ -259,6 +260,23 @@ describe('CapabilitiesPage', () => {
 
     api.unmount()
     expect(api.unsubscribeRuntimeReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the gated capability registry table and opens dependency drill-downs', async () => {
+    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    renderCapabilitiesPage()
+
+    expect(await screen.findByRole('heading', { name: 'Capabilities' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'table' }))
+    expect(screen.getByRole('table', { name: 'Capability registry table' })).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Select Chart MCP'))
+    const drillDown = screen.getByRole('button', { name: 'Open dependency drill-down' })
+    expect(drillDown).toBeEnabled()
+    await user.click(drillDown)
+
+    expect(await screen.findByRole('heading', { name: 'Chart MCP' })).toBeInTheDocument()
   })
 
   it('surfaces tool-skill relationships in the map and opens linked details', async () => {

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.tsx
@@ -22,6 +22,14 @@ import {
 import { EmptyGrid } from './capabilities-page-components.tsx'
 import { CapabilitySkillDetailView, CapabilityToolDetailView } from './CapabilitiesDetailViews'
 import { CapabilityMapView } from './CapabilityMapView'
+import { FleetRegistryTable, FleetRegistryViewToggle } from '../fleet/FleetRegistryTable'
+import {
+  buildCapabilityRegistryItems,
+  filterFleetRegistryItems,
+  isFleetRegistryViewsEnabled,
+  sortFleetRegistryItems,
+} from '../fleet/fleet-registry-model'
+import { useFleetRegistryPreferences } from '../fleet/useFleetRegistryPreferences'
 
 export function CapabilitiesPage({
   onClose,
@@ -120,6 +128,29 @@ export function CapabilitiesPage({
   const filteredSkillGroups = useMemo(
     () => mapGroups.filter((group) => group.skills.length > 0),
     [mapGroups],
+  )
+  const registryEnabled = isFleetRegistryViewsEnabled()
+  const registryItems = useMemo(
+    () => buildCapabilityRegistryItems({ tools, skills, runtimeTools }),
+    [runtimeTools, skills, tools],
+  )
+  const registryPreferences = useFleetRegistryPreferences('capabilities', registryItems.length)
+  const tabFilteredRegistryItems = useMemo(
+    () => registryItems.filter((item) => {
+      if (tab === 'map') return true
+      return item.metadata?.capabilityType === (tab === 'tools' ? 'tool' : 'skill')
+    }),
+    [registryItems, tab],
+  )
+  const visibleRegistryItems = useMemo(
+    () => sortFleetRegistryItems(
+      filterFleetRegistryItems(tabFilteredRegistryItems, {
+        query: search,
+        quickFilter: registryPreferences.quickFilter,
+      }),
+      registryPreferences.sort,
+    ),
+    [registryPreferences.quickFilter, registryPreferences.sort, search, tabFilteredRegistryItems],
   )
 
   const selectedTool = selection?.type === 'tool'
@@ -230,6 +261,12 @@ export function CapabilitiesPage({
   const addButtonLabel = tab === 'skills'
     ? t('capabilities.addSkillButton', 'Add skill')
     : t('capabilities.addTool', 'Add tool')
+  const openRegistryItem = (item: (typeof registryItems)[number]) => {
+    const capabilityType = item.metadata?.capabilityType
+    const capabilityId = typeof item.metadata?.capabilityId === 'string' ? item.metadata.capabilityId : item.id
+    if (capabilityType === 'tool') setSelection({ type: 'tool', id: capabilityId })
+    if (capabilityType === 'skill') setSelection({ type: 'skill', name: capabilityId })
+  }
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -269,6 +306,12 @@ export function CapabilitiesPage({
               </button>
             ))}
           </div>
+          {registryEnabled ? (
+            <FleetRegistryViewToggle
+              viewMode={registryPreferences.viewMode}
+              onViewModeChange={registryPreferences.setViewMode}
+            />
+          ) : null}
           <button
             onClick={() => tab === 'skills' ? setSkillForm('new') : setMcpForm('new')}
             className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-[12px] font-medium hover:opacity-90 cursor-pointer"
@@ -281,7 +324,22 @@ export function CapabilitiesPage({
           </button>
         </div>
 
-        {tab === 'map' ? (
+        {registryEnabled && registryPreferences.viewMode === 'table' ? (
+          <FleetRegistryTable
+            surfaceLabel="Capability"
+            items={visibleRegistryItems}
+            totalCount={registryItems.length}
+            quickFilter={registryPreferences.quickFilter}
+            sort={registryPreferences.sort}
+            onQuickFilterChange={registryPreferences.setQuickFilter}
+            onSortChange={registryPreferences.setSort}
+            onOpenItem={openRegistryItem}
+            onBulkAction={(action, items) => {
+              if (action.kind === 'open_dependency' && items[0]) openRegistryItem(items[0])
+            }}
+            emptyMessage="No capabilities match the current registry filters."
+          />
+        ) : tab === 'map' ? (
           <CapabilityMapView
             groups={mapGroups}
             tools={tools}

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { CrewDetail, CrewListPayload, CrewRunDetail } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { CrewsPage } from './CrewsPage'
+import { FLEET_REGISTRY_FEATURE_GATE_KEY } from '../fleet/fleet-registry-model'
 
 vi.mock('../../helpers/i18n', () => ({
   t: (_key: string, fallback: string) => fallback,
@@ -233,6 +234,34 @@ describe('CrewsPage', () => {
     expect(screen.getByText('Research notes')).toBeInTheDocument()
     expect(screen.getByText('web_search')).toBeInTheDocument()
     expect(screen.getByText('Quality gate')).toBeInTheDocument()
+  })
+
+  it('renders the gated crew registry table with search and disabled unsupported bulk actions', async () => {
+    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    installRendererTestCoworkApi({
+      crews: {
+        list: vi.fn(async () => payload()),
+        get: vi.fn(async () => detail),
+        runDetail: vi.fn(async () => runDetail),
+        evaluate: vi.fn(async () => runDetail),
+        exportTrace: vi.fn(async () => traceNdjson),
+      },
+    })
+
+    render(<CrewsPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Supervised agent teams' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'table' }))
+    expect(screen.getByRole('table', { name: 'Crew registry table' })).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText('Search crews, members, runs, or status...'), 'Planner')
+    expect(screen.getByRole('button', { name: 'Operations Crew' })).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Select Operations Crew'))
+    const tagButton = screen.getByRole('button', { name: 'Tag selected' })
+    expect(tagButton).toBeDisabled()
+    expect(tagButton).toHaveAttribute('title', expect.stringContaining('not persisted'))
   })
 
   it('creates the starter crew and runs the team', async () => {

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
@@ -10,6 +10,14 @@ import {
   traceToolName,
 } from './crew-run-detail-utils'
 import { CrewVersionEditor } from './CrewVersionEditor'
+import { FleetRegistryTable, FleetRegistryViewToggle } from '../fleet/FleetRegistryTable'
+import {
+  buildCrewRegistryItems,
+  filterFleetRegistryItems,
+  isFleetRegistryViewsEnabled,
+  sortFleetRegistryItems,
+} from '../fleet/fleet-registry-model'
+import { useFleetRegistryPreferences } from '../fleet/useFleetRegistryPreferences'
 
 const STARTER_CREW_MEMBERS = [
   { role: 'lead' as const, agentName: 'plan', displayName: 'Planner', description: 'Decomposes the work and keeps the run scoped.' },
@@ -309,8 +317,22 @@ export function CrewsPage() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [editingCrew, setEditingCrew] = useState(false)
+  const [registrySearch, setRegistrySearch] = useState('')
   const loadRequestIdRef = useRef(0)
   const runDetailRequestIdRef = useRef(0)
+  const registryEnabled = isFleetRegistryViewsEnabled()
+  const registryItems = useMemo(() => buildCrewRegistryItems(crews), [crews])
+  const registryPreferences = useFleetRegistryPreferences('crews', registryItems.length)
+  const visibleRegistryItems = useMemo(
+    () => sortFleetRegistryItems(
+      filterFleetRegistryItems(registryItems, {
+        query: registrySearch,
+        quickFilter: registryPreferences.quickFilter,
+      }),
+      registryPreferences.sort,
+    ),
+    [registryItems, registryPreferences.quickFilter, registryPreferences.sort, registrySearch],
+  )
 
   const selectedCrew = useMemo(
     () => crews.find((item) => item.definition.id === selectedCrewId) || crews[0] || null,
@@ -502,6 +524,12 @@ export function CrewsPage() {
             </p>
           </div>
           <div className="flex gap-2">
+            {registryEnabled ? (
+              <FleetRegistryViewToggle
+                viewMode={registryPreferences.viewMode}
+                onViewModeChange={registryPreferences.setViewMode}
+              />
+            ) : null}
             <button
               type="button"
               onClick={createStarterCrew}
@@ -523,7 +551,7 @@ export function CrewsPage() {
         {error ? <div role="alert" className="mt-4 rounded-md border border-red-400/30 bg-red-500/10 px-3 py-2 text-[12px] text-red-100">{error}</div> : null}
       </header>
 
-      <div className="grid min-h-0 flex-1 grid-cols-[320px_minmax(0,1fr)]">
+      <div className={`grid min-h-0 flex-1 ${registryEnabled && registryPreferences.viewMode === 'table' ? 'grid-cols-[minmax(520px,0.95fr)_minmax(0,1.05fr)]' : 'grid-cols-[320px_minmax(0,1fr)]'}`}>
         <aside className="min-h-0 overflow-y-auto border-r border-border-subtle p-4">
           {loading ? <div className="text-[12px] text-text-muted">Loading crews...</div> : null}
           {!loading && crews.length === 0 ? (
@@ -531,19 +559,47 @@ export function CrewsPage() {
               No crews yet. Create a starter crew to seed your first supervised team.
             </div>
           ) : null}
-          <div className="space-y-3">
-            {crews.map((item) => (
-              <CrewCard
-                key={item.definition.id}
-                item={item}
-                selected={selectedCrew?.definition.id === item.definition.id}
-                onSelect={() => {
-                  setSelectedCrewId(item.definition.id)
-                  void load(item.definition.id)
-                }}
+          {registryEnabled && registryPreferences.viewMode === 'table' ? (
+            <div className="space-y-3">
+              <input
+                type="text"
+                value={registrySearch}
+                onChange={(event) => setRegistrySearch(event.target.value)}
+                placeholder="Search crews, members, runs, or status..."
+                className="w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[12px] text-text placeholder:text-text-muted outline-none focus:border-border"
               />
-            ))}
-          </div>
+              <FleetRegistryTable
+                surfaceLabel="Crew"
+                items={visibleRegistryItems}
+                totalCount={registryItems.length}
+                quickFilter={registryPreferences.quickFilter}
+                sort={registryPreferences.sort}
+                onQuickFilterChange={registryPreferences.setQuickFilter}
+                onSortChange={registryPreferences.setSort}
+                onOpenItem={(item) => {
+                  setSelectedCrewId(item.id)
+                  void load(item.id)
+                }}
+                onBulkAction={() => undefined}
+                emptyMessage="No crews match the current registry filters."
+                minTableWidthClass="min-w-[780px]"
+              />
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {crews.map((item) => (
+                <CrewCard
+                  key={item.definition.id}
+                  item={item}
+                  selected={selectedCrew?.definition.id === item.definition.id}
+                  onSelect={() => {
+                    setSelectedCrewId(item.definition.id)
+                    void load(item.definition.id)
+                  }}
+                />
+              ))}
+            </div>
+          )}
         </aside>
 
         <section className="min-h-0 overflow-y-auto p-6">

--- a/apps/desktop/src/renderer/components/fleet/FleetRegistryTable.tsx
+++ b/apps/desktop/src/renderer/components/fleet/FleetRegistryTable.tsx
@@ -1,0 +1,332 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { FleetBulkAction, FleetBulkActionKind, FleetRegistryItem } from '@open-cowork/shared'
+import {
+  FLEET_REGISTRY_QUICK_FILTERS,
+  FLEET_REGISTRY_SORT_LABELS,
+  toggleFleetRegistrySort,
+  type FleetRegistryQuickFilter,
+  type FleetRegistrySort,
+  type FleetRegistrySortKey,
+  type FleetRegistryViewMode,
+} from './fleet-registry-model'
+
+const BULK_ACTION_ORDER: FleetBulkActionKind[] = [
+  'pause',
+  'resume',
+  'archive',
+  'tag',
+  'untag',
+  'duplicate',
+  'open_dependency',
+  'run',
+  'test',
+]
+
+type Props = {
+  surfaceLabel: string
+  items: FleetRegistryItem[]
+  totalCount: number
+  quickFilter: FleetRegistryQuickFilter
+  sort: FleetRegistrySort
+  onQuickFilterChange: (filter: FleetRegistryQuickFilter) => void
+  onSortChange: (sort: FleetRegistrySort) => void
+  onOpenItem: (item: FleetRegistryItem) => void
+  onBulkAction?: (action: FleetBulkAction, items: FleetRegistryItem[]) => void | Promise<void>
+  emptyMessage?: string
+  minTableWidthClass?: string
+}
+
+export function FleetRegistryViewToggle({
+  viewMode,
+  onViewModeChange,
+}: {
+  viewMode: FleetRegistryViewMode
+  onViewModeChange: (viewMode: FleetRegistryViewMode) => void
+}) {
+  return (
+    <div className="flex rounded-lg border border-border-subtle overflow-hidden" aria-label="Registry view mode">
+      {(['cards', 'table'] as const).map((mode) => (
+        <button
+          key={mode}
+          type="button"
+          aria-pressed={viewMode === mode}
+          onClick={() => onViewModeChange(mode)}
+          className={`px-3 py-1.5 text-[12px] font-medium capitalize transition-colors ${viewMode === mode ? 'bg-surface-active text-text' : 'text-text-muted hover:text-text-secondary'}`}
+        >
+          {mode}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function FleetRegistryTable({
+  surfaceLabel,
+  items,
+  totalCount,
+  quickFilter,
+  sort,
+  onQuickFilterChange,
+  onSortChange,
+  onOpenItem,
+  onBulkAction,
+  emptyMessage,
+  minTableWidthClass = 'min-w-[1120px]',
+}: Props) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const visibleIds = useMemo(() => new Set(items.map((item) => item.id)), [items])
+
+  useEffect(() => {
+    setSelectedIds((current) => {
+      const next = new Set(Array.from(current).filter((id) => visibleIds.has(id)))
+      return next.size === current.size ? current : next
+    })
+  }, [visibleIds])
+
+  const selectedItems = useMemo(
+    () => items.filter((item) => selectedIds.has(item.id)),
+    [items, selectedIds],
+  )
+  const allVisibleSelected = items.length > 0 && items.every((item) => selectedIds.has(item.id))
+  const bulkActions = useMemo(() => buildBulkActions(selectedItems, items, Boolean(onBulkAction)), [items, onBulkAction, selectedItems])
+
+  const toggleAll = () => {
+    setSelectedIds((current) => {
+      if (items.length === 0) return current
+      if (items.every((item) => current.has(item.id))) return new Set()
+      return new Set(items.map((item) => item.id))
+    })
+  }
+
+  const toggleOne = (id: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  return (
+    <section className="min-h-0 rounded-lg border border-border-subtle bg-surface" aria-label={`${surfaceLabel} registry`}>
+      <div className="border-b border-border-subtle px-3 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="text-[12px] font-semibold text-text">{surfaceLabel} registry</div>
+            <div className="mt-1 text-[11px] text-text-muted">
+              {items.length} shown of {totalCount}
+              {selectedIds.size > 0 ? ` · ${selectedIds.size} selected` : ''}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {bulkActions.map((entry) => (
+              <button
+                key={entry.action.kind}
+                type="button"
+                disabled={entry.disabled}
+                title={entry.reason || undefined}
+                onClick={() => {
+                  if (entry.disabled || !onBulkAction) return
+                  void onBulkAction(entry.action, selectedItems)
+                }}
+                className={`rounded-md border px-2.5 py-1.5 text-[11px] font-medium disabled:cursor-not-allowed disabled:opacity-50 ${entry.action.destructive ? 'border-red-400/40 text-red-100' : 'border-border-subtle text-text-secondary hover:bg-surface-hover'}`}
+              >
+                {entry.action.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="mt-3 flex gap-2 overflow-x-auto pb-1" aria-label={`${surfaceLabel} quick filters`}>
+          {FLEET_REGISTRY_QUICK_FILTERS.map((filter) => (
+            <button
+              key={filter.id}
+              type="button"
+              aria-pressed={quickFilter === filter.id}
+              onClick={() => onQuickFilterChange(filter.id)}
+              className={`shrink-0 rounded-md border px-2.5 py-1 text-[11px] ${quickFilter === filter.id ? 'border-accent bg-accent/10 text-text' : 'border-border-subtle text-text-muted hover:text-text-secondary'}`}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className={`${minTableWidthClass} w-full border-collapse text-left text-[12px]`} aria-label={`${surfaceLabel} registry table`}>
+          <thead className="bg-elevated text-[10px] uppercase tracking-[0.12em] text-text-muted">
+            <tr>
+              <th className="w-10 border-b border-border-subtle px-3 py-2">
+                <label className="sr-only" htmlFor={`${surfaceLabel}-registry-select-all`}>Select all visible {surfaceLabel}</label>
+                <input
+                  id={`${surfaceLabel}-registry-select-all`}
+                  type="checkbox"
+                  checked={allVisibleSelected}
+                  onChange={toggleAll}
+                  disabled={items.length === 0}
+                />
+              </th>
+              <SortableHeader label="Name" columnKey="name" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Kind" columnKey="kind" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Status" columnKey="status" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Source" columnKey="source" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Model" columnKey="model" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Caps" columnKey="capabilities" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Activity" columnKey="activity" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Runs" columnKey="runs" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Review" columnKey="backlog" sort={sort} onSortChange={onSortChange} />
+              <SortableHeader label="Cost" columnKey="cost" sort={sort} onSortChange={onSortChange} />
+              <th className="border-b border-border-subtle px-3 py-2">Tags</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 ? (
+              <tr>
+                <td colSpan={12} className="px-3 py-10 text-center text-[12px] text-text-muted">
+                  {emptyMessage || 'No registry items match the current filters.'}
+                </td>
+              </tr>
+            ) : items.map((item) => (
+              <tr key={item.id} className="border-b border-border-subtle last:border-b-0 hover:bg-surface-hover">
+                <td className="px-3 py-2 align-top">
+                  <label className="sr-only" htmlFor={`${surfaceLabel}-registry-${item.id}`}>Select {item.name}</label>
+                  <input
+                    id={`${surfaceLabel}-registry-${item.id}`}
+                    type="checkbox"
+                    checked={selectedIds.has(item.id)}
+                    onChange={() => toggleOne(item.id)}
+                  />
+                </td>
+                <td className="max-w-[260px] px-3 py-2 align-top">
+                  <button type="button" onClick={() => onOpenItem(item)} className="block max-w-full truncate text-left font-semibold text-text hover:text-accent">
+                    {item.name}
+                  </button>
+                  {item.description ? <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-text-muted">{item.description}</div> : null}
+                </td>
+                <td className="px-3 py-2 align-top text-text-secondary">{item.typeLabel}</td>
+                <td className="px-3 py-2 align-top"><StatusBadge status={item.statusLabel} /></td>
+                <td className="px-3 py-2 align-top text-text-secondary">{item.source}</td>
+                <td className="px-3 py-2 align-top text-text-secondary">{item.model || item.provider || 'Default'}</td>
+                <td className="px-3 py-2 align-top text-text-secondary">
+                  <div>{item.capabilitiesCount}</div>
+                  <div className="text-[10px] text-text-muted">{item.skillsCount} skills · {item.toolsCount} tools</div>
+                </td>
+                <td className="px-3 py-2 align-top text-text-secondary">{formatActivity(item)}</td>
+                <td className="px-3 py-2 align-top text-text-secondary">{item.activeRuns} active · {item.failedRuns} failed</td>
+                <td className="px-3 py-2 align-top text-text-secondary">{item.reviewBacklog + item.approvalBacklog}</td>
+                <td className="px-3 py-2 align-top text-text-secondary">
+                  {formatCost(item.costUsd)}
+                  <div className="text-[10px] text-text-muted">{formatTokens(item.tokenCount)}</div>
+                </td>
+                <td className="max-w-[220px] px-3 py-2 align-top">
+                  <div className="flex flex-wrap gap-1">
+                    {item.tags.slice(0, 4).map((tag) => (
+                      <span key={tag} className="rounded border border-border-subtle px-1.5 py-0.5 text-[10px] text-text-muted">{tag}</span>
+                    ))}
+                    {item.tags.length > 4 ? <span className="text-[10px] text-text-muted">+{item.tags.length - 4}</span> : null}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function SortableHeader({
+  label,
+  columnKey,
+  sort,
+  onSortChange,
+}: {
+  label: string
+  columnKey: FleetRegistrySortKey
+  sort: FleetRegistrySort
+  onSortChange: (sort: FleetRegistrySort) => void
+}) {
+  const active = sort.key === columnKey
+  return (
+    <th className="border-b border-border-subtle px-3 py-2">
+      <button
+        type="button"
+        onClick={() => onSortChange(toggleFleetRegistrySort(sort, columnKey))}
+        className={`inline-flex items-center gap-1 ${active ? 'text-text' : 'text-text-muted hover:text-text-secondary'}`}
+        title={`Sort by ${FLEET_REGISTRY_SORT_LABELS[columnKey]}`}
+      >
+        {label}
+        <span aria-hidden="true">{active ? (sort.direction === 'asc' ? '↑' : '↓') : ''}</span>
+      </button>
+    </th>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const normalized = status.toLowerCase()
+  const tone = normalized.includes('failed') || normalized.includes('blocked') || normalized.includes('disabled')
+    ? 'border-red-400/30 bg-red-500/10 text-red-100'
+    : normalized.includes('paused') || normalized.includes('review')
+      ? 'border-amber-400/30 bg-amber-500/10 text-amber-100'
+      : normalized.includes('active') || normalized.includes('ready') || normalized.includes('completed')
+        ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-100'
+        : 'border-border-subtle bg-elevated text-text-secondary'
+  return <span className={`inline-flex rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest ${tone}`}>{status}</span>
+}
+
+function formatActivity(item: FleetRegistryItem) {
+  return formatDate(item.lastRunAt || item.lastUsedAt || null)
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return 'Never'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function formatCost(value: number | null | undefined) {
+  if (!value) return '$0.00'
+  return value < 0.01 ? '<$0.01' : `$${value.toFixed(2)}`
+}
+
+function formatTokens(value: number | null | undefined) {
+  if (!value) return '0 tokens'
+  return `${new Intl.NumberFormat().format(value)} tokens`
+}
+
+function buildBulkActions(selectedItems: FleetRegistryItem[], allItems: FleetRegistryItem[], hasHandler: boolean) {
+  const candidates = selectedItems.length > 0 ? selectedItems : allItems
+  const kinds = BULK_ACTION_ORDER.filter((kind) => candidates.some((item) => item.bulkActions.some((action) => action.kind === kind)))
+  return kinds.map((kind) => {
+    const firstAction = candidates.flatMap((item) => item.bulkActions).find((action) => action.kind === kind) || fallbackAction(kind)
+    const selectedActions = selectedItems.map((item) => item.bulkActions.find((action) => action.kind === kind) || null)
+    const missing = selectedItems.length > 0 && selectedActions.some((action) => action === null)
+    const unsupported = selectedActions.find((action) => action && !action.supported)
+    const singleOnly = firstAction.selection === 'single' && selectedItems.length !== 1
+    const disabled = selectedItems.length === 0 || missing || Boolean(unsupported) || singleOnly || !hasHandler
+    const reason = selectedItems.length === 0
+      ? 'Select one or more rows first.'
+      : !hasHandler
+        ? 'This surface has not wired a bulk action handler yet.'
+        : singleOnly
+          ? 'Select exactly one row for this action.'
+          : missing
+            ? 'At least one selected row does not expose this action.'
+            : unsupported?.disabledReason || null
+    return {
+      action: firstAction,
+      disabled,
+      reason,
+    }
+  })
+}
+
+function fallbackAction(kind: FleetBulkActionKind): FleetBulkAction {
+  return {
+    id: kind,
+    kind,
+    label: kind.replaceAll('_', ' '),
+    supported: false,
+    disabledReason: 'This action is unavailable.',
+  }
+}

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
@@ -169,14 +169,34 @@ describe('fleet registry model', () => {
         finishedAt: null,
       },
     }
+    const unusedCrew: CrewListItem = {
+      ...crew,
+      definition: {
+        ...crew.definition,
+        id: 'crew-unused',
+        name: 'Unused Crew',
+        status: 'active',
+        activeVersionId: 'version-unused',
+        updatedAt: '2026-05-03T01:00:00.000Z',
+      },
+      activeVersion: crew.activeVersion
+        ? {
+            ...crew.activeVersion,
+            id: 'version-unused',
+            crewId: 'crew-unused',
+          }
+        : null,
+      latestRun: null,
+    }
 
-    const items = buildCrewRegistryItems([crew])
+    const items = buildCrewRegistryItems([crew, unusedCrew])
     expect(items[0]).toMatchObject({
       status: 'waiting_review',
       activeRuns: 1,
       reviewBacklog: 1,
       capabilitiesCount: 1,
     })
+    expect(filterFleetRegistryItems(items, { quickFilter: 'unused' }).map((item) => item.id)).toEqual(['crew-unused'])
     expect(shouldDefaultFleetRegistryToTable(23)).toBe(false)
     expect(shouldDefaultFleetRegistryToTable(24)).toBe(true)
   })

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
@@ -81,6 +81,11 @@ describe('fleet registry model', () => {
     expect(isFleetRegistryViewsEnabled()).toBe(false)
     window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
     expect(isFleetRegistryViewsEnabled()).toBe(true)
+    expect(isFleetRegistryViewsEnabled({
+      getItem: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    } as unknown as Storage)).toBe(false)
 
     writeFleetRegistryPreference('agents', {
       viewMode: 'table',
@@ -182,6 +187,7 @@ describe('fleet registry model', () => {
         automation({ id: 'ready', title: 'Ready automation', status: 'ready' }),
         automation({ id: 'paused', title: 'Paused automation', status: 'paused' }),
         automation({ id: 'completed', title: 'Completed automation', status: 'completed', lastRunAt: '2026-05-02T00:00:00.000Z' }),
+        automation({ id: 'never-run', title: 'Never run automation', status: 'draft' }),
       ],
       inbox: [{
         id: 'inbox-1',
@@ -223,6 +229,7 @@ describe('fleet registry model', () => {
     expect(items.find((item) => item.id === 'ready')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: false })
     expect(items.find((item) => item.id === 'paused')?.bulkActions.find((action) => action.kind === 'resume')).toMatchObject({ supported: true })
     expect(items.find((item) => item.id === 'completed')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: true })
+    expect(filterFleetRegistryItems(items, { quickFilter: 'unused' }).map((item) => item.id)).toEqual(['paused', 'never-run'])
   })
 
   it('normalizes capability dependency rows and sorts by activity/capability counts', () => {

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  AutomationListPayload,
+  AutomationSummary,
+  CapabilitySkill,
+  CapabilityTool,
+  CrewListItem,
+  CustomAgentSummary,
+} from '@open-cowork/shared'
+import {
+  FLEET_REGISTRY_FEATURE_GATE_KEY,
+  buildAgentRegistryItems,
+  buildAutomationRegistryItems,
+  buildCapabilityRegistryItems,
+  buildCrewRegistryItems,
+  filterFleetRegistryItems,
+  isFleetRegistryViewsEnabled,
+  readFleetRegistryPreference,
+  shouldDefaultFleetRegistryToTable,
+  sortFleetRegistryItems,
+  writeFleetRegistryPreference,
+} from './fleet-registry-model'
+
+const customAgent: CustomAgentSummary = {
+  scope: 'project',
+  directory: '/work/project',
+  name: 'market-analyst',
+  description: 'Prepares market analysis.',
+  instructions: 'Use research evidence.',
+  skillNames: ['research'],
+  toolIds: ['charts'],
+  enabled: true,
+  color: 'accent',
+  avatar: null,
+  model: 'openai/gpt-5.2',
+  variant: null,
+  temperature: null,
+  top_p: null,
+  steps: null,
+  options: null,
+  deniedToolPatterns: [],
+  writeAccess: true,
+  valid: true,
+  issues: [],
+}
+
+function automation(overrides: Partial<AutomationSummary> = {}): AutomationSummary {
+  return {
+    id: overrides.id || 'auto-1',
+    title: overrides.title || 'Weekly report',
+    goal: overrides.goal || 'Prepare a report.',
+    kind: overrides.kind || 'recurring',
+    status: overrides.status || 'ready',
+    schedule: overrides.schedule || {
+      type: 'weekly',
+      timezone: 'UTC',
+      dayOfWeek: 1,
+      runAtHour: 9,
+      runAtMinute: 0,
+    },
+    heartbeatMinutes: overrides.heartbeatMinutes ?? 15,
+    retryPolicy: overrides.retryPolicy || { maxRetries: 3, baseDelayMinutes: 5, maxDelayMinutes: 60 },
+    runPolicy: overrides.runPolicy || { dailyRunCap: 6, maxRunDurationMinutes: 120 },
+    executionMode: overrides.executionMode || 'planning_only',
+    autonomyPolicy: overrides.autonomyPolicy || 'review-first',
+    projectDirectory: overrides.projectDirectory ?? '/work/project',
+    preferredAgentNames: overrides.preferredAgentNames || ['market-analyst'],
+    createdAt: overrides.createdAt || '2026-05-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt || '2026-05-01T01:00:00.000Z',
+    nextRunAt: overrides.nextRunAt ?? null,
+    lastRunAt: overrides.lastRunAt ?? null,
+    nextHeartbeatAt: overrides.nextHeartbeatAt ?? null,
+    lastHeartbeatAt: overrides.lastHeartbeatAt ?? null,
+    latestRunStatus: overrides.latestRunStatus ?? null,
+    latestRunId: overrides.latestRunId ?? null,
+  }
+}
+
+describe('fleet registry model', () => {
+  it('keeps the feature gate default-off and persists table preferences', () => {
+    expect(isFleetRegistryViewsEnabled()).toBe(false)
+    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    expect(isFleetRegistryViewsEnabled()).toBe(true)
+
+    writeFleetRegistryPreference('agents', {
+      viewMode: 'table',
+      quickFilter: 'custom_only',
+      sort: { key: 'status', direction: 'desc' },
+    })
+
+    expect(readFleetRegistryPreference('agents')).toEqual({
+      viewMode: 'table',
+      quickFilter: 'custom_only',
+      sort: { key: 'status', direction: 'desc' },
+    })
+  })
+
+  it('normalizes agents into searchable registry rows with disabled unsupported bulk actions', () => {
+    const items = buildAgentRegistryItems({
+      customAgents: [customAgent],
+      builtInAgents: [],
+      runtimeAgents: [{ name: 'runtime-helper', description: 'Plugin helper', disabled: true, toolIds: ['web'] }],
+    })
+
+    expect(items).toHaveLength(2)
+    expect(items[0]).toMatchObject({
+      kind: 'agent',
+      name: 'market-analyst',
+      source: 'Custom project',
+      status: 'active',
+      provider: 'openai',
+      capabilitiesCount: 2,
+    })
+    expect(filterFleetRegistryItems(items, { query: 'research' }).map((item) => item.name)).toEqual(['market-analyst'])
+    expect(filterFleetRegistryItems(items, { quickFilter: 'builtin_runtime' }).map((item) => item.name)).toEqual(['runtime-helper'])
+    expect(items[0]?.bulkActions.find((action) => action.kind === 'tag')).toMatchObject({
+      supported: false,
+      disabledReason: expect.stringContaining('not persisted'),
+    })
+  })
+
+  it('normalizes crew lifecycle and table threshold defaults', () => {
+    const crew: CrewListItem = {
+      definition: {
+        schemaVersion: 1,
+        id: 'crew-1',
+        name: 'Operations Crew',
+        description: 'Runs supervised work.',
+        status: 'review',
+        activeVersionId: 'version-1',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T01:00:00.000Z',
+      },
+      activeVersion: {
+        schemaVersion: 1,
+        id: 'version-1',
+        crewId: 'crew-1',
+        version: 2,
+        members: [
+          { schemaVersion: 1, id: 'lead', role: 'lead', agentName: 'plan', displayName: 'Planner', description: 'Plans', required: true },
+        ],
+        workspaceProfileId: null,
+        outcomeRubricId: null,
+        evalSuiteId: null,
+        certificationStatus: 'required',
+        certifiedAt: null,
+        budgetCapUsd: 3,
+        workflow: ['plan'],
+        createdAt: '2026-05-01T01:00:00.000Z',
+        createdBy: null,
+      },
+      latestRun: {
+        schemaVersion: 1,
+        id: 'run-1',
+        crewId: 'crew-1',
+        crewVersionId: 'version-1',
+        workItemId: null,
+        status: 'blocked',
+        title: 'Review run',
+        summary: null,
+        rootSessionId: null,
+        createdAt: '2026-05-01T02:00:00.000Z',
+        startedAt: '2026-05-01T02:01:00.000Z',
+        finishedAt: null,
+      },
+    }
+
+    const items = buildCrewRegistryItems([crew])
+    expect(items[0]).toMatchObject({
+      status: 'waiting_review',
+      activeRuns: 1,
+      reviewBacklog: 1,
+      capabilitiesCount: 1,
+    })
+    expect(shouldDefaultFleetRegistryToTable(23)).toBe(false)
+    expect(shouldDefaultFleetRegistryToTable(24)).toBe(true)
+  })
+
+  it('normalizes automations with supported pause/resume/archive gates', () => {
+    const payload: AutomationListPayload = {
+      automations: [
+        automation({ id: 'ready', title: 'Ready automation', status: 'ready' }),
+        automation({ id: 'paused', title: 'Paused automation', status: 'paused' }),
+        automation({ id: 'completed', title: 'Completed automation', status: 'completed', lastRunAt: '2026-05-02T00:00:00.000Z' }),
+      ],
+      inbox: [{
+        id: 'inbox-1',
+        automationId: 'ready',
+        runId: null,
+        sessionId: null,
+        questionId: null,
+        type: 'approval',
+        status: 'open',
+        title: 'Approve',
+        body: 'Approve this run.',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      }],
+      workItems: [],
+      runs: [{
+        id: 'run-1',
+        automationId: 'ready',
+        sessionId: null,
+        kind: 'execution',
+        status: 'failed',
+        title: 'Failed run',
+        summary: null,
+        error: 'Provider failed',
+        failureCode: null,
+        attempt: 1,
+        retryOfRunId: null,
+        nextRetryAt: null,
+        createdAt: '2026-05-01T00:00:00.000Z',
+        startedAt: null,
+        finishedAt: null,
+      }],
+      deliveries: [],
+    }
+
+    const items = buildAutomationRegistryItems(payload)
+    expect(filterFleetRegistryItems(items, { quickFilter: 'waiting_review' }).map((item) => item.id)).toEqual(['ready'])
+    expect(items.find((item) => item.id === 'ready')?.bulkActions.find((action) => action.kind === 'pause')).toMatchObject({ supported: true })
+    expect(items.find((item) => item.id === 'ready')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: false })
+    expect(items.find((item) => item.id === 'paused')?.bulkActions.find((action) => action.kind === 'resume')).toMatchObject({ supported: true })
+    expect(items.find((item) => item.id === 'completed')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: true })
+  })
+
+  it('normalizes capability dependency rows and sorts by activity/capability counts', () => {
+    const tool: CapabilityTool = {
+      id: 'charts',
+      name: 'Chart MCP',
+      description: 'Creates charts.',
+      kind: 'mcp',
+      source: 'custom',
+      origin: 'custom',
+      scope: 'project',
+      namespace: 'charts',
+      patterns: ['mcp__charts__*'],
+      availableTools: [{ id: 'mcp__charts__bar', description: 'Bar chart' }],
+      agentNames: ['chart-agent'],
+      authMode: 'api_token',
+      enabled: false,
+    }
+    const skill: CapabilitySkill = {
+      name: 'research',
+      label: 'Research',
+      description: 'Finds evidence.',
+      source: 'builtin',
+      origin: 'open-cowork',
+      scope: 'project',
+      toolIds: ['charts'],
+      agentNames: ['research-agent'],
+    }
+
+    const items = buildCapabilityRegistryItems({
+      tools: [tool],
+      skills: [skill],
+      runtimeTools: [{ id: 'mcp__charts__line', description: 'Line chart' }],
+    })
+
+    expect(items.find((item) => item.name === 'Chart MCP')).toMatchObject({
+      status: 'blocked',
+      approvalBacklog: 1,
+      toolsCount: 1,
+      skillsCount: 1,
+    })
+    expect(filterFleetRegistryItems(items, { quickFilter: 'missing_credentials' }).map((item) => item.name)).toEqual(['Chart MCP'])
+    expect(items[0]?.bulkActions.find((action) => action.kind === 'open_dependency')).toMatchObject({
+      supported: true,
+      selection: 'single',
+    })
+    expect(sortFleetRegistryItems(items, { key: 'capabilities', direction: 'desc' })[0]?.name).toBe('Chart MCP')
+  })
+})

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
@@ -287,7 +287,7 @@ describe('fleet registry model', () => {
       availableTools: [{ id: 'mcp__charts__bar', description: 'Bar chart' }],
       agentNames: ['chart-agent'],
       authMode: 'api_token',
-      enabled: false,
+      credentialReady: false,
     }
     const skill: CapabilitySkill = {
       name: 'research',

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
@@ -186,6 +186,8 @@ describe('fleet registry model', () => {
       automations: [
         automation({ id: 'ready', title: 'Ready automation', status: 'ready' }),
         automation({ id: 'paused', title: 'Paused automation', status: 'paused' }),
+        automation({ id: 'archived', title: 'Archived automation', status: 'archived', lastRunAt: '2026-05-03T00:00:00.000Z' }),
+        automation({ id: 'running', title: 'Running automation', status: 'running' }),
         automation({ id: 'completed', title: 'Completed automation', status: 'completed', lastRunAt: '2026-05-02T00:00:00.000Z' }),
         automation({ id: 'never-run', title: 'Never run automation', status: 'draft' }),
       ],
@@ -219,6 +221,22 @@ describe('fleet registry model', () => {
         createdAt: '2026-05-01T00:00:00.000Z',
         startedAt: null,
         finishedAt: null,
+      }, {
+        id: 'run-2',
+        automationId: 'running',
+        sessionId: null,
+        kind: 'execution',
+        status: 'running',
+        title: 'Running work',
+        summary: null,
+        error: null,
+        failureCode: null,
+        attempt: 1,
+        retryOfRunId: null,
+        nextRetryAt: null,
+        createdAt: '2026-05-01T00:00:00.000Z',
+        startedAt: '2026-05-01T00:00:00.000Z',
+        finishedAt: null,
       }],
       deliveries: [],
     }
@@ -226,8 +244,11 @@ describe('fleet registry model', () => {
     const items = buildAutomationRegistryItems(payload)
     expect(filterFleetRegistryItems(items, { quickFilter: 'waiting_review' }).map((item) => item.id)).toEqual(['ready'])
     expect(items.find((item) => item.id === 'ready')?.bulkActions.find((action) => action.kind === 'pause')).toMatchObject({ supported: true })
-    expect(items.find((item) => item.id === 'ready')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: false })
+    expect(items.find((item) => item.id === 'ready')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: true })
     expect(items.find((item) => item.id === 'paused')?.bulkActions.find((action) => action.kind === 'resume')).toMatchObject({ supported: true })
+    expect(items.find((item) => item.id === 'archived')?.bulkActions.find((action) => action.kind === 'resume')).toMatchObject({ supported: true })
+    expect(items.find((item) => item.id === 'archived')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: false })
+    expect(items.find((item) => item.id === 'running')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: false })
     expect(items.find((item) => item.id === 'completed')?.bulkActions.find((action) => action.kind === 'archive')).toMatchObject({ supported: true })
     expect(filterFleetRegistryItems(items, { quickFilter: 'unused' }).map((item) => item.id)).toEqual(['paused', 'never-run'])
   })

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
@@ -543,7 +543,7 @@ export function buildCapabilityRegistryItems(input: {
   const toolItems = input.tools.map((tool) => {
     const linkedSkills = skillByToolId.get(tool.id) || []
     const methodsCount = runtimeMethodCount(tool, input.runtimeTools || [])
-    const missingCredentials = tool.authMode === 'api_token' && tool.enabled === false
+    const missingCredentials = tool.authMode === 'api_token' && tool.enabled !== false && tool.credentialReady !== true
     return registryItem({
       id: `capability:tool:${tool.id}`,
       kind: 'capability',

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
@@ -1,0 +1,720 @@
+import {
+  COWORK_FLEET_REGISTRY_SCHEMA_VERSION,
+  type AutomationListPayload,
+  type AutomationStatus,
+  type BuiltInAgentDetail,
+  type CapabilitySkill,
+  type CapabilityTool,
+  type CrewLifecycleStatus,
+  type CrewListItem,
+  type CrewRunStatus,
+  type CustomAgentSummary,
+  type FleetBulkAction,
+  type FleetBulkActionKind,
+  type FleetRegistryItem,
+  type FleetRegistryStatus,
+  type RuntimeAgentDescriptor,
+  type RuntimeToolDescriptor,
+} from '@open-cowork/shared'
+
+export const FLEET_REGISTRY_FEATURE_GATE_KEY = 'open-cowork.feature.fleetRegistryViews'
+export const FLEET_REGISTRY_LARGE_INVENTORY_THRESHOLD = 24
+
+export type FleetRegistrySurface = 'agents' | 'crews' | 'automations' | 'capabilities'
+export type FleetRegistryViewMode = 'cards' | 'table'
+export type FleetRegistryQuickFilter =
+  | 'all'
+  | 'active'
+  | 'paused'
+  | 'failing'
+  | 'unused'
+  | 'expensive'
+  | 'missing_credentials'
+  | 'waiting_review'
+  | 'custom_only'
+  | 'builtin_runtime'
+export type FleetRegistrySortKey =
+  | 'name'
+  | 'kind'
+  | 'status'
+  | 'source'
+  | 'model'
+  | 'capabilities'
+  | 'activity'
+  | 'runs'
+  | 'backlog'
+  | 'cost'
+  | 'tokens'
+export type FleetRegistrySortDirection = 'asc' | 'desc'
+
+export interface FleetRegistrySort {
+  key: FleetRegistrySortKey
+  direction: FleetRegistrySortDirection
+}
+
+export interface FleetRegistryPreference {
+  viewMode?: FleetRegistryViewMode
+  quickFilter?: FleetRegistryQuickFilter
+  sort?: FleetRegistrySort
+}
+
+export const DEFAULT_FLEET_REGISTRY_SORT: FleetRegistrySort = {
+  key: 'name',
+  direction: 'asc',
+}
+
+export const FLEET_REGISTRY_QUICK_FILTERS: Array<{ id: FleetRegistryQuickFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'active', label: 'Active' },
+  { id: 'paused', label: 'Paused' },
+  { id: 'failing', label: 'Failing' },
+  { id: 'unused', label: 'Unused' },
+  { id: 'expensive', label: 'Expensive' },
+  { id: 'missing_credentials', label: 'Missing credentials' },
+  { id: 'waiting_review', label: 'Waiting review' },
+  { id: 'custom_only', label: 'Custom only' },
+  { id: 'builtin_runtime', label: 'Built-in/runtime' },
+]
+
+export const FLEET_REGISTRY_SORT_LABELS: Record<FleetRegistrySortKey, string> = {
+  name: 'Name',
+  kind: 'Kind',
+  status: 'Status',
+  source: 'Source',
+  model: 'Model',
+  capabilities: 'Capabilities',
+  activity: 'Last activity',
+  runs: 'Runs',
+  backlog: 'Review',
+  cost: 'Cost',
+  tokens: 'Tokens',
+}
+
+function storageOrNull(storage?: Storage | null) {
+  if (storage) return storage
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function fleetRegistryPreferenceKey(surface: FleetRegistrySurface) {
+  return `open-cowork.fleetRegistry.${surface}.preferences`
+}
+
+export function isFleetRegistryViewsEnabled(storage?: Storage | null) {
+  return storageOrNull(storage)?.getItem(FLEET_REGISTRY_FEATURE_GATE_KEY) === 'true'
+}
+
+export function shouldDefaultFleetRegistryToTable(count: number, threshold = FLEET_REGISTRY_LARGE_INVENTORY_THRESHOLD) {
+  return count >= threshold
+}
+
+export function readFleetRegistryPreference(surface: FleetRegistrySurface, storage?: Storage | null): FleetRegistryPreference {
+  const target = storageOrNull(storage)
+  if (!target) return {}
+  try {
+    const raw = target.getItem(fleetRegistryPreferenceKey(surface))
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as FleetRegistryPreference
+    return normalizeFleetRegistryPreference(parsed)
+  } catch {
+    return {}
+  }
+}
+
+export function writeFleetRegistryPreference(surface: FleetRegistrySurface, preference: FleetRegistryPreference, storage?: Storage | null) {
+  const target = storageOrNull(storage)
+  if (!target) return
+  try {
+    target.setItem(fleetRegistryPreferenceKey(surface), JSON.stringify(normalizeFleetRegistryPreference(preference)))
+  } catch {
+    // Renderer preferences are best-effort; unavailable storage should not hide the inventory.
+  }
+}
+
+export function toggleFleetRegistrySort(current: FleetRegistrySort, key: FleetRegistrySortKey): FleetRegistrySort {
+  if (current.key !== key) return { key, direction: key === 'activity' || key === 'runs' || key === 'backlog' ? 'desc' : 'asc' }
+  return { key, direction: current.direction === 'asc' ? 'desc' : 'asc' }
+}
+
+function normalizeFleetRegistryPreference(preference: FleetRegistryPreference): FleetRegistryPreference {
+  const quickFilter = FLEET_REGISTRY_QUICK_FILTERS.some((entry) => entry.id === preference.quickFilter)
+    ? preference.quickFilter
+    : undefined
+  const viewMode = preference.viewMode === 'cards' || preference.viewMode === 'table' ? preference.viewMode : undefined
+  const sort = preference.sort && preference.sort.key in FLEET_REGISTRY_SORT_LABELS
+    ? { key: preference.sort.key, direction: preference.sort.direction === 'desc' ? 'desc' : 'asc' } satisfies FleetRegistrySort
+    : undefined
+  return { viewMode, quickFilter, sort }
+}
+
+function compact(values: Array<string | number | null | undefined | false>) {
+  return values
+    .filter((value): value is string | number => value !== null && value !== undefined && value !== false && String(value).trim().length > 0)
+    .map((value) => String(value))
+}
+
+function searchText(values: Array<string | number | null | undefined | false>) {
+  return compact(values).join(' ').toLowerCase()
+}
+
+function statusLabel(status: FleetRegistryStatus) {
+  return status.replaceAll('_', ' ')
+}
+
+function providerFromModel(model?: string | null) {
+  if (!model || !model.includes('/')) return null
+  return model.split('/')[0] || null
+}
+
+function action(
+  kind: FleetBulkActionKind,
+  label: string,
+  supported: boolean,
+  disabledReason?: string,
+  options: Partial<Pick<FleetBulkAction, 'destructive' | 'requiresConfirmation' | 'selection'>> = {},
+): FleetBulkAction {
+  return {
+    id: kind,
+    kind,
+    label,
+    supported,
+    disabledReason: supported ? null : disabledReason || 'This bulk action is not available for the selected registry item.',
+    ...options,
+  }
+}
+
+function registryItem(input: Omit<FleetRegistryItem, 'schemaVersion' | 'statusLabel' | 'metrics' | 'searchText'> & {
+  statusLabel?: string
+  metrics?: FleetRegistryItem['metrics']
+  searchValues: Array<string | number | null | undefined | false>
+}): FleetRegistryItem {
+  const { metrics, searchValues: additionalSearchValues, statusLabel: explicitStatusLabel, ...rest } = input
+  return {
+    schemaVersion: COWORK_FLEET_REGISTRY_SCHEMA_VERSION,
+    ...rest,
+    statusLabel: explicitStatusLabel || statusLabel(input.status),
+    metrics: metrics || [],
+    searchText: searchText([
+      input.name,
+      input.description || '',
+      input.typeLabel,
+      input.status,
+      input.source,
+      input.owner || '',
+      input.provider || '',
+      input.model || '',
+      ...input.tags,
+      ...additionalSearchValues,
+    ]),
+  }
+}
+
+function mapCrewStatus(status: CrewLifecycleStatus): FleetRegistryStatus {
+  if (status === 'active') return 'active'
+  if (status === 'paused') return 'paused'
+  if (status === 'retired') return 'retired'
+  if (status === 'review') return 'waiting_review'
+  if (status === 'approved') return 'ready'
+  return 'draft'
+}
+
+function mapCrewRunActive(status: CrewRunStatus | null | undefined) {
+  return status === 'queued' || status === 'planning' || status === 'running' || status === 'blocked' || status === 'evaluating' || status === 'delivering'
+}
+
+function mapAutomationStatus(status: AutomationStatus): FleetRegistryStatus {
+  if (status === 'needs_user') return 'waiting_review'
+  if (status === 'enriching') return 'running'
+  return status
+}
+
+export function buildAgentRegistryItems(input: {
+  customAgents: readonly CustomAgentSummary[]
+  builtInAgents: readonly BuiltInAgentDetail[]
+  runtimeAgents: readonly RuntimeAgentDescriptor[]
+}): FleetRegistryItem[] {
+  const customItems = input.customAgents.map((agent) => {
+    const status: FleetRegistryStatus = !agent.valid ? 'blocked' : agent.enabled ? 'active' : 'disabled'
+    const source = agent.scope === 'project' ? 'Custom project' : 'Custom machine'
+    return registryItem({
+      id: `agent:custom:${agent.name}`,
+      kind: 'agent',
+      name: agent.name,
+      description: agent.description,
+      typeLabel: 'Custom agent',
+      status,
+      source,
+      owner: agent.scope,
+      provider: providerFromModel(agent.model),
+      model: agent.model || agent.variant || null,
+      skillsCount: agent.skillNames.length,
+      toolsCount: agent.toolIds.length,
+      capabilitiesCount: agent.skillNames.length + agent.toolIds.length,
+      lastUsedAt: null,
+      lastRunAt: null,
+      activeRuns: 0,
+      failedRuns: agent.issues.length,
+      costUsd: null,
+      tokenCount: null,
+      reviewBacklog: agent.valid ? 0 : agent.issues.length,
+      approvalBacklog: 0,
+      tags: compact([
+        'custom',
+        agent.scope,
+        agent.enabled ? 'enabled' : 'disabled',
+        agent.writeAccess ? 'write access' : 'read only',
+        !agent.valid && 'needs repair',
+      ]),
+      bulkActions: [
+        action('tag', 'Tag selected', false, 'Agent tags are not persisted by the current custom agent service.'),
+        action('untag', 'Untag selected', false, 'Agent tags are not persisted by the current custom agent service.'),
+        action('duplicate', 'Duplicate agent', false, 'Use Export and Import until custom agent duplication has a backing service.'),
+      ],
+      metadata: {
+        agentName: agent.name,
+        agentKind: 'custom',
+        scope: agent.scope,
+        writeAccess: agent.writeAccess,
+        valid: agent.valid,
+      },
+      searchValues: [
+        agent.instructions,
+        ...agent.skillNames,
+        ...agent.toolIds,
+        ...agent.issues.map((issue) => issue.message),
+      ],
+    })
+  })
+
+  const builtInItems = input.builtInAgents.map((agent) => {
+    const source = agent.source === 'open-cowork' ? 'Built-in Open Cowork' : 'OpenCode built-in'
+    return registryItem({
+      id: `agent:builtin:${agent.name}`,
+      kind: 'agent',
+      name: agent.label || agent.name,
+      description: agent.description,
+      typeLabel: agent.mode === 'primary' ? 'Primary agent' : 'Subagent',
+      status: agent.disabled || agent.hidden ? 'disabled' : 'active',
+      source,
+      owner: agent.source === 'open-cowork' ? 'Open Cowork' : 'OpenCode',
+      provider: providerFromModel(agent.model),
+      model: agent.model || agent.variant || null,
+      skillsCount: agent.skills.length,
+      toolsCount: agent.toolAccess.length,
+      capabilitiesCount: agent.skills.length + agent.toolAccess.length,
+      lastUsedAt: null,
+      lastRunAt: null,
+      activeRuns: 0,
+      failedRuns: 0,
+      costUsd: null,
+      tokenCount: null,
+      reviewBacklog: 0,
+      approvalBacklog: 0,
+      tags: compact([
+        'built-in',
+        agent.source,
+        agent.mode,
+        agent.hidden && 'hidden',
+        agent.disabled && 'disabled',
+      ]),
+      bulkActions: [
+        action('tag', 'Tag selected', false, 'Built-in agent metadata is runtime-owned and cannot be bulk tagged.'),
+        action('untag', 'Untag selected', false, 'Built-in agent metadata is runtime-owned and cannot be bulk untagged.'),
+        action('duplicate', 'Duplicate agent', false, 'Create a custom agent from this built-in in the agent builder.'),
+      ],
+      metadata: {
+        agentName: agent.name,
+        agentKind: 'builtin',
+        source: agent.source,
+        mode: agent.mode,
+        hidden: agent.hidden,
+      },
+      searchValues: [
+        agent.name,
+        agent.instructions,
+        ...agent.skills,
+        ...agent.toolAccess,
+        ...agent.nativeToolIds,
+        ...agent.configuredToolIds,
+      ],
+    })
+  })
+
+  const runtimeItems = input.runtimeAgents.map((agent) => {
+    const toolsCount = agent.toolIds?.length || agent.toolCount || 0
+    return registryItem({
+      id: `agent:runtime:${agent.name}`,
+      kind: 'agent',
+      name: agent.name,
+      description: agent.description || '',
+      typeLabel: agent.mode === 'primary' ? 'Primary runtime agent' : agent.mode === 'subagent' ? 'Runtime subagent' : 'Runtime agent',
+      status: agent.disabled ? 'disabled' : 'active',
+      source: 'Runtime',
+      owner: 'OpenCode plugin',
+      provider: providerFromModel(agent.model),
+      model: agent.model || null,
+      skillsCount: 0,
+      toolsCount,
+      capabilitiesCount: toolsCount,
+      lastUsedAt: null,
+      lastRunAt: null,
+      activeRuns: 0,
+      failedRuns: 0,
+      costUsd: null,
+      tokenCount: null,
+      reviewBacklog: 0,
+      approvalBacklog: 0,
+      tags: compact(['runtime', agent.mode || 'agent', agent.writeAccess ? 'write access' : 'read only', agent.disabled && 'disabled']),
+      bulkActions: [
+        action('tag', 'Tag selected', false, 'Runtime agent metadata is supplied by OpenCode plugins.'),
+        action('untag', 'Untag selected', false, 'Runtime agent metadata is supplied by OpenCode plugins.'),
+        action('duplicate', 'Duplicate agent', false, 'Runtime agents must be converted through the agent builder before duplication.'),
+      ],
+      metadata: {
+        agentName: agent.name,
+        agentKind: 'runtime',
+        mode: agent.mode || null,
+        writeAccess: agent.writeAccess || false,
+        steps: agent.steps || null,
+      },
+      searchValues: [agent.name, agent.description || '', ...(agent.toolIds || [])],
+    })
+  })
+
+  return [...customItems, ...builtInItems, ...runtimeItems]
+}
+
+export function buildCrewRegistryItems(crews: readonly CrewListItem[]): FleetRegistryItem[] {
+  return crews.map((crew) => {
+    const status = mapCrewStatus(crew.definition.status)
+    const memberCount = crew.activeVersion?.members.length || 0
+    const latestRunStatus = crew.latestRun?.status || null
+    const activeRuns = mapCrewRunActive(latestRunStatus) ? 1 : 0
+    const failedRuns = latestRunStatus === 'failed' ? 1 : 0
+    return registryItem({
+      id: crew.definition.id,
+      kind: 'crew',
+      name: crew.definition.name,
+      description: crew.definition.description,
+      typeLabel: 'Agent team',
+      status,
+      statusLabel: crew.definition.status.replaceAll('_', ' '),
+      source: 'Custom crew',
+      owner: 'Open Cowork',
+      provider: null,
+      model: null,
+      skillsCount: 0,
+      toolsCount: 0,
+      capabilitiesCount: memberCount,
+      lastUsedAt: crew.definition.updatedAt,
+      lastRunAt: crew.latestRun?.startedAt || crew.latestRun?.createdAt || null,
+      activeRuns,
+      failedRuns,
+      costUsd: crew.activeVersion?.budgetCapUsd || null,
+      tokenCount: null,
+      reviewBacklog: crew.definition.status === 'review' ? 1 : 0,
+      approvalBacklog: 0,
+      tags: compact([
+        'custom',
+        'crew',
+        `v${crew.activeVersion?.version || 0}`,
+        crew.latestRun?.status && `latest ${crew.latestRun.status}`,
+        crew.activeVersion?.certificationStatus,
+      ]),
+      bulkActions: [
+        action('tag', 'Tag selected', false, 'Crew tags are not persisted by the current crew service.'),
+        action('untag', 'Untag selected', false, 'Crew tags are not persisted by the current crew service.'),
+        action('duplicate', 'Duplicate crew', false, 'Crew template duplication needs a backing service before bulk use.'),
+      ],
+      metadata: {
+        version: crew.activeVersion?.version || 0,
+        workspaceProfileId: crew.activeVersion?.workspaceProfileId || null,
+        certificationStatus: crew.activeVersion?.certificationStatus || null,
+      },
+      searchValues: [
+        crew.definition.status,
+        crew.latestRun?.title || '',
+        crew.latestRun?.status || '',
+        ...(crew.activeVersion?.members || []).flatMap((member) => [member.agentName, member.displayName, member.role]),
+      ],
+    })
+  })
+}
+
+export function buildAutomationRegistryItems(payload: AutomationListPayload): FleetRegistryItem[] {
+  const runsByAutomation = groupBy(payload.runs, (run) => run.automationId)
+  const inboxByAutomation = groupBy(payload.inbox.filter((entry) => entry.status === 'open'), (entry) => entry.automationId)
+  const workItemsByAutomation = groupBy(payload.workItems, (workItem) => workItem.automationId)
+  return payload.automations.map((automation) => {
+    const runs = runsByAutomation.get(automation.id) || []
+    const inbox = inboxByAutomation.get(automation.id) || []
+    const workItems = workItemsByAutomation.get(automation.id) || []
+    const activeRuns = runs.filter((run) => run.status === 'queued' || run.status === 'running' || run.status === 'needs_user').length
+    const failedRuns = runs.filter((run) => run.status === 'failed').length
+    const reviewBacklog = inbox.filter((entry) => entry.type === 'approval' || entry.type === 'clarification' || entry.type === 'failure').length
+    const approvalBacklog = inbox.filter((entry) => entry.type === 'approval').length
+    const status = mapAutomationStatus(automation.status)
+    const canPause = automation.status !== 'paused' && automation.status !== 'archived'
+    const canResume = automation.status === 'paused'
+    const canArchive = automation.status === 'completed' || automation.status === 'failed' || automation.status === 'paused'
+    return registryItem({
+      id: automation.id,
+      kind: 'automation',
+      name: automation.title,
+      description: automation.goal,
+      typeLabel: automation.kind === 'managed-project' ? 'Managed project' : 'Recurring automation',
+      status,
+      statusLabel: automation.status.replaceAll('_', ' '),
+      source: 'Automation',
+      owner: automation.projectDirectory || 'Global',
+      provider: null,
+      model: automation.executionMode.replaceAll('_', ' '),
+      skillsCount: 0,
+      toolsCount: 0,
+      capabilitiesCount: automation.preferredAgentNames.length,
+      lastUsedAt: automation.lastHeartbeatAt || automation.updatedAt,
+      lastRunAt: automation.lastRunAt,
+      activeRuns,
+      failedRuns,
+      costUsd: null,
+      tokenCount: null,
+      reviewBacklog,
+      approvalBacklog,
+      tags: compact([
+        automation.kind,
+        automation.executionMode.replaceAll('_', ' '),
+        automation.autonomyPolicy,
+        automation.latestRunStatus && `latest ${automation.latestRunStatus}`,
+        automation.nextRunAt && 'scheduled',
+      ]),
+      bulkActions: [
+        action('pause', 'Pause selected', canPause, 'Only non-archived automations can be paused.'),
+        action('resume', 'Resume selected', canResume, 'Only paused automations can be resumed.'),
+        action('archive', 'Archive selected', canArchive, 'Archive is limited to paused, failed, or completed automations.', { destructive: true, requiresConfirmation: true }),
+        action('duplicate', 'Duplicate automation', false, 'Automation template duplication needs a backing service before bulk use.'),
+      ],
+      metadata: {
+        scheduleType: automation.schedule.type,
+        heartbeatMinutes: automation.heartbeatMinutes,
+        workItems: workItems.length,
+      },
+      searchValues: [
+        automation.kind,
+        automation.status,
+        automation.executionMode,
+        automation.autonomyPolicy,
+        automation.projectDirectory || '',
+        ...automation.preferredAgentNames,
+        ...runs.flatMap((run) => [run.title, run.summary || '', run.error || '', run.status]),
+        ...inbox.flatMap((entry) => [entry.title, entry.body, entry.type]),
+        ...workItems.flatMap((workItem) => [workItem.title, workItem.description, workItem.status, workItem.ownerAgent || '']),
+      ],
+    })
+  })
+}
+
+export function buildCapabilityRegistryItems(input: {
+  tools: readonly CapabilityTool[]
+  skills: readonly CapabilitySkill[]
+  runtimeTools?: readonly RuntimeToolDescriptor[]
+}): FleetRegistryItem[] {
+  const skillByToolId = new Map<string, CapabilitySkill[]>()
+  for (const skill of input.skills) {
+    for (const toolId of skill.toolIds || []) {
+      const list = skillByToolId.get(toolId) || []
+      list.push(skill)
+      skillByToolId.set(toolId, list)
+    }
+  }
+
+  const toolItems = input.tools.map((tool) => {
+    const linkedSkills = skillByToolId.get(tool.id) || []
+    const methodsCount = runtimeMethodCount(tool, input.runtimeTools || [])
+    const missingCredentials = tool.authMode === 'api_token' && tool.enabled === false
+    return registryItem({
+      id: `capability:tool:${tool.id}`,
+      kind: 'capability',
+      name: tool.name,
+      description: tool.description,
+      typeLabel: tool.kind === 'built-in' ? 'Tool' : 'MCP tool',
+      status: missingCredentials ? 'blocked' : tool.enabled === false ? 'disabled' : 'active',
+      source: tool.source === 'custom' ? 'Custom capability' : tool.origin === 'opencode' ? 'OpenCode runtime' : 'Built-in capability',
+      owner: tool.scope || tool.origin || null,
+      provider: tool.integrationId || tool.namespace || null,
+      model: tool.authMode || null,
+      skillsCount: linkedSkills.length,
+      toolsCount: methodsCount,
+      capabilitiesCount: methodsCount + linkedSkills.length,
+      lastUsedAt: null,
+      lastRunAt: null,
+      activeRuns: 0,
+      failedRuns: 0,
+      costUsd: null,
+      tokenCount: null,
+      reviewBacklog: 0,
+      approvalBacklog: missingCredentials ? 1 : 0,
+      tags: compact([
+        tool.kind,
+        tool.source,
+        tool.origin,
+        tool.scope,
+        tool.authMode && `auth ${tool.authMode}`,
+        missingCredentials && 'missing credentials',
+      ]),
+      bulkActions: [
+        action('open_dependency', 'Open dependency drill-down', true, undefined, { selection: 'single' }),
+        action('tag', 'Tag selected', false, 'Capability tags need a registry-backed metadata service before bulk use.'),
+        action('untag', 'Untag selected', false, 'Capability tags need a registry-backed metadata service before bulk use.'),
+      ],
+      metadata: {
+        capabilityType: 'tool',
+        capabilityId: tool.id,
+        integrationId: tool.integrationId || null,
+      },
+      searchValues: [
+        tool.id,
+        tool.namespace || '',
+        ...tool.patterns,
+        ...tool.agentNames,
+        ...linkedSkills.flatMap((skill) => [skill.name, skill.label]),
+        ...(tool.availableTools || []).flatMap((entry) => [entry.id, entry.description]),
+      ],
+    })
+  })
+
+  const skillItems = input.skills.map((skill) => {
+    const linkedTools = input.tools.filter((tool) => (skill.toolIds || []).includes(tool.id))
+    return registryItem({
+      id: `capability:skill:${skill.name}`,
+      kind: 'capability',
+      name: skill.label || skill.name,
+      description: skill.description,
+      typeLabel: 'Skill',
+      status: 'active',
+      source: skill.source === 'custom' ? 'Custom capability' : 'Built-in capability',
+      owner: skill.scope || skill.origin || null,
+      provider: null,
+      model: null,
+      skillsCount: 1,
+      toolsCount: linkedTools.length,
+      capabilitiesCount: 1 + linkedTools.length,
+      lastUsedAt: null,
+      lastRunAt: null,
+      activeRuns: 0,
+      failedRuns: 0,
+      costUsd: null,
+      tokenCount: null,
+      reviewBacklog: 0,
+      approvalBacklog: 0,
+      tags: compact(['skill', skill.source, skill.origin, skill.scope, linkedTools.length === 0 && 'standalone']),
+      bulkActions: [
+        action('open_dependency', 'Open dependency drill-down', true, undefined, { selection: 'single' }),
+        action('tag', 'Tag selected', false, 'Capability tags need a registry-backed metadata service before bulk use.'),
+        action('untag', 'Untag selected', false, 'Capability tags need a registry-backed metadata service before bulk use.'),
+      ],
+      metadata: {
+        capabilityType: 'skill',
+        capabilityId: skill.name,
+        location: skill.location || null,
+      },
+      searchValues: [
+        skill.name,
+        skill.location || '',
+        ...skill.agentNames,
+        ...(skill.toolIds || []),
+        ...linkedTools.flatMap((tool) => [tool.id, tool.name]),
+      ],
+    })
+  })
+
+  return [...toolItems, ...skillItems]
+}
+
+export function filterFleetRegistryItems(
+  items: readonly FleetRegistryItem[],
+  options: { query?: string; quickFilter?: FleetRegistryQuickFilter } = {},
+) {
+  const query = (options.query || '').trim().toLowerCase()
+  const quickFilter = options.quickFilter || 'all'
+  return items.filter((item) => {
+    if (query && !item.searchText.includes(query)) return false
+    if (quickFilter === 'all') return true
+    if (quickFilter === 'active') return item.status === 'active' || item.status === 'ready' || item.status === 'running'
+    if (quickFilter === 'paused') return item.status === 'paused'
+    if (quickFilter === 'failing') return item.status === 'failed' || item.status === 'blocked' || item.failedRuns > 0
+    if (quickFilter === 'unused') return !item.lastRunAt && !item.lastUsedAt && item.activeRuns === 0
+    if (quickFilter === 'expensive') return (item.costUsd || 0) >= 1 || (item.tokenCount || 0) >= 100_000
+    if (quickFilter === 'missing_credentials') return item.tags.some((tag) => tag.toLowerCase().includes('missing credentials'))
+    if (quickFilter === 'waiting_review') return item.status === 'waiting_review' || item.reviewBacklog + item.approvalBacklog > 0
+    if (quickFilter === 'custom_only') return item.source.toLowerCase().includes('custom') || item.tags.includes('custom')
+    if (quickFilter === 'builtin_runtime') {
+      const source = item.source.toLowerCase()
+      return source.includes('built-in') || source.includes('runtime') || source.includes('opencode')
+    }
+    return true
+  })
+}
+
+export function sortFleetRegistryItems(items: readonly FleetRegistryItem[], sort: FleetRegistrySort = DEFAULT_FLEET_REGISTRY_SORT) {
+  const direction = sort.direction === 'desc' ? -1 : 1
+  return [...items].sort((left, right) => {
+    const compared = compareSortValue(sortValue(left, sort.key), sortValue(right, sort.key))
+    if (compared !== 0) return compared * direction
+    return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
+  })
+}
+
+function sortValue(item: FleetRegistryItem, key: FleetRegistrySortKey) {
+  if (key === 'name') return item.name
+  if (key === 'kind') return item.typeLabel
+  if (key === 'status') return item.statusLabel
+  if (key === 'source') return item.source
+  if (key === 'model') return item.model || item.provider || ''
+  if (key === 'capabilities') return item.capabilitiesCount
+  if (key === 'activity') return dateValue(item.lastRunAt || item.lastUsedAt || (typeof item.metadata?.updatedAt === 'string' ? item.metadata.updatedAt : null))
+  if (key === 'runs') return item.activeRuns * 1000 + item.failedRuns
+  if (key === 'backlog') return item.reviewBacklog + item.approvalBacklog
+  if (key === 'cost') return item.costUsd || 0
+  if (key === 'tokens') return item.tokenCount || 0
+  return item.name
+}
+
+function compareSortValue(left: string | number, right: string | number) {
+  if (typeof left === 'number' && typeof right === 'number') return left - right
+  return String(left).localeCompare(String(right), undefined, { sensitivity: 'base', numeric: true })
+}
+
+function dateValue(value: string | null | undefined) {
+  if (!value) return 0
+  const time = Date.parse(value)
+  return Number.isNaN(time) ? 0 : time
+}
+
+function groupBy<T>(items: readonly T[], key: (item: T) => string) {
+  const grouped = new Map<string, T[]>()
+  for (const item of items) {
+    const groupKey = key(item)
+    const list = grouped.get(groupKey) || []
+    list.push(item)
+    grouped.set(groupKey, list)
+  }
+  return grouped
+}
+
+function runtimeMethodCount(tool: CapabilityTool, runtimeTools: readonly RuntimeToolDescriptor[]) {
+  const prefixes = compact([
+    tool.namespace && `mcp__${tool.namespace}__`,
+    tool.namespace && `${tool.namespace}_`,
+    `mcp__${tool.id}__`,
+    `${tool.id}_`,
+  ])
+  const runtimeCount = runtimeTools.filter((entry) => {
+    const id = entry.id || entry.name || ''
+    return id === tool.id || prefixes.some((prefix) => id.startsWith(prefix))
+  }).length
+  return runtimeCount || tool.availableTools?.length || 0
+}

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
@@ -460,13 +460,14 @@ export function buildAutomationRegistryItems(payload: AutomationListPayload): Fl
     const inbox = inboxByAutomation.get(automation.id) || []
     const workItems = workItemsByAutomation.get(automation.id) || []
     const activeRuns = runs.filter((run) => run.status === 'queued' || run.status === 'running' || run.status === 'needs_user').length
+    const blockingRuns = runs.filter((run) => run.status === 'queued' || run.status === 'running').length
     const failedRuns = runs.filter((run) => run.status === 'failed').length
     const reviewBacklog = inbox.filter((entry) => entry.type === 'approval' || entry.type === 'clarification' || entry.type === 'failure').length
     const approvalBacklog = inbox.filter((entry) => entry.type === 'approval').length
     const status = mapAutomationStatus(automation.status)
     const canPause = automation.status !== 'paused' && automation.status !== 'archived'
-    const canResume = automation.status === 'paused'
-    const canArchive = automation.status === 'completed' || automation.status === 'failed' || automation.status === 'paused'
+    const canResume = automation.status === 'paused' || automation.status === 'archived'
+    const canArchive = automation.status !== 'archived' && blockingRuns === 0
     return registryItem({
       id: automation.id,
       kind: 'automation',
@@ -499,8 +500,8 @@ export function buildAutomationRegistryItems(payload: AutomationListPayload): Fl
       ]),
       bulkActions: [
         action('pause', 'Pause selected', canPause, 'Only non-archived automations can be paused.'),
-        action('resume', 'Resume selected', canResume, 'Only paused automations can be resumed.'),
-        action('archive', 'Archive selected', canArchive, 'Archive is limited to paused, failed, or completed automations.', { destructive: true, requiresConfirmation: true }),
+        action('resume', 'Resume selected', canResume, 'Only paused or archived automations can be resumed.'),
+        action('archive', 'Archive selected', canArchive, 'Only non-archived automations without queued or running work can be archived.', { destructive: true, requiresConfirmation: true }),
         action('duplicate', 'Duplicate automation', false, 'Automation template duplication needs a backing service before bulk use.'),
       ],
       metadata: {

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
@@ -416,7 +416,7 @@ export function buildCrewRegistryItems(crews: readonly CrewListItem[]): FleetReg
       skillsCount: 0,
       toolsCount: 0,
       capabilitiesCount: memberCount,
-      lastUsedAt: crew.definition.updatedAt,
+      lastUsedAt: null,
       lastRunAt: crew.latestRun?.startedAt || crew.latestRun?.createdAt || null,
       activeRuns,
       failedRuns,
@@ -440,6 +440,7 @@ export function buildCrewRegistryItems(crews: readonly CrewListItem[]): FleetReg
         version: crew.activeVersion?.version || 0,
         workspaceProfileId: crew.activeVersion?.workspaceProfileId || null,
         certificationStatus: crew.activeVersion?.certificationStatus || null,
+        updatedAt: crew.definition.updatedAt,
       },
       searchValues: [
         crew.definition.status,

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.ts
@@ -105,7 +105,13 @@ export function fleetRegistryPreferenceKey(surface: FleetRegistrySurface) {
 }
 
 export function isFleetRegistryViewsEnabled(storage?: Storage | null) {
-  return storageOrNull(storage)?.getItem(FLEET_REGISTRY_FEATURE_GATE_KEY) === 'true'
+  const target = storageOrNull(storage)
+  if (!target) return false
+  try {
+    return target.getItem(FLEET_REGISTRY_FEATURE_GATE_KEY) === 'true'
+  } catch {
+    return false
+  }
 }
 
 export function shouldDefaultFleetRegistryToTable(count: number, threshold = FLEET_REGISTRY_LARGE_INVENTORY_THRESHOLD) {
@@ -476,7 +482,7 @@ export function buildAutomationRegistryItems(payload: AutomationListPayload): Fl
       skillsCount: 0,
       toolsCount: 0,
       capabilitiesCount: automation.preferredAgentNames.length,
-      lastUsedAt: automation.lastHeartbeatAt || automation.updatedAt,
+      lastUsedAt: automation.lastHeartbeatAt,
       lastRunAt: automation.lastRunAt,
       activeRuns,
       failedRuns,
@@ -501,6 +507,7 @@ export function buildAutomationRegistryItems(payload: AutomationListPayload): Fl
         scheduleType: automation.schedule.type,
         heartbeatMinutes: automation.heartbeatMinutes,
         workItems: workItems.length,
+        updatedAt: automation.updatedAt,
       },
       searchValues: [
         automation.kind,
@@ -646,7 +653,7 @@ export function filterFleetRegistryItems(
     if (quickFilter === 'active') return item.status === 'active' || item.status === 'ready' || item.status === 'running'
     if (quickFilter === 'paused') return item.status === 'paused'
     if (quickFilter === 'failing') return item.status === 'failed' || item.status === 'blocked' || item.failedRuns > 0
-    if (quickFilter === 'unused') return !item.lastRunAt && !item.lastUsedAt && item.activeRuns === 0
+    if (quickFilter === 'unused') return !item.lastRunAt && !item.lastUsedAt && item.activeRuns === 0 && item.failedRuns === 0
     if (quickFilter === 'expensive') return (item.costUsd || 0) >= 1 || (item.tokenCount || 0) >= 100_000
     if (quickFilter === 'missing_credentials') return item.tags.some((tag) => tag.toLowerCase().includes('missing credentials'))
     if (quickFilter === 'waiting_review') return item.status === 'waiting_review' || item.reviewBacklog + item.approvalBacklog > 0

--- a/apps/desktop/src/renderer/components/fleet/useFleetRegistryPreferences.ts
+++ b/apps/desktop/src/renderer/components/fleet/useFleetRegistryPreferences.ts
@@ -1,0 +1,42 @@
+import { useMemo, useState } from 'react'
+import {
+  DEFAULT_FLEET_REGISTRY_SORT,
+  readFleetRegistryPreference,
+  shouldDefaultFleetRegistryToTable,
+  writeFleetRegistryPreference,
+  type FleetRegistryPreference,
+  type FleetRegistryQuickFilter,
+  type FleetRegistrySort,
+  type FleetRegistrySurface,
+  type FleetRegistryViewMode,
+} from './fleet-registry-model'
+
+export function useFleetRegistryPreferences(surface: FleetRegistrySurface, itemCount: number) {
+  const [preference, setPreference] = useState<FleetRegistryPreference>(() => readFleetRegistryPreference(surface))
+
+  const effective = useMemo(() => {
+    return {
+      viewMode: preference.viewMode || (shouldDefaultFleetRegistryToTable(itemCount) ? 'table' : 'cards'),
+      quickFilter: preference.quickFilter || 'all',
+      sort: preference.sort || DEFAULT_FLEET_REGISTRY_SORT,
+    } satisfies Required<FleetRegistryPreference>
+  }, [itemCount, preference])
+
+  const updatePreference = (patch: FleetRegistryPreference) => {
+    setPreference((current) => {
+      const next = { ...current, ...patch }
+      writeFleetRegistryPreference(surface, next)
+      return next
+    })
+  }
+
+  return {
+    preference,
+    viewMode: effective.viewMode,
+    quickFilter: effective.quickFilter,
+    sort: effective.sort,
+    setViewMode: (viewMode: FleetRegistryViewMode) => updatePreference({ viewMode }),
+    setQuickFilter: (quickFilter: FleetRegistryQuickFilter) => updatePreference({ quickFilter }),
+    setSort: (sort: FleetRegistrySort) => updatePreference({ sort }),
+  }
+}

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -65,6 +65,14 @@ filters, and bulk-safe actions. Use cards for browse/detail previews, not as
 the only way to manage large inventories. Empty states should offer a direct
 next action and avoid marketing copy.
 
+The `fleetRegistryViews` feature gate is default-off while shared registry
+contracts and persistence settle. When enabled, Agents, Crews, Automations, and
+Capabilities expose table mode beside the existing card/board views. The
+registry tables share quick filters, sortable operational columns, row
+selection, and disabled states for bulk actions that do not yet have a backing
+service. Automations wire supported bulk pause, resume, and archive actions;
+Capabilities wire single-row dependency drill-downs.
+
 ## Home
 
 ![Home composer with greeting, @-agent suggestion pills, and the execution status strip](assets/auto/home.png)

--- a/packages/shared/src/capabilities.ts
+++ b/packages/shared/src/capabilities.ts
@@ -59,6 +59,10 @@ export interface CapabilityTool {
   // to interpret this directly — it just renders the toggle's current
   // position.
   enabled?: boolean
+  // Whether required integration credentials are present. This is
+  // separate from `enabled` because API-token integrations can be
+  // readiness-driven without a persisted user toggle override.
+  credentialReady?: boolean
 }
 
 export interface CapabilitySkill {

--- a/packages/shared/src/operations.ts
+++ b/packages/shared/src/operations.ts
@@ -1,5 +1,6 @@
 export const COWORK_OPERATION_SCHEMA_VERSION = 1
 export const COWORK_WORKSPACE_PROFILE_SCHEMA_VERSION = 1
+export const COWORK_FLEET_REGISTRY_SCHEMA_VERSION = 1
 
 export type AutonomyLevel = 'observe' | 'draft' | 'approve' | 'supervised' | 'bounded-auto'
 export type CapabilityRiskLevel = 'low' | 'medium' | 'high'
@@ -7,9 +8,85 @@ export type WorkspaceProfileKind = 'personal_sandbox' | 'project_workspace' | 'a
 export type OperationalRunKind = 'agent' | 'crew' | 'automation' | 'sop' | 'channel' | 'dream'
 export type OperationalQueueStatus = 'queued' | 'running' | 'blocked' | 'completed' | 'failed' | 'cancelled'
 export type OperationalQueueKind = 'agent' | 'crew' | 'project' | 'channel' | 'external_system'
+export type FleetRegistryKind = 'agent' | 'crew' | 'automation' | 'capability'
+export type FleetRegistryStatus =
+  | 'draft'
+  | 'active'
+  | 'ready'
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'failed'
+  | 'archived'
+  | 'retired'
+  | 'disabled'
+  | 'blocked'
+  | 'waiting_review'
+  | 'idle'
+  | 'unknown'
+export type FleetRegistryMetricTone = 'neutral' | 'success' | 'warning' | 'danger' | 'info'
+export type FleetBulkActionKind =
+  | 'pause'
+  | 'resume'
+  | 'archive'
+  | 'tag'
+  | 'untag'
+  | 'duplicate'
+  | 'open_dependency'
+  | 'run'
+  | 'test'
 
 export interface OperationSchemaVersionedRecord {
   schemaVersion: number
+}
+
+export interface FleetRegistryMetric {
+  id: string
+  label: string
+  value: number | string
+  unit?: string | null
+  tone?: FleetRegistryMetricTone
+}
+
+export interface FleetBulkAction {
+  id: string
+  kind: FleetBulkActionKind
+  label: string
+  supported: boolean
+  disabledReason?: string | null
+  destructive?: boolean
+  requiresConfirmation?: boolean
+  selection?: 'single' | 'multiple'
+}
+
+export interface FleetRegistryItem extends OperationSchemaVersionedRecord {
+  id: string
+  kind: FleetRegistryKind
+  name: string
+  description?: string | null
+  typeLabel: string
+  status: FleetRegistryStatus
+  statusLabel: string
+  source: string
+  owner?: string | null
+  provider?: string | null
+  model?: string | null
+  skillsCount: number
+  toolsCount: number
+  capabilitiesCount: number
+  lastUsedAt?: string | null
+  lastRunAt?: string | null
+  activeRuns: number
+  failedRuns: number
+  costUsd?: number | null
+  tokenCount?: number | null
+  reviewBacklog: number
+  approvalBacklog: number
+  tags: string[]
+  metrics: FleetRegistryMetric[]
+  searchText: string
+  bulkActions: FleetBulkAction[]
+  metadata?: Record<string, string | number | boolean | null>
 }
 
 export interface CapabilityRiskMetadata extends OperationSchemaVersionedRecord {


### PR DESCRIPTION
Closes #340

## Summary
- Adds shared fleet registry contracts for agents, crews, automations, and capabilities.
- Adds a default-off fleetRegistryViews renderer gate with persisted per-surface table preferences.
- Adds reusable registry normalization, quick filters, sorting, row selection, and bulk-action enablement.
- Wires table mode into Agents, Crews, Automations, and Capabilities while preserving existing card/board views.
- Wires backed bulk automation pause/resume/archive actions and capability dependency drill-downs; unsupported tag/duplicate actions render disabled with reasons.

## Test gates
- pnpm typecheck
- pnpm lint
- pnpm lint:a11y
- pnpm --filter @open-cowork/desktop test:renderer -- src/renderer/components/agents/AgentsPage.test.tsx src/renderer/components/fleet/fleet-registry-model.test.ts
- pnpm test
- uv run mkdocs build --strict
- git diff --check