### PR TITLE
Clean renderer dead exports

### DIFF
--- a/apps/desktop/src/renderer/components/chat/agent-run-filter-model.ts
+++ b/apps/desktop/src/renderer/components/chat/agent-run-filter-model.ts
@@ -80,7 +80,7 @@ export function writeAgentRunFilterState(storage: StorageLike, key: string, stat
   }
 }
 
-export function normalizeAgentRunFilterState(input: Partial<AgentRunFilterState> | null | undefined): AgentRunFilterState {
+function normalizeAgentRunFilterState(input: Partial<AgentRunFilterState> | null | undefined): AgentRunFilterState {
   return {
     statusFilter: input?.statusFilter && statusFilters.has(input.statusFilter) ? input.statusFilter : 'all',
     agentFilter: typeof input?.agentFilter === 'string' ? input.agentFilter : 'all',
@@ -139,7 +139,7 @@ export function agentRunStatusForTask(taskRun: TaskRun, activity: TaskReviewActi
   return 'running'
 }
 
-export function taskRunMatchesAgentRunFilters(
+function taskRunMatchesAgentRunFilters(
   taskRun: TaskRun,
   state: AgentRunFilterState,
   activity: TaskReviewActivity,
@@ -212,14 +212,14 @@ function parseTimestamp(value: string | null | undefined, fallback: number) {
   return Number.isFinite(timestamp) ? timestamp : fallback
 }
 
-export function taskRunDurationMs(taskRun: TaskRun, now = Date.now()) {
+function taskRunDurationMs(taskRun: TaskRun, now = Date.now()) {
   if (!taskRun.startedAt) return 0
   const startedAt = parseTimestamp(taskRun.startedAt, now)
   const finishedAt = taskRun.finishedAt ? parseTimestamp(taskRun.finishedAt, startedAt) : now
   return Math.max(0, finishedAt - startedAt)
 }
 
-export function taskRunTokenTotal(taskRun: TaskRun) {
+function taskRunTokenTotal(taskRun: TaskRun) {
   return taskRun.sessionTokens.input
     + taskRun.sessionTokens.output
     + taskRun.sessionTokens.reasoning

--- a/apps/desktop/src/renderer/components/chat/markdown-stream.ts
+++ b/apps/desktop/src/renderer/components/chat/markdown-stream.ts
@@ -287,7 +287,7 @@ function normalizeMissingSeparatorTableLines(text: string) {
   return out.join('\n')
 }
 
-export function normalizeCollapsedMarkdownTables(text: string) {
+function normalizeCollapsedMarkdownTables(text: string) {
   if (!text.includes('|')) return text
 
   const lines = text.split('\n')
@@ -313,7 +313,7 @@ export function normalizeCollapsedMarkdownTables(text: string) {
   return normalizeMissingSeparatorTableLines(normalized)
 }
 
-export function normalizeFencedCodeBlocks(text: string) {
+function normalizeFencedCodeBlocks(text: string) {
   if (!text || (!text.includes('```') && !text.includes('~~~'))) return text
 
   const lines = text.split('\n')

--- a/apps/desktop/src/renderer/components/chat/session-inspector-utils.ts
+++ b/apps/desktop/src/renderer/components/chat/session-inspector-utils.ts
@@ -60,7 +60,7 @@ export function formatDateTime(value: string | null | undefined) {
   })
 }
 
-export function estimateTokensFromText(value: string) {
+function estimateTokensFromText(value: string) {
   const normalized = value.trim()
   if (!normalized) return 0
   return Math.max(1, Math.round(normalized.length / 4))

--- a/apps/desktop/src/renderer/components/chat/tool-trace-utils.ts
+++ b/apps/desktop/src/renderer/components/chat/tool-trace-utils.ts
@@ -88,15 +88,11 @@ function normalizedRules(rules?: readonly ToolTraceRule[]) {
   return rules?.length ? rules : DEFAULT_TOOL_TRACE_RULES
 }
 
-export function toolTraceRuleForName(rawName: string, rules?: readonly ToolTraceRule[]) {
+function toolTraceRuleForName(rawName: string, rules?: readonly ToolTraceRule[]) {
   const name = rawName.trim().toLowerCase()
   return normalizedRules(rules).find((rule) => {
     return rule.match.some((matcher) => matcherMatches(name, matcher))
   }) || FALLBACK_TOOL_TRACE_RULE
-}
-
-export function toolCategory(rawName: string, rules?: readonly ToolTraceRule[]) {
-  return toolTraceRuleForName(rawName, rules).id
 }
 
 function pluralLabel(rule: ToolTraceRule) {

--- a/apps/desktop/src/renderer/components/chat/vega-chart-utils.ts
+++ b/apps/desktop/src/renderer/components/chat/vega-chart-utils.ts
@@ -1,7 +1,5 @@
 export {
   applyVegaTheme,
-  isFullVegaSpec,
   makeInteractiveVegaSpecResponsive,
-  normalizeVegaSpecSchema,
   type VegaChartTheme,
 } from '../../../lib/vega-spec.ts'

--- a/apps/desktop/src/renderer/components/command-palette-items.ts
+++ b/apps/desktop/src/renderer/components/command-palette-items.ts
@@ -47,7 +47,7 @@ export function getShortcutPlatform(source: NavigatorPlatformSource | undefined 
   return source?.platform || ''
 }
 
-export function formatShortcutLabel(shortcut: string, platform = getShortcutPlatform()) {
+function formatShortcutLabel(shortcut: string, platform = getShortcutPlatform()) {
   const isMac = platform.toLowerCase().includes('mac')
   return shortcut
     .replace('CmdOrCtrl', isMac ? 'Cmd' : 'Ctrl')

--- a/apps/desktop/src/renderer/helpers/i18n.ts
+++ b/apps/desktop/src/renderer/helpers/i18n.ts
@@ -147,10 +147,8 @@ export async function setLocale(locale: string | null) {
     /* non-fatal */
   }
   cachedLocale = locale || configuredLocale || systemLocale() || undefined
-  // Clear memoized Intl formatters so subsequent formatNumber/Date
-  // calls reflect the new locale immediately.
-  numberFormatters.clear()
-  currencyFormatters.clear()
+  // Clear memoized Intl formatters so subsequent formatDate calls
+  // reflect the new locale immediately.
   dateFormatters.clear()
   await rebuildCatalog()
 }
@@ -189,23 +187,10 @@ export function t(key: string, fallback: string, vars?: Record<string, string | 
   })
 }
 
-// Cached Intl formatters keyed by locale so we don't recreate them on
-// every render. Formatters are among the most expensive built-ins to
+// Cached Intl date formatters keyed by locale/options so we don't recreate
+// them on every render. Formatters are among the most expensive built-ins to
 // instantiate, and chat / Home render paths are hot.
-const numberFormatters = new Map<string, Intl.NumberFormat>()
-const currencyFormatters = new Map<string, Intl.NumberFormat>()
 const dateFormatters = new Map<string, Intl.DateTimeFormat>()
-
-export function formatNumber(value: number): string {
-  const locale = cachedLocale
-  const key = locale || '_default_'
-  let formatter = numberFormatters.get(key)
-  if (!formatter) {
-    formatter = new Intl.NumberFormat(locale)
-    numberFormatters.set(key, formatter)
-  }
-  return formatter.format(value)
-}
 
 export function formatDate(value: Date | string | number, options?: Intl.DateTimeFormatOptions): string {
   const locale = cachedLocale
@@ -219,18 +204,6 @@ export function formatDate(value: Date | string | number, options?: Intl.DateTim
   return formatter.format(date)
 }
 
-// Currency formatter. Downstream forks can pass currency via options;
-// default is USD to match the upstream pricing catalog.
-export function formatCurrency(value: number, currency: string = 'USD'): string {
-  const locale = cachedLocale
-  const key = `${locale || '_default_'}:${currency}`
-  let formatter = currencyFormatters.get(key)
-  if (!formatter) {
-    formatter = new Intl.NumberFormat(locale, { style: 'currency', currency })
-    currencyFormatters.set(key, formatter)
-  }
-  return formatter.format(value)
-}
 
 // Auto-derived from the built-in catalog registry so adding a
 // language in `i18n-catalogs/registry.ts` is a one-line change that

--- a/tests/command-palette-items.test.ts
+++ b/tests/command-palette-items.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import type { BuiltInAgentDetail, CustomAgentSummary, SessionInfo } from '@open-cowork/shared'
-import { buildCommandPaletteItems, formatShortcutLabel, getShortcutPlatform } from '../apps/desktop/src/renderer/components/command-palette-items.ts'
+import { buildCommandPaletteItems, getShortcutPlatform } from '../apps/desktop/src/renderer/components/command-palette-items.ts'
 
 function createCallbacks() {
   const calls: Array<{ type: string; value?: string }> = []
@@ -46,9 +46,25 @@ function createCallbacks() {
   }
 }
 
-test('formatShortcutLabel adapts CmdOrCtrl for mac and non-mac labels', () => {
-  assert.equal(formatShortcutLabel('CmdOrCtrl+Shift+P', 'MacIntel'), 'Cmd + Shift + P')
-  assert.equal(formatShortcutLabel('CmdOrCtrl+Shift+P', 'Linux x86_64'), 'Ctrl + Shift + P')
+test('buildCommandPaletteItems adapts shortcut hints for mac and non-mac platforms', () => {
+  const { callbacks } = createCallbacks()
+  const macItems = buildCommandPaletteItems({
+    commands: [],
+    builtinAgents: [],
+    customAgents: [],
+    platform: 'MacIntel',
+    ...callbacks,
+  })
+  const linuxItems = buildCommandPaletteItems({
+    commands: [],
+    builtinAgents: [],
+    customAgents: [],
+    platform: 'Linux x86_64',
+    ...callbacks,
+  })
+
+  assert.equal(macItems.find((item) => item.id === 'create:search')?.hint, 'Cmd + K')
+  assert.equal(linuxItems.find((item) => item.id === 'create:search')?.hint, 'Ctrl + K')
 })
 
 test('getShortcutPlatform prefers userAgentData and falls back to legacy platform', () => {

--- a/tests/i18n-runtime.test.ts
+++ b/tests/i18n-runtime.test.ts
@@ -32,7 +32,7 @@ Object.defineProperty(globalThis, 'navigator', {
 })
 
 // Import after globals are stubbed — the runtime reads them at first use.
-const { setLocale, getLocale, t, configureI18n, getBuiltInLocales, formatCurrency, formatNumber } = await import(
+const { setLocale, getLocale, t, configureI18n, getBuiltInLocales } = await import(
   '../apps/desktop/src/renderer/helpers/i18n.ts'
 )
 
@@ -99,30 +99,6 @@ describe('i18n runtime', () => {
     await setLocale('fr')
     const rendered = t('sidebar.threadFallback', 'Thread {{id}}', { id: 'abc123' })
     assert.equal(rendered, 'Conversation abc123')
-  })
-
-  it('Intl.NumberFormat respects the active locale', async () => {
-    await setLocale('fr')
-    // French thousands separator is a non-breaking space (or narrow nbsp)
-    const french = formatNumber(1234567)
-    assert.ok(/1[\s\u00a0\u202f]234[\s\u00a0\u202f]567/.test(french), `expected French grouping, got: ${JSON.stringify(french)}`)
-
-    await setLocale('de')
-    const german = formatNumber(1234567)
-    assert.equal(german, '1.234.567')
-
-    await setLocale('en')
-    const english = formatNumber(1234567)
-    assert.equal(english, '1,234,567')
-  })
-
-  it('currency formatting respects active locale and currency', async () => {
-    await setLocale('fr')
-    const frenchEuro = formatCurrency(1234.5, 'EUR')
-    assert.ok(/1[\s\u00a0\u202f]234,50[\s\u00a0\u202f]€/.test(frenchEuro), `expected French EUR format, got: ${JSON.stringify(frenchEuro)}`)
-
-    await setLocale('en')
-    assert.equal(formatCurrency(1234.5, 'USD'), '$1,234.50')
   })
 
   it('reads user preference from localStorage at configure time, overriding system locale', async () => {

--- a/tests/markdown-stream.test.ts
+++ b/tests/markdown-stream.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { normalizeCollapsedMarkdownTables, normalizeFencedCodeBlocks, streamMarkdown } from '../apps/desktop/src/renderer/components/chat/markdown-stream.ts'
+import { streamMarkdown } from '../apps/desktop/src/renderer/components/chat/markdown-stream.ts'
 
 test('normalizes nested fences inside a top-level code block', () => {
   const source = [
@@ -23,7 +23,7 @@ test('normalizes nested fences inside a top-level code block', () => {
     '**Key Julia features demonstrated:**',
   ].join('\n')
 
-  const normalized = normalizeFencedCodeBlocks(source)
+  const normalized = streamMarkdown(source, false)[0]?.src ?? ''
 
   assert.match(normalized, /````julia/)
   assert.match(normalized, /\n````\n\n\*\*Key Julia features demonstrated:\*\*/)
@@ -44,7 +44,7 @@ test('keeps separate top-level code fences unchanged', () => {
     '```',
   ].join('\n')
 
-  assert.equal(normalizeFencedCodeBlocks(source), source)
+  assert.equal(streamMarkdown(source, false)[0]?.src, source)
 })
 
 test('widens an incomplete outer fence during streaming when nested fences appear inside', () => {
@@ -67,7 +67,7 @@ test('widens an incomplete outer fence during streaming when nested fences appea
 
 test('normalizes model-collapsed GFM tables before final rendering', () => {
   const source = '| Day | Date (2026) | Sessions | CVR | |---|---|---|---| | Sun | 26 Apr | 152,762 | 3.03% | | Mon | 27 Apr | 185,921 | 2.90% |'
-  const normalized = normalizeCollapsedMarkdownTables(source)
+  const normalized = streamMarkdown(source, false)[0]?.src
 
   assert.equal(normalized, [
     '| Day | Date (2026) | Sessions | CVR |',
@@ -80,7 +80,7 @@ test('normalizes model-collapsed GFM tables before final rendering', () => {
 
 test('normalizes collapsed table rows with empty cells without splitting them as row boundaries', () => {
   const source = '| Metric | Current | Notes | |---|---|---| | Sessions | 906,321 | All days down YoY | | CVR | 2.79% | |'
-  const normalized = normalizeCollapsedMarkdownTables(source)
+  const normalized = streamMarkdown(source, false)[0]?.src
 
   assert.equal(normalized, [
     '| Metric | Current | Notes |',
@@ -92,7 +92,7 @@ test('normalizes collapsed table rows with empty cells without splitting them as
 
 test('normalizes collapsed table separators with padded cells', () => {
   const source = '| Day | Sessions | | --- | ---: | | Sun | 10 | | Mon | 12 |'
-  const normalized = normalizeCollapsedMarkdownTables(source)
+  const normalized = streamMarkdown(source, false)[0]?.src
 
   assert.equal(normalized, [
     '| Day | Sessions |',
@@ -109,5 +109,5 @@ test('does not normalize collapsed-looking tables inside code fences', () => {
     '```',
   ].join('\n')
 
-  assert.equal(normalizeCollapsedMarkdownTables(source), source)
+  assert.equal(streamMarkdown(source, false)[0]?.src, source)
 })

--- a/tests/tool-trace-utils.test.ts
+++ b/tests/tool-trace-utils.test.ts
@@ -4,7 +4,6 @@ import { DEFAULT_TOOL_TRACE_RULES } from '../packages/shared/src/tool-trace.ts'
 import {
   buildCustomMcpToolTraceRules,
   summarizeTools,
-  toolCategory,
   tryParseChartOutput,
 } from '../apps/desktop/src/renderer/components/chat/tool-trace-utils.ts'
 
@@ -35,14 +34,14 @@ test('tryParseChartOutput parses stringified vega specs and mermaid diagrams', (
   assert.equal(tryParseChartOutput({ type: 'vega', spec: '{bad json}' }), null)
 })
 
-test('toolCategory classifies key runtime tool families', () => {
-  assert.equal(toolCategory('read'), 'file read')
-  assert.equal(toolCategory('bash'), 'command')
-  assert.equal(toolCategory('charts_mermaid'), 'chart')
-  assert.equal(toolCategory('mcp__nova__get_context'), 'inspection')
-  assert.equal(toolCategory('mcp__github__pull_request_read'), 'github pr')
-  assert.equal(toolCategory('mcp__perplexity__perplexity_research'), 'perplexity research')
-  assert.equal(toolCategory('mcp__google-drive__list_files'), 'drive action')
+test('summarizeTools classifies key runtime tool families', () => {
+  assert.equal(summarizeTools([{ name: 'read' }]), '1 file read')
+  assert.equal(summarizeTools([{ name: 'bash' }]), '1 command')
+  assert.equal(summarizeTools([{ name: 'charts_mermaid' }]), '1 chart')
+  assert.equal(summarizeTools([{ name: 'mcp__nova__get_context' }]), '1 inspection')
+  assert.equal(summarizeTools([{ name: 'mcp__github__pull_request_read' }]), '1 github PR action')
+  assert.equal(summarizeTools([{ name: 'mcp__perplexity__perplexity_research' }]), '1 perplexity research run')
+  assert.equal(summarizeTools([{ name: 'mcp__google-drive__list_files' }]), '1 drive action')
 })
 
 test('summarizeTools groups repeated tool categories into readable text', () => {
@@ -73,7 +72,6 @@ test('tool trace rules can be configured ahead of the defaults', () => {
     ...DEFAULT_TOOL_TRACE_RULES,
   ]
 
-  assert.equal(toolCategory('mcp__jira__create_issue', rules), 'ticket')
   assert.equal(
     summarizeTools([
       { name: 'mcp__jira__create_issue' },
@@ -92,7 +90,6 @@ test('custom MCP metadata creates project-specific trace grouping rules', () => 
     tracePluralLabel: 'ticket updates',
   }])
 
-  assert.equal(toolCategory('mcp__ticketing__create_issue', rules), 'custom-mcp:ticketing')
   assert.equal(
     summarizeTools([
       { name: 'mcp__ticketing__create_issue' },

--- a/tests/vega-chart-utils.test.ts
+++ b/tests/vega-chart-utils.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { applyVegaTheme, isFullVegaSpec, makeInteractiveVegaSpecResponsive, normalizeVegaSpecSchema } from '../apps/desktop/src/renderer/components/chat/vega-chart-utils.ts'
+import { isFullVegaSpec, normalizeVegaSpecSchema } from '../apps/desktop/src/lib/vega-spec.ts'
+import { applyVegaTheme, makeInteractiveVegaSpecResponsive } from '../apps/desktop/src/renderer/components/chat/vega-chart-utils.ts'
 
 test('normalizeVegaSpecSchema upgrades legacy vega-lite schemas to v6', () => {
   const spec = {


### PR DESCRIPTION
## Summary
- remove unused renderer i18n number/currency helpers and formatter caches
- narrow internal-only chat, command palette, and Vega utility exports
- update tests to exercise public behavior instead of private helper exports

## Validation
- pnpm lint
- pnpm lint:dead-code
- pnpm typecheck
- pnpm test
- renderer tests
- targeted updated tests
- git diff --check