### PR TITLE
Add cloud and gateway distribution packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,29 @@ jobs:
         run: |
           docker compose -f docker-compose.cloud.yml config --quiet
           docker compose -f docker-compose.cloud.split.yml config --quiet
+          docker compose -f docker-compose.cloud-gateway.yml config --quiet
 
       - name: Build cloud OCI image
-        run: docker build -f docker/open-cowork-cloud/Dockerfile -t open-cowork-cloud:ci .
+        run: |
+          image_tag="${GITHUB_SHA:-ci}"
+          docker build -f docker/open-cowork-cloud/Dockerfile \
+            -t open-cowork-cloud:ci \
+            -t ghcr.io/joe-broadhead/open-cowork-cloud:"${image_tag}" \
+            .
+
+      - name: Build gateway OCI image
+        run: |
+          image_tag="${GITHUB_SHA:-ci}"
+          docker build -f docker/open-cowork-gateway/Dockerfile \
+            -t open-cowork-gateway:ci \
+            -t ghcr.io/joe-broadhead/open-cowork-gateway:"${image_tag}" \
+            .
 
       - name: Run split-role cloud Compose smoke test
         run: bash scripts/ci-cloud-compose-smoke.sh docker-compose.cloud.split.yml
+
+      - name: Run cloud plus gateway Compose smoke test
+        run: OPEN_COWORK_GATEWAY_SMOKE_URL=http://127.0.0.1:8790/ready bash scripts/ci-cloud-compose-smoke.sh docker-compose.cloud-gateway.yml
 
       - name: Install Helm
         run: |
@@ -156,6 +173,7 @@ jobs:
 
       - name: Validate cloud Helm chart
         run: |
+          helm dependency build helm/open-cowork-cloud
           helm lint helm/open-cowork-cloud \
             --set cloud.auth.mode=oidc \
             --set cloud.auth.oidcIssuerUrl=https://issuer.example.com \
@@ -174,6 +192,36 @@ jobs:
             > /tmp/open-cowork-cloud-rendered.yaml
           test -s /tmp/open-cowork-cloud-rendered.yaml
           grep -q "OPEN_COWORK_CLOUD_ROLE" /tmp/open-cowork-cloud-rendered.yaml
+          helm template open-cowork-cloud-with-gateway helm/open-cowork-cloud \
+            --set image.repository=example.com/open-cowork-cloud \
+            --set image.tag=ci \
+            --set cloud.auth.mode=oidc \
+            --set cloud.auth.oidcIssuerUrl=https://issuer.example.com \
+            --set cloud.auth.oidcClientId=open-cowork-cloud-ci \
+            --set cloud.controlPlaneUrl='postgres://postgres:postgres@postgres:5432/open_cowork_cloud_test' \
+            --set cloud.secretKey='ci-secret-key' \
+            --set cloud.cookieSecret='ci-cookie-secret' \
+            --set cloud.objectStore.kind=s3 \
+            --set cloud.objectStore.bucket=open-cowork-cloud-ci \
+            --set gateway.enabled=true \
+            --set gateway.gateway.cloudBaseUrl=https://cloud.example.com \
+            --set gateway.gateway.serviceToken=ci-gateway-token \
+            > /tmp/open-cowork-cloud-with-gateway-rendered.yaml
+          grep -q "OPEN_COWORK_GATEWAY_SERVICE_TOKEN" /tmp/open-cowork-cloud-with-gateway-rendered.yaml
+
+      - name: Validate gateway Helm chart
+        run: |
+          helm lint helm/open-cowork-gateway \
+            --set gateway.cloudBaseUrl=https://cloud.example.com \
+            --set gateway.serviceToken=ci-gateway-token
+          helm template open-cowork-gateway helm/open-cowork-gateway \
+            --set image.repository=example.com/open-cowork-gateway \
+            --set image.tag=ci \
+            --set gateway.cloudBaseUrl=https://cloud.example.com \
+            --set gateway.serviceToken=ci-gateway-token \
+            > /tmp/open-cowork-gateway-rendered.yaml
+          test -s /tmp/open-cowork-gateway-rendered.yaml
+          grep -q "OPEN_COWORK_GATEWAY_SERVICE_TOKEN" /tmp/open-cowork-gateway-rendered.yaml
 
   # Run the desktop smoke suite and package the app on macOS so
   # platform-specific regressions (IPC, renderer boot, native modules,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,12 +363,60 @@ jobs:
       - name: Confirm release policy
         run: echo "Release policy passed for ${GITHUB_REF_NAME}; GitHub Release publication may proceed."
 
+  publish-oci-images:
+    if: startsWith(github.ref, 'refs/tags/v') && needs.release-policy.result == 'success'
+    needs:
+      - release-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Build and publish cloud OCI image
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          image="ghcr.io/${owner}/open-cowork-cloud"
+          docker build -f docker/open-cowork-cloud/Dockerfile \
+            --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --label "org.opencontainers.image.version=${version}" \
+            -t "${image}:${GITHUB_REF_NAME}" \
+            -t "${image}:${version}" \
+            .
+          docker push "${image}:${GITHUB_REF_NAME}"
+          docker push "${image}:${version}"
+
+      - name: Build and publish gateway OCI image
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          image="ghcr.io/${owner}/open-cowork-gateway"
+          docker build -f docker/open-cowork-gateway/Dockerfile \
+            --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --label "org.opencontainers.image.version=${version}" \
+            -t "${image}:${GITHUB_REF_NAME}" \
+            -t "${image}:${version}" \
+            .
+          docker push "${image}:${GITHUB_REF_NAME}"
+          docker push "${image}:${version}"
+
   publish:
     if: startsWith(github.ref, 'refs/tags/v') && needs.release-policy.result == 'success'
     needs:
       - build-macos
       - build-linux
       - release-policy
