### PR TITLE
Add configurable update release sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ planned before broad distribution.
   tools can control chat timeline summaries without hardcoded tool-name rules.
 - Optional detached `SHA256SUMS.txt.asc` checksum signatures for tagged
   releases when a release GPG key is configured.
+- Configurable update release sources for downstream signed macOS builds,
+  including public GitHub Releases, generic HTTPS feeds, and private GCS feeds
+  authenticated through Google OAuth or a signed-URL broker.
 
 ### Changed
 
@@ -51,6 +54,9 @@ planned before broad distribution.
   timestamped HMAC.
 - Release policy now requires a configured checksum-signing key for Linux
   releases at `v1.0.0` and later.
+- Private update release source credentials stay in the main process; renderer
+  IPC receives only safe source labels/status, and signed URL query strings are
+  redacted from logs and diagnostics.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Windows is not currently supported.
 ## Install
 
 Release artifacts are published on [GitHub Releases](https://github.com/joe-broadhead/open-cowork/releases) when a tagged build completes.
+Signed macOS builds can check and install updates from Settings; downstream
+builders can configure private update release sources such as generic HTTPS
+feeds or Google Cloud Storage without exposing release credentials to the
+renderer.
 
 > **Important**
 > The `v0.x` public preview is intentionally unsigned while Apple Developer validation is pending. The release workflow can publish unsigned `v0.x` artifacts only when the explicit preview override is enabled; macOS will warn on first launch in that mode.

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -212,6 +212,11 @@ function normalizeConfig(raw: OpenCoworkConfig): OpenCoworkConfig {
       modelInfo: raw.providers?.modelInfo || DEFAULT_CONFIG.providers.modelInfo,
       custom: raw.providers?.custom || {},
     },
+    updates: {
+      ...DEFAULT_CONFIG.updates,
+      ...(raw.updates || {}),
+      ...(raw.updates?.releaseSource ? { releaseSource: { ...raw.updates.releaseSource } } : {}),
+    },
     tools: Array.isArray(raw.tools) ? raw.tools : [],
     skills: Array.isArray(raw.skills) ? raw.skills : [],
     mcps: Array.isArray(raw.mcps) ? raw.mcps : [],

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -5,6 +5,8 @@ import type {
   CredentialField,
   ModelInfoSnapshot,
   ProviderModelDescriptor,
+  UpdateReleaseSourceAuthKind,
+  UpdateReleaseSourceKind,
 } from '@open-cowork/shared'
 
 export type ConfiguredSkill = {
@@ -151,6 +153,44 @@ export type ConfiguredProviderDescriptor = {
   }
 }
 
+export type UpdateReleaseSourceConfig =
+  | {
+    kind: Extract<UpdateReleaseSourceKind, 'github-releases'>
+    label?: string
+    owner?: string
+    repo?: string
+    channel?: string
+    auth?: {
+      kind: Extract<UpdateReleaseSourceAuthKind, 'none' | 'github-token'>
+      token?: string
+    }
+  }
+  | {
+    kind: Extract<UpdateReleaseSourceKind, 'generic-http'>
+    label?: string
+    url: string
+    channel?: string
+    auth?: {
+      kind: Extract<UpdateReleaseSourceAuthKind, 'none' | 'static-headers'>
+      headers?: Record<string, string>
+    }
+  }
+  | {
+    kind: Extract<UpdateReleaseSourceKind, 'gcs'>
+    label?: string
+    bucket: string
+    prefix?: string
+    channel?: string
+    auth?: {
+      kind: Extract<UpdateReleaseSourceAuthKind, 'google-oauth'>
+      requiredScopes?: string[]
+    } | {
+      kind: Extract<UpdateReleaseSourceAuthKind, 'signed-url-broker'>
+      brokerUrl: string
+      requiredScopes?: string[]
+    }
+  }
+
 export type OpenCoworkConfig = {
   allowedEnvPlaceholders: string[]
   branding: BrandingConfig
@@ -169,6 +209,11 @@ export type OpenCoworkConfig = {
     defaultModel: string | null
     modelInfo?: Record<string, ConfiguredModelInfo>
     custom?: Record<string, CustomProviderRuntimeConfig>
+  }
+  updates?: {
+    enabled?: boolean
+    manualFallbackUrl?: string
+    releaseSource?: UpdateReleaseSourceConfig
   }
   tools: ConfiguredTool[]
   skills: ConfiguredSkill[]
@@ -258,6 +303,9 @@ export const DEFAULT_CONFIG: OpenCoworkConfig = {
     defaultModel: null,
     modelInfo: {},
     custom: {},
+  },
+  updates: {
+    enabled: true,
   },
   tools: [],
   skills: [],

--- a/apps/desktop/src/main/log-sanitizer.ts
+++ b/apps/desktop/src/main/log-sanitizer.ts
@@ -36,6 +36,7 @@ const TOKEN_PATTERNS = [
 
 const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
 const KEYED_SECRET_PATTERN = /\b(api[_-]?key|token|secret|password|client[_-]?secret)\s*[:=]\s*(['"]?)[A-Za-z0-9+/=_-]{32,}\2/gi
+const SIGNED_URL_QUERY_PATTERN = /\b(https?:\/\/[^\s"'<>?]+)\?[^"'<> \t\r\n]+/gi
 
 // Home-directory-prefixed paths leak usernames and project-folder
 // layouts into exported diagnostics bundles. Sanitizing every log
@@ -72,6 +73,7 @@ export function sanitizeLogMessage(message: string) {
     sanitized = sanitized.replace(pattern, '[REDACTED_TOKEN]')
   }
   sanitized = sanitized.replace(KEYED_SECRET_PATTERN, (_match, key: string) => `${key}=[REDACTED_TOKEN]`)
+  sanitized = sanitized.replace(SIGNED_URL_QUERY_PATTERN, '$1?[REDACTED_QUERY]')
 
   sanitized = sanitized.replace(EMAIL_PATTERN, '[REDACTED_EMAIL]')
   return sanitized

--- a/apps/desktop/src/main/update-check.ts
+++ b/apps/desktop/src/main/update-check.ts
@@ -1,40 +1,8 @@
-import semver from 'semver'
-import { getBranding } from './config-loader.ts'
 import { log } from './logger.ts'
-
-export type UpdateCheckResult =
-  | { status: 'ok'; currentVersion: string; latestVersion: string; hasUpdate: boolean; releaseUrl: string }
-  | { status: 'error'; currentVersion: string; message: string }
-  | { status: 'disabled'; currentVersion: string; message: string }
-
-// Parse owner/repo from a GitHub URL. Returns null for anything that
-// isn't github.com — downstream forks on GitLab / internal hosts
-// can extend this later; for now the upstream points at github.com.
-export function parseGithubRepo(url: string): { owner: string; repo: string } | null {
-  try {
-    const parsed = new URL(url)
-    if (parsed.hostname !== 'github.com' && parsed.hostname !== 'www.github.com') return null
-    const segments = parsed.pathname.split('/').filter(Boolean)
-    if (segments.length < 2) return null
-    const [owner, repoRaw] = segments
-    const repo = repoRaw.replace(/\.git$/, '')
-    if (!owner || !repo) return null
-    return { owner, repo }
-  } catch {
-    return null
-  }
-}
-
-function normalizeVersion(value: string): string {
-  const trimmed = value.trim()
-  return semver.clean(trimmed) || semver.coerce(trimmed)?.version || '0.0.0'
-}
-
-export function compareVersions(a: string, b: string): number {
-  return Math.sign(semver.compare(normalizeVersion(a), normalizeVersion(b)))
-}
-
-const FETCH_TIMEOUT_MS = 5000
+import type { UpdateCheckResult } from '@open-cowork/shared'
+import { resolveUpdateReleaseSource, UpdateReleaseSourceError } from './update-release-source.ts'
+import { sanitizeLogMessage } from './log-sanitizer.ts'
+export { compareVersions, parseGithubRepo } from './update-version.ts'
 
 // Package.json's `version` is load-bearing for this check — it's what
 // we compare against the remote `tag_name`. We read it lazily because
@@ -52,69 +20,25 @@ export async function getCurrentVersion(): Promise<string> {
   }
 }
 
-export async function checkForUpdates(): Promise<UpdateCheckResult> {
-  const current = await getCurrentVersion()
+export async function checkForUpdates(options: Parameters<typeof resolveUpdateReleaseSource>[0] = {}): Promise<UpdateCheckResult> {
+  const current = options?.currentVersion ?? await getCurrentVersion()
   try {
-    const helpUrl = getBranding().helpUrl?.trim()
-    if (!helpUrl) {
-      return {
-        status: 'disabled',
-        currentVersion: current,
-        message: 'No helpUrl configured — downstream builds set their own update endpoint.',
-      }
+    const source = await resolveUpdateReleaseSource({ ...options, currentVersion: current })
+    const result = await source.discoverLatest()
+    if (result.status === 'ok') {
+      log('app', `Update check: source=${source.descriptor.kind} current=${current} latest=${result.latestVersion} hasUpdate=${result.hasUpdate}`)
     }
-
-    const repo = parseGithubRepo(helpUrl)
-    if (!repo) {
-      return {
-        status: 'disabled',
-        currentVersion: current,
-        message: 'Update check only supports GitHub-hosted releases. Downstream forks can wire their own endpoint.',
-      }
-    }
-
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-    try {
-      const response = await fetch(`https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/latest`, {
-        signal: controller.signal,
-        headers: {
-          // Identify the client so GitHub's unauthenticated rate limit
-          // bucket is at least attributable if a downstream user hits
-          // it. The 60/hr limit on anonymous requests is plenty for a
-          // user-initiated click.
-          'User-Agent': 'open-cowork-update-check',
-          'Accept': 'application/vnd.github+json',
-        },
-      })
-
-      if (response.status === 404) {
-        return { status: 'error', currentVersion: current, message: 'No releases published yet.' }
-      }
-      if (!response.ok) {
-        return { status: 'error', currentVersion: current, message: `GitHub API responded with ${response.status}.` }
-      }
-      const body = await response.json() as { tag_name?: string; html_url?: string }
-      if (!body.tag_name || !body.html_url) {
-        return { status: 'error', currentVersion: current, message: 'Malformed release payload.' }
-      }
-
-      const hasUpdate = compareVersions(body.tag_name, current) > 0
-
-      log('app', `Update check: current=${current} latest=${body.tag_name} hasUpdate=${hasUpdate}`)
-
-      return {
-        status: 'ok',
-        currentVersion: current,
-        latestVersion: normalizeVersion(body.tag_name),
-        hasUpdate,
-        releaseUrl: body.html_url,
-      }
-    } finally {
-      clearTimeout(timeout)
-    }
+    return result
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    if (err instanceof UpdateReleaseSourceError) {
+      const disabledReasons = new Set(['source-disabled', 'source-misconfigured', 'auth-required', 'auth-expired'])
+      return {
+        status: disabledReasons.has(err.reason) ? 'disabled' : 'error',
+        currentVersion: current,
+        message: sanitizeLogMessage(err.message),
+      }
+    }
+    const message = sanitizeLogMessage(err instanceof Error ? err.message : String(err))
     return { status: 'error', currentVersion: current, message }
   }
 }

--- a/apps/desktop/src/main/update-release-source-gcs.ts
+++ b/apps/desktop/src/main/update-release-source-gcs.ts
@@ -1,0 +1,59 @@
+import type { UpdateReleaseSourceDescriptor } from '@open-cowork/shared'
+import type { UpdateReleaseSourceConfig } from './config-types.ts'
+import { normalizeUpdateSourceUrl } from './update-release-source-generic.ts'
+
+export type GcsReleaseSourceConfig = Extract<UpdateReleaseSourceConfig, { kind: 'gcs' }>
+
+function encodePathSegment(value: string) {
+  return encodeURIComponent(value).replace(/%2F/gi, '/')
+}
+
+export function normalizeGcsPrefix(prefix?: string | null) {
+  const trimmed = prefix?.trim().replace(/^\/+|\/+$/g, '') || ''
+  if (!trimmed) return ''
+  const segments = trimmed.split('/').filter(Boolean)
+  if (segments.some((segment) => segment === '..' || segment === '.')) return null
+  return segments.map(encodePathSegment).join('/')
+}
+
+export function gcsReleaseBaseUrl(input: { bucket: string; prefix?: string | null; channel: string }) {
+  const bucket = input.bucket.trim()
+  if (!bucket) return null
+  const prefix = normalizeGcsPrefix(input.prefix)
+  if (prefix === null) return null
+  const path = [bucket, prefix, input.channel].filter(Boolean).join('/')
+  return `https://storage.googleapis.com/${path}/`
+}
+
+export function gcsReleaseSourceDescriptor(input: {
+  label: string
+  channel: string
+  authKind: 'google-oauth' | 'signed-url-broker'
+}): UpdateReleaseSourceDescriptor {
+  return {
+    kind: 'gcs',
+    label: input.label,
+    channel: input.channel,
+    requiresAuth: true,
+    authKind: input.authKind,
+  }
+}
+
+export function normalizeBrokerProviderPayload(value: unknown): {
+  providerUrl: string
+  requestHeaders: Record<string, string>
+} | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const providerUrl = typeof record.providerUrl === 'string'
+    ? normalizeUpdateSourceUrl(record.providerUrl)
+    : null
+  if (!providerUrl) return null
+  const requestHeaders = record.requestHeaders && typeof record.requestHeaders === 'object' && !Array.isArray(record.requestHeaders)
+    ? Object.fromEntries(
+        Object.entries(record.requestHeaders as Record<string, unknown>)
+          .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[0].trim().length > 0),
+      )
+    : {}
+  return { providerUrl, requestHeaders }
+}

--- a/apps/desktop/src/main/update-release-source-generic.ts
+++ b/apps/desktop/src/main/update-release-source-generic.ts
@@ -1,0 +1,48 @@
+import type { UpdateReleaseSourceDescriptor } from '@open-cowork/shared'
+import type { UpdateReleaseSourceConfig } from './config-types.ts'
+
+export type GenericHttpReleaseSourceConfig = Extract<UpdateReleaseSourceConfig, { kind: 'generic-http' }>
+
+export function normalizeUpdateSourceUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value)
+    const isLocalHttp = parsed.protocol === 'http:'
+      && (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost')
+    if (parsed.protocol !== 'https:' && !isLocalHttp) return null
+    parsed.username = ''
+    parsed.password = ''
+    parsed.hash = ''
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+export function channelFileName(channel: string) {
+  return `${channel}-mac.yml`
+}
+
+export function releaseFeedFileUrl(baseUrl: string, channel: string) {
+  const base = new URL(baseUrl)
+  if (!base.pathname.endsWith('/')) base.pathname += '/'
+  return new URL(channelFileName(channel), base).toString()
+}
+
+export function genericReleaseSourceDescriptor(input: {
+  label: string
+  channel: string
+  hasHeaders: boolean
+}): UpdateReleaseSourceDescriptor {
+  return {
+    kind: 'generic-http',
+    label: input.label,
+    channel: input.channel,
+    requiresAuth: input.hasHeaders,
+    authKind: input.hasHeaders ? 'static-headers' : 'none',
+  }
+}
+
+export function parseUpdateInfoVersion(yamlText: string): string | null {
+  const match = yamlText.match(/(?:^|\n)version:\s*["']?([^"'\n\r]+)["']?/)
+  return match?.[1]?.trim() || null
+}

--- a/apps/desktop/src/main/update-release-source-github.ts
+++ b/apps/desktop/src/main/update-release-source-github.ts
@@ -1,0 +1,48 @@
+import type { UpdateReleaseSourceDescriptor } from '@open-cowork/shared'
+import type { UpdateReleaseSourceConfig } from './config-types.ts'
+import { parseGithubRepo } from './update-version.ts'
+
+export type GithubReleaseSourceConfig = Extract<UpdateReleaseSourceConfig, { kind: 'github-releases' }>
+
+export function resolveGithubReleaseSourceInput(input: {
+  config?: GithubReleaseSourceConfig
+  brandingHelpUrl?: string | null
+}): { owner: string; repo: string; channel: string; label: string; token: string | null } | null {
+  const channel = input.config?.channel?.trim() || 'latest'
+  const label = input.config?.label?.trim() || 'GitHub Releases'
+  const token = input.config?.auth?.kind === 'github-token' && input.config.auth.token?.trim()
+    ? input.config.auth.token.trim()
+    : null
+
+  const owner = input.config?.owner?.trim()
+  const repo = input.config?.repo?.trim()
+  if (owner && repo) return { owner, repo, channel, label, token }
+
+  const parsed = input.brandingHelpUrl ? parseGithubRepo(input.brandingHelpUrl) : null
+  if (!parsed) return null
+  return { ...parsed, channel, label, token }
+}
+
+export function githubReleaseSourceDescriptor(input: {
+  label: string
+  channel: string
+  token: string | null
+}): UpdateReleaseSourceDescriptor {
+  return {
+    kind: 'github-releases',
+    label: input.label,
+    channel: input.channel,
+    requiresAuth: Boolean(input.token),
+    authKind: input.token ? 'github-token' : 'none',
+  }
+}
+
+export function githubApiReleaseUrl(owner: string, repo: string, channel: string) {
+  return channel === 'latest'
+    ? `https://api.github.com/repos/${owner}/${repo}/releases/latest`
+    : `https://api.github.com/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(channel)}`
+}
+
+export function githubHtmlReleasesUrl(owner: string, repo: string) {
+  return `https://github.com/${owner}/${repo}/releases`
+}

--- a/apps/desktop/src/main/update-release-source.ts
+++ b/apps/desktop/src/main/update-release-source.ts
@@ -1,0 +1,514 @@
+import type {
+  AuthState,
+  UpdateCheckResult,
+  UpdateInstallUnsupportedReason,
+  UpdateReleaseSourceDescriptor,
+} from '@open-cowork/shared'
+import type { OpenCoworkConfig, UpdateReleaseSourceConfig } from './config-types.ts'
+import { getAppConfig, getBranding } from './config-loader.ts'
+import { compareVersions, normalizeVersion } from './update-version.ts'
+import {
+  githubApiReleaseUrl,
+  githubHtmlReleasesUrl,
+  githubReleaseSourceDescriptor,
+  resolveGithubReleaseSourceInput,
+} from './update-release-source-github.ts'
+import {
+  genericReleaseSourceDescriptor,
+  normalizeUpdateSourceUrl,
+  parseUpdateInfoVersion,
+  releaseFeedFileUrl,
+} from './update-release-source-generic.ts'
+import {
+  gcsReleaseBaseUrl,
+  gcsReleaseSourceDescriptor,
+  normalizeBrokerProviderPayload,
+} from './update-release-source-gcs.ts'
+
+const DEFAULT_CHANNEL = 'latest'
+const DEFAULT_GCS_REQUIRED_SCOPE = 'https://www.googleapis.com/auth/devstorage.read_only'
+const GOOGLE_CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform'
+const FETCH_TIMEOUT_MS = 5000
+
+export type ElectronUpdaterProviderConfig = Record<string, unknown>
+
+export interface ResolvedUpdateReleaseSource {
+  descriptor: UpdateReleaseSourceDescriptor
+  manualReleaseUrl: string | null
+  installProvider: ElectronUpdaterProviderConfig
+  requestHeaders: Record<string, string>
+  discoverLatest: () => Promise<UpdateCheckResult>
+}
+
+export class UpdateReleaseSourceError extends Error {
+  readonly reason: UpdateInstallUnsupportedReason
+  readonly descriptor: UpdateReleaseSourceDescriptor | null
+  readonly manualReleaseUrl: string | null
+
+  constructor(
+    reason: UpdateInstallUnsupportedReason,
+    message: string,
+    options: {
+      descriptor?: UpdateReleaseSourceDescriptor | null
+      manualReleaseUrl?: string | null
+      cause?: unknown
+    } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause })
+    this.name = 'UpdateReleaseSourceError'
+    this.reason = reason
+    this.descriptor = options.descriptor ?? null
+    this.manualReleaseUrl = options.manualReleaseUrl ?? null
+  }
+}
+
+export interface ResolveUpdateReleaseSourceOptions {
+  config?: OpenCoworkConfig
+  currentVersion?: string
+  fetchImpl?: typeof fetch
+  getAuthState?: () => AuthState
+  refreshGoogleAccessToken?: () => Promise<string | null>
+}
+
+function channelFromConfig(config?: { channel?: string }) {
+  return config?.channel?.trim() || DEFAULT_CHANNEL
+}
+
+function safeManualReleaseUrl(value?: string | null) {
+  if (!value) return null
+  return normalizeUpdateSourceUrl(value.trim())
+}
+
+function updateConfig(config: OpenCoworkConfig) {
+  return config.updates || { enabled: true }
+}
+
+function releaseSourceConfig(config: OpenCoworkConfig): UpdateReleaseSourceConfig | undefined {
+  return updateConfig(config).releaseSource
+}
+
+function manualReleaseUrlFor(config: OpenCoworkConfig, fallback?: string | null) {
+  return safeManualReleaseUrl(updateConfig(config).manualFallbackUrl) || safeManualReleaseUrl(fallback)
+}
+
+async function currentVersionFromOptions(options: ResolveUpdateReleaseSourceOptions) {
+  if (options.currentVersion) return options.currentVersion
+  try {
+    const electron = await import('electron')
+    return electron.app?.getVersion?.() || '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
+
+async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function fetchTextOrThrow(input: {
+  fetchImpl: typeof fetch
+  url: string
+  headers?: Record<string, string>
+  descriptor: UpdateReleaseSourceDescriptor
+  manualReleaseUrl: string | null
+}) {
+  const response = await fetchWithTimeout(input.fetchImpl, input.url, {
+    headers: input.headers || {},
+  })
+  if (response.status === 401 || response.status === 403) {
+    throw new UpdateReleaseSourceError(
+      'auth-forbidden',
+      'The private update release source rejected the current credentials.',
+      { descriptor: input.descriptor, manualReleaseUrl: input.manualReleaseUrl },
+    )
+  }
+  if (!response.ok) {
+    throw new UpdateReleaseSourceError(
+      'source-unreachable',
+      `The update release source responded with ${response.status}.`,
+      { descriptor: input.descriptor, manualReleaseUrl: input.manualReleaseUrl },
+    )
+  }
+  return response.text()
+}
+
+function hasRequiredGoogleScopes(config: OpenCoworkConfig, requiredScopes: string[]) {
+  if (config.auth.mode !== 'google-oauth') return false
+  const configured = new Set(config.auth.googleOAuth?.scopes?.length
+    ? config.auth.googleOAuth.scopes
+    : [GOOGLE_CLOUD_PLATFORM_SCOPE])
+  if (configured.has(GOOGLE_CLOUD_PLATFORM_SCOPE)) return true
+  return requiredScopes.every((scope) => configured.has(scope))
+}
+
+async function resolveGoogleAccessToken(input: {
+  config: OpenCoworkConfig
+  descriptor: UpdateReleaseSourceDescriptor
+  manualReleaseUrl: string | null
+  options: ResolveUpdateReleaseSourceOptions
+  requiredScopes?: string[]
+}) {
+  const requiredScopes = input.requiredScopes?.length ? input.requiredScopes : [DEFAULT_GCS_REQUIRED_SCOPE]
+  if (input.config.auth.mode !== 'google-oauth' || !hasRequiredGoogleScopes(input.config, requiredScopes)) {
+    throw new UpdateReleaseSourceError(
+      'source-misconfigured',
+      'This private update release source requires Google OAuth with release-read scopes.',
+      { descriptor: input.descriptor, manualReleaseUrl: input.manualReleaseUrl },
+    )
+  }
+  const authState = input.options.getAuthState
+    ? input.options.getAuthState()
+    : (await import('./auth.ts')).getAuthState()
+  if (!authState.authenticated) {
+    throw new UpdateReleaseSourceError(
+      'auth-required',
+      'Sign in with Google to check this private update release source.',
+      { descriptor: input.descriptor, manualReleaseUrl: input.manualReleaseUrl },
+    )
+  }
+  const token = input.options.refreshGoogleAccessToken
+    ? await input.options.refreshGoogleAccessToken()
+    : await (await import('./auth.ts')).refreshAccessToken()
+  if (!token) {
+    throw new UpdateReleaseSourceError(
+      'auth-expired',
+      'Your Google session expired before the private update release source could be checked.',
+      { descriptor: input.descriptor, manualReleaseUrl: input.manualReleaseUrl },
+    )
+  }
+  return token
+}
+
+function checkResultFromLatest(input: {
+  currentVersion: string
+  latestVersion: string
+  releaseUrl: string
+}): UpdateCheckResult {
+  const latestVersion = normalizeVersion(input.latestVersion)
+  return {
+    status: 'ok',
+    currentVersion: input.currentVersion,
+    latestVersion,
+    hasUpdate: compareVersions(latestVersion, input.currentVersion) > 0,
+    releaseUrl: input.releaseUrl,
+  }
+}
+
+async function resolveGithubSource(input: {
+  config: OpenCoworkConfig
+  sourceConfig?: Extract<UpdateReleaseSourceConfig, { kind: 'github-releases' }>
+  options: ResolveUpdateReleaseSourceOptions
+  currentVersion: string
+}) {
+  const normalized = resolveGithubReleaseSourceInput({
+    config: input.sourceConfig,
+    brandingHelpUrl: input.config.branding.helpUrl,
+  })
+  if (!normalized) {
+    throw new UpdateReleaseSourceError(
+      'source-misconfigured',
+      'No GitHub release source is configured.',
+      { manualReleaseUrl: manualReleaseUrlFor(input.config, null) },
+    )
+  }
+  const descriptor = githubReleaseSourceDescriptor(normalized)
+  const manualReleaseUrl = manualReleaseUrlFor(input.config, githubHtmlReleasesUrl(normalized.owner, normalized.repo))
+  const requestHeaders: Record<string, string> = normalized.token ? { Authorization: `Bearer ${normalized.token}` } : {}
+
+  return {
+    descriptor,
+    manualReleaseUrl,
+    installProvider: {
+      provider: 'github',
+      owner: normalized.owner,
+      repo: normalized.repo,
+      channel: normalized.channel,
+      ...(normalized.token ? { private: true, token: normalized.token } : {}),
+    },
+    requestHeaders,
+    discoverLatest: async () => {
+      const responseText = await fetchTextOrThrow({
+        fetchImpl: input.options.fetchImpl || fetch,
+        url: githubApiReleaseUrl(normalized.owner, normalized.repo, normalized.channel),
+        headers: {
+          'User-Agent': 'open-cowork-update-check',
+          'Accept': 'application/vnd.github+json',
+          ...requestHeaders,
+        },
+        descriptor,
+        manualReleaseUrl,
+      })
+      const body = JSON.parse(responseText) as { tag_name?: string; html_url?: string }
+      if (!body.tag_name || !body.html_url) {
+        throw new UpdateReleaseSourceError(
+          'source-unreachable',
+          'The GitHub release payload was malformed.',
+          { descriptor, manualReleaseUrl },
+        )
+      }
+      return checkResultFromLatest({
+        currentVersion: input.currentVersion,
+        latestVersion: body.tag_name,
+        releaseUrl: body.html_url,
+      })
+    },
+  } satisfies ResolvedUpdateReleaseSource
+}
+
+function staticHeaders(sourceConfig: Extract<UpdateReleaseSourceConfig, { kind: 'generic-http' }>) {
+  if (sourceConfig.auth?.kind !== 'static-headers') return {}
+  return Object.fromEntries(
+    Object.entries(sourceConfig.auth.headers || {})
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[0].trim().length > 0),
+  )
+}
+
+async function resolveGenericSource(input: {
+  config: OpenCoworkConfig
+  sourceConfig: Extract<UpdateReleaseSourceConfig, { kind: 'generic-http' }>
+  currentVersion: string
+  options: ResolveUpdateReleaseSourceOptions
+}) {
+  const url = normalizeUpdateSourceUrl(input.sourceConfig.url)
+  if (!url) {
+    throw new UpdateReleaseSourceError('source-misconfigured', 'The generic update release source URL must be HTTPS.')
+  }
+  const channel = channelFromConfig(input.sourceConfig)
+  const requestHeaders = staticHeaders(input.sourceConfig)
+  const descriptor = genericReleaseSourceDescriptor({
+    label: input.sourceConfig.label?.trim() || 'Private release feed',
+    channel,
+    hasHeaders: Object.keys(requestHeaders).length > 0,
+  })
+  const manualReleaseFallback = Object.keys(requestHeaders).length > 0 ? null : url
+  const manualReleaseUrl = manualReleaseUrlFor(input.config, manualReleaseFallback)
+  return {
+    descriptor,
+    manualReleaseUrl,
+    installProvider: {
+      provider: 'generic',
+      url,
+      channel,
+      ...(Object.keys(requestHeaders).length > 0 ? { requestHeaders } : {}),
+    },
+    requestHeaders,
+    discoverLatest: async () => {
+      const yamlText = await fetchTextOrThrow({
+        fetchImpl: input.options.fetchImpl || fetch,
+        url: releaseFeedFileUrl(url, channel),
+        headers: requestHeaders,
+        descriptor,
+        manualReleaseUrl,
+      })
+      const latestVersion = parseUpdateInfoVersion(yamlText)
+      if (!latestVersion) {
+        throw new UpdateReleaseSourceError(
+          'source-unreachable',
+          'The update feed metadata did not include a version.',
+          { descriptor, manualReleaseUrl },
+        )
+      }
+      return checkResultFromLatest({
+        currentVersion: input.currentVersion,
+        latestVersion,
+        releaseUrl: manualReleaseUrl || (Object.keys(requestHeaders).length > 0 ? '' : url),
+      })
+    },
+  } satisfies ResolvedUpdateReleaseSource
+}
+
+async function resolveGcsSource(input: {
+  config: OpenCoworkConfig
+  sourceConfig: Extract<UpdateReleaseSourceConfig, { kind: 'gcs' }>
+  currentVersion: string
+  options: ResolveUpdateReleaseSourceOptions
+}) {
+  const channel = channelFromConfig(input.sourceConfig)
+  const auth = input.sourceConfig.auth || { kind: 'google-oauth' as const }
+  const descriptor = gcsReleaseSourceDescriptor({
+    label: input.sourceConfig.label?.trim() || 'Private release feed',
+    channel,
+    authKind: auth.kind,
+  })
+  const manualReleaseUrl = manualReleaseUrlFor(input.config, null)
+  const token = await resolveGoogleAccessToken({
+    config: input.config,
+    descriptor,
+    manualReleaseUrl,
+    options: input.options,
+    requiredScopes: auth.requiredScopes,
+  })
+
+  if (auth.kind === 'signed-url-broker') {
+    const brokerUrl = normalizeUpdateSourceUrl(auth.brokerUrl)
+    if (!brokerUrl) {
+      throw new UpdateReleaseSourceError(
+        'source-misconfigured',
+        'The signed update URL broker must use HTTPS.',
+        { descriptor, manualReleaseUrl },
+      )
+    }
+    const response = await fetchWithTimeout(input.options.fetchImpl || fetch, brokerUrl, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        channel,
+        platform: 'darwin',
+      }),
+    })
+    if (response.status === 401 || response.status === 403) {
+      throw new UpdateReleaseSourceError(
+        'auth-forbidden',
+        'The update URL broker rejected the current credentials.',
+        { descriptor, manualReleaseUrl },
+      )
+    }
+    if (!response.ok) {
+      throw new UpdateReleaseSourceError(
+        'source-unreachable',
+        `The update URL broker responded with ${response.status}.`,
+        { descriptor, manualReleaseUrl },
+      )
+    }
+    const brokerPayload = normalizeBrokerProviderPayload(await response.json())
+    if (!brokerPayload) {
+      throw new UpdateReleaseSourceError(
+        'source-unreachable',
+        'The update URL broker returned malformed release metadata.',
+        { descriptor, manualReleaseUrl },
+      )
+    }
+    const requestHeaders = brokerPayload.requestHeaders
+    return {
+      descriptor,
+      manualReleaseUrl,
+      installProvider: {
+        provider: 'generic',
+        url: brokerPayload.providerUrl,
+        channel,
+        ...(Object.keys(requestHeaders).length > 0 ? { requestHeaders } : {}),
+      },
+      requestHeaders,
+      discoverLatest: async () => {
+        const yamlText = await fetchTextOrThrow({
+          fetchImpl: input.options.fetchImpl || fetch,
+          url: releaseFeedFileUrl(brokerPayload.providerUrl, channel),
+          headers: requestHeaders,
+          descriptor,
+          manualReleaseUrl,
+        })
+        const latestVersion = parseUpdateInfoVersion(yamlText)
+        if (!latestVersion) {
+          throw new UpdateReleaseSourceError(
+            'source-unreachable',
+            'The brokered update feed metadata did not include a version.',
+            { descriptor, manualReleaseUrl },
+          )
+        }
+        return checkResultFromLatest({
+          currentVersion: input.currentVersion,
+          latestVersion,
+          releaseUrl: manualReleaseUrl || '',
+        })
+      },
+    } satisfies ResolvedUpdateReleaseSource
+  }
+
+  const baseUrl = gcsReleaseBaseUrl({
+    bucket: input.sourceConfig.bucket,
+    prefix: input.sourceConfig.prefix,
+    channel,
+  })
+  if (!baseUrl) {
+    throw new UpdateReleaseSourceError(
+      'source-misconfigured',
+      'The GCS update release source is missing a valid bucket or prefix.',
+      { descriptor, manualReleaseUrl },
+    )
+  }
+  const requestHeaders = { Authorization: `Bearer ${token}` }
+  return {
+    descriptor,
+    manualReleaseUrl,
+    installProvider: {
+      provider: 'generic',
+      url: baseUrl,
+      channel,
+      requestHeaders,
+    },
+    requestHeaders,
+    discoverLatest: async () => {
+      const yamlText = await fetchTextOrThrow({
+        fetchImpl: input.options.fetchImpl || fetch,
+        url: releaseFeedFileUrl(baseUrl, channel),
+        headers: requestHeaders,
+        descriptor,
+        manualReleaseUrl,
+      })
+      const latestVersion = parseUpdateInfoVersion(yamlText)
+      if (!latestVersion) {
+        throw new UpdateReleaseSourceError(
+          'source-unreachable',
+          'The GCS update feed metadata did not include a version.',
+          { descriptor, manualReleaseUrl },
+        )
+      }
+      return checkResultFromLatest({
+        currentVersion: input.currentVersion,
+        latestVersion,
+        releaseUrl: manualReleaseUrl || 'https://storage.cloud.google.com/',
+      })
+    },
+  } satisfies ResolvedUpdateReleaseSource
+}
+
+export async function resolveUpdateReleaseSource(
+  options: ResolveUpdateReleaseSourceOptions = {},
+): Promise<ResolvedUpdateReleaseSource> {
+  const config = options.config || getAppConfig()
+  const currentVersion = await currentVersionFromOptions(options)
+  const updates = updateConfig(config)
+  if (updates.enabled === false) {
+    throw new UpdateReleaseSourceError(
+      'source-disabled',
+      'Update checks are disabled for this build.',
+      { manualReleaseUrl: manualReleaseUrlFor(config, config.branding.helpUrl) },
+    )
+  }
+
+  const source = releaseSourceConfig(config)
+  if (!source) {
+    return resolveGithubSource({
+      config,
+      currentVersion,
+      options,
+    })
+  }
+  switch (source.kind) {
+    case 'github-releases':
+      return resolveGithubSource({ config, sourceConfig: source, currentVersion, options })
+    case 'generic-http':
+      return resolveGenericSource({ config, sourceConfig: source, currentVersion, options })
+    case 'gcs':
+      return resolveGcsSource({ config, sourceConfig: source, currentVersion, options })
+    default:
+      throw new UpdateReleaseSourceError(
+        'source-misconfigured',
+        'The update release source kind is not supported.',
+        { manualReleaseUrl: manualReleaseUrlFor(config, getBranding().helpUrl) },
+      )
+  }
+}

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -16,19 +16,32 @@ import type {
   UpdateInfo,
 } from 'electron-updater'
 import { getBranding } from './config-loader.ts'
+import type { OpenCoworkConfig } from './config-types.ts'
 import { log } from './logger.ts'
+import { sanitizeLogMessage } from './log-sanitizer.ts'
 import { getCurrentVersion, parseGithubRepo } from './update-check.ts'
+import {
+  type ResolvedUpdateReleaseSource,
+  type ResolveUpdateReleaseSourceOptions,
+  resolveUpdateReleaseSource,
+  UpdateReleaseSourceError,
+} from './update-release-source.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
 const updateInstallCapabilityResourceName = 'open-cowork-update-capability.json'
 const updateInstallEventSubscribers = new Set<(event: UpdateInstallEvent) => void>()
 const configuredUpdaters = new WeakSet<UpdateInstallRuntime>()
+const updaterCapabilities = new WeakMap<UpdateInstallRuntime, UpdateInstallCapability>()
+let defaultInstallUpdater: UpdateInstallRuntime | null = null
 let availableUpdateVersion: string | null = null
 let downloadedUpdateVersion: string | null = null
 
 interface UpdateInstallCapabilityResource {
+  schemaVersion?: number
   signedInstallEligible: boolean
   feedConfigured: boolean
+  releaseSourceKind?: string
+  channel?: string
 }
 
 type UpdateInstallRuntime = Pick<AppUpdater,
@@ -37,9 +50,11 @@ type UpdateInstallRuntime = Pick<AppUpdater,
   | 'checkForUpdates'
   | 'downloadUpdate'
   | 'quitAndInstall'
+  | 'setFeedURL'
   | 'on'
 > & {
   logger: AppUpdater['logger']
+  requestHeaders: AppUpdater['requestHeaders']
 }
 
 type UpdateServiceOptions = {
@@ -50,6 +65,10 @@ type UpdateServiceOptions = {
   currentVersion?: string
   manualReleaseUrl?: string | null
   resourcePath?: string | null
+  config?: OpenCoworkConfig
+  getAuthState?: ResolveUpdateReleaseSourceOptions['getAuthState']
+  refreshGoogleAccessToken?: ResolveUpdateReleaseSourceOptions['refreshGoogleAccessToken']
+  fetchImpl?: ResolveUpdateReleaseSourceOptions['fetchImpl']
 }
 
 type UpdateActionOptions = UpdateServiceOptions & {
@@ -77,13 +96,29 @@ function reasonCapability(input: {
   return null
 }
 
+function sourceErrorCapability(
+  error: UpdateReleaseSourceError,
+  currentVersion: string,
+): UpdateInstallCapability {
+  return {
+    supported: false,
+    reason: error.reason,
+    currentVersion,
+    manualReleaseUrl: error.manualReleaseUrl,
+    releaseSource: error.descriptor,
+  }
+}
+
 function normalizeEmbeddedCapability(value: unknown): UpdateInstallCapabilityResource | null {
   if (!value || typeof value !== 'object') return null
   const record = value as Record<string, unknown>
-  if (record.schemaVersion !== 1) return null
+  if (record.schemaVersion !== 1 && record.schemaVersion !== 2) return null
   return {
+    schemaVersion: typeof record.schemaVersion === 'number' ? record.schemaVersion : undefined,
     signedInstallEligible: record.signedInstallEligible === true,
     feedConfigured: record.feedConfigured === true,
+    releaseSourceKind: typeof record.releaseSourceKind === 'string' ? record.releaseSourceKind : undefined,
+    channel: typeof record.channel === 'string' ? record.channel : undefined,
   }
 }
 
@@ -104,11 +139,12 @@ function readEmbeddedUpdateInstallCapability(resourcePath?: string | null): Upda
 }
 
 function safeMessage(error: unknown) {
-  return error instanceof Error
+  const message = error instanceof Error
     ? error.message
     : typeof error === 'string'
       ? error
       : 'Update installation failed.'
+  return sanitizeLogMessage(message)
 }
 
 function updateInfoVersion(info?: Pick<UpdateInfo, 'version'> | null) {
@@ -171,9 +207,20 @@ function errorStatus(capability: UpdateInstallCapability, error: unknown): Updat
   }
 }
 
-function configureUpdater(updater: UpdateInstallRuntime, capability: UpdateInstallCapability) {
+function capabilityForUpdater(updater: UpdateInstallRuntime, fallback: UpdateInstallCapability) {
+  return updaterCapabilities.get(updater) || fallback
+}
+
+function configureUpdater(
+  updater: UpdateInstallRuntime,
+  capability: UpdateInstallCapability,
+  source: ResolvedUpdateReleaseSource,
+) {
   updater.autoDownload = false
   updater.autoInstallOnAppQuit = false
+  updater.setFeedURL(source.installProvider as Parameters<UpdateInstallRuntime['setFeedURL']>[0])
+  updater.requestHeaders = Object.keys(source.requestHeaders).length > 0 ? source.requestHeaders : null
+  updaterCapabilities.set(updater, capability)
   updater.logger = {
     info: (message?: unknown) => log('updates', String(message ?? '')),
     warn: (message?: unknown) => log('updates', `warning: ${String(message ?? '')}`),
@@ -182,54 +229,75 @@ function configureUpdater(updater: UpdateInstallRuntime, capability: UpdateInsta
   if (configuredUpdaters.has(updater)) return
   configuredUpdaters.add(updater)
   updater.on('checking-for-update', () => {
+    const current = capabilityForUpdater(updater, capability)
     publishUpdateInstallEvent({
       status: 'checking',
-      currentVersion: capability.currentVersion,
-      manualReleaseUrl: capability.manualReleaseUrl,
+      currentVersion: current.currentVersion,
+      manualReleaseUrl: current.manualReleaseUrl,
     })
   })
   updater.on('download-progress', (info: ProgressInfo) => {
+    const current = capabilityForUpdater(updater, capability)
     publishUpdateInstallEvent({
       status: 'downloading',
-      currentVersion: capability.currentVersion,
-      latestVersion: availableUpdateVersion || downloadedUpdateVersion || capability.currentVersion,
+      currentVersion: current.currentVersion,
+      latestVersion: availableUpdateVersion || downloadedUpdateVersion || current.currentVersion,
       progress: normalizeProgress(info),
-      manualReleaseUrl: capability.manualReleaseUrl,
+      manualReleaseUrl: current.manualReleaseUrl,
     })
   })
   updater.on('update-downloaded', (event: UpdateDownloadedEvent) => {
-    downloadedUpdateVersion = updateInfoVersion(event) || downloadedUpdateVersion || capability.currentVersion
-    publishUpdateInstallEvent(statusFromUpdateInfo('downloaded', capability, event))
+    const current = capabilityForUpdater(updater, capability)
+    downloadedUpdateVersion = updateInfoVersion(event) || downloadedUpdateVersion || current.currentVersion
+    publishUpdateInstallEvent(statusFromUpdateInfo('downloaded', current, event))
   })
   updater.on('update-cancelled', (info: UpdateInfo) => {
+    const current = capabilityForUpdater(updater, capability)
     publishUpdateInstallEvent({
       status: 'error',
-      currentVersion: capability.currentVersion,
+      currentVersion: current.currentVersion,
       latestVersion: updateInfoVersion(info) || undefined,
       message: 'Update download was cancelled.',
-      manualReleaseUrl: capability.manualReleaseUrl,
+      manualReleaseUrl: current.manualReleaseUrl,
     })
   })
   updater.on('error', (error: Error) => {
+    const current = capabilityForUpdater(updater, capability)
     log('error', `updates.install failed: ${safeMessage(error)}`)
-    publishUpdateInstallEvent(errorStatus(capability, error))
+    publishUpdateInstallEvent(errorStatus(current, error))
   })
 }
 
 async function getDefaultUpdater(): Promise<UpdateInstallRuntime> {
-  const { autoUpdater } = await import('electron-updater')
-  return autoUpdater
+  if (defaultInstallUpdater) return defaultInstallUpdater
+  const { MacUpdater, autoUpdater } = await import('electron-updater')
+  const updater = process.platform === 'darwin'
+    ? new MacUpdater()
+    : autoUpdater
+  defaultInstallUpdater = updater
+  return updater
 }
 
 async function getGuardedUpdater(options: UpdateActionOptions = {}) {
-  const capability = await getUpdateInstallCapability(options)
+  const context = await getUpdateInstallContext(options)
+  const { capability, source } = context
   if (!capability.supported) {
     const status = unsupportedStatus(capability)
     publishUpdateInstallEvent(status)
     return { capability, status, updater: null }
   }
+  if (!source) {
+    const unavailable: UpdateInstallCapability = {
+      ...capability,
+      supported: false,
+      reason: 'unavailable',
+    }
+    const status = unsupportedStatus(unavailable)
+    publishUpdateInstallEvent(status)
+    return { capability: unavailable, status, updater: null }
+  }
   const updater = options.updater || await getDefaultUpdater()
-  configureUpdater(updater, capability)
+  configureUpdater(updater, capability, source)
   return { capability, status: null, updater }
 }
 
@@ -241,31 +309,87 @@ function assertSupportedGuard(result: Awaited<ReturnType<typeof getGuardedUpdate
   return result.updater
 }
 
-export async function getUpdateInstallCapability(options?: UpdateServiceOptions): Promise<UpdateInstallCapability> {
+async function getUpdateInstallContext(options: UpdateServiceOptions = {}): Promise<{
+  capability: UpdateInstallCapability
+  source: ResolvedUpdateReleaseSource | null
+}> {
   const embedded = readEmbeddedUpdateInstallCapability(options?.resourcePath)
   const currentVersion = options?.currentVersion ?? await getCurrentVersion()
+  let source: ResolvedUpdateReleaseSource | null = null
+  let sourceError: UpdateReleaseSourceError | null = null
+  try {
+    source = await resolveUpdateReleaseSource({
+      config: options.config,
+      currentVersion,
+      fetchImpl: options.fetchImpl,
+      getAuthState: options.getAuthState,
+      refreshGoogleAccessToken: options.refreshGoogleAccessToken,
+    })
+  } catch (error) {
+    if (error instanceof UpdateReleaseSourceError) {
+      sourceError = error
+    } else {
+      sourceError = new UpdateReleaseSourceError(
+        'source-misconfigured',
+        error instanceof Error ? error.message : 'The update release source could not be resolved.',
+      )
+    }
+  }
   const manualReleaseUrl = options && 'manualReleaseUrl' in options
     ? options.manualReleaseUrl ?? null
-    : manualReleaseUrlFromHelpUrl(getBranding().helpUrl)
+    : source?.manualReleaseUrl ?? sourceError?.manualReleaseUrl ?? manualReleaseUrlFromHelpUrl(getBranding().helpUrl)
   const reason = reasonCapability({
     isPackaged: options?.isPackaged ?? (electronApp?.isPackaged === true),
     platform: options?.platform ?? process.platform,
     signedInstallEligible: options?.signedInstallEligible ?? embedded.signedInstallEligible,
     feedConfigured: options?.feedConfigured ?? embedded.feedConfigured,
   })
+  if (sourceError) {
+    if (reason && !['source-disabled', 'source-misconfigured'].includes(sourceError.reason)) {
+      return {
+        capability: {
+          supported: false,
+          reason,
+          currentVersion,
+          manualReleaseUrl,
+          releaseSource: sourceError.descriptor,
+        },
+        source: null,
+      }
+    }
+    return {
+      capability: {
+        ...sourceErrorCapability(sourceError, currentVersion),
+        manualReleaseUrl,
+      },
+      source: null,
+    }
+  }
   if (reason) {
     return {
-      supported: false,
-      reason,
-      currentVersion,
-      manualReleaseUrl,
+      capability: {
+        supported: false,
+        reason,
+        currentVersion,
+        manualReleaseUrl,
+        releaseSource: source?.descriptor || null,
+      },
+      source: null,
     }
   }
   return {
-    supported: true,
-    currentVersion,
-    manualReleaseUrl,
+    capability: {
+      supported: true,
+      currentVersion,
+      manualReleaseUrl,
+      releaseSource: source?.descriptor || null,
+    },
+    source,
   }
+}
+
+export async function getUpdateInstallCapability(options?: UpdateServiceOptions): Promise<UpdateInstallCapability> {
+  return (await getUpdateInstallContext(options)).capability
 }
 
 export function subscribeUpdateInstallEvents(subscriber: (event: UpdateInstallEvent) => void) {

--- a/apps/desktop/src/main/update-version.ts
+++ b/apps/desktop/src/main/update-version.ts
@@ -1,0 +1,25 @@
+import semver from 'semver'
+
+export function parseGithubRepo(url: string): { owner: string; repo: string } | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.hostname !== 'github.com' && parsed.hostname !== 'www.github.com') return null
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    if (segments.length < 2) return null
+    const [owner, repoRaw] = segments
+    const repo = repoRaw.replace(/\.git$/, '')
+    if (!owner || !repo) return null
+    return { owner, repo }
+  } catch {
+    return null
+  }
+}
+
+export function normalizeVersion(value: string): string {
+  const trimmed = value.trim()
+  return semver.clean(trimmed) || semver.coerce(trimmed)?.version || '0.0.0'
+}
+
+export function compareVersions(a: string, b: string): number {
+  return Math.sign(semver.compare(normalizeVersion(a), normalizeVersion(b)))
+}

--- a/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsStoragePanel.test.tsx
@@ -110,7 +110,7 @@ describe('StoragePanel', () => {
       />,
     )
 
-    expect(await screen.findByText('This signed macOS build can download and install signed updates from Settings.')).toBeInTheDocument()
+    expect(await screen.findByText('This signed macOS build can download and install signed updates from the configured release source.')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: /Check for updates/ }))
     await waitFor(() => expect(checkInstallable).toHaveBeenCalledTimes(1))
     expect(await screen.findByText('New version available: 1.0.1')).toBeInTheDocument()
@@ -172,7 +172,7 @@ describe('StoragePanel', () => {
         onCleanup={vi.fn(async () => undefined)}
       />,
     )
-    await screen.findByText('This signed macOS build can download and install signed updates from Settings.')
+    await screen.findByText('This signed macOS build can download and install signed updates from the configured release source.')
 
     first.unmount()
     act(() => {

--- a/apps/desktop/src/renderer/components/sidebar/SettingsUpdatesPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsUpdatesPanel.tsx
@@ -120,7 +120,7 @@ function useSettingsUpdatesState() {
 
 function describeInstallCapability(capability: UpdateInstallCapability) {
   if (capability.supported) {
-    return t('settings.updates.installSupported', 'This signed macOS build can download and install signed updates from Settings.')
+    return t('settings.updates.installSupported', 'This signed macOS build can download and install signed updates from the configured release source.')
   }
   switch (capability.reason) {
     case 'dev':
@@ -131,9 +131,38 @@ function describeInstallCapability(capability: UpdateInstallCapability) {
       return t('settings.updates.installUnsupportedUnsigned', 'This build is not signed for in-app update installation, so updates stay manual.')
     case 'missing-feed':
       return t('settings.updates.installUnsupportedFeed', 'This build does not include signed update feed metadata, so updates stay manual.')
+    case 'source-disabled':
+      return t('settings.updates.installUnsupportedSourceDisabled', 'Update checks are disabled for this build.')
+    case 'source-misconfigured':
+      return t('settings.updates.installUnsupportedSourceMisconfigured', 'The configured update release source is incomplete or invalid.')
+    case 'auth-required':
+      return t('settings.updates.installUnsupportedAuthRequired', 'Sign in with Google to check this private update release source.')
+    case 'auth-expired':
+      return t('settings.updates.installUnsupportedAuthExpired', 'Your Google session expired. Sign in again to check private updates.')
+    case 'auth-forbidden':
+      return t('settings.updates.installUnsupportedAuthForbidden', 'Your account is not allowed to read this private update release source.')
+    case 'source-unreachable':
+      return t('settings.updates.installUnsupportedSourceUnreachable', 'The update release source could not be reached.')
     default:
       return t('settings.updates.installUnsupportedGeneric', 'In-app installation is unavailable for this build. Use the manual release link.')
   }
+}
+
+function releaseSourceLabel(capability: UpdateInstallCapability | null) {
+  return capability?.releaseSource?.label || t('settings.updates.defaultReleaseSource', 'GitHub Releases')
+}
+
+function releaseSourceDetail(capability: UpdateInstallCapability | null) {
+  const source = capability?.releaseSource
+  if (!source) return t('settings.updates.releaseSourceUnknown', 'Release source will be resolved by the main process.')
+  const auth = source.requiresAuth
+    ? t('settings.updates.releaseSourcePrivate', 'Private')
+    : t('settings.updates.releaseSourcePublic', 'Public')
+  return t('settings.updates.releaseSourceDetail', '{{auth}} · {{kind}} · {{channel}}', {
+    auth,
+    kind: source.kind,
+    channel: source.channel,
+  })
 }
 
 function formatBytes(value: number) {
@@ -202,6 +231,7 @@ function statusDetail(state: SettingsUpdatesState) {
     reason: status.reason,
     currentVersion: status.currentVersion,
     manualReleaseUrl: status.manualReleaseUrl,
+    releaseSource: state.capability?.releaseSource || null,
   })
   if (status?.status === 'error') return status.message
   if (state.manualStatus.kind === 'available') {
@@ -345,6 +375,27 @@ async function restartToInstall() {
   }
 }
 
+async function signInForUpdates() {
+  setUpdatesState({ action: 'checking' })
+  try {
+    await window.coworkApi.auth.login()
+    await refreshCapability()
+  } catch (error) {
+    setUpdatesState((current) => ({
+      ...current,
+      manualStatus: {
+        kind: 'error',
+        message: error instanceof Error ? error.message : t('settings.updates.authFailedGeneric', 'Could not sign in for private updates.'),
+      },
+    }))
+  } finally {
+    setUpdatesState((current) => ({
+      ...current,
+      action: current.installStatus?.status === 'installing' ? 'installing' : 'idle',
+    }))
+  }
+}
+
 function openReleaseNotes(url: string) {
   try {
     window.open(url, '_blank')
@@ -372,6 +423,7 @@ export function SettingsUpdatesPanel() {
     && state.installStatus?.status === 'downloaded'
     && state.action !== 'checking'
     && state.action !== 'downloading'
+  const canSignInForUpdates = state.capability?.reason === 'auth-required' || state.capability?.reason === 'auth-expired'
   const progress = state.installStatus?.status === 'downloading' ? state.installStatus.progress : null
   const latest = latestVersion(state)
 
@@ -385,6 +437,11 @@ export function SettingsUpdatesPanel() {
       </div>
       <div className="text-[11px] text-text-muted leading-relaxed">
         {t('settings.updates.description', 'Check releases manually, then download and restart only when this signed build supports in-app installation.')}
+      </div>
+      <div className="rounded-xl border border-border-subtle bg-base px-3 py-2.5">
+        <div className="text-[10px] uppercase tracking-[0.18em] text-text-muted">{t('settings.updates.releaseSource', 'Release source')}</div>
+        <div className="mt-1 text-[12px] font-semibold text-text">{releaseSourceLabel(state.capability)}</div>
+        <div className="mt-1 text-[11px] text-text-muted">{releaseSourceDetail(state.capability)}</div>
       </div>
       {state.capability ? (
         <div className="rounded-xl border border-border-subtle bg-base px-3 py-2.5 text-[11px] leading-relaxed text-text-muted">
@@ -460,6 +517,19 @@ export function SettingsUpdatesPanel() {
             <div className="text-[12px] font-semibold text-accent">{t('settings.updates.restartToInstall', 'Restart to install')}</div>
             <div className="text-[11px] text-text-muted mt-1">
               {t('settings.updates.restartButtonHint', 'Closes Open Cowork and completes the signed update installation.')}
+            </div>
+          </button>
+        ) : null}
+
+        {canSignInForUpdates ? (
+          <button
+            onClick={() => void signInForUpdates()}
+            disabled={state.action === 'checking' || state.action === 'downloading' || state.action === 'installing'}
+            className="w-full text-start rounded-2xl border border-border-subtle p-3 transition-colors cursor-pointer hover:bg-surface-hover disabled:opacity-60 disabled:cursor-wait"
+          >
+            <div className="text-[12px] font-semibold text-text">{t('settings.updates.signIn', 'Sign in with Google')}</div>
+            <div className="text-[11px] text-text-muted mt-1">
+              {t('settings.updates.signInHint', 'Private release sources use the app sign-in in the main process; tokens are never exposed to the renderer.')}
             </div>
           </button>
         ) : null}

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -254,6 +254,13 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
         reason: 'dev',
         currentVersion: '0.0.0',
         manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+        releaseSource: {
+          kind: 'github-releases',
+          label: 'GitHub Releases',
+          channel: 'latest',
+          requiresAuth: false,
+          authKind: 'none',
+        },
       })),
       checkInstallable: vi.fn(async () => ({
         status: 'unsupported',

--- a/apps/desktop/tests/packaged-relaunch.packaged.test.ts
+++ b/apps/desktop/tests/packaged-relaunch.packaged.test.ts
@@ -17,6 +17,12 @@ const updateInstallUnsupportedReasons = new Set([
   'unsigned',
   'platform',
   'missing-feed',
+  'source-disabled',
+  'source-misconfigured',
+  'auth-required',
+  'auth-expired',
+  'auth-forbidden',
+  'source-unreachable',
   'unavailable',
 ])
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -376,6 +376,106 @@ The same `limit` and `cost` blocks are also accepted on entries in
 may be either `model` or `provider/model`; Open Cowork stores both aliases so
 downstream bundles do not need renderer-specific glue.
 
+## Update Release Sources
+
+The upstream app checks public GitHub Releases by default. Downstream
+builds can replace that with an explicit update release source without
+changing renderer code. Release-source auth is resolved only in the main
+process; the renderer receives a safe label, channel, and status reason,
+never bearer tokens, signed URLs, bucket paths, or request headers.
+
+```json
+{
+  "updates": {
+    "enabled": true,
+    "manualFallbackUrl": "https://github.com/joe-broadhead/open-cowork/releases",
+    "releaseSource": {
+      "kind": "github-releases",
+      "owner": "joe-broadhead",
+      "repo": "open-cowork",
+      "channel": "latest",
+      "label": "GitHub Releases"
+    }
+  }
+}
+```
+
+Supported `releaseSource.kind` values:
+
+- `github-releases` — public GitHub Releases by default. Downstream
+  private GitHub feeds can set `auth.kind: "github-token"` and pass the
+  token through an allowlisted config placeholder.
+- `generic-http` — an HTTPS directory containing Electron updater
+  metadata such as `latest-mac.yml`. Optional `auth.kind:
+  "static-headers"` attaches private headers in the main process.
+- `gcs` — a private Google Cloud Storage feed laid out as
+  `gs://<bucket>/<prefix>/<channel>/latest-mac.yml`. Use
+  `auth.kind: "google-oauth"` to reuse the app Google sign-in, or
+  `auth.kind: "signed-url-broker"` to ask a downstream broker for a
+  short-lived updater-compatible generic feed.
+
+Example GCS OAuth feed:
+
+```json
+{
+  "auth": {
+    "mode": "google-oauth",
+    "googleOAuth": {
+      "clientId": "your-google-client-id",
+      "scopes": [
+        "openid",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/devstorage.read_only"
+      ]
+    }
+  },
+  "updates": {
+    "enabled": true,
+    "manualFallbackUrl": "https://support.example.test/releases",
+    "releaseSource": {
+      "kind": "gcs",
+      "label": "Private release feed",
+      "bucket": "acme-cowork-releases",
+      "prefix": "desktop",
+      "channel": "latest",
+      "auth": {
+        "kind": "google-oauth",
+        "requiredScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only"
+        ]
+      }
+    }
+  }
+}
+```
+
+Example signed URL broker:
+
+```json
+{
+  "updates": {
+    "enabled": true,
+    "manualFallbackUrl": "https://support.example.test/releases",
+    "releaseSource": {
+      "kind": "gcs",
+      "label": "Private release feed",
+      "bucket": "acme-cowork-releases",
+      "channel": "latest",
+      "auth": {
+        "kind": "signed-url-broker",
+        "brokerUrl": "https://updates.example.test/cowork/broker"
+      }
+    }
+  }
+}
+```
+
+Private update sources still obey the signed-install gate: in-app
+download and restart-to-install are available only for signed packaged
+macOS builds with feed metadata. Development, unsigned, unsupported,
+misconfigured, or unauthenticated builds stay on the manual fallback
+path.
+
 ## Tools
 
 `tools` defines the curated tool catalog shown in the app.

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -164,6 +164,76 @@ app and `latest-mac.yml` is published for that signed release. Keeping
 the updater dependency in the package avoids downstream forks needing a
 different dependency graph when they enable a signed feed.
 
+## Configurable Update Release Sources
+
+Open Cowork's public distribution uses GitHub Releases as its default
+update release source. Downstream distributions can keep their release
+metadata and artifacts private by setting `updates.releaseSource` in the
+app config instead of patching the updater code. Supported source kinds
+are `github-releases`, `generic-http`, and `gcs`.
+
+The updater marker embedded during packaging is schema version 2:
+
+```json
+{
+  "schemaVersion": 2,
+  "signedInstallEligible": true,
+  "feedConfigured": true,
+  "releaseSourceKind": "gcs",
+  "channel": "latest"
+}
+```
+
+The marker intentionally contains only capability metadata. It must not
+contain bearer tokens, signed URLs, bucket credentials, static headers,
+or mutable auth state. Release-source credentials are resolved in the
+main process at check/download time.
+
+For a private GCS feed, upload Electron updater metadata and artifacts
+to:
+
+```text
+gs://<bucket>/<prefix>/<channel>/latest-mac.yml
+gs://<bucket>/<prefix>/<channel>/<artifact files referenced by latest-mac.yml>
+```
+
+Then configure:
+
+```json
+{
+  "auth": {
+    "mode": "google-oauth",
+    "googleOAuth": {
+      "clientId": "your-google-client-id",
+      "scopes": [
+        "openid",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/devstorage.read_only"
+      ]
+    }
+  },
+  "updates": {
+    "enabled": true,
+    "manualFallbackUrl": "https://support.example.test/releases",
+    "releaseSource": {
+      "kind": "gcs",
+      "label": "Private release feed",
+      "bucket": "acme-cowork-releases",
+      "prefix": "desktop",
+      "channel": "latest",
+      "auth": { "kind": "google-oauth" }
+    }
+  }
+}
+```
+
+If a downstream builder needs entitlement checks or very short-lived
+artifact URLs, use `auth.kind: "signed-url-broker"`. The app calls the
+broker from the main process after Google sign-in; the broker returns an
+updater-compatible generic feed URL. Treat those returned URLs as
+credentials: keep TTLs short and do not copy them into docs, logs, IPC
+payloads, crash reports, or diagnostics.
+
 Before announcing a signed public tag, run one manual staging update from
 version `N` to `N+1`: install the previous signed build, open Settings,
 check for updates, download the new signed update, restart to install,

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -63,6 +63,8 @@ Reference workflows in the repository root:
 - [ ] Linux artifacts are either covered by a detached `SHA256SUMS.txt.asc` signature (`OPEN_COWORK_RELEASE_GPG_PRIVATE_KEY`, optional `OPEN_COWORK_RELEASE_GPG_PASSPHRASE`) or explicitly documented as unsigned `v0.x` artifacts verified through `SHA256SUMS.txt` plus GitHub provenance
 - [ ] release assets still include `SHA256SUMS.txt`, `SHA256SUMS.txt.asc` when checksum signing is configured, `THIRD_PARTY_NOTICES.md`, `THIRD_PARTY_LICENSES/`, SBOMs, and provenance attestation
 - [ ] signed macOS releases include `latest-mac.yml`; unsigned preview releases do not include signed update feed metadata
+- [ ] packaged signed-update marker is schema version 2 and contains only `signedInstallEligible`, `feedConfigured`, `releaseSourceKind`, and `channel` metadata
+- [ ] downstream/private update release sources have no tokens, signed URL query strings, bucket credentials, or static headers in renderer IPC payloads, logs, diagnostics, or packaged marker files
 - [ ] for signed macOS releases, Settings reports in-app update installation as supported in the packaged smoke run
 - [ ] docs drift is acceptable for this release: through the `0.x` preview series, the published Pages site intentionally tracks `master` rather than immutable versioned docs
 - [ ] every `[Unreleased]` changelog bullet has been checked against the app before moving it into the tagged release section

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -349,6 +349,25 @@ artifacts. Downstream forks that need Developer ID / Authenticode
 signing plug into the existing `dist:ci:mac` step. The steps for signing
 are documented in `docs/packaging-and-releases.md`.
 
+## Update Release Source Credentials
+
+Settings can check public GitHub Releases or a downstream-configured
+private update release source. Private source auth is always resolved in
+the main process:
+
+- renderer IPC payloads include only the safe source label, kind,
+  channel, and unsupported reason
+- Google OAuth access tokens, static headers, GitHub tokens, signed URL
+  query strings, bucket names, and object paths are never sent to the
+  renderer
+- signed URL query strings and authorization headers are redacted by the
+  log sanitizer before logs or diagnostics leave the machine
+- in-app download and restart-to-install remain gated to signed packaged
+  macOS builds with embedded feed metadata and explicit user action
+
+Manual fallback URLs must be ordinary HTTPS support/release pages, not
+credential-bearing signed artifact URLs.
+
 ## Dependency posture
 
 - `pnpm audit --prod --audit-level high` runs as part of the CI gate.

--- a/open-cowork.config.json
+++ b/open-cowork.config.json
@@ -69,6 +69,17 @@
     "defaultModel": "deepseek/deepseek-v4-flash:free",
     "custom": {}
   },
+  "updates": {
+    "enabled": true,
+    "manualFallbackUrl": "https://github.com/joe-broadhead/open-cowork/releases",
+    "releaseSource": {
+      "kind": "github-releases",
+      "owner": "joe-broadhead",
+      "repo": "open-cowork",
+      "channel": "latest",
+      "label": "GitHub Releases"
+    }
+  },
   "tools": [
     {
       "id": "clock",

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -124,6 +124,15 @@
       },
       "required": ["available", "defaultProvider", "defaultModel"]
     },
+    "updates": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "manualFallbackUrl": { "$ref": "#/$defs/httpsOrLocalhostUrl" },
+        "releaseSource": { "$ref": "#/$defs/updateReleaseSource" }
+      }
+    },
     "tools": {
       "type": "array",
       "items": { "$ref": "#/$defs/configuredTool" }
@@ -240,6 +249,116 @@
   },
   "required": ["allowedEnvPlaceholders", "branding", "auth", "providers", "tools", "skills", "mcps", "agents", "permissions"],
   "$defs": {
+    "httpsOrLocalhostUrl": {
+      "type": "string",
+      "maxLength": 2048,
+      "pattern": "^(https://|http://(127\\.0\\.0\\.1|localhost)(:[0-9]+)?/).+"
+    },
+    "updateChannel": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "updateReleaseSource": {
+      "oneOf": [
+        { "$ref": "#/$defs/githubUpdateReleaseSource" },
+        { "$ref": "#/$defs/genericHttpUpdateReleaseSource" },
+        { "$ref": "#/$defs/gcsUpdateReleaseSource" }
+      ]
+    },
+    "githubUpdateReleaseSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "github-releases" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "owner": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "repo": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "channel": { "$ref": "#/$defs/updateChannel" },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "type": "string", "enum": ["none", "github-token"] },
+            "token": { "type": "string", "maxLength": 4096 }
+          },
+          "required": ["kind"]
+        }
+      },
+      "required": ["kind"]
+    },
+    "genericHttpUpdateReleaseSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "generic-http" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "url": { "$ref": "#/$defs/httpsOrLocalhostUrl" },
+        "channel": { "$ref": "#/$defs/updateChannel" },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "type": "string", "enum": ["none", "static-headers"] },
+            "headers": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string",
+                "maxLength": 4096
+              }
+            }
+          },
+          "required": ["kind"]
+        }
+      },
+      "required": ["kind", "url"]
+    },
+    "gcsUpdateReleaseSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "gcs" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "bucket": { "type": "string", "minLength": 3, "maxLength": 222 },
+        "prefix": {
+          "type": "string",
+          "maxLength": 512,
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).*$"
+        },
+        "channel": { "$ref": "#/$defs/updateChannel" },
+        "auth": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "const": "google-oauth" },
+                "requiredScopes": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+                }
+              },
+              "required": ["kind"]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "const": "signed-url-broker" },
+                "brokerUrl": { "$ref": "#/$defs/httpsOrLocalhostUrl" },
+                "requiredScopes": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+                }
+              },
+              "required": ["kind", "brokerUrl"]
+            }
+          ]
+        }
+      },
+      "required": ["kind", "bucket"]
+    },
     "brandingSidebar": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -90,6 +90,7 @@ import type {
   ThreadTagInput,
 } from './threads.js'
 import type {
+  UpdateCheckResult,
   UpdateInstallCapability,
   UpdateInstallEvent,
   UpdateInstallStatus,
@@ -246,11 +247,7 @@ export interface CoworkAPI {
     // Queries the configured releases endpoint (GitHub by default). A
     // `disabled` status means the build's helpUrl doesn't resolve to a
     // known host; the renderer just doesn't surface an update hint.
-    checkUpdates: () => Promise<
-      | { status: 'ok'; currentVersion: string; latestVersion: string; hasUpdate: boolean; releaseUrl: string }
-      | { status: 'error'; currentVersion: string; message: string }
-      | { status: 'disabled'; currentVersion: string; message: string }
-    >
+    checkUpdates: () => Promise<UpdateCheckResult>
     // Wipes user-data dir + sandbox workspaces and relaunches. Behind
     // a destructive confirmation token; call confirm.requestDestructive
     // with `{ action: 'app.reset' }` first to get the token.

--- a/packages/shared/src/updates.ts
+++ b/packages/shared/src/updates.ts
@@ -3,13 +3,37 @@ export type UpdateInstallUnsupportedReason =
   | 'unsigned'
   | 'platform'
   | 'missing-feed'
+  | 'source-disabled'
+  | 'source-misconfigured'
+  | 'auth-required'
+  | 'auth-expired'
+  | 'auth-forbidden'
+  | 'source-unreachable'
   | 'unavailable'
+
+export type UpdateReleaseSourceKind = 'github-releases' | 'generic-http' | 'gcs'
+
+export type UpdateReleaseSourceAuthKind =
+  | 'none'
+  | 'github-token'
+  | 'static-headers'
+  | 'google-oauth'
+  | 'signed-url-broker'
+
+export interface UpdateReleaseSourceDescriptor {
+  kind: UpdateReleaseSourceKind
+  label: string
+  channel: string
+  requiresAuth: boolean
+  authKind: UpdateReleaseSourceAuthKind
+}
 
 export interface UpdateInstallCapability {
   supported: boolean
   reason?: UpdateInstallUnsupportedReason
   currentVersion: string
   manualReleaseUrl: string | null
+  releaseSource: UpdateReleaseSourceDescriptor | null
 }
 
 export interface UpdateInstallProgress {
@@ -53,3 +77,8 @@ export type UpdateInstallStatus =
   }
 
 export type UpdateInstallEvent = UpdateInstallStatus
+
+export type UpdateCheckResult =
+  | { status: 'ok'; currentVersion: string; latestVersion: string; hasUpdate: boolean; releaseUrl: string }
+  | { status: 'error'; currentVersion: string; message: string }
+  | { status: 'disabled'; currentVersion: string; message: string }

--- a/scripts/desktop-after-pack.mjs
+++ b/scripts/desktop-after-pack.mjs
@@ -107,9 +107,11 @@ export function buildUpdateInstallCapabilityResource(context, env = process.env)
   const feedConfigured = isTruthyEnv(env.OPEN_COWORK_UPDATE_FEED_CONFIGURED)
   if (!signedInstallEligible && !feedConfigured) return null
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     signedInstallEligible,
     feedConfigured,
+    releaseSourceKind: env.OPEN_COWORK_UPDATE_RELEASE_SOURCE_KIND || 'github-releases',
+    channel: env.OPEN_COWORK_UPDATE_CHANNEL || 'latest',
   }
 }
 

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -177,6 +177,60 @@ test('telemetry schema rejects unknown keys and non-https endpoints', () => {
   assert.throws(() => validateResolvedConfig(config, 'telemetry config'), /telemetry/)
 })
 
