### PR TITLE
Harden update release source validation

### DIFF
--- a/apps/desktop/src/main/update-release-source-gcs.ts
+++ b/apps/desktop/src/main/update-release-source-gcs.ts
@@ -4,6 +4,8 @@ import { normalizeUpdateSourceUrl } from './update-release-source-generic.ts'
 
 export type GcsReleaseSourceConfig = Extract<UpdateReleaseSourceConfig, { kind: 'gcs' }>
 
+const GCS_BUCKET_PATTERN = /^(?=.{3,222}$)(?!.*\.\.)(?!\d{1,3}(?:\.\d{1,3}){3}$)[a-z0-9][a-z0-9._-]*[a-z0-9]$/
+
 function encodePathSegment(value: string) {
   return encodeURIComponent(value).replace(/%2F/gi, '/')
 }
@@ -18,7 +20,7 @@ export function normalizeGcsPrefix(prefix?: string | null) {
 
 export function gcsReleaseBaseUrl(input: { bucket: string; prefix?: string | null; channel: string }) {
   const bucket = input.bucket.trim()
-  if (!bucket) return null
+  if (!GCS_BUCKET_PATTERN.test(bucket)) return null
   const prefix = normalizeGcsPrefix(input.prefix)
   if (prefix === null) return null
   const path = [bucket, prefix, input.channel].filter(Boolean).join('/')

--- a/apps/desktop/src/main/update-release-source-generic.ts
+++ b/apps/desktop/src/main/update-release-source-generic.ts
@@ -3,6 +3,13 @@ import type { UpdateReleaseSourceConfig } from './config-types.ts'
 
 export type GenericHttpReleaseSourceConfig = Extract<UpdateReleaseSourceConfig, { kind: 'generic-http' }>
 
+const UPDATE_CHANNEL_PATTERN = /^[A-Za-z0-9._-]{1,80}$/
+
+export function normalizeUpdateChannel(value?: string | null) {
+  const channel = value?.trim() || 'latest'
+  return UPDATE_CHANNEL_PATTERN.test(channel) ? channel : null
+}
+
 export function normalizeUpdateSourceUrl(value: string): string | null {
   try {
     const parsed = new URL(value)

--- a/apps/desktop/src/main/update-release-source-github.ts
+++ b/apps/desktop/src/main/update-release-source-github.ts
@@ -1,14 +1,27 @@
 import type { UpdateReleaseSourceDescriptor } from '@open-cowork/shared'
 import type { UpdateReleaseSourceConfig } from './config-types.ts'
 import { parseGithubRepo } from './update-version.ts'
+import { normalizeUpdateChannel } from './update-release-source-generic.ts'
 
 export type GithubReleaseSourceConfig = Extract<UpdateReleaseSourceConfig, { kind: 'github-releases' }>
+
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+const GITHUB_REPO_PATTERN = /^[A-Za-z0-9._-]{1,100}$/
+
+function normalizeGithubOwnerRepo(owner?: string | null, repo?: string | null) {
+  const normalizedOwner = owner?.trim()
+  const normalizedRepo = repo?.trim()
+  if (!normalizedOwner || !normalizedRepo) return null
+  if (!GITHUB_OWNER_PATTERN.test(normalizedOwner) || !GITHUB_REPO_PATTERN.test(normalizedRepo)) return null
+  return { owner: normalizedOwner, repo: normalizedRepo }
+}
 
 export function resolveGithubReleaseSourceInput(input: {
   config?: GithubReleaseSourceConfig
   brandingHelpUrl?: string | null
 }): { owner: string; repo: string; channel: string; label: string; token: string | null } | null {
-  const channel = input.config?.channel?.trim() || 'latest'
+  const channel = normalizeUpdateChannel(input.config?.channel || 'latest')
+  if (!channel) return null
   const label = input.config?.label?.trim() || 'GitHub Releases'
   const token = input.config?.auth?.kind === 'github-token' && input.config.auth.token?.trim()
     ? input.config.auth.token.trim()
@@ -16,11 +29,15 @@ export function resolveGithubReleaseSourceInput(input: {
 
   const owner = input.config?.owner?.trim()
   const repo = input.config?.repo?.trim()
-  if (owner && repo) return { owner, repo, channel, label, token }
+  if (owner || repo) {
+    const normalized = normalizeGithubOwnerRepo(owner, repo)
+    return normalized ? { ...normalized, channel, label, token } : null
+  }
 
   const parsed = input.brandingHelpUrl ? parseGithubRepo(input.brandingHelpUrl) : null
-  if (!parsed) return null
-  return { ...parsed, channel, label, token }
+  const normalized = parsed ? normalizeGithubOwnerRepo(parsed.owner, parsed.repo) : null
+  if (!normalized) return null
+  return { ...normalized, channel, label, token }
 }
 
 export function githubReleaseSourceDescriptor(input: {

--- a/apps/desktop/src/main/update-release-source.ts
+++ b/apps/desktop/src/main/update-release-source.ts
@@ -15,6 +15,7 @@ import {
 } from './update-release-source-github.ts'
 import {
   genericReleaseSourceDescriptor,
+  normalizeUpdateChannel,
   normalizeUpdateSourceUrl,
   parseUpdateInfoVersion,
   releaseFeedFileUrl,
@@ -70,13 +71,13 @@ export interface ResolveUpdateReleaseSourceOptions {
   refreshGoogleAccessToken?: () => Promise<string | null>
 }
 
-function channelFromConfig(config?: { channel?: string }) {
-  return config?.channel?.trim() || DEFAULT_CHANNEL
-}
-
 function safeManualReleaseUrl(value?: string | null) {
   if (!value) return null
-  return normalizeUpdateSourceUrl(value.trim())
+  const normalized = normalizeUpdateSourceUrl(value.trim())
+  if (!normalized) return null
+  const parsed = new URL(normalized)
+  parsed.search = ''
+  return parsed.toString()
 }
 
 function updateConfig(config: OpenCoworkConfig) {
@@ -89,6 +90,20 @@ function releaseSourceConfig(config: OpenCoworkConfig): UpdateReleaseSourceConfi
 
 function manualReleaseUrlFor(config: OpenCoworkConfig, fallback?: string | null) {
   return safeManualReleaseUrl(updateConfig(config).manualFallbackUrl) || safeManualReleaseUrl(fallback)
+}
+
+function channelFromConfig(
+  config: { channel?: string } | undefined,
+  descriptor?: UpdateReleaseSourceDescriptor | null,
+  manualReleaseUrl?: string | null,
+) {
+  const channel = normalizeUpdateChannel(config?.channel || DEFAULT_CHANNEL)
+  if (channel) return channel
+  throw new UpdateReleaseSourceError(
+    'source-misconfigured',
+    'The update release source channel must use 1-80 letters, numbers, dots, underscores, or hyphens.',
+    { descriptor, manualReleaseUrl },
+  )
 }
 
 async function currentVersionFromOptions(options: ResolveUpdateReleaseSourceOptions) {

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -273,8 +273,18 @@
       "properties": {
         "kind": { "const": "github-releases" },
         "label": { "type": "string", "minLength": 1, "maxLength": 80 },
-        "owner": { "type": "string", "minLength": 1, "maxLength": 128 },
-        "repo": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 39,
+          "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100,
+          "pattern": "^[A-Za-z0-9._-]+$"
+        },
         "channel": { "$ref": "#/$defs/updateChannel" },
         "auth": {
           "type": "object",
@@ -320,7 +330,12 @@
       "properties": {
         "kind": { "const": "gcs" },
         "label": { "type": "string", "minLength": 1, "maxLength": 80 },
-        "bucket": { "type": "string", "minLength": 3, "maxLength": 222 },
+        "bucket": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 222,
+          "pattern": "^(?!.*\\.\\.)(?!\\d{1,3}(?:\\.\\d{1,3}){3}$)[a-z0-9][a-z0-9._-]*[a-z0-9]$"
+        },
         "prefix": {
           "type": "string",
           "maxLength": 512,

--- a/scripts/desktop-after-pack.mjs
+++ b/scripts/desktop-after-pack.mjs
@@ -101,6 +101,15 @@ function isTruthyEnv(value) {
   return value === '1' || value === 'true'
 }
 
+function safeReleaseSourceKind(value) {
+  return ['github-releases', 'generic-http', 'gcs'].includes(value) ? value : 'github-releases'
+}
+
+function safeUpdateChannel(value) {
+  const channel = typeof value === 'string' && value.trim() ? value.trim() : 'latest'
+  return /^[A-Za-z0-9._-]{1,80}$/.test(channel) ? channel : 'latest'
+}
+
 export function buildUpdateInstallCapabilityResource(context, env = process.env) {
   if (context.electronPlatformName !== 'darwin') return null
   const signedInstallEligible = isTruthyEnv(env.OPEN_COWORK_SIGNED_UPDATE_INSTALL_ELIGIBLE)
@@ -110,8 +119,8 @@ export function buildUpdateInstallCapabilityResource(context, env = process.env)
     schemaVersion: 2,
     signedInstallEligible,
     feedConfigured,
-    releaseSourceKind: env.OPEN_COWORK_UPDATE_RELEASE_SOURCE_KIND || 'github-releases',
-    channel: env.OPEN_COWORK_UPDATE_CHANNEL || 'latest',
+    releaseSourceKind: safeReleaseSourceKind(env.OPEN_COWORK_UPDATE_RELEASE_SOURCE_KIND),
+    channel: safeUpdateChannel(env.OPEN_COWORK_UPDATE_CHANNEL),
   }
 }
 

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -231,6 +231,32 @@ test('update release source schema rejects non-https public endpoints', () => {
   assert.throws(() => validateResolvedConfig(config, 'update source config'), /updates/)
 })
 
+test('update release source schema rejects unsafe release identifiers', () => {
+  const config = cloneConfig()
+  config.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'github-releases',
+      owner: 'joe-broadhead/other',
+      repo: 'open-cowork',
+    },
+  }
+  assert.throws(() => validateResolvedConfig(config, 'update source config'), /updates/)
+
+  config.updates.releaseSource = {
+    kind: 'gcs',
+    bucket: 'acme/releases',
+  }
+  assert.throws(() => validateResolvedConfig(config, 'update source config'), /updates/)
+
+  config.updates.releaseSource = {
+    kind: 'generic-http',
+    url: 'https://updates.acme.example/cowork',
+    channel: '../latest',
+  }
+  assert.throws(() => validateResolvedConfig(config, 'update source config'), /updates/)
+})
+
 test('provider dynamic catalogs require https URLs and valid SHA-256 pins', () => {
   const config = cloneConfig()
   config.providers.descriptors.openrouter.dynamicCatalog = {

--- a/tests/desktop-after-pack.test.ts
+++ b/tests/desktop-after-pack.test.ts
@@ -116,6 +116,22 @@ test('desktop-after-pack writes signed macOS update capability metadata only whe
         channel: 'latest',
       },
     )
+
+    assert.deepEqual(buildUpdateInstallCapabilityResource(
+      { electronPlatformName: 'darwin' },
+      {
+        OPEN_COWORK_SIGNED_UPDATE_INSTALL_ELIGIBLE: 'true',
+        OPEN_COWORK_UPDATE_FEED_CONFIGURED: 'true',
+        OPEN_COWORK_UPDATE_RELEASE_SOURCE_KIND: 'https://signed.example.test/feed?token=private',
+        OPEN_COWORK_UPDATE_CHANNEL: '../latest?token=private',
+      },
+    ), {
+      schemaVersion: 2,
+      signedInstallEligible: true,
+      feedConfigured: true,
+      releaseSourceKind: 'github-releases',
+      channel: 'latest',
+    })
   } finally {
     rmSync(root, { recursive: true, force: true })
   }

--- a/tests/update-release-source.test.ts
+++ b/tests/update-release-source.test.ts
@@ -44,7 +44,7 @@ test('generic update release source discovers latest version from updater metada
   const config = baseConfig()
   config.updates = {
     enabled: true,
-    manualFallbackUrl: 'https://updates.example.test/cowork',
+    manualFallbackUrl: 'https://updates.example.test/cowork?download_token=private',
     releaseSource: {
       kind: 'generic-http',
       url: 'https://updates.example.test/cowork',
@@ -68,6 +68,56 @@ test('generic update release source discovers latest version from updater metada
     hasUpdate: true,
     releaseUrl: 'https://updates.example.test/cowork',
   })
+})
+
+test('update release source resolver rejects unsafe identifiers defensively', async () => {
+  const invalidGithub = baseConfig()
+  invalidGithub.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'github-releases',
+      owner: 'joe-broadhead/other',
+      repo: 'open-cowork',
+    },
+  }
+  await assert.rejects(
+    () => resolveUpdateReleaseSource({ config: invalidGithub, currentVersion: '1.0.0' }),
+    (error) => error instanceof UpdateReleaseSourceError && error.reason === 'source-misconfigured',
+  )
+
+  const invalidChannel = baseConfig()
+  invalidChannel.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'generic-http',
+      url: 'https://updates.example.test/cowork',
+      channel: '../private',
+    },
+  }
+  await assert.rejects(
+    () => resolveUpdateReleaseSource({ config: invalidChannel, currentVersion: '1.0.0' }),
+    (error) => error instanceof UpdateReleaseSourceError && error.reason === 'source-misconfigured',
+  )
+
+  const invalidBucket = baseConfig()
+  invalidBucket.auth = { mode: 'google-oauth', googleOAuth: { clientId: 'client-id' } }
+  invalidBucket.updates = {
+    enabled: true,
+    releaseSource: {
+      kind: 'gcs',
+      bucket: 'secret-bucket/private',
+      auth: { kind: 'google-oauth' },
+    },
+  }
+  await assert.rejects(
+    () => resolveUpdateReleaseSource({
+      config: invalidBucket,
+      currentVersion: '1.0.0',
+      getAuthState: () => ({ authenticated: true, email: 'user@example.test' }),
+      refreshGoogleAccessToken: async () => 'ya29.private-token',
+    }),
+    (error) => error instanceof UpdateReleaseSourceError && error.reason === 'source-misconfigured',
+  )
 })
 
 test('authenticated generic update release source does not expose feed URL without explicit fallback', async () => {


### PR DESCRIPTION
## Summary
- validate update release channels, GitHub owner/repo identifiers, and GCS bucket names at runtime as defense in depth
- sanitize packaged update marker source kind/channel values before embedding them into app resources
- strip query strings from renderer-facing manual fallback URLs and add regression coverage

## Validation
- pnpm test -- tests/update-release-source.test.ts tests/config-schema-validation.test.ts tests/desktop-after-pack.test.ts tests/update-service.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check