### PR TITLE
Implement synced cloud workspaces

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `049fa10a273b8479c18614f20033470787d581ad4ed8097ccad02ce2a9aa198f`
+- pnpm lockfile SHA-256: `70dd073e872c1667e0e411344074783a9bfd70e12894ae97d10c69f63a4302e6`
 - Production package entries: 481
 - Bundled license directories: 453 (28 package entries have no standalone license file or are workspace links)
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,7 +22,7 @@
     "test:renderer:watch": "pnpm --dir ../.. build:shared && vitest --config vitest.renderer.config.ts",
     "test:coverage:renderer": "pnpm --dir ../.. build:shared && vitest run --config vitest.renderer.config.ts --coverage",
     "test:e2e": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && node ../../scripts/run-desktop-smoke-tests.mjs --pattern \"tests/*.smoke.test.ts\" --timeout=120000 --retries=1",
-    "test:e2e:packaged": "node ../../scripts/run-desktop-smoke-tests.mjs --pattern \"tests/*.packaged.test.ts\" --timeout=240000 --retries=1",
+    "test:e2e:packaged": "node ../../scripts/require-packaged-executable.mjs && node ../../scripts/run-desktop-smoke-tests.mjs --pattern \"tests/*.packaged.test.ts\" --timeout=240000 --retries=1",
     "screenshots": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && node --no-warnings --experimental-strip-types tests/screenshots.ts",
     "dist": "node ../../scripts/desktop-dist.mjs",
     "dist:ci": "node ../../scripts/desktop-dist.mjs --mac zip --x64 --arm64 --publish never",

--- a/apps/desktop/src/lib/session-streaming-flush.ts
+++ b/apps/desktop/src/lib/session-streaming-flush.ts
@@ -3,6 +3,7 @@ import type { SessionViewState } from './session-view-model.ts'
 
 type SessionStreamingFlushSnapshot = {
   currentSessionId: string | null
+  currentSessionKey?: string | null
   sessionStateById: Record<string, SessionViewState>
 }
 
@@ -12,7 +13,7 @@ export function shouldCommitStreamingTextImmediately(
 ) {
   if (snapshot.currentSessionId !== part.sessionId) return false
 
-  const sessionState = snapshot.sessionStateById[part.sessionId]
+  const sessionState = snapshot.sessionStateById[snapshot.currentSessionKey || part.sessionId]
   if (!sessionState) return true
 
   if (part.type === 'task_text' || part.type === 'task_reasoning') {

--- a/apps/desktop/src/lib/session-view-model.ts
+++ b/apps/desktop/src/lib/session-view-model.ts
@@ -4,6 +4,7 @@ import type {
   MessageAttachment,
   PendingApproval,
   PendingQuestion,
+  SessionArtifact,
   SessionError,
   SessionTokens,
   SessionView,
@@ -140,6 +141,7 @@ export interface SessionViewState {
   compactions: CompactionNotice[]
   pendingApprovals: PendingApproval[]
   pendingQuestions: PendingQuestion[]
+  artifacts: SessionArtifact[]
   errors: SessionError[]
   todos: TodoItem[]
   executionPlan: ExecutionPlanItem[]
@@ -168,6 +170,7 @@ export function createEmptySessionViewState(
     compactions: [],
     pendingApprovals: [],
     pendingQuestions: [],
+    artifacts: [],
     errors: [],
     todos: [],
     executionPlan: [],
@@ -250,6 +253,7 @@ export function deriveVisibleSessionPatch(
     compactions: state.compactions,
     pendingApprovals: state.pendingApprovals,
     pendingQuestions: state.pendingQuestions,
+    ...(state.artifacts.length > 0 ? { artifacts: state.artifacts } : {}),
     errors: state.errors,
     todos: state.todos,
     executionPlan,
@@ -278,6 +282,7 @@ export function buildSessionStateFromItems(
     hydrated: true,
     pendingApprovals: existing?.pendingApprovals || [],
     pendingQuestions: existing?.pendingQuestions || [],
+    artifacts: existing?.artifacts || [],
     errors: existing?.errors || [],
     todos: existing?.todos || [],
     executionPlan: existing?.executionPlan || [],
@@ -500,6 +505,7 @@ export function buildSessionStateFromView(view: SessionView, existing?: SessionV
     hydrated: true,
     pendingApprovals: view.pendingApprovals || [],
     pendingQuestions: view.pendingQuestions || [],
+    artifacts: view.artifacts || [],
     errors: view.errors || [],
     todos: view.todos || [],
     executionPlan: view.executionPlan || [],

--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -1,0 +1,511 @@
+import type {
+  MessageAttachment,
+  CapabilitySkill,
+  CapabilitySkillBundle,
+  CapabilityTool,
+  SessionArtifact,
+  SessionArtifactAttachment,
+  SessionArtifactUploadRequest,
+  SessionInfo,
+  SessionView,
+  ThreadFacetSummary,
+  ThreadSearchQuery,
+  ThreadSearchResult,
+  ThreadSmartFilter,
+  ThreadSmartFilterInput,
+  ThreadTag,
+  ThreadTagInput,
+  WorkflowDetail,
+  WorkflowListPayload,
+  WorkflowRun,
+  WorkspacePolicy,
+} from '@open-cowork/shared'
+import type { SessionRecord } from './cloud/control-plane-store.ts'
+import { cloudSessionViewToSessionView } from './cloud/session-view-contract.ts'
+import {
+  createHttpSseCloudTransportAdapter,
+  type CloudTransportAdapter,
+  type CloudTransportConfig,
+  type CloudTransportSettingMetadata,
+  type CloudTransportSessionEvent,
+  type CloudTransportSubscription,
+  type CloudTransportWorkspaceEvent,
+} from './cloud/transport-adapter.ts'
+import type { CloudWorkspaceConnectionRecord } from './cloud-workspace-registry.ts'
+import {
+  createFileCloudWorkspaceCache,
+  type CloudWorkspaceCache,
+  type CloudWorkspaceCacheEncryptionFallback,
+  type CloudWorkspaceCacheMode,
+} from './cloud-workspace-cache.ts'
+
+export type CloudPromptInput = {
+  text: string
+  agent?: string | null
+  attachments?: MessageAttachment[]
+}
+
+export type CloudWorkspaceSessionAdapter = {
+  policy(): Promise<WorkspacePolicy>
+  listSessions(): Promise<SessionInfo[]>
+  createSession(): Promise<SessionInfo>
+  getSessionInfo(sessionId: string): Promise<SessionInfo | null>
+  getSessionView(sessionId: string): Promise<SessionView>
+  promptSession(sessionId: string, input: CloudPromptInput): Promise<void>
+  abortSession(sessionId: string): Promise<void>
+  listWorkflows?(): Promise<WorkflowListPayload>
+  getWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  runWorkflow?(workflowId: string): Promise<WorkflowRun | null>
+  pauseWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  resumeWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  archiveWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  searchThreads?(query?: ThreadSearchQuery): Promise<ThreadSearchResult>
+  threadFacets?(query?: ThreadSearchQuery): Promise<ThreadFacetSummary>
+  listThreadTags?(): Promise<ThreadTag[]>
+  createThreadTag?(input: ThreadTagInput): Promise<ThreadTag>
+  updateThreadTag?(tagId: string, input: ThreadTagInput): Promise<ThreadTag | null>
+  deleteThreadTag?(tagId: string): Promise<boolean>
+  applyThreadTags?(sessionIds: string[], tagIds: string[]): Promise<boolean>
+  removeThreadTags?(sessionIds: string[], tagIds: string[]): Promise<boolean>
+  listThreadSmartFilters?(): Promise<ThreadSmartFilter[]>
+  createThreadSmartFilter?(input: ThreadSmartFilterInput): Promise<ThreadSmartFilter>
+  updateThreadSmartFilter?(filterId: string, input: ThreadSmartFilterInput): Promise<ThreadSmartFilter | null>
+  deleteThreadSmartFilter?(filterId: string): Promise<boolean>
+  listArtifacts?(sessionId: string): Promise<SessionArtifact[]>
+  uploadArtifact?(input: SessionArtifactUploadRequest): Promise<SessionArtifact>
+  readArtifactAttachment?(sessionId: string, filePathOrArtifactId: string): Promise<SessionArtifactAttachment>
+  listCapabilityTools?(): Promise<CapabilityTool[]>
+  getCapabilityTool?(toolId: string): Promise<CapabilityTool | null>
+  listCapabilitySkills?(): Promise<CapabilitySkill[]>
+  getCapabilitySkillBundle?(skillName: string): Promise<CapabilitySkillBundle | null>
+  readCapabilitySkillBundleFile?(skillName: string, filePath: string): Promise<string | null>
+  listSettings?(): Promise<CloudTransportSettingMetadata[]>
+  getSetting?(key: string): Promise<CloudTransportSettingMetadata | null>
+  setSetting?(key: string, value: Record<string, unknown>): Promise<CloudTransportSettingMetadata>
+  subscribeWorkspaceEvents?(input: {
+    afterSequence?: number
+    onEvent: (event: CloudTransportWorkspaceEvent) => void
+    onError?: (error: unknown) => void
+  }): CloudTransportSubscription
+  subscribeSessionEvents?(
+    sessionId: string,
+    input: {
+      afterSequence?: number
+      onEvent: (event: CloudTransportSessionEvent) => void
+      onError?: (error: unknown) => void
+    },
+  ): CloudTransportSubscription
+}
+
+export type CloudWorkspaceAdapterOptions = {
+  connection: CloudWorkspaceConnectionRecord
+  transport?: CloudTransportAdapter
+  accessToken?: string | null
+  cache?: CloudWorkspaceCache | null
+  cacheMode?: CloudWorkspaceCacheMode
+  cacheEncryptionFallback?: CloudWorkspaceCacheEncryptionFallback
+}
+
+function toSessionInfo(record: SessionRecord): SessionInfo {
+  return {
+    id: record.sessionId,
+    title: record.title || 'New session',
+    directory: null,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    kind: 'interactive',
+  }
+}
+
+function policyFromConfig(config: CloudTransportConfig): WorkspacePolicy {
+  return {
+    features: config.features || {},
+    allowedAgents: config.allowedAgents,
+    allowedTools: config.allowedTools,
+    allowedMcps: config.allowedMcps,
+    localFiles: 'disabled',
+    localStdioMcps: 'disabled',
+    machineRuntimeConfig: 'disabled',
+  }
+}
+
+export function cloudWorkspaceCacheKey(connection: CloudWorkspaceConnectionRecord) {
+  return [
+    `connection:${connection.id}`,
+    `workspace:${connection.id}`,
+    `tenant:${connection.tenantId || 'unknown'}`,
+    `user:${connection.userId || 'unknown'}`,
+    `profile:${connection.profileName || 'default'}`,
+  ].join('|')
+}
+
+export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
+  private readonly transport: CloudTransportAdapter
+  private readonly connection: CloudWorkspaceConnectionRecord
+  private readonly cache: CloudWorkspaceCache | null
+
+  constructor(options: CloudWorkspaceAdapterOptions) {
+    this.connection = options.connection
+    this.cache = options.cache === undefined
+      ? createFileCloudWorkspaceCache({
+          mode: options.cacheMode,
+          encryptionFallback: options.cacheEncryptionFallback,
+        })
+      : options.cache
+    this.transport = options.transport || createHttpSseCloudTransportAdapter({
+      baseUrl: options.connection.baseUrl,
+      headers: options.accessToken
+        ? { authorization: `Bearer ${options.accessToken}` }
+        : undefined,
+    })
+  }
+
+  async policy(): Promise<WorkspacePolicy> {
+    return policyFromConfig(await this.transport.getConfig())
+  }
+
+  async listSessions(): Promise<SessionInfo[]> {
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    try {
+      const sessions = (await this.transport.listSessions()).map(toSessionInfo)
+      this.cache?.upsertSessionList(cacheKey, sessions)
+      return sessions
+    } catch (error) {
+      const cached = this.cache?.listSessions(cacheKey)
+      if (cached) return cached
+      throw error
+    }
+  }
+
+  async createSession(): Promise<SessionInfo> {
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    const session = toSessionInfo((await this.transport.createSession()).session)
+    this.cache?.upsertSessionInfo(cacheKey, session)
+    return session
+  }
+
+  async getSessionInfo(sessionId: string): Promise<SessionInfo | null> {
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    try {
+      const session = toSessionInfo((await this.transport.getSession(sessionId)).session)
+      this.cache?.upsertSessionInfo(cacheKey, session)
+      return session
+    } catch (error) {
+      const cached = this.cache?.getSessionInfo(cacheKey, sessionId)
+      if (cached) return cached
+      throw error
+    }
+  }
+
+  async getSessionView(sessionId: string): Promise<SessionView> {
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    try {
+      const view = cloudSessionViewToSessionView(await this.transport.getSession(sessionId))
+      this.cache?.upsertSessionView(cacheKey, sessionId, view)
+      return view
+    } catch (error) {
+      const cached = this.cache?.getSessionView(cacheKey, sessionId)
+      if (cached) return cached
+      throw error
+    }
+  }
+
+  async promptSession(sessionId: string, input: CloudPromptInput): Promise<void> {
+    if (input.attachments && input.attachments.length > 0) {
+      throw new Error('Cloud workspace prompts do not support local attachments yet.')
+    }
+    await this.transport.promptSession(sessionId, {
+      text: input.text,
+      agent: input.agent || null,
+    })
+  }
+
+  async abortSession(sessionId: string): Promise<void> {
+    await this.transport.abortSession(sessionId)
+  }
+
+  async listWorkflows(): Promise<WorkflowListPayload> {
+    if (!this.transport.listWorkflows) throw new Error('Cloud workflows are not supported by this workspace.')
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    try {
+      const workflows = await this.transport.listWorkflows()
+      this.cache?.upsertWorkflowList(cacheKey, workflows)
+      return workflows
+    } catch (error) {
+      const cached = this.cache?.getWorkflowList(cacheKey)
+      if (cached) return cached
+      throw error
+    }
+  }
+
+  async getWorkflow(workflowId: string): Promise<WorkflowDetail | null> {
+    if (!this.transport.getWorkflow) throw new Error('Cloud workflows are not supported by this workspace.')
+    return this.transport.getWorkflow(workflowId)
+  }
+
+  async runWorkflow(workflowId: string): Promise<WorkflowRun | null> {
+    if (!this.transport.runWorkflow) throw new Error('Cloud workflow runs are not supported by this workspace.')
+    return this.transport.runWorkflow(workflowId, {
+      triggerType: 'manual',
+      triggerPayload: {
+        source: 'desktop',
+        requestedAt: new Date().toISOString(),
+      },
+    })
+  }
+
+  async pauseWorkflow(workflowId: string): Promise<WorkflowDetail | null> {
+    if (!this.transport.pauseWorkflow) throw new Error('Cloud workflow pause is not supported by this workspace.')
+    return this.transport.pauseWorkflow(workflowId)
+  }
+
+  async resumeWorkflow(workflowId: string): Promise<WorkflowDetail | null> {
+    if (!this.transport.resumeWorkflow) throw new Error('Cloud workflow resume is not supported by this workspace.')
+    return this.transport.resumeWorkflow(workflowId)
+  }
+
+  async archiveWorkflow(workflowId: string): Promise<WorkflowDetail | null> {
+    if (!this.transport.archiveWorkflow) throw new Error('Cloud workflow archive is not supported by this workspace.')
+    return this.transport.archiveWorkflow(workflowId)
+  }
+
+  async searchThreads(query?: ThreadSearchQuery): Promise<ThreadSearchResult> {
+    if (!this.transport.searchThreads) throw new Error('Cloud thread search is not supported by this workspace.')
+    return this.transport.searchThreads(query)
+  }
+
+  async threadFacets(query?: ThreadSearchQuery): Promise<ThreadFacetSummary> {
+    if (!this.transport.threadFacets) throw new Error('Cloud thread facets are not supported by this workspace.')
+    return this.transport.threadFacets(query)
+  }
+
+  async listThreadTags(): Promise<ThreadTag[]> {
+    if (!this.transport.listThreadTags) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return this.transport.listThreadTags()
+  }
+
+  async createThreadTag(input: ThreadTagInput): Promise<ThreadTag> {
+    if (!this.transport.createThreadTag) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return this.transport.createThreadTag(input)
+  }
+
+  async updateThreadTag(tagId: string, input: ThreadTagInput): Promise<ThreadTag | null> {
+    if (!this.transport.updateThreadTag) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return this.transport.updateThreadTag(tagId, input)
+  }
+
+  async deleteThreadTag(tagId: string): Promise<boolean> {
+    if (!this.transport.deleteThreadTag) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return this.transport.deleteThreadTag(tagId)
+  }
+
+  async applyThreadTags(sessionIds: string[], tagIds: string[]): Promise<boolean> {
+    if (!this.transport.applyThreadTags) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return this.transport.applyThreadTags(sessionIds, tagIds)
+  }
+
+  async removeThreadTags(sessionIds: string[], tagIds: string[]): Promise<boolean> {
+    if (!this.transport.removeThreadTags) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return this.transport.removeThreadTags(sessionIds, tagIds)
+  }
+
+  async listThreadSmartFilters(): Promise<ThreadSmartFilter[]> {
+    if (!this.transport.listThreadSmartFilters) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return this.transport.listThreadSmartFilters()
+  }
+
+  async createThreadSmartFilter(input: ThreadSmartFilterInput): Promise<ThreadSmartFilter> {
+    if (!this.transport.createThreadSmartFilter) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return this.transport.createThreadSmartFilter(input)
+  }
+
+  async updateThreadSmartFilter(filterId: string, input: ThreadSmartFilterInput): Promise<ThreadSmartFilter | null> {
+    if (!this.transport.updateThreadSmartFilter) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return this.transport.updateThreadSmartFilter(filterId, input)
+  }
+
+  async deleteThreadSmartFilter(filterId: string): Promise<boolean> {
+    if (!this.transport.deleteThreadSmartFilter) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return this.transport.deleteThreadSmartFilter(filterId)
+  }
+
+  async listArtifacts(sessionId: string): Promise<SessionArtifact[]> {
+    if (!this.transport.listArtifacts) throw new Error('Cloud artifacts are not supported by this workspace.')
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    try {
+      const artifacts = await this.transport.listArtifacts(sessionId)
+      this.cache?.upsertArtifactList(cacheKey, sessionId, artifacts)
+      return artifacts
+    } catch (error) {
+      const cached = this.cache?.listArtifacts(cacheKey, sessionId)
+      if (cached) return cached
+      throw error
+    }
+  }
+
+  async uploadArtifact(input: SessionArtifactUploadRequest): Promise<SessionArtifact> {
+    if (!this.transport.uploadArtifact) throw new Error('Cloud artifact uploads are not supported by this workspace.')
+    const artifact = await this.transport.uploadArtifact(input.sessionId, {
+      filename: input.filename,
+      contentType: input.contentType || null,
+      dataBase64: input.dataBase64,
+    })
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    const existing = this.cache?.listArtifacts(cacheKey, input.sessionId) || []
+    this.cache?.upsertArtifactList(cacheKey, input.sessionId, [
+      ...existing.filter((entry) => entry.id !== artifact.id),
+      artifact,
+    ])
+    return artifact
+  }
+
+  async readArtifactAttachment(sessionId: string, filePathOrArtifactId: string): Promise<SessionArtifactAttachment> {
+    if (!this.transport.readArtifactAttachment) throw new Error('Cloud artifact downloads are not supported by this workspace.')
+    return this.transport.readArtifactAttachment(sessionId, filePathOrArtifactId)
+  }
+
+  async listCapabilityTools(): Promise<CapabilityTool[]> {
+    if (!this.transport.listCapabilityTools) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return this.transport.listCapabilityTools()
+  }
+
+  async getCapabilityTool(toolId: string): Promise<CapabilityTool | null> {
+    if (!this.transport.getCapabilityTool) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return this.transport.getCapabilityTool(toolId)
+  }
+
+  async listCapabilitySkills(): Promise<CapabilitySkill[]> {
+    if (!this.transport.listCapabilitySkills) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return this.transport.listCapabilitySkills()
+  }
+
+  async getCapabilitySkillBundle(skillName: string): Promise<CapabilitySkillBundle | null> {
+    if (!this.transport.getCapabilitySkillBundle) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return this.transport.getCapabilitySkillBundle(skillName)
+  }
+
+  async readCapabilitySkillBundleFile(skillName: string, filePath: string): Promise<string | null> {
+    if (!this.transport.readCapabilitySkillBundleFile) throw new Error('Cloud capability bundle files are not supported by this workspace.')
+    return this.transport.readCapabilitySkillBundleFile(skillName, filePath)
+  }
+
+  async listSettings(): Promise<CloudTransportSettingMetadata[]> {
+    if (!this.transport.listSettings) throw new Error('Cloud settings are not supported by this workspace.')
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    try {
+      const settings = await this.transport.listSettings()
+      this.cache?.upsertSettings(cacheKey, settings)
+      return settings
+    } catch (error) {
+      const cached = this.cache?.listSettings(cacheKey)
+      if (cached) return cached
+      throw error
+    }
+  }
+
+  async getSetting(key: string): Promise<CloudTransportSettingMetadata | null> {
+    if (!this.transport.getSetting) throw new Error('Cloud settings are not supported by this workspace.')
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    try {
+      const setting = await this.transport.getSetting(key)
+      if (setting) this.cache?.upsertSetting(cacheKey, setting)
+      return setting
+    } catch (error) {
+      const cached = this.cache?.getSetting(cacheKey, key)
+      if (cached) return cached
+      throw error
+    }
+  }
+
+  async setSetting(key: string, value: Record<string, unknown>): Promise<CloudTransportSettingMetadata> {
+    if (!this.transport.setSetting) throw new Error('Cloud settings are not supported by this workspace.')
+    const setting = await this.transport.setSetting(key, value)
+    this.cache?.upsertSetting(cloudWorkspaceCacheKey(this.connection), setting)
+    return setting
+  }
+
+  private async refreshWorkspaceSnapshot(): Promise<void> {
+    const sessions = await this.listSessions()
+    await Promise.allSettled(sessions.map((session) => this.getSessionView(session.id)))
+    if (this.transport.listArtifacts) {
+      await Promise.allSettled(sessions.map((session) => this.listArtifacts(session.id)))
+    }
+    if (this.transport.listWorkflows) {
+      await this.listWorkflows().catch(() => undefined)
+    }
+    if (this.transport.listSettings) {
+      await this.listSettings().catch(() => undefined)
+    }
+  }
+
+  subscribeWorkspaceEvents(
+    input: {
+      afterSequence?: number
+      onEvent: (event: CloudTransportWorkspaceEvent) => void
+      onError?: (error: unknown) => void
+    },
+  ): CloudTransportSubscription {
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    const afterSequence = input.afterSequence ?? this.cache?.getEventCursor(cacheKey, 'workspace') ?? undefined
+    return this.transport.subscribeWorkspaceEvents({
+      afterSequence,
+      onEvent: (event) => {
+        void (async () => {
+          try {
+            if (event.type === 'snapshot.required') {
+              await this.refreshWorkspaceSnapshot()
+              this.cache?.resetEventCursor(cacheKey, 'workspace', 0)
+              input.onEvent(event)
+              return
+            }
+            this.cache?.setEventCursor(cacheKey, 'workspace', event.sequence)
+            input.onEvent(event)
+          } catch (error) {
+            input.onError?.(error)
+          }
+        })()
+      },
+      onError: input.onError,
+    })
+  }
+
+  subscribeSessionEvents(
+    sessionId: string,
+    input: {
+      afterSequence?: number
+      onEvent: (event: CloudTransportSessionEvent) => void
+      onError?: (error: unknown) => void
+    },
+  ): CloudTransportSubscription {
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    // Session events also hydrate the main-process SessionEngine. After an
+    // app restart that engine is empty even when the durable cache has a
+    // later cursor, so replay from the beginning unless the caller explicitly
+    // supplies a cursor for a known-hydrated stream.
+    const afterSequence = input.afterSequence
+    return this.transport.subscribeSessionEvents(sessionId, {
+      afterSequence,
+      onEvent: (event) => {
+        this.cache?.setEventCursor(cacheKey, `session:${sessionId}`, event.sequence)
+        input.onEvent(event)
+      },
+      onError: input.onError,
+    })
+  }
+}
+
+export function createCloudWorkspaceAdapter(
+  connection: CloudWorkspaceConnectionRecord,
+  accessToken?: string | null,
+  options: {
+    cacheMode?: CloudWorkspaceCacheMode
+    cacheEncryptionFallback?: CloudWorkspaceCacheEncryptionFallback
+  } = {},
+) {
+  return new CloudWorkspaceAdapter({
+    connection,
+    accessToken,
+    cacheMode: options.cacheMode,
+    cacheEncryptionFallback: options.cacheEncryptionFallback,
+  })
+}

--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -53,6 +53,9 @@ export type CloudWorkspaceSessionAdapter = {
   getSessionView(sessionId: string): Promise<SessionView>
   promptSession(sessionId: string, input: CloudPromptInput): Promise<void>
   abortSession(sessionId: string): Promise<void>
+  replyToQuestion?(sessionId: string, requestId: string, answers: unknown[]): Promise<void>
+  rejectQuestion?(sessionId: string, requestId: string): Promise<void>
+  respondToPermission?(sessionId: string, permissionId: string, allowed: boolean): Promise<void>
   listWorkflows?(): Promise<WorkflowListPayload>
   getWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
   runWorkflow?(workflowId: string): Promise<WorkflowRun | null>
@@ -222,6 +225,21 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
 
   async abortSession(sessionId: string): Promise<void> {
     await this.transport.abortSession(sessionId)
+  }
+
+  async replyToQuestion(sessionId: string, requestId: string, answers: unknown[]): Promise<void> {
+    await this.transport.replyToQuestion(sessionId, { requestId, answers })
+  }
+
+  async rejectQuestion(sessionId: string, requestId: string): Promise<void> {
+    await this.transport.rejectQuestion(sessionId, { requestId })
+  }
+
+  async respondToPermission(sessionId: string, permissionId: string, allowed: boolean): Promise<void> {
+    await this.transport.respondToPermission(sessionId, {
+      permissionId,
+      response: { allowed },
+    })
   }
 
   async listWorkflows(): Promise<WorkflowListPayload> {

--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -516,6 +516,7 @@ export function createCloudWorkspaceAdapter(
   connection: CloudWorkspaceConnectionRecord,
   accessToken?: string | null,
   options: {
+    cache?: CloudWorkspaceCache | null
     cacheMode?: CloudWorkspaceCacheMode
     cacheEncryptionFallback?: CloudWorkspaceCacheEncryptionFallback
   } = {},
@@ -523,6 +524,7 @@ export function createCloudWorkspaceAdapter(
   return new CloudWorkspaceAdapter({
     connection,
     accessToken,
+    cache: options.cache,
     cacheMode: options.cacheMode,
     cacheEncryptionFallback: options.cacheEncryptionFallback,
   })

--- a/apps/desktop/src/main/cloud-workspace-auth.ts
+++ b/apps/desktop/src/main/cloud-workspace-auth.ts
@@ -1,0 +1,355 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import electron from 'electron'
+import type { CloudWorkspaceConnectionRecord } from './cloud-workspace-registry.ts'
+
+type CloudWorkspaceAuthResponse = {
+  ok: boolean
+  status: number
+  json(): Promise<unknown>
+  text?(): Promise<string>
+}
+
+export type CloudWorkspaceAuthFetch = (
+  url: string,
+  init?: {
+    method?: string
+    headers?: Record<string, string>
+    body?: string
+  },
+) => Promise<CloudWorkspaceAuthResponse>
+
+export type CloudWorkspaceDesktopAuthConfig = {
+  mode: 'oidc'
+  issuerUrl: string
+  clientId: string
+  scope?: string
+}
+
+export type CloudWorkspaceLoginResult = {
+  accessToken: string
+  refreshToken: string | null
+  expiresAt: string
+  tenantId?: string
+  userId?: string
+  profileName?: string
+}
+
+export type CloudWorkspaceDesktopAuthenticatorOptions = {
+  fetch?: CloudWorkspaceAuthFetch
+  openExternal?: (url: string) => Promise<unknown> | unknown
+  callbackTimeoutMs?: number
+}
+
+type OidcDiscovery = {
+  authorization_endpoint?: string
+  token_endpoint?: string
+}
+
+const DEFAULT_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
+const DEFAULT_SCOPE = 'openid email profile offline_access'
+
+function defaultFetch(): CloudWorkspaceAuthFetch {
+  return (url, init) => globalThis.fetch(url, init as RequestInit) as Promise<CloudWorkspaceAuthResponse>
+}
+
+function defaultOpenExternal(url: string) {
+  return electron.shell.openExternal(url)
+}
+
+function jsonRecord(value: unknown, label: string) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} response must be a JSON object.`)
+  }
+  return value as Record<string, unknown>
+}
+
+async function readJsonRecord(response: CloudWorkspaceAuthResponse, label: string) {
+  const body = jsonRecord(await response.json(), label)
+  if (!response.ok) {
+    const message = typeof body.error === 'string' && body.error.trim()
+      ? body.error.trim()
+      : `${label} request failed with HTTP ${response.status}.`
+    throw new Error(message)
+  }
+  return body
+}
+
+function readRequiredString(record: Record<string, unknown>, key: string, label: string) {
+  const value = record[key]
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is missing ${key}.`)
+  return value.trim()
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string) {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function base64Url(bytes: Buffer | string) {
+  return Buffer.from(bytes).toString('base64url')
+}
+
+function codeChallenge(verifier: string) {
+  return createHash('sha256').update(verifier).digest('base64url')
+}
+
+function tokenExpiresAt(record: Record<string, unknown>) {
+  const expiresAt = readOptionalString(record, 'expires_at')
+  if (expiresAt && Number.isFinite(Date.parse(expiresAt))) return new Date(Date.parse(expiresAt)).toISOString()
+  const expiresIn = record.expires_in
+  const seconds = typeof expiresIn === 'number' && Number.isFinite(expiresIn)
+    ? expiresIn
+    : typeof expiresIn === 'string'
+      ? Number(expiresIn)
+      : 3600
+  const ttlMs = Math.max(60, Number.isFinite(seconds) ? seconds : 3600) * 1000
+  return new Date(Date.now() + ttlMs).toISOString()
+}
+
+function normalizeBaseUrl(baseUrl: string) {
+  return baseUrl.replace(/\/+$/, '')
+}
+
+async function closeServer(server: Server) {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}
+
+async function createLoopbackCallback(timeoutMs: number) {
+  let resolveCallback: ((value: { code: string; state: string }) => void) | null = null
+  let rejectCallback: ((error: Error) => void) | null = null
+  const callbackPromise = new Promise<{ code: string; state: string }>((resolve, reject) => {
+    resolveCallback = resolve
+    rejectCallback = reject
+  })
+  const server = createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1')
+    if (url.pathname !== '/callback') {
+      res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' })
+      res.end('Not found')
+      return
+    }
+    const error = url.searchParams.get('error')
+    const code = url.searchParams.get('code')
+    const state = url.searchParams.get('state')
+    if (error) {
+      res.writeHead(400, { 'content-type': 'text/html; charset=utf-8' })
+      res.end('<html><body><h2>Open Cowork Cloud login failed</h2></body></html>')
+      rejectCallback?.(new Error(`Cloud OIDC login failed: ${error}.`))
+      return
+    }
+    if (!code || !state) {
+      res.writeHead(400, { 'content-type': 'text/html; charset=utf-8' })
+      res.end('<html><body><h2>Open Cowork Cloud login failed</h2></body></html>')
+      rejectCallback?.(new Error('Cloud OIDC callback requires code and state.'))
+      return
+    }
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    res.end('<html><body><h2>Open Cowork Cloud login complete</h2><p>You can return to Open Cowork.</p></body></html>')
+    resolveCallback?.({ code, state })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+  const address = server.address() as AddressInfo | null
+  if (!address) throw new Error('Cloud OIDC callback server did not bind.')
+  const timeout = setTimeout(() => {
+    rejectCallback?.(new Error('Cloud OIDC login timed out.'))
+  }, timeoutMs)
+  timeout.unref()
+  return {
+    redirectUri: `http://127.0.0.1:${address.port}/callback`,
+    async wait() {
+      try {
+        return await callbackPromise
+      } finally {
+        clearTimeout(timeout)
+      }
+    },
+    close: () => closeServer(server),
+  }
+}
+
+export class CloudWorkspaceDesktopAuthenticator {
+  private readonly fetcher: CloudWorkspaceAuthFetch
+  private readonly openExternal: (url: string) => Promise<unknown> | unknown
+  private readonly callbackTimeoutMs: number
+
+  constructor(options: CloudWorkspaceDesktopAuthenticatorOptions = {}) {
+    this.fetcher = options.fetch || defaultFetch()
+    this.openExternal = options.openExternal || defaultOpenExternal
+    this.callbackTimeoutMs = options.callbackTimeoutMs || DEFAULT_CALLBACK_TIMEOUT_MS
+  }
+
+  async login(connection: CloudWorkspaceConnectionRecord): Promise<CloudWorkspaceLoginResult> {
+    const config = await this.fetchDesktopConfig(connection)
+    const discovery = await this.fetchDiscovery(config.issuerUrl)
+    const authorizationEndpoint = readRequiredString(discovery, 'authorization_endpoint', 'OIDC discovery')
+    const tokenEndpoint = readRequiredString(discovery, 'token_endpoint', 'OIDC discovery')
+    const state = base64Url(randomBytes(24))
+    const nonce = base64Url(randomBytes(24))
+    const verifier = base64Url(randomBytes(32))
+    const callback = await createLoopbackCallback(this.callbackTimeoutMs)
+    try {
+      const authUrl = new URL(authorizationEndpoint)
+      authUrl.searchParams.set('response_type', 'code')
+      authUrl.searchParams.set('client_id', config.clientId)
+      authUrl.searchParams.set('redirect_uri', callback.redirectUri)
+      authUrl.searchParams.set('scope', config.scope || DEFAULT_SCOPE)
+      authUrl.searchParams.set('state', state)
+      authUrl.searchParams.set('nonce', nonce)
+      authUrl.searchParams.set('code_challenge', codeChallenge(verifier))
+      authUrl.searchParams.set('code_challenge_method', 'S256')
+      await this.openExternal(authUrl.toString())
+      const completed = await callback.wait()
+      if (completed.state !== state) throw new Error('Cloud OIDC callback state is invalid.')
+      const token = await this.exchangeCode(tokenEndpoint, {
+        code: completed.code,
+        clientId: config.clientId,
+        redirectUri: callback.redirectUri,
+        verifier,
+      })
+      const accessToken = readOptionalString(token, 'access_token') || readOptionalString(token, 'id_token')
+      if (!accessToken) throw new Error('Cloud OIDC token response is missing access_token.')
+      const me = await this.fetchPrincipal(connection, accessToken)
+      const principal = jsonRecord(me.principal, 'Cloud principal')
+      return {
+        accessToken,
+        refreshToken: readOptionalString(token, 'refresh_token'),
+        expiresAt: tokenExpiresAt(token),
+        tenantId: readOptionalString(principal, 'tenantId') || undefined,
+        userId: readOptionalString(principal, 'userId') || undefined,
+        profileName: readOptionalString(me, 'profileName') || undefined,
+      }
+    } finally {
+      await callback.close()
+    }
+  }
+
+  async refresh(connection: CloudWorkspaceConnectionRecord, refreshToken: string): Promise<CloudWorkspaceLoginResult> {
+    const config = await this.fetchDesktopConfig(connection)
+    const discovery = await this.fetchDiscovery(config.issuerUrl)
+    const tokenEndpoint = readRequiredString(discovery, 'token_endpoint', 'OIDC discovery')
+    const token = await this.refreshToken(tokenEndpoint, {
+      clientId: config.clientId,
+      refreshToken,
+    })
+    const accessToken = readOptionalString(token, 'access_token') || readOptionalString(token, 'id_token')
+    if (!accessToken) throw new Error('Cloud OIDC refresh response is missing access_token.')
+    const me = await this.fetchPrincipal(connection, accessToken)
+    const principal = jsonRecord(me.principal, 'Cloud principal')
+    return {
+      accessToken,
+      refreshToken: readOptionalString(token, 'refresh_token') || refreshToken,
+      expiresAt: tokenExpiresAt(token),
+      tenantId: readOptionalString(principal, 'tenantId') || undefined,
+      userId: readOptionalString(principal, 'userId') || undefined,
+      profileName: readOptionalString(me, 'profileName') || undefined,
+    }
+  }
+
+  private async fetchDesktopConfig(connection: CloudWorkspaceConnectionRecord): Promise<CloudWorkspaceDesktopAuthConfig> {
+    const body = await readJsonRecord(
+      await this.fetcher(`${normalizeBaseUrl(connection.baseUrl)}/auth/desktop/config`, {
+        headers: { accept: 'application/json' },
+      }),
+      'Cloud desktop auth config',
+    )
+    const mode = readRequiredString(body, 'mode', 'Cloud desktop auth config')
+    if (mode !== 'oidc') throw new Error(`Unsupported cloud desktop auth mode: ${mode}.`)
+    return {
+      mode: 'oidc',
+      issuerUrl: readRequiredString(body, 'issuerUrl', 'Cloud desktop auth config'),
+      clientId: readRequiredString(body, 'clientId', 'Cloud desktop auth config'),
+      scope: readOptionalString(body, 'scope') || DEFAULT_SCOPE,
+    }
+  }
+
+  private async fetchDiscovery(issuerUrl: string): Promise<OidcDiscovery & Record<string, unknown>> {
+    const issuer = normalizeBaseUrl(issuerUrl)
+    return await readJsonRecord(
+      await this.fetcher(`${issuer}/.well-known/openid-configuration`, {
+        headers: { accept: 'application/json' },
+      }),
+      'OIDC discovery',
+    ) as OidcDiscovery & Record<string, unknown>
+  }
+
+  private async exchangeCode(
+    tokenEndpoint: string,
+    input: {
+      code: string
+      clientId: string
+      redirectUri: string
+      verifier: string
+    },
+  ) {
+    const form = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: input.code,
+      redirect_uri: input.redirectUri,
+      client_id: input.clientId,
+      code_verifier: input.verifier,
+    })
+    return readJsonRecord(
+      await this.fetcher(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: form.toString(),
+      }),
+      'OIDC token',
+    )
+  }
+
+  private async refreshToken(
+    tokenEndpoint: string,
+    input: {
+      clientId: string
+      refreshToken: string
+    },
+  ) {
+    const form = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: input.refreshToken,
+      client_id: input.clientId,
+    })
+    return readJsonRecord(
+      await this.fetcher(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: form.toString(),
+      }),
+      'OIDC refresh',
+    )
+  }
+
+  private async fetchPrincipal(connection: CloudWorkspaceConnectionRecord, accessToken: string) {
+    return readJsonRecord(
+      await this.fetcher(`${normalizeBaseUrl(connection.baseUrl)}/auth/me`, {
+        headers: {
+          accept: 'application/json',
+          authorization: `Bearer ${accessToken}`,
+        },
+      }),
+      'Cloud auth bootstrap',
+    )
+  }
+}
+
+export function createCloudWorkspaceDesktopAuthenticator(options?: CloudWorkspaceDesktopAuthenticatorOptions) {
+  return new CloudWorkspaceDesktopAuthenticator(options)
+}

--- a/apps/desktop/src/main/cloud-workspace-cache.ts
+++ b/apps/desktop/src/main/cloud-workspace-cache.ts
@@ -421,7 +421,10 @@ export class FileCloudWorkspaceCache implements CloudWorkspaceCache {
   removeWorkspace(workspaceId: string): void {
     const id = normalizeWorkspaceId(workspaceId)
     if (!id) return
-    this.writeRecords(this.readRecords().filter((record) => record.workspaceId !== id))
+    const records = this.readRecords()
+    const next = records.filter((record) => record.workspaceId !== id)
+    if (next.length === records.length) return
+    this.writeRecords(next)
   }
 
   private emptyRecord(workspaceId: string, now = new Date()): CloudWorkspaceCacheRecord {

--- a/apps/desktop/src/main/cloud-workspace-cache.ts
+++ b/apps/desktop/src/main/cloud-workspace-cache.ts
@@ -1,0 +1,509 @@
+import electron from 'electron'
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import type {
+  SessionArtifact,
+  SessionInfo,
+  SessionView,
+  WorkflowListPayload,
+} from '@open-cowork/shared'
+import type { CloudTransportSettingMetadata } from './cloud/transport-adapter.ts'
+import { getAppDataDir } from './config-loader.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
+import {
+  readSafeStorageBackendForPolicy,
+  resolveSecretStorageMode,
+  type SecretStorageMode,
+} from './secure-storage-policy.ts'
+
+const electronSafeStorage = (electron as { safeStorage?: typeof import('electron').safeStorage }).safeStorage
+const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
+  getSelectedStorageBackend?: () => string
+}) | undefined
+
+type SecretStorageAdapter = {
+  mode: SecretStorageMode
+  encryptString: (plaintext: string) => Buffer
+  decryptString: (encrypted: Buffer) => string
+}
+
+export type CloudWorkspaceCacheMode = 'full' | 'metadata-only' | 'disabled'
+export type CloudWorkspaceCacheEncryptionFallback = 'metadata-only' | 'disabled' | 'fail-startup'
+
+export type CloudWorkspaceCacheRecord = {
+  workspaceId: string
+  sessions: SessionInfo[]
+  views: Record<string, SessionView>
+  eventCursors: Record<string, number>
+  workflows: WorkflowListPayload | null
+  settings: CloudTransportSettingMetadata[]
+  artifactsBySession: Record<string, SessionArtifact[]>
+  updatedAt: string
+}
+
+export type CloudWorkspaceCache = {
+  mode: CloudWorkspaceCacheMode
+  listSessions(workspaceId: string): SessionInfo[] | null
+  getSessionInfo(workspaceId: string, sessionId: string): SessionInfo | null
+  getSessionView(workspaceId: string, sessionId: string): SessionView | null
+  getEventCursor(workspaceId: string, scope: string): number | null
+  setEventCursor(workspaceId: string, scope: string, sequence: number, now?: Date): void
+  resetEventCursor(workspaceId: string, scope: string, sequence?: number, now?: Date): void
+  getWorkflowList(workspaceId: string): WorkflowListPayload | null
+  upsertWorkflowList(workspaceId: string, workflows: WorkflowListPayload, now?: Date): void
+  listSettings(workspaceId: string): CloudTransportSettingMetadata[] | null
+  getSetting(workspaceId: string, key: string): CloudTransportSettingMetadata | null
+  upsertSettings(workspaceId: string, settings: CloudTransportSettingMetadata[], now?: Date): void
+  upsertSetting(workspaceId: string, setting: CloudTransportSettingMetadata, now?: Date): void
+  listArtifacts(workspaceId: string, sessionId: string): SessionArtifact[] | null
+  upsertArtifactList(workspaceId: string, sessionId: string, artifacts: SessionArtifact[], now?: Date): void
+  upsertSessionList(workspaceId: string, sessions: SessionInfo[], now?: Date): void
+  upsertSessionInfo(workspaceId: string, session: SessionInfo, now?: Date): void
+  upsertSessionView(workspaceId: string, sessionId: string, view: SessionView, now?: Date): void
+  removeWorkspace(workspaceId: string): void
+}
+
+function defaultCachePath() {
+  const dir = getAppDataDir()
+  mkdirSync(dir, { recursive: true })
+  return join(dir, 'cloud-workspace-cache.json')
+}
+
+function defaultSecretStorageMode() {
+  return resolveSecretStorageMode({
+    isPackaged: Boolean(electron.app?.isPackaged),
+    encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
+    selectedStorageBackend: readSafeStorageBackendForPolicy(
+      electronSafeStorageBackend?.getSelectedStorageBackend?.bind(electronSafeStorageBackend),
+    ),
+  })
+}
+
+function requireSafeStorage() {
+  if (!electronSafeStorage) throw new Error('Electron safeStorage is unavailable')
+  return electronSafeStorage
+}
+
+function normalizeWorkspaceId(value: unknown) {
+  return typeof value === 'string' && value.trim() && Buffer.byteLength(value.trim(), 'utf8') <= 512
+    ? value.trim()
+    : null
+}
+
+function normalizeSessionInfo(value: unknown): SessionInfo | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Partial<SessionInfo>
+  if (typeof record.id !== 'string' || !record.id.trim()) return null
+  if (typeof record.createdAt !== 'string' || typeof record.updatedAt !== 'string') return null
+  return {
+    id: record.id,
+    title: typeof record.title === 'string' ? record.title : undefined,
+    directory: null,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    kind: record.kind,
+    workflowId: record.workflowId ?? null,
+    runId: record.runId ?? null,
+    parentSessionId: record.parentSessionId ?? null,
+    changeSummary: record.changeSummary ?? null,
+    revertedMessageId: record.revertedMessageId ?? null,
+    composerModelId: record.composerModelId ?? null,
+    composerReasoningVariant: record.composerReasoningVariant ?? null,
+  }
+}
+
+function normalizeEventCursors(value: unknown): Record<string, number> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const cursors: Record<string, number> = {}
+  for (const [scope, sequence] of Object.entries(value as Record<string, unknown>)) {
+    if (!scope || Buffer.byteLength(scope, 'utf8') > 512) continue
+    if (typeof sequence !== 'number' || !Number.isFinite(sequence) || sequence < 0) continue
+    cursors[scope] = Math.floor(sequence)
+  }
+  return cursors
+}
+
+function normalizeWorkflowList(value: unknown): WorkflowListPayload | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Partial<WorkflowListPayload>
+  return {
+    workflows: Array.isArray(record.workflows) ? record.workflows as WorkflowListPayload['workflows'] : [],
+    runs: Array.isArray(record.runs) ? record.runs as WorkflowListPayload['runs'] : [],
+  }
+}
+
+function normalizeSetting(value: unknown): CloudTransportSettingMetadata | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Partial<CloudTransportSettingMetadata>
+  if (typeof record.key !== 'string' || !record.key.trim()) return null
+  if (!record.value || typeof record.value !== 'object' || Array.isArray(record.value)) return null
+  return {
+    tenantId: typeof record.tenantId === 'string' ? record.tenantId : undefined,
+    userId: typeof record.userId === 'string' ? record.userId : record.userId === null ? null : undefined,
+    key: record.key.trim(),
+    value: record.value as Record<string, unknown>,
+    updatedAt: typeof record.updatedAt === 'string' && record.updatedAt ? record.updatedAt : new Date(0).toISOString(),
+  }
+}
+
+function normalizeSettings(value: unknown): CloudTransportSettingMetadata[] {
+  return Array.isArray(value)
+    ? value.map(normalizeSetting).filter((setting): setting is CloudTransportSettingMetadata => Boolean(setting))
+    : []
+}
+
+function normalizeArtifact(value: unknown): SessionArtifact | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Partial<SessionArtifact>
+  if (typeof record.id !== 'string' || !record.id.trim()) return null
+  if (typeof record.filePath !== 'string' || !record.filePath.trim()) return null
+  return {
+    id: record.id,
+    toolId: typeof record.toolId === 'string' ? record.toolId : 'cloud-artifact',
+    toolName: typeof record.toolName === 'string' ? record.toolName : 'cloud.artifact',
+    taskRunId: typeof record.taskRunId === 'string' ? record.taskRunId : record.taskRunId === null ? null : undefined,
+    filename: typeof record.filename === 'string' && record.filename ? record.filename : record.id,
+    filePath: record.filePath,
+    order: typeof record.order === 'number' && Number.isFinite(record.order) ? record.order : 0,
+    mime: typeof record.mime === 'string' ? record.mime : undefined,
+    source: record.source === 'local' || record.source === 'cloud' ? record.source : undefined,
+    cloudArtifactId: typeof record.cloudArtifactId === 'string' ? record.cloudArtifactId : undefined,
+    size: typeof record.size === 'number' && Number.isFinite(record.size) ? record.size : undefined,
+    createdAt: typeof record.createdAt === 'string' ? record.createdAt : undefined,
+    chart: record.chart ?? undefined,
+  }
+}
+
+function normalizeArtifactsBySession(value: unknown): Record<string, SessionArtifact[]> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const artifactsBySession: Record<string, SessionArtifact[]> = {}
+  for (const [sessionId, artifacts] of Object.entries(value as Record<string, unknown>)) {
+    if (!sessionId || Buffer.byteLength(sessionId, 'utf8') > 512 || !Array.isArray(artifacts)) continue
+    artifactsBySession[sessionId] = artifacts
+      .map(normalizeArtifact)
+      .filter((artifact): artifact is SessionArtifact => Boolean(artifact))
+  }
+  return artifactsBySession
+}
+
+function normalizeRecord(value: unknown): CloudWorkspaceCacheRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const raw = value as Partial<CloudWorkspaceCacheRecord>
+  const workspaceId = normalizeWorkspaceId(raw.workspaceId)
+  if (!workspaceId) return null
+  const sessions = Array.isArray(raw.sessions)
+    ? raw.sessions.map(normalizeSessionInfo).filter((session): session is SessionInfo => Boolean(session))
+    : []
+  const views = raw.views && typeof raw.views === 'object' && !Array.isArray(raw.views)
+    ? raw.views as Record<string, SessionView>
+    : {}
+  return {
+    workspaceId,
+    sessions,
+    views,
+    eventCursors: normalizeEventCursors(raw.eventCursors),
+    workflows: normalizeWorkflowList(raw.workflows),
+    settings: normalizeSettings(raw.settings),
+    artifactsBySession: normalizeArtifactsBySession(raw.artifactsBySession),
+    updatedAt: typeof raw.updatedAt === 'string' && raw.updatedAt ? raw.updatedAt : new Date(0).toISOString(),
+  }
+}
+
+function mergeSession(sessions: SessionInfo[], session: SessionInfo) {
+  const normalized = normalizeSessionInfo(session)
+  if (!normalized) return sessions
+  const next = sessions.some((entry) => entry.id === normalized.id)
+    ? sessions.map((entry) => entry.id === normalized.id ? normalized : entry)
+    : [normalized, ...sessions]
+  return next.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.id.localeCompare(b.id))
+}
+
+export class FileCloudWorkspaceCache implements CloudWorkspaceCache {
+  readonly mode: CloudWorkspaceCacheMode
+  private readonly path: string
+  private readonly secretStorage: SecretStorageAdapter | null
+
+  constructor(options: {
+    path?: string
+    mode?: CloudWorkspaceCacheMode
+    encryptionFallback?: CloudWorkspaceCacheEncryptionFallback
+    secretStorage?: SecretStorageAdapter | null
+  } = {}) {
+    this.path = options.path || defaultCachePath()
+    const requestedMode = options.mode || 'full'
+    this.secretStorage = options.secretStorage === undefined ? null : options.secretStorage
+    if (requestedMode === 'full' && this.storageMode() === 'unavailable') {
+      const fallback = options.encryptionFallback || 'metadata-only'
+      if (fallback === 'fail-startup') {
+        throw new Error('Secure storage unavailable on this system. Open Cowork cannot persist full cloud workspace cache in production without OS-backed secret storage.')
+      }
+      this.mode = fallback
+      return
+    }
+    this.mode = requestedMode
+  }
+
+  listSessions(workspaceId: string): SessionInfo[] | null {
+    return this.readRecord(workspaceId)?.sessions || null
+  }
+
+  getSessionInfo(workspaceId: string, sessionId: string): SessionInfo | null {
+    return this.readRecord(workspaceId)?.sessions.find((session) => session.id === sessionId) || null
+  }
+
+  getSessionView(workspaceId: string, sessionId: string): SessionView | null {
+    if (this.mode !== 'full') return null
+    return this.readRecord(workspaceId)?.views[sessionId] || null
+  }
+
+  getEventCursor(workspaceId: string, scope: string): number | null {
+    return this.readRecord(workspaceId)?.eventCursors[scope] ?? null
+  }
+
+  setEventCursor(workspaceId: string, scope: string, sequence: number, now = new Date()): void {
+    if (this.mode === 'disabled' || !scope || !Number.isFinite(sequence) || sequence < 0) return
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    const current = existing.eventCursors[scope] || 0
+    this.writeRecord(records, {
+      ...existing,
+      eventCursors: {
+        ...existing.eventCursors,
+        [scope]: Math.max(current, Math.floor(sequence)),
+      },
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  resetEventCursor(workspaceId: string, scope: string, sequence = 0, now = new Date()): void {
+    if (this.mode === 'disabled' || !scope || !Number.isFinite(sequence) || sequence < 0) return
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    this.writeRecord(records, {
+      ...existing,
+      eventCursors: {
+        ...existing.eventCursors,
+        [scope]: Math.floor(sequence),
+      },
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  getWorkflowList(workspaceId: string): WorkflowListPayload | null {
+    return this.readRecord(workspaceId)?.workflows || null
+  }
+
+  upsertWorkflowList(workspaceId: string, workflows: WorkflowListPayload, now = new Date()): void {
+    if (this.mode === 'disabled') return
+    const id = normalizeWorkspaceId(workspaceId)
+    const normalized = normalizeWorkflowList(workflows)
+    if (!id || !normalized) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    this.writeRecord(records, {
+      ...existing,
+      workflows: normalized,
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  listSettings(workspaceId: string): CloudTransportSettingMetadata[] | null {
+    return this.readRecord(workspaceId)?.settings || null
+  }
+
+  getSetting(workspaceId: string, key: string): CloudTransportSettingMetadata | null {
+    return this.readRecord(workspaceId)?.settings.find((setting) => setting.key === key) || null
+  }
+
+  upsertSettings(workspaceId: string, settings: CloudTransportSettingMetadata[], now = new Date()): void {
+    if (this.mode === 'disabled') return
+    const id = normalizeWorkspaceId(workspaceId)
+    const normalized = normalizeSettings(settings)
+    if (!id) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    this.writeRecord(records, {
+      ...existing,
+      settings: normalized,
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  upsertSetting(workspaceId: string, setting: CloudTransportSettingMetadata, now = new Date()): void {
+    if (this.mode === 'disabled') return
+    const id = normalizeWorkspaceId(workspaceId)
+    const normalized = normalizeSetting(setting)
+    if (!id || !normalized) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    this.writeRecord(records, {
+      ...existing,
+      settings: [
+        ...existing.settings.filter((entry) => entry.key !== normalized.key),
+        normalized,
+      ].sort((left, right) => left.key.localeCompare(right.key)),
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  listArtifacts(workspaceId: string, sessionId: string): SessionArtifact[] | null {
+    return this.readRecord(workspaceId)?.artifactsBySession[sessionId] || null
+  }
+
+  upsertArtifactList(workspaceId: string, sessionId: string, artifacts: SessionArtifact[], now = new Date()): void {
+    if (this.mode === 'disabled' || !sessionId.trim()) return
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    this.writeRecord(records, {
+      ...existing,
+      artifactsBySession: {
+        ...existing.artifactsBySession,
+        [sessionId]: artifacts.map(normalizeArtifact).filter((artifact): artifact is SessionArtifact => Boolean(artifact)),
+      },
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  upsertSessionList(workspaceId: string, sessions: SessionInfo[], now = new Date()): void {
+    if (this.mode === 'disabled') return
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || null
+    const next: CloudWorkspaceCacheRecord = {
+      workspaceId: id,
+      sessions: sessions.map(normalizeSessionInfo).filter((session): session is SessionInfo => Boolean(session)),
+      views: this.mode === 'full' ? existing?.views || {} : {},
+      eventCursors: existing?.eventCursors || {},
+      workflows: existing?.workflows || null,
+      settings: existing?.settings || [],
+      artifactsBySession: existing?.artifactsBySession || {},
+      updatedAt: now.toISOString(),
+    }
+    this.writeRecord(records, next)
+  }
+
+  upsertSessionInfo(workspaceId: string, session: SessionInfo, now = new Date()): void {
+    if (this.mode === 'disabled') return
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    this.writeRecord(records, {
+      ...existing,
+      sessions: mergeSession(existing.sessions, session),
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  upsertSessionView(workspaceId: string, sessionId: string, view: SessionView, now = new Date()): void {
+    if (this.mode !== 'full') return
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id || !sessionId.trim()) return
+    const records = this.readRecords()
+    const existing = records.find((record) => record.workspaceId === id) || this.emptyRecord(id, now)
+    this.writeRecord(records, {
+      ...existing,
+      views: {
+        ...existing.views,
+        [sessionId]: view,
+      },
+      updatedAt: now.toISOString(),
+    })
+  }
+
+  removeWorkspace(workspaceId: string): void {
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id) return
+    this.writeRecords(this.readRecords().filter((record) => record.workspaceId !== id))
+  }
+
+  private emptyRecord(workspaceId: string, now = new Date()): CloudWorkspaceCacheRecord {
+    return {
+      workspaceId,
+      sessions: [],
+      views: {},
+      eventCursors: {},
+      workflows: null,
+      settings: [],
+      artifactsBySession: {},
+      updatedAt: now.toISOString(),
+    }
+  }
+
+  private readRecord(workspaceId: string) {
+    const id = normalizeWorkspaceId(workspaceId)
+    if (!id || this.mode === 'disabled') return null
+    return this.readRecords().find((record) => record.workspaceId === id) || null
+  }
+
+  private storageMode() {
+    return this.secretStorage?.mode || defaultSecretStorageMode()
+  }
+
+  private storage() {
+    return this.secretStorage || requireSafeStorage()
+  }
+
+  private readRecords(): CloudWorkspaceCacheRecord[] {
+    if (this.mode === 'disabled' || !existsSync(this.path)) return []
+    const storageMode = this.storageMode()
+    if (storageMode === 'unavailable' && this.mode === 'full') return []
+    try {
+      const raw = readFileSync(this.path)
+      const json = this.mode === 'full' && storageMode === 'encrypted'
+        ? this.storage().decryptString(raw)
+        : raw.toString('utf-8')
+      const parsed = JSON.parse(json) as unknown
+      if (!Array.isArray(parsed)) return []
+      return parsed.map(normalizeRecord).filter((record): record is CloudWorkspaceCacheRecord => Boolean(record))
+    } catch {
+      if (this.mode === 'full' && storageMode === 'encrypted') {
+        try { rmSync(this.path, { force: true }) } catch { /* ignore corrupted cache cleanup */ }
+      }
+      return []
+    }
+  }
+
+  private writeRecord(records: CloudWorkspaceCacheRecord[], nextRecord: CloudWorkspaceCacheRecord) {
+    this.writeRecords([
+      ...records.filter((record) => record.workspaceId !== nextRecord.workspaceId),
+      nextRecord,
+    ])
+  }
+
+  private writeRecords(records: CloudWorkspaceCacheRecord[]) {
+    if (this.mode === 'disabled') return
+    const safeRecords = records
+      .map((record) => normalizeRecord({
+        ...record,
+        views: this.mode === 'full' ? record.views : {},
+      }))
+      .filter((record): record is CloudWorkspaceCacheRecord => Boolean(record))
+      .sort((a, b) => a.workspaceId.localeCompare(b.workspaceId))
+    const json = JSON.stringify(safeRecords, null, 2)
+    const storageMode = this.storageMode()
+    if (this.mode === 'full' && storageMode === 'encrypted') {
+      writeFileAtomic(this.path, this.storage().encryptString(json), { mode: 0o600 })
+      return
+    }
+    if (this.mode === 'full' && storageMode === 'unavailable') {
+      throw new Error('Secure storage unavailable on this system. Open Cowork cannot persist full cloud workspace cache in production without OS-backed secret storage.')
+    }
+    writeFileAtomic(this.path, json, { mode: 0o600 })
+  }
+}
+
+export function createFileCloudWorkspaceCache(options?: {
+  path?: string
+  mode?: CloudWorkspaceCacheMode
+  encryptionFallback?: CloudWorkspaceCacheEncryptionFallback
+}) {
+  return new FileCloudWorkspaceCache(options)
+}

--- a/apps/desktop/src/main/cloud-workspace-credentials.ts
+++ b/apps/desktop/src/main/cloud-workspace-credentials.ts
@@ -1,0 +1,228 @@
+import electron from 'electron'
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { getAppDataDir } from './config-loader.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
+import {
+  readSafeStorageBackendForPolicy,
+  resolveSecretStorageMode,
+  type SecretStorageMode,
+} from './secure-storage-policy.ts'
+
+const electronSafeStorage = (electron as { safeStorage?: typeof import('electron').safeStorage }).safeStorage
+const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
+  getSelectedStorageBackend?: () => string
+}) | undefined
+
+type SecretStorageAdapter = {
+  mode: SecretStorageMode
+  encryptString: (plaintext: string) => Buffer
+  decryptString: (encrypted: Buffer) => string
+}
+
+export type CloudWorkspaceCredentialRecord = {
+  workspaceId: string
+  accessToken: string
+  refreshToken: string | null
+  expiresAt: string
+  tokenType: 'Bearer'
+  updatedAt: string
+}
+
+export type CloudWorkspaceCredentialInput = {
+  workspaceId: string
+  accessToken: string
+  refreshToken?: string | null
+  expiresAt: string
+}
+
+export type CloudWorkspaceCredentialMetadata = {
+  workspaceId: string
+  hasAccessToken: boolean
+  hasRefreshToken: boolean
+  expiresAt: string
+  updatedAt: string
+}
+
+export type CloudWorkspaceCredentialStore = {
+  get(workspaceId: string): CloudWorkspaceCredentialRecord | null
+  getUsableAccessToken(workspaceId: string, now?: Date): string | null
+  listMetadata(): CloudWorkspaceCredentialMetadata[]
+  save(input: CloudWorkspaceCredentialInput, now?: Date): CloudWorkspaceCredentialRecord
+  remove(workspaceId: string): boolean
+}
+
+function defaultCredentialPath() {
+  const dir = getAppDataDir()
+  mkdirSync(dir, { recursive: true })
+  return join(dir, 'cloud-workspace-credentials.json')
+}
+
+function defaultSecretStorageMode() {
+  return resolveSecretStorageMode({
+    isPackaged: Boolean(electron.app?.isPackaged),
+    encryptionAvailable: Boolean(electronSafeStorage?.isEncryptionAvailable?.()),
+    selectedStorageBackend: readSafeStorageBackendForPolicy(
+      electronSafeStorageBackend?.getSelectedStorageBackend?.bind(electronSafeStorageBackend),
+    ),
+  })
+}
+
+function requireSafeStorage() {
+  if (!electronSafeStorage) throw new Error('Electron safeStorage is unavailable')
+  return electronSafeStorage
+}
+
+function boundedToken(value: unknown, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const trimmed = value.trim()
+  if (Buffer.byteLength(trimmed, 'utf8') > 32 * 1024) throw new Error(`${label} is too large.`)
+  return trimmed
+}
+
+function boundedOptionalToken(value: unknown, label: string) {
+  if (value === undefined || value === null || value === '') return null
+  return boundedToken(value, label)
+}
+
+function normalizeWorkspaceId(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error('Cloud workspace credential workspace id is required.')
+  const trimmed = value.trim()
+  if (Buffer.byteLength(trimmed, 'utf8') > 512) throw new Error('Cloud workspace credential workspace id is too large.')
+  return trimmed
+}
+
+function normalizeIso(value: unknown, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const trimmed = value.trim()
+  const time = Date.parse(trimmed)
+  if (!Number.isFinite(time)) throw new Error(`${label} must be an ISO timestamp.`)
+  return new Date(time).toISOString()
+}
+
+function normalizeRecord(value: unknown): CloudWorkspaceCredentialRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const raw = value as Partial<CloudWorkspaceCredentialRecord>
+  try {
+    return {
+      workspaceId: normalizeWorkspaceId(raw.workspaceId),
+      accessToken: boundedToken(raw.accessToken, 'Cloud access token'),
+      refreshToken: boundedOptionalToken(raw.refreshToken, 'Cloud refresh token'),
+      expiresAt: normalizeIso(raw.expiresAt, 'Cloud token expiry'),
+      tokenType: 'Bearer',
+      updatedAt: normalizeIso(raw.updatedAt, 'Cloud token update time'),
+    }
+  } catch {
+    return null
+  }
+}
+
+function metadata(record: CloudWorkspaceCredentialRecord): CloudWorkspaceCredentialMetadata {
+  return {
+    workspaceId: record.workspaceId,
+    hasAccessToken: Boolean(record.accessToken),
+    hasRefreshToken: Boolean(record.refreshToken),
+    expiresAt: record.expiresAt,
+    updatedAt: record.updatedAt,
+  }
+}
+
+export class FileCloudWorkspaceCredentialStore implements CloudWorkspaceCredentialStore {
+  private readonly path: string
+  private readonly secretStorage: SecretStorageAdapter | null
+
+  constructor(options: { path?: string; secretStorage?: SecretStorageAdapter | null } = {}) {
+    this.path = options.path || defaultCredentialPath()
+    this.secretStorage = options.secretStorage === undefined ? null : options.secretStorage
+  }
+
+  get(workspaceId: string): CloudWorkspaceCredentialRecord | null {
+    const id = normalizeWorkspaceId(workspaceId)
+    return this.readRecords().find((record) => record.workspaceId === id) || null
+  }
+
+  getUsableAccessToken(workspaceId: string, now = new Date()): string | null {
+    const record = this.get(workspaceId)
+    if (!record) return null
+    if (Date.parse(record.expiresAt) <= now.getTime() + 30_000) return null
+    return record.accessToken
+  }
+
+  listMetadata(): CloudWorkspaceCredentialMetadata[] {
+    return this.readRecords().map(metadata)
+  }
+
+  save(input: CloudWorkspaceCredentialInput, now = new Date()): CloudWorkspaceCredentialRecord {
+    const record: CloudWorkspaceCredentialRecord = {
+      workspaceId: normalizeWorkspaceId(input.workspaceId),
+      accessToken: boundedToken(input.accessToken, 'Cloud access token'),
+      refreshToken: boundedOptionalToken(input.refreshToken, 'Cloud refresh token'),
+      expiresAt: normalizeIso(input.expiresAt, 'Cloud token expiry'),
+      tokenType: 'Bearer',
+      updatedAt: now.toISOString(),
+    }
+    const records = this.readRecords()
+    const next = records.some((entry) => entry.workspaceId === record.workspaceId)
+      ? records.map((entry) => entry.workspaceId === record.workspaceId ? record : entry)
+      : [...records, record]
+    this.writeRecords(next)
+    return record
+  }
+
+  remove(workspaceId: string): boolean {
+    const id = normalizeWorkspaceId(workspaceId)
+    const records = this.readRecords()
+    const next = records.filter((record) => record.workspaceId !== id)
+    if (next.length === records.length) return false
+    this.writeRecords(next)
+    return true
+  }
+
+  private storageMode() {
+    return this.secretStorage?.mode || defaultSecretStorageMode()
+  }
+
+  private storage() {
+    return this.secretStorage || requireSafeStorage()
+  }
+
+  private readRecords(): CloudWorkspaceCredentialRecord[] {
+    if (!existsSync(this.path)) return []
+    const mode = this.storageMode()
+    if (mode === 'unavailable') return []
+    try {
+      const raw = readFileSync(this.path)
+      const json = mode === 'encrypted'
+        ? this.storage().decryptString(raw)
+        : raw.toString('utf-8')
+      const parsed = JSON.parse(json) as unknown
+      if (!Array.isArray(parsed)) return []
+      return parsed
+        .map(normalizeRecord)
+        .filter((record): record is CloudWorkspaceCredentialRecord => Boolean(record))
+    } catch {
+      if (mode === 'encrypted') {
+        try { rmSync(this.path, { force: true }) } catch { /* ignore corrupted credential cleanup */ }
+      }
+      return []
+    }
+  }
+
+  private writeRecords(records: CloudWorkspaceCredentialRecord[]) {
+    const json = JSON.stringify(records, null, 2)
+    const mode = this.storageMode()
+    if (mode === 'encrypted') {
+      writeFileAtomic(this.path, this.storage().encryptString(json), { mode: 0o600 })
+      return
+    }
+    if (mode === 'plaintext') {
+      writeFileAtomic(this.path, json, { mode: 0o600 })
+      return
+    }
+    throw new Error('Secure storage unavailable on this system. Open Cowork cannot persist cloud workspace tokens in production without OS-backed secret storage.')
+  }
+}
+
+export function createFileCloudWorkspaceCredentialStore() {
+  return new FileCloudWorkspaceCredentialStore()
+}

--- a/apps/desktop/src/main/cloud-workspace-registry.ts
+++ b/apps/desktop/src/main/cloud-workspace-registry.ts
@@ -1,0 +1,199 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { getAppDataDir } from './config-loader.ts'
+import { writeFileAtomic } from './fs-atomic.ts'
+
+export type CloudWorkspaceConnectionRecord = {
+  id: string
+  baseUrl: string
+  label: string
+  tenantId?: string
+  userId?: string
+  profileName?: string
+  lastSyncedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type CloudWorkspaceConnectionInput = {
+  baseUrl: string
+  label?: string
+  tenantId?: string | null
+  userId?: string | null
+  profileName?: string | null
+  lastSyncedAt?: string | null
+}
+
+export type CloudWorkspaceRegistry = {
+  list(): CloudWorkspaceConnectionRecord[]
+  upsert(input: CloudWorkspaceConnectionInput, now?: Date): CloudWorkspaceConnectionRecord
+  remove(workspaceId: string): boolean
+  touchSync(workspaceId: string, syncedAt: string, now?: Date): CloudWorkspaceConnectionRecord | null
+}
+
+type StoredCloudWorkspaceConnection = Partial<CloudWorkspaceConnectionRecord> & {
+  token?: unknown
+  accessToken?: unknown
+  refreshToken?: unknown
+  apiKey?: unknown
+  secret?: unknown
+}
+
+function defaultRegistryPath() {
+  return join(getAppDataDir(), 'cloud-workspaces.json')
+}
+
+function isLoopbackHost(hostname: string) {
+  const host = hostname.trim().toLowerCase()
+  return host === 'localhost'
+    || host === '127.0.0.1'
+    || host === '::1'
+    || host === '[::1]'
+    || /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+}
+
+export function normalizeCloudWorkspaceBaseUrl(input: string) {
+  const parsed = new URL(input)
+  if (parsed.protocol !== 'https:') {
+    if (parsed.protocol !== 'http:' || !isLoopbackHost(parsed.hostname)) {
+      throw new Error('Cloud workspace URL must use https, except for localhost development.')
+    }
+  }
+  parsed.hash = ''
+  parsed.search = ''
+  return parsed.toString().replace(/\/+$/, '')
+}
+
+export function cloudWorkspaceIdForBaseUrl(baseUrl: string) {
+  return `cloud:${createHash('sha256').update(normalizeCloudWorkspaceBaseUrl(baseUrl)).digest('hex').slice(0, 16)}`
+}
+
+function optionalText(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function nullableIsoText(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function normalizeRecord(value: unknown): CloudWorkspaceConnectionRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const raw = value as StoredCloudWorkspaceConnection
+  if (typeof raw.baseUrl !== 'string' || !raw.baseUrl.trim()) return null
+  let baseUrl: string
+  try {
+    baseUrl = normalizeCloudWorkspaceBaseUrl(raw.baseUrl)
+  } catch {
+    return null
+  }
+  const id = typeof raw.id === 'string' && raw.id.startsWith('cloud:')
+    ? raw.id
+    : cloudWorkspaceIdForBaseUrl(baseUrl)
+  const createdAt = typeof raw.createdAt === 'string' && raw.createdAt
+    ? raw.createdAt
+    : new Date(0).toISOString()
+  const updatedAt = typeof raw.updatedAt === 'string' && raw.updatedAt
+    ? raw.updatedAt
+    : createdAt
+  return {
+    id,
+    baseUrl,
+    label: optionalText(raw.label) || new URL(baseUrl).host,
+    tenantId: optionalText(raw.tenantId),
+    userId: optionalText(raw.userId),
+    profileName: optionalText(raw.profileName),
+    lastSyncedAt: nullableIsoText(raw.lastSyncedAt),
+    createdAt,
+    updatedAt,
+  }
+}
+
+function sortRecords(records: CloudWorkspaceConnectionRecord[]) {
+  return records.slice().sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id))
+}
+
+export class FileCloudWorkspaceRegistry implements CloudWorkspaceRegistry {
+  private readonly path: string
+
+  constructor(path = defaultRegistryPath()) {
+    this.path = path
+  }
+
+  list(): CloudWorkspaceConnectionRecord[] {
+    return sortRecords(this.readRecords())
+  }
+
+  upsert(input: CloudWorkspaceConnectionInput, now = new Date()): CloudWorkspaceConnectionRecord {
+    const baseUrl = normalizeCloudWorkspaceBaseUrl(input.baseUrl)
+    const id = cloudWorkspaceIdForBaseUrl(baseUrl)
+    const records = this.readRecords()
+    const existing = records.find((record) => record.id === id) || null
+    const timestamp = now.toISOString()
+    const next: CloudWorkspaceConnectionRecord = {
+      id,
+      baseUrl,
+      label: input.label?.trim() || existing?.label || new URL(baseUrl).host,
+      tenantId: optionalText(input.tenantId) || existing?.tenantId,
+      userId: optionalText(input.userId) || existing?.userId,
+      profileName: optionalText(input.profileName) || existing?.profileName,
+      lastSyncedAt: input.lastSyncedAt === undefined ? existing?.lastSyncedAt || null : nullableIsoText(input.lastSyncedAt),
+      createdAt: existing?.createdAt || timestamp,
+      updatedAt: timestamp,
+    }
+    const merged = existing
+      ? records.map((record) => record.id === id ? next : record)
+      : [...records, next]
+    this.writeRecords(merged)
+    return next
+  }
+
+  remove(workspaceId: string): boolean {
+    const records = this.readRecords()
+    const next = records.filter((record) => record.id !== workspaceId)
+    if (next.length === records.length) return false
+    this.writeRecords(next)
+    return true
+  }
+
+  touchSync(workspaceId: string, syncedAt: string, now = new Date()): CloudWorkspaceConnectionRecord | null {
+    const records = this.readRecords()
+    let updated: CloudWorkspaceConnectionRecord | null = null
+    const next = records.map((record) => {
+      if (record.id !== workspaceId) return record
+      updated = {
+        ...record,
+        lastSyncedAt: syncedAt,
+        updatedAt: now.toISOString(),
+      }
+      return updated
+    })
+    if (!updated) return null
+    this.writeRecords(next)
+    return updated
+  }
+
+  private readRecords(): CloudWorkspaceConnectionRecord[] {
+    if (!existsSync(this.path)) return []
+    try {
+      const parsed = JSON.parse(readFileSync(this.path, 'utf-8')) as unknown
+      if (!Array.isArray(parsed)) return []
+      return parsed
+        .map(normalizeRecord)
+        .filter((record): record is CloudWorkspaceConnectionRecord => Boolean(record))
+    } catch {
+      return []
+    }
+  }
+
+  private writeRecords(records: CloudWorkspaceConnectionRecord[]) {
+    const safeRecords = sortRecords(records)
+      .map((record) => normalizeRecord(record))
+      .filter((record): record is CloudWorkspaceConnectionRecord => Boolean(record))
+    writeFileAtomic(this.path, JSON.stringify(safeRecords, null, 2), { mode: 0o600 })
+  }
+}
+
+export function createFileCloudWorkspaceRegistry(path?: string) {
+  return new FileCloudWorkspaceRegistry(path)
+}

--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -11,6 +11,7 @@ import {
   createCloudHttpServer,
   type CloudAuthResolver,
   type CloudBrowserAuthProvider,
+  type CloudDesktopAuthConfig,
   type CloudHttpServer,
 } from './http-server.ts'
 import {
@@ -295,6 +296,16 @@ export function createCloudAuthResolverForConfig(
   return createLocalCloudAuthResolver()
 }
 
+export function createCloudDesktopAuthConfig(auth: CloudAuthConfig): CloudDesktopAuthConfig | null {
+  if (auth.mode !== 'oidc' || !auth.issuerUrl?.trim() || !auth.clientId?.trim()) return null
+  return {
+    mode: 'oidc',
+    issuerUrl: auth.issuerUrl.trim(),
+    clientId: auth.clientId.trim(),
+    scope: 'openid email profile offline_access',
+  }
+}
+
 export function isLoopbackCloudHost(hostname: string | null | undefined) {
   const host = (hostname || '').trim().toLowerCase()
   if (!host) return false
@@ -524,6 +535,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
         sessionCookies,
         observability,
         browserAuth,
+        desktopAuth: createCloudDesktopAuthConfig(authConfig),
         auth: options.auth || createCloudAuthResolverForConfig(resolvedAuthConfig),
         internalToken: resolveCloudInternalToken(env),
         webhookSecurity,

--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -243,6 +243,7 @@ function createUnavailableRuntimeAdapter(): CloudRuntimeAdapter {
     promptSession: fail,
     abortSession: fail,
     replyToQuestion: fail,
+    rejectQuestion: fail,
     respondToPermission: fail,
   }
 }

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -9,7 +9,7 @@ import type {
 
 export type ControlPlaneRole = 'owner' | 'member'
 export type ControlPlaneSessionStatus = 'idle' | 'running' | 'closed' | 'errored'
-export type ControlPlaneCommandKind = 'prompt' | 'abort' | 'permission.respond' | 'question.reply'
+export type ControlPlaneCommandKind = 'prompt' | 'abort' | 'permission.respond' | 'question.reply' | 'question.reject'
 export type ControlPlaneCommandStatus = 'pending' | 'running' | 'acked' | 'failed'
 export type WorkerRole = 'all-in-one' | 'web' | 'worker' | 'scheduler'
 

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -49,6 +49,21 @@ export type SessionEventRecord = {
   createdAt: string
 }
 
+export type WorkspaceEventRecord = {
+  tenantId: string
+  userId: string
+  sessionId: string | null
+  eventId: string
+  sequence: number
+  entityType: string
+  entityId: string
+  operation: string
+  projectionVersion: number
+  type: string
+  payload: Record<string, unknown>
+  createdAt: string
+}
+
 export type SessionProjectionRecord = {
   tenantId: string
   sessionId: string
@@ -178,6 +193,20 @@ export type AppendEventInput = {
   tenantId: string
   sessionId: string
   eventId?: string
+  type: string
+  payload?: Record<string, unknown>
+  createdAt?: Date
+}
+
+export type AppendWorkspaceEventInput = {
+  tenantId: string
+  userId: string
+  sessionId?: string | null
+  eventId?: string
+  entityType?: string
+  entityId?: string
+  operation?: string
+  projectionVersion?: number
   type: string
   payload?: Record<string, unknown>
   createdAt?: Date
@@ -336,6 +365,8 @@ export type ControlPlaneStore = {
   }): MaybePromise<SessionRecord>
   appendSessionEvent(input: AppendEventInput): MaybePromise<SessionEventRecord>
   listSessionEvents(tenantId: string, sessionId: string, afterSequence?: number): MaybePromise<SessionEventRecord[]>
+  appendWorkspaceEvent(input: AppendWorkspaceEventInput): MaybePromise<WorkspaceEventRecord>
+  listWorkspaceEvents(tenantId: string, userId: string, afterSequence?: number): MaybePromise<WorkspaceEventRecord[]>
   writeSessionProjection(input: WriteProjectionInput): MaybePromise<SessionProjectionRecord>
   getSessionProjection(tenantId: string, sessionId: string): MaybePromise<SessionProjectionRecord | null>
   claimSessionLease(
@@ -429,6 +460,16 @@ function key(...parts: string[]) {
   return parts.join('\0')
 }
 
+function workspaceOperationFromType(type: string) {
+  if (/\b(created|submitted|uploaded|started)\b/.test(type)) return 'create'
+  if (/\b(deleted|removed|archived)\b/.test(type)) return 'delete'
+  return 'update'
+}
+
+function optionalTrimmedText(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
@@ -482,6 +523,7 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly threadTagLinks = new Map<string, Set<string>>()
   private readonly threadSmartFilters = new Map<string, ThreadSmartFilterRecord>()
   private readonly migrations = new Map<string, SchemaMigrationRecord>()
+  private readonly workspaceEvents = new Map<string, { nextSequence: number, events: WorkspaceEventRecord[] }>()
 
   createTenant(input: { tenantId: string, name: string, createdAt?: Date }): TenantRecord {
     const existing = this.tenants.get(input.tenantId)
@@ -638,6 +680,71 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   listSessionEvents(tenantId: string, sessionId: string, afterSequence = 0): SessionEventRecord[] {
     const session = this.requireSession(tenantId, sessionId)
     return session.events
+      .filter((event) => event.sequence > afterSequence)
+      .map((event) => clone(event))
+  }
+
+  appendWorkspaceEvent(input: AppendWorkspaceEventInput): WorkspaceEventRecord {
+    this.requireTenantUser(input.tenantId, input.userId)
+    if (input.sessionId) {
+      const session = this.requireSession(input.tenantId, input.sessionId)
+      if (session.record.userId !== input.userId) {
+        throw new Error(`Session ${input.sessionId} does not belong to user ${input.userId}.`)
+      }
+    }
+    const workspaceKey = `${input.tenantId}:${input.userId}`
+    const state = this.workspaceEvents.get(workspaceKey) || { nextSequence: 0, events: [] }
+    const payload = input.payload || {}
+    const eventId = input.eventId || `${input.userId}:${state.nextSequence + 1}`
+    const sequence = state.nextSequence + 1
+    const entityType = optionalTrimmedText(input.entityType) || (input.sessionId ? 'session' : 'workspace')
+    const entityId = optionalTrimmedText(input.entityId) || input.sessionId || input.userId
+    const operation = optionalTrimmedText(input.operation) || workspaceOperationFromType(input.type)
+    const projectionVersion = Number.isFinite(input.projectionVersion)
+      ? Math.max(0, Math.floor(input.projectionVersion || 0))
+      : sequence
+    const existing = state.events.find((event) => event.eventId === eventId)
+    if (existing) {
+      const expectedProjectionVersion = Number.isFinite(input.projectionVersion)
+        ? projectionVersion
+        : existing.projectionVersion
+      if (
+        existing.type !== input.type
+        || stableJson(existing.payload) !== stableJson(payload)
+        || (existing.sessionId || null) !== (input.sessionId || null)
+        || existing.entityType !== entityType
+        || existing.entityId !== entityId
+        || existing.operation !== operation
+        || existing.projectionVersion !== expectedProjectionVersion
+      ) {
+        throw new Error(`Workspace event id ${eventId} was reused with different content.`)
+      }
+      return clone(existing)
+    }
+    const event: WorkspaceEventRecord = {
+      tenantId: input.tenantId,
+      userId: input.userId,
+      sessionId: input.sessionId || null,
+      eventId,
+      sequence,
+      entityType,
+      entityId,
+      operation,
+      projectionVersion,
+      type: input.type,
+      payload,
+      createdAt: nowIso(input.createdAt),
+    }
+    state.nextSequence = sequence
+    state.events.push(event)
+    this.workspaceEvents.set(workspaceKey, state)
+    return clone(event)
+  }
+
+  listWorkspaceEvents(tenantId: string, userId: string, afterSequence = 0): WorkspaceEventRecord[] {
+    this.requireTenantUser(tenantId, userId)
+    const workspaceKey = `${tenantId}:${userId}`
+    return (this.workspaceEvents.get(workspaceKey)?.events || [])
       .filter((event) => event.sequence > afterSequence)
       .map((event) => clone(event))
   }

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -5,6 +5,7 @@ import type { WorkflowDraft, WorkflowStatus, WorkflowTriggerType } from '@open-c
 import type { CloudArtifactService } from './artifact-service.ts'
 import { cloudBrowserAppHtml } from './browser-app.ts'
 import type { CloudPrincipal, CloudSessionService } from './session-service.ts'
+import { cloudSessionViewToSessionView } from './session-view-contract.ts'
 import type { CloudWorker } from './worker.ts'
 import type { CloudRuntimePolicy } from './cloud-config.ts'
 import type { CloudObservabilityAdapter } from './observability.ts'
@@ -36,12 +37,20 @@ export type CloudBrowserAuthProvider = {
   callback(req: IncomingMessage, url: URL): Promise<CloudBrowserAuthCallback> | CloudBrowserAuthCallback
 }
 
+export type CloudDesktopAuthConfig = {
+  mode: 'oidc'
+  issuerUrl: string
+  clientId: string
+  scope: string
+}
+
 export type CloudHttpServerOptions = {
   service: CloudSessionService
   artifacts?: CloudArtifactService | null
   policy: CloudRuntimePolicy
   auth?: CloudAuthResolver
   browserAuth?: CloudBrowserAuthProvider | null
+  desktopAuth?: CloudDesktopAuthConfig | null
   worker?: CloudWorker | null
   webhookSecurity?: WorkflowWebhookSecurityStore | null
   internalToken?: string | null
@@ -145,6 +154,23 @@ function writeHtml(res: ServerResponse, status: number, body: string, origin?: s
 
 function writeError(res: ServerResponse, status: number, message: string, origin?: string | null) {
   writeJson(res, status, { error: message }, origin)
+}
+
+function writePolicyError(
+  res: ServerResponse,
+  status: number,
+  message: string,
+  policyCode: string,
+  origin?: string | null,
+) {
+  writeJson(res, status, {
+    error: message,
+    verdict: {
+      allowed: false,
+      reason: message,
+      policyCode,
+    },
+  }, origin)
 }
 
 function writeRedirect(
@@ -262,10 +288,41 @@ function extractSignatureWebhookAuth(req: IncomingMessage, rawBody: string): Wor
   return { kind: 'signature', timestamp, signature, rawBody }
 }
 
-function writeSseEvent(res: ServerResponse, event: { sequence: number, type: string, eventId: string, payload: Record<string, unknown> }) {
+function writeSseEvent(res: ServerResponse, event: {
+  tenantId?: string
+  userId?: string
+  sessionId?: string | null
+  sequence: number
+  entityType?: string
+  entityId?: string
+  operation?: string
+  projectionVersion?: number
+  type: string
+  eventId: string
+  payload: Record<string, unknown>
+  createdAt?: string
+}) {
   res.write(`id: ${event.sequence}\n`)
   res.write(`event: ${event.type}\n`)
   res.write(`data: ${JSON.stringify(event)}\n\n`)
+}
+
+function writeSnapshotRequiredEvent(
+  res: ServerResponse,
+  afterSequence: number,
+  payload: Record<string, unknown>,
+) {
+  writeSseEvent(res, {
+    sequence: afterSequence,
+    type: 'snapshot.required',
+    eventId: `snapshot-required:${afterSequence}`,
+    entityType: 'workspace',
+    entityId: 'workspace',
+    operation: 'snapshot_required',
+    projectionVersion: afterSequence,
+    createdAt: new Date().toISOString(),
+    payload,
+  })
 }
 
 function ssePollMs(options: CloudHttpServerOptions) {
@@ -419,6 +476,87 @@ async function handleSse(
   })
 }
 
+async function handleWorkspaceSse(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: CloudHttpServerOptions,
+  context: RouteContext,
+) {
+  const afterSequence = parseAfterSequence(req, context.url)
+  writeCorsHeaders(res, options.corsOrigin)
+  res.writeHead(200, {
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-store, no-transform',
+    connection: 'keep-alive',
+    'x-accel-buffering': 'no',
+  })
+  res.write(': connected\n\n')
+  let lastSequence = afterSequence
+  const writeIfNew = (event: {
+    tenantId?: string
+    userId?: string
+    sessionId?: string | null
+    sequence: number
+    entityType?: string
+    entityId?: string
+    operation?: string
+    projectionVersion?: number
+    type: string
+    eventId: string
+    payload: Record<string, unknown>
+    createdAt?: string
+  }) => {
+    if (event.sequence <= lastSequence) return
+    writeSseEvent(res, event)
+    lastSequence = event.sequence
+  }
+
+  const retainedEvents = await options.service.listWorkspaceEvents(context.principal, 0)
+  const earliestSequence = retainedEvents[0]?.sequence
+  const hasReplayGap = afterSequence > 0
+    && earliestSequence !== undefined
+    && earliestSequence > afterSequence + 1
+
+  if (hasReplayGap) {
+    const latestSequence = retainedEvents[retainedEvents.length - 1]?.sequence || afterSequence
+    writeSnapshotRequiredEvent(res, afterSequence, {
+      reason: 'event_retention_gap',
+      afterSequence,
+      earliestSequence,
+      latestSequence,
+    })
+    lastSequence = Math.max(lastSequence, latestSequence)
+  } else {
+    for (const event of retainedEvents) writeIfNew(event)
+  }
+
+  const unsubscribe = options.service.workspaceEventBus.subscribe({
+    tenantId: context.principal.tenantId,
+    userId: context.principal.userId,
+    afterSequence: lastSequence,
+  }, (event) => {
+    writeIfNew(event)
+  })
+  let pollActive = false
+  const pollTimer = setInterval(() => {
+    if (pollActive) return
+    pollActive = true
+    void options.service.listWorkspaceEvents(context.principal, lastSequence)
+      .then((events) => {
+        for (const event of events) writeIfNew(event)
+        res.write(': keep-alive\n\n')
+      })
+      .catch(() => {})
+      .finally(() => {
+        pollActive = false
+      })
+  }, ssePollMs(options))
+  req.on('close', () => {
+    clearInterval(pollTimer)
+    unsubscribe()
+  })
+}
+
 async function handleApiRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -453,6 +591,31 @@ async function handleApiRequest(
     return
   }
 
+  if (resource === 'workspace' && !sessionId && req.method === 'GET') {
+    writeJson(res, 200, {
+      tenantId: context.principal.tenantId,
+      tenantName: context.principal.tenantName || null,
+      userId: context.principal.userId,
+      email: context.principal.email,
+      profileName: options.policy.profileName,
+      policy: {
+        features: options.policy.features,
+        allowedAgents: options.policy.allowedAgents,
+        allowedTools: options.policy.allowedTools,
+        allowedMcps: options.policy.allowedMcps,
+        localFiles: 'disabled',
+        localStdioMcps: 'disabled',
+        machineRuntimeConfig: 'disabled',
+      },
+    }, options.corsOrigin)
+    return
+  }
+
+  if (resource === 'events' && !sessionId && req.method === 'GET') {
+    await handleWorkspaceSse(req, res, options, context)
+    return
+  }
+
   if (resource === 'workers' && sessionId === 'heartbeats' && !action && req.method === 'GET') {
     writeJson(res, 200, {
       heartbeats: await options.service.listWorkerHeartbeats(),
@@ -478,7 +641,7 @@ async function handleApiRequest(
 
   if (resource === 'capabilities') {
     if (!options.policy.features.agents && !options.policy.features.customSkills && !options.policy.features.customMcps) {
-      writeError(res, 403, 'Capabilities are disabled for this cloud profile.', options.corsOrigin)
+      writePolicyError(res, 403, 'Capabilities are disabled for this cloud profile.', 'capabilities.disabled', options.corsOrigin)
       return
     }
     const collection = sessionId
@@ -533,7 +696,7 @@ async function handleApiRequest(
 
   if (resource === 'settings') {
     if (!options.policy.features.settings) {
-      writeError(res, 403, 'Settings are disabled for this cloud profile.', options.corsOrigin)
+      writePolicyError(res, 403, 'Settings are disabled for this cloud profile.', 'settings.disabled', options.corsOrigin)
       return
     }
     const settingKey = sessionId ? decodeURIComponent(sessionId) : null
@@ -571,7 +734,7 @@ async function handleApiRequest(
 
   if (resource === 'threads') {
     if (!options.policy.features.threadIndex) {
-      writeError(res, 403, 'Thread index is disabled for this cloud profile.', options.corsOrigin)
+      writePolicyError(res, 403, 'Thread index is disabled for this cloud profile.', 'thread_index.disabled', options.corsOrigin)
       return
     }
     const collection = sessionId
@@ -689,7 +852,7 @@ async function handleApiRequest(
 
   if (resource === 'workflows') {
     if (!options.policy.features.workflows) {
-      writeError(res, 403, 'Workflows are disabled for this cloud profile.', options.corsOrigin)
+      writePolicyError(res, 403, 'Workflows are disabled for this cloud profile.', 'workflows.disabled', options.corsOrigin)
       return
     }
 
@@ -831,6 +994,16 @@ async function handleApiRequest(
     return
   }
 
+  if (action === 'view' && req.method === 'GET') {
+    const cloudView = await options.service.getSessionView(context.principal, sessionId)
+    writeJson(res, 200, {
+      session: cloudView.session,
+      projection: cloudView.projection,
+      view: cloudSessionViewToSessionView(cloudView),
+    }, options.corsOrigin)
+    return
+  }
+
   if (action === 'events' && req.method === 'GET') {
     await handleSse(req, res, options, context, sessionId)
     return
@@ -838,7 +1011,7 @@ async function handleApiRequest(
 
   if (action === 'artifacts') {
     if (!options.policy.features.artifacts) {
-      writeError(res, 403, 'Artifacts are disabled for this cloud profile.', options.corsOrigin)
+      writePolicyError(res, 403, 'Artifacts are disabled for this cloud profile.', 'artifacts.disabled', options.corsOrigin)
       return
     }
     if (!options.artifacts) {
@@ -952,6 +1125,15 @@ async function handleAuthRequest(
       csrfToken: context.cookieSession?.csrfToken || null,
       expiresAt: context.cookieSession?.expiresAt || null,
     }, options.corsOrigin)
+    return
+  }
+
+  if (url.pathname === '/auth/desktop/config' && req.method === 'GET') {
+    if (!options.desktopAuth) {
+      writeError(res, 404, 'Cloud desktop auth is not configured.', options.corsOrigin)
+      return
+    }
+    writeJson(res, 200, options.desktopAuth, options.corsOrigin)
     return
   }
 

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -1088,6 +1088,21 @@ async function handleApiRequest(
     return
   }
 
+  if (action === 'question-reject' && req.method === 'POST') {
+    const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+    const requestId = readString(body.requestId)
+    if (!requestId) {
+      writeError(res, 400, 'Question rejection requires requestId.', options.corsOrigin)
+      return
+    }
+    const command = await options.service.enqueueQuestionReject(context.principal, sessionId, {
+      requestId,
+    })
+    const processed = await processCommandIfConfigured(options, context.principal, sessionId)
+    writeJson(res, 202, { command, processed }, options.corsOrigin)
+    return
+  }
+
   if (action === 'permission-respond' && req.method === 'POST') {
     const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
     const permissionId = readString(body.permissionId)

--- a/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
@@ -9,6 +9,7 @@ import {
   normalizeRuntimeEventEnvelope,
   normalizeSessionInfo,
 } from '../opencode-adapter.ts'
+import { normalizePermissionEvent } from '../runtime-event-normalizers.ts'
 import { buildManagedRuntimeEnvironment } from '../runtime-environment.ts'
 import {
   createManagedOpencodeServerAuth,
@@ -70,6 +71,14 @@ function readNestedString(record: Record<string, unknown>, keys: string[]) {
   return null
 }
 
+function readNestedRecord(record: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const nested = asRecord(record[key])
+    if (Object.keys(nested).length > 0) return nested
+  }
+  return {}
+}
+
 function readSessionId(properties: Record<string, unknown>) {
   const part = asRecord(properties.part)
   const info = asRecord(properties.info)
@@ -97,7 +106,48 @@ function readErrorMessage(properties: Record<string, unknown>) {
 
 function eventFromMessagePartUpdated(properties: Record<string, unknown>): CloudRuntimeEvent[] {
   const part = normalizeMessagePart(properties.part)
-  if (!part || part.type !== 'text' || !part.text) return []
+  if (!part) return []
+
+  if (part.type === 'tool') {
+    const state = part.state
+    const isError = state.status === 'error' || state.error !== undefined
+    const isComplete = !isError && (state.status === 'completed' || state.status === 'complete' || state.output !== undefined)
+    const status = isError ? 'error' : isComplete ? 'complete' : 'running'
+    const input = Object.keys(state.input).length > 0 ? state.input : state.args
+    const sessionId = readSessionId(properties)
+    return [{
+      type: 'tool.call',
+      payload: {
+        ...(sessionId ? { sessionId } : {}),
+        id: part.callId || part.id || undefined,
+        name: part.tool || part.name || part.title || 'tool',
+        input,
+        status,
+        ...(state.output !== undefined ? { output: state.output } : state.result !== undefined ? { output: state.result } : {}),
+        ...(state.attachments.length > 0 ? { attachments: state.attachments } : part.attachments.length > 0 ? { attachments: part.attachments } : {}),
+        ...(part.agent ? { agent: part.agent } : {}),
+      },
+    }]
+  }
+
+  if (part.type === 'step-finish' && (part.cost !== null || part.tokens)) {
+    const sessionId = readSessionId(properties)
+    return [{
+      type: 'cost.updated',
+      payload: {
+        ...(sessionId ? { sessionId } : {}),
+        id: [
+          sessionId || 'session',
+          readMessageId(properties) || 'message',
+          part.id || 'step-finish',
+        ].join(':'),
+        cost: part.cost || 0,
+        tokens: part.tokens,
+      },
+    }]
+  }
+
+  if (part.type !== 'text' || !part.text) return []
   const role = readString(properties.role)
     || readString(asRecord(properties.info).role)
     || readString(asRecord(properties.message).role)
@@ -109,6 +159,110 @@ function eventFromMessagePartUpdated(properties: Record<string, unknown>): Cloud
       ...(sessionId ? { sessionId } : {}),
       messageId: readMessageId(properties) || part.id || undefined,
       content: part.text,
+    },
+  }]
+}
+
+function eventsFromPermissionRequested(properties: Record<string, unknown>): CloudRuntimeEvent[] {
+  const normalized = normalizePermissionEvent(properties)
+  if (!normalized.id) return []
+  return [{
+    type: 'permission.requested',
+    payload: {
+      permissionId: normalized.id,
+      id: normalized.id,
+      ...(normalized.sessionId ? { sessionId: normalized.sessionId } : {}),
+      tool: normalized.title,
+      input: normalized.input,
+      description: normalized.title || `Permission requested for ${normalized.permissionType}`,
+    },
+  }]
+}
+
+function eventsFromPermissionResolved(properties: Record<string, unknown>): CloudRuntimeEvent[] {
+  const normalized = normalizePermissionEvent(properties)
+  if (!normalized.id) return []
+  return [{
+    type: 'permission.resolved',
+    payload: {
+      permissionId: normalized.id,
+      id: normalized.id,
+      ...(normalized.sessionId ? { sessionId: normalized.sessionId } : {}),
+    },
+  }]
+}
+
+function normalizeQuestionPrompt(value: unknown) {
+  const record = asRecord(value)
+  return {
+    header: readString(record.header) || '',
+    question: readString(record.question) || '',
+    options: Array.isArray(record.options)
+      ? record.options.map((option) => {
+          const optionRecord = asRecord(option)
+          return {
+            label: readString(optionRecord.label) || '',
+            description: readString(optionRecord.description) || '',
+          }
+        })
+      : [],
+    multiple: record.multiple === true,
+    custom: record.custom !== false,
+  }
+}
+
+function eventsFromQuestionAsked(properties: Record<string, unknown>): CloudRuntimeEvent[] {
+  const requestId = readNestedString(properties, ['id', 'requestID', 'requestId'])
+  if (!requestId) return []
+  const tool = readNestedRecord(properties, ['tool'])
+  return [{
+    type: 'question.asked',
+    payload: {
+      requestId,
+      id: requestId,
+      ...(readSessionId(properties) ? { sessionId: readSessionId(properties) } : {}),
+      questions: Array.isArray(properties.questions) ? properties.questions.map(normalizeQuestionPrompt) : [],
+      ...(Object.keys(tool).length > 0
+        ? {
+            tool: {
+              messageId: readNestedString(tool, ['messageID', 'messageId']) || '',
+              callId: readNestedString(tool, ['callID', 'callId']) || '',
+            },
+          }
+        : {}),
+    },
+  }]
+}
+
+function eventsFromQuestionResolved(properties: Record<string, unknown>): CloudRuntimeEvent[] {
+  const requestId = readNestedString(properties, ['requestID', 'requestId', 'id'])
+  if (!requestId) return []
+  return [{
+    type: 'question.resolved',
+    payload: {
+      requestId,
+      id: requestId,
+      ...(readSessionId(properties) ? { sessionId: readSessionId(properties) } : {}),
+    },
+  }]
+}
+
+function normalizeTodo(value: unknown) {
+  const record = asRecord(value)
+  return {
+    ...(readString(record.id) ? { id: readString(record.id) } : {}),
+    content: readString(record.content) || '',
+    status: readString(record.status) || 'pending',
+    priority: readString(record.priority) || 'medium',
+  }
+}
+
+function eventsFromTodosUpdated(properties: Record<string, unknown>): CloudRuntimeEvent[] {
+  return [{
+    type: 'todos.updated',
+    payload: {
+      ...(readSessionId(properties) ? { sessionId: readSessionId(properties) } : {}),
+      todos: Array.isArray(properties.todos) ? properties.todos.map(normalizeTodo) : [],
     },
   }]
 }
@@ -178,6 +332,22 @@ export function translateOpencodeRuntimeEvent(raw: unknown): CloudRuntimeEvent[]
           message: readErrorMessage(properties),
         },
       }]
+    case 'permission.asked':
+    case 'permission.updated':
+      return eventsFromPermissionRequested(properties)
+    case 'permission.replied':
+    case 'permission.rejected':
+    case 'permission.resolved':
+      return eventsFromPermissionResolved(properties)
+    case 'question.asked':
+      return eventsFromQuestionAsked(properties)
+    case 'question.replied':
+    case 'question.rejected':
+    case 'question.resolved':
+      return eventsFromQuestionResolved(properties)
+    case 'todo.updated':
+    case 'todos.updated':
+      return eventsFromTodosUpdated(properties)
     default:
       return []
   }

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -7,6 +7,7 @@ import type {
 } from '@open-cowork/shared'
 import type {
   AttachWorkflowRunSessionInput,
+  AppendWorkspaceEventInput,
   ClaimDueWorkflowRunInput,
   ClaimedWorkflowRunRecord,
   CloudWorkflowRecord,
@@ -39,6 +40,7 @@ import type {
   WorkerHeartbeatRecord,
   WorkerLeaseRecord,
   WorkerRole,
+  WorkspaceEventRecord,
 } from './control-plane-store.ts'
 import type {
   WebhookAuthFailureRecord,
@@ -98,6 +100,16 @@ function stableJson(value: unknown): string {
       .join(',')}}`
   }
   return JSON.stringify(value)
+}
+
+function workspaceOperationFromType(type: string) {
+  if (/\b(created|submitted|uploaded|started)\b/.test(type)) return 'create'
+  if (/\b(deleted|removed|archived)\b/.test(type)) return 'delete'
+  return 'update'
+}
+
+function optionalTrimmedText(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
 function iso(value: unknown) {
@@ -209,6 +221,23 @@ function eventFromRow(row: QueryRow): SessionEventRecord {
     sessionId: String(row.session_id),
     eventId: String(row.event_id),
     sequence: numberValue(row.sequence),
+    type: String(row.type),
+    payload: jsonRecord(row.payload),
+    createdAt: iso(row.created_at),
+  }
+}
+
+function workspaceEventFromRow(row: QueryRow): WorkspaceEventRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    userId: String(row.user_id),
+    sessionId: stringOrNull(row.session_id),
+    eventId: String(row.event_id),
+    sequence: numberValue(row.sequence),
+    entityType: String(row.entity_type),
+    entityId: String(row.entity_id),
+    operation: String(row.operation),
+    projectionVersion: numberValue(row.projection_version),
     type: String(row.type),
     payload: jsonRecord(row.payload),
     createdAt: iso(row.created_at),
@@ -601,6 +630,101 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       [tenantId, sessionId, afterSequence],
     )
     return result.rows.map(eventFromRow)
+  }
+
+  async appendWorkspaceEvent(input: AppendWorkspaceEventInput) {
+    return this.withTransaction(async (client) => {
+      await this.requireTenantUser(input.tenantId, input.userId, client)
+      if (input.sessionId) {
+        const session = await this.requireSession(input.tenantId, input.sessionId, client, true)
+        if (String(session.user_id) !== input.userId) {
+          throw new Error(`Session ${input.sessionId} does not belong to user ${input.userId}.`)
+        }
+      }
+
+      const payload = input.payload || {}
+      const sessionId = input.sessionId || null
+      const entityType = optionalTrimmedText(input.entityType) || (sessionId ? 'session' : 'workspace')
+      const entityId = optionalTrimmedText(input.entityId) || sessionId || input.userId
+      const operation = optionalTrimmedText(input.operation) || workspaceOperationFromType(input.type)
+      await client.query(
+        `INSERT INTO cloud_workspace_event_counters (tenant_id, user_id, next_sequence)
+         VALUES ($1, $2, 0)
+         ON CONFLICT (tenant_id, user_id) DO NOTHING`,
+        [input.tenantId, input.userId],
+      )
+      const counter = await this.one(
+        `SELECT next_sequence
+         FROM cloud_workspace_event_counters
+         WHERE tenant_id = $1 AND user_id = $2
+         FOR UPDATE`,
+        [input.tenantId, input.userId],
+        client,
+      )
+      if (input.eventId) {
+        const existing = await this.findWorkspaceEvent(input.tenantId, input.userId, input.eventId, client)
+        if (existing) {
+          const projectionVersion = Number.isFinite(input.projectionVersion)
+            ? Math.max(0, Math.floor(input.projectionVersion || 0))
+            : existing.projectionVersion
+          return this.replayOrRejectWorkspaceEvent(existing, input.type, payload, {
+            sessionId,
+            entityType,
+            entityId,
+            operation,
+            projectionVersion,
+          })
+        }
+      }
+
+      const sequence = numberValue(counter.next_sequence) + 1
+      const eventId = input.eventId || `${input.userId}:${sequence}`
+      const projectionVersion = Number.isFinite(input.projectionVersion)
+        ? Math.max(0, Math.floor(input.projectionVersion || 0))
+        : sequence
+      await client.query(
+        `UPDATE cloud_workspace_event_counters
+         SET next_sequence = $3
+         WHERE tenant_id = $1 AND user_id = $2`,
+        [input.tenantId, input.userId, sequence],
+      )
+      const createdAt = nowIso(input.createdAt)
+      const inserted = await client.query(
+        `INSERT INTO cloud_workspace_events (
+          tenant_id, user_id, event_id, sequence, session_id,
+          entity_type, entity_id, operation, projection_version,
+          type, payload, created_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12)
+         RETURNING *`,
+        [
+          input.tenantId,
+          input.userId,
+          eventId,
+          sequence,
+          sessionId,
+          entityType,
+          entityId,
+          operation,
+          projectionVersion,
+          input.type,
+          JSON.stringify(payload),
+          createdAt,
+        ],
+      )
+      return workspaceEventFromRow(inserted.rows[0])
+    })
+  }
+
+  async listWorkspaceEvents(tenantId: string, userId: string, afterSequence = 0) {
+    await this.requireTenantUser(tenantId, userId)
+    const result = await this.pool.query(
+      `SELECT * FROM cloud_workspace_events
+       WHERE tenant_id = $1 AND user_id = $2 AND sequence > $3
+       ORDER BY sequence`,
+      [tenantId, userId, afterSequence],
+    )
+    return result.rows.map(workspaceEventFromRow)
   }
 
   async writeSessionProjection(input: {
@@ -1826,6 +1950,21 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     return row ? eventFromRow(row) : null
   }
 
+  private async findWorkspaceEvent(
+    tenantId: string,
+    userId: string,
+    eventId: string,
+    executor: PgExecutor,
+  ) {
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_workspace_events
+       WHERE tenant_id = $1 AND user_id = $2 AND event_id = $3`,
+      [tenantId, userId, eventId],
+      executor,
+    )
+    return row ? workspaceEventFromRow(row) : null
+  }
+
   private replayOrRejectEvent(
     existing: SessionEventRecord,
     type: string,
@@ -1833,6 +1972,32 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   ) {
     if (existing.type !== type || stableJson(existing.payload) !== stableJson(payload)) {
       throw new Error(`Event id ${existing.eventId} was reused with different content.`)
+    }
+    return existing
+  }
+
+  private replayOrRejectWorkspaceEvent(
+    existing: WorkspaceEventRecord,
+    type: string,
+    payload: Record<string, unknown>,
+    expected: {
+      sessionId: string | null
+      entityType: string
+      entityId: string
+      operation: string
+      projectionVersion: number
+    },
+  ) {
+    if (
+      existing.type !== type
+      || stableJson(existing.payload) !== stableJson(payload)
+      || existing.sessionId !== expected.sessionId
+      || existing.entityType !== expected.entityType
+      || existing.entityId !== expected.entityId
+      || existing.operation !== expected.operation
+      || existing.projectionVersion !== expected.projectionVersion
+    ) {
+      throw new Error(`Workspace event id ${existing.eventId} was reused with different content.`)
     }
     return existing
   }

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -47,6 +47,41 @@ export const CLOUD_CONTROL_PLANE_SCHEMA_STATEMENTS = [
   )`,
   `CREATE INDEX IF NOT EXISTS cloud_session_events_sequence_idx
     ON cloud_session_events (tenant_id, session_id, sequence)`,
+  `CREATE TABLE IF NOT EXISTS cloud_workspace_event_counters (
+    tenant_id text NOT NULL,
+    user_id text NOT NULL,
+    next_sequence integer NOT NULL DEFAULT 0,
+    PRIMARY KEY (tenant_id, user_id),
+    FOREIGN KEY (tenant_id, user_id) REFERENCES cloud_users(tenant_id, user_id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS cloud_workspace_events (
+    tenant_id text NOT NULL,
+    user_id text NOT NULL,
+    event_id text NOT NULL,
+    sequence integer NOT NULL,
+    session_id text,
+    entity_type text NOT NULL DEFAULT 'session',
+    entity_id text NOT NULL,
+    operation text NOT NULL DEFAULT 'update',
+    projection_version integer NOT NULL DEFAULT 0,
+    type text NOT NULL,
+    payload jsonb NOT NULL,
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (tenant_id, user_id, event_id),
+    UNIQUE (tenant_id, user_id, sequence),
+    FOREIGN KEY (tenant_id, user_id) REFERENCES cloud_users(tenant_id, user_id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, session_id) REFERENCES cloud_sessions(tenant_id, session_id) ON DELETE CASCADE
+  )`,
+  `ALTER TABLE cloud_workspace_events
+    ADD COLUMN IF NOT EXISTS entity_type text NOT NULL DEFAULT 'session'`,
+  `ALTER TABLE cloud_workspace_events
+    ADD COLUMN IF NOT EXISTS entity_id text NOT NULL DEFAULT ''`,
+  `ALTER TABLE cloud_workspace_events
+    ADD COLUMN IF NOT EXISTS operation text NOT NULL DEFAULT 'update'`,
+  `ALTER TABLE cloud_workspace_events
+    ADD COLUMN IF NOT EXISTS projection_version integer NOT NULL DEFAULT 0`,
+  `CREATE INDEX IF NOT EXISTS cloud_workspace_events_sequence_idx
+    ON cloud_workspace_events (tenant_id, user_id, sequence)`,
   `CREATE TABLE IF NOT EXISTS cloud_session_projections (
     tenant_id text NOT NULL,
     session_id text NOT NULL,

--- a/apps/desktop/src/main/cloud/runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/runtime-adapter.ts
@@ -31,6 +31,7 @@ export type CloudRuntimeAdapter = {
   }): Promise<CloudPromptResult | void>
   abortSession(input: { sessionId: string }): Promise<void>
   replyToQuestion?(input: { requestId: string, answers: unknown[] }): Promise<void>
+  rejectQuestion?(input: { requestId: string }): Promise<void>
   respondToPermission?(input: { permissionId: string, allowed: boolean }): Promise<void>
   subscribeEvents?: (
     listener: CloudRuntimeEventListener,
@@ -51,6 +52,7 @@ type SdkLikeClient = {
   }
   question?: {
     reply?: unknown
+    reject?: unknown
   }
   permission?: {
     reply?: unknown
@@ -95,6 +97,16 @@ export function createSdkCloudRuntimeAdapter(client: SdkLikeClient): CloudRuntim
       await reply.call(client.question, {
         requestID: input.requestId,
         answers: input.answers,
+      }, { throwOnError: true })
+    },
+    async rejectQuestion(input) {
+      if (typeof client.question?.reject !== 'function') throw new Error('OpenCode question rejection is not available.')
+      const reject = client.question.reject as (
+        request: { requestID: string },
+        options?: { throwOnError?: boolean },
+      ) => Promise<unknown>
+      await reject.call(client.question, {
+        requestID: input.requestId,
       }, { throwOnError: true })
     },
     async respondToPermission(input) {

--- a/apps/desktop/src/main/cloud/session-event-bus.ts
+++ b/apps/desktop/src/main/cloud/session-event-bus.ts
@@ -1,4 +1,4 @@
-import type { SessionEventRecord } from './control-plane-store.ts'
+import type { SessionEventRecord, WorkspaceEventRecord } from './control-plane-store.ts'
 
 export type CloudSessionEventFilter = {
   tenantId?: string
@@ -31,6 +31,49 @@ export class CloudSessionEventBus {
   }
 
   subscribe(filter: CloudSessionEventFilter, listener: CloudSessionEventListener) {
+    const subscription = { filter, listener }
+    this.subscriptions.add(subscription)
+    return () => {
+      this.subscriptions.delete(subscription)
+    }
+  }
+
+  get subscriberCount() {
+    return this.subscriptions.size
+  }
+}
+
+export type CloudWorkspaceEventFilter = {
+  tenantId?: string
+  userId?: string
+  afterSequence?: number
+}
+
+export type CloudWorkspaceEventListener = (event: WorkspaceEventRecord) => void
+
+type WorkspaceSubscription = {
+  filter: CloudWorkspaceEventFilter
+  listener: CloudWorkspaceEventListener
+}
+
+function matchesWorkspaceEvent(filter: CloudWorkspaceEventFilter, event: WorkspaceEventRecord) {
+  if (filter.tenantId && filter.tenantId !== event.tenantId) return false
+  if (filter.userId && filter.userId !== event.userId) return false
+  if (filter.afterSequence !== undefined && event.sequence <= filter.afterSequence) return false
+  return true
+}
+
+export class CloudWorkspaceEventBus {
+  private readonly subscriptions = new Set<WorkspaceSubscription>()
+
+  publish(event: WorkspaceEventRecord) {
+    for (const subscription of this.subscriptions) {
+      if (!matchesWorkspaceEvent(subscription.filter, event)) continue
+      subscription.listener(event)
+    }
+  }
+
+  subscribe(filter: CloudWorkspaceEventFilter, listener: CloudWorkspaceEventListener) {
     const subscription = { filter, listener }
     this.subscriptions.add(subscription)
     return () => {

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -123,6 +123,10 @@ type QuestionReplyPayload = {
   answers: unknown[]
 }
 
+type QuestionRejectPayload = {
+  requestId: string
+}
+
 type PermissionRespondPayload = {
   permissionId: string
   response: unknown
@@ -853,6 +857,12 @@ function normalizeQuestionReplyPayload(payload: Record<string, unknown>): Questi
   }
 }
 
+function normalizeQuestionRejectPayload(payload: Record<string, unknown>): QuestionRejectPayload {
+  return {
+    requestId: readString(payload.requestId),
+  }
+}
+
 function normalizePermissionPayload(payload: Record<string, unknown>): PermissionRespondPayload {
   return {
     permissionId: readString(payload.permissionId),
@@ -1345,6 +1355,22 @@ export class CloudSessionService {
     })
   }
 
+  async enqueueQuestionReject(
+    principal: CloudPrincipal,
+    sessionId: string,
+    payload: QuestionRejectPayload,
+  ): Promise<SessionCommandRecord> {
+    await this.getSessionView(principal, sessionId)
+    return this.store.enqueueSessionCommand({
+      commandId: this.ids.randomUUID(),
+      tenantId: principal.tenantId,
+      userId: principal.userId,
+      sessionId,
+      kind: 'question.reject',
+      payload,
+    })
+  }
+
   async enqueuePermissionResponse(
     principal: CloudPrincipal,
     sessionId: string,
@@ -1372,6 +1398,9 @@ export class CloudSessionService {
           break
         case 'question.reply':
           await this.executeQuestionReplyCommand(lease, command)
+          break
+        case 'question.reject':
+          await this.executeQuestionRejectCommand(lease, command)
           break
         case 'permission.respond':
           await this.executePermissionCommand(lease, command)
@@ -1516,6 +1545,26 @@ export class CloudSessionService {
       payload: {
         commandId: command.commandId,
         requestId: payload.requestId,
+      },
+      leaseToken: lease.leaseToken,
+    })
+  }
+
+  private async executeQuestionRejectCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
+    const payload = normalizeQuestionRejectPayload(command.payload)
+    if (!payload.requestId) throw new Error('Question rejection requires a request id.')
+    if (!this.runtime.rejectQuestion) throw new Error('OpenCode question rejection is not available.')
+    await this.runtime.rejectQuestion({
+      requestId: payload.requestId,
+    })
+    await this.appendProjectedEvent({
+      tenantId: command.tenantId,
+      sessionId: command.sessionId,
+      type: 'question.resolved',
+      payload: {
+        commandId: command.commandId,
+        requestId: payload.requestId,
+        rejected: true,
       },
       leaseToken: lease.leaseToken,
     })

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -599,7 +599,7 @@ function pendingApprovalFromPayload(
   const id = eventPayloadId(payload, ['permissionId', 'id', 'requestId', 'requestID'], `${session.sessionId}:permission:${event.sequence}`)
   return {
     id,
-    sessionId: readString(payload.sessionId, session.sessionId),
+    sessionId: session.sessionId,
     taskRunId: readNullableString(payload.taskRunId),
     tool: readString(payload.tool, 'permission'),
     input: asRecord(payload.input),
@@ -617,7 +617,7 @@ function pendingQuestionFromPayload(
   const tool = asRecord(payload.tool)
   return {
     id,
-    sessionId: readString(payload.sessionId, session.sessionId),
+    sessionId: session.sessionId,
     sourceSessionId: readNullableString(payload.sourceSessionId),
     questions: Array.isArray(payload.questions)
       ? payload.questions.map(normalizeQuestionPrompt).filter((entry): entry is PendingQuestion['questions'][number] => Boolean(entry))

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -670,8 +670,8 @@ function reduceProjectedEvent(
     case 'assistant.message':
       return addMessage({
         ...current,
-        status: 'idle',
-        isGenerating: false,
+        status: current.status,
+        isGenerating: current.isGenerating,
         lastError: null,
         updatedAt: eventTime,
       }, {
@@ -1432,7 +1432,7 @@ export class CloudSessionService {
     event: CloudRuntimeEvent
     leaseToken?: string | null
   }): Promise<SessionEventRecord> {
-    if (input.event.type === 'assistant.message' || input.event.type === 'session.idle') {
+    if (input.event.type === 'session.idle') {
       return this.updateStatusThenAppendRuntimeEvent(input, 'idle')
     } else if (input.event.type === 'session.status') {
       const statusType = readString(input.event.payload.statusType)

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -1,7 +1,16 @@
 import { createHash, randomUUID } from 'crypto'
+import { cloudArtifactFilePath } from '@open-cowork/shared'
 import type {
   CapabilitySkill,
   CapabilityTool,
+  PendingApproval,
+  PendingQuestion,
+  SessionArtifact,
+  SessionError,
+  SessionTokens,
+  TaskRun,
+  TodoItem,
+  ToolCall,
   WorkflowDetail,
   WorkflowDraft,
   WorkflowListPayload,
@@ -31,7 +40,7 @@ import type {
 } from './control-plane-store.ts'
 import type { CloudRuntimeAdapter, CloudRuntimeEvent, CloudRuntimePromptPart } from './runtime-adapter.ts'
 import { evaluateCloudProjectDirectoryPolicy, type CloudRuntimePolicy } from './cloud-config.ts'
-import { CloudSessionEventBus } from './session-event-bus.ts'
+import { CloudSessionEventBus, CloudWorkspaceEventBus } from './session-event-bus.ts'
 import { computeNextWorkflowRunAt, validateWorkflowSchedule } from '../workflow/workflow-schedule.ts'
 import {
   verifyWorkflowWebhookAuth,
@@ -61,6 +70,16 @@ export type CloudSessionProjectionView = {
   profileName: string
   isGenerating: boolean
   messages: CloudSessionMessage[]
+  toolCalls: ToolCall[]
+  taskRuns: TaskRun[]
+  pendingApprovals: PendingApproval[]
+  pendingQuestions: PendingQuestion[]
+  artifacts: SessionArtifact[]
+  todos: TodoItem[]
+  errors: SessionError[]
+  sessionCost: number
+  sessionTokens: SessionTokens
+  lastInputTokens: number
   lastError: string | null
   updatedAt: string
 }
@@ -116,6 +135,13 @@ const WORKFLOW_MAX_LIST_VALUES = 100
 const WORKFLOW_VALID_TRIGGER_TYPES = new Set<WorkflowTriggerType>(['manual', 'schedule', 'webhook'])
 const WEBHOOK_SIGNATURE_REPLAY_WINDOW_MS = 5 * 60 * 1000
 const WEBHOOK_SIGNATURE_REPLAY_CACHE_LIMIT = 512
+const EMPTY_SESSION_TOKENS: SessionTokens = {
+  input: 0,
+  output: 0,
+  reasoning: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+}
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -125,6 +151,10 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function readString(value: unknown, fallback = '') {
   return typeof value === 'string' && value.trim() ? value : fallback
+}
+
+function readNumber(value: unknown, fallback = 0) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
 }
 
 function readNullableString(value: unknown) {
@@ -167,6 +197,216 @@ function toMessage(value: unknown): CloudSessionMessage | null {
   }
 }
 
+function normalizeSessionTokens(value: unknown): SessionTokens {
+  const record = asRecord(value)
+  const cache = asRecord(record.cache)
+  return {
+    input: readNumber(record.input),
+    output: readNumber(record.output),
+    reasoning: readNumber(record.reasoning),
+    cacheRead: readNumber(record.cacheRead, readNumber(cache.read)),
+    cacheWrite: readNumber(record.cacheWrite, readNumber(cache.write)),
+  }
+}
+
+function addSessionTokens(current: SessionTokens, delta: SessionTokens): SessionTokens {
+  return {
+    input: current.input + delta.input,
+    output: current.output + delta.output,
+    reasoning: current.reasoning + delta.reasoning,
+    cacheRead: current.cacheRead + delta.cacheRead,
+    cacheWrite: current.cacheWrite + delta.cacheWrite,
+  }
+}
+
+function normalizeToolStatus(value: unknown): ToolCall['status'] {
+  return value === 'complete' || value === 'error' || value === 'running' ? value : 'running'
+}
+
+function normalizeTaskStatus(value: unknown): TaskRun['status'] {
+  return value === 'queued' || value === 'running' || value === 'complete' || value === 'error'
+    ? value
+    : 'queued'
+}
+
+function toTodoItem(value: unknown): TodoItem | null {
+  const record = asRecord(value)
+  const content = readString(record.content)
+  if (!content) return null
+  return {
+    content,
+    status: readString(record.status, 'pending'),
+    priority: readString(record.priority, 'medium'),
+    ...(readNullableString(record.id) ? { id: readNullableString(record.id) || undefined } : {}),
+  }
+}
+
+function normalizeTodos(value: unknown): TodoItem[] {
+  return Array.isArray(value)
+    ? value.map(toTodoItem).filter((entry): entry is TodoItem => Boolean(entry))
+    : []
+}
+
+function normalizeToolCall(value: unknown): ToolCall | null {
+  const record = asRecord(value)
+  const id = readString(record.id)
+  if (!id) return null
+  return {
+    id,
+    name: readString(record.name, 'tool'),
+    input: asRecord(record.input),
+    status: normalizeToolStatus(record.status),
+    ...(record.output !== undefined ? { output: record.output } : {}),
+    ...(Array.isArray(record.attachments) ? { attachments: record.attachments as ToolCall['attachments'] } : {}),
+    agent: readNullableString(record.agent),
+    sourceSessionId: readNullableString(record.sourceSessionId),
+    order: readNumber(record.order),
+  }
+}
+
+function normalizeTaskRun(value: unknown): TaskRun | null {
+  const record = asRecord(value)
+  const id = readString(record.id)
+  if (!id) return null
+  return {
+    id,
+    title: readString(record.title, 'Task'),
+    agent: readNullableString(record.agent),
+    status: normalizeTaskStatus(record.status),
+    sourceSessionId: readNullableString(record.sourceSessionId),
+    parentSessionId: readNullableString(record.parentSessionId),
+    content: readString(record.content),
+    transcript: Array.isArray(record.transcript) ? record.transcript as TaskRun['transcript'] : [],
+    reasoning: Array.isArray(record.reasoning) ? record.reasoning as TaskRun['reasoning'] : undefined,
+    toolCalls: Array.isArray(record.toolCalls)
+      ? record.toolCalls.map(normalizeToolCall).filter((entry): entry is ToolCall => Boolean(entry))
+      : [],
+    compactions: Array.isArray(record.compactions) ? record.compactions as TaskRun['compactions'] : [],
+    todos: normalizeTodos(record.todos),
+    error: readNullableString(record.error),
+    sessionCost: readNumber(record.sessionCost),
+    sessionTokens: normalizeSessionTokens(record.sessionTokens),
+    order: readNumber(record.order),
+    startedAt: readNullableString(record.startedAt),
+    finishedAt: readNullableString(record.finishedAt),
+  }
+}
+
+function normalizeQuestionPrompt(value: unknown): PendingQuestion['questions'][number] | null {
+  const record = asRecord(value)
+  const question = readString(record.question)
+  if (!question) return null
+  return {
+    header: readString(record.header),
+    question,
+    options: Array.isArray(record.options)
+      ? record.options.map((option) => {
+          const optionRecord = asRecord(option)
+          return {
+            label: readString(optionRecord.label),
+            description: readString(optionRecord.description),
+          }
+        }).filter((option) => option.label || option.description)
+      : [],
+    multiple: record.multiple === true,
+    custom: record.custom !== false,
+  }
+}
+
+function normalizePendingQuestion(value: unknown): PendingQuestion | null {
+  const record = asRecord(value)
+  const id = readString(record.id)
+  const sessionId = readString(record.sessionId)
+  if (!id || !sessionId) return null
+  const tool = asRecord(record.tool)
+  return {
+    id,
+    sessionId,
+    sourceSessionId: readNullableString(record.sourceSessionId),
+    questions: Array.isArray(record.questions)
+      ? record.questions.map(normalizeQuestionPrompt).filter((entry): entry is PendingQuestion['questions'][number] => Boolean(entry))
+      : [],
+    ...(Object.keys(tool).length > 0
+      ? {
+          tool: {
+            messageId: readString(tool.messageId),
+            callId: readString(tool.callId),
+          },
+        }
+      : {}),
+  }
+}
+
+function normalizePendingApproval(value: unknown): PendingApproval | null {
+  const record = asRecord(value)
+  const id = readString(record.id)
+  const sessionId = readString(record.sessionId)
+  if (!id || !sessionId) return null
+  return {
+    id,
+    sessionId,
+    taskRunId: readNullableString(record.taskRunId),
+    tool: readString(record.tool, 'permission'),
+    input: asRecord(record.input),
+    description: readString(record.description, 'Permission requested'),
+    order: readNumber(record.order),
+  }
+}
+
+function normalizeSessionError(value: unknown): SessionError | null {
+  const record = asRecord(value)
+  const id = readString(record.id)
+  const message = readString(record.message)
+  if (!id || !message) return null
+  return {
+    id,
+    sessionId: readNullableString(record.sessionId),
+    message,
+    order: readNumber(record.order),
+  }
+}
+
+function normalizeSessionArtifact(value: unknown, fallbackOrder = 0): SessionArtifact | null {
+  const record = asRecord(value)
+  const artifactId = readString(record.artifactId, readString(record.cloudArtifactId, readString(record.id)))
+  const filename = readString(record.filename, 'artifact')
+  const filePath = readString(record.filePath, artifactId ? cloudArtifactFilePath(artifactId, filename) : '')
+  if (!artifactId || !filePath) return null
+  const size = readNumber(record.size, Number.NaN)
+  return {
+    id: artifactId,
+    toolId: readString(record.toolId, 'cloud-artifact'),
+    toolName: readString(record.toolName, 'cloud.artifact'),
+    filePath,
+    filename,
+    order: readNumber(record.order, fallbackOrder),
+    source: 'cloud',
+    cloudArtifactId: artifactId,
+    taskRunId: readNullableString(record.taskRunId),
+    mime: readNullableString(record.mime) || readNullableString(record.contentType) || undefined,
+    ...(Number.isFinite(size) ? { size } : {}),
+    createdAt: readNullableString(record.createdAt) || undefined,
+  }
+}
+
+function upsertById<T extends { id: string }>(entries: T[], incoming: T): T[] {
+  const index = entries.findIndex((entry) => entry.id === incoming.id)
+  if (index === -1) return [...entries, incoming]
+  return entries.map((entry, entryIndex) => entryIndex === index
+    ? (() => {
+        const merged = { ...entry, ...incoming } as T
+        if ('order' in entry && 'order' in merged) {
+          ;(merged as T & { order: unknown }).order = (entry as T & { order: unknown }).order
+        }
+        return merged
+      })()
+    : entry)
+}
+
+function removeById<T extends { id: string }>(entries: T[], id: string): T[] {
+  return entries.filter((entry) => entry.id !== id)
+}
+
 function projectionViewFromRecord(session: SessionRecord): CloudSessionProjectionView {
   return {
     sessionId: session.sessionId,
@@ -175,6 +415,16 @@ function projectionViewFromRecord(session: SessionRecord): CloudSessionProjectio
     profileName: session.profileName,
     isGenerating: session.status === 'running',
     messages: [],
+    toolCalls: [],
+    taskRuns: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    artifacts: [],
+    todos: [],
+    errors: [],
+    sessionCost: 0,
+    sessionTokens: { ...EMPTY_SESSION_TOKENS },
+    lastInputTokens: 0,
     lastError: null,
     updatedAt: session.updatedAt,
   }
@@ -193,6 +443,28 @@ function normalizeProjectionView(value: unknown, session: SessionRecord): CloudS
     profileName: readString(record.profileName, session.profileName),
     isGenerating: typeof record.isGenerating === 'boolean' ? record.isGenerating : session.status === 'running',
     messages,
+    toolCalls: Array.isArray(record.toolCalls)
+      ? record.toolCalls.map(normalizeToolCall).filter((entry): entry is ToolCall => Boolean(entry))
+      : [],
+    taskRuns: Array.isArray(record.taskRuns)
+      ? record.taskRuns.map(normalizeTaskRun).filter((entry): entry is TaskRun => Boolean(entry))
+      : [],
+    pendingApprovals: Array.isArray(record.pendingApprovals)
+      ? record.pendingApprovals.map(normalizePendingApproval).filter((entry): entry is PendingApproval => Boolean(entry))
+      : [],
+    pendingQuestions: Array.isArray(record.pendingQuestions)
+      ? record.pendingQuestions.map(normalizePendingQuestion).filter((entry): entry is PendingQuestion => Boolean(entry))
+      : [],
+    artifacts: Array.isArray(record.artifacts)
+      ? record.artifacts.map((entry, index) => normalizeSessionArtifact(entry, index)).filter((entry): entry is SessionArtifact => Boolean(entry))
+      : [],
+    todos: normalizeTodos(record.todos),
+    errors: Array.isArray(record.errors)
+      ? record.errors.map(normalizeSessionError).filter((entry): entry is SessionError => Boolean(entry))
+      : [],
+    sessionCost: readNumber(record.sessionCost),
+    sessionTokens: normalizeSessionTokens(record.sessionTokens),
+    lastInputTokens: readNumber(record.lastInputTokens),
     lastError: typeof record.lastError === 'string' ? record.lastError : null,
     updatedAt: readString(record.updatedAt, session.updatedAt),
   }
@@ -207,6 +479,158 @@ function addMessage(
     ...view,
     messages: [...view.messages, message],
   }
+}
+
+function eventPayloadId(payload: Record<string, unknown>, keys: string[], fallback: string) {
+  for (const key of keys) {
+    const value = readString(payload[key])
+    if (value) return value
+  }
+  return fallback
+}
+
+function workspaceOperationFromEventType(type: string) {
+  if (/\b(created|submitted|uploaded|started)\b/.test(type)) return 'create'
+  if (/\b(deleted|removed|archived)\b/.test(type)) return 'delete'
+  return 'update'
+}
+
+function workspaceEntityForProjectedEvent(input: AppendProjectedEventInput, event: SessionEventRecord) {
+  const payload = input.payload || {}
+  if (input.type === 'artifact.created') {
+    return {
+      entityType: 'artifact',
+      entityId: eventPayloadId(payload, ['artifactId', 'cloudArtifactId', 'id'], input.sessionId),
+      operation: 'create',
+      projectionVersion: event.sequence,
+    }
+  }
+  return {
+    entityType: 'session',
+    entityId: input.sessionId,
+    operation: workspaceOperationFromEventType(input.type),
+    projectionVersion: event.sequence,
+  }
+}
+
+function taskRunFromPayload(
+  session: SessionRecord,
+  payload: Record<string, unknown>,
+  event: SessionEventRecord,
+): TaskRun {
+  const id = eventPayloadId(payload, ['taskRunId', 'id'], `${session.sessionId}:task:${event.sequence}`)
+  return {
+    id,
+    title: readString(payload.title, readString(payload.taskTitle, 'Task')),
+    agent: readNullableString(payload.agent),
+    status: normalizeTaskStatus(payload.status),
+    sourceSessionId: readNullableString(payload.sourceSessionId),
+    parentSessionId: readNullableString(payload.parentSessionId),
+    content: readString(payload.content),
+    transcript: [],
+    toolCalls: [],
+    compactions: [],
+    todos: [],
+    error: readNullableString(payload.error),
+    sessionCost: readNumber(payload.sessionCost),
+    sessionTokens: normalizeSessionTokens(payload.sessionTokens),
+    order: event.sequence,
+    startedAt: readNullableString(payload.startedAt),
+    finishedAt: readNullableString(payload.finishedAt),
+  }
+}
+
+function toolCallFromPayload(
+  session: SessionRecord,
+  payload: Record<string, unknown>,
+  event: SessionEventRecord,
+): ToolCall {
+  const id = eventPayloadId(payload, ['id', 'callId', 'toolCallId'], `${session.sessionId}:tool:${event.sequence}`)
+  return {
+    id,
+    name: readString(payload.name, readString(payload.tool, 'tool')),
+    input: asRecord(payload.input),
+    status: normalizeToolStatus(payload.status),
+    ...(payload.output !== undefined ? { output: payload.output } : {}),
+    ...(Array.isArray(payload.attachments) ? { attachments: payload.attachments as ToolCall['attachments'] } : {}),
+    agent: readNullableString(payload.agent),
+    sourceSessionId: readNullableString(payload.sourceSessionId),
+    order: event.sequence,
+  }
+}
+
+function withTaskRunToolCall(
+  view: CloudSessionProjectionView,
+  session: SessionRecord,
+  taskRunId: string,
+  toolCall: ToolCall,
+  payload: Record<string, unknown>,
+  event: SessionEventRecord,
+): CloudSessionProjectionView {
+  const existing = view.taskRuns.find((entry) => entry.id === taskRunId)
+  const taskRun = existing || {
+    ...taskRunFromPayload(session, {
+      ...payload,
+      id: taskRunId,
+      status: 'running',
+    }, event),
+    toolCalls: [],
+  }
+  const updated: TaskRun = {
+    ...taskRun,
+    status: taskRun.status === 'queued' ? 'running' : taskRun.status,
+    toolCalls: upsertById(taskRun.toolCalls, toolCall),
+  }
+  return {
+    ...view,
+    taskRuns: upsertById(view.taskRuns, updated),
+  }
+}
+
+function pendingApprovalFromPayload(
+  session: SessionRecord,
+  payload: Record<string, unknown>,
+  event: SessionEventRecord,
+): PendingApproval {
+  const id = eventPayloadId(payload, ['permissionId', 'id', 'requestId', 'requestID'], `${session.sessionId}:permission:${event.sequence}`)
+  return {
+    id,
+    sessionId: readString(payload.sessionId, session.sessionId),
+    taskRunId: readNullableString(payload.taskRunId),
+    tool: readString(payload.tool, 'permission'),
+    input: asRecord(payload.input),
+    description: readString(payload.description, readString(payload.tool, 'Permission requested')),
+    order: event.sequence,
+  }
+}
+
+function pendingQuestionFromPayload(
+  session: SessionRecord,
+  payload: Record<string, unknown>,
+  event: SessionEventRecord,
+): PendingQuestion {
+  const id = eventPayloadId(payload, ['requestId', 'requestID', 'id'], `${session.sessionId}:question:${event.sequence}`)
+  const tool = asRecord(payload.tool)
+  return {
+    id,
+    sessionId: readString(payload.sessionId, session.sessionId),
+    sourceSessionId: readNullableString(payload.sourceSessionId),
+    questions: Array.isArray(payload.questions)
+      ? payload.questions.map(normalizeQuestionPrompt).filter((entry): entry is PendingQuestion['questions'][number] => Boolean(entry))
+      : [],
+    ...(Object.keys(tool).length > 0
+      ? {
+          tool: {
+            messageId: readString(tool.messageId, readString(tool.messageID)),
+            callId: readString(tool.callId, readString(tool.callID)),
+          },
+        }
+      : {}),
+  }
+}
+
+function costTokensFromPayload(payload: Record<string, unknown>): SessionTokens {
+  return normalizeSessionTokens(payload.tokens)
 }
 
 function reduceProjectedEvent(
@@ -252,6 +676,90 @@ function reduceProjectedEvent(
         content: readString(payload.content),
         createdAt: eventTime,
       })
+    case 'tool.call': {
+      const toolCall = toolCallFromPayload(session, payload, event)
+      const taskRunId = readNullableString(payload.taskRunId)
+      const next = {
+        ...current,
+        status: 'running' as const,
+        isGenerating: true,
+        lastError: null,
+        updatedAt: eventTime,
+      }
+      if (taskRunId) return withTaskRunToolCall(next, session, taskRunId, toolCall, payload, event)
+      return {
+        ...next,
+        toolCalls: upsertById(next.toolCalls, toolCall),
+      }
+    }
+    case 'task.run': {
+      const taskRun = taskRunFromPayload(session, payload, event)
+      return {
+        ...current,
+        taskRuns: upsertById(current.taskRuns, taskRun),
+        updatedAt: eventTime,
+      }
+    }
+    case 'permission.requested':
+      return {
+        ...current,
+        status: 'running',
+        isGenerating: false,
+        pendingApprovals: upsertById(current.pendingApprovals, pendingApprovalFromPayload(session, payload, event)),
+        updatedAt: eventTime,
+      }
+    case 'permission.resolved': {
+      const permissionId = eventPayloadId(payload, ['permissionId', 'id', 'requestId', 'requestID'], '')
+      return {
+        ...current,
+        pendingApprovals: permissionId ? removeById(current.pendingApprovals, permissionId) : current.pendingApprovals,
+        isGenerating: false,
+        updatedAt: eventTime,
+      }
+    }
+    case 'question.asked':
+      return {
+        ...current,
+        status: 'running',
+        isGenerating: false,
+        pendingQuestions: upsertById(current.pendingQuestions, pendingQuestionFromPayload(session, payload, event)),
+        updatedAt: eventTime,
+      }
+    case 'question.resolved': {
+      const questionId = eventPayloadId(payload, ['requestId', 'requestID', 'id'], '')
+      return {
+        ...current,
+        pendingQuestions: questionId ? removeById(current.pendingQuestions, questionId) : current.pendingQuestions,
+        isGenerating: false,
+        updatedAt: eventTime,
+      }
+    }
+    case 'todos.updated':
+      return {
+        ...current,
+        todos: normalizeTodos(payload.todos),
+        updatedAt: eventTime,
+      }
+    case 'cost.updated': {
+      const tokens = costTokensFromPayload(payload)
+      const cost = readNumber(payload.cost)
+      const lastInputTokens = tokens.input > 0 ? tokens.input : current.lastInputTokens
+      return {
+        ...current,
+        sessionCost: current.sessionCost + cost,
+        sessionTokens: addSessionTokens(current.sessionTokens, tokens),
+        lastInputTokens,
+        updatedAt: eventTime,
+      }
+    }
+    case 'artifact.created': {
+      const artifact = normalizeSessionArtifact(payload, event.sequence)
+      return {
+        ...current,
+        artifacts: artifact ? upsertById(current.artifacts, artifact) : current.artifacts,
+        updatedAt: eventTime,
+      }
+    }
     case 'session.aborted':
       return {
         ...current,
@@ -280,14 +788,22 @@ function reduceProjectedEvent(
         updatedAt: eventTime,
       }
     }
-    case 'runtime.error':
+    case 'runtime.error': {
+      const message = readString(payload.message, 'Runtime command failed.')
       return {
         ...current,
         status: 'errored',
         isGenerating: false,
-        lastError: readString(payload.message, 'Runtime command failed.'),
+        lastError: message,
+        errors: upsertById(current.errors, {
+          id: eventPayloadId(payload, ['id', 'commandId'], `${session.sessionId}:error:${event.sequence}`),
+          sessionId: session.sessionId,
+          message,
+          order: event.sequence,
+        }),
         updatedAt: eventTime,
       }
+    }
     default:
       return {
         ...current,
@@ -349,6 +865,7 @@ export class CloudSessionService {
   private readonly runtime: CloudRuntimeAdapter
   private readonly policy: CloudRuntimePolicy
   private readonly events: CloudSessionEventBus
+  private readonly workspaceEvents: CloudWorkspaceEventBus
   private readonly ids: { randomUUID: () => string }
 
   constructor(
@@ -357,16 +874,22 @@ export class CloudSessionService {
     policy: CloudRuntimePolicy,
     events = new CloudSessionEventBus(),
     ids: { randomUUID: () => string } = { randomUUID },
+    workspaceEvents = new CloudWorkspaceEventBus(),
   ) {
     this.store = store
     this.runtime = runtime
     this.policy = policy
     this.events = events
+    this.workspaceEvents = workspaceEvents
     this.ids = ids
   }
 
   get eventBus() {
     return this.events
+  }
+
+  get workspaceEventBus() {
+    return this.workspaceEvents
   }
 
   async ensurePrincipal(principal: CloudPrincipal) {
@@ -411,6 +934,11 @@ export class CloudSessionService {
   async listEvents(principal: CloudPrincipal, sessionId: string, afterSequence = 0): Promise<SessionEventRecord[]> {
     await this.getSessionView(principal, sessionId)
     return this.store.listSessionEvents(principal.tenantId, sessionId, afterSequence)
+  }
+
+  async listWorkspaceEvents(principal: CloudPrincipal, afterSequence = 0) {
+    await this.ensurePrincipal(principal)
+    return this.store.listWorkspaceEvents(principal.tenantId, principal.userId, afterSequence)
   }
 
   async listWorkerHeartbeats() {
@@ -1036,6 +1564,19 @@ export class CloudSessionService {
       createdAt: input.createdAt,
     })
     const session = await this.requireSessionRecord(input.tenantId, input.sessionId)
+    const workspaceEntity = workspaceEntityForProjectedEvent(input, event)
+    const workspaceEvent = await this.store.appendWorkspaceEvent({
+      tenantId: input.tenantId,
+      userId: session.userId,
+      sessionId: input.sessionId,
+      eventId: event.eventId.startsWith(`${input.sessionId}:`)
+        ? event.eventId
+        : `${input.sessionId}:${event.eventId}`,
+      ...workspaceEntity,
+      type: input.type,
+      payload: input.payload || {},
+      createdAt: new Date(event.createdAt),
+    })
     const currentProjection = await this.store.getSessionProjection(input.tenantId, input.sessionId)
     const currentView = normalizeProjectionView(currentProjection?.view, session)
     const nextView = reduceProjectedEvent(session, currentView, event)
@@ -1048,6 +1589,7 @@ export class CloudSessionService {
       updatedAt: new Date(event.createdAt),
     })
     this.events.publish(event)
+    this.workspaceEvents.publish(workspaceEvent)
     return event
   }
 

--- a/apps/desktop/src/main/cloud/session-view-contract.ts
+++ b/apps/desktop/src/main/cloud/session-view-contract.ts
@@ -1,0 +1,200 @@
+import type {
+  Message,
+  PendingApproval,
+  PendingQuestion,
+  SessionArtifact,
+  SessionError,
+  SessionTokens,
+  SessionView,
+  TaskRun,
+  TodoItem,
+  ToolCall,
+} from '@open-cowork/shared'
+import type {
+  CloudSessionMessage,
+  CloudSessionProjectionView,
+  CloudSessionView,
+} from './session-service.ts'
+
+const EMPTY_TOKENS: SessionTokens = {
+  input: 0,
+  output: 0,
+  reasoning: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+}
+
+function isCloudSessionMessage(value: unknown): value is CloudSessionMessage {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<CloudSessionMessage>
+  return typeof record.id === 'string'
+    && (record.role === 'user' || record.role === 'assistant' || record.role === 'system')
+    && typeof record.content === 'string'
+}
+
+function isToolCall(value: unknown): value is ToolCall {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<ToolCall>
+  return typeof record.id === 'string'
+    && typeof record.name === 'string'
+    && (record.status === 'running' || record.status === 'complete' || record.status === 'error')
+}
+
+function isTaskRun(value: unknown): value is TaskRun {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<TaskRun>
+  return typeof record.id === 'string'
+    && typeof record.title === 'string'
+    && (record.status === 'queued' || record.status === 'running' || record.status === 'complete' || record.status === 'error')
+}
+
+function isPendingApproval(value: unknown): value is PendingApproval {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<PendingApproval>
+  return typeof record.id === 'string'
+    && typeof record.sessionId === 'string'
+    && typeof record.tool === 'string'
+}
+
+function isPendingQuestion(value: unknown): value is PendingQuestion {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<PendingQuestion>
+  return typeof record.id === 'string'
+    && typeof record.sessionId === 'string'
+    && Array.isArray(record.questions)
+}
+
+function isTodoItem(value: unknown): value is TodoItem {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<TodoItem>
+  return typeof record.content === 'string'
+}
+
+function isSessionError(value: unknown): value is SessionError {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<SessionError>
+  return typeof record.id === 'string' && typeof record.message === 'string'
+}
+
+function isSessionArtifact(value: unknown): value is SessionArtifact {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<SessionArtifact>
+  return typeof record.id === 'string'
+    && typeof record.filePath === 'string'
+    && typeof record.filename === 'string'
+}
+
+function readSessionTokens(value: unknown): SessionTokens {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { ...EMPTY_TOKENS }
+  const record = value as Partial<SessionTokens>
+  return {
+    input: typeof record.input === 'number' ? record.input : 0,
+    output: typeof record.output === 'number' ? record.output : 0,
+    reasoning: typeof record.reasoning === 'number' ? record.reasoning : 0,
+    cacheRead: typeof record.cacheRead === 'number' ? record.cacheRead : 0,
+    cacheWrite: typeof record.cacheWrite === 'number' ? record.cacheWrite : 0,
+  }
+}
+
+export function readCloudSessionProjection(view: CloudSessionView): CloudSessionProjectionView | null {
+  const raw = view.projection?.view
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const record = raw as Partial<CloudSessionProjectionView>
+  if (typeof record.sessionId !== 'string') return null
+  if (!Array.isArray(record.messages)) return null
+  return {
+    sessionId: record.sessionId,
+    title: typeof record.title === 'string' && record.title.trim() ? record.title : view.session.title || 'New session',
+    status: record.status === 'running' || record.status === 'closed' || record.status === 'errored' ? record.status : 'idle',
+    profileName: typeof record.profileName === 'string' && record.profileName ? record.profileName : view.session.profileName,
+    isGenerating: Boolean(record.isGenerating),
+    messages: record.messages.filter(isCloudSessionMessage),
+    toolCalls: Array.isArray(record.toolCalls) ? record.toolCalls.filter(isToolCall) : [],
+    taskRuns: Array.isArray(record.taskRuns) ? record.taskRuns.filter(isTaskRun) : [],
+    pendingApprovals: Array.isArray(record.pendingApprovals) ? record.pendingApprovals.filter(isPendingApproval) : [],
+    pendingQuestions: Array.isArray(record.pendingQuestions) ? record.pendingQuestions.filter(isPendingQuestion) : [],
+    artifacts: Array.isArray(record.artifacts) ? record.artifacts.filter(isSessionArtifact) : [],
+    todos: Array.isArray(record.todos) ? record.todos.filter(isTodoItem) : [],
+    errors: Array.isArray(record.errors) ? record.errors.filter(isSessionError) : [],
+    sessionCost: typeof record.sessionCost === 'number' ? record.sessionCost : 0,
+    sessionTokens: readSessionTokens(record.sessionTokens),
+    lastInputTokens: typeof record.lastInputTokens === 'number' ? record.lastInputTokens : 0,
+    lastError: typeof record.lastError === 'string' && record.lastError ? record.lastError : null,
+    updatedAt: typeof record.updatedAt === 'string' && record.updatedAt ? record.updatedAt : view.session.updatedAt,
+  }
+}
+
+function toMessage(message: CloudSessionMessage, order: number): Message | null {
+  if (message.role !== 'user' && message.role !== 'assistant') return null
+  return {
+    id: message.id,
+    role: message.role,
+    content: message.content,
+    timestamp: message.createdAt,
+    order,
+  }
+}
+
+export function emptySessionView(overrides: Partial<SessionView> = {}): SessionView {
+  return {
+    messages: [],
+    toolCalls: [],
+    taskRuns: [],
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    artifacts: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { ...EMPTY_TOKENS },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision: 0,
+    lastEventAt: 0,
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+    ...overrides,
+  }
+}
+
+export function cloudSessionViewToSessionView(view: CloudSessionView): SessionView {
+  const projection = readCloudSessionProjection(view)
+  if (!projection) return emptySessionView()
+  const messages = projection.messages
+    .map((message, index) => toMessage(message, index + 1))
+    .filter((message): message is Message => Boolean(message))
+  return emptySessionView({
+    messages,
+    toolCalls: projection.toolCalls,
+    taskRuns: projection.taskRuns,
+    pendingApprovals: projection.pendingApprovals,
+    pendingQuestions: projection.pendingQuestions,
+    artifacts: projection.artifacts,
+    todos: projection.todos,
+    errors: projection.errors.length > 0
+      ? projection.errors
+      : projection.lastError
+        ? [{
+            id: `${projection.sessionId}:cloud-error`,
+            sessionId: projection.sessionId,
+            message: projection.lastError,
+            order: messages.length + 1,
+          }]
+        : [],
+    sessionCost: projection.sessionCost,
+    sessionTokens: projection.sessionTokens,
+    lastInputTokens: projection.lastInputTokens,
+    revision: view.projection?.sequence || 0,
+    lastEventAt: view.projection?.sequence || 0,
+    isGenerating: projection.isGenerating && projection.pendingApprovals.length === 0 && projection.pendingQuestions.length === 0,
+    isAwaitingPermission: projection.pendingApprovals.length > 0,
+    isAwaitingQuestion: projection.pendingQuestions.length > 0,
+  })
+}

--- a/apps/desktop/src/main/cloud/transport-adapter.ts
+++ b/apps/desktop/src/main/cloud/transport-adapter.ts
@@ -1,5 +1,29 @@
 import type { SessionCommandRecord, SessionRecord } from './control-plane-store.ts'
 import type { CloudSessionView } from './session-service.ts'
+import {
+  cloudArtifactFilePath,
+  cloudArtifactIdFromFilePath,
+} from '@open-cowork/shared'
+import type {
+  CapabilitySkill,
+  CapabilitySkillBundle,
+  CapabilityTool,
+  WorkflowDetail,
+  WorkflowListPayload,
+  WorkflowRun,
+  WorkflowTriggerType,
+  SessionArtifact,
+  SessionArtifactAttachment,
+  SessionArtifactUploadRequest,
+  ThreadFacetSummary,
+  ThreadListItem,
+  ThreadSearchQuery,
+  ThreadSearchResult,
+  ThreadSmartFilter,
+  ThreadSmartFilterInput,
+  ThreadTag,
+  ThreadTagInput,
+} from '@open-cowork/shared'
 
 export type CloudRuntimeStatus = {
   role: string
@@ -31,11 +55,13 @@ export type CloudTransportFetch = (
     headers?: Record<string, string>
     body?: string
     credentials?: 'include'
+    signal?: AbortSignal
   },
 ) => Promise<{
   ok: boolean
   status: number
   text(): Promise<string>
+  body?: ReadableStream<Uint8Array> | null
 }>
 
 export type CloudTransportEventSource = new (
@@ -66,9 +92,23 @@ export type CloudTransportSessionEvent = {
   sessionId?: string
   eventId: string
   sequence: number
+  entityType?: string
+  entityId?: string
+  operation?: string
+  projectionVersion?: number
   type: string
   payload: Record<string, unknown>
   createdAt?: string
+}
+
+export type CloudTransportWorkspaceEvent = CloudTransportSessionEvent
+
+export type CloudTransportSettingMetadata = {
+  tenantId?: string
+  userId?: string | null
+  key: string
+  value: Record<string, unknown>
+  updatedAt: string
 }
 
 export type CloudTransportAdapter = {
@@ -91,7 +131,42 @@ export type CloudTransportAdapter = {
     command: SessionCommandRecord
     processed: number
   }>
+  listWorkflows?(): Promise<WorkflowListPayload>
+  getWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  runWorkflow?(workflowId: string, input?: { triggerType?: WorkflowTriggerType, triggerPayload?: Record<string, unknown> | null }): Promise<WorkflowRun | null>
+  pauseWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  resumeWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  archiveWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
+  searchThreads?(query?: ThreadSearchQuery): Promise<ThreadSearchResult>
+  threadFacets?(query?: ThreadSearchQuery): Promise<ThreadFacetSummary>
+  listThreadTags?(): Promise<ThreadTag[]>
+  createThreadTag?(input: ThreadTagInput): Promise<ThreadTag>
+  updateThreadTag?(tagId: string, input: ThreadTagInput): Promise<ThreadTag | null>
+  deleteThreadTag?(tagId: string): Promise<boolean>
+  applyThreadTags?(sessionIds: string[], tagIds: string[]): Promise<boolean>
+  removeThreadTags?(sessionIds: string[], tagIds: string[]): Promise<boolean>
+  listThreadSmartFilters?(): Promise<ThreadSmartFilter[]>
+  createThreadSmartFilter?(input: ThreadSmartFilterInput): Promise<ThreadSmartFilter>
+  updateThreadSmartFilter?(filterId: string, input: ThreadSmartFilterInput): Promise<ThreadSmartFilter | null>
+  deleteThreadSmartFilter?(filterId: string): Promise<boolean>
+  listArtifacts?(sessionId: string): Promise<SessionArtifact[]>
+  uploadArtifact?(sessionId: string, input: Omit<SessionArtifactUploadRequest, 'sessionId' | 'workspaceId'>): Promise<SessionArtifact>
+  readArtifactAttachment?(sessionId: string, filePathOrArtifactId: string): Promise<SessionArtifactAttachment>
+  listCapabilityTools?(): Promise<CapabilityTool[]>
+  getCapabilityTool?(toolId: string): Promise<CapabilityTool | null>
+  listCapabilitySkills?(): Promise<CapabilitySkill[]>
+  getCapabilitySkillBundle?(skillName: string): Promise<CapabilitySkillBundle | null>
+  readCapabilitySkillBundleFile?(skillName: string, filePath: string): Promise<string | null>
+  listSettings?(): Promise<CloudTransportSettingMetadata[]>
+  getSetting?(key: string): Promise<CloudTransportSettingMetadata | null>
+  setSetting?(key: string, value: Record<string, unknown>): Promise<CloudTransportSettingMetadata>
+  workspaceEventsUrl(afterSequence?: number): string
   sessionEventsUrl(sessionId: string, afterSequence?: number): string
+  subscribeWorkspaceEvents(input: {
+    afterSequence?: number
+    onEvent: (event: CloudTransportWorkspaceEvent) => void
+    onError?: (error: unknown) => void
+  }): CloudTransportSubscription
   subscribeSessionEvents(
     sessionId: string,
     input: {
@@ -114,9 +189,305 @@ function encodePath(value: string) {
   return encodeURIComponent(value)
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function readString(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value : fallback
+}
+
+function readNullableString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function readNumber(value: unknown, fallback = 0) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function normalizeThreadTag(value: unknown): ThreadTag {
+  const record = asRecord(value)
+  const id = readString(record.id, readString(record.tagId))
+  return {
+    id,
+    name: readString(record.name, 'Tag'),
+    color: readString(record.color, '#64748b'),
+    createdAt: readString(record.createdAt, new Date(0).toISOString()),
+    updatedAt: readString(record.updatedAt, new Date(0).toISOString()),
+  }
+}
+
+function normalizeThreadSmartFilter(value: unknown): ThreadSmartFilter {
+  const record = asRecord(value)
+  return {
+    id: readString(record.id, readString(record.filterId)),
+    name: readString(record.name, 'Smart filter'),
+    query: asRecord(record.query) as ThreadSearchQuery,
+    createdAt: readString(record.createdAt, new Date(0).toISOString()),
+    updatedAt: readString(record.updatedAt, new Date(0).toISOString()),
+  }
+}
+
+function normalizeThreadStatus(value: unknown): ThreadListItem['status'] {
+  if (value === 'running') return 'running'
+  if (value === 'errored' || value === 'error') return 'error'
+  return 'idle'
+}
+
+function normalizeThreadListItem(value: unknown): ThreadListItem {
+  const record = asRecord(value)
+  const tags = Array.isArray(record.tags) ? record.tags.map(normalizeThreadTag) : []
+  return {
+    sessionId: readString(record.sessionId),
+    title: readString(record.title, 'New session'),
+    directory: null,
+    projectLabel: null,
+    providerId: null,
+    modelId: null,
+    status: normalizeThreadStatus(record.status),
+    createdAt: readString(record.createdAt, new Date(0).toISOString()),
+    updatedAt: readString(record.updatedAt, new Date(0).toISOString()),
+    parentSessionId: null,
+    workflowId: null,
+    runId: null,
+    revertedMessageId: null,
+    tags,
+    actualAgents: readNullableString(record.profileName) ? [{ name: readString(record.profileName), count: 1 }] : [],
+    actualTools: [],
+    suggestions: [],
+    usage: {
+      messages: 0,
+      toolCalls: 0,
+      taskRuns: 0,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    },
+    changeSummary: null,
+  }
+}
+
+function normalizeThreadSearchResult(value: unknown): ThreadSearchResult {
+  const record = asRecord(value)
+  const threads = Array.isArray(record.threads) ? record.threads.map(normalizeThreadListItem) : []
+  return {
+    threads,
+    nextCursor: readNullableString(record.nextCursor),
+    totalEstimate: readNumber(record.totalEstimate, threads.length),
+  }
+}
+
+function normalizeCloudArtifact(value: unknown, fallbackOrder = 0): SessionArtifact {
+  const record = asRecord(value)
+  const artifactId = readString(record.artifactId, readString(record.cloudArtifactId, readString(record.id)))
+  const filename = readString(record.filename, 'artifact')
+  return {
+    id: artifactId,
+    toolId: readString(record.toolId, 'cloud-artifact'),
+    toolName: readString(record.toolName, 'cloud.artifact'),
+    filePath: readString(record.filePath, cloudArtifactFilePath(artifactId, filename)),
+    filename,
+    order: readNumber(record.order, fallbackOrder),
+    source: 'cloud',
+    cloudArtifactId: artifactId,
+    taskRunId: readNullableString(record.taskRunId),
+    mime: readNullableString(record.mime) || readNullableString(record.contentType) || undefined,
+    size: readNumber(record.size),
+    createdAt: readNullableString(record.createdAt) || undefined,
+  }
+}
+
+function normalizeCloudArtifactAttachment(value: unknown): SessionArtifactAttachment {
+  const record = asRecord(value)
+  const artifact = asRecord(record.artifact || record)
+  const mime = readNullableString(artifact.contentType) || readNullableString(artifact.mime) || 'application/octet-stream'
+  const dataBase64 = readString(artifact.dataBase64)
+  return {
+    mime,
+    url: `data:${mime};base64,${dataBase64}`,
+    filename: readString(artifact.filename, 'artifact'),
+  }
+}
+
+function normalizeSettingMetadata(value: unknown): CloudTransportSettingMetadata | null {
+  const record = asRecord(value)
+  const key = readString(record.key)
+  if (!key) return null
+  return {
+    tenantId: readNullableString(record.tenantId) || undefined,
+    userId: readNullableString(record.userId),
+    key,
+    value: asRecord(record.value),
+    updatedAt: readString(record.updatedAt, new Date(0).toISOString()),
+  }
+}
+
 function eventUrl(baseUrl: string, sessionId: string, afterSequence = 0) {
   const path = `${baseUrl}/api/sessions/${encodePath(sessionId)}/events`
   return afterSequence > 0 ? `${path}?after=${afterSequence}` : path
+}
+
+function workspaceEventUrl(baseUrl: string, afterSequence = 0) {
+  const path = `${baseUrl}/api/events`
+  return afterSequence > 0 ? `${path}?after=${afterSequence}` : path
+}
+
+const CLOUD_EVENT_TYPES = [
+  'session.created',
+  'prompt.submitted',
+  'assistant.message',
+  'tool.call',
+  'task.run',
+  'permission.requested',
+  'permission.resolved',
+  'question.asked',
+  'question.resolved',
+  'todos.updated',
+  'cost.updated',
+  'artifact.created',
+  'session.status',
+  'session.idle',
+  'session.aborted',
+  'runtime.error',
+  'snapshot.required',
+] as const
+
+function subscribeEventSource(
+  EventSourceImpl: CloudTransportEventSource,
+  url: string,
+  input: {
+    credentials?: 'include'
+    onEvent: (event: CloudTransportWorkspaceEvent) => void
+    onError?: (error: unknown) => void
+  },
+) {
+  const source = new EventSourceImpl(url, {
+    withCredentials: input.credentials === 'include',
+  })
+  const onEvent = (event: { data: string }) => {
+    const parsed = JSON.parse(event.data) as CloudTransportWorkspaceEvent
+    input.onEvent(parsed)
+  }
+  source.onmessage = onEvent
+  for (const type of CLOUD_EVENT_TYPES) source.addEventListener(type, onEvent)
+  source.onerror = (error) => input.onError?.(error)
+  return {
+    close() {
+      source.close()
+    },
+  }
+}
+
+function subscribeFetchSse(
+  fetcher: CloudTransportFetch,
+  url: string,
+  input: {
+    headers?: Record<string, string>
+    credentials?: 'include'
+    onEvent: (event: CloudTransportWorkspaceEvent) => void
+    onError?: (error: unknown) => void
+  },
+) {
+  const controller = new AbortController()
+  let closed = false
+
+  const dispatch = (dataLines: string[]) => {
+    if (dataLines.length === 0) return
+    const parsed = JSON.parse(dataLines.join('\n')) as CloudTransportWorkspaceEvent
+    input.onEvent(parsed)
+  }
+
+  void (async () => {
+    const response = await fetcher(url, {
+      method: 'GET',
+      headers: {
+        ...(input.headers || {}),
+        accept: 'text/event-stream',
+      },
+      credentials: input.credentials,
+      signal: controller.signal,
+    })
+    if (!response.ok) {
+      throw new Error(`Cloud transport SSE subscription failed with HTTP ${response.status}: ${url}`)
+    }
+    if (!response.body) {
+      throw new Error('Cloud transport SSE response did not include a readable stream.')
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffered = ''
+    let dataLines: string[] = []
+
+    const processLine = (rawLine: string) => {
+      const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+      if (line === '') {
+        dispatch(dataLines)
+        dataLines = []
+        return
+      }
+      if (line.startsWith(':')) return
+      const delimiter = line.indexOf(':')
+      const field = delimiter === -1 ? line : line.slice(0, delimiter)
+      const value = delimiter === -1
+        ? ''
+        : line.slice(delimiter + 1).replace(/^ /, '')
+      if (field === 'data') dataLines.push(value)
+    }
+
+    try {
+      while (!closed) {
+        const chunk = await reader.read()
+        if (chunk.done) break
+        buffered += decoder.decode(chunk.value, { stream: true })
+        let newlineIndex = buffered.indexOf('\n')
+        while (newlineIndex >= 0) {
+          processLine(buffered.slice(0, newlineIndex))
+          buffered = buffered.slice(newlineIndex + 1)
+          newlineIndex = buffered.indexOf('\n')
+        }
+      }
+      buffered += decoder.decode()
+      if (buffered) processLine(buffered)
+      dispatch(dataLines)
+    } finally {
+      reader.releaseLock()
+    }
+  })().catch((error) => {
+    if (!closed) input.onError?.(error)
+  })
+
+  return {
+    close() {
+      closed = true
+      controller.abort()
+    },
+  }
+}
+
+function queryString(input: Record<string, unknown>) {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (typeof entry === 'string' && entry) params.append(key, entry)
+      }
+    } else if (typeof value === 'string' && value) {
+      params.set(key, value)
+    } else if (typeof value === 'number' && Number.isFinite(value)) {
+      params.set(key, String(value))
+    }
+  }
+  const serialized = params.toString()
+  return serialized ? `?${serialized}` : ''
 }
 
 async function parseJson<T>(response: Awaited<ReturnType<CloudTransportFetch>>, url: string): Promise<T> {
@@ -204,30 +575,230 @@ export function createHttpSseCloudTransportAdapter(
         body: input,
       })
     },
+    listWorkflows() {
+      return request<WorkflowListPayload>('/api/workflows')
+    },
+    async getWorkflow(workflowId) {
+      return (await request<{ workflow: WorkflowDetail | null }>(`/api/workflows/${encodePath(workflowId)}`)).workflow
+    },
+    async runWorkflow(workflowId, input = {}) {
+      return (await request<{ run: WorkflowRun | null }>(`/api/workflows/${encodePath(workflowId)}/run`, {
+        method: 'POST',
+        body: input,
+      })).run
+    },
+    async pauseWorkflow(workflowId) {
+      return (await request<{ workflow: WorkflowDetail | null }>(`/api/workflows/${encodePath(workflowId)}/pause`, {
+        method: 'POST',
+        body: {},
+      })).workflow
+    },
+    async resumeWorkflow(workflowId) {
+      return (await request<{ workflow: WorkflowDetail | null }>(`/api/workflows/${encodePath(workflowId)}/resume`, {
+        method: 'POST',
+        body: {},
+      })).workflow
+    },
+    async archiveWorkflow(workflowId) {
+      return (await request<{ workflow: WorkflowDetail | null }>(`/api/workflows/${encodePath(workflowId)}/archive`, {
+        method: 'POST',
+        body: {},
+      })).workflow
+    },
+    async searchThreads(query = {}) {
+      const result = await request<unknown>(`/api/threads${queryString({
+        limit: query.limit,
+        tagId: query.tagIds || [],
+      })}`)
+      return normalizeThreadSearchResult(result)
+    },
+    async threadFacets(query = {}) {
+      const result = normalizeThreadSearchResult(await request<unknown>(`/api/threads${queryString({
+        limit: query.limit,
+        tagId: query.tagIds || [],
+      })}`))
+      const tags = (await request<{ tags: unknown[] }>('/api/threads/tags')).tags.map(normalizeThreadTag)
+      const tagCounts = new Map<string, { label: string, color?: string, count: number }>()
+      for (const thread of result.threads) {
+        for (const tag of thread.tags || []) {
+          const existing = tagCounts.get(tag.id) || { label: tag.name, color: tag.color, count: 0 }
+          existing.count += 1
+          tagCounts.set(tag.id, existing)
+        }
+      }
+      return {
+        projects: [],
+        providers: [],
+        models: [],
+        agents: [],
+        tools: [],
+        mcps: [],
+        statuses: [],
+        tags: tags.map((tag) => ({
+          value: tag.id,
+          label: tag.name,
+          color: tag.color,
+          count: tagCounts.get(tag.id)?.count || 0,
+        })),
+      }
+    },
+    async listThreadTags() {
+      return (await request<{ tags: unknown[] }>('/api/threads/tags')).tags.map(normalizeThreadTag)
+    },
+    async createThreadTag(input) {
+      return normalizeThreadTag((await request<{ tag: unknown }>('/api/threads/tags', {
+        method: 'POST',
+        body: input,
+      })).tag)
+    },
+    async updateThreadTag(tagId, input) {
+      const tag = (await request<{ tag: unknown | null }>(`/api/threads/tags/${encodePath(tagId)}`, {
+        method: 'PATCH',
+        body: input,
+      })).tag
+      return tag ? normalizeThreadTag(tag) : null
+    },
+    async deleteThreadTag(tagId) {
+      return (await request<{ deleted: boolean }>(`/api/threads/tags/${encodePath(tagId)}`, {
+        method: 'DELETE',
+      })).deleted
+    },
+    async applyThreadTags(sessionIds, tagIds) {
+      for (const tagId of tagIds) {
+        await request<{ ok: true }>(`/api/threads/tags/${encodePath(tagId)}/apply`, {
+          method: 'POST',
+          body: { sessionIds },
+        })
+      }
+      return true
+    },
+    async removeThreadTags(sessionIds, tagIds) {
+      for (const tagId of tagIds) {
+        await request<{ ok: true }>(`/api/threads/tags/${encodePath(tagId)}/remove`, {
+          method: 'POST',
+          body: { sessionIds },
+        })
+      }
+      return true
+    },
+    async listThreadSmartFilters() {
+      return (await request<{ filters: unknown[] }>('/api/threads/smart-filters')).filters.map(normalizeThreadSmartFilter)
+    },
+    async createThreadSmartFilter(input) {
+      return normalizeThreadSmartFilter((await request<{ filter: unknown }>('/api/threads/smart-filters', {
+        method: 'POST',
+        body: input,
+      })).filter)
+    },
+    async updateThreadSmartFilter(filterId, input) {
+      const filter = (await request<{ filter: unknown | null }>(`/api/threads/smart-filters/${encodePath(filterId)}`, {
+        method: 'PATCH',
+        body: input,
+      })).filter
+      return filter ? normalizeThreadSmartFilter(filter) : null
+    },
+    async deleteThreadSmartFilter(filterId) {
+      return (await request<{ deleted: boolean }>(`/api/threads/smart-filters/${encodePath(filterId)}`, {
+        method: 'DELETE',
+      })).deleted
+    },
+    async listArtifacts(sessionId) {
+      return (await request<{ artifacts: unknown[] }>(`/api/sessions/${encodePath(sessionId)}/artifacts`))
+        .artifacts
+        .map((artifact, index) => normalizeCloudArtifact(artifact, index))
+    },
+    async uploadArtifact(sessionId, input) {
+      return normalizeCloudArtifact((await request<{ artifact: unknown }>(`/api/sessions/${encodePath(sessionId)}/artifacts`, {
+        method: 'POST',
+        body: {
+          filename: input.filename,
+          contentType: input.contentType || null,
+          dataBase64: input.dataBase64,
+        },
+      })).artifact)
+    },
+    async readArtifactAttachment(sessionId, filePathOrArtifactId) {
+      const artifactId = cloudArtifactIdFromFilePath(filePathOrArtifactId) || filePathOrArtifactId.trim()
+      if (!artifactId) throw new Error('Cloud artifact id is required.')
+      return normalizeCloudArtifactAttachment(await request<{ artifact: unknown }>(
+        `/api/sessions/${encodePath(sessionId)}/artifacts/${encodePath(artifactId)}`,
+      ))
+    },
+    async listCapabilityTools() {
+      return (await request<{ tools: CapabilityTool[] }>('/api/capabilities/tools')).tools
+    },
+    async getCapabilityTool(toolId) {
+      const response = await request<{ tool: CapabilityTool }>(`/api/capabilities/tools/${encodePath(toolId)}`)
+      return response.tool || null
+    },
+    async listCapabilitySkills() {
+      return (await request<{ skills: CapabilitySkill[] }>('/api/capabilities/skills')).skills
+    },
+    async getCapabilitySkillBundle(skillName) {
+      const response = await request<{ bundle: CapabilitySkillBundle | null }>(`/api/capabilities/skills/${encodePath(skillName)}/bundle`)
+      return response.bundle || null
+    },
+    async readCapabilitySkillBundleFile(skillName, filePath) {
+      const bundle = (await request<{ bundle: CapabilitySkillBundle | null }>(`/api/capabilities/skills/${encodePath(skillName)}/bundle`)).bundle
+      const file = bundle?.files.find((entry) => entry.path === filePath) as { content?: unknown } | undefined
+      return typeof file?.content === 'string' ? file.content : null
+    },
+    async listSettings() {
+      return (await request<{ settings: unknown[] }>('/api/settings')).settings
+        .map(normalizeSettingMetadata)
+        .filter((setting): setting is CloudTransportSettingMetadata => Boolean(setting))
+    },
+    async getSetting(key) {
+      const setting = normalizeSettingMetadata((await request<{ setting: unknown | null }>(`/api/settings/${encodePath(key)}`)).setting)
+      return setting
+    },
+    async setSetting(key, value) {
+      const setting = normalizeSettingMetadata((await request<{ setting: unknown }>(`/api/settings/${encodePath(key)}`, {
+        method: 'PUT',
+        body: { value },
+      })).setting)
+      if (!setting) throw new Error('Cloud setting response was invalid.')
+      return setting
+    },
+    workspaceEventsUrl(afterSequence = 0) {
+      return workspaceEventUrl(baseUrl, afterSequence)
+    },
     sessionEventsUrl(sessionId, afterSequence = 0) {
       return eventUrl(baseUrl, sessionId, afterSequence)
     },
-    subscribeSessionEvents(sessionId, input) {
+    subscribeWorkspaceEvents(input) {
+      if (Object.keys(headers).length > 0) {
+        return subscribeFetchSse(fetcher, workspaceEventUrl(baseUrl, input.afterSequence), {
+          headers,
+          credentials: options.credentials,
+          onEvent: input.onEvent,
+          onError: input.onError,
+        })
+      }
       const EventSourceImpl = options.eventSource || (globalThis as unknown as { EventSource?: CloudTransportEventSource }).EventSource
       if (!EventSourceImpl) throw new Error('EventSource is not available for cloud transport subscriptions.')
-      const source = new EventSourceImpl(eventUrl(baseUrl, sessionId, input.afterSequence), {
-        withCredentials: options.credentials === 'include',
+      return subscribeEventSource(EventSourceImpl, workspaceEventUrl(baseUrl, input.afterSequence), {
+        credentials: options.credentials,
+        onEvent: input.onEvent,
+        onError: input.onError,
       })
-      const onEvent = (event: { data: string }) => {
-        const parsed = JSON.parse(event.data) as CloudTransportSessionEvent
-        input.onEvent(parsed)
+    },
+    subscribeSessionEvents(sessionId, input) {
+      if (Object.keys(headers).length > 0) {
+        return subscribeFetchSse(fetcher, eventUrl(baseUrl, sessionId, input.afterSequence), {
+          headers,
+          credentials: options.credentials,
+          onEvent: input.onEvent,
+          onError: input.onError,
+        })
       }
-      source.onmessage = onEvent
-      source.addEventListener('session.created', onEvent)
-      source.addEventListener('prompt.submitted', onEvent)
-      source.addEventListener('assistant.message', onEvent)
-      source.addEventListener('runtime.error', onEvent)
-      source.onerror = (error) => input.onError?.(error)
-      return {
-        close() {
-          source.close()
-        },
-      }
+      const EventSourceImpl = options.eventSource || (globalThis as unknown as { EventSource?: CloudTransportEventSource }).EventSource
+      if (!EventSourceImpl) throw new Error('EventSource is not available for cloud transport subscriptions.')
+      return subscribeEventSource(EventSourceImpl, eventUrl(baseUrl, sessionId, input.afterSequence), {
+        credentials: options.credentials,
+        onEvent: input.onEvent,
+        onError: input.onError,
+      })
     },
   }
 }

--- a/apps/desktop/src/main/cloud/transport-adapter.ts
+++ b/apps/desktop/src/main/cloud/transport-adapter.ts
@@ -127,6 +127,10 @@ export type CloudTransportAdapter = {
     command: SessionCommandRecord
     processed: number
   }>
+  rejectQuestion(sessionId: string, input: { requestId: string }): Promise<{
+    command: SessionCommandRecord
+    processed: number
+  }>
   respondToPermission(sessionId: string, input: { permissionId: string, response: unknown }): Promise<{
     command: SessionCommandRecord
     processed: number
@@ -565,6 +569,12 @@ export function createHttpSseCloudTransportAdapter(
     },
     replyToQuestion(sessionId, input) {
       return request(`/api/sessions/${encodePath(sessionId)}/question-reply`, {
+        method: 'POST',
+        body: input,
+      })
+    },
+    rejectQuestion(sessionId, input) {
+      return request(`/api/sessions/${encodePath(sessionId)}/question-reject`, {
         method: 'POST',
         body: input,
       })

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -22,6 +22,7 @@ import {
 } from './config-layer-utils.ts'
 import type {
   CloudConfig,
+  CloudDesktopConfig,
   CloudFeatureConfig,
   CloudProfileConfig,
   CloudRole,
@@ -304,6 +305,35 @@ function normalizeCloudConfig(raw: CloudConfig | undefined): CloudConfig {
   }
 }
 
+function normalizeCloudDesktopConfig(raw: CloudDesktopConfig | undefined): CloudDesktopConfig {
+  const source = raw || DEFAULT_CONFIG.cloudDesktop
+  const cacheModes = new Set(['full', 'metadata-only', 'disabled'])
+  const fallbackModes = new Set(['metadata-only', 'disabled', 'fail-startup'])
+  return {
+    ...DEFAULT_CONFIG.cloudDesktop,
+    ...source,
+    enabled: typeof source.enabled === 'boolean' ? source.enabled : DEFAULT_CONFIG.cloudDesktop.enabled,
+    allowUserAddedConnections: typeof source.allowUserAddedConnections === 'boolean'
+      ? source.allowUserAddedConnections
+      : DEFAULT_CONFIG.cloudDesktop.allowUserAddedConnections,
+    preconfiguredConnections: Array.isArray(source.preconfiguredConnections)
+      ? source.preconfiguredConnections
+        .filter((connection) => connection && typeof connection.baseUrl === 'string' && connection.baseUrl.trim())
+        .map((connection) => ({
+          baseUrl: connection.baseUrl.trim(),
+          ...(typeof connection.label === 'string' && connection.label.trim() ? { label: connection.label.trim() } : {}),
+        }))
+      : DEFAULT_CONFIG.cloudDesktop.preconfiguredConnections,
+    requireManagedOrg: typeof source.requireManagedOrg === 'boolean'
+      ? source.requireManagedOrg
+      : DEFAULT_CONFIG.cloudDesktop.requireManagedOrg,
+    cacheMode: cacheModes.has(source.cacheMode) ? source.cacheMode : DEFAULT_CONFIG.cloudDesktop.cacheMode,
+    cacheEncryptionFallback: fallbackModes.has(source.cacheEncryptionFallback)
+      ? source.cacheEncryptionFallback
+      : DEFAULT_CONFIG.cloudDesktop.cacheEncryptionFallback,
+  }
+}
+
 function normalizeConfig(raw: OpenCoworkConfig): OpenCoworkConfig {
   return {
     ...raw,
@@ -362,6 +392,7 @@ function normalizeConfig(raw: OpenCoworkConfig): OpenCoworkConfig {
       ...(raw.compaction?.agent ? { agent: { ...raw.compaction.agent } } : {}),
     },
     cloud: normalizeCloudConfig(raw.cloud),
+    cloudDesktop: normalizeCloudDesktopConfig(raw.cloudDesktop),
   }
 }
 

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -262,6 +262,20 @@ export type CloudStorageConfig = {
   }
 }
 
+export type CloudDesktopConnectionConfig = {
+  baseUrl: string
+  label?: string
+}
+
+export type CloudDesktopConfig = {
+  enabled: boolean
+  allowUserAddedConnections: boolean
+  preconfiguredConnections: CloudDesktopConnectionConfig[]
+  requireManagedOrg: boolean
+  cacheMode: 'full' | 'metadata-only' | 'disabled'
+  cacheEncryptionFallback: 'metadata-only' | 'disabled' | 'fail-startup'
+}
+
 export type CloudConfig = {
   role: CloudRole
   profiles: Record<string, CloudProfileConfig>
@@ -335,6 +349,7 @@ export type OpenCoworkConfig = {
     }
   }
   cloud: CloudConfig
+  cloudDesktop: CloudDesktopConfig
   // Optional translation + locale overlay. Downstream forks set
   // `i18n.locale` to e.g. "de-DE" so Intl.NumberFormat / Intl.DateTimeFormat
   // produce locale-appropriate output, and `i18n.strings` to a
@@ -385,6 +400,15 @@ const DEFAULT_CLOUD_RUNTIME: CloudRuntimePolicyConfig = {
   allowHostProjectDirectories: false,
   allowedLocalMcpNames: [],
   allowedHostProjectDirectories: [],
+}
+
+const DEFAULT_CLOUD_DESKTOP: CloudDesktopConfig = {
+  enabled: true,
+  allowUserAddedConnections: true,
+  preconfiguredConnections: [],
+  requireManagedOrg: false,
+  cacheMode: 'full',
+  cacheEncryptionFallback: 'metadata-only',
 }
 
 export const DEFAULT_CONFIG: OpenCoworkConfig = {
@@ -480,4 +504,5 @@ export const DEFAULT_CONFIG: OpenCoworkConfig = {
       },
     },
   },
+  cloudDesktop: DEFAULT_CLOUD_DESKTOP,
 }

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -12,6 +12,7 @@ import {
   getRuntimeHomeDir,
 } from './runtime.ts'
 import { getEffectiveSettings } from './settings.ts'
+import { getAppConfig } from './config-loader.ts'
 import { log } from './logger.ts'
 import { getMcpStatus } from './events.ts'
 import { shortSessionId } from './log-sanitizer.ts'
@@ -31,6 +32,7 @@ import { registerWorkflowHandlers } from './ipc/workflow-handlers.ts'
 import { registerCustomContentHandlers } from './ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from './ipc/explorer-handlers.ts'
 import { registerThreadHandlers } from './ipc/thread-handlers.ts'
+import { registerWorkspaceHandlers } from './ipc/workspace-handlers.ts'
 import type { IpcHandlerContext } from './ipc/context.ts'
 import { objectArg, registerIpcInvoke } from './ipc/schema.ts'
 import { validateDestructiveConfirmationRequest } from './ipc/object-validators.ts'
@@ -49,6 +51,7 @@ import { createIpcRuntimeContext } from './ipc-runtime-context.ts'
 import { getThreadIndexService } from './thread-index/thread-index-service.ts'
 import { showNativeConfirmation, type NativeConfirmationOptions } from './native-confirmation.ts'
 import { sdkErrorMessage } from './sdk-error.ts'
+import { createWorkspaceGateway } from './workspace-gateway.ts'
 
 export { invalidateRuntimeToolCache } from './runtime-tool-cache.ts'
 
@@ -141,6 +144,9 @@ export function setupIpcHandlers(
 
 
   const destructiveConfirmations = createDestructiveConfirmationManager()
+  const workspaceGateway = createWorkspaceGateway({
+    cloudDesktop: getAppConfig().cloudDesktop,
+  })
   const capabilityToolMethodCache = new Map<string, { expiresAt: number; entries: CapabilityToolEntry[] }>()
   const approvedSkillImportDirectories = new Map<string, string>()
 
@@ -305,6 +311,7 @@ export function setupIpcHandlers(
 
   const context: IpcHandlerContext = {
     ipcMain: instrumentedIpcMain,
+    workspaceGateway,
     getMainWindow,
     normalizeDirectory,
     ensureSessionRecord,
@@ -343,6 +350,7 @@ export function setupIpcHandlers(
 
   getThreadIndexService().reconcileThreadIndexFromRegistry()
 
+  registerWorkspaceHandlers(context)
   registerAppHandlers(context)
   registerArtifactHandlers(context)
   registerWorkflowHandlers(context)

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -1,7 +1,7 @@
 import electron from 'electron'
 import type { IpcHandlerContext } from './context.ts'
-import { objectArg, registerIpcInvoke } from './schema.ts'
-import { validateChartSaveArtifactRequest, validateSettingsUpdate } from './object-validators.ts'
+import { objectArg, optionalObjectArg, registerIpcInvoke } from './schema.ts'
+import { validateChartSaveArtifactRequest, validateSettingsUpdate, validateWorkspaceOptions } from './object-validators.ts'
 import {
   ensureRuntimeAfterAuthLogin,
   MAX_CLIPBOARD_TEXT_LENGTH,
@@ -57,7 +57,10 @@ import { writeFileAtomic } from '../fs-atomic.ts'
 import type {
   ChartSaveArtifactRequest,
   DestructiveConfirmationRequest,
+  EffectiveAppSettings,
+  WorkspaceOptions,
 } from '@open-cowork/shared'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
 export {
   ensureRuntimeAfterAuthLogin,
@@ -67,6 +70,80 @@ export {
 
 async function loadAuthModule() {
   return import('../auth.ts')
+}
+
+const CLOUD_PORTABLE_SETTINGS_KEY = 'portable-settings'
+const CLOUD_PORTABLE_SETTING_KEYS = new Set<keyof CoworkSettings>([
+  'selectedProviderId',
+  'selectedModelId',
+  'selectedSmallModelId',
+  'workflowDesktopNotifications',
+  'workflowQuietHoursStart',
+  'workflowQuietHoursEnd',
+])
+const CLOUD_FORBIDDEN_SETTING_KEYS = new Set<string>([
+  'providerCredentials',
+  'integrationCredentials',
+  'integrationEnabled',
+  'bashPermission',
+  'fileWritePermission',
+  'enableBash',
+  'enableFileWrite',
+  'runtimeConfigSource',
+  'runtimeToolingBridgeEnabled',
+  'workflowLaunchAtLogin',
+  'workflowRunInBackground',
+])
+
+function pickPortableCloudSettings(updates: Partial<CoworkSettings>) {
+  const value: Record<string, unknown> = {}
+  for (const key of CLOUD_PORTABLE_SETTING_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(updates, key)) value[key] = updates[key]
+  }
+  return value
+}
+
+function assertCloudSettingsUpdateIsPortable(updates: Partial<CoworkSettings>) {
+  for (const key of CLOUD_FORBIDDEN_SETTING_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(updates, key)) {
+      throw new Error(`Cloud settings do not sync raw or local-only setting "${key}".`)
+    }
+  }
+}
+
+function buildCloudEffectiveSettings(base: EffectiveAppSettings, value: Record<string, unknown>): EffectiveAppSettings {
+  const selectedProviderId = typeof value.selectedProviderId === 'string' || value.selectedProviderId === null
+    ? value.selectedProviderId
+    : base.selectedProviderId
+  const selectedModelId = typeof value.selectedModelId === 'string' || value.selectedModelId === null
+    ? value.selectedModelId
+    : base.selectedModelId
+  const selectedSmallModelId = typeof value.selectedSmallModelId === 'string' || value.selectedSmallModelId === null
+    ? value.selectedSmallModelId
+    : base.selectedSmallModelId
+  return {
+    ...base,
+    selectedProviderId,
+    selectedModelId,
+    selectedSmallModelId,
+    providerCredentials: {},
+    integrationCredentials: {},
+    integrationEnabled: {},
+    runtimeConfigSource: 'app',
+    runtimeToolingBridgeEnabled: false,
+    workflowDesktopNotifications: typeof value.workflowDesktopNotifications === 'boolean'
+      ? value.workflowDesktopNotifications
+      : base.workflowDesktopNotifications,
+    workflowQuietHoursStart: typeof value.workflowQuietHoursStart === 'string' || value.workflowQuietHoursStart === null
+      ? value.workflowQuietHoursStart
+      : base.workflowQuietHoursStart,
+    workflowQuietHoursEnd: typeof value.workflowQuietHoursEnd === 'string' || value.workflowQuietHoursEnd === null
+      ? value.workflowQuietHoursEnd
+      : base.workflowQuietHoursEnd,
+    effectiveProviderId: selectedProviderId,
+    effectiveModel: selectedModelId,
+    effectiveSmallModel: selectedSmallModelId,
+  }
 }
 
 const electronShell = (electron as { shell?: typeof import('electron').shell }).shell
@@ -214,11 +291,15 @@ export function registerAppHandlers(context: IpcHandlerContext) {
 
   registerProviderHandlers(context, electronShell)
 
-  context.ipcMain.handle('settings:get', async () => {
+  registerIpcInvoke(context, 'settings:get', optionalObjectArg<WorkspaceOptions>('workspace options', validateWorkspaceOptions), async (event, options) => {
     // Default surface returns credentials masked so the raw API keys
     // don't live in the renderer heap / DevTools for every consumer that
     // only needs provider ids + model ids + feature flags.
-    return maskEffectiveSettingsCredentials(getEffectiveSettings())
+    const base = maskEffectiveSettingsCredentials(getEffectiveSettings())
+    const workspaceId = readWorkspaceIdOption(options)
+    if (context.workspaceGateway.isLocalWorkspace(event, workspaceId)) return base
+    const setting = await context.workspaceGateway.getCloudSetting(event, CLOUD_PORTABLE_SETTINGS_KEY, workspaceId)
+    return buildCloudEffectiveSettings(base, setting?.value || {})
   })
 
   context.ipcMain.handle('settings:get-provider-credentials', async (_event, providerId: unknown) => {
@@ -233,7 +314,19 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     return getIntegrationCredentials(normalizeCredentialScopeId(integrationId, 'Integration'))
   })
 
-  registerIpcInvoke(context, 'settings:set', objectArg<Partial<CoworkSettings>>('settings update', validateSettingsUpdate), async (_event, updates) => {
+  registerIpcInvoke(context, 'settings:set', objectArg<Partial<CoworkSettings> & WorkspaceOptions>('settings update', validateSettingsUpdate), async (_event, updates) => {
+    const workspaceId = readWorkspaceIdOption(updates)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      assertCloudSettingsUpdateIsPortable(updates)
+      const base = maskEffectiveSettingsCredentials(getEffectiveSettings())
+      const existing = await context.workspaceGateway.getCloudSetting(_event, CLOUD_PORTABLE_SETTINGS_KEY, workspaceId)
+      const nextValue = {
+        ...(existing?.value || {}),
+        ...pickPortableCloudSettings(updates),
+      }
+      await context.workspaceGateway.setCloudSetting(_event, CLOUD_PORTABLE_SETTINGS_KEY, nextValue, workspaceId)
+      return buildCloudEffectiveSettings(base, nextValue)
+    }
     const result = saveSettings(updates)
     const { invalidateRuntimeCatalogSnapshotCache } = await import('../runtime-catalog-snapshot.ts')
     invalidateRuntimeCatalogSnapshotCache()

--- a/apps/desktop/src/main/ipc/artifact-handlers.ts
+++ b/apps/desktop/src/main/ipc/artifact-handlers.ts
@@ -50,7 +50,7 @@ function safeRealPath(path: string) {
 }
 
 export function decodeCloudArtifactDataUrl(url: string) {
-  const match = /^data:([^;,]+)?;base64,(.*)$/s.exec(url)
+  const match = /^data:([^,]*);base64,(.*)$/s.exec(url)
   if (!match) throw new Error('Cloud artifact attachment is not a base64 data URL.')
   const dataBase64 = (match[2] || '').replace(/\s+/g, '')
   if (!BASE64_RE.test(dataBase64) || dataBase64.length % 4 === 1) {

--- a/apps/desktop/src/main/ipc/artifact-handlers.ts
+++ b/apps/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,11 +1,22 @@
 import electron from 'electron'
 import { resolve } from 'path'
 import { basename, join } from 'path'
-import { chmodSync, copyFileSync, existsSync, realpathSync } from 'fs'
-import type { SessionArtifactExportRequest, SessionArtifactRequest } from '@open-cowork/shared'
+import { chmodSync, copyFileSync, existsSync, realpathSync, writeFileSync } from 'fs'
+import type {
+  SessionArtifact,
+  SessionArtifactExportRequest,
+  SessionArtifactListRequest,
+  SessionArtifactRequest,
+  SessionArtifactUploadRequest,
+} from '@open-cowork/shared'
 import type { IpcHandlerContext } from './context.ts'
 import { noIpcArgs, objectArg, registerIpcInvoke, stringArg } from './schema.ts'
-import { validateSessionArtifactExportRequest, validateSessionArtifactRequest } from './object-validators.ts'
+import {
+  validateSessionArtifactExportRequest,
+  validateSessionArtifactListRequest,
+  validateSessionArtifactRequest,
+  validateSessionArtifactUploadRequest,
+} from './object-validators.ts'
 import { buildArtifactAttachmentPayload } from '../artifact-attachments.ts'
 import { getChartArtifactsRoot } from '../chart-artifacts.ts'
 import { cleanupSandboxStorage, getSandboxStorageStats } from '../sandbox-storage.ts'
@@ -13,6 +24,7 @@ import { shortSessionId } from '../log-sanitizer.ts'
 import { log } from '../logger.ts'
 import { sessionEngine } from '../session-engine.ts'
 import { isReadableSessionArtifact } from '../session-artifact-access.ts'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
 export function copyArtifactForExport(source: string, destination: string) {
   copyFileSync(source, destination)
@@ -27,11 +39,46 @@ function safeRealPath(path: string) {
   }
 }
 
+function decodeAttachmentDataUrl(url: string) {
+  const match = /^data:([^;,]+)?;base64,(.*)$/s.exec(url)
+  if (!match) throw new Error('Cloud artifact attachment is not a base64 data URL.')
+  return Buffer.from(match[2] || '', 'base64')
+}
+
 export function registerArtifactHandlers(context: IpcHandlerContext) {
   const { app, shell } = electron
 
+  registerIpcInvoke(context, 'artifact:list', objectArg<SessionArtifactListRequest>('artifact list request', validateSessionArtifactListRequest), async (event, request): Promise<SessionArtifact[]> => {
+    const workspaceId = readWorkspaceIdOption(request)
+    if (context.workspaceGateway.isLocalWorkspace(event, workspaceId)) return []
+    return context.workspaceGateway.listCloudArtifacts(event, request.sessionId, workspaceId)
+  })
+
+  registerIpcInvoke(context, 'artifact:upload', objectArg<SessionArtifactUploadRequest>('artifact upload request', validateSessionArtifactUploadRequest), async (event, request): Promise<SessionArtifact> => {
+    const workspaceId = readWorkspaceIdOption(request)
+    if (context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      throw new Error('Artifact upload is only available for Cloud workspaces.')
+    }
+    return context.workspaceGateway.uploadCloudArtifact(event, request, workspaceId)
+  })
+
   registerIpcInvoke(context, 'artifact:export', objectArg<SessionArtifactExportRequest>('artifact export request', validateSessionArtifactExportRequest), async (_event, request) => {
     const { dialog } = await import('electron')
+    const workspaceId = readWorkspaceIdOption(request)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      const defaultName = request.suggestedName || basename(request.filePath) || 'artifact'
+      const result = await dialog.showSaveDialog({
+        title: 'Save Artifact As',
+        defaultPath: join(app.getPath('downloads'), defaultName),
+      })
+      if (result.canceled || !result.filePath) return null
+      const attachment = await context.workspaceGateway.readCloudArtifactAttachment(_event, request.sessionId, request.filePath, workspaceId)
+      writeFileSync(result.filePath, decodeAttachmentDataUrl(attachment.url))
+      chmodSync(result.filePath, 0o600)
+      log('artifact', `Exported cloud artifact ${attachment.filename} from ${shortSessionId(request.sessionId)}`)
+      return result.filePath
+    }
+
     const { source } = context.resolvePrivateArtifactPath(request)
 
     const result = await dialog.showSaveDialog({
@@ -45,14 +92,22 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
     return result.filePath
   })
 
-  registerIpcInvoke(context, 'artifact:reveal', objectArg<SessionArtifactRequest>('artifact request', validateSessionArtifactRequest), async (_event, request) => {
+  registerIpcInvoke(context, 'artifact:reveal', objectArg<SessionArtifactRequest>('artifact request', validateSessionArtifactRequest), async (event, request) => {
+    const workspaceId = readWorkspaceIdOption(request)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      throw new Error('Cloud artifacts cannot be revealed in the local filesystem. Export the artifact instead.')
+    }
     const { source } = context.resolvePrivateArtifactPath(request)
     shell.showItemInFolder(source)
     log('artifact', `Revealed artifact ${basename(source)} from ${shortSessionId(request.sessionId)}`)
     return true
   })
 
-  registerIpcInvoke(context, 'artifact:read-attachment', objectArg<SessionArtifactRequest>('artifact request', validateSessionArtifactRequest), async (_event, request) => {
+  registerIpcInvoke(context, 'artifact:read-attachment', objectArg<SessionArtifactRequest>('artifact request', validateSessionArtifactRequest), async (event, request) => {
+    const workspaceId = readWorkspaceIdOption(request)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.readCloudArtifactAttachment(event, request.sessionId, request.filePath, workspaceId)
+    }
     const { root, source } = context.resolvePrivateArtifactPath(request)
     const chartRoot = resolve(getChartArtifactsRoot(request.sessionId))
     const isChartArtifact = root === safeRealPath(chartRoot)

--- a/apps/desktop/src/main/ipc/artifact-handlers.ts
+++ b/apps/desktop/src/main/ipc/artifact-handlers.ts
@@ -4,6 +4,7 @@ import { basename, join } from 'path'
 import { chmodSync, copyFileSync, existsSync, realpathSync, writeFileSync } from 'fs'
 import type {
   SessionArtifact,
+  SessionArtifactAttachment,
   SessionArtifactExportRequest,
   SessionArtifactListRequest,
   SessionArtifactRequest,
@@ -26,9 +27,18 @@ import { sessionEngine } from '../session-engine.ts'
 import { isReadableSessionArtifact } from '../session-artifact-access.ts'
 import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
+const MAX_CLOUD_ARTIFACT_EXPORT_BYTES = 50 * 1024 * 1024
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/
+
 export function copyArtifactForExport(source: string, destination: string) {
   copyFileSync(source, destination)
   chmodSync(destination, 0o600)
+}
+
+export function safeArtifactExportFilename(input: string | null | undefined) {
+  const candidate = basename(input || '').trim()
+  if (!candidate || candidate === '.' || candidate === '..') return 'artifact'
+  return candidate
 }
 
 function safeRealPath(path: string) {
@@ -39,10 +49,31 @@ function safeRealPath(path: string) {
   }
 }
 
-function decodeAttachmentDataUrl(url: string) {
+export function decodeCloudArtifactDataUrl(url: string) {
   const match = /^data:([^;,]+)?;base64,(.*)$/s.exec(url)
   if (!match) throw new Error('Cloud artifact attachment is not a base64 data URL.')
-  return Buffer.from(match[2] || '', 'base64')
+  const dataBase64 = (match[2] || '').replace(/\s+/g, '')
+  if (!BASE64_RE.test(dataBase64) || dataBase64.length % 4 === 1) {
+    throw new Error('Cloud artifact attachment is not valid base64.')
+  }
+  const estimatedBytes = Math.floor((dataBase64.length * 3) / 4)
+  if (estimatedBytes > MAX_CLOUD_ARTIFACT_EXPORT_BYTES) {
+    throw new Error('Cloud artifact exceeds the export size limit.')
+  }
+  const bytes = Buffer.from(dataBase64, 'base64')
+  if (bytes.length > MAX_CLOUD_ARTIFACT_EXPORT_BYTES) {
+    throw new Error('Cloud artifact exceeds the export size limit.')
+  }
+  return bytes
+}
+
+export function writeCloudArtifactForExport(destination: string, attachment: Pick<SessionArtifactAttachment, 'url'>) {
+  const bytes = decodeCloudArtifactDataUrl(attachment.url)
+  // User-selected cloud artifact export. The bytes are validated as a bounded
+  // base64 data URL above and only written after an explicit save dialog.
+  // codeql[js/network-data-written-to-file]
+  writeFileSync(destination, bytes)
+  chmodSync(destination, 0o600)
 }
 
 export function registerArtifactHandlers(context: IpcHandlerContext) {
@@ -66,15 +97,14 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
     const { dialog } = await import('electron')
     const workspaceId = readWorkspaceIdOption(request)
     if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
-      const defaultName = request.suggestedName || basename(request.filePath) || 'artifact'
+      const defaultName = safeArtifactExportFilename(request.suggestedName || basename(request.filePath))
       const result = await dialog.showSaveDialog({
         title: 'Save Artifact As',
         defaultPath: join(app.getPath('downloads'), defaultName),
       })
       if (result.canceled || !result.filePath) return null
       const attachment = await context.workspaceGateway.readCloudArtifactAttachment(_event, request.sessionId, request.filePath, workspaceId)
-      writeFileSync(result.filePath, decodeAttachmentDataUrl(attachment.url))
-      chmodSync(result.filePath, 0o600)
+      writeCloudArtifactForExport(result.filePath, attachment)
       log('artifact', `Exported cloud artifact ${attachment.filename} from ${shortSessionId(request.sessionId)}`)
       return result.filePath
     }
@@ -83,7 +113,7 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
 
     const result = await dialog.showSaveDialog({
       title: 'Save Artifact As',
-      defaultPath: join(app.getPath('downloads'), request.suggestedName || basename(source)),
+      defaultPath: join(app.getPath('downloads'), safeArtifactExportFilename(request.suggestedName || basename(source))),
     })
     if (result.canceled || !result.filePath) return null
 

--- a/apps/desktop/src/main/ipc/catalog-handlers.ts
+++ b/apps/desktop/src/main/ipc/catalog-handlers.ts
@@ -1,5 +1,14 @@
-import type { RuntimeAgentDescriptor, RuntimeContextOptions, ScopedArtifactRef, ToolListOptions, CustomAgentConfig } from '@open-cowork/shared'
+import type {
+  CapabilitySkill,
+  CapabilityTool,
+  CustomAgentConfig,
+  RuntimeAgentDescriptor,
+  RuntimeContextOptions,
+  ScopedArtifactRef,
+  ToolListOptions,
+} from '@open-cowork/shared'
 import { performance } from 'node:perf_hooks'
+import type { IpcMainInvokeEvent } from 'electron'
 import type { IpcHandlerContext } from './context.ts'
 import {
   objectAndObjectArgs,
@@ -20,7 +29,7 @@ import {
 import { getClient } from '../runtime.ts'
 import { invalidateRuntimeToolCache } from '../runtime-tool-cache.ts'
 import { listBuiltInAgentDetails } from '../built-in-agent-details.ts'
-import { getCustomAgentCatalog, getCustomAgentSummaries, invalidateCustomAgentCatalogCache, normalizeCustomAgent, validateCustomAgent } from '../custom-agents.ts'
+import { getCustomAgentCatalog, getCustomAgentSummaries, invalidateCustomAgentCatalogCache, normalizeCustomAgent, validateCustomAgent, type CustomAgentCatalog } from '../custom-agents.ts'
 import { listCustomAgents, removeCustomAgent, saveCustomAgent } from '../native-customizations.ts'
 import { getCapabilitySkillBundle, getCapabilityTool, listCapabilitySkills, listCapabilityTools } from '../capability-catalog.ts'
 import { readEffectiveSkillBundleFile } from '../effective-skills.ts'
@@ -28,6 +37,7 @@ import { expandMcpToolPermissionPatterns, getConfiguredToolPatterns, getConfigur
 import { log } from '../logger.ts'
 import { createKeyedPromiseChain } from '../promise-chain.ts'
 import { preflightConfiguredApiTokenMcp } from '../mcp-preflight.ts'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
 function resolveContext(context: IpcHandlerContext, options?: RuntimeContextOptions) {
   return {
@@ -59,10 +69,70 @@ const runMcpTransitionForName = createKeyedPromiseChain()
 
 const WRITE_TOOL_IDS = new Set(['edit', 'write', 'apply_patch', 'todowrite'])
 const WRITE_PERMISSION_ACTIONS = new Set(['ask', 'allow'])
+const AGENT_COLORS: CustomAgentCatalog['colors'] = ['primary', 'warning', 'accent', 'success', 'info', 'secondary']
 
 function invalidateRuntimeCapabilityCaches() {
   invalidateRuntimeToolCache()
   invalidateCustomAgentCatalogCache()
+}
+
+function cloudCatalogTool(tool: CapabilityTool): CustomAgentCatalog['tools'][number] {
+  return {
+    id: tool.id,
+    name: tool.name,
+    icon: tool.kind === 'mcp' ? 'plug' : 'terminal',
+    description: tool.description,
+    supportsWrite: tool.patterns.some((pattern) => WRITE_TOOL_IDS.has(pattern) || pattern.includes('write') || pattern.includes('edit')),
+    source: tool.source === 'custom' ? 'custom' : 'builtin',
+    patterns: tool.patterns,
+    allowPatterns: tool.patterns,
+    askPatterns: [],
+  }
+}
+
+function cloudCatalogSkill(skill: CapabilitySkill): CustomAgentCatalog['skills'][number] {
+  return {
+    name: skill.name,
+    label: skill.label,
+    description: skill.description,
+    source: skill.source,
+    origin: skill.origin,
+    scope: skill.scope,
+    location: null,
+    toolIds: skill.toolIds,
+  }
+}
+
+async function getCloudAgentCatalog(context: IpcHandlerContext, event: IpcMainInvokeEvent, workspaceId: string | null): Promise<CustomAgentCatalog> {
+  const [tools, skills, customAgents] = await Promise.all([
+    context.workspaceGateway.listCloudCapabilityTools(event, workspaceId),
+    context.workspaceGateway.listCloudCapabilitySkills(event, workspaceId),
+    context.workspaceGateway.listCloudCustomAgents(event, workspaceId),
+  ])
+  return {
+    tools: tools.map(cloudCatalogTool),
+    skills: skills.map(cloudCatalogSkill),
+    reservedNames: customAgents.map((agent) => agent.name).sort((a, b) => a.localeCompare(b)),
+    colors: AGENT_COLORS,
+  }
+}
+
+function assertCloudAgentIsPortable(agent: CustomAgentConfig): CustomAgentConfig {
+  if (agent.scope === 'project' || agent.directory) throw new Error('Cloud custom agents cannot reference local project paths.')
+  return {
+    ...agent,
+    scope: 'machine',
+    directory: null,
+  }
+}
+
+function cloudAgentSummary(agent: CustomAgentConfig) {
+  return {
+    ...agent,
+    writeAccess: agent.toolIds.some((toolId) => WRITE_TOOL_IDS.has(toolId) || toolId === 'bash'),
+    valid: true,
+    issues: [],
+  }
 }
 
 async function timeAgentCatalogHandler<T>(name: 'agents:list' | 'agents:catalog' | 'agents:runtime', work: () => Promise<T>) {
@@ -290,11 +360,20 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'agents:catalog', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return timeAgentCatalogHandler('agents:catalog', () => getCloudAgentCatalog(context, _event, workspaceId))
+    }
     return timeAgentCatalogHandler('agents:catalog', () =>
       getCustomAgentCatalog(resolveContext(context, options)))
   })
 
   registerIpcInvoke(context, 'agents:list', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return timeAgentCatalogHandler('agents:list', async () =>
+        (await context.workspaceGateway.listCloudCustomAgents(_event, workspaceId)).map(cloudAgentSummary))
+    }
     return timeAgentCatalogHandler('agents:list', () =>
       getCustomAgentSummaries(resolveContext(context, options)))
   })
@@ -339,6 +418,15 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
 
   registerIpcInvoke(context, 'agents:create', objectArg<CustomAgentConfig>('custom agent', validateCustomAgentConfig), async (_event, agent) => {
     const normalized = normalizeCustomAgent(agent)
+    const workspaceId = readWorkspaceIdOption(agent)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      const portable = assertCloudAgentIsPortable(normalized)
+      const catalog = await getCloudAgentCatalog(context, _event, workspaceId)
+      const siblingNames = (await context.workspaceGateway.listCloudCustomAgents(_event, workspaceId)).map((entry) => normalizeCustomAgent(entry).name)
+      const issues = validateCustomAgent(portable, catalog, siblingNames)
+      if (issues.length > 0) throw new Error(issues[0]?.message || 'Invalid custom agent')
+      return context.workspaceGateway.saveCloudCustomAgent(_event, portable, workspaceId)
+    }
     const catalogContext = {
       directory: agent.scope === 'project' ? context.resolveScopedTarget(agent).directory : null,
     }
@@ -359,6 +447,18 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
 
   registerIpcInvoke(context, 'agents:update', objectAndObjectArgs<ScopedArtifactRef, CustomAgentConfig>('custom agent target', 'custom agent', validateScopedArtifactRef, validateCustomAgentConfig), async (_event, target, agent) => {
     const normalized = normalizeCustomAgent(agent)
+    const workspaceId = readWorkspaceIdOption(agent) || readWorkspaceIdOption(target)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      const portable = assertCloudAgentIsPortable(normalized)
+      const catalog = await getCloudAgentCatalog(context, _event, workspaceId)
+      const siblingNames = (await context.workspaceGateway.listCloudCustomAgents(_event, workspaceId))
+        .filter((entry) => !(entry.name === target.name && entry.scope === target.scope && (entry.directory || null) === (target.directory || null)))
+        .map((entry) => normalizeCustomAgent(entry).name)
+      const issues = validateCustomAgent(portable, catalog, siblingNames)
+      if (issues.length > 0) throw new Error(issues[0]?.message || 'Invalid custom agent')
+      await context.workspaceGateway.removeCloudCustomAgent(_event, target, workspaceId)
+      return context.workspaceGateway.saveCloudCustomAgent(_event, portable, workspaceId)
+    }
     const resolvedTarget = context.resolveScopedTarget(target)
     const catalogContext = {
       directory: normalized.scope === 'project' ? context.resolveScopedTarget(normalized).directory : resolvedTarget.directory,
@@ -382,6 +482,13 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'agents:remove', objectAndOptionalStringArgs<ScopedArtifactRef>('custom agent target', 'confirmation token', validateScopedArtifactRef), async (_event, target, confirmationToken) => {
+    const workspaceId = readWorkspaceIdOption(target)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      if (!context.consumeDestructiveConfirmation({ action: 'agent.remove', target }, confirmationToken)) {
+        throw new Error('Confirmation required before deleting an agent.')
+      }
+      return context.workspaceGateway.removeCloudCustomAgent(_event, target, workspaceId)
+    }
     const resolvedTarget = context.resolveScopedTarget(target)
     try {
       if (!context.consumeDestructiveConfirmation({ action: 'agent.remove', target: resolvedTarget }, confirmationToken)) {
@@ -401,6 +508,10 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'capabilities:tools', optionalObjectArg<ToolListOptions>('tool list options', validateToolListOptions), async (_event, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return context.workspaceGateway.listCloudCapabilityTools(_event, workspaceId)
+    }
     const runtimeTools = await context.listRuntimeTools(options)
     // List view — render just the cards; skip the expensive
     // per-MCP method probe. `deep` defaults to false in shared types
@@ -414,6 +525,10 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'capabilities:tool', stringAndOptionalObjectArgs<ToolListOptions>('tool id', 'tool list options', {}, validateToolListOptions), async (_event, id, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return context.workspaceGateway.getCloudCapabilityTool(_event, id, workspaceId)
+    }
     const runtimeTools = await context.listRuntimeTools(options)
     // Detail view — user actually opened one tool; spend the time
     // probing its MCP so the method table renders. Scoped to a single
@@ -429,14 +544,26 @@ export function registerCatalogHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'capabilities:skills', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return context.workspaceGateway.listCloudCapabilitySkills(_event, workspaceId)
+    }
     return await listCapabilitySkills(resolveContext(context, options))
   })
 
   registerIpcInvoke(context, 'capabilities:skill-bundle', stringAndOptionalObjectArgs<RuntimeContextOptions>('skill name', 'runtime context options', {}, validateRuntimeContextOptions), async (_event, skillName, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return context.workspaceGateway.getCloudCapabilitySkillBundle(_event, skillName, workspaceId)
+    }
     return await getCapabilitySkillBundle(skillName, resolveContext(context, options))
   })
 
   registerIpcInvoke(context, 'capabilities:skill-bundle-file', twoStringsAndOptionalObjectArgs<RuntimeContextOptions>('skill name', 'file path', 'runtime context options', {}, validateRuntimeContextOptions), async (_event, skillName, filePath, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return context.workspaceGateway.readCloudCapabilitySkillBundleFile(_event, skillName, filePath, workspaceId)
+    }
     return await readEffectiveSkillBundleFile(skillName, filePath, resolveContext(context, options))
   })
 }

--- a/apps/desktop/src/main/ipc/context.ts
+++ b/apps/desktop/src/main/ipc/context.ts
@@ -12,6 +12,7 @@ import type {
 import type { OpencodeClient } from '@opencode-ai/sdk/v2'
 import type { SessionRecord } from '../session-registry'
 import type { NativeConfirmationOptions } from '../native-confirmation.ts'
+import type { WorkspaceGateway } from '../workspace-gateway.ts'
 
 export type SessionClientContext = {
   client: OpencodeClient
@@ -26,6 +27,7 @@ export type SessionV2ClientContext = {
 
 export type IpcHandlerContext = {
   ipcMain: Pick<IpcMain, 'handle' | 'on'>
+  workspaceGateway: WorkspaceGateway
   getMainWindow: () => BrowserWindow | null
   normalizeDirectory: (directory?: string | null) => string
   ensureSessionRecord: (sessionId: string) => SessionRecord | null

--- a/apps/desktop/src/main/ipc/custom-content-handlers.ts
+++ b/apps/desktop/src/main/ipc/custom-content-handlers.ts
@@ -19,6 +19,7 @@ import { VALID_OPENCODE_SKILL_NAME } from '../skill-bundle-validation.ts'
 import { assertCustomMcpContentLimits, assertCustomSkillContent } from '../custom-content-limits.ts'
 import { computeCustomSkillBundleDigest } from '../custom-skill-integrity.ts'
 import { invalidateCustomAgentCatalogCache } from '../custom-agents.ts'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
 const VALID_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
@@ -38,6 +39,31 @@ function resolveCustomContext(context: IpcHandlerContext, options?: RuntimeConte
   return {
     ...options,
     directory: context.resolveContextDirectory(options),
+  }
+}
+
+function assertCloudMcpIsPortable(mcp: CustomMcpConfig): CustomMcpConfig {
+  if (mcp.type !== 'http') throw new Error('Cloud custom MCPs must be remote HTTP MCPs. Local stdio MCPs stay in the Local workspace.')
+  if (mcp.scope === 'project' || mcp.directory) throw new Error('Cloud custom MCPs cannot reference local project paths.')
+  if (mcp.env && Object.keys(mcp.env).length > 0) throw new Error('Cloud custom MCPs cannot sync raw environment secrets.')
+  if (mcp.headers && Object.keys(mcp.headers).length > 0) throw new Error('Cloud custom MCPs cannot sync raw header secrets.')
+  if (mcp.allowPrivateNetwork) throw new Error('Cloud custom MCPs cannot enable private-network access from desktop metadata.')
+  return {
+    ...mcp,
+    scope: 'machine',
+    directory: null,
+    env: undefined,
+    headers: undefined,
+    allowPrivateNetwork: false,
+  }
+}
+
+function assertCloudSkillIsPortable(skill: CustomSkillConfig): CustomSkillConfig {
+  if (skill.scope === 'project' || skill.directory) throw new Error('Cloud custom skills cannot reference local project paths.')
+  return {
+    ...skill,
+    scope: 'machine',
+    directory: null,
   }
 }
 
@@ -78,12 +104,26 @@ async function confirmUnsignedSkillWrite(
 
 export function registerCustomContentHandlers(context: IpcHandlerContext) {
   registerIpcInvoke(context, 'custom:list-mcps', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return context.workspaceGateway.listCloudCustomMcps(_event, workspaceId)
+    }
     return listCustomMcps(resolveCustomContext(context, options))
   })
 
   registerIpcInvoke(context, 'custom:test-mcp', objectArg<CustomMcpConfig>('custom MCP', validateCustomMcpConfig), async (_event, mcp): Promise<CustomMcpTestResult> => {
     try {
       assertCustomMcpContentLimits(mcp)
+      const workspaceId = readWorkspaceIdOption(mcp)
+      if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+        assertCloudMcpIsPortable(mcp)
+        return {
+          ok: false,
+          methods: [],
+          authRequired: false,
+          error: 'Cloud MCP connection testing runs in the cloud worker and is not available from desktop yet.',
+        }
+      }
       if (mcp.type === 'stdio') {
         validateCustomMcpStdioCommand(mcp)
       }
@@ -131,6 +171,11 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
   registerIpcInvoke(context, 'custom:add-mcp', objectArg<CustomMcpConfig>('custom MCP', validateCustomMcpConfig), async (_event, mcp) => {
     validateName(mcp.name, 'MCP')
     assertCustomMcpContentLimits(mcp)
+    const workspaceId = readWorkspaceIdOption(mcp)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      const portable = assertCloudMcpIsPortable(mcp)
+      return context.workspaceGateway.saveCloudCustomMcp(_event, portable, workspaceId)
+    }
     const resolved = context.resolveScopedTarget(mcp) as CustomMcpConfig
     if (resolved.type === 'stdio') {
       validateCustomMcpStdioCommand(resolved)
@@ -159,6 +204,13 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'custom:remove-mcp', objectAndOptionalStringArgs<ScopedArtifactRef>('custom MCP target', 'confirmation token', validateScopedArtifactRef), async (_event, target, confirmationToken) => {
+    const workspaceId = readWorkspaceIdOption(target)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      if (!context.consumeDestructiveConfirmation({ action: 'mcp.remove', target }, confirmationToken)) {
+        throw new Error('Confirmation required before removing an MCP.')
+      }
+      return context.workspaceGateway.removeCloudCustomMcp(_event, target, workspaceId)
+    }
     const resolvedTarget = context.resolveScopedTarget(target)
     try {
       if (!context.consumeDestructiveConfirmation({ action: 'mcp.remove', target: resolvedTarget }, confirmationToken)) {
@@ -178,12 +230,21 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'custom:list-skills', optionalObjectArg<RuntimeContextOptions>('runtime context options', validateRuntimeContextOptions), async (_event, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      return context.workspaceGateway.listCloudCustomSkills(_event, workspaceId)
+    }
     return listCustomSkills(resolveCustomContext(context, options))
   })
 
   registerIpcInvoke(context, 'custom:add-skill', objectArg<CustomSkillConfig>('custom skill', validateCustomSkillConfig), async (_event, skill) => {
     validateSkillName(skill.name)
     assertCustomSkillContent(skill.content || '')
+    const workspaceId = readWorkspaceIdOption(skill)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      const portable = assertCloudSkillIsPortable(skill)
+      return context.workspaceGateway.saveCloudCustomSkill(_event, portable, workspaceId)
+    }
     const resolved = context.resolveScopedTarget(skill) as CustomSkillConfig
     const existing = listCustomSkills({ directory: resolved.directory || null })
       .find((entry) => entry.name === resolved.name && entry.scope === resolved.scope) || null
@@ -214,6 +275,10 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'custom:import-skill-directory', stringAndObjectArgs<ScopedArtifactRef>('selection token', 'skill import target', {}, validateScopedArtifactRef), async (_event, selectionToken, target) => {
+    const workspaceId = readWorkspaceIdOption(target)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      throw new Error('Importing local skill directories into Cloud workspaces is not supported.')
+    }
     const resolvedTarget = context.resolveScopedTarget(target)
     const directory = context.approvedSkillImportDirectories.get(selectionToken)
     context.approvedSkillImportDirectories.delete(selectionToken)
@@ -239,6 +304,13 @@ export function registerCustomContentHandlers(context: IpcHandlerContext) {
   })
 
   registerIpcInvoke(context, 'custom:remove-skill', objectAndOptionalStringArgs<ScopedArtifactRef>('custom skill target', 'confirmation token', validateScopedArtifactRef), async (_event, target, confirmationToken) => {
+    const workspaceId = readWorkspaceIdOption(target)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      if (!context.consumeDestructiveConfirmation({ action: 'skill.remove', target }, confirmationToken)) {
+        throw new Error('Confirmation required before removing a skill.')
+      }
+      return context.workspaceGateway.removeCloudCustomSkill(_event, target, workspaceId)
+    }
     const resolvedTarget = context.resolveScopedTarget(target)
     try {
       if (!context.consumeDestructiveConfirmation({ action: 'skill.remove', target: resolvedTarget }, confirmationToken)) {

--- a/apps/desktop/src/main/ipc/object-validators.ts
+++ b/apps/desktop/src/main/ipc/object-validators.ts
@@ -7,9 +7,12 @@ import type {
   RuntimeContextOptions,
   ScopedArtifactRef,
   SessionArtifactExportRequest,
+  SessionArtifactListRequest,
   SessionArtifactRequest,
+  SessionArtifactUploadRequest,
   ThreadSearchQuery,
   ToolListOptions,
+  WorkspaceOptions,
 } from '@open-cowork/shared'
 import type { CoworkSettings } from '../settings.ts'
 import { assertCustomMcpContentLimits, assertCustomSkillContent, assertCustomSkillFiles } from '../custom-content-limits.ts'
@@ -20,6 +23,7 @@ const MAX_IPC_STRING_BYTES = 64 * 1024
 const MAX_IPC_ID_BYTES = 512
 const MAX_SETTINGS_UPDATE_BYTES = 512 * 1024
 const MAX_CHART_DATA_URL_BYTES = 8 * 1024 * 1024 + 128
+const MAX_ARTIFACT_UPLOAD_BASE64_BYTES = 35 * 1024 * 1024
 const SCOPES = new Set(['machine', 'project'])
 const MCP_TYPES = new Set(['stdio', 'http'])
 const MCP_PERMISSION_MODES = new Set(['ask', 'allow'])
@@ -47,6 +51,7 @@ const SETTINGS_UPDATE_KEYS = new Set([
   'workflowDesktopNotifications',
   'workflowQuietHoursStart',
   'workflowQuietHoursEnd',
+  'workspaceId',
 ])
 
 function byteLength(value: string) {
@@ -191,8 +196,15 @@ function requiredScope(record: Record<string, unknown>) {
 
 export function validateRuntimeContextOptions(record: Record<string, unknown>): RuntimeContextOptions {
   return {
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
     sessionId: optionalString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
     directory: optionalNullableString(record, 'directory', 'Directory'),
+  }
+}
+
+export function validateWorkspaceOptions(record: Record<string, unknown>): WorkspaceOptions {
+  return {
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
   }
 }
 
@@ -207,6 +219,7 @@ export function validateToolListOptions(record: Record<string, unknown>): ToolLi
 
 export function validateScopedArtifactRef(record: Record<string, unknown>): ScopedArtifactRef {
   return {
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
     name: requiredString(record, 'name', 'Name', MAX_IPC_ID_BYTES),
     scope: requiredScope(record),
     directory: optionalNullableString(record, 'directory', 'Directory'),
@@ -217,6 +230,7 @@ export function validateSessionArtifactRequest(record: Record<string, unknown>):
   return {
     sessionId: requiredString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
     filePath: requiredString(record, 'filePath', 'Artifact path'),
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
   }
 }
 
@@ -224,6 +238,23 @@ export function validateSessionArtifactExportRequest(record: Record<string, unkn
   return {
     ...validateSessionArtifactRequest(record),
     suggestedName: optionalString(record, 'suggestedName', 'Suggested filename', MAX_IPC_ID_BYTES),
+  }
+}
+
+export function validateSessionArtifactListRequest(record: Record<string, unknown>): SessionArtifactListRequest {
+  return {
+    sessionId: requiredString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
+  }
+}
+
+export function validateSessionArtifactUploadRequest(record: Record<string, unknown>): SessionArtifactUploadRequest {
+  return {
+    sessionId: requiredString(record, 'sessionId', 'Session id', MAX_IPC_ID_BYTES),
+    filename: requiredString(record, 'filename', 'Artifact filename', MAX_IPC_ID_BYTES),
+    contentType: optionalNullableString(record, 'contentType', 'Artifact content type', MAX_IPC_ID_BYTES),
+    dataBase64: requiredString(record, 'dataBase64', 'Artifact data', MAX_ARTIFACT_UPLOAD_BASE64_BYTES),
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
   }
 }
 
@@ -243,18 +274,19 @@ export function validateChartSaveArtifactRequest(record: Record<string, unknown>
   }
 }
 
-export function validateSettingsUpdate(record: Record<string, unknown>): Partial<CoworkSettings> {
+export function validateSettingsUpdate(record: Record<string, unknown>): Partial<CoworkSettings> & WorkspaceOptions {
   assertJsonSize(record, 'Settings update', MAX_SETTINGS_UPDATE_BYTES)
   for (const key of Object.keys(record)) {
     if (!SETTINGS_UPDATE_KEYS.has(key)) throw new Error(`Unknown settings key: ${key}`)
   }
-  const update: Partial<CoworkSettings> = {}
+  const update: Partial<CoworkSettings> & WorkspaceOptions = {}
   if (record._schemaVersion !== undefined) {
     if (typeof record._schemaVersion !== 'number' || !Number.isInteger(record._schemaVersion)) {
       throw new Error('Settings schema version must be an integer.')
     }
     update._schemaVersion = record._schemaVersion
   }
+  update.workspaceId = optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES)
   update.selectedProviderId = optionalNullableString(record, 'selectedProviderId', 'Selected provider id', MAX_IPC_ID_BYTES) as string | null | undefined
   update.selectedModelId = optionalNullableString(record, 'selectedModelId', 'Selected model id', MAX_IPC_ID_BYTES) as string | null | undefined
   update.selectedSmallModelId = optionalNullableString(record, 'selectedSmallModelId', 'Selected small model id', MAX_IPC_ID_BYTES) as string | null | undefined
@@ -297,6 +329,7 @@ export function validateCustomMcpConfig(record: Record<string, unknown>): Custom
     throw new Error('MCP permission mode must be ask or allow.')
   }
   const config: CustomMcpConfig = {
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
     scope: requiredScope(record),
     directory: optionalNullableString(record, 'directory', 'Directory'),
     name: requiredString(record, 'name', 'MCP name', MAX_IPC_ID_BYTES),
@@ -334,6 +367,7 @@ export function validateCustomSkillConfig(record: Record<string, unknown>): Cust
     })
   }
   const skill: CustomSkillConfig = {
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
     scope: requiredScope(record),
     directory: optionalNullableString(record, 'directory', 'Directory'),
     name: requiredString(record, 'name', 'Skill name', MAX_IPC_ID_BYTES),
@@ -348,6 +382,7 @@ export function validateCustomSkillConfig(record: Record<string, unknown>): Cust
 
 export function validateCustomAgentConfig(record: Record<string, unknown>): CustomAgentConfig {
   const agent: CustomAgentConfig = {
+    workspaceId: optionalString(record, 'workspaceId', 'Workspace id', MAX_IPC_ID_BYTES),
     scope: requiredScope(record),
     directory: optionalNullableString(record, 'directory', 'Directory'),
     name: requiredString(record, 'name', 'Agent name', MAX_IPC_ID_BYTES),

--- a/apps/desktop/src/main/ipc/schema.ts
+++ b/apps/desktop/src/main/ipc/schema.ts
@@ -111,7 +111,7 @@ export function stringAndOptionalObjectArgs<T extends object>(
 ) {
   return createIpcArgsSchema<[string, T | undefined]>((channel, args) => {
     if (args.length < 1 || args.length > 2) {
-      throw new Error(`${channel} requires ${stringLabel}.`)
+      throw new Error(`${channel} requires ${stringLabel} and accepts optional ${objectLabel}.`)
     }
     if (typeof args[0] !== 'string') {
       throw new Error(`${channel} requires ${stringLabel} to be a string.`)
@@ -162,6 +162,50 @@ export function objectAndObjectArgs<TFirst extends object, TSecond extends objec
     return [
       normalizeObjectArg<TFirst>(channel, firstLabel, args[0], firstValidator),
       normalizeObjectArg<TSecond>(channel, secondLabel, args[1], secondValidator),
+    ]
+  })
+}
+
+export function objectAndOptionalObjectArgs<TFirst extends object, TSecond extends object>(
+  firstLabel: string,
+  secondLabel: string,
+  firstValidator?: IpcObjectValidator<TFirst>,
+  secondValidator?: IpcObjectValidator<TSecond>,
+) {
+  return createIpcArgsSchema<[TFirst, TSecond | undefined]>((channel, args) => {
+    if (args.length < 1 || args.length > 2) {
+      throw new Error(`${channel} requires ${firstLabel} and accepts optional ${secondLabel}.`)
+    }
+    return [
+      normalizeObjectArg<TFirst>(channel, firstLabel, args[0], firstValidator),
+      args[1] === undefined || args[1] === null
+        ? undefined
+        : normalizeObjectArg<TSecond>(channel, secondLabel, args[1], secondValidator),
+    ]
+  })
+}
+
+export function stringAndObjectAndOptionalObjectArgs<TFirst extends object, TSecond extends object>(
+  stringLabel: string,
+  firstObjectLabel: string,
+  secondObjectLabel: string,
+  options: { maxBytes?: number } = {},
+  firstValidator?: IpcObjectValidator<TFirst>,
+  secondValidator?: IpcObjectValidator<TSecond>,
+) {
+  return createIpcArgsSchema<[string, TFirst, TSecond | undefined]>((channel, args) => {
+    if (args.length < 2 || args.length > 3) {
+      throw new Error(`${channel} requires ${stringLabel} and ${firstObjectLabel}.`)
+    }
+    if (typeof args[0] !== 'string') {
+      throw new Error(`${channel} requires ${stringLabel} to be a string.`)
+    }
+    return [
+      normalizeStringArg(channel, stringLabel, args[0], options.maxBytes),
+      normalizeObjectArg<TFirst>(channel, firstObjectLabel, args[1], firstValidator),
+      args[2] === undefined || args[2] === null
+        ? undefined
+        : normalizeObjectArg<TSecond>(channel, secondObjectLabel, args[2], secondValidator),
     ]
   })
 }

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -82,6 +82,14 @@ function dispatchCloudWorkspaceSessionEvent(
   if (!win || win.isDestroyed()) return
   const payload = event.payload || {}
   const eventAt = event.sequence || Date.now()
+  let shouldRefreshCloudProjection = false
+  const publishCloudProjection = () => {
+    void context.workspaceGateway.getCloudSessionView(sourceEvent, sessionId, workspaceId)
+      .then((view) => {
+        if (!win.isDestroyed()) win.webContents.send('session:view', { sessionId, workspaceId: workspaceId || undefined, view })
+      })
+      .catch((error) => context.logHandlerError(`cloud session:view ${shortSessionId(sessionId)}`, error))
+  }
   const dispatchCloudRuntimeEvent = (runtimeEvent: Parameters<typeof dispatchRuntimeSessionEvent>[1]) => {
     dispatchRuntimeSessionEvent(win, {
       ...runtimeEvent,
@@ -108,6 +116,7 @@ function dispatchCloudWorkspaceSessionEvent(
       sessionId,
       data: { type: 'busy' },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'assistant.message') {
     const messageId = payloadString(payload, 'messageId') || `${sessionId}:${event.sequence}:cloud-assistant`
     dispatchCloudRuntimeEvent({
@@ -128,6 +137,7 @@ function dispatchCloudWorkspaceSessionEvent(
       sessionId,
       data: { type: 'done', synthetic: true },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'tool.call') {
     dispatchCloudRuntimeEvent({
       type: 'tool_call',
@@ -144,6 +154,7 @@ function dispatchCloudWorkspaceSessionEvent(
         sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'task.run') {
     dispatchCloudRuntimeEvent({
       type: 'task_run',
@@ -160,6 +171,7 @@ function dispatchCloudWorkspaceSessionEvent(
         finishedAt: payloadString(payload, 'finishedAt') || null,
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'permission.requested') {
     const permissionId = payloadString(payload, 'permissionId') || payloadString(payload, 'id') || `${sessionId}:permission:${event.sequence}`
     dispatchCloudRuntimeEvent({
@@ -175,6 +187,7 @@ function dispatchCloudWorkspaceSessionEvent(
         sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'permission.resolved') {
     dispatchCloudRuntimeEvent({
       type: 'approval_resolved',
@@ -184,6 +197,7 @@ function dispatchCloudWorkspaceSessionEvent(
         id: payloadString(payload, 'permissionId') || payloadString(payload, 'id'),
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'question.asked') {
     dispatchCloudRuntimeEvent({
       type: 'question_asked',
@@ -196,6 +210,7 @@ function dispatchCloudWorkspaceSessionEvent(
         sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'question.resolved') {
     dispatchCloudRuntimeEvent({
       type: 'question_resolved',
@@ -206,6 +221,7 @@ function dispatchCloudWorkspaceSessionEvent(
         sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'todos.updated') {
     dispatchCloudRuntimeEvent({
       type: 'todos',
@@ -215,6 +231,7 @@ function dispatchCloudWorkspaceSessionEvent(
         todos: Array.isArray(payload.todos) ? payload.todos as NonNullable<Parameters<typeof dispatchRuntimeSessionEvent>[1]['data']>['todos'] : [],
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'cost.updated') {
     dispatchCloudRuntimeEvent({
       type: 'cost',
@@ -228,12 +245,9 @@ function dispatchCloudWorkspaceSessionEvent(
         sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
       },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'artifact.created') {
-    void context.workspaceGateway.getCloudSessionView(sourceEvent, sessionId, workspaceId)
-      .then((view) => {
-        if (!win.isDestroyed()) win.webContents.send('session:view', { sessionId, workspaceId: workspaceId || undefined, view })
-      })
-      .catch((error) => context.logHandlerError(`cloud artifact ${shortSessionId(sessionId)}`, error))
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'session.status') {
     const statusType = payloadString(payload, 'statusType')
     dispatchCloudRuntimeEvent({
@@ -243,12 +257,14 @@ function dispatchCloudWorkspaceSessionEvent(
         ? { type: 'busy' }
         : { type: 'done', synthetic: true },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'session.aborted' || event.type === 'session.idle') {
     dispatchCloudRuntimeEvent({
       type: 'done',
       sessionId,
       data: { type: 'done', synthetic: true },
     })
+    shouldRefreshCloudProjection = true
   } else if (event.type === 'runtime.error') {
     dispatchCloudRuntimeEvent({
       type: 'error',
@@ -263,7 +279,9 @@ function dispatchCloudWorkspaceSessionEvent(
       sessionId,
       data: { type: 'done', synthetic: true },
     })
+    shouldRefreshCloudProjection = true
   }
+  if (shouldRefreshCloudProjection) publishCloudProjection()
 }
 
 function resolvePromptModel(

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -1,5 +1,6 @@
 import type { IpcHandlerContext } from './context.ts'
 import type { SessionChangeSummary } from '@open-cowork/shared'
+import type { IpcMainInvokeEvent } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { getEffectiveSettings, getProviderCredentialValue } from '../settings.ts'
 import { getProviderDescriptor } from '../config-loader.ts'
@@ -32,6 +33,8 @@ import { registerSessionFileHandlers } from './session-file-handlers.ts'
 import { registerSessionInteractionHandlers } from './session-interaction-handlers.ts'
 import { registerIpcInvoke, sessionPromptArgs, stringAndObjectArgs } from './schema.ts'
 import { sdkErrorMessage } from '../sdk-error.ts'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
+import type { CloudTransportSessionEvent } from '../cloud/transport-adapter.ts'
 import {
   normalizeComposerPreferences,
   normalizePromptAgent,
@@ -45,6 +48,223 @@ type PromptAttachment = ReturnType<typeof normalizePromptAttachments>[number]
 type PromptPart =
   | { type: 'file'; mime: string; url: string; filename?: string }
   | { type: 'text'; text: string }
+
+function payloadString(payload: Record<string, unknown>, key: string) {
+  const value = payload[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function payloadRecord(payload: Record<string, unknown>, key: string) {
+  const value = payload[key]
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function payloadQuestionTool(payload: Record<string, unknown>) {
+  const value = payload.tool
+  if (typeof value === 'string') return value
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const tool = value as Record<string, unknown>
+  return {
+    messageId: typeof tool.messageId === 'string' ? tool.messageId : typeof tool.messageID === 'string' ? tool.messageID : '',
+    callId: typeof tool.callId === 'string' ? tool.callId : typeof tool.callID === 'string' ? tool.callID : '',
+  }
+}
+
+function dispatchCloudWorkspaceSessionEvent(
+  context: IpcHandlerContext,
+  event: CloudTransportSessionEvent,
+  sourceEvent?: IpcMainInvokeEvent,
+  workspaceId?: string | null,
+) {
+  const sessionId = event.sessionId
+  if (!sessionId) return
+  const win = context.getMainWindow()
+  if (!win || win.isDestroyed()) return
+  const payload = event.payload || {}
+  const eventAt = event.sequence || Date.now()
+  const dispatchCloudRuntimeEvent = (runtimeEvent: Parameters<typeof dispatchRuntimeSessionEvent>[1]) => {
+    dispatchRuntimeSessionEvent(win, {
+      ...runtimeEvent,
+      workspaceId: workspaceId || undefined,
+    })
+  }
+  if (event.type === 'prompt.submitted') {
+    const messageId = payloadString(payload, 'messageId') || `${sessionId}:${event.sequence}:cloud-user`
+    dispatchCloudRuntimeEvent({
+      type: 'text',
+      sessionId,
+      data: {
+        type: 'text',
+        role: 'user',
+        content: payloadString(payload, 'text'),
+        mode: 'replace',
+        messageId,
+        partId: `${messageId}:text`,
+        eventAt,
+      },
+    })
+    dispatchCloudRuntimeEvent({
+      type: 'busy',
+      sessionId,
+      data: { type: 'busy' },
+    })
+  } else if (event.type === 'assistant.message') {
+    const messageId = payloadString(payload, 'messageId') || `${sessionId}:${event.sequence}:cloud-assistant`
+    dispatchCloudRuntimeEvent({
+      type: 'text',
+      sessionId,
+      data: {
+        type: 'text',
+        role: 'assistant',
+        content: payloadString(payload, 'content'),
+        mode: 'replace',
+        messageId,
+        partId: `${messageId}:text`,
+        eventAt,
+      },
+    })
+    dispatchCloudRuntimeEvent({
+      type: 'done',
+      sessionId,
+      data: { type: 'done', synthetic: true },
+    })
+  } else if (event.type === 'tool.call') {
+    dispatchCloudRuntimeEvent({
+      type: 'tool_call',
+      sessionId,
+      data: {
+        type: 'tool_call',
+        id: payloadString(payload, 'id') || payloadString(payload, 'callId') || `${sessionId}:tool:${event.sequence}`,
+        name: payloadString(payload, 'name') || payloadString(payload, 'tool') || 'tool',
+        input: payloadRecord(payload, 'input'),
+        status: payloadString(payload, 'status') || 'running',
+        output: payload.output,
+        agent: payloadString(payload, 'agent') || null,
+        taskRunId: payloadString(payload, 'taskRunId') || null,
+        sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
+      },
+    })
+  } else if (event.type === 'task.run') {
+    dispatchCloudRuntimeEvent({
+      type: 'task_run',
+      sessionId,
+      data: {
+        type: 'task_run',
+        id: payloadString(payload, 'taskRunId') || payloadString(payload, 'id') || `${sessionId}:task:${event.sequence}`,
+        title: payloadString(payload, 'title') || 'Task',
+        agent: payloadString(payload, 'agent') || null,
+        status: payloadString(payload, 'status') || 'queued',
+        sourceSessionId: payloadString(payload, 'sourceSessionId') || null,
+        parentSessionId: payloadString(payload, 'parentSessionId') || null,
+        startedAt: payloadString(payload, 'startedAt') || null,
+        finishedAt: payloadString(payload, 'finishedAt') || null,
+      },
+    })
+  } else if (event.type === 'permission.requested') {
+    const permissionId = payloadString(payload, 'permissionId') || payloadString(payload, 'id') || `${sessionId}:permission:${event.sequence}`
+    dispatchCloudRuntimeEvent({
+      type: 'approval',
+      sessionId,
+      data: {
+        type: 'approval',
+        id: permissionId,
+        taskRunId: payloadString(payload, 'taskRunId') || null,
+        tool: payloadString(payload, 'tool') || 'permission',
+        input: payloadRecord(payload, 'input'),
+        description: payloadString(payload, 'description') || payloadString(payload, 'tool') || 'Permission requested',
+        sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
+      },
+    })
+  } else if (event.type === 'permission.resolved') {
+    dispatchCloudRuntimeEvent({
+      type: 'approval_resolved',
+      sessionId,
+      data: {
+        type: 'approval_resolved',
+        id: payloadString(payload, 'permissionId') || payloadString(payload, 'id'),
+      },
+    })
+  } else if (event.type === 'question.asked') {
+    dispatchCloudRuntimeEvent({
+      type: 'question_asked',
+      sessionId,
+      data: {
+        type: 'question_asked',
+        id: payloadString(payload, 'requestId') || payloadString(payload, 'id') || `${sessionId}:question:${event.sequence}`,
+        questions: Array.isArray(payload.questions) ? payload.questions as NonNullable<Parameters<typeof dispatchRuntimeSessionEvent>[1]['data']>['questions'] : [],
+        tool: payloadQuestionTool(payload),
+        sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
+      },
+    })
+  } else if (event.type === 'question.resolved') {
+    dispatchCloudRuntimeEvent({
+      type: 'question_resolved',
+      sessionId,
+      data: {
+        type: 'question_resolved',
+        id: payloadString(payload, 'requestId') || payloadString(payload, 'id'),
+        sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
+      },
+    })
+  } else if (event.type === 'todos.updated') {
+    dispatchCloudRuntimeEvent({
+      type: 'todos',
+      sessionId,
+      data: {
+        type: 'todos',
+        todos: Array.isArray(payload.todos) ? payload.todos as NonNullable<Parameters<typeof dispatchRuntimeSessionEvent>[1]['data']>['todos'] : [],
+      },
+    })
+  } else if (event.type === 'cost.updated') {
+    dispatchCloudRuntimeEvent({
+      type: 'cost',
+      sessionId,
+      data: {
+        type: 'cost',
+        id: payloadString(payload, 'id') || `${sessionId}:cost:${event.sequence}`,
+        cost: typeof payload.cost === 'number' ? payload.cost : 0,
+        tokens: payloadRecord(payload, 'tokens') as NonNullable<Parameters<typeof dispatchRuntimeSessionEvent>[1]['data']>['tokens'],
+        taskRunId: payloadString(payload, 'taskRunId') || null,
+        sourceSessionId: payloadString(payload, 'sourceSessionId') || sessionId,
+      },
+    })
+  } else if (event.type === 'artifact.created') {
+    void context.workspaceGateway.getCloudSessionView(sourceEvent, sessionId, workspaceId)
+      .then((view) => {
+        if (!win.isDestroyed()) win.webContents.send('session:view', { sessionId, workspaceId: workspaceId || undefined, view })
+      })
+      .catch((error) => context.logHandlerError(`cloud artifact ${shortSessionId(sessionId)}`, error))
+  } else if (event.type === 'session.status') {
+    const statusType = payloadString(payload, 'statusType')
+    dispatchCloudRuntimeEvent({
+      type: statusType === 'busy' || statusType === 'running' ? 'busy' : 'done',
+      sessionId,
+      data: statusType === 'busy' || statusType === 'running'
+        ? { type: 'busy' }
+        : { type: 'done', synthetic: true },
+    })
+  } else if (event.type === 'session.aborted' || event.type === 'session.idle') {
+    dispatchCloudRuntimeEvent({
+      type: 'done',
+      sessionId,
+      data: { type: 'done', synthetic: true },
+    })
+  } else if (event.type === 'runtime.error') {
+    dispatchCloudRuntimeEvent({
+      type: 'error',
+      sessionId,
+      data: {
+        type: 'error',
+        message: payloadString(payload, 'message') || 'Cloud runtime command failed.',
+      },
+    })
+    dispatchCloudRuntimeEvent({
+      type: 'done',
+      sessionId,
+      data: { type: 'done', synthetic: true },
+    })
+  }
+}
 
 function resolvePromptModel(
   settings: ReturnType<typeof getEffectiveSettings>,
@@ -223,7 +443,14 @@ async function assertSelectedProviderReadyForPrompt(
 }
 
 export function registerSessionHandlers(context: IpcHandlerContext) {
-  context.ipcMain.handle('session:create', async (_event, directory?: string) => {
+  context.ipcMain.handle('session:create', async (event, directory?: string, options?: unknown) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      if (typeof directory === 'string' && directory.trim()) {
+        throw new Error('Local project directories are not available in Cloud workspaces.')
+      }
+      return context.workspaceGateway.createCloudSession(event, workspaceId)
+    }
     const opencodeDirectory = context.normalizeDirectory(directory)
     await ensureRuntimeContextDirectory(opencodeDirectory)
     const client = getClientForDirectory(opencodeDirectory)
@@ -261,10 +488,19 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
         })
   })
 
-  registerIpcInvoke(context, 'session:prompt', sessionPromptArgs(), async (_event, sessionId, text, attachments, agent, options) => {
+  registerIpcInvoke(context, 'session:prompt', sessionPromptArgs(), async (event, sessionId, text, attachments, agent, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
     const promptText = normalizePromptText(text)
     const promptAttachments = normalizePromptAttachments(attachments)
     const requestedAgent = normalizePromptAgent(agent)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      await context.workspaceGateway.promptCloudSession(event, sessionId, {
+        text: promptText,
+        attachments: promptAttachments,
+        agent: requestedAgent,
+      }, workspaceId)
+      return
+    }
     const promptOptions = normalizePromptOptions(options)
     const { client, record } = await context.getSessionClient(sessionId)
     const settings = getEffectiveSettings()
@@ -354,8 +590,17 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:activate', async (_event, sessionIdInput: unknown, options?: { force?: boolean }) => {
+  context.ipcMain.handle('session:activate', async (event, sessionIdInput: unknown, options?: { force?: boolean; workspaceId?: string }) => {
+    const workspaceId = readWorkspaceIdOption(options)
     const sessionId = normalizeSessionId(sessionIdInput)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      await context.workspaceGateway.subscribeCloudSessionEvents(event, sessionId, {
+        workspaceId,
+        onEvent: (cloudEvent) => dispatchCloudWorkspaceSessionEvent(context, cloudEvent, event, workspaceId),
+        onError: (error) => context.logHandlerError(`cloud session:events ${shortSessionId(sessionId)}`, error),
+      })
+      return context.workspaceGateway.getCloudSessionView(event, sessionId, workspaceId)
+    }
     try {
       const shouldRetryFullHydration = !options?.force && isSessionPartiallyHydrated(sessionId)
       const progressive = !options?.force && (
@@ -405,7 +650,11 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:list', async () => {
+  context.ipcMain.handle('session:list', async (event, options?: unknown) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.listCloudSessions(event, workspaceId)
+    }
     return listSessionRecords().map(toRendererSession)
   })
 
@@ -425,8 +674,12 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     return record ? toRendererSession(record) : null
   })
 
-  context.ipcMain.handle('session:get', async (_event, idInput: unknown) => {
+  context.ipcMain.handle('session:get', async (event, idInput: unknown, options?: unknown) => {
+    const workspaceId = readWorkspaceIdOption(options)
     const id = normalizeSessionId(idInput)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.getCloudSessionInfo(event, id, workspaceId)
+    }
     const record = context.ensureSessionRecord(id)
     if (!record) return null
     try {
@@ -450,8 +703,13 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('session:abort', async (_event, sessionIdInput: unknown) => {
+  context.ipcMain.handle('session:abort', async (event, sessionIdInput: unknown, options?: unknown) => {
     const sessionId = normalizeSessionId(sessionIdInput)
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      await context.workspaceGateway.abortCloudSession(event, sessionId, workspaceId)
+      return
+    }
     const { client } = await context.getSessionClient(sessionId)
     log('session', `Aborting ${shortSessionId(sessionId)}`)
     stopSessionStatusReconciliation(sessionId)

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -612,12 +612,13 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
     const workspaceId = readWorkspaceIdOption(options)
     const sessionId = normalizeSessionId(sessionIdInput)
     if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      const cloudWorkspaceId = workspaceId || context.workspaceGateway.activeWorkspaceId(event)
       await context.workspaceGateway.subscribeCloudSessionEvents(event, sessionId, {
-        workspaceId,
-        onEvent: (cloudEvent) => dispatchCloudWorkspaceSessionEvent(context, cloudEvent, event, workspaceId),
+        workspaceId: cloudWorkspaceId,
+        onEvent: (cloudEvent) => dispatchCloudWorkspaceSessionEvent(context, cloudEvent, event, cloudWorkspaceId),
         onError: (error) => context.logHandlerError(`cloud session:events ${shortSessionId(sessionId)}`, error),
       })
-      return context.workspaceGateway.getCloudSessionView(event, sessionId, workspaceId)
+      return context.workspaceGateway.getCloudSessionView(event, sessionId, cloudWorkspaceId)
     }
     try {
       const shouldRetryFullHydration = !options?.force && isSessionPartiallyHydrated(sessionId)

--- a/apps/desktop/src/main/ipc/session-interaction-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-interaction-handlers.ts
@@ -1,4 +1,5 @@
 import type { IpcHandlerContext } from './context.ts'
+import type { IpcMainInvokeEvent } from 'electron'
 import { normalizeSessionId } from './session-handler-validation.ts'
 import { normalizeQuestionAnswers, normalizeQuestionRequestId } from '../question-normalization.ts'
 import { clearPermission, getPermissionSession } from '../permission-tracker.ts'
@@ -6,6 +7,25 @@ import { dispatchRuntimeSessionEvent } from '../session-event-dispatcher.ts'
 import { sessionEngine } from '../session-engine.ts'
 import { startSessionStatusReconciliation } from '../session-status-reconciler.ts'
 import { log } from '../logger.ts'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
+
+async function publishCloudSessionView(
+  context: IpcHandlerContext,
+  event: IpcMainInvokeEvent,
+  sessionId: string,
+  workspaceId?: string | null,
+) {
+  const win = context.getMainWindow()
+  if (!win || win.isDestroyed()) return
+  const view = await context.workspaceGateway.getCloudSessionView(event, sessionId, workspaceId)
+  if (!win.isDestroyed()) {
+    win.webContents.send('session:view', {
+      sessionId,
+      workspaceId: workspaceId || undefined,
+      view,
+    })
+  }
+}
 
 function resolveQuestionLocally(context: IpcHandlerContext, sessionId: string, requestId: string) {
   const win = context.getMainWindow()
@@ -25,7 +45,16 @@ export function registerSessionInteractionHandlers(context: IpcHandlerContext) {
     permissionId: string,
     allowed: boolean,
     explicitSessionId?: string | null,
+    optionsInput?: unknown,
   ) => {
+    const workspaceId = readWorkspaceIdOption(optionsInput)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      const sessionId = normalizeSessionId(explicitSessionId)
+      await context.workspaceGateway.respondCloudPermission(_event, sessionId, permissionId, allowed, workspaceId)
+      await publishCloudSessionView(context, _event, sessionId, workspaceId)
+      return
+    }
+
     const sessionId = explicitSessionId || getPermissionSession(permissionId)
     if (!sessionId) throw new Error(`No session for permission ${permissionId}`)
     const { client } = await context.getSessionV2Client(sessionId)
@@ -49,10 +78,17 @@ export function registerSessionInteractionHandlers(context: IpcHandlerContext) {
     }
   })
 
-  context.ipcMain.handle('question:reply', async (_event, sessionIdInput: unknown, requestIdInput: unknown, answersInput: unknown) => {
+  context.ipcMain.handle('question:reply', async (_event, sessionIdInput: unknown, requestIdInput: unknown, answersInput: unknown, optionsInput?: unknown) => {
     const sessionId = normalizeSessionId(sessionIdInput)
     const requestId = normalizeQuestionRequestId(requestIdInput)
     const answers = normalizeQuestionAnswers(answersInput)
+    const workspaceId = readWorkspaceIdOption(optionsInput)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      await context.workspaceGateway.replyCloudQuestion(_event, sessionId, requestId, answers, workspaceId)
+      await publishCloudSessionView(context, _event, sessionId, workspaceId)
+      return
+    }
+
     const { client } = await context.getSessionV2Client(sessionId)
     await client.question.reply({
       requestID: requestId,
@@ -67,9 +103,16 @@ export function registerSessionInteractionHandlers(context: IpcHandlerContext) {
     })
   })
 
-  context.ipcMain.handle('question:reject', async (_event, sessionIdInput: unknown, requestIdInput: unknown) => {
+  context.ipcMain.handle('question:reject', async (_event, sessionIdInput: unknown, requestIdInput: unknown, optionsInput?: unknown) => {
     const sessionId = normalizeSessionId(sessionIdInput)
     const requestId = normalizeQuestionRequestId(requestIdInput)
+    const workspaceId = readWorkspaceIdOption(optionsInput)
+    if (!context.workspaceGateway.isLocalWorkspace(_event, workspaceId)) {
+      await context.workspaceGateway.rejectCloudQuestion(_event, sessionId, requestId, workspaceId)
+      await publishCloudSessionView(context, _event, sessionId, workspaceId)
+      return
+    }
+
     const { client } = await context.getSessionV2Client(sessionId)
     await client.question.reject({
       requestID: requestId,

--- a/apps/desktop/src/main/ipc/thread-handlers.ts
+++ b/apps/desktop/src/main/ipc/thread-handlers.ts
@@ -6,10 +6,19 @@ import {
   type ThreadSearchQuery,
   type ThreadSmartFilterInput,
   type ThreadTagInput,
+  type WorkspaceOptions,
+  type WorkspaceScoped,
 } from '@open-cowork/shared'
-import { objectArg, optionalObjectArg, registerIpcInvoke, stringAndObjectArgs } from './schema.ts'
+import {
+  objectAndOptionalObjectArgs,
+  optionalObjectArg,
+  registerIpcInvoke,
+  stringAndObjectAndOptionalObjectArgs,
+  stringAndOptionalObjectArgs,
+} from './schema.ts'
 import { validateThreadSearchQuery } from './object-validators.ts'
 import { normalizeSmartFilterInput, normalizeTagInput } from '../thread-index/thread-index-normalizers.ts'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
 function requireStringArray(value: unknown, label: string, max = THREAD_BULK_MAX_SESSION_IDS) {
   if (!Array.isArray(value)) throw new Error(`${label} must be an array.`)
@@ -22,60 +31,145 @@ function requireStringArray(value: unknown, label: string, max = THREAD_BULK_MAX
   })
 }
 
+function normalizeWorkspaceOptions(value: Record<string, unknown>): WorkspaceOptions {
+  const workspaceId = readWorkspaceIdOption(value)
+  return workspaceId ? { workspaceId } : {}
+}
+
+function validateThreadSearchWorkspaceQuery(record: Record<string, unknown>): WorkspaceScoped<ThreadSearchQuery> {
+  const workspaceId = readWorkspaceIdOption(record)
+  const query = validateThreadSearchQuery(record)
+  return workspaceId ? { ...query, workspaceId } : query
+}
+
+function workspaceIdFromOptions(options?: WorkspaceOptions | null) {
+  return readWorkspaceIdOption(options || undefined)
+}
+
 export function registerThreadHandlers(context: IpcHandlerContext) {
   const threads = () => getThreadIndexService()
 
-  registerIpcInvoke(context, 'threads:search', optionalObjectArg<ThreadSearchQuery>('thread search query', validateThreadSearchQuery), async (_event, query) => (
-    threads().search(query)
-  ))
+  registerIpcInvoke(context, 'threads:search', optionalObjectArg<WorkspaceScoped<ThreadSearchQuery>>('thread search query', validateThreadSearchWorkspaceQuery), async (event, query) => {
+    const workspaceId = workspaceIdFromOptions(query)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.searchCloudThreads(event, query, workspaceId)
+    }
+    return threads().search(query)
+  })
 
-  registerIpcInvoke(context, 'threads:facets', optionalObjectArg<ThreadSearchQuery>('thread facet query', validateThreadSearchQuery), async (_event, query) => (
-    threads().facets(query)
-  ))
+  registerIpcInvoke(context, 'threads:facets', optionalObjectArg<WorkspaceScoped<ThreadSearchQuery>>('thread facet query', validateThreadSearchWorkspaceQuery), async (event, query) => {
+    const workspaceId = workspaceIdFromOptions(query)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.cloudThreadFacets(event, query, workspaceId)
+    }
+    return threads().facets(query)
+  })
 
-  context.ipcMain.handle('threads:tags:list', async () => (
-    threads().listTags()
-  ))
+  registerIpcInvoke(context, 'threads:tags:list', optionalObjectArg<WorkspaceOptions>('workspace options', normalizeWorkspaceOptions), async (event, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.listCloudThreadTags(event, workspaceId)
+    }
+    return threads().listTags()
+  })
 
-  registerIpcInvoke(context, 'threads:tags:create', objectArg<ThreadTagInput>('thread tag input', (input) => normalizeTagInput(input as unknown as ThreadTagInput)), async (_event, input) => (
-    threads().createTag(input)
-  ))
+  registerIpcInvoke(context, 'threads:tags:create', objectAndOptionalObjectArgs<ThreadTagInput, WorkspaceOptions>(
+    'thread tag input',
+    'workspace options',
+    (input) => normalizeTagInput(input as unknown as ThreadTagInput),
+    normalizeWorkspaceOptions,
+  ), async (event, input, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.createCloudThreadTag(event, input, workspaceId)
+    }
+    return threads().createTag(input)
+  })
 
-  registerIpcInvoke(context, 'threads:tags:update', stringAndObjectArgs<ThreadTagInput>('thread tag id', 'thread tag input', {}, (input) => normalizeTagInput(input as unknown as ThreadTagInput)), async (_event, tagId, input) => (
-    threads().updateTag(tagId, input)
-  ))
+  registerIpcInvoke(context, 'threads:tags:update', stringAndObjectAndOptionalObjectArgs<ThreadTagInput, WorkspaceOptions>(
+    'thread tag id',
+    'thread tag input',
+    'workspace options',
+    {},
+    (input) => normalizeTagInput(input as unknown as ThreadTagInput),
+    normalizeWorkspaceOptions,
+  ), async (event, tagId, input, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.updateCloudThreadTag(event, tagId, input, workspaceId)
+    }
+    return threads().updateTag(tagId, input)
+  })
 
-  context.ipcMain.handle('threads:tags:delete', async (_event, tagId: unknown) => {
-    if (typeof tagId !== 'string') throw new Error('Tag id must be a string.')
+  registerIpcInvoke(context, 'threads:tags:delete', stringAndOptionalObjectArgs<WorkspaceOptions>('thread tag id', 'workspace options', {}, normalizeWorkspaceOptions), async (event, tagId, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.deleteCloudThreadTag(event, tagId, workspaceId)
+    }
     return threads().deleteTag(tagId)
   })
 
-  context.ipcMain.handle('threads:tags:apply', async (_event, sessionIds: unknown, tagIds: unknown) => {
+  context.ipcMain.handle('threads:tags:apply', async (event, sessionIds: unknown, tagIds: unknown, options?: unknown) => {
     const normalizedSessionIds = requireStringArray(sessionIds, 'sessionIds')
     const normalizedTagIds = requireStringArray(tagIds, 'tagIds', THREAD_FILTER_MAX_VALUES)
+    const workspaceId = readWorkspaceIdOption(options || undefined)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.applyCloudThreadTags(event, normalizedSessionIds, normalizedTagIds, workspaceId)
+    }
     return threads().applyTags(normalizedSessionIds, normalizedTagIds)
   })
 
-  context.ipcMain.handle('threads:tags:remove', async (_event, sessionIds: unknown, tagIds: unknown) => {
+  context.ipcMain.handle('threads:tags:remove', async (event, sessionIds: unknown, tagIds: unknown, options?: unknown) => {
     const normalizedSessionIds = requireStringArray(sessionIds, 'sessionIds')
     const normalizedTagIds = requireStringArray(tagIds, 'tagIds', THREAD_FILTER_MAX_VALUES)
+    const workspaceId = readWorkspaceIdOption(options || undefined)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.removeCloudThreadTags(event, normalizedSessionIds, normalizedTagIds, workspaceId)
+    }
     return threads().removeTags(normalizedSessionIds, normalizedTagIds)
   })
 
-  context.ipcMain.handle('threads:smart-filters:list', async () => (
-    threads().listSmartFilters()
-  ))
+  registerIpcInvoke(context, 'threads:smart-filters:list', optionalObjectArg<WorkspaceOptions>('workspace options', normalizeWorkspaceOptions), async (event, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.listCloudThreadSmartFilters(event, workspaceId)
+    }
+    return threads().listSmartFilters()
+  })
 
-  registerIpcInvoke(context, 'threads:smart-filters:create', objectArg<ThreadSmartFilterInput>('smart filter input', (input) => normalizeSmartFilterInput(input as unknown as ThreadSmartFilterInput)), async (_event, input) => (
-    threads().createSmartFilter(input)
-  ))
+  registerIpcInvoke(context, 'threads:smart-filters:create', objectAndOptionalObjectArgs<ThreadSmartFilterInput, WorkspaceOptions>(
+    'smart filter input',
+    'workspace options',
+    (input) => normalizeSmartFilterInput(input as unknown as ThreadSmartFilterInput),
+    normalizeWorkspaceOptions,
+  ), async (event, input, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.createCloudThreadSmartFilter(event, input, workspaceId)
+    }
+    return threads().createSmartFilter(input)
+  })
 
-  registerIpcInvoke(context, 'threads:smart-filters:update', stringAndObjectArgs<ThreadSmartFilterInput>('smart filter id', 'smart filter input', {}, (input) => normalizeSmartFilterInput(input as unknown as ThreadSmartFilterInput)), async (_event, filterId, input) => (
-    threads().updateSmartFilter(filterId, input)
-  ))
+  registerIpcInvoke(context, 'threads:smart-filters:update', stringAndObjectAndOptionalObjectArgs<ThreadSmartFilterInput, WorkspaceOptions>(
+    'smart filter id',
+    'smart filter input',
+    'workspace options',
+    {},
+    (input) => normalizeSmartFilterInput(input as unknown as ThreadSmartFilterInput),
+    normalizeWorkspaceOptions,
+  ), async (event, filterId, input, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.updateCloudThreadSmartFilter(event, filterId, input, workspaceId)
+    }
+    return threads().updateSmartFilter(filterId, input)
+  })
 
-  context.ipcMain.handle('threads:smart-filters:delete', async (_event, filterId: unknown) => {
-    if (typeof filterId !== 'string') throw new Error('Smart filter id must be a string.')
+  registerIpcInvoke(context, 'threads:smart-filters:delete', stringAndOptionalObjectArgs<WorkspaceOptions>('smart filter id', 'workspace options', {}, normalizeWorkspaceOptions), async (event, filterId, options) => {
+    const workspaceId = workspaceIdFromOptions(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.deleteCloudThreadSmartFilter(event, filterId, workspaceId)
+    }
     return threads().deleteSmartFilter(filterId)
   })
 

--- a/apps/desktop/src/main/ipc/workflow-handlers.ts
+++ b/apps/desktop/src/main/ipc/workflow-handlers.ts
@@ -1,5 +1,12 @@
 import type { IpcHandlerContext } from './context.ts'
-import { noIpcArgs, optionalStringArg, registerIpcInvoke, stringArg } from './schema.ts'
+import type { WorkspaceOptions } from '@open-cowork/shared'
+import {
+  optionalObjectArg,
+  optionalStringArg,
+  registerIpcInvoke,
+  stringAndOptionalObjectArgs,
+  stringArg,
+} from './schema.ts'
 import {
   archiveWorkflow,
   getWorkflowDetail,
@@ -10,6 +17,7 @@ import {
   runWorkflowNow,
   startWorkflowDraft,
 } from '../workflow/workflow-service.ts'
+import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
 function assertWorkflowId(value: unknown) {
   if (typeof value !== 'string' || !value.trim() || value.length > 256) {
@@ -26,36 +34,67 @@ function resolveOptionalDirectory(context: IpcHandlerContext, value: unknown) {
   return context.resolveGrantedProjectDirectory(trimmed)
 }
 
+function normalizeWorkspaceOptions(value: Record<string, unknown>): WorkspaceOptions {
+  const workspaceId = readWorkspaceIdOption(value)
+  return workspaceId ? { workspaceId } : {}
+}
+
 export function registerWorkflowHandlers(context: IpcHandlerContext) {
-  registerIpcInvoke(context, 'workflows:list', noIpcArgs, async () => {
+  registerIpcInvoke(context, 'workflows:list', optionalObjectArg<WorkspaceOptions>('workspace options', normalizeWorkspaceOptions), async (event, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.listCloudWorkflows(event, workspaceId)
+    }
     return listWorkflows()
   })
 
-  registerIpcInvoke(context, 'workflows:get', stringArg('workflow id'), async (_event, workflowId) => {
+  registerIpcInvoke(context, 'workflows:get', stringAndOptionalObjectArgs<WorkspaceOptions>('workflow id', 'workspace options', {}, normalizeWorkspaceOptions), async (event, workflowId, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.getCloudWorkflow(event, assertWorkflowId(workflowId), workspaceId)
+    }
     return getWorkflowDetail(assertWorkflowId(workflowId))
   })
 
-  registerIpcInvoke(context, 'workflows:start-draft', optionalStringArg('workflow directory'), async (_event, directory) => {
+  registerIpcInvoke(context, 'workflows:start-draft', optionalStringArg('workflow directory'), async (event, directory) => {
+    context.workspaceGateway.assertLocalWorkspace(event)
     return startWorkflowDraft(resolveOptionalDirectory(context, directory))
   })
 
-  registerIpcInvoke(context, 'workflows:run-now', stringArg('workflow id'), async (_event, workflowId) => {
+  registerIpcInvoke(context, 'workflows:run-now', stringAndOptionalObjectArgs<WorkspaceOptions>('workflow id', 'workspace options', {}, normalizeWorkspaceOptions), async (event, workflowId, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.runCloudWorkflow(event, assertWorkflowId(workflowId), workspaceId)
+    }
     return runWorkflowNow(assertWorkflowId(workflowId))
   })
 
-  registerIpcInvoke(context, 'workflows:pause', stringArg('workflow id'), async (_event, workflowId) => {
+  registerIpcInvoke(context, 'workflows:pause', stringAndOptionalObjectArgs<WorkspaceOptions>('workflow id', 'workspace options', {}, normalizeWorkspaceOptions), async (event, workflowId, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.pauseCloudWorkflow(event, assertWorkflowId(workflowId), workspaceId)
+    }
     return pauseWorkflow(assertWorkflowId(workflowId))
   })
 
-  registerIpcInvoke(context, 'workflows:resume', stringArg('workflow id'), async (_event, workflowId) => {
+  registerIpcInvoke(context, 'workflows:resume', stringAndOptionalObjectArgs<WorkspaceOptions>('workflow id', 'workspace options', {}, normalizeWorkspaceOptions), async (event, workflowId, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.resumeCloudWorkflow(event, assertWorkflowId(workflowId), workspaceId)
+    }
     return resumeWorkflow(assertWorkflowId(workflowId))
   })
 
-  registerIpcInvoke(context, 'workflows:archive', stringArg('workflow id'), async (_event, workflowId) => {
+  registerIpcInvoke(context, 'workflows:archive', stringAndOptionalObjectArgs<WorkspaceOptions>('workflow id', 'workspace options', {}, normalizeWorkspaceOptions), async (event, workflowId, options) => {
+    const workspaceId = readWorkspaceIdOption(options)
+    if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
+      return context.workspaceGateway.archiveCloudWorkflow(event, assertWorkflowId(workflowId), workspaceId)
+    }
     return archiveWorkflow(assertWorkflowId(workflowId))
   })
 
-  registerIpcInvoke(context, 'workflows:regenerate-webhook-secret', stringArg('workflow id'), async (_event, workflowId) => {
+  registerIpcInvoke(context, 'workflows:regenerate-webhook-secret', stringArg('workflow id'), async (event, workflowId) => {
+    context.workspaceGateway.assertLocalWorkspace(event)
     return regenerateWebhookSecret(assertWorkflowId(workflowId))
   })
 }

--- a/apps/desktop/src/main/ipc/workspace-handlers.ts
+++ b/apps/desktop/src/main/ipc/workspace-handlers.ts
@@ -1,0 +1,93 @@
+import type { AddCloudWorkspaceInput } from '@open-cowork/shared'
+import type { IpcMainInvokeEvent } from 'electron'
+import type { IpcHandlerContext } from './context.ts'
+import {
+  noIpcArgs,
+  objectArg,
+  optionalStringArg,
+  registerIpcInvoke,
+  stringArg,
+} from './schema.ts'
+
+async function subscribeWorkspaceUpdates(context: IpcHandlerContext, event: IpcMainInvokeEvent, workspaceId: string) {
+  const workspace = context.workspaceGateway.list(event).find((entry) => entry.id === workspaceId)
+  if (!workspace || workspace.kind !== 'cloud' || workspace.status !== 'online') return
+  await context.workspaceGateway.subscribeCloudWorkspaceEvents(event, {
+    workspaceId,
+    onEvent: (cloudEvent) => {
+      void context.workspaceGateway.listCloudSessions(event, workspaceId)
+        .then((sessions) => {
+          const sender = event.sender as { isDestroyed?: () => boolean, send?: (channel: string, payload: unknown) => void }
+          if (sender.isDestroyed?.()) return
+          sender.send?.('workspace:sessions-updated', {
+            workspaceId,
+            sessions,
+            lastEventSequence: Number.isFinite(cloudEvent.sequence) ? cloudEvent.sequence : null,
+            syncedAt: new Date().toISOString(),
+          })
+        })
+        .catch((error) => context.logHandlerError('workspace:sessions-updated', error))
+    },
+    onError: (error) => context.logHandlerError('workspace:events', error),
+  })
+}
+
+function validateAddCloudWorkspaceInput(value: Record<string, unknown>): AddCloudWorkspaceInput {
+  if (typeof value.baseUrl !== 'string' || !value.baseUrl.trim()) {
+    throw new Error('workspace:add-cloud requires baseUrl.')
+  }
+  const input: AddCloudWorkspaceInput = {
+    baseUrl: value.baseUrl.trim(),
+  }
+  if (value.label !== undefined && value.label !== null) {
+    if (typeof value.label !== 'string') throw new Error('workspace:add-cloud label must be a string.')
+    const label = value.label.trim()
+    if (label) input.label = label
+  }
+  return input
+}
+
+export function registerWorkspaceHandlers(context: IpcHandlerContext) {
+  registerIpcInvoke(context, 'workspace:list', noIpcArgs, async (event) => {
+    return context.workspaceGateway.list(event)
+  })
+
+  registerIpcInvoke(context, 'workspace:activate', stringArg('workspace id'), async (event, workspaceId) => {
+    const activated = context.workspaceGateway.activate(event, workspaceId)
+    await subscribeWorkspaceUpdates(context, event, activated.id)
+    return activated
+  })
+
+  registerIpcInvoke(context, 'workspace:add-cloud', objectArg<AddCloudWorkspaceInput>('cloud workspace input', validateAddCloudWorkspaceInput), async (event, input) => {
+    return context.workspaceGateway.addCloud(event, input)
+  })
+
+  registerIpcInvoke(context, 'workspace:remove', stringArg('workspace id'), async (event, workspaceId) => {
+    return context.workspaceGateway.remove(event, workspaceId)
+  })
+
+  registerIpcInvoke(context, 'workspace:login', stringArg('workspace id'), async (event, workspaceId) => {
+    const loggedIn = await context.workspaceGateway.login(event, workspaceId)
+    await subscribeWorkspaceUpdates(context, event, loggedIn.id)
+    return loggedIn
+  })
+
+  registerIpcInvoke(context, 'workspace:logout', stringArg('workspace id'), async (event, workspaceId) => {
+    return context.workspaceGateway.logout(event, workspaceId)
+  })
+
+  registerIpcInvoke(context, 'workspace:policy', optionalStringArg('workspace id'), async (event, workspaceId) => {
+    return context.workspaceGateway.cloudPolicy(event, workspaceId)
+  })
+
+  registerIpcInvoke(context, 'workspace:support', optionalStringArg('workspace id'), async (event, workspaceId) => {
+    return context.workspaceGateway.supportMatrix(event, workspaceId)
+  })
+
+  registerIpcInvoke(context, 'workspace:sync', optionalStringArg('workspace id'), async (event, workspaceId) => {
+    const result = await context.workspaceGateway.sync(event, workspaceId)
+    const activeWorkspaceId = workspaceId || context.workspaceGateway.activeWorkspaceId(event)
+    await subscribeWorkspaceUpdates(context, event, activeWorkspaceId)
+    return result
+  })
+}

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -209,6 +209,7 @@ export function publishSessionView(
   workspaceId?: string | null,
 ) {
   if (!win || win.isDestroyed() || !sessionId) return
+  if (workspaceId && workspaceId !== 'local') return
   incrementPerfCounter('session.view.published')
   win.webContents.send('session:view', {
     sessionId,

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -10,6 +10,7 @@ import { getSessionRecord } from './session-registry.ts'
 export type RuntimeSessionEvent = {
   type?: string
   sessionId?: string | null
+  workspaceId?: string | null
   data?: {
     type?: string
     content?: string
@@ -57,7 +58,7 @@ export type RuntimeSessionEvent = {
 
 type PendingViewFlush = {
   win: BrowserWindow
-  sessionIds: Set<string>
+  sessions: Map<string, { sessionId: string; workspaceId?: string | null }>
   queuedAt: number
   timer: ReturnType<typeof setTimeout> | null
 }
@@ -85,8 +86,16 @@ const historyRefreshQueue = new Map<string, {
   promise: Promise<void>
 }>()
 
+function sessionFlushKey(sessionId: string, workspaceId?: string | null) {
+  return `${workspaceId || 'local'}:${sessionId}`
+}
+
 function getEventType(event: RuntimeSessionEvent) {
   return String(event.data?.type || event.type || '')
+}
+
+function workspacePatch(workspaceId?: string | null) {
+  return workspaceId ? { workspaceId } : {}
 }
 
 export function shouldPublishSessionView(event: RuntimeSessionEvent) {
@@ -109,6 +118,7 @@ export function getSessionPatch(event: RuntimeSessionEvent): SessionPatch | null
     return {
       type: isReasoning ? 'task_reasoning' : 'task_text',
       sessionId: event.sessionId,
+      ...workspacePatch(event.workspaceId),
       taskRunId: event.data.taskRunId,
       segmentId: typeof event.data.partId === 'string' && event.data.partId
         ? event.data.partId
@@ -133,6 +143,7 @@ export function getSessionPatch(event: RuntimeSessionEvent): SessionPatch | null
     return {
       type: 'message_reasoning',
       sessionId: event.sessionId,
+      ...workspacePatch(event.workspaceId),
       messageId,
       segmentId,
       content,
@@ -144,6 +155,7 @@ export function getSessionPatch(event: RuntimeSessionEvent): SessionPatch | null
   return {
     type: 'message_text',
     sessionId: event.sessionId,
+    ...workspacePatch(event.workspaceId),
     messageId,
     segmentId,
     content,
@@ -160,6 +172,7 @@ export function getRuntimeNotification(event: RuntimeSessionEvent): RuntimeNotif
     return {
       type: 'done',
       sessionId: event.sessionId || null,
+      ...workspacePatch(event.workspaceId),
       synthetic: Boolean(event.data?.synthetic),
     }
   }
@@ -167,6 +180,7 @@ export function getRuntimeNotification(event: RuntimeSessionEvent): RuntimeNotif
     return {
       type: 'error',
       sessionId: null,
+      ...workspacePatch(event.workspaceId),
       message: typeof event.data?.message === 'string' ? event.data.message : 'An error occurred',
     }
   }
@@ -188,11 +202,16 @@ export function publishNotification(
   win.webContents.send('runtime:notification', notification)
 }
 
-export function publishSessionView(win: BrowserWindow | null | undefined, sessionId: string | null | undefined) {
+export function publishSessionView(
+  win: BrowserWindow | null | undefined,
+  sessionId: string | null | undefined,
+  workspaceId?: string | null,
+) {
   if (!win || win.isDestroyed() || !sessionId) return
   incrementPerfCounter('session.view.published')
   win.webContents.send('session:view', {
     sessionId,
+    workspaceId: workspaceId || undefined,
     view: sessionEngine.getSessionView(sessionId),
   })
 }
@@ -221,45 +240,47 @@ export function publishSessionPatch(
   win.webContents.send('session:patch', patch)
 }
 
-function markSessionPatchViewRecovery(windowId: number, sessionId: string) {
+function markSessionPatchViewRecovery(windowId: number, sessionId: string, workspaceId?: string | null) {
   const existing = patchViewRecoverySessionIdsByWindowId.get(windowId)
+  const key = sessionFlushKey(sessionId, workspaceId)
   if (existing) {
-    existing.add(sessionId)
+    existing.add(key)
     return
   }
-  patchViewRecoverySessionIdsByWindowId.set(windowId, new Set([sessionId]))
+  patchViewRecoverySessionIdsByWindowId.set(windowId, new Set([key]))
 }
 
-function clearSessionPatchViewRecovery(windowId: number, sessionId: string) {
+function clearSessionPatchViewRecovery(windowId: number, sessionId: string, workspaceId?: string | null) {
   const existing = patchViewRecoverySessionIdsByWindowId.get(windowId)
   if (!existing) return
-  existing.delete(sessionId)
+  existing.delete(sessionFlushKey(sessionId, workspaceId))
   if (existing.size === 0) patchViewRecoverySessionIdsByWindowId.delete(windowId)
 }
 
-function sessionNeedsPatchViewRecovery(windowId: number, sessionId: string) {
-  return patchViewRecoverySessionIdsByWindowId.get(windowId)?.has(sessionId) === true
+function sessionNeedsPatchViewRecovery(windowId: number, sessionId: string, workspaceId?: string | null) {
+  return patchViewRecoverySessionIdsByWindowId.get(windowId)?.has(sessionFlushKey(sessionId, workspaceId)) === true
 }
 
-function dropQueuedSessionPatches(pending: PendingPatchFlush, sessionId: string) {
+function dropQueuedSessionPatches(pending: PendingPatchFlush, sessionId: string, workspaceId?: string | null) {
+  const key = sessionFlushKey(sessionId, workspaceId)
   const before = pending.patches.length
-  pending.patches = pending.patches.filter((queuedPatch) => queuedPatch.sessionId !== sessionId)
+  pending.patches = pending.patches.filter((queuedPatch) => sessionFlushKey(queuedPatch.sessionId, queuedPatch.workspaceId) !== key)
   return before - pending.patches.length
 }
 
-function recoverSessionWithViewOnlyCatchUp(windowId: number, sessionId: string, pending?: PendingPatchFlush) {
-  markSessionPatchViewRecovery(windowId, sessionId)
+function recoverSessionWithViewOnlyCatchUp(windowId: number, sessionId: string, workspaceId?: string | null, pending?: PendingPatchFlush) {
+  markSessionPatchViewRecovery(windowId, sessionId, workspaceId)
   if (!pending) return
-  const dropped = dropQueuedSessionPatches(pending, sessionId)
+  const dropped = dropQueuedSessionPatches(pending, sessionId, workspaceId)
   if (dropped > 0) pending.droppedPatches += dropped
-  pending.overflowSessionIds.add(sessionId)
+  pending.overflowSessionIds.add(sessionFlushKey(sessionId, workspaceId))
 }
 
-function sessionHasQueuedView(windowId: number, sessionId: string) {
-  return pendingViewFlushByWindowId.get(windowId)?.sessionIds.has(sessionId) === true
+function sessionHasQueuedView(windowId: number, sessionId: string, workspaceId?: string | null) {
+  return pendingViewFlushByWindowId.get(windowId)?.sessions.has(sessionFlushKey(sessionId, workspaceId)) === true
 }
 
-function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: string) {
+function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: string, workspaceId?: string | null) {
   const webContents = win.webContents as BrowserWindow['webContents'] & { isDestroyed?: () => boolean }
   if (win.isDestroyed() || webContents.isDestroyed?.()) return
   const windowId = webContents.id
@@ -267,8 +288,9 @@ function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: stri
   if (!pending || pending.patches.length === 0) return
 
   const queuedForSession: SessionPatch[] = []
+  const key = sessionFlushKey(sessionId, workspaceId)
   pending.patches = pending.patches.filter((patch) => {
-    if (patch.sessionId !== sessionId) return true
+    if (sessionFlushKey(patch.sessionId, patch.workspaceId) !== key) return true
     queuedForSession.push(patch)
     return false
   })
@@ -324,7 +346,7 @@ function flushPendingSessionPatches(windowId: number) {
 function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null | undefined) {
   if (!patch) return
   const windowId = win.webContents.id
-  if (sessionNeedsPatchViewRecovery(windowId, patch.sessionId)) {
+  if (sessionNeedsPatchViewRecovery(windowId, patch.sessionId, patch.workspaceId)) {
     let pending = pendingPatchFlushByWindowId.get(windowId)
     if (!pending) {
       pending = {
@@ -341,11 +363,11 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
       pendingPatchFlushByWindowId.set(windowId, pending)
     }
     pending.droppedPatches += 1
-    pending.overflowSessionIds.add(patch.sessionId)
+    pending.overflowSessionIds.add(sessionFlushKey(patch.sessionId, patch.workspaceId))
     return
   }
 
-  if (sessionHasQueuedView(windowId, patch.sessionId)) {
+  if (sessionHasQueuedView(windowId, patch.sessionId, patch.workspaceId)) {
     publishSessionPatch(win, patch)
     return
   }
@@ -367,9 +389,9 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
   }
 
   if (pending.patches.length >= MAX_PENDING_SESSION_PATCHES_PER_WINDOW) {
-    recoverSessionWithViewOnlyCatchUp(windowId, patch.sessionId, pending)
+    recoverSessionWithViewOnlyCatchUp(windowId, patch.sessionId, patch.workspaceId, pending)
     pending.droppedPatches += 1
-    queueSessionViewPublish(win, patch.sessionId)
+    queueSessionViewPublish(win, patch.sessionId, patch.workspaceId)
     return
   }
 
@@ -381,44 +403,45 @@ function flushPendingSessionViews(windowId: number) {
   if (!pending) return
   pendingViewFlushByWindowId.delete(windowId)
   if (pending.win.isDestroyed()) {
-    for (const sessionId of pending.sessionIds) clearSessionPatchViewRecovery(windowId, sessionId)
+    for (const entry of pending.sessions.values()) clearSessionPatchViewRecovery(windowId, entry.sessionId, entry.workspaceId)
     return
   }
   incrementPerfCounter('session.view.flushes')
   observePerf('session.view.flush.wait', Date.now() - pending.queuedAt, {
     unit: 'ms',
   })
-  observePerf('session.view.flush.batch_size', pending.sessionIds.size, {
+  observePerf('session.view.flush.batch_size', pending.sessions.size, {
     unit: 'count',
   })
   measurePerf('session.view.flush.duration', () => {
-    for (const sessionId of pending.sessionIds) {
-      publishSessionView(pending.win, sessionId)
-      clearSessionPatchViewRecovery(windowId, sessionId)
+    for (const entry of pending.sessions.values()) {
+      publishSessionView(pending.win, entry.sessionId, entry.workspaceId)
+      clearSessionPatchViewRecovery(windowId, entry.sessionId, entry.workspaceId)
     }
   }, {
     slowThresholdMs: 8,
     slowData: {
       windowId,
-      sessionCount: pending.sessionIds.size,
+      sessionCount: pending.sessions.size,
     },
   })
 }
 
-function queueSessionViewPublish(win: BrowserWindow, sessionId: string) {
+function queueSessionViewPublish(win: BrowserWindow, sessionId: string, workspaceId?: string | null) {
   const windowId = win.webContents.id
-  if (!sessionNeedsPatchViewRecovery(windowId, sessionId)) {
-    flushQueuedSessionPatchesBeforeView(win, sessionId)
+  if (!sessionNeedsPatchViewRecovery(windowId, sessionId, workspaceId)) {
+    flushQueuedSessionPatchesBeforeView(win, sessionId, workspaceId)
   }
+  const key = sessionFlushKey(sessionId, workspaceId)
   const existing = pendingViewFlushByWindowId.get(windowId)
   if (existing) {
-    existing.sessionIds.add(sessionId)
+    existing.sessions.set(key, { sessionId, workspaceId })
     return
   }
 
   const pending: PendingViewFlush = {
     win,
-    sessionIds: new Set([sessionId]),
+    sessions: new Map([[key, { sessionId, workspaceId }]]),
     queuedAt: Date.now(),
     timer: null,
   }
@@ -485,20 +508,20 @@ function queueSessionHistoryRefresh(win: BrowserWindow, sessionId: string) {
 export function dropSessionFromDispatcherQueues(sessionId: string) {
   historyRefreshQueue.delete(sessionId)
   for (const [windowId, recoverySessionIds] of patchViewRecoverySessionIdsByWindowId.entries()) {
-    recoverySessionIds.delete(sessionId)
+    recoverySessionIds.delete(sessionFlushKey(sessionId))
     if (recoverySessionIds.size === 0) patchViewRecoverySessionIdsByWindowId.delete(windowId)
   }
   for (const [windowId, pending] of pendingPatchFlushByWindowId.entries()) {
     dropQueuedSessionPatches(pending, sessionId)
-    pending.overflowSessionIds.delete(sessionId)
+    pending.overflowSessionIds.delete(sessionFlushKey(sessionId))
     if (pending.patches.length === 0 && pending.overflowSessionIds.size === 0) {
       if (pending.timer) clearTimeout(pending.timer)
       pendingPatchFlushByWindowId.delete(windowId)
     }
   }
   for (const [windowId, pending] of pendingViewFlushByWindowId.entries()) {
-    if (!pending.sessionIds.delete(sessionId)) continue
-    if (pending.sessionIds.size === 0) {
+    if (!pending.sessions.delete(sessionFlushKey(sessionId))) continue
+    if (pending.sessions.size === 0) {
       if (pending.timer) clearTimeout(pending.timer)
       pendingViewFlushByWindowId.delete(windowId)
     }
@@ -526,6 +549,6 @@ export function dispatchRuntimeSessionEvent(
   }
   queueSessionPatchPublish(win, getSessionPatch(event))
   if (event.sessionId && shouldPublishSessionView(event)) {
-    queueSessionViewPublish(win, event.sessionId)
+    queueSessionViewPublish(win, event.sessionId, event.workspaceId)
   }
 }

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -100,6 +100,7 @@ function workspacePatch(workspaceId?: string | null) {
 
 export function shouldPublishSessionView(event: RuntimeSessionEvent) {
   if (!event.sessionId) return false
+  if (event.workspaceId && event.workspaceId !== 'local') return false
   const eventType = getEventType(event)
   return eventType !== 'text' && eventType !== 'reasoning' && eventType !== 'history_refresh'
 }
@@ -428,6 +429,7 @@ function flushPendingSessionViews(windowId: number) {
 }
 
 function queueSessionViewPublish(win: BrowserWindow, sessionId: string, workspaceId?: string | null) {
+  if (workspaceId && workspaceId !== 'local') return
   const windowId = win.webContents.id
   if (!sessionNeedsPatchViewRecovery(windowId, sessionId, workspaceId)) {
     flushQueuedSessionPatchesBeforeView(win, sessionId, workspaceId)

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -524,6 +524,41 @@ export class WorkspaceGateway {
     await (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).abortSession(sessionId)
   }
 
+  async replyCloudQuestion(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    requestId: string,
+    answers: unknown[],
+    workspaceIdInput?: string | null,
+  ): Promise<void> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.replyToQuestion) throw new Error('Cloud question replies are not supported by this workspace.')
+    await adapter.replyToQuestion(sessionId, requestId, answers)
+  }
+
+  async rejectCloudQuestion(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    requestId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<void> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.rejectQuestion) throw new Error('Cloud question rejection is not supported by this workspace.')
+    await adapter.rejectQuestion(sessionId, requestId)
+  }
+
+  async respondCloudPermission(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    permissionId: string,
+    allowed: boolean,
+    workspaceIdInput?: string | null,
+  ): Promise<void> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.respondToPermission) throw new Error('Cloud permission responses are not supported by this workspace.')
+    await adapter.respondToPermission(sessionId, permissionId, allowed)
+  }
+
   async listCloudWorkflows(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<WorkflowListPayload> {
     const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
     if (!adapter.listWorkflows) throw new Error('Cloud workflows are not supported by this workspace.')

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -1,0 +1,1078 @@
+import type { IpcMainInvokeEvent } from 'electron'
+import type {
+  AddCloudWorkspaceInput,
+  CapabilitySkill,
+  CapabilitySkillBundle,
+  CapabilityTool,
+  CustomAgentConfig,
+  CustomMcpConfig,
+  CustomSkillConfig,
+  SessionArtifact,
+  SessionArtifactAttachment,
+  SessionArtifactUploadRequest,
+  SessionInfo,
+  SessionView,
+  ThreadFacetSummary,
+  ThreadSearchQuery,
+  ThreadSearchResult,
+  ThreadSmartFilter,
+  ThreadSmartFilterInput,
+  ThreadTag,
+  ThreadTagInput,
+  WorkflowDetail,
+  WorkflowListPayload,
+  WorkflowRun,
+  WorkspaceInfo,
+  WorkspaceApiSupport,
+  WorkspaceApiSupportStatus,
+  WorkspacePolicy,
+  WorkspaceStatus,
+  WorkspaceSyncResult,
+  ScopedArtifactRef,
+} from '@open-cowork/shared'
+import {
+  createCloudWorkspaceAdapter,
+  type CloudPromptInput,
+  type CloudWorkspaceSessionAdapter,
+} from './cloud-workspace-adapter.ts'
+import {
+  createCloudWorkspaceDesktopAuthenticator,
+  type CloudWorkspaceLoginResult,
+} from './cloud-workspace-auth.ts'
+import type {
+  CloudTransportSettingMetadata,
+  CloudTransportSessionEvent,
+  CloudTransportSubscription,
+  CloudTransportWorkspaceEvent,
+} from './cloud/transport-adapter.ts'
+import {
+  cloudWorkspaceIdForBaseUrl,
+  createFileCloudWorkspaceRegistry,
+  normalizeCloudWorkspaceBaseUrl,
+  type CloudWorkspaceConnectionRecord,
+  type CloudWorkspaceRegistry,
+} from './cloud-workspace-registry.ts'
+import {
+  createFileCloudWorkspaceCredentialStore,
+  type CloudWorkspaceCredentialStore,
+} from './cloud-workspace-credentials.ts'
+import { DEFAULT_CONFIG, type CloudDesktopConfig } from './config-types.ts'
+
+export const LOCAL_WORKSPACE_ID = 'local'
+
+type WorkspaceRegistration = Omit<WorkspaceInfo, 'active'>
+
+type WorkspaceEventLike = Pick<IpcMainInvokeEvent, 'sender'> | null | undefined
+
+export type WorkspaceGatewayOptions = {
+  workspaces?: WorkspaceRegistration[]
+  cloudDesktop?: CloudDesktopConfig
+  cloudRegistry?: CloudWorkspaceRegistry | null
+  cloudCredentialStore?: CloudWorkspaceCredentialStore | null
+  cloudAdapterFactory?: (connection: CloudWorkspaceConnectionRecord, accessToken?: string | null) => CloudWorkspaceSessionAdapter
+  cloudLogin?: (connection: CloudWorkspaceConnectionRecord) => Promise<CloudWorkspaceLoginResult>
+  cloudRefresh?: (connection: CloudWorkspaceConnectionRecord, refreshToken: string) => Promise<CloudWorkspaceLoginResult>
+}
+
+const LOCAL_WORKSPACE: WorkspaceRegistration = {
+  id: LOCAL_WORKSPACE_ID,
+  kind: 'local',
+  label: 'Local',
+  status: 'online',
+  lastSyncedAt: null,
+}
+
+const LOCAL_WORKSPACE_POLICY: WorkspacePolicy = {
+  features: {
+    sessions: true,
+    threads: true,
+    workflows: true,
+    artifacts: true,
+    settings: true,
+    customContent: true,
+    capabilities: true,
+  },
+  allowedAgents: null,
+  allowedTools: null,
+  allowedMcps: null,
+  localFiles: 'enabled',
+  localStdioMcps: 'enabled',
+  machineRuntimeConfig: 'allowlisted',
+}
+
+const DISABLED_CLOUD_POLICY: WorkspacePolicy = {
+  features: {
+    sessions: false,
+    threads: false,
+    workflows: false,
+    artifacts: false,
+    settings: false,
+    customContent: false,
+    capabilities: false,
+  },
+  allowedAgents: [],
+  allowedTools: [],
+  allowedMcps: [],
+  localFiles: 'disabled',
+  localStdioMcps: 'disabled',
+  machineRuntimeConfig: 'disabled',
+}
+
+const WORKSPACE_SUPPORT_APIS = [
+  'sessions.list',
+  'sessions.create',
+  'sessions.activate',
+  'sessions.get',
+  'sessions.prompt',
+  'sessions.abort',
+  'sessions.fileSnippet',
+  'sessions.diff',
+  'threads.search',
+  'threads.tags',
+  'threads.smartFilters',
+  'workflows.list',
+  'workflows.run',
+  'artifacts.list',
+  'artifacts.upload',
+  'artifacts.download',
+  'settings.portable',
+  'customContent.agents',
+  'customContent.skills',
+  'customContent.mcps',
+  'capabilities.catalog',
+  'localFiles',
+  'localStdioMcps',
+  'machineRuntimeConfig',
+] as const
+
+const CLOUD_CUSTOM_AGENTS_KEY = 'custom-agents'
+const CLOUD_CUSTOM_MCPS_KEY = 'custom-mcps'
+const CLOUD_CUSTOM_SKILLS_KEY = 'custom-skills'
+
+function senderKey(event: WorkspaceEventLike) {
+  const id = event?.sender?.id
+  return typeof id === 'number' && Number.isFinite(id) ? id : 0
+}
+
+function normalizeWorkspaceId(workspaceId?: string | null) {
+  if (workspaceId === undefined || workspaceId === null || workspaceId === '') return null
+  const trimmed = workspaceId.trim()
+  if (!trimmed) return null
+  if (Buffer.byteLength(trimmed, 'utf8') > 512) {
+    throw new Error('Workspace id is too large.')
+  }
+  return trimmed
+}
+
+export function readWorkspaceIdOption(input: unknown): string | null {
+  if (input === undefined || input === null) return null
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Workspace options must be an object when provided.')
+  }
+  const workspaceId = (input as { workspaceId?: unknown }).workspaceId
+  if (workspaceId === undefined || workspaceId === null || workspaceId === '') return null
+  if (typeof workspaceId !== 'string') throw new Error('Workspace id must be a string.')
+  return normalizeWorkspaceId(workspaceId)
+}
+
+function cloudRegistrationFromConnection(connection: CloudWorkspaceConnectionRecord): WorkspaceRegistration {
+  return {
+    id: connection.id,
+    kind: 'cloud',
+    label: connection.label,
+    status: 'auth_required',
+    baseUrl: connection.baseUrl,
+    tenantId: connection.tenantId,
+    userId: connection.userId,
+    profileName: connection.profileName,
+    lastSyncedAt: connection.lastSyncedAt,
+    error: 'Sign in to this cloud workspace to enable sync.',
+  }
+}
+
+function connectionFromWorkspace(workspace: WorkspaceRegistration): CloudWorkspaceConnectionRecord {
+  if (workspace.kind !== 'cloud' || !workspace.baseUrl) {
+    throw new Error('Cloud workspace requires a base URL.')
+  }
+  const timestamp = new Date(0).toISOString()
+  return {
+    id: workspace.id,
+    baseUrl: normalizeCloudWorkspaceBaseUrl(workspace.baseUrl),
+    label: workspace.label,
+    tenantId: workspace.tenantId,
+    userId: workspace.userId,
+    profileName: workspace.profileName,
+    lastSyncedAt: workspace.lastSyncedAt || null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }
+}
+
+export class WorkspaceGateway {
+  private readonly workspaces = new Map<string, WorkspaceRegistration>()
+  private readonly cloudConnections = new Map<string, CloudWorkspaceConnectionRecord>()
+  private readonly cloudAdapters = new Map<string, CloudWorkspaceSessionAdapter>()
+  private readonly cloudSessionSubscriptions = new Map<string, CloudTransportSubscription>()
+  private readonly cloudWorkspaceSubscriptions = new Map<string, CloudTransportSubscription>()
+  private readonly managedCloudWorkspaceIds = new Set<string>()
+  private readonly activeBySender = new Map<number, string>()
+  private readonly syncedAtByWorkspace = new Map<string, string>()
+  private readonly cloudDesktopConfig: CloudDesktopConfig
+  private readonly cloudRegistry: CloudWorkspaceRegistry | null
+  private readonly cloudCredentialStore: CloudWorkspaceCredentialStore | null
+  private readonly cloudAdapterFactory: (connection: CloudWorkspaceConnectionRecord, accessToken?: string | null) => CloudWorkspaceSessionAdapter
+  private readonly cloudLogin: (connection: CloudWorkspaceConnectionRecord) => Promise<CloudWorkspaceLoginResult>
+  private readonly cloudRefresh: (connection: CloudWorkspaceConnectionRecord, refreshToken: string) => Promise<CloudWorkspaceLoginResult>
+
+  constructor(options: WorkspaceGatewayOptions = {}) {
+    this.cloudDesktopConfig = options.cloudDesktop || DEFAULT_CONFIG.cloudDesktop
+    this.cloudRegistry = options.cloudRegistry === undefined ? createFileCloudWorkspaceRegistry() : options.cloudRegistry
+    this.cloudCredentialStore = options.cloudCredentialStore === undefined ? createFileCloudWorkspaceCredentialStore() : options.cloudCredentialStore
+    this.cloudAdapterFactory = options.cloudAdapterFactory || ((connection, accessToken) => createCloudWorkspaceAdapter(connection, accessToken, {
+      cacheMode: this.cloudDesktopConfig.cacheMode,
+      cacheEncryptionFallback: this.cloudDesktopConfig.cacheEncryptionFallback,
+    }))
+    const authenticator = createCloudWorkspaceDesktopAuthenticator()
+    this.cloudLogin = options.cloudLogin || ((connection) => authenticator.login(connection))
+    this.cloudRefresh = options.cloudRefresh || ((connection, refreshToken) => authenticator.refresh(connection, refreshToken))
+    this.registerWorkspace(LOCAL_WORKSPACE)
+    if (!this.cloudDesktopConfig.enabled) return
+    const persistedConnections = new Map((this.cloudRegistry?.list() || []).map((connection) => [connection.id, connection]))
+    for (const preconfigured of this.cloudDesktopConfig.preconfiguredConnections) {
+      const baseUrl = normalizeCloudWorkspaceBaseUrl(preconfigured.baseUrl)
+      const id = cloudWorkspaceIdForBaseUrl(baseUrl)
+      const persisted = persistedConnections.get(id)
+      const connection: CloudWorkspaceConnectionRecord = {
+        id,
+        baseUrl,
+        label: preconfigured.label?.trim() || persisted?.label || new URL(baseUrl).host,
+        tenantId: persisted?.tenantId,
+        userId: persisted?.userId,
+        profileName: persisted?.profileName,
+        lastSyncedAt: persisted?.lastSyncedAt || null,
+        createdAt: persisted?.createdAt || new Date(0).toISOString(),
+        updatedAt: persisted?.updatedAt || new Date(0).toISOString(),
+      }
+      this.managedCloudWorkspaceIds.add(id)
+      this.cloudConnections.set(connection.id, connection)
+      this.registerWorkspace(this.applyCredentialStatus(cloudRegistrationFromConnection(connection)))
+    }
+    for (const connection of this.cloudRegistry?.list() || []) {
+      if (this.cloudDesktopConfig.requireManagedOrg && !this.managedCloudWorkspaceIds.has(connection.id)) continue
+      if (this.cloudConnections.has(connection.id)) continue
+      this.cloudConnections.set(connection.id, connection)
+      this.registerWorkspace(this.applyCredentialStatus(cloudRegistrationFromConnection(connection)))
+    }
+    for (const workspace of options.workspaces || []) {
+      this.registerWorkspace(workspace)
+    }
+  }
+
+  registerWorkspace(workspace: WorkspaceRegistration) {
+    this.workspaces.set(workspace.id, { ...workspace })
+    if (workspace.kind === 'cloud' && workspace.baseUrl && !this.cloudConnections.has(workspace.id)) {
+      this.cloudConnections.set(workspace.id, connectionFromWorkspace(workspace))
+    }
+  }
+
+  list(event?: WorkspaceEventLike): WorkspaceInfo[] {
+    const activeId = this.activeWorkspaceId(event)
+    return Array.from(this.workspaces.values()).map((workspace) => this.toInfo(workspace, workspace.id === activeId))
+  }
+
+  activate(event: WorkspaceEventLike, workspaceIdInput: string): WorkspaceInfo {
+    const workspace = this.getWorkspace(workspaceIdInput)
+    this.activeBySender.set(senderKey(event), workspace.id)
+    return this.toInfo(workspace, true)
+  }
+
+  addCloud(event: WorkspaceEventLike, input: AddCloudWorkspaceInput): WorkspaceInfo {
+    if (!this.cloudDesktopConfig.enabled) {
+      throw new Error('Cloud workspaces are disabled by this build configuration.')
+    }
+    if (!this.cloudDesktopConfig.allowUserAddedConnections || this.cloudDesktopConfig.requireManagedOrg) {
+      throw new Error('User-added cloud workspaces are disabled by this build configuration.')
+    }
+    if (!input || typeof input.baseUrl !== 'string' || !input.baseUrl.trim()) {
+      throw new Error('Cloud workspace URL is required.')
+    }
+    const baseUrl = normalizeCloudWorkspaceBaseUrl(input.baseUrl)
+    const connection = this.cloudRegistry?.upsert({
+      baseUrl,
+      label: input.label,
+    }) || {
+      id: cloudWorkspaceIdForBaseUrl(baseUrl),
+      baseUrl,
+      label: input.label?.trim() || new URL(baseUrl).host,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastSyncedAt: null,
+    }
+    const workspace = this.applyCredentialStatus(cloudRegistrationFromConnection(connection))
+    this.registerWorkspace(workspace)
+    return this.toInfo(workspace, workspace.id === this.activeWorkspaceId(event))
+  }
+
+  remove(event: WorkspaceEventLike, workspaceIdInput: string): boolean {
+    const workspaceId = normalizeWorkspaceId(workspaceIdInput)
+    if (!workspaceId || workspaceId === LOCAL_WORKSPACE_ID) return false
+    if (this.cloudDesktopConfig.requireManagedOrg && this.managedCloudWorkspaceIds.has(workspaceId)) return false
+    const removed = this.workspaces.delete(workspaceId)
+    const persistedRemoved = this.cloudRegistry?.remove(workspaceId) || false
+    this.cloudConnections.delete(workspaceId)
+    this.cloudAdapters.delete(workspaceId)
+    this.closeCloudSubscriptionsForWorkspace(workspaceId)
+    for (const [sender, activeWorkspaceId] of this.activeBySender.entries()) {
+      if (activeWorkspaceId === workspaceId) this.activeBySender.set(sender, LOCAL_WORKSPACE_ID)
+    }
+    this.syncedAtByWorkspace.delete(workspaceId)
+    // Resolve the active workspace for this sender so callers see a stable
+    // local fallback after removing a selected cloud placeholder.
+    this.activeWorkspaceId(event)
+    return removed || persistedRemoved
+  }
+
+  async login(event: WorkspaceEventLike, workspaceIdInput: string): Promise<WorkspaceInfo> {
+    const workspace = this.getWorkspace(workspaceIdInput)
+    if (workspace.kind === 'local') return this.toInfo(workspace, workspace.id === this.activeWorkspaceId(event))
+    const connection = this.cloudConnections.get(workspace.id)
+    if (!connection) throw new Error('Cloud workspace connection is missing.')
+    if (!this.cloudCredentialStore) throw new Error('Cloud workspace credential storage is not configured.')
+    const loggedIn = await this.cloudLogin(connection)
+    this.cloudCredentialStore.save({
+      workspaceId: workspace.id,
+      accessToken: loggedIn.accessToken,
+      refreshToken: loggedIn.refreshToken,
+      expiresAt: loggedIn.expiresAt,
+    })
+    const updatedConnection = this.cloudRegistry?.upsert({
+      baseUrl: connection.baseUrl,
+      label: workspace.label,
+      tenantId: loggedIn.tenantId || connection.tenantId,
+      userId: loggedIn.userId || connection.userId,
+      profileName: loggedIn.profileName || connection.profileName,
+      lastSyncedAt: connection.lastSyncedAt,
+    }) || {
+      ...connection,
+      tenantId: loggedIn.tenantId || connection.tenantId,
+      userId: loggedIn.userId || connection.userId,
+      profileName: loggedIn.profileName || connection.profileName,
+      updatedAt: new Date().toISOString(),
+    }
+    this.cloudConnections.set(workspace.id, updatedConnection)
+    this.cloudAdapters.delete(workspace.id)
+    const next = {
+      ...workspace,
+      tenantId: updatedConnection.tenantId,
+      userId: updatedConnection.userId,
+      profileName: updatedConnection.profileName,
+      status: 'online',
+      error: null,
+    } satisfies WorkspaceRegistration
+    this.workspaces.set(workspace.id, next)
+    return this.toInfo(next, workspace.id === this.activeWorkspaceId(event))
+  }
+
+  logout(event: WorkspaceEventLike, workspaceIdInput: string): WorkspaceInfo {
+    const workspace = this.getWorkspace(workspaceIdInput)
+    if (workspace.kind === 'local') return this.toInfo(workspace, workspace.id === this.activeWorkspaceId(event))
+    this.cloudCredentialStore?.remove(workspace.id)
+    this.cloudAdapters.delete(workspace.id)
+    this.closeCloudSubscriptionsForWorkspace(workspace.id)
+    const next = {
+      ...workspace,
+      status: 'auth_required',
+      userId: undefined,
+      error: 'Sign in to this cloud workspace to enable sync.',
+    } satisfies WorkspaceRegistration
+    this.workspaces.set(workspace.id, next)
+    return this.toInfo(next, workspace.id === this.activeWorkspaceId(event))
+  }
+
+  policy(event: WorkspaceEventLike, workspaceIdInput?: string | null): WorkspacePolicy {
+    const workspace = this.resolveWorkspace(event, workspaceIdInput)
+    return workspace.kind === 'local' ? LOCAL_WORKSPACE_POLICY : DISABLED_CLOUD_POLICY
+  }
+
+  async cloudPolicy(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<WorkspacePolicy> {
+    const workspace = this.resolveWorkspace(event, workspaceIdInput)
+    if (workspace.kind === 'local') return LOCAL_WORKSPACE_POLICY
+    try {
+      return (await this.requireCloudAdapter(workspace)).policy()
+    } catch {
+      return DISABLED_CLOUD_POLICY
+    }
+  }
+
+  async supportMatrix(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<WorkspaceApiSupport[]> {
+    const workspace = this.resolveWorkspace(event, workspaceIdInput)
+    if (workspace.kind === 'local') {
+      return WORKSPACE_SUPPORT_APIS.map((api) => ({
+        api,
+        status: 'supported',
+        verdict: { allowed: true, reason: null },
+      }))
+    }
+    const policy = await this.cloudPolicy(event, workspace.id)
+    const feature = (key: string, fallback = false) => policy.features[key] ?? fallback
+    const cloudSupport = (api: string, status: WorkspaceApiSupportStatus, reason: string | null = null): WorkspaceApiSupport => ({
+      api,
+      status,
+      verdict: {
+        allowed: status === 'supported' || status === 'read_only',
+        reason,
+        ...(reason ? { policyCode: status } : {}),
+      },
+    })
+    const supportedIf = (api: string, allowed: boolean, reason: string): WorkspaceApiSupport => (
+      allowed ? cloudSupport(api, 'supported') : cloudSupport(api, 'blocked_by_policy', reason)
+    )
+    const chatEnabled = feature('chat', feature('sessions', true))
+    return [
+      supportedIf('sessions.list', chatEnabled, 'Cloud chat is disabled by this workspace policy.'),
+      supportedIf('sessions.create', chatEnabled, 'Cloud chat is disabled by this workspace policy.'),
+      supportedIf('sessions.activate', chatEnabled, 'Cloud chat is disabled by this workspace policy.'),
+      supportedIf('sessions.get', chatEnabled, 'Cloud chat is disabled by this workspace policy.'),
+      supportedIf('sessions.prompt', chatEnabled, 'Cloud chat is disabled by this workspace policy.'),
+      supportedIf('sessions.abort', chatEnabled, 'Cloud chat is disabled by this workspace policy.'),
+      cloudSupport('sessions.fileSnippet', 'not_supported', 'Cloud workspaces cannot read arbitrary local host paths.'),
+      cloudSupport('sessions.diff', 'not_supported', 'Cloud workspaces cannot diff arbitrary local host paths.'),
+      supportedIf('threads.search', feature('threadIndex'), 'Cloud thread index is disabled by this workspace policy.'),
+      supportedIf('threads.tags', feature('threadIndex'), 'Cloud thread index is disabled by this workspace policy.'),
+      supportedIf('threads.smartFilters', feature('threadIndex'), 'Cloud thread index is disabled by this workspace policy.'),
+      supportedIf('workflows.list', feature('workflows'), 'Cloud workflows are disabled by this workspace policy.'),
+      supportedIf('workflows.run', feature('workflows'), 'Cloud workflows are disabled by this workspace policy.'),
+      supportedIf('artifacts.list', feature('artifacts'), 'Cloud artifacts are disabled by this workspace policy.'),
+      supportedIf('artifacts.upload', feature('artifacts'), 'Cloud artifacts are disabled by this workspace policy.'),
+      supportedIf('artifacts.download', feature('artifacts'), 'Cloud artifacts are disabled by this workspace policy.'),
+      supportedIf('settings.portable', feature('settings'), 'Cloud portable settings are disabled by this workspace policy.'),
+      supportedIf('customContent.agents', feature('customAgents'), 'Cloud custom agents are disabled by this workspace policy.'),
+      supportedIf('customContent.skills', feature('customSkills'), 'Cloud custom skills are disabled by this workspace policy.'),
+      supportedIf('customContent.mcps', feature('customMcps'), 'Cloud custom MCPs are disabled by this workspace policy.'),
+      supportedIf('capabilities.catalog', feature('agents'), 'Cloud capability catalog is disabled by this workspace policy.'),
+      cloudSupport('localFiles', 'not_supported', 'Cloud workspaces do not implicitly upload local files.'),
+      cloudSupport('localStdioMcps', 'not_supported', 'Cloud workspaces do not execute arbitrary local stdio MCPs.'),
+      cloudSupport('machineRuntimeConfig', 'not_supported', 'Cloud workspaces do not use machine-native runtime config.'),
+    ]
+  }
+
+  async sync(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<WorkspaceSyncResult> {
+    const workspace = this.resolveWorkspace(event, workspaceIdInput)
+    if (workspace.kind === 'cloud') {
+      await this.requireCloudAdapter(workspace)
+    }
+    const syncedAt = new Date().toISOString()
+    this.syncedAtByWorkspace.set(workspace.id, syncedAt)
+    if (workspace.kind === 'cloud') {
+      this.cloudRegistry?.touchSync(workspace.id, syncedAt)
+      const latestWorkspace = this.workspaces.get(workspace.id) || workspace
+      this.workspaces.set(workspace.id, {
+        ...latestWorkspace,
+        lastSyncedAt: syncedAt,
+      })
+    }
+    return { ok: true, syncedAt }
+  }
+
+  activeWorkspaceId(event?: WorkspaceEventLike) {
+    const active = this.activeBySender.get(senderKey(event))
+    return active && this.workspaces.has(active) ? active : LOCAL_WORKSPACE_ID
+  }
+
+  assertLocalWorkspace(event: WorkspaceEventLike, workspaceIdInput?: string | null): WorkspaceInfo {
+    const workspace = this.resolveWorkspace(event, workspaceIdInput)
+    if (workspace.kind !== 'local') {
+      throw new Error('This desktop action is only available in the Local workspace.')
+    }
+    return this.toInfo(workspace, true)
+  }
+
+  isLocalWorkspace(event: WorkspaceEventLike, workspaceIdInput?: string | null): boolean {
+    return this.resolveWorkspace(event, workspaceIdInput).kind === 'local'
+  }
+
+  async listCloudSessions(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<SessionInfo[]> {
+    return (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).listSessions()
+  }
+
+  async createCloudSession(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<SessionInfo> {
+    return (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).createSession()
+  }
+
+  async getCloudSessionInfo(event: WorkspaceEventLike, sessionId: string, workspaceIdInput?: string | null): Promise<SessionInfo | null> {
+    return (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).getSessionInfo(sessionId)
+  }
+
+  async getCloudSessionView(event: WorkspaceEventLike, sessionId: string, workspaceIdInput?: string | null): Promise<SessionView> {
+    return (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).getSessionView(sessionId)
+  }
+
+  async promptCloudSession(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    input: CloudPromptInput,
+    workspaceIdInput?: string | null,
+  ): Promise<void> {
+    await (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).promptSession(sessionId, input)
+  }
+
+  async abortCloudSession(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<void> {
+    await (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).abortSession(sessionId)
+  }
+
+  async listCloudWorkflows(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<WorkflowListPayload> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.listWorkflows) throw new Error('Cloud workflows are not supported by this workspace.')
+    return adapter.listWorkflows()
+  }
+
+  async getCloudWorkflow(
+    event: WorkspaceEventLike,
+    workflowId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<WorkflowDetail | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.getWorkflow) throw new Error('Cloud workflows are not supported by this workspace.')
+    return adapter.getWorkflow(workflowId)
+  }
+
+  async runCloudWorkflow(
+    event: WorkspaceEventLike,
+    workflowId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<WorkflowRun | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.runWorkflow) throw new Error('Cloud workflow runs are not supported by this workspace.')
+    return adapter.runWorkflow(workflowId)
+  }
+
+  async pauseCloudWorkflow(
+    event: WorkspaceEventLike,
+    workflowId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<WorkflowDetail | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.pauseWorkflow) throw new Error('Cloud workflow pause is not supported by this workspace.')
+    return adapter.pauseWorkflow(workflowId)
+  }
+
+  async resumeCloudWorkflow(
+    event: WorkspaceEventLike,
+    workflowId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<WorkflowDetail | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.resumeWorkflow) throw new Error('Cloud workflow resume is not supported by this workspace.')
+    return adapter.resumeWorkflow(workflowId)
+  }
+
+  async archiveCloudWorkflow(
+    event: WorkspaceEventLike,
+    workflowId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<WorkflowDetail | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.archiveWorkflow) throw new Error('Cloud workflow archive is not supported by this workspace.')
+    return adapter.archiveWorkflow(workflowId)
+  }
+
+  async searchCloudThreads(
+    event: WorkspaceEventLike,
+    query?: ThreadSearchQuery,
+    workspaceIdInput?: string | null,
+  ): Promise<ThreadSearchResult> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.searchThreads) throw new Error('Cloud thread search is not supported by this workspace.')
+    return adapter.searchThreads(query)
+  }
+
+  async cloudThreadFacets(
+    event: WorkspaceEventLike,
+    query?: ThreadSearchQuery,
+    workspaceIdInput?: string | null,
+  ): Promise<ThreadFacetSummary> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.threadFacets) throw new Error('Cloud thread facets are not supported by this workspace.')
+    return adapter.threadFacets(query)
+  }
+
+  async listCloudThreadTags(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<ThreadTag[]> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.listThreadTags) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return adapter.listThreadTags()
+  }
+
+  async createCloudThreadTag(
+    event: WorkspaceEventLike,
+    input: ThreadTagInput,
+    workspaceIdInput?: string | null,
+  ): Promise<ThreadTag> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.createThreadTag) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return adapter.createThreadTag(input)
+  }
+
+  async updateCloudThreadTag(
+    event: WorkspaceEventLike,
+    tagId: string,
+    input: ThreadTagInput,
+    workspaceIdInput?: string | null,
+  ): Promise<ThreadTag | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.updateThreadTag) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return adapter.updateThreadTag(tagId, input)
+  }
+
+  async deleteCloudThreadTag(
+    event: WorkspaceEventLike,
+    tagId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.deleteThreadTag) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return adapter.deleteThreadTag(tagId)
+  }
+
+  async applyCloudThreadTags(
+    event: WorkspaceEventLike,
+    sessionIds: string[],
+    tagIds: string[],
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.applyThreadTags) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return adapter.applyThreadTags(sessionIds, tagIds)
+  }
+
+  async removeCloudThreadTags(
+    event: WorkspaceEventLike,
+    sessionIds: string[],
+    tagIds: string[],
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.removeThreadTags) throw new Error('Cloud thread tags are not supported by this workspace.')
+    return adapter.removeThreadTags(sessionIds, tagIds)
+  }
+
+  async listCloudThreadSmartFilters(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<ThreadSmartFilter[]> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.listThreadSmartFilters) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return adapter.listThreadSmartFilters()
+  }
+
+  async createCloudThreadSmartFilter(
+    event: WorkspaceEventLike,
+    input: ThreadSmartFilterInput,
+    workspaceIdInput?: string | null,
+  ): Promise<ThreadSmartFilter> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.createThreadSmartFilter) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return adapter.createThreadSmartFilter(input)
+  }
+
+  async updateCloudThreadSmartFilter(
+    event: WorkspaceEventLike,
+    filterId: string,
+    input: ThreadSmartFilterInput,
+    workspaceIdInput?: string | null,
+  ): Promise<ThreadSmartFilter | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.updateThreadSmartFilter) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return adapter.updateThreadSmartFilter(filterId, input)
+  }
+
+  async deleteCloudThreadSmartFilter(
+    event: WorkspaceEventLike,
+    filterId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.deleteThreadSmartFilter) throw new Error('Cloud smart filters are not supported by this workspace.')
+    return adapter.deleteThreadSmartFilter(filterId)
+  }
+
+  async listCloudArtifacts(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<SessionArtifact[]> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.listArtifacts) throw new Error('Cloud artifacts are not supported by this workspace.')
+    return adapter.listArtifacts(sessionId)
+  }
+
+  async uploadCloudArtifact(
+    event: WorkspaceEventLike,
+    input: SessionArtifactUploadRequest,
+    workspaceIdInput?: string | null,
+  ): Promise<SessionArtifact> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.uploadArtifact) throw new Error('Cloud artifact uploads are not supported by this workspace.')
+    return adapter.uploadArtifact(input)
+  }
+
+  async readCloudArtifactAttachment(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    filePathOrArtifactId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<SessionArtifactAttachment> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.readArtifactAttachment) throw new Error('Cloud artifact downloads are not supported by this workspace.')
+    return adapter.readArtifactAttachment(sessionId, filePathOrArtifactId)
+  }
+
+  async listCloudCapabilityTools(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<CapabilityTool[]> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.listCapabilityTools) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return adapter.listCapabilityTools()
+  }
+
+  async getCloudCapabilityTool(
+    event: WorkspaceEventLike,
+    toolId: string,
+    workspaceIdInput?: string | null,
+  ): Promise<CapabilityTool | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.getCapabilityTool) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return adapter.getCapabilityTool(toolId)
+  }
+
+  async listCloudCapabilitySkills(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<CapabilitySkill[]> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.listCapabilitySkills) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return adapter.listCapabilitySkills()
+  }
+
+  async getCloudCapabilitySkillBundle(
+    event: WorkspaceEventLike,
+    skillName: string,
+    workspaceIdInput?: string | null,
+  ): Promise<CapabilitySkillBundle | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.getCapabilitySkillBundle) throw new Error('Cloud capabilities are not supported by this workspace.')
+    return adapter.getCapabilitySkillBundle(skillName)
+  }
+
+  async readCloudCapabilitySkillBundleFile(
+    event: WorkspaceEventLike,
+    skillName: string,
+    filePath: string,
+    workspaceIdInput?: string | null,
+  ): Promise<string | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.readCapabilitySkillBundleFile) throw new Error('Cloud capability bundle files are not supported by this workspace.')
+    return adapter.readCapabilitySkillBundleFile(skillName, filePath)
+  }
+
+  async listCloudSettings(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<CloudTransportSettingMetadata[]> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.listSettings) throw new Error('Cloud settings are not supported by this workspace.')
+    return adapter.listSettings()
+  }
+
+  async getCloudSetting(
+    event: WorkspaceEventLike,
+    key: string,
+    workspaceIdInput?: string | null,
+  ): Promise<CloudTransportSettingMetadata | null> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.getSetting) throw new Error('Cloud settings are not supported by this workspace.')
+    return adapter.getSetting(key)
+  }
+
+  async setCloudSetting(
+    event: WorkspaceEventLike,
+    key: string,
+    value: Record<string, unknown>,
+    workspaceIdInput?: string | null,
+  ): Promise<CloudTransportSettingMetadata> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.setSetting) throw new Error('Cloud settings are not supported by this workspace.')
+    return adapter.setSetting(key, value)
+  }
+
+  async listCloudCustomAgents(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<CustomAgentConfig[]> {
+    return this.readCloudItemsSetting<CustomAgentConfig>(event, CLOUD_CUSTOM_AGENTS_KEY, workspaceIdInput)
+  }
+
+  async saveCloudCustomAgent(
+    event: WorkspaceEventLike,
+    agent: CustomAgentConfig,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    await this.upsertCloudItemSetting(event, CLOUD_CUSTOM_AGENTS_KEY, agent, workspaceIdInput)
+    return true
+  }
+
+  async removeCloudCustomAgent(
+    event: WorkspaceEventLike,
+    target: ScopedArtifactRef,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    return this.removeCloudItemSetting(event, CLOUD_CUSTOM_AGENTS_KEY, target, workspaceIdInput)
+  }
+
+  async listCloudCustomMcps(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<CustomMcpConfig[]> {
+    return this.readCloudItemsSetting<CustomMcpConfig>(event, CLOUD_CUSTOM_MCPS_KEY, workspaceIdInput)
+  }
+
+  async saveCloudCustomMcp(
+    event: WorkspaceEventLike,
+    mcp: CustomMcpConfig,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    await this.upsertCloudItemSetting(event, CLOUD_CUSTOM_MCPS_KEY, mcp, workspaceIdInput)
+    return true
+  }
+
+  async removeCloudCustomMcp(
+    event: WorkspaceEventLike,
+    target: ScopedArtifactRef,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    return this.removeCloudItemSetting(event, CLOUD_CUSTOM_MCPS_KEY, target, workspaceIdInput)
+  }
+
+  async listCloudCustomSkills(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<CustomSkillConfig[]> {
+    return this.readCloudItemsSetting<CustomSkillConfig>(event, CLOUD_CUSTOM_SKILLS_KEY, workspaceIdInput)
+  }
+
+  async saveCloudCustomSkill(
+    event: WorkspaceEventLike,
+    skill: CustomSkillConfig,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    await this.upsertCloudItemSetting(event, CLOUD_CUSTOM_SKILLS_KEY, skill, workspaceIdInput)
+    return true
+  }
+
+  async removeCloudCustomSkill(
+    event: WorkspaceEventLike,
+    target: ScopedArtifactRef,
+    workspaceIdInput?: string | null,
+  ): Promise<boolean> {
+    return this.removeCloudItemSetting(event, CLOUD_CUSTOM_SKILLS_KEY, target, workspaceIdInput)
+  }
+
+  async subscribeCloudSessionEvents(
+    event: WorkspaceEventLike,
+    sessionId: string,
+    input: {
+      workspaceId?: string | null
+      afterSequence?: number
+      onEvent: (event: CloudTransportSessionEvent) => void
+      onError?: (error: unknown) => void
+    },
+  ): Promise<void> {
+    const workspace = this.resolveWorkspace(event, input.workspaceId)
+    const adapter = await this.requireCloudAdapter(workspace)
+    if (!adapter.subscribeSessionEvents) return
+    const key = this.cloudSessionSubscriptionKey(workspace.id, sessionId)
+    if (this.cloudSessionSubscriptions.has(key)) return
+    const subscription = adapter.subscribeSessionEvents(sessionId, {
+      afterSequence: input.afterSequence,
+      onEvent: input.onEvent,
+      onError: input.onError,
+    })
+    this.cloudSessionSubscriptions.set(key, subscription)
+  }
+
+  async subscribeCloudWorkspaceEvents(
+    event: WorkspaceEventLike,
+    input: {
+      workspaceId?: string | null
+      afterSequence?: number
+      onEvent: (event: CloudTransportWorkspaceEvent) => void
+      onError?: (error: unknown) => void
+    },
+  ): Promise<void> {
+    const workspace = this.resolveWorkspace(event, input.workspaceId)
+    const adapter = await this.requireCloudAdapter(workspace)
+    if (!adapter.subscribeWorkspaceEvents) return
+    const key = this.cloudWorkspaceSubscriptionKey(workspace.id, senderKey(event))
+    if (this.cloudWorkspaceSubscriptions.has(key)) return
+    const subscription = adapter.subscribeWorkspaceEvents({
+      afterSequence: input.afterSequence,
+      onEvent: input.onEvent,
+      onError: input.onError,
+    })
+    this.cloudWorkspaceSubscriptions.set(key, subscription)
+  }
+
+  private resolveWorkspace(event: WorkspaceEventLike, workspaceIdInput?: string | null): WorkspaceRegistration {
+    const workspaceId = normalizeWorkspaceId(workspaceIdInput) || this.activeWorkspaceId(event)
+    return this.getWorkspace(workspaceId)
+  }
+
+  private getWorkspace(workspaceIdInput: string): WorkspaceRegistration {
+    const workspaceId = normalizeWorkspaceId(workspaceIdInput)
+    if (!workspaceId) throw new Error('Workspace id is required.')
+    const workspace = this.workspaces.get(workspaceId)
+    if (!workspace) throw new Error(`Unknown workspace: ${workspaceId}`)
+    return workspace
+  }
+
+  private async requireCloudAdapter(workspace: WorkspaceRegistration): Promise<CloudWorkspaceSessionAdapter> {
+    if (workspace.kind !== 'cloud') throw new Error('This action requires a Cloud workspace.')
+    const connection = this.cloudConnections.get(workspace.id)
+    if (!connection) throw new Error('Cloud workspace connection is missing.')
+    const accessToken = await this.ensureCloudAccessToken(workspace, connection)
+    if (!accessToken) {
+      throw new Error(workspace.error || 'Cloud workspace is not available.')
+    }
+    const existing = this.cloudAdapters.get(workspace.id)
+    if (existing) return existing
+    const adapter = this.cloudAdapterFactory(connection, accessToken)
+    this.cloudAdapters.set(workspace.id, adapter)
+    return adapter
+  }
+
+  private async ensureCloudAccessToken(
+    workspace: WorkspaceRegistration,
+    connection: CloudWorkspaceConnectionRecord,
+  ) {
+    const current = this.cloudCredentialStore?.getUsableAccessToken(workspace.id) || null
+    if (current) return current
+    const credential = this.cloudCredentialStore?.get(workspace.id)
+    if (!credential?.refreshToken || !this.cloudCredentialStore) return null
+    try {
+      const refreshed = await this.cloudRefresh(connection, credential.refreshToken)
+      this.cloudCredentialStore.save({
+        workspaceId: workspace.id,
+        accessToken: refreshed.accessToken,
+        refreshToken: refreshed.refreshToken || credential.refreshToken,
+        expiresAt: refreshed.expiresAt,
+      })
+      const nextConnection = this.cloudRegistry?.upsert({
+        baseUrl: connection.baseUrl,
+        label: connection.label,
+        tenantId: refreshed.tenantId || connection.tenantId,
+        userId: refreshed.userId || connection.userId,
+        profileName: refreshed.profileName || connection.profileName,
+        lastSyncedAt: connection.lastSyncedAt,
+      }) || {
+        ...connection,
+        tenantId: refreshed.tenantId || connection.tenantId,
+        userId: refreshed.userId || connection.userId,
+        profileName: refreshed.profileName || connection.profileName,
+        updatedAt: new Date().toISOString(),
+      }
+      this.cloudConnections.set(workspace.id, nextConnection)
+      this.cloudAdapters.delete(workspace.id)
+      this.workspaces.set(workspace.id, {
+        ...workspace,
+        tenantId: nextConnection.tenantId,
+        userId: nextConnection.userId,
+        profileName: nextConnection.profileName,
+        status: 'online',
+        error: null,
+      })
+      return refreshed.accessToken
+    } catch {
+      this.cloudCredentialStore.remove(workspace.id)
+      this.cloudAdapters.delete(workspace.id)
+      this.workspaces.set(workspace.id, {
+        ...workspace,
+        status: 'auth_required',
+        error: 'Sign in to this cloud workspace to enable sync.',
+      })
+      return null
+    }
+  }
+
+  private cloudSessionSubscriptionKey(workspaceId: string, sessionId: string) {
+    return `${workspaceId}:${sessionId}`
+  }
+
+  private cloudWorkspaceSubscriptionKey(workspaceId: string, senderId: number) {
+    return `${workspaceId}:${senderId}`
+  }
+
+  private closeCloudSubscriptionsForWorkspace(workspaceId: string) {
+    for (const [key, subscription] of this.cloudSessionSubscriptions.entries()) {
+      if (!key.startsWith(`${workspaceId}:`)) continue
+      try { subscription.close() } catch { /* best effort */ }
+      this.cloudSessionSubscriptions.delete(key)
+    }
+    for (const [key, subscription] of this.cloudWorkspaceSubscriptions.entries()) {
+      if (!key.startsWith(`${workspaceId}:`)) continue
+      try { subscription.close() } catch { /* best effort */ }
+      this.cloudWorkspaceSubscriptions.delete(key)
+    }
+  }
+
+  private async readCloudItemsSetting<T extends { name: string }>(
+    event: WorkspaceEventLike,
+    keyName: string,
+    workspaceIdInput?: string | null,
+  ): Promise<T[]> {
+    const setting = await this.getCloudSetting(event, keyName, workspaceIdInput)
+    return Array.isArray(setting?.value.items) ? setting.value.items as T[] : []
+  }
+
+  private async upsertCloudItemSetting<T extends { name: string; scope?: string; directory?: string | null }>(
+    event: WorkspaceEventLike,
+    keyName: string,
+    item: T,
+    workspaceIdInput?: string | null,
+  ) {
+    const items = await this.readCloudItemsSetting<T>(event, keyName, workspaceIdInput)
+    const next = [
+      ...items.filter((entry) => !this.sameScopedName(entry, item)),
+      item,
+    ].sort((left, right) => left.name.localeCompare(right.name))
+    await this.setCloudSetting(event, keyName, { items: next }, workspaceIdInput)
+  }
+
+  private async removeCloudItemSetting(
+    event: WorkspaceEventLike,
+    keyName: string,
+    target: ScopedArtifactRef,
+    workspaceIdInput?: string | null,
+  ) {
+    const items = await this.readCloudItemsSetting<ScopedArtifactRef>(event, keyName, workspaceIdInput)
+    const next = items.filter((entry) => !this.sameScopedName(entry, target))
+    if (next.length === items.length) return false
+    await this.setCloudSetting(event, keyName, { items: next }, workspaceIdInput)
+    return true
+  }
+
+  private sameScopedName(
+    left: { name: string; scope?: string; directory?: string | null },
+    right: { name: string; scope?: string; directory?: string | null },
+  ) {
+    return left.name === right.name
+      && (left.scope || 'machine') === (right.scope || 'machine')
+      && (left.directory || null) === (right.directory || null)
+  }
+
+  private applyCredentialStatus(workspace: WorkspaceRegistration): WorkspaceRegistration {
+    if (workspace.kind !== 'cloud') return workspace
+    const accessToken = this.cloudCredentialStore?.getUsableAccessToken(workspace.id)
+    if (!accessToken) return workspace
+    return {
+      ...workspace,
+      status: 'online',
+      error: null,
+    }
+  }
+
+  private toInfo(workspace: WorkspaceRegistration, active: boolean): WorkspaceInfo {
+    return {
+      ...workspace,
+      active,
+      lastSyncedAt: this.syncedAtByWorkspace.get(workspace.id) || workspace.lastSyncedAt || null,
+      status: workspace.status as WorkspaceStatus,
+    }
+  }
+}
+
+export function createWorkspaceGateway(options?: WorkspaceGatewayOptions) {
+  return new WorkspaceGateway(options)
+}

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -932,11 +932,25 @@ export class WorkspaceGateway {
     if (!adapter.subscribeSessionEvents) return
     const key = this.cloudSessionSubscriptionKey(workspace.id, sessionId)
     if (this.cloudSessionSubscriptions.has(key)) return
-    const subscription = adapter.subscribeSessionEvents(sessionId, {
+    let subscription: CloudTransportSubscription | null = null
+    let failedDuringSubscribe = false
+    const onError = (error: unknown) => {
+      failedDuringSubscribe = true
+      if (subscription && this.cloudSessionSubscriptions.get(key) === subscription) {
+        this.cloudSessionSubscriptions.delete(key)
+        try { subscription.close() } catch { /* best effort */ }
+      }
+      input.onError?.(error)
+    }
+    subscription = adapter.subscribeSessionEvents(sessionId, {
       afterSequence: input.afterSequence,
       onEvent: input.onEvent,
-      onError: input.onError,
+      onError,
     })
+    if (failedDuringSubscribe) {
+      try { subscription.close() } catch { /* best effort */ }
+      return
+    }
     this.cloudSessionSubscriptions.set(key, subscription)
   }
 
@@ -954,11 +968,25 @@ export class WorkspaceGateway {
     if (!adapter.subscribeWorkspaceEvents) return
     const key = this.cloudWorkspaceSubscriptionKey(workspace.id, senderKey(event))
     if (this.cloudWorkspaceSubscriptions.has(key)) return
-    const subscription = adapter.subscribeWorkspaceEvents({
+    let subscription: CloudTransportSubscription | null = null
+    let failedDuringSubscribe = false
+    const onError = (error: unknown) => {
+      failedDuringSubscribe = true
+      if (subscription && this.cloudWorkspaceSubscriptions.get(key) === subscription) {
+        this.cloudWorkspaceSubscriptions.delete(key)
+        try { subscription.close() } catch { /* best effort */ }
+      }
+      input.onError?.(error)
+    }
+    subscription = adapter.subscribeWorkspaceEvents({
       afterSequence: input.afterSequence,
       onEvent: input.onEvent,
-      onError: input.onError,
+      onError,
     })
+    if (failedDuringSubscribe) {
+      try { subscription.close() } catch { /* best effort */ }
+      return
+    }
     this.cloudWorkspaceSubscriptions.set(key, subscription)
   }
 

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -31,6 +31,7 @@ import type {
   ScopedArtifactRef,
 } from '@open-cowork/shared'
 import {
+  cloudWorkspaceCacheKey,
   createCloudWorkspaceAdapter,
   type CloudPromptInput,
   type CloudWorkspaceSessionAdapter,
@@ -56,6 +57,10 @@ import {
   createFileCloudWorkspaceCredentialStore,
   type CloudWorkspaceCredentialStore,
 } from './cloud-workspace-credentials.ts'
+import {
+  createFileCloudWorkspaceCache,
+  type CloudWorkspaceCache,
+} from './cloud-workspace-cache.ts'
 import { DEFAULT_CONFIG, type CloudDesktopConfig } from './config-types.ts'
 
 export const LOCAL_WORKSPACE_ID = 'local'
@@ -69,6 +74,7 @@ export type WorkspaceGatewayOptions = {
   cloudDesktop?: CloudDesktopConfig
   cloudRegistry?: CloudWorkspaceRegistry | null
   cloudCredentialStore?: CloudWorkspaceCredentialStore | null
+  cloudCache?: CloudWorkspaceCache | null
   cloudAdapterFactory?: (connection: CloudWorkspaceConnectionRecord, accessToken?: string | null) => CloudWorkspaceSessionAdapter
   cloudLogin?: (connection: CloudWorkspaceConnectionRecord) => Promise<CloudWorkspaceLoginResult>
   cloudRefresh?: (connection: CloudWorkspaceConnectionRecord, refreshToken: string) => Promise<CloudWorkspaceLoginResult>
@@ -149,6 +155,16 @@ const CLOUD_CUSTOM_AGENTS_KEY = 'custom-agents'
 const CLOUD_CUSTOM_MCPS_KEY = 'custom-mcps'
 const CLOUD_CUSTOM_SKILLS_KEY = 'custom-skills'
 
+function cloudRefreshErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isCredentialRefreshAuthFailure(error: unknown) {
+  const message = cloudRefreshErrorMessage(error).toLowerCase()
+  return /\b(invalid_grant|invalid_token|invalid_request|unauthorized_client|access_denied)\b/.test(message)
+    || /\bhttp\s+(400|401|403)\b/.test(message)
+}
+
 function senderKey(event: WorkspaceEventLike) {
   const id = event?.sender?.id
   return typeof id === 'number' && Number.isFinite(id) ? id : 0
@@ -220,6 +236,7 @@ export class WorkspaceGateway {
   private readonly cloudDesktopConfig: CloudDesktopConfig
   private readonly cloudRegistry: CloudWorkspaceRegistry | null
   private readonly cloudCredentialStore: CloudWorkspaceCredentialStore | null
+  private cloudCache: CloudWorkspaceCache | null | undefined
   private readonly cloudAdapterFactory: (connection: CloudWorkspaceConnectionRecord, accessToken?: string | null) => CloudWorkspaceSessionAdapter
   private readonly cloudLogin: (connection: CloudWorkspaceConnectionRecord) => Promise<CloudWorkspaceLoginResult>
   private readonly cloudRefresh: (connection: CloudWorkspaceConnectionRecord, refreshToken: string) => Promise<CloudWorkspaceLoginResult>
@@ -228,7 +245,9 @@ export class WorkspaceGateway {
     this.cloudDesktopConfig = options.cloudDesktop || DEFAULT_CONFIG.cloudDesktop
     this.cloudRegistry = options.cloudRegistry === undefined ? createFileCloudWorkspaceRegistry() : options.cloudRegistry
     this.cloudCredentialStore = options.cloudCredentialStore === undefined ? createFileCloudWorkspaceCredentialStore() : options.cloudCredentialStore
+    this.cloudCache = options.cloudCache
     this.cloudAdapterFactory = options.cloudAdapterFactory || ((connection, accessToken) => createCloudWorkspaceAdapter(connection, accessToken, {
+      cache: this.getCloudCache(),
       cacheMode: this.cloudDesktopConfig.cacheMode,
       cacheEncryptionFallback: this.cloudDesktopConfig.cacheEncryptionFallback,
     }))
@@ -317,8 +336,11 @@ export class WorkspaceGateway {
     const workspaceId = normalizeWorkspaceId(workspaceIdInput)
     if (!workspaceId || workspaceId === LOCAL_WORKSPACE_ID) return false
     if (this.cloudDesktopConfig.requireManagedOrg && this.managedCloudWorkspaceIds.has(workspaceId)) return false
+    const connection = this.cloudConnections.get(workspaceId)
     const removed = this.workspaces.delete(workspaceId)
     const persistedRemoved = this.cloudRegistry?.remove(workspaceId) || false
+    this.cloudCredentialStore?.remove(workspaceId)
+    this.clearCloudCache(connection)
     this.cloudConnections.delete(workspaceId)
     this.cloudAdapters.delete(workspaceId)
     this.closeCloudSubscriptionsForWorkspace(workspaceId)
@@ -945,6 +967,25 @@ export class WorkspaceGateway {
     return this.getWorkspace(workspaceId)
   }
 
+  private getCloudCache() {
+    if (this.cloudCache !== undefined) return this.cloudCache
+    this.cloudCache = createFileCloudWorkspaceCache({
+      mode: this.cloudDesktopConfig.cacheMode,
+      encryptionFallback: this.cloudDesktopConfig.cacheEncryptionFallback,
+    })
+    return this.cloudCache
+  }
+
+  private clearCloudCache(connection?: CloudWorkspaceConnectionRecord) {
+    if (!connection) return
+    try {
+      this.getCloudCache()?.removeWorkspace(cloudWorkspaceCacheKey(connection))
+    } catch {
+      // Cache cleanup is best-effort; credential and registry removal still
+      // need to complete if secure storage is unavailable or the cache is corrupt.
+    }
+  }
+
   private getWorkspace(workspaceIdInput: string): WorkspaceRegistration {
     const workspaceId = normalizeWorkspaceId(workspaceIdInput)
     if (!workspaceId) throw new Error('Workspace id is required.')
@@ -959,7 +1000,8 @@ export class WorkspaceGateway {
     if (!connection) throw new Error('Cloud workspace connection is missing.')
     const accessToken = await this.ensureCloudAccessToken(workspace, connection)
     if (!accessToken) {
-      throw new Error(workspace.error || 'Cloud workspace is not available.')
+      const latestWorkspace = this.workspaces.get(workspace.id) || workspace
+      throw new Error(latestWorkspace.error || 'Cloud workspace is not available.')
     }
     const existing = this.cloudAdapters.get(workspace.id)
     if (existing) return existing
@@ -1009,14 +1051,22 @@ export class WorkspaceGateway {
         error: null,
       })
       return refreshed.accessToken
-    } catch {
-      this.cloudCredentialStore.remove(workspace.id)
+    } catch (error) {
       this.cloudAdapters.delete(workspace.id)
-      this.workspaces.set(workspace.id, {
-        ...workspace,
-        status: 'auth_required',
-        error: 'Sign in to this cloud workspace to enable sync.',
-      })
+      if (isCredentialRefreshAuthFailure(error)) {
+        this.cloudCredentialStore.remove(workspace.id)
+        this.workspaces.set(workspace.id, {
+          ...workspace,
+          status: 'auth_required',
+          error: 'Sign in to this cloud workspace to enable sync.',
+        })
+      } else {
+        this.workspaces.set(workspace.id, {
+          ...workspace,
+          status: 'offline',
+          error: 'Cloud workspace is offline or unavailable. Retry when the connection recovers.',
+        })
+      }
       return null
     }
   }

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -1168,7 +1168,8 @@ export class WorkspaceGateway {
   private applyCredentialStatus(workspace: WorkspaceRegistration): WorkspaceRegistration {
     if (workspace.kind !== 'cloud') return workspace
     const accessToken = this.cloudCredentialStore?.getUsableAccessToken(workspace.id)
-    if (!accessToken) return workspace
+    const credential = accessToken ? null : this.cloudCredentialStore?.get(workspace.id)
+    if (!accessToken && !credential?.refreshToken) return workspace
     return {
       ...workspace,
       status: 'online',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -8,9 +8,19 @@ import type {
   SessionPatch,
   SessionView,
   UpdateInstallEvent,
+  WorkspaceSessionsUpdatedEvent,
 } from '@open-cowork/shared'
 
 const PRELOAD_INVOKE_CHANNELS = [
+  'workspace:list',
+  'workspace:activate',
+  'workspace:add-cloud',
+  'workspace:remove',
+  'workspace:login',
+  'workspace:logout',
+  'workspace:policy',
+  'workspace:support',
+  'workspace:sync',
   'auth:status',
   'auth:login',
   'auth:logout',
@@ -41,6 +51,8 @@ const PRELOAD_INVOKE_CHANNELS = [
   'dialog:save-text',
   'chart:render-svg',
   'chart:save-artifact',
+  'artifact:list',
+  'artifact:upload',
   'artifact:export',
   'artifact:reveal',
   'artifact:read-attachment',
@@ -157,6 +169,7 @@ const PRELOAD_LISTEN_CHANNELS = [
   'runtime:loading-status',
   'session:updated',
   'session:deleted',
+  'workspace:sessions-updated',
   'workflow:updated',
 ] as const
 
@@ -192,19 +205,30 @@ function listen(channel: PreloadListenChannel, handler: IpcRendererListener) {
 }
 
 const api: CoworkAPI = {
+  workspace: {
+    list: () => invoke('workspace:list'),
+    activate: (workspaceId) => invoke('workspace:activate', workspaceId),
+    addCloud: (input) => invoke('workspace:add-cloud', input),
+    remove: (workspaceId) => invoke('workspace:remove', workspaceId),
+    login: (workspaceId) => invoke('workspace:login', workspaceId),
+    logout: (workspaceId) => invoke('workspace:logout', workspaceId),
+    policy: (workspaceId) => invoke('workspace:policy', workspaceId),
+    support: (workspaceId) => invoke('workspace:support', workspaceId),
+    sync: (workspaceId) => invoke('workspace:sync', workspaceId),
+  },
   auth: {
     status: () => invoke('auth:status'),
     login: () => invoke('auth:login'),
     logout: () => invoke('auth:logout'),
   },
   session: {
-    create: (directory?) => invoke('session:create', directory),
+    create: (directory?, options?) => invoke('session:create', directory, options),
     activate: (sessionId, options) => invoke('session:activate', sessionId, options),
     prompt: (sessionId, text, attachments, agent, options) => invoke('session:prompt', sessionId, text, attachments, agent, options),
     setComposerPreferences: (sessionId, preferences) => invoke('session:set-composer-preferences', sessionId, preferences),
-    list: () => invoke('session:list'),
-    get: (id) => invoke('session:get', id),
-    abort: (sessionId) => invoke('session:abort', sessionId),
+    list: (options?) => invoke('session:list', options),
+    get: (id, options?) => invoke('session:get', id, options),
+    abort: (sessionId, options) => invoke('session:abort', sessionId, options),
     abortTask: (rootSessionId, childSessionId) => invoke('session:abort-task', rootSessionId, childSessionId),
     rename: (sessionId, title) => invoke('session:rename', sessionId, title),
     delete: (sessionId, confirmationToken) => invoke('session:delete', sessionId, confirmationToken),
@@ -231,6 +255,8 @@ const api: CoworkAPI = {
     saveArtifact: (request) => invoke('chart:save-artifact', request),
   },
   artifact: {
+    list: (request) => invoke('artifact:list', request),
+    upload: (request) => invoke('artifact:upload', request),
     export: (request) => invoke('artifact:export', request),
     reveal: (request) => invoke('artifact:reveal', request),
     readAttachment: (request) => invoke('artifact:read-attachment', request),
@@ -258,7 +284,7 @@ const api: CoworkAPI = {
     reject: (sessionId, requestId) => invoke('question:reject', sessionId, requestId),
   },
   settings: {
-    get: () => invoke('settings:get'),
+    get: (options) => invoke('settings:get', options),
     getProviderCredentials: (providerId) => invoke('settings:get-provider-credentials', providerId),
     getIntegrationCredentials: (integrationId) => invoke('settings:get-integration-credentials', integrationId),
     set: (updates) => invoke('settings:set', updates),
@@ -313,31 +339,31 @@ const api: CoworkAPI = {
     },
   },
   workflows: {
-    list: () => invoke('workflows:list'),
-    get: (workflowId) => invoke('workflows:get', workflowId),
+    list: (options) => options ? invoke('workflows:list', options) : invoke('workflows:list'),
+    get: (workflowId, options) => options ? invoke('workflows:get', workflowId, options) : invoke('workflows:get', workflowId),
     startDraft: (directory) => invoke('workflows:start-draft', directory),
-    runNow: (workflowId) => invoke('workflows:run-now', workflowId),
-    pause: (workflowId) => invoke('workflows:pause', workflowId),
-    resume: (workflowId) => invoke('workflows:resume', workflowId),
-    archive: (workflowId) => invoke('workflows:archive', workflowId),
+    runNow: (workflowId, options) => options ? invoke('workflows:run-now', workflowId, options) : invoke('workflows:run-now', workflowId),
+    pause: (workflowId, options) => options ? invoke('workflows:pause', workflowId, options) : invoke('workflows:pause', workflowId),
+    resume: (workflowId, options) => options ? invoke('workflows:resume', workflowId, options) : invoke('workflows:resume', workflowId),
+    archive: (workflowId, options) => options ? invoke('workflows:archive', workflowId, options) : invoke('workflows:archive', workflowId),
     regenerateWebhookSecret: (workflowId) => invoke('workflows:regenerate-webhook-secret', workflowId),
   },
   threads: {
     search: (query) => invoke('threads:search', query),
     facets: (query) => invoke('threads:facets', query),
     tags: {
-      list: () => invoke('threads:tags:list'),
-      create: (input) => invoke('threads:tags:create', input),
-      update: (tagId, input) => invoke('threads:tags:update', tagId, input),
-      delete: (tagId) => invoke('threads:tags:delete', tagId),
-      apply: (sessionIds, tagIds) => invoke('threads:tags:apply', sessionIds, tagIds),
-      remove: (sessionIds, tagIds) => invoke('threads:tags:remove', sessionIds, tagIds),
+      list: (options) => options ? invoke('threads:tags:list', options) : invoke('threads:tags:list'),
+      create: (input, options) => options ? invoke('threads:tags:create', input, options) : invoke('threads:tags:create', input),
+      update: (tagId, input, options) => options ? invoke('threads:tags:update', tagId, input, options) : invoke('threads:tags:update', tagId, input),
+      delete: (tagId, options) => options ? invoke('threads:tags:delete', tagId, options) : invoke('threads:tags:delete', tagId),
+      apply: (sessionIds, tagIds, options) => options ? invoke('threads:tags:apply', sessionIds, tagIds, options) : invoke('threads:tags:apply', sessionIds, tagIds),
+      remove: (sessionIds, tagIds, options) => options ? invoke('threads:tags:remove', sessionIds, tagIds, options) : invoke('threads:tags:remove', sessionIds, tagIds),
     },
     smartFilters: {
-      list: () => invoke('threads:smart-filters:list'),
-      create: (input) => invoke('threads:smart-filters:create', input),
-      update: (filterId, input) => invoke('threads:smart-filters:update', filterId, input),
-      delete: (filterId) => invoke('threads:smart-filters:delete', filterId),
+      list: (options) => options ? invoke('threads:smart-filters:list', options) : invoke('threads:smart-filters:list'),
+      create: (input, options) => options ? invoke('threads:smart-filters:create', input, options) : invoke('threads:smart-filters:create', input),
+      update: (filterId, input, options) => options ? invoke('threads:smart-filters:update', filterId, input, options) : invoke('threads:smart-filters:update', filterId, input),
+      delete: (filterId, options) => options ? invoke('threads:smart-filters:delete', filterId, options) : invoke('threads:smart-filters:delete', filterId),
     },
     suggestions: {
       accept: (suggestionId) => invoke('threads:suggestions:accept', suggestionId),
@@ -390,7 +416,7 @@ const api: CoworkAPI = {
       return listen('runtime:notification', handler)
     },
     sessionView: (callback) => {
-      const handler = (_event: Electron.IpcRendererEvent, data: { sessionId: string; view: SessionView }) => callback(data)
+      const handler = (_event: Electron.IpcRendererEvent, data: { sessionId: string; workspaceId?: string | null; view: SessionView }) => callback(data)
       return listen('session:view', handler)
     },
     permissionRequest: (callback: (request: PermissionRequest) => void) => {
@@ -432,6 +458,10 @@ const api: CoworkAPI = {
     sessionDeleted: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) => callback(data)
       return listen('session:deleted', handler)
+    },
+    workspaceSessionsUpdated: (callback: (data: WorkspaceSessionsUpdatedEvent) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: WorkspaceSessionsUpdatedEvent) => callback(data)
+      return listen('workspace:sessions-updated', handler)
     },
     workflowUpdated: (callback: () => void) => {
       const handler = () => callback()

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -277,11 +277,11 @@ const api: CoworkAPI = {
     run: (sessionId, name) => invoke('command:run', sessionId, name),
   },
   permission: {
-    respond: (id, allowed, sessionId) => invoke('permission:respond', id, allowed, sessionId),
+    respond: (id, allowed, sessionId, options) => invoke('permission:respond', id, allowed, sessionId, options),
   },
   question: {
-    reply: (sessionId, requestId, answers) => invoke('question:reply', sessionId, requestId, answers),
-    reject: (sessionId, requestId) => invoke('question:reject', sessionId, requestId),
+    reply: (sessionId, requestId, answers, options) => invoke('question:reply', sessionId, requestId, answers, options),
+    reject: (sessionId, requestId, options) => invoke('question:reject', sessionId, requestId, options),
   },
   settings: {
     get: (options) => invoke('settings:get', options),

--- a/apps/desktop/src/renderer/components/chat/ApprovalCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ApprovalCard.test.tsx
@@ -28,7 +28,7 @@ describe('ApprovalCard', () => {
     await user.click(screen.getByRole('button', { name: 'Deny' }))
 
     await waitFor(() => expect(window.coworkApi.permission.respond).toHaveBeenCalledTimes(2))
-    expect(window.coworkApi.permission.respond).toHaveBeenNthCalledWith(1, 'permission-1', true, 'session-1')
-    expect(window.coworkApi.permission.respond).toHaveBeenNthCalledWith(2, 'permission-1', false, 'session-1')
+    expect(window.coworkApi.permission.respond).toHaveBeenNthCalledWith(1, 'permission-1', true, 'session-1', { workspaceId: 'local' })
+    expect(window.coworkApi.permission.respond).toHaveBeenNthCalledWith(2, 'permission-1', false, 'session-1', { workspaceId: 'local' })
   })
 })

--- a/apps/desktop/src/renderer/components/chat/ApprovalCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ApprovalCard.tsx
@@ -1,4 +1,5 @@
 import type { PendingApproval } from '../../stores/session'
+import { useSessionStore } from '../../stores/session'
 import { t } from '../../helpers/i18n'
 
 // Map tool names to user-friendly descriptions
@@ -31,9 +32,12 @@ function describeAction(tool: string, input: Record<string, unknown>): { verb: s
 }
 
 export function ApprovalCard({ approval }: { approval: PendingApproval }) {
+  const activeWorkspaceId = useSessionStore((state) => state.activeWorkspaceId)
   const respond = async (allowed: boolean) => {
     try {
-      await window.coworkApi.permission.respond(approval.id, allowed, approval.sessionId)
+      await window.coworkApi.permission.respond(approval.id, allowed, approval.sessionId, {
+        workspaceId: approval.workspaceId || activeWorkspaceId,
+      })
     } catch {
       // Permission response errors are surfaced through the session error channel.
     }

--- a/apps/desktop/src/renderer/components/chat/SessionInspector.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionInspector.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ModelInfoSnapshot, SessionView, TaskRun } from '@open-cowork/shared'
 import { useSessionStore, type Message } from '../../stores/session'
+import { sessionWorkspaceKey } from '../../stores/session-workspace-keys'
 import { t } from '../../helpers/i18n'
 import { listSessionArtifacts } from './session-artifacts'
 import { SessionArtifactList } from './SessionArtifactList'
@@ -145,6 +146,7 @@ function MessageList({ messages }: { messages: Message[] }) {
 
 export function SessionInspector({ onClose }: InspectorProps) {
   const currentSessionId = useSessionStore((state) => state.currentSessionId)
+  const activeWorkspaceId = useSessionStore((state) => state.activeWorkspaceId)
   const sessions = useSessionStore((state) => state.sessions)
   const currentView = useSessionStore((state) => state.currentView)
   // Subscribe to the whole map so the selector returns a stable
@@ -153,8 +155,11 @@ export function SessionInspector({ onClose }: InspectorProps) {
   // locally inside useMemo for the merged list.
   const chartArtifactsBySession = useSessionStore((state) => state.chartArtifactsBySession)
   const chartArtifacts = useMemo(
-    () => (currentSessionId ? chartArtifactsBySession[currentSessionId] || [] : []),
-    [chartArtifactsBySession, currentSessionId],
+    () => {
+      if (!currentSessionId) return []
+      return chartArtifactsBySession[sessionWorkspaceKey(activeWorkspaceId, currentSessionId)] || []
+    },
+    [activeWorkspaceId, chartArtifactsBySession, currentSessionId],
   )
   const [tab, setTab] = useState<InspectorTab>('context')
   const [runtimeModel, setRuntimeModel] = useState<RuntimeModelState>({

--- a/apps/desktop/src/renderer/components/chat/SessionQuestionDock.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionQuestionDock.test.tsx
@@ -33,6 +33,7 @@ function installQuestionApi() {
 function resetSessionStore() {
   const currentView = useSessionStore.getState().currentView
   useSessionStore.setState({
+    activeWorkspaceId: 'local',
     currentSessionId: 'session-1',
     currentView: {
       ...currentView,
@@ -97,7 +98,7 @@ describe('SessionQuestionDock', () => {
     await waitFor(() => expect(api.question.reply).toHaveBeenCalledWith('session-1', 'question-1', [
       ['Use the safe path'],
       ['Run tests', 'Capture screenshots'],
-    ]))
+    ], { workspaceId: 'local' }))
   })
 
   it('surfaces the scoped tool call and scrolls to it on request', async () => {
@@ -133,7 +134,7 @@ describe('SessionQuestionDock', () => {
 
     await user.click(screen.getByRole('button', { name: 'Dismiss' }))
 
-    await waitFor(() => expect(api.question.reject).toHaveBeenCalledWith('session-1', 'question-1'))
+    await waitFor(() => expect(api.question.reject).toHaveBeenCalledWith('session-1', 'question-1', { workspaceId: 'local' }))
     expect(api.question.reply).not.toHaveBeenCalled()
   })
 
@@ -178,6 +179,6 @@ describe('SessionQuestionDock', () => {
 
     await waitFor(() => expect(api.question.reply).toHaveBeenCalledWith('session-1', 'question-2', [
       ['Continue'],
-    ]))
+    ], { workspaceId: 'local' }))
   })
 })

--- a/apps/desktop/src/renderer/components/chat/SessionQuestionDock.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionQuestionDock.tsx
@@ -10,6 +10,7 @@ type Props = {
 
 export function SessionQuestionDock({ request, queueCount = 1 }: Props) {
   const currentSessionId = useSessionStore((s) => s.currentSessionId)
+  const activeWorkspaceId = useSessionStore((s) => s.activeWorkspaceId)
   const toolCalls = useSessionStore((s) => s.currentView.toolCalls)
   const [step, setStep] = useState(0)
   const [answers, setAnswers] = useState<string[][]>([])
@@ -96,7 +97,9 @@ export function SessionQuestionDock({ request, queueCount = 1 }: Props) {
 
     setSubmitting(true)
     try {
-      await window.coworkApi.question.reply(currentSessionId, request.id, answers)
+      await window.coworkApi.question.reply(currentSessionId, request.id, answers, {
+        workspaceId: request.workspaceId || activeWorkspaceId,
+      })
     } finally {
       setSubmitting(false)
     }
@@ -106,7 +109,9 @@ export function SessionQuestionDock({ request, queueCount = 1 }: Props) {
     if (!currentSessionId || submitting) return
     setSubmitting(true)
     try {
-      await window.coworkApi.question.reject(currentSessionId, request.id)
+      await window.coworkApi.question.reject(currentSessionId, request.id, {
+        workspaceId: request.workspaceId || activeWorkspaceId,
+      })
     } finally {
       setSubmitting(false)
     }

--- a/apps/desktop/src/renderer/components/chat/session-artifacts.ts
+++ b/apps/desktop/src/renderer/components/chat/session-artifacts.ts
@@ -49,6 +49,7 @@ export function listSessionArtifacts(
     ...view.taskRuns.flatMap((taskRun) =>
       taskRun.toolCalls.map((tool) => artifactFromTool(tool, taskRun.id)),
     ),
+    ...(view.artifacts || []),
     // Extras typically come from renderer-side state (e.g. chart PNG
     // captures) that aren't represented as tool-call inputs. Dedupe
     // treats them the same as any other artifact.

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { Sidebar } from './Sidebar'
+import { installRendererTestCoworkApi } from '../../test/setup'
 
 describe('Sidebar', () => {
   it('keeps the upstream sidebar layout when no branding config is provided', () => {
@@ -15,6 +16,159 @@ describe('Sidebar', () => {
     expect(screen.getByText('Workflows')).toBeTruthy()
     expect(screen.getByText('Tools & Skills')).toBeTruthy()
     expect(screen.queryByText('Acme AI')).toBeNull()
+  })
+
+  it('renders the workspace switcher and activates a selected workspace', async () => {
+    installRendererTestCoworkApi({
+      workspace: {
+        list: vi.fn()
+          .mockResolvedValueOnce([
+            {
+              id: 'local',
+              kind: 'local',
+              label: 'Local',
+              status: 'online',
+              active: true,
+              lastSyncedAt: null,
+            },
+            {
+              id: 'cloud:acme',
+              kind: 'cloud',
+              label: 'Acme Cloud',
+              status: 'disabled',
+              active: false,
+              baseUrl: 'https://cloud.acme.test',
+              lastSyncedAt: null,
+            },
+          ])
+          .mockResolvedValueOnce([
+            {
+              id: 'local',
+              kind: 'local',
+              label: 'Local',
+              status: 'online',
+              active: false,
+              lastSyncedAt: null,
+            },
+            {
+              id: 'cloud:acme',
+              kind: 'cloud',
+              label: 'Acme Cloud',
+              status: 'disabled',
+              active: true,
+              baseUrl: 'https://cloud.acme.test',
+              lastSyncedAt: null,
+            },
+          ]),
+        activate: vi.fn(async () => ({
+          id: 'cloud:acme',
+          kind: 'cloud',
+          label: 'Acme Cloud',
+          status: 'disabled',
+          active: true,
+          baseUrl: 'https://cloud.acme.test',
+          lastSyncedAt: null,
+        })),
+      },
+    })
+
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+      />,
+    )
+
+    const switcher = await screen.findByRole('button', { name: /Local.*Online.*Local workspace/i })
+    fireEvent.click(switcher)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Disabled/i }))
+
+    await waitFor(() => {
+      expect(window.coworkApi.workspace.activate).toHaveBeenCalledWith('cloud:acme')
+    })
+  })
+
+  it('starts login when selecting an auth-required cloud workspace', async () => {
+    const sessionList = vi.fn(async () => [])
+    installRendererTestCoworkApi({
+      workspace: {
+        list: vi.fn()
+          .mockResolvedValueOnce([
+            {
+              id: 'local',
+              kind: 'local',
+              label: 'Local',
+              status: 'online',
+              active: true,
+              lastSyncedAt: null,
+            },
+            {
+              id: 'cloud:acme',
+              kind: 'cloud',
+              label: 'Acme Cloud',
+              status: 'auth_required',
+              active: false,
+              baseUrl: 'https://cloud.acme.test',
+              lastSyncedAt: null,
+            },
+          ])
+          .mockResolvedValueOnce([
+            {
+              id: 'local',
+              kind: 'local',
+              label: 'Local',
+              status: 'online',
+              active: false,
+              lastSyncedAt: null,
+            },
+            {
+              id: 'cloud:acme',
+              kind: 'cloud',
+              label: 'Acme Cloud',
+              status: 'online',
+              active: true,
+              baseUrl: 'https://cloud.acme.test',
+              lastSyncedAt: '2026-05-27T10:00:00.000Z',
+            },
+          ]),
+        activate: vi.fn(async () => ({
+          id: 'cloud:acme',
+          kind: 'cloud',
+          label: 'Acme Cloud',
+          status: 'auth_required',
+          active: true,
+          baseUrl: 'https://cloud.acme.test',
+          lastSyncedAt: null,
+        })),
+        login: vi.fn(async () => ({
+          id: 'cloud:acme',
+          kind: 'cloud',
+          label: 'Acme Cloud',
+          status: 'online',
+          active: true,
+          baseUrl: 'https://cloud.acme.test',
+          lastSyncedAt: '2026-05-27T10:00:00.000Z',
+        })),
+      },
+      session: {
+        list: sessionList,
+      },
+    })
+
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Sign in/i }))
+
+    await waitFor(() => {
+      expect(window.coworkApi.workspace.login).toHaveBeenCalledWith('cloud:acme')
+      expect(sessionList).toHaveBeenCalledWith({ workspaceId: 'cloud:acme' })
+    })
   })
 
   it('renders configured top and lower downstream branding surfaces', () => {

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -135,10 +135,10 @@ describe('Sidebar', () => {
           id: 'cloud:acme',
           kind: 'cloud',
           label: 'Acme Cloud',
-          status: 'auth_required',
+          status: 'online',
           active: true,
           baseUrl: 'https://cloud.acme.test',
-          lastSyncedAt: null,
+          lastSyncedAt: '2026-05-27T10:00:00.000Z',
         })),
         login: vi.fn(async () => ({
           id: 'cloud:acme',
@@ -169,6 +169,86 @@ describe('Sidebar', () => {
       expect(window.coworkApi.workspace.login).toHaveBeenCalledWith('cloud:acme')
       expect(sessionList).toHaveBeenCalledWith({ workspaceId: 'cloud:acme' })
     })
+  })
+
+  it('restores the previous workspace when cloud login fails', async () => {
+    const sessionList = vi.fn(async () => [])
+    const activate = vi.fn(async (workspaceId: string) => ({
+      id: workspaceId,
+      kind: workspaceId === 'local' ? 'local' : 'cloud',
+      label: workspaceId === 'local' ? 'Local' : 'Acme Cloud',
+      status: workspaceId === 'local' ? 'online' : 'auth_required',
+      active: true,
+      ...(workspaceId === 'local' ? {} : { baseUrl: 'https://cloud.acme.test' }),
+      lastSyncedAt: null,
+    }))
+    installRendererTestCoworkApi({
+      workspace: {
+        list: vi.fn()
+          .mockResolvedValueOnce([
+            {
+              id: 'local',
+              kind: 'local',
+              label: 'Local',
+              status: 'online',
+              active: true,
+              lastSyncedAt: null,
+            },
+            {
+              id: 'cloud:acme',
+              kind: 'cloud',
+              label: 'Acme Cloud',
+              status: 'auth_required',
+              active: false,
+              baseUrl: 'https://cloud.acme.test',
+              lastSyncedAt: null,
+            },
+          ])
+          .mockResolvedValueOnce([
+            {
+              id: 'local',
+              kind: 'local',
+              label: 'Local',
+              status: 'online',
+              active: true,
+              lastSyncedAt: null,
+            },
+            {
+              id: 'cloud:acme',
+              kind: 'cloud',
+              label: 'Acme Cloud',
+              status: 'auth_required',
+              active: false,
+              baseUrl: 'https://cloud.acme.test',
+              lastSyncedAt: null,
+            },
+          ]),
+        activate,
+        login: vi.fn(async () => {
+          throw new Error('Login cancelled')
+        }),
+      },
+      session: {
+        list: sessionList,
+      },
+    })
+
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Sign in/i }))
+
+    await waitFor(() => {
+      expect(window.coworkApi.workspace.login).toHaveBeenCalledWith('cloud:acme')
+      expect(activate).toHaveBeenCalledWith('local')
+    })
+    expect(activate).not.toHaveBeenCalledWith('cloud:acme')
+    expect(sessionList).toHaveBeenCalledWith({ workspaceId: 'local' })
   })
 
   it('renders configured top and lower downstream branding surfaces', () => {

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -1,10 +1,11 @@
 import { lazy, Suspense, useEffect, useState, type CSSProperties } from 'react'
-import type { BrandingSidebarConfig, BrandingSidebarLowerConfig, BrandingSidebarTopConfig } from '@open-cowork/shared'
+import type { BrandingSidebarConfig, BrandingSidebarLowerConfig, BrandingSidebarTopConfig, WorkspaceInfo } from '@open-cowork/shared'
 import { ThreadList } from '../sidebar/ThreadList'
 import { McpStatus } from '../sidebar/McpStatus'
 import { NewThreadButton } from '../sidebar/NewThreadButton'
 import { t } from '../../helpers/i18n'
 import type { AppView } from '../../app-types'
+import { useSessionStore } from '../../stores/session'
 
 interface Props {
   currentView: AppView
@@ -213,6 +214,154 @@ function SidebarLowerBranding({ lower }: { lower?: BrandingSidebarLowerConfig })
   )
 }
 
+const LOCAL_WORKSPACE_FALLBACK: WorkspaceInfo = {
+  id: 'local',
+  kind: 'local',
+  label: 'Local',
+  status: 'online',
+  active: true,
+  lastSyncedAt: null,
+}
+
+function workspaceStatusLabel(status: WorkspaceInfo['status']) {
+  switch (status) {
+    case 'online':
+      return t('workspace.status.online', 'Online')
+    case 'offline':
+      return t('workspace.status.offline', 'Offline')
+    case 'auth_required':
+      return t('workspace.status.authRequired', 'Sign in')
+    case 'disabled':
+      return t('workspace.status.disabled', 'Disabled')
+    case 'error':
+      return t('workspace.status.error', 'Error')
+    default:
+      return status
+  }
+}
+
+function workspaceStatusClass(status: WorkspaceInfo['status']) {
+  if (status === 'online') return 'border-green-500/30 text-green-200'
+  if (status === 'offline') return 'border-amber-500/30 text-amber-200'
+  if (status === 'auth_required') return 'border-sky-400/30 text-sky-200'
+  return 'border-red-400/30 text-red-200'
+}
+
+function WorkspaceSwitcher() {
+  const setSessions = useSessionStore((state) => state.setSessions)
+  const setCurrentSession = useSessionStore((state) => state.setCurrentSession)
+  const setActiveWorkspace = useSessionStore((state) => state.setActiveWorkspace)
+  const addGlobalError = useSessionStore((state) => state.addGlobalError)
+  const [workspaces, setWorkspaces] = useState<WorkspaceInfo[]>([LOCAL_WORKSPACE_FALLBACK])
+  const [open, setOpen] = useState(false)
+
+  const activeWorkspace = workspaces.find((workspace) => workspace.active) || workspaces[0] || LOCAL_WORKSPACE_FALLBACK
+
+  useEffect(() => {
+    let cancelled = false
+    const workspaceApi = window.coworkApi?.workspace
+    if (!workspaceApi) return
+    workspaceApi.list()
+      .then(async (next) => {
+        if (cancelled) return
+        const listedWorkspaces = next.length > 0 ? next : [LOCAL_WORKSPACE_FALLBACK]
+        setWorkspaces(listedWorkspaces)
+        const active = listedWorkspaces.find((workspace) => workspace.active) || listedWorkspaces[0] || LOCAL_WORKSPACE_FALLBACK
+        setActiveWorkspace(active.id)
+        if (active.kind === 'local' || active.status === 'online') {
+          const sessions = await window.coworkApi.session.list({ workspaceId: active.id })
+          if (!cancelled) setSessions(sessions)
+        } else if (!cancelled) {
+          setSessions([])
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setWorkspaces([LOCAL_WORKSPACE_FALLBACK])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [setActiveWorkspace, setSessions])
+
+  const activateWorkspace = async (workspace: WorkspaceInfo) => {
+    const previousId = activeWorkspace.id
+    setOpen(false)
+    try {
+      let activated = await window.coworkApi.workspace.activate(workspace.id)
+      if (activated.kind === 'cloud' && activated.status === 'auth_required') {
+        activated = await window.coworkApi.workspace.login(activated.id)
+      }
+      const nextWorkspaces = await window.coworkApi.workspace.list()
+      setWorkspaces(nextWorkspaces.length > 0 ? nextWorkspaces : [activated])
+      if (activated.id !== previousId) {
+        setActiveWorkspace(activated.id)
+        setCurrentSession(null)
+      }
+      if (activated.kind === 'local' || activated.status === 'online') {
+        setSessions(await window.coworkApi.session.list({ workspaceId: activated.id }))
+      } else {
+        setSessions([])
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      addGlobalError(message || t('workspace.switchFailed', 'Could not switch workspace.'))
+    }
+  }
+
+  return (
+    <div className="relative px-3 pb-2">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="w-full rounded-lg border border-border-subtle px-3 py-2 text-start text-[12px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text"
+      >
+        <div className="flex min-w-0 items-center justify-between gap-2">
+          <span className="min-w-0 truncate font-medium">{activeWorkspace.label}</span>
+          <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] ${workspaceStatusClass(activeWorkspace.status)}`}>
+            {workspaceStatusLabel(activeWorkspace.status)}
+          </span>
+        </div>
+        <div className="mt-0.5 truncate text-[10px] text-text-muted">
+          {activeWorkspace.kind === 'local'
+            ? t('workspace.local', 'Local workspace')
+            : activeWorkspace.profileName || activeWorkspace.baseUrl || t('workspace.cloud', 'Cloud workspace')}
+        </div>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute start-3 end-3 top-full z-50 mt-1 overflow-hidden rounded-lg border border-border-subtle bg-elevated shadow-card"
+        >
+          {workspaces.map((workspace) => (
+            <button
+              key={workspace.id}
+              type="button"
+              role="menuitem"
+              onClick={() => void activateWorkspace(workspace)}
+              className={`w-full px-3 py-2 text-start text-[12px] transition-colors hover:bg-surface-hover ${workspace.active ? 'text-text' : 'text-text-secondary'}`}
+            >
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <span className="truncate font-medium">{workspace.label}</span>
+                <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] ${workspaceStatusClass(workspace.status)}`}>
+                  {workspaceStatusLabel(workspace.status)}
+                </span>
+              </div>
+              <div className="mt-0.5 truncate text-[10px] text-text-muted">
+                {workspace.kind === 'local'
+                  ? t('workspace.local', 'Local workspace')
+                  : workspace.profileName || workspace.baseUrl || t('workspace.cloud', 'Cloud workspace')}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function Sidebar({
   currentView,
   onViewChange,
@@ -252,6 +401,7 @@ export function Sidebar({
       ) : (
         <>
           <SidebarBrandTop top={branding?.top} />
+          <WorkspaceSwitcher />
           <div className="p-3 pb-1 flex gap-2">
             <div className="flex-1">
               <NewThreadButton onClick={() => onViewChange('chat')} />

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -287,9 +287,13 @@ function WorkspaceSwitcher() {
     const previousId = activeWorkspace.id
     setOpen(false)
     try {
+      if (workspace.kind === 'cloud' && workspace.status === 'auth_required') {
+        await window.coworkApi.workspace.login(workspace.id)
+      }
       let activated = await window.coworkApi.workspace.activate(workspace.id)
       if (activated.kind === 'cloud' && activated.status === 'auth_required') {
-        activated = await window.coworkApi.workspace.login(activated.id)
+        await window.coworkApi.workspace.login(activated.id)
+        activated = await window.coworkApi.workspace.activate(activated.id)
       }
       const nextWorkspaces = await window.coworkApi.workspace.list()
       setWorkspaces(nextWorkspaces.length > 0 ? nextWorkspaces : [activated])
@@ -304,6 +308,20 @@ function WorkspaceSwitcher() {
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      try {
+        const restored = await window.coworkApi.workspace.activate(previousId)
+        const restoredWorkspaces = await window.coworkApi.workspace.list()
+        setWorkspaces(restoredWorkspaces.length > 0 ? restoredWorkspaces : [restored])
+        setActiveWorkspace(restored.id)
+        if (restored.kind === 'local' || restored.status === 'online') {
+          setSessions(await window.coworkApi.session.list({ workspaceId: restored.id }))
+        } else {
+          setSessions([])
+        }
+      } catch {
+        // Leave the visible workspace unchanged if rollback also fails; the
+        // original login error is still the actionable user-facing failure.
+      }
       addGlobalError(message || t('workspace.switchFailed', 'Could not switch workspace.'))
     }
   }

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.test.tsx
@@ -55,6 +55,8 @@ function emptySessionView(): SessionView {
 
 beforeEach(() => {
   useSessionStore.setState({
+    activeWorkspaceId: 'local',
+    sessionsByWorkspace: { local: sessions },
     sessions,
     currentSessionId: 'session-1',
     currentView: emptySessionView(),
@@ -104,5 +106,27 @@ describe('ThreadList', () => {
     fireEvent.keyDown(menu, { key: 'Escape' })
     await waitFor(() => expect(row).toHaveFocus())
     expect(row).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('hides local-only thread action menus in cloud workspaces', () => {
+    useSessionStore.setState({
+      activeWorkspaceId: 'cloud:acme',
+      sessionsByWorkspace: { 'cloud:acme': sessions },
+      sessions,
+      currentSessionId: 'session-1',
+    })
+
+    render(<ThreadList />)
+
+    const row = screen.getByRole('button', { name: /Current thread/ })
+    expect(row).not.toHaveAttribute('aria-haspopup')
+    expect(row).not.toHaveAttribute('aria-expanded')
+
+    fireEvent.keyDown(row, { key: 'ContextMenu' })
+    fireEvent.contextMenu(row)
+
+    expect(screen.queryByRole('menu', { name: 'Thread actions' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Rename' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useSessionStore } from '../../stores/session'
-import { sessionWorkspaceKey } from '../../stores/session-workspace-keys'
+import { LOCAL_WORKSPACE_ID, normalizeWorkspaceId, sessionWorkspaceKey } from '../../stores/session-workspace-keys'
 import { loadSessionMessages } from '../../helpers/loadSessionMessages'
 import { DiffViewer } from '../chat/DiffViewer'
 import { confirmSessionDelete } from '../../helpers/destructive-actions'
@@ -27,6 +27,7 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   const removeSession = useSessionStore((s) => s.removeSession)
   const busySessions = useSessionStore((s) => s.busySessions)
   const awaitingQuestionSessions = useSessionStore((s) => s.awaitingQuestionSessions)
+  const activeWorkspaceIsLocal = normalizeWorkspaceId(activeWorkspaceId) === LOCAL_WORKSPACE_ID
 
   const [menuId, setMenuId] = useState<string | null>(null)
   const [menuPos, setMenuPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
@@ -91,6 +92,13 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
     if (focusRowTimerRef.current) window.clearTimeout(focusRowTimerRef.current)
   }, [])
 
+  useEffect(() => {
+    if (activeWorkspaceIsLocal) return
+    setMenuId(null)
+    setEditingId(null)
+    setDiffSessionId(null)
+  }, [activeWorkspaceIsLocal])
+
   if (interactiveSessions.length === 0) {
     return <div className="px-2 py-3 text-[11px] text-text-muted text-center">{t('sidebar.noThreads', 'No threads yet')}</div>
   }
@@ -107,6 +115,7 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   }
 
   const handleRename = async (id: string) => {
+    if (!activeWorkspaceIsLocal) { setEditingId(null); setMenuId(null); return }
     if (!editTitle.trim()) { setEditingId(null); return }
     const ok = await window.coworkApi.session.rename(id, editTitle.trim())
     if (ok) renameSession(id, editTitle.trim())
@@ -115,6 +124,7 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   }
 
   const handleDelete = async (id: string) => {
+    if (!activeWorkspaceIsLocal) { setMenuId(null); return }
     const confirmation = await confirmSessionDelete(id)
     if (!confirmation) {
       setMenuId(null)
@@ -126,6 +136,7 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   }
 
   const openMenuAt = (xInput: number, yInput: number, sessionId: string) => {
+    if (!activeWorkspaceIsLocal) return
     // Clamp so the menu doesn't go off-screen
     const y = Math.min(yInput, window.innerHeight - 140)
     const x = Math.min(xInput, window.innerWidth - 170)
@@ -212,10 +223,10 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
                   else rowRefs.current.delete(session.id)
                 }}
                 onClick={() => handleSelect(session.id)}
-                onContextMenu={(e) => openMenu(e, session.id)}
-                onKeyDown={(e) => openMenuFromKeyboard(e, session.id)}
-                aria-haspopup="menu"
-                aria-expanded={menuId === session.id}
+                onContextMenu={activeWorkspaceIsLocal ? (e) => openMenu(e, session.id) : undefined}
+                onKeyDown={activeWorkspaceIsLocal ? (e) => openMenuFromKeyboard(e, session.id) : undefined}
+                aria-haspopup={activeWorkspaceIsLocal ? 'menu' : undefined}
+                aria-expanded={activeWorkspaceIsLocal ? menuId === session.id : undefined}
                 className={`w-full text-start px-3 py-[7px] rounded-md text-[13px] truncate transition-colors cursor-pointer flex items-center justify-between gap-1 ${isActive ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
                 <span className="truncate flex-1">
                   <span className="flex items-center gap-1.5">
@@ -284,11 +295,13 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
                     via the row's onContextMenu handler — native
                     "context-menu key" / Shift+F10 path works because
                     the outer button owns that listener. */}
-                <span onClick={(e) => openMenu(e, session.id)}
-                  aria-hidden="true"
-                  className="opacity-0 group-hover:opacity-100 shrink-0 w-5 h-5 flex items-center justify-center rounded text-text-muted hover:text-text-secondary transition-opacity cursor-pointer">
-                  <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="6" cy="3" r="1"/><circle cx="6" cy="6" r="1"/><circle cx="6" cy="9" r="1"/></svg>
-                </span>
+                {activeWorkspaceIsLocal && (
+                  <span onClick={(e) => openMenu(e, session.id)}
+                    aria-hidden="true"
+                    className="opacity-0 group-hover:opacity-100 shrink-0 w-5 h-5 flex items-center justify-center rounded text-text-muted hover:text-text-secondary transition-opacity cursor-pointer">
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="6" cy="3" r="1"/><circle cx="6" cy="6" r="1"/><circle cx="6" cy="9" r="1"/></svg>
+                  </span>
+                )}
               </button>
             )}
       </div>

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useSessionStore } from '../../stores/session'
+import { sessionWorkspaceKey } from '../../stores/session-workspace-keys'
 import { loadSessionMessages } from '../../helpers/loadSessionMessages'
 import { DiffViewer } from '../chat/DiffViewer'
 import { confirmSessionDelete } from '../../helpers/destructive-actions'
@@ -21,6 +22,7 @@ const ESTIMATED_ROW_HEIGHT = 48
 export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; searchQuery?: string }) {
   const sessions = useSessionStore((s) => s.sessions)
   const currentSessionId = useSessionStore((s) => s.currentSessionId)
+  const activeWorkspaceId = useSessionStore((s) => s.activeWorkspaceId)
   const renameSession = useSessionStore((s) => s.renameSession)
   const removeSession = useSessionStore((s) => s.removeSession)
   const busySessions = useSessionStore((s) => s.busySessions)
@@ -190,8 +192,9 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   const renderRow = (session: typeof filtered[number]) => {
     const isActive = session.id === currentSessionId
     const isEditing = editingId === session.id
-    const isAwaitingQuestion = awaitingQuestionSessions.has(session.id)
-    const isBusy = busySessions.has(session.id) && !isAwaitingQuestion
+    const sessionKey = sessionWorkspaceKey(activeWorkspaceId, session.id)
+    const isAwaitingQuestion = awaitingQuestionSessions.has(sessionKey)
+    const isBusy = busySessions.has(sessionKey) && !isAwaitingQuestion
     return (
       <div key={session.id} className="relative group">
         {isEditing ? (

--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
@@ -1,6 +1,6 @@
 import { act, render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RuntimeNotification, SessionPatch, SessionView } from '@open-cowork/shared'
+import type { RuntimeNotification, SessionPatch, SessionView, WorkspaceSessionsUpdatedEvent } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../test/setup'
 import { useSessionStore } from '../stores/session'
 import { useOpenCodeEvents } from './useOpenCodeEvents'
@@ -14,6 +14,7 @@ describe('useOpenCodeEvents', () => {
   let notify: ((event: RuntimeNotification) => void) | null = null
   let sessionPatch: ((event: SessionPatch) => void) | null = null
   let sessionView: ((event: { sessionId: string; view: SessionView }) => void) | null = null
+  let workspaceSessionsUpdated: ((event: WorkspaceSessionsUpdatedEvent) => void) | null = null
   let closeAudioContext: ReturnType<typeof vi.fn>
 
   const tokens = {
@@ -54,11 +55,13 @@ describe('useOpenCodeEvents', () => {
 
   function resetSessionStore() {
     useSessionStore.setState({
+      activeWorkspaceId: 'local',
+      sessionsByWorkspace: { local: [] },
       sessions: [],
       currentSessionId: 'session-1',
       currentView: view(),
       globalErrors: [],
-      mcpConnections: [],
+    mcpConnections: [],
       agentMode: 'build',
       reasoningVariant: null,
       totalCost: 0,
@@ -67,7 +70,7 @@ describe('useOpenCodeEvents', () => {
       awaitingPermissionSessions: new Set(),
       awaitingQuestionSessions: new Set(),
       sessionStateById: {},
-      chartArtifactsBySession: {},
+    chartArtifactsBySession: {},
     })
   }
 
@@ -75,6 +78,7 @@ describe('useOpenCodeEvents', () => {
     notify = null
     sessionPatch = null
     sessionView = null
+    workspaceSessionsUpdated = null
     closeAudioContext = vi.fn(async () => undefined)
     resetSessionStore()
 
@@ -133,6 +137,10 @@ describe('useOpenCodeEvents', () => {
         sessionUpdated: vi.fn(() => vi.fn()),
         sessionView: vi.fn((callback: (event: { sessionId: string; view: SessionView }) => void) => {
           sessionView = callback
+          return vi.fn()
+        }),
+        workspaceSessionsUpdated: vi.fn((callback: (event: WorkspaceSessionsUpdatedEvent) => void) => {
+          workspaceSessionsUpdated = callback
           return vi.fn()
         }),
       },
@@ -222,6 +230,41 @@ describe('useOpenCodeEvents', () => {
     requestFrame.mockRestore()
     cancelFrame.mockRestore()
     vi.useRealTimers()
+  })
+
+  it('applies workspace session-list updates only for the active workspace', () => {
+    render(<Harness />)
+    useSessionStore.getState().setActiveWorkspace('cloud:active')
+    useSessionStore.getState().setSessions([])
+
+    act(() => {
+      workspaceSessionsUpdated?.({
+        workspaceId: 'cloud:other',
+        sessions: [{
+          id: 'other-session',
+          title: 'Other',
+          createdAt: '2026-05-27T10:00:00.000Z',
+          updatedAt: '2026-05-27T10:00:00.000Z',
+        }],
+        syncedAt: '2026-05-27T10:00:00.000Z',
+      })
+    })
+    expect(useSessionStore.getState().sessions).toEqual([])
+
+    act(() => {
+      workspaceSessionsUpdated?.({
+        workspaceId: 'cloud:active',
+        sessions: [{
+          id: 'active-session',
+          title: 'Active',
+          createdAt: '2026-05-27T10:00:00.000Z',
+          updatedAt: '2026-05-27T10:00:00.000Z',
+        }],
+        syncedAt: '2026-05-27T10:00:01.000Z',
+      })
+    })
+
+    expect(useSessionStore.getState().sessions.map((session) => session.id)).toEqual(['active-session'])
   })
 
   it('flushes older buffered text before immediately committing a newer task patch', () => {

--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import type { SessionPatch } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
+import { normalizeWorkspaceId, sessionWorkspaceKey } from '../stores/session-workspace-keys'
 import { shouldCommitStreamingTextImmediately } from '../../lib/session-streaming-flush.ts'
 
 const STREAM_FLUSH_INTERVAL_MS = 32
@@ -45,9 +46,15 @@ export function useOpenCodeEvents() {
       textBuffers.push({ ...part })
     }
 
-    const pruneCoveredTextBuffers = (sessionId: string, lastEventAt: number) => {
+    const isActiveWorkspaceEvent = (workspaceId?: string | null) => {
+      return normalizeWorkspaceId(workspaceId) === normalizeWorkspaceId(useSessionStore.getState().activeWorkspaceId)
+    }
+
+    const pruneCoveredTextBuffers = (sessionId: string, lastEventAt: number, workspaceId?: string | null) => {
       textBuffers = textBuffers.filter((buffer) => (
-        buffer.sessionId !== sessionId || buffer.eventAt > lastEventAt
+        buffer.sessionId !== sessionId
+          || normalizeWorkspaceId(buffer.workspaceId) !== normalizeWorkspaceId(workspaceId)
+          || buffer.eventAt > lastEventAt
       ))
     }
 
@@ -61,15 +68,29 @@ export function useOpenCodeEvents() {
     }
 
     const shouldCommitTextImmediately = (part: SessionPatch) => {
-      const { currentSessionId, sessionStateById } = useSessionStore.getState()
-      return shouldCommitStreamingTextImmediately(part, { currentSessionId, sessionStateById })
+      const { activeWorkspaceId, currentSessionId, sessionStateById } = useSessionStore.getState()
+      return shouldCommitStreamingTextImmediately(part, {
+        currentSessionId,
+        currentSessionKey: sessionWorkspaceKey(part.workspaceId || activeWorkspaceId, part.sessionId),
+        sessionStateById,
+      })
     }
 
-    const flushTextBuffers = (store: ReturnType<typeof useSessionStore.getState>, sessionId?: string) => {
+    const flushTextBuffers = (
+      store: ReturnType<typeof useSessionStore.getState>,
+      sessionId?: string,
+      workspaceId?: string | null,
+    ) => {
       const parts: SessionPatch[] = []
       const retained: SessionPatch[] = []
       for (const buffer of textBuffers) {
-        if (sessionId && buffer.sessionId !== sessionId) {
+        if (
+          sessionId
+          && (
+            buffer.sessionId !== sessionId
+            || normalizeWorkspaceId(buffer.workspaceId) !== normalizeWorkspaceId(workspaceId)
+          )
+        ) {
           retained.push(buffer)
           continue
         }
@@ -131,9 +152,10 @@ export function useOpenCodeEvents() {
     }
 
     const unsubSessionPatch = window.coworkApi.on.sessionPatch((patch: SessionPatch) => {
+      if (!isActiveWorkspaceEvent(patch.workspaceId)) return
       if (shouldCommitTextImmediately(patch)) {
         const store = useSessionStore.getState()
-        flushTextBuffers(store, patch.sessionId)
+        flushTextBuffers(store, patch.sessionId, patch.workspaceId)
         commitTextParts(useSessionStore.getState(), [patch])
         lastFlushAt = performance.now()
       } else {
@@ -143,6 +165,7 @@ export function useOpenCodeEvents() {
     })
 
     const unsubNotification = window.coworkApi.on.notification((event) => {
+      if (!isActiveWorkspaceEvent(event.workspaceId)) return
       switch (event.type) {
         case 'done':
           if (!event.synthetic) playDoneSound()
@@ -155,12 +178,14 @@ export function useOpenCodeEvents() {
       }
     })
 
-    const unsubSessionView = window.coworkApi.on.sessionView(({ sessionId, view }) => {
-      pruneCoveredTextBuffers(sessionId, view.lastEventAt || 0)
-      useSessionStore.getState().setSessionView(sessionId, view)
+    const unsubSessionView = window.coworkApi.on.sessionView(({ sessionId, workspaceId, view }) => {
+      if (!isActiveWorkspaceEvent(workspaceId)) return
+      pruneCoveredTextBuffers(sessionId, view.lastEventAt || 0, workspaceId)
+      useSessionStore.getState().setSessionView(sessionId, view, workspaceId)
     })
 
     const unsubPermissionRequest = window.coworkApi.on.permissionRequest((request) => {
+      if (!isActiveWorkspaceEvent(request.workspaceId)) return
       useSessionStore.getState().addPendingApproval(request)
     })
 
@@ -181,6 +206,12 @@ export function useOpenCodeEvents() {
       useSessionStore.getState().removeSession(data.id)
     })
 
+    const unsubWorkspaceSessions = window.coworkApi.on.workspaceSessionsUpdated((data) => {
+      const store = useSessionStore.getState()
+      if (normalizeWorkspaceId(data.workspaceId) !== normalizeWorkspaceId(store.activeWorkspaceId)) return
+      store.setSessions(data.sessions)
+    })
+
     const unsubAuth = window.coworkApi.on.authExpired(() => {
       window.dispatchEvent(new CustomEvent('open-cowork:auth-expired'))
     })
@@ -197,6 +228,7 @@ export function useOpenCodeEvents() {
     const unsubscribeAll = combineSubscriptions(
       unsubSessionUpdate,
       unsubSessionDelete,
+      unsubWorkspaceSessions,
       unsubPermissionRequest,
       unsubSessionView,
       unsubSessionPatch,

--- a/apps/desktop/src/renderer/stores/session-view-reducer.ts
+++ b/apps/desktop/src/renderer/stores/session-view-reducer.ts
@@ -13,6 +13,7 @@ import {
   type SessionViewState,
 } from '../../lib/session-view-model.ts'
 import type { SessionStore } from './session.ts'
+import { activeSessionWorkspaceKey } from './session-workspace-keys.ts'
 
 export function sumSessionCosts(sessionStateById: Record<string, SessionViewState>) {
   return Object.values(sessionStateById)
@@ -70,25 +71,27 @@ export function updateSessionState(
 ) {
   const sessionStateById = { ...state.sessionStateById }
   const timing = sessionViewTiming()
-  const current = getOrCreateSessionState(sessionStateById, sessionId, timing)
+  const sessionKey = activeSessionWorkspaceKey(state, sessionId)
+  const currentSessionKey = state.currentSessionId ? activeSessionWorkspaceKey(state, state.currentSessionId) : null
+  const current = getOrCreateSessionState(sessionStateById, sessionKey, timing)
   const updated = updater(current)
   const next = {
     ...updated,
     revision: current.revision + 1,
     lastEventAt: options?.eventAt ?? timing.nowMs,
   }
-  sessionStateById[sessionId] = next
-  const prunedSessionStateById = pruneSessionDetailCache(sessionStateById, state.currentSessionId, state.busySessions)
+  sessionStateById[sessionKey] = next
+  const prunedSessionStateById = pruneSessionDetailCache(sessionStateById, currentSessionKey, state.busySessions)
 
   const patch: Partial<SessionStore> = {
     sessionStateById: prunedSessionStateById,
     totalCost: sumSessionCosts(prunedSessionStateById),
   }
   if (state.currentSessionId === sessionId) {
-    const visibleState = prunedSessionStateById[sessionId] || next
+    const visibleState = prunedSessionStateById[sessionKey] || next
     patch.currentView = deriveVisibleSessionPatch(
       visibleState,
-      sessionId,
+      sessionKey,
       state.busySessions,
       state.awaitingPermissionSessions,
       timing,

--- a/apps/desktop/src/renderer/stores/session-workspace-keys.ts
+++ b/apps/desktop/src/renderer/stores/session-workspace-keys.ts
@@ -1,0 +1,16 @@
+export const LOCAL_WORKSPACE_ID = 'local'
+
+export function normalizeWorkspaceId(workspaceId?: string | null) {
+  const trimmed = workspaceId?.trim()
+  return trimmed || LOCAL_WORKSPACE_ID
+}
+
+export function sessionWorkspaceKey(workspaceId: string | null | undefined, sessionId: string) {
+  const normalized = normalizeWorkspaceId(workspaceId)
+  if (normalized === LOCAL_WORKSPACE_ID) return sessionId
+  return `workspace:${encodeURIComponent(normalized)}:session:${encodeURIComponent(sessionId)}`
+}
+
+export function activeSessionWorkspaceKey(state: { activeWorkspaceId?: string | null }, sessionId: string) {
+  return sessionWorkspaceKey(state.activeWorkspaceId, sessionId)
+}

--- a/apps/desktop/src/renderer/stores/session.test.ts
+++ b/apps/desktop/src/renderer/stores/session.test.ts
@@ -7,6 +7,7 @@ import {
   type SessionViewState,
 } from '../../lib/session-view-model'
 import { useSessionStore } from './session'
+import { sessionWorkspaceKey } from './session-workspace-keys'
 
 function resetStore() {
   useSessionStore.setState(useSessionStore.getInitialState(), true)
@@ -104,6 +105,37 @@ describe('useSessionStore', () => {
     expect(useSessionStore.getState().busySessions.has('ses_1')).toBe(false)
     expect(useSessionStore.getState().awaitingPermissionSessions.has('ses_1')).toBe(false)
     expect(useSessionStore.getState().totalCost).toBe(2)
+  })
+
+  it('keeps same-id session state separate across workspaces', () => {
+    const store = useSessionStore.getState()
+
+    store.setSessions([session('shared', 'Local shared')])
+    store.setCurrentSession('shared')
+    useSessionStore.getState().setSessionView('shared', view({ sessionCost: 1 }))
+    expect(useSessionStore.getState().currentView.sessionCost).toBe(1)
+
+    useSessionStore.getState().setActiveWorkspace('cloud:acme')
+    useSessionStore.getState().setSessions([session('shared', 'Cloud shared')])
+    useSessionStore.getState().setCurrentSession('shared')
+    useSessionStore.getState().setSessionView('shared', view({
+      isAwaitingQuestion: true,
+      sessionCost: 2,
+    }))
+
+    const cloudState = useSessionStore.getState()
+    expect(cloudState.sessions[0]?.title).toBe('Cloud shared')
+    expect(cloudState.currentView.sessionCost).toBe(2)
+    expect(cloudState.awaitingQuestionSessions.has(sessionWorkspaceKey('cloud:acme', 'shared'))).toBe(true)
+    expect(cloudState.awaitingQuestionSessions.has('shared')).toBe(false)
+
+    useSessionStore.getState().setActiveWorkspace('local')
+    useSessionStore.getState().setCurrentSession('shared')
+
+    const localState = useSessionStore.getState()
+    expect(localState.sessions[0]?.title).toBe('Local shared')
+    expect(localState.currentView.sessionCost).toBe(1)
+    expect(localState.currentView.isAwaitingQuestion).toBe(false)
   })
 
   it('applies message and task text patches to the visible session', () => {

--- a/apps/desktop/src/renderer/stores/session.ts
+++ b/apps/desktop/src/renderer/stores/session.ts
@@ -24,6 +24,12 @@ import {
   sumSessionCosts,
   updateSessionState,
 } from './session-view-reducer.ts'
+import {
+  activeSessionWorkspaceKey,
+  LOCAL_WORKSPACE_ID,
+  normalizeWorkspaceId,
+  sessionWorkspaceKey,
+} from './session-workspace-keys.ts'
 
 export type {
   CompactionNotice,
@@ -52,10 +58,13 @@ export interface McpConnection {
 }
 
 export interface SessionStore {
+  activeWorkspaceId: string
+  sessionsByWorkspace: Record<string, Session[]>
   sessions: Session[]
   currentSessionId: string | null
   currentView: SessionView
   globalErrors: SessionError[]
+  setActiveWorkspace: (workspaceId: string) => void
   setSessions: (sessions: Session[]) => void
   setCurrentSession: (id: string | null) => void
   addSession: (session: Session) => void
@@ -74,7 +83,7 @@ export interface SessionStore {
     composerReasoningVariant?: string | null
   }) => void
   removeSession: (id: string) => void
-  setSessionView: (sessionId: string, view: SessionView) => void
+  setSessionView: (sessionId: string, view: SessionView, workspaceId?: string | null) => void
   applySessionPatch: (patch: SessionPatch) => void
   applySessionPatches: (patches: SessionPatch[]) => void
   addPendingApproval: (approval: PermissionRequest) => void
@@ -112,11 +121,39 @@ export interface SessionStore {
 }
 
 export const useSessionStore = create<SessionStore>((set) => ({
+  activeWorkspaceId: LOCAL_WORKSPACE_ID,
+  sessionsByWorkspace: { [LOCAL_WORKSPACE_ID]: [] },
   sessions: [],
   currentSessionId: null,
   currentView: deriveVisibleSessionPatch(createEmptySessionViewState({}, sessionViewTiming()), null, new Set<string>(), new Set<string>(), sessionViewTiming()),
   globalErrors: [],
-  setSessions: (sessions) => set({ sessions }),
+  setActiveWorkspace: (workspaceId) => set((state) => {
+    const nextWorkspaceId = normalizeWorkspaceId(workspaceId)
+    if (nextWorkspaceId === normalizeWorkspaceId(state.activeWorkspaceId)) return {}
+    const timing = sessionViewTiming()
+    return {
+      activeWorkspaceId: nextWorkspaceId,
+      sessions: state.sessionsByWorkspace[nextWorkspaceId] || [],
+      currentSessionId: null,
+      currentView: deriveVisibleSessionPatch(
+        createEmptySessionViewState({}, timing),
+        null,
+        state.busySessions,
+        state.awaitingPermissionSessions,
+        timing,
+      ),
+    }
+  }),
+  setSessions: (sessions) => set((state) => {
+    const workspaceId = normalizeWorkspaceId(state.activeWorkspaceId)
+    return {
+      sessions,
+      sessionsByWorkspace: {
+        ...state.sessionsByWorkspace,
+        [workspaceId]: sessions,
+      },
+    }
+  }),
   setCurrentSession: (id) => set((state) => {
     let sessionStateById = { ...state.sessionStateById }
     if (!id) {
@@ -134,19 +171,20 @@ export const useSessionStore = create<SessionStore>((set) => ({
     }
 
     const timing = sessionViewTiming()
-    const next = getOrCreateSessionState(sessionStateById, id, timing)
-    sessionStateById[id] = {
+    const sessionKey = activeSessionWorkspaceKey(state, id)
+    const next = getOrCreateSessionState(sessionStateById, sessionKey, timing)
+    sessionStateById[sessionKey] = {
       ...next,
       lastViewedAt: timing.nowMs,
     }
-    sessionStateById = pruneSessionDetailCache(sessionStateById, id, state.busySessions)
+    sessionStateById = pruneSessionDetailCache(sessionStateById, sessionKey, state.busySessions)
 
     return {
       sessionStateById,
       currentSessionId: id,
       currentView: deriveVisibleSessionPatch(
-        sessionStateById[id],
-        id,
+        sessionStateById[sessionKey],
+        sessionKey,
         state.busySessions,
         state.awaitingPermissionSessions,
         timing,
@@ -155,9 +193,17 @@ export const useSessionStore = create<SessionStore>((set) => ({
   }),
   addSession: (session) => set((state) => ({
     sessions: [session, ...state.sessions],
+    sessionsByWorkspace: {
+      ...state.sessionsByWorkspace,
+      [normalizeWorkspaceId(state.activeWorkspaceId)]: [session, ...state.sessions],
+    },
   })),
   renameSession: (id, title) => set((state) => ({
     sessions: state.sessions.map((session) => (session.id === id ? { ...session, title } : session)),
+    sessionsByWorkspace: {
+      ...state.sessionsByWorkspace,
+      [normalizeWorkspaceId(state.activeWorkspaceId)]: state.sessions.map((session) => (session.id === id ? { ...session, title } : session)),
+    },
   })),
   setSessionComposerPreferences: (id, preferences) => set((state) => ({
     sessions: state.sessions.map((session) => {
@@ -172,6 +218,21 @@ export const useSessionStore = create<SessionStore>((set) => ({
           : {}),
       }
     }),
+    sessionsByWorkspace: {
+      ...state.sessionsByWorkspace,
+      [normalizeWorkspaceId(state.activeWorkspaceId)]: state.sessions.map((session) => {
+        if (session.id !== id) return session
+        return {
+          ...session,
+          ...(Object.prototype.hasOwnProperty.call(preferences, 'modelId')
+            ? { composerModelId: preferences.modelId ?? null }
+            : {}),
+          ...(Object.prototype.hasOwnProperty.call(preferences, 'reasoningVariant')
+            ? { composerReasoningVariant: preferences.reasoningVariant ?? null }
+            : {}),
+        }
+      }),
+    },
   })),
   applySessionMetadata: (patch) => set((state) => ({
     sessions: state.sessions.map((session) => {
@@ -187,29 +248,49 @@ export const useSessionStore = create<SessionStore>((set) => ({
       if (patch.composerReasoningVariant !== undefined) next.composerReasoningVariant = patch.composerReasoningVariant
       return next
     }),
+    sessionsByWorkspace: {
+      ...state.sessionsByWorkspace,
+      [normalizeWorkspaceId(state.activeWorkspaceId)]: state.sessions.map((session) => {
+        if (session.id !== patch.id) return session
+        const next: Session = { ...session }
+        if (patch.title !== null && patch.title !== undefined) next.title = patch.title
+        if (patch.parentSessionId) next.parentSessionId = patch.parentSessionId
+        if (patch.changeSummary !== undefined) next.changeSummary = patch.changeSummary
+        if (patch.revertedMessageId !== undefined) next.revertedMessageId = patch.revertedMessageId
+        if (patch.composerModelId !== undefined) next.composerModelId = patch.composerModelId
+        if (patch.composerReasoningVariant !== undefined) next.composerReasoningVariant = patch.composerReasoningVariant
+        return next
+      }),
+    },
   })),
   removeSession: (id) => set((state) => {
+    const sessionKey = activeSessionWorkspaceKey(state, id)
     const sessionStateById = { ...state.sessionStateById }
-    delete sessionStateById[id]
+    delete sessionStateById[sessionKey]
     const chartArtifactsBySession = { ...state.chartArtifactsBySession }
-    delete chartArtifactsBySession[id]
+    delete chartArtifactsBySession[sessionKey]
 
     // Drop the id from the status Sets too — otherwise a session that was
     // busy / awaiting-permission / awaiting-question at delete time leaves
     // a stale entry that leaks memory and could mis-color a future row if
     // an id ever collides.
-    const nextBusy = state.busySessions.has(id)
-      ? new Set(Array.from(state.busySessions).filter((sid) => sid !== id))
+    const nextBusy = state.busySessions.has(sessionKey)
+      ? new Set(Array.from(state.busySessions).filter((sid) => sid !== sessionKey))
       : state.busySessions
-    const nextAwaitingPermission = state.awaitingPermissionSessions.has(id)
-      ? new Set(Array.from(state.awaitingPermissionSessions).filter((sid) => sid !== id))
+    const nextAwaitingPermission = state.awaitingPermissionSessions.has(sessionKey)
+      ? new Set(Array.from(state.awaitingPermissionSessions).filter((sid) => sid !== sessionKey))
       : state.awaitingPermissionSessions
-    const nextAwaitingQuestion = state.awaitingQuestionSessions.has(id)
-      ? new Set(Array.from(state.awaitingQuestionSessions).filter((sid) => sid !== id))
+    const nextAwaitingQuestion = state.awaitingQuestionSessions.has(sessionKey)
+      ? new Set(Array.from(state.awaitingQuestionSessions).filter((sid) => sid !== sessionKey))
       : state.awaitingQuestionSessions
+    const nextSessions = state.sessions.filter((session) => session.id !== id)
 
     const patch: Partial<SessionStore> = {
-      sessions: state.sessions.filter((session) => session.id !== id),
+      sessions: nextSessions,
+      sessionsByWorkspace: {
+        ...state.sessionsByWorkspace,
+        [normalizeWorkspaceId(state.activeWorkspaceId)]: nextSessions,
+      },
       sessionStateById,
       totalCost: sumSessionCosts(sessionStateById),
       busySessions: nextBusy,
@@ -233,23 +314,28 @@ export const useSessionStore = create<SessionStore>((set) => ({
 
     return patch
   }),
-  setSessionView: (sessionId, view) => set((state) => {
-    const existing = state.sessionStateById[sessionId]
+  setSessionView: (sessionId, view, workspaceId) => set((state) => {
+    if (workspaceId && normalizeWorkspaceId(workspaceId) !== normalizeWorkspaceId(state.activeWorkspaceId)) return {}
+    const sessionKey = workspaceId
+      ? sessionWorkspaceKey(workspaceId, sessionId)
+      : activeSessionWorkspaceKey(state, sessionId)
+    const currentSessionKey = state.currentSessionId ? activeSessionWorkspaceKey(state, state.currentSessionId) : null
+    const existing = state.sessionStateById[sessionKey]
     const timing = sessionViewTiming()
     const next = buildSessionStateFromView(view, existing, timing)
     const busySessions = new Set(state.busySessions)
-    if (view.isGenerating || view.isAwaitingPermission || view.isAwaitingQuestion) busySessions.add(sessionId)
-    else busySessions.delete(sessionId)
+    if (view.isGenerating || view.isAwaitingPermission || view.isAwaitingQuestion) busySessions.add(sessionKey)
+    else busySessions.delete(sessionKey)
     const awaitingPermissionSessions = new Set(state.awaitingPermissionSessions)
-    if (view.isAwaitingPermission) awaitingPermissionSessions.add(sessionId)
-    else awaitingPermissionSessions.delete(sessionId)
+    if (view.isAwaitingPermission) awaitingPermissionSessions.add(sessionKey)
+    else awaitingPermissionSessions.delete(sessionKey)
     const awaitingQuestionSessions = new Set(state.awaitingQuestionSessions)
-    if (view.isAwaitingQuestion) awaitingQuestionSessions.add(sessionId)
-    else awaitingQuestionSessions.delete(sessionId)
+    if (view.isAwaitingQuestion) awaitingQuestionSessions.add(sessionKey)
+    else awaitingQuestionSessions.delete(sessionKey)
 
     const sessionStateById = pruneSessionDetailCache(
-      { ...state.sessionStateById, [sessionId]: next },
-      state.currentSessionId,
+      { ...state.sessionStateById, [sessionKey]: next },
+      currentSessionKey,
       busySessions,
     )
 
@@ -262,8 +348,8 @@ export const useSessionStore = create<SessionStore>((set) => ({
     }
     if (state.currentSessionId === sessionId) {
       patch.currentView = deriveVisibleSessionPatch(
-        sessionStateById[sessionId],
-        sessionId,
+        sessionStateById[sessionKey],
+        sessionKey,
         busySessions,
         awaitingPermissionSessions,
         timing,
@@ -271,7 +357,10 @@ export const useSessionStore = create<SessionStore>((set) => ({
     }
     return patch
   }),
-  applySessionPatch: (patch) => set((state) => applySessionPatchToState(state, patch)),
+  applySessionPatch: (patch) => set((state) => {
+    if (patch.workspaceId && normalizeWorkspaceId(patch.workspaceId) !== normalizeWorkspaceId(state.activeWorkspaceId)) return {}
+    return applySessionPatchToState(state, patch)
+  }),
   applySessionPatches: (patches) => {
     if (patches.length === 0) return
 
@@ -279,7 +368,9 @@ export const useSessionStore = create<SessionStore>((set) => ({
       let nextState = state
       let combinedPatch: Partial<SessionStore> = {}
 
-      for (const patch of orderSessionPatches(patches)) {
+      for (const patch of orderSessionPatches(patches).filter((candidate) => (
+        !candidate.workspaceId || normalizeWorkspaceId(candidate.workspaceId) === normalizeWorkspaceId(state.activeWorkspaceId)
+      ))) {
         const partial = applySessionPatchToState(nextState, patch)
         combinedPatch = {
           ...combinedPatch,
@@ -295,10 +386,14 @@ export const useSessionStore = create<SessionStore>((set) => ({
     })
   },
   addPendingApproval: (approval) => set((state) => {
+    if (approval.workspaceId && normalizeWorkspaceId(approval.workspaceId) !== normalizeWorkspaceId(state.activeWorkspaceId)) return {}
+    const sessionKey = approval.workspaceId
+      ? sessionWorkspaceKey(approval.workspaceId, approval.sessionId)
+      : activeSessionWorkspaceKey(state, approval.sessionId)
     const awaitingPermissionSessions = new Set(state.awaitingPermissionSessions)
-    awaitingPermissionSessions.add(approval.sessionId)
+    awaitingPermissionSessions.add(sessionKey)
     const busySessions = new Set(state.busySessions)
-    busySessions.add(approval.sessionId)
+    busySessions.add(sessionKey)
 
     const patch = updateSessionState(
       {
@@ -317,7 +412,7 @@ export const useSessionStore = create<SessionStore>((set) => ({
           },
         ],
       }),
-      { eventAt: state.sessionStateById[approval.sessionId]?.lastEventAt ?? 0 },
+      { eventAt: state.sessionStateById[sessionKey]?.lastEventAt ?? 0 },
     )
 
     return {
@@ -358,14 +453,15 @@ export const useSessionStore = create<SessionStore>((set) => ({
 
   chartArtifactsBySession: {},
   registerChartArtifact: (sessionId, artifact) => set((state) => {
-    const current = state.chartArtifactsBySession[sessionId] || []
+    const sessionKey = activeSessionWorkspaceKey(state, sessionId)
+    const current = state.chartArtifactsBySession[sessionKey] || []
     // De-dupe on filePath so repeat captures (HMR, re-render) replace
     // the older record in place rather than stacking duplicates.
     const next = [...current.filter((entry) => entry.filePath !== artifact.filePath), artifact]
     return {
       chartArtifactsBySession: {
         ...state.chartArtifactsBySession,
-        [sessionId]: next,
+        [sessionKey]: next,
       },
     }
   }),

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -32,6 +32,61 @@ function createDefaultSettings(overrides: Partial<EffectiveAppSettings> = {}): E
 
 function installCoworkApi(overrides: TestCoworkApi = {}) {
   const api: TestCoworkApi = {
+    workspace: {
+      list: vi.fn(async () => [{
+        id: 'local',
+        kind: 'local',
+        label: 'Local',
+        status: 'online',
+        active: true,
+        lastSyncedAt: null,
+      }]),
+      activate: vi.fn(async () => ({
+        id: 'local',
+        kind: 'local',
+        label: 'Local',
+        status: 'online',
+        active: true,
+        lastSyncedAt: null,
+      })),
+      addCloud: vi.fn(async (input: { baseUrl: string; label?: string }) => ({
+        id: 'cloud:test',
+        kind: 'cloud',
+        label: input.label || 'Cloud',
+        status: 'disabled',
+        active: false,
+        baseUrl: input.baseUrl,
+        lastSyncedAt: null,
+      })),
+      remove: vi.fn(async () => true),
+      login: vi.fn(async () => ({
+        id: 'local',
+        kind: 'local',
+        label: 'Local',
+        status: 'online',
+        active: true,
+        lastSyncedAt: null,
+      })),
+      logout: vi.fn(async () => ({
+        id: 'local',
+        kind: 'local',
+        label: 'Local',
+        status: 'online',
+        active: true,
+        lastSyncedAt: null,
+      })),
+      policy: vi.fn(async () => ({
+        features: {},
+        allowedAgents: null,
+        allowedTools: null,
+        allowedMcps: null,
+        localFiles: 'enabled',
+        localStdioMcps: 'enabled',
+        machineRuntimeConfig: 'allowlisted',
+      })),
+      support: vi.fn(async () => []),
+      sync: vi.fn(async () => ({ ok: true, syncedAt: new Date().toISOString() })),
+    },
     app: {
       builtinAgents: vi.fn(async () => []),
       metadata: vi.fn(async () => ({ version: '0.0.0', preview: true })),
@@ -376,6 +431,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       runtimeLoadingStatus: vi.fn(() => () => undefined),
       sessionUpdated: vi.fn(() => () => undefined),
       sessionDeleted: vi.fn(() => () => undefined),
+      workspaceSessionsUpdated: vi.fn(() => () => undefined),
       workflowUpdated: vi.fn(() => () => undefined),
     },
   }

--- a/apps/desktop/tests/preload-api.smoke.test.ts
+++ b/apps/desktop/tests/preload-api.smoke.test.ts
@@ -19,6 +19,8 @@ test('preload exposes the expected coworkApi surface', async () => {
           workflowsStartDraft: typeof api.workflows?.startDraft,
           chartRenderSvg: typeof api.chart?.renderSvg,
           artifactReadAttachment: typeof api.artifact?.readAttachment,
+          workspaceList: typeof api.workspace?.list,
+          workspaceActivate: typeof api.workspace?.activate,
           onSessionPatch: typeof api.on?.sessionPatch,
         },
       }
@@ -32,6 +34,8 @@ test('preload exposes the expected coworkApi surface', async () => {
       workflowsStartDraft: 'function',
       chartRenderSvg: 'function',
       artifactReadAttachment: 'function',
+      workspaceList: 'function',
+      workspaceActivate: 'function',
       onSessionPatch: 'function',
     })
     assert.deepEqual(surface.groups, [
@@ -62,6 +66,7 @@ test('preload exposes the expected coworkApi surface', async () => {
       'tools',
       'updates',
       'workflows',
+      'workspace',
     ])
   } finally {
     await cleanup()

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -164,6 +164,51 @@ directories, arbitrary local stdio MCPs, and machine-native runtime config
 unless a deployer explicitly allows a controlled image or volume-backed
 environment.
 
+## Desktop Sync Configuration
+
+Desktop-to-cloud sync is configured separately from the cloud service roles.
+Downstream desktop builds can preconfigure managed cloud orgs without changing
+renderer code by setting `cloudDesktop` in `open-cowork.config.json` or a
+managed config layer:
+
+```json
+{
+  "cloudDesktop": {
+    "enabled": true,
+    "allowUserAddedConnections": false,
+    "requireManagedOrg": true,
+    "cacheMode": "metadata-only",
+    "cacheEncryptionFallback": "disabled",
+    "preconfiguredConnections": [
+      {
+        "baseUrl": "https://cowork.acme.example",
+        "label": "Acme Cloud"
+      }
+    ]
+  }
+}
+```
+
+`enabled: false` hides cloud workspaces and keeps the desktop fully local.
+`requireManagedOrg: true` limits desktop sync to the configured org list and
+blocks user-added cloud URLs. `cacheMode` controls the local cloud cache:
+
+- `full` caches encrypted session projections and metadata.
+- `metadata-only` caches lists, cursors, and metadata but strips message
+  bodies and full projections.
+- `disabled` avoids durable cloud cache state.
+
+When `cacheMode` is `full`, the desktop requires OS-backed encrypted storage or
+uses `cacheEncryptionFallback` to degrade to `metadata-only`, `disabled`, or
+fail startup. OAuth access and refresh tokens are stored in OS secure storage,
+not in the cloud cache.
+
+Every workspace-scoped API also has a typed support matrix exposed through
+`workspace.support()`. Cloud-only clients should use it to distinguish
+`supported`, `blocked_by_policy`, `not_supported`, and later-phase surfaces
+instead of assuming local desktop APIs such as host-path diffs or local stdio
+MCPs are available in cloud workspaces.
+
 ## Provider Mapping
 
 Provider-specific recipes should remain thin compositions of the same image,

--- a/mcps/agents/package.json
+++ b/mcps/agents/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
+    "typecheck": "tsc --noEmit --rootDir ../..",
     "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
     "security": "pnpm audit --prod --audit-level high"
   },
@@ -23,6 +24,8 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "esbuild": "^0.28.0"
+    "@types/node": "^22.12.0",
+    "esbuild": "^0.28.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/mcps/charts/package.json
+++ b/mcps/charts/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
+    "typecheck": "tsc --noEmit --rootDir ../..",
     "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
     "security": "pnpm audit --prod --audit-level high"
   },
@@ -23,6 +24,8 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "esbuild": "^0.28.0"
+    "@types/node": "^22.12.0",
+    "esbuild": "^0.28.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/mcps/clock/package.json
+++ b/mcps/clock/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
+    "typecheck": "tsc --noEmit --rootDir ../..",
     "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
     "security": "pnpm audit --prod --audit-level high"
   },
@@ -23,6 +24,8 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "esbuild": "^0.28.0"
+    "@types/node": "^22.12.0",
+    "esbuild": "^0.28.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/mcps/skills/package.json
+++ b/mcps/skills/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
+    "typecheck": "tsc --noEmit --rootDir ../..",
     "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
     "security": "pnpm audit --prod --audit-level high"
   },
@@ -24,6 +25,8 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "esbuild": "^0.28.0"
+    "@types/node": "^22.12.0",
+    "esbuild": "^0.28.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/mcps/workflows/package.json
+++ b/mcps/workflows/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node ../build.mjs",
     "dev": "node ../build.mjs",
+    "typecheck": "tsc --noEmit --rootDir ../..",
     "test": "pnpm build && node --no-warnings --experimental-strip-types --test tests/*.test.ts",
     "security": "pnpm audit --prod --audit-level high"
   },
@@ -23,6 +24,8 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "esbuild": "^0.28.0"
+    "@types/node": "^22.12.0",
+    "esbuild": "^0.28.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -212,6 +212,7 @@
       }
     },
     "cloud": { "$ref": "#/$defs/cloudConfig" },
+    "cloudDesktop": { "$ref": "#/$defs/cloudDesktopConfig" },
     "i18n": {
       "type": "object",
       "additionalProperties": false,
@@ -275,6 +276,30 @@
     "cloudRole": {
       "type": "string",
       "enum": ["all-in-one", "web", "worker", "scheduler"]
+    },
+    "cloudDesktopConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowUserAddedConnections": { "type": "boolean" },
+        "preconfiguredConnections": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/cloudDesktopConnection" }
+        },
+        "requireManagedOrg": { "type": "boolean" },
+        "cacheMode": { "type": "string", "enum": ["full", "metadata-only", "disabled"] },
+        "cacheEncryptionFallback": { "type": "string", "enum": ["metadata-only", "disabled", "fail-startup"] }
+      }
+    },
+    "cloudDesktopConnection": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "baseUrl": { "$ref": "#/$defs/httpsOrLocalhostUrl" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 80 }
+      },
+      "required": ["baseUrl"]
     },
     "cloudName": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "build:shared": "pnpm --filter @open-cowork/shared build",
     "docs:build": "mkdocs build --strict",
     "docs:serve": "mkdocs serve",
-    "typecheck": "pnpm --filter @open-cowork/shared build && pnpm --filter @open-cowork/desktop build:electron && pnpm --filter @open-cowork/desktop typecheck",
+    "typecheck": "pnpm --filter @open-cowork/shared build && pnpm typecheck:mcps && pnpm --filter @open-cowork/desktop build:electron && pnpm --filter @open-cowork/desktop typecheck",
+    "typecheck:mcps": "pnpm --filter=./mcps/* typecheck",
     "dist": "pnpm build && pnpm --filter @open-cowork/desktop dist",
     "lint": "eslint . --max-warnings 0 && node scripts/lint.mjs && node scripts/check-preload-channels.mjs && node scripts/check-shared-dist.mjs",
     "lint:dead-code": "knip --production --files",
@@ -72,7 +73,8 @@
       "electron-builder-squirrel-windows": "26.8.1",
       "ip-address@<=10.1.0": ">=10.1.1",
       "mermaid>uuid": "^14.0.0",
-      "qs@>=6.11.1 <=6.15.1": "6.15.2"
+      "qs@>=6.11.1 <=6.15.1": "6.15.2",
+      "tmp@<0.2.7": "0.2.7"
     }
   },
   "devDependencies": {

--- a/packages/shared/src/artifacts.ts
+++ b/packages/shared/src/artifacts.ts
@@ -1,10 +1,43 @@
+import type { WorkspaceOptions } from './workspace.js'
+
+export const CLOUD_ARTIFACT_FILE_PATH_PREFIX = 'cloud-artifact://'
+
+export function cloudArtifactFilePath(artifactId: string, filename = 'artifact') {
+  const safeFilename = filename.trim() || 'artifact'
+  return `${CLOUD_ARTIFACT_FILE_PATH_PREFIX}${encodeURIComponent(artifactId)}/${encodeURIComponent(safeFilename)}`
+}
+
+export function cloudArtifactIdFromFilePath(filePath: string) {
+  if (!filePath.startsWith(CLOUD_ARTIFACT_FILE_PATH_PREFIX)) return null
+  const remainder = filePath.slice(CLOUD_ARTIFACT_FILE_PATH_PREFIX.length)
+  const [encodedId] = remainder.split('/')
+  if (!encodedId) return null
+  try {
+    return decodeURIComponent(encodedId)
+  } catch {
+    return null
+  }
+}
+
 export interface SessionArtifactRequest {
   sessionId: string
   filePath: string
+  workspaceId?: string
 }
 
 export interface SessionArtifactExportRequest extends SessionArtifactRequest {
   suggestedName?: string
+}
+
+export interface SessionArtifactListRequest extends WorkspaceOptions {
+  sessionId: string
+}
+
+export interface SessionArtifactUploadRequest extends WorkspaceOptions {
+  sessionId: string
+  filename: string
+  contentType?: string | null
+  dataBase64: string
 }
 
 export interface ChartArtifactSource {
@@ -20,8 +53,12 @@ export interface SessionArtifact {
   filePath: string
   filename: string
   order: number
+  source?: 'local' | 'cloud'
+  cloudArtifactId?: string
   taskRunId?: string | null
   mime?: string
+  size?: number
+  createdAt?: string
   chart?: ChartArtifactSource | null
 }
 

--- a/packages/shared/src/custom-content.ts
+++ b/packages/shared/src/custom-content.ts
@@ -3,6 +3,7 @@ import type { WorkflowSurface } from './workflow.js'
 export type CustomMcpPermissionMode = 'ask' | 'allow'
 
 export interface CustomMcpConfig {
+  workspaceId?: string
   scope: 'machine' | 'project'
   directory?: string | null
   name: string
@@ -56,6 +57,7 @@ export interface McpPreflightResult {
 }
 
 export interface CustomSkillConfig {
+  workspaceId?: string
   scope: 'machine' | 'project'
   directory?: string | null
   name: string
@@ -83,6 +85,7 @@ export interface AgentInferenceOptions {
 }
 
 export interface CustomAgentConfig extends AgentInferenceOptions {
+  workspaceId?: string
   scope: 'machine' | 'project'
   directory?: string | null
   name: string
@@ -130,6 +133,7 @@ export interface CustomAgentSummary extends CustomAgentConfig {
 }
 
 export interface ScopedArtifactRef {
+  workspaceId?: string
   name: string
   scope: 'machine' | 'project'
   directory?: string | null

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -1,6 +1,7 @@
 export interface PermissionRequest {
   id: string
   sessionId: string
+  workspaceId?: string | null
   taskRunId?: string | null
   tool: string
   input: Record<string, unknown>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,7 +42,9 @@ import type {
   SessionArtifact,
   SessionArtifactAttachment,
   SessionArtifactExportRequest,
+  SessionArtifactListRequest,
   SessionArtifactRequest,
+  SessionArtifactUploadRequest,
 } from './artifacts.js'
 import type {
   AgentCatalog,
@@ -80,9 +82,17 @@ import type {
   RuntimeProviderDescriptor,
 } from './providers.js'
 import type {
+  AddCloudWorkspaceInput,
   SandboxCleanupResult,
   SandboxStorageStats,
   SkillImportSelection,
+  WorkspaceInfo,
+  WorkspaceApiSupport,
+  WorkspaceOptions,
+  WorkspacePolicy,
+  WorkspaceScoped,
+  WorkspaceSessionsUpdatedEvent,
+  WorkspaceSyncResult,
 } from './workspace.js'
 import type {
   ThreadFacetSummary,
@@ -120,19 +130,30 @@ export * from './workspace.js'
 export * from './workflow.js'
 
 export interface CoworkAPI {
+  workspace: {
+    list: () => Promise<WorkspaceInfo[]>
+    activate: (workspaceId: string) => Promise<WorkspaceInfo>
+    addCloud: (input: AddCloudWorkspaceInput) => Promise<WorkspaceInfo>
+    remove: (workspaceId: string) => Promise<boolean>
+    login: (workspaceId: string) => Promise<WorkspaceInfo>
+    logout: (workspaceId: string) => Promise<WorkspaceInfo>
+    policy: (workspaceId?: string) => Promise<WorkspacePolicy>
+    support: (workspaceId?: string) => Promise<WorkspaceApiSupport[]>
+    sync: (workspaceId?: string) => Promise<WorkspaceSyncResult>
+  }
   auth: {
     status: () => Promise<AuthState>
     login: () => Promise<AuthState>
     logout: () => Promise<AuthState>
   }
   session: {
-    create: (directory?: string) => Promise<SessionInfo>
-    activate: (sessionId: string, options?: { force?: boolean }) => Promise<SessionView>
+    create: (directory?: string, options?: WorkspaceOptions) => Promise<SessionInfo>
+    activate: (sessionId: string, options?: WorkspaceScoped<{ force?: boolean }>) => Promise<SessionView>
     prompt: (sessionId: string, text: string, attachments?: Array<{ mime: string; url: string; filename?: string }>, agent?: string, options?: SessionPromptOptions) => Promise<void>
     setComposerPreferences: (sessionId: string, preferences: SessionComposerPreferences) => Promise<SessionInfo | null>
-    list: () => Promise<SessionInfo[]>
-    get: (id: string) => Promise<SessionInfo | null>
-    abort: (sessionId: string) => Promise<void>
+    list: (options?: WorkspaceOptions) => Promise<SessionInfo[]>
+    get: (id: string, options?: WorkspaceOptions) => Promise<SessionInfo | null>
+    abort: (sessionId: string, options?: WorkspaceOptions) => Promise<void>
     // Aborts a single sub-agent task under a root session without
     // cancelling the root or its siblings. Used by the task drill-in
     // drawer's per-task abort button.
@@ -161,12 +182,12 @@ export interface CoworkAPI {
   settings: {
     // Returns credentials masked ('••••••••' for set values). Safe default
     // for any consumer that only needs non-secret fields.
-    get: () => Promise<EffectiveAppSettings>
+    get: (options?: WorkspaceOptions) => Promise<EffectiveAppSettings>
     // Scoped unmasked reads for credential editor surfaces. The renderer
     // never receives the full effective settings object with every secret.
     getProviderCredentials: (providerId: string) => Promise<Record<string, string>>
     getIntegrationCredentials: (integrationId: string) => Promise<Record<string, string>>
-    set: (updates: Partial<AppSettings>) => Promise<EffectiveAppSettings>
+    set: (updates: WorkspaceScoped<Partial<AppSettings>>) => Promise<EffectiveAppSettings>
   }
   mcp: {
     auth: (mcpName: string) => Promise<boolean>
@@ -193,6 +214,8 @@ export interface CoworkAPI {
     saveArtifact: (request: ChartSaveArtifactRequest) => Promise<SessionArtifact>
   }
   artifact: {
+    list: (request: SessionArtifactListRequest) => Promise<SessionArtifact[]>
+    upload: (request: SessionArtifactUploadRequest) => Promise<SessionArtifact>
     export: (request: SessionArtifactExportRequest) => Promise<string | null>
     reveal: (request: SessionArtifactRequest) => Promise<boolean>
     readAttachment: (request: SessionArtifactRequest) => Promise<SessionArtifactAttachment>
@@ -275,31 +298,31 @@ export interface CoworkAPI {
     onInstallEvent: (callback: (event: UpdateInstallEvent) => void) => () => void
   }
   workflows: {
-    list: () => Promise<WorkflowListPayload>
-    get: (workflowId: string) => Promise<WorkflowDetail | null>
-    startDraft: (directory?: string | null) => Promise<SessionInfo>
-    runNow: (workflowId: string) => Promise<WorkflowRun | null>
-    pause: (workflowId: string) => Promise<WorkflowDetail | null>
-    resume: (workflowId: string) => Promise<WorkflowDetail | null>
-    archive: (workflowId: string) => Promise<WorkflowDetail | null>
+    list: (options?: WorkspaceOptions) => Promise<WorkflowListPayload>
+    get: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowDetail | null>
+    startDraft: (directory?: string | null, options?: WorkspaceOptions) => Promise<SessionInfo>
+    runNow: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowRun | null>
+    pause: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowDetail | null>
+    resume: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowDetail | null>
+    archive: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowDetail | null>
     regenerateWebhookSecret: (workflowId: string) => Promise<WorkflowDetail | null>
   }
   threads: {
-    search: (query?: ThreadSearchQuery) => Promise<ThreadSearchResult>
-    facets: (query?: ThreadSearchQuery) => Promise<ThreadFacetSummary>
+    search: (query?: WorkspaceScoped<ThreadSearchQuery>) => Promise<ThreadSearchResult>
+    facets: (query?: WorkspaceScoped<ThreadSearchQuery>) => Promise<ThreadFacetSummary>
     tags: {
-      list: () => Promise<ThreadTag[]>
-      create: (input: ThreadTagInput) => Promise<ThreadTag>
-      update: (tagId: string, input: ThreadTagInput) => Promise<ThreadTag | null>
-      delete: (tagId: string) => Promise<boolean>
-      apply: (sessionIds: string[], tagIds: string[]) => Promise<boolean>
-      remove: (sessionIds: string[], tagIds: string[]) => Promise<boolean>
+      list: (options?: WorkspaceOptions) => Promise<ThreadTag[]>
+      create: (input: ThreadTagInput, options?: WorkspaceOptions) => Promise<ThreadTag>
+      update: (tagId: string, input: ThreadTagInput, options?: WorkspaceOptions) => Promise<ThreadTag | null>
+      delete: (tagId: string, options?: WorkspaceOptions) => Promise<boolean>
+      apply: (sessionIds: string[], tagIds: string[], options?: WorkspaceOptions) => Promise<boolean>
+      remove: (sessionIds: string[], tagIds: string[], options?: WorkspaceOptions) => Promise<boolean>
     }
     smartFilters: {
-      list: () => Promise<ThreadSmartFilter[]>
-      create: (input: ThreadSmartFilterInput) => Promise<ThreadSmartFilter>
-      update: (filterId: string, input: ThreadSmartFilterInput) => Promise<ThreadSmartFilter | null>
-      delete: (filterId: string) => Promise<boolean>
+      list: (options?: WorkspaceOptions) => Promise<ThreadSmartFilter[]>
+      create: (input: ThreadSmartFilterInput, options?: WorkspaceOptions) => Promise<ThreadSmartFilter>
+      update: (filterId: string, input: ThreadSmartFilterInput, options?: WorkspaceOptions) => Promise<ThreadSmartFilter | null>
+      delete: (filterId: string, options?: WorkspaceOptions) => Promise<boolean>
     }
     suggestions: {
       accept: (suggestionId: string) => Promise<boolean>
@@ -345,7 +368,7 @@ export interface CoworkAPI {
   on: {
     sessionPatch: (callback: (patch: SessionPatch) => void) => () => void
     notification: (callback: (event: RuntimeNotification) => void) => () => void
-    sessionView: (callback: (data: { sessionId: string; view: SessionView }) => void) => () => void
+    sessionView: (callback: (data: { sessionId: string; workspaceId?: string | null; view: SessionView }) => void) => () => void
     permissionRequest: (callback: (request: PermissionRequest) => void) => () => void
     mcpStatus: (callback: (statuses: McpStatus[]) => void) => () => void
     authExpired: (callback: () => void) => () => void
@@ -364,6 +387,7 @@ export interface CoworkAPI {
       composerReasoningVariant?: string | null
     }) => void) => () => void
     sessionDeleted: (callback: (data: { id: string }) => void) => () => void
+    workspaceSessionsUpdated: (callback: (data: WorkspaceSessionsUpdatedEvent) => void) => () => void
     workflowUpdated: (callback: () => void) => () => void
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -173,11 +173,11 @@ export interface CoworkAPI {
     todo: (sessionId: string) => Promise<TodoItem[]>
   }
   permission: {
-    respond: (id: string, allowed: boolean, sessionId?: string | null) => Promise<void>
+    respond: (id: string, allowed: boolean, sessionId?: string | null, options?: WorkspaceOptions) => Promise<void>
   }
   question: {
-    reply: (sessionId: string, requestId: string, answers: string[][]) => Promise<void>
-    reject: (sessionId: string, requestId: string) => Promise<void>
+    reply: (sessionId: string, requestId: string, answers: string[][], options?: WorkspaceOptions) => Promise<void>
+    reject: (sessionId: string, requestId: string, options?: WorkspaceOptions) => Promise<void>
   }
   settings: {
     // Returns credentials masked ('••••••••' for set values). Safe default

--- a/packages/shared/src/runtime.ts
+++ b/packages/shared/src/runtime.ts
@@ -75,6 +75,7 @@ export interface RecentProject {
 }
 
 export interface ToolListOptions {
+  workspaceId?: string
   sessionId?: string
   directory?: string | null
   provider?: string | null
@@ -95,6 +96,7 @@ export interface RuntimeToolDescriptor {
 }
 
 export interface RuntimeContextOptions {
+  workspaceId?: string
   sessionId?: string
   directory?: string | null
 }

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -204,6 +204,7 @@ export interface TaskRun {
 export interface PendingApproval {
   id: string
   sessionId: string
+  workspaceId?: string | null
   taskRunId?: string | null
   tool: string
   input: Record<string, unknown>
@@ -227,6 +228,7 @@ export interface PendingQuestionPrompt {
 export interface PendingQuestion {
   id: string
   sessionId: string
+  workspaceId?: string | null
   sourceSessionId?: string | null
   questions: PendingQuestionPrompt[]
   tool?: {

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -1,3 +1,5 @@
+import type { SessionArtifact } from './artifacts.js'
+
 // Aggregate diff stats for a session, mirroring SDK Session.summary (additions
 // + deletions + file count across the session's snapshot diff). Distinct from
 // SessionUsageSummary below, which is our product-side cost/token rollup.
@@ -42,6 +44,7 @@ export interface SessionInfo {
 
 export interface SessionPromptOptions {
   variant?: string | null
+  workspaceId?: string
 }
 
 export interface SessionComposerPreferences {
@@ -246,6 +249,7 @@ export interface SessionView {
   compactions: CompactionNotice[]
   pendingApprovals: PendingApproval[]
   pendingQuestions: PendingQuestion[]
+  artifacts?: SessionArtifact[]
   errors: SessionError[]
   todos: TodoItem[]
   executionPlan: ExecutionPlanItem[]
@@ -267,6 +271,7 @@ export interface SessionView {
 export interface SessionMessageTextPatch {
   type: 'message_text'
   sessionId: string
+  workspaceId?: string | null
   messageId: string
   segmentId: string
   content: string
@@ -279,6 +284,7 @@ export interface SessionMessageTextPatch {
 export interface SessionTaskTextPatch {
   type: 'task_text'
   sessionId: string
+  workspaceId?: string | null
   taskRunId: string
   segmentId: string
   content: string
@@ -289,6 +295,7 @@ export interface SessionTaskTextPatch {
 export interface SessionMessageReasoningPatch {
   type: 'message_reasoning'
   sessionId: string
+  workspaceId?: string | null
   messageId: string
   segmentId: string
   content: string
@@ -299,6 +306,7 @@ export interface SessionMessageReasoningPatch {
 export interface SessionTaskReasoningPatch {
   type: 'task_reasoning'
   sessionId: string
+  workspaceId?: string | null
   taskRunId: string
   segmentId: string
   content: string
@@ -315,6 +323,7 @@ export type SessionPatch =
 export interface RuntimeNotification {
   type: 'done' | 'error'
   sessionId?: string | null
+  workspaceId?: string | null
   synthetic?: boolean
   message?: string
 }

--- a/packages/shared/src/workspace.ts
+++ b/packages/shared/src/workspace.ts
@@ -1,3 +1,80 @@
+export type WorkspaceKind = 'local' | 'cloud'
+
+export type WorkspaceStatus = 'online' | 'offline' | 'auth_required' | 'disabled' | 'error'
+
+export type WorkspaceInfo = {
+  id: string
+  kind: WorkspaceKind
+  label: string
+  status: WorkspaceStatus
+  active: boolean
+  tenantId?: string
+  userId?: string
+  baseUrl?: string
+  profileName?: string
+  lastSyncedAt?: string | null
+  error?: string | null
+}
+
+export type WorkspaceRef = {
+  workspaceId: string
+  sessionId?: string
+}
+
+export type WorkspaceScoped<T> = T & {
+  workspaceId?: string
+}
+
+export type WorkspaceOptions = {
+  workspaceId?: string
+}
+
+export type WorkspacePolicy = {
+  features: Record<string, boolean>
+  allowedAgents: string[] | null
+  allowedTools: string[] | null
+  allowedMcps: string[] | null
+  localFiles: 'enabled' | 'disabled'
+  localStdioMcps: 'enabled' | 'disabled' | 'allowlisted'
+  machineRuntimeConfig: 'disabled' | 'allowlisted'
+}
+
+export type WorkspaceActionVerdict = {
+  allowed: boolean
+  reason: string | null
+  policyCode?: string
+}
+
+export type WorkspaceApiSupportStatus =
+  | 'supported'
+  | 'read_only'
+  | 'blocked_by_policy'
+  | 'not_supported'
+  | 'deferred'
+
+export type WorkspaceApiSupport = {
+  api: string
+  status: WorkspaceApiSupportStatus
+  verdict?: WorkspaceActionVerdict
+}
+
+export type AddCloudWorkspaceInput = {
+  baseUrl: string
+  label?: string
+}
+
+export type WorkspaceSyncResult = {
+  ok: true
+  syncedAt: string
+}
+
+export type WorkspaceSessionsUpdatedEvent = {
+  workspaceId: string
+  sessions: Array<import('./session.js').SessionInfo>
+  lastEventSequence?: number | null
+  syncedAt: string
+}
+
 export interface SkillImportSelection {
   token: string
   directory: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   ip-address@<=10.1.0: '>=10.1.1'
   mermaid>uuid: ^14.0.0
   qs@>=6.11.1 <=6.15.1: 6.15.2
+  tmp@<0.2.7: 0.2.7
 
 importers:
 
@@ -190,9 +191,15 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@types/node':
+        specifier: ^22.12.0
+        version: 22.19.19
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   mcps/charts:
     dependencies:
@@ -203,9 +210,15 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@types/node':
+        specifier: ^22.12.0
+        version: 22.19.19
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   mcps/clock:
     dependencies:
@@ -216,9 +229,15 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@types/node':
+        specifier: ^22.12.0
+        version: 22.19.19
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   mcps/skills:
     dependencies:
@@ -232,9 +251,15 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@types/node':
+        specifier: ^22.12.0
+        version: 22.19.19
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   mcps/workflows:
     dependencies:
@@ -245,9 +270,15 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@types/node':
+        specifier: ^22.12.0
+        version: 22.19.19
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/shared:
     devDependencies:
@@ -4254,8 +4285,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   toidentifier@1.0.1:
@@ -9458,9 +9489,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   toidentifier@1.0.1: {}
 

--- a/scripts/require-packaged-executable.mjs
+++ b/scripts/require-packaged-executable.mjs
@@ -1,0 +1,30 @@
+import { accessSync, constants, statSync } from 'node:fs'
+
+const envName = 'OPEN_COWORK_PACKAGED_EXECUTABLE'
+const executablePath = process.env[envName]?.trim()
+
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}
+
+if (!executablePath) {
+  fail(`${envName} must point at a packaged desktop executable before running packaged smoke tests.`)
+}
+
+let stats
+try {
+  stats = statSync(executablePath)
+} catch {
+  fail(`${envName} does not exist: ${executablePath}`)
+}
+
+if (!stats.isFile()) {
+  fail(`${envName} must point at an executable file: ${executablePath}`)
+}
+
+try {
+  accessSync(executablePath, constants.X_OK)
+} catch {
+  fail(`${envName} is not executable: ${executablePath}`)
+}

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -36,6 +36,7 @@ const TEST_COOKIE_KEY = 'not-a-real-cookie-key-for-tests'
 class FakeRuntime implements CloudRuntimeAdapter {
   prompts: Array<{ sessionId: string, parts: CloudRuntimePromptPart[], agent: string }> = []
   questionReplies: Array<{ requestId: string, answers: unknown[] }> = []
+  questionRejects: Array<{ requestId: string }> = []
   permissionResponses: Array<{ permissionId: string, allowed: boolean }> = []
   listeners: CloudRuntimeEventListener[] = []
   closed = false
@@ -69,6 +70,10 @@ class FakeRuntime implements CloudRuntimeAdapter {
 
   async replyToQuestion(input: { requestId: string, answers: unknown[] }) {
     this.questionReplies.push(input)
+  }
+
+  async rejectQuestion(input: { requestId: string }) {
+    this.questionRejects.push(input)
   }
 
   async respondToPermission(input: { permissionId: string, allowed: boolean }) {
@@ -653,6 +658,11 @@ test('cloud worker applies durable question replies and permission responses to 
       headers,
       body: JSON.stringify({ requestId: 'question-1', answers: [{ value: 'yes' }] }),
     }))
+    const questionReject = await readJson(await fetch(`${web.url}/api/sessions/${sessionId}/question-reject`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ requestId: 'question-2' }),
+    }))
     const permission = await readJson(await fetch(`${web.url}/api/sessions/${sessionId}/permission-respond`, {
       method: 'POST',
       headers,
@@ -660,9 +670,11 @@ test('cloud worker applies durable question replies and permission responses to 
     }))
 
     assert.equal(question.processed, 0)
+    assert.equal(questionReject.processed, 0)
     assert.equal(permission.processed, 0)
-    assert.equal(await worker.worker?.processAllSessionCommands(), 2)
+    assert.equal(await worker.worker?.processAllSessionCommands(), 3)
     assert.deepEqual(runtime.questionReplies, [{ requestId: 'question-1', answers: [{ value: 'yes' }] }])
+    assert.deepEqual(runtime.questionRejects, [{ requestId: 'question-2' }])
     assert.deepEqual(runtime.permissionResponses, [{ permissionId: 'permission-1', allowed: true }])
 
     const events = await store.listSessionEvents('tenant-a', sessionId)

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -62,6 +62,11 @@ class FakeRuntime implements CloudRuntimeAdapter {
           messageId: `${input.sessionId}:assistant`,
           content: 'runtime answer',
         },
+      }, {
+        type: 'session.idle',
+        payload: {
+          sessionId: input.sessionId,
+        },
       }],
     }
   }

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -53,6 +53,70 @@ test('cloud control plane appends ordered idempotent session events', () => {
   }), /reused/)
 })
 
+test('cloud control plane appends user-scoped workspace events across sessions', () => {
+  const store = seededStore()
+  store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-2',
+    opencodeSessionId: 'oc-session-2',
+    profileName: 'full',
+  })
+  store.ensureUser({ tenantId: 'tenant-1', userId: 'user-2', email: 'b@example.com' })
+  store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-2',
+    sessionId: 'session-other',
+    opencodeSessionId: 'oc-session-other',
+    profileName: 'full',
+  })
+
+  const first = store.appendWorkspaceEvent({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    eventId: 'session-1:event-1',
+    type: 'assistant.message',
+    payload: { content: 'first' },
+  })
+  const second = store.appendWorkspaceEvent({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-2',
+    eventId: 'session-2:event-1',
+    type: 'assistant.message',
+    payload: { content: 'second' },
+  })
+  const replay = store.appendWorkspaceEvent({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    eventId: 'session-1:event-1',
+    type: 'assistant.message',
+    payload: { content: 'first' },
+  })
+
+  assert.equal(first.sequence, 1)
+  assert.equal(first.entityType, 'session')
+  assert.equal(first.entityId, 'session-1')
+  assert.equal(first.operation, 'update')
+  assert.equal(first.projectionVersion, 1)
+  assert.equal(second.sequence, 2)
+  assert.deepEqual(replay, first)
+  assert.deepEqual(
+    store.listWorkspaceEvents('tenant-1', 'user-1', 1).map((event) => [event.sequence, event.sessionId]),
+    [[2, 'session-2']],
+  )
+  assert.deepEqual(store.listWorkspaceEvents('tenant-1', 'user-2', 0), [])
+  assert.throws(() => store.appendWorkspaceEvent({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-other',
+    eventId: 'bad-owner',
+    type: 'assistant.message',
+  }), /does not belong/)
+})
+
 test('cloud control plane fences projection writes by worker lease token', () => {
   const store = seededStore()
   const firstLease = store.claimSessionLease(

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -52,6 +52,11 @@ class FakeRuntimeAdapter implements CloudRuntimeAdapter {
           messageId: `${input.sessionId}:assistant:${this.prompts.length}`,
           content: `echo: ${text}`,
         },
+      }, {
+        type: 'session.idle',
+        payload: {
+          sessionId: input.sessionId,
+        },
       }],
     }
   }

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -9,7 +9,10 @@ import {
   createCloudHttpServer,
   type CloudAuthResolver,
   type CloudBrowserAuthProvider,
+  type CloudDesktopAuthConfig,
 } from '../apps/desktop/src/main/cloud/http-server.ts'
+import { createHttpSseCloudTransportAdapter } from '../apps/desktop/src/main/cloud/transport-adapter.ts'
+import { CloudWorkspaceAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 import { createInMemoryObjectStore } from '../apps/desktop/src/main/cloud/object-store.ts'
 import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
 import { createCloudSessionCookieManager } from '../apps/desktop/src/main/cloud/session-cookie-auth.ts'
@@ -65,6 +68,7 @@ function createFixture(options: {
     sessionCookies?: ReturnType<typeof createCloudSessionCookieManager> | null
     auth?: CloudAuthResolver
     browserAuth?: CloudBrowserAuthProvider | null
+    desktopAuth?: CloudDesktopAuthConfig | null
     observability?: CloudObservabilityAdapter | null
     internalToken?: string | null
   } = {}) {
@@ -89,6 +93,7 @@ function createFixture(options: {
     ssePollMs: options.ssePollMs,
     sessionCookies: options.sessionCookies,
       browserAuth: options.browserAuth,
+      desktopAuth: options.desktopAuth,
       observability: options.observability,
       internalToken: options.internalToken,
       auth: options.auth || (() => ({
@@ -193,6 +198,11 @@ test('cloud HTTP server exposes health, config, session create/list/get, prompt,
     assert.equal(runtimeStatus.canExecute, true)
     assert.equal(runtimeStatus.commandProcessing, 'inline')
 
+    const workspace = await readJson(await fetch(`${baseUrl}/api/workspace`))
+    assert.equal(workspace.tenantId, 'tenant-1')
+    assert.equal(workspace.userId, 'user-1')
+    assert.equal(asRecord(workspace.policy).localFiles, 'disabled')
+
     const createdResponse = await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -224,6 +234,12 @@ test('cloud HTTP server exposes health, config, session create/list/get, prompt,
     const sessionView = asRecord(asRecord(session.projection).view)
     assert.equal(sessionView.isGenerating, false)
     assert.equal(asRecord(asArray(sessionView.messages)[0]).content, 'hello cloud')
+
+    const sharedViewResponse = await readJson(await fetch(`${baseUrl}/api/sessions/oc-session-1/view`))
+    const sharedView = asRecord(sharedViewResponse.view)
+    assert.equal(asArray(sharedView.messages).length, 2)
+    assert.equal(asRecord(asArray(sharedView.messages)[0]).content, 'hello cloud')
+    assert.equal(sharedView.isGenerating, false)
 
     const abortResponse = await fetch(`${baseUrl}/api/sessions/oc-session-1/abort`, { method: 'POST' })
     assert.equal(abortResponse.status, 202)
@@ -355,6 +371,32 @@ test('cloud HTTP browser session cookies use secure flags and enforce CSRF on mu
   }
 })
 
+test('cloud HTTP exposes public desktop OIDC config without cookies', async () => {
+  const fixture = createFixture({
+    desktopAuth: {
+      mode: 'oidc',
+      issuerUrl: 'https://issuer.example.test',
+      clientId: 'open-cowork-desktop',
+      scope: 'openid email profile offline_access',
+    },
+  })
+  const baseUrl = await fixture.server.listen()
+
+  try {
+    const response = await fetch(`${baseUrl}/auth/desktop/config`)
+    assert.equal(response.status, 200)
+    const body = await readJson(response)
+    assert.deepEqual(body, {
+      mode: 'oidc',
+      issuerUrl: 'https://issuer.example.test',
+      clientId: 'open-cowork-desktop',
+      scope: 'openid email profile offline_access',
+    })
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP bearer auth remains usable without CSRF when session cookies are configured', async () => {
   const sessionCookies = createCloudSessionCookieManager({
     secret: TEST_COOKIE_KEY,
@@ -476,6 +518,216 @@ test('cloud HTTP SSE streams durable session events without sticky renderer stat
     assert.equal(asRecord(event.payload).content, 'echo: stream me')
   } finally {
     controller.abort()
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP workspace event feed streams owned session deltas', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  const controller = new AbortController()
+  try {
+    await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    const stream = await fetch(`${baseUrl}/api/events?after=1`, {
+      signal: controller.signal,
+    })
+    assert.equal(stream.status, 200)
+
+    await fetch(`${baseUrl}/api/sessions/oc-session-1/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'workspace stream', agent: 'build' }),
+    })
+
+    const event = await readSseUntil(stream, (entry) => entry.type === 'assistant.message')
+    assert.equal(event.sessionId, 'oc-session-1')
+    assert.equal(event.entityType, 'session')
+    assert.equal(event.entityId, 'oc-session-1')
+    assert.equal(event.operation, 'update')
+    assert.equal(event.projectionVersion, event.sequence)
+    assert.equal(asRecord(event.payload).content, 'echo: workspace stream')
+  } finally {
+    controller.abort()
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP workspace event feed replays one ordered user stream across sessions', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  const controller = new AbortController()
+  const principal = {
+    tenantId: 'tenant-1',
+    tenantName: 'Tenant 1',
+    userId: 'user-1',
+    email: 'user@example.test',
+  }
+  try {
+    await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    await fetch(`${baseUrl}/api/sessions/oc-session-1/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'first session', agent: 'build' }),
+    })
+    await fetch(`${baseUrl}/api/sessions/oc-session-2/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'second session', agent: 'build' }),
+    })
+
+    const events = await fixture.service.listWorkspaceEvents(principal, 0)
+    assert.deepEqual(
+      events.map((event) => event.sequence),
+      Array.from({ length: events.length }, (_, index) => index + 1),
+    )
+    assert.deepEqual(
+      events.filter((event) => event.type === 'assistant.message').map((event) => event.sessionId),
+      ['oc-session-1', 'oc-session-2'],
+    )
+
+    const firstAssistant = events.find((event) => event.type === 'assistant.message' && event.sessionId === 'oc-session-1')
+    assert.ok(firstAssistant)
+    const stream = await fetch(`${baseUrl}/api/events?after=${firstAssistant.sequence}`, {
+      signal: controller.signal,
+    })
+    assert.equal(stream.status, 200)
+    const replayed = await readSseUntil(stream, (entry) => (
+      entry.type === 'assistant.message' && entry.sessionId === 'oc-session-2'
+    ))
+    assert.equal(asRecord(replayed.payload).content, 'echo: second session')
+  } finally {
+    controller.abort()
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP workspace event feed polls durable events written by another service instance', async () => {
+  const fixture = createFixture({ autoProcessCommands: false, ssePollMs: 10 })
+  const baseUrl = await fixture.server.listen()
+  const controller = new AbortController()
+  try {
+    await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    const stream = await fetch(`${baseUrl}/api/events?after=0`, {
+      signal: controller.signal,
+    })
+    assert.equal(stream.status, 200)
+
+    const workerSideService = new CloudSessionService(fixture.store, fixture.runtime, fixture.policy)
+    await workerSideService.appendRuntimeEvent({
+      tenantId: 'tenant-1',
+      sessionId: 'oc-session-1',
+      event: {
+        type: 'assistant.message',
+        payload: {
+          messageId: 'external-workspace-message',
+          content: 'from another workspace worker',
+        },
+      },
+    })
+
+    const event = await readSseUntil(stream, (entry) => entry.type === 'assistant.message')
+    assert.equal(event.sessionId, 'oc-session-1')
+    assert.equal(asRecord(event.payload).messageId, 'external-workspace-message')
+  } finally {
+    controller.abort()
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP workspace event feed asks clients to refresh snapshots after retention gaps', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  const controller = new AbortController()
+  const originalListWorkspaceEvents = fixture.service.listWorkspaceEvents.bind(fixture.service)
+  try {
+    await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    fixture.service.listWorkspaceEvents = async (principal, afterSequence = 0) => {
+      if (afterSequence === 0) {
+        return [{
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          sessionId: 'oc-session-1',
+          eventId: 'oc-session-1:retained-event-10',
+          sequence: 10,
+          type: 'assistant.message',
+          payload: { content: 'retained only' },
+          createdAt: '2026-01-01T00:00:00.000Z',
+        }]
+      }
+      return originalListWorkspaceEvents(principal, afterSequence)
+    }
+
+    const stream = await fetch(`${baseUrl}/api/events?after=1`, {
+      signal: controller.signal,
+    })
+    assert.equal(stream.status, 200)
+
+    const event = await readSseUntil(stream, (entry) => entry.type === 'snapshot.required')
+    assert.equal(asRecord(event.payload).reason, 'event_retention_gap')
+    assert.equal(asRecord(event.payload).afterSequence, 1)
+    assert.equal(asRecord(event.payload).earliestSequence, 10)
+    assert.equal(asRecord(event.payload).latestSequence, 10)
+  } finally {
+    controller.abort()
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP clients share session state across desktop adapter and web transport', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  try {
+    const web = createHttpSseCloudTransportAdapter({ baseUrl })
+    const desktop = new CloudWorkspaceAdapter({
+      connection: {
+        id: 'cloud:test',
+        baseUrl,
+        label: 'Test Cloud',
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+        lastSyncedAt: null,
+      },
+      transport: createHttpSseCloudTransportAdapter({ baseUrl }),
+      cache: null,
+    })
+
+    const created = await desktop.createSession()
+    assert.equal((await web.listSessions()).some((session) => session.sessionId === created.id), true)
+
+    await web.promptSession(created.id, { text: 'from web', agent: 'build' })
+    const desktopAfterWebPrompt = await desktop.getSessionView(created.id)
+    assert.equal(desktopAfterWebPrompt.messages.some((message) => message.content === 'echo: from web'), true)
+
+    await desktop.promptSession(created.id, { text: 'from desktop', agent: 'build' })
+    const webAfterDesktopPrompt = await web.getSession(created.id)
+    assert.equal(
+      webAfterDesktopPrompt.projection?.view.messages.some((message) => message.content === 'echo: from desktop'),
+      true,
+    )
+  } finally {
     await fixture.server.close()
   }
 })
@@ -627,6 +879,35 @@ test('cloud HTTP exposes a read-only capability catalog filtered by profile allo
   }
 })
 
+test('cloud HTTP returns policy verdicts when capabilities are disabled', async () => {
+  const basePolicy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
+  const fixture = createFixture({
+    policy: {
+      ...basePolicy,
+      features: {
+        ...basePolicy.features,
+        agents: false,
+        customSkills: false,
+        customMcps: false,
+      },
+    },
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const response = await fetch(`${baseUrl}/api/capabilities`)
+    assert.equal(response.status, 403)
+    const body = await readJson(response)
+    assert.match(String(body.error), /Capabilities are disabled/)
+    assert.deepEqual(asRecord(body.verdict), {
+      allowed: false,
+      reason: 'Capabilities are disabled for this cloud profile.',
+      policyCode: 'capabilities.disabled',
+    })
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP exposes user-scoped settings metadata', async () => {
   const fixture = createFixture()
   const baseUrl = await fixture.server.listen()
@@ -665,7 +946,13 @@ test('cloud HTTP rejects settings APIs when the cloud profile disables them', as
   try {
     const response = await fetch(`${baseUrl}/api/settings`)
     assert.equal(response.status, 403)
-    assert.match(String((await readJson(response)).error), /Settings are disabled/)
+    const body = await readJson(response)
+    assert.match(String(body.error), /Settings are disabled/)
+    assert.deepEqual(asRecord(body.verdict), {
+      allowed: false,
+      reason: 'Settings are disabled for this cloud profile.',
+      policyCode: 'settings.disabled',
+    })
   } finally {
     await fixture.server.close()
   }
@@ -751,7 +1038,13 @@ test('cloud HTTP rejects thread-index APIs when the cloud profile disables them'
   try {
     const response = await fetch(`${baseUrl}/api/threads/tags`)
     assert.equal(response.status, 403)
-    assert.match(String((await readJson(response)).error), /Thread index is disabled/)
+    const body = await readJson(response)
+    assert.match(String(body.error), /Thread index is disabled/)
+    assert.deepEqual(asRecord(body.verdict), {
+      allowed: false,
+      reason: 'Thread index is disabled for this cloud profile.',
+      policyCode: 'thread_index.disabled',
+    })
   } finally {
     await fixture.server.close()
   }
@@ -978,7 +1271,13 @@ test('cloud HTTP rejects workflow APIs when the cloud profile disables them', as
   try {
     const response = await fetch(`${baseUrl}/api/workflows`)
     assert.equal(response.status, 403)
-    assert.match(String((await readJson(response)).error), /Workflows are disabled/)
+    const body = await readJson(response)
+    assert.match(String(body.error), /Workflows are disabled/)
+    assert.deepEqual(asRecord(body.verdict), {
+      allowed: false,
+      reason: 'Workflows are disabled for this cloud profile.',
+      policyCode: 'workflows.disabled',
+    })
   } finally {
     await fixture.server.close()
   }
@@ -1017,6 +1316,33 @@ test('cloud HTTP artifacts use object storage and durable artifact events', asyn
     const read = await readJson(await fetch(`${baseUrl}/api/sessions/oc-session-1/artifacts/${uploaded.artifactId}`))
     const artifact = asRecord(read.artifact)
     assert.equal(Buffer.from(String(artifact.dataBase64), 'base64').toString('utf8'), 'cloud artifact')
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP returns policy verdicts when artifacts are disabled', async () => {
+  const basePolicy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
+  const fixture = createFixture({
+    policy: {
+      ...basePolicy,
+      features: {
+        ...basePolicy.features,
+        artifacts: false,
+      },
+    },
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const response = await fetch(`${baseUrl}/api/sessions/oc-session-1/artifacts`)
+    assert.equal(response.status, 403)
+    const body = await readJson(response)
+    assert.match(String(body.error), /Artifacts are disabled/)
+    assert.deepEqual(asRecord(body.verdict), {
+      allowed: false,
+      reason: 'Artifacts are disabled for this cloud profile.',
+      policyCode: 'artifacts.disabled',
+    })
   } finally {
     await fixture.server.close()
   }

--- a/tests/cloud-opencode-runtime-adapter.test.ts
+++ b/tests/cloud-opencode-runtime-adapter.test.ts
@@ -105,6 +105,109 @@ test('cloud OpenCode event translator ignores user text echoes', () => {
   }), [])
 })
 
+test('cloud OpenCode event translator preserves projection-critical runtime events', () => {
+  assert.deepEqual(translateOpencodeRuntimeEvent({
+    payload: {
+      type: 'permission.asked',
+      properties: {
+        sessionID: 'session-1',
+        permission: {
+          id: 'permission-1',
+          tool: 'bash',
+          input: { command: 'git status' },
+        },
+      },
+    },
+  }), [{
+    type: 'permission.requested',
+    payload: {
+      permissionId: 'permission-1',
+      id: 'permission-1',
+      sessionId: 'session-1',
+      tool: 'bash',
+      input: { command: 'git status' },
+      description: 'bash',
+    },
+  }])
+
+  assert.deepEqual(translateOpencodeRuntimeEvent({
+    payload: {
+      type: 'question.asked',
+      properties: {
+        sessionID: 'session-1',
+        id: 'question-1',
+        questions: [{
+          header: 'Pick',
+          question: 'Proceed?',
+          options: [{ label: 'Yes', description: 'Continue' }],
+        }],
+        tool: { messageID: 'message-1', callID: 'call-1' },
+      },
+    },
+  }), [{
+    type: 'question.asked',
+    payload: {
+      requestId: 'question-1',
+      id: 'question-1',
+      sessionId: 'session-1',
+      questions: [{
+        header: 'Pick',
+        question: 'Proceed?',
+        options: [{ label: 'Yes', description: 'Continue' }],
+        multiple: false,
+        custom: true,
+      }],
+      tool: { messageId: 'message-1', callId: 'call-1' },
+    },
+  }])
+
+  assert.deepEqual(translateOpencodeRuntimeEvent({
+    payload: {
+      type: 'message.part.updated',
+      data: {
+        sessionID: 'session-1',
+        part: {
+          id: 'part-1',
+          callID: 'tool-call-1',
+          type: 'tool',
+          tool: 'read',
+          state: {
+            input: { file: 'README.md' },
+            output: 'contents',
+            status: 'completed',
+          },
+        },
+      },
+    },
+  }), [{
+    type: 'tool.call',
+    payload: {
+      sessionId: 'session-1',
+      id: 'tool-call-1',
+      name: 'read',
+      input: { file: 'README.md' },
+      status: 'complete',
+      output: 'contents',
+    },
+  }])
+
+  assert.deepEqual(translateOpencodeRuntimeEvent({
+    payload: {
+      type: 'todo.updated',
+      properties: {
+        sessionID: 'session-1',
+        todos: [{ content: 'Ship sync', status: 'in_progress', priority: 'high', id: 'todo-1' }],
+      },
+    },
+  }), [{
+    type: 'todos.updated',
+    payload: {
+      sessionId: 'session-1',
+      todos: [{ id: 'todo-1', content: 'Ship sync', status: 'in_progress', priority: 'high' }],
+    },
+  }])
+})
+
 test('cloud OpenCode runtime subscription translates stream events and reports failures', async () => {
   const delivered: unknown[] = []
   const errors: unknown[] = []

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -168,6 +168,57 @@ test('real Postgres cloud store assigns unique ordered event sequences under con
   })
 })
 
+test('real Postgres cloud store assigns one ordered workspace stream across sessions', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const secondSessionId = `${ids.sessionId}-two`
+    await store.createSession({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      sessionId: secondSessionId,
+      opencodeSessionId: `${secondSessionId}-opencode`,
+      profileName: 'full',
+    })
+
+    const writes = await Promise.all([
+      store.appendWorkspaceEvent({
+        tenantId: ids.tenantId,
+        userId: ids.userId,
+        sessionId: ids.sessionId,
+        eventId: `${ids.sessionId}:event-1`,
+        type: 'assistant.message',
+        payload: { messageId: 'm-1', content: 'first' },
+      }),
+      store.appendWorkspaceEvent({
+        tenantId: ids.tenantId,
+        userId: ids.userId,
+        sessionId: secondSessionId,
+        eventId: `${secondSessionId}:event-1`,
+        type: 'assistant.message',
+        payload: { messageId: 'm-2', content: 'second' },
+      }),
+      store.appendWorkspaceEvent({
+        tenantId: ids.tenantId,
+        userId: ids.userId,
+        sessionId: ids.sessionId,
+        eventId: `${ids.sessionId}:event-2`,
+        type: 'assistant.message',
+        payload: { messageId: 'm-3', content: 'third' },
+      }),
+    ])
+
+    assert.deepEqual(
+      writes.map((event) => event.sequence).sort((left, right) => left - right),
+      [1, 2, 3],
+    )
+    assert.deepEqual(
+      (await store.listWorkspaceEvents(ids.tenantId, ids.userId, 0)).map((event) => event.sequence),
+      [1, 2, 3],
+    )
+  })
+})
+
 test('real Postgres cloud store keeps session commands idempotent and lease-fenced', {
   skip: POSTGRES_SKIP,
 }, async () => {

--- a/tests/cloud-session-projection.test.ts
+++ b/tests/cloud-session-projection.test.ts
@@ -65,6 +65,7 @@ test('cloud session projection persists approvals questions tools todos costs an
     type: 'permission.requested',
     payload: {
       permissionId: 'permission-1',
+      sessionId: 'opencode-runtime-session-1',
       tool: 'bash',
       input: { command: 'git status' },
       description: 'Run git status',
@@ -74,6 +75,7 @@ test('cloud session projection persists approvals questions tools todos costs an
     type: 'question.asked',
     payload: {
       requestId: 'question-1',
+      sessionId: 'opencode-runtime-session-1',
       questions: [{
         header: 'Pick',
         question: 'Proceed?',
@@ -111,9 +113,13 @@ test('cloud session projection persists approvals questions tools todos costs an
   assert.equal(asArray(pending.toolCalls).length, 1)
   assert.equal(asRecord(asArray(pending.toolCalls)[0]).name, 'read')
   assert.equal(asArray(pending.pendingApprovals).length, 1)
-  assert.equal(asRecord(asArray(pending.pendingApprovals)[0]).description, 'Run git status')
+  const pendingApproval = asRecord(asArray(pending.pendingApprovals)[0])
+  assert.equal(pendingApproval.sessionId, sessionId)
+  assert.equal(pendingApproval.description, 'Run git status')
   assert.equal(asArray(pending.pendingQuestions).length, 1)
-  assert.equal(asRecord(asArray(pending.pendingQuestions)[0]).id, 'question-1')
+  const pendingQuestion = asRecord(asArray(pending.pendingQuestions)[0])
+  assert.equal(pendingQuestion.sessionId, sessionId)
+  assert.equal(pendingQuestion.id, 'question-1')
   assert.equal(asArray(pending.todos).length, 1)
   assert.equal(asRecord(asArray(pending.todos)[0]).content, 'Ship sync')
   assert.equal(asRecord(asArray(pending.artifacts)[0]).cloudArtifactId, 'artifact-1')

--- a/tests/cloud-session-projection.test.ts
+++ b/tests/cloud-session-projection.test.ts
@@ -1,0 +1,138 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { DEFAULT_CONFIG } from '../apps/desktop/src/main/config-types.ts'
+import { resolveCloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
+import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
+import type {
+  CloudRuntimeAdapter,
+  CloudRuntimePromptPart,
+} from '../apps/desktop/src/main/cloud/runtime-adapter.ts'
+import { CloudSessionService } from '../apps/desktop/src/main/cloud/session-service.ts'
+
+class FakeRuntime implements CloudRuntimeAdapter {
+  async createSession() {
+    return {
+      id: 'session-1',
+      title: 'Projection session',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }
+  }
+
+  async promptSession(_input: { sessionId: string, parts: CloudRuntimePromptPart[], agent: string }) {
+    return { events: [] }
+  }
+
+  async abortSession(_input: { sessionId: string }) {}
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  assert.equal(Boolean(value && typeof value === 'object' && !Array.isArray(value)), true)
+  return value as Record<string, unknown>
+}
+
+function asArray(value: unknown): unknown[] {
+  assert.equal(Array.isArray(value), true)
+  return value as unknown[]
+}
+
+test('cloud session projection persists approvals questions tools todos costs and resolution state', async () => {
+  const service = new CloudSessionService(
+    new InMemoryControlPlaneStore(),
+    new FakeRuntime(),
+    resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+  )
+  const principal = {
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    email: 'user@example.test',
+  }
+  const created = await service.createSession(principal)
+  const sessionId = created.session.sessionId
+
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'tool.call',
+    payload: {
+      id: 'tool-1',
+      name: 'read',
+      input: { file: 'README.md' },
+      status: 'complete',
+      output: 'contents',
+    },
+  })
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'permission.requested',
+    payload: {
+      permissionId: 'permission-1',
+      tool: 'bash',
+      input: { command: 'git status' },
+      description: 'Run git status',
+    },
+  })
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'question.asked',
+    payload: {
+      requestId: 'question-1',
+      questions: [{
+        header: 'Pick',
+        question: 'Proceed?',
+        options: [{ label: 'Yes', description: 'Continue' }],
+      }],
+    },
+  })
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'todos.updated',
+    payload: {
+      todos: [{ id: 'todo-1', content: 'Ship sync', status: 'in_progress', priority: 'high' }],
+    },
+  })
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'cost.updated',
+    payload: {
+      cost: 0.42,
+      tokens: { input: 11, output: 7, reasoning: 3, cache: { read: 2, write: 1 } },
+    },
+  })
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'artifact.created',
+    payload: {
+      artifactId: 'artifact-1',
+      sessionId,
+      filename: 'result.txt',
+      contentType: 'text/plain',
+      size: 5,
+      key: 'tenant/session/artifact-1/result.txt',
+      createdAt: '2026-05-27T10:02:00.000Z',
+    },
+  })
+
+  const pending = asRecord(asRecord((await service.getSessionView(principal, sessionId)).projection).view)
+  assert.equal(asArray(pending.toolCalls).length, 1)
+  assert.equal(asRecord(asArray(pending.toolCalls)[0]).name, 'read')
+  assert.equal(asArray(pending.pendingApprovals).length, 1)
+  assert.equal(asRecord(asArray(pending.pendingApprovals)[0]).description, 'Run git status')
+  assert.equal(asArray(pending.pendingQuestions).length, 1)
+  assert.equal(asRecord(asArray(pending.pendingQuestions)[0]).id, 'question-1')
+  assert.equal(asArray(pending.todos).length, 1)
+  assert.equal(asRecord(asArray(pending.todos)[0]).content, 'Ship sync')
+  assert.equal(asRecord(asArray(pending.artifacts)[0]).cloudArtifactId, 'artifact-1')
+  assert.equal(asRecord(asArray(pending.artifacts)[0]).filePath, 'cloud-artifact://artifact-1/result.txt')
+  assert.equal(pending.sessionCost, 0.42)
+  assert.equal(asRecord(pending.sessionTokens).cacheRead, 2)
+  assert.equal(pending.lastInputTokens, 11)
+  assert.equal(pending.isGenerating, false)
+
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'permission.resolved',
+    payload: { permissionId: 'permission-1' },
+  })
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'question.resolved',
+    payload: { requestId: 'question-1' },
+  })
+
+  const resolved = asRecord(asRecord((await service.getSessionView(principal, sessionId)).projection).view)
+  assert.equal(asArray(resolved.pendingApprovals).length, 0)
+  assert.equal(asArray(resolved.pendingQuestions).length, 0)
+})

--- a/tests/cloud-session-projection.test.ts
+++ b/tests/cloud-session-projection.test.ts
@@ -136,3 +136,63 @@ test('cloud session projection persists approvals questions tools todos costs an
   assert.equal(asArray(resolved.pendingApprovals).length, 0)
   assert.equal(asArray(resolved.pendingQuestions).length, 0)
 })
+
+test('cloud assistant chunks keep projection running until explicit idle event', async () => {
+  const store = new InMemoryControlPlaneStore()
+  const service = new CloudSessionService(
+    store,
+    new FakeRuntime(),
+    resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+  )
+  const principal = {
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    email: 'user@example.test',
+  }
+  const created = await service.createSession(principal)
+  const sessionId = created.session.sessionId
+
+  await store.updateSessionStatus({
+    tenantId: principal.tenantId,
+    sessionId,
+    status: 'running',
+  })
+  await service.appendProductEvent(principal, sessionId, {
+    type: 'prompt.submitted',
+    payload: {
+      messageId: 'command-1:user',
+      text: 'stream a long answer',
+      agent: 'build',
+    },
+  })
+  await service.appendRuntimeEvent({
+    tenantId: principal.tenantId,
+    sessionId,
+    event: {
+      type: 'assistant.message',
+      payload: {
+        messageId: 'assistant-1',
+        content: 'partial answer',
+      },
+    },
+  })
+
+  const chunkView = asRecord(asRecord((await service.getSessionView(principal, sessionId)).projection).view)
+  assert.equal(chunkView.status, 'running')
+  assert.equal(chunkView.isGenerating, true)
+  assert.equal((await store.getSessionForTenant(principal.tenantId, sessionId))?.status, 'running')
+
+  await service.appendRuntimeEvent({
+    tenantId: principal.tenantId,
+    sessionId,
+    event: {
+      type: 'session.idle',
+      payload: { sessionId },
+    },
+  })
+
+  const idleView = asRecord(asRecord((await service.getSessionView(principal, sessionId)).projection).view)
+  assert.equal(idleView.status, 'idle')
+  assert.equal(idleView.isGenerating, false)
+  assert.equal((await store.getSessionForTenant(principal.tenantId, sessionId))?.status, 'idle')
+})

--- a/tests/cloud-transport-adapter.test.ts
+++ b/tests/cloud-transport-adapter.test.ts
@@ -46,6 +46,100 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
     if (url.endsWith('/api/sessions/session-1/permission-respond')) {
       return jsonResponse({ command: { commandId: 'cmd-3' }, processed: 0 }, 202)
     }
+    if (url.endsWith('/api/sessions/session-1/artifacts')) {
+      if (init?.method === 'POST') {
+        return jsonResponse({
+          artifact: {
+            artifactId: 'artifact-2',
+            sessionId: 'session-1',
+            filename: 'upload.txt',
+            contentType: 'text/plain',
+            size: 5,
+            key: 'tenant/session/artifact-2/upload.txt',
+            createdAt: '2026-05-27T10:02:00.000Z',
+          },
+        }, 201)
+      }
+      return jsonResponse({
+        artifacts: [{
+          artifactId: 'artifact-1',
+          sessionId: 'session-1',
+          filename: 'result.txt',
+          contentType: 'text/plain',
+          size: 5,
+          key: 'tenant/session/artifact-1/result.txt',
+          createdAt: '2026-05-27T10:01:00.000Z',
+        }],
+      })
+    }
+    if (url.endsWith('/api/sessions/session-1/artifacts/artifact-1')) {
+      return jsonResponse({
+        artifact: {
+          artifactId: 'artifact-1',
+          sessionId: 'session-1',
+          filename: 'result.txt',
+          contentType: 'text/plain',
+          size: 5,
+          key: 'tenant/session/artifact-1/result.txt',
+          createdAt: '2026-05-27T10:01:00.000Z',
+          dataBase64: Buffer.from('hello').toString('base64'),
+        },
+      })
+    }
+    if (url.endsWith('/api/workflows')) {
+      return jsonResponse({ workflows: [{ id: 'workflow-1' }], runs: [] })
+    }
+    if (url.endsWith('/api/workflows/workflow-1')) {
+      return jsonResponse({ workflow: { id: 'workflow-1', status: 'active' } })
+    }
+    if (url.endsWith('/api/workflows/workflow-1/run')) {
+      return jsonResponse({ run: { id: 'run-1', workflowId: 'workflow-1', status: 'running' } }, 202)
+    }
+    if (url.endsWith('/api/workflows/workflow-1/pause')) {
+      return jsonResponse({ workflow: { id: 'workflow-1', status: 'paused' } })
+    }
+    if (url.includes('/api/threads?')) {
+      return jsonResponse({
+        threads: [{
+          sessionId: 'session-1',
+          title: 'Cloud thread',
+          profileName: 'default',
+          status: 'running',
+          createdAt: '2026-05-27T10:00:00.000Z',
+          updatedAt: '2026-05-27T10:01:00.000Z',
+          tags: [{
+            tagId: 'tag-1',
+            name: 'Important',
+            color: '#123456',
+            createdAt: '2026-05-27T10:00:00.000Z',
+            updatedAt: '2026-05-27T10:00:00.000Z',
+          }],
+        }],
+      })
+    }
+    if (url.endsWith('/api/threads/tags')) {
+      if (init?.method === 'POST') {
+        return jsonResponse({ tag: { tagId: 'tag-2', name: 'New', color: '#abcdef' } }, 201)
+      }
+      return jsonResponse({ tags: [{ tagId: 'tag-1', name: 'Important', color: '#123456' }] })
+    }
+    if (url.endsWith('/api/threads/tags/tag-1')) {
+      if (init?.method === 'DELETE') return jsonResponse({ deleted: true })
+      return jsonResponse({ tag: { tagId: 'tag-1', name: 'Renamed', color: '#654321' } })
+    }
+    if (url.endsWith('/api/threads/tags/tag-1/apply') || url.endsWith('/api/threads/tags/tag-1/remove')) {
+      return jsonResponse({ ok: true })
+    }
+    if (url.endsWith('/api/threads/smart-filters')) {
+      if (init?.method === 'POST') {
+        return jsonResponse({ filter: { filterId: 'filter-2', name: 'New filter', query: {}, createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' } }, 201)
+      }
+      return jsonResponse({ filters: [{ filterId: 'filter-1', name: 'Mine', query: {}, createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }] })
+    }
+    if (url.endsWith('/api/threads/smart-filters/filter-1')) {
+      if (init?.method === 'DELETE') return jsonResponse({ deleted: true })
+      return jsonResponse({ filter: { filterId: 'filter-1', name: 'Updated', query: {}, createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' } })
+    }
     if (url.endsWith('/api/runtime/status')) {
       return jsonResponse({
         role: 'web',
@@ -54,6 +148,81 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
         commandProcessing: 'delegated',
         checkpoints: false,
         heartbeats: [],
+      })
+    }
+    if (url.endsWith('/api/capabilities/tools')) {
+      return jsonResponse({
+        tools: [{
+          id: 'read',
+          name: 'Read',
+          description: 'Read files',
+          kind: 'built-in',
+          source: 'builtin',
+          patterns: ['read'],
+          agentNames: ['build'],
+        }],
+      })
+    }
+    if (url.endsWith('/api/capabilities/tools/read')) {
+      return jsonResponse({
+        tool: {
+          id: 'read',
+          name: 'Read',
+          description: 'Read files',
+          kind: 'built-in',
+          source: 'builtin',
+          patterns: ['read'],
+          agentNames: ['build'],
+        },
+      })
+    }
+    if (url.endsWith('/api/capabilities/skills')) {
+      return jsonResponse({
+        skills: [{
+          name: 'analysis',
+          label: 'Analysis',
+          description: 'Analyze data',
+          source: 'builtin',
+          toolIds: ['read'],
+          agentNames: ['data-analyst'],
+        }],
+      })
+    }
+    if (url.endsWith('/api/capabilities/skills/analysis/bundle')) {
+      return jsonResponse({
+        bundle: {
+          name: 'analysis',
+          source: 'builtin',
+          content: '# Analysis',
+          files: [{ path: 'examples/report.md', content: 'report example' }],
+        },
+      })
+    }
+    if (url.endsWith('/api/settings')) {
+      return jsonResponse({
+        settings: [{
+          key: 'portable-settings',
+          value: { selectedProviderId: 'anthropic' },
+          updatedAt: '2026-05-27T10:00:00.000Z',
+        }],
+      })
+    }
+    if (url.endsWith('/api/settings/portable-settings')) {
+      if (init?.method === 'PUT') {
+        return jsonResponse({
+          setting: {
+            key: 'portable-settings',
+            value: JSON.parse(init.body || '{}').value,
+            updatedAt: '2026-05-27T10:01:00.000Z',
+          },
+        })
+      }
+      return jsonResponse({
+        setting: {
+          key: 'portable-settings',
+          value: { selectedProviderId: 'anthropic' },
+          updatedAt: '2026-05-27T10:00:00.000Z',
+        },
       })
     }
     return jsonResponse({ error: 'not found' }, 404)
@@ -72,10 +241,48 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
   assert.equal((await transport.promptSession('session-1', { text: 'hello' })).processed, 0)
   assert.equal((await transport.replyToQuestion('session-1', { requestId: 'q1', answers: ['A'] })).processed, 0)
   assert.equal((await transport.respondToPermission('session-1', { permissionId: 'p1', response: { allowed: true } })).processed, 0)
+  assert.equal((await transport.listWorkflows?.())?.workflows[0]?.id, 'workflow-1')
+  assert.equal((await transport.getWorkflow?.('workflow-1'))?.id, 'workflow-1')
+  assert.equal((await transport.runWorkflow?.('workflow-1'))?.id, 'run-1')
+  assert.equal((await transport.pauseWorkflow?.('workflow-1'))?.status, 'paused')
+  assert.equal((await transport.searchThreads?.({ tagIds: ['tag-1'], limit: 10 }))?.threads[0]?.tags[0]?.id, 'tag-1')
+  assert.equal((await transport.threadFacets?.({ tagIds: ['tag-1'] }))?.tags[0]?.value, 'tag-1')
+  assert.equal((await transport.listThreadTags?.())?.[0]?.id, 'tag-1')
+  assert.equal((await transport.createThreadTag?.({ name: 'New' }))?.id, 'tag-2')
+  assert.equal((await transport.updateThreadTag?.('tag-1', { name: 'Renamed', color: '#654321' }))?.name, 'Renamed')
+  assert.equal(await transport.applyThreadTags?.(['session-1'], ['tag-1']), true)
+  assert.equal(await transport.removeThreadTags?.(['session-1'], ['tag-1']), true)
+  assert.equal(await transport.deleteThreadTag?.('tag-1'), true)
+  assert.equal((await transport.listThreadSmartFilters?.())?.[0]?.id, 'filter-1')
+  assert.equal((await transport.createThreadSmartFilter?.({ name: 'New filter', query: {} }))?.id, 'filter-2')
+  assert.equal((await transport.updateThreadSmartFilter?.('filter-1', { name: 'Updated', query: {} }))?.name, 'Updated')
+  assert.equal(await transport.deleteThreadSmartFilter?.('filter-1'), true)
+  const artifact = (await transport.listArtifacts?.('session-1'))?.[0]
+  assert.equal(artifact?.cloudArtifactId, 'artifact-1')
+  assert.equal(artifact?.filePath, 'cloud-artifact://artifact-1/result.txt')
+  assert.equal((await transport.uploadArtifact?.('session-1', {
+    filename: 'upload.txt',
+    contentType: 'text/plain',
+    dataBase64: Buffer.from('hello').toString('base64'),
+  }))?.cloudArtifactId, 'artifact-2')
+  const attachment = await transport.readArtifactAttachment?.('session-1', artifact?.filePath || 'artifact-1')
+  assert.equal(attachment?.mime, 'text/plain')
+  assert.equal(attachment?.filename, 'result.txt')
+  assert.equal(attachment?.url, `data:text/plain;base64,${Buffer.from('hello').toString('base64')}`)
+  assert.equal((await transport.listCapabilityTools?.())?.[0]?.id, 'read')
+  assert.equal((await transport.getCapabilityTool?.('read'))?.name, 'Read')
+  assert.equal((await transport.listCapabilitySkills?.())?.[0]?.name, 'analysis')
+  assert.equal((await transport.getCapabilitySkillBundle?.('analysis'))?.name, 'analysis')
+  assert.equal(await transport.readCapabilitySkillBundleFile?.('analysis', 'examples/report.md'), 'report example')
+  assert.equal((await transport.listSettings?.())?.[0]?.key, 'portable-settings')
+  assert.equal((await transport.getSetting?.('portable-settings'))?.value.selectedProviderId, 'anthropic')
+  assert.equal((await transport.setSetting?.('portable-settings', { selectedProviderId: 'openai' }))?.value.selectedProviderId, 'openai')
 
   const mutating = requests.filter((request) => request.init?.method === 'POST')
+  const putRequests = requests.filter((request) => request.init?.method === 'PUT')
   assert.equal(mutating.every((request) => request.init?.headers?.['x-csrf-token'] === 'csrf-token'), true)
   assert.equal(mutating.every((request) => request.init?.credentials === 'include'), true)
+  assert.equal(putRequests.every((request) => request.init?.headers?.['x-csrf-token'] === 'csrf-token'), true)
   assert.deepEqual(
     mutating.map((request) => new URL(request.url).pathname),
     [
@@ -83,6 +290,13 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
       '/api/sessions/session-1/prompt',
       '/api/sessions/session-1/question-reply',
       '/api/sessions/session-1/permission-respond',
+      '/api/workflows/workflow-1/run',
+      '/api/workflows/workflow-1/pause',
+      '/api/threads/tags',
+      '/api/threads/tags/tag-1/apply',
+      '/api/threads/tags/tag-1/remove',
+      '/api/threads/smart-filters',
+      '/api/sessions/session-1/artifacts',
     ],
   )
 })
@@ -136,8 +350,16 @@ test('cloud transport adapter builds Last-Event-ID compatible SSE URLs and subsc
     transport.sessionEventsUrl('session 1', 42),
     'https://cloud.example.test/api/sessions/session%201/events?after=42',
   )
+  assert.equal(
+    transport.workspaceEventsUrl(42),
+    'https://cloud.example.test/api/events?after=42',
+  )
   assert.equal(instances[0]?.url, 'https://cloud.example.test/api/sessions/session%201/events?after=42')
   assert.equal(instances[0]?.init?.withCredentials, true)
+  assert.equal(instances[0]?.listeners.has('permission.requested'), true)
+  assert.equal(instances[0]?.listeners.has('question.asked'), true)
+  assert.equal(instances[0]?.listeners.has('tool.call'), true)
+  assert.equal(instances[0]?.listeners.has('artifact.created'), true)
   instances[0]?.listeners.get('assistant.message')?.({
     data: JSON.stringify({
       sequence: 43,
@@ -154,4 +376,94 @@ test('cloud transport adapter builds Last-Event-ID compatible SSE URLs and subsc
   }])
   subscription.close()
   assert.equal(instances[0]?.closed, true)
+
+  const workspaceEvents: unknown[] = []
+  const workspaceSubscription = transport.subscribeWorkspaceEvents({
+    afterSequence: 44,
+    onEvent: (event) => workspaceEvents.push(event),
+  })
+  assert.equal(instances[1]?.url, 'https://cloud.example.test/api/events?after=44')
+  assert.equal(instances[1]?.listeners.has('session.created'), true)
+  assert.equal(instances[1]?.listeners.has('snapshot.required'), true)
+  instances[1]?.listeners.get('session.created')?.({
+    data: JSON.stringify({
+      sequence: 45,
+      eventId: 'event-45',
+      sessionId: 'session-2',
+      type: 'session.created',
+      payload: { title: 'New cloud session' },
+    }),
+  })
+  assert.deepEqual(workspaceEvents, [{
+    sequence: 45,
+    eventId: 'event-45',
+    sessionId: 'session-2',
+    type: 'session.created',
+    payload: { title: 'New cloud session' },
+  }])
+  workspaceSubscription.close()
+  assert.equal(instances[1]?.closed, true)
+})
+
+test('cloud transport adapter authenticates SSE subscriptions with bearer headers', async () => {
+  const requests: Array<{ url: string, init?: Parameters<CloudTransportFetch>[1] }> = []
+  const fetcher: CloudTransportFetch = async (url, init) => {
+    requests.push({ url, init })
+    return {
+      ok: true,
+      status: 200,
+      async text() {
+        return ''
+      },
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode([
+            'event: assistant.message',
+            'data: {"sequence":7,"eventId":"event-7","type":"assistant.message","payload":{"content":"hello"}}',
+            '',
+            '',
+          ].join('\n')))
+          controller.close()
+        },
+      }),
+    }
+  }
+  const EventSourceImpl: CloudTransportEventSource = class {
+    constructor() {
+      throw new Error('EventSource should not be used when bearer headers are configured.')
+    }
+    close() {}
+    addEventListener() {}
+    onmessage = null
+    onerror = null
+  }
+  const transport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    fetch: fetcher,
+    eventSource: EventSourceImpl,
+    credentials: 'include',
+    headers: {
+      authorization: 'Bearer cloud-token',
+    },
+  })
+  const delivered = new Promise<unknown>((resolve, reject) => {
+    const subscription = transport.subscribeSessionEvents('session-1', {
+      onEvent: (event) => {
+        subscription.close()
+        resolve(event)
+      },
+      onError: reject,
+    })
+  })
+
+  assert.deepEqual(await delivered, {
+    sequence: 7,
+    eventId: 'event-7',
+    type: 'assistant.message',
+    payload: { content: 'hello' },
+  })
+  assert.equal(requests[0]?.url, 'https://cloud.example.test/api/sessions/session-1/events')
+  assert.equal(requests[0]?.init?.headers?.authorization, 'Bearer cloud-token')
+  assert.equal(requests[0]?.init?.headers?.accept, 'text/event-stream')
+  assert.equal(requests[0]?.init?.credentials, 'include')
 })

--- a/tests/cloud-transport-adapter.test.ts
+++ b/tests/cloud-transport-adapter.test.ts
@@ -43,8 +43,11 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
     if (url.endsWith('/api/sessions/session-1/question-reply')) {
       return jsonResponse({ command: { commandId: 'cmd-2' }, processed: 0 }, 202)
     }
-    if (url.endsWith('/api/sessions/session-1/permission-respond')) {
+    if (url.endsWith('/api/sessions/session-1/question-reject')) {
       return jsonResponse({ command: { commandId: 'cmd-3' }, processed: 0 }, 202)
+    }
+    if (url.endsWith('/api/sessions/session-1/permission-respond')) {
+      return jsonResponse({ command: { commandId: 'cmd-4' }, processed: 0 }, 202)
     }
     if (url.endsWith('/api/sessions/session-1/artifacts')) {
       if (init?.method === 'POST') {
@@ -240,6 +243,7 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
   assert.equal((await transport.createSession()).session.sessionId, 'session-1')
   assert.equal((await transport.promptSession('session-1', { text: 'hello' })).processed, 0)
   assert.equal((await transport.replyToQuestion('session-1', { requestId: 'q1', answers: ['A'] })).processed, 0)
+  assert.equal((await transport.rejectQuestion('session-1', { requestId: 'q2' })).processed, 0)
   assert.equal((await transport.respondToPermission('session-1', { permissionId: 'p1', response: { allowed: true } })).processed, 0)
   assert.equal((await transport.listWorkflows?.())?.workflows[0]?.id, 'workflow-1')
   assert.equal((await transport.getWorkflow?.('workflow-1'))?.id, 'workflow-1')
@@ -289,6 +293,7 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
       '/api/sessions',
       '/api/sessions/session-1/prompt',
       '/api/sessions/session-1/question-reply',
+      '/api/sessions/session-1/question-reject',
       '/api/sessions/session-1/permission-respond',
       '/api/workflows/workflow-1/run',
       '/api/workflows/workflow-1/pause',

--- a/tests/cloud-workspace-adapter.test.ts
+++ b/tests/cloud-workspace-adapter.test.ts
@@ -1,0 +1,847 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  CloudWorkspaceAdapter,
+  cloudWorkspaceCacheKey,
+} from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
+import { FileCloudWorkspaceCache } from '../apps/desktop/src/main/cloud-workspace-cache.ts'
+import type { CloudTransportAdapter } from '../apps/desktop/src/main/cloud/transport-adapter.ts'
+import type { WorkflowRun, WorkflowStatus } from '@open-cowork/shared'
+
+function workflowSummary(status: WorkflowStatus = 'active') {
+  return {
+    id: 'workflow-1',
+    title: 'Daily report',
+    instructions: 'Report',
+    agentName: 'data-analyst',
+    skillNames: [],
+    toolIds: [],
+    status,
+    projectDirectory: null,
+    draftSessionId: null,
+    triggers: [],
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    nextRunAt: null,
+    lastRunAt: null,
+    latestRunId: null,
+    latestRunStatus: null,
+    latestRunSessionId: null,
+    latestRunSummary: null,
+    webhookUrl: null,
+  }
+}
+
+function workflowDetail(status: WorkflowStatus = 'active') {
+  return {
+    ...workflowSummary(status),
+    runs: [],
+  }
+}
+
+function workflowRun(workflowId: string): WorkflowRun {
+  return {
+    id: 'run-1',
+    workflowId,
+    sessionId: 'session-1',
+    triggerType: 'manual',
+    triggerPayload: null,
+    status: 'running',
+    title: 'Daily report',
+    summary: null,
+    error: null,
+    createdAt: '2026-05-27T10:00:00.000Z',
+    startedAt: '2026-05-27T10:00:00.000Z',
+    finishedAt: null,
+  }
+}
+
+function threadTag(name = 'Important') {
+  return {
+    id: 'tag-1',
+    name,
+    color: '#123456',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }
+}
+
+function smartFilter(name = 'Mine') {
+  return {
+    id: 'filter-1',
+    name,
+    query: { tagIds: ['tag-1'] },
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }
+}
+
+function transport(): CloudTransportAdapter {
+  return {
+    getConfig: async () => ({
+      role: 'web',
+      profileName: 'default',
+      features: { sessions: true },
+      allowedAgents: ['data-analyst'],
+      allowedTools: ['read'],
+      allowedMcps: [],
+    }),
+    getRuntimeStatus: async () => ({
+      role: 'web',
+      profileName: 'default',
+      canExecute: false,
+      commandProcessing: 'delegated',
+      checkpoints: true,
+      heartbeats: [],
+    }),
+    listSessions: async () => [{
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      sessionId: 'session-1',
+      opencodeSessionId: 'opencode-session-1',
+      profileName: 'default',
+      status: 'idle',
+      title: 'Cloud session',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }],
+    createSession: async () => ({
+      session: {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        sessionId: 'session-2',
+        opencodeSessionId: 'opencode-session-2',
+        profileName: 'default',
+        status: 'idle',
+        title: 'New cloud session',
+        createdAt: '2026-05-27T11:00:00.000Z',
+        updatedAt: '2026-05-27T11:00:00.000Z',
+      },
+      projection: null,
+    }),
+    getSession: async (sessionId) => ({
+      session: {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        sessionId,
+        opencodeSessionId: `opencode-${sessionId}`,
+        profileName: 'default',
+        status: 'running',
+        title: 'Cloud session',
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:01:00.000Z',
+      },
+      projection: {
+        tenantId: 'tenant-1',
+        sessionId,
+        sequence: 7,
+        updatedAt: '2026-05-27T10:01:00.000Z',
+        view: {
+          sessionId,
+          title: 'Cloud session',
+          status: 'running',
+          profileName: 'default',
+          isGenerating: true,
+          messages: [
+            { id: 'm1', role: 'user', content: 'Hello', createdAt: '2026-05-27T10:00:01.000Z' },
+            { id: 'm2', role: 'assistant', content: 'Hi', createdAt: '2026-05-27T10:00:02.000Z' },
+          ],
+          toolCalls: [{
+            id: 'tool-1',
+            name: 'read',
+            input: { file: 'README.md' },
+            status: 'complete',
+            output: 'contents',
+            order: 3,
+          }],
+          taskRuns: [],
+          pendingApprovals: [{
+            id: 'permission-1',
+            sessionId,
+            tool: 'bash',
+            input: { command: 'git status' },
+            description: 'Run git status',
+            order: 4,
+          }],
+          pendingQuestions: [{
+            id: 'question-1',
+            sessionId,
+            questions: [{
+              header: 'Pick',
+              question: 'Proceed?',
+              options: [{ label: 'Yes', description: 'Continue' }],
+            }],
+          }],
+          artifacts: [{
+            id: 'artifact-1',
+            toolId: 'cloud-artifact',
+            toolName: 'cloud.artifact',
+            filePath: 'cloud-artifact://artifact-1/result.txt',
+            filename: 'result.txt',
+            order: 5,
+            source: 'cloud',
+            cloudArtifactId: 'artifact-1',
+            mime: 'text/plain',
+          }],
+          todos: [{ id: 'todo-1', content: 'Ship sync', status: 'in_progress', priority: 'high' }],
+          errors: [],
+          sessionCost: 0.42,
+          sessionTokens: { input: 11, output: 7, reasoning: 3, cacheRead: 2, cacheWrite: 1 },
+          lastInputTokens: 11,
+          lastError: null,
+          updatedAt: '2026-05-27T10:01:00.000Z',
+        },
+      },
+    }),
+    promptSession: async () => ({
+      command: {
+        commandId: 'command-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        sessionId: 'session-1',
+        kind: 'prompt',
+        payload: {},
+        targetLeaseToken: null,
+        createdSequence: 1,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        status: 'acked',
+        claimedBy: null,
+        claimedLeaseToken: null,
+        ackedAt: null,
+        error: null,
+      },
+      processed: 1,
+      view: {
+        session: {
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          sessionId: 'session-1',
+          opencodeSessionId: 'opencode-session-1',
+          profileName: 'default',
+          status: 'running',
+          title: 'Cloud session',
+          createdAt: '2026-05-27T10:00:00.000Z',
+          updatedAt: '2026-05-27T10:01:00.000Z',
+        },
+        projection: null,
+      },
+    }),
+    abortSession: async () => ({
+      command: {
+        commandId: 'command-2',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        sessionId: 'session-1',
+        kind: 'abort',
+        payload: {},
+        targetLeaseToken: null,
+        createdSequence: 2,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        status: 'acked',
+        claimedBy: null,
+        claimedLeaseToken: null,
+        ackedAt: null,
+        error: null,
+      },
+      processed: 1,
+      view: {
+        session: {
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          sessionId: 'session-1',
+          opencodeSessionId: 'opencode-session-1',
+          profileName: 'default',
+          status: 'idle',
+          title: 'Cloud session',
+          createdAt: '2026-05-27T10:00:00.000Z',
+          updatedAt: '2026-05-27T10:01:00.000Z',
+        },
+        projection: null,
+      },
+    }),
+    replyToQuestion: async () => ({ command: {} as never, processed: 1 }),
+    respondToPermission: async () => ({ command: {} as never, processed: 1 }),
+    listWorkflows: async () => ({
+      workflows: [workflowSummary()],
+      runs: [],
+    }),
+    getWorkflow: async () => workflowDetail(),
+    runWorkflow: async (workflowId) => workflowRun(workflowId),
+    pauseWorkflow: async () => workflowDetail('paused'),
+    resumeWorkflow: async () => workflowDetail('active'),
+    archiveWorkflow: async () => workflowDetail('archived'),
+    searchThreads: async () => ({
+      threads: [{
+        sessionId: 'session-1',
+        title: 'Cloud thread',
+        directory: null,
+        projectLabel: null,
+        providerId: null,
+        modelId: null,
+        status: 'running',
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:01:00.000Z',
+        parentSessionId: null,
+        workflowId: null,
+        runId: null,
+        revertedMessageId: null,
+        tags: [threadTag()],
+        actualAgents: [],
+        actualTools: [],
+        suggestions: [],
+        usage: {
+          messages: 0,
+          toolCalls: 0,
+          taskRuns: 0,
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+        },
+        changeSummary: null,
+      }],
+      nextCursor: null,
+      totalEstimate: 1,
+    }),
+    threadFacets: async () => ({
+      projects: [],
+      providers: [],
+      models: [],
+      agents: [],
+      tools: [],
+      mcps: [],
+      statuses: [],
+      tags: [{ value: 'tag-1', label: 'Important', color: '#123456', count: 1 }],
+    }),
+    listThreadTags: async () => [threadTag()],
+    createThreadTag: async (input) => ({ ...threadTag(input.name), color: input.color || '#123456' }),
+    updateThreadTag: async (_tagId, input) => ({ ...threadTag(input.name), color: input.color || '#123456' }),
+    deleteThreadTag: async () => true,
+    applyThreadTags: async () => true,
+    removeThreadTags: async () => true,
+    listThreadSmartFilters: async () => [smartFilter()],
+    createThreadSmartFilter: async (input) => ({ ...smartFilter(input.name), query: input.query }),
+    updateThreadSmartFilter: async (_filterId, input) => ({ ...smartFilter(input.name), query: input.query }),
+    deleteThreadSmartFilter: async () => true,
+    listArtifacts: async () => [{
+      id: 'artifact-1',
+      toolId: 'cloud-artifact',
+      toolName: 'cloud.artifact',
+      filePath: 'cloud-artifact://artifact-1/result.txt',
+      filename: 'result.txt',
+      order: 0,
+      source: 'cloud',
+      cloudArtifactId: 'artifact-1',
+      mime: 'text/plain',
+    }],
+    uploadArtifact: async (_sessionId, input) => ({
+      id: 'artifact-2',
+      toolId: 'cloud-artifact',
+      toolName: 'cloud.artifact',
+      filePath: 'cloud-artifact://artifact-2/upload.txt',
+      filename: input.filename,
+      order: 0,
+      source: 'cloud',
+      cloudArtifactId: 'artifact-2',
+      mime: input.contentType || undefined,
+    }),
+    readArtifactAttachment: async () => ({
+      mime: 'text/plain',
+      filename: 'result.txt',
+      url: `data:text/plain;base64,${Buffer.from('hello').toString('base64')}`,
+    }),
+    listCapabilityTools: async () => [{
+      id: 'read',
+      name: 'Read',
+      description: 'Read files',
+      kind: 'built-in',
+      source: 'builtin',
+      patterns: ['read'],
+      agentNames: ['build'],
+    }],
+    getCapabilityTool: async () => ({
+      id: 'read',
+      name: 'Read',
+      description: 'Read files',
+      kind: 'built-in',
+      source: 'builtin',
+      patterns: ['read'],
+      agentNames: ['build'],
+    }),
+    listCapabilitySkills: async () => [{
+      name: 'analysis',
+      label: 'Analysis',
+      description: 'Analyze data',
+      source: 'builtin',
+      toolIds: ['read'],
+      agentNames: ['data-analyst'],
+    }],
+    getCapabilitySkillBundle: async () => ({
+      name: 'analysis',
+      source: 'builtin',
+      content: '# Analysis',
+      files: [{ path: 'examples/report.md' }],
+    }),
+    readCapabilitySkillBundleFile: async () => 'report example',
+    listSettings: async () => [{
+      key: 'portable-settings',
+      value: { selectedProviderId: 'anthropic' },
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }],
+    getSetting: async () => ({
+      key: 'portable-settings',
+      value: { selectedProviderId: 'anthropic' },
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }),
+    setSetting: async (_key, value) => ({
+      key: 'portable-settings',
+      value,
+      updatedAt: '2026-05-27T10:01:00.000Z',
+    }),
+    workspaceEventsUrl: () => 'https://cloud.example.test/api/events',
+    sessionEventsUrl: () => 'https://cloud.example.test/api/sessions/session-1/events',
+    subscribeWorkspaceEvents: () => ({ close() {} }),
+    subscribeSessionEvents: () => ({ close() {} }),
+  }
+}
+
+function failingTransport(): CloudTransportAdapter {
+  const fail = async () => {
+    throw new Error('offline')
+  }
+  return {
+    getConfig: fail,
+    getRuntimeStatus: fail,
+    listSessions: fail,
+    createSession: fail,
+    getSession: fail,
+    promptSession: fail,
+    abortSession: fail,
+    replyToQuestion: fail,
+    respondToPermission: fail,
+    listWorkflows: fail,
+    getWorkflow: fail,
+    runWorkflow: fail,
+    pauseWorkflow: fail,
+    resumeWorkflow: fail,
+    archiveWorkflow: fail,
+    searchThreads: fail,
+    threadFacets: fail,
+    listThreadTags: fail,
+    createThreadTag: fail,
+    updateThreadTag: fail,
+    deleteThreadTag: fail,
+    applyThreadTags: fail,
+    removeThreadTags: fail,
+    listThreadSmartFilters: fail,
+    createThreadSmartFilter: fail,
+    updateThreadSmartFilter: fail,
+    deleteThreadSmartFilter: fail,
+    listArtifacts: fail,
+    uploadArtifact: fail,
+    readArtifactAttachment: fail,
+    listSettings: fail,
+    getSetting: fail,
+    setSetting: fail,
+    workspaceEventsUrl: () => 'https://cloud.example.test/api/events',
+    sessionEventsUrl: () => 'https://cloud.example.test/api/sessions/session-1/events',
+    subscribeWorkspaceEvents: () => ({ close() {} }),
+    subscribeSessionEvents: () => ({ close() {} }),
+  }
+}
+
+test('cloud workspace adapter maps cloud records to desktop session contracts', async () => {
+  const adapter = new CloudWorkspaceAdapter({
+    connection: {
+      id: 'cloud:test',
+      baseUrl: 'https://cloud.example.test',
+      label: 'Test Cloud',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+      lastSyncedAt: null,
+    },
+    transport: transport(),
+    cache: null,
+  })
+
+  const policy = await adapter.policy()
+  assert.equal(policy.localFiles, 'disabled')
+  assert.deepEqual(policy.allowedAgents, ['data-analyst'])
+
+  const sessions = await adapter.listSessions()
+  assert.equal(sessions[0]?.id, 'session-1')
+  assert.equal(sessions[0]?.directory, null)
+
+  const created = await adapter.createSession()
+  assert.equal(created.id, 'session-2')
+
+  const view = await adapter.getSessionView('session-1')
+  assert.equal(view.messages.length, 2)
+  assert.equal(view.messages[0]?.content, 'Hello')
+  assert.equal(view.revision, 7)
+  assert.equal(view.toolCalls[0]?.name, 'read')
+  assert.equal(view.pendingApprovals[0]?.id, 'permission-1')
+  assert.equal(view.pendingQuestions[0]?.id, 'question-1')
+  assert.equal(view.artifacts?.[0]?.cloudArtifactId, 'artifact-1')
+  assert.equal(view.todos[0]?.content, 'Ship sync')
+  assert.equal(view.sessionCost, 0.42)
+  assert.equal(view.sessionTokens.cacheRead, 2)
+  assert.equal(view.isGenerating, false)
+  assert.equal(view.isAwaitingPermission, true)
+  assert.equal(view.isAwaitingQuestion, true)
+
+  assert.equal((await adapter.listWorkflows()).workflows[0]?.id, 'workflow-1')
+  assert.equal((await adapter.getWorkflow('workflow-1'))?.id, 'workflow-1')
+  assert.equal((await adapter.runWorkflow('workflow-1'))?.id, 'run-1')
+  assert.equal((await adapter.pauseWorkflow('workflow-1'))?.status, 'paused')
+  assert.equal((await adapter.resumeWorkflow('workflow-1'))?.status, 'active')
+  assert.equal((await adapter.archiveWorkflow('workflow-1'))?.status, 'archived')
+
+  assert.equal((await adapter.searchThreads({ tagIds: ['tag-1'] })).threads[0]?.sessionId, 'session-1')
+  assert.equal((await adapter.threadFacets()).tags[0]?.value, 'tag-1')
+  assert.equal((await adapter.listThreadTags())[0]?.id, 'tag-1')
+  assert.equal((await adapter.createThreadTag({ name: 'New' })).name, 'New')
+  assert.equal((await adapter.updateThreadTag('tag-1', { name: 'Renamed' }))?.name, 'Renamed')
+  assert.equal(await adapter.applyThreadTags(['session-1'], ['tag-1']), true)
+  assert.equal(await adapter.removeThreadTags(['session-1'], ['tag-1']), true)
+  assert.equal(await adapter.deleteThreadTag('tag-1'), true)
+  assert.equal((await adapter.listThreadSmartFilters())[0]?.id, 'filter-1')
+  assert.equal((await adapter.createThreadSmartFilter({ name: 'New filter', query: {} })).name, 'New filter')
+  assert.equal((await adapter.updateThreadSmartFilter('filter-1', { name: 'Updated filter', query: {} }))?.name, 'Updated filter')
+  assert.equal(await adapter.deleteThreadSmartFilter('filter-1'), true)
+  assert.equal((await adapter.listArtifacts('session-1'))[0]?.cloudArtifactId, 'artifact-1')
+  assert.equal((await adapter.uploadArtifact({
+    sessionId: 'session-1',
+    filename: 'upload.txt',
+    contentType: 'text/plain',
+    dataBase64: Buffer.from('hello').toString('base64'),
+  })).cloudArtifactId, 'artifact-2')
+  assert.equal((await adapter.readArtifactAttachment('session-1', 'cloud-artifact://artifact-1/result.txt')).filename, 'result.txt')
+  assert.equal((await adapter.listCapabilityTools())[0]?.id, 'read')
+  assert.equal((await adapter.getCapabilityTool('read'))?.name, 'Read')
+  assert.equal((await adapter.listCapabilitySkills())[0]?.name, 'analysis')
+  assert.equal((await adapter.getCapabilitySkillBundle('analysis'))?.name, 'analysis')
+  assert.equal(await adapter.readCapabilitySkillBundleFile('analysis', 'examples/report.md'), 'report example')
+  assert.equal((await adapter.listSettings())[0]?.key, 'portable-settings')
+  assert.equal((await adapter.getSetting('portable-settings'))?.value.selectedProviderId, 'anthropic')
+  assert.equal((await adapter.setSetting('portable-settings', { selectedProviderId: 'openai' })).value.selectedProviderId, 'openai')
+})
+
+test('cloud workspace adapter blocks local attachments in cloud prompts', async () => {
+  const adapter = new CloudWorkspaceAdapter({
+    connection: {
+      id: 'cloud:test',
+      baseUrl: 'https://cloud.example.test',
+      label: 'Test Cloud',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+      lastSyncedAt: null,
+    },
+    transport: transport(),
+    cache: null,
+  })
+
+  await assert.rejects(
+    () => adapter.promptSession('session-1', {
+      text: 'hello',
+      attachments: [{ mime: 'text/plain', url: 'file:///tmp/local.txt' }],
+    }),
+    /local attachments/,
+  )
+})
+
+test('cloud workspace adapter falls back to read-only cached state when transport is unavailable', async () => {
+  const cache = new FileCloudWorkspaceCache({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-adapter-cache-')), 'cloud-workspace-cache.json'),
+    mode: 'full',
+    secretStorage: {
+      mode: 'plaintext',
+      encryptString: (plaintext) => Buffer.from(plaintext, 'utf-8'),
+      decryptString: (encrypted) => encrypted.toString('utf-8'),
+    },
+  })
+  const connection = {
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Test Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }
+  const online = new CloudWorkspaceAdapter({
+    connection,
+    transport: transport(),
+    cache,
+  })
+  await online.listSessions()
+  await online.getSessionView('session-1')
+  await online.listWorkflows()
+  await online.listArtifacts('session-1')
+  await online.listSettings()
+
+  const offline = new CloudWorkspaceAdapter({
+    connection,
+    transport: failingTransport(),
+    cache,
+  })
+
+  assert.equal((await offline.listSessions())[0]?.id, 'session-1')
+  assert.equal((await offline.getSessionInfo('session-1'))?.title, 'Cloud session')
+  assert.equal((await offline.getSessionView('session-1')).messages[0]?.content, 'Hello')
+  assert.equal((await offline.listWorkflows()).workflows[0]?.id, 'workflow-1')
+  assert.equal((await offline.listArtifacts('session-1'))[0]?.cloudArtifactId, 'artifact-1')
+  assert.equal((await offline.listSettings())[0]?.key, 'portable-settings')
+  await assert.rejects(
+    () => offline.promptSession('session-1', { text: 'mutate while offline' }),
+    /offline/,
+  )
+})
+
+test('cloud workspace adapter isolates cached state by connection tenant user and profile', async () => {
+  const cache = new FileCloudWorkspaceCache({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-adapter-cache-isolation-')), 'cloud-workspace-cache.json'),
+    mode: 'full',
+    secretStorage: {
+      mode: 'plaintext',
+      encryptString: (plaintext) => Buffer.from(plaintext, 'utf-8'),
+      decryptString: (encrypted) => encrypted.toString('utf-8'),
+    },
+  })
+  const baseConnection = {
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Test Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }
+  const tenantA = {
+    ...baseConnection,
+    tenantId: 'tenant-a',
+    userId: 'user-a',
+    profileName: 'full',
+  }
+  const tenantB = {
+    ...baseConnection,
+    tenantId: 'tenant-b',
+    userId: 'user-b',
+    profileName: 'full',
+  }
+  const online = new CloudWorkspaceAdapter({
+    connection: tenantA,
+    transport: transport(),
+    cache,
+  })
+
+  await online.listSessions()
+  await online.getSessionView('session-1')
+
+  const offlineOtherTenant = new CloudWorkspaceAdapter({
+    connection: tenantB,
+    transport: failingTransport(),
+    cache,
+  })
+
+  assert.notEqual(cloudWorkspaceCacheKey(tenantA), cloudWorkspaceCacheKey(tenantB))
+  assert.equal(cache.listSessions(cloudWorkspaceCacheKey(tenantA))?.[0]?.id, 'session-1')
+  assert.equal(cache.listSessions(cloudWorkspaceCacheKey(tenantB)), null)
+  await assert.rejects(
+    () => offlineOtherTenant.listSessions(),
+    /offline/,
+  )
+})
+
+test('cloud workspace adapter ignores cached session cursors until caller provides a hydrated stream cursor', async () => {
+  const cache = new FileCloudWorkspaceCache({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-adapter-cursor-')), 'cloud-workspace-cache.json'),
+    mode: 'metadata-only',
+    secretStorage: {
+      mode: 'plaintext',
+      encryptString: (plaintext) => Buffer.from(plaintext, 'utf-8'),
+      decryptString: (encrypted) => encrypted.toString('utf-8'),
+    },
+  })
+  const connection = {
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Test Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }
+  const cacheKey = cloudWorkspaceCacheKey(connection)
+  cache.setEventCursor(cacheKey, 'session:session-1', 41)
+  let observedAfterSequence: number | undefined
+  const adapter = new CloudWorkspaceAdapter({
+    connection,
+    cache,
+    transport: {
+      ...transport(),
+      subscribeSessionEvents: (_sessionId, input) => {
+        observedAfterSequence = input.afterSequence
+        input.onEvent({
+          eventId: 'event-42',
+          sequence: 42,
+          sessionId: 'session-1',
+          type: 'assistant.message',
+          payload: { content: 'hello' },
+        })
+        return { close() {} }
+      },
+    },
+  })
+
+  adapter.subscribeSessionEvents('session-1', {
+    onEvent: () => {},
+  })
+
+  assert.equal(observedAfterSequence, undefined)
+  assert.equal(cache.getEventCursor(cacheKey, 'session:session-1'), 42)
+})
+
+test('cloud workspace adapter resumes workspace event streams from cached cursors', async () => {
+  const cache = new FileCloudWorkspaceCache({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-adapter-workspace-cursor-')), 'cloud-workspace-cache.json'),
+    mode: 'metadata-only',
+    secretStorage: {
+      mode: 'plaintext',
+      encryptString: (plaintext) => Buffer.from(plaintext, 'utf-8'),
+      decryptString: (encrypted) => encrypted.toString('utf-8'),
+    },
+  })
+  const connection = {
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Test Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }
+  const cacheKey = cloudWorkspaceCacheKey(connection)
+  cache.setEventCursor(cacheKey, 'workspace', 100)
+  let observedAfterSequence: number | undefined
+  const adapter = new CloudWorkspaceAdapter({
+    connection,
+    cache,
+    transport: {
+      ...transport(),
+      subscribeWorkspaceEvents: (input) => {
+        observedAfterSequence = input.afterSequence
+        input.onEvent({
+          eventId: 'event-101',
+          sequence: 101,
+          sessionId: 'session-1',
+          type: 'session.status',
+          payload: { statusType: 'running' },
+        })
+        return { close() {} }
+      },
+    },
+  })
+
+  adapter.subscribeWorkspaceEvents({
+    onEvent: () => {},
+  })
+
+  assert.equal(observedAfterSequence, 100)
+  assert.equal(cache.getEventCursor(cacheKey, 'workspace'), 101)
+})
+
+test('cloud workspace adapter refreshes snapshots and resets cursor on workspace retention gap', async () => {
+  const cache = new FileCloudWorkspaceCache({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-adapter-snapshot-required-')), 'cloud-workspace-cache.json'),
+    mode: 'full',
+    secretStorage: {
+      mode: 'plaintext',
+      encryptString: (plaintext) => Buffer.from(plaintext, 'utf-8'),
+      decryptString: (encrypted) => encrypted.toString('utf-8'),
+    },
+  })
+  const connection = {
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Test Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }
+  const base = transport()
+  const cacheKey = cloudWorkspaceCacheKey(connection)
+  cache.setEventCursor(cacheKey, 'workspace', 100)
+  let observedAfterSequence: number | undefined
+  let listSessionsCount = 0
+  let getSessionCount = 0
+  let listWorkflowsCount = 0
+  let listSettingsCount = 0
+  let listArtifactsCount = 0
+  const delivered = new Promise<void>((resolve, reject) => {
+    const adapter = new CloudWorkspaceAdapter({
+      connection,
+      cache,
+      transport: {
+        ...base,
+        listSessions: async () => {
+          listSessionsCount += 1
+          return base.listSessions()
+        },
+        getSession: async (sessionId) => {
+          getSessionCount += 1
+          return base.getSession(sessionId)
+        },
+        listWorkflows: async () => {
+          listWorkflowsCount += 1
+          return base.listWorkflows?.() as ReturnType<NonNullable<CloudTransportAdapter['listWorkflows']>>
+        },
+        listSettings: async () => {
+          listSettingsCount += 1
+          return base.listSettings?.() as ReturnType<NonNullable<CloudTransportAdapter['listSettings']>>
+        },
+        listArtifacts: async (sessionId) => {
+          listArtifactsCount += 1
+          return base.listArtifacts?.(sessionId) as ReturnType<NonNullable<CloudTransportAdapter['listArtifacts']>>
+        },
+        subscribeWorkspaceEvents: (input) => {
+          observedAfterSequence = input.afterSequence
+          input.onEvent({
+            eventId: 'snapshot-required:100',
+            sequence: 100,
+            type: 'snapshot.required',
+            payload: {
+              reason: 'event_retention_gap',
+              afterSequence: 100,
+            },
+          })
+          return { close() {} }
+        },
+      },
+    })
+
+    adapter.subscribeWorkspaceEvents({
+      onEvent: (event) => {
+        try {
+          assert.equal(event.type, 'snapshot.required')
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      },
+      onError: reject,
+    })
+  })
+
+  await delivered
+
+  assert.equal(observedAfterSequence, 100)
+  assert.equal(listSessionsCount, 1)
+  assert.equal(getSessionCount, 1)
+  assert.equal(listArtifactsCount, 1)
+  assert.equal(listWorkflowsCount, 1)
+  assert.equal(listSettingsCount, 1)
+  assert.equal(cache.getEventCursor(cacheKey, 'workspace'), 0)
+  assert.equal(cache.listSessions(cacheKey)?.[0]?.id, 'session-1')
+  assert.equal(cache.getSessionView(cacheKey, 'session-1')?.messages[0]?.content, 'Hello')
+  assert.equal(cache.getWorkflowList(cacheKey)?.workflows[0]?.id, 'workflow-1')
+  assert.equal(cache.listSettings(cacheKey)?.[0]?.key, 'portable-settings')
+  assert.equal(cache.listArtifacts(cacheKey, 'session-1')?.[0]?.cloudArtifactId, 'artifact-1')
+})

--- a/tests/cloud-workspace-auth.test.ts
+++ b/tests/cloud-workspace-auth.test.ts
@@ -1,0 +1,197 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CloudWorkspaceDesktopAuthenticator,
+  type CloudWorkspaceAuthFetch,
+} from '../apps/desktop/src/main/cloud-workspace-auth.ts'
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body
+    },
+    async text() {
+      return JSON.stringify(body)
+    },
+  }
+}
+
+test('cloud workspace desktop authenticator performs OIDC PKCE loopback login', async () => {
+  const calls: string[] = []
+  let tokenBody: URLSearchParams | null = null
+  const fetcher: CloudWorkspaceAuthFetch = async (url, init) => {
+    calls.push(url)
+    if (url === 'https://cloud.example.test/auth/desktop/config') {
+      return jsonResponse({
+        mode: 'oidc',
+        issuerUrl: 'https://issuer.example.test',
+        clientId: 'open-cowork-desktop',
+        scope: 'openid email profile offline_access',
+      })
+    }
+    if (url === 'https://issuer.example.test/.well-known/openid-configuration') {
+      return jsonResponse({
+        authorization_endpoint: 'https://issuer.example.test/authorize',
+        token_endpoint: 'https://issuer.example.test/token',
+      })
+    }
+    if (url === 'https://issuer.example.test/token') {
+      tokenBody = new URLSearchParams(init?.body || '')
+      return jsonResponse({
+        access_token: 'access-token-1',
+        refresh_token: 'refresh-token-1',
+        expires_in: 3600,
+      })
+    }
+    if (url === 'https://cloud.example.test/auth/me') {
+      assert.equal(init?.headers?.authorization, 'Bearer access-token-1')
+      return jsonResponse({
+        principal: {
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          email: 'user@example.test',
+        },
+        profileName: 'default',
+      })
+    }
+    throw new Error(`Unexpected URL ${url}`)
+  }
+  const authenticator = new CloudWorkspaceDesktopAuthenticator({
+    fetch: fetcher,
+    openExternal: async (authUrl) => {
+      const parsed = new URL(authUrl)
+      assert.equal(parsed.origin + parsed.pathname, 'https://issuer.example.test/authorize')
+      assert.equal(parsed.searchParams.get('response_type'), 'code')
+      assert.equal(parsed.searchParams.get('client_id'), 'open-cowork-desktop')
+      assert.equal(parsed.searchParams.get('code_challenge_method'), 'S256')
+      assert.ok(parsed.searchParams.get('code_challenge'))
+      const redirectUri = parsed.searchParams.get('redirect_uri')
+      const state = parsed.searchParams.get('state')
+      assert.ok(redirectUri)
+      assert.ok(state)
+      await fetch(`${redirectUri}?code=code-1&state=${state}`)
+    },
+    callbackTimeoutMs: 2000,
+  })
+
+  const result = await authenticator.login({
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  })
+
+  assert.equal(result.accessToken, 'access-token-1')
+  assert.equal(result.refreshToken, 'refresh-token-1')
+  assert.equal(result.tenantId, 'tenant-1')
+  assert.equal(result.userId, 'user-1')
+  assert.equal(result.profileName, 'default')
+  assert.equal(tokenBody?.get('grant_type'), 'authorization_code')
+  assert.equal(tokenBody?.get('code'), 'code-1')
+  assert.equal(tokenBody?.get('client_id'), 'open-cowork-desktop')
+  assert.ok(tokenBody?.get('redirect_uri')?.startsWith('http://127.0.0.1:'))
+  assert.ok(tokenBody?.get('code_verifier'))
+  assert.deepEqual(calls, [
+    'https://cloud.example.test/auth/desktop/config',
+    'https://issuer.example.test/.well-known/openid-configuration',
+    'https://issuer.example.test/token',
+    'https://cloud.example.test/auth/me',
+  ])
+})
+
+test('cloud workspace desktop authenticator rejects invalid callback state', async () => {
+  const fetcher: CloudWorkspaceAuthFetch = async (url) => {
+    if (url === 'https://cloud.example.test/auth/desktop/config') {
+      return jsonResponse({
+        mode: 'oidc',
+        issuerUrl: 'https://issuer.example.test',
+        clientId: 'open-cowork-desktop',
+      })
+    }
+    if (url === 'https://issuer.example.test/.well-known/openid-configuration') {
+      return jsonResponse({
+        authorization_endpoint: 'https://issuer.example.test/authorize',
+        token_endpoint: 'https://issuer.example.test/token',
+      })
+    }
+    throw new Error(`Unexpected URL ${url}`)
+  }
+  const authenticator = new CloudWorkspaceDesktopAuthenticator({
+    fetch: fetcher,
+    openExternal: async (authUrl) => {
+      const redirectUri = new URL(authUrl).searchParams.get('redirect_uri')
+      assert.ok(redirectUri)
+      await fetch(`${redirectUri}?code=code-1&state=wrong-state`)
+    },
+    callbackTimeoutMs: 2000,
+  })
+
+  await assert.rejects(
+    () => authenticator.login({
+      id: 'cloud:test',
+      baseUrl: 'https://cloud.example.test',
+      label: 'Cloud',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+      lastSyncedAt: null,
+    }),
+    /state is invalid/,
+  )
+})
+
+test('cloud workspace desktop authenticator refreshes OIDC access tokens', async () => {
+  let tokenBody: URLSearchParams | null = null
+  const fetcher: CloudWorkspaceAuthFetch = async (url, init) => {
+    if (url === 'https://cloud.example.test/auth/desktop/config') {
+      return jsonResponse({
+        mode: 'oidc',
+        issuerUrl: 'https://issuer.example.test',
+        clientId: 'open-cowork-desktop',
+      })
+    }
+    if (url === 'https://issuer.example.test/.well-known/openid-configuration') {
+      return jsonResponse({
+        authorization_endpoint: 'https://issuer.example.test/authorize',
+        token_endpoint: 'https://issuer.example.test/token',
+      })
+    }
+    if (url === 'https://issuer.example.test/token') {
+      tokenBody = new URLSearchParams(init?.body || '')
+      return jsonResponse({
+        access_token: 'access-token-2',
+        expires_in: 3600,
+      })
+    }
+    if (url === 'https://cloud.example.test/auth/me') {
+      assert.equal(init?.headers?.authorization, 'Bearer access-token-2')
+      return jsonResponse({
+        principal: {
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          email: 'user@example.test',
+        },
+      })
+    }
+    throw new Error(`Unexpected URL ${url}`)
+  }
+  const authenticator = new CloudWorkspaceDesktopAuthenticator({ fetch: fetcher })
+
+  const result = await authenticator.refresh({
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }, 'refresh-token-1')
+
+  assert.equal(result.accessToken, 'access-token-2')
+  assert.equal(result.refreshToken, 'refresh-token-1')
+  assert.equal(tokenBody?.get('grant_type'), 'refresh_token')
+  assert.equal(tokenBody?.get('refresh_token'), 'refresh-token-1')
+  assert.equal(tokenBody?.get('client_id'), 'open-cowork-desktop')
+})

--- a/tests/cloud-workspace-cache.test.ts
+++ b/tests/cloud-workspace-cache.test.ts
@@ -1,0 +1,237 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { FileCloudWorkspaceCache } from '../apps/desktop/src/main/cloud-workspace-cache.ts'
+import type { SessionView } from '@open-cowork/shared'
+
+function cachePath() {
+  return join(mkdtempSync(join(tmpdir(), 'open-cowork-cloud-cache-')), 'cloud-workspace-cache.json')
+}
+
+function encryptedStorage() {
+  return {
+    mode: 'encrypted' as const,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${Buffer.from(plaintext, 'utf-8').toString('base64')}`, 'utf-8'),
+    decryptString: (encrypted: Buffer) => {
+      const raw = encrypted.toString('utf-8')
+      assert.ok(raw.startsWith('encrypted:'))
+      return Buffer.from(raw.slice('encrypted:'.length), 'base64').toString('utf-8')
+    },
+  }
+}
+
+function emptyView(message = 'hello'): SessionView {
+  return {
+    messages: [{
+      id: 'message-1',
+      role: 'user',
+      content: message,
+      order: 1,
+    }],
+    toolCalls: [],
+    taskRuns: [],
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision: 0,
+    lastEventAt: 0,
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+  }
+}
+
+test('cloud workspace full cache encrypts cached session views', () => {
+  const path = cachePath()
+  const cache = new FileCloudWorkspaceCache({
+    path,
+    mode: 'full',
+    secretStorage: encryptedStorage(),
+  })
+
+  cache.upsertSessionList('cloud:test', [{
+    id: 'session-1',
+    title: 'Cloud thread',
+    directory: null,
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }])
+  cache.upsertSessionView('cloud:test', 'session-1', emptyView('secret message'))
+
+  assert.equal(cache.listSessions('cloud:test')?.[0]?.id, 'session-1')
+  assert.equal(cache.getSessionView('cloud:test', 'session-1')?.messages[0]?.content, 'secret message')
+  const stored = readFileSync(path, 'utf-8')
+  assert.equal(stored.includes('secret message'), false)
+})
+
+test('cloud workspace metadata-only cache strips session views', () => {
+  const path = cachePath()
+  const cache = new FileCloudWorkspaceCache({
+    path,
+    mode: 'metadata-only',
+    secretStorage: encryptedStorage(),
+  })
+
+  cache.upsertSessionList('cloud:test', [{
+    id: 'session-1',
+    title: 'Cloud thread',
+    directory: null,
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }])
+  cache.upsertSessionView('cloud:test', 'session-1', emptyView('should not persist'))
+
+  assert.equal(cache.listSessions('cloud:test')?.[0]?.title, 'Cloud thread')
+  assert.equal(cache.getSessionView('cloud:test', 'session-1'), null)
+  const stored = readFileSync(path, 'utf-8')
+  assert.equal(stored.includes('should not persist'), false)
+})
+
+test('cloud workspace cache persists portable product metadata without message bodies', () => {
+  const path = cachePath()
+  const cache = new FileCloudWorkspaceCache({
+    path,
+    mode: 'metadata-only',
+    secretStorage: encryptedStorage(),
+  })
+
+  cache.setEventCursor('cloud:test', 'session:session-1', 4)
+  cache.setEventCursor('cloud:test', 'session:session-1', 3)
+  cache.upsertWorkflowList('cloud:test', {
+    workflows: [{
+      id: 'workflow-1',
+      title: 'Daily report',
+      instructions: 'Summarize',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      status: 'active',
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [],
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+      nextRunAt: null,
+      lastRunAt: null,
+      latestRunId: null,
+      latestRunStatus: null,
+      latestRunSessionId: null,
+      latestRunSummary: null,
+      webhookUrl: null,
+    }],
+    runs: [],
+  })
+  cache.upsertSettings('cloud:test', [{
+    key: 'custom-agents',
+    value: { items: [{ name: 'Data Analyst' }] },
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }])
+  cache.upsertArtifactList('cloud:test', 'session-1', [{
+    id: 'artifact-1',
+    toolId: 'cloud-artifact',
+    toolName: 'cloud.artifact',
+    filePath: 'cloud-artifact://artifact-1/result.txt',
+    filename: 'result.txt',
+    order: 1,
+    source: 'cloud',
+    cloudArtifactId: 'artifact-1',
+    mime: 'text/plain',
+  }])
+  cache.upsertSessionView('cloud:test', 'session-1', emptyView('do not store this body'))
+
+  assert.equal(cache.getEventCursor('cloud:test', 'session:session-1'), 4)
+  assert.equal(cache.getWorkflowList('cloud:test')?.workflows[0]?.id, 'workflow-1')
+  assert.equal(cache.getSetting('cloud:test', 'custom-agents')?.value.items instanceof Array, true)
+  assert.equal(cache.listArtifacts('cloud:test', 'session-1')?.[0]?.cloudArtifactId, 'artifact-1')
+  assert.equal(cache.getSessionView('cloud:test', 'session-1'), null)
+
+  const stored = readFileSync(path, 'utf-8')
+  assert.equal(stored.includes('do not store this body'), false)
+})
+
+test('cloud workspace disabled cache does not persist state', () => {
+  const path = cachePath()
+  const cache = new FileCloudWorkspaceCache({
+    path,
+    mode: 'disabled',
+    secretStorage: encryptedStorage(),
+  })
+
+  cache.upsertSessionList('cloud:test', [{
+    id: 'session-1',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }])
+
+  assert.equal(cache.listSessions('cloud:test'), null)
+})
+
+test('cloud workspace full cache degrades when encrypted storage is unavailable', () => {
+  const unavailableStorage = {
+    mode: 'unavailable' as const,
+    encryptString: (plaintext: string) => Buffer.from(plaintext, 'utf-8'),
+    decryptString: (encrypted: Buffer) => encrypted.toString('utf-8'),
+  }
+  const metadataOnly = new FileCloudWorkspaceCache({
+    path: cachePath(),
+    mode: 'full',
+    encryptionFallback: 'metadata-only',
+    secretStorage: unavailableStorage,
+  })
+  metadataOnly.upsertSessionView('cloud:test', 'session-1', emptyView('body'))
+  assert.equal(metadataOnly.mode, 'metadata-only')
+  assert.equal(metadataOnly.getSessionView('cloud:test', 'session-1'), null)
+
+  const disabled = new FileCloudWorkspaceCache({
+    path: cachePath(),
+    mode: 'full',
+    encryptionFallback: 'disabled',
+    secretStorage: unavailableStorage,
+  })
+  disabled.upsertSessionList('cloud:test', [{
+    id: 'session-1',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }])
+  assert.equal(disabled.mode, 'disabled')
+  assert.equal(disabled.listSessions('cloud:test'), null)
+
+  assert.throws(
+    () => new FileCloudWorkspaceCache({
+      path: cachePath(),
+      mode: 'full',
+      encryptionFallback: 'fail-startup',
+      secretStorage: unavailableStorage,
+    }),
+    /Secure storage unavailable/,
+  )
+})
+
+test('cloud workspace cache can reset a cursor after replay snapshot recovery', () => {
+  const path = cachePath()
+  const cache = new FileCloudWorkspaceCache({
+    path,
+    mode: 'metadata-only',
+    secretStorage: encryptedStorage(),
+  })
+
+  cache.setEventCursor('cloud:test', 'workspace', 100)
+  cache.setEventCursor('cloud:test', 'workspace', 90)
+  assert.equal(cache.getEventCursor('cloud:test', 'workspace'), 100)
+
+  cache.resetEventCursor('cloud:test', 'workspace')
+  assert.equal(cache.getEventCursor('cloud:test', 'workspace'), 0)
+})

--- a/tests/cloud-workspace-credentials.test.ts
+++ b/tests/cloud-workspace-credentials.test.ts
@@ -1,0 +1,95 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { FileCloudWorkspaceCredentialStore } from '../apps/desktop/src/main/cloud-workspace-credentials.ts'
+
+function credentialPath() {
+  return join(mkdtempSync(join(tmpdir(), 'open-cowork-cloud-credentials-')), 'cloud-workspace-credentials.json')
+}
+
+function encryptedStorage() {
+  return {
+    mode: 'encrypted' as const,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${Buffer.from(plaintext, 'utf-8').toString('base64')}`, 'utf-8'),
+    decryptString: (encrypted: Buffer) => {
+      const raw = encrypted.toString('utf-8')
+      assert.ok(raw.startsWith('encrypted:'))
+      return Buffer.from(raw.slice('encrypted:'.length), 'base64').toString('utf-8')
+    },
+  }
+}
+
+test('cloud workspace credential store encrypts tokens and exposes metadata separately', () => {
+  const path = credentialPath()
+  const store = new FileCloudWorkspaceCredentialStore({ path, secretStorage: encryptedStorage() })
+  const saved = store.save({
+    workspaceId: 'cloud:test',
+    accessToken: 'access-token-secret',
+    refreshToken: 'refresh-token-secret',
+    expiresAt: '2026-05-27T12:00:00.000Z',
+  }, new Date('2026-05-27T10:00:00.000Z'))
+
+  assert.equal(saved.workspaceId, 'cloud:test')
+  assert.equal(store.get('cloud:test')?.accessToken, 'access-token-secret')
+  assert.deepEqual(store.listMetadata(), [{
+    workspaceId: 'cloud:test',
+    hasAccessToken: true,
+    hasRefreshToken: true,
+    expiresAt: '2026-05-27T12:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }])
+
+  const stored = readFileSync(path, 'utf-8')
+  assert.equal(stored.includes('access-token-secret'), false)
+  assert.equal(stored.includes('refresh-token-secret'), false)
+})
+
+test('cloud workspace credential store returns only non-expired access tokens', () => {
+  const path = credentialPath()
+  const store = new FileCloudWorkspaceCredentialStore({ path, secretStorage: encryptedStorage() })
+  store.save({
+    workspaceId: 'cloud:test',
+    accessToken: 'access-token-secret',
+    expiresAt: '2026-05-27T12:00:00.000Z',
+  }, new Date('2026-05-27T10:00:00.000Z'))
+
+  assert.equal(store.getUsableAccessToken('cloud:test', new Date('2026-05-27T11:59:00.000Z')), 'access-token-secret')
+  assert.equal(store.getUsableAccessToken('cloud:test', new Date('2026-05-27T11:59:40.000Z')), null)
+})
+
+test('cloud workspace credential store removes workspace credentials', () => {
+  const path = credentialPath()
+  const store = new FileCloudWorkspaceCredentialStore({ path, secretStorage: encryptedStorage() })
+  store.save({
+    workspaceId: 'cloud:test',
+    accessToken: 'access-token-secret',
+    expiresAt: '2026-05-27T12:00:00.000Z',
+  }, new Date('2026-05-27T10:00:00.000Z'))
+
+  assert.equal(store.remove('cloud:test'), true)
+  assert.equal(store.get('cloud:test'), null)
+  assert.equal(store.remove('cloud:test'), false)
+})
+
+test('cloud workspace credential store fails closed when secure storage is unavailable', () => {
+  const path = credentialPath()
+  const store = new FileCloudWorkspaceCredentialStore({
+    path,
+    secretStorage: {
+      mode: 'unavailable',
+      encryptString: () => Buffer.from(''),
+      decryptString: () => '',
+    },
+  })
+
+  assert.throws(
+    () => store.save({
+      workspaceId: 'cloud:test',
+      accessToken: 'access-token-secret',
+      expiresAt: '2026-05-27T12:00:00.000Z',
+    }),
+    /Secure storage unavailable/,
+  )
+})

--- a/tests/cloud-workspace-registry.test.ts
+++ b/tests/cloud-workspace-registry.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  FileCloudWorkspaceRegistry,
+  cloudWorkspaceIdForBaseUrl,
+  normalizeCloudWorkspaceBaseUrl,
+} from '../apps/desktop/src/main/cloud-workspace-registry.ts'
+
+function registryPath() {
+  return join(mkdtempSync(join(tmpdir(), 'open-cowork-cloud-workspaces-')), 'cloud-workspaces.json')
+}
+
+test('cloud workspace registry normalizes and persists non-secret connections', () => {
+  const path = registryPath()
+  const registry = new FileCloudWorkspaceRegistry(path)
+  const createdAt = new Date('2026-05-27T10:00:00.000Z')
+  const record = registry.upsert({
+    baseUrl: 'https://cloud.example.test/api/?token=secret#fragment',
+    label: ' Acme Cloud ',
+  }, createdAt)
+
+  assert.equal(record.id, cloudWorkspaceIdForBaseUrl('https://cloud.example.test/api'))
+  assert.equal(record.baseUrl, 'https://cloud.example.test/api')
+  assert.equal(record.label, 'Acme Cloud')
+  assert.equal(record.lastSyncedAt, null)
+  assert.equal(record.createdAt, createdAt.toISOString())
+
+  const reloaded = new FileCloudWorkspaceRegistry(path).list()
+  assert.deepEqual(reloaded, [record])
+  const stored = readFileSync(path, 'utf-8')
+  assert.equal(stored.includes('token=secret'), false)
+  assert.equal(stored.includes('refreshToken'), false)
+})
+
+test('cloud workspace registry updates existing connections without changing id', () => {
+  const path = registryPath()
+  const registry = new FileCloudWorkspaceRegistry(path)
+  const first = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'First' }, new Date('2026-05-27T10:00:00.000Z'))
+  const second = registry.upsert({ baseUrl: 'https://cloud.example.test/', label: 'Second' }, new Date('2026-05-27T11:00:00.000Z'))
+
+  assert.equal(second.id, first.id)
+  assert.equal(second.label, 'Second')
+  assert.equal(second.createdAt, first.createdAt)
+  assert.equal(second.updatedAt, '2026-05-27T11:00:00.000Z')
+  assert.equal(registry.list().length, 1)
+})
+
+test('cloud workspace registry tracks sync timestamps and removes records', () => {
+  const path = registryPath()
+  const registry = new FileCloudWorkspaceRegistry(path)
+  const record = registry.upsert({ baseUrl: 'https://cloud.example.test' }, new Date('2026-05-27T10:00:00.000Z'))
+
+  const touched = registry.touchSync(record.id, '2026-05-27T12:00:00.000Z', new Date('2026-05-27T12:00:01.000Z'))
+  assert.equal(touched?.lastSyncedAt, '2026-05-27T12:00:00.000Z')
+  assert.equal(touched?.updatedAt, '2026-05-27T12:00:01.000Z')
+  assert.equal(registry.remove(record.id), true)
+  assert.deepEqual(registry.list(), [])
+  assert.equal(registry.remove(record.id), false)
+})
+
+test('cloud workspace registry rejects unsupported URL schemes', () => {
+  assert.throws(() => normalizeCloudWorkspaceBaseUrl('file:///tmp/open-cowork'), /https/)
+})
+
+test('cloud workspace registry rejects cleartext non-loopback cloud URLs', () => {
+  assert.throws(
+    () => normalizeCloudWorkspaceBaseUrl('http://cloud.example.test'),
+    /https, except for localhost/,
+  )
+  assert.equal(
+    normalizeCloudWorkspaceBaseUrl('http://localhost:8787/api?token=secret#frag'),
+    'http://localhost:8787/api',
+  )
+  assert.equal(
+    normalizeCloudWorkspaceBaseUrl('http://127.0.0.1:8787'),
+    'http://127.0.0.1:8787',
+  )
+})

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -220,6 +220,26 @@ test('cloud deployment config rejects machine runtime config and unknown cloud k
   assert.throws(() => validateResolvedConfig(config, 'cloud config'), /cloud\.runtime/)
 })
 
+test('cloud desktop managed org config validates and rejects unsafe values', () => {
+  const config = cloneConfig()
+  config.cloudDesktop = {
+    enabled: true,
+    allowUserAddedConnections: false,
+    requireManagedOrg: true,
+    cacheMode: 'metadata-only',
+    cacheEncryptionFallback: 'disabled',
+    preconfiguredConnections: [{
+      baseUrl: 'https://cloud.example.test',
+      label: 'Acme Cloud',
+    }],
+  }
+
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'cloud desktop config'))
+
+  config.cloudDesktop.preconfiguredConnections[0].baseUrl = 'http://cloud.example.test'
+  assert.throws(() => validateResolvedConfig(config, 'cloud desktop config'), /cloudDesktop/)
+})
+
 test('downstream tool trace rules validate', () => {
   const config = cloneConfig()
   config.toolTrace = {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -20,6 +20,8 @@ import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-st
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { stopSessionStatusReconciliation } from '../apps/desktop/src/main/session-status-reconciler.ts'
 import { clearSessionRegistryCache, toSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
+import { createWorkspaceGateway } from '../apps/desktop/src/main/workspace-gateway.ts'
+import type { CloudWorkspaceSessionAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 
 function createBaseContext() {
   const handlers = new Map<string, (...args: any[]) => any>()
@@ -31,6 +33,7 @@ function createBaseContext() {
       },
       on() {},
     },
+    workspaceGateway: createWorkspaceGateway({ cloudRegistry: null, cloudCredentialStore: null }),
     getMainWindow: () => null,
     normalizeDirectory: () => '/tmp',
     ensureSessionRecord: () => null,
@@ -214,6 +217,140 @@ test('session:prompt rejects malformed argument tuples before runtime dispatch',
     /session id to be a string/,
   )
   assert.equal(clientRequested, false)
+})
+
+test('session handlers route cloud workspace calls through the workspace gateway', async () => {
+  const { context, handlers } = createBaseContext()
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => {
+      calls.push('list')
+      return [{
+        id: 'cloud-session-1',
+        title: 'Cloud thread',
+        directory: null,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }]
+    },
+    createSession: async () => {
+      calls.push('create')
+      return {
+        id: 'cloud-session-2',
+        title: 'New cloud thread',
+        directory: null,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }
+    },
+    getSessionInfo: async (sessionId) => {
+      calls.push(`get:${sessionId}`)
+      return {
+        id: sessionId,
+        title: 'Cloud thread',
+        directory: null,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }
+    },
+    getSessionView: async (sessionId) => {
+      calls.push(`activate:${sessionId}`)
+      return {
+        messages: [],
+        toolCalls: [],
+        taskRuns: [],
+        compactions: [],
+        pendingApprovals: [],
+        pendingQuestions: [],
+        errors: [],
+        todos: [],
+        executionPlan: [],
+        sessionCost: 0,
+        sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+        lastInputTokens: 0,
+        contextState: 'idle',
+        compactionCount: 0,
+        lastCompactedAt: null,
+        activeAgent: null,
+        lastItemWasTool: false,
+        revision: 0,
+        lastEventAt: 0,
+        isGenerating: false,
+        isAwaitingPermission: false,
+        isAwaitingQuestion: false,
+      }
+    },
+    promptSession: async (sessionId, input) => {
+      calls.push(`prompt:${sessionId}:${input.text}:${input.agent}`)
+    },
+    abortSession: async (sessionId) => {
+      calls.push(`abort:${sessionId}`)
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => ({
+        workspaceId: 'cloud:test',
+        accessToken: 'cloud-access-token',
+        refreshToken: null,
+        expiresAt: '2030-05-27T12:00:00.000Z',
+        tokenType: 'Bearer',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }),
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => ({
+        workspaceId: 'cloud:test',
+        accessToken: 'cloud-access-token',
+        refreshToken: null,
+        expiresAt: '2030-05-27T12:00:00.000Z',
+        tokenType: 'Bearer',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }),
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerSessionHandlers(context)
+
+  assert.equal((await handlers.get('session:list')?.({}, { workspaceId: 'cloud:test' }))?.[0]?.id, 'cloud-session-1')
+  assert.equal((await handlers.get('session:create')?.({}, undefined, { workspaceId: 'cloud:test' }))?.id, 'cloud-session-2')
+  await assert.rejects(
+    () => handlers.get('session:create')?.({}, '/Users/joe/project', { workspaceId: 'cloud:test' }),
+    /Local project directories/,
+  )
+  assert.equal((await handlers.get('session:get')?.({}, 'cloud-session-1', { workspaceId: 'cloud:test' }))?.id, 'cloud-session-1')
+  assert.equal((await handlers.get('session:activate')?.({}, 'cloud-session-1', { workspaceId: 'cloud:test' }))?.messages.length, 0)
+  await handlers.get('session:prompt')?.({}, 'cloud-session-1', 'hello', [], 'data-analyst', { workspaceId: 'cloud:test' })
+  await handlers.get('session:abort')?.({}, 'cloud-session-1', { workspaceId: 'cloud:test' })
+
+  assert.deepEqual(calls, [
+    'list',
+    'create',
+    'get:cloud-session-1',
+    'activate:cloud-session-1',
+    'prompt:cloud-session-1:hello:data-analyst',
+    'abort:cloud-session-1',
+  ])
 })
 
 test('session:prompt rejects too many attachments before runtime dispatch', async () => {
@@ -449,6 +586,101 @@ test('workflow mutation handlers reject malformed workflow ids before service ca
   await assert.rejects(
     () => handler({}, { id: 'workflow-1' }),
     /workflow id to be a string/,
+  )
+})
+
+test('workflow handlers route cloud workspace operations through the workspace gateway', async () => {
+  const { context, handlers } = createBaseContext()
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { workflows: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      throw new Error('not used')
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    listWorkflows: async () => {
+      calls.push('list')
+      return { workflows: [], runs: [] }
+    },
+    getWorkflow: async (workflowId) => {
+      calls.push(`get:${workflowId}`)
+      return null
+    },
+    runWorkflow: async (workflowId) => {
+      calls.push(`run:${workflowId}`)
+      return null
+    },
+    pauseWorkflow: async (workflowId) => {
+      calls.push(`pause:${workflowId}`)
+      return null
+    },
+    resumeWorkflow: async (workflowId) => {
+      calls.push(`resume:${workflowId}`)
+      return null
+    },
+    archiveWorkflow: async (workflowId) => {
+      calls.push(`archive:${workflowId}`)
+      return null
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerWorkflowHandlers(context)
+
+  await handlers.get('workflows:list')?.({}, { workspaceId: 'cloud:test' })
+  await handlers.get('workflows:get')?.({}, 'workflow-1', { workspaceId: 'cloud:test' })
+  await handlers.get('workflows:run-now')?.({}, 'workflow-1', { workspaceId: 'cloud:test' })
+  await handlers.get('workflows:pause')?.({}, 'workflow-1', { workspaceId: 'cloud:test' })
+  await handlers.get('workflows:resume')?.({}, 'workflow-1', { workspaceId: 'cloud:test' })
+  await handlers.get('workflows:archive')?.({}, 'workflow-1', { workspaceId: 'cloud:test' })
+
+  assert.deepEqual(calls, [
+    'list',
+    'get:workflow-1',
+    'run:workflow-1',
+    'pause:workflow-1',
+    'resume:workflow-1',
+    'archive:workflow-1',
+  ])
+
+  context.workspaceGateway.activate({}, 'cloud:test')
+  await assert.rejects(
+    () => handlers.get('workflows:start-draft')?.({}, undefined),
+    /Local workspace/,
   )
 })
 
@@ -971,6 +1203,97 @@ test('settings:set rejects unknown and malformed settings payloads before saving
   )
 })
 
+test('settings handlers sync only portable settings for cloud workspaces', async () => {
+  const { context, handlers } = createBaseContext()
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { settings: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      throw new Error('not used')
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    getSetting: async (key) => {
+      calls.push(`get:${key}`)
+      return {
+        key,
+        value: { selectedProviderId: 'anthropic', selectedModelId: 'claude-test' },
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }
+    },
+    setSetting: async (key, value) => {
+      calls.push(`set:${key}:${value.selectedProviderId}`)
+      return {
+        key,
+        value,
+        updatedAt: '2026-05-27T10:01:00.000Z',
+      }
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerAppHandlers(context)
+
+  const current = await handlers.get('settings:get')?.({}, { workspaceId: 'cloud:test' })
+  assert.equal(current.selectedProviderId, 'anthropic')
+  assert.deepEqual(current.providerCredentials, {})
+
+  await assert.rejects(
+    () => handlers.get('settings:set')?.({}, {
+      workspaceId: 'cloud:test',
+      providerCredentials: { openai: { apiKey: 'secret' } },
+    }),
+    /do not sync raw/,
+  )
+
+  const updated = await handlers.get('settings:set')?.({}, {
+    workspaceId: 'cloud:test',
+    selectedProviderId: 'openai',
+    selectedModelId: 'gpt-test',
+  })
+  assert.equal(updated.selectedProviderId, 'openai')
+  assert.deepEqual(updated.providerCredentials, {})
+
+  assert.deepEqual(calls, [
+    'get:portable-settings',
+    'get:portable-settings',
+    'set:portable-settings:openai',
+  ])
+})
+
 test('custom MCP IPC rejects malformed nested records before persistence', async () => {
   const { context, handlers } = createBaseContext()
 
@@ -1007,6 +1330,482 @@ test('thread object IPC validates query and tag payload shape before store acces
     () => createTag({}, { color: '#ffffff' }),
     /Tag name must be a string/,
   )
+})
+
+test('thread handlers route cloud workspace calls through the workspace gateway', async () => {
+  const { context, handlers } = createBaseContext()
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { threadIndex: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      throw new Error('not used')
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    searchThreads: async () => {
+      calls.push('search')
+      return { threads: [], nextCursor: null, totalEstimate: 0 }
+    },
+    threadFacets: async () => {
+      calls.push('facets')
+      return { projects: [], providers: [], models: [], agents: [], tools: [], mcps: [], statuses: [], tags: [] }
+    },
+    listThreadTags: async () => {
+      calls.push('tags:list')
+      return []
+    },
+    createThreadTag: async (input) => {
+      calls.push(`tags:create:${input.name}`)
+      return { id: 'tag-1', name: input.name, color: input.color || '#64748b', createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    updateThreadTag: async (tagId, input) => {
+      calls.push(`tags:update:${tagId}:${input.name}`)
+      return { id: tagId, name: input.name, color: input.color || '#64748b', createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    deleteThreadTag: async (tagId) => {
+      calls.push(`tags:delete:${tagId}`)
+      return true
+    },
+    applyThreadTags: async (sessionIds, tagIds) => {
+      calls.push(`tags:apply:${sessionIds.join(',')}:${tagIds.join(',')}`)
+      return true
+    },
+    removeThreadTags: async (sessionIds, tagIds) => {
+      calls.push(`tags:remove:${sessionIds.join(',')}:${tagIds.join(',')}`)
+      return true
+    },
+    listThreadSmartFilters: async () => {
+      calls.push('filters:list')
+      return []
+    },
+    createThreadSmartFilter: async (input) => {
+      calls.push(`filters:create:${input.name}`)
+      return { id: 'filter-1', name: input.name, query: input.query, createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    updateThreadSmartFilter: async (filterId, input) => {
+      calls.push(`filters:update:${filterId}:${input.name}`)
+      return { id: filterId, name: input.name, query: input.query, createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    deleteThreadSmartFilter: async (filterId) => {
+      calls.push(`filters:delete:${filterId}`)
+      return true
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerThreadHandlers(context)
+
+  await handlers.get('threads:search')?.({}, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:facets')?.({}, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:tags:list')?.({}, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:tags:create')?.({}, { name: 'Important' }, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:tags:update')?.({}, 'tag-1', { name: 'Renamed' }, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:tags:apply')?.({}, ['session-1'], ['tag-1'], { workspaceId: 'cloud:test' })
+  await handlers.get('threads:tags:remove')?.({}, ['session-1'], ['tag-1'], { workspaceId: 'cloud:test' })
+  await handlers.get('threads:tags:delete')?.({}, 'tag-1', { workspaceId: 'cloud:test' })
+  await handlers.get('threads:smart-filters:list')?.({}, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:smart-filters:create')?.({}, { name: 'Mine', query: {} }, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:smart-filters:update')?.({}, 'filter-1', { name: 'Updated', query: {} }, { workspaceId: 'cloud:test' })
+  await handlers.get('threads:smart-filters:delete')?.({}, 'filter-1', { workspaceId: 'cloud:test' })
+
+  assert.deepEqual(calls, [
+    'search',
+    'facets',
+    'tags:list',
+    'tags:create:Important',
+    'tags:update:tag-1:Renamed',
+    'tags:apply:session-1:tag-1',
+    'tags:remove:session-1:tag-1',
+    'tags:delete:tag-1',
+    'filters:list',
+    'filters:create:Mine',
+    'filters:update:filter-1:Updated',
+    'filters:delete:filter-1',
+  ])
+})
+
+test('artifact handlers route cloud workspace calls through the workspace gateway', async () => {
+  const { context, handlers } = createBaseContext()
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { artifacts: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      throw new Error('not used')
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    listArtifacts: async (sessionId) => {
+      calls.push(`list:${sessionId}`)
+      return [{
+        id: 'artifact-1',
+        toolId: 'cloud-artifact',
+        toolName: 'cloud.artifact',
+        filePath: 'cloud-artifact://artifact-1/result.txt',
+        filename: 'result.txt',
+        order: 0,
+        source: 'cloud',
+        cloudArtifactId: 'artifact-1',
+        mime: 'text/plain',
+      }]
+    },
+    uploadArtifact: async (input) => {
+      calls.push(`upload:${input.sessionId}:${input.filename}`)
+      return {
+        id: 'artifact-2',
+        toolId: 'cloud-artifact',
+        toolName: 'cloud.artifact',
+        filePath: 'cloud-artifact://artifact-2/upload.txt',
+        filename: input.filename,
+        order: 0,
+        source: 'cloud',
+        cloudArtifactId: 'artifact-2',
+        mime: input.contentType || undefined,
+      }
+    },
+    readArtifactAttachment: async (sessionId, filePath) => {
+      calls.push(`read:${sessionId}:${filePath}`)
+      return {
+        mime: 'text/plain',
+        filename: 'result.txt',
+        url: `data:text/plain;base64,${Buffer.from('hello').toString('base64')}`,
+      }
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerArtifactHandlers(context)
+
+  assert.equal((await handlers.get('artifact:list')?.({}, { sessionId: 'session-1', workspaceId: 'cloud:test' }))?.[0]?.cloudArtifactId, 'artifact-1')
+  assert.equal((await handlers.get('artifact:upload')?.({}, {
+    sessionId: 'session-1',
+    workspaceId: 'cloud:test',
+    filename: 'upload.txt',
+    contentType: 'text/plain',
+    dataBase64: Buffer.from('hello').toString('base64'),
+  }))?.cloudArtifactId, 'artifact-2')
+  assert.equal((await handlers.get('artifact:read-attachment')?.({}, {
+    sessionId: 'session-1',
+    workspaceId: 'cloud:test',
+    filePath: 'cloud-artifact://artifact-1/result.txt',
+  }))?.filename, 'result.txt')
+  await assert.rejects(
+    () => handlers.get('artifact:reveal')?.({}, {
+      sessionId: 'session-1',
+      workspaceId: 'cloud:test',
+      filePath: 'cloud-artifact://artifact-1/result.txt',
+    }),
+    /Cloud artifacts cannot be revealed/,
+  )
+
+  assert.deepEqual(calls, [
+    'list:session-1',
+    'upload:session-1:upload.txt',
+    'read:session-1:cloud-artifact://artifact-1/result.txt',
+  ])
+})
+
+test('capability handlers route cloud workspace calls through the workspace gateway', async () => {
+  const { context, handlers } = createBaseContext()
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { capabilities: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      throw new Error('not used')
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    listCapabilityTools: async () => {
+      calls.push('tools')
+      return [{
+        id: 'read',
+        name: 'Read',
+        description: 'Read files',
+        kind: 'built-in',
+        source: 'builtin',
+        patterns: ['read'],
+        agentNames: ['build'],
+      }]
+    },
+    getCapabilityTool: async (toolId) => {
+      calls.push(`tool:${toolId}`)
+      return {
+        id: toolId,
+        name: 'Read',
+        description: 'Read files',
+        kind: 'built-in',
+        source: 'builtin',
+        patterns: ['read'],
+        agentNames: ['build'],
+      }
+    },
+    listCapabilitySkills: async () => {
+      calls.push('skills')
+      return [{
+        name: 'analysis',
+        label: 'Analysis',
+        description: 'Analyze data',
+        source: 'builtin',
+        toolIds: ['read'],
+        agentNames: ['data-analyst'],
+      }]
+    },
+    getCapabilitySkillBundle: async (skillName) => {
+      calls.push(`bundle:${skillName}`)
+      return {
+        name: skillName,
+        source: 'builtin',
+        content: '# Analysis',
+        files: [{ path: 'examples/report.md' }],
+      }
+    },
+    readCapabilitySkillBundleFile: async (skillName, filePath) => {
+      calls.push(`file:${skillName}:${filePath}`)
+      return 'report example'
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerCatalogHandlers(context)
+
+  assert.equal((await handlers.get('capabilities:tools')?.({}, { workspaceId: 'cloud:test' }))?.[0]?.id, 'read')
+  assert.equal((await handlers.get('capabilities:tool')?.({}, 'read', { workspaceId: 'cloud:test' }))?.name, 'Read')
+  assert.equal((await handlers.get('capabilities:skills')?.({}, { workspaceId: 'cloud:test' }))?.[0]?.name, 'analysis')
+  assert.equal((await handlers.get('capabilities:skill-bundle')?.({}, 'analysis', { workspaceId: 'cloud:test' }))?.name, 'analysis')
+  assert.equal(await handlers.get('capabilities:skill-bundle-file')?.({}, 'analysis', 'examples/report.md', { workspaceId: 'cloud:test' }), 'report example')
+
+  assert.deepEqual(calls, [
+    'tools',
+    'tool:read',
+    'skills',
+    'bundle:analysis',
+    'file:analysis:examples/report.md',
+  ])
+})
+
+test('custom content handlers sync portable cloud metadata and block local-only content', async () => {
+  const { context, handlers } = createBaseContext()
+  const settings = new Map<string, Record<string, unknown>>()
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { customMcps: true, customSkills: true, agents: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      throw new Error('not used')
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    listCapabilityTools: async () => [{
+      id: 'read',
+      name: 'Read',
+      description: 'Read files',
+      kind: 'built-in',
+      source: 'builtin',
+      patterns: ['read'],
+      agentNames: ['build'],
+    }],
+    listCapabilitySkills: async () => [{
+      name: 'analysis',
+      label: 'Analysis',
+      description: 'Analyze data',
+      source: 'builtin',
+      toolIds: ['read'],
+      agentNames: ['build'],
+    }],
+    getSetting: async (key) => ({
+      key,
+      value: settings.get(key) || { items: [] },
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }),
+    setSetting: async (key, value) => {
+      settings.set(key, value)
+      return {
+        key,
+        value,
+        updatedAt: '2026-05-27T10:01:00.000Z',
+      }
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerCustomContentHandlers(context)
+  registerCatalogHandlers(context)
+
+  assert.equal(await handlers.get('custom:add-mcp')?.({}, {
+    workspaceId: 'cloud:test',
+    scope: 'machine',
+    name: 'remote_docs',
+    type: 'http',
+    url: 'https://mcp.example.test',
+  }), true)
+  assert.equal((await handlers.get('custom:list-mcps')?.({}, { workspaceId: 'cloud:test' }))?.[0]?.name, 'remote_docs')
+  await assert.rejects(
+    () => handlers.get('custom:add-mcp')?.({}, {
+      workspaceId: 'cloud:test',
+      scope: 'machine',
+      name: 'local_shell',
+      type: 'stdio',
+      command: 'node',
+    }),
+    /Local stdio MCPs stay in the Local workspace/,
+  )
+
+  assert.equal(await handlers.get('custom:add-skill')?.({}, {
+    workspaceId: 'cloud:test',
+    scope: 'machine',
+    name: 'analysis',
+    content: '# Analysis\n\nUse the read tool.',
+    toolIds: ['read'],
+  }), true)
+  assert.equal((await handlers.get('custom:list-skills')?.({}, { workspaceId: 'cloud:test' }))?.[0]?.name, 'analysis')
+
+  assert.equal(await handlers.get('agents:create')?.({}, {
+    workspaceId: 'cloud:test',
+    scope: 'machine',
+    name: 'analyst',
+    description: 'Analyze data',
+    instructions: 'Use the analysis skill.',
+    skillNames: ['analysis'],
+    toolIds: ['read'],
+    enabled: true,
+    color: 'primary',
+  }), true)
+  assert.equal((await handlers.get('agents:list')?.({}, { workspaceId: 'cloud:test' }))?.[0]?.name, 'analyst')
+  assert.equal((await handlers.get('agents:catalog')?.({}, { workspaceId: 'cloud:test' }))?.tools[0]?.id, 'read')
+  assert.equal(await handlers.get('agents:remove')?.({}, {
+    workspaceId: 'cloud:test',
+    scope: 'machine',
+    name: 'analyst',
+  }, 'confirm'), true)
 })
 
 test('artifact IPC validates request shape before resolving private paths', async () => {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -505,7 +505,9 @@ test('cloud session SSE publishes authoritative cloud projections instead of loc
   })
 
   registerSessionHandlers(context)
-  await handlers.get('session:activate')?.({}, 'cloud-session-1', { workspaceId: 'cloud:test' })
+  const invokeEvent = { sender: { id: 202 } }
+  context.workspaceGateway.activate(invokeEvent, 'cloud:test')
+  await handlers.get('session:activate')?.(invokeEvent, 'cloud-session-1')
   assert.ok(subscribedEventHandler, 'expected cloud session event subscription')
 
   subscribedEventHandler({

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -73,6 +73,59 @@ function createBaseContext() {
   return { context, handlers, errors }
 }
 
+function emptySessionView(overrides: Record<string, unknown> = {}) {
+  return {
+    messages: [],
+    toolCalls: [],
+    taskRuns: [],
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    artifacts: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision: 0,
+    lastEventAt: 0,
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+    ...overrides,
+  }
+}
+
+function installCloudWorkspace(context: IpcHandlerContext, adapter: CloudWorkspaceSessionAdapter) {
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+}
+
 function withPromptProviderConfig() {
   const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-prompt-provider-'))
   const configPath = join(tempRoot, 'open-cowork.config.json')
@@ -1010,6 +1063,67 @@ test('permission:respond can answer a reopened approval using the hydrated sessi
   }])
 })
 
+test('permission:respond routes cloud approvals through the cloud workspace adapter', async () => {
+  const { context, handlers } = createBaseContext()
+  const permissionResponses: Array<Record<string, unknown>> = []
+  const sentViews: unknown[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => emptySessionView({
+      revision: 10,
+      lastEventAt: 10,
+    }) as any,
+    promptSession: async () => {},
+    abortSession: async () => {},
+    respondToPermission: async (sessionId, permissionId, allowed) => {
+      permissionResponses.push({ sessionId, permissionId, allowed })
+    },
+  }
+  installCloudWorkspace(context, adapter)
+  context.getMainWindow = () => ({
+    isDestroyed: () => false,
+    webContents: {
+      id: 301,
+      send: (channel: string, payload: unknown) => {
+        if (channel === 'session:view') sentViews.push(payload)
+      },
+    },
+  } as any)
+  context.getSessionV2Client = async () => {
+    throw new Error('local runtime should not be reached')
+  }
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('permission:respond')
+  assert.ok(handler, 'expected permission:respond handler to be registered')
+
+  await handler({ sender: { id: 301 } }, 'permission-cloud', true, 'cloud-session-1', { workspaceId: 'cloud:test' })
+
+  assert.deepEqual(permissionResponses, [{
+    sessionId: 'cloud-session-1',
+    permissionId: 'permission-cloud',
+    allowed: true,
+  }])
+  assert.deepEqual(sentViews, [{
+    sessionId: 'cloud-session-1',
+    workspaceId: 'cloud:test',
+    view: await adapter.getSessionView('cloud-session-1'),
+  }])
+})
+
 test('question:reply clears the answered request locally so queued questions advance', async () => {
   const { context, handlers } = createBaseContext()
   const sessionId = 'question-ipc-reply-session'
@@ -1086,6 +1200,67 @@ test('question:reply clears the answered request locally so queued questions adv
     stopSessionStatusReconciliation(sessionId)
     sessionEngine.removeSession(sessionId)
   }
+})
+
+test('question:reply routes cloud answers through the cloud workspace adapter', async () => {
+  const { context, handlers } = createBaseContext()
+  const questionReplies: Array<Record<string, unknown>> = []
+  const sentViews: unknown[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => emptySessionView({
+      revision: 11,
+      lastEventAt: 11,
+    }) as any,
+    promptSession: async () => {},
+    abortSession: async () => {},
+    replyToQuestion: async (sessionId, requestId, answers) => {
+      questionReplies.push({ sessionId, requestId, answers })
+    },
+  }
+  installCloudWorkspace(context, adapter)
+  context.getMainWindow = () => ({
+    isDestroyed: () => false,
+    webContents: {
+      id: 302,
+      send: (channel: string, payload: unknown) => {
+        if (channel === 'session:view') sentViews.push(payload)
+      },
+    },
+  } as any)
+  context.getSessionV2Client = async () => {
+    throw new Error('local runtime should not be reached')
+  }
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('question:reply')
+  assert.ok(handler, 'expected question:reply handler to be registered')
+
+  await handler({ sender: { id: 302 } }, 'cloud-session-1', 'question-cloud', [['Yes']], { workspaceId: 'cloud:test' })
+
+  assert.deepEqual(questionReplies, [{
+    sessionId: 'cloud-session-1',
+    requestId: 'question-cloud',
+    answers: [['Yes']],
+  }])
+  assert.deepEqual(sentViews, [{
+    sessionId: 'cloud-session-1',
+    workspaceId: 'cloud:test',
+    view: await adapter.getSessionView('cloud-session-1'),
+  }])
 })
 
 test('session:file-snippet rejects oversized files before reading snippet contents', async () => {
@@ -1233,6 +1408,66 @@ test('question:reject clears the rejected request locally', async () => {
     stopSessionStatusReconciliation(sessionId)
     sessionEngine.removeSession(sessionId)
   }
+})
+
+test('question:reject routes cloud dismissals through the cloud workspace adapter', async () => {
+  const { context, handlers } = createBaseContext()
+  const questionRejects: Array<Record<string, unknown>> = []
+  const sentViews: unknown[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => emptySessionView({
+      revision: 12,
+      lastEventAt: 12,
+    }) as any,
+    promptSession: async () => {},
+    abortSession: async () => {},
+    rejectQuestion: async (sessionId, requestId) => {
+      questionRejects.push({ sessionId, requestId })
+    },
+  }
+  installCloudWorkspace(context, adapter)
+  context.getMainWindow = () => ({
+    isDestroyed: () => false,
+    webContents: {
+      id: 303,
+      send: (channel: string, payload: unknown) => {
+        if (channel === 'session:view') sentViews.push(payload)
+      },
+    },
+  } as any)
+  context.getSessionV2Client = async () => {
+    throw new Error('local runtime should not be reached')
+  }
+
+  registerSessionHandlers(context)
+  const handler = handlers.get('question:reject')
+  assert.ok(handler, 'expected question:reject handler to be registered')
+
+  await handler({ sender: { id: 303 } }, 'cloud-session-1', 'question-cloud', { workspaceId: 'cloud:test' })
+
+  assert.deepEqual(questionRejects, [{
+    sessionId: 'cloud-session-1',
+    requestId: 'question-cloud',
+  }])
+  assert.deepEqual(sentViews, [{
+    sessionId: 'cloud-session-1',
+    workspaceId: 'cloud:test',
+    view: await adapter.getSessionView('cloud-session-1'),
+  }])
 })
 
 test('custom:test-mcp reports OAuth guidance for remote MCP auth errors', async () => {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -6,7 +6,11 @@ import { join } from 'node:path'
 import type { CustomMcpConfig } from '@open-cowork/shared'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
 import { registerAppHandlers, resolveSafeSaveTextPath, saveTextExportFile } from '../apps/desktop/src/main/ipc/app-handlers.ts'
-import { registerArtifactHandlers } from '../apps/desktop/src/main/ipc/artifact-handlers.ts'
+import {
+  decodeCloudArtifactDataUrl,
+  registerArtifactHandlers,
+  safeArtifactExportFilename,
+} from '../apps/desktop/src/main/ipc/artifact-handlers.ts'
 import { registerSessionHandlers } from '../apps/desktop/src/main/ipc/session-handlers.ts'
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { normalizeFindTextPattern, registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
@@ -351,6 +355,125 @@ test('session handlers route cloud workspace calls through the workspace gateway
     'prompt:cloud-session-1:hello:data-analyst',
     'abort:cloud-session-1',
   ])
+})
+
+test('cloud session SSE publishes authoritative cloud projections instead of local views', async () => {
+  const { context, handlers } = createBaseContext()
+  const sentViews: unknown[] = []
+  let subscribedEventHandler: ((event: any) => void) | null = null
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => ({
+      messages: [{
+        id: 'cloud-projected-message',
+        role: 'assistant',
+        segments: [{ id: 'segment-1', kind: 'text', text: 'from cloud projection' }],
+        attachments: [],
+        createdAt: 1,
+      }],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [{
+        id: 'permission-1',
+        taskRunId: null,
+        tool: 'read',
+        description: 'Read file',
+        input: {},
+        sourceSessionId: 'cloud-session-1',
+      }],
+      pendingQuestions: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      lastInputTokens: 0,
+      contextState: 'running',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 7,
+      lastEventAt: 42,
+      isGenerating: true,
+      isAwaitingPermission: true,
+      isAwaitingQuestion: false,
+    }),
+    promptSession: async () => {},
+    abortSession: async () => {},
+    subscribeSessionEvents: (_sessionId, input) => {
+      subscribedEventHandler = input.onEvent
+      return { close: () => {} }
+    },
+  }
+  context.getMainWindow = () => ({
+    isDestroyed: () => false,
+    webContents: {
+      id: 202,
+      send: (channel: string, payload: unknown) => {
+        if (channel === 'session:view') sentViews.push(payload)
+      },
+    },
+  } as any)
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: {
+      get: () => null,
+      getUsableAccessToken: () => 'cloud-access-token',
+      listMetadata: () => [],
+      save: () => {
+        throw new Error('not used')
+      },
+      remove: () => true,
+    },
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  registerSessionHandlers(context)
+  await handlers.get('session:activate')?.({}, 'cloud-session-1', { workspaceId: 'cloud:test' })
+  assert.ok(subscribedEventHandler, 'expected cloud session event subscription')
+
+  subscribedEventHandler({
+    type: 'permission.requested',
+    sessionId: 'cloud-session-1',
+    sequence: 42,
+    payload: {
+      permissionId: 'permission-1',
+      tool: 'read',
+      description: 'Read file',
+    },
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 25))
+
+  assert.equal(sentViews.length, 1)
+  assert.deepEqual(sentViews[0], {
+    sessionId: 'cloud-session-1',
+    workspaceId: 'cloud:test',
+    view: await adapter.getSessionView('cloud-session-1'),
+  })
 })
 
 test('session:prompt rejects too many attachments before runtime dispatch', async () => {
@@ -1568,6 +1691,25 @@ test('artifact handlers route cloud workspace calls through the workspace gatewa
     'upload:session-1:upload.txt',
     'read:session-1:cloud-artifact://artifact-1/result.txt',
   ])
+})
+
+test('cloud artifact export helpers validate data URLs and sanitize default filenames', () => {
+  assert.deepEqual(
+    decodeCloudArtifactDataUrl(`data:text/plain;base64,${Buffer.from('hello').toString('base64')}`),
+    Buffer.from('hello'),
+  )
+  assert.throws(
+    () => decodeCloudArtifactDataUrl('https://cloud.example.test/artifact.txt'),
+    /base64 data URL/,
+  )
+  assert.throws(
+    () => decodeCloudArtifactDataUrl('data:text/plain;base64,not valid base64!'),
+    /valid base64/,
+  )
+
+  assert.equal(safeArtifactExportFilename('../report.txt'), 'report.txt')
+  assert.equal(safeArtifactExportFilename('/tmp/report.txt'), 'report.txt')
+  assert.equal(safeArtifactExportFilename(''), 'artifact')
 })
 
 test('capability handlers route cloud workspace calls through the workspace gateway', async () => {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -1935,6 +1935,10 @@ test('cloud artifact export helpers validate data URLs and sanitize default file
     decodeCloudArtifactDataUrl(`data:text/plain;base64,${Buffer.from('hello').toString('base64')}`),
     Buffer.from('hello'),
   )
+  assert.deepEqual(
+    decodeCloudArtifactDataUrl(`data:text/plain; charset=utf-8;base64,${Buffer.from('hello').toString('base64')}`),
+    Buffer.from('hello'),
+  )
   assert.throws(
     () => decodeCloudArtifactDataUrl('https://cloud.example.test/artifact.txt'),
     /base64 data URL/,

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -10,6 +10,8 @@ import { registerWorkflowHandlers } from '../apps/desktop/src/main/ipc/workflow-
 import { registerCustomContentHandlers } from '../apps/desktop/src/main/ipc/custom-content-handlers.ts'
 import { registerExplorerHandlers } from '../apps/desktop/src/main/ipc/explorer-handlers.ts'
 import { registerThreadHandlers } from '../apps/desktop/src/main/ipc/thread-handlers.ts'
+import { registerWorkspaceHandlers } from '../apps/desktop/src/main/ipc/workspace-handlers.ts'
+import { createWorkspaceGateway } from '../apps/desktop/src/main/workspace-gateway.ts'
 
 function createTestContext() {
   const handlers = new Map<string, unknown>()
@@ -25,6 +27,7 @@ function createTestContext() {
         listeners.set(channel, listener)
       },
     },
+    workspaceGateway: createWorkspaceGateway({ cloudRegistry: null, cloudCredentialStore: null }),
     getMainWindow: () => null,
     normalizeDirectory: () => '/tmp',
     ensureSessionRecord: () => null,
@@ -79,6 +82,7 @@ function readPreloadApiGroups(source: string) {
 test('IPC handler modules register their core channels', () => {
   const { context, handlers, listeners } = createTestContext()
 
+  registerWorkspaceHandlers(context)
   registerAppHandlers(context)
   registerArtifactHandlers(context)
   registerWorkflowHandlers(context)
@@ -94,6 +98,10 @@ test('IPC handler modules register their core channels', () => {
   // reporter going missing.
   assert.equal(listeners.has('diagnostics:renderer-error'), true)
 
+  assert.equal(handlers.has('workspace:list'), true)
+  assert.equal(handlers.has('workspace:activate'), true)
+  assert.equal(handlers.has('workspace:policy'), true)
+  assert.equal(handlers.has('workspace:support'), true)
   assert.equal(handlers.has('auth:status'), true)
   assert.equal(handlers.has('settings:set'), true)
   assert.equal(handlers.has('settings:get-provider-credentials'), true)
@@ -130,6 +138,7 @@ test('IPC handler modules register their core channels', () => {
 test('preload invoke/send channels match registered main-process IPC channels', () => {
   const { context, handlers, listeners } = createTestContext()
 
+  registerWorkspaceHandlers(context)
   registerAppHandlers(context)
   registerArtifactHandlers(context)
   registerWorkflowHandlers(context)

--- a/tests/ipc-thread-handlers.test.ts
+++ b/tests/ipc-thread-handlers.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
 import { registerThreadHandlers } from '../apps/desktop/src/main/ipc/thread-handlers.ts'
+import { createWorkspaceGateway } from '../apps/desktop/src/main/workspace-gateway.ts'
 
 function createThreadHandlerContext() {
   const handlers = new Map<string, (...args: any[]) => any>()
@@ -12,6 +13,7 @@ function createThreadHandlerContext() {
       },
       on() {},
     },
+    workspaceGateway: createWorkspaceGateway({ cloudRegistry: null, cloudCredentialStore: null }),
     getMainWindow: () => null,
     normalizeDirectory: () => '/tmp',
     ensureSessionRecord: () => null,

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -7,9 +7,10 @@ type PackageJson = {
 }
 
 const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as PackageJson
+const desktopPackageJson = JSON.parse(readFileSync(new URL('../apps/desktop/package.json', import.meta.url), 'utf8')) as PackageJson
 
-function requireScript(name: string): string {
-  const script = packageJson.scripts?.[name]
+function requireScript(name: string, source: PackageJson = packageJson): string {
+  const script = source.scripts?.[name]
   assert.equal(typeof script, 'string', `Missing package script: ${name}`)
   return script
 }
@@ -35,5 +36,49 @@ test('root node test scripts prepare generated shared artifacts before tests run
     'pnpm --filter=./mcps/* test',
     'node scripts/run-node-tests.mjs --coverage',
     'node scripts/coverage-summary.mjs --check --node-only --no-write',
+  ])
+})
+
+test('root lint script runs all release gate checks', () => {
+  assert.deepEqual(splitScriptSteps(requireScript('lint')), [
+    'eslint . --max-warnings 0',
+    'node scripts/lint.mjs',
+    'node scripts/check-preload-channels.mjs',
+    'node scripts/check-shared-dist.mjs',
+  ])
+})
+
+test('root build and dist scripts preserve release build prerequisites', () => {
+  assert.deepEqual(splitScriptSteps(requireScript('build')), [
+    'pnpm --filter @open-cowork/shared build',
+    'pnpm build:mcps',
+    'pnpm --filter @open-cowork/desktop build',
+  ])
+
+  assert.deepEqual(splitScriptSteps(requireScript('dist')), [
+    'pnpm build',
+    'pnpm --filter @open-cowork/desktop dist',
+  ])
+})
+
+test('root typecheck script covers shared, MCP, and desktop packages', () => {
+  assert.deepEqual(splitScriptSteps(requireScript('typecheck')), [
+    'pnpm --filter @open-cowork/shared build',
+    'pnpm typecheck:mcps',
+    'pnpm --filter @open-cowork/desktop build:electron',
+    'pnpm --filter @open-cowork/desktop typecheck',
+  ])
+
+  assert.equal(requireScript('typecheck:mcps'), 'pnpm --filter=./mcps/* typecheck')
+})
+
+test('packaged e2e script fails before smoke discovery without a packaged executable', () => {
+  assert.deepEqual(splitScriptSteps(requireScript('test:e2e:packaged')), [
+    'pnpm --filter @open-cowork/desktop test:e2e:packaged',
+  ])
+
+  assert.deepEqual(splitScriptSteps(requireScript('test:e2e:packaged', desktopPackageJson)), [
+    'node ../../scripts/require-packaged-executable.mjs',
+    'node ../../scripts/run-desktop-smoke-tests.mjs --pattern "tests/*.packaged.test.ts" --timeout=240000 --retries=1',
   ])
 })

--- a/tests/session-artifacts.test.ts
+++ b/tests/session-artifacts.test.ts
@@ -64,6 +64,23 @@ test('listSessionArtifacts extracts downloadable files from write tools', () => 
   ])
 })
 
+test('listSessionArtifacts includes cloud projection artifacts', () => {
+  const view = emptyView()
+  view.artifacts = [{
+    id: 'artifact-1',
+    toolId: 'cloud-artifact',
+    toolName: 'cloud.artifact',
+    filePath: 'cloud-artifact://artifact-1/result.txt',
+    filename: 'result.txt',
+    order: 3,
+    source: 'cloud',
+    cloudArtifactId: 'artifact-1',
+    mime: 'text/plain',
+  }]
+
+  assert.equal(listSessionArtifacts(view)[0]?.cloudArtifactId, 'artifact-1')
+})
+
 test('sanitizeArtifactToolInput hides sandbox file paths behind artifact urls', () => {
   const artifact = artifactForTool(tool({
     id: 'write-2',

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -8,6 +8,7 @@ import {
   dispatchRuntimeSessionEvent,
   getRuntimeNotification,
   getSessionPatch,
+  publishSessionView,
   setSessionHistoryRefreshHandler,
   shouldPublishSessionView,
 } from '../apps/desktop/src/main/session-event-dispatcher.ts'
@@ -390,6 +391,14 @@ test('dispatcher never publishes local full views for cloud workspace events', a
   })
 
   await wait(40)
+
+  assert.equal(sent.some((entry) => entry.channel === 'session:view'), false)
+})
+
+test('publishSessionView refuses cloud workspace views from the local session engine', () => {
+  const { win, sent } = createWindowCollector(56)
+
+  publishSessionView(win as any, 'cloud-session-view-direct', 'cloud:test')
 
   assert.equal(sent.some((entry) => entry.channel === 'session:view'), false)
 })

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -368,6 +368,30 @@ test('dispatcher publishes session views for non-text session state transitions'
   assert.equal(shouldPublishSessionView(eventOf('error', 'session-1')), true)
   assert.equal(shouldPublishSessionView(eventOf('done', 'session-1')), true)
   assert.equal(shouldPublishSessionView(eventOf('busy')), false)
+  assert.equal(shouldPublishSessionView({
+    ...eventOf('tool_call', 'session-1'),
+    workspaceId: 'cloud:test',
+  }), false)
+})
+
+test('dispatcher never publishes local full views for cloud workspace events', async () => {
+  const { win, sent } = createWindowCollector(55)
+
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'tool_call',
+    sessionId: 'cloud-session-view-skip',
+    workspaceId: 'cloud:test',
+    data: {
+      type: 'tool_call',
+      id: 'tool-1',
+      name: 'read',
+      status: 'running',
+    },
+  })
+
+  await wait(40)
+
+  assert.equal(sent.some((entry) => entry.channel === 'session:view'), false)
 })
 
 test('dispatcher derives notifications for completion and global errors', () => {

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -10,7 +10,11 @@ import {
   createWorkspaceGateway,
   readWorkspaceIdOption,
 } from '../apps/desktop/src/main/workspace-gateway.ts'
-import type { CloudWorkspaceSessionAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
+import {
+  cloudWorkspaceCacheKey,
+  type CloudWorkspaceSessionAdapter,
+} from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
+import type { CloudWorkspaceCache } from '../apps/desktop/src/main/cloud-workspace-cache.ts'
 
 function event(senderId: number) {
   return { sender: { id: senderId } } as never
@@ -21,6 +25,32 @@ function encryptedStorage() {
     mode: 'encrypted' as const,
     encryptString: (plaintext: string) => Buffer.from(plaintext, 'utf-8'),
     decryptString: (encrypted: Buffer) => encrypted.toString('utf-8'),
+  }
+}
+
+function recordingCloudCache(removedWorkspaceIds: string[]): CloudWorkspaceCache {
+  return {
+    mode: 'full',
+    listSessions: () => null,
+    getSessionInfo: () => null,
+    getSessionView: () => null,
+    getEventCursor: () => null,
+    setEventCursor: () => {},
+    resetEventCursor: () => {},
+    getWorkflowList: () => null,
+    upsertWorkflowList: () => {},
+    listSettings: () => null,
+    getSetting: () => null,
+    upsertSettings: () => {},
+    upsertSetting: () => {},
+    listArtifacts: () => null,
+    upsertArtifactList: () => {},
+    upsertSessionList: () => {},
+    upsertSessionInfo: () => {},
+    upsertSessionView: () => {},
+    removeWorkspace: (workspaceId) => {
+      removedWorkspaceIds.push(workspaceId)
+    },
   }
 }
 
@@ -146,18 +176,35 @@ test('workspace gateway registers cloud connections without enabling unauthentic
 })
 
 test('workspace gateway loads and removes persisted cloud connections', () => {
-  const path = join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-gateway-')), 'cloud-workspaces.json')
-  const registry = new FileCloudWorkspaceRegistry(path)
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-gateway-'))
+  const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(root, 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
   const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' }, new Date('2026-05-27T10:00:00.000Z'))
-  const gateway = createWorkspaceGateway({ cloudRegistry: registry, cloudCredentialStore: null })
+  const removedCacheWorkspaceIds: string[] = []
+  credentials.save({
+    workspaceId: persisted.id,
+    accessToken: 'cloud-access-token',
+    refreshToken: 'cloud-refresh-token',
+    expiresAt: '2030-05-27T12:00:00.000Z',
+  })
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: credentials,
+    cloudCache: recordingCloudCache(removedCacheWorkspaceIds),
+  })
 
   const workspace = gateway.list(event(1)).find((entry) => entry.id === persisted.id)
   assert.equal(workspace?.kind, 'cloud')
-  assert.equal(workspace?.status, 'auth_required')
+  assert.equal(workspace?.status, 'online')
   assert.equal(workspace?.label, 'Acme')
 
   assert.equal(gateway.remove(event(1), persisted.id), true)
   assert.equal(registry.list().length, 0)
+  assert.equal(credentials.get(persisted.id), null)
+  assert.deepEqual(removedCacheWorkspaceIds, [cloudWorkspaceCacheKey(persisted)])
 })
 
 test('workspace gateway routes online cloud session calls through the cloud adapter', async () => {
@@ -830,6 +877,73 @@ test('workspace gateway refreshes expired cloud tokens before adapter calls', as
   assert.equal(credentials.get(persisted.id)?.accessToken, 'fresh-access-token')
   assert.equal(credentials.get(persisted.id)?.refreshToken, 'refresh-token-2')
   assert.equal(gateway.list(event(1)).find((entry) => entry.id === persisted.id)?.status, 'online')
+})
+
+test('workspace gateway preserves cloud credentials on transient refresh failures', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-refresh-transient-'))
+  const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(root, 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' }, new Date('2026-05-27T10:00:00.000Z'))
+  credentials.save({
+    workspaceId: persisted.id,
+    accessToken: 'expired-access-token',
+    refreshToken: 'refresh-token-1',
+    expiresAt: '2026-05-27T10:00:00.000Z',
+  }, new Date('2026-05-27T10:00:00.000Z'))
+  let adapterCalls = 0
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: credentials,
+    cloudRefresh: async () => {
+      throw new Error('fetch failed')
+    },
+    cloudAdapterFactory: () => {
+      adapterCalls += 1
+      throw new Error('adapter should not be created without a usable access token')
+    },
+  })
+
+  await assert.rejects(() => gateway.sync(event(1), persisted.id), /offline or unavailable/)
+
+  const stored = credentials.get(persisted.id)
+  assert.equal(adapterCalls, 0)
+  assert.equal(stored?.accessToken, 'expired-access-token')
+  assert.equal(stored?.refreshToken, 'refresh-token-1')
+  assert.equal(gateway.list(event(1)).find((entry) => entry.id === persisted.id)?.status, 'offline')
+})
+
+test('workspace gateway clears cloud credentials on refresh auth failures', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-refresh-auth-'))
+  const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(root, 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' }, new Date('2026-05-27T10:00:00.000Z'))
+  credentials.save({
+    workspaceId: persisted.id,
+    accessToken: 'expired-access-token',
+    refreshToken: 'refresh-token-1',
+    expiresAt: '2026-05-27T10:00:00.000Z',
+  }, new Date('2026-05-27T10:00:00.000Z'))
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: credentials,
+    cloudRefresh: async () => {
+      throw new Error('invalid_grant')
+    },
+    cloudAdapterFactory: () => {
+      throw new Error('adapter should not be created without a usable access token')
+    },
+  })
+
+  await assert.rejects(() => gateway.sync(event(1), persisted.id), /Sign in to this cloud workspace/)
+
+  assert.equal(credentials.get(persisted.id), null)
+  assert.equal(gateway.list(event(1)).find((entry) => entry.id === persisted.id)?.status, 'auth_required')
 })
 
 test('workspace option reader accepts optional workspace id only from objects', () => {

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -679,6 +679,124 @@ test('workspace gateway subscribes cloud workspace events once per sender', asyn
   assert.deepEqual(calls, ['subscribe:cached', 'subscribe:5', 'close', 'close'])
 })
 
+test('workspace gateway drops failed cloud event subscriptions before retry', async () => {
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-event-retry-')), 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  credentials.save({
+    workspaceId: 'cloud:test',
+    accessToken: 'cloud-access-token',
+    expiresAt: '2030-05-27T12:00:00.000Z',
+  })
+  type WorkspaceSubscriptionInput = Parameters<NonNullable<CloudWorkspaceSessionAdapter['subscribeWorkspaceEvents']>>[0]
+  type SessionSubscriptionInput = Parameters<NonNullable<CloudWorkspaceSessionAdapter['subscribeSessionEvents']>>[1]
+  const calls: string[] = []
+  const errors: string[] = []
+  const workspaceInputs: WorkspaceSubscriptionInput[] = []
+  const sessionInputs: SessionSubscriptionInput[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => ({
+      id: 'cloud-session-1',
+      title: 'Cloud session',
+      directory: null,
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }),
+    getSessionInfo: async () => null,
+    getSessionView: async () => ({
+      messages: [],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      lastInputTokens: 0,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 0,
+      lastEventAt: 0,
+      isGenerating: false,
+      isAwaitingPermission: false,
+      isAwaitingQuestion: false,
+    }),
+    promptSession: async () => undefined,
+    abortSession: async () => undefined,
+    subscribeWorkspaceEvents: (input) => {
+      calls.push('workspace:subscribe')
+      workspaceInputs.push(input)
+      return { close() { calls.push('workspace:close') } }
+    },
+    subscribeSessionEvents: (sessionId, input) => {
+      calls.push(`session:subscribe:${sessionId}`)
+      sessionInputs.push(input)
+      return { close() { calls.push(`session:close:${sessionId}`) } }
+    },
+  }
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: credentials,
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  await gateway.subscribeCloudWorkspaceEvents(event(1), {
+    workspaceId: 'cloud:test',
+    onEvent: () => {},
+    onError: (error) => { errors.push(error instanceof Error ? error.message : String(error)) },
+  })
+  workspaceInputs[0]?.onError?.(new Error('workspace 401'))
+  await gateway.subscribeCloudWorkspaceEvents(event(1), {
+    workspaceId: 'cloud:test',
+    onEvent: () => {},
+  })
+  await gateway.subscribeCloudSessionEvents(event(1), 'cloud-session-1', {
+    workspaceId: 'cloud:test',
+    onEvent: () => {},
+    onError: (error) => { errors.push(error instanceof Error ? error.message : String(error)) },
+  })
+  sessionInputs[0]?.onError?.(new Error('session 401'))
+  await gateway.subscribeCloudSessionEvents(event(1), 'cloud-session-1', {
+    workspaceId: 'cloud:test',
+    onEvent: () => {},
+  })
+
+  assert.deepEqual(calls, [
+    'workspace:subscribe',
+    'workspace:close',
+    'workspace:subscribe',
+    'session:subscribe:cloud-session-1',
+    'session:close:cloud-session-1',
+    'session:subscribe:cloud-session-1',
+  ])
+  assert.deepEqual(errors, ['workspace 401', 'session 401'])
+})
+
 test('workspace gateway marks persisted cloud workspaces online when a usable token exists', async () => {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-token-'))
   const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -988,6 +988,8 @@ test('workspace gateway refreshes expired cloud tokens before adapter calls', as
     },
   })
 
+  assert.equal(gateway.list(event(1)).find((entry) => entry.id === persisted.id)?.status, 'online')
+
   const syncResult = await gateway.sync(event(1), persisted.id)
 
   assert.equal(syncResult.ok, true)

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -1,0 +1,840 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { FileCloudWorkspaceRegistry } from '../apps/desktop/src/main/cloud-workspace-registry.ts'
+import { FileCloudWorkspaceCredentialStore } from '../apps/desktop/src/main/cloud-workspace-credentials.ts'
+import {
+  LOCAL_WORKSPACE_ID,
+  createWorkspaceGateway,
+  readWorkspaceIdOption,
+} from '../apps/desktop/src/main/workspace-gateway.ts'
+import type { CloudWorkspaceSessionAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
+
+function event(senderId: number) {
+  return { sender: { id: senderId } } as never
+}
+
+function encryptedStorage() {
+  return {
+    mode: 'encrypted' as const,
+    encryptString: (plaintext: string) => Buffer.from(plaintext, 'utf-8'),
+    decryptString: (encrypted: Buffer) => encrypted.toString('utf-8'),
+  }
+}
+
+test('workspace gateway exposes local workspace by default', () => {
+  const gateway = createWorkspaceGateway({ cloudRegistry: null, cloudCredentialStore: null })
+  const workspaces = gateway.list(event(1))
+
+  assert.equal(workspaces.length, 1)
+  assert.equal(workspaces[0]?.id, LOCAL_WORKSPACE_ID)
+  assert.equal(workspaces[0]?.kind, 'local')
+  assert.equal(workspaces[0]?.status, 'online')
+  assert.equal(workspaces[0]?.active, true)
+})
+
+test('workspace gateway honors disabled cloud desktop config', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-disabled-cloud-')), 'cloud-workspaces.json')
+  const registry = new FileCloudWorkspaceRegistry(path)
+  registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' })
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: null,
+    cloudDesktop: {
+      enabled: false,
+      allowUserAddedConnections: true,
+      preconfiguredConnections: [],
+      requireManagedOrg: false,
+      cacheMode: 'full',
+      cacheEncryptionFallback: 'metadata-only',
+    },
+  })
+
+  assert.deepEqual(gateway.list(event(1)).map((workspace) => workspace.id), [LOCAL_WORKSPACE_ID])
+  assert.throws(
+    () => gateway.addCloud(event(1), { baseUrl: 'https://other-cloud.example.test' }),
+    /disabled by this build configuration/,
+  )
+})
+
+test('workspace gateway supports managed preconfigured cloud orgs', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-managed-cloud-')), 'cloud-workspaces.json')
+  const registry = new FileCloudWorkspaceRegistry(path)
+  registry.upsert({ baseUrl: 'https://managed.example.test', label: 'Persisted Managed' })
+  registry.upsert({ baseUrl: 'https://unmanaged.example.test', label: 'Unmanaged' })
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: null,
+    cloudDesktop: {
+      enabled: true,
+      allowUserAddedConnections: true,
+      preconfiguredConnections: [{ baseUrl: 'https://managed.example.test', label: 'Managed Cloud' }],
+      requireManagedOrg: true,
+      cacheMode: 'metadata-only',
+      cacheEncryptionFallback: 'disabled',
+    },
+  })
+
+  const workspaces = gateway.list(event(1))
+  const managed = workspaces.find((workspace) => workspace.baseUrl === 'https://managed.example.test')
+  assert.equal(workspaces.some((workspace) => workspace.baseUrl === 'https://unmanaged.example.test'), false)
+  assert.equal(managed?.label, 'Managed Cloud')
+  assert.equal(managed?.status, 'auth_required')
+  assert.throws(
+    () => gateway.addCloud(event(1), { baseUrl: 'https://other-cloud.example.test' }),
+    /User-added cloud workspaces are disabled/,
+  )
+  assert.equal(managed ? gateway.remove(event(1), managed.id) : true, false)
+})
+
+test('workspace gateway tracks active workspace per sender', () => {
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: null,
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'disabled',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+  })
+
+  gateway.activate(event(1), 'cloud:test')
+
+  assert.equal(gateway.list(event(1)).find((workspace) => workspace.id === 'cloud:test')?.active, true)
+  assert.equal(gateway.list(event(2)).find((workspace) => workspace.id === LOCAL_WORKSPACE_ID)?.active, true)
+})
+
+test('workspace gateway keeps local desktop actions local-only', () => {
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: null,
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'disabled',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+  })
+
+  assert.equal(gateway.assertLocalWorkspace(event(1)).id, LOCAL_WORKSPACE_ID)
+  assert.throws(
+    () => gateway.assertLocalWorkspace(event(1), 'cloud:test'),
+    /only available in the Local workspace/,
+  )
+})
+
+test('workspace gateway registers cloud connections without enabling unauthenticated execution', async () => {
+  const gateway = createWorkspaceGateway({ cloudRegistry: null, cloudCredentialStore: null })
+  const workspace = gateway.addCloud(event(1), { baseUrl: 'https://cloud.example.test/api/', label: 'Acme' })
+
+  assert.equal(workspace.kind, 'cloud')
+  assert.equal(workspace.label, 'Acme')
+  assert.equal(workspace.status, 'auth_required')
+  assert.equal(workspace.baseUrl, 'https://cloud.example.test/api')
+  assert.equal(gateway.policy(event(1), workspace.id).localFiles, 'disabled')
+  const support = await gateway.supportMatrix(event(1), workspace.id)
+  assert.equal(support.find((entry) => entry.api === 'sessions.prompt')?.status, 'blocked_by_policy')
+  assert.equal(support.find((entry) => entry.api === 'localFiles')?.status, 'not_supported')
+  await assert.rejects(() => gateway.sync(event(1), workspace.id), /Sign in|not available/)
+})
+
+test('workspace gateway loads and removes persisted cloud connections', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-gateway-')), 'cloud-workspaces.json')
+  const registry = new FileCloudWorkspaceRegistry(path)
+  const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' }, new Date('2026-05-27T10:00:00.000Z'))
+  const gateway = createWorkspaceGateway({ cloudRegistry: registry, cloudCredentialStore: null })
+
+  const workspace = gateway.list(event(1)).find((entry) => entry.id === persisted.id)
+  assert.equal(workspace?.kind, 'cloud')
+  assert.equal(workspace?.status, 'auth_required')
+  assert.equal(workspace?.label, 'Acme')
+
+  assert.equal(gateway.remove(event(1), persisted.id), true)
+  assert.equal(registry.list().length, 0)
+})
+
+test('workspace gateway routes online cloud session calls through the cloud adapter', async () => {
+  const calls: string[] = []
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-route-')), 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  credentials.save({
+    workspaceId: 'cloud:test',
+    accessToken: 'cloud-access-token',
+    expiresAt: '2030-05-27T12:00:00.000Z',
+  })
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: ['data-analyst'],
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => {
+      calls.push('list')
+      return [{
+        id: 'cloud-session-1',
+        title: 'Cloud thread',
+        directory: null,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }]
+    },
+    createSession: async () => {
+      calls.push('create')
+      return {
+        id: 'cloud-session-2',
+        title: 'New cloud thread',
+        directory: null,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }
+    },
+    getSessionInfo: async (sessionId) => {
+      calls.push(`get:${sessionId}`)
+      return {
+        id: sessionId,
+        title: 'Cloud thread',
+        directory: null,
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }
+    },
+    getSessionView: async (sessionId) => {
+      calls.push(`view:${sessionId}`)
+      return {
+        messages: [],
+        toolCalls: [],
+        taskRuns: [],
+        compactions: [],
+        pendingApprovals: [],
+        pendingQuestions: [],
+        errors: [],
+        todos: [],
+        executionPlan: [],
+        sessionCost: 0,
+        sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+        lastInputTokens: 0,
+        contextState: 'idle',
+        compactionCount: 0,
+        lastCompactedAt: null,
+        activeAgent: null,
+        lastItemWasTool: false,
+        revision: 0,
+        lastEventAt: 0,
+        isGenerating: false,
+        isAwaitingPermission: false,
+        isAwaitingQuestion: false,
+      }
+    },
+    promptSession: async (sessionId, input) => {
+      calls.push(`prompt:${sessionId}:${input.text}:${input.agent}`)
+    },
+    abortSession: async (sessionId) => {
+      calls.push(`abort:${sessionId}`)
+    },
+    listWorkflows: async () => {
+      calls.push('workflows:list')
+      return { workflows: [], runs: [] }
+    },
+    getWorkflow: async (workflowId) => {
+      calls.push(`workflows:get:${workflowId}`)
+      return null
+    },
+    runWorkflow: async (workflowId) => {
+      calls.push(`workflows:run:${workflowId}`)
+      return null
+    },
+    pauseWorkflow: async (workflowId) => {
+      calls.push(`workflows:pause:${workflowId}`)
+      return null
+    },
+    resumeWorkflow: async (workflowId) => {
+      calls.push(`workflows:resume:${workflowId}`)
+      return null
+    },
+    archiveWorkflow: async (workflowId) => {
+      calls.push(`workflows:archive:${workflowId}`)
+      return null
+    },
+    searchThreads: async () => {
+      calls.push('threads:search')
+      return { threads: [], nextCursor: null, totalEstimate: 0 }
+    },
+    threadFacets: async () => {
+      calls.push('threads:facets')
+      return { projects: [], providers: [], models: [], agents: [], tools: [], mcps: [], statuses: [], tags: [] }
+    },
+    listThreadTags: async () => {
+      calls.push('threads:tags:list')
+      return []
+    },
+    createThreadTag: async (input) => {
+      calls.push(`threads:tags:create:${input.name}`)
+      return { id: 'tag-1', name: input.name, color: input.color || '#64748b', createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    updateThreadTag: async (tagId, input) => {
+      calls.push(`threads:tags:update:${tagId}:${input.name}`)
+      return { id: tagId, name: input.name, color: input.color || '#64748b', createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    deleteThreadTag: async (tagId) => {
+      calls.push(`threads:tags:delete:${tagId}`)
+      return true
+    },
+    applyThreadTags: async (sessionIds, tagIds) => {
+      calls.push(`threads:tags:apply:${sessionIds.join(',')}:${tagIds.join(',')}`)
+      return true
+    },
+    removeThreadTags: async (sessionIds, tagIds) => {
+      calls.push(`threads:tags:remove:${sessionIds.join(',')}:${tagIds.join(',')}`)
+      return true
+    },
+    listThreadSmartFilters: async () => {
+      calls.push('threads:filters:list')
+      return []
+    },
+    createThreadSmartFilter: async (input) => {
+      calls.push(`threads:filters:create:${input.name}`)
+      return { id: 'filter-1', name: input.name, query: input.query, createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    updateThreadSmartFilter: async (filterId, input) => {
+      calls.push(`threads:filters:update:${filterId}:${input.name}`)
+      return { id: filterId, name: input.name, query: input.query, createdAt: '2026-05-27T10:00:00.000Z', updatedAt: '2026-05-27T10:00:00.000Z' }
+    },
+    deleteThreadSmartFilter: async (filterId) => {
+      calls.push(`threads:filters:delete:${filterId}`)
+      return true
+    },
+    listArtifacts: async (sessionId) => {
+      calls.push(`artifacts:list:${sessionId}`)
+      return [{
+        id: 'artifact-1',
+        toolId: 'cloud-artifact',
+        toolName: 'cloud.artifact',
+        filePath: 'cloud-artifact://artifact-1/result.txt',
+        filename: 'result.txt',
+        order: 0,
+        source: 'cloud',
+        cloudArtifactId: 'artifact-1',
+        mime: 'text/plain',
+      }]
+    },
+    uploadArtifact: async (input) => {
+      calls.push(`artifacts:upload:${input.sessionId}:${input.filename}`)
+      return {
+        id: 'artifact-2',
+        toolId: 'cloud-artifact',
+        toolName: 'cloud.artifact',
+        filePath: 'cloud-artifact://artifact-2/upload.txt',
+        filename: input.filename,
+        order: 0,
+        source: 'cloud',
+        cloudArtifactId: 'artifact-2',
+        mime: input.contentType || undefined,
+      }
+    },
+    readArtifactAttachment: async (sessionId, filePath) => {
+      calls.push(`artifacts:read:${sessionId}:${filePath}`)
+      return {
+        mime: 'text/plain',
+        filename: 'result.txt',
+        url: `data:text/plain;base64,${Buffer.from('hello').toString('base64')}`,
+      }
+    },
+    listCapabilityTools: async () => {
+      calls.push('capabilities:tools')
+      return [{
+        id: 'read',
+        name: 'Read',
+        description: 'Read files',
+        kind: 'built-in',
+        source: 'builtin',
+        patterns: ['read'],
+        agentNames: ['build'],
+      }]
+    },
+    getCapabilityTool: async (toolId) => {
+      calls.push(`capabilities:tool:${toolId}`)
+      return {
+        id: toolId,
+        name: 'Read',
+        description: 'Read files',
+        kind: 'built-in',
+        source: 'builtin',
+        patterns: ['read'],
+        agentNames: ['build'],
+      }
+    },
+    listCapabilitySkills: async () => {
+      calls.push('capabilities:skills')
+      return [{
+        name: 'analysis',
+        label: 'Analysis',
+        description: 'Analyze data',
+        source: 'builtin',
+        toolIds: ['read'],
+        agentNames: ['data-analyst'],
+      }]
+    },
+    getCapabilitySkillBundle: async (skillName) => {
+      calls.push(`capabilities:skill-bundle:${skillName}`)
+      return {
+        name: skillName,
+        source: 'builtin',
+        content: '# Analysis',
+        files: [{ path: 'examples/report.md' }],
+      }
+    },
+    readCapabilitySkillBundleFile: async (skillName, filePath) => {
+      calls.push(`capabilities:skill-file:${skillName}:${filePath}`)
+      return 'report example'
+    },
+    listSettings: async () => {
+      calls.push('settings:list')
+      return [{
+        key: 'portable-settings',
+        value: { selectedProviderId: 'anthropic' },
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }]
+    },
+    getSetting: async (key) => {
+      calls.push(`settings:get:${key}`)
+      return {
+        key,
+        value: { selectedProviderId: 'anthropic' },
+        updatedAt: '2026-05-27T10:00:00.000Z',
+      }
+    },
+    setSetting: async (key, value) => {
+      calls.push(`settings:set:${key}:${value.selectedProviderId}`)
+      return {
+        key,
+        value,
+        updatedAt: '2026-05-27T10:01:00.000Z',
+      }
+    },
+  }
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: credentials,
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  const support = await gateway.supportMatrix(event(1), 'cloud:test')
+  assert.equal(support.find((entry) => entry.api === 'sessions.prompt')?.status, 'supported')
+  assert.equal(support.find((entry) => entry.api === 'workflows.run')?.status, 'blocked_by_policy')
+  assert.equal(support.find((entry) => entry.api === 'sessions.fileSnippet')?.status, 'not_supported')
+
+  assert.deepEqual(await gateway.listCloudSessions(event(1), 'cloud:test'), [{
+    id: 'cloud-session-1',
+    title: 'Cloud thread',
+    directory: null,
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }])
+  assert.equal((await gateway.createCloudSession(event(1), 'cloud:test')).id, 'cloud-session-2')
+  assert.equal((await gateway.getCloudSessionInfo(event(1), 'cloud-session-1', 'cloud:test'))?.id, 'cloud-session-1')
+  assert.equal((await gateway.getCloudSessionView(event(1), 'cloud-session-1', 'cloud:test')).messages.length, 0)
+  await gateway.promptCloudSession(event(1), 'cloud-session-1', { text: 'hello', agent: 'data-analyst' }, 'cloud:test')
+  await gateway.abortCloudSession(event(1), 'cloud-session-1', 'cloud:test')
+  await gateway.listCloudWorkflows(event(1), 'cloud:test')
+  await gateway.getCloudWorkflow(event(1), 'workflow-1', 'cloud:test')
+  await gateway.runCloudWorkflow(event(1), 'workflow-1', 'cloud:test')
+  await gateway.pauseCloudWorkflow(event(1), 'workflow-1', 'cloud:test')
+  await gateway.resumeCloudWorkflow(event(1), 'workflow-1', 'cloud:test')
+  await gateway.archiveCloudWorkflow(event(1), 'workflow-1', 'cloud:test')
+  await gateway.searchCloudThreads(event(1), {}, 'cloud:test')
+  await gateway.cloudThreadFacets(event(1), {}, 'cloud:test')
+  await gateway.listCloudThreadTags(event(1), 'cloud:test')
+  await gateway.createCloudThreadTag(event(1), { name: 'Important' }, 'cloud:test')
+  await gateway.updateCloudThreadTag(event(1), 'tag-1', { name: 'Renamed' }, 'cloud:test')
+  await gateway.applyCloudThreadTags(event(1), ['cloud-session-1'], ['tag-1'], 'cloud:test')
+  await gateway.removeCloudThreadTags(event(1), ['cloud-session-1'], ['tag-1'], 'cloud:test')
+  await gateway.deleteCloudThreadTag(event(1), 'tag-1', 'cloud:test')
+  await gateway.listCloudThreadSmartFilters(event(1), 'cloud:test')
+  await gateway.createCloudThreadSmartFilter(event(1), { name: 'Mine', query: {} }, 'cloud:test')
+  await gateway.updateCloudThreadSmartFilter(event(1), 'filter-1', { name: 'Updated', query: {} }, 'cloud:test')
+  await gateway.deleteCloudThreadSmartFilter(event(1), 'filter-1', 'cloud:test')
+  assert.equal((await gateway.listCloudArtifacts(event(1), 'cloud-session-1', 'cloud:test'))[0]?.cloudArtifactId, 'artifact-1')
+  assert.equal((await gateway.uploadCloudArtifact(event(1), {
+    sessionId: 'cloud-session-1',
+    filename: 'upload.txt',
+    contentType: 'text/plain',
+    dataBase64: Buffer.from('hello').toString('base64'),
+  }, 'cloud:test')).cloudArtifactId, 'artifact-2')
+  assert.equal((await gateway.readCloudArtifactAttachment(event(1), 'cloud-session-1', 'cloud-artifact://artifact-1/result.txt', 'cloud:test')).filename, 'result.txt')
+  assert.equal((await gateway.listCloudCapabilityTools(event(1), 'cloud:test'))[0]?.id, 'read')
+  assert.equal((await gateway.getCloudCapabilityTool(event(1), 'read', 'cloud:test'))?.name, 'Read')
+  assert.equal((await gateway.listCloudCapabilitySkills(event(1), 'cloud:test'))[0]?.name, 'analysis')
+  assert.equal((await gateway.getCloudCapabilitySkillBundle(event(1), 'analysis', 'cloud:test'))?.name, 'analysis')
+  assert.equal(await gateway.readCloudCapabilitySkillBundleFile(event(1), 'analysis', 'examples/report.md', 'cloud:test'), 'report example')
+  assert.equal((await gateway.listCloudSettings(event(1), 'cloud:test'))[0]?.key, 'portable-settings')
+  assert.equal((await gateway.getCloudSetting(event(1), 'portable-settings', 'cloud:test'))?.value.selectedProviderId, 'anthropic')
+  assert.equal((await gateway.setCloudSetting(event(1), 'portable-settings', { selectedProviderId: 'openai' }, 'cloud:test')).value.selectedProviderId, 'openai')
+
+  assert.deepEqual(calls, [
+    'list',
+    'create',
+    'get:cloud-session-1',
+    'view:cloud-session-1',
+    'prompt:cloud-session-1:hello:data-analyst',
+    'abort:cloud-session-1',
+    'workflows:list',
+    'workflows:get:workflow-1',
+    'workflows:run:workflow-1',
+    'workflows:pause:workflow-1',
+    'workflows:resume:workflow-1',
+    'workflows:archive:workflow-1',
+    'threads:search',
+    'threads:facets',
+    'threads:tags:list',
+    'threads:tags:create:Important',
+    'threads:tags:update:tag-1:Renamed',
+    'threads:tags:apply:cloud-session-1:tag-1',
+    'threads:tags:remove:cloud-session-1:tag-1',
+    'threads:tags:delete:tag-1',
+    'threads:filters:list',
+    'threads:filters:create:Mine',
+    'threads:filters:update:filter-1:Updated',
+    'threads:filters:delete:filter-1',
+    'artifacts:list:cloud-session-1',
+    'artifacts:upload:cloud-session-1:upload.txt',
+    'artifacts:read:cloud-session-1:cloud-artifact://artifact-1/result.txt',
+    'capabilities:tools',
+    'capabilities:tool:read',
+    'capabilities:skills',
+    'capabilities:skill-bundle:analysis',
+    'capabilities:skill-file:analysis:examples/report.md',
+    'settings:list',
+    'settings:get:portable-settings',
+    'settings:set:portable-settings:openai',
+  ])
+})
+
+test('workspace gateway subscribes cloud workspace events once per sender', async () => {
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-events-')), 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  credentials.save({
+    workspaceId: 'cloud:test',
+    accessToken: 'cloud-access-token',
+    expiresAt: '2030-05-27T12:00:00.000Z',
+  })
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => ({
+      id: 'cloud-session-1',
+      title: 'Cloud session',
+      directory: null,
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }),
+    getSessionInfo: async () => null,
+    getSessionView: async () => ({
+      messages: [],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      lastInputTokens: 0,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 0,
+      lastEventAt: 0,
+      isGenerating: false,
+      isAwaitingPermission: false,
+      isAwaitingQuestion: false,
+    }),
+    promptSession: async () => undefined,
+    abortSession: async () => undefined,
+    subscribeWorkspaceEvents: (input) => {
+      calls.push(`subscribe:${input.afterSequence ?? 'cached'}`)
+      input.onEvent({
+        eventId: 'event-1',
+        sequence: 1,
+        sessionId: 'cloud-session-1',
+        type: 'session.created',
+        payload: {},
+      })
+      return { close() { calls.push('close') } }
+    },
+  }
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: credentials,
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Test Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+  let events = 0
+
+  await gateway.subscribeCloudWorkspaceEvents(event(1), {
+    workspaceId: 'cloud:test',
+    onEvent: () => { events += 1 },
+  })
+  await gateway.subscribeCloudWorkspaceEvents(event(1), {
+    workspaceId: 'cloud:test',
+    onEvent: () => { events += 1 },
+  })
+  await gateway.subscribeCloudWorkspaceEvents(event(2), {
+    workspaceId: 'cloud:test',
+    afterSequence: 5,
+    onEvent: () => { events += 1 },
+  })
+  gateway.remove(event(1), 'cloud:test')
+
+  assert.equal(events, 2)
+  assert.deepEqual(calls, ['subscribe:cached', 'subscribe:5', 'close', 'close'])
+})
+
+test('workspace gateway marks persisted cloud workspaces online when a usable token exists', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-token-'))
+  const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(root, 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' }, new Date('2026-05-27T10:00:00.000Z'))
+  credentials.save({
+    workspaceId: persisted.id,
+    accessToken: 'cloud-access-token',
+    expiresAt: '2030-05-27T12:00:00.000Z',
+  }, new Date('2026-05-27T10:00:00.000Z'))
+  let adapterToken: string | null | undefined
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: credentials,
+    cloudAdapterFactory: (_connection, accessToken) => {
+      adapterToken = accessToken
+      return {
+        policy: async () => ({
+          features: { sessions: true },
+          allowedAgents: null,
+          allowedTools: null,
+          allowedMcps: null,
+          localFiles: 'disabled',
+          localStdioMcps: 'disabled',
+          machineRuntimeConfig: 'disabled',
+        }),
+        listSessions: async () => [],
+        createSession: async () => ({
+          id: 'session-1',
+          title: 'Cloud session',
+          directory: null,
+          createdAt: '2026-05-27T10:00:00.000Z',
+          updatedAt: '2026-05-27T10:00:00.000Z',
+        }),
+        getSessionInfo: async () => null,
+        getSessionView: async () => ({
+          messages: [],
+          toolCalls: [],
+          taskRuns: [],
+          compactions: [],
+          pendingApprovals: [],
+          pendingQuestions: [],
+          errors: [],
+          todos: [],
+          executionPlan: [],
+          sessionCost: 0,
+          sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+          lastInputTokens: 0,
+          contextState: 'idle',
+          compactionCount: 0,
+          lastCompactedAt: null,
+          activeAgent: null,
+          lastItemWasTool: false,
+          revision: 0,
+          lastEventAt: 0,
+          isGenerating: false,
+          isAwaitingPermission: false,
+          isAwaitingQuestion: false,
+        }),
+        promptSession: async () => {},
+        abortSession: async () => {},
+      }
+    },
+  })
+
+  const workspace = gateway.list(event(1)).find((entry) => entry.id === persisted.id)
+  assert.equal(workspace?.status, 'online')
+  await gateway.createCloudSession(event(1), persisted.id)
+  assert.equal(adapterToken, 'cloud-access-token')
+  gateway.logout(event(1), persisted.id)
+  assert.equal(credentials.get(persisted.id), null)
+  assert.equal(gateway.list(event(1)).find((entry) => entry.id === persisted.id)?.status, 'auth_required')
+})
+
+test('workspace gateway login stores cloud tokens without exposing them in workspace info', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-login-'))
+  const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(root, 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' }, new Date('2026-05-27T10:00:00.000Z'))
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: credentials,
+    cloudLogin: async (connection) => {
+      assert.equal(connection.id, persisted.id)
+      return {
+        accessToken: 'access-token-1',
+        refreshToken: 'refresh-token-1',
+        expiresAt: '2030-05-27T12:00:00.000Z',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        profileName: 'default',
+      }
+    },
+  })
+
+  const workspace = await gateway.login(event(1), persisted.id)
+
+  assert.equal(workspace.status, 'online')
+  assert.equal(workspace.tenantId, 'tenant-1')
+  assert.equal(workspace.userId, 'user-1')
+  assert.equal(workspace.profileName, 'default')
+  assert.equal(Object.values(workspace as Record<string, unknown>).includes('access-token-1'), false)
+  assert.equal(credentials.get(persisted.id)?.accessToken, 'access-token-1')
+  assert.equal(registry.list()[0]?.tenantId, 'tenant-1')
+})
+
+test('workspace gateway refreshes expired cloud tokens before adapter calls', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-refresh-'))
+  const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(root, 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' }, new Date('2026-05-27T10:00:00.000Z'))
+  credentials.save({
+    workspaceId: persisted.id,
+    accessToken: 'expired-access-token',
+    refreshToken: 'refresh-token-1',
+    expiresAt: '2026-05-27T10:00:00.000Z',
+  }, new Date('2026-05-27T10:00:00.000Z'))
+  let adapterToken: string | null | undefined
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: credentials,
+    cloudRefresh: async (_connection, refreshToken) => {
+      assert.equal(refreshToken, 'refresh-token-1')
+      return {
+        accessToken: 'fresh-access-token',
+        refreshToken: 'refresh-token-2',
+        expiresAt: '2030-05-27T12:00:00.000Z',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      }
+    },
+    cloudAdapterFactory: (_connection, accessToken) => {
+      adapterToken = accessToken
+      return {
+        policy: async () => ({
+          features: { sessions: true },
+          allowedAgents: null,
+          allowedTools: null,
+          allowedMcps: null,
+          localFiles: 'disabled',
+          localStdioMcps: 'disabled',
+          machineRuntimeConfig: 'disabled',
+        }),
+        listSessions: async () => [],
+        createSession: async () => ({
+          id: 'session-1',
+          title: 'Cloud session',
+          directory: null,
+          createdAt: '2026-05-27T10:00:00.000Z',
+          updatedAt: '2026-05-27T10:00:00.000Z',
+        }),
+        getSessionInfo: async () => null,
+        getSessionView: async () => ({
+          messages: [],
+          toolCalls: [],
+          taskRuns: [],
+          compactions: [],
+          pendingApprovals: [],
+          pendingQuestions: [],
+          errors: [],
+          todos: [],
+          executionPlan: [],
+          sessionCost: 0,
+          sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+          lastInputTokens: 0,
+          contextState: 'idle',
+          compactionCount: 0,
+          lastCompactedAt: null,
+          activeAgent: null,
+          lastItemWasTool: false,
+          revision: 0,
+          lastEventAt: 0,
+          isGenerating: false,
+          isAwaitingPermission: false,
+          isAwaitingQuestion: false,
+        }),
+        promptSession: async () => {},
+        abortSession: async () => {},
+      }
+    },
+  })
+
+  const syncResult = await gateway.sync(event(1), persisted.id)
+
+  assert.equal(syncResult.ok, true)
+  assert.equal(adapterToken, 'fresh-access-token')
+  assert.equal(credentials.get(persisted.id)?.accessToken, 'fresh-access-token')
+  assert.equal(credentials.get(persisted.id)?.refreshToken, 'refresh-token-2')
+  assert.equal(gateway.list(event(1)).find((entry) => entry.id === persisted.id)?.status, 'online')
+})
+
+test('workspace option reader accepts optional workspace id only from objects', () => {
+  assert.equal(readWorkspaceIdOption(undefined), null)
+  assert.equal(readWorkspaceIdOption({ variant: 'fast' }), null)
+  assert.equal(readWorkspaceIdOption({ workspaceId: ' local ' }), 'local')
+  assert.throws(() => readWorkspaceIdOption('local'), /must be an object/)
+})


### PR DESCRIPTION
## Summary
- Adds workspace-scoped local/cloud desktop routing with workspace IPC/preload APIs, a sidebar selector, and renderer state isolation.
- Adds cloud desktop auth, secure token/connection storage, a cloud adapter/cache, durable workspace event replay, full cloud SessionView projection, and policy-gated synced product surfaces.
- Fixes review issues: bearer-auth SSE via fetch streaming, no cached session cursor resume before hydration, HTTPS-only cloud URLs except localhost, and auth-required login from the sidebar.

## Verification
- node --no-warnings --experimental-strip-types --test tests/cloud-transport-adapter.test.ts tests/cloud-workspace-adapter.test.ts tests/cloud-workspace-registry.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- src/renderer/components/layout/Sidebar.test.tsx
- pnpm --filter @open-cowork/desktop typecheck
- pnpm lint
- pnpm test
- git diff --check
- pnpm typecheck
- pnpm test:e2e