### PR TITLE
Productize gated crew builder

### DIFF
--- a/apps/desktop/src/main/crew-operational-queue.ts
+++ b/apps/desktop/src/main/crew-operational-queue.ts
@@ -45,6 +45,7 @@ function terminalOperationalStatus(status: CrewRunStatus): Exclude<OperationalQu
 export function enqueueCrewOperationalQueueItem(detail: CrewRunDetail, options: {
   workspaceProfileId?: string | null
   channelId?: string | null
+  budgetCapUsd?: number | null
 } = {}) {
   const workspaceProfileId = resolveCrewWorkspaceProfileId(options.workspaceProfileId || detail.version.workspaceProfileId)
   const profile = getWorkspaceProfile(workspaceProfileId)
@@ -56,6 +57,11 @@ export function enqueueCrewOperationalQueueItem(detail: CrewRunDetail, options: 
     profile?.authority.filesystem.writeAllowed
       || externalSystemIds.length > 0,
   )
+  const maxCostUsd = typeof options.budgetCapUsd === 'number' && Number.isFinite(options.budgetCapUsd) && options.budgetCapUsd > 0
+    ? (typeof detail.version.budgetCapUsd === 'number' && detail.version.budgetCapUsd > 0
+        ? Math.min(options.budgetCapUsd, detail.version.budgetCapUsd)
+        : options.budgetCapUsd)
+    : detail.version.budgetCapUsd
   return enqueueOperationalRun({
     runKind: 'crew',
     runId: detail.run.id,
@@ -71,7 +77,7 @@ export function enqueueCrewOperationalQueueItem(detail: CrewRunDetail, options: 
     caps: applyOperationalQueueSettings({
       maxParallel: 1,
       maxRunDurationMinutes: 60,
-      maxCostUsd: detail.version.budgetCapUsd,
+      maxCostUsd,
       maxRetries: 0,
     }, { writeCapable }),
   })

--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -1042,6 +1042,7 @@ export function startCrewRun(
   const specialists = activeVersion.members.filter((member) => member.role === 'specialist')
   const evaluator = activeVersion.members.find((member) => member.role === 'evaluator')
   if (specialists.length < 2 || !evaluator) throw new Error('Crew active version needs at least two specialists and one evaluator before it can run.')
+  const runBudgetCapUsd = boundedOptionalPositiveNumber(draft.budgetCapUsd, 'Crew run budget cap')
 
   return withCrewTransaction(() => {
     const workItemTitle = boundedOptionalString(draft.workItemTitle, 'Crew work item title')
@@ -1052,7 +1053,7 @@ export function startCrewRun(
       || draft.constraints
       || draft.dueAt
       || draft.urgency
-      || draft.budgetCapUsd
+      || runBudgetCapUsd !== null
       || draft.approvalRequirements
       || draft.sourceContext
     )

--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -224,6 +224,14 @@ function normalizeApprovalPolicy(value: CrewDefinitionDraft['approvalPolicy']): 
   throw new Error('Crew approval policy is invalid.')
 }
 
+function resolveUpdatedApprovalPolicy(
+  value: CrewDefinitionDraft['approvalPolicy'],
+  currentPolicy: CrewApprovalPolicy | null | undefined,
+): CrewApprovalPolicy {
+  if (value === undefined || value === null) return currentPolicy || DEFAULT_CREW_APPROVAL_POLICY
+  return normalizeApprovalPolicy(value)
+}
+
 export function validateCrewDefinitionDraft(
   draft: CrewDefinitionDraft,
   options: { knownAgentNames?: readonly string[] } = {},
@@ -290,6 +298,7 @@ export function updateCrewFromDraft(crewId: string, draft: CrewDefinitionDraft):
   return withCrewTransaction(() => {
     const current = getCrewDefinition(id)
     if (!current) throw new Error(`Crew ${id} does not exist.`)
+    const currentVersion = current.activeVersionId ? getCrewVersion(current.activeVersionId) : null
     const definition = updateCrewDefinitionMetadata(id, {
       name: boundedString(draft.name, 'Crew name'),
       description: boundedString(draft.description, 'Crew description'),
@@ -302,7 +311,7 @@ export function updateCrewFromDraft(crewId: string, draft: CrewDefinitionDraft):
       outcomeRubricId: ensureCrewOutcomeRubricId(draft.outcomeRubricId || null),
       evalSuiteId: ensureCrewEvalSuiteId(draft.evalSuiteId || null),
       budgetCapUsd: draft.budgetCapUsd ?? null,
-      approvalPolicy: normalizeApprovalPolicy(draft.approvalPolicy),
+      approvalPolicy: resolveUpdatedApprovalPolicy(draft.approvalPolicy, currentVersion?.approvalPolicy),
       workflow: [...FIXED_CREW_WORKFLOW],
       createdBy: 'local-user',
     })

--- a/apps/desktop/src/main/crew-service.ts
+++ b/apps/desktop/src/main/crew-service.ts
@@ -3,6 +3,7 @@ import {
   COWORK_EVAL_SCHEMA_VERSION,
   type CrewDefinitionDraft,
   type CrewDetail,
+  type CrewApprovalPolicy,
   type CrewLifecycleStatus,
   type CrewListPayload,
   type CrewMember,
@@ -12,6 +13,7 @@ import {
   type OutcomeEvaluationStatus,
   type CrewRunDetail,
   type CrewRunDraft,
+  type CrewRunUrgency,
   type TraceActor,
   type TraceEventSource,
   type GovernancePrincipal,
@@ -82,9 +84,12 @@ const MAX_CREW_STRING_BYTES = 16 * 1024
 const MAX_EVALUATION_EVIDENCE_EVENTS = 100
 const MAX_EVALUATION_TRACE_PROMPT_EVENTS = 80
 const FIXED_CREW_WORKFLOW = ['plan', 'delegate', 'join', 'evaluate', 'deliver'] as const
+const DEFAULT_CREW_APPROVAL_POLICY: CrewApprovalPolicy = 'review-before-delivery'
+const CREW_APPROVAL_POLICIES = new Set<CrewApprovalPolicy>(['review-before-delivery', 'auto-deliver-after-evaluation'])
+const CREW_RUN_URGENCIES = new Set<CrewRunUrgency>(['low', 'normal', 'high', 'urgent'])
 const inFlightEvaluationRunIds = new Set<string>()
 const DEFAULT_CREW_OUTCOME_RUBRIC = {
-  name: 'Research crew outcome rubric',
+  name: 'Crew outcome rubric',
   description: 'Checks whether the crew output is correct, evidence-backed, and useful enough to deliver.',
   passingScore: 80,
   criteria: [
@@ -133,6 +138,52 @@ function boundedOptionalString(value: unknown, label: string) {
   return boundedString(value, label)
 }
 
+function boundedOptionalPositiveNumber(value: unknown, label: string) {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a positive number.`)
+  }
+  return value
+}
+
+function normalizeCrewRunUrgency(value: CrewRunDraft['urgency']) {
+  if (value === undefined || value === null) return null
+  if (CREW_RUN_URGENCIES.has(value)) return value
+  throw new Error('Crew run urgency is invalid.')
+}
+
+function normalizeCrewRunDueAt(value: CrewRunDraft['dueAt']) {
+  const dueAt = boundedOptionalString(value, 'Crew run due date')
+  if (!dueAt) return null
+  if (Number.isNaN(Date.parse(dueAt))) throw new Error('Crew run due date is invalid.')
+  return dueAt
+}
+
+function appendRunDetailLine(lines: string[], label: string, value: string | number | null | undefined) {
+  if (value === undefined || value === null || value === '') return
+  lines.push(`${label}: ${value}`)
+}
+
+function crewRunWorkItemDescription(draft: CrewRunDraft, fallback: string) {
+  const description = boundedOptionalString(draft.workItemDescription, 'Crew work item description')
+  const expectedDeliverable = boundedOptionalString(draft.expectedDeliverable, 'Crew expected deliverable')
+  const constraints = boundedOptionalString(draft.constraints, 'Crew run constraints')
+  const dueAt = normalizeCrewRunDueAt(draft.dueAt)
+  const urgency = normalizeCrewRunUrgency(draft.urgency)
+  const budgetCapUsd = boundedOptionalPositiveNumber(draft.budgetCapUsd, 'Crew run budget cap')
+  const approvalRequirements = boundedOptionalString(draft.approvalRequirements, 'Crew approval requirements')
+  const sourceContext = boundedOptionalString(draft.sourceContext, 'Crew source context')
+  const lines = [description || fallback]
+  appendRunDetailLine(lines, 'Expected deliverable', expectedDeliverable)
+  appendRunDetailLine(lines, 'Constraints', constraints)
+  appendRunDetailLine(lines, 'Due date', dueAt)
+  appendRunDetailLine(lines, 'Urgency', urgency)
+  appendRunDetailLine(lines, 'Run budget cap USD', budgetCapUsd)
+  appendRunDetailLine(lines, 'Approval requirements', approvalRequirements)
+  appendRunDetailLine(lines, 'Source context', sourceContext)
+  return lines.join('\n')
+}
+
 function boundedIncidentReason(value: unknown, fallback: string) {
   if (value === undefined || value === null) return fallback
   if (typeof value !== 'string') throw new Error('Crew incident reason must be a string.')
@@ -167,12 +218,31 @@ function normalizeCrewMember(draft: CrewMemberDraft, index: number): CrewMember 
   }
 }
 
-export function validateCrewDefinitionDraft(draft: CrewDefinitionDraft) {
+function normalizeApprovalPolicy(value: CrewDefinitionDraft['approvalPolicy']): CrewApprovalPolicy {
+  if (value === undefined || value === null) return DEFAULT_CREW_APPROVAL_POLICY
+  if (CREW_APPROVAL_POLICIES.has(value)) return value
+  throw new Error('Crew approval policy is invalid.')
+}
+
+export function validateCrewDefinitionDraft(
+  draft: CrewDefinitionDraft,
+  options: { knownAgentNames?: readonly string[] } = {},
+) {
   boundedString(draft.name, 'Crew name')
   boundedString(draft.description, 'Crew description')
   if (!Array.isArray(draft.members)) throw new Error('Crew members must be an array.')
   if (draft.members.length > MAX_CREW_MEMBERS) throw new Error('Crew has too many members.')
   const members = draft.members.map(normalizeCrewMember)
+  const knownAgents = new Set((options.knownAgentNames || []).map((name) => name.trim().toLowerCase()).filter(Boolean))
+  const agentNames = new Set<string>()
+  for (const member of members) {
+    const normalizedAgentName = member.agentName.toLowerCase()
+    if (agentNames.has(normalizedAgentName)) throw new Error(`Crew member ${member.agentName} is assigned more than once.`)
+    agentNames.add(normalizedAgentName)
+    if (knownAgents.size > 0 && !knownAgents.has(normalizedAgentName)) {
+      throw new Error(`Crew member ${member.agentName} does not match a known agent.`)
+    }
+  }
   const leadCount = members.filter((member) => member.role === 'lead').length
   const specialistCount = members.filter((member) => member.role === 'specialist').length
   const evaluatorCount = members.filter((member) => member.role === 'evaluator').length
@@ -184,6 +254,7 @@ export function validateCrewDefinitionDraft(draft: CrewDefinitionDraft) {
       throw new Error('Crew budget cap must be a positive number.')
     }
   }
+  normalizeApprovalPolicy(draft.approvalPolicy)
   return members
 }
 
@@ -202,6 +273,7 @@ export function createCrewFromDraft(draft: CrewDefinitionDraft): CrewDetail {
       outcomeRubricId: ensureCrewOutcomeRubricId(draft.outcomeRubricId || null),
       evalSuiteId: ensureCrewEvalSuiteId(draft.evalSuiteId || null),
       budgetCapUsd: draft.budgetCapUsd ?? null,
+      approvalPolicy: normalizeApprovalPolicy(draft.approvalPolicy),
       workflow: [...FIXED_CREW_WORKFLOW],
       createdBy: 'local-user',
     })
@@ -230,6 +302,7 @@ export function updateCrewFromDraft(crewId: string, draft: CrewDefinitionDraft):
       outcomeRubricId: ensureCrewOutcomeRubricId(draft.outcomeRubricId || null),
       evalSuiteId: ensureCrewEvalSuiteId(draft.evalSuiteId || null),
       budgetCapUsd: draft.budgetCapUsd ?? null,
+      approvalPolicy: normalizeApprovalPolicy(draft.approvalPolicy),
       workflow: [...FIXED_CREW_WORKFLOW],
       createdBy: 'local-user',
     })
@@ -483,6 +556,7 @@ function buildCrewLeadPrompt(detail: CrewRunDetail) {
     `Crew: ${detail.crew.name}`,
     `Lead agent: ${lead?.agentName || 'unknown'}`,
     `Evaluator agent: ${evaluator?.agentName || 'none configured'}`,
+    `Approval policy: ${detail.version.approvalPolicy.replaceAll('-', ' ')}`,
     workItem,
     '',
     'Workflow:',
@@ -696,6 +770,7 @@ export async function startCrewRunWithOpenCode(
   const queueItem = enqueueCrewOperationalQueueItem(runDetail, {
     workspaceProfileId: options.workspaceProfileId,
     channelId: options.channelId,
+    budgetCapUsd: draft.budgetCapUsd ?? null,
   })
   const started = startCrewOperationalQueueItem(runDetail.run.id)
   if (started?.status !== 'running') {
@@ -966,12 +1041,23 @@ export function startCrewRun(
   }
   const specialists = activeVersion.members.filter((member) => member.role === 'specialist')
   const evaluator = activeVersion.members.find((member) => member.role === 'evaluator')
-  if (specialists.length < 2 || !evaluator) throw new Error('Crew active version does not satisfy the MVP branch/join shape.')
+  if (specialists.length < 2 || !evaluator) throw new Error('Crew active version needs at least two specialists and one evaluator before it can run.')
 
   return withCrewTransaction(() => {
     const workItemTitle = boundedOptionalString(draft.workItemTitle, 'Crew work item title')
-    const workItemDescription = boundedOptionalString(draft.workItemDescription, 'Crew work item description')
-    const workItem = workItemTitle || workItemDescription
+    const hasWorkItem = Boolean(
+      workItemTitle
+      || draft.workItemDescription
+      || draft.expectedDeliverable
+      || draft.constraints
+      || draft.dueAt
+      || draft.urgency
+      || draft.budgetCapUsd
+      || draft.approvalRequirements
+      || draft.sourceContext
+    )
+    const workItemDescription = hasWorkItem ? crewRunWorkItemDescription(draft, workItemTitle || title) : null
+    const workItem = hasWorkItem
       ? createCoworkWorkItem({
         title: workItemTitle || title,
         description: workItemDescription || workItemTitle || title,
@@ -1031,6 +1117,9 @@ export function startCrewRun(
         crewId,
         crewVersionId: activeVersion.id,
         workflow: activeVersion.workflow,
+        approvalPolicy: activeVersion.approvalPolicy,
+        urgency: normalizeCrewRunUrgency(draft.urgency),
+        dueAt: normalizeCrewRunDueAt(draft.dueAt),
       },
     })
     for (const node of [plan, ...delegates, join, evaluate, deliver]) {

--- a/apps/desktop/src/main/crew-store.ts
+++ b/apps/desktop/src/main/crew-store.ts
@@ -7,6 +7,7 @@ import {
   COWORK_TRACE_EVENT_SCHEMA_VERSION,
   type CoworkWorkItem,
   type CrewCertificationStatus,
+  type CrewApprovalPolicy,
   type CrewDefinition,
   type CrewApproval,
   type CrewApprovalStatus,
@@ -38,10 +39,12 @@ import {
 } from '@open-cowork/shared'
 import { getAppDataDir } from './config-loader.ts'
 
-export const CREW_STORE_SCHEMA_VERSION = 2
+export const CREW_STORE_SCHEMA_VERSION = 3
 const CREW_SCHEMA_VERSION_KEY = 'schema_version'
 const EVALUATION_STATUSES = new Set<OutcomeEvaluationStatus>(['passed', 'failed', 'needs_revision', 'needs_human'])
 const EVALUATION_RECOMMENDATIONS = new Set<OutcomeEvaluation['recommendation']>(['deliver', 'revise', 'escalate'])
+const DEFAULT_CREW_APPROVAL_POLICY: CrewApprovalPolicy = 'review-before-delivery'
+const CREW_APPROVAL_POLICIES = new Set<CrewApprovalPolicy>(['review-before-delivery', 'auto-deliver-after-evaluation'])
 
 type DbRow = Record<string, unknown>
 
@@ -111,6 +114,11 @@ function migrateCrewStore(db: DatabaseSync) {
       db.exec('alter table crew_versions add column certified_at text;')
     }
   }
+  if (version < 3) {
+    if (!tableHasColumn(db, 'crew_versions', 'approval_policy')) {
+      db.exec(`alter table crew_versions add column approval_policy text not null default '${DEFAULT_CREW_APPROVAL_POLICY}';`)
+    }
+  }
 }
 
 export function getCrewDb() {
@@ -177,6 +185,7 @@ export function getCrewDb() {
         certification_status text not null default 'not_required',
         certified_at text,
         budget_cap_usd real,
+        approval_policy text not null default 'review-before-delivery',
         workflow_json text not null,
         created_at text not null,
         created_by text,
@@ -403,6 +412,9 @@ function rowToCrewDefinition(row: DbRow): CrewDefinition {
 }
 
 function rowToCrewVersion(row: DbRow): CrewVersion {
+  const approvalPolicy = CREW_APPROVAL_POLICIES.has(row.approval_policy as CrewApprovalPolicy)
+    ? row.approval_policy as CrewApprovalPolicy
+    : DEFAULT_CREW_APPROVAL_POLICY
   return {
     schemaVersion: Number(row.schema_version || COWORK_CREW_SCHEMA_VERSION),
     id: String(row.id || ''),
@@ -415,6 +427,7 @@ function rowToCrewVersion(row: DbRow): CrewVersion {
     certificationStatus: String(row.certification_status || 'not_required') as CrewCertificationStatus,
     certifiedAt: typeof row.certified_at === 'string' ? row.certified_at : null,
     budgetCapUsd: typeof row.budget_cap_usd === 'number' ? row.budget_cap_usd : null,
+    approvalPolicy,
     workflow: parseJson<CrewVersion['workflow']>(row.workflow_json, []),
     createdAt: String(row.created_at || ''),
     createdBy: typeof row.created_by === 'string' ? row.created_by : null,
@@ -697,6 +710,7 @@ export function createCrewVersion(input: {
   outcomeRubricId?: string | null
   evalSuiteId?: string | null
   budgetCapUsd?: number | null
+  approvalPolicy?: CrewApprovalPolicy | null
   workflow?: CrewVersion['workflow']
   createdBy?: string | null
 }) {
@@ -713,8 +727,8 @@ export function createCrewVersion(input: {
       insert into crew_versions (
         id, schema_version, crew_id, version, members_json, workspace_profile_id,
         outcome_rubric_id, eval_suite_id, certification_status, certified_at,
-        budget_cap_usd, workflow_json, created_at, created_by
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, null, ?, ?, ?, ?)
+        budget_cap_usd, approval_policy, workflow_json, created_at, created_by
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, null, ?, ?, ?, ?, ?)
     `).run(
       id,
       COWORK_CREW_SCHEMA_VERSION,
@@ -726,6 +740,7 @@ export function createCrewVersion(input: {
       input.evalSuiteId || null,
       input.evalSuiteId ? 'required' : 'not_required',
       input.budgetCapUsd ?? null,
+      input.approvalPolicy || DEFAULT_CREW_APPROVAL_POLICY,
       JSON.stringify(input.workflow || ['plan', 'delegate', 'join', 'evaluate', 'deliver']),
       now,
       input.createdBy || null,

--- a/apps/desktop/src/main/ipc/crew-handlers.ts
+++ b/apps/desktop/src/main/ipc/crew-handlers.ts
@@ -54,6 +54,14 @@ function assertCrewDraftPayload(value: unknown): asserts value is CrewDefinition
   if (value.budgetCapUsd !== undefined && value.budgetCapUsd !== null && typeof value.budgetCapUsd !== 'number') {
     throw new Error('Crew budget cap must be a number.')
   }
+  if (
+    value.approvalPolicy !== undefined
+    && value.approvalPolicy !== null
+    && value.approvalPolicy !== 'review-before-delivery'
+    && value.approvalPolicy !== 'auto-deliver-after-evaluation'
+  ) {
+    throw new Error('Crew approval policy is invalid.')
+  }
 }
 
 function assertCrewRunDraftPayload(value: unknown): asserts value is CrewRunDraft {
@@ -62,6 +70,24 @@ function assertCrewRunDraftPayload(value: unknown): asserts value is CrewRunDraf
   assertString(value.title, 'Crew run title')
   assertOptionalString(value.workItemTitle, 'Crew work item title')
   assertOptionalString(value.workItemDescription, 'Crew work item description')
+  assertOptionalString(value.expectedDeliverable, 'Crew expected deliverable')
+  assertOptionalString(value.constraints, 'Crew run constraints')
+  assertOptionalString(value.dueAt, 'Crew run due date')
+  assertOptionalString(value.approvalRequirements, 'Crew approval requirements')
+  assertOptionalString(value.sourceContext, 'Crew source context')
+  if (
+    value.urgency !== undefined
+    && value.urgency !== null
+    && value.urgency !== 'low'
+    && value.urgency !== 'normal'
+    && value.urgency !== 'high'
+    && value.urgency !== 'urgent'
+  ) {
+    throw new Error('Crew run urgency is invalid.')
+  }
+  if (value.budgetCapUsd !== undefined && value.budgetCapUsd !== null && typeof value.budgetCapUsd !== 'number') {
+    throw new Error('Crew run budget cap must be a number.')
+  }
 }
 
 export function registerCrewHandlers(context: IpcHandlerContext) {

--- a/apps/desktop/src/renderer/components/crews/CrewVersionEditor.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewVersionEditor.tsx
@@ -64,6 +64,12 @@ function displayNameForAgent(agentName: string, options: CrewAgentOption[]) {
   return agentOptionByName(options).get(agentName)?.label || agentName
 }
 
+function resolveWorkspaceProfileId(value: string | null | undefined, profiles: readonly WorkspaceProfile[]) {
+  if (!value || value === 'default') return null
+  if (profiles.length === 0) return value
+  return normalizeWorkspaceProfileId(value, profiles)
+}
+
 function firstAvailableAgent(options: CrewAgentOption[], usedAgentNames: Set<string>) {
   return options.find((option) => !option.disabled && !usedAgentNames.has(option.name)) || options.find((option) => !option.disabled) || options[0] || null
 }
@@ -132,7 +138,7 @@ export function CrewVersionEditor({
     if (!valid || busy) return
     await onSave({
       ...draft,
-      workspaceProfileId: normalizeWorkspaceProfileId(draft.workspaceProfileId || '', workspaceProfiles),
+      workspaceProfileId: resolveWorkspaceProfileId(draft.workspaceProfileId, workspaceProfiles),
       approvalPolicy: draft.approvalPolicy || 'review-before-delivery',
     })
   }

--- a/apps/desktop/src/renderer/components/crews/CrewVersionEditor.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewVersionEditor.tsx
@@ -1,14 +1,31 @@
 import { useMemo, useState } from 'react'
-import type { CrewDefinitionDraft, CrewDetail, CrewMemberDraft } from '@open-cowork/shared'
+import type { CrewApprovalPolicy, CrewDefinitionDraft, CrewDetail, CrewMemberDraft, WorkspaceProfile } from '@open-cowork/shared'
+import {
+  CREW_TEMPLATES,
+  draftFromCrewTemplate,
+  normalizeWorkspaceProfileId,
+  summarizeAgentOption,
+  validateCrewDraftForBuilder,
+  type CrewAgentOption,
+  type CrewTemplateId,
+} from './crew-builder-ui'
 
 type CrewVersionEditorProps = {
-  detail: CrewDetail
+  detail?: CrewDetail | null
+  initialDraft?: CrewDefinitionDraft | null
+  mode?: 'create' | 'edit'
   busy: boolean
+  agentOptions?: CrewAgentOption[]
+  workspaceProfiles?: WorkspaceProfile[]
   onCancel: () => void
   onSave: (draft: CrewDefinitionDraft) => Promise<void>
 }
 
 const ROLE_OPTIONS: CrewMemberDraft['role'][] = ['lead', 'specialist', 'evaluator']
+const APPROVAL_POLICIES: Array<{ value: CrewApprovalPolicy; label: string }> = [
+  { value: 'review-before-delivery', label: 'Review before delivery' },
+  { value: 'auto-deliver-after-evaluation', label: 'Auto-deliver after evaluation' },
+]
 
 function draftFromDetail(detail: CrewDetail): CrewDefinitionDraft {
   return {
@@ -25,37 +42,63 @@ function draftFromDetail(detail: CrewDetail): CrewDefinitionDraft {
     outcomeRubricId: detail.activeVersion?.outcomeRubricId || null,
     evalSuiteId: detail.activeVersion?.evalSuiteId || null,
     budgetCapUsd: detail.activeVersion?.budgetCapUsd ?? null,
+    approvalPolicy: detail.activeVersion?.approvalPolicy || 'review-before-delivery',
   }
 }
 
-function countRole(members: CrewMemberDraft[], role: CrewMemberDraft['role']) {
-  return members.filter((member) => member.role === role).length
+function initialEditorDraft(input: {
+  detail?: CrewDetail | null
+  initialDraft?: CrewDefinitionDraft | null
+  agentOptions: CrewAgentOption[]
+}) {
+  if (input.initialDraft) return input.initialDraft
+  if (input.detail) return draftFromDetail(input.detail)
+  return draftFromCrewTemplate('operations', input.agentOptions)
 }
 
-function canSaveDraft(draft: CrewDefinitionDraft) {
-  return draft.name.trim().length > 0
-    && draft.description.trim().length > 0
-    && countRole(draft.members, 'lead') >= 1
-    && countRole(draft.members, 'specialist') >= 2
-    && countRole(draft.members, 'evaluator') >= 1
-    && draft.members.every((member) => member.agentName.trim().length > 0)
-    && (draft.budgetCapUsd === null || draft.budgetCapUsd === undefined || draft.budgetCapUsd > 0)
+function agentOptionByName(options: CrewAgentOption[]) {
+  return new Map(options.map((option) => [option.name, option]))
 }
 
-function newMember(role: CrewMemberDraft['role']): CrewMemberDraft {
+function displayNameForAgent(agentName: string, options: CrewAgentOption[]) {
+  return agentOptionByName(options).get(agentName)?.label || agentName
+}
+
+function firstAvailableAgent(options: CrewAgentOption[], usedAgentNames: Set<string>) {
+  return options.find((option) => !option.disabled && !usedAgentNames.has(option.name)) || options.find((option) => !option.disabled) || options[0] || null
+}
+
+function newMember(role: CrewMemberDraft['role'], options: CrewAgentOption[], usedAgentNames: Set<string>): CrewMemberDraft {
+  const fallbackAgent = role === 'lead' ? 'plan' : role === 'evaluator' ? 'general' : 'build'
+  const option = options.find((entry) => entry.name === fallbackAgent && !entry.disabled && !usedAgentNames.has(entry.name))
+    || firstAvailableAgent(options, usedAgentNames)
+  const agentName = option?.name || fallbackAgent
   return {
     role,
-    agentName: role === 'lead' ? 'plan' : role === 'evaluator' ? 'general' : 'build',
-    displayName: role === 'lead' ? 'Lead' : role === 'evaluator' ? 'Evaluator' : 'Specialist',
+    agentName,
+    displayName: option?.label || (role === 'lead' ? 'Lead' : role === 'evaluator' ? 'Evaluator' : 'Specialist'),
     description: '',
     required: true,
   }
 }
 
-export function CrewVersionEditor({ detail, busy, onCancel, onSave }: CrewVersionEditorProps) {
-  const [draft, setDraft] = useState<CrewDefinitionDraft>(() => draftFromDetail(detail))
-  const valid = useMemo(() => canSaveDraft(draft), [draft])
-  const nextVersion = (detail.activeVersion?.version || detail.versions.length || 0) + 1
+export function CrewVersionEditor({
+  detail = null,
+  initialDraft = null,
+  mode = 'edit',
+  busy,
+  agentOptions = [],
+  workspaceProfiles = [],
+  onCancel,
+  onSave,
+}: CrewVersionEditorProps) {
+  const [templateId, setTemplateId] = useState<CrewTemplateId>('operations')
+  const [draft, setDraft] = useState<CrewDefinitionDraft>(() => initialEditorDraft({ detail, initialDraft, agentOptions }))
+  const issues = useMemo(() => validateCrewDraftForBuilder(draft, agentOptions), [agentOptions, draft])
+  const valid = issues.length === 0
+  const nextVersion = mode === 'create' ? 1 : (detail?.activeVersion?.version || detail?.versions.length || 0) + 1
+  const agentOptionsByName = useMemo(() => agentOptionByName(agentOptions), [agentOptions])
+  const usedAgentNames = useMemo(() => new Set(draft.members.map((member) => member.agentName).filter(Boolean)), [draft.members])
 
   const updateMember = (index: number, patch: Partial<CrewMemberDraft>) => {
     setDraft((current) => ({
@@ -76,23 +119,38 @@ export function CrewVersionEditor({ detail, busy, onCancel, onSave }: CrewVersio
   const addMember = (role: CrewMemberDraft['role']) => {
     setDraft((current) => ({
       ...current,
-      members: [...current.members, newMember(role)],
+      members: [...current.members, newMember(role, agentOptions, usedAgentNames)],
     }))
+  }
+
+  const applyTemplate = (nextTemplateId: CrewTemplateId) => {
+    setTemplateId(nextTemplateId)
+    setDraft(draftFromCrewTemplate(nextTemplateId, agentOptions))
   }
 
   const save = async () => {
     if (!valid || busy) return
-    await onSave(draft)
+    await onSave({
+      ...draft,
+      workspaceProfileId: normalizeWorkspaceProfileId(draft.workspaceProfileId || '', workspaceProfiles),
+      approvalPolicy: draft.approvalPolicy || 'review-before-delivery',
+    })
   }
 
   return (
     <section className="rounded-lg border border-border-subtle bg-surface p-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <div className="text-[11px] font-semibold uppercase tracking-widest text-text-muted">Crew editor</div>
-          <h3 className="mt-1 text-[17px] font-semibold text-text">Save version {nextVersion}</h3>
+          <div className="text-[11px] font-semibold uppercase tracking-widest text-text-muted">
+            {mode === 'create' ? 'Crew builder' : 'Crew editor'}
+          </div>
+          <h3 className="mt-1 text-[17px] font-semibold text-text">
+            {mode === 'create' ? 'Create reusable team' : `Save version ${nextVersion}`}
+          </h3>
           <p className="mt-1 max-w-2xl text-[13px] leading-6 text-text-secondary">
-            Edits create a new active crew version. Existing runs stay pinned to the exact version that created them.
+            {mode === 'create'
+              ? 'Versioned team definitions capture member roles, authority, and evaluation policy before runs begin.'
+              : 'Edits create a new active crew version. Existing runs stay pinned to the exact version that created them.'}
           </p>
         </div>
         <div className="flex gap-2">
@@ -110,10 +168,27 @@ export function CrewVersionEditor({ detail, busy, onCancel, onSave }: CrewVersio
             disabled={busy || !valid}
             className="rounded-md bg-accent px-3 py-2 text-[12px] font-semibold text-background hover:opacity-90 disabled:opacity-50"
           >
-            {busy ? 'Saving...' : 'Save new version'}
+            {busy ? 'Saving...' : mode === 'create' ? 'Create crew' : 'Save new version'}
           </button>
         </div>
       </div>
+
+      {mode === 'create' ? (
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          {CREW_TEMPLATES.map((template) => (
+            <button
+              key={template.id}
+              type="button"
+              onClick={() => applyTemplate(template.id)}
+              aria-current={templateId === template.id ? 'true' : undefined}
+              className={`rounded-md border px-3 py-3 text-left ${templateId === template.id ? 'border-accent bg-accent/10' : 'border-border-subtle bg-elevated hover:bg-surface-hover'}`}
+            >
+              <div className="text-[13px] font-semibold text-text">{template.label}</div>
+              <div className="mt-1 text-[12px] leading-5 text-text-secondary">{template.description}</div>
+            </button>
+          ))}
+        </div>
+      ) : null}
 
       <div className="mt-5 grid gap-3 md:grid-cols-2">
         <label className="block text-[12px] font-medium text-text-secondary">
@@ -138,8 +213,52 @@ export function CrewVersionEditor({ detail, busy, onCancel, onSave }: CrewVersio
             className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
           />
         </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Workspace profile
+          <select
+            value={draft.workspaceProfileId || 'default'}
+            onChange={(event) => setDraft((current) => ({
+              ...current,
+              workspaceProfileId: normalizeWorkspaceProfileId(event.target.value, workspaceProfiles),
+            }))}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          >
+            <option value="default">Default sandbox</option>
+            {workspaceProfiles.map((profile) => (
+              <option key={profile.id} value={profile.id}>{profile.name}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Approval policy
+          <select
+            value={draft.approvalPolicy || 'review-before-delivery'}
+            onChange={(event) => setDraft((current) => ({ ...current, approvalPolicy: event.target.value as CrewApprovalPolicy }))}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          >
+            {APPROVAL_POLICIES.map((policy) => (
+              <option key={policy.value} value={policy.value}>{policy.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Rubric id
+          <input
+            value={draft.outcomeRubricId || ''}
+            onChange={(event) => setDraft((current) => ({ ...current, outcomeRubricId: event.target.value || null }))}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Eval suite id
+          <input
+            value={draft.evalSuiteId || ''}
+            onChange={(event) => setDraft((current) => ({ ...current, evalSuiteId: event.target.value || null }))}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          />
+        </label>
         <label className="block text-[12px] font-medium text-text-secondary md:col-span-2">
-          Description
+          Purpose
           <textarea
             value={draft.description}
             onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))}
@@ -154,7 +273,7 @@ export function CrewVersionEditor({ detail, busy, onCancel, onSave }: CrewVersio
           <div>
             <div className="text-[12px] font-semibold uppercase tracking-widest text-text-muted">Members</div>
             <div className="mt-1 text-[12px] text-text-secondary">
-              Requires at least one lead, two specialists, and one evaluator.
+              Crew shape: one lead, at least two specialists, and one evaluator from the loaded agent catalog.
             </div>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -165,55 +284,90 @@ export function CrewVersionEditor({ detail, busy, onCancel, onSave }: CrewVersio
         </div>
 
         <div className="mt-3 space-y-3">
-          {draft.members.map((member, index) => (
-            <div key={`${member.role}-${index}`} className="rounded-md border border-border-subtle bg-elevated p-3">
-              <div className="grid gap-3 md:grid-cols-[160px_1fr_1fr_auto]">
-                <label className="block text-[11px] font-medium uppercase tracking-widest text-text-muted">
-                  Role
-                  <select
-                    value={member.role}
-                    onChange={(event) => updateMember(index, { role: event.target.value as CrewMemberDraft['role'] })}
-                    className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
+          {draft.members.map((member, index) => {
+            const option = agentOptionsByName.get(member.agentName)
+            return (
+              <div key={`${member.role}-${index}`} className="rounded-md border border-border-subtle bg-elevated p-3">
+                <div className="grid gap-3 xl:grid-cols-[150px_minmax(180px,1fr)_minmax(180px,1fr)_120px_auto]">
+                  <label className="block text-[11px] font-medium uppercase tracking-widest text-text-muted">
+                    Role
+                    <select
+                      value={member.role}
+                      onChange={(event) => updateMember(index, { role: event.target.value as CrewMemberDraft['role'] })}
+                      className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
+                    >
+                      {ROLE_OPTIONS.map((role) => <option key={role} value={role}>{role}</option>)}
+                    </select>
+                  </label>
+                  <label className="block text-[11px] font-medium uppercase tracking-widest text-text-muted">
+                    Agent
+                    {agentOptions.length > 0 ? (
+                      <select
+                        value={member.agentName}
+                        onChange={(event) => updateMember(index, {
+                          agentName: event.target.value,
+                          displayName: displayNameForAgent(event.target.value, agentOptions),
+                        })}
+                        className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
+                      >
+                        {agentOptions.map((agent) => (
+                          <option key={agent.name} value={agent.name} disabled={agent.disabled}>{agent.label}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        value={member.agentName}
+                        onChange={(event) => updateMember(index, { agentName: event.target.value })}
+                        className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
+                      />
+                    )}
+                  </label>
+                  <label className="block text-[11px] font-medium uppercase tracking-widest text-text-muted">
+                    Display name
+                    <input
+                      value={member.displayName || ''}
+                      onChange={(event) => updateMember(index, { displayName: event.target.value })}
+                      className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
+                    />
+                  </label>
+                  <label className="flex items-end gap-2 pb-2 text-[12px] text-text-secondary">
+                    <input
+                      type="checkbox"
+                      checked={member.required ?? true}
+                      onChange={(event) => updateMember(index, { required: event.target.checked })}
+                    />
+                    Required
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => removeMember(index)}
+                    className="self-end rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover"
                   >
-                    {ROLE_OPTIONS.map((role) => <option key={role} value={role}>{role}</option>)}
-                  </select>
-                </label>
-                <label className="block text-[11px] font-medium uppercase tracking-widest text-text-muted">
-                  Agent
+                    Remove
+                  </button>
+                </div>
+                <label className="mt-3 block text-[11px] font-medium uppercase tracking-widest text-text-muted">
+                  Responsibility
                   <input
-                    value={member.agentName}
-                    onChange={(event) => updateMember(index, { agentName: event.target.value })}
+                    value={member.description || ''}
+                    onChange={(event) => updateMember(index, { description: event.target.value })}
                     className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
                   />
                 </label>
-                <label className="block text-[11px] font-medium uppercase tracking-widest text-text-muted">
-                  Display name
-                  <input
-                    value={member.displayName || ''}
-                    onChange={(event) => updateMember(index, { displayName: event.target.value })}
-                    className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
-                  />
-                </label>
-                <button
-                  type="button"
-                  onClick={() => removeMember(index)}
-                  className="self-end rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover"
-                >
-                  Remove
-                </button>
+                <div className="mt-2 text-[11px] text-text-muted">
+                  {summarizeAgentOption(option)} | Max parallel tasks: 1 per crew run
+                </div>
               </div>
-              <label className="mt-3 block text-[11px] font-medium uppercase tracking-widest text-text-muted">
-                Description
-                <input
-                  value={member.description || ''}
-                  onChange={(event) => updateMember(index, { description: event.target.value })}
-                  className="mt-1 w-full rounded-md border border-border-subtle bg-surface px-2 py-2 text-[12px] normal-case tracking-normal text-text outline-none focus:border-accent"
-                />
-              </label>
-            </div>
-          ))}
+            )
+          })}
         </div>
       </div>
+
+      {issues.length > 0 ? (
+        <div className="mt-4 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-100">
+          {issues[0]}
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/apps/desktop/src/renderer/components/crews/CrewVersionEditor.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewVersionEditor.tsx
@@ -67,7 +67,7 @@ function displayNameForAgent(agentName: string, options: CrewAgentOption[]) {
 function resolveWorkspaceProfileId(value: string | null | undefined, profiles: readonly WorkspaceProfile[]) {
   if (!value || value === 'default') return null
   if (profiles.length === 0) return value
-  return normalizeWorkspaceProfileId(value, profiles)
+  return normalizeWorkspaceProfileId(value, profiles) || value
 }
 
 function firstAvailableAgent(options: CrewAgentOption[], usedAgentNames: Set<string>) {
@@ -105,6 +105,8 @@ export function CrewVersionEditor({
   const nextVersion = mode === 'create' ? 1 : (detail?.activeVersion?.version || detail?.versions.length || 0) + 1
   const agentOptionsByName = useMemo(() => agentOptionByName(agentOptions), [agentOptions])
   const usedAgentNames = useMemo(() => new Set(draft.members.map((member) => member.agentName).filter(Boolean)), [draft.members])
+  const workspaceProfileIds = useMemo(() => new Set(workspaceProfiles.map((profile) => profile.id)), [workspaceProfiles])
+  const unlistedWorkspaceProfileId = draft.workspaceProfileId && !workspaceProfileIds.has(draft.workspaceProfileId) ? draft.workspaceProfileId : null
 
   const updateMember = (index: number, patch: Partial<CrewMemberDraft>) => {
     setDraft((current) => ({
@@ -225,11 +227,14 @@ export function CrewVersionEditor({
             value={draft.workspaceProfileId || 'default'}
             onChange={(event) => setDraft((current) => ({
               ...current,
-              workspaceProfileId: normalizeWorkspaceProfileId(event.target.value, workspaceProfiles),
+              workspaceProfileId: resolveWorkspaceProfileId(event.target.value, workspaceProfiles),
             }))}
             className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
           >
             <option value="default">Default sandbox</option>
+            {unlistedWorkspaceProfileId ? (
+              <option value={unlistedWorkspaceProfileId}>Current profile ({unlistedWorkspaceProfileId})</option>
+            ) : null}
             {workspaceProfiles.map((profile) => (
               <option key={profile.id} value={profile.id}>{profile.name}</option>
             ))}

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -406,6 +406,45 @@ describe('CrewsPage', () => {
     })))
   })
 
+  it('keeps create form edits when the gated agent catalog finishes loading', async () => {
+    window.localStorage.setItem(CREW_BUILDER_V2_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    let resolveBuiltInAgents: (agents: BuiltInAgentDetail[]) => void = () => undefined
+    const builtInAgents = new Promise<BuiltInAgentDetail[]>((resolve) => {
+      resolveBuiltInAgents = resolve
+    })
+    installRendererTestCoworkApi({
+      app: {
+        builtinAgents: vi.fn(() => builtInAgents),
+      },
+      agents: {
+        list: vi.fn(async () => []),
+        runtime: vi.fn(async () => []),
+      },
+      operations: {
+        workspaceProfiles: vi.fn(async () => []),
+      },
+      crews: {
+        list: vi.fn(async () => ({ crews: [] })),
+        get: vi.fn(async () => detail),
+        create: vi.fn(async () => detail),
+        runDetail: vi.fn(async () => null),
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Create crew' }))
+    const name = screen.getByLabelText('Crew name')
+    await user.clear(name)
+    await user.type(name, 'Slow Catalog Team')
+
+    resolveBuiltInAgents(builderAgents)
+
+    await waitFor(() => expect(window.coworkApi.app.builtinAgents).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.getByDisplayValue('Slow Catalog Team')).toBeInTheDocument())
+  })
+
   it('saves crew edits through a new active version', async () => {
     const user = userEvent.setup()
     const updatedVersion = {

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -462,6 +462,44 @@ describe('CrewsPage', () => {
     }))
   })
 
+  it('preserves an existing workspace profile when editing without a loaded profile catalog', async () => {
+    const user = userEvent.setup()
+    const workspaceVersion = {
+      ...version,
+      workspaceProfileId: 'project-workspace',
+    }
+    const workspaceDetail: CrewDetail = {
+      ...detail,
+      versions: [workspaceVersion],
+      activeVersion: workspaceVersion,
+    }
+    const update = vi.fn(async () => workspaceDetail)
+    installRendererTestCoworkApi({
+      crews: {
+        list: vi.fn(async () => ({
+          crews: [{ definition: crew, activeVersion: workspaceVersion, latestRun: run }],
+        })),
+        get: vi.fn(async () => workspaceDetail),
+        runDetail: vi.fn(async () => runDetail),
+        update,
+        evaluate: vi.fn(async () => runDetail),
+        exportTrace: vi.fn(async () => traceNdjson),
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Edit crew' }))
+    const budget = screen.getByLabelText('Budget cap')
+    await user.clear(budget)
+    await user.type(budget, '5')
+    await user.click(screen.getByRole('button', { name: 'Save new version' }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith(crew.id, expect.objectContaining({
+      workspaceProfileId: 'project-workspace',
+    })))
+  })
+
   it('uses the gated agent picker when saving a new crew version', async () => {
     window.localStorage.setItem(CREW_BUILDER_V2_FEATURE_GATE_KEY, 'true')
     const user = userEvent.setup()

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import type { CrewDetail, CrewListPayload, CrewRunDetail } from '@open-cowork/shared'
+import type { BuiltInAgentDetail, CrewDetail, CrewListPayload, CrewRunDetail, WorkspaceProfile } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { CrewsPage } from './CrewsPage'
 import { FLEET_REGISTRY_FEATURE_GATE_KEY } from '../fleet/fleet-registry-model'
+import { CREW_BUILDER_V2_FEATURE_GATE_KEY } from './crew-builder-ui'
 
 vi.mock('../../helpers/i18n', () => ({
   t: (_key: string, fallback: string) => fallback,
@@ -38,6 +39,7 @@ const version = {
   certificationStatus: 'not_required' as const,
   certifiedAt: null,
   budgetCapUsd: 4,
+  approvalPolicy: 'review-before-delivery' as const,
   workflow: ['plan' as const, 'delegate' as const, 'join' as const, 'evaluate' as const, 'deliver' as const],
   createdAt: '2026-05-10T00:00:00.000Z',
   createdBy: 'local-user',
@@ -50,7 +52,7 @@ const run = {
   crewVersionId: version.id,
   workItemId: 'work-1',
   status: 'planning' as const,
-  title: 'Starter team run',
+  title: 'Team run',
   summary: null,
   rootSessionId: null,
   createdAt: '2026-05-10T00:01:00.000Z',
@@ -210,6 +212,65 @@ const traceNdjson = [
   '{"schemaVersion":1,"id":"trace-2","payload":{"type":"crew_run.tool_call","toolName":"web_search"}}',
 ].join('\n')
 
+function builtinAgent(name: string, label: string): BuiltInAgentDetail {
+  return {
+    name,
+    label,
+    source: 'open-cowork',
+    mode: name === 'plan' ? 'primary' : 'subagent',
+    hidden: false,
+    disabled: false,
+    color: 'info',
+    description: `${label} agent.`,
+    instructions: `${label} instructions.`,
+    skills: [],
+    toolAccess: [],
+    nativeToolIds: [],
+    configuredToolIds: name === 'build' ? ['edit'] : [],
+    model: null,
+    variant: null,
+    temperature: null,
+    top_p: null,
+    steps: null,
+    options: null,
+  }
+}
+
+const builderAgents = [
+  builtinAgent('plan', 'Planner'),
+  builtinAgent('explore', 'Explorer'),
+  builtinAgent('build', 'Builder'),
+  builtinAgent('general', 'Generalist'),
+]
+
+const projectWorkspace: WorkspaceProfile = {
+  schemaVersion: 1,
+  id: 'project-workspace',
+  kind: 'project_workspace',
+  name: 'Project workspace',
+  description: 'Project-bound workspace.',
+  authority: {
+    schemaVersion: 1,
+    filesystem: {
+      mode: 'project',
+      roots: ['/workspace/project'],
+      writeAllowed: true,
+    },
+    externalSystems: [],
+    cleanup: {
+      retentionDays: 90,
+      deletesUnreferencedArtifacts: false,
+    },
+    isolation: {
+      projectBound: true,
+      channelBound: false,
+      highRiskIsolated: false,
+    },
+  },
+  createdAt: '2026-05-10T00:00:00.000Z',
+  updatedAt: '2026-05-10T00:00:00.000Z',
+}
+
 describe('CrewsPage', () => {
   it('loads crew detail and renders operational run panels from trace state', async () => {
     installRendererTestCoworkApi({
@@ -264,7 +325,7 @@ describe('CrewsPage', () => {
     expect(tagButton).toHaveAttribute('title', expect.stringContaining('not persisted'))
   })
 
-  it('creates the starter crew and runs the team', async () => {
+  it('creates the default crew and runs the team while the builder gate is off', async () => {
     const user = userEvent.setup()
     const create = vi.fn(async () => detail)
     const runCrew = vi.fn(async () => runDetail)
@@ -282,9 +343,10 @@ describe('CrewsPage', () => {
 
     render(<CrewsPage />)
 
-    await user.click(await screen.findByRole('button', { name: 'Create starter crew' }))
+    await user.click(await screen.findByRole('button', { name: 'Create crew' }))
     await waitFor(() => expect(create).toHaveBeenCalledWith(expect.objectContaining({
-      name: 'Operations Crew',
+      name: 'Operations Team',
+      approvalPolicy: 'review-before-delivery',
       members: expect.arrayContaining([
         expect.objectContaining({ role: 'lead', agentName: 'plan' }),
         expect.objectContaining({ role: 'evaluator', agentName: 'general' }),
@@ -294,7 +356,53 @@ describe('CrewsPage', () => {
     await user.click(screen.getByRole('button', { name: 'Run team' }))
     await waitFor(() => expect(runCrew).toHaveBeenCalledWith(expect.objectContaining({
       crewId: crew.id,
-      title: 'Starter team run',
+      title: 'Team run',
+    })))
+  })
+
+  it('creates a gated reusable crew from a template with explicit agent assignments', async () => {
+    window.localStorage.setItem(CREW_BUILDER_V2_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    const create = vi.fn(async () => detail)
+    installRendererTestCoworkApi({
+      app: {
+        builtinAgents: vi.fn(async () => builderAgents),
+      },
+      agents: {
+        list: vi.fn(async () => []),
+        runtime: vi.fn(async () => []),
+      },
+      operations: {
+        workspaceProfiles: vi.fn(async () => [projectWorkspace]),
+      },
+      crews: {
+        list: vi.fn(async () => ({ crews: [] })),
+        get: vi.fn(async () => detail),
+        create,
+        runDetail: vi.fn(async () => null),
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Create crew' }))
+    expect(await screen.findByText('Crew builder')).toBeInTheDocument()
+    await waitFor(() => expect(window.coworkApi.app.builtinAgents).toHaveBeenCalledTimes(1))
+    await user.click(screen.getByRole('button', { name: /Analysis team/ }))
+    await user.selectOptions(screen.getByLabelText('Workspace profile'), 'project-workspace')
+    const saveButtons = screen.getAllByRole('button', { name: 'Create crew' })
+    await user.click(saveButtons[saveButtons.length - 1]!)
+
+    await waitFor(() => expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Analysis Team',
+      workspaceProfileId: 'project-workspace',
+      approvalPolicy: 'review-before-delivery',
+      members: [
+        expect.objectContaining({ role: 'lead', agentName: 'plan' }),
+        expect.objectContaining({ role: 'specialist', agentName: 'explore' }),
+        expect.objectContaining({ role: 'specialist', agentName: 'general' }),
+        expect.objectContaining({ role: 'evaluator', agentName: 'build' }),
+      ],
     })))
   })
 
@@ -354,6 +462,100 @@ describe('CrewsPage', () => {
     }))
   })
 
+  it('uses the gated agent picker when saving a new crew version', async () => {
+    window.localStorage.setItem(CREW_BUILDER_V2_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    const update = vi.fn(async () => detail)
+    installRendererTestCoworkApi({
+      app: {
+        builtinAgents: vi.fn(async () => builderAgents),
+      },
+      agents: {
+        list: vi.fn(async () => []),
+        runtime: vi.fn(async () => []),
+      },
+      crews: {
+        list: vi.fn(async () => payload()),
+        get: vi.fn(async () => detail),
+        runDetail: vi.fn(async () => runDetail),
+        update,
+        evaluate: vi.fn(async () => runDetail),
+        exportTrace: vi.fn(async () => traceNdjson),
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Edit crew' }))
+    await waitFor(() => expect(window.coworkApi.app.builtinAgents).toHaveBeenCalledTimes(1))
+    const agentSelects = screen.getAllByLabelText('Agent')
+    await user.selectOptions(agentSelects[1]!, 'general')
+    await user.selectOptions(agentSelects[3]!, 'explore')
+    await user.click(screen.getByRole('button', { name: 'Save new version' }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith(crew.id, expect.objectContaining({
+      approvalPolicy: 'review-before-delivery',
+      members: expect.arrayContaining([
+        expect.objectContaining({ role: 'specialist', agentName: 'general' }),
+        expect.objectContaining({ role: 'evaluator', agentName: 'explore' }),
+      ]),
+    })))
+  })
+
+  it('starts a gated crew run from a structured run request', async () => {
+    window.localStorage.setItem(CREW_BUILDER_V2_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    const runCrew = vi.fn(async () => ({
+      ...runDetail,
+      run: {
+        ...runDetail.run,
+        title: 'Weekly operations review',
+      },
+    }))
+    installRendererTestCoworkApi({
+      crews: {
+        list: vi.fn(async () => payload()),
+        get: vi.fn(async () => detail),
+        run: runCrew,
+        runDetail: vi.fn(async () => runDetail),
+        evaluate: vi.fn(async () => runDetail),
+        exportTrace: vi.fn(async () => traceNdjson),
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'New run request' }))
+    await user.clear(screen.getByLabelText('Run title'))
+    await user.type(screen.getByLabelText('Run title'), 'Weekly operations review')
+    await user.type(screen.getByLabelText('Work item'), 'Week 20 operator handoff')
+    await user.type(screen.getByLabelText('Objective'), 'Prepare the weekly operating review and call out blocked work.')
+    await user.type(screen.getByLabelText('Expected deliverable'), 'Markdown briefing')
+    await user.type(screen.getByLabelText('Due date'), '2026-05-20T09:30')
+    await user.selectOptions(screen.getByLabelText('Urgency'), 'high')
+    await user.type(screen.getByLabelText('Run budget cap'), '2.5')
+    await user.type(screen.getByLabelText('Constraints'), 'Use only in-repo evidence.')
+    await user.clear(screen.getByLabelText('Approval requirements'))
+    await user.type(screen.getByLabelText('Approval requirements'), 'Require evaluator pass before delivery.')
+    await user.type(screen.getByLabelText('Source context'), 'Operations notes are in docs/operations.md.')
+    await user.click(screen.getByRole('button', { name: 'Start run' }))
+
+    await waitFor(() => expect(runCrew).toHaveBeenCalledWith({
+      crewId: crew.id,
+      title: 'Weekly operations review',
+      workItemTitle: 'Week 20 operator handoff',
+      workItemDescription: 'Prepare the weekly operating review and call out blocked work.',
+      expectedDeliverable: 'Markdown briefing',
+      dueAt: '2026-05-20T09:30',
+      urgency: 'high',
+      budgetCapUsd: 2.5,
+      approvalRequirements: 'Require evaluator pass before delivery.',
+      constraints: 'Use only in-repo evidence.',
+      sourceContext: 'Operations notes are in docs/operations.md.',
+      workItemSource: 'manual',
+    }))
+  })
+
   it('exports trace events as deterministic NDJSON through the save dialog', async () => {
     const user = userEvent.setup()
     const saveText = vi.fn(async (_defaultFilename: string, _content: string) => '/tmp/crew-trace.ndjson')
@@ -377,7 +579,7 @@ describe('CrewsPage', () => {
 
     await waitFor(() => expect(saveText).toHaveBeenCalledTimes(1))
     expect(exportTrace).toHaveBeenCalledWith(run.id)
-    expect(saveText.mock.calls[0]?.[0]).toBe('starter-team-run-trace.ndjson')
+    expect(saveText.mock.calls[0]?.[0]).toBe('team-run-trace.ndjson')
     expect(saveText.mock.calls[0]?.[1]).toContain('"id":"trace-1"')
     expect(saveText.mock.calls[0]?.[1]).toContain('"type":"crew_run.tool_call"')
   })
@@ -501,7 +703,7 @@ describe('CrewsPage', () => {
 
     await waitFor(() => expect(deleteCrew).toHaveBeenCalledWith(crew.id, 'delete-token'))
     expect(requestDestructive).toHaveBeenCalledWith({ action: 'crew.delete', crewId: crew.id })
-    expect(await screen.findByText('No crews yet. Create a starter crew to seed your first supervised team.')).toBeInTheDocument()
+    expect(await screen.findByText('No crews yet. Create a crew to seed your first supervised team.')).toBeInTheDocument()
   })
 
   it('retires a crew with run history and disables new runs', async () => {

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.test.tsx
@@ -500,6 +500,57 @@ describe('CrewsPage', () => {
     })))
   })
 
+  it('preserves an unlisted existing workspace profile when the gated catalog is incomplete', async () => {
+    window.localStorage.setItem(CREW_BUILDER_V2_FEATURE_GATE_KEY, 'true')
+    const user = userEvent.setup()
+    const workspaceVersion = {
+      ...version,
+      workspaceProfileId: 'project-workspace',
+    }
+    const workspaceDetail: CrewDetail = {
+      ...detail,
+      versions: [workspaceVersion],
+      activeVersion: workspaceVersion,
+    }
+    const update = vi.fn(async () => workspaceDetail)
+    installRendererTestCoworkApi({
+      app: {
+        builtinAgents: vi.fn(async () => builderAgents),
+      },
+      agents: {
+        list: vi.fn(async () => []),
+        runtime: vi.fn(async () => []),
+      },
+      operations: {
+        workspaceProfiles: vi.fn(async () => [{ ...projectWorkspace, id: 'other-workspace', name: 'Other workspace' }]),
+      },
+      crews: {
+        list: vi.fn(async () => ({
+          crews: [{ definition: crew, activeVersion: workspaceVersion, latestRun: run }],
+        })),
+        get: vi.fn(async () => workspaceDetail),
+        runDetail: vi.fn(async () => runDetail),
+        update,
+        evaluate: vi.fn(async () => runDetail),
+        exportTrace: vi.fn(async () => traceNdjson),
+      },
+    })
+
+    render(<CrewsPage />)
+
+    await waitFor(() => expect(window.coworkApi.operations.workspaceProfiles).toHaveBeenCalledTimes(1))
+    await user.click(await screen.findByRole('button', { name: 'Edit crew' }))
+    expect(screen.getByRole('option', { name: 'Current profile (project-workspace)' })).toBeInTheDocument()
+    const budget = screen.getByLabelText('Budget cap')
+    await user.clear(budget)
+    await user.type(budget, '5')
+    await user.click(screen.getByRole('button', { name: 'Save new version' }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith(crew.id, expect.objectContaining({
+      workspaceProfileId: 'project-workspace',
+    })))
+  })
+
   it('uses the gated agent picker when saving a new crew version', async () => {
     window.localStorage.setItem(CREW_BUILDER_V2_FEATURE_GATE_KEY, 'true')
     const user = userEvent.setup()

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
@@ -829,7 +829,6 @@ export function CrewsPage() {
         <section className="min-h-0 overflow-y-auto p-6">
           {creatingCrew ? (
             <CrewVersionEditor
-              key={`create-${agentOptions.map((agent) => agent.name).join('|')}`}
               mode="create"
               initialDraft={draftFromCrewTemplate('operations', agentOptions)}
               busy={busy}

--- a/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
+++ b/apps/desktop/src/renderer/components/crews/CrewsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { CrewDefinitionDraft, CrewDetail, CrewListItem, CrewRunDetail } from '@open-cowork/shared'
+import type { CrewDefinitionDraft, CrewDetail, CrewListItem, CrewRunDetail, CrewRunUrgency, WorkspaceProfile } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import { confirmCrewDelete, confirmCrewRetire } from '../../helpers/destructive-actions'
 import {
@@ -10,6 +10,15 @@ import {
   traceToolName,
 } from './crew-run-detail-utils'
 import { CrewVersionEditor } from './CrewVersionEditor'
+import {
+  buildCrewAgentOptions,
+  draftFromCrewTemplate,
+  emptyRunRequest,
+  isCrewBuilderV2Enabled,
+  runDraftFromRequest,
+  type CrewAgentOption,
+  type CrewRunRequestDraft,
+} from './crew-builder-ui'
 import { FleetRegistryTable, FleetRegistryViewToggle } from '../fleet/FleetRegistryTable'
 import {
   buildCrewRegistryItems,
@@ -19,7 +28,7 @@ import {
 } from '../fleet/fleet-registry-model'
 import { useFleetRegistryPreferences } from '../fleet/useFleetRegistryPreferences'
 
-const STARTER_CREW_MEMBERS = [
+const DEFAULT_CREW_MEMBERS = [
   { role: 'lead' as const, agentName: 'plan', displayName: 'Planner', description: 'Decomposes the work and keeps the run scoped.' },
   { role: 'specialist' as const, agentName: 'explore', displayName: 'Explorer', description: 'Finds evidence and maps unknowns.' },
   { role: 'specialist' as const, agentName: 'build', displayName: 'Builder', description: 'Turns evidence into the requested artifact.' },
@@ -133,9 +142,10 @@ function AuthorityPanel({ detail }: { detail: CrewRunDetail }) {
         </div>
         <StatusPill value={detail.run.status} />
       </div>
-      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
         <MetricTile label="Workspace" value={version.workspaceProfileId || 'Default'} hint="Crew workspace profile" />
         <MetricTile label="Budget cap" value={version.budgetCapUsd ? formatMoney(version.budgetCapUsd) : 'None'} hint="Run cost guardrail" />
+        <MetricTile label="Approval" value={version.approvalPolicy.replaceAll('-', ' ')} hint="Delivery policy" />
         <MetricTile label="Policy decisions" value={String(decisions.length)} hint={decisions.length ? decisions.map((decision) => decision.status.replaceAll('_', ' ')).join(', ') : 'No decisions yet'} />
         <MetricTile label="Root session" value={detail.run.rootSessionId ? detail.run.rootSessionId.slice(0, 8) : 'Pending'} hint="OpenCode execution source" />
       </div>
@@ -307,6 +317,156 @@ function TraceTimeline({ detail }: { detail: CrewRunDetail }) {
   )
 }
 
+function CrewRunRequestPanel({
+  crewName,
+  versionBudgetCapUsd,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  crewName: string
+  versionBudgetCapUsd: number | null
+  busy: boolean
+  onCancel: () => void
+  onSubmit: (request: CrewRunRequestDraft) => Promise<void>
+}) {
+  const [request, setRequest] = useState<CrewRunRequestDraft>(() => emptyRunRequest(crewName))
+  const valid = request.title.trim().length > 0 && request.objective.trim().length > 0
+    && (!request.budgetCapUsd.trim() || (Number.isFinite(Number(request.budgetCapUsd)) && Number(request.budgetCapUsd) > 0))
+
+  const update = (patch: Partial<CrewRunRequestDraft>) => setRequest((current) => ({ ...current, ...patch }))
+
+  return (
+    <section className="rounded-lg border border-border-subtle bg-surface p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-widest text-text-muted">Run request</div>
+          <h3 className="mt-1 text-[17px] font-semibold text-text">Start crew work</h3>
+          <p className="mt-1 max-w-2xl text-[13px] leading-6 text-text-secondary">
+            Structured intake becomes durable run context before lead dispatch through OpenCode.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[12px] font-medium text-text hover:bg-surface-hover disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void onSubmit(request)}
+            disabled={busy || !valid}
+            className="rounded-md bg-accent px-3 py-2 text-[12px] font-semibold text-background hover:opacity-90 disabled:opacity-50"
+          >
+            {busy ? 'Starting...' : 'Start run'}
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Run title
+          <input
+            value={request.title}
+            onChange={(event) => update({ title: event.target.value })}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Work item
+          <input
+            value={request.workItemTitle}
+            onChange={(event) => update({ workItemTitle: event.target.value })}
+            placeholder="Optional short label"
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent placeholder:text-text-muted"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary md:col-span-2">
+          Objective
+          <textarea
+            value={request.objective}
+            onChange={(event) => update({ objective: event.target.value })}
+            rows={3}
+            className="mt-1 w-full resize-none rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] leading-5 text-text outline-none focus:border-accent"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Expected deliverable
+          <input
+            value={request.expectedDeliverable}
+            onChange={(event) => update({ expectedDeliverable: event.target.value })}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Due date
+          <input
+            type="datetime-local"
+            value={request.dueAt}
+            onChange={(event) => update({ dueAt: event.target.value })}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Urgency
+          <select
+            value={request.urgency}
+            onChange={(event) => update({ urgency: event.target.value as CrewRunUrgency })}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          >
+            <option value="low">Low</option>
+            <option value="normal">Normal</option>
+            <option value="high">High</option>
+            <option value="urgent">Urgent</option>
+          </select>
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Run budget cap
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={request.budgetCapUsd}
+            placeholder={versionBudgetCapUsd ? String(versionBudgetCapUsd) : 'No per-run cap'}
+            onChange={(event) => update({ budgetCapUsd: event.target.value })}
+            className="mt-1 w-full rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] text-text outline-none focus:border-accent placeholder:text-text-muted"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary md:col-span-2">
+          Constraints
+          <textarea
+            value={request.constraints}
+            onChange={(event) => update({ constraints: event.target.value })}
+            rows={2}
+            className="mt-1 w-full resize-none rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] leading-5 text-text outline-none focus:border-accent"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Approval requirements
+          <textarea
+            value={request.approvalRequirements}
+            onChange={(event) => update({ approvalRequirements: event.target.value })}
+            rows={2}
+            className="mt-1 w-full resize-none rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] leading-5 text-text outline-none focus:border-accent"
+          />
+        </label>
+        <label className="block text-[12px] font-medium text-text-secondary">
+          Source context
+          <textarea
+            value={request.sourceContext}
+            onChange={(event) => update({ sourceContext: event.target.value })}
+            rows={2}
+            className="mt-1 w-full resize-none rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[13px] leading-5 text-text outline-none focus:border-accent"
+          />
+        </label>
+      </div>
+    </section>
+  )
+}
+
 export function CrewsPage() {
   const [crews, setCrews] = useState<CrewListItem[]>([])
   const [selectedCrewId, setSelectedCrewId] = useState<string | null>(null)
@@ -317,9 +477,14 @@ export function CrewsPage() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [editingCrew, setEditingCrew] = useState(false)
+  const [creatingCrew, setCreatingCrew] = useState(false)
+  const [runRequestOpen, setRunRequestOpen] = useState(false)
+  const [agentOptions, setAgentOptions] = useState<CrewAgentOption[]>([])
+  const [workspaceProfiles, setWorkspaceProfiles] = useState<WorkspaceProfile[]>([])
   const [registrySearch, setRegistrySearch] = useState('')
   const loadRequestIdRef = useRef(0)
   const runDetailRequestIdRef = useRef(0)
+  const crewBuilderEnabled = useMemo(() => isCrewBuilderV2Enabled(), [])
   const registryEnabled = isFleetRegistryViewsEnabled()
   const registryItems = useMemo(() => buildCrewRegistryItems(crews), [crews])
   const registryPreferences = useFleetRegistryPreferences('crews', registryItems.length)
@@ -380,16 +545,30 @@ export function CrewsPage() {
     void load()
   }, [load])
 
-  const createStarterCrew = async () => {
+  useEffect(() => {
+    if (!crewBuilderEnabled) return
+    let cancelled = false
+    void Promise.all([
+      window.coworkApi.app.builtinAgents().catch(() => []),
+      window.coworkApi.agents.list().catch(() => []),
+      window.coworkApi.agents.runtime().catch(() => []),
+      window.coworkApi.operations.workspaceProfiles().catch(() => []),
+    ]).then(([builtInAgents, customAgents, runtimeAgents, profiles]) => {
+      if (cancelled) return
+      setAgentOptions(buildCrewAgentOptions({ builtInAgents, customAgents, runtimeAgents }))
+      setWorkspaceProfiles(profiles)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [crewBuilderEnabled])
+
+  const createCrewFromDraft = async (draft: CrewDefinitionDraft) => {
     setBusy(true)
     setError(null)
     try {
-      const created = await window.coworkApi.crews.create({
-        name: 'Operations Crew',
-        description: 'Lead scopes the request, specialists branch out, and an evaluator checks the result.',
-        members: STARTER_CREW_MEMBERS,
-        budgetCapUsd: 4,
-      })
+      const created = await window.coworkApi.crews.create(draft)
+      setCreatingCrew(false)
       await load(created.definition.id)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create crew.')
@@ -398,17 +577,49 @@ export function CrewsPage() {
     }
   }
 
+  const createDefaultCrew = async () => {
+    await createCrewFromDraft({
+      name: 'Operations Team',
+      description: 'Lead scopes the request, specialists branch out, and an evaluator checks the result.',
+      members: DEFAULT_CREW_MEMBERS,
+      budgetCapUsd: 4,
+      approvalPolicy: 'review-before-delivery',
+    })
+  }
+
   const startRun = async () => {
     if (!detail || !crewCanStartRun) return
+    if (crewBuilderEnabled) {
+      setRunRequestOpen(true)
+      setEditingCrew(false)
+      return
+    }
     setBusy(true)
     setError(null)
     try {
       const nextRun = await window.coworkApi.crews.run({
         crewId: detail.definition.id,
-        title: 'Starter team run',
+        title: 'Team run',
         workItemTitle: 'Validate reusable crew workflow',
         workItemDescription: 'Plan, branch to specialists, join, evaluate, and deliver a reviewed result.',
       })
+      setRunDetail(nextRun)
+      setSelectedRunId(nextRun.run.id)
+      await load(detail.definition.id, nextRun.run.id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start crew run.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const submitRunRequest = async (request: CrewRunRequestDraft) => {
+    if (!detail || !crewCanStartRun) return
+    setBusy(true)
+    setError(null)
+    try {
+      const nextRun = await window.coworkApi.crews.run(runDraftFromRequest(detail.definition.id, request))
+      setRunRequestOpen(false)
       setRunDetail(nextRun)
       setSelectedRunId(nextRun.run.id)
       await load(detail.definition.id, nextRun.run.id)
@@ -426,6 +637,7 @@ export function CrewsPage() {
     try {
       const updated = await window.coworkApi.crews.update(detail.definition.id, draft)
       setEditingCrew(false)
+      setCreatingCrew(false)
       await load(updated.definition.id, selectedRunId)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save crew version.')
@@ -532,11 +744,19 @@ export function CrewsPage() {
             ) : null}
             <button
               type="button"
-              onClick={createStarterCrew}
+              onClick={() => {
+                if (crewBuilderEnabled) {
+                  setCreatingCrew(true)
+                  setEditingCrew(false)
+                  setRunRequestOpen(false)
+                } else {
+                  void createDefaultCrew()
+                }
+              }}
               disabled={busy}
               className="rounded-md border border-border-subtle bg-surface px-3 py-2 text-[12px] font-medium text-text hover:bg-surface-hover disabled:opacity-50"
             >
-              {t('crews.createStarterCrew', 'Create starter crew')}
+              {t('crews.createCrew', 'Create crew')}
             </button>
             <button
               type="button"
@@ -544,7 +764,7 @@ export function CrewsPage() {
               disabled={busy || !crewCanStartRun}
               className="rounded-md bg-accent px-3 py-2 text-[12px] font-semibold text-background hover:opacity-90 disabled:opacity-50"
             >
-              {t('crews.startRun', 'Run team')}
+              {crewBuilderEnabled ? t('crews.newRunRequest', 'New run request') : t('crews.startRun', 'Run team')}
             </button>
           </div>
         </div>
@@ -556,7 +776,7 @@ export function CrewsPage() {
           {loading ? <div className="text-[12px] text-text-muted">Loading crews...</div> : null}
           {!loading && crews.length === 0 ? (
             <div className="rounded-lg border border-dashed border-border-subtle p-4 text-[13px] text-text-secondary">
-              No crews yet. Create a starter crew to seed your first supervised team.
+              No crews yet. Create a crew to seed your first supervised team.
             </div>
           ) : null}
           {registryEnabled && registryPreferences.viewMode === 'table' ? (
@@ -578,6 +798,8 @@ export function CrewsPage() {
                 onSortChange={registryPreferences.setSort}
                 onOpenItem={(item) => {
                   setSelectedCrewId(item.id)
+                  setCreatingCrew(false)
+                  setRunRequestOpen(false)
                   void load(item.id)
                 }}
                 onBulkAction={() => undefined}
@@ -594,6 +816,8 @@ export function CrewsPage() {
                   selected={selectedCrew?.definition.id === item.definition.id}
                   onSelect={() => {
                     setSelectedCrewId(item.definition.id)
+                    setCreatingCrew(false)
+                    setRunRequestOpen(false)
                     void load(item.definition.id)
                   }}
                 />
@@ -603,7 +827,18 @@ export function CrewsPage() {
         </aside>
 
         <section className="min-h-0 overflow-y-auto p-6">
-          {!detail ? (
+          {creatingCrew ? (
+            <CrewVersionEditor
+              key={`create-${agentOptions.map((agent) => agent.name).join('|')}`}
+              mode="create"
+              initialDraft={draftFromCrewTemplate('operations', agentOptions)}
+              busy={busy}
+              agentOptions={agentOptions}
+              workspaceProfiles={workspaceProfiles}
+              onCancel={() => setCreatingCrew(false)}
+              onSave={createCrewFromDraft}
+            />
+          ) : !detail ? (
             <div className="rounded-lg border border-border-subtle bg-surface p-6 text-[13px] text-text-secondary">
               Select or create a crew to inspect its versioned membership and runs.
             </div>
@@ -632,7 +867,10 @@ export function CrewsPage() {
                     </div>
                     <button
                       type="button"
-                      onClick={() => setEditingCrew(true)}
+                      onClick={() => {
+                        setEditingCrew(true)
+                        setRunRequestOpen(false)
+                      }}
                       disabled={busy || !crewCanEdit}
                       className="rounded-md border border-border-subtle bg-elevated px-3 py-2 text-[12px] font-medium text-text hover:bg-surface-hover disabled:opacity-50"
                     >
@@ -673,8 +911,20 @@ export function CrewsPage() {
                   key={detail.activeVersion?.id || detail.definition.id}
                   detail={detail}
                   busy={busy}
+                  agentOptions={agentOptions}
+                  workspaceProfiles={workspaceProfiles}
                   onCancel={() => setEditingCrew(false)}
                   onSave={saveCrewVersion}
+                />
+              ) : null}
+
+              {runRequestOpen ? (
+                <CrewRunRequestPanel
+                  crewName={detail.definition.name}
+                  versionBudgetCapUsd={detail.activeVersion?.budgetCapUsd ?? null}
+                  busy={busy}
+                  onCancel={() => setRunRequestOpen(false)}
+                  onSubmit={submitRunRequest}
                 />
               ) : null}
 

--- a/apps/desktop/src/renderer/components/crews/crew-builder-ui.test.ts
+++ b/apps/desktop/src/renderer/components/crews/crew-builder-ui.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  draftFromCrewTemplate,
+  validateCrewDraftForBuilder,
+  type CrewAgentOption,
+} from './crew-builder-ui'
+
+function agent(name: string, disabled = false): CrewAgentOption {
+  return {
+    name,
+    label: name,
+    description: `${name} agent`,
+    source: 'built-in',
+    model: null,
+    skills: [],
+    tools: [],
+    disabled,
+    writeAccess: false,
+  }
+}
+
+describe('crew builder ui helpers', () => {
+  it('skips disabled agents and keeps template member assignments distinct when possible', () => {
+    const draft = draftFromCrewTemplate('operations', [
+      agent('plan', true),
+      agent('explore'),
+      agent('build'),
+      agent('general'),
+      agent('review'),
+    ])
+
+    expect(draft.members.map((member) => member.agentName)).toEqual(['explore', 'general', 'build', 'review'])
+    expect(validateCrewDraftForBuilder(draft, [
+      agent('plan', true),
+      agent('explore'),
+      agent('build'),
+      agent('general'),
+      agent('review'),
+    ])).toEqual([])
+  })
+
+  it('rejects manually selected disabled agents from the loaded catalog', () => {
+    const draft = draftFromCrewTemplate('operations')
+
+    expect(validateCrewDraftForBuilder(draft, [
+      agent('plan', true),
+      agent('explore'),
+      agent('build'),
+      agent('general'),
+    ])).toContain('plan is disabled in the loaded agent catalog.')
+  })
+})

--- a/apps/desktop/src/renderer/components/crews/crew-builder-ui.ts
+++ b/apps/desktop/src/renderer/components/crews/crew-builder-ui.ts
@@ -1,0 +1,292 @@
+import type {
+  BuiltInAgentDetail,
+  CrewApprovalPolicy,
+  CrewDefinitionDraft,
+  CrewMemberDraft,
+  CrewRunDraft,
+  CrewRunUrgency,
+  CustomAgentSummary,
+  RuntimeAgentDescriptor,
+  WorkspaceProfile,
+} from '@open-cowork/shared'
+
+export const CREW_BUILDER_V2_FEATURE_GATE_KEY = 'open-cowork.feature.crewBuilderV2'
+
+export type CrewAgentOptionSource = 'built-in' | 'custom' | 'runtime'
+
+export type CrewAgentOption = {
+  name: string
+  label: string
+  description: string
+  source: CrewAgentOptionSource
+  model: string | null
+  skills: string[]
+  tools: string[]
+  disabled: boolean
+  writeAccess: boolean
+}
+
+export type CrewTemplateId = 'operations' | 'analysis' | 'delivery'
+
+export type CrewTemplate = {
+  id: CrewTemplateId
+  label: string
+  description: string
+  draft: Omit<CrewDefinitionDraft, 'members'> & { members: CrewMemberDraft[] }
+}
+
+export type CrewRunRequestDraft = {
+  title: string
+  workItemTitle: string
+  objective: string
+  expectedDeliverable: string
+  constraints: string
+  dueAt: string
+  urgency: CrewRunUrgency
+  budgetCapUsd: string
+  approvalRequirements: string
+  sourceContext: string
+}
+
+const DEFAULT_APPROVAL_POLICY: CrewApprovalPolicy = 'review-before-delivery'
+
+export const CREW_TEMPLATES: CrewTemplate[] = [
+  {
+    id: 'operations',
+    label: 'Operations team',
+    description: 'Lead planning, specialist execution, and evaluator review for recurring product work.',
+    draft: {
+      name: 'Operations Team',
+      description: 'Reusable team for scoped planning, specialist execution, and final quality review.',
+      workspaceProfileId: null,
+      outcomeRubricId: null,
+      evalSuiteId: null,
+      budgetCapUsd: 4,
+      approvalPolicy: DEFAULT_APPROVAL_POLICY,
+      members: [
+        { role: 'lead', agentName: 'plan', displayName: 'Planner', description: 'Scopes the work, assigns branches, and keeps the run on policy.', required: true },
+        { role: 'specialist', agentName: 'explore', displayName: 'Explorer', description: 'Maps unknowns, gathers evidence, and reports risks.', required: true },
+        { role: 'specialist', agentName: 'build', displayName: 'Builder', description: 'Produces the requested artifact or implementation.', required: true },
+        { role: 'evaluator', agentName: 'general', displayName: 'Evaluator', description: 'Checks the result against the crew rubric before delivery.', required: true },
+      ],
+    },
+  },
+  {
+    id: 'analysis',
+    label: 'Analysis team',
+    description: 'Evidence gathering, synthesis, and evaluator review for investigation-heavy work.',
+    draft: {
+      name: 'Analysis Team',
+      description: 'Reusable team for evidence-backed analysis, synthesis, and quality review.',
+      workspaceProfileId: null,
+      outcomeRubricId: null,
+      evalSuiteId: null,
+      budgetCapUsd: 3,
+      approvalPolicy: DEFAULT_APPROVAL_POLICY,
+      members: [
+        { role: 'lead', agentName: 'plan', displayName: 'Lead Analyst', description: 'Frames the question, assigns specialist branches, and manages scope.', required: true },
+        { role: 'specialist', agentName: 'explore', displayName: 'Evidence Specialist', description: 'Finds sources, extracts facts, and records confidence.', required: true },
+        { role: 'specialist', agentName: 'general', displayName: 'Synthesis Specialist', description: 'Combines findings into a coherent answer.', required: true },
+        { role: 'evaluator', agentName: 'build', displayName: 'Quality Reviewer', description: 'Checks completeness, evidence quality, and actionability.', required: true },
+      ],
+    },
+  },
+  {
+    id: 'delivery',
+    label: 'Delivery team',
+    description: 'Builder-led artifact creation with review gates before the result is shipped.',
+    draft: {
+      name: 'Delivery Team',
+      description: 'Reusable team for producing, checking, and delivering user-facing work.',
+      workspaceProfileId: null,
+      outcomeRubricId: null,
+      evalSuiteId: null,
+      budgetCapUsd: 5,
+      approvalPolicy: DEFAULT_APPROVAL_POLICY,
+      members: [
+        { role: 'lead', agentName: 'build', displayName: 'Delivery Lead', description: 'Owns the final artifact and coordinates supporting branches.', required: true },
+        { role: 'specialist', agentName: 'plan', displayName: 'Scope Reviewer', description: 'Checks constraints, acceptance criteria, and sequencing.', required: true },
+        { role: 'specialist', agentName: 'explore', displayName: 'Evidence Specialist', description: 'Verifies assumptions and external context.', required: true },
+        { role: 'evaluator', agentName: 'general', displayName: 'Release Reviewer', description: 'Grades the output and calls out remaining risks.', required: true },
+      ],
+    },
+  },
+]
+
+export function isCrewBuilderV2Enabled(storage?: Storage | null) {
+  try {
+    const target = storage || (typeof window !== 'undefined' ? window.localStorage : null)
+    return target?.getItem(CREW_BUILDER_V2_FEATURE_GATE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function cloneDraft(draft: CrewDefinitionDraft): CrewDefinitionDraft {
+  return {
+    ...draft,
+    members: draft.members.map((member) => ({ ...member })),
+  }
+}
+
+function agentByName(options: readonly CrewAgentOption[]) {
+  return new Map(options.map((option) => [option.name, option]))
+}
+
+function pickAgentName(preferred: string, fallback: string, options: readonly CrewAgentOption[]) {
+  if (options.length === 0) return preferred
+  const byName = agentByName(options)
+  if (byName.has(preferred)) return preferred
+  if (byName.has(fallback)) return fallback
+  return options.find((option) => !option.disabled)?.name || preferred
+}
+
+export function draftFromCrewTemplate(templateId: CrewTemplateId, options: readonly CrewAgentOption[] = []) {
+  const template = CREW_TEMPLATES.find((entry) => entry.id === templateId) || CREW_TEMPLATES[0]!
+  const draft = cloneDraft(template.draft)
+  const fallbackByRole: Record<CrewMemberDraft['role'], string> = {
+    lead: 'plan',
+    specialist: 'general',
+    evaluator: 'general',
+  }
+  return {
+    ...draft,
+    members: draft.members.map((member) => ({
+      ...member,
+      agentName: pickAgentName(member.agentName, fallbackByRole[member.role], options),
+    })),
+  }
+}
+
+export function emptyRunRequest(crewName = 'Crew'): CrewRunRequestDraft {
+  return {
+    title: `${crewName} run`,
+    workItemTitle: '',
+    objective: '',
+    expectedDeliverable: '',
+    constraints: '',
+    dueAt: '',
+    urgency: 'normal',
+    budgetCapUsd: '',
+    approvalRequirements: 'Review evaluator verdict before delivery.',
+    sourceContext: '',
+  }
+}
+
+function uniquePush(map: Map<string, CrewAgentOption>, option: CrewAgentOption) {
+  const key = option.name.trim()
+  if (!key || map.has(key)) return
+  map.set(key, { ...option, name: key })
+}
+
+export function buildCrewAgentOptions(input: {
+  builtInAgents?: readonly BuiltInAgentDetail[]
+  customAgents?: readonly CustomAgentSummary[]
+  runtimeAgents?: readonly RuntimeAgentDescriptor[]
+}): CrewAgentOption[] {
+  const map = new Map<string, CrewAgentOption>()
+  for (const agent of input.builtInAgents || []) {
+    if (agent.hidden) continue
+    uniquePush(map, {
+      name: agent.name,
+      label: agent.label || agent.name,
+      description: agent.description || 'Built-in agent',
+      source: 'built-in',
+      model: agent.model || null,
+      skills: agent.skills || [],
+      tools: [...(agent.nativeToolIds || []), ...(agent.configuredToolIds || [])],
+      disabled: agent.disabled,
+      writeAccess: (agent.configuredToolIds || []).length > 0 || (agent.nativeToolIds || []).some((tool) => ['edit', 'write', 'apply_patch', 'bash'].includes(tool)),
+    })
+  }
+  for (const agent of input.customAgents || []) {
+    uniquePush(map, {
+      name: agent.name,
+      label: agent.name,
+      description: agent.description || 'Custom agent',
+      source: 'custom',
+      model: agent.model || null,
+      skills: agent.skillNames || [],
+      tools: agent.toolIds || [],
+      disabled: !agent.enabled || !agent.valid,
+      writeAccess: agent.writeAccess,
+    })
+  }
+  for (const agent of input.runtimeAgents || []) {
+    uniquePush(map, {
+      name: agent.name,
+      label: agent.name,
+      description: agent.description || 'Runtime agent',
+      source: 'runtime',
+      model: agent.model || null,
+      skills: [],
+      tools: agent.toolIds || [],
+      disabled: Boolean(agent.disabled),
+      writeAccess: Boolean(agent.writeAccess),
+    })
+  }
+  return Array.from(map.values()).sort((left, right) => left.label.localeCompare(right.label) || left.name.localeCompare(right.name))
+}
+
+export function summarizeAgentOption(option: CrewAgentOption | undefined) {
+  if (!option) return 'No matching agent metadata loaded.'
+  const parts = [
+    option.source,
+    option.model ? `model ${option.model}` : null,
+    option.skills.length ? `${option.skills.length} skills` : null,
+    option.tools.length ? `${option.tools.length} tools` : null,
+    option.writeAccess ? 'write-capable' : 'read-oriented',
+  ].filter(Boolean)
+  return parts.join(' | ')
+}
+
+export function validateCrewDraftForBuilder(draft: CrewDefinitionDraft, options: readonly CrewAgentOption[] = []) {
+  const issues: string[] = []
+  if (!draft.name.trim()) issues.push('Crew name is required.')
+  if (!draft.description.trim()) issues.push('Crew purpose is required.')
+  const knownAgents = new Set(options.map((option) => option.name))
+  const duplicateAgents = new Set<string>()
+  const seenAgents = new Set<string>()
+  for (const member of draft.members) {
+    const agentName = member.agentName.trim()
+    if (!agentName) issues.push('Every crew member needs an assigned agent.')
+    if (options.length > 0 && agentName && !knownAgents.has(agentName)) issues.push(`${agentName} is not in the loaded agent catalog.`)
+    if (agentName) {
+      if (seenAgents.has(agentName)) duplicateAgents.add(agentName)
+      seenAgents.add(agentName)
+    }
+  }
+  for (const agentName of duplicateAgents) issues.push(`${agentName} is assigned to more than one member.`)
+  if (draft.members.filter((member) => member.role === 'lead').length < 1) issues.push('At least one lead is required.')
+  if (draft.members.filter((member) => member.role === 'specialist').length < 2) issues.push('At least two specialists are required.')
+  if (draft.members.filter((member) => member.role === 'evaluator').length < 1) issues.push('At least one evaluator is required.')
+  if (draft.budgetCapUsd !== null && draft.budgetCapUsd !== undefined && (!Number.isFinite(draft.budgetCapUsd) || draft.budgetCapUsd <= 0)) {
+    issues.push('Budget cap must be a positive number.')
+  }
+  if (draft.approvalPolicy && draft.approvalPolicy !== 'review-before-delivery' && draft.approvalPolicy !== 'auto-deliver-after-evaluation') {
+    issues.push('Approval policy is invalid.')
+  }
+  return issues
+}
+
+export function normalizeWorkspaceProfileId(value: string, profiles: readonly WorkspaceProfile[]) {
+  if (!value || value === 'default') return null
+  return profiles.some((profile) => profile.id === value) ? value : null
+}
+
+export function runDraftFromRequest(crewId: string, request: CrewRunRequestDraft): CrewRunDraft {
+  return {
+    crewId,
+    title: request.title.trim(),
+    workItemTitle: request.workItemTitle.trim() || request.title.trim(),
+    workItemDescription: request.objective.trim(),
+    expectedDeliverable: request.expectedDeliverable.trim() || null,
+    constraints: request.constraints.trim() || null,
+    dueAt: request.dueAt.trim() || null,
+    urgency: request.urgency,
+    budgetCapUsd: request.budgetCapUsd.trim() ? Number(request.budgetCapUsd) : null,
+    approvalRequirements: request.approvalRequirements.trim() || null,
+    sourceContext: request.sourceContext.trim() || null,
+    workItemSource: 'manual',
+  }
+}

--- a/apps/desktop/src/renderer/components/crews/crew-builder-ui.ts
+++ b/apps/desktop/src/renderer/components/crews/crew-builder-ui.ts
@@ -133,17 +133,22 @@ function agentByName(options: readonly CrewAgentOption[]) {
   return new Map(options.map((option) => [option.name, option]))
 }
 
-function pickAgentName(preferred: string, fallback: string, options: readonly CrewAgentOption[]) {
+function pickAgentName(preferred: string, fallback: string, options: readonly CrewAgentOption[], usedAgentNames: Set<string>) {
   if (options.length === 0) return preferred
   const byName = agentByName(options)
-  if (byName.has(preferred)) return preferred
-  if (byName.has(fallback)) return fallback
-  return options.find((option) => !option.disabled)?.name || preferred
+  const preferredOption = byName.get(preferred)
+  if (preferredOption && !preferredOption.disabled && !usedAgentNames.has(preferred)) return preferred
+  const fallbackOption = byName.get(fallback)
+  if (fallbackOption && !fallbackOption.disabled && !usedAgentNames.has(fallback)) return fallback
+  return options.find((option) => !option.disabled && !usedAgentNames.has(option.name))?.name
+    || options.find((option) => !option.disabled)?.name
+    || preferred
 }
 
 export function draftFromCrewTemplate(templateId: CrewTemplateId, options: readonly CrewAgentOption[] = []) {
   const template = CREW_TEMPLATES.find((entry) => entry.id === templateId) || CREW_TEMPLATES[0]!
   const draft = cloneDraft(template.draft)
+  const usedAgentNames = new Set<string>()
   const fallbackByRole: Record<CrewMemberDraft['role'], string> = {
     lead: 'plan',
     specialist: 'general',
@@ -151,10 +156,14 @@ export function draftFromCrewTemplate(templateId: CrewTemplateId, options: reado
   }
   return {
     ...draft,
-    members: draft.members.map((member) => ({
-      ...member,
-      agentName: pickAgentName(member.agentName, fallbackByRole[member.role], options),
-    })),
+    members: draft.members.map((member) => {
+      const agentName = pickAgentName(member.agentName, fallbackByRole[member.role], options, usedAgentNames)
+      if (agentName) usedAgentNames.add(agentName)
+      return {
+        ...member,
+        agentName,
+      }
+    }),
   }
 }
 
@@ -250,7 +259,9 @@ export function validateCrewDraftForBuilder(draft: CrewDefinitionDraft, options:
   for (const member of draft.members) {
     const agentName = member.agentName.trim()
     if (!agentName) issues.push('Every crew member needs an assigned agent.')
+    const option = agentName ? options.find((entry) => entry.name === agentName) : undefined
     if (options.length > 0 && agentName && !knownAgents.has(agentName)) issues.push(`${agentName} is not in the loaded agent catalog.`)
+    if (option?.disabled) issues.push(`${agentName} is disabled in the loaded agent catalog.`)
     if (agentName) {
       if (seenAgents.has(agentName)) duplicateAgents.add(agentName)
       seenAgents.add(agentName)

--- a/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
+++ b/apps/desktop/src/renderer/components/fleet/fleet-registry-model.test.ts
@@ -150,6 +150,7 @@ describe('fleet registry model', () => {
         certificationStatus: 'required',
         certifiedAt: null,
         budgetCapUsd: 3,
+        approvalPolicy: 'review-before-delivery',
         workflow: ['plan'],
         createdAt: '2026-05-01T01:00:00.000Z',
         createdBy: null,

--- a/apps/desktop/tests/navigation-wiring.smoke.test.ts
+++ b/apps/desktop/tests/navigation-wiring.smoke.test.ts
@@ -145,8 +145,8 @@ test('sidebar Crews button opens the supervised team workspace', async () => {
     await page.getByRole('button', { name: 'Crews', exact: true }).click()
     await page.locator('main').getByRole('heading', { name: 'Supervised agent teams' }).waitFor({ timeout: 10_000 })
 
-    await page.locator('main').getByRole('button', { name: 'Create starter crew' }).click()
-    await page.locator('main').getByText('Operations Crew', { exact: true }).first().waitFor({ timeout: 10_000 })
+    await page.locator('main').getByRole('button', { name: 'Create crew' }).click()
+    await page.locator('main').getByText('Operations Team', { exact: true }).first().waitFor({ timeout: 10_000 })
 
     await page.locator('main').getByRole('button', { name: 'Run team' }).click()
     await page.locator('main').getByText('Trace timeline', { exact: true }).waitFor({ timeout: 10_000 })

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -240,8 +240,14 @@ brief, run timeline, reliability, and run policy:
 
 ## Crews
 
-Crews are supervised multi-agent product runs. A crew version defines a lead,
-specialists, an evaluator, a workspace profile, and an optional budget cap.
+Crews are reusable, supervised multi-agent product runs. A crew version defines
+a lead, specialists, an evaluator, agent assignments, a workspace profile,
+evaluation hooks, an approval policy, and optional budget caps. The
+`crewBuilderV2` feature gate adds the generic crew builder with templates,
+agent-catalog pickers, role responsibilities, rubric/eval-suite fields, and a
+structured run request form for objective, deliverable, constraints, due date,
+urgency, budget, approvals, and source context.
+
 When a crew run starts, Open Cowork records the durable product run, enters it
 into the operations queue, and only then dispatches the lead through OpenCode.
 Crews without run history can be deleted from the crew detail page; crews with

--- a/packages/shared/src/crews.ts
+++ b/packages/shared/src/crews.ts
@@ -9,6 +9,8 @@ export type CrewLifecycleStatus = 'draft' | 'review' | 'approved' | 'active' | '
 export type CrewRunStatus = 'queued' | 'planning' | 'running' | 'blocked' | 'evaluating' | 'delivering' | 'completed' | 'failed' | 'cancelled'
 export type CrewRunNodeKind = 'plan' | 'delegate' | 'join' | 'evaluate' | 'deliver' | 'revision' | 'approval' | 'system'
 export type CrewRunNodeStatus = 'queued' | 'running' | 'blocked' | 'completed' | 'failed' | 'skipped'
+export type CrewApprovalPolicy = 'review-before-delivery' | 'auto-deliver-after-evaluation'
+export type CrewRunUrgency = 'low' | 'normal' | 'high' | 'urgent'
 export type TraceRedactionState = 'none' | 'redacted' | 'restricted'
 export type TraceEventSource = 'opencode_event' | 'cowork_policy' | 'cowork_eval' | 'cowork_ui' | 'cowork_worker'
 export type TraceActorKind = 'user' | 'agent' | 'crew' | 'sop' | 'system' | 'opencode'
@@ -46,6 +48,7 @@ export interface CrewDefinitionDraft {
   outcomeRubricId?: string | null
   evalSuiteId?: string | null
   budgetCapUsd?: number | null
+  approvalPolicy?: CrewApprovalPolicy | null
 }
 
 export interface OutcomeRubricCriterion extends SchemaVersionedRecord {
@@ -87,6 +90,7 @@ export interface CrewVersion extends SchemaVersionedRecord {
   certificationStatus: CrewCertificationStatus
   certifiedAt: string | null
   budgetCapUsd: number | null
+  approvalPolicy: CrewApprovalPolicy
   workflow: CrewRunNodeKind[]
   createdAt: string
   createdBy: string | null
@@ -231,6 +235,13 @@ export interface CrewRunDraft {
   workItemTitle?: string | null
   workItemDescription?: string | null
   workItemSource?: CoworkWorkItem['source']
+  expectedDeliverable?: string | null
+  constraints?: string | null
+  dueAt?: string | null
+  urgency?: CrewRunUrgency | null
+  budgetCapUsd?: number | null
+  approvalRequirements?: string | null
+  sourceContext?: string | null
 }
 
 export interface TraceActor {

--- a/tests/channel-dispatch.test.ts
+++ b/tests/channel-dispatch.test.ts
@@ -97,6 +97,7 @@ function crewDetail(overrides: Partial<CrewRunDetail> = {}): CrewRunDetail {
       certificationStatus: 'not_required',
       certifiedAt: null,
       budgetCapUsd: null,
+      approvalPolicy: 'review-before-delivery',
       workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
       createdAt: '2026-05-11T00:00:00.000Z',
       createdBy: 'local-user',

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -251,6 +251,16 @@ test('crew service rejects unknown outcome rubric ids instead of silently downgr
   assert.throws(() => createCrewFromDraft(draft({ outcomeRubricId: 'missing-rubric' })), /Outcome rubric missing-rubric does not exist/)
 }))
 
+test('crew service validates run budget caps even without work item context', () => withCrewStore('run-budget-validation', () => {
+  const created = createCrewFromDraft(draft())
+
+  assert.throws(() => startCrewRun({
+    crewId: created.definition.id,
+    title: 'Invalid budget-only run',
+    budgetCapUsd: 0,
+  }), /Crew run budget cap must be a positive number/)
+}))
+
 test('crew service blocks eval-suite crew versions until certification evidence passes', () => withCrewStore('certification-gate', () => {
   const suite = createEvalSuite({
     name: 'Sensitive research certification',

--- a/tests/crew-service.test.ts
+++ b/tests/crew-service.test.ts
@@ -247,6 +247,21 @@ test('crew service saves edits as new crew versions without rewriting run histor
   assert.equal(reloaded?.activeVersion?.id, updated.activeVersion?.id)
 }))
 
+test('crew service preserves approval policy when an update omits it', () => withCrewStore('approval-policy-edit', () => {
+  const created = createCrewFromDraft(draft({
+    approvalPolicy: 'auto-deliver-after-evaluation',
+  }))
+
+  const updated = updateCrewFromDraft(created.definition.id, draft({
+    name: 'Research Crew Plus',
+    budgetCapUsd: 6,
+  }))
+
+  assert.equal(created.activeVersion?.approvalPolicy, 'auto-deliver-after-evaluation')
+  assert.equal(updated.activeVersion?.version, 2)
+  assert.equal(updated.activeVersion?.approvalPolicy, 'auto-deliver-after-evaluation')
+}))
+
 test('crew service rejects unknown outcome rubric ids instead of silently downgrading', () => withCrewStore('unknown-rubric', () => {
   assert.throws(() => createCrewFromDraft(draft({ outcomeRubricId: 'missing-rubric' })), /Outcome rubric missing-rubric does not exist/)
 }))

--- a/tests/crew-store.test.ts
+++ b/tests/crew-store.test.ts
@@ -168,9 +168,47 @@ test('crew store versions crew definitions without rewriting previous versions',
     assert.equal(versions[0]?.version, 1)
     assert.equal(versions[0]?.members.length, 3)
     assert.equal(versions[0]?.budgetCapUsd, 5)
+    assert.equal(versions[0]?.approvalPolicy, 'review-before-delivery')
     assert.equal(versions[1]?.version, 2)
     assert.equal(versions[1]?.members.length, 4)
     assert.equal(versions[1]?.budgetCapUsd, 8)
+    assert.equal(versions[1]?.approvalPolicy, 'review-before-delivery')
+  } finally {
+    clearCrewStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('crew store persists explicit crew approval policy on versions', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('approval-policy')
+
+  try {
+    resetCrewStore(userDataDir)
+
+    const crew = createCrewDefinition({
+      name: 'Reviewed Delivery Crew',
+      description: 'A crew with explicit delivery policy.',
+    })
+    assert.ok(crew)
+    const version = createCrewVersion({
+      crewId: crew!.id,
+      members: [
+        member('lead', 'lead', 'lead-agent'),
+        member('analyst', 'specialist', 'analyst-agent'),
+        member('charts', 'specialist', 'charts-agent'),
+        member('evaluator', 'evaluator', 'eval-agent'),
+      ],
+      approvalPolicy: 'auto-deliver-after-evaluation',
+      createdBy: 'user-1',
+    })
+    assert.ok(version)
+
+    const versions = listCrewVersions(crew!.id)
+    assert.equal(versions[0]?.approvalPolicy, 'auto-deliver-after-evaluation')
   } finally {
     clearCrewStoreCache()
     clearConfigCaches()
@@ -644,7 +682,7 @@ test('crew store records schema version and persists trace events', () => {
   }
 })
 
-test('crew store migrates v1 crew versions to certification-aware schema', () => {
+test('crew store migrates v1 crew versions to certification and approval-policy schema', () => {
   const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
   const userDataDir = uniqueUserDataDir('migrate-v1-certification')
 
@@ -670,6 +708,31 @@ test('crew store migrates v1 crew versions to certification-aware schema', () =>
         created_by text,
         unique (crew_id, version)
       );
+      insert into crew_versions (
+        id,
+        schema_version,
+        crew_id,
+        version,
+        members_json,
+        workspace_profile_id,
+        outcome_rubric_id,
+        budget_cap_usd,
+        workflow_json,
+        created_at,
+        created_by
+      ) values (
+        'crew-version-old',
+        1,
+        'crew-old',
+        1,
+        '[]',
+        null,
+        null,
+        null,
+        '["plan","delegate","join","evaluate","deliver"]',
+        '2026-05-10T00:00:00.000Z',
+        'legacy-user'
+      );
     `)
     oldDb.close()
 
@@ -678,11 +741,15 @@ test('crew store migrates v1 crew versions to certification-aware schema', () =>
       .map((column) => column.name)
     const meta = getCrewDb().prepare('select value from crew_meta where key = ?')
       .get('schema_version') as { value?: string } | undefined
+    const migrated = getCrewDb().prepare('select approval_policy from crew_versions where id = ?')
+      .get('crew-version-old') as { approval_policy?: string } | undefined
 
     assert.equal(meta?.value, String(CREW_STORE_SCHEMA_VERSION))
     assert.equal(columns.includes('eval_suite_id'), true)
     assert.equal(columns.includes('certification_status'), true)
     assert.equal(columns.includes('certified_at'), true)
+    assert.equal(columns.includes('approval_policy'), true)
+    assert.equal(migrated?.approval_policy, 'review-before-delivery')
   } finally {
     clearCrewStoreCache()
     clearConfigCaches()

--- a/tests/governance-registry.test.ts
+++ b/tests/governance-registry.test.ts
@@ -161,6 +161,7 @@ function crewCatalog(overrides: Partial<CrewListPayload['crews'][number]> = {}):
           certificationStatus: 'required',
           certifiedAt: null,
           budgetCapUsd: 5,
+          approvalPolicy: 'review-before-delivery',
           workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
           createdAt: generatedAt,
           createdBy: 'local-user',
@@ -679,6 +680,7 @@ test('governance registry gives crews without stored suites an explicit baseline
     evalSuiteId: null,
     certificationStatus: 'not_required',
     certifiedAt: null,
+    approvalPolicy: 'review-before-delivery',
   }
   const payload = buildGovernanceRegistry({
     builtinAgents: [builtInAgent()],

--- a/tests/operational-queue-store.test.ts
+++ b/tests/operational-queue-store.test.ts
@@ -142,6 +142,7 @@ function crewRunDetail(overrides: Partial<CrewRunDetail> = {}): CrewRunDetail {
       certificationStatus: 'not_required',
       certifiedAt: null,
       budgetCapUsd: null,
+      approvalPolicy: 'review-before-delivery',
       workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
       createdAt: '2026-05-11T00:00:00.000Z',
       createdBy: 'local-user',
@@ -218,6 +219,34 @@ test('channel-triggered Crew runs inherit the channel sandbox queue authority', 
   assert.equal(item.authority.isolation.channelBound, true)
   assert.equal(item.authority.filesystem.writeAllowed, false)
   assert.deepEqual(item.queueKeys, [])
+}))
+
+test('crew operational queue applies the tighter run or version budget cap', () => withOperationalStore('crew-budget-cap', () => {
+  const lowRunCapDetail = crewRunDetail({
+    run: {
+      ...crewRunDetail().run,
+      id: 'crew-run-low-cap',
+    },
+    version: {
+      ...crewRunDetail().version,
+      budgetCapUsd: 4,
+    },
+  })
+  const highRunCapDetail = crewRunDetail({
+    run: {
+      ...crewRunDetail().run,
+      id: 'crew-run-high-cap',
+    },
+    version: {
+      ...crewRunDetail().version,
+      budgetCapUsd: 4,
+    },
+  })
+  const lowRunCap = enqueueCrewOperationalQueueItem(lowRunCapDetail, { budgetCapUsd: 2.5 })
+  const highRunCap = enqueueCrewOperationalQueueItem(highRunCapDetail, { budgetCapUsd: 7 })
+
+  assert.equal(lowRunCap.caps.maxCostUsd, 2.5)
+  assert.equal(highRunCap.caps.maxCostUsd, 4)
 }))
 
 test('operational queues allow read-only research fanout without serialization keys', () => withOperationalStore('read-fanout', () => {

--- a/tests/work-ledger-service.test.ts
+++ b/tests/work-ledger-service.test.ts
@@ -173,6 +173,7 @@ function crewCatalog(): CrewListPayload {
         certificationStatus: 'not_required',
         certifiedAt: null,
         budgetCapUsd: null,
+        approvalPolicy: 'review-before-delivery',
         workflow: ['plan', 'delegate', 'join', 'evaluate', 'deliver'],
         createdAt: '2026-01-01T00:00:00.000Z',
         createdBy: 'local-user',


### PR DESCRIPTION
## Summary
- add the default-off crewBuilderV2 builder with crew templates, agent-catalog assignment, workspace/eval/approval fields, and structured run request intake
- extend crew storage/shared contracts with approval policy and per-run request metadata, including schema migration and IPC validation
- propagate per-run crew budget caps into the operational queue and document the gated crew workflow

## Validation
- pnpm test -- crew-store operational-queue-store product-language
- pnpm --filter @open-cowork/desktop test:renderer -- CrewsPage fleet-registry-model
- pnpm typecheck
- pnpm lint
- uv run mkdocs build --strict
- git diff --check

Fixes #339