### PR TITLE
Harden audit action item coverage

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -11,7 +11,7 @@ events.
 Key paths:
 
 - `src/main/` — Electron main process, OpenCode runtime composition, IPC
-  handlers, storage, auth, automation control plane
+  handlers, storage, auth, workflow control plane
 - `src/preload/` — typed `window.coworkApi` bridge
 - `src/renderer/` — React renderer and app UI
 - `runtime-config/` — generated runtime instructions and runtime-facing

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,7 +27,8 @@
     "dist": "node ../../scripts/desktop-dist.mjs",
     "dist:ci": "node ../../scripts/desktop-dist.mjs --mac zip --x64 --arm64 --publish never",
     "dist:ci:mac": "node ../../scripts/desktop-dist.mjs --mac zip dmg --x64 --arm64 --publish never",
-    "dist:ci:linux": "node ../../scripts/desktop-dist.mjs --linux AppImage deb --x64 --publish never"
+    "dist:ci:linux": "node ../../scripts/desktop-dist.mjs --linux AppImage deb --x64 --publish never",
+    "security": "pnpm audit --prod --audit-level high"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/apps/desktop/src/main/custom-agents-utils.ts
+++ b/apps/desktop/src/main/custom-agents-utils.ts
@@ -9,12 +9,10 @@ import {
   type ConfiguredSkill,
   type ConfiguredTool,
 } from './config-loader.ts'
-import { validateCustomAgentDraft } from '@open-cowork/shared'
+import { validateCustomAgentDraft, type AgentColor, type CustomAgentIssue } from '@open-cowork/shared'
 import type { NativeConfigScope } from './runtime-paths.ts'
 import { humanizeToolId, nativeToolPermissionPatterns, nativeToolSupportsWrite } from './runtime-tools.ts'
 import { validateCustomAgentContentLimits } from './custom-content-limits.ts'
