### PR TITLE
Harden storage and replay audit findings

### DIFF
--- a/apps/desktop/src/main/agent-tool-bridge.ts
+++ b/apps/desktop/src/main/agent-tool-bridge.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
-import { randomBytes } from 'node:crypto'
+import { randomBytes, timingSafeEqual } from 'node:crypto'
 import type { CustomAgentConfig, ScopedArtifactRef } from '@open-cowork/shared'
 import {
   deleteAgentFromTool,
@@ -62,7 +62,14 @@ async function readJsonBody(req: IncomingMessage) {
 function assertAuthorized(req: IncomingMessage) {
   const expected = token
   const auth = String(req.headers.authorization || '')
-  if (!expected || auth !== `Bearer ${expected}`) throw new ToolBridgeHttpError(401, 'Unauthorized agent tool request.')
+  const prefix = 'Bearer '
+  const candidate = auth.startsWith(prefix) ? auth.slice(prefix.length) : ''
+  if (!expected || !candidate) throw new ToolBridgeHttpError(401, 'Unauthorized agent tool request.')
+  const expectedBytes = Buffer.from(expected)
+  const candidateBytes = Buffer.from(candidate)
+  if (expectedBytes.length !== candidateBytes.length || !timingSafeEqual(expectedBytes, candidateBytes)) {
+    throw new ToolBridgeHttpError(401, 'Unauthorized agent tool request.')
+  }
 }
 
 function scheduleRuntimeRefresh() {

--- a/apps/desktop/src/main/auth.ts
+++ b/apps/desktop/src/main/auth.ts
@@ -10,7 +10,7 @@ import { log } from './logger.ts'
 import { getUsableAccessToken } from './auth-utils.ts'
 import { getAppConfig, getAppDataDir, getBrandName } from './config-loader.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
-import { resolveSecretStorageMode } from './secure-storage-policy.ts'
+import { resolveSecretStorageMode, type SecretStorageMode } from './secure-storage-policy.ts'
 import { escapeHtml } from './html-escape.ts'
 
 const { shell, BrowserWindow } = electron
@@ -18,6 +18,12 @@ const electronSafeStorage = (electron as { safeStorage?: typeof import('electron
 const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
   getSelectedStorageBackend?: () => string
 }) | undefined
+
+type SecretStorageAdapter = {
+  mode: SecretStorageMode
+  encryptString: (plaintext: string) => Buffer
+  decryptString: (encrypted: Buffer) => string
+}
 
 type StoredTokens = {
   access_token: string
@@ -34,6 +40,7 @@ const DEFAULT_GOOGLE_SCOPES = [
 
 let cachedClient: OAuth2Client | null = null
 let cachedTokens: { path: string; tokens: StoredTokens | null } | null = null
+let authSecretStorageForTests: SecretStorageAdapter | null = null
 
 type GoogleOAuthConfig = {
   clientId: string
@@ -55,6 +62,7 @@ function getTokenPath() {
 }
 
 function getSecretStorageMode() {
+  if (authSecretStorageForTests) return authSecretStorageForTests.mode
   return resolveSecretStorageMode({
     isPackaged: Boolean(electron.app?.isPackaged),
     encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
@@ -63,10 +71,16 @@ function getSecretStorageMode() {
 }
 
 function requireSafeStorage() {
+  if (authSecretStorageForTests) return authSecretStorageForTests
   if (!electronSafeStorage) {
     throw new Error('Electron safeStorage is unavailable')
   }
   return electronSafeStorage
+}
+
+export function setAuthSecretStorageForTests(adapter: SecretStorageAdapter | null) {
+  authSecretStorageForTests = adapter
+  cachedTokens = null
 }
 
 function getServerPort(server: ReturnType<typeof createServer>) {
@@ -113,6 +127,34 @@ function createGoogleOAuthClient(oauth: GoogleOAuthConfig, redirectUri?: string)
   })
 }
 
+function decryptLegacyDevelopmentSecret(raw: Buffer) {
+  const testDecrypt = authSecretStorageForTests?.decryptString
+  if (testDecrypt) {
+    try { return testDecrypt(raw) } catch { return null }
+  }
+  if (electron.app?.isPackaged) return null
+  if (!electronSafeStorage?.isEncryptionAvailable?.() || !electronSafeStorage.decryptString) return null
+  try { return electronSafeStorage.decryptString(raw) } catch { return null }
+}
+
+function migrateLegacyEncryptedDevelopmentTokens(path: string, raw: Buffer) {
+  const decrypted = decryptLegacyDevelopmentSecret(raw)
+  if (!decrypted) return null
+  try {
+    const tokens = JSON.parse(decrypted) as StoredTokens
+    try {
+      saveTokens(tokens)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      log('auth', `Could not rewrite legacy encrypted development tokens at ${path}: ${message}`)
+      cachedTokens = { path, tokens }
+    }
+    return tokens
+  } catch {
+    return null
+  }
+}
+
 function loadTokens(): StoredTokens | null {
   const path = getTokenPath()
   if (cachedTokens?.path === path) return cachedTokens.tokens
@@ -149,9 +191,18 @@ function loadTokens(): StoredTokens | null {
       cachedTokens = { path, tokens: null }
       return null
     }
-    // Dev-only plaintext fallback when safeStorage is unavailable. File perms
-    // are still 0600 via writeSecureFile.
-    const tokens = JSON.parse(raw.toString('utf-8'))
+    // Dev-only plaintext fallback when safeStorage is unavailable or only
+    // offers Linux's non-protective `basic_text` backend. Existing dev
+    // installs may still have an encrypted basic_text blob from earlier
+    // builds; migrate it once instead of silently dropping auth state.
+    let tokens: StoredTokens
+    try {
+      tokens = JSON.parse(raw.toString('utf-8'))
+    } catch (error) {
+      const migrated = migrateLegacyEncryptedDevelopmentTokens(path, raw)
+      if (migrated) return migrated
+      throw error
+    }
     cachedTokens = { path, tokens }
     return tokens
   } catch {

--- a/apps/desktop/src/main/auth.ts
+++ b/apps/desktop/src/main/auth.ts
@@ -15,6 +15,9 @@ import { escapeHtml } from './html-escape.ts'
 
 const { shell, BrowserWindow } = electron
 const electronSafeStorage = (electron as { safeStorage?: typeof import('electron').safeStorage }).safeStorage
+const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
+  getSelectedStorageBackend?: () => string
+}) | undefined
 
 type StoredTokens = {
   access_token: string
@@ -55,6 +58,7 @@ function getSecretStorageMode() {
   return resolveSecretStorageMode({
     isPackaged: Boolean(electron.app?.isPackaged),
     encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
+    selectedStorageBackend: electronSafeStorageBackend?.getSelectedStorageBackend?.() || null,
   })
 }
 

--- a/apps/desktop/src/main/auth.ts
+++ b/apps/desktop/src/main/auth.ts
@@ -10,7 +10,11 @@ import { log } from './logger.ts'
 import { getUsableAccessToken } from './auth-utils.ts'
 import { getAppConfig, getAppDataDir, getBrandName } from './config-loader.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
-import { resolveSecretStorageMode, type SecretStorageMode } from './secure-storage-policy.ts'
+import {
+  readSafeStorageBackendForPolicy,
+  resolveSecretStorageMode,
+  type SecretStorageMode,
+} from './secure-storage-policy.ts'
 import { escapeHtml } from './html-escape.ts'
 
 const { shell, BrowserWindow } = electron
@@ -66,7 +70,9 @@ function getSecretStorageMode() {
   return resolveSecretStorageMode({
     isPackaged: Boolean(electron.app?.isPackaged),
     encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
-    selectedStorageBackend: electronSafeStorageBackend?.getSelectedStorageBackend?.() || null,
+    selectedStorageBackend: readSafeStorageBackendForPolicy(
+      electronSafeStorageBackend?.getSelectedStorageBackend?.bind(electronSafeStorageBackend),
+    ),
   })
 }
 

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -25,6 +25,9 @@ import type {
   ModelFallbackInfo,
   OpenCoworkConfig,
 } from './config-types.ts'
+import { applyE2EArgEnvironment } from './e2e-remote-debugging.ts'
+
+applyE2EArgEnvironment()
 
 export type {
   BuiltInAgentOverrideConfig,

--- a/apps/desktop/src/main/custom-agent-store.ts
+++ b/apps/desktop/src/main/custom-agent-store.ts
@@ -2,7 +2,7 @@ import {
   basename,
   join,
 } from 'path'
-import { type Dirent, readdirSync, rmSync } from 'fs'
+import { type Dirent, readdirSync, rmSync, statSync } from 'fs'
 import {
   VALID_CUSTOM_AGENT_NAME,
   type AgentColor,
@@ -56,6 +56,13 @@ type ManagedAgentMetadata = {
   top_p?: number | null
   steps?: number | null
   options?: Record<string, unknown> | null
+}
+
+type AgentMarkdownCandidate = {
+  fullPath: string
+  name: string
+  enabled: boolean
+  mtimeMs: number
 }
 
 const RUNTIME_DIRECTIVE_START = '<!-- open-cowork:runtime-directive:start -->'
@@ -322,6 +329,43 @@ function parseFrontmatter(content: string) {
   return root
 }
 
+function agentMarkdownCandidate(root: string, entry: Dirent): AgentMarkdownCandidate | null {
+  if (!entry.isFile()) return null
+  if (!entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')) return null
+  if (entry.name.endsWith(getSidecarJsonSuffix())) return null
+
+  const enabled = entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')
+  const name = basename(entry.name, enabled ? '.md' : '.disabled.md')
+  const fullPath = join(root, entry.name)
+  try {
+    return {
+      fullPath,
+      name,
+      enabled,
+      mtimeMs: statSync(fullPath).mtimeMs,
+    }
+  } catch {
+    return null
+  }
+}
+
+function currentAgentMarkdownCandidates(root: string, entries: Dirent[]) {
+  const byName = new Map<string, AgentMarkdownCandidate>()
+  for (const entry of entries) {
+    const candidate = agentMarkdownCandidate(root, entry)
+    if (!candidate) continue
+    const existing = byName.get(candidate.name)
+    if (
+      !existing
+      || candidate.mtimeMs > existing.mtimeMs
+      || (candidate.mtimeMs === existing.mtimeMs && candidate.enabled && !existing.enabled)
+    ) {
+      byName.set(candidate.name, candidate)
+    }
+  }
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name))
+}
+
 function deriveSkillNamesFromPermission(permission: unknown) {
   if (!permission || typeof permission !== 'object' || Array.isArray(permission)) return []
   const skillRules = (permission as Record<string, unknown>).skill
@@ -485,21 +529,15 @@ function readScopedAgents(scope: NativeConfigScope, directory?: string | null) {
   const entries = readdirSync(root, { withFileTypes: true })
   const agents: CustomAgentConfig[] = []
 
-  for (const entry of entries) {
-    if (!entry.isFile()) continue
-    if (!entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')) continue
-    if (entry.name.endsWith(getSidecarJsonSuffix())) continue
-
-    const fullPath = join(root, entry.name)
+  for (const candidate of currentAgentMarkdownCandidates(root, entries)) {
     let content: string
     try {
-      content = readTextFileCheckedSync(fullPath).content
+      content = readTextFileCheckedSync(candidate.fullPath).content
     } catch {
       continue
     }
 
-    const enabled = entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')
-    const name = basename(entry.name, enabled ? '.md' : '.disabled.md')
+    const { enabled, name } = candidate
     const metadata = readManagedAgentMetadata(root, name)
     const frontmatter = parseFrontmatter(content)
     const permission = frontmatter.permission
@@ -561,21 +599,15 @@ function syncScopedAgentRuntimeGuidance(scope: NativeConfigScope, directory?: st
     return
   }
 
-  for (const entry of entries) {
-    if (!entry.isFile()) continue
-    if (!entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')) continue
-    if (entry.name.endsWith(getSidecarJsonSuffix())) continue
-
-    const fullPath = join(root, entry.name)
+  for (const candidate of currentAgentMarkdownCandidates(root, entries)) {
     let content: string
     try {
-      content = readTextFileCheckedSync(fullPath).content
+      content = readTextFileCheckedSync(candidate.fullPath).content
     } catch {
       continue
     }
 
-    const enabled = entry.name.endsWith('.md') && !entry.name.endsWith('.disabled.md')
-    const name = basename(entry.name, enabled ? '.md' : '.disabled.md')
+    const { name } = candidate
     const metadata = readManagedAgentMetadata(root, name)
     const frontmatter = parseFrontmatter(content)
     const skillNames = metadata.skillNames ?? deriveSkillNamesFromPermission(frontmatter.permission)
@@ -585,9 +617,9 @@ function syncScopedAgentRuntimeGuidance(scope: NativeConfigScope, directory?: st
     const nextContent = `${runtimeFrontmatter ? `${runtimeFrontmatter}\n\n` : ''}${runtimeBody}`.trimEnd() + '\n'
     if (nextContent !== content) {
       try {
-        writeFileAtomic(fullPath, nextContent)
+        writeFileAtomic(candidate.fullPath, nextContent)
       } catch (err) {
-        log('agents', `Skipped runtime guidance rewrite for ${fullPath}: ${err instanceof Error ? err.message : String(err)}`)
+        log('agents', `Skipped runtime guidance rewrite for ${candidate.fullPath}: ${err instanceof Error ? err.message : String(err)}`)
       }
     }
   }

--- a/apps/desktop/src/main/custom-agent-store.ts
+++ b/apps/desktop/src/main/custom-agent-store.ts
@@ -358,7 +358,7 @@ function currentAgentMarkdownCandidates(root: string, entries: Dirent[]) {
     if (
       !existing
       || candidate.mtimeMs > existing.mtimeMs
-      || (candidate.mtimeMs === existing.mtimeMs && candidate.enabled && !existing.enabled)
+      || (candidate.mtimeMs === existing.mtimeMs && !candidate.enabled && existing.enabled)
     ) {
       byName.set(candidate.name, candidate)
     }

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -27,11 +27,43 @@ type E2EProbeFile = {
 }
 
 const WINDOWS_ROOTED_PATH_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/
+const E2E_ENV_ARG_PREFIX = '--open-cowork-e2e-env='
+const E2E_ARG_ENV_KEYS = new Set([
+  'OPEN_COWORK_CHART_TIMEOUT_MS',
+  'OPEN_COWORK_CONFIG_PATH',
+  'OPEN_COWORK_E2E',
+  'OPEN_COWORK_E2E_PROBE_ACTION',
+  'OPEN_COWORK_E2E_READY_FILE',
+  'OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT',
+  'OPEN_COWORK_SANDBOX_DIR',
+  'OPEN_COWORK_USER_DATA_DIR',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+])
 
 export function e2eReadyFileRelativePathIsContained(relativeToTmp: string) {
   if (!relativeToTmp || relativeToTmp.startsWith('..')) return false
   if (isAbsolute(relativeToTmp)) return false
   return !WINDOWS_ROOTED_PATH_RE.test(relativeToTmp)
+}
+
+export function buildE2EArgEnvironment(env: Record<string, string>) {
+  return Object.entries(env)
+    .filter(([key]) => E2E_ARG_ENV_KEYS.has(key))
+    .map(([key, value]) => `${E2E_ENV_ARG_PREFIX}${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+}
+
+export function applyE2EArgEnvironment(argv: readonly string[] = process.argv, env: NodeJS.ProcessEnv = process.env) {
+  for (const arg of argv) {
+    if (!arg.startsWith(E2E_ENV_ARG_PREFIX)) continue
+    const encoded = arg.slice(E2E_ENV_ARG_PREFIX.length)
+    const separatorIndex = encoded.indexOf('=')
+    if (separatorIndex <= 0) continue
+    const key = decodeURIComponent(encoded.slice(0, separatorIndex))
+    if (!E2E_ARG_ENV_KEYS.has(key)) continue
+    env[key] = decodeURIComponent(encoded.slice(separatorIndex + 1))
+  }
 }
 
 function writeE2EProbeFile(target: string, payload: Omit<E2EProbeFile, 'writtenAt'>) {

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -29,7 +29,6 @@ type E2EProbeFile = {
 const WINDOWS_ROOTED_PATH_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/
 const E2E_ENV_ARG_PREFIX = '--open-cowork-e2e-env='
 export const E2E_ARG_ENV_ENABLE_KEY = 'OPEN_COWORK_E2E_ARG_ENV'
-export const E2E_ARG_ENV_ENABLE_ARG = '--open-cowork-e2e-arg-env=1'
 const E2E_ARG_ENV_KEYS = new Set([
   'OPEN_COWORK_CHART_TIMEOUT_MS',
   'OPEN_COWORK_CONFIG_PATH',
@@ -59,7 +58,7 @@ export function buildE2EArgEnvironment(env: Record<string, string>) {
 }
 
 export function applyE2EArgEnvironment(argv: readonly string[] = process.argv, env: NodeJS.ProcessEnv = process.env) {
-  if (env[E2E_ARG_ENV_ENABLE_KEY] !== '1' && !argv.includes(E2E_ARG_ENV_ENABLE_ARG)) return
+  if (env[E2E_ARG_ENV_ENABLE_KEY] !== '1') return
   const appliedKeys = new Set<string>()
   for (const arg of argv) {
     if (!arg.startsWith(E2E_ENV_ARG_PREFIX)) continue

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -1,7 +1,23 @@
+import { tmpdir } from 'node:os'
+import { relative, resolve } from 'node:path'
+import { writeFileAtomic } from './fs-atomic.ts'
+
 type ElectronAppWithCommandLine = {
   commandLine: {
     appendSwitch(name: string, value?: string): void
   }
+}
+type WebContentsProbe = {
+  executeJavaScript<T = unknown>(code: string, userGesture?: boolean): Promise<T>
+}
+type E2EProbeResult = {
+  reloading?: boolean
+  waiting?: boolean
+  surface?: Record<string, string>
+  settings?: Record<string, unknown>
+  installCapability?: Record<string, unknown>
+  sessions?: Array<{ id: string }>
+  createdSessionId?: string | null
 }
 
 export function resolveE2ERemoteDebuggingPort(env: NodeJS.ProcessEnv = process.env) {
@@ -18,5 +34,115 @@ export function appendE2ERemoteDebuggingSwitches(electronApp: ElectronAppWithCom
   if (!port) return false
   electronApp.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1')
   electronApp.commandLine.appendSwitch('remote-debugging-port', port)
+  return true
+}
+
+function resolveE2EReadyFile(env: NodeJS.ProcessEnv = process.env) {
+  if (env.OPEN_COWORK_E2E !== '1') return null
+  const raw = env.OPEN_COWORK_E2E_READY_FILE?.trim()
+  if (!raw) return null
+  const target = resolve(raw)
+  const tmpRoot = resolve(env.TMPDIR || tmpdir())
+  const relativeToTmp = relative(tmpRoot, target)
+  if (relativeToTmp.startsWith('..') || relativeToTmp === '' || relativeToTmp.startsWith('/')) return null
+  return target
+}
+
+export async function writeE2EWindowReadyProbe(webContents: WebContentsProbe, env: NodeJS.ProcessEnv = process.env) {
+  const target = resolveE2EReadyFile(env)
+  if (!target) return false
+  const action = env.OPEN_COWORK_E2E_PROBE_ACTION === 'create-session'
+    || env.OPEN_COWORK_E2E_PROBE_ACTION === 'list-sessions'
+    ? env.OPEN_COWORK_E2E_PROBE_ACTION
+    : 'surface'
+  const result = await webContents.executeJavaScript<E2EProbeResult>(`
+    (async () => {
+      const api = window.coworkApi || {};
+      if (typeof api.settings?.get !== 'function' || typeof api.updates?.installCapability !== 'function') {
+        return { waiting: true };
+      }
+      const delay = (ms) => new Promise((done) => setTimeout(done, ms));
+      const setupComplete = async () => {
+        const [config, settings] = await Promise.all([
+          api.app.config(),
+          api.settings.get(),
+        ]);
+        if (!settings.effectiveProviderId || !settings.effectiveModel) return false;
+        const provider = config.providers.available.find((entry) => entry.id === settings.effectiveProviderId);
+        if (!provider) return false;
+        const providerCredentials = await api.settings.getProviderCredentials(provider.id);
+        return provider.credentials.every((credential) => {
+          if (credential.required === false) return true;
+          const value = providerCredentials[credential.key];
+          return typeof value === 'string' && value.trim().length > 0;
+        });
+      };
+      if (!(await setupComplete())) {
+        await api.settings.set({
+          selectedProviderId: 'openrouter',
+          selectedModelId: 'anthropic/claude-sonnet-4',
+          providerCredentials: {
+            openrouter: { apiKey: 'placeholder-key' },
+          },
+        });
+        setTimeout(() => window.location.reload(), 0);
+        return { reloading: true };
+      }
+      const surface = {
+        sessionCreate: typeof api.session?.create,
+        settingsSet: typeof api.settings?.set,
+        workflowsStartDraft: typeof api.workflows?.startDraft,
+        updatesInstallCapability: typeof api.updates?.installCapability,
+        onSessionPatch: typeof api.on?.sessionPatch,
+      };
+      const settings = await api.settings.get();
+      const installCapability = await api.updates.installCapability();
+      const action = ${JSON.stringify(action)};
+      const waitForRuntimeReady = async () => {
+        const deadline = Date.now() + 30000;
+        while (Date.now() < deadline) {
+          const status = await api.runtime.status().catch(() => null);
+          if (status?.ready) return true;
+          await delay(500);
+        }
+        return false;
+      };
+      const initialSessions = await api.session.list();
+      const initialIds = initialSessions.map((session) => session.id);
+      let sessions = initialSessions;
+      let createdSessionId = null;
+      if (action === 'create-session') {
+        if (!(await waitForRuntimeReady())) {
+          throw new Error('Runtime did not become ready for packaged session probe');
+        }
+        await api.session.create(null);
+        const deadline = Date.now() + 15000;
+        while (Date.now() < deadline) {
+          sessions = await api.session.list();
+          createdSessionId = sessions.find((session) => !initialIds.includes(session.id))?.id || null;
+          if (createdSessionId) break;
+          await delay(250);
+        }
+      } else if (action === 'list-sessions') {
+        sessions = await api.session.list();
+      }
+      return {
+        surface,
+        settings: {
+          effectiveProviderId: settings.effectiveProviderId,
+          effectiveModel: settings.effectiveModel,
+        },
+        installCapability: {
+          supported: installCapability.supported,
+          reason: installCapability.reason,
+          currentVersion: installCapability.currentVersion,
+        },
+        sessions: sessions.map((session) => ({ id: session.id })),
+        createdSessionId,
+      };
+    })()
+  `, false)
+  if (result?.reloading || result?.waiting) return true
+  writeFileAtomic(target, JSON.stringify({ ok: true, result, writtenAt: new Date().toISOString() }), { mode: 0o600 })
   return true
 }

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -1,5 +1,5 @@
 import { tmpdir } from 'node:os'
-import { relative, resolve } from 'node:path'
+import { isAbsolute, relative, resolve } from 'node:path'
 import { writeFileAtomic } from './fs-atomic.ts'
 
 type ElectronAppWithCommandLine = {
@@ -18,6 +18,14 @@ type E2EProbeResult = {
   installCapability?: Record<string, unknown>
   sessions?: Array<{ id: string }>
   createdSessionId?: string | null
+}
+
+const WINDOWS_ROOTED_PATH_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/
+
+export function e2eReadyFileRelativePathIsContained(relativeToTmp: string) {
+  if (!relativeToTmp || relativeToTmp.startsWith('..')) return false
+  if (isAbsolute(relativeToTmp)) return false
+  return !WINDOWS_ROOTED_PATH_RE.test(relativeToTmp)
 }
 
 export function resolveE2ERemoteDebuggingPort(env: NodeJS.ProcessEnv = process.env) {
@@ -44,7 +52,7 @@ function resolveE2EReadyFile(env: NodeJS.ProcessEnv = process.env) {
   const target = resolve(raw)
   const tmpRoot = resolve(env.TMPDIR || tmpdir())
   const relativeToTmp = relative(tmpRoot, target)
-  if (relativeToTmp.startsWith('..') || relativeToTmp === '' || relativeToTmp.startsWith('/')) return null
+  if (!e2eReadyFileRelativePathIsContained(relativeToTmp)) return null
   return target
 }
 

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -19,6 +19,12 @@ type E2EProbeResult = {
   sessions?: Array<{ id: string }>
   createdSessionId?: string | null
 }
+type E2EProbeFile = {
+  ok: boolean
+  result?: E2EProbeResult
+  error?: string
+  writtenAt: string
+}
 
 const WINDOWS_ROOTED_PATH_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/
 
@@ -26,6 +32,10 @@ export function e2eReadyFileRelativePathIsContained(relativeToTmp: string) {
   if (!relativeToTmp || relativeToTmp.startsWith('..')) return false
   if (isAbsolute(relativeToTmp)) return false
   return !WINDOWS_ROOTED_PATH_RE.test(relativeToTmp)
+}
+
+function writeE2EProbeFile(target: string, payload: Omit<E2EProbeFile, 'writtenAt'>) {
+  writeFileAtomic(target, JSON.stringify({ ...payload, writtenAt: new Date().toISOString() }), { mode: 0o600 })
 }
 
 export function resolveE2ERemoteDebuggingPort(env: NodeJS.ProcessEnv = process.env) {
@@ -63,13 +73,20 @@ export async function writeE2EWindowReadyProbe(webContents: WebContentsProbe, en
     || env.OPEN_COWORK_E2E_PROBE_ACTION === 'list-sessions'
     ? env.OPEN_COWORK_E2E_PROBE_ACTION
     : 'surface'
-  const result = await webContents.executeJavaScript<E2EProbeResult>(`
+  try {
+    const result = await webContents.executeJavaScript<E2EProbeResult>(`
     (async () => {
       const api = window.coworkApi || {};
       if (typeof api.settings?.get !== 'function' || typeof api.updates?.installCapability !== 'function') {
         return { waiting: true };
       }
       const delay = (ms) => new Promise((done) => setTimeout(done, ms));
+      const withTimeout = (promise, ms, label) => Promise.race([
+        promise,
+        delay(ms).then(() => {
+          throw new Error(label + ' timed out after ' + ms + 'ms');
+        }),
+      ]);
       const setupComplete = async () => {
         const [config, settings] = await Promise.all([
           api.app.config(),
@@ -106,24 +123,12 @@ export async function writeE2EWindowReadyProbe(webContents: WebContentsProbe, en
       const settings = await api.settings.get();
       const installCapability = await api.updates.installCapability();
       const action = ${JSON.stringify(action)};
-      const waitForRuntimeReady = async () => {
-        const deadline = Date.now() + 30000;
-        while (Date.now() < deadline) {
-          const status = await api.runtime.status().catch(() => null);
-          if (status?.ready) return true;
-          await delay(500);
-        }
-        return false;
-      };
       const initialSessions = await api.session.list();
       const initialIds = initialSessions.map((session) => session.id);
       let sessions = initialSessions;
       let createdSessionId = null;
       if (action === 'create-session') {
-        if (!(await waitForRuntimeReady())) {
-          throw new Error('Runtime did not become ready for packaged session probe');
-        }
-        await api.session.create(null);
+        await withTimeout(api.session.create(null), 30000, 'Creating packaged smoke session');
         const deadline = Date.now() + 15000;
         while (Date.now() < deadline) {
           sessions = await api.session.list();
@@ -149,8 +154,15 @@ export async function writeE2EWindowReadyProbe(webContents: WebContentsProbe, en
         createdSessionId,
       };
     })()
-  `, false)
-  if (result?.reloading || result?.waiting) return true
-  writeFileAtomic(target, JSON.stringify({ ok: true, result, writtenAt: new Date().toISOString() }), { mode: 0o600 })
-  return true
+    `, false)
+    if (result?.reloading || result?.waiting) return true
+    writeE2EProbeFile(target, { ok: true, result })
+    return true
+  } catch (error) {
+    writeE2EProbeFile(target, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
 }

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -28,6 +28,7 @@ type E2EProbeFile = {
 
 const WINDOWS_ROOTED_PATH_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/
 const E2E_ENV_ARG_PREFIX = '--open-cowork-e2e-env='
+export const E2E_ARG_ENV_ENABLE_KEY = 'OPEN_COWORK_E2E_ARG_ENV'
 const E2E_ARG_ENV_KEYS = new Set([
   'OPEN_COWORK_CHART_TIMEOUT_MS',
   'OPEN_COWORK_CONFIG_PATH',
@@ -55,6 +56,7 @@ export function buildE2EArgEnvironment(env: Record<string, string>) {
 }
 
 export function applyE2EArgEnvironment(argv: readonly string[] = process.argv, env: NodeJS.ProcessEnv = process.env) {
+  if (env[E2E_ARG_ENV_ENABLE_KEY] !== '1') return
   for (const arg of argv) {
     if (!arg.startsWith(E2E_ENV_ARG_PREFIX)) continue
     const encoded = arg.slice(E2E_ENV_ARG_PREFIX.length)

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -29,9 +29,12 @@ type E2EProbeFile = {
 const WINDOWS_ROOTED_PATH_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/
 const E2E_ENV_ARG_PREFIX = '--open-cowork-e2e-env='
 export const E2E_ARG_ENV_ENABLE_KEY = 'OPEN_COWORK_E2E_ARG_ENV'
+export const E2E_ARG_ENV_ENABLE_ARG = '--open-cowork-e2e-arg-env=1'
 const E2E_ARG_ENV_KEYS = new Set([
   'OPEN_COWORK_CHART_TIMEOUT_MS',
   'OPEN_COWORK_CONFIG_PATH',
+  'HOME',
+  'TMPDIR',
   'OPEN_COWORK_E2E',
   'OPEN_COWORK_E2E_PROBE_ACTION',
   'OPEN_COWORK_E2E_READY_FILE',
@@ -56,7 +59,8 @@ export function buildE2EArgEnvironment(env: Record<string, string>) {
 }
 
 export function applyE2EArgEnvironment(argv: readonly string[] = process.argv, env: NodeJS.ProcessEnv = process.env) {
-  if (env[E2E_ARG_ENV_ENABLE_KEY] !== '1') return
+  if (env[E2E_ARG_ENV_ENABLE_KEY] !== '1' && !argv.includes(E2E_ARG_ENV_ENABLE_ARG)) return
+  const appliedKeys = new Set<string>()
   for (const arg of argv) {
     if (!arg.startsWith(E2E_ENV_ARG_PREFIX)) continue
     const encoded = arg.slice(E2E_ENV_ARG_PREFIX.length)
@@ -71,7 +75,9 @@ export function applyE2EArgEnvironment(argv: readonly string[] = process.argv, e
       continue
     }
     if (!E2E_ARG_ENV_KEYS.has(key)) continue
+    if (appliedKeys.has(key)) continue
     env[key] = value
+    appliedKeys.add(key)
   }
 }
 

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -1,0 +1,22 @@
+type ElectronAppWithCommandLine = {
+  commandLine: {
+    appendSwitch(name: string, value?: string): void
+  }
+}
+
+export function resolveE2ERemoteDebuggingPort(env: NodeJS.ProcessEnv = process.env) {
+  if (env.OPEN_COWORK_E2E !== '1') return null
+  const raw = env.OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT?.trim()
+  if (!raw || !/^\d{1,5}$/.test(raw)) return null
+  const port = Number.parseInt(raw, 10)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null
+  return String(port)
+}
+
+export function appendE2ERemoteDebuggingSwitches(electronApp: ElectronAppWithCommandLine, env: NodeJS.ProcessEnv = process.env) {
+  const port = resolveE2ERemoteDebuggingPort(env)
+  if (!port) return false
+  electronApp.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1')
+  electronApp.commandLine.appendSwitch('remote-debugging-port', port)
+  return true
+}

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -60,9 +60,16 @@ export function applyE2EArgEnvironment(argv: readonly string[] = process.argv, e
     const encoded = arg.slice(E2E_ENV_ARG_PREFIX.length)
     const separatorIndex = encoded.indexOf('=')
     if (separatorIndex <= 0) continue
-    const key = decodeURIComponent(encoded.slice(0, separatorIndex))
+    let key: string
+    let value: string
+    try {
+      key = decodeURIComponent(encoded.slice(0, separatorIndex))
+      value = decodeURIComponent(encoded.slice(separatorIndex + 1))
+    } catch {
+      continue
+    }
     if (!E2E_ARG_ENV_KEYS.has(key)) continue
-    env[key] = decodeURIComponent(encoded.slice(separatorIndex + 1))
+    env[key] = value
   }
 }
 

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -66,6 +66,10 @@ function resolveE2EReadyFile(env: NodeJS.ProcessEnv = process.env) {
   return target
 }
 
+export function e2eWindowReadyProbeEnabled(env: NodeJS.ProcessEnv = process.env) {
+  return Boolean(resolveE2EReadyFile(env))
+}
+
 export async function writeE2EWindowReadyProbe(webContents: WebContentsProbe, env: NodeJS.ProcessEnv = process.env) {
   const target = resolveE2EReadyFile(env)
   if (!target) return false
@@ -128,6 +132,15 @@ export async function writeE2EWindowReadyProbe(webContents: WebContentsProbe, en
       let sessions = initialSessions;
       let createdSessionId = null;
       if (action === 'create-session') {
+        await withTimeout((async () => {
+          const deadline = Date.now() + 60000;
+          while (Date.now() < deadline) {
+            const status = await api.runtime?.status?.().catch(() => null);
+            if (status?.ready) return;
+            await delay(250);
+          }
+          throw new Error('Runtime readiness timed out after 60000ms');
+        })(), 65000, 'Waiting for packaged smoke runtime readiness');
         await withTimeout(api.session.create(null), 30000, 'Creating packaged smoke session');
         const deadline = Date.now() + 15000;
         while (Date.now() < deadline) {

--- a/apps/desktop/src/main/fs-atomic.ts
+++ b/apps/desktop/src/main/fs-atomic.ts
@@ -1,4 +1,4 @@
-import { closeSync, fsyncSync, mkdirSync, openSync, renameSync, unlinkSync, writeSync } from 'fs'
+import { closeSync, fchmodSync, fsyncSync, mkdirSync, openSync, renameSync, unlinkSync, writeSync } from 'fs'
 import { dirname } from 'path'
 
 // Atomic-write helper used for every on-disk file that holds
@@ -53,10 +53,12 @@ export function writeFileAtomic(
   // openSync, crashing the main process instead of self-healing.
   // mkdirSync with recursive:true is a no-op when the dir exists.
   mkdirSync(dirname(targetPath), { recursive: true })
+  try { unlinkSync(tempPath) } catch { /* stale temp from a crashed writer is harmless if absent */ }
 
   let fd: number | null = null
   try {
     fd = openSync(tempPath, 'w', mode)
+    if (process.platform !== 'win32') fchmodSync(fd, mode)
     const bytes = typeof data === 'string' ? Buffer.from(data, 'utf-8') : data
     writeBufferFullySync(fd, bytes)
     // fsync forces the bytes out of the page cache so a power-loss

--- a/apps/desktop/src/main/fs-atomic.ts
+++ b/apps/desktop/src/main/fs-atomic.ts
@@ -58,7 +58,15 @@ export function writeFileAtomic(
   let fd: number | null = null
   try {
     fd = openSync(tempPath, 'w', mode)
-    if (process.platform !== 'win32') fchmodSync(fd, mode)
+    if (process.platform !== 'win32') {
+      try {
+        fchmodSync(fd, mode)
+      } catch {
+        // openSync(..., mode) already applies permissions on creation. Some
+        // filesystems reject chmod-on-fd, and that should not turn a durable
+        // write into a persistence failure.
+      }
+    }
     const bytes = typeof data === 'string' ? Buffer.from(data, 'utf-8') : data
     writeBufferFullySync(fd, bytes)
     // fsync forces the bytes out of the page cache so a power-loss

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -49,8 +49,10 @@ import { createMainWindowController } from './main-window-controller.ts'
 
 import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
+import { appendE2ERemoteDebuggingSwitches } from './e2e-remote-debugging.ts'
 
 registerAppProtocolSchemes()
+appendE2ERemoteDebuggingSwitches(app)
 
 let runtimeStarted = false
 let reconnectTimer: NodeJS.Timeout | null = null

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -49,8 +49,13 @@ import { createMainWindowController } from './main-window-controller.ts'
 
 import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
-import { appendE2ERemoteDebuggingSwitches, e2eWindowReadyProbeEnabled } from './e2e-remote-debugging.ts'
+import {
+  appendE2ERemoteDebuggingSwitches,
+  applyE2EArgEnvironment,
+  e2eWindowReadyProbeEnabled,
+} from './e2e-remote-debugging.ts'
 
+applyE2EArgEnvironment()
 registerAppProtocolSchemes()
 appendE2ERemoteDebuggingSwitches(app)
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -49,7 +49,7 @@ import { createMainWindowController } from './main-window-controller.ts'
 
 import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
-import { appendE2ERemoteDebuggingSwitches } from './e2e-remote-debugging.ts'
+import { appendE2ERemoteDebuggingSwitches, e2eWindowReadyProbeEnabled } from './e2e-remote-debugging.ts'
 
 registerAppProtocolSchemes()
 appendE2ERemoteDebuggingSwitches(app)
@@ -443,7 +443,11 @@ app.whenReady().then(async () => {
   primeShellEnvironment()
   if (await runtimePrerequisitesSatisfied()) {
     log('main', 'Runtime prerequisites satisfied, starting runtime before opening main window')
-    createLoadingWindow()
+    if (e2eWindowReadyProbeEnabled()) {
+      createWindow('e2e-runtime-probe')
+    } else {
+      createLoadingWindow()
+    }
     void bootRuntime().catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err)
       log('error', `Runtime startup failed from loading window: ${message}`)

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -51,11 +51,9 @@ import { log, getLogFilePath, closeLogger } from './logger.ts'
 import { telemetry } from './telemetry.ts'
 import {
   appendE2ERemoteDebuggingSwitches,
-  applyE2EArgEnvironment,
   e2eWindowReadyProbeEnabled,
 } from './e2e-remote-debugging.ts'
 
-applyE2EArgEnvironment()
 registerAppProtocolSchemes()
 appendE2ERemoteDebuggingSwitches(app)
 

--- a/apps/desktop/src/main/ipc/app-handler-support.ts
+++ b/apps/desktop/src/main/ipc/app-handler-support.ts
@@ -86,6 +86,33 @@ export function resolveSafeSaveTextPath(filePath: string) {
   return targetPath
 }
 
+export function sniffImageMime(bytes: Buffer): string | null {
+  if (bytes.length >= 8
+    && bytes[0] === 0x89
+    && bytes[1] === 0x50
+    && bytes[2] === 0x4e
+    && bytes[3] === 0x47
+    && bytes[4] === 0x0d
+    && bytes[5] === 0x0a
+    && bytes[6] === 0x1a
+    && bytes[7] === 0x0a) {
+    return 'image/png'
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg'
+  }
+  if (bytes.length >= 6) {
+    const header = bytes.subarray(0, 6).toString('ascii')
+    if (header === 'GIF87a' || header === 'GIF89a') return 'image/gif'
+  }
+  if (bytes.length >= 12
+    && bytes.subarray(0, 4).toString('ascii') === 'RIFF'
+    && bytes.subarray(8, 12).toString('ascii') === 'WEBP') {
+    return 'image/webp'
+  }
+  return null
+}
+
 export function resolveKnownProviderId(providerId: unknown): string {
   if (typeof providerId !== 'string') throw new Error('Invalid provider id.')
   const normalized = providerId.trim()

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -9,6 +9,7 @@ import {
   normalizeBoundedString,
   normalizeCredentialScopeId,
   resolveSafeSaveTextPath,
+  sniffImageMime,
 } from './app-handler-support.ts'
 import { getPublicAppConfigWithRuntimeModels, registerProviderHandlers } from './provider-handlers.ts'
 import {
@@ -324,9 +325,9 @@ export function registerAppHandlers(context: IpcHandlerContext) {
   // Image picker for custom agent avatars. Returns raw bytes so the
   // renderer can downsample + re-encode before persisting. Capped at
   // 8 MB to keep the IPC buffer sane — the renderer further caps the
-  // final data URI to ~80 KB after downsampling. MIME is inferred from
-  // the filter that matched; gif frames will render statically (first
-  // frame) once the renderer draws them to a canvas.
+  // final data URI to ~80 KB after downsampling. MIME is detected from
+  // magic bytes instead of the file extension; gif frames will render
+  // statically (first frame) once the renderer draws them to a canvas.
   context.ipcMain.handle('dialog:select-image', async () => {
     const { dialog } = await import('electron')
     const result = await dialog.showOpenDialog({
@@ -341,14 +342,11 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     try {
       const MAX_BYTES = 8 * 1024 * 1024
       const { bytes } = readFileCheckedSync(path, { maxBytes: MAX_BYTES })
-      const ext = path.toLowerCase().split('.').pop() || ''
-      const mime = ext === 'jpg' || ext === 'jpeg'
-        ? 'image/jpeg'
-        : ext === 'webp'
-          ? 'image/webp'
-          : ext === 'gif'
-            ? 'image/gif'
-            : 'image/png'
+      const mime = sniffImageMime(bytes)
+      if (!mime) {
+        log('error', 'dialog:select-image rejected non-image payload.')
+        return null
+      }
       return { mime, base64: bytes.toString('base64') }
     } catch (err) {
       log('error', `dialog:select-image read failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/apps/desktop/src/main/ipc/explorer-handlers.ts
+++ b/apps/desktop/src/main/ipc/explorer-handlers.ts
@@ -25,6 +25,8 @@ function resolveExplorerClient(directory: string) {
 }
 
 type ExplorerClient = NonNullable<ReturnType<typeof resolveExplorerClient>>
+const MAX_FIND_TEXT_PATTERN_BYTES = 512
+const NESTED_QUANTIFIER_PATTERN = /\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)\s*(?:[+*]|\{\d+(?:,\d*)?\})/
 
 function resolveExplorerDirectory(context: IpcHandlerContext, directory?: string | null) {
   if (!directory) return null
@@ -49,6 +51,19 @@ export function isExplorerPathInsideDirectory(path: string, directory?: string |
   } catch {
     return false
   }
+}
+
+export function normalizeFindTextPattern(pattern: unknown) {
+  if (typeof pattern !== 'string') throw new Error('Find text pattern must be a string.')
+  const trimmed = pattern.trim()
+  if (!trimmed) return null
+  if (Buffer.byteLength(trimmed, 'utf8') > MAX_FIND_TEXT_PATTERN_BYTES) {
+    throw new Error(`Find text pattern exceeds ${MAX_FIND_TEXT_PATTERN_BYTES} bytes.`)
+  }
+  if (NESTED_QUANTIFIER_PATTERN.test(trimmed)) {
+    throw new Error('Find text pattern contains a high-cost nested quantifier.')
+  }
+  return trimmed
 }
 
 async function runExplorerOperation<T>(
@@ -140,7 +155,7 @@ export function registerExplorerHandlers(context: IpcHandlerContext) {
   })
 
   context.ipcMain.handle('explorer:find-text', async (_event, pattern: string, directory?: string | null): Promise<TextMatch[]> => {
-    const trimmed = (pattern || '').trim()
+    const trimmed = normalizeFindTextPattern(pattern)
     if (!trimmed) return []
     return runExplorerOperation(context, directory, [], `explorer:find-text ${trimmed}`, async (client, resolvedDirectory) => {
       const result = await client.find.text({

--- a/apps/desktop/src/main/main-window-controller.ts
+++ b/apps/desktop/src/main/main-window-controller.ts
@@ -10,6 +10,7 @@ import {
   rendererUrlLooksWrong,
   shouldRecoverMainWindowFromDidFailLoad,
 } from './main-window-lifecycle.ts'
+import { writeE2EWindowReadyProbe } from './e2e-remote-debugging.ts'
 import { loadSettings } from './settings.ts'
 import { resolveStartupSplashTemplatePath, writeStartupSplashFile } from './startup-splash.ts'
 import { createWindowState } from './window-state.ts'
@@ -280,6 +281,9 @@ export function createMainWindowController(options: {
     })
     window.webContents.on('did-finish-load', () => {
       options.log('renderer', 'Renderer did-finish-load')
+      void writeE2EWindowReadyProbe(window.webContents).catch((error: unknown) => {
+        options.log('error', `E2E ready probe failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
       revealCurrentWindow('did-finish-load')
     })
     window.once('ready-to-show', () => {

--- a/apps/desktop/src/main/secure-storage-policy.ts
+++ b/apps/desktop/src/main/secure-storage-policy.ts
@@ -2,6 +2,18 @@ export type SecretStorageMode = 'encrypted' | 'plaintext' | 'unavailable'
 
 const NON_PROTECTIVE_BACKENDS = new Set(['basic_text'])
 
+export function readSafeStorageBackendForPolicy(
+  readBackend: (() => string | null | undefined) | undefined,
+  platform = process.platform,
+) {
+  if (platform !== 'linux' || !readBackend) return null
+  try {
+    return readBackend() || null
+  } catch {
+    return null
+  }
+}
+
 export function resolveSecretStorageMode(options: {
   isPackaged: boolean
   encryptionAvailable: boolean

--- a/apps/desktop/src/main/secure-storage-policy.ts
+++ b/apps/desktop/src/main/secure-storage-policy.ts
@@ -1,9 +1,15 @@
 export type SecretStorageMode = 'encrypted' | 'plaintext' | 'unavailable'
 
+const NON_PROTECTIVE_BACKENDS = new Set(['basic_text'])
+
 export function resolveSecretStorageMode(options: {
   isPackaged: boolean
   encryptionAvailable: boolean
+  selectedStorageBackend?: string | null
 }): SecretStorageMode {
-  if (options.encryptionAvailable) return 'encrypted'
+  if (options.encryptionAvailable) {
+    const backend = options.selectedStorageBackend?.trim().toLowerCase()
+    if (!backend || !NON_PROTECTIVE_BACKENDS.has(backend)) return 'encrypted'
+  }
   return options.isPackaged ? 'unavailable' : 'plaintext'
 }

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -24,6 +24,7 @@ import {
   type ChildSessionRecord,
   type TaskStatus,
 } from './session-history-task-binding.ts'
+import { findOnlyIndexedCandidate } from './task-binding-policy.ts'
 
 type TaskRunSnapshot = {
   title: string
@@ -148,31 +149,6 @@ function fallbackTaskToolStatus(part: NormalizedMessagePart): TaskStatus {
   return 'queued'
 }
 
-function normalizeMatchText(value: string | null | undefined) {
-  return (value || '')
-    .toLowerCase()
-    .replace(/@\w[\w-]*/g, ' ')
-    .replace(/\bsubagent\b/g, ' ')
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim()
-}
-
-function childLooksLikeTaskTool(part: NormalizedMessagePart, child: ChildSessionRecord) {
-  const childTitle = normalizeMatchText(child.title)
-  if (!childTitle) return false
-
-  const descriptor = taskToolDescriptor(part)
-  const titleCandidates = descriptor.titleCandidates
-    .map(normalizeMatchText)
-    .filter((candidate) => candidate.length >= 8)
-  if (titleCandidates.length > 0) {
-    return titleCandidates.some((candidate) => childTitle.includes(candidate) || candidate.includes(childTitle))
-  }
-
-  const agent = normalizeMatchText(descriptor.agent)
-  return agent.length > 0 && childTitle.includes(agent)
-}
-
 function taskToolChildSessionId(part: NormalizedMessagePart) {
   return stringField(part.state.metadata, 'sessionId')
     || stringField(part.state.metadata, 'sessionID')
@@ -182,12 +158,20 @@ function taskToolChildSessionId(part: NormalizedMessagePart) {
     || stringField(part.metadata, 'session_id')
 }
 
+function isDelegationPart(part: NormalizedMessagePart) {
+  return part.type === 'subtask' || (part.type === 'tool' && part.tool === 'task')
+}
+
 export async function projectSessionHistory(input: ProjectSessionHistoryInput): Promise<ProjectedHistoryItem[]> {
   const { sessionId, cachedModelId, rootMessages, rootTodos, statuses, loadChildSnapshot } = input
   const generateId = input.generateId || crypto.randomUUID
   const normalizedRootMessages = rootMessages
     .map((rawMsg) => normalizeSessionMessages([rawMsg])[0])
     .filter((msg): msg is NonNullable<ReturnType<typeof normalizeSessionMessages>[number]> => Boolean(msg))
+  const rootDelegationTimes = normalizedRootMessages
+    .filter((msg) => msg.parts.some(isDelegationPart))
+    .map((msg) => toHistorySortTime(msg.info.time.created || msg.time.created || Date.now()))
+    .sort((a, b) => a - b)
   type InternalProjectedHistoryItem = ProjectedHistoryItem & { sortTime: number }
   const normalizedStatuses = normalizeSessionStatuses(statuses)
   const statusFor = (id: string) => normalizedStatuses[id] || { type: null }
@@ -212,6 +196,10 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       ...item,
       sortTime,
     })
+  }
+
+  const nextRootDelegationBoundary = (sortTime: number) => {
+    return rootDelegationTimes.find((time) => time > sortTime) ?? Number.POSITIVE_INFINITY
   }
 
   const getTaskStatus = (childId?: string | null): TaskStatus => {
@@ -273,14 +261,21 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     return { child, hasExplicitChild: true }
   }
 
-  const takeChildForTaskTool = (
+  const takeOnlyChildForTaskTool = (
     parentSessionId: string,
-    part: NormalizedMessagePart,
-    requireTaskMatch: boolean,
+    options: { after?: number; before?: number } = {},
   ) => {
-    for (const child of children) {
-      if (matchedChildIds.has(child.id) || !childBelongsToParent(child, parentSessionId)) continue
-      if (requireTaskMatch && !childLooksLikeTaskTool(part, child)) continue
+    const candidates = children.filter((child) => {
+      if (matchedChildIds.has(child.id) || !childBelongsToParent(child, parentSessionId)) return false
+      const created = toHistorySortTime(child.time?.created || 0)
+      if (options.after !== undefined && created < options.after) return false
+      if (options.before !== undefined && created >= options.before) return false
+      return true
+    })
+    const candidateIndex = findOnlyIndexedCandidate(candidates)
+    if (candidateIndex >= 0) {
+      const child = candidates[candidateIndex]
+      if (!child) return null
       matchedChildIds.add(child.id)
       return child
     }
@@ -429,12 +424,12 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
       if (part.type === 'tool' && part.tool === 'task') {
         const fallbackStatus = fallbackTaskToolStatus(part)
-        const requireTaskMatch = fallbackStatus === 'complete' || fallbackStatus === 'error'
         const explicit = takeExplicitChildForTaskTool(sessionId, part)
         const child = explicit.child || (explicit.hasExplicitChild
           ? null
-          : takeDirectChildForSubtask((candidate) => {
-              return !requireTaskMatch || childLooksLikeTaskTool(part, candidate)
+          : takeOnlyChildForTaskTool(sessionId, {
+              after: tsMs,
+              before: nextRootDelegationBoundary(tsMs),
             }))
         const taskId = child?.id
           ? `child:${child.id}`
@@ -637,11 +632,10 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
         if (part.type === 'tool' && part.tool === 'task') {
           const fallbackStatus = fallbackTaskToolStatus(part)
-          const requireTaskMatch = fallbackStatus === 'complete' || fallbackStatus === 'error'
           const explicit = takeExplicitChildForTaskTool(child.id, part)
           const nestedChild = explicit.child || (explicit.hasExplicitChild
             ? null
-            : takeChildForTaskTool(child.id, part, requireTaskMatch))
+            : takeOnlyChildForTaskTool(child.id))
           const nestedTaskId = nestedChild?.id
             ? `child:${nestedChild.id}`
             : `pending:${part.callId || part.id || generateId()}`

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -162,6 +162,11 @@ function isDelegationPart(part: NormalizedMessagePart) {
   return part.type === 'subtask' || (part.type === 'tool' && part.tool === 'task')
 }
 
+function messageCreatedSortTime(msg: NonNullable<ReturnType<typeof normalizeSessionMessages>[number]>) {
+  const created = msg.info.time.created || msg.time.created
+  return created ? toHistorySortTime(created) : null
+}
+
 export async function projectSessionHistory(input: ProjectSessionHistoryInput): Promise<ProjectedHistoryItem[]> {
   const { sessionId, cachedModelId, rootMessages, rootTodos, statuses, loadChildSnapshot } = input
   const generateId = input.generateId || crypto.randomUUID
@@ -170,9 +175,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     .filter((msg): msg is NonNullable<ReturnType<typeof normalizeSessionMessages>[number]> => Boolean(msg))
   const rootDelegationBoundaries = normalizedRootMessages
     .map((msg, index) => msg.parts.some(isDelegationPart)
-      ? { index, sortTime: toHistorySortTime(msg.info.time.created || msg.time.created || Date.now()) }
+      ? { index, sortTime: messageCreatedSortTime(msg) }
       : null)
-    .filter((boundary): boundary is { index: number; sortTime: number } => Boolean(boundary))
+    .filter((boundary): boundary is { index: number; sortTime: number | null } => Boolean(boundary))
   type InternalProjectedHistoryItem = ProjectedHistoryItem & { sortTime: number }
   const normalizedStatuses = normalizeSessionStatuses(statuses)
   const statusFor = (id: string) => normalizedStatuses[id] || { type: null }
@@ -200,7 +205,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   }
 
   const nextRootDelegationBoundary = (messageIndex: number) => {
-    return rootDelegationBoundaries.find((boundary) => boundary.index > messageIndex)?.sortTime ?? Number.POSITIVE_INFINITY
+    return rootDelegationBoundaries.find((boundary) => boundary.index > messageIndex)?.sortTime ?? undefined
   }
 
   const getTaskStatus = (childId?: string | null): TaskStatus => {
@@ -393,7 +398,8 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     if (!msg) continue
     const info = msg.info
     const parts = msg.parts
-    const tsMs = toHistorySortTime(info.time.created || msg.time.created || Date.now())
+    const childBindingAfter = messageCreatedSortTime(msg)
+    const tsMs = childBindingAfter ?? Date.now()
     const ts = toIsoTimestamp(tsMs)
     const msgId = info.id || msg.id || generateId()
     const role = info.role || msg.role || 'assistant'
@@ -482,7 +488,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         const explicit = takeExplicitChildForTaskTool(sessionId, part)
         if (!explicit.hasExplicitChild && !taskToolChildBinder) {
           taskToolChildBinder = createOrderedTaskToolChildBinder(sessionId, parts.slice(partIndex), {
-            after: tsMs,
+            after: childBindingAfter ?? undefined,
             before: nextRootDelegationBoundary(msgIndex),
           })
         }
@@ -492,7 +498,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
             || (taskToolChildBinder?.hasParallelImplicitTasks
               ? null
               : takeOnlyChildForTaskTool(sessionId, {
-                  after: tsMs,
+                  after: childBindingAfter ?? undefined,
                   before: nextRootDelegationBoundary(msgIndex),
                 })))
         const taskId = child?.id

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -286,8 +286,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   const takeOnlyChildForTaskTool = (
     parentSessionId: string,
     options: { after?: number; before?: number } = {},
+    excludedChildIds = new Set<string>(),
   ) => {
-    const candidates = candidateChildrenForTaskTool(parentSessionId, options)
+    const candidates = candidateChildrenForTaskTool(parentSessionId, options, excludedChildIds)
     const candidateIndex = findOnlyIndexedCandidate(candidates)
     if (candidateIndex >= 0) {
       const child = candidates[candidateIndex]
@@ -296,6 +297,15 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       return child
     }
     return null
+  }
+
+  const explicitChildIdsForTaskTools = (parts: NormalizedMessagePart[]) => {
+    return new Set(
+      parts
+        .filter((part) => part.type === 'tool' && part.tool === 'task')
+        .map(taskToolChildSessionId)
+        .filter((id): id is string => Boolean(id)),
+    )
   }
 
   const createOrderedTaskToolChildBinder = (
@@ -310,23 +320,27 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     ))
     const hasParallelImplicitTasks = implicitTaskParts.length > 1
     if (!hasParallelImplicitTasks) {
-      return { hasParallelImplicitTasks, take: () => null as ChildSessionRecord | null }
+      return {
+        hasParallelImplicitTasks,
+        explicitChildIds: explicitChildIdsForTaskTools(remainingParts),
+        take: () => null as ChildSessionRecord | null,
+      }
     }
 
-    const explicitChildIds = new Set(
-      remainingParts
-        .filter((part) => part.type === 'tool' && part.tool === 'task')
-        .map(taskToolChildSessionId)
-        .filter((id): id is string => Boolean(id)),
-    )
+    const explicitChildIds = explicitChildIdsForTaskTools(remainingParts)
     const candidates = candidateChildrenForTaskTool(parentSessionId, options, explicitChildIds)
     if (candidates.length !== implicitTaskParts.length) {
-      return { hasParallelImplicitTasks, take: () => null as ChildSessionRecord | null }
+      return {
+        hasParallelImplicitTasks,
+        explicitChildIds,
+        take: () => null as ChildSessionRecord | null,
+      }
     }
 
     let candidateIndex = 0
     return {
       hasParallelImplicitTasks,
+      explicitChildIds,
       take: () => {
         const child = candidates[candidateIndex]
         candidateIndex += 1
@@ -500,7 +514,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
               : takeOnlyChildForTaskTool(sessionId, {
                   after: childBindingAfter ?? undefined,
                   before: nextRootDelegationBoundary(msgIndex),
-                })))
+                }, taskToolChildBinder?.explicitChildIds)))
         const taskId = child?.id
           ? `child:${child.id}`
           : `pending:${part.callId || part.id || generateId()}`
@@ -712,7 +726,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
           const nestedChild = explicit.child || (explicit.hasExplicitChild
             ? null
             : taskToolChildBinder?.take()
-              || (taskToolChildBinder?.hasParallelImplicitTasks ? null : takeOnlyChildForTaskTool(child.id)))
+              || (taskToolChildBinder?.hasParallelImplicitTasks
+                ? null
+                : takeOnlyChildForTaskTool(child.id, {}, taskToolChildBinder?.explicitChildIds)))
           const nestedTaskId = nestedChild?.id
             ? `child:${nestedChild.id}`
             : `pending:${part.callId || part.id || generateId()}`

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -342,22 +342,62 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       return {
         usesOrderedImplicitBindings: false,
         explicitChildIds: explicitChildIdsForTaskTools(remainingParts),
+        takeSubtask: () => null as ChildSessionRecord | null,
         take: () => null as ChildSessionRecord | null,
       }
     }
 
     const explicitChildIds = explicitChildIdsForTaskTools(remainingParts)
+    let slotIndex = 0
     let candidateIndex = 0
     const candidates = candidateChildrenForTaskTool(parentSessionId, options, explicitChildIds)
+    const skipMatchedCandidates = () => {
+      while (candidateIndex < candidates.length) {
+        const child = candidates[candidateIndex]
+        if (child && !matchedChildIds.has(child.id)) return
+        candidateIndex += 1
+      }
+    }
+    const remainingUnmatchedCandidateCount = () => {
+      let count = 0
+      for (let index = candidateIndex; index < candidates.length; index += 1) {
+        const child = candidates[index]
+        if (child && !matchedChildIds.has(child.id)) count += 1
+      }
+      return count
+    }
+    const remainingTaskToolSlotCount = () => {
+      let count = 0
+      for (let index = slotIndex; index < orderedImplicitBindingParts.length; index += 1) {
+        const part = orderedImplicitBindingParts[index]
+        if (part?.type === 'tool' && part.tool === 'task' && !taskToolChildSessionId(part)) count += 1
+      }
+      return count
+    }
     return {
       usesOrderedImplicitBindings: true,
       explicitChildIds,
-      take: () => {
-        while (candidateIndex < orderedImplicitBindingParts.length) {
-          const part = orderedImplicitBindingParts[candidateIndex]
+      takeSubtask: () => {
+        while (slotIndex < orderedImplicitBindingParts.length) {
+          const part = orderedImplicitBindingParts[slotIndex]
+          if (part?.type !== 'subtask') return null
+          slotIndex += 1
+          skipMatchedCandidates()
+          if (remainingUnmatchedCandidateCount() <= remainingTaskToolSlotCount()) return null
           const child = candidates[candidateIndex]
           candidateIndex += 1
+          return child && !matchedChildIds.has(child.id) ? child : null
+        }
+        return null
+      },
+      take: () => {
+        while (slotIndex < orderedImplicitBindingParts.length) {
+          const part = orderedImplicitBindingParts[slotIndex]
+          slotIndex += 1
           if (part?.type !== 'tool' || part.tool !== 'task' || taskToolChildSessionId(part)) continue
+          skipMatchedCandidates()
+          const child = candidates[candidateIndex]
+          candidateIndex += 1
           if (!child || matchedChildIds.has(child.id)) return null
           matchedChildIds.add(child.id)
           return child
@@ -479,7 +519,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       }
 
       if (part.type === 'subtask') {
-        const child = takeDirectChildForSubtask()
+        const child = taskToolChildBinder?.usesOrderedImplicitBindings
+          ? taskToolChildBinder.takeSubtask()
+          : takeDirectChildForSubtask()
         const taskId = child?.id
           ? `child:${child.id}`
           : `pending:${part.id || generateId()}`

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -209,14 +209,29 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     })
   }
 
-  const taskToolBindingWindow = (messageIndex: number, after: number | null) => {
+  type TaskToolBindingWindow = {
+    after?: number
+    before?: number
+    excludeUntimed?: boolean
+  }
+
+  const taskToolBindingWindow = (messageIndex: number, after: number | null): TaskToolBindingWindow | null => {
     const nextBoundary = rootDelegationBoundaries.find((boundary) => boundary.index > messageIndex)
     if (!nextBoundary) return { after: after ?? undefined }
     if (nextBoundary.sortTime === null) {
       // An untimed later delegation is still a real ordering boundary. Without
       // an upper timestamp, implicit binding would be allowed to consume that
       // later child session and leave the actual delegation pending on replay.
-      return null
+      if (after === null) return null
+      const laterDelegationSlotCount = normalizedRootMessages[nextBoundary.index]?.parts.filter(isDelegationPart).length || 0
+      const availableDirectChildCount = directChildren.filter((child) => {
+        if (matchedChildIds.has(child.id)) return false
+        const created = childCreatedSortTime(child)
+        return created === null || created >= after
+      }).length
+      return availableDirectChildCount > laterDelegationSlotCount
+        ? { after, excludeUntimed: true }
+        : null
     }
     return {
       after: after ?? undefined,
@@ -285,7 +300,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
   const candidateChildrenForTaskTool = (
     parentSessionId: string,
-    options: { after?: number; before?: number } = {},
+    options: TaskToolBindingWindow = {},
     excludedChildIds = new Set<string>(),
   ) => {
     return children.filter((child) => {
@@ -293,7 +308,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         return false
       }
       const created = childCreatedSortTime(child)
-      if (created === null && options.before !== undefined) return false
+      if (created === null && (options.before !== undefined || options.excludeUntimed)) return false
       if (created !== null && options.after !== undefined && created < options.after) return false
       if (created !== null && options.before !== undefined && created >= options.before) return false
       return true
@@ -302,7 +317,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
   const takeOnlyChildForTaskTool = (
     parentSessionId: string,
-    options: { after?: number; before?: number } = {},
+    options: TaskToolBindingWindow = {},
     excludedChildIds = new Set<string>(),
   ) => {
     const candidates = candidateChildrenForTaskTool(parentSessionId, options, excludedChildIds)
@@ -328,7 +343,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   const createOrderedTaskToolChildBinder = (
     parentSessionId: string,
     remainingParts: NormalizedMessagePart[],
-    options: { after?: number; before?: number } = {},
+    options: TaskToolBindingWindow = {},
   ) => {
     const orderedImplicitBindingParts = remainingParts.filter((part) => (
       part.type === 'subtask'

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -167,6 +167,11 @@ function messageCreatedSortTime(msg: NonNullable<ReturnType<typeof normalizeSess
   return created ? toHistorySortTime(created) : null
 }
 
+function childCreatedSortTime(child: ChildSessionRecord) {
+  const created = child.time?.created
+  return created === null || created === undefined ? null : toHistorySortTime(created)
+}
+
 export async function projectSessionHistory(input: ProjectSessionHistoryInput): Promise<ProjectedHistoryItem[]> {
   const { sessionId, cachedModelId, rootMessages, rootTodos, statuses, loadChildSnapshot } = input
   const generateId = input.generateId || crypto.randomUUID
@@ -287,9 +292,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       if (matchedChildIds.has(child.id) || excludedChildIds.has(child.id) || !childBelongsToParent(child, parentSessionId)) {
         return false
       }
-      const created = toHistorySortTime(child.time?.created || 0)
-      if (options.after !== undefined && created < options.after) return false
-      if (options.before !== undefined && created >= options.before) return false
+      const created = childCreatedSortTime(child)
+      if (created !== null && options.after !== undefined && created < options.after) return false
+      if (created !== null && options.before !== undefined && created >= options.before) return false
       return true
     })
   }

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -168,10 +168,11 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   const normalizedRootMessages = rootMessages
     .map((rawMsg) => normalizeSessionMessages([rawMsg])[0])
     .filter((msg): msg is NonNullable<ReturnType<typeof normalizeSessionMessages>[number]> => Boolean(msg))
-  const rootDelegationTimes = normalizedRootMessages
-    .filter((msg) => msg.parts.some(isDelegationPart))
-    .map((msg) => toHistorySortTime(msg.info.time.created || msg.time.created || Date.now()))
-    .sort((a, b) => a - b)
+  const rootDelegationBoundaries = normalizedRootMessages
+    .map((msg, index) => msg.parts.some(isDelegationPart)
+      ? { index, sortTime: toHistorySortTime(msg.info.time.created || msg.time.created || Date.now()) }
+      : null)
+    .filter((boundary): boundary is { index: number; sortTime: number } => Boolean(boundary))
   type InternalProjectedHistoryItem = ProjectedHistoryItem & { sortTime: number }
   const normalizedStatuses = normalizeSessionStatuses(statuses)
   const statusFor = (id: string) => normalizedStatuses[id] || { type: null }
@@ -198,8 +199,8 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     })
   }
 
-  const nextRootDelegationBoundary = (sortTime: number) => {
-    return rootDelegationTimes.find((time) => time > sortTime) ?? Number.POSITIVE_INFINITY
+  const nextRootDelegationBoundary = (messageIndex: number) => {
+    return rootDelegationBoundaries.find((boundary) => boundary.index > messageIndex)?.sortTime ?? Number.POSITIVE_INFINITY
   }
 
   const getTaskStatus = (childId?: string | null): TaskStatus => {
@@ -338,7 +339,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     return null
   }
 
-  for (const msg of normalizedRootMessages) {
+  for (let msgIndex = 0; msgIndex < normalizedRootMessages.length; msgIndex += 1) {
+    const msg = normalizedRootMessages[msgIndex]
+    if (!msg) continue
     const info = msg.info
     const parts = msg.parts
     const tsMs = toHistorySortTime(info.time.created || msg.time.created || Date.now())
@@ -429,7 +432,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
           ? null
           : takeOnlyChildForTaskTool(sessionId, {
               after: tsMs,
-              before: nextRootDelegationBoundary(tsMs),
+              before: nextRootDelegationBoundary(msgIndex),
             }))
         const taskId = child?.id
           ? `child:${child.id}`

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -262,17 +262,27 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     return { child, hasExplicitChild: true }
   }
 
-  const takeOnlyChildForTaskTool = (
+  const candidateChildrenForTaskTool = (
     parentSessionId: string,
     options: { after?: number; before?: number } = {},
+    excludedChildIds = new Set<string>(),
   ) => {
-    const candidates = children.filter((child) => {
-      if (matchedChildIds.has(child.id) || !childBelongsToParent(child, parentSessionId)) return false
+    return children.filter((child) => {
+      if (matchedChildIds.has(child.id) || excludedChildIds.has(child.id) || !childBelongsToParent(child, parentSessionId)) {
+        return false
+      }
       const created = toHistorySortTime(child.time?.created || 0)
       if (options.after !== undefined && created < options.after) return false
       if (options.before !== undefined && created >= options.before) return false
       return true
     })
+  }
+
+  const takeOnlyChildForTaskTool = (
+    parentSessionId: string,
+    options: { after?: number; before?: number } = {},
+  ) => {
+    const candidates = candidateChildrenForTaskTool(parentSessionId, options)
     const candidateIndex = findOnlyIndexedCandidate(candidates)
     if (candidateIndex >= 0) {
       const child = candidates[candidateIndex]
@@ -281,6 +291,45 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       return child
     }
     return null
+  }
+
+  const createOrderedTaskToolChildBinder = (
+    parentSessionId: string,
+    remainingParts: NormalizedMessagePart[],
+    options: { after?: number; before?: number } = {},
+  ) => {
+    const implicitTaskParts = remainingParts.filter((part) => (
+      part.type === 'tool'
+      && part.tool === 'task'
+      && !taskToolChildSessionId(part)
+    ))
+    const hasParallelImplicitTasks = implicitTaskParts.length > 1
+    if (!hasParallelImplicitTasks) {
+      return { hasParallelImplicitTasks, take: () => null as ChildSessionRecord | null }
+    }
+
+    const explicitChildIds = new Set(
+      remainingParts
+        .filter((part) => part.type === 'tool' && part.tool === 'task')
+        .map(taskToolChildSessionId)
+        .filter((id): id is string => Boolean(id)),
+    )
+    const candidates = candidateChildrenForTaskTool(parentSessionId, options, explicitChildIds)
+    if (candidates.length !== implicitTaskParts.length) {
+      return { hasParallelImplicitTasks, take: () => null as ChildSessionRecord | null }
+    }
+
+    let candidateIndex = 0
+    return {
+      hasParallelImplicitTasks,
+      take: () => {
+        const child = candidates[candidateIndex]
+        candidateIndex += 1
+        if (!child || matchedChildIds.has(child.id)) return null
+        matchedChildIds.add(child.id)
+        return child
+      },
+    }
   }
 
   const enqueueUnmatchedChildren = (parentSessionId?: string) => {
@@ -353,7 +402,10 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
     let textIndex = 0
     let reasoningIndex = 0
-    for (const part of parts) {
+    let taskToolChildBinder: ReturnType<typeof createOrderedTaskToolChildBinder> | null = null
+    for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+      const part = parts[partIndex]
+      if (!part) continue
       if (part.type === 'text' && typeof part.text === 'string' && part.text.length > 0) {
         const partId = part.id || `${msgId}:part:${textIndex++}`
         if (fullText && !isInternalCoworkMessage(fullText)) {
@@ -428,12 +480,21 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       if (part.type === 'tool' && part.tool === 'task') {
         const fallbackStatus = fallbackTaskToolStatus(part)
         const explicit = takeExplicitChildForTaskTool(sessionId, part)
+        if (!explicit.hasExplicitChild && !taskToolChildBinder) {
+          taskToolChildBinder = createOrderedTaskToolChildBinder(sessionId, parts.slice(partIndex), {
+            after: tsMs,
+            before: nextRootDelegationBoundary(msgIndex),
+          })
+        }
         const child = explicit.child || (explicit.hasExplicitChild
           ? null
-          : takeOnlyChildForTaskTool(sessionId, {
-              after: tsMs,
-              before: nextRootDelegationBoundary(msgIndex),
-            }))
+          : taskToolChildBinder?.take()
+            || (taskToolChildBinder?.hasParallelImplicitTasks
+              ? null
+              : takeOnlyChildForTaskTool(sessionId, {
+                  after: tsMs,
+                  before: nextRootDelegationBoundary(msgIndex),
+                })))
         const taskId = child?.id
           ? `child:${child.id}`
           : `pending:${part.callId || part.id || generateId()}`
@@ -577,7 +638,10 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
       let textIndex = 0
       let reasoningIndex = 0
-      for (const part of parts) {
+      let taskToolChildBinder: ReturnType<typeof createOrderedTaskToolChildBinder> | null = null
+      for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+        const part = parts[partIndex]
+        if (!part) continue
         if (part.type === 'text' && typeof part.text === 'string' && part.text.length > 0) {
           const messageId = info.id || generateId()
           const partId = part.id || `${messageId}:part:${textIndex++}`
@@ -636,9 +700,13 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         if (part.type === 'tool' && part.tool === 'task') {
           const fallbackStatus = fallbackTaskToolStatus(part)
           const explicit = takeExplicitChildForTaskTool(child.id, part)
+          if (!explicit.hasExplicitChild && !taskToolChildBinder) {
+            taskToolChildBinder = createOrderedTaskToolChildBinder(child.id, parts.slice(partIndex))
+          }
           const nestedChild = explicit.child || (explicit.hasExplicitChild
             ? null
-            : takeOnlyChildForTaskTool(child.id))
+            : taskToolChildBinder?.take()
+              || (taskToolChildBinder?.hasParallelImplicitTasks ? null : takeOnlyChildForTaskTool(child.id)))
           const nestedTaskId = nestedChild?.id
             ? `child:${nestedChild.id}`
             : `pending:${part.callId || part.id || generateId()}`

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -347,16 +347,8 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     }
 
     const explicitChildIds = explicitChildIdsForTaskTools(remainingParts)
-    const candidates = candidateChildrenForTaskTool(parentSessionId, options, explicitChildIds)
-    if (candidates.length !== orderedImplicitBindingParts.length) {
-      return {
-        usesOrderedImplicitBindings: true,
-        explicitChildIds,
-        take: () => null as ChildSessionRecord | null,
-      }
-    }
-
     let candidateIndex = 0
+    const candidates = candidateChildrenForTaskTool(parentSessionId, options, explicitChildIds)
     return {
       usesOrderedImplicitBindings: true,
       explicitChildIds,

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -329,15 +329,18 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     remainingParts: NormalizedMessagePart[],
     options: { after?: number; before?: number } = {},
   ) => {
-    const implicitTaskParts = remainingParts.filter((part) => (
-      part.type === 'tool'
-      && part.tool === 'task'
-      && !taskToolChildSessionId(part)
+    const orderedImplicitBindingParts = remainingParts.filter((part) => (
+      part.type === 'subtask'
+      || (
+        part.type === 'tool'
+        && part.tool === 'task'
+        && !taskToolChildSessionId(part)
+      )
     ))
-    const hasParallelImplicitTasks = implicitTaskParts.length > 1
-    if (!hasParallelImplicitTasks) {
+    const hasOrderedImplicitBindings = orderedImplicitBindingParts.length > 1
+    if (!hasOrderedImplicitBindings) {
       return {
-        hasParallelImplicitTasks,
+        usesOrderedImplicitBindings: false,
         explicitChildIds: explicitChildIdsForTaskTools(remainingParts),
         take: () => null as ChildSessionRecord | null,
       }
@@ -345,9 +348,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
     const explicitChildIds = explicitChildIdsForTaskTools(remainingParts)
     const candidates = candidateChildrenForTaskTool(parentSessionId, options, explicitChildIds)
-    if (candidates.length !== implicitTaskParts.length) {
+    if (candidates.length !== orderedImplicitBindingParts.length) {
       return {
-        hasParallelImplicitTasks,
+        usesOrderedImplicitBindings: true,
         explicitChildIds,
         take: () => null as ChildSessionRecord | null,
       }
@@ -355,14 +358,19 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
 
     let candidateIndex = 0
     return {
-      hasParallelImplicitTasks,
+      usesOrderedImplicitBindings: true,
       explicitChildIds,
       take: () => {
-        const child = candidates[candidateIndex]
-        candidateIndex += 1
-        if (!child || matchedChildIds.has(child.id)) return null
-        matchedChildIds.add(child.id)
-        return child
+        while (candidateIndex < orderedImplicitBindingParts.length) {
+          const part = orderedImplicitBindingParts[candidateIndex]
+          const child = candidates[candidateIndex]
+          candidateIndex += 1
+          if (part?.type !== 'tool' || part.tool !== 'task' || taskToolChildSessionId(part)) continue
+          if (!child || matchedChildIds.has(child.id)) return null
+          matchedChildIds.add(child.id)
+          return child
+        }
+        return null
       },
     }
   }
@@ -523,9 +531,9 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
             : null
         }
         const child = explicit.child || (explicit.hasExplicitChild
-          ? null
+            ? null
           : taskToolChildBinder?.take()
-            || (taskToolChildBinder?.hasParallelImplicitTasks
+            || (taskToolChildBinder?.usesOrderedImplicitBindings
               ? null
               : bindingWindow
                 ? takeOnlyChildForTaskTool(sessionId, bindingWindow, taskToolChildBinder?.explicitChildIds)
@@ -740,8 +748,8 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
           }
           const nestedChild = explicit.child || (explicit.hasExplicitChild
             ? null
-            : taskToolChildBinder?.take()
-              || (taskToolChildBinder?.hasParallelImplicitTasks
+          : taskToolChildBinder?.take()
+              || (taskToolChildBinder?.usesOrderedImplicitBindings
                 ? null
                 : takeOnlyChildForTaskTool(child.id, {}, taskToolChildBinder?.explicitChildIds)))
           const nestedTaskId = nestedChild?.id

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -204,8 +204,19 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     })
   }
 
-  const nextRootDelegationBoundary = (messageIndex: number) => {
-    return rootDelegationBoundaries.find((boundary) => boundary.index > messageIndex)?.sortTime ?? undefined
+  const taskToolBindingWindow = (messageIndex: number, after: number | null) => {
+    const nextBoundary = rootDelegationBoundaries.find((boundary) => boundary.index > messageIndex)
+    if (!nextBoundary) return { after: after ?? undefined }
+    if (nextBoundary.sortTime === null) {
+      // An untimed later delegation is still a real ordering boundary. Without
+      // an upper timestamp, implicit binding would be allowed to consume that
+      // later child session and leave the actual delegation pending on replay.
+      return null
+    }
+    return {
+      after: after ?? undefined,
+      before: nextBoundary.sortTime,
+    }
   }
 
   const getTaskStatus = (childId?: string | null): TaskStatus => {
@@ -500,21 +511,20 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       if (part.type === 'tool' && part.tool === 'task') {
         const fallbackStatus = fallbackTaskToolStatus(part)
         const explicit = takeExplicitChildForTaskTool(sessionId, part)
+        const bindingWindow = taskToolBindingWindow(msgIndex, childBindingAfter)
         if (!explicit.hasExplicitChild && !taskToolChildBinder) {
-          taskToolChildBinder = createOrderedTaskToolChildBinder(sessionId, parts.slice(partIndex), {
-            after: childBindingAfter ?? undefined,
-            before: nextRootDelegationBoundary(msgIndex),
-          })
+          taskToolChildBinder = bindingWindow
+            ? createOrderedTaskToolChildBinder(sessionId, parts.slice(partIndex), bindingWindow)
+            : null
         }
         const child = explicit.child || (explicit.hasExplicitChild
           ? null
           : taskToolChildBinder?.take()
             || (taskToolChildBinder?.hasParallelImplicitTasks
               ? null
-              : takeOnlyChildForTaskTool(sessionId, {
-                  after: childBindingAfter ?? undefined,
-                  before: nextRootDelegationBoundary(msgIndex),
-                }, taskToolChildBinder?.explicitChildIds)))
+              : bindingWindow
+                ? takeOnlyChildForTaskTool(sessionId, bindingWindow, taskToolChildBinder?.explicitChildIds)
+                : null))
         const taskId = child?.id
           ? `child:${child.id}`
           : `pending:${part.callId || part.id || generateId()}`

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -293,6 +293,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         return false
       }
       const created = childCreatedSortTime(child)
+      if (created === null && options.before !== undefined) return false
       if (created !== null && options.after !== undefined && created < options.after) return false
       if (created !== null && options.before !== undefined && created >= options.before) return false
       return true

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -17,7 +17,11 @@ import {
 } from './config-loader.ts'
 import { log } from './logger.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
-import { resolveSecretStorageMode, type SecretStorageMode } from './secure-storage-policy.ts'
+import {
+  readSafeStorageBackendForPolicy,
+  resolveSecretStorageMode,
+  type SecretStorageMode,
+} from './secure-storage-policy.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
 const electronSafeStorage = (electron as { safeStorage?: typeof import('electron').safeStorage }).safeStorage
@@ -382,7 +386,9 @@ function getSecretStorageMode() {
   return resolveSecretStorageMode({
     isPackaged: Boolean(electronApp?.isPackaged),
     encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
-    selectedStorageBackend: electronSafeStorageBackend?.getSelectedStorageBackend?.() || null,
+    selectedStorageBackend: readSafeStorageBackendForPolicy(
+      electronSafeStorageBackend?.getSelectedStorageBackend?.bind(electronSafeStorageBackend),
+    ),
   })
 }
 

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -21,6 +21,9 @@ import { resolveSecretStorageMode } from './secure-storage-policy.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
 const electronSafeStorage = (electron as { safeStorage?: typeof import('electron').safeStorage }).safeStorage
+const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
+  getSelectedStorageBackend?: () => string
+}) | undefined
 
 export type CoworkSettings = AppSettings
 export type { AgentColor }
@@ -371,6 +374,7 @@ function getSecretStorageMode() {
   return resolveSecretStorageMode({
     isPackaged: Boolean(electronApp?.isPackaged),
     encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
+    selectedStorageBackend: electronSafeStorageBackend?.getSelectedStorageBackend?.() || null,
   })
 }
 

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -1,5 +1,5 @@
 import electron from 'electron'
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import {
   SMALL_MODEL_USE_MAIN,
@@ -17,7 +17,7 @@ import {
 } from './config-loader.ts'
 import { log } from './logger.ts'
 import { writeFileAtomic } from './fs-atomic.ts'
-import { resolveSecretStorageMode } from './secure-storage-policy.ts'
+import { resolveSecretStorageMode, type SecretStorageMode } from './secure-storage-policy.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
 const electronSafeStorage = (electron as { safeStorage?: typeof import('electron').safeStorage }).safeStorage
@@ -25,10 +25,17 @@ const electronSafeStorageBackend = electronSafeStorage as (typeof import('electr
   getSelectedStorageBackend?: () => string
 }) | undefined
 
+type SecretStorageAdapter = {
+  mode: SecretStorageMode
+  encryptString: (plaintext: string) => Buffer
+  decryptString: (encrypted: Buffer) => string
+}
+
 export type CoworkSettings = AppSettings
 export type { AgentColor }
 
 let settingsCache: AppSettings | null = null
+let settingsSecretStorageForTests: SecretStorageAdapter | null = null
 
 export const SETTINGS_SCHEMA_VERSION = 8
 
@@ -371,6 +378,7 @@ function getLegacySettingsPath() {
 }
 
 function getSecretStorageMode() {
+  if (settingsSecretStorageForTests) return settingsSecretStorageForTests.mode
   return resolveSecretStorageMode({
     isPackaged: Boolean(electronApp?.isPackaged),
     encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
@@ -395,10 +403,26 @@ export function applySettingsSideEffects(settings = loadSettings()) {
 }
 
 function requireSafeStorage() {
+  if (settingsSecretStorageForTests) return settingsSecretStorageForTests
   if (!electronSafeStorage) {
     throw new Error('Electron safeStorage is unavailable')
   }
   return electronSafeStorage
+}
+
+export function setSettingsSecretStorageForTests(adapter: SecretStorageAdapter | null) {
+  settingsSecretStorageForTests = adapter
+  settingsCache = null
+}
+
+function decryptLegacyDevelopmentSecret(raw: Buffer) {
+  const testDecrypt = settingsSecretStorageForTests?.decryptString
+  if (testDecrypt) {
+    try { return testDecrypt(raw) } catch { return null }
+  }
+  if (electronApp?.isPackaged) return null
+  if (!electronSafeStorage?.isEncryptionAvailable?.() || !electronSafeStorage.decryptString) return null
+  try { return electronSafeStorage.decryptString(raw) } catch { return null }
 }
 
 // Sentinel rendered into masked credential fields returned by
@@ -460,7 +484,8 @@ export function loadSettings(): AppSettings {
   if (settingsCache) return settingsCache
 
   const encryptedPath = getSettingsPath()
-  if (existsSync(encryptedPath) && getSecretStorageMode() === 'encrypted') {
+  const storageMode = getSecretStorageMode()
+  if (existsSync(encryptedPath) && storageMode === 'encrypted') {
     try {
       const safeStorage = requireSafeStorage()
       const raw = readFileSync(encryptedPath)
@@ -471,6 +496,26 @@ export function loadSettings(): AppSettings {
     } catch (err: unknown) {
       if (isUnsupportedSettingsSchemaVersionError(err)) throw err
       log('error', `Settings load failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  if (existsSync(encryptedPath) && storageMode === 'plaintext') {
+    try {
+      const raw = readFileSync(encryptedPath)
+      const decrypted = decryptLegacyDevelopmentSecret(raw)
+      if (!decrypted) throw new Error('safeStorage could not decrypt legacy development settings')
+      const result = migrateLegacySettings(JSON.parse(decrypted))
+      settingsCache = result
+      try {
+        saveSettings(result)
+        try { rmSync(encryptedPath, { force: true }) } catch { /* best effort */ }
+      } catch (rewriteErr: unknown) {
+        log('error', `Settings development storage migration rewrite failed: ${rewriteErr instanceof Error ? rewriteErr.message : String(rewriteErr)}`)
+      }
+      return result
+    } catch (err: unknown) {
+      if (isUnsupportedSettingsSchemaVersionError(err)) throw err
+      log('error', `Settings development encrypted load failed: ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -15,7 +15,11 @@ import type {
   WorkflowTriggerType,
 } from '@open-cowork/shared'
 import { getAppDataDir } from '../config-loader.ts'
-import { resolveSecretStorageMode, type SecretStorageMode } from '../secure-storage-policy.ts'
+import {
+  readSafeStorageBackendForPolicy,
+  resolveSecretStorageMode,
+  type SecretStorageMode,
+} from '../secure-storage-policy.ts'
 import { computeNextWorkflowRunAt, validateWorkflowSchedule } from './workflow-schedule.ts'
 
 const WORKFLOW_DB_SCHEMA_VERSION = 1
@@ -92,7 +96,9 @@ function getWorkflowSecretStorage(): WorkflowSecretStorageAdapter {
   const mode = resolveSecretStorageMode({
     isPackaged: Boolean(electronApp?.isPackaged),
     encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
-    selectedStorageBackend: electronSafeStorageBackend?.getSelectedStorageBackend?.() || null,
+    selectedStorageBackend: readSafeStorageBackendForPolicy(
+      electronSafeStorageBackend?.getSelectedStorageBackend?.bind(electronSafeStorageBackend),
+    ),
   })
   return {
     mode,

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -133,7 +133,9 @@ export function serializeWorkflowTriggersForStorage(triggers: WorkflowTrigger[])
 }
 
 export function parseWorkflowTriggersFromStorage(value: unknown) {
-  return parseJson<WorkflowTrigger[]>(value, []).map((trigger) => trigger.type === 'webhook'
+  const parsed = parseJson<unknown>(value, [])
+  if (!Array.isArray(parsed)) return []
+  return (parsed as WorkflowTrigger[]).map((trigger) => trigger.type === 'webhook'
     ? { ...trigger, webhookSecret: decodeWebhookSecretFromStorage(trigger.webhookSecret) }
     : trigger)
 }

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -139,8 +139,9 @@ function tryDecryptWebhookSecretPayload(storage: WorkflowSecretStorageAdapter, p
   }
 }
 
-function encodeWebhookSecretForStorage(secret: string | null | undefined): string | EncryptedWebhookSecretRecord | null {
-  if (!secret) return null
+function encodeWebhookSecretForStorage(secret: unknown): string | EncryptedWebhookSecretRecord | null {
+  if (isEncryptedWebhookSecretRecord(secret)) return secret
+  if (typeof secret !== 'string' || !secret) return null
   const storage = getWorkflowSecretStorage()
   if (storage.mode === 'encrypted') {
     return encryptWebhookSecretValue(storage, secret)
@@ -152,7 +153,7 @@ function encodeWebhookSecretForStorage(secret: string | null | undefined): strin
 function decodeWebhookSecretFromStorage(secret: unknown) {
   const storage = getWorkflowSecretStorage()
   if (isEncryptedWebhookSecretRecord(secret)) {
-    return tryDecryptWebhookSecretPayload(storage, secret.value)
+    return tryDecryptWebhookSecretPayload(storage, secret.value) ?? secret
   }
 
   if (typeof secret !== 'string' || !secret.trim()) return null
@@ -342,7 +343,12 @@ function withTransaction<T>(callback: (db: DatabaseSync) => T): T {
 
 function webhookUrlForWorkflow(workflow: WorkflowSummary, webhookBaseUrl?: string | null) {
   if (!webhookBaseUrl) return null
-  const webhook = workflow.triggers.find((trigger) => trigger.enabled && trigger.type === 'webhook' && trigger.webhookSecret)
+  const webhook = workflow.triggers.find((trigger) => (
+    trigger.enabled
+    && trigger.type === 'webhook'
+    && typeof trigger.webhookSecret === 'string'
+    && trigger.webhookSecret.length > 0
+  ))
   return webhook ? `${webhookBaseUrl}/workflows/${encodeURIComponent(workflow.id)}` : null
 }
 

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from 'node:sqlite'
 import { chmodSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
+import electron from 'electron'
 import type {
   WorkflowDetail,
   WorkflowDraft,
@@ -14,6 +15,7 @@ import type {
   WorkflowTriggerType,
 } from '@open-cowork/shared'
 import { getAppDataDir } from '../config-loader.ts'
+import { resolveSecretStorageMode, type SecretStorageMode } from '../secure-storage-policy.ts'
 import { computeNextWorkflowRunAt, validateWorkflowSchedule } from './workflow-schedule.ts'
 
 const WORKFLOW_DB_SCHEMA_VERSION = 1
@@ -26,10 +28,23 @@ const VALID_TRIGGER_TYPES = new Set<WorkflowTriggerType>(['manual', 'schedule', 
 
 let workflowDb: DatabaseSync | null = null
 let transactionCounter = 0
+let workflowSecretStorageForTests: WorkflowSecretStorageAdapter | null = null
+
+const electronApp = (electron as { app?: typeof import('electron').app }).app
+const electronSafeStorage = (electron as { safeStorage?: typeof import('electron').safeStorage }).safeStorage
+const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
+  getSelectedStorageBackend?: () => string
+}) | undefined
+const ENCRYPTED_WEBHOOK_SECRET_PREFIX = 'enc:v1:'
 
 type DbRow = Record<string, unknown>
 type WorkflowWriteOptions = {
   now?: Date
+}
+type WorkflowSecretStorageAdapter = {
+  mode: SecretStorageMode
+  encryptString?: (value: string) => Buffer
+  decryptString?: (value: Buffer) => string
 }
 
 function workflowDbPath() {
@@ -70,6 +85,59 @@ function parseJson<T>(value: unknown, fallback: T): T {
   } catch {
     return fallback
   }
+}
+
+function getWorkflowSecretStorage(): WorkflowSecretStorageAdapter {
+  if (workflowSecretStorageForTests) return workflowSecretStorageForTests
+  const mode = resolveSecretStorageMode({
+    isPackaged: Boolean(electronApp?.isPackaged),
+    encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
+    selectedStorageBackend: electronSafeStorageBackend?.getSelectedStorageBackend?.() || null,
+  })
+  return {
+    mode,
+    encryptString: electronSafeStorage?.encryptString?.bind(electronSafeStorage),
+    decryptString: electronSafeStorage?.decryptString?.bind(electronSafeStorage),
+  }
+}
+
+function encodeWebhookSecretForStorage(secret: string | null | undefined) {
+  if (!secret) return null
+  const storage = getWorkflowSecretStorage()
+  if (storage.mode === 'encrypted') {
+    if (!storage.encryptString) throw new Error('Electron safeStorage is unavailable')
+    return `${ENCRYPTED_WEBHOOK_SECRET_PREFIX}${Buffer.from(storage.encryptString(secret)).toString('base64')}`
+  }
+  if (storage.mode === 'plaintext') return secret
+  throw new Error('Secure storage unavailable on this system. Open Cowork cannot persist workflow webhook secrets in production without OS-backed secret storage.')
+}
+
+function decodeWebhookSecretFromStorage(secret: unknown) {
+  if (typeof secret !== 'string' || !secret.trim()) return null
+  if (!secret.startsWith(ENCRYPTED_WEBHOOK_SECRET_PREFIX)) return secret
+  const storage = getWorkflowSecretStorage()
+  if (storage.mode !== 'encrypted' || !storage.decryptString) return null
+  try {
+    return storage.decryptString(Buffer.from(secret.slice(ENCRYPTED_WEBHOOK_SECRET_PREFIX.length), 'base64'))
+  } catch {
+    return null
+  }
+}
+
+export function serializeWorkflowTriggersForStorage(triggers: WorkflowTrigger[]) {
+  return JSON.stringify(triggers.map((trigger) => trigger.type === 'webhook'
+    ? { ...trigger, webhookSecret: encodeWebhookSecretForStorage(trigger.webhookSecret) }
+    : trigger))
+}
+
+export function parseWorkflowTriggersFromStorage(value: unknown) {
+  return parseJson<WorkflowTrigger[]>(value, []).map((trigger) => trigger.type === 'webhook'
+    ? { ...trigger, webhookSecret: decodeWebhookSecretFromStorage(trigger.webhookSecret) }
+    : trigger)
+}
+
+export function setWorkflowSecretStorageForTests(adapter: WorkflowSecretStorageAdapter | null) {
+  workflowSecretStorageForTests = adapter
 }
 
 function normalizeStringList(value: unknown, label: string) {
@@ -244,7 +312,7 @@ function rowToWorkflow(row: DbRow, webhookBaseUrl?: string | null): WorkflowSumm
     status,
     projectDirectory: typeof row.project_directory === 'string' ? row.project_directory : null,
     draftSessionId: typeof row.draft_session_id === 'string' ? row.draft_session_id : null,
-    triggers: parseJson<WorkflowTrigger[]>(row.triggers_json, []),
+    triggers: parseWorkflowTriggersFromStorage(row.triggers_json),
     createdAt: String(row.created_at || ''),
     updatedAt: String(row.updated_at || ''),
     nextRunAt: typeof row.next_run_at === 'string' ? row.next_run_at : null,
@@ -347,7 +415,7 @@ export function createWorkflow(draft: WorkflowDraft, webhookBaseUrl?: string | n
       'active',
       normalized.projectDirectory || null,
       normalized.draftSessionId || null,
-      JSON.stringify(normalized.triggers),
+      serializeWorkflowTriggersForStorage(normalized.triggers),
       now,
       now,
       nextRunAt,
@@ -362,7 +430,7 @@ export function updateWorkflowStatus(workflowId: string, status: WorkflowStatus,
   const now = nowDate.toISOString()
   withTransaction((db) => {
     const row = db.prepare('select triggers_json from workflows where id = ?').get(workflowId) as DbRow | undefined
-    const triggers = parseJson<WorkflowTrigger[]>(row?.triggers_json, [])
+    const triggers = parseWorkflowTriggersFromStorage(row?.triggers_json)
     const nextRunAt = status === 'active' ? computeNextWorkflowRunAt(triggers, nowDate) : null
     db.prepare('update workflows set status = ?, updated_at = ?, next_run_at = ? where id = ?')
       .run(status, now, nextRunAt, workflowId)
@@ -379,7 +447,7 @@ export function regenerateWorkflowWebhookSecret(workflowId: string, webhookBaseU
   const now = new Date().toISOString()
   withTransaction((db) => {
     db.prepare('update workflows set triggers_json = ?, updated_at = ? where id = ?')
-      .run(JSON.stringify(triggers), now, workflowId)
+      .run(serializeWorkflowTriggersForStorage(triggers), now, workflowId)
   })
   return getWorkflow(workflowId, webhookBaseUrl)
 }
@@ -508,7 +576,7 @@ export function recoverInterruptedWorkflowRuns(error = 'Workflow run was interru
           ? String(workflowRow.status) as WorkflowStatus
           : 'active'
         const nextStatus = status === 'paused' || status === 'archived' ? status : 'active'
-        const triggers = parseJson<WorkflowTrigger[]>(workflowRow.triggers_json, [])
+        const triggers = parseWorkflowTriggersFromStorage(workflowRow.triggers_json)
         const nextRunAt = nextStatus === 'active' ? computeNextWorkflowRunAt(triggers, now) : null
         db.prepare(`
           update workflows

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -116,7 +116,9 @@ function decodeWebhookSecretFromStorage(secret: unknown) {
   if (typeof secret !== 'string' || !secret.trim()) return null
   if (!secret.startsWith(ENCRYPTED_WEBHOOK_SECRET_PREFIX)) return secret
   const storage = getWorkflowSecretStorage()
-  if (storage.mode !== 'encrypted' || !storage.decryptString) return null
+  if (storage.mode !== 'encrypted' || !storage.decryptString) {
+    return storage.mode === 'plaintext' ? secret : null
+  }
   try {
     return storage.decryptString(Buffer.from(secret.slice(ENCRYPTED_WEBHOOK_SECRET_PREFIX.length), 'base64'))
   } catch {

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -39,7 +39,8 @@ const electronSafeStorage = (electron as { safeStorage?: typeof import('electron
 const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
   getSelectedStorageBackend?: () => string
 }) | undefined
-const ENCRYPTED_WEBHOOK_SECRET_PREFIX = 'enc:v1:'
+const LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX = 'enc:v1:'
+const ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION = 2
 
 type DbRow = Record<string, unknown>
 type WorkflowWriteOptions = {
@@ -49,6 +50,10 @@ type WorkflowSecretStorageAdapter = {
   mode: SecretStorageMode
   encryptString?: (value: string) => Buffer
   decryptString?: (value: Buffer) => string
+}
+type EncryptedWebhookSecretRecord = {
+  __openCoworkEncryptedWebhookSecret: typeof ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION
+  value: string
 }
 
 function workflowDbPath() {
@@ -107,29 +112,58 @@ function getWorkflowSecretStorage(): WorkflowSecretStorageAdapter {
   }
 }
 
-function encodeWebhookSecretForStorage(secret: string | null | undefined) {
+function isEncryptedWebhookSecretRecord(value: unknown): value is EncryptedWebhookSecretRecord {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && (value as Partial<EncryptedWebhookSecretRecord>).__openCoworkEncryptedWebhookSecret === ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION
+    && typeof (value as Partial<EncryptedWebhookSecretRecord>).value === 'string',
+  )
+}
+
+function encryptWebhookSecretValue(storage: WorkflowSecretStorageAdapter, secret: string): EncryptedWebhookSecretRecord {
+  if (!storage.encryptString) throw new Error('Electron safeStorage is unavailable')
+  return {
+    __openCoworkEncryptedWebhookSecret: ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION,
+    value: Buffer.from(storage.encryptString(secret)).toString('base64'),
+  }
+}
+
+function tryDecryptWebhookSecretPayload(storage: WorkflowSecretStorageAdapter, payload: string) {
+  if (!storage.decryptString) return null
+  try {
+    return storage.decryptString(Buffer.from(payload, 'base64'))
+  } catch {
+    return null
+  }
+}
+
+function encodeWebhookSecretForStorage(secret: string | null | undefined): string | EncryptedWebhookSecretRecord | null {
   if (!secret) return null
   const storage = getWorkflowSecretStorage()
   if (storage.mode === 'encrypted') {
-    if (!storage.encryptString) throw new Error('Electron safeStorage is unavailable')
-    return `${ENCRYPTED_WEBHOOK_SECRET_PREFIX}${Buffer.from(storage.encryptString(secret)).toString('base64')}`
+    return encryptWebhookSecretValue(storage, secret)
   }
   if (storage.mode === 'plaintext') return secret
   throw new Error('Secure storage unavailable on this system. Open Cowork cannot persist workflow webhook secrets in production without OS-backed secret storage.')
 }
 
 function decodeWebhookSecretFromStorage(secret: unknown) {
-  if (typeof secret !== 'string' || !secret.trim()) return null
-  if (!secret.startsWith(ENCRYPTED_WEBHOOK_SECRET_PREFIX)) return secret
   const storage = getWorkflowSecretStorage()
-  if (storage.mode !== 'encrypted' || !storage.decryptString) {
-    return storage.mode === 'plaintext' ? secret : null
+  if (isEncryptedWebhookSecretRecord(secret)) {
+    return tryDecryptWebhookSecretPayload(storage, secret.value)
   }
-  try {
-    return storage.decryptString(Buffer.from(secret.slice(ENCRYPTED_WEBHOOK_SECRET_PREFIX.length), 'base64'))
-  } catch {
-    return null
-  }
+
+  if (typeof secret !== 'string' || !secret.trim()) return null
+  if (!secret.startsWith(LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX)) return secret
+
+  const legacyPayload = secret.slice(LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX.length)
+  const decrypted = tryDecryptWebhookSecretPayload(storage, legacyPayload)
+  // Older builds stored encrypted webhook secrets as strings prefixed with
+  // enc:v1:. If decryption fails, preserve the original value so an imported
+  // plaintext secret with that literal prefix still round-trips.
+  return decrypted ?? secret
 }
 
 export function serializeWorkflowTriggersForStorage(triggers: WorkflowTrigger[]) {

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -175,9 +175,14 @@ export function serializeWorkflowTriggersForStorage(triggers: WorkflowTrigger[])
 export function parseWorkflowTriggersFromStorage(value: unknown) {
   const parsed = parseJson<unknown>(value, [])
   if (!Array.isArray(parsed)) return []
-  return (parsed as WorkflowTrigger[]).map((trigger) => trigger.type === 'webhook'
-    ? { ...trigger, webhookSecret: decodeWebhookSecretFromStorage(trigger.webhookSecret) }
-    : trigger)
+  return parsed.flatMap((raw): WorkflowTrigger[] => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return []
+    const trigger = raw as Partial<WorkflowTrigger>
+    if (!VALID_TRIGGER_TYPES.has(trigger.type as WorkflowTriggerType)) return []
+    return [trigger.type === 'webhook'
+      ? { ...trigger, webhookSecret: decodeWebhookSecretFromStorage(trigger.webhookSecret) } as WorkflowTrigger
+      : trigger as WorkflowTrigger]
+  })
 }
 
 export function setWorkflowSecretStorageForTests(adapter: WorkflowSecretStorageAdapter | null) {

--- a/apps/desktop/tests/packaged-relaunch.packaged.test.ts
+++ b/apps/desktop/tests/packaged-relaunch.packaged.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   cleanupSmokePaths,
   createSmokePaths,
@@ -13,6 +15,7 @@ const expectSignedUpdateInstall = process.env.OPEN_COWORK_EXPECT_SIGNED_UPDATE_I
 const packagedRelaunchTimeoutMs = 240_000
 const packagedLaunchTimeoutMs = 90_000
 const packagedIpcTimeoutMs = 60_000
+const packagedMacSeedSessionId = 'packaged_mac_seed_session'
 const updateInstallUnsupportedReasons = new Set([
   'dev',
   'unsigned',
@@ -26,6 +29,30 @@ const updateInstallUnsupportedReasons = new Set([
   'source-unreachable',
   'unavailable',
 ])
+
+function makePackagedMacSeedSession() {
+  const now = new Date(Date.UTC(2026, 0, 1, 12, 0, 0)).toISOString()
+  return {
+    id: packagedMacSeedSessionId,
+    title: 'Packaged macOS seed thread',
+    directory: null,
+    opencodeDirectory: '/tmp/open-cowork-packaged-mac-seed',
+    createdAt: now,
+    updatedAt: now,
+    kind: 'interactive',
+    workflowId: null,
+    runId: null,
+    providerId: 'openrouter',
+    modelId: 'anthropic/claude-sonnet-4',
+    composerModelId: null,
+    composerReasoningVariant: null,
+    summary: null,
+    parentSessionId: null,
+    changeSummary: null,
+    revertedMessageId: null,
+    managedByCowork: true as const,
+  }
+}
 
 async function withTimeout<T>(label: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timeout: NodeJS.Timeout | undefined
@@ -58,14 +85,20 @@ test(
       'OPEN_COWORK_PACKAGED_EXECUTABLE must point at a packaged desktop executable',
     )
 
-    const paths = createSmokePaths()
+    const paths = createSmokePaths(process.platform === 'darwin'
+      ? {
+          seedBeforeLaunch: ({ dataRoot }) => {
+            writeFileSync(join(dataRoot, 'sessions.json'), JSON.stringify([makePackagedMacSeedSession()], null, 2))
+          },
+        }
+      : undefined)
     let firstLaunch: SmokeSession | null = null
     let secondLaunch: SmokeSession | null = null
 
     try {
       if (process.platform === 'darwin') {
         const firstProbe = await launchPackagedMacProbe(paths, executablePath, {
-          action: 'create-session',
+          action: 'list-sessions',
           timeoutMs: packagedLaunchTimeoutMs,
         })
         assert.equal(
@@ -90,15 +123,18 @@ test(
           )
         }
 
-        assert.ok(firstProbe.createdSessionId, 'expected packaged app to persist a newly created session before relaunch')
+        assert.ok(
+          firstProbe.sessions.some((session) => session.id === packagedMacSeedSessionId),
+          'expected packaged app to load the seeded session before relaunch',
+        )
 
         const secondProbe = await launchPackagedMacProbe(paths, executablePath, {
           action: 'list-sessions',
           timeoutMs: packagedLaunchTimeoutMs,
         })
         assert.ok(
-          secondProbe.sessions.some((session) => session.id === firstProbe.createdSessionId),
-          'expected created session to survive a packaged-app relaunch',
+          secondProbe.sessions.some((session) => session.id === packagedMacSeedSessionId),
+          'expected seeded session to survive a packaged-app relaunch',
         )
         return
       }

--- a/apps/desktop/tests/packaged-relaunch.packaged.test.ts
+++ b/apps/desktop/tests/packaged-relaunch.packaged.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   cleanupSmokePaths,
   createSmokePaths,
+  launchPackagedMacProbe,
   launchSmokeSession,
   type SmokeSession,
 } from './smoke-helpers.ts'
@@ -62,6 +63,46 @@ test(
     let secondLaunch: SmokeSession | null = null
 
     try {
+      if (process.platform === 'darwin') {
+        const firstProbe = await launchPackagedMacProbe(paths, executablePath, {
+          action: 'create-session',
+          timeoutMs: packagedLaunchTimeoutMs,
+        })
+        assert.equal(
+          typeof firstProbe.installCapability.currentVersion,
+          'string',
+          'expected packaged update capability to include the running app version',
+        )
+        assert.equal(
+          String(firstProbe.installCapability.currentVersion).length > 0,
+          true,
+          'expected packaged update capability version to be non-empty',
+        )
+        if (expectSignedUpdateInstall) {
+          assert.equal(firstProbe.installCapability.supported, true, 'expected signed packaged macOS build to advertise in-app update install support')
+          assert.equal(firstProbe.installCapability.reason, undefined)
+        } else {
+          assert.equal(firstProbe.installCapability.supported, false, 'expected unsigned or unsupported packaged build to keep in-app update install disabled')
+          assert.equal(
+            updateInstallUnsupportedReasons.has(String(firstProbe.installCapability.reason)),
+            true,
+            `expected a known update install unsupported reason, got ${String(firstProbe.installCapability.reason)}`,
+          )
+        }
+
+        assert.ok(firstProbe.createdSessionId, 'expected packaged app to persist a newly created session before relaunch')
+
+        const secondProbe = await launchPackagedMacProbe(paths, executablePath, {
+          action: 'list-sessions',
+          timeoutMs: packagedLaunchTimeoutMs,
+        })
+        assert.ok(
+          secondProbe.sessions.some((session) => session.id === firstProbe.createdSessionId),
+          'expected created session to survive a packaged-app relaunch',
+        )
+        return
+      }
+
       firstLaunch = await launchSmokeSession(paths, {
         executablePath,
         appShellTimeoutMs: packagedLaunchTimeoutMs,

--- a/apps/desktop/tests/packaged-surface.packaged.test.ts
+++ b/apps/desktop/tests/packaged-surface.packaged.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   cleanupSmokePaths,
   createSmokePaths,
+  launchPackagedMacProbe,
   launchSmokeSession,
   type SmokeSession,
 } from './smoke-helpers.ts'
@@ -47,6 +48,25 @@ test(
     let session: SmokeSession | null = null
 
     try {
+      if (process.platform === 'darwin') {
+        const probe = await launchPackagedMacProbe(paths, executablePath, { timeoutMs: packagedLaunchTimeoutMs })
+        assert.deepEqual(probe.surface, {
+          sessionCreate: 'function',
+          settingsSet: 'function',
+          workflowsStartDraft: 'function',
+          updatesInstallCapability: 'function',
+          onSessionPatch: 'function',
+        })
+        assert.equal(typeof probe.settings.effectiveProviderId, 'string')
+        assert.equal(typeof probe.settings.effectiveModel, 'string')
+        assert.equal(typeof probe.installCapability.supported, 'boolean')
+        assert.ok(
+          probe.installCapability.reason === undefined
+            || typeof probe.installCapability.reason === 'string',
+        )
+        return
+      }
+
       session = await launchSmokeSession(paths, {
         executablePath,
         appShellTimeoutMs: packagedLaunchTimeoutMs,

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -5,10 +5,6 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
-  buildE2EArgEnvironment,
-  E2E_ARG_ENV_ENABLE_ARG,
-} from '../src/main/e2e-remote-debugging.ts'
-import {
   _electron as electron,
   chromium,
   type Browser,
@@ -251,6 +247,7 @@ function getSmokeEnvironment(paths: SmokePaths) {
   return {
     ...process.env,
     HOME: paths.tempHome,
+    TMPDIR: process.env.TMPDIR || tmpdir(),
     XDG_CONFIG_HOME: paths.xdgConfigHome,
     XDG_DATA_HOME: paths.xdgDataHome,
     XDG_CACHE_HOME: paths.xdgCacheHome,
@@ -276,8 +273,6 @@ function getLaunchServicesEnvironment(paths: SmokePaths, overrides?: Record<stri
   }
   const keys = new Set([
     'HOME',
-    'PATH',
-    'SHELL',
     'TMPDIR',
     'XDG_CONFIG_HOME',
     'XDG_DATA_HOME',
@@ -289,7 +284,6 @@ function getLaunchServicesEnvironment(paths: SmokePaths, overrides?: Record<stri
     'OPEN_COWORK_E2E',
     'OPEN_COWORK_E2E_PROBE_ACTION',
     'OPEN_COWORK_E2E_READY_FILE',
-    'CI',
   ])
 
   return Object.fromEntries(
@@ -441,6 +435,21 @@ function runCommand(command: string, args: string[], timeoutMs = 10_000) {
   })
 }
 
+async function withLaunchServicesEnvironment<T>(env: Record<string, string>, fn: () => Promise<T>): Promise<T> {
+  const appliedKeys: string[] = []
+  try {
+    for (const [key, value] of Object.entries(env)) {
+      await runCommand('launchctl', ['setenv', key, value])
+      appliedKeys.push(key)
+    }
+    return await fn()
+  } finally {
+    for (const key of appliedKeys.reverse()) {
+      await runCommand('launchctl', ['unsetenv', key]).catch(() => {})
+    }
+  }
+}
+
 async function waitForElectronAppPage(app: ElectronApplication, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -475,31 +484,19 @@ export async function launchPackagedMacProbe(
     OPEN_COWORK_E2E_PROBE_ACTION: action,
     OPEN_COWORK_E2E_READY_FILE: readyFile,
   })
-  const envArgs = buildE2EArgEnvironment(launchEnvironment)
-  const child = spawn(executablePath, [
-    E2E_ARG_ENV_ENABLE_ARG,
-    ...envArgs,
-  ], {
-    cwd: desktopAppDir,
-    env: launchEnvironment,
-    stdio: 'ignore',
-  })
-  const childExited = new Promise<never>((_, reject) => {
-    child.once('error', reject)
-    child.once('exit', (code, signal) => {
-      reject(new Error(`Packaged macOS app exited before writing probe file with ${signal || code}`))
-    })
-  })
-  childExited.catch(() => {})
 
   try {
-    return await Promise.race([
-      waitForPackagedMacProbeFile(readyFile, options?.timeoutMs ?? 90_000),
-      childExited,
-    ])
+    return await withLaunchServicesEnvironment(launchEnvironment, async () => {
+      await runCommand('open', [
+        '-n',
+        '-g',
+        '-j',
+        macAppBundlePath,
+      ])
+      return await waitForPackagedMacProbeFile(readyFile, options?.timeoutMs ?? 90_000)
+    })
   } finally {
     await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
-    await stopSpawnedSmokeProcess(child)
     await delay(1_000)
   }
 }

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -230,38 +230,6 @@ function getSmokeEnvironment(paths: SmokePaths) {
   }
 }
 
-function getMacAppBundlePath(executablePath: string) {
-  const bundleMarker = '.app/Contents/MacOS/'
-  const markerIndex = executablePath.indexOf(bundleMarker)
-  if (markerIndex < 0) return null
-  return executablePath.slice(0, markerIndex + '.app'.length)
-}
-
-function getLaunchServicesEnvironment(paths: SmokePaths) {
-  const env = getSmokeEnvironment(paths)
-  const keys = new Set([
-    'HOME',
-    'PATH',
-    'SHELL',
-    'TMPDIR',
-    'XDG_CONFIG_HOME',
-    'XDG_DATA_HOME',
-    'XDG_CACHE_HOME',
-    'OPEN_COWORK_CONFIG_PATH',
-    'OPEN_COWORK_USER_DATA_DIR',
-    'OPEN_COWORK_SANDBOX_DIR',
-    'OPEN_COWORK_CHART_TIMEOUT_MS',
-    'OPEN_COWORK_E2E',
-    'CI',
-  ])
-
-  return Object.fromEntries(
-    Array.from(keys)
-      .map((key) => [key, env[key]] as const)
-      .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
-  )
-}
-
 async function delay(ms: number) {
   await new Promise((done) => setTimeout(done, ms))
 }
@@ -296,28 +264,6 @@ async function getAvailablePort() {
     })
   })
   return address.port
-}
-
-function runCommand(command: string, args: string[], timeoutMs = 10_000) {
-  return new Promise<void>((resolveCommand, rejectCommand) => {
-    const child = spawn(command, args, { stdio: 'ignore' })
-    const timeout = setTimeout(() => {
-      child.kill('SIGTERM')
-      rejectCommand(new Error(`${command} timed out after ${timeoutMs}ms`))
-    }, timeoutMs)
-    child.once('error', (error) => {
-      clearTimeout(timeout)
-      rejectCommand(error)
-    })
-    child.once('exit', (code, signal) => {
-      clearTimeout(timeout)
-      if (code === 0) {
-        resolveCommand()
-        return
-      }
-      rejectCommand(new Error(`${command} exited with ${signal || code}`))
-    })
-  })
 }
 
 async function isCdpAvailable(port: number) {
@@ -395,32 +341,6 @@ async function waitForElectronAppPage(app: ElectronApplication, timeoutMs = 30_0
   }
   const diagnostics = await Promise.all(app.windows().map((page) => getAppShellDiagnostics(page)))
   throw new Error(`Timed out waiting for Electron app shell page\nDiagnostics: ${JSON.stringify(diagnostics)}`)
-}
-
-async function closeCdpSmokeApp(browser: Browser, port: number) {
-  try {
-    const cdpSession = await browser.newBrowserCDPSession()
-    await withSmokeTimeout('closing packaged app over CDP', cdpSession.send('Browser.close'), 2_000)
-  } catch {
-    // Fall through to the normal Playwright close/disconnect path.
-  }
-
-  try {
-    await withSmokeTimeout('closing packaged browser connection', browser.close(), 5_000)
-  } catch {
-    // The process may already be gone after Browser.close reaches CDP.
-  }
-
-  for (let attempts = 0; attempts < 20; attempts += 1) {
-    if (!(await isCdpAvailable(port))) {
-      await delay(1_000)
-      return
-    }
-    await delay(250)
-  }
-
-  await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
-  await delay(1_000)
 }
 
 async function stopSpawnedSmokeProcess(child: ChildProcess) {
@@ -544,50 +464,11 @@ export async function launchSmokeSession(
   options?: LaunchSmokeSessionOptions,
 ): Promise<SmokeSession> {
   const appShellTimeoutMs = options?.appShellTimeoutMs ?? 30_000
-  const macAppBundlePath = options?.executablePath && process.platform === 'darwin'
-    ? getMacAppBundlePath(options.executablePath)
-    : null
-
-  if (macAppBundlePath) {
-    const port = await getAvailablePort()
-    const launchEnvironment = getLaunchServicesEnvironment(paths)
-    const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
-    await runCommand('open', [
-      '-n',
-      '-g',
-      '-j',
-      ...envArgs,
-      macAppBundlePath,
-      '--args',
-      `--remote-debugging-port=${port}`,
-    ])
-
-    let browser: Browser | null = null
-    try {
-      await waitForCdp(port)
-      browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`)
-      await waitForCdpPage(browser)
-      const page = await waitForCdpAppPage(browser)
-      await bootstrapSmokeSettings(page, appShellTimeoutMs)
-
-      return {
-        page,
-        async close() {
-          if (browser) await closeCdpSmokeApp(browser, port)
-        },
-      }
-    } catch (error) {
-      if (browser) await closeCdpSmokeApp(browser, port)
-      throw error
-    }
-  }
-
-  if (options?.executablePath && process.platform === 'linux') {
+  if (options?.executablePath && (process.platform === 'darwin' || process.platform === 'linux')) {
     const port = await getAvailablePort()
     const childArgs = [
       `--remote-debugging-port=${port}`,
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
+      ...(process.platform === 'linux' ? ['--no-sandbox', '--disable-setuid-sandbox'] : []),
     ]
     const child = spawn(options.executablePath, childArgs, {
       cwd: desktopAppDir,

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -571,7 +571,10 @@ export async function launchSmokeSession(
     ]
     const child = spawn(options.executablePath, childArgs, {
       cwd: desktopAppDir,
-      env: getSmokeEnvironment(paths),
+      env: {
+        ...getSmokeEnvironment(paths),
+        OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: String(port),
+      },
       stdio: 'ignore',
     })
     let clearEarlyExit: () => void = () => undefined

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -75,6 +75,13 @@ export type PackagedMacProbe = {
   createdSessionId: string | null
 }
 
+type PackagedMacProbeFile = {
+  ok: boolean
+  result?: PackagedMacProbe
+  error?: string
+  writtenAt: string
+}
+
 export interface LaunchSmokeAppOptions {
   // Called with the isolated data root *before* Electron launches.
   // Use this to seed files like `sessions.json` under the path the
@@ -258,8 +265,11 @@ function getMacAppBundlePath(executablePath: string) {
   return executablePath.slice(0, markerIndex + '.app'.length)
 }
 
-function getLaunchServicesEnvironment(paths: SmokePaths) {
-  const env = getSmokeEnvironment(paths)
+function getLaunchServicesEnvironment(paths: SmokePaths, overrides?: Record<string, string>) {
+  const env = {
+    ...getSmokeEnvironment(paths),
+    ...overrides,
+  }
   const keys = new Set([
     'HOME',
     'PATH',
@@ -273,6 +283,8 @@ function getLaunchServicesEnvironment(paths: SmokePaths) {
     'OPEN_COWORK_SANDBOX_DIR',
     'OPEN_COWORK_CHART_TIMEOUT_MS',
     'OPEN_COWORK_E2E',
+    'OPEN_COWORK_E2E_PROBE_ACTION',
+    'OPEN_COWORK_E2E_READY_FILE',
     'CI',
   ])
 
@@ -381,6 +393,28 @@ async function waitForCdpAppPage(browser: Browser, timeoutMs = 30_000) {
   throw new Error('Timed out waiting for packaged app shell page')
 }
 
+async function waitForPackagedMacProbeFile(targetPath: string, timeoutMs = 90_000): Promise<PackagedMacProbe> {
+  const deadline = Date.now() + timeoutMs
+  let lastReadError: string | null = null
+  while (Date.now() < deadline) {
+    try {
+      const parsed = JSON.parse(readFileSync(targetPath, 'utf8')) as PackagedMacProbeFile
+      if (!parsed.ok) {
+        throw new Error(parsed.error || 'packaged macOS probe failed')
+      }
+      if (parsed.result) return parsed.result
+      lastReadError = 'probe file did not include a result payload'
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== 'ENOENT') {
+        lastReadError = error instanceof Error ? error.message : String(error)
+      }
+    }
+    await delay(250)
+  }
+  throw new Error(`Timed out waiting for packaged macOS probe file ${targetPath}${lastReadError ? `; last error: ${lastReadError}` : ''}`)
+}
+
 function runCommand(command: string, args: string[], timeoutMs = 10_000) {
   return new Promise<void>((resolveCommand, rejectCommand) => {
     const child = spawn(command, args, { stdio: 'ignore' })
@@ -426,68 +460,31 @@ export async function launchPackagedMacProbe(
   if (process.platform !== 'darwin') {
     throw new Error('launchPackagedMacProbe is only supported on macOS')
   }
-  let session: SmokeSession | null = null
+  const macAppBundlePath = getMacAppBundlePath(executablePath)
+  if (!macAppBundlePath) {
+    throw new Error(`Packaged macOS executable is not inside an app bundle: ${executablePath}`)
+  }
+
+  const action = options?.action || 'surface'
+  const readyFile = join(paths.tempRoot, `packaged-mac-probe-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`)
+  const launchEnvironment = getLaunchServicesEnvironment(paths, {
+    OPEN_COWORK_E2E_PROBE_ACTION: action,
+    OPEN_COWORK_E2E_READY_FILE: readyFile,
+  })
+  const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
+
   try {
-    session = await launchSmokeSession(paths, {
-      executablePath,
-      appShellTimeoutMs: options?.timeoutMs ?? 90_000,
-    })
-    const action = options?.action || 'surface'
-    return await withSmokeTimeout(
-      'running packaged macOS probe',
-      session.page.evaluate(async (probeAction): Promise<PackagedMacProbe> => {
-        const surface = {
-          sessionCreate: typeof window.coworkApi.session?.create,
-          settingsSet: typeof window.coworkApi.settings?.set,
-          workflowsStartDraft: typeof window.coworkApi.workflows?.startDraft,
-          updatesInstallCapability: typeof window.coworkApi.updates?.installCapability,
-          onSessionPatch: typeof window.coworkApi.on?.sessionPatch,
-        }
-        const [settings, installCapability] = await Promise.all([
-          window.coworkApi.settings.get(),
-          window.coworkApi.updates.installCapability(),
-        ])
-        const initialSessions = await window.coworkApi.session.list()
-        const initialIds = initialSessions.map((candidate) => candidate.id)
-        let sessions = initialSessions
-        let createdSessionId: string | null = null
-        if (probeAction === 'create-session') {
-          const runtimeDeadline = Date.now() + 60_000
-          while (Date.now() < runtimeDeadline) {
-            const status = await window.coworkApi.runtime.status().catch(() => null)
-            if (status?.ready) break
-            await new Promise((done) => setTimeout(done, 250))
-          }
-          await window.coworkApi.session.create(null)
-          const sessionDeadline = Date.now() + 15_000
-          while (Date.now() < sessionDeadline) {
-            sessions = await window.coworkApi.session.list()
-            createdSessionId = sessions.find((candidate) => !initialIds.includes(candidate.id))?.id || null
-            if (createdSessionId) break
-            await new Promise((done) => setTimeout(done, 250))
-          }
-        } else if (probeAction === 'list-sessions') {
-          sessions = await window.coworkApi.session.list()
-        }
-        return {
-          surface,
-          settings: {
-            effectiveProviderId: settings.effectiveProviderId,
-            effectiveModel: settings.effectiveModel,
-          },
-          installCapability: {
-            supported: installCapability.supported,
-            reason: installCapability.reason,
-            currentVersion: installCapability.currentVersion,
-          },
-          sessions: sessions.map((candidate) => ({ id: candidate.id })),
-          createdSessionId,
-        }
-      }, action),
-      options?.timeoutMs ?? 90_000,
-    )
+    await runCommand('open', [
+      '-n',
+      '-g',
+      '-j',
+      ...envArgs,
+      macAppBundlePath,
+    ])
+    return await waitForPackagedMacProbeFile(readyFile, options?.timeoutMs ?? 90_000)
   } finally {
-    if (session) await session.close()
+    await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
+    await delay(1_000)
   }
 }
 

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -464,7 +464,7 @@ export async function launchSmokeSession(
   options?: LaunchSmokeSessionOptions,
 ): Promise<SmokeSession> {
   const appShellTimeoutMs = options?.appShellTimeoutMs ?? 30_000
-  if (options?.executablePath && (process.platform === 'darwin' || process.platform === 'linux')) {
+  if (options?.executablePath && process.platform === 'linux') {
     const port = await getAvailablePort()
     const childArgs = [
       `--remote-debugging-port=${port}`,

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -11,6 +11,10 @@ import {
   type ElectronApplication,
   type Page,
 } from 'playwright-core'
+import {
+  buildE2EArgEnvironment,
+  E2E_ARG_ENV_ENABLE_KEY,
+} from '../src/main/e2e-remote-debugging.ts'
 
 // Shared bootstrap for every Electron smoke test: launches the packaged
 // renderer bundle against an isolated HOME + XDG dirs so tests never
@@ -251,6 +255,44 @@ function getSmokeEnvironment(paths: SmokePaths) {
   }
 }
 
+function getMacAppBundlePath(executablePath: string) {
+  const bundleMarker = '.app/Contents/MacOS/'
+  const markerIndex = executablePath.indexOf(bundleMarker)
+  if (markerIndex < 0) return null
+  return executablePath.slice(0, markerIndex + '.app'.length)
+}
+
+function getLaunchServicesEnvironment(paths: SmokePaths, port: number) {
+  const env = {
+    ...getSmokeEnvironment(paths),
+    [E2E_ARG_ENV_ENABLE_KEY]: '1',
+    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: String(port),
+  }
+  const keys = new Set([
+    'HOME',
+    'PATH',
+    'SHELL',
+    'TMPDIR',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_CACHE_HOME',
+    'OPEN_COWORK_CONFIG_PATH',
+    'OPEN_COWORK_USER_DATA_DIR',
+    'OPEN_COWORK_SANDBOX_DIR',
+    'OPEN_COWORK_CHART_TIMEOUT_MS',
+    'OPEN_COWORK_E2E',
+    'OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT',
+    E2E_ARG_ENV_ENABLE_KEY,
+    'CI',
+  ])
+
+  return Object.fromEntries(
+    Array.from(keys)
+      .map((key) => [key, env[key]] as const)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  )
+}
+
 async function delay(ms: number) {
   await new Promise((done) => setTimeout(done, ms))
 }
@@ -349,6 +391,28 @@ async function waitForCdpAppPage(browser: Browser, timeoutMs = 30_000) {
   throw new Error('Timed out waiting for packaged app shell page')
 }
 
+function runCommand(command: string, args: string[], timeoutMs = 10_000) {
+  return new Promise<void>((resolveCommand, rejectCommand) => {
+    const child = spawn(command, args, { stdio: 'ignore' })
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      rejectCommand(new Error(`${command} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      rejectCommand(error)
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolveCommand()
+        return
+      }
+      rejectCommand(new Error(`${command} exited with ${signal || code}`))
+    })
+  })
+}
+
 async function waitForElectronAppPage(app: ElectronApplication, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -435,6 +499,32 @@ export async function launchPackagedMacProbe(
   } finally {
     if (session) await session.close()
   }
+}
+
+async function closeCdpSmokeApp(browser: Browser, port: number) {
+  try {
+    const cdpSession = await browser.newBrowserCDPSession()
+    await withSmokeTimeout('closing packaged app over CDP', cdpSession.send('Browser.close'), 2_000)
+  } catch {
+    // Fall through to the normal Playwright close/disconnect path.
+  }
+
+  try {
+    await withSmokeTimeout('closing packaged browser connection', browser.close(), 5_000)
+  } catch {
+    // The process may already be gone after Browser.close reaches CDP.
+  }
+
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    if (!(await isCdpAvailable(port))) {
+      await delay(1_000)
+      return
+    }
+    await delay(250)
+  }
+
+  await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
+  await delay(1_000)
 }
 
 async function stopSpawnedSmokeProcess(child: ChildProcess) {
@@ -562,12 +652,54 @@ export async function launchSmokeSession(
   options?: LaunchSmokeSessionOptions,
 ): Promise<SmokeSession> {
   const appShellTimeoutMs = options?.appShellTimeoutMs ?? 30_000
-  if (options?.executablePath && (process.platform === 'darwin' || process.platform === 'linux')) {
+  const macAppBundlePath = options?.executablePath && process.platform === 'darwin'
+    ? getMacAppBundlePath(options.executablePath)
+    : null
+
+  if (macAppBundlePath) {
+    const port = await getAvailablePort()
+    const launchEnvironment = getLaunchServicesEnvironment(paths, port)
+    const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
+    const argvEnvArgs = buildE2EArgEnvironment(launchEnvironment)
+    await runCommand('open', [
+      '-n',
+      '-g',
+      '-j',
+      ...envArgs,
+      macAppBundlePath,
+      '--args',
+      ...argvEnvArgs,
+      '--remote-debugging-address=127.0.0.1',
+      `--remote-debugging-port=${port}`,
+    ])
+
+    let browser: Browser | null = null
+    try {
+      await waitForCdp(port)
+      browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`)
+      await waitForCdpPage(browser)
+      const page = await waitForCdpAppPage(browser)
+      await bootstrapSmokeSettings(page, appShellTimeoutMs)
+
+      return {
+        page,
+        async close() {
+          if (browser) await closeCdpSmokeApp(browser, port)
+        },
+      }
+    } catch (error) {
+      if (browser) await closeCdpSmokeApp(browser, port)
+      throw error
+    }
+  }
+
+  if (options?.executablePath && process.platform === 'linux') {
     const port = await getAvailablePort()
     const childArgs = [
       '--remote-debugging-address=127.0.0.1',
       `--remote-debugging-port=${port}`,
-      ...(process.platform === 'linux' ? ['--no-sandbox', '--disable-setuid-sandbox'] : []),
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
     ]
     const child = spawn(options.executablePath, childArgs, {
       cwd: desktopAppDir,

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -230,6 +230,38 @@ function getSmokeEnvironment(paths: SmokePaths) {
   }
 }
 
+function getMacAppBundlePath(executablePath: string) {
+  const bundleMarker = '.app/Contents/MacOS/'
+  const markerIndex = executablePath.indexOf(bundleMarker)
+  if (markerIndex < 0) return null
+  return executablePath.slice(0, markerIndex + '.app'.length)
+}
+
+function getLaunchServicesEnvironment(paths: SmokePaths) {
+  const env = getSmokeEnvironment(paths)
+  const keys = new Set([
+    'HOME',
+    'PATH',
+    'SHELL',
+    'TMPDIR',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_CACHE_HOME',
+    'OPEN_COWORK_CONFIG_PATH',
+    'OPEN_COWORK_USER_DATA_DIR',
+    'OPEN_COWORK_SANDBOX_DIR',
+    'OPEN_COWORK_CHART_TIMEOUT_MS',
+    'OPEN_COWORK_E2E',
+    'CI',
+  ])
+
+  return Object.fromEntries(
+    Array.from(keys)
+      .map((key) => [key, env[key]] as const)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  )
+}
+
 async function delay(ms: number) {
   await new Promise((done) => setTimeout(done, ms))
 }
@@ -264,6 +296,28 @@ async function getAvailablePort() {
     })
   })
   return address.port
+}
+
+function runCommand(command: string, args: string[], timeoutMs = 10_000) {
+  return new Promise<void>((resolveCommand, rejectCommand) => {
+    const child = spawn(command, args, { stdio: 'ignore' })
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      rejectCommand(new Error(`${command} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      rejectCommand(error)
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolveCommand()
+        return
+      }
+      rejectCommand(new Error(`${command} exited with ${signal || code}`))
+    })
+  })
 }
 
 async function isCdpAvailable(port: number) {
@@ -341,6 +395,32 @@ async function waitForElectronAppPage(app: ElectronApplication, timeoutMs = 30_0
   }
   const diagnostics = await Promise.all(app.windows().map((page) => getAppShellDiagnostics(page)))
   throw new Error(`Timed out waiting for Electron app shell page\nDiagnostics: ${JSON.stringify(diagnostics)}`)
+}
+
+async function closeCdpSmokeApp(browser: Browser, port: number) {
+  try {
+    const cdpSession = await browser.newBrowserCDPSession()
+    await withSmokeTimeout('closing packaged app over CDP', cdpSession.send('Browser.close'), 2_000)
+  } catch {
+    // Fall through to the normal Playwright close/disconnect path.
+  }
+
+  try {
+    await withSmokeTimeout('closing packaged browser connection', browser.close(), 5_000)
+  } catch {
+    // The process may already be gone after Browser.close reaches CDP.
+  }
+
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    if (!(await isCdpAvailable(port))) {
+      await delay(1_000)
+      return
+    }
+    await delay(250)
+  }
+
+  await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
+  await delay(1_000)
 }
 
 async function stopSpawnedSmokeProcess(child: ChildProcess) {
@@ -464,6 +544,44 @@ export async function launchSmokeSession(
   options?: LaunchSmokeSessionOptions,
 ): Promise<SmokeSession> {
   const appShellTimeoutMs = options?.appShellTimeoutMs ?? 30_000
+  const macAppBundlePath = options?.executablePath && process.platform === 'darwin'
+    ? getMacAppBundlePath(options.executablePath)
+    : null
+
+  if (macAppBundlePath) {
+    const port = await getAvailablePort()
+    const launchEnvironment = getLaunchServicesEnvironment(paths)
+    const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
+    await runCommand('open', [
+      '-n',
+      '-g',
+      '-j',
+      ...envArgs,
+      macAppBundlePath,
+      '--args',
+      `--remote-debugging-port=${port}`,
+    ])
+
+    let browser: Browser | null = null
+    try {
+      await waitForCdp(port)
+      browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`)
+      await waitForCdpPage(browser)
+      const page = await waitForCdpAppPage(browser)
+      await bootstrapSmokeSettings(page, appShellTimeoutMs)
+
+      return {
+        page,
+        async close() {
+          if (browser) await closeCdpSmokeApp(browser, port)
+        },
+      }
+    } catch (error) {
+      if (browser) await closeCdpSmokeApp(browser, port)
+      throw error
+    }
+  }
+
   if (options?.executablePath && process.platform === 'linux') {
     const port = await getAvailablePort()
     const childArgs = [

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -517,14 +517,18 @@ export async function launchPackagedMacProbe(
 }
 
 async function stopSpawnedSmokeProcess(child: ChildProcess) {
-  if (child.killed || child.exitCode !== null || child.signalCode !== null) return
+  if (child.exitCode !== null || child.signalCode !== null) return
   child.kill('SIGTERM')
-  await Promise.race([
-    new Promise<void>((resolveExit) => child.once('exit', () => resolveExit())),
-    delay(5_000),
+  const exitedAfterTerm = await Promise.race([
+    new Promise<boolean>((resolveExit) => child.once('exit', () => resolveExit(true))),
+    delay(5_000).then(() => false),
   ])
-  if (!child.killed && child.exitCode === null && child.signalCode === null) {
+  if (!exitedAfterTerm && child.exitCode === null && child.signalCode === null) {
     child.kill('SIGKILL')
+    await Promise.race([
+      new Promise<void>((resolveExit) => child.once('exit', () => resolveExit())),
+      delay(5_000),
+    ])
   }
 }
 

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -550,7 +550,10 @@ export async function launchSmokeSession(
 
   if (macAppBundlePath) {
     const port = await getAvailablePort()
-    const launchEnvironment = getLaunchServicesEnvironment(paths)
+    const launchEnvironment = {
+      ...getLaunchServicesEnvironment(paths),
+      OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: String(port),
+    }
     const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
     await runCommand('open', [
       '-n',
@@ -559,6 +562,7 @@ export async function launchSmokeSession(
       ...envArgs,
       macAppBundlePath,
       '--args',
+      '--remote-debugging-address=127.0.0.1',
       `--remote-debugging-port=${port}`,
     ])
 
@@ -585,6 +589,7 @@ export async function launchSmokeSession(
   if (options?.executablePath && process.platform === 'linux') {
     const port = await getAvailablePort()
     const childArgs = [
+      '--remote-debugging-address=127.0.0.1',
       `--remote-debugging-port=${port}`,
       ...(process.platform === 'linux' ? ['--no-sandbox', '--disable-setuid-sandbox'] : []),
     ]

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -292,10 +292,16 @@ async function waitForJsonFile<T>(path: string, timeoutMs = 30_000): Promise<T> 
   let lastError: unknown = null
   while (Date.now() < deadline) {
     try {
-      const parsed = JSON.parse(readFileSync(path, 'utf8')) as { ok?: boolean; result?: T }
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as { ok?: boolean; result?: T; error?: string }
       if (parsed.ok) return parsed.result as T
+      if (parsed.ok === false) {
+        throw new Error(`Probe file reported failure: ${parsed.error || 'unknown error'}`)
+      }
       lastError = new Error(`Probe file did not report ok=true: ${path}`)
     } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Probe file reported failure:')) {
+        throw error
+      }
       lastError = error
     }
     await delay(100)
@@ -474,22 +480,37 @@ export async function launchPackagedMacProbe(
 
   const readyFile = join(paths.tempRoot, `packaged-mac-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`)
   const launchEnvironment = {
-    ...getLaunchServicesEnvironment(paths),
+    ...getSmokeEnvironment(paths),
     OPEN_COWORK_E2E_READY_FILE: readyFile,
     OPEN_COWORK_E2E_PROBE_ACTION: options?.action || 'surface',
   }
-  const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
-  await runCommand('open', [
-    '-n',
-    '-g',
-    '-j',
-    ...envArgs,
-    macAppBundlePath,
-  ])
+  const child = spawn(executablePath, [], {
+    cwd: desktopAppDir,
+    env: launchEnvironment,
+    stdio: 'ignore',
+  })
+  let clearEarlyExit: () => void = () => undefined
+  const earlyExit = new Promise<never>((_resolve, reject) => {
+    const onError = (error: Error) => reject(error)
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      reject(new Error(`Packaged app exited before probe file was written: ${signal || code}`))
+    }
+    child.once('error', onError)
+    child.once('exit', onExit)
+    clearEarlyExit = () => {
+      child.off('error', onError)
+      child.off('exit', onExit)
+    }
+  })
 
   try {
-    return await waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000)
+    return await Promise.race([
+      waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000),
+      earlyExit,
+    ])
   } finally {
+    clearEarlyExit()
+    await stopSpawnedSmokeProcess(child)
     await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
     await delay(1_000)
   }

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -11,6 +11,7 @@ import {
   type ElectronApplication,
   type Page,
 } from 'playwright-core'
+import { buildE2EArgEnvironment } from '../src/main/e2e-remote-debugging.ts'
 
 // Shared bootstrap for every Electron smoke test: launches the packaged
 // renderer bundle against an isolated HOME + XDG dirs so tests never
@@ -485,9 +486,10 @@ export async function launchPackagedMacProbe(
     OPEN_COWORK_E2E_PROBE_ACTION: options?.action || 'surface',
   }
   const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
+  const appArgs = buildE2EArgEnvironment(launchEnvironment)
 
   try {
-    await runCommand('open', ['-n', '-g', '-j', ...envArgs, macAppBundlePath])
+    await runCommand('open', ['-n', '-g', '-j', ...envArgs, macAppBundlePath, '--args', ...appArgs])
     return await waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000)
   } finally {
     await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -476,20 +476,30 @@ export async function launchPackagedMacProbe(
     OPEN_COWORK_E2E_READY_FILE: readyFile,
   })
   const envArgs = buildE2EArgEnvironment(launchEnvironment)
+  const child = spawn(executablePath, [
+    E2E_ARG_ENV_ENABLE_ARG,
+    ...envArgs,
+  ], {
+    cwd: desktopAppDir,
+    env: launchEnvironment,
+    stdio: 'ignore',
+  })
+  const childExited = new Promise<never>((_, reject) => {
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      reject(new Error(`Packaged macOS app exited before writing probe file with ${signal || code}`))
+    })
+  })
+  childExited.catch(() => {})
 
   try {
-    await runCommand('open', [
-      '-n',
-      '-g',
-      '-j',
-      macAppBundlePath,
-      '--args',
-      E2E_ARG_ENV_ENABLE_ARG,
-      ...envArgs,
+    return await Promise.race([
+      waitForPackagedMacProbeFile(readyFile, options?.timeoutMs ?? 90_000),
+      childExited,
     ])
-    return await waitForPackagedMacProbeFile(readyFile, options?.timeoutMs ?? 90_000)
   } finally {
     await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
+    await stopSpawnedSmokeProcess(child)
     await delay(1_000)
   }
 }

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -11,10 +11,6 @@ import {
   type ElectronApplication,
   type Page,
 } from 'playwright-core'
-import {
-  buildE2EArgEnvironment,
-  E2E_ARG_ENV_ENABLE_KEY,
-} from '../src/main/e2e-remote-debugging.ts'
 
 // Shared bootstrap for every Electron smoke test: launches the packaged
 // renderer bundle against an isolated HOME + XDG dirs so tests never
@@ -262,12 +258,8 @@ function getMacAppBundlePath(executablePath: string) {
   return executablePath.slice(0, markerIndex + '.app'.length)
 }
 
-function getLaunchServicesEnvironment(paths: SmokePaths, port: number) {
-  const env = {
-    ...getSmokeEnvironment(paths),
-    [E2E_ARG_ENV_ENABLE_KEY]: '1',
-    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: String(port),
-  }
+function getLaunchServicesEnvironment(paths: SmokePaths) {
+  const env = getSmokeEnvironment(paths)
   const keys = new Set([
     'HOME',
     'PATH',
@@ -281,8 +273,6 @@ function getLaunchServicesEnvironment(paths: SmokePaths, port: number) {
     'OPEN_COWORK_SANDBOX_DIR',
     'OPEN_COWORK_CHART_TIMEOUT_MS',
     'OPEN_COWORK_E2E',
-    'OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT',
-    E2E_ARG_ENV_ENABLE_KEY,
     'CI',
   ])
 
@@ -658,9 +648,8 @@ export async function launchSmokeSession(
 
   if (macAppBundlePath) {
     const port = await getAvailablePort()
-    const launchEnvironment = getLaunchServicesEnvironment(paths, port)
+    const launchEnvironment = getLaunchServicesEnvironment(paths)
     const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
-    const argvEnvArgs = buildE2EArgEnvironment(launchEnvironment)
     await runCommand('open', [
       '-n',
       '-g',
@@ -668,8 +657,6 @@ export async function launchSmokeSession(
       ...envArgs,
       macAppBundlePath,
       '--args',
-      ...argvEnvArgs,
-      '--remote-debugging-address=127.0.0.1',
       `--remote-debugging-port=${port}`,
     ])
 

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -5,6 +5,10 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  buildE2EArgEnvironment,
+  E2E_ARG_ENV_ENABLE_ARG,
+} from '../src/main/e2e-remote-debugging.ts'
+import {
   _electron as electron,
   chromium,
   type Browser,
@@ -471,15 +475,17 @@ export async function launchPackagedMacProbe(
     OPEN_COWORK_E2E_PROBE_ACTION: action,
     OPEN_COWORK_E2E_READY_FILE: readyFile,
   })
-  const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
+  const envArgs = buildE2EArgEnvironment(launchEnvironment)
 
   try {
     await runCommand('open', [
       '-n',
       '-g',
       '-j',
-      ...envArgs,
       macAppBundlePath,
+      '--args',
+      E2E_ARG_ENV_ENABLE_ARG,
+      ...envArgs,
     ])
     return await waitForPackagedMacProbeFile(readyFile, options?.timeoutMs ?? 90_000)
   } finally {

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -54,6 +54,27 @@ export interface SmokeSession {
   close: () => Promise<void>
 }
 
+export type PackagedMacProbe = {
+  surface: {
+    sessionCreate: string
+    settingsSet: string
+    workflowsStartDraft: string
+    updatesInstallCapability: string
+    onSessionPatch: string
+  }
+  settings: {
+    effectiveProviderId: unknown
+    effectiveModel: unknown
+  }
+  installCapability: {
+    supported: unknown
+    reason?: unknown
+    currentVersion?: unknown
+  }
+  sessions: Array<{ id: string }>
+  createdSessionId: string | null
+}
+
 export interface LaunchSmokeAppOptions {
   // Called with the isolated data root *before* Electron launches.
   // Use this to seed files like `sessions.json` under the path the
@@ -266,6 +287,23 @@ async function delay(ms: number) {
   await new Promise((done) => setTimeout(done, ms))
 }
 
+async function waitForJsonFile<T>(path: string, timeoutMs = 30_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown = null
+  while (Date.now() < deadline) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as { ok?: boolean; result?: T }
+      if (parsed.ok) return parsed.result as T
+      lastError = new Error(`Probe file did not report ok=true: ${path}`)
+    } catch (error) {
+      lastError = error
+    }
+    await delay(100)
+  }
+  const suffix = lastError instanceof Error ? ` Last error: ${lastError.message}` : ''
+  throw new Error(`Timed out waiting for probe file ${path}.${suffix}`)
+}
+
 async function withSmokeTimeout<T>(label: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timeout: NodeJS.Timeout | undefined
   try {
@@ -421,6 +459,40 @@ async function closeCdpSmokeApp(browser: Browser, port: number) {
 
   await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
   await delay(1_000)
+}
+
+export async function launchPackagedMacProbe(
+  paths: SmokePaths,
+  executablePath: string,
+  options?: { action?: 'surface' | 'create-session' | 'list-sessions'; timeoutMs?: number },
+): Promise<PackagedMacProbe> {
+  if (process.platform !== 'darwin') {
+    throw new Error('launchPackagedMacProbe is only supported on macOS')
+  }
+  const macAppBundlePath = getMacAppBundlePath(executablePath)
+  if (!macAppBundlePath) throw new Error(`Expected a macOS .app executable path, got ${executablePath}`)
+
+  const readyFile = join(paths.tempRoot, `packaged-mac-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`)
+  const launchEnvironment = {
+    ...getLaunchServicesEnvironment(paths),
+    OPEN_COWORK_E2E_READY_FILE: readyFile,
+    OPEN_COWORK_E2E_PROBE_ACTION: options?.action || 'surface',
+  }
+  const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
+  await runCommand('open', [
+    '-n',
+    '-g',
+    '-j',
+    ...envArgs,
+    macAppBundlePath,
+  ])
+
+  try {
+    return await waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000)
+  } finally {
+    await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
+    await delay(1_000)
+  }
 }
 
 async function stopSpawnedSmokeProcess(child: ChildProcess) {

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -11,7 +11,6 @@ import {
   type ElectronApplication,
   type Page,
 } from 'playwright-core'
-import { buildE2EArgEnvironment, E2E_ARG_ENV_ENABLE_KEY } from '../src/main/e2e-remote-debugging.ts'
 
 // Shared bootstrap for every Electron smoke test: launches the packaged
 // renderer bundle against an isolated HOME + XDG dirs so tests never
@@ -252,63 +251,8 @@ function getSmokeEnvironment(paths: SmokePaths) {
   }
 }
 
-function getMacAppBundlePath(executablePath: string) {
-  const bundleMarker = '.app/Contents/MacOS/'
-  const markerIndex = executablePath.indexOf(bundleMarker)
-  if (markerIndex < 0) return null
-  return executablePath.slice(0, markerIndex + '.app'.length)
-}
-
-function getLaunchServicesEnvironment(paths: SmokePaths) {
-  const env = getSmokeEnvironment(paths)
-  const keys = new Set([
-    'HOME',
-    'PATH',
-    'SHELL',
-    'TMPDIR',
-    'XDG_CONFIG_HOME',
-    'XDG_DATA_HOME',
-    'XDG_CACHE_HOME',
-    'OPEN_COWORK_CONFIG_PATH',
-    'OPEN_COWORK_USER_DATA_DIR',
-    'OPEN_COWORK_SANDBOX_DIR',
-    'OPEN_COWORK_CHART_TIMEOUT_MS',
-    'OPEN_COWORK_E2E',
-    'CI',
-  ])
-
-  return Object.fromEntries(
-    Array.from(keys)
-      .map((key) => [key, env[key]] as const)
-      .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
-  )
-}
-
 async function delay(ms: number) {
   await new Promise((done) => setTimeout(done, ms))
-}
-
-async function waitForJsonFile<T>(path: string, timeoutMs = 30_000): Promise<T> {
-  const deadline = Date.now() + timeoutMs
-  let lastError: unknown = null
-  while (Date.now() < deadline) {
-    try {
-      const parsed = JSON.parse(readFileSync(path, 'utf8')) as { ok?: boolean; result?: T; error?: string }
-      if (parsed.ok) return parsed.result as T
-      if (parsed.ok === false) {
-        throw new Error(`Probe file reported failure: ${parsed.error || 'unknown error'}`)
-      }
-      lastError = new Error(`Probe file did not report ok=true: ${path}`)
-    } catch (error) {
-      if (error instanceof Error && error.message.startsWith('Probe file reported failure:')) {
-        throw error
-      }
-      lastError = error
-    }
-    await delay(100)
-  }
-  const suffix = lastError instanceof Error ? ` Last error: ${lastError.message}` : ''
-  throw new Error(`Timed out waiting for probe file ${path}.${suffix}`)
 }
 
 async function withSmokeTimeout<T>(label: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -341,28 +285,6 @@ async function getAvailablePort() {
     })
   })
   return address.port
-}
-
-function runCommand(command: string, args: string[], timeoutMs = 10_000) {
-  return new Promise<void>((resolveCommand, rejectCommand) => {
-    const child = spawn(command, args, { stdio: 'ignore' })
-    const timeout = setTimeout(() => {
-      child.kill('SIGTERM')
-      rejectCommand(new Error(`${command} timed out after ${timeoutMs}ms`))
-    }, timeoutMs)
-    child.once('error', (error) => {
-      clearTimeout(timeout)
-      rejectCommand(error)
-    })
-    child.once('exit', (code, signal) => {
-      clearTimeout(timeout)
-      if (code === 0) {
-        resolveCommand()
-        return
-      }
-      rejectCommand(new Error(`${command} exited with ${signal || code}`))
-    })
-  })
 }
 
 async function isCdpAvailable(port: number) {
@@ -442,32 +364,6 @@ async function waitForElectronAppPage(app: ElectronApplication, timeoutMs = 30_0
   throw new Error(`Timed out waiting for Electron app shell page\nDiagnostics: ${JSON.stringify(diagnostics)}`)
 }
 
-async function closeCdpSmokeApp(browser: Browser, port: number) {
-  try {
-    const cdpSession = await browser.newBrowserCDPSession()
-    await withSmokeTimeout('closing packaged app over CDP', cdpSession.send('Browser.close'), 2_000)
-  } catch {
-    // Fall through to the normal Playwright close/disconnect path.
-  }
-
-  try {
-    await withSmokeTimeout('closing packaged browser connection', browser.close(), 5_000)
-  } catch {
-    // The process may already be gone after Browser.close reaches CDP.
-  }
-
-  for (let attempts = 0; attempts < 20; attempts += 1) {
-    if (!(await isCdpAvailable(port))) {
-      await delay(1_000)
-      return
-    }
-    await delay(250)
-  }
-
-  await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
-  await delay(1_000)
-}
-
 export async function launchPackagedMacProbe(
   paths: SmokePaths,
   executablePath: string,
@@ -476,31 +372,68 @@ export async function launchPackagedMacProbe(
   if (process.platform !== 'darwin') {
     throw new Error('launchPackagedMacProbe is only supported on macOS')
   }
-  const macAppBundlePath = getMacAppBundlePath(executablePath)
-  if (!macAppBundlePath) throw new Error(`Expected a macOS .app executable path, got ${executablePath}`)
-
-  const readyFile = join(paths.tempRoot, `packaged-mac-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`)
-  const launchEnvironment = {
-    ...getLaunchServicesEnvironment(paths),
-    [E2E_ARG_ENV_ENABLE_KEY]: '1',
-    OPEN_COWORK_E2E_READY_FILE: readyFile,
-    OPEN_COWORK_E2E_PROBE_ACTION: options?.action || 'surface',
-  }
-  const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
-  const appArgs = buildE2EArgEnvironment(launchEnvironment)
-
-  let launchServicesMarkerSet = false
+  let session: SmokeSession | null = null
   try {
-    await runCommand('launchctl', ['setenv', E2E_ARG_ENV_ENABLE_KEY, '1'])
-    launchServicesMarkerSet = true
-    await runCommand('open', ['-n', '-g', '-j', ...envArgs, macAppBundlePath, '--args', ...appArgs])
-    return await waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000)
+    session = await launchSmokeSession(paths, {
+      executablePath,
+      appShellTimeoutMs: options?.timeoutMs ?? 90_000,
+    })
+    const action = options?.action || 'surface'
+    return await withSmokeTimeout(
+      'running packaged macOS probe',
+      session.page.evaluate(async (probeAction): Promise<PackagedMacProbe> => {
+        const surface = {
+          sessionCreate: typeof window.coworkApi.session?.create,
+          settingsSet: typeof window.coworkApi.settings?.set,
+          workflowsStartDraft: typeof window.coworkApi.workflows?.startDraft,
+          updatesInstallCapability: typeof window.coworkApi.updates?.installCapability,
+          onSessionPatch: typeof window.coworkApi.on?.sessionPatch,
+        }
+        const [settings, installCapability] = await Promise.all([
+          window.coworkApi.settings.get(),
+          window.coworkApi.updates.installCapability(),
+        ])
+        const initialSessions = await window.coworkApi.session.list()
+        const initialIds = initialSessions.map((candidate) => candidate.id)
+        let sessions = initialSessions
+        let createdSessionId: string | null = null
+        if (probeAction === 'create-session') {
+          const runtimeDeadline = Date.now() + 60_000
+          while (Date.now() < runtimeDeadline) {
+            const status = await window.coworkApi.runtime.status().catch(() => null)
+            if (status?.ready) break
+            await new Promise((done) => setTimeout(done, 250))
+          }
+          await window.coworkApi.session.create(null)
+          const sessionDeadline = Date.now() + 15_000
+          while (Date.now() < sessionDeadline) {
+            sessions = await window.coworkApi.session.list()
+            createdSessionId = sessions.find((candidate) => !initialIds.includes(candidate.id))?.id || null
+            if (createdSessionId) break
+            await new Promise((done) => setTimeout(done, 250))
+          }
+        } else if (probeAction === 'list-sessions') {
+          sessions = await window.coworkApi.session.list()
+        }
+        return {
+          surface,
+          settings: {
+            effectiveProviderId: settings.effectiveProviderId,
+            effectiveModel: settings.effectiveModel,
+          },
+          installCapability: {
+            supported: installCapability.supported,
+            reason: installCapability.reason,
+            currentVersion: installCapability.currentVersion,
+          },
+          sessions: sessions.map((candidate) => ({ id: candidate.id })),
+          createdSessionId,
+        }
+      }, action),
+      options?.timeoutMs ?? 90_000,
+    )
   } finally {
-    if (launchServicesMarkerSet) {
-      await runCommand('launchctl', ['unsetenv', E2E_ARG_ENV_ENABLE_KEY]).catch(() => {})
-    }
-    await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
-    await delay(1_000)
+    if (session) await session.close()
   }
 }
 
@@ -629,49 +562,7 @@ export async function launchSmokeSession(
   options?: LaunchSmokeSessionOptions,
 ): Promise<SmokeSession> {
   const appShellTimeoutMs = options?.appShellTimeoutMs ?? 30_000
-  const macAppBundlePath = options?.executablePath && process.platform === 'darwin'
-    ? getMacAppBundlePath(options.executablePath)
-    : null
-
-  if (macAppBundlePath) {
-    const port = await getAvailablePort()
-    const launchEnvironment = {
-      ...getLaunchServicesEnvironment(paths),
-      OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: String(port),
-    }
-    const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
-    await runCommand('open', [
-      '-n',
-      '-g',
-      '-j',
-      ...envArgs,
-      macAppBundlePath,
-      '--args',
-      '--remote-debugging-address=127.0.0.1',
-      `--remote-debugging-port=${port}`,
-    ])
-
-    let browser: Browser | null = null
-    try {
-      await waitForCdp(port)
-      browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`)
-      await waitForCdpPage(browser)
-      const page = await waitForCdpAppPage(browser)
-      await bootstrapSmokeSettings(page, appShellTimeoutMs)
-
-      return {
-        page,
-        async close() {
-          if (browser) await closeCdpSmokeApp(browser, port)
-        },
-      }
-    } catch (error) {
-      if (browser) await closeCdpSmokeApp(browser, port)
-      throw error
-    }
-  }
-
-  if (options?.executablePath && process.platform === 'linux') {
+  if (options?.executablePath && (process.platform === 'darwin' || process.platform === 'linux')) {
     const port = await getAvailablePort()
     const childArgs = [
       '--remote-debugging-address=127.0.0.1',

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -480,37 +480,16 @@ export async function launchPackagedMacProbe(
 
   const readyFile = join(paths.tempRoot, `packaged-mac-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`)
   const launchEnvironment = {
-    ...getSmokeEnvironment(paths),
+    ...getLaunchServicesEnvironment(paths),
     OPEN_COWORK_E2E_READY_FILE: readyFile,
     OPEN_COWORK_E2E_PROBE_ACTION: options?.action || 'surface',
   }
-  const child = spawn(executablePath, [], {
-    cwd: desktopAppDir,
-    env: launchEnvironment,
-    stdio: 'ignore',
-  })
-  let clearEarlyExit: () => void = () => undefined
-  const earlyExit = new Promise<never>((_resolve, reject) => {
-    const onError = (error: Error) => reject(error)
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      reject(new Error(`Packaged app exited before probe file was written: ${signal || code}`))
-    }
-    child.once('error', onError)
-    child.once('exit', onExit)
-    clearEarlyExit = () => {
-      child.off('error', onError)
-      child.off('exit', onExit)
-    }
-  })
+  const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
 
   try {
-    return await Promise.race([
-      waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000),
-      earlyExit,
-    ])
+    await runCommand('open', ['-n', '-g', '-j', ...envArgs, macAppBundlePath])
+    return await waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000)
   } finally {
-    clearEarlyExit()
-    await stopSpawnedSmokeProcess(child)
     await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
     await delay(1_000)
   }

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -11,7 +11,7 @@ import {
   type ElectronApplication,
   type Page,
 } from 'playwright-core'
-import { buildE2EArgEnvironment } from '../src/main/e2e-remote-debugging.ts'
+import { buildE2EArgEnvironment, E2E_ARG_ENV_ENABLE_KEY } from '../src/main/e2e-remote-debugging.ts'
 
 // Shared bootstrap for every Electron smoke test: launches the packaged
 // renderer bundle against an isolated HOME + XDG dirs so tests never
@@ -482,16 +482,23 @@ export async function launchPackagedMacProbe(
   const readyFile = join(paths.tempRoot, `packaged-mac-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`)
   const launchEnvironment = {
     ...getLaunchServicesEnvironment(paths),
+    [E2E_ARG_ENV_ENABLE_KEY]: '1',
     OPEN_COWORK_E2E_READY_FILE: readyFile,
     OPEN_COWORK_E2E_PROBE_ACTION: options?.action || 'surface',
   }
   const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
   const appArgs = buildE2EArgEnvironment(launchEnvironment)
 
+  let launchServicesMarkerSet = false
   try {
+    await runCommand('launchctl', ['setenv', E2E_ARG_ENV_ENABLE_KEY, '1'])
+    launchServicesMarkerSet = true
     await runCommand('open', ['-n', '-g', '-j', ...envArgs, macAppBundlePath, '--args', ...appArgs])
     return await waitForJsonFile<PackagedMacProbe>(readyFile, options?.timeoutMs ?? 90_000)
   } finally {
+    if (launchServicesMarkerSet) {
+      await runCommand('launchctl', ['unsetenv', E2E_ARG_ENV_ENABLE_KEY]).catch(() => {})
+    }
     await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
     await delay(1_000)
   }

--- a/tests/agent-tool-actions.test.ts
+++ b/tests/agent-tool-actions.test.ts
@@ -91,6 +91,18 @@ test('agent tool bridge requires bearer auth and returns before scheduling runti
     assert.equal(unauthorized.status, 401)
     assert.match(await unauthorized.text(), /Unauthorized agent tool request/)
 
+    const wrongSameLengthToken = token!.replace(/.$/, (last) => last === 'A' ? 'B' : 'A')
+    const wrongToken = await fetch(`${baseUrl}/preview`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${wrongSameLengthToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(draft),
+    })
+    assert.equal(wrongToken.status, 401)
+    assert.match(await wrongToken.text(), /Unauthorized agent tool request/)
+
     const preview = await fetch(`${baseUrl}/preview`, {
       method: 'POST',
       headers: {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 
@@ -115,6 +115,32 @@ test('Google OAuth state stays authenticated with expired access token but does 
 
     assert.deepEqual(auth.getAuthState(), { authenticated: true, email: 'user@example.com' })
     assert.equal(auth.getCachedAccessToken(), null)
+  })
+})
+
+test('Google OAuth tokens migrate legacy encrypted development storage to plaintext', async () => {
+  await withGoogleAuthFixture('legacy-encrypted-dev-tokens', async ({ userDataDir }) => {
+    const tokens = {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expiry_date: Date.now() + 3_600_000,
+      email: 'user@example.com',
+    }
+    mkdirSync(userDataDir, { recursive: true })
+    writeFileSync(join(userDataDir, 'google-tokens.json'), `sealed:${JSON.stringify(tokens)}`)
+
+    const auth = await importFreshAuthModule('legacy-encrypted-dev-tokens')
+    auth.setAuthSecretStorageForTests({
+      mode: 'plaintext',
+      encryptString: (value: string) => Buffer.from(`sealed:${value}`),
+      decryptString: (raw: Buffer) => raw.toString('utf-8').replace(/^sealed:/, ''),
+    })
+
+    assert.deepEqual(auth.getAuthState(), { authenticated: true, email: 'user@example.com' })
+
+    const persisted = JSON.parse(readFileSync(join(userDataDir, 'google-tokens.json'), 'utf-8'))
+    assert.deepEqual(persisted, tokens)
+    auth.setAuthSecretStorageForTests(null)
   })
 })
 

--- a/tests/custom-agent-store.test.ts
+++ b/tests/custom-agent-store.test.ts
@@ -110,3 +110,36 @@ test('custom agent store reconciles interrupted enabled-disabled file pairs', ()
   assert.equal(agent?.description, 'Disabled copy.')
   assert.equal(agent?.instructions, 'Disabled instructions.')
 }))
+
+test('custom agent store prefers disabled copies when interrupted file pairs tie', () => withTempUserData(() => {
+  assert.equal(saveCustomAgent({
+    scope: 'machine',
+    directory: null,
+    name: 'weekly-analyst',
+    description: 'Enabled copy.',
+    instructions: 'Enabled instructions.',
+    skillNames: [],
+    toolIds: [],
+    enabled: true,
+    color: 'accent',
+  }, {}), true)
+
+  const root = getMachineAgentsDir()
+  const enabledPath = join(root, 'weekly-analyst.md')
+  const disabledPath = join(root, 'weekly-analyst.disabled.md')
+  writeFileSync(disabledPath, [
+    '---',
+    'description: "Disabled copy."',
+    '---',
+    '',
+    'Disabled instructions.',
+    '',
+  ].join('\n'))
+  const sameTimestamp = new Date('2026-05-26T10:00:00.000Z')
+  utimesSync(enabledPath, sameTimestamp, sameTimestamp)
+  utimesSync(disabledPath, sameTimestamp, sameTimestamp)
+
+  const agent = listCustomAgents().find((entry) => entry.name === 'weekly-analyst')
+  assert.equal(agent?.enabled, false)
+  assert.equal(agent?.description, 'Disabled copy.')
+}))

--- a/tests/custom-agent-store.test.ts
+++ b/tests/custom-agent-store.test.ts
@@ -1,10 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { listCustomAgents, removeCustomAgent, saveCustomAgent } from '../apps/desktop/src/main/native-customizations.ts'
+import { getMachineAgentsDir } from '../apps/desktop/src/main/runtime-paths.ts'
 
 function withTempUserData<T>(fn: () => T): T {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-custom-agent-store-'))
@@ -77,4 +78,35 @@ test('custom agent store rejects invalid removal names before touching the files
   assert.throws(() => {
     removeCustomAgent({ scope: 'machine', directory: null, name: '../weekly-analyst' })
   }, /single managed file name/)
+}))
+
+test('custom agent store reconciles interrupted enabled-disabled file pairs', () => withTempUserData(() => {
+  assert.equal(saveCustomAgent({
+    scope: 'machine',
+    directory: null,
+    name: 'weekly-analyst',
+    description: 'Enabled copy.',
+    instructions: 'Enabled instructions.',
+    skillNames: [],
+    toolIds: [],
+    enabled: true,
+    color: 'accent',
+  }, {}), true)
+
+  const disabledPath = join(getMachineAgentsDir(), 'weekly-analyst.disabled.md')
+  writeFileSync(disabledPath, [
+    '---',
+    'description: "Disabled copy."',
+    '---',
+    '',
+    'Disabled instructions.',
+    '',
+  ].join('\n'))
+  const newer = new Date(Date.now() + 2_000)
+  utimesSync(disabledPath, newer, newer)
+
+  const agent = listCustomAgents().find((entry) => entry.name === 'weekly-analyst')
+  assert.equal(agent?.enabled, false)
+  assert.equal(agent?.description, 'Disabled copy.')
+  assert.equal(agent?.instructions, 'Disabled instructions.')
 }))

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  appendE2ERemoteDebuggingSwitches,
+  resolveE2ERemoteDebuggingPort,
+} from '../apps/desktop/src/main/e2e-remote-debugging.ts'
+
+test('e2e remote debugging port is ignored unless smoke mode is enabled', () => {
+  assert.equal(resolveE2ERemoteDebuggingPort({
+    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: '9222',
+  }), null)
+})
+
+test('e2e remote debugging port must be a valid TCP port', () => {
+  assert.equal(resolveE2ERemoteDebuggingPort({
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: '0',
+  }), null)
+  assert.equal(resolveE2ERemoteDebuggingPort({
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: '65536',
+  }), null)
+  assert.equal(resolveE2ERemoteDebuggingPort({
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: '9222',
+  }), '9222')
+})
+
+test('e2e remote debugging appends address and port switches', () => {
+  const switches: Array<[string, string]> = []
+  const didAppend = appendE2ERemoteDebuggingSwitches({
+    commandLine: {
+      appendSwitch(name: string, value?: string) {
+        switches.push([name, value || ''])
+      },
+    },
+  }, {
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: '9333',
+  })
+
+  assert.equal(didAppend, true)
+  assert.deepEqual(switches, [
+    ['remote-debugging-address', '127.0.0.1'],
+    ['remote-debugging-port', '9333'],
+  ])
+})

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -100,6 +100,7 @@ test('e2e arg environment applies only smoke allowlisted keys', () => {
     'Open Cowork',
     ...args,
     '--open-cowork-e2e-env=HOME=%2Ftmp%2Fnot-applied',
+    '--open-cowork-e2e-env=OPEN_COWORK_E2E_READY_FILE=%',
   ], env)
 
   assert.deepEqual(env, {

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -1,8 +1,12 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   appendE2ERemoteDebuggingSwitches,
   e2eReadyFileRelativePathIsContained,
+  e2eWindowReadyProbeEnabled,
   resolveE2ERemoteDebuggingPort,
 } from '../apps/desktop/src/main/e2e-remote-debugging.ts'
 
@@ -56,4 +60,26 @@ test('e2e ready file containment rejects rooted and cross-volume relative paths'
   assert.equal(e2eReadyFileRelativePathIsContained('/tmp/ready.json'), false)
   assert.equal(e2eReadyFileRelativePathIsContained('\\tmp\\ready.json'), false)
   assert.equal(e2eReadyFileRelativePathIsContained('D:\\tmp\\ready.json'), false)
+})
+
+test('e2e window ready probe is enabled only for contained smoke files', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'open-cowork-e2e-probe-'))
+  try {
+    assert.equal(e2eWindowReadyProbeEnabled({
+      OPEN_COWORK_E2E: '1',
+      TMPDIR: tempRoot,
+      OPEN_COWORK_E2E_READY_FILE: join(tempRoot, 'probe.json'),
+    }), true)
+    assert.equal(e2eWindowReadyProbeEnabled({
+      OPEN_COWORK_E2E: '1',
+      TMPDIR: tempRoot,
+      OPEN_COWORK_E2E_READY_FILE: join(tempRoot, '..', 'probe.json'),
+    }), false)
+    assert.equal(e2eWindowReadyProbeEnabled({
+      TMPDIR: tempRoot,
+      OPEN_COWORK_E2E_READY_FILE: join(tempRoot, 'probe.json'),
+    }), false)
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
 })

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   appendE2ERemoteDebuggingSwitches,
+  applyE2EArgEnvironment,
+  buildE2EArgEnvironment,
   e2eReadyFileRelativePathIsContained,
   e2eWindowReadyProbeEnabled,
   resolveE2ERemoteDebuggingPort,
@@ -82,4 +84,27 @@ test('e2e window ready probe is enabled only for contained smoke files', () => {
   } finally {
     rmSync(tempRoot, { recursive: true, force: true })
   }
+})
+
+test('e2e arg environment applies only smoke allowlisted keys', () => {
+  const args = buildE2EArgEnvironment({
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
+    OPEN_COWORK_CONFIG_PATH: '/tmp/open-cowork/config.json',
+    HOME: '/tmp/should-not-apply',
+  })
+  assert.equal(args.length, 3)
+
+  const env: NodeJS.ProcessEnv = {}
+  applyE2EArgEnvironment([
+    'Open Cowork',
+    ...args,
+    '--open-cowork-e2e-env=HOME=%2Ftmp%2Fnot-applied',
+  ], env)
+
+  assert.deepEqual(env, {
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
+    OPEN_COWORK_CONFIG_PATH: '/tmp/open-cowork/config.json',
+  })
 })

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -7,7 +7,6 @@ import {
   appendE2ERemoteDebuggingSwitches,
   applyE2EArgEnvironment,
   buildE2EArgEnvironment,
-  E2E_ARG_ENV_ENABLE_ARG,
   E2E_ARG_ENV_ENABLE_KEY,
   e2eReadyFileRelativePathIsContained,
   e2eWindowReadyProbeEnabled,
@@ -115,21 +114,6 @@ test('e2e arg environment applies only smoke allowlisted keys', () => {
   })
 })
 
-test('e2e arg environment can be enabled with a smoke command-line marker', () => {
-  const args = buildE2EArgEnvironment({
-    OPEN_COWORK_E2E: '1',
-    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
-  })
-  const env: NodeJS.ProcessEnv = {}
-
-  applyE2EArgEnvironment(['Open Cowork', E2E_ARG_ENV_ENABLE_ARG, ...args], env)
-
-  assert.deepEqual(env, {
-    OPEN_COWORK_E2E: '1',
-    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
-  })
-})
-
 test('e2e arg environment is ignored without the trusted smoke marker', () => {
   const args = buildE2EArgEnvironment({
     OPEN_COWORK_E2E: '1',
@@ -137,7 +121,11 @@ test('e2e arg environment is ignored without the trusted smoke marker', () => {
   })
   const env: NodeJS.ProcessEnv = {}
 
-  applyE2EArgEnvironment(['Open Cowork', ...args], env)
+  applyE2EArgEnvironment([
+    'Open Cowork',
+    '--open-cowork-e2e-arg-env=1',
+    ...args,
+  ], env)
 
   assert.deepEqual(env, {})
 })

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   appendE2ERemoteDebuggingSwitches,
+  e2eReadyFileRelativePathIsContained,
   resolveE2ERemoteDebuggingPort,
 } from '../apps/desktop/src/main/e2e-remote-debugging.ts'
 
@@ -44,4 +45,15 @@ test('e2e remote debugging appends address and port switches', () => {
     ['remote-debugging-address', '127.0.0.1'],
     ['remote-debugging-port', '9333'],
   ])
+})
+
+test('e2e ready file containment rejects rooted and cross-volume relative paths', () => {
+  assert.equal(e2eReadyFileRelativePathIsContained('probe/ready.json'), true)
+  assert.equal(e2eReadyFileRelativePathIsContained('probe\\ready.json'), true)
+  assert.equal(e2eReadyFileRelativePathIsContained(''), false)
+  assert.equal(e2eReadyFileRelativePathIsContained('../ready.json'), false)
+  assert.equal(e2eReadyFileRelativePathIsContained('..\\ready.json'), false)
+  assert.equal(e2eReadyFileRelativePathIsContained('/tmp/ready.json'), false)
+  assert.equal(e2eReadyFileRelativePathIsContained('\\tmp\\ready.json'), false)
+  assert.equal(e2eReadyFileRelativePathIsContained('D:\\tmp\\ready.json'), false)
 })

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -7,6 +7,7 @@ import {
   appendE2ERemoteDebuggingSwitches,
   applyE2EArgEnvironment,
   buildE2EArgEnvironment,
+  E2E_ARG_ENV_ENABLE_ARG,
   E2E_ARG_ENV_ENABLE_KEY,
   e2eReadyFileRelativePathIsContained,
   e2eWindowReadyProbeEnabled,
@@ -92,9 +93,10 @@ test('e2e arg environment applies only smoke allowlisted keys', () => {
     OPEN_COWORK_E2E: '1',
     OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
     OPEN_COWORK_CONFIG_PATH: '/tmp/open-cowork/config.json',
-    HOME: '/tmp/should-not-apply',
+    HOME: '/tmp/open-cowork-home',
+    PATH: '/tmp/should-not-apply',
   })
-  assert.equal(args.length, 3)
+  assert.equal(args.length, 4)
 
   const env: NodeJS.ProcessEnv = { [E2E_ARG_ENV_ENABLE_KEY]: '1' }
   applyE2EArgEnvironment([
@@ -109,6 +111,22 @@ test('e2e arg environment applies only smoke allowlisted keys', () => {
     OPEN_COWORK_E2E: '1',
     OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
     OPEN_COWORK_CONFIG_PATH: '/tmp/open-cowork/config.json',
+    HOME: '/tmp/open-cowork-home',
+  })
+})
+
+test('e2e arg environment can be enabled with a smoke command-line marker', () => {
+  const args = buildE2EArgEnvironment({
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
+  })
+  const env: NodeJS.ProcessEnv = {}
+
+  applyE2EArgEnvironment(['Open Cowork', E2E_ARG_ENV_ENABLE_ARG, ...args], env)
+
+  assert.deepEqual(env, {
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
   })
 })
 

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -7,6 +7,7 @@ import {
   appendE2ERemoteDebuggingSwitches,
   applyE2EArgEnvironment,
   buildE2EArgEnvironment,
+  E2E_ARG_ENV_ENABLE_KEY,
   e2eReadyFileRelativePathIsContained,
   e2eWindowReadyProbeEnabled,
   resolveE2ERemoteDebuggingPort,
@@ -95,7 +96,7 @@ test('e2e arg environment applies only smoke allowlisted keys', () => {
   })
   assert.equal(args.length, 3)
 
-  const env: NodeJS.ProcessEnv = {}
+  const env: NodeJS.ProcessEnv = { [E2E_ARG_ENV_ENABLE_KEY]: '1' }
   applyE2EArgEnvironment([
     'Open Cowork',
     ...args,
@@ -104,8 +105,21 @@ test('e2e arg environment applies only smoke allowlisted keys', () => {
   ], env)
 
   assert.deepEqual(env, {
+    [E2E_ARG_ENV_ENABLE_KEY]: '1',
     OPEN_COWORK_E2E: '1',
     OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
     OPEN_COWORK_CONFIG_PATH: '/tmp/open-cowork/config.json',
   })
+})
+
+test('e2e arg environment is ignored without the trusted smoke marker', () => {
+  const args = buildE2EArgEnvironment({
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: '9333',
+  })
+  const env: NodeJS.ProcessEnv = {}
+
+  applyE2EArgEnvironment(['Open Cowork', ...args], env)
+
+  assert.deepEqual(env, {})
 })

--- a/tests/fs-atomic.test.ts
+++ b/tests/fs-atomic.test.ts
@@ -33,6 +33,16 @@ test('writeFileAtomic replaces an existing file in place', () => withTempDir((di
   assert.equal(readFileSync(target, 'utf-8'), 'new-content')
 }))
 
+test('writeFileAtomic applies requested perms when replacing an existing file', () => withTempDir((dir) => {
+  const target = join(dir, 'settings.enc')
+  writeFileSync(target, 'old-content', { mode: 0o644 })
+  writeFileAtomic(target, 'new-content', { mode: 0o600 })
+  assert.equal(readFileSync(target, 'utf-8'), 'new-content')
+  if (process.platform !== 'win32') {
+    assert.equal(statSync(target).mode & 0o777, 0o600)
+  }
+}))
+
 test('writeFileAtomic does not leave temp files behind after a successful write', () => withTempDir((dir) => {
   const target = join(dir, 'settings.enc')
   writeFileAtomic(target, 'ok')

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -9,9 +9,10 @@ import { registerAppHandlers, resolveSafeSaveTextPath, saveTextExportFile } from
 import { registerArtifactHandlers } from '../apps/desktop/src/main/ipc/artifact-handlers.ts'
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
-import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
+import { normalizeFindTextPattern, registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
 import { registerWorkflowHandlers } from '../apps/desktop/src/main/ipc/workflow-handlers.ts'
 import { registerCatalogHandlers } from '../apps/desktop/src/main/ipc/catalog-handlers.ts'
+import { sniffImageMime } from '../apps/desktop/src/main/ipc/app-handler-support.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
@@ -462,6 +463,14 @@ test('settings:set rejects non-object payloads before saving settings', async ()
   )
 })
 
+test('sniffImageMime accepts only image magic bytes', () => {
+  assert.equal(sniffImageMime(Buffer.from('89504e470d0a1a0a0000', 'hex')), 'image/png')
+  assert.equal(sniffImageMime(Buffer.from('ffd8ffe000104a464946', 'hex')), 'image/jpeg')
+  assert.equal(sniffImageMime(Buffer.from('4749463839610000', 'hex')), 'image/gif')
+  assert.equal(sniffImageMime(Buffer.from('524946460000000057454250', 'hex')), 'image/webp')
+  assert.equal(sniffImageMime(Buffer.from('not really an image')), null)
+})
+
 test('custom content write handlers reject malformed objects before save paths', async () => {
   const { context, handlers } = createBaseContext()
   let confirmed = false
@@ -502,6 +511,13 @@ test('explorer:file-read returns null for ungranted renderer-supplied directorie
   assert.equal(result, null)
   assert.match(errors[0] || '', /explorer:directory/)
   assert.match(errors[0] || '', /native directory picker/)
+})
+
+test('explorer find-text pattern validation caps costly regex input', () => {
+  assert.equal(normalizeFindTextPattern('  TODO  '), 'TODO')
+  assert.equal(normalizeFindTextPattern('   '), null)
+  assert.throws(() => normalizeFindTextPattern('x'.repeat(513)), /exceeds 512 bytes/)
+  assert.throws(() => normalizeFindTextPattern('(a+)+$'), /nested quantifier/)
 })
 
 test('artifact:read-attachment rejects private files that were not surfaced by the session', async () => {

--- a/tests/secure-storage-policy.test.ts
+++ b/tests/secure-storage-policy.test.ts
@@ -2,12 +2,35 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { resolveSecretStorageMode } from '../apps/desktop/src/main/secure-storage-policy.ts'
 
-test('resolveSecretStorageMode prefers encrypted storage whenever safeStorage is available', () => {
+test('resolveSecretStorageMode prefers encrypted storage whenever protective safeStorage is available', () => {
   assert.equal(resolveSecretStorageMode({ isPackaged: false, encryptionAvailable: true }), 'encrypted')
   assert.equal(resolveSecretStorageMode({ isPackaged: true, encryptionAvailable: true }), 'encrypted')
+  assert.equal(resolveSecretStorageMode({
+    isPackaged: true,
+    encryptionAvailable: true,
+    selectedStorageBackend: 'gnome_libsecret',
+  }), 'encrypted')
+  assert.equal(resolveSecretStorageMode({
+    isPackaged: true,
+    encryptionAvailable: true,
+    selectedStorageBackend: 'kwallet',
+  }), 'encrypted')
 })
 
 test('resolveSecretStorageMode only allows plaintext secret storage in development', () => {
   assert.equal(resolveSecretStorageMode({ isPackaged: false, encryptionAvailable: false }), 'plaintext')
   assert.equal(resolveSecretStorageMode({ isPackaged: true, encryptionAvailable: false }), 'unavailable')
+})
+
+test('resolveSecretStorageMode treats Linux basic_text as non-protective', () => {
+  assert.equal(resolveSecretStorageMode({
+    isPackaged: false,
+    encryptionAvailable: true,
+    selectedStorageBackend: 'basic_text',
+  }), 'plaintext')
+  assert.equal(resolveSecretStorageMode({
+    isPackaged: true,
+    encryptionAvailable: true,
+    selectedStorageBackend: 'basic_text',
+  }), 'unavailable')
 })

--- a/tests/secure-storage-policy.test.ts
+++ b/tests/secure-storage-policy.test.ts
@@ -1,6 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { resolveSecretStorageMode } from '../apps/desktop/src/main/secure-storage-policy.ts'
+import {
+  readSafeStorageBackendForPolicy,
+  resolveSecretStorageMode,
+} from '../apps/desktop/src/main/secure-storage-policy.ts'
 
 test('resolveSecretStorageMode prefers encrypted storage whenever protective safeStorage is available', () => {
   assert.equal(resolveSecretStorageMode({ isPackaged: false, encryptionAvailable: true }), 'encrypted')
@@ -33,4 +36,24 @@ test('resolveSecretStorageMode treats Linux basic_text as non-protective', () =>
     encryptionAvailable: true,
     selectedStorageBackend: 'basic_text',
   }), 'unavailable')
+})
+
+test('readSafeStorageBackendForPolicy probes only Linux safeStorage backends', () => {
+  let calls = 0
+  const readBackend = () => {
+    calls += 1
+    return 'basic_text'
+  }
+
+  assert.equal(readSafeStorageBackendForPolicy(readBackend, 'darwin'), null)
+  assert.equal(readSafeStorageBackendForPolicy(readBackend, 'win32'), null)
+  assert.equal(calls, 0)
+  assert.equal(readSafeStorageBackendForPolicy(readBackend, 'linux'), 'basic_text')
+  assert.equal(calls, 1)
+})
+
+test('readSafeStorageBackendForPolicy fails closed when backend probing throws', () => {
+  assert.equal(readSafeStorageBackendForPolicy(() => {
+    throw new Error('backend unavailable')
+  }, 'linux'), null)
 })

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -384,6 +384,78 @@ test('history projector binds task tool metadata session ids exactly once', asyn
   )
 })
 
+test('history projector binds parallel task tools to same-turn child sessions by order', async () => {
+  const childIds = ['child-parallel-a', 'child-parallel-b']
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-parallel',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-parallel-task-msg', role: 'assistant', time: { created: 10 } },
+      parts: [
+        {
+          id: 'root-parallel-task-a',
+          type: 'tool',
+          tool: 'task',
+          callID: 'parallel-task-call-a',
+          state: {
+            status: 'completed',
+            input: { agent: 'analyst', description: 'Analyze churn' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+        {
+          id: 'root-parallel-task-b',
+          type: 'tool',
+          tool: 'task',
+          callID: 'parallel-task-call-b',
+          state: {
+            status: 'completed',
+            input: { agent: 'research', description: 'Research market' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+      ],
+    }],
+    rootTodos: [],
+    children: childIds.map((childId, index) => ({
+      id: childId,
+      title: `Parallel child ${index + 1}`,
+      parentSessionId: 'root-task-tool-parallel',
+      time: { created: 11 + index, updated: 20 + index },
+    })),
+    statuses: {
+      'root-task-tool-parallel': { type: 'idle' },
+      'child-parallel-a': { type: 'idle' },
+      'child-parallel-b': { type: 'idle' },
+    },
+    loadChildSnapshot: async (childId) => ({
+      messages: [{
+        info: { id: `${childId}-msg`, role: 'assistant', time: { created: 30 } },
+        parts: [
+          { id: `${childId}-text`, type: 'text', text: `${childId} result` },
+          { id: `${childId}-finish`, type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const taskRuns = items.filter((item) => item.type === 'task_run')
+  assert.equal(taskRuns.some((item) => item.id.startsWith('pending:')), false)
+  assert.deepEqual(
+    taskRuns.map((item) => item.taskRun?.sourceSessionId),
+    childIds,
+  )
+  assert.deepEqual(
+    taskRuns.map((item) => item.taskRun?.title),
+    ['Analyze churn', 'Research market'],
+  )
+  assert.equal(items.find((item) => item.content === 'child-parallel-a result')?.taskRunId, 'child:child-parallel-a')
+  assert.equal(items.find((item) => item.content === 'child-parallel-b result')?.taskRunId, 'child:child-parallel-b')
+})
+
 test('history projector does not bind a terminal task tool to a later unrelated child session', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-unrelated-child',
@@ -788,6 +860,110 @@ test('history projector binds nested task tools to grandchild sessions during re
   assert.ok(before.sequence < nestedRun.sequence)
   assert.ok(nestedRun.sequence < after.sequence)
   assert.equal(nestedText.taskRunId, 'child:grandchild-nested-task')
+})
+
+test('history projector binds nested parallel task tools to grandchildren by order', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-nested-parallel-task-tool',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-nested-parallel-msg', role: 'assistant', time: { created: 1 } },
+      parts: [
+        { id: 'root-nested-parallel-subtask', type: 'subtask', agent: 'research', description: 'Coordinate nested parallel work' },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-nested-parallel-parent',
+        title: 'Coordinate nested parallel work (@research subagent)',
+        parentSessionId: 'root-nested-parallel-task-tool',
+        time: { created: 2, updated: 8 },
+      },
+      {
+        id: 'grandchild-nested-parallel-a',
+        title: 'Nested parallel A (@analyst subagent)',
+        parentSessionId: 'child-nested-parallel-parent',
+        time: { created: 4, updated: 7 },
+      },
+      {
+        id: 'grandchild-nested-parallel-b',
+        title: 'Nested parallel B (@writer subagent)',
+        parentSessionId: 'child-nested-parallel-parent',
+        time: { created: 5, updated: 8 },
+      },
+    ],
+    statuses: {
+      'root-nested-parallel-task-tool': { type: 'idle' },
+      'child-nested-parallel-parent': { type: 'idle' },
+      'grandchild-nested-parallel-a': { type: 'idle' },
+      'grandchild-nested-parallel-b': { type: 'idle' },
+    },
+    loadChildSnapshot: async (childId) => {
+      if (childId === 'child-nested-parallel-parent') {
+        return {
+          messages: [{
+            info: { id: 'child-nested-parallel-parent-msg', role: 'assistant', time: { created: 3 } },
+            parts: [
+              {
+                id: 'child-nested-parallel-task-a',
+                type: 'tool',
+                tool: 'task',
+                callID: 'nested-parallel-call-a',
+                state: {
+                  status: 'completed',
+                  input: { agent: 'analyst', description: 'Nested parallel A' },
+                  output: 'started',
+                  metadata: {},
+                },
+              },
+              {
+                id: 'child-nested-parallel-task-b',
+                type: 'tool',
+                tool: 'task',
+                callID: 'nested-parallel-call-b',
+                state: {
+                  status: 'completed',
+                  input: { agent: 'writer', description: 'Nested parallel B' },
+                  output: 'started',
+                  metadata: {},
+                },
+              },
+              { id: 'child-nested-parallel-finish', type: 'step-finish', reason: 'stop' },
+            ],
+          }],
+          todos: [],
+        }
+      }
+
+      return {
+        messages: [{
+          info: { id: `${childId}-msg`, role: 'assistant', time: { created: 6 } },
+          parts: [
+            { id: `${childId}-text`, type: 'text', text: `${childId} result` },
+            { id: `${childId}-finish`, type: 'step-finish', reason: 'stop' },
+          ],
+        }],
+        todos: [],
+      }
+    },
+  })
+
+  const nestedTaskRuns = items
+    .filter((item) => item.type === 'task_run')
+    .map((item) => item.taskRun)
+    .filter((taskRun) => taskRun?.parentSessionId === 'child-nested-parallel-parent')
+
+  assert.deepEqual(
+    nestedTaskRuns.map((taskRun) => taskRun?.sourceSessionId),
+    ['grandchild-nested-parallel-a', 'grandchild-nested-parallel-b'],
+  )
+  assert.deepEqual(
+    nestedTaskRuns.map((taskRun) => taskRun?.title),
+    ['Nested parallel A', 'Nested parallel B'],
+  )
+  assert.equal(items.find((item) => item.content === 'grandchild-nested-parallel-a result')?.taskRunId, 'child:grandchild-nested-parallel-a')
+  assert.equal(items.find((item) => item.content === 'grandchild-nested-parallel-b result')?.taskRunId, 'child:grandchild-nested-parallel-b')
 })
 
 test('history projector preserves nested child parentage when replaying reopened threads', async () => {

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -1032,6 +1032,60 @@ test('history projector treats untimed later delegations as task-tool binding bo
   assert.equal(childTask.title, 'Later untimed delegation')
 })
 
+test('history projector does not bind bounded task tools to untimed later children', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-bounded-untimed-child',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-bounded-task-msg', role: 'assistant', time: { created: 10 } },
+        parts: [{
+          id: 'root-bounded-task-tool',
+          type: 'tool',
+          tool: 'task',
+          callID: 'bounded-task-call',
+          state: {
+            status: 'completed',
+            input: {
+              agent: 'analyst',
+              description: 'Earlier bounded task tool',
+            },
+            output: 'started',
+            metadata: {},
+          },
+        }],
+      },
+      {
+        info: { id: 'root-later-timed-subtask-msg', role: 'assistant', time: { created: 20 } },
+        parts: [
+          { id: 'root-later-timed-subtask', type: 'subtask', agent: 'research', description: 'Later timed delegation' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [{
+      id: 'child-later-untimed',
+      title: 'Later timed delegation (@research subagent)',
+      parentSessionId: 'root-bounded-untimed-child',
+    }],
+    statuses: {
+      'root-bounded-untimed-child': { type: 'idle' },
+      'child-later-untimed': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const pendingTask = items.find((item) => item.id === 'pending:bounded-task-call')?.taskRun
+  const childTask = items.find((item) => item.id === 'child:child-later-untimed')?.taskRun
+
+  assert.ok(pendingTask)
+  assert.equal(pendingTask.sourceSessionId, null)
+  assert.equal(pendingTask.title, 'Earlier bounded task tool')
+  assert.ok(childTask)
+  assert.equal(childTask.sourceSessionId, 'child-later-untimed')
+  assert.equal(childTask.title, 'Later timed delegation')
+})
+
 test('history projector binds task tools when the root message has no created timestamp', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-missing-time',

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -522,6 +522,63 @@ test('history projector does not bind task tools by fuzzy child title matches', 
   assert.equal(targetTask.title, 'Target market analysis')
 })
 
+test('history projector does not bind task tools across same-timestamp delegation boundaries', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-same-timestamp-boundary',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-first-task-msg', role: 'assistant', time: { created: 20 } },
+        parts: [
+          {
+            id: 'root-first-task-part',
+            type: 'tool',
+            tool: 'task',
+            callID: 'first-task-call',
+            state: {
+              status: 'completed',
+              input: {
+                agent: 'analyst',
+                description: 'Earlier same timestamp delegation',
+              },
+              output: 'done',
+              metadata: {},
+            },
+          },
+        ],
+      },
+      {
+        info: { id: 'root-second-subtask-msg', role: 'assistant', time: { created: 20 } },
+        parts: [
+          { id: 'root-second-subtask', type: 'subtask', agent: 'research', description: 'Later same timestamp delegation' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [{
+      id: 'child-later-same-timestamp',
+      title: 'Later same timestamp delegation (@research subagent)',
+      parentSessionId: 'root-same-timestamp-boundary',
+      time: { created: 21, updated: 24 },
+    }],
+    statuses: {
+      'root-same-timestamp-boundary': { type: 'idle' },
+      'child-later-same-timestamp': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const pendingTask = items.find((item) => item.id === 'pending:first-task-call')?.taskRun
+  const childTask = items.find((item) => item.id === 'child:child-later-same-timestamp')?.taskRun
+
+  assert.ok(pendingTask)
+  assert.equal(pendingTask.sourceSessionId, null)
+  assert.equal(pendingTask.title, 'Earlier same timestamp delegation')
+  assert.ok(childTask)
+  assert.equal(childTask.sourceSessionId, 'child-later-same-timestamp')
+  assert.equal(childTask.title, 'Later same timestamp delegation')
+})
+
 test('history projector preserves root message part order around task tools', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-order',

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -719,6 +719,63 @@ test('history projector does not bind task tools across same-timestamp delegatio
   assert.equal(childTask.title, 'Later same timestamp delegation')
 })
 
+test('history projector treats untimed later delegations as task-tool binding boundaries', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-untimed-boundary',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-earlier-task-msg', role: 'assistant', time: { created: 10 } },
+        parts: [
+          {
+            id: 'root-earlier-task-part',
+            type: 'tool',
+            tool: 'task',
+            callID: 'earlier-task-call',
+            state: {
+              status: 'completed',
+              input: {
+                agent: 'analyst',
+                description: 'Earlier timed task tool',
+              },
+              output: 'done',
+              metadata: {},
+            },
+          },
+        ],
+      },
+      {
+        info: { id: 'root-later-untimed-subtask-msg', role: 'assistant' },
+        parts: [
+          { id: 'root-later-untimed-subtask', type: 'subtask', agent: 'research', description: 'Later untimed delegation' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [{
+      id: 'child-later-untimed-boundary',
+      title: 'Later untimed delegation (@research subagent)',
+      parentSessionId: 'root-untimed-boundary',
+      time: { created: 11, updated: 14 },
+    }],
+    statuses: {
+      'root-untimed-boundary': { type: 'idle' },
+      'child-later-untimed-boundary': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const pendingTask = items.find((item) => item.id === 'pending:earlier-task-call')?.taskRun
+  const childTask = items.find((item) => item.id === 'child:child-later-untimed-boundary')?.taskRun
+
+  assert.ok(pendingTask)
+  assert.equal(pendingTask.sourceSessionId, null)
+  assert.equal(pendingTask.title, 'Earlier timed task tool')
+  assert.ok(childTask)
+  assert.equal(childTask.sourceSessionId, 'child-later-untimed-boundary')
+  assert.equal(childTask.title, 'Later untimed delegation')
+})
+
 test('history projector binds task tools when the root message has no created timestamp', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-missing-time',

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -1032,6 +1032,71 @@ test('history projector treats untimed later delegations as task-tool binding bo
   assert.equal(childTask.title, 'Later untimed delegation')
 })
 
+test('history projector binds earlier timed child before an untimed later delegation when another child remains', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-untimed-boundary-with-extra-child',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-extra-earlier-task-msg', role: 'assistant', time: { created: 10 } },
+        parts: [
+          {
+            id: 'root-extra-earlier-task-part',
+            type: 'tool',
+            tool: 'task',
+            callID: 'extra-earlier-task-call',
+            state: {
+              status: 'completed',
+              input: {
+                agent: 'analyst',
+                description: 'Earlier timestamped task tool',
+              },
+              output: 'done',
+              metadata: {},
+            },
+          },
+        ],
+      },
+      {
+        info: { id: 'root-extra-later-untimed-subtask-msg', role: 'assistant' },
+        parts: [
+          { id: 'root-extra-later-untimed-subtask', type: 'subtask', agent: 'research', description: 'Later untimed delegation with remaining child' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-extra-later-untimed',
+        title: 'Later untimed delegation with remaining child (@research subagent)',
+        parentSessionId: 'root-untimed-boundary-with-extra-child',
+      },
+      {
+        id: 'child-extra-earlier-timed',
+        title: 'Earlier timestamped task tool (@analyst subagent)',
+        parentSessionId: 'root-untimed-boundary-with-extra-child',
+        time: { created: 11, updated: 14 },
+      },
+    ],
+    statuses: {
+      'root-untimed-boundary-with-extra-child': { type: 'idle' },
+      'child-extra-earlier-timed': { type: 'idle' },
+      'child-extra-later-untimed': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const earlierTask = items.find((item) => item.id === 'child:child-extra-earlier-timed')?.taskRun
+  const laterTask = items.find((item) => item.id === 'child:child-extra-later-untimed')?.taskRun
+
+  assert.ok(earlierTask)
+  assert.equal(earlierTask.sourceSessionId, 'child-extra-earlier-timed')
+  assert.equal(earlierTask.title, 'Earlier timestamped task tool')
+  assert.ok(laterTask)
+  assert.equal(laterTask.sourceSessionId, 'child-extra-later-untimed')
+  assert.equal(laterTask.title, 'Later untimed delegation with remaining child')
+})
+
 test('history projector does not bind bounded task tools to untimed later children', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-bounded-untimed-child',

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -323,6 +323,69 @@ test('history projector anchors root task tool runs before the parent follow-up 
   assert.ok(taskRun.sequence < (finalMessage?.sequence || 0))
 })
 
+test('history projector preserves task-tool binding before later subtask parts', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-mixed-delegation',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-mixed-msg', role: 'assistant', time: { created: 10 } },
+      parts: [
+        {
+          id: 'root-mixed-task-tool',
+          type: 'tool',
+          tool: 'task',
+          callID: 'mixed-task-call',
+          state: {
+            status: 'completed',
+            input: {
+              agent: 'analyst',
+              description: 'Analyze first child',
+            },
+            output: 'done',
+            metadata: {},
+          },
+        },
+        { id: 'root-mixed-subtask', type: 'subtask', agent: 'research', description: 'Research second child' },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      { id: 'child-first', title: 'First delegated child', parentSessionId: 'root-mixed-delegation', time: { created: 20, updated: 25 } },
+      { id: 'child-second', title: 'Second delegated child', parentSessionId: 'root-mixed-delegation', time: { created: 21, updated: 26 } },
+    ],
+    statuses: {
+      'root-mixed-delegation': { type: 'idle' },
+      'child-first': { type: 'idle' },
+      'child-second': { type: 'idle' },
+    },
+    loadChildSnapshot: async (childId) => ({
+      messages: [{
+        info: { id: `${childId}-msg`, role: 'assistant', time: { created: childId === 'child-first' ? 22 : 23 } },
+        parts: [
+          { id: `${childId}-text`, type: 'text', text: `${childId} result` },
+          { id: `${childId}-finish`, type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const taskRuns = items
+    .filter((item) => item.type === 'task_run')
+    .map((item) => item.taskRun)
+    .filter(Boolean)
+
+  assert.deepEqual(
+    taskRuns.map((taskRun) => ({ source: taskRun?.sourceSessionId, title: taskRun?.title })),
+    [
+      { source: 'child-first', title: 'Analyze first child' },
+      { source: 'child-second', title: 'Research second child' },
+    ],
+  )
+  assert.equal(items.find((item) => item.content === 'child-first result')?.taskRunId, 'child:child-first')
+  assert.equal(items.find((item) => item.content === 'child-second result')?.taskRunId, 'child:child-second')
+})
+
 test('history projector binds task tool metadata session ids exactly once', async () => {
   const childIds = ['child-a', 'child-b', 'child-c']
   const items = await projectSessionHistory({

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -456,6 +456,74 @@ test('history projector binds parallel task tools to same-turn child sessions by
   assert.equal(items.find((item) => item.content === 'child-parallel-b result')?.taskRunId, 'child:child-parallel-b')
 })
 
+test('history projector reserves explicit task-tool children when binding implicit task tools', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-mixed-explicit',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-mixed-task-msg', role: 'assistant', time: { created: 10 } },
+      parts: [
+        {
+          id: 'root-mixed-implicit-task',
+          type: 'tool',
+          tool: 'task',
+          callID: 'mixed-implicit-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'analyst', description: 'Implicit child work' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+        {
+          id: 'root-mixed-explicit-task',
+          type: 'tool',
+          tool: 'task',
+          callID: 'mixed-explicit-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'research', description: 'Explicit child work' },
+            output: 'started',
+            metadata: { sessionId: 'child-mixed-explicit' },
+          },
+        },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-mixed-implicit',
+        title: 'Implicit child work (@analyst subagent)',
+        parentSessionId: 'root-task-tool-mixed-explicit',
+        time: { created: 11, updated: 20 },
+      },
+      {
+        id: 'child-mixed-explicit',
+        title: 'Explicit child work (@research subagent)',
+        parentSessionId: 'root-task-tool-mixed-explicit',
+        time: { created: 12, updated: 21 },
+      },
+    ],
+    statuses: {
+      'root-task-tool-mixed-explicit': { type: 'idle' },
+      'child-mixed-implicit': { type: 'idle' },
+      'child-mixed-explicit': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const taskRuns = items.filter((item) => item.type === 'task_run')
+  assert.equal(taskRuns.some((item) => item.id.startsWith('pending:')), false)
+  assert.deepEqual(
+    taskRuns.map((item) => item.taskRun?.sourceSessionId),
+    ['child-mixed-implicit', 'child-mixed-explicit'],
+  )
+  assert.deepEqual(
+    taskRuns.map((item) => item.taskRun?.title),
+    ['Implicit child work', 'Explicit child work'],
+  )
+})
+
 test('history projector does not bind a terminal task tool to a later unrelated child session', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-unrelated-child',
@@ -1006,6 +1074,99 @@ test('history projector binds nested parallel task tools to grandchildren by ord
   )
   assert.equal(items.find((item) => item.content === 'grandchild-nested-parallel-a result')?.taskRunId, 'child:grandchild-nested-parallel-a')
   assert.equal(items.find((item) => item.content === 'grandchild-nested-parallel-b result')?.taskRunId, 'child:grandchild-nested-parallel-b')
+})
+
+test('history projector reserves explicit nested task-tool grandchildren when binding implicit nested task tools', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-nested-mixed-task-tool',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-nested-mixed-msg', role: 'assistant', time: { created: 1 } },
+      parts: [
+        { id: 'root-nested-mixed-subtask', type: 'subtask', agent: 'research', description: 'Coordinate nested mixed work' },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-nested-mixed-parent',
+        title: 'Coordinate nested mixed work (@research subagent)',
+        parentSessionId: 'root-nested-mixed-task-tool',
+        time: { created: 2, updated: 8 },
+      },
+      {
+        id: 'grandchild-nested-mixed-implicit',
+        title: 'Nested implicit work (@analyst subagent)',
+        parentSessionId: 'child-nested-mixed-parent',
+        time: { created: 4, updated: 7 },
+      },
+      {
+        id: 'grandchild-nested-mixed-explicit',
+        title: 'Nested explicit work (@writer subagent)',
+        parentSessionId: 'child-nested-mixed-parent',
+        time: { created: 5, updated: 8 },
+      },
+    ],
+    statuses: {
+      'root-nested-mixed-task-tool': { type: 'idle' },
+      'child-nested-mixed-parent': { type: 'idle' },
+      'grandchild-nested-mixed-implicit': { type: 'idle' },
+      'grandchild-nested-mixed-explicit': { type: 'idle' },
+    },
+    loadChildSnapshot: async (childId) => {
+      if (childId === 'child-nested-mixed-parent') {
+        return {
+          messages: [{
+            info: { id: 'child-nested-mixed-parent-msg', role: 'assistant', time: { created: 3 } },
+            parts: [
+              {
+                id: 'child-nested-mixed-implicit-task',
+                type: 'tool',
+                tool: 'task',
+                callID: 'nested-mixed-implicit-call',
+                state: {
+                  status: 'completed',
+                  input: { agent: 'analyst', description: 'Nested implicit work' },
+                  output: 'started',
+                  metadata: {},
+                },
+              },
+              {
+                id: 'child-nested-mixed-explicit-task',
+                type: 'tool',
+                tool: 'task',
+                callID: 'nested-mixed-explicit-call',
+                state: {
+                  status: 'completed',
+                  input: { agent: 'writer', description: 'Nested explicit work' },
+                  output: 'started',
+                  metadata: { sessionId: 'grandchild-nested-mixed-explicit' },
+                },
+              },
+              { id: 'child-nested-mixed-finish', type: 'step-finish', reason: 'stop' },
+            ],
+          }],
+          todos: [],
+        }
+      }
+
+      return { messages: [], todos: [] }
+    },
+  })
+
+  const nestedTaskRuns = items
+    .filter((item) => item.type === 'task_run')
+    .map((item) => item.taskRun)
+    .filter((taskRun) => taskRun?.parentSessionId === 'child-nested-mixed-parent')
+
+  assert.deepEqual(
+    nestedTaskRuns.map((taskRun) => taskRun?.sourceSessionId),
+    ['grandchild-nested-mixed-implicit', 'grandchild-nested-mixed-explicit'],
+  )
+  assert.deepEqual(
+    nestedTaskRuns.map((taskRun) => taskRun?.title),
+    ['Nested implicit work', 'Nested explicit work'],
+  )
 })
 
 test('history projector preserves nested child parentage when replaying reopened threads', async () => {

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -651,6 +651,48 @@ test('history projector does not bind task tools across same-timestamp delegatio
   assert.equal(childTask.title, 'Later same timestamp delegation')
 })
 
+test('history projector binds task tools when the root message has no created timestamp', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-missing-time',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-missing-time-task-msg', role: 'assistant' },
+      parts: [
+        {
+          id: 'root-missing-time-task-part',
+          type: 'tool',
+          tool: 'task',
+          callID: 'missing-time-task-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'analyst', description: 'Analyze missing timestamp replay' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+      ],
+    }],
+    rootTodos: [],
+    children: [{
+      id: 'child-missing-time',
+      title: 'Analyze missing timestamp replay (@analyst subagent)',
+      parentSessionId: 'root-task-tool-missing-time',
+      time: { created: 20, updated: 30 },
+    }],
+    statuses: {
+      'root-task-tool-missing-time': { type: 'idle' },
+      'child-missing-time': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const taskRun = items.find((item) => item.type === 'task_run')?.taskRun
+
+  assert.ok(taskRun)
+  assert.equal(taskRun.sourceSessionId, 'child-missing-time')
+  assert.equal(taskRun.title, 'Analyze missing timestamp replay')
+})
+
 test('history projector preserves root message part order around task tools', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-order',

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -704,6 +704,82 @@ test('history projector preserves mixed task-tool and subtask child order in one
   )
 })
 
+test('history projector does not let a missing subtask consume a later task-tool child', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-missing-subtask-slot',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-missing-subtask-slot-msg', role: 'assistant', time: { created: 10 } },
+      parts: [
+        {
+          id: 'root-first-task-tool',
+          type: 'tool',
+          tool: 'task',
+          callID: 'first-task-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'analyst', description: 'First delegated child' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+        {
+          id: 'root-missing-subtask',
+          type: 'subtask',
+          agent: 'research',
+          description: 'Missing middle child',
+        },
+        {
+          id: 'root-later-task-tool',
+          type: 'tool',
+          tool: 'task',
+          callID: 'later-task-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'writer', description: 'Later delegated child' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-first-task-tool',
+        title: 'First delegated child (@analyst subagent)',
+        parentSessionId: 'root-task-tool-missing-subtask-slot',
+        time: { created: 11, updated: 20 },
+      },
+      {
+        id: 'child-later-task-tool',
+        title: 'Later delegated child (@writer subagent)',
+        parentSessionId: 'root-task-tool-missing-subtask-slot',
+        time: { created: 12, updated: 21 },
+      },
+    ],
+    statuses: {
+      'root-task-tool-missing-subtask-slot': { type: 'idle' },
+      'child-first-task-tool': { type: 'idle' },
+      'child-later-task-tool': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const taskRuns = items
+    .filter((item) => item.type === 'task_run')
+    .map((item) => item.taskRun)
+
+  assert.deepEqual(
+    taskRuns.map((taskRun) => taskRun?.sourceSessionId),
+    ['child-first-task-tool', null, 'child-later-task-tool'],
+  )
+  assert.deepEqual(
+    taskRuns.map((taskRun) => taskRun?.title),
+    ['First delegated child', 'Missing middle child', 'Later delegated child'],
+  )
+})
+
 test('history projector does not bind a terminal task tool to a later unrelated child session', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-unrelated-child',

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -451,7 +451,7 @@ test('history projector does not bind a terminal task tool to a later unrelated 
   assert.equal(childTask.title, 'Actual child work')
 })
 
-test('history projector scans later direct children when matching task tool sessions', async () => {
+test('history projector does not bind task tools by fuzzy child title matches', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-later-child-match',
     cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
@@ -506,15 +506,20 @@ test('history projector scans later direct children when matching task tool sess
     loadChildSnapshot: async () => ({ messages: [], todos: [] }),
   })
 
-  const targetTask = items.find((item) => item.id === 'child:child-target')?.taskRun
+  const pendingTask = items.find((item) => item.id === 'pending:task-call-target')?.taskRun
   const unrelatedTask = items.find((item) => item.id === 'child:child-unrelated')?.taskRun
+  const targetTask = items.find((item) => item.id === 'child:child-target')?.taskRun
 
-  assert.ok(targetTask)
-  assert.equal(targetTask.sourceSessionId, 'child-target')
-  assert.equal(targetTask.title, 'Target market analysis')
+  assert.ok(pendingTask)
+  assert.equal(pendingTask.sourceSessionId, null)
+  assert.equal(pendingTask.title, 'Target market analysis')
+  assert.equal(pendingTask.agent, 'analyst')
   assert.ok(unrelatedTask)
   assert.equal(unrelatedTask.sourceSessionId, 'child-unrelated')
   assert.equal(unrelatedTask.title, 'Earlier unrelated research')
+  assert.ok(targetTask)
+  assert.equal(targetTask.sourceSessionId, 'child-target')
+  assert.equal(targetTask.title, 'Target market analysis')
 })
 
 test('history projector preserves root message part order around task tools', async () => {

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -587,6 +587,123 @@ test('history projector reserves explicit task-tool children when binding implic
   )
 })
 
+test('history projector binds an implicit task tool before a later subtask when only one child is present', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-partial-mixed',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-partial-mixed-msg', role: 'assistant', time: { created: 10 } },
+      parts: [
+        {
+          id: 'root-partial-task',
+          type: 'tool',
+          tool: 'task',
+          callID: 'partial-task-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'analyst', description: 'Partial task child' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+        {
+          id: 'root-partial-subtask',
+          type: 'subtask',
+          agent: 'research',
+          description: 'Missing later child',
+        },
+      ],
+    }],
+    rootTodos: [],
+    children: [{
+      id: 'child-partial-task',
+      title: 'Partial task child (@analyst subagent)',
+      parentSessionId: 'root-task-tool-partial-mixed',
+      time: { created: 11, updated: 20 },
+    }],
+    statuses: {
+      'root-task-tool-partial-mixed': { type: 'idle' },
+      'child-partial-task': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const taskRuns = items.filter((item) => item.type === 'task_run')
+  const taskToolRun = taskRuns.find((item) => item.id === 'child:child-partial-task')?.taskRun
+  const pendingSubtask = taskRuns.find((item) => item.id === 'pending:root-partial-subtask')?.taskRun
+
+  assert.ok(taskToolRun)
+  assert.equal(taskToolRun.sourceSessionId, 'child-partial-task')
+  assert.equal(taskToolRun.title, 'Partial task child')
+  assert.ok(pendingSubtask)
+  assert.equal(pendingSubtask.sourceSessionId, null)
+  assert.equal(pendingSubtask.title, 'Missing later child')
+})
+
+test('history projector preserves mixed task-tool and subtask child order in one message', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-subtask-order',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-mixed-order-msg', role: 'assistant', time: { created: 10 } },
+      parts: [
+        {
+          id: 'root-mixed-order-task',
+          type: 'tool',
+          tool: 'task',
+          callID: 'mixed-order-task-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'analyst', description: 'First delegated child' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+        {
+          id: 'root-mixed-order-subtask',
+          type: 'subtask',
+          agent: 'research',
+          description: 'Second delegated child',
+        },
+      ],
+    }],
+    rootTodos: [],
+    children: [
+      {
+        id: 'child-mixed-order-first',
+        title: 'First delegated child (@analyst subagent)',
+        parentSessionId: 'root-task-tool-subtask-order',
+        time: { created: 11, updated: 20 },
+      },
+      {
+        id: 'child-mixed-order-second',
+        title: 'Second delegated child (@research subagent)',
+        parentSessionId: 'root-task-tool-subtask-order',
+        time: { created: 12, updated: 21 },
+      },
+    ],
+    statuses: {
+      'root-task-tool-subtask-order': { type: 'idle' },
+      'child-mixed-order-first': { type: 'idle' },
+      'child-mixed-order-second': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const taskRuns = items
+    .filter((item) => item.type === 'task_run')
+    .map((item) => item.taskRun)
+
+  assert.deepEqual(
+    taskRuns.map((taskRun) => taskRun?.sourceSessionId),
+    ['child-mixed-order-first', 'child-mixed-order-second'],
+  )
+  assert.deepEqual(
+    taskRuns.map((taskRun) => taskRun?.title),
+    ['First delegated child', 'Second delegated child'],
+  )
+})
+
 test('history projector does not bind a terminal task tool to a later unrelated child session', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-tool-unrelated-child',

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -818,6 +818,48 @@ test('history projector binds task tools when the root message has no created ti
   assert.equal(taskRun.title, 'Analyze missing timestamp replay')
 })
 
+test('history projector binds task tools to child sessions with missing created timestamps', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-task-tool-child-missing-time',
+    cachedModelId: 'openrouter/anthropic/claude-sonnet-4',
+    rootMessages: [{
+      info: { id: 'root-child-missing-time-task-msg', role: 'assistant', time: { created: 10 } },
+      parts: [
+        {
+          id: 'root-child-missing-time-task-part',
+          type: 'tool',
+          tool: 'task',
+          callID: 'child-missing-time-task-call',
+          state: {
+            status: 'completed',
+            input: { agent: 'analyst', description: 'Analyze child missing timestamp replay' },
+            output: 'started',
+            metadata: {},
+          },
+        },
+      ],
+    }],
+    rootTodos: [],
+    children: [{
+      id: 'child-without-created-time',
+      title: 'Analyze child missing timestamp replay (@analyst subagent)',
+      parentSessionId: 'root-task-tool-child-missing-time',
+      time: { updated: 30 },
+    }],
+    statuses: {
+      'root-task-tool-child-missing-time': { type: 'idle' },
+      'child-without-created-time': { type: 'idle' },
+    },
+    loadChildSnapshot: async () => ({ messages: [], todos: [] }),
+  })
+
+  const taskRun = items.find((item) => item.type === 'task_run')?.taskRun
+
+  assert.ok(taskRun)
+  assert.equal(taskRun.sourceSessionId, 'child-without-created-time')
+  assert.equal(taskRun.title, 'Analyze child missing timestamp replay')
+})
+
 test('history projector preserves root message part order around task tools', async () => {
   const items = await projectSessionHistory({
     sessionId: 'root-task-order',

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { SMALL_MODEL_USE_MAIN } from '../packages/shared/src/app-config.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
@@ -262,6 +262,55 @@ test('loadSettings rejects settings from a newer schema version', async () => {
       () => loadSettings(),
       /newer than supported/,
     )
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('loadSettings migrates legacy encrypted development settings to plaintext', async () => {
+  const tempRoot = testTempDir('opencowork-settings-legacy-encrypted-dev-')
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeEmptyConfig(configDir)
+  mkdirSync(userDataDir, { recursive: true })
+  const encryptedSettings = {
+    selectedProviderId: 'openrouter',
+    selectedModelId: 'openrouter/auto',
+    providerCredentials: {
+      openrouter: {
+        apiKey: 'provider-secret',
+      },
+    },
+  }
+  writeFileSync(join(userDataDir, 'settings.enc'), `sealed:${JSON.stringify(encryptedSettings)}`)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const settingsModule = await importFreshSettingsModule('legacy-encrypted-dev-settings')
+    settingsModule.setSettingsSecretStorageForTests({
+      mode: 'plaintext',
+      encryptString: (value: string) => Buffer.from(`sealed:${value}`),
+      decryptString: (raw: Buffer) => raw.toString('utf-8').replace(/^sealed:/, ''),
+    })
+
+    const settings = settingsModule.loadSettings()
+    assert.equal(settings.selectedProviderId, 'openrouter')
+    assert.equal(settings.providerCredentials.openrouter.apiKey, 'provider-secret')
+
+    const persisted = JSON.parse(readFileSync(join(userDataDir, 'settings.json'), 'utf-8'))
+    assert.equal(persisted.providerCredentials.openrouter.apiKey, 'provider-secret')
+    assert.equal(existsSync(join(userDataDir, 'settings.enc')), false)
+    settingsModule.setSettingsSecretStorageForTests(null)
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { DatabaseSync } from 'node:sqlite'
 import { existsSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -18,6 +19,8 @@ import {
   previewWorkflowDraft,
   regenerateWorkflowWebhookSecret,
   recoverInterruptedWorkflowRuns,
+  parseWorkflowTriggersFromStorage,
+  setWorkflowSecretStorageForTests,
   updateWorkflowStatus,
 } from '../apps/desktop/src/main/workflow/workflow-store.ts'
 
@@ -34,6 +37,7 @@ function withWorkflowStore(name: string, run: (userDataDir: string) => void) {
     clearWorkflowStoreCache()
     run(userDataDir)
   } finally {
+    setWorkflowSecretStorageForTests(null)
     clearWorkflowStoreCache()
     clearConfigCaches()
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
@@ -81,6 +85,31 @@ test('workflow store saves thread-created workflows and exposes webhook URLs', (
   assert.equal(existsSync(dbPath), true)
   if (process.platform !== 'win32') {
     assert.equal(statSync(dbPath).mode & 0o777, 0o600)
+  }
+}))
+
+test('workflow store encrypts webhook secrets at the SQLite boundary when secure storage is available', () => withWorkflowStore('secret-storage', (userDataDir) => {
+  setWorkflowSecretStorageForTests({
+    mode: 'encrypted',
+    encryptString: (value) => Buffer.from(`sealed:${value}`, 'utf8'),
+    decryptString: (value) => value.toString('utf8').replace(/^sealed:/, ''),
+  })
+
+  const workflow = createWorkflow(draft)
+  const webhookSecret = workflow.triggers.find((trigger) => trigger.type === 'webhook')?.webhookSecret
+  assert.equal(typeof webhookSecret, 'string')
+
+  const db = new DatabaseSync(join(userDataDir, 'workflows.sqlite'))
+  try {
+    const row = db.prepare('select triggers_json from workflows where id = ?').get(workflow.id) as { triggers_json?: string }
+    const raw = row.triggers_json || ''
+    assert.match(raw, /enc:v1:/)
+    assert.equal(raw.includes(webhookSecret!), false)
+
+    const parsed = parseWorkflowTriggersFromStorage(raw)
+    assert.equal(parsed.find((trigger) => trigger.type === 'webhook')?.webhookSecret, webhookSecret)
+  } finally {
+    db.close()
   }
 }))
 

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -103,7 +103,7 @@ test('workflow store encrypts webhook secrets at the SQLite boundary when secure
   try {
     const row = db.prepare('select triggers_json from workflows where id = ?').get(workflow.id) as { triggers_json?: string }
     const raw = row.triggers_json || ''
-    assert.match(raw, /enc:v1:/)
+    assert.match(raw, /__openCoworkEncryptedWebhookSecret/)
     assert.equal(raw.includes(webhookSecret!), false)
 
     const parsed = parseWorkflowTriggersFromStorage(raw)
@@ -114,11 +114,36 @@ test('workflow store encrypts webhook secrets at the SQLite boundary when secure
 }))
 
 test('workflow store preserves plaintext webhook secrets that look like encrypted sentinels', () => withWorkflowStore('plaintext-secret-prefix', () => {
-  setWorkflowSecretStorageForTests({ mode: 'plaintext' })
+  setWorkflowSecretStorageForTests({
+    mode: 'encrypted',
+    encryptString: (value) => Buffer.from(`sealed:${value}`, 'utf8'),
+    decryptString: () => {
+      throw new Error('not ciphertext')
+    },
+  })
 
   const rawSecret = 'enc:v1:user-supplied-secret'
   const parsed = parseWorkflowTriggersFromStorage(JSON.stringify([
     { id: 'webhook', type: 'webhook', enabled: true, webhookSecret: rawSecret },
+  ]))
+
+  assert.equal(parsed[0]?.webhookSecret, rawSecret)
+}))
+
+test('workflow store decrypts legacy prefixed webhook secrets in plaintext mode when possible', () => withWorkflowStore('legacy-secret-prefix', () => {
+  setWorkflowSecretStorageForTests({
+    mode: 'plaintext',
+    decryptString: (value) => value.toString('utf8').replace(/^sealed:/, ''),
+  })
+
+  const rawSecret = 'legacy-webhook-secret'
+  const parsed = parseWorkflowTriggersFromStorage(JSON.stringify([
+    {
+      id: 'webhook',
+      type: 'webhook',
+      enabled: true,
+      webhookSecret: `enc:v1:${Buffer.from(`sealed:${rawSecret}`, 'utf8').toString('base64')}`,
+    },
   ]))
 
   assert.equal(parsed[0]?.webhookSecret, rawSecret)

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -20,6 +20,7 @@ import {
   regenerateWorkflowWebhookSecret,
   recoverInterruptedWorkflowRuns,
   parseWorkflowTriggersFromStorage,
+  serializeWorkflowTriggersForStorage,
   setWorkflowSecretStorageForTests,
   updateWorkflowStatus,
 } from '../apps/desktop/src/main/workflow/workflow-store.ts'
@@ -147,6 +148,28 @@ test('workflow store decrypts legacy prefixed webhook secrets in plaintext mode 
   ]))
 
   assert.equal(parsed[0]?.webhookSecret, rawSecret)
+}))
+
+test('workflow store preserves encrypted webhook secret records when decryption fails', () => withWorkflowStore('secret-record-preserve', () => {
+  setWorkflowSecretStorageForTests({
+    mode: 'encrypted',
+    encryptString: (value) => Buffer.from(`sealed:${value}`, 'utf8'),
+    decryptString: () => {
+      throw new Error('keychain unavailable')
+    },
+  })
+
+  const storedSecret = {
+    __openCoworkEncryptedWebhookSecret: 2,
+    value: Buffer.from('sealed:webhook-secret', 'utf8').toString('base64'),
+  }
+  const parsed = parseWorkflowTriggersFromStorage(JSON.stringify([
+    { id: 'webhook', type: 'webhook', enabled: true, webhookSecret: storedSecret },
+  ]))
+
+  assert.deepEqual(parsed[0]?.webhookSecret, storedSecret)
+  const serialized = JSON.parse(serializeWorkflowTriggersForStorage(parsed)) as Array<{ webhookSecret?: unknown }>
+  assert.deepEqual(serialized[0]?.webhookSecret, storedSecret)
 }))
 
 test('workflow store treats valid non-array trigger JSON as empty', () => withWorkflowStore('non-array-triggers', () => {

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -154,6 +154,20 @@ test('workflow store treats valid non-array trigger JSON as empty', () => withWo
   assert.deepEqual(parseWorkflowTriggersFromStorage('"manual"'), [])
 }))
 
+test('workflow store skips malformed trigger array entries during storage parsing', () => withWorkflowStore('malformed-trigger-entries', () => {
+  const parsed = parseWorkflowTriggersFromStorage(JSON.stringify([
+    null,
+    'manual',
+    {},
+    [],
+    { id: 'manual', type: 'manual', enabled: true },
+    { id: 'webhook', type: 'webhook', enabled: true, webhookSecret: 'secret' },
+  ]))
+
+  assert.deepEqual(parsed.map((trigger) => trigger.type), ['manual', 'webhook'])
+  assert.equal(parsed[1]?.webhookSecret, 'secret')
+}))
+
 test('workflow store tracks run lifecycle and next scheduled run', () => withWorkflowStore('runs', () => {
   const workflow = createWorkflow(draft)
   const run = createWorkflowRun(workflow.id, 'manual', { source: 'test' })

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -113,6 +113,17 @@ test('workflow store encrypts webhook secrets at the SQLite boundary when secure
   }
 }))
 
+test('workflow store preserves plaintext webhook secrets that look like encrypted sentinels', () => withWorkflowStore('plaintext-secret-prefix', () => {
+  setWorkflowSecretStorageForTests({ mode: 'plaintext' })
+
+  const rawSecret = 'enc:v1:user-supplied-secret'
+  const parsed = parseWorkflowTriggersFromStorage(JSON.stringify([
+    { id: 'webhook', type: 'webhook', enabled: true, webhookSecret: rawSecret },
+  ]))
+
+  assert.equal(parsed[0]?.webhookSecret, rawSecret)
+}))
+
 test('workflow store tracks run lifecycle and next scheduled run', () => withWorkflowStore('runs', () => {
   const workflow = createWorkflow(draft)
   const run = createWorkflowRun(workflow.id, 'manual', { source: 'test' })

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -124,6 +124,11 @@ test('workflow store preserves plaintext webhook secrets that look like encrypte
   assert.equal(parsed[0]?.webhookSecret, rawSecret)
 }))
 
+test('workflow store treats valid non-array trigger JSON as empty', () => withWorkflowStore('non-array-triggers', () => {
+  assert.deepEqual(parseWorkflowTriggersFromStorage('{}'), [])
+  assert.deepEqual(parseWorkflowTriggersFromStorage('"manual"'), [])
+}))
+
 test('workflow store tracks run lifecycle and next scheduled run', () => withWorkflowStore('runs', () => {
   const workflow = createWorkflow(draft)
   const run = createWorkflowRun(workflow.id, 'manual', { source: 'test' })


### PR DESCRIPTION
Summary
- Treat Linux safeStorage basic_text as non-protective and fail closed in packaged builds
- Encrypt workflow webhook secrets at the SQLite boundary and remove fuzzy child-session matching from history replay
- Harden avatar image sniffing, explorer text search patterns, agent-tool bearer comparison, atomic write modes, and interrupted custom-agent state reads

Validation
- pnpm test -- secure-storage-policy fs-atomic agent-tool-actions ipc-handler-behavior custom-agent-store workflow-store session-history-projector
- pnpm typecheck
- pnpm lint
- pnpm test:renderer
- pnpm lint:dead-code
- pnpm test:e2e
- git diff --check