### PR TITLE
Implement headless channel control plane

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -321,6 +321,7 @@ export function createApiTokenCloudAuthResolver(store: ControlPlaneStore): Cloud
       role: membership.membership.role,
       authSource: 'api_token',
       tokenId: record.tokenId,
+      tokenScopes: record.scopes,
     }
   }
 }

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -16,6 +16,15 @@ export type ControlPlaneSessionStatus = 'idle' | 'running' | 'closed' | 'errored
 export type ControlPlaneCommandKind = 'prompt' | 'abort' | 'permission.respond' | 'question.reply' | 'question.reject'
 export type ControlPlaneCommandStatus = 'pending' | 'running' | 'acked' | 'failed'
 export type WorkerRole = 'all-in-one' | 'web' | 'worker' | 'scheduler'
+export type ChannelProviderId = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
+export type HeadlessAgentStatus = 'active' | 'disabled'
+export type ChannelBindingStatus = 'active' | 'disabled' | 'auth_required' | 'error'
+export type ChannelIdentityRole = ControlPlaneRole | 'approver' | 'viewer'
+export type ChannelIdentityStatus = 'active' | 'disabled' | 'pending'
+export type ChannelSessionBindingStatus = 'active' | 'archived'
+export type ChannelInteractionKind = 'permission' | 'question'
+export type ChannelInteractionStatus = 'pending' | 'used' | 'expired' | 'revoked'
+export type ChannelDeliveryStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead'
 
 export type TenantRecord = {
   tenantId: string
@@ -96,6 +105,108 @@ export type AuditEventRecord = {
   targetId: string | null
   metadata: Record<string, unknown>
   createdAt: string
+}
+
+export type HeadlessAgentRecord = {
+  agentId: string
+  orgId: string
+  tenantId: string
+  profileName: string
+  name: string
+  status: HeadlessAgentStatus
+  managed: boolean
+  createdByAccountId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelBindingRecord = {
+  bindingId: string
+  orgId: string
+  agentId: string
+  provider: ChannelProviderId
+  externalWorkspaceId: string | null
+  displayName: string
+  status: ChannelBindingStatus
+  credentialRef: string | null
+  settings: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelIdentityRecord = {
+  identityId: string
+  orgId: string
+  provider: ChannelProviderId
+  externalWorkspaceId: string | null
+  externalUserId: string
+  accountId: string | null
+  role: ChannelIdentityRole
+  status: ChannelIdentityStatus
+  metadata: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelSessionBindingRecord = {
+  bindingId: string
+  orgId: string
+  agentId: string
+  channelBindingId: string
+  provider: ChannelProviderId
+  externalWorkspaceId: string | null
+  externalThreadId: string
+  externalChatId: string
+  sessionId: string
+  lastEventSequence: number
+  lastWorkspaceSequence: number
+  lastChatMessageId: string | null
+  status: ChannelSessionBindingStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelInteractionRecord = {
+  interactionId: string
+  orgId: string
+  agentId: string
+  sessionId: string
+  provider: ChannelProviderId
+  externalInteractionId: string | null
+  tokenHash: string
+  kind: ChannelInteractionKind
+  targetId: string
+  status: ChannelInteractionStatus
+  createdByIdentityId: string | null
+  expiresAt: string
+  usedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type IssuedChannelInteractionRecord = {
+  interaction: ChannelInteractionRecord
+  plaintextToken: string
+}
+
+export type ChannelDeliveryRecord = {
+  deliveryId: string
+  orgId: string
+  agentId: string
+  channelBindingId: string
+  sessionBindingId: string | null
+  provider: ChannelProviderId
+  target: Record<string, unknown>
+  eventType: string
+  payload: Record<string, unknown>
+  status: ChannelDeliveryStatus
+  attemptCount: number
+  claimedBy: string | null
+  claimExpiresAt: string | null
+  nextAttemptAt: string
+  lastError: string | null
+  createdAt: string
+  updatedAt: string
 }
 
 export type SessionRecord = {
@@ -314,6 +425,154 @@ export type RecordAuditEventInput = {
   createdAt?: Date
 }
 
+export type CreateHeadlessAgentInput = {
+  agentId: string
+  orgId: string
+  tenantId: string
+  profileName: string
+  name: string
+  status?: HeadlessAgentStatus
+  managed?: boolean
+  createdByAccountId?: string | null
+  createdAt?: Date
+}
+
+export type UpdateHeadlessAgentInput = {
+  orgId: string
+  agentId: string
+  profileName?: string
+  name?: string
+  status?: HeadlessAgentStatus
+  managed?: boolean
+  updatedAt?: Date
+}
+
+export type CreateChannelBindingInput = {
+  bindingId: string
+  orgId: string
+  agentId: string
+  provider: ChannelProviderId
+  externalWorkspaceId?: string | null
+  displayName: string
+  status?: ChannelBindingStatus
+  credentialRef?: string | null
+  settings?: Record<string, unknown>
+  createdAt?: Date
+}
+
+export type UpdateChannelBindingInput = {
+  orgId: string
+  bindingId: string
+  displayName?: string
+  status?: ChannelBindingStatus
+  credentialRef?: string | null
+  settings?: Record<string, unknown>
+  updatedAt?: Date
+}
+
+export type UpsertChannelIdentityInput = {
+  identityId?: string
+  orgId: string
+  provider: ChannelProviderId
+  externalWorkspaceId?: string | null
+  externalUserId: string
+  accountId?: string | null
+  role?: ChannelIdentityRole
+  status?: ChannelIdentityStatus
+  metadata?: Record<string, unknown>
+  updatedAt?: Date
+}
+
+export type BindChannelSessionInput = {
+  bindingId: string
+  orgId: string
+  agentId: string
+  channelBindingId: string
+  provider: ChannelProviderId
+  externalWorkspaceId?: string | null
+  externalThreadId: string
+  externalChatId: string
+  sessionId: string
+  lastEventSequence?: number
+  lastWorkspaceSequence?: number
+  lastChatMessageId?: string | null
+  status?: ChannelSessionBindingStatus
+  createdAt?: Date
+}
+
+export type UpdateChannelCursorInput = {
+  orgId: string
+  bindingId: string
+  lastEventSequence: number
+  lastWorkspaceSequence: number
+  lastChatMessageId?: string | null
+  updatedAt?: Date
+}
+
+export type CreateChannelInteractionInput = {
+  interactionId: string
+  orgId: string
+  agentId: string
+  sessionId: string
+  provider: ChannelProviderId
+  externalInteractionId?: string | null
+  kind: ChannelInteractionKind
+  targetId: string
+  createdByIdentityId?: string | null
+  expiresAt: Date
+  tokenSecret?: string
+  createdAt?: Date
+}
+
+export type ResolveChannelInteractionInput = {
+  orgId: string
+  token?: string | null
+  externalInteractionId?: string | null
+  provider?: ChannelProviderId | null
+  identityId: string
+  usedAt?: Date
+}
+
+export type FindChannelInteractionInput = Omit<ResolveChannelInteractionInput, 'identityId' | 'usedAt'> & {
+  now?: Date
+}
+
+export type ResolveChannelInteractionWithCommandInput = ResolveChannelInteractionInput & {
+  command: EnqueueCommandInput
+}
+
+export type CreateChannelDeliveryInput = {
+  deliveryId: string
+  orgId: string
+  agentId: string
+  channelBindingId: string
+  sessionBindingId?: string | null
+  provider: ChannelProviderId
+  target: Record<string, unknown>
+  eventType: string
+  payload: Record<string, unknown>
+  status?: ChannelDeliveryStatus
+  nextAttemptAt?: Date
+  createdAt?: Date
+}
+
+export type ClaimChannelDeliveryInput = {
+  orgId: string
+  claimedBy: string
+  now?: Date
+  ttlMs?: number
+}
+
+export type AckChannelDeliveryInput = {
+  orgId: string
+  deliveryId: string
+  claimedBy?: string | null
+  status: Extract<ChannelDeliveryStatus, 'sent' | 'failed' | 'dead'>
+  lastError?: string | null
+  nextAttemptAt?: Date | null
+  updatedAt?: Date
+}
+
 export type AppendEventInput = {
   tenantId: string
   sessionId: string
@@ -480,6 +739,43 @@ export type ControlPlaneStore = {
   revokeApiToken(input: RevokeApiTokenInput): MaybePromise<ApiTokenRecord | null>
   recordAuditEvent(input: RecordAuditEventInput): MaybePromise<AuditEventRecord>
   listAuditEvents(orgId: string, limit?: number): MaybePromise<AuditEventRecord[]>
+  createHeadlessAgent(input: CreateHeadlessAgentInput): MaybePromise<HeadlessAgentRecord>
+  updateHeadlessAgent(input: UpdateHeadlessAgentInput): MaybePromise<HeadlessAgentRecord | null>
+  getHeadlessAgent(orgId: string, agentId: string): MaybePromise<HeadlessAgentRecord | null>
+  listHeadlessAgents(orgId: string): MaybePromise<HeadlessAgentRecord[]>
+  createChannelBinding(input: CreateChannelBindingInput): MaybePromise<ChannelBindingRecord>
+  updateChannelBinding(input: UpdateChannelBindingInput): MaybePromise<ChannelBindingRecord | null>
+  getChannelBinding(orgId: string, bindingId: string): MaybePromise<ChannelBindingRecord | null>
+  listChannelBindings(orgId: string, agentId?: string | null): MaybePromise<ChannelBindingRecord[]>
+  upsertChannelIdentity(input: UpsertChannelIdentityInput): MaybePromise<ChannelIdentityRecord>
+  getChannelIdentity(orgId: string, identityId: string): MaybePromise<ChannelIdentityRecord | null>
+  findChannelIdentity(input: {
+    orgId: string
+    provider: ChannelProviderId
+    externalWorkspaceId?: string | null
+    externalUserId: string
+  }): MaybePromise<ChannelIdentityRecord | null>
+  bindChannelSession(input: BindChannelSessionInput): MaybePromise<ChannelSessionBindingRecord>
+  getChannelSessionBinding(orgId: string, bindingId: string): MaybePromise<ChannelSessionBindingRecord | null>
+  findChannelSessionBindingByThread(input: {
+    orgId: string
+    provider: ChannelProviderId
+    externalWorkspaceId?: string | null
+    externalChatId: string
+    externalThreadId: string
+  }): MaybePromise<ChannelSessionBindingRecord | null>
+  listChannelSessionBindingsForSession(orgId: string, sessionId: string): MaybePromise<ChannelSessionBindingRecord[]>
+  updateChannelCursor(input: UpdateChannelCursorInput): MaybePromise<ChannelSessionBindingRecord | null>
+  createChannelInteraction(input: CreateChannelInteractionInput): MaybePromise<IssuedChannelInteractionRecord>
+  findChannelInteraction(input: FindChannelInteractionInput): MaybePromise<ChannelInteractionRecord | null>
+  resolveChannelInteraction(input: ResolveChannelInteractionInput): MaybePromise<ChannelInteractionRecord | null>
+  resolveChannelInteractionWithCommand(input: ResolveChannelInteractionWithCommandInput): MaybePromise<{
+    interaction: ChannelInteractionRecord
+    command: SessionCommandRecord
+  } | null>
+  createChannelDelivery(input: CreateChannelDeliveryInput): MaybePromise<ChannelDeliveryRecord>
+  claimNextChannelDelivery(input: ClaimChannelDeliveryInput): MaybePromise<ChannelDeliveryRecord | null>
+  ackChannelDelivery(input: AckChannelDeliveryInput): MaybePromise<ChannelDeliveryRecord | null>
   createSession(input: CreateSessionInput): MaybePromise<SessionRecord>
   getSession(tenantId: string, userId: string, sessionId: string): MaybePromise<SessionRecord | null>
   getSessionForTenant(tenantId: string, sessionId: string): MaybePromise<SessionRecord | null>
@@ -577,6 +873,9 @@ const THREAD_FILTER_MAX_VALUES = 50
 const THREAD_BULK_MAX_SESSION_IDS = 500
 const SMART_FILTER_QUERY_MAX_BYTES = 16_384
 const WORKFLOW_RUN_LIST_LIMIT = 100
+const CHANNEL_TEXT_MAX_LENGTH = 256
+const CHANNEL_METADATA_MAX_BYTES = 16_384
+const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
 
 function nowIso(now: Date | undefined) {
   return (now || new Date()).toISOString()
@@ -590,6 +889,10 @@ export function hashCloudApiToken(plaintext: string) {
   return `scrypt:${scryptSync(plaintext, 'open-cowork-cloud-api-token-hash-v1', 32).toString('base64url')}`
 }
 
+export function hashChannelInteractionToken(plaintext: string) {
+  return `scrypt:${scryptSync(plaintext, 'open-cowork-channel-interaction-token-v1', 32).toString('base64url')}`
+}
+
 export function generateCloudApiToken(input: { tokenId?: string, secret?: string } = {}) {
   const tokenId = input.tokenId || `tok_${randomBytes(12).toString('base64url')}`
   const secret = input.secret || randomBytes(32).toString('base64url')
@@ -597,6 +900,11 @@ export function generateCloudApiToken(input: { tokenId?: string, secret?: string
     tokenId,
     plaintext: `occ_${tokenId}_${secret}`,
   }
+}
+
+export function generateChannelInteractionToken(input: { interactionId: string, secret?: string }) {
+  const secret = input.secret || randomBytes(24).toString('base64url')
+  return `occi_${input.interactionId}_${secret}`
 }
 
 function constantTimeStringEquals(left: string, right: string) {
@@ -687,6 +995,52 @@ function normalizeThreadQuery(value: unknown) {
   return query
 }
 
+function normalizeRecord(value: unknown, label: string, maxBytes = CHANNEL_METADATA_MAX_BYTES): Record<string, unknown> {
+  const record = value && typeof value === 'object' && !Array.isArray(value)
+    ? clone(value as Record<string, unknown>)
+    : {}
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function normalizeNullableText(value: unknown, maxLength: number, label: string): string | null {
+  if (value === undefined || value === null || value === '') return null
+  return normalizeText(value, maxLength, label)
+}
+
+function normalizeNonNegativeInteger(value: unknown, label: string) {
+  const parsed = Number(value ?? 0)
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${label} must be a non-negative integer.`)
+  return parsed
+}
+
+function normalizeProvider(value: unknown): ChannelProviderId {
+  const provider = normalizeText(value, 32, 'Channel provider') as ChannelProviderId
+  if (!['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(provider)) {
+    throw new Error(`Unsupported channel provider ${provider}.`)
+  }
+  return provider
+}
+
+function normalizeChannelIdentityRole(value: unknown): ChannelIdentityRole {
+  const role = normalizeText(value || 'viewer', 32, 'Channel identity role') as ChannelIdentityRole
+  if (!['owner', 'admin', 'member', 'approver', 'viewer'].includes(role)) {
+    throw new Error(`Unsupported channel identity role ${role}.`)
+  }
+  return role
+}
+
+function channelScopeKey(provider: ChannelProviderId, externalWorkspaceId: string | null, externalId: string) {
+  return key(provider, externalWorkspaceId || '', externalId)
+}
+
+function channelThreadKey(provider: ChannelProviderId, externalWorkspaceId: string | null, externalChatId: string, externalThreadId: string) {
+  return key(provider, externalWorkspaceId || '', externalChatId, externalThreadId)
+}
+
 export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly tenants = new Map<string, TenantRecord>()
   private readonly users = new Map<string, UserRecord>()
@@ -698,6 +1052,16 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly memberships = new Map<string, MembershipRecord>()
   private readonly apiTokens = new Map<string, ApiTokenRecord>()
   private readonly auditEvents = new Map<string, AuditEventRecord>()
+  private readonly headlessAgents = new Map<string, HeadlessAgentRecord>()
+  private readonly channelBindings = new Map<string, ChannelBindingRecord>()
+  private readonly channelIdentities = new Map<string, ChannelIdentityRecord>()
+  private readonly channelIdentitiesByExternal = new Map<string, string>()
+  private readonly channelSessionBindings = new Map<string, ChannelSessionBindingRecord>()
+  private readonly channelSessionBindingsByThread = new Map<string, string>()
+  private readonly channelInteractions = new Map<string, ChannelInteractionRecord>()
+  private readonly channelInteractionsByTokenHash = new Map<string, string>()
+  private readonly channelInteractionsByExternal = new Map<string, string>()
+  private readonly channelDeliveries = new Map<string, ChannelDeliveryRecord>()
   private readonly sessions = new Map<string, SessionState>()
   private readonly heartbeats = new Map<string, WorkerHeartbeatRecord>()
   private readonly settings = new Map<string, SettingMetadataRecord>()
@@ -955,6 +1319,409 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
       .slice(0, limit)
       .map((event) => clone(event))
+  }
+
+  createHeadlessAgent(input: CreateHeadlessAgentInput): HeadlessAgentRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    this.requireTenant(input.tenantId)
+    if (input.createdByAccountId && !this.accounts.has(input.createdByAccountId)) {
+      throw new Error(`Unknown account ${input.createdByAccountId}.`)
+    }
+    const existing = this.headlessAgents.get(input.agentId)
+    if (existing) return clone(existing)
+    const now = nowIso(input.createdAt)
+    const record: HeadlessAgentRecord = {
+      agentId: normalizeText(input.agentId, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent id'),
+      orgId: input.orgId,
+      tenantId: input.tenantId,
+      profileName: normalizeText(input.profileName, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent profile'),
+      name: normalizeText(input.name, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent name'),
+      status: input.status || 'active',
+      managed: input.managed === true,
+      createdByAccountId: input.createdByAccountId || null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.headlessAgents.set(record.agentId, record)
+    this.recordAuditEvent({
+      orgId: record.orgId,
+      accountId: record.createdByAccountId,
+      actorType: 'system',
+      actorId: 'headless_agent.create',
+      eventType: 'headless_agent.created',
+      targetType: 'headless_agent',
+      targetId: record.agentId,
+      metadata: { name: record.name, profileName: record.profileName, managed: record.managed },
+      createdAt: input.createdAt,
+    })
+    return clone(record)
+  }
+
+  updateHeadlessAgent(input: UpdateHeadlessAgentInput): HeadlessAgentRecord | null {
+    const existing = this.headlessAgents.get(input.agentId)
+    if (!existing || existing.orgId !== input.orgId) return null
+    const updatedAt = nowIso(input.updatedAt)
+    existing.profileName = input.profileName === undefined ? existing.profileName : normalizeText(input.profileName, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent profile')
+    existing.name = input.name === undefined ? existing.name : normalizeText(input.name, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent name')
+    existing.status = input.status || existing.status
+    existing.managed = input.managed === undefined ? existing.managed : input.managed
+    existing.updatedAt = updatedAt
+    return clone(existing)
+  }
+
+  getHeadlessAgent(orgId: string, agentId: string): HeadlessAgentRecord | null {
+    const agent = this.headlessAgents.get(agentId)
+    return agent && agent.orgId === orgId ? clone(agent) : null
+  }
+
+  listHeadlessAgents(orgId: string): HeadlessAgentRecord[] {
+    return Array.from(this.headlessAgents.values())
+      .filter((agent) => agent.orgId === orgId)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.agentId.localeCompare(right.agentId))
+      .map((agent) => clone(agent))
+  }
+
+  createChannelBinding(input: CreateChannelBindingInput): ChannelBindingRecord {
+    const agent = this.headlessAgents.get(input.agentId)
+    if (!agent || agent.orgId !== input.orgId) throw new Error(`Unknown headless agent ${input.agentId}.`)
+    const existing = this.channelBindings.get(input.bindingId)
+    if (existing) return clone(existing)
+    const now = nowIso(input.createdAt)
+    const record: ChannelBindingRecord = {
+      bindingId: normalizeText(input.bindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding id'),
+      orgId: input.orgId,
+      agentId: input.agentId,
+      provider: normalizeProvider(input.provider),
+      externalWorkspaceId: normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id'),
+      displayName: normalizeText(input.displayName, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding name'),
+      status: input.status || 'active',
+      credentialRef: normalizeNullableText(input.credentialRef, CHANNEL_TEXT_MAX_LENGTH, 'Credential ref'),
+      settings: normalizeRecord(input.settings, 'Channel binding settings'),
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.channelBindings.set(record.bindingId, record)
+    this.recordAuditEvent({
+      orgId: record.orgId,
+      actorType: 'system',
+      actorId: 'channel_binding.create',
+      eventType: 'channel_binding.created',
+      targetType: 'channel_binding',
+      targetId: record.bindingId,
+      metadata: { provider: record.provider, displayName: record.displayName, credentialRef: record.credentialRef },
+      createdAt: input.createdAt,
+    })
+    return clone(record)
+  }
+
+  updateChannelBinding(input: UpdateChannelBindingInput): ChannelBindingRecord | null {
+    const existing = this.channelBindings.get(input.bindingId)
+    if (!existing || existing.orgId !== input.orgId) return null
+    existing.displayName = input.displayName === undefined ? existing.displayName : normalizeText(input.displayName, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding name')
+    existing.status = input.status || existing.status
+    existing.credentialRef = input.credentialRef === undefined ? existing.credentialRef : normalizeNullableText(input.credentialRef, CHANNEL_TEXT_MAX_LENGTH, 'Credential ref')
+    existing.settings = input.settings === undefined ? existing.settings : normalizeRecord(input.settings, 'Channel binding settings')
+    existing.updatedAt = nowIso(input.updatedAt)
+    return clone(existing)
+  }
+
+  getChannelBinding(orgId: string, bindingId: string): ChannelBindingRecord | null {
+    const binding = this.channelBindings.get(bindingId)
+    return binding && binding.orgId === orgId ? clone(binding) : null
+  }
+
+  listChannelBindings(orgId: string, agentId?: string | null): ChannelBindingRecord[] {
+    return Array.from(this.channelBindings.values())
+      .filter((binding) => binding.orgId === orgId && (!agentId || binding.agentId === agentId))
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.bindingId.localeCompare(right.bindingId))
+      .map((binding) => clone(binding))
+  }
+
+  upsertChannelIdentity(input: UpsertChannelIdentityInput): ChannelIdentityRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    if (input.accountId && !this.accounts.has(input.accountId)) throw new Error(`Unknown account ${input.accountId}.`)
+    const provider = normalizeProvider(input.provider)
+    const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id')
+    const externalUserId = normalizeText(input.externalUserId, CHANNEL_TEXT_MAX_LENGTH, 'External user id')
+    const externalKey = key(input.orgId, channelScopeKey(provider, externalWorkspaceId, externalUserId))
+    const existingId = this.channelIdentitiesByExternal.get(externalKey)
+    const existing = existingId ? this.channelIdentities.get(existingId) : null
+    const now = nowIso(input.updatedAt)
+    const record: ChannelIdentityRecord = {
+      identityId: existing?.identityId || input.identityId || stableId('chid', input.orgId, provider, externalWorkspaceId || '', externalUserId),
+      orgId: input.orgId,
+      provider,
+      externalWorkspaceId,
+      externalUserId,
+      accountId: input.accountId === undefined ? existing?.accountId || null : input.accountId || null,
+      role: input.role === undefined ? existing?.role || 'viewer' : normalizeChannelIdentityRole(input.role),
+      status: input.status || existing?.status || 'pending',
+      metadata: input.metadata === undefined ? existing?.metadata || {} : normalizeRecord(input.metadata, 'Channel identity metadata'),
+      createdAt: existing?.createdAt || now,
+      updatedAt: now,
+    }
+    this.channelIdentities.set(record.identityId, record)
+    this.channelIdentitiesByExternal.set(externalKey, record.identityId)
+    return clone(record)
+  }
+
+  getChannelIdentity(orgId: string, identityId: string): ChannelIdentityRecord | null {
+    const identity = this.channelIdentities.get(identityId)
+    return identity && identity.orgId === orgId ? clone(identity) : null
+  }
+
+  findChannelIdentity(input: { orgId: string, provider: ChannelProviderId, externalWorkspaceId?: string | null, externalUserId: string }): ChannelIdentityRecord | null {
+    const provider = normalizeProvider(input.provider)
+    const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id')
+    const externalUserId = normalizeText(input.externalUserId, CHANNEL_TEXT_MAX_LENGTH, 'External user id')
+    const identityId = this.channelIdentitiesByExternal.get(key(input.orgId, channelScopeKey(provider, externalWorkspaceId, externalUserId)))
+    return identityId ? clone(this.channelIdentities.get(identityId) || null) : null
+  }
+
+  bindChannelSession(input: BindChannelSessionInput): ChannelSessionBindingRecord {
+    const channelBinding = this.channelBindings.get(input.channelBindingId)
+    if (!channelBinding || channelBinding.orgId !== input.orgId) throw new Error(`Unknown channel binding ${input.channelBindingId}.`)
+    if (!this.headlessAgents.has(input.agentId)) throw new Error(`Unknown headless agent ${input.agentId}.`)
+    const provider = normalizeProvider(input.provider)
+    const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id')
+    const externalChatId = normalizeText(input.externalChatId, CHANNEL_TEXT_MAX_LENGTH, 'External chat id')
+    const externalThreadId = normalizeText(input.externalThreadId, CHANNEL_TEXT_MAX_LENGTH, 'External thread id')
+    const threadKey = key(input.orgId, channelThreadKey(provider, externalWorkspaceId, externalChatId, externalThreadId))
+    const existingId = this.channelSessionBindingsByThread.get(threadKey)
+    if (existingId) return clone(this.channelSessionBindings.get(existingId) as ChannelSessionBindingRecord)
+    const session = this.getSessionForTenant(this.orgs.get(input.orgId)?.tenantId || input.orgId, input.sessionId)
+    if (!session) throw new Error(`Unknown session ${input.sessionId}.`)
+    const now = nowIso(input.createdAt)
+    const record: ChannelSessionBindingRecord = {
+      bindingId: normalizeText(input.bindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel session binding id'),
+      orgId: input.orgId,
+      agentId: input.agentId,
+      channelBindingId: input.channelBindingId,
+      provider,
+      externalWorkspaceId,
+      externalThreadId,
+      externalChatId,
+      sessionId: input.sessionId,
+      lastEventSequence: normalizeNonNegativeInteger(input.lastEventSequence, 'Last event sequence'),
+      lastWorkspaceSequence: normalizeNonNegativeInteger(input.lastWorkspaceSequence, 'Last workspace sequence'),
+      lastChatMessageId: normalizeNullableText(input.lastChatMessageId, CHANNEL_TEXT_MAX_LENGTH, 'Last chat message id'),
+      status: input.status || 'active',
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.channelSessionBindings.set(record.bindingId, record)
+    this.channelSessionBindingsByThread.set(threadKey, record.bindingId)
+    this.recordAuditEvent({
+      orgId: record.orgId,
+      actorType: 'system',
+      actorId: 'channel_session.bind',
+      eventType: 'channel_session_bound',
+      targetType: 'channel_session_binding',
+      targetId: record.bindingId,
+      metadata: { provider: record.provider, sessionId: record.sessionId },
+      createdAt: input.createdAt,
+    })
+    return clone(record)
+  }
+
+  getChannelSessionBinding(orgId: string, bindingId: string): ChannelSessionBindingRecord | null {
+    const binding = this.channelSessionBindings.get(bindingId)
+    return binding && binding.orgId === orgId ? clone(binding) : null
+  }
+
+  findChannelSessionBindingByThread(input: { orgId: string, provider: ChannelProviderId, externalWorkspaceId?: string | null, externalChatId: string, externalThreadId: string }): ChannelSessionBindingRecord | null {
+    const provider = normalizeProvider(input.provider)
+    const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id')
+    const externalChatId = normalizeText(input.externalChatId, CHANNEL_TEXT_MAX_LENGTH, 'External chat id')
+    const externalThreadId = normalizeText(input.externalThreadId, CHANNEL_TEXT_MAX_LENGTH, 'External thread id')
+    const bindingId = this.channelSessionBindingsByThread.get(key(input.orgId, channelThreadKey(provider, externalWorkspaceId, externalChatId, externalThreadId)))
+    return bindingId ? clone(this.channelSessionBindings.get(bindingId) || null) : null
+  }
+
+  listChannelSessionBindingsForSession(orgId: string, sessionId: string): ChannelSessionBindingRecord[] {
+    return Array.from(this.channelSessionBindings.values())
+      .filter((binding) => binding.orgId === orgId && binding.sessionId === sessionId && binding.status === 'active')
+      .map((binding) => clone(binding))
+  }
+
+  updateChannelCursor(input: UpdateChannelCursorInput): ChannelSessionBindingRecord | null {
+    const existing = this.channelSessionBindings.get(input.bindingId)
+    if (!existing || existing.orgId !== input.orgId) return null
+    const lastEventSequence = normalizeNonNegativeInteger(input.lastEventSequence, 'Last event sequence')
+    const lastWorkspaceSequence = normalizeNonNegativeInteger(input.lastWorkspaceSequence, 'Last workspace sequence')
+    if (lastEventSequence < existing.lastEventSequence || lastWorkspaceSequence < existing.lastWorkspaceSequence) {
+      throw new Error('Channel cursor updates must be monotonic.')
+    }
+    existing.lastEventSequence = lastEventSequence
+    existing.lastWorkspaceSequence = lastWorkspaceSequence
+    if (input.lastChatMessageId !== undefined) {
+      existing.lastChatMessageId = normalizeNullableText(input.lastChatMessageId, CHANNEL_TEXT_MAX_LENGTH, 'Last chat message id')
+    }
+    existing.updatedAt = nowIso(input.updatedAt)
+    return clone(existing)
+  }
+
+  createChannelInteraction(input: CreateChannelInteractionInput): IssuedChannelInteractionRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    const plaintextToken = generateChannelInteractionToken({ interactionId: input.interactionId, secret: input.tokenSecret })
+    const tokenHash = hashChannelInteractionToken(plaintextToken)
+    const existing = this.channelInteractions.get(input.interactionId)
+    if (existing) throw new Error(`Channel interaction ${input.interactionId} already exists.`)
+    const now = nowIso(input.createdAt)
+    const record: ChannelInteractionRecord = {
+      interactionId: normalizeText(input.interactionId, CHANNEL_TEXT_MAX_LENGTH, 'Channel interaction id'),
+      orgId: input.orgId,
+      agentId: normalizeText(input.agentId, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent id'),
+      sessionId: normalizeText(input.sessionId, CHANNEL_TEXT_MAX_LENGTH, 'Session id'),
+      provider: normalizeProvider(input.provider),
+      externalInteractionId: normalizeNullableText(input.externalInteractionId, CHANNEL_TEXT_MAX_LENGTH, 'External interaction id'),
+      tokenHash,
+      kind: input.kind,
+      targetId: normalizeText(input.targetId, CHANNEL_TEXT_MAX_LENGTH, 'Interaction target id'),
+      status: 'pending',
+      createdByIdentityId: input.createdByIdentityId || null,
+      expiresAt: input.expiresAt.toISOString(),
+      usedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.channelInteractions.set(record.interactionId, record)
+    this.channelInteractionsByTokenHash.set(record.tokenHash, record.interactionId)
+    if (record.externalInteractionId) {
+      this.channelInteractionsByExternal.set(key(record.orgId, record.provider, record.externalInteractionId), record.interactionId)
+    }
+    return { interaction: clone(record), plaintextToken }
+  }
+
+  private findChannelInteractionMutable(input: FindChannelInteractionInput): ChannelInteractionRecord | null {
+    const tokenHash = input.token ? hashChannelInteractionToken(input.token) : null
+    const interactionId = tokenHash
+      ? this.channelInteractionsByTokenHash.get(tokenHash)
+      : input.externalInteractionId && input.provider
+        ? this.channelInteractionsByExternal.get(key(input.orgId, input.provider, input.externalInteractionId))
+        : undefined
+    const interaction = interactionId ? this.channelInteractions.get(interactionId) : null
+    if (!interaction || interaction.orgId !== input.orgId) return null
+    const now = input.now || new Date()
+    if (interaction.status !== 'pending') return null
+    if (new Date(interaction.expiresAt).getTime() <= now.getTime()) {
+      interaction.status = 'expired'
+      interaction.updatedAt = now.toISOString()
+      return null
+    }
+    return interaction
+  }
+
+  findChannelInteraction(input: FindChannelInteractionInput): ChannelInteractionRecord | null {
+    const interaction = this.findChannelInteractionMutable(input)
+    return interaction ? clone(interaction) : null
+  }
+
+  resolveChannelInteraction(input: ResolveChannelInteractionInput): ChannelInteractionRecord | null {
+    const now = input.usedAt || new Date()
+    const interaction = this.findChannelInteractionMutable({ ...input, now })
+    if (!interaction) return null
+    interaction.status = 'used'
+    interaction.usedAt = now.toISOString()
+    interaction.updatedAt = interaction.usedAt
+    this.recordAuditEvent({
+      orgId: interaction.orgId,
+      actorType: 'system',
+      actorId: input.identityId,
+      eventType: 'channel_interaction.used',
+      targetType: 'channel_interaction',
+      targetId: interaction.interactionId,
+      metadata: { kind: interaction.kind, targetId: interaction.targetId, tokenHash: interaction.tokenHash },
+      createdAt: now,
+    })
+    return clone(interaction)
+  }
+
+  resolveChannelInteractionWithCommand(input: ResolveChannelInteractionWithCommandInput): {
+    interaction: ChannelInteractionRecord
+    command: SessionCommandRecord
+  } | null {
+    const now = input.usedAt || new Date()
+    const interaction = this.findChannelInteractionMutable({ ...input, now })
+    if (!interaction) return null
+    if (input.command.sessionId !== interaction.sessionId) throw new Error('Channel interaction command session does not match interaction session.')
+    const command = this.enqueueSessionCommand(input.command)
+    interaction.status = 'used'
+    interaction.usedAt = now.toISOString()
+    interaction.updatedAt = interaction.usedAt
+    this.recordAuditEvent({
+      orgId: interaction.orgId,
+      actorType: 'system',
+      actorId: input.identityId,
+      eventType: 'channel_interaction.used',
+      targetType: 'channel_interaction',
+      targetId: interaction.interactionId,
+      metadata: { kind: interaction.kind, targetId: interaction.targetId },
+      createdAt: now,
+    })
+    return { interaction: clone(interaction), command }
+  }
+
+  createChannelDelivery(input: CreateChannelDeliveryInput): ChannelDeliveryRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    const existing = this.channelDeliveries.get(input.deliveryId)
+    if (existing) return clone(existing)
+    const now = nowIso(input.createdAt)
+    const record: ChannelDeliveryRecord = {
+      deliveryId: normalizeText(input.deliveryId, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery id'),
+      orgId: input.orgId,
+      agentId: normalizeText(input.agentId, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent id'),
+      channelBindingId: normalizeText(input.channelBindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding id'),
+      sessionBindingId: normalizeNullableText(input.sessionBindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel session binding id'),
+      provider: normalizeProvider(input.provider),
+      target: normalizeRecord(input.target, 'Channel delivery target'),
+      eventType: normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery event type'),
+      payload: normalizeRecord(input.payload, 'Channel delivery payload'),
+      status: input.status || 'pending',
+      attemptCount: 0,
+      claimedBy: null,
+      claimExpiresAt: null,
+      nextAttemptAt: (input.nextAttemptAt || input.createdAt || new Date()).toISOString(),
+      lastError: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.channelDeliveries.set(record.deliveryId, record)
+    return clone(record)
+  }
+
+  claimNextChannelDelivery(input: ClaimChannelDeliveryInput): ChannelDeliveryRecord | null {
+    const now = input.now || new Date()
+    const nowMs = now.getTime()
+    const candidate = Array.from(this.channelDeliveries.values())
+      .filter((delivery) => delivery.orgId === input.orgId)
+      .filter((delivery) => (
+        (delivery.status === 'pending' && new Date(delivery.nextAttemptAt).getTime() <= nowMs)
+        || (delivery.status === 'failed' && new Date(delivery.nextAttemptAt).getTime() <= nowMs)
+        || (delivery.status === 'claimed' && delivery.claimExpiresAt && new Date(delivery.claimExpiresAt).getTime() <= nowMs)
+      ))
+      .sort((left, right) => left.nextAttemptAt.localeCompare(right.nextAttemptAt) || left.createdAt.localeCompare(right.createdAt))[0]
+    if (!candidate) return null
+    candidate.status = 'claimed'
+    candidate.claimedBy = normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery claimant')
+    candidate.claimExpiresAt = new Date(nowMs + (input.ttlMs || 30_000)).toISOString()
+    candidate.attemptCount += 1
+    candidate.updatedAt = now.toISOString()
+    return clone(candidate)
+  }
+
+  ackChannelDelivery(input: AckChannelDeliveryInput): ChannelDeliveryRecord | null {
+    const delivery = this.channelDeliveries.get(input.deliveryId)
+    if (!delivery || delivery.orgId !== input.orgId) return null
+    if (input.claimedBy && delivery.claimedBy !== input.claimedBy) return null
+    const updatedAt = nowIso(input.updatedAt)
+    delivery.status = input.status
+    delivery.claimedBy = null
+    delivery.claimExpiresAt = null
+    delivery.lastError = input.lastError ? normalizeText(input.lastError, CHANNEL_DELIVERY_ERROR_MAX_LENGTH, 'Delivery error') : null
+    delivery.nextAttemptAt = (input.nextAttemptAt || input.updatedAt || new Date()).toISOString()
+    delivery.updatedAt = updatedAt
+    return clone(delivery)
   }
 
   createSession(input: CreateSessionInput): SessionRecord {

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -4,11 +4,12 @@ import type { AddressInfo } from 'node:net'
 import type { WorkflowDraft, WorkflowStatus, WorkflowTriggerType } from '@open-cowork/shared'
 import type { CloudArtifactService } from './artifact-service.ts'
 import { cloudBrowserAppHtml } from './browser-app.ts'
-import type { CloudPrincipal, CloudSessionService } from './session-service.ts'
+import { CloudServiceError, type CloudPrincipal, type CloudSessionService } from './session-service.ts'
 import { cloudSessionViewToSessionView } from './session-view-contract.ts'
 import type { CloudWorker } from './worker.ts'
 import type { CloudRuntimePolicy } from './cloud-config.ts'
 import type { CloudObservabilityAdapter } from './observability.ts'
+import type { ChannelProviderId } from './control-plane-store.ts'
 import { recordCloudHttpRequest } from './observability.ts'
 import type { CloudCookieSession, CloudSessionCookieManager } from './session-cookie-auth.ts'
 import {
@@ -256,6 +257,34 @@ function parseLimit(url: URL) {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
 }
 
+function readNonNegativeInteger(value: unknown, fallback = 0) {
+  const parsed = Number(value ?? fallback)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+function readOptionalDate(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date : null
+}
+
+function readEnum<T extends string>(value: unknown, allowed: readonly T[]): T | undefined {
+  const raw = readString(value)
+  return raw && (allowed as readonly string[]).includes(raw) ? raw as T : undefined
+}
+
+function readChannelProvider(value: unknown): ChannelProviderId | undefined {
+  return readEnum(value, ['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'] as const)
+}
+
+function principalHasGatewayAccess(principal: CloudPrincipal) {
+  if (principal.authSource === 'local' || principal.authSource === 'header') return true
+  if (principal.authSource === 'api_token') {
+    return principal.tokenScopes?.includes('gateway') || principal.tokenScopes?.includes('admin') || false
+  }
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
 function parseTagIds(url: URL) {
   const repeated = url.searchParams.getAll('tagId')
   const csv = url.searchParams.get('tagIds')?.split(',') || []
@@ -305,6 +334,20 @@ function writeSseEvent(res: ServerResponse, event: {
   res.write(`id: ${event.sequence}\n`)
   res.write(`event: ${event.type}\n`)
   res.write(`data: ${JSON.stringify(event)}\n\n`)
+}
+
+function writeChannelDeliverySseEvent(res: ServerResponse, delivery: unknown) {
+  const record = readRecord(delivery) || {}
+  const deliveryId = readString(record.deliveryId) || 'delivery'
+  res.write(`id: ${deliveryId}\n`)
+  res.write('event: channel.delivery\n')
+  res.write(`data: ${JSON.stringify({ delivery })}\n\n`)
+}
+
+function publicChannelInteraction(value: unknown) {
+  const record = { ...(readRecord(value) || {}) }
+  delete record.tokenHash
+  return record
 }
 
 function writeSnapshotRequiredEvent(
@@ -554,6 +597,58 @@ async function handleWorkspaceSse(
   req.on('close', () => {
     clearInterval(pollTimer)
     unsubscribe()
+  })
+}
+
+async function handleChannelDeliveriesSse(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: CloudHttpServerOptions,
+  context: RouteContext,
+) {
+  if (!principalHasGatewayAccess(context.principal)) {
+    writeError(res, 403, 'Gateway channel access requires a gateway-scoped API token.', options.corsOrigin)
+    return
+  }
+  writeCorsHeaders(res, options.corsOrigin)
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-store',
+    connection: 'keep-alive',
+  })
+  const claimedBy = context.url.searchParams.get('claimedBy') || context.principal.tokenId || context.principal.userId || 'gateway'
+  const ttlMsRaw = Number(context.url.searchParams.get('ttlMs') || 30_000)
+  const ttlMs = Number.isInteger(ttlMsRaw) && ttlMsRaw > 0 ? ttlMsRaw : 30_000
+  let closed = false
+  let pollActive = false
+  const poll = async () => {
+    if (pollActive || closed) return
+    pollActive = true
+    try {
+      let claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy, ttlMs })
+      while (claimed && !closed) {
+        writeChannelDeliverySseEvent(res, claimed)
+        claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy, ttlMs })
+      }
+      if (!closed) res.write(': keep-alive\n\n')
+    } catch (error) {
+      if (!closed) {
+        const message = error instanceof CloudServiceError
+          ? error.publicMessage
+          : 'Channel delivery stream failed.'
+        res.write(`event: error\ndata: ${JSON.stringify({ error: message })}\n\n`)
+      }
+    } finally {
+      pollActive = false
+    }
+  }
+  await poll()
+  const pollTimer = setInterval(() => {
+    void poll()
+  }, ssePollMs(options))
+  req.on('close', () => {
+    closed = true
+    clearInterval(pollTimer)
   })
 }
 
@@ -842,6 +937,323 @@ async function handleApiRequest(
         writeJson(res, 200, {
           deleted: await options.service.deleteThreadSmartFilter(context.principal, itemId),
         }, options.corsOrigin)
+        return
+      }
+    }
+
+    writeError(res, 404, 'Not found.', options.corsOrigin)
+    return
+  }
+
+  if (resource === 'channels') {
+    const collection = sessionId
+    const itemId = action
+    const itemAction = artifactId
+
+    if (collection === 'agents') {
+      if (!itemId && req.method === 'GET') {
+        writeJson(res, 200, { agents: await options.service.listHeadlessAgents(context.principal) }, options.corsOrigin)
+        return
+      }
+      if (!itemId && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const name = readString(body.name)
+        if (!name) {
+          writeError(res, 400, 'Headless agent name is required.', options.corsOrigin)
+          return
+        }
+        const agent = await options.service.createHeadlessAgent(context.principal, {
+          agentId: readString(body.agentId),
+          name,
+          profileName: readString(body.profileName),
+          status: readEnum(body.status, ['active', 'disabled'] as const),
+          managed: body.managed === true,
+        })
+        writeJson(res, 201, { agent }, options.corsOrigin)
+        return
+      }
+      if (itemId && !itemAction && req.method === 'PATCH') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const agent = await options.service.updateHeadlessAgent(context.principal, itemId, {
+          name: body.name === undefined ? undefined : readString(body.name) || '',
+          profileName: body.profileName === undefined ? undefined : readString(body.profileName) || '',
+          status: body.status === undefined ? undefined : readEnum(body.status, ['active', 'disabled'] as const),
+          managed: body.managed === undefined ? undefined : body.managed === true,
+        })
+        if (!agent) {
+          writeError(res, 404, 'Headless agent was not found.', options.corsOrigin)
+          return
+        }
+        writeJson(res, 200, { agent }, options.corsOrigin)
+        return
+      }
+    }
+
+    if (collection === 'bindings') {
+      if (!itemId && req.method === 'GET') {
+        writeJson(res, 200, {
+          bindings: await options.service.listChannelBindings(context.principal, context.url.searchParams.get('agentId')),
+        }, options.corsOrigin)
+        return
+      }
+      if (!itemId && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const agentId = readString(body.agentId)
+        const provider = readChannelProvider(body.provider)
+        const displayName = readString(body.displayName)
+        if (!agentId || !provider || !displayName) {
+          writeError(res, 400, 'Channel binding requires agentId, provider, and displayName.', options.corsOrigin)
+          return
+        }
+        const binding = await options.service.createChannelBinding(context.principal, {
+          bindingId: readString(body.bindingId),
+          agentId,
+          provider,
+          externalWorkspaceId: readString(body.externalWorkspaceId),
+          displayName,
+          status: readEnum(body.status, ['active', 'disabled', 'auth_required', 'error'] as const),
+          credentialRef: readString(body.credentialRef),
+          settings: readRecord(body.settings) || {},
+        })
+        writeJson(res, 201, { binding }, options.corsOrigin)
+        return
+      }
+      if (itemId && !itemAction && req.method === 'PATCH') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const binding = await options.service.updateChannelBinding(context.principal, itemId, {
+          displayName: body.displayName === undefined ? undefined : readString(body.displayName) || '',
+          status: body.status === undefined ? undefined : readEnum(body.status, ['active', 'disabled', 'auth_required', 'error'] as const),
+          credentialRef: body.credentialRef === undefined ? undefined : readString(body.credentialRef),
+          settings: body.settings === undefined ? undefined : readRecord(body.settings) || {},
+        })
+        if (!binding) {
+          writeError(res, 404, 'Channel binding was not found.', options.corsOrigin)
+          return
+        }
+        writeJson(res, 200, { binding }, options.corsOrigin)
+        return
+      }
+    }
+
+    if (collection === 'identities' && itemId === 'resolve' && !itemAction && req.method === 'POST') {
+      const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const provider = readChannelProvider(body.provider)
+      const externalUserId = readString(body.externalUserId)
+      if (!provider || !externalUserId) {
+        writeError(res, 400, 'Channel identity resolution requires provider and externalUserId.', options.corsOrigin)
+        return
+      }
+      const identity = await options.service.resolveChannelIdentity(context.principal, {
+        identityId: readString(body.identityId),
+        provider,
+        externalWorkspaceId: readString(body.externalWorkspaceId),
+        externalUserId,
+        accountId: readString(body.accountId),
+        role: readEnum(body.role, ['owner', 'admin', 'member', 'approver', 'viewer'] as const),
+        status: readEnum(body.status, ['active', 'disabled', 'pending'] as const),
+        metadata: readRecord(body.metadata) || {},
+      })
+      writeJson(res, 200, { identity }, options.corsOrigin)
+      return
+    }
+
+    if (collection === 'sessions') {
+      if (itemId === 'bind' && !itemAction && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const channelBindingId = readString(body.channelBindingId)
+        const provider = readChannelProvider(body.provider)
+        const externalChatId = readString(body.externalChatId)
+        const externalThreadId = readString(body.externalThreadId)
+        if (!channelBindingId || !provider || !externalChatId || !externalThreadId) {
+          writeError(res, 400, 'Channel session binding requires channelBindingId, provider, externalChatId, and externalThreadId.', options.corsOrigin)
+          return
+        }
+        const bound = await options.service.bindChannelSession(context.principal, {
+          identityId: readString(body.identityId),
+          externalUserId: readString(body.externalUserId),
+          externalWorkspaceId: readString(body.externalWorkspaceId),
+          channelBindingId,
+          provider,
+          externalChatId,
+          externalThreadId,
+          sessionId: readString(body.sessionId),
+          title: readString(body.title),
+          lastEventSequence: readNonNegativeInteger(body.lastEventSequence),
+          lastWorkspaceSequence: readNonNegativeInteger(body.lastWorkspaceSequence),
+          lastChatMessageId: readString(body.lastChatMessageId),
+        })
+        writeJson(res, 200, bound, options.corsOrigin)
+        return
+      }
+      if (itemId === 'by-thread' && !itemAction && req.method === 'GET') {
+        const provider = readChannelProvider(context.url.searchParams.get('provider'))
+        const externalChatId = context.url.searchParams.get('externalChatId')
+        const externalThreadId = context.url.searchParams.get('externalThreadId')
+        if (!provider || !externalChatId || !externalThreadId) {
+          writeError(res, 400, 'Channel thread lookup requires provider, externalChatId, and externalThreadId.', options.corsOrigin)
+          return
+        }
+        const found = await options.service.getChannelSessionByThread(context.principal, {
+          provider,
+          externalWorkspaceId: context.url.searchParams.get('externalWorkspaceId'),
+          externalChatId,
+          externalThreadId,
+        })
+        if (!found) {
+          writeError(res, 404, 'Channel session binding was not found.', options.corsOrigin)
+          return
+        }
+        writeJson(res, 200, found, options.corsOrigin)
+        return
+      }
+      if (itemId === 'prompt' && !itemAction && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const bindingId = readString(body.bindingId)
+        const text = readString(body.text)
+        if (!bindingId || !text) {
+          writeError(res, 400, 'Channel prompt requires bindingId and text.', options.corsOrigin)
+          return
+        }
+        const result = await options.service.enqueueChannelPrompt(context.principal, {
+          bindingId,
+          text,
+          agent: readString(body.agent),
+          identityId: readString(body.identityId),
+          provider: readChannelProvider(body.provider),
+          externalWorkspaceId: readString(body.externalWorkspaceId),
+          externalUserId: readString(body.externalUserId),
+        })
+        const processed = await processSessionCommandIfConfigured(options, context.principal.tenantId, result.binding.sessionId)
+        writeJson(res, 202, { ...result, processed }, options.corsOrigin)
+        return
+      }
+    }
+
+    if (collection === 'cursor' && !itemId && req.method === 'POST') {
+      const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const bindingId = readString(body.bindingId)
+      if (!bindingId) {
+        writeError(res, 400, 'Channel cursor update requires bindingId.', options.corsOrigin)
+        return
+      }
+      const binding = await options.service.updateChannelCursor(context.principal, {
+        bindingId,
+        lastEventSequence: readNonNegativeInteger(body.lastEventSequence),
+        lastWorkspaceSequence: readNonNegativeInteger(body.lastWorkspaceSequence),
+        lastChatMessageId: body.lastChatMessageId === undefined ? undefined : readString(body.lastChatMessageId),
+      })
+      if (!binding) {
+        writeError(res, 404, 'Channel session binding was not found.', options.corsOrigin)
+        return
+      }
+      writeJson(res, 200, { binding }, options.corsOrigin)
+      return
+    }
+
+    if (collection === 'interactions') {
+      if (!itemId && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const agentId = readString(body.agentId)
+        const sessionForInteraction = readString(body.sessionId)
+        const provider = readChannelProvider(body.provider)
+        const kind = readEnum(body.kind, ['permission', 'question'] as const)
+        const targetId = readString(body.targetId)
+        if (!agentId || !sessionForInteraction || !provider || !kind || !targetId) {
+          writeError(res, 400, 'Channel interaction requires agentId, sessionId, provider, kind, and targetId.', options.corsOrigin)
+          return
+        }
+        const issued = await options.service.createChannelInteraction(context.principal, {
+          interactionId: readString(body.interactionId),
+          agentId,
+          sessionId: sessionForInteraction,
+          provider,
+          kind,
+          targetId,
+          externalInteractionId: readString(body.externalInteractionId),
+          createdByIdentityId: readString(body.createdByIdentityId),
+          expiresAt: readOptionalDate(body.expiresAt),
+          tokenSecret: readString(body.tokenSecret),
+        })
+        writeJson(res, 201, {
+          interaction: publicChannelInteraction(issued.interaction),
+          plaintextToken: issued.plaintextToken,
+        }, options.corsOrigin)
+        return
+      }
+      if (itemId === 'resolve' && !itemAction && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const result = await options.service.resolveChannelInteraction(context.principal, {
+          identityId: readString(body.identityId),
+          provider: readChannelProvider(body.provider),
+          externalWorkspaceId: readString(body.externalWorkspaceId),
+          externalUserId: readString(body.externalUserId),
+          token: readString(body.token),
+          externalInteractionId: readString(body.externalInteractionId),
+          response: body.response ?? null,
+          answers: Array.isArray(body.answers) ? body.answers : undefined,
+          reject: body.reject === true,
+        })
+        const processed = await processSessionCommandIfConfigured(options, context.principal.tenantId, result.interaction.sessionId)
+        writeJson(res, 202, {
+          interaction: publicChannelInteraction(result.interaction),
+          command: result.command,
+          processed,
+        }, options.corsOrigin)
+        return
+      }
+    }
+
+    if (collection === 'deliveries') {
+      if (itemId === 'stream' && !itemAction && req.method === 'GET') {
+        await handleChannelDeliveriesSse(req, res, options, context)
+        return
+      }
+      if (!itemId && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const agentId = readString(body.agentId)
+        const channelBindingId = readString(body.channelBindingId)
+        const provider = readChannelProvider(body.provider)
+        const eventType = readString(body.eventType)
+        const target = readRecord(body.target)
+        const payload = readRecord(body.payload)
+        if (!agentId || !channelBindingId || !provider || !eventType || !target || !payload) {
+          writeError(res, 400, 'Channel delivery requires agentId, channelBindingId, provider, target, eventType, and payload.', options.corsOrigin)
+          return
+        }
+        const delivery = await options.service.createChannelDelivery(context.principal, {
+          deliveryId: readString(body.deliveryId),
+          agentId,
+          channelBindingId,
+          sessionBindingId: readString(body.sessionBindingId),
+          provider,
+          target,
+          eventType,
+          payload,
+          status: readEnum(body.status, ['pending', 'claimed', 'sent', 'failed', 'dead'] as const),
+          nextAttemptAt: readOptionalDate(body.nextAttemptAt),
+        })
+        writeJson(res, 201, { delivery }, options.corsOrigin)
+        return
+      }
+      if (itemId && itemAction === 'ack' && req.method === 'POST') {
+        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+        const status = readString(body.status) as 'sent' | 'failed' | 'dead' | null
+        if (!status || !['sent', 'failed', 'dead'].includes(status)) {
+          writeError(res, 400, 'Channel delivery ack requires status sent, failed, or dead.', options.corsOrigin)
+          return
+        }
+        const delivery = await options.service.ackChannelDelivery(context.principal, {
+          deliveryId: itemId,
+          claimedBy: readString(body.claimedBy) || context.url.searchParams.get('claimedBy') || context.principal.tokenId || context.principal.userId,
+          status,
+          lastError: readString(body.lastError),
+          nextAttemptAt: readOptionalDate(body.nextAttemptAt),
+        })
+        if (!delivery) {
+          writeError(res, 404, 'Channel delivery was not found.', options.corsOrigin)
+          return
+        }
+        writeJson(res, 200, { delivery }, options.corsOrigin)
         return
       }
     }
@@ -1327,6 +1739,10 @@ export class CloudHttpServer {
       })
     } catch (error) {
       if (error instanceof CloudHttpError) {
+        writeError(res, error.status, error.publicMessage, this.options.corsOrigin)
+        return
+      }
+      if (error instanceof CloudServiceError) {
         writeError(res, error.status, error.publicMessage, this.options.corsOrigin)
         return
       }

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -1,5 +1,10 @@
 import { createRequire } from 'node:module'
-import { generateCloudApiToken, hashCloudApiToken } from './control-plane-store.ts'
+import {
+  generateChannelInteractionToken,
+  generateCloudApiToken,
+  hashChannelInteractionToken,
+  hashCloudApiToken,
+} from './control-plane-store.ts'
 import type {
   WorkflowRunStatus,
   WorkflowStatus,
@@ -12,7 +17,16 @@ import type {
   AccountRecord,
   ApiTokenRecord,
   AuditEventRecord,
+  AckChannelDeliveryInput,
+  BindChannelSessionInput,
+  ChannelBindingRecord,
+  ChannelDeliveryRecord,
+  ChannelIdentityRecord,
+  ChannelInteractionRecord,
+  ChannelProviderId,
+  ChannelSessionBindingRecord,
   ClaimDueWorkflowRunInput,
+  ClaimChannelDeliveryInput,
   ClaimedWorkflowRunRecord,
   CloudWorkflowRecord,
   CloudWorkflowRunRecord,
@@ -21,19 +35,28 @@ import type {
   ControlPlaneRole,
   ControlPlaneSessionStatus,
   ControlPlaneStore,
+  CreateChannelBindingInput,
+  CreateChannelDeliveryInput,
+  CreateChannelInteractionInput,
   CreateAccountInput,
+  CreateHeadlessAgentInput,
   CreateWorkflowInput,
   CreateWorkflowRunInput,
   CreateThreadSmartFilterInput,
   CreateThreadTagInput,
   FailWorkflowRunInput,
+  FindChannelInteractionInput,
+  HeadlessAgentRecord,
   IssuedApiTokenRecord,
+  IssuedChannelInteractionRecord,
   IssueApiTokenInput,
   MembershipRecord,
   OrgRecord,
   PrincipalMembershipRecord,
   RecordAuditEventInput,
   RevokeApiTokenInput,
+  ResolveChannelInteractionInput,
+  ResolveChannelInteractionWithCommandInput,
   SchemaMigrationRecord,
   SessionCommandRecord,
   SessionEventRecord,
@@ -45,9 +68,13 @@ import type {
   ThreadSmartFilterRecord,
   ThreadTagLinkInput,
   ThreadTagRecord,
+  UpdateChannelBindingInput,
+  UpdateChannelCursorInput,
+  UpdateHeadlessAgentInput,
   UpdateWorkflowStatusInput,
   UpdateThreadSmartFilterInput,
   UpdateThreadTagInput,
+  UpsertChannelIdentityInput,
   UpsertMembershipInput,
   UserRecord,
   WorkerHeartbeatRecord,
@@ -91,6 +118,9 @@ const THREAD_FILTER_MAX_VALUES = 50
 const THREAD_BULK_MAX_SESSION_IDS = 500
 const SMART_FILTER_QUERY_MAX_BYTES = 16_384
 const WORKFLOW_RUN_LIST_LIMIT = 100
+const CHANNEL_TEXT_MAX_LENGTH = 256
+const CHANNEL_METADATA_MAX_BYTES = 16_384
+const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
 
 function loadPgPool(connectionString: string): PgPool {
   const pg = require('pg') as {
@@ -195,6 +225,34 @@ function normalizeThreadQuery(value: unknown) {
   return query
 }
 
+function normalizeRecord(value: unknown, label: string, maxBytes = CHANNEL_METADATA_MAX_BYTES): Record<string, unknown> {
+  const record = jsonRecord(value)
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function normalizeNullableText(value: unknown, maxLength: number, label: string): string | null {
+  if (value === undefined || value === null || value === '') return null
+  return normalizeText(value, maxLength, label)
+}
+
+function normalizeNonNegativeInteger(value: unknown, label: string) {
+  const parsed = Number(value ?? 0)
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${label} must be a non-negative integer.`)
+  return parsed
+}
+
+function normalizeProvider(value: unknown): ChannelProviderId {
+  const provider = normalizeText(value, 32, 'Channel provider') as ChannelProviderId
+  if (!['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(provider)) {
+    throw new Error(`Unsupported channel provider ${provider}.`)
+  }
+  return provider
+}
+
 function redactAuditMetadata(value: Record<string, unknown> | undefined): Record<string, unknown> {
   const redacted: Record<string, unknown> = {}
   for (const [field, entry] of Object.entries(value || {})) {
@@ -292,6 +350,115 @@ function auditEventFromRow(row: QueryRow): AuditEventRecord {
     targetId: stringOrNull(row.target_id),
     metadata: jsonRecord(row.metadata),
     createdAt: iso(row.created_at),
+  }
+}
+
+function headlessAgentFromRow(row: QueryRow): HeadlessAgentRecord {
+  return {
+    agentId: String(row.agent_id),
+    orgId: String(row.org_id),
+    tenantId: String(row.tenant_id),
+    profileName: String(row.profile_name),
+    name: String(row.name),
+    status: String(row.status) as HeadlessAgentRecord['status'],
+    managed: row.managed === true,
+    createdByAccountId: stringOrNull(row.created_by_account_id),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+function channelBindingFromRow(row: QueryRow): ChannelBindingRecord {
+  return {
+    bindingId: String(row.binding_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalWorkspaceId: stringOrNull(row.external_workspace_id),
+    displayName: String(row.display_name),
+    status: String(row.status) as ChannelBindingRecord['status'],
+    credentialRef: stringOrNull(row.credential_ref),
+    settings: jsonRecord(row.settings),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+function channelIdentityFromRow(row: QueryRow): ChannelIdentityRecord {
+  return {
+    identityId: String(row.identity_id),
+    orgId: String(row.org_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalWorkspaceId: stringOrNull(row.external_workspace_id),
+    externalUserId: String(row.external_user_id),
+    accountId: stringOrNull(row.account_id),
+    role: String(row.role) as ChannelIdentityRecord['role'],
+    status: String(row.status) as ChannelIdentityRecord['status'],
+    metadata: jsonRecord(row.metadata),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+function channelSessionBindingFromRow(row: QueryRow): ChannelSessionBindingRecord {
+  return {
+    bindingId: String(row.binding_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    channelBindingId: String(row.channel_binding_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalWorkspaceId: stringOrNull(row.external_workspace_id),
+    externalThreadId: String(row.external_thread_id),
+    externalChatId: String(row.external_chat_id),
+    sessionId: String(row.session_id),
+    lastEventSequence: numberValue(row.last_event_sequence),
+    lastWorkspaceSequence: numberValue(row.last_workspace_sequence),
+    lastChatMessageId: stringOrNull(row.last_chat_message_id),
+    status: String(row.status) as ChannelSessionBindingRecord['status'],
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+function channelInteractionFromRow(row: QueryRow): ChannelInteractionRecord {
+  return {
+    interactionId: String(row.interaction_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    sessionId: String(row.session_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalInteractionId: stringOrNull(row.external_interaction_id),
+    tokenHash: String(row.token_hash),
+    kind: String(row.kind) as ChannelInteractionRecord['kind'],
+    targetId: String(row.target_id),
+    status: String(row.status) as ChannelInteractionRecord['status'],
+    createdByIdentityId: stringOrNull(row.created_by_identity_id),
+    expiresAt: iso(row.expires_at),
+    usedAt: isoOrNull(row.used_at),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+function channelDeliveryFromRow(row: QueryRow): ChannelDeliveryRecord {
+  return {
+    deliveryId: String(row.delivery_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    channelBindingId: String(row.channel_binding_id),
+    sessionBindingId: stringOrNull(row.session_binding_id),
+    provider: String(row.provider) as ChannelProviderId,
+    target: jsonRecord(row.target),
+    eventType: String(row.event_type),
+    payload: jsonRecord(row.payload),
+    status: String(row.status) as ChannelDeliveryRecord['status'],
+    attemptCount: numberValue(row.attempt_count),
+    claimedBy: stringOrNull(row.claimed_by),
+    claimExpiresAt: isoOrNull(row.claim_expires_at),
+    nextAttemptAt: iso(row.next_attempt_at),
+    lastError: stringOrNull(row.last_error),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
   }
 }
 
@@ -793,6 +960,626 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       [orgId, Math.max(1, Math.min(limit, 500))],
     )
     return result.rows.map(auditEventFromRow)
+  }
+
+  async createHeadlessAgent(input: CreateHeadlessAgentInput) {
+    return this.withTransaction(async (client) => {
+      const now = nowIso(input.createdAt)
+      const result = await client.query(
+        `INSERT INTO headless_agents (
+          agent_id, org_id, tenant_id, profile_name, name, status, managed,
+          created_by_account_id, created_at, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
+         ON CONFLICT (agent_id) DO NOTHING
+         RETURNING *`,
+        [
+          normalizeText(input.agentId, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent id'),
+          input.orgId,
+          input.tenantId,
+          normalizeText(input.profileName, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent profile'),
+          normalizeText(input.name, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent name'),
+          input.status || 'active',
+          input.managed === true,
+          input.createdByAccountId || null,
+          now,
+        ],
+      )
+      const row = result.rows[0] || await this.one(
+        `SELECT * FROM headless_agents WHERE agent_id = $1 AND org_id = $2`,
+        [input.agentId, input.orgId],
+        client,
+      )
+      const agent = headlessAgentFromRow(row)
+      if (result.rows[0]) {
+        await this.recordAuditEventWithExecutor(client, {
+          orgId: agent.orgId,
+          accountId: agent.createdByAccountId,
+          actorType: 'system',
+          actorId: 'headless_agent.create',
+          eventType: 'headless_agent.created',
+          targetType: 'headless_agent',
+          targetId: agent.agentId,
+          metadata: { name: agent.name, profileName: agent.profileName, managed: agent.managed },
+          createdAt: input.createdAt,
+        })
+      }
+      return agent
+    })
+  }
+
+  async updateHeadlessAgent(input: UpdateHeadlessAgentInput) {
+    const result = await this.pool.query(
+      `UPDATE headless_agents
+       SET profile_name = CASE WHEN $3::boolean THEN $4 ELSE profile_name END,
+           name = CASE WHEN $5::boolean THEN $6 ELSE name END,
+           status = COALESCE($7, status),
+           managed = CASE WHEN $8::boolean THEN $9 ELSE managed END,
+           updated_at = $10
+       WHERE org_id = $1 AND agent_id = $2
+       RETURNING *`,
+      [
+        input.orgId,
+        input.agentId,
+        input.profileName !== undefined,
+        input.profileName === undefined ? null : normalizeText(input.profileName, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent profile'),
+        input.name !== undefined,
+        input.name === undefined ? null : normalizeText(input.name, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent name'),
+        input.status || null,
+        input.managed !== undefined,
+        input.managed ?? null,
+        nowIso(input.updatedAt),
+      ],
+    )
+    return result.rows[0] ? headlessAgentFromRow(result.rows[0]) : null
+  }
+
+  async getHeadlessAgent(orgId: string, agentId: string) {
+    const row = await this.maybeOne(`SELECT * FROM headless_agents WHERE org_id = $1 AND agent_id = $2`, [orgId, agentId])
+    return row ? headlessAgentFromRow(row) : null
+  }
+
+  async listHeadlessAgents(orgId: string) {
+    const result = await this.pool.query(
+      `SELECT * FROM headless_agents WHERE org_id = $1 ORDER BY updated_at DESC, agent_id`,
+      [orgId],
+    )
+    return result.rows.map(headlessAgentFromRow)
+  }
+
+  async createChannelBinding(input: CreateChannelBindingInput) {
+    return this.withTransaction(async (client) => {
+      const now = nowIso(input.createdAt)
+      const result = await client.query(
+        `INSERT INTO cloud_channel_bindings (
+          binding_id, org_id, agent_id, provider, external_workspace_id,
+          display_name, status, credential_ref, settings, created_at, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $10)
+         ON CONFLICT (binding_id) DO NOTHING
+         RETURNING *`,
+        [
+          normalizeText(input.bindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding id'),
+          input.orgId,
+          input.agentId,
+          normalizeProvider(input.provider),
+          normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id'),
+          normalizeText(input.displayName, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding name'),
+          input.status || 'active',
+          normalizeNullableText(input.credentialRef, CHANNEL_TEXT_MAX_LENGTH, 'Credential ref'),
+          JSON.stringify(normalizeRecord(input.settings, 'Channel binding settings')),
+          now,
+        ],
+      )
+      const row = result.rows[0] || await this.one(
+        `SELECT * FROM cloud_channel_bindings WHERE org_id = $1 AND binding_id = $2`,
+        [input.orgId, input.bindingId],
+        client,
+      )
+      const binding = channelBindingFromRow(row)
+      if (result.rows[0]) {
+        await this.recordAuditEventWithExecutor(client, {
+          orgId: binding.orgId,
+          actorType: 'system',
+          actorId: 'channel_binding.create',
+          eventType: 'channel_binding.created',
+          targetType: 'channel_binding',
+          targetId: binding.bindingId,
+          metadata: { provider: binding.provider, displayName: binding.displayName, credentialRef: binding.credentialRef },
+          createdAt: input.createdAt,
+        })
+      }
+      return binding
+    })
+  }
+
+  async updateChannelBinding(input: UpdateChannelBindingInput) {
+    const result = await this.pool.query(
+      `UPDATE cloud_channel_bindings
+       SET display_name = CASE WHEN $3::boolean THEN $4 ELSE display_name END,
+           status = COALESCE($5, status),
+           credential_ref = CASE WHEN $6::boolean THEN $7 ELSE credential_ref END,
+           settings = CASE WHEN $8::boolean THEN $9::jsonb ELSE settings END,
+           updated_at = $10
+       WHERE org_id = $1 AND binding_id = $2
+       RETURNING *`,
+      [
+        input.orgId,
+        input.bindingId,
+        input.displayName !== undefined,
+        input.displayName === undefined ? null : normalizeText(input.displayName, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding name'),
+        input.status || null,
+        input.credentialRef !== undefined,
+        input.credentialRef === undefined ? null : normalizeNullableText(input.credentialRef, CHANNEL_TEXT_MAX_LENGTH, 'Credential ref'),
+        input.settings !== undefined,
+        input.settings === undefined ? null : JSON.stringify(normalizeRecord(input.settings, 'Channel binding settings')),
+        nowIso(input.updatedAt),
+      ],
+    )
+    return result.rows[0] ? channelBindingFromRow(result.rows[0]) : null
+  }
+
+  async getChannelBinding(orgId: string, bindingId: string) {
+    const row = await this.maybeOne(`SELECT * FROM cloud_channel_bindings WHERE org_id = $1 AND binding_id = $2`, [orgId, bindingId])
+    return row ? channelBindingFromRow(row) : null
+  }
+
+  async listChannelBindings(orgId: string, agentId?: string | null) {
+    const result = await this.pool.query(
+      `SELECT * FROM cloud_channel_bindings
+       WHERE org_id = $1 AND ($2::text IS NULL OR agent_id = $2)
+       ORDER BY updated_at DESC, binding_id`,
+      [orgId, agentId || null],
+    )
+    return result.rows.map(channelBindingFromRow)
+  }
+
+  async upsertChannelIdentity(input: UpsertChannelIdentityInput) {
+    const now = nowIso(input.updatedAt)
+    const provider = normalizeProvider(input.provider)
+    const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id')
+    const externalUserId = normalizeText(input.externalUserId, CHANNEL_TEXT_MAX_LENGTH, 'External user id')
+    const result = await this.pool.query(
+      `INSERT INTO cloud_channel_identities (
+        identity_id, org_id, provider, external_workspace_id, external_user_id,
+        account_id, role, status, metadata, created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $10)
+       ON CONFLICT (org_id, provider, (COALESCE(external_workspace_id, '')), external_user_id) DO UPDATE
+       SET account_id = CASE
+             WHEN EXCLUDED.account_id IS NOT NULL THEN EXCLUDED.account_id
+             ELSE cloud_channel_identities.account_id
+           END,
+           role = EXCLUDED.role,
+           status = EXCLUDED.status,
+           metadata = EXCLUDED.metadata,
+           updated_at = EXCLUDED.updated_at
+       RETURNING *`,
+      [
+        input.identityId || `chid_${provider}_${externalUserId}`,
+        input.orgId,
+        provider,
+        externalWorkspaceId,
+        externalUserId,
+        input.accountId || null,
+        input.role || 'viewer',
+        input.status || 'pending',
+        JSON.stringify(normalizeRecord(input.metadata, 'Channel identity metadata')),
+        now,
+      ],
+    )
+    return channelIdentityFromRow(result.rows[0])
+  }
+
+  async getChannelIdentity(orgId: string, identityId: string) {
+    const row = await this.maybeOne(`SELECT * FROM cloud_channel_identities WHERE org_id = $1 AND identity_id = $2`, [orgId, identityId])
+    return row ? channelIdentityFromRow(row) : null
+  }
+
+  async findChannelIdentity(input: { orgId: string, provider: ChannelProviderId, externalWorkspaceId?: string | null, externalUserId: string }) {
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_channel_identities
+       WHERE org_id = $1
+         AND provider = $2
+         AND COALESCE(external_workspace_id, '') = COALESCE($3, '')
+         AND external_user_id = $4`,
+      [
+        input.orgId,
+        normalizeProvider(input.provider),
+        normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id'),
+        normalizeText(input.externalUserId, CHANNEL_TEXT_MAX_LENGTH, 'External user id'),
+      ],
+    )
+    return row ? channelIdentityFromRow(row) : null
+  }
+
+  async bindChannelSession(input: BindChannelSessionInput) {
+    const provider = normalizeProvider(input.provider)
+    const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id')
+    const now = nowIso(input.createdAt)
+    const result = await this.pool.query(
+      `INSERT INTO cloud_channel_session_bindings (
+        binding_id, org_id, agent_id, channel_binding_id, provider,
+        external_workspace_id, external_thread_id, external_chat_id, session_id,
+        last_event_sequence, last_workspace_sequence, last_chat_message_id,
+        status, created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $14)
+       ON CONFLICT DO NOTHING
+       RETURNING *`,
+      [
+        normalizeText(input.bindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel session binding id'),
+        input.orgId,
+        input.agentId,
+        input.channelBindingId,
+        provider,
+        externalWorkspaceId,
+        normalizeText(input.externalThreadId, CHANNEL_TEXT_MAX_LENGTH, 'External thread id'),
+        normalizeText(input.externalChatId, CHANNEL_TEXT_MAX_LENGTH, 'External chat id'),
+        input.sessionId,
+        normalizeNonNegativeInteger(input.lastEventSequence, 'Last event sequence'),
+        normalizeNonNegativeInteger(input.lastWorkspaceSequence, 'Last workspace sequence'),
+        normalizeNullableText(input.lastChatMessageId, CHANNEL_TEXT_MAX_LENGTH, 'Last chat message id'),
+        input.status || 'active',
+        now,
+      ],
+    )
+    const row = result.rows[0] || await this.one(
+      `SELECT * FROM cloud_channel_session_bindings
+       WHERE org_id = $1 AND provider = $2 AND COALESCE(external_workspace_id, '') = COALESCE($3::text, '')
+         AND external_chat_id = $4 AND external_thread_id = $5`,
+      [input.orgId, provider, externalWorkspaceId, input.externalChatId, input.externalThreadId],
+    )
+    const binding = channelSessionBindingFromRow(row)
+    if (result.rows[0]) {
+      await this.recordAuditEvent({
+        orgId: binding.orgId,
+        actorType: 'system',
+        actorId: 'channel_session.bind',
+        eventType: 'channel_session_bound',
+        targetType: 'channel_session_binding',
+        targetId: binding.bindingId,
+        metadata: { provider: binding.provider, sessionId: binding.sessionId },
+        createdAt: input.createdAt,
+      })
+    }
+    return binding
+  }
+
+  async getChannelSessionBinding(orgId: string, bindingId: string) {
+    const row = await this.maybeOne(`SELECT * FROM cloud_channel_session_bindings WHERE org_id = $1 AND binding_id = $2`, [orgId, bindingId])
+    return row ? channelSessionBindingFromRow(row) : null
+  }
+
+  async findChannelSessionBindingByThread(input: { orgId: string, provider: ChannelProviderId, externalWorkspaceId?: string | null, externalChatId: string, externalThreadId: string }) {
+    const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'External workspace id')
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_channel_session_bindings
+       WHERE org_id = $1 AND provider = $2 AND COALESCE(external_workspace_id, '') = COALESCE($3::text, '')
+         AND external_chat_id = $4 AND external_thread_id = $5`,
+      [input.orgId, normalizeProvider(input.provider), externalWorkspaceId, input.externalChatId, input.externalThreadId],
+    )
+    return row ? channelSessionBindingFromRow(row) : null
+  }
+
+  async listChannelSessionBindingsForSession(orgId: string, sessionId: string) {
+    const result = await this.pool.query(
+      `SELECT * FROM cloud_channel_session_bindings
+       WHERE org_id = $1 AND session_id = $2 AND status = 'active'
+       ORDER BY updated_at DESC, binding_id`,
+      [orgId, sessionId],
+    )
+    return result.rows.map(channelSessionBindingFromRow)
+  }
+
+  async updateChannelCursor(input: UpdateChannelCursorInput) {
+    const result = await this.pool.query(
+      `UPDATE cloud_channel_session_bindings
+       SET last_event_sequence = $3,
+           last_workspace_sequence = $4,
+           last_chat_message_id = CASE WHEN $5::boolean THEN $6 ELSE last_chat_message_id END,
+           updated_at = $7
+       WHERE org_id = $1
+         AND binding_id = $2
+         AND last_event_sequence <= $3
+         AND last_workspace_sequence <= $4
+       RETURNING *`,
+      [
+        input.orgId,
+        input.bindingId,
+        normalizeNonNegativeInteger(input.lastEventSequence, 'Last event sequence'),
+        normalizeNonNegativeInteger(input.lastWorkspaceSequence, 'Last workspace sequence'),
+        input.lastChatMessageId !== undefined,
+        normalizeNullableText(input.lastChatMessageId, CHANNEL_TEXT_MAX_LENGTH, 'Last chat message id'),
+        nowIso(input.updatedAt),
+      ],
+    )
+    return result.rows[0] ? channelSessionBindingFromRow(result.rows[0]) : null
+  }
+
+  async createChannelInteraction(input: CreateChannelInteractionInput): Promise<IssuedChannelInteractionRecord> {
+    const plaintextToken = generateChannelInteractionToken({ interactionId: input.interactionId, secret: input.tokenSecret })
+    const result = await this.pool.query(
+      `INSERT INTO cloud_channel_interactions (
+        interaction_id, org_id, agent_id, session_id, provider, external_interaction_id,
+        token_hash, kind, target_id, status, created_by_identity_id,
+        expires_at, used_at, created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending', $10, $11, NULL, $12, $12)
+       ON CONFLICT (interaction_id) DO NOTHING
+       RETURNING *`,
+      [
+        input.interactionId,
+        input.orgId,
+        input.agentId,
+        input.sessionId,
+        normalizeProvider(input.provider),
+        normalizeNullableText(input.externalInteractionId, CHANNEL_TEXT_MAX_LENGTH, 'External interaction id'),
+        hashChannelInteractionToken(plaintextToken),
+        input.kind,
+        normalizeText(input.targetId, CHANNEL_TEXT_MAX_LENGTH, 'Interaction target id'),
+        input.createdByIdentityId || null,
+        input.expiresAt.toISOString(),
+        nowIso(input.createdAt),
+      ],
+    )
+    if (!result.rows[0]) throw new Error(`Channel interaction ${input.interactionId} already exists.`)
+    return { interaction: channelInteractionFromRow(result.rows[0]), plaintextToken }
+  }
+
+  async findChannelInteraction(input: FindChannelInteractionInput) {
+    const tokenHash = input.token ? hashChannelInteractionToken(input.token) : null
+    const now = nowIso(input.now)
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_channel_interactions
+       WHERE org_id = $1
+         AND status = 'pending'
+         AND expires_at > $5
+         AND (
+           ($2::text IS NOT NULL AND token_hash = $2)
+           OR (
+             $3::text IS NOT NULL
+             AND $4::text IS NOT NULL
+             AND provider = $3
+             AND external_interaction_id = $4
+           )
+         )`,
+      [input.orgId, tokenHash, input.provider || null, input.externalInteractionId || null, now],
+    )
+    return row ? channelInteractionFromRow(row) : null
+  }
+
+  async resolveChannelInteraction(input: ResolveChannelInteractionInput) {
+    const tokenHash = input.token ? hashChannelInteractionToken(input.token) : null
+    const now = nowIso(input.usedAt)
+    const result = await this.pool.query(
+      `UPDATE cloud_channel_interactions
+       SET status = 'used', used_at = $5, updated_at = $5
+       WHERE org_id = $1
+         AND status = 'pending'
+         AND expires_at > $5
+         AND (
+           ($2::text IS NOT NULL AND token_hash = $2)
+           OR (
+             $3::text IS NOT NULL
+             AND $4::text IS NOT NULL
+             AND provider = $3
+             AND external_interaction_id = $4
+           )
+         )
+       RETURNING *`,
+      [input.orgId, tokenHash, input.provider || null, input.externalInteractionId || null, now],
+    )
+    const interaction = result.rows[0] ? channelInteractionFromRow(result.rows[0]) : null
+    if (interaction) {
+      await this.recordAuditEvent({
+        orgId: interaction.orgId,
+        actorType: 'system',
+        actorId: input.identityId,
+        eventType: 'channel_interaction.used',
+        targetType: 'channel_interaction',
+        targetId: interaction.interactionId,
+        metadata: { kind: interaction.kind, targetId: interaction.targetId },
+        createdAt: input.usedAt,
+      })
+    }
+    return interaction
+  }
+
+  async resolveChannelInteractionWithCommand(input: ResolveChannelInteractionWithCommandInput) {
+    return this.withTransaction(async (client) => {
+      const tokenHash = input.token ? hashChannelInteractionToken(input.token) : null
+      const usedAt = nowIso(input.usedAt)
+      const selected = await this.maybeOne(
+        `SELECT * FROM cloud_channel_interactions
+         WHERE org_id = $1
+           AND status = 'pending'
+           AND expires_at > $5
+           AND (
+             ($2::text IS NOT NULL AND token_hash = $2)
+             OR (
+               $3::text IS NOT NULL
+               AND $4::text IS NOT NULL
+               AND provider = $3
+               AND external_interaction_id = $4
+             )
+           )
+         FOR UPDATE`,
+        [input.orgId, tokenHash, input.provider || null, input.externalInteractionId || null, usedAt],
+        client,
+      )
+      if (!selected) return null
+      const interaction = channelInteractionFromRow(selected)
+      if (input.command.sessionId !== interaction.sessionId) {
+        throw new Error('Channel interaction command session does not match interaction session.')
+      }
+      await this.requireTenantUser(input.command.tenantId, input.command.userId, client)
+      await this.requireSession(input.command.tenantId, input.command.sessionId, client, true)
+      const payload = input.command.payload || {}
+      const existingCommand = await this.maybeOne(
+        `SELECT * FROM cloud_session_commands WHERE command_id = $1`,
+        [input.command.commandId],
+        client,
+      )
+      let command: SessionCommandRecord
+      if (existingCommand) {
+        command = commandFromRow(existingCommand)
+        if (
+          command.tenantId !== input.command.tenantId
+          || command.userId !== input.command.userId
+          || command.sessionId !== input.command.sessionId
+          || command.kind !== input.command.kind
+          || command.targetLeaseToken !== (input.command.targetLeaseToken ?? null)
+          || stableJson(command.payload) !== stableJson(payload)
+        ) {
+          throw new Error(`Command id ${input.command.commandId} was reused with different content.`)
+        }
+      } else {
+        const createdAt = nowIso(input.command.createdAt)
+        const sequence = await this.incrementSessionCounter(
+          client,
+          input.command.tenantId,
+          input.command.sessionId,
+          'next_command_sequence',
+        )
+        const commandResult = await client.query(
+          `INSERT INTO cloud_session_commands (
+            command_id, tenant_id, user_id, session_id, kind, payload,
+            target_lease_token, created_sequence, created_at, status
+           )
+           VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, 'pending')
+           RETURNING *`,
+          [
+            input.command.commandId,
+            input.command.tenantId,
+            input.command.userId,
+            input.command.sessionId,
+            input.command.kind,
+            JSON.stringify(payload),
+            input.command.targetLeaseToken ?? null,
+            sequence,
+            createdAt,
+          ],
+        )
+        command = commandFromRow(commandResult.rows[0])
+      }
+      const updated = await client.query(
+        `UPDATE cloud_channel_interactions
+         SET status = 'used', used_at = $2, updated_at = $2
+         WHERE interaction_id = $1
+         RETURNING *`,
+        [interaction.interactionId, usedAt],
+      )
+      const resolvedInteraction = channelInteractionFromRow(updated.rows[0])
+      await this.recordAuditEventWithExecutor(client, {
+        orgId: resolvedInteraction.orgId,
+        actorType: 'system',
+        actorId: input.identityId,
+        eventType: 'channel_interaction.used',
+        targetType: 'channel_interaction',
+        targetId: resolvedInteraction.interactionId,
+        metadata: { kind: resolvedInteraction.kind, targetId: resolvedInteraction.targetId },
+        createdAt: input.usedAt,
+      })
+      return { interaction: resolvedInteraction, command }
+    })
+  }
+
+  async createChannelDelivery(input: CreateChannelDeliveryInput) {
+    const now = nowIso(input.createdAt)
+    const result = await this.pool.query(
+      `INSERT INTO cloud_channel_deliveries (
+        delivery_id, org_id, agent_id, channel_binding_id, session_binding_id,
+        provider, target, event_type, payload, status, attempt_count,
+        claimed_by, claim_expires_at, next_attempt_at, last_error, created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9::jsonb, $10, 0, NULL, NULL, $11, NULL, $12, $12)
+       ON CONFLICT (delivery_id) DO NOTHING
+       RETURNING *`,
+      [
+        input.deliveryId,
+        input.orgId,
+        input.agentId,
+        input.channelBindingId,
+        input.sessionBindingId || null,
+        normalizeProvider(input.provider),
+        JSON.stringify(normalizeRecord(input.target, 'Channel delivery target')),
+        normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery event type'),
+        JSON.stringify(normalizeRecord(input.payload, 'Channel delivery payload')),
+        input.status || 'pending',
+        (input.nextAttemptAt || input.createdAt || new Date()).toISOString(),
+        now,
+      ],
+    )
+    const row = result.rows[0] || await this.one(
+      `SELECT * FROM cloud_channel_deliveries WHERE org_id = $1 AND delivery_id = $2`,
+      [input.orgId, input.deliveryId],
+    )
+    return channelDeliveryFromRow(row)
+  }
+
+  async claimNextChannelDelivery(input: ClaimChannelDeliveryInput) {
+    return this.withTransaction(async (client) => {
+      const now = input.now || new Date()
+      const selected = await this.maybeOne(
+        `SELECT * FROM cloud_channel_deliveries
+         WHERE org_id = $1
+           AND (
+             (status = 'pending' AND next_attempt_at <= $2)
+             OR (status = 'failed' AND next_attempt_at <= $2)
+             OR (status = 'claimed' AND claim_expires_at <= $2)
+           )
+         ORDER BY next_attempt_at, created_at
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1`,
+        [input.orgId, now.toISOString()],
+        client,
+      )
+      if (!selected) return null
+      const result = await client.query(
+        `UPDATE cloud_channel_deliveries
+         SET status = 'claimed',
+             claimed_by = $2,
+             claim_expires_at = $3,
+             attempt_count = attempt_count + 1,
+             updated_at = $4
+         WHERE delivery_id = $1
+         RETURNING *`,
+        [
+          String(selected.delivery_id),
+          normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery claimant'),
+          new Date(now.getTime() + (input.ttlMs || 30_000)).toISOString(),
+          now.toISOString(),
+        ],
+      )
+      return channelDeliveryFromRow(result.rows[0])
+    })
+  }
+
+  async ackChannelDelivery(input: AckChannelDeliveryInput) {
+    const result = await this.pool.query(
+      `UPDATE cloud_channel_deliveries
+       SET status = $3,
+           claimed_by = NULL,
+           claim_expires_at = NULL,
+           last_error = $4,
+           next_attempt_at = $5,
+           updated_at = $6
+       WHERE org_id = $1
+         AND delivery_id = $2
+         AND ($7::text IS NULL OR claimed_by = $7)
+       RETURNING *`,
+      [
+        input.orgId,
+        input.deliveryId,
+        input.status,
+        input.lastError ? normalizeText(input.lastError, CHANNEL_DELIVERY_ERROR_MAX_LENGTH, 'Delivery error') : null,
+        (input.nextAttemptAt || input.updatedAt || new Date()).toISOString(),
+        nowIso(input.updatedAt),
+        input.claimedBy || null,
+      ],
+    )
+    return result.rows[0] ? channelDeliveryFromRow(result.rows[0]) : null
   }
 
   async createSession(input: {

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -319,6 +319,133 @@ export const CLOUD_CONTROL_PLANE_ORG_IDENTITY_TOKENS_AUDIT_STATEMENTS = [
     ON cloud_audit_events (org_id, created_at DESC)`,
 ] as const
 
+export const CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_MIGRATION_ID = '003_headless_channels'
+
+export const CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS headless_agents (
+    agent_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    tenant_id text NOT NULL REFERENCES cloud_tenants(tenant_id) ON DELETE CASCADE,
+    profile_name text NOT NULL,
+    name text NOT NULL,
+    status text NOT NULL,
+    managed boolean NOT NULL DEFAULT false,
+    created_by_account_id text REFERENCES cloud_accounts(account_id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS headless_agents_org_idx
+    ON headless_agents (org_id, updated_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS cloud_channel_bindings (
+    binding_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    agent_id text NOT NULL REFERENCES headless_agents(agent_id) ON DELETE CASCADE,
+    provider text NOT NULL,
+    external_workspace_id text,
+    display_name text NOT NULL,
+    status text NOT NULL,
+    credential_ref text,
+    settings jsonb NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_channel_bindings_org_agent_idx
+    ON cloud_channel_bindings (org_id, agent_id, updated_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS cloud_channel_identities (
+    identity_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    provider text NOT NULL,
+    external_workspace_id text,
+    external_user_id text NOT NULL,
+    account_id text REFERENCES cloud_accounts(account_id) ON DELETE SET NULL,
+    role text NOT NULL,
+    status text NOT NULL,
+    metadata jsonb NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS cloud_channel_identities_external_idx
+    ON cloud_channel_identities (org_id, provider, COALESCE(external_workspace_id, ''), external_user_id)`,
+  `CREATE TABLE IF NOT EXISTS cloud_channel_session_bindings (
+    binding_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    agent_id text NOT NULL REFERENCES headless_agents(agent_id) ON DELETE CASCADE,
+    channel_binding_id text NOT NULL REFERENCES cloud_channel_bindings(binding_id) ON DELETE CASCADE,
+    provider text NOT NULL,
+    external_workspace_id text,
+    external_thread_id text NOT NULL,
+    external_chat_id text NOT NULL,
+    session_id text NOT NULL,
+    last_event_sequence integer NOT NULL DEFAULT 0,
+    last_workspace_sequence integer NOT NULL DEFAULT 0,
+    last_chat_message_id text,
+    status text NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `ALTER TABLE cloud_channel_session_bindings
+    ADD COLUMN IF NOT EXISTS external_workspace_id text`,
+  `DO $$
+   BEGIN
+     IF EXISTS (
+       SELECT 1
+       FROM pg_indexes
+       WHERE schemaname = current_schema()
+         AND indexname = 'cloud_channel_session_bindings_thread_idx'
+         AND indexdef NOT LIKE '%COALESCE(external_workspace_id%'
+     ) THEN
+       DROP INDEX cloud_channel_session_bindings_thread_idx;
+     END IF;
+   END $$`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS cloud_channel_session_bindings_thread_idx
+    ON cloud_channel_session_bindings (org_id, provider, COALESCE(external_workspace_id, ''), external_chat_id, external_thread_id)`,
+  `CREATE INDEX IF NOT EXISTS cloud_channel_session_bindings_session_idx
+    ON cloud_channel_session_bindings (org_id, session_id)`,
+  `CREATE TABLE IF NOT EXISTS cloud_channel_interactions (
+    interaction_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    agent_id text NOT NULL REFERENCES headless_agents(agent_id) ON DELETE CASCADE,
+    session_id text NOT NULL,
+    provider text NOT NULL,
+    external_interaction_id text,
+    token_hash text UNIQUE NOT NULL,
+    kind text NOT NULL,
+    target_id text NOT NULL,
+    status text NOT NULL,
+    created_by_identity_id text REFERENCES cloud_channel_identities(identity_id) ON DELETE SET NULL,
+    expires_at timestamptz NOT NULL,
+    used_at timestamptz,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS cloud_channel_interactions_external_idx
+    ON cloud_channel_interactions (org_id, provider, external_interaction_id)
+    WHERE external_interaction_id IS NOT NULL`,
+  `CREATE INDEX IF NOT EXISTS cloud_channel_interactions_session_idx
+    ON cloud_channel_interactions (org_id, session_id, status)`,
+  `CREATE TABLE IF NOT EXISTS cloud_channel_deliveries (
+    delivery_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    agent_id text NOT NULL REFERENCES headless_agents(agent_id) ON DELETE CASCADE,
+    channel_binding_id text NOT NULL REFERENCES cloud_channel_bindings(binding_id) ON DELETE CASCADE,
+    session_binding_id text REFERENCES cloud_channel_session_bindings(binding_id) ON DELETE SET NULL,
+    provider text NOT NULL,
+    target jsonb NOT NULL,
+    event_type text NOT NULL,
+    payload jsonb NOT NULL,
+    status text NOT NULL,
+    attempt_count integer NOT NULL DEFAULT 0,
+    claimed_by text,
+    claim_expires_at timestamptz,
+    next_attempt_at timestamptz NOT NULL,
+    last_error text,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_channel_deliveries_claim_idx
+    ON cloud_channel_deliveries (org_id, status, next_attempt_at, created_at)`,
+] as const
+
 export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration[] = [
   {
     id: CLOUD_CONTROL_PLANE_MIGRATION_ID,
@@ -327,5 +454,9 @@ export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration
   {
     id: CLOUD_CONTROL_PLANE_ORG_IDENTITY_TOKENS_AUDIT_MIGRATION_ID,
     statements: CLOUD_CONTROL_PLANE_ORG_IDENTITY_TOKENS_AUDIT_STATEMENTS,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_STATEMENTS,
   },
 ] as const

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -26,10 +26,20 @@ import {
   listCapabilityTools,
 } from '../capability-catalog.ts'
 import type {
+  ApiTokenScope,
+  ChannelBindingRecord,
+  ChannelDeliveryRecord,
+  ChannelIdentityRecord,
+  ChannelIdentityRole,
+  ChannelInteractionRecord,
+  ChannelProviderId,
+  ChannelSessionBindingRecord,
   ClaimedWorkflowRunRecord,
   CloudWorkflowRecord,
   CloudWorkflowRunRecord,
   ControlPlaneStore,
+  HeadlessAgentRecord,
+  IssuedChannelInteractionRecord,
   SessionCommandRecord,
   SessionEventRecord,
   SessionProjectionRecord,
@@ -59,6 +69,18 @@ export type CloudPrincipal = {
   role?: 'owner' | 'admin' | 'member'
   authSource?: 'user' | 'api_token' | 'local' | 'header'
   tokenId?: string
+  tokenScopes?: ApiTokenScope[]
+}
+
+export class CloudServiceError extends Error {
+  readonly status: number
+  readonly publicMessage: string
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+    this.publicMessage = message
+  }
 }
 
 export type CloudSessionMessage = {
@@ -98,6 +120,7 @@ type CreateCloudSessionRecordInput = {
   tenantId: string
   userId: string
   profileName: string
+  sessionId?: string | null
   title?: string | null
 }
 
@@ -137,6 +160,21 @@ type PermissionRespondPayload = {
   response: unknown
 }
 
+type ChannelActorInput = {
+  identityId?: string | null
+  provider?: ChannelProviderId | null
+  externalWorkspaceId?: string | null
+  externalUserId?: string | null
+}
+
+type ChannelInteractionResolutionInput = ChannelActorInput & {
+  token?: string | null
+  externalInteractionId?: string | null
+  response?: unknown
+  answers?: unknown[]
+  reject?: boolean
+}
+
 const WORKFLOW_MAX_TEXT = 50_000
 const WORKFLOW_TITLE_MAX_LENGTH = 512
 const WORKFLOW_FIELD_MAX_LENGTH = 4096
@@ -168,6 +206,34 @@ function readNumber(value: unknown, fallback = 0) {
 
 function readNullableString(value: unknown) {
   return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function channelRoleCanPrompt(role: ChannelIdentityRole) {
+  return role === 'owner' || role === 'admin' || role === 'member'
+}
+
+function channelRoleCanApprove(role: ChannelIdentityRole) {
+  return role === 'owner' || role === 'admin' || role === 'member' || role === 'approver'
+}
+
+function hasTokenScope(principal: CloudPrincipal, scope: ApiTokenScope) {
+  return principal.tokenScopes?.includes(scope) || principal.tokenScopes?.includes('admin') || false
+}
+
+function stableCloudId(prefix: string, ...parts: string[]) {
+  return `${prefix}_${createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32)}`
+}
+
+function principalCanManageChannels(principal: CloudPrincipal) {
+  if (principal.authSource === 'local' || principal.authSource === 'header') return true
+  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
+function principalCanUseGatewayRoutes(principal: CloudPrincipal) {
+  if (principal.authSource === 'local' || principal.authSource === 'header') return true
+  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'gateway')
+  return principal.role === 'owner' || principal.role === 'admin'
 }
 
 function boundedText(value: unknown, label: string, maxLength: number) {
@@ -987,6 +1053,499 @@ export class CloudSessionService {
     return this.store.listWorkerHeartbeats()
   }
 
+  async listHeadlessAgents(principal: CloudPrincipal): Promise<HeadlessAgentRecord[]> {
+    await this.ensurePrincipal(principal)
+    this.assertChannelSetupAllowed(principal)
+    return this.store.listHeadlessAgents(this.principalOrgId(principal))
+  }
+
+  async createHeadlessAgent(
+    principal: CloudPrincipal,
+    input: {
+      name: string
+      profileName?: string | null
+      status?: HeadlessAgentRecord['status']
+      managed?: boolean
+      agentId?: string | null
+    },
+  ): Promise<HeadlessAgentRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertChannelSetupAllowed(principal)
+    return this.store.createHeadlessAgent({
+      agentId: input.agentId || this.ids.randomUUID(),
+      orgId: this.principalOrgId(principal),
+      tenantId: principal.tenantId,
+      profileName: input.profileName || this.policy.profileName,
+      name: input.name,
+      status: input.status,
+      managed: input.managed,
+      createdByAccountId: principal.accountId || principal.userId,
+    })
+  }
+
+  async updateHeadlessAgent(
+    principal: CloudPrincipal,
+    agentId: string,
+    input: {
+      name?: string
+      profileName?: string
+      status?: HeadlessAgentRecord['status']
+      managed?: boolean
+    },
+  ): Promise<HeadlessAgentRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertChannelSetupAllowed(principal)
+    return this.store.updateHeadlessAgent({
+      orgId: this.principalOrgId(principal),
+      agentId,
+      name: input.name,
+      profileName: input.profileName,
+      status: input.status,
+      managed: input.managed,
+    })
+  }
+
+  async listChannelBindings(principal: CloudPrincipal, agentId?: string | null): Promise<ChannelBindingRecord[]> {
+    await this.ensurePrincipal(principal)
+    this.assertChannelSetupAllowed(principal)
+    return this.store.listChannelBindings(this.principalOrgId(principal), agentId)
+  }
+
+  async createChannelBinding(
+    principal: CloudPrincipal,
+    input: {
+      agentId: string
+      provider: ChannelProviderId
+      displayName: string
+      externalWorkspaceId?: string | null
+      status?: ChannelBindingRecord['status']
+      credentialRef?: string | null
+      settings?: Record<string, unknown>
+      bindingId?: string | null
+    },
+  ): Promise<ChannelBindingRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertChannelSetupAllowed(principal)
+    const orgId = this.principalOrgId(principal)
+    const agent = await this.store.getHeadlessAgent(orgId, input.agentId)
+    if (!agent) throw new CloudServiceError(404, 'Headless agent was not found.')
+    return this.store.createChannelBinding({
+      bindingId: input.bindingId || this.ids.randomUUID(),
+      orgId,
+      agentId: input.agentId,
+      provider: input.provider,
+      externalWorkspaceId: input.externalWorkspaceId,
+      displayName: input.displayName,
+      status: input.status,
+      credentialRef: input.credentialRef,
+      settings: input.settings,
+    })
+  }
+
+  async updateChannelBinding(
+    principal: CloudPrincipal,
+    bindingId: string,
+    input: {
+      displayName?: string
+      status?: ChannelBindingRecord['status']
+      credentialRef?: string | null
+      settings?: Record<string, unknown>
+    },
+  ): Promise<ChannelBindingRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertChannelSetupAllowed(principal)
+    return this.store.updateChannelBinding({
+      orgId: this.principalOrgId(principal),
+      bindingId,
+      displayName: input.displayName,
+      status: input.status,
+      credentialRef: input.credentialRef,
+      settings: input.settings,
+    })
+  }
+
+  async resolveChannelIdentity(
+    principal: CloudPrincipal,
+    input: {
+      provider: ChannelProviderId
+      externalWorkspaceId?: string | null
+      externalUserId: string
+      identityId?: string | null
+      accountId?: string | null
+      role?: ChannelIdentityRecord['role']
+      status?: ChannelIdentityRecord['status']
+      metadata?: Record<string, unknown>
+    },
+  ): Promise<ChannelIdentityRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    const orgId = this.principalOrgId(principal)
+    const existing = await this.store.findChannelIdentity({
+      orgId,
+      provider: input.provider,
+      externalWorkspaceId: input.externalWorkspaceId,
+      externalUserId: input.externalUserId,
+    })
+    const setupAllowed = principalCanManageChannels(principal)
+    return this.store.upsertChannelIdentity({
+      identityId: existing?.identityId || input.identityId || this.ids.randomUUID(),
+      orgId,
+      provider: input.provider,
+      externalWorkspaceId: input.externalWorkspaceId,
+      externalUserId: input.externalUserId,
+      accountId: setupAllowed ? input.accountId : existing?.accountId,
+      role: setupAllowed ? input.role || existing?.role || 'viewer' : existing?.role || 'viewer',
+      status: setupAllowed ? input.status || existing?.status || 'pending' : existing?.status || 'pending',
+      metadata: input.metadata || existing?.metadata || {},
+    })
+  }
+
+  async bindChannelSession(
+    principal: CloudPrincipal,
+    input: ChannelActorInput & {
+      channelBindingId: string
+      provider: ChannelProviderId
+      externalChatId: string
+      externalThreadId: string
+      sessionId?: string | null
+      title?: string | null
+      lastEventSequence?: number
+      lastWorkspaceSequence?: number
+      lastChatMessageId?: string | null
+    },
+  ): Promise<{ binding: ChannelSessionBindingRecord, session: CloudSessionView }> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    const orgId = this.principalOrgId(principal)
+    const channelBinding = await this.store.getChannelBinding(orgId, input.channelBindingId)
+    if (!channelBinding) throw new CloudServiceError(404, 'Channel binding was not found.')
+    if (channelBinding.status !== 'active') throw new CloudServiceError(403, 'Channel binding is not active.')
+    if (channelBinding.provider !== input.provider) throw new CloudServiceError(400, 'Channel provider does not match binding.')
+    const actor = await this.requireChannelActor(principal, input, 'prompt', {
+      provider: channelBinding.provider,
+      externalWorkspaceId: channelBinding.externalWorkspaceId,
+    })
+    const agent = await this.store.getHeadlessAgent(orgId, channelBinding.agentId)
+    if (!agent || agent.status !== 'active') throw new CloudServiceError(403, 'Headless agent is not active.')
+
+    const existing = await this.store.findChannelSessionBindingByThread({
+      orgId,
+      provider: input.provider,
+      externalWorkspaceId: channelBinding.externalWorkspaceId,
+      externalChatId: input.externalChatId,
+      externalThreadId: input.externalThreadId,
+    })
+    if (existing) {
+      if (existing.channelBindingId !== channelBinding.bindingId) {
+        throw new CloudServiceError(409, 'Channel thread is already bound to a different channel binding.')
+      }
+      const owned = await this.store.getSession(principal.tenantId, principal.userId, existing.sessionId)
+      if (!owned) throw new CloudServiceError(403, 'Channel session binding requires a session owned by the gateway principal.')
+      return {
+        binding: existing,
+        session: {
+          session: owned,
+          projection: await this.store.getSessionProjection(principal.tenantId, existing.sessionId),
+        },
+      }
+    }
+
+    if (input.sessionId) {
+      const owned = await this.store.getSession(principal.tenantId, principal.userId, input.sessionId)
+      if (!owned) throw new CloudServiceError(403, 'Channel session binding requires a session owned by the gateway principal.')
+    }
+    const sessionId = input.sessionId || (await this.createCloudSessionRecord({
+      tenantId: principal.tenantId,
+      userId: principal.userId,
+      profileName: agent.profileName,
+      sessionId: stableCloudId(
+        'channel_session',
+        orgId,
+        input.provider,
+        channelBinding.externalWorkspaceId || '',
+        input.externalChatId,
+        input.externalThreadId,
+      ),
+      title: input.title || `Channel ${input.provider}`,
+    })).sessionId
+    const binding = await this.store.bindChannelSession({
+      bindingId: this.ids.randomUUID(),
+      orgId,
+      agentId: agent.agentId,
+      channelBindingId: channelBinding.bindingId,
+      provider: input.provider,
+      externalWorkspaceId: channelBinding.externalWorkspaceId,
+      externalThreadId: input.externalThreadId,
+      externalChatId: input.externalChatId,
+      sessionId,
+      lastEventSequence: input.lastEventSequence,
+      lastWorkspaceSequence: input.lastWorkspaceSequence,
+      lastChatMessageId: input.lastChatMessageId,
+    })
+    await this.store.recordAuditEvent({
+      orgId,
+      accountId: actor.accountId,
+      actorType: 'api_token',
+      actorId: principal.tokenId || principal.userId,
+      eventType: 'channel_session.bound_by_identity',
+      targetType: 'channel_session_binding',
+      targetId: binding.bindingId,
+      metadata: { identityId: actor.identityId, provider: actor.provider, sessionId },
+    })
+    return { binding, session: await this.getTenantSessionView(principal.tenantId, sessionId) }
+  }
+
+  async getChannelSessionByThread(
+    principal: CloudPrincipal,
+    input: {
+      provider: ChannelProviderId
+      externalWorkspaceId?: string | null
+      externalChatId: string
+      externalThreadId: string
+    },
+  ): Promise<{ binding: ChannelSessionBindingRecord, session: CloudSessionView } | null> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    const binding = await this.store.findChannelSessionBindingByThread({
+      orgId: this.principalOrgId(principal),
+      provider: input.provider,
+      externalWorkspaceId: input.externalWorkspaceId,
+      externalChatId: input.externalChatId,
+      externalThreadId: input.externalThreadId,
+    })
+    if (!binding) return null
+    const session = await this.store.getSession(principal.tenantId, principal.userId, binding.sessionId)
+    if (!session) throw new CloudServiceError(403, 'Channel thread lookup requires a session owned by the gateway principal.')
+    return {
+      binding,
+      session: {
+        session,
+        projection: await this.store.getSessionProjection(principal.tenantId, binding.sessionId),
+      },
+    }
+  }
+
+  async updateChannelCursor(
+    principal: CloudPrincipal,
+    input: {
+      bindingId: string
+      lastEventSequence: number
+      lastWorkspaceSequence: number
+      lastChatMessageId?: string | null
+    },
+  ): Promise<ChannelSessionBindingRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    return this.store.updateChannelCursor({
+      orgId: this.principalOrgId(principal),
+      bindingId: input.bindingId,
+      lastEventSequence: input.lastEventSequence,
+      lastWorkspaceSequence: input.lastWorkspaceSequence,
+      lastChatMessageId: input.lastChatMessageId,
+    })
+  }
+
+  async enqueueChannelPrompt(
+    principal: CloudPrincipal,
+    input: ChannelActorInput & {
+      bindingId: string
+      text: string
+      agent?: string | null
+    },
+  ): Promise<{ binding: ChannelSessionBindingRecord, command: SessionCommandRecord }> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    const binding = await this.store.getChannelSessionBinding(this.principalOrgId(principal), input.bindingId)
+    if (!binding || binding.status !== 'active') throw new CloudServiceError(404, 'Channel session binding was not found.')
+    const channelBinding = await this.store.getChannelBinding(this.principalOrgId(principal), binding.channelBindingId)
+    if (!channelBinding) throw new CloudServiceError(404, 'Channel binding was not found.')
+    const actor = await this.requireChannelActor(principal, input, 'prompt', {
+      provider: binding.provider,
+      externalWorkspaceId: channelBinding.externalWorkspaceId,
+    })
+    const session = await this.store.getSession(principal.tenantId, principal.userId, binding.sessionId)
+    if (!session) throw new CloudServiceError(403, 'Channel prompt requires a session owned by the gateway principal.')
+    await this.store.recordAuditEvent({
+      orgId: this.principalOrgId(principal),
+      accountId: actor.accountId,
+      actorType: 'api_token',
+      actorId: principal.tokenId || principal.userId,
+      eventType: 'channel_prompt.enqueued',
+      targetType: 'session',
+      targetId: binding.sessionId,
+      metadata: { identityId: actor.identityId, provider: actor.provider },
+    })
+    const command = await this.store.enqueueSessionCommand({
+      commandId: this.ids.randomUUID(),
+      tenantId: principal.tenantId,
+      userId: session.userId,
+      sessionId: binding.sessionId,
+      kind: 'prompt',
+      payload: {
+        text: input.text,
+        agent: input.agent || 'build',
+      },
+    })
+    return { binding, command }
+  }
+
+  async createChannelInteraction(
+    principal: CloudPrincipal,
+    input: {
+      agentId: string
+      sessionId: string
+      provider: ChannelProviderId
+      kind: ChannelInteractionRecord['kind']
+      targetId: string
+      externalInteractionId?: string | null
+      createdByIdentityId?: string | null
+      expiresAt?: Date | null
+      interactionId?: string | null
+      tokenSecret?: string | null
+    },
+  ): Promise<IssuedChannelInteractionRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    const session = await this.store.getSession(principal.tenantId, principal.userId, input.sessionId)
+    if (!session) throw new CloudServiceError(403, 'Channel interaction requires a session owned by the gateway principal.')
+    const orgId = this.principalOrgId(principal)
+    const agent = await this.store.getHeadlessAgent(orgId, input.agentId)
+    if (!agent) throw new CloudServiceError(404, 'Headless agent was not found.')
+    return this.store.createChannelInteraction({
+      interactionId: input.interactionId || this.ids.randomUUID(),
+      orgId,
+      agentId: agent.agentId,
+      sessionId: input.sessionId,
+      provider: input.provider,
+      externalInteractionId: input.externalInteractionId,
+      kind: input.kind,
+      targetId: input.targetId,
+      createdByIdentityId: input.createdByIdentityId,
+      expiresAt: input.expiresAt || new Date(Date.now() + 10 * 60 * 1000),
+      tokenSecret: input.tokenSecret || undefined,
+    })
+  }
+
+  async resolveChannelInteraction(
+    principal: CloudPrincipal,
+    input: ChannelInteractionResolutionInput,
+  ): Promise<{ interaction: ChannelInteractionRecord, command: SessionCommandRecord }> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    const pendingInteraction = await this.store.findChannelInteraction({
+      orgId: this.principalOrgId(principal),
+      token: input.token,
+      externalInteractionId: input.externalInteractionId,
+      provider: input.provider,
+    })
+    if (!pendingInteraction) throw new CloudServiceError(404, 'Channel interaction was not found or is no longer pending.')
+    const actor = await this.requireChannelActorForSession(principal, input, 'approve', pendingInteraction.sessionId, pendingInteraction.provider)
+    const session = await this.store.getSession(principal.tenantId, principal.userId, pendingInteraction.sessionId)
+    if (!session) throw new CloudServiceError(403, 'Channel interaction requires a session owned by the gateway principal.')
+    const command = {
+      commandId: this.ids.randomUUID(),
+      tenantId: principal.tenantId,
+      userId: session.userId,
+      sessionId: pendingInteraction.sessionId,
+      kind: pendingInteraction.kind === 'permission'
+        ? 'permission.respond' as const
+        : input.reject
+          ? 'question.reject' as const
+          : 'question.reply' as const,
+      payload: pendingInteraction.kind === 'permission'
+        ? {
+            permissionId: pendingInteraction.targetId,
+            response: input.response ?? null,
+          }
+        : input.reject
+          ? {
+              requestId: pendingInteraction.targetId,
+            }
+          : {
+              requestId: pendingInteraction.targetId,
+              answers: Array.isArray(input.answers) ? input.answers : [],
+            },
+    }
+    const resolved = await this.store.resolveChannelInteractionWithCommand({
+      orgId: this.principalOrgId(principal),
+      token: input.token,
+      externalInteractionId: input.externalInteractionId,
+      provider: input.provider,
+      identityId: actor.identityId,
+      command,
+    })
+    if (!resolved) throw new CloudServiceError(409, 'Channel interaction was already resolved.')
+    return resolved
+  }
+
+  async createChannelDelivery(
+    principal: CloudPrincipal,
+    input: {
+      agentId: string
+      channelBindingId: string
+      sessionBindingId?: string | null
+      provider: ChannelProviderId
+      target: Record<string, unknown>
+      eventType: string
+      payload: Record<string, unknown>
+      status?: ChannelDeliveryRecord['status']
+      nextAttemptAt?: Date | null
+      deliveryId?: string | null
+    },
+  ): Promise<ChannelDeliveryRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    return this.store.createChannelDelivery({
+      deliveryId: input.deliveryId || this.ids.randomUUID(),
+      orgId: this.principalOrgId(principal),
+      agentId: input.agentId,
+      channelBindingId: input.channelBindingId,
+      sessionBindingId: input.sessionBindingId,
+      provider: input.provider,
+      target: input.target,
+      eventType: input.eventType,
+      payload: input.payload,
+      status: input.status,
+      nextAttemptAt: input.nextAttemptAt || undefined,
+    })
+  }
+
+  async claimNextChannelDelivery(
+    principal: CloudPrincipal,
+    input: { claimedBy: string, ttlMs?: number, now?: Date },
+  ): Promise<ChannelDeliveryRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    return this.store.claimNextChannelDelivery({
+      orgId: this.principalOrgId(principal),
+      claimedBy: input.claimedBy,
+      ttlMs: input.ttlMs,
+      now: input.now,
+    })
+  }
+
+  async ackChannelDelivery(
+    principal: CloudPrincipal,
+    input: {
+      deliveryId: string
+      claimedBy?: string | null
+      status: Extract<ChannelDeliveryRecord['status'], 'sent' | 'failed' | 'dead'>
+      lastError?: string | null
+      nextAttemptAt?: Date | null
+    },
+  ): Promise<ChannelDeliveryRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertGatewayAccess(principal)
+    return this.store.ackChannelDelivery({
+      orgId: this.principalOrgId(principal),
+      deliveryId: input.deliveryId,
+      claimedBy: input.claimedBy,
+      status: input.status,
+      lastError: input.lastError,
+      nextAttemptAt: input.nextAttemptAt,
+    })
+  }
+
   async listSettingMetadata(principal: CloudPrincipal) {
     await this.ensurePrincipal(principal)
     this.assertSettingsEnabled()
@@ -1685,6 +2244,33 @@ export class CloudSessionService {
   }
 
   private async createCloudSessionRecord(input: CreateCloudSessionRecordInput): Promise<SessionRecord> {
+    if (input.sessionId) {
+      const existing = await this.store.getSessionForTenant(input.tenantId, input.sessionId)
+      if (existing) return existing
+      const now = new Date()
+      const title = input.title || 'New session'
+      await this.store.createSession({
+        tenantId: input.tenantId,
+        userId: input.userId,
+        sessionId: input.sessionId,
+        opencodeSessionId: '',
+        profileName: input.profileName,
+        title,
+        createdAt: now,
+      })
+      await this.appendProjectedEvent({
+        tenantId: input.tenantId,
+        sessionId: input.sessionId,
+        type: 'session.created',
+        payload: {
+          title,
+          runtimePending: true,
+        },
+        createdAt: now,
+      })
+      return this.requireSessionRecord(input.tenantId, input.sessionId)
+    }
+
     if (this.shouldCreateRuntimeSessionsEagerly()) {
       const runtimeSession = await this.runtime.createSession({ profileName: input.profileName })
       const title = input.title || runtimeSession.title
@@ -1894,6 +2480,14 @@ export class CloudSessionService {
       nextRunAt: nextStatus === 'active' ? computeNextWorkflowRunAt(workflow.triggers, now) : null,
       finishedAt: now,
     })
+    await this.enqueueWorkflowChannelDeliveries(tenantId, sessionId, {
+      eventType: 'workflow.completed',
+      workflowId: workflow.id,
+      runId: run.id,
+      status: 'completed',
+      summary,
+      finishedAt: now.toISOString(),
+    })
   }
 
   private async failWorkflowRunForSession(tenantId: string, sessionId: string, error: string) {
@@ -1912,12 +2506,137 @@ export class CloudSessionService {
       nextRunAt: nextStatus === 'active' ? computeNextWorkflowRunAt(workflow.triggers, now) : null,
       finishedAt: now,
     })
+    await this.enqueueWorkflowChannelDeliveries(tenantId, sessionId, {
+      eventType: 'workflow.failed',
+      workflowId: workflow.id,
+      runId: run.id,
+      status: 'failed',
+      error,
+      finishedAt: now.toISOString(),
+    })
   }
 
   private nextWorkflowStatusAfterRun(workflow: CloudWorkflowRecord): WorkflowStatus {
     return workflow.status === 'paused' || workflow.status === 'archived'
       ? workflow.status
       : 'active'
+  }
+
+  private async enqueueWorkflowChannelDeliveries(
+    tenantId: string,
+    sessionId: string,
+    input: {
+      eventType: string
+      workflowId: string
+      runId: string
+      status: string
+      summary?: string | null
+      error?: string | null
+      finishedAt: string
+    },
+  ) {
+    const org = await this.store.ensureOrgForTenant({ tenantId, name: tenantId })
+    const bindings = await this.store.listChannelSessionBindingsForSession(org.orgId, sessionId)
+    await Promise.all(bindings.map((binding) => this.store.createChannelDelivery({
+      deliveryId: stableCloudId('channel_delivery', org.orgId, input.eventType, input.runId, binding.bindingId),
+      orgId: org.orgId,
+      agentId: binding.agentId,
+      channelBindingId: binding.channelBindingId,
+      sessionBindingId: binding.bindingId,
+      provider: binding.provider,
+      target: {
+        externalChatId: binding.externalChatId,
+        externalThreadId: binding.externalThreadId,
+        lastChatMessageId: binding.lastChatMessageId,
+      },
+      eventType: input.eventType,
+      payload: {
+        workflowId: input.workflowId,
+        runId: input.runId,
+        sessionId,
+        status: input.status,
+        summary: input.summary || null,
+        error: input.error || null,
+        finishedAt: input.finishedAt,
+      },
+    })))
+  }
+
+  private principalOrgId(principal: CloudPrincipal) {
+    return principal.orgId || principal.tenantId
+  }
+
+  private assertChannelSetupAllowed(principal: CloudPrincipal) {
+    if (!principalCanManageChannels(principal)) {
+      throw new CloudServiceError(403, 'Channel administration requires an org admin or admin-scoped API token.')
+    }
+  }
+
+  private assertGatewayAccess(principal: CloudPrincipal) {
+    if (!principalCanUseGatewayRoutes(principal)) {
+      throw new CloudServiceError(403, 'Gateway channel access requires a gateway-scoped API token.')
+    }
+  }
+
+  private async getTenantSessionView(tenantId: string, sessionId: string): Promise<CloudSessionView> {
+    const session = await this.store.getSessionForTenant(tenantId, sessionId)
+    if (!session) throw new CloudServiceError(404, 'Cloud session was not found.')
+    return {
+      session,
+      projection: await this.store.getSessionProjection(tenantId, sessionId),
+    }
+  }
+
+  private async requireChannelActor(
+    principal: CloudPrincipal,
+    input: ChannelActorInput,
+    purpose: 'prompt' | 'approve',
+    scope: { provider?: ChannelProviderId | null, externalWorkspaceId?: string | null } = {},
+  ): Promise<ChannelIdentityRecord> {
+    const orgId = this.principalOrgId(principal)
+    const identity = input.identityId
+      ? await this.store.getChannelIdentity(orgId, input.identityId)
+      : input.provider && input.externalUserId
+        ? await this.store.findChannelIdentity({
+            orgId,
+            provider: input.provider,
+            externalWorkspaceId: input.externalWorkspaceId,
+            externalUserId: input.externalUserId,
+          })
+        : null
+    if (!identity) throw new CloudServiceError(403, 'Channel actor identity is not authorized.')
+    if (identity.status !== 'active') throw new CloudServiceError(403, 'Channel actor identity is not active.')
+    if (scope.provider && identity.provider !== scope.provider) {
+      throw new CloudServiceError(403, 'Channel actor identity is not authorized for this provider.')
+    }
+    if (scope.externalWorkspaceId !== undefined && identity.externalWorkspaceId !== (scope.externalWorkspaceId || null)) {
+      throw new CloudServiceError(403, 'Channel actor identity is not authorized for this channel workspace.')
+    }
+    if (purpose === 'prompt' && !channelRoleCanPrompt(identity.role)) {
+      throw new CloudServiceError(403, 'Channel actor is not allowed to prompt this agent.')
+    }
+    if (purpose === 'approve' && !channelRoleCanApprove(identity.role)) {
+      throw new CloudServiceError(403, 'Channel actor is not allowed to approve this interaction.')
+    }
+    return identity
+  }
+
+  private async requireChannelActorForSession(
+    principal: CloudPrincipal,
+    input: ChannelActorInput,
+    purpose: 'prompt' | 'approve',
+    sessionId: string,
+    provider: ChannelProviderId,
+  ): Promise<ChannelIdentityRecord> {
+    const actor = await this.requireChannelActor(principal, input, purpose, { provider })
+    const bindings = await this.store.listChannelSessionBindingsForSession(this.principalOrgId(principal), sessionId)
+    for (const binding of bindings) {
+      if (binding.provider !== provider) continue
+      const channelBinding = await this.store.getChannelBinding(this.principalOrgId(principal), binding.channelBindingId)
+      if (!channelBinding) continue
+      if (channelBinding.externalWorkspaceId === actor.externalWorkspaceId) return actor
+    }
+    throw new CloudServiceError(403, 'Channel actor identity is not authorized for this channel session.')
   }
 
   private assertWorkflowsEnabled() {

--- a/packages/cloud-client/src/index.ts
+++ b/packages/cloud-client/src/index.ts
@@ -52,6 +52,119 @@ function cloudArtifactIdFromFilePath(filePath: string) {
 export type CloudClientSessionStatus = 'idle' | 'running' | 'closed' | 'errored'
 export type CloudClientCommandKind = 'prompt' | 'abort' | 'permission.respond' | 'question.reply' | 'question.reject'
 export type CloudClientCommandStatus = 'pending' | 'running' | 'acked' | 'failed'
+export type CloudChannelProviderId = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
+export type CloudChannelIdentityRole = 'owner' | 'admin' | 'member' | 'approver' | 'viewer'
+export type CloudChannelIdentityStatus = 'active' | 'disabled' | 'pending'
+export type CloudChannelDeliveryStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead'
+
+export type HeadlessAgentRecord = {
+  agentId: string
+  orgId: string
+  tenantId: string
+  profileName: string
+  name: string
+  status: 'active' | 'disabled'
+  managed: boolean
+  createdByAccountId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelBindingRecord = {
+  bindingId: string
+  orgId: string
+  agentId: string
+  provider: CloudChannelProviderId
+  externalWorkspaceId: string | null
+  displayName: string
+  status: 'active' | 'disabled' | 'auth_required' | 'error'
+  credentialRef: string | null
+  settings: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelIdentityRecord = {
+  identityId: string
+  orgId: string
+  provider: CloudChannelProviderId
+  externalWorkspaceId: string | null
+  externalUserId: string
+  accountId: string | null
+  role: CloudChannelIdentityRole
+  status: CloudChannelIdentityStatus
+  metadata: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelSessionBindingRecord = {
+  bindingId: string
+  orgId: string
+  agentId: string
+  channelBindingId: string
+  provider: CloudChannelProviderId
+  externalWorkspaceId: string | null
+  externalThreadId: string
+  externalChatId: string
+  sessionId: string
+  lastEventSequence: number
+  lastWorkspaceSequence: number
+  lastChatMessageId: string | null
+  status: 'active' | 'archived'
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelInteractionRecord = {
+  interactionId: string
+  orgId: string
+  agentId: string
+  sessionId: string
+  provider: CloudChannelProviderId
+  externalInteractionId: string | null
+  tokenHash?: string
+  kind: 'permission' | 'question'
+  targetId: string
+  status: 'pending' | 'used' | 'expired' | 'revoked'
+  createdByIdentityId: string | null
+  expiresAt: string
+  usedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type IssuedChannelInteractionRecord = {
+  interaction: ChannelInteractionRecord
+  plaintextToken: string
+}
+
+export type ChannelDeliveryRecord = {
+  deliveryId: string
+  orgId: string
+  agentId: string
+  channelBindingId: string
+  sessionBindingId: string | null
+  provider: CloudChannelProviderId
+  target: Record<string, unknown>
+  eventType: string
+  payload: Record<string, unknown>
+  status: CloudChannelDeliveryStatus
+  attemptCount: number
+  claimedBy: string | null
+  claimExpiresAt: string | null
+  nextAttemptAt: string
+  lastError: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelActorInput = {
+  identityId?: string | null
+  provider?: CloudChannelProviderId | null
+  externalWorkspaceId?: string | null
+  externalUserId?: string | null
+}
 
 export type SessionRecord = {
   tenantId: string
@@ -234,6 +347,108 @@ export type CloudTransportAdapter = {
   listSettings?(): Promise<CloudTransportSettingMetadata[]>
   getSetting?(key: string): Promise<CloudTransportSettingMetadata | null>
   setSetting?(key: string, value: Record<string, unknown>): Promise<CloudTransportSettingMetadata>
+  listHeadlessAgents?(): Promise<HeadlessAgentRecord[]>
+  createHeadlessAgent?(input: {
+    name: string
+    profileName?: string | null
+    status?: 'active' | 'disabled'
+    managed?: boolean
+    agentId?: string | null
+  }): Promise<HeadlessAgentRecord>
+  updateHeadlessAgent?(agentId: string, input: {
+    name?: string
+    profileName?: string
+    status?: 'active' | 'disabled'
+    managed?: boolean
+  }): Promise<HeadlessAgentRecord | null>
+  listChannelBindings?(agentId?: string | null): Promise<ChannelBindingRecord[]>
+  createChannelBinding?(input: {
+    agentId: string
+    provider: CloudChannelProviderId
+    displayName: string
+    externalWorkspaceId?: string | null
+    status?: 'active' | 'disabled' | 'auth_required' | 'error'
+    credentialRef?: string | null
+    settings?: Record<string, unknown>
+    bindingId?: string | null
+  }): Promise<ChannelBindingRecord>
+  resolveChannelIdentity?(input: {
+    provider: CloudChannelProviderId
+    externalUserId: string
+    externalWorkspaceId?: string | null
+    identityId?: string | null
+    accountId?: string | null
+    role?: CloudChannelIdentityRole
+    status?: CloudChannelIdentityStatus
+    metadata?: Record<string, unknown>
+  }): Promise<ChannelIdentityRecord>
+  bindChannelSession?(input: ChannelActorInput & {
+    channelBindingId: string
+    provider: CloudChannelProviderId
+    externalChatId: string
+    externalThreadId: string
+    sessionId?: string | null
+    title?: string | null
+  }): Promise<{ binding: ChannelSessionBindingRecord, session: CloudSessionView }>
+  getChannelSessionByThread?(input: {
+    provider: CloudChannelProviderId
+    externalWorkspaceId?: string | null
+    externalChatId: string
+    externalThreadId: string
+  }): Promise<{ binding: ChannelSessionBindingRecord, session: CloudSessionView } | null>
+  promptChannelSession?(input: ChannelActorInput & {
+    bindingId: string
+    text: string
+    agent?: string | null
+  }): Promise<{ binding: ChannelSessionBindingRecord, command: SessionCommandRecord, processed: number }>
+  updateChannelCursor?(input: {
+    bindingId: string
+    lastEventSequence: number
+    lastWorkspaceSequence: number
+    lastChatMessageId?: string | null
+  }): Promise<ChannelSessionBindingRecord | null>
+  createChannelInteraction?(input: {
+    agentId: string
+    sessionId: string
+    provider: CloudChannelProviderId
+    kind: 'permission' | 'question'
+    targetId: string
+    externalInteractionId?: string | null
+    createdByIdentityId?: string | null
+    expiresAt?: string | null
+    interactionId?: string | null
+  }): Promise<IssuedChannelInteractionRecord>
+  resolveChannelInteraction?(input: ChannelActorInput & {
+    token?: string | null
+    externalInteractionId?: string | null
+    response?: unknown
+    answers?: unknown[]
+    reject?: boolean
+  }): Promise<{ interaction: ChannelInteractionRecord, command: SessionCommandRecord, processed: number }>
+  createChannelDelivery?(input: {
+    agentId: string
+    channelBindingId: string
+    sessionBindingId?: string | null
+    provider: CloudChannelProviderId
+    target: Record<string, unknown>
+    eventType: string
+    payload: Record<string, unknown>
+    deliveryId?: string | null
+    nextAttemptAt?: string | null
+  }): Promise<ChannelDeliveryRecord>
+  ackChannelDelivery?(deliveryId: string, input: {
+    claimedBy?: string | null
+    status: Extract<CloudChannelDeliveryStatus, 'sent' | 'failed' | 'dead'>
+    lastError?: string | null
+    nextAttemptAt?: string | null
+  }): Promise<ChannelDeliveryRecord | null>
+  channelDeliveriesUrl?(input?: { claimedBy?: string, ttlMs?: number }): string
+  subscribeChannelDeliveries?(input: {
+    claimedBy?: string
+    ttlMs?: number
+    onDelivery: (delivery: ChannelDeliveryRecord) => void
+    onError?: (error: unknown) => void
+  }): CloudTransportSubscription
   workspaceEventsUrl(afterSequence?: number): string
   sessionEventsUrl(sessionId: string, afterSequence?: number): string
   subscribeWorkspaceEvents(input: {
@@ -415,6 +630,10 @@ function workspaceEventUrl(baseUrl: string, afterSequence = 0) {
   return afterSequence > 0 ? `${path}?after=${afterSequence}` : path
 }
 
+function channelDeliveriesUrl(baseUrl: string, input: { claimedBy?: string, ttlMs?: number } = {}) {
+  return `${baseUrl}/api/channels/deliveries/stream${queryString(input)}`
+}
+
 const CLOUD_EVENT_TYPES = [
   'session.created',
   'prompt.submitted',
@@ -433,6 +652,7 @@ const CLOUD_EVENT_TYPES = [
   'session.aborted',
   'runtime.error',
   'snapshot.required',
+  'channel.delivery',
 ] as const
 
 function subscribeEventSource(
@@ -841,6 +1061,115 @@ export function createHttpSseCloudTransportAdapter(
       })).setting)
       if (!setting) throw new Error('Cloud setting response was invalid.')
       return setting
+    },
+    async listHeadlessAgents() {
+      return (await request<{ agents: HeadlessAgentRecord[] }>('/api/channels/agents')).agents
+    },
+    async createHeadlessAgent(input) {
+      return (await request<{ agent: HeadlessAgentRecord }>('/api/channels/agents', {
+        method: 'POST',
+        body: input,
+      })).agent
+    },
+    async updateHeadlessAgent(agentId, input) {
+      return (await request<{ agent: HeadlessAgentRecord | null }>(`/api/channels/agents/${encodePath(agentId)}`, {
+        method: 'PATCH',
+        body: input,
+      })).agent
+    },
+    async listChannelBindings(agentId) {
+      return (await request<{ bindings: ChannelBindingRecord[] }>(`/api/channels/bindings${queryString({ agentId })}`)).bindings
+    },
+    async createChannelBinding(input) {
+      return (await request<{ binding: ChannelBindingRecord }>('/api/channels/bindings', {
+        method: 'POST',
+        body: input,
+      })).binding
+    },
+    async resolveChannelIdentity(input) {
+      return (await request<{ identity: ChannelIdentityRecord }>('/api/channels/identities/resolve', {
+        method: 'POST',
+        body: input,
+      })).identity
+    },
+    bindChannelSession(input) {
+      return request('/api/channels/sessions/bind', {
+        method: 'POST',
+        body: input,
+      })
+    },
+    async getChannelSessionByThread(input) {
+      try {
+        return await request(`/api/channels/sessions/by-thread${queryString(input)}`)
+      } catch (error) {
+        if (error instanceof Error && /not found/i.test(error.message)) return null
+        throw error
+      }
+    },
+    promptChannelSession(input) {
+      return request('/api/channels/sessions/prompt', {
+        method: 'POST',
+        body: input,
+      })
+    },
+    async updateChannelCursor(input) {
+      return (await request<{ binding: ChannelSessionBindingRecord | null }>('/api/channels/cursor', {
+        method: 'POST',
+        body: input,
+      })).binding
+    },
+    createChannelInteraction(input) {
+      return request('/api/channels/interactions', {
+        method: 'POST',
+        body: input,
+      })
+    },
+    resolveChannelInteraction(input) {
+      return request('/api/channels/interactions/resolve', {
+        method: 'POST',
+        body: input,
+      })
+    },
+    async createChannelDelivery(input) {
+      return (await request<{ delivery: ChannelDeliveryRecord }>('/api/channels/deliveries', {
+        method: 'POST',
+        body: input,
+      })).delivery
+    },
+    async ackChannelDelivery(deliveryId, input) {
+      return (await request<{ delivery: ChannelDeliveryRecord | null }>(`/api/channels/deliveries/${encodePath(deliveryId)}/ack`, {
+        method: 'POST',
+        body: input,
+      })).delivery
+    },
+    channelDeliveriesUrl(input = {}) {
+      return channelDeliveriesUrl(baseUrl, input)
+    },
+    subscribeChannelDeliveries(input) {
+      const url = channelDeliveriesUrl(baseUrl, {
+        claimedBy: input.claimedBy,
+        ttlMs: input.ttlMs,
+      })
+      const onEvent = (event: unknown) => {
+        const record = asRecord(event)
+        const delivery = record.delivery
+        if (delivery && typeof delivery === 'object') input.onDelivery(delivery as ChannelDeliveryRecord)
+      }
+      if (Object.keys(headers).length > 0) {
+        return subscribeFetchSse(fetcher, url, {
+          headers,
+          credentials: options.credentials,
+          onEvent,
+          onError: input.onError,
+        })
+      }
+      const EventSourceImpl = options.eventSource || (globalThis as unknown as { EventSource?: CloudTransportEventSource }).EventSource
+      if (!EventSourceImpl) throw new Error('EventSource is not available for cloud delivery subscriptions.')
+      return subscribeEventSource(EventSourceImpl, url, {
+        credentials: options.credentials,
+        onEvent,
+        onError: input.onError,
+      })
     },
     workspaceEventsUrl(afterSequence = 0) {
       return workspaceEventUrl(baseUrl, afterSequence)

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -304,6 +304,212 @@ test('cloud control plane resolves org accounts memberships, tokens, and audit e
   assert.equal(store.listAuditEvents(org.orgId).some((event) => event.eventType === 'api_token.created'), true)
 })
 
+test('cloud control plane stores headless channel bindings, interactions, cursors, and deliveries', () => {
+  const store = seededStore()
+  const org = store.ensureOrgForTenant({ tenantId: 'tenant-1', name: 'Acme' })
+
+  const agent = store.createHeadlessAgent({
+    agentId: 'agent-1',
+    orgId: org.orgId,
+    tenantId: 'tenant-1',
+    profileName: 'data-analyst',
+    name: 'Data analyst',
+    createdByAccountId: 'user-1',
+  })
+  const channelBinding = store.createChannelBinding({
+    bindingId: 'telegram-binding',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    displayName: 'Telegram',
+    credentialRef: 'secret/telegram',
+    settings: { parseMode: 'markdown' },
+  })
+  const identity = store.upsertChannelIdentity({
+    orgId: org.orgId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    externalUserId: 'tg-user-1',
+    accountId: 'user-1',
+    role: 'member',
+    status: 'active',
+    metadata: { username: 'alice' },
+  })
+
+  assert.equal(agent.status, 'active')
+  assert.equal(channelBinding.credentialRef, 'secret/telegram')
+  assert.equal(store.findChannelIdentity({
+    orgId: org.orgId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    externalUserId: 'tg-user-1',
+  })?.identityId, identity.identityId)
+
+  const sessionBinding = store.bindChannelSession({
+    bindingId: 'session-binding-1',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    channelBindingId: channelBinding.bindingId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+    sessionId: 'session-1',
+  })
+  assert.equal(sessionBinding.sessionId, 'session-1')
+  assert.equal(sessionBinding.externalWorkspaceId, 'bot-1')
+  assert.equal(store.findChannelSessionBindingByThread({
+    orgId: org.orgId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+  })?.bindingId, sessionBinding.bindingId)
+
+  const cursor = store.updateChannelCursor({
+    orgId: org.orgId,
+    bindingId: sessionBinding.bindingId,
+    lastEventSequence: 7,
+    lastWorkspaceSequence: 3,
+    lastChatMessageId: 'message-7',
+  })
+  assert.equal(cursor?.lastEventSequence, 7)
+  assert.throws(() => store.updateChannelCursor({
+    orgId: org.orgId,
+    bindingId: sessionBinding.bindingId,
+    lastEventSequence: 6,
+    lastWorkspaceSequence: 3,
+  }), /monotonic/)
+
+  const issued = store.createChannelInteraction({
+    interactionId: 'interaction-1',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    sessionId: 'session-1',
+    provider: 'telegram',
+    externalInteractionId: 'button-1',
+    kind: 'permission',
+    targetId: 'permission-1',
+    createdByIdentityId: identity.identityId,
+    expiresAt: new Date('2026-01-01T01:00:00.000Z'),
+    tokenSecret: 'test-secret',
+  })
+  assert.match(issued.plaintextToken, /^occi_interaction-1_/)
+  assert.notEqual(issued.interaction.tokenHash, issued.plaintextToken)
+  assert.throws(() => store.createChannelInteraction({
+    interactionId: 'interaction-1',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    sessionId: 'session-1',
+    provider: 'telegram',
+    kind: 'permission',
+    targetId: 'permission-1',
+    expiresAt: new Date('2026-01-01T01:00:00.000Z'),
+  }), /already exists/)
+  assert.equal(store.resolveChannelInteraction({
+    orgId: org.orgId,
+    token: issued.plaintextToken,
+    identityId: identity.identityId,
+    usedAt: new Date('2026-01-01T00:01:00.000Z'),
+  })?.status, 'used')
+  assert.equal(store.resolveChannelInteraction({
+    orgId: org.orgId,
+    token: issued.plaintextToken,
+    identityId: identity.identityId,
+    usedAt: new Date('2026-01-01T00:02:00.000Z'),
+  }), null)
+
+  const delivery = store.createChannelDelivery({
+    deliveryId: 'delivery-1',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    channelBindingId: channelBinding.bindingId,
+    sessionBindingId: sessionBinding.bindingId,
+    provider: 'telegram',
+    target: { externalChatId: 'chat-1' },
+    eventType: 'workflow.completed',
+    payload: { runId: 'run-1' },
+    nextAttemptAt: new Date('2026-01-01T00:00:10.000Z'),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  })
+  assert.equal(delivery.status, 'pending')
+  assert.equal(store.claimNextChannelDelivery({
+    orgId: org.orgId,
+    claimedBy: 'gateway-early',
+    now: new Date('2026-01-01T00:00:01.000Z'),
+  }), null)
+  const claimed = store.claimNextChannelDelivery({
+    orgId: org.orgId,
+    claimedBy: 'gateway-1',
+    now: new Date('2026-01-01T00:00:10.000Z'),
+    ttlMs: 30_000,
+  })
+  assert.equal(claimed?.deliveryId, delivery.deliveryId)
+  assert.equal(store.claimNextChannelDelivery({
+    orgId: org.orgId,
+    claimedBy: 'gateway-2',
+    now: new Date('2026-01-01T00:00:02.000Z'),
+  }), null)
+  assert.equal(store.ackChannelDelivery({
+    orgId: org.orgId,
+    deliveryId: delivery.deliveryId,
+    claimedBy: 'wrong-gateway',
+    status: 'sent',
+    updatedAt: new Date('2026-01-01T00:00:03.000Z'),
+  }), null)
+  assert.equal(store.ackChannelDelivery({
+    orgId: org.orgId,
+    deliveryId: delivery.deliveryId,
+    claimedBy: 'gateway-1',
+    status: 'sent',
+    updatedAt: new Date('2026-01-01T00:00:03.000Z'),
+  })?.status, 'sent')
+
+  const secondInteraction = store.createChannelInteraction({
+    interactionId: 'interaction-2',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    sessionId: 'session-1',
+    provider: 'telegram',
+    kind: 'question',
+    targetId: 'question-1',
+    expiresAt: new Date('2027-01-01T01:00:00.000Z'),
+  })
+  assert.throws(() => store.resolveChannelInteractionWithCommand({
+    orgId: org.orgId,
+    token: secondInteraction.plaintextToken,
+    identityId: identity.identityId,
+    command: {
+      commandId: 'bad-command',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      sessionId: 'missing-session',
+      kind: 'question.reply',
+      payload: { requestId: 'question-1', answers: [] },
+    },
+  }), /does not match/)
+  assert.equal(store.findChannelInteraction({
+    orgId: org.orgId,
+    token: secondInteraction.plaintextToken,
+  })?.status, 'pending')
+  const resolvedWithCommand = store.resolveChannelInteractionWithCommand({
+    orgId: org.orgId,
+    token: secondInteraction.plaintextToken,
+    identityId: identity.identityId,
+    command: {
+      commandId: 'question-command',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      sessionId: 'session-1',
+      kind: 'question.reply',
+      payload: { requestId: 'question-1', answers: ['ok'] },
+    },
+  })
+  assert.equal(resolvedWithCommand?.interaction.status, 'used')
+  assert.equal(resolvedWithCommand?.command.kind, 'question.reply')
+})
+
 test('cloud control plane persists tenant-scoped thread tags and session links', () => {
   const store = seededStore()
   const tag = store.createThreadTag({

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -30,6 +30,7 @@ const TEST_COOKIE_KEY = 'not-a-real-cookie-key-for-tests'
 class FakeRuntimeAdapter implements CloudRuntimeAdapter {
   prompts: Array<{ sessionId: string, parts: CloudRuntimePromptPart[], agent: string }> = []
   aborted: string[] = []
+  permissions: Array<{ permissionId: string, allowed: boolean }> = []
   private nextSession = 0
 
   async createSession() {
@@ -64,6 +65,10 @@ class FakeRuntimeAdapter implements CloudRuntimeAdapter {
 
   async abortSession(input: { sessionId: string }) {
     this.aborted.push(input.sessionId)
+  }
+
+  async respondToPermission(input: { permissionId: string, allowed: boolean }) {
+    this.permissions.push(input)
   }
 }
 
@@ -318,6 +323,301 @@ test('cloud HTTP server authenticates bearer API tokens and rejects revoked toke
       headers: { authorization: `Bearer ${issued.plaintext}` },
     })
     assert.equal(rejected.status, 401)
+  } finally {
+    await server.close()
+  }
+})
+
+test('cloud HTTP server exposes gateway channel identity, binding, interaction, and delivery APIs', async () => {
+  const store = new InMemoryControlPlaneStore()
+  store.createTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
+  const org = store.ensureOrgForTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
+  const account = store.createAccount({
+    accountId: 'account-1',
+    idpSubject: 'subject-1',
+    email: 'member@example.test',
+  })
+  store.ensureUser({ tenantId: 'tenant-1', userId: account.accountId, email: account.email, role: 'admin' })
+  store.upsertMembership({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    role: 'admin',
+    status: 'active',
+  })
+  const issued = store.issueApiToken({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    name: 'Gateway token',
+    scopes: ['gateway', 'admin'],
+  })
+
+  const runtime = new FakeRuntimeAdapter()
+  const policy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
+  let nextId = 0
+  const service = new CloudSessionService(store, runtime, policy, undefined, {
+    randomUUID: () => `channel-id-${nextId += 1}`,
+  })
+  const worker = new CloudWorker(store, service, 'worker-1')
+  const server = createCloudHttpServer({
+    service,
+    worker,
+    policy,
+    auth: createApiTokenCloudAuthResolver(store),
+    autoProcessCommands: true,
+    ssePollMs: 10,
+  })
+  const baseUrl = await server.listen()
+  const headers = {
+    authorization: `Bearer ${issued.plaintext}`,
+    'content-type': 'application/json',
+  }
+  try {
+    const agentResponse = await fetch(`${baseUrl}/api/channels/agents`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        agentId: 'agent-1',
+        name: 'Data analyst',
+        profileName: 'data-analyst',
+      }),
+    })
+    assert.equal(agentResponse.status, 201)
+    assert.equal(asRecord((await readJson(agentResponse)).agent).agentId, 'agent-1')
+
+    const bindingResponse = await fetch(`${baseUrl}/api/channels/bindings`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        bindingId: 'telegram-binding',
+        agentId: 'agent-1',
+        provider: 'telegram',
+        displayName: 'Telegram',
+        externalWorkspaceId: 'bot-1',
+        credentialRef: 'secret/telegram',
+      }),
+    })
+    assert.equal(bindingResponse.status, 201)
+    const channelBinding = asRecord((await readJson(bindingResponse)).binding)
+    assert.equal(channelBinding.credentialRef, 'secret/telegram')
+
+    const identityResponse = await fetch(`${baseUrl}/api/channels/identities/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        provider: 'telegram',
+        externalWorkspaceId: 'bot-1',
+        externalUserId: 'tg-user-1',
+        accountId: account.accountId,
+        role: 'member',
+        status: 'active',
+      }),
+    })
+    assert.equal(identityResponse.status, 200)
+    const identity = asRecord((await readJson(identityResponse)).identity)
+    assert.equal(identity.status, 'active')
+
+    const wrongWorkspaceIdentityResponse = await fetch(`${baseUrl}/api/channels/identities/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        provider: 'telegram',
+        externalWorkspaceId: 'bot-2',
+        externalUserId: 'tg-user-2',
+        accountId: account.accountId,
+        role: 'member',
+        status: 'active',
+      }),
+    })
+    assert.equal(wrongWorkspaceIdentityResponse.status, 200)
+    const wrongWorkspaceIdentity = asRecord((await readJson(wrongWorkspaceIdentityResponse)).identity)
+
+    const secondBindingResponse = await fetch(`${baseUrl}/api/channels/bindings`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        bindingId: 'telegram-binding-2',
+        agentId: 'agent-1',
+        provider: 'telegram',
+        displayName: 'Telegram second workspace',
+        externalWorkspaceId: 'bot-2',
+        credentialRef: 'secret/telegram-2',
+      }),
+    })
+    assert.equal(secondBindingResponse.status, 201)
+    const secondChannelBinding = asRecord((await readJson(secondBindingResponse)).binding)
+
+    store.ensureUser({ tenantId: 'tenant-1', userId: 'other-user', email: 'other@example.test' })
+    store.createSession({
+      tenantId: 'tenant-1',
+      userId: 'other-user',
+      sessionId: 'other-session',
+      opencodeSessionId: 'other-opencode-session',
+      profileName: 'full',
+    })
+    const stolenSessionBind = await fetch(`${baseUrl}/api/channels/sessions/bind`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: identity.identityId,
+        channelBindingId: channelBinding.bindingId,
+        provider: 'telegram',
+        externalChatId: 'chat-1',
+        externalThreadId: 'thread-stolen',
+        sessionId: 'other-session',
+      }),
+    })
+    assert.equal(stolenSessionBind.status, 403)
+
+    const bindResponse = await fetch(`${baseUrl}/api/channels/sessions/bind`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: identity.identityId,
+        channelBindingId: channelBinding.bindingId,
+        provider: 'telegram',
+        externalChatId: 'chat-1',
+        externalThreadId: 'thread-1',
+        title: 'Telegram thread',
+      }),
+    })
+    assert.equal(bindResponse.status, 200)
+    const bound = await readJson(bindResponse)
+    const sessionBinding = asRecord(bound.binding)
+    const cloudSession = asRecord(asRecord(bound.session).session)
+    assert.equal(sessionBinding.sessionId, cloudSession.sessionId)
+    assert.equal(sessionBinding.externalWorkspaceId, 'bot-1')
+
+    const secondWorkspaceBindResponse = await fetch(`${baseUrl}/api/channels/sessions/bind`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: wrongWorkspaceIdentity.identityId,
+        channelBindingId: secondChannelBinding.bindingId,
+        provider: 'telegram',
+        externalChatId: 'chat-1',
+        externalThreadId: 'thread-1',
+        title: 'Telegram thread in second workspace',
+      }),
+    })
+    assert.equal(secondWorkspaceBindResponse.status, 200)
+    const secondWorkspaceSessionBinding = asRecord((await readJson(secondWorkspaceBindResponse)).binding)
+    assert.equal(secondWorkspaceSessionBinding.externalWorkspaceId, 'bot-2')
+    assert.notEqual(secondWorkspaceSessionBinding.bindingId, sessionBinding.bindingId)
+
+    const wrongWorkspacePrompt = await fetch(`${baseUrl}/api/channels/sessions/prompt`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: wrongWorkspaceIdentity.identityId,
+        bindingId: sessionBinding.bindingId,
+        text: 'should not run',
+      }),
+    })
+    assert.equal(wrongWorkspacePrompt.status, 403)
+
+    const promptResponse = await fetch(`${baseUrl}/api/channels/sessions/prompt`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: identity.identityId,
+        bindingId: sessionBinding.bindingId,
+        text: 'summarize revenue',
+        agent: 'data-analyst',
+      }),
+    })
+    assert.equal(promptResponse.status, 202)
+    assert.equal((await readJson(promptResponse)).processed, 1)
+    assert.equal(runtime.prompts[0]?.agent, 'data-analyst')
+
+    const interactionResponse = await fetch(`${baseUrl}/api/channels/interactions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        interactionId: 'interaction-1',
+        agentId: 'agent-1',
+        sessionId: cloudSession.sessionId,
+        provider: 'telegram',
+        kind: 'permission',
+        targetId: 'permission-1',
+        tokenSecret: 'test-secret',
+      }),
+    })
+    assert.equal(interactionResponse.status, 201)
+    const issuedInteraction = await readJson(interactionResponse)
+    assert.equal(typeof issuedInteraction.plaintextToken, 'string')
+    assert.equal('tokenHash' in asRecord(issuedInteraction.interaction), false)
+
+    const serviceTokenOnlyApproval = await fetch(`${baseUrl}/api/channels/interactions/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        token: issuedInteraction.plaintextToken,
+        response: { allowed: true },
+      }),
+    })
+    assert.equal(serviceTokenOnlyApproval.status, 403)
+
+    const wrongWorkspaceApproval = await fetch(`${baseUrl}/api/channels/interactions/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: wrongWorkspaceIdentity.identityId,
+        token: issuedInteraction.plaintextToken,
+        response: { allowed: true },
+      }),
+    })
+    assert.equal(wrongWorkspaceApproval.status, 403)
+
+    const approvalResponse = await fetch(`${baseUrl}/api/channels/interactions/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: identity.identityId,
+        token: issuedInteraction.plaintextToken,
+        response: { allowed: true },
+      }),
+    })
+    assert.equal(approvalResponse.status, 202)
+    const approval = await readJson(approvalResponse)
+    assert.equal(asRecord(approval.command).kind, 'permission.respond')
+    assert.equal(approval.processed, 1)
+    assert.deepEqual(runtime.permissions, [{ permissionId: 'permission-1', allowed: true }])
+
+    const deliveryResponse = await fetch(`${baseUrl}/api/channels/deliveries`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        deliveryId: 'delivery-1',
+        agentId: 'agent-1',
+        channelBindingId: channelBinding.bindingId,
+        sessionBindingId: sessionBinding.bindingId,
+        provider: 'telegram',
+        target: { externalChatId: 'chat-1', externalThreadId: 'thread-1' },
+        eventType: 'workflow.completed',
+        payload: { runId: 'run-1' },
+      }),
+    })
+    assert.equal(deliveryResponse.status, 201)
+
+    const controller = new AbortController()
+    const stream = await fetch(`${baseUrl}/api/channels/deliveries/stream?claimedBy=test-gateway`, {
+      headers: { authorization: `Bearer ${issued.plaintext}` },
+      signal: controller.signal,
+    })
+    assert.equal(stream.status, 200)
+    const deliveryEvent = await readSseUntil(stream, (event) => (
+      asRecord(event.delivery).deliveryId === 'delivery-1'
+    ))
+    controller.abort()
+    assert.equal(asRecord(deliveryEvent.delivery).status, 'claimed')
+
+    const ackResponse = await fetch(`${baseUrl}/api/channels/deliveries/delivery-1/ack`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ status: 'sent', claimedBy: 'test-gateway' }),
+    })
+    assert.equal(ackResponse.status, 200)
+    assert.equal(asRecord((await readJson(ackResponse)).delivery).status, 'sent')
   } finally {
     await server.close()
   }

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -89,6 +89,7 @@ test('real Postgres cloud store serializes concurrent schema migrations', {
       assert.deepEqual(migrations?.map((migration) => migration.id), [
         '001_cloud_control_plane',
         '002_org_identity_tokens_audit',
+        '003_headless_channels',
       ])
     } finally {
       await Promise.all(stores.map((store) => store.close?.()))
@@ -314,6 +315,112 @@ test('real Postgres cloud store keeps session commands idempotent and lease-fenc
     assert.equal(reclaimed?.commandId, `${ids.tenantId}-cmd`)
     assert.equal(reclaimed?.claimedLeaseToken, takeoverLease.leaseToken)
     assert.equal((await store.ackSessionCommand(takeoverLease, `${ids.tenantId}-cmd`)).status, 'acked')
+  })
+})
+
+test('real Postgres cloud store keeps channel identities, cursors, and delivery claims atomic', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const org = await store.ensureOrgForTenant({ tenantId: ids.tenantId, name: 'Tenant' })
+    const agent = await store.createHeadlessAgent({
+      agentId: `${ids.tenantId}-agent`,
+      orgId: org.orgId,
+      tenantId: ids.tenantId,
+      profileName: 'data-analyst',
+      name: 'Data analyst',
+      createdByAccountId: ids.userId,
+    })
+    const channelBinding = await store.createChannelBinding({
+      bindingId: `${ids.tenantId}-telegram`,
+      orgId: org.orgId,
+      agentId: agent.agentId,
+      provider: 'telegram',
+      externalWorkspaceId: 'bot-1',
+      displayName: 'Telegram',
+    })
+
+    const identities = await Promise.all(Array.from({ length: 6 }, (_, index) => (
+      store.upsertChannelIdentity({
+        orgId: org.orgId,
+        provider: 'telegram',
+        externalWorkspaceId: 'bot-1',
+        externalUserId: 'tg-user-1',
+        accountId: ids.userId,
+        role: index % 2 === 0 ? 'member' : 'approver',
+        status: 'active',
+        metadata: { index },
+      })
+    )))
+    assert.equal(new Set(identities.map((identity) => identity.identityId)).size, 1)
+    assert.equal((await store.findChannelIdentity({
+      orgId: org.orgId,
+      provider: 'telegram',
+      externalWorkspaceId: 'bot-1',
+      externalUserId: 'tg-user-1',
+    }))?.status, 'active')
+
+    const sessionBinding = await store.bindChannelSession({
+      bindingId: `${ids.tenantId}-channel-session`,
+      orgId: org.orgId,
+      agentId: agent.agentId,
+      channelBindingId: channelBinding.bindingId,
+      provider: 'telegram',
+      externalWorkspaceId: 'bot-1',
+      externalChatId: 'chat-1',
+      externalThreadId: 'thread-1',
+      sessionId: ids.sessionId,
+    })
+    assert.equal((await store.updateChannelCursor({
+      orgId: org.orgId,
+      bindingId: sessionBinding.bindingId,
+      lastEventSequence: 10,
+      lastWorkspaceSequence: 8,
+    }))?.lastEventSequence, 10)
+    assert.equal(await store.updateChannelCursor({
+      orgId: org.orgId,
+      bindingId: sessionBinding.bindingId,
+      lastEventSequence: 9,
+      lastWorkspaceSequence: 8,
+    }), null)
+
+    await store.createChannelDelivery({
+      deliveryId: `${ids.tenantId}-delivery`,
+      orgId: org.orgId,
+      agentId: agent.agentId,
+      channelBindingId: channelBinding.bindingId,
+      sessionBindingId: sessionBinding.bindingId,
+      provider: 'telegram',
+      target: { externalChatId: 'chat-1' },
+      eventType: 'workflow.completed',
+      payload: { runId: 'run-1' },
+      nextAttemptAt: new Date('2026-01-01T00:00:10.000Z'),
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    })
+    assert.equal(await store.claimNextChannelDelivery({
+      orgId: org.orgId,
+      claimedBy: 'gateway-early',
+      now: new Date('2026-01-01T00:00:01.000Z'),
+      ttlMs: 30_000,
+    }), null)
+    const claims = await Promise.all(Array.from({ length: 8 }, (_, index) => (
+      store.claimNextChannelDelivery({
+        orgId: org.orgId,
+        claimedBy: `gateway-${index}`,
+        now: new Date('2026-01-01T00:00:10.000Z'),
+        ttlMs: 30_000,
+      })
+    )))
+    const claimed = claims.filter((delivery) => delivery !== null)
+    assert.equal(claimed.length, 1)
+    assert.equal(claimed[0]?.deliveryId, `${ids.tenantId}-delivery`)
+    assert.equal((await store.ackChannelDelivery({
+      orgId: org.orgId,
+      deliveryId: `${ids.tenantId}-delivery`,
+      claimedBy: claimed[0]?.claimedBy,
+      status: 'sent',
+      updatedAt: new Date('2026-01-01T00:00:02.000Z'),
+    }))?.status, 'sent')
   })
 })
 


### PR DESCRIPTION
## Summary
- adds the Phase 2 headless channel control-plane schema, store contracts, and Postgres/in-memory implementations
- exposes headless agent, channel binding, identity, session binding, prompt, interaction, delivery stream, and delivery ack APIs
- extends the cloud client with typed channel/gateway methods and delivery SSE support
- adds RBAC, workspace-scoped channel identity/session checks, interaction-command atomic resolution, delivery claim fencing, and workflow delivery enqueueing

## Verification
- `node --no-warnings --experimental-strip-types --test tests/cloud-control-plane-store.test.ts tests/cloud-http-server.test.ts tests/cloud-postgres-concurrency.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`

Postgres integration cases remain skipped locally unless `OPEN_COWORK_TEST_POSTGRES_URL` is configured.