### PR TITLE
Promote Connections and Governance navigation

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { LoginScreen } from './components/LoginScreen'
 import { LoadingScreen } from './components/LoadingScreen'
 import { SetupScreen } from './components/SetupScreen'
 import { HomePage } from './components/HomePage'
+import { isConnectionsGovernanceNavEnabled } from './components/operations/connections-governance-ui'
 import { isOperationsCommandCenterEnabled } from './components/operations/operations-ui'
 import type { AppView } from './app-types'
 
@@ -19,6 +20,8 @@ const AgentsPage = lazy(() => import('./components/agents/AgentsPage').then((m) 
 const CrewsPage = lazy(() => import('./components/crews/CrewsPage').then((m) => ({ default: m.CrewsPage })))
 const CapabilitiesPage = lazy(() => import('./components/capabilities/CapabilitiesPage').then((m) => ({ default: m.CapabilitiesPage })))
 const OperationsPage = lazy(() => import('./components/operations/OperationsPage').then((m) => ({ default: m.OperationsPage })))
+const ConnectionsPage = lazy(() => import('./components/operations/ConnectionsPage').then((m) => ({ default: m.ConnectionsPage })))
+const GovernancePage = lazy(() => import('./components/operations/GovernancePage').then((m) => ({ default: m.GovernancePage })))
 // Pulse is the diagnostic workspace view — runtime pills, MCP status, usage
 // metrics, perf. Lazy-loaded because most users landing on Home don't need it
 // right away, and it pulls a lot of formatting helpers that would otherwise
@@ -113,6 +116,7 @@ export function App() {
   const [rendererErrorNotice, setRendererErrorNotice] = useRendererErrorNotice()
   const [bootstrapError, setBootstrapError] = useState<string | null>(null)
   const operationsEnabled = useMemo(() => isOperationsCommandCenterEnabled(), [])
+  const connectionsGovernanceEnabled = useMemo(() => isConnectionsGovernanceNavEnabled(), [])
 
   const reportAppError = useCallback((notice: string, error: unknown, viewName = 'app') => {
     setRendererErrorNotice(notice)
@@ -266,6 +270,12 @@ export function App() {
       setView('home')
     }
   }, [view, currentSessionId])
+
+  useEffect(() => {
+    if (!connectionsGovernanceEnabled && (view === 'connections' || view === 'governance')) {
+      setView('pulse')
+    }
+  }, [connectionsGovernanceEnabled, view])
 
   useEffect(() => {
     if (view !== 'chat' || !pendingComposerInsert) return
@@ -455,6 +465,7 @@ export function App() {
             searchRequestNonce={sidebarSearchNonce}
             settingsRequestNonce={sidebarSettingsNonce}
             branding={config.branding.sidebar}
+            connectionsGovernanceEnabled={connectionsGovernanceEnabled}
           />
         )}
         <main className="flex-1 flex flex-col min-h-0 min-w-0">
@@ -517,12 +528,29 @@ export function App() {
                   onOpenThread={(sessionId) => void openExistingThread(sessionId)}
                   onOpenRoute={openWorkLedgerRoute}
                   onOpenDiagnostics={() => setView('pulse')}
+                  onOpenConnections={connectionsGovernanceEnabled ? () => setView('connections') : undefined}
+                  onOpenGovernance={connectionsGovernanceEnabled ? () => setView('governance') : undefined}
                 />
+              </Suspense>
+            )}
+            {view === 'connections' && connectionsGovernanceEnabled && (
+              <Suspense fallback={null}>
+                <ConnectionsPage onOpenSettings={openSidebarSettings} />
+              </Suspense>
+            )}
+            {view === 'governance' && connectionsGovernanceEnabled && (
+              <Suspense fallback={null}>
+                <GovernancePage onOpenSettings={openSidebarSettings} />
               </Suspense>
             )}
             {view === 'pulse' && (
               <Suspense fallback={null}>
-                <PulsePage onOpenThread={() => setView('chat')} brandName={config.branding.name} />
+                <PulsePage
+                  onOpenThread={() => setView('chat')}
+                  brandName={config.branding.name}
+                  onOpenConnections={connectionsGovernanceEnabled ? () => setView('connections') : undefined}
+                  onOpenGovernance={connectionsGovernanceEnabled ? () => setView('governance') : undefined}
+                />
               </Suspense>
             )}
           </ViewErrorBoundary>
@@ -544,6 +572,7 @@ export function App() {
             onOpenSettings={openSidebarSettings}
             onToggleSearch={openSidebarSearch}
             operationsEnabled={operationsEnabled}
+            connectionsGovernanceEnabled={connectionsGovernanceEnabled}
           />
         </Suspense>
       )}

--- a/apps/desktop/src/renderer/app-types.ts
+++ b/apps/desktop/src/renderer/app-types.ts
@@ -1,1 +1,1 @@
-export type AppView = 'home' | 'chat' | 'threads' | 'automations' | 'agents' | 'crews' | 'capabilities' | 'operations' | 'pulse'
+export type AppView = 'home' | 'chat' | 'threads' | 'automations' | 'agents' | 'crews' | 'capabilities' | 'operations' | 'connections' | 'governance' | 'pulse'

--- a/apps/desktop/src/renderer/components/CommandPalette.test.tsx
+++ b/apps/desktop/src/renderer/components/CommandPalette.test.tsx
@@ -57,4 +57,31 @@ describe('CommandPalette', () => {
     expect(onInsertComposer).toHaveBeenCalledWith('@research ')
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('adds gated Connections and Governance destinations to the command palette', async () => {
+    const onClose = vi.fn()
+    const onNavigate = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CommandPalette
+        onClose={onClose}
+        onNavigate={onNavigate}
+        onCreateThread={vi.fn(async () => null)}
+        onEnsureSession={vi.fn(async () => true)}
+        onInsertComposer={vi.fn()}
+        onSetAgentMode={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onToggleSearch={vi.fn()}
+        connectionsGovernanceEnabled
+      />,
+    )
+
+    const search = screen.getByRole('combobox', { name: 'Search command palette' })
+    await user.type(search, 'governance')
+    await user.click(await screen.findByRole('option', { name: /Governance/ }))
+
+    expect(onNavigate).toHaveBeenCalledWith('governance')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/renderer/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/components/CommandPalette.tsx
@@ -26,6 +26,7 @@ interface CommandPaletteProps {
   onOpenSettings: () => void
   onToggleSearch: () => void
   operationsEnabled?: boolean
+  connectionsGovernanceEnabled?: boolean
 }
 
 export function CommandPalette({
@@ -38,6 +39,7 @@ export function CommandPalette({
   onOpenSettings,
   onToggleSearch,
   operationsEnabled = false,
+  connectionsGovernanceEnabled = false,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState('')
   const [commands, setCommands] = useState<RuntimeCommand[]>([])
@@ -84,13 +86,14 @@ export function CommandPalette({
       onOpenSettings,
       onToggleSearch,
       operationsEnabled,
+      connectionsGovernanceEnabled,
       onRunCommand: async (name) => {
         const sessionId = useSessionStore.getState().currentSessionId
         if (!sessionId) return false
         return window.coworkApi.command.run(sessionId, name)
       },
     })
-  }, [builtinAgents, commands, customAgents, onCreateThread, onEnsureSession, onInsertComposer, onNavigate, onSetAgentMode, onOpenSettings, onToggleSearch, operationsEnabled])
+  }, [builtinAgents, commands, connectionsGovernanceEnabled, customAgents, onCreateThread, onEnsureSession, onInsertComposer, onNavigate, onSetAgentMode, onOpenSettings, onToggleSearch, operationsEnabled])
 
   const filteredItems = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase()

--- a/apps/desktop/src/renderer/components/PulsePage.tsx
+++ b/apps/desktop/src/renderer/components/PulsePage.tsx
@@ -387,7 +387,17 @@ function deliveryCanCancel(delivery: ChannelDeliveryRecord) {
   return delivery.status === 'draft' || delivery.status === 'approval_required'
 }
 
-export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => void; brandName: string }) {
+export function PulsePage({
+  onOpenThread,
+  brandName,
+  onOpenConnections,
+  onOpenGovernance,
+}: {
+  onOpenThread: () => void
+  brandName: string
+  onOpenConnections?: () => void
+  onOpenGovernance?: () => void
+}) {
   const addSession = useSessionStore((s) => s.addSession)
   const setCurrentSession = useSessionStore((s) => s.setCurrentSession)
   const addGlobalError = useSessionStore((s) => s.addGlobalError)
@@ -1136,6 +1146,17 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                             emptyLabel={t('homepage.governance.empty', 'No governed dependencies registered yet.')}
                           />
                         </div>
+                        {onOpenGovernance ? (
+                          <div className="mt-3">
+                            <button
+                              type="button"
+                              onClick={onOpenGovernance}
+                              className="rounded-full border border-border-subtle px-3 py-1.5 text-[11px] font-semibold text-text-secondary transition-colors hover:bg-surface-hover hover:text-text"
+                            >
+                              {t('homepage.governance.openGovernance', 'Open Governance')}
+                            </button>
+                          </div>
+                        ) : null}
                         {governanceSummary.dependencyDetails.length > 0 ? (
                           <div className="mt-3 space-y-2" aria-label={t('homepage.governance.dependencyMap', 'Governance dependency map')}>
                             <div className="text-[10px] uppercase tracking-[0.12em] text-text-muted">
@@ -1347,6 +1368,17 @@ export function PulsePage({ onOpenThread, brandName }: { onOpenThread: () => voi
                         { label: t('homepage.channels.deliveryDrafts', 'Delivery drafts'), value: formatInteger.format(draftChannelDeliveries.length), tone: draftChannelDeliveries.length > 0 ? 'accent' : undefined },
                       ]}
                     />
+                    {onOpenConnections ? (
+                      <div className="mt-3">
+                        <button
+                          type="button"
+                          onClick={onOpenConnections}
+                          className="rounded-full border border-border-subtle px-3 py-1.5 text-[11px] font-semibold text-text-secondary transition-colors hover:bg-surface-hover hover:text-text"
+                        >
+                          {t('homepage.channels.openConnections', 'Open Connections')}
+                        </button>
+                      </div>
+                    ) : null}
                     <div className="mt-4 space-y-3">
                       <Row
                         label={t('homepage.channels.localWebhook', 'Local webhook')}

--- a/apps/desktop/src/renderer/components/command-palette-items.ts
+++ b/apps/desktop/src/renderer/components/command-palette-items.ts
@@ -10,7 +10,7 @@ import type {
 } from '@open-cowork/shared'
 import { compactDescription } from '../helpers/format.ts'
 
-export type View = 'home' | 'chat' | 'threads' | 'automations' | 'agents' | 'crews' | 'capabilities' | 'operations' | 'pulse'
+export type View = 'home' | 'chat' | 'threads' | 'automations' | 'agents' | 'crews' | 'capabilities' | 'operations' | 'connections' | 'governance' | 'pulse'
 export type PaletteSection = 'Go To' | 'Create' | 'Modes' | 'Commands' | 'Agents'
 const COMMAND_PALETTE_DESCRIPTION_MAX_LENGTH = 96
 
@@ -76,6 +76,7 @@ type BuildPaletteItemsInput = {
   onToggleSearch: () => void
   onRunCommand: (name: string) => Promise<boolean | void> | boolean | void
   operationsEnabled?: boolean
+  connectionsGovernanceEnabled?: boolean
 }
 
 export function buildCommandPaletteItems(input: BuildPaletteItemsInput): PaletteItem[] {
@@ -94,6 +95,7 @@ export function buildCommandPaletteItems(input: BuildPaletteItemsInput): Palette
     onToggleSearch,
     onRunCommand,
     operationsEnabled = false,
+    connectionsGovernanceEnabled = false,
   } = input
 
   const runtimeCommands = commands
@@ -209,6 +211,26 @@ export function buildCommandPaletteItems(input: BuildPaletteItemsInput): Palette
       keywords: 'operations command center queue work blockers approvals deliveries risk',
       run: () => onNavigate('operations'),
     }] : []),
+    ...(connectionsGovernanceEnabled ? [
+      {
+        id: 'nav:connections',
+        title: 'Connections',
+        subtitle: 'Inspect channel routes, webhook health, MCPs, credentials, and inbound delivery state.',
+        section: 'Go To' as const,
+        badge: 'Navigate',
+        keywords: 'connections channels webhooks inbound routes mcps credentials integrations',
+        run: () => onNavigate('connections'),
+      },
+      {
+        id: 'nav:governance',
+        title: 'Governance',
+        subtitle: 'Inspect permission policy, guardrails, incidents, audit export, and risk labels.',
+        section: 'Go To' as const,
+        badge: 'Navigate',
+        keywords: 'governance permissions guardrails incidents audit risk policy destructive actions',
+        run: () => onNavigate('governance'),
+      },
+    ] : []),
     {
       id: 'nav:pulse',
       title: 'Pulse',

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -301,4 +301,31 @@ describe('Sidebar', () => {
     expect(screen.getByText('Acme internal build')).toBeTruthy()
     expect(screen.queryByRole('link', { name: 'Unsafe help' })).toBeNull()
   })
+
+  it('gates Connections and Governance as operational navigation buttons', () => {
+    const onViewChange = vi.fn()
+    const { rerender } = render(
+      <Sidebar
+        currentView="home"
+        onViewChange={onViewChange}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Connections' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Governance' })).toBeNull()
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={onViewChange}
+        connectionsGovernanceEnabled
+      />,
+    )
+
+    screen.getByRole('button', { name: 'Connections' }).click()
+    screen.getByRole('button', { name: 'Governance' }).click()
+
+    expect(onViewChange).toHaveBeenCalledWith('connections')
+    expect(onViewChange).toHaveBeenCalledWith('governance')
+  })
 })

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ interface Props {
   searchRequestNonce?: number
   settingsRequestNonce?: number
   branding?: BrandingSidebarConfig
+  connectionsGovernanceEnabled?: boolean
 }
 
 const SettingsPanel = lazy(() =>
@@ -220,6 +221,7 @@ export function Sidebar({
   searchRequestNonce = 0,
   settingsRequestNonce = 0,
   branding,
+  connectionsGovernanceEnabled = false,
 }: Props) {
   const [showSettings, setShowSettings] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -247,7 +249,14 @@ export function Sidebar({
     >
       {showSettings ? (
         <Suspense fallback={<div className="p-4 text-[12px] text-text-muted">{t('settings.loading', 'Loading settings...')}</div>}>
-          <SettingsPanel onClose={() => setShowSettings(false)} />
+          <SettingsPanel
+            onClose={() => setShowSettings(false)}
+            operationalNavEnabled={connectionsGovernanceEnabled}
+            onOpenOperationalView={(view) => {
+              setShowSettings(false)
+              onViewChange(view)
+            }}
+          />
         </Suspense>
       ) : (
         <>
@@ -342,6 +351,29 @@ export function Sidebar({
               </svg>
               {t('sidebar.capabilities', 'Capabilities')}
             </button>
+            {connectionsGovernanceEnabled ? (
+              <>
+                <button onClick={() => onViewChange('connections')}
+                  aria-current={currentView === 'connections' ? 'page' : undefined}
+                  className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'connections' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
+                  <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M2.2 4.2h2.2a2.1 2.1 0 0 1 4.2 0h2.2" />
+                    <path d="M2.2 8.8h2.2a2.1 2.1 0 0 0 4.2 0h2.2" />
+                    <path d="M6.5 6.3v.4" />
+                  </svg>
+                  {t('sidebar.connectionsNav', 'Connections')}
+                </button>
+                <button onClick={() => onViewChange('governance')}
+                  aria-current={currentView === 'governance' ? 'page' : undefined}
+                  className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'governance' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
+                  <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M6.5 1.8 10.5 3.2v3.3c0 2.2-1.5 4-4 4.7-2.5-.7-4-2.5-4-4.7V3.2l4-1.4Z" />
+                    <path d="m4.7 6.4 1.2 1.2 2.4-2.7" />
+                  </svg>
+                  {t('sidebar.governance', 'Governance')}
+                </button>
+              </>
+            ) : null}
             {operationsEnabled ? (
               <button onClick={() => onViewChange('operations')}
                 aria-current={currentView === 'operations' ? 'page' : undefined}

--- a/apps/desktop/src/renderer/components/operations/ConnectionsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/operations/ConnectionsPage.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ChannelListPayload, LocalWebhookReceiverStatus } from '@open-cowork/shared'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { ConnectionsPage } from './ConnectionsPage'
+
+const channelState: ChannelListPayload = {
+  channels: [{
+    schemaVersion: 1,
+    id: 'channel-ops',
+    provider: 'local_webhook',
+    name: 'Ops Intake',
+    description: 'Operational intake',
+    sourceKey: 'ops',
+    enabled: true,
+    senderAllowlist: ['ops@example.com'],
+    allowedCapabilityIds: ['tool:browser'],
+    route: {
+      schemaVersion: 1,
+      activationMode: 'run_crew',
+      targetSopId: null,
+      targetCrewId: 'crew-field',
+    },
+    workspaceProfileId: 'channel-sandbox',
+    createdAt: '2026-05-13T00:00:00.000Z',
+    updatedAt: '2026-05-13T09:00:00.000Z',
+  }],
+  inboundItems: [{
+    schemaVersion: 1,
+    id: 'item-1',
+    channelId: 'channel-ops',
+    provider: 'local_webhook',
+    source: {
+      schemaVersion: 1,
+      provider: 'local_webhook',
+      sourceKey: 'ops',
+      externalMessageId: null,
+      replyTarget: null,
+    },
+    sender: 'ops@example.com',
+    subject: 'Ship report',
+    body: 'Please ship the report.',
+    route: {
+      schemaVersion: 1,
+      activationMode: 'run_crew',
+      targetSopId: null,
+      targetCrewId: 'crew-field',
+    },
+    status: 'needs_user',
+    auditState: 'user_review_required',
+    allowedCapabilityIds: ['tool:browser'],
+    workspaceProfileId: 'channel-sandbox',
+    queueItemId: null,
+    deliveryRecordId: null,
+    workItemId: null,
+    runKind: 'crew',
+    runId: 'run-1',
+    runStatus: 'needs_user',
+    approvedAt: null,
+    approvedBy: null,
+    reviewNote: null,
+    receivedAt: '2026-05-13T09:00:00.000Z',
+    updatedAt: '2026-05-13T09:00:00.000Z',
+    error: null,
+  }],
+  deliveries: [],
+}
+
+const webhookStatus: LocalWebhookReceiverStatus = {
+  schemaVersion: 1,
+  enabled: true,
+  listening: true,
+  host: '127.0.0.1',
+  port: 3929,
+  url: 'http://127.0.0.1:3929/hooks/:sourceKey',
+  pairedChannels: 1,
+  lastError: null,
+}
+
+describe('ConnectionsPage', () => {
+  it('shows channel route targets and webhook health as an operational view', async () => {
+    installRendererTestCoworkApi({
+      capabilities: {
+        skills: vi.fn(async () => []),
+        tools: vi.fn(async () => []),
+      },
+      channels: {
+        list: vi.fn(async () => channelState),
+        localWebhookStatus: vi.fn(async () => webhookStatus),
+      },
+      model: {
+        info: vi.fn(async () => null),
+      },
+    })
+
+    render(<ConnectionsPage onOpenSettings={vi.fn()} />)
+
+    expect(await screen.findByRole('heading', { name: 'Connections' })).toBeInTheDocument()
+    expect(await screen.findByText('Ops Intake')).toBeInTheDocument()
+    expect(screen.getAllByText(/Run crew/).length).toBeGreaterThan(0)
+    expect(screen.getByText('Crew: crew-field')).toBeInTheDocument()
+    expect(screen.getByText('tool:browser')).toBeInTheDocument()
+    expect(screen.getAllByText('Listening').length).toBeGreaterThan(0)
+    expect(screen.getByText('Ship report')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/operations/ConnectionsPage.tsx
+++ b/apps/desktop/src/renderer/components/operations/ConnectionsPage.tsx
@@ -1,0 +1,202 @@
+import type { ChannelActivationMode, ChannelDefinition, LocalWebhookReceiverStatus } from '@open-cowork/shared'
+import { t } from '../../helpers/i18n'
+import { usePulseDiagnostics } from '../usePulseDiagnostics'
+
+const formatInteger = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+
+function formatRoute(mode: ChannelActivationMode) {
+  switch (mode) {
+    case 'ignore':
+      return t('connections.route.ignore', 'Ignore')
+    case 'draft_reply':
+      return t('connections.route.draftReply', 'Draft reply')
+    case 'ask_user':
+      return t('connections.route.askUser', 'Ask user')
+    case 'run_sop':
+      return t('connections.route.runSop', 'Run workflow')
+    case 'run_crew':
+      return t('connections.route.runCrew', 'Run crew')
+  }
+}
+
+function routeTarget(channel: ChannelDefinition) {
+  if (channel.route.targetCrewId) return `Crew: ${channel.route.targetCrewId}`
+  if (channel.route.targetSopId) return `Workflow: ${channel.route.targetSopId}`
+  return t('connections.route.noTarget', 'No fixed target')
+}
+
+function receiverEndpoint(status: LocalWebhookReceiverStatus | null, sourceKey: string) {
+  if (!status?.url) return null
+  return status.url.replace(':sourceKey', encodeURIComponent(sourceKey))
+}
+
+function formatTime(value: string | null | undefined) {
+  if (!value) return t('common.never', 'Never')
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(date)
+}
+
+function Stat({ label, value, tone = 'default' }: { label: string; value: string; tone?: 'default' | 'accent' | 'warn' }) {
+  const color = tone === 'warn' ? 'var(--color-orange)' : tone === 'accent' ? 'var(--color-accent)' : 'var(--color-text)'
+  return (
+    <div className="rounded-lg border border-border-subtle bg-elevated px-3 py-3">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{label}</div>
+      <div className="mt-2 text-[20px] font-semibold tabular-nums" style={{ color }}>{value}</div>
+    </div>
+  )
+}
+
+function StatusPill({ active, label }: { active: boolean; label: string }) {
+  return (
+    <span
+      className="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em]"
+      style={{
+        color: active ? 'var(--color-green)' : 'var(--color-text-muted)',
+        borderColor: active ? 'color-mix(in srgb, var(--color-green) 35%, transparent)' : 'var(--color-border-subtle)',
+        background: active ? 'color-mix(in srgb, var(--color-green) 9%, transparent)' : 'var(--color-surface)',
+      }}
+    >
+      {label}
+    </span>
+  )
+}
+
+export function ConnectionsPage({ onOpenSettings }: { onOpenSettings?: () => void }) {
+  const {
+    diagnostics,
+    channelState,
+    localWebhookStatus,
+    queueItems,
+    refreshDiagnostics,
+  } = usePulseDiagnostics()
+  const activeChannels = channelState.channels.filter((channel) => channel.enabled)
+  const reviewItems = channelState.inboundItems.filter((item) => item.status === 'needs_user' || item.status === 'queued' || item.status === 'drafted')
+  const failedItems = channelState.inboundItems.filter((item) => item.status === 'denied' || item.status === 'failed')
+  const deliveryDrafts = channelState.deliveries.filter((delivery) => delivery.status === 'draft' || delivery.status === 'approval_required' || delivery.status === 'sending')
+  const channelQueueItems = queueItems.filter((item) => item.authority.isolation.channelBound)
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-base text-text">
+      <header className="border-b border-border-subtle px-4 py-3">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="truncate text-[18px] font-semibold">{t('connections.title', 'Connections')}</h1>
+            <p className="mt-1 max-w-[720px] text-[12px] leading-relaxed text-text-muted">
+              {t('connections.subtitle', 'Operational health for inbound channels, webhooks, MCP-backed tools, credentials, and route targets.')}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button type="button" onClick={() => void refreshDiagnostics()} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">
+              {diagnostics.loading ? t('common.refreshing', 'Refreshing...') : t('common.refresh', 'Refresh')}
+            </button>
+            {onOpenSettings ? (
+              <button type="button" onClick={onOpenSettings} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">
+                {t('connections.openSettings', 'Channel settings')}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <section className="grid grid-cols-6 gap-3 max-[1200px]:grid-cols-3 max-[760px]:grid-cols-2">
+          <Stat label={t('connections.activeChannels', 'Active channels')} value={formatInteger.format(activeChannels.length)} tone={activeChannels.length > 0 ? 'accent' : 'default'} />
+          <Stat label={t('connections.inboundItems', 'Inbound items')} value={formatInteger.format(channelState.inboundItems.length)} />
+          <Stat label={t('connections.needsReview', 'Needs review')} value={formatInteger.format(reviewItems.length)} tone={reviewItems.length > 0 ? 'warn' : 'default'} />
+          <Stat label={t('connections.deliveryDrafts', 'Delivery drafts')} value={formatInteger.format(deliveryDrafts.length)} tone={deliveryDrafts.length > 0 ? 'warn' : 'default'} />
+          <Stat label={t('connections.configuredMcps', 'Configured MCPs')} value={formatInteger.format(diagnostics.customMcps.length)} />
+          <Stat label={t('connections.runtimeTools', 'Runtime tools')} value={formatInteger.format(diagnostics.tools.length)} />
+        </section>
+
+        <section className="mt-4 grid grid-cols-[minmax(0,1fr)_320px] gap-4 max-[980px]:grid-cols-1">
+          <div className="rounded-lg border border-border-subtle bg-elevated">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle px-4 py-3">
+              <div>
+                <h2 className="text-[14px] font-semibold">{t('connections.routes', 'Inbound routes')}</h2>
+                <p className="mt-0.5 text-[11px] text-text-muted">{t('connections.routesHint', 'Configured channels, route modes, targets, allowed capabilities, and isolation profile.')}</p>
+              </div>
+              <StatusPill active={Boolean(localWebhookStatus?.listening)} label={localWebhookStatus?.listening ? t('connections.webhookListening', 'Webhook listening') : t('connections.webhookNotListening', 'Webhook inactive')} />
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {channelState.channels.map((channel) => {
+                const endpoint = receiverEndpoint(localWebhookStatus, channel.sourceKey)
+                return (
+                  <article key={channel.id} className="px-4 py-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <h3 className="truncate text-[13px] font-semibold">{channel.name}</h3>
+                          <StatusPill active={channel.enabled} label={channel.enabled ? t('common.enabled', 'Enabled') : t('common.disabled', 'Disabled')} />
+                        </div>
+                        <p className="mt-1 text-[11px] text-text-muted">{channel.provider} / {channel.sourceKey} / {formatRoute(channel.route.activationMode)}</p>
+                      </div>
+                      <div className="shrink-0 text-right text-[11px] text-text-muted">
+                        {formatTime(channel.updatedAt)}
+                      </div>
+                    </div>
+                    <div className="mt-3 grid grid-cols-4 gap-2 max-[980px]:grid-cols-2">
+                      <div className="rounded-md border border-border-subtle bg-surface px-3 py-2">
+                        <div className="text-[10px] uppercase tracking-[0.1em] text-text-muted">{t('connections.target', 'Target')}</div>
+                        <div className="mt-1 truncate text-[12px] text-text-secondary">{routeTarget(channel)}</div>
+                      </div>
+                      <div className="rounded-md border border-border-subtle bg-surface px-3 py-2">
+                        <div className="text-[10px] uppercase tracking-[0.1em] text-text-muted">{t('connections.capabilities', 'Capabilities')}</div>
+                        <div className="mt-1 truncate text-[12px] text-text-secondary">{channel.allowedCapabilityIds.join(', ') || t('connections.noCapabilityLimit', 'No limit')}</div>
+                      </div>
+                      <div className="rounded-md border border-border-subtle bg-surface px-3 py-2">
+                        <div className="text-[10px] uppercase tracking-[0.1em] text-text-muted">{t('connections.workspace', 'Workspace')}</div>
+                        <div className="mt-1 truncate text-[12px] text-text-secondary">{channel.workspaceProfileId}</div>
+                      </div>
+                      <div className="rounded-md border border-border-subtle bg-surface px-3 py-2">
+                        <div className="text-[10px] uppercase tracking-[0.1em] text-text-muted">{t('connections.senders', 'Senders')}</div>
+                        <div className="mt-1 truncate text-[12px] text-text-secondary">{channel.senderAllowlist.length || t('connections.anySender', 'Any')}</div>
+                      </div>
+                    </div>
+                    {endpoint ? <div className="mt-3 break-all rounded-md border border-border-subtle bg-base px-3 py-2 font-mono text-[10px] text-text-muted">{endpoint}</div> : null}
+                  </article>
+                )
+              })}
+              {channelState.channels.length === 0 ? (
+                <div className="px-4 py-10 text-center text-[12px] text-text-muted">{t('connections.noChannels', 'No inbound channels configured yet.')}</div>
+              ) : null}
+            </div>
+          </div>
+
+          <aside className="flex flex-col gap-4">
+            <section className="rounded-lg border border-border-subtle bg-elevated px-4 py-4">
+              <h2 className="text-[13px] font-semibold">{t('connections.webhookHealth', 'Local webhook')}</h2>
+              <div className="mt-3 space-y-2 text-[12px]">
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('connections.status', 'Status')}</span><span className="text-text-secondary">{localWebhookStatus?.listening ? t('connections.listening', 'Listening') : localWebhookStatus?.enabled ? t('connections.notListening', 'Not listening') : t('connections.disabled', 'Disabled')}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('connections.pairedChannels', 'Paired channels')}</span><span className="text-text-secondary">{formatInteger.format(localWebhookStatus?.pairedChannels || 0)}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('connections.port', 'Port')}</span><span className="text-text-secondary">{localWebhookStatus?.port || '-'}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('connections.channelQueue', 'Channel queue')}</span><span className="text-text-secondary">{formatInteger.format(channelQueueItems.length)}</span></div>
+              </div>
+              {localWebhookStatus?.lastError ? <p className="mt-3 rounded-md border border-red-400/25 bg-red-500/10 px-3 py-2 text-[11px] text-red">{localWebhookStatus.lastError}</p> : null}
+            </section>
+            <section className="rounded-lg border border-border-subtle bg-elevated px-4 py-4">
+              <h2 className="text-[13px] font-semibold">{t('connections.reviewQueue', 'Review queue')}</h2>
+              <div className="mt-3 space-y-2">
+                {reviewItems.slice(0, 4).map((item) => (
+                  <div key={item.id} className="rounded-md border border-border-subtle bg-surface px-3 py-2">
+                    <div className="truncate text-[12px] font-medium">{item.subject || item.sender}</div>
+                    <div className="mt-1 text-[11px] text-text-muted">{item.status.replace(/_/g, ' ')} / {formatRoute(item.route.activationMode)}</div>
+                  </div>
+                ))}
+                {reviewItems.length === 0 ? <div className="rounded-md border border-border-subtle bg-surface px-3 py-3 text-[12px] text-text-muted">{t('connections.noReviewItems', 'No channel items are waiting for review.')}</div> : null}
+              </div>
+            </section>
+            <section className="rounded-lg border border-border-subtle bg-elevated px-4 py-4">
+              <h2 className="text-[13px] font-semibold">{t('connections.incidents', 'Connection incidents')}</h2>
+              <div className="mt-3 text-[12px] text-text-secondary">
+                {failedItems.length === 0
+                  ? t('connections.noIncidents', 'No denied or failed inbound items recorded.')
+                  : t('connections.incidentCount', '{{count}} denied or failed item(s) need inspection.', { count: formatInteger.format(failedItems.length) })}
+              </div>
+            </section>
+          </aside>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/operations/GovernancePage.test.tsx
+++ b/apps/desktop/src/renderer/components/operations/GovernancePage.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  CapabilityRiskMetadata,
+  GovernanceAuditEvent,
+  GovernanceRegistryPayload,
+} from '@open-cowork/shared'
+import { installRendererTestCoworkApi } from '../../test/setup'
+import { GovernancePage } from './GovernancePage'
+
+const registry: GovernanceRegistryPayload = {
+  schemaVersion: 1,
+  generatedAt: '2026-05-13T09:00:00.000Z',
+  organization: {
+    schemaVersion: 1,
+    id: 'local',
+    tenantId: 'local',
+    displayName: 'Local Governance',
+    mode: 'local',
+  },
+  principals: [],
+  groups: [],
+  secretVaults: [],
+  executionNodes: [],
+  subjects: [{
+    schemaVersion: 1,
+    subjectKind: 'crew',
+    subjectId: 'crew:field',
+    name: 'field',
+    displayName: 'Field Crew',
+    description: 'Runs field operations.',
+    owner: { kind: 'user', id: 'local-user', displayName: 'Local user' },
+    approvers: [],
+    lifecycle: 'active',
+    scope: { kind: 'machine', id: 'machine', label: 'Machine' },
+    memoryBoundary: { kind: 'none', id: null, label: 'No memory' },
+    evalSuiteId: null,
+    offboardingPath: 'Retire crew.',
+    credentialBindings: [],
+    dependencies: [],
+    incidentControls: [{
+      kind: 'retire_crew',
+      label: 'Retire crew',
+      available: true,
+      requiresConfirmation: true,
+    }],
+  }],
+  dependencyIndex: [{
+    dependency: {
+      kind: 'tool',
+      id: 'browser',
+      label: 'Browser',
+      source: 'direct',
+      required: true,
+    },
+    subjectIds: ['crew:field'],
+  }],
+}
+
+const auditEvents: GovernanceAuditEvent[] = [{
+  schemaVersion: 1,
+  id: 'audit-1',
+  kind: 'incident_control',
+  subjectKind: 'crew',
+  subjectId: 'crew:field',
+  action: 'retire_crew',
+  outcome: 'succeeded',
+  actor: { kind: 'user', id: 'local-user', displayName: 'Local user' },
+  reason: 'Routine cleanup.',
+  beforeLifecycle: 'active',
+  afterLifecycle: 'retired',
+  metadata: {},
+  createdAt: '2026-05-13T09:00:00.000Z',
+}]
+
+const risks: CapabilityRiskMetadata[] = [{
+  schemaVersion: 1,
+  capabilityId: 'tool:browser',
+  toolPattern: 'mcp__browser__*',
+  risk: 'high',
+  writeCapable: true,
+  approvalRequired: true,
+  reason: 'Browser can reach external systems.',
+}]
+
+describe('GovernancePage', () => {
+  it('shows permission policy, guardrails, dependency map, and recent audit incidents', async () => {
+    installRendererTestCoworkApi({
+      capabilities: {
+        skills: vi.fn(async () => []),
+        tools: vi.fn(async () => []),
+      },
+      model: {
+        info: vi.fn(async () => null),
+      },
+      operations: {
+        governanceRegistry: vi.fn(async () => registry),
+        governanceAuditEvents: vi.fn(async () => auditEvents),
+        capabilityRisks: vi.fn(async () => risks),
+      },
+      settings: {
+        get: vi.fn(async () => ({
+          selectedProviderId: null,
+          selectedModelId: null,
+          providerCredentials: {},
+          integrationCredentials: {},
+          integrationEnabled: {},
+          bashPermission: 'ask',
+          fileWritePermission: 'deny',
+          enableBash: true,
+          enableFileWrite: false,
+          runtimeToolingBridgeEnabled: false,
+          automationLaunchAtLogin: false,
+          automationRunInBackground: false,
+          automationDesktopNotifications: true,
+          automationQuietHoursStart: null,
+          automationQuietHoursEnd: null,
+          defaultAutomationAutonomyPolicy: 'review-first',
+          defaultAutomationExecutionMode: 'scoped_execution',
+          operationalMaxAutonomy: 'approve',
+          operationalWriteMaxParallel: 2,
+          operationalMaxRunDurationMinutes: 90,
+          operationalMaxCostUsd: 12,
+          operationalMaxRetries: 4,
+          improvementProposalsEnabled: true,
+          improvementProposalsDisabledAgents: {},
+          improvementProposalsDisabledProjects: {},
+          improvementProposalsDisabledCrews: {},
+          dreamConsolidationScheduleEnabled: false,
+          dreamConsolidationIntervalHours: 168,
+          effectiveProviderId: null,
+          effectiveModel: null,
+        })),
+      },
+    })
+
+    render(<GovernancePage onOpenSettings={vi.fn()} />)
+
+    expect(await screen.findByRole('heading', { name: 'Governance' })).toBeInTheDocument()
+    expect(await screen.findByText('Local Governance')).toBeInTheDocument()
+    expect(screen.getByText('Browser')).toBeInTheDocument()
+    expect(screen.getByText(/Ask \/ max Allow/)).toBeInTheDocument()
+    expect(screen.getByText(/Deny \/ max Allow/)).toBeInTheDocument()
+    expect(screen.getByText(/retire crew/)).toBeInTheDocument()
+    expect(screen.getByText('Routine cleanup.')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/operations/GovernancePage.tsx
+++ b/apps/desktop/src/renderer/components/operations/GovernancePage.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  EffectiveAppSettings,
+  GovernanceAuditEvent,
+  GovernanceRegistryPayload,
+  PublicAppConfig,
+  RuntimePermissionPolicy,
+} from '@open-cowork/shared'
+import { writeTextToClipboard } from '../../helpers/clipboard'
+import { t } from '../../helpers/i18n'
+import { useSessionStore } from '../../stores/session'
+import { usePulseDiagnostics } from '../usePulseDiagnostics'
+
+const formatInteger = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+const formatCurrency = new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
+
+function permissionLabel(value: RuntimePermissionPolicy | undefined) {
+  if (value === 'allow') return t('governance.permission.allow', 'Allow')
+  if (value === 'ask') return t('governance.permission.ask', 'Ask')
+  return t('governance.permission.deny', 'Deny')
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return t('common.never', 'Never')
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(date)
+}
+
+function summarizeRegistry(registry: GovernanceRegistryPayload | null) {
+  const subjects = registry?.subjects || []
+  const controls = subjects.flatMap((subject) => subject.incidentControls)
+  return {
+    org: registry?.organization.displayName || t('governance.localOrg', 'Local organization'),
+    agents: subjects.filter((subject) => subject.subjectKind === 'agent').length,
+    crews: subjects.filter((subject) => subject.subjectKind === 'crew').length,
+    tools: subjects.filter((subject) => subject.subjectKind === 'tool').length,
+    memories: subjects.filter((subject) => subject.subjectKind === 'memory').length,
+    dependencies: registry?.dependencyIndex.length || 0,
+    controls: controls.length,
+    availableControls: controls.filter((control) => control.available).length,
+    vaults: registry?.secretVaults.length || 0,
+    activeVaults: registry?.secretVaults.filter((vault) => vault.status === 'active').length || 0,
+    nodes: registry?.executionNodes.length || 0,
+    activeNodes: registry?.executionNodes.filter((node) => node.status === 'active').length || 0,
+  }
+}
+
+function Stat({ label, value, tone = 'default' }: { label: string; value: string; tone?: 'default' | 'accent' | 'warn' }) {
+  const color = tone === 'warn' ? 'var(--color-orange)' : tone === 'accent' ? 'var(--color-accent)' : 'var(--color-text)'
+  return (
+    <div className="rounded-lg border border-border-subtle bg-elevated px-3 py-3">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{label}</div>
+      <div className="mt-2 text-[20px] font-semibold tabular-nums" style={{ color }}>{value}</div>
+    </div>
+  )
+}
+
+function AuditRow({ event }: { event: GovernanceAuditEvent }) {
+  return (
+    <div className="rounded-md border border-border-subtle bg-surface px-3 py-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-[12px] font-medium text-text">{event.subjectKind}: {event.subjectId}</div>
+          <div className="mt-1 text-[11px] text-text-muted">{event.action.replace(/_/g, ' ')} / {formatDate(event.createdAt)}</div>
+        </div>
+        <span className={`shrink-0 text-[10px] font-semibold uppercase tracking-[0.1em] ${event.outcome === 'failed' ? 'text-red' : 'text-accent'}`}>{event.outcome}</span>
+      </div>
+      {event.reason ? <div className="mt-2 line-clamp-2 text-[11px] text-text-secondary">{event.reason}</div> : null}
+    </div>
+  )
+}
+
+export function GovernancePage({ onOpenSettings }: { onOpenSettings?: () => void }) {
+  const {
+    diagnostics,
+    capabilityRisks,
+    governanceRegistry,
+    governanceAuditEvents,
+    improvementSummary,
+    refreshDiagnostics,
+  } = usePulseDiagnostics()
+  const [settings, setSettings] = useState<EffectiveAppSettings | null>(null)
+  const [config, setConfig] = useState<PublicAppConfig | null>(null)
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'working' | 'copied' | 'empty' | 'failed'>('idle')
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([
+      window.coworkApi.settings.get(),
+      window.coworkApi.app.config(),
+    ]).then(([nextSettings, nextConfig]) => {
+      if (cancelled) return
+      setSettings(nextSettings)
+      setConfig(nextConfig)
+    }).catch((error) => {
+      if (cancelled) return
+      addGlobalError(t('governance.settingsLoadFailed', 'Could not load governance settings. Please try again.'))
+      try {
+        window.coworkApi?.diagnostics?.reportRendererError?.({
+          message: `Governance settings load failed: ${error instanceof Error ? error.message : String(error)}`,
+          stack: error instanceof Error ? error.stack : undefined,
+          view: 'governance',
+        })
+      } catch {
+        // Diagnostics are best-effort from this recovery path.
+      }
+    })
+    return () => { cancelled = true }
+  }, [addGlobalError])
+
+  const registrySummary = useMemo(() => summarizeRegistry(governanceRegistry), [governanceRegistry])
+  const riskSummary = useMemo(() => ({
+    high: capabilityRisks.filter((risk) => risk.risk === 'high').length,
+    write: capabilityRisks.filter((risk) => risk.writeCapable).length,
+    approval: capabilityRisks.filter((risk) => risk.approvalRequired).length,
+  }), [capabilityRisks])
+
+  async function copyAuditExport() {
+    setCopyStatus('working')
+    try {
+      const payload = await window.coworkApi.operations.exportGovernanceAudit({ format: 'ndjson' })
+      if (!payload.body.trim()) {
+        setCopyStatus('empty')
+        return
+      }
+      const copied = await writeTextToClipboard(payload.body)
+      setCopyStatus(copied ? 'copied' : 'failed')
+    } catch (error) {
+      setCopyStatus('failed')
+      addGlobalError(t('governance.auditExportFailed', 'Could not export the governance audit. Please try again.'))
+      try {
+        window.coworkApi?.diagnostics?.reportRendererError?.({
+          message: `Governance audit export failed: ${error instanceof Error ? error.message : String(error)}`,
+          stack: error instanceof Error ? error.stack : undefined,
+          view: 'governance',
+        })
+      } catch {
+        // Diagnostics are best-effort from this recovery path.
+      }
+    }
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-base text-text">
+      <header className="border-b border-border-subtle px-4 py-3">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="truncate text-[18px] font-semibold">{t('governance.title', 'Governance')}</h1>
+            <p className="mt-1 max-w-[760px] text-[12px] leading-relaxed text-text-muted">
+              {t('governance.subtitle', 'Operational policy, destructive-action controls, audit incidents, capability risk, and guardrail health.')}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button type="button" onClick={() => void refreshDiagnostics()} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">
+              {diagnostics.loading ? t('common.refreshing', 'Refreshing...') : t('common.refresh', 'Refresh')}
+            </button>
+            {onOpenSettings ? (
+              <button type="button" onClick={onOpenSettings} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">
+                {t('governance.openSettings', 'Policy settings')}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <section className="grid grid-cols-6 gap-3 max-[1200px]:grid-cols-3 max-[760px]:grid-cols-2">
+          <Stat label={t('governance.agents', 'Agents')} value={formatInteger.format(registrySummary.agents)} />
+          <Stat label={t('governance.crews', 'Crews')} value={formatInteger.format(registrySummary.crews)} />
+          <Stat label={t('governance.dependencies', 'Dependencies')} value={formatInteger.format(registrySummary.dependencies)} />
+          <Stat label={t('governance.controls', 'Controls')} value={`${formatInteger.format(registrySummary.availableControls)}/${formatInteger.format(registrySummary.controls)}`} tone={registrySummary.availableControls > 0 ? 'accent' : 'default'} />
+          <Stat label={t('governance.highRisk', 'High risk')} value={formatInteger.format(riskSummary.high)} tone={riskSummary.high > 0 ? 'warn' : 'default'} />
+          <Stat label={t('governance.writeCaps', 'Write caps')} value={formatInteger.format(riskSummary.write)} tone={riskSummary.write > 0 ? 'warn' : 'default'} />
+        </section>
+
+        <section className="mt-4 grid grid-cols-[minmax(0,1fr)_360px] gap-4 max-[1040px]:grid-cols-1">
+          <div className="rounded-lg border border-border-subtle bg-elevated">
+            <div className="border-b border-border-subtle px-4 py-3">
+              <h2 className="text-[14px] font-semibold">{registrySummary.org}</h2>
+              <p className="mt-0.5 text-[11px] text-text-muted">
+                {t('governance.registryHint', 'Current governed subjects, dependencies, vaults, execution nodes, and incident controls.')}
+              </p>
+            </div>
+            <div className="grid grid-cols-4 gap-3 px-4 py-4 max-[980px]:grid-cols-2">
+              {[
+                { label: t('governance.tools', 'Tools'), value: registrySummary.tools },
+                { label: t('governance.memories', 'Memories'), value: registrySummary.memories },
+                { label: t('governance.vaults', 'Vaults'), value: `${registrySummary.activeVaults}/${registrySummary.vaults}` },
+                { label: t('governance.nodes', 'Nodes'), value: `${registrySummary.activeNodes}/${registrySummary.nodes}` },
+              ].map((item) => (
+                <div key={item.label} className="rounded-md border border-border-subtle bg-surface px-3 py-3">
+                  <div className="text-[10px] uppercase tracking-[0.1em] text-text-muted">{item.label}</div>
+                  <div className="mt-1 text-[14px] font-semibold text-text">{item.value}</div>
+                </div>
+              ))}
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {(governanceRegistry?.dependencyIndex || []).slice(0, 8).map((entry) => (
+                <div key={`${entry.dependency.kind}:${entry.dependency.id}`} className="px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{entry.dependency.kind.replace(/_/g, ' ')}</div>
+                      <div className="mt-1 truncate text-[13px] font-medium text-text">{entry.dependency.label}</div>
+                    </div>
+                    <div className="shrink-0 text-[11px] text-text-muted">{formatInteger.format(entry.subjectIds.length)} subject(s)</div>
+                  </div>
+                </div>
+              ))}
+              {(governanceRegistry?.dependencyIndex.length || 0) === 0 ? (
+                <div className="px-4 py-10 text-center text-[12px] text-text-muted">{t('governance.noDependencies', 'No governed dependency map is available yet.')}</div>
+              ) : null}
+            </div>
+          </div>
+
+          <aside className="flex flex-col gap-4">
+            <section className="rounded-lg border border-border-subtle bg-elevated px-4 py-4">
+              <h2 className="text-[13px] font-semibold">{t('governance.permissionPolicy', 'Permission policy')}</h2>
+              <div className="mt-3 space-y-2 text-[12px]">
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.shellCommands', 'Shell commands')}</span><span className="text-text-secondary">{permissionLabel(settings?.bashPermission)} / max {permissionLabel(config?.permissions.bash)}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.fileEditing', 'File editing')}</span><span className="text-text-secondary">{permissionLabel(settings?.fileWritePermission)} / max {permissionLabel(config?.permissions.fileWrite)}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.toolingBridge', 'Developer config bridge')}</span><span className="text-text-secondary">{settings?.runtimeToolingBridgeEnabled ? t('common.enabled', 'Enabled') : t('common.disabled', 'Disabled')}</span></div>
+              </div>
+            </section>
+            <section className="rounded-lg border border-border-subtle bg-elevated px-4 py-4">
+              <h2 className="text-[13px] font-semibold">{t('governance.guardrails', 'Automation guardrails')}</h2>
+              <div className="mt-3 space-y-2 text-[12px]">
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.maxAutonomy', 'Max autonomy')}</span><span className="text-text-secondary">{settings?.operationalMaxAutonomy || '-'}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.writeParallelism', 'Write parallelism')}</span><span className="text-text-secondary">{settings ? formatInteger.format(settings.operationalWriteMaxParallel) : '-'}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.maxRunDuration', 'Max run duration')}</span><span className="text-text-secondary">{settings ? `${settings.operationalMaxRunDurationMinutes}m` : '-'}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.queueBudget', 'Queue budget')}</span><span className="text-text-secondary">{settings?.operationalMaxCostUsd == null ? t('governance.noBudgetCap', 'No cap') : formatCurrency.format(settings.operationalMaxCostUsd)}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.governedLearning', 'Governed learning')}</span><span className="text-text-secondary">{settings?.improvementProposalsEnabled ? t('common.enabled', 'Enabled') : t('common.disabled', 'Disabled')}</span></div>
+                <div className="flex justify-between gap-3"><span className="text-text-muted">{t('governance.pendingProposals', 'Pending proposals')}</span><span className="text-text-secondary">{formatInteger.format(improvementSummary?.proposals.proposed || 0)}</span></div>
+              </div>
+            </section>
+            <section className="rounded-lg border border-border-subtle bg-elevated px-4 py-4">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-[13px] font-semibold">{t('governance.recentIncidents', 'Recent incidents')}</h2>
+                <button type="button" onClick={() => void copyAuditExport()} disabled={copyStatus === 'working'} className="rounded-md border border-border-subtle px-2.5 py-1.5 text-[11px] text-text-secondary hover:bg-surface-hover disabled:cursor-wait disabled:opacity-60">
+                  {copyStatus === 'working' ? t('common.copying', 'Copying...') : t('governance.copyAudit', 'Copy audit')}
+                </button>
+              </div>
+              {copyStatus !== 'idle' && copyStatus !== 'working' ? (
+                <div className="mt-2 text-[11px] text-text-muted">
+                  {copyStatus === 'copied' ? t('governance.copied', 'Copied') : copyStatus === 'empty' ? t('governance.emptyAudit', 'No records') : t('governance.copyFailed', 'Copy failed')}
+                </div>
+              ) : null}
+              <div className="mt-3 space-y-2">
+                {governanceAuditEvents.slice(0, 5).map((event) => <AuditRow key={event.id} event={event} />)}
+                {governanceAuditEvents.length === 0 ? <div className="rounded-md border border-border-subtle bg-surface px-3 py-3 text-[12px] text-text-muted">{t('governance.noIncidents', 'No governance audit incidents recorded yet.')}</div> : null}
+              </div>
+            </section>
+          </aside>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/operations/OperationsPage.tsx
+++ b/apps/desktop/src/renderer/components/operations/OperationsPage.tsx
@@ -51,6 +51,8 @@ export type OperationsPageProps = {
   onOpenThread: (sessionId: string) => void
   onOpenRoute: (route: WorkLedgerDrilldownRoute) => void
   onOpenDiagnostics: () => void
+  onOpenConnections?: () => void
+  onOpenGovernance?: () => void
 }
 
 function statusLabel(value: string) {
@@ -196,7 +198,13 @@ function WorkRow({
   )
 }
 
-export function OperationsPage({ onOpenThread, onOpenRoute, onOpenDiagnostics }: OperationsPageProps) {
+export function OperationsPage({
+  onOpenThread,
+  onOpenRoute,
+  onOpenDiagnostics,
+  onOpenConnections,
+  onOpenGovernance,
+}: OperationsPageProps) {
   const preference = useMemo(() => readOperationsPreference(), [])
   const [summary, setSummary] = useState<OperationsSummary>(EMPTY_OPERATIONS_SUMMARY)
   const [savedFilter, setSavedFilter] = useState<OperationsSavedFilterId>(preference.savedFilter || 'attention')
@@ -308,6 +316,8 @@ export function OperationsPage({ onOpenThread, onOpenRoute, onOpenDiagnostics }:
             <div className="mt-0.5 text-[11px] text-text-muted">{loading ? 'Loading...' : `Updated ${formatDate(summary.generatedAt)}`}</div>
           </div>
           <div className="flex items-center gap-2">
+            {onOpenConnections ? <button type="button" onClick={onOpenConnections} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">Connections</button> : null}
+            {onOpenGovernance ? <button type="button" onClick={onOpenGovernance} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">Governance</button> : null}
             <button type="button" onClick={() => void loadSummary()} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">Refresh</button>
             <button type="button" onClick={onOpenDiagnostics} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover hover:text-text">Diagnostics</button>
           </div>

--- a/apps/desktop/src/renderer/components/operations/connections-governance-ui.test.ts
+++ b/apps/desktop/src/renderer/components/operations/connections-governance-ui.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONNECTIONS_GOVERNANCE_NAV_FEATURE_GATE_KEY,
+  isConnectionsGovernanceNavEnabled,
+} from './connections-governance-ui'
+
+describe('connections-governance-ui', () => {
+  it('keeps Connections and Governance navigation behind a default-off feature gate', () => {
+    window.localStorage.removeItem(CONNECTIONS_GOVERNANCE_NAV_FEATURE_GATE_KEY)
+    expect(isConnectionsGovernanceNavEnabled()).toBe(false)
+
+    window.localStorage.setItem(CONNECTIONS_GOVERNANCE_NAV_FEATURE_GATE_KEY, 'true')
+    expect(isConnectionsGovernanceNavEnabled()).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/components/operations/connections-governance-ui.ts
+++ b/apps/desktop/src/renderer/components/operations/connections-governance-ui.ts
@@ -1,0 +1,11 @@
+export const CONNECTIONS_GOVERNANCE_NAV_FEATURE_GATE_KEY = 'open-cowork.feature.connectionsGovernanceNav'
+
+type StorageLike = Pick<Storage, 'getItem'> | null | undefined
+
+export function isConnectionsGovernanceNavEnabled(storage: StorageLike = typeof window !== 'undefined' ? window.localStorage : null) {
+  try {
+    return storage?.getItem(CONNECTIONS_GOVERNANCE_NAV_FEATURE_GATE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -115,6 +115,34 @@ beforeEach(() => {
 })
 
 describe('SettingsPanel', () => {
+  it('shows gated links into operational Connections and Governance views', async () => {
+    const onOpenOperationalView = vi.fn()
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(async () => ({})),
+      },
+    })
+
+    render(
+      <SettingsPanel
+        onClose={vi.fn()}
+        operationalNavEnabled
+        onOpenOperationalView={onOpenOperationalView}
+      />,
+    )
+
+    await screen.findByText('Operational views')
+    fireEvent.click(screen.getByRole('button', { name: 'Open Connections' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open Governance' }))
+
+    expect(onOpenOperationalView).toHaveBeenCalledWith('connections')
+    expect(onOpenOperationalView).toHaveBeenCalledWith('governance')
+  })
+
   it('surfaces initial settings load failures through the chat error channel and diagnostics', async () => {
     const reportRendererError = vi.fn()
     installRendererTestCoworkApi({

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -21,8 +21,10 @@ import { LanguagePicker } from './SettingsLanguagePicker'
 import { ModelsPanel } from './SettingsModelsPanel'
 import { PermissionsPanel } from './SettingsPermissionsPanel'
 import { StoragePanel } from './SettingsStoragePanel'
+import type { AppView } from '../../app-types'
 
 type SettingsTab = 'appearance' | 'models' | 'permissions' | 'automations' | 'channels' | 'storage'
+type OperationalSettingsView = Extract<AppView, 'connections' | 'governance'>
 
 function describeSettingsPanelError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
@@ -48,7 +50,15 @@ function stripMaskedSettingsCredentials(settings: EffectiveAppSettings): Effecti
   }
 }
 
-export function SettingsPanel({ onClose }: { onClose: () => void }) {
+export function SettingsPanel({
+  onClose,
+  operationalNavEnabled = false,
+  onOpenOperationalView,
+}: {
+  onClose: () => void
+  operationalNavEnabled?: boolean
+  onOpenOperationalView?: (view: OperationalSettingsView) => void
+}) {
   const [settings, setSettings] = useState<EffectiveAppSettings | null>(null)
   const [config, setConfig] = useState<PublicAppConfig | null>(null)
   const [saved, setSaved] = useState(false)
@@ -289,6 +299,34 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
 
         <div className="flex-1 min-w-0 flex flex-col">
           <div className="flex-1 overflow-y-auto px-5 py-5">
+            {operationalNavEnabled && onOpenOperationalView ? (
+              <div className="mb-5 rounded-lg border border-border-subtle bg-surface px-4 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-[12px] font-semibold text-text">{t('settings.operationsLinks.title', 'Operational views')}</div>
+                    <div className="mt-1 max-w-[520px] text-[11px] leading-relaxed text-text-muted">
+                      {t('settings.operationsLinks.description', 'Daily channel routing and governance risk now have dedicated operational views. Settings keeps the lower-frequency controls.')}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onOpenOperationalView('connections')}
+                      className="rounded-md border border-border-subtle px-3 py-2 text-[11px] font-semibold text-text-secondary hover:bg-surface-hover hover:text-text"
+                    >
+                      {t('settings.operationsLinks.connections', 'Open Connections')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onOpenOperationalView('governance')}
+                      className="rounded-md border border-border-subtle px-3 py-2 text-[11px] font-semibold text-text-secondary hover:bg-surface-hover hover:text-text"
+                    >
+                      {t('settings.operationsLinks.governance', 'Open Governance')}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : null}
             {tab === 'appearance' && (
               <div className="flex flex-col gap-5">
                 <AppearancePreview appearance={appearance} onUpdate={updateAppearance} />

--- a/apps/desktop/tests/navigation-wiring.smoke.test.ts
+++ b/apps/desktop/tests/navigation-wiring.smoke.test.ts
@@ -196,6 +196,27 @@ test('gated Operations button opens the command center route', async () => {
   }
 })
 
+test('gated Connections and Governance buttons open operational routes', async () => {
+  const { page, cleanup } = await launchSmokeApp()
+
+  try {
+    await waitForAppShell(page, 30_000)
+    await page.evaluate(() => {
+      window.localStorage.setItem('open-cowork.feature.connectionsGovernanceNav', 'true')
+    })
+    await page.reload()
+    await waitForAppShell(page, 30_000)
+
+    await page.getByRole('button', { name: 'Connections', exact: true }).click()
+    await page.locator('main').getByRole('heading', { name: 'Connections' }).waitFor({ timeout: 10_000 })
+
+    await page.getByRole('button', { name: 'Governance', exact: true }).click()
+    await page.locator('main').getByRole('heading', { name: 'Governance' }).waitFor({ timeout: 10_000 })
+  } finally {
+    await cleanup()
+  }
+})
+
 test('search shortcut reveals the sidebar search when the sidebar is collapsed', async () => {
   const { page, cleanup } = await launchSmokeApp()
 


### PR DESCRIPTION
## Summary
- Adds feature-gated top-level Connections and Governance routes for daily operational monitoring.
- Keeps Settings as the configuration owner while linking operators to the new read-only operational views.
- Wires sidebar, command palette, Pulse, Operations, and navigation smoke coverage behind `open-cowork.feature.connectionsGovernanceNav`.

## Implementation Notes
- Connections surfaces inbound route targets, allowed capabilities, webhook health, MCP/tool counts, review queue, and connection incidents from existing Pulse diagnostics.
- Governance surfaces governed registry counts, dependency map, permission policy, automation guardrails, capability risk, recent audit events, and NDJSON audit export.
- Route access is default-off and redirects back to Pulse when the feature gate is disabled.

## Feature Gate
- `open-cowork.feature.connectionsGovernanceNav=true` enables the sidebar, command palette, and routes.
- Disabled state preserves the current Settings-first experience.

## Test Gates
- `pnpm --filter @open-cowork/desktop test:renderer -- ConnectionsPage GovernancePage Sidebar CommandPalette SettingsPanel OperationsPage connections-governance-ui`
- `pnpm --filter @open-cowork/desktop test:renderer -- ConnectionsPage GovernancePage connections-governance-ui`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @open-cowork/desktop build`
- `node ../../scripts/run-desktop-smoke-tests.mjs --pattern "tests/navigation-wiring.smoke.test.ts" --timeout=120000 --retries=1` from `apps/desktop`
- `git diff --check`

Closes #345