### PR TITLE
Add BYOK secret store and metadata APIs

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -20,6 +20,7 @@ import {
   type CloudObservabilityAdapter,
 } from './observability.ts'
 import { createObjectStoreForCloud, type ObjectStoreAdapter } from './object-store.ts'
+import { createByokSecretStore, type ByokSecretStore } from './byok-secret-store.ts'
 import {
   createOidcBrowserAuthProvider,
   createOidcCloudAuthResolver,
@@ -29,7 +30,7 @@ import { createCloudPathProvider, type PathProvider } from './path-provider.ts'
 import { createPostgresControlPlaneStore } from './postgres-control-plane-store.ts'
 import { createNodeOpencodeCloudRuntimeAdapter } from './opencode-runtime-adapter.ts'
 import type { CloudRuntimeAdapter, CloudRuntimeEvent } from './runtime-adapter.ts'
-import { createCloudSecretAdapterFromEnv } from './secret-adapter.ts'
+import { createCloudSecretAdapterFromEnv, type SecretAdapter } from './secret-adapter.ts'
 import { createCloudSessionCookieManager, type CloudSessionCookieManager } from './session-cookie-auth.ts'
 import { CloudSessionService, type CloudPrincipal } from './session-service.ts'
 import { CloudScheduler } from './scheduler.ts'
@@ -81,6 +82,7 @@ export type CloudAppOptions = {
   storeFactory?: CloudControlPlaneStoreFactory
   objectStore?: ObjectStoreAdapter
   objectStoreFactory?: CloudObjectStoreFactory
+  secretAdapter?: SecretAdapter
   runtime?: CloudRuntimeAdapter
   runtimeFactory?: CloudRuntimeFactory
   paths?: PathProvider
@@ -102,6 +104,7 @@ export type CloudApp = {
   policy: CloudRuntimePolicy
   store: ControlPlaneStore
   objectStore: ObjectStoreAdapter
+  byokSecrets: ByokSecretStore
   checkpointStore: WorkspaceCheckpointStore | null
   paths: PathProvider
   runtime: CloudRuntimeAdapter
@@ -487,6 +490,8 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
   const paths = options.paths || createCloudPathProvider(envOptions.root)
   const store = options.store || await (options.storeFactory || createControlPlaneStoreForCloud)({ config, env })
   const objectStore = options.objectStore || await (options.objectStoreFactory || createObjectStoreForCloud)({ config, env, paths })
+  const secretAdapter = options.secretAdapter || await createCloudSecretAdapterFromEnv(env)
+  const byokSecrets = createByokSecretStore(store, secretAdapter)
   const checkpointsEnabled = options.checkpointsEnabled ?? envOptions.checkpointsEnabled
   const hasCheckpointStoreOverride = Object.prototype.hasOwnProperty.call(options, 'checkpointStore')
   const checkpointStore = shouldRunCloudWorker(policy.role)
@@ -495,7 +500,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
       : checkpointsEnabled
         ? createObjectWorkspaceCheckpointStore({
             objectStore,
-            secretAdapter: await createCloudSecretAdapterFromEnv(env),
+            secretAdapter,
           })
         : null
     : null
@@ -504,7 +509,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
       ? await (options.runtimeFactory || defaultCloudRuntimeFactory)({ paths, policy, env })
       : createUnavailableRuntimeAdapter()
   )
-  const service = new CloudSessionService(store, runtime, policy)
+  const service = new CloudSessionService(store, runtime, policy, undefined, undefined, undefined, byokSecrets)
   const artifacts = new CloudArtifactService(service, objectStore)
   const hasSessionCookieOverride = Object.prototype.hasOwnProperty.call(options, 'sessionCookies')
   const cookieSecret = resolveCloudCookieSecret(resolvedAuthConfig, env)
@@ -612,6 +617,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
     policy,
     store,
     objectStore,
+    byokSecrets,
     checkpointStore,
     paths,
     runtime,

--- a/apps/desktop/src/main/cloud/byok-secret-store.ts
+++ b/apps/desktop/src/main/cloud/byok-secret-store.ts
@@ -1,0 +1,218 @@
+import { createHash, randomUUID } from 'node:crypto'
+import type {
+  AuditActorInput,
+  ByokSecretRecord,
+  ByokSecretStatus,
+  ControlPlaneStore,
+} from './control-plane-store.ts'
+import type { SecretAdapter } from './secret-adapter.ts'
+
+export type ByokSecretMetadata = {
+  secretId: string
+  providerId: string
+  status: ByokSecretStatus
+  last4: string
+  keyFingerprint: string
+  lastValidatedAt: string | null
+  validationError: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type SetByokSecretInput = {
+  orgId: string
+  providerId: string
+  plaintext?: string | null
+  kmsRef?: string | null
+  createdByAccountId?: string | null
+  actor?: AuditActorInput
+}
+
+export type RecordByokValidationInput = {
+  orgId: string
+  providerId: string
+  secretId?: string | null
+  status?: ByokSecretStatus
+  validationError?: string | null
+  actor?: AuditActorInput
+}
+
+export type RevealByokSecretInput = {
+  orgId: string
+  providerId: string
+}
+
+export type ByokSecretStore = {
+  listMetadata(orgId: string): Promise<ByokSecretMetadata[]>
+  getMetadata(orgId: string, providerId: string): Promise<ByokSecretMetadata | null>
+  setSecret(input: SetByokSecretInput): Promise<ByokSecretMetadata>
+  disableSecret(input: { orgId: string, providerId: string, actor?: AuditActorInput }): Promise<ByokSecretMetadata | null>
+  recordValidation(input: RecordByokValidationInput): Promise<ByokSecretMetadata | null>
+  revealActiveSecret(input: RevealByokSecretInput): Promise<string>
+}
+
+export type ByokSecretStoreOptions = {
+  ids?: { randomUUID: () => string }
+}
+
+const PROVIDER_ID_MAX_LENGTH = 64
+const VALIDATION_ERROR_MAX_LENGTH = 512
+
+function normalizeProviderId(value: string) {
+  const providerId = value.trim().toLowerCase()
+  if (!providerId || providerId.length > PROVIDER_ID_MAX_LENGTH || !/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) {
+    throw new Error(`Unsupported BYOK provider id ${providerId || '<empty>'}.`)
+  }
+  return providerId
+}
+
+function nonEmptyText(value: string | null | undefined, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  return value.trim()
+}
+
+function fingerprintSecret(value: string) {
+  return createHash('sha256')
+    .update('open-cowork-byok-provider-secret-v1\0', 'utf8')
+    .update(value, 'utf8')
+    .digest('hex')
+    .slice(0, 24)
+}
+
+function byokAad(orgId: string, providerId: string, secretId: string) {
+  return `byok:${orgId}:${providerId}:${secretId}`
+}
+
+function redactSecretLikeText(value: string) {
+  return value
+    .replace(/\b(sk-[A-Za-z0-9._-]{6,})\b/g, '[redacted]')
+    .replace(/\b(occ_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
+}
+
+function sanitizeValidationError(value: string | null | undefined) {
+  if (!value) return null
+  const sanitized = redactSecretLikeText(value.trim())
+  return sanitized.length > VALIDATION_ERROR_MAX_LENGTH
+    ? `${sanitized.slice(0, VALIDATION_ERROR_MAX_LENGTH - 3)}...`
+    : sanitized
+}
+
+export function byokSecretMetadata(record: ByokSecretRecord): ByokSecretMetadata {
+  return {
+    secretId: record.secretId,
+    providerId: record.providerId,
+    status: record.status,
+    last4: record.last4,
+    keyFingerprint: record.keyFingerprint,
+    lastValidatedAt: record.lastValidatedAt,
+    validationError: record.validationError,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  }
+}
+
+function latestByProvider(records: ByokSecretRecord[]) {
+  const byProvider = new Map<string, ByokSecretRecord>()
+  for (const record of records) {
+    const existing = byProvider.get(record.providerId)
+    const order = existing
+      ? record.updatedAt.localeCompare(existing.updatedAt)
+        || record.createdAt.localeCompare(existing.createdAt)
+        || record.secretId.localeCompare(existing.secretId)
+      : 1
+    if (order > 0) {
+      byProvider.set(record.providerId, record)
+    }
+  }
+  return Array.from(byProvider.values())
+    .sort((left, right) => left.providerId.localeCompare(right.providerId))
+}
+
+export function createByokSecretStore(
+  store: ControlPlaneStore,
+  secretAdapter: SecretAdapter,
+  options: ByokSecretStoreOptions = {},
+): ByokSecretStore {
+  const ids = options.ids || { randomUUID }
+
+  return {
+    async listMetadata(orgId) {
+      const secrets = await store.listByokSecrets(orgId)
+      return latestByProvider(secrets).map(byokSecretMetadata)
+    },
+
+    async getMetadata(orgId, providerId) {
+      const secret = await store.getByokSecret(orgId, normalizeProviderId(providerId))
+      return secret ? byokSecretMetadata(secret) : null
+    },
+
+    async setSecret(input) {
+      const providerId = normalizeProviderId(input.providerId)
+      const plaintext = input.plaintext === undefined ? null : input.plaintext
+      const kmsRef = input.kmsRef === undefined ? null : input.kmsRef
+      if (plaintext && kmsRef) throw new Error('BYOK secret accepts either plaintext or kmsRef, not both.')
+      if (!plaintext && !kmsRef) throw new Error('BYOK secret requires plaintext or kmsRef.')
+
+      const secretId = `byok_${ids.randomUUID()}`
+      if (plaintext) {
+        const normalizedPlaintext = nonEmptyText(plaintext, 'BYOK plaintext')
+        const ciphertext = secretAdapter.protect(normalizedPlaintext, byokAad(input.orgId, providerId, secretId))
+        const record = await store.createByokSecret({
+          secretId,
+          orgId: input.orgId,
+          providerId,
+          ciphertext,
+          last4: normalizedPlaintext.slice(-4),
+          keyFingerprint: fingerprintSecret(normalizedPlaintext),
+          createdByAccountId: input.createdByAccountId,
+          actor: input.actor,
+        })
+        return byokSecretMetadata(record)
+      }
+
+      const normalizedKmsRef = nonEmptyText(kmsRef, 'BYOK KMS ref')
+      const record = await store.createByokSecret({
+        secretId,
+        orgId: input.orgId,
+        providerId,
+        kmsRef: normalizedKmsRef,
+        last4: normalizedKmsRef.slice(-4),
+        keyFingerprint: fingerprintSecret(`kms:${normalizedKmsRef}`),
+        createdByAccountId: input.createdByAccountId,
+        actor: input.actor,
+      })
+      return byokSecretMetadata(record)
+    },
+
+    async disableSecret(input) {
+      const record = await store.disableByokSecret({
+        orgId: input.orgId,
+        providerId: normalizeProviderId(input.providerId),
+        actor: input.actor,
+      })
+      return record ? byokSecretMetadata(record) : null
+    },
+
+    async recordValidation(input) {
+      const record = await store.recordByokSecretValidation({
+        orgId: input.orgId,
+        providerId: normalizeProviderId(input.providerId),
+        secretId: input.secretId,
+        status: input.status,
+        validationError: sanitizeValidationError(input.validationError),
+        actor: input.actor,
+      })
+      return record ? byokSecretMetadata(record) : null
+    },
+
+    async revealActiveSecret(input) {
+      const providerId = normalizeProviderId(input.providerId)
+      const secret = await store.getActiveByokSecret(input.orgId, providerId)
+      if (!secret) throw new Error(`No active BYOK secret configured for provider ${providerId}.`)
+      if (secret.kmsRef) throw new Error('KMS-backed BYOK secrets are not revealable by this store yet.')
+      if (!secret.ciphertext) throw new Error(`BYOK secret ${secret.secretId} has no encrypted material.`)
+      return secretAdapter.reveal(secret.ciphertext, byokAad(input.orgId, providerId, secret.secretId))
+    },
+  }
+}

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -25,6 +25,7 @@ export type ChannelSessionBindingStatus = 'active' | 'archived'
 export type ChannelInteractionKind = 'permission' | 'question'
 export type ChannelInteractionStatus = 'pending' | 'used' | 'expired' | 'revoked'
 export type ChannelDeliveryStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead'
+export type ByokSecretStatus = 'active' | 'disabled' | 'expired' | 'invalid'
 
 export type TenantRecord = {
   tenantId: string
@@ -105,6 +106,23 @@ export type AuditEventRecord = {
   targetId: string | null
   metadata: Record<string, unknown>
   createdAt: string
+}
+
+export type ByokSecretRecord = {
+  secretId: string
+  orgId: string
+  providerId: string
+  status: ByokSecretStatus
+  ciphertext: string | null
+  kmsRef: string | null
+  last4: string
+  keyFingerprint: string
+  createdByAccountId: string | null
+  rotatedFromSecretId: string | null
+  lastValidatedAt: string | null
+  validationError: string | null
+  createdAt: string
+  updatedAt: string
 }
 
 export type HeadlessAgentRecord = {
@@ -425,6 +443,39 @@ export type RecordAuditEventInput = {
   createdAt?: Date
 }
 
+export type CreateByokSecretInput = {
+  secretId: string
+  orgId: string
+  providerId: string
+  status?: ByokSecretStatus
+  ciphertext?: string | null
+  kmsRef?: string | null
+  last4: string
+  keyFingerprint: string
+  createdByAccountId?: string | null
+  rotatedFromSecretId?: string | null
+  createdAt?: Date
+  actor?: AuditActorInput
+}
+
+export type DisableByokSecretInput = {
+  orgId: string
+  providerId: string
+  secretId?: string | null
+  disabledAt?: Date
+  actor?: AuditActorInput
+}
+
+export type RecordByokSecretValidationInput = {
+  orgId: string
+  providerId: string
+  secretId?: string | null
+  status?: ByokSecretStatus
+  validationError?: string | null
+  validatedAt?: Date
+  actor?: AuditActorInput
+}
+
 export type CreateHeadlessAgentInput = {
   agentId: string
   orgId: string
@@ -739,6 +790,12 @@ export type ControlPlaneStore = {
   revokeApiToken(input: RevokeApiTokenInput): MaybePromise<ApiTokenRecord | null>
   recordAuditEvent(input: RecordAuditEventInput): MaybePromise<AuditEventRecord>
   listAuditEvents(orgId: string, limit?: number): MaybePromise<AuditEventRecord[]>
+  createByokSecret(input: CreateByokSecretInput): MaybePromise<ByokSecretRecord>
+  getByokSecret(orgId: string, providerId: string): MaybePromise<ByokSecretRecord | null>
+  getActiveByokSecret(orgId: string, providerId: string): MaybePromise<ByokSecretRecord | null>
+  listByokSecrets(orgId: string): MaybePromise<ByokSecretRecord[]>
+  disableByokSecret(input: DisableByokSecretInput): MaybePromise<ByokSecretRecord | null>
+  recordByokSecretValidation(input: RecordByokSecretValidationInput): MaybePromise<ByokSecretRecord | null>
   createHeadlessAgent(input: CreateHeadlessAgentInput): MaybePromise<HeadlessAgentRecord>
   updateHeadlessAgent(input: UpdateHeadlessAgentInput): MaybePromise<HeadlessAgentRecord | null>
   getHeadlessAgent(orgId: string, agentId: string): MaybePromise<HeadlessAgentRecord | null>
@@ -876,6 +933,8 @@ const WORKFLOW_RUN_LIST_LIMIT = 100
 const CHANNEL_TEXT_MAX_LENGTH = 256
 const CHANNEL_METADATA_MAX_BYTES = 16_384
 const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
+const BYOK_PROVIDER_ID_MAX_LENGTH = 64
+const BYOK_SECRET_TEXT_MAX_LENGTH = 4096
 
 function nowIso(now: Date | undefined) {
   return (now || new Date()).toISOString()
@@ -1025,6 +1084,12 @@ function normalizeProvider(value: unknown): ChannelProviderId {
   return provider
 }
 
+function normalizeByokProviderId(value: unknown) {
+  const providerId = normalizeText(value, BYOK_PROVIDER_ID_MAX_LENGTH, 'BYOK provider id').toLowerCase()
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) throw new Error(`Unsupported BYOK provider id ${providerId}.`)
+  return providerId
+}
+
 function normalizeChannelIdentityRole(value: unknown): ChannelIdentityRole {
   const role = normalizeText(value || 'viewer', 32, 'Channel identity role') as ChannelIdentityRole
   if (!['owner', 'admin', 'member', 'approver', 'viewer'].includes(role)) {
@@ -1052,6 +1117,7 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly memberships = new Map<string, MembershipRecord>()
   private readonly apiTokens = new Map<string, ApiTokenRecord>()
   private readonly auditEvents = new Map<string, AuditEventRecord>()
+  private readonly byokSecrets = new Map<string, ByokSecretRecord>()
   private readonly headlessAgents = new Map<string, HeadlessAgentRecord>()
   private readonly channelBindings = new Map<string, ChannelBindingRecord>()
   private readonly channelIdentities = new Map<string, ChannelIdentityRecord>()
@@ -1319,6 +1385,153 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
       .slice(0, limit)
       .map((event) => clone(event))
+  }
+
+  createByokSecret(input: CreateByokSecretInput): ByokSecretRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    if (input.createdByAccountId && !this.accounts.has(input.createdByAccountId)) {
+      throw new Error(`Unknown account ${input.createdByAccountId}.`)
+    }
+    const providerId = normalizeByokProviderId(input.providerId)
+    const ciphertext = normalizeNullableText(input.ciphertext, BYOK_SECRET_TEXT_MAX_LENGTH, 'BYOK ciphertext')
+    const kmsRef = normalizeNullableText(input.kmsRef, BYOK_SECRET_TEXT_MAX_LENGTH, 'BYOK KMS ref')
+    if ((ciphertext && kmsRef) || (!ciphertext && !kmsRef)) {
+      throw new Error('BYOK secret requires exactly one of ciphertext or kmsRef.')
+    }
+    const now = nowIso(input.createdAt)
+    const status = input.status || 'active'
+    const priorActive = status === 'active'
+      ? this.getActiveByokSecret(input.orgId, providerId)
+      : null
+    if (priorActive) {
+      const previous = this.byokSecrets.get(priorActive.secretId)
+      if (previous) {
+        previous.status = 'disabled'
+        previous.updatedAt = now
+      }
+    }
+    const record: ByokSecretRecord = {
+      secretId: normalizeText(input.secretId, CHANNEL_TEXT_MAX_LENGTH, 'BYOK secret id'),
+      orgId: input.orgId,
+      providerId,
+      status,
+      ciphertext,
+      kmsRef,
+      last4: normalizeText(input.last4, 32, 'BYOK secret last4'),
+      keyFingerprint: normalizeText(input.keyFingerprint, 128, 'BYOK key fingerprint'),
+      createdByAccountId: input.createdByAccountId || null,
+      rotatedFromSecretId: input.rotatedFromSecretId || priorActive?.secretId || null,
+      lastValidatedAt: null,
+      validationError: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    if (this.byokSecrets.has(record.secretId)) throw new Error(`BYOK secret ${record.secretId} already exists.`)
+    this.byokSecrets.set(record.secretId, record)
+    this.recordAuditEvent({
+      orgId: record.orgId,
+      accountId: record.createdByAccountId,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: priorActive ? 'byok_secret.rotated' : 'byok_secret.created',
+      targetType: 'byok_secret',
+      targetId: record.secretId,
+      metadata: {
+        providerId: record.providerId,
+        status: record.status,
+        last4: record.last4,
+        keyFingerprint: record.keyFingerprint,
+        rotatedFromSecretId: record.rotatedFromSecretId,
+      },
+      createdAt: input.createdAt,
+    })
+    return clone(record)
+  }
+
+  getByokSecret(orgId: string, providerId: string): ByokSecretRecord | null {
+    const normalizedProviderId = normalizeByokProviderId(providerId)
+    return Array.from(this.byokSecrets.values())
+      .filter((secret) => secret.orgId === orgId && secret.providerId === normalizedProviderId)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || right.createdAt.localeCompare(left.createdAt))
+      .map((secret) => clone(secret))[0] || null
+  }
+
+  getActiveByokSecret(orgId: string, providerId: string): ByokSecretRecord | null {
+    const normalizedProviderId = normalizeByokProviderId(providerId)
+    const secret = Array.from(this.byokSecrets.values()).find((candidate) => (
+      candidate.orgId === orgId
+      && candidate.providerId === normalizedProviderId
+      && candidate.status === 'active'
+    ))
+    return secret ? clone(secret) : null
+  }
+
+  listByokSecrets(orgId: string): ByokSecretRecord[] {
+    if (!this.orgs.has(orgId)) throw new Error(`Unknown org ${orgId}.`)
+    return Array.from(this.byokSecrets.values())
+      .filter((secret) => secret.orgId === orgId)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.providerId.localeCompare(right.providerId))
+      .map((secret) => clone(secret))
+  }
+
+  disableByokSecret(input: DisableByokSecretInput): ByokSecretRecord | null {
+    const providerId = normalizeByokProviderId(input.providerId)
+    const existing = input.secretId
+      ? this.byokSecrets.get(input.secretId)
+      : Array.from(this.byokSecrets.values()).find((secret) => (
+        secret.orgId === input.orgId
+        && secret.providerId === providerId
+        && secret.status === 'active'
+      ))
+    if (!existing || existing.orgId !== input.orgId || existing.providerId !== providerId) return null
+    existing.status = 'disabled'
+    existing.updatedAt = nowIso(input.disabledAt)
+    this.recordAuditEvent({
+      orgId: existing.orgId,
+      accountId: input.actor?.accountId || existing.createdByAccountId,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: 'byok_secret.disabled',
+      targetType: 'byok_secret',
+      targetId: existing.secretId,
+      metadata: { providerId: existing.providerId, status: existing.status, last4: existing.last4, keyFingerprint: existing.keyFingerprint },
+      createdAt: input.disabledAt,
+    })
+    return clone(existing)
+  }
+
+  recordByokSecretValidation(input: RecordByokSecretValidationInput): ByokSecretRecord | null {
+    const providerId = normalizeByokProviderId(input.providerId)
+    const existing = input.secretId
+      ? this.byokSecrets.get(input.secretId)
+      : Array.from(this.byokSecrets.values()).find((secret) => (
+        secret.orgId === input.orgId
+        && secret.providerId === providerId
+        && secret.status === 'active'
+      ))
+    if (!existing || existing.orgId !== input.orgId || existing.providerId !== providerId) return null
+    existing.lastValidatedAt = nowIso(input.validatedAt)
+    existing.validationError = input.validationError || null
+    if (input.status) existing.status = input.status
+    existing.updatedAt = existing.lastValidatedAt
+    this.recordAuditEvent({
+      orgId: existing.orgId,
+      accountId: input.actor?.accountId || existing.createdByAccountId,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: 'byok_secret.validated',
+      targetType: 'byok_secret',
+      targetId: existing.secretId,
+      metadata: {
+        providerId: existing.providerId,
+        status: existing.status,
+        last4: existing.last4,
+        keyFingerprint: existing.keyFingerprint,
+        validationError: existing.validationError,
+      },
+      createdAt: input.validatedAt,
+    })
+    return clone(existing)
   }
 
   createHeadlessAgent(input: CreateHeadlessAgentInput): HeadlessAgentRecord {

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -734,6 +734,41 @@ async function handleApiRequest(
     return
   }
 
+  if (resource === 'byok') {
+    const providerId = sessionId
+    if (!providerId && !action && req.method === 'GET') {
+      writeJson(res, 200, { secrets: await options.service.listByokSecrets(context.principal) }, options.corsOrigin)
+      return
+    }
+    if (providerId && !action && req.method === 'GET') {
+      writeJson(res, 200, { secret: await options.service.getByokSecret(context.principal, providerId) }, options.corsOrigin)
+      return
+    }
+    if (providerId && !action && req.method === 'POST') {
+      const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const plaintext = readString(body.plaintext) || readString(body.apiKey) || readString(body.key) || readString(body.secret)
+      const kmsRef = readString(body.kmsRef)
+      if ((plaintext && kmsRef) || (!plaintext && !kmsRef)) {
+        writeError(res, 400, 'BYOK credential requires exactly one of plaintext/apiKey/key/secret or kmsRef.', options.corsOrigin)
+        return
+      }
+      const secret = await options.service.setByokSecret(context.principal, {
+        providerId,
+        plaintext: plaintext || null,
+        kmsRef: kmsRef || null,
+      })
+      writeJson(res, 201, { secret }, options.corsOrigin)
+      return
+    }
+    if (providerId && !action && req.method === 'DELETE') {
+      const secret = await options.service.disableByokSecret(context.principal, providerId)
+      writeJson(res, 200, { secret, disabled: Boolean(secret) }, options.corsOrigin)
+      return
+    }
+    writeError(res, 404, 'Not found.', options.corsOrigin)
+    return
+  }
+
   if (resource === 'capabilities') {
     if (!options.policy.features.agents && !options.policy.features.customSkills && !options.policy.features.customMcps) {
       writePolicyError(res, 403, 'Capabilities are disabled for this cloud profile.', 'capabilities.disabled', options.corsOrigin)

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -19,6 +19,7 @@ import type {
   AuditEventRecord,
   AckChannelDeliveryInput,
   BindChannelSessionInput,
+  ByokSecretRecord,
   ChannelBindingRecord,
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
@@ -39,11 +40,13 @@ import type {
   CreateChannelDeliveryInput,
   CreateChannelInteractionInput,
   CreateAccountInput,
+  CreateByokSecretInput,
   CreateHeadlessAgentInput,
   CreateWorkflowInput,
   CreateWorkflowRunInput,
   CreateThreadSmartFilterInput,
   CreateThreadTagInput,
+  DisableByokSecretInput,
   FailWorkflowRunInput,
   FindChannelInteractionInput,
   HeadlessAgentRecord,
@@ -54,6 +57,7 @@ import type {
   OrgRecord,
   PrincipalMembershipRecord,
   RecordAuditEventInput,
+  RecordByokSecretValidationInput,
   RevokeApiTokenInput,
   ResolveChannelInteractionInput,
   ResolveChannelInteractionWithCommandInput,
@@ -121,6 +125,8 @@ const WORKFLOW_RUN_LIST_LIMIT = 100
 const CHANNEL_TEXT_MAX_LENGTH = 256
 const CHANNEL_METADATA_MAX_BYTES = 16_384
 const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
+const BYOK_PROVIDER_ID_MAX_LENGTH = 64
+const BYOK_SECRET_TEXT_MAX_LENGTH = 4096
 
 function loadPgPool(connectionString: string): PgPool {
   const pg = require('pg') as {
@@ -253,6 +259,12 @@ function normalizeProvider(value: unknown): ChannelProviderId {
   return provider
 }
 
+function normalizeByokProviderId(value: unknown) {
+  const providerId = normalizeText(value, BYOK_PROVIDER_ID_MAX_LENGTH, 'BYOK provider id').toLowerCase()
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) throw new Error(`Unsupported BYOK provider id ${providerId}.`)
+  return providerId
+}
+
 function redactAuditMetadata(value: Record<string, unknown> | undefined): Record<string, unknown> {
   const redacted: Record<string, unknown> = {}
   for (const [field, entry] of Object.entries(value || {})) {
@@ -350,6 +362,25 @@ function auditEventFromRow(row: QueryRow): AuditEventRecord {
     targetId: stringOrNull(row.target_id),
     metadata: jsonRecord(row.metadata),
     createdAt: iso(row.created_at),
+  }
+}
+
+function byokSecretFromRow(row: QueryRow): ByokSecretRecord {
+  return {
+    secretId: String(row.secret_id),
+    orgId: String(row.org_id),
+    providerId: String(row.provider_id),
+    status: String(row.status) as ByokSecretRecord['status'],
+    ciphertext: stringOrNull(row.ciphertext),
+    kmsRef: stringOrNull(row.kms_ref),
+    last4: String(row.last4),
+    keyFingerprint: String(row.key_fingerprint),
+    createdByAccountId: stringOrNull(row.created_by_account_id),
+    rotatedFromSecretId: stringOrNull(row.rotated_from_secret_id),
+    lastValidatedAt: isoOrNull(row.last_validated_at),
+    validationError: stringOrNull(row.validation_error),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
   }
 }
 
@@ -960,6 +991,173 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       [orgId, Math.max(1, Math.min(limit, 500))],
     )
     return result.rows.map(auditEventFromRow)
+  }
+
+  async createByokSecret(input: CreateByokSecretInput) {
+    return this.withTransaction(async (client) => {
+      const providerId = normalizeByokProviderId(input.providerId)
+      const ciphertext = normalizeNullableText(input.ciphertext, BYOK_SECRET_TEXT_MAX_LENGTH, 'BYOK ciphertext')
+      const kmsRef = normalizeNullableText(input.kmsRef, BYOK_SECRET_TEXT_MAX_LENGTH, 'BYOK KMS ref')
+      if ((ciphertext && kmsRef) || (!ciphertext && !kmsRef)) {
+        throw new Error('BYOK secret requires exactly one of ciphertext or kmsRef.')
+      }
+      const status = input.status || 'active'
+      const now = nowIso(input.createdAt)
+      let priorActive: ByokSecretRecord | null = null
+      if (status === 'active') {
+        const prior = await client.query(
+          `UPDATE cloud_byok_secrets
+           SET status = 'disabled', updated_at = $3
+           WHERE org_id = $1 AND provider_id = $2 AND status = 'active'
+           RETURNING *`,
+          [input.orgId, providerId, now],
+        )
+        priorActive = prior.rows[0] ? byokSecretFromRow(prior.rows[0]) : null
+      }
+      const result = await client.query(
+        `INSERT INTO cloud_byok_secrets (
+          secret_id, org_id, provider_id, status, ciphertext, kms_ref, last4,
+          key_fingerprint, created_by_account_id, rotated_from_secret_id,
+          last_validated_at, validation_error, created_at, updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULL, NULL, $11, $11)
+        RETURNING *`,
+        [
+          normalizeText(input.secretId, CHANNEL_TEXT_MAX_LENGTH, 'BYOK secret id'),
+          input.orgId,
+          providerId,
+          status,
+          ciphertext,
+          kmsRef,
+          normalizeText(input.last4, 32, 'BYOK secret last4'),
+          normalizeText(input.keyFingerprint, 128, 'BYOK key fingerprint'),
+          input.createdByAccountId || null,
+          input.rotatedFromSecretId || priorActive?.secretId || null,
+          now,
+        ],
+      )
+      const secret = byokSecretFromRow(result.rows[0])
+      await this.recordAuditEventWithExecutor(client, {
+        orgId: secret.orgId,
+        accountId: secret.createdByAccountId,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: priorActive ? 'byok_secret.rotated' : 'byok_secret.created',
+        targetType: 'byok_secret',
+        targetId: secret.secretId,
+        metadata: {
+          providerId: secret.providerId,
+          status: secret.status,
+          last4: secret.last4,
+          keyFingerprint: secret.keyFingerprint,
+          rotatedFromSecretId: secret.rotatedFromSecretId,
+        },
+        createdAt: input.createdAt,
+      })
+      return secret
+    })
+  }
+
+  async getByokSecret(orgId: string, providerId: string) {
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_byok_secrets
+       WHERE org_id = $1 AND provider_id = $2
+       ORDER BY updated_at DESC, created_at DESC, secret_id DESC
+       LIMIT 1`,
+      [orgId, normalizeByokProviderId(providerId)],
+    )
+    return row ? byokSecretFromRow(row) : null
+  }
+
+  async getActiveByokSecret(orgId: string, providerId: string) {
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_byok_secrets
+       WHERE org_id = $1 AND provider_id = $2 AND status = 'active'
+       LIMIT 1`,
+      [orgId, normalizeByokProviderId(providerId)],
+    )
+    return row ? byokSecretFromRow(row) : null
+  }
+
+  async listByokSecrets(orgId: string) {
+    const result = await this.pool.query(
+      `SELECT * FROM cloud_byok_secrets
+       WHERE org_id = $1
+       ORDER BY updated_at DESC, provider_id, secret_id`,
+      [orgId],
+    )
+    return result.rows.map(byokSecretFromRow)
+  }
+
+  async disableByokSecret(input: DisableByokSecretInput) {
+    return this.withTransaction(async (client) => {
+      const providerId = normalizeByokProviderId(input.providerId)
+      const now = nowIso(input.disabledAt)
+      const result = await client.query(
+        `UPDATE cloud_byok_secrets
+         SET status = 'disabled', updated_at = $4
+         WHERE org_id = $1
+           AND provider_id = $2
+           AND ($3::text IS NULL OR secret_id = $3)
+           AND status = 'active'
+         RETURNING *`,
+        [input.orgId, providerId, input.secretId || null, now],
+      )
+      if (!result.rows[0]) return null
+      const secret = byokSecretFromRow(result.rows[0])
+      await this.recordAuditEventWithExecutor(client, {
+        orgId: secret.orgId,
+        accountId: input.actor?.accountId || secret.createdByAccountId,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: 'byok_secret.disabled',
+        targetType: 'byok_secret',
+        targetId: secret.secretId,
+        metadata: { providerId: secret.providerId, status: secret.status, last4: secret.last4, keyFingerprint: secret.keyFingerprint },
+        createdAt: input.disabledAt,
+      })
+      return secret
+    })
+  }
+
+  async recordByokSecretValidation(input: RecordByokSecretValidationInput) {
+    return this.withTransaction(async (client) => {
+      const providerId = normalizeByokProviderId(input.providerId)
+      const now = nowIso(input.validatedAt)
+      const result = await client.query(
+        `UPDATE cloud_byok_secrets
+         SET status = COALESCE($4, status),
+             last_validated_at = $5,
+             validation_error = $6,
+             updated_at = $5
+         WHERE org_id = $1
+           AND provider_id = $2
+           AND ($3::text IS NULL OR secret_id = $3)
+           AND ($3::text IS NOT NULL OR status = 'active')
+         RETURNING *`,
+        [input.orgId, providerId, input.secretId || null, input.status || null, now, input.validationError || null],
+      )
+      if (!result.rows[0]) return null
+      const secret = byokSecretFromRow(result.rows[0])
+      await this.recordAuditEventWithExecutor(client, {
+        orgId: secret.orgId,
+        accountId: input.actor?.accountId || secret.createdByAccountId,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: 'byok_secret.validated',
+        targetType: 'byok_secret',
+        targetId: secret.secretId,
+        metadata: {
+          providerId: secret.providerId,
+          status: secret.status,
+          last4: secret.last4,
+          keyFingerprint: secret.keyFingerprint,
+          validationError: secret.validationError,
+        },
+        createdAt: input.validatedAt,
+      })
+      return secret
+    })
   }
 
   async createHeadlessAgent(input: CreateHeadlessAgentInput) {

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -446,6 +446,36 @@ export const CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_STATEMENTS = [
     ON cloud_channel_deliveries (org_id, status, next_attempt_at, created_at)`,
 ] as const
 
+export const CLOUD_CONTROL_PLANE_BYOK_SECRETS_MIGRATION_ID = '004_byok_secrets'
+
+export const CLOUD_CONTROL_PLANE_BYOK_SECRETS_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS cloud_byok_secrets (
+    secret_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    provider_id text NOT NULL,
+    status text NOT NULL,
+    ciphertext text,
+    kms_ref text,
+    last4 text NOT NULL,
+    key_fingerprint text NOT NULL,
+    created_by_account_id text REFERENCES cloud_accounts(account_id) ON DELETE SET NULL,
+    rotated_from_secret_id text REFERENCES cloud_byok_secrets(secret_id) ON DELETE SET NULL,
+    last_validated_at timestamptz,
+    validation_error text,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CHECK (
+      (ciphertext IS NOT NULL AND kms_ref IS NULL)
+      OR (ciphertext IS NULL AND kms_ref IS NOT NULL)
+    )
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_byok_secrets_org_provider_idx
+    ON cloud_byok_secrets (org_id, provider_id, updated_at DESC)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS cloud_byok_secrets_one_active_idx
+    ON cloud_byok_secrets (org_id, provider_id)
+    WHERE status = 'active'`,
+] as const
+
 export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration[] = [
   {
     id: CLOUD_CONTROL_PLANE_MIGRATION_ID,
@@ -458,5 +488,9 @@ export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration
   {
     id: CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_MIGRATION_ID,
     statements: CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_STATEMENTS,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_BYOK_SECRETS_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_BYOK_SECRETS_STATEMENTS,
   },
 ] as const

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -48,6 +48,7 @@ import type {
   ThreadTagRecord,
   WorkerLeaseRecord,
 } from './control-plane-store.ts'
+import type { ByokSecretMetadata, ByokSecretStore } from './byok-secret-store.ts'
 import type { CloudRuntimeAdapter, CloudRuntimeEvent, CloudRuntimePromptPart } from './runtime-adapter.ts'
 import { evaluateCloudProjectDirectoryPolicy, type CloudRuntimePolicy } from './cloud-config.ts'
 import { CloudSessionEventBus, CloudWorkspaceEventBus } from './session-event-bus.ts'
@@ -225,6 +226,12 @@ function stableCloudId(prefix: string, ...parts: string[]) {
 }
 
 function principalCanManageChannels(principal: CloudPrincipal) {
+  if (principal.authSource === 'local' || principal.authSource === 'header') return true
+  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
+function principalCanManageByok(principal: CloudPrincipal) {
   if (principal.authSource === 'local' || principal.authSource === 'header') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
   return principal.role === 'owner' || principal.role === 'admin'
@@ -948,6 +955,7 @@ export class CloudSessionService {
   private readonly events: CloudSessionEventBus
   private readonly workspaceEvents: CloudWorkspaceEventBus
   private readonly ids: { randomUUID: () => string }
+  private readonly byokSecrets: ByokSecretStore | null
 
   constructor(
     store: ControlPlaneStore,
@@ -956,6 +964,7 @@ export class CloudSessionService {
     events = new CloudSessionEventBus(),
     ids: { randomUUID: () => string } = { randomUUID },
     workspaceEvents = new CloudWorkspaceEventBus(),
+    byokSecrets: ByokSecretStore | null = null,
   ) {
     this.store = store
     this.runtime = runtime
@@ -963,6 +972,7 @@ export class CloudSessionService {
     this.events = events
     this.workspaceEvents = workspaceEvents
     this.ids = ids
+    this.byokSecrets = byokSecrets
   }
 
   get eventBus() {
@@ -1051,6 +1061,52 @@ export class CloudSessionService {
 
   async listWorkerHeartbeats() {
     return this.store.listWorkerHeartbeats()
+  }
+
+  async listByokSecrets(principal: CloudPrincipal): Promise<ByokSecretMetadata[]> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    return this.requireByokSecrets().listMetadata(this.principalOrgId(principal))
+  }
+
+  async getByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    return this.requireByokSecrets().getMetadata(this.principalOrgId(principal), providerId)
+  }
+
+  async setByokSecret(
+    principal: CloudPrincipal,
+    input: { providerId: string, plaintext?: string | null, kmsRef?: string | null },
+  ): Promise<ByokSecretMetadata> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    return this.requireByokSecrets().setSecret({
+      orgId: this.principalOrgId(principal),
+      providerId: input.providerId,
+      plaintext: input.plaintext,
+      kmsRef: input.kmsRef,
+      createdByAccountId: principal.accountId || principal.userId,
+      actor: {
+        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+        actorId: principal.tokenId || principal.userId,
+        accountId: principal.accountId || principal.userId,
+      },
+    })
+  }
+
+  async disableByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    return this.requireByokSecrets().disableSecret({
+      orgId: this.principalOrgId(principal),
+      providerId,
+      actor: {
+        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+        actorId: principal.tokenId || principal.userId,
+        accountId: principal.accountId || principal.userId,
+      },
+    })
   }
 
   async listHeadlessAgents(principal: CloudPrincipal): Promise<HeadlessAgentRecord[]> {
@@ -2570,6 +2626,17 @@ export class CloudSessionService {
     if (!principalCanManageChannels(principal)) {
       throw new CloudServiceError(403, 'Channel administration requires an org admin or admin-scoped API token.')
     }
+  }
+
+  private assertByokAllowed(principal: CloudPrincipal) {
+    if (!principalCanManageByok(principal)) {
+      throw new CloudServiceError(403, 'BYOK credential administration requires an org admin or admin-scoped API token.')
+    }
+  }
+
+  private requireByokSecrets() {
+    if (!this.byokSecrets) throw new CloudServiceError(503, 'BYOK secret storage is not configured.')
+    return this.byokSecrets
   }
 
   private assertGatewayAccess(principal: CloudPrincipal) {

--- a/packages/cloud-client/src/index.ts
+++ b/packages/cloud-client/src/index.ts
@@ -56,6 +56,27 @@ export type CloudChannelProviderId = 'telegram' | 'slack' | 'email' | 'discord' 
 export type CloudChannelIdentityRole = 'owner' | 'admin' | 'member' | 'approver' | 'viewer'
 export type CloudChannelIdentityStatus = 'active' | 'disabled' | 'pending'
 export type CloudChannelDeliveryStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead'
+export type CloudByokSecretStatus = 'active' | 'disabled' | 'expired' | 'invalid'
+
+export type CloudByokSecretMetadata = {
+  secretId: string
+  providerId: string
+  status: CloudByokSecretStatus
+  last4: string
+  keyFingerprint: string
+  lastValidatedAt: string | null
+  validationError: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type CloudSetByokSecretInput = {
+  plaintext?: string | null
+  apiKey?: string | null
+  key?: string | null
+  secret?: string | null
+  kmsRef?: string | null
+}
 
 export type HeadlessAgentRecord = {
   agentId: string
@@ -347,6 +368,10 @@ export type CloudTransportAdapter = {
   listSettings?(): Promise<CloudTransportSettingMetadata[]>
   getSetting?(key: string): Promise<CloudTransportSettingMetadata | null>
   setSetting?(key: string, value: Record<string, unknown>): Promise<CloudTransportSettingMetadata>
+  listByokSecrets?(): Promise<CloudByokSecretMetadata[]>
+  getByokSecret?(providerId: string): Promise<CloudByokSecretMetadata | null>
+  setByokSecret?(providerId: string, input: CloudSetByokSecretInput): Promise<CloudByokSecretMetadata>
+  deleteByokSecret?(providerId: string): Promise<CloudByokSecretMetadata | null>
   listHeadlessAgents?(): Promise<HeadlessAgentRecord[]>
   createHeadlessAgent?(input: {
     name: string
@@ -1061,6 +1086,23 @@ export function createHttpSseCloudTransportAdapter(
       })).setting)
       if (!setting) throw new Error('Cloud setting response was invalid.')
       return setting
+    },
+    async listByokSecrets() {
+      return (await request<{ secrets: CloudByokSecretMetadata[] }>('/api/byok')).secrets
+    },
+    async getByokSecret(providerId) {
+      return (await request<{ secret: CloudByokSecretMetadata | null }>(`/api/byok/${encodePath(providerId)}`)).secret
+    },
+    async setByokSecret(providerId, input) {
+      return (await request<{ secret: CloudByokSecretMetadata }>(`/api/byok/${encodePath(providerId)}`, {
+        method: 'POST',
+        body: input,
+      })).secret
+    },
+    async deleteByokSecret(providerId) {
+      return (await request<{ secret: CloudByokSecretMetadata | null }>(`/api/byok/${encodePath(providerId)}`, {
+        method: 'DELETE',
+      })).secret
     },
     async listHeadlessAgents() {
       return (await request<{ agents: HeadlessAgentRecord[] }>('/api/channels/agents')).agents

--- a/tests/byok-secret-store.test.ts
+++ b/tests/byok-secret-store.test.ts
@@ -1,0 +1,122 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createByokSecretStore } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
+import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
+import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secret-adapter.ts'
+
+const FIRST_KEY = 'credential-sample-first-1234567890'
+const SECOND_KEY = 'credential-sample-second-abcdefghi'
+
+function seededStore() {
+  const store = new InMemoryControlPlaneStore()
+  store.createTenant({ tenantId: 'tenant-1', name: 'Acme' })
+  store.ensureUser({ tenantId: 'tenant-1', userId: 'owner-1', email: 'owner@example.test', role: 'owner' })
+  store.createTenant({ tenantId: 'tenant-2', name: 'Other' })
+  store.ensureUser({ tenantId: 'tenant-2', userId: 'owner-2', email: 'owner2@example.test', role: 'owner' })
+  return store
+}
+
+test('BYOK secret store encrypts keys, returns metadata only, rotates active records, and reveals active plaintext', async () => {
+  const store = seededStore()
+  let nextId = 0
+  const byok = createByokSecretStore(store, createEnvelopeSecretAdapter('unit-test-byok-key'), {
+    ids: { randomUUID: () => `secret-${nextId += 1}` },
+  })
+
+  const first = await byok.setSecret({
+    orgId: 'tenant-1',
+    providerId: 'Anthropic',
+    plaintext: FIRST_KEY,
+    createdByAccountId: 'owner-1',
+    actor: { actorType: 'user', actorId: 'owner-1', accountId: 'owner-1' },
+  })
+  assert.equal(first.providerId, 'anthropic')
+  assert.equal(first.status, 'active')
+  assert.equal(first.last4, '7890')
+  assert.equal(await byok.revealActiveSecret({ orgId: 'tenant-1', providerId: 'anthropic' }), FIRST_KEY)
+
+  const rawFirst = await store.getActiveByokSecret('tenant-1', 'anthropic')
+  assert.ok(rawFirst?.ciphertext)
+  assert.notEqual(rawFirst.ciphertext, FIRST_KEY)
+  assert.equal(JSON.stringify(first).includes(FIRST_KEY), false)
+  assert.equal(JSON.stringify(await byok.listMetadata('tenant-1')).includes(FIRST_KEY), false)
+
+  const second = await byok.setSecret({
+    orgId: 'tenant-1',
+    providerId: 'anthropic',
+    plaintext: SECOND_KEY,
+    createdByAccountId: 'owner-1',
+  })
+  assert.equal(second.status, 'active')
+  assert.equal(second.last4, 'fghi')
+  assert.equal(await byok.revealActiveSecret({ orgId: 'tenant-1', providerId: 'anthropic' }), SECOND_KEY)
+
+  const records = await store.listByokSecrets('tenant-1')
+  assert.equal(records.length, 2)
+  assert.equal(records.filter((record) => record.providerId === 'anthropic' && record.status === 'active').length, 1)
+  assert.equal(records.find((record) => record.secretId === first.secretId)?.status, 'disabled')
+  assert.equal(records.find((record) => record.secretId === second.secretId)?.rotatedFromSecretId, first.secretId)
+})
+
+test('BYOK disable prevents active reveal', async () => {
+  const store = seededStore()
+  const byok = createByokSecretStore(store, createEnvelopeSecretAdapter('unit-test-byok-key'), {
+    ids: { randomUUID: () => 'secret-disable' },
+  })
+
+  await byok.setSecret({ orgId: 'tenant-1', providerId: 'openai', plaintext: FIRST_KEY })
+  const disabled = await byok.disableSecret({ orgId: 'tenant-1', providerId: 'openai' })
+  assert.equal(disabled?.status, 'disabled')
+  await assert.rejects(
+    () => byok.revealActiveSecret({ orgId: 'tenant-1', providerId: 'openai' }),
+    /No active BYOK secret/,
+  )
+})
+
+test('BYOK ciphertext is bound to org provider and secret context', async () => {
+  const store = seededStore()
+  const byok = createByokSecretStore(store, createEnvelopeSecretAdapter('unit-test-byok-key'), {
+    ids: { randomUUID: () => 'secret-cross-org' },
+  })
+
+  await byok.setSecret({ orgId: 'tenant-1', providerId: 'anthropic', plaintext: FIRST_KEY })
+  const source = await store.getActiveByokSecret('tenant-1', 'anthropic')
+  assert.ok(source?.ciphertext)
+
+  await store.createByokSecret({
+    secretId: 'byok_copied_ciphertext',
+    orgId: 'tenant-2',
+    providerId: 'anthropic',
+    ciphertext: source.ciphertext,
+    last4: source.last4,
+    keyFingerprint: source.keyFingerprint,
+  })
+
+  await assert.rejects(
+    () => byok.revealActiveSecret({ orgId: 'tenant-2', providerId: 'anthropic' }),
+    /authenticate|Unsupported state|bad decrypt|unable to authenticate/i,
+  )
+})
+
+test('BYOK validation audit metadata is redacted', async () => {
+  const store = seededStore()
+  const byok = createByokSecretStore(store, createEnvelopeSecretAdapter('unit-test-byok-key'), {
+    ids: { randomUUID: () => 'secret-audit' },
+  })
+
+  const created = await byok.setSecret({ orgId: 'tenant-1', providerId: 'anthropic', plaintext: FIRST_KEY })
+  await byok.recordValidation({
+    orgId: 'tenant-1',
+    providerId: 'anthropic',
+    secretId: created.secretId,
+    status: 'invalid',
+    validationError: `provider rejected ${FIRST_KEY}`,
+  })
+
+  const audit = await store.listAuditEvents('tenant-1')
+  assert.equal(audit.some((event) => event.eventType === 'byok_secret.created'), true)
+  assert.equal(audit.some((event) => event.eventType === 'byok_secret.validated'), true)
+  assert.equal(JSON.stringify(audit).includes(FIRST_KEY), false)
+  assert.match(JSON.stringify(audit), /\[redacted\]/)
+})

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import { DEFAULT_CONFIG } from '../apps/desktop/src/main/config-types.ts'
 import { CloudArtifactService } from '../apps/desktop/src/main/cloud/artifact-service.ts'
 import { createApiTokenCloudAuthResolver } from '../apps/desktop/src/main/cloud/app.ts'
+import { createByokSecretStore } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
 import { resolveCloudRuntimePolicy, type CloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
 import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
 import {
@@ -16,6 +17,7 @@ import { createHttpSseCloudTransportAdapter } from '../apps/desktop/src/main/clo
 import { CloudWorkspaceAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 import { createInMemoryObjectStore } from '../apps/desktop/src/main/cloud/object-store.ts'
 import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
+import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secret-adapter.ts'
 import { createCloudSessionCookieManager } from '../apps/desktop/src/main/cloud/session-cookie-auth.ts'
 import { CloudSessionService } from '../apps/desktop/src/main/cloud/session-service.ts'
 import { CloudWorker } from '../apps/desktop/src/main/cloud/worker.ts'
@@ -88,9 +90,12 @@ function createFixture(options: {
   const objectStore = createInMemoryObjectStore()
   const policy = options.policy || resolveCloudRuntimePolicy(DEFAULT_CONFIG)
   let nextId = 0
+  const byokSecrets = createByokSecretStore(store, createEnvelopeSecretAdapter('cloud-http-test-byok-key'), {
+    ids: { randomUUID: () => `byok-${nextId += 1}` },
+  })
   const service = new CloudSessionService(store, runtime, policy, undefined, {
     randomUUID: () => `cmd-${nextId += 1}`,
-  })
+  }, undefined, byokSecrets)
   const artifacts = new CloudArtifactService(service, objectStore, {
     randomUUID: () => `artifact-${nextId += 1}`,
   })
@@ -257,6 +262,81 @@ test('cloud HTTP server exposes health, config, session create/list/get, prompt,
     const abort = await readJson(abortResponse)
     assert.equal(abort.processed, 1)
     assert.deepEqual(fixture.runtime.aborted, ['oc-session-1'])
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server exposes metadata-only BYOK APIs with rotation, disable, and audit records', async () => {
+  const rawFirst = 'credential-http-first-1234567890'
+  const rawSecond = 'credential-http-second-abcdefghi'
+  const fixture = createFixture({
+    auth: () => ({
+      tenantId: 'tenant-1',
+      orgId: 'tenant-1',
+      tenantName: 'Tenant 1',
+      userId: 'owner-1',
+      accountId: 'owner-1',
+      email: 'owner@example.test',
+      role: 'owner',
+      authSource: 'user',
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const createResponse = await fetch(`${baseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ apiKey: rawFirst }),
+    })
+    assert.equal(createResponse.status, 201)
+    const created = await readJson(createResponse)
+    const createdSecret = asRecord(created.secret)
+    assert.equal(createdSecret.providerId, 'anthropic')
+    assert.equal(createdSecret.status, 'active')
+    assert.equal(createdSecret.last4, '7890')
+    assert.equal(JSON.stringify(created).includes(rawFirst), false)
+    assert.equal(JSON.stringify(created).includes('ciphertext'), false)
+    assert.equal(JSON.stringify(created).includes('kmsRef'), false)
+
+    const list = await readJson(await fetch(`${baseUrl}/api/byok`))
+    assert.equal(asArray(list.secrets).length, 1)
+    assert.equal(JSON.stringify(list).includes(rawFirst), false)
+
+    const rotateResponse = await fetch(`${baseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ key: rawSecond }),
+    })
+    assert.equal(rotateResponse.status, 201)
+    const rotated = await readJson(rotateResponse)
+    assert.equal(asRecord(rotated.secret).last4, 'fghi')
+    assert.equal(JSON.stringify(rotated).includes(rawSecond), false)
+
+    const records = await fixture.store.listByokSecrets('tenant-1')
+    assert.equal(records.length, 2)
+    assert.equal(records.filter((record) => record.status === 'active').length, 1)
+    assert.equal(records.some((record) => record.status === 'disabled'), true)
+    assert.equal(JSON.stringify(records).includes(rawFirst), false)
+    assert.equal(JSON.stringify(records).includes(rawSecond), false)
+
+    const deleteResponse = await fetch(`${baseUrl}/api/byok/anthropic`, { method: 'DELETE' })
+    assert.equal(deleteResponse.status, 200)
+    const deleted = await readJson(deleteResponse)
+    assert.equal(deleted.disabled, true)
+    assert.equal(asRecord(deleted.secret).status, 'disabled')
+    assert.equal(await fixture.store.getActiveByokSecret('tenant-1', 'anthropic'), null)
+
+    const provider = await readJson(await fetch(`${baseUrl}/api/byok/anthropic`))
+    assert.equal(asRecord(provider.secret).status, 'disabled')
+    assert.equal(JSON.stringify(provider).includes(rawSecond), false)
+
+    const audit = await fixture.store.listAuditEvents('tenant-1')
+    assert.equal(audit.some((event) => event.eventType === 'byok_secret.created'), true)
+    assert.equal(audit.some((event) => event.eventType === 'byok_secret.rotated'), true)
+    assert.equal(audit.some((event) => event.eventType === 'byok_secret.disabled'), true)
+    assert.equal(JSON.stringify(audit).includes(rawFirst), false)
+    assert.equal(JSON.stringify(audit).includes(rawSecond), false)
   } finally {
     await fixture.server.close()
   }

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -90,6 +90,7 @@ test('real Postgres cloud store serializes concurrent schema migrations', {
         '001_cloud_control_plane',
         '002_org_identity_tokens_audit',
         '003_headless_channels',
+        '004_byok_secrets',
       ])
     } finally {
       await Promise.all(stores.map((store) => store.close?.()))
@@ -125,6 +126,38 @@ test('real Postgres cloud store persists org identity, API tokens, and audit eve
     await store.revokeApiToken({ tokenId: issued.token.tokenId })
     assert.equal(await store.findApiTokenByPlaintext(issued.plaintext), null)
     assert.equal((await store.listAuditEvents(org.orgId)).some((event) => event.eventType === 'api_token.created'), true)
+  })
+})
+
+test('real Postgres cloud store persists and rotates BYOK secrets atomically', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const org = await store.ensureOrgForTenant({ tenantId: ids.tenantId, name: 'Tenant' })
+    const first = await store.createByokSecret({
+      secretId: `${ids.tenantId}-byok-1`,
+      orgId: org.orgId,
+      providerId: 'anthropic',
+      ciphertext: 'enc:v1:first',
+      last4: '1111',
+      keyFingerprint: 'fingerprint-1',
+    })
+    assert.equal(first.status, 'active')
+    const second = await store.createByokSecret({
+      secretId: `${ids.tenantId}-byok-2`,
+      orgId: org.orgId,
+      providerId: 'anthropic',
+      ciphertext: 'enc:v1:second',
+      last4: '2222',
+      keyFingerprint: 'fingerprint-2',
+    })
+    assert.equal(second.status, 'active')
+    assert.equal(second.rotatedFromSecretId, first.secretId)
+    const records = await store.listByokSecrets(org.orgId)
+    assert.equal(records.filter((record) => record.providerId === 'anthropic' && record.status === 'active').length, 1)
+    assert.equal(records.find((record) => record.secretId === first.secretId)?.status, 'disabled')
+    assert.equal((await store.disableByokSecret({ orgId: org.orgId, providerId: 'anthropic' }))?.status, 'disabled')
+    assert.equal(await store.getActiveByokSecret(org.orgId, 'anthropic'), null)
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #425.

Adds the Phase 5.1 BYOK foundation:

- adds the `004_byok_secrets` cloud control-plane migration
- extends the in-memory and Postgres control-plane stores with BYOK secret records
- adds an encrypted `ByokSecretStore` with metadata-only reads, rotation, disable, validation metadata, and org/provider/secret AAD binding
- exposes metadata-only BYOK HTTP APIs and cloud-client helpers
- wires BYOK storage into the cloud app/session service behind admin-scoped access checks
- adds targeted unit, HTTP, and optional Postgres coverage

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`
- `node scripts/run-node-tests.mjs tests/byok-secret-store.test.ts tests/cloud-http-server.test.ts tests/cloud-postgres-concurrency.test.ts`

## Notes

This intentionally does not inject BYOK credentials into OpenCode runtime config. That is the next phase tracked by #426.