### PR TITLE
Polish provider auth copy flows

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -383,18 +383,28 @@ export function App() {
   // Sidebar), which was the bug this replaced.
   void localeVersion
   const showPreviewNotice = Boolean(metadata?.preview && !previewNoticeDismissed)
+  const previewNoticeStyle = {
+    borderColor: 'color-mix(in srgb, var(--color-amber) 34%, var(--color-border-subtle))',
+    background: 'color-mix(in srgb, var(--color-amber) 10%, var(--color-surface))',
+    color: 'var(--color-text)',
+  }
+  const previewNoticeButtonStyle = {
+    borderColor: 'color-mix(in srgb, var(--color-amber) 30%, var(--color-border-subtle))',
+    color: 'var(--color-text)',
+  }
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden bg-base">
       <TitleBar />
       {showPreviewNotice && metadata ? (
-        <div className="flex items-center gap-3 border-b border-amber-500/30 bg-amber-50 px-4 py-2 text-[12px] text-amber-950 dark:border-amber-400/25 dark:bg-amber-500/10 dark:text-amber-100">
+        <div className="flex items-center gap-3 border-b px-4 py-2 text-[12px]" style={previewNoticeStyle}>
           <span className="font-semibold">Public preview {metadata.version}</span>
-          <span className="min-w-0 flex-1 text-amber-800 dark:text-amber-100/80">
+          <span className="min-w-0 flex-1 text-text-muted">
             This v0.x build may change quickly. macOS preview artifacts can be unsigned until signing is configured.
           </span>
           <button
             type="button"
-            className="rounded border border-amber-600/30 px-2 py-1 text-[11px] text-amber-900 hover:bg-amber-200/50 dark:border-amber-300/30 dark:text-amber-50 dark:hover:bg-amber-200/10"
+            className="rounded border px-2 py-1 text-[11px] hover:bg-surface-hover"
+            style={previewNoticeButtonStyle}
             onClick={() => {
               dismissPreview(metadata.version)
               setPreviewNoticeDismissed(true)

--- a/apps/desktop/src/renderer/components/chat/MarkdownContent.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { MarkdownContent } from './MarkdownContent'
@@ -32,8 +32,9 @@ describe('MarkdownContent', () => {
     expect(button.getAttribute('aria-label')).toBe('Copied')
   })
 
-  it('leaves the copy affordance unchanged when clipboard writing fails', async () => {
+  it('falls back to the browser clipboard when the app clipboard bridge returns false', async () => {
     vi.mocked(window.coworkApi.clipboard.writeText).mockResolvedValueOnce(false)
+    const browserWrite = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValueOnce(undefined)
     const user = userEvent.setup()
     const { container } = render(<MarkdownContent text={'```txt\ncopy me\n```'} />)
 
@@ -41,6 +42,28 @@ describe('MarkdownContent', () => {
     await user.click(button)
 
     expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('copy me'))
+    expect(browserWrite).toHaveBeenCalledWith(expect.stringContaining('copy me'))
+    expect(button.getAttribute('aria-label')).toBe('Copied')
+  })
+
+  it('restarts code-copy feedback cleanly on repeated clicks', async () => {
+    const { container } = render(<MarkdownContent text={'```txt\ncopy me\n```'} />)
+    const button = await copyButton(container)
+    vi.useFakeTimers()
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+    expect(button.getAttribute('aria-label')).toBe('Copied')
+
+    act(() => vi.advanceTimersByTime(1500))
+    await act(async () => {
+      fireEvent.click(button)
+    })
+    act(() => vi.advanceTimersByTime(1999))
+    expect(button.getAttribute('aria-label')).toBe('Copied')
+
+    act(() => vi.advanceTimersByTime(1))
     expect(button.getAttribute('aria-label')).toBe('Copy code')
   })
 

--- a/apps/desktop/src/renderer/components/chat/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownContent.tsx
@@ -151,7 +151,7 @@ export function MarkdownContent({
   streaming?: boolean
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null)
-  const copyResetTimersRef = useRef(new Set<number>())
+  const copyResetTimersRef = useRef(new Map<HTMLButtonElement, number>())
   const html = useMemo(() => renderHtml(text, streaming), [text, streaming])
 
   useLayoutEffect(() => {
@@ -198,18 +198,21 @@ export function MarkdownContent({
       if (!content) return
       const copied = await writeTextToClipboard(content)
       if (!copied) return
+      const existingTimer = copyResetTimersRef.current.get(button)
+      if (existingTimer) window.clearTimeout(existingTimer)
       setCopyButtonState(button, true)
       const timer = window.setTimeout(() => {
-        copyResetTimersRef.current.delete(timer)
+        if (copyResetTimersRef.current.get(button) !== timer) return
+        copyResetTimersRef.current.delete(button)
         setCopyButtonState(button, false)
       }, 2000)
-      copyResetTimersRef.current.add(timer)
+      copyResetTimersRef.current.set(button, timer)
     }
 
     container.addEventListener('click', handleClick)
     return () => {
       container.removeEventListener('click', handleClick)
-      for (const timer of copyResetTimersRef.current) window.clearTimeout(timer)
+      for (const timer of copyResetTimersRef.current.values()) window.clearTimeout(timer)
       copyResetTimersRef.current.clear()
     }
   }, [])

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.test.tsx
@@ -45,6 +45,7 @@ describe('ProviderAuthControls', () => {
     await user.click(screen.getByRole('button', { name: "I've finished signing in" }))
 
     await waitFor(() => expect(onAuthUpdated).toHaveBeenCalledTimes(1))
+    expect(window.coworkApi.provider.callback).toHaveBeenCalledWith('openai', 0)
     expect(window.coworkApi.runtime.restart).not.toHaveBeenCalled()
     expect(screen.getByText('Provider login completed.')).toBeTruthy()
   })
@@ -56,7 +57,7 @@ describe('ProviderAuthControls', () => {
     vi.mocked(window.coworkApi.provider.authorize).mockResolvedValue({
       url: 'https://github.com/login/device',
       method: 'auto',
-      instructions: 'Enter code ABCD-1234 at https://github.com/login/device',
+      instructions: 'Enter code ABCD 1234 at https://github.com/login/device',
     })
     const user = userEvent.setup()
 
@@ -72,12 +73,70 @@ describe('ProviderAuthControls', () => {
 
     expect(screen.getByText('Browser login opened. Follow the instructions below, then return here and confirm so Open Cowork can verify the new login.')).toBeTruthy()
     expect(screen.getByText('Login instructions')).toBeTruthy()
-    expect(screen.getByText('Enter code ABCD-1234 at https://github.com/login/device')).toBeTruthy()
+    expect(screen.getByText('Enter code ABCD 1234 at https://github.com/login/device')).toBeTruthy()
 
     await user.click(screen.getByRole('button', { name: 'Copy' }))
 
-    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith('Enter code ABCD-1234 at https://github.com/login/device')
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith('ABCD-1234')
     expect(screen.getByText('Login instructions copied to clipboard.')).toBeTruthy()
+  })
+
+  it('copies full browser auth instructions when no device code is present', async () => {
+    vi.mocked(window.coworkApi.provider.authMethods).mockResolvedValue({
+      'github-copilot': [{ type: 'oauth', label: 'GitHub Copilot' }],
+    })
+    vi.mocked(window.coworkApi.provider.authorize).mockResolvedValue({
+      url: 'https://github.com/login/device',
+      method: 'auto',
+      instructions: 'Open the browser, choose Continue, then return to Open Cowork.',
+    })
+    const user = userEvent.setup()
+
+    render(
+      <ProviderAuthControls
+        providerId="github-copilot"
+        providerName="GitHub Copilot"
+        connected={false}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Sign in with GitHub Copilot' }))
+    await user.click(screen.getByRole('button', { name: 'Copy' }))
+
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith('Open the browser, choose Continue, then return to Open Cowork.')
+  })
+
+  it('accepts already-consumed browser auth callbacks when provider verification succeeds', async () => {
+    vi.mocked(window.coworkApi.provider.authMethods).mockResolvedValue({
+      openai: [browserMethod],
+    })
+    vi.mocked(window.coworkApi.provider.authorize).mockResolvedValue({
+      url: 'https://auth.example.test',
+      method: 'auto',
+      instructions: '',
+    })
+    vi.mocked(window.coworkApi.provider.callback).mockRejectedValueOnce(new Error('callback already consumed'))
+    vi.mocked(window.coworkApi.provider.list).mockResolvedValue([
+      { id: 'openai', name: 'OpenAI', connected: true },
+    ])
+    const onAuthUpdated = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ProviderAuthControls
+        providerId="openai"
+        providerName="OpenAI"
+        connected={false}
+        onAuthUpdated={onAuthUpdated}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Sign in with ChatGPT' }))
+    await user.click(screen.getByRole('button', { name: "I've finished signing in" }))
+
+    await waitFor(() => expect(onAuthUpdated).toHaveBeenCalledTimes(1))
+    expect(window.coworkApi.provider.callback).toHaveBeenCalledWith('openai', 0)
+    expect(screen.getByText('Provider login completed.')).toBeTruthy()
   })
 
   it('can clear stale OpenCode-native provider auth before a fresh login', async () => {

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { ProviderAuthAuthorization, ProviderAuthMethod, ProviderAuthPrompt } from '@open-cowork/shared'
+import type { ProviderAuthMethod, ProviderAuthPrompt } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import { writeTextToClipboard } from '../../helpers/clipboard'
 
@@ -31,6 +31,44 @@ interface Props {
   onAuthUpdated?: () => void | Promise<void>
 }
 
+type PendingAuth =
+  | { kind: 'code'; method: number }
+  | { kind: 'browser'; method: number; instructions: string | null }
+
+function deviceCodeFromInstructions(instructions: string) {
+  const normalizeCandidate = (candidate: string) => {
+    const groups = candidate.split(/[ -]+/).filter(Boolean)
+    const normalized = groups.join('').toUpperCase()
+    if (groups.length < 2 || !groups.every((group) => group.length === 4)) return null
+    if (groups[0]?.toUpperCase() === 'CODE') return null
+    if (!/[A-Z]/.test(normalized)) return null
+    return groups.map((group) => group.toUpperCase()).join('-')
+  }
+
+  const contextualPatterns = [
+    /\bcode[^a-z0-9\n]{1,20}([a-z0-9]{4}(?:[ -][a-z0-9]{4}){1,2})\b/i,
+    /\b(?:enter|paste)[^a-z0-9\n]{1,40}(?:code[^a-z0-9\n]{1,20})?([a-z0-9]{4}(?:[ -][a-z0-9]{4}){1,2})\b/i,
+  ]
+  for (const pattern of contextualPatterns) {
+    const contextual = instructions.match(pattern)
+    if (!contextual?.[1]) continue
+    const normalized = normalizeCandidate(contextual[1])
+    if (normalized) return normalized
+  }
+
+  for (const match of instructions.matchAll(/\b([a-z0-9]{4}(?:[ -][a-z0-9]{4}){1,2})\b/gi)) {
+    const normalized = normalizeCandidate(match[1] || '')
+    if (!normalized) continue
+    return normalized
+  }
+  return null
+}
+
+function copyPayloadForAuthInstructions(instructions: string) {
+  const trimmed = instructions.trim()
+  return deviceCodeFromInstructions(trimmed) || trimmed
+}
+
 export function ProviderAuthControls({
   providerId,
   providerName,
@@ -47,9 +85,7 @@ export function ProviderAuthControls({
   const [loading, setLoading] = useState(false)
   const [authorizing, setAuthorizing] = useState<number | null>(null)
   const [status, setStatus] = useState<string | null>(null)
-  const [pending, setPending] = useState<{ method: number; authorization: ProviderAuthAuthorization } | null>(null)
-  const [pendingBrowserLogin, setPendingBrowserLogin] = useState(false)
-  const [browserLoginInstructions, setBrowserLoginInstructions] = useState<string | null>(null)
+  const [pendingAuth, setPendingAuth] = useState<PendingAuth | null>(null)
   const [code, setCode] = useState('')
   const [methodInputs, setMethodInputs] = useState<Record<number, Record<string, string>>>({})
 
@@ -95,9 +131,7 @@ export function ProviderAuthControls({
   useEffect(() => {
     setMethods([])
     setStatus(null)
-    setPending(null)
-    setPendingBrowserLogin(false)
-    setBrowserLoginInstructions(null)
+    setPendingAuth(null)
     setCode('')
     setMethodInputs({})
     void loadMethods()
@@ -126,9 +160,7 @@ export function ProviderAuthControls({
     if (!providerId) return
     setAuthorizing(methodIndex ?? -1)
     setStatus(null)
-    setPending(null)
-    setPendingBrowserLogin(false)
-    setBrowserLoginInstructions(null)
+    setPendingAuth(null)
     try {
       if (onBeforeAuthorize) {
         const ok = await onBeforeAuthorize()
@@ -153,12 +185,11 @@ export function ProviderAuthControls({
         return
       }
       if (authorization.method === 'code') {
-        setPending({ method: selectedIndex, authorization })
+        setPendingAuth({ kind: 'code', method: selectedIndex })
         setStatus(authorization.instructions || t('providerAuth.enterCode', 'Complete the browser login, then paste the authorization code here.'))
       } else {
-        setPendingBrowserLogin(true)
         const instructions = authorization.instructions?.trim() || null
-        setBrowserLoginInstructions(instructions)
+        setPendingAuth({ kind: 'browser', method: selectedIndex, instructions })
         setStatus(instructions
           ? t('providerAuth.browserOpenedWithInstructions', 'Browser login opened. Follow the instructions below, then return here and confirm so Open Cowork can verify the new login.')
           : t('providerAuth.browserOpened', 'Browser login opened. Complete the flow there, then return here and confirm so Open Cowork can verify the new login.'))
@@ -171,7 +202,8 @@ export function ProviderAuthControls({
   }
 
   const completeCodeFlow = async () => {
-    if (!providerId || !pending) return
+    if (!providerId || pendingAuth?.kind !== 'code') return
+    const pending = pendingAuth
     setAuthorizing(pending.method)
     setStatus(null)
     try {
@@ -184,8 +216,7 @@ export function ProviderAuthControls({
           setStatus(t('providerAuth.notVerified', 'OpenCode still does not report this provider as signed in. Finish the browser login, then try confirming again.'))
           return
         }
-        setPending(null)
-        setBrowserLoginInstructions(null)
+        setPendingAuth(null)
         setCode('')
         await onAuthUpdated?.()
       }
@@ -222,16 +253,25 @@ export function ProviderAuthControls({
   }
 
   const finishBrowserLogin = async () => {
+    if (!providerId || pendingAuth?.kind !== 'browser') return
+    const pending = pendingAuth
     setAuthorizing(-1)
     setStatus(null)
     try {
+      try {
+        await window.coworkApi.provider.callback(providerId, pending.method)
+      } catch {
+        // Some providers consume the callback before the user returns to
+        // Open Cowork. Provider verification below is the authoritative
+        // success check for those already-completed browser flows.
+      }
+
       if (!await verifyProviderConnected()) {
         setStatus(t('providerAuth.notVerified', 'OpenCode still does not report this provider as signed in. Finish the browser login, then try confirming again.'))
         return
       }
       await onAuthUpdated?.()
-      setPendingBrowserLogin(false)
-      setBrowserLoginInstructions(null)
+      setPendingAuth(null)
       setStatus(t('providerAuth.connected', 'Provider login completed.'))
     } catch (err) {
       setStatus(err instanceof Error ? err.message : String(err))
@@ -246,9 +286,7 @@ export function ProviderAuthControls({
     setStatus(null)
     try {
       await window.coworkApi.provider.logout(providerId)
-      setPending(null)
-      setPendingBrowserLogin(false)
-      setBrowserLoginInstructions(null)
+      setPendingAuth(null)
       setCode('')
       setStatus(t('providerAuth.removed', 'Provider login removed. Sign in again to refresh the token.'))
       await onAuthUpdated?.()
@@ -262,12 +300,14 @@ export function ProviderAuthControls({
 
   const entries = oauthMethods
   const copyBrowserLoginInstructions = async () => {
-    if (!browserLoginInstructions) return
-    const copied = await writeTextToClipboard(browserLoginInstructions)
+    if (pendingAuth?.kind !== 'browser' || !pendingAuth.instructions) return
+    const copied = await writeTextToClipboard(copyPayloadForAuthInstructions(pendingAuth.instructions))
     setStatus(copied
       ? t('providerAuth.instructionsCopied', 'Login instructions copied to clipboard.')
       : t('providerAuth.instructionsCopyFailed', 'Could not copy login instructions. Select the instructions and copy them manually.'))
   }
+  const pendingCodeAuth = pendingAuth?.kind === 'code' ? pendingAuth : null
+  const pendingBrowserAuth = pendingAuth?.kind === 'browser' ? pendingAuth : null
 
   return (
     <div className="flex flex-col gap-3">
@@ -350,7 +390,7 @@ export function ProviderAuthControls({
             </div>
           )
         })}
-        {pending ? (
+        {pendingCodeAuth ? (
           <div className="flex flex-col gap-2">
             <input
               type="text"
@@ -373,9 +413,9 @@ export function ProviderAuthControls({
             </button>
           </div>
         ) : null}
-        {pendingBrowserLogin ? (
+        {pendingBrowserAuth ? (
           <div className="flex flex-col gap-2">
-            {browserLoginInstructions ? (
+            {pendingBrowserAuth.instructions ? (
               <div className="rounded-xl border border-border-subtle p-3 flex flex-col gap-2" style={{ background: 'var(--color-surface)' }}>
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-[11px] font-semibold text-text">
@@ -390,7 +430,7 @@ export function ProviderAuthControls({
                   </button>
                 </div>
                 <pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-text">
-                  {browserLoginInstructions}
+                  {pendingBrowserAuth.instructions}
                 </pre>
               </div>
             ) : null}

--- a/apps/desktop/src/renderer/helpers/clipboard.test.ts
+++ b/apps/desktop/src/renderer/helpers/clipboard.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeTextToClipboard } from './clipboard'
+
+describe('writeTextToClipboard', () => {
+  beforeEach(() => {
+    vi.mocked(window.coworkApi.clipboard.writeText).mockClear()
+    const browserWrite = vi.spyOn(navigator.clipboard, 'writeText')
+    browserWrite.mockClear()
+    browserWrite.mockResolvedValue(undefined)
+  })
+
+  it('uses the app clipboard bridge when it succeeds', async () => {
+    await expect(writeTextToClipboard('copy me')).resolves.toBe(true)
+
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith('copy me')
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the browser clipboard when the app bridge returns false', async () => {
+    vi.mocked(window.coworkApi.clipboard.writeText).mockResolvedValueOnce(false)
+
+    await expect(writeTextToClipboard('copy me')).resolves.toBe(true)
+
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith('copy me')
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('copy me')
+  })
+
+  it('falls back to the browser clipboard when the app bridge throws', async () => {
+    vi.mocked(window.coworkApi.clipboard.writeText).mockRejectedValueOnce(new Error('clipboard denied'))
+
+    await expect(writeTextToClipboard('copy me')).resolves.toBe(true)
+
+    expect(window.coworkApi.clipboard.writeText).toHaveBeenCalledWith('copy me')
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('copy me')
+  })
+
+  it('returns false when every clipboard path fails', async () => {
+    vi.mocked(window.coworkApi.clipboard.writeText).mockResolvedValueOnce(false)
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('clipboard denied'))
+
+    await expect(writeTextToClipboard('copy me')).resolves.toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/helpers/clipboard.ts
+++ b/apps/desktop/src/renderer/helpers/clipboard.ts
@@ -3,9 +3,15 @@ export async function writeTextToClipboard(text: string) {
 
   try {
     if (window.coworkApi?.clipboard?.writeText) {
-      return window.coworkApi.clipboard.writeText(text)
+      const copied = await window.coworkApi.clipboard.writeText(text)
+      if (copied) return true
     }
+  } catch {
+    // Fall back to the browser clipboard API below.
+  }
 
+  try {
+    if (!navigator.clipboard?.writeText) return false
     await navigator.clipboard.writeText(text)
     return true
   } catch {


### PR DESCRIPTION
## Summary
- finish browser-based provider auth through the selected OpenCode auth method, then verify provider connection as the authoritative success signal
- copy normalized device codes from browser auth instructions when present, with full-instruction fallback
- centralize clipboard fallback from the Electron bridge to the browser Clipboard API and harden Markdown copy feedback timers
- restyle the preview notice with theme tokens instead of fixed amber classes

Fixes #387

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- src/renderer/components/provider/ProviderAuthControls.test.tsx src/renderer/components/chat/MarkdownContent.test.tsx src/renderer/helpers/clipboard.test.ts src/renderer/App.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:e2e
- git diff --check