### PR TITLE
Complete gateway session stream loop

### DIFF
--- a/apps/gateway/src/cloud-gateway.test.ts
+++ b/apps/gateway/src/cloud-gateway.test.ts
@@ -46,6 +46,10 @@ test('cloud gateway wraps all required channel and session operations', async ()
       calls.push(`interaction:${JSON.stringify(input)}`)
       return { interaction: { interactionId: 'interaction-1' }, command: { commandId: 'cmd-interaction' }, processed: 1 }
     },
+    async createChannelInteraction(input: unknown) {
+      calls.push(`interaction-create:${JSON.stringify(input)}`)
+      return { interaction: { interactionId: 'interaction-created' }, plaintextToken: 'token-created' }
+    },
     subscribeSessionEvents(sessionId: string, input: { onEvent: (event: unknown) => void }) {
       calls.push(`session-events:${sessionId}`)
       input.onEvent({ eventId: 'event-1', sequence: 1, type: 'assistant.message', payload: {} })
@@ -79,6 +83,13 @@ test('cloud gateway wraps all required channel and session operations', async ()
   await gateway.replyToQuestion('session-1', { requestId: 'question-1', answers: ['yes'] })
   await gateway.rejectQuestion('session-1', { requestId: 'question-2' })
   await gateway.resolveChannelInteraction({ token: 'token-1', response: { allowed: true } })
+  await gateway.createChannelInteraction({
+    agentId: 'agent-1',
+    sessionId: 'session-1',
+    provider: 'telegram',
+    kind: 'permission',
+    targetId: 'permission-1',
+  })
   const sessionEvents = gateway.subscribeSessionEvents({ sessionId: 'session-1', onEvent() {} })
   const deliveries = gateway.subscribeDeliveries({ onDelivery() {} })
   await gateway.updateCursor({ bindingId: 'binding-1', lastEventSequence: 5, lastWorkspaceSequence: 7 })
@@ -98,6 +109,7 @@ test('cloud gateway wraps all required channel and session operations', async ()
     'question-reply',
     'question-reject',
     'interaction',
+    'interaction-create',
     'session-events',
     'deliveries',
     'cursor',

--- a/apps/gateway/src/cloud-gateway.ts
+++ b/apps/gateway/src/cloud-gateway.ts
@@ -9,6 +9,7 @@ import {
   type CloudTransportAdapter,
   type CloudTransportSessionEvent,
   type CloudTransportSubscription,
+  type IssuedChannelInteractionRecord,
   type SessionCommandRecord,
 } from '@open-cowork/cloud-client'
 
@@ -47,6 +48,17 @@ export type CloudGateway = {
     answers?: unknown[]
     reject?: boolean
   }): Promise<{ interaction: unknown, command: SessionCommandRecord, processed: number }>
+  createChannelInteraction(input: {
+    agentId: string
+    sessionId: string
+    provider: CloudChannelProviderId
+    kind: 'permission' | 'question'
+    targetId: string
+    externalInteractionId?: string | null
+    createdByIdentityId?: string | null
+    expiresAt?: string | null
+    interactionId?: string | null
+  }): Promise<IssuedChannelInteractionRecord>
   abortSession(sessionId: string): Promise<{ command: SessionCommandRecord, processed: number, view: CloudSessionView }>
   respondToPermission(sessionId: string, input: { permissionId: string, response: unknown }): Promise<{
     command: SessionCommandRecord
@@ -107,6 +119,10 @@ export function createCloudGateway(config: GatewayConfig, adapter = createCloudA
     async resolveChannelInteraction(input) {
       assertMethod(adapter.resolveChannelInteraction, 'resolveChannelInteraction')
       return adapter.resolveChannelInteraction(input)
+    },
+    async createChannelInteraction(input) {
+      assertMethod(adapter.createChannelInteraction, 'createChannelInteraction')
+      return adapter.createChannelInteraction(input)
     },
     abortSession(sessionId) {
       return adapter.abortSession(sessionId)

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -71,6 +71,7 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     async respondToPermission() { return { command: { commandId: 'cmd-permission' } as never, processed: 1 } },
     async replyToQuestion() { return { command: { commandId: 'cmd-question' } as never, processed: 1 } },
     async rejectQuestion() { return { command: { commandId: 'cmd-reject' } as never, processed: 1 } },
+    async createChannelInteraction() { return { interaction: { interactionId: 'interaction-1' } as never, plaintextToken: 'token-1' } },
     async resolveChannelInteraction() { return { interaction: {}, command: { commandId: 'cmd-interaction' } as never, processed: 1 } },
     subscribeSessionEvents() { return { close() {} } },
     subscribeDeliveries() { return { close() {} } },

--- a/apps/gateway/src/event-renderer.ts
+++ b/apps/gateway/src/event-renderer.ts
@@ -1,0 +1,155 @@
+import { randomBytes } from 'node:crypto'
+
+import type {
+  ChannelButton,
+  ChannelProviderId,
+  ChannelProvider,
+  ChannelTarget,
+  SentMessage,
+} from '@open-cowork/gateway-channel'
+import { chunkText } from '@open-cowork/gateway-channel'
+import type {
+  ChannelSessionBindingRecord,
+  CloudTransportSessionEvent,
+} from '@open-cowork/cloud-client'
+
+import type { CloudGateway } from './cloud-gateway.js'
+
+export type RenderGatewaySessionEventInput = {
+  cloud: CloudGateway
+  provider: ChannelProvider
+  binding: ChannelSessionBindingRecord
+  event: CloudTransportSessionEvent
+}
+
+export type RenderGatewaySessionEventResult = {
+  handled: boolean
+  lastChatMessageId?: string | null
+}
+
+export async function renderGatewaySessionEvent(
+  input: RenderGatewaySessionEventInput,
+): Promise<RenderGatewaySessionEventResult> {
+  if (input.event.type === 'assistant.message') {
+    return sendAssistantMessage(input.provider, targetForBinding(input.binding, input.provider.id), readAssistantText(input.event))
+  }
+
+  if (input.event.type === 'permission.requested') {
+    return sendPermissionRequest(input)
+  }
+
+  if (input.event.type === 'question.asked') {
+    return sendQuestion(input.provider, targetForBinding(input.binding, input.provider.id), readQuestionText(input.event))
+  }
+
+  return { handled: false }
+}
+
+async function sendAssistantMessage(
+  provider: ChannelProvider,
+  target: ChannelTarget,
+  text: string,
+): Promise<RenderGatewaySessionEventResult> {
+  if (!text.trim()) return { handled: false }
+  const sent = await sendTextChunks(provider, target, text)
+  return { handled: true, lastChatMessageId: sent?.messageId ?? null }
+}
+
+async function sendPermissionRequest(input: RenderGatewaySessionEventInput): Promise<RenderGatewaySessionEventResult> {
+  const permissionId = stringField(input.event.payload, 'permissionId')
+    || stringField(input.event.payload, 'id')
+  if (!permissionId) return { handled: false }
+
+  const issued = await input.cloud.createChannelInteraction({
+    interactionId: channelInteractionId(input.binding, input.event, permissionId),
+    agentId: input.binding.agentId,
+    sessionId: input.binding.sessionId,
+    provider: input.binding.provider,
+    kind: 'permission',
+    targetId: permissionId,
+  })
+  const title = stringField(input.event.payload, 'title') || 'Permission requested'
+  const description = stringField(input.event.payload, 'description')
+    || stringField(input.event.payload, 'summary')
+    || stringField(input.event.payload, 'tool')
+  const text = description ? `${title}\n${description}` : title
+  const buttons: ChannelButton[][] = [[{
+    label: 'Approve',
+    token: issued.plaintextToken,
+    style: 'success',
+  }]]
+  const sent = await input.provider.sendButtons(targetForBinding(input.binding, input.provider.id), text, buttons)
+  return { handled: true, lastChatMessageId: sent.messageId }
+}
+
+async function sendQuestion(
+  provider: ChannelProvider,
+  target: ChannelTarget,
+  text: string,
+): Promise<RenderGatewaySessionEventResult> {
+  if (!text.trim()) return { handled: false }
+  const sent = await sendTextChunks(provider, target, text)
+  return { handled: true, lastChatMessageId: sent?.messageId ?? null }
+}
+
+async function sendTextChunks(
+  provider: ChannelProvider,
+  target: ChannelTarget,
+  text: string,
+): Promise<SentMessage | null> {
+  let sent: SentMessage | null = null
+  for (const chunk of chunkText(text, provider.capabilities.maxTextLength)) {
+    sent = await provider.sendText(target, chunk)
+  }
+  return sent
+}
+
+function targetForBinding(binding: ChannelSessionBindingRecord, provider: ChannelProviderId): ChannelTarget {
+  return {
+    provider,
+    chatId: binding.externalChatId,
+    threadId: binding.externalThreadId,
+    messageId: binding.lastChatMessageId,
+  }
+}
+
+function readAssistantText(event: CloudTransportSessionEvent): string {
+  return stringField(event.payload, 'content')
+    || stringField(event.payload, 'text')
+    || stringField(event.payload, 'message')
+    || ''
+}
+
+function readQuestionText(event: CloudTransportSessionEvent): string {
+  const title = stringField(event.payload, 'title') || 'Question requested'
+  const question = stringField(event.payload, 'question')
+    || stringField(event.payload, 'prompt')
+    || readFirstQuestionText(event.payload)
+  return question ? `${title}\n${question}` : title
+}
+
+function readFirstQuestionText(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const questions = (payload as Record<string, unknown>).questions
+  if (!Array.isArray(questions)) return null
+  const first = questions[0]
+  if (typeof first === 'string') return first
+  if (first && typeof first === 'object') {
+    return stringField(first, 'label') || stringField(first, 'prompt') || stringField(first, 'text')
+  }
+  return null
+}
+
+function channelInteractionId(
+  _binding: ChannelSessionBindingRecord,
+  _event: CloudTransportSessionEvent,
+  _targetId: string,
+) {
+  return `gw_${randomBytes(9).toString('base64url')}`
+}
+
+function stringField(payload: unknown, key: string): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const value = (payload as Record<string, unknown>)[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -8,12 +8,15 @@ import type { ChannelDeliveryRecord, CloudChannelProviderId } from '@open-cowork
 
 import type { CloudGateway } from './cloud-gateway.js'
 import type { GatewayConfig, GatewayProviderConfig } from './config.js'
+import { routeGatewayInteraction } from './interaction-router.js'
 import { createGatewayMetrics, type GatewayMetrics } from './metrics.js'
 import { createGatewayProviderRegistry, type GatewayProviderRegistry, type ProviderRegistration } from './provider-registry.js'
+import { createGatewaySessionStreamManager, type GatewaySessionStreamManager } from './session-stream-manager.js'
 
 export type GatewayRuntime = {
   readonly metrics: GatewayMetrics
   readonly providers: GatewayProviderRegistry
+  readonly streams: GatewaySessionStreamManager
   start(): Promise<void>
   stop(): Promise<void>
   ready(): boolean
@@ -30,15 +33,17 @@ export function createGatewayRuntime(
   options: GatewayRuntimeOptions = {},
 ): GatewayRuntime {
   const metrics = createGatewayMetrics()
+  const streams = createGatewaySessionStreamManager(cloud, metrics)
   const deliverySubscriptions: Array<{ close(): void }> = []
   let started = false
 
   const runtime: GatewayRuntime = {
     metrics,
     providers,
+    streams,
     async start() {
       if (started) return
-      await providers.start((providerConfig, message) => handleMessage(providerConfig, message, cloud, metrics))
+      await providers.start((providerConfig, message) => handleMessage(providerConfig, message, cloud, providers, streams, metrics))
       started = true
       if (options.subscribeDeliveries !== false) {
         deliverySubscriptions.push(cloud.subscribeDeliveries({
@@ -53,6 +58,7 @@ export function createGatewayRuntime(
       }
     },
     async stop() {
+      streams.closeAll()
       for (const subscription of deliverySubscriptions.splice(0)) subscription.close()
       await providers.stop()
       started = false
@@ -69,6 +75,8 @@ async function handleMessage(
   providerConfig: GatewayProviderConfig,
   message: IncomingChannelMessage,
   cloud: CloudGateway,
+  providers: GatewayProviderRegistry,
+  streams: GatewaySessionStreamManager,
   metrics: GatewayMetrics,
 ) {
   metrics.incomingMessages += 1
@@ -78,14 +86,9 @@ async function handleMessage(
 
   try {
     if (message.interaction?.token) {
-      await cloud.resolveChannelInteraction({
-        provider,
-        externalWorkspaceId,
-        externalUserId,
-        token: message.interaction.token,
-        externalInteractionId: message.interaction.id,
-      })
-      metrics.interactionsResolved += 1
+      const registration = providers.get(providerConfig.id)
+      if (!registration) throw new Error(`Unknown gateway provider ${providerConfig.id}.`)
+      await routeGatewayInteraction({ cloud, provider: registration.provider, providerConfig, message, metrics })
       return
     }
 
@@ -111,6 +114,9 @@ async function handleMessage(
       externalThreadId: message.target.threadId || message.target.chatId,
       title: text.slice(0, 80),
     })
+    const registration = providers.get(providerConfig.id)
+    if (!registration) throw new Error(`Unknown gateway provider ${providerConfig.id}.`)
+    streams.ensure({ binding: bound.binding, provider: registration.provider })
     await cloud.prompt({
       bindingId: bound.binding.bindingId,
       text,
@@ -173,10 +179,7 @@ async function sendDelivery(provider: ChannelProvider, delivery: ChannelDelivery
 }
 
 function findDeliveryProvider(providers: GatewayProviderRegistry, delivery: ChannelDeliveryRecord): ProviderRegistration | null {
-  return providers.registrations.find((entry) => (
-    entry.config.channelBindingId === delivery.channelBindingId
-    || entry.provider.id === delivery.provider
-  )) || null
+  return providers.registrations.find((entry) => entry.config.channelBindingId === delivery.channelBindingId) || null
 }
 
 function readDeliveryTarget(delivery: ChannelDeliveryRecord): ChannelTarget {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -24,9 +24,24 @@ export {
   type GatewayRuntime,
 } from './gateway-runtime.js'
 export {
+  createGatewayMetrics,
+  renderPrometheusMetrics,
+  type GatewayMetrics,
+} from './metrics.js'
+export {
+  renderGatewaySessionEvent,
+} from './event-renderer.js'
+export {
+  routeGatewayInteraction,
+} from './interaction-router.js'
+export {
   createGatewayProviderRegistry,
   type GatewayProviderRegistry,
 } from './provider-registry.js'
+export {
+  createGatewaySessionStreamManager,
+  type GatewaySessionStreamManager,
+} from './session-stream-manager.js'
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const daemon = createGatewayDaemon(loadGatewayConfig())

--- a/apps/gateway/src/interaction-router.test.ts
+++ b/apps/gateway/src/interaction-router.test.ts
@@ -1,0 +1,112 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { FakeChannelProvider } from '@open-cowork/gateway-testing'
+
+import type { CloudGateway } from '../dist/index.js'
+import { createGatewayMetrics, resolveGatewayConfig, routeGatewayInteraction } from '../dist/index.js'
+
+test('interaction router resolves channel button tokens through cloud and acknowledges provider callback', async () => {
+  const provider = new FakeChannelProvider()
+  const calls: unknown[] = []
+  const cloud = {
+    async resolveChannelInteraction(input: unknown) {
+      calls.push(input)
+      return { interaction: { interactionId: 'interaction-1' }, command: { commandId: 'cmd-1' }, processed: 1 }
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }).providers[0]
+  const metrics = createGatewayMetrics()
+
+  const handled = await routeGatewayInteraction({
+    cloud,
+    provider,
+    providerConfig: config,
+    metrics,
+    message: {
+      id: 'message-1',
+      provider: 'cli',
+      target: {
+        provider: 'cli',
+        chatId: 'chat-1',
+        threadId: 'thread-1',
+      },
+      sender: {
+        providerUserId: 'user-1',
+      },
+      text: 'token-1',
+      rawText: 'token-1',
+      isCommand: false,
+      attachments: [],
+      interaction: {
+        id: 'callback-1',
+        token: 'token-1',
+        kind: 'button',
+      },
+      receivedAt: new Date(0),
+      raw: {},
+    },
+  })
+
+  assert.equal(handled, true)
+  assert.deepEqual(calls, [{
+    provider: 'cli',
+    externalWorkspaceId: null,
+    externalUserId: 'user-1',
+    token: 'token-1',
+    externalInteractionId: 'callback-1',
+    response: { allowed: true },
+  }])
+  assert.deepEqual(provider.answered, [{
+    interactionId: 'callback-1',
+    text: 'Approved',
+    alert: undefined,
+  }])
+  assert.equal(metrics.interactionsResolved, 1)
+})
+
+test('interaction router ignores ordinary channel messages', async () => {
+  const provider = new FakeChannelProvider()
+  const cloud = {} as CloudGateway
+  const config = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }).providers[0]
+  const handled = await routeGatewayInteraction({
+    cloud,
+    provider,
+    providerConfig: config,
+    metrics: createGatewayMetrics(),
+    message: {
+      id: 'message-1',
+      provider: 'cli',
+      target: { provider: 'cli', chatId: 'chat-1' },
+      sender: { providerUserId: 'user-1' },
+      text: 'hello',
+      rawText: 'hello',
+      isCommand: false,
+      attachments: [],
+      receivedAt: new Date(0),
+      raw: {},
+    },
+  })
+
+  assert.equal(handled, false)
+})

--- a/apps/gateway/src/interaction-router.ts
+++ b/apps/gateway/src/interaction-router.ts
@@ -1,0 +1,39 @@
+import type { ChannelProvider, IncomingChannelMessage } from '@open-cowork/gateway-channel'
+import type { CloudChannelProviderId } from '@open-cowork/cloud-client'
+
+import type { CloudGateway } from './cloud-gateway.js'
+import type { GatewayProviderConfig } from './config.js'
+import type { GatewayMetrics } from './metrics.js'
+
+export type RouteGatewayInteractionInput = {
+  cloud: CloudGateway
+  provider: ChannelProvider
+  providerConfig: GatewayProviderConfig
+  message: IncomingChannelMessage
+  metrics: GatewayMetrics
+}
+
+export async function routeGatewayInteraction(input: RouteGatewayInteractionInput): Promise<boolean> {
+  const interaction = input.message.interaction
+  if (!interaction?.token) return false
+
+  const cloudProvider = input.message.provider as CloudChannelProviderId
+  await input.cloud.resolveChannelInteraction({
+    provider: cloudProvider,
+    externalWorkspaceId: input.providerConfig.externalWorkspaceId ?? null,
+    externalUserId: input.message.sender.providerUserId,
+    token: interaction.token,
+    externalInteractionId: interaction.id,
+    response: { allowed: true },
+  })
+  input.metrics.interactionsResolved += 1
+
+  if (input.provider.answerInteraction) {
+    try {
+      await input.provider.answerInteraction(interaction.id, 'Approved')
+    } catch {
+      input.metrics.errors += 1
+    }
+  }
+  return true
+}

--- a/apps/gateway/src/provider-registry.ts
+++ b/apps/gateway/src/provider-registry.ts
@@ -1,6 +1,7 @@
 import type { IncomingHttpHeaders } from 'node:http'
 
 import type {
+  ChannelInteraction,
   ChannelProvider,
   ChannelTarget,
   IncomingChannelMessage,
@@ -28,6 +29,11 @@ export type GatewayProviderRegistry = {
     chatId?: string
     threadId?: string | null
     userId?: string
+    interaction?: {
+      id: string
+      token: string
+      kind?: 'button' | 'command'
+    }
   }): Promise<void>
 }
 
@@ -132,6 +138,7 @@ function fakeMessage(provider: ChannelProvider['id'], payload: unknown): Incomin
   const chatId = typeof record.chatId === 'string' && record.chatId ? record.chatId : 'fake-chat'
   const threadId = typeof record.threadId === 'string' ? record.threadId : null
   const userId = typeof record.userId === 'string' && record.userId ? record.userId : 'fake-user'
+  const interaction = readFakeInteraction(record)
   const target: ChannelTarget = {
     provider,
     chatId,
@@ -153,9 +160,21 @@ function fakeMessage(provider: ChannelProvider['id'], payload: unknown): Incomin
     command: text.startsWith('/') ? text.slice(1).split(/\s+/)[0] : undefined,
     commandArgs: text.startsWith('/') ? text.slice(1).split(/\s+/).slice(1).join(' ') : undefined,
     attachments: [],
+    interaction,
     receivedAt: new Date(),
     raw: payload,
   }
+}
+
+function readFakeInteraction(record: Record<string, unknown>): ChannelInteraction | undefined {
+  const interaction = record.interaction
+  if (!interaction || typeof interaction !== 'object' || Array.isArray(interaction)) return undefined
+  const input = interaction as Record<string, unknown>
+  const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : null
+  const token = typeof input.token === 'string' && input.token.trim() ? input.token.trim() : null
+  const kind = input.kind === 'command' ? 'command' : 'button'
+  if (!id || !token) return undefined
+  return { id, token, kind }
 }
 
 function requiredCredential(config: GatewayProviderConfig, key: string) {

--- a/apps/gateway/src/session-stream-manager.test.ts
+++ b/apps/gateway/src/session-stream-manager.test.ts
@@ -1,0 +1,365 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { FakeChannelProvider } from '@open-cowork/gateway-testing'
+
+import type { CloudGateway } from '../dist/index.js'
+import { createGatewayMetrics, createGatewaySessionStreamManager } from '../dist/index.js'
+
+test('session stream manager renders session events once and persists cursor after provider send', async () => {
+  const provider = new FakeChannelProvider()
+  const subscriptions: Array<{
+    sessionId: string
+    afterSequence: number | undefined
+    onEvent: (event: unknown) => void
+    onError?: (error: unknown) => void
+    closed: boolean
+  }> = []
+  const cursorUpdates: unknown[] = []
+  const cloud = {
+    subscribeSessionEvents(input: { sessionId: string, afterSequence?: number, onEvent: (event: unknown) => void, onError?: (error: unknown) => void }) {
+      subscriptions.push({ ...input, closed: false })
+      return {
+        close() {
+          subscriptions[subscriptions.length - 1].closed = true
+        },
+      }
+    },
+    async updateCursor(input: unknown) {
+      cursorUpdates.push(input)
+      return {
+        bindingId: 'binding-1',
+        orgId: 'tenant-1',
+        agentId: 'agent-1',
+        channelBindingId: 'channel-binding-1',
+        provider: 'cli',
+        externalWorkspaceId: null,
+        externalThreadId: 'thread-1',
+        externalChatId: 'chat-1',
+        sessionId: 'session-1',
+        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
+        lastWorkspaceSequence: (input as { lastWorkspaceSequence: number }).lastWorkspaceSequence,
+        lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
+        status: 'active',
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+    async createChannelInteraction() {
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'token-1',
+      }
+    },
+  } as CloudGateway
+  const manager = createGatewaySessionStreamManager(cloud, createGatewayMetrics())
+
+  manager.ensure({
+    provider,
+    binding: {
+      bindingId: 'binding-1',
+      orgId: 'tenant-1',
+      agentId: 'agent-1',
+      channelBindingId: 'channel-binding-1',
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalThreadId: 'thread-1',
+      externalChatId: 'chat-1',
+      sessionId: 'session-1',
+      lastEventSequence: 4,
+      lastWorkspaceSequence: 8,
+      lastChatMessageId: null,
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+  })
+  manager.ensure({
+    provider,
+    binding: {
+      bindingId: 'binding-1',
+      orgId: 'tenant-1',
+      agentId: 'agent-1',
+      channelBindingId: 'channel-binding-1',
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalThreadId: 'thread-1',
+      externalChatId: 'chat-1',
+      sessionId: 'session-1',
+      lastEventSequence: 4,
+      lastWorkspaceSequence: 8,
+      lastChatMessageId: null,
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+  })
+
+  assert.equal(manager.activeCount(), 1)
+  assert.equal(subscriptions.length, 1)
+  assert.equal(subscriptions[0].afterSequence, 4)
+
+  subscriptions[0].onEvent({
+    eventId: 'event-4',
+    sequence: 4,
+    type: 'assistant.message',
+    payload: { content: 'stale response' },
+  })
+  subscriptions[0].onEvent({
+    eventId: 'event-5',
+    sequence: 5,
+    type: 'assistant.message',
+    payload: { content: 'fresh response' },
+  })
+  await waitFor(() => cursorUpdates.length === 1)
+
+  assert.deepEqual(provider.sent.map((entry) => entry.text), ['fresh response'])
+  assert.deepEqual(cursorUpdates, [{
+    bindingId: 'binding-1',
+    lastEventSequence: 5,
+    lastWorkspaceSequence: 8,
+    lastChatMessageId: '1',
+  }])
+
+  subscriptions[0].onEvent({
+    eventId: 'event-5-again',
+    sequence: 5,
+    type: 'assistant.message',
+    payload: { content: 'duplicate response' },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  assert.deepEqual(provider.sent.map((entry) => entry.text), ['fresh response'])
+  manager.closeAll()
+})
+
+test('session stream manager renders permission requests as channel buttons', async () => {
+  const provider = new FakeChannelProvider()
+  const interactions: unknown[] = []
+  let onEvent: ((event: unknown) => void) | null = null
+  const cloud = {
+    subscribeSessionEvents(input: { onEvent: (event: unknown) => void }) {
+      onEvent = input.onEvent
+      return { close() {} }
+    },
+    async createChannelInteraction(input: unknown) {
+      interactions.push(input)
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'approve-token',
+      }
+    },
+    async updateCursor(input: unknown) {
+      return {
+        bindingId: 'binding-1',
+        orgId: 'tenant-1',
+        agentId: 'agent-1',
+        channelBindingId: 'channel-binding-1',
+        provider: 'cli',
+        externalWorkspaceId: null,
+        externalThreadId: 'thread-1',
+        externalChatId: 'chat-1',
+        sessionId: 'session-1',
+        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
+        lastWorkspaceSequence: 0,
+        lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
+        status: 'active',
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+  } as CloudGateway
+  const manager = createGatewaySessionStreamManager(cloud, createGatewayMetrics())
+
+  manager.ensure({
+    provider,
+    binding: {
+      bindingId: 'binding-1',
+      orgId: 'tenant-1',
+      agentId: 'agent-1',
+      channelBindingId: 'channel-binding-1',
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalThreadId: 'thread-1',
+      externalChatId: 'chat-1',
+      sessionId: 'session-1',
+      lastEventSequence: 0,
+      lastWorkspaceSequence: 0,
+      lastChatMessageId: null,
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+  })
+  onEvent?.({
+    eventId: 'event-1',
+    sequence: 1,
+    type: 'permission.requested',
+    payload: {
+      permissionId: 'permission-1',
+      title: 'Run command',
+      description: 'Allow shell command?',
+    },
+  })
+  await waitFor(() => provider.sent.some((entry) => entry.buttons))
+
+  const created = interactions[0] as { interactionId?: string }
+  assert.equal(created.interactionId?.startsWith('gw_'), true)
+  assert.deepEqual({ ...created, interactionId: undefined }, {
+    interactionId: undefined,
+    agentId: 'agent-1',
+    sessionId: 'session-1',
+    provider: 'cli',
+    kind: 'permission',
+    targetId: 'permission-1',
+  })
+  assert.equal(provider.sent[0].text, 'Run command\nAllow shell command?')
+  assert.deepEqual(provider.sent[0].buttons, [[{
+    label: 'Approve',
+    token: 'approve-token',
+    style: 'success',
+  }]])
+  manager.closeAll()
+})
+
+test('session stream manager reconnects from the last persisted cursor', async () => {
+  const provider = new FakeChannelProvider()
+  const metrics = createGatewayMetrics()
+  const subscriptions: Array<{
+    afterSequence?: number
+    onError?: (error: unknown) => void
+  }> = []
+  const cloud = {
+    subscribeSessionEvents(input: { afterSequence?: number, onError?: (error: unknown) => void }) {
+      subscriptions.push(input)
+      return { close() {} }
+    },
+    async updateCursor() { return null },
+    async createChannelInteraction() {
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'token-1',
+      }
+    },
+  } as CloudGateway
+  const manager = createGatewaySessionStreamManager(cloud, metrics, { retryDelayMs: 1 })
+
+  manager.ensure({
+    provider,
+    binding: {
+      bindingId: 'binding-1',
+      orgId: 'tenant-1',
+      agentId: 'agent-1',
+      channelBindingId: 'channel-binding-1',
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalThreadId: 'thread-1',
+      externalChatId: 'chat-1',
+      sessionId: 'session-1',
+      lastEventSequence: 9,
+      lastWorkspaceSequence: 0,
+      lastChatMessageId: null,
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+  })
+  subscriptions[0].onError?.(new Error('stream broke'))
+  await waitFor(() => subscriptions.length === 2)
+
+  assert.equal(metrics.errors, 1)
+  assert.equal(subscriptions[1].afterSequence, 9)
+  manager.closeAll()
+})
+
+test('session stream manager leaves failed provider sends retryable', async () => {
+  const provider = new FakeChannelProvider()
+  const originalSendText = provider.sendText.bind(provider)
+  let failNextSend = true
+  provider.sendText = async (...args) => {
+    if (failNextSend) {
+      failNextSend = false
+      throw new Error('provider down')
+    }
+    return originalSendText(...args)
+  }
+  const metrics = createGatewayMetrics()
+  let onEvent: ((event: unknown) => void) | null = null
+  const cursorUpdates: unknown[] = []
+  const cloud = {
+    subscribeSessionEvents(input: { onEvent: (event: unknown) => void }) {
+      onEvent = input.onEvent
+      return { close() {} }
+    },
+    async updateCursor(input: unknown) {
+      cursorUpdates.push(input)
+      return {
+        bindingId: 'binding-1',
+        orgId: 'tenant-1',
+        agentId: 'agent-1',
+        channelBindingId: 'channel-binding-1',
+        provider: 'cli',
+        externalWorkspaceId: null,
+        externalThreadId: 'thread-1',
+        externalChatId: 'chat-1',
+        sessionId: 'session-1',
+        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
+        lastWorkspaceSequence: 0,
+        lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
+        status: 'active',
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+    async createChannelInteraction() {
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'token-1',
+      }
+    },
+  } as CloudGateway
+  const manager = createGatewaySessionStreamManager(cloud, metrics)
+
+  manager.ensure({
+    provider,
+    binding: {
+      bindingId: 'binding-1',
+      orgId: 'tenant-1',
+      agentId: 'agent-1',
+      channelBindingId: 'channel-binding-1',
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalThreadId: 'thread-1',
+      externalChatId: 'chat-1',
+      sessionId: 'session-1',
+      lastEventSequence: 0,
+      lastWorkspaceSequence: 0,
+      lastChatMessageId: null,
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+  })
+
+  const event = {
+    eventId: 'event-1',
+    sequence: 1,
+    type: 'assistant.message',
+    payload: { content: 'retry me' },
+  }
+  onEvent?.(event)
+  await waitFor(() => metrics.errors === 1)
+  assert.equal(cursorUpdates.length, 0)
+
+  onEvent?.(event)
+  await waitFor(() => cursorUpdates.length === 1)
+  assert.deepEqual(provider.sent.map((entry) => entry.text), ['retry me'])
+  manager.closeAll()
+})
+
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error('Timed out waiting for predicate.')
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}

--- a/apps/gateway/src/session-stream-manager.ts
+++ b/apps/gateway/src/session-stream-manager.ts
@@ -1,0 +1,152 @@
+import type {
+  ChannelProvider,
+} from '@open-cowork/gateway-channel'
+import type {
+  ChannelSessionBindingRecord,
+  CloudTransportSessionEvent,
+  CloudTransportSubscription,
+} from '@open-cowork/cloud-client'
+
+import type { CloudGateway } from './cloud-gateway.js'
+import { renderGatewaySessionEvent } from './event-renderer.js'
+import type { GatewayMetrics } from './metrics.js'
+
+export type GatewaySessionStreamManager = {
+  ensure(input: {
+    binding: ChannelSessionBindingRecord
+    provider: ChannelProvider
+  }): void
+  close(bindingId: string): void
+  closeAll(): void
+  activeCount(): number
+}
+
+export type GatewaySessionStreamManagerOptions = {
+  retryDelayMs?: number
+}
+
+type StreamState = {
+  binding: ChannelSessionBindingRecord
+  provider: ChannelProvider
+  subscription: CloudTransportSubscription | null
+  lastEventSequence: number
+  lastWorkspaceSequence: number
+  lastChatMessageId: string | null
+  queue: Promise<void>
+  closed: boolean
+  retryTimer?: ReturnType<typeof setTimeout>
+}
+
+export function createGatewaySessionStreamManager(
+  cloud: CloudGateway,
+  metrics: GatewayMetrics,
+  options: GatewaySessionStreamManagerOptions = {},
+): GatewaySessionStreamManager {
+  const streams = new Map<string, StreamState>()
+  const retryDelayMs = options.retryDelayMs ?? 250
+
+  const manager: GatewaySessionStreamManager = {
+    ensure(input) {
+      const existing = streams.get(input.binding.bindingId)
+      if (existing) {
+        existing.binding = input.binding
+        existing.provider = input.provider
+        existing.lastWorkspaceSequence = Math.max(existing.lastWorkspaceSequence, input.binding.lastWorkspaceSequence)
+        existing.lastChatMessageId = input.binding.lastChatMessageId ?? existing.lastChatMessageId
+        return
+      }
+
+      const state: StreamState = {
+        binding: input.binding,
+        provider: input.provider,
+        subscription: null,
+        lastEventSequence: input.binding.lastEventSequence,
+        lastWorkspaceSequence: input.binding.lastWorkspaceSequence,
+        lastChatMessageId: input.binding.lastChatMessageId,
+        queue: Promise.resolve(),
+        closed: false,
+      }
+      streams.set(input.binding.bindingId, state)
+      subscribe(state)
+    },
+    close(bindingId) {
+      const state = streams.get(bindingId)
+      if (!state) return
+      closeState(state)
+      streams.delete(bindingId)
+    },
+    closeAll() {
+      for (const state of streams.values()) closeState(state)
+      streams.clear()
+    },
+    activeCount() {
+      return streams.size
+    },
+  }
+
+  function subscribe(state: StreamState) {
+    if (state.closed) return
+    state.subscription = cloud.subscribeSessionEvents({
+      sessionId: state.binding.sessionId,
+      afterSequence: state.lastEventSequence,
+      onEvent: (event) => {
+        state.queue = state.queue.then(() => handleEvent(state, event))
+      },
+      onError: () => {
+        metrics.errors += 1
+        state.subscription?.close()
+        state.subscription = null
+        scheduleRetry(state)
+      },
+    })
+  }
+
+  function scheduleRetry(state: StreamState) {
+    if (state.closed || state.retryTimer) return
+    state.retryTimer = setTimeout(() => {
+      state.retryTimer = undefined
+      subscribe(state)
+    }, retryDelayMs)
+    state.retryTimer.unref?.()
+  }
+
+  async function handleEvent(state: StreamState, event: CloudTransportSessionEvent) {
+    if (state.closed) return
+    if (event.sequence <= state.lastEventSequence) return
+
+    try {
+      const rendered = await renderGatewaySessionEvent({
+        cloud,
+        provider: state.provider,
+        binding: {
+          ...state.binding,
+          lastEventSequence: state.lastEventSequence,
+          lastWorkspaceSequence: state.lastWorkspaceSequence,
+          lastChatMessageId: state.lastChatMessageId,
+        },
+        event,
+      })
+      const lastChatMessageId = rendered.lastChatMessageId ?? state.lastChatMessageId
+      const updated = await cloud.updateCursor({
+        bindingId: state.binding.bindingId,
+        lastEventSequence: event.sequence,
+        lastWorkspaceSequence: state.lastWorkspaceSequence,
+        lastChatMessageId,
+      })
+      state.lastEventSequence = updated?.lastEventSequence ?? event.sequence
+      state.lastWorkspaceSequence = updated?.lastWorkspaceSequence ?? state.lastWorkspaceSequence
+      state.lastChatMessageId = updated?.lastChatMessageId ?? lastChatMessageId
+      if (updated) state.binding = updated
+    } catch {
+      metrics.errors += 1
+    }
+  }
+
+  return manager
+}
+
+function closeState(state: StreamState) {
+  state.closed = true
+  state.subscription?.close()
+  if (state.retryTimer) clearTimeout(state.retryTimer)
+}

--- a/packages/gateway-testing/src/fake-channel.test.ts
+++ b/packages/gateway-testing/src/fake-channel.test.ts
@@ -18,6 +18,7 @@ describe("FakeChannelProvider", () => {
       messageId: "1"
     });
     await provider.sendButtons(target, "approve?", [[{ label: "Approve", token: "p:abc123" }]]);
+    await provider.answerInteraction("callback-1", "Approved");
     await provider.sendFile(target, { filename: "result.txt", data: new TextEncoder().encode("ok") });
 
     expect(provider.sent).toHaveLength(3);
@@ -28,6 +29,7 @@ describe("FakeChannelProvider", () => {
     expect(provider.sent[2]).toMatchObject({
       file: { filename: "result.txt" }
     });
+    expect(provider.answered).toEqual([{ interactionId: "callback-1", text: "Approved", alert: undefined }]);
   });
 
   it("dispatches emitted messages only while started", async () => {

--- a/packages/gateway-testing/src/fake-channel.ts
+++ b/packages/gateway-testing/src/fake-channel.ts
@@ -23,6 +23,7 @@ export class FakeChannelProvider implements ChannelProvider {
   };
 
   readonly sent: Array<{ target: ChannelTarget; text?: string; file?: OutgoingFile; buttons?: ChannelButton[][] }> = [];
+  readonly answered: Array<{ interactionId: string; text?: string; alert?: boolean }> = [];
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
 
   async start(handler: (message: IncomingChannelMessage) => Promise<void>): Promise<void> {
@@ -61,6 +62,10 @@ export class FakeChannelProvider implements ChannelProvider {
   ): Promise<SentMessage> {
     this.sent.push({ target, text, buttons });
     return sent(target, this.sent.length);
+  }
+
+  async answerInteraction(interactionId: string, text?: string, alert?: boolean): Promise<void> {
+    this.answered.push({ interactionId, text, alert });
   }
 }
 

--- a/tests/gateway-cloud-smoke.test.ts
+++ b/tests/gateway-cloud-smoke.test.ts
@@ -40,6 +40,14 @@ class FakeRuntime implements CloudRuntimeAdapter {
           content: 'gateway smoke response',
         },
       }, {
+        type: 'permission.requested',
+        payload: {
+          sessionId: input.sessionId,
+          permissionId: `${input.sessionId}:permission:${this.prompts.length}`,
+          title: 'Approve smoke permission',
+          description: 'Allow the fake runtime action?',
+        },
+      }, {
         type: 'session.idle',
         payload: { sessionId: input.sessionId },
       }],
@@ -308,6 +316,11 @@ test('gateway daemon prompts an in-process cloud session through fake provider w
     }))
     const promptsBeforeDaemon = runtime.prompts.length
     const gatewayUrl = await gateway.start()
+    const fakeProvider = gateway.runtime.providers.get('fake')?.provider as {
+      sent: Array<{ text?: string, buttons?: Array<Array<{ token: string }>> }>
+      answered: Array<{ interactionId: string, text?: string }>
+    } | undefined
+    assert.ok(fakeProvider)
 
     try {
       assert.equal((await fetch(`${gatewayUrl}/health`)).status, 200)
@@ -324,6 +337,28 @@ test('gateway daemon prompts an in-process cloud session through fake provider w
       assert.equal(prompt.status, 202)
       assert.equal(runtime.prompts.length, promptsBeforeDaemon + 1)
       assert.equal(runtime.prompts.at(-1)?.parts.find((part) => part.type === 'text')?.text, 'summarize this repo')
+      await waitUntil(() => fakeProvider.sent.some((entry) => entry.text === 'gateway smoke response'))
+      await waitUntil(() => fakeProvider.sent.some((entry) => entry.buttons))
+      const approveToken = fakeProvider.sent.find((entry) => entry.buttons)?.buttons?.[0]?.[0]?.token
+      assert.ok(approveToken)
+
+      const approval = await fetch(`${gatewayUrl}/webhooks/fake`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          text: approveToken,
+          chatId: 'chat-1',
+          userId: 'user-1',
+          interaction: {
+            id: 'fake-callback-1',
+            token: approveToken,
+            kind: 'button',
+          },
+        }),
+      })
+      assert.equal(approval.status, 202)
+      await waitUntil(() => runtime.permissions.some((permission) => permission.allowed))
+      assert.equal(fakeProvider.answered.at(-1)?.interactionId, 'fake-callback-1')
     } finally {
       await gateway.stop()
     }
@@ -331,3 +366,11 @@ test('gateway daemon prompts an in-process cloud session through fake provider w
     await cloud.close()
   }
 })
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error('Timed out waiting for gateway smoke predicate.')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}


### PR DESCRIPTION
## Summary
- add gateway session stream manager with serialized SSE rendering, cursor persistence, reconnect, and retryable provider-send failures
- add MVP event renderer for assistant text, questions, and permission approval buttons backed by cloud channel interactions
- route channel callback interactions through cloud interaction resolution and wire fake provider interaction support for E2E coverage

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check

Closes #421