-
-export type AgentColor = 'primary' | 'warning' | 'accent' | 'success' | 'info' | 'secondary'
 
 export type CustomSkillLike = {
   name: string
@@ -61,11 +59,6 @@ export type CustomAgentCatalogState = {
   customSkills: CustomSkillLike[]
   customAgents: CustomAgentLike[]
   [key: string]: unknown
-}
-
-export type CustomAgentIssue = {
-  code: string
-  message: string
 }
 
 export type CustomAgentCatalogTool = {

--- a/apps/desktop/src/main/custom-agents.ts
+++ b/apps/desktop/src/main/custom-agents.ts
@@ -1,5 +1,5 @@
 import { getConfiguredSkillsFromConfig, getConfiguredToolsFromConfig } from './config-loader.ts'
-import type { RuntimeContextOptions } from '@open-cowork/shared'
+import type { CustomAgentIssue, RuntimeContextOptions } from '@open-cowork/shared'
 import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
 import { listEffectiveSkills } from './effective-skills.ts'
 import { listRuntimeToolsForContext, toRuntimeToolMetadata } from './runtime-tools.ts'
@@ -12,7 +12,6 @@ import {
   CUSTOM_AGENT_COLORS,
   RESERVED_AGENT_NAMES,
   type CustomAgentCatalog,
-  type CustomAgentIssue,
   type CustomAgentSummary,
   type RuntimeCustomAgent,
   type CustomAgentCatalogState,

--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -1,6 +1,5 @@
 import type { BrowserWindow } from 'electron'
 import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
-import { dispatchRuntimeSessionEvent } from './session-event-dispatcher.ts'
 import {
   normalizeMessagePart,
   normalizeSessionInfo,
@@ -10,15 +9,14 @@ import { resolveDisplayCost } from './pricing.ts'
 import {
   ensureTaskRunForChild,
   findFallbackTaskRun,
-  getImmediateParentSession,
   getTaskRunIdForChild,
   registerSession,
   registerTaskRun,
   resolveRootSession,
-  type TaskRunMeta,
   updateTaskRun,
   consumePendingPromptEcho,
 } from './event-task-state.ts'
+import { emitTaskRun } from './event-task-run-dispatch.ts'
 import {
   chooseTaskTitle,
   extractAgentName,
@@ -279,27 +277,6 @@ function dispatchReasoningPatch(
       sourceSessionId: input.actualSessionId,
       messageId: input.messageId,
       partId: input.partId,
-    },
-  })
-}
-
-function emitTaskRun(win: BrowserWindow, taskRun: TaskRunMeta) {
-  const parentSessionId = taskRun.childSessionId
-    ? getImmediateParentSession(taskRun.childSessionId)
-    : taskRun.parentSessionId
-  dispatchRuntimeSessionEvent(win, {
-    type: 'task_run',
-    sessionId: taskRun.rootSessionId,
-    data: {
-      type: 'task_run',
-      id: taskRun.id,
-      title: taskRun.title,
-      agent: taskRun.agent,
-      status: taskRun.status,
-      sourceSessionId: taskRun.childSessionId,
-      parentSessionId,
-      startedAt: taskRun.startedAt ?? null,
-      finishedAt: taskRun.finishedAt ?? null,
     },
   })
 }

--- a/apps/desktop/src/main/event-runtime-handlers.ts
+++ b/apps/desktop/src/main/event-runtime-handlers.ts
@@ -17,7 +17,7 @@ import {
   readRuntimeSessionId,
 } from './runtime-event-normalizers.ts'
 import type { RuntimeSessionEvent } from './session-event-dispatcher.ts'
-import { dispatchRuntimeSessionEvent, dropSessionFromDispatcherQueues } from './session-event-dispatcher.ts'
+import { dropSessionFromDispatcherQueues } from './session-event-dispatcher.ts'
 import { shortSessionId } from './log-sanitizer.ts'
 import { touchSessionRecord, updateSessionRecord } from './session-registry.ts'
 import { sessionEngine } from './session-engine.ts'
@@ -29,7 +29,6 @@ import {
 import {
   ensureTaskRunForChild,
   forgetSubmittedPrompt,
-  getImmediateParentSession,
   getTaskRun,
   getTaskRunIdForChild,
   isTrackedParentSession,
@@ -40,8 +39,8 @@ import {
   resolveRootSession,
   untrackParentSession,
   updateTaskRun,
-  type TaskRunMeta,
 } from './event-task-state.ts'
+import { emitTaskRun } from './event-task-run-dispatch.ts'
 import {
   chooseTaskTitle,
   extractAgentName,
@@ -56,31 +55,6 @@ function runRuntimeSideEffect(scope: string, task: () => void | Promise<unknown>
   void Promise.resolve().then(task).catch((err) => {
     const message = err instanceof Error ? err.message : String(err)
     log('error', `${scope} failed: ${message}`)
-  })
-}
-
-function emitTaskRun(win: BrowserWindow, taskRun: TaskRunMeta) {
-  // Thread the immediate parent session so the renderer can reconstruct
-  // a two-level tree (root task → sub-sub-agent spawned by one of the
-  // root's tasks). The child session's lineage was registered in the
-  // `session.created` handler via `registerSession(sessionId, parentID)`.
-  const parentSessionId = taskRun.childSessionId
-    ? getImmediateParentSession(taskRun.childSessionId)
-    : taskRun.parentSessionId
-  dispatchRuntimeSessionEvent(win, {
-    type: 'task_run',
-    sessionId: taskRun.rootSessionId,
-    data: {
-      type: 'task_run',
-      id: taskRun.id,
-      title: taskRun.title,
-      agent: taskRun.agent,
-      status: taskRun.status,
-      sourceSessionId: taskRun.childSessionId,
-      parentSessionId,
-      startedAt: taskRun.startedAt ?? null,
-      finishedAt: taskRun.finishedAt ?? null,
-    },
   })
 }
 

--- a/apps/desktop/src/main/event-task-run-dispatch.ts
+++ b/apps/desktop/src/main/event-task-run-dispatch.ts
@@ -1,0 +1,26 @@
+import type { BrowserWindow } from 'electron'
+import { getImmediateParentSession, type TaskRunMeta } from './event-task-state.ts'
+import { dispatchRuntimeSessionEvent } from './session-event-dispatcher.ts'
+
+export function emitTaskRun(win: BrowserWindow, taskRun: TaskRunMeta) {
+  // Thread the immediate parent session so the renderer can reconstruct
+  // nested delegation without guessing from task titles.
+  const parentSessionId = taskRun.childSessionId
+    ? getImmediateParentSession(taskRun.childSessionId)
+    : taskRun.parentSessionId
+  dispatchRuntimeSessionEvent(win, {
+    type: 'task_run',
+    sessionId: taskRun.rootSessionId,
+    data: {
+      type: 'task_run',
+      id: taskRun.id,
+      title: taskRun.title,
+      agent: taskRun.agent,
+      status: taskRun.status,
+      sourceSessionId: taskRun.childSessionId,
+      parentSessionId,
+      startedAt: taskRun.startedAt ?? null,
+      finishedAt: taskRun.finishedAt ?? null,
+    },
+  })
+}

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -34,6 +34,7 @@ import { registerCustomContentHandlers } from './ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from './ipc/explorer-handlers.ts'
 import { registerThreadHandlers } from './ipc/thread-handlers.ts'
 import type { IpcHandlerContext } from './ipc/context.ts'
+import { objectArg, registerIpcInvoke } from './ipc/schema.ts'
 import { clearPermissionsForSession, trackPermission } from './permission-tracker.ts'
 import { ProjectDirectoryGrantRegistry, trustedRecordDirectoryMatches } from './directory-grants.ts'
 import { isTrustedRendererIpcUrl } from './main-window-lifecycle.ts'
@@ -346,7 +347,7 @@ export function setupIpcHandlers(
     capabilityToolMethodCache,
   }
 
-  instrumentedIpcMain.handle('confirm:request-destructive', async (_event, request: DestructiveConfirmationRequest) => {
+  registerIpcInvoke(context, 'confirm:request-destructive', objectArg<DestructiveConfirmationRequest>('destructive confirmation request'), async (_event, request) => {
     const confirmed = await showNativeConfirmation(getMainWindow(), destructiveConfirmationPrompt(request))
     if (!confirmed) {
       log('audit', `confirmation.cancelled ${request.action} ${describeDestructiveRequest(request)}`)

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -340,7 +340,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('chart:render-svg', async (_event, spec: Record<string, unknown>) => {
+  registerIpcInvoke(context, 'chart:render-svg', objectArg<Record<string, unknown>>('chart specification'), async (_event, spec) => {
     return renderChartSpecToSvg(spec)
   })
 

--- a/apps/desktop/src/main/ipc/catalog-handlers.ts
+++ b/apps/desktop/src/main/ipc/catalog-handlers.ts
@@ -1,5 +1,6 @@
 import type { RuntimeAgentDescriptor, RuntimeContextOptions, ScopedArtifactRef, ToolListOptions, CustomAgentConfig } from '@open-cowork/shared'
 import type { IpcHandlerContext } from './context.ts'
+import { optionalObjectArg, registerIpcInvoke, stringArg } from './schema.ts'
 import { getClient } from '../runtime.ts'
 import { invalidateRuntimeToolCache } from '../runtime-tool-cache.ts'
 import { listBuiltInAgentDetails } from '../built-in-agent-details.ts'
@@ -186,7 +187,7 @@ export async function authenticateMcpThroughRuntime(client: {
 }
 
 export function registerCatalogHandlers(context: IpcHandlerContext) {
-  context.ipcMain.handle('tool:list', async (_event, options?: ToolListOptions) => {
+  registerIpcInvoke(context, 'tool:list', optionalObjectArg<ToolListOptions>('tool list options'), async (_event, options) => {
     return context.listRuntimeTools(options)
   })
 
@@ -195,7 +196,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   // runtime-tool cache so the Capabilities UI doesn't keep rendering
   // the pre-transition tool list for up to 30s — the user clicks
   // "Authenticate" and immediately expects the new tools to show.
-  context.ipcMain.handle('mcp:auth', async (_event, mcpName: string) => {
+  registerIpcInvoke(context, 'mcp:auth', stringArg('MCP name'), async (_event, mcpName) => {
     return runMcpTransitionForName(mcpName, async () => {
       const client = getClient()
       if (!client) throw new Error('Runtime not started')
@@ -212,7 +213,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     })
   })
 
-  context.ipcMain.handle('mcp:connect', async (_event, name: string) => {
+  registerIpcInvoke(context, 'mcp:connect', stringArg('MCP name'), async (_event, name) => {
     return runMcpTransitionForName(name, async () => {
       const client = getClient()
       if (!client) throw new Error('Runtime not started')
@@ -228,7 +229,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     })
   })
 
-  context.ipcMain.handle('mcp:disconnect', async (_event, name: string) => {
+  registerIpcInvoke(context, 'mcp:disconnect', stringArg('MCP name'), async (_event, name) => {
     return runMcpTransitionForName(name, async () => {
       const client = getClient()
       if (!client) throw new Error('Runtime not started')

--- a/apps/desktop/src/main/ipc/schema.ts
+++ b/apps/desktop/src/main/ipc/schema.ts
@@ -67,6 +67,16 @@ export function objectArg<T extends object>(label: string) {
   })
 }
 
+export function optionalObjectArg<T extends object>(label: string) {
+  return createIpcArgsSchema<[T | undefined]>((channel, args) => {
+    if (args.length > 1) {
+      throw new Error(`${channel} accepts at most one argument.`)
+    }
+    if (args[0] === undefined || args[0] === null) return [undefined]
+    return [normalizeObjectArg<T>(channel, label, args[0])]
+  })
+}
+
 export function stringAndObjectArgs<T extends object>(
   stringLabel: string,
   objectLabel: string,

--- a/apps/desktop/src/main/ipc/thread-handlers.ts
+++ b/apps/desktop/src/main/ipc/thread-handlers.ts
@@ -1,6 +1,13 @@
 import type { IpcHandlerContext } from './context.ts'
 import { getThreadIndexService } from '../thread-index-service.ts'
-import { THREAD_BULK_MAX_SESSION_IDS, THREAD_FILTER_MAX_VALUES } from '@open-cowork/shared'
+import {
+  THREAD_BULK_MAX_SESSION_IDS,
+  THREAD_FILTER_MAX_VALUES,
+  type ThreadSearchQuery,
+  type ThreadSmartFilterInput,
+  type ThreadTagInput,
+} from '@open-cowork/shared'
+import { objectArg, optionalObjectArg, registerIpcInvoke, stringAndObjectArgs } from './schema.ts'
 
 function requireStringArray(value: unknown, label: string, max = THREAD_BULK_MAX_SESSION_IDS) {
   if (!Array.isArray(value)) throw new Error(`${label} must be an array.`)
@@ -16,20 +23,20 @@ function requireStringArray(value: unknown, label: string, max = THREAD_BULK_MAX
 export function registerThreadHandlers(context: IpcHandlerContext) {
   const threads = () => getThreadIndexService()
 
-  context.ipcMain.handle('threads:search', async (_event, query?: unknown) => (
-    threads().search(query as never)
+  registerIpcInvoke(context, 'threads:search', optionalObjectArg<ThreadSearchQuery>('thread search query'), async (_event, query) => (
+    threads().search(query)
   ))
 
-  context.ipcMain.handle('threads:facets', async (_event, query?: unknown) => (
-    threads().facets(query as never)
+  registerIpcInvoke(context, 'threads:facets', optionalObjectArg<ThreadSearchQuery>('thread facet query'), async (_event, query) => (
+    threads().facets(query)
   ))
 
   context.ipcMain.handle('threads:tags:list', async () => (
     threads().listTags()
   ))
 
-  context.ipcMain.handle('threads:tags:create', async (_event, input: unknown) => (
-    threads().createTag(input as never)
+  registerIpcInvoke(context, 'threads:tags:create', objectArg<ThreadTagInput>('thread tag input'), async (_event, input) => (
+    threads().createTag(input)
   ))
 
   context.ipcMain.handle('threads:tags:update', async (_event, tagId: unknown, input: unknown) => {
@@ -58,14 +65,13 @@ export function registerThreadHandlers(context: IpcHandlerContext) {
     threads().listSmartFilters()
   ))
 
-  context.ipcMain.handle('threads:smart-filters:create', async (_event, input: unknown) => (
-    threads().createSmartFilter(input as never)
+  registerIpcInvoke(context, 'threads:smart-filters:create', objectArg<ThreadSmartFilterInput>('smart filter input'), async (_event, input) => (
+    threads().createSmartFilter(input)
   ))
 
-  context.ipcMain.handle('threads:smart-filters:update', async (_event, filterId: unknown, input: unknown) => {
-    if (typeof filterId !== 'string') throw new Error('Smart filter id must be a string.')
-    return threads().updateSmartFilter(filterId, input as never)
-  })
+  registerIpcInvoke(context, 'threads:smart-filters:update', stringAndObjectArgs<ThreadSmartFilterInput>('smart filter id', 'smart filter input'), async (_event, filterId, input) => (
+    threads().updateSmartFilter(filterId, input)
+  ))
 
   context.ipcMain.handle('threads:smart-filters:delete', async (_event, filterId: unknown) => {
     if (typeof filterId !== 'string') throw new Error('Smart filter id must be a string.')

--- a/apps/desktop/src/main/pricing-core.ts
+++ b/apps/desktop/src/main/pricing-core.ts
@@ -1,11 +1,5 @@
+import type { ModelPricing } from '@open-cowork/shared'
 import { getMeaningfulSdkPricing, normalizeModelId, resolveMeaningfulCost } from './pricing-utils.ts'
-
-export interface ModelPricing {
-  inputPer1M: number
-  outputPer1M: number
-  cachePer1M?: number
-  cacheWritePer1M?: number
-}
 
 function resolvePricing(
   modelId: string,

--- a/apps/desktop/src/main/pricing.ts
+++ b/apps/desktop/src/main/pricing.ts
@@ -1,5 +1,6 @@
+import type { ModelPricing } from '@open-cowork/shared'
 import { getModelInfo } from './runtime.ts'
-import { resolveDisplayCostForModel, type ModelPricing } from './pricing-core.ts'
+import { resolveDisplayCostForModel } from './pricing-core.ts'
 
 export function resolveDisplayCost(
   modelId: string,

--- a/apps/desktop/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.tsx
@@ -50,6 +50,7 @@ export function ChatInput() {
   const inputChromeRef = useRef<HTMLDivElement>(null)
   const inlinePickerRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const focusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const modelBtnRef = useRef<HTMLButtonElement>(null)
   const reasoningBtnRef = useRef<HTMLButtonElement>(null)
   const currentSessionId = useSessionStore((s) => s.currentSessionId)
@@ -154,8 +155,18 @@ export function ChatInput() {
 
   // Autofocus textarea when session changes
   useEffect(() => {
+    if (focusTimerRef.current) clearTimeout(focusTimerRef.current)
     if (currentSessionId && textareaRef.current) {
-      setTimeout(() => textareaRef.current?.focus(), 100)
+      focusTimerRef.current = setTimeout(() => {
+        focusTimerRef.current = null
+        textareaRef.current?.focus()
+      }, 100)
+    }
+    return () => {
+      if (focusTimerRef.current) {
+        clearTimeout(focusTimerRef.current)
+        focusTimerRef.current = null
+      }
     }
   }, [currentSessionId])
 

--- a/apps/desktop/src/renderer/components/chat/DiffViewerRowBlocks.tsx
+++ b/apps/desktop/src/renderer/components/chat/DiffViewerRowBlocks.tsx
@@ -16,7 +16,7 @@ function keyFragment(value: string) {
   return `${value.length}:${value.slice(0, 64)}:${value.slice(-64)}`
 }
 
-export function diffRowKey(row: DiffRow) {
+function diffRowKey(row: DiffRow) {
   return `${row.kind}:${row.oldLine ?? '-'}:${row.newLine ?? '-'}:${keyFragment(row.content)}`
 }
 

--- a/apps/desktop/src/renderer/components/chat/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownContent.tsx
@@ -151,6 +151,7 @@ export function MarkdownContent({
   streaming?: boolean
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const copyResetTimersRef = useRef(new Set<number>())
   const html = useMemo(() => renderHtml(text, streaming), [text, streaming])
 
   useLayoutEffect(() => {
@@ -198,14 +199,18 @@ export function MarkdownContent({
       const copied = await writeTextToClipboard(content)
       if (!copied) return
       setCopyButtonState(button, true)
-      window.setTimeout(() => {
+      const timer = window.setTimeout(() => {
+        copyResetTimersRef.current.delete(timer)
         setCopyButtonState(button, false)
       }, 2000)
+      copyResetTimersRef.current.add(timer)
     }
 
     container.addEventListener('click', handleClick)
     return () => {
       container.removeEventListener('click', handleClick)
+      for (const timer of copyResetTimersRef.current) window.clearTimeout(timer)
+      copyResetTimersRef.current.clear()
     }
   }, [])
 

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ProviderAuthAuthorization, ProviderAuthMethod, ProviderAuthPrompt } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 
@@ -38,6 +38,10 @@ export function ProviderAuthControls({
   onBeforeAuthorize,
   onAuthUpdated,
 }: Props) {
+  const pollDelayTimersRef = useRef(new Set<{
+    id: ReturnType<typeof setTimeout>
+    resolve: (completed: boolean) => void
+  }>())
   const [methods, setMethods] = useState<ProviderAuthMethod[]>([])
   const [loading, setLoading] = useState(false)
   const [authorizing, setAuthorizing] = useState<number | null>(null)
@@ -46,6 +50,29 @@ export function ProviderAuthControls({
   const [pendingBrowserLogin, setPendingBrowserLogin] = useState(false)
   const [code, setCode] = useState('')
   const [methodInputs, setMethodInputs] = useState<Record<number, Record<string, string>>>({})
+
+  useEffect(() => () => {
+    for (const timer of pollDelayTimersRef.current) {
+      clearTimeout(timer.id)
+      timer.resolve(false)
+    }
+    pollDelayTimersRef.current.clear()
+  }, [])
+
+  const waitForProviderPoll = useCallback((ms: number) => new Promise<boolean>((resolve) => {
+    let timer!: {
+      id: ReturnType<typeof setTimeout>
+      resolve: (completed: boolean) => void
+    }
+    timer = {
+      id: setTimeout(() => {
+        pollDelayTimersRef.current.delete(timer)
+        resolve(true)
+      }, ms),
+      resolve,
+    }
+    pollDelayTimersRef.current.add(timer)
+  }), [])
 
   const loadMethods = useCallback(async () => {
     if (!providerId) return []
@@ -171,7 +198,7 @@ export function ProviderAuthControls({
         ))) {
           return true
         }
-        await new Promise((resolve) => setTimeout(resolve, 1_000))
+        if (!await waitForProviderPoll(1_000)) return false
       }
       return false
     }

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type {
   SandboxCleanupResult,
   SandboxStorageStats,
@@ -55,7 +55,20 @@ export function StoragePanel({
 }) {
   const [diagnosticsStatus, setDiagnosticsStatus] = useState<'idle' | 'working' | 'copied' | 'error'>('idle')
   const [resetting, setResetting] = useState(false)
+  const diagnosticsResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
+
+  useEffect(() => () => {
+    if (diagnosticsResetTimerRef.current) clearTimeout(diagnosticsResetTimerRef.current)
+  }, [])
+
+  const scheduleDiagnosticsIdle = () => {
+    if (diagnosticsResetTimerRef.current) clearTimeout(diagnosticsResetTimerRef.current)
+    diagnosticsResetTimerRef.current = setTimeout(() => {
+      diagnosticsResetTimerRef.current = null
+      setDiagnosticsStatus('idle')
+    }, 3_000)
+  }
 
   const handleResetAppData = async () => {
     const confirmation = await confirmAppReset()
@@ -83,12 +96,12 @@ export function StoragePanel({
       }
       const copied = await writeTextToClipboard(bundle)
       setDiagnosticsStatus(copied ? 'copied' : 'error')
-      setTimeout(() => setDiagnosticsStatus('idle'), 3_000)
+      scheduleDiagnosticsIdle()
     } catch (err) {
       addGlobalError(t('settings.storage.exportDiagnosticsFailed', 'Could not export diagnostics. Please try again.'))
       reportStorageError(err, 'Failed to export diagnostics')
       setDiagnosticsStatus('error')
-      setTimeout(() => setDiagnosticsStatus('idle'), 3_000)
+      scheduleDiagnosticsIdle()
     }
   }
 

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -33,6 +33,8 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   const menuRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const rowRefs = useRef(new Map<string, HTMLButtonElement>())
+  const closeMenuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const focusRowTimerRef = useRef<number | null>(null)
 
   const interactiveSessions = useMemo(
     () => sessions.filter((session) => (session.kind || 'interactive') === 'interactive'),
@@ -80,6 +82,11 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
     if (!menuId) return
     menuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus()
   }, [menuId])
+
+  useEffect(() => () => {
+    if (closeMenuTimerRef.current) clearTimeout(closeMenuTimerRef.current)
+    if (focusRowTimerRef.current) window.clearTimeout(focusRowTimerRef.current)
+  }, [])
 
   if (interactiveSessions.length === 0) {
     return <div className="px-2 py-3 text-[11px] text-text-muted text-center">{t('sidebar.noThreads', 'No threads yet')}</div>
@@ -138,7 +145,11 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   }
 
   const focusThreadRow = (sessionId: string) => {
-    window.setTimeout(() => rowRefs.current.get(sessionId)?.focus(), 0)
+    if (focusRowTimerRef.current) window.clearTimeout(focusRowTimerRef.current)
+    focusRowTimerRef.current = window.setTimeout(() => {
+      focusRowTimerRef.current = null
+      rowRefs.current.get(sessionId)?.focus()
+    }, 0)
   }
 
   const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -357,7 +368,11 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
               // Brief visual feedback
               const btn = document.activeElement as HTMLElement
               if (btn) btn.textContent = copied ? t('thread.linkCopied', 'Link copied!') : t('thread.linkCopyFailed', 'Copy failed')
-              setTimeout(() => setMenuId(null), 800)
+              if (closeMenuTimerRef.current) clearTimeout(closeMenuTimerRef.current)
+              closeMenuTimerRef.current = setTimeout(() => {
+                closeMenuTimerRef.current = null
+                setMenuId(null)
+              }, 800)
             } else {
               setMenuId(null)
             }

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
@@ -193,7 +193,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
               <p className="mt-2 max-w-md text-sm text-muted">
                 {workflowDraftBlocked
                   ? 'Workflow setup requires the in-app OpenCode config source because it uses Cowork’s Workflow Designer agent and Workflows tool.'
-                  : 'Start with a thread. The Plan agent will help clarify the task, tools, skills, agent, schedule, and webhook trigger before saving anything.'}
+                  : 'Start with a thread. The Workflow Designer agent will help clarify the task, tools, skills, agent, schedule, and webhook trigger before saving anything.'}
               </p>
               <button
                 type="button"

--- a/apps/desktop/src/renderer/helpers/format.ts
+++ b/apps/desktop/src/renderer/helpers/format.ts
@@ -1,7 +1,7 @@
 // Shared formatters for dollar amounts and token counts.
 //
 // Four different `formatCost` implementations used to live scattered
-// across HomePage / StatusBar / session-inspector-utils / task-card-utils
+// across HomePage / StatusBar / session-inspector-utils / agent-run-utils
 // with divergent behaviour for zero and sub-cent values — a cost pill
 // sitting on a delegated-task card would read `<$0.01` while the same
 // value in Home totals read `$0.00` and in the StatusBar it read

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -52,13 +52,6 @@ body {
 }
 
 .shadow-card { box-shadow: var(--shadow-card); }
-.shadow-elevated { box-shadow: var(--shadow-elevated); }
-
-/* Vibrancy / glass effects */
-.glass-panel {
-  backdrop-filter: blur(40px) saturate(180%);
-  -webkit-backdrop-filter: blur(40px) saturate(180%);
-}
 
 .theme-popover {
   background: color-mix(in srgb, var(--color-elevated) 88%, var(--color-base) 12%);
@@ -67,10 +60,6 @@ body {
     0 0 0 1px color-mix(in srgb, var(--color-base) 36%, transparent),
     0 10px 26px color-mix(in srgb, var(--color-base) 42%, transparent),
     0 24px 64px color-mix(in srgb, var(--color-base) 34%, transparent);
-}
-
-.theme-chrome {
-  background: color-mix(in srgb, var(--color-base) 90%, var(--color-elevated) 10%);
 }
 
 /* Remove default focus outlines — use custom focus styles where needed */
@@ -193,7 +182,6 @@ body {
 .prose hr { border: none; border-top: 1px solid var(--color-border); margin: 1em 0; }
 
 /* Inline code */
-.prose .inline-code,
 .prose code:not([class]) {
   background: color-mix(in srgb, var(--color-text) 8%, transparent);
   padding: 0.15em 0.4em;
@@ -205,7 +193,6 @@ body {
 }
 
 /* Code blocks */
-.prose .code-block,
 .prose pre {
   background: color-mix(in srgb, var(--color-base) 95%, var(--color-text) 5%);
   border: 1px solid var(--color-border-subtle);
@@ -216,8 +203,7 @@ body {
   font-size: 0.85em;
   line-height: 1.6;
 }
-.prose pre code,
-.prose .code-block code {
+.prose pre code {
   background: none !important;
   padding: 0 !important;
   border-radius: 0 !important;
@@ -316,12 +302,6 @@ body {
 .hljs-name { color: #7ee787; }
 
 /* Tables */
-.prose .table-wrap {
-  overflow-x: auto;
-  margin-bottom: 0.75em;
-  border-radius: 10px;
-  border: 1px solid var(--color-border-subtle);
-}
 .prose table {
   border-collapse: collapse;
   width: 100%;
@@ -352,29 +332,6 @@ body {
   margin-bottom: 0.6em;
 }
 .prose blockquote p:last-child { margin-bottom: 0; }
-
-/* Details / Summary (collapsible) */
-.prose .details-block {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: 10px;
-  margin-bottom: 0.75em;
-  overflow: hidden;
-}
-.prose .details-summary {
-  padding: 0.6em 1em;
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--color-text);
-  user-select: none;
-}
-.prose .details-summary:hover { background: var(--color-surface-hover); }
-.prose .details-block[open] .details-summary {
-  border-bottom: 1px solid var(--color-border-subtle);
-}
-.prose .details-block > *:not(summary) {
-  padding: 0.8em 1em;
-}
 
 /* Images */
 .prose img {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -303,7 +303,9 @@ Agents package:
 
 Built-in and custom agents compile into OpenCode-native agent definitions.
 The bundled Agents tool can create or update custom agents only; code-owned
-built-ins such as Build, Plan, and Autoresearch remain read-only product policy.
+built-ins such as Autoresearch remain read-only product policy, while the
+configurable built-ins documented in `builtInAgents` can be tuned by downstream
+configuration.
 
 ## Naming and storage namespaces
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -605,8 +605,8 @@ with `steps`.
 
 ### Overriding built-in agents
 
-The four Cowork built-ins (`build`, `plan`, `general`, `explore`) can be
-tuned or silenced via `builtInAgents`:
+The configurable Cowork built-ins (`build`, `plan`, `general`, `explore`)
+can be tuned or silenced via `builtInAgents`:
 
 ```json
 {
@@ -626,6 +626,9 @@ tuned or silenced via `builtInAgents`:
 `disable: true` removes the agent from the runtime entirely — it will
 no longer appear in the UI or accept delegations. Any inference field
 can be set independently; unset fields keep Cowork's defaults.
+
+Code-owned product agents, including Autoresearch, are intentionally not
+configured through `builtInAgents`; they remain read-only product policy.
 
 ### Agent starter templates
 

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -158,8 +158,9 @@ deliberate: Open Cowork does not implicitly pull arbitrary secrets from the
 host environment, so downstream configs have to opt each variable in.
 
 Provider credentials the user enters in the app's UI take a separate path
-(through `settings.json` and `provider.options.<runtimeKey>` in the built
-OpenCode config) and do not need to be listed in `allowedEnvPlaceholders`.
+(through the app settings store, `settings.enc` in production, and
+`provider.options.<runtimeKey>` in the built OpenCode config) and do not
+need to be listed in `allowedEnvPlaceholders`.
 
 ## Worked example
 

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -88,7 +88,7 @@ GitHub build provenance is attached to the release artifacts. With the
 GitHub CLI installed, verify an artifact against this repository:
 
 ```bash
-gh attestation verify ./Open-Cowork-0.0.0-arm64.dmg --repo joe-broadhead/open-cowork
+gh attestation verify ./Open-Cowork-<version>-arm64.dmg --repo joe-broadhead/open-cowork
 ```
 
 Replace the filename with the artifact you downloaded.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -64,7 +64,7 @@ Reference workflows in the repository root:
 - [ ] release assets still include `SHA256SUMS.txt`, `SHA256SUMS.txt.asc` when checksum signing is configured, `THIRD_PARTY_NOTICES.md`, `THIRD_PARTY_LICENSES/`, SBOMs, and provenance attestation
 - [ ] signed macOS releases include `latest-mac.yml`; unsigned preview releases do not include signed update feed metadata
 - [ ] for signed macOS releases, Settings reports in-app update installation as supported in the packaged smoke run
-- [ ] docs drift is acceptable for this release: the published Pages site tracks `master`, not immutable versioned docs; decide on versioned docs before v0.2.0
+- [ ] docs drift is acceptable for this release: through the `0.x` preview series, the published Pages site intentionally tracks `master` rather than immutable versioned docs
 - [ ] every `[Unreleased]` changelog bullet has been checked against the app before moving it into the tagged release section
 - [ ] `CHANGELOG.md`: rename the `[Unreleased]` heading to `[X.Y.Z] - YYYY-MM-DD` with the tag version (without the leading `v`) and tag date, then add a fresh empty `[Unreleased]` section above it for the next cycle
 - [ ] `CHANGELOG.md` release date equals the tag date

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -306,9 +306,9 @@ HMR origin to `connect-src`; packaged builds do not set
 `devServerUrl` and stay on the policy above. External images from
 agent, MCP, or markdown content are blocked by default to avoid turning
 message rendering into an HTTP beacon. Images should be attached as
-local artifacts or data/blob URLs until a user-controlled remote-image
-allowlist exists. There are two exceptions, both scoped to specific
-URLs:
+local artifacts or data/blob URLs; remote image fetching is not part of
+the default renderer trust model. There are two exceptions, both scoped to
+specific URLs:
 
 1. The chart iframe uses `buildChartFrameContentSecurityPolicy` (see
    above).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,6 @@ const nodeTsFiles = [
   'packages/**/*.ts',
   'mcps/**/*.ts',
   'scripts/**/*.ts',
-  'tests/**/*.ts',
 ]
 const jsFiles = ['**/*.js', '**/*.mjs']
 

--- a/mcps/agents/package.json
+++ b/mcps/agents/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
-    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts"
+    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
+    "security": "pnpm audit --prod --audit-level high"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcps/agents/tests/contract.test.ts
+++ b/mcps/agents/tests/contract.test.ts
@@ -42,6 +42,31 @@ async function withBridge<T>(fn: (baseUrl: string, seen: Array<{ url: string; bo
   }
 }
 
+async function withFailingBridge<T>(fn: (baseUrl: string) => Promise<T>) {
+  const server = createServer((req, res) => {
+    req.on('data', () => {})
+    req.on('end', () => {
+      assert.equal(req.headers.authorization, `Bearer ${contractToken}`)
+      res.statusCode = 500
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ error: 'bridge exploded' }))
+    })
+  })
+
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolvePromise())
+  })
+
+  const address = server.address()
+  assert.ok(address && typeof address === 'object')
+  try {
+    return await fn(`http://127.0.0.1:${address.port}`)
+  } finally {
+    await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()))
+  }
+}
+
 async function withAgentsClient<T>(baseUrl: string, fn: (client: Client) => Promise<T>) {
   const client = new Client({ name: 'agents-contract-test', version: '1.0.0' }, { capabilities: {} })
   const transport = new StdioClientTransport({
@@ -70,6 +95,16 @@ function parseTextResult(result: Awaited<ReturnType<Client['callTool']>>) {
   assert.equal(first?.type, 'text')
   assert.equal(typeof first.text, 'string')
   return JSON.parse(first.text) as Record<string, unknown>
+}
+
+async function assertToolError(client: Client, request: Parameters<Client['callTool']>[0], pattern: RegExp) {
+  try {
+    const result = await client.callTool(request)
+    assert.equal('isError' in result ? result.isError : false, true)
+    assert.match(JSON.stringify('content' in result ? result.content : result), pattern)
+  } catch (error) {
+    assert.match(error instanceof Error ? error.message : String(error), pattern)
+  }
 }
 
 const draft = {
@@ -103,5 +138,25 @@ test('agents MCP routes custom agent operations through the app bridge', async (
     })
     assert.deepEqual(seen.map((entry) => entry.url), ['/list', '/get', '/preview', '/save', '/delete'])
     assert.equal((seen[2]?.body as { name?: string }).name, 'weekly-analyst')
+  })
+})
+
+test('agents MCP rejects invalid drafts and surfaces bridge errors', async () => {
+  await withBridge(async (baseUrl) => {
+    await withAgentsClient(baseUrl, async (client) => {
+      await assertToolError(client, {
+        name: 'save_agent',
+        arguments: { name: 'missing-fields', scope: 'machine' },
+      }, /description|instructions/i)
+    })
+  })
+
+  await withFailingBridge(async (baseUrl) => {
+    await withAgentsClient(baseUrl, async (client) => {
+      await assertToolError(client, {
+        name: 'preview_agent',
+        arguments: draft,
+      }, /bridge exploded/)
+    })
   })
 })

--- a/mcps/charts/package.json
+++ b/mcps/charts/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
-    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts"
+    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
+    "security": "pnpm audit --prod --audit-level high"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcps/charts/src/chart-utils.ts
+++ b/mcps/charts/src/chart-utils.ts
@@ -124,7 +124,7 @@ export function getFieldValues(data: ChartRow[], field: string) {
     .filter((value) => value != null)
 }
 
-export function isDateOnlyFieldValues(values: unknown[]) {
+function isDateOnlyFieldValues(values: unknown[]) {
   return values.length > 0 && values.every(isDateOnlyString)
 }
 

--- a/mcps/clock/package.json
+++ b/mcps/clock/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
-    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts"
+    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
+    "security": "pnpm audit --prod --audit-level high"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcps/skills/package.json
+++ b/mcps/skills/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
-    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts"
+    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
+    "security": "pnpm audit --prod --audit-level high"
   },
   "dependencies": {
     "@open-cowork/shared": "workspace:*",

--- a/mcps/skills/src/index.ts
+++ b/mcps/skills/src/index.ts
@@ -305,7 +305,7 @@ server.tool(
   },
 )
 
-export async function startSkillsMcpServer() {
+async function startSkillsMcpServer() {
   process.stderr.write('[skills-mcp] Server started\n')
   const transport = new StdioServerTransport()
   await server.connect(transport)

--- a/mcps/skills/tests/contract.test.ts
+++ b/mcps/skills/tests/contract.test.ts
@@ -41,6 +41,16 @@ function parseTextResult(result: Awaited<ReturnType<Client['callTool']>>) {
   return JSON.parse(first.text) as unknown
 }
 
+async function assertToolError(client: Client, request: Parameters<Client['callTool']>[0], pattern: RegExp) {
+  try {
+    const result = await client.callTool(request)
+    assert.equal('isError' in result ? result.isError : false, true)
+    assert.match(JSON.stringify('content' in result ? result.content : result), pattern)
+  } catch (error) {
+    assert.match(error instanceof Error ? error.message : String(error), pattern)
+  }
+}
+
 test('skills MCP lists, saves, reads, and deletes bundles over stdio', async () => {
   await withSkillsClient(async (client, skillsRoot) => {
     const listed = await client.listTools()
@@ -112,5 +122,36 @@ test('skills MCP lists, saves, reads, and deletes bundles over stdio', async () 
       { deleted: true, name: 'contract-skill' },
     )
     assert.deepEqual(parseTextResult(await client.callTool({ name: 'list_skill_bundles', arguments: {} })), [])
+  })
+})
+
+test('skills MCP rejects invalid bundle names, traversal, and invalid frontmatter', async () => {
+  await withSkillsClient(async (client) => {
+    await assertToolError(client, {
+      name: 'save_skill_bundle',
+      arguments: {
+        name: 'Bad_Skill',
+        skill_md: '---\nname: Bad_Skill\ndescription: Bad skill.\n---\n# Bad',
+        files: [],
+      },
+    }, /lowercase|skill-name|invalid/i)
+
+    await assertToolError(client, {
+      name: 'save_skill_bundle',
+      arguments: {
+        name: 'safe-skill',
+        skill_md: '---\nname: safe-skill\ndescription: Safe skill.\n---\n# Safe',
+        files: [{ path: '../escape.md', content: 'nope' }],
+      },
+    }, /Invalid skill file path|path/i)
+
+    await assertToolError(client, {
+      name: 'save_skill_bundle',
+      arguments: {
+        name: 'missing-frontmatter',
+        skill_md: '# Missing frontmatter',
+        files: [],
+      },
+    }, /frontmatter|description/i)
   })
 })

--- a/mcps/workflows/package.json
+++ b/mcps/workflows/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
-    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts"
+    "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
+    "security": "pnpm audit --prod --audit-level high"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcps/workflows/tests/contract.test.ts
+++ b/mcps/workflows/tests/contract.test.ts
@@ -42,6 +42,31 @@ async function withBridge<T>(fn: (baseUrl: string, seen: Array<{ url: string; bo
   }
 }
 
+async function withFailingBridge<T>(fn: (baseUrl: string) => Promise<T>) {
+  const server = createServer((req, res) => {
+    req.on('data', () => {})
+    req.on('end', () => {
+      assert.equal(req.headers.authorization, `Bearer ${contractToken}`)
+      res.statusCode = 500
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ error: 'workflow bridge exploded' }))
+    })
+  })
+
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolvePromise())
+  })
+
+  const address = server.address()
+  assert.ok(address && typeof address === 'object')
+  try {
+    return await fn(`http://127.0.0.1:${address.port}`)
+  } finally {
+    await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()))
+  }
+}
+
 async function withWorkflowsClient<T>(baseUrl: string, fn: (client: Client) => Promise<T>) {
   const client = new Client({ name: 'workflows-contract-test', version: '1.0.0' }, { capabilities: {} })
   const transport = new StdioClientTransport({
@@ -72,6 +97,16 @@ function parseTextResult(result: Awaited<ReturnType<Client['callTool']>>) {
   return JSON.parse(first.text) as Record<string, unknown>
 }
 
+async function assertToolError(client: Client, request: Parameters<Client['callTool']>[0], pattern: RegExp) {
+  try {
+    const result = await client.callTool(request)
+    assert.equal('isError' in result ? result.isError : false, true)
+    assert.match(JSON.stringify('content' in result ? result.content : result), pattern)
+  } catch (error) {
+    assert.match(error instanceof Error ? error.message : String(error), pattern)
+  }
+}
+
 const draft = {
   title: 'Inbox summary',
   instructions: 'Scan the inbox and summarize urgent workload.',
@@ -95,5 +130,25 @@ test('workflows MCP previews and creates through the app bridge', async () => {
     })
     assert.deepEqual(seen.map((entry) => entry.url), ['/preview', '/create'])
     assert.equal((seen[0]?.body as { title?: string }).title, 'Inbox summary')
+  })
+})
+
+test('workflows MCP rejects invalid drafts and surfaces bridge errors', async () => {
+  await withBridge(async (baseUrl) => {
+    await withWorkflowsClient(baseUrl, async (client) => {
+      await assertToolError(client, {
+        name: 'preview_workflow',
+        arguments: { title: 'Missing instructions', triggers: [] },
+      }, /instructions|triggers/i)
+    })
+  })
+
+  await withFailingBridge(async (baseUrl) => {
+    await withWorkflowsClient(baseUrl, async (client) => {
+      await assertToolError(client, {
+        name: 'create_workflow',
+        arguments: draft,
+      }, /workflow bridge exploded/)
+    })
   })
 })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,8 +106,8 @@ nav:
       - Threads: threads.md
       - Workflows: workflows.md
       - Workflow Recipes: workflow-recipes.md
-      - Agent Authoring: agent-authoring.md
-      - Skills & MCPs: skills-and-mcps.md
+      - Agents: agent-authoring.md
+      - Tools & Skills: skills-and-mcps.md
       - Custom MCPs: custom-mcps.md
       - Configuration: configuration.md
   - Build & Extend:

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -20,7 +20,6 @@ const secretScanFilenames = new Set([
 const ignoredDirs = new Set([
   '.git',
   '.claude',
-  '.generated',
   '.open-cowork-test',
   '.opencode',
   '.pnpm-store',

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -250,10 +250,10 @@ Remaining failures: <short evidence>
 
 When the Charts MCP is available, create native Open Cowork charts from `results.json` data:
 
-- Use `charts_line_chart` for score or pass-rate trend over experiment number.
-- Use `charts_bar_chart` for keep/discard/crash counts.
-- Use `charts_bar_chart` for per-eval pass rate.
-- Use `charts_mermaid` for the final mutate -> verify -> keep/discard flow only when a process diagram helps.
+- Use `mcp__charts__line_chart` for score or pass-rate trend over experiment number.
+- Use `mcp__charts__bar_chart` for keep/discard/crash counts.
+- Use `mcp__charts__bar_chart` for per-eval pass rate.
+- Use `mcp__charts__mermaid` for the final mutate -> verify -> keep/discard flow only when a process diagram helps.
 
 Do not create an HTML dashboard with CDN dependencies. Prefer in-app chart artifacts.
 

--- a/skills/chart-creator/SKILL.md
+++ b/skills/chart-creator/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when the user asks for a chart, diagram, visual explanation, or c
 
 ## Core Rule
 
-When the charts MCP is available, call the appropriate `charts_*` tool. Do not merely print a Vega-Lite spec or Mermaid source unless the user explicitly asks for raw source only.
+When the charts MCP is available, call the appropriate `mcp__charts__*` tool. Do not merely print a Vega-Lite spec or Mermaid source unless the user explicitly asks for raw source only.
 
 ## Workflow
 
@@ -22,19 +22,19 @@ When the charts MCP is available, call the appropriate `charts_*` tool. Do not m
 
 ## Tool Choice
 
-- `charts_line_chart`: default for ordered trends over dates, times, weeks, months, versions, or ranks.
-- `charts_bar_chart`: category comparison or ranking. Use bars for dates only when discrete daily/weekly/monthly magnitudes are the point; keep dates chronological, not value-sorted. For horizontal bars, use `x` for the numeric value and `y` for the category.
-- `charts_area_chart`: magnitude or composition over an ordered sequence; use only when filled area helps, not for ordinary single-series trends.
-- `charts_scatter_plot`: relationship between two numeric measures.
-- `charts_pie_chart`: simple part-to-whole with a small category count; use `donut` for a cleaner share view.
-- `charts_heatmap`: intensity by two dimensions.
-- `charts_histogram` or `charts_boxplot`: distributions.
-- `charts_funnel_chart`: ordered stage dropoff.
-- `charts_waterfall_chart`: additive positive/negative contributions.
-- `charts_bump_chart`: rank changes over time.
-- `charts_sankey`: weighted flows between stages or categories.
-- `charts_mermaid`: process, flow, sequence, or architecture diagrams rather than quantitative charts.
-- `charts_custom_spec`: only when the standard tools cannot express the needed visual.
+- `mcp__charts__line_chart`: default for ordered trends over dates, times, weeks, months, versions, or ranks.
+- `mcp__charts__bar_chart`: category comparison or ranking. Use bars for dates only when discrete daily/weekly/monthly magnitudes are the point; keep dates chronological, not value-sorted. For horizontal bars, use `x` for the numeric value and `y` for the category.
+- `mcp__charts__area_chart`: magnitude or composition over an ordered sequence; use only when filled area helps, not for ordinary single-series trends.
+- `mcp__charts__scatter_plot`: relationship between two numeric measures.
+- `mcp__charts__pie_chart`: simple part-to-whole with a small category count; use `donut` for a cleaner share view.
+- `mcp__charts__heatmap`: intensity by two dimensions.
+- `mcp__charts__histogram` or `mcp__charts__boxplot`: distributions.
+- `mcp__charts__funnel_chart`: ordered stage dropoff.
+- `mcp__charts__waterfall_chart`: additive positive/negative contributions.
+- `mcp__charts__bump_chart`: rank changes over time.
+- `mcp__charts__sankey`: weighted flows between stages or categories.
+- `mcp__charts__mermaid`: process, flow, sequence, or architecture diagrams rather than quantitative charts.
+- `mcp__charts__custom_spec`: only when the standard tools cannot express the needed visual.
 
 ## Data Viz Standards
 

--- a/skills/clock/SKILL.md
+++ b/skills/clock/SKILL.md
@@ -11,19 +11,19 @@ boundaries.
 
 ## Core Rule
 
-When the clock MCP is available, call the relevant `clock_*` tool before doing
+When the clock MCP is available, call the relevant `mcp__clock__*` tool before doing
 date or time calculations. Do not rely on model memory for "today", "now",
 "last week", "next month", timezones, offsets, or elapsed time.
 
 ## Tool Choice
 
-- `clock_current_time`: get the authoritative current time for a timezone.
-- `clock_convert_time`: convert an instant or source-local datetime between
+- `mcp__clock__current_time`: get the authoritative current time for a timezone.
+- `mcp__clock__convert_time`: convert an instant or source-local datetime between
   timezones.
-- `clock_date_math`: add or subtract calendar and clock units.
-- `clock_date_range`: resolve today, yesterday, this week, last month, rolling
+- `mcp__clock__date_math`: add or subtract calendar and clock units.
+- `mcp__clock__date_range`: resolve today, yesterday, this week, last month, rolling
   N days, and similar calendar windows.
-- `clock_duration_between`: compute elapsed time between two dates or times.
+- `mcp__clock__duration_between`: compute elapsed time between two dates or times.
 
 ## Guardrails
 

--- a/tests/custom-agent-store.test.ts
+++ b/tests/custom-agent-store.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { listCustomAgents, removeCustomAgent, saveCustomAgent } from '../apps/desktop/src/main/native-customizations.ts'
+
+function withTempUserData<T>(fn: () => T): T {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-custom-agent-store-'))
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  process.env.OPEN_COWORK_USER_DATA_DIR = root
+  clearConfigCaches()
+  try {
+    return fn()
+  } finally {
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('custom agent store saves, updates, lists, and removes machine agents', () => withTempUserData(() => {
+  assert.equal(saveCustomAgent({
+    scope: 'machine',
+    directory: null,
+    name: 'weekly-analyst',
+    description: 'Analyze weekly business performance.',
+    instructions: 'Load the analyst skill and write a concise weekly summary.',
+    skillNames: ['analyst'],
+    toolIds: ['websearch'],
+    enabled: true,
+    color: 'success',
+    avatar: null,
+    deniedToolPatterns: ['bash'],
+    model: 'openrouter/deepseek/deepseek-v4-flash:free',
+    temperature: 0.2,
+    steps: 20,
+  }, { websearch: 'allow', bash: 'deny' }), true)
+
+  const saved = listCustomAgents().find((entry) => entry.name === 'weekly-analyst')
+  assert.equal(saved?.description, 'Analyze weekly business performance.')
+  assert.equal(saved?.enabled, true)
+  assert.equal(saved?.color, 'success')
+  assert.deepEqual(saved?.skillNames, ['analyst'])
+  assert.deepEqual(saved?.toolIds, ['websearch'])
+  assert.deepEqual(saved?.deniedToolPatterns, ['bash'])
+  assert.equal(saved?.model, 'openrouter/deepseek/deepseek-v4-flash:free')
+
+  assert.equal(saveCustomAgent({
+    scope: 'machine',
+    directory: null,
+    name: 'weekly-analyst',
+    description: 'Updated analyst.',
+    instructions: 'Updated instructions.',
+    skillNames: [],
+    toolIds: [],
+    enabled: false,
+    color: 'accent',
+    avatar: 'WA',
+  }, { websearch: 'deny' }), true)
+
+  const updated = listCustomAgents().find((entry) => entry.name === 'weekly-analyst')
+  assert.equal(updated?.description, 'Updated analyst.')
+  assert.equal(updated?.enabled, false)
+  assert.equal(updated?.color, 'accent')
+  assert.equal(updated?.avatar, 'WA')
+  assert.deepEqual(updated?.skillNames, [])
+  assert.deepEqual(updated?.toolIds, [])
+
+  assert.equal(removeCustomAgent({ scope: 'machine', directory: null, name: 'weekly-analyst' }), true)
+  assert.equal(listCustomAgents().some((entry) => entry.name === 'weekly-analyst'), false)
+}))
+
+test('custom agent store rejects invalid removal names before touching the filesystem', () => withTempUserData(() => {
+  assert.throws(() => {
+    removeCustomAgent({ scope: 'machine', directory: null, name: '../weekly-analyst' })
+  }, /single managed file name/)
+}))

--- a/tests/custom-mcp-store.test.ts
+++ b/tests/custom-mcp-store.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { listCustomMcps, removeCustomMcp, saveCustomMcp } from '../apps/desktop/src/main/native-customizations.ts'
+
+function withTempUserData<T>(fn: () => T): T {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-custom-mcp-store-'))
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  process.env.OPEN_COWORK_USER_DATA_DIR = root
+  clearConfigCaches()
+  try {
+    return fn()
+  } finally {
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('custom MCP store saves, updates, lists, and removes machine MCPs', () => withTempUserData(() => {
+  assert.equal(saveCustomMcp({
+    scope: 'machine',
+    directory: null,
+    name: 'tickets',
+    label: 'Tickets',
+    description: 'Internal ticket workflow tools.',
+    type: 'http',
+    url: 'https://example.com/mcp',
+    headers: { authorization: 'Bearer token' },
+    allowPrivateNetwork: true,
+    permissionMode: 'allow',
+    traceLabel: 'ticket',
+    tracePluralLabel: 'tickets',
+  }), true)
+
+  const saved = listCustomMcps().find((entry) => entry.name === 'tickets')
+  assert.equal(saved?.type, 'http')
+  assert.equal(saved?.label, 'Tickets')
+  assert.equal(saved?.allowPrivateNetwork, true)
+  assert.equal(saved?.permissionMode, 'allow')
+  assert.equal(saved?.tracePluralLabel, 'tickets')
+
+  assert.equal(saveCustomMcp({
+    scope: 'machine',
+    directory: null,
+    name: 'tickets',
+    type: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    env: { NODE_ENV: 'test' },
+  }), true)
+
+  const updated = listCustomMcps().find((entry) => entry.name === 'tickets')
+  assert.equal(updated?.type, 'stdio')
+  assert.equal(updated?.command, 'node')
+  assert.deepEqual(updated?.args, ['server.js'])
+  assert.deepEqual(updated?.env, { NODE_ENV: 'test' })
+  assert.equal(updated?.label, undefined)
+
+  assert.equal(removeCustomMcp({ scope: 'machine', directory: null, name: 'tickets' }), true)
+  assert.equal(listCustomMcps().some((entry) => entry.name === 'tickets'), false)
+}))
+
+test('custom MCP store rejects incomplete MCP definitions before writing', () => withTempUserData(() => {
+  assert.throws(() => {
+    saveCustomMcp({
+      scope: 'machine',
+      directory: null,
+      name: 'broken',
+      type: 'http',
+      url: '',
+    })
+  }, /Remote MCPs require a URL/)
+  assert.equal(listCustomMcps().some((entry) => entry.name === 'broken'), false)
+}))

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -11,6 +11,7 @@ import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-ha
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
 import { registerWorkflowHandlers } from '../apps/desktop/src/main/ipc/workflow-handlers.ts'
+import { registerCatalogHandlers } from '../apps/desktop/src/main/ipc/catalog-handlers.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
@@ -835,6 +836,38 @@ test('dialog:save-text rejects oversized renderer content before opening a save 
     () => handler({}, 'agent.cowork-agent.json', 'x'.repeat((2 * 1024 * 1024) + 1)),
     /Save content is too large/,
   )
+})
+
+test('chart:render-svg rejects non-object renderer payloads before rendering', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerAppHandlers(context)
+  const handler = handlers.get('chart:render-svg')
+
+  assert.ok(handler, 'expected chart:render-svg handler to be registered')
+  await assert.rejects(
+    () => handler({}, 'not-a-spec'),
+    /chart specification to be an object/,
+  )
+})
+
+test('tool:list rejects malformed options before runtime tool discovery', async () => {
+  const { context, handlers } = createBaseContext()
+  let runtimeToolListCalled = false
+  context.listRuntimeTools = async () => {
+    runtimeToolListCalled = true
+    return []
+  }
+
+  registerCatalogHandlers(context)
+  const handler = handlers.get('tool:list')
+
+  assert.ok(handler, 'expected tool:list handler to be registered')
+  await assert.rejects(
+    () => handler({}, 'not-options'),
+    /tool list options to be an object/,
+  )
+  assert.equal(runtimeToolListCalled, false)
 })
 
 test('chart:save-artifact rejects unknown sessions before writing chart bytes', async () => {

--- a/tests/ipc-thread-handlers.test.ts
+++ b/tests/ipc-thread-handlers.test.ts
@@ -79,8 +79,20 @@ test('thread IPC handlers reject malformed bulk and suggestion inputs before ser
     /include a label/,
   )
   await assert.rejects(
+    () => handlers.get('threads:search')!({}, 'not-a-query'),
+    /thread search query to be an object/,
+  )
+  await assert.rejects(
+    () => handlers.get('threads:tags:create')!({}, null),
+    /thread tag input to be an object/,
+  )
+  await assert.rejects(
+    () => handlers.get('threads:smart-filters:create')!({}, 'not-a-filter'),
+    /smart filter input to be an object/,
+  )
+  await assert.rejects(
     () => handlers.get('threads:smart-filters:update')!({}, 123, { name: 'x', query: {} }),
-    /Smart filter id must be a string/,
+    /smart filter id to be a string/,
   )
   await assert.rejects(
     () => handlers.get('threads:reindex')!({}, Array.from({ length: 501 }, (_, index) => `session-${index}`)),


### PR DESCRIPTION
## Summary
- add centralized IPC argument schemas to additional high-risk handlers
- consolidate task-run event dispatch and shared type usage
- clean renderer timer lifecycles, stale CSS/docs, and bundled skill tool names
- add custom store tests plus MCP error-path contract coverage

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:renderer
- pnpm test:e2e
- pnpm --filter './mcps/*' test
- pnpm lint:dead-code
- pnpm audit --prod --audit-level high
- uv run mkdocs build --strict
- pnpm perf:check
- git diff --check