### PR TITLE
Implement workspace product contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ In other words:
 
 **OpenCode is the engine. Open Cowork is the cockpit.**
 
+## Product surfaces and sync contract
+
+Open Cowork is organized around three surfaces on the same OpenCode boundary:
+
+- **Desktop** can run a Local workspace with the current private-on-device
+  behavior, or connect to a Cloud workspace.
+- **Cloud workspace** is the shared control plane. Desktop, web, and gateway
+  clients see the same cloud threads because they read and write the same
+  tenant-scoped sessions, events, projections, artifacts, workflows, settings,
+  and policy verdicts.
+- **Gateway** is a headless client for Telegram, Slack, email, webhooks, and
+  similar channels. It routes channel messages to cloud sessions; it does not
+  spawn OpenCode or own a second runtime.
+
+Local threads stay local. Open Cowork does not upload local projects, local
+stdio MCPs, machine runtime config, provider keys, or local-only artifacts just
+because a user connects a cloud org. Cloud-safe actions are explicit, policy
+gated, and reported through the workspace support matrix.
+
 ## Why it exists
 
 AI coding agents are powerful.

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -79,9 +79,9 @@ describe('Sidebar', () => {
       />,
     )
 
-    const switcher = await screen.findByRole('button', { name: /Local.*Online.*Local workspace/i })
+    const switcher = await screen.findByRole('button', { name: /Local.*Online.*Local workspace - private on this device/i })
     fireEvent.click(switcher)
-    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Disabled/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Policy disabled/i }))
 
     await waitFor(() => {
       expect(window.coworkApi.workspace.activate).toHaveBeenCalledWith('cloud:acme')
@@ -162,8 +162,8 @@ describe('Sidebar', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace/i }))
-    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Sign in/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace - private on this device/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Auth required/i }))
 
     await waitFor(() => {
       expect(window.coworkApi.workspace.login).toHaveBeenCalledWith('cloud:acme')
@@ -240,8 +240,8 @@ describe('Sidebar', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace/i }))
-    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Sign in/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace - private on this device/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Acme Cloud.*Auth required/i }))
 
     await waitFor(() => {
       expect(window.coworkApi.workspace.login).toHaveBeenCalledWith('cloud:acme')
@@ -249,6 +249,55 @@ describe('Sidebar', () => {
     })
     expect(activate).not.toHaveBeenCalledWith('cloud:acme')
     expect(sessionList).toHaveBeenCalledWith({ workspaceId: 'local' })
+  })
+
+  it('explains policy-disabled cloud workspaces with workspace support verdicts', async () => {
+    const support = vi.fn(async (workspaceId?: string) => workspaceId === 'cloud:acme'
+      ? [{
+          api: 'sessions.prompt',
+          status: 'blocked_by_policy',
+          verdict: {
+            allowed: false,
+            reason: 'Cloud chat is disabled by this workspace policy.',
+          },
+        }]
+      : [])
+    installRendererTestCoworkApi({
+      workspace: {
+        list: vi.fn(async () => [
+          {
+            id: 'local',
+            kind: 'local',
+            label: 'Local',
+            status: 'online',
+            active: false,
+            lastSyncedAt: null,
+          },
+          {
+            id: 'cloud:acme',
+            kind: 'cloud',
+            label: 'Acme Cloud',
+            status: 'disabled',
+            active: true,
+            baseUrl: 'https://cloud.acme.test',
+            lastSyncedAt: null,
+          },
+        ]),
+        support,
+      },
+    })
+
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByRole('button', {
+      name: /Acme Cloud.*Policy disabled.*Cloud chat is disabled by this workspace policy/i,
+    })).toBeTruthy()
+    expect(support).toHaveBeenCalledWith('cloud:acme')
   })
 
   it('renders configured top and lower downstream branding surfaces', () => {

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -1,5 +1,11 @@
 import { lazy, Suspense, useEffect, useState, type CSSProperties } from 'react'
-import type { BrandingSidebarConfig, BrandingSidebarLowerConfig, BrandingSidebarTopConfig, WorkspaceInfo } from '@open-cowork/shared'
+import type {
+  BrandingSidebarConfig,
+  BrandingSidebarLowerConfig,
+  BrandingSidebarTopConfig,
+  WorkspaceApiSupport,
+  WorkspaceInfo,
+} from '@open-cowork/shared'
 import { ThreadList } from '../sidebar/ThreadList'
 import { McpStatus } from '../sidebar/McpStatus'
 import { NewThreadButton } from '../sidebar/NewThreadButton'
@@ -228,11 +234,11 @@ function workspaceStatusLabel(status: WorkspaceInfo['status']) {
     case 'online':
       return t('workspace.status.online', 'Online')
     case 'offline':
-      return t('workspace.status.offline', 'Offline')
+      return t('workspace.status.offline', 'Offline cached')
     case 'auth_required':
-      return t('workspace.status.authRequired', 'Sign in')
+      return t('workspace.status.authRequired', 'Auth required')
     case 'disabled':
-      return t('workspace.status.disabled', 'Disabled')
+      return t('workspace.status.disabled', 'Policy disabled')
     case 'error':
       return t('workspace.status.error', 'Error')
     default:
@@ -247,15 +253,60 @@ function workspaceStatusClass(status: WorkspaceInfo['status']) {
   return 'border-red-400/30 text-red-200'
 }
 
+function workspaceSupportReason(support: WorkspaceApiSupport[] | undefined, ...apis: string[]) {
+  for (const api of apis) {
+    const reason = support?.find((entry) => entry.api === api)?.verdict?.reason
+    if (reason) return reason
+  }
+  return null
+}
+
+function workspaceDescription(workspace: WorkspaceInfo, support: WorkspaceApiSupport[] | undefined) {
+  if (workspace.kind === 'local') {
+    return t('workspace.local', 'Local workspace - private on this device')
+  }
+  if (workspace.status === 'offline') {
+    return t('workspace.offlineCached', 'Offline cached - cloud sends are disabled')
+  }
+  if (workspace.status === 'auth_required') {
+    return t('workspace.authRequiredDescription', 'Auth required - sign in to sync this workspace')
+  }
+  if (workspace.status === 'disabled') {
+    const reason = workspaceSupportReason(support, 'sessions.prompt', 'sessions.create') || workspace.error
+    return reason
+      ? `${t('workspace.policyDisabled', 'Policy disabled')} - ${reason}`
+      : t('workspace.policyDisabledDescription', 'Policy disabled - this workspace cannot run cloud actions')
+  }
+  if (workspace.status === 'error') {
+    return workspace.error || t('workspace.errorDescription', 'Cloud workspace error')
+  }
+  const cloudTarget = workspace.profileName || workspace.baseUrl || t('workspace.cloud', 'Cloud workspace')
+  return `${cloudTarget} - ${t('workspace.cloudSynced', 'syncs with web and gateway')}`
+}
+
 function WorkspaceSwitcher() {
   const setSessions = useSessionStore((state) => state.setSessions)
   const setCurrentSession = useSessionStore((state) => state.setCurrentSession)
   const setActiveWorkspace = useSessionStore((state) => state.setActiveWorkspace)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
   const [workspaces, setWorkspaces] = useState<WorkspaceInfo[]>([LOCAL_WORKSPACE_FALLBACK])
+  const [supportByWorkspace, setSupportByWorkspace] = useState<Record<string, WorkspaceApiSupport[]>>({})
   const [open, setOpen] = useState(false)
 
   const activeWorkspace = workspaces.find((workspace) => workspace.active) || workspaces[0] || LOCAL_WORKSPACE_FALLBACK
+
+  const refreshSupport = async (listedWorkspaces: WorkspaceInfo[], cancelled: () => boolean) => {
+    const workspaceApi = window.coworkApi?.workspace
+    if (!workspaceApi?.support) return
+    const entries = await Promise.all(listedWorkspaces.map(async (workspace) => {
+      try {
+        return [workspace.id, await workspaceApi.support(workspace.id)] as const
+      } catch {
+        return [workspace.id, []] as const
+      }
+    }))
+    if (!cancelled()) setSupportByWorkspace(Object.fromEntries(entries))
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -266,6 +317,7 @@ function WorkspaceSwitcher() {
         if (cancelled) return
         const listedWorkspaces = next.length > 0 ? next : [LOCAL_WORKSPACE_FALLBACK]
         setWorkspaces(listedWorkspaces)
+        void refreshSupport(listedWorkspaces, () => cancelled)
         const active = listedWorkspaces.find((workspace) => workspace.active) || listedWorkspaces[0] || LOCAL_WORKSPACE_FALLBACK
         setActiveWorkspace(active.id)
         if (active.kind === 'local' || active.status === 'online') {
@@ -297,6 +349,7 @@ function WorkspaceSwitcher() {
       }
       const nextWorkspaces = await window.coworkApi.workspace.list()
       setWorkspaces(nextWorkspaces.length > 0 ? nextWorkspaces : [activated])
+      void refreshSupport(nextWorkspaces.length > 0 ? nextWorkspaces : [activated], () => false)
       if (activated.id !== previousId) {
         setActiveWorkspace(activated.id)
         setCurrentSession(null)
@@ -312,6 +365,7 @@ function WorkspaceSwitcher() {
         const restored = await window.coworkApi.workspace.activate(previousId)
         const restoredWorkspaces = await window.coworkApi.workspace.list()
         setWorkspaces(restoredWorkspaces.length > 0 ? restoredWorkspaces : [restored])
+        void refreshSupport(restoredWorkspaces.length > 0 ? restoredWorkspaces : [restored], () => false)
         setActiveWorkspace(restored.id)
         if (restored.kind === 'local' || restored.status === 'online') {
           setSessions(await window.coworkApi.session.list({ workspaceId: restored.id }))
@@ -337,14 +391,12 @@ function WorkspaceSwitcher() {
       >
         <div className="flex min-w-0 items-center justify-between gap-2">
           <span className="min-w-0 truncate font-medium">{activeWorkspace.label}</span>
-          <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] ${workspaceStatusClass(activeWorkspace.status)}`}>
+          <span className={`max-w-[96px] shrink-0 truncate rounded border px-1.5 py-0.5 text-[10px] ${workspaceStatusClass(activeWorkspace.status)}`}>
             {workspaceStatusLabel(activeWorkspace.status)}
           </span>
         </div>
         <div className="mt-0.5 truncate text-[10px] text-text-muted">
-          {activeWorkspace.kind === 'local'
-            ? t('workspace.local', 'Local workspace')
-            : activeWorkspace.profileName || activeWorkspace.baseUrl || t('workspace.cloud', 'Cloud workspace')}
+          {workspaceDescription(activeWorkspace, supportByWorkspace[activeWorkspace.id])}
         </div>
       </button>
 
@@ -363,14 +415,12 @@ function WorkspaceSwitcher() {
             >
               <div className="flex min-w-0 items-center justify-between gap-2">
                 <span className="truncate font-medium">{workspace.label}</span>
-                <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] ${workspaceStatusClass(workspace.status)}`}>
+                <span className={`max-w-[96px] shrink-0 truncate rounded border px-1.5 py-0.5 text-[10px] ${workspaceStatusClass(workspace.status)}`}>
                   {workspaceStatusLabel(workspace.status)}
                 </span>
               </div>
               <div className="mt-0.5 truncate text-[10px] text-text-muted">
-                {workspace.kind === 'local'
-                  ? t('workspace.local', 'Local workspace')
-                  : workspace.profileName || workspace.baseUrl || t('workspace.cloud', 'Cloud workspace')}
+                {workspaceDescription(workspace, supportByWorkspace[workspace.id])}
               </div>
             </button>
           ))}

--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.test.tsx
@@ -7,6 +7,8 @@ import { NewThreadButton } from './NewThreadButton'
 
 function resetSessionStore() {
   useSessionStore.setState({
+    activeWorkspaceId: 'local',
+    sessionsByWorkspace: { local: [] },
     sessions: [],
     currentSessionId: null,
     globalErrors: [],
@@ -118,5 +120,60 @@ describe('NewThreadButton', () => {
     })
     expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not create a new thread. Please try again.')
     expect(screen.queryByRole('button', { name: /Blank thread/ })).not.toBeInTheDocument()
+  })
+
+  it('disables local project creation in cloud workspaces using the support matrix reason', async () => {
+    const user = userEvent.setup()
+    const selectDirectory = vi.fn(async () => '/tmp/project')
+    const create = vi.fn(async () => ({
+      id: 'cloud-session-1',
+      title: 'Cloud session',
+      directory: null,
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }))
+    installRendererTestCoworkApi({
+      workspace: {
+        support: vi.fn(async () => [
+          {
+            api: 'sessions.create',
+            status: 'supported',
+            verdict: { allowed: true, reason: null },
+          },
+          {
+            api: 'localFiles',
+            status: 'not_supported',
+            verdict: {
+              allowed: false,
+              reason: 'Cloud workspaces do not implicitly upload local files.',
+            },
+          },
+        ]),
+      },
+      dialog: {
+        selectDirectory,
+      },
+      session: {
+        create,
+        activate: vi.fn(async () => undefined),
+      },
+    })
+    useSessionStore.getState().setActiveWorkspace('cloud:acme')
+
+    render(<NewThreadButton />)
+
+    await user.click(screen.getByRole('button', { name: 'New Thread' }))
+
+    expect(await screen.findByText('Cloud-safe action - start a synced cloud thread')).toBeTruthy()
+    expect(screen.getByText('Local-only action - Cloud workspaces do not implicitly upload local files.')).toBeTruthy()
+    const projectButton = screen.getByRole('button', { name: /Open Project/ })
+    expect(projectButton).toBeDisabled()
+    await user.click(projectButton)
+    expect(selectDirectory).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: /Blank thread/ }))
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(undefined, { workspaceId: 'cloud:acme' })
+    })
   })
 })