+      - publish-oci-images
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/apps/desktop/src/main/cloud/observability.ts
+++ b/apps/desktop/src/main/cloud/observability.ts
@@ -71,6 +71,12 @@ export type CloudHttpRequestObservation = {
 const DEFAULT_SERVICE_NAME = 'open-cowork-cloud'
 const SENSITIVE_FIELD = /(authorization|cookie|token|secret|password|credential|key)$/i
 const MAX_STRING_LENGTH = 512
+const SIGNED_URL_QUERY_PATTERN = /\b(https?:\/\/[^\s"'<>?]+)\?[^"'<> \t\r\n]+/gi
+const LOCAL_PATH_PATTERNS = [
+  /\/Users\/[^\s"'`:]+/g,
+  /\/home\/[^\s"'`:]+/g,
+  /[A-Z]:\\Users\\[^\s"'`:]+/gi,
+]
 
 function serviceAttributes(serviceName: string, serviceVersion: string | null | undefined) {
   return {
@@ -87,10 +93,21 @@ function redactAttribute(key: string, value: CloudObservabilityAttributeValue) {
   if (value === undefined) return undefined
   if (value === null) return null
   if (SENSITIVE_FIELD.test(key)) return '[redacted]'
-  if (typeof value === 'string') return value.slice(0, MAX_STRING_LENGTH)
+  if (typeof value === 'string') return redactCloudAttributeString(value).slice(0, MAX_STRING_LENGTH)
   if (typeof value === 'number') return Number.isFinite(value) ? value : undefined
   if (typeof value === 'boolean') return value
   return String(value).slice(0, MAX_STRING_LENGTH)
+}
+
+function redactCloudAttributeString(value: string) {
+  let redacted = value.replace(SIGNED_URL_QUERY_PATTERN, '$1?[redacted]')
+  for (const pattern of LOCAL_PATH_PATTERNS) {
+    redacted = redacted.replace(pattern, (match) => {
+      const prefix = match.match(/^(\/Users|\/home|[A-Z]:\\Users)/i)?.[0] || '[home]'
+      return `${prefix}/[redacted]`
+    })
+  }
+  return redacted
 }
 
 export function sanitizeCloudObservabilityAttributes(attributes: CloudObservabilityAttributes = {}) {

--- a/apps/desktop/src/main/log-sanitizer.ts
+++ b/apps/desktop/src/main/log-sanitizer.ts
@@ -30,6 +30,9 @@ const TOKEN_PATTERNS = [
   /\bdapi[0-9a-f]{32}\b/g,
   // Hugging Face tokens are `hf_` plus an opaque blob.
   /\bhf_[A-Za-z0-9]{20,}\b/g,
+  // Open Cowork service/gateway tokens and Telegram bot tokens.
+  /\boc(?:c|gw)_[A-Za-z0-9_-]{20,}\b/g,
+  /\b\d{5,}:[A-Za-z0-9_-]{20,}\b/g,
   // Google OAuth client secrets.
   /\bGOCSPX-[A-Za-z0-9_-]{20,}\b/g,
   // AWS access key ids.
@@ -39,7 +42,7 @@ const TOKEN_PATTERNS = [
 ]
 
 const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
-const KEYED_SECRET_PATTERN = /\b(api[_-]?key|token|secret|password|client[_-]?secret)\s*[:=]\s*(['"]?)[A-Za-z0-9+/=_-]{32,}\2/gi
+const KEYED_SECRET_PATTERN = /\b([A-Za-z0-9_-]*(?:api[_-]?key|access[_-]?key|secret[_-]?access[_-]?key|token|secret|password|client[_-]?secret)[A-Za-z0-9_-]*)\s*[:=]\s*(['"]?)[A-Za-z0-9+/=_-]{32,}\2/gi
 const SIGNED_URL_QUERY_PATTERN = /\b(https?:\/\/[^\s"'<>?]+)\?[^"'<> \t\r\n]+/gi
 
 // Home-directory-prefixed paths leak usernames and project-folder

--- a/apps/gateway/src/config.test.ts
+++ b/apps/gateway/src/config.test.ts
@@ -56,6 +56,7 @@ test('gateway config loads explicit provider credentials and redacts secrets', (
         deliveryUrl: 'https://webhook.example.test/out?token=provider-token-1234567890',
         callbackSecret: 'provider-secret-1234567890',
         privateKey: 'provider-private-key-1234567890',
+        workspacePath: '/Users/alice/acme-private',
       },
     }],
   })
@@ -72,18 +73,44 @@ test('gateway config loads explicit provider credentials and redacts secrets', (
   assert.equal(providers[0]?.settings.callbackSecret, 'prov...[redacted]...7890')
   assert.equal(providers[0]?.settings.privateKey, 'prov...[redacted]...7890')
   assert.equal(providers[0]?.settings.deliveryUrl, 'https://webhook.example.test/out?token=%5Bredacted%5D')
+  assert.equal(providers[0]?.settings.workspacePath, '/Users/[redacted]')
 })
 
 test('gateway env redaction catches token and secret names', () => {
-  assert.deepEqual(redactGatewayEnv({
+  const redacted = redactGatewayEnv({
     OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'token-1234567890',
     OPEN_COWORK_GATEWAY_MODE: 'self-host',
+    OPEN_COWORK_GATEWAY_PROVIDERS: '[{"credentials":{"botToken":"telegram-token-1234567890"}}]',
     CUSTOM_PASSWORD_VALUE: 'password-1234567890',
-  }), {
-    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'toke...[redacted]...7890',
-    OPEN_COWORK_GATEWAY_MODE: 'self-host',
-    CUSTOM_PASSWORD_VALUE: 'pass...[redacted]...7890',
   })
+  assert.equal(redacted.OPEN_COWORK_GATEWAY_SERVICE_TOKEN, 'toke...[redacted]...7890')
+  assert.equal(redacted.OPEN_COWORK_GATEWAY_MODE, 'self-host')
+  assert.equal(redacted.CUSTOM_PASSWORD_VALUE, 'pass...[redacted]...7890')
+  assert.equal(redacted.OPEN_COWORK_GATEWAY_PROVIDERS?.includes('telegram-token'), false)
+  assert.match(redacted.OPEN_COWORK_GATEWAY_PROVIDERS || '', /\[redacted\]/)
+})
+
+test('gateway diagnostics default to self-host only unless explicitly enabled', () => {
+  const managed = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    mode: 'managed',
+  })
+  assert.equal(managed.diagnostics.enabled, false)
+
+  const explicitlyEnabled = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    mode: 'managed',
+    diagnostics: {
+      enabled: true,
+    },
+  })
+  assert.equal(explicitlyEnabled.diagnostics.enabled, true)
 })
 
 test('gateway config rejects missing cloud auth and unsupported providers', () => {

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -24,6 +24,9 @@ export type GatewayConfig = {
   metrics: {
     enabled: boolean
   }
+  diagnostics: {
+    enabled: boolean
+  }
   providers: GatewayProviderConfig[]
 }
 
@@ -44,6 +47,7 @@ export type GatewayRawConfig = Partial<{
   mode: GatewayMode
   logging: Partial<GatewayConfig['logging']>
   metrics: Partial<GatewayConfig['metrics']>
+  diagnostics: Partial<GatewayConfig['diagnostics']>
   providers: Array<Partial<GatewayProviderConfig> & {
     kind: GatewayProviderKind
   }>
@@ -58,6 +62,7 @@ const secretEnvKeys = [
   'OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN',
   'OPEN_COWORK_GATEWAY_TELEGRAM_WEBHOOK_SECRET',
   'OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET',
+  'OPEN_COWORK_GATEWAY_PROVIDERS',
 ]
 
 export function loadGatewayConfig(env: GatewayEnv = process.env): GatewayConfig {
@@ -69,6 +74,7 @@ export function resolveGatewayConfig(raw: GatewayRawConfig = {}, env: GatewayEnv
   const cloudBaseUrl = readString(env.OPEN_COWORK_CLOUD_BASE_URL) || readString(raw.cloud?.baseUrl)
   const serviceToken = readString(env.OPEN_COWORK_GATEWAY_SERVICE_TOKEN) || readString(raw.cloud?.serviceToken)
   const allowInsecureHttp = readBoolean(env.OPEN_COWORK_GATEWAY_ALLOW_INSECURE_HTTP, raw.cloud?.allowInsecureHttp ?? false)
+  const mode = readMode(env.OPEN_COWORK_GATEWAY_MODE) || raw.mode || 'self-host'
   if (!cloudBaseUrl) throw new Error('OPEN_COWORK_CLOUD_BASE_URL or cloud.baseUrl is required.')
   if (!serviceToken) throw new Error('OPEN_COWORK_GATEWAY_SERVICE_TOKEN or cloud.serviceToken is required.')
 
@@ -83,12 +89,15 @@ export function resolveGatewayConfig(raw: GatewayRawConfig = {}, env: GatewayEnv
       port: readPort(env.OPEN_COWORK_GATEWAY_PORT ?? raw.server?.port, defaultPort),
       publicBaseUrl: readNullableString(env.OPEN_COWORK_GATEWAY_PUBLIC_URL) ?? readNullableString(raw.server?.publicBaseUrl),
     },
-    mode: readMode(env.OPEN_COWORK_GATEWAY_MODE) || raw.mode || 'self-host',
+    mode,
     logging: {
       level: readLogLevel(env.OPEN_COWORK_GATEWAY_LOG_LEVEL) || raw.logging?.level || 'info',
     },
     metrics: {
       enabled: readBoolean(env.OPEN_COWORK_GATEWAY_METRICS_ENABLED, raw.metrics?.enabled ?? true),
+    },
+    diagnostics: {
+      enabled: readBoolean(env.OPEN_COWORK_GATEWAY_DIAGNOSTICS_ENABLED, raw.diagnostics?.enabled ?? mode === 'self-host'),
     },
     providers: normalizeProviders(raw.providers, env),
   }
@@ -306,7 +315,7 @@ function redactUnknown(value: unknown): unknown {
 function redactValue(key: string, value: unknown): unknown {
   if (typeof value === 'string') {
     if (/token|secret|password|credential|authorization|api[_-]?key|private[_-]?key|access[_-]?key/i.test(key)) return redactSecret(value)
-    return redactUrlSecrets(value)
+    return redactLocalPaths(redactUrlSecrets(value))
   }
   return redactUnknown(value)
 }
@@ -326,6 +335,13 @@ function redactUrlSecrets(value: string) {
     }
   }
   return url.toString()
+}
+
+function redactLocalPaths(value: string) {
+  return value
+    .replace(/\/Users\/[^\s"'`:]+/g, '/Users/[redacted]')
+    .replace(/\/home\/[^\s"'`:]+/g, '/home/[redacted]')
+    .replace(/[A-Z]:\\Users\\[^\s"'`:]+/gi, 'C:\\Users\\[redacted]')
 }
 
 function redactSecret(value: string | null | undefined) {

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -92,6 +92,7 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
       settings: {
         callbackSecret: 'provider-callback-secret-1234567890',
         deliveryUrl: 'https://example.test/deliver?token=provider-token-1234567890',
+        workspacePath: '/home/alice/acme-private',
       },
     }],
   }, {
@@ -124,6 +125,7 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     assert.equal(diagnosticProvider?.credentials.apiKey, 'prov...[redacted]...7890')
     assert.equal(diagnosticProvider?.settings.callbackSecret, 'prov...[redacted]...7890')
     assert.equal(diagnosticProvider?.settings.deliveryUrl, 'https://example.test/deliver?token=%5Bredacted%5D')
+    assert.equal(diagnosticProvider?.settings.workspacePath, '/home/[redacted]')
 
     const webhook = await fetch(`${url}/webhooks/fake`, {
       method: 'POST',
@@ -132,6 +134,38 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     })
     assert.equal(webhook.status, 202)
     assert.deepEqual(prompted, ['ship it'])
+  } finally {
+    await http.close()
+    await runtime.stop()
+  }
+})
+
+test('gateway diagnostics are disabled by default in managed mode', async () => {
+  const cloud = {
+    subscribeDeliveries() { return { close() {} } },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    mode: 'managed',
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_GATEWAY_PORT: '0',
+  })
+  const runtime = createGatewayRuntime(config, cloud, undefined, { subscribeDeliveries: false })
+  await runtime.start()
+  const http = createGatewayHttpServer(config, runtime)
+  const url = await http.listen()
+
+  try {
+    const response = await fetch(`${url}/diagnostics`)
+    assert.equal(response.status, 404)
   } finally {
     await http.close()
     await runtime.stop()

--- a/apps/gateway/src/daemon.ts
+++ b/apps/gateway/src/daemon.ts
@@ -116,6 +116,10 @@ async function handleRequest(
   }
 
   if (req.method === 'GET' && url.pathname === '/diagnostics') {
+    if (!config.diagnostics.enabled) {
+      writeJson(res, 404, { ok: false, error: 'Diagnostics are disabled.' })
+      return
+    }
     writeJson(res, 200, {
       ok: true,
       config: redactGatewayConfig(config),

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,13 +1,15 @@
 # Open Cowork Cloud Deploy Recipes
 
 These recipes are thin provider-specific compositions of the same
-`open-cowork-cloud` image, roles, and adapters. Provider behavior should stay
-in deployment configuration, cloud services, and adapter wiring rather than in
-core runtime/session logic.
+`open-cowork-cloud` and `open-cowork-gateway` images, roles, and adapters.
+Provider behavior should stay in deployment configuration, cloud services, and
+adapter wiring rather than in core runtime/session logic.
 
 Use these invariants across every provider:
 
 - Run `web`, `worker`, and `scheduler` as separate roles for production.
+- Run the gateway as a separate deployment or service. It owns channel
+  credentials and long-poll/webhook connections, not OpenCode execution.
 - Use Postgres for the control plane.
 - Use object storage for artifacts and runtime/workspace checkpoints.
 - Use OIDC or explicit `OPEN_COWORK_CLOUD_AUTH_MODE=header` behind a trusted
@@ -15,11 +17,13 @@ Use these invariants across every provider:
   `OPEN_COWORK_CLOUD_AUTH_MODE=none` requires an explicit insecure local/demo
   override when the process binds beyond loopback.
 - Store `OPEN_COWORK_CLOUD_SECRET_KEY`, `OPEN_COWORK_CLOUD_INTERNAL_TOKEN`,
-  database URLs, and object-store credentials in the provider secret manager.
+  database URLs, object-store credentials, gateway service tokens, and channel
+  credentials in the provider secret manager.
 - Keep Cloud Run/App Platform/all-in-one deployments for demos or focused
   pilots unless the platform gives workers predictable long-running CPU.
 - Enable `OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED=true` before scaling worker
   replicas beyond one.
 
 The canonical scalable manifest is the provider-neutral Helm chart in
-`helm/open-cowork-cloud`.
+`helm/open-cowork-cloud`; the gateway chart lives in `helm/open-cowork-gateway`
+and can also be enabled as the cloud chart's optional gateway dependency.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,15 +1,17 @@
 # AWS Recipe
 
-Use the same `open-cowork-cloud` image on AWS with these services:
+Use the same `open-cowork-cloud` and `open-cowork-gateway` images on AWS with
+these services:
 
 | Role | Recommended service |
 | --- | --- |
 | `web` | ECS/Fargate service or EKS Deployment |
 | `worker` | ECS service or EKS Deployment |
 | `scheduler` | ECS service or EKS Deployment |
+| Gateway | ECS/Fargate service or EKS Deployment |
 | Control plane | RDS for PostgreSQL |
 | Object store | S3 |
-| Secrets | Secrets Manager or SSM Parameter Store |
+| Secrets | Secrets Manager or SSM Parameter Store for cloud keys, gateway tokens, and channel credentials |
 
 For Kubernetes-first deployments, install the provider-neutral Helm chart on
 EKS and connect it to RDS, S3, and Secrets Manager through External Secrets or
@@ -30,6 +32,20 @@ helm upgrade --install open-cowork-cloud ../../helm/open-cowork-cloud \
   --set cloud.objectStore.region=REGION \
   --set cloud.existingSecret=open-cowork-cloud-secrets
 ```
+
+Install the gateway as a separate ECS service or EKS Deployment:
+
+```bash
+helm upgrade --install open-cowork-gateway ../../helm/open-cowork-gateway \
+  --set image.repository=ACCOUNT.dkr.ecr.REGION.amazonaws.com/open-cowork-gateway \
+  --set gateway.cloudBaseUrl=https://cowork.example.com \
+  --set gateway.existingSecret=open-cowork-gateway-secrets
+```
+
+Use Secrets Manager or SSM to inject `OPEN_COWORK_GATEWAY_SERVICE_TOKEN`,
+`OPEN_COWORK_GATEWAY_PROVIDERS`, and channel credentials. Expose gateway ingress
+only for webhook-mode providers; polling gateways can run without public
+inbound traffic.
 
 Keep ECS/Fargate task definitions aligned with the same environment variables
 used by the Helm chart: `OPEN_COWORK_CLOUD_ROLE`, control-plane URL,

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -1,15 +1,17 @@
 # Azure Recipe
 
-Use the same `open-cowork-cloud` image on Azure with these services:
+Use the same `open-cowork-cloud` and `open-cowork-gateway` images on Azure
+with these services:
 
 | Role | Recommended service |
 | --- | --- |
 | `web` | Azure Container Apps or AKS Deployment |
 | `worker` | Azure Container Apps service/jobs or AKS Deployment |
 | `scheduler` | Azure Container Apps service/job or AKS Deployment |
+| Gateway | Azure Container Apps service or AKS Deployment |
 | Control plane | Azure Database for PostgreSQL |
 | Object store | Azure Blob Storage |
-| Secrets | Key Vault |
+| Secrets | Key Vault for cloud keys, gateway tokens, and channel credentials |
 
 For scalable deployments, install the provider-neutral Helm chart on AKS and
 connect it to Azure Database for PostgreSQL, Blob Storage, and Key Vault
@@ -30,6 +32,20 @@ helm upgrade --install open-cowork-cloud ../../helm/open-cowork-cloud \
   --set cloud.objectStore.accountName=STORAGE_ACCOUNT \
   --set cloud.existingSecret=open-cowork-cloud-secrets
 ```
+
+Install the gateway as a separate Container Apps service or AKS Deployment:
+
+```bash
+helm upgrade --install open-cowork-gateway ../../helm/open-cowork-gateway \
+  --set image.repository=REGISTRY.azurecr.io/open-cowork-gateway \
+  --set gateway.cloudBaseUrl=https://cowork.example.com \
+  --set gateway.existingSecret=open-cowork-gateway-secrets
+```
+
+Use Key Vault-backed secret injection for
+`OPEN_COWORK_GATEWAY_SERVICE_TOKEN`, provider JSON, and channel credentials.
+Webhook providers require a public HTTPS gateway URL; polling providers can
+remain private with outbound channel API access.
 
 Use Container Apps for focused pilots when that operational model is simpler,
 but keep split roles and checkpointing enabled before adding worker replicas.

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -1,12 +1,14 @@
 # DigitalOcean Recipe
 
-Use the same `open-cowork-cloud` image on DigitalOcean with these services:
+Use the same `open-cowork-cloud` and `open-cowork-gateway` images on
+DigitalOcean with these services:
 
 | Role | Recommended service |
 | --- | --- |
 | `web` | App Platform for demos or DOKS Deployment for production |
 | `worker` | DOKS Deployment |
 | `scheduler` | DOKS Deployment |
+| Gateway | App Platform component or DOKS Deployment |
 | Control plane | Managed PostgreSQL |
 | Object store | Spaces |
 | Secrets | App Platform or Kubernetes secrets, preferably External Secrets |
@@ -29,6 +31,20 @@ helm upgrade --install open-cowork-cloud ../../helm/open-cowork-cloud \
   --set cloud.objectStore.endpoint=https://REGION.digitaloceanspaces.com \
   --set cloud.existingSecret=open-cowork-cloud-secrets
 ```
+
+Install the gateway as an App Platform component for simple channel bots or as
+a DOKS Deployment for production:
+
+```bash
+helm upgrade --install open-cowork-gateway ../../helm/open-cowork-gateway \
+  --set image.repository=registry.digitalocean.com/REGISTRY/open-cowork-gateway \
+  --set gateway.cloudBaseUrl=https://cowork.example.com \
+  --set gateway.existingSecret=open-cowork-gateway-secrets
+```
+
+Keep gateway service tokens and channel credentials in App Platform secrets or
+External Secrets. Only expose the gateway publicly when a webhook-mode provider
+needs inbound callbacks.
 
 App Platform all-in-one is acceptable for demos and focused-agent pilots.
 Production worker execution should use DOKS split roles.

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,15 +1,17 @@
 # GCP Recipe
 
-Use the same `open-cowork-cloud` image on GCP with these services:
+Use the same `open-cowork-cloud` and `open-cowork-gateway` images on GCP with
+these services:
 
 | Role | Recommended service |
 | --- | --- |
 | `web` | Cloud Run or GKE Deployment |
 | `worker` | GKE Deployment for production; Cloud Run all-in-one only for demos |
 | `scheduler` | GKE Deployment or a small Cloud Run service if polling is acceptable |
+| Gateway | Cloud Run for webhook/polling gateways or a GKE Deployment |
 | Control plane | Cloud SQL for PostgreSQL |
 | Object store | Cloud Storage |
-| Secrets | Secret Manager |
+| Secrets | Secret Manager for cloud keys, gateway tokens, and channel credentials |
 
 For scalable deployments, install the provider-neutral Helm chart on GKE and
 wire it to Cloud SQL, Cloud Storage, and Secret Manager through External
@@ -29,6 +31,21 @@ helm upgrade --install open-cowork-cloud ../../helm/open-cowork-cloud \
   --set cloud.objectStore.bucket=OPEN_COWORK_BUCKET \
   --set cloud.existingSecret=open-cowork-cloud-secrets
 ```
+
+Install the gateway as a separate Cloud Run service or GKE Deployment. For
+Helm-based GKE:
+
+```bash
+helm upgrade --install open-cowork-gateway ../../helm/open-cowork-gateway \
+  --set image.repository=REGION-docker.pkg.dev/PROJECT/open-cowork/open-cowork-gateway \
+  --set gateway.cloudBaseUrl=https://cowork.example.com \
+  --set gateway.existingSecret=open-cowork-gateway-secrets
+```
+
+The gateway secret should provide `OPEN_COWORK_GATEWAY_SERVICE_TOKEN` plus
+provider credentials such as `OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN`.
+Webhook-mode providers need a public HTTPS gateway URL and ingress or Cloud Run
+service URL; polling providers can stay private with egress to the channel API.
 
 When not using External Secrets to inject `OPEN_COWORK_CLOUD_SECRET_KEY`
 directly, set `OPEN_COWORK_CLOUD_SECRET_KEY_REF` to a Secret Manager URI such

--- a/docker-compose.cloud-gateway.yml
+++ b/docker-compose.cloud-gateway.yml
@@ -1,0 +1,111 @@
+services:
+  open-cowork-cloud:
+    init: true
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: docker/open-cowork-cloud/Dockerfile
+    environment:
+      OPEN_COWORK_CLOUD_ROLE: all-in-one
+      OPEN_COWORK_CLOUD_PROFILE: full
+      OPEN_COWORK_CLOUD_ROOT: /data/open-cowork-cloud
+      OPEN_COWORK_CLOUD_HOST: 0.0.0.0
+      OPEN_COWORK_CLOUD_ALLOW_INSECURE_AUTH: "true"
+      OPEN_COWORK_CLOUD_PORT: 8787
+      OPEN_COWORK_CLOUD_SECRET_KEY: ${OPEN_COWORK_CLOUD_SECRET_KEY:-change-me-for-local-dev}
+      OPEN_COWORK_CLOUD_COOKIE_SECRET: ${OPEN_COWORK_CLOUD_COOKIE_SECRET:-change-me-for-local-cookie-secret}
+      OPEN_COWORK_CLOUD_INTERNAL_TOKEN: ${OPEN_COWORK_CLOUD_INTERNAL_TOKEN:-change-me-for-local-internal-token}
+      OPEN_COWORK_CLOUD_COOKIE_SECURE: "false"
+      OPEN_COWORK_CLOUD_PUBLIC_URL: ${OPEN_COWORK_CLOUD_PUBLIC_URL:-http://localhost:8787}
+      OPEN_COWORK_CLOUD_SERVICE_NAME: open-cowork-cloud
+      OPEN_COWORK_CLOUD_LOG_FORMAT: json
+      OPEN_COWORK_CLOUD_AUTO_PROCESS_COMMANDS: "true"
+      OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED: "true"
+      OPEN_COWORK_CLOUD_CONTROL_PLANE_URL: postgres://open_cowork:open_cowork@postgres:5432/open_cowork
+      OPEN_COWORK_CLOUD_OBJECT_STORE_KIND: minio
+      OPEN_COWORK_CLOUD_OBJECT_STORE_ENDPOINT: http://minio:9000
+      OPEN_COWORK_CLOUD_OBJECT_STORE_BUCKET: open-cowork
+      OPEN_COWORK_CLOUD_OBJECT_STORE_ACCESS_KEY_ID: open_cowork
+      OPEN_COWORK_CLOUD_OBJECT_STORE_SECRET_ACCESS_KEY: ${OPEN_COWORK_CLOUD_OBJECT_STORE_SECRET_ACCESS_KEY:-open_cowork_local_dev}
+    ports:
+      - "8787:8787"
+    volumes:
+      - open-cowork-cloud-data:/data/open-cowork-cloud
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+
+  open-cowork-gateway:
+    init: true
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: docker/open-cowork-gateway/Dockerfile
+    environment:
+      OPEN_COWORK_CLOUD_BASE_URL: http://open-cowork-cloud:8787
+      OPEN_COWORK_GATEWAY_ALLOW_INSECURE_HTTP: "true"
+      OPEN_COWORK_GATEWAY_SERVICE_TOKEN: ${OPEN_COWORK_GATEWAY_SERVICE_TOKEN:-replace-with-dashboard-gateway-token}
+      OPEN_COWORK_GATEWAY_HOST: 0.0.0.0
+      OPEN_COWORK_GATEWAY_PORT: 8790
+      OPEN_COWORK_GATEWAY_PUBLIC_URL: ${OPEN_COWORK_GATEWAY_PUBLIC_URL:-http://localhost:8790}
+      OPEN_COWORK_GATEWAY_MODE: self-host
+      OPEN_COWORK_GATEWAY_LOG_LEVEL: info
+      OPEN_COWORK_GATEWAY_METRICS_ENABLED: "true"
+      OPEN_COWORK_GATEWAY_FAKE_CHANNEL_BINDING_ID: ${OPEN_COWORK_GATEWAY_FAKE_CHANNEL_BINDING_ID:-fake-binding}
+      OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN: ${OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN:-}
+      OPEN_COWORK_GATEWAY_TELEGRAM_CHANNEL_BINDING_ID: ${OPEN_COWORK_GATEWAY_TELEGRAM_CHANNEL_BINDING_ID:-telegram}
+      OPEN_COWORK_GATEWAY_TELEGRAM_MODE: ${OPEN_COWORK_GATEWAY_TELEGRAM_MODE:-polling}
+      OPEN_COWORK_GATEWAY_TELEGRAM_WEBHOOK_SECRET: ${OPEN_COWORK_GATEWAY_TELEGRAM_WEBHOOK_SECRET:-}
+      OPEN_COWORK_GATEWAY_WEBHOOK_DELIVERY_URL: ${OPEN_COWORK_GATEWAY_WEBHOOK_DELIVERY_URL:-}
+      OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET: ${OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET:-}
+      OPEN_COWORK_GATEWAY_WEBHOOK_CHANNEL_BINDING_ID: ${OPEN_COWORK_GATEWAY_WEBHOOK_CHANNEL_BINDING_ID:-webhook}
+    ports:
+      - "8790:8790"
+    depends_on:
+      open-cowork-cloud:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: open_cowork
+      POSTGRES_USER: open_cowork
+      POSTGRES_PASSWORD: open_cowork
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U open_cowork -d open_cowork"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - open-cowork-cloud-postgres:/var/lib/postgresql/data
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: open_cowork
+      MINIO_ROOT_PASSWORD: open_cowork_local_dev
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - open-cowork-cloud-minio:/data
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      minio:
+        condition: service_started
+    restart: on-failure:20
+    environment:
+      MC_HOST_local: http://open_cowork:open_cowork_local_dev@minio:9000
+    command: ["mb", "--ignore-existing", "local/open-cowork"]
+
+volumes:
+  open-cowork-cloud-data:
+  open-cowork-cloud-postgres:
+  open-cowork-cloud-minio:

--- a/docker/open-cowork-gateway/Dockerfile
+++ b/docker/open-cowork-gateway/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+COPY mcps ./mcps
+COPY scripts ./scripts
+COPY tsconfig.base.json ./
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @open-cowork/shared build
+RUN pnpm --filter @open-cowork/gateway build
+
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY --from=build /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+COPY --from=build /app/apps ./apps
+COPY --from=build /app/packages ./packages
+COPY --from=build /app/mcps ./mcps
+COPY --from=build /app/scripts ./scripts
+COPY --from=build /app/tsconfig.base.json ./
+
+RUN pnpm install --frozen-lockfile --prod
+
+ENV NODE_ENV=production
+ENV OPEN_COWORK_GATEWAY_HOST=0.0.0.0
+ENV OPEN_COWORK_GATEWAY_PORT=8790
+ENV OPEN_COWORK_GATEWAY_METRICS_ENABLED=true
+
+EXPOSE 8790
+
+USER node
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD node -e "fetch('http://127.0.0.1:'+(process.env.OPEN_COWORK_GATEWAY_PORT||'8790')+'/ready').then((response)=>process.exit(response.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["pnpm", "--dir", "apps/gateway", "start"]

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -81,6 +81,51 @@ Self-hosted deployments can run with the stub/no billing adapter. In that mode
 the dashboard keeps the billing panel non-blocking while BYOK, desktop token,
 gateway token, and usage surfaces remain available.
 
+## Generic Docker: Cloud + Gateway
+
+Use the combined self-host reference when validating the browser dashboard,
+desktop token flow, and headless gateway together:
+
+```bash
+docker compose -f docker-compose.cloud-gateway.yml up --build
+```
+
+That file starts:
+
+- Open Cowork Cloud in `all-in-one` mode on <http://localhost:8787>,
+- Postgres for the control plane,
+- MinIO for artifacts and checkpoints,
+- Open Cowork Gateway on <http://localhost:8790>.
+
+The gateway starts with the fake channel provider by default so the process can
+boot before a real Telegram or webhook binding is configured. For a real
+self-hosted gateway:
+
+1. Open the dashboard at <http://localhost:8787>.
+2. Configure BYOK provider credentials if your profile requires them.
+3. Create a scoped gateway API token from the dashboard.
+4. Create a headless agent and channel binding.
+5. Restart the gateway with `OPEN_COWORK_GATEWAY_SERVICE_TOKEN` set to that
+   one-time token and provider credentials such as
+   `OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN`.
+
+For local demos the cloud compose file uses `auth.mode=none` and explicit
+insecure overrides. Public deployments must use OIDC or a trusted identity
+proxy for the cloud web role and a real gateway service token.
+
+Gateway health endpoints:
+
+- `GET /health` reports process liveness.
+- `GET /ready` reports provider readiness.
+- `GET /metrics` exposes Prometheus metrics when enabled.
+- `GET /diagnostics` returns redacted gateway config, provider state, and
+  counters for support.
+
+The gateway image is separate from the cloud image because it owns channel
+secrets, long-polling or webhook connections, and a different scaling profile.
+It does not import the OpenCode SDK and does not own control-plane Postgres
+state.
+
 For Kubernetes, use the provider-neutral Helm chart as the scalable starting
 point:
 
@@ -101,6 +146,22 @@ helm upgrade --install open-cowork-cloud helm/open-cowork-cloud \
 Use `cloud.existingSecret` in production so database URLs, object-store
 credentials, and envelope keys come from your platform secret manager rather
 than from Helm values.
+
+Install the gateway chart next to cloud when you want channel access:
+
+```bash
+helm upgrade --install open-cowork-gateway helm/open-cowork-gateway \
+  --set image.repository=ghcr.io/joe-broadhead/open-cowork-gateway \
+  --set gateway.cloudBaseUrl='https://cowork.example.com' \
+  --set gateway.serviceToken='replace-with-secret-manager-value'
+```
+
+For production, set `gateway.existingSecret` and inject
+`OPEN_COWORK_GATEWAY_SERVICE_TOKEN`, `OPEN_COWORK_GATEWAY_PROVIDERS`, and
+provider-specific credentials through External Secrets, sealed secrets, or the
+platform secret manager. The cloud chart also exposes the gateway as an
+optional dependency under `gateway.enabled=true` for installations that prefer
+one parent release.
 
 The chart fails closed when `cloud.auth.mode=none` is used without
 `cloud.allowInsecureAuth=true`. Keep that override for local demos only; use
@@ -174,6 +235,24 @@ Set these environment variables in every role:
 | `OPEN_COWORK_CLOUD_OTLP_ENDPOINT` | Optional OpenTelemetry OTLP HTTP base endpoint; exports traces to `/v1/traces` and metrics to `/v1/metrics`. |
 | `OPEN_COWORK_CLOUD_OTLP_HEADERS` | Optional JSON object of OTLP HTTP headers, stored as a secret when it contains collector credentials. |
 | `OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED` | `true` enables worker runtime/workspace checkpoints in object storage. |
+
+Gateway variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `OPEN_COWORK_CLOUD_BASE_URL` | Cloud web base URL used by the gateway HTTP/SSE client. |
+| `OPEN_COWORK_GATEWAY_SERVICE_TOKEN` | Scoped cloud API token with gateway access. Store it as a secret. |
+| `OPEN_COWORK_GATEWAY_ALLOW_INSECURE_HTTP` | Allows non-loopback HTTP cloud URLs for local Docker networks only. |
+| `OPEN_COWORK_GATEWAY_HOST` / `OPEN_COWORK_GATEWAY_PORT` | Gateway HTTP bind address and port. |
+| `OPEN_COWORK_GATEWAY_PUBLIC_URL` | Public gateway URL for channel webhook registration. |
+| `OPEN_COWORK_GATEWAY_MODE` | `self-host` or `managed`; affects diagnostics and deployment labeling. |
+| `OPEN_COWORK_GATEWAY_METRICS_ENABLED` | Enables `/metrics`. |
+| `OPEN_COWORK_GATEWAY_DIAGNOSTICS_ENABLED` | Enables `/diagnostics`; defaults to `true` for self-host and `false` for managed mode. |
+| `OPEN_COWORK_GATEWAY_PROVIDERS` | JSON provider array for multi-provider deployments. Treat as secret when it carries credentials. |
+| `OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN` | Telegram bot token for the Telegram provider. |
+| `OPEN_COWORK_GATEWAY_TELEGRAM_WEBHOOK_SECRET` | Telegram webhook secret token when running webhook mode. |
+| `OPEN_COWORK_GATEWAY_WEBHOOK_DELIVERY_URL` | Outbound URL for the generic webhook provider. |
+| `OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET` | Shared secret for generic webhook signing. |
 
 Hosted/public deployments should keep abuse controls enabled. The defaults are
 conservative and can be tuned per deployment; set an individual numeric quota
@@ -265,16 +344,16 @@ MCPs are available in cloud workspaces.
 
 ## Provider Mapping
 
-Provider-specific recipes should remain thin compositions of the same image,
+Provider-specific recipes should remain thin compositions of the same images,
 roles, Postgres control plane, object-store adapter, and secret adapter.
 
-| Provider | Web | Worker/Scheduler | Control plane | Object store | Secret store |
-| --- | --- | --- | --- | --- | --- |
-| Kubernetes | Deployment + Service/Ingress | Deployments or jobs with HPA/KEDA as needed | Managed or in-cluster Postgres | S3-compatible, GCS, Azure Blob, or MinIO | External Secrets or sealed secrets |
-| GCP | Cloud Run or GKE | GKE for production workers; Cloud Run all-in-one demo only | Cloud SQL for PostgreSQL | Cloud Storage | Secret Manager |
-| AWS | ECS/Fargate or EKS | ECS services or EKS deployments | RDS PostgreSQL | S3 | Secrets Manager |
-| Azure | Container Apps or AKS | Container Apps jobs/services or AKS | Azure Database for PostgreSQL | Azure Blob Storage | Key Vault |
-| DigitalOcean | App Platform for demos; DOKS for scale | DOKS deployments | Managed PostgreSQL | Spaces | App Platform/DOKS secrets |
+| Provider | Web | Worker/Scheduler | Gateway | Control plane | Object store | Secret store |
+| --- | --- | --- | --- | --- | --- | --- |
+| Kubernetes | Deployment + Service/Ingress | Deployments or jobs with HPA/KEDA as needed | Separate Deployment + Service/Ingress for webhook channels | Managed or in-cluster Postgres | S3-compatible, GCS, Azure Blob, or MinIO | External Secrets or sealed secrets |
+| GCP | Cloud Run or GKE | GKE for production workers; Cloud Run all-in-one demo only | Cloud Run or GKE Deployment | Cloud SQL for PostgreSQL | Cloud Storage | Secret Manager |
+| AWS | ECS/Fargate or EKS | ECS services or EKS deployments | ECS service or EKS Deployment | RDS PostgreSQL | S3 | Secrets Manager |
+| Azure | Container Apps or AKS | Container Apps jobs/services or AKS | Container Apps service or AKS Deployment | Azure Database for PostgreSQL | Azure Blob Storage | Key Vault |
+| DigitalOcean | App Platform for demos; DOKS for scale | DOKS deployments | App Platform component or DOKS Deployment | Managed PostgreSQL | Spaces | App Platform/DOKS secrets |
 
 The app core should not contain provider-specific branches. Provider behavior
 belongs in config, adapters, and deployment recipes.
@@ -282,6 +361,11 @@ belongs in config, adapters, and deployment recipes.
 Recipe starting points live under `deploy/gcp`, `deploy/aws`, `deploy/azure`,
 and `deploy/digitalocean`. Each one maps provider services back to the same
 role, Postgres, object-store, and secret-manager contract.
+
+Managed operators should also keep the runbook in
+[`docs/runbooks/cloud-managed-operations.md`](runbooks/cloud-managed-operations.md)
+current for readiness, rollback, gateway backlog, secret rotation, and
+diagnostic export procedures.
 
 ## Focused Agent Deployments
 

--- a/docs/runbooks/cloud-managed-operations.md
+++ b/docs/runbooks/cloud-managed-operations.md
@@ -1,0 +1,131 @@
+---
+title: Cloud Managed Operations Runbook
+description: Health, readiness, rollback, diagnostics, and recovery procedures for managed Open Cowork Cloud and Gateway deployments.
+---
+
+# Cloud Managed Operations Runbook
+
+This runbook is for operators running hosted or managed Open Cowork Cloud plus
+the headless gateway. It assumes split cloud roles, managed Postgres, object
+storage, provider secret management, and a separate gateway deployment.
+
+## Readiness Checks
+
+Before routing traffic to a new deployment:
+
+1. Confirm the cloud web role returns `200` from `GET /healthz`.
+2. Confirm authenticated operators can read `GET /api/runtime/status`.
+3. Confirm `GET /api/workers/heartbeats` shows at least one fresh worker and
+   one fresh scheduler heartbeat when those roles are enabled.
+4. Confirm the gateway returns `200` from `GET /health` and `GET /ready`.
+5. Confirm gateway `/metrics` includes provider count, delivery counters, and
+   error counters when metrics are enabled.
+6. Confirm object-store writes work by creating a small artifact or running a
+   checkpoint-enabled smoke session.
+7. Confirm BYOK status reads return metadata only and no plaintext keys.
+
+## Rollback
+
+Rollback is image-based. Schema migrations must remain additive and
+idempotent, so rollback does not require destructive database migration.
+
+1. Pause new rollout traffic at the load balancer or ingress.
+2. Scale new workers to zero first so they stop claiming new sessions.
+3. Keep at least one scheduler active unless scheduled workflow execution is
+   intentionally paused.
+4. Roll back cloud `web`, `worker`, and `scheduler` images to the previous
+   known-good tag.
+5. Roll back gateway images independently if channel delivery or webhook
+   handling regressed.
+6. Verify `GET /healthz`, `GET /api/workers/heartbeats`, gateway `/ready`, and
+   one cloud session prompt.
+7. Resume traffic and monitor error rate, command latency, projection lag, and
+   gateway delivery retries.
+
+If a release introduced a bad additive column or index, keep the column in
+place and ship a forward fix. Do not drop columns during incident rollback.
+
+## Worker Drains
+
+Workers own OpenCode execution while a lease is active. To drain safely:
+
+1. Mark the deployment unavailable to the scheduler/HPA or set replicas down
+   gradually.
+2. Allow active leases to finish or expire.
+3. Confirm no stale owner writes are accepted by checking projection version
+   and lease-token error logs.
+4. Confirm checkpoint writes are enabled before moving active sessions across
+   nodes.
+
+No database transaction should remain open while OpenCode is running.
+
+## Gateway Backlog
+
+Gateway delivery lag is operationally separate from cloud execution lag.
+
+1. Check gateway `/ready` for provider startup state.
+2. Check `/metrics` for `open_cowork_gateway_deliveries_received_total` and
+   `open_cowork_gateway_errors_total`.
+3. Inspect pending `cloud_channel_deliveries` rows by status and
+   `next_attempt_at`.
+4. For channel-provider outages, keep cloud sessions running and let deliveries
+   retry with backoff.
+5. For bad provider credentials, rotate the channel secret and restart only the
+   affected gateway deployment.
+
+## Secret Rotation
+
+Rotate secrets without moving them through logs, chat, issue comments, or
+renderer state.
+
+- Cloud envelope key: rotate through the platform secret manager and verify
+  BYOK reveal tests before deleting old key material.
+- Cookie secret: rotate during a maintenance window because existing browser
+  sessions may be invalidated.
+- Gateway service token: issue a new scoped token in the dashboard, update the
+  gateway secret, restart the gateway, then revoke the old token.
+- Channel credentials: rotate in the channel provider first, update the gateway
+  secret, then verify provider readiness.
+- Object-store keys: prefer workload identity or short-lived credentials; if a
+  static key is used, update the secret and verify artifact read/write.
+
+## Diagnostics
+
+Diagnostics must be redacted before leaving the deployment boundary.
+
+Allowed to include:
+
+- service name, version, role, profile, and image tag,
+- health/readiness JSON,
+- worker heartbeat age and scheduler heartbeat age,
+- gateway provider ids, provider kinds, and started flags,
+- counters and non-secret policy verdicts,
+- sanitized log excerpts.
+
+Must be redacted:
+
+- API tokens, BYOK keys, provider credentials, OAuth tokens, cookies,
+  authorization headers, and webhook secrets,
+- Postgres URLs with credentials,
+- object-store signed URLs, bucket-private URLs, SAS tokens, and pre-signed
+  query strings,
+- local host paths and workspace paths,
+- user email addresses.
+
+Gateway `/diagnostics` is suitable for support only because it returns redacted
+gateway configuration and counters. Put it behind private networking, VPN, or
+operator auth in managed deployments; do not expose it as a public webhook
+surface.
+
+## Restore Check
+
+After restoring from backup:
+
+1. Restore Postgres first.
+2. Restore object-store artifacts and checkpoint prefixes for the same point in
+   time.
+3. Start web with workers scaled to zero.
+4. Verify session list and projections load from durable state.
+5. Start one worker, run a smoke prompt, and verify checkpoint writes.
+6. Start scheduler, then gateway.
+7. Verify channel deliveries resume from durable cursors without duplicates.

--- a/helm/open-cowork-cloud/Chart.yaml
+++ b/helm/open-cowork-cloud/Chart.yaml
@@ -1,6 +1,12 @@
 apiVersion: v2
 name: open-cowork-cloud
-description: Provider-neutral Helm chart for Open Cowork Cloud web, worker, and scheduler roles.
+description: Provider-neutral Helm chart for Open Cowork Cloud web, worker, scheduler, and optional gateway roles.
 type: application
 version: 0.1.0
 appVersion: "0.0.0"
+dependencies:
+  - name: open-cowork-gateway
+    alias: gateway
+    version: 0.1.0
+    repository: file://../open-cowork-gateway
+    condition: gateway.enabled

--- a/helm/open-cowork-cloud/values.yaml
+++ b/helm/open-cowork-cloud/values.yaml
@@ -3,6 +3,17 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+gateway:
+  enabled: false
+  image:
+    repository: ghcr.io/joe-broadhead/open-cowork-gateway
+    tag: latest
+    pullPolicy: IfNotPresent
+  gateway:
+    cloudBaseUrl: ""
+    serviceToken: ""
+    existingSecret: ""
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm/open-cowork-gateway/Chart.yaml
+++ b/helm/open-cowork-gateway/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: open-cowork-gateway
+description: Provider-neutral Helm chart for the Open Cowork headless channel gateway.
+type: application
+version: 0.1.0
+appVersion: "0.0.0"

--- a/helm/open-cowork-gateway/templates/_helpers.tpl
+++ b/helm/open-cowork-gateway/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{- define "open-cowork-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "open-cowork-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "open-cowork-gateway.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "open-cowork-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "open-cowork-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "open-cowork-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "open-cowork-gateway.secretName" -}}
+{{- if .Values.gateway.existingSecret -}}
+{{- .Values.gateway.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secret" (include "open-cowork-gateway.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/open-cowork-gateway/templates/configmap.yaml
+++ b/helm/open-cowork-gateway/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "open-cowork-gateway.fullname" . }}-config
+  labels:
+    {{- include "open-cowork-gateway.labels" . | nindent 4 }}
+data:
+  OPEN_COWORK_CLOUD_BASE_URL: {{ .Values.gateway.cloudBaseUrl | quote }}
+  OPEN_COWORK_GATEWAY_ALLOW_INSECURE_HTTP: {{ .Values.gateway.allowInsecureHttp | quote }}
+  OPEN_COWORK_GATEWAY_HOST: {{ .Values.gateway.host | quote }}
+  OPEN_COWORK_GATEWAY_PORT: {{ .Values.gateway.port | quote }}
+  OPEN_COWORK_GATEWAY_PUBLIC_URL: {{ .Values.gateway.publicUrl | quote }}
+  OPEN_COWORK_GATEWAY_MODE: {{ .Values.gateway.mode | quote }}
+  OPEN_COWORK_GATEWAY_LOG_LEVEL: {{ .Values.gateway.logLevel | quote }}
+  OPEN_COWORK_GATEWAY_METRICS_ENABLED: {{ .Values.gateway.metrics.enabled | quote }}
+  OPEN_COWORK_GATEWAY_TELEGRAM_CHANNEL_BINDING_ID: {{ .Values.gateway.telegram.channelBindingId | quote }}
+  OPEN_COWORK_GATEWAY_TELEGRAM_MODE: {{ .Values.gateway.telegram.mode | quote }}
+  OPEN_COWORK_GATEWAY_WEBHOOK_DELIVERY_URL: {{ .Values.gateway.webhook.deliveryUrl | quote }}
+  OPEN_COWORK_GATEWAY_WEBHOOK_CHANNEL_BINDING_ID: {{ .Values.gateway.webhook.channelBindingId | quote }}

--- a/helm/open-cowork-gateway/templates/deployment.yaml
+++ b/helm/open-cowork-gateway/templates/deployment.yaml
@@ -1,0 +1,57 @@
+{{- if not .Values.gateway.cloudBaseUrl }}
+{{- fail "gateway.cloudBaseUrl is required." }}
+{{- end }}
+{{- if and (not .Values.gateway.serviceToken) (not .Values.gateway.existingSecret) }}
+{{- fail "gateway.serviceToken or gateway.existingSecret is required." }}
+{{- end }}
+{{- if and .Values.ingress.enabled (not .Values.gateway.publicUrl) }}
+{{- fail "gateway.publicUrl is required when gateway ingress is enabled." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "open-cowork-gateway.fullname" . }}
+  labels:
+    {{- include "open-cowork-gateway.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "open-cowork-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "open-cowork-gateway.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: open-cowork-gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "open-cowork-gateway.fullname" . }}-config
+            - secretRef:
+                name: {{ include "open-cowork-gateway.secretName" . }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/open-cowork-gateway/templates/ingress.yaml
+++ b/helm/open-cowork-gateway/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "open-cowork-gateway.fullname" . }}
+  labels:
+    {{- include "open-cowork-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "open-cowork-gateway.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/open-cowork-gateway/templates/secret.yaml
+++ b/helm/open-cowork-gateway/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.gateway.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "open-cowork-gateway.secretName" . }}
+  labels:
+    {{- include "open-cowork-gateway.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  OPEN_COWORK_GATEWAY_SERVICE_TOKEN: {{ .Values.gateway.serviceToken | quote }}
+  OPEN_COWORK_GATEWAY_PROVIDERS: {{ .Values.gateway.providersJson | quote }}
+  OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN: {{ .Values.gateway.telegram.botToken | quote }}
+  OPEN_COWORK_GATEWAY_TELEGRAM_WEBHOOK_SECRET: {{ .Values.gateway.telegram.webhookSecret | quote }}
+  OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET: {{ .Values.gateway.webhook.sharedSecret | quote }}
+{{- end }}

--- a/helm/open-cowork-gateway/templates/service.yaml
+++ b/helm/open-cowork-gateway/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "open-cowork-gateway.fullname" . }}
+  labels:
+    {{- include "open-cowork-gateway.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "open-cowork-gateway.selectorLabels" . | nindent 4 }}

--- a/helm/open-cowork-gateway/values.yaml
+++ b/helm/open-cowork-gateway/values.yaml
@@ -1,0 +1,61 @@
+image:
+  repository: ghcr.io/joe-broadhead/open-cowork-gateway
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+gateway:
+  mode: self-host
+  cloudBaseUrl: ""
+  allowInsecureHttp: false
+  serviceToken: ""
+  existingSecret: ""
+  host: 0.0.0.0
+  port: 8790
+  publicUrl: ""
+  logLevel: info
+  metrics:
+    enabled: true
+  providersJson: ""
+  telegram:
+    botToken: ""
+    channelBindingId: telegram
+    mode: polling
+    webhookSecret: ""
+  webhook:
+    deliveryUrl: ""
+    sharedSecret: ""
+    channelBindingId: webhook
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 80
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+resources: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: open-cowork-gateway.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - Telemetry and Privacy: privacy.md
   - Operate:
       - Open Cowork Cloud: open-cowork-cloud.md
+      - Cloud Managed Operations: runbooks/cloud-managed-operations.md
       - Branch Protection: branch-protection.md
       - Packaging and Releases: packaging-and-releases.md
       - Release Checklist: release-checklist.md

--- a/scripts/ci-cloud-compose-smoke.sh
+++ b/scripts/ci-cloud-compose-smoke.sh
@@ -5,10 +5,12 @@ compose_file="${1:-docker-compose.cloud.split.yml}"
 project_suffix="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-${RANDOM}"
 project_name="open-cowork-cloud-smoke-${project_suffix}"
 health_file="${TMPDIR:-/tmp}/open-cowork-cloud-healthz-${project_suffix}.json"
+gateway_health_file="${TMPDIR:-/tmp}/open-cowork-gateway-ready-${project_suffix}.json"
+gateway_smoke_url="${OPEN_COWORK_GATEWAY_SMOKE_URL:-}"
 
 cleanup() {
   docker compose -p "${project_name}" -f "${compose_file}" down -v --remove-orphans >/dev/null 2>&1 || true
-  rm -f "${health_file}"
+  rm -f "${health_file}" "${gateway_health_file}"
 }
 
 trap cleanup EXIT
@@ -22,12 +24,29 @@ fi
 for _ in $(seq 1 90); do
   if curl -fsS "http://127.0.0.1:8787/healthz" >"${health_file}"; then
     cat "${health_file}"
-    exit 0
+    if [ -z "${gateway_smoke_url}" ]; then
+      exit 0
+    fi
+    break
   fi
   sleep 2
 done
 
+if [ -n "${gateway_smoke_url}" ]; then
+  for _ in $(seq 1 90); do
+    if curl -fsS "${gateway_smoke_url}" >"${gateway_health_file}"; then
+      cat "${gateway_health_file}"
+      exit 0
+    fi
+    sleep 2
+  done
+fi
+
 docker compose -p "${project_name}" -f "${compose_file}" ps
 docker compose -p "${project_name}" -f "${compose_file}" logs --no-color --tail=200
-echo "open-cowork-cloud compose smoke test did not reach /healthz" >&2
+if [ -n "${gateway_smoke_url}" ]; then
+  echo "open-cowork cloud+gateway compose smoke test did not reach ${gateway_smoke_url}" >&2
+else
+  echo "open-cowork-cloud compose smoke test did not reach /healthz" >&2
+fi
 exit 1

--- a/tests/cloud-deployment-artifacts.test.ts
+++ b/tests/cloud-deployment-artifacts.test.ts
@@ -31,6 +31,20 @@ test('split cloud compose declares web, worker, and scheduler roles', () => {
   assert.match(compose, /minio:/)
 })
 
+test('combined cloud and gateway compose declares self-host gateway wiring', () => {
+  const compose = readRepoFile('docker-compose.cloud-gateway.yml')
+  assert.match(compose, /open-cowork-cloud:/)
+  assert.match(compose, /open-cowork-gateway:/)
+  assert.match(compose, /docker\/open-cowork-gateway\/Dockerfile/)
+  assert.match(compose, /OPEN_COWORK_CLOUD_BASE_URL: http:\/\/open-cowork-cloud:8787/)
+  assert.match(compose, /OPEN_COWORK_GATEWAY_SERVICE_TOKEN/)
+  assert.match(compose, /OPEN_COWORK_GATEWAY_ALLOW_INSECURE_HTTP: "true"/)
+  assert.match(compose, /OPEN_COWORK_GATEWAY_FAKE_CHANNEL_BINDING_ID/)
+  assert.match(compose, /OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN/)
+  assert.match(compose, /OPEN_COWORK_GATEWAY_WEBHOOK_DELIVERY_URL/)
+  assert.match(compose, /8790:8790/)
+})
+
 test('cloud deployment docs cover provider-neutral split deployment', () => {
   const docs = readRepoFile('docs/open-cowork-cloud.md')
   for (const provider of ['GCP', 'AWS', 'Azure', 'DigitalOcean', 'Kubernetes']) {
@@ -66,6 +80,13 @@ test('cloud deployment docs cover provider-neutral split deployment', () => {
   assert.match(docs, /GET \/api\/workers\/heartbeats/)
   assert.match(docs, /web app at `\/`/)
   assert.match(docs, /createHttpSseCloudTransportAdapter/)
+  assert.match(docs, /Generic Docker: Cloud \+ Gateway/)
+  assert.match(docs, /docker-compose\.cloud-gateway\.yml/)
+  assert.match(docs, /GET \/ready/)
+  assert.match(docs, /OPEN_COWORK_GATEWAY_SERVICE_TOKEN/)
+  assert.match(docs, /OPEN_COWORK_GATEWAY_DIAGNOSTICS_ENABLED/)
+  assert.match(docs, /helm\/open-cowork-gateway/)
+  assert.match(docs, /cloud-managed-operations\.md/)
 })
 
 test('cloud Helm chart keeps provider-neutral role wiring explicit', () => {
@@ -76,9 +97,11 @@ test('cloud Helm chart keeps provider-neutral role wiring explicit', () => {
   const secret = readRepoFile('helm/open-cowork-cloud/templates/secret.yaml')
 
   assert.match(chart, /name: open-cowork-cloud/)
+  assert.match(chart, /open-cowork-gateway/)
   assert.match(values, /web:/)
   assert.match(values, /worker:/)
   assert.match(values, /scheduler:/)
+  assert.match(values, /gateway:/)
   assert.equal(values.includes('worker:\n    enabled: false\n    replicas: 1'), true)
   assert.match(values, /checkpoints:/)
   assert.match(values, /secretKeyRef: ""/)
@@ -134,6 +157,38 @@ test('cloud Helm chart keeps provider-neutral role wiring explicit', () => {
   assert.match(secret, /OPEN_COWORK_CLOUD_OTLP_HEADERS/)
 })
 
+test('gateway Helm chart keeps provider-neutral gateway wiring explicit', () => {
+  const chart = readRepoFile('helm/open-cowork-gateway/Chart.yaml')
+  const values = readRepoFile('helm/open-cowork-gateway/values.yaml')
+  const deployment = readRepoFile('helm/open-cowork-gateway/templates/deployment.yaml')
+  const configMap = readRepoFile('helm/open-cowork-gateway/templates/configmap.yaml')
+  const secret = readRepoFile('helm/open-cowork-gateway/templates/secret.yaml')
+
+  assert.match(chart, /name: open-cowork-gateway/)
+  assert.match(values, /repository: ghcr\.io\/joe-broadhead\/open-cowork-gateway/)
+  assert.match(values, /mode: self-host/)
+  assert.match(values, /cloudBaseUrl: ""/)
+  assert.match(values, /serviceToken: ""/)
+  assert.match(values, /providersJson: ""/)
+  assert.match(values, /telegram:/)
+  assert.match(values, /webhook:/)
+  assert.match(values, /podSecurityContext:/)
+  assert.match(values, /runAsNonRoot: true/)
+  assert.match(values, /containerSecurityContext:/)
+  assert.match(values, /allowPrivilegeEscalation: false/)
+  assert.match(deployment, /gateway\.cloudBaseUrl is required/)
+  assert.match(deployment, /gateway\.serviceToken or gateway\.existingSecret is required/)
+  assert.match(deployment, /\/health/)
+  assert.match(deployment, /\/ready/)
+  assert.match(configMap, /OPEN_COWORK_CLOUD_BASE_URL/)
+  assert.match(configMap, /OPEN_COWORK_GATEWAY_MODE/)
+  assert.match(configMap, /OPEN_COWORK_GATEWAY_METRICS_ENABLED/)
+  assert.match(secret, /OPEN_COWORK_GATEWAY_SERVICE_TOKEN/)
+  assert.match(secret, /OPEN_COWORK_GATEWAY_PROVIDERS/)
+  assert.match(secret, /OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN/)
+  assert.match(secret, /OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET/)
+})
+
 test('cloud CLI entrypoint uses the shared config loader and cloud app bootstrap', () => {
   const script = readRepoFile('scripts/open-cowork-cloud.ts')
   assert.match(script, /getAppConfig/)
@@ -143,6 +198,7 @@ test('cloud CLI entrypoint uses the shared config loader and cloud app bootstrap
 
 test('cloud image builds workspace packages required by package entrypoints', () => {
   const dockerfile = readRepoFile('docker/open-cowork-cloud/Dockerfile')
+  const gatewayDockerfile = readRepoFile('docker/open-cowork-gateway/Dockerfile')
   const buildScript = readRepoFile('scripts/build-cloud.mjs')
 
   assert.match(buildScript, /cloudElectronShimPlugin/)
@@ -156,19 +212,29 @@ test('cloud image builds workspace packages required by package entrypoints', ()
   assert.match(dockerfile, /USER node/)
   assert.match(dockerfile, /HEALTHCHECK/)
   assert.match(dockerfile, /CMD \["pnpm", "cloud:start"\]/)
+
+  assert.match(gatewayDockerfile, /pnpm --filter @open-cowork\/gateway build/)
+  assert.match(gatewayDockerfile, /pnpm --filter @open-cowork\/shared build/)
+  assert.match(gatewayDockerfile, /COPY scripts \.\/scripts/)
+  assert.match(gatewayDockerfile, /pnpm install --frozen-lockfile --prod/)
+  assert.match(gatewayDockerfile, /OPEN_COWORK_GATEWAY_PORT=8790/)
+  assert.match(gatewayDockerfile, /USER node/)
+  assert.match(gatewayDockerfile, /\/ready/)
+  assert.match(gatewayDockerfile, /CMD \["pnpm", "--dir", "apps\/gateway", "start"\]/)
 })
 
 test('cloud provider recipes stay thin compositions of the shared image and adapters', () => {
   const index = readRepoFile('deploy/README.md')
-  assert.match(index, /same\n`open-cowork-cloud` image/)
+  assert.match(index, /`open-cowork-cloud` and `open-cowork-gateway` images/)
+  assert.match(index, /open-cowork-gateway/)
   assert.match(index, /Postgres/)
   assert.match(index, /OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED=true/)
 
   const recipes = {
-    gcp: ['Cloud SQL for PostgreSQL', 'Cloud Storage', 'Secret Manager', 'GKE'],
-    aws: ['RDS for PostgreSQL', 'S3', 'Secrets Manager', 'EKS'],
-    azure: ['Azure Database for PostgreSQL', 'Azure Blob Storage', 'Key Vault', 'AKS'],
-    digitalocean: ['Managed PostgreSQL', 'Spaces', 'DOKS', 'App Platform'],
+    gcp: ['Cloud SQL for PostgreSQL', 'Cloud Storage', 'Secret Manager', 'GKE', 'open-cowork-gateway'],
+    aws: ['RDS for PostgreSQL', 'S3', 'Secrets Manager', 'EKS', 'open-cowork-gateway'],
+    azure: ['Azure Database for PostgreSQL', 'Azure Blob Storage', 'Key Vault', 'AKS', 'open-cowork-gateway'],
+    digitalocean: ['Managed PostgreSQL', 'Spaces', 'DOKS', 'App Platform', 'open-cowork-gateway'],
   }
 
   for (const [provider, expected] of Object.entries(recipes)) {
@@ -176,9 +242,33 @@ test('cloud provider recipes stay thin compositions of the shared image and adap
     assert.match(readme, /open-cowork-cloud/)
     assert.match(readme, /cloud.checkpoints.enabled=true/)
     assert.match(readme, /helm upgrade --install open-cowork-cloud/)
+    assert.match(readme, /helm upgrade --install open-cowork-gateway/)
+    assert.match(readme, /gateway.existingSecret=open-cowork-gateway-secrets/)
     for (const phrase of expected) {
       assert.match(readme, new RegExp(phrase))
     }
+  }
+})
+
+test('managed operations runbook covers readiness, rollback, diagnostics, and gateway backlog', () => {
+  const runbook = readRepoFile('docs/runbooks/cloud-managed-operations.md')
+
+  for (const phrase of [
+    'GET /healthz',
+    'GET /api/workers/heartbeats',
+    'GET /ready',
+    'Rollback',
+    'Worker Drains',
+    'Gateway Backlog',
+    'Secret Rotation',
+    'Diagnostics',
+    'API tokens',
+    'BYOK keys',
+    'object-store signed URLs',
+    'local host paths',
+    'Restore Check',
+  ]) {
+    assert.match(runbook, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
   }
 })
 
@@ -192,13 +282,36 @@ test('CI enforces cloud portability, concurrency, and deployment gates', () => {
   assert.match(workflow, /cloud-postgres-concurrency\.test\.ts/)
   assert.match(workflow, /docker compose -f docker-compose\.cloud\.yml config --quiet/)
   assert.match(workflow, /docker compose -f docker-compose\.cloud\.split\.yml config --quiet/)
+  assert.match(workflow, /docker compose -f docker-compose\.cloud-gateway\.yml config --quiet/)
   assert.match(workflow, /docker build -f docker\/open-cowork-cloud\/Dockerfile/)
+  assert.match(workflow, /docker build -f docker\/open-cowork-gateway\/Dockerfile/)
   assert.match(workflow, /bash scripts\/ci-cloud-compose-smoke\.sh docker-compose\.cloud\.split\.yml/)
+  assert.match(workflow, /OPEN_COWORK_GATEWAY_SMOKE_URL=http:\/\/127\.0\.0\.1:8790\/ready bash scripts\/ci-cloud-compose-smoke\.sh docker-compose\.cloud-gateway\.yml/)
+  assert.match(workflow, /helm dependency build helm\/open-cowork-cloud/)
   assert.match(workflow, /helm lint helm\/open-cowork-cloud/)
   assert.match(workflow, /helm template open-cowork-cloud helm\/open-cowork-cloud/)
+  assert.match(workflow, /gateway\.enabled=true/)
+  assert.match(workflow, /OPEN_COWORK_GATEWAY_SERVICE_TOKEN/)
+  assert.match(workflow, /helm lint helm\/open-cowork-gateway/)
+  assert.match(workflow, /helm template open-cowork-gateway helm\/open-cowork-gateway/)
 
   const smoke = readRepoFile('scripts/ci-cloud-compose-smoke.sh')
   assert.match(smoke, /docker compose -p "\$\{project_name\}" -f "\$\{compose_file\}" up --build -d/)
   assert.match(smoke, /http:\/\/127\.0\.0\.1:8787\/healthz/)
+  assert.match(smoke, /OPEN_COWORK_GATEWAY_SMOKE_URL/)
   assert.match(smoke, /docker compose -p "\$\{project_name\}" -f "\$\{compose_file\}" logs --no-color --tail=200/)
+})
+
+test('release workflow publishes versioned cloud and gateway OCI images', () => {
+  const workflow = readRepoFile('.github/workflows/release.yml')
+
+  assert.match(workflow, /publish-oci-images:/)
+  assert.match(workflow, /packages: write/)
+  assert.match(workflow, /docker login ghcr\.io/)
+  assert.match(workflow, /docker\/open-cowork-cloud\/Dockerfile/)
+  assert.match(workflow, /docker\/open-cowork-gateway\/Dockerfile/)
+  assert.match(workflow, /image="ghcr\.io\/\$\{owner\}\/open-cowork-cloud"/)
+  assert.match(workflow, /image="ghcr\.io\/\$\{owner\}\/open-cowork-gateway"/)
+  assert.match(workflow, /-t "\$\{image\}:\$\{GITHUB_REF_NAME\}"/)
+  assert.match(workflow, /docker push "\$\{image\}:\$\{version\}"/)
 })

--- a/tests/cloud-distribution-redaction.test.ts
+++ b/tests/cloud-distribution-redaction.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { sanitizeForExport } from '../apps/desktop/src/main/log-sanitizer.ts'
+import { sanitizeCloudObservabilityAttributes } from '../apps/desktop/src/main/cloud/observability.ts'
+import { redactGatewayConfig, resolveGatewayConfig } from '../apps/gateway/src/config.ts'
+
+test('cloud and gateway distribution diagnostics redact secrets, signed URLs, and local paths', () => {
+  const rawByok = ['sk', 'distributionsecretvalue1234567890abcdef123456'].join('-')
+  const gatewayToken = ['ocgw', 'distribution_secret_token_1234567890'].join('_')
+  const telegramToken = ['123456', 'telegram-secret-token-abcdefghijklmnopqrstuvwxyz'].join(':')
+  const objectStoreSecret = ['object-store-secret', 'abcdefghijklmnopqrstuvwxyz'].join('-')
+  const signedUrlSecret = ['object-store-url', 'secret'].join('-')
+  const bundle = [
+    `OPEN_COWORK_GATEWAY_SERVICE_TOKEN=${gatewayToken}`,
+    `OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN=${telegramToken}`,
+    `OPEN_COWORK_CLOUD_OBJECT_STORE_SECRET_ACCESS_KEY=${objectStoreSecret}`,
+    `OPEN_COWORK_CLOUD_BYOK=${rawByok}`,
+    'artifact=https://bucket.s3.amazonaws.com/private/output.txt?X-Amz-Signature=abcdef&X-Amz-Credential=secret',
+    'workspace=/Users/alice/acme-private-project',
+    'linuxWorkspace=/home/bob/customer-repo',
+  ].join('\n')
+
+  const redactedBundle = sanitizeForExport(bundle)
+  for (const forbidden of [
+    rawByok,
+    gatewayToken,
+    telegramToken,
+    objectStoreSecret,
+    'X-Amz-Signature=abcdef',
+    'alice',
+    'acme-private-project',
+    'bob',
+    'customer-repo',
+  ]) {
+    assert.equal(redactedBundle.includes(forbidden), false, `diagnostics leaked ${forbidden}`)
+  }
+  assert.match(redactedBundle, /\[REDACTED_TOKEN\]/)
+  assert.match(redactedBundle, /\[REDACTED_QUERY\]/)
+  assert.match(redactedBundle, /\[REDACTED_HOME\]/)
+
+  const gatewayConfig = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: gatewayToken,
+    },
+    providers: [{
+      id: 'telegram',
+      kind: 'telegram',
+      channelBindingId: 'telegram',
+      credentials: {
+        botToken: telegramToken,
+      },
+      settings: {
+        deliveryUrl: `https://object-store.example.test/private/file.txt?token=${signedUrlSecret}`,
+        localPath: '/Users/alice/acme-private-project',
+      },
+    }],
+  })
+  const gatewayDiagnostics = JSON.stringify(redactGatewayConfig(gatewayConfig))
+  assert.equal(gatewayDiagnostics.includes(gatewayToken), false)
+  assert.equal(gatewayDiagnostics.includes(telegramToken), false)
+  assert.equal(gatewayDiagnostics.includes(signedUrlSecret), false)
+  assert.equal(gatewayDiagnostics.includes('acme-private-project'), false)
+
+  assert.deepEqual(sanitizeCloudObservabilityAttributes({
+    token: gatewayToken,
+    object_store_url: 'https://bucket.s3.amazonaws.com/private/output.txt?X-Amz-Signature=abcdef',
+    local_path: '/home/bob/customer-repo',
+  }), {
+    token: '[redacted]',
+    object_store_url: 'https://bucket.s3.amazonaws.com/private/output.txt?[redacted]',
+    local_path: '/home/[redacted]',
+  })
+})

--- a/tests/cloud-observability.test.ts
+++ b/tests/cloud-observability.test.ts
@@ -16,6 +16,8 @@ test('cloud observability sanitizes secret-bearing attributes', () => {
     authorization: 'Bearer private-token',
     cookie: 'session=private',
     nested_secret: 'private',
+    object_store_url: 'https://bucket.s3.amazonaws.com/private/file.txt?X-Amz-Signature=private',
+    local_path: '/Users/alice/acme-private',
     count: 2,
     ok: true,
   }), {
@@ -23,6 +25,8 @@ test('cloud observability sanitizes secret-bearing attributes', () => {
     authorization: '[redacted]',
     cookie: '[redacted]',
     nested_secret: '[redacted]',
+    object_store_url: 'https://bucket.s3.amazonaws.com/private/file.txt?[redacted]',
+    local_path: '/Users/[redacted]',
     count: 2,
     ok: true,
   })


### PR DESCRIPTION
## Summary

Closes #431.

- adds a gateway OCI image, combined cloud+gateway Docker Compose path, and gateway Helm chart/sub-chart wiring
- extends CI/release workflows to dry-run build cloud/gateway images, validate Compose, lint/template Helm, and publish versioned GHCR images on release tags
- documents generic Docker, Kubernetes, GCP, AWS, Azure, DigitalOcean, and managed operations paths
- hardens diagnostics/redaction for gateway config, cloud observability attributes, service tokens, provider credentials, signed object URLs, and local paths

## Verification

- docker compose config validation for cloud, split cloud, and cloud+gateway
- Docker build: `docker/open-cowork-cloud/Dockerfile`
- Docker build: `docker/open-cowork-gateway/Dockerfile`
- Helm dependency build/lint/template for cloud and gateway charts
- `node --no-warnings --experimental-strip-types --test tests/cloud-deployment-artifacts.test.ts tests/cloud-distribution-redaction.test.ts tests/cloud-observability.test.ts tests/log-sanitizer.test.ts`
- `pnpm --filter @open-cowork/gateway test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm perf:check`
- `mkdocs build --strict`
- `git diff --check`