+test('update release sources validate for GitHub, generic HTTP, and GCS', () => {
+  const config = cloneConfig()
+  config.updates = {
+    enabled: true,
+    manualFallbackUrl: 'https://releases.acme.example/open-cowork',
+    releaseSource: {
+      kind: 'gcs',
+      label: 'Acme private releases',
+      bucket: 'acme-cowork-releases',
+      prefix: 'desktop',
+      channel: 'latest',
+      auth: {
+        kind: 'google-oauth',
+        requiredScopes: ['https://www.googleapis.com/auth/devstorage.read_only'],
+      },
+    },
+  }
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'update source config'))
+
+  config.updates.releaseSource = {
+    kind: 'generic-http',
+    label: 'Acme generic feed',
+    url: 'https://updates.acme.example/cowork',
+    channel: 'beta',
+    auth: {
+      kind: 'static-headers',
+      headers: {
+        Authorization: 'Bearer resolved-token',
+      },
+    },
+  }
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'update source config'))
+
+  config.updates.releaseSource = {
+    kind: 'github-releases',
+    owner: 'joe-broadhead',
+    repo: 'open-cowork',
+  }
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'update source config'))
+})
+
+test('update release source schema rejects non-https public endpoints', () => {
+  const config = cloneConfig()
+  config.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'generic-http',
+      url: 'http://updates.acme.example/cowork',
+    },
+  }
+
+  assert.throws(() => validateResolvedConfig(config, 'update source config'), /updates/)
+})
+
 test('provider dynamic catalogs require https URLs and valid SHA-256 pins', () => {
   const config = cloneConfig()
   config.providers.descriptors.openrouter.dynamicCatalog = {

--- a/tests/desktop-after-pack.test.ts
+++ b/tests/desktop-after-pack.test.ts
@@ -109,9 +109,11 @@ test('desktop-after-pack writes signed macOS update capability metadata only whe
     assert.deepEqual(
       JSON.parse(readFileSync(join(resourcesDir, updateInstallCapabilityResourceName), 'utf8')),
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         signedInstallEligible: true,
         feedConfigured: true,
+        releaseSourceKind: 'github-releases',
+        channel: 'latest',
       },
     )
   } finally {

--- a/tests/update-release-source.test.ts
+++ b/tests/update-release-source.test.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { DEFAULT_CONFIG, type OpenCoworkConfig } from '../apps/desktop/src/main/config-types.ts'
+import { resolveUpdateReleaseSource, UpdateReleaseSourceError } from '../apps/desktop/src/main/update-release-source.ts'
+import { checkForUpdates } from '../apps/desktop/src/main/update-check.ts'
+import { sanitizeLogMessage } from '../apps/desktop/src/main/log-sanitizer.ts'
+
+function baseConfig(): OpenCoworkConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    branding: {
+      ...DEFAULT_CONFIG.branding,
+      helpUrl: 'https://github.com/joe-broadhead/open-cowork',
+    },
+    auth: {
+      mode: 'none',
+    },
+  }
+}
+
+test('update release source resolver preserves the upstream GitHub default', async () => {
+  const source = await resolveUpdateReleaseSource({
+    config: baseConfig(),
+    currentVersion: '1.0.0',
+  })
+
+  assert.deepEqual(source.descriptor, {
+    kind: 'github-releases',
+    label: 'GitHub Releases',
+    channel: 'latest',
+    requiresAuth: false,
+    authKind: 'none',
+  })
+  assert.deepEqual(source.installProvider, {
+    provider: 'github',
+    owner: 'joe-broadhead',
+    repo: 'open-cowork',
+    channel: 'latest',
+  })
+  assert.equal(source.manualReleaseUrl, 'https://github.com/joe-broadhead/open-cowork/releases')
+})
+
+test('generic update release source discovers latest version from updater metadata', async () => {
+  const config = baseConfig()
+  config.updates = {
+    enabled: true,
+    manualFallbackUrl: 'https://updates.example.test/cowork',
+    releaseSource: {
+      kind: 'generic-http',
+      url: 'https://updates.example.test/cowork',
+      channel: 'beta',
+    },
+  }
+
+  const result = await checkForUpdates({
+    config,
+    currentVersion: '1.2.3',
+    fetchImpl: async (input) => {
+      assert.equal(String(input), 'https://updates.example.test/cowork/beta-mac.yml')
+      return new Response('version: 1.2.4\nfiles: []\n', { status: 200 })
+    },
+  })
+
+  assert.deepEqual(result, {
+    status: 'ok',
+    currentVersion: '1.2.3',
+    latestVersion: '1.2.4',
+    hasUpdate: true,
+    releaseUrl: 'https://updates.example.test/cowork',
+  })
+})
+
+test('authenticated generic update release source does not expose feed URL without explicit fallback', async () => {
+  const config = baseConfig()
+  config.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'generic-http',
+      url: 'https://private-updates.example.test/cowork',
+      channel: 'latest',
+      auth: {
+        kind: 'static-headers',
+        headers: { Authorization: 'Bearer private-token' },
+      },
+    },
+  }
+
+  const source = await resolveUpdateReleaseSource({
+    config,
+    currentVersion: '1.2.3',
+    fetchImpl: async (input, init) => {
+      assert.equal(String(input), 'https://private-updates.example.test/cowork/latest-mac.yml')
+      assert.equal((init?.headers as Record<string, string>).Authorization, 'Bearer private-token')
+      return new Response('version: 1.2.4\nfiles: []\n', { status: 200 })
+    },
+  })
+
+  assert.equal(source.manualReleaseUrl, null)
+  assert.deepEqual(await source.discoverLatest(), {
+    status: 'ok',
+    currentVersion: '1.2.3',
+    latestVersion: '1.2.4',
+    hasUpdate: true,
+    releaseUrl: '',
+  })
+})
+
+test('GCS OAuth release source requires Google sign-in before private metadata is read', async () => {
+  const config = baseConfig()
+  config.auth = { mode: 'google-oauth', googleOAuth: { clientId: 'client-id' } }
+  config.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'gcs',
+      bucket: 'acme-cowork-releases',
+      prefix: 'desktop',
+      channel: 'latest',
+      auth: { kind: 'google-oauth' },
+    },
+  }
+
+  await assert.rejects(
+    () => resolveUpdateReleaseSource({
+      config,
+      currentVersion: '1.0.0',
+      getAuthState: () => ({ authenticated: false, email: null }),
+    }),
+    (error) => error instanceof UpdateReleaseSourceError && error.reason === 'auth-required',
+  )
+})
+
+test('GCS OAuth release source attaches bearer auth only inside main-process fetches', async () => {
+  const config = baseConfig()
+  config.auth = { mode: 'google-oauth', googleOAuth: { clientId: 'client-id' } }
+  config.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'gcs',
+      bucket: 'acme-cowork-releases',
+      prefix: 'desktop/releases',
+      channel: 'latest',
+      auth: { kind: 'google-oauth' },
+    },
+  }
+
+  const source = await resolveUpdateReleaseSource({
+    config,
+    currentVersion: '1.2.3',
+    getAuthState: () => ({ authenticated: true, email: 'user@example.test' }),
+    refreshGoogleAccessToken: async () => 'ya29.private-token',
+    fetchImpl: async (input, init) => {
+      assert.equal(String(input), 'https://storage.googleapis.com/acme-cowork-releases/desktop/releases/latest/latest-mac.yml')
+      assert.equal((init?.headers as Record<string, string>).Authorization, 'Bearer ya29.private-token')
+      return new Response('version: 1.2.4\nfiles: []\n', { status: 200 })
+    },
+  })
+
+  assert.deepEqual(source.descriptor, {
+    kind: 'gcs',
+    label: 'Private release feed',
+    channel: 'latest',
+    requiresAuth: true,
+    authKind: 'google-oauth',
+  })
+  assert.deepEqual(source.installProvider, {
+    provider: 'generic',
+    url: 'https://storage.googleapis.com/acme-cowork-releases/desktop/releases/latest/',
+    channel: 'latest',
+    requestHeaders: { Authorization: 'Bearer ya29.private-token' },
+  })
+  assert.deepEqual(await source.discoverLatest(), {
+    status: 'ok',
+    currentVersion: '1.2.3',
+    latestVersion: '1.2.4',
+    hasUpdate: true,
+    releaseUrl: 'https://storage.cloud.google.com/',
+  })
+})
+
+test('GCS signed-url broker does not expose brokered artifact URLs in check results', async () => {
+  const config = baseConfig()
+  config.auth = { mode: 'google-oauth', googleOAuth: { clientId: 'client-id' } }
+  config.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'gcs',
+      bucket: 'acme-cowork-releases',
+      prefix: 'desktop/releases',
+      channel: 'latest',
+      auth: {
+        kind: 'signed-url-broker',
+        brokerUrl: 'https://updates.example.test/cowork/broker',
+      },
+    },
+  }
+
+  const source = await resolveUpdateReleaseSource({
+    config,
+    currentVersion: '1.2.3',
+    getAuthState: () => ({ authenticated: true, email: 'user@example.test' }),
+    refreshGoogleAccessToken: async () => 'ya29.private-token',
+    fetchImpl: async (input, init) => {
+      const url = String(input)
+      if (url === 'https://updates.example.test/cowork/broker') {
+        assert.equal(init?.method, 'POST')
+        assert.equal((init?.headers as Record<string, string>).Authorization, 'Bearer ya29.private-token')
+        return Response.json({
+          providerUrl: 'https://brokered.example.test/releases/',
+          releaseUrl: 'https://brokered.example.test/releases/Open-Cowork.dmg?X-Goog-Signature=private',
+          requestHeaders: { 'X-Release-Token': 'private-feed-token' },
+        })
+      }
+      assert.equal(url, 'https://brokered.example.test/releases/latest-mac.yml')
+      assert.equal((init?.headers as Record<string, string>)['X-Release-Token'], 'private-feed-token')
+      return new Response('version: 1.2.4\nfiles: []\n', { status: 200 })
+    },
+  })
+
+  assert.equal(source.manualReleaseUrl, null)
+  assert.deepEqual(await source.discoverLatest(), {
+    status: 'ok',
+    currentVersion: '1.2.3',
+    latestVersion: '1.2.4',
+    hasUpdate: true,
+    releaseUrl: '',
+  })
+})
+
+test('private release source authorization failures are non-sensitive', async () => {
+  const config = baseConfig()
+  config.auth = { mode: 'google-oauth', googleOAuth: { clientId: 'client-id' } }
+  config.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'gcs',
+      bucket: 'secret-bucket',
+      prefix: 'desktop',
+      auth: { kind: 'google-oauth' },
+    },
+  }
+  const source = await resolveUpdateReleaseSource({
+    config,
+    currentVersion: '1.2.3',
+    getAuthState: () => ({ authenticated: true, email: 'user@example.test' }),
+    refreshGoogleAccessToken: async () => 'ya29.private-token',
+    fetchImpl: async () => new Response('no', { status: 403 }),
+  })
+
+  await assert.rejects(
+    () => source.discoverLatest(),
+    (error) => error instanceof UpdateReleaseSourceError
+      && error.reason === 'auth-forbidden'
+      && !error.message.includes('secret-bucket'),
+  )
+})
+
+test('signed update URLs have credential query strings redacted from logs', () => {
+  const sanitized = sanitizeLogMessage('download https://updates.example.test/latest-mac.yml?X-Goog-Signature=abc&X-Goog-Credential=secret')
+  assert.equal(sanitized, 'download https://updates.example.test/latest-mac.yml?[REDACTED_QUERY]')
+})