--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import type { WorkspaceApiSupport } from '@open-cowork/shared'
 import { useSessionStore } from '../../stores/session'
+import { LOCAL_WORKSPACE_ID, normalizeWorkspaceId } from '../../stores/session-workspace-keys'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
 import { t } from '../../helpers/i18n'
 
@@ -21,18 +23,107 @@ function reportThreadError(error: unknown, view: string) {
   }
 }
 
+function supportEntry(support: WorkspaceApiSupport[], api: string) {
+  return support.find((entry) => entry.api === api)
+}
+
+function supportAllows(entry: WorkspaceApiSupport | undefined) {
+  if (!entry) return true
+  return entry.status === 'supported' || entry.status === 'read_only' || entry.verdict?.allowed === true
+}
+
 export function NewThreadButton({ onClick }: { onClick?: () => void }) {
   const addSession = useSessionStore((s) => s.addSession)
   const setCurrentSession = useSessionStore((s) => s.setCurrentSession)
   const addGlobalError = useSessionStore((s) => s.addGlobalError)
+  const activeWorkspaceId = useSessionStore((s) => s.activeWorkspaceId)
   const [showMenu, setShowMenu] = useState(false)
+  const [workspaceSupportState, setWorkspaceSupportState] = useState<{
+    workspaceId: string
+    entries: WorkspaceApiSupport[]
+    loaded: boolean
+    error: string | null
+  }>({
+    workspaceId: 'local',
+    entries: [],
+    loaded: false,
+    error: null,
+  })
+
+  const normalizedWorkspaceId = normalizeWorkspaceId(activeWorkspaceId)
+  const activeWorkspaceIsLocal = normalizedWorkspaceId === LOCAL_WORKSPACE_ID
+  const workspaceSupport = workspaceSupportState.workspaceId === normalizedWorkspaceId ? workspaceSupportState.entries : []
+  const workspaceSupportLoaded = workspaceSupportState.workspaceId === normalizedWorkspaceId && workspaceSupportState.loaded
+  const workspaceSupportError = workspaceSupportState.workspaceId === normalizedWorkspaceId ? workspaceSupportState.error : null
+  const createSupport = supportEntry(workspaceSupport, 'sessions.create')
+  const localFilesSupport = supportEntry(workspaceSupport, 'localFiles')
+  const cloudCreateReason = workspaceSupportError
+    || (!activeWorkspaceIsLocal && !workspaceSupportLoaded
+      ? t('newThread.policyChecking', 'Checking cloud workspace policy.')
+      : createSupport?.verdict?.reason || t('newThread.createBlocked', 'Thread creation is disabled by this workspace policy.'))
+  const localFilesReason = localFilesSupport?.verdict?.reason || t('newThread.localFilesBlocked', 'Cloud workspaces do not implicitly upload local files.')
+  const blankDisabled = (!activeWorkspaceIsLocal && (!workspaceSupportLoaded || Boolean(workspaceSupportError))) || !supportAllows(createSupport)
+  const projectDisabled = !activeWorkspaceIsLocal || blankDisabled || !supportAllows(localFilesSupport)
+  const projectDisabledReason = blankDisabled ? cloudCreateReason : localFilesReason
+  const blankHint = activeWorkspaceIsLocal
+    ? t('newThread.blankHint', 'Local workspace - start with Build and the currently available agents, tools, and skills')
+    : t('newThread.blankCloudHint', 'Cloud-safe action - start a synced cloud thread')
+  const projectHint = projectDisabled
+    ? `${t('newThread.localOnlyAction', 'Local-only action')} - ${projectDisabledReason}`
+    : t('newThread.projectHint', 'Local-only action - choose a directory the agent can read and edit')
+
+  useEffect(() => {
+    let cancelled = false
+    setWorkspaceSupportState({
+      workspaceId: normalizedWorkspaceId,
+      entries: [],
+      loaded: false,
+      error: null,
+    })
+    window.coworkApi.workspace.support(normalizedWorkspaceId)
+      .then((support) => {
+        if (!cancelled) {
+          setWorkspaceSupportState({
+            workspaceId: normalizedWorkspaceId,
+            entries: support,
+            loaded: true,
+            error: null,
+          })
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWorkspaceSupportState({
+            workspaceId: normalizedWorkspaceId,
+            entries: [],
+            loaded: true,
+            error: t('newThread.policyUnavailable', 'Could not load this workspace policy.'),
+          })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [normalizedWorkspaceId])
 
   const createThread = async (directory?: string) => {
+    if (directory && projectDisabled) {
+      addGlobalError(projectDisabledReason)
+      setShowMenu(false)
+      return
+    }
     try {
-      const session = await window.coworkApi.session.create(directory)
+      const workspaceOptions = activeWorkspaceIsLocal ? undefined : { workspaceId: normalizedWorkspaceId }
+      const session = workspaceOptions
+        ? await window.coworkApi.session.create(directory, workspaceOptions)
+        : await window.coworkApi.session.create(directory)
       addSession(session)
       setCurrentSession(session.id)
-      await window.coworkApi.session.activate(session.id)
+      if (workspaceOptions) {
+        await window.coworkApi.session.activate(session.id, workspaceOptions)
+      } else {
+        await window.coworkApi.session.activate(session.id)
+      }
       onClick?.()
     } catch (err) {
       addGlobalError(t('newThread.createFailed', 'Could not create a new thread. Please try again.'))
@@ -62,7 +153,9 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
           >
             <button
               onClick={() => createThread()}
-              className="w-full text-start px-3 py-2.5 text-[12px] text-text hover:bg-surface-hover cursor-pointer transition-colors flex items-center gap-2.5"
+              disabled={blankDisabled}
+              title={blankDisabled ? cloudCreateReason : undefined}
+              className="w-full text-start px-3 py-2.5 text-[12px] text-text hover:bg-surface-hover cursor-pointer transition-colors flex items-center gap-2.5 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" className="text-text-muted">
                 <circle cx="7" cy="7" r="5" />
@@ -70,12 +163,17 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
               </svg>
               <div>
                 <div className="font-medium">{t('newThread.blank', 'Blank thread')}</div>
-                <div className="text-[10px] text-text-muted mt-px">{t('newThread.blankHint', 'Start with Build and the currently available agents, tools, and skills')}</div>
+                <div className="text-[10px] text-text-muted mt-px">{blankHint}</div>
               </div>
             </button>
             <div className="border-t" style={{ borderColor: 'var(--color-border-subtle)' }} />
             <button
               onClick={async () => {
+                if (projectDisabled) {
+                  addGlobalError(projectDisabledReason)
+                  setShowMenu(false)
+                  return
+                }
                 try {
                   const dir = await window.coworkApi.dialog.selectDirectory()
                   if (dir) createThread(dir)
@@ -86,14 +184,16 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
                   setShowMenu(false)
                 }
               }}
-              className="w-full text-start px-3 py-2.5 text-[12px] text-text hover:bg-surface-hover cursor-pointer transition-colors flex items-center gap-2.5"
+              disabled={projectDisabled}
+              title={projectDisabled ? projectDisabledReason : undefined}
+              className="w-full text-start px-3 py-2.5 text-[12px] text-text hover:bg-surface-hover cursor-pointer transition-colors flex items-center gap-2.5 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" className="text-text-muted">
                 <path d="M2 3.5C2 2.67 2.67 2 3.5 2H5.5L7 3.5H10.5C11.33 3.5 12 4.17 12 5V10.5C12 11.33 11.33 12 10.5 12H3.5C2.67 12 2 11.33 2 10.5V3.5Z" />
               </svg>
               <div>
                 <div className="font-medium">{t('newThread.project', 'Open Project')}</div>
-                <div className="text-[10px] text-text-muted mt-px">{t('newThread.projectHint', 'Choose a directory — agent can read and edit files')}</div>
+                <div className="text-[10px] text-text-muted mt-px">{projectHint}</div>
               </div>
             </button>
           </div>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,34 @@ is real drift, not a cosmetic update.
 - runtime composition for the packaged app
 - event projection into a renderer-safe state model
 
+## Product surface contract
+
+Open Cowork exposes three product surfaces without changing the execution
+owner:
+
+- **Desktop Local workspace** uses the local Electron main process and local
+  OpenCode runtime. Threads, local project paths, local stdio MCPs, machine
+  runtime config, local settings, and local artifacts remain on that device.
+- **Cloud workspace** uses Open Cowork Cloud as the control plane. Desktop and
+  web clients sync because both read and write the same tenant-scoped cloud
+  sessions, event log, projections, workflows, artifacts, settings metadata,
+  and policy verdicts.
+- **Gateway** is a headless cloud client. It adapts Telegram, Slack, email,
+  webhooks, and other channels onto the cloud HTTP/SSE contract. It never
+  imports the OpenCode SDK, starts OpenCode, or owns control-plane Postgres
+  state.
+
+A thread belongs to exactly one workspace. Local threads do not become cloud
+threads unless a user intentionally creates or imports cloud-safe content
+through an explicit product flow. Normal sync is product-state sync, not
+OpenCode runtime-home replication and not peer-to-peer desktop sync.
+
+Renderer code should treat `workspace.support()` as the canonical capability
+source for workspace-scoped actions. The support matrix distinguishes local
+actions, cloud-safe actions, policy-disabled actions, offline cached state, and
+future/deferred surfaces before the renderer opens project pickers, exposes
+host-path diffs, enables custom content, or sends mutations.
+
 ## High-level layers
 
 Each layer maps to a small cluster of files. If you are making changes, start

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -60,6 +60,27 @@ review a workflow, it does not belong in the primary app navigation.
 Shared visible statuses should stay consistent across Chat, Threads, and
 Workflows: `active`, `running`, `failed`, `paused`, and `archived`.
 
+Workspace copy should also stay stable:
+
+- **Local workspace** means private local desktop state backed by the local
+  OpenCode runtime.
+- **Cloud workspace** means synced cloud state shared with web and gateway
+  clients through Open Cowork Cloud.
+- **Offline cached** means cached cloud state is visible, but cloud sends and
+  mutations are disabled until the connection recovers.
+- **Auth required** means the desktop has a cloud connection but no usable
+  token.
+- **Policy disabled** means the org/profile returned a support-matrix verdict
+  that blocks the action.
+- **Local-only action** means the action depends on local host paths, local
+  stdio MCPs, or machine runtime config and must not run in a cloud workspace.
+- **Cloud-safe action** means the action can be represented through the cloud
+  control plane without implicit local file, local MCP, or secret upload.
+
+The renderer should not infer those states from workspace ids alone. Use
+`workspace.support()` for action-level capability and policy verdicts, then
+show the returned reason when disabling a control.
+
 For dense operational lists, prefer compact tables, split panes, saved filters,
 and bulk-safe actions. Use cards for browse/detail previews, not as the only
 way to manage large inventories. Empty states should offer a direct next

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -8,6 +8,34 @@ files.
 
 This page is the reference for that model.
 
+## Distribution modes
+
+Downstream operators should choose the product surface intentionally:
+
+- **Local-only desktop** sets `cloudDesktop.enabled=false`. Users get the
+  current private desktop behavior with local OpenCode runtime ownership,
+  local project directories, local stdio MCPs, local settings, and no cloud
+  dependency.
+- **Cloud-enabled desktop** sets `cloudDesktop.enabled=true` and can allow
+  user-added cloud connections. Local and cloud workspaces appear side by side,
+  but local threads remain local and cloud threads sync through Open Cowork
+  Cloud.
+- **Managed-org-only desktop** sets `cloudDesktop.enabled=true`,
+  `allowUserAddedConnections=false`, `requireManagedOrg=true`, and
+  `preconfiguredConnections[]`. This is the right mode for internal company
+  builds that must pin users to approved cloud orgs.
+- **Gateway-enabled deployment** runs Open Cowork Gateway next to a cloud org.
+  The gateway is a headless client for approved channels; it uses cloud service
+  tokens and channel bindings but does not spawn OpenCode or own a second
+  control plane.
+
+Branding, providers, skills, MCPs, agents, cloud connections, gateway
+credentials, and telemetry are configurable, but the workspace contract is not:
+no build should implicitly upload local threads, local project files, provider
+keys, local stdio MCP commands, or machine runtime config into cloud. Use
+cloud-safe remote MCPs, explicit artifact upload, or admin-managed profiles
+when a capability must be available in cloud.
+
 ## Mental model
 
 Everything downstream-customizable goes through two layers:

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -28,6 +28,27 @@ enabled for your deployment. Multiple workers can claim fenced sessions, and
 checkpointing externalizes the proven OpenCode runtime/XDG and workspace
 portable set so a different worker can restore before resuming a session.
 
+## Workspace sync contract
+
+Cloud is the source of truth only for cloud workspaces. A user can start a
+cloud thread in desktop, continue it in the browser, and interact with the same
+thread through a gateway channel because all three clients read and write the
+same cloud session, command, event, projection, artifact, workflow, settings,
+and policy records.
+
+Local desktop workspaces are separate. Cloud does not automatically ingest
+local threads, host project paths, local stdio MCP commands, machine-native
+runtime config, provider keys, OAuth tokens, or local-only artifacts. The cloud
+worker owns OpenCode execution for cloud threads; the desktop owns OpenCode
+execution for local threads; the gateway owns only channel I/O.
+
+`workspace.support()` is the capability contract between cloud policy and
+clients. It returns `supported`, `read_only`, `blocked_by_policy`,
+`not_supported`, or `deferred` entries with user-facing verdict reasons. Web,
+desktop, and gateway clients should use those verdicts before enabling sends,
+project pickers, host-path diffs, custom content, artifacts, workflows, or
+gateway interactions.
+
 ## Local References
 
 Use the all-in-one reference for quick local checks:

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -37,6 +37,28 @@ runtime work:
   to a provider such as OpenAI from setup or Settings.
 - GitHub links opened by the user in their browser.
 
+## Local, cloud, and gateway data boundaries
+
+The workspace selector is a privacy boundary:
+
+- **Local workspace** data stays on the desktop except for the model,
+  provider, MCP, or user-opened network calls needed for that local runtime
+  work.
+- **Cloud workspace** prompts, cloud artifacts, event projections, workflow
+  metadata, portable settings, custom-content metadata, and policy verdicts are
+  sent to the configured Open Cowork Cloud org so desktop, web, and gateway
+  clients can sync.
+- **Gateway** messages are channel input for cloud workspaces. The gateway
+  sends channel text, approved attachments, and interaction decisions to the
+  cloud control plane; it does not receive local desktop runtime state.
+
+Open Cowork does not implicitly sync local threads, local project files, local
+host paths, local stdio MCP commands, machine runtime config, provider API
+keys, OAuth tokens, or refresh tokens. Secrets sync only as metadata or secret
+references where a cloud deployment explicitly supports them. The renderer uses
+the workspace support matrix to disable local-only actions in cloud workspaces
+and to show the server policy reason.
+
 Local workflow webhooks are loopback-only. They listen on
 `127.0.0.1`, require bearer/header/HMAC authentication, and do not send
 webhook payloads to any Open Cowork service. A workflow run may still

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -15,6 +15,7 @@ import {
   type CloudWorkspaceSessionAdapter,
 } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 import type { CloudWorkspaceCache } from '../apps/desktop/src/main/cloud-workspace-cache.ts'
+import type { WorkspaceApiSupport } from '@open-cowork/shared'
 
 function event(senderId: number) {
   return { sender: { id: senderId } } as never
@@ -52,6 +53,12 @@ function recordingCloudCache(removedWorkspaceIds: string[]): CloudWorkspaceCache
       removedWorkspaceIds.push(workspaceId)
     },
   }
+}
+
+function supportStatus(support: WorkspaceApiSupport[], api: string) {
+  const entry = support.find((candidate) => candidate.api === api)
+  assert.ok(entry, `missing support entry for ${api}`)
+  return entry
 }
 
 test('workspace gateway exposes local workspace by default', () => {
@@ -160,6 +167,18 @@ test('workspace gateway keeps local desktop actions local-only', () => {
   )
 })
 
+test('workspace gateway marks local desktop-only capabilities as local supported', async () => {
+  const gateway = createWorkspaceGateway({ cloudRegistry: null, cloudCredentialStore: null })
+  const support = await gateway.supportMatrix(event(1), LOCAL_WORKSPACE_ID)
+
+  assert.equal(supportStatus(support, 'sessions.fileSnippet').status, 'supported')
+  assert.equal(supportStatus(support, 'sessions.diff').status, 'supported')
+  assert.equal(supportStatus(support, 'localFiles').status, 'supported')
+  assert.equal(supportStatus(support, 'localStdioMcps').status, 'supported')
+  assert.equal(supportStatus(support, 'machineRuntimeConfig').status, 'supported')
+  assert.equal(supportStatus(support, 'localFiles').verdict?.allowed, true)
+})
+
 test('workspace gateway registers cloud connections without enabling unauthenticated execution', async () => {
   const gateway = createWorkspaceGateway({ cloudRegistry: null, cloudCredentialStore: null })
   const workspace = gateway.addCloud(event(1), { baseUrl: 'https://cloud.example.test/api/', label: 'Acme' })
@@ -173,6 +192,100 @@ test('workspace gateway registers cloud connections without enabling unauthentic
   assert.equal(support.find((entry) => entry.api === 'sessions.prompt')?.status, 'blocked_by_policy')
   assert.equal(support.find((entry) => entry.api === 'localFiles')?.status, 'not_supported')
   await assert.rejects(() => gateway.sync(event(1), workspace.id), /Sign in|not available/)
+})
+
+test('workspace gateway keeps host paths, local stdio MCPs, and machine config out of cloud support', async () => {
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-cloud-boundary-')), 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  credentials.save({
+    workspaceId: 'cloud:test',
+    accessToken: 'cloud-access-token',
+    expiresAt: '2030-05-27T12:00:00.000Z',
+  })
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: {
+        sessions: true,
+        threadIndex: true,
+        workflows: true,
+        artifacts: true,
+        settings: true,
+        customAgents: true,
+        customSkills: true,
+        customMcps: true,
+        agents: true,
+      },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'enabled',
+      localStdioMcps: 'allowlisted',
+      machineRuntimeConfig: 'allowlisted',
+    }),
+    listSessions: async () => [],
+    createSession: async () => ({
+      id: 'cloud-session-1',
+      title: 'Cloud session',
+      directory: null,
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }),
+    getSessionInfo: async () => null,
+    getSessionView: async () => ({
+      messages: [],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      lastInputTokens: 0,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 0,
+      lastEventAt: 0,
+      isGenerating: false,
+      isAwaitingPermission: false,
+      isAwaitingQuestion: false,
+    }),
+    promptSession: async () => undefined,
+    abortSession: async () => undefined,
+  }
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: credentials,
+    workspaces: [{
+      id: 'cloud:test',
+      kind: 'cloud',
+      label: 'Cloud',
+      status: 'online',
+      baseUrl: 'https://cloud.example.test',
+      lastSyncedAt: null,
+    }],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  const support = await gateway.supportMatrix(event(1), 'cloud:test')
+
+  assert.equal(supportStatus(support, 'sessions.prompt').status, 'supported')
+  assert.equal(supportStatus(support, 'sessions.fileSnippet').status, 'not_supported')
+  assert.match(supportStatus(support, 'sessions.fileSnippet').verdict?.reason || '', /local host paths/)
+  assert.equal(supportStatus(support, 'sessions.diff').status, 'not_supported')
+  assert.equal(supportStatus(support, 'localFiles').status, 'not_supported')
+  assert.match(supportStatus(support, 'localFiles').verdict?.reason || '', /implicitly upload local files/)
+  assert.equal(supportStatus(support, 'localStdioMcps').status, 'not_supported')
+  assert.match(supportStatus(support, 'localStdioMcps').verdict?.reason || '', /local stdio MCPs/)
+  assert.equal(supportStatus(support, 'machineRuntimeConfig').status, 'not_supported')
+  assert.match(supportStatus(support, 'machineRuntimeConfig').verdict?.reason || '', /machine-native runtime config/)
 })
 
 test('workspace gateway loads and removes persisted cloud connections', () => {


### PR DESCRIPTION
## Summary
- Document the Desktop, Cloud workspace, and Gateway product contract across README, architecture, cloud, desktop, downstream, and privacy docs.
- Standardize workspace UI copy for Local, Cloud workspace, Offline cached, Auth required, Policy disabled, Local-only action, and Cloud-safe action.
- Route renderer affordances through `workspace.support()` so cloud policy verdicts explain disabled workspace and local project actions.
- Add local/cloud support-matrix tests proving cloud workspaces do not expose host-path diffs, arbitrary local files, local stdio MCPs, or machine runtime config.

Closes #449.

## Verification
- `pnpm test tests/workspace-gateway.test.ts`
- `pnpm --filter @open-cowork/desktop test:renderer -- Sidebar.test.tsx NewThreadButton.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `/tmp/open-cowork-docs-venv/bin/mkdocs build --strict`
- `git diff --check`