### PR TITLE
Handle SDK thread event shapes

### DIFF
--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -4,7 +4,7 @@ import {
   normalizeMessagePart,
   normalizeSessionInfo,
 } from './opencode-adapter.ts'
-import { readRecordValue, readString } from './normalizer-utils.ts'
+import { asRecord, readRecordValue, readString } from './normalizer-utils.ts'
 import { resolveDisplayCost } from './pricing.ts'
 import {
   aliasTaskRunId,
@@ -334,11 +334,20 @@ export function handleMessagePartDeltaEvent(
   properties: Record<string, unknown> | null | undefined,
   messageState: SessionScopedMessageState,
 ) {
+  const rawPart = asRecord(readRecordValue(properties, 'part'))
   const messageId = readString(readRecordValue(properties, 'messageID'))
     || readString(readRecordValue(properties, 'messageId'))
+    || readString(readRecordValue(rawPart, 'messageID'))
+    || readString(readRecordValue(rawPart, 'messageId'))
     || null
   const actualSessionId = readString(readRecordValue(properties, 'sessionID'))
     || readString(readRecordValue(properties, 'sessionId'))
+    || readString(readRecordValue(rawPart, 'sessionID'))
+    || readString(readRecordValue(rawPart, 'sessionId'))
+    || null
+  const partId = readString(readRecordValue(properties, 'partID'))
+    || readString(readRecordValue(properties, 'partId'))
+    || readString(readRecordValue(rawPart, 'id'))
     || null
   const sessionId = resolveRootSession(actualSessionId)
   const rawDelta = readString(readRecordValue(properties, 'delta'))
@@ -365,7 +374,7 @@ export function handleMessagePartDeltaEvent(
         actualSessionId,
         taskRunId,
         messageId,
-        partId: readString(readRecordValue(properties, 'partID')) || readString(readRecordValue(properties, 'partId')) || null,
+        partId,
         content: delta,
       })
       return
@@ -378,7 +387,7 @@ export function handleMessagePartDeltaEvent(
       actualSessionId,
       taskRunId,
       messageId,
-      partId: readString(readRecordValue(properties, 'partID')) || readString(readRecordValue(properties, 'partId')) || null,
+      partId,
       content: delta,
       mode: 'append',
     })
@@ -390,7 +399,7 @@ export function handleMessagePartDeltaEvent(
     actualSessionId,
     taskRunId,
     messageId,
-    partId: readString(readRecordValue(properties, 'partID')) || readString(readRecordValue(properties, 'partId')) || null,
+    partId,
     content: delta,
     mode: 'append',
   })
