### PR TITLE
Scale catalog and thread loading

### DIFF
--- a/apps/desktop/src/main/bundled-skill-index.ts
+++ b/apps/desktop/src/main/bundled-skill-index.ts
@@ -10,8 +10,19 @@ export type BundledSkillIndexEntry = {
 }
 
 type CachedBundledSkillIndex = {
-  key: string
+  rootsKey: string
+  treeKey: string
   index: Map<string, BundledSkillIndexEntry>
+}
+
+type BundledSkillRoot = {
+  requestedRoot: string
+  realRoot: string
+}
+
+type BundledSkillRootScan = {
+  entries: BundledSkillIndexEntry[]
+  treeKey: string
 }
 
 let cachedIndex: CachedBundledSkillIndex | null = null
@@ -26,52 +37,62 @@ function isInsideRoot(root: string, candidate: string) {
   )
 }
 
-function isSafeDirectoryInsideRoot(root: string, candidate: string) {
-  const absoluteRoot = resolve(root)
+function resolveBundledSkillRoot(root: string): BundledSkillRoot | null {
+  const requestedRoot = resolve(root)
+  if (!existsSync(requestedRoot)) return null
+
+  try {
+    const realRoot = realpathSync.native(requestedRoot)
+    if (!statSync(realRoot).isDirectory()) return null
+    return { requestedRoot, realRoot }
+  } catch {
+    return null
+  }
+}
+
+function isSafeDirectoryInsideRoot(root: BundledSkillRoot, candidate: string) {
   const absoluteCandidate = resolve(candidate)
-  if (!isInsideRoot(absoluteRoot, absoluteCandidate)) return false
+  if (!isInsideRoot(root.requestedRoot, absoluteCandidate)) return false
   if (!existsSync(absoluteCandidate)) return false
 
   try {
     if (lstatSync(absoluteCandidate).isSymbolicLink()) return false
-    const realRoot = realpathSync.native(absoluteRoot)
     const realCandidate = realpathSync.native(absoluteCandidate)
-    if (!isInsideRoot(realRoot, realCandidate)) return false
+    if (!isInsideRoot(root.realRoot, realCandidate)) return false
     return statSync(realCandidate).isDirectory()
   } catch {
     return false
   }
 }
 
-function isSafeSkillDefinition(root: string, skillPath: string) {
-  const absoluteRoot = resolve(root)
+function isSafeSkillDefinition(root: BundledSkillRoot, skillPath: string) {
   const absoluteSkillPath = resolve(skillPath)
-  if (!isInsideRoot(absoluteRoot, absoluteSkillPath)) return false
+  if (!isInsideRoot(root.requestedRoot, absoluteSkillPath)) return false
   if (!existsSync(absoluteSkillPath)) return false
 
   try {
     if (lstatSync(absoluteSkillPath).isSymbolicLink()) return false
-    const realRoot = realpathSync.native(absoluteRoot)
     const realSkillPath = realpathSync.native(absoluteSkillPath)
-    if (!isInsideRoot(realRoot, realSkillPath)) return false
+    if (!isInsideRoot(root.realRoot, realSkillPath)) return false
     return statSync(realSkillPath).isFile()
   } catch {
     return false
   }
 }
 
-function rootSignature(root: string) {
-  const resolvedRoot = resolve(root)
+function statsSignature(kind: 'dir' | 'file' | 'root', root: BundledSkillRoot, path: string) {
   try {
-    const stats = statSync(resolvedRoot)
-    return `${resolvedRoot}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}`
+    const realPath = realpathSync.native(path)
+    const stats = statSync(realPath)
+    const relativePath = relative(root.realRoot, realPath) || '.'
+    return `${kind}:${relativePath}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}`
   } catch {
-    return `${resolvedRoot}:missing`
+    return `${kind}:missing:${path}`
   }
 }
 
-function cacheKeyForRoots(roots: string[]) {
-  return roots.map(rootSignature).join('|')
+function cacheRootsKey(roots: string[]) {
+  return roots.map((root) => resolve(root)).join('|')
 }
 
 function entrySortKey(entry: BundledSkillIndexEntry) {
@@ -83,12 +104,16 @@ function shouldReplaceEntry(existing: BundledSkillIndexEntry | undefined, next: 
   return entrySortKey(next).localeCompare(entrySortKey(existing)) < 0
 }
 
-function scanBundledSkillRoot(root: string) {
-  const absoluteRoot = resolve(root)
-  if (!isSafeDirectoryInsideRoot(absoluteRoot, absoluteRoot)) return []
+function scanBundledSkillRoot(root: string): BundledSkillRootScan {
+  const resolvedRoot = resolveBundledSkillRoot(root)
+  if (!resolvedRoot) return { entries: [], treeKey: `${resolve(root)}:missing` }
 
   const entries: BundledSkillIndexEntry[] = []
-  const queue = [absoluteRoot]
+  const signatureParts = [
+    `root:${resolvedRoot.requestedRoot}:${resolvedRoot.realRoot}`,
+    statsSignature('root', resolvedRoot, resolvedRoot.realRoot),
+  ]
+  const queue = [resolvedRoot.requestedRoot]
   const visited = new Set<string>()
 
   for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
@@ -102,6 +127,7 @@ function scanBundledSkillRoot(root: string) {
     }
     if (visited.has(realCurrent)) continue
     visited.add(realCurrent)
+    signatureParts.push(statsSignature('dir', resolvedRoot, realCurrent))
 
     let children
     try {
@@ -109,18 +135,20 @@ function scanBundledSkillRoot(root: string) {
     } catch {
       continue
     }
+    signatureParts.push(`children:${relative(resolvedRoot.realRoot, realCurrent) || '.'}:${children.join('\u0000')}`)
 
     for (const child of children) {
       const candidate = join(current, child)
-      if (!isSafeDirectoryInsideRoot(absoluteRoot, candidate)) continue
+      if (!isSafeDirectoryInsideRoot(resolvedRoot, candidate)) continue
 
       const skillPath = join(candidate, 'SKILL.md')
-      if (isSafeSkillDefinition(absoluteRoot, skillPath)) {
-        const relativePath = relative(absoluteRoot, candidate)
+      if (isSafeSkillDefinition(resolvedRoot, skillPath)) {
+        const relativePath = relative(resolvedRoot.requestedRoot, candidate)
         const depth = relativePath ? relativePath.split(/[\\/]/).length : 0
+        signatureParts.push(statsSignature('file', resolvedRoot, skillPath))
         entries.push({
           name: basename(candidate),
-          root: absoluteRoot,
+          root: resolvedRoot.requestedRoot,
           skillDir: candidate,
           skillPath,
           depth,
@@ -131,7 +159,7 @@ function scanBundledSkillRoot(root: string) {
     }
   }
 
-  return entries
+  return { entries, treeKey: signatureParts.join('|') }
 }
 
 export function clearBundledSkillIndexCache() {
@@ -143,7 +171,7 @@ export function buildBundledSkillIndex(roots: string[]) {
 
   for (const root of roots.map((entry) => resolve(entry))) {
     const rootEntries = new Map<string, BundledSkillIndexEntry>()
-    for (const entry of scanBundledSkillRoot(root)) {
+    for (const entry of scanBundledSkillRoot(root).entries) {
       if (shouldReplaceEntry(rootEntries.get(entry.name), entry)) {
         rootEntries.set(entry.name, entry)
       }
@@ -160,11 +188,26 @@ export function buildBundledSkillIndex(roots: string[]) {
 }
 
 export function getBundledSkillIndex(roots: string[]) {
-  const key = cacheKeyForRoots(roots)
-  if (cachedIndex?.key === key) return cachedIndex.index
+  const rootsKey = cacheRootsKey(roots)
+  const scans = roots.map((root) => scanBundledSkillRoot(root))
+  const treeKey = scans.map((scan) => scan.treeKey).join('||')
+  if (cachedIndex?.rootsKey === rootsKey && cachedIndex.treeKey === treeKey) return cachedIndex.index
 
-  const index = buildBundledSkillIndex(roots)
-  cachedIndex = { key, index }
+  const index = new Map<string, BundledSkillIndexEntry>()
+  for (const scan of scans) {
+    const rootEntries = new Map<string, BundledSkillIndexEntry>()
+    for (const entry of scan.entries) {
+      if (shouldReplaceEntry(rootEntries.get(entry.name), entry)) {
+        rootEntries.set(entry.name, entry)
+      }
+    }
+    for (const [name, entry] of rootEntries.entries()) {
+      if (!index.has(name)) {
+        index.set(name, entry)
+      }
+    }
+  }
+  cachedIndex = { rootsKey, treeKey, index }
   return index
 }
 

--- a/apps/desktop/src/main/bundled-skill-index.ts
+++ b/apps/desktop/src/main/bundled-skill-index.ts
@@ -1,0 +1,173 @@
+import { existsSync, lstatSync, readdirSync, realpathSync, statSync } from 'fs'
+import { basename, isAbsolute, join, relative, resolve } from 'path'
+
+export type BundledSkillIndexEntry = {
+  name: string
+  root: string
+  skillDir: string
+  skillPath: string
+  depth: number
+}
+
+type CachedBundledSkillIndex = {
+  key: string
+  index: Map<string, BundledSkillIndexEntry>
+}
+
+let cachedIndex: CachedBundledSkillIndex | null = null
+
+function isInsideRoot(root: string, candidate: string) {
+  const relativePath = relative(root, candidate)
+  const firstSegment = relativePath.split(/[\\/]/, 1)[0]
+  return relativePath === '' || (
+    Boolean(relativePath)
+    && firstSegment !== '..'
+    && !isAbsolute(relativePath)
+  )
+}
+
+function isSafeDirectoryInsideRoot(root: string, candidate: string) {
+  const absoluteRoot = resolve(root)
+  const absoluteCandidate = resolve(candidate)
+  if (!isInsideRoot(absoluteRoot, absoluteCandidate)) return false
+  if (!existsSync(absoluteCandidate)) return false
+
+  try {
+    if (lstatSync(absoluteCandidate).isSymbolicLink()) return false
+    const realRoot = realpathSync.native(absoluteRoot)
+    const realCandidate = realpathSync.native(absoluteCandidate)
+    if (!isInsideRoot(realRoot, realCandidate)) return false
+    return statSync(realCandidate).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function isSafeSkillDefinition(root: string, skillPath: string) {
+  const absoluteRoot = resolve(root)
+  const absoluteSkillPath = resolve(skillPath)
+  if (!isInsideRoot(absoluteRoot, absoluteSkillPath)) return false
+  if (!existsSync(absoluteSkillPath)) return false
+
+  try {
+    if (lstatSync(absoluteSkillPath).isSymbolicLink()) return false
+    const realRoot = realpathSync.native(absoluteRoot)
+    const realSkillPath = realpathSync.native(absoluteSkillPath)
+    if (!isInsideRoot(realRoot, realSkillPath)) return false
+    return statSync(realSkillPath).isFile()
+  } catch {
+    return false
+  }
+}
+
+function rootSignature(root: string) {
+  const resolvedRoot = resolve(root)
+  try {
+    const stats = statSync(resolvedRoot)
+    return `${resolvedRoot}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}`
+  } catch {
+    return `${resolvedRoot}:missing`
+  }
+}
+
+function cacheKeyForRoots(roots: string[]) {
+  return roots.map(rootSignature).join('|')
+}
+
+function entrySortKey(entry: BundledSkillIndexEntry) {
+  return `${entry.depth.toString().padStart(6, '0')}:${entry.skillDir}`
+}
+
+function shouldReplaceEntry(existing: BundledSkillIndexEntry | undefined, next: BundledSkillIndexEntry) {
+  if (!existing) return true
+  return entrySortKey(next).localeCompare(entrySortKey(existing)) < 0
+}
+
+function scanBundledSkillRoot(root: string) {
+  const absoluteRoot = resolve(root)
+  if (!isSafeDirectoryInsideRoot(absoluteRoot, absoluteRoot)) return []
+
+  const entries: BundledSkillIndexEntry[] = []
+  const queue = [absoluteRoot]
+  const visited = new Set<string>()
+
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
+    const current = queue[queueIndex]
+
+    let realCurrent: string
+    try {
+      realCurrent = realpathSync.native(current)
+    } catch {
+      continue
+    }
+    if (visited.has(realCurrent)) continue
+    visited.add(realCurrent)
+
+    let children
+    try {
+      children = readdirSync(current).sort((a, b) => a.localeCompare(b))
+    } catch {
+      continue
+    }
+
+    for (const child of children) {
+      const candidate = join(current, child)
+      if (!isSafeDirectoryInsideRoot(absoluteRoot, candidate)) continue
+
+      const skillPath = join(candidate, 'SKILL.md')
+      if (isSafeSkillDefinition(absoluteRoot, skillPath)) {
+        const relativePath = relative(absoluteRoot, candidate)
+        const depth = relativePath ? relativePath.split(/[\\/]/).length : 0
+        entries.push({
+          name: basename(candidate),
+          root: absoluteRoot,
+          skillDir: candidate,
+          skillPath,
+          depth,
+        })
+      }
+
+      queue.push(candidate)
+    }
+  }
+
+  return entries
+}
+
+export function clearBundledSkillIndexCache() {
+  cachedIndex = null
+}
+
+export function buildBundledSkillIndex(roots: string[]) {
+  const index = new Map<string, BundledSkillIndexEntry>()
+
+  for (const root of roots.map((entry) => resolve(entry))) {
+    const rootEntries = new Map<string, BundledSkillIndexEntry>()
+    for (const entry of scanBundledSkillRoot(root)) {
+      if (shouldReplaceEntry(rootEntries.get(entry.name), entry)) {
+        rootEntries.set(entry.name, entry)
+      }
+    }
+
+    for (const [name, entry] of rootEntries.entries()) {
+      if (!index.has(name)) {
+        index.set(name, entry)
+      }
+    }
+  }
+
+  return index
+}
+
+export function getBundledSkillIndex(roots: string[]) {
+  const key = cacheKeyForRoots(roots)
+  if (cachedIndex?.key === key) return cachedIndex.index
+
+  const index = buildBundledSkillIndex(roots)
+  cachedIndex = { key, index }
+  return index
+}
+
+export function findBundledSkillDirInRoot(root: string, skillName: string) {
+  return buildBundledSkillIndex([root]).get(skillName)?.skillDir || null
+}

--- a/apps/desktop/src/main/custom-agents.ts
+++ b/apps/desktop/src/main/custom-agents.ts
@@ -3,6 +3,7 @@ import type { CustomAgentIssue, RuntimeContextOptions } from '@open-cowork/share
 import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
 import { listEffectiveSkills } from './effective-skills.ts'
 import { listRuntimeToolsForContext, toRuntimeToolMetadata } from './runtime-tools.ts'
+import { getEffectiveSettings } from './settings.ts'
 import {
   buildCustomAgentCatalog,
   buildRuntimeCustomAgents,
@@ -34,6 +35,66 @@ export type {
   RuntimeCustomAgent,
 }
 
+const CUSTOM_AGENT_CATALOG_CACHE_TTL_MS = 30_000
+const CUSTOM_AGENT_CATALOG_CACHE_MAX_ENTRIES = 64
+
+type AgentCatalogCacheEntry<T> = {
+  expiresAt: number
+  value?: T
+  promise?: Promise<T>
+}
+
+let customAgentCatalogCacheGeneration = 0
+const customAgentCatalogCache = new Map<string, AgentCatalogCacheEntry<CustomAgentCatalog>>()
+const customAgentSummaryCache = new Map<string, AgentCatalogCacheEntry<CustomAgentSummary[]>>()
+
+export function invalidateCustomAgentCatalogCache() {
+  customAgentCatalogCacheGeneration += 1
+  customAgentCatalogCache.clear()
+  customAgentSummaryCache.clear()
+}
+
+function cacheKeyForContext(options?: RuntimeContextOptions) {
+  const settings = getEffectiveSettings()
+  return JSON.stringify({
+    generation: customAgentCatalogCacheGeneration,
+    directory: options?.directory || null,
+    provider: settings.effectiveProviderId || '',
+    model: settings.effectiveModel || '',
+  })
+}
+
+async function getCachedAgentCatalog<T>(
+  cache: Map<string, AgentCatalogCacheEntry<T>>,
+  key: string,
+  load: () => Promise<T>,
+) {
+  const now = Date.now()
+  const cached = cache.get(key)
+  if (cached?.value !== undefined && cached.expiresAt > now) return cached.value
+  if (cached?.promise) return await cached.promise
+
+  const remember = (entry: AgentCatalogCacheEntry<T>) => {
+    cache.set(key, entry)
+    while (cache.size > CUSTOM_AGENT_CATALOG_CACHE_MAX_ENTRIES) {
+      const oldestKey = cache.keys().next().value
+      if (typeof oldestKey !== 'string') break
+      cache.delete(oldestKey)
+    }
+  }
+
+  const promise = load()
+  remember({ expiresAt: now + CUSTOM_AGENT_CATALOG_CACHE_TTL_MS, promise })
+  try {
+    const value = await promise
+    remember({ expiresAt: Date.now() + CUSTOM_AGENT_CATALOG_CACHE_TTL_MS, value })
+    return value
+  } catch (error) {
+    if (cache.get(key)?.promise === promise) cache.delete(key)
+    throw error
+  }
+}
+
 function getCustomAgentState(options?: RuntimeContextOptions): CustomAgentCatalogState {
   return {
     customMcps: listCustomMcps(options),
@@ -43,6 +104,11 @@ function getCustomAgentState(options?: RuntimeContextOptions): CustomAgentCatalo
 }
 
 export async function getCustomAgentCatalog(options?: RuntimeContextOptions): Promise<CustomAgentCatalog> {
+  return getCachedAgentCatalog(customAgentCatalogCache, cacheKeyForContext(options), () =>
+    buildCustomAgentCatalogForContext(options))
+}
+
+async function buildCustomAgentCatalogForContext(options?: RuntimeContextOptions): Promise<CustomAgentCatalog> {
   const state = getCustomAgentState(options)
   const runtimeTools = (await listRuntimeToolsForContext(options))
     .map(toRuntimeToolMetadata)
@@ -69,6 +135,11 @@ export async function getCustomAgentCatalog(options?: RuntimeContextOptions): Pr
 }
 
 export async function getCustomAgentSummaries(options?: RuntimeContextOptions): Promise<CustomAgentSummary[]> {
+  return getCachedAgentCatalog(customAgentSummaryCache, cacheKeyForContext(options), () =>
+    buildCustomAgentSummariesForContext(options))
+}
+
+async function buildCustomAgentSummariesForContext(options?: RuntimeContextOptions): Promise<CustomAgentSummary[]> {
   const state = getCustomAgentState(options)
   const runtimeTools = (await listRuntimeToolsForContext(options))
     .map(toRuntimeToolMetadata)

--- a/apps/desktop/src/main/effective-skills.ts
+++ b/apps/desktop/src/main/effective-skills.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from 'fs'
-import { dirname, isAbsolute, join, relative, resolve } from 'path'
+import { isAbsolute, join, relative, resolve } from 'path'
 import {
   extractSkillFrontmatterField,
   type CapabilitySkillBundle,
@@ -8,9 +8,11 @@ import {
 import { getConfiguredSkillsFromConfig } from './config-loader.ts'
 import { getCustomSkill, listCustomSkills } from './native-customizations.ts'
 import type { NativeConfigScope } from './runtime-paths.ts'
-import { findBundledSkillDir as findBundledSkillDirInRoot, getBundledSkillRoots } from './runtime-content.ts'
+import { getBundledSkillRoots } from './runtime-content.ts'
+import { getBundledSkillIndex, type BundledSkillIndexEntry } from './bundled-skill-index.ts'
 import { log } from './logger.ts'
 import { validateOpenCodeSkillBundle } from './skill-bundle-validation.ts'
+import { measurePerf } from './perf-metrics.ts'
 
 export type EffectiveSkillDefinition = {
   name: string
@@ -27,6 +29,8 @@ export type EffectiveSkillDefinition = {
 export type EffectiveSkillBundle = Omit<CapabilitySkillBundle, 'files'> & {
   files: Array<{ path: string; content?: string }>
 }
+
+type ConfiguredSkill = ReturnType<typeof getConfiguredSkillsFromConfig>[number]
 
 function logSkippedSkill(name: string, source: 'builtin' | 'custom', issues: string[]) {
   if (issues.length === 0) return
@@ -99,18 +103,10 @@ function listBundleFiles(root: string, current = root): Array<{ path: string }> 
   return files.sort((a, b) => a.path.localeCompare(b.path))
 }
 
-// Walks every configured bundle root (downstream `skills/`, upstream
-// `skills/`, packaged resources) and recursively searches for a
-// directory named `skillName` containing a `SKILL.md`. Downstream
-// distributions commonly nest skills one level deep
-// (`skills/<product>/<skill-name>/SKILL.md`) — a shallow join would
-// miss those and the Capabilities UI would render an empty bundle.
-function findBundledSkillDir(skillName: string) {
+function findBundledSkillEntry(skillName: string) {
   const roots = getBundledSkillRoots()
-  for (const root of roots) {
-    const hit = findBundledSkillDirInRoot(root, skillName)
-    if (hit) return hit
-  }
+  const entry = getBundledSkillIndex(roots).get(skillName) || null
+  if (entry) return entry
   // Diagnostic — fires every time the Capabilities UI opens a skill
   // with no resolvable bundle. Prints the roots it actually searched so
   // downstream packaging issues (wrong `OPEN_COWORK_DOWNSTREAM_ROOT`,
@@ -125,69 +121,118 @@ function buildConfiguredSkillMap() {
   )
 }
 
+function readBundledSkillContent(entry: BundledSkillIndexEntry) {
+  try {
+    return readFileSync(entry.skillPath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+function buildBundledSkillDefinition(
+  skillName: string,
+  configured: ConfiguredSkill,
+  entry: BundledSkillIndexEntry | null,
+) {
+  if (!entry) {
+    log('capability', `Configured skill ${skillName} is not present in the bundled runtime roots and will not be advertised to agents.`)
+    return null
+  }
+  const content = readBundledSkillContent(entry)
+  if (!content) {
+    log('capability', `Configured skill ${skillName} is not present in the bundled runtime roots and will not be advertised to agents.`)
+    return null
+  }
+
+  const issues = validateOpenCodeSkillBundle({ name: skillName, content })
+  if (issues.length > 0) {
+    logSkippedSkill(skillName, 'builtin', issues)
+    return null
+  }
+
+  return {
+    name: skillName,
+    label: configured.name,
+    description: extractSkillFrontmatterField(content, 'description') || configured.description,
+    source: 'builtin' as const,
+    origin: 'open-cowork' as const,
+    scope: null,
+    location: resolve(entry.skillPath),
+    toolIds: configured.toolIds ? [...configured.toolIds] : undefined,
+    content,
+  } satisfies EffectiveSkillDefinition
+}
+
+function readBundledSkillBundle(
+  skill: EffectiveSkillDefinition,
+  entry: BundledSkillIndexEntry,
+): EffectiveSkillBundle {
+  return {
+    name: skill.name,
+    source: skill.source,
+    origin: skill.origin,
+    scope: skill.scope,
+    location: skill.location,
+    content: skill.content,
+    files: listBundleFiles(entry.skillDir)
+      .map((file) => {
+        const resolved = resolveBundleFilePath(entry.skillDir, file.path)
+        return resolved
+          ? {
+              path: file.path,
+              content: readFileSync(resolved, 'utf-8'),
+            }
+          : null
+      })
+      .filter((file): file is { path: string; content: string } => Boolean(file)),
+  }
+}
+
 export function listEffectiveSkillsSync(context?: RuntimeContextOptions): EffectiveSkillDefinition[] {
-  const configuredSkills = buildConfiguredSkillMap()
-  const managedCustomSkills = new Map(
-    listCustomSkills(context).map((skill) => [skill.name, skill] as const),
-  )
-  const skills = new Map<string, EffectiveSkillDefinition>()
+  return measurePerf('skills.effective.list', () => {
+    const configuredSkills = buildConfiguredSkillMap()
+    const managedCustomSkills = new Map(
+      listCustomSkills(context).map((skill) => [skill.name, skill] as const),
+    )
+    const bundledSkillIndex = getBundledSkillIndex(getBundledSkillRoots())
+    const skills = new Map<string, EffectiveSkillDefinition>()
 
-  for (const managed of managedCustomSkills.values()) {
-    const issues = validateOpenCodeSkillBundle({ name: managed.name, content: managed.content })
-    if (issues.length > 0) {
-      logSkippedSkill(managed.name, 'custom', issues)
-      continue
+    for (const managed of managedCustomSkills.values()) {
+      const issues = validateOpenCodeSkillBundle({ name: managed.name, content: managed.content })
+      if (issues.length > 0) {
+        logSkippedSkill(managed.name, 'custom', issues)
+        continue
+      }
+
+      skills.set(managed.name, {
+        name: managed.name,
+        label: extractSkillFrontmatterField(managed.content, 'title')
+          || extractSkillFrontmatterField(managed.content, 'name')
+          || humanize(managed.name),
+        description: extractSkillFrontmatterField(managed.content, 'description') || 'Custom skill',
+        source: 'custom',
+        origin: 'custom',
+        scope: managed.scope,
+        location: null,
+        // Surface the toolIds the custom skill declared in its frontmatter
+        // so the agent builder's "skill needs these tools" auto-attach hint
+        // works for custom skills too, not just upstream-configured ones.
+        toolIds: managed.toolIds?.length ? [...managed.toolIds] : undefined,
+        content: managed.content,
+      })
     }
 
-    skills.set(managed.name, {
-      name: managed.name,
-      label: extractSkillFrontmatterField(managed.content, 'title')
-        || extractSkillFrontmatterField(managed.content, 'name')
-        || humanize(managed.name),
-      description: extractSkillFrontmatterField(managed.content, 'description') || 'Custom skill',
-      source: 'custom',
-      origin: 'custom',
-      scope: managed.scope,
-      location: null,
-      // Surface the toolIds the custom skill declared in its frontmatter
-      // so the agent builder's "skill needs these tools" auto-attach hint
-      // works for custom skills too, not just upstream-configured ones.
-      toolIds: managed.toolIds?.length ? [...managed.toolIds] : undefined,
-      content: managed.content,
-    })
-  }
-
-  for (const [skillName, configured] of configuredSkills.entries()) {
-    if (skills.has(skillName)) continue
-    const bundledDir = findBundledSkillDir(skillName)
-    const bundledSkillPath = bundledDir ? join(bundledDir, 'SKILL.md') : null
-    const content = bundledSkillPath && existsSync(bundledSkillPath)
-      ? readFileSync(bundledSkillPath, 'utf-8')
-      : null
-    if (!content) {
-      log('capability', `Configured skill ${skillName} is not present in the bundled runtime roots and will not be advertised to agents.`)
-      continue
-    }
-    const issues = validateOpenCodeSkillBundle({ name: skillName, content })
-    if (issues.length > 0) {
-      logSkippedSkill(skillName, 'builtin', issues)
-      continue
+    for (const [skillName, configured] of configuredSkills.entries()) {
+      if (skills.has(skillName)) continue
+      const skill = buildBundledSkillDefinition(skillName, configured, bundledSkillIndex.get(skillName) || null)
+      if (skill) skills.set(skillName, skill)
     }
 
-    skills.set(skillName, {
-      name: skillName,
-      label: configured.name,
-      description: extractSkillFrontmatterField(content || '', 'description') || configured.description,
-      source: 'builtin',
-      origin: 'open-cowork',
-      scope: null,
-      location: bundledSkillPath ? resolve(bundledSkillPath) : null,
-      toolIds: configured.toolIds ? [...configured.toolIds] : undefined,
-      content,
-    })
-  }
-
-  return Array.from(skills.values()).sort((a, b) => a.label.localeCompare(b.label))
+    return Array.from(skills.values()).sort((a, b) => a.label.localeCompare(b.label))
+  }, {
+    slowThresholdMs: 100,
+    slowData: { context: context?.directory ? 'project' : 'global' },
+  })
 }
 
 export async function listEffectiveSkills(context?: RuntimeContextOptions): Promise<EffectiveSkillDefinition[]> {
@@ -218,36 +263,34 @@ export function getEffectiveSkillBundleSync(
     }
   }
 
-  const effectiveSkill = listEffectiveSkillsSync(context).find((skill) => skill.name === skillName) || null
-  if (!effectiveSkill) return null
+  const configured = buildConfiguredSkillMap().get(skillName)
+  if (!configured) return null
+  const entry = findBundledSkillEntry(skillName)
+  const skill = buildBundledSkillDefinition(skillName, configured, entry)
+  return skill && entry ? readBundledSkillBundle(skill, entry) : null
+}
 
-  const location = effectiveSkill.location
-  const root = location
-    ? (location.endsWith('SKILL.md') ? dirname(location) : location)
-    : findBundledSkillDir(skillName)
-  const skillPath = root ? resolveBundleFilePath(root, 'SKILL.md') : null
+export function listEffectiveBuiltInSkillBundlesSync(context?: RuntimeContextOptions): EffectiveSkillBundle[] {
+  return measurePerf('skills.effective.bundles', () => {
+    const configuredSkills = buildConfiguredSkillMap()
+    const managedCustomSkillNames = new Set(listCustomSkills(context).map((skill) => skill.name))
+    const bundledSkillIndex = getBundledSkillIndex(getBundledSkillRoots())
+    const bundles: EffectiveSkillBundle[] = []
 
-  return {
-    name: effectiveSkill.name,
-    source: effectiveSkill.source,
-    origin: effectiveSkill.origin,
-    scope: effectiveSkill.scope,
-    location,
-    content: effectiveSkill.content || (skillPath && existsSync(skillPath) ? readFileSync(skillPath, 'utf-8') : null),
-    files: root
-      ? listBundleFiles(root)
-        .map((file) => {
-          const resolved = resolveBundleFilePath(root, file.path)
-          return resolved
-            ? {
-                path: file.path,
-                content: readFileSync(resolved, 'utf-8'),
-              }
-            : null
-        })
-        .filter((file): file is { path: string; content: string } => Boolean(file))
-      : [],
-  }
+    for (const [skillName, configured] of configuredSkills.entries()) {
+      if (managedCustomSkillNames.has(skillName)) continue
+      const entry = bundledSkillIndex.get(skillName) || null
+      const skill = buildBundledSkillDefinition(skillName, configured, entry)
+      if (skill && entry) {
+        bundles.push(readBundledSkillBundle(skill, entry))
+      }
+    }
+
+    return bundles.sort((a, b) => a.name.localeCompare(b.name))
+  }, {
+    slowThresholdMs: 150,
+    slowData: { context: context?.directory ? 'project' : 'global' },
+  })
 }
 
 // Read a single file from a skill bundle on demand. Called by the
@@ -279,7 +322,7 @@ export async function readEffectiveSkillBundleFile(
     return match?.content ?? null
   }
 
-  const root = findBundledSkillDir(skillName)
+  const root = findBundledSkillEntry(skillName)?.skillDir || null
   if (!root) return null
 
   const candidate = resolveBundleFilePath(root, filePath)

--- a/apps/desktop/src/main/effective-skills.ts
+++ b/apps/desktop/src/main/effective-skills.ts
@@ -31,10 +31,20 @@ export type EffectiveSkillBundle = Omit<CapabilitySkillBundle, 'files'> & {
 }
 
 type ConfiguredSkill = ReturnType<typeof getConfiguredSkillsFromConfig>[number]
+type ManagedCustomSkill = ReturnType<typeof listCustomSkills>[number]
 
 function logSkippedSkill(name: string, source: 'builtin' | 'custom', issues: string[]) {
   if (issues.length === 0) return
   log('capability', `Skipping ${source} skill ${name}: ${issues.join(' ')}`)
+}
+
+function customSkillIsValid(managed: ManagedCustomSkill) {
+  const issues = validateOpenCodeSkillBundle({ name: managed.name, content: managed.content })
+  if (issues.length > 0) {
+    logSkippedSkill(managed.name, 'custom', issues)
+    return false
+  }
+  return true
 }
 
 function humanize(value: string) {
@@ -198,11 +208,7 @@ export function listEffectiveSkillsSync(context?: RuntimeContextOptions): Effect
     const skills = new Map<string, EffectiveSkillDefinition>()
 
     for (const managed of managedCustomSkills.values()) {
-      const issues = validateOpenCodeSkillBundle({ name: managed.name, content: managed.content })
-      if (issues.length > 0) {
-        logSkippedSkill(managed.name, 'custom', issues)
-        continue
-      }
+      if (!customSkillIsValid(managed)) continue
 
       skills.set(managed.name, {
         name: managed.name,
@@ -251,7 +257,7 @@ export function getEffectiveSkillBundleSync(
   context?: RuntimeContextOptions,
 ): EffectiveSkillBundle | null {
   const managed = getCustomSkill(skillName, context)
-  if (managed) {
+  if (managed && customSkillIsValid(managed)) {
     return {
       name: managed.name,
       source: 'custom',
@@ -273,7 +279,11 @@ export function getEffectiveSkillBundleSync(
 export function listEffectiveBuiltInSkillBundlesSync(context?: RuntimeContextOptions): EffectiveSkillBundle[] {
   return measurePerf('skills.effective.bundles', () => {
     const configuredSkills = buildConfiguredSkillMap()
-    const managedCustomSkillNames = new Set(listCustomSkills(context).map((skill) => skill.name))
+    const managedCustomSkillNames = new Set(
+      listCustomSkills(context)
+        .filter(customSkillIsValid)
+        .map((skill) => skill.name),
+    )
     const bundledSkillIndex = getBundledSkillIndex(getBundledSkillRoots())
     const bundles: EffectiveSkillBundle[] = []
 
@@ -313,7 +323,7 @@ export async function readEffectiveSkillBundleFile(
   if (!filePath || filePath.trim().length === 0) return null
 
   const managed = getCustomSkill(skillName, context)
-  if (managed) {
+  if (managed && customSkillIsValid(managed)) {
     // Custom skills carry their file list in memory already; we can't
     // expand arbitrary content from disk because the custom-skill
     // store may not even surface a filesystem location. Return the

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -168,7 +168,9 @@ export async function rebootRuntime(): Promise<void> {
     // or model may have changed, and serving stale tool metadata from
     // the Capabilities UI would mislead the user.
     const { invalidateRuntimeToolCache } = await import('./runtime-tool-cache.ts')
+    const { invalidateCustomAgentCatalogCache } = await import('./custom-agents.ts')
     invalidateRuntimeToolCache()
+    invalidateCustomAgentCatalogCache()
     await stopRuntime()
     try {
       await bootRuntime(runtimeProjectDirectory)

--- a/apps/desktop/src/main/ipc/catalog-handlers.ts
+++ b/apps/desktop/src/main/ipc/catalog-handlers.ts
@@ -5,7 +5,7 @@ import { optionalObjectArg, registerIpcInvoke, stringArg } from './schema.ts'
 import { getClient } from '../runtime.ts'
 import { invalidateRuntimeToolCache } from '../runtime-tool-cache.ts'
 import { listBuiltInAgentDetails } from '../built-in-agent-details.ts'
-import { getCustomAgentCatalog, getCustomAgentSummaries, normalizeCustomAgent, validateCustomAgent } from '../custom-agents.ts'
+import { getCustomAgentCatalog, getCustomAgentSummaries, invalidateCustomAgentCatalogCache, normalizeCustomAgent, validateCustomAgent } from '../custom-agents.ts'
 import { listCustomAgents, removeCustomAgent, saveCustomAgent } from '../native-customizations.ts'
 import { getCapabilitySkillBundle, getCapabilityTool, listCapabilitySkills, listCapabilityTools } from '../capability-catalog.ts'
 import { readEffectiveSkillBundleFile } from '../effective-skills.ts'
@@ -43,6 +43,11 @@ const runMcpTransitionForName = createKeyedPromiseChain()
 
 const WRITE_TOOL_IDS = new Set(['edit', 'write', 'apply_patch', 'todowrite'])
 const WRITE_PERMISSION_ACTIONS = new Set(['ask', 'allow'])
+
+function invalidateRuntimeCapabilityCaches() {
+  invalidateRuntimeToolCache()
+  invalidateCustomAgentCatalogCache()
+}
 
 async function timeAgentCatalogHandler<T>(name: 'agents:list' | 'agents:catalog' | 'agents:runtime', work: () => Promise<T>) {
   const start = performance.now()
@@ -193,7 +198,7 @@ export async function authenticateMcpThroughRuntime(client: {
     }
   }
   await client.mcp.auth.authenticate({ name: mcpName })
-  invalidateRuntimeToolCache()
+  invalidateRuntimeCapabilityCaches()
   return true
 }
 
@@ -231,7 +236,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
       try {
         await client.mcp.connect({ name })
         log('mcp', `Connected: ${name}`)
-        invalidateRuntimeToolCache()
+        invalidateRuntimeCapabilityCaches()
         return true
       } catch (err) {
         context.logHandlerError(`mcp:connect ${name}`, err)
@@ -247,7 +252,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
       try {
         await client.mcp.disconnect({ name })
         log('mcp', `Disconnected: ${name}`)
-        invalidateRuntimeToolCache()
+        invalidateRuntimeCapabilityCaches()
         return true
       } catch (err) {
         context.logHandlerError(`mcp:disconnect ${name}`, err)
@@ -321,6 +326,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     }
 
     saveCustomAgent(normalized, await context.buildCustomAgentPermission(normalized, catalogContext))
+    invalidateCustomAgentCatalogCache()
     log('agent', `Added custom agent: ${normalized.name}`)
     const { rebootRuntime } = await import('../index.ts')
     await rebootRuntime()
@@ -344,6 +350,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
 
     removeCustomAgent(resolvedTarget)
     saveCustomAgent(normalized, await context.buildCustomAgentPermission(normalized, catalogContext))
+    invalidateCustomAgentCatalogCache()
     log('agent', `Updated custom agent: ${resolvedTarget.name} -> ${normalized.name}`)
     const { rebootRuntime } = await import('../index.ts')
     await rebootRuntime()
@@ -357,6 +364,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
         throw new Error('Confirmation required before deleting an agent.')
       }
       removeCustomAgent(resolvedTarget)
+      invalidateCustomAgentCatalogCache()
       log('agent', `Removed custom agent: ${resolvedTarget.name}`)
       log('audit', `agent.remove completed ${context.describeDestructiveRequest({ action: 'agent.remove', target: resolvedTarget })}`)
       const { rebootRuntime } = await import('../index.ts')

--- a/apps/desktop/src/main/ipc/custom-content-handlers.ts
+++ b/apps/desktop/src/main/ipc/custom-content-handlers.ts
@@ -16,6 +16,7 @@ import { getBrandName } from '../config-loader.ts'
 import { VALID_OPENCODE_SKILL_NAME } from '../skill-bundle-validation.ts'
 import { assertCustomMcpContentLimits, assertCustomSkillContent } from '../custom-content-limits.ts'
 import { computeCustomSkillBundleDigest } from '../custom-skill-integrity.ts'
+import { invalidateCustomAgentCatalogCache } from '../custom-agents.ts'
 
 const VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
@@ -141,6 +142,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     }
     try {
       saveCustomMcp(resolved)
+      invalidateCustomAgentCatalogCache()
       if (resolved.allowPrivateNetwork === true) {
         log('audit', `mcp.allowPrivateNetwork enabled name=${resolved.name} scope=${resolved.scope || 'machine'}`)
       }
@@ -161,6 +163,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
         throw new Error('Confirmation required before removing an MCP.')
       }
       removeCustomMcp(resolvedTarget)
+      invalidateCustomAgentCatalogCache()
       log('custom', `Removed MCP: ${resolvedTarget.name}`)
       log('audit', `mcp.remove completed ${context.describeDestructiveRequest({ action: 'mcp.remove', target: resolvedTarget })}`)
       const { rebootRuntime } = await import('../index.ts')
@@ -187,6 +190,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
       if (!confirmed) return false
     }
     saveCustomSkill(resolved)
+    invalidateCustomAgentCatalogCache()
     logUnsignedSkillBundle('add', resolved)
     log('custom', `Added skill: ${resolved.name}`)
     const { rebootRuntime } = await import('../index.ts')
@@ -224,6 +228,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     const confirmed = await confirmUnsignedSkillWrite(context, 'import', imported)
     if (!confirmed) return null
     saveCustomSkill(imported)
+    invalidateCustomAgentCatalogCache()
     logUnsignedSkillBundle('import', imported)
     log('custom', `Imported skill directory: ${imported.name}`)
     const { rebootRuntime } = await import('../index.ts')
@@ -238,6 +243,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
         throw new Error('Confirmation required before removing a skill.')
       }
       removeCustomSkill(resolvedTarget)
+      invalidateCustomAgentCatalogCache()
       log('custom', `Removed skill: ${resolvedTarget.name}`)
       log('audit', `skill.remove completed ${context.describeDestructiveRequest({ action: 'skill.remove', target: resolvedTarget })}`)
       const { rebootRuntime } = await import('../index.ts')

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -6,7 +6,7 @@ import { getProviderDescriptor } from '../config-loader.ts'
 import { getClient, getClientForDirectory, getRuntimeHomeDir } from '../runtime.ts'
 import { normalizeProviderListResponse, type ProviderLike } from '../provider-utils.ts'
 import { forgetSubmittedPrompt, rememberSubmittedPrompt, trackParentSession } from '../event-task-state.ts'
-import { dispatchRuntimeSessionEvent, publishSessionView } from '../session-event-dispatcher.ts'
+import { dispatchRuntimeSessionEvent, publishSessionMetadata, publishSessionView } from '../session-event-dispatcher.ts'
 import { startSessionStatusReconciliation, stopSessionStatusReconciliation } from '../session-status-reconciler.ts'
 import {
   getSessionRecord,
@@ -20,6 +20,7 @@ import {
 } from '../session-registry.ts'
 import { toIsoTimestamp } from '../task-run-utils.ts'
 import { syncSessionView } from '../session-history-loader.ts'
+import { sessionEngine } from '../session-engine.ts'
 import { normalizeSessionInfo } from '../opencode-adapter.ts'
 import { shortSessionId } from '../log-sanitizer.ts'
 import { log } from '../logger.ts'
@@ -356,9 +357,11 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('session:activate', async (_event, sessionIdInput: unknown, options?: { force?: boolean }) => {
     const sessionId = normalizeSessionId(sessionIdInput)
     try {
+      const rootFirst = !options?.force && !sessionEngine.isHydrated(sessionId)
       const view = await syncSessionView(sessionId, {
         force: options?.force,
         activate: true,
+        progressive: rootFirst,
       })
       getThreadIndexService().refreshThreadMetadata(sessionId, view)
       if (view.isGenerating) {
@@ -375,18 +378,21 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
         // Broadcast SDK-owned fields that syncSessionView refreshed (parent,
         // summary, revertedMessageId) so the sidebar/header chips update
         // without waiting for a session.updated SSE event.
-        const record = getSessionRecord(sessionId)
-        if (record) {
-          win.webContents.send('session:updated', {
-            id: record.id,
-            title: record.title || null,
-            parentSessionId: record.parentSessionId,
-            changeSummary: record.changeSummary,
-            revertedMessageId: record.revertedMessageId,
-            composerModelId: record.composerModelId,
-            composerReasoningVariant: record.composerReasoningVariant,
-          })
-        }
+        publishSessionMetadata(win, sessionId)
+      }
+      if (rootFirst) {
+        void syncSessionView(sessionId, {
+          force: true,
+          activate: false,
+        }).then((hydratedView) => {
+          getThreadIndexService().refreshThreadMetadata(sessionId, hydratedView)
+          const hydratedWin = context.getMainWindow()
+          if (!hydratedWin || hydratedWin.isDestroyed()) return
+          publishSessionView(hydratedWin, sessionId)
+          publishSessionMetadata(hydratedWin, sessionId)
+        }).catch((err) => {
+          context.logHandlerError(`session:activate hydrate ${shortSessionId(sessionId)}`, err)
+        })
       }
       return view
     } catch (err) {

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -19,7 +19,7 @@ import {
   upsertSessionRecord,
 } from '../session-registry.ts'
 import { toIsoTimestamp } from '../task-run-utils.ts'
-import { syncSessionView } from '../session-history-loader.ts'
+import { isSessionPartiallyHydrated, syncSessionView } from '../session-history-loader.ts'
 import { sessionEngine } from '../session-engine.ts'
 import { normalizeSessionInfo } from '../opencode-adapter.ts'
 import { shortSessionId } from '../log-sanitizer.ts'
@@ -357,11 +357,15 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
   context.ipcMain.handle('session:activate', async (_event, sessionIdInput: unknown, options?: { force?: boolean }) => {
     const sessionId = normalizeSessionId(sessionIdInput)
     try {
-      const rootFirst = !options?.force && !sessionEngine.isHydrated(sessionId)
+      const shouldRetryFullHydration = !options?.force && isSessionPartiallyHydrated(sessionId)
+      const progressive = !options?.force && (
+        !sessionEngine.isHydrated(sessionId)
+        || shouldRetryFullHydration
+      )
       const view = await syncSessionView(sessionId, {
         force: options?.force,
         activate: true,
-        progressive: rootFirst,
+        progressive,
       })
       getThreadIndexService().refreshThreadMetadata(sessionId, view)
       if (view.isGenerating) {
@@ -380,7 +384,7 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
         // without waiting for a session.updated SSE event.
         publishSessionMetadata(win, sessionId)
       }
-      if (rootFirst) {
+      if (progressive) {
         void syncSessionView(sessionId, {
           force: true,
           activate: false,

--- a/apps/desktop/src/main/logger.ts
+++ b/apps/desktop/src/main/logger.ts
@@ -84,6 +84,11 @@ function getLogPath(): string {
 function getStream(): ReturnType<typeof createWriteStream> {
   if (logStream) return logStream
   logStream = createWriteStream(getLogPath(), { flags: 'a' })
+  logStream.on('error', () => {
+    // File stream errors are asynchronous, so the log() try/catch cannot
+    // catch them. Logging must remain best-effort even if a test or app
+    // cleanup removes the log directory after the stream is created.
+  })
   return logStream
 }
 

--- a/apps/desktop/src/main/runtime-content.ts
+++ b/apps/desktop/src/main/runtime-content.ts
@@ -1,6 +1,6 @@
 import electron from 'electron'
-import { cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs'
-import { isAbsolute, join, relative, resolve } from 'path'
+import { cpSync, existsSync, lstatSync, mkdirSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
 import { getConfiguredSkillsFromConfig } from './config-loader.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
 import { log } from './logger.ts'
@@ -9,57 +9,9 @@ import { syncProjectOverlayToRuntime } from './runtime-project-overlay.ts'
 import { buildRuntimeSkillCatalog } from './runtime-skill-catalog.ts'
 import { pruneManagedSkillMirror } from './runtime-skill-mirror.ts'
 import { syncCustomAgentRuntimeGuidance } from './native-customizations.ts'
+import { findBundledSkillDirInRoot, getBundledSkillIndex } from './bundled-skill-index.ts'
 
 const { app } = electron
-
-function isInsideRoot(root: string, candidate: string) {
-  const relativePath = relative(root, candidate)
-  const firstSegment = relativePath.split(/[\\/]/, 1)[0]
-  return relativePath === '' || (
-    Boolean(relativePath)
-    && firstSegment !== '..'
-    && !isAbsolute(relativePath)
-  )
-}
-
-function isSafeDirectoryInsideRoot(root: string, candidate: string) {
-  const absoluteRoot = resolve(root)
-  const absoluteCandidate = resolve(candidate)
-  if (!isInsideRoot(absoluteRoot, absoluteCandidate)) return false
-  if (!existsSync(absoluteCandidate)) return false
-
-  try {
-    if (lstatSync(absoluteCandidate).isSymbolicLink()) return false
-    const realRoot = realpathSync.native(absoluteRoot)
-    const realCandidate = realpathSync.native(absoluteCandidate)
-    if (!isInsideRoot(realRoot, realCandidate)) return false
-    return statSync(realCandidate).isDirectory()
-  } catch {
-    return false
-  }
-}
-
-function isSafeFileInsideRoot(root: string, candidate: string) {
-  const absoluteRoot = resolve(root)
-  const absoluteCandidate = resolve(candidate)
-  if (!isInsideRoot(absoluteRoot, absoluteCandidate)) return false
-  if (!existsSync(absoluteCandidate)) return false
-
-  try {
-    if (lstatSync(absoluteCandidate).isSymbolicLink()) return false
-    const realRoot = realpathSync.native(absoluteRoot)
-    const realCandidate = realpathSync.native(absoluteCandidate)
-    if (!isInsideRoot(realRoot, realCandidate)) return false
-    return statSync(realCandidate).isFile()
-  } catch {
-    return false
-  }
-}
-
-function hasSafeSkillDefinition(root: string, skillDir: string) {
-  return isSafeDirectoryInsideRoot(root, skillDir)
-    && isSafeFileInsideRoot(root, join(skillDir, 'SKILL.md'))
-}
 
 function copySkillDirectory(source: string, destination: string) {
   rmSync(destination, { recursive: true, force: true })
@@ -116,26 +68,7 @@ export function getBundledSkillRoots(): string[] {
 }
 
 export function findBundledSkillDir(root: string, skillName: string): string | null {
-  const direct = join(root, skillName)
-  if (hasSafeSkillDefinition(root, direct)) return direct
-  if (!existsSync(root)) return null
-
-  const queue = [root]
-  while (queue.length > 0) {
-    const current = queue.shift()
-    if (!current) continue
-
-    for (const entry of readdirSync(current)) {
-      const candidate = join(current, entry)
-      if (!isSafeDirectoryInsideRoot(root, candidate)) continue
-      if (entry === skillName && hasSafeSkillDefinition(root, candidate)) {
-        return candidate
-      }
-      queue.push(candidate)
-    }
-  }
-
-  return null
+  return findBundledSkillDirInRoot(root, skillName)
 }
 
 // Copies the configured-skill subset into Cowork-managed mirrors. The
@@ -163,6 +96,7 @@ export function copySkillsAndAgents(projectDirectory?: string | null) {
   const customSkillsDst = getMachineSkillsDir()
   const runtimeSkillCatalog = getRuntimeSkillCatalogDir()
   const skillSourceRoots = getBundledSkillRoots()
+  const bundledSkillIndex = getBundledSkillIndex(skillSourceRoots)
   const configuredSkillNames = new Set(getConfiguredSkillsFromConfig().map((skill) => skill.sourceName))
   pruneManagedSkillMirror({
     discoverableSkillsDir: customSkillsDst,
@@ -186,9 +120,7 @@ export function copySkillsAndAgents(projectDirectory?: string | null) {
 
   for (const skillName of Array.from(configuredSkillNames)) {
     const destination = join(skillsDst, skillName)
-    const source = skillSourceRoots
-      .map((root) => findBundledSkillDir(root, skillName))
-      .find((candidate) => candidate && existsSync(candidate))
+    const source = bundledSkillIndex.get(skillName)?.skillDir || null
 
     if (!source) {
       log('runtime', `Bundled skill not found: ${skillName}`)

--- a/apps/desktop/src/main/runtime-skill-catalog.ts
+++ b/apps/desktop/src/main/runtime-skill-catalog.ts
@@ -2,7 +2,7 @@ import { mkdirSync, rmSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import type { RuntimeContextOptions } from '@open-cowork/shared'
 import { getProjectOverlayDirName } from './config-loader.ts'
-import { getEffectiveSkillBundleSync, listEffectiveSkillsSync } from './effective-skills.ts'
+import { listEffectiveBuiltInSkillBundlesSync } from './effective-skills.ts'
 import { log } from './logger.ts'
 import { getRuntimeHomeDir, getRuntimeSkillCatalogDir } from './runtime-paths.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
@@ -144,14 +144,11 @@ export function writeRuntimeSkillBundle(root: string, bundle: RuntimeSkillBundle
 }
 
 function listContextBundles(context?: RuntimeContextOptions): RuntimeSkillBundle[] {
-  return listEffectiveSkillsSync(context)
-    // OpenCode already discovers user-authored machine and project skills
-    // from its native skills directory. The generated SDK skills.paths
-    // catalog is only for Cowork-curated built-in bundles; including custom
-    // skills here exposes the same skill twice to OpenCode.
-    .filter((skill) => skill.source === 'builtin')
-    .map((skill) => getEffectiveSkillBundleSync(skill.name, context))
-    .filter((bundle): bundle is NonNullable<typeof bundle> => Boolean(bundle))
+  // OpenCode already discovers user-authored machine and project skills
+  // from its native skills directory. The generated SDK skills.paths
+  // catalog is only for Cowork-curated built-in bundles; including custom
+  // skills here exposes the same skill twice to OpenCode.
+  return listEffectiveBuiltInSkillBundlesSync(context)
     .map((bundle) => ({
       name: bundle.name,
       content: bundle.content || '',

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -248,6 +248,8 @@ const defaultSessionHistoryServiceDeps: SessionHistoryServiceDeps = {
 export function createSessionHistoryService(
   deps: SessionHistoryServiceDeps = defaultSessionHistoryServiceDeps,
 ) {
+  const partiallyHydratedSessions = new Set<string>()
+
   async function loadChildSessionsRecursive(
     client: OpencodeClient,
     parentSessionId: string,
@@ -420,6 +422,11 @@ export function createSessionHistoryService(
         })
         deps.sessionEngine.setPendingQuestions(sessionId, questions)
         deps.sessionEngine.setPendingApprovals(sessionId, approvals)
+        if (progressive) {
+          partiallyHydratedSessions.add(sessionId)
+        } else {
+          partiallyHydratedSessions.delete(sessionId)
+        }
       }
       const view = deps.sessionEngine.getSessionView(sessionId)
       const patch: Parameters<typeof deps.updateSessionRecord>[1] = {
@@ -464,6 +471,9 @@ export function createSessionHistoryService(
 
   return {
     loadSessionHistory,
+    isSessionPartiallyHydrated(sessionId: string) {
+      return partiallyHydratedSessions.has(sessionId)
+    },
     syncSessionView(sessionId: string, options?: SessionSyncOptions) {
       return runSessionSync(sessionId, options)
     },
@@ -473,4 +483,5 @@ export function createSessionHistoryService(
 const sessionHistoryService = createSessionHistoryService()
 
 export const loadSessionHistory = sessionHistoryService.loadSessionHistory
+export const isSessionPartiallyHydrated = sessionHistoryService.isSessionPartiallyHydrated
 export const syncSessionView = sessionHistoryService.syncSessionView

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -42,6 +42,11 @@ async function listPendingPermissions(client: OpencodeClient): Promise<Permissio
 type SessionSyncOptions = {
   force?: boolean
   activate?: boolean
+  progressive?: boolean
+}
+
+type LoadSessionHistoryOptions = {
+  includeChildren?: boolean
 }
 
 type ChildSessionRecord = {
@@ -268,8 +273,9 @@ export function createSessionHistoryService(
     return directChildren.concat(nestedChildren.flat())
   }
 
-  async function loadSessionHistory(sessionId: string) {
-    return measureAsyncPerf('session.history.load', async () => {
+  async function loadSessionHistory(sessionId: string, options: LoadSessionHistoryOptions = {}) {
+    const includeChildren = options.includeChildren !== false
+    return measureAsyncPerf(includeChildren ? 'session.history.load' : 'session.history.load.root', async () => {
       const { client, questionClient, record } = await deps.getSessionClient(sessionId)
       const [
         rootMessagesResult,
@@ -311,7 +317,9 @@ export function createSessionHistoryService(
 
       const rootMessages = normalizeSessionMessages(rootMessagesResult.data)
       const rootTodos = readRecordArray({ value: readResponseData(rootTodosResult) }, 'value')
-      const children = await loadChildSessionsRecursive(client, sessionId)
+      const children = includeChildren
+        ? await loadChildSessionsRecursive(client, sessionId)
+        : []
       const statuses = normalizeSessionStatuses(readResponseData(statusResult))
       const descendantSessionIds = new Set([sessionId, ...children.map((child) => child.id)])
       const questions = normalizePendingQuestions(readResponseData(questionResult), sessionId, descendantSessionIds)
@@ -380,15 +388,21 @@ export function createSessionHistoryService(
       }
       return { items, questions, approvals }
     }, {
-      slowThresholdMs: 250,
-      slowData: { sessionId: shortSessionId(sessionId) },
+      slowThresholdMs: includeChildren ? 250 : 100,
+      slowData: {
+        sessionId: shortSessionId(sessionId),
+        includeChildren,
+      },
     })
   }
 
   async function performSessionSync(sessionId: string, options?: SessionSyncOptions): Promise<SessionView> {
     const shouldActivate = options?.activate !== false
+    const progressive = Boolean(options?.progressive && !options.force)
     const metric = options?.force
       ? 'session.sync.force'
+      : progressive
+        ? 'session.sync.progressive'
       : deps.sessionEngine.isHydrated(sessionId)
         ? 'session.sync.warm'
         : 'session.sync.cold'
@@ -398,7 +412,9 @@ export function createSessionHistoryService(
         deps.sessionEngine.activateSession(sessionId)
       }
       if (options?.force || !deps.sessionEngine.isHydrated(sessionId)) {
-        const { items, questions, approvals } = await loadSessionHistory(sessionId)
+        const { items, questions, approvals } = await loadSessionHistory(sessionId, {
+          includeChildren: !progressive,
+        })
         deps.sessionEngine.setSessionFromHistory(sessionId, items, {
           force: options?.force,
         })
@@ -410,21 +426,23 @@ export function createSessionHistoryService(
         summary: deps.buildSessionUsageSummary(view),
       }
 
-      try {
-        const { client, record } = await deps.getSessionClient(sessionId)
-        const diffResult = await client.session.diff({
-          sessionID: sessionId,
-        }).catch((err) => {
-          logHistoryError('session:diff summary', sessionId, err)
-          return { data: [] }
-        })
-        const sdkDiffs = normalizeSessionFileDiffs(Array.isArray(diffResult.data) ? diffResult.data : [])
-        const rootDir = record?.opencodeDirectory || getRuntimeHomeDir()
-        patch.changeSummary = summarizeSessionDiffs(
-          mergeSessionDiffsWithSynthetic(sdkDiffs, view, rootDir),
-        )
-      } catch (err) {
-        logHistoryError('session:diff summary client', sessionId, err)
+      if (!progressive) {
+        try {
+          const { client, record } = await deps.getSessionClient(sessionId)
+          const diffResult = await client.session.diff({
+            sessionID: sessionId,
+          }).catch((err) => {
+            logHistoryError('session:diff summary', sessionId, err)
+            return { data: [] }
+          })
+          const sdkDiffs = normalizeSessionFileDiffs(Array.isArray(diffResult.data) ? diffResult.data : [])
+          const rootDir = record?.opencodeDirectory || getRuntimeHomeDir()
+          patch.changeSummary = summarizeSessionDiffs(
+            mergeSessionDiffsWithSynthetic(sdkDiffs, view, rootDir),
+          )
+        } catch (err) {
+          logHistoryError('session:diff summary client', sessionId, err)
+        }
       }
 
       deps.updateSessionRecord(sessionId, patch)
@@ -435,6 +453,7 @@ export function createSessionHistoryService(
         sessionId: shortSessionId(sessionId),
         force: Boolean(options?.force),
         activate: shouldActivate,
+        progressive,
       },
     })
   }

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -20,6 +20,7 @@ const secretScanFilenames = new Set([
 const ignoredDirs = new Set([
   '.git',
   '.claude',
+  '.generated',
   '.open-cowork-test',
   '.opencode',
   '.pnpm-store',

--- a/tests/effective-skills.test.ts
+++ b/tests/effective-skills.test.ts
@@ -263,7 +263,7 @@ test('effective skill bundle file reads return null when a validated file become
   }
 })
 
-test('built-in skill bundles are materialized in one pass while custom skills shadow configured bundles', () => {
+test('built-in skill bundles are materialized in one pass while only valid custom skills shadow configured bundles', () => {
   const tempRoot = testTempDir('opencowork-effective-builtins-')
   const configDir = join(tempRoot, 'config')
   const downstreamRoot = join(tempRoot, 'downstream')
@@ -298,11 +298,16 @@ test('built-in skill bundles are materialized in one pass while custom skills sh
     mkdirSync(customAnalyst, { recursive: true })
     writeFileSync(join(customAnalyst, 'SKILL.md'), '---\nname: analyst\ndescription: Custom analyst.\n---\n# Custom Analyst\n')
 
+    const invalidCustomChart = join(getMachineSkillsDir(), 'chart-creator')
+    mkdirSync(invalidCustomChart, { recursive: true })
+    writeFileSync(join(invalidCustomChart, 'SKILL.md'), '---\nname: chart-creator\n---\n# Invalid Custom Chart\n')
+
     const bundles = listEffectiveBuiltInSkillBundlesSync()
     assert.equal(bundles.some((bundle) => bundle.name === 'analyst'), false)
     const chartBundle = bundles.find((bundle) => bundle.name === 'chart-creator')
     assert.equal(chartBundle?.content?.includes('Bundled charting'), true)
     assert.equal(chartBundle?.files.some((file) => file.path === 'reference.md' && file.content === 'chart reference'), true)
+    assert.equal(getEffectiveSkillBundleSync('chart-creator')?.origin, 'open-cowork')
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir

--- a/tests/effective-skills.test.ts
+++ b/tests/effective-skills.test.ts
@@ -4,10 +4,17 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync }
 import { join } from 'path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import {
+  buildBundledSkillIndex,
+  clearBundledSkillIndexCache,
+  getBundledSkillIndex,
+} from '../apps/desktop/src/main/bundled-skill-index.ts'
+import {
   getEffectiveSkillBundleSync,
+  listEffectiveBuiltInSkillBundlesSync,
   readEffectiveSkillBundleFile,
 } from '../apps/desktop/src/main/effective-skills.ts'
 import { findBundledSkillDir } from '../apps/desktop/src/main/runtime-content.ts'
+import { getMachineSkillsDir } from '../apps/desktop/src/main/runtime-paths.ts'
 
 function testTempDir(prefix: string) {
   const parent = join(process.cwd(), '.open-cowork-test')
@@ -128,6 +135,35 @@ test('bundled skill discovery rejects symlinked SKILL.md definitions', () => {
   }
 })
 
+test('bundled skill index prefers root order and shallower duplicate bundles', () => {
+  const tempRoot = testTempDir('opencowork-skill-index-')
+  const firstRoot = join(tempRoot, 'first', 'skills')
+  const secondRoot = join(tempRoot, 'second', 'skills')
+  const firstNested = join(firstRoot, 'nested', 'duplicate-skill')
+  const firstDirect = join(firstRoot, 'duplicate-skill')
+  const secondDirect = join(secondRoot, 'duplicate-skill')
+
+  mkdirSync(firstNested, { recursive: true })
+  mkdirSync(firstDirect, { recursive: true })
+  mkdirSync(secondDirect, { recursive: true })
+  writeFileSync(join(firstNested, 'SKILL.md'), '---\nname: duplicate-skill\ndescription: Nested\n---\n# Nested\n')
+  writeFileSync(join(firstDirect, 'SKILL.md'), '---\nname: duplicate-skill\ndescription: Direct\n---\n# Direct\n')
+  writeFileSync(join(secondDirect, 'SKILL.md'), '---\nname: duplicate-skill\ndescription: Second\n---\n# Second\n')
+
+  try {
+    clearBundledSkillIndexCache()
+    const directIndex = buildBundledSkillIndex([firstRoot, secondRoot])
+    assert.equal(directIndex.get('duplicate-skill')?.skillDir, firstDirect)
+
+    const cachedIndex = getBundledSkillIndex([secondRoot, firstRoot])
+    assert.equal(cachedIndex.get('duplicate-skill')?.skillDir, secondDirect)
+    assert.equal(getBundledSkillIndex([secondRoot, firstRoot]), cachedIndex)
+  } finally {
+    clearBundledSkillIndexCache()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('effective skill bundle file reads return null when a validated file becomes unreadable', async () => {
   const tempRoot = testTempDir('opencowork-effective-skills-unreadable-')
   const configDir = join(tempRoot, 'config')
@@ -169,6 +205,59 @@ test('effective skill bundle file reads return null when a validated file become
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
     if (previousDownstreamRoot === undefined) delete process.env.OPEN_COWORK_DOWNSTREAM_ROOT
     else process.env.OPEN_COWORK_DOWNSTREAM_ROOT = previousDownstreamRoot
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('built-in skill bundles are materialized in one pass while custom skills shadow configured bundles', () => {
+  const tempRoot = testTempDir('opencowork-effective-builtins-')
+  const configDir = join(tempRoot, 'config')
+  const downstreamRoot = join(tempRoot, 'downstream')
+  const downstreamSkills = join(downstreamRoot, 'skills')
+  const bundledAnalyst = join(downstreamSkills, 'analyst')
+  const bundledChart = join(downstreamSkills, 'chart-creator')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousDownstreamRoot = process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  mkdirSync(configDir, { recursive: true })
+  mkdirSync(bundledAnalyst, { recursive: true })
+  mkdirSync(bundledChart, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({
+    skills: [
+      { name: 'Analyst', description: 'Bundled analyst.', badge: 'Skill', sourceName: 'analyst', toolIds: [] },
+      { name: 'Chart Creator', description: 'Bundled charting.', badge: 'Skill', sourceName: 'chart-creator', toolIds: ['charts'] },
+    ],
+  }, null, 2))
+  writeFileSync(join(bundledAnalyst, 'SKILL.md'), '---\nname: analyst\ndescription: Bundled analyst.\n---\n# Analyst\n')
+  writeFileSync(join(bundledChart, 'SKILL.md'), '---\nname: chart-creator\ndescription: Bundled charting.\n---\n# Chart\n')
+  writeFileSync(join(bundledChart, 'reference.md'), 'chart reference')
+
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_DOWNSTREAM_ROOT = downstreamRoot
+  process.env.OPEN_COWORK_USER_DATA_DIR = join(tempRoot, 'user-data')
+  clearBundledSkillIndexCache()
+  clearConfigCaches()
+
+  try {
+    const customAnalyst = join(getMachineSkillsDir(), 'analyst')
+    mkdirSync(customAnalyst, { recursive: true })
+    writeFileSync(join(customAnalyst, 'SKILL.md'), '---\nname: analyst\ndescription: Custom analyst.\n---\n# Custom Analyst\n')
+
+    const bundles = listEffectiveBuiltInSkillBundlesSync()
+    assert.equal(bundles.some((bundle) => bundle.name === 'analyst'), false)
+    const chartBundle = bundles.find((bundle) => bundle.name === 'chart-creator')
+    assert.equal(chartBundle?.content?.includes('Bundled charting'), true)
+    assert.equal(chartBundle?.files.some((file) => file.path === 'reference.md' && file.content === 'chart reference'), true)
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousDownstreamRoot === undefined) delete process.env.OPEN_COWORK_DOWNSTREAM_ROOT
+    else process.env.OPEN_COWORK_DOWNSTREAM_ROOT = previousDownstreamRoot
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearBundledSkillIndexCache()
     clearConfigCaches()
     rmSync(tempRoot, { recursive: true, force: true })
   }

--- a/tests/effective-skills.test.ts
+++ b/tests/effective-skills.test.ts
@@ -164,6 +164,59 @@ test('bundled skill index prefers root order and shallower duplicate bundles', (
   }
 })
 
+test('bundled skill index accepts symlinked bundle roots while rejecting nested symlink escapes', () => {
+  const tempRoot = testTempDir('opencowork-skill-index-symlink-root-')
+  const realRoot = join(tempRoot, 'real-skills')
+  const linkedRoot = join(tempRoot, 'linked-skills')
+  const skillDir = join(realRoot, 'linked-skill')
+  const outsideSkill = join(tempRoot, 'outside-skill')
+
+  mkdirSync(skillDir, { recursive: true })
+  mkdirSync(outsideSkill, { recursive: true })
+  writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: linked-skill\ndescription: Linked\n---\n# Linked\n')
+  writeFileSync(join(outsideSkill, 'SKILL.md'), '---\nname: outside-skill\ndescription: Outside\n---\n# Outside\n')
+  symlinkSync(realRoot, linkedRoot, 'dir')
+  symlinkSync(outsideSkill, join(realRoot, 'outside-skill'), 'dir')
+
+  try {
+    clearBundledSkillIndexCache()
+    const index = getBundledSkillIndex([linkedRoot])
+    assert.equal(index.get('linked-skill')?.skillDir, join(linkedRoot, 'linked-skill'))
+    assert.equal(index.has('outside-skill'), false)
+  } finally {
+    clearBundledSkillIndexCache()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('bundled skill index reflects nested tree changes without a manual cache clear', () => {
+  const tempRoot = testTempDir('opencowork-skill-index-refresh-')
+  const skillRoot = join(tempRoot, 'skills')
+  const firstSkill = join(skillRoot, 'first-skill')
+  const nestedSkill = join(skillRoot, 'vendor', 'nested-skill')
+
+  mkdirSync(firstSkill, { recursive: true })
+  writeFileSync(join(firstSkill, 'SKILL.md'), '---\nname: first-skill\ndescription: First\n---\n# First\n')
+
+  try {
+    clearBundledSkillIndexCache()
+    const initialIndex = getBundledSkillIndex([skillRoot])
+    assert.equal(initialIndex.has('first-skill'), true)
+    assert.equal(initialIndex.has('nested-skill'), false)
+
+    mkdirSync(nestedSkill, { recursive: true })
+    writeFileSync(join(nestedSkill, 'SKILL.md'), '---\nname: nested-skill\ndescription: Nested\n---\n# Nested\n')
+
+    const refreshedIndex = getBundledSkillIndex([skillRoot])
+    assert.equal(refreshedIndex.has('first-skill'), true)
+    assert.equal(refreshedIndex.get('nested-skill')?.skillDir, nestedSkill)
+    assert.notEqual(refreshedIndex, initialIndex)
+  } finally {
+    clearBundledSkillIndexCache()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('effective skill bundle file reads return null when a validated file becomes unreadable', async () => {
   const tempRoot = testTempDir('opencowork-effective-skills-unreadable-')
   const configDir = join(tempRoot, 'config')

--- a/tests/session-history-loader.test.ts
+++ b/tests/session-history-loader.test.ts
@@ -669,6 +669,7 @@ test('createSessionHistoryService can hydrate root history before child transcri
   assert.equal(calls.childSnapshot, 0)
   assert.equal(calls.diff, 0)
   assert.equal(calls.setHistory, 1)
+  assert.equal(service.isSessionPartiallyHydrated('session-progressive'), true)
   assert.deepEqual(updates[0], {
     summary: {
       messages: 0,
@@ -686,6 +687,101 @@ test('createSessionHistoryService can hydrate root history before child transcri
       },
     },
   })
+})
+
+test('createSessionHistoryService keeps partial hydration retryable until a full sync succeeds', async () => {
+  const view = createEmptySessionView()
+  const calls = {
+    children: 0,
+    setHistory: 0,
+  }
+  const projectedChildren: string[][] = []
+  let hydrated = false
+
+  const service = createSessionHistoryService({
+    getSessionClient: async () => ({
+      client: {
+        session: {
+          messages: async () => ({ data: [] }),
+          todo: async () => ({ data: [] }),
+          children: async ({ sessionID }: { sessionID: string }) => {
+            calls.children += 1
+            return {
+              data: sessionID === 'session-partial'
+                ? [{ id: 'child-1', title: 'Analyst', parentID: 'session-partial', time: { created: 1 } }]
+                : [],
+            }
+          },
+          diff: async () => ({ data: [] }),
+          status: async () => ({ data: {} }),
+          get: async () => ({ data: null }),
+        },
+      },
+      questionClient: {},
+      record: null,
+    }),
+    listPendingQuestions: async () => ({ data: [] }),
+    listPendingPermissions: async () => ({ data: [] }),
+    projectSessionHistory: async (input) => {
+      projectedChildren.push(input.children.map((child) => child.id))
+      return []
+    },
+    getCachedModelId: () => '',
+    updateSessionRecord: () => null,
+    buildSessionUsageSummary: () => ({
+      messages: 0,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      taskRuns: 0,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    }),
+    sessionEngine: {
+      isHydrated: () => hydrated,
+      activateSession: () => {},
+      setSessionFromHistory: () => {
+        calls.setHistory += 1
+        hydrated = true
+      },
+      setPendingQuestions: () => {},
+      setPendingApprovals: () => {},
+      getSessionView: () => view,
+    },
+  })
+
+  await service.syncSessionView('session-partial', {
+    activate: true,
+    progressive: true,
+  })
+  assert.equal(service.isSessionPartiallyHydrated('session-partial'), true)
+  assert.equal(calls.setHistory, 1)
+  assert.equal(calls.children, 0)
+  assert.deepEqual(projectedChildren, [[]])
+
+  await service.syncSessionView('session-partial', {
+    activate: true,
+    progressive: true,
+  })
+  assert.equal(service.isSessionPartiallyHydrated('session-partial'), true)
+  assert.equal(calls.setHistory, 1)
+  assert.equal(calls.children, 0)
+  assert.deepEqual(projectedChildren, [[]])
+
+  await service.syncSessionView('session-partial', {
+    force: true,
+    activate: false,
+  })
+  assert.equal(service.isSessionPartiallyHydrated('session-partial'), false)
+  assert.equal(calls.setHistory, 2)
+  assert.equal(calls.children, 2)
+  assert.deepEqual(projectedChildren, [[], ['child-1']])
 })
 
 test('createSessionHistoryService synthesizes changeSummary for write-only session artifacts', async () => {

--- a/tests/session-history-loader.test.ts
+++ b/tests/session-history-loader.test.ts
@@ -587,6 +587,107 @@ test('createSessionHistoryService forwards forced refresh syncs without caller-m
   }])
 })
 
+test('createSessionHistoryService can hydrate root history before child transcripts', async () => {
+  const view = createEmptySessionView()
+  const calls = {
+    children: 0,
+    childSnapshot: 0,
+    diff: 0,
+    setHistory: 0,
+  }
+  const updates: Array<Record<string, unknown>> = []
+
+  const service = createSessionHistoryService({
+    getSessionClient: async () => ({
+      client: {
+        session: {
+          messages: async ({ sessionID }: { sessionID: string }) => {
+            if (sessionID !== 'session-progressive') calls.childSnapshot += 1
+            return { data: [] }
+          },
+          todo: async () => ({ data: [] }),
+          children: async () => {
+            calls.children += 1
+            return { data: [{ id: 'child-1', title: 'Analyst', parentID: 'session-progressive', time: { created: 1 } }] }
+          },
+          diff: async () => {
+            calls.diff += 1
+            return { data: [] }
+          },
+          status: async () => ({ data: {} }),
+          get: async () => ({ data: null }),
+        },
+      },
+      questionClient: {},
+      record: null,
+    }),
+    listPendingQuestions: async () => ({ data: [] }),
+    listPendingPermissions: async () => ({ data: [] }),
+    projectSessionHistory: async (input) => {
+      assert.deepEqual(input.children, [])
+      return []
+    },
+    getCachedModelId: () => '',
+    updateSessionRecord: (_sessionId, patch) => {
+      updates.push(patch)
+      return null
+    },
+    buildSessionUsageSummary: () => ({
+      messages: 0,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      taskRuns: 0,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    }),
+    sessionEngine: {
+      isHydrated: () => false,
+      activateSession: () => {},
+      setSessionFromHistory: () => {
+        calls.setHistory += 1
+      },
+      setPendingQuestions: () => {},
+      setPendingApprovals: () => {},
+      getSessionView: () => view,
+    },
+  })
+
+  const result = await service.syncSessionView('session-progressive', {
+    activate: true,
+    progressive: true,
+  })
+
+  assert.equal(result, view)
+  assert.equal(calls.children, 0)
+  assert.equal(calls.childSnapshot, 0)
+  assert.equal(calls.diff, 0)
+  assert.equal(calls.setHistory, 1)
+  assert.deepEqual(updates[0], {
+    summary: {
+      messages: 0,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      taskRuns: 0,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    },
+  })
+})
+
 test('createSessionHistoryService synthesizes changeSummary for write-only session artifacts', async () => {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-sync-summary-'))
   try {


### PR DESCRIPTION
## Summary
- add a safe cached bundled-skill index and one-pass built-in skill bundle materialization for large downstream catalogs
- cache agent catalog/summary responses with bounded TTL and invalidate on agent, skill, MCP, and runtime changes
- make cold thread activation render root history first, then hydrate child transcripts/diff summaries in the background
- align local lint secret scanning with ignored generated output directories

## Validation
- pnpm test -- session-history-loader.test.ts effective-skills.test.ts runtime-content.test.ts runtime-skill-catalog.test.ts custom-agents-regression.test.ts capability-catalog.test.ts
- pnpm typecheck
- pnpm lint
- pnpm perf:check
- git diff --check