### PR TITLE
Add cloud project sources

### DIFF
--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -3,6 +3,10 @@ import type {
   CapabilitySkill,
   CapabilitySkillBundle,
   CapabilityTool,
+  CloudProjectSnapshotUploadInput,
+  CloudProjectSnapshotUploadResult,
+  CloudProjectSourceInput,
+  CloudProjectSourcePolicyVerdict,
   SessionArtifact,
   SessionArtifactAttachment,
   SessionImportRequest,
@@ -49,7 +53,9 @@ export type CloudPromptInput = {
 export type CloudWorkspaceSessionAdapter = {
   policy(): Promise<WorkspacePolicy>
   listSessions(): Promise<SessionInfo[]>
-  createSession(): Promise<SessionInfo>
+  createSession(input?: { projectSource?: CloudProjectSourceInput | null }): Promise<SessionInfo>
+  validateProjectSource?(input: CloudProjectSourceInput): Promise<CloudProjectSourcePolicyVerdict>
+  uploadProjectSnapshot?(input: CloudProjectSnapshotUploadInput): Promise<CloudProjectSnapshotUploadResult>
   importSession(input: SessionImportRequest): Promise<{ session: SessionInfo, view: SessionView }>
   getSessionInfo(sessionId: string): Promise<SessionInfo | null>
   getSessionView(sessionId: string): Promise<SessionView>
@@ -182,11 +188,19 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
     }
   }
 
-  async createSession(): Promise<SessionInfo> {
+  async createSession(input: { projectSource?: CloudProjectSourceInput | null } = {}): Promise<SessionInfo> {
     const cacheKey = cloudWorkspaceCacheKey(this.connection)
-    const session = toSessionInfo((await this.transport.createSession()).session)
+    const session = toSessionInfo((await this.transport.createSession(input)).session)
     this.cache?.upsertSessionInfo(cacheKey, session)
     return session
+  }
+
+  validateProjectSource(input: CloudProjectSourceInput): Promise<CloudProjectSourcePolicyVerdict> {
+    return this.transport.validateProjectSource(input)
+  }
+
+  uploadProjectSnapshot(input: CloudProjectSnapshotUploadInput): Promise<CloudProjectSnapshotUploadResult> {
+    return this.transport.uploadProjectSnapshot(input)
   }
 
   async importSession(input: SessionImportRequest): Promise<{ session: SessionInfo, view: SessionView }> {

--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { timingSafeEqual } from 'node:crypto'
+import { mkdir } from 'node:fs/promises'
 import type { IncomingMessage } from 'node:http'
 import { DEFAULT_CONFIG, type CloudAbuseConfig, type CloudAuthConfig, type CloudBillingConfig, type OpenCoworkConfig } from '../config-types.ts'
 import { CloudArtifactService } from './artifact-service.ts'
@@ -34,6 +35,7 @@ import {
 } from './oidc-auth.ts'
 import { createCloudPathProvider, createCloudSessionPathProvider, type PathProvider } from './path-provider.ts'
 import { createPostgresControlPlaneStore } from './postgres-control-plane-store.ts'
+import { createCloudProjectSourceService } from './project-source-service.ts'
 import { createNodeOpencodeCloudRuntimeAdapter } from './opencode-runtime-adapter.ts'
 import type { CloudRuntimeAdapter, CloudRuntimeEvent } from './runtime-adapter.ts'
 import { createCloudSecretAdapterFromEnv, resolveCloudSecretRef, type SecretAdapter } from './secret-adapter.ts'
@@ -375,6 +377,7 @@ function defaultCloudRuntimeFactory(input: CloudRoleRuntimeFactoryInput) {
     env: input.env as NodeJS.ProcessEnv,
     config: input.runtimeConfig,
     configDelivery: 'ephemeral-file',
+    cwd: input.paths.resolveWorkspacePath(input.execution.tenantId, input.execution.sessionId),
   })
 }
 
@@ -702,6 +705,11 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
         })
       : createUnavailableRuntimeAdapter()
   )
+  const projectSources = createCloudProjectSourceService({
+    policy,
+    objectStore,
+    credentialResolver: (credentialRef) => resolveCloudSecretRef(credentialRef, { env }),
+  })
   const service = new CloudSessionService(
     store,
     runtime,
@@ -715,6 +723,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
     billingConfig,
     billingAdapter,
     { allowSelfServiceSignup: authConfig.allowSelfServiceSignup ?? authConfig.mode !== 'oidc' },
+    projectSources,
   )
   const artifacts = new CloudArtifactService(service, objectStore)
   const hasSessionCookieOverride = Object.prototype.hasOwnProperty.call(options, 'sessionCookies')
@@ -748,31 +757,46 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
         service,
         envValue(env, 'OPEN_COWORK_CLOUD_WORKER_ID') || `${policy.role}-worker`,
         30_000,
