### PR TITLE
Harden gateway artifact delivery and cursors

### DIFF
--- a/apps/gateway/src/cloud-gateway.test.ts
+++ b/apps/gateway/src/cloud-gateway.test.ts
@@ -22,6 +22,10 @@ test('cloud gateway wraps all required channel and session operations', async ()
       calls.push(`by-thread:${JSON.stringify(input)}`)
       return null
     },
+    async getSession(sessionId: string) {
+      calls.push(`session:${sessionId}`)
+      return { session: { sessionId }, projection: null }
+    },
     async promptChannelSession(input: unknown) {
       calls.push(`prompt:${JSON.stringify(input)}`)
       return { binding: { bindingId: 'binding-1' }, command: { commandId: 'cmd-1' }, processed: 1 }
@@ -50,6 +54,10 @@ test('cloud gateway wraps all required channel and session operations', async ()
       calls.push(`interaction-create:${JSON.stringify(input)}`)
       return { interaction: { interactionId: 'interaction-created' }, plaintextToken: 'token-created' }
     },
+    async readArtifactAttachment(sessionId: string, artifactId: string) {
+      calls.push(`artifact:${sessionId}:${artifactId}`)
+      return { filename: 'artifact.txt', mime: 'text/plain', url: 'data:text/plain;base64,b2s=' }
+    },
     subscribeSessionEvents(sessionId: string, input: { onEvent: (event: unknown) => void }) {
       calls.push(`session-events:${sessionId}`)
       input.onEvent({ eventId: 'event-1', sequence: 1, type: 'assistant.message', payload: {} })
@@ -77,6 +85,7 @@ test('cloud gateway wraps all required channel and session operations', async ()
   await gateway.resolveIdentity({ provider: 'telegram', externalUserId: 'user-1' })
   await gateway.bindSession({ channelBindingId: 'channel-1', provider: 'telegram', externalChatId: 'chat-1', externalThreadId: 'thread-1' })
   await gateway.findSessionByThread({ provider: 'telegram', externalChatId: 'chat-1', externalThreadId: 'thread-1' })
+  await gateway.getSession('session-1')
   await gateway.prompt({ bindingId: 'binding-1', text: 'hello' })
   await gateway.abortSession('session-1')
   await gateway.respondToPermission('session-1', { permissionId: 'permission-1', response: { allowed: true } })
@@ -90,6 +99,8 @@ test('cloud gateway wraps all required channel and session operations', async ()
     kind: 'permission',
     targetId: 'permission-1',
   })
+  await gateway.readArtifactAttachment?.('session-1', 'artifact-1')
+  assert.equal(gateway.artifactUrl('session-1', 'artifact-1'), 'https://cloud.example.test/api/sessions/session-1/artifacts/artifact-1')
   const sessionEvents = gateway.subscribeSessionEvents({ sessionId: 'session-1', onEvent() {} })
   const deliveries = gateway.subscribeDeliveries({ onDelivery() {} })
   await gateway.updateCursor({ bindingId: 'binding-1', lastEventSequence: 5, lastWorkspaceSequence: 7 })
@@ -103,6 +114,7 @@ test('cloud gateway wraps all required channel and session operations', async ()
     'identity',
     'bind',
     'by-thread',
+    'session',
     'prompt',
     'abort',
     'permission',
@@ -110,6 +122,7 @@ test('cloud gateway wraps all required channel and session operations', async ()
     'question-reject',
     'interaction',
     'interaction-create',
+    'artifact',
     'session-events',
     'deliveries',
     'cursor',

--- a/apps/gateway/src/cloud-gateway.ts
+++ b/apps/gateway/src/cloud-gateway.ts
@@ -5,6 +5,7 @@ import {
   type ChannelIdentityRecord,
   type ChannelSessionBindingRecord,
   type CloudChannelProviderId,
+  type SessionArtifactAttachment,
   type CloudSessionView,
   type CloudTransportAdapter,
   type CloudTransportSessionEvent,
@@ -36,6 +37,7 @@ export type CloudGateway = {
     externalChatId: string
     externalThreadId: string
   }): Promise<{ binding: ChannelSessionBindingRecord, session: CloudSessionView } | null>
+  getSession(sessionId: string): Promise<CloudSessionView>
   prompt(input: ChannelActorInput & {
     bindingId: string
     text: string
@@ -72,6 +74,8 @@ export type CloudGateway = {
     command: SessionCommandRecord
     processed: number
   }>
+  readArtifactAttachment?(sessionId: string, filePathOrArtifactId: string): Promise<SessionArtifactAttachment>
+  artifactUrl(sessionId: string, artifactId: string): string
   subscribeSessionEvents(input: {
     sessionId: string
     afterSequence?: number
@@ -112,6 +116,9 @@ export function createCloudGateway(config: GatewayConfig, adapter = createCloudA
       assertMethod(adapter.getChannelSessionByThread, 'getChannelSessionByThread')
       return adapter.getChannelSessionByThread(input)
     },
+    getSession(sessionId) {
+      return adapter.getSession(sessionId)
+    },
     async prompt(input) {
       assertMethod(adapter.promptChannelSession, 'promptChannelSession')
       return adapter.promptChannelSession(input)
@@ -135,6 +142,13 @@ export function createCloudGateway(config: GatewayConfig, adapter = createCloudA
     },
     rejectQuestion(sessionId, input) {
       return adapter.rejectQuestion(sessionId, input)
+    },
+    readArtifactAttachment(sessionId, filePathOrArtifactId) {
+      assertMethod(adapter.readArtifactAttachment, 'readArtifactAttachment')
+      return adapter.readArtifactAttachment(sessionId, filePathOrArtifactId)
+    },
+    artifactUrl(sessionId, artifactId) {
+      return `${normalizeBaseUrl(config.cloud.baseUrl)}/api/sessions/${encodeURIComponent(sessionId)}/artifacts/${encodeURIComponent(artifactId)}`
     },
     subscribeSessionEvents(input) {
       return adapter.subscribeSessionEvents(input.sessionId, {
@@ -165,6 +179,12 @@ function createCloudAdapter(config: GatewayConfig): CloudTransportAdapter {
       authorization: `Bearer ${config.cloud.serviceToken}`,
     },
   })
+}
+
+function normalizeBaseUrl(value: string) {
+  let normalized = value.trim()
+  while (normalized.endsWith('/')) normalized = normalized.slice(0, -1)
+  return normalized
 }
 
 function assertMethod<T>(method: T, name: string): asserts method is NonNullable<T> {

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -63,6 +63,7 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
       }
     },
     async findSessionByThread() { return null },
+    async getSession() { return { session: { sessionId: 'session-1' }, projection: null } as never },
     async prompt(input) {
       prompted.push(input.text)
       return { binding: { bindingId: input.bindingId } as never, command: { commandId: 'cmd-1' } as never, processed: 1 }
@@ -71,6 +72,8 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     async respondToPermission() { return { command: { commandId: 'cmd-permission' } as never, processed: 1 } },
     async replyToQuestion() { return { command: { commandId: 'cmd-question' } as never, processed: 1 } },
     async rejectQuestion() { return { command: { commandId: 'cmd-reject' } as never, processed: 1 } },
+    async readArtifactAttachment() { return { filename: 'artifact.txt', mime: 'text/plain', url: 'data:text/plain;base64,b2s=' } },
+    artifactUrl() { return 'https://cloud.example.test/api/sessions/session-1/artifacts/artifact-1' },
     async createChannelInteraction() { return { interaction: { interactionId: 'interaction-1' } as never, plaintextToken: 'token-1' } },
     async resolveChannelInteraction() { return { interaction: {}, command: { commandId: 'cmd-interaction' } as never, processed: 1 } },
     subscribeSessionEvents() { return { close() {} } },
@@ -188,6 +191,97 @@ test('gateway provider registry wires fake, Telegram, and webhook providers', ()
     provider: 'webhook',
   }])
 })
+
+test('gateway runtime retries transient deliveries and marks permanent failures dead', async () => {
+  let onDelivery: ((delivery: unknown) => void) | null = null
+  const acks: Array<{ deliveryId: string, input: Record<string, unknown> }> = []
+  const cloud = {
+    subscribeDeliveries(input: { onDelivery: (delivery: unknown) => void }) {
+      onDelivery = input.onDelivery
+      return { close() {} }
+    },
+    async ackDelivery(deliveryId: string, input: Record<string, unknown>) {
+      acks.push({ deliveryId, input })
+      return { deliveryId, ...input } as never
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud)
+  const provider = runtime.providers.get('fake')?.provider
+  assert.ok(provider)
+  const originalSendText = provider.sendText.bind(provider)
+  const failures = [
+    new Error('provider temporarily down token=super-secret-token'),
+    new Error('invalid target token=super-secret-token'),
+  ]
+  provider.sendText = async (...args) => {
+    const failure = failures.shift()
+    if (failure) throw failure
+    return originalSendText(...args)
+  }
+
+  await runtime.start()
+  try {
+    onDelivery?.(deliveryRecord({ deliveryId: 'delivery-1', attemptCount: 1 }))
+    await waitFor(() => acks.length === 1)
+    assert.equal(acks[0]?.input.status, 'failed')
+    assert.equal(typeof acks[0]?.input.nextAttemptAt, 'string')
+    assert.doesNotMatch(String(acks[0]?.input.lastError), /super-secret-token/)
+
+    onDelivery?.(deliveryRecord({ deliveryId: 'delivery-2', attemptCount: 1 }))
+    await waitFor(() => acks.length === 2)
+    assert.equal(acks[1]?.input.status, 'dead')
+    assert.equal(acks[1]?.input.nextAttemptAt, null)
+    assert.doesNotMatch(String(acks[1]?.input.lastError), /super-secret-token/)
+  } finally {
+    await runtime.stop()
+  }
+})
+
+function deliveryRecord(overrides: Partial<{
+  deliveryId: string
+  attemptCount: number
+}> = {}) {
+  return {
+    deliveryId: overrides.deliveryId || 'delivery-1',
+    orgId: 'tenant-1',
+    agentId: 'agent-1',
+    channelBindingId: 'fake-binding',
+    sessionBindingId: null,
+    provider: 'cli',
+    target: {
+      externalChatId: 'chat-1',
+      externalThreadId: 'thread-1',
+    },
+    eventType: 'workflow.completed',
+    payload: { text: 'delivery text' },
+    status: 'claimed',
+    attemptCount: overrides.attemptCount ?? 1,
+    claimedBy: 'gateway:test',
+    claimExpiresAt: new Date(Date.now() + 30_000).toISOString(),
+    nextAttemptAt: new Date(0).toISOString(),
+    lastError: null,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error('Timed out waiting for predicate.')
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
 
 async function readJson(response: Response) {
   assert.equal(response.headers.get('content-type')?.includes('application/json'), true)

--- a/apps/gateway/src/event-renderer.test.ts
+++ b/apps/gateway/src/event-renderer.test.ts
@@ -5,6 +5,7 @@ import {
   createButtonCapableFakeProvider,
   createButtonlessFakeProvider,
   createConstrainedMessageFakeProvider,
+  createFileCapableFakeProvider,
 } from '@open-cowork/gateway-testing'
 
 import type { CloudGateway } from '../dist/index.js'
@@ -277,6 +278,96 @@ test('event renderer falls back to question text when option tokens exceed provi
   assert.equal(provider.sent[0]?.kind, 'text')
   assert.equal(provider.sent[0]?.buttons, undefined)
   assert.match(provider.sent[0]?.text || '', /\/answer question-token-that-is-too-long-for-buttons <response>/)
+})
+
+test('event renderer sends cloud artifacts as files when provider limits allow it', async () => {
+  const provider = createFileCapableFakeProvider()
+  const state = createGatewaySessionRenderState()
+  const cloud = cloudStub({
+    async readArtifactAttachment(sessionId: string, artifactId: string) {
+      assert.equal(sessionId, 'session-1')
+      assert.equal(artifactId, 'artifact-1')
+      return {
+        filename: 'report.txt',
+        mime: 'text/plain',
+        url: `data:text/plain;base64,${Buffer.from('artifact body').toString('base64')}`,
+      }
+    },
+    artifactUrl() {
+      throw new Error('artifact link fallback should not be used')
+    },
+  })
+
+  await renderGatewaySessionEvent({
+    cloud,
+    provider,
+    binding: bindingRecord(),
+    state,
+    event: {
+      eventId: 'event-1',
+      sequence: 1,
+      type: 'artifact.created',
+      payload: {
+        artifactId: 'artifact-1',
+        filename: 'report.txt',
+        contentType: 'text/plain',
+        size: 13,
+        key: 'tenants/tenant-1/private-object-key',
+      },
+    },
+  })
+  const duplicate = await renderGatewaySessionEvent({
+    cloud,
+    provider,
+    binding: bindingRecord(),
+    state,
+    event: {
+      eventId: 'event-1-again',
+      sequence: 1,
+      type: 'artifact.created',
+      payload: { artifactId: 'artifact-1', filename: 'report.txt', size: 13 },
+    },
+  })
+
+  assert.equal(duplicate.handled, false)
+  assert.equal(provider.sent.length, 1)
+  assert.equal(provider.sent[0]?.kind, 'file')
+  assert.equal(provider.sent[0]?.file?.filename, 'report.txt')
+  assert.equal(Buffer.from(provider.sent[0]?.file?.data || []).toString('utf8'), 'artifact body')
+})
+
+test('event renderer sends authenticated artifact links for link-only or oversized channels', async () => {
+  const provider = createButtonlessFakeProvider({ capabilities: { fileDownloads: false } })
+  await renderGatewaySessionEvent({
+    cloud: cloudStub({
+      async readArtifactAttachment() {
+        throw new Error('link-only provider should not fetch artifact bytes')
+      },
+      artifactUrl(sessionId: string, artifactId: string) {
+        return `https://cloud.example.test/api/sessions/${sessionId}/artifacts/${artifactId}`
+      },
+    }),
+    provider,
+    binding: bindingRecord(),
+    state: createGatewaySessionRenderState(),
+    event: {
+      eventId: 'event-1',
+      sequence: 1,
+      type: 'artifact.created',
+      payload: {
+        artifactId: 'artifact-1',
+        filename: 'report-token=secret.txt',
+        contentType: 'text/plain',
+        size: 13,
+        key: 'tenants/tenant-1/private-object-key',
+      },
+    },
+  })
+
+  assert.equal(provider.sent[0]?.kind, 'text')
+  assert.match(provider.sent[0]?.text || '', /https:\/\/cloud\.example\.test\/api\/sessions\/session-1\/artifacts\/artifact-1/)
+  assert.doesNotMatch(provider.sent[0]?.text || '', /private-object-key/)
+  assert.doesNotMatch(provider.sent[0]?.text || '', /secret/)
 })
 
 function bindingRecord() {

--- a/apps/gateway/src/event-renderer.ts
+++ b/apps/gateway/src/event-renderer.ts
@@ -9,6 +9,7 @@ import type {
 } from '@open-cowork/cloud-client'
 
 import type { CloudGateway } from './cloud-gateway.js'
+import { renderArtifactCreated } from './render/artifact-renderer.js'
 import { renderApprovalRequest } from './render/approval-renderer.js'
 import { renderQuestionRequest } from './render/question-renderer.js'
 import type { GatewaySessionRenderState } from './render/state.js'
@@ -57,6 +58,10 @@ export async function renderGatewaySessionEvent(
 
   if (input.event.type === 'question.asked') {
     return renderQuestionRequest({ ...input, target })
+  }
+
+  if (input.event.type === 'artifact.created') {
+    return renderArtifactCreated({ ...input, target })
   }
 
   return { handled: false }

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -4,14 +4,18 @@ import type {
   IncomingChannelMessage,
   SentMessage,
 } from '@open-cowork/gateway-channel'
+import { chunkText } from '@open-cowork/gateway-channel'
 import type { ChannelDeliveryRecord, CloudChannelProviderId } from '@open-cowork/cloud-client'
 
 import type { CloudGateway } from './cloud-gateway.js'
 import type { GatewayConfig, GatewayProviderConfig } from './config.js'
 import { routeGatewayInteraction } from './interaction-router.js'
 import { createGatewayMetrics, type GatewayMetrics } from './metrics.js'
+import { classifyProviderFailure } from './provider-errors.js'
 import { createGatewayProviderRegistry, type GatewayProviderRegistry, type ProviderRegistration } from './provider-registry.js'
 import { createGatewaySessionStreamManager, type GatewaySessionStreamManager } from './session-stream-manager.js'
+
+const MAX_DELIVERY_ATTEMPTS = 5
 
 export type GatewayRuntime = {
   readonly metrics: GatewayMetrics
@@ -141,7 +145,7 @@ async function handleDelivery(
   if (!registration) {
     metrics.errors += 1
     await cloud.ackDelivery(delivery.deliveryId, {
-      status: 'failed',
+      status: 'dead',
       claimedBy: delivery.claimedBy,
       lastError: `No provider registered for ${delivery.provider}.`,
     })
@@ -157,10 +161,13 @@ async function handleDelivery(
     })
   } catch (error) {
     metrics.errors += 1
+    const failure = classifyProviderFailure(error)
+    const shouldRetry = failure.transient && delivery.attemptCount < MAX_DELIVERY_ATTEMPTS
     await cloud.ackDelivery(delivery.deliveryId, {
-      status: 'failed',
+      status: shouldRetry ? 'failed' : 'dead',
       claimedBy: delivery.claimedBy,
-      lastError: error instanceof Error ? error.message : String(error),
+      lastError: failure.message,
+      nextAttemptAt: shouldRetry ? new Date(Date.now() + deliveryRetryDelayMs(delivery.attemptCount)).toISOString() : null,
     })
   }
 }
@@ -172,7 +179,17 @@ async function sendDelivery(provider: ChannelProvider, delivery: ChannelDelivery
     : typeof delivery.payload.message === 'string'
       ? delivery.payload.message
       : JSON.stringify(delivery.payload)
-  return provider.sendText(target, text)
+  let sent: SentMessage | null = null
+  for (const chunk of chunkText(text, provider.capabilities.maxTextLength)) {
+    sent = await provider.sendText(target, chunk)
+  }
+  if (!sent) throw new Error('Channel delivery payload was empty.')
+  return sent
+}
+
+function deliveryRetryDelayMs(attemptCount: number) {
+  const retryIndex = Math.max(0, attemptCount - 1)
+  return Math.min(60_000, 1000 * 2 ** retryIndex)
 }
 
 function findDeliveryProvider(providers: GatewayProviderRegistry, delivery: ChannelDeliveryRecord): ProviderRegistration | null {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -45,6 +45,9 @@ export {
   type GatewaySessionRenderState,
 } from './render/state.js'
 export {
+  renderArtifactCreated,
+} from './render/artifact-renderer.js'
+export {
   mergeStreamingText,
 } from './render/text-stream-renderer.js'
 export {

--- a/apps/gateway/src/provider-errors.ts
+++ b/apps/gateway/src/provider-errors.ts
@@ -1,0 +1,25 @@
+import { sanitizeChannelText } from './render/sanitize.js'
+
+export type GatewayProviderFailure = {
+  transient: boolean
+  message: string
+}
+
+const permanentPatterns = [
+  /does not support/i,
+  /unsupported/i,
+  /exceeds .*limit/i,
+  /exceeds provider/i,
+  /invalid/i,
+  /malformed/i,
+  /too large/i,
+]
+
+export function classifyProviderFailure(error: unknown): GatewayProviderFailure {
+  const raw = error instanceof Error ? error.message : String(error)
+  const message = sanitizeChannelText(raw || 'Provider delivery failed.', 320)
+  return {
+    message,
+    transient: !permanentPatterns.some((pattern) => pattern.test(message)),
+  }
+}

--- a/apps/gateway/src/render-operation.test.ts
+++ b/apps/gateway/src/render-operation.test.ts
@@ -34,6 +34,7 @@ test('normalizes provider capabilities with render-operation defaults and overri
   assert.equal(normalized.maxButtonsPerMessage, 3)
   assert.equal(normalized.maxButtonRowsPerMessage, 4)
   assert.equal(normalized.maxButtonTokenBytes, 32)
+  assert.equal(normalized.maxFileBytes, 25 * 1024 * 1024)
   assert.equal(normalized.supportsEphemeralResponses, true)
 })
 
@@ -140,6 +141,14 @@ test('capability matrix executes supported operations and rejects unsupported bu
       file: { filename: 'artifact.txt', data: new Uint8Array() },
     }),
     /outgoing files/,
+  )
+  await assert.rejects(
+    executeRenderOperation(createFileCapableFakeProvider({ capabilities: { maxFileBytes: 2 } }), {
+      type: 'send_file',
+      target,
+      file: { filename: 'artifact.txt', data: new Uint8Array([1, 2, 3]) },
+    }),
+    /maxFileBytes 2/,
   )
   await assert.rejects(
     executeRenderOperation(constrained, {

--- a/apps/gateway/src/render/artifact-renderer.ts
+++ b/apps/gateway/src/render/artifact-renderer.ts
@@ -1,0 +1,134 @@
+import type {
+  ChannelProvider,
+  ChannelTarget,
+} from '@open-cowork/gateway-channel'
+import type {
+  ChannelSessionBindingRecord,
+  CloudTransportSessionEvent,
+} from '@open-cowork/cloud-client'
+
+import type { CloudGateway } from '../cloud-gateway.js'
+import {
+  executeRenderOperation,
+  normalizeChannelCapabilities,
+} from './operations.js'
+import { sanitizeChannelText } from './sanitize.js'
+import type { GatewaySessionRenderState } from './state.js'
+
+export type RenderArtifactInput = {
+  cloud: CloudGateway
+  provider: ChannelProvider
+  target: ChannelTarget
+  binding: ChannelSessionBindingRecord
+  event: CloudTransportSessionEvent
+  state: GatewaySessionRenderState
+}
+
+export type RenderArtifactResult = {
+  handled: boolean
+  lastChatMessageId?: string | null
+}
+
+export async function renderArtifactCreated(input: RenderArtifactInput): Promise<RenderArtifactResult> {
+  const artifact = readArtifact(input.event)
+  if (!artifact.artifactId) return { handled: false }
+
+  const existing = input.state.artifacts.get(artifact.artifactId)
+  if (existing && existing.renderedSequence >= input.event.sequence) {
+    return { handled: false, lastChatMessageId: existing.providerMessageId }
+  }
+
+  const capabilities = normalizeChannelCapabilities(input.provider.capabilities)
+  if (capabilities.fileDownloads && artifact.size <= capabilities.maxFileBytes && input.cloud.readArtifactAttachment) {
+    const attachment = await input.cloud.readArtifactAttachment(input.binding.sessionId, artifact.artifactId)
+    const file = dataUrlToFile(attachment.url, attachment.filename || artifact.filename, attachment.mime || artifact.mime)
+    if (file.data.byteLength <= capabilities.maxFileBytes) {
+      const result = await executeRenderOperation(input.provider, {
+        type: 'send_file',
+        target: input.target,
+        file,
+      })
+      const providerMessageId = result.sentMessage?.messageId ?? existing?.providerMessageId ?? null
+      input.state.artifacts.set(artifact.artifactId, {
+        artifactId: artifact.artifactId,
+        providerMessageId,
+        renderedSequence: input.event.sequence,
+      })
+      return { handled: true, lastChatMessageId: providerMessageId }
+    }
+  }
+
+  const result = await executeRenderOperation(input.provider, {
+    type: 'send_artifact_link',
+    target: input.target,
+    artifact: {
+      filename: artifact.filename,
+      label: artifact.label,
+      url: input.cloud.artifactUrl(input.binding.sessionId, artifact.artifactId),
+    },
+  })
+  const providerMessageId = result.sentMessage?.messageId ?? existing?.providerMessageId ?? null
+  input.state.artifacts.set(artifact.artifactId, {
+    artifactId: artifact.artifactId,
+    providerMessageId,
+    renderedSequence: input.event.sequence,
+  })
+  return { handled: true, lastChatMessageId: providerMessageId }
+}
+
+function readArtifact(event: CloudTransportSessionEvent) {
+  const artifactId = stringField(event.payload, 'artifactId')
+    || stringField(event.payload, 'cloudArtifactId')
+    || stringField(event.payload, 'id')
+    || artifactIdFromFilePath(stringField(event.payload, 'filePath'))
+    || event.entityId
+    || ''
+  const filename = safeFilename(stringField(event.payload, 'filename')) || 'artifact'
+  return {
+    artifactId,
+    filename,
+    label: sanitizeChannelText(filename, 160),
+    mime: stringField(event.payload, 'contentType') || stringField(event.payload, 'mime') || 'application/octet-stream',
+    size: numberField(event.payload, 'size'),
+  }
+}
+
+function dataUrlToFile(url: string, filename: string, mime?: string) {
+  const match = /^data:([^;,]+)?;base64,([A-Za-z0-9+/=_-]+)$/i.exec(url)
+  if (!match) throw new Error('Cloud artifact attachment did not include a base64 data URL.')
+  const data = Buffer.from(match[2] || '', 'base64')
+  if (data.byteLength === 0) throw new Error('Cloud artifact attachment is empty.')
+  return {
+    filename: safeFilename(filename) || 'artifact',
+    mimeType: match[1] || mime || 'application/octet-stream',
+    data,
+  }
+}
+
+function artifactIdFromFilePath(filePath: string | null) {
+  if (!filePath?.startsWith('cloud-artifact://')) return null
+  const [encoded] = filePath.slice('cloud-artifact://'.length).split('/')
+  if (!encoded) return null
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return null
+  }
+}
+
+function safeFilename(value: string | null) {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed || trimmed === '.' || trimmed === '..') return null
+  return sanitizeChannelText(trimmed.replace(/[\\/:\0]/g, '-'), 180)
+}
+
+function stringField(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function numberField(payload: Record<string, unknown>, key: string): number {
+  const value = payload[key]
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0
+}

--- a/apps/gateway/src/render/operations.ts
+++ b/apps/gateway/src/render/operations.ts
@@ -23,6 +23,7 @@ export type NormalizedChannelCapabilities = {
   maxButtonsPerMessage: number
   maxButtonRowsPerMessage: number
   maxButtonTokenBytes: number
+  maxFileBytes: number
   supportsEphemeralResponses: boolean
 }
 
@@ -108,6 +109,7 @@ export function normalizeChannelCapabilities(capabilities: ChannelCapabilities):
     maxButtonsPerMessage: positiveInteger(capabilities.maxButtonsPerMessage ?? 8, 'maxButtonsPerMessage'),
     maxButtonRowsPerMessage: positiveInteger(capabilities.maxButtonRowsPerMessage ?? 4, 'maxButtonRowsPerMessage'),
     maxButtonTokenBytes: positiveInteger(capabilities.maxButtonTokenBytes ?? 128, 'maxButtonTokenBytes'),
+    maxFileBytes: positiveInteger(capabilities.maxFileBytes ?? 25 * 1024 * 1024, 'maxFileBytes'),
     supportsEphemeralResponses: capabilities.supportsEphemeralResponses ?? false,
   }
 }
@@ -144,6 +146,10 @@ export async function executeRenderOperation(
     case 'send_file': {
       if (!capabilities.fileDownloads) {
         throw new Error('Channel provider does not support outgoing files.')
+      }
+      const size = operation.file.data?.byteLength
+      if (typeof size === 'number' && size > capabilities.maxFileBytes) {
+        throw new Error(`Rendered file exceeds provider maxFileBytes ${capabilities.maxFileBytes}.`)
       }
       const sentMessage = await provider.sendFile(operation.target, operation.file)
       return { operationType: operation.type, handled: true, sentMessage }

--- a/apps/gateway/src/render/state.ts
+++ b/apps/gateway/src/render/state.ts
@@ -11,14 +11,22 @@ export type ToolProgressRenderState = {
   status: string
 }
 
+export type ArtifactRenderState = {
+  artifactId: string
+  providerMessageId: string | null
+  renderedSequence: number
+}
+
 export type GatewaySessionRenderState = {
   assistantStreams: Map<string, AssistantStreamRenderState>
   toolProgress: Map<string, ToolProgressRenderState>
+  artifacts: Map<string, ArtifactRenderState>
 }
 
 export function createGatewaySessionRenderState(): GatewaySessionRenderState {
   return {
     assistantStreams: new Map(),
     toolProgress: new Map(),
+    artifacts: new Map(),
   }
 }

--- a/apps/gateway/src/session-stream-manager.test.ts
+++ b/apps/gateway/src/session-stream-manager.test.ts
@@ -275,6 +275,100 @@ test('session stream manager reconnects from the last persisted cursor', async (
   manager.closeAll()
 })
 
+test('session stream manager hydrates snapshot-required retention gaps', async () => {
+  const provider = new FakeChannelProvider()
+  let onEvent: ((event: unknown) => void) | null = null
+  const cursorUpdates: unknown[] = []
+  let hydrated = 0
+  const cloud = {
+    subscribeSessionEvents(input: { onEvent: (event: unknown) => void }) {
+      onEvent = input.onEvent
+      return { close() {} }
+    },
+    async getSession(sessionId: string) {
+      hydrated += 1
+      return {
+        session: { sessionId },
+        projection: {
+          tenantId: 'tenant-1',
+          sessionId,
+          sequence: 42,
+          view: {},
+          updatedAt: new Date(0).toISOString(),
+        },
+      }
+    },
+    async updateCursor(input: unknown) {
+      cursorUpdates.push(input)
+      return {
+        bindingId: 'binding-1',
+        orgId: 'tenant-1',
+        agentId: 'agent-1',
+        channelBindingId: 'channel-binding-1',
+        provider: 'cli',
+        externalWorkspaceId: null,
+        externalThreadId: 'thread-1',
+        externalChatId: 'chat-1',
+        sessionId: 'session-1',
+        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
+        lastWorkspaceSequence: 0,
+        lastChatMessageId: null,
+        status: 'active',
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+    async createChannelInteraction() {
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'token-1',
+      }
+    },
+  } as CloudGateway
+  const manager = createGatewaySessionStreamManager(cloud, createGatewayMetrics())
+
+  manager.ensure({
+    provider,
+    binding: {
+      bindingId: 'binding-1',
+      orgId: 'tenant-1',
+      agentId: 'agent-1',
+      channelBindingId: 'channel-binding-1',
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalThreadId: 'thread-1',
+      externalChatId: 'chat-1',
+      sessionId: 'session-1',
+      lastEventSequence: 10,
+      lastWorkspaceSequence: 0,
+      lastChatMessageId: null,
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+  })
+  onEvent?.({
+    eventId: 'snapshot-required:10',
+    sequence: 10,
+    type: 'snapshot.required',
+    payload: {
+      reason: 'event_retention_gap',
+      latestSequence: 42,
+    },
+  })
+  await waitFor(() => cursorUpdates.length === 1)
+
+  assert.equal(hydrated, 1)
+  assert.deepEqual(cursorUpdates, [{
+    bindingId: 'binding-1',
+    lastEventSequence: 42,
+    lastWorkspaceSequence: 0,
+    lastChatMessageId: null,
+  }])
+  assert.equal(provider.sent.length, 0)
+  manager.closeAll()
+})
+
 test('session stream manager leaves failed provider sends retryable', async () => {
   const provider = new FakeChannelProvider()
   const originalSendText = provider.sendText.bind(provider)
@@ -287,11 +381,11 @@ test('session stream manager leaves failed provider sends retryable', async () =
     return originalSendText(...args)
   }
   const metrics = createGatewayMetrics()
-  let onEvent: ((event: unknown) => void) | null = null
+  const subscriptions: Array<{ onEvent: (event: unknown) => void }> = []
   const cursorUpdates: unknown[] = []
   const cloud = {
     subscribeSessionEvents(input: { onEvent: (event: unknown) => void }) {
-      onEvent = input.onEvent
+      subscriptions.push(input)
       return { close() {} }
     },
     async updateCursor(input: unknown) {
@@ -321,7 +415,7 @@ test('session stream manager leaves failed provider sends retryable', async () =
       }
     },
   } as CloudGateway
-  const manager = createGatewaySessionStreamManager(cloud, metrics)
+  const manager = createGatewaySessionStreamManager(cloud, metrics, { retryDelayMs: 1 })
 
   manager.ensure({
     provider,
@@ -350,11 +444,12 @@ test('session stream manager leaves failed provider sends retryable', async () =
     type: 'assistant.message',
     payload: { content: 'retry me' },
   }
-  onEvent?.(event)
+  subscriptions[0].onEvent(event)
   await waitFor(() => metrics.errors === 1)
   assert.equal(cursorUpdates.length, 0)
+  await waitFor(() => subscriptions.length === 2)
 
-  onEvent?.(event)
+  subscriptions[1].onEvent(event)
   await waitFor(() => cursorUpdates.length === 1)
   assert.deepEqual(provider.sent.map((entry) => entry.text), ['retry me'])
   manager.closeAll()

--- a/apps/gateway/src/session-stream-manager.ts
+++ b/apps/gateway/src/session-stream-manager.ts
@@ -10,6 +10,7 @@ import type {
 import type { CloudGateway } from './cloud-gateway.js'
 import { renderGatewaySessionEvent } from './event-renderer.js'
 import type { GatewayMetrics } from './metrics.js'
+import { classifyProviderFailure } from './provider-errors.js'
 import {
   createGatewaySessionRenderState,
   type GatewaySessionRenderState,
@@ -27,6 +28,7 @@ export type GatewaySessionStreamManager = {
 
 export type GatewaySessionStreamManagerOptions = {
   retryDelayMs?: number
+  maxRenderAttempts?: number
 }
 
 type StreamState = {
@@ -37,6 +39,7 @@ type StreamState = {
   lastWorkspaceSequence: number
   lastChatMessageId: string | null
   renderState: GatewaySessionRenderState
+  renderFailures: Map<number, number>
   queue: Promise<void>
   closed: boolean
   retryTimer?: ReturnType<typeof setTimeout>
@@ -49,6 +52,7 @@ export function createGatewaySessionStreamManager(
 ): GatewaySessionStreamManager {
   const streams = new Map<string, StreamState>()
   const retryDelayMs = options.retryDelayMs ?? 250
+  const maxRenderAttempts = options.maxRenderAttempts ?? 5
 
   const manager: GatewaySessionStreamManager = {
     ensure(input) {
@@ -69,6 +73,7 @@ export function createGatewaySessionStreamManager(
         lastWorkspaceSequence: input.binding.lastWorkspaceSequence,
         lastChatMessageId: input.binding.lastChatMessageId,
         renderState: createGatewaySessionRenderState(),
+        renderFailures: new Map(),
         queue: Promise.resolve(),
         closed: false,
       }
@@ -92,6 +97,7 @@ export function createGatewaySessionStreamManager(
 
   function subscribe(state: StreamState) {
     if (state.closed) return
+    state.subscription?.close()
     state.subscription = cloud.subscribeSessionEvents({
       sessionId: state.binding.sessionId,
       afterSequence: state.lastEventSequence,
@@ -118,6 +124,14 @@ export function createGatewaySessionStreamManager(
 
   async function handleEvent(state: StreamState, event: CloudTransportSessionEvent) {
     if (state.closed) return
+    if (event.type === 'snapshot.required') {
+      try {
+        await hydrateSnapshot(state, event)
+      } catch {
+        metrics.errors += 1
+      }
+      return
+    }
     if (event.sequence <= state.lastEventSequence) return
 
     try {
@@ -143,13 +157,48 @@ export function createGatewaySessionStreamManager(
       state.lastEventSequence = updated?.lastEventSequence ?? event.sequence
       state.lastWorkspaceSequence = updated?.lastWorkspaceSequence ?? state.lastWorkspaceSequence
       state.lastChatMessageId = updated?.lastChatMessageId ?? lastChatMessageId
+      state.renderFailures.delete(event.sequence)
       if (updated) state.binding = updated
-    } catch {
+    } catch (error) {
       metrics.errors += 1
+      const attempts = (state.renderFailures.get(event.sequence) ?? 0) + 1
+      state.renderFailures.set(event.sequence, attempts)
+      const failure = classifyProviderFailure(error)
+      if (failure.transient && attempts < maxRenderAttempts) {
+        state.subscription?.close()
+        state.subscription = null
+        scheduleRetry(state)
+      }
     }
   }
 
+  async function hydrateSnapshot(state: StreamState, event: CloudTransportSessionEvent) {
+    const snapshot = await cloud.getSession(state.binding.sessionId)
+    const latestSequence = Math.max(
+      state.lastEventSequence,
+      numberField(event.payload, 'latestSequence'),
+      snapshot.projection?.sequence ?? 0,
+      event.sequence,
+    )
+    if (latestSequence <= state.lastEventSequence) return
+    const updated = await cloud.updateCursor({
+      bindingId: state.binding.bindingId,
+      lastEventSequence: latestSequence,
+      lastWorkspaceSequence: state.lastWorkspaceSequence,
+      lastChatMessageId: state.lastChatMessageId,
+    })
+    state.lastEventSequence = updated?.lastEventSequence ?? latestSequence
+    state.lastWorkspaceSequence = updated?.lastWorkspaceSequence ?? state.lastWorkspaceSequence
+    state.lastChatMessageId = updated?.lastChatMessageId ?? state.lastChatMessageId
+    if (updated) state.binding = updated
+  }
+
   return manager
+}
+
+function numberField(payload: Record<string, unknown>, key: string): number {
+  const value = payload[key]
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0
 }
 
 function closeState(state: StreamState) {

--- a/packages/gateway-channel/src/provider.ts
+++ b/packages/gateway-channel/src/provider.ts
@@ -32,6 +32,7 @@ export interface ChannelCapabilities {
   maxButtonsPerMessage?: number;
   maxButtonRowsPerMessage?: number;
   maxButtonTokenBytes?: number;
+  maxFileBytes?: number;
   supportsEphemeralResponses?: boolean;
 }
 

--- a/packages/gateway-provider-telegram/src/telegram-provider.ts
+++ b/packages/gateway-provider-telegram/src/telegram-provider.ts
@@ -55,6 +55,7 @@ export class TelegramProvider implements ChannelProvider {
     maxButtonsPerMessage: 8,
     maxButtonRowsPerMessage: 4,
     maxButtonTokenBytes: 64,
+    maxFileBytes: 20 * 1024 * 1024,
     supportsEphemeralResponses: true
   };
 

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -84,6 +84,7 @@ export class WebhookProvider implements ChannelProvider {
     maxButtonsPerMessage: 8,
     maxButtonRowsPerMessage: 4,
     maxButtonTokenBytes: 64,
+    maxFileBytes: 25 * 1024 * 1024,
     supportsEphemeralResponses: false
   };
 

--- a/packages/gateway-testing/src/fake-channel.ts
+++ b/packages/gateway-testing/src/fake-channel.ts
@@ -40,6 +40,7 @@ const defaultFakeCapabilities: ChannelCapabilities = {
   maxButtonsPerMessage: 8,
   maxButtonRowsPerMessage: 4,
   maxButtonTokenBytes: 128,
+  maxFileBytes: 25 * 1024 * 1024,
   supportsEphemeralResponses: true
 };
 
@@ -94,6 +95,9 @@ export class FakeChannelProvider implements ChannelProvider {
   async sendFile(target: ChannelTarget, file: OutgoingFile): Promise<SentMessage> {
     if (!this.capabilities.fileDownloads) {
       throw new Error("Fake channel provider does not support outgoing files");
+    }
+    if (file.data && file.data.byteLength > (this.capabilities.maxFileBytes ?? 25 * 1024 * 1024)) {
+      throw new Error(`Fake channel file exceeds maxFileBytes ${this.capabilities.maxFileBytes}`);
     }
     this.sent.push({ kind: "file", target, file });
     return sent(target, this.sent.length, this.now());


### PR DESCRIPTION
## Summary
- Render cloud artifacts through file-capable providers when limits allow, otherwise emit authenticated cloud artifact links without exposing object-store keys.
- Retry transient provider failures while marking permanent delivery failures dead with redacted errors.
- Preserve cursor idempotency by advancing cursors only after successful rendering and hydrating snapshot-required retention gaps.

Closes #424.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`