### PR TITLE
Productize automation operations UX

### DIFF
--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.test.tsx
@@ -7,6 +7,7 @@ import {
   buildAutomationCardModel,
   resolveAutomationDropAction,
 } from './automation-board-support'
+import { AUTOMATION_UX_V2_FEATURE_GATE_KEY } from './automation-view-model'
 import { FLEET_REGISTRY_FEATURE_GATE_KEY } from '../fleet/fleet-registry-model'
 
 function automation(overrides: Partial<AutomationSummary>): AutomationSummary {
@@ -174,6 +175,7 @@ describe('AutomationBoard', () => {
     expect(screen.getByText('1 active')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Setup' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Weekly report/ })).toBeInTheDocument()
+    expect(screen.getByText('Every Monday at 09:00')).toBeInTheDocument()
   })
 
   it('hides archived automations until the board toggle is enabled', () => {
@@ -219,7 +221,7 @@ describe('AutomationBoard', () => {
   })
 
   it('renders the gated registry table and enables only backed bulk actions', () => {
-    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    window.localStorage.setItem(AUTOMATION_UX_V2_FEATURE_GATE_KEY, 'true')
     const onBulkAction = vi.fn()
     render(
       <AutomationBoard
@@ -257,5 +259,24 @@ describe('AutomationBoard', () => {
     fireEvent.click(screen.getByLabelText('Select Ready automation'))
     fireEvent.click(screen.getByLabelText('Select Running automation'))
     expect(screen.getByRole('button', { name: 'Archive selected' })).toBeDisabled()
+  })
+
+  it('keeps the automation table available through the fleet registry gate', () => {
+    window.localStorage.setItem(FLEET_REGISTRY_FEATURE_GATE_KEY, 'true')
+    render(
+      <AutomationBoard
+        payload={payload({ automations: [automation({ title: 'Fleet-gated automation' })] })}
+        selectedAutomationId={null}
+        onSelectAutomation={vi.fn()}
+        onDropAutomation={vi.fn()}
+        onNewAutomation={vi.fn()}
+        onLearnMore={vi.fn()}
+        showArchived={false}
+        onShowArchivedChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'table' }))
+    expect(screen.getByRole('table', { name: 'Automation registry table' })).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationBoard.tsx
@@ -21,7 +21,7 @@ import {
   type AutomationColumn,
   type AutomationColumnId,
 } from './automation-board-support'
-import { AUTOMATION_TEMPLATES } from './automation-view-model'
+import { AUTOMATION_TEMPLATES, isAutomationUxV2Enabled } from './automation-view-model'
 import { FleetRegistryTable, FleetRegistryViewToggle } from '../fleet/FleetRegistryTable'
 import {
   buildAutomationRegistryItems,
@@ -170,7 +170,7 @@ export function AutomationBoard({
   const visiblePayload = useMemo(() => filterBoardPayload(payload, showArchived), [payload, showArchived])
   const columns = useMemo(() => buildAutomationBoard(visiblePayload), [visiblePayload])
   const stats = useMemo(() => summarizeAutomationBoard(visiblePayload), [visiblePayload])
-  const registryEnabled = isFleetRegistryViewsEnabled()
+  const registryEnabled = isFleetRegistryViewsEnabled() || isAutomationUxV2Enabled()
   const registryItems = useMemo(() => buildAutomationRegistryItems(visiblePayload), [visiblePayload])
   const registryPreferences = useFleetRegistryPreferences('automations', registryItems.length)
   const visibleRegistryItems = useMemo(

--- a/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCard.tsx
@@ -67,7 +67,7 @@ export function AutomationCard({ card, selected, onSelect, dragDisabled = false 
       <div className="mt-3 flex flex-wrap gap-1.5">
         {card.inboxCount > 0 ? (
           <span className="rounded-full px-2 py-0.5 text-[10px]" style={{ background: 'color-mix(in srgb, var(--color-warning) 14%, transparent)', color: 'var(--color-warning)' }}>
-            {card.inboxCount} inbox
+            {card.inboxCount} {card.inboxCount === 1 ? 'review' : 'reviews'}
           </span>
         ) : null}
         {card.activeRun ? (

--- a/apps/desktop/src/renderer/components/automations/AutomationCardDetail.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCardDetail.test.tsx
@@ -166,7 +166,7 @@ function sopRunDetail(overrides: Partial<SopRunDetail> = {}): SopRunDetail {
     definition: {
       schemaVersion: COWORK_SOP_SCHEMA_VERSION,
       id: 'sop-1',
-      name: 'Weekly report SOP',
+      name: 'Weekly report workflow',
       description: 'Reusable weekly report process.',
       status: 'active',
       activeVersionId: 'sop-version-2',
@@ -281,8 +281,14 @@ describe('AutomationCardDetail', () => {
 
     expect(screen.getByRole('dialog', { name: 'Weekly report' })).toBeInTheDocument()
     expect(screen.getByText('Run now')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Overview' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Schedule' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reviews' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Runs' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Outputs' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'History' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Outputs' }))
     expect(screen.getByText('Report ready')).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Work' }))
     expect(screen.getByText('Draft report')).toBeInTheDocument()
     expect(screen.getByText('Find source data')).toBeInTheDocument()
 
@@ -315,6 +321,7 @@ describe('AutomationCardDetail', () => {
     })
 
     await user.click(screen.getAllByRole('button', { name: 'Approve brief' })[0]!)
+    await user.click(screen.getByRole('button', { name: 'Reviews' }))
     await user.type(screen.getByPlaceholderText('Reply to continue'), 'Cover public equities.')
     await user.click(screen.getByRole('button', { name: 'Send' }))
     await user.click(screen.getAllByRole('button', { name: 'Dismiss' })[1]!)
@@ -373,7 +380,7 @@ describe('AutomationCardDetail', () => {
       ],
     })
 
-    await user.click(screen.getByRole('button', { name: 'History' }))
+    await user.click(screen.getByRole('button', { name: 'Runs' }))
     await user.click(screen.getByRole('button', { name: 'Retry run' }))
     await user.click(screen.getByRole('button', { name: 'Open thread' }))
 
@@ -393,7 +400,7 @@ describe('AutomationCardDetail', () => {
       ],
     })
 
-    await user.click(screen.getByRole('button', { name: 'History' }))
+    await user.click(screen.getByRole('button', { name: 'Runs' }))
     await user.click(screen.getAllByRole('button', { name: 'Save as workflow' })[1]!)
 
     expect(props.onSaveAsSop).toHaveBeenCalledWith('completed-run')
@@ -408,7 +415,7 @@ describe('AutomationCardDetail', () => {
       },
     })
 
-    await user.click(screen.getByRole('button', { name: 'History' }))
+    await user.click(screen.getByRole('button', { name: 'Runs' }))
 
     const detailCard = screen.getByLabelText('Saved workflow detail for Execute report')
     expect(within(detailCard).getByText('Workflow v2')).toBeInTheDocument()

--- a/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCardDetail.tsx
@@ -13,6 +13,7 @@ import { useFocusTrap } from '../../hooks/useFocusTrap'
 import { AutomationAgentTeamSelector } from './AutomationAgentTeamSelector'
 import { DetailGroup, DetailSection, SummaryCard } from './AutomationDetailPrimitives'
 import {
+  buildAutomationSchedulePreview,
   dailyRunAttemptCapLabel,
   dailyRunAttemptCapPlaceholder,
   deriveNextAction,
@@ -27,7 +28,7 @@ import {
   type AutomationAgentOption,
 } from './automation-view-model'
 
-type DetailTab = 'now' | 'brief' | 'work' | 'history' | 'settings'
+type DetailTab = 'overview' | 'schedule' | 'reviews' | 'runs' | 'outputs' | 'settings' | 'history'
 
 type Props = {
   automation: AutomationDetail
@@ -51,6 +52,8 @@ type Props = {
   onRetryRun: (runId: string) => Promise<void>
   onInboxRespond: (itemId: string, response: string) => Promise<void>
   onInboxDismiss: (itemId: string) => Promise<void>
+  quietHoursStart?: string | null
+  quietHoursEnd?: string | null
 }
 
 function PanelField({ label, children }: { label: string; children: ReactNode }) {
@@ -63,9 +66,11 @@ function PanelField({ label, children }: { label: string; children: ReactNode })
 }
 
 function tabLabel(tab: DetailTab) {
-  if (tab === 'now') return 'Now'
-  if (tab === 'brief') return 'Brief'
-  if (tab === 'work') return 'Work'
+  if (tab === 'overview') return 'Overview'
+  if (tab === 'schedule') return 'Schedule'
+  if (tab === 'reviews') return 'Reviews'
+  if (tab === 'runs') return 'Runs'
+  if (tab === 'outputs') return 'Outputs'
   if (tab === 'history') return 'History'
   return 'Settings'
 }
@@ -98,9 +103,11 @@ export function AutomationCardDetail({
   onRetryRun,
   onInboxRespond,
   onInboxDismiss,
+  quietHoursStart = null,
+  quietHoursEnd = null,
 }: Props) {
   const panelRef = useRef<HTMLDivElement>(null)
-  const [tab, setTab] = useState<DetailTab>('now')
+  const [tab, setTab] = useState<DetailTab>('overview')
   const [edit, setEdit] = useState({
     title: automation.title,
     goal: automation.goal,
@@ -123,7 +130,7 @@ export function AutomationCardDetail({
   }, [automation.id, automation.title, automation.goal, automation.projectDirectory, automation.preferredAgentNames, automation.runPolicy])
 
   useEffect(() => {
-    setTab('now')
+    setTab('overview')
   }, [automation.id])
 
   const activeRun = useMemo(() => runs.find((run) => run.status === 'queued' || run.status === 'running') || null, [runs])
@@ -133,6 +140,14 @@ export function AutomationCardDetail({
   const backlog = useMemo(() => summarizeWorkItems(workItems), [workItems])
   const nextAction = useMemo(() => deriveNextAction({ automation, inbox, activeRun, latestRun, latestDelivery }), [automation, inbox, activeRun, latestRun, latestDelivery])
   const reliability = useMemo(() => deriveReliabilityState({ automation, inbox, activeRun, latestRun }), [automation, inbox, activeRun, latestRun])
+  const schedulePreview = useMemo(() => buildAutomationSchedulePreview({
+    schedule: automation.schedule,
+    status: automation.status,
+    nextRunAt: automation.nextRunAt,
+    nextHeartbeatAt: automation.nextHeartbeatAt,
+    quietHoursStart,
+    quietHoursEnd,
+  }), [automation.nextHeartbeatAt, automation.nextRunAt, automation.schedule, automation.status, quietHoursEnd, quietHoursStart])
   const preferredAgentLabels = useMemo(() => resolveAgentLabels(automation.preferredAgentNames, agentOptions), [automation.preferredAgentNames, agentOptions])
   const isArchived = automation.status === 'archived'
   const hasActiveRun = Boolean(activeRun)
@@ -183,7 +198,7 @@ export function AutomationCardDetail({
 
           <div className="mt-4 flex flex-wrap gap-2">
             {automation.status === 'draft' || !automation.brief ? (
-              <button type="button" disabled={hasActiveRun || isArchived} onClick={() => void onPreviewBrief()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">Preview brief</button>
+              <button type="button" disabled={hasActiveRun || isArchived} onClick={() => void onPreviewBrief()} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer disabled:opacity-50">Prepare brief</button>
             ) : null}
             {inbox.some((item) => item.type === 'approval') ? (
               <button type="button" disabled={isArchived} onClick={() => void onApproveBrief()} className="rounded-xl px-3 py-2 text-[12px] font-medium cursor-pointer disabled:opacity-50" style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}>Approve brief</button>
@@ -209,7 +224,7 @@ export function AutomationCardDetail({
         </div>
 
         <div className="flex gap-2 overflow-x-auto border-b border-border-subtle px-5 py-3">
-          {(['now', 'brief', 'work', 'history', 'settings'] as DetailTab[]).map((entry) => (
+          {(['overview', 'schedule', 'reviews', 'runs', 'outputs', 'settings', 'history'] as DetailTab[]).map((entry) => (
             <button
               key={entry}
               type="button"
@@ -226,16 +241,40 @@ export function AutomationCardDetail({
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto p-5">
-          {tab === 'now' ? (
+          {tab === 'overview' ? (
             <div className="space-y-5">
               <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
                 <SummaryCard label="Next step" value={nextAction} detail={activeRun ? `Active run: ${activeRun.title}` : latestRunSummary(latestRun)} accent />
                 <SummaryCard label="Reliability" value={reliability.value} detail={reliability.detail} compact />
                 <SummaryCard label="Run policy" value={dailyRunAttemptCapLabel(automation.runPolicy.dailyRunCap)} detail={describeRunPolicy(automation, latestRun)} compact />
               </div>
+              <DetailSection title="Schedule">
+                <div className="grid gap-3 md:grid-cols-3">
+                  <SummaryCard label="Cadence" value={schedulePreview.cadence} detail={automation.schedule.timezone} compact />
+                  <SummaryCard label="Next run" value={schedulePreview.nextRun} detail={schedulePreview.checkIn} compact />
+                  <SummaryCard label="Review policy" value={automation.autonomyPolicy === 'review-first' ? 'Review first' : 'Mostly autonomous'} detail={automation.executionMode === 'scoped_execution' ? 'Scoped execution' : 'Planning only'} compact />
+                </div>
+              </DetailSection>
+            </div>
+          ) : null}
+
+          {tab === 'schedule' ? (
+            <DetailSection title="Schedule">
+              <div className="grid gap-3 md:grid-cols-2">
+                <SummaryCard label="Cadence" value={schedulePreview.cadence} detail={automation.schedule.timezone} />
+                <SummaryCard label="Next run" value={schedulePreview.nextRun} detail={schedulePreview.checkIn} />
+                <SummaryCard label="Policy" value={automation.autonomyPolicy === 'review-first' ? 'Review first' : 'Mostly autonomous'} detail={automation.executionMode === 'scoped_execution' ? 'Scoped execution' : 'Planning only'} />
+                <SummaryCard label="Run limits" value={dailyRunAttemptCapLabel(automation.runPolicy.dailyRunCap)} detail={describeRunPolicy(automation, latestRun)} />
+              </div>
+              {schedulePreview.quietHours ? <div className="mt-4 rounded-xl border border-border-subtle px-3 py-3 text-[12px] leading-6 text-text-secondary">{schedulePreview.quietHours}</div> : null}
+            </DetailSection>
+          ) : null}
+
+          {tab === 'reviews' ? (
+            <div className="space-y-5">
               <DetailSection title="Attention">
                 {inbox.length === 0 ? (
-                  <div className="text-[12px] text-text-muted">No open inbox items.</div>
+                  <div className="text-[12px] text-text-muted">No open review items.</div>
                 ) : (
                   <div className="space-y-3">
                     {inbox.map((item) => (
@@ -269,19 +308,12 @@ export function AutomationCardDetail({
                   </div>
                 )}
               </DetailSection>
-              {latestDelivery ? (
-                <DetailSection title="Latest delivery">
-                  <div className="text-[12px] font-medium text-text">{latestDelivery.title}</div>
-                  <div className="mt-1 text-[11px] text-text-muted">{latestDelivery.provider} · {formatTimestamp(latestDelivery.createdAt)}</div>
-                  <div className="mt-2 whitespace-pre-wrap text-[12px] leading-6 text-text-secondary">{latestDelivery.body}</div>
-                </DetailSection>
-              ) : null}
             </div>
           ) : null}
 
-          {tab === 'brief' ? (
+          {tab === 'history' ? (
             <DetailSection
-              title="Execution brief"
+              title="Prepared brief"
               action={automation.latestSessionId && onOpenThread ? (
                 <button type="button" onClick={() => onOpenThread(automation.latestSessionId!)} className="text-[11px] text-text-muted underline cursor-pointer">Open linked thread</button>
               ) : undefined}
@@ -302,13 +334,29 @@ export function AutomationCardDetail({
                   </div>
                 </div>
               ) : (
-                <div className="text-[12px] text-text-muted">No execution brief yet. Preview the brief to route this through the plan agent.</div>
+                <div className="text-[12px] text-text-muted">No prepared brief yet. Prepare the brief to route this through the plan agent.</div>
               )}
             </DetailSection>
           ) : null}
 
-          {tab === 'work' ? (
-            <DetailSection title="Tasks">
+          {tab === 'outputs' ? (
+            <div className="space-y-5">
+              <DetailSection title="Deliveries">
+                {deliveries.length === 0 ? (
+                  <div className="text-[12px] text-text-muted">No delivery records yet.</div>
+                ) : (
+                  <div className="space-y-3">
+                    {deliveries.map((delivery) => (
+                      <div key={delivery.id} className="rounded-xl border border-border px-3 py-3">
+                        <div className="text-[12px] font-medium text-text">{delivery.title}</div>
+                        <div className="mt-1 text-[11px] text-text-muted">{delivery.provider} · {formatTimestamp(delivery.createdAt)}</div>
+                        <div className="mt-2 whitespace-pre-wrap text-[12px] leading-6 text-text-secondary">{delivery.body}</div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </DetailSection>
+              <DetailSection title="Tasks">
               <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-4">
                 <SummaryCard label="Total" value={String(backlog.total)} detail="Tasks in this brief" />
                 <SummaryCard label="Completed" value={String(backlog.completed)} detail="Finished work" />
@@ -333,10 +381,11 @@ export function AutomationCardDetail({
                   </div>
                 ))}
               </div>
-            </DetailSection>
+              </DetailSection>
+            </div>
           ) : null}
 
-          {tab === 'history' ? (
+          {tab === 'runs' ? (
             <DetailSection title="Run timeline">
               <div className="space-y-3">
                 {runs.length === 0 ? (

--- a/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.test.tsx
@@ -40,32 +40,34 @@ describe('AutomationCreateWizard', () => {
 
     await user.click(screen.getByRole('button', { name: 'Continue' }))
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Add a title and goal before choosing schedule details.')
-    expect(screen.getByRole('heading', { name: 'What & Why' })).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Add an outcome and audience before choosing schedule details.')
+    expect(screen.getByRole('heading', { name: 'Outcome & Audience' })).toBeInTheDocument()
   })
 
   it('blocks scoped execution without a selected project directory', async () => {
     const user = userEvent.setup()
     renderWizard()
 
-    await user.type(screen.getByLabelText('Title'), 'Scoped roadmap')
-    await user.type(screen.getByLabelText('Goal'), 'Keep the project roadmap current.')
+    await user.type(screen.getByLabelText('Outcome'), 'Scoped roadmap')
+    await user.type(screen.getByLabelText('Audience and success criteria'), 'Keep the project roadmap current.')
     await user.click(screen.getByRole('button', { name: 'Continue' }))
     await user.click(screen.getByRole('button', { name: /Scoped execution/ }))
     await user.click(screen.getByRole('button', { name: 'Continue' }))
 
     expect(screen.getByRole('alert')).toHaveTextContent('Scoped execution automations require a project directory.')
-    expect(screen.getByRole('heading', { name: 'When & How' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Schedule & Controls' })).toBeInTheDocument()
   })
 
   it('creates an automation with the completed wizard draft', async () => {
     const user = userEvent.setup()
     const { onClose, onCreate } = renderWizard()
 
-    await user.type(screen.getByLabelText('Title'), 'Weekly market review')
-    await user.type(screen.getByLabelText('Goal'), 'Summarize market movement before the Monday planning meeting.')
+    await user.type(screen.getByLabelText('Outcome'), 'Weekly market review')
+    await user.type(screen.getByLabelText('Audience and success criteria'), 'Summarize market movement before the Monday planning meeting.')
     await user.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(screen.getByText('Every Monday at 09:00')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(screen.getByText('Review required before execution')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Create automation' }))
 
     await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1))

--- a/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationCreateWizard.tsx
@@ -4,6 +4,7 @@ import { useFocusTrap } from '../../hooks/useFocusTrap'
 import { AutomationAgentTeamSelector } from './AutomationAgentTeamSelector'
 import {
   AUTOMATION_TEMPLATES,
+  buildDraftSchedulePreview,
   createDefaultDraft,
   dailyRunAttemptCapPlaceholder,
   draftToPayload,
@@ -17,9 +18,11 @@ type Props = {
   onCreate: (draft: DraftState) => Promise<void>
   onClose: () => void
   loadAgentOptions: (directory: string | null | undefined, selectedNames: string[]) => Promise<AutomationAgentOption[]>
+  quietHoursStart?: string | null
+  quietHoursEnd?: string | null
 }
 
-const STEPS = ['What & Why', 'When & How', 'Review & Create']
+const STEPS = ['Outcome & Audience', 'Schedule & Controls', 'Review & Create']
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -74,7 +77,7 @@ function validateWizardDraft(draft: DraftState) {
   return null
 }
 
-export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentOptions }: Props) {
+export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentOptions, quietHoursStart = null, quietHoursEnd = null }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const [step, setStep] = useState(0)
   const [draft, setDraft] = useState<DraftState>(() => ({ ...createDefaultDraft(), ...defaults }))
@@ -82,6 +85,7 @@ export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentO
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const schedulePreview = buildDraftSchedulePreview({ draft, quietHoursStart, quietHoursEnd })
   useFocusTrap(dialogRef, { onEscape: saving ? undefined : onClose })
 
   useEffect(() => {
@@ -100,7 +104,7 @@ export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentO
   const goNext = () => {
     setError(null)
     if (step === 0 && (!draft.title.trim() || !draft.goal.trim())) {
-      setError('Add a title and goal before choosing schedule details.')
+      setError('Add an outcome and audience before choosing schedule details.')
       return
     }
     if (step === 1 && draft.executionMode === 'scoped_execution' && !draft.projectDirectory.trim()) {
@@ -186,11 +190,11 @@ export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentO
                   </button>
                 ))}
               </div>
-              <Field label="Title">
+              <Field label="Outcome">
                 <input autoFocus value={draft.title} onChange={(event) => updateDraft({ title: event.target.value })} className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="Weekly market report" />
               </Field>
-              <Field label="Goal">
-                <textarea value={draft.goal} onChange={(event) => updateDraft({ goal: event.target.value })} rows={6} className="w-full resize-y rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="Describe the repeated outcome Cowork should keep moving." />
+              <Field label="Audience and success criteria">
+                <textarea value={draft.goal} onChange={(event) => updateDraft({ goal: event.target.value })} rows={6} className="w-full resize-y rounded-xl border border-border bg-transparent px-3 py-2 text-[13px]" placeholder="Describe who consumes the output, the repeated outcome, and what good looks like." />
               </Field>
               <div className="grid gap-3 sm:grid-cols-2">
                 <SegmentedButton selected={draft.kind === 'recurring'} title="Recurring program" detail="Repeats on a schedule and produces a regular output." onClick={() => updateDraft({ kind: 'recurring' as AutomationKind })} />
@@ -238,7 +242,7 @@ export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentO
               <div className="grid gap-3 sm:grid-cols-2">
                 <SegmentedButton selected={draft.autonomyPolicy === 'review-first'} title="Review first" detail="Cowork asks before executing a new brief." onClick={() => updateDraft({ autonomyPolicy: 'review-first' as AutomationAutonomyPolicy })} />
                 <SegmentedButton selected={draft.autonomyPolicy === 'mostly-autonomous'} title="Mostly autonomous" detail="Cowork can continue after planning when no review is needed." onClick={() => updateDraft({ autonomyPolicy: 'mostly-autonomous' as AutomationAutonomyPolicy })} />
-                <SegmentedButton selected={draft.executionMode === 'planning_only'} title="Planning only" detail="Good for research, briefs, and inbox-ready output." onClick={() => updateDraft({ executionMode: 'planning_only' as AutomationExecutionMode })} />
+                <SegmentedButton selected={draft.executionMode === 'planning_only'} title="Planning only" detail="Good for research, briefs, and review-ready output." onClick={() => updateDraft({ executionMode: 'planning_only' as AutomationExecutionMode })} />
                 <SegmentedButton selected={draft.executionMode === 'scoped_execution'} title="Scoped execution" detail="Runs against an explicit project directory." onClick={() => updateDraft({ executionMode: 'scoped_execution' as AutomationExecutionMode })} />
               </div>
               {draft.executionMode === 'scoped_execution' ? (
@@ -259,6 +263,24 @@ export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentO
                   </div>
                 </Field>
               ) : null}
+              <div className="rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>
+                <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Schedule preview</div>
+                <div className="mt-2 grid gap-3 md:grid-cols-3">
+                  <div>
+                    <div className="text-[12px] font-medium text-text">{schedulePreview.cadence}</div>
+                    <div className="mt-1 text-[11px] leading-5 text-text-muted">Cadence</div>
+                  </div>
+                  <div>
+                    <div className="text-[12px] font-medium text-text">{schedulePreview.nextRun}</div>
+                    <div className="mt-1 text-[11px] leading-5 text-text-muted">First run</div>
+                  </div>
+                  <div>
+                    <div className="text-[12px] font-medium text-text">{schedulePreview.checkIn}</div>
+                    <div className="mt-1 text-[11px] leading-5 text-text-muted">Check-in</div>
+                  </div>
+                </div>
+                {schedulePreview.quietHours ? <div className="mt-3 text-[11px] leading-5 text-text-muted">{schedulePreview.quietHours}</div> : null}
+              </div>
             </div>
           ) : null}
 
@@ -267,11 +289,25 @@ export function AutomationCreateWizard({ defaults, onCreate, onClose, loadAgentO
               <div className="rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>
                 <div className="text-[15px] font-semibold text-text">{draft.title || 'Untitled automation'}</div>
                 <p className="mt-2 text-[12px] leading-6 text-text-secondary">{draft.goal || 'No goal yet.'}</p>
-                <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-muted">
-                  <span>{draft.kind === 'managed-project' ? 'Managed project' : 'Recurring program'}</span>
-                  <span>{draft.scheduleType}</span>
-                  <span>{draft.autonomyPolicy}</span>
-                  <span>{draft.executionMode === 'scoped_execution' ? 'Scoped execution' : 'Planning only'}</span>
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <div>
+                    <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Schedule</div>
+                    <div className="mt-1 text-[12px] leading-5 text-text-secondary">{schedulePreview.cadence}</div>
+                    <div className="mt-1 text-[12px] leading-5 text-text-secondary">{schedulePreview.nextRun}</div>
+                    {schedulePreview.quietHours ? <div className="mt-1 text-[11px] leading-5 text-text-muted">{schedulePreview.quietHours}</div> : null}
+                  </div>
+                  <div>
+                    <div className="text-[11px] uppercase tracking-[0.14em] text-text-muted">Controls</div>
+                    <div className="mt-1 text-[12px] leading-5 text-text-secondary">
+                      {draft.autonomyPolicy === 'review-first' ? 'Review required before execution' : 'Can continue after planning when no review is needed'}
+                    </div>
+                    <div className="mt-1 text-[12px] leading-5 text-text-secondary">
+                      {draft.executionMode === 'scoped_execution' ? `Scoped to ${draft.projectDirectory || 'a required project directory'}` : 'Planning-only output'}
+                    </div>
+                    <div className="mt-1 text-[12px] leading-5 text-text-secondary">
+                      {draft.dailyRunCap || '1'} execution attempts/day · {draft.maxRunDurationMinutes || '1'} minute max/run
+                    </div>
+                  </div>
                 </div>
               </div>
               <button type="button" onClick={() => setAdvancedOpen((current) => !current)} className="rounded-xl border border-border px-3 py-2 text-[12px] cursor-pointer">

--- a/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.test.tsx
@@ -8,7 +8,7 @@ describe('AutomationHelpDrawer', () => {
     render(<AutomationHelpDrawer onClose={onClose} />)
 
     expect(screen.getByRole('dialog', { name: 'Standing agent programs' })).toBeInTheDocument()
-    expect(screen.getByText('1. Enrich')).toBeInTheDocument()
+    expect(screen.getByText('1. Prepare')).toBeInTheDocument()
     expect(screen.getByText('2. Review')).toBeInTheDocument()
     expect(screen.getByText('3. Execute')).toBeInTheDocument()
 

--- a/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationHelpDrawer.tsx
@@ -31,8 +31,8 @@ export function AutomationHelpDrawer({ onClose }: Props) {
         </div>
         <div className="space-y-4 overflow-y-auto p-5">
           {[
-            ['1. Enrich', 'Cowork routes the raw ask through OpenCode plan and turns it into an execution-ready brief.'],
-            ['2. Review', 'Approvals, missing context, and failures become Inbox items so the automation pauses instead of guessing.'],
+            ['1. Prepare', 'Cowork routes the raw ask through OpenCode plan and turns it into a reviewed brief.'],
+            ['2. Review', 'Approvals, missing context, and failures become review items so the automation pauses instead of guessing.'],
             ['3. Execute', 'Approved work runs through OpenCode build and specialist subagents, then lands as in-app delivery.'],
           ].map(([title, body]) => (
             <div key={title} className="rounded-2xl border border-border-subtle p-4" style={{ background: 'var(--color-elevated)' }}>

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.test.tsx
@@ -81,7 +81,7 @@ function sopPayload(overrides: Partial<SopListPayload> = {}): SopListPayload {
         definition: {
           schemaVersion: COWORK_SOP_SCHEMA_VERSION,
           id: 'sop-1',
-          name: 'Weekly report SOP',
+          name: 'Weekly report workflow',
           description: 'Reusable weekly report process.',
           status: 'active',
           activeVersionId: 'sop-version-1',
@@ -102,7 +102,7 @@ function sopPayload(overrides: Partial<SopListPayload> = {}): SopListPayload {
               schemaVersion: COWORK_SOP_SCHEMA_VERSION,
               id: 'project-directory',
               label: 'Project directory',
-              description: 'Directory to run the SOP against.',
+              description: 'Directory to run the workflow against.',
               required: true,
             },
           ],
@@ -345,7 +345,7 @@ describe('AutomationsPage', () => {
     expect(await screen.findByRole('dialog', { name: 'Weekly report' })).toBeInTheDocument()
     expect(api.get).toHaveBeenCalledWith('auto-1')
 
-    await user.click(screen.getByRole('button', { name: 'Preview brief' }))
+    await user.click(screen.getByRole('button', { name: 'Prepare brief' }))
     await waitFor(() => expect(api.previewBrief).toHaveBeenCalledWith('auto-1'))
     expect(api.list).toHaveBeenCalledTimes(2)
 
@@ -362,8 +362,8 @@ describe('AutomationsPage', () => {
     await screen.findByRole('heading', { name: 'Turn repeatable work into a standing agent program' })
     await user.click(screen.getByRole('button', { name: 'New automation' }))
 
-    await user.type(screen.getByLabelText('Title'), 'Weekly market review')
-    await user.type(screen.getByLabelText('Goal'), 'Summarize market movement before the planning meeting.')
+    await user.type(screen.getByLabelText('Outcome'), 'Weekly market review')
+    await user.type(screen.getByLabelText('Audience and success criteria'), 'Summarize market movement before the planning meeting.')
     await user.click(screen.getByRole('button', { name: 'Continue' }))
     await user.click(screen.getByRole('button', { name: 'Continue' }))
     await user.click(screen.getByRole('button', { name: 'Create automation' }))
@@ -386,7 +386,7 @@ describe('AutomationsPage', () => {
     })
 
     expect(await screen.findByRole('region', { name: 'Reusable workflows' })).toBeInTheDocument()
-    expect(screen.getByText('Weekly report SOP')).toBeInTheDocument()
+    expect(screen.getByText('Weekly report workflow')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Run workflow' }))
 
     await waitFor(() => expect(api.sopsRunNow).toHaveBeenCalledWith('sop-1', expect.objectContaining({

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -126,6 +126,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
   const [selectedAgentOptions, setSelectedAgentOptions] = useState<AutomationAgentOption[]>([])
   const [draftDefaults, setDraftDefaults] = useState<DraftState>(() => createDefaultDraft())
   const [wizardDefaults, setWizardDefaults] = useState<DraftState>(() => createDefaultDraft())
+  const [automationQuietHours, setAutomationQuietHours] = useState<{ start: string | null; end: string | null }>({ start: null, end: null })
   const [wizardOpen, setWizardOpen] = useState(false)
   const [helpOpen, setHelpOpen] = useState(false)
   const [showArchived, setShowArchived] = useState(false)
@@ -205,6 +206,10 @@ export function AutomationsPage({ onOpenThread }: Props) {
         autonomyPolicy: settings.defaultAutomationAutonomyPolicy,
         executionMode: settings.defaultAutomationExecutionMode,
       }))
+      setAutomationQuietHours({
+        start: settings.automationQuietHoursStart,
+        end: settings.automationQuietHoursEnd,
+      })
     }).catch((err) => {
       if (cancelled) return
       addGlobalError(t('automations.defaultsLoadFailed', 'Could not load automation defaults. New automations will use standard defaults.'))
@@ -398,7 +403,7 @@ export function AutomationsPage({ onOpenThread }: Props) {
           <div className="text-[11px] uppercase tracking-[0.18em] text-text-muted">{t('automations.label', 'Automations')}</div>
           <h1 className="mt-1 text-[24px] font-semibold text-text">{t('automations.title', 'Always-on work')}</h1>
           <p className="mt-2 max-w-2xl text-[13px] leading-6 text-text-secondary">
-            See every standing agent program by lifecycle stage. Drag supported cards to trigger existing actions, or open a card for focused details.
+            See every standing agent program by lifecycle stage, schedule, review state, and latest output. Open a program for explicit controls, or drag supported cards when you prefer board movement.
           </p>
         </div>
         {loading ? <div className="text-[11px] text-text-muted">{t('common.loading', 'Loading…')}</div> : null}
@@ -480,6 +485,8 @@ export function AutomationsPage({ onOpenThread }: Props) {
           onClose={() => setWizardOpen(false)}
           onCreate={createAutomation}
           loadAgentOptions={loadAgentOptions}
+          quietHoursStart={automationQuietHours.start}
+          quietHoursEnd={automationQuietHours.end}
         />
       ) : null}
 
@@ -511,6 +518,8 @@ export function AutomationsPage({ onOpenThread }: Props) {
           onRetryRun={(runId) => runAndRefresh(() => window.coworkApi.automation.retryRun(runId))}
           onInboxRespond={(itemId, response) => runAndRefresh(() => window.coworkApi.automation.inboxRespond(itemId, response))}
           onInboxDismiss={(itemId) => runAndRefresh(() => window.coworkApi.automation.inboxDismiss(itemId))}
+          quietHoursStart={automationQuietHours.start}
+          quietHoursEnd={automationQuietHours.end}
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/components/automations/automation-board-support.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-board-support.ts
@@ -76,7 +76,7 @@ export const AUTOMATION_COLUMNS: Array<Omit<AutomationColumn, 'cards'>> = [
   {
     id: 'draft',
     title: 'Setup',
-    description: 'New programs that still need an execution brief.',
+    description: 'New programs that still need a prepared brief.',
   },
   {
     id: 'planning',
@@ -228,7 +228,7 @@ export function resolveAutomationDropAction(
       automationId,
       targetColumn,
       type: 'approveBrief',
-      title: 'Approve execution brief',
+      title: 'Approve prepared brief',
       message: `Approve the brief for ${card.automation.title} so it can move into ready work.`,
       confirm: true,
     }

--- a/apps/desktop/src/renderer/components/automations/automation-view-model.test.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-view-model.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUTOMATION_UX_V2_FEATURE_GATE_KEY,
+  buildAutomationSchedulePreview,
+  buildDraftSchedulePreview,
+  createDefaultDraft,
+  formatSchedule,
+  isAutomationUxV2Enabled,
+} from './automation-view-model'
+
+describe('automation-view-model', () => {
+  it('keeps automation UX v2 default-off behind an explicit feature gate', () => {
+    window.localStorage.removeItem(AUTOMATION_UX_V2_FEATURE_GATE_KEY)
+
+    try {
+      expect(isAutomationUxV2Enabled()).toBe(false)
+
+      window.localStorage.setItem(AUTOMATION_UX_V2_FEATURE_GATE_KEY, 'true')
+
+      expect(isAutomationUxV2Enabled()).toBe(true)
+    } finally {
+      window.localStorage.removeItem(AUTOMATION_UX_V2_FEATURE_GATE_KEY)
+    }
+  })
+
+  it('formats schedules in operator-facing language', () => {
+    expect(formatSchedule({
+      type: 'weekly',
+      timezone: 'UTC',
+      dayOfWeek: 1,
+      runAtHour: 9,
+      runAtMinute: 0,
+    })).toBe('Every Monday at 09:00')
+    expect(formatSchedule({
+      type: 'monthly',
+      timezone: 'UTC',
+      dayOfMonth: 31,
+      runAtHour: 16,
+      runAtMinute: 30,
+    })).toBe('Every month on day 31 at 16:30')
+  })
+
+  it('summarizes saved automation schedules, check-ins, and quiet-hour impact', () => {
+    const preview = buildAutomationSchedulePreview({
+      schedule: {
+        type: 'daily',
+        timezone: 'UTC',
+        runAtHour: 23,
+        runAtMinute: 0,
+      },
+      nextRunAt: '2026-05-14T23:00:00.000Z',
+      nextHeartbeatAt: '2026-05-14T12:00:00.000Z',
+      quietHoursStart: '22:00',
+      quietHoursEnd: '07:00',
+    })
+
+    expect(preview.cadence).toBe('Every day at 23:00')
+    expect(preview.nextRun).toContain('Next run')
+    expect(preview.checkIn).toContain('Next check-in')
+    expect(preview.quietHours).toContain('inside notification quiet hours')
+  })
+
+  it('previews draft schedules before creation', () => {
+    const preview = buildDraftSchedulePreview({
+      draft: createDefaultDraft(),
+      quietHoursStart: '22:00',
+      quietHoursEnd: '07:00',
+    })
+
+    expect(preview.cadence).toBe('Every Monday at 09:00')
+    expect(preview.nextRun).toContain('First run')
+    expect(preview.checkIn).toBe('15 minute check-ins after creation.')
+    expect(preview.quietHours).toContain('do not overlap')
+  })
+})

--- a/apps/desktop/src/renderer/components/automations/automation-view-model.test.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-view-model.test.ts
@@ -4,8 +4,10 @@ import {
   buildAutomationSchedulePreview,
   buildDraftSchedulePreview,
   createDefaultDraft,
+  describeQuietHoursImpact,
   formatSchedule,
   isAutomationUxV2Enabled,
+  nextRunPreviewFromSchedule,
 } from './automation-view-model'
 
 describe('automation-view-model', () => {
@@ -71,5 +73,34 @@ describe('automation-view-model', () => {
     expect(preview.nextRun).toContain('First run')
     expect(preview.checkIn).toBe('15 minute check-ins after creation.')
     expect(preview.quietHours).toContain('do not overlap')
+  })
+
+  it('computes draft next-run previews in the configured schedule timezone', () => {
+    const nextRunAt = nextRunPreviewFromSchedule({
+      type: 'daily',
+      timezone: 'America/New_York',
+      runAtHour: 9,
+      runAtMinute: 0,
+    }, new Date('2026-05-13T16:00:00.000Z'))
+
+    expect(nextRunAt).toBe('2026-05-14T13:00:00.000Z')
+  })
+
+  it('uses one-time startAt when describing quiet-hour impact', () => {
+    const startAt = new Date('2026-05-13T12:00:00.000Z')
+    startAt.setHours(23, 30, 0, 0)
+
+    const quietHours = describeQuietHoursImpact({
+      schedule: {
+        type: 'one_time',
+        startAt: startAt.toISOString(),
+        runAtHour: 9,
+        runAtMinute: 0,
+      },
+      quietHoursStart: '22:00',
+      quietHoursEnd: '07:00',
+    })
+
+    expect(quietHours).toContain('inside notification quiet hours')
   })
 })

--- a/apps/desktop/src/renderer/components/automations/automation-view-model.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-view-model.ts
@@ -16,6 +16,8 @@ import type {
 import { t } from '../../helpers/i18n'
 import { formatAgentLabel } from '../chat/chat-input-utils'
 
+export const AUTOMATION_UX_V2_FEATURE_GATE_KEY = 'open-cowork.feature.automationUxV2'
+
 export type DraftState = {
   title: string
   goal: string
@@ -37,6 +39,13 @@ export type DraftState = {
   autonomyPolicy: AutomationAutonomyPolicy
   projectDirectory: string
   preferredAgentNames: string[]
+}
+
+export type AutomationSchedulePreview = {
+  cadence: string
+  nextRun: string
+  checkIn: string
+  quietHours: string | null
 }
 
 export type AutomationAgentOption = {
@@ -134,16 +143,181 @@ export function formatRunKindForUser(kind: AutomationRun['kind']) {
   return 'execution'
 }
 
+function storageOrNull(storage?: Storage | null) {
+  if (storage) return storage
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function isAutomationUxV2Enabled(storage?: Storage | null) {
+  const target = storageOrNull(storage)
+  if (!target) return false
+  try {
+    return target.getItem(AUTOMATION_UX_V2_FEATURE_GATE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+function clampClock(value: number | null | undefined, min: number, max: number, fallback: number) {
+  return Number.isFinite(value) ? Math.max(min, Math.min(max, Number(value))) : fallback
+}
+
+function formatClock(hour: number | null | undefined, minute: number | null | undefined) {
+  const safeHour = clampClock(hour, 0, 23, 9)
+  const safeMinute = clampClock(minute, 0, 59, 0)
+  return `${String(safeHour).padStart(2, '0')}:${String(safeMinute).padStart(2, '0')}`
+}
+
 export function formatSchedule(schedule: AutomationSchedule) {
-  const time = `${String(schedule.runAtHour ?? 9).padStart(2, '0')}:${String(schedule.runAtMinute ?? 0).padStart(2, '0')}`
-  if (schedule.type === 'one_time') return schedule.startAt || 'One time'
-  if (schedule.type === 'daily') return `Daily at ${time}`
-  if (schedule.type === 'weekly') return `Weekly (day ${schedule.dayOfWeek ?? 1}) at ${time}`
-  return `Monthly (day ${schedule.dayOfMonth ?? 1}) at ${time}`
+  const time = formatClock(schedule.runAtHour, schedule.runAtMinute)
+  if (schedule.type === 'one_time') return schedule.startAt ? `Once on ${formatTimestamp(schedule.startAt, '')}` : 'Manual one-time run'
+  if (schedule.type === 'daily') return `Every day at ${time}`
+  if (schedule.type === 'weekly') return `Every ${WEEKDAY_NAMES[clampClock(schedule.dayOfWeek, 0, 6, 1)] || 'Monday'} at ${time}`
+  return `Every month on day ${clampClock(schedule.dayOfMonth, 1, 31, 1)} at ${time}`
 }
 
 export function formatTimestamp(value: string | null | undefined, empty = 'Not scheduled') {
   return value ? new Date(value).toLocaleString() : empty
+}
+
+function parseClockMinutes(value: string | null | undefined) {
+  if (!value) return null
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim())
+  if (!match) return null
+  const hour = Number.parseInt(match[1]!, 10)
+  const minute = Number.parseInt(match[2]!, 10)
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null
+  return hour * 60 + minute
+}
+
+function isMinuteWithinQuietHours(minute: number, quietStart: string | null | undefined, quietEnd: string | null | undefined) {
+  const start = parseClockMinutes(quietStart)
+  const end = parseClockMinutes(quietEnd)
+  if (start === null || end === null || start === end) return false
+  if (start < end) return minute >= start && minute < end
+  return minute >= start || minute < end
+}
+
+export function describeQuietHoursImpact(input: {
+  schedule: Pick<AutomationSchedule, 'runAtHour' | 'runAtMinute'>
+  quietHoursStart?: string | null
+  quietHoursEnd?: string | null
+}) {
+  if (!input.quietHoursStart || !input.quietHoursEnd) return null
+  const runMinute = clampClock(input.schedule.runAtHour, 0, 23, 9) * 60 + clampClock(input.schedule.runAtMinute, 0, 59, 0)
+  const quietWindow = `${input.quietHoursStart}-${input.quietHoursEnd}`
+  if (isMinuteWithinQuietHours(runMinute, input.quietHoursStart, input.quietHoursEnd)) {
+    return `Run time falls inside notification quiet hours (${quietWindow}); work can still queue, but desktop alerts stay quiet.`
+  }
+  return `Notification quiet hours (${quietWindow}) do not overlap the scheduled run time.`
+}
+
+function scheduleFromDraft(draft: DraftState): AutomationSchedule | null {
+  try {
+    return draftToPayload(draft).schedule
+  } catch {
+    return null
+  }
+}
+
+function nextRunPreviewFromSchedule(schedule: AutomationSchedule, from = new Date()) {
+  if (schedule.type === 'one_time') {
+    const at = schedule.startAt ? new Date(schedule.startAt) : null
+    if (!at || Number.isNaN(at.getTime())) return null
+    return at.getTime() > from.getTime() ? at.toISOString() : null
+  }
+
+  const runAtHour = clampClock(schedule.runAtHour, 0, 23, 9)
+  const runAtMinute = clampClock(schedule.runAtMinute, 0, 59, 0)
+  const candidate = new Date(from)
+  candidate.setSeconds(0, 0)
+  candidate.setHours(runAtHour, runAtMinute, 0, 0)
+
+  if (schedule.type === 'daily') {
+    if (candidate.getTime() <= from.getTime()) candidate.setDate(candidate.getDate() + 1)
+    return candidate.toISOString()
+  }
+
+  if (schedule.type === 'weekly') {
+    const targetDay = clampClock(schedule.dayOfWeek, 0, 6, 1)
+    let delta = targetDay - candidate.getDay()
+    if (delta < 0 || (delta === 0 && candidate.getTime() <= from.getTime())) delta += 7
+    candidate.setDate(candidate.getDate() + delta)
+    return candidate.toISOString()
+  }
+
+  const targetDay = clampClock(schedule.dayOfMonth, 1, 31, 1)
+  candidate.setDate(Math.min(targetDay, new Date(candidate.getFullYear(), candidate.getMonth() + 1, 0).getDate()))
+  if (candidate.getTime() <= from.getTime()) {
+    candidate.setMonth(candidate.getMonth() + 1, 1)
+    candidate.setDate(Math.min(targetDay, new Date(candidate.getFullYear(), candidate.getMonth() + 1, 0).getDate()))
+  }
+  return candidate.toISOString()
+}
+
+export function buildAutomationSchedulePreview(input: {
+  schedule: AutomationSchedule
+  status?: AutomationDetail['status']
+  nextRunAt?: string | null
+  nextHeartbeatAt?: string | null
+  quietHoursStart?: string | null
+  quietHoursEnd?: string | null
+}): AutomationSchedulePreview {
+  const paused = input.status === 'paused' || input.status === 'archived'
+  return {
+    cadence: formatSchedule(input.schedule),
+    nextRun: paused
+      ? 'Paused; scheduled runs resume only after you resume this automation.'
+      : input.nextRunAt
+        ? `Next run ${formatTimestamp(input.nextRunAt, '')}`
+        : input.schedule.type === 'one_time'
+          ? 'No future one-time run is scheduled.'
+          : 'Next run will be calculated after the automation is saved.',
+    checkIn: input.nextHeartbeatAt ? `Next check-in ${formatTimestamp(input.nextHeartbeatAt, '')}` : 'No check-in is currently scheduled.',
+    quietHours: describeQuietHoursImpact({
+      schedule: input.schedule,
+      quietHoursStart: input.quietHoursStart,
+      quietHoursEnd: input.quietHoursEnd,
+    }),
+  }
+}
+
+export function buildDraftSchedulePreview(input: {
+  draft: DraftState
+  quietHoursStart?: string | null
+  quietHoursEnd?: string | null
+}): AutomationSchedulePreview {
+  const schedule = scheduleFromDraft(input.draft)
+  if (!schedule) {
+    return {
+      cadence: 'Check the schedule fields before creating this automation.',
+      nextRun: 'Next run cannot be previewed yet.',
+      checkIn: `${input.draft.heartbeatMinutes || '15'} minute check-ins after creation.`,
+      quietHours: null,
+    }
+  }
+  const nextRunAt = nextRunPreviewFromSchedule(schedule)
+  return {
+    cadence: formatSchedule(schedule),
+    nextRun: nextRunAt
+      ? `First run ${formatTimestamp(nextRunAt, '')}`
+      : schedule.type === 'one_time'
+        ? 'No future one-time run is scheduled.'
+        : 'First run will be calculated after creation.',
+    checkIn: `${Number.parseInt(input.draft.heartbeatMinutes, 10) || 15} minute check-ins after creation.`,
+    quietHours: describeQuietHoursImpact({
+      schedule,
+      quietHoursStart: input.quietHoursStart,
+      quietHoursEnd: input.quietHoursEnd,
+    }),
+  }
 }
 
 export function pluralize(count: number, singular: string, plural = `${singular}s`) {
@@ -182,9 +356,10 @@ export function deriveReliabilityState(input: {
     }
   }
   if (automation.status === 'needs_user') {
+    const reviewItems = pluralize(inbox.length, 'open review item')
     return {
       value: 'Waiting on you',
-      detail: inbox.length > 0 ? `${pluralize(inbox.length, 'open inbox item')} is blocking progress.` : 'Waiting for clarification or approval.',
+      detail: inbox.length > 0 ? `${reviewItems} ${inbox.length === 1 ? 'is' : 'are'} blocking progress.` : 'Waiting for clarification or approval.',
     }
   }
   if (activeRun) {
@@ -212,7 +387,7 @@ export function describeRunPolicy(automation: AutomationDetail, latestRun: Autom
   if (latestRun?.error?.includes('timed out')) {
     return latestRun.error
   }
-  return `${automation.runPolicy.dailyRunCap} execution attempt${automation.runPolicy.dailyRunCap === 1 ? '' : 's'} per day (including retries) · ${automation.runPolicy.maxRunDurationMinutes} minute max per run · ${automation.retryPolicy.maxRetries} retry${automation.retryPolicy.maxRetries === 1 ? '' : 'ies'} available.`
+  return `${automation.runPolicy.dailyRunCap} execution attempt${automation.runPolicy.dailyRunCap === 1 ? '' : 's'} per day (including retries) · ${automation.runPolicy.maxRunDurationMinutes} minute max per run · ${automation.retryPolicy.maxRetries} ${automation.retryPolicy.maxRetries === 1 ? 'retry' : 'retries'} available.`
 }
 
 export function latestRunSummary(run: AutomationRun | null) {
@@ -233,11 +408,11 @@ export function deriveNextAction(input: {
   const { automation, inbox, activeRun, latestRun, latestDelivery } = input
   if (activeRun) return `Monitor the ${formatRunKindForUser(activeRun.kind)} run in progress`
   if (automation.status === 'needs_user') {
-    return inbox.length > 0 ? `Resolve ${pluralize(inbox.length, 'open inbox item')}` : 'Provide the missing context'
+    return inbox.length > 0 ? `Resolve ${pluralize(inbox.length, 'open review item')}` : 'Provide the missing context'
   }
   if (automation.status === 'paused') return 'Resume when you want work to continue'
-  if (!automation.brief) return 'Preview the execution brief'
-  if (!automation.brief.approvedAt) return 'Approve the execution brief'
+  if (!automation.brief) return 'Prepare the brief'
+  if (!automation.brief.approvedAt) return 'Approve the prepared brief'
   if (automation.status === 'failed') {
     return latestRun?.nextRetryAt
       ? 'Wait for the scheduled retry or inspect the failed run'

--- a/apps/desktop/src/renderer/components/automations/automation-view-model.ts
+++ b/apps/desktop/src/renderer/components/automations/automation-view-model.ts
@@ -165,6 +165,15 @@ export function isAutomationUxV2Enabled(storage?: Storage | null) {
 
 const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
+type ZonedParts = {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+}
+
 function clampClock(value: number | null | undefined, min: number, max: number, fallback: number) {
   return Number.isFinite(value) ? Math.max(min, Math.min(max, Number(value))) : fallback
 }
@@ -205,13 +214,23 @@ function isMinuteWithinQuietHours(minute: number, quietStart: string | null | un
   return minute >= start || minute < end
 }
 
+function localClockMinuteFromIso(value: string | null | undefined) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.getHours() * 60 + date.getMinutes()
+}
+
 export function describeQuietHoursImpact(input: {
-  schedule: Pick<AutomationSchedule, 'runAtHour' | 'runAtMinute'>
+  schedule: Pick<AutomationSchedule, 'type' | 'startAt' | 'runAtHour' | 'runAtMinute'>
+  runAtIso?: string | null
   quietHoursStart?: string | null
   quietHoursEnd?: string | null
 }) {
   if (!input.quietHoursStart || !input.quietHoursEnd) return null
-  const runMinute = clampClock(input.schedule.runAtHour, 0, 23, 9) * 60 + clampClock(input.schedule.runAtMinute, 0, 59, 0)
+  const runMinute = localClockMinuteFromIso(input.runAtIso)
+    ?? (input.schedule.type === 'one_time' ? localClockMinuteFromIso(input.schedule.startAt) : null)
+    ?? clampClock(input.schedule.runAtHour, 0, 23, 9) * 60 + clampClock(input.schedule.runAtMinute, 0, 59, 0)
   const quietWindow = `${input.quietHoursStart}-${input.quietHoursEnd}`
   if (isMinuteWithinQuietHours(runMinute, input.quietHoursStart, input.quietHoursEnd)) {
     return `Run time falls inside notification quiet hours (${quietWindow}); work can still queue, but desktop alerts stay quiet.`
@@ -227,39 +246,131 @@ function scheduleFromDraft(draft: DraftState): AutomationSchedule | null {
   }
 }
 
-function nextRunPreviewFromSchedule(schedule: AutomationSchedule, from = new Date()) {
+function numberPart(value: string | undefined, fallback = 0) {
+  const numeric = Number.parseInt(value || '', 10)
+  return Number.isFinite(numeric) ? numeric : fallback
+}
+
+function getZonedParts(date: Date, timeZone: string): ZonedParts {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  })
+  const parts = formatter.formatToParts(date)
+  const map = Object.fromEntries(parts.map((part) => [part.type, part.value]))
+  return {
+    year: numberPart(map.year),
+    month: numberPart(map.month),
+    day: numberPart(map.day),
+    hour: numberPart(map.hour),
+    minute: numberPart(map.minute),
+    second: numberPart(map.second),
+  }
+}
+
+function getTimeZoneOffsetMs(timeZone: string, date: Date) {
+  const zoned = getZonedParts(date, timeZone)
+  const utc = Date.UTC(zoned.year, zoned.month - 1, zoned.day, zoned.hour, zoned.minute, zoned.second)
+  return utc - date.getTime()
+}
+
+function zonedDateTimeToUtc(timeZone: string, year: number, month: number, day: number, hour: number, minute: number) {
+  const guess = new Date(Date.UTC(year, month - 1, day, hour, minute, 0))
+  const firstOffset = getTimeZoneOffsetMs(timeZone, guess)
+  const candidate = new Date(guess.getTime() - firstOffset)
+  const secondOffset = getTimeZoneOffsetMs(timeZone, candidate)
+  if (secondOffset !== firstOffset) return new Date(guess.getTime() - secondOffset)
+  return candidate
+}
+
+function daysInMonth(year: number, month: number) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
+}
+
+function clampDayOfMonth(year: number, month: number, requested: number) {
+  return Math.max(1, Math.min(requested, daysInMonth(year, month)))
+}
+
+function addZonedDays(parts: ZonedParts, days: number): ZonedParts {
+  const shifted = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days, parts.hour, parts.minute, parts.second))
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+    hour: parts.hour,
+    minute: parts.minute,
+    second: parts.second,
+  }
+}
+
+function sameScheduledLocalTime(schedule: AutomationSchedule, date: Date) {
+  const parts = getZonedParts(date, schedule.timezone)
+  const runAtHour = clampClock(schedule.runAtHour, 0, 23, 9)
+  const runAtMinute = clampClock(schedule.runAtMinute, 0, 59, 0)
+  return parts.hour === runAtHour && parts.minute === runAtMinute
+}
+
+export function nextRunPreviewFromSchedule(schedule: AutomationSchedule, from = new Date()) {
   if (schedule.type === 'one_time') {
     const at = schedule.startAt ? new Date(schedule.startAt) : null
     if (!at || Number.isNaN(at.getTime())) return null
     return at.getTime() > from.getTime() ? at.toISOString() : null
   }
 
-  const runAtHour = clampClock(schedule.runAtHour, 0, 23, 9)
-  const runAtMinute = clampClock(schedule.runAtMinute, 0, 59, 0)
-  const candidate = new Date(from)
-  candidate.setSeconds(0, 0)
-  candidate.setHours(runAtHour, runAtMinute, 0, 0)
+  try {
+    const runAtHour = clampClock(schedule.runAtHour, 0, 23, 9)
+    const runAtMinute = clampClock(schedule.runAtMinute, 0, 59, 0)
+    const zonedNow = getZonedParts(from, schedule.timezone || 'UTC')
 
-  if (schedule.type === 'daily') {
-    if (candidate.getTime() <= from.getTime()) candidate.setDate(candidate.getDate() + 1)
+    if (schedule.type === 'daily') {
+      let candidate = zonedDateTimeToUtc(schedule.timezone || 'UTC', zonedNow.year, zonedNow.month, zonedNow.day, runAtHour, runAtMinute)
+      if (candidate.getTime() <= from.getTime()) {
+        const tomorrow = addZonedDays(zonedNow, 1)
+        candidate = zonedDateTimeToUtc(schedule.timezone || 'UTC', tomorrow.year, tomorrow.month, tomorrow.day, runAtHour, runAtMinute)
+      }
+      return candidate.toISOString()
+    }
+
+    if (schedule.type === 'weekly') {
+      const currentDay = new Date(Date.UTC(zonedNow.year, zonedNow.month - 1, zonedNow.day)).getUTCDay()
+      const targetDay = clampClock(schedule.dayOfWeek, 0, 6, 1)
+      let delta = targetDay - currentDay
+      if (delta < 0 || (delta === 0 && sameScheduledLocalTime(schedule, from))) delta += 7
+      const target = addZonedDays(zonedNow, delta)
+      let candidate = zonedDateTimeToUtc(schedule.timezone || 'UTC', target.year, target.month, target.day, runAtHour, runAtMinute)
+      if (candidate.getTime() <= from.getTime()) {
+        const nextWeek = addZonedDays(target, 7)
+        candidate = zonedDateTimeToUtc(schedule.timezone || 'UTC', nextWeek.year, nextWeek.month, nextWeek.day, runAtHour, runAtMinute)
+      }
+      return candidate.toISOString()
+    }
+
+    const requestedDay = clampClock(schedule.dayOfMonth, 1, 31, 1)
+    const day = clampDayOfMonth(zonedNow.year, zonedNow.month, requestedDay)
+    let candidate = zonedDateTimeToUtc(schedule.timezone || 'UTC', zonedNow.year, zonedNow.month, day, runAtHour, runAtMinute)
+    if (candidate.getTime() <= from.getTime()) {
+      const nextMonth = zonedNow.month === 12
+        ? { year: zonedNow.year + 1, month: 1 }
+        : { year: zonedNow.year, month: zonedNow.month + 1 }
+      candidate = zonedDateTimeToUtc(
+        schedule.timezone || 'UTC',
+        nextMonth.year,
+        nextMonth.month,
+        clampDayOfMonth(nextMonth.year, nextMonth.month, requestedDay),
+        runAtHour,
+        runAtMinute,
+      )
+    }
     return candidate.toISOString()
+  } catch {
+    return null
   }
-
-  if (schedule.type === 'weekly') {
-    const targetDay = clampClock(schedule.dayOfWeek, 0, 6, 1)
-    let delta = targetDay - candidate.getDay()
-    if (delta < 0 || (delta === 0 && candidate.getTime() <= from.getTime())) delta += 7
-    candidate.setDate(candidate.getDate() + delta)
-    return candidate.toISOString()
-  }
-
-  const targetDay = clampClock(schedule.dayOfMonth, 1, 31, 1)
-  candidate.setDate(Math.min(targetDay, new Date(candidate.getFullYear(), candidate.getMonth() + 1, 0).getDate()))
-  if (candidate.getTime() <= from.getTime()) {
-    candidate.setMonth(candidate.getMonth() + 1, 1)
-    candidate.setDate(Math.min(targetDay, new Date(candidate.getFullYear(), candidate.getMonth() + 1, 0).getDate()))
-  }
-  return candidate.toISOString()
 }
 
 export function buildAutomationSchedulePreview(input: {
@@ -283,6 +394,7 @@ export function buildAutomationSchedulePreview(input: {
     checkIn: input.nextHeartbeatAt ? `Next check-in ${formatTimestamp(input.nextHeartbeatAt, '')}` : 'No check-in is currently scheduled.',
     quietHours: describeQuietHoursImpact({
       schedule: input.schedule,
+      runAtIso: input.nextRunAt,
       quietHoursStart: input.quietHoursStart,
       quietHoursEnd: input.quietHoursEnd,
     }),
@@ -314,6 +426,7 @@ export function buildDraftSchedulePreview(input: {
     checkIn: `${Number.parseInt(input.draft.heartbeatMinutes, 10) || 15} minute check-ins after creation.`,
     quietHours: describeQuietHoursImpact({
       schedule,
+      runAtIso: nextRunAt,
       quietHoursStart: input.quietHoursStart,
       quietHoursEnd: input.quietHoursEnd,
     }),

--- a/apps/desktop/tests/automations-page.smoke.test.ts
+++ b/apps/desktop/tests/automations-page.smoke.test.ts
@@ -20,8 +20,8 @@ test('automations page shows an overview landing state before any automation exi
 
 async function createWeeklyAutomation(page: Page, title: string, goal: string) {
   await page.getByRole('button', { name: /New automation/i }).first().click()
-  await page.getByLabel('Title').fill(title)
-  await page.getByLabel('Goal').fill(goal)
+  await page.getByRole('textbox', { name: 'Outcome', exact: true }).fill(title)
+  await page.getByRole('textbox', { name: 'Audience and success criteria', exact: true }).fill(goal)
   await page.getByRole('button', { name: 'Continue', exact: true }).click()
   await page.getByRole('button', { name: 'Continue', exact: true }).click()
   await page.getByRole('button', { name: 'Create automation', exact: true }).click()
@@ -69,11 +69,11 @@ test('automation templates prefill the draft and scoped execution requires a pro
     await page.getByRole('button', { name: 'Automations', exact: true }).click()
 
     await page.getByRole('button', { name: /New automation/i }).first().click()
-    await page.getByRole('dialog', { name: /What & Why/i }).getByRole('button', { name: /Managed project/ }).first().click()
+    await page.getByRole('dialog', { name: /Outcome & Audience/i }).getByRole('button', { name: /Managed project/ }).first().click()
 
-    assert.equal(await page.getByLabel('Title').inputValue(), 'Managed product roadmap')
+    assert.equal(await page.getByRole('textbox', { name: 'Outcome', exact: true }).inputValue(), 'Managed product roadmap')
     assert.equal(
-      await page.getByLabel('Goal').inputValue(),
+      await page.getByRole('textbox', { name: 'Audience and success criteria', exact: true }).inputValue(),
       'Maintain a clear roadmap for this project, prepare the next execution-ready tasks, and keep progress moving forward without guessing when context is missing.',
     )
 
@@ -110,8 +110,8 @@ test('automation draft resets to the saved automation defaults after create', as
     await page.getByRole('button', { name: 'Close automation details' }).click()
 
     await page.getByRole('button', { name: /New automation/i }).first().click()
-    await page.getByLabel('Title').fill('Defaults snapshot')
-    await page.getByLabel('Goal').fill('Check defaults after create.')
+    await page.getByRole('textbox', { name: 'Outcome', exact: true }).fill('Defaults snapshot')
+    await page.getByRole('textbox', { name: 'Audience and success criteria', exact: true }).fill('Check defaults after create.')
     await page.getByRole('button', { name: 'Continue', exact: true }).click()
     await page.getByRole('button', { name: /Mostly autonomous/ }).waitFor()
     await page.getByRole('button', { name: /Planning only/ }).waitFor()
@@ -128,8 +128,8 @@ test('automation creation persists preferred specialists', async () => {
     await page.getByRole('button', { name: 'Automations', exact: true }).click()
 
     await page.getByRole('button', { name: /New automation/i }).first().click()
-    await page.getByLabel('Title').fill('Specialist team check')
-    await page.getByLabel('Goal').fill('Verify the selected specialist team persists through automation creation.')
+    await page.getByRole('textbox', { name: 'Outcome', exact: true }).fill('Specialist team check')
+    await page.getByRole('textbox', { name: 'Audience and success criteria', exact: true }).fill('Verify the selected specialist team persists through automation creation.')
     await page.getByRole('button', { name: 'Continue', exact: true }).click()
     await page.getByRole('button', { name: 'Continue', exact: true }).click()
     await page.getByRole('button', { name: 'Show advanced settings', exact: true }).click()

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -18,24 +18,24 @@ use, but wrap it in a more durable product layer.
 stateDiagram-v2
     [*] --> Scheduled: schedule fires
     Scheduled --> PrepareBrief: scheduler claims work
-    PrepareBrief --> Inbox: missing context / approval
-    Inbox --> PrepareBrief: user clarifies
-    Inbox --> PrepareBrief: user approves brief
+    PrepareBrief --> Review: missing context / approval
+    Review --> PrepareBrief: user clarifies
+    Review --> PrepareBrief: user approves brief
     PrepareBrief --> Executing: brief approved
     Executing --> CheckIn: long-running pause
     CheckIn --> Executing: resume
-    CheckIn --> Inbox: needs input
+    CheckIn --> Review: needs input
     Executing --> Delivered: success
     Executing --> Retry: transient failure
     Retry --> Executing: backoff elapsed
     Retry --> Failed: retry budget exhausted
-    Failed --> Inbox: surfaces failure item
+    Failed --> Review: surfaces failure item
     Delivered --> [*]
     Failed --> [*]
 ```
 
 Every transition is durable — a crash mid-run resumes from the last
-recorded state, not from scratch. The Inbox is the universal escape
+recorded state, not from scratch. The Reviews queue is the universal escape
 hatch: clarification asks, approvals, and failure handling all flow
 through it instead of through the chat thread list.
 
@@ -45,8 +45,8 @@ Automations add durable product state around OpenCode execution:
 
 - schedules
 - review check-ins
-- execution briefs
-- inbox items
+- prepared briefs
+- review items
 - tasks
 - runs
 - delivery records
@@ -74,7 +74,7 @@ retry ceilings. These are ceilings, not permission grants. Lowering them makes
 future automation, saved workflow, and crew queue items more conservative; raising write
 parallelism is the explicit opt-in for concurrent writes to the same authority.
 
-Completed automation runs can also be saved as **saved workflows (SOPs)**. A SOP is a reusable,
+Completed automation runs can also be saved as **saved workflows**. A saved workflow is a reusable,
 versioned process definition derived from a successful run: it preserves the
 brief shape, task graph, approval boundary, retry/run policy, and delivery
 policy without copying OpenCode's execution engine. Later workflow edits create new versions,
@@ -97,10 +97,16 @@ Each automation has:
 
 The current UI supports:
 
-- `one_time`
-- `daily`
-- `weekly`
-- `monthly`
+- one-time runs
+- daily runs
+- weekly runs
+- monthly runs
+
+The renderer presents those schedules in operator language instead of schema
+labels. For example, a weekly schedule becomes “Every Monday at 09:00,” and the
+creation wizard previews the first run, the check-in cadence, and whether the
+run time overlaps desktop-notification quiet hours. Quiet hours suppress alerts;
+they do not prevent durable work from queueing.
 
 The scheduler creates durable runs when work is due. Check-ins are separate;
 they are lightweight supervisory review loops, not the primary scheduler.
@@ -110,8 +116,8 @@ they are lightweight supervisory review loops, not the primary scheduler.
 The default posture is review-first:
 
 1. The automation prepares a brief.
-2. `plan` turns the raw goal into an execution brief.
-3. Missing context or approvals become inbox items.
+2. `plan` turns the raw goal into a prepared brief.
+3. Missing context or approvals become review items.
 4. Only an approved brief moves into execution.
 
 This is deliberate. Automations should stop and ask instead of guessing.
@@ -128,8 +134,8 @@ execution.
 
 The Automations page is split into durable operational surfaces:
 
-- **Automations** — the list of standing programs
-- **Inbox** — approvals, clarifications, failures, and informational notices
+- **Automations** — the board or gated table of standing programs
+- **Reviews** — approvals, clarifications, failures, and informational notices
 - **Tasks** — the durable backlog derived from the current brief
 - **Runs** — actual execution attempts linked to OpenCode sessions
 - **Deliveries** — current output records (in-app today)
@@ -137,6 +143,13 @@ The Automations page is split into durable operational surfaces:
   processes from the run detail surface
 
 This keeps operational state separate from the chat thread list.
+
+The automation detail drawer follows the same operator IA as the desktop app:
+Overview, Schedule, Reviews, Runs, Outputs, Settings, and History. Board movement
+still maps to the same underlying services, but the daily workflow is explicit:
+prepare the brief, approve review items, run now, pause or resume, cancel an
+active run, retry failures, archive completed programs, or save a successful run
+as a reusable workflow.
 
 ## Check-ins
 
@@ -169,7 +182,7 @@ These controls exist to keep always-on work bounded and reviewable.
 
 The current upstream build records delivery in-app only.
 
-Successful runs create delivery records and inbox-visible output. That keeps the
+Successful runs create delivery records and review-visible output. That keeps the
 public upstream focused and safe while leaving room for downstream integrations
 later.
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -6,7 +6,7 @@ The desktop app is centered around nine areas:
 - `Home` — welcoming landing surface
 - `Chat` — where OpenCode sessions run
 - `Threads` — searchable history, metadata facets, user tags, saved filters, and the gated Work Ledger
-- `Automations` — the durable schedule / inbox / run control plane
+- `Automations` — the durable schedule / review / run control plane
 - `Crews` — supervised multi-agent runs with trace, queue, and eval visibility
 - `Agents` — manage built-in and custom agents
 - `Capabilities` — browse tools, skills, and MCPs
@@ -18,7 +18,7 @@ flowchart TD
     Home["Home<br/>composer · recent threads · @-agent pills"]
     Chat["Chat<br/>session UI · streamed events · approvals"]
     Threads["Threads<br/>search · facets · tags · filters · ledger"]
-    Auto["Automations<br/>list · inbox · tasks · runs · deliveries"]
+    Auto["Automations<br/>list · reviews · tasks · runs · deliveries"]
     Crews["Crews<br/>lead · specialists · evaluator · queue"]
     Agents["Agents<br/>built-in + custom"]
     Caps["Capabilities<br/>tools · skills · MCPs"]
@@ -80,6 +80,12 @@ registry tables share quick filters, sortable operational columns, row
 selection, and disabled states for bulk actions that do not yet have a backing
 service. Automations wire supported bulk pause, resume, and archive actions;
 Capabilities wire single-row dependency drill-downs.
+
+The `automationUxV2` feature gate is also default-off. Enable it with the
+renderer preference key `open-cowork.feature.automationUxV2=true` to expose the
+fleet-scale automation table from the Automations page even when the broader
+registry gate is off. The existing board remains available while the v2
+creation, schedule preview, and detail-drawer IA settle.
 
 The `workLedgerV1` feature gate is also default-off. Enable it with the
 renderer preference key `open-cowork.feature.workLedgerV1=true` to show the
@@ -221,22 +227,27 @@ Automations are the durable product layer for always-on work.
 
 They keep the runtime split clean:
 - OpenCode still executes `plan`, `build`, subagents, approvals, questions, and tools
-- Open Cowork adds the durable scheduling, inbox, task, retry, and delivery surfaces around that execution
+- Open Cowork adds the durable scheduling, review, task, retry, and delivery surfaces around that execution
 
 The current upstream surface includes:
-- recurring schedules (`one_time`, `daily`, `weekly`, `monthly`)
+- recurring schedules shown in operator language, such as “Every Monday at
+  09:00” or “Every month on day 1 at 09:00”
+- next-run and check-in previews during creation and in the detail drawer
 - review-first brief preparation before execution
 - check-ins for due or blocked work
-- inbox items for clarification, approval, and failure handling
+- review items for clarification, approval, and failure handling
 - durable tasks, runs, and in-app deliveries
 - operations queue authority for automation and saved-workflow execution runs,
   including serialized project-scoped writes and visible queue guardrails
 - optional preferred specialists that bias routing without replacing the `plan` / `build` flow
 
-Once an automation exists it gets a dedicated detail surface for
-brief, run timeline, reliability, and run policy:
+Once an automation exists it gets a dedicated detail surface for Overview,
+Schedule, Reviews, Runs, Outputs, Settings, and History. The primary controls
+are explicit buttons for preparing the brief, approving review items, running
+now, pausing/resuming, cancelling active runs, archiving, retrying failed runs,
+and saving successful runs as reusable workflows:
 
-![Automation detail with execution brief, run timeline, reliability, and run policy panels](assets/auto/automations-detail.png)
+![Automation detail with prepared brief, run timeline, reliability, and run policy panels](assets/auto/automations-detail.png)
 
 ## Crews
 
@@ -354,7 +365,7 @@ controls for old or unused sandbox workspaces.
 
 The Channels section creates local webhook pairings against channel-bound
 workspace profiles. Each pairing records a source key, sender allowlist,
-activation mode, optional saved workflow (SOP) or Crew route, and optional capability scope.
+activation mode, optional saved workflow or Crew route, and optional capability scope.
 Pairing tokens are only revealed when created or rotated.
 
 Channel items configured for `run_sop` or `run_crew` still stop at Pulse for


### PR DESCRIPTION
## Summary
- add the default-off automationUxV2 gate and use it to expose the automation table independently of the broader registry gate
- add operator-facing automation schedule previews, quiet-hours impact copy, and natural schedule labels
- reorganize automation creation/detail flows around outcome, schedule, reviews, runs, outputs, settings, and history with explicit lifecycle actions and clearer blocked/failure copy
- update automation docs and desktop app UX language to prefer prepared briefs, review items, and saved workflows

## Test gates
- pnpm --filter @open-cowork/desktop test:renderer -- AutomationBoard AutomationCreateWizard AutomationCardDetail AutomationsPage AutomationHelpDrawer automation-view-model
- pnpm typecheck
- pnpm lint
- pnpm test
- uv run mkdocs build --strict
- git diff --check

Fixes #342