### PR TITLE
Scale thread and capability loading

### DIFF
--- a/apps/desktop/src/main/agent-tool-actions.ts
+++ b/apps/desktop/src/main/agent-tool-actions.ts
@@ -1,6 +1,6 @@
 import type { CustomAgentConfig, ScopedArtifactRef } from '@open-cowork/shared'
 import { getBrandName } from './config-loader.ts'
-import { getCustomAgentCatalog } from './custom-agents.ts'
+import { getCustomAgentCatalog, invalidateCustomAgentCatalogCache } from './custom-agents.ts'
 import {
   buildCustomAgentPermissionFromCatalog,
   normalizeCustomAgent,
@@ -85,6 +85,7 @@ export async function saveAgentFromTool(agent: CustomAgentConfig) {
   }
   const normalized = normalizeCustomAgent(agent)
   saveCustomAgent(normalized, preview.permission || {})
+  invalidateCustomAgentCatalogCache()
   return {
     ok: true,
     saved: true,
@@ -117,6 +118,7 @@ export function getAgentFromTool(target: ScopedArtifactRef) {
 export function deleteAgentFromTool(target: ScopedArtifactRef) {
   const normalizedTarget = normalizeTarget(target)
   removeCustomAgent(normalizedTarget)
+  invalidateCustomAgentCatalogCache()
   return {
     ok: true,
     deleted: true,

--- a/apps/desktop/src/main/bundled-skill-index.ts
+++ b/apps/desktop/src/main/bundled-skill-index.ts
@@ -13,6 +13,7 @@ type CachedBundledSkillIndex = {
   rootsKey: string
   treeKey: string
   index: Map<string, BundledSkillIndexEntry>
+  trustUntilInvalidated: boolean
 }
 
 type BundledSkillRoot = {
@@ -166,12 +167,28 @@ export function clearBundledSkillIndexCache() {
   cachedIndex = null
 }
 
-export function buildBundledSkillIndex(roots: string[]) {
-  const index = new Map<string, BundledSkillIndexEntry>()
+export function warmBundledSkillIndex(roots: string[]) {
+  const rootsKey = cacheRootsKey(roots)
+  const scans = roots.map((root) => scanBundledSkillRoot(root))
+  const treeKey = scans.map((scan) => scan.treeKey).join('||')
+  cachedIndex = {
+    rootsKey,
+    treeKey,
+    index: buildBundledSkillIndexFromScans(scans),
+    trustUntilInvalidated: true,
+  }
+  return cachedIndex.index
+}
 
-  for (const root of roots.map((entry) => resolve(entry))) {
+export function buildBundledSkillIndex(roots: string[]) {
+  return buildBundledSkillIndexFromScans(roots.map((root) => scanBundledSkillRoot(root)))
+}
+
+function buildBundledSkillIndexFromScans(scans: BundledSkillRootScan[]) {
+  const index = new Map<string, BundledSkillIndexEntry>()
+  for (const scan of scans) {
     const rootEntries = new Map<string, BundledSkillIndexEntry>()
-    for (const entry of scanBundledSkillRoot(root).entries) {
+    for (const entry of scan.entries) {
       if (shouldReplaceEntry(rootEntries.get(entry.name), entry)) {
         rootEntries.set(entry.name, entry)
       }
@@ -189,25 +206,16 @@ export function buildBundledSkillIndex(roots: string[]) {
 
 export function getBundledSkillIndex(roots: string[]) {
   const rootsKey = cacheRootsKey(roots)
+  if (cachedIndex?.rootsKey === rootsKey && cachedIndex.trustUntilInvalidated) {
+    return cachedIndex.index
+  }
+
   const scans = roots.map((root) => scanBundledSkillRoot(root))
   const treeKey = scans.map((scan) => scan.treeKey).join('||')
   if (cachedIndex?.rootsKey === rootsKey && cachedIndex.treeKey === treeKey) return cachedIndex.index
 
-  const index = new Map<string, BundledSkillIndexEntry>()
-  for (const scan of scans) {
-    const rootEntries = new Map<string, BundledSkillIndexEntry>()
-    for (const entry of scan.entries) {
-      if (shouldReplaceEntry(rootEntries.get(entry.name), entry)) {
-        rootEntries.set(entry.name, entry)
-      }
-    }
-    for (const [name, entry] of rootEntries.entries()) {
-      if (!index.has(name)) {
-        index.set(name, entry)
-      }
-    }
-  }
-  cachedIndex = { rootsKey, treeKey, index }
+  const index = buildBundledSkillIndexFromScans(scans)
+  cachedIndex = { rootsKey, treeKey, index, trustUntilInvalidated: false }
   return index
 }
 

--- a/apps/desktop/src/main/capability-catalog.ts
+++ b/apps/desktop/src/main/capability-catalog.ts
@@ -7,16 +7,14 @@ import {
   type RuntimeContextOptions,
 } from '@open-cowork/shared'
 import {
-  getConfiguredAgentsFromConfig,
   getConfiguredMcpsFromConfig,
   getConfiguredToolById,
   getConfiguredToolPatterns,
   getConfiguredToolsFromConfig,
 } from './config-loader.ts'
-import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
-import { summarizeCustomAgents, type CustomAgentCatalogSkill } from './custom-agents-utils.ts'
-import { getEffectiveSkillBundle, listEffectiveSkills, listEffectiveSkillsSync } from './effective-skills.ts'
+import { getEffectiveSkillBundle } from './effective-skills.ts'
 import { getEffectiveSettings, getIntegrationCredentialValue } from './settings.ts'
+import { getRuntimeCatalogSnapshot } from './runtime-catalog-snapshot.ts'
 
 function humanize(value: string) {
   return value
@@ -52,62 +50,8 @@ function hasRequiredIntegrationCredentials(
   })
 }
 
-function listRuntimeEligibleCustomAgents(
-  availableSkills: CustomAgentCatalogSkill[],
-  context?: RuntimeContextOptions,
-) {
-  const customMcps = listCustomMcps(context)
-  const customSkills = listCustomSkills(context)
-  const customAgents = listCustomAgents(context)
-  return summarizeCustomAgents({
-    availableSkills,
-    state: {
-      customMcps,
-      customSkills,
-      customAgents,
-    },
-  }).filter((agent) => agent.enabled && agent.valid)
-}
-
-function configuredAgentNamesForTool(
-  toolId: string,
-  availableSkills: CustomAgentCatalogSkill[],
-  context?: RuntimeContextOptions,
-) {
-  const builtIn = getConfiguredAgentsFromConfig()
-    .filter((agent) => (agent.toolIds || []).includes(toolId))
-    .map((agent) => agent.label || agent.name)
-  const custom = listRuntimeEligibleCustomAgents(availableSkills, context)
-    .filter((agent) => agent.toolIds.includes(toolId))
-    .map((agent) => humanize(agent.name))
-  return Array.from(new Set([...builtIn, ...custom])).sort((a, b) => a.localeCompare(b))
-}
-
-function configuredAgentNamesForSkill(
-  skillName: string,
-  availableSkills: CustomAgentCatalogSkill[],
-  context?: RuntimeContextOptions,
-) {
-  const builtIn = getConfiguredAgentsFromConfig()
-    .filter((agent) => (agent.skillNames || []).includes(skillName))
-    .map((agent) => agent.label || agent.name)
-  const custom = listRuntimeEligibleCustomAgents(availableSkills, context)
-    .filter((agent) => agent.skillNames.includes(skillName))
-    .map((agent) => humanize(agent.name))
-  return Array.from(new Set([...builtIn, ...custom])).sort((a, b) => a.localeCompare(b))
-}
-
-export function listCapabilityTools(context?: RuntimeContextOptions): CapabilityTool[] {
-  const availableSkills = listEffectiveSkillsSync(context).map((skill) => ({
-    name: skill.name,
-    label: skill.label,
-    description: skill.description,
-    source: skill.source,
-    origin: skill.origin,
-    scope: skill.scope,
-    location: skill.location,
-    toolIds: skill.toolIds,
-  }))
+export async function listCapabilityTools(context?: RuntimeContextOptions): Promise<CapabilityTool[]> {
+  const snapshot = await getRuntimeCatalogSnapshot(context)
   // Index configured MCPs by name so we can splice their credential
   // metadata onto the matching Tool entry. Downstream bundles (e.g. the
   // GitHub hosted MCP, Perplexity) declare credentials on the MCP
@@ -143,7 +87,7 @@ export function listCapabilityTools(context?: RuntimeContextOptions): Capability
       namespace,
       patterns,
       availableTools: [] as CapabilityToolEntry[],
-      agentNames: configuredAgentNamesForTool(tool.id, availableSkills, context),
+      agentNames: snapshot.toolAgentNames.get(tool.id) || [],
       // For every MCP-backed tool, forward the integration id + auth
       // metadata + current enable state so the detail view can render
       // the right CTA (credential form for api_token, "Enable & sign
@@ -164,7 +108,7 @@ export function listCapabilityTools(context?: RuntimeContextOptions): Capability
     }
   })
 
-  const custom = listCustomMcps(context)
+  const custom = snapshot.customMcps
     .filter((entry) => entry.name)
     .map((entry) => ({
       id: entry.name,
@@ -180,29 +124,19 @@ export function listCapabilityTools(context?: RuntimeContextOptions): Capability
       namespace: entry.name,
       patterns: [`mcp__${entry.name}__*`],
       availableTools: [] as CapabilityToolEntry[],
-      agentNames: configuredAgentNamesForTool(entry.name, availableSkills, context),
+      agentNames: snapshot.toolAgentNames.get(entry.name) || [],
     }))
 
   return [...configured, ...custom].sort((a, b) => a.name.localeCompare(b.name))
 }
 
-export function getCapabilityTool(id: string, context?: RuntimeContextOptions) {
-  return listCapabilityTools(context).find((tool) => tool.id === id) || null
+export async function getCapabilityTool(id: string, context?: RuntimeContextOptions) {
+  return (await listCapabilityTools(context)).find((tool) => tool.id === id) || null
 }
 
 export async function listCapabilitySkills(context?: RuntimeContextOptions): Promise<CapabilitySkill[]> {
-  const effectiveSkills = await listEffectiveSkills(context)
-  const availableSkills = effectiveSkills.map((skill) => ({
-    name: skill.name,
-    label: skill.label,
-    description: skill.description,
-    source: skill.source,
-    origin: skill.origin,
-    scope: skill.scope,
-    location: skill.location,
-    toolIds: skill.toolIds,
-  }))
-  return effectiveSkills
+  const snapshot = await getRuntimeCatalogSnapshot(context)
+  return snapshot.availableSkills
     .map((skill) => ({
       name: skill.name,
       label: skill.label,
@@ -212,7 +146,7 @@ export async function listCapabilitySkills(context?: RuntimeContextOptions): Pro
       scope: skill.scope,
       location: skill.location,
       toolIds: skill.toolIds,
-      agentNames: configuredAgentNamesForSkill(skill.name, availableSkills, context),
+      agentNames: snapshot.skillAgentNames.get(skill.name) || [],
     }))
     .sort((a, b) => a.label.localeCompare(b.label))
 }

--- a/apps/desktop/src/main/custom-agents.ts
+++ b/apps/desktop/src/main/custom-agents.ts
@@ -1,9 +1,5 @@
-import { getConfiguredSkillsFromConfig, getConfiguredToolsFromConfig } from './config-loader.ts'
 import type { CustomAgentIssue, RuntimeContextOptions } from '@open-cowork/shared'
-import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
-import { listEffectiveSkills } from './effective-skills.ts'
-import { listRuntimeToolsForContext, toRuntimeToolMetadata } from './runtime-tools.ts'
-import { getEffectiveSettings } from './settings.ts'
+import { getRuntimeCatalogSnapshot, invalidateRuntimeCatalogSnapshotCache } from './runtime-catalog-snapshot.ts'
 import {
   buildCustomAgentCatalog,
   buildRuntimeCustomAgents,
@@ -35,130 +31,27 @@ export type {
   RuntimeCustomAgent,
 }
 
-const CUSTOM_AGENT_CATALOG_CACHE_TTL_MS = 30_000
-const CUSTOM_AGENT_CATALOG_CACHE_MAX_ENTRIES = 64
-
-type AgentCatalogCacheEntry<T> = {
-  expiresAt: number
-  value?: T
-  promise?: Promise<T>
-}
-
-let customAgentCatalogCacheGeneration = 0
-const customAgentCatalogCache = new Map<string, AgentCatalogCacheEntry<CustomAgentCatalog>>()
-const customAgentSummaryCache = new Map<string, AgentCatalogCacheEntry<CustomAgentSummary[]>>()
-
 export function invalidateCustomAgentCatalogCache() {
-  customAgentCatalogCacheGeneration += 1
-  customAgentCatalogCache.clear()
-  customAgentSummaryCache.clear()
-}
-
-function cacheKeyForContext(options?: RuntimeContextOptions) {
-  const settings = getEffectiveSettings()
-  return JSON.stringify({
-    generation: customAgentCatalogCacheGeneration,
-    directory: options?.directory || null,
-    provider: settings.effectiveProviderId || '',
-    model: settings.effectiveModel || '',
-  })
-}
-
-async function getCachedAgentCatalog<T>(
-  cache: Map<string, AgentCatalogCacheEntry<T>>,
-  key: string,
-  load: () => Promise<T>,
-) {
-  const now = Date.now()
-  const cached = cache.get(key)
-  if (cached?.value !== undefined && cached.expiresAt > now) return cached.value
-  if (cached?.promise) return await cached.promise
-
-  const remember = (entry: AgentCatalogCacheEntry<T>) => {
-    cache.set(key, entry)
-    while (cache.size > CUSTOM_AGENT_CATALOG_CACHE_MAX_ENTRIES) {
-      const oldestKey = cache.keys().next().value
-      if (typeof oldestKey !== 'string') break
-      cache.delete(oldestKey)
-    }
-  }
-
-  const promise = load()
-  remember({ expiresAt: now + CUSTOM_AGENT_CATALOG_CACHE_TTL_MS, promise })
-  try {
-    const value = await promise
-    remember({ expiresAt: Date.now() + CUSTOM_AGENT_CATALOG_CACHE_TTL_MS, value })
-    return value
-  } catch (error) {
-    if (cache.get(key)?.promise === promise) cache.delete(key)
-    throw error
-  }
-}
-
-function getCustomAgentState(options?: RuntimeContextOptions): CustomAgentCatalogState {
-  return {
-    customMcps: listCustomMcps(options),
-    customSkills: listCustomSkills(options),
-    customAgents: listCustomAgents(options),
-  }
+  invalidateRuntimeCatalogSnapshotCache()
 }
 
 export async function getCustomAgentCatalog(options?: RuntimeContextOptions): Promise<CustomAgentCatalog> {
-  return getCachedAgentCatalog(customAgentCatalogCache, cacheKeyForContext(options), () =>
-    buildCustomAgentCatalogForContext(options))
-}
-
-async function buildCustomAgentCatalogForContext(options?: RuntimeContextOptions): Promise<CustomAgentCatalog> {
-  const state = getCustomAgentState(options)
-  const runtimeTools = (await listRuntimeToolsForContext(options))
-    .map(toRuntimeToolMetadata)
-    .filter((tool): tool is NonNullable<typeof tool> => Boolean(tool))
-  const availableSkills = (await listEffectiveSkills(options)).map((skill) => ({
-    name: skill.name,
-    label: skill.label,
-    description: skill.description,
-    source: skill.source,
-    origin: skill.origin,
-    scope: skill.scope,
-    location: skill.location,
-    toolIds: skill.toolIds,
-  }))
+  const snapshot = await getRuntimeCatalogSnapshot(options)
   return buildCustomAgentCatalog({
-    builtinTools: getConfiguredToolsFromConfig(),
-    builtinSkills: getConfiguredSkillsFromConfig(),
-    runtimeTools,
-    availableSkills,
-    customMcps: state.customMcps || [],
-    customSkills: state.customSkills || [],
-    state,
+    builtinTools: snapshot.builtinTools,
+    builtinSkills: snapshot.builtinSkills,
+    runtimeTools: snapshot.runtimeTools,
+    availableSkills: snapshot.availableSkills,
+    customMcps: snapshot.customMcps || [],
+    customSkills: snapshot.customSkills || [],
+    state: {
+      customMcps: snapshot.customMcps,
+      customSkills: snapshot.customSkills,
+      customAgents: snapshot.customAgents,
+    } satisfies CustomAgentCatalogState,
   })
 }
 
 export async function getCustomAgentSummaries(options?: RuntimeContextOptions): Promise<CustomAgentSummary[]> {
-  return getCachedAgentCatalog(customAgentSummaryCache, cacheKeyForContext(options), () =>
-    buildCustomAgentSummariesForContext(options))
-}
-
-async function buildCustomAgentSummariesForContext(options?: RuntimeContextOptions): Promise<CustomAgentSummary[]> {
-  const state = getCustomAgentState(options)
-  const runtimeTools = (await listRuntimeToolsForContext(options))
-    .map(toRuntimeToolMetadata)
-    .filter((tool): tool is NonNullable<typeof tool> => Boolean(tool))
-  const availableSkills = (await listEffectiveSkills(options)).map((skill) => ({
-    name: skill.name,
-    label: skill.label,
-    description: skill.description,
-    source: skill.source,
-    origin: skill.origin,
-    scope: skill.scope,
-    location: skill.location,
-    toolIds: skill.toolIds,
-  }))
-  return summarizeCustomAgents({
-    state,
-    builtinTools: getConfiguredToolsFromConfig(),
-    builtinSkills: getConfiguredSkillsFromConfig(),
-    runtimeTools,
-    availableSkills,
-  })
+  return (await getRuntimeCatalogSnapshot(options)).customAgentSummaries
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -296,6 +296,11 @@ async function runBootRuntime(projectDirectory?: string | null) {
     }
 
     eventSubscriptions.ensure(getRuntimeHomeDir(), client)
+    void import('./runtime-catalog-snapshot.ts').then(({ getRuntimeCatalogSnapshot }) =>
+      getRuntimeCatalogSnapshot(runtimeProjectDirectory ? { directory: runtimeProjectDirectory } : undefined)
+    ).catch((err) => {
+      log('main', `Runtime catalog warmup skipped: ${err instanceof Error ? err.message : String(err)}`)
+    })
 
     setRuntimeInitializationPhase('mcp', 'Checking tools and MCP status...')
     mcpInterval = restartRuntimeMcpStatusPolling({

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -232,6 +232,8 @@ export function registerAppHandlers(context: IpcHandlerContext) {
 
   registerIpcInvoke(context, 'settings:set', objectArg<Partial<CoworkSettings>>('settings update'), async (_event, updates) => {
     const result = saveSettings(updates)
+    const { invalidateRuntimeCatalogSnapshotCache } = await import('../runtime-catalog-snapshot.ts')
+    invalidateRuntimeCatalogSnapshotCache()
     const runtimeSensitiveUpdate = hasRuntimeSensitiveSettingsUpdate(updates)
 
     if (isSetupComplete(result)) {

--- a/apps/desktop/src/main/ipc/catalog-handlers.ts
+++ b/apps/desktop/src/main/ipc/catalog-handlers.ts
@@ -386,7 +386,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
       directory: context.resolveContextDirectory(options),
       deep: false,
     }
-    return context.withDiscoveredBuiltInTools(listCapabilityTools(capabilityContext), runtimeTools, capabilityContext)
+    return context.withDiscoveredBuiltInTools(await listCapabilityTools(capabilityContext), runtimeTools, capabilityContext)
   })
 
   context.ipcMain.handle('capabilities:tool', async (_event, id: string, options?: ToolListOptions) => {
@@ -400,8 +400,8 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
       directory: context.resolveContextDirectory(options),
       deep: true,
     }
-    return (await context.withDiscoveredBuiltInTools(listCapabilityTools(capabilityContext), runtimeTools, capabilityContext)).find((tool) => tool.id === id)
-      || getCapabilityTool(id, capabilityContext)
+    return (await context.withDiscoveredBuiltInTools(await listCapabilityTools(capabilityContext), runtimeTools, capabilityContext)).find((tool) => tool.id === id)
+      || await getCapabilityTool(id, capabilityContext)
   })
 
   context.ipcMain.handle('capabilities:skills', async (_event, options?: RuntimeContextOptions) => {

--- a/apps/desktop/src/main/runtime-catalog-snapshot.ts
+++ b/apps/desktop/src/main/runtime-catalog-snapshot.ts
@@ -1,0 +1,196 @@
+import type { RuntimeContextOptions } from '@open-cowork/shared'
+import {
+  getConfiguredAgentsFromConfig,
+  getConfiguredSkillsFromConfig,
+  getConfiguredToolsFromConfig,
+} from './config-loader.ts'
+import { summarizeCustomAgents, type CustomAgentCatalogSkill, type CustomAgentSummary } from './custom-agents-utils.ts'
+import { listEffectiveSkills } from './effective-skills.ts'
+import { measureAsyncPerf } from './perf-metrics.ts'
+import { getRuntimeHomeDir, resolveProjectDirectory } from './runtime-paths.ts'
+import { currentRuntimeToolCacheGeneration } from './runtime-tool-cache.ts'
+import { listRuntimeToolsForContext, toRuntimeToolMetadata, type RuntimeToolMetadata } from './runtime-tools.ts'
+import { getEffectiveSettings } from './settings.ts'
+import { listCustomAgents, listCustomMcps, listCustomSkills } from './native-customizations.ts'
+
+const RUNTIME_CATALOG_SNAPSHOT_TTL_MS = 30_000
+const RUNTIME_CATALOG_SNAPSHOT_MAX_ENTRIES = 64
+
+type RuntimeCatalogSnapshotCacheEntry = {
+  expiresAt: number
+  value?: RuntimeCatalogSnapshot
+  promise?: Promise<RuntimeCatalogSnapshot>
+}
+
+export type RuntimeCatalogSnapshot = {
+  context: RuntimeContextOptions | undefined
+  builtinTools: ReturnType<typeof getConfiguredToolsFromConfig>
+  builtinSkills: ReturnType<typeof getConfiguredSkillsFromConfig>
+  customMcps: ReturnType<typeof listCustomMcps>
+  customSkills: ReturnType<typeof listCustomSkills>
+  customAgents: ReturnType<typeof listCustomAgents>
+  runtimeTools: RuntimeToolMetadata[]
+  availableSkills: CustomAgentCatalogSkill[]
+  customAgentSummaries: CustomAgentSummary[]
+  toolAgentNames: Map<string, string[]>
+  skillAgentNames: Map<string, string[]>
+}
+
+let runtimeCatalogSnapshotGeneration = 0
+const runtimeCatalogSnapshotCache = new Map<string, RuntimeCatalogSnapshotCacheEntry>()
+
+function humanize(value: string) {
+  return value
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function normalizeContext(options?: RuntimeContextOptions): RuntimeContextOptions | undefined {
+  const directory = resolveProjectDirectory(options?.directory)
+  return directory ? { directory } : undefined
+}
+
+function snapshotCacheKey(options?: RuntimeContextOptions) {
+  const settings = getEffectiveSettings()
+  const directory = resolveProjectDirectory(options?.directory) || getRuntimeHomeDir()
+  return JSON.stringify({
+    generation: runtimeCatalogSnapshotGeneration,
+    runtimeToolGeneration: currentRuntimeToolCacheGeneration(),
+    directory,
+    provider: settings.effectiveProviderId || '',
+    model: settings.effectiveModel || '',
+  })
+}
+
+function rememberSnapshotEntry(key: string, entry: RuntimeCatalogSnapshotCacheEntry) {
+  runtimeCatalogSnapshotCache.set(key, entry)
+  while (runtimeCatalogSnapshotCache.size > RUNTIME_CATALOG_SNAPSHOT_MAX_ENTRIES) {
+    const oldestKey = runtimeCatalogSnapshotCache.keys().next().value
+    if (typeof oldestKey !== 'string') break
+    runtimeCatalogSnapshotCache.delete(oldestKey)
+  }
+}
+
+function uniqueSortedLabels(values: string[]) {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b))
+}
+
+function buildAgentRelationshipMaps(
+  configuredAgents: ReturnType<typeof getConfiguredAgentsFromConfig>,
+  customAgentSummaries: CustomAgentSummary[],
+) {
+  const toolAgentNames = new Map<string, string[]>()
+  const skillAgentNames = new Map<string, string[]>()
+
+  const addToolAgent = (toolId: string, label: string) => {
+    toolAgentNames.set(toolId, [...(toolAgentNames.get(toolId) || []), label])
+  }
+  const addSkillAgent = (skillName: string, label: string) => {
+    skillAgentNames.set(skillName, [...(skillAgentNames.get(skillName) || []), label])
+  }
+
+  for (const agent of configuredAgents) {
+    const label = agent.label || agent.name
+    for (const toolId of agent.toolIds || []) addToolAgent(toolId, label)
+    for (const skillName of agent.skillNames || []) addSkillAgent(skillName, label)
+  }
+
+  for (const agent of customAgentSummaries) {
+    if (!agent.enabled || !agent.valid) continue
+    const label = humanize(agent.name)
+    for (const toolId of agent.toolIds || []) addToolAgent(toolId, label)
+    for (const skillName of agent.skillNames || []) addSkillAgent(skillName, label)
+  }
+
+  return {
+    toolAgentNames: new Map(Array.from(toolAgentNames.entries()).map(([key, values]) => [key, uniqueSortedLabels(values)])),
+    skillAgentNames: new Map(Array.from(skillAgentNames.entries()).map(([key, values]) => [key, uniqueSortedLabels(values)])),
+  }
+}
+
+async function buildRuntimeCatalogSnapshot(options?: RuntimeContextOptions): Promise<RuntimeCatalogSnapshot> {
+  return measureAsyncPerf('catalog.snapshot.build', async () => {
+    const context = normalizeContext(options)
+    const [
+      effectiveSkills,
+      runtimeToolEntries,
+    ] = await Promise.all([
+      listEffectiveSkills(context),
+      listRuntimeToolsForContext(context),
+    ])
+    const builtinTools = getConfiguredToolsFromConfig()
+    const builtinSkills = getConfiguredSkillsFromConfig()
+    const customMcps = listCustomMcps(context)
+    const customSkills = listCustomSkills(context)
+    const customAgents = listCustomAgents(context)
+    const runtimeTools = runtimeToolEntries
+      .map(toRuntimeToolMetadata)
+      .filter((tool): tool is RuntimeToolMetadata => Boolean(tool))
+    const availableSkills = effectiveSkills.map((skill) => ({
+      name: skill.name,
+      label: skill.label,
+      description: skill.description,
+      source: skill.source,
+      origin: skill.origin,
+      scope: skill.scope,
+      location: skill.location,
+      toolIds: skill.toolIds,
+    }))
+    const customAgentSummaries = summarizeCustomAgents({
+      availableSkills,
+      state: {
+        customMcps,
+        customSkills,
+        customAgents,
+      },
+      builtinTools,
+      builtinSkills,
+      runtimeTools,
+    })
+    const relationships = buildAgentRelationshipMaps(getConfiguredAgentsFromConfig(), customAgentSummaries)
+
+    return {
+      context,
+      builtinTools,
+      builtinSkills,
+      customMcps,
+      customSkills,
+      customAgents,
+      runtimeTools,
+      availableSkills,
+      customAgentSummaries,
+      ...relationships,
+    }
+  }, {
+    slowThresholdMs: 150,
+    slowData: { context: options?.directory ? 'project' : 'global' },
+  })
+}
+
+export function invalidateRuntimeCatalogSnapshotCache() {
+  runtimeCatalogSnapshotGeneration += 1
+  runtimeCatalogSnapshotCache.clear()
+}
+
+export async function getRuntimeCatalogSnapshot(options?: RuntimeContextOptions): Promise<RuntimeCatalogSnapshot> {
+  const key = snapshotCacheKey(options)
+  const now = Date.now()
+  const cached = runtimeCatalogSnapshotCache.get(key)
+  if (cached?.value && cached.expiresAt > now) return cached.value
+  if (cached?.promise) return await cached.promise
+
+  const promise = buildRuntimeCatalogSnapshot(options)
+  rememberSnapshotEntry(key, { expiresAt: now + RUNTIME_CATALOG_SNAPSHOT_TTL_MS, promise })
+  try {
+    const value = await promise
+    rememberSnapshotEntry(key, { expiresAt: Date.now() + RUNTIME_CATALOG_SNAPSHOT_TTL_MS, value })
+    return value
+  } catch (error) {
+    if (runtimeCatalogSnapshotCache.get(key)?.promise === promise) {
+      runtimeCatalogSnapshotCache.delete(key)
+    }
+    throw error
+  }
+}

--- a/apps/desktop/src/main/runtime-catalog-snapshot.ts
+++ b/apps/desktop/src/main/runtime-catalog-snapshot.ts
@@ -188,9 +188,7 @@ export async function getRuntimeCatalogSnapshot(options?: RuntimeContextOptions)
     rememberSnapshotEntry(key, { expiresAt: Date.now() + RUNTIME_CATALOG_SNAPSHOT_TTL_MS, value })
     return value
   } catch (error) {
-    if (runtimeCatalogSnapshotCache.get(key)?.promise === promise) {
-      runtimeCatalogSnapshotCache.delete(key)
-    }
+    runtimeCatalogSnapshotCache.delete(key)
     throw error
   }
 }

--- a/apps/desktop/src/main/runtime-skill-catalog.ts
+++ b/apps/desktop/src/main/runtime-skill-catalog.ts
@@ -3,8 +3,10 @@ import { dirname, join, resolve } from 'path'
 import type { RuntimeContextOptions } from '@open-cowork/shared'
 import { getProjectOverlayDirName } from './config-loader.ts'
 import { listEffectiveBuiltInSkillBundlesSync } from './effective-skills.ts'
+import { warmBundledSkillIndex } from './bundled-skill-index.ts'
 import { log } from './logger.ts'
 import { getRuntimeHomeDir, getRuntimeSkillCatalogDir } from './runtime-paths.ts'
+import { getBundledSkillRoots } from './runtime-content.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
 
 export type RuntimeSkillBundle = {
@@ -186,6 +188,7 @@ export function buildRuntimeSkillCatalog(context?: RuntimeContextOptions) {
   rmSync(catalogRoot, { recursive: true, force: true })
   mkdirSync(catalogRoot, { recursive: true })
 
+  warmBundledSkillIndex(getBundledSkillRoots())
   const bundles = listContextBundles(context)
   for (const bundle of bundles) {
     writeRuntimeSkillBundle(catalogRoot, bundle, buildRuntimeSkillContent(bundle.name, bundle.content, bundle.files), { includeFiles: false })

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -116,7 +116,7 @@ export function createBoundedChildSnapshotLoader(options: {
 
   return {
     prefetch(ids = options.ids) {
-      for (const id of ids) ensure(id)
+      for (const id of ids) void ensure(id).catch(() => undefined)
     },
     load(id: string) {
       return ensure(id)

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -49,6 +49,8 @@ type LoadSessionHistoryOptions = {
   includeChildren?: boolean
 }
 
+const CHILD_SNAPSHOT_PREFETCH_CONCURRENCY = 8
+
 type ChildSessionRecord = {
   id: string
   title?: string
@@ -57,6 +59,69 @@ type ChildSessionRecord = {
     updated?: number
   }
   parentSessionId?: string | null
+}
+
+type ChildSnapshot = { messages: unknown[]; todos: unknown[] }
+
+export function createBoundedChildSnapshotLoader(options: {
+  ids: string[]
+  concurrency?: number
+  load: (id: string) => Promise<ChildSnapshot>
+}) {
+  const concurrency = Math.max(1, Math.floor(options.concurrency || CHILD_SNAPSHOT_PREFETCH_CONCURRENCY))
+  const entries = new Map<string, {
+    started: boolean
+    promise: Promise<ChildSnapshot>
+    resolve: (value: ChildSnapshot) => void
+    reject: (error: unknown) => void
+  }>()
+  const queue: string[] = []
+  let active = 0
+
+  const schedule = () => {
+    while (active < concurrency && queue.length > 0) {
+      const id = queue.shift()
+      if (!id) continue
+      const entry = entries.get(id)
+      if (!entry || entry.started) continue
+      entry.started = true
+      active += 1
+      void options.load(id).then(entry.resolve, entry.reject).finally(() => {
+        active -= 1
+        schedule()
+      })
+    }
+  }
+
+  const ensure = (id: string) => {
+    const existing = entries.get(id)
+    if (existing) return existing.promise
+
+    let resolveEntry!: (value: ChildSnapshot) => void
+    let rejectEntry!: (error: unknown) => void
+    const promise = new Promise<ChildSnapshot>((resolve, reject) => {
+      resolveEntry = resolve
+      rejectEntry = reject
+    })
+    entries.set(id, {
+      started: false,
+      promise,
+      resolve: resolveEntry,
+      reject: rejectEntry,
+    })
+    queue.push(id)
+    schedule()
+    return promise
+  }
+
+  return {
+    prefetch(ids = options.ids) {
+      for (const id of ids) ensure(id)
+    },
+    load(id: string) {
+      return ensure(id)
+    },
+  }
 }
 
 const DEFAULT_SDK_SESSION_TITLE_RE = /^New session(?: - \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)?$/i
@@ -327,15 +392,10 @@ export function createSessionHistoryService(
       const questions = normalizePendingQuestions(readResponseData(questionResult), sessionId, descendantSessionIds)
       const approvals = normalizePendingApprovals(readResponseData(permissionResult), sessionId, descendantSessionIds)
       const cachedModelId = deps.getCachedModelId()
-
-      const items = await deps.projectSessionHistory({
-        sessionId,
-        cachedModelId,
-        rootMessages,
-        rootTodos,
-        children,
-        statuses,
-        loadChildSnapshot: async (childId) => {
+      const childSnapshotLoader = createBoundedChildSnapshotLoader({
+        ids: children.map((child) => child.id),
+        concurrency: CHILD_SNAPSHOT_PREFETCH_CONCURRENCY,
+        load: async (childId) => {
           const [result, childTodoResult] = await Promise.all([
             client.session.messages({
               sessionID: childId,
@@ -352,6 +412,19 @@ export function createSessionHistoryService(
             todos: readRecordArray({ value: readResponseData(childTodoResult) }, 'value'),
           }
         },
+      })
+      if (includeChildren) {
+        childSnapshotLoader.prefetch()
+      }
+
+      const items = await deps.projectSessionHistory({
+        sessionId,
+        cachedModelId,
+        rootMessages,
+        rootTodos,
+        children,
+        statuses,
+        loadChildSnapshot: childSnapshotLoader.load,
       })
       const latestModeledItem = [...items]
         .reverse()

--- a/apps/desktop/src/main/thread-index-store.ts
+++ b/apps/desktop/src/main/thread-index-store.ts
@@ -36,6 +36,7 @@ export { THREAD_INDEX_SCHEMA_VERSION }
 
 const THREAD_INDEX_METADATA_VERSION = 1
 const THREAD_DEFAULT_TAG_COLOR = '#64748b'
+const THREAD_QUERY_CACHE_MAX_ENTRIES = 128
 const SMART_FILTER_QUERY_MAX_BYTES = 16_384
 const MAX_SUGGESTION_EVIDENCE_ITEMS = 12
 const SUGGESTION_EVIDENCE_TYPES = new Set(['title', 'project', 'provider', 'model', 'agent', 'tool'])
@@ -271,6 +272,9 @@ export class ThreadIndexStore {
   private db: DatabaseSync
   private transactionCounter = 0
   private readonly dbPath: string
+  private queryCacheGeneration = 0
+  private readonly searchCache = new Map<string, ThreadSearchResult>()
+  private readonly facetCache = new Map<string, ThreadFacetSummary>()
 
   constructor(dbPath = getThreadIndexDbPath()) {
     this.dbPath = dbPath
@@ -297,6 +301,7 @@ export class ThreadIndexStore {
       const result = callback()
       this.db.exec(`release savepoint ${savepoint}`)
       ensureThreadIndexDbFileModes(this.dbPath)
+      this.invalidateQueryCache()
       return result
     } catch (error) {
       try {
@@ -307,6 +312,30 @@ export class ThreadIndexStore {
       }
       throw error
     }
+  }
+
+  private invalidateQueryCache() {
+    this.queryCacheGeneration += 1
+    this.searchCache.clear()
+    this.facetCache.clear()
+  }
+
+  private rememberCachedQuery<T>(cache: Map<string, T>, key: string, value: T) {
+    cache.set(key, value)
+    while (cache.size > THREAD_QUERY_CACHE_MAX_ENTRIES) {
+      const oldestKey = cache.keys().next().value
+      if (typeof oldestKey !== 'string') break
+      cache.delete(oldestKey)
+    }
+    return value
+  }
+
+  private queryCacheKey(kind: 'search' | 'facets', query: ThreadSearchQuery) {
+    return JSON.stringify({
+      generation: this.queryCacheGeneration,
+      kind,
+      query,
+    })
   }
 
   upsertThread(input: ThreadIndexUpsertInput) {
@@ -527,6 +556,9 @@ export class ThreadIndexStore {
 
   searchThreads(input: ThreadSearchQuery = {}): ThreadSearchResult {
     const query = this.mergeSmartFilter(normalizeThreadSearchQuery(input))
+    const cacheKey = this.queryCacheKey('search', query)
+    const cached = this.searchCache.get(cacheKey)
+    if (cached) return cached
     const limit = query.limit || THREAD_SEARCH_DEFAULT_LIMIT
     const offset = decodeCursor(query.cursor)
     const where = this.buildWhere(query)
@@ -541,11 +573,11 @@ export class ThreadIndexStore {
     const threads = this.hydrateRows(rows)
     const totalEstimate = Number(total?.count || 0)
     const nextOffset = offset + rows.length
-    return {
+    return this.rememberCachedQuery(this.searchCache, cacheKey, {
       threads,
       nextCursor: nextOffset < totalEstimate ? encodeCursor(nextOffset) : null,
       totalEstimate,
-    }
+    })
   }
 
   getThread(sessionId: string): ThreadListItem | null {
@@ -557,6 +589,9 @@ export class ThreadIndexStore {
 
   listFacets(input: ThreadSearchQuery = {}): ThreadFacetSummary {
     const query = this.mergeSmartFilter(normalizeThreadSearchQuery({ ...input, cursor: null }))
+    const cacheKey = this.queryCacheKey('facets', query)
+    const cached = this.facetCache.get(cacheKey)
+    if (cached) return cached
     const where = this.buildWhere(query)
     const bucket = (sql: string, args: SQLInputValue[] = where.args): ThreadFacetBucket[] => (
       this.db.prepare(sql).all(...args) as Row[]
@@ -567,7 +602,7 @@ export class ThreadIndexStore {
     }))
     const baseWhere = where.sql
     const whereAnd = (extra: string) => baseWhere ? `${baseWhere} and ${extra}` : `where ${extra}`
-    return {
+    return this.rememberCachedQuery(this.facetCache, cacheKey, {
       projects: bucket(`select project_label as value, project_label as label, count(*) as count from thread_index ${whereAnd('project_label is not null')} group by project_label order by count desc, project_label asc`),
       providers: bucket(`select provider_id as value, provider_id as label, count(*) as count from thread_index ${whereAnd('provider_id is not null')} group by provider_id order by count desc, provider_id asc`),
       models: bucket(`select model_id as value, model_id as label, count(*) as count from thread_index ${whereAnd('model_id is not null')} group by model_id order by count desc, model_id asc`),
@@ -589,7 +624,7 @@ export class ThreadIndexStore {
         color: asString(row.color),
         count: asNumber(row.count),
       })),
-    }
+    })
   }
 
   private hydrateRows(rows: Row[]): ThreadListItem[] {
@@ -722,6 +757,7 @@ export class ThreadIndexStore {
       values (?, ?, ?, ?, ?)
     `).run(id, tag.name, tag.color, timestamp, timestamp)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return this.getTag(id)!
   }
 
@@ -731,6 +767,7 @@ export class ThreadIndexStore {
     this.db.prepare('update thread_tags set name = ?, color = ?, updated_at = ? where id = ?')
       .run(tag.name, tag.color, nowIso(), id)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return this.getTag(id)
   }
 
@@ -785,6 +822,7 @@ export class ThreadIndexStore {
         and tag_id in (${makePlaceholders(tags)})
     `).run(...sessions, ...tags)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return true
   }
 
@@ -819,6 +857,7 @@ export class ThreadIndexStore {
       values (?, ?, ?, ?, ?)
     `).run(id, filter.name, filter.serialized, timestamp, timestamp)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return this.getSmartFilter(id)!
   }
 
@@ -828,6 +867,7 @@ export class ThreadIndexStore {
     this.db.prepare('update thread_smart_filters set name = ?, query_json = ?, updated_at = ? where id = ?')
       .run(filter.name, filter.serialized, nowIso(), id)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return this.getSmartFilter(id)
   }
 
@@ -835,6 +875,7 @@ export class ThreadIndexStore {
     const id = normalizeText(filterId, 256, 'Smart filter id')
     this.db.prepare('delete from thread_smart_filters where id = ?').run(id)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return true
   }
 
@@ -847,6 +888,7 @@ export class ThreadIndexStore {
       values (?, ?, ?, ?, ?, ?, ?, ?)
     `).run(id, normalizeText(sessionId, 256, 'Session id'), normalized.label, normalized.reason, json(normalized.evidence), status, timestamp, timestamp)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return this.rowToSuggestion(this.db.prepare('select * from thread_category_suggestions where id = ?').get(id) as Row)
   }
 
@@ -888,6 +930,7 @@ export class ThreadIndexStore {
     this.db.prepare("update thread_category_suggestions set label = ?, status = 'accepted', updated_at = ? where id = ?")
       .run(nextLabel, nowIso(), id)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return true
   }
 
@@ -896,6 +939,7 @@ export class ThreadIndexStore {
     this.db.prepare('update thread_category_suggestions set status = ?, updated_at = ? where id = ?')
       .run(status, nowIso(), id)
     ensureThreadIndexDbFileModes(this.dbPath)
+    this.invalidateQueryCache()
     return true
   }
 }

--- a/apps/desktop/src/renderer/components/chat/useChatAgentVisuals.ts
+++ b/apps/desktop/src/renderer/components/chat/useChatAgentVisuals.ts
@@ -6,32 +6,84 @@ import type {
 } from '@open-cowork/shared'
 import { buildAgentVisualMap } from './agent-visuals'
 
+type AgentVisualMap = Record<string, { avatar: string | null; color: string | null }>
+
+type AgentVisualCacheEntry = {
+  value: AgentVisualMap
+  promise?: Promise<AgentVisualMap>
+}
+
+const agentVisualCache = new Map<string, AgentVisualCacheEntry>()
+
+function scheduleIdle(task: () => void) {
+  if (typeof window.requestIdleCallback === 'function') {
+    const handle = window.requestIdleCallback(task, { timeout: 750 })
+    return () => window.cancelIdleCallback(handle)
+  }
+  const handle = window.setTimeout(task, 50)
+  return () => window.clearTimeout(handle)
+}
+
+function cacheKeyForDirectory(currentDirectory: string | null | undefined) {
+  return currentDirectory || ''
+}
+
+function loadAgentVisualMap(context: { directory: string } | undefined, cacheKey: string) {
+  const cached = agentVisualCache.get(cacheKey)
+  if (cached?.promise) return cached.promise
+
+  const promise = Promise.all([
+    window.coworkApi.app.builtinAgents().catch(() => [] as BuiltInAgentDetail[]),
+    window.coworkApi.agents.list(context).catch(() => [] as CustomAgentSummary[]),
+    window.coworkApi.agents.runtime().catch(() => [] as RuntimeAgentDescriptor[]),
+  ]).then(([builtinAgents, customAgents, runtimeAgents]) => buildAgentVisualMap({
+    builtinAgents,
+    customAgents,
+    runtimeAgents,
+  }))
+
+  agentVisualCache.set(cacheKey, { value: cached?.value || {}, promise })
+  return promise.then((value) => {
+    agentVisualCache.set(cacheKey, { value })
+    return value
+  }).catch((error) => {
+    if (agentVisualCache.get(cacheKey)?.promise === promise) {
+      agentVisualCache.set(cacheKey, { value: cached?.value || {} })
+    }
+    throw error
+  })
+}
+
 export function useChatAgentVisuals(currentDirectory: string | null | undefined) {
-  const [agentVisuals, setAgentVisuals] = useState<Record<string, { avatar: string | null; color: string | null }>>({})
+  const cacheKey = cacheKeyForDirectory(currentDirectory)
+  const [agentVisuals, setAgentVisuals] = useState<AgentVisualMap>(() =>
+    agentVisualCache.get(cacheKey)?.value || {})
 
   useEffect(() => {
     let cancelled = false
+    let cancelIdle: (() => void) | null = null
     const context = currentDirectory ? { directory: currentDirectory } : undefined
+    const nextCacheKey = cacheKeyForDirectory(currentDirectory)
+    const cached = agentVisualCache.get(nextCacheKey)?.value
+    if (cached) setAgentVisuals(cached)
 
     const loadAgentVisuals = () => {
-      void Promise.all([
-        window.coworkApi.app.builtinAgents().catch(() => [] as BuiltInAgentDetail[]),
-        window.coworkApi.agents.list(context).catch(() => [] as CustomAgentSummary[]),
-        window.coworkApi.agents.runtime().catch(() => [] as RuntimeAgentDescriptor[]),
-      ]).then(([builtinAgents, customAgents, runtimeAgents]) => {
+      void loadAgentVisualMap(context, nextCacheKey).then((value) => {
         if (cancelled) return
-        setAgentVisuals(buildAgentVisualMap({
-          builtinAgents,
-          customAgents,
-          runtimeAgents,
-        }))
+        setAgentVisuals(value)
+      }).catch(() => {
+        if (!cancelled) setAgentVisuals(agentVisualCache.get(nextCacheKey)?.value || {})
       })
     }
 
-    loadAgentVisuals()
-    const unsubscribe = window.coworkApi.on.runtimeReady(() => loadAgentVisuals())
+    cancelIdle = scheduleIdle(loadAgentVisuals)
+    const unsubscribe = window.coworkApi.on.runtimeReady(() => {
+      cancelIdle?.()
+      cancelIdle = scheduleIdle(loadAgentVisuals)
+    })
     return () => {
       cancelled = true
+      cancelIdle?.()
       unsubscribe()
     }
   }, [currentDirectory])

--- a/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
+++ b/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
@@ -10,6 +10,21 @@ import { COMPOSER_COMPOSE_EVENT, COMPOSER_INSERT_EVENT, type ComposerComposeDeta
 type ModelCatalog = Record<string, ChatInputModelEntry[]>
 
 type ResizeComposerTextarea = (element?: HTMLTextAreaElement | null) => void
+type MentionableAgentCacheEntry = {
+  value: MentionableAgent[]
+  promise?: Promise<MentionableAgent[]>
+}
+
+const mentionableAgentCache = new Map<string, MentionableAgentCacheEntry>()
+
+function scheduleIdle(task: () => void) {
+  if (typeof window.requestIdleCallback === 'function') {
+    const handle = window.requestIdleCallback(task, { timeout: 750 })
+    return () => window.cancelIdleCallback(handle)
+  }
+  const handle = window.setTimeout(task, 50)
+  return () => window.clearTimeout(handle)
+}
 
 function describeChatSettingsError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
@@ -128,16 +143,25 @@ export function useReasoningVariantSelection(
 }
 
 export function useMentionableAgents(currentProjectDirectory: string | null) {
-  const [specialistAgents, setSpecialistAgents] = useState<MentionableAgent[]>([])
+  const cacheKey = currentProjectDirectory || ''
+  const [specialistAgents, setSpecialistAgents] = useState<MentionableAgent[]>(() =>
+    mentionableAgentCache.get(cacheKey)?.value || [])
 
   useEffect(() => {
     let disposed = false
-    const loadRuntimeCatalog = () => {
-      Promise.all([
+    let cancelIdle: (() => void) | null = null
+    const nextCacheKey = currentProjectDirectory || ''
+    const cached = mentionableAgentCache.get(nextCacheKey)?.value
+    if (cached) setSpecialistAgents(cached)
+
+    const loadMentionableAgents = () => {
+      const existing = mentionableAgentCache.get(nextCacheKey)
+      if (existing?.promise) return existing.promise
+      const context = currentProjectDirectory ? { directory: currentProjectDirectory } : undefined
+      const promise = Promise.all([
         window.coworkApi.app.builtinAgents(),
-        window.coworkApi.agents.list(currentProjectDirectory ? { directory: currentProjectDirectory } : undefined),
+        window.coworkApi.agents.list(context),
       ]).then(([builtins, customAgents]) => {
-        if (disposed) return
         const builtinAgents = (builtins || [])
           .filter((agent) => agent.mode === 'subagent' && !agent.hidden && agent.surface !== 'workflow')
           .map((agent) => ({
@@ -153,18 +177,38 @@ export function useMentionableAgents(currentProjectDirectory: string | null) {
             description: agent.description || 'Focused delegated work',
           }))
 
-        setSpecialistAgents(
-          [...builtinAgents, ...userAgents].sort((a, b) => a.label.localeCompare(b.label)),
-        )
+        return [...builtinAgents, ...userAgents].sort((a, b) => a.label.localeCompare(b.label))
+      })
+
+      mentionableAgentCache.set(nextCacheKey, { value: existing?.value || [], promise })
+      return promise.then((value) => {
+        mentionableAgentCache.set(nextCacheKey, { value })
+        return value
+      }).catch((error) => {
+        if (mentionableAgentCache.get(nextCacheKey)?.promise === promise) {
+          mentionableAgentCache.set(nextCacheKey, { value: existing?.value || [] })
+        }
+        throw error
+      })
+    }
+
+    const loadRuntimeCatalog = () => {
+      loadMentionableAgents().then((agents) => {
+        if (disposed) return
+        setSpecialistAgents(agents)
       }).catch(() => {
         if (!disposed) setSpecialistAgents([])
       })
     }
 
-    loadRuntimeCatalog()
-    const unsubscribe = window.coworkApi.on.runtimeReady(() => loadRuntimeCatalog())
+    cancelIdle = scheduleIdle(loadRuntimeCatalog)
+    const unsubscribe = window.coworkApi.on.runtimeReady(() => {
+      cancelIdle?.()
+      cancelIdle = scheduleIdle(loadRuntimeCatalog)
+    })
     return () => {
       disposed = true
+      cancelIdle?.()
       unsubscribe()
     }
   }, [currentProjectDirectory])

--- a/scripts/perf/suite.ts
+++ b/scripts/perf/suite.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { SessionEngine } from '../../apps/desktop/src/main/session-engine.ts'
 import { buildOpenCoworkAgentConfig } from '../../apps/desktop/src/main/agent-config.ts'
+import { summarizeCustomAgents } from '../../apps/desktop/src/main/custom-agents-utils.ts'
 import { buildCoworkRuntimePermissionConfig } from '../../apps/desktop/src/main/runtime-permissions.ts'
 import { ThreadIndexStore } from '../../apps/desktop/src/main/thread-index-store.ts'
 import { buildCapabilityMapGroups } from '../../apps/desktop/src/renderer/components/capabilities/capabilities-page-support.ts'
@@ -149,6 +150,44 @@ export async function runSessionBenchmarks() {
         )
         if (groups.length === 0) {
           throw new Error('capabilities.map.downstreamCatalog produced no groups')
+        }
+      }, { batchSize: 8, warmupIterations: 3 }),
+      await runBenchmark('catalog.relationship.downstreamCatalog', 30, () => {
+        const summaries = summarizeCustomAgents({
+          state: {
+            customMcps: downstreamCatalog.tools.map((tool) => ({
+              name: tool.id,
+              label: tool.name,
+              description: tool.description,
+              permissionMode: tool.source === 'custom' ? 'ask' as const : 'allow' as const,
+            })),
+            customSkills: downstreamCatalog.skills.map((skill) => ({
+              name: skill.name,
+              label: skill.label,
+              description: skill.description,
+              content: `---\nname: ${skill.name}\ndescription: ${skill.description}\n---\n# ${skill.label}`,
+              toolIds: skill.toolIds,
+            })),
+            customAgents: downstreamCatalog.customAgents.map((agent) => ({
+              name: agent.name,
+              description: agent.description,
+              instructions: agent.instructions,
+              skillNames: agent.skillNames,
+              toolIds: downstreamCatalog.tools.slice(0, 3).map((tool) => tool.id),
+              enabled: !agent.disabled,
+              color: agent.color,
+            })),
+          },
+          availableSkills: downstreamCatalog.agentCatalog.skills,
+          runtimeTools: downstreamCatalog.agentCatalog.tools.map((tool) => ({
+            id: tool.id,
+            description: tool.description,
+          })),
+          builtinTools: [],
+          builtinSkills: [],
+        })
+        if (summaries.length !== downstreamCatalog.customAgents.length) {
+          throw new Error('catalog.relationship.downstreamCatalog lost custom agents')
         }
       }, { batchSize: 8, warmupIterations: 3 }),
       await runBenchmark('agents.preview.downstreamCatalog', 30, () => {

--- a/tests/capability-catalog.test.ts
+++ b/tests/capability-catalog.test.ts
@@ -7,8 +7,8 @@ import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { getMachineSkillsDir } from '../apps/desktop/src/main/runtime-paths.ts'
 
 test('built-in capabilities expose discoverable metadata without source parsing', async () => {
-  const tools = listCapabilityTools()
-  const charts = getCapabilityTool('charts')
+  const tools = await listCapabilityTools()
+  const charts = await getCapabilityTool('charts')
   const skills = await listCapabilitySkills()
   const autoresearchBundle = await getCapabilitySkillBundle('autoresearch')
 

--- a/tests/effective-skills.test.ts
+++ b/tests/effective-skills.test.ts
@@ -7,6 +7,7 @@ import {
   buildBundledSkillIndex,
   clearBundledSkillIndexCache,
   getBundledSkillIndex,
+  warmBundledSkillIndex,
 } from '../apps/desktop/src/main/bundled-skill-index.ts'
 import {
   getEffectiveSkillBundleSync,
@@ -211,6 +212,34 @@ test('bundled skill index reflects nested tree changes without a manual cache cl
     assert.equal(refreshedIndex.has('first-skill'), true)
     assert.equal(refreshedIndex.get('nested-skill')?.skillDir, nestedSkill)
     assert.notEqual(refreshedIndex, initialIndex)
+  } finally {
+    clearBundledSkillIndexCache()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('warmed bundled skill index stays stable until explicit invalidation', () => {
+  const tempRoot = testTempDir('opencowork-skill-index-warm-')
+  const skillRoot = join(tempRoot, 'skills')
+  const firstSkill = join(skillRoot, 'first-skill')
+  const lateSkill = join(skillRoot, 'late-skill')
+
+  mkdirSync(firstSkill, { recursive: true })
+  writeFileSync(join(firstSkill, 'SKILL.md'), '---\nname: first-skill\ndescription: First\n---\n# First\n')
+
+  try {
+    clearBundledSkillIndexCache()
+    const warmedIndex = warmBundledSkillIndex([skillRoot])
+    assert.equal(warmedIndex.has('first-skill'), true)
+
+    mkdirSync(lateSkill, { recursive: true })
+    writeFileSync(join(lateSkill, 'SKILL.md'), '---\nname: late-skill\ndescription: Late\n---\n# Late\n')
+
+    assert.equal(getBundledSkillIndex([skillRoot]), warmedIndex)
+    assert.equal(getBundledSkillIndex([skillRoot]).has('late-skill'), false)
+
+    clearBundledSkillIndexCache()
+    assert.equal(getBundledSkillIndex([skillRoot]).has('late-skill'), true)
   } finally {
     clearBundledSkillIndexCache()
     rmSync(tempRoot, { recursive: true, force: true })

--- a/tests/session-history-loader.test.ts
+++ b/tests/session-history-loader.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import test from 'node:test'
 import type { SessionView } from '@open-cowork/shared'
 import type { ProjectedHistoryItem } from '../apps/desktop/src/main/session-history-projector.ts'
-import { createSessionHistoryService } from '../apps/desktop/src/main/session-history-loader.ts'
+import { createBoundedChildSnapshotLoader, createSessionHistoryService } from '../apps/desktop/src/main/session-history-loader.ts'
 
 function createEmptySessionView(): SessionView {
   return {
@@ -39,6 +39,43 @@ function createEmptySessionView(): SessionView {
     isAwaitingQuestion: false,
   }
 }
+
+test('bounded child snapshot loader prefetches without exceeding the concurrency cap', async () => {
+  let active = 0
+  let maxActive = 0
+  const completed: string[] = []
+  const loader = createBoundedChildSnapshotLoader({
+    ids: ['child-1', 'child-2', 'child-3', 'child-4', 'child-5'],
+    concurrency: 2,
+    load: async (id) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      active -= 1
+      completed.push(id)
+      return { messages: [{ id }], todos: [] }
+    },
+  })
+
+  loader.prefetch()
+  const snapshots = await Promise.all([
+    loader.load('child-1'),
+    loader.load('child-2'),
+    loader.load('child-3'),
+    loader.load('child-4'),
+    loader.load('child-5'),
+  ])
+
+  assert.equal(maxActive, 2)
+  assert.deepEqual(snapshots.map((snapshot) => snapshot.messages[0]), [
+    { id: 'child-1' },
+    { id: 'child-2' },
+    { id: 'child-3' },
+    { id: 'child-4' },
+    { id: 'child-5' },
+  ])
+  assert.deepEqual(completed.sort(), ['child-1', 'child-2', 'child-3', 'child-4', 'child-5'])
+})
 
 test('createSessionHistoryService loads questions and updates provider/model from projected history', async () => {
   const updates: Array<Record<string, unknown>> = []

--- a/tests/session-history-loader.test.ts
+++ b/tests/session-history-loader.test.ts
@@ -77,6 +77,23 @@ test('bounded child snapshot loader prefetches without exceeding the concurrency
   assert.deepEqual(completed.sort(), ['child-1', 'child-2', 'child-3', 'child-4', 'child-5'])
 })
 
+test('bounded child snapshot prefetch handles early rejections while preserving load errors', async () => {
+  const loader = createBoundedChildSnapshotLoader({
+    ids: ['child-1'],
+    concurrency: 1,
+    load: async () => {
+      throw new Error('child unavailable')
+    },
+  })
+
+  loader.prefetch()
+  await new Promise((resolve) => setTimeout(resolve, 5))
+  await assert.rejects(
+    loader.load('child-1'),
+    /child unavailable/,
+  )
+})
+
 test('createSessionHistoryService loads questions and updates provider/model from projected history', async () => {
   const updates: Array<Record<string, unknown>> = []
   const projectedItems: ProjectedHistoryItem[] = [


### PR DESCRIPTION
## Summary
- add a shared runtime catalog snapshot cache for agents and capabilities, with explicit invalidation on settings/custom content/runtime changes
- warm the bundled skill index for large downstream skill catalogs and reuse it across agent/capability reads
- keep large thread activation responsive with bounded child-session snapshot prefetching and cached thread search/facet queries
- defer chat agent visual and mentionable-agent catalog loading to idle time

## Production review
- cache keys include runtime context, provider/model, runtime tool cache generation, and explicit catalog generation
- custom MCP/skill/agent writes, agent-tool mutations, settings changes, MCP transitions, and runtime reboots invalidate the catalog snapshot path
- thread search/facet cache is bounded and invalidated by thread/tag/filter/suggestion writes
- full child hydration remains OpenCode-owned and ordered, with only bounded SDK fetch concurrency added around the existing projection

## Validation
- pnpm typecheck
- pnpm lint
- pnpm lint:dead-code
- pnpm test
- pnpm test:renderer
- pnpm perf:check
- pnpm test:e2e
- git diff --check

Closes #383