### PR TITLE
Implement gated Work Ledger projection

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -38,6 +38,7 @@ import { registerSopHandlers } from './ipc/sop-handlers.ts'
 import { registerCustomContentHandlers } from './ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from './ipc/explorer-handlers.ts'
 import { registerThreadHandlers } from './ipc/thread-handlers.ts'
+import { registerWorkLedgerHandlers } from './ipc/work-ledger-handlers.ts'
 import type { IpcHandlerContext } from './ipc/context.ts'
 import { clearPermissionsForSession, trackPermission } from './permission-tracker.ts'
 import { ProjectDirectoryGrantRegistry, trustedRecordDirectoryMatches } from './directory-grants.ts'
@@ -401,6 +402,7 @@ export function setupIpcHandlers(ipcMain: IpcMain, getMainWindow: () => BrowserW
   registerSopHandlers(context)
 
   registerThreadHandlers(context)
+  registerWorkLedgerHandlers(context)
   registerSessionHandlers(context)
   registerCatalogHandlers(context)
   registerCustomContentHandlers(context)

--- a/apps/desktop/src/main/ipc/work-ledger-handlers.ts
+++ b/apps/desktop/src/main/ipc/work-ledger-handlers.ts
@@ -1,0 +1,18 @@
+import type { IpcHandlerContext } from './context.ts'
+import { getWorkLedgerService } from '../work-ledger-service.ts'
+
+export function registerWorkLedgerHandlers(context: IpcHandlerContext) {
+  const ledger = () => getWorkLedgerService()
+
+  context.ipcMain.handle('work-ledger:search', async (_event, query?: unknown) => (
+    ledger().search(query as never)
+  ))
+
+  context.ipcMain.handle('work-ledger:facets', async (_event, query?: unknown) => (
+    ledger().facets(query as never)
+  ))
+
+  context.ipcMain.handle('work-ledger:reindex', async () => (
+    ledger().reindex()
+  ))
+}

--- a/apps/desktop/src/main/work-ledger-service.ts
+++ b/apps/desktop/src/main/work-ledger-service.ts
@@ -1,0 +1,829 @@
+import type {
+  AutomationInboxItem,
+  AutomationListPayload,
+  AutomationRunStatus,
+  AutomationStatus,
+  AutomationWorkItem,
+  ChannelDeliveryRecord,
+  ChannelInboundItem,
+  ChannelListPayload,
+  CoworkWorkItem,
+  CrewApproval,
+  CrewApprovalStatus,
+  CrewArtifact,
+  CrewListPayload,
+  CrewRun,
+  CrewRunNode,
+  CrewRunNodeStatus,
+  CrewRunStatus,
+  GovernanceAuditEvent,
+  GovernanceAuditOutcome,
+  PolicyDecision,
+  PolicyDecisionStatus,
+  SessionTokens,
+  ThreadListItem,
+  WorkLedgerReviewState,
+  WorkLedgerSearchQuery,
+  WorkLedgerSourceKind,
+  WorkLedgerStatus,
+  WorkLedgerUpsertInput,
+} from '@open-cowork/shared'
+import { listAutomationState } from './automation-store.ts'
+import { listChannelState } from './channel-store.ts'
+import { listCrewCatalog } from './crew-service.ts'
+import {
+  listCoworkWorkItems,
+  listCrewApprovalsForAudit,
+  listCrewArtifactsForRun,
+  listCrewRunNodes,
+  listCrewRunsForAudit,
+  listPolicyDecisionsForAudit,
+} from './crew-store.ts'
+import { listGovernanceAuditEvents } from './governance-audit-store.ts'
+import { getThreadIndexService } from './thread-index-service.ts'
+import {
+  getWorkLedgerStore,
+  normalizeWorkLedgerSearchQuery,
+  type WorkLedgerStore,
+} from './work-ledger-store.ts'
+import { log } from './logger.ts'
+
+const LEDGER_REFRESH_TTL_MS = 5_000
+const RECENT_THREAD_PAGE_LIMIT = 100
+const RECENT_GOVERNANCE_AUDIT_LIMIT = 500
+
+export interface WorkLedgerCrewSnapshot {
+  catalog: CrewListPayload
+  runs: CrewRun[]
+  nodes: CrewRunNode[]
+  workItems: CoworkWorkItem[]
+  approvals: CrewApproval[]
+  policyDecisions: PolicyDecision[]
+  artifacts: CrewArtifact[]
+}
+
+export interface WorkLedgerSnapshot {
+  threads: ThreadListItem[]
+  automations: AutomationListPayload
+  crews: WorkLedgerCrewSnapshot
+  channels: ChannelListPayload
+  governanceAuditEvents: GovernanceAuditEvent[]
+}
+
+type WorkLedgerSnapshotLoader = () => WorkLedgerSnapshot
+
+function emptyTokens(): SessionTokens {
+  return {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  }
+}
+
+function emptyUsage() {
+  return { cost: 0, tokens: emptyTokens() }
+}
+
+function compactStrings(values: Array<string | null | undefined | false>) {
+  return Array.from(new Set(values
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => value.trim())))
+}
+
+function sourceId(kind: WorkLedgerSourceKind, id: string) {
+  return `${kind}:${id}`
+}
+
+function reviewFromStatus(status: WorkLedgerStatus): WorkLedgerReviewState {
+  if (status === 'needs_user' || status === 'blocked') return 'needs_review'
+  if (status === 'approval_required') return 'approval_requested'
+  if (status === 'approved') return 'approved'
+  if (status === 'denied') return 'denied'
+  if (status === 'failed' || status === 'error') return 'failed'
+  if (status === 'completed' || status === 'delivered' || status === 'succeeded' || status === 'cancelled') return 'resolved'
+  return 'none'
+}
+
+function routeForThread(sessionId: string) {
+  return {
+    surface: 'thread' as const,
+    sessionId,
+  }
+}
+
+function automationRoute(automationId: string, automationRunId?: string | null, sessionId?: string | null) {
+  return {
+    surface: 'automations' as const,
+    automationId,
+    automationRunId: automationRunId || null,
+    sessionId: sessionId || null,
+  }
+}
+
+function crewRoute(crewId?: string | null, crewRunId?: string | null, sessionId?: string | null) {
+  return {
+    surface: sessionId ? 'thread' as const : 'crews' as const,
+    crewId: crewId || null,
+    crewRunId: crewRunId || null,
+    sessionId: sessionId || null,
+  }
+}
+
+function channelRoute(channelId: string) {
+  return {
+    surface: 'channels' as const,
+    channelId,
+  }
+}
+
+function governanceRoute(eventId: string) {
+  return {
+    surface: 'operations' as const,
+    governanceAuditEventId: eventId,
+  }
+}
+
+function mapThreadStatus(status: ThreadListItem['status']): WorkLedgerStatus {
+  if (status === 'error') return 'error'
+  return status
+}
+
+function mapAutomationStatus(status: AutomationStatus): WorkLedgerStatus {
+  return status
+}
+
+function mapAutomationRunStatus(status: AutomationRunStatus): WorkLedgerStatus {
+  return status
+}
+
+function mapAutomationWorkItemStatus(status: AutomationWorkItem['status']): WorkLedgerStatus {
+  return status
+}
+
+function mapCrewRunStatus(status: CrewRunStatus): WorkLedgerStatus {
+  return status
+}
+
+function mapCrewNodeStatus(status: CrewRunNodeStatus): WorkLedgerStatus {
+  if (status === 'skipped') return 'cancelled'
+  return status
+}
+
+function mapCrewApprovalStatus(status: CrewApprovalStatus): WorkLedgerStatus {
+  if (status === 'requested') return 'approval_required'
+  if (status === 'cancelled') return 'cancelled'
+  return status
+}
+
+function mapPolicyStatus(status: PolicyDecisionStatus): WorkLedgerStatus {
+  if (status === 'approval_required') return 'approval_required'
+  if (status === 'denied') return 'denied'
+  return 'approved'
+}
+
+function mapGovernanceOutcome(outcome: GovernanceAuditOutcome): WorkLedgerStatus {
+  return outcome === 'failed' ? 'failed' : 'succeeded'
+}
+
+function titleWithPrefix(prefix: string, title: string) {
+  return title.toLowerCase().startsWith(prefix.toLowerCase()) ? title : `${prefix}: ${title}`
+}
+
+function threadEntries(threads: ThreadListItem[]): WorkLedgerUpsertInput[] {
+  return threads.map((thread) => {
+    const status = mapThreadStatus(thread.status)
+    return {
+      id: sourceId('thread', thread.sessionId),
+      sourceKind: 'thread',
+      sourceId: thread.sessionId,
+      title: thread.title || 'New session',
+      summary: thread.changeSummary?.files
+        ? `${thread.changeSummary.files} files changed, ${thread.changeSummary.additions} additions, ${thread.changeSummary.deletions} deletions.`
+        : null,
+      status,
+      sourceLabel: thread.projectLabel || thread.directory || 'Thread',
+      owner: thread.projectLabel || null,
+      agents: thread.actualAgents.map((agent) => agent.name),
+      capabilities: thread.actualTools.map((tool) => tool.name),
+      usage: {
+        cost: thread.usage.cost,
+        tokens: thread.usage.tokens,
+      },
+      riskLabels: [],
+      governanceLabels: compactStrings([
+        thread.automationId ? 'automation-linked' : null,
+        thread.revertedMessageId ? 'reverted' : null,
+      ]),
+      reviewState: reviewFromStatus(status),
+      needsUserAttention: status === 'needs_user',
+      sourceRef: {
+        kind: 'thread',
+        id: thread.sessionId,
+        sessionId: thread.sessionId,
+        automationId: thread.automationId,
+        automationRunId: thread.runId,
+      },
+      route: routeForThread(thread.sessionId),
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      startedAt: null,
+      finishedAt: null,
+    }
+  })
+}
+
+function automationEntries(snapshot: AutomationListPayload): WorkLedgerUpsertInput[] {
+  const entries: WorkLedgerUpsertInput[] = []
+  const automations = new Map(snapshot.automations.map((automation) => [automation.id, automation]))
+  for (const automation of snapshot.automations) {
+    const status = mapAutomationStatus(automation.status)
+    entries.push({
+      id: sourceId('automation', automation.id),
+      sourceKind: 'automation',
+      sourceId: automation.id,
+      title: automation.title,
+      summary: automation.goal,
+      status,
+      sourceLabel: 'Automation',
+      owner: automation.projectDirectory,
+      agents: automation.preferredAgentNames,
+      capabilities: [],
+      usage: emptyUsage(),
+      riskLabels: [],
+      governanceLabels: compactStrings([automation.autonomyPolicy, automation.executionMode, automation.kind]),
+      reviewState: automation.status === 'needs_user' ? 'needs_review' : reviewFromStatus(status),
+      needsUserAttention: automation.status === 'needs_user' || automation.latestRunStatus === 'needs_user',
+      sourceRef: {
+        kind: 'automation',
+        id: automation.id,
+        automationId: automation.id,
+        automationRunId: automation.latestRunId,
+      },
+      route: automationRoute(automation.id, automation.latestRunId),
+      createdAt: automation.createdAt,
+      updatedAt: automation.updatedAt,
+      startedAt: automation.lastRunAt,
+      finishedAt: null,
+    })
+  }
+  for (const run of snapshot.runs) {
+    const automation = automations.get(run.automationId)
+    const status = mapAutomationRunStatus(run.status)
+    entries.push({
+      id: sourceId('automation_run', run.id),
+      sourceKind: 'automation_run',
+      sourceId: run.id,
+      title: run.title,
+      summary: run.summary,
+      status,
+      sourceLabel: automation?.title || 'Automation run',
+      owner: automation?.projectDirectory || null,
+      agents: automation?.preferredAgentNames || [],
+      capabilities: [],
+      usage: emptyUsage(),
+      riskLabels: compactStrings([run.failureCode || null]),
+      governanceLabels: compactStrings([run.kind, run.retryOfRunId ? 'retry' : null]),
+      reviewState: reviewFromStatus(status),
+      needsUserAttention: status === 'needs_user' || status === 'failed',
+      sourceRef: {
+        kind: 'automation_run',
+        id: run.id,
+        automationId: run.automationId,
+        automationRunId: run.id,
+        sessionId: run.sessionId,
+      },
+      route: automationRoute(run.automationId, run.id, run.sessionId),
+      createdAt: run.createdAt,
+      updatedAt: run.finishedAt || run.startedAt || run.createdAt,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt,
+    })
+  }
+  for (const item of snapshot.workItems) {
+    const automation = automations.get(item.automationId)
+    const status = mapAutomationWorkItemStatus(item.status)
+    entries.push({
+      id: sourceId('delegated_task', `automation_work_item:${item.id}`),
+      sourceKind: 'delegated_task',
+      sourceId: `automation_work_item:${item.id}`,
+      title: titleWithPrefix('Automation task', item.title),
+      summary: item.description,
+      status,
+      sourceLabel: automation?.title || 'Automation work item',
+      owner: item.ownerAgent,
+      agents: compactStrings([item.ownerAgent]),
+      capabilities: [],
+      usage: emptyUsage(),
+      riskLabels: [],
+      governanceLabels: compactStrings([item.blockingReason ? 'blocked' : null]),
+      reviewState: item.status === 'blocked' ? 'needs_review' : reviewFromStatus(status),
+      needsUserAttention: item.status === 'blocked' || item.status === 'failed',
+      sourceRef: {
+        kind: 'delegated_task',
+        id: item.id,
+        automationId: item.automationId,
+        automationRunId: item.runId,
+      },
+      route: automationRoute(item.automationId, item.runId),
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+      startedAt: null,
+      finishedAt: null,
+    })
+  }
+  for (const item of snapshot.inbox) {
+    entries.push(automationInboxEntry(item, automations.get(item.automationId)))
+  }
+  for (const delivery of snapshot.deliveries) {
+    const automation = automations.get(delivery.automationId)
+    const status: WorkLedgerStatus = delivery.status === 'delivered' ? 'delivered' : 'failed'
+    entries.push({
+      id: sourceId('delivery', `automation_delivery:${delivery.id}`),
+      sourceKind: 'delivery',
+      sourceId: `automation_delivery:${delivery.id}`,
+      title: titleWithPrefix('Delivery', delivery.title),
+      summary: null,
+      status,
+      sourceLabel: automation?.title || 'Automation delivery',
+      owner: automation?.projectDirectory || null,
+      agents: automation?.preferredAgentNames || [],
+      capabilities: compactStrings([delivery.provider]),
+      usage: emptyUsage(),
+      riskLabels: [],
+      governanceLabels: compactStrings([delivery.status]),
+      reviewState: reviewFromStatus(status),
+      needsUserAttention: delivery.status === 'failed',
+      sourceRef: {
+        kind: 'delivery',
+        id: delivery.id,
+        automationId: delivery.automationId,
+        automationRunId: delivery.runId,
+        deliveryId: delivery.id,
+      },
+      route: automationRoute(delivery.automationId, delivery.runId),
+      createdAt: delivery.createdAt,
+      updatedAt: delivery.createdAt,
+      startedAt: null,
+      finishedAt: delivery.createdAt,
+    })
+  }
+  return entries
+}
+
+function automationInboxEntry(item: AutomationInboxItem, automation?: AutomationListPayload['automations'][number]): WorkLedgerUpsertInput {
+  const sourceKind: WorkLedgerSourceKind = item.type === 'approval'
+    ? 'approval'
+    : item.type === 'clarification'
+      ? 'question'
+      : 'governance_incident'
+  const status: WorkLedgerStatus = item.status === 'open'
+    ? item.type === 'approval' ? 'approval_required' : 'needs_user'
+    : item.status === 'dismissed' ? 'dismissed' : 'completed'
+  return {
+    id: sourceId(sourceKind, `automation_inbox:${item.id}`),
+    sourceKind,
+    sourceId: `automation_inbox:${item.id}`,
+    title: item.title,
+    summary: null,
+    status,
+    sourceLabel: automation?.title || 'Automation inbox',
+    owner: automation?.projectDirectory || null,
+    agents: automation?.preferredAgentNames || [],
+    capabilities: [],
+    usage: emptyUsage(),
+    riskLabels: item.type === 'failure' ? ['failure'] : [],
+    governanceLabels: compactStrings([item.type, item.status]),
+    reviewState: item.status === 'open'
+      ? item.type === 'approval' ? 'approval_requested' : 'needs_review'
+      : 'resolved',
+    needsUserAttention: item.status === 'open' && (item.type === 'approval' || item.type === 'clarification' || item.type === 'failure'),
+    sourceRef: {
+      kind: sourceKind,
+      id: item.id,
+      automationId: item.automationId,
+      automationRunId: item.runId,
+      sessionId: item.sessionId,
+      questionId: item.questionId,
+      approvalId: item.type === 'approval' ? item.id : null,
+    },
+    route: automationRoute(item.automationId, item.runId, item.sessionId),
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    startedAt: null,
+    finishedAt: item.status === 'open' ? null : item.updatedAt,
+  }
+}
+
+function crewEntries(snapshot: WorkLedgerCrewSnapshot): WorkLedgerUpsertInput[] {
+  const entries: WorkLedgerUpsertInput[] = []
+  const crewItems = new Map(snapshot.catalog.crews.map((item) => [item.definition.id, item]))
+  const runs = new Map(snapshot.runs.map((run) => [run.id, run]))
+  const workItems = new Map(snapshot.workItems.map((item) => [item.id, item]))
+  for (const item of snapshot.catalog.crews) {
+    const status = item.definition.status as WorkLedgerStatus
+    entries.push({
+      id: sourceId('crew', item.definition.id),
+      sourceKind: 'crew',
+      sourceId: item.definition.id,
+      title: item.definition.name,
+      summary: item.definition.description,
+      status,
+      sourceLabel: 'Crew',
+      owner: item.activeVersion?.workspaceProfileId || null,
+      agents: compactStrings(item.activeVersion?.members.map((member) => member.agentName) || []),
+      capabilities: compactStrings([item.activeVersion?.evalSuiteId || null, item.activeVersion?.outcomeRubricId || null]),
+      usage: emptyUsage(),
+      riskLabels: compactStrings([item.activeVersion?.certificationStatus === 'required' ? 'certification-required' : null]),
+      governanceLabels: compactStrings([item.definition.status]),
+      reviewState: item.definition.status === 'review' ? 'needs_review' : reviewFromStatus(status),
+      needsUserAttention: item.definition.status === 'review',
+      sourceRef: {
+        kind: 'crew',
+        id: item.definition.id,
+        crewId: item.definition.id,
+        crewRunId: item.latestRun?.id,
+      },
+      route: crewRoute(item.definition.id, item.latestRun?.id),
+      createdAt: item.definition.createdAt,
+      updatedAt: item.definition.updatedAt,
+      startedAt: item.latestRun?.startedAt || null,
+      finishedAt: item.latestRun?.finishedAt || null,
+    })
+  }
+  for (const run of snapshot.runs) {
+    const crew = crewItems.get(run.crewId)
+    const workItem = run.workItemId ? workItems.get(run.workItemId) : null
+    const status = mapCrewRunStatus(run.status)
+    entries.push({
+      id: sourceId('crew_run', run.id),
+      sourceKind: 'crew_run',
+      sourceId: run.id,
+      title: run.title,
+      summary: run.summary || workItem?.description || null,
+      status,
+      sourceLabel: crew?.definition.name || 'Crew run',
+      owner: crew?.activeVersion?.workspaceProfileId || null,
+      agents: compactStrings(crew?.activeVersion?.members.map((member) => member.agentName) || []),
+      capabilities: [],
+      usage: emptyUsage(),
+      riskLabels: [],
+      governanceLabels: compactStrings([workItem?.source || null]),
+      reviewState: reviewFromStatus(status),
+      needsUserAttention: status === 'blocked' || status === 'failed',
+      sourceRef: {
+        kind: 'crew_run',
+        id: run.id,
+        crewId: run.crewId,
+        crewRunId: run.id,
+        sessionId: run.rootSessionId,
+      },
+      route: crewRoute(run.crewId, run.id, run.rootSessionId),
+      createdAt: run.createdAt,
+      updatedAt: run.finishedAt || run.startedAt || run.createdAt,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt,
+    })
+  }
+  for (const node of snapshot.nodes) {
+    if (!node.agentName && node.kind !== 'delegate') continue
+    const run = runs.get(node.crewRunId)
+    const crew = run ? crewItems.get(run.crewId) : null
+    const status = mapCrewNodeStatus(node.status)
+    entries.push({
+      id: sourceId('delegated_task', `crew_node:${node.id}`),
+      sourceKind: 'delegated_task',
+      sourceId: `crew_node:${node.id}`,
+      title: titleWithPrefix('Crew task', node.title),
+      summary: null,
+      status,
+      sourceLabel: crew?.definition.name || 'Crew task',
+      owner: node.agentName,
+      agents: compactStrings([node.agentName]),
+      capabilities: [],
+      usage: emptyUsage(),
+      riskLabels: [],
+      governanceLabels: compactStrings([node.kind]),
+      reviewState: reviewFromStatus(status),
+      needsUserAttention: status === 'blocked' || status === 'failed',
+      sourceRef: {
+        kind: 'delegated_task',
+        id: node.id,
+        crewId: run?.crewId || null,
+        crewRunId: node.crewRunId,
+        crewNodeId: node.id,
+        sessionId: node.sessionId,
+      },
+      route: crewRoute(run?.crewId, node.crewRunId, node.sessionId),
+      createdAt: node.startedAt || run?.createdAt || new Date(0).toISOString(),
+      updatedAt: node.finishedAt || node.startedAt || run?.createdAt || new Date(0).toISOString(),
+      startedAt: node.startedAt,
+      finishedAt: node.finishedAt,
+    })
+  }
+  for (const approval of snapshot.approvals) {
+    const run = runs.get(approval.crewRunId)
+    const crew = run ? crewItems.get(run.crewId) : null
+    const status = mapCrewApprovalStatus(approval.status)
+    entries.push({
+      id: sourceId('approval', `crew_approval:${approval.id}`),
+      sourceKind: 'approval',
+      sourceId: `crew_approval:${approval.id}`,
+      title: titleWithPrefix('Approval', approval.title),
+      summary: null,
+      status,
+      sourceLabel: crew?.definition.name || 'Crew approval',
+      owner: approval.resolvedBy,
+      agents: compactStrings(crew?.activeVersion?.members.map((member) => member.agentName) || []),
+      capabilities: [],
+      usage: emptyUsage(),
+      riskLabels: [],
+      governanceLabels: compactStrings([approval.status]),
+      reviewState: approval.status === 'requested' ? 'approval_requested' : approval.status === 'approved' ? 'approved' : approval.status === 'denied' ? 'denied' : 'resolved',
+      needsUserAttention: approval.status === 'requested',
+      sourceRef: {
+        kind: 'approval',
+        id: approval.id,
+        crewId: run?.crewId || null,
+        crewRunId: approval.crewRunId,
+        crewNodeId: approval.nodeId,
+        approvalId: approval.id,
+      },
+      route: crewRoute(run?.crewId, approval.crewRunId),
+      createdAt: approval.requestedAt,
+      updatedAt: approval.resolvedAt || approval.requestedAt,
+      startedAt: approval.requestedAt,
+      finishedAt: approval.resolvedAt,
+    })
+  }
+  for (const decision of snapshot.policyDecisions) {
+    const run = runs.get(decision.runId)
+    const status = mapPolicyStatus(decision.status)
+    entries.push({
+      id: sourceId('approval', `policy_decision:${decision.id}`),
+      sourceKind: 'approval',
+      sourceId: `policy_decision:${decision.id}`,
+      title: `Policy decision: ${decision.capabilityId || decision.runKind}`,
+      summary: decision.reason,
+      status,
+      sourceLabel: 'Policy decision',
+      owner: null,
+      agents: [],
+      capabilities: compactStrings([decision.capabilityId]),
+      usage: emptyUsage(),
+      riskLabels: decision.status === 'denied' || decision.status === 'approval_required' ? ['policy'] : [],
+      governanceLabels: compactStrings([decision.status, decision.runKind]),
+      reviewState: decision.status === 'approval_required' ? 'approval_requested' : decision.status === 'denied' ? 'denied' : 'approved',
+      needsUserAttention: decision.status === 'approval_required' || decision.status === 'denied',
+      sourceRef: {
+        kind: 'approval',
+        id: decision.id,
+        crewId: run?.crewId || null,
+        crewRunId: decision.runId,
+        crewNodeId: decision.nodeId,
+        approvalId: decision.id,
+      },
+      route: crewRoute(run?.crewId, decision.runId),
+      createdAt: decision.createdAt,
+      updatedAt: decision.createdAt,
+      startedAt: null,
+      finishedAt: decision.status === 'approval_required' ? null : decision.createdAt,
+    })
+  }
+  for (const artifact of snapshot.artifacts) {
+    const run = runs.get(artifact.crewRunId)
+    entries.push({
+      id: sourceId('delivery', `crew_artifact:${artifact.id}`),
+      sourceKind: 'delivery',
+      sourceId: `crew_artifact:${artifact.id}`,
+      title: titleWithPrefix('Artifact', artifact.title),
+      summary: null,
+      status: 'delivered',
+      sourceLabel: 'Crew artifact',
+      owner: null,
+      agents: [],
+      capabilities: compactStrings([artifact.mime]),
+      usage: emptyUsage(),
+      riskLabels: [],
+      governanceLabels: ['artifact'],
+      reviewState: 'resolved',
+      needsUserAttention: false,
+      sourceRef: {
+        kind: 'delivery',
+        id: artifact.id,
+        crewId: run?.crewId || null,
+        crewRunId: artifact.crewRunId,
+        crewNodeId: artifact.nodeId,
+        artifactId: artifact.id,
+      },
+      route: crewRoute(run?.crewId, artifact.crewRunId),
+      createdAt: artifact.createdAt,
+      updatedAt: artifact.createdAt,
+      startedAt: null,
+      finishedAt: artifact.createdAt,
+    })
+  }
+  return entries
+}
+
+function channelEntries(snapshot: ChannelListPayload): WorkLedgerUpsertInput[] {
+  const entries: WorkLedgerUpsertInput[] = []
+  const channels = new Map(snapshot.channels.map((channel) => [channel.id, channel]))
+  for (const item of snapshot.inboundItems) entries.push(channelInboundEntry(item, channels.get(item.channelId)?.name || 'Channel event'))
+  for (const delivery of snapshot.deliveries) entries.push(channelDeliveryEntry(delivery, channels.get(delivery.channelId)?.name || 'Channel delivery'))
+  return entries
+}
+
+function channelInboundEntry(item: ChannelInboundItem, sourceLabel: string): WorkLedgerUpsertInput {
+  const status = item.status as WorkLedgerStatus
+  return {
+    id: sourceId('channel_event', `channel_inbound:${item.id}`),
+    sourceKind: 'channel_event',
+    sourceId: `channel_inbound:${item.id}`,
+    title: item.subject || `${item.provider} inbound message`,
+    summary: null,
+    status,
+    sourceLabel,
+    owner: item.sender,
+    agents: [],
+    capabilities: item.allowedCapabilityIds,
+    usage: emptyUsage(),
+    riskLabels: item.status === 'denied' || item.status === 'failed' ? [item.auditState] : [],
+    governanceLabels: compactStrings([item.auditState, item.route.activationMode]),
+    reviewState: item.status === 'needs_user' ? 'needs_review' : reviewFromStatus(status),
+    needsUserAttention: item.status === 'needs_user' || item.status === 'failed',
+    sourceRef: {
+      kind: 'channel_event',
+      id: item.id,
+      channelId: item.channelId,
+      channelEventId: item.id,
+      deliveryId: item.deliveryRecordId,
+    },
+    route: channelRoute(item.channelId),
+    createdAt: item.receivedAt,
+    updatedAt: item.updatedAt,
+    startedAt: null,
+    finishedAt: item.status === 'dispatched' || item.status === 'failed' || item.status === 'denied' ? item.updatedAt : null,
+  }
+}
+
+function channelDeliveryEntry(delivery: ChannelDeliveryRecord, sourceLabel: string): WorkLedgerUpsertInput {
+  const status = delivery.status as WorkLedgerStatus
+  return {
+    id: sourceId('delivery', `channel_delivery:${delivery.id}`),
+    sourceKind: 'delivery',
+    sourceId: `channel_delivery:${delivery.id}`,
+    title: titleWithPrefix('Delivery', delivery.title),
+    summary: null,
+    status,
+    sourceLabel,
+    owner: delivery.target,
+    agents: [],
+    capabilities: compactStrings([delivery.provider, ...delivery.artifactIds.map((id) => `artifact:${id}`)]),
+    usage: emptyUsage(),
+    riskLabels: delivery.status === 'failed' ? ['delivery_failed'] : [],
+    governanceLabels: compactStrings([
+      delivery.draftFirst ? 'draft-first' : null,
+      delivery.runKind,
+      ...delivery.policyDecisionIds.map((id) => `policy:${id}`),
+    ]),
+    reviewState: delivery.status === 'approval_required' ? 'approval_requested' : reviewFromStatus(status),
+    needsUserAttention: delivery.status === 'approval_required' || delivery.status === 'failed',
+    sourceRef: {
+      kind: 'delivery',
+      id: delivery.id,
+      channelId: delivery.channelId,
+      channelEventId: delivery.inboundItemId,
+      deliveryId: delivery.id,
+    },
+    route: channelRoute(delivery.channelId),
+    createdAt: delivery.createdAt,
+    updatedAt: delivery.updatedAt,
+    startedAt: delivery.status === 'sending' ? delivery.updatedAt : null,
+    finishedAt: delivery.status === 'delivered' || delivery.status === 'failed' || delivery.status === 'cancelled' ? delivery.updatedAt : null,
+  }
+}
+
+function governanceEntries(events: GovernanceAuditEvent[]): WorkLedgerUpsertInput[] {
+  return events.map((event) => {
+    const status = mapGovernanceOutcome(event.outcome)
+    return {
+      id: sourceId('governance_incident', event.id),
+      sourceKind: 'governance_incident',
+      sourceId: event.id,
+      title: `Governance: ${event.action.replaceAll('_', ' ')}`,
+      summary: event.reason,
+      status,
+      sourceLabel: event.subjectKind,
+      owner: event.actor.displayName,
+      agents: event.subjectKind === 'agent' ? [event.subjectId] : [],
+      capabilities: event.subjectKind === 'tool' ? [event.subjectId] : [],
+      usage: emptyUsage(),
+      riskLabels: event.outcome === 'failed' ? ['incident-control-failed'] : [],
+      governanceLabels: compactStrings([event.kind, event.action, event.subjectKind, event.outcome]),
+      reviewState: event.outcome === 'failed' ? 'failed' : 'resolved',
+      needsUserAttention: event.outcome === 'failed',
+      sourceRef: {
+        kind: 'governance_incident',
+        id: event.id,
+        governanceAuditEventId: event.id,
+      },
+      route: governanceRoute(event.id),
+      createdAt: event.createdAt,
+      updatedAt: event.createdAt,
+      startedAt: null,
+      finishedAt: event.createdAt,
+    }
+  })
+}
+
+export function buildWorkLedgerEntriesFromSnapshot(snapshot: WorkLedgerSnapshot): WorkLedgerUpsertInput[] {
+  return [
+    ...threadEntries(snapshot.threads),
+    ...automationEntries(snapshot.automations),
+    ...crewEntries(snapshot.crews),
+    ...channelEntries(snapshot.channels),
+    ...governanceEntries(snapshot.governanceAuditEvents),
+  ]
+}
+
+function loadAllIndexedThreads() {
+  const service = getThreadIndexService()
+  const threads: ThreadListItem[] = []
+  let cursor: string | null = null
+  do {
+    const result = service.search({ limit: RECENT_THREAD_PAGE_LIMIT, cursor })
+    threads.push(...result.threads)
+    cursor = result.nextCursor
+  } while (cursor)
+  return threads
+}
+
+function loadDurableSnapshot(): WorkLedgerSnapshot {
+  const runs = listCrewRunsForAudit()
+  return {
+    threads: loadAllIndexedThreads(),
+    automations: listAutomationState(),
+    crews: {
+      catalog: listCrewCatalog(),
+      runs,
+      nodes: runs.flatMap((run) => listCrewRunNodes(run.id)),
+      workItems: listCoworkWorkItems(),
+      approvals: listCrewApprovalsForAudit(),
+      policyDecisions: listPolicyDecisionsForAudit(),
+      artifacts: runs.flatMap((run) => listCrewArtifactsForRun(run.id)),
+    },
+    channels: listChannelState(),
+    governanceAuditEvents: listGovernanceAuditEvents({ limit: RECENT_GOVERNANCE_AUDIT_LIMIT }),
+  }
+}
+
+export class WorkLedgerService {
+  private lastRefreshAt = 0
+  private readonly store: WorkLedgerStore
+  private readonly loadSnapshot: WorkLedgerSnapshotLoader
+
+  constructor(store: WorkLedgerStore = getWorkLedgerStore(), options: { loadSnapshot?: WorkLedgerSnapshotLoader } = {}) {
+    this.store = store
+    this.loadSnapshot = options.loadSnapshot || loadDurableSnapshot
+  }
+
+  reindex() {
+    const snapshot = this.loadSnapshot()
+    const entries = this.store.upsertEntries(buildWorkLedgerEntriesFromSnapshot(snapshot))
+    this.store.deleteEntriesNotIn(entries.map((entry) => entry.id))
+    this.lastRefreshAt = Date.now()
+    return true
+  }
+
+  private ensureFresh() {
+    if (Date.now() - this.lastRefreshAt < LEDGER_REFRESH_TTL_MS) return
+    try {
+      this.reindex()
+    } catch (err) {
+      log('work-ledger', `Reindex failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  search(query?: WorkLedgerSearchQuery) {
+    this.ensureFresh()
+    return this.store.searchEntries(normalizeWorkLedgerSearchQuery(query))
+  }
+
+  facets(query?: WorkLedgerSearchQuery) {
+    this.ensureFresh()
+    return this.store.listFacets(normalizeWorkLedgerSearchQuery(query))
+  }
+}
+
+let workLedgerService: WorkLedgerService | null = null
+
+export function getWorkLedgerService() {
+  if (!workLedgerService) workLedgerService = new WorkLedgerService()
+  return workLedgerService
+}
+
+export function clearWorkLedgerServiceCache() {
+  workLedgerService = null
+}

--- a/apps/desktop/src/main/work-ledger-store.ts
+++ b/apps/desktop/src/main/work-ledger-store.ts
@@ -1,0 +1,780 @@
+import { chmodSync, existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync, type SQLInputValue } from 'node:sqlite'
+import type {
+  WorkLedgerDrilldownRoute,
+  WorkLedgerEntry,
+  WorkLedgerFacetBucket,
+  WorkLedgerFacetSummary,
+  WorkLedgerReviewState,
+  WorkLedgerSearchQuery,
+  WorkLedgerSearchResult,
+  WorkLedgerSort,
+  WorkLedgerSourceKind,
+  WorkLedgerSourceRef,
+  WorkLedgerStatus,
+  WorkLedgerUpsertInput,
+} from '@open-cowork/shared'
+import {
+  COWORK_WORK_LEDGER_SCHEMA_VERSION,
+  WORK_LEDGER_FILTER_MAX_VALUES,
+  WORK_LEDGER_QUERY_MAX_LENGTH,
+  WORK_LEDGER_SEARCH_DEFAULT_LIMIT,
+  WORK_LEDGER_SEARCH_MAX_LIMIT,
+} from '@open-cowork/shared'
+import { getAppDataDir } from './config-loader.ts'
+
+export const WORK_LEDGER_SCHEMA_VERSION = 1
+const WORK_LEDGER_SCHEMA_VERSION_KEY = 'schema_version'
+const WORK_LEDGER_METADATA_VERSION = 1
+const MAX_ENTRY_TEXT_BYTES = 512
+const MAX_SUMMARY_BYTES = 1024
+const MAX_JSON_BYTES = 16 * 1024
+
+const SOURCE_KINDS = new Set<WorkLedgerSourceKind>([
+  'thread',
+  'automation',
+  'automation_run',
+  'crew',
+  'crew_run',
+  'delegated_task',
+  'approval',
+  'question',
+  'delivery',
+  'channel_event',
+  'governance_incident',
+])
+
+const STATUSES = new Set<WorkLedgerStatus>([
+  'active',
+  'approval_required',
+  'approved',
+  'archived',
+  'automation',
+  'blocked',
+  'cancelled',
+  'completed',
+  'delivered',
+  'delivering',
+  'denied',
+  'dispatching',
+  'dispatched',
+  'dismissed',
+  'draft',
+  'drafted',
+  'enriching',
+  'error',
+  'evaluating',
+  'failed',
+  'idle',
+  'needs_user',
+  'paused',
+  'planning',
+  'queued',
+  'ready',
+  'received',
+  'retired',
+  'reverted',
+  'review',
+  'running',
+  'sending',
+  'succeeded',
+  'unknown',
+])
+
+const REVIEW_STATES = new Set<WorkLedgerReviewState>([
+  'none',
+  'needs_review',
+  'approval_requested',
+  'approved',
+  'denied',
+  'resolved',
+  'failed',
+])
+
+type Row = Record<string, unknown>
+type WhereClause = { sql: string; args: SQLInputValue[] }
+
+let workLedgerStore: WorkLedgerStore | null = null
+
+function getWorkLedgerDbPath() {
+  const dir = getAppDataDir()
+  mkdirSync(dir, { recursive: true })
+  return join(dir, 'work-ledger.sqlite')
+}
+
+function ensureWorkLedgerDbFileModes(dbPath: string) {
+  if (process.platform === 'win32') return
+  for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (!existsSync(path)) continue
+    chmodSync(path, 0o600)
+  }
+}
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function asString(value: unknown, fallback = '') {
+  return typeof value === 'string' ? value : fallback
+}
+
+function asNullableString(value: unknown) {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function asNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : Number(value) || 0
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number) {
+  const next = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(next)) return fallback
+  return Math.max(min, Math.min(max, Math.trunc(next)))
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== 'string' || !value.trim()) return fallback
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+function json(value: unknown) {
+  return JSON.stringify(value)
+}
+
+export function redactWorkLedgerText(value: string) {
+  return value
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._~+/=-]{8,}/gi, '$1 [redacted]')
+    .replace(/\b(api[_-]?key|authorization|credential|password|secret|token)\s*[:=]\s*([^\s,;]+)/gi, '$1=[redacted]')
+}
+
+function normalizeText(value: unknown, maxLength: number, field: string) {
+  if (typeof value !== 'string') throw new Error(`${field} must be a string.`)
+  const trimmed = redactWorkLedgerText(value.trim())
+  if (!trimmed) throw new Error(`${field} is required.`)
+  if (Buffer.byteLength(trimmed, 'utf8') > maxLength) throw new Error(`${field} exceeds ${maxLength} bytes.`)
+  return trimmed
+}
+
+function normalizeOptionalText(value: unknown, maxLength: number, field: string) {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') throw new Error(`${field} must be a string.`)
+  const trimmed = redactWorkLedgerText(value.trim())
+  if (!trimmed) return null
+  if (Buffer.byteLength(trimmed, 'utf8') > maxLength) throw new Error(`${field} exceeds ${maxLength} bytes.`)
+  return trimmed
+}
+
+function normalizeOptionalQueryText(value: unknown) {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') throw new Error('Work ledger query text must be a string.')
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  if (Buffer.byteLength(trimmed, 'utf8') > WORK_LEDGER_QUERY_MAX_LENGTH) {
+    throw new Error(`Work ledger query text exceeds ${WORK_LEDGER_QUERY_MAX_LENGTH} bytes.`)
+  }
+  return trimmed
+}
+
+function normalizeIdList(value: unknown, field: string, max = WORK_LEDGER_FILTER_MAX_VALUES) {
+  if (value === undefined || value === null) return undefined
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array.`)
+  if (value.length > max) throw new Error(`${field} exceeds ${max} values.`)
+  const entries = value.map((item) => {
+    if (typeof item !== 'string') throw new Error(`${field} entries must be strings.`)
+    const trimmed = item.trim()
+    if (!trimmed || trimmed.length > 256) throw new Error(`${field} contains an invalid entry.`)
+    return trimmed
+  })
+  return Array.from(new Set(entries))
+}
+
+function normalizeSourceKinds(value: unknown) {
+  const values = normalizeIdList(value, 'sourceKinds')
+  if (!values) return undefined
+  return values.map((kind) => {
+    if (!SOURCE_KINDS.has(kind as WorkLedgerSourceKind)) throw new Error(`Invalid work ledger source kind: ${kind}`)
+    return kind as WorkLedgerSourceKind
+  })
+}
+
+function normalizeStatuses(value: unknown) {
+  const values = normalizeIdList(value, 'statuses')
+  if (!values) return undefined
+  return values.map((status) => {
+    if (!STATUSES.has(status as WorkLedgerStatus)) throw new Error(`Invalid work ledger status: ${status}`)
+    return status as WorkLedgerStatus
+  })
+}
+
+function normalizeReviewStates(value: unknown) {
+  const values = normalizeIdList(value, 'reviewStates')
+  if (!values) return undefined
+  return values.map((state) => {
+    if (!REVIEW_STATES.has(state as WorkLedgerReviewState)) throw new Error(`Invalid work ledger review state: ${state}`)
+    return state as WorkLedgerReviewState
+  })
+}
+
+function normalizeDateRange(value: unknown) {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'object' || Array.isArray(value)) throw new Error('dateRange must be an object.')
+  const input = value as { from?: unknown; to?: unknown }
+  const from = typeof input.from === 'string' && input.from.trim() ? input.from.trim() : undefined
+  const to = typeof input.to === 'string' && input.to.trim() ? input.to.trim() : undefined
+  return from || to ? { from, to } : undefined
+}
+
+function normalizeSort(value: unknown): WorkLedgerSort {
+  if (value === undefined || value === null) return 'updated_desc'
+  if (value === 'updated_desc' || value === 'created_desc' || value === 'title_asc') return value
+  throw new Error(`Invalid work ledger sort: ${String(value)}`)
+}
+
+export function normalizeWorkLedgerSearchQuery(input: unknown = {}): WorkLedgerSearchQuery {
+  if (input === undefined || input === null) return { limit: WORK_LEDGER_SEARCH_DEFAULT_LIMIT, sort: 'updated_desc' }
+  if (typeof input !== 'object' || Array.isArray(input)) throw new Error('Work ledger search query must be an object.')
+  const query = input as WorkLedgerSearchQuery
+  return {
+    text: normalizeOptionalQueryText(query.text),
+    cursor: typeof query.cursor === 'string' && query.cursor.trim() ? query.cursor.trim() : null,
+    limit: clampInteger(query.limit, WORK_LEDGER_SEARCH_DEFAULT_LIMIT, 1, WORK_LEDGER_SEARCH_MAX_LIMIT),
+    dateRange: normalizeDateRange(query.dateRange),
+    sourceKinds: normalizeSourceKinds(query.sourceKinds),
+    statuses: normalizeStatuses(query.statuses),
+    owners: normalizeIdList(query.owners, 'owners'),
+    agents: normalizeIdList(query.agents, 'agents'),
+    capabilities: normalizeIdList(query.capabilities, 'capabilities'),
+    riskLabels: normalizeIdList(query.riskLabels, 'riskLabels'),
+    governanceLabels: normalizeIdList(query.governanceLabels, 'governanceLabels'),
+    reviewStates: normalizeReviewStates(query.reviewStates),
+    needsUserAttention: typeof query.needsUserAttention === 'boolean' ? query.needsUserAttention : null,
+    sort: normalizeSort(query.sort),
+  }
+}
+
+function likePattern(text: string) {
+  return `%${text.toLowerCase().replace(/[\\%_]/g, (match) => `\\${match}`)}%`
+}
+
+function makePlaceholders(values: unknown[]) {
+  return values.map(() => '?').join(', ')
+}
+
+function encodeCursor(offset: number) {
+  return Buffer.from(JSON.stringify({ offset }), 'utf8').toString('base64url')
+}
+
+function decodeCursor(cursor?: string | null) {
+  if (!cursor) return 0
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as { offset?: unknown }
+    return clampInteger(parsed.offset, 0, 0, Number.MAX_SAFE_INTEGER)
+  } catch {
+    throw new Error('Invalid work ledger cursor.')
+  }
+}
+
+function sortSql(sort: WorkLedgerSort | undefined) {
+  if (sort === 'created_desc') return 'created_at desc, id asc'
+  if (sort === 'title_asc') return 'lower(title) asc, updated_at desc, id asc'
+  return 'updated_at desc, id asc'
+}
+
+function tokensFromRow(row: Row) {
+  return {
+    input: asNumber(row.input_tokens),
+    output: asNumber(row.output_tokens),
+    reasoning: asNumber(row.reasoning_tokens),
+    cacheRead: asNumber(row.cache_read_tokens),
+    cacheWrite: asNumber(row.cache_write_tokens),
+  }
+}
+
+function normalizeSidecarValues(values: string[] | undefined, field: string) {
+  if (!values) return []
+  return (normalizeIdList(values, field, WORK_LEDGER_FILTER_MAX_VALUES) || [])
+    .map((value) => redactWorkLedgerText(value))
+}
+
+function assertJsonSize(value: unknown, label: string) {
+  const serialized = json(value)
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_JSON_BYTES) throw new Error(`${label} is too large.`)
+  return serialized
+}
+
+function normalizeEntry(input: WorkLedgerUpsertInput): WorkLedgerEntry {
+  if (!SOURCE_KINDS.has(input.sourceKind)) throw new Error(`Invalid work ledger source kind: ${input.sourceKind}`)
+  if (!STATUSES.has(input.status)) throw new Error(`Invalid work ledger status: ${input.status}`)
+  if (!REVIEW_STATES.has(input.reviewState)) throw new Error(`Invalid work ledger review state: ${input.reviewState}`)
+  const sourceId = normalizeText(input.sourceId, 512, 'Work ledger source id')
+  const id = normalizeText(input.id || `${input.sourceKind}:${sourceId}`, 768, 'Work ledger id')
+  const sourceRef = { ...input.sourceRef, kind: input.sourceKind, id: input.sourceRef?.id || sourceId } satisfies WorkLedgerSourceRef
+  assertJsonSize(sourceRef, 'Work ledger source reference')
+  assertJsonSize(input.route, 'Work ledger route')
+  return {
+    schemaVersion: input.schemaVersion || COWORK_WORK_LEDGER_SCHEMA_VERSION,
+    id,
+    sourceKind: input.sourceKind,
+    sourceId,
+    title: normalizeText(input.title || 'Untitled work', MAX_ENTRY_TEXT_BYTES, 'Work ledger title'),
+    summary: normalizeOptionalText(input.summary, MAX_SUMMARY_BYTES, 'Work ledger summary'),
+    status: input.status,
+    sourceLabel: normalizeText(input.sourceLabel || input.sourceKind, 256, 'Work ledger source label'),
+    owner: normalizeOptionalText(input.owner, 256, 'Work ledger owner'),
+    agents: normalizeSidecarValues(input.agents, 'agents'),
+    capabilities: normalizeSidecarValues(input.capabilities, 'capabilities'),
+    usage: {
+      cost: Math.max(0, Number(input.usage?.cost || 0) || 0),
+      tokens: {
+        input: Math.max(0, Math.trunc(Number(input.usage?.tokens?.input || 0) || 0)),
+        output: Math.max(0, Math.trunc(Number(input.usage?.tokens?.output || 0) || 0)),
+        reasoning: Math.max(0, Math.trunc(Number(input.usage?.tokens?.reasoning || 0) || 0)),
+        cacheRead: Math.max(0, Math.trunc(Number(input.usage?.tokens?.cacheRead || 0) || 0)),
+        cacheWrite: Math.max(0, Math.trunc(Number(input.usage?.tokens?.cacheWrite || 0) || 0)),
+      },
+    },
+    riskLabels: normalizeSidecarValues(input.riskLabels, 'riskLabels'),
+    governanceLabels: normalizeSidecarValues(input.governanceLabels, 'governanceLabels'),
+    reviewState: input.reviewState,
+    needsUserAttention: Boolean(input.needsUserAttention),
+    sourceRef,
+    route: input.route,
+    createdAt: normalizeText(input.createdAt, 64, 'Work ledger createdAt'),
+    updatedAt: normalizeText(input.updatedAt, 64, 'Work ledger updatedAt'),
+    startedAt: normalizeOptionalText(input.startedAt, 64, 'Work ledger startedAt'),
+    finishedAt: normalizeOptionalText(input.finishedAt, 64, 'Work ledger finishedAt'),
+    indexedAt: input.indexedAt || nowIso(),
+  }
+}
+
+export class WorkLedgerStore {
+  private db: DatabaseSync
+  private transactionCounter = 0
+  private readonly dbPath: string
+
+  constructor(dbPath = getWorkLedgerDbPath()) {
+    this.dbPath = dbPath
+    mkdirSync(join(dbPath, '..'), { recursive: true })
+    this.db = new DatabaseSync(dbPath)
+    try {
+      this.db.exec('pragma journal_mode = WAL;')
+      this.migrate()
+      ensureWorkLedgerDbFileModes(this.dbPath)
+    } catch (error) {
+      this.db.close()
+      throw error
+    }
+  }
+
+  close() {
+    this.db.close()
+  }
+
+  private migrate() {
+    this.db.exec(`
+      create table if not exists work_ledger_meta (
+        key text primary key,
+        value text not null
+      );
+    `)
+    const version = this.readSchemaVersion()
+    if (version > WORK_LEDGER_SCHEMA_VERSION) {
+      throw new Error(`Work ledger schema version ${version} is newer than supported version ${WORK_LEDGER_SCHEMA_VERSION}.`)
+    }
+    this.db.exec(`
+      create table if not exists work_ledger_entries (
+        id text primary key,
+        source_kind text not null,
+        source_id text not null,
+        title text not null,
+        summary text,
+        status text not null,
+        source_label text not null,
+        owner text,
+        created_at text not null,
+        updated_at text not null,
+        started_at text,
+        finished_at text,
+        cost real not null default 0,
+        input_tokens integer not null default 0,
+        output_tokens integer not null default 0,
+        reasoning_tokens integer not null default 0,
+        cache_read_tokens integer not null default 0,
+        cache_write_tokens integer not null default 0,
+        review_state text not null,
+        needs_user_attention integer not null default 0,
+        source_ref_json text not null,
+        route_json text not null,
+        indexed_at text not null,
+        schema_version integer not null,
+        metadata_version integer not null,
+        unique(source_kind, source_id)
+      );
+
+      create table if not exists work_ledger_entry_agents (
+        entry_id text not null,
+        value text not null,
+        primary key(entry_id, value)
+      );
+
+      create table if not exists work_ledger_entry_capabilities (
+        entry_id text not null,
+        value text not null,
+        primary key(entry_id, value)
+      );
+
+      create table if not exists work_ledger_entry_risk_labels (
+        entry_id text not null,
+        value text not null,
+        primary key(entry_id, value)
+      );
+
+      create table if not exists work_ledger_entry_governance_labels (
+        entry_id text not null,
+        value text not null,
+        primary key(entry_id, value)
+      );
+
+      create index if not exists idx_work_ledger_updated on work_ledger_entries(updated_at desc, id);
+      create index if not exists idx_work_ledger_created on work_ledger_entries(created_at desc, id);
+      create index if not exists idx_work_ledger_title on work_ledger_entries(lower(title), id);
+      create index if not exists idx_work_ledger_source on work_ledger_entries(source_kind, source_id);
+      create index if not exists idx_work_ledger_status on work_ledger_entries(status);
+      create index if not exists idx_work_ledger_owner on work_ledger_entries(owner);
+      create index if not exists idx_work_ledger_attention on work_ledger_entries(needs_user_attention, updated_at desc);
+      create index if not exists idx_work_ledger_review on work_ledger_entries(review_state);
+      create index if not exists idx_work_ledger_agents_value on work_ledger_entry_agents(value);
+      create index if not exists idx_work_ledger_capabilities_value on work_ledger_entry_capabilities(value);
+      create index if not exists idx_work_ledger_risk_value on work_ledger_entry_risk_labels(value);
+      create index if not exists idx_work_ledger_governance_value on work_ledger_entry_governance_labels(value);
+    `)
+    this.recordSchemaVersion()
+  }
+
+  private readSchemaVersion() {
+    const row = this.db.prepare('select value from work_ledger_meta where key = ?')
+      .get(WORK_LEDGER_SCHEMA_VERSION_KEY) as { value?: string } | undefined
+    const version = Number(row?.value || 0)
+    return Number.isInteger(version) && version >= 0 ? version : 0
+  }
+
+  private recordSchemaVersion() {
+    this.db.prepare(`
+      insert into work_ledger_meta (key, value)
+      values (?, ?)
+      on conflict(key) do update set value = excluded.value
+    `).run(WORK_LEDGER_SCHEMA_VERSION_KEY, String(WORK_LEDGER_SCHEMA_VERSION))
+  }
+
+  private withTransaction<T>(callback: () => T): T {
+    const savepoint = `work_ledger_tx_${this.transactionCounter += 1}`
+    this.db.exec(`savepoint ${savepoint}`)
+    try {
+      const result = callback()
+      this.db.exec(`release savepoint ${savepoint}`)
+      ensureWorkLedgerDbFileModes(this.dbPath)
+      return result
+    } catch (error) {
+      try {
+        this.db.exec(`rollback to savepoint ${savepoint}`)
+      } finally {
+        this.db.exec(`release savepoint ${savepoint}`)
+        ensureWorkLedgerDbFileModes(this.dbPath)
+      }
+      throw error
+    }
+  }
+
+  upsertEntries(inputs: WorkLedgerUpsertInput[]) {
+    const entries = inputs.map(normalizeEntry)
+    this.withTransaction(() => {
+      for (const entry of entries) this.upsertEntryInTransaction(entry)
+    })
+    return entries
+  }
+
+  upsertEntry(input: WorkLedgerUpsertInput) {
+    return this.upsertEntries([input])[0]!
+  }
+
+  private upsertEntryInTransaction(entry: WorkLedgerEntry) {
+    this.db.prepare(`
+      insert into work_ledger_entries (
+        id, source_kind, source_id, title, summary, status, source_label, owner,
+        created_at, updated_at, started_at, finished_at,
+        cost, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_write_tokens,
+        review_state, needs_user_attention, source_ref_json, route_json, indexed_at, schema_version, metadata_version
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      on conflict(id) do update set
+        source_kind = excluded.source_kind,
+        source_id = excluded.source_id,
+        title = excluded.title,
+        summary = excluded.summary,
+        status = excluded.status,
+        source_label = excluded.source_label,
+        owner = excluded.owner,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        started_at = excluded.started_at,
+        finished_at = excluded.finished_at,
+        cost = excluded.cost,
+        input_tokens = excluded.input_tokens,
+        output_tokens = excluded.output_tokens,
+        reasoning_tokens = excluded.reasoning_tokens,
+        cache_read_tokens = excluded.cache_read_tokens,
+        cache_write_tokens = excluded.cache_write_tokens,
+        review_state = excluded.review_state,
+        needs_user_attention = excluded.needs_user_attention,
+        source_ref_json = excluded.source_ref_json,
+        route_json = excluded.route_json,
+        indexed_at = excluded.indexed_at,
+        schema_version = excluded.schema_version,
+        metadata_version = excluded.metadata_version
+    `).run(
+      entry.id,
+      entry.sourceKind,
+      entry.sourceId,
+      entry.title,
+      entry.summary,
+      entry.status,
+      entry.sourceLabel,
+      entry.owner,
+      entry.createdAt,
+      entry.updatedAt,
+      entry.startedAt,
+      entry.finishedAt,
+      entry.usage.cost,
+      entry.usage.tokens.input,
+      entry.usage.tokens.output,
+      entry.usage.tokens.reasoning,
+      entry.usage.tokens.cacheRead,
+      entry.usage.tokens.cacheWrite,
+      entry.reviewState,
+      entry.needsUserAttention ? 1 : 0,
+      assertJsonSize(entry.sourceRef, 'Work ledger source reference'),
+      assertJsonSize(entry.route, 'Work ledger route'),
+      entry.indexedAt,
+      entry.schemaVersion,
+      WORK_LEDGER_METADATA_VERSION,
+    )
+    this.replaceSidecar('work_ledger_entry_agents', entry.id, entry.agents)
+    this.replaceSidecar('work_ledger_entry_capabilities', entry.id, entry.capabilities)
+    this.replaceSidecar('work_ledger_entry_risk_labels', entry.id, entry.riskLabels)
+    this.replaceSidecar('work_ledger_entry_governance_labels', entry.id, entry.governanceLabels)
+  }
+
+  deleteEntriesNotIn(entryIds: string[]) {
+    const ids = normalizeIdList(entryIds, 'entryIds', Number.MAX_SAFE_INTEGER) || []
+    this.withTransaction(() => {
+      this.db.exec('create temp table if not exists work_ledger_keep_ids (id text primary key);')
+      this.db.exec('delete from work_ledger_keep_ids;')
+      const insert = this.db.prepare('insert into work_ledger_keep_ids (id) values (?)')
+      for (const id of ids) insert.run(id)
+      this.db.prepare(`
+        delete from work_ledger_entries
+        where not exists (
+          select 1 from work_ledger_keep_ids keep where keep.id = work_ledger_entries.id
+        )
+      `).run()
+      this.deleteOrphanSidecars()
+      this.db.exec('delete from work_ledger_keep_ids;')
+    })
+  }
+
+  private replaceSidecar(tableName: string, entryId: string, values: string[]) {
+    this.db.prepare(`delete from ${tableName} where entry_id = ?`).run(entryId)
+    const insert = this.db.prepare(`insert into ${tableName} (entry_id, value) values (?, ?)`)
+    for (const value of values.slice(0, WORK_LEDGER_FILTER_MAX_VALUES)) {
+      insert.run(entryId, normalizeText(value, 256, 'Work ledger sidecar value'))
+    }
+  }
+
+  private deleteOrphanSidecars() {
+    for (const table of [
+      'work_ledger_entry_agents',
+      'work_ledger_entry_capabilities',
+      'work_ledger_entry_risk_labels',
+      'work_ledger_entry_governance_labels',
+    ]) {
+      this.db.prepare(`
+        delete from ${table}
+        where not exists (
+          select 1 from work_ledger_entries entry where entry.id = ${table}.entry_id
+        )
+      `).run()
+    }
+  }
+
+  private buildWhere(input: WorkLedgerSearchQuery): WhereClause {
+    const query = normalizeWorkLedgerSearchQuery(input)
+    const clauses: string[] = []
+    const args: SQLInputValue[] = []
+    if (query.text) {
+      const pattern = likePattern(query.text)
+      clauses.push(`(
+        lower(title) like ? escape '\\'
+        or lower(coalesce(summary, '')) like ? escape '\\'
+        or lower(source_label) like ? escape '\\'
+        or lower(coalesce(owner, '')) like ? escape '\\'
+        or exists (select 1 from work_ledger_entry_agents agent where agent.entry_id = work_ledger_entries.id and lower(agent.value) like ? escape '\\')
+        or exists (select 1 from work_ledger_entry_capabilities capability where capability.entry_id = work_ledger_entries.id and lower(capability.value) like ? escape '\\')
+        or exists (select 1 from work_ledger_entry_risk_labels risk where risk.entry_id = work_ledger_entries.id and lower(risk.value) like ? escape '\\')
+        or exists (select 1 from work_ledger_entry_governance_labels governance where governance.entry_id = work_ledger_entries.id and lower(governance.value) like ? escape '\\')
+      )`)
+      args.push(pattern, pattern, pattern, pattern, pattern, pattern, pattern, pattern)
+    }
+    if (query.dateRange?.from) {
+      clauses.push('updated_at >= ?')
+      args.push(query.dateRange.from)
+    }
+    if (query.dateRange?.to) {
+      clauses.push('updated_at <= ?')
+      args.push(query.dateRange.to)
+    }
+    const addInClause = (field: string, values?: string[]) => {
+      if (!values?.length) return
+      clauses.push(`${field} in (${makePlaceholders(values)})`)
+      args.push(...values)
+    }
+    addInClause('source_kind', query.sourceKinds)
+    addInClause('status', query.statuses)
+    addInClause('owner', query.owners)
+    addInClause('review_state', query.reviewStates)
+    if (query.needsUserAttention !== null && query.needsUserAttention !== undefined) {
+      clauses.push('needs_user_attention = ?')
+      args.push(query.needsUserAttention ? 1 : 0)
+    }
+    const addSidecarFilter = (tableName: string, values?: string[]) => {
+      if (!values?.length) return
+      clauses.push(`exists (select 1 from ${tableName} sidecar where sidecar.entry_id = work_ledger_entries.id and sidecar.value in (${makePlaceholders(values)}))`)
+      args.push(...values)
+    }
+    addSidecarFilter('work_ledger_entry_agents', query.agents)
+    addSidecarFilter('work_ledger_entry_capabilities', query.capabilities)
+    addSidecarFilter('work_ledger_entry_risk_labels', query.riskLabels)
+    addSidecarFilter('work_ledger_entry_governance_labels', query.governanceLabels)
+    return { sql: clauses.length ? `where ${clauses.join(' and ')}` : '', args }
+  }
+
+  searchEntries(input: WorkLedgerSearchQuery = {}): WorkLedgerSearchResult {
+    const query = normalizeWorkLedgerSearchQuery(input)
+    const limit = query.limit || WORK_LEDGER_SEARCH_DEFAULT_LIMIT
+    const offset = decodeCursor(query.cursor)
+    const where = this.buildWhere(query)
+    const total = this.db.prepare(`select count(*) as count from work_ledger_entries ${where.sql}`)
+      .get(...where.args) as { count?: number } | undefined
+    const rows = this.db.prepare(`
+      select *
+      from work_ledger_entries
+      ${where.sql}
+      order by ${sortSql(query.sort)}
+      limit ? offset ?
+    `).all(...where.args, limit, offset) as Row[]
+    const entries = this.hydrateRows(rows)
+    const totalEstimate = Number(total?.count || 0)
+    const nextOffset = offset + rows.length
+    return {
+      entries,
+      nextCursor: nextOffset < totalEstimate ? encodeCursor(nextOffset) : null,
+      totalEstimate,
+    }
+  }
+
+  listFacets(input: WorkLedgerSearchQuery = {}): WorkLedgerFacetSummary {
+    const query = normalizeWorkLedgerSearchQuery({ ...input, cursor: null })
+    const where = this.buildWhere(query)
+    const bucket = (sql: string, args: SQLInputValue[] = where.args): WorkLedgerFacetBucket[] => (
+      this.db.prepare(sql).all(...args) as Row[]
+    ).map((row) => ({
+      value: asString(row.value),
+      label: asString(row.label, asString(row.value)),
+      count: asNumber(row.count),
+    }))
+    const baseWhere = where.sql
+    const whereAnd = (extra: string) => baseWhere ? `${baseWhere} and ${extra}` : `where ${extra}`
+    return {
+      sourceKinds: bucket(`select source_kind as value, source_kind as label, count(*) as count from work_ledger_entries ${baseWhere} group by source_kind order by count desc, source_kind asc`),
+      statuses: bucket(`select status as value, status as label, count(*) as count from work_ledger_entries ${baseWhere} group by status order by count desc, status asc`),
+      owners: bucket(`select owner as value, owner as label, count(*) as count from work_ledger_entries ${whereAnd('owner is not null')} group by owner order by count desc, owner asc`),
+      reviewStates: bucket(`select review_state as value, review_state as label, count(*) as count from work_ledger_entries ${baseWhere} group by review_state order by count desc, review_state asc`),
+      agents: bucket(`select sidecar.value as value, sidecar.value as label, count(*) as count from work_ledger_entries join work_ledger_entry_agents sidecar on sidecar.entry_id = work_ledger_entries.id ${baseWhere} group by sidecar.value order by count desc, sidecar.value asc`),
+      capabilities: bucket(`select sidecar.value as value, sidecar.value as label, count(*) as count from work_ledger_entries join work_ledger_entry_capabilities sidecar on sidecar.entry_id = work_ledger_entries.id ${baseWhere} group by sidecar.value order by count desc, sidecar.value asc`),
+      riskLabels: bucket(`select sidecar.value as value, sidecar.value as label, count(*) as count from work_ledger_entries join work_ledger_entry_risk_labels sidecar on sidecar.entry_id = work_ledger_entries.id ${baseWhere} group by sidecar.value order by count desc, sidecar.value asc`),
+      governanceLabels: bucket(`select sidecar.value as value, sidecar.value as label, count(*) as count from work_ledger_entries join work_ledger_entry_governance_labels sidecar on sidecar.entry_id = work_ledger_entries.id ${baseWhere} group by sidecar.value order by count desc, sidecar.value asc`),
+    }
+  }
+
+  private hydrateRows(rows: Row[]): WorkLedgerEntry[] {
+    if (rows.length === 0) return []
+    const ids = rows.map((row) => asString(row.id))
+    const agents = this.groupSidecar('work_ledger_entry_agents', ids)
+    const capabilities = this.groupSidecar('work_ledger_entry_capabilities', ids)
+    const riskLabels = this.groupSidecar('work_ledger_entry_risk_labels', ids)
+    const governanceLabels = this.groupSidecar('work_ledger_entry_governance_labels', ids)
+    return rows.map((row) => {
+      const id = asString(row.id)
+      const sourceKind = asString(row.source_kind, 'thread') as WorkLedgerSourceKind
+      const sourceId = asString(row.source_id)
+      return {
+        schemaVersion: asNumber(row.schema_version) || COWORK_WORK_LEDGER_SCHEMA_VERSION,
+        id,
+        sourceKind,
+        sourceId,
+        title: asString(row.title, 'Untitled work'),
+        summary: asNullableString(row.summary),
+        status: asString(row.status, 'unknown') as WorkLedgerStatus,
+        sourceLabel: asString(row.source_label, sourceKind),
+        owner: asNullableString(row.owner),
+        agents: agents.get(id) || [],
+        capabilities: capabilities.get(id) || [],
+        usage: {
+          cost: asNumber(row.cost),
+          tokens: tokensFromRow(row),
+        },
+        riskLabels: riskLabels.get(id) || [],
+        governanceLabels: governanceLabels.get(id) || [],
+        reviewState: asString(row.review_state, 'none') as WorkLedgerReviewState,
+        needsUserAttention: Number(row.needs_user_attention || 0) === 1,
+        sourceRef: parseJson<WorkLedgerSourceRef>(row.source_ref_json, { kind: sourceKind, id: sourceId }),
+        route: parseJson<WorkLedgerDrilldownRoute>(row.route_json, { surface: 'operations' }),
+        createdAt: asString(row.created_at),
+        updatedAt: asString(row.updated_at),
+        startedAt: asNullableString(row.started_at),
+        finishedAt: asNullableString(row.finished_at),
+        indexedAt: asString(row.indexed_at),
+      }
+    })
+  }
+
+  private groupSidecar(tableName: string, entryIds: string[]) {
+    const map = new Map<string, string[]>()
+    if (entryIds.length === 0) return map
+    const placeholders = makePlaceholders(entryIds)
+    const rows = this.db.prepare(`
+      select entry_id, value
+      from ${tableName}
+      where entry_id in (${placeholders})
+      order by value asc
+    `).all(...entryIds) as Row[]
+    for (const row of rows) {
+      const entryId = asString(row.entry_id)
+      map.set(entryId, [...(map.get(entryId) || []), asString(row.value)])
+    }
+    return map
+  }
+}
+
+export function getWorkLedgerStore() {
+  if (!workLedgerStore) workLedgerStore = new WorkLedgerStore()
+  return workLedgerStore
+}
+
+export function clearWorkLedgerStoreCache() {
+  workLedgerStore?.close()
+  workLedgerStore = null
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -167,6 +167,9 @@ const PRELOAD_INVOKE_CHANNELS = [
   'threads:suggestions:edit',
   'threads:suggestions:dismiss',
   'threads:reindex',
+  'work-ledger:search',
+  'work-ledger:facets',
+  'work-ledger:reindex',
   'agents:catalog',
   'agents:list',
   'agents:runtime',
@@ -440,6 +443,11 @@ const api: CoworkAPI = {
       dismiss: (suggestionId) => invoke('threads:suggestions:dismiss', suggestionId),
     },
     reindex: (sessionIds) => invoke('threads:reindex', sessionIds),
+  },
+  workLedger: {
+    search: (query) => invoke('work-ledger:search', query),
+    facets: (query) => invoke('work-ledger:facets', query),
+    reindex: () => invoke('work-ledger:reindex'),
   },
   agents: {
     catalog: (options) => invoke('agents:catalog', options),

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, lazy, Suspense } from 'react'
-import type { AppMetadata, CustomAgentConfig, EffectiveAppSettings, PublicAppConfig, SessionInfo, SessionPromptOptions } from '@open-cowork/shared'
+import type { AppMetadata, CustomAgentConfig, EffectiveAppSettings, PublicAppConfig, SessionInfo, SessionPromptOptions, WorkLedgerDrilldownRoute } from '@open-cowork/shared'
 import { Sidebar } from './components/layout/Sidebar'
 import { TitleBar } from './components/layout/TitleBar'
 import { StatusBar } from './components/layout/StatusBar'
@@ -156,6 +156,22 @@ export function App() {
     setView('chat')
     await loadSessionMessages(sessionId)
   }, [])
