### PR TITLE
Add cloud billing entitlements

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -1,7 +1,8 @@
 import { resolve } from 'node:path'
 import type { IncomingMessage } from 'node:http'
-import { DEFAULT_CONFIG, type CloudAbuseConfig, type CloudAuthConfig, type OpenCoworkConfig } from '../config-types.ts'
+import { DEFAULT_CONFIG, type CloudAbuseConfig, type CloudAuthConfig, type CloudBillingConfig, type OpenCoworkConfig } from '../config-types.ts'
 import { CloudArtifactService } from './artifact-service.ts'
+import { evaluateBillingEntitlement, type BillingAdapter } from './billing-adapter.ts'
 import {
   resolveCloudRuntimePolicy,
   type CloudRuntimePolicy,
@@ -38,6 +39,8 @@ import { createCloudSecretAdapterFromEnv, resolveCloudSecretRef, type SecretAdap
 import { createCloudSessionCookieManager, type CloudSessionCookieManager } from './session-cookie-auth.ts'
 import { CloudSessionService, type ByokManagementPolicy, type CloudPrincipal } from './session-service.ts'
 import { CloudScheduler } from './scheduler.ts'
+import { createStripeBillingAdapter } from './stripe-billing-adapter.ts'
+import { createStubBillingAdapter } from './stub-billing-adapter.ts'
 import { CloudWorker } from './worker.ts'
 import { createWorkerScopedRuntimeAdapter } from './worker-scoped-runtime-adapter.ts'
 import {
@@ -97,6 +100,7 @@ export type CloudAppOptions = {
   secretAdapter?: SecretAdapter
   byokSecretStoreOptions?: Pick<ByokSecretStoreOptions, 'kmsRefResolver' | 'validators'>
   byokPolicy?: ByokManagementPolicy
+  billingAdapter?: BillingAdapter | null
   runtime?: CloudRuntimeAdapter
   runtimeFactory?: CloudRuntimeFactory
   paths?: PathProvider
@@ -250,6 +254,46 @@ export function resolveCloudAbuseConfig(config: Pick<OpenCoworkConfig, 'cloud'>,
       backoffMs: parsePositiveInt(envValue(env, 'OPEN_COWORK_CLOUD_AUTH_BACKOFF_MS'), defaults.authBackoff.backoffMs),
     },
   }
+}
+
+export function resolveCloudBillingConfig(config: Pick<OpenCoworkConfig, 'cloud'>, env: Env = process.env): CloudBillingConfig {
+  const defaults = config.cloud.billing
+  const provider = envValue(env, 'OPEN_COWORK_CLOUD_BILLING_PROVIDER') || defaults.provider
+  return {
+    ...defaults,
+    enabled: parseBoolean(envValue(env, 'OPEN_COWORK_CLOUD_BILLING_ENABLED'), defaults.enabled),
+    provider: provider === 'none' || provider === 'stub' || provider === 'stripe' ? provider : defaults.provider,
+    defaultPlanKey: envValue(env, 'OPEN_COWORK_CLOUD_BILLING_DEFAULT_PLAN') || defaults.defaultPlanKey,
+    stripe: {
+      ...(defaults.stripe || {}),
+      apiKeyRef: envValue(env, 'OPEN_COWORK_CLOUD_STRIPE_API_KEY_REF') || defaults.stripe?.apiKeyRef,
+      webhookSecretRef: envValue(env, 'OPEN_COWORK_CLOUD_STRIPE_WEBHOOK_SECRET_REF') || defaults.stripe?.webhookSecretRef,
+      defaultPriceId: envValue(env, 'OPEN_COWORK_CLOUD_STRIPE_PRICE_ID') || defaults.stripe?.defaultPriceId,
+      successUrl: envValue(env, 'OPEN_COWORK_CLOUD_STRIPE_SUCCESS_URL') || defaults.stripe?.successUrl,
+      cancelUrl: envValue(env, 'OPEN_COWORK_CLOUD_STRIPE_CANCEL_URL') || defaults.stripe?.cancelUrl,
+      portalReturnUrl: envValue(env, 'OPEN_COWORK_CLOUD_STRIPE_PORTAL_RETURN_URL') || defaults.stripe?.portalReturnUrl,
+    },
+  }
+}
+
+async function createBillingAdapterForCloud(input: {
+  config: CloudBillingConfig
+  env: Env
+}): Promise<BillingAdapter | null> {
+  if (!input.config.enabled || input.config.provider === 'none') return null
+  if (input.config.provider === 'stub') return createStubBillingAdapter(input.config)
+  if (input.config.provider === 'stripe') {
+    const apiKey = envValue(input.env, 'OPEN_COWORK_CLOUD_STRIPE_API_KEY')
+      || resolveEnvRef(input.config.stripe?.apiKeyRef, input.env)
+    const webhookSecret = envValue(input.env, 'OPEN_COWORK_CLOUD_STRIPE_WEBHOOK_SECRET')
+      || resolveEnvRef(input.config.stripe?.webhookSecretRef, input.env)
+    return createStripeBillingAdapter({
+      config: input.config,
+      apiKey,
+      webhookSecret,
+    })
+  }
+  return null
 }
 
 export function resolveCloudOidcClientSecret(config: Pick<OpenCoworkConfig, 'cloud'>, env: Env = process.env) {
@@ -544,6 +588,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
   const policy = resolveCloudRuntimePolicy(config, env)
   const authConfig = resolveCloudAuthConfig(config, env)
   const abuseConfig = resolveCloudAbuseConfig(config, env)
+  const billingConfig = resolveCloudBillingConfig(config, env)
   const listenHostname = options.hostname || envOptions.hostname
   assertCloudAuthDeploymentSafe({
     role: policy.role,
@@ -566,10 +611,30 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
   const store = options.store || await (options.storeFactory || createControlPlaneStoreForCloud)({ config, env })
   const objectStore = options.objectStore || await (options.objectStoreFactory || createObjectStoreForCloud)({ config, env, paths })
   const secretAdapter = options.secretAdapter || await createCloudSecretAdapterFromEnv(env)
+  const billingAdapter = Object.prototype.hasOwnProperty.call(options, 'billingAdapter')
+    ? options.billingAdapter || null
+    : await createBillingAdapterForCloud({ config: billingConfig, env })
   const byokPolicy: ByokManagementPolicy = {
     allowedProviderIds: options.byokPolicy?.allowedProviderIds ?? listConfiguredByokProviderIds(config),
     checkEntitlement: options.byokPolicy?.checkEntitlement ?? null,
-    checkRuntimeEntitlement: options.byokPolicy?.checkRuntimeEntitlement ?? null,
+    checkRuntimeEntitlement: async (input) => {
+      const subscription = await store.getBillingSubscription(input.orgId)
+      if (billingConfig.enabled && billingConfig.provider !== 'none') {
+        const billingVerdict = evaluateBillingEntitlement({
+          config: billingConfig,
+          subscription,
+          action: 'byok.provider',
+          providerId: input.providerId,
+        })
+        if (!billingVerdict.allowed) {
+          return {
+            allowed: false,
+            reason: billingVerdict.reason || 'BYOK provider is not included in this billing entitlement.',
+          }
+        }
+      }
+      return options.byokPolicy?.checkRuntimeEntitlement?.(input) ?? { allowed: true }
+    },
     kmsRefs: options.byokPolicy?.kmsRefs ?? null,
   }
   const byokSecrets = createByokSecretStore(store, secretAdapter, {
@@ -615,6 +680,8 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
     byokSecrets,
     byokPolicy,
     abuseConfig,
+    billingConfig,
+    billingAdapter,
   )
   const artifacts = new CloudArtifactService(service, objectStore)
   const hasSessionCookieOverride = Object.prototype.hasOwnProperty.call(options, 'sessionCookies')

--- a/apps/desktop/src/main/cloud/billing-adapter.ts
+++ b/apps/desktop/src/main/cloud/billing-adapter.ts
@@ -1,0 +1,201 @@
+import type {
+  CloudBillingConfig,
+  CloudBillingEntitlements,
+  CloudSubscriptionStatus,
+} from '../config-types.ts'
+import type {
+  BillingSubscriptionRecord,
+  UpsertBillingSubscriptionInput,
+} from './control-plane-store.ts'
+
+export type BillingAction = 'session.create' | 'prompt.enqueue' | 'worker.execute' | 'byok.provider'
+
+export type BillingEntitlementVerdict = {
+  allowed: boolean
+  status?: number
+  reason?: string | null
+  policyCode?: string | null
+}
+
+export type BillingCheckoutInput = {
+  orgId: string
+  accountId: string | null
+  email: string
+  planKey: string
+  successUrl?: string | null
+  cancelUrl?: string | null
+}
+
+export type BillingCheckoutResult = {
+  providerId: string
+  providerSessionId: string | null
+  url: string
+  subscription?: UpsertBillingSubscriptionInput | null
+}
+
+export type BillingPortalInput = {
+  orgId: string
+  email: string
+  subscription: BillingSubscriptionRecord | null
+  returnUrl?: string | null
+}
+
+export type BillingPortalResult = {
+  providerId: string
+  url: string
+}
+
+export type BillingWebhookInput = {
+  headers: Record<string, string | undefined>
+  rawBody: string
+  body: Record<string, unknown>
+}
+
+export type BillingWebhookResult = {
+  providerId: string
+  eventId: string
+  eventType: string
+  subscription?: UpsertBillingSubscriptionInput | null
+}
+
+export type BillingAdapter = {
+  readonly providerId: string
+  readonly enabled: boolean
+  createCheckoutSession(input: BillingCheckoutInput): Promise<BillingCheckoutResult> | BillingCheckoutResult
+  createPortalSession(input: BillingPortalInput): Promise<BillingPortalResult> | BillingPortalResult
+  handleWebhook(input: BillingWebhookInput): Promise<BillingWebhookResult> | BillingWebhookResult
+}
+
+export class BillingAdapterError extends Error {
+  readonly status: number
+  readonly publicMessage: string
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+    this.publicMessage = message
+  }
+}
+
+export class BillingWebhookAuthError extends BillingAdapterError {
+  constructor(message = 'Billing webhook authorization failed.') {
+    super(401, message)
+  }
+}
+
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set<CloudSubscriptionStatus>(['active', 'trialing'])
+
+function entitlementList(value: string[] | null | undefined) {
+  const list = (value || []).map((entry) => entry.trim()).filter(Boolean)
+  return list.length > 0 ? new Set(list) : null
+}
+
+export function isBillingConfigured(config: CloudBillingConfig) {
+  return config.enabled === true && config.provider !== 'none'
+}
+
+export function isBillingSubscriptionActive(subscription: BillingSubscriptionRecord | null | undefined) {
+  return Boolean(subscription && ACTIVE_SUBSCRIPTION_STATUSES.has(subscription.status))
+}
+
+export function planEntitlements(config: CloudBillingConfig, planKey: string | null | undefined): CloudBillingEntitlements {
+  return {
+    ...(config.plans[planKey || config.defaultPlanKey]?.entitlements || {}),
+  }
+}
+
+export function resolvedBillingEntitlements(
+  config: CloudBillingConfig,
+  subscription: BillingSubscriptionRecord | null | undefined,
+): CloudBillingEntitlements {
+  return {
+    ...planEntitlements(config, subscription?.planKey || config.defaultPlanKey),
+    ...(subscription?.entitlements || {}),
+  }
+}
+
+export function subscriptionPlanKeyForPrice(config: CloudBillingConfig, priceId: string | null | undefined) {
+  if (!priceId) return config.defaultPlanKey
+  for (const [planKey, plan] of Object.entries(config.plans)) {
+    if (plan.stripePriceId === priceId) return planKey
+  }
+  return config.defaultPlanKey
+}
+
+export function evaluateBillingEntitlement(input: {
+  config: CloudBillingConfig
+  subscription: BillingSubscriptionRecord | null
+  action: BillingAction
+  profileName?: string | null
+  providerId?: string | null
+}): BillingEntitlementVerdict {
+  if (!isBillingConfigured(input.config)) return { allowed: true }
+
+  if (!input.subscription) {
+    return {
+      allowed: false,
+      status: 402,
+      reason: 'A billing subscription is required for this cloud org.',
+      policyCode: 'billing.subscription_required',
+    }
+  }
+
+  if (!isBillingSubscriptionActive(input.subscription)) {
+    return {
+      allowed: false,
+      status: 402,
+      reason: `Billing subscription is ${input.subscription.status}.`,
+      policyCode: 'billing.subscription_inactive',
+    }
+  }
+
+  const entitlements = resolvedBillingEntitlements(input.config, input.subscription)
+  const allowedProfiles = entitlementList(entitlements.allowedProfiles)
+  if (input.profileName && allowedProfiles && !allowedProfiles.has(input.profileName)) {
+    return {
+      allowed: false,
+      status: 402,
+      reason: `Cloud profile "${input.profileName}" is not included in this plan.`,
+      policyCode: 'billing.profile_not_entitled',
+    }
+  }
+
+  if (input.action === 'byok.provider' && input.providerId) {
+    const allowedProviders = entitlementList(entitlements.allowedProviders)
+    if (allowedProviders && !allowedProviders.has(input.providerId)) {
+      return {
+        allowed: false,
+        status: 402,
+        reason: `Provider "${input.providerId}" is not included in this plan.`,
+        policyCode: 'billing.provider_not_entitled',
+      }
+    }
+  }
+
+  if (input.action === 'session.create' && entitlements.allowNewSessions === false) {
+    return {
+      allowed: false,
+      status: 402,
+      reason: 'Creating new cloud sessions is not included in this plan.',
+      policyCode: 'billing.sessions_not_entitled',
+    }
+  }
+  if (input.action === 'prompt.enqueue' && entitlements.allowPrompts === false) {
+    return {
+      allowed: false,
+      status: 402,
+      reason: 'Cloud prompts are not included in this plan.',
+      policyCode: 'billing.prompts_not_entitled',
+    }
+  }
+  if (input.action === 'worker.execute' && entitlements.allowWorkers === false) {
+    return {
+      allowed: false,
+      status: 402,
+      reason: 'Cloud worker execution is not included in this plan.',
+      policyCode: 'billing.workers_not_entitled',
+    }
+  }
+
+  return { allowed: true }
+}

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowSummary,
   WorkflowTriggerType,
 } from '@open-cowork/shared'
+import type { CloudBillingEntitlements, CloudSubscriptionStatus } from '../config-types.ts'
 
 export type ControlPlaneRole = 'owner' | 'admin' | 'member'
 export type ControlPlaneMembershipStatus = 'active' | 'invited' | 'disabled'
@@ -33,6 +34,7 @@ export type UsageEventType =
   | 'artifact.uploaded'
   | 'gateway.delivery.claimed'
 export type UsageUnit = 'count' | 'byte' | 'minute'
+export type BillingSubscriptionStatus = CloudSubscriptionStatus
 
 export type QuotaPolicyCode =
   | 'quota.concurrent_sessions_exceeded'
@@ -52,6 +54,22 @@ export type UsageEventRecord = {
   unit: UsageUnit | string
   metadata: Record<string, unknown>
   createdAt: string
+}
+
+export type BillingSubscriptionRecord = {
+  orgId: string
+  planKey: string
+  providerId: string
+  providerCustomerId: string | null
+  providerSubscriptionId: string | null
+  status: BillingSubscriptionStatus
+  seats: number
+  entitlements: CloudBillingEntitlements
+  currentPeriodEnd: string | null
+  cancelAtPeriodEnd: boolean
+  metadata: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
 }
 
 export type QuotaConsumptionRecord = {
@@ -501,6 +519,21 @@ export type RecordUsageEventInput = {
   createdAt?: Date
 }
 
+export type UpsertBillingSubscriptionInput = {
+  orgId: string
+  planKey: string
+  providerId: string
+  providerCustomerId?: string | null
+  providerSubscriptionId?: string | null
+  status: BillingSubscriptionStatus
+  seats?: number
+  entitlements?: CloudBillingEntitlements
+  currentPeriodEnd?: Date | string | null
+  cancelAtPeriodEnd?: boolean
+  metadata?: Record<string, unknown>
+  updatedAt?: Date
+}
+
 export type ClaimRateLimitInput = {
   scope: string
   source: string
@@ -930,6 +963,13 @@ export type ControlPlaneStore = {
   consumeUsageQuota(input: ConsumeUsageQuotaInput): MaybePromise<QuotaConsumptionRecord>
   recordUsageEvent(input: RecordUsageEventInput): MaybePromise<UsageEventRecord>
   listUsageEvents(orgId: string, limit?: number): MaybePromise<UsageEventRecord[]>
+  upsertBillingSubscription(input: UpsertBillingSubscriptionInput): MaybePromise<BillingSubscriptionRecord>
+  getBillingSubscription(orgId: string): MaybePromise<BillingSubscriptionRecord | null>
+  findBillingSubscriptionByProvider(input: {
+    providerId: string
+    providerCustomerId?: string | null
+    providerSubscriptionId?: string | null
+  }): MaybePromise<BillingSubscriptionRecord | null>
   claimRateLimit(input: ClaimRateLimitInput): MaybePromise<RateLimitClaimRecord>
   checkCloudAuthBackoff(input: CheckCloudAuthBackoffInput): MaybePromise<CloudAuthBackoffRecord>
   recordCloudAuthFailure(input: RecordCloudAuthFailureInput): MaybePromise<CloudAuthBackoffRecord>
@@ -1083,6 +1123,15 @@ const CHANNEL_METADATA_MAX_BYTES = 16_384
 const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
 const BYOK_PROVIDER_ID_MAX_LENGTH = 64
 const BYOK_SECRET_TEXT_MAX_LENGTH = 4096
+const BILLING_TEXT_MAX_LENGTH = 256
+const BILLING_METADATA_MAX_BYTES = 16_384
+const BILLING_SUBSCRIPTION_STATUSES = new Set<BillingSubscriptionStatus>([
+  'trialing',
+  'active',
+  'past_due',
+  'canceled',
+  'incomplete',
+])
 
 function nowIso(now: Date | undefined) {
   return (now || new Date()).toISOString()
@@ -1257,6 +1306,20 @@ function normalizeProvider(value: unknown): ChannelProviderId {
   return provider
 }
 
+function normalizeBillingStatus(value: unknown): BillingSubscriptionStatus {
+  const status = normalizeText(value || 'incomplete', 32, 'Billing subscription status') as BillingSubscriptionStatus
+  return BILLING_SUBSCRIPTION_STATUSES.has(status) ? status : 'incomplete'
+}
+
+function billingProviderKey(providerId: string, providerRecordId: string | null | undefined) {
+  return key(normalizeText(providerId, BILLING_TEXT_MAX_LENGTH, 'Billing provider id'), providerRecordId || '')
+}
+
+function isoNullable(value: Date | string | null | undefined) {
+  if (!value) return null
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
 function normalizeByokProviderId(value: unknown) {
   const providerId = normalizeText(value, BYOK_PROVIDER_ID_MAX_LENGTH, 'BYOK provider id').toLowerCase()
   if (!/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) throw new Error(`Unsupported BYOK provider id ${providerId}.`)
@@ -1291,6 +1354,9 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly apiTokens = new Map<string, ApiTokenRecord>()
   private readonly auditEvents = new Map<string, AuditEventRecord>()
   private readonly usageEvents = new Map<string, UsageEventRecord>()
+  private readonly billingSubscriptions = new Map<string, BillingSubscriptionRecord>()
+  private readonly billingSubscriptionsByProviderSubscription = new Map<string, string>()
+  private readonly billingSubscriptionsByProviderCustomer = new Map<string, string>()
   private readonly usageCounters = new Map<string, { windowStartedAtMs: number, quantity: number }>()
   private readonly rateLimits = new Map<string, { windowStartedAtMs: number, count: number }>()
   private readonly authFailures = new Map<string, CloudAuthBackoffRecord>()
@@ -1632,6 +1698,82 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
       .slice(0, limit)
       .map((event) => clone(event))
+  }
+
+  upsertBillingSubscription(input: UpsertBillingSubscriptionInput): BillingSubscriptionRecord {
+    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    const existing = this.billingSubscriptions.get(input.orgId)
+    const now = nowIso(input.updatedAt)
+    const providerId = normalizeText(input.providerId, BILLING_TEXT_MAX_LENGTH, 'Billing provider id')
+    const providerCustomerId = normalizeNullableText(input.providerCustomerId, BILLING_TEXT_MAX_LENGTH, 'Billing provider customer id')
+    const providerSubscriptionId = normalizeNullableText(input.providerSubscriptionId, BILLING_TEXT_MAX_LENGTH, 'Billing provider subscription id')
+    const record: BillingSubscriptionRecord = {
+      orgId: input.orgId,
+      planKey: normalizeText(input.planKey || existing?.planKey, BILLING_TEXT_MAX_LENGTH, 'Billing plan key'),
+      providerId,
+      providerCustomerId,
+      providerSubscriptionId,
+      status: normalizeBillingStatus(input.status),
+      seats: normalizePositiveInteger(input.seats || existing?.seats || 1, 'Billing seats'),
+      entitlements: normalizeRecord(input.entitlements, 'Billing entitlements', BILLING_METADATA_MAX_BYTES) as CloudBillingEntitlements,
+      currentPeriodEnd: isoNullable(input.currentPeriodEnd),
+      cancelAtPeriodEnd: input.cancelAtPeriodEnd === undefined ? existing?.cancelAtPeriodEnd || false : input.cancelAtPeriodEnd === true,
+      metadata: redactAuditMetadata(normalizeRecord(input.metadata, 'Billing metadata', BILLING_METADATA_MAX_BYTES)),
+      createdAt: existing?.createdAt || now,
+      updatedAt: now,
+    }
+    if (existing?.providerSubscriptionId) {
+      this.billingSubscriptionsByProviderSubscription.delete(billingProviderKey(existing.providerId, existing.providerSubscriptionId))
+    }
+    if (existing?.providerCustomerId) {
+      this.billingSubscriptionsByProviderCustomer.delete(billingProviderKey(existing.providerId, existing.providerCustomerId))
+    }
+    this.billingSubscriptions.set(record.orgId, record)
+    if (record.providerSubscriptionId) {
+      this.billingSubscriptionsByProviderSubscription.set(billingProviderKey(record.providerId, record.providerSubscriptionId), record.orgId)
+    }
+    if (record.providerCustomerId) {
+      this.billingSubscriptionsByProviderCustomer.set(billingProviderKey(record.providerId, record.providerCustomerId), record.orgId)
+    }
+    this.recordAuditEvent({
+      orgId: record.orgId,
+      actorType: 'system',
+      actorId: 'billing.subscription.upsert',
+      eventType: existing ? 'billing.subscription.updated' : 'billing.subscription.created',
+      targetType: 'billing_subscription',
+      targetId: record.providerSubscriptionId || record.orgId,
+      metadata: {
+        providerId: record.providerId,
+        planKey: record.planKey,
+        status: record.status,
+        seats: record.seats,
+        providerCustomerId: record.providerCustomerId,
+        providerSubscriptionId: record.providerSubscriptionId,
+      },
+      createdAt: input.updatedAt,
+    })
+    return clone(record)
+  }
+
+  getBillingSubscription(orgId: string): BillingSubscriptionRecord | null {
+    const subscription = this.billingSubscriptions.get(orgId)
+    return subscription ? clone(subscription) : null
+  }
+
+  findBillingSubscriptionByProvider(input: {
+    providerId: string
+    providerCustomerId?: string | null
+    providerSubscriptionId?: string | null
+  }): BillingSubscriptionRecord | null {
+    const providerId = normalizeText(input.providerId, BILLING_TEXT_MAX_LENGTH, 'Billing provider id')
+    const bySubscription = input.providerSubscriptionId
+      ? this.billingSubscriptionsByProviderSubscription.get(billingProviderKey(providerId, input.providerSubscriptionId))
+      : null
+    const byCustomer = input.providerCustomerId
+      ? this.billingSubscriptionsByProviderCustomer.get(billingProviderKey(providerId, input.providerCustomerId))
+      : null
+    const subscription = this.billingSubscriptions.get(bySubscription || byCustomer || '')
+    return subscription ? clone(subscription) : null
   }
 
   claimRateLimit(input: ClaimRateLimitInput): RateLimitClaimRecord {

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -101,6 +101,8 @@ const CLOUD_WEBHOOK_REQUEST_LIMIT = 120
 const CLOUD_WEBHOOK_AUTH_FAILURE_WINDOW_MS = 60 * 1000
 const CLOUD_WEBHOOK_AUTH_FAILURE_LIMIT = 5
 const CLOUD_WEBHOOK_AUTH_BACKOFF_MS = 60 * 1000
+const WEBHOOK_SIGNATURE_REPLAY_WINDOW_MS = 5 * 60 * 1000
+const WEBHOOK_SIGNATURE_REPLAY_CACHE_LIMIT = 512
 
 function defaultAuthResolver(): CloudPrincipal {
   return DEFAULT_PRINCIPAL
@@ -334,6 +336,14 @@ function requestSource(req: IncomingMessage) {
   return forwardedFor || req.socket.remoteAddress || 'unknown'
 }
 
+function requestHeaderRecord(req: IncomingMessage): Record<string, string | undefined> {
+  const headers: Record<string, string | undefined> = {}
+  for (const [name, value] of Object.entries(req.headers)) {
+    headers[name.toLowerCase()] = Array.isArray(value) ? value[0] : value
+  }
+  return headers
+}
+
 function authFailureScopes(req: IncomingMessage) {
   const source = requestSource(req)
   const authorization = firstHeader(req.headers.authorization).trim()
@@ -498,6 +508,84 @@ async function handleCloudWorkflowWebhook(
         backoffMs: CLOUD_WEBHOOK_AUTH_BACKOFF_MS,
       })
     }
+    writeError(res, status, message, options.corsOrigin)
+  }
+}
+
+async function handleBillingWebhook(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: CloudHttpServerOptions,
+) {
+  if (req.method !== 'POST') {
+    writeError(res, 405, 'Method not allowed.', options.corsOrigin)
+    return
+  }
+
+  const source = `billing:${requestSource(req)}`
+  const startedAt = Date.now()
+  const securityStore = options.webhookSecurity || new InMemoryWorkflowWebhookSecurityStore()
+  let replayClaim: Awaited<ReturnType<WorkflowWebhookSecurityStore['claimSignature']>> | null = null
+  try {
+    const requestAccepted = await securityStore.claimRequest({
+      source,
+      nowMs: startedAt,
+      windowMs: CLOUD_WEBHOOK_REQUEST_WINDOW_MS,
+      limit: CLOUD_WEBHOOK_REQUEST_LIMIT,
+    })
+    if (!requestAccepted) throw new CloudHttpError(429, 'Too many billing webhook requests. Try again later.')
+    const authAccepted = await securityStore.checkAuthBackoff({
+      scope: source,
+      nowMs: startedAt,
+    })
+    if (!authAccepted) throw new CloudHttpError(429, 'Too many rejected billing webhook requests. Try again later.')
+    const { body, rawBody } = await readJsonBodyWithRaw(req, options.maxBodyBytes || 256 * 1024)
+    const eventId = readString(body.id) || createHash('sha256').update(rawBody).digest('hex')
+    replayClaim = await securityStore.claimSignature({
+      key: `billing:${eventId}`,
+      nowMs: startedAt,
+      windowMs: WEBHOOK_SIGNATURE_REPLAY_WINDOW_MS,
+      cacheLimit: WEBHOOK_SIGNATURE_REPLAY_CACHE_LIMIT,
+    })
+    if (!replayClaim) {
+      writeJson(res, 200, { ok: true, replayed: true }, options.corsOrigin)
+      return
+    }
+    const result = await options.service.handleBillingWebhook({
+      headers: requestHeaderRecord(req),
+      rawBody,
+      body,
+    })
+    await replayClaim.accept()
+    writeJson(res, 200, {
+      ok: true,
+      providerId: result.providerId,
+      eventId: result.eventId,
+      eventType: result.eventType,
+      subscription: result.subscriptionRecord || null,
+    }, options.corsOrigin)
+  } catch (error) {
+    await replayClaim?.release()
+    const status = error instanceof CloudHttpError
+      ? error.status
+      : error instanceof CloudServiceError
+        ? error.status
+        : 400
+    if (status === 401) {
+      await securityStore.recordAuthFailure({
+        scope: source,
+        source,
+        nowMs: Date.now(),
+        windowMs: CLOUD_WEBHOOK_AUTH_FAILURE_WINDOW_MS,
+        limit: CLOUD_WEBHOOK_AUTH_FAILURE_LIMIT,
+        backoffMs: CLOUD_WEBHOOK_AUTH_BACKOFF_MS,
+      })
+    }
+    const message = error instanceof CloudHttpError
+      ? error.publicMessage
+      : error instanceof CloudServiceError
+        ? error.publicMessage
+        : 'Billing webhook request failed.'
     writeError(res, status, message, options.corsOrigin)
   }
 }
@@ -778,6 +866,33 @@ async function handleApiRequest(
     writeJson(res, 200, {
       events: await options.service.listUsageEvents(context.principal, parseLimit(context.url)),
     }, options.corsOrigin)
+    return
+  }
+
+  if (resource === 'billing') {
+    if (sessionId === 'subscription' && !action && req.method === 'GET') {
+      writeJson(res, 200, await options.service.getBillingSubscription(context.principal), options.corsOrigin)
+      return
+    }
+    if (sessionId === 'checkout' && !action && req.method === 'POST') {
+      const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const checkout = await options.service.createBillingCheckout(context.principal, {
+        planKey: readString(body.planKey),
+        successUrl: readString(body.successUrl),
+        cancelUrl: readString(body.cancelUrl),
+      })
+      writeJson(res, 200, checkout, options.corsOrigin)
+      return
+    }
+    if (sessionId === 'portal' && !action && req.method === 'POST') {
+      const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const portal = await options.service.createBillingPortal(context.principal, {
+        returnUrl: readString(body.returnUrl),
+      })
+      writeJson(res, 200, portal, options.corsOrigin)
+      return
+    }
+    writeError(res, 404, 'Not found.', options.corsOrigin)
     return
   }
 
@@ -1829,6 +1944,11 @@ export class CloudHttpServer {
 
       if (url.pathname.startsWith('/webhooks/workflows/')) {
         await handleCloudWorkflowWebhook(req, res, this.options, url)
+        return
+      }
+
+      if (url.pathname === '/webhooks/billing') {
+        await handleBillingWebhook(req, res, this.options)
         return
       }
 

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -20,6 +20,7 @@ import type {
   AuditEventRecord,
   AckChannelDeliveryInput,
   BindChannelSessionInput,
+  BillingSubscriptionRecord,
   ByokSecretRecord,
   ChannelBindingRecord,
   ChannelDeliveryRecord,
@@ -85,6 +86,7 @@ import type {
   UpdateWorkflowStatusInput,
   UpdateThreadSmartFilterInput,
   UpdateThreadTagInput,
+  UpsertBillingSubscriptionInput,
   UpsertChannelIdentityInput,
   UpsertMembershipInput,
   UserRecord,
@@ -500,6 +502,24 @@ function channelInteractionFromRow(row: QueryRow): ChannelInteractionRecord {
     createdByIdentityId: stringOrNull(row.created_by_identity_id),
     expiresAt: iso(row.expires_at),
     usedAt: isoOrNull(row.used_at),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+function billingSubscriptionFromRow(row: QueryRow): BillingSubscriptionRecord {
+  return {
+    orgId: String(row.org_id),
+    planKey: String(row.plan_key),
+    providerId: String(row.provider_id),
+    providerCustomerId: stringOrNull(row.provider_customer_id),
+    providerSubscriptionId: stringOrNull(row.provider_subscription_id),
+    status: String(row.status) as BillingSubscriptionRecord['status'],
+    seats: numberValue(row.seats),
+    entitlements: jsonRecord(row.entitlements) as BillingSubscriptionRecord['entitlements'],
+    currentPeriodEnd: isoOrNull(row.current_period_end),
+    cancelAtPeriodEnd: row.cancel_at_period_end === true,
+    metadata: jsonRecord(row.metadata),
     createdAt: iso(row.created_at),
     updatedAt: iso(row.updated_at),
   }
@@ -1056,6 +1076,97 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       [orgId, Math.max(1, Math.min(limit, 500))],
     )
     return result.rows.map(usageEventFromRow)
+  }
+
+  async upsertBillingSubscription(input: UpsertBillingSubscriptionInput) {
+    await this.requireOrg(input.orgId)
+    const now = nowIso(input.updatedAt)
+    const result = await this.pool.query(
+      `INSERT INTO cloud_subscriptions (
+        org_id, plan_key, provider_id, provider_customer_id, provider_subscription_id,
+        status, seats, entitlements, current_period_end, cancel_at_period_end,
+        metadata, created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11::jsonb, $12, $12)
+       ON CONFLICT (org_id) DO UPDATE
+       SET plan_key = EXCLUDED.plan_key,
+           provider_id = EXCLUDED.provider_id,
+           provider_customer_id = EXCLUDED.provider_customer_id,
+           provider_subscription_id = EXCLUDED.provider_subscription_id,
+           status = EXCLUDED.status,
+           seats = EXCLUDED.seats,
+           entitlements = EXCLUDED.entitlements,
+           current_period_end = EXCLUDED.current_period_end,
+           cancel_at_period_end = EXCLUDED.cancel_at_period_end,
+           metadata = EXCLUDED.metadata,
+           updated_at = EXCLUDED.updated_at
+       RETURNING *`,
+      [
+        input.orgId,
+        normalizeText(input.planKey, CHANNEL_TEXT_MAX_LENGTH, 'Billing plan key'),
+        normalizeText(input.providerId, CHANNEL_TEXT_MAX_LENGTH, 'Billing provider id'),
+        input.providerCustomerId ? normalizeText(input.providerCustomerId, CHANNEL_TEXT_MAX_LENGTH, 'Billing provider customer id') : null,
+        input.providerSubscriptionId ? normalizeText(input.providerSubscriptionId, CHANNEL_TEXT_MAX_LENGTH, 'Billing provider subscription id') : null,
+        input.status,
+        normalizePositiveInteger(input.seats || 1, 'Billing seats'),
+        JSON.stringify(jsonRecord(input.entitlements)),
+        input.currentPeriodEnd ? (input.currentPeriodEnd instanceof Date ? input.currentPeriodEnd.toISOString() : new Date(input.currentPeriodEnd).toISOString()) : null,
+        input.cancelAtPeriodEnd === true,
+        JSON.stringify(redactAuditMetadata(input.metadata)),
+        now,
+      ],
+    )
+    const subscription = billingSubscriptionFromRow(result.rows[0])
+    await this.recordAuditEvent({
+      orgId: subscription.orgId,
+      actorType: 'system',
+      actorId: 'billing.subscription.upsert',
+      eventType: 'billing.subscription.updated',
+      targetType: 'billing_subscription',
+      targetId: subscription.providerSubscriptionId || subscription.orgId,
+      metadata: {
+        providerId: subscription.providerId,
+        planKey: subscription.planKey,
+        status: subscription.status,
+        seats: subscription.seats,
+        providerCustomerId: subscription.providerCustomerId,
+        providerSubscriptionId: subscription.providerSubscriptionId,
+      },
+      createdAt: input.updatedAt,
+    })
+    return subscription
+  }
+
+  async getBillingSubscription(orgId: string) {
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_subscriptions WHERE org_id = $1`,
+      [orgId],
+    )
+    return row ? billingSubscriptionFromRow(row) : null
+  }
+
+  async findBillingSubscriptionByProvider(input: {
+    providerId: string
+    providerCustomerId?: string | null
+    providerSubscriptionId?: string | null
+  }) {
+    const providerId = normalizeText(input.providerId, CHANNEL_TEXT_MAX_LENGTH, 'Billing provider id')
+    const row = input.providerSubscriptionId
+      ? await this.maybeOne(
+        `SELECT * FROM cloud_subscriptions
+         WHERE provider_id = $1 AND provider_subscription_id = $2`,
+        [providerId, input.providerSubscriptionId],
+      )
+      : input.providerCustomerId
+        ? await this.maybeOne(
+          `SELECT * FROM cloud_subscriptions
+           WHERE provider_id = $1 AND provider_customer_id = $2
+           ORDER BY updated_at DESC
+           LIMIT 1`,
+          [providerId, input.providerCustomerId],
+        )
+        : null
+    return row ? billingSubscriptionFromRow(row) : null
   }
 
   async claimRateLimit(input: ClaimRateLimitInput) {
@@ -3292,6 +3403,7 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   }
 
   async clear() {
+    await this.pool.query('DELETE FROM cloud_subscriptions')
     await this.pool.query('DELETE FROM cloud_auth_failures')
     await this.pool.query('DELETE FROM cloud_rate_limits')
     await this.pool.query('DELETE FROM cloud_quota_locks')
@@ -3451,6 +3563,16 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     )
     if (!row) throw new Error(`Unknown tenant ${tenantId}.`)
     return tenantFromRow(row)
+  }
+
+  private async requireOrg(orgId: string, executor: PgExecutor = this.pool) {
+    const row = await this.maybeOne(
+      `SELECT * FROM cloud_orgs WHERE org_id = $1`,
+      [orgId],
+      executor,
+    )
+    if (!row) throw new Error(`Unknown org ${orgId}.`)
+    return orgFromRow(row)
   }
 
   private async requireTenantUser(

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -520,6 +520,32 @@ export const CLOUD_CONTROL_PLANE_USAGE_QUOTAS_STATEMENTS = [
   )`,
 ] as const
 
+export const CLOUD_CONTROL_PLANE_BILLING_SUBSCRIPTIONS_MIGRATION_ID = '006_billing_subscriptions'
+
+export const CLOUD_CONTROL_PLANE_BILLING_SUBSCRIPTIONS_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS cloud_subscriptions (
+    org_id text PRIMARY KEY REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    plan_key text NOT NULL,
+    provider_id text NOT NULL,
+    provider_customer_id text,
+    provider_subscription_id text,
+    status text NOT NULL,
+    seats integer NOT NULL DEFAULT 1,
+    entitlements jsonb NOT NULL,
+    current_period_end timestamptz,
+    cancel_at_period_end boolean NOT NULL DEFAULT false,
+    metadata jsonb NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_subscriptions_provider_customer_idx
+    ON cloud_subscriptions (provider_id, provider_customer_id)
+    WHERE provider_customer_id IS NOT NULL`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS cloud_subscriptions_provider_subscription_idx
+    ON cloud_subscriptions (provider_id, provider_subscription_id)
+    WHERE provider_subscription_id IS NOT NULL`,
+] as const
+
 export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration[] = [
   {
     id: CLOUD_CONTROL_PLANE_MIGRATION_ID,
@@ -540,5 +566,9 @@ export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration
   {
     id: CLOUD_CONTROL_PLANE_USAGE_QUOTAS_MIGRATION_ID,
     statements: CLOUD_CONTROL_PLANE_USAGE_QUOTAS_STATEMENTS,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_BILLING_SUBSCRIPTIONS_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_BILLING_SUBSCRIPTIONS_STATEMENTS,
   },
 ] as const

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -28,6 +28,7 @@ import {
 import { ControlPlaneQuotaExceededError } from './control-plane-store.ts'
 import type {
   ApiTokenScope,
+  BillingSubscriptionRecord,
   ChannelBindingRecord,
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
@@ -51,6 +52,17 @@ import type {
   UsageEventRecord,
   WorkerLeaseRecord,
 } from './control-plane-store.ts'
+import {
+  BillingAdapterError,
+  evaluateBillingEntitlement,
+  isBillingConfigured,
+  resolvedBillingEntitlements,
+  type BillingAdapter,
+  type BillingAction,
+  type BillingCheckoutResult,
+  type BillingPortalResult,
+  type BillingWebhookResult,
+} from './billing-adapter.ts'
 import type { ByokSecretMetadata, ByokSecretStore } from './byok-secret-store.ts'
 import type {
   CloudRuntimeAdapter,
@@ -67,7 +79,7 @@ import {
   type WorkflowWebhookAuth,
   type WorkflowWebhookSecurityStore,
 } from '../workflow/workflow-webhook-server.ts'
-import type { CloudAbuseConfig } from '../config-types.ts'
+import type { CloudAbuseConfig, CloudBillingConfig } from '../config-types.ts'
 
 export type CloudPrincipal = {
   tenantId: string
@@ -301,6 +313,12 @@ function principalCanManageChannels(principal: CloudPrincipal) {
 }
 
 function principalCanManageByok(principal: CloudPrincipal) {
+  if (principal.authSource === 'local' || principal.authSource === 'header') return true
+  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
+function principalCanManageBilling(principal: CloudPrincipal) {
   if (principal.authSource === 'local' || principal.authSource === 'header') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
   return principal.role === 'owner' || principal.role === 'admin'
@@ -1035,6 +1053,8 @@ export class CloudSessionService {
   private readonly byokSecrets: ByokSecretStore | null
   private readonly byokPolicy: ByokManagementPolicy
   private readonly abuse: CloudAbuseConfig
+  private readonly billingConfig: CloudBillingConfig | null
+  private readonly billingAdapter: BillingAdapter | null
 
   constructor(
     store: ControlPlaneStore,
@@ -1046,6 +1066,8 @@ export class CloudSessionService {
     byokSecrets: ByokSecretStore | null = null,
     byokPolicy: ByokManagementPolicy = {},
     abuse: CloudAbuseConfig = DISABLED_ABUSE_POLICY,
+    billingConfig: CloudBillingConfig | null = null,
+    billingAdapter: BillingAdapter | null = null,
   ) {
     this.store = store
     this.runtime = runtime
@@ -1056,6 +1078,8 @@ export class CloudSessionService {
     this.byokSecrets = byokSecrets
     this.byokPolicy = byokPolicy
     this.abuse = abuse
+    this.billingConfig = billingConfig
+    this.billingAdapter = billingAdapter
   }
 
   get eventBus() {
@@ -1090,12 +1114,17 @@ export class CloudSessionService {
     orgId: string
     quotaKey: string
     limit: number | null | undefined
+    entitlementLimitKey?: 'maxPromptsPerHour' | 'maxGatewayDeliveriesPerHour' | 'maxArtifactBytesPerDay'
     quantity?: number
     windowMs: number
     policyCode: QuotaPolicyCode
     message: string
   }) {
-    const limit = this.quotaLimit(input.limit)
+    const limit = this.quotaLimit(await this.effectiveQuotaLimit(
+      input.orgId,
+      input.limit,
+      input.entitlementLimitKey,
+    ))
     if (!limit) return null
     const result = await this.store.consumeUsageQuota({
       orgId: input.orgId,
@@ -1109,6 +1138,19 @@ export class CloudSessionService {
       throw this.quotaError(input.message, input.policyCode, result.retryAfterMs)
     }
     return result
+  }
+
+  private async effectiveQuotaLimit(
+    orgId: string,
+    fallback: number | null | undefined,
+    key?: 'maxConcurrentSessionsPerOrg' | 'maxActiveWorkersPerOrg' | 'maxPromptsPerHour' | 'maxGatewayDeliveriesPerHour' | 'maxArtifactBytesPerDay',
+  ) {
+    if (!key || !this.billingConfig || !isBillingConfigured(this.billingConfig)) return fallback
+    const subscription = await this.store.getBillingSubscription(orgId)
+    if (!subscription) return fallback
+    const entitlements = resolvedBillingEntitlements(this.billingConfig, subscription)
+    const value = entitlements[key]
+    return value === undefined ? fallback : value
   }
 
   private async recordUsage(input: {
@@ -1166,6 +1208,11 @@ export class CloudSessionService {
     await this.ensurePrincipal(principal)
     if (!this.policy.features.chat) throw new Error('Chat is disabled for this cloud profile.')
     const profileName = input.profileName || this.policy.profileName
+    await this.assertBillingAllowed({
+      orgId: this.principalOrgId(principal),
+      action: 'session.create',
+      profileName,
+    })
     const session = await this.createCloudSessionRecord({
       tenantId: principal.tenantId,
       userId: principal.userId,
@@ -1570,6 +1617,11 @@ export class CloudSessionService {
     })
     const session = await this.store.getSession(principal.tenantId, principal.userId, binding.sessionId)
     if (!session) throw new CloudServiceError(403, 'Channel prompt requires a session owned by the gateway principal.')
+    await this.assertBillingAllowed({
+      orgId: this.principalOrgId(principal),
+      action: 'prompt.enqueue',
+      profileName: session.profileName,
+    })
     await this.store.recordAuditEvent({
       orgId: this.principalOrgId(principal),
       accountId: actor.accountId,
@@ -1584,6 +1636,7 @@ export class CloudSessionService {
       orgId: this.principalOrgId(principal),
       quotaKey: 'prompts:hour',
       limit: this.abuse.maxPromptsPerHour,
+      entitlementLimitKey: 'maxPromptsPerHour',
       windowMs: HOUR_MS,
       policyCode: 'quota.prompts_per_hour_exceeded',
       message: 'Cloud prompt quota exceeded.',
@@ -1742,15 +1795,20 @@ export class CloudSessionService {
     await this.ensurePrincipal(principal)
     this.assertGatewayAccess(principal)
     try {
+      const gatewayDeliveryLimit = await this.effectiveQuotaLimit(
+        this.principalOrgId(principal),
+        this.abuse.maxGatewayDeliveriesPerHour,
+        'maxGatewayDeliveriesPerHour',
+      )
       const delivery = await this.store.claimNextChannelDelivery({
         orgId: this.principalOrgId(principal),
         claimedBy: input.claimedBy,
         ttlMs: input.ttlMs,
         now: input.now,
-        quota: this.quotaLimit(this.abuse.maxGatewayDeliveriesPerHour)
+        quota: this.quotaLimit(gatewayDeliveryLimit)
           ? {
               quotaKey: 'gateway_deliveries:hour',
-              limit: this.abuse.maxGatewayDeliveriesPerHour!,
+              limit: gatewayDeliveryLimit!,
               windowMs: HOUR_MS,
               policyCode: 'quota.gateway_deliveries_per_hour_exceeded',
             }
@@ -2154,6 +2212,7 @@ export class CloudSessionService {
       orgId: this.principalOrgId(principal),
       quotaKey: 'artifact_bytes:day',
       limit: this.abuse.maxArtifactBytesPerDay,
+      entitlementLimitKey: 'maxArtifactBytesPerDay',
       quantity: bytes,
       windowMs: DAY_MS,
       policyCode: 'quota.artifact_bytes_per_day_exceeded',
@@ -2200,6 +2259,120 @@ export class CloudSessionService {
     return this.store.listUsageEvents(this.principalOrgId(principal), limit)
   }
 
+  async getBillingSubscription(principal: CloudPrincipal) {
+    await this.ensurePrincipal(principal)
+    const subscription = await this.store.getBillingSubscription(this.principalOrgId(principal))
+    return {
+      enabled: Boolean(this.billingConfig && isBillingConfigured(this.billingConfig)),
+      providerId: this.billingAdapter?.providerId || this.billingConfig?.provider || 'none',
+      subscription,
+      entitlements: this.billingConfig ? resolvedBillingEntitlements(this.billingConfig, subscription) : {},
+      active: this.billingConfig ? evaluateBillingEntitlement({
+        config: this.billingConfig,
+        subscription,
+        action: 'session.create',
+        profileName: this.policy.profileName,
+      }).allowed : true,
+    }
+  }
+
+  async createBillingCheckout(
+    principal: CloudPrincipal,
+    input: { planKey?: string | null, successUrl?: string | null, cancelUrl?: string | null },
+  ): Promise<BillingCheckoutResult> {
+    await this.ensurePrincipal(principal)
+    this.assertBillingAdmin(principal)
+    if (!this.billingConfig || !isBillingConfigured(this.billingConfig) || !this.billingAdapter) {
+      throw new CloudServiceError(404, 'Billing is not enabled for this cloud deployment.')
+    }
+    const planKey = input.planKey || this.billingConfig.defaultPlanKey
+    if (!this.billingConfig.plans[planKey]) throw new CloudServiceError(400, `Unknown billing plan "${planKey}".`)
+    try {
+      const result = await this.billingAdapter.createCheckoutSession({
+        orgId: this.principalOrgId(principal),
+        accountId: principal.accountId || principal.userId,
+        email: principal.email,
+        planKey,
+        successUrl: input.successUrl,
+        cancelUrl: input.cancelUrl,
+      })
+      if (result.subscription) await this.store.upsertBillingSubscription(result.subscription)
+      await this.store.recordAuditEvent({
+        orgId: this.principalOrgId(principal),
+        accountId: principal.accountId || principal.userId,
+        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+        actorId: principal.tokenId || principal.userId,
+        eventType: 'billing.checkout.created',
+        targetType: 'billing_subscription',
+        targetId: result.providerSessionId || planKey,
+        metadata: { providerId: result.providerId, planKey },
+      })
+      return result
+    } catch (error) {
+      this.translateBillingAdapterError(error)
+    }
+  }
+
+  async createBillingPortal(
+    principal: CloudPrincipal,
+    input: { returnUrl?: string | null },
+  ): Promise<BillingPortalResult> {
+    await this.ensurePrincipal(principal)
+    this.assertBillingAdmin(principal)
+    if (!this.billingConfig || !isBillingConfigured(this.billingConfig) || !this.billingAdapter) {
+      throw new CloudServiceError(404, 'Billing is not enabled for this cloud deployment.')
+    }
+    try {
+      const subscription = await this.store.getBillingSubscription(this.principalOrgId(principal))
+      return await this.billingAdapter.createPortalSession({
+        orgId: this.principalOrgId(principal),
+        email: principal.email,
+        subscription,
+        returnUrl: input.returnUrl,
+      })
+    } catch (error) {
+      this.translateBillingAdapterError(error)
+    }
+  }
+
+  async handleBillingWebhook(input: {
+    headers: Record<string, string | undefined>
+    rawBody: string
+    body: Record<string, unknown>
+  }): Promise<BillingWebhookResult & { subscriptionRecord?: BillingSubscriptionRecord | null }> {
+    if (!this.billingConfig || !isBillingConfigured(this.billingConfig) || !this.billingAdapter) {
+      throw new CloudServiceError(404, 'Billing is not enabled for this cloud deployment.')
+    }
+    try {
+      const result = await this.billingAdapter.handleWebhook(input)
+      let subscriptionRecord: BillingSubscriptionRecord | null = null
+      if (result.subscription) {
+        subscriptionRecord = await this.store.upsertBillingSubscription(result.subscription)
+        await this.store.recordAuditEvent({
+          eventId: `billing_${result.providerId}_${result.eventId}`,
+          orgId: result.subscription.orgId,
+          actorType: 'system',
+          actorId: `billing.${result.providerId}`,
+          eventType: 'billing.webhook.processed',
+          targetType: 'billing_subscription',
+          targetId: result.subscription.providerSubscriptionId || result.subscription.orgId,
+          metadata: {
+            providerId: result.providerId,
+            eventType: result.eventType,
+            planKey: result.subscription.planKey,
+            status: result.subscription.status,
+          },
+        })
+      }
+      return {
+        ...result,
+        subscriptionRecord,
+      }
+    } catch (error) {
+      this.translateBillingAdapterError(error)
+    }
+  }
+
   async claimHttpRateLimit(input: {
     scope: string
     source: string
@@ -2244,11 +2417,17 @@ export class CloudSessionService {
     sessionId: string,
     input: { text: string, agent?: string | null },
   ): Promise<SessionCommandRecord> {
-    await this.getSessionView(principal, sessionId)
+    const view = await this.getSessionView(principal, sessionId)
+    await this.assertBillingAllowed({
+      orgId: this.principalOrgId(principal),
+      action: 'prompt.enqueue',
+      profileName: view.session.profileName,
+    })
     await this.consumeQuota({
       orgId: this.principalOrgId(principal),
       quotaKey: 'prompts:hour',
       limit: this.abuse.maxPromptsPerHour,
+      entitlementLimitKey: 'maxPromptsPerHour',
       windowMs: HOUR_MS,
       policyCode: 'quota.prompts_per_hour_exceeded',
       message: 'Cloud prompt quota exceeded.',
@@ -2632,6 +2811,11 @@ export class CloudSessionService {
     createdAt?: Date
   }) {
     try {
+      const concurrentSessionLimit = await this.effectiveQuotaLimit(
+        input.orgId || input.tenantId,
+        this.abuse.maxConcurrentSessionsPerOrg,
+        'maxConcurrentSessionsPerOrg',
+      )
       const session = await this.store.createSession({
         tenantId: input.tenantId,
         userId: input.userId,
@@ -2640,10 +2824,10 @@ export class CloudSessionService {
         profileName: input.profileName,
         title: input.title,
         createdAt: input.createdAt,
-        quota: this.quotaLimit(this.abuse.maxConcurrentSessionsPerOrg)
+        quota: this.quotaLimit(concurrentSessionLimit)
           ? {
               orgId: input.orgId || input.tenantId,
-              maxConcurrentSessionsPerOrg: this.abuse.maxConcurrentSessionsPerOrg,
+              maxConcurrentSessionsPerOrg: concurrentSessionLimit,
               policyCode: 'quota.concurrent_sessions_exceeded',
             }
           : null,
@@ -3012,6 +3196,61 @@ export class CloudSessionService {
     }
   }
 
+  private assertBillingAdmin(principal: CloudPrincipal) {
+    if (!principalCanManageBilling(principal)) {
+      throw new CloudServiceError(403, 'Billing administration requires an org admin or admin-scoped API token.')
+    }
+  }
+
+  private translateBillingAdapterError(error: unknown): never {
+    if (error instanceof BillingAdapterError) {
+      throw new CloudServiceError(error.status, error.publicMessage)
+    }
+    throw error
+  }
+
+  private async assertBillingAllowed(input: {
+    orgId: string
+    action: BillingAction
+    profileName?: string | null
+    providerId?: string | null
+  }) {
+    if (!this.billingConfig || !isBillingConfigured(this.billingConfig)) return
+    const subscription = await this.store.getBillingSubscription(input.orgId)
+    const verdict = evaluateBillingEntitlement({
+      config: this.billingConfig,
+      subscription,
+      action: input.action,
+      profileName: input.profileName,
+      providerId: input.providerId,
+    })
+    if (!verdict.allowed) {
+      throw new CloudServiceError(
+        verdict.status || 402,
+        verdict.reason || 'Billing entitlement does not allow this action.',
+        { policyCode: verdict.policyCode || 'billing.entitlement_denied' },
+      )
+    }
+  }
+
+  async assertWorkerExecutionAllowed(tenantId: string) {
+    const org = await this.store.ensureOrgForTenant({ tenantId, name: tenantId })
+    await this.assertBillingAllowed({
+      orgId: org.orgId,
+      action: 'worker.execute',
+      profileName: this.policy.profileName,
+    })
+  }
+
+  async activeWorkerQuotaForTenant(tenantId: string) {
+    const org = await this.store.ensureOrgForTenant({ tenantId, name: tenantId })
+    return this.quotaLimit(await this.effectiveQuotaLimit(
+      org.orgId,
+      this.abuse.maxActiveWorkersPerOrg,
+      'maxActiveWorkersPerOrg',
+    ))
+  }
+
   private byokAuditActor(principal: CloudPrincipal) {
     return {
       actorType: principal.authSource === 'api_token' ? 'api_token' as const : 'user' as const,
@@ -3028,6 +3267,11 @@ export class CloudSessionService {
     if (allowedProviderIds?.size && !allowedProviderIds.has(providerId)) {
       throw new CloudServiceError(403, `Provider "${providerId}" is not enabled for BYOK in this cloud profile.`)
     }
+    await this.assertBillingAllowed({
+      orgId: this.principalOrgId(principal),
+      action: 'byok.provider',
+      providerId,
+    })
     const entitlement = await this.byokPolicy.checkEntitlement?.({
       principal,
       orgId: this.principalOrgId(principal),

--- a/apps/desktop/src/main/cloud/stripe-billing-adapter.ts
+++ b/apps/desktop/src/main/cloud/stripe-billing-adapter.ts
@@ -1,0 +1,273 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import type { CloudBillingConfig, CloudSubscriptionStatus } from '../config-types.ts'
+import type {
+  BillingAdapter,
+  BillingCheckoutInput,
+  BillingCheckoutResult,
+  BillingPortalInput,
+  BillingPortalResult,
+  BillingWebhookInput,
+  BillingWebhookResult,
+} from './billing-adapter.ts'
+import {
+  BillingAdapterError,
+  BillingWebhookAuthError,
+  planEntitlements,
+  subscriptionPlanKeyForPrice,
+} from './billing-adapter.ts'
+
+type FetchLike = typeof fetch
+
+export type StripeBillingAdapterOptions = {
+  config: CloudBillingConfig
+  apiKey?: string | null
+  webhookSecret?: string | null
+  fetch?: FetchLike
+  now?: () => Date
+}
+
+function readString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function readBoolean(value: unknown) {
+  return value === true
+}
+
+function firstHeader(headers: Record<string, string | undefined>, name: string) {
+  return headers[name.toLowerCase()] || headers[name] || null
+}
+
+function stripeStatus(value: unknown, deleted = false): CloudSubscriptionStatus {
+  if (deleted) return 'canceled'
+  const status = readString(value)
+  if (status === 'trialing' || status === 'active' || status === 'past_due' || status === 'canceled' || status === 'incomplete') {
+    return status
+  }
+  return 'incomplete'
+}
+
+function metadataObject(value: unknown) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function firstSubscriptionPriceId(subscription: Record<string, unknown>) {
+  const items = metadataObject(subscription.items)
+  const data = Array.isArray(items.data) ? items.data : []
+  const first = data[0] && typeof data[0] === 'object' && !Array.isArray(data[0])
+    ? data[0] as Record<string, unknown>
+    : null
+  const price = first?.price && typeof first.price === 'object' && !Array.isArray(first.price)
+    ? first.price as Record<string, unknown>
+    : null
+  return readString(price?.id)
+}
+
+function verifyStripeSignature(input: {
+  rawBody: string
+  signatureHeader: string | null
+  webhookSecret: string
+  now: Date
+}) {
+  const header = input.signatureHeader
+  if (!header) throw new BillingWebhookAuthError('Stripe-Signature header is required.')
+  const values = new Map<string, string[]>()
+  for (const entry of header.split(',')) {
+    const [key, value] = entry.split('=')
+    if (!key || !value) continue
+    const bucket = values.get(key) || []
+    bucket.push(value)
+    values.set(key, bucket)
+  }
+  const timestamp = values.get('t')?.[0]
+  const signatures = values.get('v1') || []
+  if (!timestamp || signatures.length === 0) throw new BillingWebhookAuthError('Stripe webhook signature is malformed.')
+  const timestampMs = Number(timestamp) * 1000
+  if (!Number.isFinite(timestampMs) || Math.abs(input.now.getTime() - timestampMs) > 5 * 60 * 1000) {
+    throw new BillingWebhookAuthError('Stripe webhook timestamp is outside the replay window.')
+  }
+  const expected = createHmac('sha256', input.webhookSecret)
+    .update(`${timestamp}.${input.rawBody}`)
+    .digest('hex')
+  const expectedBytes = Buffer.from(expected)
+  const accepted = signatures.some((signature) => {
+    const actualBytes = Buffer.from(signature)
+    return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes)
+  })
+  if (!accepted) throw new BillingWebhookAuthError()
+}
+
+async function postStripeForm(input: {
+  apiKey: string
+  path: string
+  form: URLSearchParams
+  fetchImpl: FetchLike
+}) {
+  const response = await input.fetchImpl(`https://api.stripe.com/v1/${input.path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${input.apiKey}`,
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    body: input.form,
+  })
+  const json = await response.json().catch(() => ({})) as Record<string, unknown>
+  if (!response.ok) {
+    const error = metadataObject(json.error)
+    throw new BillingAdapterError(response.status, readString(error.message) || 'Stripe billing request failed.')
+  }
+  return json
+}
+
+export function createStripeBillingAdapter(options: StripeBillingAdapterOptions): BillingAdapter {
+  const fetchImpl = options.fetch || fetch
+  const now = options.now || (() => new Date())
+  const stripeConfig = options.config.stripe || {}
+
+  return {
+    providerId: 'stripe',
+    enabled: true,
+
+    async createCheckoutSession(input: BillingCheckoutInput): Promise<BillingCheckoutResult> {
+      if (!options.apiKey) throw new BillingAdapterError(503, 'Stripe API key is not configured.')
+      const plan = options.config.plans[input.planKey]
+      const priceId = plan?.stripePriceId || stripeConfig.defaultPriceId
+      if (!priceId) throw new BillingAdapterError(400, `No Stripe price is configured for plan "${input.planKey}".`)
+      const successUrl = input.successUrl || stripeConfig.successUrl
+      const cancelUrl = input.cancelUrl || stripeConfig.cancelUrl
+      if (!successUrl || !cancelUrl) throw new BillingAdapterError(400, 'Stripe checkout requires success and cancel URLs.')
+
+      const form = new URLSearchParams()
+      form.set('mode', 'subscription')
+      form.set('success_url', successUrl)
+      form.set('cancel_url', cancelUrl)
+      form.set('client_reference_id', input.orgId)
+      form.set('customer_email', input.email)
+      form.set('metadata[orgId]', input.orgId)
+      form.set('metadata[accountId]', input.accountId || '')
+      form.set('metadata[planKey]', input.planKey)
+      form.set('subscription_data[metadata][orgId]', input.orgId)
+      form.set('subscription_data[metadata][accountId]', input.accountId || '')
+      form.set('subscription_data[metadata][planKey]', input.planKey)
+      form.set('line_items[0][price]', priceId)
+      form.set('line_items[0][quantity]', '1')
+
+      const json = await postStripeForm({
+        apiKey: options.apiKey,
+        path: 'checkout/sessions',
+        form,
+        fetchImpl,
+      })
+      const url = readString(json.url)
+      if (!url) throw new BillingAdapterError(502, 'Stripe checkout did not return a URL.')
+      return {
+        providerId: 'stripe',
+        providerSessionId: readString(json.id),
+        url,
+      }
+    },
+
+    async createPortalSession(input: BillingPortalInput): Promise<BillingPortalResult> {
+      if (!options.apiKey) throw new BillingAdapterError(503, 'Stripe API key is not configured.')
+      const customerId = input.subscription?.providerCustomerId
+      if (!customerId) throw new BillingAdapterError(404, 'No Stripe customer is associated with this org.')
+      const returnUrl = input.returnUrl || stripeConfig.portalReturnUrl
+      if (!returnUrl) throw new BillingAdapterError(400, 'Stripe portal requires a return URL.')
+      const form = new URLSearchParams()
+      form.set('customer', customerId)
+      form.set('return_url', returnUrl)
+      const json = await postStripeForm({
+        apiKey: options.apiKey,
+        path: 'billing_portal/sessions',
+        form,
+        fetchImpl,
+      })
+      const url = readString(json.url)
+      if (!url) throw new BillingAdapterError(502, 'Stripe portal did not return a URL.')
+      return {
+        providerId: 'stripe',
+        url,
+      }
+    },
+
+    handleWebhook(input: BillingWebhookInput): BillingWebhookResult {
+      if (options.webhookSecret) {
+        verifyStripeSignature({
+          rawBody: input.rawBody,
+          signatureHeader: firstHeader(input.headers, 'stripe-signature'),
+          webhookSecret: options.webhookSecret,
+          now: now(),
+        })
+      }
+      const event = input.body
+      const eventId = readString(event.id)
+      const eventType = readString(event.type)
+      if (!eventId || !eventType) throw new BillingAdapterError(400, 'Stripe webhook event id and type are required.')
+      const data = metadataObject(event.data)
+      const object = metadataObject(data.object)
+
+      if (eventType === 'checkout.session.completed') {
+        const metadata = metadataObject(object.metadata)
+        const orgId = readString(metadata.orgId) || readString(object.client_reference_id)
+        const planKey = readString(metadata.planKey) || options.config.defaultPlanKey
+        if (!orgId) {
+          return { providerId: 'stripe', eventId, eventType }
+        }
+        return {
+          providerId: 'stripe',
+          eventId,
+          eventType,
+          subscription: {
+            orgId,
+            providerId: 'stripe',
+            providerCustomerId: readString(object.customer),
+            providerSubscriptionId: readString(object.subscription),
+            planKey,
+            status: 'active',
+            seats: 1,
+            entitlements: planEntitlements(options.config, planKey),
+            metadata: { stripeEventType: eventType },
+          },
+        }
+      }
+
+      if (eventType.startsWith('customer.subscription.')) {
+        const metadata = metadataObject(object.metadata)
+        const priceId = firstSubscriptionPriceId(object)
+        const planKey = readString(metadata.planKey) || subscriptionPlanKeyForPrice(options.config, priceId)
+        const orgId = readString(metadata.orgId)
+        if (!orgId) {
+          return { providerId: 'stripe', eventId, eventType }
+        }
+        const currentPeriodEndSeconds = Number(object.current_period_end)
+        return {
+          providerId: 'stripe',
+          eventId,
+          eventType,
+          subscription: {
+            orgId,
+            providerId: 'stripe',
+            providerCustomerId: readString(object.customer),
+            providerSubscriptionId: readString(object.id),
+            planKey,
+            status: stripeStatus(object.status, eventType === 'customer.subscription.deleted'),
+            seats: Number(object.quantity) || 1,
+            entitlements: planEntitlements(options.config, planKey),
+            currentPeriodEnd: Number.isFinite(currentPeriodEndSeconds)
+              ? new Date(currentPeriodEndSeconds * 1000)
+              : null,
+            cancelAtPeriodEnd: readBoolean(object.cancel_at_period_end),
+            metadata: {
+              stripeEventType: eventType,
+              priceId,
+            },
+          },
+        }
+      }
+
+      return { providerId: 'stripe', eventId, eventType }
+    },
+  }
+}

--- a/apps/desktop/src/main/cloud/stub-billing-adapter.ts
+++ b/apps/desktop/src/main/cloud/stub-billing-adapter.ts
@@ -1,0 +1,86 @@
+import type { CloudBillingConfig, CloudSubscriptionStatus } from '../config-types.ts'
+import type {
+  BillingAdapter,
+  BillingCheckoutInput,
+  BillingCheckoutResult,
+  BillingPortalInput,
+  BillingPortalResult,
+  BillingWebhookInput,
+  BillingWebhookResult,
+} from './billing-adapter.ts'
+import { planEntitlements } from './billing-adapter.ts'
+
+function readString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function createStubBillingAdapter(config: CloudBillingConfig): BillingAdapter {
+  return {
+    providerId: 'stub',
+    enabled: true,
+
+    createCheckoutSession(input: BillingCheckoutInput): BillingCheckoutResult {
+      const planKey = input.planKey || config.defaultPlanKey
+      return {
+        providerId: 'stub',
+        providerSessionId: `stub_checkout_${input.orgId}_${planKey}`,
+        url: `https://billing.local/checkout?orgId=${encodeURIComponent(input.orgId)}&plan=${encodeURIComponent(planKey)}`,
+        subscription: {
+          orgId: input.orgId,
+          providerId: 'stub',
+          providerCustomerId: `stub_customer_${input.orgId}`,
+          providerSubscriptionId: `stub_subscription_${input.orgId}`,
+          planKey,
+          status: 'active',
+          seats: 1,
+          entitlements: planEntitlements(config, planKey),
+          metadata: {
+            source: 'stub_checkout',
+            accountId: input.accountId,
+          },
+        },
+      }
+    },
+
+    createPortalSession(input: BillingPortalInput): BillingPortalResult {
+      return {
+        providerId: 'stub',
+        url: `https://billing.local/portal?orgId=${encodeURIComponent(input.orgId)}`,
+      }
+    },
+
+    handleWebhook(input: BillingWebhookInput): BillingWebhookResult {
+      const body = input.body
+      const subscription = body.subscription && typeof body.subscription === 'object' && !Array.isArray(body.subscription)
+        ? body.subscription as Record<string, unknown>
+        : body
+      const orgId = readString(subscription.orgId)
+      if (!orgId) {
+        return {
+          providerId: 'stub',
+          eventId: readString(body.id) || `stub_event_${Date.now()}`,
+          eventType: readString(body.type) || 'stub.ignored',
+        }
+      }
+      const planKey = readString(subscription.planKey) || config.defaultPlanKey
+      return {
+        providerId: 'stub',
+        eventId: readString(body.id) || `stub_event_${orgId}_${planKey}`,
+        eventType: readString(body.type) || 'customer.subscription.updated',
+        subscription: {
+          orgId,
+          providerId: 'stub',
+          providerCustomerId: readString(subscription.providerCustomerId) || `stub_customer_${orgId}`,
+          providerSubscriptionId: readString(subscription.providerSubscriptionId) || `stub_subscription_${orgId}`,
+          planKey,
+          status: (readString(subscription.status) || 'active') as CloudSubscriptionStatus,
+          seats: Number(subscription.seats) || 1,
+          entitlements: planEntitlements(config, planKey),
+          metadata: {
+            source: 'stub_webhook',
+          },
+        },
+      }
+    },
+  }
+}

--- a/apps/desktop/src/main/cloud/worker.ts
+++ b/apps/desktop/src/main/cloud/worker.ts
@@ -97,6 +97,14 @@ export class CloudWorker {
 
   private async getOrClaimLease(tenantId: string, sessionId: string): Promise<WorkerLeaseRecord | null> {
     const leaseKey = this.leaseKey(tenantId, sessionId)
+    try {
+      await this.service.assertWorkerExecutionAllowed(tenantId)
+    } catch (error) {
+      if (error && typeof error === 'object' && 'status' in error && (error as { status?: unknown }).status === 402) {
+        return null
+      }
+      throw error
+    }
     const existing = this.leases.get(leaseKey)
     if (existing) {
       try {
@@ -107,16 +115,17 @@ export class CloudWorker {
         this.leases.delete(leaseKey)
       }
     }
+    const maxActiveWorkersPerOrg = await this.service.activeWorkerQuotaForTenant(tenantId)
     const claimed = await this.store.claimSessionLease(
       tenantId,
       sessionId,
       this.workerId,
       new Date(),
       this.leaseTtlMs,
-      this.abuse?.enabled && this.abuse.maxActiveWorkersPerOrg
+      this.abuse?.enabled && maxActiveWorkersPerOrg
         ? {
             orgId: tenantId,
-            maxActiveWorkersPerOrg: this.abuse.maxActiveWorkersPerOrg,
+            maxActiveWorkersPerOrg,
             policyCode: 'quota.active_workers_exceeded',
           }
         : null,

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -256,6 +256,59 @@ function normalizeCloudAbuseConfig(raw: CloudConfig['abuse'] | undefined): Cloud
   }
 }
 
+function normalizeBillingEntitlements(raw: CloudConfig['billing']['plans'][string]['entitlements'] | undefined): CloudConfig['billing']['plans'][string]['entitlements'] {
+  if (!raw) return undefined
+  return {
+    ...raw,
+    allowedProfiles: raw.allowedProfiles === null ? null : stringArray(raw.allowedProfiles),
+    allowedProviders: raw.allowedProviders === null ? null : stringArray(raw.allowedProviders),
+    maxConcurrentSessionsPerOrg: nullablePositiveNumber(raw.maxConcurrentSessionsPerOrg, null),
+    maxActiveWorkersPerOrg: nullablePositiveNumber(raw.maxActiveWorkersPerOrg, null),
+    maxPromptsPerHour: nullablePositiveNumber(raw.maxPromptsPerHour, null),
+    maxGatewayDeliveriesPerHour: nullablePositiveNumber(raw.maxGatewayDeliveriesPerHour, null),
+    maxArtifactBytesPerDay: nullablePositiveNumber(raw.maxArtifactBytesPerDay, null),
+  }
+}
+
+function normalizeCloudBillingConfig(raw: CloudConfig['billing'] | undefined): CloudConfig['billing'] {
+  const defaults = DEFAULT_CONFIG.cloud.billing
+  const source = raw || defaults
+  const providers = new Set(['none', 'stub', 'stripe'])
+  const plans: CloudConfig['billing']['plans'] = {}
+  for (const [planKey, plan] of Object.entries(defaults.plans)) {
+    plans[planKey] = {
+      ...plan,
+      entitlements: normalizeBillingEntitlements(plan.entitlements),
+    }
+  }
+  for (const [planKey, plan] of Object.entries(source.plans || {})) {
+    if (!planKey.trim()) continue
+    plans[planKey] = {
+      ...(plans[planKey] || {}),
+      ...plan,
+      entitlements: normalizeBillingEntitlements({
+        ...(plans[planKey]?.entitlements || {}),
+        ...(plan.entitlements || {}),
+      }),
+    }
+  }
+  const defaultPlanKey = source.defaultPlanKey && plans[source.defaultPlanKey]
+    ? source.defaultPlanKey
+    : defaults.defaultPlanKey
+  return {
+    ...defaults,
+    ...source,
+    enabled: typeof source.enabled === 'boolean' ? source.enabled : defaults.enabled,
+    provider: providers.has(source.provider) ? source.provider : defaults.provider,
+    defaultPlanKey,
+    plans,
+    stripe: {
+      ...(defaults.stripe || {}),
+      ...(source.stripe || {}),
+    },
+  }
+}
+
 function normalizeCloudProfile(raw: CloudProfileConfig | undefined): CloudProfileConfig {
   return {
     ...(raw || {}),
@@ -342,6 +395,7 @@ function normalizeCloudConfig(raw: CloudConfig | undefined): CloudConfig {
     },
     features: normalizeCloudFeatures(source.features),
     abuse: normalizeCloudAbuseConfig(source.abuse),
+    billing: normalizeCloudBillingConfig(source.billing),
   }
 }
 

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -286,6 +286,45 @@ export type CloudAbuseConfig = {
   authBackoff: CloudAuthBackoffConfig
 }
 
+export type CloudBillingProvider = 'none' | 'stub' | 'stripe'
+
+export type CloudSubscriptionStatus = 'trialing' | 'active' | 'past_due' | 'canceled' | 'incomplete'
+
+export type CloudBillingEntitlements = {
+  features?: Partial<CloudFeatureConfig>
+  allowedProfiles?: string[] | null
+  allowedProviders?: string[] | null
+  maxConcurrentSessionsPerOrg?: number | null
+  maxActiveWorkersPerOrg?: number | null
+  maxPromptsPerHour?: number | null
+  maxGatewayDeliveriesPerHour?: number | null
+  maxArtifactBytesPerDay?: number | null
+  allowNewSessions?: boolean
+  allowPrompts?: boolean
+  allowWorkers?: boolean
+}
+
+export type CloudBillingPlanConfig = {
+  label?: string
+  stripePriceId?: string
+  entitlements?: CloudBillingEntitlements
+}
+
+export type CloudBillingConfig = {
+  enabled: boolean
+  provider: CloudBillingProvider
+  defaultPlanKey: string
+  plans: Record<string, CloudBillingPlanConfig>
+  stripe?: {
+    apiKeyRef?: string
+    webhookSecretRef?: string
+    defaultPriceId?: string
+    successUrl?: string
+    cancelUrl?: string
+    portalReturnUrl?: string
+  }
+}
+
 export type CloudDesktopConnectionConfig = {
   baseUrl: string
   label?: string
@@ -309,6 +348,7 @@ export type CloudConfig = {
   runtime: CloudRuntimePolicyConfig
   features: CloudFeatureConfig
   abuse: CloudAbuseConfig
+  billing: CloudBillingConfig
 }
 
 export type OpenCoworkConfig = {
@@ -447,6 +487,22 @@ const DEFAULT_CLOUD_ABUSE: CloudAbuseConfig = {
   },
 }
 
+const DEFAULT_CLOUD_BILLING: CloudBillingConfig = {
+  enabled: false,
+  provider: 'none',
+  defaultPlanKey: 'self-host',
+  plans: {
+    'self-host': {
+      label: 'Self-host',
+      entitlements: {
+        allowNewSessions: true,
+        allowPrompts: true,
+        allowWorkers: true,
+      },
+    },
+  },
+}
+
 const DEFAULT_CLOUD_DESKTOP: CloudDesktopConfig = {
   enabled: true,
   allowUserAddedConnections: true,
@@ -518,6 +574,7 @@ export const DEFAULT_CONFIG: OpenCoworkConfig = {
     runtime: DEFAULT_CLOUD_RUNTIME,
     features: DEFAULT_CLOUD_FEATURES,
     abuse: DEFAULT_CLOUD_ABUSE,
+    billing: DEFAULT_CLOUD_BILLING,
     profiles: {
       full: {
         label: 'Full app',

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -271,7 +271,8 @@
         "storage": { "$ref": "#/$defs/cloudStorage" },
         "runtime": { "$ref": "#/$defs/cloudRuntimePolicy" },
         "features": { "$ref": "#/$defs/cloudFeatures" },
-        "abuse": { "$ref": "#/$defs/cloudAbuse" }
+        "abuse": { "$ref": "#/$defs/cloudAbuse" },
+        "billing": { "$ref": "#/$defs/cloudBilling" }
       }
     },
     "cloudRole": {
@@ -370,6 +371,68 @@
         { "$ref": "#/$defs/cloudPositiveInteger" },
         { "type": "null" }
       ]
+    },
+    "cloudBilling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "provider": { "type": "string", "enum": ["none", "stub", "stripe"] },
+        "defaultPlanKey": { "$ref": "#/$defs/cloudName" },
+        "plans": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/cloudBillingPlan" }
+        },
+        "stripe": { "$ref": "#/$defs/cloudStripeBilling" }
+      }
+    },
+    "cloudBillingPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": { "type": "string", "maxLength": 80 },
+        "stripePriceId": { "type": "string", "maxLength": 256 },
+        "entitlements": { "$ref": "#/$defs/cloudBillingEntitlements" }
+      }
+    },
+    "cloudBillingEntitlements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "features": { "$ref": "#/$defs/cloudFeatures" },
+        "allowedProfiles": {
+          "anyOf": [
+            { "$ref": "#/$defs/cloudStringList" },
+            { "type": "null" }
+          ]
+        },
+        "allowedProviders": {
+          "anyOf": [
+            { "$ref": "#/$defs/cloudStringList" },
+            { "type": "null" }
+          ]
+        },
+        "maxConcurrentSessionsPerOrg": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxActiveWorkersPerOrg": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxPromptsPerHour": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxGatewayDeliveriesPerHour": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "maxArtifactBytesPerDay": { "$ref": "#/$defs/cloudPositiveIntegerOrNull" },
+        "allowNewSessions": { "type": "boolean" },
+        "allowPrompts": { "type": "boolean" },
+        "allowWorkers": { "type": "boolean" }
+      }
+    },
+    "cloudStripeBilling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apiKeyRef": { "type": "string", "maxLength": 512 },
+        "webhookSecretRef": { "type": "string", "maxLength": 512 },
+        "defaultPriceId": { "type": "string", "maxLength": 256 },
+        "successUrl": { "$ref": "#/$defs/httpsOrLocalhostUrl" },
+        "cancelUrl": { "$ref": "#/$defs/httpsOrLocalhostUrl" },
+        "portalReturnUrl": { "$ref": "#/$defs/httpsOrLocalhostUrl" }
+      }
     },
     "cloudRuntimePolicy": {
       "type": "object",

--- a/tests/billing-adapter.test.ts
+++ b/tests/billing-adapter.test.ts
@@ -1,0 +1,167 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac } from 'node:crypto'
+
+import { DEFAULT_CONFIG, type CloudBillingConfig } from '../apps/desktop/src/main/config-types.ts'
+import { evaluateBillingEntitlement } from '../apps/desktop/src/main/cloud/billing-adapter.ts'
+import { createStripeBillingAdapter } from '../apps/desktop/src/main/cloud/stripe-billing-adapter.ts'
+import { createStubBillingAdapter } from '../apps/desktop/src/main/cloud/stub-billing-adapter.ts'
+
+function billingConfig(): CloudBillingConfig {
+  return {
+    ...DEFAULT_CONFIG.cloud.billing,
+    enabled: true,
+    provider: 'stripe',
+    defaultPlanKey: 'pro',
+    plans: {
+      pro: {
+        label: 'Pro',
+        stripePriceId: 'price_pro',
+        entitlements: {
+          allowNewSessions: true,
+          allowPrompts: true,
+          allowWorkers: true,
+          allowedProviders: ['anthropic'],
+        },
+      },
+    },
+    stripe: {
+      defaultPriceId: 'price_pro',
+      successUrl: 'https://app.example.test/success',
+      cancelUrl: 'https://app.example.test/cancel',
+      portalReturnUrl: 'https://app.example.test/billing',
+    },
+  }
+}
+
+function signedStripePayload(secret: string, body: string, timestamp = 1_778_000_000) {
+  const signature = createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex')
+  return `t=${timestamp},v1=${signature}`
+}
+
+test('stub billing adapter creates an active local subscription checkout', async () => {
+  const config = {
+    ...billingConfig(),
+    provider: 'stub' as const,
+  }
+  const adapter = createStubBillingAdapter(config)
+  const checkout = await adapter.createCheckoutSession({
+    orgId: 'org-1',
+    accountId: 'account-1',
+    email: 'owner@example.test',
+    planKey: 'pro',
+  })
+
+  assert.equal(checkout.providerId, 'stub')
+  assert.match(checkout.url, /billing\.local/)
+  assert.equal(checkout.subscription?.status, 'active')
+  assert.equal(checkout.subscription?.entitlements.allowedProviders?.[0], 'anthropic')
+})
+
+test('stripe billing adapter creates checkout and verifies subscription webhooks without importing Stripe', async () => {
+  const config = billingConfig()
+  const requests: Array<{ url: string, body: string }> = []
+  const adapter = createStripeBillingAdapter({
+    config,
+    apiKey: 'sk_test_secret',
+    webhookSecret: 'whsec_test',
+    now: () => new Date(1_778_000_000_000),
+    fetch: (async (url, init) => {
+      requests.push({ url: String(url), body: String(init?.body) })
+      return new Response(JSON.stringify({
+        id: 'cs_test_123',
+        url: 'https://checkout.stripe.test/session',
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as typeof fetch,
+  })
+
+  const checkout = await adapter.createCheckoutSession({
+    orgId: 'org-1',
+    accountId: 'account-1',
+    email: 'owner@example.test',
+    planKey: 'pro',
+  })
+  assert.equal(checkout.url, 'https://checkout.stripe.test/session')
+  assert.equal(requests[0]?.url, 'https://api.stripe.com/v1/checkout/sessions')
+  assert.match(requests[0]?.body || '', /metadata%5BorgId%5D=org-1/)
+
+  const updatedBody = JSON.stringify({
+    id: 'evt_updated',
+    type: 'customer.subscription.updated',
+    data: {
+      object: {
+        id: 'sub_123',
+        customer: 'cus_123',
+        status: 'active',
+        quantity: 3,
+        current_period_end: 1779000000,
+        metadata: { orgId: 'org-1', planKey: 'pro' },
+        items: { data: [{ price: { id: 'price_pro' } }] },
+      },
+    },
+  })
+  const updated = await adapter.handleWebhook({
+    headers: { 'stripe-signature': signedStripePayload('whsec_test', updatedBody) },
+    rawBody: updatedBody,
+    body: JSON.parse(updatedBody) as Record<string, unknown>,
+  })
+  assert.equal(updated.subscription?.status, 'active')
+  assert.equal(updated.subscription?.seats, 3)
+  assert.equal(updated.subscription?.entitlements.allowedProviders?.[0], 'anthropic')
+
+  const deletedBody = JSON.stringify({
+    id: 'evt_deleted',
+    type: 'customer.subscription.deleted',
+    data: {
+      object: {
+        id: 'sub_123',
+        customer: 'cus_123',
+        status: 'active',
+        metadata: { orgId: 'org-1', planKey: 'pro' },
+      },
+    },
+  })
+  const deleted = await adapter.handleWebhook({
+    headers: { 'stripe-signature': signedStripePayload('whsec_test', deletedBody) },
+    rawBody: deletedBody,
+    body: JSON.parse(deletedBody) as Record<string, unknown>,
+  })
+  assert.equal(deleted.subscription?.status, 'canceled')
+
+  assert.throws(() => adapter.handleWebhook({
+    headers: { 'stripe-signature': 't=1778000000,v1=bad' },
+    rawBody: updatedBody,
+    body: JSON.parse(updatedBody) as Record<string, unknown>,
+  }), /authorization/i)
+})
+
+test('billing entitlement evaluator returns machine-readable 402 decisions', () => {
+  const config = billingConfig()
+  assert.equal(evaluateBillingEntitlement({
+    config,
+    subscription: null,
+    action: 'session.create',
+  }).policyCode, 'billing.subscription_required')
+
+  const inactive = evaluateBillingEntitlement({
+    config,
+    subscription: {
+      orgId: 'org-1',
+      planKey: 'pro',
+      providerId: 'stripe',
+      providerCustomerId: 'cus_123',
+      providerSubscriptionId: 'sub_123',
+      status: 'past_due',
+      seats: 1,
+      entitlements: {},
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      metadata: {},
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    action: 'worker.execute',
+  })
+  assert.equal(inactive.status, 402)
+  assert.equal(inactive.policyCode, 'billing.subscription_inactive')
+})

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -14,6 +14,7 @@ import {
   resolveCloudAuthConfig,
   resolveCloudControlPlaneUrl,
   resolveCloudBootstrapOptionsFromEnv,
+  resolveCloudBillingConfig,
   resolveCloudInternalToken,
   resolveCloudOidcClientSecret,
   shouldRunCloudScheduler,
@@ -219,6 +220,27 @@ test('cloud internal token resolves from explicit env before env refs', () => {
     OPEN_COWORK_CLOUD_INTERNAL_TOKEN_REF: 'INTERNAL_TOKEN_REF',
     INTERNAL_TOKEN_REF: 'from-ref',
   }), 'from-env')
+})
+
+test('cloud billing config resolves provider, plan, and Stripe refs from env', () => {
+  const resolved = resolveCloudBillingConfig(DEFAULT_CONFIG, {
+    OPEN_COWORK_CLOUD_BILLING_ENABLED: 'true',
+    OPEN_COWORK_CLOUD_BILLING_PROVIDER: 'stripe',
+    OPEN_COWORK_CLOUD_BILLING_DEFAULT_PLAN: 'pro',
+    OPEN_COWORK_CLOUD_STRIPE_API_KEY_REF: 'env:STRIPE_API_KEY',
+    OPEN_COWORK_CLOUD_STRIPE_WEBHOOK_SECRET_REF: 'env:STRIPE_WEBHOOK_SECRET',
+    OPEN_COWORK_CLOUD_STRIPE_PRICE_ID: 'price_pro',
+    OPEN_COWORK_CLOUD_STRIPE_SUCCESS_URL: 'https://app.example.test/success',
+    OPEN_COWORK_CLOUD_STRIPE_CANCEL_URL: 'https://app.example.test/cancel',
+    OPEN_COWORK_CLOUD_STRIPE_PORTAL_RETURN_URL: 'https://app.example.test/billing',
+  })
+
+  assert.equal(resolved.enabled, true)
+  assert.equal(resolved.provider, 'stripe')
+  assert.equal(resolved.defaultPlanKey, 'pro')
+  assert.equal(resolved.stripe?.apiKeyRef, 'env:STRIPE_API_KEY')
+  assert.equal(resolved.stripe?.webhookSecretRef, 'env:STRIPE_WEBHOOK_SECRET')
+  assert.equal(resolved.stripe?.defaultPriceId, 'price_pro')
 })
 
 test('cloud auth config resolves OIDC deployment settings from env', () => {

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -296,6 +296,51 @@ test('cloud control plane records usage and enforces windowed quotas', () => {
   assert.equal(usage[0]?.metadata.safe, 'yes')
 })
 
+test('cloud control plane stores billing subscriptions by org and provider ids', () => {
+  const store = seededStore()
+  const orgId = 'tenant-1'
+
+  const active = store.upsertBillingSubscription({
+    orgId,
+    planKey: 'pro',
+    providerId: 'stripe',
+    providerCustomerId: 'cus_123',
+    providerSubscriptionId: 'sub_123',
+    status: 'active',
+    seats: 2,
+    entitlements: { allowPrompts: true, maxPromptsPerHour: 10 },
+    currentPeriodEnd: new Date('2026-02-01T00:00:00.000Z'),
+    metadata: { source: 'test', apiKey: 'secret-value' },
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  })
+  assert.equal(active.status, 'active')
+  assert.equal(active.seats, 2)
+  assert.equal(active.metadata.apiKey, '[redacted]')
+  assert.equal(store.getBillingSubscription(orgId)?.providerSubscriptionId, 'sub_123')
+  assert.equal(store.findBillingSubscriptionByProvider({
+    providerId: 'stripe',
+    providerSubscriptionId: 'sub_123',
+  })?.orgId, orgId)
+  assert.equal(store.findBillingSubscriptionByProvider({
+    providerId: 'stripe',
+    providerCustomerId: 'cus_123',
+  })?.orgId, orgId)
+
+  const canceled = store.upsertBillingSubscription({
+    orgId,
+    planKey: 'pro',
+    providerId: 'stripe',
+    providerCustomerId: 'cus_123',
+    providerSubscriptionId: 'sub_123',
+    status: 'canceled',
+    entitlements: { allowPrompts: false },
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  })
+  assert.equal(canceled.status, 'canceled')
+  assert.equal(store.getBillingSubscription(orgId)?.status, 'canceled')
+  assert.equal(store.listAuditEvents(orgId).some((event) => event.eventType === 'billing.subscription.updated'), true)
+})
+
 test('cloud control plane caps concurrent sessions and active workers', () => {
   const store = seededStore()
   assert.throws(() => store.createSession({

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -1,8 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { DEFAULT_CONFIG, type CloudAbuseConfig } from '../apps/desktop/src/main/config-types.ts'
+import { DEFAULT_CONFIG, type CloudAbuseConfig, type CloudBillingConfig } from '../apps/desktop/src/main/config-types.ts'
 import { CloudArtifactService } from '../apps/desktop/src/main/cloud/artifact-service.ts'
+import type { BillingAdapter } from '../apps/desktop/src/main/cloud/billing-adapter.ts'
 import { createApiTokenCloudAuthResolver } from '../apps/desktop/src/main/cloud/app.ts'
 import { createByokSecretStore } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
 import { resolveCloudRuntimePolicy, type CloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
@@ -21,6 +22,7 @@ import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/o
 import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secret-adapter.ts'
 import { createCloudSessionCookieManager } from '../apps/desktop/src/main/cloud/session-cookie-auth.ts'
 import { CloudSessionService, type ByokManagementPolicy } from '../apps/desktop/src/main/cloud/session-service.ts'
+import { createStubBillingAdapter } from '../apps/desktop/src/main/cloud/stub-billing-adapter.ts'
 import { CloudWorker } from '../apps/desktop/src/main/cloud/worker.ts'
 import type {
   CloudRuntimeAdapter,
@@ -89,6 +91,8 @@ function createFixture(options: {
     internalToken?: string | null
     byokPolicy?: ByokManagementPolicy
     abuse?: CloudAbuseConfig
+    billing?: CloudBillingConfig | null
+    billingAdapter?: BillingAdapter | null
   } = {}) {
   const runtime = new FakeRuntimeAdapter()
   const store = new InMemoryControlPlaneStore()
@@ -100,7 +104,7 @@ function createFixture(options: {
   })
   const service = new CloudSessionService(store, runtime, policy, undefined, {
     randomUUID: () => `cmd-${nextId += 1}`,
-  }, undefined, byokSecrets, options.byokPolicy, options.abuse)
+  }, undefined, byokSecrets, options.byokPolicy, options.abuse, options.billing || null, options.billingAdapter || null)
   const artifacts = new CloudArtifactService(service, objectStore, {
     randomUUID: () => `artifact-${nextId += 1}`,
   })
@@ -173,6 +177,35 @@ function testAbuseConfig(overrides: Partial<CloudAbuseConfig> = {}): CloudAbuseC
     authBackoff: {
       ...DEFAULT_CONFIG.cloud.abuse.authBackoff,
       ...(overrides.authBackoff || {}),
+    },
+  }
+}
+
+function testBillingConfig(overrides: Partial<CloudBillingConfig> = {}): CloudBillingConfig {
+  return {
+    ...DEFAULT_CONFIG.cloud.billing,
+    ...overrides,
+    enabled: overrides.enabled ?? true,
+    provider: overrides.provider || 'stub',
+    defaultPlanKey: overrides.defaultPlanKey || 'pro',
+    plans: {
+      pro: {
+        label: 'Pro',
+        entitlements: {
+          allowNewSessions: true,
+          allowPrompts: true,
+          allowWorkers: true,
+        },
+      },
+      blocked: {
+        label: 'Blocked',
+        entitlements: {
+          allowNewSessions: false,
+          allowPrompts: false,
+          allowWorkers: false,
+        },
+      },
+      ...(overrides.plans || {}),
     },
   }
 }
@@ -581,6 +614,140 @@ test('cloud HTTP BYOK APIs enforce provider availability and org entitlement pol
     })
     assert.equal(blocked.status, 402)
     assert.match(JSON.stringify(await readJson(blocked)), /not included/)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP billing routes use stub adapter and gate canceled subscriptions with 402', async () => {
+  const billing = testBillingConfig()
+  const fixture = createFixture({
+    billing,
+    billingAdapter: createStubBillingAdapter(billing),
+    autoProcessCommands: false,
+    auth: () => ({
+      tenantId: 'tenant-1',
+      orgId: 'tenant-1',
+      tenantName: 'Tenant 1',
+      userId: 'owner-1',
+      accountId: 'owner-1',
+      email: 'owner@example.test',
+      role: 'owner',
+      authSource: 'user',
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const initial = await readJson(await fetch(`${baseUrl}/api/billing/subscription`))
+    assert.equal(initial.enabled, true)
+    assert.equal(initial.subscription, null)
+
+    const checkoutResponse = await fetch(`${baseUrl}/api/billing/checkout`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planKey: 'pro' }),
+    })
+    assert.equal(checkoutResponse.status, 200)
+    assert.match(String((await readJson(checkoutResponse)).url), /billing\.local/)
+
+    const active = await readJson(await fetch(`${baseUrl}/api/billing/subscription`))
+    assert.equal(asRecord(active.subscription).status, 'active')
+    assert.equal(active.active, true)
+
+    const createdResponse = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    assert.equal(createdResponse.status, 201)
+    const sessionId = String(asRecord((await readJson(createdResponse)).session).sessionId)
+
+    await fixture.store.upsertBillingSubscription({
+      orgId: 'tenant-1',
+      providerId: 'stub',
+      providerCustomerId: 'stub_customer_tenant-1',
+      providerSubscriptionId: 'stub_subscription_tenant-1',
+      planKey: 'pro',
+      status: 'canceled',
+    })
+
+    const blockedCreate = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    assert.equal(blockedCreate.status, 402)
+    const createBody = await readJson(blockedCreate)
+    assert.equal(asRecord(createBody.verdict).policyCode, 'billing.subscription_inactive')
+
+    const blockedPrompt = await fetch(`${baseUrl}/api/sessions/${sessionId}/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'should not run' }),
+    })
+    assert.equal(blockedPrompt.status, 402)
+    const promptBody = await readJson(blockedPrompt)
+    assert.equal(asRecord(promptBody.verdict).policyCode, 'billing.subscription_inactive')
+
+    await fixture.store.enqueueSessionCommand({
+      commandId: 'queued-before-cancel',
+      tenantId: 'tenant-1',
+      userId: 'owner-1',
+      sessionId,
+      kind: 'prompt',
+      payload: { text: 'queued', agent: 'build' },
+    })
+    assert.equal(await fixture.worker.processSessionCommands('tenant-1', sessionId), 0)
+    assert.equal(fixture.runtime.prompts.length, 0)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud billing webhook updates subscriptions idempotently with replay protection', async () => {
+  const billing = testBillingConfig()
+  const fixture = createFixture({
+    billing,
+    billingAdapter: createStubBillingAdapter(billing),
+    auth: () => ({
+      tenantId: 'tenant-1',
+      orgId: 'tenant-1',
+      tenantName: 'Tenant 1',
+      userId: 'owner-1',
+      accountId: 'owner-1',
+      email: 'owner@example.test',
+      role: 'owner',
+      authSource: 'user',
+    }),
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    await readJson(await fetch(`${baseUrl}/api/billing/subscription`))
+    const payload = {
+      id: 'evt_stub_1',
+      type: 'customer.subscription.updated',
+      subscription: {
+        orgId: 'tenant-1',
+        planKey: 'pro',
+        status: 'active',
+      },
+    }
+    const first = await fetch(`${baseUrl}/webhooks/billing`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    assert.equal(first.status, 200)
+    assert.equal(asRecord((await readJson(first)).subscription).status, 'active')
+
+    const replay = await fetch(`${baseUrl}/webhooks/billing`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    assert.equal(replay.status, 200)
+    assert.equal((await readJson(replay)).replayed, true)
+    assert.equal((await fixture.store.listAuditEvents('tenant-1')).filter((event) => event.eventType === 'billing.webhook.processed').length, 1)
   } finally {
     await fixture.server.close()
   }

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -93,6 +93,7 @@ test('real Postgres cloud store serializes concurrent schema migrations', {
         '003_headless_channels',
         '004_byok_secrets',
         '005_usage_quotas_rate_limits',
+        '006_billing_subscriptions',
       ])
     } finally {
       await Promise.all(stores.map((store) => store.close?.()))


### PR DESCRIPTION
## Summary

- add provider-neutral cloud billing config, subscription schema, and store methods
- add stub and Stripe billing adapters with idempotent webhook handling
- add billing HTTP routes, subscription status, checkout/portal flows, and protected `/webhooks/billing`
- gate cloud session creation, prompt enqueue, BYOK provider use, and worker execution through billing entitlements
- add tests for adapters, config/env resolution, subscription persistence, webhook replay, HTTP 402 gating, and worker refusal

Closes #428.

## Verification

- `pnpm --filter @open-cowork/desktop build:electron`
- `node --no-warnings --experimental-strip-types --test tests/billing-adapter.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-http-server.test.ts tests/cloud-app.test.ts`
- `git diff --check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
