### PR TITLE
Add API-token MCP preflight diagnostics

### DIFF
--- a/apps/desktop/src/main/capability-tool-discovery.ts
+++ b/apps/desktop/src/main/capability-tool-discovery.ts
@@ -56,7 +56,7 @@ function isMcpBackedCapability(tool: CapabilityTool) {
   return Boolean(tool.namespace) || tool.patterns.some((pattern) => pattern.startsWith('mcp__'))
 }
 
-export async function listToolsFromMcpEntry(entry: unknown) {
+export async function listToolsFromMcpEntry(entry: unknown, options: { timeoutMs?: number } = {}) {
   if (!entry) return []
 
   const runtimeEntry = entry as ResolvedRuntimeMcpEntry
@@ -65,32 +65,42 @@ export async function listToolsFromMcpEntry(entry: unknown) {
     { capabilities: {} },
   )
 
-  if (runtimeEntry.type === 'local') {
-    const [command, ...args] = runtimeEntry.command
-    if (!command) return []
-    const transport = new StdioClientTransport({
-      command,
-      args,
-      env: runtimeEntry.environment,
-      stderr: 'pipe',
-    })
-    await client.connect(transport)
-  } else {
-    const transport = new StreamableHTTPClientTransport(new URL(runtimeEntry.url), {
-      requestInit: runtimeEntry.headers
-        ? { headers: runtimeEntry.headers }
-        : undefined,
-    })
-    await client.connect(transport)
-  }
+  const abortController = runtimeEntry.type === 'remote' && options.timeoutMs
+    ? new AbortController()
+    : null
+  const timeout = abortController && options.timeoutMs
+    ? setTimeout(() => abortController.abort(), options.timeoutMs)
+    : null
 
   try {
+    if (runtimeEntry.type === 'local') {
+      const [command, ...args] = runtimeEntry.command
+      if (!command) return []
+      const transport = new StdioClientTransport({
+        command,
+        args,
+        env: runtimeEntry.environment,
+        stderr: 'pipe',
+      })
+      await client.connect(transport)
+    } else {
+      const requestInit: RequestInit = {
+        ...(runtimeEntry.headers ? { headers: runtimeEntry.headers } : {}),
+        ...(abortController ? { signal: abortController.signal } : {}),
+      }
+      const transport = new StreamableHTTPClientTransport(new URL(runtimeEntry.url), {
+        requestInit,
+      })
+      await client.connect(transport)
+    }
+
     const result = await client.listTools()
     return (result.tools || []).map((tool: { name: string; description?: string }) => ({
       id: tool.name,
       description: tool.description?.trim() || 'No description available for this MCP method.',
     }))
   } finally {
+    if (timeout) clearTimeout(timeout)
     await client.close().catch(() => {})
   }
 }

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -62,6 +62,10 @@ export type BundleMcp = {
   // like GitHub (PAT) or Perplexity (API key) collect their secrets
   // without each downstream fork having to build its own UI.
   credentials?: CredentialField[]
+  // Optional downstream-authored troubleshooting text shown with API-token
+  // preflight failures. Example: GitHub PAT scopes, SSO authorization, or
+  // enterprise policy checks.
+  credentialHelp?: string
   // Opt-in: forward the app-level Google OAuth credentials into this MCP
   // via `GOOGLE_APPLICATION_CREDENTIALS`. See `CustomMcpConfig.googleAuth`
   // for the contract. Gated on `auth.mode: google-oauth` + a successful

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -66,6 +66,10 @@ export type BundleMcp = {
   // preflight failures. Example: GitHub PAT scopes, SSO authorization, or
   // enterprise policy checks.
   credentialHelp?: string
+  // Opt-in for downstream-hosted remote MCPs that intentionally live on
+  // private DNS/IP ranges, such as an internal GCS or intranet MCP. Cloud
+  // metadata endpoints remain blocked by the URL policy even when this is true.
+  allowPrivateNetwork?: boolean
   // Opt-in: forward the app-level Google OAuth credentials into this MCP
   // via `GOOGLE_APPLICATION_CREDENTIALS`. See `CustomMcpConfig.googleAuth`
   // for the contract. Gated on `auth.mode: google-oauth` + a successful

--- a/apps/desktop/src/main/ipc/catalog-handlers.ts
+++ b/apps/desktop/src/main/ipc/catalog-handlers.ts
@@ -12,6 +12,7 @@ import { readEffectiveSkillBundleFile } from '../effective-skills.ts'
 import { expandMcpToolPermissionPatterns, getConfiguredToolPatterns, getConfiguredToolsFromConfig } from '../config-loader.ts'
 import { log } from '../logger.ts'
 import { createKeyedPromiseChain } from '../promise-chain.ts'
+import { preflightConfiguredApiTokenMcp } from '../mcp-preflight.ts'
 
 function resolveContext(context: IpcHandlerContext, options?: RuntimeContextOptions) {
   return {
@@ -259,6 +260,14 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
         return false
       }
     })
+  })
+
+  registerIpcInvoke(context, 'mcp:preflight', stringArg('MCP name'), async (_event, name) => {
+    const result = await preflightConfiguredApiTokenMcp(name, {
+      listToolsFromMcpEntry: context.listToolsFromMcpEntry,
+    })
+    log('mcp', `Preflight ${name}: ${result.status}${result.httpStatus ? ` http=${result.httpStatus}` : ''} ${result.message}`)
+    return result
   })
 
   context.ipcMain.handle('app:builtin-agents', async () => {

--- a/apps/desktop/src/main/ipc/context.ts
+++ b/apps/desktop/src/main/ipc/context.ts
@@ -50,7 +50,7 @@ export type IpcHandlerContext = {
     runtimeTools: unknown[],
     options?: RuntimeContextOptions,
   ) => Promise<CapabilityTool[]>
-  listToolsFromMcpEntry: (entry: unknown) => Promise<CapabilityToolEntry[]>
+  listToolsFromMcpEntry: (entry: unknown, options?: { timeoutMs?: number }) => Promise<CapabilityToolEntry[]>
   isLikelyMcpAuthError: (error: unknown) => boolean
   authenticateNewRemoteMcpIfNeeded: (name: string) => Promise<void>
   approvedSkillImportDirectories: Map<string, string>

--- a/apps/desktop/src/main/mcp-preflight.ts
+++ b/apps/desktop/src/main/mcp-preflight.ts
@@ -1,0 +1,281 @@
+import { credentialFieldIsVisible, type CapabilityToolEntry, type McpPreflightResult } from '@open-cowork/shared'
+import { getConfiguredMcpsFromConfig, type BundleMcp } from './config-loader.ts'
+import { evaluateHttpMcpUrlResolved, type McpDnsResolver } from './mcp-url-policy.ts'
+import { resolveConfiguredMcpRuntimeEntry, type ResolvedRuntimeMcpEntry } from './runtime-mcp.ts'
+import { getEffectiveSettings, getIntegrationCredentialValue, type CoworkSettings } from './settings.ts'
+import { sanitizeLogMessage } from './log-sanitizer.ts'
+
+type FetchLike = typeof fetch
+
+type McpPreflightDeps = {
+  fetchImpl?: FetchLike
+  listToolsFromMcpEntry: (entry: ResolvedRuntimeMcpEntry, options?: { timeoutMs?: number }) => Promise<CapabilityToolEntry[]>
+  resolveHostname?: McpDnsResolver
+  timeoutMs?: number
+}
+
+type AuthProbeResult =
+  | { ok: true }
+  | { ok: false; result: McpPreflightResult }
+
+const DEFAULT_PREFLIGHT_TIMEOUT_MS = 5_000
+const MAX_RESPONSE_BODY_CHARS = 1_000
+
+function result(input: Omit<McpPreflightResult, 'ok'> & { ok?: boolean }): McpPreflightResult {
+  return {
+    ok: input.ok ?? input.status === 'ok',
+    ...input,
+  }
+}
+
+function responseBodyPreview(body: string) {
+  const normalized = body.replace(/\s+/g, ' ').trim()
+  if (!normalized) return undefined
+  return sanitizeLogMessage(normalized.slice(0, MAX_RESPONSE_BODY_CHARS))
+}
+
+async function readResponseBody(response: Response) {
+  try {
+    return responseBodyPreview(await response.text())
+  } catch {
+    return undefined
+  }
+}
+
+function configuredMcpHelpText(mcp: BundleMcp) {
+  return typeof mcp.credentialHelp === 'string' && mcp.credentialHelp.trim()
+    ? mcp.credentialHelp.trim()
+    : undefined
+}
+
+function requiredCredentialKeys(mcp: BundleMcp, settings: CoworkSettings) {
+  const credentials = mcp.credentials || []
+  const credentialValues = Object.fromEntries(
+    credentials.map((credential) => [
+      credential.key,
+      getIntegrationCredentialValue(settings, mcp.name, credential.key) || '',
+    ]),
+  )
+  return credentials
+    .filter((credential) => credentialFieldIsVisible(credential, credentialValues))
+    .filter((credential) => credential.required !== false)
+    .filter((credential) => !getIntegrationCredentialValue(settings, mcp.name, credential.key))
+    .map((credential) => credential.label || credential.key)
+}
+
+function classifyProtocolError(name: string, host: string | undefined, error: unknown, helpText?: string): McpPreflightResult {
+  const message = error instanceof Error ? error.message : String(error || '')
+  const lower = message.toLowerCase()
+  if (/401|unauthorized|invalid[_-]?token|missing authorization header|bad credentials/.test(lower)) {
+    return result({
+      status: 'auth_rejected',
+      mcpName: name,
+      host,
+      message: `${name} rejected the saved token. Check that the token is valid, not revoked, and has the required scopes.`,
+      helpText,
+    })
+  }
+  if (/403|forbidden|sso|policy|organization|enterprise/.test(lower)) {
+    return result({
+      status: 'forbidden',
+      mcpName: name,
+      host,
+      message: `${name} accepted the request but denied access. Check token scopes, SSO authorization, repository restrictions, or organization policy.`,
+      helpText,
+    })
+  }
+  if (/enotfound|econnrefused|econnreset|etimedout|timeout|network|tls|certificate|proxy/.test(lower)) {
+    return result({
+      status: 'network_error',
+      mcpName: name,
+      host,
+      message: `Could not reach ${host || name}. Check DNS, TLS certificates, VPN, proxy, or firewall settings.`,
+      helpText,
+    })
+  }
+  return result({
+    status: 'protocol_error',
+    mcpName: name,
+    host,
+    message: `${name} responded, but the MCP tool-list handshake failed: ${message || 'unknown protocol error'}`,
+    helpText,
+  })
+}
+
+async function runAuthProbe(
+  mcp: BundleMcp,
+  entry: ResolvedRuntimeMcpEntry,
+  deps: Pick<McpPreflightDeps, 'fetchImpl' | 'timeoutMs'>,
+): Promise<AuthProbeResult> {
+  if (entry.type !== 'remote') return { ok: true }
+  const url = new URL(entry.url)
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_PREFLIGHT_TIMEOUT_MS
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await (deps.fetchImpl || fetch)(url, {
+      method: 'GET',
+      headers: entry.headers,
+      redirect: 'manual',
+      signal: controller.signal,
+    })
+    const responseBody = response.status >= 400 ? await readResponseBody(response) : undefined
+    if (response.status === 401) {
+      return {
+        ok: false,
+        result: result({
+          status: 'auth_rejected',
+          mcpName: mcp.name,
+          host: url.host,
+          httpStatus: response.status,
+          responseBody,
+          message: `${mcp.name} rejected the saved token with HTTP 401. Check that the token is valid and not revoked.`,
+          helpText: configuredMcpHelpText(mcp),
+        }),
+      }
+    }
+    if (response.status === 403) {
+      return {
+        ok: false,
+        result: result({
+          status: 'forbidden',
+          mcpName: mcp.name,
+          host: url.host,
+          httpStatus: response.status,
+          responseBody,
+          message: `${mcp.name} returned HTTP 403. Check token scopes, SSO authorization, repository restrictions, or organization policy.`,
+          helpText: configuredMcpHelpText(mcp),
+        }),
+      }
+    }
+    if (response.status === 407) {
+      return {
+        ok: false,
+        result: result({
+          status: 'network_error',
+          mcpName: mcp.name,
+          host: url.host,
+          httpStatus: response.status,
+          responseBody,
+          message: `${mcp.name} returned HTTP 407. Check proxy authentication or network policy on this machine.`,
+          helpText: configuredMcpHelpText(mcp),
+        }),
+      }
+    }
+    if (response.status >= 500) {
+      return {
+        ok: false,
+        result: result({
+          status: 'http_error',
+          mcpName: mcp.name,
+          host: url.host,
+          httpStatus: response.status,
+          responseBody,
+          message: `${mcp.name} returned HTTP ${response.status}. The remote MCP endpoint is reachable but unhealthy.`,
+          helpText: configuredMcpHelpText(mcp),
+        }),
+      }
+    }
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      result: result({
+        status: 'network_error',
+        mcpName: mcp.name,
+        host: url.host,
+        message: `Could not reach ${url.host}. Check DNS, TLS certificates, VPN, proxy, or firewall settings.`,
+        responseBody: responseBodyPreview(error instanceof Error ? error.message : String(error || '')),
+        helpText: configuredMcpHelpText(mcp),
+      }),
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export async function preflightConfiguredApiTokenMcp(
+  name: string,
+  deps: McpPreflightDeps,
+): Promise<McpPreflightResult> {
+  const mcp = getConfiguredMcpsFromConfig().find((entry) => entry.name === name)
+  if (!mcp) {
+    return result({
+      status: 'not_found',
+      mcpName: name,
+      message: `No bundled MCP named "${name}" is configured.`,
+    })
+  }
+
+  const helpText = configuredMcpHelpText(mcp)
+  if (mcp.type !== 'remote' || mcp.authMode !== 'api_token') {
+    return result({
+      status: 'not_applicable',
+      mcpName: name,
+      message: `${name} does not use remote API-token authentication.`,
+      helpText,
+    })
+  }
+  if (!mcp.url) {
+    return result({
+      status: 'invalid_config',
+      mcpName: name,
+      message: `${name} is missing a remote MCP URL.`,
+      helpText,
+    })
+  }
+
+  const urlVerdict = await evaluateHttpMcpUrlResolved(mcp.url, {
+    resolveHostname: deps.resolveHostname,
+  })
+  if (!urlVerdict.ok) {
+    return result({
+      status: 'invalid_config',
+      mcpName: name,
+      message: urlVerdict.reason,
+      helpText,
+    })
+  }
+
+  const settings = getEffectiveSettings()
+  const missing = requiredCredentialKeys(mcp, settings)
+  if (missing.length > 0) {
+    return result({
+      status: 'missing_credentials',
+      mcpName: name,
+      host: urlVerdict.url.host,
+      message: `Save ${missing.join(', ')} before testing ${name}.`,
+      helpText,
+    })
+  }
+
+  const entry = resolveConfiguredMcpRuntimeEntry(name, settings)
+  if (!entry || entry.type !== 'remote') {
+    return result({
+      status: 'invalid_config',
+      mcpName: name,
+      host: urlVerdict.url.host,
+      message: `${name} is not ready to connect. Check its URL, credentials, and enablement state.`,
+      helpText,
+    })
+  }
+
+  const authProbe = await runAuthProbe(mcp, entry, deps)
+  if (!authProbe.ok) return authProbe.result
+
+  try {
+    const methods = await deps.listToolsFromMcpEntry(entry, { timeoutMs: deps.timeoutMs ?? DEFAULT_PREFLIGHT_TIMEOUT_MS })
+    return result({
+      status: 'ok',
+      mcpName: name,
+      host: urlVerdict.url.host,
+      methodCount: methods.length,
+      message: methods.length > 0
+        ? `${name} connected and exposed ${methods.length} MCP method${methods.length === 1 ? '' : 's'}.`
+        : `${name} connected, but it did not expose any MCP methods.`,
+      helpText,
+    })
+  } catch (error) {
+    return classifyProtocolError(name, urlVerdict.url.host, error, helpText)
+  }
+}

--- a/apps/desktop/src/main/mcp-preflight.ts
+++ b/apps/desktop/src/main/mcp-preflight.ts
@@ -247,6 +247,7 @@ export async function preflightConfiguredApiTokenMcp(
   }
 
   const urlVerdict = await evaluateHttpMcpUrlResolved(mcp.url, {
+    allowPrivateNetwork: mcp.allowPrivateNetwork,
     resolveHostname: deps.resolveHostname,
   })
   if (!urlVerdict.ok) {

--- a/apps/desktop/src/main/mcp-preflight.ts
+++ b/apps/desktop/src/main/mcp-preflight.ts
@@ -75,6 +75,7 @@ function requiredCredentialKeys(mcp: BundleMcp, settings: CoworkSettings) {
 function classifyProtocolError(name: string, host: string | undefined, error: unknown, helpText?: string): McpPreflightResult {
   const message = error instanceof Error ? error.message : String(error || '')
   const lower = message.toLowerCase()
+  const safeMessage = responseBodyPreview(message)
   if (/401|unauthorized|invalid[_-]?token|missing authorization header|bad credentials/.test(lower)) {
     return result({
       status: 'auth_rejected',
@@ -106,7 +107,7 @@ function classifyProtocolError(name: string, host: string | undefined, error: un
     status: 'protocol_error',
     mcpName: name,
     host,
-    message: `${name} responded, but the MCP tool-list handshake failed: ${message || 'unknown protocol error'}`,
+    message: `${name} responded, but the MCP tool-list handshake failed: ${safeMessage || 'unknown protocol error'}`,
     helpText,
   })
 }

--- a/apps/desktop/src/main/mcp-preflight.ts
+++ b/apps/desktop/src/main/mcp-preflight.ts
@@ -74,7 +74,8 @@ function requiredCredentialKeys(mcp: BundleMcp, settings: CoworkSettings) {
 
 function classifyProtocolError(name: string, host: string | undefined, error: unknown, helpText?: string): McpPreflightResult {
   const message = error instanceof Error ? error.message : String(error || '')
-  const lower = message.toLowerCase()
+  const errorName = error instanceof Error ? error.name : ''
+  const lower = `${errorName} ${message}`.toLowerCase()
   const safeMessage = responseBodyPreview(message)
   if (/401|unauthorized|invalid[_-]?token|missing authorization header|bad credentials/.test(lower)) {
     return result({
@@ -94,7 +95,7 @@ function classifyProtocolError(name: string, host: string | undefined, error: un
       helpText,
     })
   }
-  if (/enotfound|econnrefused|econnreset|etimedout|timeout|network|tls|certificate|proxy/.test(lower)) {
+  if (/abort|aborted|enotfound|econnrefused|econnreset|etimedout|timeout|network|tls|certificate|proxy/.test(lower)) {
     return result({
       status: 'network_error',
       mcpName: name,

--- a/apps/desktop/src/main/mcp-preflight.ts
+++ b/apps/desktop/src/main/mcp-preflight.ts
@@ -159,7 +159,7 @@ async function runAuthProbe(
         }),
       }
     }
-    if (response.status === 407) {
+    if (response.status === 407 || response.status === 511) {
       return {
         ok: false,
         result: result({
@@ -168,7 +168,7 @@ async function runAuthProbe(
           host: url.host,
           httpStatus: response.status,
           responseBody,
-          message: `${mcp.name} returned HTTP 407. Check proxy authentication or network policy on this machine.`,
+          message: `${mcp.name} returned HTTP ${response.status}. Check proxy authentication, captive portal sign-in, or network policy on this machine.`,
           helpText: configuredMcpHelpText(mcp),
         }),
       }

--- a/apps/desktop/src/main/mcp-preflight.ts
+++ b/apps/desktop/src/main/mcp-preflight.ts
@@ -48,6 +48,15 @@ function configuredMcpHelpText(mcp: BundleMcp) {
     : undefined
 }
 
+function configuredMcpHost(mcp: BundleMcp) {
+  if (!mcp.url) return undefined
+  try {
+    return new URL(mcp.url).host
+  } catch {
+    return undefined
+  }
+}
+
 function requiredCredentialKeys(mcp: BundleMcp, settings: CoworkSettings) {
   const credentials = mcp.credentials || []
   const credentialValues = Object.fromEntries(
@@ -225,6 +234,18 @@ export async function preflightConfiguredApiTokenMcp(
     })
   }
 
+  const settings = getEffectiveSettings()
+  const missing = requiredCredentialKeys(mcp, settings)
+  if (missing.length > 0) {
+    return result({
+      status: 'missing_credentials',
+      mcpName: name,
+      host: configuredMcpHost(mcp),
+      message: `Save ${missing.join(', ')} before testing ${name}.`,
+      helpText,
+    })
+  }
+
   const urlVerdict = await evaluateHttpMcpUrlResolved(mcp.url, {
     resolveHostname: deps.resolveHostname,
   })
@@ -233,18 +254,6 @@ export async function preflightConfiguredApiTokenMcp(
       status: 'invalid_config',
       mcpName: name,
       message: urlVerdict.reason,
-      helpText,
-    })
-  }
-
-  const settings = getEffectiveSettings()
-  const missing = requiredCredentialKeys(mcp, settings)
-  if (missing.length > 0) {
-    return result({
-      status: 'missing_credentials',
-      mcpName: name,
-      host: urlVerdict.url.host,
-      message: `Save ${missing.join(', ')} before testing ${name}.`,
       helpText,
     })
   }

--- a/apps/desktop/src/main/runtime-tool-cache.ts
+++ b/apps/desktop/src/main/runtime-tool-cache.ts
@@ -12,8 +12,9 @@
 // test-environment friendly.
 export const RUNTIME_TOOL_CACHE_TTL_MS = 30_000
 type RuntimeToolCacheEntry = { expiresAt: number; tools: unknown[] }
+type RuntimeToolInflightEntry = { promise: Promise<unknown[]> }
 export const runtimeToolCache = new Map<string, RuntimeToolCacheEntry>()
-export const runtimeToolInflight = new Map<string, Promise<unknown[]>>()
+export const runtimeToolInflight = new Map<string, RuntimeToolInflightEntry>()
 let runtimeToolCacheGeneration = 0
 
 export function currentRuntimeToolCacheGeneration() {

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -86,7 +86,7 @@ export async function listRuntimeToolsForResolvedContext(context: ResolvedRuntim
   }
 
   const inflight = runtimeToolInflight.get(cacheKey)
-  if (inflight) return await inflight
+  if (inflight) return await inflight.promise
 
   const generation = currentRuntimeToolCacheGeneration()
   const promise = (async () => {
@@ -113,12 +113,13 @@ export async function listRuntimeToolsForResolvedContext(context: ResolvedRuntim
       return []
     }
   })()
+  const inflightEntry = { promise }
 
-  runtimeToolInflight.set(cacheKey, promise)
+  runtimeToolInflight.set(cacheKey, inflightEntry)
   try {
     return await promise
   } finally {
-    if (runtimeToolInflight.get(cacheKey) === promise) {
+    if (runtimeToolInflight.get(cacheKey) === inflightEntry) {
       runtimeToolInflight.delete(cacheKey)
     }
   }

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -322,7 +322,11 @@ export function dispatchRuntimeSessionEvent(
   const eventType = getEventType(event)
   sessionEngine.applyStreamEvent(event)
   if (event.sessionId) {
-    getThreadIndexService().scheduleThreadMetadataRefresh(event.sessionId)
+    try {
+      getThreadIndexService().scheduleThreadMetadataRefresh(event.sessionId)
+    } catch (err) {
+      log('thread-index', `Metadata refresh scheduling failed session=${shortSessionId(event.sessionId)}: ${err instanceof Error ? err.message : String(err)}`)
+    }
   }
   if (!win || win.isDestroyed()) return
   publishNotification(win, getRuntimeNotification(event))

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -61,6 +61,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'mcp:auth',
   'mcp:connect',
   'mcp:disconnect',
+  'mcp:preflight',
   'model:info',
   'provider:list',
   'provider:auth-methods',
@@ -266,6 +267,7 @@ const api: CoworkAPI = {
     auth: (mcpName) => invoke('mcp:auth', mcpName),
     connect: (name) => invoke('mcp:connect', name),
     disconnect: (name) => invoke('mcp:disconnect', name),
+    preflight: (name) => invoke('mcp:preflight', name),
   },
   model: {
     info: () => invoke('model:info'),

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesDetailViews.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesDetailViews.tsx
@@ -180,7 +180,6 @@ export function CapabilityToolDetailView({
                 integrationId={selectedTool.integrationId}
                 credentials={selectedTool.credentials}
                 authMode={selectedTool.authMode}
-                enabled={selectedTool.enabled}
               />
             ) : null}
           </div>

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesDetailViews.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesDetailViews.tsx
@@ -179,6 +179,7 @@ export function CapabilityToolDetailView({
               <ToolCredentialsCard
                 integrationId={selectedTool.integrationId}
                 credentials={selectedTool.credentials}
+                authMode={selectedTool.authMode}
               />
             ) : null}
           </div>

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesDetailViews.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesDetailViews.tsx
@@ -180,6 +180,7 @@ export function CapabilityToolDetailView({
                 integrationId={selectedTool.integrationId}
                 credentials={selectedTool.credentials}
                 authMode={selectedTool.authMode}
+                enabled={selectedTool.enabled}
               />
             ) : null}
           </div>

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -151,6 +151,7 @@ function renderCapabilitiesPage(overrides: {
   customMcps?: CustomMcpConfig[]
   customSkills?: CustomSkillConfig[]
   integrationCredentials?: Record<string, string>
+  integrationEnabled?: Record<string, boolean>
   integrationCredentialsError?: Error
   settingsGetError?: Error
   mcpPreflight?: ReturnType<typeof vi.fn>
@@ -186,35 +187,50 @@ function renderCapabilitiesPage(overrides: {
   const listAgents = vi.fn(async () => overrides.customAgents ?? [])
   const builtinAgents = vi.fn(async () => overrides.builtInAgents ?? [])
   const listWorkflows = vi.fn(async () => overrides.workflows ?? { workflows: [], runs: [] })
+  let settingsSnapshot = {
+    selectedProviderId: null,
+    selectedModelId: null,
+    providerCredentials: {},
+    integrationCredentials: {
+      charts: overrides.integrationCredentials ?? { apiKey: 'ck-stored' },
+    },
+    integrationEnabled: overrides.integrationEnabled ?? {},
+    bashPermission: 'deny',
+    fileWritePermission: 'deny',
+    enableBash: false,
+    enableFileWrite: false,
+    runtimeToolingBridgeEnabled: true,
+    workflowLaunchAtLogin: false,
+    workflowRunInBackground: false,
+    workflowDesktopNotifications: true,
+    workflowQuietHoursStart: null,
+    workflowQuietHoursEnd: null,
+    effectiveProviderId: null,
+    effectiveModel: null,
+  }
   const get = vi.fn(async () => {
     if (overrides.settingsGetError) throw overrides.settingsGetError
-    return {
-      selectedProviderId: null,
-      selectedModelId: null,
-      providerCredentials: {},
-      integrationCredentials: {
-        charts: overrides.integrationCredentials ?? { apiKey: 'ck-stored' },
-      },
-      integrationEnabled: {},
-      bashPermission: 'deny',
-      fileWritePermission: 'deny',
-      enableBash: false,
-      enableFileWrite: false,
-      runtimeToolingBridgeEnabled: true,
-      workflowLaunchAtLogin: false,
-      workflowRunInBackground: false,
-      workflowDesktopNotifications: true,
-      workflowQuietHoursStart: null,
-      workflowQuietHoursEnd: null,
-      effectiveProviderId: null,
-      effectiveModel: null,
-    }
+    return settingsSnapshot
   })
   const getIntegrationCredentials = vi.fn(async () => {
     if (overrides.integrationCredentialsError) throw overrides.integrationCredentialsError
-    return overrides.integrationCredentials ?? { apiKey: 'ck-stored' }
+    return settingsSnapshot.integrationCredentials.charts ?? {}
   })
-  const set = vi.fn(async (updates) => ({ ...(await get()), ...updates }))
+  const set = vi.fn(async (updates) => {
+    settingsSnapshot = {
+      ...settingsSnapshot,
+      ...updates,
+      integrationCredentials: {
+        ...settingsSnapshot.integrationCredentials,
+        ...updates.integrationCredentials,
+      },
+      integrationEnabled: {
+        ...settingsSnapshot.integrationEnabled,
+        ...updates.integrationEnabled,
+      },
+    }
+    return settingsSnapshot
+  })
   const mcpPreflight = overrides.mcpPreflight || vi.fn(async (name: string) => ({
     ok: true,
     status: 'ok',
@@ -613,6 +629,7 @@ describe('CapabilitiesPage', () => {
       tools: [disabledTool, shellTool],
       mcpPreflight,
       integrationCredentials: {},
+      integrationEnabled: { charts: false },
     })
 
     await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
@@ -632,6 +649,51 @@ describe('CapabilitiesPage', () => {
     })
     expect(mcpPreflight).not.toHaveBeenCalled()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('preflights after enabling an API-token MCP before saving credentials', async () => {
+    const user = userEvent.setup()
+    const disabledTool: CapabilityTool = {
+      ...chartTool,
+      enabled: false,
+    }
+    const mcpPreflight = vi.fn(async (name: string) => ({
+      ok: true,
+      status: 'ok',
+      mcpName: name,
+      message: `${name} connected and exposed 1 MCP method.`,
+      methodCount: 1,
+    }))
+    const api = renderCapabilitiesPage({
+      tools: [disabledTool, shellTool],
+      mcpPreflight,
+      integrationCredentials: {},
+      integrationEnabled: { charts: false },
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+    await user.click(screen.getByRole('switch', { name: 'Enable' }))
+    await waitFor(() => {
+      expect(api.settingsSet).toHaveBeenCalledWith({
+        integrationEnabled: { charts: true },
+      })
+    })
+
+    const apiKeyInput = await screen.findByLabelText(/Charts API key/)
+    await user.type(apiKeyInput, 'ck-enabled')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.settingsSet).toHaveBeenCalledWith({
+        integrationCredentials: {
+          charts: { apiKey: 'ck-enabled' },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(api.mcpPreflight).toHaveBeenCalledWith('charts')
+    })
+    expect(screen.getByRole('status')).toHaveTextContent('charts connected')
   })
 
   it('shows non-applicable API-token preflight results as non-error status', async () => {

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -597,6 +597,31 @@ describe('CapabilitiesPage', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Response: Bad credentials')
   })
 
+  it('shows non-applicable API-token preflight results as non-error status', async () => {
+    const user = userEvent.setup()
+    const mcpPreflight = vi.fn(async (name: string) => ({
+      ok: false,
+      status: 'not_applicable',
+      mcpName: name,
+      message: `${name} does not use remote API-token authentication.`,
+    }))
+    renderCapabilitiesPage({
+      mcpPreflight,
+      integrationCredentials: {},
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+    const apiKeyInput = await screen.findByLabelText(/Charts API key/)
+    await user.type(apiKeyInput, 'ck-local')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mcpPreflight).toHaveBeenCalledWith('charts')
+    })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('charts does not use remote API-token authentication.')
+  })
+
   it('renders radio credential options and saves the selected value', async () => {
     const user = userEvent.setup()
     const radioTool: CapabilityTool = {

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -597,6 +597,43 @@ describe('CapabilitiesPage', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Response: Bad credentials')
   })
 
+  it('skips automatic API-token preflight when the integration is explicitly disabled', async () => {
+    const user = userEvent.setup()
+    const disabledTool: CapabilityTool = {
+      ...chartTool,
+      enabled: false,
+    }
+    const mcpPreflight = vi.fn(async (name: string) => ({
+      ok: false,
+      status: 'invalid_config',
+      mcpName: name,
+      message: `${name} is not ready to connect.`,
+    }))
+    const api = renderCapabilitiesPage({
+      tools: [disabledTool, shellTool],
+      mcpPreflight,
+      integrationCredentials: {},
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+    const apiKeyInput = await screen.findByLabelText(/Charts API key/)
+    await user.type(apiKeyInput, 'ck-disabled')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.settingsSet).toHaveBeenCalledWith({
+        integrationCredentials: {
+          charts: { apiKey: 'ck-disabled' },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(api.getIntegrationCredentials).toHaveBeenCalledTimes(2)
+    })
+    expect(mcpPreflight).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
   it('shows non-applicable API-token preflight results as non-error status', async () => {
     const user = userEvent.setup()
     const mcpPreflight = vi.fn(async (name: string) => ({

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -153,6 +153,7 @@ function renderCapabilitiesPage(overrides: {
   integrationCredentials?: Record<string, string>
   integrationCredentialsError?: Error
   settingsGetError?: Error
+  mcpPreflight?: ReturnType<typeof vi.fn>
   reportRendererError?: ReturnType<typeof vi.fn>
   customAgents?: CustomAgentSummary[]
   builtInAgents?: BuiltInAgentDetail[]
@@ -214,6 +215,13 @@ function renderCapabilitiesPage(overrides: {
     return overrides.integrationCredentials ?? { apiKey: 'ck-stored' }
   })
   const set = vi.fn(async (updates) => ({ ...(await get()), ...updates }))
+  const mcpPreflight = overrides.mcpPreflight || vi.fn(async (name: string) => ({
+    ok: true,
+    status: 'ok',
+    mcpName: name,
+    message: `${name} connected and exposed 1 MCP method.`,
+    methodCount: 1,
+  }))
   const unsubscribeRuntimeReady = vi.fn()
   const runtimeReady = vi.fn(() => unsubscribeRuntimeReady)
   const reportRendererError = overrides.reportRendererError || vi.fn()
@@ -248,6 +256,9 @@ function renderCapabilitiesPage(overrides: {
       getIntegrationCredentials,
       set,
     },
+    mcp: {
+      preflight: mcpPreflight,
+    },
     diagnostics: {
       reportRendererError,
     },
@@ -276,6 +287,7 @@ function renderCapabilitiesPage(overrides: {
     getIntegrationCredentials,
     reportRendererError,
     settingsSet: set,
+    mcpPreflight,
     runtimeReady,
     unsubscribeRuntimeReady,
     unmount: view.unmount,
@@ -547,6 +559,42 @@ describe('CapabilitiesPage', () => {
         },
       })
     })
+  })
+
+  it('preflights API-token MCP credentials after saving', async () => {
+    const user = userEvent.setup()
+    const mcpPreflight = vi.fn(async (name: string) => ({
+      ok: false,
+      status: 'auth_rejected',
+      mcpName: name,
+      message: 'charts rejected the saved token with HTTP 401. Check that the token is valid and not revoked.',
+      httpStatus: 401,
+      responseBody: 'Bad credentials',
+      helpText: 'Authorize the token for SSO and required repositories.',
+    }))
+    const api = renderCapabilitiesPage({
+      mcpPreflight,
+      integrationCredentials: {},
+    })
+
+    await user.click(await screen.findByRole('button', { name: /Chart MCP/ }))
+    const apiKeyInput = await screen.findByLabelText(/Charts API key/)
+    await user.type(apiKeyInput, 'ck-new')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.settingsSet).toHaveBeenCalledWith({
+        integrationCredentials: {
+          charts: { apiKey: 'ck-new' },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(api.mcpPreflight).toHaveBeenCalledWith('charts')
+    })
+    expect(screen.getByRole('alert')).toHaveTextContent('charts rejected the saved token')
+    expect(screen.getByRole('alert')).toHaveTextContent('Authorize the token for SSO')
+    expect(screen.getByRole('alert')).toHaveTextContent('Response: Bad credentials')
   })
 
   it('renders radio credential options and saves the selected value', async () => {

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -146,12 +146,10 @@ export function ToolCredentialsCard({
   integrationId,
   credentials,
   authMode,
-  enabled,
 }: {
   integrationId: string
   credentials: NonNullable<CapabilityTool['credentials']>
   authMode?: CapabilityTool['authMode']
-  enabled?: CapabilityTool['enabled']
 }) {
   const [stored, setStored] = useState<Record<string, string>>({})
   const [drafts, setDrafts] = useState<Record<string, string>>({})
@@ -231,7 +229,7 @@ export function ToolCredentialsCard({
       setStored(refreshed)
       setDrafts({})
       setSavedAt(Date.now())
-      if (enabled !== false && savedSettings.integrationEnabled?.[integrationId] !== false) {
+      if (savedSettings.integrationEnabled?.[integrationId] !== false) {
         await runPreflight()
       }
     } catch (error) {

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -146,10 +146,12 @@ export function ToolCredentialsCard({
   integrationId,
   credentials,
   authMode,
+  enabled,
 }: {
   integrationId: string
   credentials: NonNullable<CapabilityTool['credentials']>
   authMode?: CapabilityTool['authMode']
+  enabled?: CapabilityTool['enabled']
 }) {
   const [stored, setStored] = useState<Record<string, string>>({})
   const [drafts, setDrafts] = useState<Record<string, string>>({})
@@ -220,7 +222,7 @@ export function ToolCredentialsCard({
         if (draft === undefined) continue
         patch[credential.key] = draft
       }
-      await window.coworkApi.settings.set({
+      const savedSettings = await window.coworkApi.settings.set({
         integrationCredentials: {
           [integrationId]: patch,
         },
@@ -229,7 +231,9 @@ export function ToolCredentialsCard({
       setStored(refreshed)
       setDrafts({})
       setSavedAt(Date.now())
-      await runPreflight()
+      if (enabled !== false && savedSettings.integrationEnabled?.[integrationId] !== false) {
+        await runPreflight()
+      }
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : String(error))
     } finally {

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -194,7 +194,11 @@ export function ToolCredentialsCard({
         result.responseBody ? `Response: ${result.responseBody}` : null,
       ].filter(Boolean)
       setPreflightMessage(parts.join(' '))
-      setPreflightTone(result.ok ? 'success' : result.status === 'missing_credentials' ? 'warning' : 'error')
+      setPreflightTone(result.ok
+        ? 'success'
+        : result.status === 'missing_credentials' || result.status === 'not_applicable'
+          ? 'warning'
+          : 'error')
     } catch (error) {
       setPreflightMessage(error instanceof Error ? error.message : String(error))
       setPreflightTone('error')

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -145,15 +145,20 @@ function credentialValueForConditions(
 export function ToolCredentialsCard({
   integrationId,
   credentials,
+  authMode,
 }: {
   integrationId: string
   credentials: NonNullable<CapabilityTool['credentials']>
+  authMode?: CapabilityTool['authMode']
 }) {
   const [stored, setStored] = useState<Record<string, string>>({})
   const [drafts, setDrafts] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
   const [savedAt, setSavedAt] = useState<number | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [preflightMessage, setPreflightMessage] = useState<string | null>(null)
+  const [preflightTone, setPreflightTone] = useState<'success' | 'warning' | 'error' | null>(null)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
 
   useEffect(() => {
@@ -163,6 +168,8 @@ export function ToolCredentialsCard({
         if (cancelled) return
         setStored(current)
         setDrafts({})
+        setPreflightMessage(null)
+        setPreflightTone(null)
       })
       .catch((err) => {
         if (cancelled) return
@@ -174,10 +181,34 @@ export function ToolCredentialsCard({
 
   const dirty = Object.keys(drafts).some((key) => drafts[key] !== undefined && drafts[key] !== '')
 
+  async function runPreflight() {
+    if (authMode !== 'api_token') return
+    setTesting(true)
+    setPreflightMessage(null)
+    setPreflightTone(null)
+    try {
+      const result = await window.coworkApi.mcp.preflight(integrationId)
+      const parts = [
+        result.message,
+        result.helpText,
+        result.responseBody ? `Response: ${result.responseBody}` : null,
+      ].filter(Boolean)
+      setPreflightMessage(parts.join(' '))
+      setPreflightTone(result.ok ? 'success' : result.status === 'missing_credentials' ? 'warning' : 'error')
+    } catch (error) {
+      setPreflightMessage(error instanceof Error ? error.message : String(error))
+      setPreflightTone('error')
+    } finally {
+      setTesting(false)
+    }
+  }
+
   async function handleSave() {
-    if (!dirty || saving) return
+    if (!dirty || saving || testing) return
     setSaving(true)
     setErrorMessage(null)
+    setPreflightMessage(null)
+    setPreflightTone(null)
     try {
       const patch: Record<string, string> = {}
       for (const credential of credentials) {
@@ -194,6 +225,7 @@ export function ToolCredentialsCard({
       setStored(refreshed)
       setDrafts({})
       setSavedAt(Date.now())
+      await runPreflight()
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : String(error))
     } finally {
@@ -324,11 +356,21 @@ export function ToolCredentialsCard({
           )
         })}
       </div>
-      <div className="flex justify-end mt-4">
+      <div className="flex justify-end gap-2 mt-4">
+        {authMode === 'api_token' ? (
+          <button
+            type="button"
+            onClick={() => { void runPreflight() }}
+            disabled={dirty || saving || testing}
+            className="px-3 py-2 rounded-lg text-[12px] font-medium border border-border-subtle text-text-secondary hover:bg-surface-hover cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {testing ? t('capabilities.credentialsTesting', 'Testing…') : t('capabilities.credentialsTest', 'Test')}
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={handleSave}
-          disabled={!dirty || saving}
+          disabled={!dirty || saving || testing}
           className="px-3 py-2 rounded-lg text-[12px] font-medium cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           style={{ background: 'var(--color-accent)', color: 'var(--color-accent-contrast, #fff)' }}
         >
@@ -338,6 +380,21 @@ export function ToolCredentialsCard({
       {errorMessage ? (
         <div className="mt-3 text-[11px]" style={{ color: 'var(--color-red)' }}>
           {errorMessage}
+        </div>
+      ) : null}
+      {preflightMessage ? (
+        <div
+          className="mt-3 text-[11px] leading-relaxed"
+          style={{
+            color: preflightTone === 'success'
+              ? 'var(--color-green)'
+              : preflightTone === 'warning'
+                ? 'var(--color-warning)'
+                : 'var(--color-red)',
+          }}
+          role={preflightTone === 'error' ? 'alert' : 'status'}
+        >
+          {preflightMessage}
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -138,6 +138,18 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       list: vi.fn(async () => []),
       run: vi.fn(async () => true),
     },
+    mcp: {
+      auth: vi.fn(async () => true),
+      connect: vi.fn(async () => undefined),
+      disconnect: vi.fn(async () => undefined),
+      preflight: vi.fn(async (name: string) => ({
+        ok: true,
+        status: 'ok',
+        mcpName: name,
+        message: `${name} connected.`,
+        methodCount: 1,
+      })),
+    },
     custom: {
       addSkill: vi.fn(async () => true),
       addMcp: vi.fn(async () => true),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -622,6 +622,11 @@ provider-specific guidance with preflight failures, such as required PAT
 scopes, SSO authorization, repository restrictions, or organization
 policy settings.
 
+Remote bundled MCPs that intentionally live on an internal network can set
+`allowPrivateNetwork: true`. This preserves the normal DNS-aware SSRF guard
+for public builds by default; cloud metadata endpoints remain blocked even
+when private network access is enabled.
+
 ```json
 {
   "mcps": [

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -604,12 +604,23 @@ Bundled MCPs can declare `credentials[]` metadata for the Tools & Skills
 detail panel. Each field persists to
 `integrationCredentials[mcpName][key]`; `envSettings` and
 `headerSettings` can then map those stored values into the spawned MCP.
+Remote MCPs with `authMode: "api_token"` also get a per-MCP preflight
+check after credentials are saved. The preflight distinguishes missing
+credentials, rejected tokens (`401`), forbidden or policy responses
+(`403`), network/proxy failures, and MCP protocol/tool-list failures.
+Credential changes reload the OpenCode runtime when setup is complete,
+so users do not need to restart the desktop app manually.
 
 Text fields are the default. For discrete modes, set `type` to
 `"select"` or `"radio"` and provide `options[]`. Use `when` to hide a
 dependent field unless another credential has the expected value. Hidden
 fields are only hidden in the UI; their stored values are preserved and
 are not cleared when the selector changes.
+
+Downstream builds can add `credentialHelp` to a bundled MCP to surface
+provider-specific guidance with preflight failures, such as required PAT
+scopes, SSO authorization, repository restrictions, or organization
+policy settings.
 
 ```json
 {
@@ -619,6 +630,7 @@ are not cleared when the selector changes.
       "type": "local",
       "description": "Example MCP",
       "authMode": "api_token",
+      "credentialHelp": "If this token is rejected, confirm it has the required scopes and any organization SSO authorization.",
       "envSettings": [
         { "env": "MY_MCP_AUTH_METHOD", "key": "authMethod" },
         { "env": "MY_MCP_API_KEY", "key": "apiKey" },

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -672,6 +672,7 @@
           "items": { "$ref": "#/$defs/credentialField" }
         },
         "credentialHelp": { "type": "string" },
+        "allowPrivateNetwork": { "type": "boolean" },
         "googleAuth": { "type": "boolean" }
       },
       "required": ["name", "type", "description", "authMode"]

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -671,6 +671,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/credentialField" }
         },
+        "credentialHelp": { "type": "string" },
         "googleAuth": { "type": "boolean" }
       },
       "required": ["name", "type", "description", "authMode"]

--- a/packages/shared/src/custom-content.ts
+++ b/packages/shared/src/custom-content.ts
@@ -31,6 +31,30 @@ export interface CustomMcpTestResult {
   error?: string | null
 }
 
+export type McpPreflightStatus =
+  | 'ok'
+  | 'missing_credentials'
+  | 'auth_rejected'
+  | 'forbidden'
+  | 'network_error'
+  | 'http_error'
+  | 'protocol_error'
+  | 'invalid_config'
+  | 'not_found'
+  | 'not_applicable'
+
+export interface McpPreflightResult {
+  ok: boolean
+  status: McpPreflightStatus
+  mcpName: string
+  message: string
+  host?: string
+  httpStatus?: number
+  responseBody?: string
+  methodCount?: number
+  helpText?: string
+}
+
 export interface CustomSkillConfig {
   scope: 'machine' | 'project'
   directory?: string | null

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -50,6 +50,7 @@ import type {
   CustomAgentConfig,
   CustomAgentSummary,
   CustomMcpConfig,
+  McpPreflightResult,
   CustomMcpTestResult,
   CustomSkillConfig,
   RuntimeAgentDescriptor,
@@ -171,6 +172,7 @@ export interface CoworkAPI {
     auth: (mcpName: string) => Promise<boolean>
     connect: (name: string) => Promise<void>
     disconnect: (name: string) => Promise<void>
+    preflight: (name: string) => Promise<McpPreflightResult>
   }
   dialog: {
     selectDirectory: () => Promise<string | null>

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -1,0 +1,187 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { AppSettings, CapabilityToolEntry } from '@open-cowork/shared'
+import { preflightConfiguredApiTokenMcp } from '../apps/desktop/src/main/mcp-preflight.ts'
+import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { clearSettingsCache, saveSettings } from '../apps/desktop/src/main/settings.ts'
+import type { ResolvedRuntimeMcpEntry } from '../apps/desktop/src/main/runtime-mcp.ts'
+
+const resolvePublicTestHost = async () => [{ address: '140.82.112.22', family: 4 }]
+
+function baseSettings(): AppSettings {
+  return {
+    selectedProviderId: null,
+    selectedModelId: null,
+    providerCredentials: {},
+    integrationCredentials: {},
+    integrationEnabled: {},
+    bashPermission: 'deny',
+    fileWritePermission: 'deny',
+    enableBash: false,
+    enableFileWrite: false,
+    runtimeConfigSource: 'app',
+    runtimeToolingBridgeEnabled: true,
+    workflowLaunchAtLogin: false,
+    workflowRunInBackground: false,
+    workflowDesktopNotifications: true,
+    workflowQuietHoursStart: '22:00',
+    workflowQuietHoursEnd: '07:00',
+  }
+}
+
+async function withRemoteMcpConfig(fn: () => Promise<void>) {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-mcp-preflight-'))
+  const configDir = join(tempRoot, 'config')
+  const userDataDir = join(tempRoot, 'user-data')
+  mkdirSync(configDir, { recursive: true })
+  mkdirSync(userDataDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({
+    allowedEnvPlaceholders: [],
+    providers: {
+      available: ['test'],
+      defaultProvider: 'test',
+      defaultModel: 'fast',
+      descriptors: {
+        test: { name: 'Test', description: '', credentials: [], models: [{ id: 'fast', name: 'Fast' }] },
+      },
+    },
+    mcps: [{
+      name: 'github',
+      type: 'remote',
+      description: 'GitHub hosted MCP',
+      authMode: 'api_token',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: { 'X-MCP-Toolsets': 'repos,issues' },
+      headerSettings: [{ header: 'Authorization', key: 'token', prefix: 'Bearer ' }],
+      credentialHelp: 'Authorize fine-grained PATs for SSO and required repositories.',
+      credentials: [{
+        key: 'token',
+        label: 'GitHub token',
+        description: 'GitHub PAT',
+        required: true,
+        secret: true,
+      }],
+    }],
+  }))
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+  clearSettingsCache()
+  try {
+    await fn()
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    clearSettingsCache()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+test('preflightConfiguredApiTokenMcp reports missing required credentials without fetching', async () => {
+  await withRemoteMcpConfig(async () => {
+    saveSettings(baseSettings())
+    let fetched = false
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: resolvePublicTestHost,
+      fetchImpl: (async () => {
+        fetched = true
+        return new Response('', { status: 200 })
+      }) as typeof fetch,
+      listToolsFromMcpEntry: async () => [],
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 'missing_credentials')
+    assert.match(result.message, /GitHub token/)
+    assert.equal(fetched, false)
+  })
+})
+
+test('preflightConfiguredApiTokenMcp classifies rejected tokens with sanitized response bodies', async () => {
+  await withRemoteMcpConfig(async () => {
+    const fakeToken = ['ghp', '_', 'abcdefghijklmnopqrstuvwxyz', '123456'].join('')
+    saveSettings({
+      ...baseSettings(),
+      integrationCredentials: { github: { token: fakeToken } },
+    })
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: resolvePublicTestHost,
+      fetchImpl: (async (_url, init) => {
+        assert.equal((init?.headers as Record<string, string>)?.Authorization, `Bearer ${fakeToken}`)
+        return new Response(`token ${fakeToken} rejected`, { status: 401 })
+      }) as typeof fetch,
+      listToolsFromMcpEntry: async () => {
+        throw new Error('should not list tools after auth rejection')
+      },
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 'auth_rejected')
+    assert.equal(result.httpStatus, 401)
+    assert.match(result.responseBody || '', /\[REDACTED_TOKEN\]/)
+    assert.match(result.helpText || '', /SSO/)
+  })
+})
+
+test('preflightConfiguredApiTokenMcp classifies forbidden policy responses', async () => {
+  await withRemoteMcpConfig(async () => {
+    const fakeToken = ['ghp', '_', 'forbidden', 'token', 'value', '123456'].join('')
+    saveSettings({
+      ...baseSettings(),
+      integrationCredentials: { github: { token: fakeToken } },
+    })
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: resolvePublicTestHost,
+      fetchImpl: (async () => new Response('SSO authorization required', { status: 403 })) as typeof fetch,
+      listToolsFromMcpEntry: async () => {
+        throw new Error('should not list tools after policy rejection')
+      },
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 'forbidden')
+    assert.equal(result.httpStatus, 403)
+    assert.match(result.message, /SSO authorization/)
+    assert.match(result.responseBody || '', /SSO authorization required/)
+  })
+})
+
+test('preflightConfiguredApiTokenMcp confirms MCP tool-list connectivity', async () => {
+  await withRemoteMcpConfig(async () => {
+    const fakeToken = ['github', '_pat_', 'valid', 'token', 'value', '1234567890'].join('')
+    saveSettings({
+      ...baseSettings(),
+      integrationCredentials: { github: { token: fakeToken } },
+    })
+    const entries: ResolvedRuntimeMcpEntry[] = []
+    const methods: CapabilityToolEntry[] = [{ id: 'list_repositories', description: 'List repositories.' }]
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: resolvePublicTestHost,
+      fetchImpl: (async () => new Response('', { status: 405 })) as typeof fetch,
+      listToolsFromMcpEntry: async (entry) => {
+        entries.push(entry)
+        return methods
+      },
+    })
+
+    assert.equal(result.ok, true)
+    assert.equal(result.status, 'ok')
+    assert.equal(result.methodCount, 1)
+    assert.equal(entries[0]?.type, 'remote')
+    if (entries[0]?.type !== 'remote') return
+    assert.equal(entries[0].headers?.Authorization, `Bearer ${fakeToken}`)
+    assert.equal(entries[0].headers?.['X-MCP-Toolsets'], 'repos,issues')
+  })
+})

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -228,3 +228,26 @@ test('preflightConfiguredApiTokenMcp preserves bundled private-network opt-in', 
     allowPrivateNetwork: true,
   })
 })
+
+test('preflightConfiguredApiTokenMcp sanitizes protocol error text before returning it', async () => {
+  await withRemoteMcpConfig(async () => {
+    const fakeToken = ['ghp', '_', 'protocol', 'secret', 'token', '1234567890'].join('')
+    saveSettings({
+      ...baseSettings(),
+      integrationCredentials: { github: { token: fakeToken } },
+    })
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: resolvePublicTestHost,
+      fetchImpl: (async () => new Response('', { status: 405 })) as typeof fetch,
+      listToolsFromMcpEntry: async () => {
+        throw new Error(`handshake failed with Authorization: Bearer ${fakeToken}`)
+      },
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 'protocol_error')
+    assert.doesNotMatch(result.message, new RegExp(fakeToken))
+    assert.match(result.message, /\[REDACTED_TOKEN\]/)
+  })
+})

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { AppSettings, CapabilityToolEntry } from '@open-cowork/shared'
 import { preflightConfiguredApiTokenMcp } from '../apps/desktop/src/main/mcp-preflight.ts'
-import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
+import { clearConfigCaches, type BundleMcp } from '../apps/desktop/src/main/config-loader.ts'
 import { clearSettingsCache, saveSettings } from '../apps/desktop/src/main/settings.ts'
 import type { ResolvedRuntimeMcpEntry } from '../apps/desktop/src/main/runtime-mcp.ts'
 
@@ -32,7 +32,10 @@ function baseSettings(): AppSettings {
   }
 }
 
-async function withRemoteMcpConfig(fn: () => Promise<void>) {
+async function withRemoteMcpConfig(
+  fn: () => Promise<void>,
+  mcpOverrides: Partial<BundleMcp> = {},
+) {
   const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-mcp-preflight-'))
   const configDir = join(tempRoot, 'config')
   const userDataDir = join(tempRoot, 'user-data')
@@ -64,6 +67,7 @@ async function withRemoteMcpConfig(fn: () => Promise<void>) {
         required: true,
         secret: true,
       }],
+      ...mcpOverrides,
     }],
   }))
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
@@ -188,5 +192,39 @@ test('preflightConfiguredApiTokenMcp confirms MCP tool-list connectivity', async
     if (entries[0]?.type !== 'remote') return
     assert.equal(entries[0].headers?.Authorization, `Bearer ${fakeToken}`)
     assert.equal(entries[0].headers?.['X-MCP-Toolsets'], 'repos,issues')
+  })
+})
+
+test('preflightConfiguredApiTokenMcp preserves bundled private-network opt-in', async () => {
+  await withRemoteMcpConfig(async () => {
+    const fakeToken = ['github', '_pat_', 'private', 'token', 'value', '1234567890'].join('')
+    saveSettings({
+      ...baseSettings(),
+      integrationCredentials: { github: { token: fakeToken } },
+    })
+    let resolvedHost = ''
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: async (hostname) => {
+        resolvedHost = hostname
+        return [{ address: '10.0.0.5', family: 4 }]
+      },
+      fetchImpl: (async () => new Response('', { status: 405 })) as typeof fetch,
+      listToolsFromMcpEntry: async (entry) => {
+        assert.equal(entry.type, 'remote')
+        if (entry.type === 'remote') {
+          assert.equal(entry.url, 'https://internal.example/mcp/')
+        }
+        return [{ id: 'internal_lookup', description: 'Look up internal resources.' }]
+      },
+    })
+
+    assert.equal(resolvedHost, 'internal.example')
+    assert.equal(result.ok, true)
+    assert.equal(result.status, 'ok')
+    assert.equal(result.methodCount, 1)
+  }, {
+    url: 'https://internal.example/mcp/',
+    allowPrivateNetwork: true,
   })
 })

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -251,3 +251,25 @@ test('preflightConfiguredApiTokenMcp sanitizes protocol error text before return
     assert.match(result.message, /\[REDACTED_TOKEN\]/)
   })
 })
+
+test('preflightConfiguredApiTokenMcp classifies aborted tool-list probes as network errors', async () => {
+  await withRemoteMcpConfig(async () => {
+    const fakeToken = ['github', '_pat_', 'aborted', 'token', 'value', '1234567890'].join('')
+    saveSettings({
+      ...baseSettings(),
+      integrationCredentials: { github: { token: fakeToken } },
+    })
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: resolvePublicTestHost,
+      fetchImpl: (async () => new Response('', { status: 405 })) as typeof fetch,
+      listToolsFromMcpEntry: async () => {
+        throw new DOMException('The operation was aborted.', 'AbortError')
+      },
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 'network_error')
+    assert.match(result.message, /Could not reach/)
+  })
+})

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -89,9 +89,13 @@ test('preflightConfiguredApiTokenMcp reports missing required credentials withou
   await withRemoteMcpConfig(async () => {
     saveSettings(baseSettings())
     let fetched = false
+    let resolved = false
 
     const result = await preflightConfiguredApiTokenMcp('github', {
-      resolveHostname: resolvePublicTestHost,
+      resolveHostname: async () => {
+        resolved = true
+        throw new Error('should not resolve before credential validation')
+      },
       fetchImpl: (async () => {
         fetched = true
         return new Response('', { status: 200 })
@@ -103,6 +107,7 @@ test('preflightConfiguredApiTokenMcp reports missing required credentials withou
     assert.equal(result.status, 'missing_credentials')
     assert.match(result.message, /GitHub token/)
     assert.equal(fetched, false)
+    assert.equal(resolved, false)
   })
 })
 

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -166,6 +166,30 @@ test('preflightConfiguredApiTokenMcp classifies forbidden policy responses', asy
   })
 })
 
+test('preflightConfiguredApiTokenMcp classifies network authentication responses as network errors', async () => {
+  await withRemoteMcpConfig(async () => {
+    const fakeToken = ['ghp', '_', 'network', 'auth', 'token', '123456'].join('')
+    saveSettings({
+      ...baseSettings(),
+      integrationCredentials: { github: { token: fakeToken } },
+    })
+
+    const result = await preflightConfiguredApiTokenMcp('github', {
+      resolveHostname: resolvePublicTestHost,
+      fetchImpl: (async () => new Response('Network Authentication Required', { status: 511 })) as typeof fetch,
+      listToolsFromMcpEntry: async () => {
+        throw new Error('should not list tools after network auth rejection')
+      },
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 'network_error')
+    assert.equal(result.httpStatus, 511)
+    assert.match(result.message, /captive portal/)
+    assert.match(result.responseBody || '', /Network Authentication Required/)
+  })
+})
+
 test('preflightConfiguredApiTokenMcp confirms MCP tool-list connectivity', async () => {
   await withRemoteMcpConfig(async () => {
     const fakeToken = ['github', '_pat_', 'valid', 'token', 'value', '1234567890'].join('')

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdtempSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -17,6 +18,8 @@ import {
   updateSessionRecord,
   upsertSessionRecord,
 } from '../apps/desktop/src/main/session-registry.ts'
+import { clearThreadIndexServiceCache } from '../apps/desktop/src/main/thread-index/thread-index-service.ts'
+import { clearThreadIndexStoreCache } from '../apps/desktop/src/main/thread-index/thread-index-store.ts'
 
 function eventOf(type: string, sessionId?: string | null) {
   return {
@@ -209,9 +212,55 @@ test('history refresh publishes SDK-owned session metadata after registry sync',
     )
   } finally {
     setSessionHistoryRefreshHandler(null)
+    clearThreadIndexServiceCache()
+    clearThreadIndexStoreCache()
     clearSessionRegistryCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
     else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+  }
+})
+
+test('dispatcher keeps renderer events flowing when thread index scheduling is unavailable', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = mkdtempSync(join(tmpdir(), 'open-cowork-dispatcher-locked-index-'))
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearThreadIndexServiceCache()
+  clearThreadIndexStoreCache()
+  clearConfigCaches()
+
+  const dbPath = join(userDataDir, 'thread-index.sqlite')
+  mkdirSync(userDataDir, { recursive: true })
+  const lockDb = new DatabaseSync(dbPath)
+  lockDb.exec('create table if not exists lock_probe (id integer); begin exclusive;')
+
+  try {
+    const sent: Array<{ channel: string; payload: unknown }> = []
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        id: 43,
+        isDestroyed: () => false,
+        send: (channel: string, payload: unknown) => sent.push({ channel, payload }),
+      },
+    }
+
+    assert.doesNotThrow(() => {
+      dispatchRuntimeSessionEvent(win as any, eventOf('done', 'session-locked-index'))
+    })
+    assert.deepEqual(sent.find((entry) => entry.channel === 'runtime:notification')?.payload, {
+      type: 'done',
+      sessionId: 'session-locked-index',
+      synthetic: false,
+    })
+  } finally {
+    lockDb.exec('rollback;')
+    lockDb.close()
+    clearThreadIndexServiceCache()
+    clearThreadIndexStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary
- Add an mcp.preflight API and IPC path for configured remote API-token MCPs, with missing credential, auth, policy, network, HTTP, and MCP protocol classifications.
- Add Tools & Skills credential preflight after save plus a manual Test action for API-token integrations.
- Add downstream credentialHelp schema and docs support for provider-specific troubleshooting guidance.
- Refactor runtime tool in-flight caching to avoid Promise identity comparison while preserving stale-inflight invalidation behavior.

Closes #278

## Review notes
- Preflight keeps the existing MCP URL SSRF policy in production.
- Tests inject DNS resolution so the new preflight unit coverage is hermetic and does not depend on public DNS.
- Code scanning open alerts checked after the runtime-tool cache refactor: 0 open alerts.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- mcp-preflight runtime-tools
- pnpm test:renderer -- CapabilitiesPage
- pnpm lint:dead-code
- pnpm build
- pnpm test:e2e
- uv run mkdocs build --strict
- pnpm audit --prod --audit-level high
- git diff --check