### PR TITLE
Add cloud quotas and usage metering

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import type { IncomingMessage } from 'node:http'
-import { DEFAULT_CONFIG, type CloudAuthConfig, type OpenCoworkConfig } from '../config-types.ts'
+import { DEFAULT_CONFIG, type CloudAbuseConfig, type CloudAuthConfig, type OpenCoworkConfig } from '../config-types.ts'
 import { CloudArtifactService } from './artifact-service.ts'
 import {
   resolveCloudRuntimePolicy,
@@ -156,6 +156,16 @@ function parsePositiveInt(value: string | null | undefined, fallback: number) {
   return parsed
 }
 
+function parseOptionalPositiveInt(value: string | null | undefined, fallback: number | null) {
+  if (!value) return fallback
+  const parsed = Number(value)
+  if (parsed === 0) return null
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid non-negative integer "${value}".`)
+  }
+  return parsed
+}
+
 function parseBoolean(value: string | null | undefined, fallback: boolean) {
   if (!value) return fallback
   if (/^(1|true|yes|on)$/i.test(value)) return true
@@ -199,6 +209,47 @@ export function resolveCloudCookieSecret(config: Pick<OpenCoworkConfig, 'cloud'>
   return envValue(env, 'OPEN_COWORK_CLOUD_COOKIE_SECRET')
     || resolveEnvRef(config.cloud.auth.cookieSecretRef, env)
     || envValue(env, 'OPEN_COWORK_CLOUD_SECRET_KEY')
+}
+
+export function resolveCloudAbuseConfig(config: Pick<OpenCoworkConfig, 'cloud'>, env: Env = process.env): CloudAbuseConfig {
+  const defaults = config.cloud.abuse
+  return {
+    ...defaults,
+    enabled: parseBoolean(envValue(env, 'OPEN_COWORK_CLOUD_ABUSE_ENABLED'), defaults.enabled),
+    maxConcurrentSessionsPerOrg: parseOptionalPositiveInt(
+      envValue(env, 'OPEN_COWORK_CLOUD_MAX_CONCURRENT_SESSIONS_PER_ORG'),
+      defaults.maxConcurrentSessionsPerOrg,
+    ),
+    maxActiveWorkersPerOrg: parseOptionalPositiveInt(
+      envValue(env, 'OPEN_COWORK_CLOUD_MAX_ACTIVE_WORKERS_PER_ORG'),
+      defaults.maxActiveWorkersPerOrg,
+    ),
+    maxPromptsPerHour: parseOptionalPositiveInt(
+      envValue(env, 'OPEN_COWORK_CLOUD_MAX_PROMPTS_PER_HOUR'),
+      defaults.maxPromptsPerHour,
+    ),
+    maxGatewayDeliveriesPerHour: parseOptionalPositiveInt(
+      envValue(env, 'OPEN_COWORK_CLOUD_MAX_GATEWAY_DELIVERIES_PER_HOUR'),
+      defaults.maxGatewayDeliveriesPerHour,
+    ),
+    maxArtifactBytesPerDay: parseOptionalPositiveInt(
+      envValue(env, 'OPEN_COWORK_CLOUD_MAX_ARTIFACT_BYTES_PER_DAY'),
+      defaults.maxArtifactBytesPerDay,
+    ),
+    httpRateLimit: {
+      ...defaults.httpRateLimit,
+      enabled: parseBoolean(envValue(env, 'OPEN_COWORK_CLOUD_HTTP_RATE_LIMIT_ENABLED'), defaults.httpRateLimit.enabled),
+      windowMs: parsePositiveInt(envValue(env, 'OPEN_COWORK_CLOUD_HTTP_RATE_LIMIT_WINDOW_MS'), defaults.httpRateLimit.windowMs),
+      maxRequests: parsePositiveInt(envValue(env, 'OPEN_COWORK_CLOUD_HTTP_RATE_LIMIT_MAX_REQUESTS'), defaults.httpRateLimit.maxRequests),
+    },
+    authBackoff: {
+      ...defaults.authBackoff,
+      enabled: parseBoolean(envValue(env, 'OPEN_COWORK_CLOUD_AUTH_BACKOFF_ENABLED'), defaults.authBackoff.enabled),
+      windowMs: parsePositiveInt(envValue(env, 'OPEN_COWORK_CLOUD_AUTH_BACKOFF_WINDOW_MS'), defaults.authBackoff.windowMs),
+      maxFailures: parsePositiveInt(envValue(env, 'OPEN_COWORK_CLOUD_AUTH_BACKOFF_MAX_FAILURES'), defaults.authBackoff.maxFailures),
+      backoffMs: parsePositiveInt(envValue(env, 'OPEN_COWORK_CLOUD_AUTH_BACKOFF_MS'), defaults.authBackoff.backoffMs),
+    },
+  }
 }
 
 export function resolveCloudOidcClientSecret(config: Pick<OpenCoworkConfig, 'cloud'>, env: Env = process.env) {
@@ -492,6 +543,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
   const config = options.config || DEFAULT_CONFIG
   const policy = resolveCloudRuntimePolicy(config, env)
   const authConfig = resolveCloudAuthConfig(config, env)
+  const abuseConfig = resolveCloudAbuseConfig(config, env)
   const listenHostname = options.hostname || envOptions.hostname
   assertCloudAuthDeploymentSafe({
     role: policy.role,
@@ -562,6 +614,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
     undefined,
     byokSecrets,
     byokPolicy,
+    abuseConfig,
   )
   const artifacts = new CloudArtifactService(service, objectStore)
   const hasSessionCookieOverride = Object.prototype.hasOwnProperty.call(options, 'sessionCookies')
@@ -618,8 +671,9 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
                   roots: defaultCloudSessionCheckpointRoots(leasePaths, lease.tenantId, lease.sessionId),
                 })
               },
-            }
+          }
           : {},
+        abuseConfig,
       )
     : null
   const scheduler = shouldRunCloudScheduler(policy.role)

--- a/apps/desktop/src/main/cloud/artifact-service.ts
+++ b/apps/desktop/src/main/cloud/artifact-service.ts
@@ -99,6 +99,7 @@ export class CloudArtifactService {
     const filename = boundedFilename(input.filename)
     const contentType = boundedContentType(input.contentType)
     const body = decodeBase64(input.dataBase64)
+    await this.sessionService.assertArtifactUploadAllowed(principal, body.byteLength)
     const key = artifactObjectKey({
       tenantId: principal.tenantId,
       sessionId,
@@ -128,6 +129,7 @@ export class CloudArtifactService {
       type: 'artifact.created',
       payload: record,
     })
+    await this.sessionService.recordArtifactUploaded(principal, sessionId, artifactId, stored.size)
     return record
   }
 

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -26,6 +26,92 @@ export type ChannelInteractionKind = 'permission' | 'question'
 export type ChannelInteractionStatus = 'pending' | 'used' | 'expired' | 'revoked'
 export type ChannelDeliveryStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead'
 export type ByokSecretStatus = 'active' | 'disabled' | 'expired' | 'invalid'
+export type UsageEventType =
+  | 'session.created'
+  | 'prompt.enqueued'
+  | 'worker.minute'
+  | 'artifact.uploaded'
+  | 'gateway.delivery.claimed'
+export type UsageUnit = 'count' | 'byte' | 'minute'
+
+export type QuotaPolicyCode =
+  | 'quota.concurrent_sessions_exceeded'
+  | 'quota.active_workers_exceeded'
+  | 'quota.prompts_per_hour_exceeded'
+  | 'quota.gateway_deliveries_per_hour_exceeded'
+  | 'quota.artifact_bytes_per_day_exceeded'
+  | 'rate_limit.http_exceeded'
+  | 'auth.backoff'
+
+export type UsageEventRecord = {
+  eventId: string
+  orgId: string
+  accountId: string | null
+  eventType: UsageEventType | string
+  quantity: number
+  unit: UsageUnit | string
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
+export type QuotaConsumptionRecord = {
+  allowed: boolean
+  orgId: string
+  quotaKey: string
+  limit: number
+  used: number
+  remaining: number
+  resetAt: string
+  retryAfterMs: number
+  policyCode?: QuotaPolicyCode | string
+}
+
+export type RateLimitClaimRecord = {
+  allowed: boolean
+  scope: string
+  source: string
+  limit: number
+  count: number
+  resetAt: string
+  retryAfterMs: number
+  policyCode?: QuotaPolicyCode | string
+}
+
+export type CloudAuthBackoffRecord = {
+  allowed: boolean
+  scope: string
+  source: string
+  failureCount: number
+  blockedUntilMs: number
+  retryAfterMs: number
+}
+
+export class ControlPlaneQuotaExceededError extends Error {
+  readonly status = 429
+  readonly publicMessage: string
+  readonly policyCode: QuotaPolicyCode | string
+  readonly retryAfterMs: number
+  readonly limit: number
+  readonly used: number
+  readonly resetAt: string
+
+  constructor(input: {
+    message: string
+    policyCode: QuotaPolicyCode | string
+    retryAfterMs: number
+    limit: number
+    used: number
+    resetAt: string
+  }) {
+    super(input.message)
+    this.publicMessage = input.message
+    this.policyCode = input.policyCode
+    this.retryAfterMs = input.retryAfterMs
+    this.limit = input.limit
+    this.used = input.used
+    this.resetAt = input.resetAt
+  }
+}
 
 export type TenantRecord = {
   tenantId: string
@@ -387,6 +473,56 @@ export type CreateSessionInput = {
   profileName: string
   title?: string | null
   createdAt?: Date
+  quota?: {
+    orgId?: string | null
+    maxConcurrentSessionsPerOrg?: number | null
+    policyCode?: QuotaPolicyCode | string
+  } | null
+}
+
+export type ConsumeUsageQuotaInput = {
+  orgId: string
+  quotaKey: string
+  limit: number
+  quantity?: number
+  windowMs: number
+  now?: Date
+  policyCode?: QuotaPolicyCode | string
+}
+
+export type RecordUsageEventInput = {
+  eventId?: string
+  orgId: string
+  accountId?: string | null
+  eventType: UsageEventType | string
+  quantity?: number
+  unit?: UsageUnit | string
+  metadata?: Record<string, unknown>
+  createdAt?: Date
+}
+
+export type ClaimRateLimitInput = {
+  scope: string
+  source: string
+  limit: number
+  windowMs: number
+  now?: Date
+  policyCode?: QuotaPolicyCode | string
+}
+
+export type CheckCloudAuthBackoffInput = {
+  scope: string
+  source?: string
+  now?: Date
+}
+
+export type RecordCloudAuthFailureInput = {
+  scope: string
+  source: string
+  windowMs: number
+  limit: number
+  backoffMs: number
+  now?: Date
 }
 
 export type CreateAccountInput = {
@@ -612,6 +748,7 @@ export type ClaimChannelDeliveryInput = {
   claimedBy: string
   now?: Date
   ttlMs?: number
+  quota?: Omit<ConsumeUsageQuotaInput, 'orgId'> | null
 }
 
 export type AckChannelDeliveryInput = {
@@ -790,6 +927,12 @@ export type ControlPlaneStore = {
   revokeApiToken(input: RevokeApiTokenInput): MaybePromise<ApiTokenRecord | null>
   recordAuditEvent(input: RecordAuditEventInput): MaybePromise<AuditEventRecord>
   listAuditEvents(orgId: string, limit?: number): MaybePromise<AuditEventRecord[]>
+  consumeUsageQuota(input: ConsumeUsageQuotaInput): MaybePromise<QuotaConsumptionRecord>
+  recordUsageEvent(input: RecordUsageEventInput): MaybePromise<UsageEventRecord>
+  listUsageEvents(orgId: string, limit?: number): MaybePromise<UsageEventRecord[]>
+  claimRateLimit(input: ClaimRateLimitInput): MaybePromise<RateLimitClaimRecord>
+  checkCloudAuthBackoff(input: CheckCloudAuthBackoffInput): MaybePromise<CloudAuthBackoffRecord>
+  recordCloudAuthFailure(input: RecordCloudAuthFailureInput): MaybePromise<CloudAuthBackoffRecord>
   createByokSecret(input: CreateByokSecretInput): MaybePromise<ByokSecretRecord>
   getByokSecret(orgId: string, providerId: string): MaybePromise<ByokSecretRecord | null>
   getActiveByokSecret(orgId: string, providerId: string): MaybePromise<ByokSecretRecord | null>
@@ -865,6 +1008,11 @@ export type ControlPlaneStore = {
     workerId: string,
     now?: Date,
     ttlMs?: number,
+    quota?: {
+      orgId?: string | null
+      maxActiveWorkersPerOrg?: number | null
+      policyCode?: QuotaPolicyCode | string
+    } | null,
   ): MaybePromise<WorkerLeaseRecord | null>
   renewSessionLease(lease: WorkerLeaseRecord, now?: Date, ttlMs?: number): MaybePromise<WorkerLeaseRecord>
   checkpointSession(lease: WorkerLeaseRecord): MaybePromise<WorkerLeaseRecord>
@@ -1076,6 +1224,31 @@ function normalizeNonNegativeInteger(value: unknown, label: string) {
   return parsed
 }
 
+function normalizePositiveInteger(value: unknown, label: string) {
+  const parsed = Number(value ?? 0)
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${label} must be a positive integer.`)
+  return parsed
+}
+
+function windowStart(nowMs: number, windowMs: number) {
+  return Math.floor(nowMs / windowMs) * windowMs
+}
+
+function quotaRetryAfterMs(nowMs: number, startedAtMs: number, windowMs: number) {
+  return Math.max(1, startedAtMs + windowMs - nowMs)
+}
+
+function quotaExceeded(input: {
+  message: string
+  policyCode: QuotaPolicyCode | string
+  retryAfterMs: number
+  limit: number
+  used: number
+  resetAt: string
+}): never {
+  throw new ControlPlaneQuotaExceededError(input)
+}
+
 function normalizeProvider(value: unknown): ChannelProviderId {
   const provider = normalizeText(value, 32, 'Channel provider') as ChannelProviderId
   if (!['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(provider)) {
@@ -1117,6 +1290,11 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly memberships = new Map<string, MembershipRecord>()
   private readonly apiTokens = new Map<string, ApiTokenRecord>()
   private readonly auditEvents = new Map<string, AuditEventRecord>()
+  private readonly usageEvents = new Map<string, UsageEventRecord>()
+  private readonly usageCounters = new Map<string, { windowStartedAtMs: number, quantity: number }>()
+  private readonly rateLimits = new Map<string, { windowStartedAtMs: number, count: number }>()
+  private readonly authFailures = new Map<string, CloudAuthBackoffRecord>()
+  private readonly authFailureWindows = new Map<string, number>()
   private readonly byokSecrets = new Map<string, ByokSecretRecord>()
   private readonly headlessAgents = new Map<string, HeadlessAgentRecord>()
   private readonly channelBindings = new Map<string, ChannelBindingRecord>()
@@ -1385,6 +1563,138 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
       .slice(0, limit)
       .map((event) => clone(event))
+  }
+
+  consumeUsageQuota(input: ConsumeUsageQuotaInput): QuotaConsumptionRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    const limit = normalizePositiveInteger(input.limit, 'Quota limit')
+    const quantity = normalizePositiveInteger(input.quantity || 1, 'Quota quantity')
+    const windowMs = normalizePositiveInteger(input.windowMs, 'Quota window')
+    const now = input.now || new Date()
+    const nowMs = now.getTime()
+    const startedAtMs = windowStart(nowMs, windowMs)
+    const counterKey = key(input.orgId, input.quotaKey)
+    const existing = this.usageCounters.get(counterKey)
+    const current = existing && existing.windowStartedAtMs === startedAtMs ? existing.quantity : 0
+    const next = current + quantity
+    const retryAfterMs = quotaRetryAfterMs(nowMs, startedAtMs, windowMs)
+    const resetAt = new Date(nowMs + retryAfterMs).toISOString()
+    if (next > limit) {
+      return {
+        allowed: false,
+        orgId: input.orgId,
+        quotaKey: input.quotaKey,
+        limit,
+        used: current,
+        remaining: Math.max(0, limit - current),
+        resetAt,
+        retryAfterMs,
+        policyCode: input.policyCode,
+      }
+    }
+    this.usageCounters.set(counterKey, { windowStartedAtMs: startedAtMs, quantity: next })
+    return {
+      allowed: true,
+      orgId: input.orgId,
+      quotaKey: input.quotaKey,
+      limit,
+      used: next,
+      remaining: Math.max(0, limit - next),
+      resetAt,
+      retryAfterMs,
+      policyCode: input.policyCode,
+    }
+  }
+
+  recordUsageEvent(input: RecordUsageEventInput): UsageEventRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    const eventId = input.eventId || stableId('usage', input.orgId, input.eventType, String(this.usageEvents.size + 1), nowIso(input.createdAt))
+    const existing = this.usageEvents.get(eventId)
+    if (existing) return clone(existing)
+    const record: UsageEventRecord = {
+      eventId,
+      orgId: input.orgId,
+      accountId: input.accountId || null,
+      eventType: input.eventType,
+      quantity: normalizePositiveInteger(input.quantity || 1, 'Usage quantity'),
+      unit: input.unit || 'count',
+      metadata: redactAuditMetadata(input.metadata),
+      createdAt: nowIso(input.createdAt),
+    }
+    this.usageEvents.set(eventId, record)
+    return clone(record)
+  }
+
+  listUsageEvents(orgId: string, limit = 100): UsageEventRecord[] {
+    if (!this.orgs.has(orgId)) throw new Error(`Unknown org ${orgId}.`)
+    return Array.from(this.usageEvents.values())
+      .filter((event) => event.orgId === orgId)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .slice(0, limit)
+      .map((event) => clone(event))
+  }
+
+  claimRateLimit(input: ClaimRateLimitInput): RateLimitClaimRecord {
+    const limit = normalizePositiveInteger(input.limit, 'Rate limit')
+    const windowMs = normalizePositiveInteger(input.windowMs, 'Rate-limit window')
+    const now = input.now || new Date()
+    const nowMs = now.getTime()
+    const startedAtMs = windowStart(nowMs, windowMs)
+    const rateKey = key(input.scope, input.source)
+    const existing = this.rateLimits.get(rateKey)
+    const count = existing && existing.windowStartedAtMs === startedAtMs ? existing.count + 1 : 1
+    this.rateLimits.set(rateKey, { windowStartedAtMs: startedAtMs, count })
+    const retryAfterMs = quotaRetryAfterMs(nowMs, startedAtMs, windowMs)
+    return {
+      allowed: count <= limit,
+      scope: input.scope,
+      source: input.source,
+      limit,
+      count,
+      resetAt: new Date(nowMs + retryAfterMs).toISOString(),
+      retryAfterMs,
+      policyCode: input.policyCode,
+    }
+  }
+
+  checkCloudAuthBackoff(input: CheckCloudAuthBackoffInput): CloudAuthBackoffRecord {
+    const nowMs = (input.now || new Date()).getTime()
+    const existing = this.authFailures.get(input.scope)
+    return {
+      allowed: !existing || existing.blockedUntilMs <= nowMs,
+      scope: input.scope,
+      source: input.source || existing?.source || input.scope,
+      failureCount: existing?.failureCount || 0,
+      blockedUntilMs: existing?.blockedUntilMs || 0,
+      retryAfterMs: existing ? Math.max(0, existing.blockedUntilMs - nowMs) : 0,
+    }
+  }
+
+  recordCloudAuthFailure(input: RecordCloudAuthFailureInput): CloudAuthBackoffRecord {
+    const windowMs = normalizePositiveInteger(input.windowMs, 'Auth backoff window')
+    const limit = normalizePositiveInteger(input.limit, 'Auth failure limit')
+    const backoffMs = normalizePositiveInteger(input.backoffMs, 'Auth backoff duration')
+    const nowMs = (input.now || new Date()).getTime()
+    const existing = this.authFailures.get(input.scope)
+    const currentWindowStartedAtMs = windowStart(nowMs, windowMs)
+    const existingWindowStartedAtMs = this.authFailureWindows.get(input.scope)
+    const failureCount = existing && existingWindowStartedAtMs === currentWindowStartedAtMs
+      ? existing.failureCount + 1
+      : 1
+    const blockedUntilMs = failureCount >= limit
+      ? Math.max(existing?.blockedUntilMs || 0, nowMs + backoffMs)
+      : existing?.blockedUntilMs || 0
+    const record: CloudAuthBackoffRecord = {
+      allowed: blockedUntilMs <= nowMs,
+      scope: input.scope,
+      source: input.source,
+      failureCount,
+      blockedUntilMs,
+      retryAfterMs: Math.max(0, blockedUntilMs - nowMs),
+    }
+    this.authFailures.set(input.scope, record)
+    this.authFailureWindows.set(input.scope, currentWindowStartedAtMs)
+    return clone(record)
   }
 
   createByokSecret(input: CreateByokSecretInput): ByokSecretRecord {
@@ -1915,6 +2225,23 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       ))
       .sort((left, right) => left.nextAttemptAt.localeCompare(right.nextAttemptAt) || left.createdAt.localeCompare(right.createdAt))[0]
     if (!candidate) return null
