### PR TITLE
Harden cloud BYOK validation and KMS handling

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -20,7 +20,11 @@ import {
   type CloudObservabilityAdapter,
 } from './observability.ts'
 import { createObjectStoreForCloud, type ObjectStoreAdapter } from './object-store.ts'
-import { createByokSecretStore, type ByokSecretStore } from './byok-secret-store.ts'
+import {
+  createByokSecretStore,
+  type ByokSecretStore,
+  type ByokSecretStoreOptions,
+} from './byok-secret-store.ts'
 import {
   createOidcBrowserAuthProvider,
   createOidcCloudAuthResolver,
@@ -30,9 +34,9 @@ import { createCloudPathProvider, createCloudSessionPathProvider, type PathProvi
 import { createPostgresControlPlaneStore } from './postgres-control-plane-store.ts'
 import { createNodeOpencodeCloudRuntimeAdapter } from './opencode-runtime-adapter.ts'
 import type { CloudRuntimeAdapter, CloudRuntimeEvent } from './runtime-adapter.ts'
-import { createCloudSecretAdapterFromEnv, type SecretAdapter } from './secret-adapter.ts'
+import { createCloudSecretAdapterFromEnv, resolveCloudSecretRef, type SecretAdapter } from './secret-adapter.ts'
 import { createCloudSessionCookieManager, type CloudSessionCookieManager } from './session-cookie-auth.ts'
-import { CloudSessionService, type CloudPrincipal } from './session-service.ts'
+import { CloudSessionService, type ByokManagementPolicy, type CloudPrincipal } from './session-service.ts'
 import { CloudScheduler } from './scheduler.ts'
 import { CloudWorker } from './worker.ts'
 import { createWorkerScopedRuntimeAdapter } from './worker-scoped-runtime-adapter.ts'
@@ -91,6 +95,8 @@ export type CloudAppOptions = {
   objectStore?: ObjectStoreAdapter
   objectStoreFactory?: CloudObjectStoreFactory
   secretAdapter?: SecretAdapter
+  byokSecretStoreOptions?: Pick<ByokSecretStoreOptions, 'kmsRefResolver' | 'validators'>
+  byokPolicy?: ByokManagementPolicy
   runtime?: CloudRuntimeAdapter
   runtimeFactory?: CloudRuntimeFactory
   paths?: PathProvider
@@ -267,6 +273,13 @@ function defaultCloudRuntimeFactory(input: CloudRoleRuntimeFactoryInput) {
     config: input.runtimeConfig,
     configDelivery: 'ephemeral-file',
   })
+}
+
+function listConfiguredByokProviderIds(config: OpenCoworkConfig) {
+  const providerIds = (config.providers.available || [])
+    .map((providerId) => providerId.trim().toLowerCase())
+    .filter(Boolean)
+  return providerIds.length > 0 ? Array.from(new Set(providerIds)) : null
 }
 
 function readHeader(req: IncomingMessage, name: string) {
@@ -501,7 +514,17 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
   const store = options.store || await (options.storeFactory || createControlPlaneStoreForCloud)({ config, env })
   const objectStore = options.objectStore || await (options.objectStoreFactory || createObjectStoreForCloud)({ config, env, paths })
   const secretAdapter = options.secretAdapter || await createCloudSecretAdapterFromEnv(env)
-  const byokSecrets = createByokSecretStore(store, secretAdapter)
+  const byokPolicy: ByokManagementPolicy = {
+    allowedProviderIds: options.byokPolicy?.allowedProviderIds ?? listConfiguredByokProviderIds(config),
+    checkEntitlement: options.byokPolicy?.checkEntitlement ?? null,
+    checkRuntimeEntitlement: options.byokPolicy?.checkRuntimeEntitlement ?? null,
+    kmsRefs: options.byokPolicy?.kmsRefs ?? null,
+  }
+  const byokSecrets = createByokSecretStore(store, secretAdapter, {
+    ...options.byokSecretStoreOptions,
+    kmsRefResolver: options.byokSecretStoreOptions?.kmsRefResolver
+      || (({ kmsRef }) => resolveCloudSecretRef(kmsRef, { env })),
+  })
   const checkpointsEnabled = options.checkpointsEnabled ?? envOptions.checkpointsEnabled
   const hasCheckpointStoreOverride = Object.prototype.hasOwnProperty.call(options, 'checkpointStore')
   const checkpointStore = shouldRunCloudWorker(policy.role)
@@ -522,11 +545,24 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
           env,
           config,
           byokSecrets,
+          byokPolicy: {
+            allowedProviderIds: byokPolicy.allowedProviderIds,
+            checkEntitlement: byokPolicy.checkRuntimeEntitlement,
+          },
           runtimeFactory: options.runtimeFactory || defaultCloudRuntimeFactory,
         })
       : createUnavailableRuntimeAdapter()
   )
-  const service = new CloudSessionService(store, runtime, policy, undefined, undefined, undefined, byokSecrets)
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    policy,
+    undefined,
+    undefined,
+    undefined,
+    byokSecrets,
+    byokPolicy,
+  )
   const artifacts = new CloudArtifactService(service, objectStore)
   const hasSessionCookieOverride = Object.prototype.hasOwnProperty.call(options, 'sessionCookies')
   const cookieSecret = resolveCloudCookieSecret(resolvedAuthConfig, env)