-        checkpointStore
-          ? {
-              async restoreBeforeCommands(lease) {
-                const leasePaths = createCloudSessionPathProvider(paths, lease.tenantId, lease.sessionId)
-                try {
-                  await checkpointStore.restoreSessionCheckpoint({
-                    tenantId: lease.tenantId,
-                    sessionId: lease.sessionId,
-                    roots: defaultCloudSessionCheckpointRoots(leasePaths, lease.tenantId, lease.sessionId),
-                  })
-                } catch (error) {
-                  if (!isMissingCheckpointError(error)) throw error
-                }
-              },
-              async saveAfterCommand(lease) {
-                const leasePaths = createCloudSessionPathProvider(paths, lease.tenantId, lease.sessionId)
-                await checkpointStore.saveSessionCheckpoint({
+        {
+          async restoreBeforeCommands(lease) {
+            const leasePaths = createCloudSessionPathProvider(paths, lease.tenantId, lease.sessionId)
+            await mkdir(leasePaths.resolveWorkspacePath(lease.tenantId, lease.sessionId), { recursive: true })
+            let restoredCheckpointEntries = 0
+            if (checkpointStore) {
+              try {
+                const restored = await checkpointStore.restoreSessionCheckpoint({
                   tenantId: lease.tenantId,
                   sessionId: lease.sessionId,
-                  checkpointVersion: lease.checkpointVersion,
                   roots: defaultCloudSessionCheckpointRoots(leasePaths, lease.tenantId, lease.sessionId),
                 })
-              },
-          }
-          : {},
+                restoredCheckpointEntries = restored.restoredEntries
+              } catch (error) {
+                if (!isMissingCheckpointError(error)) throw error
+              }
+            }
+            if (restoredCheckpointEntries === 0) {
+              const source = await service.getSessionProjectSource(lease.tenantId, lease.sessionId)
+              if (source) {
+                await projectSources.restoreProjectSource({
+                  tenantId: lease.tenantId,
+                  sessionId: lease.sessionId,
+                  source,
+                  paths: leasePaths,
+                })
+              }
+            }
+          },
+          async saveAfterCommand(lease) {
+            if (!checkpointStore) return
+            const leasePaths = createCloudSessionPathProvider(paths, lease.tenantId, lease.sessionId)
+            await checkpointStore.saveSessionCheckpoint({
+              tenantId: lease.tenantId,
+              sessionId: lease.sessionId,
+              checkpointVersion: lease.checkpointVersion,
+              roots: defaultCloudSessionCheckpointRoots(leasePaths, lease.tenantId, lease.sessionId),
+            })
+          },
+        },
         abuseConfig,
       )
     : null

--- a/apps/desktop/src/main/cloud/cloud-config.ts
+++ b/apps/desktop/src/main/cloud/cloud-config.ts
@@ -1,10 +1,17 @@
 import { resolve } from 'path'
-import type { AppSettings, CustomMcpConfig } from '@open-cowork/shared'
+import {
+  normalizeCloudProjectSource,
+  type AppSettings,
+  type CloudProjectSourceInput,
+  type CloudProjectSourcePolicyVerdict,
+  type CustomMcpConfig,
+} from '@open-cowork/shared'
 import { DEFAULT_CONFIG } from '../config-types.ts'
 import type {
   BundleMcp,
   CloudFeatureConfig,
   CloudProfileConfig,
+  CloudProjectSourcePolicyConfig,
   CloudRole,
   OpenCoworkConfig,
 } from '../config-types.ts'
@@ -22,6 +29,7 @@ export type CloudRuntimePolicy = {
   allowMachineRuntimeConfig: boolean
   allowLocalStdioMcps: boolean
   allowHostProjectDirectories: boolean
+  projectSources: CloudProjectSourcePolicyConfig
   allowedAgents: string[] | null
   allowedTools: string[] | null
   allowedMcps: string[] | null
@@ -60,6 +68,48 @@ function isPathInside(candidate: string, root: string) {
   const resolvedCandidate = resolve(candidate)
   const resolvedRoot = resolve(root)
   return resolvedCandidate === resolvedRoot || resolvedCandidate.startsWith(`${resolvedRoot}/`)
+}
+
+function normalizeHost(host: string) {
+  return host.trim().toLowerCase()
+}
+
+function normalizeRepositoryAllowKey(url: URL) {
+  const pathname = url.pathname.replace(/^\/+|\/+$/g, '').replace(/\.git$/i, '')
+  const parts = pathname.split('/').filter(Boolean)
+  if (parts.length < 2) return null
+  return `${normalizeHost(url.hostname)}/${parts[0].toLowerCase()}/${parts[1].toLowerCase()}`
+}
+
+function isSafeSubdirectory(subdirectory: string | null | undefined) {
+  if (!subdirectory) return true
+  if (subdirectory.includes('\0') || subdirectory.includes('\\') || subdirectory.startsWith('/')) return false
+  return !subdirectory.split('/').some((part) => !part || part === '.' || part === '..')
+}
+
+function isSupportedCloudSecretRef(ref: string | null | undefined) {
+  if (!ref) return true
+  const trimmed = ref.trim()
+  if (
+    trimmed.startsWith('env:')
+    || trimmed.startsWith('gcp-sm://')
+    || trimmed.startsWith('aws-sm://')
+    || trimmed.startsWith('azure-kv://')
+  ) {
+    return true
+  }
+  if (trimmed.startsWith('https://')) {
+    try {
+      const url = new URL(trimmed)
+      return !url.username
+        && !url.password
+        && url.hostname.toLowerCase().endsWith('.vault.azure.net')
+        && url.pathname.split('/').filter(Boolean)[0] === 'secrets'
+    } catch {
+      return false
+    }
+  }
+  return false
 }
 
 export function resolveCloudRole(
@@ -108,6 +158,7 @@ export function resolveCloudRuntimePolicy(
     allowMachineRuntimeConfig: runtime.allowMachineRuntimeConfig === true,
     allowLocalStdioMcps: runtime.allowLocalStdioMcps === true,
     allowHostProjectDirectories: runtime.allowHostProjectDirectories === true,
+    projectSources: cloud.projectSources,
     allowedAgents: allowlist(profile.agents),
     allowedTools: allowlist(profile.tools),
     allowedMcps: allowlist(profile.mcps),
@@ -194,4 +245,75 @@ export function isCloudProjectDirectoryAllowed(
   extraAllowedRoots: readonly string[] = [],
 ) {
   return evaluateCloudProjectDirectoryPolicy(directory, policy, extraAllowedRoots).allowed
+}
+
+export function evaluateCloudProjectSourcePolicy(
+  input: CloudProjectSourceInput | null | undefined,
+  policy: CloudRuntimePolicy,
+): CloudProjectSourcePolicyVerdict {
+  const source = normalizeCloudProjectSource(input)
+  if (!source) {
+    return { allowed: false, reason: 'Cloud project source is required.', policyCode: 'project_source.required' }
+  }
+
+  if (source.kind === 'git') {
+    if (!policy.projectSources.git.enabled) {
+      return { allowed: false, reason: 'Git project sources are disabled for this cloud profile.', policyCode: 'project_source.git.disabled' }
+    }
+    let url: URL
+    try {
+      url = new URL(source.repositoryUrl)
+    } catch {
+      return { allowed: false, reason: 'Git repository URL is invalid.', policyCode: 'project_source.git.invalid_url' }
+    }
+    if (url.username || url.password) {
+      return {
+        allowed: false,
+        reason: 'Git credentials must be stored as credential refs, not embedded in repository URLs.',
+        policyCode: 'project_source.git.raw_credentials',
+      }
+    }
+    if (url.protocol === 'file:' && !policy.projectSources.git.allowFileUrls) {
+      return { allowed: false, reason: 'Local file Git URLs are disabled for this cloud profile.', policyCode: 'project_source.git.file_url_disabled' }
+    }
+    if (url.protocol !== 'https:' && url.protocol !== 'file:') {
+      return { allowed: false, reason: 'Git repository URLs must use HTTPS.', policyCode: 'project_source.git.scheme' }
+    }
+    if (url.protocol !== 'file:') {
+      const host = normalizeHost(url.hostname)
+      const allowedHosts = policy.projectSources.git.allowedHosts.map(normalizeHost)
+      if (allowedHosts.length > 0 && !allowedHosts.includes(host)) {
+        return { allowed: false, reason: `Git host "${host}" is not allowed.`, policyCode: 'project_source.git.host_denied' }
+      }
+      const allowedRepos = policy.projectSources.git.allowedRepositories.map((entry) => entry.trim().toLowerCase()).filter(Boolean)
+      if (allowedRepos.length > 0) {
+        const key = normalizeRepositoryAllowKey(url)
+        if (!key || !allowedRepos.includes(key)) {
+          return { allowed: false, reason: 'Git repository is not allowed for this cloud profile.', policyCode: 'project_source.git.repo_denied' }
+        }
+      }
+    }
+    if (!isSafeSubdirectory(source.subdirectory)) {
+      return { allowed: false, reason: 'Git subdirectory must be a safe relative path.', policyCode: 'project_source.git.subdirectory' }
+    }
+    if (!isSupportedCloudSecretRef(source.credentialRef)) {
+      return {
+        allowed: false,
+        reason: 'Git credential refs must reference a cloud secret store, not raw credentials.',
+        policyCode: 'project_source.git.credential_ref',
+      }
+    }
+    return { allowed: true, reason: null }
+  }
+
+  if (!policy.projectSources.uploadedSnapshots.enabled) {
+    return { allowed: false, reason: 'Uploaded snapshots are disabled for this cloud profile.', policyCode: 'project_source.snapshot.disabled' }
+  }
+  if (source.fileCount > policy.projectSources.uploadedSnapshots.maxFiles) {
+    return { allowed: false, reason: 'Uploaded snapshot has too many files.', policyCode: 'project_source.snapshot.too_many_files' }
+  }
+  if (source.byteCount > policy.projectSources.uploadedSnapshots.maxBytes) {
+    return { allowed: false, reason: 'Uploaded snapshot is too large.', policyCode: 'project_source.snapshot.too_large' }
+  }
+  return { allowed: true, reason: null }
 }

--- a/apps/desktop/src/main/cloud/cloud-config.ts
+++ b/apps/desktop/src/main/cloud/cloud-config.ts
@@ -87,6 +87,14 @@ function isSafeSubdirectory(subdirectory: string | null | undefined) {
   return !subdirectory.split('/').some((part) => !part || part === '.' || part === '..')
 }
 
+function isSafeGitRef(ref: string | null | undefined) {
+  if (!ref) return true
+  const trimmed = ref.trim()
+  if (!trimmed || trimmed.startsWith('-') || trimmed.includes('\0') || trimmed.includes('\\')) return false
+  if (trimmed.includes('..') || trimmed.includes('@{') || trimmed.endsWith('.') || trimmed.includes('//')) return false
+  return !trimmed.split('/').some((part) => !part || part === '.' || part === '..')
+}
+
 function isSupportedCloudSecretRef(ref: string | null | undefined) {
   if (!ref) return true
   const trimmed = ref.trim()
@@ -295,6 +303,9 @@ export function evaluateCloudProjectSourcePolicy(
     }
     if (!isSafeSubdirectory(source.subdirectory)) {
       return { allowed: false, reason: 'Git subdirectory must be a safe relative path.', policyCode: 'project_source.git.subdirectory' }
+    }
+    if (!isSafeGitRef(source.ref)) {
+      return { allowed: false, reason: 'Git ref must be a safe branch, tag, or commit reference.', policyCode: 'project_source.git.ref' }
     }
     if (!isSupportedCloudSecretRef(source.credentialRef)) {
       return {

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -3,6 +3,9 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { AddressInfo } from 'node:net'
 import {
   emptySessionImportItemCounts,
+  normalizeCloudProjectSource,
+  type CloudProjectSnapshotUploadInput,
+  type CloudProjectSourceInput,
   type SessionImportRequest,
   type WorkflowDraft,
   type WorkflowStatus,
@@ -266,6 +269,15 @@ async function readJsonBody(req: IncomingMessage, maxBodyBytes: number) {
 
 function readString(value: unknown) {
   return typeof value === 'string' && value.trim() ? value : null
+}
+
+function readOptionalCloudProjectSource(body: Record<string, unknown>): CloudProjectSourceInput | null | undefined {
+  if (!Object.prototype.hasOwnProperty.call(body, 'projectSource')) return undefined
+  const raw = body.projectSource
+  if (raw === undefined || raw === null) return null
+  const normalized = normalizeCloudProjectSource(raw)
+  if (!normalized) throw new CloudHttpError(400, 'Cloud project source is invalid.')
+  return normalized
 }
 
 function readStringArray(value: unknown) {
@@ -880,6 +892,29 @@ async function handleApiRequest(
     return
   }
 
+  if (resource === 'project-sources') {
+    if (sessionId === 'validate' && !action && req.method === 'POST') {
+      const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      writeJson(res, 200, options.service.validateProjectSource(normalizeCloudProjectSource(body.projectSource)), options.corsOrigin)
+      return
+    }
+    if (sessionId === 'snapshots' && !action && req.method === 'POST') {
+      const body = await readJsonBody(req, options.maxBodyBytes || 35 * 1024 * 1024)
+      const uploaded = await options.service.uploadProjectSnapshot(context.principal, {
+        title: readString(body.title),
+        files: Array.isArray(body.files) ? body.files as CloudProjectSnapshotUploadInput['files'] : [],
+        excluded: Array.isArray(body.excluded) ? body.excluded as CloudProjectSnapshotUploadInput['excluded'] : [],
+        warnings: Array.isArray(body.warnings) ? body.warnings.filter((entry): entry is string => typeof entry === 'string') : [],
+        fileCount: typeof body.fileCount === 'number' ? body.fileCount : undefined,
+        byteCount: typeof body.byteCount === 'number' ? body.byteCount : undefined,
+      })
+      writeJson(res, 201, uploaded, options.corsOrigin)
+      return
+    }
+    writeError(res, 404, 'Not found.', options.corsOrigin)
+    return
+  }
+
   if (resource === 'api-tokens') {
     if (!sessionId && req.method === 'GET') {
       writeJson(res, 200, { tokens: await options.service.listApiTokens(context.principal) }, options.corsOrigin)
@@ -1395,6 +1430,7 @@ async function handleApiRequest(
     const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
     const created = await options.service.createSession(context.principal, {
       profileName: readString(body.profileName),
+      projectSource: readOptionalCloudProjectSource(body),
     })
     writeJson(res, 201, created, options.corsOrigin)
     return

--- a/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
@@ -49,6 +49,7 @@ export type NodeOpencodeCloudRuntimeOptions = {
   hostname?: string
   port?: number
   timeout?: number
+  cwd?: string
   logLevel?: ManagedOpencodeServerLogLevel
   opencodeBinPath?: string | null
   enableNativeWebSearch?: boolean
@@ -460,7 +461,7 @@ export async function createNodeOpencodeCloudRuntimeAdapter(
       timeout: options.timeout ?? 5000,
       config: serverConfig,
       env,
-      cwd: options.paths.getRuntimeHomeDir(),
+      cwd: options.cwd || options.paths.getRuntimeHomeDir(),
       logLevel: options.logLevel,
       opencodeBinPath: options.opencodeBinPath,
       onUnexpectedExit: options.onUnexpectedExit,

--- a/apps/desktop/src/main/cloud/project-source-service.ts
+++ b/apps/desktop/src/main/cloud/project-source-service.ts
@@ -186,6 +186,35 @@ function assertSafeSnapshotUpload(input: CloudProjectSnapshotUploadInput, policy
   return counts
 }
 
+function countStoredSnapshot(snapshot: StoredSnapshot) {
+  return countSnapshot({ files: snapshot.files })
+}
+
+function assertStoredSnapshotAllowed(
+  source: CloudProjectSource & { kind: 'snapshot' },
+  snapshot: StoredSnapshot,
+  policy: CloudRuntimePolicy,
+) {
+  const counts = countStoredSnapshot(snapshot)
+  if (snapshot.fileCount !== counts.fileCount || snapshot.byteCount !== counts.byteCount) {
+    throw new Error('Project snapshot metadata is invalid.')
+  }
+  if (source.fileCount !== counts.fileCount || source.byteCount !== counts.byteCount) {
+    throw new Error('Project snapshot source metadata is invalid.')
+  }
+  const verdict = evaluateCloudProjectSourcePolicy({
+    kind: 'snapshot',
+    snapshotId: source.snapshotId,
+    objectKey: source.objectKey,
+    fileCount: counts.fileCount,
+    byteCount: counts.byteCount,
+    title: source.title,
+  }, policy)
+  if (!verdict.allowed) {
+    throw new Error(verdict.reason || 'Project snapshot is blocked by cloud policy.')
+  }
+}
+
 async function restoreSnapshotFiles(workspaceDir: string, snapshot: StoredSnapshot) {
   for (const file of snapshot.files) {
     const reason = cloudProjectSnapshotPathReason(file.path)
@@ -360,6 +389,7 @@ export function createCloudProjectSourceService(input: {
         if (snapshot.version !== SNAPSHOT_FORMAT_VERSION || snapshot.snapshotId !== source.snapshotId) {
           throw new Error('Project snapshot metadata is invalid.')
         }
+        assertStoredSnapshotAllowed(source, snapshot, policy)
         await restoreSnapshotFiles(workspaceDir, snapshot)
       }
       await writeMarker(workspaceDir, source)

--- a/apps/desktop/src/main/cloud/project-source-service.ts
+++ b/apps/desktop/src/main/cloud/project-source-service.ts
@@ -1,0 +1,369 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { execFile as execFileCallback } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { promisify } from 'node:util'
+import type {
+  CloudProjectSnapshotFile,
+  CloudProjectSnapshotUploadInput,
+  CloudProjectSnapshotUploadResult,
+  CloudProjectSource,
+  CloudProjectSourceInput,
+  CloudProjectSourcePolicyVerdict,
+} from '@open-cowork/shared'
+import {
+  evaluateCloudProjectSourcePolicy,
+  type CloudRuntimePolicy,
+} from './cloud-config.ts'
+import type { ObjectStoreAdapter } from './object-store.ts'
+import type { PathProvider } from './path-provider.ts'
+import type { CloudPrincipal } from './session-service.ts'
+
+const execFile = promisify(execFileCallback)
+const SNAPSHOT_FORMAT_VERSION = 1
+const PROJECT_SOURCE_MARKER = '.open-cowork-project-source.json'
+
+export const SECRET_PROJECT_PATH_REASON = 'secret-bearing file'
+export const GENERATED_PROJECT_PATH_REASON = 'dependency or build output'
+
+type StoredSnapshot = {
+  version: 1
+  snapshotId: string
+  createdAt: string
+  title: string | null
+  fileCount: number
+  byteCount: number
+  files: CloudProjectSnapshotFile[]
+  excluded?: unknown[]
+  warnings?: string[]
+}
+
+type ProjectRestoreInput = {
+  tenantId: string
+  sessionId: string
+  source: CloudProjectSource
+  paths: PathProvider
+}
+
+type GitCredential = {
+  username: string
+  password: string
+}
+
+export type CloudProjectSourceService = {
+  validateProjectSource(source: CloudProjectSourceInput | null | undefined): CloudProjectSourcePolicyVerdict
+  uploadSnapshot(principal: CloudPrincipal, input: CloudProjectSnapshotUploadInput): Promise<CloudProjectSnapshotUploadResult>
+  restoreProjectSource(input: ProjectRestoreInput): Promise<{ restored: boolean; workspaceDir: string; reason: string }>
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function safeObjectSegment(value: string, fallback: string) {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '')
+  const hash = createHash('sha256').update(value).digest('hex').slice(0, 12)
+  return `${normalized.slice(0, 72) || fallback}-${hash}`
+}
+
+function snapshotObjectKey(tenantId: string, snapshotId: string) {
+  return [
+    'project-snapshots',
+    safeObjectSegment(tenantId, 'tenant'),
+    safeObjectSegment(snapshotId, 'snapshot'),
+    'snapshot.json',
+  ].join('/')
+}
+
+export function isCloudProjectSnapshotObjectKeyForTenant(tenantId: string, objectKey: string) {
+  return objectKey.startsWith(`project-snapshots/${safeObjectSegment(tenantId, 'tenant')}/`)
+}
+
+function isSafeRelativePath(path: string) {
+  if (!path || path.includes('\0') || path.includes('\\') || isAbsolute(path)) return false
+  const parts = path.split('/')
+  return !parts.some((part) => !part || part === '.' || part === '..')
+}
+
+export function cloudProjectSnapshotPathReason(path: string): string | null {
+  if (!isSafeRelativePath(path)) return 'unsafe path'
+  const parts = path.toLowerCase().split('/')
+  const basename = parts[parts.length - 1] || ''
+  if (
+    basename === '.env'
+    || basename.startsWith('.env.')
+    || basename === '.git-credentials'
+    || basename === '.npmrc'
+    || basename === '.pypirc'
+    || basename === '.netrc'
+    || basename === 'credentials'
+    || basename === 'credentials.json'
+    || basename === 'application_default_credentials.json'
+    || /^id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$/.test(basename)
+    || /\.(pem|key|p12|pfx)$/i.test(basename)
+    || parts.includes('.ssh')
+    || parts.includes('.aws')
+    || parts.includes('.azure')
+    || parts.includes('gcloud')
+  ) {
+    return SECRET_PROJECT_PATH_REASON
+  }
+  if (
+    parts.includes('.git')
+    || parts.includes('node_modules')
+    || parts.includes('dist')
+    || parts.includes('build')
+    || parts.includes('.next')
+    || parts.includes('.nuxt')
+    || parts.includes('coverage')
+    || parts.includes('.turbo')
+    || parts.includes('.cache')
+    || parts.includes('target')
+    || parts.includes('vendor')
+  ) {
+    return GENERATED_PROJECT_PATH_REASON
+  }
+  return null
+}
+
+function sourceFingerprint(source: CloudProjectSource) {
+  return createHash('sha256').update(JSON.stringify(source)).digest('hex')
+}
+
+async function readMarker(workspaceDir: string) {
+  try {
+    return asRecord(JSON.parse(await readFile(resolve(workspaceDir, PROJECT_SOURCE_MARKER), 'utf8')))
+  } catch {
+    return null
+  }
+}
+
+async function writeMarker(workspaceDir: string, source: CloudProjectSource) {
+  await writeFile(resolve(workspaceDir, PROJECT_SOURCE_MARKER), `${JSON.stringify({
+    source,
+    fingerprint: sourceFingerprint(source),
+    restoredAt: new Date().toISOString(),
+  }, null, 2)}\n`)
+}
+
+function ensureInside(root: string, path: string) {
+  const resolvedRoot = resolve(root)
+  const target = resolve(resolvedRoot, ...path.split('/'))
+  const rel = relative(resolvedRoot, target)
+  if (rel && (rel.startsWith('..') || isAbsolute(rel))) {
+    throw new Error('Snapshot file path escapes the project workspace.')
+  }
+  return target
+}
+
+function countSnapshot(input: CloudProjectSnapshotUploadInput) {
+  let byteCount = 0
+  for (const file of input.files) {
+    byteCount += Buffer.from(file.dataBase64, 'base64').byteLength
+  }
+  return {
+    fileCount: input.files.length,
+    byteCount,
+  }
+}
+
+function assertSafeSnapshotUpload(input: CloudProjectSnapshotUploadInput, policy: CloudRuntimePolicy) {
+  const counts = countSnapshot(input)
+  const fileCount = input.fileCount ?? counts.fileCount
+  const byteCount = input.byteCount ?? counts.byteCount
+  if (fileCount !== counts.fileCount) throw new Error('Snapshot file count does not match uploaded files.')
+  if (byteCount !== counts.byteCount) throw new Error('Snapshot byte count does not match uploaded files.')
+  if (fileCount > policy.projectSources.uploadedSnapshots.maxFiles) throw new Error('Uploaded snapshot has too many files.')
+  if (byteCount > policy.projectSources.uploadedSnapshots.maxBytes) throw new Error('Uploaded snapshot is too large.')
+  for (const file of input.files) {
+    const reason = cloudProjectSnapshotPathReason(file.path)
+    if (reason) throw new Error(`Snapshot includes blocked file "${file.path}" (${reason}).`)
+  }
+  return counts
+}
+
+async function restoreSnapshotFiles(workspaceDir: string, snapshot: StoredSnapshot) {
+  for (const file of snapshot.files) {
+    const reason = cloudProjectSnapshotPathReason(file.path)
+    if (reason) throw new Error(`Stored snapshot includes blocked file "${file.path}" (${reason}).`)
+    const target = ensureInside(workspaceDir, file.path)
+    await mkdir(dirname(target), { recursive: true })
+    await writeFile(target, Buffer.from(file.dataBase64, 'base64'))
+    if (typeof file.mode === 'number' && Number.isFinite(file.mode)) {
+      await chmod(target, file.mode & 0o777).catch(() => undefined)
+    }
+  }
+}
+
+function parseGitCredential(secret: string): GitCredential {
+  const trimmed = secret.trim()
+  if (!trimmed) throw new Error('Git credential secret is empty.')
+  try {
+    const parsed = asRecord(JSON.parse(trimmed))
+    const username = typeof parsed.username === 'string' && parsed.username.trim()
+      ? parsed.username.trim()
+      : 'x-access-token'
+    const password = typeof parsed.password === 'string' && parsed.password
+      ? parsed.password
+      : typeof parsed.token === 'string'
+        ? parsed.token
+        : ''
+    if (!password) throw new Error('Git credential JSON must include password or token.')
+    return { username, password }
+  } catch (error) {
+    if (error instanceof SyntaxError) return { username: 'x-access-token', password: trimmed }
+    throw error
+  }
+}
+
+async function createGitCredentialEnv(
+  source: CloudProjectSource & { kind: 'git' },
+  credentialResolver: ((credentialRef: string) => Promise<string>) | null,
+) {
+  if (!source.credentialRef?.trim()) return { env: {}, cleanup: async () => undefined }
+  if (!credentialResolver) throw new Error('Git credential refs are not configured for this cloud worker.')
+  const credential = parseGitCredential(await credentialResolver(source.credentialRef))
+  const tempDir = await mkdtemp(join(tmpdir(), 'open-cowork-git-'))
+  const usernameFile = join(tempDir, 'username')
+  const passwordFile = join(tempDir, 'password')
+  const askpassFile = join(tempDir, 'askpass.sh')
+  await writeFile(usernameFile, credential.username, { mode: 0o600 })
+  await writeFile(passwordFile, credential.password, { mode: 0o600 })
+  await writeFile(askpassFile, [
+    '#!/bin/sh',
+    'case "$1" in',
+    '  *Username*) cat "$OPEN_COWORK_GIT_USERNAME_FILE" ;;',
+    '  *) cat "$OPEN_COWORK_GIT_PASSWORD_FILE" ;;',
+    'esac',
+    '',
+  ].join('\n'), { mode: 0o700 })
+  return {
+    env: {
+      GIT_ASKPASS: askpassFile,
+      GIT_TERMINAL_PROMPT: '0',
+      OPEN_COWORK_GIT_USERNAME_FILE: usernameFile,
+      OPEN_COWORK_GIT_PASSWORD_FILE: passwordFile,
+    },
+    cleanup: async () => {
+      await rm(tempDir, { recursive: true, force: true })
+    },
+  }
+}
+
+async function restoreGitSource(
+  workspaceDir: string,
+  source: CloudProjectSource & { kind: 'git' },
+  credentialResolver: ((credentialRef: string) => Promise<string>) | null,
+) {
+  const credentialEnv = await createGitCredentialEnv(source, credentialResolver)
+  const env = { ...process.env, ...credentialEnv.env }
+  const checkoutDir = source.subdirectory?.trim() ? resolve(workspaceDir, '.open-cowork-git-checkout') : workspaceDir
+  try {
+    await execFile('git', ['clone', '--no-checkout', source.repositoryUrl, checkoutDir], { env })
+    const ref = source.ref?.trim() || 'HEAD'
+    await execFile('git', ['-C', checkoutDir, 'checkout', '--force', ref], { env })
+    if (source.subdirectory?.trim()) {
+      const subdirectory = ensureInside(checkoutDir, source.subdirectory.trim())
+      if (!existsSync(subdirectory)) {
+        throw new Error(`Git source subdirectory "${source.subdirectory}" was not found after checkout.`)
+      }
+      await cp(subdirectory, workspaceDir, { recursive: true, force: true })
+      await rm(checkoutDir, { recursive: true, force: true })
+    }
+  } finally {
+    await credentialEnv.cleanup()
+  }
+}
+
+export function createCloudProjectSourceService(input: {
+  policy: CloudRuntimePolicy
+  objectStore: ObjectStoreAdapter
+  credentialResolver?: (credentialRef: string) => Promise<string>
+}): CloudProjectSourceService {
+  const { policy, objectStore, credentialResolver = null } = input
+  return {
+    validateProjectSource(source) {
+      return evaluateCloudProjectSourcePolicy(source, policy)
+    },
+
+    async uploadSnapshot(principal, upload) {
+      if (!policy.projectSources.uploadedSnapshots.enabled) {
+        throw new Error('Uploaded snapshots are disabled for this cloud profile.')
+      }
+      const counts = assertSafeSnapshotUpload(upload, policy)
+      const snapshotId = randomUUID()
+      const createdAt = new Date().toISOString()
+      const objectKey = snapshotObjectKey(principal.tenantId, snapshotId)
+      const stored: StoredSnapshot = {
+        version: SNAPSHOT_FORMAT_VERSION,
+        snapshotId,
+        createdAt,
+        title: upload.title?.trim() || null,
+        fileCount: counts.fileCount,
+        byteCount: counts.byteCount,
+        files: upload.files,
+        excluded: upload.excluded || [],
+        warnings: upload.warnings || [],
+      }
+      await objectStore.putObject({
+        key: objectKey,
+        body: `${JSON.stringify(stored)}\n`,
+        contentType: 'application/vnd.open-cowork.project-snapshot+json',
+        metadata: {
+          tenant: safeObjectSegment(principal.tenantId, 'tenant'),
+          snapshot: snapshotId,
+        },
+      })
+      const projectSource = {
+        kind: 'snapshot' as const,
+        snapshotId,
+        objectKey,
+        fileCount: counts.fileCount,
+        byteCount: counts.byteCount,
+        title: stored.title,
+      }
+      return {
+        snapshotId,
+        objectKey,
+        fileCount: counts.fileCount,
+        byteCount: counts.byteCount,
+        createdAt,
+        projectSource,
+      }
+    },
+
+    async restoreProjectSource({ tenantId, sessionId, source, paths }) {
+      const verdict = evaluateCloudProjectSourcePolicy(source, policy)
+      if (!verdict.allowed) {
+        throw new Error(verdict.reason || 'Project source is blocked by cloud policy.')
+      }
+      const workspaceDir = paths.resolveWorkspacePath(tenantId, sessionId)
+      const marker = await readMarker(workspaceDir)
+      if (marker?.fingerprint === sourceFingerprint(source)) {
+        return { restored: false, workspaceDir, reason: 'already-restored' }
+      }
+      await rm(workspaceDir, { recursive: true, force: true })
+      await mkdir(workspaceDir, { recursive: true })
+      if (source.kind === 'git') {
+        await restoreGitSource(workspaceDir, source, credentialResolver)
+      } else {
+        if (!isCloudProjectSnapshotObjectKeyForTenant(tenantId, source.objectKey)) {
+          throw new Error('Project snapshot does not belong to this tenant.')
+        }
+        const object = await objectStore.getObject(source.objectKey)
+        if (!object) throw new Error('Project snapshot object was not found.')
+        const snapshot = JSON.parse(object.body.toString('utf8')) as StoredSnapshot
+        if (snapshot.version !== SNAPSHOT_FORMAT_VERSION || snapshot.snapshotId !== source.snapshotId) {
+          throw new Error('Project snapshot metadata is invalid.')
+        }
+        await restoreSnapshotFiles(workspaceDir, snapshot)
+      }
+      await writeMarker(workspaceDir, source)
+      return { restored: true, workspaceDir, reason: source.kind }
+    },
+  }
+}

--- a/apps/desktop/src/main/cloud/project-source-service.ts
+++ b/apps/desktop/src/main/cloud/project-source-service.ts
@@ -263,7 +263,7 @@ async function restoreGitSource(
   const env = { ...process.env, ...credentialEnv.env }
   const checkoutDir = source.subdirectory?.trim() ? resolve(workspaceDir, '.open-cowork-git-checkout') : workspaceDir
   try {
-    await execFile('git', ['clone', '--no-checkout', source.repositoryUrl, checkoutDir], { env })
+    await execFile('git', ['clone', '--no-checkout', '--', source.repositoryUrl, checkoutDir], { env })
     const ref = source.ref?.trim() || 'HEAD'
     await execFile('git', ['-C', checkoutDir, 'checkout', '--force', ref], { env })
     if (source.subdirectory?.trim()) {

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -15,8 +15,14 @@ import {
   type CloudSessionMessage,
   type CloudSessionProjectionView,
   type CloudSessionViewRecord,
+  type CloudProjectSnapshotUploadInput,
+  type CloudProjectSnapshotUploadResult,
+  type CloudProjectSource,
+  type CloudProjectSourceInput,
+  type CloudProjectSourcePolicyVerdict,
   type SessionImportItemCounts,
   type SessionImportRequest,
+  normalizeCloudProjectSource,
 } from '@open-cowork/shared'
 import {
   getCapabilitySkillBundle,
@@ -70,7 +76,15 @@ import type {
   CloudRuntimeExecutionContext,
   CloudRuntimePromptPart,
 } from './runtime-adapter.ts'
-import { evaluateCloudProjectDirectoryPolicy, type CloudRuntimePolicy } from './cloud-config.ts'
+import {
+  evaluateCloudProjectDirectoryPolicy,
+  evaluateCloudProjectSourcePolicy,
+  type CloudRuntimePolicy,
+} from './cloud-config.ts'
+import {
+  isCloudProjectSnapshotObjectKeyForTenant,
+  type CloudProjectSourceService,
+} from './project-source-service.ts'
 import { CloudSessionEventBus, CloudWorkspaceEventBus } from './session-event-bus.ts'
 import {
   CloudSessionProjectionService,
@@ -192,6 +206,7 @@ type CreateCloudSessionRecordInput = {
   profileName: string
   sessionId?: string | null
   title?: string | null
+  deferRuntime?: boolean
 }
 
 export type CloudWorkflowStartResult = {
@@ -480,6 +495,7 @@ export class CloudSessionService {
   private readonly billingConfig: CloudBillingConfig | null
   private readonly billingAdapter: BillingAdapter | null
   private readonly identityPolicy: CloudIdentityPolicy
+  private readonly projectSources: CloudProjectSourceService | null
 
   constructor(
     store: ControlPlaneStore,
@@ -494,6 +510,7 @@ export class CloudSessionService {
     billingConfig: CloudBillingConfig | null = null,
     billingAdapter: BillingAdapter | null = null,
     identityPolicy: CloudIdentityPolicy = { allowSelfServiceSignup: true },
+    projectSources: CloudProjectSourceService | null = null,
   ) {
     this.store = store
     this.runtime = runtime
@@ -508,6 +525,7 @@ export class CloudSessionService {
     this.billingConfig = billingConfig
     this.billingAdapter = billingAdapter
     this.identityPolicy = identityPolicy
+    this.projectSources = projectSources
   }
 
   get eventBus() {
@@ -516,6 +534,57 @@ export class CloudSessionService {
 
   get workspaceEventBus() {
     return this.workspaceEvents
+  }
+
+  validateProjectSource(source: CloudProjectSourceInput | null | undefined): CloudProjectSourcePolicyVerdict {
+    return this.projectSources?.validateProjectSource(source) || evaluateCloudProjectSourcePolicy(source, this.policy)
+  }
+
+  async uploadProjectSnapshot(
+    principal: CloudPrincipal,
+    input: CloudProjectSnapshotUploadInput,
+  ): Promise<CloudProjectSnapshotUploadResult> {
+    await this.ensurePrincipal(principal)
+    if (!this.projectSources) throw new CloudServiceError(503, 'Cloud project snapshot storage is not configured.')
+    return this.projectSources.uploadSnapshot(principal, input)
+  }
+
+  async getSessionProjectSource(tenantId: string, sessionId: string): Promise<CloudProjectSource | null> {
+    const projection = await this.store.getSessionProjection(tenantId, sessionId)
+    return normalizeCloudProjectSource(projection?.view?.projectSource)
+  }
+
+  private normalizeAndValidateProjectSource(
+    source: CloudProjectSourceInput | null | undefined,
+    tenantId: string,
+  ) {
+    if (source === undefined || source === null) return null
+    const normalized = normalizeCloudProjectSource(source)
+    const verdict = this.validateProjectSource(normalized)
+    if (!normalized || !verdict.allowed) {
+      throw new CloudServiceError(400, verdict.reason || 'Cloud project source is not allowed.', {
+        policyCode: verdict.policyCode || 'project_source.denied',
+      })
+    }
+    if (normalized.kind === 'snapshot' && !isCloudProjectSnapshotObjectKeyForTenant(tenantId, normalized.objectKey)) {
+      throw new CloudServiceError(400, 'Project snapshot does not belong to this tenant.', {
+        policyCode: 'project_source.snapshot.tenant',
+      })
+    }
+    return normalized
+  }
+
+  private async bindSessionProjectSource(
+    tenantId: string,
+    sessionId: string,
+    projectSource: CloudProjectSource,
+  ) {
+    await this.appendProjectedEvent({
+      tenantId,
+      sessionId,
+      type: 'session.project_source.bound',
+      payload: { projectSource },
+    })
   }
 
   private quotaLimit(value: number | null | undefined) {
@@ -665,10 +734,14 @@ export class CloudSessionService {
     }
   }
 
-  async createSession(principal: CloudPrincipal, input: { profileName?: string | null } = {}): Promise<CloudSessionView> {
+  async createSession(principal: CloudPrincipal, input: {
+    profileName?: string | null
+    projectSource?: CloudProjectSourceInput | null
+  } = {}): Promise<CloudSessionView> {
     await this.ensurePrincipal(principal)
     if (!this.policy.features.chat) throw new Error('Chat is disabled for this cloud profile.')
     const profileName = input.profileName || this.policy.profileName
+    const projectSource = this.normalizeAndValidateProjectSource(input.projectSource, principal.tenantId)
     await this.assertBillingAllowed({
       orgId: this.principalOrgId(principal),
       action: 'session.create',
@@ -680,7 +753,9 @@ export class CloudSessionService {
       orgId: this.principalOrgId(principal),
       accountId: principal.accountId || principal.userId,
       profileName,
+      deferRuntime: Boolean(projectSource),
     })
+    if (projectSource) await this.bindSessionProjectSource(principal.tenantId, session.sessionId, projectSource)
     return this.getSessionView(principal, session.sessionId)
   }
 
@@ -1149,9 +1224,18 @@ export class CloudSessionService {
       const owned = await this.store.getSession(principal.tenantId, principal.userId, input.sessionId)
       if (!owned) throw new CloudServiceError(403, 'Channel session binding requires a session owned by the gateway principal.')
     }
+    const defaultProjectSource = input.sessionId
+      ? null
+      : this.normalizeAndValidateProjectSource(
+          normalizeCloudProjectSource(channelBinding.settings.defaultProjectSource)
+            || normalizeCloudProjectSource(this.policy.profile.defaultProjectSource),
+          principal.tenantId,
+        )
     const sessionId = input.sessionId || (await this.createCloudSessionRecord({
       tenantId: principal.tenantId,
       userId: principal.userId,
+      orgId,
+      accountId: principal.accountId || principal.userId,
       profileName: agent.profileName,
       sessionId: stableCloudId(
         'channel_session',
@@ -1162,7 +1246,11 @@ export class CloudSessionService {
         input.externalThreadId,
       ),
       title: input.title || `Channel ${input.provider}`,
+      deferRuntime: Boolean(defaultProjectSource),
     })).sessionId
+    if (defaultProjectSource) {
+      await this.bindSessionProjectSource(principal.tenantId, sessionId, defaultProjectSource)
+    }
     const binding = await this.store.bindChannelSession({
       bindingId: this.ids.randomUUID(),
       orgId,
@@ -2534,7 +2622,7 @@ export class CloudSessionService {
       return this.requireSessionRecord(input.tenantId, input.sessionId)
     }
 
-    if (this.shouldCreateRuntimeSessionsEagerly() && !this.quotaLimit(this.abuse.maxConcurrentSessionsPerOrg)) {
+    if (!input.deferRuntime && this.shouldCreateRuntimeSessionsEagerly() && !this.quotaLimit(this.abuse.maxConcurrentSessionsPerOrg)) {
       const runtimeSession = await this.runtime.createSession({
         profileName: input.profileName,
         context: this.runtimeContext({

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -3,6 +3,7 @@ import { cpSync, existsSync, mkdirSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join, resolve } from 'path'
 import type { ProviderModelDescriptor, PublicAppConfig } from '@open-cowork/shared'
+import { normalizeCloudProjectSource } from '@open-cowork/shared'
 import {
   buildConfiguredModelFallbacks,
   buildProviderDescriptors,
@@ -217,6 +218,39 @@ function normalizeCloudFeatures(raw: Partial<CloudFeatureConfig> | undefined): C
   }
 }
 
+function normalizeCloudProjectSources(raw: CloudConfig['projectSources'] | undefined): CloudConfig['projectSources'] {
+  const defaults = DEFAULT_CONFIG.cloud.projectSources
+  const source = raw || defaults
+  return {
+    git: {
+      ...defaults.git,
+      ...(source.git || {}),
+      enabled: typeof source.git?.enabled === 'boolean' ? source.git.enabled : defaults.git.enabled,
+      allowedHosts: stringArray(source.git?.allowedHosts, defaults.git.allowedHosts),
+      allowedRepositories: stringArray(source.git?.allowedRepositories, defaults.git.allowedRepositories),
+      allowFileUrls: typeof source.git?.allowFileUrls === 'boolean' ? source.git.allowFileUrls : defaults.git.allowFileUrls,
+    },
+    uploadedSnapshots: {
+      ...defaults.uploadedSnapshots,
+      ...(source.uploadedSnapshots || {}),
+      enabled: typeof source.uploadedSnapshots?.enabled === 'boolean'
+        ? source.uploadedSnapshots.enabled
+        : defaults.uploadedSnapshots.enabled,
+      maxFiles: nullablePositiveNumber(source.uploadedSnapshots?.maxFiles, defaults.uploadedSnapshots.maxFiles)
+        || defaults.uploadedSnapshots.maxFiles,
+      maxBytes: nullablePositiveNumber(source.uploadedSnapshots?.maxBytes, defaults.uploadedSnapshots.maxBytes)
+        || defaults.uploadedSnapshots.maxBytes,
+    },
+    managedWorkspaces: {
+      ...defaults.managedWorkspaces,
+      ...(source.managedWorkspaces || {}),
+      enabled: typeof source.managedWorkspaces?.enabled === 'boolean'
+        ? source.managedWorkspaces.enabled
+        : defaults.managedWorkspaces.enabled,
+    },
+  }
+}
+
 function nullablePositiveNumber(value: unknown, fallback: number | null): number | null {
   if (value === null) return null
   const parsed = Number(value ?? fallback)
@@ -310,12 +344,16 @@ function normalizeCloudBillingConfig(raw: CloudConfig['billing'] | undefined): C
 }
 
 function normalizeCloudProfile(raw: CloudProfileConfig | undefined): CloudProfileConfig {
+  const defaultProjectSource = Object.prototype.hasOwnProperty.call(raw || {}, 'defaultProjectSource')
+    ? normalizeCloudProjectSource(raw?.defaultProjectSource)
+    : undefined
   return {
     ...(raw || {}),
     agents: stringArray(raw?.agents),
     tools: stringArray(raw?.tools),
     mcps: stringArray(raw?.mcps),
     features: raw?.features ? normalizeCloudFeatures(raw.features) : undefined,
+    ...(defaultProjectSource !== undefined ? { defaultProjectSource } : {}),
     runtime: raw?.runtime
       ? {
           ...raw.runtime,
@@ -401,6 +439,7 @@ function normalizeCloudConfig(raw: CloudConfig | undefined): CloudConfig {
       allowedLocalMcpNames: stringArray(source.runtime?.allowedLocalMcpNames),
       allowedHostProjectDirectories: stringArray(source.runtime?.allowedHostProjectDirectories),
     },
+    projectSources: normalizeCloudProjectSources(source.projectSources),
     features: normalizeCloudFeatures(source.features),
     abuse: normalizeCloudAbuseConfig(source.abuse),
     billing: normalizeCloudBillingConfig(source.billing),

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -2,6 +2,7 @@ import { DEFAULT_TOOL_TRACE_RULES, type ToolTraceConfig } from '@open-cowork/sha
 import type {
   AgentStarterTemplate,
   BrandingConfig,
+  CloudProjectSourceInput,
   CredentialField,
   ModelInfoSnapshot,
   ProviderModelDescriptor,
@@ -227,6 +228,23 @@ export type CloudRuntimePolicyConfig = {
   allowedHostProjectDirectories: string[]
 }
 
+export type CloudProjectSourcePolicyConfig = {
+  git: {
+    enabled: boolean
+    allowedHosts: string[]
+    allowedRepositories: string[]
+    allowFileUrls: boolean
+  }
+  uploadedSnapshots: {
+    enabled: boolean
+    maxFiles: number
+    maxBytes: number
+  }
+  managedWorkspaces: {
+    enabled: boolean
+  }
+}
+
 export type CloudProfileConfig = {
   label?: string
   description?: string
@@ -235,6 +253,7 @@ export type CloudProfileConfig = {
   mcps?: string[]
   features?: Partial<CloudFeatureConfig>
   runtime?: Partial<CloudRuntimePolicyConfig>
+  defaultProjectSource?: CloudProjectSourceInput | null
 }
 
 export type CloudAuthConfig = {
@@ -348,6 +367,7 @@ export type CloudConfig = {
   auth: CloudAuthConfig
   storage: CloudStorageConfig
   runtime: CloudRuntimePolicyConfig
+  projectSources: CloudProjectSourcePolicyConfig
   features: CloudFeatureConfig
   abuse: CloudAbuseConfig
   billing: CloudBillingConfig
@@ -469,6 +489,23 @@ const DEFAULT_CLOUD_RUNTIME: CloudRuntimePolicyConfig = {
   allowedHostProjectDirectories: [],
 }
 
+const DEFAULT_CLOUD_PROJECT_SOURCES: CloudProjectSourcePolicyConfig = {
+  git: {
+    enabled: true,
+    allowedHosts: ['github.com', 'gitlab.com'],
+    allowedRepositories: [],
+    allowFileUrls: false,
+  },
+  uploadedSnapshots: {
+    enabled: true,
+    maxFiles: 2000,
+    maxBytes: 25 * 1024 * 1024,
+  },
+  managedWorkspaces: {
+    enabled: false,
+  },
+}
+
 const DEFAULT_CLOUD_ABUSE: CloudAbuseConfig = {
   enabled: true,
   maxConcurrentSessionsPerOrg: 100,
@@ -575,6 +612,7 @@ export const DEFAULT_CONFIG: OpenCoworkConfig = {
       },
     },
     runtime: DEFAULT_CLOUD_RUNTIME,
+    projectSources: DEFAULT_CLOUD_PROJECT_SOURCES,
     features: DEFAULT_CLOUD_FEATURES,
     abuse: DEFAULT_CLOUD_ABUSE,
     billing: DEFAULT_CLOUD_BILLING,

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -1,5 +1,10 @@
 import type { IpcHandlerContext } from './context.ts'
-import type { SessionChangeSummary, SessionImportSelection } from '@open-cowork/shared'
+import {
+  normalizeCloudProjectSource,
+  type CloudProjectSourceInput,
+  type SessionChangeSummary,
+  type SessionImportSelection,
+} from '@open-cowork/shared'
 import type { IpcMainInvokeEvent } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { closeSync, constants as fsConstants, fstatSync, openSync, readFileSync } from 'node:fs'
@@ -40,6 +45,10 @@ import { registerSessionInteractionHandlers } from './session-interaction-handle
 import { registerIpcInvoke, sessionPromptArgs, stringAndObjectArgs } from './schema.ts'
 import { sdkErrorMessage } from '../sdk-error.ts'
 import { readWorkspaceIdOption } from '../workspace-gateway.ts'
+import {
+  buildCloudProjectSnapshotInventory,
+  buildCloudProjectSnapshotUpload,
+} from '../project-source-snapshot.ts'
 import type { CloudTransportSessionEvent } from '../cloud/transport-adapter.ts'
 import {
   normalizeComposerPreferences,
@@ -76,6 +85,16 @@ function payloadQuestionTool(payload: Record<string, unknown>) {
     messageId: typeof tool.messageId === 'string' ? tool.messageId : typeof tool.messageID === 'string' ? tool.messageID : '',
     callId: typeof tool.callId === 'string' ? tool.callId : typeof tool.callID === 'string' ? tool.callID : '',
   }
+}
+
+function readCloudProjectSourceOption(input: unknown): CloudProjectSourceInput | null | undefined {
+  if (input === undefined || input === null || typeof input !== 'object' || Array.isArray(input)) return undefined
+  if (!Object.prototype.hasOwnProperty.call(input, 'projectSource')) return undefined
+  const raw = (input as { projectSource?: unknown }).projectSource
+  if (raw === undefined || raw === null) return null
+  const normalized = normalizeCloudProjectSource(raw)
+  if (!normalized) throw new Error('Cloud project source is invalid.')
+  return normalized
 }
 
 function dispatchCloudWorkspaceSessionEvent(
@@ -508,13 +527,40 @@ async function assertSelectedProviderReadyForPrompt(
 }
 
 export function registerSessionHandlers(context: IpcHandlerContext) {
+  context.ipcMain.handle('project-source:validate', async (event, input?: unknown) => {
+    const workspaceId = readWorkspaceIdOption(input)
+    const projectSource = readCloudProjectSourceOption(input)
+    if (!projectSource) throw new Error('Cloud project source is required.')
+    return context.workspaceGateway.validateCloudProjectSource(event, workspaceId, projectSource)
+  })
+
+  context.ipcMain.handle('project-source:snapshot-inventory', async (_event, input?: unknown) => {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('Snapshot inventory input is required.')
+    const directory = context.normalizeDirectory((input as { directory?: unknown }).directory as string | undefined)
+    return buildCloudProjectSnapshotInventory(directory)
+  })
+
+  context.ipcMain.handle('project-source:upload-snapshot', async (event, input?: unknown) => {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('Snapshot upload input is required.')
+    const workspaceId = readWorkspaceIdOption(input)
+    const record = input as { directory?: unknown; title?: unknown }
+    const directory = context.normalizeDirectory(record.directory as string | undefined)
+    const upload = await buildCloudProjectSnapshotUpload(directory)
+    return context.workspaceGateway.uploadCloudProjectSnapshot(event, workspaceId, {
+      ...upload,
+      title: typeof record.title === 'string' && record.title.trim() ? record.title.trim() : upload.title,
+    })
+  })
+
   context.ipcMain.handle('session:create', async (event, directory?: string, options?: unknown) => {
     const workspaceId = readWorkspaceIdOption(options)
     if (!context.workspaceGateway.isLocalWorkspace(event, workspaceId)) {
       if (typeof directory === 'string' && directory.trim()) {
         throw new Error('Local project directories are not available in Cloud workspaces.')
       }
-      return context.workspaceGateway.createCloudSession(event, workspaceId)
+      return context.workspaceGateway.createCloudSession(event, workspaceId, {
+        projectSource: readCloudProjectSourceOption(options),
+      })
     }
     const opencodeDirectory = context.normalizeDirectory(directory)
     await ensureRuntimeContextDirectory(opencodeDirectory)

--- a/apps/desktop/src/main/project-source-snapshot.ts
+++ b/apps/desktop/src/main/project-source-snapshot.ts
@@ -1,0 +1,130 @@
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { basename, join, relative, resolve, sep } from 'node:path'
+import type {
+  CloudProjectSnapshotFile,
+  CloudProjectSnapshotInventory,
+  CloudProjectSnapshotUploadInput,
+} from '@open-cowork/shared'
+import {
+  cloudProjectSnapshotPathReason,
+  GENERATED_PROJECT_PATH_REASON,
+  SECRET_PROJECT_PATH_REASON,
+} from './cloud/project-source-service.ts'
+
+const DEFAULT_MAX_FILES = 2000
+const DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+
+type SnapshotLimits = {
+  maxFiles?: number
+  maxBytes?: number
+}
+
+function toRelativePosix(root: string, path: string) {
+  return relative(root, path).split(sep).join('/')
+}
+
+function shouldSkipDirectory(relativePath: string) {
+  const reason = cloudProjectSnapshotPathReason(relativePath ? `${relativePath}/placeholder.txt` : 'placeholder.txt')
+  if (reason === GENERATED_PROJECT_PATH_REASON || reason === SECRET_PROJECT_PATH_REASON) return reason
+  const name = basename(relativePath).toLowerCase()
+  if (name === '.git' || name === 'node_modules' || name === 'dist' || name === 'build') return GENERATED_PROJECT_PATH_REASON
+  if (name === '.ssh' || name === '.aws' || name === '.azure') return SECRET_PROJECT_PATH_REASON
+  return null
+}
+
+export async function buildCloudProjectSnapshotInventory(
+  directory: string,
+  limits: SnapshotLimits = {},
+): Promise<CloudProjectSnapshotInventory> {
+  const root = resolve(directory)
+  const maxFiles = limits.maxFiles || DEFAULT_MAX_FILES
+  const maxBytes = limits.maxBytes || DEFAULT_MAX_BYTES
+  const files: CloudProjectSnapshotInventory['files'] = []
+  const excluded: CloudProjectSnapshotInventory['excluded'] = []
+  const warnings: string[] = []
+  let byteCount = 0
+
+  async function visit(current: string) {
+    const entries = await readdir(current, { withFileTypes: true })
+    for (const entry of entries) {
+      const absolute = join(current, entry.name)
+      const relativePath = toRelativePosix(root, absolute)
+      if (entry.isSymbolicLink()) {
+        excluded.push({ path: relativePath, reason: 'symlink' })
+        continue
+      }
+      if (entry.isDirectory()) {
+        const directoryReason = shouldSkipDirectory(relativePath)
+        if (directoryReason) {
+          excluded.push({ path: relativePath, reason: directoryReason })
+          continue
+        }
+        await visit(absolute)
+        continue
+      }
+      if (!entry.isFile()) {
+        excluded.push({ path: relativePath, reason: 'unsupported file type' })
+        continue
+      }
+      const reason = cloudProjectSnapshotPathReason(relativePath)
+      if (reason) {
+        excluded.push({ path: relativePath, reason })
+        continue
+      }
+      const size = (await stat(absolute)).size
+      if (files.length + 1 > maxFiles) {
+        excluded.push({ path: relativePath, reason: 'file limit exceeded' })
+        continue
+      }
+      if (byteCount + size > maxBytes) {
+        excluded.push({ path: relativePath, reason: 'byte limit exceeded' })
+        continue
+      }
+      files.push({ path: relativePath, byteCount: size })
+      byteCount += size
+    }
+  }
+
+  await visit(root)
+  if (excluded.some((entry) => entry.reason === SECRET_PROJECT_PATH_REASON)) {
+    warnings.push('Secret-bearing files were excluded from the snapshot.')
+  }
+  if (excluded.some((entry) => entry.reason === GENERATED_PROJECT_PATH_REASON)) {
+    warnings.push('Dependency and build output folders were excluded from the snapshot.')
+  }
+  return {
+    rootDirectory: root,
+    files,
+    excluded,
+    warnings,
+    fileCount: files.length,
+    byteCount,
+    maxFiles,
+    maxBytes,
+  }
+}
+
+export async function buildCloudProjectSnapshotUpload(
+  directory: string,
+  limits: SnapshotLimits = {},
+): Promise<CloudProjectSnapshotUploadInput> {
+  const inventory = await buildCloudProjectSnapshotInventory(directory, limits)
+  const root = resolve(directory)
+  const files: CloudProjectSnapshotFile[] = []
+  for (const file of inventory.files) {
+    const absolute = resolve(root, ...file.path.split('/'))
+    files.push({
+      path: file.path,
+      dataBase64: (await readFile(absolute)).toString('base64'),
+      byteCount: file.byteCount,
+    })
+  }
+  return {
+    title: basename(root),
+    files,
+    excluded: inventory.excluded,
+    warnings: inventory.warnings,
+    fileCount: inventory.fileCount,
+    byteCount: inventory.byteCount,
+  }
+}

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -4,6 +4,10 @@ import type {
   CapabilitySkill,
   CapabilitySkillBundle,
   CapabilityTool,
+  CloudProjectSnapshotUploadInput,
+  CloudProjectSnapshotUploadResult,
+  CloudProjectSourceInput,
+  CloudProjectSourcePolicyVerdict,
   CustomAgentConfig,
   CustomMcpConfig,
   CustomSkillConfig,
@@ -519,8 +523,36 @@ export class WorkspaceGateway {
     return (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).listSessions()
   }
 
-  async createCloudSession(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<SessionInfo> {
-    return (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).createSession()
+  async createCloudSession(
+    event: WorkspaceEventLike,
+    workspaceIdInput?: string | null,
+    input: { projectSource?: CloudProjectSourceInput | null } = {},
+  ): Promise<SessionInfo> {
+    return (await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))).createSession(input)
+  }
+
+  async validateCloudProjectSource(
+    event: WorkspaceEventLike,
+    workspaceIdInput: string | null | undefined,
+    projectSource: CloudProjectSourceInput,
+  ): Promise<CloudProjectSourcePolicyVerdict> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.validateProjectSource) {
+      return { allowed: false, reason: 'Cloud workspace does not support project source validation.' }
+    }
+    return adapter.validateProjectSource(projectSource)
+  }
+
+  async uploadCloudProjectSnapshot(
+    event: WorkspaceEventLike,
+    workspaceIdInput: string | null | undefined,
+    input: CloudProjectSnapshotUploadInput,
+  ): Promise<CloudProjectSnapshotUploadResult> {
+    const adapter = await this.requireCloudAdapter(this.resolveWorkspace(event, workspaceIdInput))
+    if (!adapter.uploadProjectSnapshot) {
+      throw new Error('Cloud workspace does not support project snapshot uploads.')
+    }
+    return adapter.uploadProjectSnapshot(input)
   }
 
   async importLocalSessionToCloud(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -47,6 +47,9 @@ const PRELOAD_INVOKE_CHANNELS = [
   'session:diff',
   'session:file-snippet',
   'session:todo',
+  'project-source:validate',
+  'project-source:snapshot-inventory',
+  'project-source:upload-snapshot',
   'dialog:select-directory',
   'dialog:select-image',
   'dialog:open-json',
@@ -247,6 +250,11 @@ const api: CoworkAPI = {
     diff: (sessionId, messageId) => invoke('session:diff', sessionId, messageId),
     fileSnippet: (request) => invoke('session:file-snippet', request),
     todo: (sessionId) => invoke('session:todo', sessionId),
+  },
+  projectSource: {
+    validate: (input) => invoke('project-source:validate', input),
+    snapshotInventory: (input) => invoke('project-source:snapshot-inventory', input),
+    uploadSnapshot: (input) => invoke('project-source:upload-snapshot', input),
   },
   dialog: {
     selectDirectory: () => invoke('dialog:select-directory'),

--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.test.tsx
@@ -122,9 +122,10 @@ describe('NewThreadButton', () => {
     expect(screen.queryByRole('button', { name: /Blank thread/ })).not.toBeInTheDocument()
   })
 
-  it('disables local project creation in cloud workspaces using the support matrix reason', async () => {
+  it('opens the cloud project-source flow instead of the local directory picker', async () => {
     const user = userEvent.setup()
     const selectDirectory = vi.fn(async () => '/tmp/project')
+    const validate = vi.fn(async () => ({ allowed: true, reason: null }))
     const create = vi.fn(async () => ({
       id: 'cloud-session-1',
       title: 'Cloud session',
@@ -153,6 +154,9 @@ describe('NewThreadButton', () => {
       dialog: {
         selectDirectory,
       },
+      projectSource: {
+        validate,
+      },
       session: {
         create,
         activate: vi.fn(async () => undefined),
@@ -165,15 +169,36 @@ describe('NewThreadButton', () => {
     await user.click(screen.getByRole('button', { name: 'New Thread' }))
 
     expect(await screen.findByText('Cloud-safe action - start a synced cloud thread')).toBeTruthy()
-    expect(screen.getByText('Local-only action - Cloud workspaces do not implicitly upload local files.')).toBeTruthy()
+    expect(screen.getByText('Cloud-safe action - choose Git or upload an explicit snapshot')).toBeTruthy()
     const projectButton = screen.getByRole('button', { name: /Open Project/ })
-    expect(projectButton).toBeDisabled()
     await user.click(projectButton)
     expect(selectDirectory).not.toHaveBeenCalled()
+    expect(await screen.findByText('Cloud project source')).toBeTruthy()
 
-    await user.click(screen.getByRole('button', { name: /Blank thread/ }))
+    await user.type(screen.getByPlaceholderText('https://github.com/org/repo.git'), 'https://github.com/acme/repo.git')
+    await user.click(screen.getByRole('button', { name: 'Create thread' }))
+
     await waitFor(() => {
-      expect(create).toHaveBeenCalledWith(undefined, { workspaceId: 'cloud:acme' })
+      expect(validate).toHaveBeenCalledWith({
+        workspaceId: 'cloud:acme',
+        projectSource: {
+          kind: 'git',
+          repositoryUrl: 'https://github.com/acme/repo.git',
+          ref: null,
+          subdirectory: null,
+          credentialRef: null,
+        },
+      })
+      expect(create).toHaveBeenCalledWith(undefined, {
+        workspaceId: 'cloud:acme',
+        projectSource: {
+          kind: 'git',
+          repositoryUrl: 'https://github.com/acme/repo.git',
+          ref: null,
+          subdirectory: null,
+          credentialRef: null,
+        },
+      })
     })
   })
 })

--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react'
-import type { WorkspaceApiSupport } from '@open-cowork/shared'
+import type {
+  CloudProjectSnapshotInventory,
+  CloudProjectSourceInput,
+  WorkspaceApiSupport,
+} from '@open-cowork/shared'
 import { useSessionStore } from '../../stores/session'
 import { LOCAL_WORKSPACE_ID, normalizeWorkspaceId } from '../../stores/session-workspace-keys'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
@@ -38,6 +42,16 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
   const addGlobalError = useSessionStore((s) => s.addGlobalError)
   const activeWorkspaceId = useSessionStore((s) => s.activeWorkspaceId)
   const [showMenu, setShowMenu] = useState(false)
+  const [showCloudProjectDialog, setShowCloudProjectDialog] = useState(false)
+  const [projectMode, setProjectMode] = useState<'git' | 'snapshot'>('git')
+  const [gitUrl, setGitUrl] = useState('')
+  const [gitRef, setGitRef] = useState('')
+  const [gitSubdirectory, setGitSubdirectory] = useState('')
+  const [gitCredentialRef, setGitCredentialRef] = useState('')
+  const [snapshotDirectory, setSnapshotDirectory] = useState<string | null>(null)
+  const [snapshotInventory, setSnapshotInventory] = useState<CloudProjectSnapshotInventory | null>(null)
+  const [projectBusy, setProjectBusy] = useState(false)
+  const [projectError, setProjectError] = useState<string | null>(null)
   const [workspaceSupportState, setWorkspaceSupportState] = useState<{
     workspaceId: string
     entries: WorkspaceApiSupport[]
@@ -63,14 +77,22 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
       : createSupport?.verdict?.reason || t('newThread.createBlocked', 'Thread creation is disabled by this workspace policy.'))
   const localFilesReason = localFilesSupport?.verdict?.reason || t('newThread.localFilesBlocked', 'Cloud workspaces do not implicitly upload local files.')
   const blankDisabled = (!activeWorkspaceIsLocal && (!workspaceSupportLoaded || Boolean(workspaceSupportError))) || !supportAllows(createSupport)
-  const projectDisabled = !activeWorkspaceIsLocal || blankDisabled || !supportAllows(localFilesSupport)
-  const projectDisabledReason = blankDisabled ? cloudCreateReason : localFilesReason
+  const projectDisabled = activeWorkspaceIsLocal
+    ? blankDisabled || !supportAllows(localFilesSupport)
+    : blankDisabled
+  const projectDisabledReason = blankDisabled
+    ? cloudCreateReason
+    : activeWorkspaceIsLocal
+      ? localFilesReason
+      : null
   const blankHint = activeWorkspaceIsLocal
     ? t('newThread.blankHint', 'Local workspace - start with Build and the currently available agents, tools, and skills')
     : t('newThread.blankCloudHint', 'Cloud-safe action - start a synced cloud thread')
   const projectHint = projectDisabled
-    ? `${t('newThread.localOnlyAction', 'Local-only action')} - ${projectDisabledReason}`
-    : t('newThread.projectHint', 'Local-only action - choose a directory the agent can read and edit')
+    ? `${activeWorkspaceIsLocal ? t('newThread.localOnlyAction', 'Local-only action') : t('newThread.cloudAction', 'Cloud action')} - ${projectDisabledReason || ''}`
+    : activeWorkspaceIsLocal
+      ? t('newThread.projectHint', 'Local-only action - choose a directory the agent can read and edit')
+      : t('newThread.cloudProjectHint', 'Cloud-safe action - choose Git or upload an explicit snapshot')
 
   useEffect(() => {
     let cancelled = false
@@ -106,14 +128,23 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
     }
   }, [normalizedWorkspaceId])
 
-  const createThread = async (directory?: string) => {
-    if (directory && projectDisabled) {
-      addGlobalError(projectDisabledReason)
+  const closeProjectDialog = () => {
+    setShowCloudProjectDialog(false)
+    setProjectError(null)
+    setProjectBusy(false)
+  }
+
+  const createThread = async (directory?: string, projectSource?: CloudProjectSourceInput | null) => {
+    if ((directory || projectSource) && projectDisabled) {
+      addGlobalError(projectDisabledReason || t('newThread.projectBlocked', 'Project thread creation is disabled.'))
       setShowMenu(false)
       return
     }
     try {
-      const workspaceOptions = activeWorkspaceIsLocal ? undefined : { workspaceId: normalizedWorkspaceId }
+      const workspaceOptions = activeWorkspaceIsLocal ? undefined : {
+        workspaceId: normalizedWorkspaceId,
+        ...(projectSource ? { projectSource } : {}),
+      }
       const session = workspaceOptions
         ? await window.coworkApi.session.create(directory, workspaceOptions)
         : await window.coworkApi.session.create(directory)
@@ -125,11 +156,84 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
         await window.coworkApi.session.activate(session.id)
       }
       onClick?.()
+      closeProjectDialog()
     } catch (err) {
       addGlobalError(t('newThread.createFailed', 'Could not create a new thread. Please try again.'))
       reportThreadError(err, `Failed to create session${directory ? ` for ${directory}` : ''}`)
     }
     setShowMenu(false)
+  }
+
+  const createGitCloudThread = async () => {
+    const repositoryUrl = gitUrl.trim()
+    if (!repositoryUrl) {
+      setProjectError(t('newThread.gitUrlRequired', 'Git repository URL is required.'))
+      return
+    }
+    setProjectBusy(true)
+    setProjectError(null)
+    try {
+      const projectSource: CloudProjectSourceInput = {
+        kind: 'git',
+        repositoryUrl,
+        ref: gitRef.trim() || null,
+        subdirectory: gitSubdirectory.trim() || null,
+        credentialRef: gitCredentialRef.trim() || null,
+      }
+      const verdict = await window.coworkApi.projectSource.validate({
+        workspaceId: normalizedWorkspaceId,
+        projectSource,
+      })
+      if (!verdict.allowed) {
+        setProjectError(verdict.reason || t('newThread.gitBlocked', 'Git source is blocked by workspace policy.'))
+        setProjectBusy(false)
+        return
+      }
+      await createThread(undefined, projectSource)
+    } catch (err) {
+      setProjectError(describeThreadError(err))
+      reportThreadError(err, 'Failed to create cloud git thread')
+    } finally {
+      setProjectBusy(false)
+    }
+  }
+
+  const chooseSnapshotDirectory = async () => {
+    setProjectError(null)
+    const directory = await window.coworkApi.dialog.selectDirectory()
+    if (!directory) return
+    setProjectBusy(true)
+    try {
+      const inventory = await window.coworkApi.projectSource.snapshotInventory({ directory })
+      setSnapshotDirectory(directory)
+      setSnapshotInventory(inventory)
+    } catch (err) {
+      setProjectError(describeThreadError(err))
+      reportThreadError(err, 'Failed to inventory project snapshot')
+    } finally {
+      setProjectBusy(false)
+    }
+  }
+
+  const createSnapshotCloudThread = async () => {
+    if (!snapshotDirectory || !snapshotInventory) {
+      setProjectError(t('newThread.snapshotRequired', 'Choose a snapshot directory first.'))
+      return
+    }
+    setProjectBusy(true)
+    setProjectError(null)
+    try {
+      const uploaded = await window.coworkApi.projectSource.uploadSnapshot({
+        workspaceId: normalizedWorkspaceId,
+        directory: snapshotDirectory,
+      })
+      await createThread(undefined, uploaded.projectSource)
+    } catch (err) {
+      setProjectError(describeThreadError(err))
+      reportThreadError(err, 'Failed to create cloud snapshot thread')
+    } finally {
+      setProjectBusy(false)
+    }
   }
 
   return (
@@ -170,8 +274,13 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
             <button
               onClick={async () => {
                 if (projectDisabled) {
-                  addGlobalError(projectDisabledReason)
+                  addGlobalError(projectDisabledReason || t('newThread.projectBlocked', 'Project thread creation is disabled.'))
                   setShowMenu(false)
+                  return
+                }
+                if (!activeWorkspaceIsLocal) {
+                  setShowMenu(false)
+                  setShowCloudProjectDialog(true)
                   return
                 }
                 try {
@@ -185,7 +294,7 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
                 }
               }}
               disabled={projectDisabled}
-              title={projectDisabled ? projectDisabledReason : undefined}
+              title={projectDisabled ? projectDisabledReason || undefined : undefined}
               className="w-full text-start px-3 py-2.5 text-[12px] text-text hover:bg-surface-hover cursor-pointer transition-colors flex items-center gap-2.5 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" className="text-text-muted">
@@ -196,6 +305,138 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
                 <div className="text-[10px] text-text-muted mt-px">{projectHint}</div>
               </div>
             </button>
+          </div>
+        </>
+      )}
+      {showCloudProjectDialog && (
+        <>
+          <ModalBackdrop onDismiss={closeProjectDialog} className="fixed inset-0 z-50" />
+          <div className="fixed inset-x-4 top-20 z-[60] mx-auto max-w-[520px] rounded-xl theme-popover p-4 shadow-xl">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-[13px] font-semibold text-text">{t('newThread.cloudProjectTitle', 'Cloud project source')}</div>
+                <div className="text-[11px] text-text-muted mt-1">{t('newThread.cloudProjectSubtitle', 'Start a cloud thread from Git or an explicit uploaded snapshot.')}</div>
+              </div>
+              <button
+                type="button"
+                onClick={closeProjectDialog}
+                className="px-2 py-1 text-[12px] rounded-md text-text-muted hover:bg-surface-hover"
+              >
+                {t('common.close', 'Close')}
+              </button>
+            </div>
+
+            <div
+              className="mt-4 grid grid-cols-2 gap-2 rounded-lg p-1"
+              style={{ background: 'var(--color-surface-hover)' }}
+            >
+              <button
+                type="button"
+                onClick={() => setProjectMode('git')}
+                className={`rounded-md px-3 py-1.5 text-[12px] ${projectMode === 'git' ? 'bg-surface text-text shadow-sm' : 'text-text-muted hover:text-text'}`}
+              >
+                {t('newThread.gitSource', 'Git source')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setProjectMode('snapshot')}
+                className={`rounded-md px-3 py-1.5 text-[12px] ${projectMode === 'snapshot' ? 'bg-surface text-text shadow-sm' : 'text-text-muted hover:text-text'}`}
+              >
+                {t('newThread.snapshotSource', 'Uploaded snapshot')}
+              </button>
+            </div>
+
+            {projectMode === 'git' ? (
+              <div className="mt-4 space-y-3">
+                <input
+                  value={gitUrl}
+                  onChange={(event) => setGitUrl(event.target.value)}
+                  placeholder="https://github.com/org/repo.git"
+                  className="w-full rounded-md border border-border-subtle bg-surface px-3 py-2 text-[12px] text-text outline-none focus:border-border"
+                />
+                <div className="grid grid-cols-2 gap-2">
+                  <input
+                    value={gitRef}
+                    onChange={(event) => setGitRef(event.target.value)}
+                    placeholder={t('newThread.gitRefPlaceholder', 'branch, tag, or commit')}
+                    className="w-full rounded-md border border-border-subtle bg-surface px-3 py-2 text-[12px] text-text outline-none focus:border-border"
+                  />
+                  <input
+                    value={gitSubdirectory}
+                    onChange={(event) => setGitSubdirectory(event.target.value)}
+                    placeholder={t('newThread.gitSubdirPlaceholder', 'subdirectory')}
+                    className="w-full rounded-md border border-border-subtle bg-surface px-3 py-2 text-[12px] text-text outline-none focus:border-border"
+                  />
+                </div>
+                <input
+                  value={gitCredentialRef}
+                  onChange={(event) => setGitCredentialRef(event.target.value)}
+                  placeholder={t('newThread.gitCredentialPlaceholder', 'credential ref')}
+                  className="w-full rounded-md border border-border-subtle bg-surface px-3 py-2 text-[12px] text-text outline-none focus:border-border"
+                />
+              </div>
+            ) : (
+              <div className="mt-4 space-y-3">
+                <button
+                  type="button"
+                  onClick={chooseSnapshotDirectory}
+                  disabled={projectBusy}
+                  className="w-full rounded-md border border-border-subtle px-3 py-2 text-[12px] text-text hover:bg-surface-hover disabled:opacity-50"
+                >
+                  {snapshotDirectory
+                    ? t('newThread.chooseDifferentSnapshot', 'Choose different directory')
+                    : t('newThread.chooseSnapshot', 'Choose directory')}
+                </button>
+                {snapshotInventory && (
+                  <div className="rounded-lg border border-border-subtle p-3 text-[11px] text-text-muted">
+                    <div className="text-text">
+                      {snapshotInventory.fileCount} {t('newThread.files', 'files')} · {Math.ceil(snapshotInventory.byteCount / 1024)} KB
+                    </div>
+                    <div className="mt-1">
+                      {snapshotInventory.excluded.length} {t('newThread.excludedFiles', 'excluded by policy')}
+                    </div>
+                    {snapshotInventory.warnings.length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        {snapshotInventory.warnings.map((warning) => (
+                          <div key={warning}>{warning}</div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {projectError && (
+              <div
+                className="mt-3 rounded-md border px-3 py-2 text-[12px]"
+                style={{
+                  borderColor: 'color-mix(in srgb, var(--color-red) 35%, transparent)',
+                  background: 'color-mix(in srgb, var(--color-red) 10%, transparent)',
+                  color: 'var(--color-red)',
+                }}
+              >
+                {projectError}
+              </div>
+            )}
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeProjectDialog}
+                className="rounded-md px-3 py-2 text-[12px] text-text-muted hover:bg-surface-hover"
+              >
+                {t('common.cancel', 'Cancel')}
+              </button>
+              <button
+                type="button"
+                disabled={projectBusy || (projectMode === 'snapshot' && !snapshotInventory)}
+                onClick={projectMode === 'git' ? createGitCloudThread : createSnapshotCloudThread}
+                className="rounded-md bg-accent px-3 py-2 text-[12px] font-medium text-accent-foreground disabled:opacity-50"
+              >
+                {projectBusy ? t('common.working', 'Working...') : t('newThread.createCloudProject', 'Create thread')}
+              </button>
+            </div>
           </div>
         </>
       )}

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -341,6 +341,33 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       fileSnippet: vi.fn(async () => []),
       todo: vi.fn(async () => []),
     },
+    projectSource: {
+      validate: vi.fn(async () => ({ allowed: true, reason: null })),
+      snapshotInventory: vi.fn(async (input: { directory: string }) => ({
+        rootDirectory: input.directory,
+        files: [{ path: 'README.md', byteCount: 12 }],
+        excluded: [],
+        warnings: [],
+        fileCount: 1,
+        byteCount: 12,
+        maxFiles: 2000,
+        maxBytes: 25 * 1024 * 1024,
+      })),
+      uploadSnapshot: vi.fn(async () => ({
+        snapshotId: 'snapshot-1',
+        objectKey: 'project-snapshots/tenant/snapshot/snapshot.json',
+        fileCount: 1,
+        byteCount: 12,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        projectSource: {
+          kind: 'snapshot',
+          snapshotId: 'snapshot-1',
+          objectKey: 'project-snapshots/tenant/snapshot/snapshot.json',
+          fileCount: 1,
+          byteCount: 12,
+        },
+      })),
+    },
     threads: {
       search: vi.fn(async () => ({ threads: [], nextCursor: null, totalEstimate: 0 })),
       facets: vi.fn(async () => ({

--- a/apps/desktop/tests/preload-api.smoke.test.ts
+++ b/apps/desktop/tests/preload-api.smoke.test.ts
@@ -19,9 +19,10 @@ test('preload exposes the expected coworkApi surface', async () => {
           workflowsStartDraft: typeof api.workflows?.startDraft,
           chartRenderSvg: typeof api.chart?.renderSvg,
           artifactReadAttachment: typeof api.artifact?.readAttachment,
-          workspaceList: typeof api.workspace?.list,
-          workspaceActivate: typeof api.workspace?.activate,
-          onSessionPatch: typeof api.on?.sessionPatch,
+      workspaceList: typeof api.workspace?.list,
+      workspaceActivate: typeof api.workspace?.activate,
+      projectSourceValidate: typeof api.projectSource?.validate,
+      onSessionPatch: typeof api.on?.sessionPatch,
         },
       }
     })
@@ -36,6 +37,7 @@ test('preload exposes the expected coworkApi surface', async () => {
       artifactReadAttachment: 'function',
       workspaceList: 'function',
       workspaceActivate: 'function',
+      projectSourceValidate: 'function',
       onSessionPatch: 'function',
     })
     assert.deepEqual(surface.groups, [
@@ -56,6 +58,7 @@ test('preload exposes the expected coworkApi surface', async () => {
       'model',
       'on',
       'permission',
+      'projectSource',
       'projects',
       'provider',
       'question',

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -49,6 +49,88 @@ desktop, and gateway clients should use those verdicts before enabling sends,
 project pickers, host-path diffs, custom content, artifacts, workflows, or
 gateway interactions.
 
+## Cloud Project Context
+
+Cloud sessions do not read arbitrary desktop or server host paths. A cloud
+thread starts with an explicit project source that the worker restores into an
+isolated app-managed workspace before creating or prompting the OpenCode
+session.
+
+Supported v1 sources:
+
+- Git source: HTTPS repository URL, optional branch/tag/commit ref, optional
+  subdirectory, and optional credential ref. Credentials must be stored as
+  secret references (`env:`, `gcp-sm://`, `aws-sm://`, `azure-kv://`, or
+  Azure Key Vault `https://` URLs); they must not be embedded in repository
+  URLs. A credential secret may be a raw access token, or JSON with
+  `username` plus `password` or `token` for hosts that require a specific Git
+  username.
+- Uploaded snapshot: the desktop inventories a selected directory, excludes
+  secret-bearing files and dependency/build output, shows file count and bytes,
+  uploads the bounded snapshot to object storage, and sends only the snapshot
+  reference in the session create request.
+
+Default policy:
+
+```json
+{
+  "cloud": {
+    "projectSources": {
+      "git": {
+        "enabled": true,
+        "allowedHosts": ["github.com", "gitlab.com"],
+        "allowedRepositories": [],
+        "allowFileUrls": false
+      },
+      "uploadedSnapshots": {
+        "enabled": true,
+        "maxFiles": 2000,
+        "maxBytes": 26214400
+      },
+      "managedWorkspaces": {
+        "enabled": false
+      }
+    }
+  }
+}
+```
+
+For GitHub Enterprise or GitLab self-managed, add the host to
+`cloud.projectSources.git.allowedHosts`. To restrict tenants to approved repos,
+set `allowedRepositories` to exact lowercase `host/org/repo` keys, for example
+`git.internal.example/platform/api`.
+
+Deployments that cannot allow local uploads should set:
+
+```json
+{
+  "cloud": {
+    "projectSources": {
+      "uploadedSnapshots": { "enabled": false }
+    }
+  }
+}
+```
+
+Managed workspace checkpointing is the v2 path for long-running or scheduled
+cloud work. Enable it only with object storage and checkpoint encryption
+configured:
+
+```json
+{
+  "cloud": {
+    "projectSources": {
+      "managedWorkspaces": { "enabled": true }
+    }
+  }
+}
+```
+
+Headless gateway agents can define a default project source on a channel
+binding via `settings.defaultProjectSource`, or through a profile-level
+`defaultProjectSource`. The gateway passes the binding to cloud; cloud workers
+still own restore and execution.
+
 ## Local References
 
 Use the all-in-one reference for quick local checks:

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -270,6 +270,7 @@
         "auth": { "$ref": "#/$defs/cloudAuth" },
         "storage": { "$ref": "#/$defs/cloudStorage" },
         "runtime": { "$ref": "#/$defs/cloudRuntimePolicy" },
+        "projectSources": { "$ref": "#/$defs/cloudProjectSources" },
         "features": { "$ref": "#/$defs/cloudFeatures" },
         "abuse": { "$ref": "#/$defs/cloudAbuse" },
         "billing": { "$ref": "#/$defs/cloudBilling" }
@@ -447,6 +448,67 @@
         "allowedHostProjectDirectories": { "$ref": "#/$defs/cloudStringList" }
       }
     },
+    "cloudProjectSources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "allowedHosts": { "$ref": "#/$defs/cloudStringList" },
+            "allowedRepositories": { "$ref": "#/$defs/cloudStringList" },
+            "allowFileUrls": { "type": "boolean" }
+          }
+        },
+        "uploadedSnapshots": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "maxFiles": { "type": "integer", "minimum": 1 },
+            "maxBytes": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "managedWorkspaces": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "cloudProjectSource": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "git" },
+            "repositoryUrl": { "type": "string", "minLength": 1, "maxLength": 2048 },
+            "ref": { "type": ["string", "null"], "maxLength": 512 },
+            "subdirectory": { "type": ["string", "null"], "maxLength": 1024 },
+            "credentialRef": { "type": ["string", "null"], "maxLength": 512 }
+          },
+          "required": ["kind", "repositoryUrl"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "snapshot" },
+            "snapshotId": { "type": "string", "minLength": 1, "maxLength": 512 },
+            "objectKey": { "type": "string", "minLength": 1, "maxLength": 1024 },
+            "fileCount": { "type": "integer", "minimum": 0 },
+            "byteCount": { "type": "integer", "minimum": 0 },
+            "title": { "type": ["string", "null"], "maxLength": 256 }
+          },
+          "required": ["kind", "snapshotId", "objectKey", "fileCount", "byteCount"]
+        }
+      ]
+    },
     "cloudProfile": {
       "type": "object",
       "additionalProperties": false,
@@ -457,7 +519,13 @@
         "tools": { "$ref": "#/$defs/cloudStringList" },
         "mcps": { "$ref": "#/$defs/cloudStringList" },
         "features": { "$ref": "#/$defs/cloudFeatures" },
-        "runtime": { "$ref": "#/$defs/cloudRuntimePolicy" }
+        "runtime": { "$ref": "#/$defs/cloudRuntimePolicy" },
+        "defaultProjectSource": {
+          "anyOf": [
+            { "$ref": "#/$defs/cloudProjectSource" },
+            { "type": "null" }
+          ]
+        }
       }
     },
     "cloudAuth": {

--- a/packages/cloud-client/src/index.ts
+++ b/packages/cloud-client/src/index.ts
@@ -3,6 +3,10 @@ import type {
   CapabilitySkill,
   CapabilitySkillBundle,
   CapabilityTool,
+  CloudProjectSnapshotUploadInput,
+  CloudProjectSnapshotUploadResult,
+  CloudProjectSourceInput,
+  CloudProjectSourcePolicyVerdict,
   CloudSessionProjectionRecord,
   CloudSessionViewRecord,
   SessionArtifact,
@@ -27,6 +31,10 @@ export type {
   CapabilitySkill,
   CapabilitySkillBundle,
   CapabilityTool,
+  CloudProjectSnapshotUploadInput,
+  CloudProjectSnapshotUploadResult,
+  CloudProjectSourceInput,
+  CloudProjectSourcePolicyVerdict,
   SessionArtifact,
   SessionArtifactAttachment,
   SessionArtifactUploadRequest,
@@ -404,7 +412,9 @@ export type CloudTransportAdapter = {
   getWorkspace(): Promise<CloudWorkspaceOverview>
   getRuntimeStatus(): Promise<CloudRuntimeStatus>
   listSessions(): Promise<SessionRecord[]>
-  createSession(input?: { profileName?: string | null }): Promise<CloudSessionView>
+  createSession(input?: { profileName?: string | null; projectSource?: CloudProjectSourceInput | null }): Promise<CloudSessionView>
+  validateProjectSource(input: CloudProjectSourceInput): Promise<CloudProjectSourcePolicyVerdict>
+  uploadProjectSnapshot(input: CloudProjectSnapshotUploadInput): Promise<CloudProjectSnapshotUploadResult>
   importSession(input: SessionImportRequest): Promise<CloudSessionView>
   getSession(sessionId: string): Promise<CloudSessionView>
   promptSession(sessionId: string, input: { text: string, agent?: string | null }): Promise<{
@@ -949,6 +959,18 @@ export function createHttpSseCloudTransportAdapter(
     },
     createSession(input = {}) {
       return request<CloudSessionView>('/api/sessions', {
+        method: 'POST',
+        body: input,
+      })
+    },
+    validateProjectSource(input) {
+      return request<CloudProjectSourcePolicyVerdict>('/api/project-sources/validate', {
+        method: 'POST',
+        body: { projectSource: input },
+      })
+    },
+    uploadProjectSnapshot(input) {
+      return request<CloudProjectSnapshotUploadResult>('/api/project-sources/snapshots', {
         method: 'POST',
         body: input,
       })

--- a/packages/shared/src/cloud-session-projection.ts
+++ b/packages/shared/src/cloud-session-projection.ts
@@ -11,6 +11,10 @@ import type {
   TodoItem,
   ToolCall,
 } from './session.js'
+import {
+  normalizeCloudProjectSource,
+  type CloudProjectSource,
+} from './project-source.js'
 
 export type CloudSessionMessage = {
   id: string
@@ -32,6 +36,7 @@ export type CloudSessionProjectionOrigin = {
 export const CLOUD_SESSION_EVENT_TYPES = [
   'session.created',
   'session.imported',
+  'session.project_source.bound',
   'prompt.submitted',
   'assistant.message',
   'tool.call',
@@ -72,6 +77,7 @@ export type CloudSessionProjectionView = {
   lastInputTokens: number
   lastError: string | null
   origin: CloudSessionProjectionOrigin | null
+  projectSource: CloudProjectSource | null
   updatedAt: string
 }
 
@@ -540,6 +546,7 @@ export function createCloudSessionProjectionView(session: CloudProjectionSession
     lastInputTokens: 0,
     lastError: null,
     origin: null,
+    projectSource: null,
     updatedAt: session.updatedAt,
   }
 }
@@ -584,6 +591,7 @@ export function normalizeCloudSessionProjectionView(
     lastInputTokens: readNumber(record.lastInputTokens),
     lastError: typeof record.lastError === 'string' ? record.lastError : null,
     origin: normalizeOrigin(record.origin),
+    projectSource: normalizeCloudProjectSource(record.projectSource),
     updatedAt: readString(record.updatedAt, session.updatedAt),
   }
 }
@@ -617,6 +625,12 @@ export function reduceCloudSessionProjectionEvent(
         status: 'idle',
         isGenerating: false,
         lastError: null,
+        updatedAt: eventTime,
+      }
+    case 'session.project_source.bound':
+      return {
+        ...current,
+        projectSource: normalizeCloudProjectSource(payload.projectSource),
         updatedAt: eventTime,
       }
     case 'prompt.submitted':
@@ -882,6 +896,7 @@ export function readCloudSessionProjection<Session extends CloudProjectionSessio
     lastInputTokens: typeof record.lastInputTokens === 'number' ? record.lastInputTokens : 0,
     lastError: typeof record.lastError === 'string' && record.lastError ? record.lastError : null,
     origin: normalizeOrigin(record.origin),
+    projectSource: normalizeCloudProjectSource(record.projectSource),
     updatedAt: typeof record.updatedAt === 'string' && record.updatedAt ? record.updatedAt : view.session.updatedAt,
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -100,6 +100,13 @@ import type {
   WorkspaceSyncResult,
 } from './workspace.js'
 import type {
+  CloudProjectSnapshotInventory,
+  CloudProjectSnapshotUploadResult,
+  CloudProjectSourceInput,
+  CloudProjectSourcePolicyVerdict,
+  CloudSessionCreateOptions,
+} from './project-source.js'
+import type {
   ThreadFacetSummary,
   ThreadSearchQuery,
   ThreadSearchResult,
@@ -125,6 +132,7 @@ export * from './destructive-actions.js'
 export * from './events.js'
 export * from './explorer.js'
 export * from './providers.js'
+export * from './project-source.js'
 export * from './runtime.js'
 export * from './session.js'
 export * from './session-import.js'
@@ -154,7 +162,7 @@ export interface CoworkAPI {
     logout: () => Promise<AuthState>
   }
   session: {
-    create: (directory?: string, options?: WorkspaceOptions) => Promise<SessionInfo>
+    create: (directory?: string, options?: CloudSessionCreateOptions) => Promise<SessionInfo>
     activate: (sessionId: string, options?: WorkspaceScoped<{ force?: boolean }>) => Promise<SessionView>
     prompt: (sessionId: string, text: string, attachments?: Array<{ mime: string; url: string; filename?: string }>, agent?: string, options?: SessionPromptOptions) => Promise<void>
     setComposerPreferences: (sessionId: string, preferences: SessionComposerPreferences) => Promise<SessionInfo | null>
@@ -180,6 +188,11 @@ export interface CoworkAPI {
     diff: (sessionId: string, messageId?: string) => Promise<SessionFileDiff[]>
     fileSnippet: (request: { sessionId: string; filePath: string; startLine: number; endLine: number }) => Promise<string[]>
     todo: (sessionId: string) => Promise<TodoItem[]>
+  }
+  projectSource: {
+    validate: (input: { workspaceId?: string; projectSource: CloudProjectSourceInput }) => Promise<CloudProjectSourcePolicyVerdict>
+    snapshotInventory: (input: { directory: string }) => Promise<CloudProjectSnapshotInventory>
+    uploadSnapshot: (input: { workspaceId?: string; directory: string; title?: string | null }) => Promise<CloudProjectSnapshotUploadResult>
   }
   permission: {
     respond: (id: string, allowed: boolean, sessionId?: string | null, options?: WorkspaceOptions) => Promise<void>

--- a/packages/shared/src/project-source.ts
+++ b/packages/shared/src/project-source.ts
@@ -1,0 +1,121 @@
+export type CloudProjectSourceKind = 'git' | 'snapshot'
+
+export type CloudGitProjectSource = {
+  kind: 'git'
+  repositoryUrl: string
+  ref?: string | null
+  subdirectory?: string | null
+  credentialRef?: string | null
+}
+
+export type CloudSnapshotProjectSource = {
+  kind: 'snapshot'
+  snapshotId: string
+  objectKey: string
+  fileCount: number
+  byteCount: number
+  title?: string | null
+}
+
+export type CloudProjectSource = CloudGitProjectSource | CloudSnapshotProjectSource
+export type CloudProjectSourceInput = CloudProjectSource
+
+export type CloudProjectSourcePolicyVerdict = {
+  allowed: boolean
+  reason: string | null
+  policyCode?: string
+}
+
+export type CloudProjectSnapshotFile = {
+  path: string
+  dataBase64: string
+  byteCount?: number
+  mode?: number | null
+}
+
+export type CloudProjectSnapshotExcludedEntry = {
+  path: string
+  reason: string
+}
+
+export type CloudProjectSnapshotInventoryFile = {
+  path: string
+  byteCount: number
+}
+
+export type CloudProjectSnapshotInventory = {
+  rootDirectory: string
+  files: CloudProjectSnapshotInventoryFile[]
+  excluded: CloudProjectSnapshotExcludedEntry[]
+  warnings: string[]
+  fileCount: number
+  byteCount: number
+  maxFiles: number
+  maxBytes: number
+}
+
+export type CloudProjectSnapshotUploadInput = {
+  title?: string | null
+  files: CloudProjectSnapshotFile[]
+  excluded?: CloudProjectSnapshotExcludedEntry[]
+  warnings?: string[]
+  fileCount?: number
+  byteCount?: number
+}
+
+export type CloudProjectSnapshotUploadResult = {
+  snapshotId: string
+  objectKey: string
+  fileCount: number
+  byteCount: number
+  createdAt: string
+  projectSource: CloudSnapshotProjectSource
+}
+
+export type CloudSessionCreateOptions = {
+  workspaceId?: string
+  projectSource?: CloudProjectSourceInput | null
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function readString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function readNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0
+}
+
+export function normalizeCloudProjectSource(value: unknown): CloudProjectSource | null {
+  const record = asRecord(value)
+  if (record.kind === 'git') {
+    const repositoryUrl = readString(record.repositoryUrl)
+    if (!repositoryUrl) return null
+    return {
+      kind: 'git',
+      repositoryUrl,
+      ref: readString(record.ref),
+      subdirectory: readString(record.subdirectory),
+      credentialRef: readString(record.credentialRef),
+    }
+  }
+  if (record.kind === 'snapshot') {
+    const snapshotId = readString(record.snapshotId)
+    const objectKey = readString(record.objectKey)
+    if (!snapshotId || !objectKey) return null
+    return {
+      kind: 'snapshot',
+      snapshotId,
+      objectKey,
+      fileCount: readNumber(record.fileCount),
+      byteCount: readNumber(record.byteCount),
+      title: readString(record.title),
+    }
+  }
+  return null
+}

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -1,8 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import type { IncomingMessage } from 'node:http'
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { mkdtemp, readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
 import { DEFAULT_CONFIG } from '../apps/desktop/src/main/config-types.ts'
@@ -123,11 +123,6 @@ function asRecord(value: unknown): Record<string, unknown> {
 function asArray(value: unknown): unknown[] {
   assert.equal(Array.isArray(value), true)
   return value as unknown[]
-}
-
-async function writeFixture(path: string, value: string) {
-  await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, value)
 }
 
 test('cloud bootstrap parses env options and role helpers', () => {
@@ -419,9 +414,11 @@ test('cloud app lets deployers inject a durable control-plane store factory', as
 
 test('cloud all-in-one app starts web and worker and routes runtime events into projections', async () => {
   const runtime = new FakeRuntime()
+  const paths = createCloudPathProvider(await mkdtemp(join(tmpdir(), 'open-cowork-cloud-blank-')))
   const app = await startCloudApp({
     config: DEFAULT_CONFIG,
     runtime,
+    paths,
     env: {
         OPEN_COWORK_CLOUD_ROLE: 'all-in-one',
         OPEN_COWORK_CLOUD_PROFILE: 'full',
@@ -462,6 +459,7 @@ test('cloud all-in-one app starts web and worker and routes runtime events into 
     }))
     assert.equal(prompted.processed, 1)
     assert.equal(runtime.prompts.length, 1)
+    assert.equal((await stat(paths.resolveWorkspacePath('tenant-a', coworkSessionId))).isDirectory(), true)
 
     await runtime.emitAssistant('session-1', 'external event')
     const view = await readJson(await fetch(`${app.url}/api/sessions/${coworkSessionId}`, {
@@ -513,6 +511,39 @@ test('cloud web role starts transport without processing worker commands inline'
     }))
     assert.equal(prompted.processed, 0)
     assert.equal(runtime.prompts.length, 0)
+  } finally {
+    await app.close()
+  }
+})
+
+test('cloud all-in-one app rejects malformed project source payloads', async () => {
+  const app = await startCloudApp({
+    config: DEFAULT_CONFIG,
+    runtime: new FakeRuntime(),
+    env: {
+        OPEN_COWORK_CLOUD_ROLE: 'all-in-one',
+        OPEN_COWORK_CLOUD_PROFILE: 'full',
+        OPEN_COWORK_CLOUD_AUTH_MODE: 'header',
+    },
+    hostname: '127.0.0.1',
+    port: 0,
+  })
+
+  try {
+    assert.ok(app.url)
+    const response = await fetch(`${app.url}/api/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-open-cowork-tenant-id': 'tenant-a',
+        'x-open-cowork-user-id': 'user-a',
+        'x-open-cowork-user-email': 'a@example.test',
+      },
+      body: JSON.stringify({ projectSource: { kind: 'git' } }),
+    })
+    assert.equal(response.status, 400)
+    const body = await readJson(response)
+    assert.match(String(body.error), /project source/i)
   } finally {
     await app.close()
   }
@@ -790,16 +821,32 @@ test('cloud worker can checkpoint workspace state to object storage after comman
       'x-open-cowork-user-id': 'user-a',
       'x-open-cowork-user-email': 'a@example.test',
     }
+    const snapshot = await readJson(await fetch(`${web.url}/api/project-sources/snapshots`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...principalHeaders,
+      },
+      body: JSON.stringify({
+        title: 'fixture',
+        files: [{
+          path: 'README.md',
+          dataBase64: Buffer.from('checkpoint me').toString('base64'),
+          byteCount: 'checkpoint me'.length,
+        }],
+        fileCount: 1,
+        byteCount: 'checkpoint me'.length,
+      }),
+    }))
     const created = await readJson(await fetch(`${web.url}/api/sessions`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
         ...principalHeaders,
       },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ projectSource: snapshot.projectSource }),
     }))
     const coworkSessionId = String(asRecord(created.session).sessionId)
-    await writeFixture(workerPaths.resolveWorkspacePath('tenant-a', coworkSessionId, 'README.md'), 'checkpoint me')
 
     const prompted = await readJson(await fetch(`${web.url}/api/sessions/${coworkSessionId}/prompt`, {
       method: 'POST',
@@ -811,6 +858,10 @@ test('cloud worker can checkpoint workspace state to object storage after comman
     }))
     assert.equal(prompted.processed, 0)
     assert.equal(await worker.worker?.processAllSessionCommands(), 1)
+    assert.equal(
+      await readFile(workerPaths.resolveWorkspacePath('tenant-a', coworkSessionId, 'README.md'), 'utf8'),
+      'checkpoint me',
+    )
 
     const manifest = await worker.checkpointStore.readSessionCheckpoint({
       tenantId: 'tenant-a',

--- a/tests/cloud-config.test.ts
+++ b/tests/cloud-config.test.ts
@@ -43,6 +43,16 @@ test('cloud project source policy allows safe git sources and blocks disallowed 
   assert.equal(evaluateCloudProjectSourcePolicy({
     kind: 'git',
     repositoryUrl: 'https://github.com/acme/repo.git',
+    ref: '--upload-pack=/tmp/pwned',
+  }, policy).policyCode, 'project_source.git.ref')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git',
+    ref: 'feature/cloud-project-context',
+  }, policy).allowed, true)
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git',
     credentialRef: 'ghp_raw_token',
   }, policy).policyCode, 'project_source.git.credential_ref')
   assert.equal(evaluateCloudProjectSourcePolicy({

--- a/tests/cloud-config.test.ts
+++ b/tests/cloud-config.test.ts
@@ -6,6 +6,7 @@ import {
   coerceCloudRuntimeSettings,
   evaluateCloudMcpPolicy,
   evaluateCloudProjectDirectoryPolicy,
+  evaluateCloudProjectSourcePolicy,
   resolveCloudRuntimePolicy,
   resolveCloudRole,
 } from '../apps/desktop/src/main/cloud/cloud-config.ts'
@@ -21,6 +22,89 @@ test('cloud role and profile resolve from deployment environment', () => {
   assert.equal(policy.profileName, 'focused-agent')
   assert.equal(policy.features.workflows, false)
   assert.equal(policy.features.customMcps, false)
+})
+
+test('cloud project source policy allows safe git sources and blocks disallowed hosts or raw credentials', () => {
+  const policy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
+
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git',
+    ref: 'main',
+  }, policy).allowed, true)
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://example.com/acme/repo.git',
+  }, policy).policyCode, 'project_source.git.host_denied')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://token@example.com/acme/repo.git',
+  }, policy).policyCode, 'project_source.git.raw_credentials')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git',
+    credentialRef: 'ghp_raw_token',
+  }, policy).policyCode, 'project_source.git.credential_ref')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git',
+    credentialRef: 'https://raw-token@example.com',
+  }, policy).policyCode, 'project_source.git.credential_ref')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git',
+    credentialRef: 'env:GITHUB_TOKEN',
+  }, policy).allowed, true)
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git',
+    credentialRef: 'https://vault-name.vault.azure.net/secrets/github-token',
+  }, policy).allowed, true)
+})
+
+test('cloud project source policy enforces repository and uploaded snapshot limits', () => {
+  const config = {
+    ...DEFAULT_CONFIG,
+    cloud: {
+      ...DEFAULT_CONFIG.cloud,
+      projectSources: {
+        ...DEFAULT_CONFIG.cloud.projectSources,
+        git: {
+          ...DEFAULT_CONFIG.cloud.projectSources.git,
+          allowedRepositories: ['github.com/acme/allowed'],
+        },
+        uploadedSnapshots: {
+          ...DEFAULT_CONFIG.cloud.projectSources.uploadedSnapshots,
+          maxFiles: 2,
+          maxBytes: 10,
+        },
+      },
+    },
+  }
+  const policy = resolveCloudRuntimePolicy(config)
+
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/allowed.git',
+  }, policy).allowed, true)
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/denied.git',
+  }, policy).policyCode, 'project_source.git.repo_denied')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'snapshot',
+    snapshotId: 'snapshot-1',
+    objectKey: 'project-snapshots/t/s/snapshot.json',
+    fileCount: 3,
+    byteCount: 9,
+  }, policy).policyCode, 'project_source.snapshot.too_many_files')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'snapshot',
+    snapshotId: 'snapshot-1',
+    objectKey: 'project-snapshots/t/s/snapshot.json',
+    fileCount: 1,
+    byteCount: 11,
+  }, policy).policyCode, 'project_source.snapshot.too_large')
 })
 
 test('cloud runtime policy rejects machine-native config by default', () => {

--- a/tests/cloud-project-source-restore.test.ts
+++ b/tests/cloud-project-source-restore.test.ts
@@ -99,6 +99,35 @@ test('cloud project source service refuses to restore snapshots across tenants',
   }), /does not belong/)
 })
 
+test('cloud project source service refuses forged snapshot size metadata at restore', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'open-cowork-project-restore-metadata-'))
+  const paths = createCloudPathProvider(root)
+  const objectStore = createInMemoryObjectStore()
+  const service = createCloudProjectSourceService({
+    policy: resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+    objectStore,
+  })
+  const uploaded = await service.uploadSnapshot(principal(), {
+    files: [{
+      path: 'README.md',
+      dataBase64: Buffer.from('from snapshot').toString('base64'),
+      byteCount: 'from snapshot'.length,
+    }],
+    fileCount: 1,
+    byteCount: 'from snapshot'.length,
+  })
+
+  await assert.rejects(() => service.restoreProjectSource({
+    tenantId: 'tenant-a',
+    sessionId: 'session-a',
+    source: {
+      ...uploaded.projectSource,
+      byteCount: 0,
+    },
+    paths,
+  }), /source metadata/)
+})
+
 test('cloud project source service restores a git source from a local fixture repo when policy permits file URLs', async (t) => {
   try {
     await execFile('git', ['--version'])

--- a/tests/cloud-project-source-restore.test.ts
+++ b/tests/cloud-project-source-restore.test.ts
@@ -1,0 +1,208 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFile as execFileCallback } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
+
+import { DEFAULT_CONFIG } from '../apps/desktop/src/main/config-types.ts'
+import { resolveCloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
+import { createInMemoryObjectStore } from '../apps/desktop/src/main/cloud/object-store.ts'
+import { createCloudPathProvider } from '../apps/desktop/src/main/cloud/path-provider.ts'
+import { createCloudProjectSourceService } from '../apps/desktop/src/main/cloud/project-source-service.ts'
+
+const execFile = promisify(execFileCallback)
+
+function principal() {
+  return {
+    tenantId: 'tenant-a',
+    userId: 'user-a',
+    email: 'user@example.test',
+  }
+}
+
+test('cloud project source service uploads and restores a snapshot into a sandbox workspace', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'open-cowork-project-restore-'))
+  const paths = createCloudPathProvider(root)
+  const objectStore = createInMemoryObjectStore()
+  const service = createCloudProjectSourceService({
+    policy: resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+    objectStore,
+  })
+
+  const uploaded = await service.uploadSnapshot(principal(), {
+    title: 'fixture',
+    files: [{
+      path: 'README.md',
+      dataBase64: Buffer.from('from snapshot').toString('base64'),
+      byteCount: 'from snapshot'.length,
+    }],
+    fileCount: 1,
+    byteCount: 'from snapshot'.length,
+  })
+  const restored = await service.restoreProjectSource({
+    tenantId: 'tenant-a',
+    sessionId: 'session-a',
+    source: uploaded.projectSource,
+    paths,
+  })
+
+  assert.equal(restored.restored, true)
+  assert.equal(
+    await readFile(paths.resolveWorkspacePath('tenant-a', 'session-a', 'README.md'), 'utf8'),
+    'from snapshot',
+  )
+})
+
+test('cloud project source service rejects secret-bearing snapshot uploads', async () => {
+  const service = createCloudProjectSourceService({
+    policy: resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+    objectStore: createInMemoryObjectStore(),
+  })
+
+  await assert.rejects(() => service.uploadSnapshot(principal(), {
+    files: [{
+      path: '.env',
+      dataBase64: Buffer.from('SECRET=value').toString('base64'),
+      byteCount: 12,
+    }],
+    fileCount: 1,
+    byteCount: 12,
+  }), /blocked file/)
+})
+
+test('cloud project source service refuses to restore snapshots across tenants', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'open-cowork-project-restore-tenant-'))
+  const paths = createCloudPathProvider(root)
+  const objectStore = createInMemoryObjectStore()
+  const service = createCloudProjectSourceService({
+    policy: resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+    objectStore,
+  })
+  const uploaded = await service.uploadSnapshot(principal(), {
+    files: [{
+      path: 'README.md',
+      dataBase64: Buffer.from('from tenant a').toString('base64'),
+      byteCount: 'from tenant a'.length,
+    }],
+    fileCount: 1,
+    byteCount: 'from tenant a'.length,
+  })
+
+  await assert.rejects(() => service.restoreProjectSource({
+    tenantId: 'tenant-b',
+    sessionId: 'session-b',
+    source: uploaded.projectSource,
+    paths,
+  }), /does not belong/)
+})
+
+test('cloud project source service restores a git source from a local fixture repo when policy permits file URLs', async (t) => {
+  try {
+    await execFile('git', ['--version'])
+  } catch {
+    t.skip('git is not available')
+    return
+  }
+
+  const root = await mkdtemp(join(tmpdir(), 'open-cowork-project-git-'))
+  const repo = join(root, 'repo')
+  await mkdir(repo)
+  await execFile('git', ['init'], { cwd: repo })
+  await execFile('git', ['config', 'user.email', 'test@example.test'], { cwd: repo })
+  await execFile('git', ['config', 'user.name', 'Test User'], { cwd: repo })
+  await writeFile(join(repo, 'README.md'), 'from git')
+  await execFile('git', ['add', 'README.md'], { cwd: repo })
+  await execFile('git', ['commit', '-m', 'initial'], { cwd: repo })
+
+  const policy = resolveCloudRuntimePolicy({
+    ...DEFAULT_CONFIG,
+    cloud: {
+      ...DEFAULT_CONFIG.cloud,
+      projectSources: {
+        ...DEFAULT_CONFIG.cloud.projectSources,
+        git: {
+          ...DEFAULT_CONFIG.cloud.projectSources.git,
+          allowFileUrls: true,
+        },
+      },
+    },
+  })
+  const paths = createCloudPathProvider(join(root, 'worker'))
+  const service = createCloudProjectSourceService({
+    policy,
+    objectStore: createInMemoryObjectStore(),
+  })
+  await service.restoreProjectSource({
+    tenantId: 'tenant-a',
+    sessionId: 'session-a',
+    source: {
+      kind: 'git',
+      repositoryUrl: pathToFileURL(repo).toString(),
+      ref: 'HEAD',
+    },
+    paths,
+  })
+
+  assert.equal(
+    await readFile(paths.resolveWorkspacePath('tenant-a', 'session-a', 'README.md'), 'utf8'),
+    'from git',
+  )
+})
+
+test('cloud project source service restores git subdirectories as the sandbox root', async (t) => {
+  try {
+    await execFile('git', ['--version'])
+  } catch {
+    t.skip('git is not available')
+    return
+  }
+
+  const root = await mkdtemp(join(tmpdir(), 'open-cowork-project-git-subdir-'))
+  const repo = join(root, 'repo')
+  await mkdir(join(repo, 'packages', 'app'), { recursive: true })
+  await execFile('git', ['init'], { cwd: repo })
+  await execFile('git', ['config', 'user.email', 'test@example.test'], { cwd: repo })
+  await execFile('git', ['config', 'user.name', 'Test User'], { cwd: repo })
+  await writeFile(join(repo, 'README.md'), 'repo root')
+  await writeFile(join(repo, 'packages', 'app', 'README.md'), 'app root')
+  await execFile('git', ['add', 'README.md', 'packages/app/README.md'], { cwd: repo })
+  await execFile('git', ['commit', '-m', 'initial'], { cwd: repo })
+
+  const policy = resolveCloudRuntimePolicy({
+    ...DEFAULT_CONFIG,
+    cloud: {
+      ...DEFAULT_CONFIG.cloud,
+      projectSources: {
+        ...DEFAULT_CONFIG.cloud.projectSources,
+        git: {
+          ...DEFAULT_CONFIG.cloud.projectSources.git,
+          allowFileUrls: true,
+        },
+      },
+    },
+  })
+  const paths = createCloudPathProvider(join(root, 'worker'))
+  const service = createCloudProjectSourceService({
+    policy,
+    objectStore: createInMemoryObjectStore(),
+  })
+  await service.restoreProjectSource({
+    tenantId: 'tenant-a',
+    sessionId: 'session-a',
+    source: {
+      kind: 'git',
+      repositoryUrl: pathToFileURL(repo).toString(),
+      ref: 'HEAD',
+      subdirectory: 'packages/app',
+    },
+    paths,
+  })
+
+  assert.equal(
+    await readFile(paths.resolveWorkspacePath('tenant-a', 'session-a', 'README.md'), 'utf8'),
+    'app root',
+  )
+})

--- a/tests/cloud-workspace-adapter.test.ts
+++ b/tests/cloud-workspace-adapter.test.ts
@@ -89,6 +89,26 @@ function transport(): CloudTransportAdapter {
       allowedTools: ['read'],
       allowedMcps: [],
     }),
+    getWorkspace: async () => ({
+      tenantId: 'tenant-1',
+      tenantName: 'Tenant',
+      orgId: 'org-1',
+      orgName: 'Org',
+      userId: 'user-1',
+      accountId: 'account-1',
+      email: 'user@example.test',
+      role: 'owner',
+      profileName: 'default',
+      policy: {
+        features: {},
+        allowedAgents: null,
+        allowedTools: null,
+        allowedMcps: null,
+        localFiles: 'disabled',
+        localStdioMcps: 'disabled',
+        machineRuntimeConfig: 'disabled',
+      },
+    }),
     getRuntimeStatus: async () => ({
       role: 'web',
       profileName: 'default',
@@ -121,6 +141,21 @@ function transport(): CloudTransportAdapter {
         updatedAt: '2026-05-27T11:00:00.000Z',
       },
       projection: null,
+    }),
+    validateProjectSource: async () => ({ allowed: true, reason: null }),
+    uploadProjectSnapshot: async () => ({
+      snapshotId: 'snapshot-1',
+      objectKey: 'project-snapshots/tenant/snapshot/snapshot.json',
+      fileCount: 1,
+      byteCount: 12,
+      createdAt: '2026-05-27T11:00:00.000Z',
+      projectSource: {
+        kind: 'snapshot',
+        snapshotId: 'snapshot-1',
+        objectKey: 'project-snapshots/tenant/snapshot/snapshot.json',
+        fileCount: 1,
+        byteCount: 12,
+      },
     }),
     getSession: async (sessionId) => ({
       session: {
@@ -412,9 +447,12 @@ function failingTransport(): CloudTransportAdapter {
   }
   return {
     getConfig: fail,
+    getWorkspace: fail,
     getRuntimeStatus: fail,
     listSessions: fail,
     createSession: fail,
+    validateProjectSource: fail,
+    uploadProjectSnapshot: fail,
     getSession: fail,
     promptSession: fail,
     abortSession: fail,

--- a/tests/project-source-snapshot.test.ts
+++ b/tests/project-source-snapshot.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import {
+  buildCloudProjectSnapshotInventory,
+  buildCloudProjectSnapshotUpload,
+} from '../apps/desktop/src/main/project-source-snapshot.ts'
+
+test('cloud project snapshot inventory excludes secrets and generated dependency folders', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'open-cowork-project-snapshot-'))
+  await writeFile(join(root, 'README.md'), 'hello')
+  await writeFile(join(root, '.env'), 'SECRET=value')
+  await writeFile(join(root, '.git-credentials'), 'https://token@example.test')
+  await mkdir(join(root, 'node_modules'), { recursive: true })
+  await writeFile(join(root, 'node_modules', 'package.js'), 'generated')
+  await mkdir(join(root, '.ssh'), { recursive: true })
+  await writeFile(join(root, '.ssh', 'id_ed25519'), 'key')
+
+  const inventory = await buildCloudProjectSnapshotInventory(root)
+
+  assert.deepEqual(inventory.files, [{ path: 'README.md', byteCount: 5 }])
+  assert.equal(inventory.excluded.some((entry) => entry.path === '.env' && /secret/i.test(entry.reason)), true)
+  assert.equal(inventory.excluded.some((entry) => entry.path === '.git-credentials' && /secret/i.test(entry.reason)), true)
+  assert.equal(inventory.excluded.some((entry) => entry.path === 'node_modules' && /dependency/i.test(entry.reason)), true)
+  assert.equal(inventory.excluded.some((entry) => entry.path === '.ssh' && /secret/i.test(entry.reason)), true)
+  assert.equal(inventory.warnings.some((entry) => /Secret-bearing/i.test(entry)), true)
+})
+
+test('cloud project snapshot upload contains only inventoried files', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'open-cowork-project-upload-'))
+  await writeFile(join(root, 'README.md'), 'hello')
+  await writeFile(join(root, '.npmrc'), '//registry.example/:_authToken=secret')
+
+  const upload = await buildCloudProjectSnapshotUpload(root)
+
+  assert.equal(upload.fileCount, 1)
+  assert.equal(upload.byteCount, 5)
+  assert.deepEqual(upload.files.map((file) => file.path), ['README.md'])
+  assert.equal(Buffer.from(upload.files[0]!.dataBase64, 'base64').toString('utf8'), 'hello')
+})


### PR DESCRIPTION
## Summary
- add shared cloud project source types, projection events, HTTP/client/IPC APIs, and desktop cloud thread creation UI for Git and explicit snapshots
- add policy-gated snapshot inventory/upload/restore and Git restore into tenant/session workspaces before OpenCode runtime execution
- wire profile/channel default project sources, cloud runtime cwd, docs, and coverage for policy, restore, snapshot exclusions, and checkpoint context

Closes #458.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- node scripts/run-node-tests.mjs tests/cloud-config.test.ts tests/project-source-snapshot.test.ts tests/cloud-project-source-restore.test.ts tests/cloud-app.test.ts tests/ipc-handler-registration.test.ts
- pnpm --filter @open-cowork/desktop test:renderer -- NewThreadButton.test.tsx
- git diff --check

## Docs
- uv run mkdocs build --strict could not run locally because uv is not installed
- mkdocs build --strict could not run locally because mkdocs is not installed