### PR TITLE
Scale Mission Control for large delegated runs

### DIFF
--- a/apps/desktop/src/renderer/components/chat/ChatView.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatView.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { useSessionStore, type TaskRun } from '../../stores/session'
+import { useSessionStore, type PendingApproval, type TaskRun } from '../../stores/session'
 import { loadSessionMessages } from '../../helpers/loadSessionMessages'
 import { t } from '../../helpers/i18n'
 import { MessageBubble } from './MessageBubble'
@@ -15,6 +15,10 @@ import { SessionInspector } from './SessionInspector'
 import { SessionQuestionDock } from './SessionQuestionDock'
 import { buildChatTimeline, type TimelineItem } from './chat-view-timeline'
 import { useChatAgentVisuals } from './useChatAgentVisuals'
+import {
+  isMissionControlScaleEnabled,
+  missionControlScaleStorageKey,
+} from './mission-control-scale-model'
 
 // Virtualize when the transcript gets long enough that inline
 // rendering starts to bite. Below the threshold we keep the simple
@@ -46,8 +50,10 @@ export function ChatView() {
   const isGenerating = currentView.isGenerating
   const scrollRef = useRef<HTMLDivElement>(null)
   const [focusedTaskRunId, setFocusedTaskRunId] = useState<string | null>(null)
+  const [focusedTaskContextIds, setFocusedTaskContextIds] = useState<string[]>([])
   const [expandedTaskGroups, setExpandedTaskGroups] = useState<Record<string, boolean>>({})
   const [inspectorOpen, setInspectorOpen] = useState(true)
+  const missionControlScaleEnabled = useMemo(() => isMissionControlScaleEnabled(), [])
   const visibleApprovals = pendingApprovals
   const transcriptMaxWidth = inspectorOpen ? THREAD_MAX_WIDTH_WITH_INSPECTOR : THREAD_MAX_WIDTH
   const currentSession = useMemo(
@@ -156,6 +162,7 @@ export function ChatView() {
 
   useEffect(() => {
     setFocusedTaskRunId(null)
+    setFocusedTaskContextIds([])
     setExpandedTaskGroups({})
   }, [currentSessionId])
 
@@ -163,14 +170,20 @@ export function ChatView() {
     setInspectorOpen(true)
   }, [currentSessionId])
 
-  const onFocusTask = (taskRun: TaskRun) => {
+  const onFocusTask = (taskRun: TaskRun, visibleTaskRuns?: TaskRun[]) => {
     setFocusedTaskRunId(taskRun.id)
+    setFocusedTaskContextIds((visibleTaskRuns && visibleTaskRuns.length > 0 ? visibleTaskRuns : taskRuns).map((task) => task.id))
   }
   const onCloseFocusedTask = () => setFocusedTaskRunId(null)
   const focusedTaskRun = useMemo(
     () => (focusedTaskRunId ? taskRuns.find((task) => task.id === focusedTaskRunId) || null : null),
     [taskRuns, focusedTaskRunId],
   )
+  const focusedTaskNavigationRuns = useMemo(() => {
+    if (focusedTaskContextIds.length === 0) return taskRuns
+    const byId = new Map(taskRuns.map((task) => [task.id, task]))
+    return focusedTaskContextIds.map((id) => byId.get(id)).filter(Boolean) as TaskRun[]
+  }, [focusedTaskContextIds, taskRuns])
 
   // Stable key across siblings being added mid-dispatch. The old
   // "ids.join(':')" flipped every time a new task joined the fan-out, so
@@ -178,6 +191,45 @@ export function ChatView() {
   // moment a sub-agent spawned. Keying on the first task's id keeps the
   // user's intent stable.
   const taskGroupKey = (groupedTaskRuns: TaskRun[]) => groupedTaskRuns[0]?.id || ''
+
+  const scrollTaskRunIntoView = (taskRun: TaskRun) => {
+    setFocusedTaskRunId(null)
+    const timelineIndex = timeline.findIndex((item) => {
+      if (item.kind === 'task') return item.data.id === taskRun.id
+      if (item.kind === 'task_group') return item.data.some((task) => task.id === taskRun.id)
+      return false
+    })
+
+    requestAnimationFrame(() => {
+      if (virtualize && timelineIndex >= 0) {
+        virtualizerRef.current.scrollToIndex(timelineIndex, { align: 'center' })
+        return
+      }
+      const selector = `[data-task-run-id="${escapeAttributeSelector(taskRun.id)}"], [data-mission-control-task-ids~="${escapeAttributeSelector(taskRun.id)}"]`
+      const target = scrollRef.current?.querySelector<HTMLElement>(selector)
+      target?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    })
+  }
+
+  const scrollApprovalIntoView = (approval: PendingApproval) => {
+    setFocusedTaskRunId(null)
+    const timelineIndex = timeline.findIndex((item) => item.kind === 'approval' && item.data.id === approval.id)
+    requestAnimationFrame(() => {
+      if (virtualize && timelineIndex >= 0) {
+        virtualizerRef.current.scrollToIndex(timelineIndex, { align: 'center' })
+        return
+      }
+      const target = scrollRef.current?.querySelector<HTMLElement>(`[data-approval-id="${escapeAttributeSelector(approval.id)}"]`)
+      target?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    })
+  }
+
+  const openQuestionDock = () => {
+    setFocusedTaskRunId(null)
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
+    })
+  }
 
   const isTaskGroupExpanded = (groupedTaskRuns: TaskRun[]) => {
     const key = taskGroupKey(groupedTaskRuns)
@@ -208,6 +260,10 @@ export function ChatView() {
             onToggle={() => toggleTaskGroupExpanded([item.data])}
             focusedTaskId={focusedTaskRunId}
             onFocusTask={onFocusTask}
+            pendingApprovals={pendingApprovals}
+            pendingQuestions={pendingQuestions}
+            scaleEnabled={missionControlScaleEnabled}
+            scaleStorageKey={missionControlScaleStorageKey(currentSessionId, taskGroupKey([item.data]))}
           />
         )
       case 'task_group':
@@ -220,12 +276,20 @@ export function ChatView() {
             onToggle={() => toggleTaskGroupExpanded(item.data)}
             focusedTaskId={focusedTaskRunId}
             onFocusTask={onFocusTask}
+            pendingApprovals={pendingApprovals}
+            pendingQuestions={pendingQuestions}
+            scaleEnabled={missionControlScaleEnabled}
+            scaleStorageKey={missionControlScaleStorageKey(currentSessionId, taskGroupKey(item.data))}
           />
         )
       case 'compaction':
         return <CompactionNoticeCard key={item.data.id} notice={item.data} />
       case 'approval':
-        return <ApprovalCard key={item.data.id} approval={item.data} />
+        return (
+          <div key={item.data.id} data-approval-id={item.data.id}>
+            <ApprovalCard approval={item.data} />
+          </div>
+        )
       case 'error':
         return (
           <div key={item.data.id} className="flex items-start gap-2.5 px-4 py-2.5 rounded-lg border text-[12px]" style={{ borderColor: 'color-mix(in srgb, var(--color-red) 30%, var(--color-border))', background: 'color-mix(in srgb, var(--color-red) 5%, transparent)' }}>
@@ -393,9 +457,21 @@ export function ChatView() {
           allTaskRuns={taskRuns}
           agentVisuals={agentVisuals}
           rootSessionId={currentSessionId}
+          navigationTaskRuns={focusedTaskNavigationRuns}
+          pendingApprovals={pendingApprovals}
+          pendingQuestions={pendingQuestions}
+          onNavigateTask={onFocusTask}
+          onOpenTaskInTranscript={scrollTaskRunIntoView}
+          onOpenApproval={scrollApprovalIntoView}
+          onOpenQuestion={openQuestionDock}
           onClose={onCloseFocusedTask}
         />
       )}
     </div>
   )
+}
+
+function escapeAttributeSelector(value: string) {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(value)
+  return value.replace(/["\\]/g, '\\$&')
 }

--- a/apps/desktop/src/renderer/components/chat/MissionControl.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MissionControl.test.tsx
@@ -226,4 +226,64 @@ describe('MissionControl', () => {
     expect(screen.getByText('Agents errored')).toBeInTheDocument()
     expect(screen.getByText('1 running')).toBeInTheDocument()
   })
+
+  it('filters large task groups by review activity and persists the scale controls', async () => {
+    const user = userEvent.setup()
+    const storageKey = 'mission-control-test:scale'
+    window.localStorage.removeItem(storageKey)
+    const root = task({
+      id: 'root',
+      agent: 'research-agent',
+      sourceSessionId: 'root-session',
+      status: 'running',
+      order: 1,
+    })
+    const waitingChild = task({
+      id: 'waiting-child',
+      agent: 'explore',
+      sourceSessionId: 'waiting-session',
+      parentSessionId: 'root-session',
+      status: 'running',
+      order: 2,
+    })
+    const writer = task({
+      id: 'writer',
+      agent: 'writer',
+      sourceSessionId: 'writer-session',
+      status: 'running',
+      order: 3,
+    })
+
+    render(
+      <MissionControl
+        taskRuns={[root, waitingChild, writer]}
+        agentVisuals={agentVisuals}
+        expanded
+        onToggle={vi.fn()}
+        focusedTaskId={null}
+        onFocusTask={vi.fn()}
+        pendingApprovals={[{
+          id: 'approval-1',
+          sessionId: 'waiting-session',
+          taskRunId: 'waiting-child',
+          tool: 'bash',
+          input: {},
+          description: 'Run command',
+          order: 5,
+        }]}
+        scaleEnabled
+        scaleStorageKey={storageKey}
+      />,
+    )
+
+    expect(screen.getByText('Waiting 1')).toBeInTheDocument()
+    expect(screen.getByText('Showing')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Writer — running' })).toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText('Activity'), 'approvals')
+
+    expect(screen.getByText('2/3')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Writer — running' })).not.toBeInTheDocument()
+    expect(window.localStorage.getItem(storageKey)).toContain('"activityFilter":"approvals"')
+  })
 })

--- a/apps/desktop/src/renderer/components/chat/MissionControl.tsx
+++ b/apps/desktop/src/renderer/components/chat/MissionControl.tsx
@@ -1,5 +1,6 @@
-import { memo, useMemo } from 'react'
-import type { TaskRun } from '../../stores/session'
+import { memo, useEffect, useMemo, useState } from 'react'
+import type { PendingQuestion } from '@open-cowork/shared'
+import type { PendingApproval, TaskRun } from '../../stores/session'
 import type { AgentVisual } from './agent-visuals'
 import { ElapsedClock } from './ElapsedClock'
 import { MissionControlLane } from './MissionControlLane'
@@ -15,6 +16,19 @@ import {
   selectAggregateTiming,
   summarizeStatus,
 } from './mission-control-utils'
+import {
+  DEFAULT_MISSION_CONTROL_SCALE_STATE,
+  type MissionControlActivityFilter,
+  type MissionControlScaleState,
+  type MissionControlStatusFilter,
+  buildMissionControlSummary,
+  buildTaskRunMetrics,
+  buildTaskReviewIndex,
+  readMissionControlScaleState,
+  reviewActivityForTask,
+  selectMissionControlVisibleTasks,
+  writeMissionControlScaleState,
+} from './mission-control-scale-model'
 
 // Swim-lane block that renders a group of delegated tasks as a compact
 // timeline. Each task is one lane. Nested sub-agent delegations render
@@ -29,8 +43,34 @@ interface Props {
   expanded: boolean
   onToggle: () => void
   focusedTaskId: string | null
-  onFocusTask: (task: TaskRun) => void
+  onFocusTask: (task: TaskRun, visibleTasks?: TaskRun[]) => void
+  pendingApprovals?: PendingApproval[]
+  pendingQuestions?: PendingQuestion[]
+  scaleEnabled?: boolean
+  scaleStorageKey?: string
 }
+
+const statusOptions: Array<{ id: MissionControlStatusFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'running', label: 'Running' },
+  { id: 'waiting', label: 'Waiting' },
+  { id: 'blocked', label: 'Blocked' },
+  { id: 'errored', label: 'Errored' },
+  { id: 'complete', label: 'Complete' },
+  { id: 'cancelled', label: 'Cancelled' },
+]
+
+const statusOutlineOptions = statusOptions.filter((option): option is { id: Exclude<MissionControlStatusFilter, 'all'>; label: string } => option.id !== 'all')
+
+const activityOptions: Array<{ id: MissionControlActivityFilter; label: string }> = [
+  { id: 'all', label: 'All activity' },
+  { id: 'needs_review', label: 'Needs review' },
+  { id: 'approvals', label: 'Approvals' },
+  { id: 'questions', label: 'Questions' },
+  { id: 'tools', label: 'Tool activity' },
+  { id: 'artifacts', label: 'Artifacts' },
+  { id: 'errors', label: 'Errors' },
+]
 
 export const MissionControl = memo(function MissionControl({
   taskRuns,
@@ -39,12 +79,41 @@ export const MissionControl = memo(function MissionControl({
   onToggle,
   focusedTaskId,
   onFocusTask,
+  pendingApprovals = [],
+  pendingQuestions = [],
+  scaleEnabled = false,
+  scaleStorageKey,
 }: Props) {
-  const tree = useMemo(() => buildOrchestrationTree(taskRuns), [taskRuns])
+  const storageKey = scaleStorageKey || `inline:${taskRuns.map((task) => task.id).join(',')}`
+  const [scaleState, setScaleState] = useState<MissionControlScaleState>(() => DEFAULT_MISSION_CONTROL_SCALE_STATE)
+
+  useEffect(() => {
+    if (!scaleEnabled) return
+    setScaleState(readMissionControlScaleState(typeof window !== 'undefined' ? window.localStorage : null, storageKey))
+  }, [scaleEnabled, storageKey])
+
+  useEffect(() => {
+    if (!scaleEnabled) return
+    writeMissionControlScaleState(typeof window !== 'undefined' ? window.localStorage : null, storageKey, scaleState)
+  }, [scaleEnabled, storageKey, scaleState])
+
+  const reviewIndex = useMemo(
+    () => buildTaskReviewIndex(taskRuns, pendingApprovals, pendingQuestions),
+    [taskRuns, pendingApprovals, pendingQuestions],
+  )
+  const visibleTaskRuns = useMemo(
+    () => scaleEnabled ? selectMissionControlVisibleTasks(taskRuns, scaleState, reviewIndex) : taskRuns,
+    [scaleEnabled, taskRuns, scaleState, reviewIndex],
+  )
+  const tree = useMemo(() => buildOrchestrationTree(visibleTaskRuns), [visibleTaskRuns])
   const aggregate = useMemo(() => selectAggregateTiming(taskRuns), [taskRuns])
   const anyRunning = taskRuns.some((task) => task.status === 'running')
   const liveNow = useLiveNow(anyRunning)
-  const maxElapsed = useMemo(() => groupMaxElapsed(taskRuns, liveNow), [taskRuns, liveNow])
+  const maxElapsed = useMemo(() => groupMaxElapsed(visibleTaskRuns, liveNow), [visibleTaskRuns, liveNow])
+  const scaleSummary = useMemo(
+    () => buildMissionControlSummary(taskRuns, visibleTaskRuns, reviewIndex, liveNow),
+    [taskRuns, visibleTaskRuns, reviewIndex, liveNow],
+  )
   const uniqueAgents = useMemo(() => {
     const set = new Set<string>()
     for (const task of taskRuns) {
@@ -54,6 +123,14 @@ export const MissionControl = memo(function MissionControl({
   }, [taskRuns])
   const tokenTotal = useMemo(() => groupTokenTotal(taskRuns), [taskRuns])
   const costTotal = useMemo(() => groupCostTotal(taskRuns), [taskRuns])
+  const activeFilters = scaleState.statusFilter !== 'all' || scaleState.agentFilter !== 'all' || scaleState.activityFilter !== 'all'
+  const focusTask = (taskRun: TaskRun) => {
+    if (scaleEnabled) {
+      onFocusTask(taskRun, visibleTaskRuns)
+      return
+    }
+    onFocusTask(taskRun)
+  }
 
   const allComplete = taskRuns.every((task) => task.status === 'complete')
   const anyErrored = taskRuns.some((task) => task.status === 'error')
@@ -102,6 +179,7 @@ export const MissionControl = memo(function MissionControl({
     <section
       className="rounded-xl border bg-surface overflow-hidden"
       style={{ borderColor: 'var(--color-border-subtle)' }}
+      data-mission-control-task-ids={taskRuns.map((task) => task.id).join(' ')}
     >
       <button
         type="button"
@@ -160,6 +238,12 @@ export const MissionControl = memo(function MissionControl({
               </span>
             </>
           )}
+          {scaleEnabled && activeFilters && (
+            <>
+              <span className="text-text-muted">·</span>
+              <span className="text-text-muted">{scaleSummary.filtered}/{scaleSummary.total} shown</span>
+            </>
+          )}
         </span>
         <Chevron expanded={expanded} />
       </button>
@@ -169,6 +253,19 @@ export const MissionControl = memo(function MissionControl({
         className="flex flex-col gap-0.5 px-2 pb-2 pt-1 border-t"
         style={{ borderColor: 'var(--color-border-subtle)' }}
       >
+        {scaleEnabled && (
+          <MissionControlScaleControls
+            state={scaleState}
+            summary={scaleSummary}
+            onChange={setScaleState}
+            onReset={() => setScaleState(DEFAULT_MISSION_CONTROL_SCALE_STATE)}
+          />
+        )}
+        {scaleEnabled && visibleTaskRuns.length === 0 ? (
+          <div className="rounded-lg border border-border-subtle bg-elevated px-3 py-4 text-center text-[12px] text-text-muted">
+            No delegated tasks match the current Mission Control filters.
+          </div>
+        ) : null}
         {tree.map((lane) => (
           <div key={lane.taskRun.id} className="flex flex-col">
             <MissionControlLane
@@ -177,7 +274,8 @@ export const MissionControl = memo(function MissionControl({
               groupMaxElapsedMs={maxElapsed}
               now={liveNow}
               expanded={focusedTaskId === lane.taskRun.id}
-              onToggle={() => onFocusTask(lane.taskRun)}
+              metrics={scaleEnabled ? scaleSummaryForTask(lane.taskRun, reviewIndex, liveNow) : undefined}
+              onToggle={() => focusTask(lane.taskRun)}
             />
             {lane.children.map((nested) => (
               <MissionControlLane
@@ -189,7 +287,8 @@ export const MissionControl = memo(function MissionControl({
                 indentLevel={1}
                 expanded={focusedTaskId === nested.taskRun.id}
                 deeperCount={nested.deeperCount}
-                onToggle={() => onFocusTask(nested.taskRun)}
+                metrics={scaleEnabled ? scaleSummaryForTask(nested.taskRun, reviewIndex, liveNow) : undefined}
+                onToggle={() => focusTask(nested.taskRun)}
               />
             ))}
           </div>
@@ -199,6 +298,132 @@ export const MissionControl = memo(function MissionControl({
     </section>
   )
 })
+
+function scaleSummaryForTask(taskRun: TaskRun, reviewIndex: ReturnType<typeof buildTaskReviewIndex>, now: number) {
+  const activity = reviewActivityForTask(reviewIndex, taskRun.id)
+  return buildTaskRunMetrics(taskRun, activity, now)
+}
+
+function MissionControlScaleControls({
+  state,
+  summary,
+  onChange,
+  onReset,
+}: {
+  state: MissionControlScaleState
+  summary: ReturnType<typeof buildMissionControlSummary>
+  onChange: (next: MissionControlScaleState | ((current: MissionControlScaleState) => MissionControlScaleState)) => void
+  onReset: () => void
+}) {
+  const hasFilters = state.statusFilter !== 'all' || state.agentFilter !== 'all' || state.activityFilter !== 'all'
+  const update = (patch: Partial<MissionControlScaleState>) => {
+    onChange((current) => ({ ...current, ...patch }))
+  }
+
+  return (
+    <div className="mb-2 rounded-lg border border-border-subtle bg-elevated px-3 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-1.5">
+          {statusOutlineOptions.map((option) => {
+            const active = state.statusFilter === option.id
+            const count = summary.statuses[option.id]
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => update({ statusFilter: active ? 'all' : option.id })}
+                className="rounded-md border px-2 py-1 text-[10px] font-medium transition-colors hover:bg-surface-hover"
+                style={{
+                  color: active ? 'var(--color-accent)' : 'var(--color-text-muted)',
+                  borderColor: active ? 'color-mix(in srgb, var(--color-accent) 45%, transparent)' : 'var(--color-border-subtle)',
+                  background: active ? 'color-mix(in srgb, var(--color-accent) 10%, transparent)' : 'transparent',
+                }}
+              >
+                {option.label} {count}
+              </button>
+            )
+          })}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.08em] text-text-muted">
+            Status
+            <select
+              value={state.statusFilter}
+              onChange={(event) => update({ statusFilter: event.target.value as MissionControlStatusFilter })}
+              className="rounded-md border border-border-subtle bg-surface px-2 py-1 text-[11px] normal-case tracking-normal text-text-secondary"
+            >
+              {statusOptions.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
+            </select>
+          </label>
+          <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.08em] text-text-muted">
+            Agent
+            <select
+              value={state.agentFilter}
+              onChange={(event) => update({ agentFilter: event.target.value })}
+              className="max-w-[160px] rounded-md border border-border-subtle bg-surface px-2 py-1 text-[11px] normal-case tracking-normal text-text-secondary"
+            >
+              <option value="all">All agents</option>
+              {summary.agents.map((agent) => (
+                <option key={agent.id || 'unassigned'} value={agent.id}>{agent.label} ({agent.count})</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.08em] text-text-muted">
+            Activity
+            <select
+              value={state.activityFilter}
+              onChange={(event) => update({ activityFilter: event.target.value as MissionControlActivityFilter })}
+              className="rounded-md border border-border-subtle bg-surface px-2 py-1 text-[11px] normal-case tracking-normal text-text-secondary"
+            >
+              {activityOptions.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
+            </select>
+          </label>
+          {hasFilters ? (
+            <button type="button" onClick={onReset} className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:bg-surface-hover hover:text-text">
+              Reset
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-3 grid grid-cols-6 gap-2 max-[860px]:grid-cols-3 max-[560px]:grid-cols-2">
+        <ScaleMetric label="Showing" value={`${summary.filtered}/${summary.total}`} />
+        <ScaleMetric label="Duration" value={formatDuration(summary.metrics.durationMs)} />
+        <ScaleMetric label="Tools" value={String(summary.metrics.toolCount)} />
+        <ScaleMetric label="Approvals" value={String(summary.metrics.approvalCount)} />
+        <ScaleMetric label="Artifacts" value={String(summary.metrics.artifactCount)} />
+        <ScaleMetric label="Last event" value={formatLastEvent(summary.metrics.lastEventAt)} />
+      </div>
+    </div>
+  )
+}
+
+function ScaleMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border-subtle bg-surface px-2 py-2">
+      <div className="text-[9px] uppercase tracking-[0.08em] text-text-muted">{label}</div>
+      <div className="mt-1 truncate text-[12px] font-medium text-text-secondary">{value}</div>
+    </div>
+  )
+}
+
+function formatDuration(durationMs: number) {
+  if (durationMs <= 0) return '-'
+  const seconds = Math.round(durationMs / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60) return remainingSeconds ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+}
+
+function formatLastEvent(value: string | null) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(date)
+}
 
 function Chevron({ expanded }: { expanded: boolean }) {
   return (

--- a/apps/desktop/src/renderer/components/chat/MissionControlLane.tsx
+++ b/apps/desktop/src/renderer/components/chat/MissionControlLane.tsx
@@ -12,6 +12,7 @@ import {
   formatTokensCompact,
   sumTokens,
 } from './mission-control-utils'
+import type { TaskRunMetrics } from './mission-control-scale-model'
 import { latestTranscriptLine } from './task-timeline-utils'
 
 // A single horizontal swim lane showing one delegated sub-agent task.
@@ -31,6 +32,7 @@ interface Props {
   // users aren't surprised when the drill-in drawer reveals more nesting.
   // 0 / undefined means nothing is hidden; the chip doesn't render.
   deeperCount?: number
+  metrics?: TaskRunMetrics
   onToggle?: () => void
 }
 
@@ -58,6 +60,7 @@ export const MissionControlLane = memo(function MissionControlLane({
   indentLevel = 0,
   expanded,
   deeperCount = 0,
+  metrics,
   onToggle,
 }: Props) {
   const tone = agentTone(agentVisual?.color ?? null)
@@ -84,6 +87,7 @@ export const MissionControlLane = memo(function MissionControlLane({
       style={{
         paddingLeft: indentLevel > 0 ? 10 : undefined,
       }}
+      data-task-run-id={taskRun.id}
       aria-expanded={expanded}
       aria-label={`${formatAgentName(taskRun.agent)} — ${statusLabel(taskRun.status)}`}
     >
@@ -138,6 +142,21 @@ export const MissionControlLane = memo(function MissionControlLane({
         {taskRun.sessionCost > 0 && (
           <span className="text-[10px] text-text-muted font-mono tabular-nums">
             {formatCost(taskRun.sessionCost)}
+          </span>
+        )}
+        {metrics && metrics.toolCount > 0 && (
+          <span className="text-[10px] text-text-muted tabular-nums">
+            {metrics.toolCount} tools
+          </span>
+        )}
+        {metrics && (metrics.approvalCount > 0 || metrics.questionCount > 0) && (
+          <span className="text-[10px] text-amber tabular-nums">
+            {metrics.approvalCount + metrics.questionCount} review
+          </span>
+        )}
+        {metrics && metrics.artifactCount > 0 && (
+          <span className="text-[10px] text-text-muted tabular-nums">
+            {metrics.artifactCount} artifacts
           </span>
         )}
       </div>

--- a/apps/desktop/src/renderer/components/chat/TaskDrillIn.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/TaskDrillIn.test.tsx
@@ -253,6 +253,86 @@ describe('TaskDrillIn', () => {
     expect(screen.getByRole('dialog', { name: 'Code Reviewer drill-in' })).toBeInTheDocument()
   })
 
+  it('supports filtered task navigation and opens review and artifact affordances', async () => {
+    const user = userEvent.setup()
+    const api = installTaskApi()
+    const onNavigateTask = vi.fn()
+    const onOpenTaskInTranscript = vi.fn()
+    const onOpenApproval = vi.fn()
+    const onOpenQuestion = vi.fn()
+    const rootTask = createTask({
+      toolCalls: [
+        {
+          id: 'tool-write',
+          name: 'write',
+          input: { filePath: '/tmp/report.md' },
+          status: 'complete',
+          output: 'ok',
+          order: 2,
+        },
+      ],
+    })
+    const nextTask = createTask({
+      id: 'task-next',
+      title: 'Write summary',
+      agent: 'writer',
+      sourceSessionId: 'writer-session',
+      parentSessionId: null,
+      transcript: [{ id: 'segment-next', content: 'Writing summary', order: 1 }],
+      toolCalls: [],
+    })
+    const pendingApproval = {
+      id: 'approval-1',
+      sessionId: rootTask.sourceSessionId!,
+      taskRunId: rootTask.id,
+      tool: 'bash',
+      input: {},
+      description: 'Run command',
+      order: 4,
+    }
+    const pendingQuestion = {
+      id: 'question-1',
+      sessionId: rootTask.sourceSessionId!,
+      sourceSessionId: rootTask.sourceSessionId,
+      questions: [{ header: 'Scope', question: 'Continue?', options: [] }],
+    }
+
+    render(
+      <TaskDrillIn
+        rootTask={rootTask}
+        allTaskRuns={[rootTask, nextTask]}
+        agentVisuals={{ writer: { color: 'green', avatar: null } }}
+        rootSessionId="root-session"
+        navigationTaskRuns={[rootTask, nextTask]}
+        pendingApprovals={[pendingApproval]}
+        pendingQuestions={[pendingQuestion]}
+        onNavigateTask={onNavigateTask}
+        onOpenTaskInTranscript={onOpenTaskInTranscript}
+        onOpenApproval={onOpenApproval}
+        onOpenQuestion={onOpenQuestion}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Open approval/ }))
+    expect(onOpenApproval).toHaveBeenCalledWith(pendingApproval)
+
+    await user.click(screen.getByRole('button', { name: /Open question/ }))
+    expect(onOpenQuestion).toHaveBeenCalledWith(pendingQuestion)
+
+    await user.click(screen.getByRole('button', { name: /Open artifact/ }))
+    await waitFor(() => {
+      expect(api.artifact.reveal).toHaveBeenCalledWith({ sessionId: 'root-session', filePath: '/tmp/report.md' })
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Next task in current filter' }))
+    expect(onNavigateTask).toHaveBeenCalledWith(nextTask)
+    expect(screen.getByRole('dialog', { name: 'Writer drill-in' })).toBeInTheDocument()
+
+    await user.click(screen.getByText('Source'))
+    expect(onOpenTaskInTranscript).toHaveBeenCalledWith(nextTask)
+  })
+
   it('closes on Escape and shows empty transcript copy for completed tasks without output', async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()

--- a/apps/desktop/src/renderer/components/chat/TaskDrillIn.tsx
+++ b/apps/desktop/src/renderer/components/chat/TaskDrillIn.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
-import { useSessionStore, type TaskRun } from '../../stores/session'
+import type { PendingQuestion } from '@open-cowork/shared'
+import { useSessionStore, type PendingApproval, type TaskRun } from '../../stores/session'
 import { t } from '../../helpers/i18n'
 import { AgentAvatar } from '../agents/AgentAvatar'
 import { agentTone } from '../agents/agent-builder-utils'
@@ -21,6 +22,7 @@ import {
 import { buildTaskTimeline } from './task-timeline-utils'
 import { useLiveNow } from './useLiveNow'
 import { useTaskDrillInLayout } from './useTaskDrillInLayout'
+import { listArtifactsForTools } from './session-artifacts'
 
 // Slide-over drawer shown when a user clicks a Mission Control lane.
 // Superset of the previous TaskRunCard: same transcript / tools / todos /
@@ -34,6 +36,13 @@ interface Props {
   allTaskRuns: TaskRun[]
   agentVisuals: Record<string, AgentVisual>
   rootSessionId: string | null
+  navigationTaskRuns?: TaskRun[]
+  pendingApprovals?: PendingApproval[]
+  pendingQuestions?: PendingQuestion[]
+  onNavigateTask?: (task: TaskRun) => void
+  onOpenTaskInTranscript?: (task: TaskRun) => void
+  onOpenApproval?: (approval: PendingApproval) => void
+  onOpenQuestion?: (question: PendingQuestion) => void
   onClose: () => void
 }
 
@@ -79,9 +88,17 @@ export const TaskDrillIn = memo(function TaskDrillIn({
   allTaskRuns,
   agentVisuals,
   rootSessionId,
+  navigationTaskRuns = [],
+  pendingApprovals = [],
+  pendingQuestions = [],
+  onNavigateTask,
+  onOpenTaskInTranscript,
+  onOpenApproval,
+  onOpenQuestion,
   onClose,
 }: Props) {
   const [abortInFlight, setAbortInFlight] = useState(false)
+  const [artifactRevealInFlight, setArtifactRevealInFlight] = useState(false)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
   // Focus history stack. Entry 0 is the root; pushing a nested task navigates
   // deeper, popping (via back) returns to the parent.
@@ -149,6 +166,57 @@ export const TaskDrillIn = memo(function TaskDrillIn({
   const nestedLiveNow = useLiveNow(nestedAnyRunning)
   const nestedMaxElapsed = useMemo(() => groupMaxElapsed(nestedChildren, nestedLiveNow), [nestedChildren, nestedLiveNow])
   const nestedTree = useMemo(() => buildOrchestrationTree(nestedChildren), [nestedChildren])
+  const navigationIndex = useMemo(
+    () => navigationTaskRuns.findIndex((task) => task.id === focused.id),
+    [navigationTaskRuns, focused.id],
+  )
+  const previousTask = navigationIndex > 0 ? navigationTaskRuns[navigationIndex - 1] : null
+  const nextTask = navigationIndex >= 0 && navigationIndex < navigationTaskRuns.length - 1
+    ? navigationTaskRuns[navigationIndex + 1]
+    : null
+  const focusedApprovals = useMemo(
+    () => pendingApprovals.filter((approval) => approval.taskRunId === focused.id || approval.sessionId === focused.sourceSessionId),
+    [pendingApprovals, focused.id, focused.sourceSessionId],
+  )
+  const focusedQuestions = useMemo(
+    () => pendingQuestions.filter((question) => (question.sourceSessionId || question.sessionId) === focused.sourceSessionId),
+    [pendingQuestions, focused.sourceSessionId],
+  )
+  const artifacts = useMemo(
+    () => listArtifactsForTools(focused.toolCalls, focused),
+    [focused],
+  )
+
+  const navigateTo = useCallback((task: TaskRun | null) => {
+    if (!task) return
+    setFocusStack([task.id])
+    onNavigateTask?.(task)
+  }, [onNavigateTask])
+
+  const revealFirstArtifact = useCallback(async () => {
+    const artifact = artifacts[0]
+    if (!rootSessionId || !artifact) return
+    setArtifactRevealInFlight(true)
+    try {
+      await window.coworkApi.artifact.reveal({
+        sessionId: rootSessionId,
+        filePath: artifact.filePath,
+      })
+    } catch (error) {
+      addGlobalError(t('taskDrillIn.revealArtifactFailed', 'Could not reveal this artifact. Please try again.'))
+      try {
+        window.coworkApi?.diagnostics?.reportRendererError?.({
+          message: `Failed to reveal task artifact ${artifact.filePath}: ${error instanceof Error ? error.message : String(error)}`,
+          stack: error instanceof Error ? error.stack : undefined,
+          view: 'task-drill-in',
+        })
+      } catch {
+        // Diagnostics are best-effort from this recovery path.
+      }
+    } finally {
+      setArtifactRevealInFlight(false)
+    }
+  }, [addGlobalError, artifacts, rootSessionId])
 
   return (
     <>
@@ -255,6 +323,35 @@ export const TaskDrillIn = memo(function TaskDrillIn({
             )}
           </div>
           <div className="shrink-0 flex items-center gap-1">
+            {onOpenTaskInTranscript && (
+              <button
+                type="button"
+                onClick={() => onOpenTaskInTranscript(focused)}
+                className="inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.08em] font-semibold px-2 py-1 rounded border border-border-subtle text-text-muted hover:bg-surface-hover hover:text-text"
+              >
+                Source
+              </button>
+            )}
+            {previousTask && (
+              <button
+                type="button"
+                onClick={() => navigateTo(previousTask)}
+                aria-label={t('taskDrillIn.previousTask', 'Previous task in current filter')}
+                className="inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.08em] font-semibold px-2 py-1 rounded border border-border-subtle text-text-muted hover:bg-surface-hover hover:text-text"
+              >
+                Prev
+              </button>
+            )}
+            {nextTask && (
+              <button
+                type="button"
+                onClick={() => navigateTo(nextTask)}
+                aria-label={t('taskDrillIn.nextTask', 'Next task in current filter')}
+                className="inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.08em] font-semibold px-2 py-1 rounded border border-border-subtle text-text-muted hover:bg-surface-hover hover:text-text"
+              >
+                Next
+              </button>
+            )}
             {canAbort && (
               <button
                 type="button"
@@ -287,7 +384,48 @@ export const TaskDrillIn = memo(function TaskDrillIn({
         </header>
 
         <div className="flex-1 overflow-y-auto">
-          <Scorecard taskRun={focused} tokens={tokens} />
+          <Scorecard
+            taskRun={focused}
+            tokens={tokens}
+            toolCount={focused.toolCalls.length}
+            reviewCount={focusedApprovals.length + focusedQuestions.length}
+            artifactCount={artifacts.length}
+          />
+
+          {(focusedApprovals.length > 0 || focusedQuestions.length > 0 || artifacts.length > 0) && (
+            <section className="px-5 pb-4">
+              <div className="flex flex-wrap items-center gap-2">
+                {focusedApprovals[0] && onOpenApproval ? (
+                  <button
+                    type="button"
+                    onClick={() => onOpenApproval(focusedApprovals[0])}
+                    className="rounded-lg border border-border-subtle bg-elevated px-3 py-2 text-[11px] text-text-secondary hover:bg-surface-hover hover:text-text"
+                  >
+                    Open approval ({focusedApprovals.length})
+                  </button>
+                ) : null}
+                {focusedQuestions[0] && onOpenQuestion ? (
+                  <button
+                    type="button"
+                    onClick={() => onOpenQuestion(focusedQuestions[0])}
+                    className="rounded-lg border border-border-subtle bg-elevated px-3 py-2 text-[11px] text-text-secondary hover:bg-surface-hover hover:text-text"
+                  >
+                    Open question ({focusedQuestions.length})
+                  </button>
+                ) : null}
+                {artifacts[0] && rootSessionId ? (
+                  <button
+                    type="button"
+                    onClick={() => void revealFirstArtifact()}
+                    disabled={artifactRevealInFlight}
+                    className="rounded-lg border border-border-subtle bg-elevated px-3 py-2 text-[11px] text-text-secondary hover:bg-surface-hover hover:text-text disabled:cursor-wait disabled:opacity-60"
+                  >
+                    {artifactRevealInFlight ? 'Revealing...' : `Open artifact (${artifacts.length})`}
+                  </button>
+                ) : null}
+              </div>
+            </section>
+          )}
 
           {nestedTree.length > 0 && (
             <section className="px-5 py-4 border-t" style={{ borderColor: 'var(--color-border-subtle)' }}>
@@ -376,10 +514,26 @@ export const TaskDrillIn = memo(function TaskDrillIn({
   )
 })
 
-function Scorecard({ taskRun, tokens }: { taskRun: TaskRun; tokens: number }) {
+function Scorecard({
+  taskRun,
+  tokens,
+  toolCount,
+  reviewCount,
+  artifactCount,
+}: {
+  taskRun: TaskRun
+  tokens: number
+  toolCount: number
+  reviewCount: number
+  artifactCount: number
+}) {
   const cells: Array<{ label: string; value: string; tone?: string }> = [
+    { label: 'Duration', value: formatTaskDuration(taskRun) },
     { label: 'Tokens', value: formatTokensCompact(tokens) || '—' },
     { label: 'Cost', value: formatCost(taskRun.sessionCost) || '$0.00' },
+    { label: 'Tools', value: String(toolCount) },
+    { label: 'Reviews', value: String(reviewCount), tone: reviewCount > 0 ? 'var(--color-amber)' : undefined },
+    { label: 'Artifacts', value: String(artifactCount) },
     { label: 'Input', value: formatTokensCompact(taskRun.sessionTokens.input) || '—' },
     { label: 'Output', value: formatTokensCompact(taskRun.sessionTokens.output) || '—' },
     { label: 'Reasoning', value: formatTokensCompact(taskRun.sessionTokens.reasoning) || '—' },
@@ -412,4 +566,20 @@ function Scorecard({ taskRun, tokens }: { taskRun: TaskRun; tokens: number }) {
       </div>
     </section>
   )
+}
+
+function formatTaskDuration(taskRun: TaskRun) {
+  if (!taskRun.startedAt) return '—'
+  const startedAt = new Date(taskRun.startedAt).getTime()
+  if (!Number.isFinite(startedAt)) return '—'
+  const finishedAt = taskRun.finishedAt ? new Date(taskRun.finishedAt).getTime() : Date.now()
+  if (!Number.isFinite(finishedAt)) return '—'
+  const seconds = Math.max(0, Math.round((finishedAt - startedAt) / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  if (minutes < 60) return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`
 }

--- a/apps/desktop/src/renderer/components/chat/mission-control-scale-model.test.ts
+++ b/apps/desktop/src/renderer/components/chat/mission-control-scale-model.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import type { PendingApproval, PendingQuestion, TaskRun } from '@open-cowork/shared'
+import {
+  DEFAULT_MISSION_CONTROL_SCALE_STATE,
+  MISSION_CONTROL_SCALE_FEATURE_GATE_KEY,
+  buildMissionControlSummary,
+  buildTaskReviewIndex,
+  isMissionControlScaleEnabled,
+  missionControlScaleStorageKey,
+  missionControlStatusForTask,
+  readMissionControlScaleState,
+  reviewActivityForTask,
+  selectMissionControlVisibleTasks,
+  writeMissionControlScaleState,
+} from './mission-control-scale-model'
+
+const emptyTokens = {
+  input: 0,
+  output: 0,
+  reasoning: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+}
+
+function task(overrides: Partial<TaskRun>): TaskRun {
+  return {
+    id: 'task-1',
+    title: 'Work item',
+    agent: 'worker',
+    status: 'running',
+    sourceSessionId: 'child-1',
+    parentSessionId: null,
+    content: '',
+    transcript: [],
+    toolCalls: [],
+    compactions: [],
+    todos: [],
+    error: null,
+    sessionCost: 0,
+    sessionTokens: emptyTokens,
+    order: 1,
+    startedAt: '2026-05-07T00:00:00.000Z',
+    finishedAt: null,
+    ...overrides,
+  }
+}
+
+function approval(overrides: Partial<PendingApproval>): PendingApproval {
+  return {
+    id: 'approval-1',
+    sessionId: 'child-1',
+    taskRunId: null,
+    tool: 'bash',
+    input: {},
+    description: 'Run command',
+    order: 10,
+    ...overrides,
+  }
+}
+
+function question(overrides: Partial<PendingQuestion>): PendingQuestion {
+  return {
+    id: 'question-1',
+    sessionId: 'child-1',
+    sourceSessionId: 'child-1',
+    questions: [{ header: 'Scope', question: 'Continue?', options: [] }],
+    ...overrides,
+  }
+}
+
+describe('mission-control-scale-model', () => {
+  it('keeps scaled Mission Control behind an explicit default-off feature gate', () => {
+    window.localStorage.removeItem(MISSION_CONTROL_SCALE_FEATURE_GATE_KEY)
+    expect(isMissionControlScaleEnabled()).toBe(false)
+
+    window.localStorage.setItem(MISSION_CONTROL_SCALE_FEATURE_GATE_KEY, 'true')
+    expect(isMissionControlScaleEnabled()).toBe(true)
+  })
+
+  it('persists normalized filter state per session group', () => {
+    const key = missionControlScaleStorageKey('session-1', 'group-1')
+    expect(readMissionControlScaleState(window.localStorage, key)).toEqual(DEFAULT_MISSION_CONTROL_SCALE_STATE)
+
+    writeMissionControlScaleState(window.localStorage, key, {
+      statusFilter: 'waiting',
+      agentFilter: 'research',
+      activityFilter: 'approvals',
+    })
+
+    expect(readMissionControlScaleState(window.localStorage, key)).toEqual({
+      statusFilter: 'waiting',
+      agentFilter: 'research',
+      activityFilter: 'approvals',
+    })
+  })
+
+  it('classifies waiting, blocked, errored, complete, and cancelled task states', () => {
+    const waitingTask = task({ id: 'waiting', sourceSessionId: 'waiting-session' })
+    const index = buildTaskReviewIndex([waitingTask], [approval({ taskRunId: 'waiting' })], [])
+    expect(missionControlStatusForTask(waitingTask, reviewActivityForTask(index, 'waiting'))).toBe('waiting')
+
+    expect(missionControlStatusForTask(task({ status: 'queued' }), { approvals: [], questions: [] })).toBe('blocked')
+    expect(missionControlStatusForTask(task({ status: 'error', error: 'Tool failed' }), { approvals: [], questions: [] })).toBe('errored')
+    expect(missionControlStatusForTask(task({ status: 'complete' }), { approvals: [], questions: [] })).toBe('complete')
+    expect(missionControlStatusForTask(task({ status: 'error', error: 'User aborted task' }), { approvals: [], questions: [] })).toBe('cancelled')
+  })
+
+  it('filters by activity while retaining ancestor tasks for nested context', () => {
+    const root = task({ id: 'root', agent: 'lead', sourceSessionId: 'root-session', order: 1 })
+    const child = task({
+      id: 'child',
+      agent: 'research',
+      sourceSessionId: 'child-session',
+      parentSessionId: 'root-session',
+      status: 'running',
+      toolCalls: [{ id: 'tool-1', name: 'read', input: {}, status: 'complete', order: 2 }],
+      order: 2,
+    })
+    const grandchild = task({
+      id: 'grandchild',
+      agent: 'writer',
+      sourceSessionId: 'grandchild-session',
+      parentSessionId: 'child-session',
+      status: 'running',
+      toolCalls: [{ id: 'tool-2', name: 'write', input: { filePath: '/tmp/report.md' }, status: 'complete', order: 3 }],
+      order: 3,
+    })
+    const index = buildTaskReviewIndex([root, child, grandchild], [], [question({ sourceSessionId: 'grandchild-session' })])
+
+    expect(selectMissionControlVisibleTasks([root, child, grandchild], {
+      statusFilter: 'all',
+      agentFilter: 'all',
+      activityFilter: 'artifacts',
+    }, index).map((entry) => entry.id)).toEqual(['root', 'child', 'grandchild'])
+
+    expect(selectMissionControlVisibleTasks([root, child, grandchild], {
+      statusFilter: 'waiting',
+      agentFilter: 'all',
+      activityFilter: 'questions',
+    }, index).map((entry) => entry.id)).toEqual(['root', 'child', 'grandchild'])
+  })
+
+  it('summarizes status counts, review activity, artifacts, tools, and token cost', () => {
+    const running = task({
+      id: 'running',
+      agent: 'research',
+      toolCalls: [{ id: 'tool-1', name: 'write', input: { filePath: '/tmp/report.md' }, status: 'complete', order: 11 }],
+      sessionTokens: { input: 100, output: 50, reasoning: 0, cacheRead: 25, cacheWrite: 0 },
+      sessionCost: 0.03,
+      finishedAt: '2026-05-07T00:02:00.000Z',
+    })
+    const complete = task({ id: 'complete', agent: 'write', status: 'complete', sourceSessionId: 'child-2', order: 2 })
+    const index = buildTaskReviewIndex([running, complete], [approval({ taskRunId: 'running' })], [])
+
+    const summary = buildMissionControlSummary([running, complete], [running], index, new Date('2026-05-07T00:03:00.000Z').getTime())
+
+    expect(summary.statuses.waiting).toBe(1)
+    expect(summary.statuses.complete).toBe(1)
+    expect(summary.agents.map((agent) => agent.id)).toEqual(['research', 'write'])
+    expect(summary.metrics.toolCount).toBe(1)
+    expect(summary.metrics.artifactCount).toBe(1)
+    expect(summary.metrics.approvalCount).toBe(1)
+    expect(summary.metrics.tokenTotal).toBe(175)
+    expect(summary.metrics.cost).toBe(0.03)
+  })
+})

--- a/apps/desktop/src/renderer/components/chat/mission-control-scale-model.ts
+++ b/apps/desktop/src/renderer/components/chat/mission-control-scale-model.ts
@@ -1,0 +1,318 @@
+import type { PendingApproval, PendingQuestion, TaskRun } from '@open-cowork/shared'
+import { listArtifactsForTools } from './session-artifacts'
+
+export const MISSION_CONTROL_SCALE_FEATURE_GATE_KEY = 'open-cowork.feature.missionControlScale'
+export const MISSION_CONTROL_SCALE_STATE_KEY_PREFIX = 'open-cowork.missionControlScale'
+
+export type MissionControlStatusFilter = 'all' | 'running' | 'waiting' | 'blocked' | 'errored' | 'complete' | 'cancelled'
+export type MissionControlActivityFilter = 'all' | 'needs_review' | 'approvals' | 'questions' | 'tools' | 'artifacts' | 'errors'
+
+export interface MissionControlScaleState {
+  statusFilter: MissionControlStatusFilter
+  agentFilter: string
+  activityFilter: MissionControlActivityFilter
+}
+
+export interface TaskReviewActivity {
+  approvals: PendingApproval[]
+  questions: PendingQuestion[]
+}
+
+export interface TaskRunMetrics {
+  durationMs: number
+  tokenTotal: number
+  cost: number
+  toolCount: number
+  approvalCount: number
+  questionCount: number
+  artifactCount: number
+  lastEventAt: string | null
+  lastOrder: number
+}
+
+export interface MissionControlSummary {
+  total: number
+  filtered: number
+  statuses: Record<Exclude<MissionControlStatusFilter, 'all'>, number>
+  agents: Array<{ id: string; label: string; count: number }>
+  metrics: TaskRunMetrics
+}
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem'> | null | undefined
+
+export const DEFAULT_MISSION_CONTROL_SCALE_STATE: MissionControlScaleState = {
+  statusFilter: 'all',
+  agentFilter: 'all',
+  activityFilter: 'all',
+}
+
+const statusFilters = new Set<MissionControlStatusFilter>(['all', 'running', 'waiting', 'blocked', 'errored', 'complete', 'cancelled'])
+const activityFilters = new Set<MissionControlActivityFilter>(['all', 'needs_review', 'approvals', 'questions', 'tools', 'artifacts', 'errors'])
+
+export function isMissionControlScaleEnabled(storage: Pick<Storage, 'getItem'> | null | undefined = typeof window !== 'undefined' ? window.localStorage : null) {
+  try {
+    return storage?.getItem(MISSION_CONTROL_SCALE_FEATURE_GATE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function missionControlScaleStorageKey(sessionId: string | null | undefined, groupKey: string) {
+  return `${MISSION_CONTROL_SCALE_STATE_KEY_PREFIX}:${sessionId || 'detached'}:${groupKey || 'ungrouped'}`
+}
+
+export function readMissionControlScaleState(storage: StorageLike, key: string): MissionControlScaleState {
+  try {
+    const raw = storage?.getItem(key)
+    if (!raw) return DEFAULT_MISSION_CONTROL_SCALE_STATE
+    const parsed = JSON.parse(raw) as Partial<MissionControlScaleState>
+    return normalizeMissionControlScaleState(parsed)
+  } catch {
+    return DEFAULT_MISSION_CONTROL_SCALE_STATE
+  }
+}
+
+export function writeMissionControlScaleState(storage: StorageLike, key: string, state: MissionControlScaleState) {
+  try {
+    storage?.setItem(key, JSON.stringify(normalizeMissionControlScaleState(state)))
+  } catch {
+    // Persisted filters are convenience state; ignore storage failures.
+  }
+}
+
+export function normalizeMissionControlScaleState(input: Partial<MissionControlScaleState> | null | undefined): MissionControlScaleState {
+  return {
+    statusFilter: input?.statusFilter && statusFilters.has(input.statusFilter) ? input.statusFilter : 'all',
+    agentFilter: typeof input?.agentFilter === 'string' ? input.agentFilter : 'all',
+    activityFilter: input?.activityFilter && activityFilters.has(input.activityFilter) ? input.activityFilter : 'all',
+  }
+}
+
+export function buildTaskReviewIndex(
+  taskRuns: readonly TaskRun[],
+  approvals: readonly PendingApproval[] = [],
+  questions: readonly PendingQuestion[] = [],
+) {
+  const index = new Map<string, TaskReviewActivity>()
+  const bySession = new Map<string, TaskRun>()
+
+  for (const task of taskRuns) {
+    index.set(task.id, { approvals: [], questions: [] })
+    if (task.sourceSessionId) bySession.set(task.sourceSessionId, task)
+  }
+
+  for (const approval of approvals) {
+    const task = approval.taskRunId
+      ? taskRuns.find((entry) => entry.id === approval.taskRunId)
+      : bySession.get(approval.sessionId)
+    if (!task) continue
+    const activity = index.get(task.id) || { approvals: [], questions: [] }
+    activity.approvals.push(approval)
+    index.set(task.id, activity)
+  }
+
+  for (const question of questions) {
+    const sourceSessionId = question.sourceSessionId || question.sessionId
+    const task = sourceSessionId ? bySession.get(sourceSessionId) : null
+    if (!task) continue
+    const activity = index.get(task.id) || { approvals: [], questions: [] }
+    activity.questions.push(question)
+    index.set(task.id, activity)
+  }
+
+  return index
+}
+
+export function reviewActivityForTask(index: Map<string, TaskReviewActivity>, taskId: string): TaskReviewActivity {
+  return index.get(taskId) || { approvals: [], questions: [] }
+}
+
+export function missionControlStatusForTask(taskRun: TaskRun, activity: TaskReviewActivity): Exclude<MissionControlStatusFilter, 'all'> {
+  if (taskRun.status === 'error') {
+    const errorText = `${taskRun.error || ''} ${taskRun.title}`.toLowerCase()
+    if (/\b(aborted?|cancelled|canceled)\b/.test(errorText)) return 'cancelled'
+    return 'errored'
+  }
+  if (activity.approvals.length > 0 || activity.questions.length > 0) return 'waiting'
+  if (taskRun.status === 'queued') return 'blocked'
+  if (taskRun.status === 'complete') return 'complete'
+  return 'running'
+}
+
+export function taskRunMatchesMissionControlFilters(
+  taskRun: TaskRun,
+  state: MissionControlScaleState,
+  activity: TaskReviewActivity,
+) {
+  const status = missionControlStatusForTask(taskRun, activity)
+  const artifacts = listArtifactsForTools(taskRun.toolCalls, taskRun)
+
+  if (state.statusFilter !== 'all' && status !== state.statusFilter) return false
+  if (state.agentFilter !== 'all' && (taskRun.agent || '') !== state.agentFilter) return false
+
+  switch (state.activityFilter) {
+    case 'all':
+      return true
+    case 'needs_review':
+      return activity.approvals.length > 0 || activity.questions.length > 0
+    case 'approvals':
+      return activity.approvals.length > 0
+    case 'questions':
+      return activity.questions.length > 0
+    case 'tools':
+      return taskRun.toolCalls.length > 0
+    case 'artifacts':
+      return artifacts.length > 0
+    case 'errors':
+      return status === 'errored' || status === 'cancelled' || Boolean(taskRun.error)
+  }
+}
+
+export function selectMissionControlVisibleTasks(
+  taskRuns: readonly TaskRun[],
+  state: MissionControlScaleState,
+  reviewIndex: Map<string, TaskReviewActivity>,
+) {
+  if (
+    state.statusFilter === 'all'
+    && state.agentFilter === 'all'
+    && state.activityFilter === 'all'
+  ) {
+    return taskRuns.slice()
+  }
+
+  const bySourceSession = new Map<string, TaskRun>()
+  for (const task of taskRuns) {
+    if (task.sourceSessionId) bySourceSession.set(task.sourceSessionId, task)
+  }
+
+  const visibleIds = new Set<string>()
+  const includeWithAncestors = (task: TaskRun) => {
+    let current: TaskRun | undefined = task
+    const visited = new Set<string>()
+    while (current && !visited.has(current.id)) {
+      visited.add(current.id)
+      visibleIds.add(current.id)
+      current = current.parentSessionId ? bySourceSession.get(current.parentSessionId) : undefined
+    }
+  }
+
+  for (const task of taskRuns) {
+    if (taskRunMatchesMissionControlFilters(task, state, reviewActivityForTask(reviewIndex, task.id))) {
+      includeWithAncestors(task)
+    }
+  }
+
+  return taskRuns.filter((task) => visibleIds.has(task.id))
+}
+
+function parseTimestamp(value: string | null | undefined, fallback: number) {
+  if (!value) return fallback
+  const timestamp = new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : fallback
+}
+
+export function taskRunDurationMs(taskRun: TaskRun, now = Date.now()) {
+  if (!taskRun.startedAt) return 0
+  const startedAt = parseTimestamp(taskRun.startedAt, now)
+  const finishedAt = taskRun.finishedAt ? parseTimestamp(taskRun.finishedAt, startedAt) : now
+  return Math.max(0, finishedAt - startedAt)
+}
+
+export function taskRunTokenTotal(taskRun: TaskRun) {
+  return taskRun.sessionTokens.input
+    + taskRun.sessionTokens.output
+    + taskRun.sessionTokens.reasoning
+    + taskRun.sessionTokens.cacheRead
+    + taskRun.sessionTokens.cacheWrite
+}
+
+export function buildTaskRunMetrics(taskRun: TaskRun, activity: TaskReviewActivity, now = Date.now()): TaskRunMetrics {
+  const lastOrder = [
+    taskRun.order,
+    ...taskRun.transcript.map((item) => item.order),
+    ...taskRun.toolCalls.map((item) => item.order),
+    ...taskRun.compactions.map((item) => item.order),
+  ].reduce((max, order) => Math.max(max, order), 0)
+
+  return {
+    durationMs: taskRunDurationMs(taskRun, now),
+    tokenTotal: taskRunTokenTotal(taskRun),
+    cost: taskRun.sessionCost || 0,
+    toolCount: taskRun.toolCalls.length,
+    approvalCount: activity.approvals.length,
+    questionCount: activity.questions.length,
+    artifactCount: listArtifactsForTools(taskRun.toolCalls, taskRun).length,
+    lastEventAt: taskRun.finishedAt || taskRun.startedAt || null,
+    lastOrder,
+  }
+}
+
+export function buildMissionControlSummary(
+  allTasks: readonly TaskRun[],
+  visibleTasks: readonly TaskRun[],
+  reviewIndex: Map<string, TaskReviewActivity>,
+  now = Date.now(),
+): MissionControlSummary {
+  const statuses: MissionControlSummary['statuses'] = {
+    running: 0,
+    waiting: 0,
+    blocked: 0,
+    errored: 0,
+    complete: 0,
+    cancelled: 0,
+  }
+  const agentCounts = new Map<string, number>()
+
+  for (const task of allTasks) {
+    const activity = reviewActivityForTask(reviewIndex, task.id)
+    statuses[missionControlStatusForTask(task, activity)] += 1
+    const agentId = task.agent || ''
+    agentCounts.set(agentId, (agentCounts.get(agentId) || 0) + 1)
+  }
+
+  const metrics = visibleTasks.reduce<TaskRunMetrics>((acc, task) => {
+    const next = buildTaskRunMetrics(task, reviewActivityForTask(reviewIndex, task.id), now)
+    return {
+      durationMs: Math.max(acc.durationMs, next.durationMs),
+      tokenTotal: acc.tokenTotal + next.tokenTotal,
+      cost: acc.cost + next.cost,
+      toolCount: acc.toolCount + next.toolCount,
+      approvalCount: acc.approvalCount + next.approvalCount,
+      questionCount: acc.questionCount + next.questionCount,
+      artifactCount: acc.artifactCount + next.artifactCount,
+      lastEventAt: latestIso(acc.lastEventAt, next.lastEventAt),
+      lastOrder: Math.max(acc.lastOrder, next.lastOrder),
+    }
+  }, emptyTaskRunMetrics())
+
+  return {
+    total: allTasks.length,
+    filtered: visibleTasks.length,
+    statuses,
+    agents: Array.from(agentCounts.entries())
+      .map(([id, count]) => ({ id, label: id || 'Sub-agent', count }))
+      .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label)),
+    metrics,
+  }
+}
+
+function emptyTaskRunMetrics(): TaskRunMetrics {
+  return {
+    durationMs: 0,
+    tokenTotal: 0,
+    cost: 0,
+    toolCount: 0,
+    approvalCount: 0,
+    questionCount: 0,
+    artifactCount: 0,
+    lastEventAt: null,
+    lastOrder: 0,
+  }
+}
+
+function latestIso(left: string | null, right: string | null) {
+  if (!left) return right
+  if (!right) return left
+  return new Date(left).getTime() >= new Date(right).getTime() ? left : right
+}


### PR DESCRIPTION
## Summary
- Adds a default-off Mission Control scale mode behind `open-cowork.feature.missionControlScale`.
- Adds status, agent, and activity filters with grouped status counts, per-session persisted filter state, and ancestor-preserving nested task visibility.
- Adds task summary metrics for duration, tokens, cost, tools, approvals, questions, artifacts, and last event state.
- Extends task drill-in with previous/next navigation across the current filtered task set plus source, approval, question, and artifact affordances.

## Implementation Notes
- Stays in the renderer projection layer and uses existing TaskRun, pending approval/question, tool trace, artifact, and history state.
- Does not change OpenCode runtime behavior or introduce new session matching semantics.
- Preserves parent-session transcript UI separately from delegated child-session task runs.

## Feature Gate
- `open-cowork.feature.missionControlScale=true` enables the scale controls.
- Default is off; existing Mission Control behavior remains unchanged without the gate.

## Test Gates
- `pnpm --filter @open-cowork/desktop test:renderer -- MissionControl TaskDrillIn mission-control-scale-model ChatView`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @open-cowork/desktop build`
- `pnpm test`
- `git diff --check`

Closes #343