### PR TITLE
Improve thread streaming and agent controls

### DIFF
--- a/apps/desktop/src/lib/session-view-messages.ts
+++ b/apps/desktop/src/lib/session-view-messages.ts
@@ -5,8 +5,8 @@ import type {
   MessageSegment,
 } from '@open-cowork/shared'
 
-import { nextOrderFrom, nowIsoFromTiming, type SessionViewTiming } from './session-view-order.ts'
-import { mergeStreamingText, preferNewerStreamingText } from './session-view-text.ts'
+import { nextOrderFrom, nowIsoFromTiming, orderAfterSplitBoundary, type SessionViewTiming } from './session-view-order.ts'
+import { mergeStreamingText, preferNewerStreamingText, splitReplacementTextByPreviousSegments } from './session-view-text.ts'
 
 const LIVE_ASSISTANT_MESSAGE_SUFFIX = ':assistant:live'
 const LIVE_ASSISTANT_SEGMENT_SUFFIX = ':segment:live'
@@ -39,6 +39,49 @@ export interface MessageStateShape {
   messageById: Record<string, MessageEntity>
   messagePartsById: Record<string, MessagePartEntity>
   messageReasoningById: Record<string, MessagePartEntity>
+}
+
+function splitSegmentIdAfterOrder(segmentId: string, order: number) {
+  return `${segmentId}:after:${order}`
+}
+
+function splitSegmentPrefix(segmentId: string) {
+  return `${segmentId}:after:`
+}
+
+function latestSplitSegmentId(
+  messagePartsById: Record<string, MessagePartEntity>,
+  segmentIds: string[],
+  segmentId: string,
+) {
+  let latest: { id: string; order: number } | null = null
+  const prefix = splitSegmentPrefix(segmentId)
+  for (const candidateId of segmentIds) {
+    if (!candidateId.startsWith(prefix)) continue
+    const candidate = messagePartsById[candidateId]
+    if (!candidate) continue
+    if (!latest || candidate.order > latest.order) {
+      latest = { id: candidateId, order: candidate.order }
+    }
+  }
+  return latest?.id ?? null
+}
+
+export function hasMessageTextSegment(
+  state: MessageStateShape,
+  messageId: string,
+  segmentId: string,
+) {
+  return Boolean(state.messageById[messageId]?.segmentIds.includes(segmentId) && state.messagePartsById[segmentId])
+}
+
+export function hasSplitMessageTextSegment(
+  state: MessageStateShape,
+  messageId: string,
+  segmentId: string,
+) {
+  const message = state.messageById[messageId]
+  return Boolean(message && latestSplitSegmentId(state.messagePartsById, message.segmentIds, segmentId))
 }
 
 function livePlaceholderMessageSuffix(role: 'user' | 'assistant') {
@@ -371,8 +414,9 @@ export function withMessageText(
     attachments?: MessageAttachment[]
     timestamp?: string | null
     providerId?: string | null
-      modelId?: string | null
-      replace?: boolean
+    modelId?: string | null
+    replace?: boolean
+    splitAfterOrder?: number
   },
   timing?: SessionViewTiming,
 ) {
@@ -418,22 +462,60 @@ export function withMessageText(
   }
 
   const segmentIds = existingMessage.segmentIds.slice()
-  const existingSegment = messagePartsById[normalizedInput.segmentId]
-  if (!existingSegment) {
-    if (normalizedInput.content) {
-      segmentIds.push(normalizedInput.segmentId)
-      messagePartsById[normalizedInput.segmentId] = {
-        id: normalizedInput.segmentId,
-        content: normalizedInput.content,
-        order: timing?.segmentOrder ?? nextMessageStateOrder(reconciledState),
-      }
+  let handledSplitReplace = false
+  if (normalizedInput.replace) {
+    const relatedSegmentIds = segmentIds
+      .filter((segmentId) => segmentId === normalizedInput.segmentId || segmentId.startsWith(splitSegmentPrefix(normalizedInput.segmentId)))
+      .filter((segmentId) => messagePartsById[segmentId])
+      .sort((left, right) => messagePartsById[left]!.order - messagePartsById[right]!.order)
+
+    if (relatedSegmentIds.length > 1) {
+      const relatedSegments = relatedSegmentIds.map((segmentId) => messagePartsById[segmentId]!)
+      const replacementSegments = splitReplacementTextByPreviousSegments(relatedSegments, normalizedInput.content)
+      relatedSegments.forEach((segment, index) => {
+        messagePartsById[segment.id] = {
+          ...segment,
+          content: replacementSegments[index] ?? '',
+        }
+      })
+      handledSplitReplace = true
     }
-  } else {
-    messagePartsById[normalizedInput.segmentId] = {
-      ...existingSegment,
-      content: normalizedInput.replace
-        ? normalizedInput.content
-        : mergeStreamingText(existingSegment.content, normalizedInput.content),
+  }
+
+  const originalSegment = messagePartsById[normalizedInput.segmentId]
+  const shouldSplitSegment = Boolean(
+    originalSegment
+    && !normalizedInput.replace
+    && normalizedInput.splitAfterOrder !== undefined
+    && originalSegment.order <= normalizedInput.splitAfterOrder,
+  )
+  const targetSegmentId = shouldSplitSegment
+    ? splitSegmentIdAfterOrder(normalizedInput.segmentId, normalizedInput.splitAfterOrder!)
+    : (!normalizedInput.replace
+        ? latestSplitSegmentId(messagePartsById, segmentIds, normalizedInput.segmentId) || normalizedInput.segmentId
+        : normalizedInput.segmentId)
+  if (!handledSplitReplace) {
+    const existingSegment = messagePartsById[targetSegmentId]
+    if (!existingSegment) {
+      if (normalizedInput.content) {
+        if (!segmentIds.includes(targetSegmentId)) segmentIds.push(targetSegmentId)
+        const fallbackOrder = timing?.segmentOrder ?? nextMessageStateOrder(reconciledState)
+        messagePartsById[targetSegmentId] = {
+          id: targetSegmentId,
+          content: normalizedInput.content,
+          order: orderAfterSplitBoundary(
+            fallbackOrder,
+            shouldSplitSegment ? normalizedInput.splitAfterOrder : undefined,
+          ),
+        }
+      }
+    } else {
+      messagePartsById[targetSegmentId] = {
+        ...existingSegment,
+        content: normalizedInput.replace
+          ? normalizedInput.content
+          : mergeStreamingText(existingSegment.content, normalizedInput.content),
+      }
     }
   }
 

--- a/apps/desktop/src/lib/session-view-model.ts
+++ b/apps/desktop/src/lib/session-view-model.ts
@@ -45,6 +45,8 @@ export {
   LIVE_USER_MESSAGE_SUFFIX_PUBLIC,
   LIVE_USER_SEGMENT_SUFFIX_PUBLIC,
   buildMessages,
+  hasMessageTextSegment,
+  hasSplitMessageTextSegment,
   importMessage,
   withMessageReasoning,
   withMessageText,
@@ -70,6 +72,7 @@ export type HistoryItem = {
   messageId?: string
   partId?: string
   timestamp: string
+  sequence?: number
   providerId?: string | null
   modelId?: string | null
   taskRunId?: string
@@ -107,6 +110,26 @@ export type HistoryItem = {
     overflow: boolean
     sourceSessionId?: string | null
   }
+}
+
+function historyItemOrder(item: HistoryItem) {
+  return typeof item.sequence === 'number' && Number.isFinite(item.sequence)
+    ? item.sequence
+    : undefined
+}
+
+function historyItemTiming(
+  item: HistoryItem,
+  options?: { preserveStreamingState?: boolean } & SessionViewTiming,
+) {
+  const order = historyItemOrder(item)
+  return order === undefined
+    ? options
+    : {
+        ...options,
+        order,
+        segmentOrder: order,
+      }
 }
 
 export interface SessionViewState {
@@ -267,6 +290,9 @@ export function buildSessionStateFromItems(
   }, options)
 
   for (const item of items) {
+    const itemOrder = historyItemOrder(item)
+    const itemTiming = historyItemTiming(item, options)
+
     if (item.type === 'task_run' && item.taskRun) {
       next.taskRuns = upsertTaskRunList(next.taskRuns, {
         id: item.id,
@@ -277,7 +303,8 @@ export function buildSessionStateFromItems(
         parentSessionId: item.taskRun.parentSessionId,
         startedAt: item.taskRun.startedAt,
         finishedAt: item.taskRun.finishedAt,
-      }, options)
+        order: itemOrder,
+      }, itemTiming)
       next.lastItemWasTool = true
       continue
     }
@@ -291,7 +318,7 @@ export function buildSessionStateFromItems(
       next.taskRuns = withTaskRun(next.taskRuns, item.taskRunId, (taskRun) => ({
         ...taskRun,
         todos: item.todos || [],
-      }), options)
+      }), itemTiming)
       continue
     }
 
@@ -305,23 +332,29 @@ export function buildSessionStateFromItems(
           overflow: compaction.overflow,
           sourceSessionId: compaction.sourceSessionId || taskRun.sourceSessionId,
         }),
-      }), options)
+      }), itemTiming)
       next.lastItemWasTool = true
       continue
     }
 
     if (item.type === 'task_text' && item.taskRunId) {
       next.taskRuns = withTaskRun(next.taskRuns, item.taskRunId, (taskRun) => ({
-        ...withTaskTranscript(taskRun, item.partId || item.messageId || item.id, item.content || '', { replace: true }),
-      }), options)
+        ...withTaskTranscript(taskRun, item.partId || item.messageId || item.id, item.content || '', {
+          replace: true,
+          order: itemOrder,
+        }),
+      }), itemTiming)
       next.lastItemWasTool = true
       continue
     }
 
     if (item.type === 'task_reasoning' && item.taskRunId) {
       next.taskRuns = withTaskRun(next.taskRuns, item.taskRunId, (taskRun) => ({
-        ...withTaskReasoning(taskRun, item.partId || item.messageId || item.id, item.content || '', { replace: true }),
-      }), options)
+        ...withTaskReasoning(taskRun, item.partId || item.messageId || item.id, item.content || '', {
+          replace: true,
+          order: itemOrder,
+        }),
+      }), itemTiming)
       next.lastItemWasTool = true
       continue
     }
@@ -338,7 +371,7 @@ export function buildSessionStateFromItems(
           attachments: item.tool?.attachments,
           agent: item.tool?.agent || taskRun.agent,
           sourceSessionId: item.tool?.sourceSessionId || taskRun.sourceSessionId,
-          order: existingTool?.order ?? nextOrderFrom(next.toolCalls, taskRun.toolCalls),
+          order: existingTool?.order ?? itemOrder ?? nextOrderFrom(next.toolCalls, taskRun.toolCalls),
         }
 
         return {
@@ -347,7 +380,7 @@ export function buildSessionStateFromItems(
             ? taskRun.toolCalls.map((tool) => tool.id === item.id ? { ...tool, ...toolCall } : tool)
             : [...taskRun.toolCalls, toolCall],
         }
-      }, options)
+      }, itemTiming)
       next.lastItemWasTool = true
       continue
     }
@@ -371,7 +404,7 @@ export function buildSessionStateFromItems(
           cacheRead: taskRun.sessionTokens.cacheRead + item.cost!.tokens.cache.read,
           cacheWrite: taskRun.sessionTokens.cacheWrite + item.cost!.tokens.cache.write,
         },
-      }), options)
+      }), itemTiming)
       continue
     }
 
@@ -399,7 +432,7 @@ export function buildSessionStateFromItems(
         attachments: item.tool.attachments,
         agent: item.tool.agent,
         sourceSessionId: item.tool.sourceSessionId,
-        order: nextOrderFrom(next.toolCalls),
+        order: itemOrder ?? nextOrderFrom(next.toolCalls),
       }]
       next.lastItemWasTool = true
       continue
@@ -428,7 +461,7 @@ export function buildSessionStateFromItems(
         segmentId: item.partId || item.id,
         timestamp: item.timestamp,
         replace: true,
-      }, options))
+      }, itemTiming))
       next.lastItemWasTool = false
       continue
     }
@@ -442,7 +475,7 @@ export function buildSessionStateFromItems(
       providerId: item.providerId || null,
       modelId: item.modelId || null,
       replace: true,
-    }, options))
+    }, itemTiming))
     next.lastItemWasTool = false
   }
 

