### PR TITLE
Inject BYOK credentials into cloud runtime config

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -26,7 +26,7 @@ import {
   createOidcCloudAuthResolver,
   type OidcCloudAuthResolverOptions,
 } from './oidc-auth.ts'
-import { createCloudPathProvider, type PathProvider } from './path-provider.ts'
+import { createCloudPathProvider, createCloudSessionPathProvider, type PathProvider } from './path-provider.ts'
 import { createPostgresControlPlaneStore } from './postgres-control-plane-store.ts'
 import { createNodeOpencodeCloudRuntimeAdapter } from './opencode-runtime-adapter.ts'
 import type { CloudRuntimeAdapter, CloudRuntimeEvent } from './runtime-adapter.ts'
@@ -35,6 +35,7 @@ import { createCloudSessionCookieManager, type CloudSessionCookieManager } from 
 import { CloudSessionService, type CloudPrincipal } from './session-service.ts'
 import { CloudScheduler } from './scheduler.ts'
 import { CloudWorker } from './worker.ts'
+import { createWorkerScopedRuntimeAdapter } from './worker-scoped-runtime-adapter.ts'
 import {
   createObjectWorkspaceCheckpointStore,
   defaultCloudSessionCheckpointRoots,
@@ -50,6 +51,13 @@ export type CloudRoleRuntimeFactoryInput = {
   paths: PathProvider
   policy: CloudRuntimePolicy
   env: Env
+  config: OpenCoworkConfig
+  execution: {
+    tenantId: string
+    sessionId: string
+    profileName?: string | null
+  }
+  runtimeConfig: import('@opencode-ai/sdk/v2/server').ServerOptions['config']
 }
 
 export type CloudRuntimeFactory = (
@@ -256,6 +264,8 @@ function defaultCloudRuntimeFactory(input: CloudRoleRuntimeFactoryInput) {
   return createNodeOpencodeCloudRuntimeAdapter({
     paths: input.paths,
     env: input.env as NodeJS.ProcessEnv,
+    config: input.runtimeConfig,
+    configDelivery: 'ephemeral-file',
   })
 }
 
@@ -506,7 +516,14 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
     : null
   const runtime = options.runtime || (
     shouldRunCloudWorker(policy.role)
-      ? await (options.runtimeFactory || defaultCloudRuntimeFactory)({ paths, policy, env })
+      ? createWorkerScopedRuntimeAdapter({
+          paths,
+          policy,
+          env,
+          config,
+          byokSecrets,
+          runtimeFactory: options.runtimeFactory || defaultCloudRuntimeFactory,
+        })
       : createUnavailableRuntimeAdapter()
   )
   const service = new CloudSessionService(store, runtime, policy, undefined, undefined, undefined, byokSecrets)
@@ -545,22 +562,24 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
         checkpointStore
           ? {
               async restoreBeforeCommands(lease) {
+                const leasePaths = createCloudSessionPathProvider(paths, lease.tenantId, lease.sessionId)
                 try {
                   await checkpointStore.restoreSessionCheckpoint({
                     tenantId: lease.tenantId,
                     sessionId: lease.sessionId,
-                    roots: defaultCloudSessionCheckpointRoots(paths, lease.tenantId, lease.sessionId),
+                    roots: defaultCloudSessionCheckpointRoots(leasePaths, lease.tenantId, lease.sessionId),
                   })
                 } catch (error) {
                   if (!isMissingCheckpointError(error)) throw error
                 }
               },
               async saveAfterCommand(lease) {
+                const leasePaths = createCloudSessionPathProvider(paths, lease.tenantId, lease.sessionId)
                 await checkpointStore.saveSessionCheckpoint({
                   tenantId: lease.tenantId,
                   sessionId: lease.sessionId,
                   checkpointVersion: lease.checkpointVersion,
-                  roots: defaultCloudSessionCheckpointRoots(paths, lease.tenantId, lease.sessionId),
+                  roots: defaultCloudSessionCheckpointRoots(leasePaths, lease.tenantId, lease.sessionId),
                 })
               },
             }

--- a/apps/desktop/src/main/cloud/byok-runtime-config.ts
+++ b/apps/desktop/src/main/cloud/byok-runtime-config.ts
@@ -1,0 +1,117 @@
+import type { Config, ProviderConfig } from '@opencode-ai/sdk/v2'
+import type { CredentialField } from '@open-cowork/shared'
+import type { OpenCoworkConfig } from '../config-types.ts'
+import { log } from '../logger.ts'
+import { buildConfiguredDescriptorProviderRuntimeConfig } from '../runtime-config-builder.ts'
+import type { ByokSecretStore } from './byok-secret-store.ts'
+import type { CloudRuntimeExecutionContext } from './runtime-adapter.ts'
+
+export class CloudByokRuntimeConfigError extends Error {
+  readonly providerId: string
+  readonly code: 'missing_required_byok' | 'kms_not_supported'
+
+  constructor(providerId: string, code: CloudByokRuntimeConfigError['code'], message: string) {
+    super(message)
+    this.name = 'CloudByokRuntimeConfigError'
+    this.providerId = providerId
+    this.code = code
+  }
+}
+
+export type CloudByokRuntimeConfigInput = {
+  appConfig: OpenCoworkConfig
+  byokSecrets: ByokSecretStore
+  context: CloudRuntimeExecutionContext
+}
+
+function stripProviderPrefix(providerId: string, modelId: string | null | undefined) {
+  const trimmed = modelId?.trim()
+  if (!trimmed) return ''
+  const prefix = `${providerId}/`
+  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed
+}
+
+function providerCredentialField(credentials: readonly CredentialField[] | undefined) {
+  return credentials?.find((credential) => credential.secret)
+    || credentials?.find((credential) => credential.required)
+    || credentials?.[0]
+    || null
+}
+
+function providerRequiresByok(input: {
+  providerId: string
+  defaultProviderId: string | null
+  credentials: readonly CredentialField[] | undefined
+}) {
+  return input.providerId === input.defaultProviderId
+    && Boolean(input.credentials?.some((credential) => credential.secret && credential.required))
+}
+
+function redactOptionShape(options: Record<string, unknown>) {
+  return Object.entries(options).map(([key, value]) => {
+    if (key === 'baseURL' && typeof value === 'string') return `${key}=${value}`
+    if (typeof value === 'string') return `${key}=<len=${value.length} redacted>`
+    return `${key}=<${typeof value}>`
+  })
+}
+
+export async function buildCloudByokRuntimeConfig(input: CloudByokRuntimeConfigInput): Promise<Config> {
+  const { appConfig, byokSecrets, context } = input
+  const defaultProviderId = appConfig.providers.defaultProvider
+  const providerEntries: Record<string, ProviderConfig> = {}
+  const metadata = await byokSecrets.listMetadata(context.tenantId)
+  const activeProviderIds = new Set(
+    metadata
+      .filter((secret) => secret.status === 'active')
+      .map((secret) => secret.providerId),
+  )
+
+  for (const [providerId, descriptor] of Object.entries(appConfig.providers.descriptors || {})) {
+    const shouldRequire = providerRequiresByok({
+      providerId,
+      defaultProviderId,
+      credentials: descriptor.credentials,
+    })
+    const hasActiveSecret = activeProviderIds.has(providerId)
+    if (!shouldRequire && !hasActiveSecret) continue
+
+    const credential = providerCredentialField(descriptor.credentials)
+    if (!credential) continue
+    let plaintext: string
+    try {
+      plaintext = await byokSecrets.revealActiveSecret({
+        orgId: context.tenantId,
+        providerId,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const code = /kms/i.test(message) ? 'kms_not_supported' : 'missing_required_byok'
+      throw new CloudByokRuntimeConfigError(
+        providerId,
+        code,
+        `Provider "${providerId}" requires an active BYOK credential before cloud execution can start.`,
+      )
+    }
+
+    const providerConfig = buildConfiguredDescriptorProviderRuntimeConfig(descriptor, {
+      [credential.key]: plaintext,
+    })
+    if (!providerConfig) continue
+    providerEntries[providerId] = providerConfig
+    log(
+      'runtime',
+      `cloud-byok provider=${providerId} tenant=${context.tenantId} session=${context.sessionId} options {${redactOptionShape(providerConfig.options || {}).join(', ')}}`,
+    )
+  }
+
+  const providerId = defaultProviderId || Object.keys(providerEntries)[0] || 'openrouter'
+  const modelId = stripProviderPrefix(providerId, appConfig.providers.defaultModel)
+  const model = modelId ? `${providerId}/${modelId}` : providerId
+  return {
+    $schema: 'https://opencode.ai/config.json',
+    autoupdate: false,
+    share: 'manual',
+    model,
+    ...(Object.keys(providerEntries).length > 0 ? { provider: providerEntries } : {}),
+  }
+}

--- a/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
@@ -3,7 +3,8 @@ import {
   type OpencodeClientConfig,
 } from '@opencode-ai/sdk/v2'
 import type { ServerOptions as OpencodeServerOptions } from '@opencode-ai/sdk/v2/server'
-import { mkdirSync } from 'node:fs'
+import { chmodSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import {
   normalizeMessagePart,
   normalizeRuntimeEventEnvelope,
@@ -43,6 +44,7 @@ export type NodeOpencodeCloudRuntimeAdapter = CloudRuntimeAdapter & {
 export type NodeOpencodeCloudRuntimeOptions = {
   paths: PathProvider
   config?: OpencodeServerOptions['config']
+  configDelivery?: 'env' | 'ephemeral-file'
   env?: NodeJS.ProcessEnv
   hostname?: string
   port?: number
@@ -411,12 +413,33 @@ function ensureNodeRuntimeDirs(paths: PathProvider) {
   }
 }
 
+function writeEphemeralOpencodeConfig(paths: PathProvider, config: OpencodeServerOptions['config']) {
+  const configPath = join(paths.getRuntimeXdgRoots().configHome, 'opencode', 'opencode.json')
+  mkdirSync(dirname(configPath), { recursive: true })
+  writeFileSync(configPath, JSON.stringify(config ?? {}), { mode: 0o600 })
+  chmodSync(configPath, 0o600)
+  return () => {
+    try {
+      unlinkSync(configPath)
+    } catch {
+      // The runtime may already have removed or moved the file.
+    }
+  }
+}
+
 export async function createNodeOpencodeCloudRuntimeAdapter(
   options: NodeOpencodeCloudRuntimeOptions,
 ): Promise<NodeOpencodeCloudRuntimeAdapter> {
   ensureNodeRuntimeDirs(options.paths)
   const auth = createManagedOpencodeServerAuth()
   const runtimePaths = options.paths.getRuntimeXdgRoots()
+  let cleanupEphemeralConfig: (() => void) | null = null
+  const serverConfig = options.configDelivery === 'ephemeral-file'
+    ? undefined
+    : options.config
+  if (options.configDelivery === 'ephemeral-file' && options.config !== undefined) {
+    cleanupEphemeralConfig = writeEphemeralOpencodeConfig(options.paths, options.config)
+  }
   const env = buildManagedRuntimeEnvironment({
     currentEnv: options.env || process.env,
     runtimePaths: {
@@ -429,17 +452,22 @@ export async function createNodeOpencodeCloudRuntimeAdapter(
     enableNativeWebSearch: options.enableNativeWebSearch,
     serverAuth: auth,
   })
-  const server = await createNodeManagedOpencodeServer({
-    hostname: options.hostname || '127.0.0.1',
-    port: options.port ?? 0,
-    timeout: options.timeout ?? 5000,
-    config: options.config,
-    env,
-    cwd: options.paths.getRuntimeHomeDir(),
-    logLevel: options.logLevel,
-    opencodeBinPath: options.opencodeBinPath,
-    onUnexpectedExit: options.onUnexpectedExit,
-  })
+  let server: Awaited<ReturnType<typeof createNodeManagedOpencodeServer>>
+  try {
+    server = await createNodeManagedOpencodeServer({
+      hostname: options.hostname || '127.0.0.1',
+      port: options.port ?? 0,
+      timeout: options.timeout ?? 5000,
+      config: serverConfig,
+      env,
+      cwd: options.paths.getRuntimeHomeDir(),
+      logLevel: options.logLevel,
+      opencodeBinPath: options.opencodeBinPath,
+      onUnexpectedExit: options.onUnexpectedExit,
+    })
+  } finally {
+    cleanupEphemeralConfig?.()
+  }
   const client = createOpencodeClient(buildNodeOpencodeCloudRuntimeClientConfig(server.url, auth))
   const adapter = createSdkCloudRuntimeAdapter(client)
   return {

--- a/apps/desktop/src/main/cloud/path-provider.ts
+++ b/apps/desktop/src/main/cloud/path-provider.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { join, resolve, relative, isAbsolute } from 'path'
 
 export type RuntimeXdgRoots = {
@@ -92,5 +93,31 @@ export function createCloudPathProvider(root: string): PathProvider {
     xdgCacheHome: join(base, 'runtime', 'xdg', 'cache'),
     workspaceRoot: join(base, 'workspaces'),
     artifactRoot: join(base, 'artifacts'),
+  })
+}
+
+function safeScopeSegment(value: string, fallback: string) {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '')
+  const hash = createHash('sha256').update(value).digest('hex').slice(0, 12)
+  return `${normalized.slice(0, 72) || fallback}-${hash}`
+}
+
+export function createCloudSessionPathProvider(
+  base: PathProvider,
+  tenantId: string,
+  sessionId: string,
+): PathProvider {
+  const roots = base.getRuntimeXdgRoots()
+  const tenantSegment = safeScopeSegment(tenantId, 'tenant')
+  const sessionSegment = safeScopeSegment(sessionId, 'session')
+  return createStaticPathProvider({
+    appDataDir: base.getAppDataDir(),
+    runtimeHomeDir: join(base.getRuntimeHomeDir(), 'sessions', tenantSegment, sessionSegment, 'home'),
+    xdgConfigHome: join(roots.configHome, 'sessions', tenantSegment, sessionSegment),
+    xdgDataHome: join(roots.dataHome, 'sessions', tenantSegment, sessionSegment),
+    xdgStateHome: join(roots.stateHome, 'sessions', tenantSegment, sessionSegment),
+    xdgCacheHome: join(roots.cacheHome, 'sessions', tenantSegment, sessionSegment),
+    workspaceRoot: base.getWorkspaceRoot(),
+    artifactRoot: base.getArtifactRoot(),
   })
 }

--- a/apps/desktop/src/main/cloud/runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/runtime-adapter.ts
@@ -22,17 +22,25 @@ export type CloudPromptResult = {
   events?: CloudRuntimeEvent[]
 }
 
+export type CloudRuntimeExecutionContext = {
+  tenantId: string
+  sessionId: string
+  profileName?: string | null
+}
+
 export type CloudRuntimeAdapter = {
-  createSession(input?: { profileName?: string }): Promise<CloudRuntimeSession>
+  requiresWorkerContext?: boolean
+  createSession(input?: { profileName?: string | null, context?: CloudRuntimeExecutionContext | null }): Promise<CloudRuntimeSession>
   promptSession(input: {
     sessionId: string
     parts: CloudRuntimePromptPart[]
     agent: string
+    context?: CloudRuntimeExecutionContext | null
   }): Promise<CloudPromptResult | void>
-  abortSession(input: { sessionId: string }): Promise<void>
-  replyToQuestion?(input: { requestId: string, answers: unknown[] }): Promise<void>
-  rejectQuestion?(input: { requestId: string }): Promise<void>
-  respondToPermission?(input: { permissionId: string, allowed: boolean }): Promise<void>
+  abortSession(input: { sessionId: string, context?: CloudRuntimeExecutionContext | null }): Promise<void>
+  replyToQuestion?(input: { requestId: string, answers: unknown[], context?: CloudRuntimeExecutionContext | null }): Promise<void>
+  rejectQuestion?(input: { requestId: string, context?: CloudRuntimeExecutionContext | null }): Promise<void>
+  respondToPermission?(input: { permissionId: string, allowed: boolean, context?: CloudRuntimeExecutionContext | null }): Promise<void>
   subscribeEvents?: (
     listener: CloudRuntimeEventListener,
     options?: { signal?: AbortSignal, onError?: (error: unknown) => void },

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -49,7 +49,12 @@ import type {
   WorkerLeaseRecord,
 } from './control-plane-store.ts'
 import type { ByokSecretMetadata, ByokSecretStore } from './byok-secret-store.ts'
-import type { CloudRuntimeAdapter, CloudRuntimeEvent, CloudRuntimePromptPart } from './runtime-adapter.ts'
+import type {
+  CloudRuntimeAdapter,
+  CloudRuntimeEvent,
+  CloudRuntimeExecutionContext,
+  CloudRuntimePromptPart,
+} from './runtime-adapter.ts'
 import { evaluateCloudProjectDirectoryPolicy, type CloudRuntimePolicy } from './cloud-config.ts'
 import { CloudSessionEventBus, CloudWorkspaceEventBus } from './session-event-bus.ts'
 import { computeNextWorkflowRunAt, validateWorkflowSchedule } from '../workflow/workflow-schedule.ts'
@@ -2123,6 +2128,7 @@ export class CloudSessionService {
 
   private async executePromptCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
     const payload = normalizePromptPayload(command.payload)
+    const session = await this.requireSessionRecord(command.tenantId, command.sessionId)
     const runtimeSessionId = await this.ensureRuntimeSessionBound(lease)
     await this.store.updateSessionStatus({
       tenantId: command.tenantId,
@@ -2145,6 +2151,7 @@ export class CloudSessionService {
       sessionId: runtimeSessionId,
       parts: promptParts(payload.text),
       agent: payload.agent,
+      context: this.runtimeContext(session),
     })
     for (const event of result?.events || []) {
       await this.applyRuntimeEvent(lease, command.sessionId, event)
@@ -2159,7 +2166,10 @@ export class CloudSessionService {
   private async executeAbortCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
     const session = await this.requireSessionRecord(command.tenantId, command.sessionId)
     if (session.opencodeSessionId) {
-      await this.runtime.abortSession({ sessionId: session.opencodeSessionId })
+      await this.runtime.abortSession({
+        sessionId: session.opencodeSessionId,
+        context: this.runtimeContext(session),
+      })
     }
     await this.store.updateSessionStatus({
       tenantId: command.tenantId,
@@ -2181,9 +2191,11 @@ export class CloudSessionService {
     const payload = normalizeQuestionReplyPayload(command.payload)
     if (!payload.requestId) throw new Error('Question reply requires a request id.')
     if (!this.runtime.replyToQuestion) throw new Error('OpenCode question replies are not available.')
+    const session = await this.requireSessionRecord(command.tenantId, command.sessionId)
     await this.runtime.replyToQuestion({
       requestId: payload.requestId,
       answers: payload.answers,
+      context: this.runtimeContext(session),
     })
     await this.appendProjectedEvent({
       tenantId: command.tenantId,
@@ -2201,8 +2213,10 @@ export class CloudSessionService {
     const payload = normalizeQuestionRejectPayload(command.payload)
     if (!payload.requestId) throw new Error('Question rejection requires a request id.')
     if (!this.runtime.rejectQuestion) throw new Error('OpenCode question rejection is not available.')
+    const session = await this.requireSessionRecord(command.tenantId, command.sessionId)
     await this.runtime.rejectQuestion({
       requestId: payload.requestId,
+      context: this.runtimeContext(session),
     })
     await this.appendProjectedEvent({
       tenantId: command.tenantId,
@@ -2221,6 +2235,7 @@ export class CloudSessionService {
     const payload = normalizePermissionPayload(command.payload)
     if (!payload.permissionId) throw new Error('Permission response requires a permission id.')
     if (!this.runtime.respondToPermission) throw new Error('OpenCode permission responses are not available.')
+    const session = await this.requireSessionRecord(command.tenantId, command.sessionId)
     const allowed = asRecord(payload.response).allowed === true
       || payload.response === true
       || payload.response === 'allow'
@@ -2228,6 +2243,7 @@ export class CloudSessionService {
     await this.runtime.respondToPermission({
       permissionId: payload.permissionId,
       allowed,
+      context: this.runtimeContext(session),
     })
     await this.appendProjectedEvent({
       tenantId: command.tenantId,
@@ -2296,7 +2312,16 @@ export class CloudSessionService {
   }
 
   private shouldCreateRuntimeSessionsEagerly() {
+    if (this.runtime.requiresWorkerContext) return false
     return this.policy.role === 'all-in-one' || this.policy.role === 'worker'
+  }
+
+  private runtimeContext(input: { tenantId: string, sessionId: string, profileName?: string | null }): CloudRuntimeExecutionContext {
+    return {
+      tenantId: input.tenantId,
+      sessionId: input.sessionId,
+      profileName: input.profileName || this.policy.profileName,
+    }
   }
 
   private async createCloudSessionRecord(input: CreateCloudSessionRecordInput): Promise<SessionRecord> {
@@ -2328,7 +2353,14 @@ export class CloudSessionService {
     }
 
     if (this.shouldCreateRuntimeSessionsEagerly()) {
-      const runtimeSession = await this.runtime.createSession({ profileName: input.profileName })
+      const runtimeSession = await this.runtime.createSession({
+        profileName: input.profileName,
+        context: this.runtimeContext({
+          tenantId: input.tenantId,
+          sessionId: input.sessionId || '',
+          profileName: input.profileName,
+        }),
+      })
       const title = input.title || runtimeSession.title
       await this.store.createSession({
         tenantId: input.tenantId,
@@ -2378,7 +2410,10 @@ export class CloudSessionService {
     const session = await this.requireSessionRecord(lease.tenantId, lease.sessionId)
     if (session.opencodeSessionId) return session.opencodeSessionId
 
-    const runtimeSession = await this.runtime.createSession({ profileName: session.profileName })
+    const runtimeSession = await this.runtime.createSession({
+      profileName: session.profileName,
+      context: this.runtimeContext(session),
+    })
     await this.store.bindSessionRuntime({
       tenantId: session.tenantId,
       sessionId: session.sessionId,

--- a/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
@@ -1,0 +1,162 @@
+import type { OpenCoworkConfig } from '../config-types.ts'
+import type { ByokSecretStore } from './byok-secret-store.ts'
+import { buildCloudByokRuntimeConfig } from './byok-runtime-config.ts'
+import type { CloudRuntimePolicy } from './cloud-config.ts'
+import type { PathProvider } from './path-provider.ts'
+import { createCloudSessionPathProvider } from './path-provider.ts'
+import type {
+  CloudRuntimeAdapter,
+  CloudRuntimeEvent,
+  CloudRuntimeEventListener,
+  CloudRuntimeExecutionContext,
+} from './runtime-adapter.ts'
+
+type Env = Record<string, string | undefined>
+
+export type WorkerScopedRuntimeFactoryInput = {
+  paths: PathProvider
+  policy: CloudRuntimePolicy
+  env: Env
+  config: OpenCoworkConfig
+  execution: CloudRuntimeExecutionContext
+  runtimeConfig: import('@opencode-ai/sdk/v2/server').ServerOptions['config']
+}
+
+export type WorkerScopedRuntimeFactory = (
+  input: WorkerScopedRuntimeFactoryInput,
+) => Promise<CloudRuntimeAdapter> | CloudRuntimeAdapter
+
+export type WorkerScopedRuntimeAdapterOptions = {
+  paths: PathProvider
+  policy: CloudRuntimePolicy
+  env: Env
+  config: OpenCoworkConfig
+  byokSecrets: ByokSecretStore
+  runtimeFactory: WorkerScopedRuntimeFactory
+}
+
+type RuntimeEntry = {
+  adapter: CloudRuntimeAdapter
+  unsubscribe: (() => void | Promise<void>) | null
+}
+
+function runtimeKey(context: CloudRuntimeExecutionContext) {
+  return `${context.tenantId}\0${context.sessionId}`
+}
+
+function requireContext(context: CloudRuntimeExecutionContext | null | undefined) {
+  if (!context?.tenantId || !context.sessionId) {
+    throw new Error('Cloud worker runtime execution requires tenant and session context.')
+  }
+  return context
+}
+
+function mapRuntimeEventToCoworkSession(context: CloudRuntimeExecutionContext, event: CloudRuntimeEvent): CloudRuntimeEvent {
+  const runtimeSessionId = typeof event.payload.sessionId === 'string' ? event.payload.sessionId : null
+  return {
+    ...event,
+    payload: {
+      ...event.payload,
+      ...(runtimeSessionId && runtimeSessionId !== context.sessionId ? { opencodeSessionId: runtimeSessionId } : {}),
+      sessionId: context.sessionId,
+    },
+  }
+}
+
+export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAdapterOptions): CloudRuntimeAdapter {
+  const runtimes = new Map<string, RuntimeEntry>()
+  const listeners = new Map<CloudRuntimeEventListener, { onError?: (error: unknown) => void }>()
+
+  async function subscribeRuntimeEvents(context: CloudRuntimeExecutionContext, adapter: CloudRuntimeAdapter) {
+    if (!adapter.subscribeEvents || listeners.size === 0) return null
+    const unsubscribe = await adapter.subscribeEvents(
+      (event) => {
+        const mapped = mapRuntimeEventToCoworkSession(context, event)
+        for (const listener of listeners.keys()) {
+          void listener(mapped)
+        }
+      },
+      {
+        onError(error) {
+          for (const entry of listeners.values()) entry.onError?.(error)
+        },
+      },
+    )
+    return unsubscribe
+  }
+
+  async function getRuntime(contextInput: CloudRuntimeExecutionContext | null | undefined) {
+    const context = requireContext(contextInput)
+    const key = runtimeKey(context)
+    const existing = runtimes.get(key)
+    if (existing) return existing.adapter
+
+    const scopedPaths = createCloudSessionPathProvider(options.paths, context.tenantId, context.sessionId)
+    const runtimeConfig = await buildCloudByokRuntimeConfig({
+      appConfig: options.config,
+      byokSecrets: options.byokSecrets,
+      context,
+    })
+    const adapter = await options.runtimeFactory({
+      paths: scopedPaths,
+      policy: options.policy,
+      env: options.env,
+      config: options.config,
+      execution: context,
+      runtimeConfig,
+    })
+    const unsubscribe = await subscribeRuntimeEvents(context, adapter)
+    runtimes.set(key, { adapter, unsubscribe })
+    return adapter
+  }
+
+  return {
+    requiresWorkerContext: true,
+    async createSession(input) {
+      const adapter = await getRuntime(input?.context)
+      return adapter.createSession({ profileName: input?.profileName || undefined })
+    },
+    async promptSession(input) {
+      const adapter = await getRuntime(input.context)
+      return adapter.promptSession(input)
+    },
+    async abortSession(input) {
+      const adapter = await getRuntime(input.context)
+      return adapter.abortSession(input)
+    },
+    async replyToQuestion(input) {
+      const adapter = await getRuntime(input.context)
+      if (!adapter.replyToQuestion) throw new Error('OpenCode question replies are not available.')
+      return adapter.replyToQuestion(input)
+    },
+    async rejectQuestion(input) {
+      const adapter = await getRuntime(input.context)
+      if (!adapter.rejectQuestion) throw new Error('OpenCode question rejection is not available.')
+      return adapter.rejectQuestion(input)
+    },
+    async respondToPermission(input) {
+      const adapter = await getRuntime(input.context)
+      if (!adapter.respondToPermission) throw new Error('OpenCode permission responses are not available.')
+      return adapter.respondToPermission(input)
+    },
+    async subscribeEvents(listener, subscribeOptions) {
+      listeners.set(listener, { onError: subscribeOptions?.onError })
+      for (const [key, entry] of runtimes.entries()) {
+        if (entry.unsubscribe) continue
+        const [tenantId, sessionId] = key.split('\0')
+        entry.unsubscribe = await subscribeRuntimeEvents({ tenantId, sessionId }, entry.adapter)
+      }
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    async close() {
+      for (const entry of runtimes.values()) {
+        await entry.unsubscribe?.()
+        await entry.adapter.close?.()
+      }
+      runtimes.clear()
+      listeners.clear()
+    },
+  }
+}

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -10,6 +10,7 @@ import {
   getConfiguredToolsFromConfig,
   expandMcpToolPermissionPatterns,
 } from './config-loader.ts'
+import type { ConfiguredProviderDescriptor } from './config-types.ts'
 import { getEffectiveSettings, getProviderCredentialValue, type CoworkSettings } from './settings.ts'
 import { log } from './logger.ts'
 import { buildOpenCoworkAgentConfig } from './agent-config.ts'
@@ -148,6 +149,44 @@ function buildDescriptorModelRuntimeConfig(
   )
 }
 
+export function buildConfiguredDescriptorProviderRuntimeConfig(
+  descriptor: ConfiguredProviderDescriptor,
+  credentialValues: Record<string, string | null | undefined>,
+): ProviderConfig | null {
+  const credentialEntries = Object.fromEntries(
+    descriptor.credentials.flatMap((credential) => {
+      const value = credentialValues[credential.key]
+      const runtimeKey = credential.runtimeKey || credential.key
+      return value ? [[runtimeKey, value]] : []
+    }),
+  )
+  const options = {
+    // Built-in provider options (default base URLs, regions) can still
+    // resolve from `process.env` when unset — these are non-credential
+    // settings and power-user overrides via shell exports are a
+    // reasonable escape hatch. Secret credentials are overlaid by key
+    // from the explicit credential value map below.
+    ...resolveEnvPlaceholders(descriptor.options || {}),
+    ...credentialEntries,
+  }
+  const models = buildDescriptorModelRuntimeConfig(descriptor.models)
+  const hasOptions = Object.keys(options).length > 0
+
+  // For OpenCode-native providers such as OpenAI, Anthropic, and
+  // downstream providers like GitHub Copilot, omit the provider override
+  // entirely unless Cowork actually has options, API-key credentials, or
+  // model overrides to contribute. Passing a name-only provider object
+  // shadows OpenCode's built-in provider metadata and can make the
+  // runtime choose the API-key auth path even after browser login.
+  if (!hasOptions && !models) return null
+
+  return {
+    name: descriptor.name,
+    ...(hasOptions ? { options } : {}),
+    ...(models ? { models } : {}),
+  }
+}
+
 function buildProviderRuntimeConfigResult(
   providerId: string,
   provider: NonNullable<ReturnType<typeof getAppConfig>['providers']['custom']>[string],
@@ -214,39 +253,13 @@ function buildBuiltinProviderRuntimeConfig(
 ) {
   const descriptor = getAppConfig().providers.descriptors?.[providerId]
   if (!descriptor) return null
-
-  const credentialEntries = Object.fromEntries(
+  const credentialValues = Object.fromEntries(
     descriptor.credentials.flatMap((credential) => {
       const value = getProviderCredentialValue(settings, providerId, credential.key)
-      const runtimeKey = credential.runtimeKey || credential.key
-      return value ? [[runtimeKey, value]] : []
+      return value ? [[credential.key, value]] : []
     }),
   )
-  const options = {
-    // Built-in provider options (default base URLs, regions) can still
-    // resolve from `process.env` when unset — these are non-credential
-    // settings and power-user overrides via shell exports are a
-    // reasonable escape hatch. The actual secret keys are overlaid from
-    // Settings below via the `credentials` map.
-    ...resolveEnvPlaceholders(descriptor.options || {}),
-    ...credentialEntries,
-  }
-  const models = buildDescriptorModelRuntimeConfig(descriptor.models)
-  const hasOptions = Object.keys(options).length > 0
-
-  // For OpenCode-native providers such as OpenAI, Anthropic, and
-  // downstream providers like GitHub Copilot, omit the provider override
-  // entirely unless Cowork actually has options, API-key credentials, or
-  // model overrides to contribute. Passing a name-only provider object
-  // shadows OpenCode's built-in provider metadata and can make the
-  // runtime choose the API-key auth path even after browser login.
-  if (!hasOptions && !models) return null
-
-  return {
-    name: descriptor.name,
-    ...(hasOptions ? { options } : {}),
-    ...(models ? { models } : {}),
-  }
+  return buildConfiguredDescriptorProviderRuntimeConfig(descriptor, credentialValues)
 }
 
 function buildEffectiveProviderRuntimeConfigResult(

--- a/tests/byok-runtime-injection.test.ts
+++ b/tests/byok-runtime-injection.test.ts
@@ -1,0 +1,228 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { DEFAULT_CONFIG, type OpenCoworkConfig } from '../apps/desktop/src/main/config-types.ts'
+import { createByokSecretStore } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
+import { resolveCloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
+import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
+import { createCloudPathProvider } from '../apps/desktop/src/main/cloud/path-provider.ts'
+import type {
+  CloudRuntimeAdapter,
+  CloudRuntimeExecutionContext,
+  CloudRuntimePromptPart,
+} from '../apps/desktop/src/main/cloud/runtime-adapter.ts'
+import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secret-adapter.ts'
+import { CloudSessionService } from '../apps/desktop/src/main/cloud/session-service.ts'
+import { CloudWorker } from '../apps/desktop/src/main/cloud/worker.ts'
+import { createWorkerScopedRuntimeAdapter, type WorkerScopedRuntimeFactoryInput } from '../apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts'
+
+const KEY_A = ['credential', 'tenant-a', 'runtime', '1234567890abcdef'].join('-')
+const KEY_B = ['credential', 'tenant-b', 'runtime', 'abcdef1234567890'].join('-')
+
+const BYOK_TEST_CONFIG: OpenCoworkConfig = {
+  ...DEFAULT_CONFIG,
+  providers: {
+    ...DEFAULT_CONFIG.providers,
+    available: ['openrouter'],
+    defaultProvider: 'openrouter',
+    defaultModel: 'openrouter/test-model',
+    descriptors: {
+      openrouter: {
+        runtime: 'builtin',
+        name: 'OpenRouter',
+        description: 'OpenRouter test provider',
+        credentials: [{
+          key: 'apiKey',
+          label: 'API key',
+          description: 'Provider API key',
+          secret: true,
+          required: true,
+        }],
+        models: [{ id: 'test-model', name: 'Test model' }],
+      },
+    },
+    custom: {},
+  },
+}
+
+function principal(tenantId: string, userId: string) {
+  return {
+    tenantId,
+    orgId: tenantId,
+    tenantName: tenantId,
+    userId,
+    accountId: userId,
+    email: `${userId}@example.test`,
+    role: 'owner' as const,
+    authSource: 'local' as const,
+  }
+}
+
+class ConfigBackedRuntime implements CloudRuntimeAdapter {
+  readonly context: CloudRuntimeExecutionContext
+  readonly apiKey: string
+  prompts: Array<{ sessionId: string, parts: CloudRuntimePromptPart[], agent: string }> = []
+
+  constructor(input: WorkerScopedRuntimeFactoryInput) {
+    this.context = input.execution
+    const provider = input.runtimeConfig?.provider as Record<string, { options?: Record<string, unknown> }> | undefined
+    this.apiKey = String(provider?.openrouter?.options?.apiKey || '')
+  }
+
+  async createSession() {
+    return {
+      id: `runtime-${this.context.tenantId}-${this.context.sessionId}`,
+      title: 'Runtime session',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }
+  }
+
+  async promptSession(input: { sessionId: string, parts: CloudRuntimePromptPart[], agent: string }) {
+    this.prompts.push(input)
+    return {
+      events: [{
+        type: 'assistant.message',
+        payload: {
+          sessionId: input.sessionId,
+          messageId: `${input.sessionId}:assistant`,
+          content: `used-byok:${this.apiKey.slice(-4)}`,
+        },
+      }],
+    }
+  }
+
+  async abortSession() {}
+}
+
+function seededStore() {
+  const store = new InMemoryControlPlaneStore()
+  store.createTenant({ tenantId: 'tenant-a', name: 'Tenant A' })
+  store.ensureUser({ tenantId: 'tenant-a', userId: 'user-a', email: 'user-a@example.test', role: 'owner' })
+  store.createTenant({ tenantId: 'tenant-b', name: 'Tenant B' })
+  store.ensureUser({ tenantId: 'tenant-b', userId: 'user-b', email: 'user-b@example.test', role: 'owner' })
+  return store
+}
+
+test('worker-scoped BYOK runtime injects provider options for the correct tenant session without env leakage', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-byok-runtime-'))
+  const store = seededStore()
+  let nextId = 0
+  const byokSecrets = createByokSecretStore(store, createEnvelopeSecretAdapter('byok-runtime-test-key'), {
+    ids: { randomUUID: () => `secret-${nextId += 1}` },
+  })
+  await byokSecrets.setSecret({ orgId: 'tenant-a', providerId: 'openrouter', plaintext: KEY_A })
+  await byokSecrets.setSecret({ orgId: 'tenant-b', providerId: 'openrouter', plaintext: KEY_B })
+  const captures: WorkerScopedRuntimeFactoryInput[] = []
+  const runtimes: ConfigBackedRuntime[] = []
+  const runtime = createWorkerScopedRuntimeAdapter({
+    paths: createCloudPathProvider(root),
+    policy: resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    env: {
+      PATH: process.env.PATH,
+      OPENROUTER_API_KEY: 'stale-shell-value-must-not-be-used',
+    },
+    config: BYOK_TEST_CONFIG,
+    byokSecrets,
+    runtimeFactory(input) {
+      captures.push(input)
+      assert.equal(JSON.stringify(input.env).includes(KEY_A), false)
+      assert.equal(JSON.stringify(input.env).includes(KEY_B), false)
+      const next = new ConfigBackedRuntime(input)
+      runtimes.push(next)
+      return next
+    },
+  })
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    undefined,
+    { randomUUID: () => `cowork-session-${nextId += 1}` },
+    undefined,
+    byokSecrets,
+  )
+  const worker = new CloudWorker(store, service, 'worker-a')
+
+  try {
+    const sessionA = await service.createSession(principal('tenant-a', 'user-a'))
+    const sessionB = await service.createSession(principal('tenant-b', 'user-b'))
+    assert.equal(captures.length, 0, 'session creation must not reveal BYOK credentials')
+
+    await service.enqueuePrompt(principal('tenant-a', 'user-a'), sessionA.session.sessionId, { text: 'hello a', agent: 'build' })
+    await service.enqueuePrompt(principal('tenant-b', 'user-b'), sessionB.session.sessionId, { text: 'hello b', agent: 'build' })
+    assert.equal(captures.length, 0, 'web/control-plane prompt enqueue must not reveal BYOK credentials')
+
+    assert.equal(await worker.processSessionCommands('tenant-a', sessionA.session.sessionId), 1)
+    assert.equal(await worker.processSessionCommands('tenant-b', sessionB.session.sessionId), 1)
+
+    assert.equal(captures[0]?.execution.tenantId, 'tenant-a')
+    assert.equal(captures[0]?.execution.sessionId, sessionA.session.sessionId)
+    assert.equal(runtimes[0]?.apiKey, KEY_A)
+    assert.equal(captures[1]?.execution.tenantId, 'tenant-b')
+    assert.equal(captures[1]?.execution.sessionId, sessionB.session.sessionId)
+    assert.equal(runtimes[1]?.apiKey, KEY_B)
+
+    const viewA = await service.getSessionView(principal('tenant-a', 'user-a'), sessionA.session.sessionId)
+    const viewB = await service.getSessionView(principal('tenant-b', 'user-b'), sessionB.session.sessionId)
+    assert.equal(viewA.projection.view.messages.at(-1)?.content, 'used-byok:cdef')
+    assert.equal(viewB.projection.view.messages.at(-1)?.content, 'used-byok:7890')
+  } finally {
+    await runtime.close?.()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('missing or disabled required BYOK key fails before runtime spawn', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-byok-runtime-missing-'))
+  const store = seededStore()
+  let nextId = 0
+  const byokSecrets = createByokSecretStore(store, createEnvelopeSecretAdapter('byok-runtime-test-key'), {
+    ids: { randomUUID: () => `secret-${nextId += 1}` },
+  })
+  await byokSecrets.setSecret({ orgId: 'tenant-a', providerId: 'openrouter', plaintext: KEY_A })
+  await byokSecrets.disableSecret({ orgId: 'tenant-a', providerId: 'openrouter' })
+  let factoryCalls = 0
+  const runtime = createWorkerScopedRuntimeAdapter({
+    paths: createCloudPathProvider(root),
+    policy: resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    env: { PATH: process.env.PATH },
+    config: BYOK_TEST_CONFIG,
+    byokSecrets,
+    runtimeFactory() {
+      factoryCalls += 1
+      throw new Error('runtime factory should not be called')
+    },
+  })
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    undefined,
+    { randomUUID: () => `cowork-session-${nextId += 1}` },
+    undefined,
+    byokSecrets,
+  )
+  const worker = new CloudWorker(store, service, 'worker-a')
+
+  try {
+    const session = await service.createSession(principal('tenant-a', 'user-a'))
+    await service.enqueuePrompt(principal('tenant-a', 'user-a'), session.session.sessionId, { text: 'hello', agent: 'build' })
+    await assert.rejects(
+      () => worker.processSessionCommands('tenant-a', session.session.sessionId),
+      /requires an active BYOK credential/,
+    )
+    assert.equal(factoryCalls, 0)
+    const events = await service.listEvents(principal('tenant-a', 'user-a'), session.session.sessionId)
+    assert.equal(events.some((event) => (
+      event.type === 'runtime.error'
+      && JSON.stringify(event.payload).includes('requires an active BYOK credential')
+    )), true)
+  } finally {
+    await runtime.close?.()
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -53,7 +53,7 @@ class FakeRuntime implements CloudRuntimeAdapter {
   }
 
   async promptSession(input: { sessionId: string, parts: CloudRuntimePromptPart[], agent: string }) {
-    this.prompts.push(input)
+    this.prompts.push({ sessionId: input.sessionId, parts: input.parts, agent: input.agent })
     return {
       events: [{
         type: 'assistant.message',
@@ -74,15 +74,15 @@ class FakeRuntime implements CloudRuntimeAdapter {
   async abortSession() {}
 
   async replyToQuestion(input: { requestId: string, answers: unknown[] }) {
-    this.questionReplies.push(input)
+    this.questionReplies.push({ requestId: input.requestId, answers: input.answers })
   }
 
   async rejectQuestion(input: { requestId: string }) {
-    this.questionRejects.push(input)
+    this.questionRejects.push({ requestId: input.requestId })
   }
 
   async respondToPermission(input: { permissionId: string, allowed: boolean }) {
-    this.permissionResponses.push(input)
+    this.permissionResponses.push({ permissionId: input.permissionId, allowed: input.allowed })
   }
 
   subscribeEvents(listener: CloudRuntimeEventListener) {

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -47,7 +47,7 @@ class FakeRuntimeAdapter implements CloudRuntimeAdapter {
   }
 
   async promptSession(input: { sessionId: string, parts: CloudRuntimePromptPart[], agent: string }) {
-    this.prompts.push(input)
+    this.prompts.push({ sessionId: input.sessionId, parts: input.parts, agent: input.agent })
     const text = input.parts.find((part) => part.type === 'text')?.text || ''
     return {
       events: [{
@@ -70,7 +70,7 @@ class FakeRuntimeAdapter implements CloudRuntimeAdapter {
   }
 
   async respondToPermission(input: { permissionId: string, allowed: boolean }) {
-    this.permissions.push(input)
+    this.permissions.push({ permissionId: input.permissionId, allowed: input.allowed })
   }
 }
 

--- a/tests/cloud-opencode-runtime-adapter.test.ts
+++ b/tests/cloud-opencode-runtime-adapter.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
@@ -297,6 +297,56 @@ while true; do sleep 1; done
         Authorization: adapter.auth.authorizationHeader,
       },
     })
+  } finally {
+    await adapter.close?.()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('cloud Node OpenCode runtime adapter can deliver BYOK config without process env plaintext', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-cloud-node-runtime-byok-'))
+  const envFile = join(root, 'env')
+  const configCopyFile = join(root, 'config-copy')
+  const secret = ['sk', 'runtime', 'byok', 'plaintext', '1234567890abcdef1234567890abcdef'].join('-')
+  const provider = createCloudPathProvider(join(root, 'cloud-root'))
+  const configPath = join(provider.getRuntimeXdgRoots().configHome, 'opencode', 'opencode.json')
+  const executable = writeExecutable(root, 'fake-opencode', `
+env > ${JSON.stringify(envFile)}
+cat ${JSON.stringify(configPath)} > ${JSON.stringify(configCopyFile)} 2>/dev/null || true
+printf '%s\\n' 'opencode server listening on http://127.0.0.1:43231'
+while true; do sleep 1; done
+`)
+
+  const adapter = await createNodeOpencodeCloudRuntimeAdapter({
+    paths: provider,
+    env: {
+      PATH: process.env.PATH || '',
+      OPENCODE_CONFIG_CONTENT: `stale ${secret}`,
+    },
+    hostname: '127.0.0.1',
+    port: 0,
+    opencodeBinPath: executable,
+    timeout: 5000,
+    configDelivery: 'ephemeral-file',
+    config: {
+      model: 'openrouter/test-model',
+      provider: {
+        openrouter: {
+          name: 'OpenRouter',
+          options: {
+            apiKey: secret,
+          },
+        },
+      },
+    },
+  })
+
+  try {
+    assert.equal(adapter.url, 'http://127.0.0.1:43231')
+    assert.equal(readFileSync(envFile, 'utf8').includes(secret), false)
+    assert.equal(readFileSync(envFile, 'utf8').includes('OPENCODE_CONFIG_CONTENT'), false)
+    assert.match(readFileSync(configCopyFile, 'utf8'), new RegExp(secret))
+    assert.equal(existsSync(configPath), false)
   } finally {
     await adapter.close?.()
     rmSync(root, { recursive: true, force: true })

--- a/tests/gateway-cloud-smoke.test.ts
+++ b/tests/gateway-cloud-smoke.test.ts
@@ -30,7 +30,7 @@ class FakeRuntime implements CloudRuntimeAdapter {
   }
 
   async promptSession(input: { sessionId: string, parts: CloudRuntimePromptPart[], agent: string }) {
-    this.prompts.push(input)
+    this.prompts.push({ sessionId: input.sessionId, parts: input.parts, agent: input.agent })
     return {
       events: [{
         type: 'assistant.message',
@@ -59,11 +59,11 @@ class FakeRuntime implements CloudRuntimeAdapter {
   }
 
   async respondToPermission(input: { permissionId: string, allowed: boolean }) {
-    this.permissions.push(input)
+    this.permissions.push({ permissionId: input.permissionId, allowed: input.allowed })
   }
 
   async replyToQuestion(input: { requestId: string, answers: unknown[] }) {
-    this.questionReplies.push(input)
+    this.questionReplies.push({ requestId: input.requestId, answers: input.answers })
   }
 
   async rejectQuestion(input: { requestId: string }) {


### PR DESCRIPTION
## Summary
- add a worker-scoped runtime adapter that resolves BYOK credentials only while processing leased worker commands
- build OpenCode provider options from the existing descriptor runtime config helper and pass them to per-session cloud runtimes
- deliver BYOK runtime config through a short-lived private config file instead of `process.env`
- add runtime injection, missing/disabled key, env leakage, and regression coverage

Closes #426.

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `git diff --check`