### PR TITLE
Fix thread title, replay, and index regressions

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -10,7 +10,6 @@ import { fileURLToPath } from 'url'
 import {
   getClient,
   getRuntimeHomeDir,
-  getV2ClientForDirectory,
 } from './runtime.ts'
 import { getEffectiveSettings } from './settings.ts'
 import { log } from './logger.ts'
@@ -19,8 +18,7 @@ import { shortSessionId } from './log-sanitizer.ts'
 import { dispatchRuntimeSessionEvent, setSessionHistoryRefreshHandler } from './session-event-dispatcher.ts'
 import { getSessionRecord, listSessionRecords } from './session-registry.ts'
 import { syncSessionView } from './session-history-loader.ts'
-import { ensureRuntimeContextDirectory } from './runtime-context.ts'
-import { isVisibleRuntimeToolId, runtimeToolId } from './runtime-tools.ts'
+import { listRuntimeToolsForResolvedContext } from './runtime-tools.ts'
 import { createSandboxWorkspaceDir } from './runtime-paths.ts'
 import { createDestructiveConfirmationManager } from './destructive-actions.ts'
 import { listWorkflows as listWorkflowState } from './workflow-store.ts'
@@ -50,7 +48,6 @@ import { createIpcRuntimeContext } from './ipc-runtime-context.ts'
 import { getThreadIndexService } from './thread-index-service.ts'
 import { showNativeConfirmation, type NativeConfirmationOptions } from './native-confirmation.ts'
 
-import { RUNTIME_TOOL_CACHE_TTL_MS, runtimeToolCache } from './runtime-tool-cache.ts'
 export { invalidateRuntimeToolCache } from './runtime-tool-cache.ts'
 
 type IpcSenderEvent = IpcMainEvent | IpcMainInvokeEvent
