### PR TITLE
Clean stale workflow and MCP docs

### DIFF
--- a/apps/desktop/src/main/workflow-store.ts
+++ b/apps/desktop/src/main/workflow-store.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from 'node:sqlite'
-import { chmodSync, copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import type {
   WorkflowDetail,
@@ -36,10 +36,6 @@ function workflowDbPath() {
   const dir = getAppDataDir()
   mkdirSync(dir, { recursive: true })
   return join(dir, 'workflows.sqlite')
-}
-
-function legacyAutomationDbPath() {
-  return join(getAppDataDir(), 'automation.sqlite')
 }
 
 function ensureWorkflowDbFileModes(dbPath = workflowDbPath()) {
@@ -191,18 +187,6 @@ function initDb(db: DatabaseSync) {
   `).run(WORKFLOW_SCHEMA_VERSION_KEY, String(WORKFLOW_DB_SCHEMA_VERSION))
 }
 
-function backupLegacyAutomationDb() {
-  const legacy = legacyAutomationDbPath()
-  if (!existsSync(legacy)) return
-  const backup = `${legacy}.pre-workflow-rebuild.bak`
-  if (existsSync(backup)) return
-  try {
-    copyFileSync(legacy, backup)
-  } catch {
-    // Migration backup is best-effort. The legacy DB is left in place.
-  }
-}
-
 export function getWorkflowDb() {
   if (workflowDb) return workflowDb
   const dbPath = workflowDbPath()
@@ -210,7 +194,6 @@ export function getWorkflowDb() {
   try {
     db.exec('pragma journal_mode = WAL;')
     initDb(db)
-    backupLegacyAutomationDb()
     ensureWorkflowDbFileModes(dbPath)
     workflowDb = db
     return db

--- a/apps/desktop/src/renderer/components/plugins/custom-mcp-form-support.ts
+++ b/apps/desktop/src/renderer/components/plugins/custom-mcp-form-support.ts
@@ -1,11 +1,15 @@
-import type { CustomMcpConfig, CustomSkillConfig } from '@open-cowork/shared'
+import type {
+  CustomMcpConfig,
+  CustomMcpPermissionMode as SharedCustomMcpPermissionMode,
+  CustomSkillConfig,
+} from '@open-cowork/shared'
 
 export const customMcpInputClass = 'w-full px-3 py-2 rounded-lg text-[12px] bg-elevated border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-border'
 export const CUSTOM_MCP_VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
 export type CustomMcpFormType = 'stdio' | 'http'
 export type CustomMcpFormScope = 'machine' | 'project'
-export type CustomMcpPermissionMode = 'ask' | 'allow'
+export type CustomMcpPermissionMode = SharedCustomMcpPermissionMode
 export type KeyValueDraft = { id: string; key: string; value: string }
 
 let nextKeyValueDraftId = 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,10 +57,10 @@ owns its own subprocess for sessions and MCP tool calls.
 ## OpenCode dependency
 
 Open Cowork embeds the OpenCode SDK v2 API surface from the
-`@opencode-ai/sdk` package. The current pinned package version is
-tracked in `apps/desktop/package.json` — at the time of writing,
-`@opencode-ai/sdk: 1.15.3`. The packaged desktop app ships the
-OpenCode CLI binary alongside the Electron bundle (see
+`@opencode-ai/sdk` package. The pinned package version is tracked in
+`apps/desktop/package.json`, with the exact installed version locked in
+`pnpm-lock.yaml`. The packaged desktop app ships the OpenCode CLI
+binary alongside the Electron bundle (see
 `runtime-opencode-cli.ts`).
 
 SDK upgrades can change:
@@ -376,8 +376,8 @@ load-bearing and easy to regress:
 
 This repo pins `opencode-ai` (the runtime) and
 `@opencode-ai/sdk` (the client) explicitly in
-`apps/desktop/package.json`. Current pairs as of this
-writing: `opencode-ai: 1.15.3`, `@opencode-ai/sdk: 1.15.3`.
+`apps/desktop/package.json`. Treat that manifest and `pnpm-lock.yaml`
+as the source of truth for the current pair.
 
 Why the pin is load-bearing:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -84,8 +84,9 @@ Capability
 
 Tool
 :   An individual MCP-exposed function the model can call (e.g.
-    `bar_chart`, `save_skill_bundle`, `delete_skill_bundle`). Tools belong to MCPs; capabilities
-    aggregate them.
+    `mcp__charts__bar_chart`, `mcp__skills__save_skill_bundle`,
+    `mcp__skills__delete_skill_bundle`). Tools belong to MCPs;
+    capabilities aggregate them.
 
 ## Workflows
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -31,7 +31,7 @@ Reference workflows in the repository root:
 - [ ] README matches current product behavior
 - [ ] config docs match `open-cowork.config.json`
 - [ ] packaging and release docs match the workflows
-- [ ] `docs/architecture.md` OpenCode SDK versions match `apps/desktop/package.json`
+- [ ] `docs/architecture.md` OpenCode SDK policy points to `apps/desktop/package.json` and `pnpm-lock.yaml`
 - [ ] `SECURITY.md` and `SUPPORT.md` are current
 - [ ] medium-severity `pnpm audit --prod` output has been reviewed manually if CI stayed green
 

--- a/docs/skills-and-mcps.md
+++ b/docs/skills-and-mcps.md
@@ -24,6 +24,10 @@ nearly every non-trivial capability in the desktop app.</p>
 ## What ships in the box
 
 Five bundled MCPs and six bundled skills, used as worked examples below.
+When an agent calls a bundled MCP tool through OpenCode, the runtime tool id
+uses `mcp__<server>__<tool>` form, for example
+`mcp__charts__bar_chart`. Source MCP code and tests may still refer to the
+short tool name such as `bar_chart`.
 
 <div class="grid cards" markdown>
 
@@ -32,25 +36,29 @@ Five bundled MCPs and six bundled skills, used as worked examples below.
     ---
 
     Renders Vega-Lite charts and Mermaid diagrams entirely inside the main
-    process. 18+ chart tools (`bar_chart`, `line_chart`, `sankey`,
-    `mermaid`, `custom_spec`, …). Source: `mcps/charts/src/index.ts`.
+    process. 18+ chart tools; runtime ids include
+    `mcp__charts__bar_chart`, `mcp__charts__line_chart`,
+    `mcp__charts__sankey`, `mcp__charts__mermaid`, and
+    `mcp__charts__custom_spec`. Source: `mcps/charts/src/index.ts`.
 
 -   :material-clock-outline: **`clock` MCP** <span class="status-badge stable">stable</span>
 
     ---
 
     Resolves current time, timezone conversions, date ranges, durations,
-    and calendar math without network or filesystem access. Tools:
-    `current_time`, `convert_time`, `date_math`, `date_range`,
-    `duration_between`. Source: `mcps/clock/src/index.ts`.
+    and calendar math without network or filesystem access. Runtime ids
+    include `mcp__clock__current_time`, `mcp__clock__convert_time`,
+    `mcp__clock__date_math`, `mcp__clock__date_range`, and
+    `mcp__clock__duration_between`. Source: `mcps/clock/src/index.ts`.
 
 -   :material-package-variant: **`skills` MCP** <span class="status-badge stable">stable</span>
 
     ---
 
     Lets agents enumerate, read, write, and delete skill bundles from chat.
-    Tools: `list_skill_bundles`, `get_skill_bundle`, `save_skill_bundle`,
-    `delete_skill_bundle`.
+    Runtime ids include `mcp__skills__list_skill_bundles`,
+    `mcp__skills__get_skill_bundle`, `mcp__skills__save_skill_bundle`,
+    and `mcp__skills__delete_skill_bundle`.
     Source: `mcps/skills/src/index.ts`.
 
 -   :material-account-cog: **`agents` MCP** <span class="status-badge stable">stable</span>
@@ -58,17 +66,19 @@ Five bundled MCPs and six bundled skills, used as worked examples below.
     ---
 
     Lets approved agents preview, read, save, and delete custom OpenCode
-    agents through the same validation path as the desktop UI. Tools:
-    `list_agents`, `get_agent`, `preview_agent`, `save_agent`,
-    `delete_agent`. Source: `mcps/agents/src/index.ts`.
+    agents through the same validation path as the desktop UI. Runtime ids
+    include `mcp__agents__list_agents`, `mcp__agents__get_agent`,
+    `mcp__agents__preview_agent`, `mcp__agents__save_agent`, and
+    `mcp__agents__delete_agent`. Source: `mcps/agents/src/index.ts`.
 
 -   :material-calendar-sync: **`workflows` MCP** <span class="status-badge stable">stable</span>
 
     ---
 
     Lets a Workflow Designer setup thread preview and save repeatable Open Cowork
-    workflows with manual, scheduled, or webhook triggers. Tools:
-    `preview_workflow`, `create_workflow`. Source:
+    workflows with manual, scheduled, or webhook triggers. Runtime ids:
+    `mcp__workflows__preview_workflow` and
+    `mcp__workflows__create_workflow`. Source:
     `mcps/workflows/src/index.ts`.
 
 -   :material-school: **`chart-creator` skill** <span class="status-badge stable">stable</span>

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -25,10 +25,10 @@ There is no separate workflow runtime, inbox board, or hidden task engine.
 4. You describe the repeatable task in plain language.
 5. Workflow Designer asks follow-up questions until the task, tools, skills,
    agent, and triggers are clear.
-6. Workflow Designer calls the bundled `workflows.preview_workflow` tool and
-   shows the proposed workflow.
+6. Workflow Designer calls the bundled `mcp__workflows__preview_workflow`
+   tool and shows the proposed workflow.
 7. After you explicitly confirm, Workflow Designer calls
-   `workflows.create_workflow`.
+   `mcp__workflows__create_workflow`.
 
 The saved workflow points back to that setup thread so you can reopen the
 conversation that created it.

--- a/packages/shared/src/capabilities.ts
+++ b/packages/shared/src/capabilities.ts
@@ -57,7 +57,7 @@ export interface CapabilitySkill {
   agentNames: string[]
 }
 
-export interface CapabilitySkillBundleFile {
+interface CapabilitySkillBundleFile {
   path: string
 }
 
@@ -73,7 +73,7 @@ export interface CapabilitySkillBundle {
 
 export type CapabilityRiskLevel = 'low' | 'medium' | 'high'
 
-export interface CoworkSchemaVersionedRecord {
+interface CoworkSchemaVersionedRecord {
   schemaVersion: number
 }
 
@@ -86,10 +86,10 @@ export interface CapabilityRiskMetadata extends CoworkSchemaVersionedRecord {
   reason: string
 }
 
-export type CapabilityRelationshipNodeKind = 'tool' | 'skill' | 'mcp' | 'agent' | 'workflow'
-export type CapabilityRelationshipEdgeKind = 'uses' | 'requires' | 'inherits' | 'exposes'
-export type CapabilityAccessPolicyState = 'allowed' | 'denied' | 'inherited' | 'unknown' | 'credential_missing'
-export type CapabilityCredentialHealthState = 'ready' | 'missing' | 'disabled' | 'not_required' | 'unknown'
+type CapabilityRelationshipNodeKind = 'tool' | 'skill' | 'mcp' | 'agent' | 'workflow'
+type CapabilityRelationshipEdgeKind = 'uses' | 'requires' | 'inherits' | 'exposes'
+type CapabilityAccessPolicyState = 'allowed' | 'denied' | 'inherited' | 'unknown' | 'credential_missing'
+type CapabilityCredentialHealthState = 'ready' | 'missing' | 'disabled' | 'not_required' | 'unknown'
 
 export interface CapabilityConsumer extends CoworkSchemaVersionedRecord {
   id: string

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -14,7 +14,7 @@ export interface McpStatus {
   error?: string
 }
 
-export const MCP_AUTH_REQUIRED_STATUSES = [
+const MCP_AUTH_REQUIRED_STATUSES = [
   'needs_auth',
   'needs_client_registration',
   'auth_required',

--- a/packages/shared/src/explorer.ts
+++ b/packages/shared/src/explorer.ts
@@ -26,7 +26,7 @@ export interface FileStatus {
   status: 'added' | 'deleted' | 'modified'
 }
 
-export interface ExplorerRangePos {
+interface ExplorerRangePos {
   line: number
   col: number
 }

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -1,12 +1,12 @@
-export type CredentialFieldType = 'text' | 'select' | 'radio'
+type CredentialFieldType = 'text' | 'select' | 'radio'
 
-export interface CredentialFieldOption {
+interface CredentialFieldOption {
   label: string
   value: string
   hint?: string
 }
 
-export interface CredentialFieldCondition {
+interface CredentialFieldCondition {
   key: string
   op: 'eq' | 'neq'
   value: string

--- a/packages/shared/src/threads.ts
+++ b/packages/shared/src/threads.ts
@@ -52,7 +52,7 @@ export interface ThreadCategorySuggestion {
   updatedAt: string
 }
 
-export interface ThreadUsageSummary {
+interface ThreadUsageSummary {
   messages: number
   toolCalls: number
   taskRuns: number

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -159,7 +159,7 @@ function lintFile(fullPath) {
 }
 
 visit(root)
-validateArchitectureSdkVersions()
+validateArchitectureSdkVersionPolicy()
 
 if (errors.length) {
   console.error('Lint failed:\n' + errors.map((entry) => `- ${entry}`).join('\n'))
@@ -195,7 +195,7 @@ function isLegacyNamingAllowed(relPath) {
     || legacyNamingAllowlistPatterns.some((pattern) => pattern.test(relPath))
 }
 
-function validateArchitectureSdkVersions() {
+function validateArchitectureSdkVersionPolicy() {
   try {
     const desktopPackage = JSON.parse(readFileSync(join(root, 'apps/desktop/package.json'), 'utf8'))
     const runtimeVersion = desktopPackage.dependencies?.['opencode-ai']
@@ -206,14 +206,13 @@ function validateArchitectureSdkVersions() {
       errors.push('apps/desktop/package.json: missing explicit opencode-ai / @opencode-ai/sdk dependency pins')
       return
     }
-    if (!architecture.includes(`opencode-ai: ${runtimeVersion}`)) {
-      errors.push(`docs/architecture.md: opencode-ai version does not match apps/desktop/package.json (${runtimeVersion})`)
-    }
-    if (!architecture.includes(`@opencode-ai/sdk: ${sdkVersion}`)) {
-      errors.push(`docs/architecture.md: @opencode-ai/sdk version does not match apps/desktop/package.json (${sdkVersion})`)
+    for (const requiredText of ['opencode-ai', '@opencode-ai/sdk', 'apps/desktop/package.json', 'pnpm-lock.yaml']) {
+      if (!architecture.includes(requiredText)) {
+        errors.push(`docs/architecture.md: OpenCode SDK version policy must reference ${requiredText}`)
+      }
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    errors.push(`docs/architecture.md: unable to verify OpenCode SDK versions: ${message}`)
+    errors.push(`docs/architecture.md: unable to verify OpenCode SDK version policy: ${message}`)
   }
 }

--- a/skills/agent-creator/SKILL.md
+++ b/skills/agent-creator/SKILL.md
@@ -38,10 +38,10 @@ Use this skill when a user wants to create or update a custom OpenCode agent in 
    - include stop/ask conditions for missing context
    - avoid broad rules that duplicate the main Build agent
 5. Use the Agents MCP:
-   - `list_agents` and `get_agent` before updating an existing custom agent
-   - `preview_agent` before saving any new or changed agent
-   - `save_agent` only after the user explicitly confirms the preview
-   - `delete_agent` only after explicit deletion confirmation
+   - `mcp__agents__list_agents` and `mcp__agents__get_agent` before updating an existing custom agent
+   - `mcp__agents__preview_agent` before saving any new or changed agent
+   - `mcp__agents__save_agent` only after the user explicitly confirms the preview
+   - `mcp__agents__delete_agent` only after explicit deletion confirmation
 
 ## Guardrails
 

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -45,7 +45,7 @@ When optimizing an installed Open Cowork custom skill:
 2. Copy `SKILL.md` and supporting files into the run directory.
 3. Mutate the working copy during experiments.
 4. Do not overwrite the installed custom skill during the loop.
-5. At the end, ask for or rely on the approval prompt for `save_skill_bundle` before applying the final version.
+5. At the end, ask for or rely on the approval prompt for `mcp__skills__save_skill_bundle` before applying the final version.
 
 If a newly saved custom skill is not visible to the native skill loader in the same session, continue evaluating candidates from the working copy content and tell the user that a new thread or runtime refresh may be needed for normal invocation.
 
@@ -67,7 +67,7 @@ When optimizing an installed Open Cowork custom agent:
 3. Mutate only the working copy during experiments.
 4. Do not overwrite the installed custom agent during the loop.
 5. Evaluate by using the user-provided verification command, binary eval protocol, or OpenCode-native task delegation target.
-6. At the end, call `preview_agent`, show the proposed final agent clearly, and use `save_agent` only after approval.
+6. At the end, call `mcp__agents__preview_agent`, show the proposed final agent clearly, and use `mcp__agents__save_agent` only after approval.
 
 If a newly saved custom agent is not visible to the native agent loader in the same session, continue evaluating candidates from the working copy content and tell the user that a runtime refresh or new thread may be needed for normal delegation.
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -36,9 +36,9 @@ Use this skill when a user wants to create or update an OpenCode skill for Open 
    - `templates/*` for reusable output scaffolds
    - avoid extra files if the skill is simple enough to live in `SKILL.md`
 5. Use the `skills` MCP tools to save the bundle:
-   - `get_skill_bundle` before editing an existing skill
-   - `save_skill_bundle` to create or update the bundle
-   - `list_skill_bundles` to inspect what already exists
+   - `mcp__skills__get_skill_bundle` before editing an existing skill
+   - `mcp__skills__save_skill_bundle` to create or update the bundle
+   - `mcp__skills__list_skill_bundles` to inspect what already exists
 6. Summarize what was created:
    - skill id
    - main purpose


### PR DESCRIPTION
## Summary

- Removes the obsolete pre-workflow `automation.sqlite` backup path from workflow store initialization.
- Reuses the shared custom MCP permission mode type in the renderer and narrows internal-only shared helper types so they are not exported as public API.
- Standardizes docs and bundled skills on OpenCode runtime MCP tool IDs such as `mcp__workflows__preview_workflow`.
- Replaces hardcoded OpenCode SDK version prose with manifest/lockfile source-of-truth language and updates the repo lint/release checklist policy accordingly.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:dead-code`
- `pnpm test`
- `uv run mkdocs build --strict`
- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/workflow-store.test.ts tests/workflow-runtime.test.ts tests/config-elements.test.ts`
- `git diff --check`