### PR TITLE
Add gateway render operation contract

### DIFF
--- a/apps/gateway/src/event-renderer.ts
+++ b/apps/gateway/src/event-renderer.ts
@@ -14,6 +14,10 @@ import type {
 } from '@open-cowork/cloud-client'
 
 import type { CloudGateway } from './cloud-gateway.js'
+import {
+  executeRenderOperation,
+  normalizeChannelCapabilities,
+} from './render/operations.js'
 
 export type RenderGatewaySessionEventInput = {
   cloud: CloudGateway
@@ -73,13 +77,25 @@ async function sendPermissionRequest(input: RenderGatewaySessionEventInput): Pro
     || stringField(input.event.payload, 'summary')
     || stringField(input.event.payload, 'tool')
   const text = description ? `${title}\n${description}` : title
+  const target = targetForBinding(input.binding, input.provider.id)
+  const capabilities = normalizeChannelCapabilities(input.provider.capabilities)
+  if (!capabilities.inlineButtons) {
+    const sent = await sendTextChunks(input.provider, target, `${text}\n/approve ${issued.plaintextToken}`)
+    return { handled: true, lastChatMessageId: sent?.messageId ?? null }
+  }
+
   const buttons: ChannelButton[][] = [[{
     label: 'Approve',
     token: issued.plaintextToken,
     style: 'success',
   }]]
-  const sent = await input.provider.sendButtons(targetForBinding(input.binding, input.provider.id), text, buttons)
-  return { handled: true, lastChatMessageId: sent.messageId }
+  const result = await executeRenderOperation(input.provider, {
+    type: 'send_buttons',
+    target,
+    text,
+    buttons,
+  })
+  return { handled: true, lastChatMessageId: result.sentMessage?.messageId ?? null }
 }
 
 async function sendQuestion(
@@ -99,7 +115,12 @@ async function sendTextChunks(
 ): Promise<SentMessage | null> {
   let sent: SentMessage | null = null
   for (const chunk of chunkText(text, provider.capabilities.maxTextLength)) {
-    sent = await provider.sendText(target, chunk)
+    const result = await executeRenderOperation(provider, {
+      type: 'send_text',
+      target,
+      text: chunk,
+    })
+    sent = result.sentMessage ?? null
   }
   return sent
 }

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -32,6 +32,15 @@ export {
   renderGatewaySessionEvent,
 } from './event-renderer.js'
 export {
+  executeRenderOperation,
+  getGatewayRenderProfile,
+  normalizeChannelCapabilities,
+  type GatewayRenderOperation,
+  type GatewayRenderOperationResult,
+  type GatewayRenderProfile,
+  type NormalizedChannelCapabilities,
+} from './render/operations.js'
+export {
   routeGatewayInteraction,
 } from './interaction-router.js'
 export {

--- a/apps/gateway/src/render-operation.test.ts
+++ b/apps/gateway/src/render-operation.test.ts
@@ -1,0 +1,161 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createButtonCapableFakeProvider,
+  createButtonlessFakeProvider,
+  createConstrainedMessageFakeProvider,
+  createFileCapableFakeProvider,
+} from '@open-cowork/gateway-testing'
+
+import {
+  executeRenderOperation,
+  getGatewayRenderProfile,
+  normalizeChannelCapabilities,
+} from '../dist/index.js'
+
+test('normalizes provider capabilities with render-operation defaults and overrides', () => {
+  const normalized = normalizeChannelCapabilities({
+    threads: true,
+    messageEditing: true,
+    inlineButtons: true,
+    fileUploads: true,
+    fileDownloads: false,
+    typingIndicator: true,
+    maxTextLength: 4096,
+    preferredParseMode: 'markdown',
+    parseModes: ['plain'],
+    maxButtonsPerMessage: 3,
+    maxButtonTokenBytes: 32,
+    supportsEphemeralResponses: true,
+  })
+
+  assert.deepEqual(normalized.parseModes.sort(), ['markdown', 'plain'])
+  assert.equal(normalized.maxButtonsPerMessage, 3)
+  assert.equal(normalized.maxButtonRowsPerMessage, 4)
+  assert.equal(normalized.maxButtonTokenBytes, 32)
+  assert.equal(normalized.supportsEphemeralResponses, true)
+})
+
+test('render profile keeps provider identity separate from normalized capabilities', () => {
+  const provider = createButtonCapableFakeProvider()
+  const profile = getGatewayRenderProfile(provider)
+
+  assert.equal(profile.providerId, 'cli')
+  assert.equal(profile.capabilities.inlineButtons, true)
+  assert.equal(profile.capabilities.maxButtonsPerMessage, 8)
+})
+
+test('capability matrix executes supported operations and rejects unsupported button/edit/file operations', async () => {
+  const buttonCapable = createButtonCapableFakeProvider()
+  const buttonless = createButtonlessFakeProvider()
+  const noFile = createButtonlessFakeProvider({ capabilities: { fileDownloads: false } })
+  const fileCapable = createFileCapableFakeProvider()
+  const constrained = createConstrainedMessageFakeProvider()
+  const target = { provider: 'cli' as const, chatId: 'chat-1', threadId: 'thread-1' }
+
+  const text = await executeRenderOperation(buttonCapable, {
+    type: 'send_text',
+    target,
+    text: 'hello',
+  })
+  assert.equal(text.handled, true)
+  assert.equal(text.sentMessage?.messageId, '1')
+
+  await executeRenderOperation(buttonCapable, {
+    type: 'edit_text',
+    target,
+    messageId: text.sentMessage?.messageId ?? '1',
+    text: 'hello edited',
+  })
+  assert.equal(buttonCapable.sent.at(-1)?.kind, 'edit')
+
+  const buttons = await executeRenderOperation(buttonCapable, {
+    type: 'send_buttons',
+    target,
+    text: 'approve?',
+    buttons: [[{ label: 'Approve', token: 'approve-token', style: 'success' }]],
+  })
+  assert.equal(buttons.sentMessage?.messageId, '3')
+
+  const typing = await executeRenderOperation(buttonCapable, {
+    type: 'set_typing',
+    target,
+  })
+  assert.equal(typing.handled, true)
+  assert.equal(buttonCapable.typing.length, 1)
+
+  const ack = await executeRenderOperation(buttonCapable, {
+    type: 'acknowledge_interaction',
+    interactionId: 'callback-1',
+    text: 'Approved',
+  })
+  assert.equal(ack.handled, true)
+  assert.deepEqual(buttonCapable.answered, [{ interactionId: 'callback-1', text: 'Approved', alert: undefined }])
+
+  const file = await executeRenderOperation(fileCapable, {
+    type: 'send_file',
+    target,
+    file: { filename: 'artifact.txt', data: new TextEncoder().encode('ok') },
+  })
+  assert.equal(file.sentMessage?.messageId, '1')
+
+  const artifactLink = await executeRenderOperation(buttonless, {
+    type: 'send_artifact_link',
+    target,
+    artifact: { filename: 'report.md', url: 'https://cloud.example.test/artifacts/report' },
+  })
+  assert.equal(artifactLink.handled, true)
+  assert.equal(buttonless.sent[0]?.text, 'report.md: https://cloud.example.test/artifacts/report')
+
+  const unsupportedTyping = await executeRenderOperation(buttonless, {
+    type: 'set_typing',
+    target,
+  })
+  assert.equal(unsupportedTyping.handled, false)
+  assert.equal(unsupportedTyping.skippedReason, 'unsupported_capability')
+
+  await assert.rejects(
+    executeRenderOperation(buttonless, {
+      type: 'send_buttons',
+      target,
+      text: 'approve?',
+      buttons: [[{ label: 'Approve', token: 'approve-token' }]],
+    }),
+    /inline buttons/,
+  )
+  await assert.rejects(
+    executeRenderOperation(buttonless, {
+      type: 'edit_text',
+      target,
+      messageId: '1',
+      text: 'edit',
+    }),
+    /message editing/,
+  )
+  await assert.rejects(
+    executeRenderOperation(noFile, {
+      type: 'send_file',
+      target,
+      file: { filename: 'artifact.txt', data: new Uint8Array() },
+    }),
+    /outgoing files/,
+  )
+  await assert.rejects(
+    executeRenderOperation(constrained, {
+      type: 'send_text',
+      target,
+      text: 'x'.repeat(129),
+    }),
+    /maxTextLength 128/,
+  )
+  await assert.rejects(
+    executeRenderOperation(constrained, {
+      type: 'send_buttons',
+      target,
+      text: 'approve?',
+      buttons: [[{ label: 'Approve', token: 'x'.repeat(25) }]],
+    }),
+    /maxButtonTokenBytes 24/,
+  )
+})

--- a/apps/gateway/src/render/operations.ts
+++ b/apps/gateway/src/render/operations.ts
@@ -1,0 +1,221 @@
+import type {
+  ChannelButton,
+  ChannelCapabilities,
+  ChannelProvider,
+  ChannelTarget,
+  OutgoingFile,
+  SendOptions,
+  SentMessage,
+} from '@open-cowork/gateway-channel'
+
+export type ChannelParseMode = 'plain' | 'markdown' | 'html'
+
+export type NormalizedChannelCapabilities = {
+  threads: boolean
+  messageEditing: boolean
+  inlineButtons: boolean
+  fileUploads: boolean
+  fileDownloads: boolean
+  typingIndicator: boolean
+  maxTextLength: number
+  preferredParseMode: ChannelParseMode
+  parseModes: ChannelParseMode[]
+  maxButtonsPerMessage: number
+  maxButtonRowsPerMessage: number
+  maxButtonTokenBytes: number
+  supportsEphemeralResponses: boolean
+}
+
+export type GatewayRenderOperation =
+  | {
+    type: 'send_text'
+    target: ChannelTarget
+    text: string
+    options?: SendOptions
+  }
+  | {
+    type: 'edit_text'
+    target: ChannelTarget
+    messageId: string
+    text: string
+    options?: SendOptions
+  }
+  | {
+    type: 'send_buttons'
+    target: ChannelTarget
+    text: string
+    buttons: ChannelButton[][]
+  }
+  | {
+    type: 'send_file'
+    target: ChannelTarget
+    file: OutgoingFile
+  }
+  | {
+    type: 'send_artifact_link'
+    target: ChannelTarget
+    artifact: {
+      url: string
+      filename?: string
+      label?: string
+    }
+    options?: SendOptions
+  }
+  | {
+    type: 'set_typing'
+    target: ChannelTarget
+  }
+  | {
+    type: 'acknowledge_interaction'
+    interactionId: string
+    text?: string
+    alert?: boolean
+  }
+
+export type GatewayRenderOperationResult = {
+  operationType: GatewayRenderOperation['type']
+  handled: boolean
+  sentMessage?: SentMessage
+  skippedReason?: 'unsupported_capability'
+}
+
+export type GatewayRenderProfile = {
+  providerId: ChannelProvider['id']
+  capabilities: NormalizedChannelCapabilities
+}
+
+export function getGatewayRenderProfile(provider: Pick<ChannelProvider, 'id' | 'capabilities'>): GatewayRenderProfile {
+  return {
+    providerId: provider.id,
+    capabilities: normalizeChannelCapabilities(provider.capabilities),
+  }
+}
+
+export function normalizeChannelCapabilities(capabilities: ChannelCapabilities): NormalizedChannelCapabilities {
+  const preferredParseMode = capabilities.preferredParseMode
+  const parseModes = normalizeParseModes(capabilities.parseModes, preferredParseMode)
+
+  return {
+    threads: capabilities.threads,
+    messageEditing: capabilities.messageEditing,
+    inlineButtons: capabilities.inlineButtons,
+    fileUploads: capabilities.fileUploads,
+    fileDownloads: capabilities.fileDownloads,
+    typingIndicator: capabilities.typingIndicator,
+    maxTextLength: positiveInteger(capabilities.maxTextLength, 'maxTextLength'),
+    preferredParseMode,
+    parseModes,
+    maxButtonsPerMessage: positiveInteger(capabilities.maxButtonsPerMessage ?? 8, 'maxButtonsPerMessage'),
+    maxButtonRowsPerMessage: positiveInteger(capabilities.maxButtonRowsPerMessage ?? 4, 'maxButtonRowsPerMessage'),
+    maxButtonTokenBytes: positiveInteger(capabilities.maxButtonTokenBytes ?? 128, 'maxButtonTokenBytes'),
+    supportsEphemeralResponses: capabilities.supportsEphemeralResponses ?? false,
+  }
+}
+
+export async function executeRenderOperation(
+  provider: ChannelProvider,
+  operation: GatewayRenderOperation,
+): Promise<GatewayRenderOperationResult> {
+  const capabilities = normalizeChannelCapabilities(provider.capabilities)
+
+  switch (operation.type) {
+    case 'send_text': {
+      assertTextFits(operation.text, capabilities)
+      const sentMessage = await provider.sendText(operation.target, operation.text, withDefaultParseMode(operation.options, capabilities))
+      return { operationType: operation.type, handled: true, sentMessage }
+    }
+    case 'edit_text': {
+      if (!capabilities.messageEditing) {
+        throw new Error('Channel provider does not support message editing.')
+      }
+      assertTextFits(operation.text, capabilities)
+      await provider.editText(operation.target, operation.messageId, operation.text, withDefaultParseMode(operation.options, capabilities))
+      return { operationType: operation.type, handled: true }
+    }
+    case 'send_buttons': {
+      if (!capabilities.inlineButtons) {
+        throw new Error('Channel provider does not support inline buttons.')
+      }
+      assertTextFits(operation.text, capabilities)
+      assertButtonsFit(operation.buttons, capabilities)
+      const sentMessage = await provider.sendButtons(operation.target, operation.text, operation.buttons)
+      return { operationType: operation.type, handled: true, sentMessage }
+    }
+    case 'send_file': {
+      if (!capabilities.fileDownloads) {
+        throw new Error('Channel provider does not support outgoing files.')
+      }
+      const sentMessage = await provider.sendFile(operation.target, operation.file)
+      return { operationType: operation.type, handled: true, sentMessage }
+    }
+    case 'send_artifact_link': {
+      const text = formatArtifactLink(operation.artifact)
+      assertTextFits(text, capabilities)
+      const sentMessage = await provider.sendText(operation.target, text, withDefaultParseMode(operation.options, capabilities))
+      return { operationType: operation.type, handled: true, sentMessage }
+    }
+    case 'set_typing': {
+      if (!capabilities.typingIndicator || !provider.setTyping) {
+        return { operationType: operation.type, handled: false, skippedReason: 'unsupported_capability' }
+      }
+      await provider.setTyping(operation.target)
+      return { operationType: operation.type, handled: true }
+    }
+    case 'acknowledge_interaction': {
+      if (!provider.answerInteraction) {
+        return { operationType: operation.type, handled: false, skippedReason: 'unsupported_capability' }
+      }
+      await provider.answerInteraction(operation.interactionId, operation.text, operation.alert)
+      return { operationType: operation.type, handled: true }
+    }
+  }
+}
+
+function normalizeParseModes(
+  parseModes: ChannelCapabilities['parseModes'],
+  preferredParseMode: ChannelParseMode,
+): ChannelParseMode[] {
+  const unique = new Set<ChannelParseMode>(parseModes?.length ? parseModes : [preferredParseMode])
+  unique.add(preferredParseMode)
+  return Array.from(unique)
+}
+
+function withDefaultParseMode(options: SendOptions | undefined, capabilities: NormalizedChannelCapabilities): SendOptions {
+  return {
+    ...options,
+    parseMode: options?.parseMode ?? capabilities.preferredParseMode,
+  }
+}
+
+function assertTextFits(text: string, capabilities: NormalizedChannelCapabilities) {
+  if (text.length > capabilities.maxTextLength) {
+    throw new Error(`Rendered text exceeds provider maxTextLength ${capabilities.maxTextLength}.`)
+  }
+}
+
+function assertButtonsFit(buttons: ChannelButton[][], capabilities: NormalizedChannelCapabilities) {
+  if (buttons.length > capabilities.maxButtonRowsPerMessage) {
+    throw new Error(`Rendered buttons exceed provider maxButtonRowsPerMessage ${capabilities.maxButtonRowsPerMessage}.`)
+  }
+  const flat = buttons.flat()
+  if (flat.length > capabilities.maxButtonsPerMessage) {
+    throw new Error(`Rendered buttons exceed provider maxButtonsPerMessage ${capabilities.maxButtonsPerMessage}.`)
+  }
+  for (const button of flat) {
+    if (new TextEncoder().encode(button.token).byteLength > capabilities.maxButtonTokenBytes) {
+      throw new Error(`Rendered button token exceeds provider maxButtonTokenBytes ${capabilities.maxButtonTokenBytes}.`)
+    }
+  }
+}
+
+function formatArtifactLink(artifact: { url: string, filename?: string, label?: string }) {
+  const label = artifact.label || artifact.filename || 'Artifact available'
+  return `${label}: ${artifact.url}`
+}
+
+function positiveInteger(value: number, field: string) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Channel capability ${field} must be a positive integer.`)
+  }
+  return value
+}

--- a/packages/gateway-channel/src/provider.ts
+++ b/packages/gateway-channel/src/provider.ts
@@ -28,6 +28,11 @@ export interface ChannelCapabilities {
   typingIndicator: boolean;
   maxTextLength: number;
   preferredParseMode: "plain" | "markdown" | "html";
+  parseModes?: Array<"plain" | "markdown" | "html">;
+  maxButtonsPerMessage?: number;
+  maxButtonRowsPerMessage?: number;
+  maxButtonTokenBytes?: number;
+  supportsEphemeralResponses?: boolean;
 }
 
 export interface ChannelTarget {

--- a/packages/gateway-testing/src/fake-channel.test.ts
+++ b/packages/gateway-testing/src/fake-channel.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import { expect } from "../../../tests/gateway-test-expect.ts";
-import { FakeChannelProvider } from "@open-cowork/gateway-testing";
+import {
+  createButtonCapableFakeProvider,
+  createButtonlessFakeProvider,
+  createConstrainedMessageFakeProvider,
+  createFileCapableFakeProvider,
+  FakeChannelProvider
+} from "@open-cowork/gateway-testing";
 
 describe("FakeChannelProvider", () => {
   it("records sent text, files, and buttons for gateway e2e tests", async () => {
@@ -30,6 +36,31 @@ describe("FakeChannelProvider", () => {
       file: { filename: "result.txt" }
     });
     expect(provider.answered).toEqual([{ interactionId: "callback-1", text: "Approved", alert: undefined }]);
+  });
+
+  it("provides realistic fake provider capability presets", async () => {
+    const buttonCapable = createButtonCapableFakeProvider();
+    expect(buttonCapable.capabilities.inlineButtons).toBe(true);
+    expect(buttonCapable.capabilities.messageEditing).toBe(true);
+    await buttonCapable.setTyping({ provider: "cli", chatId: "chat-1" });
+    expect(buttonCapable.typing).toHaveLength(1);
+
+    const buttonless = createButtonlessFakeProvider();
+    expect(buttonless.capabilities.inlineButtons).toBe(false);
+    await expect(
+      buttonless.sendButtons({ provider: "cli", chatId: "chat-1" }, "approve?", [[{ label: "Approve", token: "token" }]]),
+    ).rejects.toThrow("does not support inline buttons");
+
+    const fileCapable = createFileCapableFakeProvider();
+    await expect(
+      fileCapable.sendFile({ provider: "cli", chatId: "chat-1" }, { filename: "artifact.txt", data: new Uint8Array() }),
+    ).resolves.toMatchObject({ messageId: "1" });
+
+    const constrained = createConstrainedMessageFakeProvider();
+    expect(constrained.capabilities.maxTextLength).toBe(128);
+    await expect(constrained.sendText({ provider: "cli", chatId: "chat-1" }, "x".repeat(129))).rejects.toThrow(
+      "maxTextLength 128",
+    );
   });
 
   it("dispatches emitted messages only while started", async () => {

--- a/packages/gateway-testing/src/fake-channel.ts
+++ b/packages/gateway-testing/src/fake-channel.ts
@@ -2,29 +2,65 @@ import type {
   ChannelButton,
   ChannelCapabilities,
   ChannelProvider,
+  ChannelProviderId,
   ChannelTarget,
+  ChannelAttachment,
   IncomingChannelMessage,
   OutgoingFile,
   SendOptions,
   SentMessage
 } from "@open-cowork/gateway-channel";
 
-export class FakeChannelProvider implements ChannelProvider {
-  readonly id = "cli" as const;
-  readonly capabilities: ChannelCapabilities = {
-    threads: false,
-    messageEditing: true,
-    inlineButtons: true,
-    fileUploads: true,
-    fileDownloads: true,
-    typingIndicator: false,
-    maxTextLength: 4096,
-    preferredParseMode: "plain"
-  };
+export type FakeChannelSentEntry = {
+  kind: "text" | "edit" | "buttons" | "file";
+  target: ChannelTarget;
+  text?: string;
+  file?: OutgoingFile;
+  buttons?: ChannelButton[][];
+  messageId?: string;
+  options?: SendOptions;
+};
 
-  readonly sent: Array<{ target: ChannelTarget; text?: string; file?: OutgoingFile; buttons?: ChannelButton[][] }> = [];
+export type FakeChannelProviderOptions = {
+  id?: ChannelProviderId;
+  capabilities?: Partial<ChannelCapabilities>;
+  now?: () => Date;
+};
+
+const defaultFakeCapabilities: ChannelCapabilities = {
+  threads: false,
+  messageEditing: true,
+  inlineButtons: true,
+  fileUploads: true,
+  fileDownloads: true,
+  typingIndicator: false,
+  maxTextLength: 4096,
+  preferredParseMode: "plain",
+  parseModes: ["plain"],
+  maxButtonsPerMessage: 8,
+  maxButtonRowsPerMessage: 4,
+  maxButtonTokenBytes: 128,
+  supportsEphemeralResponses: true
+};
+
+export class FakeChannelProvider implements ChannelProvider {
+  readonly id: ChannelProviderId;
+  readonly capabilities: ChannelCapabilities;
+
+  readonly sent: FakeChannelSentEntry[] = [];
   readonly answered: Array<{ interactionId: string; text?: string; alert?: boolean }> = [];
+  readonly typing: ChannelTarget[] = [];
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
+  private readonly now: () => Date;
+
+  constructor(options: FakeChannelProviderOptions = {}) {
+    this.id = options.id ?? "cli";
+    this.capabilities = {
+      ...defaultFakeCapabilities,
+      ...options.capabilities
+    };
+    this.now = options.now ?? (() => new Date());
+  }
 
   async start(handler: (message: IncomingChannelMessage) => Promise<void>): Promise<void> {
     this.handler = handler;
@@ -42,17 +78,25 @@ export class FakeChannelProvider implements ChannelProvider {
   }
 
   async sendText(target: ChannelTarget, text: string, _options?: SendOptions): Promise<SentMessage> {
-    this.sent.push({ target, text });
-    return sent(target, this.sent.length);
+    assertTextWithinLimit(text, this.capabilities.maxTextLength);
+    this.sent.push({ kind: "text", target, text, options: _options });
+    return sent(target, this.sent.length, this.now());
   }
 
   async editText(target: ChannelTarget, messageId: string, text: string): Promise<void> {
-    this.sent.push({ target: { ...target, messageId }, text });
+    if (!this.capabilities.messageEditing) {
+      throw new Error("Fake channel provider does not support message editing");
+    }
+    assertTextWithinLimit(text, this.capabilities.maxTextLength);
+    this.sent.push({ kind: "edit", target: { ...target, messageId }, text, messageId });
   }
 
   async sendFile(target: ChannelTarget, file: OutgoingFile): Promise<SentMessage> {
-    this.sent.push({ target, file });
-    return sent(target, this.sent.length);
+    if (!this.capabilities.fileDownloads) {
+      throw new Error("Fake channel provider does not support outgoing files");
+    }
+    this.sent.push({ kind: "file", target, file });
+    return sent(target, this.sent.length, this.now());
   }
 
   async sendButtons(
@@ -60,21 +104,118 @@ export class FakeChannelProvider implements ChannelProvider {
     text: string,
     buttons: ChannelButton[][],
   ): Promise<SentMessage> {
-    this.sent.push({ target, text, buttons });
-    return sent(target, this.sent.length);
+    if (!this.capabilities.inlineButtons) {
+      throw new Error("Fake channel provider does not support inline buttons");
+    }
+    assertTextWithinLimit(text, this.capabilities.maxTextLength);
+    assertButtonsWithinLimits(buttons, this.capabilities);
+    this.sent.push({ kind: "buttons", target, text, buttons });
+    return sent(target, this.sent.length, this.now());
   }
 
   async answerInteraction(interactionId: string, text?: string, alert?: boolean): Promise<void> {
     this.answered.push({ interactionId, text, alert });
   }
+
+  async setTyping(target: ChannelTarget): Promise<void> {
+    if (!this.capabilities.typingIndicator) {
+      throw new Error("Fake channel provider does not support typing indicators");
+    }
+    this.typing.push(target);
+  }
+
+  async downloadAttachment(attachment: ChannelAttachment): Promise<Uint8Array> {
+    if (!this.capabilities.fileUploads) {
+      throw new Error("Fake channel provider does not support incoming files");
+    }
+    if (attachment.buffer) return attachment.buffer;
+    throw new Error("Fake attachment has no buffer");
+  }
 }
 
-function sent(target: ChannelTarget, id: number): SentMessage {
+function sent(target: ChannelTarget, id: number, sentAt: Date): SentMessage {
   return {
     provider: target.provider,
     chatId: target.chatId,
     threadId: target.threadId,
     messageId: String(id),
-    sentAt: new Date()
+    sentAt
   };
+}
+
+export function createButtonCapableFakeProvider(options: FakeChannelProviderOptions = {}): FakeChannelProvider {
+  return new FakeChannelProvider({
+    ...options,
+    capabilities: {
+      messageEditing: true,
+      inlineButtons: true,
+      typingIndicator: true,
+      supportsEphemeralResponses: true,
+      ...options.capabilities
+    }
+  });
+}
+
+export function createButtonlessFakeProvider(options: FakeChannelProviderOptions = {}): FakeChannelProvider {
+  return new FakeChannelProvider({
+    ...options,
+    capabilities: {
+      messageEditing: false,
+      inlineButtons: false,
+      typingIndicator: false,
+      supportsEphemeralResponses: false,
+      ...options.capabilities
+    }
+  });
+}
+
+export function createFileCapableFakeProvider(options: FakeChannelProviderOptions = {}): FakeChannelProvider {
+  return new FakeChannelProvider({
+    ...options,
+    capabilities: {
+      fileUploads: true,
+      fileDownloads: true,
+      ...options.capabilities
+    }
+  });
+}
+
+export function createConstrainedMessageFakeProvider(options: FakeChannelProviderOptions = {}): FakeChannelProvider {
+  return new FakeChannelProvider({
+    ...options,
+    capabilities: {
+      messageEditing: false,
+      inlineButtons: true,
+      maxTextLength: 128,
+      maxButtonsPerMessage: 2,
+      maxButtonRowsPerMessage: 1,
+      maxButtonTokenBytes: 24,
+      supportsEphemeralResponses: false,
+      ...options.capabilities
+    }
+  });
+}
+
+function assertTextWithinLimit(text: string, maxTextLength: number) {
+  if (text.length > maxTextLength) {
+    throw new Error(`Fake channel text exceeds maxTextLength ${maxTextLength}`);
+  }
+}
+
+function assertButtonsWithinLimits(buttons: ChannelButton[][], capabilities: ChannelCapabilities) {
+  const maxRows = capabilities.maxButtonRowsPerMessage ?? 4;
+  const maxButtons = capabilities.maxButtonsPerMessage ?? 8;
+  const maxTokenBytes = capabilities.maxButtonTokenBytes ?? 128;
+  const flattened = buttons.flat();
+  if (buttons.length > maxRows) {
+    throw new Error(`Fake channel buttons exceed maxButtonRowsPerMessage ${maxRows}`);
+  }
+  if (flattened.length > maxButtons) {
+    throw new Error(`Fake channel buttons exceed maxButtonsPerMessage ${maxButtons}`);
+  }
+  for (const button of flattened) {
+    if (new TextEncoder().encode(button.token).byteLength > maxTokenBytes) {
+      throw new Error(`Fake channel button token exceeds maxButtonTokenBytes ${maxTokenBytes}`);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add a typed gateway render operation contract for text, edits, buttons, files, artifact links, typing, and interaction acknowledgements.
- Normalize channel capabilities with explicit render limits and expose render profiles for provider-agnostic dispatch.
- Extend fake channel providers with button-capable, button-less, file-capable, and constrained-message presets plus capability enforcement.
- Route the current session event renderer through the render operation executor and add capability matrix coverage.

Closes #422.

## Verification

- `pnpm --filter @open-cowork/gateway-testing test`
- `pnpm --filter @open-cowork/gateway test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`