### PR TITLE
Ground audit cleanup

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,8 +3,8 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `7f1395410f8813d2f25a5f40dce24fd132472166cb57c4ebbc11a35629898e20`
-- Production package entries: 418
+- pnpm lockfile SHA-256: `0ab6fe1f8cf117850f2cb44a9b329166aeeeb5f65b0169f954f8da221fe02117`
+- Production package entries: 419
 
 Each package remains licensed under its own license terms. The table below is provided for attribution and review; bundled license files are emitted under `THIRD_PARTY_LICENSES/`.
 
@@ -18,6 +18,7 @@ Each package remains licensed under its own license terms. The table below is pr
 | @iconify/utils | 3.1.0 | MIT | THIRD_PARTY_LICENSES/@iconify__utils@3.1.0/ | https://github.com/iconify/iconify.git |
 | @mermaid-js/parser | 1.1.1 | MIT | THIRD_PARTY_LICENSES/@mermaid-js__parser@1.1.1/ | https://github.com/mermaid-js/mermaid.git |
 | @modelcontextprotocol/sdk | 1.29.0 | MIT | THIRD_PARTY_LICENSES/@modelcontextprotocol__sdk@1.29.0/ | git+https://github.com/modelcontextprotocol/typescript-sdk.git |
+| @open-cowork/shared | link:../../packages/shared | MIT |  | https://github.com/joe-broadhead/open-cowork.git |
 | @opencode-ai/sdk | 1.15.3 | MIT |  | https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.3.tgz |
 | @tanstack/react-virtual | 3.13.24 | MIT | THIRD_PARTY_LICENSES/@tanstack__react-virtual@3.13.24/ | git+https://github.com/TanStack/virtual.git |
 | @tanstack/virtual-core | 3.14.0 | MIT | THIRD_PARTY_LICENSES/@tanstack__virtual-core@3.14.0/ | git+https://github.com/TanStack/virtual.git |

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -11,10 +11,10 @@ understand and that map cleanly onto OpenCode:
 - `Tools & Skills` — MCP tools, OpenCode skills, credentials, and capability relationships
 - `Settings` — appearance, models, permissions, storage, and workflow run behavior
 
-Team dashboards, incident-control dashboards, and autonomous learning controls are not
-part of the active app surface. They remain implementation history until the
-core Chat, Agents, and Workflows experience is excellent enough to justify a
-broader team layer.
+Team dashboards, incident-control dashboards, and unsupervised autonomous
+learning controls are not part of the active app surface. User-invoked
+improvement work still belongs in Chat through the bundled `autoresearch`
+skill and agent.
 
 ```mermaid
 flowchart TD
@@ -53,7 +53,7 @@ runtime kinds. Use these terms in user-facing copy:
 - **OpenCode** for execution-engine details that matter to users.
 
 Avoid presenting dormant implementation concepts such as team dashboards,
-incident-control dashboards, or autonomous learning loops as current product features. If a feature
+incident-control dashboards, or unsupervised autonomous learning loops as current product features. If a feature
 does not help a user start work, delegate to an agent, curate tools/skills, or
 review a workflow, it does not belong in the primary app navigation.
 

--- a/docs/first-contribution.md
+++ b/docs/first-contribution.md
@@ -118,7 +118,7 @@ If you're landing a change that touches a release-visible surface
 (build scripts, CI, changelog, docs), run through the checklist:
 
 ```bash
