### PR TITLE
Implement gateway channel rendering

### DIFF
--- a/apps/gateway/src/event-renderer.test.ts
+++ b/apps/gateway/src/event-renderer.test.ts
@@ -1,0 +1,312 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createButtonCapableFakeProvider,
+  createButtonlessFakeProvider,
+  createConstrainedMessageFakeProvider,
+} from '@open-cowork/gateway-testing'
+
+import type { CloudGateway } from '../dist/index.js'
+import {
+  createGatewaySessionRenderState,
+  renderGatewaySessionEvent,
+} from '../dist/index.js'
+
+test('event renderer edits streaming assistant output for button-capable providers', async () => {
+  const provider = createButtonCapableFakeProvider()
+  const state = createGatewaySessionRenderState()
+  const binding = bindingRecord()
+  const cloud = cloudStub()
+
+  const first = await renderGatewaySessionEvent({
+    cloud,
+    provider,
+    binding,
+    state,
+    event: {
+      eventId: 'event-1',
+      sequence: 1,
+      type: 'assistant.message',
+      payload: { messageId: 'assistant-1', content: 'Hel' },
+    },
+  })
+  const second = await renderGatewaySessionEvent({
+    cloud,
+    provider,
+    binding,
+    state,
+    event: {
+      eventId: 'event-2',
+      sequence: 2,
+      type: 'assistant.message',
+      payload: { messageId: 'assistant-1', content: 'Hello' },
+    },
+  })
+  const duplicate = await renderGatewaySessionEvent({
+    cloud,
+    provider,
+    binding,
+    state,
+    event: {
+      eventId: 'event-3',
+      sequence: 3,
+      type: 'assistant.message',
+      payload: { messageId: 'assistant-1', content: 'Hello' },
+    },
+  })
+
+  assert.equal(first.lastChatMessageId, '1')
+  assert.equal(second.lastChatMessageId, '1')
+  assert.equal(duplicate.handled, false)
+  assert.deepEqual(provider.sent.map((entry) => ({
+    kind: entry.kind,
+    text: entry.text,
+    messageId: entry.messageId,
+  })), [{
+    kind: 'text',
+    text: 'Hel',
+    messageId: undefined,
+  }, {
+    kind: 'edit',
+    text: 'Hello',
+    messageId: '1',
+  }])
+})
+
+test('event renderer chunks buttonless assistant output and renders approval command fallback', async () => {
+  const provider = createButtonlessFakeProvider({
+    capabilities: { maxTextLength: 128 },
+  })
+  const state = createGatewaySessionRenderState()
+  const interactions: unknown[] = []
+  const cloud = cloudStub({
+    async createChannelInteraction(input: unknown) {
+      interactions.push(input)
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'approval-token',
+      }
+    },
+  })
+
+  await renderGatewaySessionEvent({
+    cloud,
+    provider,
+    binding: bindingRecord(),
+    state,
+    event: {
+      eventId: 'event-1',
+      sequence: 1,
+      type: 'assistant.message',
+      payload: { messageId: 'assistant-1', content: 'hello '.repeat(40) },
+    },
+  })
+  await renderGatewaySessionEvent({
+    cloud,
+    provider,
+    binding: bindingRecord(),
+    state,
+    event: {
+      eventId: 'event-2',
+      sequence: 2,
+      type: 'permission.requested',
+      payload: {
+        permissionId: 'permission-1',
+        title: 'Run command',
+        description: 'Allow shell command?',
+      },
+    },
+  })
+
+  assert.equal(provider.sent.filter((entry) => entry.kind === 'text').length > 1, true)
+  const fallback = provider.sent.at(-1)?.text || ''
+  assert.match(fallback, /Run command\nAllow shell command\?/)
+  assert.match(fallback, /\/approve approval-token/)
+  assert.match(fallback, /\/deny approval-token/)
+  assert.equal(provider.sent.some((entry) => entry.buttons), false)
+  const created = interactions[0] as { interactionId?: string }
+  assert.match(created.interactionId || '', /^gw_permission_/)
+  assert.deepEqual({ ...created, interactionId: undefined }, {
+    interactionId: undefined,
+    agentId: 'agent-1',
+    sessionId: 'session-1',
+    provider: 'cli',
+    kind: 'permission',
+    targetId: 'permission-1',
+  })
+})
+
+test('event renderer keeps tool progress compact and redacts failure details', async () => {
+  const provider = createButtonCapableFakeProvider()
+  const state = createGatewaySessionRenderState()
+  const input = {
+    cloud: cloudStub(),
+    provider,
+    binding: bindingRecord(),
+    state,
+  }
+
+  await renderGatewaySessionEvent({
+    ...input,
+    event: {
+      eventId: 'event-1',
+      sequence: 1,
+      type: 'tool.call',
+      payload: { id: 'tool-1', name: 'bash', status: 'running' },
+    },
+  })
+  await renderGatewaySessionEvent({
+    ...input,
+    event: {
+      eventId: 'event-2',
+      sequence: 2,
+      type: 'tool.call',
+      payload: {
+        id: 'tool-1',
+        name: 'bash',
+        status: 'error',
+        error: 'failed with token=super-secret-token',
+      },
+    },
+  })
+
+  assert.deepEqual(provider.sent.map((entry) => ({
+    kind: entry.kind,
+    text: entry.text,
+    messageId: entry.messageId,
+  })), [{
+    kind: 'text',
+    text: 'Tool running: bash',
+    messageId: undefined,
+  }, {
+    kind: 'edit',
+    text: 'Tool failed: bash\nfailed with token=[redacted]',
+    messageId: '1',
+  }])
+})
+
+test('event renderer renders question option buttons and buttonless text fallback', async () => {
+  const buttonProvider = createButtonCapableFakeProvider()
+  const buttonlessProvider = createButtonlessFakeProvider()
+  const buttonState = createGatewaySessionRenderState()
+  const fallbackState = createGatewaySessionRenderState()
+  const cloud = cloudStub({
+    async createChannelInteraction() {
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'question-token',
+      }
+    },
+  })
+  const event = {
+    eventId: 'event-1',
+    sequence: 1,
+    type: 'question.asked',
+    payload: {
+      requestId: 'question-1',
+      questions: [{
+        header: 'Choose mode',
+        question: 'Deploy now?',
+        options: [
+          { label: 'Yes', description: 'Ship it' },
+          { label: 'No', description: 'Hold back' },
+        ],
+      }],
+    },
+  }
+
+  await renderGatewaySessionEvent({
+    cloud,
+    provider: buttonProvider,
+    binding: bindingRecord(),
+    state: buttonState,
+    event,
+  })
+  await renderGatewaySessionEvent({
+    cloud,
+    provider: buttonlessProvider,
+    binding: bindingRecord(),
+    state: fallbackState,
+    event,
+  })
+
+  const buttons = buttonProvider.sent[0]?.buttons
+  assert.equal(buttonProvider.sent[0]?.text, 'Choose mode\nDeploy now?\n- Yes: Ship it\n- No: Hold back')
+  assert.equal(buttons?.[0]?.[0]?.label, 'Yes')
+  assert.equal(buttons?.[0]?.[0]?.token.startsWith('ans:'), true)
+  assert.equal(buttons?.[1]?.[0]?.label, 'Reject')
+  assert.equal(buttons?.[1]?.[0]?.token, 'rej:question-token')
+
+  const fallback = buttonlessProvider.sent[0]?.text || ''
+  assert.match(fallback, /Choose mode\nDeploy now\?/)
+  assert.match(fallback, /\/answer question-token <response>/)
+  assert.match(fallback, /\/reject question-token/)
+})
+
+test('event renderer falls back to question text when option tokens exceed provider limits', async () => {
+  const provider = createConstrainedMessageFakeProvider({
+    capabilities: { maxTextLength: 200 },
+  })
+  await renderGatewaySessionEvent({
+    cloud: cloudStub({
+      async createChannelInteraction() {
+        return {
+          interaction: { interactionId: 'interaction-1' },
+          plaintextToken: 'question-token-that-is-too-long-for-buttons',
+        }
+      },
+    }),
+    provider,
+    binding: bindingRecord(),
+    state: createGatewaySessionRenderState(),
+    event: {
+      eventId: 'event-1',
+      sequence: 1,
+      type: 'question.asked',
+      payload: {
+        requestId: 'question-1',
+        questions: [{
+          question: 'Choose?',
+          options: [{ label: 'A very long option label', description: '' }],
+        }],
+      },
+    },
+  })
+
+  assert.equal(provider.sent[0]?.kind, 'text')
+  assert.equal(provider.sent[0]?.buttons, undefined)
+  assert.match(provider.sent[0]?.text || '', /\/answer question-token-that-is-too-long-for-buttons <response>/)
+})
+
+function bindingRecord() {
+  return {
+    bindingId: 'binding-1',
+    orgId: 'tenant-1',
+    agentId: 'agent-1',
+    channelBindingId: 'channel-binding-1',
+    provider: 'cli' as const,
+    externalWorkspaceId: null,
+    externalThreadId: 'thread-1',
+    externalChatId: 'chat-1',
+    sessionId: 'session-1',
+    lastEventSequence: 0,
+    lastWorkspaceSequence: 0,
+    lastChatMessageId: null,
+    status: 'active' as const,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  }
+}
+
+function cloudStub(overrides: Partial<CloudGateway> = {}): CloudGateway {
+  return {
+    async createChannelInteraction() {
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'interaction-token',
+      }
+    },
+    ...overrides,
+  } as CloudGateway
+}