+
+  const openWorkLedgerRoute = useCallback((route: WorkLedgerDrilldownRoute) => {
+    if (route.sessionId) {
+      void openExistingThread(route.sessionId)
+      return
+    }
+    if (route.surface === 'automations') {
+      setView('automations')
+      return
+    }
+    if (route.surface === 'crews') {
+      setView('crews')
+      return
+    }
+    setView('pulse')
+  }, [openExistingThread])
 
   const ensureSidebarVisible = useCallback(() => {
     const state = useSessionStore.getState()
@@ -456,7 +472,7 @@ export function App() {
             )}
             {view === 'threads' && (
               <Suspense fallback={null}>
-                <ThreadsPage onOpenThread={(sessionId) => void openExistingThread(sessionId)} />
+                <ThreadsPage onOpenThread={(sessionId) => void openExistingThread(sessionId)} onOpenRoute={openWorkLedgerRoute} />
               </Suspense>
             )}
             {view === 'automations' && (

--- a/apps/desktop/src/renderer/components/threads/ThreadsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/threads/ThreadsPage.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import type { ThreadFacetSummary, ThreadListItem, ThreadSearchResult, ThreadTag } from '@open-cowork/shared'
+import type { ThreadFacetSummary, ThreadListItem, ThreadSearchResult, ThreadTag, WorkLedgerEntry, WorkLedgerFacetSummary, WorkLedgerSearchResult } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { ThreadsPage } from './ThreadsPage'
+import { WORK_LEDGER_FEATURE_GATE_KEY } from './work-ledger-ui'
 
 function thread(overrides: Partial<ThreadListItem> = {}): ThreadListItem {
   return {
@@ -54,6 +55,62 @@ function facets(tag?: ThreadTag): ThreadFacetSummary {
     mcps: [{ value: 'charts', label: 'charts', count: 1 }],
     statuses: [{ value: 'idle', label: 'idle', count: 1 }],
     tags: tag ? [{ value: tag.id, label: tag.name, color: tag.color, count: 1 }] : [],
+  }
+}
+
+function ledgerEntry(overrides: Partial<WorkLedgerEntry> = {}): WorkLedgerEntry {
+  return {
+    schemaVersion: overrides.schemaVersion || 1,
+    id: overrides.id || 'approval:automation_inbox-1',
+    sourceKind: overrides.sourceKind || 'approval',
+    sourceId: overrides.sourceId || 'automation_inbox:approval-1',
+    title: overrides.title || 'Approve weekly report',
+    summary: overrides.summary ?? null,
+    status: overrides.status || 'approval_required',
+    sourceLabel: overrides.sourceLabel || 'Weekly automation',
+    owner: overrides.owner ?? '/workspace/revenue',
+    agents: overrides.agents || ['analyst'],
+    capabilities: overrides.capabilities || ['github.write'],
+    usage: overrides.usage || {
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+    riskLabels: overrides.riskLabels || ['policy'],
+    governanceLabels: overrides.governanceLabels || ['approval'],
+    reviewState: overrides.reviewState || 'approval_requested',
+    needsUserAttention: overrides.needsUserAttention ?? true,
+    sourceRef: overrides.sourceRef || {
+      kind: 'approval',
+      id: 'approval-1',
+      automationId: 'automation-1',
+      automationRunId: 'run-1',
+      sessionId: 'thread-1',
+      approvalId: 'approval-1',
+    },
+    route: overrides.route || {
+      surface: 'automations',
+      automationId: 'automation-1',
+      automationRunId: 'run-1',
+      sessionId: 'thread-1',
+    },
+    createdAt: overrides.createdAt || '2026-01-03T00:00:00.000Z',
+    updatedAt: overrides.updatedAt || '2026-01-03T00:00:00.000Z',
+    startedAt: overrides.startedAt ?? null,
+    finishedAt: overrides.finishedAt ?? null,
+    indexedAt: overrides.indexedAt || '2026-01-03T00:00:00.000Z',
+  }
+}
+
+function ledgerFacets(): WorkLedgerFacetSummary {
+  return {
+    sourceKinds: [{ value: 'approval', label: 'approval', count: 1 }],
+    statuses: [{ value: 'approval_required', label: 'approval_required', count: 1 }],
+    owners: [{ value: '/workspace/revenue', label: '/workspace/revenue', count: 1 }],
+    agents: [{ value: 'analyst', label: 'analyst', count: 1 }],
+    capabilities: [{ value: 'github.write', label: 'github.write', count: 1 }],
+    riskLabels: [{ value: 'policy', label: 'policy', count: 1 }],
+    governanceLabels: [{ value: 'approval', label: 'approval', count: 1 }],
+    reviewStates: [{ value: 'approval_requested', label: 'approval_requested', count: 1 }],
   }
 }
 
@@ -132,5 +189,50 @@ describe('ThreadsPage', () => {
     const drawer = screen.getByRole('complementary', { name: 'Thread detail' })
     await user.click(within(drawer).getByRole('button', { name: 'Accept' }))
     await waitFor(() => expect(api.threads.suggestions.accept).toHaveBeenCalledWith('suggestion-1'))
+  })
+
+  it('keeps the work ledger gated and supports search, facets, pagination, and source drill-down when enabled', async () => {
+    const onOpenThread = vi.fn()
+    const onOpenRoute = vi.fn()
+    const api = installRendererTestCoworkApi()
+    vi.mocked(api.threads.search).mockResolvedValue({
+      threads: [thread()],
+      nextCursor: null,
+      totalEstimate: 1,
+    })
+    vi.mocked(api.threads.facets).mockResolvedValue(facets())
+
+    const firstRender = render(<ThreadsPage onOpenThread={onOpenThread} onOpenRoute={onOpenRoute} />)
+    expect(screen.queryByRole('button', { name: 'Work ledger' })).not.toBeInTheDocument()
+    expect(api.workLedger.search).not.toHaveBeenCalled()
+    firstRender.unmount()
+
+    window.localStorage.setItem(WORK_LEDGER_FEATURE_GATE_KEY, 'true')
+    vi.mocked(api.workLedger.search).mockResolvedValue({
+      entries: [ledgerEntry()],
+      nextCursor: 'cursor-2',
+      totalEstimate: 2,
+    } satisfies WorkLedgerSearchResult)
+    vi.mocked(api.workLedger.facets).mockResolvedValue(ledgerFacets())
+
+    const user = userEvent.setup()
+    render(<ThreadsPage onOpenThread={onOpenThread} onOpenRoute={onOpenRoute} />)
+
+    await user.click(screen.getByRole('button', { name: 'Work ledger' }))
+    expect(await screen.findByText('Approve weekly report')).toBeInTheDocument()
+    await user.type(screen.getByRole('textbox', { name: 'Search work ledger' }), 'approve')
+    await waitFor(() => expect(api.workLedger.search).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'approve' })))
+
+    await user.click(screen.getByRole('button', { name: 'Approvals (1)' }))
+    await waitFor(() => expect(api.workLedger.search).toHaveBeenLastCalledWith(expect.objectContaining({ sourceKinds: ['approval'] })))
+
+    await user.click(screen.getByRole('button', { name: 'Needs user attention' }))
+    await waitFor(() => expect(api.workLedger.search).toHaveBeenLastCalledWith(expect.objectContaining({ needsUserAttention: true })))
+
+    await user.click(screen.getByRole('button', { name: 'Load more' }))
+    await waitFor(() => expect(api.workLedger.search).toHaveBeenLastCalledWith(expect.objectContaining({ cursor: 'cursor-2' })))
+
+    await user.click(screen.getAllByRole('button', { name: 'Open' })[0]!)
+    expect(onOpenThread).toHaveBeenCalledWith('thread-1')
   })
 })