@@ -416,18 +425,26 @@ function resolveUpdatedPartContext(
   messageState: SessionScopedMessageState,
   cachedModelId: string,
 ): MessagePartUpdatedContext | null {
-  const part = normalizeMessagePart(readRecordValue(properties, 'part'))
+  const rawPart = asRecord(readRecordValue(properties, 'part'))
+  const part = normalizeMessagePart(rawPart)
   if (!part) return null
 
   const messageId = readString(readRecordValue(properties, 'messageID'))
     || readString(readRecordValue(properties, 'messageId'))
+    || readString(readRecordValue(rawPart, 'messageID'))
+    || readString(readRecordValue(rawPart, 'messageId'))
     || null
   const partId = readString(readRecordValue(properties, 'partID'))
     || readString(readRecordValue(properties, 'partId'))
+    || readString(readRecordValue(rawPart, 'partID'))
+    || readString(readRecordValue(rawPart, 'partId'))
+    || readString(readRecordValue(rawPart, 'id'))
     || part.id
     || null
   const actualSessionId = readString(readRecordValue(properties, 'sessionID'))
     || readString(readRecordValue(properties, 'sessionId'))
+    || readString(readRecordValue(rawPart, 'sessionID'))
+    || readString(readRecordValue(rawPart, 'sessionId'))
     || null
   const messageRole = messageId ? getMessageRole(messageState, actualSessionId, messageId) : undefined
   if (messageRole === 'user') return null

--- a/apps/desktop/src/main/event-runtime-handlers.ts
+++ b/apps/desktop/src/main/event-runtime-handlers.ts
@@ -45,11 +45,21 @@ import {
   chooseTaskTitle,
   extractAgentName,
   isPlaceholderTaskTitle,
+  normalizeAgentName,
   toIsoTimestamp,
 } from './task-run-utils.ts'
 import type { PermissionRequest } from '@open-cowork/shared'
 
 type DispatchRuntimeEvent = (win: BrowserWindow, event: RuntimeSessionEvent) => void
+const IDLE_EVENT_DEDUPE_MS = 2_000
+const MAX_RECENT_IDLE_EVENTS = 1_000
+const recentIdleEventAtBySession = new Map<string, number>()
+const INTENTIONALLY_IGNORED_RUNTIME_EVENTS = new Set([
+  'server.connected',
+  'server.heartbeat',
+  'session.diff',
+  'session.next.model.switched',
+])
 
 function runRuntimeSideEffect(scope: string, task: () => void | Promise<unknown>) {
   void Promise.resolve().then(task).catch((err) => {
@@ -74,10 +84,110 @@ function dispatchSyntheticIdle(win: BrowserWindow, sessionId: string, dispatchRu
   })
 }
 
+function readEventSessionId(properties: Record<string, unknown> | null | undefined) {
+  return readString(readRecordValue(properties, 'sessionID'))
+    || readString(readRecordValue(properties, 'sessionId'))
+}
+
+function shouldProcessIdleEvent(actualSessionId: string) {
+  const now = Date.now()
+  const previous = recentIdleEventAtBySession.get(actualSessionId) || 0
+  recentIdleEventAtBySession.set(actualSessionId, now)
+  if (recentIdleEventAtBySession.size > MAX_RECENT_IDLE_EVENTS) {
+    for (const [sessionId, idleAt] of recentIdleEventAtBySession.entries()) {
+      if (now - idleAt > IDLE_EVENT_DEDUPE_MS) recentIdleEventAtBySession.delete(sessionId)
+    }
+  }
+  return now - previous > IDLE_EVENT_DEDUPE_MS
+}
+
+function clearRecentIdleEvent(actualSessionId: string | null | undefined) {
+  if (actualSessionId) recentIdleEventAtBySession.delete(actualSessionId)
+}
+
+function handleIdleTransition(input: {
+  win: BrowserWindow
+  actualSessionId: string | null | undefined
+  dispatchRuntimeEvent: DispatchRuntimeEvent
+}) {
+  const { win, actualSessionId, dispatchRuntimeEvent } = input
+  const rootSessionId = resolveRootSession(actualSessionId)
+  if (!rootSessionId || !actualSessionId) return true
+  if (!shouldProcessIdleEvent(actualSessionId)) return true
+
+  log('session', `Idle: ${shortSessionId(actualSessionId)}${rootSessionId !== actualSessionId ? ` => ${shortSessionId(rootSessionId)}` : ''}`)
+  if (rootSessionId === actualSessionId) {
+    forgetSubmittedPrompt(rootSessionId)
+    stopSessionStatusReconciliation(rootSessionId)
+    touchSessionRecord(rootSessionId)
+    dispatchRuntimeEvent(win, {
+      type: 'history_refresh',
+      sessionId: rootSessionId,
+      data: { type: 'history_refresh' },
+    })
+    dispatchRuntimeEvent(win, {
+      type: 'done',
+      sessionId: rootSessionId,
+      data: { type: 'done' },
+    })
+    if (isTrackedParentSession(rootSessionId)) {
+      untrackParentSession(rootSessionId)
+    }
+    runRuntimeSideEffect('workflow idle handling', () => handleWorkflowSessionIdle(rootSessionId))
+  } else {
+    const taskRun = ensureTaskRunForChild(rootSessionId, actualSessionId)
+    if (taskRun) {
+      const updated = updateTaskRun(taskRun.id, { status: 'complete' })
+      if (updated) emitTaskRun(win, updated)
+    }
+  }
+  return true
+}
+
+function handleAgentSwitchedEvent(input: {
+  win: BrowserWindow
+  properties: Record<string, unknown> | null | undefined
+  dispatchRuntimeEvent: DispatchRuntimeEvent
+}) {
+  const { win, properties, dispatchRuntimeEvent } = input
+  const actualSessionId = readEventSessionId(properties)
+  const rootSessionId = resolveRootSession(actualSessionId)
+  const agentName = normalizeAgentName(readString(readRecordValue(properties, 'agent')))
+    || readString(readRecordValue(properties, 'agent'))
+    || null
+  if (!rootSessionId || !actualSessionId || !agentName) return true
+
+  if (actualSessionId === rootSessionId) {
+    dispatchRuntimeEvent(win, {
+      type: 'agent',
+      sessionId: rootSessionId,
+      data: { type: 'agent', name: agentName },
+    })
+    return true
+  }
+
+  const taskRun = ensureTaskRunForChild(rootSessionId, actualSessionId, agentName)
+  if (!taskRun) return true
+  const updated = updateTaskRun(taskRun.id, {
+    agent: agentName,
+    title: chooseTaskTitle(
+      agentName,
+      !isPlaceholderTaskTitle(taskRun.title, taskRun.agent || agentName) ? taskRun.title : null,
+    ),
+    status: taskRun.status === 'queued' ? 'running' : taskRun.status,
+  })
+  if (updated) emitTaskRun(win, updated)
+  return true
+}
+
 export function removeParentSession(sessionId: string) {
   stopSessionStatusReconciliation(sessionId)
   removeParentSessionState(sessionId)
   sessionEngine.removeSession(sessionId)
+}
+
+export function resetRuntimeEventStateForTests() {
+  recentIdleEventAtBySession.clear()
 }
 
 export function handleRuntimeSideEffectEvent(input: {
@@ -209,13 +319,24 @@ export function handleRuntimeSideEffectEvent(input: {
       return true
     }
 
+    case 'session.next.agent.switched':
+      return handleAgentSwitchedEvent({ win, properties, dispatchRuntimeEvent })
+
+    case 'session.idle':
+      return handleIdleTransition({
+        win,
+        actualSessionId: readEventSessionId(properties),
+        dispatchRuntimeEvent,
+      })
+
     case 'session.status': {
       const status = asRecord(readRecordValue(properties, 'status'))
-      const actualSessionId = readString(readRecordValue(properties, 'sessionID'))
+      const actualSessionId = readEventSessionId(properties)
       const rootSessionId = resolveRootSession(actualSessionId)
       if (!rootSessionId || !actualSessionId) return true
 
       if (readString(readRecordValue(status, 'type')) === 'busy') {
+        clearRecentIdleEvent(actualSessionId)
         if (rootSessionId === actualSessionId) {
           touchSessionRecord(rootSessionId)
           dispatchRuntimeEvent(win, {
@@ -233,32 +354,11 @@ export function handleRuntimeSideEffectEvent(input: {
       }
 
       if (readString(readRecordValue(status, 'type')) === 'idle') {
-        log('session', `Idle: ${shortSessionId(actualSessionId)}${rootSessionId !== actualSessionId ? ` => ${shortSessionId(rootSessionId)}` : ''}`)
-        if (rootSessionId === actualSessionId) {
-          forgetSubmittedPrompt(rootSessionId)
-          stopSessionStatusReconciliation(rootSessionId)
-          touchSessionRecord(rootSessionId)
-          dispatchRuntimeEvent(win, {
-            type: 'history_refresh',
-            sessionId: rootSessionId,
-            data: { type: 'history_refresh' },
-          })
-          dispatchRuntimeEvent(win, {
-            type: 'done',
-            sessionId: rootSessionId,
-            data: { type: 'done' },
-          })
-          if (isTrackedParentSession(rootSessionId)) {
-            untrackParentSession(rootSessionId)
-          }
-          runRuntimeSideEffect('workflow idle handling', () => handleWorkflowSessionIdle(rootSessionId))
-        } else {
-          const taskRun = ensureTaskRunForChild(rootSessionId, actualSessionId)
-          if (taskRun) {
-            const updated = updateTaskRun(taskRun.id, { status: 'complete' })
-            if (updated) emitTaskRun(win, updated)
-          }
-        }
+        handleIdleTransition({
+          win,
+          actualSessionId,
+          dispatchRuntimeEvent,
+        })
       }
       return true
     }
@@ -437,6 +537,7 @@ export function handleRuntimeSideEffectEvent(input: {
     }
 
     default:
+      if (INTENTIONALLY_IGNORED_RUNTIME_EVENTS.has(type)) return true
       return false
   }
 }

--- a/apps/desktop/src/main/opencode-adapter.ts
+++ b/apps/desktop/src/main/opencode-adapter.ts
@@ -288,7 +288,10 @@ export function normalizeRuntimeEventEnvelope(value: unknown): NormalizedRuntime
   const payload = asRecord(envelope.payload)
   const source = readRecordString(payload, ['type']) ? payload : envelope
   const nested = asRecord(source.data)
-  const rawType = readRecordString(source, ['type']) || readRecordString(nested, ['type'])
+  const sourceType = readRecordString(source, ['type'])
+  const rawType = sourceType === 'sync'
+    ? readRecordString(source, ['name']) || readRecordString(nested, ['type'])
+    : sourceType || readRecordString(nested, ['type'])
   const type = rawType?.replace(/\.\d+$/, '') || null
   if (!type) return null
   const sourceProperties = asRecord(source.properties)

--- a/tests/event-message-handlers.test.ts
+++ b/tests/event-message-handlers.test.ts
@@ -56,6 +56,54 @@ test('message text deltas buffer until assistant role is known, then flush', () 
   assert.equal(collector.events.length, 1)
 })
 
+test('message text deltas accept SDK ids from the part payload', () => {
+  const win = {} as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+  const collector = createDispatchCollector()
+
+  handleMessageUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      info: {
+        id: 'msg_part_scoped',
+        role: 'assistant',
+        sessionID: 'sess_part_scoped',
+      },
+    },
+    messageState,
+  )
+
+  handleMessagePartDeltaEvent(
+    win,
+    collector.dispatch,
+    {
+      part: {
+        id: 'part_scoped',
+        sessionID: 'sess_part_scoped',
+        messageID: 'msg_part_scoped',
+        type: 'text',
+      },
+      delta: 'streamed from SDK shape',
+    },
+    messageState,
+  )
+
+  assert.deepEqual(collector.events[0], {
+    type: 'text',
+    sessionId: 'sess_part_scoped',
+    data: {
+      type: 'text',
+      mode: 'append',
+      content: 'streamed from SDK shape',
+      taskRunId: null,
+      sourceSessionId: 'sess_part_scoped',
+      messageId: 'msg_part_scoped',
+      partId: 'part_scoped',
+    },
+  })
+})
+
 test('user-role message updates drop buffered text instead of dispatching it', () => {
   const win = {} as BrowserWindow
   const messageState = createSessionScopedMessageState()

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { BrowserWindow } from 'electron'
-import { handleRuntimeSideEffectEvent } from '../apps/desktop/src/main/event-runtime-handlers.ts'
+import {
+  handleRuntimeSideEffectEvent,
+  resetRuntimeEventStateForTests,
+} from '../apps/desktop/src/main/event-runtime-handlers.ts'
 import {
   createSessionScopedMessageState,
+  handleMessageUpdatedEvent,
   handleMessagePartUpdatedEvent,
 } from '../apps/desktop/src/main/event-message-handlers.ts'
 import {
@@ -41,6 +45,7 @@ function createWindowSendCollector(options?: { destroyed?: boolean; webContentsD
 
 test.afterEach(() => {
   resetEventTaskState()
+  resetRuntimeEventStateForTests()
 })
 
 test('returns false for events outside the runtime side-effect handler scope', () => {
@@ -327,6 +332,103 @@ test('session.status tracks child task runs through running and complete states'
   })
 })
 
+test('session.idle drives the same root completion path as session.status idle', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  const handled = handleRuntimeSideEffectEvent({
+    win,
+    type: 'session.idle',
+    properties: {
+      sessionID: 'root-session',
+    },
+    dispatchRuntimeEvent: collector.dispatch,
+    getMainWindow: () => win,
+  })
+
+  assert.equal(handled, true)
+  assert.deepEqual(collector.events, [
+    {
+      type: 'history_refresh',
+      sessionId: 'root-session',
+      data: { type: 'history_refresh' },
+    },
+    {
+      type: 'done',
+      sessionId: 'root-session',
+      data: { type: 'done' },
+    },
+  ])
+})
+
+test('session.status idle and session.idle are deduped for the same SDK transition', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  handleRuntimeSideEffectEvent({
+    win,
+    type: 'session.status',
+    properties: {
+      sessionID: 'root-session',
+      status: { type: 'idle' },
+    },
+    dispatchRuntimeEvent: collector.dispatch,
+    getMainWindow: () => win,
+  })
+
+  handleRuntimeSideEffectEvent({
+    win,
+    type: 'session.idle',
+    properties: {
+      sessionID: 'root-session',
+    },
+    dispatchRuntimeEvent: collector.dispatch,
+    getMainWindow: () => win,
+  })
+
+  assert.equal(collector.events.length, 2)
+  assert.equal((collector.events[0] as { type?: string }).type, 'history_refresh')
+  assert.equal((collector.events[1] as { type?: string }).type, 'done')
+})
+
+test('session.next.agent.switched updates root active agent without waiting for message parts', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+
+  trackParentSession('root-session')
+
+  const handled = handleRuntimeSideEffectEvent({
+    win,
+    type: 'session.next.agent.switched',
+    properties: {
+      sessionID: 'root-session',
+      agent: 'business-analyst',
+    },
+    dispatchRuntimeEvent: collector.dispatch,
+    getMainWindow: () => win,
+  })
+
+  assert.equal(handled, true)
+  assert.deepEqual(collector.events, [{
+    type: 'agent',
+    sessionId: 'root-session',
+    data: { type: 'agent', name: 'business-analyst' },
+  }])
+})
+
 test('child tool errors do not terminalize a still-running subagent task', () => {
   const collector = createDispatchCollector()
   const win = {
@@ -377,6 +479,61 @@ test('child tool errors do not terminalize a still-running subagent task', () =>
       attachments: undefined,
       taskRunId: 'child:child-session',
       sourceSessionId: 'child-session',
+    },
+  })
+})
+
+test('message.part.updated reads SDK part-scoped ids for child transcript text', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+
+  trackParentSession('root-session')
+  registerSession('child-session', 'root-session')
+
+  handleMessageUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      info: {
+        id: 'message-1',
+        role: 'assistant',
+        sessionID: 'child-session',
+      },
+    },
+    messageState,
+  )
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      part: {
+        id: 'part-1',
+        sessionID: 'child-session',
+        messageID: 'message-1',
+        type: 'text',
+        text: 'Subagent findings should be visible.',
+      },
+    },
+    messageState,
+    'openai/gpt-5.5',
+  )
+
+  assert.deepEqual(collector.events[0], {
+    type: 'text',
+    sessionId: 'root-session',
+    data: {
+      type: 'text',
+      mode: 'replace',
+      content: 'Subagent findings should be visible.',
+      taskRunId: 'child:child-session',
+      sourceSessionId: 'child-session',
+      messageId: 'message-1',
+      partId: 'part-1',
     },
   })
 })

--- a/tests/opencode-adapter.test.ts
+++ b/tests/opencode-adapter.test.ts
@@ -115,6 +115,31 @@ test('normalizeRuntimeEventEnvelope unwraps nested properties inside sync-style 
   assert.equal(event?.properties.delta, 'world')
 })
 