--- a/apps/gateway/src/event-renderer.ts
+++ b/apps/gateway/src/event-renderer.ts
@@ -1,29 +1,26 @@
-import { randomBytes } from 'node:crypto'
-
 import type {
-  ChannelButton,
   ChannelProviderId,
   ChannelProvider,
   ChannelTarget,
-  SentMessage,
 } from '@open-cowork/gateway-channel'
-import { chunkText } from '@open-cowork/gateway-channel'
 import type {
   ChannelSessionBindingRecord,
   CloudTransportSessionEvent,
 } from '@open-cowork/cloud-client'
 
 import type { CloudGateway } from './cloud-gateway.js'
-import {
-  executeRenderOperation,
-  normalizeChannelCapabilities,
-} from './render/operations.js'
+import { renderApprovalRequest } from './render/approval-renderer.js'
+import { renderQuestionRequest } from './render/question-renderer.js'
+import type { GatewaySessionRenderState } from './render/state.js'
+import { renderAssistantStream } from './render/text-stream-renderer.js'
+import { renderToolProgress } from './render/tool-progress-renderer.js'
 
 export type RenderGatewaySessionEventInput = {
   cloud: CloudGateway
   provider: ChannelProvider
   binding: ChannelSessionBindingRecord
   event: CloudTransportSessionEvent
+  state: GatewaySessionRenderState
 }
 
 export type RenderGatewaySessionEventResult = {
@@ -34,95 +31,35 @@ export type RenderGatewaySessionEventResult = {
 export async function renderGatewaySessionEvent(
   input: RenderGatewaySessionEventInput,
 ): Promise<RenderGatewaySessionEventResult> {
+  const target = targetForBinding(input.binding, input.provider.id)
   if (input.event.type === 'assistant.message') {
-    return sendAssistantMessage(input.provider, targetForBinding(input.binding, input.provider.id), readAssistantText(input.event))
+    return renderAssistantStream({
+      provider: input.provider,
+      target,
+      state: input.state,
+      sourceMessageId: readAssistantSourceMessageId(input.event),
+      content: readAssistantText(input.event),
+    })
+  }
+
+  if (input.event.type === 'tool.call') {
+    return renderToolProgress({
+      provider: input.provider,
+      target,
+      state: input.state,
+      event: input.event,
+    })
   }
 
   if (input.event.type === 'permission.requested') {
-    return sendPermissionRequest(input)
+    return renderApprovalRequest({ ...input, target })
   }
 
   if (input.event.type === 'question.asked') {
-    return sendQuestion(input.provider, targetForBinding(input.binding, input.provider.id), readQuestionText(input.event))
+    return renderQuestionRequest({ ...input, target })
   }
 
   return { handled: false }
-}
-
-async function sendAssistantMessage(
-  provider: ChannelProvider,
-  target: ChannelTarget,
-  text: string,
-): Promise<RenderGatewaySessionEventResult> {
-  if (!text.trim()) return { handled: false }
-  const sent = await sendTextChunks(provider, target, text)
-  return { handled: true, lastChatMessageId: sent?.messageId ?? null }
-}
-
-async function sendPermissionRequest(input: RenderGatewaySessionEventInput): Promise<RenderGatewaySessionEventResult> {
-  const permissionId = stringField(input.event.payload, 'permissionId')
-    || stringField(input.event.payload, 'id')
-  if (!permissionId) return { handled: false }
-
-  const issued = await input.cloud.createChannelInteraction({
-    interactionId: channelInteractionId(input.binding, input.event, permissionId),
-    agentId: input.binding.agentId,
-    sessionId: input.binding.sessionId,
-    provider: input.binding.provider,
-    kind: 'permission',
-    targetId: permissionId,
-  })
-  const title = stringField(input.event.payload, 'title') || 'Permission requested'
-  const description = stringField(input.event.payload, 'description')
-    || stringField(input.event.payload, 'summary')
-    || stringField(input.event.payload, 'tool')
-  const text = description ? `${title}\n${description}` : title
-  const target = targetForBinding(input.binding, input.provider.id)
-  const capabilities = normalizeChannelCapabilities(input.provider.capabilities)
-  if (!capabilities.inlineButtons) {
-    const sent = await sendTextChunks(input.provider, target, `${text}\n/approve ${issued.plaintextToken}`)
-    return { handled: true, lastChatMessageId: sent?.messageId ?? null }
-  }
-
-  const buttons: ChannelButton[][] = [[{
-    label: 'Approve',
-    token: issued.plaintextToken,
-    style: 'success',
-  }]]
-  const result = await executeRenderOperation(input.provider, {
-    type: 'send_buttons',
-    target,
-    text,
-    buttons,
-  })
-  return { handled: true, lastChatMessageId: result.sentMessage?.messageId ?? null }
-}
-
-async function sendQuestion(
-  provider: ChannelProvider,
-  target: ChannelTarget,
-  text: string,
-): Promise<RenderGatewaySessionEventResult> {
-  if (!text.trim()) return { handled: false }
-  const sent = await sendTextChunks(provider, target, text)
-  return { handled: true, lastChatMessageId: sent?.messageId ?? null }
-}
-
-async function sendTextChunks(
-  provider: ChannelProvider,
-  target: ChannelTarget,
-  text: string,
-): Promise<SentMessage | null> {
-  let sent: SentMessage | null = null
-  for (const chunk of chunkText(text, provider.capabilities.maxTextLength)) {
-    const result = await executeRenderOperation(provider, {
-      type: 'send_text',
-      target,
-      text: chunk,
-    })
-    sent = result.sentMessage ?? null
-  }
-  return sent
 }
 
 function targetForBinding(binding: ChannelSessionBindingRecord, provider: ChannelProviderId): ChannelTarget {
@@ -141,32 +78,11 @@ function readAssistantText(event: CloudTransportSessionEvent): string {
     || ''
 }
 
-function readQuestionText(event: CloudTransportSessionEvent): string {
-  const title = stringField(event.payload, 'title') || 'Question requested'
-  const question = stringField(event.payload, 'question')
-    || stringField(event.payload, 'prompt')
-    || readFirstQuestionText(event.payload)
-  return question ? `${title}\n${question}` : title
-}
-
-function readFirstQuestionText(payload: unknown): string | null {
-  if (!payload || typeof payload !== 'object') return null
-  const questions = (payload as Record<string, unknown>).questions
-  if (!Array.isArray(questions)) return null
-  const first = questions[0]
-  if (typeof first === 'string') return first
-  if (first && typeof first === 'object') {
-    return stringField(first, 'label') || stringField(first, 'prompt') || stringField(first, 'text')
-  }
-  return null
-}
-
-function channelInteractionId(
-  _binding: ChannelSessionBindingRecord,
-  _event: CloudTransportSessionEvent,
-  _targetId: string,
-) {
-  return `gw_${randomBytes(9).toString('base64url')}`
+function readAssistantSourceMessageId(event: CloudTransportSessionEvent): string {
+  return stringField(event.payload, 'messageId')
+    || stringField(event.payload, 'id')
+    || event.entityId
+    || `${event.sessionId || 'session'}:assistant:${event.sequence}`
 }
 
 function stringField(payload: unknown, key: string): string | null {

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -85,10 +85,9 @@ async function handleMessage(
   const externalUserId = message.sender.providerUserId
 
   try {
-    if (message.interaction?.token) {
-      const registration = providers.get(providerConfig.id)
-      if (!registration) throw new Error(`Unknown gateway provider ${providerConfig.id}.`)
-      await routeGatewayInteraction({ cloud, provider: registration.provider, providerConfig, message, metrics })
+    const registration = providers.get(providerConfig.id)
+    if (!registration) throw new Error(`Unknown gateway provider ${providerConfig.id}.`)
+    if (await routeGatewayInteraction({ cloud, provider: registration.provider, providerConfig, message, metrics })) {
       return
     }
 
@@ -114,8 +113,6 @@ async function handleMessage(
       externalThreadId: message.target.threadId || message.target.chatId,
       title: text.slice(0, 80),
     })
-    const registration = providers.get(providerConfig.id)
-    if (!registration) throw new Error(`Unknown gateway provider ${providerConfig.id}.`)
     streams.ensure({ binding: bound.binding, provider: registration.provider })
     await cloud.prompt({
       bindingId: bound.binding.bindingId,

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -41,6 +41,13 @@ export {
   type NormalizedChannelCapabilities,
 } from './render/operations.js'
 export {
+  createGatewaySessionRenderState,
+  type GatewaySessionRenderState,
+} from './render/state.js'
+export {
+  mergeStreamingText,
+} from './render/text-stream-renderer.js'
+export {
   routeGatewayInteraction,
 } from './interaction-router.js'
 export {

--- a/apps/gateway/src/interaction-router.test.ts
+++ b/apps/gateway/src/interaction-router.test.ts
@@ -50,7 +50,7 @@ test('interaction router resolves channel button tokens through cloud and acknow
       attachments: [],
       interaction: {
         id: 'callback-1',
-        token: 'token-1',
+        token: 'apv:token-1',
         kind: 'button',
       },
       receivedAt: new Date(0),
@@ -73,6 +73,66 @@ test('interaction router resolves channel button tokens through cloud and acknow
     alert: undefined,
   }])
   assert.equal(metrics.interactionsResolved, 1)
+})
+
+test('interaction router resolves deny, answer, and reject fallback commands through cloud', async () => {
+  const provider = new FakeChannelProvider()
+  const calls: unknown[] = []
+  const cloud = {
+    async resolveChannelInteraction(input: unknown) {
+      calls.push(input)
+      return { interaction: { interactionId: 'interaction-1' }, command: { commandId: 'cmd-1' }, processed: 1 }
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }).providers[0]
+  const metrics = createGatewayMetrics()
+
+  for (const [text, expected] of [
+    ['/deny deny-token', { response: { allowed: false } }],
+    ['/answer answer-token Ship it', { answers: ['Ship it'] }],
+    ['/reject reject-token', { reject: true }],
+  ] as const) {
+    const handled = await routeGatewayInteraction({
+      cloud,
+      provider,
+      providerConfig: config,
+      metrics,
+      message: {
+        id: `message-${calls.length + 1}`,
+        provider: 'cli',
+        target: { provider: 'cli', chatId: 'chat-1' },
+        sender: { providerUserId: 'user-1' },
+        text,
+        rawText: text,
+        isCommand: true,
+        command: text.split(/\s+/)[0]?.slice(1),
+        commandArgs: text.split(/\s+/).slice(1).join(' '),
+        attachments: [],
+        receivedAt: new Date(0),
+        raw: {},
+      },
+    })
+    assert.equal(handled, true)
+    assert.deepEqual(calls.at(-1), {
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalUserId: 'user-1',
+      token: text.split(/\s+/)[1],
+      externalInteractionId: `message-${calls.length}`,
+      ...expected,
+    })
+  }
+  assert.equal(metrics.interactionsResolved, 3)
 })
 
 test('interaction router ignores ordinary channel messages', async () => {

--- a/apps/gateway/src/interaction-router.ts
+++ b/apps/gateway/src/interaction-router.ts
@@ -4,6 +4,7 @@ import type { CloudChannelProviderId } from '@open-cowork/cloud-client'
 import type { CloudGateway } from './cloud-gateway.js'
 import type { GatewayProviderConfig } from './config.js'
 import type { GatewayMetrics } from './metrics.js'
+import { parseGatewayInteractionToken } from './render/interaction-tokens.js'
 
 export type RouteGatewayInteractionInput = {
   cloud: CloudGateway
@@ -14,8 +15,8 @@ export type RouteGatewayInteractionInput = {
 }
 
 export async function routeGatewayInteraction(input: RouteGatewayInteractionInput): Promise<boolean> {
-  const interaction = input.message.interaction
-  if (!interaction?.token) return false
+  const interaction = readInteractionIntent(input.message)
+  if (!interaction) return false
 
   const cloudProvider = input.message.provider as CloudChannelProviderId
   await input.cloud.resolveChannelInteraction({
@@ -23,17 +24,116 @@ export async function routeGatewayInteraction(input: RouteGatewayInteractionInpu
     externalWorkspaceId: input.providerConfig.externalWorkspaceId ?? null,
     externalUserId: input.message.sender.providerUserId,
     token: interaction.token,
-    externalInteractionId: interaction.id,
-    response: { allowed: true },
+    externalInteractionId: interaction.externalInteractionId,
+    ...interaction.resolution,
   })
   input.metrics.interactionsResolved += 1
 
   if (input.provider.answerInteraction) {
     try {
-      await input.provider.answerInteraction(interaction.id, 'Approved')
+      await input.provider.answerInteraction(interaction.externalInteractionId, interaction.acknowledgement)
     } catch {
       input.metrics.errors += 1
     }
   }
   return true
+}
+
+type InteractionIntent = {
+  token: string
+  externalInteractionId: string
+  acknowledgement: string
+  resolution: {
+    response?: unknown
+    answers?: unknown[]
+    reject?: boolean
+  }
+}
+
+function readInteractionIntent(message: IncomingChannelMessage): InteractionIntent | null {
+  if (message.interaction?.token) {
+    const parsed = parseGatewayInteractionToken(message.interaction.token)
+    return {
+      token: parsed.token,
+      externalInteractionId: message.interaction.id,
+      acknowledgement: acknowledgementFor(parsed.action),
+      resolution: resolutionForParsedToken(parsed),
+    }
+  }
+
+  const command = parseFallbackCommand(message.rawText || message.text)
+  if (!command) return null
+  return {
+    token: command.token,
+    externalInteractionId: message.id,
+    acknowledgement: acknowledgementFor(command.action),
+    resolution: command.action === 'approve'
+      ? { response: { allowed: true } }
+      : command.action === 'deny'
+        ? { response: { allowed: false } }
+        : command.action === 'reject'
+          ? { reject: true }
+          : { answers: [command.answer] },
+  }
+}
+
+function resolutionForParsedToken(parsed: ReturnType<typeof parseGatewayInteractionToken>): InteractionIntent['resolution'] {
+  switch (parsed.action) {
+    case 'approve':
+      return { response: { allowed: true } }
+    case 'deny':
+      return { response: { allowed: false } }
+    case 'answer':
+      return { answers: [parsed.answer] }
+    case 'reject':
+      return { reject: true }
+    case 'default':
+      return { response: { allowed: true } }
+  }
+}
+
+function acknowledgementFor(action: ReturnType<typeof parseGatewayInteractionToken>['action'] | FallbackCommand['action']) {
+  return action === 'deny'
+    ? 'Denied'
+    : action === 'reject'
+      ? 'Rejected'
+      : action === 'answer'
+        ? 'Answered'
+        : 'Approved'
+}
+
+type FallbackCommand =
+  | { action: 'approve', token: string }
+  | { action: 'deny', token: string }
+  | { action: 'reject', token: string }
+  | { action: 'answer', token: string, answer: string }
+
+function parseFallbackCommand(text: string): FallbackCommand | null {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('/')) return null
+
+  const commandEnd = firstWhitespaceIndex(trimmed)
+  if (commandEnd < 0) return null
+
+  const verb = trimmed.slice(1, commandEnd).toLowerCase()
+  const rest = trimmed.slice(commandEnd).trimStart()
+  if (!rest) return null
+
+  const tokenEnd = firstWhitespaceIndex(rest)
+  const token = tokenEnd < 0 ? rest : rest.slice(0, tokenEnd)
+  const answer = tokenEnd < 0 ? '' : rest.slice(tokenEnd).trim()
+
+  if (!token) return null
+  if (verb === 'approve' || verb === 'allow') return { action: 'approve', token }
+  if (verb === 'deny') return { action: 'deny', token }
+  if (verb === 'reject') return { action: 'reject', token }
+  if (verb === 'answer' && answer) return { action: 'answer', token, answer }
+  return null
+}
+
+function firstWhitespaceIndex(value: string): number {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index]?.trim() === '') return index
+  }
+  return -1
 }

--- a/apps/gateway/src/render/approval-renderer.ts
+++ b/apps/gateway/src/render/approval-renderer.ts
@@ -1,0 +1,125 @@
+import { randomBytes } from 'node:crypto'
+
+import type {
+  ChannelButton,
+  ChannelProvider,
+  ChannelTarget,
+} from '@open-cowork/gateway-channel'
+import { chunkText } from '@open-cowork/gateway-channel'
+
+import type {
+  ChannelSessionBindingRecord,
+  CloudTransportSessionEvent,
+} from '@open-cowork/cloud-client'
+
+import type { CloudGateway } from '../cloud-gateway.js'
+import {
+  approvalToken,
+  denialToken,
+} from './interaction-tokens.js'
+import {
+  executeRenderOperation,
+  normalizeChannelCapabilities,
+} from './operations.js'
+import { sanitizeChannelText } from './sanitize.js'
+
+export type RenderApprovalRequestInput = {
+  cloud: CloudGateway
+  provider: ChannelProvider
+  target: ChannelTarget
+  binding: ChannelSessionBindingRecord
+  event: CloudTransportSessionEvent
+}
+
+export type RenderApprovalRequestResult = {
+  handled: boolean
+  lastChatMessageId?: string | null
+}
+
+export async function renderApprovalRequest(input: RenderApprovalRequestInput): Promise<RenderApprovalRequestResult> {
+  const permissionId = stringField(input.event.payload, 'permissionId')
+    || stringField(input.event.payload, 'id')
+  if (!permissionId) return { handled: false }
+
+  const issued = await input.cloud.createChannelInteraction({
+    interactionId: channelInteractionId(input.event, permissionId, 'permission'),
+    agentId: input.binding.agentId,
+    sessionId: input.binding.sessionId,
+    provider: input.binding.provider,
+    kind: 'permission',
+    targetId: permissionId,
+  })
+  const text = approvalText(input.event.payload)
+  const capabilities = normalizeChannelCapabilities(input.provider.capabilities)
+  const buttons: ChannelButton[][] = [[{
+    label: 'Approve',
+    token: approvalToken(issued.plaintextToken),
+    style: 'success',
+  }, {
+    label: 'Deny',
+    token: denialToken(issued.plaintextToken),
+    style: 'danger',
+  }]]
+
+  if (
+    capabilities.inlineButtons
+    && text.length <= capabilities.maxTextLength
+    && buttonsFit(buttons, capabilities.maxButtonsPerMessage, capabilities.maxButtonRowsPerMessage, capabilities.maxButtonTokenBytes)
+  ) {
+    const result = await executeRenderOperation(input.provider, {
+      type: 'send_buttons',
+      target: input.target,
+      text,
+      buttons,
+    })
+    return { handled: true, lastChatMessageId: result.sentMessage?.messageId ?? null }
+  }
+
+  const fallback = `${text}\n/approve ${issued.plaintextToken}\n/deny ${issued.plaintextToken}`
+  let lastChatMessageId: string | null = null
+  for (const chunk of chunkText(fallback, capabilities.maxTextLength)) {
+    const result = await executeRenderOperation(input.provider, {
+      type: 'send_text',
+      target: input.target,
+      text: chunk,
+    })
+    lastChatMessageId = result.sentMessage?.messageId ?? lastChatMessageId
+  }
+  return { handled: true, lastChatMessageId }
+}
+
+function approvalText(payload: Record<string, unknown>): string {
+  const title = sanitizeChannelText(stringField(payload, 'title') || 'Permission requested', 160)
+  const description = sanitizeChannelText(
+    stringField(payload, 'description')
+      || stringField(payload, 'summary')
+      || stringField(payload, 'tool')
+      || '',
+    320,
+  )
+  return description ? `${title}\n${description}` : title
+}
+
+function buttonsFit(
+  buttons: ChannelButton[][],
+  maxButtons: number,
+  maxRows: number,
+  maxTokenBytes: number,
+) {
+  return buttons.length <= maxRows
+    && buttons.flat().length <= maxButtons
+    && buttons.flat().every((button) => Buffer.byteLength(button.token, 'utf8') <= maxTokenBytes)
+}
+
+function channelInteractionId(
+  _event: CloudTransportSessionEvent,
+  _targetId: string,
+  kind: string,
+) {
+  return `gw_${kind}_${randomBytes(9).toString('base64url')}`
+}
+
+function stringField(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}

--- a/apps/gateway/src/render/interaction-tokens.ts
+++ b/apps/gateway/src/render/interaction-tokens.ts
@@ -1,0 +1,43 @@
+export type ParsedGatewayInteractionToken =
+  | { action: 'approve', token: string }
+  | { action: 'deny', token: string }
+  | { action: 'answer', token: string, answer: string }
+  | { action: 'reject', token: string }
+  | { action: 'default', token: string }
+
+export function approvalToken(token: string): string {
+  return `apv:${token}`
+}
+
+export function denialToken(token: string): string {
+  return `den:${token}`
+}
+
+export function answerToken(token: string, answer: string): string {
+  return `ans:${Buffer.from(answer, 'utf8').toString('base64url')}:${token}`
+}
+
+export function rejectionToken(token: string): string {
+  return `rej:${token}`
+}
+
+export function parseGatewayInteractionToken(value: string): ParsedGatewayInteractionToken {
+  const token = value.trim()
+  if (token.startsWith('apv:')) return { action: 'approve', token: token.slice(4) }
+  if (token.startsWith('den:')) return { action: 'deny', token: token.slice(4) }
+  if (token.startsWith('rej:')) return { action: 'reject', token: token.slice(4) }
+  if (token.startsWith('ans:')) {
+    const rest = token.slice(4)
+    const separator = rest.indexOf(':')
+    if (separator > 0) {
+      const encoded = rest.slice(0, separator)
+      const rawToken = rest.slice(separator + 1)
+      return {
+        action: 'answer',
+        token: rawToken,
+        answer: Buffer.from(encoded, 'base64url').toString('utf8'),
+      }
+    }
+  }
+  return { action: 'default', token }
+}

--- a/apps/gateway/src/render/question-renderer.ts
+++ b/apps/gateway/src/render/question-renderer.ts
@@ -1,0 +1,177 @@
+import { randomBytes } from 'node:crypto'
+
+import type {
+  ChannelButton,
+  ChannelProvider,
+  ChannelTarget,
+} from '@open-cowork/gateway-channel'
+import { chunkText } from '@open-cowork/gateway-channel'
+
+import type {
+  ChannelSessionBindingRecord,
+  CloudTransportSessionEvent,
+} from '@open-cowork/cloud-client'
+
+import type { CloudGateway } from '../cloud-gateway.js'
+import {
+  answerToken,
+  rejectionToken,
+} from './interaction-tokens.js'
+import {
+  executeRenderOperation,
+  normalizeChannelCapabilities,
+} from './operations.js'
+import { sanitizeChannelText } from './sanitize.js'
+
+export type RenderQuestionRequestInput = {
+  cloud: CloudGateway
+  provider: ChannelProvider
+  target: ChannelTarget
+  binding: ChannelSessionBindingRecord
+  event: CloudTransportSessionEvent
+}
+
+export type RenderQuestionRequestResult = {
+  handled: boolean
+  lastChatMessageId?: string | null
+}
+
+type QuestionPrompt = {
+  header: string
+  question: string
+  options: Array<{ label: string, description: string }>
+  multiple: boolean
+  custom: boolean
+}
+
+export async function renderQuestionRequest(input: RenderQuestionRequestInput): Promise<RenderQuestionRequestResult> {
+  const requestId = stringField(input.event.payload, 'requestId')
+    || stringField(input.event.payload, 'requestID')
+    || stringField(input.event.payload, 'id')
+  if (!requestId) return { handled: false }
+
+  const issued = await input.cloud.createChannelInteraction({
+    interactionId: `gw_question_${randomBytes(9).toString('base64url')}`,
+    agentId: input.binding.agentId,
+    sessionId: input.binding.sessionId,
+    provider: input.binding.provider,
+    kind: 'question',
+    targetId: requestId,
+  })
+  const questions = readQuestions(input.event.payload)
+  const text = questionText(questions, issued.plaintextToken)
+  const capabilities = normalizeChannelCapabilities(input.provider.capabilities)
+  const buttons = questionButtons(questions, issued.plaintextToken, capabilities.maxButtonTokenBytes)
+
+  const buttonText = baseQuestionText(questions)
+  if (
+    capabilities.inlineButtons
+    && buttons
+    && buttonText.length <= capabilities.maxTextLength
+    && buttonsFit(buttons, capabilities.maxButtonsPerMessage, capabilities.maxButtonRowsPerMessage)
+  ) {
+    const result = await executeRenderOperation(input.provider, {
+      type: 'send_buttons',
+      target: input.target,
+      text: buttonText,
+      buttons,
+    })
+    return { handled: true, lastChatMessageId: result.sentMessage?.messageId ?? null }
+  }
+
+  let lastChatMessageId: string | null = null
+  for (const chunk of chunkText(text, capabilities.maxTextLength)) {
+    const result = await executeRenderOperation(input.provider, {
+      type: 'send_text',
+      target: input.target,
+      text: chunk,
+    })
+    lastChatMessageId = result.sentMessage?.messageId ?? lastChatMessageId
+  }
+  return { handled: true, lastChatMessageId }
+}
+
+function questionText(questions: QuestionPrompt[], token: string) {
+  return `${baseQuestionText(questions)}\n/answer ${token} <response>\n/reject ${token}`
+}
+
+function baseQuestionText(questions: QuestionPrompt[]) {
+  if (questions.length === 0) return 'Question requested'
+  return questions.map((question, index) => {
+    const header = question.header || (questions.length > 1 ? `Question ${index + 1}` : 'Question requested')
+    const options = question.options.length
+      ? `\n${question.options.map((option) => {
+          const label = sanitizeChannelText(option.label, 80)
+          const description = sanitizeChannelText(option.description, 120)
+          return description ? `- ${label}: ${description}` : `- ${label}`
+        }).join('\n')}`
+      : ''
+    return `${sanitizeChannelText(header, 120)}\n${sanitizeChannelText(question.question, 320)}${options}`
+  }).join('\n\n')
+}
+
+function questionButtons(
+  questions: QuestionPrompt[],
+  token: string,
+  maxTokenBytes: number,
+): ChannelButton[][] | null {
+  if (questions.length !== 1) return null
+  const question = questions[0]
+  if (question.multiple || question.options.length === 0) return null
+  const buttons: ChannelButton[][] = [question.options.map((option) => ({
+    label: sanitizeChannelText(option.label, 40),
+    token: answerToken(token, option.label),
+  }))]
+  buttons.push([{ label: 'Reject', token: rejectionToken(token), style: 'danger' }])
+  return buttons.flat().every((button) => button.label && Buffer.byteLength(button.token, 'utf8') <= maxTokenBytes)
+    ? buttons
+    : null
+}
+
+function buttonsFit(buttons: ChannelButton[][], maxButtons: number, maxRows: number) {
+  return buttons.length <= maxRows && buttons.flat().length <= maxButtons
+}
+
+function readQuestions(payload: Record<string, unknown>): QuestionPrompt[] {
+  if (!Array.isArray(payload.questions)) {
+    const question = stringField(payload, 'question') || stringField(payload, 'prompt')
+    return question
+      ? [{
+          header: stringField(payload, 'title') || '',
+          question,
+          options: [],
+          multiple: false,
+          custom: true,
+        }]
+      : []
+  }
+  return payload.questions.map((entry): QuestionPrompt | null => {
+    if (!entry || typeof entry !== 'object') return null
+    const record = entry as Record<string, unknown>
+    const question = stringField(record, 'question') || stringField(record, 'prompt') || stringField(record, 'text')
+    if (!question) return null
+    return {
+      header: stringField(record, 'header') || '',
+      question,
+      options: Array.isArray(record.options)
+        ? record.options.map(readQuestionOption).filter((option): option is { label: string, description: string } => Boolean(option))
+        : [],
+      multiple: record.multiple === true,
+      custom: record.custom !== false,
+    }
+  }).filter((entry): entry is QuestionPrompt => Boolean(entry))
+}
+
+function readQuestionOption(value: unknown): { label: string, description: string } | null {
+  if (typeof value === 'string' && value.trim()) return { label: value.trim(), description: '' }
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const label = stringField(record, 'label')
+  const description = stringField(record, 'description') || ''
+  return label || description ? { label: label || description, description } : null
+}
+
+function stringField(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}

--- a/apps/gateway/src/render/sanitize.ts
+++ b/apps/gateway/src/render/sanitize.ts
@@ -1,0 +1,26 @@
+const secretPatterns = [
+  /(api[_-]?key|token|secret|password|credential)\s*[:=]\s*([^\s,;]+)/gi,
+  /(occ(?:i)?_[A-Za-z0-9_-]+_[A-Za-z0-9_-]+)/g,
+  /(sk-[A-Za-z0-9_-]{12,})/g,
+]
+
+export function sanitizeChannelText(value: string, maxLength = 512): string {
+  let sanitized = value
+  for (const pattern of secretPatterns) {
+    sanitized = sanitized.replace(pattern, (_match, left?: string) => {
+      return left && /api|token|secret|password|credential/i.test(left)
+        ? `${left}=[redacted]`
+        : '[redacted]'
+    })
+  }
+  sanitized = sanitized
+    .split('')
+    .filter((char) => {
+      const code = char.charCodeAt(0)
+      return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127)
+    })
+    .join('')
+  return sanitized.length > maxLength
+    ? `${sanitized.slice(0, Math.max(0, maxLength - 15)).trimEnd()}\n...[truncated]`
+    : sanitized
+}

--- a/apps/gateway/src/render/state.ts
+++ b/apps/gateway/src/render/state.ts
@@ -1,0 +1,24 @@
+export type AssistantStreamRenderState = {
+  sourceMessageId: string
+  providerMessageId: string | null
+  renderedText: string
+}
+
+export type ToolProgressRenderState = {
+  toolCallId: string
+  providerMessageId: string | null
+  renderedSummary: string
+  status: string
+}
+
+export type GatewaySessionRenderState = {
+  assistantStreams: Map<string, AssistantStreamRenderState>
+  toolProgress: Map<string, ToolProgressRenderState>
+}
+
+export function createGatewaySessionRenderState(): GatewaySessionRenderState {
+  return {
+    assistantStreams: new Map(),
+    toolProgress: new Map(),
+  }
+}

--- a/apps/gateway/src/render/text-stream-renderer.ts
+++ b/apps/gateway/src/render/text-stream-renderer.ts
@@ -1,0 +1,117 @@
+import type {
+  ChannelProvider,
+  ChannelTarget,
+  SentMessage,
+} from '@open-cowork/gateway-channel'
+import { chunkText } from '@open-cowork/gateway-channel'
+
+import {
+  executeRenderOperation,
+  normalizeChannelCapabilities,
+} from './operations.js'
+import type { GatewaySessionRenderState } from './state.js'
+
+export type RenderAssistantStreamInput = {
+  provider: ChannelProvider
+  target: ChannelTarget
+  state: GatewaySessionRenderState
+  sourceMessageId: string
+  content: string
+}
+
+export type RenderAssistantStreamResult = {
+  handled: boolean
+  lastChatMessageId?: string | null
+}
+
+export async function renderAssistantStream(input: RenderAssistantStreamInput): Promise<RenderAssistantStreamResult> {
+  const incoming = input.content.trimEnd()
+  if (!incoming.trim()) return { handled: false }
+
+  const capabilities = normalizeChannelCapabilities(input.provider.capabilities)
+  const existing = input.state.assistantStreams.get(input.sourceMessageId)
+  const nextText = existing
+    ? mergeStreamingText(existing.renderedText, incoming)
+    : incoming
+
+  if (existing && nextText === existing.renderedText) {
+    return { handled: false, lastChatMessageId: existing.providerMessageId }
+  }
+
+  if (capabilities.messageEditing && existing?.providerMessageId && nextText.length <= capabilities.maxTextLength) {
+    await executeRenderOperation(input.provider, {
+      type: 'edit_text',
+      target: input.target,
+      messageId: existing.providerMessageId,
+      text: nextText,
+    })
+    existing.renderedText = nextText
+    return { handled: true, lastChatMessageId: existing.providerMessageId }
+  }
+
+  if (capabilities.messageEditing && !existing && nextText.length <= capabilities.maxTextLength) {
+    const result = await executeRenderOperation(input.provider, {
+      type: 'send_text',
+      target: input.target,
+      text: nextText,
+    })
+    const providerMessageId = result.sentMessage?.messageId ?? null
+    input.state.assistantStreams.set(input.sourceMessageId, {
+      sourceMessageId: input.sourceMessageId,
+      providerMessageId,
+      renderedText: nextText,
+    })
+    return { handled: true, lastChatMessageId: providerMessageId }
+  }
+
+  const textToSend = existing ? streamingSuffix(existing.renderedText, nextText) : nextText
+  const sent = await sendTextChunks(input.provider, input.target, textToSend)
+  input.state.assistantStreams.set(input.sourceMessageId, {
+    sourceMessageId: input.sourceMessageId,
+    providerMessageId: sent?.messageId ?? existing?.providerMessageId ?? null,
+    renderedText: nextText,
+  })
+  return { handled: Boolean(sent), lastChatMessageId: sent?.messageId ?? existing?.providerMessageId ?? null }
+}
+
+export function mergeStreamingText(existing: string, incoming: string): string {
+  if (!existing) return incoming
+  if (!incoming || incoming === existing) return existing
+  if (incoming.startsWith(existing)) return incoming
+  if (existing.endsWith(incoming)) return existing
+
+  const overlap = longestOverlap(existing, incoming)
+  return `${existing}${incoming.slice(overlap)}`
+}
+
+function streamingSuffix(existing: string, nextText: string): string {
+  if (!existing) return nextText
+  if (nextText.startsWith(existing)) return nextText.slice(existing.length)
+  return nextText
+}
+
+async function sendTextChunks(
+  provider: ChannelProvider,
+  target: ChannelTarget,
+  text: string,
+): Promise<SentMessage | null> {
+  if (!text.trim()) return null
+  let sent: SentMessage | null = null
+  for (const chunk of chunkText(text, provider.capabilities.maxTextLength)) {
+    const result = await executeRenderOperation(provider, {
+      type: 'send_text',
+      target,
+      text: chunk,
+    })
+    sent = result.sentMessage ?? null
+  }
+  return sent
+}
+
+function longestOverlap(left: string, right: string): number {
+  const max = Math.min(left.length, right.length)
+  for (let length = max; length > 0; length -= 1) {
+    if (left.endsWith(right.slice(0, length))) return length
+  }
+  return 0
+}

--- a/apps/gateway/src/render/tool-progress-renderer.ts
+++ b/apps/gateway/src/render/tool-progress-renderer.ts
@@ -1,0 +1,100 @@
+import type {
+  ChannelProvider,
+  ChannelTarget,
+} from '@open-cowork/gateway-channel'
+
+import type { CloudTransportSessionEvent } from '@open-cowork/cloud-client'
+
+import {
+  executeRenderOperation,
+  normalizeChannelCapabilities,
+} from './operations.js'
+import { sanitizeChannelText } from './sanitize.js'
+import type { GatewaySessionRenderState } from './state.js'
+
+export type RenderToolProgressInput = {
+  provider: ChannelProvider
+  target: ChannelTarget
+  state: GatewaySessionRenderState
+  event: CloudTransportSessionEvent
+}
+
+export type RenderToolProgressResult = {
+  handled: boolean
+  lastChatMessageId?: string | null
+}
+
+export async function renderToolProgress(input: RenderToolProgressInput): Promise<RenderToolProgressResult> {
+  const toolCallId = stringField(input.event.payload, 'id')
+    || stringField(input.event.payload, 'callId')
+    || stringField(input.event.payload, 'toolCallId')
+    || `${input.event.sessionId || 'session'}:tool:${input.event.sequence}`
+  const status = normalizeStatus(stringField(input.event.payload, 'status'))
+  const summary = buildToolSummary(input.event.payload, status)
+  const existing = input.state.toolProgress.get(toolCallId)
+  if (existing?.renderedSummary === summary && existing.status === status) {
+    return { handled: false, lastChatMessageId: existing.providerMessageId }
+  }
+
+  const capabilities = normalizeChannelCapabilities(input.provider.capabilities)
+  if (existing?.providerMessageId && capabilities.messageEditing && summary.length <= capabilities.maxTextLength) {
+    await executeRenderOperation(input.provider, {
+      type: 'edit_text',
+      target: input.target,
+      messageId: existing.providerMessageId,
+      text: summary,
+    })
+    existing.renderedSummary = summary
+    existing.status = status
+    return { handled: true, lastChatMessageId: existing.providerMessageId }
+  }
+
+  const sent = await executeRenderOperation(input.provider, {
+    type: 'send_text',
+    target: input.target,
+    text: summary.length <= capabilities.maxTextLength
+      ? summary
+      : `${summary.slice(0, Math.max(0, capabilities.maxTextLength - 15)).trimEnd()}\n...[truncated]`,
+  })
+  const providerMessageId = sent.sentMessage?.messageId ?? existing?.providerMessageId ?? null
+  input.state.toolProgress.set(toolCallId, {
+    toolCallId,
+    providerMessageId,
+    renderedSummary: summary,
+    status,
+  })
+  return { handled: true, lastChatMessageId: providerMessageId }
+}
+
+function buildToolSummary(payload: Record<string, unknown>, status: string): string {
+  const name = sanitizeChannelText(
+    stringField(payload, 'name')
+      || stringField(payload, 'tool')
+      || 'tool',
+    120,
+  )
+  const prefix = status === 'error'
+    ? 'Tool failed'
+    : status === 'complete'
+      ? 'Tool complete'
+      : 'Tool running'
+  const detail = status === 'error'
+    ? stringField(payload, 'error') || stringField(payload, 'message') || stringField(payload, 'summary')
+    : null
+  return detail
+    ? `${prefix}: ${name}\n${sanitizeChannelText(detail, 320)}`
+    : `${prefix}: ${name}`
+}
+
+function normalizeStatus(value: string | null) {
+  return value === 'complete' || value === 'completed' || value === 'success'
+    ? 'complete'
+    : value === 'error' || value === 'failed' || value === 'failure'
+      ? 'error'
+      : 'running'
+}
+
+function stringField(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}

--- a/apps/gateway/src/session-stream-manager.test.ts
+++ b/apps/gateway/src/session-stream-manager.test.ts
@@ -215,8 +215,12 @@ test('session stream manager renders permission requests as channel buttons', as
   assert.equal(provider.sent[0].text, 'Run command\nAllow shell command?')
   assert.deepEqual(provider.sent[0].buttons, [[{
     label: 'Approve',
-    token: 'approve-token',
+    token: 'apv:approve-token',
     style: 'success',
+  }, {
+    label: 'Deny',
+    token: 'den:approve-token',
+    style: 'danger',
   }]])
   manager.closeAll()
 })

--- a/apps/gateway/src/session-stream-manager.ts
+++ b/apps/gateway/src/session-stream-manager.ts
@@ -10,6 +10,10 @@ import type {
 import type { CloudGateway } from './cloud-gateway.js'
 import { renderGatewaySessionEvent } from './event-renderer.js'
 import type { GatewayMetrics } from './metrics.js'
+import {
+  createGatewaySessionRenderState,
+  type GatewaySessionRenderState,
+} from './render/state.js'
 
 export type GatewaySessionStreamManager = {
   ensure(input: {
@@ -32,6 +36,7 @@ type StreamState = {
   lastEventSequence: number
   lastWorkspaceSequence: number
   lastChatMessageId: string | null
+  renderState: GatewaySessionRenderState
   queue: Promise<void>
   closed: boolean
   retryTimer?: ReturnType<typeof setTimeout>
@@ -63,6 +68,7 @@ export function createGatewaySessionStreamManager(
         lastEventSequence: input.binding.lastEventSequence,
         lastWorkspaceSequence: input.binding.lastWorkspaceSequence,
         lastChatMessageId: input.binding.lastChatMessageId,
+        renderState: createGatewaySessionRenderState(),
         queue: Promise.resolve(),
         closed: false,
       }
@@ -125,6 +131,7 @@ export function createGatewaySessionStreamManager(
           lastChatMessageId: state.lastChatMessageId,
         },
         event,
+        state: state.renderState,
       })
       const lastChatMessageId = rendered.lastChatMessageId ?? state.lastChatMessageId
       const updated = await cloud.updateCursor({

--- a/packages/gateway-provider-telegram/src/telegram-provider.ts
+++ b/packages/gateway-provider-telegram/src/telegram-provider.ts
@@ -50,7 +50,12 @@ export class TelegramProvider implements ChannelProvider {
     fileDownloads: true,
     typingIndicator: true,
     maxTextLength: 4096,
-    preferredParseMode: "plain"
+    preferredParseMode: "plain",
+    parseModes: ["plain"],
+    maxButtonsPerMessage: 8,
+    maxButtonRowsPerMessage: 4,
+    maxButtonTokenBytes: 64,
+    supportsEphemeralResponses: true
   };
 
   private readonly bot: Bot;

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -79,7 +79,12 @@ export class WebhookProvider implements ChannelProvider {
     fileDownloads: false,
     typingIndicator: true,
     maxTextLength: 4096,
-    preferredParseMode: "plain"
+    preferredParseMode: "plain",
+    parseModes: ["plain"],
+    maxButtonsPerMessage: 8,
+    maxButtonRowsPerMessage: 4,
+    maxButtonTokenBytes: 64,
+    supportsEphemeralResponses: false
   };
 
   private handler?: (message: IncomingChannelMessage) => Promise<void>;


### PR DESCRIPTION
## Summary
- add gateway render state and capability-aware assistant streaming, tool progress, approval, and question renderers
- route inline and fallback approval/question interactions through cloud channel interaction APIs
- extend provider capabilities and coverage for button-capable, buttonless, reconnect, and redaction paths

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check

Closes #423