@@ -285,33 +282,12 @@ export function setupIpcHandlers(
 
     if (!provider || !model) return []
 
-    const cacheKey = `${directory}|${provider}|${model}`
-    const now = Date.now()
-    const cached = runtimeToolCache.get(cacheKey)
-    if (cached && cached.expiresAt > now) {
-      return cached.tools
-    }
-
-    await ensureRuntimeContextDirectory(directory)
-
-    const client = getV2ClientForDirectory(directory)
-    if (!client) return []
-
-    try {
-      const result = await client.tool.list({
-        directory,
-        provider,
-        model,
-      }, {
-        throwOnError: true,
-      })
-      const tools = (result.data || []).filter((entry) => isVisibleRuntimeToolId(runtimeToolId(entry)))
-      runtimeToolCache.set(cacheKey, { expiresAt: now + RUNTIME_TOOL_CACHE_TTL_MS, tools })
-      return tools
-    } catch (err) {
-      logHandlerError('tool:list', err)
-      return []
-    }
+    return listRuntimeToolsForResolvedContext({
+      directory,
+      provider,
+      model,
+      logScope: 'tool:list',
+    })
   }
 
   const capabilityToolDiscovery = createCapabilityToolDiscovery({

--- a/apps/desktop/src/main/ipc/catalog-handlers.ts
+++ b/apps/desktop/src/main/ipc/catalog-handlers.ts
@@ -1,4 +1,5 @@
 import type { RuntimeAgentDescriptor, RuntimeContextOptions, ScopedArtifactRef, ToolListOptions, CustomAgentConfig } from '@open-cowork/shared'
+import { performance } from 'node:perf_hooks'
 import type { IpcHandlerContext } from './context.ts'
 import { optionalObjectArg, registerIpcInvoke, stringArg } from './schema.ts'
 import { getClient } from '../runtime.ts'
@@ -42,6 +43,16 @@ const runMcpTransitionForName = createKeyedPromiseChain()
 
 const WRITE_TOOL_IDS = new Set(['edit', 'write', 'apply_patch', 'todowrite'])
 const WRITE_PERMISSION_ACTIONS = new Set(['ask', 'allow'])
+
+async function timeAgentCatalogHandler<T>(name: 'agents:list' | 'agents:catalog' | 'agents:runtime', work: () => Promise<T>) {
+  const start = performance.now()
+  try {
+    return await work()
+  } finally {
+    const durationMs = performance.now() - start
+    log('agent', `${name} completed in ${Math.round(durationMs)}ms`)
+  }
+}
 
 function patternMatches(pattern: string, value: string) {
   let patternIndex = 0
@@ -250,11 +261,13 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   })
 
   context.ipcMain.handle('agents:catalog', async (_event, options?: RuntimeContextOptions) => {
-    return await getCustomAgentCatalog(resolveContext(context, options))
+    return timeAgentCatalogHandler('agents:catalog', () =>
+      getCustomAgentCatalog(resolveContext(context, options)))
   })
 
   context.ipcMain.handle('agents:list', async (_event, options?: RuntimeContextOptions) => {
-    return await getCustomAgentSummaries(resolveContext(context, options))
+    return timeAgentCatalogHandler('agents:list', () =>
+      getCustomAgentSummaries(resolveContext(context, options)))
   })
 
   // Ask the SDK what agents are actually registered at runtime. Surfaces
@@ -262,35 +275,37 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   // any agent a downstream distribution injected via the `Config.agent`
   // slot that didn't flow through Cowork's config pipeline.
   context.ipcMain.handle('agents:runtime', async (): Promise<RuntimeAgentDescriptor[]> => {
-    const client = getClient()
-    if (!client) return []
-    try {
-      const response = await client.app.agents()
-      const agents = response.data || []
-      return agents
-        .filter((agent) => agent.name)
-        .map((agent): RuntimeAgentDescriptor => {
-          const toolIds = runtimeAgentToolIds(agent)
-          return {
-            name: agent.name,
-            mode: agent.mode,
-            description: agent.description || null,
-            model: agent.model ? `${agent.model.providerID}/${agent.model.modelID}` : null,
-            color: agent.color || null,
-            // SDK's Agent type has no `disable` flag — runtime agents are by
-            // definition the registered/enabled set.
-            disabled: false,
-            toolIds,
-            toolCount: toolIds.length,
-            writeAccess: runtimeAgentCanWrite(agent),
-            steps: runtimeAgentSteps(agent),
-          }
-        })
-        .sort((a, b) => a.name.localeCompare(b.name))
-    } catch (err) {
-      context.logHandlerError('agents:runtime', err)
-      return []
-    }
+    return timeAgentCatalogHandler('agents:runtime', async () => {
+      const client = getClient()
+      if (!client) return []
+      try {
+        const response = await client.app.agents()
+        const agents = response.data || []
+        return agents
+          .filter((agent) => agent.name)
+          .map((agent): RuntimeAgentDescriptor => {
+            const toolIds = runtimeAgentToolIds(agent)
+            return {
+              name: agent.name,
+              mode: agent.mode,
+              description: agent.description || null,
+              model: agent.model ? `${agent.model.providerID}/${agent.model.modelID}` : null,
+              color: agent.color || null,
+              // SDK's Agent type has no `disable` flag — runtime agents are by
+              // definition the registered/enabled set.
+              disabled: false,
+              toolIds,
+              toolCount: toolIds.length,
+              writeAccess: runtimeAgentCanWrite(agent),
+              steps: runtimeAgentSteps(agent),
+            }
+          })
+          .sort((a, b) => a.name.localeCompare(b.name))
+      } catch (err) {
+        context.logHandlerError('agents:runtime', err)
+        return []
+      }
+    })
   })
 
   context.ipcMain.handle('agents:create', async (_event, agent: CustomAgentConfig) => {

--- a/apps/desktop/src/main/runtime-tool-cache.ts
+++ b/apps/desktop/src/main/runtime-tool-cache.ts
@@ -13,7 +13,15 @@
 export const RUNTIME_TOOL_CACHE_TTL_MS = 30_000
 type RuntimeToolCacheEntry = { expiresAt: number; tools: unknown[] }
 export const runtimeToolCache = new Map<string, RuntimeToolCacheEntry>()
+export const runtimeToolInflight = new Map<string, Promise<unknown[]>>()
+let runtimeToolCacheGeneration = 0
+
+export function currentRuntimeToolCacheGeneration() {
+  return runtimeToolCacheGeneration
+}
 
 export function invalidateRuntimeToolCache() {
+  runtimeToolCacheGeneration += 1
   runtimeToolCache.clear()
+  runtimeToolInflight.clear()
 }

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -4,10 +4,23 @@ import { getV2ClientForDirectory, getRuntimeHomeDir } from './runtime.ts'
 import { ensureRuntimeContextDirectory } from './runtime-context.ts'
 import { resolveProjectDirectory } from './runtime-paths.ts'
 import { log } from './logger.ts'
+import {
+  RUNTIME_TOOL_CACHE_TTL_MS,
+  currentRuntimeToolCacheGeneration,
+  runtimeToolCache,
+  runtimeToolInflight,
+} from './runtime-tool-cache.ts'
 
 export type RuntimeToolMetadata = {
   id: string
   description: string
+}
+
+type ResolvedRuntimeToolContext = {
+  directory: string
+  provider: string
+  model: string
+  logScope?: string
 }
 
 const HIDDEN_RUNTIME_TOOL_IDS = new Set([
@@ -60,32 +73,68 @@ export function nativeToolPermissionPatterns(id: string) {
     : { allowPatterns: [id], askPatterns: [] as string[] }
 }
 
+export async function listRuntimeToolsForResolvedContext(context: ResolvedRuntimeToolContext) {
+  const { directory, provider, model, logScope = 'runtime tool discovery' } = context
+  if (!provider || !model) return []
+
+  const cacheKey = `${directory}|${provider}|${model}`
+  const now = Date.now()
+  const cached = runtimeToolCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) {
+    return cached.tools
+  }
+
+  const inflight = runtimeToolInflight.get(cacheKey)
+  if (inflight) return await inflight
+
+  const generation = currentRuntimeToolCacheGeneration()
+  const promise = (async () => {
+    await ensureRuntimeContextDirectory(directory)
+
+    const client = getV2ClientForDirectory(directory)
+    if (!client) return []
+
+    try {
+      const result = await client.tool.list({
+        directory,
+        provider,
+        model,
+      }, {
+        throwOnError: true,
+      })
+      const tools = (result.data || []).filter((entry) => isVisibleRuntimeToolId(runtimeToolId(entry)))
+      if (currentRuntimeToolCacheGeneration() === generation) {
+        runtimeToolCache.set(cacheKey, { expiresAt: Date.now() + RUNTIME_TOOL_CACHE_TTL_MS, tools })
+      }
+      return tools
+    } catch (error) {
+      log('error', `${logScope} failed: ${error instanceof Error ? error.message : String(error)}`)
+      return []
+    }
+  })()
+
+  runtimeToolInflight.set(cacheKey, promise)
+  try {
+    return await promise
+  } finally {
+    if (runtimeToolInflight.get(cacheKey) === promise) {
+      runtimeToolInflight.delete(cacheKey)
+    }
+  }
+}
+
 export async function listRuntimeToolsForContext(context?: RuntimeContextOptions) {
   const settings = getEffectiveSettings()
   const provider = settings.effectiveProviderId || ''
   const model = settings.effectiveModel || ''
   const directory = resolveProjectDirectory(context?.directory) || getRuntimeHomeDir()
 
-  if (!provider || !model) return []
-
-  await ensureRuntimeContextDirectory(directory)
-
-  const client = getV2ClientForDirectory(directory)
-  if (!client) return []
-
-  try {
-    const result = await client.tool.list({
-      directory,
-      provider,
-      model,
-    }, {
-      throwOnError: true,
-    })
-    return (result.data || []).filter((entry) => isVisibleRuntimeToolId(runtimeToolId(entry)))
-  } catch (error) {
-    log('error', `runtime tool discovery failed: ${error instanceof Error ? error.message : String(error)}`)
-    return []
-  }
+  return listRuntimeToolsForResolvedContext({
+    directory,
+    provider,
+    model,
+    logScope: 'runtime tool discovery',
+  })
 }
 
 export function toRuntimeToolMetadata(entry: unknown): RuntimeToolMetadata | null {

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -3,10 +3,12 @@ import type { PendingApproval, PendingQuestion, SessionView } from '@open-cowork
 import { getClientForDirectory, getRuntimeHomeDir, getV2ClientForDirectory } from './runtime.ts'
 import { getBrandName } from './config-loader.ts'
 import { getEffectiveSettings, loadSettings } from './settings.ts'
+import { isInternalCoworkMessage } from './internal-message-utils.ts'
 import {
   normalizeSessionInfo,
   normalizeSessionMessages,
   normalizeSessionStatuses,
+  type NormalizedSessionMessage,
 } from './opencode-adapter.ts'
 import {
   asRecord,
@@ -51,8 +53,42 @@ type ChildSessionRecord = {
   parentSessionId?: string | null
 }
 
+const DEFAULT_SDK_SESSION_TITLE_RE = /^New session(?: - \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)?$/i
+const FALLBACK_SESSION_TITLE_MAX_CHARS = 80
+
 function readResponseData(value: unknown) {
   return readRecordValue(value, 'data')
+}
+
+function isDefaultSdkSessionTitle(title?: string | null) {
+  const trimmed = (title || '').trim()
+  return !trimmed || DEFAULT_SDK_SESSION_TITLE_RE.test(trimmed)
+}
+
+function nonDefaultPersistedSessionTitle(title?: string | null) {
+  const trimmed = title?.trim()
+  return trimmed && !isDefaultSdkSessionTitle(trimmed) ? trimmed : null
+}
+
+function truncateFallbackSessionTitle(title: string) {
+  if (title.length <= FALLBACK_SESSION_TITLE_MAX_CHARS) return title
+  const trimmed = title.slice(0, FALLBACK_SESSION_TITLE_MAX_CHARS - 3).trimEnd()
+  return `${trimmed}...`
+}
+
+function fallbackSessionTitleFromHistory(messages: NormalizedSessionMessage[]) {
+  for (const message of messages) {
+    const role = message.info.role || message.role
+    if (role !== 'user') continue
+    const text = message.parts
+      .filter((part) => part.type === 'text' && typeof part.text === 'string')
+      .map((part) => part.text)
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+    if (text && !isInternalCoworkMessage(text)) return truncateFallbackSessionTitle(text)
+  }
+  return null
 }
 
 function normalizeQuestionOptions(value: unknown) {
@@ -237,7 +273,7 @@ export function createSessionHistoryService(
 
   async function loadSessionHistory(sessionId: string) {
     return measureAsyncPerf('session.history.load', async () => {
-      const { client, questionClient } = await deps.getSessionClient(sessionId)
+      const { client, questionClient, record } = await deps.getSessionClient(sessionId)
       const [
         rootMessagesResult,
         rootTodosResult,
@@ -321,6 +357,20 @@ export function createSessionHistoryService(
       }
       const sessionInfo = normalizeSessionInfo(sessionInfoResult?.data)
       if (sessionInfo) {
+        let title = sessionInfo.title
+        if (isDefaultSdkSessionTitle(title)) {
+          const fallbackTitle = nonDefaultPersistedSessionTitle(record?.title)
+            || fallbackSessionTitleFromHistory(rootMessages)
+          if (fallbackTitle) {
+            try {
+              await client.session.update({ sessionID: sessionId, title: fallbackTitle })
+              title = fallbackTitle
+              log('session', `Auto-renamed ${shortSessionId(sessionId)} from default SDK title`)
+            } catch (err) {
+              logHistoryError('session:title fallback', sessionId, err)
+            }
+          }
+        }
         // parentSessionId is stable once set at fork time. If SDK's session.get
         // omits parentID on a later refresh (it has in practice), don't erase
         // the value we already persisted — only write when we have one.
@@ -328,7 +378,7 @@ export function createSessionHistoryService(
           ...(sessionInfo.parentID ? { parentSessionId: sessionInfo.parentID } : {}),
           changeSummary: sessionInfo.summary,
           revertedMessageId: sessionInfo.revertedMessageId,
-          ...(sessionInfo.title ? { title: sessionInfo.title } : {}),
+          ...(title ? { title } : {}),
         })
       }
       return { items, questions, approvals }

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -169,6 +169,15 @@ function childLooksLikeTaskTool(part: NormalizedMessagePart, child: ChildSession
   return agent.length > 0 && childTitle.includes(agent)
 }
 
+function taskToolChildSessionId(part: NormalizedMessagePart) {
+  return stringField(part.state.metadata, 'sessionId')
+    || stringField(part.state.metadata, 'sessionID')
+    || stringField(part.state.metadata, 'session_id')
+    || stringField(part.metadata, 'sessionId')
+    || stringField(part.metadata, 'sessionID')
+    || stringField(part.metadata, 'session_id')
+}
+
 export async function projectSessionHistory(input: ProjectSessionHistoryInput): Promise<ProjectedHistoryItem[]> {
   const { sessionId, cachedModelId, rootMessages, rootTodos, statuses, loadChildSnapshot } = input
   const generateId = input.generateId || crypto.randomUUID
@@ -181,6 +190,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   const children = (input.children || [])
     .slice()
     .sort((a, b) => (a?.time?.created || 0) - (b?.time?.created || 0))
+  const childrenById = new Map(children.map((child) => [child.id, child]))
   const directChildren = children.filter((child) => (child.parentSessionId || sessionId) === sessionId)
   const rootStatus = statusFor(sessionId).type || null
   const childCompletesById = new Map<string, boolean>()
@@ -246,6 +256,17 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
   const childBelongsToParent = (child: ChildSessionRecord, parentSessionId: string) => {
     return (child.parentSessionId || sessionId) === parentSessionId
+  }
+
+  const takeExplicitChildForTaskTool = (parentSessionId: string, part: NormalizedMessagePart) => {
+    const childSessionId = taskToolChildSessionId(part)
+    if (!childSessionId) return { child: null, hasExplicitChild: false }
+    const child = childrenById.get(childSessionId)
+    if (!child || matchedChildIds.has(child.id) || !childBelongsToParent(child, parentSessionId)) {
+      return { child: null, hasExplicitChild: true }
+    }
+    matchedChildIds.add(child.id)
+    return { child, hasExplicitChild: true }
   }
 
   const takeChildForTaskTool = (
@@ -405,9 +426,12 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       if (part.type === 'tool' && part.tool === 'task') {
         const fallbackStatus = fallbackTaskToolStatus(part)
         const requireTaskMatch = fallbackStatus === 'complete' || fallbackStatus === 'error'
-        const child = takeDirectChildForSubtask((candidate) => {
-          return !requireTaskMatch || childLooksLikeTaskTool(part, candidate)
-        })
+        const explicit = takeExplicitChildForTaskTool(sessionId, part)
+        const child = explicit.child || (explicit.hasExplicitChild
+          ? null
+          : takeDirectChildForSubtask((candidate) => {
+              return !requireTaskMatch || childLooksLikeTaskTool(part, candidate)
+            }))
         const taskId = child?.id
           ? `child:${child.id}`
           : `pending:${part.callId || part.id || generateId()}`
@@ -610,7 +634,10 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         if (part.type === 'tool' && part.tool === 'task') {
           const fallbackStatus = fallbackTaskToolStatus(part)
           const requireTaskMatch = fallbackStatus === 'complete' || fallbackStatus === 'error'
-          const nestedChild = takeChildForTaskTool(child.id, part, requireTaskMatch)
+          const explicit = takeExplicitChildForTaskTool(child.id, part)
+          const nestedChild = explicit.child || (explicit.hasExplicitChild
+            ? null
+            : takeChildForTaskTool(child.id, part, requireTaskMatch))
           const nestedTaskId = nestedChild?.id
             ? `child:${nestedChild.id}`
             : `pending:${part.callId || part.id || generateId()}`
@@ -627,7 +654,10 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
             startedAt: timing.startedAt,
             finishedAt: timing.finishedAt,
           }, ts, tsMs)
-          if (nestedChild) enqueueChildTask(nestedTaskId, nestedChild)
+          if (nestedChild) {
+            matchedChildIds.add(nestedChild.id)
+            enqueueChildTask(nestedTaskId, nestedChild)
+          }
           continue
         }
 

--- a/apps/desktop/src/main/session-registry-utils.ts
+++ b/apps/desktop/src/main/session-registry-utils.ts
@@ -24,6 +24,33 @@ const MANAGED_SESSION_PATTERNS = [
   /\bForked [^\n]* -> (ses_[A-Za-z0-9]+)\b/g,
 ]
 
+function normalizeSessionTokens(tokens: SessionUsageSummary['tokens'] | undefined | null) {
+  return {
+    input: typeof tokens?.input === 'number' ? tokens.input : 0,
+    output: typeof tokens?.output === 'number' ? tokens.output : 0,
+    reasoning: typeof tokens?.reasoning === 'number' ? tokens.reasoning : 0,
+    cacheRead: typeof tokens?.cacheRead === 'number' ? tokens.cacheRead : 0,
+    cacheWrite: typeof tokens?.cacheWrite === 'number' ? tokens.cacheWrite : 0,
+  }
+}
+
+function normalizeAgentBreakdown(value: unknown): SessionUsageSummary['agentBreakdown'] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const entries = value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
+      const record = entry as Partial<NonNullable<SessionUsageSummary['agentBreakdown']>[number]>
+      return {
+        agent: typeof record.agent === 'string' ? record.agent : null,
+        taskRuns: typeof record.taskRuns === 'number' ? record.taskRuns : 0,
+        cost: typeof record.cost === 'number' ? record.cost : 0,
+        tokens: normalizeSessionTokens(record.tokens),
+      }
+    })
+    .filter((entry): entry is NonNullable<SessionUsageSummary['agentBreakdown']>[number] => entry !== null)
+  return entries.length > 0 ? entries : undefined
+}
+
 export function extractManagedSessionIdsFromLogContents(logContents: string[]) {
   const managed = new Set<string>()
 
@@ -76,13 +103,8 @@ export function normalizeStoredSessionRecord(
           toolCalls: typeof item.summary.toolCalls === 'number' ? item.summary.toolCalls : 0,
           taskRuns: typeof item.summary.taskRuns === 'number' ? item.summary.taskRuns : 0,
           cost: typeof item.summary.cost === 'number' ? item.summary.cost : 0,
-          tokens: {
-            input: typeof item.summary.tokens?.input === 'number' ? item.summary.tokens.input : 0,
-            output: typeof item.summary.tokens?.output === 'number' ? item.summary.tokens.output : 0,
-            reasoning: typeof item.summary.tokens?.reasoning === 'number' ? item.summary.tokens.reasoning : 0,
-            cacheRead: typeof item.summary.tokens?.cacheRead === 'number' ? item.summary.tokens.cacheRead : 0,
-            cacheWrite: typeof item.summary.tokens?.cacheWrite === 'number' ? item.summary.tokens.cacheWrite : 0,
-          },
+          tokens: normalizeSessionTokens(item.summary.tokens),
+          agentBreakdown: normalizeAgentBreakdown(item.summary.agentBreakdown),
         }
       : null,
     parentSessionId: typeof item.parentSessionId === 'string' ? item.parentSessionId : null,

--- a/apps/desktop/src/main/thread-index-service.ts
+++ b/apps/desktop/src/main/thread-index-service.ts
@@ -43,6 +43,36 @@ function addTokens(target: SessionTokens, source?: Partial<SessionTokens> | null
   target.cacheWrite += source.cacheWrite || 0
 }
 
+function hasUsableThreadView(view?: SessionView | null) {
+  return Boolean(view && (
+    view.messages.length
+    || view.toolCalls.length
+    || view.taskRuns.length
+    || view.sessionCost
+  ))
+}
+
+function hasAuthoritativeThreadView(view?: SessionView | null): view is SessionView {
+  if (!view) return false
+  return Boolean(
+    hasUsableThreadView(view)
+    || view.revision > 0
+    || view.lastEventAt > 0
+    || view.pendingApprovals.length
+    || view.pendingQuestions.length
+    || view.errors.length
+    || view.todos.length
+    || view.executionPlan.length
+    || view.compactions.length
+    || view.isGenerating
+    || view.isAwaitingPermission
+    || view.isAwaitingQuestion
+    || view.contextState !== 'idle'
+    || view.compactionCount > 0
+    || Boolean(view.lastCompactedAt)
+  )
+}
+
 function usageFromRecordAndView(record: SessionRecord, view?: SessionView | null): {
   messages: number
   toolCalls: number
@@ -50,7 +80,7 @@ function usageFromRecordAndView(record: SessionRecord, view?: SessionView | null
   cost: number
   tokens: SessionTokens
 } {
-  if (view && (view.messages.length || view.toolCalls.length || view.taskRuns.length || view.sessionCost)) {
+  if (view && hasUsableThreadView(view)) {
     const tokens = emptyTokens()
     addTokens(tokens, view.sessionTokens)
     for (const taskRun of view.taskRuns) {
@@ -81,8 +111,11 @@ function agentsFromRecordAndView(record: SessionRecord, view?: SessionView | nul
     if (!normalized) return
     counts.set(normalized, (counts.get(normalized) || 0) + count)
   }
-  for (const taskRun of view?.taskRuns || []) add(taskRun.agent)
-  for (const entry of record.summary?.agentBreakdown || []) add(entry.agent, entry.taskRuns || 1)
+  if (view) {
+    for (const taskRun of view.taskRuns) add(taskRun.agent)
+  } else {
+    for (const entry of record.summary?.agentBreakdown || []) add(entry.agent, entry.taskRuns || 1)
+  }
   return Array.from(counts.entries())
     .map(([name, count]) => ({ name, count }))
     .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
@@ -142,11 +175,13 @@ function projectLabel(directory?: string | null) {
 }
 
 function threadInputFromRecord(record: SessionRecord, view?: SessionView | null): ThreadIndexUpsertInput {
-  const usage = usageFromRecordAndView(record, view)
-  const actualAgents = view || record.summary?.agentBreakdown !== undefined
-    ? agentsFromRecordAndView(record, view)
+  const statusView = hasAuthoritativeThreadView(view) ? view : null
+  const metadataView = view && hasUsableThreadView(view) ? view : null
+  const usage = usageFromRecordAndView(record, metadataView)
+  const actualAgents = metadataView || record.summary?.agentBreakdown !== undefined
+    ? agentsFromRecordAndView(record, metadataView)
     : undefined
-  const actualTools = view ? toolsFromView(view) : undefined
+  const actualTools = metadataView ? toolsFromView(metadataView) : undefined
   return {
     sessionId: record.id,
     title: record.title || 'New session',
@@ -155,7 +190,7 @@ function threadInputFromRecord(record: SessionRecord, view?: SessionView | null)
     projectLabel: projectLabel(record.directory),
     providerId: record.providerId,
     modelId: record.modelId,
-    status: statusFromRecordAndView(record, view),
+    status: statusFromRecordAndView(record, statusView),
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     parentSessionId: record.parentSessionId,
@@ -236,8 +271,10 @@ export class ThreadIndexService {
 
   upsertThreadFromSessionRecord(record: SessionRecord, view?: SessionView | null) {
     try {
-      const existing = view ? null : this.store.getThread(record.id)
       const input = threadInputFromRecord(record, view)
+      const existing = input.actualAgents === undefined || input.actualTools === undefined
+        ? this.store.getThread(record.id)
+        : null
       this.store.upsertThread(input)
       const actualAgents = input.actualAgents ?? existing?.actualAgents ?? []
       const actualTools = input.actualTools ?? existing?.actualTools ?? []

--- a/tests/runtime-tools.test.ts
+++ b/tests/runtime-tools.test.ts
@@ -1,6 +1,15 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { isVisibleRuntimeToolId, toRuntimeToolMetadata } from '../apps/desktop/src/main/runtime-tools.ts'
+import { invalidateRuntimeToolCache } from '../apps/desktop/src/main/runtime-tool-cache.ts'
+import { runtimeState } from '../apps/desktop/src/main/runtime-state.ts'
+import {
+  isVisibleRuntimeToolId,
+  listRuntimeToolsForResolvedContext,
+  runtimeToolId,
+  toRuntimeToolMetadata,
+} from '../apps/desktop/src/main/runtime-tools.ts'
+
+type RuntimeClient = Parameters<typeof runtimeState.setClient>[0]
 
 test('internal OpenCode runtime tools are hidden from Cowork tool catalogs', () => {
   assert.equal(isVisibleRuntimeToolId('skill'), false)
@@ -32,4 +41,106 @@ test('runtime tool metadata skips hidden internal tools', () => {
     }),
     { id: 'websearch', description: 'Search the web.' },
   )
+})
+
+test('runtime tool discovery coalesces concurrent calls and reuses the cache', async () => {
+  let calls = 0
+  let releaseDiscovery!: () => void
+  const discoveryGate = new Promise<void>((resolve) => {
+    releaseDiscovery = resolve
+  })
+  const fakeClient = {
+    tool: {
+      list: async (request: Record<string, unknown>) => {
+        calls += 1
+        assert.equal(request.directory, '/workspace/large-mcp-catalog')
+        assert.equal(request.provider, 'openrouter')
+        assert.equal(request.model, 'openrouter/model')
+        await discoveryGate
+        return {
+          data: [
+            { id: 'bash', description: 'Run shell commands.' },
+            { id: 'skill', description: 'Hidden runtime implementation detail.' },
+          ],
+        }
+      },
+    },
+  }
+
+  invalidateRuntimeToolCache()
+  runtimeState.setClient(fakeClient as RuntimeClient)
+  runtimeState.setServerUrl(null)
+  try {
+    const request = {
+      directory: '/workspace/large-mcp-catalog',
+      provider: 'openrouter',
+      model: 'openrouter/model',
+    }
+    const first = listRuntimeToolsForResolvedContext(request)
+    const second = listRuntimeToolsForResolvedContext(request)
+    releaseDiscovery()
+
+    const [firstTools, secondTools] = await Promise.all([first, second])
+    assert.equal(calls, 1)
+    assert.deepEqual(firstTools.map(runtimeToolId), ['bash'])
+    assert.deepEqual(secondTools.map(runtimeToolId), ['bash'])
+
+    const cachedTools = await listRuntimeToolsForResolvedContext(request)
+    assert.equal(calls, 1)
+    assert.deepEqual(cachedTools.map(runtimeToolId), ['bash'])
+  } finally {
+    invalidateRuntimeToolCache()
+    runtimeState.resetAfterStop()
+  }
+})
+
+test('runtime tool discovery does not cache stale in-flight results after invalidation', async () => {
+  let calls = 0
+  let releaseFirstDiscovery!: () => void
+  const firstDiscoveryGate = new Promise<void>((resolve) => {
+    releaseFirstDiscovery = resolve
+  })
+  const fakeClient = {
+    tool: {
+      list: async () => {
+        calls += 1
+        if (calls === 1) {
+          await firstDiscoveryGate
+        }
+        return {
+          data: [
+            { id: 'bash', description: 'Run shell commands.' },
+          ],
+        }
+      },
+    },
+  }
+
+  invalidateRuntimeToolCache()
+  runtimeState.setClient(fakeClient as RuntimeClient)
+  runtimeState.setServerUrl(null)
+  try {
+    const request = {
+      directory: '/workspace/cache-invalidation',
+      provider: 'openrouter',
+      model: 'openrouter/model',
+    }
+    const staleDiscovery = listRuntimeToolsForResolvedContext(request)
+    invalidateRuntimeToolCache()
+    releaseFirstDiscovery()
+
+    assert.deepEqual((await staleDiscovery).map(runtimeToolId), ['bash'])
+    assert.equal(calls, 1)
+
+    const freshDiscovery = await listRuntimeToolsForResolvedContext(request)
+    assert.deepEqual(freshDiscovery.map(runtimeToolId), ['bash'])
+    assert.equal(calls, 2)
+
+    const cachedFreshDiscovery = await listRuntimeToolsForResolvedContext(request)
+    assert.deepEqual(cachedFreshDiscovery.map(runtimeToolId), ['bash'])
+    assert.equal(calls, 2)
+  } finally {
+    invalidateRuntimeToolCache()
+    runtimeState.resetAfterStop()
+  }
 })

--- a/tests/session-history-loader.test.ts
+++ b/tests/session-history-loader.test.ts
@@ -185,6 +185,255 @@ test('createSessionHistoryService loads questions and updates provider/model fro
   })
 })
 
+test('createSessionHistoryService replaces SDK default titles from first user message', async () => {
+  const updates: Array<Record<string, unknown>> = []
+  const sdkTitleUpdates: Array<Record<string, unknown>> = []
+  const service = createSessionHistoryService({
+    getSessionClient: async () => ({
+      client: {
+        session: {
+          messages: async () => ({
+            data: [{
+              info: { id: 'user-message-1', role: 'user', time: { created: 1 } },
+              parts: [
+                { id: 'user-text-1', type: 'text', text: 'Please compare the Q2 launch risks and summarize the blockers.' },
+              ],
+            }],
+          }),
+          todo: async () => ({ data: [] }),
+          diff: async () => ({ data: [] }),
+          children: async () => ({ data: [] }),
+          status: async () => ({ data: {} }),
+          get: async () => ({
+            data: {
+              id: 'session-title-fallback',
+              title: 'New Session - 2026-05-19T12:07:39.243Z',
+              time: { created: 1, updated: 2 },
+            },
+          }),
+          update: async (input: Record<string, unknown>) => {
+            sdkTitleUpdates.push(input)
+            return { data: {} }
+          },
+        },
+      },
+      questionClient: {},
+      record: null,
+    }),
+    listPendingQuestions: async () => ({ data: [] }),
+    listPendingPermissions: async () => ({ data: [] }),
+    projectSessionHistory: async () => [],
+    getCachedModelId: () => '',
+    updateSessionRecord: (_sessionId, patch) => {
+      updates.push(patch)
+      return null
+    },
+    buildSessionUsageSummary: () => ({
+      messages: 0,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      taskRuns: 0,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    }),
+    sessionEngine: {
+      isHydrated: () => false,
+      activateSession: () => {},
+      setSessionFromHistory: () => {},
+      setPendingQuestions: () => {},
+      setPendingApprovals: () => {},
+      getSessionView: () => createEmptySessionView(),
+    },
+  })
+
+  await service.loadSessionHistory('session-title-fallback')
+
+  assert.deepEqual(sdkTitleUpdates, [{
+    sessionID: 'session-title-fallback',
+    title: 'Please compare the Q2 launch risks and summarize the blockers.',
+  }])
+  assert.equal(updates[0]?.title, 'Please compare the Q2 launch risks and summarize the blockers.')
+})
+
+test('createSessionHistoryService skips internal Cowork prompts for fallback titles', async () => {
+  const updates: Array<Record<string, unknown>> = []
+  const sdkTitleUpdates: Array<Record<string, unknown>> = []
+  const service = createSessionHistoryService({
+    getSessionClient: async () => ({
+      client: {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                info: { id: 'internal-message', role: 'user', time: { created: 1 } },
+                parts: [
+                  {
+                    id: 'internal-text',
+                    type: 'text',
+                    text: '[[OPEN_COWORK_INTERNAL_TEAM_CONTEXT]] Hidden workflow orchestration prompt.',
+                  },
+                ],
+              },
+              {
+                info: { id: 'user-message', role: 'user', time: { created: 2 } },
+                parts: [
+                  {
+                    id: 'user-text',
+                    type: 'text',
+                    text: 'Write a clear migration plan for the reporting pipeline.',
+                  },
+                ],
+              },
+            ],
+          }),
+          todo: async () => ({ data: [] }),
+          diff: async () => ({ data: [] }),
+          children: async () => ({ data: [] }),
+          status: async () => ({ data: {} }),
+          get: async () => ({
+            data: {
+              id: 'session-internal-title-fallback',
+              title: 'New session',
+              time: { created: 1, updated: 2 },
+            },
+          }),
+          update: async (input: Record<string, unknown>) => {
+            sdkTitleUpdates.push(input)
+            return { data: {} }
+          },
+        },
+      },
+      questionClient: {},
+      record: null,
+    }),
+    listPendingQuestions: async () => ({ data: [] }),
+    listPendingPermissions: async () => ({ data: [] }),
+    projectSessionHistory: async () => [],
+    getCachedModelId: () => '',
+    updateSessionRecord: (_sessionId, patch) => {
+      updates.push(patch)
+      return null
+    },
+    buildSessionUsageSummary: () => ({
+      messages: 0,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      taskRuns: 0,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    }),
+    sessionEngine: {
+      isHydrated: () => false,
+      activateSession: () => {},
+      setSessionFromHistory: () => {},
+      setPendingQuestions: () => {},
+      setPendingApprovals: () => {},
+      getSessionView: () => createEmptySessionView(),
+    },
+  })
+
+  await service.loadSessionHistory('session-internal-title-fallback')
+
+  assert.deepEqual(sdkTitleUpdates, [{
+    sessionID: 'session-internal-title-fallback',
+    title: 'Write a clear migration plan for the reporting pipeline.',
+  }])
+  assert.equal(updates[0]?.title, 'Write a clear migration plan for the reporting pipeline.')
+})
+
+test('createSessionHistoryService preserves product-owned workflow titles before prompt fallback', async () => {
+  const updates: Array<Record<string, unknown>> = []
+  const sdkTitleUpdates: Array<Record<string, unknown>> = []
+  const service = createSessionHistoryService({
+    getSessionClient: async () => ({
+      client: {
+        session: {
+          messages: async () => ({
+            data: [{
+              info: { id: 'workflow-prompt', role: 'user', time: { created: 1 } },
+              parts: [
+                { id: 'workflow-text', type: 'text', text: 'Help the user create and schedule a workflow.' },
+              ],
+            }],
+          }),
+          todo: async () => ({ data: [] }),
+          diff: async () => ({ data: [] }),
+          children: async () => ({ data: [] }),
+          status: async () => ({ data: {} }),
+          get: async () => ({
+            data: {
+              id: 'workflow-draft-session',
+              title: 'New session',
+              time: { created: 1, updated: 2 },
+            },
+          }),
+          update: async (input: Record<string, unknown>) => {
+            sdkTitleUpdates.push(input)
+            return { data: {} }
+          },
+        },
+      },
+      questionClient: {},
+      record: {
+        title: 'New workflow draft',
+      },
+    }),
+    listPendingQuestions: async () => ({ data: [] }),
+    listPendingPermissions: async () => ({ data: [] }),
+    projectSessionHistory: async () => [],
+    getCachedModelId: () => '',
+    updateSessionRecord: (_sessionId, patch) => {
+      updates.push(patch)
+      return null
+    },
+    buildSessionUsageSummary: () => ({
+      messages: 0,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      taskRuns: 0,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    }),
+    sessionEngine: {
+      isHydrated: () => false,
+      activateSession: () => {},
+      setSessionFromHistory: () => {},
+      setPendingQuestions: () => {},
+      setPendingApprovals: () => {},
+      getSessionView: () => createEmptySessionView(),
+    },
+  })
+
+  await service.loadSessionHistory('workflow-draft-session')
+
+  assert.deepEqual(sdkTitleUpdates, [{
+    sessionID: 'workflow-draft-session',
+    title: 'New workflow draft',
+  }])
+  assert.equal(updates[0]?.title, 'New workflow draft')
+})
+
 test('createSessionHistoryService honors activate:false during warm syncs', async () => {
   const view = createEmptySessionView()
   const calls = {

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -323,6 +323,67 @@ test('history projector anchors root task tool runs before the parent follow-up 
   assert.ok(taskRun.sequence < (finalMessage?.sequence || 0))
 })
 
+test('history projector binds task tool metadata session ids exactly once', async () => {
+  const childIds = ['child-a', 'child-b', 'child-c']
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-metadata',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-metadata-task-msg', role: 'assistant', time: { created: 10 } },
+      parts: childIds.map((childId, index) => ({
+        id: `root-task-part-${index}`,
+        type: 'tool',
+        tool: 'task',
+        callID: `task-call-${index}`,
+        state: {
+          status: 'completed',
+          input: {
+            agent: 'business-analyst',
+            description: `Generic delegation ${index}`,
+          },
+          output: 'done',
+          metadata: { sessionId: childId },
+        },
+      })),
+    }],
+    rootTodos: [],
+    children: childIds.map((childId, index) => ({
+      id: childId,
+      title: `SDK child session ${index}`,
+      parentSessionId: 'root-task-tool-metadata',
+      time: { created: 20 + index, updated: 30 + index },
+    })),
+    statuses: {
+      'root-task-tool-metadata': { type: 'idle' },
+      'child-a': { type: 'idle' },
+      'child-b': { type: 'idle' },
+      'child-c': { type: 'idle' },
+    },
+    loadChildSnapshot: async (childId) => ({
+      messages: [{
+        info: { id: `${childId}-msg`, role: 'assistant', time: { created: 40 } },
+        parts: [
+          { id: `${childId}-text`, type: 'text', text: `${childId} result` },
+          { id: `${childId}-finish`, type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const taskRuns = items.filter((item) => item.type === 'task_run')
+  assert.equal(taskRuns.length, 3)
+  assert.deepEqual(
+    taskRuns.map((item) => item.id),
+    ['child:child-a', 'child:child-b', 'child:child-c'],
+  )
+  assert.equal(taskRuns.some((item) => item.id.startsWith('pending:')), false)
+  assert.deepEqual(
+    taskRuns.map((item) => item.taskRun?.sourceSessionId),
+    childIds,
+  )
+})
+
 test('history projector does not bind a terminal task tool to a later unrelated child session', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-unrelated-child',
@@ -613,16 +674,16 @@ test('history projector binds nested task tools to grandchild sessions during re
                 type: 'tool',
                 tool: 'task',
                 callID: 'nested-task-call',
-                title: 'Deep dive into nested delegation',
+                title: 'Nested explicit metadata delegation',
                 state: {
                   status: 'completed',
                   input: {
                     agent: 'analyst',
-                    description: 'Deep dive into nested delegation',
-                    prompt: 'Deep dive into nested delegation',
+                    description: 'Nested explicit metadata delegation',
+                    prompt: 'Nested explicit metadata delegation',
                   },
                   output: 'started',
-                  metadata: {},
+                  metadata: { sessionId: 'grandchild-nested-task' },
                 },
               },
               { id: 'child-nested-after', type: 'text', text: 'After nested delegation.' },

--- a/tests/session-registry-utils.test.ts
+++ b/tests/session-registry-utils.test.ts
@@ -52,3 +52,35 @@ test('normalizeStoredSessionRecord keeps Cowork-managed records and drops extern
   })
   assert.equal(external, null)
 })
+
+test('normalizeStoredSessionRecord preserves session usage agent breakdowns', () => {
+  const record = normalizeStoredSessionRecord({
+    id: 'ses_summary',
+    opencodeDirectory: '/runtime-home',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:01.000Z',
+    managedByCowork: true,
+    summary: {
+      messages: 3,
+      userMessages: 1,
+      assistantMessages: 2,
+      toolCalls: 1,
+      taskRuns: 2,
+      cost: 0.25,
+      tokens: { input: 10, output: 20, reasoning: 3, cacheRead: 4, cacheWrite: 5 },
+      agentBreakdown: [{
+        agent: 'business-analyst',
+        taskRuns: 2,
+        cost: 0.25,
+        tokens: { input: 10, output: 20, reasoning: 3, cacheRead: 4, cacheWrite: 5 },
+      }],
+    },
+  }, (value) => value, () => null)
+
+  assert.deepEqual(record?.summary?.agentBreakdown, [{
+    agent: 'business-analyst',
+    taskRuns: 2,
+    cost: 0.25,
+    tokens: { input: 10, output: 20, reasoning: 3, cacheRead: 4, cacheWrite: 5 },
+  }])
+})

--- a/tests/thread-index-service.test.ts
+++ b/tests/thread-index-service.test.ts
@@ -3,10 +3,39 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import type { SessionView } from '@open-cowork/shared'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { clearSessionRegistryCache, removeSessionRecord, toSessionRecord, updateSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
 import { ThreadIndexService } from '../apps/desktop/src/main/thread-index-service.ts'
 import { ThreadIndexStore } from '../apps/desktop/src/main/thread-index-store.ts'
+
+function emptySessionView(overrides: Partial<SessionView> = {}): SessionView {
+  return {
+    messages: [],
+    toolCalls: [],
+    taskRuns: [],
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision: 0,
+    lastEventAt: 0,
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+    ...overrides,
+  }
+}
 
 function withThreadIndexService(name: string, run: (service: ThreadIndexService) => void) {
   const root = mkdtempSync(join(tmpdir(), `open-cowork-thread-service-${name}-`))
@@ -132,6 +161,261 @@ test('thread index service stores actual metadata and suggestion-only categories
   assert.equal(thread.usage.messages, 1)
   assert.equal(thread.usage.taskRuns, 1)
   assert.equal(thread.usage.tokens.input, 11)
+}))
+
+test('thread index service does not add persisted agent summaries on top of live views', () => withThreadIndexService('agent-dedup', (service) => {
+  const record = upsertSessionRecord(toSessionRecord({
+    id: 'session-agent-dedup',
+    title: 'Delegated analysis',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    opencodeDirectory: '/workspace/analytics',
+    summary: {
+      messages: 2,
+      userMessages: 1,
+      assistantMessages: 1,
+      toolCalls: 0,
+      taskRuns: 2,
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      agentBreakdown: [{
+        agent: 'business-analyst',
+        taskRuns: 2,
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      }],
+    },
+  }))
+  assert.ok(record)
+
+  service.upsertThreadFromSessionRecord(record, {
+    messages: [{ id: 'm1', role: 'user', content: 'delegate twice', order: 1 }],
+    toolCalls: [],
+    taskRuns: ['task-1', 'task-2'].map((id, index) => ({
+      id,
+      title: `Analysis ${index + 1}`,
+      agent: 'business-analyst',
+      status: 'complete',
+      sourceSessionId: `child-${index + 1}`,
+      content: '',
+      transcript: [],
+      toolCalls: [],
+      compactions: [],
+      todos: [],
+      error: null,
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      order: index + 2,
+    })),
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision: 1,
+    lastEventAt: Date.now(),
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+  })
+
+  const result = service.search({ text: 'analysis' })
+  assert.equal(result.threads.length, 1)
+  assert.deepEqual(result.threads[0]?.actualAgents, [{ name: 'business-analyst', count: 2 }])
+  assert.equal(result.threads[0]?.usage.taskRuns, 2)
+}))
+
+test('thread index service clears persisted agents when a live view has no task runs', () => withThreadIndexService('agent-clear', (service) => {
+  const record = upsertSessionRecord(toSessionRecord({
+    id: 'session-agent-clear',
+    title: 'Analysis without delegation',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    opencodeDirectory: '/workspace/analytics',
+    summary: {
+      messages: 2,
+      userMessages: 1,
+      assistantMessages: 1,
+      toolCalls: 0,
+      taskRuns: 1,
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      agentBreakdown: [{
+        agent: 'business-analyst',
+        taskRuns: 1,
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      }],
+    },
+  }))
+  assert.ok(record)
+
+  service.upsertThreadFromSessionRecord(record, {
+    messages: [{ id: 'm1', role: 'user', content: 'delegate once', order: 1 }],
+    toolCalls: [],
+    taskRuns: [{
+      id: 'task-1',
+      title: 'Analysis',
+      agent: 'business-analyst',
+      status: 'complete',
+      sourceSessionId: 'child-1',
+      content: '',
+      transcript: [],
+      toolCalls: [],
+      compactions: [],
+      todos: [],
+      error: null,
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      order: 2,
+    }],
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision: 1,
+    lastEventAt: Date.now(),
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+  })
+  assert.deepEqual(
+    service.search({ text: 'analysis' }).threads[0]?.actualAgents,
+    [{ name: 'business-analyst', count: 1 }],
+  )
+
+  service.upsertThreadFromSessionRecord(record, {
+    messages: [{ id: 'm1', role: 'user', content: 'analyze locally', order: 1 }],
+    toolCalls: [],
+    taskRuns: [],
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision: 1,
+    lastEventAt: Date.now(),
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+  })
+
+  const result = service.search({ text: 'analysis' })
+  assert.equal(result.threads.length, 1)
+  assert.deepEqual(result.threads[0]?.actualAgents, [])
+  assert.equal(result.threads[0]?.usage.taskRuns, 0)
+  assert.equal(service.search({ agents: ['business-analyst'] }).threads.length, 0)
+}))
+
+test('thread index service preserves persisted agents for unhydrated empty views', () => withThreadIndexService('agent-unhydrated', (service) => {
+  const record = upsertSessionRecord(toSessionRecord({
+    id: 'session-agent-unhydrated',
+    title: 'Historical analysis',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    opencodeDirectory: '/workspace/analytics',
+    summary: {
+      messages: 4,
+      userMessages: 2,
+      assistantMessages: 2,
+      toolCalls: 1,
+      taskRuns: 2,
+      cost: 0.25,
+      tokens: { input: 10, output: 20, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      agentBreakdown: [{
+        agent: 'business-analyst',
+        taskRuns: 2,
+        cost: 0.25,
+        tokens: { input: 10, output: 20, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      }],
+    },
+  }))
+  assert.ok(record)
+
+  service.upsertThreadFromSessionRecord(record, emptySessionView())
+
+  const result = service.search({ agents: ['business-analyst'] })
+  assert.equal(result.threads.length, 1)
+  assert.deepEqual(result.threads[0]?.actualAgents, [{ name: 'business-analyst', count: 2 }])
+  assert.equal(result.threads[0]?.usage.taskRuns, 2)
+}))
+
+test('thread index service preserves metadata rows during status-only view refreshes', () => withThreadIndexService('status-only-metadata', (service) => {
+  const record = upsertSessionRecord(toSessionRecord({
+    id: 'session-status-only',
+    title: 'Historical chart analysis',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    opencodeDirectory: '/workspace/analytics',
+    summary: {
+      messages: 4,
+      userMessages: 2,
+      assistantMessages: 2,
+      toolCalls: 1,
+      taskRuns: 1,
+      cost: 0.25,
+      tokens: { input: 10, output: 20, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      agentBreakdown: [{
+        agent: 'business-analyst',
+        taskRuns: 1,
+        cost: 0.25,
+        tokens: { input: 10, output: 20, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      }],
+    },
+  }))
+  assert.ok(record)
+
+  service.upsertThreadFromSessionRecord(record, {
+    ...emptySessionView({ revision: 1, lastEventAt: Date.now() }),
+    messages: [{ id: 'm1', role: 'user', content: 'make a chart', order: 1 }],
+    toolCalls: [{ id: 'tool-1', name: 'charts.create', input: {}, status: 'complete', order: 2 }],
+    taskRuns: [],
+  })
+  assert.deepEqual(
+    service.search({ text: 'charts.create' }).threads[0]?.actualTools,
+    [{ name: 'charts.create', mcpName: 'charts', count: 1 }],
+  )
+
+  service.upsertThreadFromSessionRecord(record, emptySessionView({
+    revision: 2,
+    lastEventAt: Date.now(),
+    isGenerating: true,
+  }))
+
+  const result = service.search({ agents: ['business-analyst'], tools: ['charts.create'] })
+  assert.equal(result.threads.length, 1)
+  assert.deepEqual(result.threads[0]?.actualAgents, [{ name: 'business-analyst', count: 1 }])
+  assert.deepEqual(result.threads[0]?.actualTools, [{ name: 'charts.create', mcpName: 'charts', count: 1 }])
+  assert.equal(result.threads[0]?.status, 'running')
+  assert.equal(result.threads[0]?.usage.taskRuns, 1)
 }))
 
 test('thread index service preserves view-derived tools during record-only updates', () => withThreadIndexService('partial-metadata', (service) => {


### PR DESCRIPTION
## Summary
- bind replayed task tool parts to OpenCode child sessions from explicit metadata.sessionId before heuristic matching
- prevent thread index agent counts from adding persisted summaries on top of live task-run views
- auto-rename SDK default thread titles from the first user message without making provider/model title-generation calls
- route agent catalog runtime-tool discovery through the shared cached/coalesced path, with stale in-flight cache writes blocked after invalidation
- add timing logs around agents:list, agents:catalog, and agents:runtime so slow downstream catalogs are visible

Closes #376.
Closes #377.
Closes #378.
Closes #379.

## Validation
- node --no-warnings --experimental-sqlite --experimental-strip-types tests/session-history-projector.test.ts
- node --no-warnings --experimental-sqlite --experimental-strip-types tests/thread-index-service.test.ts
- node --no-warnings --experimental-sqlite --experimental-strip-types tests/session-history-loader.test.ts
- node --no-warnings --experimental-sqlite --experimental-strip-types tests/runtime-tools.test.ts
- node --no-warnings --experimental-sqlite --experimental-strip-types tests/custom-agents-regression.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:e2e
- git diff --check