+test('normalizeRuntimeEventEnvelope accepts SDK sync events that identify the runtime event in name', () => {
+  const event = normalizeRuntimeEventEnvelope({
+    payload: {
+      type: 'sync',
+      name: 'message.part.updated.1',
+      data: {
+        sessionID: 'sess_sync',
+        part: {
+          id: 'part_sync',
+          sessionID: 'sess_sync',
+          messageID: 'msg_sync',
+          type: 'text',
+          text: 'hello from sync',
+        },
+        time: 42,
+      },
+    },
+  })
+
+  assert.ok(event)
+  assert.equal(event?.type, 'message.part.updated')
+  assert.equal(event?.properties.sessionID, 'sess_sync')
+  assert.equal((event?.properties.part as { id?: string } | undefined)?.id, 'part_sync')
+})
+
 test('normalizeMcpStatusEntries maps named status objects', () => {
   const entries = normalizeMcpStatusEntries({
     charts: { status: 'connected' },


### PR DESCRIPTION
## Summary
- accept SDK nested part payload ids for message deltas and updates so child/subagent text projects reliably
- normalize SDK sync envelopes that carry the runtime event name in name
- handle SDK session.idle and session.next.agent.switched without inventing runtime behavior
- acknowledge expected SDK telemetry events instead of logging them as unknown

## Validation
- node --no-warnings --experimental-strip-types --test tests/opencode-adapter.test.ts tests/event-message-handlers.test.ts tests/event-runtime-handlers.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check
- pnpm test