--- a/tests/update-service.test.ts
+++ b/tests/update-service.test.ts
@@ -24,6 +24,8 @@ type MockUpdateCheckResult = {
 class MockUpdater extends EventEmitter {
   autoDownload = true
   autoInstallOnAppQuit = true
+  requestHeaders: Record<string, string> | null = null
+  feedOptions: Record<string, unknown> | null = null
   logger: unknown = null
   checkCalls = 0
   downloadCalls = 0
@@ -56,6 +58,18 @@ class MockUpdater extends EventEmitter {
   quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean) {
     this.quitCalls.push({ isSilent, isForceRunAfter })
   }
+
+  setFeedURL(options: Record<string, unknown>) {
+    this.feedOptions = options
+  }
+}
+
+const githubReleaseSource = {
+  kind: 'github-releases' as const,
+  label: 'GitHub Releases',
+  channel: 'latest',
+  requiresAuth: false,
+  authKind: 'none' as const,
 }
 
 function availableResult(version = '1.2.4'): MockUpdateCheckResult {
@@ -107,6 +121,7 @@ test('update install capability disables install while running from source', asy
     reason: 'dev',
     currentVersion: '1.2.3',
     manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+    releaseSource: githubReleaseSource,
   })
 })
 
@@ -123,6 +138,7 @@ test('update install capability is macOS-only for the first signed installer pha
     reason: 'platform',
     currentVersion: '1.2.3',
     manualReleaseUrl: null,
+    releaseSource: githubReleaseSource,
   })
 })
 