--- a/apps/desktop/src/lib/session-view-order.ts
+++ b/apps/desktop/src/lib/session-view-order.ts
@@ -34,6 +34,11 @@ export function nextOrderFrom(...groups: readonly (readonly OrderedValue[] | Ord
   return max + 1
 }
 
+export function orderAfterSplitBoundary(fallbackOrder: number, splitAfterOrder?: number) {
+  const boundaryOrder = finiteOrder(splitAfterOrder)
+  return boundaryOrder === null ? fallbackOrder : Math.max(fallbackOrder, boundaryOrder + 1)
+}
+
 export function nowMsFromTiming(timing?: SessionViewTiming) {
   return finiteOrder(timing?.nowMs) ?? DEFAULT_SESSION_VIEW_NOW_MS
 }

--- a/apps/desktop/src/lib/session-view-task-runs.ts
+++ b/apps/desktop/src/lib/session-view-task-runs.ts
@@ -11,10 +11,11 @@ import { cloneCompactionNotice } from './session-view-compaction.ts'
 import {
   nextOrderFrom,
   nowIsoFromTiming,
+  orderAfterSplitBoundary,
   timestampIsoFromTiming,
   type SessionViewTiming,
 } from './session-view-order.ts'
-import { mergeStreamingText } from './session-view-text.ts'
+import { mergeStreamingText, splitReplacementTextByPreviousSegments } from './session-view-text.ts'
 import { cloneTokens, EMPTY_SESSION_TOKENS } from './session-view-tokens.ts'
 
 function appendTaskTranscript(existing: string, incoming: string, options?: { boundary?: boolean }) {
@@ -40,6 +41,22 @@ function sortTaskTranscript(transcript: TaskTranscriptSegment[]) {
   return transcript.slice().sort((a, b) => a.order - b.order)
 }
 
+function splitSegmentPrefix(segmentId: string) {
+  return `${segmentId}:after:`
+}
+
+function latestSplitSegmentId(transcript: TaskTranscriptSegment[], segmentId: string) {
+  let latest: { id: string; order: number } | null = null
+  const prefix = splitSegmentPrefix(segmentId)
+  for (const segment of transcript) {
+    if (!segment.id.startsWith(prefix)) continue
+    if (!latest || segment.order > latest.order) {
+      latest = { id: segment.id, order: segment.order }
+    }
+  }
+  return latest?.id ?? null
+}
+
 export function renderTaskTranscript(transcript: TaskTranscriptSegment[]) {
   return sortTaskTranscript(transcript)
     .map((segment) => segment.content)
@@ -51,16 +68,46 @@ function appendTaskTranscriptSegment(
   transcript: TaskTranscriptSegment[],
   segmentId: string,
   incoming: string,
-  options?: { boundary?: boolean; replace?: boolean; order?: number },
+  options?: { boundary?: boolean; replace?: boolean; order?: number; splitAfterOrder?: number },
 ) {
   if (!incoming) return transcript
 
-  const existing = transcript.find((segment) => segment.id === segmentId)
-  if (!existing) {
-    return [...transcript, { id: segmentId, content: incoming, order: options?.order ?? nextOrderFrom(transcript) }]
+  if (options?.replace) {
+    const relatedSegments = transcript
+      .filter((segment) => segment.id === segmentId || segment.id.startsWith(splitSegmentPrefix(segmentId)))
+      .sort((left, right) => left.order - right.order)
+    if (relatedSegments.length > 1) {
+      const replacementSegments = splitReplacementTextByPreviousSegments(relatedSegments, incoming)
+      const contentById = new Map(
+        relatedSegments.map((segment, index) => [segment.id, replacementSegments[index] ?? '']),
+      )
+      return transcript.map((segment) => contentById.has(segment.id)
+        ? { ...segment, content: contentById.get(segment.id) || '' }
+        : segment)
+    }
   }
 
-  return transcript.map((segment) => segment.id === segmentId
+  const originalSegment = transcript.find((segment) => segment.id === segmentId)
+  const shouldSplitSegment = Boolean(
+    originalSegment
+    && !options?.replace
+    && options?.splitAfterOrder !== undefined
+    && originalSegment.order <= options.splitAfterOrder,
+  )
+  const targetSegmentId = shouldSplitSegment
+    ? `${segmentId}:after:${options!.splitAfterOrder}`
+    : (!options?.replace ? latestSplitSegmentId(transcript, segmentId) || segmentId : segmentId)
+  const existing = transcript.find((segment) => segment.id === targetSegmentId)
+  if (!existing) {
+    const fallbackOrder = options?.order ?? nextOrderFrom(transcript)
+    return [...transcript, {
+      id: targetSegmentId,
+      content: incoming,
+      order: orderAfterSplitBoundary(fallbackOrder, shouldSplitSegment ? options?.splitAfterOrder : undefined),
+    }]
+  }
+
+  return transcript.map((segment) => segment.id === targetSegmentId
     ? {
         ...segment,
         content: options?.replace ? incoming : appendTaskTranscript(segment.content, incoming, options),
@@ -72,7 +119,7 @@ export function withTaskTranscript(
   taskRun: TaskRun,
   segmentId: string,
   incoming: string,
-  options?: { boundary?: boolean; replace?: boolean; order?: number },
+  options?: { boundary?: boolean; replace?: boolean; order?: number; splitAfterOrder?: number },
 ) {
   const transcript = appendTaskTranscriptSegment(taskRun.transcript, segmentId, incoming, options)
   return {

--- a/apps/desktop/src/lib/session-view-text.ts
+++ b/apps/desktop/src/lib/session-view-text.ts
@@ -23,3 +23,64 @@ export function preferNewerStreamingText(snapshotContent: string, existingConten
   if (existingContent.startsWith(snapshotContent)) return existingContent
   return existingContent
 }
+
+function splitReplacementTextFromRightByPreviousLengths(
+  segments: readonly { content: string }[],
+  replacement: string,
+) {
+  const result = new Array<string>(segments.length).fill('')
+  let offset = replacement.length
+  for (let index = segments.length - 1; index > 0; index -= 1) {
+    const segmentLength = segments[index]?.content.length ?? 0
+    const nextOffset = Math.max(0, offset - segmentLength)
+    result[index] = replacement.slice(nextOffset, offset)
+    offset = nextOffset
+  }
+  result[0] = replacement.slice(0, offset)
+  return result
+}
+
+export function splitReplacementTextByPreviousSegments(
+  segments: readonly { content: string }[],
+  replacement: string,
+) {
+  if (segments.length <= 1) return [replacement]
+
+  const prefixContent = segments
+    .slice(0, -1)
+    .map((segment) => segment.content)
+    .join('')
+  if (replacement.startsWith(prefixContent)) {
+    return [
+      ...segments.slice(0, -1).map((segment) => segment.content),
+      replacement.slice(prefixContent.length),
+    ]
+  }
+
+  const boundaries = new Array<number>(segments.length + 1)
+  boundaries[0] = 0
+  boundaries[segments.length] = replacement.length
+  let searchBefore = replacement.length
+
+  // Anchor later segments from the right so edits that shorten earlier text
+  // don't pull post-tool text back before the tool boundary.
+  for (let index = segments.length - 1; index > 0; index -= 1) {
+    const content = segments[index]?.content || ''
+    if (!content) {
+      boundaries[index] = searchBefore
+      continue
+    }
+
+    const match = replacement.lastIndexOf(content, searchBefore - content.length)
+    if (match < 0) {
+      return splitReplacementTextFromRightByPreviousLengths(segments, replacement)
+    }
+
+    boundaries[index] = match
+    searchBefore = match
+  }
+
+  return segments.map((_segment, index) => (
+    replacement.slice(boundaries[index], boundaries[index + 1])
+  ))
+}

--- a/apps/desktop/src/main/config-public.ts
+++ b/apps/desktop/src/main/config-public.ts
@@ -95,6 +95,7 @@ export function buildProviderDescriptors(
         credentials: builtin.credentials || [],
         models,
         ...(defaultModel ? { defaultModel } : {}),
+        ...(builtin.smallModel ? { smallModel: normalizeProviderModelId(providerId, builtin.smallModel) } : {}),
       }
     }
 
@@ -121,6 +122,7 @@ export function buildProviderDescriptors(
       credentials: custom.credentials || [],
       models,
       ...(defaultModel ? { defaultModel } : {}),
+      ...(custom.smallModel ? { smallModel: normalizeProviderModelId(providerId, custom.smallModel) } : {}),
     }
   })
 }

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -109,6 +109,7 @@ export type CustomProviderRuntimeConfig = {
   npm: string
   name: string
   defaultModel?: string
+  smallModel?: string
   options?: Record<string, unknown>
   models: Record<string, Record<string, unknown>>
   credentials?: CredentialField[]
@@ -133,6 +134,7 @@ export type ConfiguredProviderDescriptor = {
   name: string
   description: string
   defaultModel?: string
+  smallModel?: string
   options?: Record<string, unknown>
   credentials: CredentialField[]
   models: ProviderModelDescriptor[]

--- a/apps/desktop/src/main/custom-agent-store.ts
+++ b/apps/desktop/src/main/custom-agent-store.ts
@@ -81,6 +81,84 @@ function splitMarkdownFrontmatter(content: string) {
   }
 }
 
+function splitInlineYamlMappingEntries(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null
+
+  const inner = trimmed.slice(1, -1).trim()
+  if (!inner) return []
+
+  const entries: string[] = []
+  let current = ''
+  let quote: '"' | '\'' | null = null
+  let depth = 0
+  for (let index = 0; index < inner.length; index += 1) {
+    const char = inner[index]
+    if (quote) {
+      current += char
+      if (char === quote && inner[index - 1] !== '\\') quote = null
+      continue
+    }
+    if (char === '"' || char === '\'') {
+      quote = char
+      current += char
+      continue
+    }
+    if (char === '{' || char === '[') {
+      depth += 1
+      current += char
+      continue
+    }
+    if (char === '}' || char === ']') {
+      depth = Math.max(0, depth - 1)
+      current += char
+      continue
+    }
+    if (char === ',' && depth === 0) {
+      if (current.trim()) entries.push(current.trim())
+      current = ''
+      continue
+    }
+    current += char
+  }
+  if (current.trim()) entries.push(current.trim())
+  return entries
+}
+
+function inlineYamlMappingKey(entry: string) {
+  let quote: '"' | '\'' | null = null
+  let depth = 0
+  for (let index = 0; index < entry.length; index += 1) {
+    const char = entry[index]
+    if (quote) {
+      if (char === quote && entry[index - 1] !== '\\') quote = null
+      continue
+    }
+    if (char === '"' || char === '\'') {
+      quote = char
+      continue
+    }
+    if (char === '{' || char === '[') {
+      depth += 1
+      continue
+    }
+    if (char === '}' || char === ']') {
+      depth = Math.max(0, depth - 1)
+      continue
+    }
+    if (char === ':' && depth === 0) {
+      return entry.slice(0, index).trim().replace(/^['"]|['"]$/g, '')
+    }
+  }
+  return ''
+}
+
+function parseYamlKeyLine(line: string, key: string, indent: string) {
+  const match = line.match(/^(\s*)(['"]?)([^'":]+)\2\s*:(.*)$/)
+  if (!match || match[1] !== indent || match[3]?.trim() !== key) return null
+  return match[4]?.trim() ?? ''
+}
+
 function stripRuntimeDirective(markdown: string) {
   return markdown.replace(runtimeDirectivePattern, '').trim()
 }
@@ -111,8 +189,16 @@ function readAgentInstructionsFromMarkdown(content: string) {
 function ensureSkillWildcardDeny(frontmatter: string, skillNames: string[]) {
   if (skillNames.length === 0 || !frontmatter) return frontmatter
   const lines = frontmatter.split(/\r?\n/)
-  const skillLineIndex = lines.findIndex((line) => line === '  skill:')
+  const skillLineIndex = lines.findIndex((line) => parseYamlKeyLine(line, 'skill', '  ') !== null)
   if (skillLineIndex === -1) return frontmatter
+  const skillLineValue = parseYamlKeyLine(lines[skillLineIndex] || '', 'skill', '  ') || ''
+  const inlineEntries = splitInlineYamlMappingEntries(skillLineValue)
+  if (inlineEntries) {
+    if (inlineEntries.some((entry) => inlineYamlMappingKey(entry) === '*')) return frontmatter
+    const nextLines = [...lines]
+    nextLines.splice(skillLineIndex, 1, '  skill:', '    "*": deny', ...inlineEntries.map((entry) => `    ${entry}`))
+    return nextLines.join('\n')
+  }
 
   let index = skillLineIndex + 1
   while (index < lines.length && lines[index]?.startsWith('    ')) {
@@ -124,6 +210,55 @@ function ensureSkillWildcardDeny(frontmatter: string, skillNames: string[]) {
   const nextLines = [...lines]
   nextLines.splice(skillLineIndex + 1, 0, '    "*": deny')
   return nextLines.join('\n')
+}
+
+function ensureTaskDefaultDeny(frontmatter: string) {
+  if (!frontmatter) return frontmatter
+  const lines = frontmatter.split(/\r?\n/)
+  const permissionLineIndex = lines.findIndex((line) => parseYamlKeyLine(line, 'permission', '') !== null)
+  if (permissionLineIndex === -1) {
+    let closingIndex = -1
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      if (lines[index] === '---') {
+        closingIndex = index
+        break
+      }
+    }
+    if (closingIndex <= 0) return frontmatter
+    const nextLines = [...lines]
+    nextLines.splice(closingIndex, 0, 'permission:', '  task: deny')
+    return nextLines.join('\n')
+  }
+  const permissionLineValue = parseYamlKeyLine(lines[permissionLineIndex] || '', 'permission', '') || ''
+  const inlineEntries = splitInlineYamlMappingEntries(permissionLineValue)
+  if (inlineEntries) {
+    const hasTask = inlineEntries.some((entry) => inlineYamlMappingKey(entry) === 'task')
+    const nextLines = [...lines]
+    nextLines.splice(
+      permissionLineIndex,
+      1,
+      'permission:',
+      ...inlineEntries.map((entry) => `  ${entry}`),
+      ...(hasTask ? [] : ['  task: deny']),
+    )
+    return nextLines.join('\n')
+  }
+  if (permissionLineValue) return frontmatter
+
+  let index = permissionLineIndex + 1
+  while (index < lines.length && lines[index]?.startsWith('  ')) {
+    const trimmed = lines[index]!.trim()
+    if (/^['"]?task['"]?\s*:/.test(trimmed)) return frontmatter
+    index += 1
+  }
+
+  const nextLines = [...lines]
+  nextLines.splice(permissionLineIndex + 1, 0, '  task: deny')
+  return nextLines.join('\n')
+}
+
+function applyCustomAgentPermissionDefaults(frontmatter: string, skillNames: string[]) {
+  return ensureSkillWildcardDeny(ensureTaskDefaultDeny(frontmatter), skillNames)
 }
 
 function parseFrontmatter(content: string) {
@@ -206,7 +341,7 @@ function deriveToolIdsFromPermission(
 
   const patterns = new Set(
     Object.entries(permission as Record<string, unknown>)
-      .filter(([key, value]) => key !== 'skill' && key !== 'task' && (value === 'allow' || value === 'ask'))
+      .filter(([key, value]) => key !== 'skill' && (value === 'allow' || value === 'ask'))
       .map(([key]) => key),
   )
 
@@ -338,7 +473,7 @@ function serializeCustomAgentMarkdown(agent: CustomAgentConfig, permission: Reco
   }
 
   frontmatterLines.push('---')
-  const frontmatter = ensureSkillWildcardDeny(frontmatterLines.join('\n'), agent.skillNames || [])
+  const frontmatter = applyCustomAgentPermissionDefaults(frontmatterLines.join('\n'), agent.skillNames || [])
   return `${[frontmatter, renderAgentInstructionsForRuntime(agent.instructions, agent.skillNames || [])]
     .map((part) => part.trim())
     .filter(Boolean)
@@ -445,7 +580,7 @@ function syncScopedAgentRuntimeGuidance(scope: NativeConfigScope, directory?: st
     const frontmatter = parseFrontmatter(content)
     const skillNames = metadata.skillNames ?? deriveSkillNamesFromPermission(frontmatter.permission)
     const { frontmatter: frontmatterBlock } = splitMarkdownFrontmatter(content)
-    const runtimeFrontmatter = ensureSkillWildcardDeny(frontmatterBlock, skillNames)
+    const runtimeFrontmatter = applyCustomAgentPermissionDefaults(frontmatterBlock, skillNames)
     const runtimeBody = renderAgentInstructionsForRuntime(readAgentInstructionsFromMarkdown(content), skillNames)
     const nextContent = `${runtimeFrontmatter ? `${runtimeFrontmatter}\n\n` : ''}${runtimeBody}`.trimEnd() + '\n'
     if (nextContent !== content) {

--- a/apps/desktop/src/main/custom-agents-utils.ts
+++ b/apps/desktop/src/main/custom-agents-utils.ts
@@ -138,6 +138,20 @@ export const RESERVED_AGENT_NAMES = [
   'autoresearch',
 ]
 
+const BUILT_IN_NATIVE_AGENT_TOOLS: CustomAgentCatalogTool[] = [
+  {
+    id: 'task',
+    name: 'Task Delegation',
+    icon: 'task',
+    description: 'Allow this agent to delegate work to another OpenCode agent.',
+    supportsWrite: true,
+    source: 'builtin',
+    patterns: ['task'],
+    allowPatterns: ['task'],
+    askPatterns: [],
+  },
+]
+
 function unique(values: string[]) {
   return Array.from(new Set(values))
 }
@@ -238,6 +252,10 @@ export function buildCustomAgentCatalog(input: {
       .map((tool) => [tool.id, tool]),
   )
 
+  for (const tool of BUILT_IN_NATIVE_AGENT_TOOLS) {
+    tools.set(tool.id, tool)
+  }
+
   for (const runtimeTool of input.runtimeTools || []) {
     if (!runtimeTool.id || tools.has(runtimeTool.id)) continue
     const supportsWrite = nativeToolSupportsWrite(runtimeTool.id)
@@ -334,7 +352,7 @@ export function buildCustomAgentPermissionFromCatalog(agent: CustomAgentLike, ca
   const askPatterns = Array.from(new Set(selectedTools.flatMap((tool) => tool.askPatterns)))
   const deniedPatterns = Array.from(new Set((normalized.deniedToolPatterns || []).map((pattern) => pattern.trim()).filter(Boolean)))
 
-  const permission: Record<string, unknown> = {}
+  const permission: Record<string, unknown> = { task: 'deny' }
   if (normalized.skillNames.length > 0) {
     permission.skill = {
       '*': 'deny',

--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -9,6 +9,7 @@ import { resolveDisplayCost } from './pricing.ts'
 import {
   ensureTaskRunForChild,
   findFallbackTaskRun,
+  getTaskRun,
   getTaskRunIdForChild,
   registerSession,
   registerTaskRun,
@@ -611,18 +612,105 @@ function handleUpdatedCompactionPart(ctx: MessagePartUpdatedContext) {
   return true
 }
 
+function resolveTaskToolDescriptor(
+  ctx: MessagePartUpdatedContext,
+  metadata: Record<string, unknown>,
+  title: string,
+) {
+  const state = ctx.part.state
+  const metadataAgent = typeof metadata.agent === 'string' ? metadata.agent : null
+  const inputAgent = readString(readRecordValue(state.input, 'agent'))
+  const argsAgent = readString(readRecordValue(state.args, 'agent'))
+  const inputDescription = readString(readRecordValue(state.input, 'description'))
+  const argsDescription = readString(readRecordValue(state.args, 'description'))
+  const inputTitle = readString(readRecordValue(state.input, 'title'))
+  const argsTitle = readString(readRecordValue(state.args, 'title'))
+  const inputPrompt = readString(readRecordValue(state.input, 'prompt'))
+  const argsPrompt = readString(readRecordValue(state.args, 'prompt'))
+  const titleCandidates = [
+    ctx.part.description,
+    inputDescription,
+    argsDescription,
+    title,
+    state.title,
+    inputTitle,
+    argsTitle,
+    inputPrompt,
+    argsPrompt,
+    ctx.part.prompt,
+    state.raw,
+    ctx.part.raw,
+  ]
+  const agentName = normalizeAgentName(ctx.part.agent)
+    || normalizeAgentName(inputAgent)
+    || normalizeAgentName(argsAgent)
+    || normalizeAgentName(metadataAgent)
+    || extractAgentName(...titleCandidates)
+    || null
+
+  return {
+    agentName,
+    titleCandidates,
+  }
+}
+
+function handleUpdatedTaskToolPart(
+  ctx: MessagePartUpdatedContext,
+  input: {
+    isComplete: boolean
+    isError: boolean
+    metadata: Record<string, unknown>
+    title: string
+  },
+) {
+  if (ctx.part.tool !== 'task') return false
+  const parentSessionId = ctx.actualSessionId || ctx.rootSessionId
+  const taskRunId = ctx.part.callId || ctx.part.id || `${parentSessionId}:task:${crypto.randomUUID()}`
+  const { agentName, titleCandidates } = resolveTaskToolDescriptor(ctx, input.metadata, input.title)
+  const existingTaskRun = getTaskRun(taskRunId)
+  const taskStatus = input.isError
+    ? 'error'
+    : existingTaskRun?.childSessionId
+      ? existingTaskRun.status === 'queued' ? 'running' : existingTaskRun.status
+      : input.isComplete
+        ? 'complete'
+        : 'queued'
+
+  const taskRun = existingTaskRun
+    ? updateTaskRun(taskRunId, {
+        agent: agentName || existingTaskRun.agent,
+        title: chooseTaskTitle(
+          agentName || existingTaskRun.agent,
+          !isPlaceholderTaskTitle(existingTaskRun.title, existingTaskRun.agent || agentName) ? existingTaskRun.title : null,
+          ...titleCandidates,
+        ),
+        status: taskStatus,
+      })
+    : registerTaskRun({
+        id: taskRunId,
+        rootSessionId: ctx.rootSessionId,
+        parentSessionId,
+        title: chooseTaskTitle(agentName, ...titleCandidates),
+        agent: agentName,
+        childSessionId: null,
+        status: taskStatus,
+      })
+  if (taskRun) emitTaskRun(ctx.win, taskRun)
+  return true
+}
+
 function handleUpdatedToolPart(ctx: MessagePartUpdatedContext) {
   if (ctx.part.type !== 'tool') return false
   const state = ctx.part.state
   const statusValue = state.status || ''
-  const isComplete = statusValue === 'completed' || statusValue === 'complete' || state.output !== undefined
-  const isError = statusValue === 'error'
-  const status = isComplete ? 'complete' : isError ? 'error' : 'running'
+  const isError = statusValue === 'error' || state.error !== undefined
+  const isComplete = !isError && (statusValue === 'completed' || statusValue === 'complete' || state.output !== undefined)
+  const status = isError ? 'error' : isComplete ? 'complete' : 'running'
   const title = ctx.part.title || state.title || ''
   const metadata = Object.keys(ctx.part.metadata).length > 0 ? ctx.part.metadata : state.metadata
 
   if (ctx.part.tool === 'question') return true
-  if (ctx.part.tool === 'task' && ctx.actualSessionId === ctx.rootSessionId) return true
+  if (handleUpdatedTaskToolPart(ctx, { isComplete, isError, metadata, title })) return true
 
   let taskRunId: string | null = null
   if (ctx.actualSessionId && ctx.actualSessionId !== ctx.rootSessionId) {

--- a/apps/desktop/src/main/ipc/app-handler-support.ts
+++ b/apps/desktop/src/main/ipc/app-handler-support.ts
@@ -176,6 +176,7 @@ function providerWithoutDefaultModel(provider: ProviderDescriptor): ProviderDesc
     description: provider.description,
     credentials: provider.credentials,
     models: provider.models,
+    ...(provider.smallModel ? { smallModel: provider.smallModel } : {}),
     ...(provider.connected !== undefined ? { connected: provider.connected } : {}),
   }
 }

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -65,6 +65,21 @@ export function saveTextExportFile(filePath: string, content: string) {
   writeFileAtomic(filePath, content, { mode: 0o600 })
 }
 
+export function hasRuntimeSensitiveSettingsUpdate(updates: Partial<CoworkSettings>) {
+  return Boolean(
+    updates.selectedProviderId !== undefined
+    || updates.selectedModelId !== undefined
+    || updates.selectedSmallModelId !== undefined
+    || updates.providerCredentials !== undefined
+    || updates.integrationCredentials !== undefined
+    || updates.integrationEnabled !== undefined
+    || updates.enableBash !== undefined
+    || updates.enableFileWrite !== undefined
+    || updates.runtimeConfigSource !== undefined
+    || updates.runtimeToolingBridgeEnabled !== undefined
+  )
+}
+
 export function registerAppHandlers(context: IpcHandlerContext) {
   subscribeUpdateInstallEvents((event) => {
     const win = context.getMainWindow()
@@ -185,17 +200,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
 
   registerIpcInvoke(context, 'settings:set', objectArg<Partial<CoworkSettings>>('settings update'), async (_event, updates) => {
     const result = saveSettings(updates)
-    const runtimeSensitiveUpdate = Boolean(
-      updates.selectedProviderId !== undefined
-      || updates.selectedModelId !== undefined
-      || updates.providerCredentials !== undefined
-      || updates.integrationCredentials !== undefined
-      || updates.integrationEnabled !== undefined
-      || updates.enableBash !== undefined
-      || updates.enableFileWrite !== undefined
-      || updates.runtimeConfigSource !== undefined
-      || updates.runtimeToolingBridgeEnabled !== undefined
-    )
+    const runtimeSensitiveUpdate = hasRuntimeSensitiveSettingsUpdate(updates)
 
     if (isSetupComplete(result)) {
       const activeClient = getClient()

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -8,7 +8,6 @@ import {
   getConfiguredToolAskPatterns,
   getConfiguredToolPatterns,
   getConfiguredToolsFromConfig,
-  getProviderDescriptor,
   expandMcpToolPermissionPatterns,
 } from './config-loader.ts'
 import { getEffectiveSettings, getProviderCredentialValue, type CoworkSettings } from './settings.ts'
@@ -288,6 +287,27 @@ function webSearchPolicy(web: PermissionAction, enabled: boolean): PermissionAct
   return enabled ? web : 'deny'
 }
 
+function stripProviderPrefix(providerId: string, modelId: string | null | undefined) {
+  const trimmed = modelId?.trim()
+  if (!trimmed) return ''
+  const prefix = `${providerId}/`
+  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed
+}
+
+function resolveRuntimeSmallModelId(input: {
+  providerId: string
+  selectedModelId: string
+  selectedSmallModelId?: string | null
+  appConfig: ReturnType<typeof getAppConfig>
+}) {
+  const settingsSmallModel = stripProviderPrefix(input.providerId, input.selectedSmallModelId)
+  if (settingsSmallModel) return settingsSmallModel
+  const descriptorSmallModel = input.appConfig.providers.descriptors?.[input.providerId]?.smallModel
+  const customSmallModel = input.appConfig.providers.custom?.[input.providerId]?.smallModel
+  return stripProviderPrefix(input.providerId, descriptorSmallModel || customSmallModel)
+    || input.selectedModelId
+}
+
 function buildRuntimeConfigWithCustomMcpsResult(
   projectDirectory: string | null | undefined,
   customMcps: CustomMcpConfig[],
@@ -304,11 +324,15 @@ function buildRuntimeConfigWithCustomMcpsResult(
   const providerId = settings.effectiveProviderId || appConfig.providers.defaultProvider || 'openrouter'
   const configModel = settings.effectiveModel
     || (providerId === appConfig.providers.defaultProvider ? appConfig.providers.defaultModel || '' : '')
-  const providerDescriptor = getProviderDescriptor(providerId)
-  const modelId = configModel.startsWith(`${providerId}/`) ? configModel.slice(providerId.length + 1) : configModel
-  const fallbackSmallModel = providerDescriptor?.models?.find((model) => model.id !== modelId)?.id || modelId
+  const modelId = stripProviderPrefix(providerId, configModel)
   const modelStr = modelId ? `${providerId}/${modelId}` : `${providerId}`
-  const smallModelStr = fallbackSmallModel ? `${providerId}/${fallbackSmallModel}` : modelStr
+  const smallModelId = resolveRuntimeSmallModelId({
+    providerId,
+    selectedModelId: modelId,
+    selectedSmallModelId: settings.effectiveSmallModel || settings.selectedSmallModelId,
+    appConfig,
+  })
+  const smallModelStr = smallModelId ? `${providerId}/${smallModelId}` : modelStr
 
   const mcpConfig: NonNullable<Config['mcp']> = {}
   const compactionConfig = getAppConfig().compaction

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -20,6 +20,7 @@ const NATIVE_WRITE_TOOLS = new Set([
   'edit',
   'write',
   'apply_patch',
+  'task',
   'todowrite',
 ])
 
@@ -37,6 +38,7 @@ export function isVisibleRuntimeToolId(id: string) {
 }
 
 export function humanizeToolId(value: string) {
+  if (value === 'task') return 'Task Delegation'
   if (value === 'websearch') return 'Web Search'
   if (value === 'webfetch') return 'Web Fetch'
   if (value === 'todowrite') return 'Todo Write'

--- a/apps/desktop/src/main/session-engine.ts
+++ b/apps/desktop/src/main/session-engine.ts
@@ -3,6 +3,7 @@ import type {
   PendingQuestion,
   SessionError,
   SessionView,
+  TaskRun,
   TodoItem,
 } from '@open-cowork/shared'
 import {
@@ -12,6 +13,8 @@ import {
   deriveVisibleSessionPatch,
   finishCompactionNotice,
   getOrCreateSessionState,
+  hasMessageTextSegment,
+  hasSplitMessageTextSegment,
   maxSessionViewOrder,
   pruneSessionDetailCache,
   refreshContextState,
@@ -63,6 +66,41 @@ function upsertById<T extends { id: string }>(
   const existing = items.find((entry) => entry.id === item.id)
   if (!existing) return [...items, item]
   return items.map((entry) => entry.id === item.id ? merge(entry, item) : entry)
+}
+
+function latestOrder(...groups: readonly (readonly { order?: number | null }[] | null | undefined)[]) {
+  let max: number | null = null
+  for (const group of groups) {
+    if (!group) continue
+    for (const entry of group) {
+      const order = typeof entry.order === 'number' && Number.isFinite(entry.order) ? entry.order : null
+      if (order !== null && (max === null || order > max)) max = order
+    }
+  }
+  return max ?? undefined
+}
+
+function latestTaskInterruptionOrder(taskRun: TaskRun) {
+  return latestOrder(taskRun.toolCalls, taskRun.compactions)
+}
+
+function latestSessionInterruptionOrder(current: SessionViewState) {
+  return latestOrder(
+    current.toolCalls,
+    current.taskRuns,
+    current.compactions,
+    current.pendingApprovals,
+    current.errors,
+  )
+}
+
+function shouldComputeMessageSplitOrder(
+  current: SessionViewState,
+  messageId: string,
+  segmentId: string,
+) {
+  return hasMessageTextSegment(current, messageId, segmentId)
+    && (current.lastItemWasTool || !hasSplitMessageTextSegment(current, messageId, segmentId))
 }
 
 export class SessionEngine {
@@ -297,20 +335,29 @@ export class SessionEngine {
                 ...withTaskTranscript(taskRun, data.partId || data.messageId || `${data.taskRunId}:live`, data.content || '', {
                   replace: data.mode === 'replace',
                   order: this.nextSeq(),
+                  splitAfterOrder: data.mode === 'replace' ? undefined : latestTaskInterruptionOrder(taskRun),
                 }),
               })),
               lastItemWasTool: true,
             }
           }
+          const messageId = data.messageId || `${sessionId}:assistant:live`
+          const segmentId = data.partId || data.messageId || `${sessionId}:segment:live`
+          const splitAfterOrder = data.mode === 'replace'
+            ? undefined
+            : shouldComputeMessageSplitOrder(current, messageId, segmentId)
+              ? latestSessionInterruptionOrder(current)
+              : undefined
           return {
             ...current,
             ...withMessageText(current, {
-              messageId: data.messageId || `${sessionId}:assistant:live`,
+              messageId,
               role: data.role === 'user' ? 'user' : 'assistant',
               content: data.content || '',
-              segmentId: data.partId || data.messageId || `${sessionId}:segment:live`,
+              segmentId,
               attachments: data.attachments,
               replace: data.mode === 'replace',
+              splitAfterOrder,
             }, {
               ...this.sessionViewTiming(),
               order: this.nextSeq(),

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -5,6 +5,7 @@ import { shortSessionId } from './log-sanitizer.ts'
 import { incrementPerfCounter, measureAsyncPerf, measurePerf, observePerf } from './perf-metrics.ts'
 import { sessionEngine } from './session-engine.ts'
 import { getThreadIndexService } from './thread-index-service.ts'
+import { getSessionRecord } from './session-registry.ts'
 
 export type RuntimeSessionEvent = {
   type?: string
@@ -181,6 +182,19 @@ export function publishSessionView(win: BrowserWindow | null | undefined, sessio
   })
 }
 
+export function publishSessionMetadata(win: BrowserWindow | null | undefined, sessionId: string | null | undefined) {
+  if (!win || win.isDestroyed() || !sessionId) return
+  const record = getSessionRecord(sessionId)
+  if (!record) return
+  win.webContents.send('session:updated', {
+    id: record.id,
+    title: record.title || null,
+    parentSessionId: record.parentSessionId,
+    changeSummary: record.changeSummary,
+    revertedMessageId: record.revertedMessageId,
+  })
+}
+
 export function publishSessionPatch(
   win: BrowserWindow | null | undefined,
   patch: SessionPatch | null | undefined,
@@ -264,6 +278,7 @@ function queueSessionHistoryRefresh(win: BrowserWindow, sessionId: string) {
             slowData: { sessionId: shortSessionId(sessionId) },
           })
           publishSessionView(pending.win, sessionId)
+          publishSessionMetadata(pending.win, sessionId)
         } catch (err) {
           const message = err instanceof Error
             ? err.message

--- a/apps/desktop/src/main/session-history-projection-utils.ts
+++ b/apps/desktop/src/main/session-history-projection-utils.ts
@@ -22,15 +22,6 @@ export const collectHistoryTextParts = (parts: NormalizedMessagePart[]) => {
   return { textParts, fullText }
 }
 
-export const collectHistoryReasoningParts = (parts: NormalizedMessagePart[]) => {
-  const reasoningParts: NormalizedMessagePart[] = []
-  for (const part of parts) {
-    if (part.type !== 'reasoning' || typeof part.text !== 'string' || part.text.length === 0) continue
-    reasoningParts.push(part)
-  }
-  return reasoningParts
-}
-
 export const createHistoryCostPayload = (cachedModelId: string, part: NormalizedMessagePart) => {
   const tokens = part.tokens || { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
   const cost = resolveDisplayCostForModel(cachedModelId, part.cost ?? undefined, tokens)

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -3,6 +3,7 @@ import {
   normalizeTodoItems,
   normalizeSessionMessages,
   normalizeSessionStatuses,
+  type NormalizedMessagePart,
 } from './opencode-adapter.ts'
 import type { TodoItem } from '@open-cowork/shared'
 import {
@@ -13,7 +14,6 @@ import {
   toIsoTimestamp,
 } from './task-run-utils.ts'
 import {
-  collectHistoryReasoningParts,
   collectHistoryTextParts,
   createHistoryCostPayload,
   getHistoryModelMeta,
@@ -97,9 +97,84 @@ function isTerminalStepFinishReason(reason: string | null | undefined) {
   return normalized !== 'tool-calls' && normalized !== 'tool_calls'
 }
 
+function stringField(record: Record<string, unknown>, key: string) {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function taskToolDescriptor(part: NormalizedMessagePart, child?: ChildSessionRecord | null) {
+  const inputAgent = stringField(part.state.input, 'agent')
+  const argsAgent = stringField(part.state.args, 'agent')
+  const metadataAgent = stringField(part.state.metadata, 'agent') || stringField(part.metadata, 'agent')
+  const inputDescription = stringField(part.state.input, 'description')
+  const argsDescription = stringField(part.state.args, 'description')
+  const inputTitle = stringField(part.state.input, 'title')
+  const argsTitle = stringField(part.state.args, 'title')
+  const inputPrompt = stringField(part.state.input, 'prompt')
+  const argsPrompt = stringField(part.state.args, 'prompt')
+  const titleCandidates = [
+    part.description,
+    inputDescription,
+    argsDescription,
+    part.title,
+    part.state.title,
+    inputTitle,
+    argsTitle,
+    inputPrompt,
+    argsPrompt,
+    part.prompt,
+    part.state.raw,
+    part.raw,
+    child?.title,
+  ]
+  const agent = normalizeAgentName(part.agent)
+    || normalizeAgentName(inputAgent)
+    || normalizeAgentName(argsAgent)
+    || normalizeAgentName(metadataAgent)
+    || extractAgentName(...titleCandidates)
+    || null
+
+  return { agent, titleCandidates }
+}
+
+function fallbackTaskToolStatus(part: NormalizedMessagePart): TaskStatus {
+  const status = part.state.status || ''
+  if (status === 'error' || part.state.error !== undefined) return 'error'
+  if (status === 'completed' || status === 'complete' || part.state.output !== undefined) return 'complete'
+  return 'queued'
+}
+
+function normalizeMatchText(value: string | null | undefined) {
+  return (value || '')
+    .toLowerCase()
+    .replace(/@\w[\w-]*/g, ' ')
+    .replace(/\bsubagent\b/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function childLooksLikeTaskTool(part: NormalizedMessagePart, child: ChildSessionRecord) {
+  const childTitle = normalizeMatchText(child.title)
+  if (!childTitle) return false
+
+  const descriptor = taskToolDescriptor(part)
+  const titleCandidates = descriptor.titleCandidates
+    .map(normalizeMatchText)
+    .filter((candidate) => candidate.length >= 8)
+  if (titleCandidates.length > 0) {
+    return titleCandidates.some((candidate) => childTitle.includes(candidate) || candidate.includes(childTitle))
+  }
+
+  const agent = normalizeMatchText(descriptor.agent)
+  return agent.length > 0 && childTitle.includes(agent)
+}
+
 export async function projectSessionHistory(input: ProjectSessionHistoryInput): Promise<ProjectedHistoryItem[]> {
   const { sessionId, cachedModelId, rootMessages, rootTodos, statuses, loadChildSnapshot } = input
   const generateId = input.generateId || crypto.randomUUID
+  const normalizedRootMessages = rootMessages
+    .map((rawMsg) => normalizeSessionMessages([rawMsg])[0])
+    .filter((msg): msg is NonNullable<ReturnType<typeof normalizeSessionMessages>[number]> => Boolean(msg))
   type InternalProjectedHistoryItem = ProjectedHistoryItem & { sortTime: number }
   const normalizedStatuses = normalizeSessionStatuses(statuses)
   const statusFor = (id: string) => normalizedStatuses[id] || { type: null }
@@ -115,6 +190,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   const out: InternalProjectedHistoryItem[] = []
   const taskRunItems = new Map<string, InternalProjectedHistoryItem>()
   const childByTaskId = new Map<string, ChildSessionRecord>()
+  const childTaskQueue: Array<[string, ChildSessionRecord]> = []
   const matchedChildIds = new Set<string>()
 
   const pushItem = (item: ProjectedHistoryItem, sortTime: number) => {
@@ -159,18 +235,90 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     return item
   }
 
-  let nextDirectChildIndex = 0
-  const takeDirectChildForSubtask = () => {
-    while (nextDirectChildIndex < directChildren.length) {
-      const child = directChildren[nextDirectChildIndex++]
-      if (child && !matchedChildIds.has(child.id)) return child
+  const enqueueChildTask = (taskId: string, child: ChildSessionRecord) => {
+    if (childByTaskId.has(taskId)) {
+      childByTaskId.set(taskId, child)
+      return
+    }
+    childByTaskId.set(taskId, child)
+    childTaskQueue.push([taskId, child])
+  }
+
+  const childBelongsToParent = (child: ChildSessionRecord, parentSessionId: string) => {
+    return (child.parentSessionId || sessionId) === parentSessionId
+  }
+
+  const takeChildForTaskTool = (
+    parentSessionId: string,
+    part: NormalizedMessagePart,
+    requireTaskMatch: boolean,
+  ) => {
+    for (const child of children) {
+      if (matchedChildIds.has(child.id) || !childBelongsToParent(child, parentSessionId)) continue
+      if (requireTaskMatch && !childLooksLikeTaskTool(part, child)) continue
+      matchedChildIds.add(child.id)
+      return child
     }
     return null
   }
 
-  for (const rawMsg of rootMessages) {
-    const msg = normalizeSessionMessages([rawMsg])[0]
-    if (!msg) continue
+  const enqueueUnmatchedChildren = (parentSessionId?: string) => {
+    for (const child of children) {
+      if (matchedChildIds.has(child.id)) continue
+      if (parentSessionId && !childBelongsToParent(child, parentSessionId)) continue
+      const taskId = `child:${child.id}`
+      const agent = extractAgentName(child.title)
+      const sortTime = toHistorySortTime(child.time?.created || Date.now())
+      const childStatus = getTaskStatus(child.id)
+      const timing = timingFromChild(child, childStatus)
+      addTaskRun({
+        id: taskId,
+        title: chooseTaskTitle(agent, child.title),
+        agent,
+        status: childStatus,
+        sourceSessionId: child.id,
+        parentSessionId: child.parentSessionId || sessionId,
+        startedAt: timing.startedAt,
+        finishedAt: timing.finishedAt,
+      }, toIsoTimestamp(sortTime), sortTime)
+      matchedChildIds.add(child.id)
+      enqueueChildTask(taskId, child)
+    }
+  }
+
+  let nextDirectChildIndex = 0
+  const nextAvailableDirectChild = () => {
+    while (nextDirectChildIndex < directChildren.length) {
+      const child = directChildren[nextDirectChildIndex]
+      if (child && !matchedChildIds.has(child.id)) return child
+      nextDirectChildIndex += 1
+    }
+    return null
+  }
+  const takeDirectChildForSubtask = (accept?: (child: ChildSessionRecord) => boolean) => {
+    if (!accept) {
+      const child = nextAvailableDirectChild()
+      if (!child) return null
+      nextDirectChildIndex += 1
+      return child
+    }
+
+    while (nextDirectChildIndex < directChildren.length) {
+      const current = directChildren[nextDirectChildIndex]
+      if (current && !matchedChildIds.has(current.id)) break
+      nextDirectChildIndex += 1
+    }
+
+    for (let index = nextDirectChildIndex; index < directChildren.length; index += 1) {
+      const child = directChildren[index]
+      if (!child || matchedChildIds.has(child.id) || !accept(child)) continue
+      if (index === nextDirectChildIndex) nextDirectChildIndex += 1
+      return child
+    }
+    return null
+  }
+
+  for (const msg of normalizedRootMessages) {
     const info = msg.info
     const parts = msg.parts
     const tsMs = toHistorySortTime(info.time.created || msg.time.created || Date.now())
@@ -178,30 +326,32 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     const msgId = info.id || msg.id || generateId()
     const role = info.role || msg.role || 'assistant'
     const modelMeta = getHistoryModelMeta(msg)
-    const { textParts, fullText } = collectHistoryTextParts(parts)
-    const reasoningParts = collectHistoryReasoningParts(parts)
+    const { fullText } = collectHistoryTextParts(parts)
 
-    if (fullText && !isInternalCoworkMessage(fullText)) {
-      textParts.forEach((part, index: number) => {
-        const partId = part.id || `${msgId}:part:${index}`
-        pushItem({
-          type: 'message',
-          id: `${msgId}:${partId}:text`,
-          messageId: msgId,
-          partId,
-          role,
-          content: part.text || '',
-          timestamp: ts,
-          sequence: nextOrder(),
-          providerId: modelMeta.providerId,
-          modelId: modelMeta.modelId,
-        }, tsMs)
-      })
-    }
+    let textIndex = 0
+    let reasoningIndex = 0
+    for (const part of parts) {
+      if (part.type === 'text' && typeof part.text === 'string' && part.text.length > 0) {
+        const partId = part.id || `${msgId}:part:${textIndex++}`
+        if (fullText && !isInternalCoworkMessage(fullText)) {
+          pushItem({
+            type: 'message',
+            id: `${msgId}:${partId}:text`,
+            messageId: msgId,
+            partId,
+            role,
+            content: part.text || '',
+            timestamp: ts,
+            sequence: nextOrder(),
+            providerId: modelMeta.providerId,
+            modelId: modelMeta.modelId,
+          }, tsMs)
+        }
+        continue
+      }
 
-    if (role === 'assistant' && reasoningParts.length > 0) {
-      reasoningParts.forEach((part, index: number) => {
-        const partId = part.id || `${msgId}:reasoning:${index}`
+      if (part.type === 'reasoning' && role === 'assistant' && typeof part.text === 'string' && part.text.length > 0) {
+        const partId = part.id || `${msgId}:reasoning:${reasoningIndex++}`
         pushItem({
           type: 'message_reasoning',
           id: `${msgId}:${partId}:reasoning`,
@@ -214,10 +364,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
           providerId: modelMeta.providerId,
           modelId: modelMeta.modelId,
         }, tsMs)
-      })
-    }
+        continue
+      }
 
-    for (const part of parts) {
       if (part.type === 'subtask') {
         const child = takeDirectChildForSubtask()
         const taskId = child?.id
@@ -246,8 +395,38 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
           finishedAt: timing.finishedAt,
         }, ts, tsMs)
         if (child) {
-          childByTaskId.set(taskId, child)
           matchedChildIds.add(child.id)
+          enqueueChildTask(taskId, child)
+        }
+        if (!taskItem) continue
+        continue
+      }
+
+      if (part.type === 'tool' && part.tool === 'task') {
+        const fallbackStatus = fallbackTaskToolStatus(part)
+        const requireTaskMatch = fallbackStatus === 'complete' || fallbackStatus === 'error'
+        const child = takeDirectChildForSubtask((candidate) => {
+          return !requireTaskMatch || childLooksLikeTaskTool(part, candidate)
+        })
+        const taskId = child?.id
+          ? `child:${child.id}`
+          : `pending:${part.callId || part.id || generateId()}`
+        const childStatus = child ? getTaskStatus(child.id) : fallbackStatus
+        const timing = timingFromChild(child, childStatus)
+        const descriptor = taskToolDescriptor(part, child)
+        const taskItem = addTaskRun({
+          id: taskId,
+          title: chooseTaskTitle(descriptor.agent, ...descriptor.titleCandidates),
+          agent: descriptor.agent,
+          status: childStatus,
+          sourceSessionId: child?.id || null,
+          parentSessionId: child?.parentSessionId || sessionId,
+          startedAt: timing.startedAt,
+          finishedAt: timing.finishedAt,
+        }, ts, tsMs)
+        if (child) {
+          matchedChildIds.add(child.id)
+          enqueueChildTask(taskId, child)
         }
         if (!taskItem) continue
         continue
@@ -317,27 +496,20 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     }
   }
 
-  for (const child of children) {
-    if (matchedChildIds.has(child.id)) continue
-    const taskId = `child:${child.id}`
-    const agent = extractAgentName(child.title)
-    const sortTime = toHistorySortTime(child.time?.created || Date.now())
-    const childStatus = getTaskStatus(child.id)
-    const timing = timingFromChild(child, childStatus)
-    addTaskRun({
-      id: taskId,
-      title: chooseTaskTitle(agent, child.title),
-      agent,
-      status: childStatus,
-      sourceSessionId: child.id,
-      parentSessionId: child.parentSessionId || sessionId,
-      startedAt: timing.startedAt,
-      finishedAt: timing.finishedAt,
-    }, toIsoTimestamp(sortTime), sortTime)
-    childByTaskId.set(taskId, child)
-  }
+  // Queue direct orphan children before replaying child transcripts, but hold
+  // nested orphans until each parent transcript has a chance to bind task tools.
+  enqueueUnmatchedChildren(sessionId)
 
-  for (const [taskId, child] of childByTaskId.entries()) {
+  let taskQueueIndex = 0
+  let fallbackChildrenQueued = false
+  while (taskQueueIndex < childTaskQueue.length || !fallbackChildrenQueued) {
+    if (taskQueueIndex >= childTaskQueue.length) {
+      fallbackChildrenQueued = true
+      enqueueUnmatchedChildren()
+      continue
+    }
+    const [taskId, child] = childTaskQueue[taskQueueIndex]
+    taskQueueIndex += 1
     const { messages: childMessages, todos: childTodos } = await loadChildSnapshot(child.id)
     const normalizedChildTodos = normalizeTodoItems(childTodos)
     const taskRunItem = taskRunItems.get(taskId)
@@ -352,8 +524,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       const ts = toIsoTimestamp(tsMs)
       const role = info.role || msg.role || 'assistant'
       const modelMeta = getHistoryModelMeta(msg)
-      const { textParts, fullText } = collectHistoryTextParts(parts)
-      const reasoningParts = collectHistoryReasoningParts(parts)
+      const { fullText } = collectHistoryTextParts(parts)
 
       for (const part of parts) {
         if (part.type === 'agent' && taskRunItem?.taskRun) {
@@ -363,22 +534,6 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
           taskRunItem.taskRun.title = chooseTaskTitle(
             taskRunItem.taskRun.agent,
             !isPlaceholderTaskTitle(taskRunItem.taskRun.title, taskRunItem.taskRun.agent) ? taskRunItem.taskRun.title : null,
-          )
-        }
-        if (part.type === 'tool' && part.tool === 'task' && taskRunItem?.taskRun) {
-          taskRunItem.taskRun.agent = normalizeAgentName(
-            (typeof part.state.metadata.agent === 'string' ? part.state.metadata.agent : null)
-            || (typeof part.metadata.agent === 'string' ? part.metadata.agent : null),
-          )
-            || extractAgentName(part.title, part.state.title, part.state.raw)
-            || taskRunItem.taskRun.agent
-          taskRunItem.taskRun.title = chooseTaskTitle(
-            taskRunItem.taskRun.agent,
-            !isPlaceholderTaskTitle(taskRunItem.taskRun.title, taskRunItem.taskRun.agent) ? taskRunItem.taskRun.title : null,
-            part.title,
-            part.state.title,
-            part.state.raw,
-            typeof part.state.input.prompt === 'string' ? part.state.input.prompt : null,
           )
         }
         if (part.type === 'step-finish' && isTerminalStepFinishReason(part.reason)) {
@@ -394,29 +549,32 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         )
       }
 
-      if (fullText && !isInternalCoworkMessage(fullText)) {
-        textParts.forEach((part, index: number) => {
+      let textIndex = 0
+      let reasoningIndex = 0
+      for (const part of parts) {
+        if (part.type === 'text' && typeof part.text === 'string' && part.text.length > 0) {
           const messageId = info.id || generateId()
-          const partId = part.id || `${messageId}:part:${index}`
-          pushItem({
-            type: 'task_text',
-            id: `${taskId}:${messageId}:${partId}:text`,
-            timestamp: ts,
-            sequence: nextOrder(),
-            taskRunId: taskId,
-            messageId,
-            partId,
-            content: part.text || '',
-            providerId: modelMeta.providerId,
-            modelId: modelMeta.modelId,
-          }, tsMs)
-        })
-      }
+          const partId = part.id || `${messageId}:part:${textIndex++}`
+          if (fullText && !isInternalCoworkMessage(fullText)) {
+            pushItem({
+              type: 'task_text',
+              id: `${taskId}:${messageId}:${partId}:text`,
+              timestamp: ts,
+              sequence: nextOrder(),
+              taskRunId: taskId,
+              messageId,
+              partId,
+              content: part.text || '',
+              providerId: modelMeta.providerId,
+              modelId: modelMeta.modelId,
+            }, tsMs)
+          }
+          continue
+        }
 
-      if (role === 'assistant' && reasoningParts.length > 0) {
-        reasoningParts.forEach((part, index: number) => {
+        if (part.type === 'reasoning' && role === 'assistant' && typeof part.text === 'string' && part.text.length > 0) {
           const messageId = info.id || generateId()
-          const partId = part.id || `${messageId}:reasoning:${index}`
+          const partId = part.id || `${messageId}:reasoning:${reasoningIndex++}`
           pushItem({
             type: 'task_reasoning',
             id: `${taskId}:${messageId}:${partId}:reasoning`,
@@ -429,10 +587,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
             providerId: modelMeta.providerId,
             modelId: modelMeta.modelId,
           }, tsMs)
-        })
-      }
+          continue
+        }
 
-      for (const part of parts) {
         if (part.type === 'compaction') {
           pushItem({
             type: 'task_compaction',
@@ -447,6 +604,30 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
               sourceSessionId: child.id,
             },
           }, tsMs)
+          continue
+        }
+
+        if (part.type === 'tool' && part.tool === 'task') {
+          const fallbackStatus = fallbackTaskToolStatus(part)
+          const requireTaskMatch = fallbackStatus === 'complete' || fallbackStatus === 'error'
+          const nestedChild = takeChildForTaskTool(child.id, part, requireTaskMatch)
+          const nestedTaskId = nestedChild?.id
+            ? `child:${nestedChild.id}`
+            : `pending:${part.callId || part.id || generateId()}`
+          const nestedStatus = nestedChild ? getTaskStatus(nestedChild.id) : fallbackStatus
+          const timing = timingFromChild(nestedChild, nestedStatus)
+          const descriptor = taskToolDescriptor(part, nestedChild)
+          addTaskRun({
+            id: nestedTaskId,
+            title: chooseTaskTitle(descriptor.agent, ...descriptor.titleCandidates),
+            agent: descriptor.agent,
+            status: nestedStatus,
+            sourceSessionId: nestedChild?.id || null,
+            parentSessionId: nestedChild?.parentSessionId || child.id,
+            startedAt: timing.startedAt,
+            finishedAt: timing.finishedAt,
+          }, ts, tsMs)
+          if (nestedChild) enqueueChildTask(nestedTaskId, nestedChild)
           continue
         }
 
@@ -519,5 +700,8 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       const timeDiff = a.sortTime - b.sortTime
       return timeDiff !== 0 ? timeDiff : a.sequence - b.sequence
     })
-    .map(({ sortTime: _sortTime, ...item }) => item)
+    .map(({ sortTime: _sortTime, ...item }, index) => ({
+      ...item,
+      sequence: index + 1,
+    }))
 }

--- a/apps/desktop/src/main/session-task-state-store.ts
+++ b/apps/desktop/src/main/session-task-state-store.ts
@@ -188,7 +188,7 @@ export class SessionTaskStateStore {
       return bound || this.taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun
     }
 
-    if (!normalizedTaskRun.childSessionId) {
+    if (!normalizedTaskRun.childSessionId && !isTerminalTaskStatus(normalizedTaskRun.status)) {
       pushUniqueQueueValue(this.pendingTaskRunsByParent, parentQueueKey, normalizedTaskRun.id)
     }
 
@@ -258,6 +258,8 @@ export class SessionTaskStateStore {
     this.taskRuns.set(taskRunId, next)
     if (next.childSessionId) {
       this.childSessionToTaskRunId.set(next.childSessionId, next.id)
+    } else if (isTerminalTaskStatus(next.status)) {
+      this.removePendingTaskRun(next.id)
     }
     return next
   }

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -1,11 +1,12 @@
 import electron from 'electron'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
-import type {
-  AgentColor,
-  AppSettings,
-  EffectiveAppSettings,
-  RuntimePermissionPolicy,
+import {
+  SMALL_MODEL_USE_MAIN,
+  type AgentColor,
+  type AppSettings,
+  type EffectiveAppSettings,
+  type RuntimePermissionPolicy,
 } from '@open-cowork/shared'
 import {
   getAppConfig,
@@ -120,6 +121,7 @@ function createDefaults(): AppSettings {
     _schemaVersion: SETTINGS_SCHEMA_VERSION,
     selectedProviderId: defaultProvider,
     selectedModelId: defaultProviderDescriptor?.defaultModel || config.providers.defaultModel,
+    selectedSmallModelId: null,
     providerCredentials: {},
     integrationCredentials: {},
     integrationEnabled: {},
@@ -213,6 +215,8 @@ function normalizeSettingsUpdate(settings: Partial<AppSettings>) {
   if (settings.selectedProviderId === null) update.selectedProviderId = null
   if (typeof settings.selectedModelId === 'string' && Buffer.byteLength(settings.selectedModelId, 'utf8') <= MAX_SETTINGS_KEY_BYTES) update.selectedModelId = settings.selectedModelId
   if (settings.selectedModelId === null) update.selectedModelId = null
+  if (typeof settings.selectedSmallModelId === 'string' && Buffer.byteLength(settings.selectedSmallModelId, 'utf8') <= MAX_SETTINGS_KEY_BYTES) update.selectedSmallModelId = settings.selectedSmallModelId
+  if (settings.selectedSmallModelId === null) update.selectedSmallModelId = null
   if (settings.providerCredentials !== undefined) update.providerCredentials = normalizeNestedStringMap(settings.providerCredentials)
   if (settings.integrationCredentials !== undefined) update.integrationCredentials = normalizeNestedStringMap(settings.integrationCredentials)
   if (settings.integrationEnabled !== undefined) update.integrationEnabled = normalizeBoolMap(settings.integrationEnabled)
@@ -278,6 +282,9 @@ function migrateLegacySettings(raw: any): AppSettings {
       : typeof raw?.defaultModel === 'string'
         ? raw.defaultModel
         : defaults.selectedModelId,
+    selectedSmallModelId: typeof raw?.selectedSmallModelId === 'string'
+      ? raw.selectedSmallModelId
+      : null,
     providerCredentials: normalizeNestedStringMap(raw?.providerCredentials),
     integrationCredentials: normalizeNestedStringMap(raw?.integrationCredentials),
     integrationEnabled: normalizeBoolMap(raw?.integrationEnabled),
@@ -577,6 +584,15 @@ export function getEffectiveSettings(settings = loadSettings()): EffectiveAppSet
   const validSelectedModel = resolveProviderModelSelection(providerId, provider?.models, settings.selectedModelId)
   const fallbackModel = validDefaultModel || provider?.models?.[0]?.id || ''
   const selectedModelId = validSelectedModel || fallbackModel
+  const appConfig = getAppConfig()
+  const configuredSmallModel = provider?.smallModel
+    || appConfig.providers.descriptors?.[providerId || '']?.smallModel
+    || appConfig.providers.custom?.[providerId || '']?.smallModel
+  const validConfiguredSmallModel = resolveProviderModelSelection(providerId, provider?.models, configuredSmallModel)
+  const validSelectedSmallModel = settings.selectedSmallModelId === SMALL_MODEL_USE_MAIN
+    ? selectedModelId
+    : resolveProviderModelSelection(providerId, provider?.models, settings.selectedSmallModelId)
+  const effectiveSmallModel = validSelectedSmallModel || validConfiguredSmallModel || selectedModelId
   const bashPermission = clampRuntimePermissionPolicy(
     settings.enableBash === false ? 'deny' : settings.bashPermission,
     appPermissions.bash,
@@ -594,5 +610,6 @@ export function getEffectiveSettings(settings = loadSettings()): EffectiveAppSet
     enableFileWrite: fileWritePermission !== 'deny',
     effectiveProviderId: providerId,
     effectiveModel: selectedModelId,
+    effectiveSmallModel,
   }
 }

--- a/apps/desktop/src/renderer/components/agents/AgentCapabilitiesTab.test.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentCapabilitiesTab.test.tsx
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import type { AgentCatalog } from '@open-cowork/shared'
-import { buildSkillGroups } from './AgentCapabilitiesTab'
+import { AgentCapabilitiesTab, buildSkillGroups } from './AgentCapabilitiesTab'
 
 const catalog: AgentCatalog = {
   reservedNames: [],
@@ -23,6 +24,15 @@ const catalog: AgentCatalog = {
       supportsWrite: false,
       source: 'builtin',
       patterns: ['mcp__charts__*'],
+    },
+    {
+      id: 'task',
+      name: 'Task Delegation',
+      icon: 'task',
+      description: 'Allow this agent to delegate work to another OpenCode agent.',
+      supportsWrite: true,
+      source: 'builtin',
+      patterns: ['task'],
     },
   ],
   skills: [
@@ -75,5 +85,32 @@ describe('buildSkillGroups', () => {
       'repo-review',
       'release-brief',
     ])
+  })
+})
+
+describe('AgentCapabilitiesTab', () => {
+  it('lets users toggle Task Delegation for custom agents', () => {
+    const onToggleTool = vi.fn()
+
+    render(
+      <AgentCapabilitiesTab
+        catalog={catalog}
+        selectedSkillNames={[]}
+        selectedToolIds={[]}
+        onToggleSkill={vi.fn()}
+        onToggleTool={onToggleTool}
+        onAutoAttachTools={vi.fn()}
+        deniedToolPatterns={[]}
+        onToggleDeniedPattern={vi.fn()}
+        projectDirectory={null}
+      />,
+    )
+
+    const taskButton = screen.getByRole('button', { name: /Task Delegation/i })
+    expect(taskButton).toHaveTextContent('Allow this agent to delegate work')
+
+    fireEvent.click(taskButton)
+
+    expect(onToggleTool).toHaveBeenCalledWith('task')
   })
 })

--- a/apps/desktop/src/renderer/components/chat/ChatTimelineItem.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTimelineItem.tsx
@@ -45,6 +45,7 @@ export function ChatTimelineItem({
         <MessageBubble
           message={item.data}
           streaming={isGenerating && item.data.role === 'assistant' && item.data.order === latestAssistantOrder}
+          actionsEnabled={item.actionsEnabled}
         />
       )
     case 'tools':

--- a/apps/desktop/src/renderer/components/chat/ChatView.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatView.tsx
@@ -117,7 +117,7 @@ export function ChatView() {
       const item = timeline[index]
       if (!item) return index
       switch (item.kind) {
-        case 'message': return `msg:${item.data.id}`
+        case 'message': return item.key
         case 'tools': return `tools:${item.data[0]?.id || index}`
         case 'task': return `task:${item.data.id}`
         case 'task_group': return `task-group:${item.data[0]?.id || index}`
@@ -404,7 +404,7 @@ function escapeAttributeSelector(value: string) {
 
 function timelineItemKey(item: TimelineItem) {
   switch (item.kind) {
-    case 'message': return `msg:${item.data.id}`
+    case 'message': return item.key
     case 'tools': return `tools:${item.data[0]?.id || 'empty'}`
     case 'task': return `task:${item.data.id}`
     case 'task_group': return `task-group:${item.data[0]?.id || 'empty'}`

--- a/apps/desktop/src/renderer/components/chat/MessageBubble.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageBubble.test.tsx
@@ -171,6 +171,25 @@ describe('MessageBubble', () => {
     await waitFor(() => expect(api.session.revert).toHaveBeenCalledWith('session-1', 'assistant-message'))
   })
 
+  it('hides message actions when the visible bubble is only part of an SDK message', () => {
+    render(
+      <MessageBubble
+        message={{
+          id: 'assistant-message',
+          role: 'assistant',
+          content: 'Partial answer before a tool call.',
+          order: 2,
+        }}
+        actionsEnabled={false}
+      />,
+    )
+
+    expect(screen.getByTestId('markdown-content')).toHaveTextContent('Partial answer before a tool call.')
+    expect(screen.queryByRole('button', { name: 'Branch here' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Revert to here' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'View diff' })).not.toBeInTheDocument()
+  })
+
   it('keeps assistant reasoning behind a thinking disclosure', async () => {
     const user = userEvent.setup()
     const assistantMessage: Message = {

--- a/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
@@ -59,9 +59,11 @@ function AttachmentGrid({ attachments }: { attachments: import('../../stores/ses
 export const MessageBubble = memo(function MessageBubble({
   message,
   streaming = false,
+  actionsEnabled = true,
 }: {
   message: Message
   streaming?: boolean
+  actionsEnabled?: boolean
 }) {
   const isUser = message.role === 'user'
   const hasAttachments = message.attachments && message.attachments.length > 0
@@ -84,7 +86,7 @@ export const MessageBubble = memo(function MessageBubble({
             </div>
           )}
         </div>
-        <MessageActions message={message} placement="right" />
+        {actionsEnabled && <MessageActions message={message} placement="right" />}
       </article>
     )
   }
@@ -98,7 +100,11 @@ export const MessageBubble = memo(function MessageBubble({
         />
         {message.content && <MarkdownContent text={message.content} streaming={streaming} />}
       </div>
-      <MessageActions message={message} placement="left" />
+      {actionsEnabled && <MessageActions message={message} placement="left" />}
     </article>
   )
-}, (prev, next) => prev.message === next.message && prev.streaming === next.streaming)
+}, (prev, next) => (
+  prev.message === next.message
+  && prev.streaming === next.streaming
+  && prev.actionsEnabled === next.actionsEnabled
+))

--- a/apps/desktop/src/renderer/components/chat/chat-view-timeline.test.ts
+++ b/apps/desktop/src/renderer/components/chat/chat-view-timeline.test.ts
@@ -87,4 +87,100 @@ describe('buildChatTimeline', () => {
 
     expect(timeline.map((item) => item.kind)).toEqual(['tools', 'approval', 'task'])
   })
+
+  it('interleaves root message segments with tool calls by segment order', () => {
+    const timeline = buildChatTimeline({
+      messages: [{
+        id: 'message-1',
+        role: 'assistant',
+        content: 'Before tool.After tool.',
+        segments: [
+          { id: 'segment-before', content: 'Before tool.', order: 1 },
+          { id: 'segment-after', content: 'After tool.', order: 3 },
+        ],
+        order: 1,
+      }],
+      toolCalls: [
+        { id: 'tool-1', name: 'read', input: {}, status: 'complete', order: 2 },
+      ],
+      taskRuns: [],
+      compactions: [],
+      approvals: [],
+      errors: [],
+    })
+
+    expect(timeline.map((item) => item.kind)).toEqual(['message', 'tools', 'message'])
+    expect(timeline[0]).toMatchObject({
+      kind: 'message',
+      key: 'msg:message-1:timeline:segment-before',
+      actionsEnabled: false,
+      data: { id: 'message-1', content: 'Before tool.' },
+    })
+    expect(timeline[1]).toMatchObject({ kind: 'tools', data: [{ id: 'tool-1' }] })
+    expect(timeline[2]).toMatchObject({
+      kind: 'message',
+      key: 'msg:message-1:timeline:segment-after',
+      actionsEnabled: false,
+      data: { id: 'message-1', content: 'After tool.' },
+    })
+    expect(timeline[0].kind === 'message' && timeline[2].kind === 'message' && timeline[0].key !== timeline[2].key).toBe(true)
+  })
+
+  it('preserves whitespace-only segments around interleaved tools', () => {
+    const timeline = buildChatTimeline({
+      messages: [{
+        id: 'message-1',
+        role: 'assistant',
+        content: 'Before tool.\n\nAfter tool.',
+        segments: [
+          { id: 'segment-before', content: 'Before tool.', order: 1 },
+          { id: 'segment-space', content: '\n\n', order: 3 },
+          { id: 'segment-after', content: 'After tool.', order: 4 },
+        ],
+        order: 1,
+      }],
+      toolCalls: [
+        { id: 'tool-1', name: 'read', input: {}, status: 'complete', order: 2 },
+      ],
+      taskRuns: [],
+      compactions: [],
+      approvals: [],
+      errors: [],
+    })
+
+    expect(timeline.map((item) => item.kind)).toEqual(['message', 'tools', 'message'])
+    expect(timeline[2]).toMatchObject({
+      kind: 'message',
+      key: 'msg:message-1:timeline:segment-space',
+      data: { id: 'message-1', content: '\n\nAfter tool.' },
+    })
+  })
+
+  it('keeps adjacent segments from the same message in one timeline bubble', () => {
+    const timeline = buildChatTimeline({
+      messages: [{
+        id: 'message-1',
+        role: 'assistant',
+        content: 'Part one.Part two.',
+        segments: [
+          { id: 'segment-one', content: 'Part one.', order: 1 },
+          { id: 'segment-two', content: 'Part two.', order: 2 },
+        ],
+        order: 1,
+      }],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      approvals: [],
+      errors: [],
+    })
+
+    expect(timeline).toHaveLength(1)
+    expect(timeline[0]).toMatchObject({
+      kind: 'message',
+      key: 'msg:message-1',
+      actionsEnabled: true,
+      data: { id: 'message-1', content: 'Part one.Part two.' },
+    })
+  })
 })

--- a/apps/desktop/src/renderer/components/chat/chat-view-timeline.ts
+++ b/apps/desktop/src/renderer/components/chat/chat-view-timeline.ts
@@ -1,7 +1,15 @@
-import type { Message, ToolCall, PendingApproval, SessionError, TaskRun, CompactionNotice } from '../../stores/session'
+import type {
+  Message,
+  MessageSegment,
+  ToolCall,
+  PendingApproval,
+  SessionError,
+  TaskRun,
+  CompactionNotice,
+} from '../../stores/session'
 
 export type TimelineItem =
-  | { kind: 'message'; data: Message }
+  | { kind: 'message'; data: Message; key: string; actionsEnabled: boolean }
   | { kind: 'tools'; data: ToolCall[] }
   | { kind: 'task'; data: TaskRun }
   | { kind: 'task_group'; data: TaskRun[] }
@@ -11,11 +19,73 @@ export type TimelineItem =
 
 type OrderedTimelineItem =
   | { kind: 'message'; data: Message; order: number }
+  | {
+      kind: 'message_segment'
+      data: Message
+      segment: MessageSegment
+      segmentIndex: number
+      segmentCount: number
+      order: number
+    }
   | { kind: 'tool'; data: ToolCall; order: number }
   | { kind: 'task'; data: TaskRun; order: number }
   | { kind: 'compaction'; data: CompactionNotice; order: number }
   | { kind: 'approval'; data: PendingApproval; order: number }
   | { kind: 'error'; data: SessionError; order: number }
+
+type MessageSegmentTimelineItem = Extract<OrderedTimelineItem, { kind: 'message_segment' }>
+
+function messageTimelineItems(message: Message): OrderedTimelineItem[] {
+  const segments = message.segments && message.segments.length > 0
+    ? message.segments
+    : message.content
+      ? [{ id: `${message.id}:content`, content: message.content, order: message.order }]
+      : []
+
+  const visibleSegments = segments
+    .filter((segment) => segment.content.length > 0)
+    .slice()
+    .sort((left, right) => left.order - right.order)
+
+  if (visibleSegments.length === 0) {
+    return [{ kind: 'message', data: message, order: message.order }]
+  }
+
+  return visibleSegments.map((segment, segmentIndex) => ({
+    kind: 'message_segment' as const,
+    data: message,
+    segment,
+    segmentIndex,
+    segmentCount: visibleSegments.length,
+    order: segment.order,
+  }))
+}
+
+function buildGroupedMessage(
+  items: MessageSegmentTimelineItem[],
+): { message: Message; key: string; actionsEnabled: boolean } | null {
+  const first = items[0]
+  if (!first) return null
+  const segments = items.map((item) => item.segment)
+  const includesFirstSegment = items.some((item) => item.segmentIndex === 0)
+  const includesWholeMessage = items.length === first.segmentCount && first.segmentIndex === 0
+
+  return {
+    message: {
+      ...first.data,
+      id: first.data.id,
+      content: segments.map((segment) => segment.content).join(''),
+      segments,
+      attachments: includesFirstSegment ? first.data.attachments : undefined,
+      reasoning: includesFirstSegment ? first.data.reasoning : undefined,
+      order: segments[0]?.order ?? first.data.order,
+    },
+    key: includesWholeMessage
+      ? `msg:${first.data.id}`
+      : `msg:${first.data.id}:timeline:${segments[0]?.id || 'segment'}`,
+    actionsEnabled: includesWholeMessage,
+  }
+}
 
 export function buildChatTimeline({
   messages,
@@ -33,7 +103,7 @@ export function buildChatTimeline({
   errors: readonly SessionError[]
 }): TimelineItem[] {
   const rawItems: OrderedTimelineItem[] = [
-    ...messages.map((m) => ({ kind: 'message' as const, data: m, order: m.order })),
+    ...messages.flatMap(messageTimelineItems),
     ...toolCalls.map((tc) => ({ kind: 'tool' as const, data: tc, order: tc.order })),
     ...taskRuns.map((tr) => ({ kind: 'task' as const, data: tr, order: tr.order })),
     ...compactions.map((c) => ({ kind: 'compaction' as const, data: c, order: c.order })),
@@ -44,11 +114,25 @@ export function buildChatTimeline({
   const result: TimelineItem[] = []
   let toolGroup: ToolCall[] = []
   let taskGroup: TaskRun[] = []
+  let messageGroup: MessageSegmentTimelineItem[] = []
 
   const flushToolGroup = () => {
     if (toolGroup.length === 0) return
     result.push({ kind: 'tools', data: [...toolGroup] })
     toolGroup = []
+  }
+
+  const flushMessageGroup = () => {
+    const grouped = buildGroupedMessage(messageGroup)
+    if (grouped) {
+      result.push({
+        kind: 'message',
+        data: grouped.message,
+        key: grouped.key,
+        actionsEnabled: grouped.actionsEnabled,
+      })
+    }
+    messageGroup = []
   }
 
   const flushTaskGroup = () => {
@@ -62,22 +146,36 @@ export function buildChatTimeline({
   }
 
   for (const item of rawItems) {
+    if (item.kind === 'message_segment') {
+      flushToolGroup()
+      flushTaskGroup()
+      const currentMessage = messageGroup[0]?.data
+      if (currentMessage && (currentMessage.id !== item.data.id || currentMessage.role !== item.data.role)) {
+        flushMessageGroup()
+      }
+      messageGroup.push(item)
+      continue
+    }
+
     if (item.kind === 'tool') {
+      flushMessageGroup()
       flushTaskGroup()
       toolGroup.push(item.data)
       continue
     }
 
     if (item.kind === 'task') {
+      flushMessageGroup()
       flushToolGroup()
       taskGroup.push(item.data)
       continue
     }
 
+    flushMessageGroup()
     flushToolGroup()
     flushTaskGroup()
     if (item.kind === 'message') {
-      result.push({ kind: 'message', data: item.data })
+      result.push({ kind: 'message', data: item.data, key: `msg:${item.data.id}`, actionsEnabled: true })
     } else if (item.kind === 'compaction') {
       result.push({ kind: 'compaction', data: item.data })
     } else if (item.kind === 'approval') {
@@ -87,6 +185,7 @@ export function buildChatTimeline({
     }
   }
 
+  flushMessageGroup()
   flushToolGroup()
   flushTaskGroup()
   return result

--- a/apps/desktop/src/renderer/components/sidebar/SettingsModelsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsModelsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { EffectiveAppSettings, PublicAppConfig } from '@open-cowork/shared'
+import { SMALL_MODEL_USE_MAIN, type EffectiveAppSettings, type PublicAppConfig } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import { ProviderAuthControls } from '../provider/ProviderAuthControls'
 import {
@@ -77,6 +77,31 @@ export function ModelsPanel({
     }
   }
 
+  const rawSelectedSmallModelId = settings.selectedSmallModelId || null
+  const smallModelFollowsMainModel = rawSelectedSmallModelId === SMALL_MODEL_USE_MAIN
+  const selectedSmallModelId = smallModelFollowsMainModel ? '' : rawSelectedSmallModelId || ''
+  const mainModelId = settings.effectiveModel || settings.selectedModelId || ''
+  const providerSmallModelId = provider?.smallModel || ''
+  const effectiveSmallModel = settings.effectiveSmallModel || providerSmallModelId || mainModelId
+  const smallModelUsesMainModel = effectiveSmallModel === mainModelId
+  const smallModelUsesProviderDefault = !selectedSmallModelId && !!providerSmallModelId && effectiveSmallModel === providerSmallModelId
+  const updateMainModel = (modelId: string) => update({
+    selectedModelId: modelId,
+    effectiveModel: modelId,
+    ...(smallModelFollowsMainModel || (!settings.selectedSmallModelId && !providerSmallModelId) ? { effectiveSmallModel: modelId } : {}),
+  })
+  const updateSmallModel = (modelId: string) => {
+    const trimmed = modelId.trim()
+    update({
+      selectedSmallModelId: trimmed || null,
+      effectiveSmallModel: trimmed || providerSmallModelId || mainModelId || null,
+    })
+  }
+  const useMainModelForSmallModel = () => update({
+    selectedSmallModelId: SMALL_MODEL_USE_MAIN,
+    effectiveSmallModel: mainModelId || null,
+  })
+
   return (
     <div className="flex flex-col gap-5">
       {config.auth.enabled ? (
@@ -115,8 +140,10 @@ export function ModelsPanel({
                 onClick={() => update({
                   selectedProviderId: entry.id,
                   selectedModelId: nextModelId,
+                  selectedSmallModelId: smallModelFollowsMainModel ? SMALL_MODEL_USE_MAIN : null,
                   effectiveProviderId: entry.id,
                   effectiveModel: nextModelId,
+                  effectiveSmallModel: smallModelFollowsMainModel ? nextModelId : entry.smallModel || nextModelId,
                 })}
                 className="text-start rounded-2xl border p-3 transition-colors cursor-pointer"
                 style={{
@@ -184,7 +211,7 @@ export function ModelsPanel({
           <input
             type="text"
             value={settings.effectiveModel || settings.selectedModelId || ''}
-            onChange={(event) => update({ selectedModelId: event.target.value, effectiveModel: event.target.value })}
+            onChange={(event) => updateMainModel(event.target.value)}
             placeholder={t('setup.modelIdPlaceholder', 'Model ID')}
             className={inputCls}
           />
@@ -241,7 +268,7 @@ export function ModelsPanel({
                         </div>
                       )}
                       <button
-                        onClick={() => update({ selectedModelId: model.id, effectiveModel: model.id })}
+                        onClick={() => updateMainModel(model.id)}
                         className="w-full text-start px-3 py-2 border-b border-border-subtle last:border-b-0 cursor-pointer transition-colors"
                         style={{
                           background: isActive ? 'color-mix(in srgb, var(--color-accent) 10%, transparent)' : 'transparent',
@@ -281,7 +308,7 @@ export function ModelsPanel({
               {filteredModels.map((model) => (
                 <button
                   key={model.id}
-                  onClick={() => update({ selectedModelId: model.id, effectiveModel: model.id })}
+                  onClick={() => updateMainModel(model.id)}
                   className="rounded-2xl border px-3 py-3 text-start transition-colors cursor-pointer"
                   style={{
                     background: settings.effectiveModel === model.id ? 'color-mix(in srgb, var(--color-accent) 10%, transparent)' : 'var(--color-elevated)',
@@ -296,6 +323,55 @@ export function ModelsPanel({
           )}
         </div>
       )}
+
+      {provider ? (
+        <div className="flex flex-col gap-3">
+          <div>
+            <span className={sectionLabelCls}>{t('settings.models.smallModel', 'Small model')}</span>
+            <div className="text-[11px] text-text-muted mt-1 leading-relaxed">
+              {t('settings.models.smallModelDescription', 'OpenCode uses this for lightweight work such as thread titles. Leave it empty to use the provider default, or the selected chat model when no default is configured.')}
+            </div>
+          </div>
+          <div className={panelCardCls}>
+            <div className="flex flex-col gap-2">
+              <label className="flex flex-col gap-1.5">
+                <span className={fieldLabelCls}>{t('settings.models.smallModelId', 'Model ID')}</span>
+                <input
+                  type="text"
+                  list={models.length > 0 ? 'open-cowork-small-model-options' : undefined}
+                  value={selectedSmallModelId}
+                  onChange={(event) => updateSmallModel(event.target.value)}
+                  placeholder={providerSmallModelId || mainModelId || t('settings.models.sameAsMainModel', 'Same as main model')}
+                  className={inputCls}
+                />
+              </label>
+              {models.length > 0 ? (
+                <datalist id="open-cowork-small-model-options">
+                  {models.map((model) => (
+                    <option key={model.id} value={model.id}>{model.name}</option>
+                  ))}
+                </datalist>
+              ) : null}
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0 text-[10px] text-text-muted">
+                  {smallModelUsesMainModel
+                    ? t('settings.models.smallModelUsingMain', 'Using the selected chat model.')
+                    : smallModelUsesProviderDefault
+                      ? t('settings.models.smallModelUsingProviderDefault', 'Using provider default {{model}} for lightweight SDK calls.', { model: effectiveSmallModel })
+                      : t('settings.models.smallModelUsingCustom', 'Using {{model}} for lightweight SDK calls.', { model: effectiveSmallModel })}
+                </div>
+                <button
+                  type="button"
+                  onClick={useMainModelForSmallModel}
+                  className="shrink-0 text-[11px] px-2 py-1 rounded-full border border-border-subtle text-text-muted hover:text-text hover:bg-surface-hover transition-colors cursor-pointer"
+                >
+                  {t('settings.models.useMainModel', 'Use main model')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { EffectiveAppSettings, PublicAppConfig } from '@open-cowork/shared'
+import { SMALL_MODEL_USE_MAIN, type EffectiveAppSettings, type PublicAppConfig } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { useSessionStore } from '../../stores/session'
 import { SettingsPanel } from './SettingsPanel'
@@ -217,6 +217,72 @@ describe('SettingsPanel', () => {
       enableBash: true,
       enableFileWrite: true,
       runtimeToolingBridgeEnabled: false,
+    })
+  })
+
+  it('persists an explicit OpenCode small model choice', async () => {
+    const settingsSet = vi.mocked(window.coworkApi.settings.set)
+    const user = userEvent.setup()
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(async () => ({})),
+        set: settingsSet,
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await user.click(screen.getByRole('button', { name: /Models/ }))
+    await user.type(screen.getByLabelText('Model ID'), 'deepseek/deepseek-v4-flash:free')
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1))
+    expect(settingsSet.mock.calls[0]?.[0]).toMatchObject({
+      selectedSmallModelId: 'deepseek/deepseek-v4-flash:free',
+    })
+  })
+
+  it('keeps the small model linked to the main model when requested', async () => {
+    const settingsSet = vi.mocked(window.coworkApi.settings.set)
+    const user = userEvent.setup()
+    const configWithProviderSmallModel: PublicAppConfig = {
+      ...config,
+      providers: {
+        ...config.providers,
+        available: config.providers.available.map((provider) => provider.id === 'openrouter'
+          ? { ...provider, smallModel: 'deepseek/deepseek-v4-flash:free' }
+          : provider),
+      },
+    }
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => configWithProviderSmallModel),
+      },
+      settings: {
+        get: vi.fn(async () => settings({
+          selectedSmallModelId: 'openrouter/old-small',
+          effectiveSmallModel: 'openrouter/old-small',
+        })),
+        getProviderCredentials: vi.fn(async () => ({})),
+        set: settingsSet,
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await user.click(screen.getByRole('button', { name: /Models/ }))
+    await user.click(screen.getByRole('button', { name: 'Use main model' }))
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1))
+    expect(settingsSet.mock.calls[0]?.[0]).toMatchObject({
+      selectedSmallModelId: SMALL_MODEL_USE_MAIN,
     })
   })
 

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -151,6 +151,7 @@ export function SettingsPanel({
       const savedSettings = await window.coworkApi.settings.set({
         selectedProviderId: settings.selectedProviderId,
         selectedModelId: settings.selectedModelId,
+        selectedSmallModelId: settings.selectedSmallModelId ?? null,
         providerCredentials: settings.providerCredentials,
         integrationCredentials: settings.integrationCredentials,
         bashPermission: settings.bashPermission,

--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
@@ -1,7 +1,8 @@
 import { act, render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RuntimeNotification } from '@open-cowork/shared'
+import type { RuntimeNotification, SessionPatch, SessionView } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../test/setup'
+import { useSessionStore } from '../stores/session'
 import { useOpenCodeEvents } from './useOpenCodeEvents'
 
 function Harness() {
@@ -11,11 +12,71 @@ function Harness() {
 
 describe('useOpenCodeEvents', () => {
   let notify: ((event: RuntimeNotification) => void) | null = null
+  let sessionPatch: ((event: SessionPatch) => void) | null = null
+  let sessionView: ((event: { sessionId: string; view: SessionView }) => void) | null = null
   let closeAudioContext: ReturnType<typeof vi.fn>
+
+  const tokens = {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  }
+
+  function view(overrides: Partial<SessionView> = {}): SessionView {
+    return {
+      messages: [],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: tokens,
+      lastInputTokens: 0,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 0,
+      lastEventAt: 0,
+      isGenerating: false,
+      isAwaitingPermission: false,
+      isAwaitingQuestion: false,
+      ...overrides,
+    }
+  }
+
+  function resetSessionStore() {
+    useSessionStore.setState({
+      sessions: [],
+      currentSessionId: 'session-1',
+      currentView: view(),
+      globalErrors: [],
+      mcpConnections: [],
+      agentMode: 'build',
+      reasoningVariant: null,
+      totalCost: 0,
+      sidebarCollapsed: false,
+      busySessions: new Set(),
+      awaitingPermissionSessions: new Set(),
+      awaitingQuestionSessions: new Set(),
+      sessionStateById: {},
+      chartArtifactsBySession: {},
+    })
+  }
 
   beforeEach(() => {
     notify = null
+    sessionPatch = null
+    sessionView = null
     closeAudioContext = vi.fn(async () => undefined)
+    resetSessionStore()
 
     class TestAudioContext {
       currentTime = 0
@@ -65,9 +126,15 @@ describe('useOpenCodeEvents', () => {
         }),
         permissionRequest: vi.fn(() => vi.fn()),
         sessionDeleted: vi.fn(() => vi.fn()),
-        sessionPatch: vi.fn(() => vi.fn()),
+        sessionPatch: vi.fn((callback: (event: SessionPatch) => void) => {
+          sessionPatch = callback
+          return vi.fn()
+        }),
         sessionUpdated: vi.fn(() => vi.fn()),
-        sessionView: vi.fn(() => vi.fn()),
+        sessionView: vi.fn((callback: (event: { sessionId: string; view: SessionView }) => void) => {
+          sessionView = callback
+          return vi.fn()
+        }),
       },
     })
   })
@@ -87,5 +154,132 @@ describe('useOpenCodeEvents', () => {
 
     second.unmount()
     expect(closeAudioContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not replay buffered text already covered by an intervening session view', () => {
+    vi.useFakeTimers()
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => (
+      window.setTimeout(() => callback(performance.now()), 0)
+    ))
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((handle) => {
+      window.clearTimeout(handle)
+    })
+
+    const rendered = render(<Harness />)
+
+    act(() => {
+      sessionPatch?.({
+        type: 'message_text',
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        segmentId: 'segment-1',
+        content: 'Before ',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 1,
+      })
+      sessionPatch?.({
+        type: 'message_text',
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        segmentId: 'segment-1',
+        content: 'After',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 3,
+      })
+      sessionView?.({
+        sessionId: 'session-1',
+        view: view({
+          messages: [{
+            id: 'message-1',
+            role: 'assistant',
+            content: 'Before ',
+            segments: [{ id: 'segment-1', content: 'Before ', order: 1 }],
+            order: 1,
+          }],
+          toolCalls: [{
+            id: 'tool-1',
+            name: 'read',
+            input: {},
+            status: 'complete',
+            order: 2,
+          }],
+          lastItemWasTool: true,
+          lastEventAt: 2,
+          isGenerating: true,
+        }),
+      })
+      vi.advanceTimersByTime(40)
+      vi.runOnlyPendingTimers()
+    })
+
+    const message = useSessionStore.getState().currentView.messages[0]
+    expect(message?.content).toBe('Before After')
+    expect(message?.segments?.map((segment) => segment.content)).toEqual(['Before ', 'After'])
+
+    rendered.unmount()
+    requestFrame.mockRestore()
+    cancelFrame.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('flushes older buffered text before immediately committing a newer task patch', () => {
+    vi.useFakeTimers()
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => (
+      window.setTimeout(() => callback(performance.now()), 0)
+    ))
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((handle) => {
+      window.clearTimeout(handle)
+    })
+
+    const rendered = render(<Harness />)
+
+    act(() => {
+      sessionView?.({
+        sessionId: 'session-1',
+        view: view({
+          messages: [{
+            id: 'message-1',
+            role: 'assistant',
+            content: 'Intro ',
+            segments: [{ id: 'segment-1', content: 'Intro ', order: 1 }],
+            order: 1,
+          }],
+          lastEventAt: 0,
+          isGenerating: true,
+        }),
+      })
+      sessionPatch?.({
+        type: 'message_text',
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        segmentId: 'segment-1',
+        content: 'before task.',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 1,
+      })
+      sessionPatch?.({
+        type: 'task_text',
+        sessionId: 'session-1',
+        taskRunId: 'task-1',
+        segmentId: 'task-segment-1',
+        content: 'Task started.',
+        mode: 'append',
+        eventAt: 2,
+      })
+      vi.advanceTimersByTime(40)
+      vi.runOnlyPendingTimers()
+    })
+
+    const state = useSessionStore.getState().currentView
+    expect(state.messages[0]?.segments?.map((segment) => segment.content)).toEqual(['Intro before task.'])
+    expect(state.taskRuns[0]?.content).toBe('Task started.')
+
+    rendered.unmount()
+    requestFrame.mockRestore()
+    cancelFrame.mockRestore()
+    vi.useRealTimers()
   })
 })

--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
-import { flushSync } from 'react-dom'
 import type { SessionPatch } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
 import { shouldCommitStreamingTextImmediately } from '../../lib/session-streaming-flush.ts'
+
+const STREAM_FLUSH_INTERVAL_MS = 32
 
 let notifyCtx: AudioContext | null = null
 let activeHookMounts = 0
@@ -35,43 +36,28 @@ export function useOpenCodeEvents() {
 
   useEffect(() => {
     activeHookMounts += 1
-    const textBuffers = new Map<string, SessionPatch>()
+    let textBuffers: SessionPatch[] = []
     let frameHandle: number | null = null
-
-    const bufferKey = (part: SessionPatch) =>
-      part.type === 'task_text' || part.type === 'task_reasoning'
-        ? `${part.sessionId}:${part.taskRunId}:${part.segmentId}`
-        : `${part.sessionId}:${part.messageId}:${part.segmentId}`
+    let flushTimer: number | null = null
+    let lastFlushAt = 0
 
     const queueBufferedText = (part: SessionPatch) => {
-      const key = bufferKey(part)
-      const existing = textBuffers.get(key)
-
-      if (!existing || part.mode === 'replace') {
-        textBuffers.set(key, { ...part })
-        return
-      }
-
-      if (existing.mode === 'replace') return
-      existing.content += part.content
-      existing.eventAt = part.eventAt
+      textBuffers.push({ ...part })
     }
 
     const pruneCoveredTextBuffers = (sessionId: string, lastEventAt: number) => {
-      for (const [key, value] of textBuffers.entries()) {
-        if (value.sessionId !== sessionId) continue
-        if (value.eventAt <= lastEventAt) {
-          textBuffers.delete(key)
-        }
-      }
+      textBuffers = textBuffers.filter((buffer) => (
+        buffer.sessionId !== sessionId || buffer.eventAt > lastEventAt
+      ))
     }
 
-    const commitTextPart = (
+    const commitTextParts = (
       store: ReturnType<typeof useSessionStore.getState>,
-      part: SessionPatch,
+      parts: SessionPatch[],
     ) => {
-      if (!part.content) return
-      store.applySessionPatch(part)
+      const visibleParts = parts.filter((part) => part.content)
+      if (visibleParts.length === 0) return
+      store.applySessionPatches(visibleParts)
     }
 
     const shouldCommitTextImmediately = (part: SessionPatch) => {
@@ -80,15 +66,20 @@ export function useOpenCodeEvents() {
     }
 
     const flushTextBuffers = (store: ReturnType<typeof useSessionStore.getState>, sessionId?: string) => {
-      for (const [key, buffer] of textBuffers.entries()) {
-        if (sessionId && buffer.sessionId !== sessionId) continue
-        if (!buffer.content) {
-          textBuffers.delete(key)
+      const parts: SessionPatch[] = []
+      const retained: SessionPatch[] = []
+      for (const buffer of textBuffers) {
+        if (sessionId && buffer.sessionId !== sessionId) {
+          retained.push(buffer)
           continue
         }
-        commitTextPart(store, buffer)
-        textBuffers.delete(key)
+        if (!buffer.content) {
+          continue
+        }
+        parts.push({ ...buffer })
       }
+      textBuffers = retained
+      commitTextParts(store, parts)
     }
 
     const playDoneSound = () => {
@@ -109,26 +100,42 @@ export function useOpenCodeEvents() {
       }
     }
 
-    const flushStreamEvents = () => {
+    const flushStreamEvents = (timestamp: number) => {
       frameHandle = null
-      if (textBuffers.size === 0) return
+      if (textBuffers.length === 0) return
 
-      flushSync(() => {
-        const store = useSessionStore.getState()
-        flushTextBuffers(store)
-      })
+      lastFlushAt = timestamp || performance.now()
+      const store = useSessionStore.getState()
+      flushTextBuffers(store)
     }
 
-    const scheduleEventFlush = () => {
+    const requestFlushFrame = () => {
       if (frameHandle !== null) return
       frameHandle = requestAnimationFrame(flushStreamEvents)
     }
 
+    const scheduleEventFlush = () => {
+      if (frameHandle !== null || flushTimer !== null) return
+
+      const now = performance.now()
+      const waitMs = Math.max(0, STREAM_FLUSH_INTERVAL_MS - (now - lastFlushAt))
+      if (waitMs <= 0) {
+        requestFlushFrame()
+        return
+      }
+
+      flushTimer = window.setTimeout(() => {
+        flushTimer = null
+        requestFlushFrame()
+      }, waitMs)
+    }
+
     const unsubSessionPatch = window.coworkApi.on.sessionPatch((patch: SessionPatch) => {
       if (shouldCommitTextImmediately(patch)) {
-        flushSync(() => {
-          commitTextPart(useSessionStore.getState(), patch)
-        })
+        const store = useSessionStore.getState()
+        flushTextBuffers(store, patch.sessionId)
+        commitTextParts(useSessionStore.getState(), [patch])
+        lastFlushAt = performance.now()
       } else {
         queueBufferedText(patch)
         scheduleEventFlush()
@@ -202,6 +209,9 @@ export function useOpenCodeEvents() {
     return () => {
       if (frameHandle !== null) {
         cancelAnimationFrame(frameHandle)
+      }
+      if (flushTimer !== null) {
+        window.clearTimeout(flushTimer)
       }
       unsubscribeAll()
       activeHookMounts = Math.max(0, activeHookMounts - 1)

--- a/apps/desktop/src/renderer/stores/session.test.ts
+++ b/apps/desktop/src/renderer/stores/session.test.ts
@@ -147,6 +147,165 @@ describe('useSessionStore', () => {
     expect(state.currentView.lastItemWasTool).toBe(true)
   })
 
+  it('applies streamed patch batches with one store notification', () => {
+    const store = useSessionStore.getState()
+    store.setCurrentSession('ses_1')
+
+    let notifications = 0
+    const unsubscribe = useSessionStore.subscribe(() => {
+      notifications += 1
+    })
+
+    useSessionStore.getState().applySessionPatches([
+      {
+        type: 'message_text',
+        sessionId: 'ses_1',
+        messageId: 'msg_1',
+        segmentId: 'seg_1',
+        content: 'Hello',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 10,
+      },
+      {
+        type: 'message_text',
+        sessionId: 'ses_1',
+        messageId: 'msg_1',
+        segmentId: 'seg_1',
+        content: ' world',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 20,
+      },
+      {
+        type: 'task_text',
+        sessionId: 'ses_1',
+        taskRunId: 'task_1',
+        segmentId: 'task_seg',
+        content: 'Working',
+        mode: 'append',
+        eventAt: 30,
+      },
+    ])
+    unsubscribe()
+
+    const state = useSessionStore.getState()
+    expect(notifications).toBe(1)
+    expect(state.currentView.messages[0]?.content).toBe('Hello world')
+    expect(state.currentView.taskRuns[0]?.transcript[0]?.content).toBe('Working')
+    expect(state.currentView.lastEventAt).toBe(30)
+  })
+
+  it('applies streamed patch batches by main-process event time', () => {
+    const store = useSessionStore.getState()
+    store.setCurrentSession('ses_1')
+
+    useSessionStore.getState().applySessionPatches([
+      {
+        type: 'message_text',
+        sessionId: 'ses_1',
+        messageId: 'msg_1',
+        segmentId: 'seg_1',
+        content: ' world',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 20,
+      },
+      {
+        type: 'message_text',
+        sessionId: 'ses_1',
+        messageId: 'msg_1',
+        segmentId: 'seg_1',
+        content: 'Hello',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 10,
+      },
+    ])
+
+    const state = useSessionStore.getState()
+    expect(state.currentView.messages[0]?.content).toBe('Hello world')
+    expect(state.currentView.lastEventAt).toBe(20)
+  })
+
+  it('keeps streamed text after existing tools in later timeline segments', () => {
+    const store = useSessionStore.getState()
+    store.setCurrentSession('ses_1')
+    store.setSessionView('ses_1', view({
+      messages: [{
+        id: 'msg_1',
+        role: 'assistant',
+        content: 'Before tool.',
+        segments: [{ id: 'seg_1', content: 'Before tool.', order: 1 }],
+        order: 1,
+      }],
+      toolCalls: [{
+        id: 'tool_1',
+        name: 'read',
+        input: {},
+        status: 'complete',
+        order: 2,
+      }],
+      taskRuns: [{
+        id: 'task_1',
+        title: 'Research',
+        agent: 'research',
+        status: 'running',
+        sourceSessionId: 'child_1',
+        parentSessionId: null,
+        content: 'Before task tool.',
+        transcript: [{ id: 'task_seg', content: 'Before task tool.', order: 1 }],
+        toolCalls: [{
+          id: 'task_tool_1',
+          name: 'read',
+          input: {},
+          status: 'complete',
+          order: 2,
+        }],
+        compactions: [],
+        todos: [],
+        error: null,
+        sessionCost: 0,
+        sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+        order: 3,
+      }],
+    }))
+
+    useSessionStore.getState().applySessionPatches([
+      {
+        type: 'message_text',
+        sessionId: 'ses_1',
+        messageId: 'msg_1',
+        segmentId: 'seg_1',
+        content: 'After tool.',
+        mode: 'append',
+        role: 'assistant',
+        eventAt: 10,
+      },
+      {
+        type: 'task_text',
+        sessionId: 'ses_1',
+        taskRunId: 'task_1',
+        segmentId: 'task_seg',
+        content: 'After task tool.',
+        mode: 'append',
+        eventAt: 20,
+      },
+    ])
+
+    const state = useSessionStore.getState()
+    expect(state.currentView.messages[0]?.segments).toHaveLength(2)
+    expect(state.currentView.messages[0]?.segments?.[1]?.content).toBe('After tool.')
+    expect(state.currentView.messages[0]?.segments?.[1]?.order).toBeGreaterThan(
+      state.currentView.toolCalls[0]?.order ?? 0,
+    )
+    expect(state.currentView.taskRuns[0]?.transcript).toHaveLength(2)
+    expect(state.currentView.taskRuns[0]?.transcript[1]?.content).toBe('After task tool.')
+    expect(state.currentView.taskRuns[0]?.transcript[1]?.order).toBeGreaterThan(
+      state.currentView.taskRuns[0]?.toolCalls[0]?.order ?? 0,
+    )
+  })
+
   it('deduplicates pending approvals and sets awaiting state', () => {
     const approval = {
       id: 'approval_1',

--- a/apps/desktop/src/renderer/stores/session.ts
+++ b/apps/desktop/src/renderer/stores/session.ts
@@ -8,12 +8,15 @@ import type {
   SessionError,
   SessionView,
   PermissionRequest,
+  TaskRun,
 } from '@open-cowork/shared'
 import {
   buildSessionStateFromView,
   createEmptySessionViewState,
   deriveVisibleSessionPatch,
   getOrCreateSessionState,
+  hasMessageTextSegment,
+  hasSplitMessageTextSegment,
   pruneSessionDetailCache,
   withMessageReasoning,
   withMessageText,
@@ -68,6 +71,7 @@ interface SessionStore {
   removeSession: (id: string) => void
   setSessionView: (sessionId: string, view: SessionView) => void
   applySessionPatch: (patch: SessionPatch) => void
+  applySessionPatches: (patches: SessionPatch[]) => void
   addPendingApproval: (approval: PermissionRequest) => void
 
   addGlobalError: (message: string) => void
@@ -115,6 +119,41 @@ function sessionViewTiming() {
   }
 }
 
+function latestOrder(...groups: readonly (readonly { order?: number | null }[] | null | undefined)[]) {
+  let max: number | null = null
+  for (const group of groups) {
+    if (!group) continue
+    for (const entry of group) {
+      const order = typeof entry.order === 'number' && Number.isFinite(entry.order) ? entry.order : null
+      if (order !== null && (max === null || order > max)) max = order
+    }
+  }
+  return max ?? undefined
+}
+
+function latestTaskInterruptionOrder(taskRun: TaskRun) {
+  return latestOrder(taskRun.toolCalls, taskRun.compactions)
+}
+
+function latestSessionInterruptionOrder(current: SessionViewState) {
+  return latestOrder(
+    current.toolCalls,
+    current.taskRuns,
+    current.compactions,
+    current.pendingApprovals,
+    current.errors,
+  )
+}
+
+function shouldComputeMessageSplitOrder(
+  current: SessionViewState,
+  messageId: string,
+  segmentId: string,
+) {
+  return hasMessageTextSegment(current, messageId, segmentId)
+    && (current.lastItemWasTool || !hasSplitMessageTextSegment(current, messageId, segmentId))
+}
+
 function updateSessionState(
   state: SessionStore,
   sessionId: string,
@@ -148,6 +187,97 @@ function updateSessionState(
     )
   }
   return patch
+}
+
+function applySessionPatchToState(state: SessionStore, patch: SessionPatch) {
+  if (patch.type === 'task_text') {
+    return updateSessionState(
+      state,
+      patch.sessionId,
+      (current) => ({
+        ...current,
+        taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
+          ...withTaskTranscript(taskRun, patch.segmentId, patch.content, {
+            replace: patch.mode === 'replace',
+            splitAfterOrder: patch.mode === 'replace' ? undefined : latestTaskInterruptionOrder(taskRun),
+          }),
+        })),
+        lastItemWasTool: true,
+      }),
+      { eventAt: patch.eventAt },
+    )
+  }
+
+  if (patch.type === 'task_reasoning') {
+    return updateSessionState(
+      state,
+      patch.sessionId,
+      (current) => ({
+        ...current,
+        taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
+          ...withTaskReasoning(taskRun, patch.segmentId, patch.content, {
+            replace: patch.mode === 'replace',
+          }),
+        })),
+        lastItemWasTool: true,
+      }),
+      { eventAt: patch.eventAt },
+    )
+  }
+
+  if (patch.type === 'message_reasoning') {
+    return updateSessionState(
+      state,
+      patch.sessionId,
+      (current) => ({
+        ...current,
+        ...withMessageReasoning(current, {
+          messageId: patch.messageId,
+          content: patch.content,
+          segmentId: patch.segmentId,
+          replace: patch.mode === 'replace',
+        }, sessionViewTiming()),
+        lastItemWasTool: false,
+      }),
+      { eventAt: patch.eventAt },
+    )
+  }
+
+  return updateSessionState(
+    state,
+    patch.sessionId,
+    (current) => {
+      const splitAfterOrder = patch.mode === 'replace'
+        ? undefined
+        : shouldComputeMessageSplitOrder(current, patch.messageId, patch.segmentId)
+          ? latestSessionInterruptionOrder(current)
+          : undefined
+      return {
+        ...current,
+        ...withMessageText(current, {
+          messageId: patch.messageId,
+          role: patch.role || 'assistant',
+          content: patch.content,
+          segmentId: patch.segmentId,
+          attachments: patch.attachments,
+          replace: patch.mode === 'replace',
+          splitAfterOrder,
+        }, sessionViewTiming()),
+        lastItemWasTool: false,
+      }
+    },
+    { eventAt: patch.eventAt },
+  )
+}
+
+function orderSessionPatches(patches: SessionPatch[]) {
+  return patches
+    .map((patch, index) => ({ patch, index }))
+    .sort((left, right) => {
+      if (left.patch.eventAt !== right.patch.eventAt) return left.patch.eventAt - right.patch.eventAt
+      return left.index - right.index
+    })
+    .map(({ patch }) => patch)
 }
 
 export const useSessionStore = create<SessionStore>((set) => ({
@@ -294,77 +424,29 @@ export const useSessionStore = create<SessionStore>((set) => ({
     }
     return patch
   }),
-  applySessionPatch: (patch) => set((state) => {
-    if (patch.type === 'task_text') {
-      return updateSessionState(
-        state,
-        patch.sessionId,
-        (current) => ({
-          ...current,
-          taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
-            ...withTaskTranscript(taskRun, patch.segmentId, patch.content, {
-              replace: patch.mode === 'replace',
-            }),
-          })),
-          lastItemWasTool: true,
-        }),
-        { eventAt: patch.eventAt },
-      )
-    }
+  applySessionPatch: (patch) => set((state) => applySessionPatchToState(state, patch)),
+  applySessionPatches: (patches) => {
+    if (patches.length === 0) return
 
-    if (patch.type === 'task_reasoning') {
-      return updateSessionState(
-        state,
-        patch.sessionId,
-        (current) => ({
-          ...current,
-          taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
-            ...withTaskReasoning(taskRun, patch.segmentId, patch.content, {
-              replace: patch.mode === 'replace',
-            }),
-          })),
-          lastItemWasTool: true,
-        }),
-        { eventAt: patch.eventAt },
-      )
-    }
+    set((state) => {
+      let nextState = state
+      let combinedPatch: Partial<SessionStore> = {}
 
-    if (patch.type === 'message_reasoning') {
-      return updateSessionState(
-        state,
-        patch.sessionId,
-        (current) => ({
-          ...current,
-          ...withMessageReasoning(current, {
-            messageId: patch.messageId,
-            content: patch.content,
-            segmentId: patch.segmentId,
-            replace: patch.mode === 'replace',
-          }, sessionViewTiming()),
-          lastItemWasTool: false,
-        }),
-        { eventAt: patch.eventAt },
-      )
-    }
+      for (const patch of orderSessionPatches(patches)) {
+        const partial = applySessionPatchToState(nextState, patch)
+        combinedPatch = {
+          ...combinedPatch,
+          ...partial,
+        }
+        nextState = {
+          ...nextState,
+          ...partial,
+        }
+      }
 
-    return updateSessionState(
-      state,
-      patch.sessionId,
-      (current) => ({
-        ...current,
-        ...withMessageText(current, {
-          messageId: patch.messageId,
-          role: patch.role || 'assistant',
-          content: patch.content,
-          segmentId: patch.segmentId,
-          attachments: patch.attachments,
-          replace: patch.mode === 'replace',
-        }, sessionViewTiming()),
-        lastItemWasTool: false,
-      }),
-      { eventAt: patch.eventAt },
-    )
-  }),
+      return combinedPatch
+    })
+  },
   addPendingApproval: (approval) => set((state) => {
     const awaitingPermissionSessions = new Set(state.awaitingPermissionSessions)
     awaitingPermissionSessions.add(approval.sessionId)

--- a/mcps/clock/src/index.ts
+++ b/mcps/clock/src/index.ts
@@ -90,9 +90,12 @@ function getTimeZoneOffsetMs(timeZone: string, date: Date) {
 
 function formatOffset(offsetMs: number) {
   const sign = offsetMs >= 0 ? '+' : '-'
-  const absolute = Math.abs(offsetMs)
-  const hours = Math.floor(absolute / MS_PER_HOUR)
-  const minutes = Math.floor((absolute % MS_PER_HOUR) / MS_PER_MINUTE)
+  // Intl.DateTimeFormat gives local calendar parts only to whole-second
+  // precision. Round to the nearest minute so an instant with milliseconds
+  // does not turn UTC+02:00 into +01:59.
+  const absoluteMinutes = Math.round(Math.abs(offsetMs) / MS_PER_MINUTE)
+  const hours = Math.floor(absoluteMinutes / 60)
+  const minutes = absoluteMinutes % 60
   return `${sign}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
 }
 

--- a/mcps/clock/tests/contract.test.ts
+++ b/mcps/clock/tests/contract.test.ts
@@ -74,13 +74,14 @@ test('clock MCP lists and executes every read-only tool over stdio', async () =>
       name: 'date_range',
       arguments: {
         range: 'last_week',
-        timezone: 'UTC',
-        anchor: '2026-05-14T10:00:00.000Z',
+        timezone: 'Europe/Amsterdam',
+        anchor: '2026-05-14T10:00:00.387Z',
         week_starts_on: 'monday',
       },
     }))
     assert.equal((range.startInclusive as { localDate?: string }).localDate, '2026-05-04')
     assert.equal((range.endExclusive as { localDate?: string }).localDate, '2026-05-11')
+    assert.equal((range.anchor as { offset?: string }).offset, '+02:00')
     assert.equal(range.calendarDays, 7)
 
     const defaultSundayRange = parseTextResult(await client.callTool({

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -88,6 +88,7 @@
               "name": { "type": "string" },
               "description": { "type": "string" },
               "defaultModel": { "type": "string" },
+              "smallModel": { "type": "string" },
               "options": {
                 "type": "object",
                 "additionalProperties": true
@@ -542,6 +543,7 @@
         "name": { "type": "string" },
         "description": { "type": "string" },
         "defaultModel": { "type": "string" },
+        "smallModel": { "type": "string" },
         "options": {
           "type": "object",
           "additionalProperties": true

--- a/packages/shared/src/app-config.ts
+++ b/packages/shared/src/app-config.ts
@@ -5,6 +5,8 @@ import type {
   ToolTraceConfig,
 } from './tool-trace.js'
 
+export const SMALL_MODEL_USE_MAIN = '__open_cowork_use_main_model__'
+
 export interface BrandThemeTokens {
   base: string
   surface: string
@@ -137,6 +139,7 @@ export interface AppSettings {
   _schemaVersion?: number
   selectedProviderId: string | null
   selectedModelId: string | null
+  selectedSmallModelId?: string | null
   providerCredentials: Record<string, Record<string, string>>
   integrationCredentials: Record<string, Record<string, string>>
   integrationEnabled: Record<string, boolean>
@@ -158,6 +161,7 @@ export interface AppSettings {
 export interface EffectiveAppSettings extends AppSettings {
   effectiveProviderId: string | null
   effectiveModel: string | null
+  effectiveSmallModel?: string | null
 }
 
 export interface AuthState {

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -79,6 +79,7 @@ export interface ProviderDescriptor {
   credentials: CredentialField[]
   models: ProviderModelDescriptor[]
   defaultModel?: string
+  smallModel?: string
   connected?: boolean
 }
 

--- a/tests/app-handlers.test.ts
+++ b/tests/app-handlers.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { ensureRuntimeAfterAuthLogin, mergeRuntimeProviderModels } from '../apps/desktop/src/main/ipc/app-handlers.ts'
+import { ensureRuntimeAfterAuthLogin, hasRuntimeSensitiveSettingsUpdate, mergeRuntimeProviderModels } from '../apps/desktop/src/main/ipc/app-handlers.ts'
 import { clearConfigCaches, getPublicAppConfig } from '../apps/desktop/src/main/config-loader.ts'
 
 test('ensureRuntimeAfterAuthLogin reboots an active runtime after successful sign-in', async () => {
@@ -70,6 +70,12 @@ test('ensureRuntimeAfterAuthLogin does nothing for incomplete or failed auth flo
   })
 
   assert.deepEqual(calls, [])
+})
+
+test('small model changes are runtime-sensitive settings updates', () => {
+  assert.equal(hasRuntimeSensitiveSettingsUpdate({ selectedSmallModelId: 'openrouter/deepseek/deepseek-v4-flash:free' }), true)
+  assert.equal(hasRuntimeSensitiveSettingsUpdate({ selectedSmallModelId: null }), true)
+  assert.equal(hasRuntimeSensitiveSettingsUpdate({ workflowDesktopNotifications: false }), false)
 })
 
 test('mergeRuntimeProviderModels drops provider defaults absent from the live runtime catalog', () => {

--- a/tests/custom-agents-regression.test.ts
+++ b/tests/custom-agents-regression.test.ts
@@ -4,7 +4,8 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
-import { getCustomAgentSummaries } from '../apps/desktop/src/main/custom-agents.ts'
+import { getCustomAgentCatalog, getCustomAgentSummaries } from '../apps/desktop/src/main/custom-agents.ts'
+import { buildCustomAgentPermissionFromCatalog } from '../apps/desktop/src/main/custom-agents-utils.ts'
 import { getMachineAgentsDir, getMachineSkillsDir } from '../apps/desktop/src/main/runtime-paths.ts'
 import { removeCustomAgent, saveCustomAgent } from '../apps/desktop/src/main/native-customizations.ts'
 
@@ -103,6 +104,42 @@ test('custom agent markdown carries SDK-native inference fields without config.a
     assert.match(markdown, /^permission:$/m)
   } finally {
     removeCustomAgent({ scope: 'machine', directory: null, name: 'market-analyst' })
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempUserData, { recursive: true, force: true })
+  }
+})
+
+test('custom agents can explicitly opt into Task delegation', async () => {
+  const tempUserData = mkdtempSync(join(tmpdir(), 'opencowork-agent-task-tool-'))
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  process.env.OPEN_COWORK_USER_DATA_DIR = tempUserData
+  clearConfigCaches()
+
+  try {
+    const catalog = await getCustomAgentCatalog()
+    const taskTool = catalog.tools.find((tool) => tool.id === 'task')
+
+    assert.ok(taskTool, 'Task Delegation should always be available to custom agents')
+    assert.equal(taskTool.name, 'Task Delegation')
+    assert.equal(taskTool.supportsWrite, true)
+
+    const permission = buildCustomAgentPermissionFromCatalog({
+      scope: 'machine',
+      directory: null,
+      name: 'coordinator',
+      description: 'Delegates specialist work.',
+      instructions: 'Coordinate specialist work.',
+      skillNames: [],
+      toolIds: ['task'],
+      enabled: true,
+      color: 'info',
+    }, catalog)
+
+    assert.equal(permission.task, 'allow')
+  } finally {
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
     clearConfigCaches()

--- a/tests/custom-agents.test.ts
+++ b/tests/custom-agents.test.ts
@@ -49,8 +49,9 @@ test('custom agent catalog exposes configured built-in tools and skills', () => 
     state: baseSettings,
   })
 
-  assert.deepEqual(catalog.tools.map((tool) => tool.id), ['github', 'perplexity'])
+  assert.deepEqual(catalog.tools.map((tool) => tool.id), ['github', 'perplexity', 'task'])
   assert.equal(catalog.tools[0]?.supportsWrite, true)
+  assert.equal(catalog.tools.find((tool) => tool.id === 'task')?.supportsWrite, true)
   assert.equal(catalog.skills.some((skill) => skill.name === 'github:github'), true)
   assert.equal(catalog.reservedNames.includes('build'), true)
 })

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -381,6 +381,185 @@ test('child tool errors do not terminalize a still-running subagent task', () =>
   })
 })
 
+test('root task tool calls create a pending subagent lane before the child session exists', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Start task',
+        state: {
+          status: 'running',
+          input: {
+            agent: 'business-analyst',
+            description: 'UK web traffic & conversion analysis',
+            prompt: 'Analyze the UK website traffic and conversion trend.',
+          },
+          metadata: {},
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const pendingTask = getTaskRun('call-task-1')
+  assert.deepEqual({
+    ...pendingTask,
+    startedAt: undefined,
+    finishedAt: undefined,
+  }, {
+    id: 'call-task-1',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'UK web traffic & conversion analysis',
+    agent: 'business-analyst',
+    childSessionId: null,
+    status: 'queued',
+    startedAt: undefined,
+    finishedAt: undefined,
+  })
+  assert.equal(collector.events.length, 0)
+
+  handleRuntimeSideEffectEvent({
+    win,
+    type: 'session.created',
+    properties: {
+      info: {
+        id: 'child-session',
+        parentID: 'root-session',
+        title: 'UK web traffic & conversion analysis (@business-analyst subagent)',
+        time: { created: 1000, updated: 1000 },
+      },
+    },
+    dispatchRuntimeEvent: collector.dispatch,
+    getMainWindow: () => win,
+  })
+
+  const boundTask = getTaskRun('call-task-1')
+  assert.equal(boundTask?.childSessionId, 'child-session')
+  assert.equal(boundTask?.parentSessionId, 'root-session')
+  assert.equal(boundTask?.title, 'UK web traffic & conversion analysis')
+  assert.equal(boundTask?.agent, 'business-analyst')
+})
+
+test('terminal root task tool calls do not bind a later child session', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Start task',
+        state: {
+          status: 'completed',
+          input: {
+            agent: 'business-analyst',
+            description: 'UK web traffic & conversion analysis',
+            prompt: 'Analyze the UK website traffic and conversion trend.',
+          },
+          metadata: {},
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const terminalTask = getTaskRun('call-task-1')
+  assert.equal(terminalTask?.status, 'complete')
+  assert.equal(terminalTask?.childSessionId, null)
+  assert.equal(terminalTask?.parentSessionId, 'root-session')
+
+  handleRuntimeSideEffectEvent({
+    win,
+    type: 'session.created',
+    properties: {
+      info: {
+        id: 'child-session',
+        parentID: 'root-session',
+        title: 'Unrelated later child',
+        time: { created: 1000, updated: 1000 },
+      },
+    },
+    dispatchRuntimeEvent: collector.dispatch,
+    getMainWindow: () => win,
+  })
+
+  assert.equal(getTaskRun('call-task-1')?.childSessionId, null)
+  assert.equal(getTaskRun('child:child-session'), null)
+})
+
+test('root task tool state.error marks the pending subagent lane failed', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Start task',
+        state: {
+          input: {
+            agent: 'business-analyst',
+            description: 'UK web traffic & conversion analysis',
+            prompt: 'Analyze the UK website traffic and conversion trend.',
+          },
+          error: { message: 'Task delegation failed' },
+          metadata: {},
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const failedTask = getTaskRun('call-task-1')
+  assert.equal(failedTask?.status, 'error')
+  assert.equal(failedTask?.childSessionId, null)
+  assert.equal(failedTask?.parentSessionId, 'root-session')
+  assert.equal(collector.events.length, 0)
+})
+
 test('session.updated preserves event-order binding instead of rebinding from metadata', () => {
   const collector = createDispatchCollector()
   const win = {

--- a/tests/native-customizations.test.ts
+++ b/tests/native-customizations.test.ts
@@ -234,6 +234,7 @@ test('custom agent builder selections round-trip through managed sidecar metadat
 
     const markdownPath = join(projectRoot, '.opencowork', 'agents', 'researcher.md')
     const markdown = readFileSync(markdownPath, 'utf-8')
+    assert.match(markdown, /permission:\n {2}task: deny/)
     assert.match(markdown, / {2}skill:\n {4}"\*": deny\n {4}"analyst": allow\n {4}"chart-creator": allow/)
     assert.match(markdown, /open-cowork:runtime-directive:start/)
     assert.match(markdown, /Attached skills: analyst, chart-creator/)
@@ -294,6 +295,7 @@ Use Nova carefully.
 
     const markdown = readFileSync(join(agentsDir, 'analyst.md'), 'utf-8')
     assert.match(markdown, /steps: 20/)
+    assert.match(markdown, /permission:\n {2}task: deny/)
     assert.match(markdown, / {2}skill:\n {4}"\*": deny\n {4}"analyst": allow\n {4}"chart-creator": allow/)
     assert.match(markdown, /open-cowork:runtime-directive:start/)
     assert.match(markdown, /Attached skills: analyst, chart-creator/)
@@ -304,6 +306,65 @@ Use Nova carefully.
     assert.ok(agent)
     assert.equal(agent.instructions, 'Use Nova carefully.')
     assert.deepEqual(agent.skillNames, ['analyst', 'chart-creator'])
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true })
+  }
+})
+
+test('custom agent runtime guidance preserves explicit task delegation opt-in', () => {
+  const projectRoot = testTempDir('opencowork-native-agent-task-optin-')
+  const agentsDir = join(projectRoot, '.opencowork', 'agents')
+
+  mkdirSync(agentsDir, { recursive: true })
+  writeFileSync(join(agentsDir, 'coordinator.md'), `---
+description: "Coordinates specialist work"
+mode: subagent
+permission:
+  task: allow
+  webfetch: allow
+---
+
+Coordinate carefully.
+`)
+
+  try {
+    syncCustomAgentRuntimeGuidance({ directory: projectRoot })
+
+    const markdown = readFileSync(join(agentsDir, 'coordinator.md'), 'utf-8')
+    assert.match(markdown, /permission:\n {2}task: allow\n {2}webfetch: allow/)
+
+    const agent = listCustomAgents({ directory: projectRoot }).find((entry) => entry.name === 'coordinator')
+    assert.ok(agent)
+    assert.deepEqual(agent.toolIds, ['task', 'webfetch'])
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true })
+  }
+})
+
+test('custom agent runtime guidance merges inline permission maps without duplicating keys', () => {
+  const projectRoot = testTempDir('opencowork-native-agent-inline-permission-')
+  const agentsDir = join(projectRoot, '.opencowork', 'agents')
+
+  mkdirSync(agentsDir, { recursive: true })
+  writeFileSync(join(agentsDir, 'researcher.md'), `---
+description: "Researches carefully"
+mode: subagent
+permission: { bash: allow, webfetch: ask }
+---
+
+Research carefully.
+`)
+
+  try {
+    syncCustomAgentRuntimeGuidance({ directory: projectRoot })
+
+    const markdown = readFileSync(join(agentsDir, 'researcher.md'), 'utf-8')
+    assert.equal(markdown.match(/^permission:/gm)?.length, 1)
+    assert.match(markdown, /permission:\n {2}bash: allow\n {2}webfetch: ask\n {2}task: deny/)
+
+    const agent = listCustomAgents({ directory: projectRoot }).find((entry) => entry.name === 'researcher')
+    assert.ok(agent)
+    assert.deepEqual(agent.toolIds, ['bash', 'webfetch'])
   } finally {
     rmSync(projectRoot, { recursive: true, force: true })
   }

--- a/tests/runtime-config-builder.test.ts
+++ b/tests/runtime-config-builder.test.ts
@@ -40,6 +40,7 @@ test('buildRuntimeConfig resolves env-backed custom providers and project custom
       "test-provider": {
         "name": "Test Provider",
         "description": "Env-backed provider",
+        "smallModel": "small",
         "credentials": [],
         "models": [
           { "id": "fast", "name": "Fast" },
@@ -265,6 +266,7 @@ test('buildRuntimeConfig uses a custom provider local default when the saved mod
           npm: '@acme/opencode-provider',
           name: 'Acme Provider',
           defaultModel: 'balanced',
+          smallModel: 'fast',
           models: {
             fast: { name: 'Fast' },
             balanced: { name: 'Balanced' },
@@ -713,11 +715,35 @@ test('buildRuntimeConfig provisions selected built-in providers with stored cred
     const runtimeConfig = buildRuntimeConfig() as Record<string, any>
 
     assert.equal(runtimeConfig.model, 'openrouter/anthropic/claude-sonnet-4')
-    assert.equal(runtimeConfig.small_model, 'openrouter/deepseek/deepseek-v4-flash:free')
+    assert.equal(runtimeConfig.small_model, 'openrouter/anthropic/claude-sonnet-4')
     assert.equal(runtimeConfig.provider.openrouter.name, 'OpenRouter')
     assert.equal(runtimeConfig.provider.openrouter.options.apiKey, 'sk-or-test')
     assert.equal(runtimeConfig.provider.openrouter.models['deepseek/deepseek-v4-flash:free'].name, 'DeepSeek V4 Flash (free) via OpenRouter')
     assert.equal(runtimeConfig.provider.openrouter.models['anthropic/claude-sonnet-4'].name, 'Claude Sonnet 4 via OpenRouter')
+  } finally {
+    saveSettings(originalSettings)
+  }
+})
+
+test('buildRuntimeConfig uses the user-selected small model for OpenCode lightweight calls', () => {
+  const originalSettings = loadSettings()
+
+  saveSettings({
+    selectedProviderId: 'openrouter',
+    selectedModelId: 'anthropic/claude-sonnet-4',
+    selectedSmallModelId: 'deepseek/deepseek-v4-flash:free',
+    providerCredentials: {
+      openrouter: {
+        apiKey: 'sk-or-test',
+      },
+    },
+  })
+
+  try {
+    const runtimeConfig = buildRuntimeConfig()
+
+    assert.equal(runtimeConfig.model, 'openrouter/anthropic/claude-sonnet-4')
+    assert.equal(runtimeConfig.small_model, 'openrouter/deepseek/deepseek-v4-flash:free')
   } finally {
     saveSettings(originalSettings)
   }

--- a/tests/session-engine.test.ts
+++ b/tests/session-engine.test.ts
@@ -451,6 +451,422 @@ test('tool calls and transcript segments share the same sequence space so a sub-
   assert.ok(seg2.order < tool2.order, 'seg-2 must sort before tool-2')
 })
 
+test('streaming text after a task tool call is split into a later transcript segment', () => {
+  const engine = new SessionEngine()
+  const rootSessionId = 'session-sub-split'
+  const childSessionId = 'child-session-split'
+  const taskRunId = 'task-run-split'
+
+  engine.activateSession(rootSessionId)
+  apply(engine, rootSessionId, {
+    type: 'task_run',
+    id: taskRunId,
+    title: 'Explore directory',
+    agent: 'explore',
+    status: 'running',
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'I will inspect the repo.',
+    mode: 'append',
+  })
+  apply(engine, rootSessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+    taskRunId,
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'The README confirms the setup.',
+    mode: 'append',
+  })
+
+  const taskRun = engine.getSessionView(rootSessionId).taskRuns.find((task) => task.id === taskRunId)
+  assert.ok(taskRun)
+  assert.equal(taskRun.transcript.length, 2)
+  const tool = taskRun.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(tool)
+  assert.ok(taskRun.transcript[0]!.order < tool.order)
+  assert.ok(tool.order < taskRun.transcript[1]!.order)
+})
+
+test('final task text replacement reconciles split transcript segments without duplication', () => {
+  const engine = new SessionEngine()
+  const rootSessionId = 'session-sub-split-replace'
+  const childSessionId = 'child-session-split-replace'
+  const taskRunId = 'task-run-split-replace'
+
+  engine.activateSession(rootSessionId)
+  apply(engine, rootSessionId, {
+    type: 'task_run',
+    id: taskRunId,
+    title: 'Explore directory',
+    agent: 'explore',
+    status: 'running',
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.',
+    mode: 'append',
+  })
+  apply(engine, rootSessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+    taskRunId,
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'After tool.',
+    mode: 'append',
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.After tool.',
+    mode: 'replace',
+  })
+
+  const taskRun = engine.getSessionView(rootSessionId).taskRuns.find((task) => task.id === taskRunId)
+  const tool = taskRun?.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(taskRun)
+  assert.ok(tool)
+  assert.equal(taskRun.transcript.length, 2)
+  assert.equal(taskRun.transcript[0]?.content, 'Before tool.')
+  assert.equal(taskRun.transcript[1]?.content, 'After tool.')
+  assert.ok(taskRun.transcript[0]!.order < tool.order)
+  assert.ok(tool.order < taskRun.transcript[1]!.order)
+})
+
+test('final task text replacement applies authoritative text when split prefix changes', () => {
+  const engine = new SessionEngine()
+  const rootSessionId = 'session-sub-split-prefix-replace'
+  const childSessionId = 'child-session-split-prefix-replace'
+  const taskRunId = 'task-run-split-prefix-replace'
+
+  engine.activateSession(rootSessionId)
+  apply(engine, rootSessionId, {
+    type: 'task_run',
+    id: taskRunId,
+    title: 'Explore directory',
+    agent: 'explore',
+    status: 'running',
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.',
+    mode: 'append',
+  })
+  apply(engine, rootSessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+    taskRunId,
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'After tool.',
+    mode: 'append',
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool!After tool.',
+    mode: 'replace',
+  })
+
+  const taskRun = engine.getSessionView(rootSessionId).taskRuns.find((task) => task.id === taskRunId)
+  const tool = taskRun?.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(taskRun)
+  assert.ok(tool)
+  assert.equal(taskRun.transcript.length, 2)
+  assert.equal(taskRun.transcript[0]?.content, 'Before tool!')
+  assert.equal(taskRun.transcript[1]?.content, 'After tool.')
+  assert.ok(taskRun.transcript[0]!.order < tool.order)
+  assert.ok(tool.order < taskRun.transcript[1]!.order)
+})
+
+test('final task text replacement preserves post-tool segment when earlier text shortens', () => {
+  const engine = new SessionEngine()
+  const rootSessionId = 'session-sub-split-short-prefix'
+  const childSessionId = 'child-session-split-short-prefix'
+  const taskRunId = 'task-run-split-short-prefix'
+
+  engine.activateSession(rootSessionId)
+  apply(engine, rootSessionId, {
+    type: 'task_run',
+    id: taskRunId,
+    title: 'Explore directory',
+    agent: 'explore',
+    status: 'running',
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.',
+    mode: 'append',
+  })
+  apply(engine, rootSessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+    taskRunId,
+    sourceSessionId: childSessionId,
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'After tool.',
+    mode: 'append',
+  })
+  apply(engine, rootSessionId, {
+    type: 'text',
+    taskRunId,
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before After tool.',
+    mode: 'replace',
+  })
+
+  const taskRun = engine.getSessionView(rootSessionId).taskRuns.find((task) => task.id === taskRunId)
+  const tool = taskRun?.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(taskRun)
+  assert.ok(tool)
+  assert.equal(taskRun.transcript.length, 2)
+  assert.equal(taskRun.transcript[0]?.content, 'Before ')
+  assert.equal(taskRun.transcript[1]?.content, 'After tool.')
+  assert.ok(taskRun.transcript[0]!.order < tool.order)
+  assert.ok(tool.order < taskRun.transcript[1]!.order)
+})
+
+test('streaming root text after a root tool call is split into a later message segment', () => {
+  const engine = new SessionEngine()
+  const sessionId = 'session-root-split'
+
+  engine.activateSession(sessionId)
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'I will inspect the repo.',
+    mode: 'append',
+  })
+  apply(engine, sessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+  })
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'The README confirms the setup.',
+    mode: 'append',
+  })
+
+  const view = engine.getSessionView(sessionId)
+  const message = view.messages.find((entry) => entry.id === 'msg-live')
+  const tool = view.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(message?.segments)
+  assert.ok(tool)
+  assert.equal(message.segments.length, 2)
+  assert.ok(message.segments[0]!.order < tool.order)
+  assert.ok(tool.order < message.segments[1]!.order)
+})
+
+test('final root text replacement reconciles split message segments without duplication', () => {
+  const engine = new SessionEngine()
+  const sessionId = 'session-root-split-replace'
+
+  engine.activateSession(sessionId)
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.',
+    mode: 'append',
+  })
+  apply(engine, sessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+  })
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'After tool.',
+    mode: 'append',
+  })
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.After tool.',
+    mode: 'replace',
+  })
+
+  const view = engine.getSessionView(sessionId)
+  const message = view.messages.find((entry) => entry.id === 'msg-live')
+  const tool = view.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(message?.segments)
+  assert.ok(tool)
+  assert.equal(message.segments.length, 2)
+  assert.equal(message.segments[0]?.content, 'Before tool.')
+  assert.equal(message.segments[1]?.content, 'After tool.')
+  assert.ok(message.segments[0]!.order < tool.order)
+  assert.ok(tool.order < message.segments[1]!.order)
+})
+
+test('final root text replacement applies authoritative text when split prefix changes', () => {
+  const engine = new SessionEngine()
+  const sessionId = 'session-root-split-prefix-replace'
+
+  engine.activateSession(sessionId)
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.',
+    mode: 'append',
+  })
+  apply(engine, sessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+  })
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'After tool.',
+    mode: 'append',
+  })
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool!After tool.',
+    mode: 'replace',
+  })
+
+  const view = engine.getSessionView(sessionId)
+  const message = view.messages.find((entry) => entry.id === 'msg-live')
+  const tool = view.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(message?.segments)
+  assert.ok(tool)
+  assert.equal(message.segments.length, 2)
+  assert.equal(message.segments[0]?.content, 'Before tool!')
+  assert.equal(message.segments[1]?.content, 'After tool.')
+  assert.ok(message.segments[0]!.order < tool.order)
+  assert.ok(tool.order < message.segments[1]!.order)
+})
+
+test('final root text replacement preserves post-tool segment when earlier text shortens', () => {
+  const engine = new SessionEngine()
+  const sessionId = 'session-root-split-short-prefix'
+
+  engine.activateSession(sessionId)
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before tool.',
+    mode: 'append',
+  })
+  apply(engine, sessionId, {
+    type: 'tool_call',
+    id: 'tool-live',
+    name: 'read',
+    status: 'complete',
+    input: { path: 'README.md' },
+  })
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'After tool.',
+    mode: 'append',
+  })
+  apply(engine, sessionId, {
+    type: 'text',
+    messageId: 'msg-live',
+    partId: 'seg-live',
+    role: 'assistant',
+    content: 'Before After tool.',
+    mode: 'replace',
+  })
+
+  const view = engine.getSessionView(sessionId)
+  const message = view.messages.find((entry) => entry.id === 'msg-live')
+  const tool = view.toolCalls.find((entry) => entry.id === 'tool-live')
+  assert.ok(message?.segments)
+  assert.ok(tool)
+  assert.equal(message.segments.length, 2)
+  assert.equal(message.segments[0]?.content, 'Before ')
+  assert.equal(message.segments[1]?.content, 'After tool.')
+  assert.ok(message.segments[0]!.order < tool.order)
+  assert.ok(tool.order < message.segments[1]!.order)
+})
+
 test('session engine preserves newer streamed state across forced history hydration', () => {
   const engine = new SessionEngine()
   const sessionId = 'session-history-1'
@@ -481,6 +897,57 @@ test('session engine preserves newer streamed state across forced history hydrat
 
   const view = engine.getSessionView(sessionId)
   assert.equal(view.messages[0]?.content, 'Live reply')
+})
+
+test('session engine preserves global history sequence when hydrating messages and task runs', () => {
+  const engine = new SessionEngine()
+  const sessionId = 'session-history-order'
+
+  engine.setSessionFromHistory(sessionId, [
+    {
+      id: 'launch-message',
+      messageId: 'launch-message',
+      partId: 'launch-text',
+      type: 'message',
+      role: 'assistant',
+      content: 'I will delegate this.',
+      timestamp: '2026-05-18T13:42:10.000Z',
+      sequence: 1,
+    },
+    {
+      id: 'child:analyst-child',
+      type: 'task_run',
+      timestamp: '2026-05-18T13:42:12.000Z',
+      sequence: 2,
+      taskRun: {
+        title: 'UK website traffic and conversion analysis',
+        agent: 'business-analyst',
+        status: 'complete',
+        sourceSessionId: 'analyst-child',
+      },
+    },
+    {
+      id: 'final-message',
+      messageId: 'final-message',
+      partId: 'final-text',
+      type: 'message',
+      role: 'assistant',
+      content: 'The analyst finished the work.',
+      timestamp: '2026-05-18T13:46:48.000Z',
+      sequence: 3,
+    },
+  ])
+
+  const view = engine.getSessionView(sessionId)
+  const launch = view.messages.find((message) => message.id === 'launch-message')
+  const final = view.messages.find((message) => message.id === 'final-message')
+  const taskRun = view.taskRuns.find((task) => task.id === 'child:analyst-child')
+
+  assert.ok(launch?.segments?.[0])
+  assert.ok(final?.segments?.[0])
+  assert.ok(taskRun)
+  assert.ok(launch.segments[0].order < taskRun.order)
+  assert.ok(taskRun.order < final.segments[0].order)
 })
 
 test('session engine surfaces pending questions as a first-class waiting state', () => {

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -1,10 +1,22 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import {
+  dispatchRuntimeSessionEvent,
   getRuntimeNotification,
   getSessionPatch,
+  setSessionHistoryRefreshHandler,
   shouldPublishSessionView,
 } from '../apps/desktop/src/main/session-event-dispatcher.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import {
+  clearSessionRegistryCache,
+  toSessionRecord,
+  updateSessionRecord,
+  upsertSessionRecord,
+} from '../apps/desktop/src/main/session-registry.ts'
 
 function eventOf(type: string, sessionId?: string | null) {
   return {
@@ -145,4 +157,59 @@ test('dispatcher derives notifications for completion and global errors', () => 
 
   assert.equal(getRuntimeNotification(eventOf('error', 'session-1')), null)
   assert.equal(getRuntimeNotification(eventOf('busy', 'session-1')), null)
+})
+
+test('history refresh publishes SDK-owned session metadata after registry sync', async () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = mkdtempSync(join(tmpdir(), 'open-cowork-dispatcher-'))
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+  clearSessionRegistryCache()
+
+  try {
+    upsertSessionRecord(toSessionRecord({
+      id: 'session-title-sync',
+      title: 'New session',
+      createdAt: '2026-05-18T14:00:00.000Z',
+      updatedAt: '2026-05-18T14:00:00.000Z',
+      opencodeDirectory: userDataDir,
+    }))
+    setSessionHistoryRefreshHandler(async (sessionId) => {
+      updateSessionRecord(sessionId, {
+        title: 'SDK generated title',
+        updatedAt: '2026-05-18T14:00:05.000Z',
+      })
+    })
+
+    const sent: Array<{ channel: string; payload: unknown }> = []
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        id: 42,
+        isDestroyed: () => false,
+        send: (channel: string, payload: unknown) => sent.push({ channel, payload }),
+      },
+    }
+
+    dispatchRuntimeSessionEvent(win as any, eventOf('history_refresh', 'session-title-sync'))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    assert.ok(sent.some((entry) => entry.channel === 'session:view'))
+    assert.deepEqual(
+      sent.find((entry) => entry.channel === 'session:updated')?.payload,
+      {
+        id: 'session-title-sync',
+        title: 'SDK generated title',
+        parentSessionId: null,
+        changeSummary: null,
+        revertedMessageId: null,
+      },
+    )
+  } finally {
+    setSessionHistoryRefreshHandler(null)
+    clearSessionRegistryCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+  }
 })

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -253,6 +253,420 @@ test('history projector skips question tool parts so they can be rendered throug
   assert.equal(items.some((item) => item.type === 'tool'), false)
 })
 