-pnpm typecheck && pnpm lint && pnpm test && pnpm test:renderer && pnpm perf:check && python -m pip install -r docs/requirements.txt && mkdocs build --strict
+pnpm typecheck && pnpm lint && pnpm test && pnpm test:renderer && pnpm perf:check && python -m venv .venv-docs && . .venv-docs/bin/activate && python -m pip install -r docs/requirements.txt && mkdocs build --strict
 ```
 
 That covers the main repository quality gates. Release tags also run

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -84,7 +84,7 @@ Capability
 
 Tool
 :   An individual MCP-exposed function the model can call (e.g.
-    `bar_chart`, `save_skill_bundle`). Tools belong to MCPs; capabilities
+    `bar_chart`, `save_skill_bundle`, `delete_skill_bundle`). Tools belong to MCPs; capabilities
     aggregate them.
 
 ## Workflows

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ hide:
 <div class="cowork-stats" markdown>
 
 <div class="stat" markdown>
-  <div class="stat-value">5 / 6</div>
-  <div class="stat-label">Bundled MCPs / skills</div>
+  <div class="stat-value">5 MCPs · 6 skills</div>
+  <div class="stat-label">Bundled capabilities</div>
 </div>
 
 <div class="stat" markdown>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,6 +54,9 @@ These concepts are intentionally out of the active app surface:
 
 They can return only if they are explained through the core concepts above and
 have a concrete user job that cannot be solved more simply.
+This does not exclude user-invoked improvement work through the bundled
+`autoresearch` skill and agent; the non-goal is an always-on autonomous
+learning surface that creates work without a user request.
 
 ## Phase 1: Make Chat Excellent
 

--- a/docs/skills-and-mcps.md
+++ b/docs/skills-and-mcps.md
@@ -48,8 +48,9 @@ Five bundled MCPs and six bundled skills, used as worked examples below.
 
     ---
 
-    Lets agents enumerate, read, and write skill bundles from chat.
-    Tools: `list_skill_bundles`, `get_skill_bundle`, `save_skill_bundle`.
+    Lets agents enumerate, read, write, and delete skill bundles from chat.
+    Tools: `list_skill_bundles`, `get_skill_bundle`, `save_skill_bundle`,
+    `delete_skill_bundle`.
     Source: `mcps/skills/src/index.ts`.
 
 -   :material-account-cog: **`agents` MCP** <span class="status-badge stable">stable</span>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,10 +92,9 @@ or interrupted installs.
 ## Workflow webhook returns 401
 
 Workflow webhooks no longer accept secrets embedded in the copied URL.
-Workflows copied before the auth-format change must be recopied; old
-secret-bearing URLs now return 401. Supported auth is
-`Authorization: Bearer`, `x-open-cowork-webhook-secret`, or timestamped
-HMAC.
+Older copied webhook commands must be recopied; old secret-bearing URLs now
+return 401. Supported auth is `Authorization: Bearer`,
+`x-open-cowork-webhook-secret`, or timestamped HMAC.
 
 Open **Workflows**, copy the webhook command again, and use this shape:
 
@@ -114,7 +113,7 @@ If you cannot use a bearer header, send `x-open-cowork-webhook-secret:
 ## Settings reset on reboot
 
 Credentials are persisted via Electron's `safeStorage`, which uses
-Keychain on macOS, DPAPI on Windows, and libsecret on Linux. If
+Keychain on macOS and libsecret on Linux. If
 `safeStorage.isEncryptionAvailable()` returns false on your platform
 the app will refuse to persist credentials in production builds
 (dev falls back to a plaintext file). The main-process log will

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -64,9 +64,8 @@ to start a run and pass trigger payload into the run prompt. The webhook secret
 is sent in headers, not embedded in the URL, and can be regenerated from the
 Workflows page.
 
-Workflows copied before the auth-format change must be recopied; old
-secret-bearing URLs now return 401. Supported auth is `Authorization: Bearer`,
-`x-open-cowork-webhook-secret`, or timestamped HMAC.
+Supported auth is `Authorization: Bearer`, `x-open-cowork-webhook-secret`, or
+timestamped HMAC.
 
 The Workflows page copies a ready-to-run bearer example:
 

--- a/mcps/agents/src/index.ts
+++ b/mcps/agents/src/index.ts
@@ -154,5 +154,6 @@ server.tool(
   async (target) => textResult(await postToBridge('/delete', target)),
 )
 
+process.stderr.write('[agents-mcp] Server started\n')
 const transport = new StdioServerTransport()
 await server.connect(transport)

