### PR TITLE
Harden audit follow-up checklist

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `0ab6fe1f8cf117850f2cb44a9b329166aeeeb5f65b0169f954f8da221fe02117`
+- pnpm lockfile SHA-256: `7e3291f8da5fed094c711727b04c538da070a079f7d59d355140f3632f952a61`
 - Production package entries: 419
 
 Each package remains licensed under its own license terms. The table below is provided for attribution and review; bundled license files are emitted under `THIRD_PARTY_LICENSES/`.

--- a/apps/desktop/src/main/workflow-webhook-server.ts
+++ b/apps/desktop/src/main/workflow-webhook-server.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { log } from './logger.ts'
 
 const DEFAULT_WEBHOOK_PORT = 47839
+const WORKFLOW_WEBHOOK_BIND_HOST = '127.0.0.1'
 const MAX_WEBHOOK_BODY_BYTES = 256 * 1024
 
 let server: Server | null = null
@@ -17,6 +18,10 @@ let triggerHandler: ((input: {
 export type WorkflowWebhookAuth =
   | { kind: 'secret'; secret: string }
   | { kind: 'signature'; timestamp: string; signature: string; rawBody: string }
+
+export function isWorkflowWebhookLoopbackBindAddress(address: string) {
+  return address === WORKFLOW_WEBHOOK_BIND_HOST || address === `::ffff:${WORKFLOW_WEBHOOK_BIND_HOST}`
+}
 
 class WebhookHttpError extends Error {
   readonly status: number
@@ -120,7 +125,7 @@ async function handleWebhookRequest(req: IncomingMessage, res: ServerResponse) {
     writeJson(res, 405, { ok: false, error: 'Method not allowed.' })
     return
   }
-  const url = new URL(req.url || '/', 'http://127.0.0.1')
+  const url = new URL(req.url || '/', `http://${WORKFLOW_WEBHOOK_BIND_HOST}`)
   const match = url.pathname.match(/^\/workflows\/([^/]+)$/)
   if (!match) {
     writeJson(res, 404, { ok: false, error: 'Webhook not found.' })
@@ -154,15 +159,21 @@ async function listenOn(port: number) {
   })
   await new Promise<void>((resolve, reject) => {
     next.once('error', reject)
-    next.listen(port, '127.0.0.1', () => {
+    next.listen(port, WORKFLOW_WEBHOOK_BIND_HOST, () => {
       next.off('error', reject)
       resolve()
     })
   })
   server = next
   const address = next.address()
+  const resolvedHost = typeof address === 'object' && address ? address.address : WORKFLOW_WEBHOOK_BIND_HOST
+  if (!isWorkflowWebhookLoopbackBindAddress(resolvedHost)) {
+    next.close()
+    server = null
+    throw new Error(`Workflow webhook server must bind to ${WORKFLOW_WEBHOOK_BIND_HOST}; got ${resolvedHost}`)
+  }
   const resolvedPort = typeof address === 'object' && address ? address.port : port
-  baseUrl = `http://127.0.0.1:${resolvedPort}`
+  baseUrl = `http://${WORKFLOW_WEBHOOK_BIND_HOST}:${resolvedPort}`
   log('workflow', `Workflow webhook server listening on ${baseUrl}`)
 }
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,7 @@
 # Contributing
 
+This docs page intentionally delegates to the repository-level contributor
+guide so local development instructions, validation commands, PR expectations,
+and release checks have one source of truth.
+
 --8<-- "CONTRIBUTING.md"

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -46,6 +46,19 @@ only visible timeline rows plus overscan mounted, and active task /
 approval jumps route through the virtualizer so drill-ins still land on
 the right row.
 
+## Chat transcript virtualization
+
+Long chat transcripts use the same virtualizer strategy as the sidebar:
+timeline rows are keyed by session-view item id, measured after mount,
+and kept to visible rows plus overscan. The virtualizer is disabled for
+short transcripts so common small chats avoid absolute-positioned rows
+and keep simple native scroll behavior.
+
+Because assistant messages can grow while streaming, row measurement is
+allowed to settle after each patch. That keeps active approval jumps,
+task drill-ins, and scroll-to-bottom behavior stable while avoiding a
+10k-message DOM cliff.
+
 ## Main-process session eviction
 
 `SessionEngine.maybePrune()` keeps `MAX_WARM_SESSION_DETAILS` (12)
@@ -85,7 +98,6 @@ accepted.
 
 ## What's NOT optimized (yet)
 
-- **Chat transcript virtualization** — see note above.
 - **Server-side chart rendering** — charts render client-side today,
   so large datasets block the renderer briefly during the initial
   paint. Server-side SVG rendering is supported via

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -9,6 +9,22 @@ login, session creation, slow performance markers, and sanitized error
 summaries. The log stays on the user's machine and is retained for 14
 days.
 
+Examples of local diagnostic events:
+
+- App lifecycle: startup, shutdown, renderer error summaries, runtime
+  reconnect attempts, and slow-operation markers.
+- User-initiated runtime work: session ids, selected project directory
+  status, workflow ids, and whether a workflow run was manual,
+  scheduled, or webhook-triggered.
+- Integration status: MCP connection/auth states and provider model
+  catalog refresh results.
+
+The diagnostic log is sanitized before it is written. API keys, OAuth
+tokens, JWTs, cloud credentials, email addresses, and home-directory
+paths are redacted by the main-process logger. Chat message bodies,
+attachment contents, workflow webhook payloads, and credential values
+are not written as routine telemetry.
+
 No remote telemetry endpoint is configured in `open-cowork.config.json`.
 The app only sends network traffic needed for the user's configured
 runtime work:
@@ -20,6 +36,17 @@ runtime work:
 - OpenCode provider-auth browser flows when the user explicitly signs in
   to a provider such as OpenAI from setup or Settings.
 - GitHub links opened by the user in their browser.
+
+Local workflow webhooks are loopback-only. They listen on
+`127.0.0.1`, require bearer/header/HMAC authentication, and do not send
+webhook payloads to any Open Cowork service. A workflow run may still
+contact the user's selected LLM provider or enabled MCP integrations as
+part of the task the user configured.
+
+Settings can export a diagnostics bundle for support. That export is a
+user-initiated local file. It includes sanitized logs and app/runtime
+metadata useful for debugging; it does not include unmasked provider
+credentials or full chat transcript bodies.
 
 Downstream distributions can opt into remote telemetry by setting
 `telemetry.enabled` and `telemetry.endpoint` in their own config. That

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -233,13 +233,17 @@ removes the curated symlinks from the managed runtime home on the next
 runtime restart.
 
 The OpenCode server process also receives a curated environment, not the
-user's full login shell environment. Open Cowork preserves toolchain basics
-such as `PATH`, locale, temp-directory, proxy variables, custom CA trust-store
-variables, and app-managed OpenCode variables, then sets Cowork-owned
-`HOME`/XDG paths and the app-scoped Google ADC path when available. Arbitrary
-exported secrets, SSH-agent sockets, and command overrides such as
-`OPENAI_API_KEY`, cloud session tokens, `SSH_AUTH_SOCK`, and `GIT_SSH_COMMAND`
-are not forwarded into the managed runtime.
+user's full login shell environment. On macOS/Linux, Open Cowork may execute a
+trusted login shell (`bash`, `sh`, or `zsh` from a fixed allowlist, with nushell
+blocked) to discover the user's normal toolchain `PATH`. That shell execution is
+only an environment-discovery step. The result is filtered before it reaches
+OpenCode: Open Cowork preserves toolchain basics such as `PATH`, locale,
+temp-directory, proxy variables, custom CA trust-store variables, and
+app-managed OpenCode variables, then sets Cowork-owned `HOME`/XDG paths and the
+app-scoped Google ADC path when available. Arbitrary exported secrets,
+SSH-agent sockets, and command overrides such as `OPENAI_API_KEY`, cloud
+session tokens, `SSH_AUTH_SOCK`, and `GIT_SSH_COMMAND` are not forwarded into
+the managed runtime.
 
 Provider authentication is app-owned by default. OpenCode still owns
 provider login flows, but the managed runtime writes provider auth under

--- a/package.json
+++ b/package.json
@@ -65,8 +65,6 @@
     ],
     "overrides": {
       "electron-builder-squirrel-windows": "26.8.1",
-      "fast-uri@<=3.1.0": ">=3.1.1",
-      "hono@<4.12.16": ">=4.12.16",
       "ip-address@<=10.1.0": ">=10.1.1",
       "mermaid>uuid": "^14.0.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,6 @@ settings:
 
 overrides:
   electron-builder-squirrel-windows: 26.8.1
-  fast-uri@<=3.1.0: '>=3.1.1'
-  hono@<4.12.16: '>=4.12.16'
   ip-address@<=10.1.0: '>=10.1.1'
   mermaid>uuid: ^14.0.0
 
@@ -633,7 +631,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.16'
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,11 +1,33 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 
 export const NODE_COVERAGE_INPUT = { name: 'Node', path: 'coverage/node/lcov.info', thresholds: { lines: 80, functions: 74, branches: 68 } }
+export const SHARED_COVERAGE_INPUT = {
+  name: 'Shared Package',
+  path: 'coverage/node/lcov.info',
+  includePathPrefixes: ['packages/shared/'],
+  thresholds: { lines: 90, functions: 90, branches: 75 },
+}
 export const RENDERER_COVERAGE_INPUT = { name: 'Renderer', path: 'coverage/renderer/lcov.info', thresholds: { lines: 65, functions: 62, branches: 51 } }
-export const DEFAULT_INPUTS = [NODE_COVERAGE_INPUT, RENDERER_COVERAGE_INPUT]
+export const DEFAULT_INPUTS = [NODE_COVERAGE_INPUT, SHARED_COVERAGE_INPUT, RENDERER_COVERAGE_INPUT]
 
-export function parseLcovInfo(content) {
+function normalizeCoveragePath(path, includePathPrefixes = []) {
+  const normalized = path.replace(/\\/g, '/')
+  for (const prefix of includePathPrefixes) {
+    const normalizedPrefix = prefix.replace(/\\/g, '/').replace(/^\/+/, '')
+    if (normalized.startsWith(normalizedPrefix)) return normalized
+    const prefixIndex = normalized.indexOf(`/${normalizedPrefix}`)
+    if (prefixIndex >= 0) return normalized.slice(prefixIndex + 1)
+  }
+  return normalized
+}
+
+export function parseLcovInfo(content, options = {}) {
   const files = new Map()
+  const includePathPrefixes = options.includePathPrefixes || []
+
+  function shouldIncludeFile(path) {
+    return includePathPrefixes.length === 0 || includePathPrefixes.some((prefix) => path.startsWith(prefix))
+  }
 
   function currentFile(path) {
     if (!files.has(path)) {
@@ -29,7 +51,14 @@ export function parseLcovInfo(content) {
     const value = rawLine.slice(separator + 1)
 
     if (key === 'SF') {
-      file = currentFile(value)
+      const sourcePath = normalizeCoveragePath(value, includePathPrefixes)
+      if (!shouldIncludeFile(sourcePath)) {
+        file = null
+        recordFunctionKeysByName = new Map()
+        recordFunctionHitIndexByName = new Map()
+        continue
+      }
+      file = currentFile(sourcePath)
       recordFunctionKeysByName = new Map()
       recordFunctionHitIndexByName = new Map()
       continue
@@ -122,7 +151,10 @@ function status(value, threshold) {
 
 export function summarizeCoverage(inputs = DEFAULT_INPUTS) {
   return inputs.map((input) => {
-    const totals = parseLcovInfo(readFileSync(input.path, 'utf8'))
+    const totals = parseLcovInfo(readFileSync(input.path, 'utf8'), input)
+    if (input.includePathPrefixes && input.includePathPrefixes.length > 0 && totals.files === 0) {
+      throw new Error(`${input.name} coverage matched no files for prefixes: ${input.includePathPrefixes.join(', ')}`)
+    }
     const lines = percent(totals.lines.covered, totals.lines.total)
     const functions = percent(totals.functions.covered, totals.functions.total)
     const branches = percent(totals.branches.covered, totals.branches.total)
@@ -164,7 +196,7 @@ export function renderCoverageMarkdown(summary) {
 }
 
 function inputsFromArgs(args) {
-  if (args.includes('--node-only')) return [NODE_COVERAGE_INPUT]
+  if (args.includes('--node-only')) return [NODE_COVERAGE_INPUT, SHARED_COVERAGE_INPUT]
   if (args.includes('--renderer-only')) return [RENDERER_COVERAGE_INPUT]
   return DEFAULT_INPUTS
 }

--- a/tests/coverage-summary.test.ts
+++ b/tests/coverage-summary.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { DEFAULT_INPUTS, parseLcovInfo, renderCoverageMarkdown } from '../scripts/coverage-summary.mjs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DEFAULT_INPUTS, SHARED_COVERAGE_INPUT, parseLcovInfo, renderCoverageMarkdown, summarizeCoverage } from '../scripts/coverage-summary.mjs'
 
 test('coverage summary parses lcov totals and renders a PR-safe table', () => {
   const totals = parseLcovInfo([
@@ -85,6 +88,76 @@ test('coverage summary merges duplicate source-file records', () => {
   })
 })
 
+test('coverage summary can enforce package-scoped coverage from shared lcov', () => {
+  const totals = parseLcovInfo([
+    'TN:',
+    'SF:apps/desktop/src/main/runtime.ts',
+    'FN:1,startRuntime',
+    'FNDA:1,startRuntime',
+    'DA:1,1',
+    'end_of_record',
+    'SF:packages/shared/src/index.ts',
+    'FN:1,sharedContract',
+    'FNDA:1,sharedContract',
+    'BRDA:1,0,0,1',
+    'DA:1,1',
+    'DA:2,0',
+    'end_of_record',
+  ].join('\n'), { includePathPrefixes: ['packages/shared/'] })
+
+  assert.deepEqual(totals, {
+    files: 1,
+    lines: { covered: 1, total: 2 },
+    functions: { covered: 1, total: 1 },
+    branches: { covered: 1, total: 1 },
+  })
+})
+
+test('coverage summary normalizes absolute and platform-specific scoped paths', () => {
+  const totals = parseLcovInfo([
+    'TN:',
+    'SF:/home/runner/work/open-cowork/open-cowork/packages/shared/src/index.ts',
+    'FN:1,sharedContract',
+    'FNDA:1,sharedContract',
+    'DA:1,1',
+    'end_of_record',
+    String.raw`SF:C:\a\open-cowork\packages\shared\src\providers.ts`,
+    'FN:2,providerContract',
+    'FNDA:0,providerContract',
+    'DA:2,0',
+    'end_of_record',
+  ].join('\n'), { includePathPrefixes: ['packages/shared/'] })
+
+  assert.deepEqual(totals, {
+    files: 2,
+    lines: { covered: 1, total: 2 },
+    functions: { covered: 1, total: 2 },
+    branches: { covered: 0, total: 0 },
+  })
+})
+
+test('coverage summary refuses scoped input with zero matched files', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'open-cowork-coverage-summary-'))
+  const lcovPath = join(dir, 'lcov.info')
+  try {
+    writeFileSync(lcovPath, [
+      'TN:',
+      'SF:apps/desktop/src/main/runtime.ts',
+      'DA:1,1',
+      'end_of_record',
+    ].join('\n'))
+
+    assert.throws(() => summarizeCoverage([{
+      name: 'Shared Package',
+      path: lcovPath,
+      includePathPrefixes: ['packages/shared/'],
+      thresholds: { lines: 1, functions: 1, branches: 1 },
+    }]), /matched no files/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('coverage summary applies FNDA hit counts to duplicate function names in declaration order', () => {
   const totals = parseLcovInfo([
     'TN:',
@@ -114,4 +187,13 @@ test('coverage summary reports the enforced renderer ratchet', () => {
     functions: 62,
     branches: 51,
   })
+})
+
+test('coverage summary reports the enforced shared-package ratchet', () => {
+  assert.deepEqual(SHARED_COVERAGE_INPUT.thresholds, {
+    lines: 90,
+    functions: 90,
+    branches: 75,
+  })
+  assert.deepEqual(SHARED_COVERAGE_INPUT.includePathPrefixes, ['packages/shared/'])
 })

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -64,6 +64,18 @@ function readPreloadChannelArray(source: string, constantName: string) {
   )
 }
 
+function readCoworkApiGroups(source: string) {
+  const match = source.match(/export interface CoworkAPI \{([\s\S]*?)\n\}/)
+  assert.ok(match, 'missing CoworkAPI interface')
+  return Array.from(match[1].matchAll(/^ {2}([a-zA-Z][\w]*): \{/gm), (entry) => entry[1]).sort()
+}
+
+function readPreloadApiGroups(source: string) {
+  const match = source.match(/const api: CoworkAPI = \{([\s\S]*?)\n\}/)
+  assert.ok(match, 'missing preload CoworkAPI implementation')
+  return Array.from(match[1].matchAll(/^ {2}([a-zA-Z][\w]*): \{/gm), (entry) => entry[1]).sort()
+}
+
 test('IPC handler modules register their core channels', () => {
   const { context, handlers, listeners } = createTestContext()
 
@@ -144,6 +156,13 @@ test('preload invoke/send channels match registered main-process IPC channels', 
   assert.deepEqual(unexposedInvokeHandlers, [])
   assert.deepEqual(missingSendListeners, [])
   assert.deepEqual(unexposedSendListeners, [])
+})
+
+test('shared CoworkAPI groups match the preload implementation surface', () => {
+  const sharedSource = readFileSync('packages/shared/src/index.ts', 'utf-8')
+  const preloadSource = readFileSync('apps/desktop/src/preload/index.ts', 'utf-8')
+
+  assert.deepEqual(readPreloadApiGroups(preloadSource), readCoworkApiGroups(sharedSource))
 })
 
 test('provider auth IPC fails closed for malformed renderer input before runtime access', async () => {

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -20,6 +20,7 @@ import {
   configureWorkflowWebhookServer,
   ensureWorkflowWebhookServer,
   getWorkflowWebhookBaseUrl,
+  isWorkflowWebhookLoopbackBindAddress,
   signWorkflowWebhookPayload,
   stopWorkflowWebhookServer,
   verifyWorkflowWebhookAuth,
@@ -125,6 +126,8 @@ test('workflow webhook server accepts only scoped JSON POST triggers', async () 
       calls.push({ workflowId: input.workflowId, payload: input.payload })
     })
     const baseUrl = await ensureWorkflowWebhookServer()
+    assert.match(baseUrl, /^http:\/\/127\.0\.0\.1:\d+$/)
+    assert.equal(getWorkflowWebhookBaseUrl(), baseUrl)
 
     const notFound = await fetch(`${baseUrl}/unknown`, { method: 'POST', body: '{}' })
     assert.equal(notFound.status, 404)
@@ -157,6 +160,13 @@ test('workflow webhook server accepts only scoped JSON POST triggers', async () 
       payload: { source: 'test' },
     }])
   })
+})
+
+test('workflow webhook bind invariant accepts IPv4-mapped loopback addresses', () => {
+  assert.equal(isWorkflowWebhookLoopbackBindAddress('127.0.0.1'), true)
+  assert.equal(isWorkflowWebhookLoopbackBindAddress('::ffff:127.0.0.1'), true)
+  assert.equal(isWorkflowWebhookLoopbackBindAddress('0.0.0.0'), false)
+  assert.equal(isWorkflowWebhookLoopbackBindAddress('192.168.1.10'), false)
 })
 
 test('workflow webhook auth verifies HMAC payload signatures with replay bounds', () => {


### PR DESCRIPTION
## Summary
- harden the workflow webhook loopback binding with a runtime invariant and test coverage
- add a shared-package coverage ratchet and CoworkAPI/preload surface contract test
- prune obsolete dependency overrides while keeping the ip-address override that still prevents downgrade
- clarify privacy, performance, contributing, and shell environment security docs

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:coverage:node
- pnpm test:coverage:renderer
- node scripts/coverage-summary.mjs --check
- pnpm audit --prod --audit-level high
- uv run mkdocs build --strict
- pnpm perf:check
- pnpm test:e2e
- git diff --check