### PR TITLE
Fix device-code auth instructions

### DIFF
--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
@@ -17,7 +17,7 @@ describe('ProviderAuthControls', () => {
     vi.mocked(window.coworkApi.provider.authorize).mockResolvedValue({
       url: 'https://auth.example.test',
       method: 'auto',
-      instructions: 'Finish in your browser.',
+      instructions: '',
     })
     vi.mocked(window.coworkApi.provider.list).mockResolvedValue([
       { id: 'openai', name: 'OpenAI', connected: true },
@@ -47,6 +47,37 @@ describe('ProviderAuthControls', () => {
     await waitFor(() => expect(onAuthUpdated).toHaveBeenCalledTimes(1))
     expect(window.coworkApi.runtime.restart).not.toHaveBeenCalled()
     expect(screen.getByText('Provider login completed.')).toBeTruthy()
+  })
+
+  it('shows and copies auto auth instructions for device-code providers', async () => {
+    vi.mocked(window.coworkApi.provider.authMethods).mockResolvedValue({
+      'github-copilot': [{ type: 'oauth', label: 'GitHub Copilot' }],
+    })
+    vi.mocked(window.coworkApi.provider.authorize).mockResolvedValue({
+      url: 'https://github.com/login/device',
+      method: 'auto',
+      instructions: 'Enter code ABCD-1234 at https://github.com/login/device',
+    })
+    const user = userEvent.setup()
+
+    render(
+      <ProviderAuthControls
+        providerId="github-copilot"
+        providerName="GitHub Copilot"
+        connected={false}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Sign in with GitHub Copilot' }))
+
+    expect(screen.getByText('Browser login opened. Follow the instructions below, then return here and confirm so Open Cowork can verify the new login.')).toBeTruthy()
+    expect(screen.getByText('Login instructions')).toBeTruthy()
+    expect(screen.getByText('Enter code ABCD-1234 at https://github.com/login/device')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'Copy' }))
+
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith('Enter code ABCD-1234 at https://github.com/login/device')
+    expect(screen.getByText('Login instructions copied to clipboard.')).toBeTruthy()
   })
 
   it('can clear stale OpenCode-native provider auth before a fresh login', async () => {

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ProviderAuthAuthorization, ProviderAuthMethod, ProviderAuthPrompt } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
+import { writeTextToClipboard } from '../../helpers/clipboard'
 
 function suggestedAuthLabel(providerId: string | null | undefined, providerName?: string) {
   if (providerId === 'openai') return 'ChatGPT Plus/Pro'
@@ -48,6 +49,7 @@ export function ProviderAuthControls({
   const [status, setStatus] = useState<string | null>(null)
   const [pending, setPending] = useState<{ method: number; authorization: ProviderAuthAuthorization } | null>(null)
   const [pendingBrowserLogin, setPendingBrowserLogin] = useState(false)
+  const [browserLoginInstructions, setBrowserLoginInstructions] = useState<string | null>(null)
   const [code, setCode] = useState('')
   const [methodInputs, setMethodInputs] = useState<Record<number, Record<string, string>>>({})
 
@@ -95,6 +97,7 @@ export function ProviderAuthControls({
     setStatus(null)
     setPending(null)
     setPendingBrowserLogin(false)
+    setBrowserLoginInstructions(null)
     setCode('')
     setMethodInputs({})
     void loadMethods()
@@ -125,6 +128,7 @@ export function ProviderAuthControls({
     setStatus(null)
     setPending(null)
     setPendingBrowserLogin(false)
+    setBrowserLoginInstructions(null)
     try {
       if (onBeforeAuthorize) {
         const ok = await onBeforeAuthorize()
@@ -153,7 +157,11 @@ export function ProviderAuthControls({
         setStatus(authorization.instructions || t('providerAuth.enterCode', 'Complete the browser login, then paste the authorization code here.'))
       } else {
         setPendingBrowserLogin(true)
-        setStatus(t('providerAuth.browserOpened', 'Browser login opened. Complete the flow there, then return here and confirm so Open Cowork can verify the new login.'))
+        const instructions = authorization.instructions?.trim() || null
+        setBrowserLoginInstructions(instructions)
+        setStatus(instructions
+          ? t('providerAuth.browserOpenedWithInstructions', 'Browser login opened. Follow the instructions below, then return here and confirm so Open Cowork can verify the new login.')
+          : t('providerAuth.browserOpened', 'Browser login opened. Complete the flow there, then return here and confirm so Open Cowork can verify the new login.'))
       }
     } catch (err) {
       setStatus(err instanceof Error ? err.message : String(err))
@@ -177,6 +185,7 @@ export function ProviderAuthControls({
           return
         }
         setPending(null)
+        setBrowserLoginInstructions(null)
         setCode('')
         await onAuthUpdated?.()
       }
@@ -222,6 +231,7 @@ export function ProviderAuthControls({
       }
       await onAuthUpdated?.()
       setPendingBrowserLogin(false)
+      setBrowserLoginInstructions(null)
       setStatus(t('providerAuth.connected', 'Provider login completed.'))
     } catch (err) {
       setStatus(err instanceof Error ? err.message : String(err))
@@ -238,6 +248,7 @@ export function ProviderAuthControls({
       await window.coworkApi.provider.logout(providerId)
       setPending(null)
       setPendingBrowserLogin(false)
+      setBrowserLoginInstructions(null)
       setCode('')
       setStatus(t('providerAuth.removed', 'Provider login removed. Sign in again to refresh the token.'))
       await onAuthUpdated?.()
@@ -250,6 +261,13 @@ export function ProviderAuthControls({
   }
 
   const entries = oauthMethods
+  const copyBrowserLoginInstructions = async () => {
+    if (!browserLoginInstructions) return
+    const copied = await writeTextToClipboard(browserLoginInstructions)
+    setStatus(copied
+      ? t('providerAuth.instructionsCopied', 'Login instructions copied to clipboard.')
+      : t('providerAuth.instructionsCopyFailed', 'Could not copy login instructions. Select the instructions and copy them manually.'))
+  }
 
   return (
     <div className="flex flex-col gap-3">
@@ -356,16 +374,37 @@ export function ProviderAuthControls({
           </div>
         ) : null}
         {pendingBrowserLogin ? (
-          <button
-            type="button"
-            onClick={finishBrowserLogin}
-            disabled={authorizing !== null}
-            className="px-3 py-2 rounded-xl text-[12px] font-semibold cursor-pointer transition-colors disabled:opacity-60 disabled:cursor-wait border border-border-subtle text-text hover:bg-surface-hover"
-          >
-            {authorizing === -1
-              ? t('providerAuth.finishing', 'Finishing...')
-              : t('providerAuth.finishedBrowserLogin', "I've finished signing in")}
-          </button>
+          <div className="flex flex-col gap-2">
+            {browserLoginInstructions ? (
+              <div className="rounded-xl border border-border-subtle p-3 flex flex-col gap-2" style={{ background: 'var(--color-surface)' }}>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[11px] font-semibold text-text">
+                    {t('providerAuth.loginInstructions', 'Login instructions')}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => void copyBrowserLoginInstructions()}
+                    className="shrink-0 px-2 py-1 rounded-lg border border-border-subtle text-[11px] font-semibold text-text hover:bg-surface-hover cursor-pointer"
+                  >
+                    {t('providerAuth.copyInstructions', 'Copy')}
+                  </button>
+                </div>
+                <pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-text">
+                  {browserLoginInstructions}
+                </pre>
+              </div>
+            ) : null}
+            <button
+              type="button"
+              onClick={finishBrowserLogin}
+              disabled={authorizing !== null}
+              className="px-3 py-2 rounded-xl text-[12px] font-semibold cursor-pointer transition-colors disabled:opacity-60 disabled:cursor-wait border border-border-subtle text-text hover:bg-surface-hover"
+            >
+              {authorizing === -1
+                ? t('providerAuth.finishing', 'Finishing...')
+                : t('providerAuth.finishedBrowserLogin', "I've finished signing in")}
+            </button>
+          </div>
         ) : null}
         {status ? <div className="text-[11px] text-text-muted leading-relaxed">{status}</div> : null}
       </div>


### PR DESCRIPTION
Closes #382

Summary:
- show OpenCode auto-auth instructions in the provider login flow
- render instructions in a prominent copyable panel for device-code providers
- add renderer coverage for GitHub Copilot-style auto auth instructions

Validation:
- pnpm --filter @open-cowork/desktop test:renderer -- ProviderAuthControls.test.tsx
- pnpm typecheck
- pnpm lint
- git diff --check