### PR TITLE
Fix task tool child metadata projection

### DIFF
--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -7,6 +7,7 @@ import {
 import { readRecordValue, readString } from './normalizer-utils.ts'
 import { resolveDisplayCost } from './pricing.ts'
 import {
+  bindTaskRunToChild,
   ensureTaskRunForChild,
   findFallbackTaskRun,
   getTaskRun,
@@ -620,7 +621,11 @@ function resolveTaskToolDescriptor(
   const state = ctx.part.state
   const metadataAgent = typeof metadata.agent === 'string' ? metadata.agent : null
   const inputAgent = readString(readRecordValue(state.input, 'agent'))
+    || readString(readRecordValue(state.input, 'subagent_type'))
+    || readString(readRecordValue(state.input, 'subagentType'))
   const argsAgent = readString(readRecordValue(state.args, 'agent'))
+    || readString(readRecordValue(state.args, 'subagent_type'))
+    || readString(readRecordValue(state.args, 'subagentType'))
   const inputDescription = readString(readRecordValue(state.input, 'description'))
   const argsDescription = readString(readRecordValue(state.args, 'description'))
   const inputTitle = readString(readRecordValue(state.input, 'title'))
@@ -654,6 +659,18 @@ function resolveTaskToolDescriptor(
   }
 }
 
+function readTaskToolSessionId(metadata: Record<string, unknown>) {
+  return readString(readRecordValue(metadata, 'sessionId'))
+    || readString(readRecordValue(metadata, 'sessionID'))
+    || readString(readRecordValue(metadata, 'session_id'))
+}
+
+function readTaskToolParentSessionId(metadata: Record<string, unknown>) {
+  return readString(readRecordValue(metadata, 'parentSessionId'))
+    || readString(readRecordValue(metadata, 'parentSessionID'))
+    || readString(readRecordValue(metadata, 'parent_session_id'))
+}
+
 function handleUpdatedTaskToolPart(
   ctx: MessagePartUpdatedContext,
   input: {
@@ -665,13 +682,40 @@ function handleUpdatedTaskToolPart(
 ) {
   if (ctx.part.tool !== 'task') return false
   const parentSessionId = ctx.actualSessionId || ctx.rootSessionId
-  const taskRunId = ctx.part.callId || ctx.part.id || `${parentSessionId}:task:${crypto.randomUUID()}`
+  const childSessionId = readTaskToolSessionId(input.metadata)
+  const taskParentSessionId = readTaskToolParentSessionId(input.metadata) || parentSessionId
+  const providerTaskRunId = ctx.part.callId || ctx.part.id || `${parentSessionId}:task:${crypto.randomUUID()}`
+  let taskRunId = providerTaskRunId
+  let existingTaskRun = getTaskRun(providerTaskRunId)
+  let existingChildTaskRunId = childSessionId ? getTaskRunIdForChild(childSessionId) : null
+  let existingTaskRunWasChildBound = Boolean(
+    existingTaskRun?.childSessionId
+      || (existingChildTaskRunId ? getTaskRun(existingChildTaskRunId)?.childSessionId : null),
+  )
+
+  if (childSessionId) {
+    registerSession(childSessionId, taskParentSessionId)
+    if (existingTaskRun) {
+      const bound = bindTaskRunToChild(providerTaskRunId, childSessionId)
+      taskRunId = bound?.id || providerTaskRunId
+      existingTaskRun = bound || getTaskRun(taskRunId)
+    } else {
+      existingChildTaskRunId = existingChildTaskRunId || getTaskRunIdForChild(childSessionId)
+      taskRunId = existingChildTaskRunId || `child:${childSessionId}`
+      existingTaskRun = getTaskRun(taskRunId)
+      existingTaskRunWasChildBound = Boolean(existingTaskRun?.childSessionId)
+    }
+  }
   const { agentName, titleCandidates } = resolveTaskToolDescriptor(ctx, input.metadata, input.title)
-  const existingTaskRun = getTaskRun(taskRunId)
+  const preservedChildStatus = existingTaskRunWasChildBound
+    && existingTaskRun
+    && existingTaskRun.status !== 'queued'
+    ? existingTaskRun.status
+    : null
   const taskStatus = input.isError
     ? 'error'
-    : existingTaskRun?.childSessionId
-      ? existingTaskRun.status === 'queued' ? 'running' : existingTaskRun.status
+    : childSessionId
+      ? preservedChildStatus || 'running'
       : input.isComplete
         ? 'complete'
         : 'queued'
@@ -689,10 +733,10 @@ function handleUpdatedTaskToolPart(
     : registerTaskRun({
         id: taskRunId,
         rootSessionId: ctx.rootSessionId,
-        parentSessionId,
+        parentSessionId: taskParentSessionId,
         title: chooseTaskTitle(agentName, ...titleCandidates),
         agent: agentName,
-        childSessionId: null,
+        childSessionId: childSessionId || null,
         status: taskStatus,
       })
   if (taskRun) emitTaskRun(ctx.win, taskRun)
@@ -707,7 +751,10 @@ function handleUpdatedToolPart(ctx: MessagePartUpdatedContext) {
   const isComplete = !isError && (statusValue === 'completed' || statusValue === 'complete' || state.output !== undefined)
   const status = isError ? 'error' : isComplete ? 'complete' : 'running'
   const title = ctx.part.title || state.title || ''
-  const metadata = Object.keys(ctx.part.metadata).length > 0 ? ctx.part.metadata : state.metadata
+  const metadata = {
+    ...state.metadata,
+    ...ctx.part.metadata,
+  }
 
   if (ctx.part.tool === 'question') return true
   if (handleUpdatedTaskToolPart(ctx, { isComplete, isError, metadata, title })) return true

--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -14,6 +14,7 @@ import {
   getTaskRunIdForChild,
   registerSession,
   registerTaskRun,
+  resolveTaskRunId,
   resolveRootSession,
   updateTaskRun,
   consumePendingPromptEcho,
@@ -685,8 +686,9 @@ function handleUpdatedTaskToolPart(
   const childSessionId = readTaskToolSessionId(input.metadata)
   const taskParentSessionId = readTaskToolParentSessionId(input.metadata) || parentSessionId
   const providerTaskRunId = ctx.part.callId || ctx.part.id || `${parentSessionId}:task:${crypto.randomUUID()}`
-  let taskRunId = providerTaskRunId
+  let taskRunId = resolveTaskRunId(providerTaskRunId) || providerTaskRunId
   let existingTaskRun = getTaskRun(providerTaskRunId)
+  if (!existingTaskRun && taskRunId !== providerTaskRunId) existingTaskRun = getTaskRun(taskRunId)
   let existingChildTaskRunId = childSessionId ? getTaskRunIdForChild(childSessionId) : null
   let childTaskRunBeforeBind = existingTaskRun?.childSessionId
     ? existingTaskRun
@@ -708,12 +710,14 @@ function handleUpdatedTaskToolPart(
     }
   }
   const { agentName, titleCandidates } = resolveTaskToolDescriptor(ctx, input.metadata, input.title)
-  const preservedChildStatus = childTaskRunBeforeBind?.status && childTaskRunBeforeBind.status !== 'queued'
-    ? childTaskRunBeforeBind.status
+  const childOwnedTaskRun = childTaskRunBeforeBind || (existingTaskRun?.childSessionId ? existingTaskRun : null)
+  const preservedChildStatus = childOwnedTaskRun?.status && childOwnedTaskRun.status !== 'queued'
+    ? childOwnedTaskRun.status
     : null
+  const hasChildOwnedTaskRun = Boolean(childSessionId || childOwnedTaskRun)
   const taskStatus = input.isError
     ? 'error'
-    : childSessionId
+    : hasChildOwnedTaskRun
       ? preservedChildStatus || 'running'
       : input.isComplete
         ? 'complete'

--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -7,6 +7,7 @@ import {
 import { readRecordValue, readString } from './normalizer-utils.ts'
 import { resolveDisplayCost } from './pricing.ts'
 import {
+  aliasTaskRunId,
   bindTaskRunToChild,
   ensureTaskRunForChild,
   findFallbackTaskRun,
@@ -742,6 +743,9 @@ function handleUpdatedTaskToolPart(
         childSessionId: childSessionId || null,
         status: taskStatus,
       })
+  if (taskRun?.childSessionId && taskRun.id !== providerTaskRunId) {
+    aliasTaskRunId(providerTaskRunId, taskRun.id)
+  }
   if (taskRun) emitTaskRun(ctx.win, taskRun)
   return true
 }

--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -688,10 +688,11 @@ function handleUpdatedTaskToolPart(
   let taskRunId = providerTaskRunId
   let existingTaskRun = getTaskRun(providerTaskRunId)
   let existingChildTaskRunId = childSessionId ? getTaskRunIdForChild(childSessionId) : null
-  let existingTaskRunWasChildBound = Boolean(
-    existingTaskRun?.childSessionId
-      || (existingChildTaskRunId ? getTaskRun(existingChildTaskRunId)?.childSessionId : null),
-  )
+  let childTaskRunBeforeBind = existingTaskRun?.childSessionId
+    ? existingTaskRun
+    : existingChildTaskRunId
+      ? getTaskRun(existingChildTaskRunId)
+      : null
 
   if (childSessionId) {
     registerSession(childSessionId, taskParentSessionId)
@@ -703,14 +704,12 @@ function handleUpdatedTaskToolPart(
       existingChildTaskRunId = existingChildTaskRunId || getTaskRunIdForChild(childSessionId)
       taskRunId = existingChildTaskRunId || `child:${childSessionId}`
       existingTaskRun = getTaskRun(taskRunId)
-      existingTaskRunWasChildBound = Boolean(existingTaskRun?.childSessionId)
+      childTaskRunBeforeBind = existingTaskRun?.childSessionId ? existingTaskRun : null
     }
   }
   const { agentName, titleCandidates } = resolveTaskToolDescriptor(ctx, input.metadata, input.title)
-  const preservedChildStatus = existingTaskRunWasChildBound
-    && existingTaskRun
-    && existingTaskRun.status !== 'queued'
-    ? existingTaskRun.status
+  const preservedChildStatus = childTaskRunBeforeBind?.status && childTaskRunBeforeBind.status !== 'queued'
+    ? childTaskRunBeforeBind.status
     : null
   const taskStatus = input.isError
     ? 'error'

--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -76,6 +76,10 @@ export function getTaskRunIdForChild(sessionId: string | null | undefined) {
   return hierarchyStore.getTaskRunIdForChild(sessionId)
 }
 
+export function aliasTaskRunId(aliasId: string | null | undefined, targetId: string | null | undefined) {
+  hierarchyStore.aliasTaskRunId(aliasId, targetId)
+}
+
 export function resolveTaskRunId(taskRunId: string | null | undefined) {
   return hierarchyStore.resolveTaskRunId(taskRunId)
 }

--- a/apps/desktop/src/main/event-task-state.ts
+++ b/apps/desktop/src/main/event-task-state.ts
@@ -76,6 +76,10 @@ export function getTaskRunIdForChild(sessionId: string | null | undefined) {
   return hierarchyStore.getTaskRunIdForChild(sessionId)
 }
 
+export function resolveTaskRunId(taskRunId: string | null | undefined) {
+  return hierarchyStore.resolveTaskRunId(taskRunId)
+}
+
 export function rememberSubmittedPrompt(sessionId: string, text: string) {
   hierarchyStore.rememberSubmittedPrompt(sessionId, text)
 }

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -104,7 +104,11 @@ function stringField(record: Record<string, unknown>, key: string) {
 
 function taskToolDescriptor(part: NormalizedMessagePart, child?: ChildSessionRecord | null) {
   const inputAgent = stringField(part.state.input, 'agent')
+    || stringField(part.state.input, 'subagent_type')
+    || stringField(part.state.input, 'subagentType')
   const argsAgent = stringField(part.state.args, 'agent')
+    || stringField(part.state.args, 'subagent_type')
+    || stringField(part.state.args, 'subagentType')
   const metadataAgent = stringField(part.state.metadata, 'agent') || stringField(part.metadata, 'agent')
   const inputDescription = stringField(part.state.input, 'description')
   const argsDescription = stringField(part.state.args, 'description')

--- a/apps/desktop/src/main/session-task-state-store.ts
+++ b/apps/desktop/src/main/session-task-state-store.ts
@@ -40,6 +40,7 @@ export class SessionTaskStateStore {
   private readonly sessionLineage = new Map<string, string>()
   private readonly taskRuns = new Map<string, TaskRunMeta>()
   private readonly childSessionToTaskRunId = new Map<string, string>()
+  private readonly taskRunAliases = new Map<string, string>()
   private readonly pendingTaskRunsByParent = new Map<string, string[]>()
   private readonly queuedChildSessionsByParent = new Map<string, QueuedChildSessionMeta[]>()
   private readonly pendingSubmittedPromptBySession = new Map<string, string>()
@@ -49,6 +50,7 @@ export class SessionTaskStateStore {
     this.sessionLineage.clear()
     this.taskRuns.clear()
     this.childSessionToTaskRunId.clear()
+    this.taskRunAliases.clear()
     this.pendingTaskRunsByParent.clear()
     this.queuedChildSessionsByParent.clear()
     this.pendingSubmittedPromptBySession.clear()
@@ -117,11 +119,12 @@ export class SessionTaskStateStore {
   }
 
   bindTaskRunToChild(taskRunId: string, childSessionId: string) {
+    const resolvedTaskRunId = this.resolveTaskRunId(taskRunId) || taskRunId
     const existingTaskRunId = this.childSessionToTaskRunId.get(childSessionId)
     const childParentSessionId = this.getImmediateParentSession(childSessionId)
-    if (existingTaskRunId && existingTaskRunId !== taskRunId) {
+    if (existingTaskRunId && existingTaskRunId !== resolvedTaskRunId) {
       const existingTaskRun = this.taskRuns.get(existingTaskRunId)
-      const incomingTaskRun = this.taskRuns.get(taskRunId)
+      const incomingTaskRun = this.taskRuns.get(resolvedTaskRunId)
 
       if (existingTaskRun && incomingTaskRun) {
         const mergedAgent = incomingTaskRun.agent || existingTaskRun.agent
@@ -156,20 +159,23 @@ export class SessionTaskStateStore {
         }
 
         this.taskRuns.set(existingTaskRunId, mergedTaskRun)
-        this.taskRuns.delete(taskRunId)
+        this.taskRuns.delete(resolvedTaskRunId)
         this.childSessionToTaskRunId.set(childSessionId, existingTaskRunId)
-        this.removePendingTaskRun(taskRunId)
+        this.taskRunAliases.set(taskRunId, existingTaskRunId)
+        if (resolvedTaskRunId !== taskRunId) this.taskRunAliases.set(resolvedTaskRunId, existingTaskRunId)
+        this.removePendingTaskRun(resolvedTaskRunId)
         this.removeQueuedChildSession(childSessionId)
         return mergedTaskRun
       }
     }
 
-    const taskRun = this.taskRuns.get(taskRunId)
+    const taskRun = this.taskRuns.get(resolvedTaskRunId)
     if (!taskRun) return null
     taskRun.childSessionId = childSessionId
     taskRun.parentSessionId = childParentSessionId || taskRun.parentSessionId || taskRun.rootSessionId
-    this.childSessionToTaskRunId.set(childSessionId, taskRunId)
-    this.removePendingTaskRun(taskRunId)
+    this.childSessionToTaskRunId.set(childSessionId, resolvedTaskRunId)
+    if (resolvedTaskRunId !== taskRunId) this.taskRunAliases.set(taskRunId, resolvedTaskRunId)
+    this.removePendingTaskRun(resolvedTaskRunId)
     this.removeQueuedChildSession(childSessionId)
     return taskRun
   }
@@ -179,6 +185,7 @@ export class SessionTaskStateStore {
       ...taskRun,
       parentSessionId: taskRun.parentSessionId || taskRun.rootSessionId,
     })
+    this.taskRunAliases.delete(normalizedTaskRun.id)
     this.taskRuns.set(normalizedTaskRun.id, normalizedTaskRun)
     const parentQueueKey = normalizedTaskRun.parentSessionId || normalizedTaskRun.rootSessionId
 
@@ -259,12 +266,13 @@ export class SessionTaskStateStore {
   }
 
   updateTaskRun(taskRunId: string, patch: Partial<TaskRunMeta>) {
-    const existing = this.taskRuns.get(taskRunId)
+    const resolvedTaskRunId = this.resolveTaskRunId(taskRunId) || taskRunId
+    const existing = this.taskRuns.get(resolvedTaskRunId)
     if (!existing) return null
     const next = applyTaskTimingTransition(existing, patch)
-    this.taskRuns.set(taskRunId, next)
+    this.taskRuns.set(resolvedTaskRunId, next)
     if (next.childSessionId) {
-      this.childSessionToTaskRunId.set(next.childSessionId, next.id)
+      this.childSessionToTaskRunId.set(next.childSessionId, resolvedTaskRunId)
     } else if (isTerminalTaskStatus(next.status)) {
       this.removePendingTaskRun(next.id)
     }
@@ -279,6 +287,16 @@ export class SessionTaskStateStore {
   getTaskRunIdForChild(sessionId: string | null | undefined) {
     if (!sessionId) return null
     return this.childSessionToTaskRunId.get(sessionId) || null
+  }
+
+  resolveTaskRunId(taskRunId: string | null | undefined) {
+    if (!taskRunId) return null
+    if (this.taskRuns.has(taskRunId)) return taskRunId
+    const aliasedTaskRunId = this.taskRunAliases.get(taskRunId)
+    if (!aliasedTaskRunId) return null
+    if (this.taskRuns.has(aliasedTaskRunId)) return aliasedTaskRunId
+    this.taskRunAliases.delete(taskRunId)
+    return null
   }
 
   rememberSubmittedPrompt(sessionId: string, text: string) {
@@ -316,6 +334,12 @@ export class SessionTaskStateStore {
       }
     }
 
+    for (const [aliasTaskRunId, taskRunId] of this.taskRunAliases.entries()) {
+      if (!this.taskRuns.has(taskRunId) || aliasTaskRunId === taskRunId) {
+        this.taskRunAliases.delete(aliasTaskRunId)
+      }
+    }
+
     for (const [parentSessionId] of this.pendingTaskRunsByParent.entries()) {
       if (!this.isKnownSession(parentSessionId)) {
         this.pendingTaskRunsByParent.delete(parentSessionId)
@@ -344,9 +368,14 @@ export class SessionTaskStateStore {
     this.queuedChildSessionsByParent.delete(sessionId)
     this.pendingSubmittedPromptBySession.delete(sessionId)
     this.deleteTaskRunsForSessions([sessionId])
+    const deletedTaskRunIds = new Set<string>()
     for (const [taskRunId, taskRun] of this.taskRuns.entries()) {
-      if (taskRun.rootSessionId === sessionId) this.taskRuns.delete(taskRunId)
+      if (taskRun.rootSessionId === sessionId) {
+        deletedTaskRunIds.add(taskRunId)
+        this.taskRuns.delete(taskRunId)
+      }
     }
+    this.removeTaskRunAliasesForTaskIds(deletedTaskRunIds)
     this.removeDescendantLineage(sessionId)
   }
 
@@ -433,6 +462,7 @@ export class SessionTaskStateStore {
 
   private deleteTaskRunsForSessions(sessionIds: string[]) {
     const targetIds = new Set(sessionIds)
+    const deletedTaskRunIds = new Set<string>()
     for (const sessionId of targetIds) {
       this.childSessionToTaskRunId.delete(sessionId)
     }
@@ -442,7 +472,18 @@ export class SessionTaskStateStore {
         (childSessionId && targetIds.has(childSessionId))
         || (taskRunId.startsWith('child:') && targetIds.has(taskRunId.slice('child:'.length)))
       ) {
+        deletedTaskRunIds.add(taskRunId)
         this.taskRuns.delete(taskRunId)
+      }
+    }
+    this.removeTaskRunAliasesForTaskIds(deletedTaskRunIds)
+  }
+
+  private removeTaskRunAliasesForTaskIds(taskRunIds: Set<string>) {
+    if (taskRunIds.size === 0) return
+    for (const [aliasTaskRunId, targetTaskRunId] of this.taskRunAliases.entries()) {
+      if (taskRunIds.has(aliasTaskRunId) || taskRunIds.has(targetTaskRunId)) {
+        this.taskRunAliases.delete(aliasTaskRunId)
       }
     }
   }

--- a/apps/desktop/src/main/session-task-state-store.ts
+++ b/apps/desktop/src/main/session-task-state-store.ts
@@ -289,6 +289,13 @@ export class SessionTaskStateStore {
     return this.childSessionToTaskRunId.get(sessionId) || null
   }
 
+  aliasTaskRunId(aliasTaskRunId: string | null | undefined, targetTaskRunId: string | null | undefined) {
+    if (!aliasTaskRunId || !targetTaskRunId || aliasTaskRunId === targetTaskRunId) return
+    const resolvedTargetTaskRunId = this.resolveTaskRunId(targetTaskRunId) || targetTaskRunId
+    if (!this.taskRuns.has(resolvedTargetTaskRunId)) return
+    this.taskRunAliases.set(aliasTaskRunId, resolvedTargetTaskRunId)
+  }
+
   resolveTaskRunId(taskRunId: string | null | undefined) {
     if (!taskRunId) return null
     if (this.taskRuns.has(taskRunId)) return taskRunId

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -517,6 +517,246 @@ test('terminal root task tool calls do not bind a later child session', () => {
   assert.equal(getTaskRun('child:child-session'), null)
 })
 
+test('completed root task tool with explicit child metadata starts the child task lane only', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+  registerSession('child-session', 'root-session')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        state: {
+          status: 'completed',
+          input: {
+            subagent_type: 'explore',
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          output: 'task_id: child-session',
+          metadata: {
+            parentSessionId: 'root-session',
+            sessionId: 'child-session',
+          },
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const task = getTaskRun('child:child-session')
+  assert.equal(getTaskRun('call-task-1'), null)
+  assert.equal(task?.childSessionId, 'child-session')
+  assert.equal(task?.parentSessionId, 'root-session')
+  assert.equal(task?.status, 'running')
+  assert.equal(task?.agent, 'explore')
+  assert.equal(task?.title, 'Explore MCP examples and structure')
+})
+
+test('late explicit child metadata binds the pending task call without duplicating lanes', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        state: {
+          status: 'running',
+          input: {
+            subagent_type: 'explore',
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          metadata: {},
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        state: {
+          status: 'completed',
+          input: {
+            subagent_type: 'explore',
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          output: 'task_id: child-session',
+          metadata: {
+            parentSessionId: 'root-session',
+            sessionId: 'child-session',
+          },
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const task = getTaskRun('call-task-1')
+  assert.equal(getTaskRun('child:child-session'), null)
+  assert.equal(task?.childSessionId, 'child-session')
+  assert.equal(task?.parentSessionId, 'root-session')
+  assert.equal(task?.status, 'running')
+  assert.equal(task?.agent, 'explore')
+  assert.equal(task?.title, 'Explore MCP examples and structure')
+})
+
+test('late explicit child metadata preserves child-owned terminal status when merging lanes', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+  registerSession('child-session', 'root-session')
+  registerTaskRun({
+    id: 'call-task-1',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'Explore MCP examples and structure',
+    agent: 'explore',
+    childSessionId: null,
+    status: 'queued',
+  })
+  registerTaskRun({
+    id: 'child:child-session',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'Explore MCP examples and structure',
+    agent: 'explore',
+    childSessionId: 'child-session',
+    status: 'complete',
+  })
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        state: {
+          status: 'completed',
+          input: {
+            subagent_type: 'explore',
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          output: 'task_id: child-session',
+          metadata: {
+            parentSessionId: 'root-session',
+            sessionId: 'child-session',
+          },
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const task = getTaskRun('child:child-session')
+  assert.equal(getTaskRun('call-task-1'), null)
+  assert.equal(task?.childSessionId, 'child-session')
+  assert.equal(task?.status, 'complete')
+})
+
+test('task tool child ids can arrive in state metadata while top-level metadata is present', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        metadata: {
+          agent: 'explore',
+        },
+        state: {
+          status: 'completed',
+          input: {
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          output: 'task_id: child-session',
+          metadata: {
+            parentSessionId: 'root-session',
+            sessionId: 'child-session',
+          },
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const task = getTaskRun('child:child-session')
+  assert.equal(task?.childSessionId, 'child-session')
+  assert.equal(task?.parentSessionId, 'root-session')
+  assert.equal(task?.status, 'running')
+  assert.equal(task?.agent, 'explore')
+})
+
 test('root task tool state.error marks the pending subagent lane failed', () => {
   const collector = createDispatchCollector()
   const win = {

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -708,6 +708,71 @@ test('late explicit child metadata preserves child-owned terminal status when me
   assert.equal(task?.status, 'complete')
 })
 
+test('late explicit child metadata preserves child-owned running status when merging lanes', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+  registerSession('child-session', 'root-session')
+  registerTaskRun({
+    id: 'call-task-1',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'Explore MCP examples and structure',
+    agent: 'explore',
+    childSessionId: null,
+    status: 'complete',
+  })
+  registerTaskRun({
+    id: 'child:child-session',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'Explore MCP examples and structure',
+    agent: 'explore',
+    childSessionId: 'child-session',
+    status: 'running',
+  })
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        state: {
+          status: 'completed',
+          input: {
+            subagent_type: 'explore',
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          output: 'task_id: child-session',
+          metadata: {
+            parentSessionId: 'root-session',
+            sessionId: 'child-session',
+          },
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const task = getTaskRun('child:child-session')
+  assert.equal(getTaskRun('call-task-1'), null)
+  assert.equal(task?.childSessionId, 'child-session')
+  assert.equal(task?.status, 'running')
+})
+
 test('task tool child ids can arrive in state metadata while top-level metadata is present', () => {
   const collector = createDispatchCollector()
   const win = {

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -565,6 +565,39 @@ test('completed root task tool with explicit child metadata starts the child tas
   assert.equal(task?.status, 'running')
   assert.equal(task?.agent, 'explore')
   assert.equal(task?.title, 'Explore MCP examples and structure')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        state: {
+          status: 'completed',
+          input: {
+            subagent_type: 'explore',
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          output: 'task_id: child-session',
+          metadata: {},
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const updatedTask = getTaskRun('child:child-session')
+  assert.equal(getTaskRun('call-task-1'), null)
+  assert.equal(updatedTask?.childSessionId, 'child-session')
+  assert.equal(updatedTask?.status, 'running')
 })
 
 test('late explicit child metadata binds the pending task call without duplicating lanes', () => {

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -771,6 +771,39 @@ test('late explicit child metadata preserves child-owned running status when mer
   assert.equal(getTaskRun('call-task-1'), null)
   assert.equal(task?.childSessionId, 'child-session')
   assert.equal(task?.status, 'running')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        id: 'part-task',
+        callID: 'call-task-1',
+        type: 'tool',
+        tool: 'task',
+        title: 'Explore MCP examples and structure',
+        state: {
+          status: 'completed',
+          input: {
+            subagent_type: 'explore',
+            description: 'Explore MCP examples and structure',
+            prompt: 'Explore engaging MCP examples.',
+          },
+          output: 'task_id: child-session',
+          metadata: {},
+        },
+      },
+    },
+    createSessionScopedMessageState(),
+    'openai/gpt-5.5',
+  )
+
+  const updatedTask = getTaskRun('child:child-session')
+  assert.equal(getTaskRun('call-task-1'), null)
+  assert.equal(updatedTask?.childSessionId, 'child-session')
+  assert.equal(updatedTask?.status, 'running')
 })
 
 test('task tool child ids can arrive in state metadata while top-level metadata is present', () => {


### PR DESCRIPTION
Summary:
- bind late explicit task-tool child metadata onto the existing provider task call instead of creating duplicate lanes
- keep parent task-tool completion from prematurely marking child lanes complete
- merge state and top-level tool metadata so live projection matches replay
- recognize OpenCode subagent_type/subagentType agent fields in live and replay descriptors

Validation:
- pnpm test -- event-runtime-handlers.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check