### PR TITLE
Harden runtime validation and event resilience

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -33,6 +33,7 @@ import { registerExplorerHandlers } from './ipc/explorer-handlers.ts'
 import { registerThreadHandlers } from './ipc/thread-handlers.ts'
 import type { IpcHandlerContext } from './ipc/context.ts'
 import { objectArg, registerIpcInvoke } from './ipc/schema.ts'
+import { validateDestructiveConfirmationRequest } from './ipc/object-validators.ts'
 import { clearPermissionsForSession, trackPermission } from './permission-tracker.ts'
 import { ProjectDirectoryGrantRegistry, trustedRecordDirectoryMatches } from './directory-grants.ts'
 import { isTrustedRendererIpcUrl } from './main-window-lifecycle.ts'
@@ -329,7 +330,7 @@ export function setupIpcHandlers(
     capabilityToolMethodCache,
   }
 
-  registerIpcInvoke(context, 'confirm:request-destructive', objectArg<DestructiveConfirmationRequest>('destructive confirmation request'), async (_event, request) => {
+  registerIpcInvoke(context, 'confirm:request-destructive', objectArg<DestructiveConfirmationRequest>('destructive confirmation request', validateDestructiveConfirmationRequest), async (_event, request) => {
     const confirmed = await showNativeConfirmation(getMainWindow(), destructiveConfirmationPrompt(request))
     if (!confirmed) {
       log('audit', `confirmation.cancelled ${request.action} ${describeDestructiveRequest(request)}`)

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -1,6 +1,7 @@
 import electron from 'electron'
 import type { IpcHandlerContext } from './context.ts'
 import { objectArg, registerIpcInvoke } from './schema.ts'
+import { validateChartSaveArtifactRequest, validateSettingsUpdate } from './object-validators.ts'
 import {
   ensureRuntimeAfterAuthLogin,
   MAX_CLIPBOARD_TEXT_LENGTH,
@@ -40,6 +41,7 @@ import { toIsoTimestamp } from '../task-run-utils.ts'
 import { renderChartSpecToSvg } from '../chart-renderer.ts'
 import { saveChartArtifact } from '../chart-artifacts.ts'
 import { isKnownChartArtifactToolCall } from '../chart-artifact-access.ts'
+import { validateInlineChartSpec } from '../../lib/chart-spec-safety.ts'
 import { sessionEngine } from '../session-engine.ts'
 import { checkForUpdates } from '../update/update-check.ts'
 import {
@@ -231,7 +233,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     return getIntegrationCredentials(normalizeCredentialScopeId(integrationId, 'Integration'))
   })
 
-  registerIpcInvoke(context, 'settings:set', objectArg<Partial<CoworkSettings>>('settings update'), async (_event, updates) => {
+  registerIpcInvoke(context, 'settings:set', objectArg<Partial<CoworkSettings>>('settings update', validateSettingsUpdate), async (_event, updates) => {
     const result = saveSettings(updates)
     const { invalidateRuntimeCatalogSnapshotCache } = await import('../runtime-catalog-snapshot.ts')
     invalidateRuntimeCatalogSnapshotCache()
@@ -403,11 +405,14 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     }
   })
 
-  registerIpcInvoke(context, 'chart:render-svg', objectArg<Record<string, unknown>>('chart specification'), async (_event, spec) => {
+  registerIpcInvoke(context, 'chart:render-svg', objectArg<Record<string, unknown>>('chart specification', (spec) => {
+    validateInlineChartSpec(spec)
+    return spec
+  }), async (_event, spec) => {
     return renderChartSpecToSvg(spec)
   })
 
-  registerIpcInvoke(context, 'chart:save-artifact', objectArg<ChartSaveArtifactRequest>('chart artifact request'), async (_event, request) => {
+  registerIpcInvoke(context, 'chart:save-artifact', objectArg<ChartSaveArtifactRequest>('chart artifact request', validateChartSaveArtifactRequest), async (_event, request) => {
     const sessionRecord = context.ensureSessionRecord(request.sessionId)
     if (!sessionRecord) {
       throw new Error('Chart artifact save requires an existing session.')

--- a/apps/desktop/src/main/ipc/artifact-handlers.ts
+++ b/apps/desktop/src/main/ipc/artifact-handlers.ts
@@ -5,6 +5,7 @@ import { chmodSync, copyFileSync, existsSync, realpathSync } from 'fs'
 import type { SessionArtifactExportRequest, SessionArtifactRequest } from '@open-cowork/shared'
 import type { IpcHandlerContext } from './context.ts'
 import { noIpcArgs, objectArg, registerIpcInvoke, stringArg } from './schema.ts'
+import { validateSessionArtifactExportRequest, validateSessionArtifactRequest } from './object-validators.ts'
 import { buildArtifactAttachmentPayload } from '../artifact-attachments.ts'
 import { getChartArtifactsRoot } from '../chart-artifacts.ts'
 import { cleanupSandboxStorage, getSandboxStorageStats } from '../sandbox-storage.ts'
@@ -29,7 +30,7 @@ function safeRealPath(path: string) {
 export function registerArtifactHandlers(context: IpcHandlerContext) {
   const { app, shell } = electron
 
-  registerIpcInvoke(context, 'artifact:export', objectArg<SessionArtifactExportRequest>('artifact export request'), async (_event, request) => {
+  registerIpcInvoke(context, 'artifact:export', objectArg<SessionArtifactExportRequest>('artifact export request', validateSessionArtifactExportRequest), async (_event, request) => {
     const { dialog } = await import('electron')
     const { source } = context.resolvePrivateArtifactPath(request)
 
@@ -44,14 +45,14 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
     return result.filePath
   })
 
-  registerIpcInvoke(context, 'artifact:reveal', objectArg<SessionArtifactRequest>('artifact request'), async (_event, request) => {
+  registerIpcInvoke(context, 'artifact:reveal', objectArg<SessionArtifactRequest>('artifact request', validateSessionArtifactRequest), async (_event, request) => {
     const { source } = context.resolvePrivateArtifactPath(request)
     shell.showItemInFolder(source)
     log('artifact', `Revealed artifact ${basename(source)} from ${shortSessionId(request.sessionId)}`)
     return true
   })
 
-  registerIpcInvoke(context, 'artifact:read-attachment', objectArg<SessionArtifactRequest>('artifact request'), async (_event, request) => {
+  registerIpcInvoke(context, 'artifact:read-attachment', objectArg<SessionArtifactRequest>('artifact request', validateSessionArtifactRequest), async (_event, request) => {
     const { root, source } = context.resolvePrivateArtifactPath(request)
     const chartRoot = resolve(getChartArtifactsRoot(request.sessionId))
     const isChartArtifact = root === safeRealPath(chartRoot)

--- a/apps/desktop/src/main/ipc/catalog-handlers.ts
+++ b/apps/desktop/src/main/ipc/catalog-handlers.ts
@@ -1,7 +1,22 @@
 import type { RuntimeAgentDescriptor, RuntimeContextOptions, ScopedArtifactRef, ToolListOptions, CustomAgentConfig } from '@open-cowork/shared'
 import { performance } from 'node:perf_hooks'
 import type { IpcHandlerContext } from './context.ts'
-import { optionalObjectArg, registerIpcInvoke, stringArg } from './schema.ts'
+import {
+  objectAndObjectArgs,
+  objectAndOptionalStringArgs,
+  objectArg,
+  optionalObjectArg,
+  registerIpcInvoke,
+  stringAndOptionalObjectArgs,
+  stringArg,
+  twoStringsAndOptionalObjectArgs,
+} from './schema.ts'
+import {
+  validateCustomAgentConfig,
+  validateRuntimeContextOptions,
+  validateScopedArtifactRef,
+  validateToolListOptions,
+} from './object-validators.ts'
 import { getClient } from '../runtime.ts'
 import { invalidateRuntimeToolCache } from '../runtime-tool-cache.ts'
 import { listBuiltInAgentDetails } from '../built-in-agent-details.ts'
@@ -204,7 +219,7 @@ export async function authenticateMcpThroughRuntime(client: {
 }
 
 export function registerCatalogHandlers(context: IpcHandlerContext) {
-  registerIpcInvoke(context, 'tool:list', optionalObjectArg<ToolListOptions>('tool list options'), async (_event, options) => {
+  registerIpcInvoke(context, 'tool:list', optionalObjectArg<ToolListOptions>('tool list options', validateToolListOptions), async (_event, options) => {
     return context.listRuntimeTools(options)
   })
 
@@ -274,12 +289,12 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     return listBuiltInAgentDetails()
   })
 
-  context.ipcMain.handle('agents:catalog', async (_event, options?: RuntimeContextOptions) => {
+  registerIpcInvoke(context, 'agents:catalog', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
     return timeAgentCatalogHandler('agents:catalog', () =>
       getCustomAgentCatalog(resolveContext(context, options)))
   })
 
-  context.ipcMain.handle('agents:list', async (_event, options?: RuntimeContextOptions) => {
+  registerIpcInvoke(context, 'agents:list', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
     return timeAgentCatalogHandler('agents:list', () =>
       getCustomAgentSummaries(resolveContext(context, options)))
   })
@@ -322,7 +337,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     })
   })
 
-  context.ipcMain.handle('agents:create', async (_event, agent: CustomAgentConfig) => {
+  registerIpcInvoke(context, 'agents:create', objectArg<CustomAgentConfig>('custom agent', validateCustomAgentConfig), async (_event, agent) => {
     const normalized = normalizeCustomAgent(agent)
     const catalogContext = {
       directory: agent.scope === 'project' ? context.resolveScopedTarget(agent).directory : null,
@@ -342,7 +357,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     return true
   })
 
-  context.ipcMain.handle('agents:update', async (_event, target: ScopedArtifactRef, agent: CustomAgentConfig) => {
+  registerIpcInvoke(context, 'agents:update', objectAndObjectArgs<ScopedArtifactRef, CustomAgentConfig>('custom agent target', 'custom agent', validateScopedArtifactRef, validateCustomAgentConfig), async (_event, target, agent) => {
     const normalized = normalizeCustomAgent(agent)
     const resolvedTarget = context.resolveScopedTarget(target)
     const catalogContext = {
@@ -366,7 +381,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     return true
   })
 
-  context.ipcMain.handle('agents:remove', async (_event, target: ScopedArtifactRef, confirmationToken?: string | null) => {
+  registerIpcInvoke(context, 'agents:remove', objectAndOptionalStringArgs<ScopedArtifactRef>('custom agent target', 'confirmation token', validateScopedArtifactRef), async (_event, target, confirmationToken) => {
     const resolvedTarget = context.resolveScopedTarget(target)
     try {
       if (!context.consumeDestructiveConfirmation({ action: 'agent.remove', target: resolvedTarget }, confirmationToken)) {
@@ -385,7 +400,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('capabilities:tools', async (_event, options?: ToolListOptions) => {
+  registerIpcInvoke(context, 'capabilities:tools', optionalObjectArg<ToolListOptions>('tool list options', validateToolListOptions), async (_event, options) => {
     const runtimeTools = await context.listRuntimeTools(options)
     // List view — render just the cards; skip the expensive
     // per-MCP method probe. `deep` defaults to false in shared types
@@ -398,7 +413,7 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
     return context.withDiscoveredBuiltInTools(await listCapabilityTools(capabilityContext), runtimeTools, capabilityContext)
   })
 
-  context.ipcMain.handle('capabilities:tool', async (_event, id: string, options?: ToolListOptions) => {
+  registerIpcInvoke(context, 'capabilities:tool', stringAndOptionalObjectArgs<ToolListOptions>('tool id', 'tool list options', {}, validateToolListOptions), async (_event, id, options) => {
     const runtimeTools = await context.listRuntimeTools(options)
     // Detail view — user actually opened one tool; spend the time
     // probing its MCP so the method table renders. Scoped to a single
@@ -413,15 +428,15 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
       || await getCapabilityTool(id, capabilityContext)
   })
 
-  context.ipcMain.handle('capabilities:skills', async (_event, options?: RuntimeContextOptions) => {
+  registerIpcInvoke(context, 'capabilities:skills', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
     return await listCapabilitySkills(resolveContext(context, options))
   })
 
-  context.ipcMain.handle('capabilities:skill-bundle', async (_event, skillName: string, options?: RuntimeContextOptions) => {
+  registerIpcInvoke(context, 'capabilities:skill-bundle', stringAndOptionalObjectArgs<RuntimeContextOptions>('skill name', 'runtime context options', {}, validateRuntimeContextOptions), async (_event, skillName, options) => {
     return await getCapabilitySkillBundle(skillName, resolveContext(context, options))
   })
 
-  context.ipcMain.handle('capabilities:skill-bundle-file', async (_event, skillName: string, filePath: string, options?: RuntimeContextOptions) => {
+  registerIpcInvoke(context, 'capabilities:skill-bundle-file', twoStringsAndOptionalObjectArgs<RuntimeContextOptions>('skill name', 'file path', 'runtime context options', {}, validateRuntimeContextOptions), async (_event, skillName, filePath, options) => {
     return await readEffectiveSkillBundleFile(skillName, filePath, resolveContext(context, options))
   })
 }

--- a/apps/desktop/src/main/ipc/custom-content-handlers.ts
+++ b/apps/desktop/src/main/ipc/custom-content-handlers.ts
@@ -5,9 +5,11 @@ import type { IpcHandlerContext } from './context.ts'
 import {
   objectAndOptionalStringArgs,
   objectArg,
+  optionalObjectArg,
   registerIpcInvoke,
   stringAndObjectArgs,
 } from './schema.ts'
+import { validateCustomMcpConfig, validateCustomSkillConfig, validateRuntimeContextOptions, validateScopedArtifactRef } from './object-validators.ts'
 import { listCustomMcps, listCustomSkills, readSkillBundleDirectory, removeCustomMcp, removeCustomSkill, saveCustomMcp, saveCustomSkill } from '../native-customizations.ts'
 import { validateCustomMcpStdioCommand } from '../mcp-stdio-policy.ts'
 import { resolveCustomMcpRuntimeEntryForRuntime } from '../runtime-mcp.ts'
@@ -75,11 +77,11 @@ async function confirmUnsignedSkillWrite(
 }
 
 export function registerCustomContentHandlers(context: IpcHandlerContext) {
-  context.ipcMain.handle('custom:list-mcps', async (_event, options?: RuntimeContextOptions) => {
+  registerIpcInvoke(context, 'custom:list-mcps', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
     return listCustomMcps(resolveCustomContext(context, options))
   })
 
-  registerIpcInvoke(context, 'custom:test-mcp', objectArg<CustomMcpConfig>('custom MCP'), async (_event, mcp): Promise<CustomMcpTestResult> => {
+  registerIpcInvoke(context, 'custom:test-mcp', objectArg<CustomMcpConfig>('custom MCP', validateCustomMcpConfig), async (_event, mcp): Promise<CustomMcpTestResult> => {
     try {
       assertCustomMcpContentLimits(mcp)
       if (mcp.type === 'stdio') {
@@ -126,7 +128,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     }
   })
 
-  registerIpcInvoke(context, 'custom:add-mcp', objectArg<CustomMcpConfig>('custom MCP'), async (_event, mcp) => {
+  registerIpcInvoke(context, 'custom:add-mcp', objectArg<CustomMcpConfig>('custom MCP', validateCustomMcpConfig), async (_event, mcp) => {
     validateName(mcp.name, 'MCP')
     assertCustomMcpContentLimits(mcp)
     const resolved = context.resolveScopedTarget(mcp) as CustomMcpConfig
@@ -156,7 +158,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     }
   })
 
-  registerIpcInvoke(context, 'custom:remove-mcp', objectAndOptionalStringArgs<ScopedArtifactRef>('custom MCP target', 'confirmation token'), async (_event, target, confirmationToken) => {
+  registerIpcInvoke(context, 'custom:remove-mcp', objectAndOptionalStringArgs<ScopedArtifactRef>('custom MCP target', 'confirmation token', validateScopedArtifactRef), async (_event, target, confirmationToken) => {
     const resolvedTarget = context.resolveScopedTarget(target)
     try {
       if (!context.consumeDestructiveConfirmation({ action: 'mcp.remove', target: resolvedTarget }, confirmationToken)) {
@@ -175,11 +177,11 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('custom:list-skills', async (_event, options?: RuntimeContextOptions) => {
+  registerIpcInvoke(context, 'custom:list-skills', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
     return listCustomSkills(resolveCustomContext(context, options))
   })
 
-  registerIpcInvoke(context, 'custom:add-skill', objectArg<CustomSkillConfig>('custom skill'), async (_event, skill) => {
+  registerIpcInvoke(context, 'custom:add-skill', objectArg<CustomSkillConfig>('custom skill', validateCustomSkillConfig), async (_event, skill) => {
     validateSkillName(skill.name)
     assertCustomSkillContent(skill.content || '')
     const resolved = context.resolveScopedTarget(skill) as CustomSkillConfig
@@ -211,7 +213,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     return { token, directory }
   })
 
-  registerIpcInvoke(context, 'custom:import-skill-directory', stringAndObjectArgs<ScopedArtifactRef>('selection token', 'skill import target'), async (_event, selectionToken, target) => {
+  registerIpcInvoke(context, 'custom:import-skill-directory', stringAndObjectArgs<ScopedArtifactRef>('selection token', 'skill import target', {}, validateScopedArtifactRef), async (_event, selectionToken, target) => {
     const resolvedTarget = context.resolveScopedTarget(target)
     const directory = context.approvedSkillImportDirectories.get(selectionToken)
     context.approvedSkillImportDirectories.delete(selectionToken)
@@ -236,7 +238,7 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
     return imported
   })
 
-  registerIpcInvoke(context, 'custom:remove-skill', objectAndOptionalStringArgs<ScopedArtifactRef>('custom skill target', 'confirmation token'), async (_event, target, confirmationToken) => {
+  registerIpcInvoke(context, 'custom:remove-skill', objectAndOptionalStringArgs<ScopedArtifactRef>('custom skill target', 'confirmation token', validateScopedArtifactRef), async (_event, target, confirmationToken) => {
     const resolvedTarget = context.resolveScopedTarget(target)
     try {
       if (!context.consumeDestructiveConfirmation({ action: 'skill.remove', target: resolvedTarget }, confirmationToken)) {

--- a/apps/desktop/src/main/ipc/object-validators.ts
+++ b/apps/desktop/src/main/ipc/object-validators.ts
@@ -1,0 +1,389 @@
+import type {
+  ChartSaveArtifactRequest,
+  CustomAgentConfig,
+  CustomMcpConfig,
+  CustomSkillConfig,
+  DestructiveConfirmationRequest,
+  RuntimeContextOptions,
+  ScopedArtifactRef,
+  SessionArtifactExportRequest,
+  SessionArtifactRequest,
+  ThreadSearchQuery,
+  ToolListOptions,
+} from '@open-cowork/shared'
+import type { CoworkSettings } from '../settings.ts'
+import { assertCustomMcpContentLimits, assertCustomSkillContent, assertCustomSkillFiles } from '../custom-content-limits.ts'
+import { validateCustomAgentContentLimits } from '../custom-content-limits.ts'
+import { normalizeThreadSearchQuery } from '../thread-index/thread-index-normalizers.ts'
+
+const MAX_IPC_STRING_BYTES = 64 * 1024
+const MAX_IPC_ID_BYTES = 512
+const MAX_SETTINGS_UPDATE_BYTES = 512 * 1024
+const MAX_CHART_DATA_URL_BYTES = 8 * 1024 * 1024 + 128
+const SCOPES = new Set(['machine', 'project'])
+const MCP_TYPES = new Set(['stdio', 'http'])
+const MCP_PERMISSION_MODES = new Set(['ask', 'allow'])
+const AGENT_COLORS = new Set(['primary', 'warning', 'accent', 'success', 'info', 'secondary'])
+const RUNTIME_PERMISSION_POLICIES = new Set(['allow', 'ask', 'deny'])
+const RUNTIME_CONFIG_SOURCES = new Set(['app', 'machine'])
+const DESTRUCTIVE_ACTIONS = new Set(['session.delete', 'agent.remove', 'mcp.remove', 'skill.remove', 'app.reset'])
+
+const SETTINGS_UPDATE_KEYS = new Set([
+  '_schemaVersion',
+  'selectedProviderId',
+  'selectedModelId',
+  'selectedSmallModelId',
+  'providerCredentials',
+  'integrationCredentials',
+  'integrationEnabled',
+  'bashPermission',
+  'fileWritePermission',
+  'enableBash',
+  'enableFileWrite',
+  'runtimeConfigSource',
+  'runtimeToolingBridgeEnabled',
+  'workflowLaunchAtLogin',
+  'workflowRunInBackground',
+  'workflowDesktopNotifications',
+  'workflowQuietHoursStart',
+  'workflowQuietHoursEnd',
+])
+
+function byteLength(value: string) {
+  return Buffer.byteLength(value, 'utf8')
+}
+
+function assertJsonSize(value: unknown, label: string, maxBytes: number) {
+  let serialized: string
+  try {
+    serialized = JSON.stringify(value)
+  } catch {
+    throw new Error(`${label} must be JSON-serializable.`)
+  }
+  if (byteLength(serialized) > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+}
+
+function plainRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`)
+  }
+  return value as Record<string, unknown>
+}
+
+function requiredString(record: Record<string, unknown>, key: string, label: string, maxBytes = MAX_IPC_STRING_BYTES) {
+  const value = record[key]
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${label} is required.`)
+  }
+  const trimmed = value.trim()
+  if (byteLength(trimmed) > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return trimmed
+}
+
+function optionalString(record: Record<string, unknown>, key: string, label: string, maxBytes = MAX_IPC_STRING_BYTES) {
+  const value = record[key]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  if (byteLength(value) > maxBytes) throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  return value
+}
+
+function optionalNullableString(record: Record<string, unknown>, key: string, label: string, maxBytes = MAX_IPC_STRING_BYTES) {
+  const value = record[key]
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') throw new Error(`${label} must be a string or null.`)
+  if (byteLength(value) > maxBytes) throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  return value
+}
+
+function optionalBoolean(record: Record<string, unknown>, key: string, label: string) {
+  const value = record[key]
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') throw new Error(`${label} must be a boolean.`)
+  return value
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string, label: string) {
+  const value = record[key]
+  if (value === undefined || value === null) return value as undefined | null
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`${label} must be a finite number.`)
+  return value
+}
+
+function optionalStringArray(record: Record<string, unknown>, key: string, label: string, maxItems = 128) {
+  const value = record[key]
+  if (value === undefined || value === null) return undefined
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array.`)
+  if (value.length > maxItems) throw new Error(`${label} exceeds ${maxItems} entries.`)
+  return value.map((entry, index) => {
+    if (typeof entry !== 'string') throw new Error(`${label}[${index}] must be a string.`)
+    if (byteLength(entry) > MAX_IPC_STRING_BYTES) throw new Error(`${label}[${index}] is too large.`)
+    return entry
+  })
+}
+
+function optionalStringRecord(record: Record<string, unknown>, key: string, label: string, maxEntries = 128) {
+  const value = record[key]
+  if (value === undefined || value === null) return undefined
+  const input = plainRecord(value, label)
+  const entries = Object.entries(input)
+  if (entries.length > maxEntries) throw new Error(`${label} exceeds ${maxEntries} entries.`)
+  const next: Record<string, string> = {}
+  for (const [entryKey, entryValue] of entries) {
+    if (typeof entryValue !== 'string') throw new Error(`${label}.${entryKey} must be a string.`)
+    if (byteLength(entryKey) > MAX_IPC_ID_BYTES) throw new Error(`${label} key is too large.`)
+    if (byteLength(entryValue) > MAX_IPC_STRING_BYTES) throw new Error(`${label}.${entryKey} is too large.`)
+    next[entryKey] = entryValue
+  }
+  return next
+}
+
+function optionalNestedStringRecord(record: Record<string, unknown>, key: string, label: string) {
+  const value = record[key]
+  if (value === undefined || value === null) return undefined
+  const outer = plainRecord(value, label)
+  const next: Record<string, Record<string, string>> = {}
+  for (const [outerKey, outerValue] of Object.entries(outer)) {
+    next[outerKey] = optionalStringRecord({ [outerKey]: outerValue }, outerKey, `${label}.${outerKey}`) || {}
+  }
+  return next
+}
+
+function optionalBooleanRecord(record: Record<string, unknown>, key: string, label: string) {
+  const value = record[key]
+  if (value === undefined || value === null) return undefined
+  const input = plainRecord(value, label)
+  const next: Record<string, boolean> = {}
+  for (const [entryKey, entryValue] of Object.entries(input)) {
+    if (typeof entryValue !== 'boolean') throw new Error(`${label}.${entryKey} must be a boolean.`)
+    next[entryKey] = entryValue
+  }
+  return next
+}
+
+function optionalJsonRecord(record: Record<string, unknown>, key: string, label: string, maxBytes = 32 * 1024) {
+  const value = record[key]
+  if (value === undefined || value === null) return value as undefined | null
+  const input = plainRecord(value, label)
+  assertJsonSize(input, label, maxBytes)
+  return input
+}
+
+function requiredScope(record: Record<string, unknown>) {
+  const scope = record.scope
+  if (typeof scope !== 'string' || !SCOPES.has(scope)) {
+    throw new Error('Scope must be "machine" or "project".')
+  }
+  return scope as 'machine' | 'project'
+}
+
+export function validateRuntimeContextOptions(record: Record<string, unknown>): RuntimeContextOptions {
+  return {
+    sessionId: optionalString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
+    directory: optionalNullableString(record, 'directory', 'Directory'),
+  }
+}
+
+export function validateToolListOptions(record: Record<string, unknown>): ToolListOptions {
+  return {
+    ...validateRuntimeContextOptions(record),
+    provider: optionalNullableString(record, 'provider', 'Provider id', MAX_IPC_ID_BYTES),
+    model: optionalNullableString(record, 'model', 'Model id', MAX_IPC_ID_BYTES),
+    deep: optionalBoolean(record, 'deep', 'Deep tool discovery'),
+  }
+}
+
+export function validateScopedArtifactRef(record: Record<string, unknown>): ScopedArtifactRef {
+  return {
+    name: requiredString(record, 'name', 'Name', MAX_IPC_ID_BYTES),
+    scope: requiredScope(record),
+    directory: optionalNullableString(record, 'directory', 'Directory'),
+  }
+}
+
+export function validateSessionArtifactRequest(record: Record<string, unknown>): SessionArtifactRequest {
+  return {
+    sessionId: requiredString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
+    filePath: requiredString(record, 'filePath', 'Artifact path'),
+  }
+}
+
+export function validateSessionArtifactExportRequest(record: Record<string, unknown>): SessionArtifactExportRequest {
+  return {
+    ...validateSessionArtifactRequest(record),
+    suggestedName: optionalString(record, 'suggestedName', 'Suggested filename', MAX_IPC_ID_BYTES),
+  }
+}
+
+export function validateChartSaveArtifactRequest(record: Record<string, unknown>): ChartSaveArtifactRequest {
+  const dataUrl = requiredString(record, 'dataUrl', 'Chart data URL', MAX_CHART_DATA_URL_BYTES)
+  if (!dataUrl.startsWith('data:image/png;base64,')) {
+    throw new Error('Chart data URL must be a PNG data URL.')
+  }
+  const chart = record.chart === undefined || record.chart === null ? record.chart : plainRecord(record.chart, 'Chart metadata')
+  return {
+    sessionId: requiredString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
+    toolCallId: requiredString(record, 'toolCallId', 'Tool call id', MAX_IPC_ID_BYTES),
+    toolName: requiredString(record, 'toolName', 'Tool name', MAX_IPC_ID_BYTES),
+    dataUrl,
+    taskRunId: optionalNullableString(record, 'taskRunId', 'Task run id', MAX_IPC_ID_BYTES),
+    chart: chart as ChartSaveArtifactRequest['chart'],
+  }
+}
+
+export function validateSettingsUpdate(record: Record<string, unknown>): Partial<CoworkSettings> {
+  assertJsonSize(record, 'Settings update', MAX_SETTINGS_UPDATE_BYTES)
+  for (const key of Object.keys(record)) {
+    if (!SETTINGS_UPDATE_KEYS.has(key)) throw new Error(`Unknown settings key: ${key}`)
+  }
+  const update: Partial<CoworkSettings> = {}
+  if (record._schemaVersion !== undefined) {
+    if (typeof record._schemaVersion !== 'number' || !Number.isInteger(record._schemaVersion)) {
+      throw new Error('Settings schema version must be an integer.')
+    }
+    update._schemaVersion = record._schemaVersion
+  }
+  update.selectedProviderId = optionalNullableString(record, 'selectedProviderId', 'Selected provider id', MAX_IPC_ID_BYTES) as string | null | undefined
+  update.selectedModelId = optionalNullableString(record, 'selectedModelId', 'Selected model id', MAX_IPC_ID_BYTES) as string | null | undefined
+  update.selectedSmallModelId = optionalNullableString(record, 'selectedSmallModelId', 'Selected small model id', MAX_IPC_ID_BYTES) as string | null | undefined
+  update.providerCredentials = optionalNestedStringRecord(record, 'providerCredentials', 'Provider credentials')
+  update.integrationCredentials = optionalNestedStringRecord(record, 'integrationCredentials', 'Integration credentials')
+  update.integrationEnabled = optionalBooleanRecord(record, 'integrationEnabled', 'Integration enabled')
+  for (const key of ['bashPermission', 'fileWritePermission'] as const) {
+    if (record[key] !== undefined) {
+      if (typeof record[key] !== 'string' || !RUNTIME_PERMISSION_POLICIES.has(record[key])) {
+        throw new Error(`${key} must be allow, ask, or deny.`)
+      }
+      update[key] = record[key] as CoworkSettings['bashPermission']
+    }
+  }
+  update.enableBash = optionalBoolean(record, 'enableBash', 'Bash enabled')
+  update.enableFileWrite = optionalBoolean(record, 'enableFileWrite', 'File write enabled')
+  if (record.runtimeConfigSource !== undefined) {
+    if (typeof record.runtimeConfigSource !== 'string' || !RUNTIME_CONFIG_SOURCES.has(record.runtimeConfigSource)) {
+      throw new Error('Runtime config source must be app or machine.')
+    }
+    update.runtimeConfigSource = record.runtimeConfigSource as 'app' | 'machine'
+  }
+  update.runtimeToolingBridgeEnabled = optionalBoolean(record, 'runtimeToolingBridgeEnabled', 'Runtime tooling bridge enabled')
+  update.workflowLaunchAtLogin = optionalBoolean(record, 'workflowLaunchAtLogin', 'Workflow launch at login')
+  update.workflowRunInBackground = optionalBoolean(record, 'workflowRunInBackground', 'Workflow run in background')
+  update.workflowDesktopNotifications = optionalBoolean(record, 'workflowDesktopNotifications', 'Workflow desktop notifications')
+  update.workflowQuietHoursStart = optionalNullableString(record, 'workflowQuietHoursStart', 'Workflow quiet hours start', MAX_IPC_ID_BYTES) as string | null | undefined
+  update.workflowQuietHoursEnd = optionalNullableString(record, 'workflowQuietHoursEnd', 'Workflow quiet hours end', MAX_IPC_ID_BYTES) as string | null | undefined
+
+  return Object.fromEntries(Object.entries(update).filter(([, value]) => value !== undefined)) as Partial<CoworkSettings>
+}
+
+export function validateCustomMcpConfig(record: Record<string, unknown>): CustomMcpConfig {
+  const type = record.type
+  if (typeof type !== 'string' || !MCP_TYPES.has(type)) {
+    throw new Error('MCP type must be stdio or http.')
+  }
+  const permissionMode = optionalString(record, 'permissionMode', 'MCP permission mode', MAX_IPC_ID_BYTES)
+  if (permissionMode && !MCP_PERMISSION_MODES.has(permissionMode)) {
+    throw new Error('MCP permission mode must be ask or allow.')
+  }
+  const config: CustomMcpConfig = {
+    scope: requiredScope(record),
+    directory: optionalNullableString(record, 'directory', 'Directory'),
+    name: requiredString(record, 'name', 'MCP name', MAX_IPC_ID_BYTES),
+    label: optionalString(record, 'label', 'MCP label'),
+    description: optionalString(record, 'description', 'MCP description'),
+    type: type as CustomMcpConfig['type'],
+    command: optionalString(record, 'command', 'MCP command'),
+    args: optionalStringArray(record, 'args', 'MCP args'),
+    env: optionalStringRecord(record, 'env', 'MCP env'),
+    url: optionalString(record, 'url', 'MCP URL'),
+    headers: optionalStringRecord(record, 'headers', 'MCP headers'),
+    googleAuth: optionalBoolean(record, 'googleAuth', 'MCP Google auth'),
+    allowPrivateNetwork: optionalBoolean(record, 'allowPrivateNetwork', 'MCP private network access'),
+    permissionMode: permissionMode as CustomMcpConfig['permissionMode'],
+    traceLabel: optionalString(record, 'traceLabel', 'MCP trace label'),
+    tracePluralLabel: optionalString(record, 'tracePluralLabel', 'MCP trace plural label'),
+  }
+  assertCustomMcpContentLimits(config)
+  return config
+}
+
+export function validateCustomSkillConfig(record: Record<string, unknown>): CustomSkillConfig {
+  const filesInput = record.files
+  let files: CustomSkillConfig['files']
+  if (filesInput !== undefined && filesInput !== null) {
+    if (!Array.isArray(filesInput)) throw new Error('Skill files must be an array.')
+    files = filesInput.map((entry, index) => {
+      const file = plainRecord(entry, `Skill file ${index + 1}`)
+      return {
+        path: requiredString(file, 'path', `Skill file ${index + 1} path`, MAX_IPC_ID_BYTES),
+        content: requiredString(file, 'content', `Skill file ${index + 1} content`),
+      }
+    })
+  }
+  const skill: CustomSkillConfig = {
+    scope: requiredScope(record),
+    directory: optionalNullableString(record, 'directory', 'Directory'),
+    name: requiredString(record, 'name', 'Skill name', MAX_IPC_ID_BYTES),
+    content: requiredString(record, 'content', 'Skill content'),
+    files,
+    toolIds: optionalStringArray(record, 'toolIds', 'Skill tool ids'),
+  }
+  assertCustomSkillContent(skill.content || '')
+  assertCustomSkillFiles(skill.files || [])
+  return skill
+}
+
+export function validateCustomAgentConfig(record: Record<string, unknown>): CustomAgentConfig {
+  const agent: CustomAgentConfig = {
+    scope: requiredScope(record),
+    directory: optionalNullableString(record, 'directory', 'Directory'),
+    name: requiredString(record, 'name', 'Agent name', MAX_IPC_ID_BYTES),
+    description: requiredString(record, 'description', 'Agent description'),
+    instructions: requiredString(record, 'instructions', 'Agent instructions'),
+    skillNames: optionalStringArray(record, 'skillNames', 'Agent skills') || [],
+    toolIds: optionalStringArray(record, 'toolIds', 'Agent tools') || [],
+    enabled: optionalBoolean(record, 'enabled', 'Agent enabled') ?? true,
+    color: 'primary',
+    avatar: optionalNullableString(record, 'avatar', 'Agent avatar'),
+    deniedToolPatterns: optionalStringArray(record, 'deniedToolPatterns', 'Agent denied tool patterns'),
+    model: optionalNullableString(record, 'model', 'Agent model'),
+    variant: optionalNullableString(record, 'variant', 'Agent variant'),
+    temperature: optionalNumber(record, 'temperature', 'Agent temperature'),
+    top_p: optionalNumber(record, 'top_p', 'Agent top_p'),
+    steps: optionalNumber(record, 'steps', 'Agent steps'),
+    options: optionalJsonRecord(record, 'options', 'Agent options'),
+  }
+  if (typeof record.color !== 'string' || !AGENT_COLORS.has(record.color)) {
+    throw new Error('Agent color is invalid.')
+  }
+  agent.color = record.color as CustomAgentConfig['color']
+  const issue = validateCustomAgentContentLimits(agent)[0]
+  if (issue) throw new Error(issue.message)
+  return agent
+}
+
+export function validateDestructiveConfirmationRequest(record: Record<string, unknown>): DestructiveConfirmationRequest {
+  const action = record.action
+  if (typeof action !== 'string' || !DESTRUCTIVE_ACTIONS.has(action)) {
+    throw new Error('Destructive action is invalid.')
+  }
+  if (action === 'app.reset') return { action }
+  if (action === 'session.delete') {
+    return {
+      action,
+      sessionId: requiredString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
+    }
+  }
+  return {
+    action: action as 'agent.remove' | 'mcp.remove' | 'skill.remove',
+    target: validateScopedArtifactRef(plainRecord(record.target, 'Destructive target')),
+  }
+}
+
+export function validateThreadSearchQuery(record: Record<string, unknown>): ThreadSearchQuery {
+  return normalizeThreadSearchQuery(record)
+}

--- a/apps/desktop/src/main/ipc/object-validators.ts
+++ b/apps/desktop/src/main/ipc/object-validators.ts
@@ -319,6 +319,8 @@ export function validateCustomMcpConfig(record: Record<string, unknown>): Custom
 }
 
 export function validateCustomSkillConfig(record: Record<string, unknown>): CustomSkillConfig {
+  const content = rawString(record, 'content', 'Skill content')
+  if (!content.trim()) throw new Error('Skill content is required.')
   const filesInput = record.files
   let files: CustomSkillConfig['files']
   if (filesInput !== undefined && filesInput !== null) {
@@ -335,7 +337,7 @@ export function validateCustomSkillConfig(record: Record<string, unknown>): Cust
     scope: requiredScope(record),
     directory: optionalNullableString(record, 'directory', 'Directory'),
     name: requiredString(record, 'name', 'Skill name', MAX_IPC_ID_BYTES),
-    content: requiredString(record, 'content', 'Skill content'),
+    content,
     files,
     toolIds: optionalStringArray(record, 'toolIds', 'Skill tool ids'),
   }

--- a/apps/desktop/src/main/ipc/object-validators.ts
+++ b/apps/desktop/src/main/ipc/object-validators.ts
@@ -84,6 +84,13 @@ function requiredString(record: Record<string, unknown>, key: string, label: str
   return trimmed
 }
 
+function rawString(record: Record<string, unknown>, key: string, label: string, maxBytes = MAX_IPC_STRING_BYTES) {
+  const value = record[key]
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  if (byteLength(value) > maxBytes) throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  return value
+}
+
 function optionalString(record: Record<string, unknown>, key: string, label: string, maxBytes = MAX_IPC_STRING_BYTES) {
   const value = record[key]
   if (value === undefined || value === null) return undefined
@@ -320,7 +327,7 @@ export function validateCustomSkillConfig(record: Record<string, unknown>): Cust
       const file = plainRecord(entry, `Skill file ${index + 1}`)
       return {
         path: requiredString(file, 'path', `Skill file ${index + 1} path`, MAX_IPC_ID_BYTES),
-        content: requiredString(file, 'content', `Skill file ${index + 1} content`),
+        content: rawString(file, 'content', `Skill file ${index + 1} content`),
       }
     })
   }

--- a/apps/desktop/src/main/ipc/schema.ts
+++ b/apps/desktop/src/main/ipc/schema.ts
@@ -5,6 +5,12 @@ export type IpcArgsSchema<TArgs extends unknown[]> = {
   parse(channel: string, args: unknown[]): TArgs
 }
 
+export type IpcObjectValidator<T extends object> = (
+  value: Record<string, unknown>,
+  channel: string,
+  label: string,
+) => T
+
 type IpcInvokeHandler<TArgs extends unknown[], TResult> = (
   event: IpcMainInvokeEvent,
   ...args: TArgs
@@ -58,22 +64,22 @@ export function optionalStringArg(label: string, options: { maxBytes?: number } 
   })
 }
 
-export function objectArg<T extends object>(label: string) {
+export function objectArg<T extends object>(label: string, validator?: IpcObjectValidator<T>) {
   return createIpcArgsSchema<[T]>((channel, args) => {
     if (args.length !== 1) {
       throw new Error(`${channel} requires exactly one ${label} argument.`)
     }
-    return [normalizeObjectArg<T>(channel, label, args[0])]
+    return [normalizeObjectArg<T>(channel, label, args[0], validator)]
   })
 }
 
-export function optionalObjectArg<T extends object>(label: string) {
+export function optionalObjectArg<T extends object>(label: string, validator?: IpcObjectValidator<T>) {
   return createIpcArgsSchema<[T | undefined]>((channel, args) => {
     if (args.length > 1) {
       throw new Error(`${channel} accepts at most one argument.`)
     }
     if (args[0] === undefined || args[0] === null) return [undefined]
-    return [normalizeObjectArg<T>(channel, label, args[0])]
+    return [normalizeObjectArg<T>(channel, label, args[0], validator)]
   })
 }
 
@@ -81,6 +87,7 @@ export function stringAndObjectArgs<T extends object>(
   stringLabel: string,
   objectLabel: string,
   options: { maxBytes?: number } = {},
+  validator?: IpcObjectValidator<T>,
 ) {
   return createIpcArgsSchema<[string, T]>((channel, args) => {
     if (args.length !== 2) {
@@ -91,7 +98,70 @@ export function stringAndObjectArgs<T extends object>(
     }
     return [
       normalizeStringArg(channel, stringLabel, args[0], options.maxBytes),
-      normalizeObjectArg<T>(channel, objectLabel, args[1]),
+      normalizeObjectArg<T>(channel, objectLabel, args[1], validator),
+    ]
+  })
+}
+
+export function stringAndOptionalObjectArgs<T extends object>(
+  stringLabel: string,
+  objectLabel: string,
+  options: { maxBytes?: number } = {},
+  validator?: IpcObjectValidator<T>,
+) {
+  return createIpcArgsSchema<[string, T | undefined]>((channel, args) => {
+    if (args.length < 1 || args.length > 2) {
+      throw new Error(`${channel} requires ${stringLabel}.`)
+    }
+    if (typeof args[0] !== 'string') {
+      throw new Error(`${channel} requires ${stringLabel} to be a string.`)
+    }
+    return [
+      normalizeStringArg(channel, stringLabel, args[0], options.maxBytes),
+      args[1] === undefined || args[1] === null
+        ? undefined
+        : normalizeObjectArg<T>(channel, objectLabel, args[1], validator),
+    ]
+  })
+}
+
+export function twoStringsAndOptionalObjectArgs<T extends object>(
+  firstLabel: string,
+  secondLabel: string,
+  objectLabel: string,
+  options: { firstMaxBytes?: number; secondMaxBytes?: number } = {},
+  validator?: IpcObjectValidator<T>,
+) {
+  return createIpcArgsSchema<[string, string, T | undefined]>((channel, args) => {
+    if (args.length < 2 || args.length > 3) {
+      throw new Error(`${channel} requires ${firstLabel} and ${secondLabel}.`)
+    }
+    if (typeof args[0] !== 'string' || typeof args[1] !== 'string') {
+      throw new Error(`${channel} requires ${firstLabel} and ${secondLabel} to be strings.`)
+    }
+    return [
+      normalizeStringArg(channel, firstLabel, args[0], options.firstMaxBytes),
+      normalizeStringArg(channel, secondLabel, args[1], options.secondMaxBytes),
+      args[2] === undefined || args[2] === null
+        ? undefined
+        : normalizeObjectArg<T>(channel, objectLabel, args[2], validator),
+    ]
+  })
+}
+
+export function objectAndObjectArgs<TFirst extends object, TSecond extends object>(
+  firstLabel: string,
+  secondLabel: string,
+  firstValidator?: IpcObjectValidator<TFirst>,
+  secondValidator?: IpcObjectValidator<TSecond>,
+) {
+  return createIpcArgsSchema<[TFirst, TSecond]>((channel, args) => {
+    if (args.length !== 2) {
+      throw new Error(`${channel} requires ${firstLabel} and ${secondLabel}.`)
+    }
+    return [
+      normalizeObjectArg<TFirst>(channel, firstLabel, args[0], firstValidator),
+      normalizeObjectArg<TSecond>(channel, secondLabel, args[1], secondValidator),
     ]
   })
 }
@@ -99,6 +169,7 @@ export function stringAndObjectArgs<T extends object>(
 export function objectAndOptionalStringArgs<T extends object>(
   objectLabel: string,
   optionalStringLabel: string,
+  validator?: IpcObjectValidator<T>,
 ) {
   return createIpcArgsSchema<[T, string | null | undefined]>((channel, args) => {
     if (args.length < 1 || args.length > 2) {
@@ -109,7 +180,7 @@ export function objectAndOptionalStringArgs<T extends object>(
       throw new Error(`${channel} requires ${optionalStringLabel} to be a string when provided.`)
     }
     return [
-      normalizeObjectArg<T>(channel, objectLabel, args[0]),
+      normalizeObjectArg<T>(channel, objectLabel, args[0], validator),
       token,
     ]
   })
@@ -144,9 +215,15 @@ function normalizeStringArg(channel: string, label: string, value: string, maxBy
   return trimmed
 }
 
-function normalizeObjectArg<T extends object>(channel: string, label: string, value: unknown): T {
+function normalizeObjectArg<T extends object>(
+  channel: string,
+  label: string,
+  value: unknown,
+  validator?: IpcObjectValidator<T>,
+): T {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error(`${channel} requires ${label} to be an object.`)
   }
-  return value as T
+  const record = value as Record<string, unknown>
+  return validator ? validator(record, channel, label) : record as T
 }

--- a/apps/desktop/src/main/ipc/thread-handlers.ts
+++ b/apps/desktop/src/main/ipc/thread-handlers.ts
@@ -8,6 +8,8 @@ import {
   type ThreadTagInput,
 } from '@open-cowork/shared'
 import { objectArg, optionalObjectArg, registerIpcInvoke, stringAndObjectArgs } from './schema.ts'
+import { validateThreadSearchQuery } from './object-validators.ts'
+import { normalizeSmartFilterInput, normalizeTagInput } from '../thread-index/thread-index-normalizers.ts'
 
 function requireStringArray(value: unknown, label: string, max = THREAD_BULK_MAX_SESSION_IDS) {
   if (!Array.isArray(value)) throw new Error(`${label} must be an array.`)
@@ -23,11 +25,11 @@ function requireStringArray(value: unknown, label: string, max = THREAD_BULK_MAX
 export function registerThreadHandlers(context: IpcHandlerContext) {
   const threads = () => getThreadIndexService()
 
-  registerIpcInvoke(context, 'threads:search', optionalObjectArg<ThreadSearchQuery>('thread search query'), async (_event, query) => (
+  registerIpcInvoke(context, 'threads:search', optionalObjectArg<ThreadSearchQuery>('thread search query', validateThreadSearchQuery), async (_event, query) => (
     threads().search(query)
   ))
 
-  registerIpcInvoke(context, 'threads:facets', optionalObjectArg<ThreadSearchQuery>('thread facet query'), async (_event, query) => (
+  registerIpcInvoke(context, 'threads:facets', optionalObjectArg<ThreadSearchQuery>('thread facet query', validateThreadSearchQuery), async (_event, query) => (
     threads().facets(query)
   ))
 
@@ -35,14 +37,13 @@ export function registerThreadHandlers(context: IpcHandlerContext) {
     threads().listTags()
   ))
 
-  registerIpcInvoke(context, 'threads:tags:create', objectArg<ThreadTagInput>('thread tag input'), async (_event, input) => (
+  registerIpcInvoke(context, 'threads:tags:create', objectArg<ThreadTagInput>('thread tag input', (input) => normalizeTagInput(input as unknown as ThreadTagInput)), async (_event, input) => (
     threads().createTag(input)
   ))
 
-  context.ipcMain.handle('threads:tags:update', async (_event, tagId: unknown, input: unknown) => {
-    if (typeof tagId !== 'string') throw new Error('Tag id must be a string.')
-    return threads().updateTag(tagId, input as never)
-  })
+  registerIpcInvoke(context, 'threads:tags:update', stringAndObjectArgs<ThreadTagInput>('thread tag id', 'thread tag input', {}, (input) => normalizeTagInput(input as unknown as ThreadTagInput)), async (_event, tagId, input) => (
+    threads().updateTag(tagId, input)
+  ))
 
   context.ipcMain.handle('threads:tags:delete', async (_event, tagId: unknown) => {
     if (typeof tagId !== 'string') throw new Error('Tag id must be a string.')
@@ -65,11 +66,11 @@ export function registerThreadHandlers(context: IpcHandlerContext) {
     threads().listSmartFilters()
   ))
 
-  registerIpcInvoke(context, 'threads:smart-filters:create', objectArg<ThreadSmartFilterInput>('smart filter input'), async (_event, input) => (
+  registerIpcInvoke(context, 'threads:smart-filters:create', objectArg<ThreadSmartFilterInput>('smart filter input', (input) => normalizeSmartFilterInput(input as unknown as ThreadSmartFilterInput)), async (_event, input) => (
     threads().createSmartFilter(input)
   ))
 
-  registerIpcInvoke(context, 'threads:smart-filters:update', stringAndObjectArgs<ThreadSmartFilterInput>('smart filter id', 'smart filter input'), async (_event, filterId, input) => (
+  registerIpcInvoke(context, 'threads:smart-filters:update', stringAndObjectArgs<ThreadSmartFilterInput>('smart filter id', 'smart filter input', {}, (input) => normalizeSmartFilterInput(input as unknown as ThreadSmartFilterInput)), async (_event, filterId, input) => (
     threads().updateSmartFilter(filterId, input)
   ))
 

--- a/apps/desktop/src/main/runtime-process-cleanup.ts
+++ b/apps/desktop/src/main/runtime-process-cleanup.ts
@@ -17,8 +17,16 @@ export const OPEN_COWORK_MANAGED_RUNTIME_VALUE = '1'
 const MANAGED_RUNTIME_PID_LEDGER = 'managed-runtime-pids.json'
 const PS_SNAPSHOT_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
-function isPositiveInteger(value: string) {
+function isUnsignedInteger(value: string) {
   return /^[0-9]+$/.test(value)
+}
+
+function parseProcessId(value: string, allowZero: boolean) {
+  if (!isUnsignedInteger(value)) return null
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) return null
+  if (allowZero ? parsed < 0 : parsed <= 0) return null
+  return parsed
 }
 
 export function parsePsOutput(output: string): RuntimeProcessInfo[] {
@@ -30,11 +38,14 @@ export function parsePsOutput(output: string): RuntimeProcessInfo[] {
       const match = line.match(/^(\d+)\s+(\d+)\s+(.*)$/)
       if (!match) return null
       const [, pidRaw, ppidRaw, command] = match
-      if (!isPositiveInteger(pidRaw) || !isPositiveInteger(ppidRaw) || !command.trim()) return null
+      const pid = parseProcessId(pidRaw, false)
+      const ppid = parseProcessId(ppidRaw, true)
+      const normalizedCommand = command.trim()
+      if (pid === null || ppid === null || !normalizedCommand || normalizedCommand === 'COMMAND' || normalizedCommand === 'ARGS') return null
       return {
-        pid: Number(pidRaw),
-        ppid: Number(ppidRaw),
-        command: command.trim(),
+        pid,
+        ppid,
+        command: normalizedCommand,
       }
     })
     .filter((entry): entry is RuntimeProcessInfo => entry !== null)
@@ -81,10 +92,19 @@ export function collectOrphanedManagedProcessTree(processes: RuntimeProcessInfo[
   return collectProcessTreeFromRootPids(processes, roots)
 }
 
+export function buildPsSnapshotArgs(
+  platform: NodeJS.Platform = process.platform,
+  includeEnvironment = false,
+) {
+  if (platform === 'win32') return null
+  const commandColumn = platform === 'linux' ? 'args=' : 'command='
+  const args = ['-axo', `pid=,ppid=,${commandColumn}`]
+  return includeEnvironment ? ['eww', ...args] : args
+}
+
 function loadProcessSnapshot(includeEnvironment = false) {
-  const args = includeEnvironment
-    ? ['eww', '-axo', 'pid=,ppid=,command=']
-    : ['-axo', 'pid=,ppid=,command=']
+  const args = buildPsSnapshotArgs(process.platform, includeEnvironment)
+  if (!args) return []
   const output = execFileSync('ps', args, {
     encoding: 'utf8',
     maxBuffer: PS_SNAPSHOT_MAX_BUFFER_BYTES,

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -260,6 +260,7 @@ function sessionHasQueuedView(windowId: number, sessionId: string) {
 }
 
 function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: string) {
+  if (win.isDestroyed() || win.webContents.isDestroyed()) return
   const windowId = win.webContents.id
   const pending = pendingPatchFlushByWindowId.get(windowId)
   if (!pending || pending.patches.length === 0) return
@@ -454,6 +455,7 @@ function queueSessionHistoryRefresh(win: BrowserWindow, sessionId: string) {
             slowThresholdMs: 300,
             slowData: { sessionId: shortSessionId(sessionId) },
           })
+          flushQueuedSessionPatchesBeforeView(pending.win, sessionId)
           publishSessionView(pending.win, sessionId)
           publishSessionMetadata(pending.win, sessionId)
         } catch (err) {

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -260,8 +260,9 @@ function sessionHasQueuedView(windowId: number, sessionId: string) {
 }
 
 function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: string) {
-  if (win.isDestroyed() || win.webContents.isDestroyed()) return
-  const windowId = win.webContents.id
+  const webContents = win.webContents as BrowserWindow['webContents'] & { isDestroyed?: () => boolean }
+  if (win.isDestroyed() || webContents.isDestroyed?.()) return
+  const windowId = webContents.id
   const pending = pendingPatchFlushByWindowId.get(windowId)
   if (!pending || pending.patches.length === 0) return
 

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -77,6 +77,7 @@ const MAX_SESSION_PATCHES_PER_FLUSH = 128
 
 const pendingViewFlushByWindowId = new Map<number, PendingViewFlush>()
 const pendingPatchFlushByWindowId = new Map<number, PendingPatchFlush>()
+const patchViewRecoverySessionIdsByWindowId = new Map<number, Set<string>>()
 let sessionHistoryRefreshHandler: ((sessionId: string) => Promise<void>) | null = null
 const historyRefreshQueue = new Map<string, {
   win: BrowserWindow
@@ -220,6 +221,32 @@ export function publishSessionPatch(
   win.webContents.send('session:patch', patch)
 }
 
+function markSessionPatchViewRecovery(windowId: number, sessionId: string) {
+  const existing = patchViewRecoverySessionIdsByWindowId.get(windowId)
+  if (existing) {
+    existing.add(sessionId)
+    return
+  }
+  patchViewRecoverySessionIdsByWindowId.set(windowId, new Set([sessionId]))
+}
+
+function clearSessionPatchViewRecovery(windowId: number, sessionId: string) {
+  const existing = patchViewRecoverySessionIdsByWindowId.get(windowId)
+  if (!existing) return
+  existing.delete(sessionId)
+  if (existing.size === 0) patchViewRecoverySessionIdsByWindowId.delete(windowId)
+}
+
+function sessionNeedsPatchViewRecovery(windowId: number, sessionId: string) {
+  return patchViewRecoverySessionIdsByWindowId.get(windowId)?.has(sessionId) === true
+}
+
+function dropQueuedSessionPatches(pending: PendingPatchFlush, sessionId: string) {
+  const before = pending.patches.length
+  pending.patches = pending.patches.filter((queuedPatch) => queuedPatch.sessionId !== sessionId)
+  return before - pending.patches.length
+}
+
 function flushPendingSessionPatches(windowId: number) {
   const pending = pendingPatchFlushByWindowId.get(windowId)
   if (!pending) return
@@ -286,9 +313,15 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
   }
 
   if (pending.patches.length >= MAX_PENDING_SESSION_PATCHES_PER_WINDOW) {
-    pending.droppedPatches += 1
+    pending.droppedPatches += dropQueuedSessionPatches(pending, patch.sessionId) + 1
     pending.overflowSessionIds.add(patch.sessionId)
+    markSessionPatchViewRecovery(windowId, patch.sessionId)
     queueSessionViewPublish(win, patch.sessionId)
+    return
+  }
+
+  if (sessionNeedsPatchViewRecovery(windowId, patch.sessionId)) {
+    pending.droppedPatches += 1
     return
   }
 
@@ -299,7 +332,10 @@ function flushPendingSessionViews(windowId: number) {
   const pending = pendingViewFlushByWindowId.get(windowId)
   if (!pending) return
   pendingViewFlushByWindowId.delete(windowId)
-  if (pending.win.isDestroyed()) return
+  if (pending.win.isDestroyed()) {
+    for (const sessionId of pending.sessionIds) clearSessionPatchViewRecovery(windowId, sessionId)
+    return
+  }
   incrementPerfCounter('session.view.flushes')
   observePerf('session.view.flush.wait', Date.now() - pending.queuedAt, {
     unit: 'ms',
@@ -310,6 +346,7 @@ function flushPendingSessionViews(windowId: number) {
   measurePerf('session.view.flush.duration', () => {
     for (const sessionId of pending.sessionIds) {
       publishSessionView(pending.win, sessionId)
+      clearSessionPatchViewRecovery(windowId, sessionId)
     }
   }, {
     slowThresholdMs: 8,
@@ -395,8 +432,12 @@ function queueSessionHistoryRefresh(win: BrowserWindow, sessionId: string) {
 // publishSessionView (the session is gone by then) but is otherwise benign.
 export function dropSessionFromDispatcherQueues(sessionId: string) {
   historyRefreshQueue.delete(sessionId)
+  for (const [windowId, recoverySessionIds] of patchViewRecoverySessionIdsByWindowId.entries()) {
+    recoverySessionIds.delete(sessionId)
+    if (recoverySessionIds.size === 0) patchViewRecoverySessionIdsByWindowId.delete(windowId)
+  }
   for (const [windowId, pending] of pendingPatchFlushByWindowId.entries()) {
-    pending.patches = pending.patches.filter((patch) => patch.sessionId !== sessionId)
+    dropQueuedSessionPatches(pending, sessionId)
     pending.overflowSessionIds.delete(sessionId)
     if (pending.patches.length === 0 && pending.overflowSessionIds.size === 0) {
       if (pending.timer) clearTimeout(pending.timer)

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -62,7 +62,21 @@ type PendingViewFlush = {
   timer: ReturnType<typeof setTimeout> | null
 }
 
+type PendingPatchFlush = {
+  win: BrowserWindow
+  patches: SessionPatch[]
+  overflowSessionIds: Set<string>
+  droppedPatches: number
+  queuedAt: number
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+const SESSION_PATCH_FLUSH_INTERVAL_MS = 8
+const MAX_PENDING_SESSION_PATCHES_PER_WINDOW = 512
+const MAX_SESSION_PATCHES_PER_FLUSH = 128
+
 const pendingViewFlushByWindowId = new Map<number, PendingViewFlush>()
+const pendingPatchFlushByWindowId = new Map<number, PendingPatchFlush>()
 let sessionHistoryRefreshHandler: ((sessionId: string) => Promise<void>) | null = null
 const historyRefreshQueue = new Map<string, {
   win: BrowserWindow
@@ -206,6 +220,81 @@ export function publishSessionPatch(
   win.webContents.send('session:patch', patch)
 }
 
+function flushPendingSessionPatches(windowId: number) {
+  const pending = pendingPatchFlushByWindowId.get(windowId)
+  if (!pending) return
+  pending.timer = null
+
+  if (pending.win.isDestroyed() || pending.win.webContents.isDestroyed()) {
+    pendingPatchFlushByWindowId.delete(windowId)
+    return
+  }
+
+  const batch = pending.patches.splice(0, MAX_SESSION_PATCHES_PER_FLUSH)
+  if (batch.length > 0) {
+    observePerf('session.patch.flush.wait', Date.now() - pending.queuedAt, {
+      unit: 'ms',
+    })
+    observePerf('session.patch.flush.batch_size', batch.length, {
+      unit: 'count',
+    })
+    measurePerf('session.patch.flush.duration', () => {
+      for (const patch of batch) publishSessionPatch(pending.win, patch)
+    }, {
+      slowThresholdMs: 8,
+      slowData: {
+        windowId,
+        patchCount: batch.length,
+      },
+    })
+  }
+
+  if (pending.patches.length > 0) {
+    pending.timer = setTimeout(() => {
+      flushPendingSessionPatches(windowId)
+    }, 0)
+    return
+  }
+
+  pendingPatchFlushByWindowId.delete(windowId)
+  if (pending.droppedPatches > 0) {
+    incrementPerfCounter('session.patch.dropped')
+    log(
+      'events',
+      `Dropped ${pending.droppedPatches} queued session patch${pending.droppedPatches === 1 ? '' : 'es'} for window=${windowId}; queued full view catch-up for ${pending.overflowSessionIds.size} session${pending.overflowSessionIds.size === 1 ? '' : 's'}`,
+    )
+  }
+}
+
+function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null | undefined) {
+  if (!patch) return
+  const windowId = win.webContents.id
+  let pending = pendingPatchFlushByWindowId.get(windowId)
+  if (!pending) {
+    pending = {
+      win,
+      patches: [],
+      overflowSessionIds: new Set(),
+      droppedPatches: 0,
+      queuedAt: Date.now(),
+      timer: null,
+    }
+    pending.timer = setTimeout(() => {
+      flushPendingSessionPatches(windowId)
+    }, SESSION_PATCH_FLUSH_INTERVAL_MS)
+    pendingPatchFlushByWindowId.set(windowId, pending)
+  }
+
+  if (pending.patches.length >= MAX_PENDING_SESSION_PATCHES_PER_WINDOW) {
+    pending.droppedPatches += 1
+    pending.overflowSessionIds.add(patch.sessionId)
+    queueSessionViewPublish(win, patch.sessionId)
+    return
+  }
+
+  pending.patches.push(patch)
+}
+
 function flushPendingSessionViews(windowId: number) {
   const pending = pendingViewFlushByWindowId.get(windowId)
   if (!pending) return
@@ -306,6 +395,14 @@ function queueSessionHistoryRefresh(win: BrowserWindow, sessionId: string) {
 // publishSessionView (the session is gone by then) but is otherwise benign.
 export function dropSessionFromDispatcherQueues(sessionId: string) {
   historyRefreshQueue.delete(sessionId)
+  for (const [windowId, pending] of pendingPatchFlushByWindowId.entries()) {
+    pending.patches = pending.patches.filter((patch) => patch.sessionId !== sessionId)
+    pending.overflowSessionIds.delete(sessionId)
+    if (pending.patches.length === 0 && pending.overflowSessionIds.size === 0) {
+      if (pending.timer) clearTimeout(pending.timer)
+      pendingPatchFlushByWindowId.delete(windowId)
+    }
+  }
   for (const [windowId, pending] of pendingViewFlushByWindowId.entries()) {
     if (!pending.sessionIds.delete(sessionId)) continue
     if (pending.sessionIds.size === 0) {
@@ -334,7 +431,7 @@ export function dispatchRuntimeSessionEvent(
     queueSessionHistoryRefresh(win, event.sessionId)
     return
   }
-  publishSessionPatch(win, getSessionPatch(event))
+  queueSessionPatchPublish(win, getSessionPatch(event))
   if (event.sessionId && shouldPublishSessionView(event)) {
     queueSessionViewPublish(win, event.sessionId)
   }

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -247,6 +247,14 @@ function dropQueuedSessionPatches(pending: PendingPatchFlush, sessionId: string)
   return before - pending.patches.length
 }
 
+function recoverSessionWithQueuedView(windowId: number, sessionId: string, pending?: PendingPatchFlush) {
+  markSessionPatchViewRecovery(windowId, sessionId)
+  if (!pending) return
+  const dropped = dropQueuedSessionPatches(pending, sessionId)
+  if (dropped > 0) pending.droppedPatches += dropped
+  pending.overflowSessionIds.add(sessionId)
+}
+
 function flushPendingSessionPatches(windowId: number) {
   const pending = pendingPatchFlushByWindowId.get(windowId)
   if (!pending) return
@@ -312,16 +320,16 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
     pendingPatchFlushByWindowId.set(windowId, pending)
   }
 
-  if (pending.patches.length >= MAX_PENDING_SESSION_PATCHES_PER_WINDOW) {
-    pending.droppedPatches += dropQueuedSessionPatches(pending, patch.sessionId) + 1
+  if (sessionNeedsPatchViewRecovery(windowId, patch.sessionId)) {
+    pending.droppedPatches += 1
     pending.overflowSessionIds.add(patch.sessionId)
-    markSessionPatchViewRecovery(windowId, patch.sessionId)
-    queueSessionViewPublish(win, patch.sessionId)
     return
   }
 
-  if (sessionNeedsPatchViewRecovery(windowId, patch.sessionId)) {
+  if (pending.patches.length >= MAX_PENDING_SESSION_PATCHES_PER_WINDOW) {
+    recoverSessionWithQueuedView(windowId, patch.sessionId, pending)
     pending.droppedPatches += 1
+    queueSessionViewPublish(win, patch.sessionId)
     return
   }
 
@@ -359,6 +367,7 @@ function flushPendingSessionViews(windowId: number) {
 
 function queueSessionViewPublish(win: BrowserWindow, sessionId: string) {
   const windowId = win.webContents.id
+  recoverSessionWithQueuedView(windowId, sessionId, pendingPatchFlushByWindowId.get(windowId))
   const existing = pendingViewFlushByWindowId.get(windowId)
   if (existing) {
     existing.sessionIds.add(sessionId)

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -247,12 +247,30 @@ function dropQueuedSessionPatches(pending: PendingPatchFlush, sessionId: string)
   return before - pending.patches.length
 }
 
-function recoverSessionWithQueuedView(windowId: number, sessionId: string, pending?: PendingPatchFlush) {
+function recoverSessionWithViewOnlyCatchUp(windowId: number, sessionId: string, pending?: PendingPatchFlush) {
   markSessionPatchViewRecovery(windowId, sessionId)
   if (!pending) return
   const dropped = dropQueuedSessionPatches(pending, sessionId)
   if (dropped > 0) pending.droppedPatches += dropped
   pending.overflowSessionIds.add(sessionId)
+}
+
+function sessionHasQueuedView(windowId: number, sessionId: string) {
+  return pendingViewFlushByWindowId.get(windowId)?.sessionIds.has(sessionId) === true
+}
+
+function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: string) {
+  const windowId = win.webContents.id
+  const pending = pendingPatchFlushByWindowId.get(windowId)
+  if (!pending || pending.patches.length === 0) return
+
+  const queuedForSession: SessionPatch[] = []
+  pending.patches = pending.patches.filter((patch) => {
+    if (patch.sessionId !== sessionId) return true
+    queuedForSession.push(patch)
+    return false
+  })
+  for (const patch of queuedForSession) publishSessionPatch(win, patch)
 }
 
 function flushPendingSessionPatches(windowId: number) {
@@ -304,6 +322,32 @@ function flushPendingSessionPatches(windowId: number) {
 function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null | undefined) {
   if (!patch) return
   const windowId = win.webContents.id
+  if (sessionNeedsPatchViewRecovery(windowId, patch.sessionId)) {
+    let pending = pendingPatchFlushByWindowId.get(windowId)
+    if (!pending) {
+      pending = {
+        win,
+        patches: [],
+        overflowSessionIds: new Set(),
+        droppedPatches: 0,
+        queuedAt: Date.now(),
+        timer: null,
+      }
+      pending.timer = setTimeout(() => {
+        flushPendingSessionPatches(windowId)
+      }, SESSION_PATCH_FLUSH_INTERVAL_MS)
+      pendingPatchFlushByWindowId.set(windowId, pending)
+    }
+    pending.droppedPatches += 1
+    pending.overflowSessionIds.add(patch.sessionId)
+    return
+  }
+
+  if (sessionHasQueuedView(windowId, patch.sessionId)) {
+    publishSessionPatch(win, patch)
+    return
+  }
+
   let pending = pendingPatchFlushByWindowId.get(windowId)
   if (!pending) {
     pending = {
@@ -320,14 +364,8 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
     pendingPatchFlushByWindowId.set(windowId, pending)
   }
 
-  if (sessionNeedsPatchViewRecovery(windowId, patch.sessionId)) {
-    pending.droppedPatches += 1
-    pending.overflowSessionIds.add(patch.sessionId)
-    return
-  }
-
   if (pending.patches.length >= MAX_PENDING_SESSION_PATCHES_PER_WINDOW) {
-    recoverSessionWithQueuedView(windowId, patch.sessionId, pending)
+    recoverSessionWithViewOnlyCatchUp(windowId, patch.sessionId, pending)
     pending.droppedPatches += 1
     queueSessionViewPublish(win, patch.sessionId)
     return
@@ -367,7 +405,9 @@ function flushPendingSessionViews(windowId: number) {
 
 function queueSessionViewPublish(win: BrowserWindow, sessionId: string) {
   const windowId = win.webContents.id
-  recoverSessionWithQueuedView(windowId, sessionId, pendingPatchFlushByWindowId.get(windowId))
+  if (!sessionNeedsPatchViewRecovery(windowId, sessionId)) {
+    flushQueuedSessionPatchesBeforeView(win, sessionId)
+  }
   const existing = pendingViewFlushByWindowId.get(windowId)
   if (existing) {
     existing.sessionIds.add(sessionId)

--- a/apps/desktop/src/main/session-registry.ts
+++ b/apps/desktop/src/main/session-registry.ts
@@ -31,6 +31,8 @@ export interface SessionRecord {
 
 let registryCache: Map<string, SessionRecord> | null = null
 let saveTimer: NodeJS.Timeout | null = null
+let registryWriteInProgress = false
+let registryWriteRequestedDuringWrite = false
 const SAVE_DEBOUNCE_MS = 2000
 
 function getRegistryDir() {
@@ -124,7 +126,7 @@ function loadRegistryMap() {
   return next
 }
 
-function writeRegistryMap(map: Map<string, SessionRecord>) {
+function writeRegistryMapSnapshot(map: Map<string, SessionRecord>) {
   const records = Array.from(map.values()).sort((a, b) => {
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
   })
@@ -133,6 +135,25 @@ function writeRegistryMap(map: Map<string, SessionRecord>) {
   // + rename uniformly with the rest of the app's credential-bearing
   // writes.
   writeFileAtomic(getRegistryPath(), JSON.stringify(records, null, 2), { mode: 0o600 })
+}
+
+function writeRegistryMap(map: Map<string, SessionRecord>) {
+  if (registryWriteInProgress) {
+    registryWriteRequestedDuringWrite = true
+    return
+  }
+
+  registryWriteInProgress = true
+  try {
+    do {
+      registryWriteRequestedDuringWrite = false
+      // Always serialize the current in-memory map rather than a captured
+      // array so nested writes drain to the latest cache state.
+      writeRegistryMapSnapshot(map)
+    } while (registryWriteRequestedDuringWrite)
+  } finally {
+    registryWriteInProgress = false
+  }
 }
 
 function scheduleRegistrySave() {
@@ -272,5 +293,7 @@ export function clearSessionRegistryCache() {
     clearTimeout(saveTimer)
     saveTimer = null
   }
+  registryWriteRequestedDuringWrite = false
+  registryWriteInProgress = false
   registryCache = null
 }

--- a/apps/desktop/src/renderer/components/accessibility-smoke.test.tsx
+++ b/apps/desktop/src/renderer/components/accessibility-smoke.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { LoginScreen } from './LoginScreen'
 import { ApprovalCard } from './chat/ApprovalCard'
 import type { PendingApproval } from '../stores/session'
 import { SettingsPanel } from './sidebar/SettingsPanel'
+import { configureI18n } from '../helpers/i18n'
 
 const axeOptions = {
   rules: {
@@ -19,6 +20,10 @@ async function expectNoA11yViolations(container: HTMLElement) {
   const result = await axe(container, axeOptions)
   expect(result.violations).toEqual([])
 }
+
+afterEach(async () => {
+  await configureI18n({ locale: 'en' })
+})
 
 const approval: PendingApproval = {
   id: 'permission-1',
@@ -51,6 +56,18 @@ describe('focused accessibility smoke', () => {
     const { container } = render(<SettingsPanel onClose={() => undefined} />)
 
     expect(await screen.findByText('Settings')).toBeInTheDocument()
+    await expectNoA11yViolations(container)
+  })
+
+  it('keeps the settings shell accessible when the active locale is RTL', async () => {
+    await configureI18n({ locale: 'ar' })
+
+    const { container } = render(<SettingsPanel onClose={() => undefined} />)
+
+    expect(document.documentElement).toHaveAttribute('lang', 'ar')
+    expect(document.documentElement).toHaveAttribute('dir', 'rtl')
+    expect(await screen.findByText('الإعدادات')).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'اللغة' })).toHaveValue('ar')
     await expectNoA11yViolations(container)
   })
 })

--- a/apps/desktop/src/renderer/stores/session-view-reducer.ts
+++ b/apps/desktop/src/renderer/stores/session-view-reducer.ts
@@ -1,0 +1,189 @@
+import type { SessionPatch, TaskRun } from '@open-cowork/shared'
+import {
+  deriveVisibleSessionPatch,
+  getOrCreateSessionState,
+  hasMessageTextSegment,
+  hasSplitMessageTextSegment,
+  pruneSessionDetailCache,
+  withMessageReasoning,
+  withMessageText,
+  withTaskReasoning,
+  withTaskRun,
+  withTaskTranscript,
+  type SessionViewState,
+} from '../../lib/session-view-model.ts'
+import type { SessionStore } from './session.ts'
+
+export function sumSessionCosts(sessionStateById: Record<string, SessionViewState>) {
+  return Object.values(sessionStateById)
+    .reduce((sum, sessionState) => sum + (sessionState.sessionCost || 0), 0)
+}
+
+export function sessionViewTiming() {
+  return {
+    nowMs: Date.now(),
+    nowIso: new Date().toISOString(),
+    formatTimestamp: (timestamp: number) => new Date(timestamp).toISOString(),
+  }
+}
+
+function latestOrder(...groups: readonly (readonly { order?: number | null }[] | null | undefined)[]) {
+  let max: number | null = null
+  for (const group of groups) {
+    if (!group) continue
+    for (const entry of group) {
+      const order = typeof entry.order === 'number' && Number.isFinite(entry.order) ? entry.order : null
+      if (order !== null && (max === null || order > max)) max = order
+    }
+  }
+  return max ?? undefined
+}
+
+function latestTaskInterruptionOrder(taskRun: TaskRun) {
+  return latestOrder(taskRun.toolCalls, taskRun.compactions)
+}
+
+function latestSessionInterruptionOrder(current: SessionViewState) {
+  return latestOrder(
+    current.toolCalls,
+    current.taskRuns,
+    current.compactions,
+    current.pendingApprovals,
+    current.errors,
+  )
+}
+
+function shouldComputeMessageSplitOrder(
+  current: SessionViewState,
+  messageId: string,
+  segmentId: string,
+) {
+  return hasMessageTextSegment(current, messageId, segmentId)
+    && (current.lastItemWasTool || !hasSplitMessageTextSegment(current, messageId, segmentId))
+}
+
+export function updateSessionState(
+  state: SessionStore,
+  sessionId: string,
+  updater: (current: SessionViewState) => SessionViewState,
+  options?: { eventAt?: number },
+) {
+  const sessionStateById = { ...state.sessionStateById }
+  const timing = sessionViewTiming()
+  const current = getOrCreateSessionState(sessionStateById, sessionId, timing)
+  const updated = updater(current)
+  const next = {
+    ...updated,
+    revision: current.revision + 1,
+    lastEventAt: options?.eventAt ?? timing.nowMs,
+  }
+  sessionStateById[sessionId] = next
+  const prunedSessionStateById = pruneSessionDetailCache(sessionStateById, state.currentSessionId, state.busySessions)
+
+  const patch: Partial<SessionStore> = {
+    sessionStateById: prunedSessionStateById,
+    totalCost: sumSessionCosts(prunedSessionStateById),
+  }
+  if (state.currentSessionId === sessionId) {
+    const visibleState = prunedSessionStateById[sessionId] || next
+    patch.currentView = deriveVisibleSessionPatch(
+      visibleState,
+      sessionId,
+      state.busySessions,
+      state.awaitingPermissionSessions,
+      timing,
+    )
+  }
+  return patch
+}
+
+export function applySessionPatchToState(state: SessionStore, patch: SessionPatch) {
+  if (patch.type === 'task_text') {
+    return updateSessionState(
+      state,
+      patch.sessionId,
+      (current) => ({
+        ...current,
+        taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
+          ...withTaskTranscript(taskRun, patch.segmentId, patch.content, {
+            replace: patch.mode === 'replace',
+            splitAfterOrder: patch.mode === 'replace' ? undefined : latestTaskInterruptionOrder(taskRun),
+          }),
+        })),
+        lastItemWasTool: true,
+      }),
+      { eventAt: patch.eventAt },
+    )
+  }
+
+  if (patch.type === 'task_reasoning') {
+    return updateSessionState(
+      state,
+      patch.sessionId,
+      (current) => ({
+        ...current,
+        taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
+          ...withTaskReasoning(taskRun, patch.segmentId, patch.content, {
+            replace: patch.mode === 'replace',
+          }),
+        })),
+        lastItemWasTool: true,
+      }),
+      { eventAt: patch.eventAt },
+    )
+  }
+
+  if (patch.type === 'message_reasoning') {
+    return updateSessionState(
+      state,
+      patch.sessionId,
+      (current) => ({
+        ...current,
+        ...withMessageReasoning(current, {
+          messageId: patch.messageId,
+          content: patch.content,
+          segmentId: patch.segmentId,
+          replace: patch.mode === 'replace',
+        }, sessionViewTiming()),
+        lastItemWasTool: false,
+      }),
+      { eventAt: patch.eventAt },
+    )
+  }
+
+  return updateSessionState(
+    state,
+    patch.sessionId,
+    (current) => {
+      const splitAfterOrder = patch.mode === 'replace'
+        ? undefined
+        : shouldComputeMessageSplitOrder(current, patch.messageId, patch.segmentId)
+          ? latestSessionInterruptionOrder(current)
+          : undefined
+      return {
+        ...current,
+        ...withMessageText(current, {
+          messageId: patch.messageId,
+          role: patch.role || 'assistant',
+          content: patch.content,
+          segmentId: patch.segmentId,
+          attachments: patch.attachments,
+          replace: patch.mode === 'replace',
+          splitAfterOrder,
+        }, sessionViewTiming()),
+        lastItemWasTool: false,
+      }
+    },
+    { eventAt: patch.eventAt },
+  )
+}
+
+export function orderSessionPatches(patches: SessionPatch[]) {
+  return patches
+    .map((patch, index) => ({ patch, index }))
+    .sort((left, right) => {
+      if (left.patch.eventAt !== right.patch.eventAt) return left.patch.eventAt - right.patch.eventAt
+      return left.index - right.index
+    })
+    .map(({ patch }) => patch)
+}

--- a/apps/desktop/src/renderer/stores/session.ts
+++ b/apps/desktop/src/renderer/stores/session.ts
@@ -8,23 +8,22 @@ import type {
   SessionError,
   SessionView,
   PermissionRequest,
-  TaskRun,
 } from '@open-cowork/shared'
 import {
   buildSessionStateFromView,
   createEmptySessionViewState,
   deriveVisibleSessionPatch,
   getOrCreateSessionState,
-  hasMessageTextSegment,
-  hasSplitMessageTextSegment,
   pruneSessionDetailCache,
-  withMessageReasoning,
-  withMessageText,
-  withTaskReasoning,
-  withTaskRun,
-  withTaskTranscript,
   type SessionViewState,
 } from '../../lib/session-view-model.ts'
+import {
+  applySessionPatchToState,
+  orderSessionPatches,
+  sessionViewTiming,
+  sumSessionCosts,
+  updateSessionState,
+} from './session-view-reducer.ts'
 
 export type {
   CompactionNotice,
@@ -52,7 +51,7 @@ export interface McpConnection {
   error?: string
 }
 
-interface SessionStore {
+export interface SessionStore {
   sessions: Session[]
   currentSessionId: string | null
   currentView: SessionView
@@ -110,180 +109,6 @@ interface SessionStore {
   // merge them alongside the tool-derived list.
   chartArtifactsBySession: Record<string, SessionArtifact[]>
   registerChartArtifact: (sessionId: string, artifact: SessionArtifact) => void
-}
-
-function sumSessionCosts(sessionStateById: Record<string, SessionViewState>) {
-  return Object.values(sessionStateById)
-    .reduce((sum, sessionState) => sum + (sessionState.sessionCost || 0), 0)
-}
-
-function sessionViewTiming() {
-  return {
-    nowMs: Date.now(),
-    nowIso: new Date().toISOString(),
-    formatTimestamp: (timestamp: number) => new Date(timestamp).toISOString(),
-  }
-}
-
-function latestOrder(...groups: readonly (readonly { order?: number | null }[] | null | undefined)[]) {
-  let max: number | null = null
-  for (const group of groups) {
-    if (!group) continue
-    for (const entry of group) {
-      const order = typeof entry.order === 'number' && Number.isFinite(entry.order) ? entry.order : null
-      if (order !== null && (max === null || order > max)) max = order
-    }
-  }
-  return max ?? undefined
-}
-
-function latestTaskInterruptionOrder(taskRun: TaskRun) {
-  return latestOrder(taskRun.toolCalls, taskRun.compactions)
-}
-
-function latestSessionInterruptionOrder(current: SessionViewState) {
-  return latestOrder(
-    current.toolCalls,
-    current.taskRuns,
-    current.compactions,
-    current.pendingApprovals,
-    current.errors,
-  )
-}
-
-function shouldComputeMessageSplitOrder(
-  current: SessionViewState,
-  messageId: string,
-  segmentId: string,
-) {
-  return hasMessageTextSegment(current, messageId, segmentId)
-    && (current.lastItemWasTool || !hasSplitMessageTextSegment(current, messageId, segmentId))
-}
-
-function updateSessionState(
-  state: SessionStore,
-  sessionId: string,
-  updater: (current: SessionViewState) => SessionViewState,
-  options?: { eventAt?: number },
-) {
-  const sessionStateById = { ...state.sessionStateById }
-  const timing = sessionViewTiming()
-  const current = getOrCreateSessionState(sessionStateById, sessionId, timing)
-  const updated = updater(current)
-  const next = {
-    ...updated,
-    revision: current.revision + 1,
-    lastEventAt: options?.eventAt ?? timing.nowMs,
-  }
-  sessionStateById[sessionId] = next
-  const prunedSessionStateById = pruneSessionDetailCache(sessionStateById, state.currentSessionId, state.busySessions)
-
-  const patch: Partial<SessionStore> = {
-    sessionStateById: prunedSessionStateById,
-    totalCost: sumSessionCosts(prunedSessionStateById),
-  }
-  if (state.currentSessionId === sessionId) {
-    const visibleState = prunedSessionStateById[sessionId] || next
-    patch.currentView = deriveVisibleSessionPatch(
-      visibleState,
-      sessionId,
-      state.busySessions,
-      state.awaitingPermissionSessions,
-      timing,
-    )
-  }
-  return patch
-}
-
-function applySessionPatchToState(state: SessionStore, patch: SessionPatch) {
-  if (patch.type === 'task_text') {
-    return updateSessionState(
-      state,
-      patch.sessionId,
-      (current) => ({
-        ...current,
-        taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
-          ...withTaskTranscript(taskRun, patch.segmentId, patch.content, {
-            replace: patch.mode === 'replace',
-            splitAfterOrder: patch.mode === 'replace' ? undefined : latestTaskInterruptionOrder(taskRun),
-          }),
-        })),
-        lastItemWasTool: true,
-      }),
-      { eventAt: patch.eventAt },
-    )
-  }
-
-  if (patch.type === 'task_reasoning') {
-    return updateSessionState(
-      state,
-      patch.sessionId,
-      (current) => ({
-        ...current,
-        taskRuns: withTaskRun(current.taskRuns, patch.taskRunId, (taskRun) => ({
-          ...withTaskReasoning(taskRun, patch.segmentId, patch.content, {
-            replace: patch.mode === 'replace',
-          }),
-        })),
-        lastItemWasTool: true,
-      }),
-      { eventAt: patch.eventAt },
-    )
-  }
-
-  if (patch.type === 'message_reasoning') {
-    return updateSessionState(
-      state,
-      patch.sessionId,
-      (current) => ({
-        ...current,
-        ...withMessageReasoning(current, {
-          messageId: patch.messageId,
-          content: patch.content,
-          segmentId: patch.segmentId,
-          replace: patch.mode === 'replace',
-        }, sessionViewTiming()),
-        lastItemWasTool: false,
-      }),
-      { eventAt: patch.eventAt },
-    )
-  }
-
-  return updateSessionState(
-    state,
-    patch.sessionId,
-    (current) => {
-      const splitAfterOrder = patch.mode === 'replace'
-        ? undefined
-        : shouldComputeMessageSplitOrder(current, patch.messageId, patch.segmentId)
-          ? latestSessionInterruptionOrder(current)
-          : undefined
-      return {
-        ...current,
-        ...withMessageText(current, {
-          messageId: patch.messageId,
-          role: patch.role || 'assistant',
-          content: patch.content,
-          segmentId: patch.segmentId,
-          attachments: patch.attachments,
-          replace: patch.mode === 'replace',
-          splitAfterOrder,
-        }, sessionViewTiming()),
-        lastItemWasTool: false,
-      }
-    },
-    { eventAt: patch.eventAt },
-  )
-}
-
-function orderSessionPatches(patches: SessionPatch[]) {
-  return patches
-    .map((patch, index) => ({ patch, index }))
-    .sort((left, right) => {
-      if (left.patch.eventAt !== right.patch.eventAt) return left.patch.eventAt - right.patch.eventAt
-      return left.index - right.index
-    })
-    .map(({ patch }) => patch)
 }
 
 export const useSessionStore = create<SessionStore>((set) => ({

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -14,6 +14,7 @@ import { registerWorkflowHandlers } from '../apps/desktop/src/main/ipc/workflow-
 import { registerCatalogHandlers } from '../apps/desktop/src/main/ipc/catalog-handlers.ts'
 import { registerThreadHandlers } from '../apps/desktop/src/main/ipc/thread-handlers.ts'
 import { sniffImageMime } from '../apps/desktop/src/main/ipc/app-handler-support.ts'
+import { validateCustomSkillConfig } from '../apps/desktop/src/main/ipc/object-validators.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
@@ -495,6 +496,22 @@ test('custom content write handlers reject malformed objects before save paths',
     /custom MCP to be an object/,
   )
   assert.equal(confirmed, false)
+})
+
+test('custom skill IPC validation preserves supporting file content bytes', () => {
+  const paddedContent = '  keep leading whitespace\nand trailing whitespace  \n'
+  const validated = validateCustomSkillConfig({
+    scope: 'machine',
+    name: 'test-skill',
+    content: 'Skill body',
+    files: [
+      { path: 'notes.txt', content: paddedContent },
+      { path: 'empty.txt', content: '' },
+    ],
+  })
+
+  assert.equal(validated.files?.[0]?.content, paddedContent)
+  assert.equal(validated.files?.[1]?.content, '')
 })
 
 test('explorer:file-read returns null for ungranted renderer-supplied directories', async () => {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -12,6 +12,7 @@ import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/cust
 import { normalizeFindTextPattern, registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
 import { registerWorkflowHandlers } from '../apps/desktop/src/main/ipc/workflow-handlers.ts'
 import { registerCatalogHandlers } from '../apps/desktop/src/main/ipc/catalog-handlers.ts'
+import { registerThreadHandlers } from '../apps/desktop/src/main/ipc/thread-handlers.ts'
 import { sniffImageMime } from '../apps/desktop/src/main/ipc/app-handler-support.ts'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-state.ts'
@@ -928,6 +929,80 @@ test('tool:list rejects malformed options before runtime tool discovery', async 
     /tool list options to be an object/,
   )
   assert.equal(runtimeToolListCalled, false)
+})
+
+test('settings:set rejects unknown and malformed settings payloads before saving', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerAppHandlers(context)
+  const handler = handlers.get('settings:set')
+
+  assert.ok(handler, 'expected settings:set handler to be registered')
+  await assert.rejects(
+    () => handler({}, { unknownSetting: true }),
+    /Unknown settings key/,
+  )
+  await assert.rejects(
+    () => handler({}, { providerCredentials: { openai: { apiKey: 42 } } }),
+    /Provider credentials\.openai\.apiKey must be a string/,
+  )
+})
+
+test('custom MCP IPC rejects malformed nested records before persistence', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerCustomContentHandlers(context)
+  const handler = handlers.get('custom:add-mcp')
+
+  assert.ok(handler, 'expected custom:add-mcp handler to be registered')
+  await assert.rejects(
+    () => handler({}, {
+      scope: 'machine',
+      name: 'local-tools',
+      type: 'stdio',
+      command: 'node',
+      env: { OPEN_COWORK_TOKEN: 123 },
+    }),
+    /MCP env\.OPEN_COWORK_TOKEN must be a string/,
+  )
+})
+
+test('thread object IPC validates query and tag payload shape before store access', async () => {
+  const { context, handlers } = createBaseContext()
+
+  registerThreadHandlers(context)
+  const search = handlers.get('threads:search')
+  const createTag = handlers.get('threads:tags:create')
+
+  assert.ok(search, 'expected threads:search handler to be registered')
+  assert.ok(createTag, 'expected threads:tags:create handler to be registered')
+  await assert.rejects(
+    () => search({}, { statuses: ['not-a-status'] }),
+    /Invalid thread status/,
+  )
+  await assert.rejects(
+    () => createTag({}, { color: '#ffffff' }),
+    /Tag name must be a string/,
+  )
+})
+
+test('artifact IPC validates request shape before resolving private paths', async () => {
+  const { context, handlers } = createBaseContext()
+  let resolveCalled = false
+  context.resolvePrivateArtifactPath = () => {
+    resolveCalled = true
+    return { root: '/tmp', source: '/tmp/file.txt' }
+  }
+
+  registerArtifactHandlers(context)
+  const handler = handlers.get('artifact:export')
+
+  assert.ok(handler, 'expected artifact:export handler to be registered')
+  await assert.rejects(
+    () => handler({}, { sessionId: 'session-1', filePath: '' }),
+    /Artifact path is required/,
+  )
+  assert.equal(resolveCalled, false)
 })
 
 test('chart:save-artifact rejects unknown sessions before writing chart bytes', async () => {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -498,20 +498,26 @@ test('custom content write handlers reject malformed objects before save paths',
   assert.equal(confirmed, false)
 })
 
-test('custom skill IPC validation preserves supporting file content bytes', () => {
+test('custom skill IPC validation preserves authored content bytes', () => {
+  const skillContent = '  Skill body\n\nkeep intentional trailing newline\n'
   const paddedContent = '  keep leading whitespace\nand trailing whitespace  \n'
   const validated = validateCustomSkillConfig({
     scope: 'machine',
     name: 'test-skill',
-    content: 'Skill body',
+    content: skillContent,
     files: [
       { path: 'notes.txt', content: paddedContent },
       { path: 'empty.txt', content: '' },
     ],
   })
 
+  assert.equal(validated.content, skillContent)
   assert.equal(validated.files?.[0]?.content, paddedContent)
   assert.equal(validated.files?.[1]?.content, '')
+  assert.throws(
+    () => validateCustomSkillConfig({ scope: 'machine', name: 'empty-skill', content: '   \n' }),
+    /Skill content is required/,
+  )
 })
 
 test('explorer:file-read returns null for ungranted renderer-supplied directories', async () => {

--- a/tests/runtime-process-cleanup.test.ts
+++ b/tests/runtime-process-cleanup.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import {
+  buildPsSnapshotArgs,
   collectOrphanedManagedProcessTree,
   collectProcessTreeFromRootPids,
   isManagedOpencodeServeCommand,
@@ -53,6 +54,39 @@ test('parsePsOutput reads pid, ppid, and command from ps output', () => {
       command: `node /opt/open-cowork/mcps/charts/dist/index.js PATH=/usr/bin ${OPEN_COWORK_MANAGED_RUNTIME_ENV}=${OPEN_COWORK_MANAGED_RUNTIME_VALUE}`,
     },
   ])
+})
+
+test('parsePsOutput skips headers and malformed rows while preserving ppid zero', () => {
+  const parsed = parsePsOutput([
+    'PID PPID COMMAND',
+    'not-a-pid 1 /bin/echo bad',
+    '1000 0 /sbin/launchd',
+    '1001 1000',
+    '1002 1000 COMMAND',
+    '1003 1000 ARGS',
+    '1004 1000 /usr/bin/node script.js',
+  ].join('\n'))
+
+  assert.deepEqual(parsed, [
+    {
+      pid: 1000,
+      ppid: 0,
+      command: '/sbin/launchd',
+    },
+    {
+      pid: 1004,
+      ppid: 1000,
+      command: '/usr/bin/node script.js',
+    },
+  ])
+})
+
+test('buildPsSnapshotArgs chooses platform-specific command columns', () => {
+  assert.deepEqual(buildPsSnapshotArgs('darwin', false), ['-axo', 'pid=,ppid=,command='])
+  assert.deepEqual(buildPsSnapshotArgs('darwin', true), ['eww', '-axo', 'pid=,ppid=,command='])
+  assert.deepEqual(buildPsSnapshotArgs('linux', false), ['-axo', 'pid=,ppid=,args='])
+  assert.deepEqual(buildPsSnapshotArgs('linux', true), ['eww', '-axo', 'pid=,ppid=,args='])
+  assert.equal(buildPsSnapshotArgs('win32', false), null)
 })
 
 test('collectOrphanedManagedProcessTree returns orphaned Cowork runtime roots and descendants', () => {

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -149,8 +149,68 @@ test('dispatcher bounds queued patches and schedules full-view catch-up on overf
   await wait(80)
 
   const patchCount = sent.filter((entry) => entry.channel === 'session:patch').length
-  assert.equal(patchCount, 512)
+  assert.equal(patchCount, 0)
   assert.equal(sent.some((entry) => entry.channel === 'session:view'), true)
+})
+
+test('dispatcher overflow drops only patches for the recovering session', async () => {
+  const { win, sent } = createWindowCollector(52)
+
+  for (let index = 0; index < 511; index += 1) {
+    dispatchRuntimeSessionEvent(win as any, {
+      type: 'text',
+      sessionId: 'session-patch-overflow-scoped',
+      data: {
+        type: 'text',
+        messageId: 'message-overflow-scoped',
+        partId: `part-${index}`,
+        content: `overflow-${index}`,
+        mode: 'append',
+      },
+    })
+  }
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-patch-neighbor',
+    data: {
+      type: 'text',
+      messageId: 'message-neighbor',
+      partId: 'part-neighbor',
+      content: 'neighbor',
+      mode: 'append',
+    },
+  })
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-patch-overflow-scoped',
+    data: {
+      type: 'text',
+      messageId: 'message-overflow-scoped',
+      partId: 'part-overflow-trigger',
+      content: 'overflow-trigger',
+      mode: 'append',
+    },
+  })
+
+  await wait(80)
+
+  const patchPayloads = sent
+    .filter((entry) => entry.channel === 'session:patch')
+    .map((entry) => {
+      const payload = entry.payload as { sessionId?: string; content?: string }
+      return {
+        sessionId: payload.sessionId,
+        content: payload.content,
+      }
+    })
+  assert.deepEqual(patchPayloads, [{
+    sessionId: 'session-patch-neighbor',
+    content: 'neighbor',
+  }])
+  assert.equal(
+    sent.some((entry) => entry.channel === 'session:view' && (entry.payload as { sessionId?: string }).sessionId === 'session-patch-overflow-scoped'),
+    true,
+  )
 })
 
 test('dispatcher derives renderer-safe reasoning patches without forcing full view publishes', () => {

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -29,6 +29,23 @@ function eventOf(type: string, sessionId?: string | null) {
   }
 }
 
+function wait(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+function createWindowCollector(id: number) {
+  const sent: Array<{ channel: string; payload: unknown }> = []
+  const win = {
+    isDestroyed: () => false,
+    webContents: {
+      id,
+      isDestroyed: () => false,
+      send: (channel: string, payload: unknown) => sent.push({ channel, payload }),
+    },
+  }
+  return { win, sent }
+}
+
 test('dispatcher derives renderer-safe text patches', () => {
   assert.deepEqual(getSessionPatch({
     type: 'text',
@@ -75,6 +92,65 @@ test('dispatcher derives renderer-safe text patches', () => {
 
   assert.equal(getSessionPatch(eventOf('done', 'session-1')), null)
   assert.equal(getSessionPatch(eventOf('error')), null)
+})
+
+test('dispatcher batches text patches in event order', async () => {
+  const { win, sent } = createWindowCollector(50)
+
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-patch-order',
+    data: {
+      type: 'text',
+      messageId: 'message-1',
+      partId: 'part-1',
+      content: 'first',
+      mode: 'append',
+    },
+  })
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-patch-order',
+    data: {
+      type: 'text',
+      messageId: 'message-1',
+      partId: 'part-1',
+      content: 'second',
+      mode: 'append',
+    },
+  })
+
+  assert.equal(sent.some((entry) => entry.channel === 'session:patch'), false)
+  await wait(20)
+
+  assert.deepEqual(
+    sent.filter((entry) => entry.channel === 'session:patch').map((entry) => (entry.payload as { content?: string }).content),
+    ['first', 'second'],
+  )
+})
+
+test('dispatcher bounds queued patches and schedules full-view catch-up on overflow', async () => {
+  const { win, sent } = createWindowCollector(51)
+
+  for (let index = 0; index < 520; index += 1) {
+    dispatchRuntimeSessionEvent(win as any, {
+      type: 'text',
+      sessionId: 'session-patch-overflow',
+      data: {
+        type: 'text',
+        messageId: 'message-overflow',
+        partId: `part-${index}`,
+        content: `chunk-${index}`,
+        mode: 'append',
+      },
+    })
+  }
+
+  await wait(80)
+
+  const patchCount = sent.filter((entry) => entry.channel === 'session:patch').length
+  assert.equal(patchCount, 512)
+  assert.equal(sent.some((entry) => entry.channel === 'session:view'), true)
 })
 
 test('dispatcher derives renderer-safe reasoning patches without forcing full view publishes', () => {

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -213,7 +213,7 @@ test('dispatcher overflow drops only patches for the recovering session', async 
   )
 })
 
-test('dispatcher drops queued session patches when a full view is queued', async () => {
+test('dispatcher flushes queued session patches before a full view is queued', async () => {
   const { win, sent } = createWindowCollector(53)
 
   dispatchRuntimeSessionEvent(win as any, {
@@ -246,11 +246,30 @@ test('dispatcher drops queued session patches when a full view is queued', async
 
   await wait(80)
 
-  assert.equal(sent.some((entry) => entry.channel === 'session:patch'), false)
-  assert.equal(
-    sent.some((entry) => entry.channel === 'session:view' && (entry.payload as { sessionId?: string }).sessionId === 'session-view-recovers-patches'),
-    true,
-  )
+  const sessionEvents = sent
+    .filter((entry) => entry.channel === 'session:patch' || entry.channel === 'session:view')
+    .map((entry) => ({
+      channel: entry.channel,
+      sessionId: (entry.payload as { sessionId?: string }).sessionId,
+      content: (entry.payload as { content?: string }).content,
+    }))
+  assert.deepEqual(sessionEvents, [
+    {
+      channel: 'session:patch',
+      sessionId: 'session-view-recovers-patches',
+      content: 'before-view',
+    },
+    {
+      channel: 'session:patch',
+      sessionId: 'session-view-recovers-patches',
+      content: 'after-view-queued',
+    },
+    {
+      channel: 'session:view',
+      sessionId: 'session-view-recovers-patches',
+      content: undefined,
+    },
+  ])
 })
 
 test('dispatcher derives renderer-safe reasoning patches without forcing full view publishes', () => {

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -213,6 +213,46 @@ test('dispatcher overflow drops only patches for the recovering session', async 
   )
 })
 
+test('dispatcher drops queued session patches when a full view is queued', async () => {
+  const { win, sent } = createWindowCollector(53)
+
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-view-recovers-patches',
+    data: {
+      type: 'text',
+      messageId: 'message-view-recovers',
+      partId: 'part-before-view',
+      content: 'before-view',
+      mode: 'append',
+    },
+  })
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'busy',
+    sessionId: 'session-view-recovers-patches',
+    data: { type: 'busy' },
+  })
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-view-recovers-patches',
+    data: {
+      type: 'text',
+      messageId: 'message-view-recovers',
+      partId: 'part-after-view-queued',
+      content: 'after-view-queued',
+      mode: 'append',
+    },
+  })
+
+  await wait(80)
+
+  assert.equal(sent.some((entry) => entry.channel === 'session:patch'), false)
+  assert.equal(
+    sent.some((entry) => entry.channel === 'session:view' && (entry.payload as { sessionId?: string }).sessionId === 'session-view-recovers-patches'),
+    true,
+  )
+})
+
 test('dispatcher derives renderer-safe reasoning patches without forcing full view publishes', () => {
   assert.deepEqual(getSessionPatch({
     type: 'reasoning',

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -272,6 +272,50 @@ test('dispatcher flushes queued session patches before a full view is queued', a
   ])
 })
 
+test('history refresh flushes queued session patches before publishing the refreshed view', async () => {
+  const { win, sent } = createWindowCollector(54)
+  setSessionHistoryRefreshHandler(async () => undefined)
+
+  try {
+    dispatchRuntimeSessionEvent(win as any, {
+      type: 'text',
+      sessionId: 'session-history-refresh-patches',
+      data: {
+        type: 'text',
+        messageId: 'message-history-refresh',
+        partId: 'part-before-history',
+        content: 'before-history-refresh',
+        mode: 'append',
+      },
+    })
+    dispatchRuntimeSessionEvent(win as any, eventOf('history_refresh', 'session-history-refresh-patches'))
+
+    await wait(30)
+
+    const sessionEvents = sent
+      .filter((entry) => entry.channel === 'session:patch' || entry.channel === 'session:view')
+      .map((entry) => ({
+        channel: entry.channel,
+        sessionId: (entry.payload as { sessionId?: string }).sessionId,
+        content: (entry.payload as { content?: string }).content,
+      }))
+    assert.deepEqual(sessionEvents, [
+      {
+        channel: 'session:patch',
+        sessionId: 'session-history-refresh-patches',
+        content: 'before-history-refresh',
+      },
+      {
+        channel: 'session:view',
+        sessionId: 'session-history-refresh-patches',
+        content: undefined,
+      },
+    ])
+  } finally {
+    setSessionHistoryRefreshHandler(null)
+  }
+})
+
 test('dispatcher derives renderer-safe reasoning patches without forcing full view publishes', () => {
   assert.deepEqual(getSessionPatch({
     type: 'reasoning',

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -122,6 +122,36 @@ test('session composer preferences persist separately from last-used model', () 
   }
 })
 
+test('scheduled session registry writes persist the latest coalesced state', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('coalesced-writes')
+  const sessionId = `session-coalesced-${Date.now()}`
+
+  try {
+    resetRegistryTestState(userDataDir)
+
+    upsertSessionRecord(toSessionRecord({
+      id: sessionId,
+      title: 'Initial',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      opencodeDirectory: userDataDir,
+    }))
+    updateSessionRecord(sessionId, { title: 'Intermediate', updatedAt: '2026-05-18T10:00:00.000Z' })
+    updateSessionRecord(sessionId, { title: 'Latest', updatedAt: '2026-05-18T10:00:01.000Z' })
+    flushSessionRegistryWrites()
+
+    const records = JSON.parse(readFileSync(join(userDataDir, 'sessions.json'), 'utf8')) as Array<{ id: string; title?: string }>
+    assert.equal(records.find((record) => record.id === sessionId)?.title, 'Latest')
+  } finally {
+    clearSessionRegistryCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
 test('legacy session registry migration keeps only Cowork-created sessions from logs', async () => {
   const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
   const userDataDir = uniqueUserDataDir('legacy-migration')


### PR DESCRIPTION
## Summary
- add runtime object validators for high-risk IPC payloads
- batch streamed session patches with overflow diagnostics and full-view catch-up
- serialize session registry writes and harden process snapshot parsing
- extract renderer session view reducer helpers and add RTL accessibility smoke coverage

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm --dir apps/desktop test:renderer -- src/renderer/components/accessibility-smoke.test.tsx
- pnpm test:e2e