### PR TITLE
Harden audit follow-up fixes

### DIFF
--- a/apps/desktop/src/main/ipc/session-action-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-action-handlers.ts
@@ -16,7 +16,8 @@ import { getSessionRecord, removeSessionRecord, updateSessionRecord } from '../s
 import { getThreadIndexService } from '../thread-index-service.ts'
 
 export function registerSessionActionHandlers(context: IpcHandlerContext) {
-  context.ipcMain.handle('session:export', async (_event, sessionId: string) => {
+  context.ipcMain.handle('session:export', async (_event, sessionIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       const session = await client.session.get({ sessionID: sessionId })
@@ -44,7 +45,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:share', async (_event, sessionId: string) => {
+  context.ipcMain.handle('session:share', async (_event, sessionIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       const result = await client.session.share({ sessionID: sessionId })
@@ -57,7 +59,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:unshare', async (_event, sessionId: string) => {
+  context.ipcMain.handle('session:unshare', async (_event, sessionIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       await client.session.unshare({ sessionID: sessionId })
@@ -74,7 +77,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
   // auto-compaction (or just trim history proactively). The runtime then
   // emits session.compacted + a CompactionPart which our event handlers
   // render as a CompactionNoticeCard in the timeline.
-  context.ipcMain.handle('session:summarize', async (_event, sessionId: string) => {
+  context.ipcMain.handle('session:summarize', async (_event, sessionIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     log('session', `Summarizing ${shortSessionId(sessionId)}`)
     try {
@@ -93,7 +97,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:revert', async (_event, sessionId: string, messageId?: string) => {
+  context.ipcMain.handle('session:revert', async (_event, sessionIdInput: unknown, messageId?: string) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       await client.session.revert({
@@ -108,7 +113,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:unrevert', async (_event, sessionId: string) => {
+  context.ipcMain.handle('session:unrevert', async (_event, sessionIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       await client.session.unrevert({ sessionID: sessionId })
@@ -120,7 +126,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:children', async (_event, sessionId: string) => {
+  context.ipcMain.handle('session:children', async (_event, sessionIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       const result = await client.session.children({ sessionID: sessionId })
@@ -131,7 +138,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:diff', async (_event, sessionId: string, messageId?: string) => {
+  context.ipcMain.handle('session:diff', async (_event, sessionIdInput: unknown, messageId?: string) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       const result = await client.session.diff({
@@ -167,7 +175,8 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:delete', async (_event, sessionId: string, confirmationToken?: string | null) => {
+  context.ipcMain.handle('session:delete', async (_event, sessionIdInput: unknown, confirmationToken?: string | null) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     try {
       if (!context.consumeDestructiveConfirmation({ action: 'session.delete', sessionId }, confirmationToken)) {

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -35,6 +35,7 @@ import {
   normalizePromptAttachments,
   normalizePromptOptions,
   normalizePromptText,
+  normalizeSessionId,
 } from './session-handler-validation.ts'
 
 type PromptAttachment = ReturnType<typeof normalizePromptAttachments>[number]
@@ -344,7 +345,8 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:activate', async (_event, sessionId: string, options?: { force?: boolean }) => {
+  context.ipcMain.handle('session:activate', async (_event, sessionIdInput: unknown, options?: { force?: boolean }) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     try {
       const view = await syncSessionView(sessionId, {
         force: options?.force,
@@ -387,7 +389,8 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     return listSessionRecords().map(toRendererSession)
   })
 
-  context.ipcMain.handle('session:get', async (_event, id: string) => {
+  context.ipcMain.handle('session:get', async (_event, idInput: unknown) => {
+    const id = normalizeSessionId(idInput)
     const record = context.ensureSessionRecord(id)
     if (!record) return null
     try {
@@ -411,7 +414,8 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:abort', async (_event, sessionId: string) => {
+  context.ipcMain.handle('session:abort', async (_event, sessionIdInput: unknown) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client } = await context.getSessionClient(sessionId)
     log('session', `Aborting ${shortSessionId(sessionId)}`)
     stopSessionStatusReconciliation(sessionId)
@@ -440,9 +444,11 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
   // and reuse its client to issue the abort against the child id.
   context.ipcMain.handle('session:abort-task', async (
     _event,
-    rootSessionId: string,
-    childSessionId: string,
+    rootSessionIdInput: unknown,
+    childSessionIdInput: unknown,
   ) => {
+    const rootSessionId = normalizeSessionId(rootSessionIdInput)
+    const childSessionId = normalizeSessionId(childSessionIdInput)
     const { client } = await context.getSessionClient(rootSessionId)
     log('session', `Aborting task ${shortSessionId(childSessionId)} under ${shortSessionId(rootSessionId)}`)
     try {
@@ -455,7 +461,8 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:fork', async (_event, sessionId: string, messageId?: string) => {
+  context.ipcMain.handle('session:fork', async (_event, sessionIdInput: unknown, messageId?: string) => {
+    const sessionId = normalizeSessionId(sessionIdInput)
     const { client, record } = await context.getSessionClient(sessionId)
     try {
       const result = await client.session.fork({

--- a/apps/desktop/src/main/workflow-service.ts
+++ b/apps/desktop/src/main/workflow-service.ts
@@ -30,6 +30,7 @@ import {
 } from './workflow-webhook-server.ts'
 import { getClientForDirectory, getRuntimeHomeDir } from './runtime.ts'
 import { ensureRuntimeContextDirectory } from './runtime-context.ts'
+import { getConfiguredAgentsFromConfig } from './config-loader.ts'
 import { getEffectiveSettings } from './settings.ts'
 import { trackParentSession } from './event-task-state.ts'
 import { normalizeSessionInfo, normalizeSessionMessages, type NormalizedSessionMessage } from './opencode-adapter.ts'
@@ -43,6 +44,7 @@ let getMainWindow: (() => BrowserWindow | null) | null = null
 let schedulerTimer: NodeJS.Timeout | null = null
 let schedulerTickPromise: Promise<void> | null = null
 const runWorkflowFinalizerForRun = createKeyedPromiseChain()
+const WORKFLOW_DESIGNER_AGENT_NAME = 'workflow-designer'
 
 function publishWorkflowUpdated() {
   const win = getMainWindow?.()
@@ -210,11 +212,14 @@ export async function startWorkflowDraft(directory?: string | null) {
   if (settings.runtimeConfigSource === 'machine') {
     throw new Error('Workflow setup threads require the isolated in-app OpenCode config so the Workflow Designer agent and Workflows tool are available. Switch OpenCode config source to In app to add workflows.')
   }
+  if (!getConfiguredAgentsFromConfig().some((agent) => agent.name === WORKFLOW_DESIGNER_AGENT_NAME)) {
+    throw new Error(`Workflow setup threads require the configured ${WORKFLOW_DESIGNER_AGENT_NAME} agent. Restore that agent in open-cowork.config.json or update the workflow setup policy.`)
+  }
   const session = await createWorkflowThread({
     title: 'New workflow draft',
     directory: directory || null,
     kind: 'workflow_draft',
-    agent: 'workflow-designer',
+    agent: WORKFLOW_DESIGNER_AGENT_NAME,
     prompt: workflowDraftPrompt,
   })
   return session

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -484,21 +484,29 @@ export function App() {
       </div>
       <StatusBar />
       {showCommandPalette && (
-        <Suspense fallback={null}>
-          <CommandPalette
-            onClose={() => setShowCommandPalette(false)}
-            onNavigate={setView}
-            onCreateThread={createAndActivateSession}
-            onEnsureSession={ensureActiveSession}
-            onInsertComposer={(text) => {
-              setPendingComposerInsert(text)
-              setView('chat')
-            }}
-            onSetAgentMode={setAgentMode}
-            onOpenSettings={openSidebarSettings}
-            onToggleSearch={openSidebarSearch}
-          />
-        </Suspense>
+        <ViewErrorBoundary
+          resetKey="command-palette"
+          onBackHome={() => {
+            setShowCommandPalette(false)
+            setView('home')
+          }}
+        >
+          <Suspense fallback={null}>
+            <CommandPalette
+              onClose={() => setShowCommandPalette(false)}
+              onNavigate={setView}
+              onCreateThread={createAndActivateSession}
+              onEnsureSession={ensureActiveSession}
+              onInsertComposer={(text) => {
+                setPendingComposerInsert(text)
+                setView('chat')
+              }}
+              onSetAgentMode={setAgentMode}
+              onOpenSettings={openSidebarSettings}
+              onToggleSearch={openSidebarSearch}
+            />
+          </Suspense>
+        </ViewErrorBoundary>
       )}
     </div>
   )

--- a/apps/desktop/src/renderer/components/layout/ViewErrorBoundary.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/ViewErrorBoundary.test.tsx
@@ -54,4 +54,26 @@ describe('ViewErrorBoundary', () => {
 
     expect(screen.getByText('Recovered page')).toBeInTheDocument()
   })
+
+  it('supports overlay-specific fallback copy', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const onClose = vi.fn()
+
+    render(
+      <ViewErrorBoundary
+        resetKey="diff-viewer"
+        title="This panel failed to render."
+        body="Close this panel and try again."
+        actionLabel="Close panel"
+        onBackHome={onClose}
+      >
+        <BrokenView />
+      </ViewErrorBoundary>,
+    )
+
+    expect(screen.getByText('This panel failed to render.')).toBeInTheDocument()
+    expect(screen.getByText('Close this panel and try again.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/renderer/components/layout/ViewErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/components/layout/ViewErrorBoundary.tsx
@@ -6,6 +6,9 @@ interface ViewErrorBoundaryProps {
   children: ReactNode
   resetKey: string
   onBackHome: () => void
+  title?: string
+  body?: string
+  actionLabel?: string
 }
 
 interface ViewErrorBoundaryState {
@@ -50,16 +53,16 @@ export class ViewErrorBoundary extends Component<ViewErrorBoundaryProps, ViewErr
       <div className="flex-1 flex items-center justify-center px-8">
         <div className="max-w-[420px] w-full rounded-2xl border border-border-subtle bg-surface p-6 text-center">
           <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-text-muted mb-2">{t('error.viewError', 'View Error')}</div>
-          <h2 className="text-[18px] font-semibold text-text mb-2">{t('error.viewErrorTitle', 'This page failed to render.')}</h2>
+          <h2 className="text-[18px] font-semibold text-text mb-2">{this.props.title || t('error.viewErrorTitle', 'This page failed to render.')}</h2>
           <p className="text-[13px] text-text-secondary leading-relaxed mb-5">
-            {t('error.viewErrorBody', '{{brandName}} recovered the rest of the app. Go back home and try again.', { brandName: getBrandName() })}
+            {this.props.body || t('error.viewErrorBody', '{{brandName}} recovered the rest of the app. Go back home and try again.', { brandName: getBrandName() })}
           </p>
           <button
             onClick={this.props.onBackHome}
             className="px-4 py-2 rounded-lg text-[13px] font-medium cursor-pointer transition-colors"
             style={{ background: 'var(--color-accent)', color: 'var(--color-accent-foreground)' }}
           >
-            {t('error.backToHome', 'Back to home')}
+            {this.props.actionLabel || t('error.backToHome', 'Back to home')}
           </button>
         </div>
       </div>

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -6,6 +6,7 @@ import { DiffViewer } from '../chat/DiffViewer'
 import { confirmSessionDelete } from '../../helpers/destructive-actions'
 import { t } from '../../helpers/i18n'
 import { writeTextToClipboard } from '../../helpers/clipboard'
+import { ViewErrorBoundary } from '../layout/ViewErrorBoundary'
 
 // Kick in virtualization only above this count. Below it, plain
 // rendering is a wash (~8ms mount for 50 rows) and avoids the
@@ -400,7 +401,15 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
         </div>
       )}
       {diffSessionId && (
-        <DiffViewer sessionId={diffSessionId} onClose={() => setDiffSessionId(null)} />
+        <ViewErrorBoundary
+          resetKey={`diff-viewer:${diffSessionId}`}
+          title={t('error.panelErrorTitle', 'This panel failed to render.')}
+          body={t('error.panelErrorBody', 'The rest of the app recovered. Close this panel and try again.')}
+          actionLabel={t('error.closePanel', 'Close panel')}
+          onBackHome={() => setDiffSessionId(null)}
+        >
+          <DiffViewer sessionId={diffSessionId} onClose={() => setDiffSessionId(null)} />
+        </ViewErrorBoundary>
       )}
     </div>
   )

--- a/apps/desktop/src/renderer/components/threads/ThreadsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/threads/ThreadsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import type { ThreadFacetSummary, ThreadListItem, ThreadSearchResult, ThreadTag } from '@open-cowork/shared'
@@ -91,6 +91,55 @@ describe('ThreadsPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Open' }))
     expect(onOpenThread).toHaveBeenCalledWith('thread-1')
+  })
+
+  it('debounces free-text search before calling the thread index', async () => {
+    vi.useFakeTimers()
+    try {
+      const api = installRendererTestCoworkApi()
+      vi.mocked(api.threads.search).mockResolvedValue({
+        threads: [thread()],
+        nextCursor: null,
+        totalEstimate: 1,
+      })
+      vi.mocked(api.threads.facets).mockResolvedValue(facets())
+
+      render(<ThreadsPage onOpenThread={vi.fn()} />)
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(screen.getByText('Weekly chart report')).toBeInTheDocument()
+      vi.mocked(api.threads.search).mockClear()
+
+      fireEvent.change(screen.getByRole('textbox', { name: 'Search threads' }), { target: { value: 'rev' } })
+      expect(api.threads.search).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(349)
+      })
+      expect(api.threads.search).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(api.threads.search).toHaveBeenCalledWith(expect.objectContaining({ text: 'rev' }))
+
+      vi.mocked(api.threads.search).mockClear()
+      fireEvent.change(screen.getByRole('textbox', { name: 'Search threads' }), { target: { value: 'revenue' } })
+      expect(api.threads.search).not.toHaveBeenCalled()
+      fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(api.threads.search).toHaveBeenCalledWith(expect.objectContaining({ text: 'revenue' }))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('supports keyboard tagging, smart filters, and suggestion actions without drag only flows', async () => {

--- a/apps/desktop/src/renderer/components/threads/ThreadsPage.tsx
+++ b/apps/desktop/src/renderer/components/threads/ThreadsPage.tsx
@@ -21,6 +21,7 @@ const STATUS_OPTIONS: Array<{ value: ThreadStatus; label: string }> = [
 ]
 
 const TAG_COLORS = ['#64748b', '#22c55e', '#0ea5e9', '#f59e0b', '#ef4444', '#a855f7']
+const THREAD_SEARCH_DEBOUNCE_MS = 350
 
 type ThreadsPageProps = {
   onOpenThread: (sessionId: string) => void
@@ -38,6 +39,22 @@ type QueryState = {
   agents: string[]
   tools: string[]
   mcps: string[]
+}
+
+function defaultQueryState(): QueryState {
+  return {
+    text: '',
+    sort: 'updated_desc',
+    dateRange: undefined,
+    projectLabels: [],
+    statuses: [],
+    tagIds: [],
+    providerIds: [],
+    modelIds: [],
+    agents: [],
+    tools: [],
+    mcps: [],
+  }
 }
 
 const EMPTY_FACETS: ThreadFacetSummary = {
@@ -281,7 +298,7 @@ function ThreadRow({
       onDragStart={onDragStart}
       className={`grid grid-cols-[32px_minmax(220px,1.4fr)_160px_160px_120px] items-center gap-3 border-b border-border-subtle px-3 py-2.5 text-[12px] transition-colors ${selected ? 'bg-surface-active/70' : 'hover:bg-surface-hover'}`}
     >
-      <label className="flex items-center justify-center">
+      <div role="gridcell" className="flex items-center justify-center">
         <input
           type="checkbox"
           checked={selected}
@@ -289,31 +306,33 @@ function ThreadRow({
           aria-label={t('threads.selectThread', 'Select thread')}
           className="h-3.5 w-3.5 accent-[var(--color-accent)]"
         />
-      </label>
-      <button type="button" onClick={onSelect} className="min-w-0 text-start">
-        <span className="block truncate text-[13px] font-medium text-text">{thread.title}</span>
-        <span className="mt-1 flex min-w-0 items-center gap-2 text-[11px] text-text-muted">
-          {thread.projectLabel ? <span className="truncate">{thread.projectLabel}</span> : <span>Personal workspace</span>}
-          <span aria-hidden="true">·</span>
-          <span>{thread.usage.messages} messages</span>
-          {thread.changeSummary && thread.changeSummary.files > 0 ? (
-            <>
-              <span aria-hidden="true">·</span>
-              <span>{thread.changeSummary.files} files</span>
-            </>
-          ) : null}
-        </span>
-        <div className="mt-1.5">
-          <ThreadBadges thread={thread} />
-        </div>
-      </button>
-      <div className="truncate text-text-secondary">{thread.providerId || '—'}{thread.modelId ? ` / ${thread.modelId.split('/').pop()}` : ''}</div>
-      <div className="flex flex-wrap gap-1">
+      </div>
+      <div role="gridcell" className="min-w-0">
+        <button type="button" onClick={onSelect} className="w-full min-w-0 text-start">
+          <span className="block truncate text-[13px] font-medium text-text">{thread.title}</span>
+          <span className="mt-1 flex min-w-0 items-center gap-2 text-[11px] text-text-muted">
+            {thread.projectLabel ? <span className="truncate">{thread.projectLabel}</span> : <span>Personal workspace</span>}
+            <span aria-hidden="true">·</span>
+            <span>{thread.usage.messages} messages</span>
+            {thread.changeSummary && thread.changeSummary.files > 0 ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>{thread.changeSummary.files} files</span>
+              </>
+            ) : null}
+          </span>
+          <div className="mt-1.5">
+            <ThreadBadges thread={thread} />
+          </div>
+        </button>
+      </div>
+      <div role="gridcell" className="truncate text-text-secondary">{thread.providerId || '—'}{thread.modelId ? ` / ${thread.modelId.split('/').pop()}` : ''}</div>
+      <div role="gridcell" className="flex flex-wrap gap-1">
         {thread.tags.length ? thread.tags.map((tag) => (
           <span key={tag.id} className="rounded px-1.5 py-0.5 text-[10px] text-white" style={{ background: tag.color }}>{tag.name}</span>
         )) : <span className="text-text-muted">No tags</span>}
       </div>
-      <div className="flex items-center justify-between gap-2">
+      <div role="gridcell" className="flex items-center justify-between gap-2">
         <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] uppercase tracking-[0.04em] text-text-muted">{thread.status}</span>
         <button type="button" onClick={onOpen} className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-secondary hover:bg-surface-hover hover:text-text">
           Open
@@ -536,19 +555,7 @@ function DetailDrawer({
 }
 
 export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
-  const [query, setQuery] = useState<QueryState>({
-    text: '',
-    sort: 'updated_desc',
-    dateRange: undefined,
-    projectLabels: [],
-    statuses: [],
-    tagIds: [],
-    providerIds: [],
-    modelIds: [],
-    agents: [],
-    tools: [],
-    mcps: [],
-  })
+  const [query, setQuery] = useState<QueryState>(defaultQueryState)
   const [threads, setThreads] = useState<ThreadListItem[]>([])
   const [facets, setFacets] = useState<ThreadFacetSummary>(EMPTY_FACETS)
   const [tags, setTags] = useState<ThreadTag[]>([])
@@ -559,9 +566,35 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
   const [error, setError] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [detailId, setDetailId] = useState<string | null>(null)
+  const [debouncedSearchText, setDebouncedSearchText] = useState(query.text)
   const dragIdsRef = useRef<string[]>([])
 
   const selectedThread = useMemo(() => threads.find((thread) => thread.sessionId === detailId) || null, [detailId, threads])
+  const effectiveQuery = useMemo(() => ({
+    text: debouncedSearchText,
+    sort: query.sort,
+    dateRange: query.dateRange,
+    projectLabels: query.projectLabels,
+    statuses: query.statuses,
+    tagIds: query.tagIds,
+    providerIds: query.providerIds,
+    modelIds: query.modelIds,
+    agents: query.agents,
+    tools: query.tools,
+    mcps: query.mcps,
+  }), [
+    debouncedSearchText,
+    query.agents,
+    query.dateRange,
+    query.mcps,
+    query.modelIds,
+    query.projectLabels,
+    query.providerIds,
+    query.sort,
+    query.statuses,
+    query.tagIds,
+    query.tools,
+  ])
 
   const refreshAuxiliary = useCallback(async () => {
     const [tagList, filterList] = await Promise.all([
@@ -572,11 +605,20 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
     setSmartFilters(filterList)
   }, [])
 
-  const loadThreads = useCallback(async (cursor: string | null = null, append = false) => {
+  const applyQuery = useCallback((nextQuery: QueryState) => {
+    setQuery(nextQuery)
+    setDebouncedSearchText(nextQuery.text)
+  }, [])
+
+  const loadThreads = useCallback(async (
+    cursor: string | null = null,
+    append = false,
+    queryState: QueryState = effectiveQuery,
+  ) => {
     setLoading(true)
     setError(null)
     try {
-      const searchQuery = queryFromState(query, cursor)
+      const searchQuery = queryFromState(queryState, cursor)
       const [result, facetResult] = await Promise.all([
         window.coworkApi.threads.search(searchQuery),
         window.coworkApi.threads.facets(searchQuery),
@@ -591,11 +633,18 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
     } finally {
       setLoading(false)
     }
-  }, [query])
+  }, [effectiveQuery])
 
   useEffect(() => {
     void refreshAuxiliary()
   }, [refreshAuxiliary])
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearchText(query.text)
+    }, THREAD_SEARCH_DEBOUNCE_MS)
+    return () => window.clearTimeout(timeout)
+  }, [query.text])
 
   useEffect(() => {
     void loadThreads(null, false)
@@ -603,8 +652,12 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
 
   const reload = useCallback(() => {
     void refreshAuxiliary()
-    void loadThreads(null, false)
-  }, [loadThreads, refreshAuxiliary])
+    if (debouncedSearchText === query.text) {
+      void loadThreads(null, false, query)
+    } else {
+      setDebouncedSearchText(query.text)
+    }
+  }, [debouncedSearchText, loadThreads, query, refreshAuxiliary])
 
   const toggleSelection = (sessionId: string) => {
     setSelectedIds((current) => toggleValue(current, sessionId))
@@ -635,7 +688,7 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
               await window.coworkApi.threads.smartFilters.create({ name, query: queryFromState(query, null) })
               reload()
             }}
-            onApply={(filter) => setQuery(stateFromQuery(filter.query))}
+            onApply={(filter) => applyQuery(stateFromQuery(filter.query))}
             onDelete={async (filterId) => {
               await window.coworkApi.threads.smartFilters.delete(filterId)
               reload()
@@ -700,7 +753,7 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
             {hasFilters(query) ? (
               <button
                 type="button"
-                onClick={() => setQuery({ text: '', sort: 'updated_desc', dateRange: undefined, projectLabels: [], statuses: [], tagIds: [], providerIds: [], modelIds: [], agents: [], tools: [], mcps: [] })}
+                onClick={() => applyQuery(defaultQueryState())}
                 className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover"
               >
                 Clear
@@ -713,14 +766,14 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
           </div>
         </div>
         {error ? <div role="alert" className="border-b border-red-400/30 bg-red-500/10 px-4 py-2 text-[12px] text-red-100">{error}</div> : null}
-        <div className="grid grid-cols-[32px_minmax(220px,1.4fr)_160px_160px_120px] gap-3 border-b border-border-subtle px-3 py-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">
-          <span />
-          <span>Thread</span>
-          <span>Provider / model</span>
-          <span>Tags</span>
-          <span>Status</span>
-        </div>
-        <div className="min-h-0 flex-1 overflow-auto">
+        <div role="grid" aria-label={t('threads.resultsGrid', 'Thread results')} className="min-h-0 flex-1 overflow-auto">
+          <div role="row" className="grid grid-cols-[32px_minmax(220px,1.4fr)_160px_160px_120px] gap-3 border-b border-border-subtle px-3 py-2 text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+            <span role="columnheader" aria-label="Select" />
+            <span role="columnheader">Thread</span>
+            <span role="columnheader">Provider / model</span>
+            <span role="columnheader">Tags</span>
+            <span role="columnheader">Status</span>
+          </div>
           {threads.length ? threads.map((thread) => (
             <ThreadRow
               key={thread.sessionId}
@@ -734,15 +787,19 @@ export function ThreadsPage({ onOpenThread }: ThreadsPageProps) {
               }}
             />
           )) : (
-            <div className="p-8 text-center text-[13px] text-text-muted">
-              {loading ? 'Loading threads…' : 'No indexed threads match this search.'}
+            <div role="row">
+              <div role="gridcell" aria-colspan={5} className="p-8 text-center text-[13px] text-text-muted">
+                {loading ? 'Loading threads…' : 'No indexed threads match this search.'}
+              </div>
             </div>
           )}
           {nextCursor ? (
-            <div className="flex justify-center border-t border-border-subtle p-3">
-              <button type="button" onClick={() => void loadThreads(nextCursor, true)} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover">
-                Load more
-              </button>
+            <div role="row">
+              <div role="gridcell" aria-colspan={5} className="flex justify-center border-t border-border-subtle p-3">
+                <button type="button" onClick={() => void loadThreads(nextCursor, true)} className="rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text-secondary hover:bg-surface-hover">
+                  Load more
+                </button>
+              </div>
             </div>
           ) : null}
         </div>

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -48,6 +48,32 @@ Sub-views: `agents-template-picker`, `agents-builder`,
 Settings tabs: `settings-appearance`, `settings-models`,
 `settings-permissions`, `settings-workflows`, `settings-storage`.
 
+## Auto screenshot inventory
+
+| Surface | Screenshot |
+| --- | --- |
+| Home | [`auto/home.png`](auto/home.png) |
+| Chat thread | [`auto/chat-thread.png`](auto/chat-thread.png) |
+| Chat mention picker | [`auto/chat-mention-picker.png`](auto/chat-mention-picker.png) |
+| Sidebar search | [`auto/sidebar-search.png`](auto/sidebar-search.png) |
+| Agents overview | [`auto/agents.png`](auto/agents.png) |
+| Agents template picker | [`auto/agents-template-picker.png`](auto/agents-template-picker.png) |
+| Agent builder | [`auto/agents-builder.png`](auto/agents-builder.png) |
+| Agent builder detail | [`auto/agents-builder-detail.png`](auto/agents-builder-detail.png) |
+| Tools overview | [`auto/capabilities-tools.png`](auto/capabilities-tools.png) |
+| Skills overview | [`auto/capabilities-skills.png`](auto/capabilities-skills.png) |
+| Tool detail | [`auto/capabilities-tool-detail.png`](auto/capabilities-tool-detail.png) |
+| Add tool | [`auto/capabilities-add-tool.png`](auto/capabilities-add-tool.png) |
+| Add skill | [`auto/capabilities-add-skill.png`](auto/capabilities-add-skill.png) |
+| Workflows overview | [`auto/workflows-overview.png`](auto/workflows-overview.png) |
+| Workflow template | [`auto/workflows-template.png`](auto/workflows-template.png) |
+| Workflow detail | [`auto/workflows-detail.png`](auto/workflows-detail.png) |
+| Settings appearance | [`auto/settings-appearance.png`](auto/settings-appearance.png) |
+| Settings models | [`auto/settings-models.png`](auto/settings-models.png) |
+| Settings permissions | [`auto/settings-permissions.png`](auto/settings-permissions.png) |
+| Settings workflows | [`auto/settings-workflows.png`](auto/settings-workflows.png) |
+| Settings storage | [`auto/settings-storage.png`](auto/settings-storage.png) |
+
 ## Capture guidelines for manual assets
 
 - Use the packaged macOS build against the isolated `smoke`-branded

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,10 +39,12 @@ At 500+ threads:
   `scrollToIndex` API, preserving the one-click-lands-active-thread
   UX.
 
-The chat transcript is **not yet** virtualized. A 10k-message thread
-will render all bubbles, and each stream patch causes a re-flow.
-This hasn't bitten in practice because real chats rarely cross 500
-messages — but it's a known scale cliff and tracked for a follow-up.
+The chat transcript also uses `@tanstack/react-virtual` above an
+80-item threshold. Short threads stay on the plain DOM path because the
+mount cost is low and simpler scrolling feels better. Long threads keep
+only visible timeline rows plus overscan mounted, and active task /
+approval jumps route through the virtualizer so drill-ins still land on
+the right row.
 
 ## Main-process session eviction
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -8,6 +8,11 @@ description: Thread-native repeatable work in Open Cowork.
 Workflows are saved repeatable tasks created from a normal OpenCode setup
 thread with the Workflow Designer agent.
 
+Workflow setup depends on the configured agent id `workflow-designer`.
+Downstream builds that keep workflows enabled should keep that agent in
+their app config, or intentionally update the workflow setup policy in code
+and config together.
+
 The product rule is simple:
 
 - **OpenCode executes** sessions, agents, approvals, tools, skills, and
@@ -16,6 +21,9 @@ The product rule is simple:
   webhook secret, run history, and links back to the setup/run threads.
 
 There is no separate workflow runtime, inbox board, or hidden task engine.
+Open Cowork does include a hidden built-in **Executive Assistant** agent for
+workflow supervision, readiness checks, and run coordination; it is
+workflow-only and is not shown in the normal chat agent picker.
 
 ## How Creation Works
 

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -131,6 +131,50 @@ test('session:delete refuses to delete without a valid destructive confirmation'
   assert.match(errors[0] || '', /Confirmation required before deleting a thread/)
 })
 
+test('session id handlers reject malformed ids before session lookup', async () => {
+  const { context, handlers } = createBaseContext()
+  let clientRequested = 0
+  let registryRequested = 0
+
+  context.getSessionClient = async () => {
+    clientRequested += 1
+    throw new Error('runtime should not be reached')
+  }
+  context.ensureSessionRecord = () => {
+    registryRequested += 1
+    return null
+  }
+
+  registerSessionHandlers(context)
+
+  const cases: Array<{ channel: string; args: unknown[] }> = [
+    { channel: 'session:activate', args: ['   '] },
+    { channel: 'session:get', args: ['   '] },
+    { channel: 'session:abort', args: ['   '] },
+    { channel: 'session:abort-task', args: ['   ', 'child-session'] },
+    { channel: 'session:abort-task', args: ['root-session', '   '] },
+    { channel: 'session:fork', args: ['   '] },
+    { channel: 'session:export', args: ['   '] },
+    { channel: 'session:share', args: ['   '] },
+    { channel: 'session:unshare', args: ['   '] },
+    { channel: 'session:summarize', args: ['   '] },
+    { channel: 'session:revert', args: ['   '] },
+    { channel: 'session:unrevert', args: ['   '] },
+    { channel: 'session:children', args: ['   '] },
+    { channel: 'session:diff', args: ['   '] },
+    { channel: 'session:delete', args: ['   ', 'token'] },
+  ]
+
+  for (const { channel, args } of cases) {
+    const handler = handlers.get(channel)
+    assert.ok(handler, `expected ${channel} handler to be registered`)
+    await assert.rejects(async () => handler({}, ...args), /Session id/)
+  }
+
+  assert.equal(clientRequested, 0)
+  assert.equal(registryRequested, 0)
+})
+
 test('session:prompt rejects oversized text before runtime dispatch', async () => {
   const { context, handlers } = createBaseContext()
   let clientRequested = false


### PR DESCRIPTION
## Summary

- validate session IDs before session IPC handlers touch runtime/session state
- debounce free-text thread search while keeping explicit refresh/filter actions immediate
- wrap overlay surfaces in render error boundaries and tighten Threads grid semantics
- document workflow-designer and hidden Executive Assistant behavior, and inventory generated screenshots

## Validation

- pnpm test:e2e
- pnpm --dir apps/desktop test:renderer -- ThreadsPage.test.tsx ViewErrorBoundary.test.tsx ThreadList.test.tsx App.test.tsx
- pnpm test tests/ipc-handler-behavior.test.ts
- pnpm typecheck
- pnpm lint
- uv run mkdocs build --strict
- git diff --check