--- a/apps/desktop/src/renderer/components/threads/ThreadsPage.tsx
+++ b/apps/desktop/src/renderer/components/threads/ThreadsPage.tsx
@@ -8,8 +8,11 @@ import type {
   ThreadSort,
   ThreadStatus,
   ThreadTag,
+  WorkLedgerDrilldownRoute,
 } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
+import { isWorkLedgerV1Enabled } from './work-ledger-ui'
+import { WorkLedgerView } from './WorkLedgerView'
 
 const STATUS_OPTIONS: Array<{ value: ThreadStatus; label: string }> = [
   { value: 'idle', label: 'Idle' },
@@ -24,6 +27,7 @@ const TAG_COLORS = ['#64748b', '#22c55e', '#0ea5e9', '#f59e0b', '#ef4444', '#a85
 
 type ThreadsPageProps = {
   onOpenThread: (sessionId: string) => void
+  onOpenRoute?: (route: WorkLedgerDrilldownRoute) => void
 }
 
 type QueryState = {
@@ -239,6 +243,38 @@ function DateFacet({
         ))}
       </div>
     </section>
+  )
+}
+
+function SurfaceSwitcher({
+  enabled,
+  active,
+  onChange,
+}: {
+  enabled: boolean
+  active: 'threads' | 'work-ledger'
+  onChange: (surface: 'threads' | 'work-ledger') => void
+}) {
+  if (!enabled) return null
+  return (
+    <div className="mt-3 grid grid-cols-2 gap-1 rounded-md border border-border-subtle bg-surface p-1">
+      <button
+        type="button"
+        aria-pressed={active === 'threads'}
+        onClick={() => onChange('threads')}
+        className={`rounded px-2 py-1.5 text-[11px] font-medium ${active === 'threads' ? 'bg-base text-text shadow-sm' : 'text-text-muted hover:text-text'}`}
+      >
+        Threads
+      </button>
+      <button
+        type="button"
+        aria-pressed={active === 'work-ledger'}
+        onClick={() => onChange('work-ledger')}
+        className={`rounded px-2 py-1.5 text-[11px] font-medium ${active === 'work-ledger' ? 'bg-base text-text shadow-sm' : 'text-text-muted hover:text-text'}`}
+      >
+        Work ledger
+      </button>
+    </div>
   )
 }
 