@@ -139,6 +155,7 @@ test('update install capability rejects unsigned packaged macOS builds', async (
     reason: 'unsigned',
     currentVersion: '1.2.3',
     manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+    releaseSource: githubReleaseSource,
   })
 })
 
@@ -155,6 +172,7 @@ test('update install capability requires feed metadata after signing is eligible
     reason: 'missing-feed',
     currentVersion: '1.2.3',
     manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+    releaseSource: githubReleaseSource,
   })
 })
 
@@ -170,6 +188,7 @@ test('update install capability reports supported only for signed packaged macOS
     supported: true,
     currentVersion: '1.2.3',
     manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+    releaseSource: githubReleaseSource,
   })
 })
 
@@ -178,9 +197,11 @@ test('update install capability reads signed feed eligibility from packaged reso
   try {
     const markerPath = join(root, 'open-cowork-update-capability.json')
     writeFileSync(markerPath, `${JSON.stringify({
-      schemaVersion: 1,
+      schemaVersion: 2,
       signedInstallEligible: true,
       feedConfigured: true,
+      releaseSourceKind: 'github-releases',
+      channel: 'latest',
     })}\n`)
 
     assert.deepEqual(await getUpdateInstallCapability({
@@ -193,6 +214,7 @@ test('update install capability reads signed feed eligibility from packaged reso
       supported: true,
       currentVersion: '1.2.3',
       manualReleaseUrl: 'https://github.com/joe-broadhead/open-cowork/releases',
+      releaseSource: githubReleaseSource,
     })
   } finally {
     rmSync(root, { recursive: true, force: true })
@@ -203,7 +225,7 @@ test('update install capability ignores malformed packaged resource markers', as
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-update-service-'))
   try {
     const markerPath = join(root, 'open-cowork-update-capability.json')
-    writeFileSync(markerPath, '{"schemaVersion":2,"signedInstallEligible":true,"feedConfigured":true}\n')
+    writeFileSync(markerPath, '{"schemaVersion":999,"signedInstallEligible":true,"feedConfigured":true}\n')
 
     assert.deepEqual(await getUpdateInstallCapability({
       isPackaged: true,
@@ -216,6 +238,7 @@ test('update install capability ignores malformed packaged resource markers', as
       reason: 'unsigned',
       currentVersion: '1.2.3',
       manualReleaseUrl: null,
+      releaseSource: githubReleaseSource,
     })
   } finally {
     rmSync(root, { recursive: true, force: true })
@@ -235,6 +258,12 @@ test('installable update check reports available state without downloading', asy
   })
   assert.equal(updater.autoDownload, false)
   assert.equal(updater.autoInstallOnAppQuit, false)
+  assert.deepEqual(updater.feedOptions, {
+    provider: 'github',
+    owner: 'joe-broadhead',
+    repo: 'open-cowork',
+    channel: 'latest',
+  })
   assert.equal(updater.checkCalls, 1)
   assert.equal(updater.downloadCalls, 0)
   assert.deepEqual(events.map((event) => event.status), ['checking', 'available'])


### PR DESCRIPTION
## Summary
- add typed update release sources for GitHub Releases, generic HTTPS feeds, and private GCS feeds
- keep release-source credentials in the main process and expose only safe source descriptors to the renderer
- wire signed macOS install checks through the configured source and document downstream private-feed setup

## Validation
- pnpm test -- tests/update-service.test.ts tests/update-release-source.test.ts tests/desktop-after-pack.test.ts
- pnpm test -- tests/update-release-source.test.ts tests/update-service.test.ts tests/update-check-version.test.ts tests/desktop-after-pack.test.ts tests/config-schema-validation.test.ts tests/log-sanitizer.test.ts
- pnpm typecheck
- pnpm lint
- uv run mkdocs build --strict
- pnpm test:e2e
- git diff --check