+    if (input.quota) {
+      const quota = this.consumeUsageQuota({
+        ...input.quota,
+        orgId: input.orgId,
+        now,
+      })
+      if (!quota.allowed) {
+        quotaExceeded({
+          message: 'Gateway delivery quota exceeded.',
+          policyCode: quota.policyCode || 'quota.gateway_deliveries_per_hour_exceeded',
+          retryAfterMs: quota.retryAfterMs,
+          limit: quota.limit,
+          used: quota.used,
+          resetAt: quota.resetAt,
+        })
+      }
+    }
     candidate.status = 'claimed'
     candidate.claimedBy = normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery claimant')
     candidate.claimExpiresAt = new Date(nowMs + (input.ttlMs || 30_000)).toISOString()
@@ -1942,6 +2269,22 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const sessionKey = key(input.tenantId, input.sessionId)
     const existing = this.sessions.get(sessionKey)
     if (existing) return clone(existing.record)
+    const maxConcurrentSessions = input.quota?.maxConcurrentSessionsPerOrg
+    if (maxConcurrentSessions && maxConcurrentSessions > 0) {
+      const activeSessions = Array.from(this.sessions.values())
+        .filter((session) => session.record.tenantId === input.tenantId && session.record.status !== 'closed')
+        .length
+      if (activeSessions >= maxConcurrentSessions) {
+        quotaExceeded({
+          message: 'Concurrent cloud session quota exceeded.',
+          policyCode: input.quota?.policyCode || 'quota.concurrent_sessions_exceeded',
+          retryAfterMs: 60_000,
+          limit: maxConcurrentSessions,
+          used: activeSessions,
+          resetAt: new Date(Date.now() + 60_000).toISOString(),
+        })
+      }
+    }
     const createdAt = nowIso(input.createdAt)
     const record: SessionRecord = {
       tenantId: input.tenantId,
@@ -2164,10 +2507,25 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     workerId: string,
     now = new Date(),
     ttlMs = 30_000,
+    quota: {
+      orgId?: string | null
+      maxActiveWorkersPerOrg?: number | null
+      policyCode?: QuotaPolicyCode | string
+    } | null = null,
   ): WorkerLeaseRecord | null {
     const session = this.requireSession(tenantId, sessionId)
     const nowMs = now.getTime()
     if (session.lease && session.lease.leaseExpiresAt > nowMs) return null
+    const maxActiveWorkers = quota?.maxActiveWorkersPerOrg
+    if (maxActiveWorkers && maxActiveWorkers > 0) {
+      const activeLeases = Array.from(this.sessions.values())
+        .filter((state) => state.record.tenantId === tenantId)
+        .filter((state) => state.lease && state.lease.leaseExpiresAt > nowMs)
+        .length
+      if (activeLeases >= maxActiveWorkers) {
+        return null
+      }
+    }
     const attempt = session.nextLeaseAttempt += 1
     const lease: WorkerLeaseRecord = {
       tenantId,

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -66,11 +66,18 @@ export type CloudHttpServerOptions = {
 export class CloudHttpError extends Error {
   readonly status: number
   readonly publicMessage: string
+  readonly policyCode: string | null
+  readonly retryAfterMs: number | null
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, details: {
+    policyCode?: string | null
+    retryAfterMs?: number | null
+  } = {}) {
     super(message)
     this.status = status
     this.publicMessage = message
+    this.policyCode = details.policyCode || null
+    this.retryAfterMs = details.retryAfterMs || null
   }
 }
 
@@ -153,8 +160,26 @@ function writeHtml(res: ServerResponse, status: number, body: string, origin?: s
   res.end(body)
 }
 
-function writeError(res: ServerResponse, status: number, message: string, origin?: string | null) {
-  writeJson(res, status, { error: message }, origin)
+function writeError(
+  res: ServerResponse,
+  status: number,
+  message: string,
+  origin?: string | null,
+  details: { policyCode?: string | null, retryAfterMs?: number | null } = {},
+) {
+  if (details.retryAfterMs && details.retryAfterMs > 0) {
+    res.setHeader('Retry-After', String(Math.max(1, Math.ceil(details.retryAfterMs / 1000))))
+  }
+  const body: Record<string, unknown> = { error: message }
+  if (details.retryAfterMs && details.retryAfterMs > 0) body.retryAfterMs = details.retryAfterMs
+  if (details.policyCode) {
+    body.verdict = {
+      allowed: false,
+      reason: message,
+      policyCode: details.policyCode,
+    }
+  }
+  writeJson(res, status, body, origin)
 }
 
 function writePolicyError(
@@ -302,6 +327,21 @@ function workflowScopeKey(workflowId: string) {
 
 function webhookSource(req: IncomingMessage) {
   return req.socket.remoteAddress || 'unknown'
+}
+
+function requestSource(req: IncomingMessage) {
+  const forwardedFor = firstHeader(req.headers['x-forwarded-for']).split(',')[0]?.trim()
+  return forwardedFor || req.socket.remoteAddress || 'unknown'
+}
+
+function authFailureScopes(req: IncomingMessage) {
+  const source = requestSource(req)
+  const authorization = firstHeader(req.headers.authorization).trim()
+  const scopes = [`ip:${source}`]
+  if (!authorization) return scopes
+  const tokenHash = createHash('sha256').update(authorization).digest('hex').slice(0, 16)
+  scopes.push(`auth:${tokenHash}`)
+  return scopes
 }
 
 function webhookAuthScope(source: string, workflowId: string) {
@@ -730,6 +770,13 @@ async function handleApiRequest(
         : 'delegated',
       checkpoints: Boolean(options.worker),
       heartbeats: await options.service.listWorkerHeartbeats(),
+    }, options.corsOrigin)
+    return
+  }
+
+  if (resource === 'usage' && sessionId === 'events' && !action && req.method === 'GET') {
+    writeJson(res, 200, {
+      events: await options.service.listUsageEvents(context.principal, parseLimit(context.url)),
     }, options.corsOrigin)
     return
   }
@@ -1698,6 +1745,49 @@ export class CloudHttpServer {
     })
   }
 
+  private async enforceIpRateLimit(req: IncomingMessage) {
+    await this.options.service.claimHttpRateLimit({
+      scope: 'ip',
+      source: requestSource(req),
+    })
+  }
+
+  private async enforcePrincipalRateLimit(principal: CloudPrincipal) {
+    await this.options.service.claimHttpRateLimit({
+      scope: 'org',
+      source: principal.orgId || principal.tenantId,
+    })
+    if (principal.tokenId) {
+      await this.options.service.claimHttpRateLimit({
+        scope: 'token',
+        source: principal.tokenId,
+      })
+    }
+  }
+
+  private async resolvePrincipal(req: IncomingMessage, auth: CloudAuthResolver) {
+    const source = requestSource(req)
+    const scopes = authFailureScopes(req)
+    await Promise.all(scopes.map((scope) => (
+      this.options.service.checkCloudAuthBackoff({ scope, source })
+    )))
+    try {
+      return await auth(req)
+    } catch (error) {
+      const status = error instanceof CloudHttpError
+        ? error.status
+        : error instanceof CloudServiceError
+          ? error.status
+          : 401
+      if (status === 401) {
+        await Promise.all(scopes.map((scope) => (
+          this.options.service.recordCloudAuthFailure({ scope, source })
+        )))
+      }
+      throw error
+    }
+  }
+
   private async handle(req: IncomingMessage, res: ServerResponse) {
     const startedAt = Date.now()
     const requestId = firstHeader(req.headers['x-request-id']).trim() || randomUUID()
@@ -1742,14 +1832,18 @@ export class CloudHttpServer {
         return
       }
 
+      await this.enforceIpRateLimit(req)
+
       if (url.pathname.startsWith('/auth/') || this.options.browserAuth?.isCallbackPath(url.pathname)) {
         const auth = this.options.auth || defaultAuthResolver
+        const authWithBackoff: CloudAuthResolver = (request) => this.resolvePrincipal(request, auth)
         const cookieSession = this.options.sessionCookies?.read(req) || null
         const principal = cookieSession?.principal || (
           url.pathname === '/auth/me'
-            ? await auth(req)
+            ? await authWithBackoff(req)
             : null
         )
+        if (principal) await this.enforcePrincipalRateLimit(principal)
         const context = principal
           ? {
               principal,
@@ -1759,12 +1853,13 @@ export class CloudHttpServer {
               segments: url.pathname.split('/').filter(Boolean),
             }
           : null
-        await handleAuthRequest(req, res, this.options, context, auth)
+        await handleAuthRequest(req, res, this.options, context, authWithBackoff)
         return
       }
       const auth = this.options.auth || defaultAuthResolver
       const cookieSession = this.options.sessionCookies?.read(req) || null
-      const principal = cookieSession?.principal || await auth(req)
+      const principal = cookieSession?.principal || await this.resolvePrincipal(req, auth)
+      await this.enforcePrincipalRateLimit(principal)
       const context: RouteContext = {
         principal,
         authSource: cookieSession ? 'cookie' : 'resolver',
@@ -1779,11 +1874,17 @@ export class CloudHttpServer {
       })
     } catch (error) {
       if (error instanceof CloudHttpError) {
-        writeError(res, error.status, error.publicMessage, this.options.corsOrigin)
+        writeError(res, error.status, error.publicMessage, this.options.corsOrigin, {
+          policyCode: error.policyCode,
+          retryAfterMs: error.retryAfterMs,
+        })
         return
       }
       if (error instanceof CloudServiceError) {
-        writeError(res, error.status, error.publicMessage, this.options.corsOrigin)
+        writeError(res, error.status, error.publicMessage, this.options.corsOrigin, {
+          policyCode: error.policyCode,
+          retryAfterMs: error.retryAfterMs,
+        })
         return
       }
       writeError(res, 500, 'Internal server error.', this.options.corsOrigin)

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module'
 import {
+  ControlPlaneQuotaExceededError,
   generateChannelInteractionToken,
   generateCloudApiToken,
   hashChannelInteractionToken,
@@ -28,9 +29,12 @@ import type {
   ChannelSessionBindingRecord,
   ClaimDueWorkflowRunInput,
   ClaimChannelDeliveryInput,
+  ClaimRateLimitInput,
   ClaimedWorkflowRunRecord,
+  CloudAuthBackoffRecord,
   CloudWorkflowRecord,
   CloudWorkflowRunRecord,
+  ConsumeUsageQuotaInput,
   CompleteWorkflowRunInput,
   ControlPlaneCommandStatus,
   ControlPlaneRole,
@@ -58,6 +62,8 @@ import type {
   PrincipalMembershipRecord,
   RecordAuditEventInput,
   RecordByokSecretValidationInput,
+  RecordCloudAuthFailureInput,
+  RecordUsageEventInput,
   RevokeApiTokenInput,
   ResolveChannelInteractionInput,
   ResolveChannelInteractionWithCommandInput,
@@ -72,6 +78,7 @@ import type {
   ThreadSmartFilterRecord,
   ThreadTagLinkInput,
   ThreadTagRecord,
+  UsageEventRecord,
   UpdateChannelBindingInput,
   UpdateChannelCursorInput,
   UpdateHeadlessAgentInput,
@@ -251,6 +258,20 @@ function normalizeNonNegativeInteger(value: unknown, label: string) {
   return parsed
 }
 
+function normalizePositiveInteger(value: unknown, label: string) {
+  const parsed = Number(value ?? 0)
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${label} must be a positive integer.`)
+  return parsed
+}
+
+function windowStart(nowMs: number, windowMs: number) {
+  return Math.floor(nowMs / windowMs) * windowMs
+}
+
+function retryAfterMs(nowMs: number, windowStartedAtMs: number, windowMs: number) {
+  return Math.max(1, windowStartedAtMs + windowMs - nowMs)
+}
+
 function normalizeProvider(value: unknown): ChannelProviderId {
   const provider = normalizeText(value, 32, 'Channel provider') as ChannelProviderId
   if (!['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(provider)) {
@@ -360,6 +381,19 @@ function auditEventFromRow(row: QueryRow): AuditEventRecord {
     eventType: String(row.event_type),
     targetType: stringOrNull(row.target_type),
     targetId: stringOrNull(row.target_id),
+    metadata: jsonRecord(row.metadata),
+    createdAt: iso(row.created_at),
+  }
+}
+
+function usageEventFromRow(row: QueryRow): UsageEventRecord {
+  return {
+    eventId: String(row.event_id),
+    orgId: String(row.org_id),
+    accountId: stringOrNull(row.account_id),
+    eventType: String(row.event_type),
+    quantity: numberValue(row.quantity),
+    unit: String(row.unit),
     metadata: jsonRecord(row.metadata),
     createdAt: iso(row.created_at),
   }
@@ -679,6 +713,18 @@ function webhookAuthFailureFromRow(row: QueryRow): WebhookAuthFailureRecord {
   }
 }
 
+function cloudAuthBackoffFromRow(row: QueryRow, nowMs: number): CloudAuthBackoffRecord {
+  const blockedUntilMs = numberValue(row.blocked_until_ms)
+  return {
+    allowed: blockedUntilMs <= nowMs,
+    scope: String(row.scope),
+    source: String(row.source),
+    failureCount: numberValue(row.auth_failure_count),
+    blockedUntilMs,
+    retryAfterMs: Math.max(0, blockedUntilMs - nowMs),
+  }
+}
+
 export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWebhookSecurityStore {
   private readonly pool: PgPool
   private readonly ownsPool: boolean
@@ -991,6 +1037,116 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       [orgId, Math.max(1, Math.min(limit, 500))],
     )
     return result.rows.map(auditEventFromRow)
+  }
+
+  async consumeUsageQuota(input: ConsumeUsageQuotaInput) {
+    return this.withTransaction((client) => this.consumeUsageQuotaWithExecutor(client, input))
+  }
+
+  async recordUsageEvent(input: RecordUsageEventInput) {
+    return this.recordUsageEventWithExecutor(this.pool, input)
+  }
+
+  async listUsageEvents(orgId: string, limit = 100) {
+    const result = await this.pool.query(
+      `SELECT * FROM cloud_usage_events
+       WHERE org_id = $1
+       ORDER BY created_at DESC, event_id DESC
+       LIMIT $2`,
+      [orgId, Math.max(1, Math.min(limit, 500))],
+    )
+    return result.rows.map(usageEventFromRow)
+  }
+
+  async claimRateLimit(input: ClaimRateLimitInput) {
+    const limit = normalizePositiveInteger(input.limit, 'Rate limit')
+    const windowMs = normalizePositiveInteger(input.windowMs, 'Rate-limit window')
+    const now = input.now || new Date()
+    const nowMs = now.getTime()
+    const startedAtMs = windowStart(nowMs, windowMs)
+    const result = await this.pool.query(
+      `INSERT INTO cloud_rate_limits (scope, source, window_started_at_ms, count)
+       VALUES ($1, $2, $3, 1)
+       ON CONFLICT (scope, source) DO UPDATE
+       SET window_started_at_ms = CASE
+             WHEN cloud_rate_limits.window_started_at_ms = $3 THEN cloud_rate_limits.window_started_at_ms
+             ELSE $3
+           END,
+           count = CASE
+             WHEN cloud_rate_limits.window_started_at_ms = $3 THEN cloud_rate_limits.count + 1
+             ELSE 1
+           END
+       RETURNING count, window_started_at_ms`,
+      [input.scope, input.source, startedAtMs],
+    )
+    const count = numberValue(result.rows[0]?.count)
+    const resetMs = retryAfterMs(nowMs, numberValue(result.rows[0]?.window_started_at_ms), windowMs)
+    return {
+      allowed: count <= limit,
+      scope: input.scope,
+      source: input.source,
+      limit,
+      count,
+      resetAt: new Date(nowMs + resetMs).toISOString(),
+      retryAfterMs: resetMs,
+      policyCode: input.policyCode,
+    }
+  }
+
+  async checkCloudAuthBackoff(input: { scope: string, source?: string, now?: Date }) {
+    const nowMs = (input.now || new Date()).getTime()
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_auth_failures WHERE scope = $1`,
+      [input.scope],
+    )
+    if (!row) {
+      return {
+        allowed: true,
+        scope: input.scope,
+        source: input.source || input.scope,
+        failureCount: 0,
+        blockedUntilMs: 0,
+        retryAfterMs: 0,
+      }
+    }
+    return cloudAuthBackoffFromRow(row, nowMs)
+  }
+
+  async recordCloudAuthFailure(input: RecordCloudAuthFailureInput) {
+    const nowMs = (input.now || new Date()).getTime()
+    const windowMs = normalizePositiveInteger(input.windowMs, 'Auth backoff window')
+    const limit = normalizePositiveInteger(input.limit, 'Auth failure limit')
+    const backoffMs = normalizePositiveInteger(input.backoffMs, 'Auth backoff duration')
+    const startedAtMs = windowStart(nowMs, windowMs)
+    const blockedUntilMs = nowMs + backoffMs
+    const result = await this.pool.query(
+      `INSERT INTO cloud_auth_failures (
+        scope, source, auth_window_started_at_ms, auth_failure_count, blocked_until_ms
+       )
+       VALUES ($1, $2, $3, 1, CASE WHEN $4 <= 1 THEN $5 ELSE 0 END)
+       ON CONFLICT (scope) DO UPDATE
+       SET source = EXCLUDED.source,
+           auth_window_started_at_ms = CASE
+             WHEN cloud_auth_failures.auth_window_started_at_ms = $3 THEN cloud_auth_failures.auth_window_started_at_ms
+             ELSE $3
+           END,
+           auth_failure_count = CASE
+             WHEN cloud_auth_failures.auth_window_started_at_ms = $3 THEN cloud_auth_failures.auth_failure_count + 1
+             ELSE 1
+           END,
+           blocked_until_ms = CASE
+             WHEN (
+               CASE
+                 WHEN cloud_auth_failures.auth_window_started_at_ms = $3 THEN cloud_auth_failures.auth_failure_count + 1
+                 ELSE 1
+               END
+             ) >= $4 THEN GREATEST(cloud_auth_failures.blocked_until_ms, $5)
+             ELSE cloud_auth_failures.blocked_until_ms
+           END
+       RETURNING *`,
+      [input.scope, input.source, startedAtMs, limit, blockedUntilMs],
+    )
+    return cloudAuthBackoffFromRow(result.rows[0], nowMs)
   }
 
   async createByokSecret(input: CreateByokSecretInput) {
@@ -1734,6 +1890,23 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
         client,
       )
       if (!selected) return null
+      if (input.quota) {
+        const quota = await this.consumeUsageQuotaWithExecutor(client, {
+          ...input.quota,
+          orgId: input.orgId,
+          now,
+        })
+        if (!quota.allowed) {
+          throw new ControlPlaneQuotaExceededError({
+            message: 'Gateway delivery quota exceeded.',
+            policyCode: quota.policyCode || 'quota.gateway_deliveries_per_hour_exceeded',
+            retryAfterMs: quota.retryAfterMs,
+            limit: quota.limit,
+            used: quota.used,
+            resetAt: quota.resetAt,
+          })
+        }
+      }
       const result = await client.query(
         `UPDATE cloud_channel_deliveries
          SET status = 'claimed',
@@ -1788,27 +1961,63 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     profileName: string
     title?: string | null
     createdAt?: Date
+    quota?: {
+      orgId?: string | null
+      maxConcurrentSessionsPerOrg?: number | null
+      policyCode?: string
+    } | null
   }) {
-    await this.requireTenantUser(input.tenantId, input.userId)
-    const createdAt = nowIso(input.createdAt)
-    await this.pool.query(
-      `INSERT INTO cloud_sessions (
-        tenant_id, session_id, user_id, opencode_session_id, profile_name,
-        status, title, created_at, updated_at
-       )
-       VALUES ($1, $2, $3, $4, $5, 'idle', $6, $7, $7)
-       ON CONFLICT (tenant_id, session_id) DO NOTHING`,
-      [
-        input.tenantId,
-        input.sessionId,
-        input.userId,
-        input.opencodeSessionId,
-        input.profileName,
-        input.title || null,
-        createdAt,
-      ],
-    )
-    return sessionFromRow(await this.requireSession(input.tenantId, input.sessionId))
+    return this.withTransaction(async (client) => {
+      await this.requireTenantUser(input.tenantId, input.userId, client)
+      const existing = await this.maybeOne(
+        `SELECT * FROM cloud_sessions WHERE tenant_id = $1 AND session_id = $2`,
+        [input.tenantId, input.sessionId],
+        client,
+      )
+      if (existing) return sessionFromRow(existing)
+      const maxConcurrentSessions = input.quota?.maxConcurrentSessionsPerOrg
+      if (maxConcurrentSessions && maxConcurrentSessions > 0) {
+        const orgId = input.quota?.orgId || input.tenantId
+        await this.lockQuota(client, orgId, 'concurrent_sessions')
+        const countRow = await this.one(
+          `SELECT count(*)::int AS count
+           FROM cloud_sessions
+           WHERE tenant_id = $1 AND status <> 'closed'`,
+          [input.tenantId],
+          client,
+        )
+        const activeSessions = numberValue(countRow.count)
+        if (activeSessions >= maxConcurrentSessions) {
+          throw new ControlPlaneQuotaExceededError({
+            message: 'Concurrent cloud session quota exceeded.',
+            policyCode: input.quota?.policyCode || 'quota.concurrent_sessions_exceeded',
+            retryAfterMs: 60_000,
+            limit: maxConcurrentSessions,
+            used: activeSessions,
+            resetAt: new Date(Date.now() + 60_000).toISOString(),
+          })
+        }
+      }
+      const createdAt = nowIso(input.createdAt)
+      const result = await client.query(
+        `INSERT INTO cloud_sessions (
+          tenant_id, session_id, user_id, opencode_session_id, profile_name,
+          status, title, created_at, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, 'idle', $6, $7, $7)
+         RETURNING *`,
+        [
+          input.tenantId,
+          input.sessionId,
+          input.userId,
+          input.opencodeSessionId,
+          input.profileName,
+          input.title || null,
+          createdAt,
+        ],
+      )
+      return sessionFromRow(result.rows[0])
+    })
   }
 
   async getSession(tenantId: string, userId: string, sessionId: string) {
@@ -2118,12 +2327,35 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     workerId: string,
     now = new Date(),
     ttlMs = 30_000,
+    quota: {
+      orgId?: string | null
+      maxActiveWorkersPerOrg?: number | null
+      policyCode?: string
+    } | null = null,
   ) {
     return this.withTransaction(async (client) => {
       const session = await this.requireSession(tenantId, sessionId, client, true)
       const lease = await this.getLease(tenantId, sessionId, client, true)
       const nowMs = now.getTime()
       if (lease && lease.leaseExpiresAt > nowMs) return null
+      const maxActiveWorkers = quota?.maxActiveWorkersPerOrg
+      if (maxActiveWorkers && maxActiveWorkers > 0) {
+        const orgId = quota.orgId || tenantId
+        await this.lockQuota(client, orgId, 'active_workers')
+        const countRow = await this.one(
+          `SELECT count(*)::int AS count
+           FROM cloud_worker_leases leases
+           JOIN cloud_sessions sessions
+             ON sessions.tenant_id = leases.tenant_id
+            AND sessions.session_id = leases.session_id
+           WHERE sessions.tenant_id = $1
+             AND leases.lease_expires_at_ms > $2`,
+          [tenantId, nowMs],
+          client,
+        )
+        const activeWorkers = numberValue(countRow.count)
+        if (activeWorkers >= maxActiveWorkers) return null
+      }
       const attempt = numberValue(session.next_lease_attempt) + 1
       const leaseRecord: WorkerLeaseRecord = {
         tenantId,
@@ -3060,6 +3292,11 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   }
 
   async clear() {
+    await this.pool.query('DELETE FROM cloud_auth_failures')
+    await this.pool.query('DELETE FROM cloud_rate_limits')
+    await this.pool.query('DELETE FROM cloud_quota_locks')
+    await this.pool.query('DELETE FROM cloud_usage_counters')
+    await this.pool.query('DELETE FROM cloud_usage_events')
     await this.pool.query('DELETE FROM cloud_webhook_replay_claims')
     await this.pool.query('DELETE FROM cloud_webhook_auth_failures')
     await this.pool.query('DELETE FROM cloud_webhook_rate_limits')
@@ -3095,6 +3332,115 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     const existing = await this.maybeOne(`SELECT * FROM cloud_audit_events WHERE event_id = $1`, [eventId], executor)
     if (!existing) throw new Error(`Audit event ${eventId} was not recorded.`)
     return auditEventFromRow(existing)
+  }
+
+  private async recordUsageEventWithExecutor(
+    executor: PgExecutor,
+    input: RecordUsageEventInput,
+  ): Promise<UsageEventRecord> {
+    const eventId = input.eventId || `usage_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+    const result = await executor.query(
+      `INSERT INTO cloud_usage_events (
+        event_id, org_id, account_id, event_type, quantity, unit, metadata, created_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+       ON CONFLICT (event_id) DO NOTHING
+       RETURNING *`,
+      [
+        eventId,
+        input.orgId,
+        input.accountId || null,
+        input.eventType,
+        normalizePositiveInteger(input.quantity || 1, 'Usage quantity'),
+        input.unit || 'count',
+        JSON.stringify(redactAuditMetadata(input.metadata)),
+        nowIso(input.createdAt),
+      ],
+    )
+    if (result.rows[0]) return usageEventFromRow(result.rows[0])
+    const existing = await this.maybeOne(`SELECT * FROM cloud_usage_events WHERE event_id = $1`, [eventId], executor)
+    if (!existing) throw new Error(`Usage event ${eventId} was not recorded.`)
+    return usageEventFromRow(existing)
+  }
+
+  private async consumeUsageQuotaWithExecutor(
+    executor: PgExecutor,
+    input: ConsumeUsageQuotaInput,
+  ) {
+    const limit = normalizePositiveInteger(input.limit, 'Quota limit')
+    const quantity = normalizePositiveInteger(input.quantity || 1, 'Quota quantity')
+    const windowMs = normalizePositiveInteger(input.windowMs, 'Quota window')
+    const now = input.now || new Date()
+    const nowMs = now.getTime()
+    const startedAtMs = windowStart(nowMs, windowMs)
+    await executor.query(
+      `INSERT INTO cloud_usage_counters (org_id, quota_key, window_started_at_ms, quantity)
+       VALUES ($1, $2, $3, 0)
+       ON CONFLICT (org_id, quota_key) DO NOTHING`,
+      [input.orgId, input.quotaKey, startedAtMs],
+    )
+    const row = await this.one(
+      `SELECT * FROM cloud_usage_counters
+       WHERE org_id = $1 AND quota_key = $2
+       FOR UPDATE`,
+      [input.orgId, input.quotaKey],
+      executor,
+    )
+    const currentStartedAtMs = numberValue(row.window_started_at_ms)
+    const currentQuantity = currentStartedAtMs === startedAtMs ? numberValue(row.quantity) : 0
+    const nextQuantity = currentQuantity + quantity
+    const resetMs = retryAfterMs(nowMs, startedAtMs, windowMs)
+    const resetAt = new Date(nowMs + resetMs).toISOString()
+    if (nextQuantity > limit) {
+      return {
+        allowed: false,
+        orgId: input.orgId,
+        quotaKey: input.quotaKey,
+        limit,
+        used: currentQuantity,
+        remaining: Math.max(0, limit - currentQuantity),
+        resetAt,
+        retryAfterMs: resetMs,
+        policyCode: input.policyCode,
+      }
+    }
+    await executor.query(
+      `UPDATE cloud_usage_counters
+       SET window_started_at_ms = $3, quantity = $4
+       WHERE org_id = $1 AND quota_key = $2`,
+      [input.orgId, input.quotaKey, startedAtMs, nextQuantity],
+    )
+    return {
+      allowed: true,
+      orgId: input.orgId,
+      quotaKey: input.quotaKey,
+      limit,
+      used: nextQuantity,
+      remaining: Math.max(0, limit - nextQuantity),
+      resetAt,
+      retryAfterMs: resetMs,
+      policyCode: input.policyCode,
+    }
+  }
+
+  private async lockQuota(
+    executor: PgExecutor,
+    orgId: string,
+    quotaKey: string,
+    now = new Date(),
+  ) {
+    await executor.query(
+      `INSERT INTO cloud_quota_locks (org_id, quota_key, updated_at)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (org_id, quota_key) DO UPDATE
+       SET updated_at = EXCLUDED.updated_at`,
+      [orgId, quotaKey, now.toISOString()],
+    )
+    await this.one(
+      `SELECT * FROM cloud_quota_locks WHERE org_id = $1 AND quota_key = $2 FOR UPDATE`,
+      [orgId, quotaKey],
+      executor,
+    )
   }
 
   private async requireTenant(tenantId: string, executor: PgExecutor = this.pool) {

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -476,6 +476,50 @@ export const CLOUD_CONTROL_PLANE_BYOK_SECRETS_STATEMENTS = [
     WHERE status = 'active'`,
 ] as const
 
+export const CLOUD_CONTROL_PLANE_USAGE_QUOTAS_MIGRATION_ID = '005_usage_quotas_rate_limits'
+
+export const CLOUD_CONTROL_PLANE_USAGE_QUOTAS_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS cloud_usage_events (
+    event_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    account_id text REFERENCES cloud_accounts(account_id) ON DELETE SET NULL,
+    event_type text NOT NULL,
+    quantity bigint NOT NULL,
+    unit text NOT NULL,
+    metadata jsonb NOT NULL,
+    created_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_usage_events_org_created_idx
+    ON cloud_usage_events (org_id, created_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS cloud_usage_counters (
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    quota_key text NOT NULL,
+    window_started_at_ms bigint NOT NULL,
+    quantity bigint NOT NULL,
+    PRIMARY KEY (org_id, quota_key)
+  )`,
+  `CREATE TABLE IF NOT EXISTS cloud_quota_locks (
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    quota_key text NOT NULL,
+    updated_at timestamptz NOT NULL,
+    PRIMARY KEY (org_id, quota_key)
+  )`,
+  `CREATE TABLE IF NOT EXISTS cloud_rate_limits (
+    scope text NOT NULL,
+    source text NOT NULL,
+    window_started_at_ms bigint NOT NULL,
+    count integer NOT NULL,
+    PRIMARY KEY (scope, source)
+  )`,
+  `CREATE TABLE IF NOT EXISTS cloud_auth_failures (
+    scope text PRIMARY KEY,
+    source text NOT NULL,
+    auth_window_started_at_ms bigint NOT NULL,
+    auth_failure_count integer NOT NULL,
+    blocked_until_ms bigint NOT NULL
+  )`,
+] as const
+
 export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration[] = [
   {
     id: CLOUD_CONTROL_PLANE_MIGRATION_ID,
@@ -492,5 +536,9 @@ export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration
   {
     id: CLOUD_CONTROL_PLANE_BYOK_SECRETS_MIGRATION_ID,
     statements: CLOUD_CONTROL_PLANE_BYOK_SECRETS_STATEMENTS,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_USAGE_QUOTAS_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_USAGE_QUOTAS_STATEMENTS,
   },
 ] as const

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -25,6 +25,7 @@ import {
   listCapabilitySkills,
   listCapabilityTools,
 } from '../capability-catalog.ts'
+import { ControlPlaneQuotaExceededError } from './control-plane-store.ts'
 import type {
   ApiTokenScope,
   ChannelBindingRecord,
@@ -40,12 +41,14 @@ import type {
   ControlPlaneStore,
   HeadlessAgentRecord,
   IssuedChannelInteractionRecord,
+  QuotaPolicyCode,
   SessionCommandRecord,
   SessionEventRecord,
   SessionProjectionRecord,
   SessionRecord,
   ThreadSmartFilterRecord,
   ThreadTagRecord,
+  UsageEventRecord,
   WorkerLeaseRecord,
 } from './control-plane-store.ts'
 import type { ByokSecretMetadata, ByokSecretStore } from './byok-secret-store.ts'
@@ -64,6 +67,7 @@ import {
   type WorkflowWebhookAuth,
   type WorkflowWebhookSecurityStore,
 } from '../workflow/workflow-webhook-server.ts'
+import type { CloudAbuseConfig } from '../config-types.ts'
 
 export type CloudPrincipal = {
   tenantId: string
@@ -111,11 +115,18 @@ export type ByokManagementPolicy = {
 export class CloudServiceError extends Error {
   readonly status: number
   readonly publicMessage: string
+  readonly policyCode: string | null
+  readonly retryAfterMs: number | null
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, details: {
+    policyCode?: string | null
+    retryAfterMs?: number | null
+  } = {}) {
     super(message)
     this.status = status
     this.publicMessage = message
+    this.policyCode = details.policyCode || null
+    this.retryAfterMs = details.retryAfterMs || null
   }
 }
 
@@ -155,6 +166,8 @@ export type CloudSessionView = {
 type CreateCloudSessionRecordInput = {
   tenantId: string
   userId: string
+  orgId?: string | null
+  accountId?: string | null
   profileName: string
   sessionId?: string | null
   title?: string | null
@@ -218,6 +231,27 @@ const WORKFLOW_MAX_LIST_VALUES = 100
 const WORKFLOW_VALID_TRIGGER_TYPES = new Set<WorkflowTriggerType>(['manual', 'schedule', 'webhook'])
 const WEBHOOK_SIGNATURE_REPLAY_WINDOW_MS = 5 * 60 * 1000
 const WEBHOOK_SIGNATURE_REPLAY_CACHE_LIMIT = 512
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+const DISABLED_ABUSE_POLICY: CloudAbuseConfig = {
+  enabled: false,
+  maxConcurrentSessionsPerOrg: null,
+  maxActiveWorkersPerOrg: null,
+  maxPromptsPerHour: null,
+  maxGatewayDeliveriesPerHour: null,
+  maxArtifactBytesPerDay: null,
+  httpRateLimit: {
+    enabled: false,
+    windowMs: 60 * 1000,
+    maxRequests: 600,
+  },
+  authBackoff: {
+    enabled: false,
+    windowMs: 60 * 1000,
+    maxFailures: 10,
+    backoffMs: 60 * 1000,
+  },
+}
 const EMPTY_SESSION_TOKENS: SessionTokens = {
   input: 0,
   output: 0,
@@ -1000,6 +1034,7 @@ export class CloudSessionService {
   private readonly ids: { randomUUID: () => string }
   private readonly byokSecrets: ByokSecretStore | null
   private readonly byokPolicy: ByokManagementPolicy
+  private readonly abuse: CloudAbuseConfig
 
   constructor(
     store: ControlPlaneStore,
@@ -1010,6 +1045,7 @@ export class CloudSessionService {
     workspaceEvents = new CloudWorkspaceEventBus(),
     byokSecrets: ByokSecretStore | null = null,
     byokPolicy: ByokManagementPolicy = {},
+    abuse: CloudAbuseConfig = DISABLED_ABUSE_POLICY,
   ) {
     this.store = store
     this.runtime = runtime
@@ -1019,6 +1055,7 @@ export class CloudSessionService {
     this.ids = ids
     this.byokSecrets = byokSecrets
     this.byokPolicy = byokPolicy
+    this.abuse = abuse
   }
 
   get eventBus() {
@@ -1027,6 +1064,63 @@ export class CloudSessionService {
 
   get workspaceEventBus() {
     return this.workspaceEvents
+  }
+
+  private quotaLimit(value: number | null | undefined) {
+    if (!this.abuse.enabled) return null
+    return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null
+  }
+
+  private quotaError(message: string, policyCode: QuotaPolicyCode | string, retryAfterMs: number | null) {
+    return new CloudServiceError(429, message, { policyCode, retryAfterMs })
+  }
+
+  private translateQuotaError(error: unknown, fallbackMessage: string, fallbackPolicyCode: QuotaPolicyCode | string): never {
+    if (error instanceof ControlPlaneQuotaExceededError) {
+      throw this.quotaError(
+        error.publicMessage || fallbackMessage,
+        error.policyCode || fallbackPolicyCode,
+        error.retryAfterMs,
+      )
+    }
+    throw error
+  }
+
+  private async consumeQuota(input: {
+    orgId: string
+    quotaKey: string
+    limit: number | null | undefined
+    quantity?: number
+    windowMs: number
+    policyCode: QuotaPolicyCode
+    message: string
+  }) {
+    const limit = this.quotaLimit(input.limit)
+    if (!limit) return null
+    const result = await this.store.consumeUsageQuota({
+      orgId: input.orgId,
+      quotaKey: input.quotaKey,
+      limit,
+      quantity: input.quantity,
+      windowMs: input.windowMs,
+      policyCode: input.policyCode,
+    })
+    if (!result.allowed) {
+      throw this.quotaError(input.message, input.policyCode, result.retryAfterMs)
+    }
+    return result
+  }
+
+  private async recordUsage(input: {
+    orgId: string
+    accountId?: string | null
+    eventType: UsageEventRecord['eventType']
+    quantity?: number
+    unit?: UsageEventRecord['unit']
+    metadata?: Record<string, unknown>
+  }) {
+    if (!this.abuse.enabled) return null
+    return this.store.recordUsageEvent(input)
   }
 
   async ensurePrincipal(principal: CloudPrincipal) {
@@ -1075,6 +1169,8 @@ export class CloudSessionService {
     const session = await this.createCloudSessionRecord({
       tenantId: principal.tenantId,
       userId: principal.userId,
+      orgId: this.principalOrgId(principal),
+      accountId: principal.accountId || principal.userId,
       profileName,
     })
     return this.getSessionView(principal, session.sessionId)
@@ -1484,6 +1580,14 @@ export class CloudSessionService {
       targetId: binding.sessionId,
       metadata: { identityId: actor.identityId, provider: actor.provider },
     })
+    await this.consumeQuota({
+      orgId: this.principalOrgId(principal),
+      quotaKey: 'prompts:hour',
+      limit: this.abuse.maxPromptsPerHour,
+      windowMs: HOUR_MS,
+      policyCode: 'quota.prompts_per_hour_exceeded',
+      message: 'Cloud prompt quota exceeded.',
+    })
     const command = await this.store.enqueueSessionCommand({
       commandId: this.ids.randomUUID(),
       tenantId: principal.tenantId,
@@ -1493,6 +1597,18 @@ export class CloudSessionService {
       payload: {
         text: input.text,
         agent: input.agent || 'build',
+      },
+    })
+    await this.recordUsage({
+      orgId: this.principalOrgId(principal),
+      accountId: actor.accountId,
+      eventType: 'prompt.enqueued',
+      unit: 'count',
+      metadata: {
+        tenantId: principal.tenantId,
+        sessionId: binding.sessionId,
+        source: 'gateway',
+        provider: actor.provider,
       },
     })
     return { binding, command }
@@ -1625,12 +1741,38 @@ export class CloudSessionService {
   ): Promise<ChannelDeliveryRecord | null> {
     await this.ensurePrincipal(principal)
     this.assertGatewayAccess(principal)
-    return this.store.claimNextChannelDelivery({
-      orgId: this.principalOrgId(principal),
-      claimedBy: input.claimedBy,
-      ttlMs: input.ttlMs,
-      now: input.now,
-    })
+    try {
+      const delivery = await this.store.claimNextChannelDelivery({
+        orgId: this.principalOrgId(principal),
+        claimedBy: input.claimedBy,
+        ttlMs: input.ttlMs,
+        now: input.now,
+        quota: this.quotaLimit(this.abuse.maxGatewayDeliveriesPerHour)
+          ? {
+              quotaKey: 'gateway_deliveries:hour',
+              limit: this.abuse.maxGatewayDeliveriesPerHour!,
+              windowMs: HOUR_MS,
+              policyCode: 'quota.gateway_deliveries_per_hour_exceeded',
+            }
+          : null,
+      })
+      if (delivery) {
+        await this.recordUsage({
+          orgId: this.principalOrgId(principal),
+          accountId: principal.accountId || null,
+          eventType: 'gateway.delivery.claimed',
+          unit: 'count',
+          metadata: {
+            deliveryId: delivery.deliveryId,
+            provider: delivery.provider,
+            claimedBy: input.claimedBy,
+          },
+        })
+      }
+      return delivery
+    } catch (error) {
+      this.translateQuotaError(error, 'Gateway delivery quota exceeded.', 'quota.gateway_deliveries_per_hour_exceeded')
+    }
   }
 
   async ackChannelDelivery(
@@ -2007,14 +2149,112 @@ export class CloudSessionService {
     })
   }
 
+  async assertArtifactUploadAllowed(principal: CloudPrincipal, bytes: number) {
+    await this.consumeQuota({
+      orgId: this.principalOrgId(principal),
+      quotaKey: 'artifact_bytes:day',
+      limit: this.abuse.maxArtifactBytesPerDay,
+      quantity: bytes,
+      windowMs: DAY_MS,
+      policyCode: 'quota.artifact_bytes_per_day_exceeded',
+      message: 'Cloud artifact upload quota exceeded.',
+    })
+  }
+
+  async recordArtifactUploaded(principal: CloudPrincipal, sessionId: string, artifactId: string, bytes: number) {
+    await this.recordUsage({
+      orgId: this.principalOrgId(principal),
+      accountId: principal.accountId || principal.userId,
+      eventType: 'artifact.uploaded',
+      quantity: bytes,
+      unit: 'byte',
+      metadata: { tenantId: principal.tenantId, sessionId, artifactId },
+    })
+  }
+
+  async recordWorkerMinutes(input: {
+    tenantId: string
+    sessionId: string
+    workerId: string
+    elapsedMs: number
+  }) {
+    if (!this.abuse.enabled) return null
+    const org = await this.store.ensureOrgForTenant({ tenantId: input.tenantId, name: input.tenantId })
+    const minutes = Math.max(1, Math.ceil(input.elapsedMs / 60_000))
+    return this.store.recordUsageEvent({
+      orgId: org.orgId,
+      eventType: 'worker.minute',
+      quantity: minutes,
+      unit: 'minute',
+      metadata: {
+        tenantId: input.tenantId,
+        sessionId: input.sessionId,
+        workerId: input.workerId,
+        elapsedMs: Math.max(0, Math.round(input.elapsedMs)),
+      },
+    })
+  }
+
+  async listUsageEvents(principal: CloudPrincipal, limit?: number) {
+    await this.ensurePrincipal(principal)
+    return this.store.listUsageEvents(this.principalOrgId(principal), limit)
+  }
+
+  async claimHttpRateLimit(input: {
+    scope: string
+    source: string
+    now?: Date
+  }) {
+    if (!this.abuse.enabled || !this.abuse.httpRateLimit.enabled) return null
+    const result = await this.store.claimRateLimit({
+      scope: input.scope,
+      source: input.source,
+      limit: this.abuse.httpRateLimit.maxRequests,
+      windowMs: this.abuse.httpRateLimit.windowMs,
+      now: input.now,
+      policyCode: 'rate_limit.http_exceeded',
+    })
+    if (!result.allowed) {
+      throw this.quotaError('Too many cloud requests. Try again later.', 'rate_limit.http_exceeded', result.retryAfterMs)
+    }
+    return result
+  }
+
+  async checkCloudAuthBackoff(input: { scope: string, source?: string, now?: Date }) {
+    if (!this.abuse.enabled || !this.abuse.authBackoff.enabled) return null
+    const result = await this.store.checkCloudAuthBackoff(input)
+    if (!result.allowed) {
+      throw this.quotaError('Too many rejected cloud authentication attempts. Try again later.', 'auth.backoff', result.retryAfterMs)
+    }
+    return result
+  }
+
+  async recordCloudAuthFailure(input: { scope: string, source: string, now?: Date }) {
+    if (!this.abuse.enabled || !this.abuse.authBackoff.enabled) return null
+    return this.store.recordCloudAuthFailure({
+      ...input,
+      windowMs: this.abuse.authBackoff.windowMs,
+      limit: this.abuse.authBackoff.maxFailures,
+      backoffMs: this.abuse.authBackoff.backoffMs,
+    })
+  }
+
   async enqueuePrompt(
     principal: CloudPrincipal,
     sessionId: string,
     input: { text: string, agent?: string | null },
   ): Promise<SessionCommandRecord> {
     await this.getSessionView(principal, sessionId)
+    await this.consumeQuota({
+      orgId: this.principalOrgId(principal),
+      quotaKey: 'prompts:hour',
+      limit: this.abuse.maxPromptsPerHour,
+      windowMs: HOUR_MS,
+      policyCode: 'quota.prompts_per_hour_exceeded',
+      message: 'Cloud prompt quota exceeded.',
+    })
     const commandId = this.ids.randomUUID()
-    return this.store.enqueueSessionCommand({
+    const command = await this.store.enqueueSessionCommand({
       commandId,
       tenantId: principal.tenantId,
       userId: principal.userId,
@@ -2025,6 +2265,14 @@ export class CloudSessionService {
         agent: input.agent || 'build',
       },
     })
+    await this.recordUsage({
+      orgId: this.principalOrgId(principal),
+      accountId: principal.accountId || principal.userId,
+      eventType: 'prompt.enqueued',
+      unit: 'count',
+      metadata: { tenantId: principal.tenantId, sessionId, source: 'api' },
+    })
+    return command
   }
 
   async enqueueAbort(principal: CloudPrincipal, sessionId: string): Promise<SessionCommandRecord> {
@@ -2372,15 +2620,58 @@ export class CloudSessionService {
     }
   }
 
+  private async createStoredSession(input: {
+    tenantId: string
+    userId: string
+    orgId?: string | null
+    accountId?: string | null
+    sessionId: string
+    opencodeSessionId: string
+    profileName: string
+    title?: string | null
+    createdAt?: Date
+  }) {
+    try {
+      const session = await this.store.createSession({
+        tenantId: input.tenantId,
+        userId: input.userId,
+        sessionId: input.sessionId,
+        opencodeSessionId: input.opencodeSessionId,
+        profileName: input.profileName,
+        title: input.title,
+        createdAt: input.createdAt,
+        quota: this.quotaLimit(this.abuse.maxConcurrentSessionsPerOrg)
+          ? {
+              orgId: input.orgId || input.tenantId,
+              maxConcurrentSessionsPerOrg: this.abuse.maxConcurrentSessionsPerOrg,
+              policyCode: 'quota.concurrent_sessions_exceeded',
+            }
+          : null,
+      })
+      await this.recordUsage({
+        orgId: input.orgId || input.tenantId,
+        accountId: input.accountId || input.userId,
+        eventType: 'session.created',
+        unit: 'count',
+        metadata: { tenantId: input.tenantId, userId: input.userId, sessionId: input.sessionId },
+      })
+      return session
+    } catch (error) {
+      this.translateQuotaError(error, 'Concurrent cloud session quota exceeded.', 'quota.concurrent_sessions_exceeded')
+    }
+  }
+
   private async createCloudSessionRecord(input: CreateCloudSessionRecordInput): Promise<SessionRecord> {
     if (input.sessionId) {
       const existing = await this.store.getSessionForTenant(input.tenantId, input.sessionId)
       if (existing) return existing
       const now = new Date()
       const title = input.title || 'New session'
-      await this.store.createSession({
+      await this.createStoredSession({
         tenantId: input.tenantId,
         userId: input.userId,
+        orgId: input.orgId,
+        accountId: input.accountId,
         sessionId: input.sessionId,
         opencodeSessionId: '',
         profileName: input.profileName,
@@ -2400,7 +2691,7 @@ export class CloudSessionService {
       return this.requireSessionRecord(input.tenantId, input.sessionId)
     }
 
-    if (this.shouldCreateRuntimeSessionsEagerly()) {
+    if (this.shouldCreateRuntimeSessionsEagerly() && !this.quotaLimit(this.abuse.maxConcurrentSessionsPerOrg)) {
       const runtimeSession = await this.runtime.createSession({
         profileName: input.profileName,
         context: this.runtimeContext({
@@ -2410,9 +2701,11 @@ export class CloudSessionService {
         }),
       })
       const title = input.title || runtimeSession.title
-      await this.store.createSession({
+      await this.createStoredSession({
         tenantId: input.tenantId,
         userId: input.userId,
+        orgId: input.orgId,
+        accountId: input.accountId,
         sessionId: runtimeSession.id,
         opencodeSessionId: runtimeSession.id,
         profileName: input.profileName,
@@ -2432,9 +2725,11 @@ export class CloudSessionService {
     const now = new Date()
     const sessionId = this.ids.randomUUID()
     const title = input.title || 'New session'
-    await this.store.createSession({
+    await this.createStoredSession({
       tenantId: input.tenantId,
       userId: input.userId,
+      orgId: input.orgId,
+      accountId: input.accountId,
       sessionId,
       opencodeSessionId: '',
       profileName: input.profileName,

--- a/apps/desktop/src/main/cloud/worker.ts
+++ b/apps/desktop/src/main/cloud/worker.ts
@@ -1,6 +1,7 @@
 import type { ControlPlaneStore, WorkerLeaseRecord } from './control-plane-store.ts'
 import type { CloudRuntimeEvent } from './runtime-adapter.ts'
 import type { CloudSessionService } from './session-service.ts'
+import type { CloudAbuseConfig } from '../config-types.ts'
 
 export type CloudWorkerCheckpointHooks = {
   restoreBeforeCommands?: (lease: WorkerLeaseRecord) => Promise<void>
@@ -15,6 +16,7 @@ export class CloudWorker {
   private readonly workerId: string
   private readonly leaseTtlMs: number
   private readonly checkpointHooks: CloudWorkerCheckpointHooks
+  private readonly abuse: CloudAbuseConfig | null
 
   constructor(
     store: ControlPlaneStore,
@@ -22,12 +24,14 @@ export class CloudWorker {
     workerId: string,
     leaseTtlMs = 30_000,
     checkpointHooks: CloudWorkerCheckpointHooks = {},
+    abuse: CloudAbuseConfig | null = null,
   ) {
     this.store = store
     this.service = service
     this.workerId = workerId
     this.leaseTtlMs = leaseTtlMs
     this.checkpointHooks = checkpointHooks
+    this.abuse = abuse
   }
 
   async processSessionCommands(tenantId: string, sessionId: string): Promise<number> {
@@ -43,7 +47,17 @@ export class CloudWorker {
     while (true) {
       const command = await this.store.claimNextSessionCommand(lease)
       if (!command) break
-      await this.service.executeCommand(lease, command)
+      const startedAt = Date.now()
+      try {
+        await this.service.executeCommand(lease, command)
+      } finally {
+        await this.service.recordWorkerMinutes({
+          tenantId,
+          sessionId,
+          workerId: this.workerId,
+          elapsedMs: Date.now() - startedAt,
+        })
+      }
       lease = await this.store.checkpointSession(lease)
       await this.checkpointHooks.saveAfterCommand?.(lease)
       this.leases.set(this.leaseKey(tenantId, sessionId), lease)
@@ -93,7 +107,20 @@ export class CloudWorker {
         this.leases.delete(leaseKey)
       }
     }
-    const claimed = await this.store.claimSessionLease(tenantId, sessionId, this.workerId, new Date(), this.leaseTtlMs)
+    const claimed = await this.store.claimSessionLease(
+      tenantId,
+      sessionId,
+      this.workerId,
+      new Date(),
+      this.leaseTtlMs,
+      this.abuse?.enabled && this.abuse.maxActiveWorkersPerOrg
+        ? {
+            orgId: tenantId,
+            maxActiveWorkersPerOrg: this.abuse.maxActiveWorkersPerOrg,
+            policyCode: 'quota.active_workers_exceeded',
+          }
+        : null,
+    )
     if (claimed) this.leases.set(leaseKey, claimed)
     return claimed
   }

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -217,6 +217,45 @@ function normalizeCloudFeatures(raw: Partial<CloudFeatureConfig> | undefined): C
   }
 }
 
+function nullablePositiveNumber(value: unknown, fallback: number | null): number | null {
+  if (value === null) return null
+  const parsed = Number(value ?? fallback)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function normalizeCloudAbuseConfig(raw: CloudConfig['abuse'] | undefined): CloudConfig['abuse'] {
+  const defaults = DEFAULT_CONFIG.cloud.abuse
+  return {
+    ...defaults,
+    ...(raw || {}),
+    enabled: typeof raw?.enabled === 'boolean' ? raw.enabled : defaults.enabled,
+    maxConcurrentSessionsPerOrg: nullablePositiveNumber(raw?.maxConcurrentSessionsPerOrg, defaults.maxConcurrentSessionsPerOrg),
+    maxActiveWorkersPerOrg: nullablePositiveNumber(raw?.maxActiveWorkersPerOrg, defaults.maxActiveWorkersPerOrg),
+    maxPromptsPerHour: nullablePositiveNumber(raw?.maxPromptsPerHour, defaults.maxPromptsPerHour),
+    maxGatewayDeliveriesPerHour: nullablePositiveNumber(raw?.maxGatewayDeliveriesPerHour, defaults.maxGatewayDeliveriesPerHour),
+    maxArtifactBytesPerDay: nullablePositiveNumber(raw?.maxArtifactBytesPerDay, defaults.maxArtifactBytesPerDay),
+    httpRateLimit: {
+      ...defaults.httpRateLimit,
+      ...(raw?.httpRateLimit || {}),
+      enabled: typeof raw?.httpRateLimit?.enabled === 'boolean'
+        ? raw.httpRateLimit.enabled
+        : defaults.httpRateLimit.enabled,
+      windowMs: nullablePositiveNumber(raw?.httpRateLimit?.windowMs, defaults.httpRateLimit.windowMs) || defaults.httpRateLimit.windowMs,
+      maxRequests: nullablePositiveNumber(raw?.httpRateLimit?.maxRequests, defaults.httpRateLimit.maxRequests) || defaults.httpRateLimit.maxRequests,
+    },
+    authBackoff: {
+      ...defaults.authBackoff,
+      ...(raw?.authBackoff || {}),
+      enabled: typeof raw?.authBackoff?.enabled === 'boolean'
+        ? raw.authBackoff.enabled
+        : defaults.authBackoff.enabled,
+      windowMs: nullablePositiveNumber(raw?.authBackoff?.windowMs, defaults.authBackoff.windowMs) || defaults.authBackoff.windowMs,
+      maxFailures: nullablePositiveNumber(raw?.authBackoff?.maxFailures, defaults.authBackoff.maxFailures) || defaults.authBackoff.maxFailures,
+      backoffMs: nullablePositiveNumber(raw?.authBackoff?.backoffMs, defaults.authBackoff.backoffMs) || defaults.authBackoff.backoffMs,
+    },
+  }
+}
+
 function normalizeCloudProfile(raw: CloudProfileConfig | undefined): CloudProfileConfig {
   return {
     ...(raw || {}),
@@ -302,6 +341,7 @@ function normalizeCloudConfig(raw: CloudConfig | undefined): CloudConfig {
       allowedHostProjectDirectories: stringArray(source.runtime?.allowedHostProjectDirectories),
     },
     features: normalizeCloudFeatures(source.features),
+    abuse: normalizeCloudAbuseConfig(source.abuse),
   }
 }
 

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -262,6 +262,30 @@ export type CloudStorageConfig = {
   }
 }
 
+export type CloudRateLimitConfig = {
+  enabled: boolean
+  windowMs: number
+  maxRequests: number
+}
+
+export type CloudAuthBackoffConfig = {
+  enabled: boolean
+  windowMs: number
+  maxFailures: number
+  backoffMs: number
+}
+
+export type CloudAbuseConfig = {
+  enabled: boolean
+  maxConcurrentSessionsPerOrg: number | null
+  maxActiveWorkersPerOrg: number | null
+  maxPromptsPerHour: number | null
+  maxGatewayDeliveriesPerHour: number | null
+  maxArtifactBytesPerDay: number | null
+  httpRateLimit: CloudRateLimitConfig
+  authBackoff: CloudAuthBackoffConfig
+}
+
 export type CloudDesktopConnectionConfig = {
   baseUrl: string
   label?: string
@@ -284,6 +308,7 @@ export type CloudConfig = {
   storage: CloudStorageConfig
   runtime: CloudRuntimePolicyConfig
   features: CloudFeatureConfig
+  abuse: CloudAbuseConfig
 }
 
 export type OpenCoworkConfig = {
@@ -402,6 +427,26 @@ const DEFAULT_CLOUD_RUNTIME: CloudRuntimePolicyConfig = {
   allowedHostProjectDirectories: [],
 }
 
+const DEFAULT_CLOUD_ABUSE: CloudAbuseConfig = {
+  enabled: true,
+  maxConcurrentSessionsPerOrg: 100,
+  maxActiveWorkersPerOrg: 20,
+  maxPromptsPerHour: 600,
+  maxGatewayDeliveriesPerHour: 1000,
+  maxArtifactBytesPerDay: 10 * 1024 * 1024 * 1024,
+  httpRateLimit: {
+    enabled: true,
+    windowMs: 60 * 1000,
+    maxRequests: 600,
+  },
+  authBackoff: {
+    enabled: true,
+    windowMs: 60 * 1000,
+    maxFailures: 10,
+    backoffMs: 60 * 1000,
+  },
+}
+
 const DEFAULT_CLOUD_DESKTOP: CloudDesktopConfig = {
   enabled: true,
   allowUserAddedConnections: true,
@@ -472,6 +517,7 @@ export const DEFAULT_CONFIG: OpenCoworkConfig = {
     },
     runtime: DEFAULT_CLOUD_RUNTIME,
     features: DEFAULT_CLOUD_FEATURES,
+    abuse: DEFAULT_CLOUD_ABUSE,
     profiles: {
       full: {
         label: 'Full app',

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -106,7 +106,9 @@ OPEN_COWORK_TEST_POSTGRES_URL='postgres://...' pnpm test tests/cloud-postgres-co
 
 That gate proves Postgres row-lock behavior for worker leases, ordered event
 sequence writes, session command idempotency/reclaim, scheduler claims, and
-webhook replay claims.
+webhook replay claims. It also covers quota counter concurrency for prompt
+windows, concurrent session caps, and active worker caps when
+`OPEN_COWORK_TEST_POSTGRES_URL` is set.
 
 CI runs the same cloud gates in the `cloud-gates` job: OpenCode portability
 proof, real Postgres concurrency tests, Compose config validation, cloud OCI
@@ -146,6 +148,32 @@ Set these environment variables in every role:
 | `OPEN_COWORK_CLOUD_OTLP_ENDPOINT` | Optional OpenTelemetry OTLP HTTP base endpoint; exports traces to `/v1/traces` and metrics to `/v1/metrics`. |
 | `OPEN_COWORK_CLOUD_OTLP_HEADERS` | Optional JSON object of OTLP HTTP headers, stored as a secret when it contains collector credentials. |
 | `OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED` | `true` enables worker runtime/workspace checkpoints in object storage. |
+
+Hosted/public deployments should keep abuse controls enabled. The defaults are
+conservative and can be tuned per deployment; set an individual numeric quota
+to `0` to disable that quota for self-hosted/private installs.
+
+| Variable | Meaning |
+| --- | --- |
+| `OPEN_COWORK_CLOUD_ABUSE_ENABLED` | Enables quota, rate-limit, usage, and auth-backoff enforcement. |
+| `OPEN_COWORK_CLOUD_MAX_CONCURRENT_SESSIONS_PER_ORG` | Maximum non-closed cloud sessions per org. |
+| `OPEN_COWORK_CLOUD_MAX_ACTIVE_WORKERS_PER_ORG` | Maximum active worker leases per org. |
+| `OPEN_COWORK_CLOUD_MAX_PROMPTS_PER_HOUR` | Per-org prompt enqueue quota. |
+| `OPEN_COWORK_CLOUD_MAX_GATEWAY_DELIVERIES_PER_HOUR` | Per-org gateway delivery claim quota. |
+| `OPEN_COWORK_CLOUD_MAX_ARTIFACT_BYTES_PER_DAY` | Per-org artifact upload byte quota. |
+| `OPEN_COWORK_CLOUD_HTTP_RATE_LIMIT_ENABLED` | Enables HTTP request rate limiting. |
+| `OPEN_COWORK_CLOUD_HTTP_RATE_LIMIT_WINDOW_MS` | HTTP rate-limit window. |
+| `OPEN_COWORK_CLOUD_HTTP_RATE_LIMIT_MAX_REQUESTS` | Maximum HTTP requests per IP, org, and API token per window. |
+| `OPEN_COWORK_CLOUD_AUTH_BACKOFF_ENABLED` | Enables backoff after repeated rejected authentication attempts. |
+| `OPEN_COWORK_CLOUD_AUTH_BACKOFF_WINDOW_MS` | Auth failure counting window. |
+| `OPEN_COWORK_CLOUD_AUTH_BACKOFF_MAX_FAILURES` | Failures before auth backoff starts. |
+| `OPEN_COWORK_CLOUD_AUTH_BACKOFF_MS` | Backoff duration returned through `Retry-After`. |
+
+Quota and rate-limit failures return `429` with `Retry-After`, `retryAfterMs`,
+and a machine-readable policy code such as
+`quota.prompts_per_hour_exceeded` or `rate_limit.http_exceeded`. Billing or
+plan enforcement can layer separate `402` policy responses on top of this
+control-plane surface.
 
 Role-specific knobs:
 

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -270,7 +270,8 @@
         "auth": { "$ref": "#/$defs/cloudAuth" },
         "storage": { "$ref": "#/$defs/cloudStorage" },
         "runtime": { "$ref": "#/$defs/cloudRuntimePolicy" },
-        "features": { "$ref": "#/$defs/cloudFeatures" }
+        "features": { "$ref": "#/$defs/cloudFeatures" },
+        "abuse": { "$ref": "#/$defs/cloudAbuse" }
       }
     },
     "cloudRole": {
@@ -326,6 +327,49 @@
         "customAgents": { "type": "boolean" },
         "customMcps": { "type": "boolean" }
       }
+    },
+    "cloudAbuse": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "maxConcurrentSessionsPerOrg": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxActiveWorkersPerOrg": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxPromptsPerHour": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxGatewayDeliveriesPerHour": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxArtifactBytesPerDay": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "httpRateLimit": { "$ref": "#/$defs/cloudRateLimit" },
+        "authBackoff": { "$ref": "#/$defs/cloudAuthBackoff" }
+      }
+    },
+    "cloudRateLimit": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "windowMs": { "$ref": "#/$defs/cloudPositiveInteger" },
+        "maxRequests": { "$ref": "#/$defs/cloudPositiveInteger" }
+      }
+    },
+    "cloudAuthBackoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "windowMs": { "$ref": "#/$defs/cloudPositiveInteger" },
+        "maxFailures": { "$ref": "#/$defs/cloudPositiveInteger" },
+        "backoffMs": { "$ref": "#/$defs/cloudPositiveInteger" }
+      }
+    },
+    "cloudPositiveInteger": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "cloudPositiveIntegerOrNull": {
+      "anyOf": [
+        { "$ref": "#/$defs/cloudPositiveInteger" },
+        { "type": "null" }
+      ]
     },
     "cloudRuntimePolicy": {
       "type": "object",

--- a/packages/cloud-client/src/index.ts
+++ b/packages/cloud-client/src/index.ts
@@ -238,6 +238,17 @@ export type CloudRuntimeStatus = {
   heartbeats: unknown[]
 }
 
+export type CloudUsageEventRecord = {
+  eventId: string
+  orgId: string
+  accountId: string | null
+  eventType: string
+  quantity: number
+  unit: string
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
 export type CloudTransportConfig = {
   role: string
   profileName: string
@@ -373,6 +384,7 @@ export type CloudTransportAdapter = {
   setByokSecret?(providerId: string, input: CloudSetByokSecretInput): Promise<CloudByokSecretMetadata>
   validateByokSecret?(providerId: string): Promise<CloudByokSecretMetadata | null>
   deleteByokSecret?(providerId: string): Promise<CloudByokSecretMetadata | null>
+  listUsageEvents?(limit?: number): Promise<CloudUsageEventRecord[]>
   listHeadlessAgents?(): Promise<HeadlessAgentRecord[]>
   createHeadlessAgent?(input: {
     name: string
@@ -1110,6 +1122,9 @@ export function createHttpSseCloudTransportAdapter(
       return (await request<{ secret: CloudByokSecretMetadata | null }>(`/api/byok/${encodePath(providerId)}`, {
         method: 'DELETE',
       })).secret
+    },
+    async listUsageEvents(limit) {
+      return (await request<{ events: CloudUsageEventRecord[] }>(`/api/usage/events${queryString({ limit })}`)).events
     },
     async listHeadlessAgents() {
       return (await request<{ agents: HeadlessAgentRecord[] }>('/api/channels/agents')).agents

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -393,8 +393,10 @@ test('cloud all-in-one app starts web and worker and routes runtime events into 
       body: JSON.stringify({}),
     }))
     assert.equal(asRecord(created.session).tenantId, 'tenant-a')
+    const coworkSessionId = String(asRecord(created.session).sessionId)
+    assert.equal(asRecord(created.session).opencodeSessionId, '')
 
-    const prompted = await readJson(await fetch(`${app.url}/api/sessions/session-1/prompt`, {
+    const prompted = await readJson(await fetch(`${app.url}/api/sessions/${coworkSessionId}/prompt`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -408,7 +410,7 @@ test('cloud all-in-one app starts web and worker and routes runtime events into 
     assert.equal(runtime.prompts.length, 1)
 
     await runtime.emitAssistant('session-1', 'external event')
-    const view = await readJson(await fetch(`${app.url}/api/sessions/session-1`, {
+    const view = await readJson(await fetch(`${app.url}/api/sessions/${coworkSessionId}`, {
       headers: {
         'x-open-cowork-tenant-id': 'tenant-a',
         'x-open-cowork-user-id': 'user-a',

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -1,7 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
+import {
+  ControlPlaneQuotaExceededError,
+  InMemoryControlPlaneStore,
+} from '../apps/desktop/src/main/cloud/control-plane-store.ts'
 
 function seededStore() {
   const store = new InMemoryControlPlaneStore()
@@ -237,6 +240,99 @@ test('cloud control plane records worker heartbeats, settings metadata, and migr
   assert.equal(store.recordSchemaMigration('001_initial').id, '001_initial')
   assert.equal(store.recordSchemaMigration('001_initial').id, '001_initial')
   assert.equal(store.listSchemaMigrations().length, 1)
+})
+
+test('cloud control plane records usage and enforces windowed quotas', () => {
+  const store = seededStore()
+  const orgId = 'tenant-1'
+
+  const first = store.consumeUsageQuota({
+    orgId,
+    quotaKey: 'prompts:hour',
+    limit: 2,
+    quantity: 1,
+    windowMs: 60_000,
+    now: new Date('2026-01-01T00:00:00.000Z'),
+    policyCode: 'quota.prompts_per_hour_exceeded',
+  })
+  const second = store.consumeUsageQuota({
+    orgId,
+    quotaKey: 'prompts:hour',
+    limit: 2,
+    quantity: 1,
+    windowMs: 60_000,
+    now: new Date('2026-01-01T00:00:01.000Z'),
+    policyCode: 'quota.prompts_per_hour_exceeded',
+  })
+  const denied = store.consumeUsageQuota({
+    orgId,
+    quotaKey: 'prompts:hour',
+    limit: 2,
+    quantity: 1,
+    windowMs: 60_000,
+    now: new Date('2026-01-01T00:00:02.000Z'),
+    policyCode: 'quota.prompts_per_hour_exceeded',
+  })
+
+  assert.equal(first.allowed, true)
+  assert.equal(second.remaining, 0)
+  assert.equal(denied.allowed, false)
+  assert.equal(denied.policyCode, 'quota.prompts_per_hour_exceeded')
+  assert.equal(denied.retryAfterMs > 0, true)
+
+  store.recordUsageEvent({
+    orgId,
+    accountId: 'user-1',
+    eventType: 'prompt.enqueued',
+    quantity: 1,
+    unit: 'count',
+    metadata: { token: 'secret-token', safe: 'yes' },
+    createdAt: new Date('2026-01-01T00:00:03.000Z'),
+  })
+  const usage = store.listUsageEvents(orgId)
+  assert.equal(usage.length, 1)
+  assert.equal(usage[0]?.eventType, 'prompt.enqueued')
+  assert.equal(usage[0]?.metadata.token, '[redacted]')
+  assert.equal(usage[0]?.metadata.safe, 'yes')
+})
+
+test('cloud control plane caps concurrent sessions and active workers', () => {
+  const store = seededStore()
+  assert.throws(() => store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-over-limit',
+    opencodeSessionId: 'oc-session-over-limit',
+    profileName: 'full',
+    quota: {
+      orgId: 'tenant-1',
+      maxConcurrentSessionsPerOrg: 1,
+      policyCode: 'quota.concurrent_sessions_exceeded',
+    },
+  }), (error) => (
+    error instanceof ControlPlaneQuotaExceededError
+    && error.policyCode === 'quota.concurrent_sessions_exceeded'
+  ))
+
+  store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-2',
+    opencodeSessionId: 'oc-session-2',
+    profileName: 'full',
+  })
+  const firstLease = store.claimSessionLease('tenant-1', 'session-1', 'worker-a', new Date('2026-01-01T00:00:00.000Z'), 30_000, {
+    orgId: 'tenant-1',
+    maxActiveWorkersPerOrg: 1,
+    policyCode: 'quota.active_workers_exceeded',
+  })
+  const secondLease = store.claimSessionLease('tenant-1', 'session-2', 'worker-b', new Date('2026-01-01T00:00:00.000Z'), 30_000, {
+    orgId: 'tenant-1',
+    maxActiveWorkersPerOrg: 1,
+    policyCode: 'quota.active_workers_exceeded',
+  })
+  assert.ok(firstLease)
+  assert.equal(secondLease, null)
 })
 
 test('cloud control plane resolves org accounts memberships, tokens, and audit events', () => {

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -1,13 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { DEFAULT_CONFIG } from '../apps/desktop/src/main/config-types.ts'
+import { DEFAULT_CONFIG, type CloudAbuseConfig } from '../apps/desktop/src/main/config-types.ts'
 import { CloudArtifactService } from '../apps/desktop/src/main/cloud/artifact-service.ts'
 import { createApiTokenCloudAuthResolver } from '../apps/desktop/src/main/cloud/app.ts'
 import { createByokSecretStore } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
 import { resolveCloudRuntimePolicy, type CloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
 import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
 import {
+  CloudHttpError,
   createCloudHttpServer,
   type CloudAuthResolver,
   type CloudBrowserAuthProvider,
@@ -31,6 +32,7 @@ const TEST_COOKIE_KEY = 'not-a-real-cookie-key-for-tests'
 
 class FakeRuntimeAdapter implements CloudRuntimeAdapter {
   prompts: Array<{ sessionId: string, parts: CloudRuntimePromptPart[], agent: string }> = []
+  createdSessions: string[] = []
   aborted: string[] = []
   permissions: Array<{ permissionId: string, allowed: boolean }> = []
   private nextSession = 0
@@ -38,6 +40,7 @@ class FakeRuntimeAdapter implements CloudRuntimeAdapter {
   async createSession() {
     this.nextSession += 1
     const id = `oc-session-${this.nextSession}`
+    this.createdSessions.push(id)
     return {
       id,
       title: `Session ${this.nextSession}`,
@@ -85,6 +88,7 @@ function createFixture(options: {
     observability?: CloudObservabilityAdapter | null
     internalToken?: string | null
     byokPolicy?: ByokManagementPolicy
+    abuse?: CloudAbuseConfig
   } = {}) {
   const runtime = new FakeRuntimeAdapter()
   const store = new InMemoryControlPlaneStore()
@@ -96,11 +100,11 @@ function createFixture(options: {
   })
   const service = new CloudSessionService(store, runtime, policy, undefined, {
     randomUUID: () => `cmd-${nextId += 1}`,
-  }, undefined, byokSecrets, options.byokPolicy)
+  }, undefined, byokSecrets, options.byokPolicy, options.abuse)
   const artifacts = new CloudArtifactService(service, objectStore, {
     randomUUID: () => `artifact-${nextId += 1}`,
   })
-  const worker = new CloudWorker(store, service, 'worker-1')
+  const worker = new CloudWorker(store, service, 'worker-1', 30_000, {}, options.abuse || null)
   const server = createCloudHttpServer({
     service,
     artifacts,
@@ -155,6 +159,22 @@ function cookieValue(headers: string[], name: string) {
     .map((header) => header.split(';')[0])
     .find((entry) => entry.startsWith(prefix))
   return value ? decodeURIComponent(value.slice(prefix.length)) : null
+}
+
+function testAbuseConfig(overrides: Partial<CloudAbuseConfig> = {}): CloudAbuseConfig {
+  return {
+    ...DEFAULT_CONFIG.cloud.abuse,
+    ...overrides,
+    enabled: overrides.enabled ?? true,
+    httpRateLimit: {
+      ...DEFAULT_CONFIG.cloud.abuse.httpRateLimit,
+      ...(overrides.httpRateLimit || {}),
+    },
+    authBackoff: {
+      ...DEFAULT_CONFIG.cloud.abuse.authBackoff,
+      ...(overrides.authBackoff || {}),
+    },
+  }
 }
 
 async function readSseUntil(
@@ -263,6 +283,172 @@ test('cloud HTTP server exposes health, config, session create/list/get, prompt,
     const abort = await readJson(abortResponse)
     assert.equal(abort.processed, 1)
     assert.deepEqual(fixture.runtime.aborted, ['oc-session-1'])
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server enforces prompt quotas before processing commands and exposes usage events', async () => {
+  const fixture = createFixture({
+    abuse: testAbuseConfig({
+      maxPromptsPerHour: 1,
+      httpRateLimit: { enabled: false, windowMs: 60_000, maxRequests: 100 },
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const created = await readJson(await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    }))
+    const sessionId = String(asRecord(created.session).sessionId)
+    const firstPrompt = await fetch(`${baseUrl}/api/sessions/${sessionId}/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'first' }),
+    })
+    assert.equal(firstPrompt.status, 202)
+    assert.equal(fixture.runtime.prompts.length, 1)
+
+    const blockedPrompt = await fetch(`${baseUrl}/api/sessions/${sessionId}/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'second' }),
+    })
+    assert.equal(blockedPrompt.status, 429)
+    assert.equal(Number(blockedPrompt.headers.get('retry-after')) > 0, true)
+    const blocked = await readJson(blockedPrompt)
+    assert.equal(asRecord(blocked.verdict).policyCode, 'quota.prompts_per_hour_exceeded')
+    assert.equal(fixture.runtime.prompts.length, 1)
+
+    const usage = await readJson(await fetch(`${baseUrl}/api/usage/events`))
+    const events = asArray(usage.events).map(asRecord)
+    assert.equal(events.some((event) => event.eventType === 'prompt.enqueued'), true)
+    assert.equal(events.some((event) => event.eventType === 'worker.minute'), true)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server blocks session quotas before eager runtime creation', async () => {
+  const fixture = createFixture({
+    abuse: testAbuseConfig({
+      maxConcurrentSessionsPerOrg: 1,
+      httpRateLimit: { enabled: false, windowMs: 60_000, maxRequests: 100 },
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const first = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    assert.equal(first.status, 201)
+    assert.equal(fixture.runtime.createdSessions.length, 0)
+
+    const blocked = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    assert.equal(blocked.status, 429)
+    assert.equal(fixture.runtime.createdSessions.length, 0)
+    const body = await readJson(blocked)
+    assert.equal(asRecord(body.verdict).policyCode, 'quota.concurrent_sessions_exceeded')
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server returns machine-readable rate-limit and auth-backoff responses', async () => {
+  const fixture = createFixture({
+    auth: () => {
+      throw new CloudHttpError(401, 'not authorized')
+    },
+    abuse: testAbuseConfig({
+      httpRateLimit: { enabled: true, windowMs: 60_000, maxRequests: 2 },
+      authBackoff: { enabled: true, windowMs: 60_000, maxFailures: 1, backoffMs: 60_000 },
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    assert.equal((await fetch(`${baseUrl}/healthz`)).status, 200)
+    assert.equal((await fetch(`${baseUrl}/api/config`)).status, 401)
+    const authBlocked = await fetch(`${baseUrl}/api/config`)
+    assert.equal(authBlocked.status, 429)
+    const authBackoff = await readJson(authBlocked)
+    assert.equal(asRecord(authBackoff.verdict).policyCode, 'auth.backoff')
+    assert.equal(Number(authBlocked.headers.get('retry-after')) > 0, true)
+
+    const rateLimited = await fetch(`${baseUrl}/api/config`)
+    assert.equal(rateLimited.status, 429)
+    const rateBody = await readJson(rateLimited)
+    assert.equal(asRecord(rateBody.verdict).policyCode, 'rate_limit.http_exceeded')
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server auth backoff applies to the source when bearer tokens rotate', async () => {
+  const fixture = createFixture({
+    auth: () => {
+      throw new CloudHttpError(401, 'not authorized')
+    },
+    abuse: testAbuseConfig({
+      httpRateLimit: { enabled: false, windowMs: 60_000, maxRequests: 100 },
+      authBackoff: { enabled: true, windowMs: 60_000, maxFailures: 1, backoffMs: 60_000 },
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const first = await fetch(`${baseUrl}/api/config`, {
+      headers: { authorization: 'Bearer one-invalid-token' },
+    })
+    assert.equal(first.status, 401)
+
+    const rotated = await fetch(`${baseUrl}/api/config`, {
+      headers: { authorization: 'Bearer another-invalid-token' },
+    })
+    assert.equal(rotated.status, 429)
+    const blocked = await readJson(rotated)
+    assert.equal(asRecord(blocked.verdict).policyCode, 'auth.backoff')
+    assert.equal(Number(rotated.headers.get('retry-after')) > 0, true)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server blocks artifact uploads that exceed daily byte quota', async () => {
+  const fixture = createFixture({
+    abuse: testAbuseConfig({
+      maxArtifactBytesPerDay: 4,
+      httpRateLimit: { enabled: false, windowMs: 60_000, maxRequests: 100 },
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const created = await readJson(await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    }))
+    const sessionId = String(asRecord(created.session).sessionId)
+    const upload = await fetch(`${baseUrl}/api/sessions/${sessionId}/artifacts`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        filename: 'too-large.txt',
+        contentType: 'text/plain',
+        dataBase64: Buffer.from('hello').toString('base64'),
+      }),
+    })
+    assert.equal(upload.status, 429)
+    const body = await readJson(upload)
+    assert.equal(asRecord(body.verdict).policyCode, 'quota.artifact_bytes_per_day_exceeded')
+    const artifacts = await readJson(await fetch(`${baseUrl}/api/sessions/${sessionId}/artifacts`))
+    assert.equal(asArray(artifacts.artifacts).length, 0)
   } finally {
     await fixture.server.close()
   }

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 
 import { createPostgresControlPlaneStore } from '../apps/desktop/src/main/cloud/postgres-control-plane-store.ts'
+import { ControlPlaneQuotaExceededError } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
 
 const POSTGRES_URL = process.env.OPEN_COWORK_TEST_POSTGRES_URL
   || process.env.OPEN_COWORK_CLOUD_TEST_POSTGRES_URL
@@ -91,6 +92,7 @@ test('real Postgres cloud store serializes concurrent schema migrations', {
         '002_org_identity_tokens_audit',
         '003_headless_channels',
         '004_byok_secrets',
+        '005_usage_quotas_rate_limits',
       ])
     } finally {
       await Promise.all(stores.map((store) => store.close?.()))
@@ -207,6 +209,73 @@ test('real Postgres cloud store serializes worker leases and fences stale projec
       view: { messages: ['current'] },
       leaseToken: secondLease.leaseToken,
     })).sequence, 2)
+  })
+})
+
+test('real Postgres cloud store enforces quota counters under concurrent requests', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const attempts = await Promise.all(Array.from({ length: 8 }, () => (
+      store.consumeUsageQuota({
+        orgId: ids.tenantId,
+        quotaKey: 'prompts:hour',
+        limit: 3,
+        quantity: 1,
+        windowMs: 60_000,
+        now: new Date('2026-01-01T00:00:00.000Z'),
+        policyCode: 'quota.prompts_per_hour_exceeded',
+      })
+    )))
+    assert.equal(attempts.filter((attempt) => attempt.allowed).length, 3)
+    assert.equal(attempts.filter((attempt) => !attempt.allowed).length, 5)
+
+    const createAttempts = await Promise.all(Array.from({ length: 5 }, async (_, index) => {
+      try {
+        await store.createSession({
+          tenantId: ids.tenantId,
+          userId: ids.userId,
+          sessionId: `${ids.tenantId}-quota-session-${index}`,
+          opencodeSessionId: `${ids.tenantId}-quota-oc-${index}`,
+          profileName: 'full',
+          quota: {
+            orgId: ids.tenantId,
+            maxConcurrentSessionsPerOrg: 2,
+            policyCode: 'quota.concurrent_sessions_exceeded',
+          },
+        })
+        return 'created'
+      } catch (error) {
+        assert.equal(error instanceof ControlPlaneQuotaExceededError, true)
+        return 'blocked'
+      }
+    }))
+    assert.equal(createAttempts.filter((result) => result === 'created').length, 1)
+    assert.equal(createAttempts.filter((result) => result === 'blocked').length, 4)
+
+    const workerSessionId = `${ids.tenantId}-worker-quota-session`
+    await store.createSession({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      sessionId: workerSessionId,
+      opencodeSessionId: `${ids.tenantId}-worker-quota-oc`,
+      profileName: 'full',
+    })
+    const leases = await Promise.all([ids.sessionId, workerSessionId].map((sessionId, index) => (
+      store.claimSessionLease(
+        ids.tenantId,
+        sessionId,
+        `quota-worker-${index}`,
+        new Date('2026-01-01T00:00:00.000Z'),
+        30_000,
+        {
+          orgId: ids.tenantId,
+          maxActiveWorkersPerOrg: 1,
+          policyCode: 'quota.active_workers_exceeded',
+        },
+      )
+    )))
+    assert.equal(leases.filter(Boolean).length, 1)
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #429.

Adds production quota, rate-limit, usage metering, and auth backoff controls for Open Cowork Cloud:

- configurable `cloud.abuse` policy and env overrides for hosted/self-host deployments
- per-org session, worker, prompt, gateway delivery, and artifact-byte quotas
- usage event recording and `/api/usage/events`
- IP/org/token HTTP rate limits plus auth failure backoff with machine-readable 429 responses
- Postgres migration tables and concurrency-safe quota counters/locks
- worker-minute, prompt, artifact, session, and gateway-delivery usage events
- docs for cloud abuse-control configuration

## Verification

- `pnpm test tests/cloud-control-plane-store.test.ts`
- `pnpm test tests/cloud-http-server.test.ts`
- `pnpm test tests/cloud-app.test.ts`
- `pnpm test tests/cloud-postgres-concurrency.test.ts` (local real-Postgres cases skipped because `OPEN_COWORK_TEST_POSTGRES_URL` is not set)
- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/cloud-postgres-concurrency.test.ts` (same local Postgres skip)
- `pnpm typecheck`
- `pnpm lint`
- `python3 -m venv /tmp/open-cowork-docs-venv && . /tmp/open-cowork-docs-venv/bin/activate && python -m pip install -q -r docs/requirements.txt && mkdocs build --strict`
- `git diff --check`