@@ -535,7 +571,9 @@ function DetailDrawer({
   )
 }
 
-export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
+export function ThreadsPage({ onOpenThread, onOpenRoute }: ThreadsPageProps) {
+  const workLedgerEnabled = useMemo(() => isWorkLedgerV1Enabled(), [])
+  const [activeSurface, setActiveSurface] = useState<'threads' | 'work-ledger'>('threads')
   const [query, setQuery] = useState<QueryState>({
     text: '',
     sort: 'updated_desc',
@@ -621,12 +659,24 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
     onOpenThread(sessionId)
   }
 
+  if (workLedgerEnabled && activeSurface === 'work-ledger') {
+    return (
+      <WorkLedgerView
+        activeSurface={activeSurface}
+        onSurfaceChange={setActiveSurface}
+        onOpenThread={onOpenThread}
+        onOpenRoute={onOpenRoute}
+      />
+    )
+  }
+
   return (
     <div className="flex h-full min-h-0 bg-base text-text">
       <aside aria-label="Thread filters" className="flex w-[280px] shrink-0 flex-col border-e border-border-subtle bg-base">
         <div className="border-b border-border-subtle px-3 py-3">
           <div className="text-[15px] font-semibold text-text">{t('threads.title', 'Threads')}</div>
           <div className="mt-1 text-[11px] text-text-muted">{t('threads.subtitle', 'Search history, metadata, tags, and saved filters.')}</div>
+          <SurfaceSwitcher enabled={workLedgerEnabled} active={activeSurface} onChange={setActiveSurface} />
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto">
           <SmartFilters

--- a/apps/desktop/src/renderer/components/threads/WorkLedgerView.tsx
+++ b/apps/desktop/src/renderer/components/threads/WorkLedgerView.tsx
@@ -1,0 +1,603 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type {
+  WorkLedgerDrilldownRoute,
+  WorkLedgerEntry,
+  WorkLedgerFacetBucket,
+  WorkLedgerFacetSummary,
+  WorkLedgerReviewState,
+  WorkLedgerSearchQuery,
+  WorkLedgerSort,
+  WorkLedgerSourceKind,
+  WorkLedgerStatus,
+} from '@open-cowork/shared'
+import { t } from '../../helpers/i18n'
+
+const WORK_SOURCE_OPTIONS: Array<{ value: WorkLedgerSourceKind; label: string }> = [
+  { value: 'thread', label: 'Threads' },
+  { value: 'automation', label: 'Automations' },
+  { value: 'automation_run', label: 'Automation runs' },
+  { value: 'crew', label: 'Crews' },
+  { value: 'crew_run', label: 'Crew runs' },
+  { value: 'delegated_task', label: 'Delegated tasks' },
+  { value: 'approval', label: 'Approvals' },
+  { value: 'question', label: 'Questions' },
+  { value: 'delivery', label: 'Deliveries' },
+  { value: 'channel_event', label: 'Channel events' },
+  { value: 'governance_incident', label: 'Incidents' },
+]
+
+const WORK_REVIEW_OPTIONS: Array<{ value: WorkLedgerReviewState; label: string }> = [
+  { value: 'needs_review', label: 'Needs review' },
+  { value: 'approval_requested', label: 'Approval requested' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'denied', label: 'Denied' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'none', label: 'No review' },
+]
+
+const EMPTY_LEDGER_FACETS: WorkLedgerFacetSummary = {
+  sourceKinds: [],
+  statuses: [],
+  owners: [],
+  agents: [],
+  capabilities: [],
+  riskLabels: [],
+  governanceLabels: [],
+  reviewStates: [],
+}
+
+type Surface = 'threads' | 'work-ledger'
+
+type WorkLedgerQueryState = {
+  text: string
+  sort: WorkLedgerSort
+  dateRange?: WorkLedgerSearchQuery['dateRange']
+  sourceKinds: WorkLedgerSourceKind[]
+  statuses: WorkLedgerStatus[]
+  owners: string[]
+  agents: string[]
+  capabilities: string[]
+  riskLabels: string[]
+  governanceLabels: string[]
+  reviewStates: WorkLedgerReviewState[]
+  needsUserAttention: boolean | null
+}
+
+export type WorkLedgerViewProps = {
+  activeSurface: Surface
+  onSurfaceChange: (surface: Surface) => void
+  onOpenThread: (sessionId: string) => void
+  onOpenRoute?: (route: WorkLedgerDrilldownRoute) => void
+}
+
+function ledgerQueryFromState(state: WorkLedgerQueryState, cursor?: string | null): WorkLedgerSearchQuery {
+  return {
+    text: state.text || undefined,
+    cursor: cursor || null,
+    limit: 50,
+    sort: state.sort,
+    dateRange: state.dateRange,
+    sourceKinds: state.sourceKinds.length ? state.sourceKinds : undefined,
+    statuses: state.statuses.length ? state.statuses : undefined,
+    owners: state.owners.length ? state.owners : undefined,
+    agents: state.agents.length ? state.agents : undefined,
+    capabilities: state.capabilities.length ? state.capabilities : undefined,
+    riskLabels: state.riskLabels.length ? state.riskLabels : undefined,
+    governanceLabels: state.governanceLabels.length ? state.governanceLabels : undefined,
+    reviewStates: state.reviewStates.length ? state.reviewStates : undefined,
+    needsUserAttention: state.needsUserAttention,
+  }
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(date)
+}
+
+function daysAgoIso(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function isRecentRange(range: WorkLedgerSearchQuery['dateRange'], days: number) {
+  if (!range?.from || range.to) return false
+  const from = new Date(range.from).getTime()
+  if (!Number.isFinite(from)) return false
+  const expected = Date.now() - days * 24 * 60 * 60 * 1000
+  return Math.abs(from - expected) < 60_000
+}
+
+function money(value: number) {
+  if (!value) return '$0.00'
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 4 }).format(value)
+}
+
+function toggleValue<T extends string>(values: T[], value: T) {
+  return values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value]
+}
+
+function statusLabel(value: string) {
+  return value.replaceAll('_', ' ')
+}
+
+function hasLedgerFilters(state: WorkLedgerQueryState) {
+  return Boolean(
+    state.text
+    || state.dateRange
+    || state.sourceKinds.length
+    || state.statuses.length
+    || state.owners.length
+    || state.agents.length
+    || state.capabilities.length
+    || state.riskLabels.length
+    || state.governanceLabels.length
+    || state.reviewStates.length
+    || state.needsUserAttention !== null,
+  )
+}
+
+function SurfaceSwitcher({
+  active,
+  onChange,
+}: {
+  active: Surface
+  onChange: (surface: Surface) => void
+}) {
+  return (
+    <div className="mt-3 grid grid-cols-2 gap-1 rounded-md border border-border-subtle bg-surface p-1">
+      <button
+        type="button"
+        aria-pressed={active === 'threads'}
+        onClick={() => onChange('threads')}
+        className={`rounded px-2 py-1.5 text-[11px] font-medium ${active === 'threads' ? 'bg-base text-text shadow-sm' : 'text-text-muted hover:text-text'}`}
+      >
+        Threads
+      </button>
+      <button
+        type="button"
+        aria-pressed={active === 'work-ledger'}
+        onClick={() => onChange('work-ledger')}
+        className={`rounded px-2 py-1.5 text-[11px] font-medium ${active === 'work-ledger' ? 'bg-base text-text shadow-sm' : 'text-text-muted hover:text-text'}`}
+      >
+        Work ledger
+      </button>
+    </div>
+  )
+}
+
+function FacetButton({
+  bucket,
+  selected,
+  onClick,
+}: {
+  bucket: WorkLedgerFacetBucket
+  selected: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      aria-label={`${bucket.label} (${bucket.count})`}
+      onClick={onClick}
+      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-[12px] transition-colors ${selected ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}
+    >
+      <span className="min-w-0 flex-1 truncate">{bucket.label}</span>
+      <span className="shrink-0 text-[10px] text-text-muted">{bucket.count}</span>
+    </button>
+  )
+}
+
+function FacetGroup({
+  title,
+  buckets,
+  selected,
+  onToggle,
+}: {
+  title: string
+  buckets: WorkLedgerFacetBucket[]
+  selected: string[]
+  onToggle: (value: string) => void
+}) {
+  if (buckets.length === 0) return null
+  return (
+    <section className="border-b border-border-subtle px-3 py-3">
+      <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">{title}</h3>
+      <div className="flex flex-col gap-1">
+        {buckets.slice(0, 12).map((bucket) => (
+          <FacetButton
+            key={bucket.value}
+            bucket={bucket}
+            selected={selected.includes(bucket.value)}
+            onClick={() => onToggle(bucket.value)}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function OptionFacet<T extends string>({
+  title,
+  selected,
+  buckets,
+  options,
+  onToggle,
+}: {
+  title: string
+  selected: T[]
+  buckets: WorkLedgerFacetBucket[]
+  options: Array<{ value: T; label: string }>
+  onToggle: (value: T) => void
+}) {
+  const counts = new Map(buckets.map((bucket) => [bucket.value, bucket.count]))
+  return (
+    <section className="border-b border-border-subtle px-3 py-3">
+      <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">{title}</h3>
+      <div className="flex flex-col gap-1">
+        {options.map((option) => (
+          <FacetButton
+            key={option.value}
+            bucket={{ value: option.value, label: option.label, count: counts.get(option.value) || 0 }}
+            selected={selected.includes(option.value)}
+            onClick={() => onToggle(option.value)}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function DateFacet({
+  range,
+  onChange,
+}: {
+  range?: WorkLedgerSearchQuery['dateRange']
+  onChange: (range?: WorkLedgerSearchQuery['dateRange']) => void
+}) {
+  const options = [
+    { label: 'Any time', range: undefined, selected: !range },
+    { label: 'Last 7 days', range: { from: daysAgoIso(7) }, selected: isRecentRange(range, 7) },
+    { label: 'Last 30 days', range: { from: daysAgoIso(30) }, selected: isRecentRange(range, 30) },
+  ]
+  return (
+    <section className="border-b border-border-subtle px-3 py-3">
+      <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">Date</h3>
+      <div className="flex flex-col gap-1">
+        {options.map((option) => (
+          <button
+            key={option.label}
+            type="button"
+            aria-pressed={option.selected}
+            onClick={() => onChange(option.range)}
+            className={`rounded-md px-2 py-1.5 text-start text-[12px] transition-colors ${option.selected ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function WorkLedgerBadges({ entry }: { entry: WorkLedgerEntry }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {entry.agents.slice(0, 2).map((agent) => (
+        <span key={agent} className="rounded bg-surface px-1.5 py-0.5 text-[10px] text-text-muted">Agent: {agent}</span>
+      ))}
+      {entry.capabilities.slice(0, 2).map((capability) => (
+        <span key={capability} className="rounded bg-surface px-1.5 py-0.5 text-[10px] text-text-muted">Capability: {capability}</span>
+      ))}
+      {entry.riskLabels.slice(0, 2).map((label) => (
+        <span key={label} className="rounded border border-red-400/25 px-1.5 py-0.5 text-[10px] text-red-200">Risk: {statusLabel(label)}</span>
+      ))}
+      {entry.governanceLabels.slice(0, 2).map((label) => (
+        <span key={label} className="rounded border border-border-subtle px-1.5 py-0.5 text-[10px] text-text-muted">{statusLabel(label)}</span>
+      ))}
+    </div>
+  )
+}
+
+function WorkLedgerRow({
+  entry,
+  selected,
+  onSelect,
+  onOpen,
+}: {
+  entry: WorkLedgerEntry
+  selected: boolean
+  onSelect: () => void
+  onOpen: () => void
+}) {
+  return (
+    <div
+      role="row"
+      className={`grid grid-cols-[minmax(240px,1.35fr)_150px_180px_150px_130px] items-center gap-3 border-b border-border-subtle px-3 py-2.5 text-[12px] transition-colors ${selected ? 'bg-surface-active/70' : 'hover:bg-surface-hover'}`}
+    >
+      <button type="button" onClick={onSelect} className="min-w-0 text-start">
+        <span className="block truncate text-[13px] font-medium text-text">{entry.title}</span>
+        <span className="mt-1 flex min-w-0 items-center gap-2 text-[11px] text-text-muted">
+          <span className="truncate">{entry.sourceLabel}</span>
+          <span aria-hidden="true">·</span>
+          <span>{statusLabel(entry.sourceKind)}</span>
+          {entry.usage.cost ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{money(entry.usage.cost)}</span>
+            </>
+          ) : null}
+        </span>
+        <div className="mt-1.5">
+          <WorkLedgerBadges entry={entry} />
+        </div>
+      </button>
+      <span className="truncate text-text-secondary">{entry.owner || 'Local workspace'}</span>
+      <span className="truncate text-text-secondary">{entry.agents[0] || entry.capabilities[0] || '-'}</span>
+      <div className="flex flex-wrap gap-1">
+        <span className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-[0.04em] ${entry.needsUserAttention ? 'bg-amber-500/15 text-amber-200' : 'bg-surface text-text-muted'}`}>
+          {statusLabel(entry.reviewState)}
+        </span>
+        <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] uppercase tracking-[0.04em] text-text-muted">{statusLabel(entry.status)}</span>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-text-muted">{formatDate(entry.updatedAt)}</span>
+        <button type="button" onClick={onOpen} className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-secondary hover:bg-surface-hover hover:text-text">
+          Open
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function WorkLedgerDetailDrawer({
+  entry,
+  onClose,
+  onOpen,
+}: {
+  entry: WorkLedgerEntry | null
+  onClose: () => void
+  onOpen: (entry: WorkLedgerEntry) => void
+}) {
+  if (!entry) return null
+  return (
+    <aside aria-label="Work ledger detail" className="w-[360px] shrink-0 border-s border-border-subtle bg-base">
+      <div className="flex items-center justify-between border-b border-border-subtle px-4 py-3">
+        <h2 className="min-w-0 truncate text-[14px] font-semibold text-text">{entry.title}</h2>
+        <button type="button" onClick={onClose} className="rounded-md px-2 py-1 text-[12px] text-text-muted hover:bg-surface-hover">Close</button>
+      </div>
+      <div className="space-y-5 overflow-y-auto p-4 text-[12px] text-text-secondary">
+        <section>
+          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">Overview</h3>
+          <div className="grid grid-cols-[112px_1fr] gap-x-3 gap-y-1">
+            <span className="text-text-muted">Source</span><span>{statusLabel(entry.sourceKind)}</span>
+            <span className="text-text-muted">Status</span><span>{statusLabel(entry.status)}</span>
+            <span className="text-text-muted">Review</span><span>{statusLabel(entry.reviewState)}</span>
+            <span className="text-text-muted">Updated</span><span>{formatDate(entry.updatedAt)}</span>
+            <span className="text-text-muted">Owner</span><span>{entry.owner || 'Local workspace'}</span>
+            <span className="text-text-muted">Cost</span><span>{money(entry.usage.cost)}</span>
+          </div>
+          {entry.summary ? <p className="mt-3 rounded-md bg-surface px-3 py-2 text-[12px] text-text-secondary">{entry.summary}</p> : null}
+          <button type="button" onClick={() => onOpen(entry)} className="mt-3 w-full rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">
+            Open source
+          </button>
+        </section>
+        <section>
+          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">References</h3>
+          <div className="grid grid-cols-[112px_1fr] gap-x-3 gap-y-1 break-all">
+            <span className="text-text-muted">Source id</span><span>{entry.sourceId}</span>
+            {entry.sourceRef.sessionId ? <><span className="text-text-muted">Session</span><span>{entry.sourceRef.sessionId}</span></> : null}
+            {entry.sourceRef.automationId ? <><span className="text-text-muted">Automation</span><span>{entry.sourceRef.automationId}</span></> : null}
+            {entry.sourceRef.crewId ? <><span className="text-text-muted">Crew</span><span>{entry.sourceRef.crewId}</span></> : null}
+            {entry.sourceRef.channelId ? <><span className="text-text-muted">Channel</span><span>{entry.sourceRef.channelId}</span></> : null}
+          </div>
+        </section>
+        <section>
+          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">Indexed metadata</h3>
+          <div className="flex flex-wrap gap-1.5">
+            {entry.agents.map((agent) => <span key={agent} className="rounded bg-surface px-1.5 py-0.5 text-[10px]">Agent: {agent}</span>)}
+            {entry.capabilities.map((capability) => <span key={capability} className="rounded bg-surface px-1.5 py-0.5 text-[10px]">Capability: {capability}</span>)}
+            {entry.riskLabels.map((label) => <span key={label} className="rounded border border-red-400/25 px-1.5 py-0.5 text-[10px] text-red-200">Risk: {statusLabel(label)}</span>)}
+            {entry.governanceLabels.map((label) => <span key={label} className="rounded border border-border-subtle px-1.5 py-0.5 text-[10px]">{statusLabel(label)}</span>)}
+            {!entry.agents.length && !entry.capabilities.length && !entry.riskLabels.length && !entry.governanceLabels.length ? <span className="text-text-muted">No indexed agent, capability, risk, or governance labels.</span> : null}
+          </div>
+        </section>
+      </div>
+    </aside>
+  )
+}
+
+export function WorkLedgerView({
+  activeSurface,
+  onSurfaceChange,
+  onOpenThread,
+  onOpenRoute,
+}: WorkLedgerViewProps) {
+  const [query, setQuery] = useState<WorkLedgerQueryState>({
+    text: '',
+    sort: 'updated_desc',
+    dateRange: undefined,
+    sourceKinds: [],
+    statuses: [],
+    owners: [],
+    agents: [],
+    capabilities: [],
+    riskLabels: [],
+    governanceLabels: [],
+    reviewStates: [],
+    needsUserAttention: null,
+  })
+  const [entries, setEntries] = useState<WorkLedgerEntry[]>([])
+  const [facets, setFacets] = useState<WorkLedgerFacetSummary>(EMPTY_LEDGER_FACETS)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [detailId, setDetailId] = useState<string | null>(null)
+
+  const selectedEntry = useMemo(() => entries.find((entry) => entry.id === detailId) || null, [detailId, entries])
+
+  const loadLedger = useCallback(async (cursor: string | null = null, append = false) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const searchQuery = ledgerQueryFromState(query, cursor)
+      const [result, facetResult] = await Promise.all([
+        window.coworkApi.workLedger.search(searchQuery),
+        window.coworkApi.workLedger.facets(searchQuery),
+      ])
+      setEntries((current) => append ? [...current, ...result.entries] : result.entries)
+      setNextCursor(result.nextCursor)
+      setTotal(result.totalEstimate)
+      setFacets(facetResult)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [query])
+
+  useEffect(() => {
+    void loadLedger(null, false)
+  }, [loadLedger])
+
+  const reload = useCallback(() => {
+    void loadLedger(null, false)
+  }, [loadLedger])
+
+  const openEntry = useCallback((entry: WorkLedgerEntry) => {
+    if (entry.route.sessionId) {
+      onOpenThread(entry.route.sessionId)
+      return
+    }
+    onOpenRoute?.(entry.route)
+  }, [onOpenRoute, onOpenThread])
+
+  const resetQuery = () => setQuery({
+    text: '',
+    sort: 'updated_desc',
+    dateRange: undefined,
+    sourceKinds: [],
+    statuses: [],
+    owners: [],
+    agents: [],
+    capabilities: [],
+    riskLabels: [],
+    governanceLabels: [],
+    reviewStates: [],
+    needsUserAttention: null,
+  })
+
+  return (
+    <div className="flex h-full min-h-0 bg-base text-text">
+      <aside aria-label="Work ledger filters" className="flex w-[280px] shrink-0 flex-col border-e border-border-subtle bg-base">
+        <div className="border-b border-border-subtle px-3 py-3">
+          <div className="text-[15px] font-semibold text-text">{t('threads.workLedgerTitle', 'Work ledger')}</div>
+          <div className="mt-1 text-[11px] text-text-muted">{t('threads.workLedgerSubtitle', 'Search sessions, runs, approvals, deliveries, channels, and incidents.')}</div>
+          <SurfaceSwitcher active={activeSurface} onChange={onSurfaceChange} />
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <OptionFacet
+            title="Source"
+            selected={query.sourceKinds}
+            buckets={facets.sourceKinds}
+            options={WORK_SOURCE_OPTIONS}
+            onToggle={(value) => setQuery((current) => ({ ...current, sourceKinds: toggleValue(current.sourceKinds, value) }))}
+          />
+          <OptionFacet
+            title="Review"
+            selected={query.reviewStates}
+            buckets={facets.reviewStates}
+            options={WORK_REVIEW_OPTIONS}
+            onToggle={(value) => setQuery((current) => ({ ...current, reviewStates: toggleValue(current.reviewStates, value) }))}
+          />
+          <section className="border-b border-border-subtle px-3 py-3">
+            <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">Attention</h3>
+            <button
+              type="button"
+              aria-pressed={query.needsUserAttention === true}
+              onClick={() => setQuery((current) => ({ ...current, needsUserAttention: current.needsUserAttention === true ? null : true }))}
+              className={`w-full rounded-md px-2 py-1.5 text-start text-[12px] transition-colors ${query.needsUserAttention === true ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}
+            >
+              Needs user attention
+            </button>
+          </section>
+          <DateFacet range={query.dateRange} onChange={(dateRange) => setQuery((current) => ({ ...current, dateRange }))} />
+          <FacetGroup title="Statuses" buckets={facets.statuses} selected={query.statuses} onToggle={(value) => setQuery((current) => ({ ...current, statuses: toggleValue(current.statuses, value as WorkLedgerStatus) }))} />
+          <FacetGroup title="Owners" buckets={facets.owners} selected={query.owners} onToggle={(value) => setQuery((current) => ({ ...current, owners: toggleValue(current.owners, value) }))} />
+          <FacetGroup title="Agents" buckets={facets.agents} selected={query.agents} onToggle={(value) => setQuery((current) => ({ ...current, agents: toggleValue(current.agents, value) }))} />
+          <FacetGroup title="Capabilities" buckets={facets.capabilities} selected={query.capabilities} onToggle={(value) => setQuery((current) => ({ ...current, capabilities: toggleValue(current.capabilities, value) }))} />
+          <FacetGroup title="Risk" buckets={facets.riskLabels} selected={query.riskLabels} onToggle={(value) => setQuery((current) => ({ ...current, riskLabels: toggleValue(current.riskLabels, value) }))} />
+          <FacetGroup title="Governance" buckets={facets.governanceLabels} selected={query.governanceLabels} onToggle={(value) => setQuery((current) => ({ ...current, governanceLabels: toggleValue(current.governanceLabels, value) }))} />
+        </div>
+      </aside>
+      <section className="flex min-w-0 flex-1 flex-col">
+        <div className="border-b border-border-subtle px-4 py-3">
+          <div className="flex items-center gap-2">
+            <label className="sr-only" htmlFor="work-ledger-search">Search work ledger</label>
+            <input
+              id="work-ledger-search"
+              value={query.text}
+              onChange={(event) => setQuery((current) => ({ ...current, text: event.target.value }))}
+              placeholder="Search work, sources, owners, agents, capabilities, risks, and governance labels"
+              className="min-w-0 flex-1 rounded-md border border-border-subtle bg-base px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+            />
+            <label className="sr-only" htmlFor="work-ledger-sort">Sort work ledger</label>
+            <select
+              id="work-ledger-sort"
+              value={query.sort}
+              onChange={(event) => setQuery((current) => ({ ...current, sort: event.target.value as WorkLedgerSort }))}
+              className="rounded-md border border-border-subtle bg-base px-2 py-2 text-[12px] text-text"
+            >
+              <option value="updated_desc">Recently updated</option>
+              <option value="created_desc">Recently created</option>
+              <option value="title_asc">Title A-Z</option>
+            </select>
+            <button type="button" onClick={reload} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover">Refresh</button>
+            {hasLedgerFilters(query) ? (
+              <button type="button" onClick={resetQuery} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover">
+                Clear
+              </button>
+            ) : null}
+          </div>
+          <div className="mt-2 flex items-center justify-between text-[11px] text-text-muted">
+            <span>{loading ? 'Loading...' : `${total} ledger entr${total === 1 ? 'y' : 'ies'}`}</span>
+            <span>{query.needsUserAttention ? 'Filtered to work needing user attention.' : 'Rows link to their durable source records.'}</span>
+          </div>
+        </div>
+        {error ? <div role="alert" className="border-b border-red-400/30 bg-red-500/10 px-4 py-2 text-[12px] text-red-100">{error}</div> : null}
+        <div className="grid grid-cols-[minmax(240px,1.35fr)_150px_180px_150px_130px] gap-3 border-b border-border-subtle px-3 py-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+          <span>Work</span>
+          <span>Owner</span>
+          <span>Agent / capability</span>
+          <span>Review</span>
+          <span>Updated</span>
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto">
+          {entries.length ? entries.map((entry) => (
+            <WorkLedgerRow
+              key={entry.id}
+              entry={entry}
+              selected={entry.id === detailId}
+              onSelect={() => setDetailId(entry.id)}
+              onOpen={() => openEntry(entry)}
+            />
+          )) : (
+            <div className="p-8 text-center text-[13px] text-text-muted">
+              {loading ? 'Loading work ledger...' : 'No ledger entries match this search.'}
+            </div>
+          )}
+          {nextCursor ? (
+            <div className="flex justify-center border-t border-border-subtle p-3">
+              <button type="button" onClick={() => void loadLedger(nextCursor, true)} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover">
+                Load more
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </section>
+      <WorkLedgerDetailDrawer entry={selectedEntry} onClose={() => setDetailId(null)} onOpen={openEntry} />
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/threads/work-ledger-ui.ts
+++ b/apps/desktop/src/renderer/components/threads/work-ledger-ui.ts
@@ -1,0 +1,21 @@
+export const WORK_LEDGER_FEATURE_GATE_KEY = 'open-cowork.feature.workLedgerV1'
+
+function storageOrNull(storage?: Storage | null) {
+  if (storage) return storage
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function isWorkLedgerV1Enabled(storage?: Storage | null) {
+  const target = storageOrNull(storage)
+  if (!target) return false
+  try {
+    return target.getItem(WORK_LEDGER_FEATURE_GATE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -428,6 +428,20 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       },
       reindex: vi.fn(async () => true),
     },
+    workLedger: {
+      search: vi.fn(async () => ({ entries: [], nextCursor: null, totalEstimate: 0 })),
+      facets: vi.fn(async () => ({
+        sourceKinds: [],
+        statuses: [],
+        owners: [],
+        agents: [],
+        capabilities: [],
+        riskLabels: [],
+        governanceLabels: [],
+        reviewStates: [],
+      })),
+      reindex: vi.fn(async () => true),
+    },
     updates: {
       installCapability: vi.fn(async () => ({
         supported: false,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ flowchart LR
         Engine["Session engine<br/>+ event projector"]
         Runtime["Runtime composer<br/>config · provider · MCPs"]
         Auto["Automation control plane<br/>schedule · inbox · runs"]
+        Ledger["Work ledger index<br/>refs · facets · attention"]
         Policy["Safety policies<br/>CSP · MCP URL/stdio · destructive"]
     end
 
@@ -44,6 +45,8 @@ flowchart LR
     OCRT -->|SSE events| Engine
     OCRT -->|spawns| MCPs
     Auto --> Engine
+    Auto --> Ledger
+    Engine --> Ledger
     Main --> Disk
     Policy -.guards.-> Bridge
     Policy -.guards.-> MCPs
@@ -173,6 +176,11 @@ Code:
 - `apps/desktop/src/main/thread-index-store.ts` and
   `apps/desktop/src/main/thread-index-service.ts` — the local Threads
   search/tag projection over the session registry and session history.
+- `apps/desktop/src/main/work-ledger-store.ts` and
+  `apps/desktop/src/main/work-ledger-service.ts` — the durable Work Ledger
+  projection over thread, automation, crew, channel, and governance source
+  records. It stores normalized references and query metadata only, not source
+  payloads.
 
 ### 4. Event projection layer
 
@@ -213,7 +221,7 @@ The renderer owns:
 - chat UX
 - the welcoming Home composer and the Pulse diagnostic dashboard
 - the Threads workspace for indexed history search, tags, saved filters,
-  and suggestions
+  suggestions, and the gated Work Ledger view
 - capabilities and agents UI
 - settings
 - artifact presentation
@@ -273,6 +281,33 @@ Thread types:
 - bound to a private Cowork-managed workspace
 - surfaced to the user as artifacts
 - designed to avoid polluting a real project by default
+
+## Work ledger model
+
+The Work Ledger is a Cowork-owned projection for fleet operations. It is
+not a runtime and does not execute work. OpenCode still owns sessions,
+subsessions, tools, approvals, questions, MCP execution, and streaming event
+semantics; Open Cowork indexes product-layer references so users and future
+Operations surfaces can search work across multiple durable stores.
+
+Indexed sources include:
+- thread/session records from the Threads index
+- automations, recent automation runs, automation tasks, inbox approvals,
+  inbox questions, and deliveries
+- crews, crew runs, delegated crew nodes, crew approvals, policy decisions,
+  and artifacts
+- channel inbound events and delivery records
+- governance incident-control audit events
+
+The ledger schema keeps only normalized lookup fields: source kind/id, title,
+summary, status, timestamps, owner/source label, involved agents, involved
+capabilities, cost/tokens when already summarized, risk/governance labels,
+review state, attention state, source reference, and drill-down route. It
+does not copy tool traces, channel message bodies, approval bodies, webhook
+payloads, credential material, or raw governance metadata. The feature gate is
+`workLedgerV1` and the renderer preference key is
+`open-cowork.feature.workLedgerV1`; it is default-off while backfill and
+Operations integration mature.
 
 ## MCPs, skills, and agents
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -5,7 +5,7 @@
 The desktop app is centered around eight areas:
 - `Home` — welcoming landing surface
 - `Chat` — where OpenCode sessions run
-- `Threads` — searchable history, metadata facets, user tags, and saved filters
+- `Threads` — searchable history, metadata facets, user tags, saved filters, and the gated Work Ledger
 - `Automations` — the durable schedule / inbox / run control plane
 - `Crews` — supervised multi-agent runs with trace, queue, and eval visibility
 - `Agents` — manage built-in and custom agents
@@ -16,7 +16,7 @@ The desktop app is centered around eight areas:
 flowchart TD
     Home["Home<br/>composer · recent threads · @-agent pills"]
     Chat["Chat<br/>session UI · streamed events · approvals"]
-    Threads["Threads<br/>search · facets · tags · filters"]
+    Threads["Threads<br/>search · facets · tags · filters · ledger"]
     Auto["Automations<br/>list · inbox · tasks · runs · deliveries"]
     Crews["Crews<br/>lead · specialists · evaluator · queue"]
     Agents["Agents<br/>built-in + custom"]
@@ -39,7 +39,8 @@ flowchart TD
 
 Home is the landing surface; submitting a prompt routes to Chat in one
 motion. Threads is the full-history workspace for search, facets, tags,
-and saved filters. Pulse, Capabilities, Agents, Crews, and Automations each present a
+saved filters, and the gated Work Ledger. Pulse, Capabilities, Agents,
+Crews, and Automations each present a
 dedicated operational surface; Settings holds appearance, models,
 permissions, channel pairing, and storage.
 
@@ -72,6 +73,16 @@ registry tables share quick filters, sortable operational columns, row
 selection, and disabled states for bulk actions that do not yet have a backing
 service. Automations wire supported bulk pause, resume, and archive actions;
 Capabilities wire single-row dependency drill-downs.
+
+The `workLedgerV1` feature gate is also default-off. Enable it with the
+renderer preference key `open-cowork.feature.workLedgerV1=true` to show the
+Work Ledger tab inside Threads. The ledger is read-only in this phase and
+indexes normalized references to threads, automations, automation runs, crew
+runs, delegated tasks, approvals, questions, deliveries, channel events, and
+governance incidents. It stores titles, status, timestamps, source references,
+owners, agents, capabilities, cost/tokens where available, review state, and
+risk/governance labels; it does not duplicate tool traces, channel bodies,
+approval bodies, webhook payloads, or credentials.
 
 ## Home
 
@@ -144,6 +155,15 @@ Threads is the full-history workspace. The sidebar list remains the
 fast recent-thread switcher, while the Threads page provides indexed
 search, cursor-loaded results, metadata facets, user tags, smart
 filters, and suggestion chips.
+
+When `workLedgerV1` is enabled, Threads also exposes a Work Ledger tab.
+This tab searches across chat and non-chat work from one surface:
+sessions, automations, recent runs, crew runs, delegated tasks, open approvals
+and questions, deliveries, channel events, and governance incidents. Filters
+cover source type, status, review state, owners, agents, capabilities, risk
+labels, governance labels, date ranges, and whether user attention is needed.
+Rows link back to their source of truth: session-backed rows open Chat, and
+non-chat rows route to the owning operational surface.
 
 The page distinguishes actual metadata from suggestions. Actual badges
 come from session evidence such as provider/model, observed agents, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,8 +69,9 @@ own branding, providers, skills, and automations.
     ---
 
     A dedicated Threads workspace for indexed history search, metadata
-    facets, user tags, saved filters, and suggestion-only categorization.
-    The compact sidebar list stays focused on quick switching.
+    facets, user tags, saved filters, suggestion-only categorization, and
+    the gated Work Ledger for cross-surface work search. The compact sidebar
+    list stays focused on quick switching.
 
     [:octicons-arrow-right-24: Threads](threads.md)
 

--- a/docs/threads.md
+++ b/docs/threads.md
@@ -3,7 +3,8 @@
 The Threads workspace is the full-history surface for finding and organizing
 past work. The compact sidebar list stays optimized for quick switching; the
 Threads page handles deeper search, metadata facets, tags, saved filters, and
-category suggestions.
+category suggestions. The `workLedgerV1` gate adds a Work Ledger tab for
+searching non-chat work from the same workspace.
 
 ## Data model
 
@@ -26,6 +27,36 @@ The index stores renderer-safe thread metadata:
 
 It does not index full transcript text, hidden OpenCode runtime directories, or
 provider credentials.
+
+## Work Ledger
+
+The Work Ledger is a separate sidecar projection named `work-ledger.sqlite`.
+It is default-off behind the renderer preference key
+`open-cowork.feature.workLedgerV1` while the backfill and Operations command
+center integrations mature.
+
+Unlike the thread index, the ledger spans multiple durable product stores:
+
+- thread/session records
+- automations, automation runs, automation tasks, inbox approvals/questions,
+  and deliveries
+- crews, crew runs, delegated crew nodes, approvals, policy decisions, and
+  artifacts
+- channel inbound events and delivery records
+- governance incident-control audit events
+
+Every row stores a normalized source reference and drill-down route back to the
+source of truth. The ledger intentionally keeps summaries and lookup metadata
+only: source kind/id, title, status, timestamps, owner/source label, involved
+agents, involved capabilities, review state, user-attention state,
+risk/governance labels, and cost/tokens where another source already provides a
+summary. It does not copy tool traces, channel bodies, webhook payloads,
+approval bodies, raw governance metadata, or credential values.
+
+The Work Ledger tab supports cursor pagination and filters for source kind,
+status, owner, agent, capability, risk label, governance label, review state,
+date range, and user-attention state. Session-backed entries open Chat; other
+entries route to the owning operational surface.
 
 ## Search And Facets
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -118,6 +118,11 @@ import type {
   ThreadTagInput,
 } from './threads.js'
 import type {
+  WorkLedgerFacetSummary,
+  WorkLedgerSearchQuery,
+  WorkLedgerSearchResult,
+} from './work-ledger.js'
+import type {
   UpdateInstallCapability,
   UpdateInstallEvent,
   UpdateInstallStatus,
@@ -168,6 +173,7 @@ export * from './session.js'
 export * from './sops.js'
 export * from './threads.js'
 export * from './updates.js'
+export * from './work-ledger.js'
 export * from './workspace.js'
 
 export type {
@@ -347,6 +353,11 @@ export interface CoworkAPI {
     retireCrew: (request: GovernanceCrewIncidentControlRequest) => Promise<CrewDetail | null>
     quarantineMemory: (request: GovernanceMemoryIncidentControlRequest) => Promise<AgentMemoryEntry | null>
     revokeTool: (request: GovernanceToolIncidentControlRequest) => Promise<GovernanceRevokedTool>
+  }
+  workLedger: {
+    search: (query?: WorkLedgerSearchQuery) => Promise<WorkLedgerSearchResult>
+    facets: (query?: WorkLedgerSearchQuery) => Promise<WorkLedgerFacetSummary>
+    reindex: () => Promise<boolean>
   }
   channels: {
     list: () => Promise<ChannelListPayload>

--- a/packages/shared/src/work-ledger.ts
+++ b/packages/shared/src/work-ledger.ts
@@ -1,0 +1,173 @@
+import type { SessionTokens } from './session.js'
+
+export const COWORK_WORK_LEDGER_SCHEMA_VERSION = 1
+
+export type WorkLedgerSourceKind =
+  | 'thread'
+  | 'automation'
+  | 'automation_run'
+  | 'crew'
+  | 'crew_run'
+  | 'delegated_task'
+  | 'approval'
+  | 'question'
+  | 'delivery'
+  | 'channel_event'
+  | 'governance_incident'
+
+export type WorkLedgerStatus =
+  | 'active'
+  | 'approval_required'
+  | 'approved'
+  | 'archived'
+  | 'automation'
+  | 'blocked'
+  | 'cancelled'
+  | 'completed'
+  | 'delivered'
+  | 'delivering'
+  | 'denied'
+  | 'dispatching'
+  | 'dispatched'
+  | 'dismissed'
+  | 'draft'
+  | 'drafted'
+  | 'enriching'
+  | 'error'
+  | 'evaluating'
+  | 'failed'
+  | 'idle'
+  | 'needs_user'
+  | 'paused'
+  | 'planning'
+  | 'queued'
+  | 'ready'
+  | 'received'
+  | 'retired'
+  | 'reverted'
+  | 'review'
+  | 'running'
+  | 'sending'
+  | 'succeeded'
+  | 'unknown'
+
+export type WorkLedgerReviewState =
+  | 'none'
+  | 'needs_review'
+  | 'approval_requested'
+  | 'approved'
+  | 'denied'
+  | 'resolved'
+  | 'failed'
+
+export type WorkLedgerSort = 'updated_desc' | 'created_desc' | 'title_asc'
+
+export interface WorkLedgerSourceRef {
+  kind: WorkLedgerSourceKind
+  id: string
+  sessionId?: string | null
+  automationId?: string | null
+  automationRunId?: string | null
+  crewId?: string | null
+  crewRunId?: string | null
+  crewNodeId?: string | null
+  approvalId?: string | null
+  questionId?: string | null
+  deliveryId?: string | null
+  channelId?: string | null
+  channelEventId?: string | null
+  governanceAuditEventId?: string | null
+  artifactId?: string | null
+}
+
+export interface WorkLedgerDrilldownRoute {
+  surface: 'thread' | 'automations' | 'crews' | 'channels' | 'operations'
+  sessionId?: string | null
+  automationId?: string | null
+  automationRunId?: string | null
+  crewId?: string | null
+  crewRunId?: string | null
+  channelId?: string | null
+  governanceAuditEventId?: string | null
+}
+
+export interface WorkLedgerUsageSummary {
+  cost: number
+  tokens: SessionTokens
+}
+
+export interface WorkLedgerEntry {
+  schemaVersion: number
+  id: string
+  sourceKind: WorkLedgerSourceKind
+  sourceId: string
+  title: string
+  summary: string | null
+  status: WorkLedgerStatus
+  sourceLabel: string
+  owner: string | null
+  agents: string[]
+  capabilities: string[]
+  usage: WorkLedgerUsageSummary
+  riskLabels: string[]
+  governanceLabels: string[]
+  reviewState: WorkLedgerReviewState
+  needsUserAttention: boolean
+  sourceRef: WorkLedgerSourceRef
+  route: WorkLedgerDrilldownRoute
+  createdAt: string
+  updatedAt: string
+  startedAt: string | null
+  finishedAt: string | null
+  indexedAt: string
+}
+
+export type WorkLedgerUpsertInput = Omit<WorkLedgerEntry, 'schemaVersion' | 'indexedAt'> & {
+  schemaVersion?: number
+  indexedAt?: string
+}
+
+export interface WorkLedgerSearchQuery {
+  text?: string
+  cursor?: string | null
+  limit?: number
+  dateRange?: { from?: string; to?: string }
+  sourceKinds?: WorkLedgerSourceKind[]
+  statuses?: WorkLedgerStatus[]
+  owners?: string[]
+  agents?: string[]
+  capabilities?: string[]
+  riskLabels?: string[]
+  governanceLabels?: string[]
+  reviewStates?: WorkLedgerReviewState[]
+  needsUserAttention?: boolean | null
+  sort?: WorkLedgerSort
+}
+
+export interface WorkLedgerSearchResult {
+  entries: WorkLedgerEntry[]
+  nextCursor: string | null
+  totalEstimate: number
+}
+
+export interface WorkLedgerFacetBucket {
+  value: string
+  label: string
+  count: number
+}
+
+export interface WorkLedgerFacetSummary {
+  sourceKinds: WorkLedgerFacetBucket[]
+  statuses: WorkLedgerFacetBucket[]
+  owners: WorkLedgerFacetBucket[]
+  agents: WorkLedgerFacetBucket[]
+  capabilities: WorkLedgerFacetBucket[]
+  riskLabels: WorkLedgerFacetBucket[]
+  governanceLabels: WorkLedgerFacetBucket[]
+  reviewStates: WorkLedgerFacetBucket[]
+}
+
+export const WORK_LEDGER_SEARCH_DEFAULT_LIMIT = 50
+export const WORK_LEDGER_SEARCH_MAX_LIMIT = 100
+export const WORK_LEDGER_FILTER_MAX_VALUES = 50
+export const WORK_LEDGER_QUERY_MAX_LENGTH = 256

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -15,6 +15,7 @@ import { registerSopHandlers } from '../apps/desktop/src/main/ipc/sop-handlers.t
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
 import { registerThreadHandlers } from '../apps/desktop/src/main/ipc/thread-handlers.ts'
+import { registerWorkLedgerHandlers } from '../apps/desktop/src/main/ipc/work-ledger-handlers.ts'
 
 function createTestContext() {
   const handlers = new Map<string, unknown>()
@@ -85,6 +86,7 @@ test('IPC handler modules register their core channels', () => {
   registerCustomContentHandlers(context)
   registerExplorerHandlers(context)
   registerThreadHandlers(context)
+  registerWorkLedgerHandlers(context)
   context.ipcMain.handle('confirm:request-destructive', async () => ({ token: 'test' }))
 
   // One-way fire-and-forget channels (renderer uses `send`) must also
@@ -115,6 +117,9 @@ test('IPC handler modules register their core channels', () => {
   assert.equal(handlers.has('custom:add-mcp'), true)
   assert.equal(handlers.has('custom:import-skill-directory'), true)
   assert.equal(handlers.has('threads:search'), true)
+  assert.equal(handlers.has('work-ledger:search'), true)
+  assert.equal(handlers.has('work-ledger:facets'), true)
+  assert.equal(handlers.has('work-ledger:reindex'), true)
   assert.equal(handlers.has('crews:list'), true)
   assert.equal(handlers.has('crews:create'), true)
   assert.equal(handlers.has('crews:update'), true)
@@ -184,6 +189,7 @@ test('preload invoke/send channels match registered main-process IPC channels', 
   registerCustomContentHandlers(context)
   registerExplorerHandlers(context)
   registerThreadHandlers(context)
+  registerWorkLedgerHandlers(context)
   context.ipcMain.handle('confirm:request-destructive', async () => ({ token: 'test' }))
 
   const preloadSource = readFileSync('apps/desktop/src/preload/index.ts', 'utf-8')

--- a/tests/work-ledger-service.test.ts
+++ b/tests/work-ledger-service.test.ts
@@ -1,0 +1,395 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type {
+  AutomationListPayload,
+  ChannelListPayload,
+  CrewListPayload,
+  ThreadListItem,
+} from '@open-cowork/shared'
+import {
+  buildWorkLedgerEntriesFromSnapshot,
+  type WorkLedgerSnapshot,
+  WorkLedgerService,
+} from '../apps/desktop/src/main/work-ledger-service.ts'
+import { WorkLedgerStore } from '../apps/desktop/src/main/work-ledger-store.ts'
+
+function thread(overrides: Partial<ThreadListItem> = {}): ThreadListItem {
+  return {
+    sessionId: overrides.sessionId || 'session-1',
+    title: overrides.title || 'Revenue thread',
+    directory: overrides.directory ?? '/workspace/revenue',
+    projectLabel: overrides.projectLabel ?? 'revenue',
+    providerId: overrides.providerId ?? 'openrouter',
+    modelId: overrides.modelId ?? 'openrouter/sonnet',
+    status: overrides.status || 'idle',
+    createdAt: overrides.createdAt || '2026-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt || '2026-01-02T00:00:00.000Z',
+    parentSessionId: overrides.parentSessionId ?? null,
+    automationId: overrides.automationId ?? null,
+    runId: overrides.runId ?? null,
+    revertedMessageId: overrides.revertedMessageId ?? null,
+    tags: overrides.tags || [],
+    actualAgents: overrides.actualAgents || [{ name: 'research', count: 1 }],
+    actualTools: overrides.actualTools || [{ name: 'charts.create', mcpName: 'charts', count: 1 }],
+    suggestions: overrides.suggestions || [],
+    usage: overrides.usage || {
+      messages: 3,
+      toolCalls: 1,
+      taskRuns: 1,
+      cost: 0.2,
+      tokens: { input: 1, output: 2, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+    changeSummary: overrides.changeSummary ?? null,
+  }
+}
+
+function automationState(): AutomationListPayload {
+  return {
+    automations: [{
+      id: 'automation-1',
+      title: 'Weekly report automation',
+      goal: 'Produce the weekly report.',
+      kind: 'recurring',
+      status: 'needs_user',
+      schedule: { type: 'weekly', timezone: 'UTC', dayOfWeek: 1, runAtHour: 9, runAtMinute: 0 },
+      heartbeatMinutes: 60,
+      retryPolicy: { maxRetries: 2, baseDelayMinutes: 5, maxDelayMinutes: 60 },
+      runPolicy: { dailyRunCap: 2, maxRunDurationMinutes: 30 },
+      executionMode: 'scoped_execution',
+      autonomyPolicy: 'review-first',
+      projectDirectory: '/workspace/revenue',
+      preferredAgentNames: ['analyst'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-03T00:00:00.000Z',
+      nextRunAt: null,
+      lastRunAt: '2026-01-02T00:00:00.000Z',
+      nextHeartbeatAt: null,
+      lastHeartbeatAt: null,
+      latestRunStatus: 'needs_user',
+      latestRunId: 'run-1',
+    }],
+    inbox: [{
+      id: 'inbox-approval',
+      automationId: 'automation-1',
+      runId: 'run-1',
+      sessionId: 'session-1',
+      questionId: null,
+      type: 'approval',
+      status: 'open',
+      title: 'Approve delivery',
+      body: 'Do not duplicate password=hunter2',
+      createdAt: '2026-01-03T00:00:00.000Z',
+      updatedAt: '2026-01-03T00:00:00.000Z',
+    }, {
+      id: 'inbox-question',
+      automationId: 'automation-1',
+      runId: 'run-1',
+      sessionId: 'session-1',
+      questionId: 'question-1',
+      type: 'clarification',
+      status: 'open',
+      title: 'Need region',
+      body: 'Which region?',
+      createdAt: '2026-01-03T00:00:00.000Z',
+      updatedAt: '2026-01-03T00:00:00.000Z',
+    }],
+    workItems: [{
+      id: 'work-1',
+      automationId: 'automation-1',
+      runId: 'run-1',
+      title: 'Draft charts',
+      description: 'Create chart pack.',
+      status: 'blocked',
+      blockingReason: 'Approval required.',
+      ownerAgent: 'analyst',
+      dependsOn: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-03T00:00:00.000Z',
+    }],
+    runs: [{
+      id: 'run-1',
+      automationId: 'automation-1',
+      sessionId: 'session-1',
+      kind: 'execution',
+      status: 'needs_user',
+      title: 'Weekly report run',
+      summary: 'Waiting for approval.',
+      error: null,
+      failureCode: null,
+      attempt: 1,
+      retryOfRunId: null,
+      nextRetryAt: null,
+      createdAt: '2026-01-02T00:00:00.000Z',
+      startedAt: '2026-01-02T00:01:00.000Z',
+      finishedAt: null,
+    }],
+    deliveries: [{
+      id: 'delivery-1',
+      automationId: 'automation-1',
+      runId: 'run-1',
+      provider: 'in_app',
+      target: 'local',
+      status: 'delivered',
+      title: 'Weekly report delivered',
+      body: 'Body is not indexed.',
+      createdAt: '2026-01-04T00:00:00.000Z',
+    }],
+  }
+}
+
+function crewCatalog(): CrewListPayload {
+  return {
+    crews: [{
+      definition: {
+        schemaVersion: 1,
+        id: 'crew-1',
+        name: 'Research crew',
+        description: 'Coordinates research specialists.',
+        status: 'active',
+        activeVersionId: 'crew-version-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      },
+      activeVersion: {
+        schemaVersion: 1,
+        id: 'crew-version-1',
+        crewId: 'crew-1',
+        version: 1,
+        members: [{
+          schemaVersion: 1,
+          id: 'lead-research-1',
+          role: 'lead',
+          agentName: 'research',
+          displayName: 'Research',
+          description: 'Lead',
+          required: true,
+        }],
+        workspaceProfileId: 'project-workspace',
+        outcomeRubricId: null,
+        evalSuiteId: null,
+        certificationStatus: 'not_required',
+        certifiedAt: null,
+        budgetCapUsd: null,
+        workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdBy: 'local-user',
+      },
+      latestRun: {
+        schemaVersion: 1,
+        id: 'crew-run-1',
+        crewId: 'crew-1',
+        crewVersionId: 'crew-version-1',
+        workItemId: 'cowork-work-1',
+        status: 'running',
+        title: 'Market scan',
+        summary: null,
+        rootSessionId: 'session-crew',
+        createdAt: '2026-01-04T00:00:00.000Z',
+        startedAt: '2026-01-04T00:01:00.000Z',
+        finishedAt: null,
+      },
+    }],
+  }
+}
+
+function channels(): ChannelListPayload {
+  return {
+    channels: [{
+      schemaVersion: 1,
+      id: 'channel-1',
+      provider: 'local_webhook',
+      name: 'Support webhook',
+      description: null,
+      sourceKey: 'support',
+      enabled: true,
+      senderAllowlist: ['support@example.com'],
+      allowedCapabilityIds: ['support.reply'],
+      route: { schemaVersion: 1, activationMode: 'ask_user', targetSopId: null, targetCrewId: null },
+      workspaceProfileId: 'channel-sandbox',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }],
+    inboundItems: [{
+      schemaVersion: 1,
+      id: 'inbound-1',
+      channelId: 'channel-1',
+      provider: 'local_webhook',
+      source: { schemaVersion: 1, provider: 'local_webhook', sourceKey: 'support', externalMessageId: 'ext-1', replyTarget: null },
+      sender: 'support@example.com',
+      subject: 'Customer escalation',
+      body: 'Do not index token=abc123secret',
+      route: { schemaVersion: 1, activationMode: 'ask_user', targetSopId: null, targetCrewId: null },
+      status: 'needs_user',
+      auditState: 'user_review_required',
+      allowedCapabilityIds: ['support.reply'],
+      workspaceProfileId: 'channel-sandbox',
+      queueItemId: null,
+      deliveryRecordId: null,
+      workItemId: null,
+      runKind: null,
+      runId: null,
+      runStatus: null,
+      approvedAt: null,
+      approvedBy: null,
+      reviewNote: null,
+      receivedAt: '2026-01-05T00:00:00.000Z',
+      updatedAt: '2026-01-05T00:00:00.000Z',
+      error: null,
+    }],
+    deliveries: [],
+  }
+}
+
+function snapshot(): WorkLedgerSnapshot {
+  return {
+    threads: [thread()],
+    automations: automationState(),
+    crews: {
+      catalog: crewCatalog(),
+      runs: [{
+        schemaVersion: 1,
+        id: 'crew-run-1',
+        crewId: 'crew-1',
+        crewVersionId: 'crew-version-1',
+        workItemId: 'cowork-work-1',
+        status: 'running',
+        title: 'Market scan',
+        summary: null,
+        rootSessionId: 'session-crew',
+        createdAt: '2026-01-04T00:00:00.000Z',
+        startedAt: '2026-01-04T00:01:00.000Z',
+        finishedAt: null,
+      }],
+      nodes: [{
+        schemaVersion: 1,
+        id: 'node-1',
+        crewRunId: 'crew-run-1',
+        sequence: 1,
+        kind: 'delegate',
+        status: 'running',
+        agentName: 'research',
+        sessionId: 'session-node',
+        parentNodeId: null,
+        title: 'Search market',
+        startedAt: '2026-01-04T00:02:00.000Z',
+        finishedAt: null,
+      }],
+      workItems: [{
+        schemaVersion: 1,
+        id: 'cowork-work-1',
+        title: 'Market scan',
+        description: 'Scan the market.',
+        source: 'manual',
+        status: 'running',
+        createdAt: '2026-01-04T00:00:00.000Z',
+        updatedAt: '2026-01-04T00:01:00.000Z',
+      }],
+      approvals: [{
+        schemaVersion: 1,
+        id: 'crew-approval-1',
+        crewRunId: 'crew-run-1',
+        nodeId: 'node-1',
+        status: 'requested',
+        title: 'Approve external write',
+        body: 'Do not index secret=crewsecret',
+        requestedAt: '2026-01-04T00:03:00.000Z',
+        resolvedAt: null,
+        resolvedBy: null,
+      }],
+      policyDecisions: [{
+        schemaVersion: 1,
+        id: 'policy-1',
+        runId: 'crew-run-1',
+        runKind: 'crew',
+        nodeId: 'node-1',
+        status: 'approval_required',
+        reason: 'External write requires approval.',
+        capabilityId: 'github.write',
+        createdAt: '2026-01-04T00:04:00.000Z',
+      }],
+      artifacts: [{
+        schemaVersion: 1,
+        id: 'artifact-1',
+        crewRunId: 'crew-run-1',
+        nodeId: 'node-1',
+        title: 'Market scan memo',
+        mime: 'text/markdown',
+        uri: 'private://artifact',
+        hash: null,
+        createdAt: '2026-01-04T00:05:00.000Z',
+      }],
+    },
+    channels: channels(),
+    governanceAuditEvents: [{
+      schemaVersion: 1,
+      id: 'audit-1',
+      kind: 'incident_control',
+      subjectKind: 'tool',
+      subjectId: 'github.write',
+      action: 'revoke_tool',
+      outcome: 'succeeded',
+      actor: { kind: 'user', id: 'local-user', displayName: 'Local user' },
+      reason: 'Reduce blast radius.',
+      beforeLifecycle: null,
+      afterLifecycle: 'revoked',
+      metadata: { secret: 'metadata is not indexed' },
+      createdAt: '2026-01-06T00:00:00.000Z',
+    }],
+  }
+}
+
+function withService(name: string, run: (service: WorkLedgerService, store: WorkLedgerStore) => void) {
+  const root = mkdtempSync(join(tmpdir(), `open-cowork-work-ledger-service-${name}-`))
+  const store = new WorkLedgerStore(join(root, 'work-ledger.sqlite'))
+  const service = new WorkLedgerService(store, { loadSnapshot: snapshot })
+  try {
+    run(service, store)
+  } finally {
+    store.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('work ledger snapshot builder indexes every durable work source without payload bodies', () => {
+  const entries = buildWorkLedgerEntriesFromSnapshot(snapshot())
+  const kinds = new Set(entries.map((entry) => entry.sourceKind))
+  for (const kind of ['thread', 'automation', 'automation_run', 'delegated_task', 'approval', 'question', 'crew', 'crew_run', 'delivery', 'channel_event', 'governance_incident']) {
+    assert.equal(kinds.has(kind as never), true, `${kind} should be indexed`)
+  }
+  const serialized = JSON.stringify(entries)
+  assert.equal(serialized.includes('hunter2'), false)
+  assert.equal(serialized.includes('abc123secret'), false)
+  assert.equal(serialized.includes('crewsecret'), false)
+  assert.equal(serialized.includes('metadata is not indexed'), false)
+})
+
+test('work ledger service backfills, searches, filters, and replaces stale entries', () => withService('query', (service, store) => {
+  assert.equal(service.reindex(), true)
+
+  const attention = service.search({ needsUserAttention: true, limit: 50 })
+  assert.ok(attention.entries.some((entry) => entry.sourceKind === 'approval' && entry.reviewState === 'approval_requested'))
+  assert.ok(attention.entries.some((entry) => entry.sourceKind === 'channel_event'))
+
+  const github = service.search({ capabilities: ['github.write'] })
+  assert.equal(github.entries.some((entry) => entry.sourceId === 'policy_decision:policy-1'), true)
+
+  const facets = service.facets({})
+  assert.ok(facets.sourceKinds.some((bucket) => bucket.value === 'automation_run'))
+  assert.ok(facets.agents.some((bucket) => bucket.value === 'research'))
+
+  store.upsertEntry({
+    ...attention.entries[0]!,
+    id: 'thread:stale',
+    sourceKind: 'thread',
+    sourceId: 'stale',
+    title: 'Stale',
+    sourceRef: { kind: 'thread', id: 'stale', sessionId: 'stale' },
+    route: { surface: 'thread', sessionId: 'stale' },
+  })
+  assert.equal(store.searchEntries({ text: 'stale' }).entries.length, 1)
+  service.reindex()
+  assert.equal(store.searchEntries({ text: 'stale' }).entries.length, 0)
+}))

--- a/tests/work-ledger-store.test.ts
+++ b/tests/work-ledger-store.test.ts
@@ -1,0 +1,137 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { WorkLedgerUpsertInput } from '@open-cowork/shared'
+import { WorkLedgerStore, WORK_LEDGER_SCHEMA_VERSION } from '../apps/desktop/src/main/work-ledger-store.ts'
+
+function withStore(name: string, run: (store: WorkLedgerStore, root: string) => void) {
+  const root = mkdtempSync(join(tmpdir(), `open-cowork-work-ledger-${name}-`))
+  const dbPath = join(root, 'work-ledger.sqlite')
+  const store = new WorkLedgerStore(dbPath)
+  try {
+    run(store, root)
+  } finally {
+    store.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function entry(overrides: Partial<WorkLedgerUpsertInput> = {}): WorkLedgerUpsertInput {
+  const sourceKind = overrides.sourceKind || 'thread'
+  const sourceId = overrides.sourceId || 'session-1'
+  return {
+    id: overrides.id || `${sourceKind}:${sourceId}`,
+    sourceKind,
+    sourceId,
+    title: overrides.title || 'Quarterly revenue analysis',
+    summary: overrides.summary ?? 'Safe summary.',
+    status: overrides.status || 'completed',
+    sourceLabel: overrides.sourceLabel || 'Revenue workspace',
+    owner: overrides.owner ?? 'revenue',
+    agents: overrides.agents || ['research'],
+    capabilities: overrides.capabilities || ['charts.create'],
+    usage: overrides.usage || {
+      cost: 0.25,
+      tokens: { input: 10, output: 20, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+    riskLabels: overrides.riskLabels || [],
+    governanceLabels: overrides.governanceLabels || [],
+    reviewState: overrides.reviewState || 'resolved',
+    needsUserAttention: overrides.needsUserAttention ?? false,
+    sourceRef: overrides.sourceRef || { kind: sourceKind, id: sourceId, sessionId: sourceId },
+    route: overrides.route || { surface: 'thread', sessionId: sourceId },
+    createdAt: overrides.createdAt || '2026-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt || '2026-01-02T00:00:00.000Z',
+    startedAt: overrides.startedAt ?? null,
+    finishedAt: overrides.finishedAt ?? '2026-01-02T00:00:00.000Z',
+  }
+}
+
+test('work ledger store inserts, updates, facets, and cursor-pages indexed entries', () => withStore('search', (store, root) => {
+  for (let index = 0; index < 240; index += 1) {
+    store.upsertEntry(entry({
+      id: `thread:session-${index}`,
+      sourceKind: index % 3 === 0 ? 'automation_run' : 'thread',
+      sourceId: `session-${index}`,
+      title: index % 2 === 0 ? `Revenue ledger row ${index}` : `Incident review ${index}`,
+      status: index % 5 === 0 ? 'needs_user' : 'completed',
+      owner: index % 2 === 0 ? 'finance' : 'ops',
+      agents: index % 2 === 0 ? ['research'] : ['review'],
+      capabilities: index % 3 === 0 ? ['github.pr'] : ['charts.create'],
+      riskLabels: index % 5 === 0 ? ['policy'] : [],
+      governanceLabels: index % 4 === 0 ? ['approval'] : [],
+      reviewState: index % 5 === 0 ? 'needs_review' : 'resolved',
+      needsUserAttention: index % 5 === 0,
+      updatedAt: new Date(Date.UTC(2026, 0, 2, 0, 0, index % 60)).toISOString(),
+    }))
+  }
+
+  const first = store.searchEntries({ text: 'revenue', owners: ['finance'], limit: 20, sort: 'title_asc' })
+  assert.equal(first.entries.length, 20)
+  assert.ok(first.totalEstimate > 100)
+  assert.ok(first.nextCursor)
+  assert.match(first.entries[0]!.title, /Revenue ledger row/)
+
+  const second = store.searchEntries({ text: 'revenue', owners: ['finance'], limit: 20, sort: 'title_asc', cursor: first.nextCursor })
+  assert.equal(second.entries.length, 20)
+  assert.notEqual(second.entries[0]!.id, first.entries[0]!.id)
+
+  const attention = store.searchEntries({ needsUserAttention: true, reviewStates: ['needs_review'] })
+  assert.ok(attention.entries.length > 0)
+  assert.ok(attention.entries.every((item) => item.needsUserAttention))
+
+  const facets = store.listFacets({ text: 'ledger' })
+  assert.ok(facets.sourceKinds.some((bucket) => bucket.value === 'thread'))
+  assert.ok(facets.owners.some((bucket) => bucket.value === 'finance'))
+  assert.ok(facets.agents.some((bucket) => bucket.value === 'research'))
+  assert.ok(facets.capabilities.some((bucket) => bucket.value === 'charts.create'))
+
+  const dbPath = join(root, 'work-ledger.sqlite')
+  assert.equal(statSync(dbPath).mode & 0o777, 0o600)
+  assert.equal(WORK_LEDGER_SCHEMA_VERSION, 1)
+}))
+
+test('work ledger store keeps stable source references across rename and archive updates', () => withStore('refs', (store) => {
+  const original = store.upsertEntry(entry({
+    id: 'automation:automation-1',
+    sourceKind: 'automation',
+    sourceId: 'automation-1',
+    title: 'Weekly report',
+    status: 'ready',
+    sourceRef: { kind: 'automation', id: 'automation-1', automationId: 'automation-1' },
+    route: { surface: 'automations', automationId: 'automation-1' },
+  }))
+  const updated = store.upsertEntry(entry({
+    ...original,
+    title: 'Renamed weekly report',
+    status: 'archived',
+    updatedAt: '2026-02-01T00:00:00.000Z',
+  }))
+
+  assert.equal(updated.title, 'Renamed weekly report')
+  assert.equal(updated.status, 'archived')
+  assert.deepEqual(updated.sourceRef, { kind: 'automation', id: 'automation-1', automationId: 'automation-1' })
+  assert.deepEqual(updated.route, { surface: 'automations', automationId: 'automation-1' })
+  assert.equal(store.searchEntries({ text: 'weekly' }).entries.length, 1)
+}))
+
+test('work ledger store redacts obvious secrets and rejects oversized queries', () => withStore('redaction', (store) => {
+  store.upsertEntry(entry({
+    title: 'Investigate token=super-secret-value',
+    summary: 'Failed with Authorization: Bearer abcdefghijklmnopqrstuvwxyz and password=hunter2',
+  }))
+  const result = store.searchEntries({ text: 'investigate' })
+  assert.equal(result.entries.length, 1)
+  const serialized = JSON.stringify(result.entries[0])
+  assert.equal(serialized.includes('super-secret-value'), false)
+  assert.equal(serialized.includes('abcdefghijklmnopqrstuvwxyz'), false)
+  assert.equal(serialized.includes('hunter2'), false)
+  assert.match(serialized, /redacted/)
+
+  assert.throws(
+    () => store.searchEntries({ text: 'x'.repeat(300) }),
+    /query text exceeds/i,
+  )
+}))


### PR DESCRIPTION
## Summary

Closes #344. Part of #337.

- adds the shared Work Ledger contract, main-process SQLite projection, and IPC/preload API
- indexes normalized references across threads, automations, automation runs, automation work items, crews, crew runs, crew nodes, approvals, policy decisions, deliveries, channel events, and governance audit events
- adds a default-off `workLedgerV1` renderer gate via `open-cowork.feature.workLedgerV1` and a gated Work Ledger tab inside Threads
- documents the storage model, source boundaries, feature gate, and sensitive-payload exclusions

## Feature gate

- Gate: `workLedgerV1`
- Renderer preference key: `open-cowork.feature.workLedgerV1`
- Default: off

## Test Gates

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test -- work-ledger-store work-ledger-service ipc-handler-registration`
- `pnpm --filter @open-cowork/desktop test:renderer -- ThreadsPage`
- `uv run mkdocs build --strict`
- `git diff --check`