+test('history projector anchors root task tool runs before the parent follow-up response', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-task-msg', role: 'assistant', time: { created: 10 } },
+        parts: [
+          { id: 'root-task-text', type: 'text', text: 'I will delegate this to the analyst.' },
+          {
+            id: 'root-task-part',
+            type: 'tool',
+            tool: 'task',
+            callID: 'task-call-1',
+            state: {
+              status: 'completed',
+              input: {
+                agent: 'business-analyst',
+                description: 'UK website traffic and conversion analysis',
+              },
+              output: 'done',
+              metadata: {},
+            },
+          },
+          { id: 'root-task-finish', type: 'step-finish', reason: 'tool-calls' },
+        ],
+      },
+      {
+        info: { id: 'root-final-msg', role: 'assistant', time: { created: 30 } },
+        parts: [
+          { id: 'root-final-text', type: 'text', text: 'The analyst finished the work.' },
+          { id: 'root-final-finish', type: 'step-finish', reason: 'stop' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [{
+      id: 'child-analyst',
+      title: 'UK website traffic and conversion analysis (@business-analyst subagent)',
+      parentSessionId: 'root-task-tool',
+      time: { created: 20, updated: 25 },
+    }],
+    statuses: {
+      'root-task-tool': { type: 'idle' },
+      'child-analyst': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({
+      messages: [{
+        info: { id: 'child-analyst-msg', role: 'assistant', time: { created: 22 } },
+        parts: [
+          { id: 'child-analyst-text', type: 'text', text: 'Analyst details.' },
+          { id: 'child-analyst-finish', type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const taskRun = items.find((item) => item.type === 'task_run')
+  const finalMessage = items.find((item) => item.messageId === 'root-final-msg' && item.type === 'message')
+
+  assert.ok(taskRun?.taskRun)
+  assert.equal(taskRun.id, 'child:child-analyst')
+  assert.equal(taskRun.taskRun.agent, 'business-analyst')
+  assert.equal(taskRun.taskRun.sourceSessionId, 'child-analyst')
+  assert.equal(taskRun.taskRun.title, 'UK website traffic and conversion analysis')
+  assert.equal(items.some((item) => item.type === 'tool' && item.id === 'task-call-1'), false)
+  assert.ok(taskRun.sequence < (finalMessage?.sequence || 0))
+})
+
+test('history projector does not bind a terminal task tool to a later unrelated child session', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-unrelated-child',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-failed-task-msg', role: 'assistant', time: { created: 10 } },
+        parts: [
+          {
+            id: 'root-failed-task-part',
+            type: 'tool',
+            tool: 'task',
+            callID: 'failed-task-call',
+            state: {
+              status: 'completed',
+              input: {
+                agent: 'business-analyst',
+                description: 'Failed delegation attempt',
+              },
+              output: 'Delegation did not start.',
+              metadata: {},
+            },
+          },
+        ],
+      },
+      {
+        info: { id: 'root-real-subtask-msg', role: 'assistant', time: { created: 20 } },
+        parts: [
+          { id: 'root-real-subtask', type: 'subtask', agent: 'research', description: 'Actual child work' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [{
+      id: 'child-real',
+      title: 'Actual child work (@research subagent)',
+      parentSessionId: 'root-task-tool-unrelated-child',
+      time: { created: 21, updated: 25 },
+    }],
+    statuses: {
+      'root-task-tool-unrelated-child': { type: 'idle' },
+      'child-real': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({
+      messages: [{
+        info: { id: 'child-real-msg', role: 'assistant', time: { created: 22 } },
+        parts: [
+          { id: 'child-real-text', type: 'text', text: 'Child result.' },
+          { id: 'child-real-finish', type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const taskRuns = items.filter((item) => item.type === 'task_run')
+  const failedTask = taskRuns.find((item) => item.id === 'pending:failed-task-call')?.taskRun
+  const childTask = taskRuns.find((item) => item.id === 'child:child-real')?.taskRun
+
+  assert.ok(failedTask)
+  assert.equal(failedTask.status, 'complete')
+  assert.equal(failedTask.sourceSessionId, null)
+  assert.ok(childTask)
+  assert.equal(childTask.sourceSessionId, 'child-real')
+  assert.equal(childTask.title, 'Actual child work')
+})
+
+test('history projector scans later direct children when matching task tool sessions', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-later-child-match',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-task-msg', role: 'assistant', time: { created: 10 } },
+        parts: [
+          {
+            id: 'root-task-part',
+            type: 'tool',
+            tool: 'task',
+            callID: 'task-call-target',
+            state: {
+              status: 'completed',
+              input: {
+                agent: 'analyst',
+                description: 'Target market analysis',
+              },
+              output: 'done',
+              metadata: {},
+            },
+          },
+        ],
+      },
+      {
+        info: { id: 'root-subtask-msg', role: 'assistant', time: { created: 20 } },
+        parts: [
+          { id: 'root-subtask', type: 'subtask', agent: 'research', description: 'Earlier unrelated research' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-unrelated',
+        title: 'Earlier unrelated research (@research subagent)',
+        parentSessionId: 'root-task-tool-later-child-match',
+        time: { created: 11, updated: 14 },
+      },
+      {
+        id: 'child-target',
+        title: 'Target market analysis (@analyst subagent)',
+        parentSessionId: 'root-task-tool-later-child-match',
+        time: { created: 12, updated: 18 },
+      },
+    ],
+    statuses: {
+      'root-task-tool-later-child-match': { type: 'idle' },
+      'child-unrelated': { type: 'idle' },
+      'child-target': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const targetTask = items.find((item) => item.id === 'child:child-target')?.taskRun
+  const unrelatedTask = items.find((item) => item.id === 'child:child-unrelated')?.taskRun
+
+  assert.ok(targetTask)
+  assert.equal(targetTask.sourceSessionId, 'child-target')
+  assert.equal(targetTask.title, 'Target market analysis')
+  assert.ok(unrelatedTask)
+  assert.equal(unrelatedTask.sourceSessionId, 'child-unrelated')
+  assert.equal(unrelatedTask.title, 'Earlier unrelated research')
+})
+
+test('history projector preserves root message part order around task tools', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-order',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-task-order-msg', role: 'assistant', time: { created: 10 } },
+        parts: [
+          { id: 'root-task-order-before', type: 'text', text: 'Before delegation.' },
+          {
+            id: 'root-task-order-part',
+            type: 'tool',
+            tool: 'task',
+            callID: 'task-order-call',
+            state: {
+              status: 'completed',
+              input: { agent: 'analyst', description: 'Analyze order' },
+              output: 'done',
+              metadata: {},
+            },
+          },
+          { id: 'root-task-order-after', type: 'text', text: 'After delegation.' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [{
+      id: 'child-task-order',
+      title: 'Analyze order (@analyst subagent)',
+      parentSessionId: 'root-task-order',
+      time: { created: 11, updated: 12 },
+    }],
+    statuses: {
+      'root-task-order': { type: 'idle' },
+      'child-task-order': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({
+      messages: [{
+        info: { id: 'child-task-order-msg', role: 'assistant', time: { created: 11 } },
+        parts: [
+          { id: 'child-task-order-text', type: 'text', text: 'Child done.' },
+          { id: 'child-task-order-finish', type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const before = items.find((item) => item.type === 'message' && item.content === 'Before delegation.')
+  const taskRun = items.find((item) => item.type === 'task_run')
+  const after = items.find((item) => item.type === 'message' && item.content === 'After delegation.')
+
+  assert.ok(before?.sequence)
+  assert.ok(taskRun?.sequence)
+  assert.ok(after?.sequence)
+  assert.ok(before.sequence < taskRun.sequence)
+  assert.ok(taskRun.sequence < after.sequence)
+})
+
+test('history projector preserves child transcript order around tool calls', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-child-order',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-child-order-msg', role: 'assistant', time: { created: 1 } },
+      parts: [
+        { id: 'subtask-child-order', type: 'subtask', agent: 'analyst', description: 'Check child ordering' },
+      ],
+    }],
+    rootTodos: [],
+    children: [{
+      id: 'child-order',
+      title: 'Check child ordering (@analyst subagent)',
+      parentSessionId: 'root-child-order',
+      time: { created: 2, updated: 4 },
+    }],
+    statuses: {
+      'root-child-order': { type: 'idle' },
+      'child-order': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({
+      messages: [{
+        info: { id: 'child-order-msg', role: 'assistant', time: { created: 2 } },
+        parts: [
+          { id: 'child-order-before', type: 'text', text: 'Before tool.' },
+          {
+            id: 'child-order-tool',
+            type: 'tool',
+            tool: 'read',
+            callID: 'child-order-read',
+            state: {
+              input: { filePath: 'README.md' },
+              output: 'ok',
+              metadata: {},
+            },
+          },
+          { id: 'child-order-after', type: 'text', text: 'After tool.' },
+          { id: 'child-order-finish', type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const before = items.find((item) => item.type === 'task_text' && item.content === 'Before tool.')
+  const tool = items.find((item) => item.type === 'task_tool' && item.id === 'child-order-read')
+  const after = items.find((item) => item.type === 'task_text' && item.content === 'After tool.')
+
+  assert.ok(before?.sequence)
+  assert.ok(tool?.sequence)
+  assert.ok(after?.sequence)
+  assert.ok(before.sequence < tool.sequence)
+  assert.ok(tool.sequence < after.sequence)
+})
+
+test('history projector binds nested task tools to grandchild sessions during replay', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-nested-task-tool',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-nested-task-msg', role: 'assistant', time: { created: 1 } },
+      parts: [
+        { id: 'root-nested-subtask', type: 'subtask', agent: 'research', description: 'Investigate nested delegation' },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-nested-parent',
+        title: 'Investigate nested delegation (@research subagent)',
+        parentSessionId: 'root-nested-task-tool',
+        time: { created: 2, updated: 8 },
+      },
+      {
+        id: 'grandchild-nested-task',
+        title: 'Deep dive into nested delegation (@analyst subagent)',
+        parentSessionId: 'child-nested-parent',
+        time: { created: 4, updated: 7 },
+      },
+    ],
+    statuses: {
+      'root-nested-task-tool': { type: 'idle' },
+      'child-nested-parent': { type: 'idle' },
+      'grandchild-nested-task': { type: 'idle' },
+    },
+    loadChildSnapshot: async (childId) => {
+      if (childId === 'child-nested-parent') {
+        return {
+          messages: [{
+            info: { id: 'child-nested-parent-msg', role: 'assistant', time: { created: 3 } },
+            parts: [
+              { id: 'child-nested-before', type: 'text', text: 'Before nested delegation.' },
+              {
+                id: 'child-nested-task-part',
+                type: 'tool',
+                tool: 'task',
+                callID: 'nested-task-call',
+                title: 'Deep dive into nested delegation',
+                state: {
+                  status: 'completed',
+                  input: {
+                    agent: 'analyst',
+                    description: 'Deep dive into nested delegation',
+                    prompt: 'Deep dive into nested delegation',
+                  },
+                  output: 'started',
+                  metadata: {},
+                },
+              },
+              { id: 'child-nested-after', type: 'text', text: 'After nested delegation.' },
+              { id: 'child-nested-finish', type: 'step-finish', reason: 'stop' },
+            ],
+          }],
+          todos: [],
+        }
+      }
+
+      return {
+        messages: [{
+          info: { id: 'grandchild-nested-task-msg', role: 'assistant', time: { created: 5 } },
+          parts: [
+            { id: 'grandchild-nested-text', type: 'text', text: 'Nested analysis complete.' },
+            { id: 'grandchild-nested-finish', type: 'step-finish', reason: 'stop' },
+          ],
+        }],
+        todos: [],
+      }
+    },
+  })
+
+  const nestedTaskRuns = items.filter((item) => item.type === 'task_run' && item.taskRun?.sourceSessionId === 'grandchild-nested-task')
+  const nestedTool = items.find((item) => item.type === 'task_tool' && item.id === 'nested-task-call')
+  const before = items.find((item) => item.type === 'task_text' && item.content === 'Before nested delegation.')
+  const nestedRun = nestedTaskRuns[0]
+  const after = items.find((item) => item.type === 'task_text' && item.content === 'After nested delegation.')
+  const nestedText = items.find((item) => item.type === 'task_text' && item.content === 'Nested analysis complete.')
+
+  assert.equal(nestedTaskRuns.length, 1)
+  assert.equal(nestedRun?.id, 'child:grandchild-nested-task')
+  assert.equal(nestedRun?.taskRun?.parentSessionId, 'child-nested-parent')
+  assert.equal(nestedRun?.taskRun?.agent, 'analyst')
+  assert.equal(nestedTool, undefined)
+  assert.ok(before?.sequence)
+  assert.ok(nestedRun?.sequence)
+  assert.ok(after?.sequence)
+  assert.ok(nestedText?.sequence)
+  assert.ok(before.sequence < nestedRun.sequence)
+  assert.ok(nestedRun.sequence < after.sequence)
+  assert.equal(nestedText.taskRunId, 'child:grandchild-nested-task')
+})
+
 test('history projector preserves nested child parentage when replaying reopened threads', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-3',
@@ -429,6 +843,51 @@ test('history projector normalizes replayed todo snapshots', async () => {
     status: 'in_progress',
     priority: 'medium',
   })
+})
+
+test('history projector resequences orphan child task runs by chronological replay order', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-orphan-order',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      textMessage('root-before-orphan', 'assistant', 'Before orphan child.', 10),
+      textMessage('root-after-orphan', 'assistant', 'After orphan child.', 30),
+    ],
+    rootTodos: [],
+    children: [{
+      id: 'child-orphan-order',
+      title: 'Analyze order (@analyst subagent)',
+      parentSessionId: 'root-orphan-order',
+      time: { created: 20, updated: 22 },
+    }],
+    statuses: {
+      'root-orphan-order': { type: 'idle' },
+      'child-orphan-order': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({
+      messages: [{
+        info: { id: 'child-orphan-msg', role: 'assistant', time: { created: 21 } },
+        parts: [
+          { id: 'child-orphan-text', type: 'text', text: 'Child details.' },
+          { id: 'child-orphan-finish', type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const before = items.find((item) => item.messageId === 'root-before-orphan' && item.type === 'message')
+  const taskRun = items.find((item) => item.type === 'task_run' && item.id === 'child:child-orphan-order')
+  const taskText = items.find((item) => item.type === 'task_text' && item.content === 'Child details.')
+  const after = items.find((item) => item.messageId === 'root-after-orphan' && item.type === 'message')
+
+  assert.ok(before?.sequence)
+  assert.ok(taskRun?.sequence)
+  assert.ok(taskText?.sequence)
+  assert.ok(after?.sequence)
+  assert.ok(before.sequence < taskRun.sequence)
+  assert.ok(taskRun.sequence < taskText.sequence)
+  assert.ok(taskText.sequence < after.sequence)
 })
 
 test('history projector accepts deterministic fallback id generation', async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
+import { SMALL_MODEL_USE_MAIN } from '../packages/shared/src/app-config.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 
 function testTempDir(prefix: string) {
@@ -53,6 +54,7 @@ function writeProviderDefaultConfig(configDir: string, internalDefaultModel = 'i
           name: 'Internal Gateway',
           description: 'Internal model gateway',
           defaultModel: internalDefaultModel,
+          smallModel: 'internal-fast',
           credentials: [],
           models: [
             { id: 'internal-fast', name: 'Internal Fast' },
@@ -370,6 +372,7 @@ test('fresh settings initialize to the default provider local default model', as
     assert.equal(settings.selectedModelId, 'acme-large')
     assert.equal(effective.effectiveProviderId, 'acme-gateway')
     assert.equal(effective.effectiveModel, 'acme-large')
+    assert.equal(effective.effectiveSmallModel, 'acme-large')
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
@@ -402,6 +405,7 @@ test('effective settings use a selected provider local default when the saved mo
     const effective = getEffectiveSettings(loadSettings())
     assert.equal(effective.effectiveProviderId, 'internal-gateway')
     assert.equal(effective.effectiveModel, 'internal-balanced')
+    assert.equal(effective.effectiveSmallModel, 'internal-fast')
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
@@ -434,6 +438,75 @@ test('effective settings accept provider-prefixed model ids for configured provi
     const effective = getEffectiveSettings(loadSettings())
     assert.equal(effective.effectiveProviderId, 'internal-gateway')
     assert.equal(effective.effectiveModel, 'internal-fast')
+    assert.equal(effective.effectiveSmallModel, 'internal-fast')
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('effective settings accept an explicit provider-prefixed small model', async () => {
+  const tempRoot = testTempDir('opencowork-settings-small-model-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeProviderDefaultConfig(configDir)
+  mkdirSync(userDataDir, { recursive: true })
+  writeFileSync(join(userDataDir, 'settings.json'), JSON.stringify({
+    selectedProviderId: 'internal-gateway',
+    selectedModelId: 'internal-balanced',
+    selectedSmallModelId: 'internal-gateway/internal-fast',
+  }))
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, getEffectiveSettings } = await importFreshSettingsModule('explicit-small-model')
+    const effective = getEffectiveSettings(loadSettings())
+    assert.equal(effective.effectiveProviderId, 'internal-gateway')
+    assert.equal(effective.effectiveModel, 'internal-balanced')
+    assert.equal(effective.effectiveSmallModel, 'internal-fast')
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('effective settings let small model explicitly follow the selected main model', async () => {
+  const tempRoot = testTempDir('opencowork-settings-small-model-main-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeProviderDefaultConfig(configDir)
+  mkdirSync(userDataDir, { recursive: true })
+  writeFileSync(join(userDataDir, 'settings.json'), JSON.stringify({
+    selectedProviderId: 'internal-gateway',
+    selectedModelId: 'internal-balanced',
+    selectedSmallModelId: SMALL_MODEL_USE_MAIN,
+  }))
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const { loadSettings, getEffectiveSettings } = await importFreshSettingsModule('small-model-main')
+    const effective = getEffectiveSettings(loadSettings())
+    assert.equal(effective.effectiveProviderId, 'internal-gateway')
+    assert.equal(effective.effectiveModel, 'internal-balanced')
+    assert.equal(effective.effectiveSmallModel, 'internal-balanced')
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir


### PR DESCRIPTION
## Summary

- smooth streamed chat updates by batching text patches and preserving SDK event order across root and subagent timelines
- hydrate reopened threads with the same part ordering used during live streaming, including task delegation and child tool calls
- make custom-agent Task Delegation explicit and configurable, and add the small-model setting for lightweight OpenCode calls
- fix clock timezone offset rounding for millisecond anchors

## Validation

- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm --filter @open-cowork/desktop test:renderer -- components/agents/AgentCapabilitiesTab.test.tsx stores/session.test.ts components/chat/chat-view-timeline.test.ts components/sidebar/SettingsPanel.test.tsx
- git diff --check