--- a/apps/desktop/src/main/cloud/byok-runtime-config.ts
+++ b/apps/desktop/src/main/cloud/byok-runtime-config.ts
@@ -8,7 +8,7 @@ import type { CloudRuntimeExecutionContext } from './runtime-adapter.ts'
 
 export class CloudByokRuntimeConfigError extends Error {
   readonly providerId: string
-  readonly code: 'missing_required_byok' | 'kms_not_supported'
+  readonly code: 'missing_required_byok' | 'kms_not_supported' | 'provider_not_allowed' | 'provider_not_entitled'
 
   constructor(providerId: string, code: CloudByokRuntimeConfigError['code'], message: string) {
     super(message)
@@ -22,6 +22,17 @@ export type CloudByokRuntimeConfigInput = {
   appConfig: OpenCoworkConfig
   byokSecrets: ByokSecretStore
   context: CloudRuntimeExecutionContext
+  allowKmsRef?: boolean
+  byokPolicy?: CloudByokRuntimeProviderPolicy | null
+}
+
+export type CloudByokRuntimeProviderPolicy = {
+  allowedProviderIds?: readonly string[] | null
+  checkEntitlement?: ((input: {
+    orgId: string
+    providerId: string
+    context: CloudRuntimeExecutionContext
+  }) => Promise<{ allowed: boolean, reason?: string | null }> | { allowed: boolean, reason?: string | null }) | null
 }
 
 function stripProviderPrefix(providerId: string, modelId: string | null | undefined) {
@@ -55,6 +66,32 @@ function redactOptionShape(options: Record<string, unknown>) {
   })
 }
 
+async function resolveProviderPolicy(input: {
+  providerId: string
+  orgId: string
+  context: CloudRuntimeExecutionContext
+  policy?: CloudByokRuntimeProviderPolicy | null
+}): Promise<
+  | { allowed: true, code: null, reason?: null }
+  | { allowed: false, code: 'provider_not_allowed' | 'provider_not_entitled', reason?: string | null }
+> {
+  const allowedProviderIds = input.policy?.allowedProviderIds
+    ? new Set(input.policy.allowedProviderIds.map((id) => id.trim().toLowerCase()).filter(Boolean))
+    : null
+  if (allowedProviderIds?.size && !allowedProviderIds.has(input.providerId.trim().toLowerCase())) {
+    return { allowed: false, code: 'provider_not_allowed' as const }
+  }
+  const entitlement = await input.policy?.checkEntitlement?.({
+    orgId: input.orgId,
+    providerId: input.providerId,
+    context: input.context,
+  })
+  if (entitlement && !entitlement.allowed) {
+    return { allowed: false, code: 'provider_not_entitled' as const, reason: entitlement.reason || null }
+  }
+  return { allowed: true, code: null }
+}
+
 export async function buildCloudByokRuntimeConfig(input: CloudByokRuntimeConfigInput): Promise<Config> {
   const { appConfig, byokSecrets, context } = input
   const defaultProviderId = appConfig.providers.defaultProvider
@@ -67,12 +104,34 @@ export async function buildCloudByokRuntimeConfig(input: CloudByokRuntimeConfigI
   )
 
   for (const [providerId, descriptor] of Object.entries(appConfig.providers.descriptors || {})) {
+    const policyVerdict = await resolveProviderPolicy({
+      providerId,
+      orgId: context.tenantId,
+      context,
+      policy: input.byokPolicy,
+    })
     const shouldRequire = providerRequiresByok({
       providerId,
       defaultProviderId,
       credentials: descriptor.credentials,
     })
     const hasActiveSecret = activeProviderIds.has(providerId)
+    if (!policyVerdict.allowed) {
+      if (providerId === defaultProviderId || shouldRequire) {
+        throw new CloudByokRuntimeConfigError(
+          providerId,
+          policyVerdict.code,
+          policyVerdict.reason || `Provider "${providerId}" is not available for cloud BYOK execution.`,
+        )
+      }
+      if (hasActiveSecret) {
+        log(
+          'runtime',
+          `cloud-byok skipped provider=${providerId} tenant=${context.tenantId} session=${context.sessionId} reason=${policyVerdict.code}`,
+        )
+      }
+      continue
+    }
     if (!shouldRequire && !hasActiveSecret) continue
 
     const credential = providerCredentialField(descriptor.credentials)
@@ -82,6 +141,7 @@ export async function buildCloudByokRuntimeConfig(input: CloudByokRuntimeConfigI
       plaintext = await byokSecrets.revealActiveSecret({
         orgId: context.tenantId,
         providerId,
+        allowKmsRef: input.allowKmsRef,
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/main/cloud/byok-secret-store.ts
+++ b/apps/desktop/src/main/cloud/byok-secret-store.ts
@@ -40,7 +40,47 @@ export type RecordByokValidationInput = {
 export type RevealByokSecretInput = {
   orgId: string
   providerId: string
+  allowKmsRef?: boolean
 }
+
+export type ValidateByokSecretInput = {
+  orgId: string
+  providerId: string
+  actor?: AuditActorInput
+  allowKmsRef?: boolean
+}
+
+export type ByokSecretRefResolverInput = {
+  orgId: string
+  providerId: string
+  secretId: string
+  kmsRef: string
+}
+
+export type ByokSecretRefResolver = (input: ByokSecretRefResolverInput) => Promise<string> | string
+
+export type ByokProviderValidationInput = {
+  orgId: string
+  providerId: string
+  secretId: string
+  plaintext: string
+  metadata: ByokSecretMetadata
+}
+
+export type ByokProviderValidationResult =
+  | boolean
+  | {
+      ok?: boolean
+      valid?: boolean
+      status?: Extract<ByokSecretStatus, 'active' | 'invalid'>
+      error?: string | null
+      reason?: string | null
+    }
+  | void
+
+export type ByokProviderValidator = (
+  input: ByokProviderValidationInput,
+) => Promise<ByokProviderValidationResult> | ByokProviderValidationResult
 
 export type ByokSecretStore = {
   listMetadata(orgId: string): Promise<ByokSecretMetadata[]>
@@ -48,11 +88,14 @@ export type ByokSecretStore = {
   setSecret(input: SetByokSecretInput): Promise<ByokSecretMetadata>
   disableSecret(input: { orgId: string, providerId: string, actor?: AuditActorInput }): Promise<ByokSecretMetadata | null>
   recordValidation(input: RecordByokValidationInput): Promise<ByokSecretMetadata | null>
+  validateActiveSecret(input: ValidateByokSecretInput): Promise<ByokSecretMetadata | null>
   revealActiveSecret(input: RevealByokSecretInput): Promise<string>
 }
 
 export type ByokSecretStoreOptions = {
   ids?: { randomUUID: () => string }
+  kmsRefResolver?: ByokSecretRefResolver | null
+  validators?: Record<string, ByokProviderValidator | undefined> | null
 }
 
 const PROVIDER_ID_MAX_LENGTH = 64
@@ -98,6 +141,25 @@ function sanitizeValidationError(value: string | null | undefined) {
     : sanitized
 }
 
+function normalizeValidationOutcome(result: ByokProviderValidationResult): {
+  status: Extract<ByokSecretStatus, 'active' | 'invalid'>
+  validationError: string | null
+} {
+  if (typeof result === 'boolean') {
+    return result
+      ? { status: 'active', validationError: null }
+      : { status: 'invalid', validationError: 'Provider credential validation failed.' }
+  }
+  if (!result) {
+    return { status: 'active', validationError: null }
+  }
+  const valid = result.status ? result.status === 'active' : (result.valid ?? result.ok ?? true)
+  return {
+    status: valid ? 'active' : 'invalid',
+    validationError: valid ? null : (result.error ?? result.reason ?? 'Provider credential validation failed.'),
+  }
+}
+
 export function byokSecretMetadata(record: ByokSecretRecord): ByokSecretMetadata {
   return {
     secretId: record.secretId,
@@ -135,6 +197,32 @@ export function createByokSecretStore(
   options: ByokSecretStoreOptions = {},
 ): ByokSecretStore {
   const ids = options.ids || { randomUUID }
+  const validators = options.validators || {}
+
+  async function revealSecretRecord(secret: ByokSecretRecord, input: RevealByokSecretInput) {
+    if (secret.ciphertext) {
+      return secretAdapter.reveal(secret.ciphertext, byokAad(secret.orgId, secret.providerId, secret.secretId))
+    }
+    if (!secret.kmsRef) {
+      throw new Error(`BYOK secret ${secret.secretId} has no encrypted material.`)
+    }
+    if (!input.allowKmsRef) {
+      throw new Error('KMS-backed BYOK secrets require a worker-authorized reveal path.')
+    }
+    if (!options.kmsRefResolver) {
+      throw new Error('KMS-backed BYOK secret resolver is not configured.')
+    }
+    const resolved = await options.kmsRefResolver({
+      orgId: secret.orgId,
+      providerId: secret.providerId,
+      secretId: secret.secretId,
+      kmsRef: secret.kmsRef,
+    })
+    if (!resolved) {
+      throw new Error('KMS-backed BYOK secret resolver returned an empty credential.')
+    }
+    return resolved
+  }
 
   return {
     async listMetadata(orgId) {
@@ -206,13 +294,65 @@ export function createByokSecretStore(
       return record ? byokSecretMetadata(record) : null
     },
 
+    async validateActiveSecret(input) {
+      const providerId = normalizeProviderId(input.providerId)
+      const secret = await store.getActiveByokSecret(input.orgId, providerId)
+      if (!secret) return null
+      if (secret.kmsRef && !input.allowKmsRef) {
+        return byokSecretMetadata(secret)
+      }
+
+      const validator = validators[providerId]
+      if (!validator) {
+        const record = await store.recordByokSecretValidation({
+          orgId: input.orgId,
+          providerId,
+          secretId: secret.secretId,
+          status: 'active',
+          validationError: null,
+          actor: input.actor,
+        })
+        return record ? byokSecretMetadata(record) : null
+      }
+
+      try {
+        const plaintext = await revealSecretRecord(secret, { ...input, providerId })
+        const outcome = normalizeValidationOutcome(
+          await validator({
+            orgId: input.orgId,
+            providerId,
+            secretId: secret.secretId,
+            plaintext,
+            metadata: byokSecretMetadata(secret),
+          }),
+        )
+        const record = await store.recordByokSecretValidation({
+          orgId: input.orgId,
+          providerId,
+          secretId: secret.secretId,
+          status: outcome.status,
+          validationError: sanitizeValidationError(outcome.validationError),
+          actor: input.actor,
+        })
+        return record ? byokSecretMetadata(record) : null
+      } catch (error) {
+        const record = await store.recordByokSecretValidation({
+          orgId: input.orgId,
+          providerId,
+          secretId: secret.secretId,
+          status: 'invalid',
+          validationError: sanitizeValidationError(error instanceof Error ? error.message : String(error)),
+          actor: input.actor,
+        })
+        return record ? byokSecretMetadata(record) : null
+      }
+    },
+
     async revealActiveSecret(input) {
       const providerId = normalizeProviderId(input.providerId)
       const secret = await store.getActiveByokSecret(input.orgId, providerId)
       if (!secret) throw new Error(`No active BYOK secret configured for provider ${providerId}.`)
-      if (secret.kmsRef) throw new Error('KMS-backed BYOK secrets are not revealable by this store yet.')
-      if (!secret.ciphertext) throw new Error(`BYOK secret ${secret.secretId} has no encrypted material.`)
-      return secretAdapter.reveal(secret.ciphertext, byokAad(input.orgId, providerId, secret.secretId))
+      return revealSecretRecord(secret, { ...input, providerId })
     },
   }
 }

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -744,6 +744,11 @@ async function handleApiRequest(
       writeJson(res, 200, { secret: await options.service.getByokSecret(context.principal, providerId) }, options.corsOrigin)
       return
     }
+    if (providerId && action === 'validate' && req.method === 'POST') {
+      const secret = await options.service.validateByokSecret(context.principal, providerId)
+      writeJson(res, 200, { secret, validated: Boolean(secret?.lastValidatedAt) }, options.corsOrigin)
+      return
+    }
     if (providerId && !action && req.method === 'POST') {
       const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
       const plaintext = readString(body.plaintext) || readString(body.apiKey) || readString(body.key) || readString(body.secret)

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -78,6 +78,36 @@ export type CloudPrincipal = {
   tokenScopes?: ApiTokenScope[]
 }
 
+export type ByokEntitlementVerdict = {
+  allowed: boolean
+  status?: number
+  reason?: string | null
+}
+
+export type ByokEntitlementChecker = (input: {
+  principal: CloudPrincipal
+  orgId: string
+  providerId: string
+}) => Promise<ByokEntitlementVerdict> | ByokEntitlementVerdict
+
+export type ByokRuntimeEntitlementChecker = (input: {
+  orgId: string
+  providerId: string
+}) => Promise<ByokEntitlementVerdict> | ByokEntitlementVerdict
+
+export type ByokKmsRefPolicy = {
+  enabled?: boolean
+  allowedPrefixes?: readonly string[] | null
+  allowEnvRefs?: boolean
+}
+
+export type ByokManagementPolicy = {
+  allowedProviderIds?: readonly string[] | null
+  checkEntitlement?: ByokEntitlementChecker | null
+  checkRuntimeEntitlement?: ByokRuntimeEntitlementChecker | null
+  kmsRefs?: ByokKmsRefPolicy | null
+}
+
 export class CloudServiceError extends Error {
   readonly status: number
   readonly publicMessage: string
@@ -240,6 +270,14 @@ function principalCanManageByok(principal: CloudPrincipal) {
   if (principal.authSource === 'local' || principal.authSource === 'header') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
   return principal.role === 'owner' || principal.role === 'admin'
+}
+
+function normalizeByokProviderIdForPolicy(value: string) {
+  const providerId = value.trim().toLowerCase()
+  if (!providerId || providerId.length > 64 || !/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) {
+    throw new CloudServiceError(400, `Unsupported BYOK provider id ${providerId || '<empty>'}.`)
+  }
+  return providerId
 }
 
 function principalCanUseGatewayRoutes(principal: CloudPrincipal) {
@@ -961,6 +999,7 @@ export class CloudSessionService {
   private readonly workspaceEvents: CloudWorkspaceEventBus
   private readonly ids: { randomUUID: () => string }
   private readonly byokSecrets: ByokSecretStore | null
+  private readonly byokPolicy: ByokManagementPolicy
 
   constructor(
     store: ControlPlaneStore,
@@ -970,6 +1009,7 @@ export class CloudSessionService {
     ids: { randomUUID: () => string } = { randomUUID },
     workspaceEvents = new CloudWorkspaceEventBus(),
     byokSecrets: ByokSecretStore | null = null,
+    byokPolicy: ByokManagementPolicy = {},
   ) {
     this.store = store
     this.runtime = runtime
@@ -978,6 +1018,7 @@ export class CloudSessionService {
     this.workspaceEvents = workspaceEvents
     this.ids = ids
     this.byokSecrets = byokSecrets
+    this.byokPolicy = byokPolicy
   }
 
   get eventBus() {
@@ -1077,7 +1118,8 @@ export class CloudSessionService {
   async getByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
     await this.ensurePrincipal(principal)
     this.assertByokAllowed(principal)
-    return this.requireByokSecrets().getMetadata(this.principalOrgId(principal), providerId)
+    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
+    return this.requireByokSecrets().getMetadata(this.principalOrgId(principal), normalizedProviderId)
   }
 
   async setByokSecret(
@@ -1086,31 +1128,37 @@ export class CloudSessionService {
   ): Promise<ByokSecretMetadata> {
     await this.ensurePrincipal(principal)
     this.assertByokAllowed(principal)
+    const providerId = await this.assertByokProviderAllowed(principal, input.providerId)
+    this.assertByokKmsRefAllowed(providerId, input.kmsRef)
     return this.requireByokSecrets().setSecret({
       orgId: this.principalOrgId(principal),
-      providerId: input.providerId,
+      providerId,
       plaintext: input.plaintext,
       kmsRef: input.kmsRef,
       createdByAccountId: principal.accountId || principal.userId,
-      actor: {
-        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
-        actorId: principal.tokenId || principal.userId,
-        accountId: principal.accountId || principal.userId,
-      },
+      actor: this.byokAuditActor(principal),
     })
   }
 
   async disableByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
     await this.ensurePrincipal(principal)
     this.assertByokAllowed(principal)
+    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
     return this.requireByokSecrets().disableSecret({
       orgId: this.principalOrgId(principal),
-      providerId,
-      actor: {
-        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
-        actorId: principal.tokenId || principal.userId,
-        accountId: principal.accountId || principal.userId,
-      },
+      providerId: normalizedProviderId,
+      actor: this.byokAuditActor(principal),
+    })
+  }
+
+  async validateByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
+    return this.requireByokSecrets().validateActiveSecret({
+      orgId: this.principalOrgId(principal),
+      providerId: normalizedProviderId,
+      actor: this.byokAuditActor(principal),
     })
   }
 
@@ -2666,6 +2714,57 @@ export class CloudSessionService {
   private assertByokAllowed(principal: CloudPrincipal) {
     if (!principalCanManageByok(principal)) {
       throw new CloudServiceError(403, 'BYOK credential administration requires an org admin or admin-scoped API token.')
+    }
+  }
+
+  private byokAuditActor(principal: CloudPrincipal) {
+    return {
+      actorType: principal.authSource === 'api_token' ? 'api_token' as const : 'user' as const,
+      actorId: principal.tokenId || principal.userId,
+      accountId: principal.accountId || principal.userId,
+    }
+  }
+
+  private async assertByokProviderAllowed(principal: CloudPrincipal, providerIdInput: string) {
+    const providerId = normalizeByokProviderIdForPolicy(providerIdInput)
+    const allowedProviderIds = this.byokPolicy.allowedProviderIds
+      ? new Set(this.byokPolicy.allowedProviderIds.map((id) => id.trim().toLowerCase()).filter(Boolean))
+      : null
+    if (allowedProviderIds?.size && !allowedProviderIds.has(providerId)) {
+      throw new CloudServiceError(403, `Provider "${providerId}" is not enabled for BYOK in this cloud profile.`)
+    }
+    const entitlement = await this.byokPolicy.checkEntitlement?.({
+      principal,
+      orgId: this.principalOrgId(principal),
+      providerId,
+    })
+    if (entitlement && !entitlement.allowed) {
+      throw new CloudServiceError(
+        entitlement.status || 402,
+        entitlement.reason || `Provider "${providerId}" is not available for this org entitlement.`,
+      )
+    }
+    return providerId
+  }
+
+  private assertByokKmsRefAllowed(providerId: string, kmsRefInput: string | null | undefined) {
+    const kmsRef = typeof kmsRefInput === 'string' ? kmsRefInput.trim() : ''
+    if (!kmsRef) return
+    const policy = this.byokPolicy.kmsRefs
+    if (!policy?.enabled) {
+      throw new CloudServiceError(403, 'KMS-backed BYOK references are disabled for this cloud deployment.')
+    }
+    if (kmsRef.startsWith('env:') && !policy.allowEnvRefs) {
+      throw new CloudServiceError(403, 'Environment-backed BYOK references are not enabled for user-managed KMS refs.')
+    }
+    const allowedPrefixes = (policy.allowedPrefixes || [])
+      .map((prefix) => prefix.trim())
+      .filter(Boolean)
+    if (allowedPrefixes.length === 0) {
+      throw new CloudServiceError(403, 'KMS-backed BYOK references require deployer-configured allowed prefixes.')
+    }
+    if (!allowedPrefixes.some((prefix) => kmsRef.startsWith(prefix))) {
+      throw new CloudServiceError(403, `KMS-backed BYOK reference is not allowed for provider "${providerId}".`)
     }
   }
 

--- a/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
@@ -1,6 +1,6 @@
 import type { OpenCoworkConfig } from '../config-types.ts'
 import type { ByokSecretStore } from './byok-secret-store.ts'
-import { buildCloudByokRuntimeConfig } from './byok-runtime-config.ts'
+import { buildCloudByokRuntimeConfig, type CloudByokRuntimeProviderPolicy } from './byok-runtime-config.ts'
 import type { CloudRuntimePolicy } from './cloud-config.ts'
 import type { PathProvider } from './path-provider.ts'
 import { createCloudSessionPathProvider } from './path-provider.ts'
@@ -32,6 +32,7 @@ export type WorkerScopedRuntimeAdapterOptions = {
   env: Env
   config: OpenCoworkConfig
   byokSecrets: ByokSecretStore
+  byokPolicy?: CloudByokRuntimeProviderPolicy | null
   runtimeFactory: WorkerScopedRuntimeFactory
 }
 
@@ -96,6 +97,8 @@ export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAda
       appConfig: options.config,
       byokSecrets: options.byokSecrets,
       context,
+      allowKmsRef: true,
+      byokPolicy: options.byokPolicy,
     })
     const adapter = await options.runtimeFactory({
       paths: scopedPaths,

--- a/packages/cloud-client/src/index.ts
+++ b/packages/cloud-client/src/index.ts
@@ -371,6 +371,7 @@ export type CloudTransportAdapter = {
   listByokSecrets?(): Promise<CloudByokSecretMetadata[]>
   getByokSecret?(providerId: string): Promise<CloudByokSecretMetadata | null>
   setByokSecret?(providerId: string, input: CloudSetByokSecretInput): Promise<CloudByokSecretMetadata>
+  validateByokSecret?(providerId: string): Promise<CloudByokSecretMetadata | null>
   deleteByokSecret?(providerId: string): Promise<CloudByokSecretMetadata | null>
   listHeadlessAgents?(): Promise<HeadlessAgentRecord[]>
   createHeadlessAgent?(input: {
@@ -1098,6 +1099,12 @@ export function createHttpSseCloudTransportAdapter(
         method: 'POST',
         body: input,
       })).secret
+    },
+    async validateByokSecret(providerId) {
+      return (await request<{ secret: CloudByokSecretMetadata | null }>(
+        `/api/byok/${encodePath(providerId)}/validate`,
+        { method: 'POST' },
+      )).secret
     },
     async deleteByokSecret(providerId) {
       return (await request<{ secret: CloudByokSecretMetadata | null }>(`/api/byok/${encodePath(providerId)}`, {

--- a/tests/byok-boundary-regression.test.ts
+++ b/tests/byok-boundary-regression.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { sanitizeForExport, sanitizeLogMessage } from '../apps/desktop/src/main/log-sanitizer.ts'
+
+const RAW_BYOK_KEY = ['sk', 'byokboundarysecretvalue1234567890abcdef123456'].join('-')
+
+test('BYOK raw secrets are redacted from logs and diagnostics text', () => {
+  const logLine = `cloud byok provider rejected apiKey=${RAW_BYOK_KEY}`
+  assert.equal(sanitizeLogMessage(logLine).includes(RAW_BYOK_KEY), false)
+  assert.equal(sanitizeForExport(`diagnostics ${logLine}`).includes(RAW_BYOK_KEY), false)
+})
+
+test('BYOK management surface is not exposed through renderer cache or gateway payload modules', () => {
+  const files = [
+    'packages/shared/src/index.ts',
+    'apps/desktop/src/preload/index.ts',
+    'apps/desktop/src/main/cloud-workspace-adapter.ts',
+    'apps/desktop/src/main/cloud-workspace-cache.ts',
+    'apps/gateway/src/cloud-gateway.ts',
+    'apps/gateway/src/gateway-runtime.ts',
+    'apps/gateway/src/event-renderer.ts',
+    'apps/gateway/src/session-stream-manager.ts',
+  ]
+
+  for (const file of files) {
+    const source = readFileSync(join(process.cwd(), file), 'utf8')
+    assert.equal(source.toLowerCase().includes('byok'), false, `${file} must not expose BYOK payloads`)
+  }
+})

--- a/tests/byok-runtime-injection.test.ts
+++ b/tests/byok-runtime-injection.test.ts
@@ -176,6 +176,120 @@ test('worker-scoped BYOK runtime injects provider options for the correct tenant
   }
 })
 
+test('worker-scoped BYOK runtime resolves KMS references only during worker config injection', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-byok-runtime-kms-'))
+  const store = seededStore()
+  let nextId = 0
+  const kmsKey = 'credential-kms-runtime-abcdef1234567890'
+  let resolverCalls = 0
+  const byokSecrets = createByokSecretStore(store, createEnvelopeSecretAdapter('byok-runtime-test-key'), {
+    ids: { randomUUID: () => `secret-${nextId += 1}` },
+    kmsRefResolver(input) {
+      resolverCalls += 1
+      assert.equal(input.orgId, 'tenant-a')
+      assert.equal(input.providerId, 'openrouter')
+      assert.equal(input.kmsRef, 'aws-sm://open-cowork/test/openrouter')
+      return kmsKey
+    },
+  })
+  await byokSecrets.setSecret({ orgId: 'tenant-a', providerId: 'openrouter', kmsRef: 'aws-sm://open-cowork/test/openrouter' })
+  await assert.rejects(
+    () => byokSecrets.revealActiveSecret({ orgId: 'tenant-a', providerId: 'openrouter' }),
+    /worker-authorized reveal path/,
+  )
+
+  const runtimes: ConfigBackedRuntime[] = []
+  const runtime = createWorkerScopedRuntimeAdapter({
+    paths: createCloudPathProvider(root),
+    policy: resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    env: { PATH: process.env.PATH },
+    config: BYOK_TEST_CONFIG,
+    byokSecrets,
+    runtimeFactory(input) {
+      assert.equal(JSON.stringify(input.env).includes(kmsKey), false)
+      const next = new ConfigBackedRuntime(input)
+      runtimes.push(next)
+      return next
+    },
+  })
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    undefined,
+    { randomUUID: () => `cowork-session-${nextId += 1}` },
+    undefined,
+    byokSecrets,
+  )
+  const worker = new CloudWorker(store, service, 'worker-kms')
+
+  try {
+    const session = await service.createSession(principal('tenant-a', 'user-a'))
+    await service.enqueuePrompt(principal('tenant-a', 'user-a'), session.session.sessionId, { text: 'hello kms', agent: 'build' })
+    assert.equal(resolverCalls, 0, 'web/control-plane operations must not resolve KMS refs')
+
+    assert.equal(await worker.processSessionCommands('tenant-a', session.session.sessionId), 1)
+    assert.equal(resolverCalls, 1)
+    assert.equal(runtimes[0]?.apiKey, kmsKey)
+    const view = await service.getSessionView(principal('tenant-a', 'user-a'), session.session.sessionId)
+    assert.equal(view.projection.view.messages.at(-1)?.content, 'used-byok:7890')
+  } finally {
+    await runtime.close?.()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('worker-scoped BYOK runtime enforces provider policy before revealing active secrets', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-byok-runtime-policy-'))
+  const store = seededStore()
+  let nextId = 0
+  const byokSecrets = createByokSecretStore(store, createEnvelopeSecretAdapter('byok-runtime-test-key'), {
+    ids: { randomUUID: () => `secret-${nextId += 1}` },
+  })
+  await byokSecrets.setSecret({ orgId: 'tenant-a', providerId: 'openrouter', plaintext: KEY_A })
+  let factoryCalls = 0
+  const runtime = createWorkerScopedRuntimeAdapter({
+    paths: createCloudPathProvider(root),
+    policy: resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    env: { PATH: process.env.PATH },
+    config: BYOK_TEST_CONFIG,
+    byokSecrets,
+    byokPolicy: {
+      allowedProviderIds: ['anthropic'],
+      checkEntitlement() {
+        throw new Error('entitlement checker should not run for an unavailable provider')
+      },
+    },
+    runtimeFactory() {
+      factoryCalls += 1
+      throw new Error('runtime factory should not be called')
+    },
+  })
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
+    undefined,
+    { randomUUID: () => `cowork-session-${nextId += 1}` },
+    undefined,
+    byokSecrets,
+  )
+  const worker = new CloudWorker(store, service, 'worker-policy')
+
+  try {
+    const session = await service.createSession(principal('tenant-a', 'user-a'))
+    await service.enqueuePrompt(principal('tenant-a', 'user-a'), session.session.sessionId, { text: 'hello policy', agent: 'build' })
+    await assert.rejects(
+      () => worker.processSessionCommands('tenant-a', session.session.sessionId),
+      /not available for cloud BYOK execution/,
+    )
+    assert.equal(factoryCalls, 0)
+  } finally {
+    await runtime.close?.()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
 test('missing or disabled required BYOK key fails before runtime spawn', async () => {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-byok-runtime-missing-'))
   const store = seededStore()

--- a/tests/byok-secret-store.test.ts
+++ b/tests/byok-secret-store.test.ts
@@ -7,6 +7,7 @@ import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secr
 
 const FIRST_KEY = 'credential-sample-first-1234567890'
 const SECOND_KEY = 'credential-sample-second-abcdefghi'
+const VALIDATION_KEY = ['sk', 'validation', 'secret', '1234567890abcdef'].join('-')
 
 function seededStore() {
   const store = new InMemoryControlPlaneStore()
@@ -57,6 +58,13 @@ test('BYOK secret store encrypts keys, returns metadata only, rotates active rec
   assert.equal(records.filter((record) => record.providerId === 'anthropic' && record.status === 'active').length, 1)
   assert.equal(records.find((record) => record.secretId === first.secretId)?.status, 'disabled')
   assert.equal(records.find((record) => record.secretId === second.secretId)?.rotatedFromSecretId, first.secretId)
+
+  const audit = await store.listAuditEvents('tenant-1')
+  const rotationAudit = audit.find((event) => event.eventType === 'byok_secret.rotated')
+  assert.equal(rotationAudit?.actorType, 'system')
+  assert.equal(rotationAudit?.targetType, 'byok_secret')
+  assert.equal(rotationAudit?.targetId, second.secretId)
+  assert.equal(rotationAudit?.metadata.rotatedFromSecretId, '[redacted]')
 })
 
 test('BYOK disable prevents active reveal', async () => {
@@ -119,4 +127,97 @@ test('BYOK validation audit metadata is redacted', async () => {
   assert.equal(audit.some((event) => event.eventType === 'byok_secret.validated'), true)
   assert.equal(JSON.stringify(audit).includes(FIRST_KEY), false)
   assert.match(JSON.stringify(audit), /\[redacted\]/)
+})
+
+test('BYOK provider validation hooks mark active and invalid without leaking raw provider errors', async () => {
+  const store = seededStore()
+  let shouldPass = true
+  let observedPlaintext = ''
+  const byok = createByokSecretStore(store, createEnvelopeSecretAdapter('unit-test-byok-key'), {
+    ids: { randomUUID: () => 'secret-validation' },
+    validators: {
+      anthropic(input) {
+        observedPlaintext = input.plaintext
+        return shouldPass
+          ? { valid: true }
+          : { valid: false, error: `provider rejected ${input.plaintext}` }
+      },
+    },
+  })
+
+  await byok.setSecret({
+    orgId: 'tenant-1',
+    providerId: 'anthropic',
+    plaintext: VALIDATION_KEY,
+    actor: { actorType: 'user', actorId: 'owner-1', accountId: 'owner-1' },
+  })
+
+  const active = await byok.validateActiveSecret({
+    orgId: 'tenant-1',
+    providerId: 'anthropic',
+    actor: { actorType: 'user', actorId: 'owner-1', accountId: 'owner-1' },
+  })
+  assert.equal(observedPlaintext, VALIDATION_KEY)
+  assert.equal(active?.status, 'active')
+  assert.equal(active?.validationError, null)
+
+  shouldPass = false
+  const invalid = await byok.validateActiveSecret({
+    orgId: 'tenant-1',
+    providerId: 'anthropic',
+    actor: { actorType: 'user', actorId: 'owner-1', accountId: 'owner-1' },
+  })
+  assert.equal(invalid?.status, 'invalid')
+  assert.equal(invalid?.validationError?.includes(VALIDATION_KEY), false)
+  assert.match(invalid?.validationError || '', /\[redacted\]/)
+
+  const auditPayload = JSON.stringify(await store.listAuditEvents('tenant-1'))
+  assert.equal(auditPayload.includes(VALIDATION_KEY), false)
+  assert.match(auditPayload, /\[redacted\]/)
+})
+
+test('BYOK KMS references reveal only through explicit worker-authorized paths', async () => {
+  const store = seededStore()
+  const kmsPlaintext = 'credential-kms-backed-1234567890'
+  let resolvedRef = ''
+  const byok = createByokSecretStore(store, createEnvelopeSecretAdapter('unit-test-byok-key'), {
+    ids: { randomUUID: () => 'secret-kms' },
+    kmsRefResolver(input) {
+      resolvedRef = input.kmsRef
+      assert.equal(input.orgId, 'tenant-1')
+      assert.equal(input.providerId, 'anthropic')
+      assert.equal(input.secretId, 'byok_secret-kms')
+      return kmsPlaintext
+    },
+    validators: {
+      anthropic(input) {
+        return input.plaintext === kmsPlaintext
+      },
+    },
+  })
+
+  const created = await byok.setSecret({
+    orgId: 'tenant-1',
+    providerId: 'anthropic',
+    kmsRef: 'gcp-sm://projects/acme/secrets/anthropic/versions/latest',
+  })
+  assert.equal(created.status, 'active')
+  assert.equal(JSON.stringify(created).includes(kmsPlaintext), false)
+
+  await assert.rejects(
+    () => byok.revealActiveSecret({ orgId: 'tenant-1', providerId: 'anthropic' }),
+    /worker-authorized reveal path/,
+  )
+  assert.equal(
+    await byok.revealActiveSecret({ orgId: 'tenant-1', providerId: 'anthropic', allowKmsRef: true }),
+    kmsPlaintext,
+  )
+
+  const validated = await byok.validateActiveSecret({
+    orgId: 'tenant-1',
+    providerId: 'anthropic',
+    allowKmsRef: true,
+  })
+  assert.equal(validated?.status, 'active')
+  assert.equal(resolvedRef, 'gcp-sm://projects/acme/secrets/anthropic/versions/latest')
 })

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -19,7 +19,7 @@ import { createInMemoryObjectStore } from '../apps/desktop/src/main/cloud/object
 import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
 import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secret-adapter.ts'
 import { createCloudSessionCookieManager } from '../apps/desktop/src/main/cloud/session-cookie-auth.ts'
-import { CloudSessionService } from '../apps/desktop/src/main/cloud/session-service.ts'
+import { CloudSessionService, type ByokManagementPolicy } from '../apps/desktop/src/main/cloud/session-service.ts'
 import { CloudWorker } from '../apps/desktop/src/main/cloud/worker.ts'
 import type {
   CloudRuntimeAdapter,
@@ -84,6 +84,7 @@ function createFixture(options: {
     desktopAuth?: CloudDesktopAuthConfig | null
     observability?: CloudObservabilityAdapter | null
     internalToken?: string | null
+    byokPolicy?: ByokManagementPolicy
   } = {}) {
   const runtime = new FakeRuntimeAdapter()
   const store = new InMemoryControlPlaneStore()
@@ -95,7 +96,7 @@ function createFixture(options: {
   })
   const service = new CloudSessionService(store, runtime, policy, undefined, {
     randomUUID: () => `cmd-${nextId += 1}`,
-  }, undefined, byokSecrets)
+  }, undefined, byokSecrets, options.byokPolicy)
   const artifacts = new CloudArtifactService(service, objectStore, {
     randomUUID: () => `artifact-${nextId += 1}`,
   })
@@ -303,6 +304,18 @@ test('cloud HTTP server exposes metadata-only BYOK APIs with rotation, disable, 
     assert.equal(asArray(list.secrets).length, 1)
     assert.equal(JSON.stringify(list).includes(rawFirst), false)
 
+    const validateResponse = await fetch(`${baseUrl}/api/byok/anthropic/validate`, { method: 'POST' })
+    assert.equal(validateResponse.status, 200)
+    const validated = await readJson(validateResponse)
+    assert.equal(asRecord(validated.secret).status, 'active')
+    assert.equal(typeof asRecord(validated.secret).lastValidatedAt, 'string')
+    assert.equal(JSON.stringify(validated).includes(rawFirst), false)
+
+    const client = createHttpSseCloudTransportAdapter({ baseUrl })
+    const clientSecret = await client.validateByokSecret?.('anthropic')
+    assert.equal(clientSecret?.status, 'active')
+    assert.equal(JSON.stringify(clientSecret).includes(rawFirst), false)
+
     const rotateResponse = await fetch(`${baseUrl}/api/byok/anthropic`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -337,6 +350,135 @@ test('cloud HTTP server exposes metadata-only BYOK APIs with rotation, disable, 
     assert.equal(audit.some((event) => event.eventType === 'byok_secret.disabled'), true)
     assert.equal(JSON.stringify(audit).includes(rawFirst), false)
     assert.equal(JSON.stringify(audit).includes(rawSecond), false)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP BYOK APIs enforce provider availability and org entitlement policy', async () => {
+  const unavailableProviderKey = ['credential', 'policy', 'openai', '1234567890'].join('-')
+  const blockedProviderKey = ['credential', 'policy', 'anthropic', '1234567890'].join('-')
+  const fixture = createFixture({
+    byokPolicy: {
+      allowedProviderIds: ['anthropic'],
+      checkEntitlement(input) {
+        return input.providerId === 'anthropic'
+          ? { allowed: false, status: 402, reason: 'BYOK provider is not included in this plan.' }
+          : { allowed: true }
+      },
+    },
+    auth: () => ({
+      tenantId: 'tenant-1',
+      orgId: 'tenant-1',
+      tenantName: 'Tenant 1',
+      userId: 'owner-1',
+      accountId: 'owner-1',
+      email: 'owner@example.test',
+      role: 'owner',
+      authSource: 'user',
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const unavailable = await fetch(`${baseUrl}/api/byok/openai`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ apiKey: unavailableProviderKey }),
+    })
+    assert.equal(unavailable.status, 403)
+    assert.match(JSON.stringify(await readJson(unavailable)), /not enabled/)
+
+    const blocked = await fetch(`${baseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ apiKey: blockedProviderKey }),
+    })
+    assert.equal(blocked.status, 402)
+    assert.match(JSON.stringify(await readJson(blocked)), /not included/)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP BYOK KMS refs require explicit deployer policy and validate without worker reveal', async () => {
+  const defaultFixture = createFixture({
+    auth: () => ({
+      tenantId: 'tenant-1',
+      orgId: 'tenant-1',
+      tenantName: 'Tenant 1',
+      userId: 'owner-1',
+      accountId: 'owner-1',
+      email: 'owner@example.test',
+      role: 'owner',
+      authSource: 'user',
+    }),
+  })
+  const defaultBaseUrl = await defaultFixture.server.listen()
+  try {
+    const blocked = await fetch(`${defaultBaseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ kmsRef: 'gcp-sm://projects/acme/secrets/anthropic/versions/latest' }),
+    })
+    assert.equal(blocked.status, 403)
+    assert.match(JSON.stringify(await readJson(blocked)), /disabled/)
+  } finally {
+    await defaultFixture.server.close()
+  }
+
+  const fixture = createFixture({
+    byokPolicy: {
+      kmsRefs: {
+        enabled: true,
+        allowedPrefixes: ['gcp-sm://projects/acme/secrets/'],
+      },
+    },
+    auth: () => ({
+      tenantId: 'tenant-1',
+      orgId: 'tenant-1',
+      tenantName: 'Tenant 1',
+      userId: 'owner-1',
+      accountId: 'owner-1',
+      email: 'owner@example.test',
+      role: 'owner',
+      authSource: 'user',
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const envRef = await fetch(`${baseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ kmsRef: 'env:OPEN_COWORK_BYOK_ANTHROPIC' }),
+    })
+    assert.equal(envRef.status, 403)
+    assert.match(JSON.stringify(await readJson(envRef)), /Environment-backed/)
+
+    const outsidePrefix = await fetch(`${baseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ kmsRef: 'gcp-sm://projects/other/secrets/anthropic/versions/latest' }),
+    })
+    assert.equal(outsidePrefix.status, 403)
+    assert.match(JSON.stringify(await readJson(outsidePrefix)), /not allowed/)
+
+    const createResponse = await fetch(`${baseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ kmsRef: 'gcp-sm://projects/acme/secrets/anthropic/versions/latest' }),
+    })
+    assert.equal(createResponse.status, 201)
+    const created = await readJson(createResponse)
+    assert.equal(asRecord(created.secret).status, 'active')
+    assert.equal(JSON.stringify(created).includes('kmsRef'), false)
+
+    const validateResponse = await fetch(`${baseUrl}/api/byok/anthropic/validate`, { method: 'POST' })
+    assert.equal(validateResponse.status, 200)
+    const validated = await readJson(validateResponse)
+    assert.equal(validated.validated, false)
+    assert.equal(asRecord(validated.secret).status, 'active')
+    assert.equal(asRecord(validated.secret).lastValidatedAt, null)
+    assert.equal(JSON.stringify(validated).includes('kmsRef'), false)
   } finally {
     await fixture.server.close()
   }


### PR DESCRIPTION
## Summary

- Add BYOK provider validation hooks with sanitized validation failure storage.
- Add worker-authorized KMS reference reveal support and wire cloud app KMS refs through `resolveCloudSecretRef`.
- Enforce configured provider availability and optional org entitlement checks before BYOK mutations.
- Expose BYOK validation through the cloud HTTP API and shared cloud client.
- Extend regression coverage for validation, KMS reveal/injection, rotation audit metadata, provider policy, and metadata-only HTTP responses.

Closes #427.

## Validation

- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/byok-secret-store.test.ts`
- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/byok-runtime-injection.test.ts`
- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/cloud-http-server.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`