--- a/mcps/agents/tsconfig.json
+++ b/mcps/agents/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "target": "ES2024",
+    "lib": ["ESNext"],
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/mcps/build.mjs
+++ b/mcps/build.mjs
@@ -1,8 +1,11 @@
 import { createRequire } from 'module'
 import { resolve } from 'path'
+import { fileURLToPath } from 'url'
 
-const workspaceRoot = resolve(process.cwd(), '..', '..')
-const requireFromPackage = createRequire(resolve(process.cwd(), 'package.json'))
+const mcpRoot = resolve(fileURLToPath(new URL('.', import.meta.url)))
+const packageRoot = process.cwd()
+const workspaceRoot = resolve(mcpRoot, '..')
+const requireFromPackage = createRequire(resolve(packageRoot, 'package.json'))
 const { build } = requireFromPackage('esbuild')
 
 await build({

--- a/mcps/charts/src/sankey.ts
+++ b/mcps/charts/src/sankey.ts
@@ -180,7 +180,7 @@ export function buildSankeySpec(input: SankeyInput) {
       scaleCandidates.push(available / columnValue)
     }
   }
-  const valueScale = Math.max(1, Math.min(...scaleCandidates))
+  const valueScale = Math.max(1, scaleCandidates.length ? Math.min(...scaleCandidates) : 1)
 
   for (const [column, columnNodes] of nodesByColumn.entries()) {
     columnNodes.sort((left, right) => right.value - left.value || left.label.localeCompare(right.label))

--- a/mcps/skills/package.json
+++ b/mcps/skills/package.json
@@ -18,11 +18,11 @@
     "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts"
   },
   "dependencies": {
+    "@open-cowork/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "@open-cowork/shared": "workspace:*",
     "@types/node": "^22.12.0",
     "esbuild": "^0.28.0",
     "typescript": "^6.0.3"

--- a/mcps/skills/src/index.ts
+++ b/mcps/skills/src/index.ts
@@ -306,6 +306,7 @@ server.tool(
 )
 
 export async function startSkillsMcpServer() {
+  process.stderr.write('[skills-mcp] Server started\n')
   const transport = new StdioServerTransport()
   await server.connect(transport)
 }

--- a/mcps/workflows/src/index.ts
+++ b/mcps/workflows/src/index.ts
@@ -133,5 +133,6 @@ server.tool(
   async (draft) => textResult(await postToBridge('/create', draft)),
 )
 
+process.stderr.write('[workflows-mcp] Server started\n')
 const transport = new StdioServerTransport()
 await server.connect(transport)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,13 +229,13 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.2)
+      '@open-cowork/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       zod:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
-      '@open-cowork/shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
       '@types/node':
         specifier: ^22.12.0
         version: 22.19.19


### PR DESCRIPTION
## Summary

- Removes stale generated downstream artifacts locally and grounds the valid audit findings in committed docs/config cleanup.
- Documents the Skills MCP `delete_skill_bundle` tool and clarifies bundled capability counts, workflow webhook auth, safeStorage support, first-contribution docs setup, and autoresearch/non-goal language.
- Aligns the agents MCP TypeScript config with the other MCPs, makes the shared package a runtime dependency for the skills MCP, hardens the shared MCP build script path resolution, adds consistent MCP startup logs, and guards the Sankey scale fallback.

## Validation

- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/config-elements.test.ts tests/config-schema-validation.test.ts`
- `pnpm --filter './mcps/*' test`
- `pnpm typecheck`
- `pnpm lint`
- `uv run mkdocs build --strict`
- `pnpm test`
- `pnpm lint:dead-code`
- `git diff --check`

## Notes

- Verified `deepseek/deepseek-v4-flash:free` in the live OpenRouter model catalog before leaving the model docs unchanged.
- Kept protective local/tool ignore entries such as `.opencode/`, `.codex/`, and `.mcp.json`; they are intentional guardrails, not stale source references.