### PR TITLE
Harden OpenCode SDK boundary

### DIFF
--- a/apps/desktop/src/main/cloud/runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/runtime-adapter.ts
@@ -1,3 +1,4 @@
+import type { CloudSessionEventType } from '@open-cowork/shared'
 import { normalizeSessionInfo } from '../opencode-adapter.ts'
 
 export type CloudRuntimeSession = {
@@ -12,7 +13,7 @@ export type CloudRuntimePromptPart =
   | { type: 'file'; mime: string; url: string; filename?: string }
 
 export type CloudRuntimeEvent = {
-  type: string
+  type: CloudSessionEventType
   payload: Record<string, unknown>
 }
 

--- a/apps/gateway/src/event-renderer.test.ts
+++ b/apps/gateway/src/event-renderer.test.ts
@@ -138,6 +138,68 @@ test('event renderer chunks buttonless assistant output and renders approval com
   })
 })
 
+test('event renderer consumes normalized cloud events and ignores raw OpenCode SDK event envelopes', async () => {
+  const provider = createButtonlessFakeProvider()
+  const state = createGatewaySessionRenderState()
+  const interactions: unknown[] = []
+  const cloud = cloudStub({
+    async createChannelInteraction(input: unknown) {
+      interactions.push(input)
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'approval-token',
+      }
+    },
+  })
+  const input = {
+    cloud,
+    provider,
+    binding: bindingRecord(),
+    state,
+  }
+
+  const rawSdkEvent = await renderGatewaySessionEvent({
+    ...input,
+    event: {
+      eventId: 'sdk-raw-1',
+      sequence: 1,
+      type: 'permission.asked',
+      payload: {
+        sessionID: 'session-1',
+        permission: {
+          id: 'permission-1',
+          tool: 'bash',
+          input: { command: 'pnpm test' },
+        },
+      },
+    } as never,
+  })
+
+  assert.equal(rawSdkEvent.handled, false)
+  assert.equal(provider.sent.length, 0)
+  assert.equal(interactions.length, 0)
+
+  const normalizedCloudEvent = await renderGatewaySessionEvent({
+    ...input,
+    event: {
+      eventId: 'cloud-1',
+      sequence: 2,
+      type: 'permission.requested',
+      payload: {
+        permissionId: 'permission-1',
+        title: 'Run command',
+        description: 'Allow pnpm test?',
+      },
+    },
+  })
+
+  assert.equal(normalizedCloudEvent.handled, true)
+  assert.equal(provider.sent.length, 1)
+  assert.match(provider.sent[0]?.text || '', /Run command\nAllow pnpm test\?/)
+  assert.match(provider.sent[0]?.text || '', /\/approve approval-token/)
+  assert.equal(interactions.length, 1)
+})
+
 test('event renderer keeps tool progress compact and redacts failure details', async () => {
   const provider = createButtonCapableFakeProvider()
   const state = createGatewaySessionRenderState()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,9 @@ SDK upgrades can change:
 When bumping the SDK, run `pnpm typecheck` first; anything that fails
 is real drift, not a cosmetic update.
 
+The detailed import allowlist, shared event contract, and SDK v2 upgrade
+checklist live in [OpenCode SDK v2 Boundary](opencode-sdk-v2-boundary.md).
+
 ## What OpenCode owns
 
 - session execution

--- a/docs/opencode-sdk-v2-boundary.md
+++ b/docs/opencode-sdk-v2-boundary.md
@@ -1,0 +1,104 @@
+# OpenCode SDK v2 Boundary
+
+Open Cowork is a product layer on top of OpenCode. OpenCode owns execution:
+sessions, tools, permissions, questions, MCP behavior, native skills,
+compaction, and event stream semantics. Open Cowork owns composition: desktop
+and web UI, cloud control plane, projection, policy, sync, workflows, gateway
+adapters, deployment, and product ergonomics.
+
+The repository enforces that boundary with package-boundary tests. New OpenCode
+SDK imports must be intentional, documented here, and limited to runtime
+composition or SDK-event normalization code.
+
+## Import Rules
+
+- Gateway packages must not import `@opencode-ai/sdk`, `opencode-ai`, direct
+  Postgres clients, or cloud control-plane store implementations.
+- Web, website, renderer, preload, and `@open-cowork/cloud-client` code must
+  not import `@opencode-ai/sdk`.
+- Desktop and cloud runtime code may import the SDK only in the files listed
+  below.
+- After SDK events are normalized, desktop, cloud, and gateway code should use
+  Open Cowork's shared cloud projection event contract from
+  `packages/shared/src/cloud-session-projection.ts`.
+- BYOK credentials must enter OpenCode through runtime config provider options,
+  never through process environment variables.
+
+## Allowed SDK Import Paths
+
+These files are the current SDK boundary. If a path no longer needs the SDK,
+remove the import and remove it from this list. If a new file needs the SDK,
+first decide whether the concept belongs in OpenCode runtime composition or in
+Open Cowork product state.
+
+- `apps/desktop/src/main/agent-config.ts`
+- `apps/desktop/src/main/agent-prompts.ts`
+- `apps/desktop/src/main/cloud/app.ts`
+- `apps/desktop/src/main/cloud/byok-runtime-config.ts`
+- `apps/desktop/src/main/cloud/opencode-runtime-adapter.ts`
+- `apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts`
+- `apps/desktop/src/main/event-subscriptions.ts`
+- `apps/desktop/src/main/events.ts`
+- `apps/desktop/src/main/ipc/context.ts`
+- `apps/desktop/src/main/opencode-adapter.ts`
+- `apps/desktop/src/main/permission-config.ts`
+- `apps/desktop/src/main/question-normalization.ts`
+- `apps/desktop/src/main/runtime-config-builder.ts`
+- `apps/desktop/src/main/runtime-managed-server-core.ts`
+- `apps/desktop/src/main/runtime-managed-server.ts`
+- `apps/desktop/src/main/runtime-mcp-status-polling.ts`
+- `apps/desktop/src/main/runtime-node-managed-server.ts`
+- `apps/desktop/src/main/runtime-skill-verifier.ts`
+- `apps/desktop/src/main/runtime-state.ts`
+- `apps/desktop/src/main/runtime.ts`
+- `apps/desktop/src/main/session-history-loader.ts`
+
+## Shared Event Contract
+
+The OpenCode SDK event stream is normalized once at the runtime boundary:
+
+```text
+OpenCode SDK event
+  -> opencode-runtime-adapter.ts
+  -> CloudRuntimeEvent / CloudSessionEventType
+  -> shared cloud projection reducer
+  -> desktop/web/gateway rendering
+```
+
+Gateway rendering consumes `@open-cowork/cloud-client` session events. It should
+never receive SDK client objects, SDK event envelopes, or OpenCode subprocess
+handles. If a gateway feature needs more detail, add that detail to the shared
+cloud event contract and projection tests rather than importing the SDK.
+
+## SDK v2 Upgrade Checklist
+
+Use this checklist for every OpenCode SDK or `opencode-ai` runtime bump:
+
+- Confirm `apps/desktop/package.json` pins both `@opencode-ai/sdk` and
+  `opencode-ai`, then update `pnpm-lock.yaml`.
+- Run `pnpm typecheck` first. SDK type drift in runtime config, client calls, or
+  server options is treated as real drift.
+- Verify `apps/desktop/src/main/runtime-config-builder.ts` still emits
+  SDK-native config for providers, agents, skills, MCPs, permissions, and model
+  defaults.
+- Verify `apps/desktop/src/main/cloud/byok-runtime-config.ts` still injects BYOK
+  provider credentials through `provider.<id>.options` only.
+- Update SDK event fixtures for assistant message parts, tool calls,
+  permission requests/resolutions, question requests/resolutions, todos, status,
+  idle, and errors.
+- Verify cloud event normalization maps every projection-critical SDK event into
+  `CloudSessionEventType`.
+- Verify permission and question round-trips still work through desktop, web,
+  cloud worker, and gateway approval flows.
+- Verify tool-call projection preserves tool id, name, status, input, output,
+  attachments, and task-run association where the SDK provides them.
+- Verify cloud worker startup still launches OpenCode through the runtime
+  adapter and does not require Electron-only process APIs.
+- Run the portability proof for runtime home/session resume assumptions:
+  `pnpm proof:cloud:opencode-portability`.
+- Run boundary and projection tests:
+  `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/opencode-sdk-boundary.test.ts tests/opencode-sdk-event-projection.test.ts tests/cloud-opencode-runtime-adapter.test.ts tests/cloud-session-projection-contract.test.ts tests/gateway-package-boundary.test.ts`.
+- Run the BYOK runtime injection tests:
+  `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/byok-runtime-injection.test.ts tests/byok-boundary-regression.test.ts`.
+- Run gateway renderer tests after `pnpm --filter @open-cowork/gateway build`:
+  `node --no-warnings --experimental-strip-types --test apps/gateway/src/event-renderer.test.ts`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
   - Build & Extend:
       - Architecture: architecture.md
       - Downstream Customization: downstream.md
+      - OpenCode SDK Boundary: opencode-sdk-v2-boundary.md
       - Development Environment: development-environment.md
       - Performance: performance.md
       - Security Model: security-model.md

--- a/packages/cloud-client/src/adapter.ts
+++ b/packages/cloud-client/src/adapter.ts
@@ -8,6 +8,7 @@ import type {
   CloudProjectSourceInput,
   CloudProjectSourcePolicyVerdict,
   CloudSessionProjectionRecord,
+  CloudSessionEventType,
   CloudSessionViewRecord,
   SessionArtifact,
   SessionArtifactAttachment,
@@ -392,7 +393,7 @@ export type CloudTransportSessionEvent = {
   entityId?: string
   operation?: string
   projectionVersion?: number
-  type: string
+  type: CloudSessionEventType
   payload: Record<string, unknown>
   createdAt?: string
 }

--- a/tests/gateway-package-boundary.test.ts
+++ b/tests/gateway-package-boundary.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
 
 const gatewayPackages = [
@@ -30,8 +30,25 @@ const forbiddenImportPatterns = [
 
 test('gateway package names and imports stay inside channel-adapter boundaries', () => {
   for (const packageDir of gatewayPackages) {
-    const packageJson = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8')) as { name?: string }
+    const packageJson = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8')) as {
+      name?: string
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      peerDependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+    }
     assert.match(packageJson.name || '', /^@open-cowork\/gateway(?:-|$)/)
+    for (const dependencySet of [
+      packageJson.dependencies,
+      packageJson.devDependencies,
+      packageJson.peerDependencies,
+      packageJson.optionalDependencies,
+    ]) {
+      assert.equal(dependencySet?.['@opencode-ai/sdk'], undefined, `${packageDir} must not depend on @opencode-ai/sdk`)
+      assert.equal(dependencySet?.['opencode-ai'], undefined, `${packageDir} must not depend on opencode-ai`)
+      assert.equal(dependencySet?.pg, undefined, `${packageDir} must not depend on pg`)
+      assert.equal(dependencySet?.['drizzle-orm'], undefined, `${packageDir} must not depend on drizzle-orm`)
+    }
 
     for (const filePath of sourceFiles(packageDir)) {
       const contents = readFileSync(filePath, 'utf8')
@@ -56,14 +73,13 @@ function sourceFiles(root: string): string[] {
 }
 
 function allFiles(root: string): string[] {
-  const entries = readdirSync(root)
+  const entries = readdirSync(root, { withFileTypes: true })
   const files: string[] = []
   for (const entry of entries) {
-    if (generatedDirectories.has(entry)) continue
-    const path = join(root, entry)
-    const stat = statSync(path)
-    if (stat.isDirectory()) files.push(...allFiles(path))
-    else files.push(path)
+    if (generatedDirectories.has(entry.name)) continue
+    const path = join(root, entry.name)
+    if (entry.isDirectory()) files.push(...allFiles(path))
+    else if (entry.isFile()) files.push(path)
   }
   return files
 }

--- a/tests/opencode-sdk-boundary.test.ts
+++ b/tests/opencode-sdk-boundary.test.ts
@@ -1,0 +1,133 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { extname, join, relative } from 'node:path'
+
+const root = process.cwd()
+const boundaryDoc = readFileSync(join(root, 'docs/opencode-sdk-v2-boundary.md'), 'utf8')
+
+const ignoredDirectories = new Set([
+  '.git',
+  'coverage',
+  'dist',
+  'node_modules',
+  'release',
+  'site',
+])
+
+const sourceRoots = [
+  'apps/desktop/src/main',
+  'apps/desktop/src/preload',
+  'apps/desktop/src/renderer',
+  'apps/gateway/src',
+  'apps/website/src',
+  'packages',
+] as const
+
+const sdkImportPattern = /\bfrom\s+['"]@opencode-ai\/sdk(?:\/v2(?:\/server)?)?['"]|import\s*\(\s*['"]@opencode-ai\/sdk(?:\/v2(?:\/server)?)?['"]\s*\)/
+
+const allowedSdkImportPaths = new Set([
+  'apps/desktop/src/main/agent-config.ts',
+  'apps/desktop/src/main/agent-prompts.ts',
+  'apps/desktop/src/main/cloud/app.ts',
+  'apps/desktop/src/main/cloud/byok-runtime-config.ts',
+  'apps/desktop/src/main/cloud/opencode-runtime-adapter.ts',
+  'apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts',
+  'apps/desktop/src/main/event-subscriptions.ts',
+  'apps/desktop/src/main/events.ts',
+  'apps/desktop/src/main/ipc/context.ts',
+  'apps/desktop/src/main/opencode-adapter.ts',
+  'apps/desktop/src/main/permission-config.ts',
+  'apps/desktop/src/main/question-normalization.ts',
+  'apps/desktop/src/main/runtime-config-builder.ts',
+  'apps/desktop/src/main/runtime-managed-server-core.ts',
+  'apps/desktop/src/main/runtime-managed-server.ts',
+  'apps/desktop/src/main/runtime-mcp-status-polling.ts',
+  'apps/desktop/src/main/runtime-node-managed-server.ts',
+  'apps/desktop/src/main/runtime-skill-verifier.ts',
+  'apps/desktop/src/main/runtime-state.ts',
+  'apps/desktop/src/main/runtime.ts',
+  'apps/desktop/src/main/session-history-loader.ts',
+])
+
+test('OpenCode SDK imports stay inside documented runtime boundary modules', () => {
+  const seenSdkImports = new Set<string>()
+  for (const sourceRoot of sourceRoots) {
+    for (const filePath of sourceFiles(join(root, sourceRoot))) {
+      const relativePath = relative(root, filePath)
+      const source = readFileSync(filePath, 'utf8')
+      if (!sdkImportPattern.test(source)) continue
+      seenSdkImports.add(relativePath)
+      assert.equal(
+        allowedSdkImportPaths.has(relativePath),
+        true,
+        `${relativePath} imports @opencode-ai/sdk outside the documented runtime boundary`,
+      )
+    }
+  }
+
+  for (const allowedPath of allowedSdkImportPaths) {
+    assert.equal(
+      seenSdkImports.has(allowedPath),
+      true,
+      `${allowedPath} is documented as an SDK boundary file but no longer imports the SDK`,
+    )
+    assert.match(
+      boundaryDoc,
+      new RegExp(`\`${escapeRegex(allowedPath)}\``),
+      `${allowedPath} must be listed in docs/opencode-sdk-v2-boundary.md`,
+    )
+  }
+})
+
+test('only the desktop package declares OpenCode runtime dependencies', () => {
+  const opencodeManifests: string[] = []
+  for (const manifestPath of packageManifests(root)) {
+    const relativePath = relative(root, manifestPath)
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      peerDependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+    }
+    const dependencySets = [
+      manifest.dependencies,
+      manifest.devDependencies,
+      manifest.peerDependencies,
+      manifest.optionalDependencies,
+    ]
+    const declaresOpencode = dependencySets.some((dependencies) => dependencies?.['@opencode-ai/sdk'] || dependencies?.['opencode-ai'])
+    if (declaresOpencode) opencodeManifests.push(relativePath)
+  }
+  assert.deepEqual(opencodeManifests.sort(), ['apps/desktop/package.json'])
+})
+
+function sourceFiles(directory: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (ignoredDirectories.has(entry.name)) continue
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...sourceFiles(path))
+    else if (entry.isFile() && sourceExtension(path)) files.push(path)
+  }
+  return files
+}
+
+function packageManifests(directory: string): string[] {
+  const manifests: string[] = []
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (ignoredDirectories.has(entry.name)) continue
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) manifests.push(...packageManifests(path))
+    else if (entry.isFile() && entry.name === 'package.json') manifests.push(path)
+  }
+  return manifests
+}
+
+function sourceExtension(path: string) {
+  return ['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(extname(path))
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/tests/opencode-sdk-event-projection.test.ts
+++ b/tests/opencode-sdk-event-projection.test.ts
@@ -1,0 +1,206 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { translateOpencodeRuntimeEvent } from '../apps/desktop/src/main/cloud/opencode-runtime-adapter.ts'
+import {
+  CLOUD_SESSION_EVENT_TYPES,
+  cloudSessionViewToSessionView,
+  createCloudSessionProjectionView,
+  reduceCloudSessionProjectionEvent,
+} from '../packages/shared/dist/cloud-session-projection.js'
+
+function sessionRecord() {
+  return {
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    profileName: 'default',
+    status: 'running' as const,
+    title: 'SDK fixture session',
+    updatedAt: '2026-05-29T10:00:00.000Z',
+  }
+}
+
+function eventRecord(sequence: number, event: { type: string, payload: Record<string, unknown> }) {
+  return {
+    sequence,
+    type: event.type,
+    payload: event.payload,
+    createdAt: `2026-05-29T10:${String(sequence).padStart(2, '0')}:00.000Z`,
+  }
+}
+
+test('SDK v2 event fixtures normalize into the shared cloud projection contract', () => {
+  const rawSdkEvents = [
+    {
+      payload: {
+        type: 'message.part.updated',
+        data: {
+          sessionID: 'session-1',
+          messageID: 'assistant-message-1',
+          role: 'assistant',
+          part: { id: 'part-1', type: 'text', text: 'normalized assistant text' },
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'message.part.updated',
+        data: {
+          sessionID: 'session-1',
+          part: {
+            id: 'part-2',
+            callID: 'tool-call-1',
+            type: 'tool',
+            tool: 'bash',
+            state: {
+              input: { command: 'pnpm test' },
+              status: 'completed',
+              output: 'ok',
+            },
+          },
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'permission.asked',
+        properties: {
+          sessionID: 'session-1',
+          permission: {
+            id: 'permission-1',
+            tool: 'bash',
+            input: { command: 'pnpm test' },
+          },
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'question.asked',
+        properties: {
+          sessionID: 'session-1',
+          id: 'question-1',
+          questions: [{
+            header: 'Scope',
+            question: 'Run all checks?',
+            options: [{ label: 'Yes', description: 'Run the full suite' }],
+          }],
+          tool: { messageID: 'assistant-message-1', callID: 'tool-call-1' },
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'todo.updated',
+        properties: {
+          sessionID: 'session-1',
+          todos: [{ id: 'todo-1', content: 'Harden SDK boundary', status: 'in_progress', priority: 'high' }],
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'session.status',
+        properties: {
+          sessionID: 'session-1',
+          status: { type: 'idle' },
+        },
+      },
+    },
+  ]
+
+  const normalized = rawSdkEvents.flatMap(translateOpencodeRuntimeEvent)
+  assert.deepEqual(normalized.map((event) => event.type), [
+    'assistant.message',
+    'tool.call',
+    'permission.requested',
+    'question.asked',
+    'todos.updated',
+    'session.status',
+  ])
+
+  const session = sessionRecord()
+  let projection = createCloudSessionProjectionView(session)
+  normalized.forEach((event, index) => {
+    assert.equal(CLOUD_SESSION_EVENT_TYPES.includes(event.type), true, `${event.type} must be a shared cloud event`)
+    projection = reduceCloudSessionProjectionEvent(session, projection, eventRecord(index + 1, event))
+  })
+
+  assert.deepEqual(projection.messages.map((message) => message.content), ['normalized assistant text'])
+  assert.equal(projection.toolCalls[0]?.name, 'bash')
+  assert.equal(projection.toolCalls[0]?.status, 'complete')
+  assert.equal(projection.pendingApprovals[0]?.id, 'permission-1')
+  assert.equal(projection.pendingQuestions[0]?.id, 'question-1')
+  assert.equal(projection.pendingQuestions[0]?.tool?.callId, 'tool-call-1')
+  assert.deepEqual(projection.todos.map((todo) => todo.content), ['Harden SDK boundary'])
+  assert.equal(projection.status, 'idle')
+
+  const desktopView = cloudSessionViewToSessionView({
+    session,
+    projection: {
+      tenantId: session.tenantId,
+      sessionId: session.sessionId,
+      sequence: normalized.length,
+      view: projection,
+      updatedAt: projection.updatedAt,
+    },
+  })
+  assert.equal(desktopView.messages[0]?.content, 'normalized assistant text')
+  assert.equal(desktopView.pendingApprovals[0]?.id, 'permission-1')
+  assert.equal(desktopView.pendingQuestions[0]?.id, 'question-1')
+})
+
+test('SDK v2 permission and question resolution fixtures clear shared pending state', () => {
+  const session = sessionRecord()
+  const rawSdkEvents = [
+    {
+      payload: {
+        type: 'permission.asked',
+        properties: {
+          sessionID: 'session-1',
+          permission: { id: 'permission-1', tool: 'bash', input: { command: 'pwd' } },
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'question.asked',
+        properties: {
+          sessionID: 'session-1',
+          id: 'question-1',
+          questions: [{ question: 'Continue?', options: [] }],
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'permission.resolved',
+        properties: {
+          sessionID: 'session-1',
+          permission: { id: 'permission-1' },
+        },
+      },
+    },
+    {
+      payload: {
+        type: 'question.resolved',
+        properties: {
+          sessionID: 'session-1',
+          id: 'question-1',
+        },
+      },
+    },
+  ]
+
+  let projection = createCloudSessionProjectionView(session)
+  rawSdkEvents
+    .flatMap(translateOpencodeRuntimeEvent)
+    .forEach((event, index) => {
+      assert.equal(CLOUD_SESSION_EVENT_TYPES.includes(event.type), true, `${event.type} must be a shared cloud event`)
+      projection = reduceCloudSessionProjectionEvent(session, projection, eventRecord(index + 1, event))
+    })
+
+  assert.equal(projection.pendingApprovals.length, 0)
+  assert.equal(projection.pendingQuestions.length, 0)
+})


### PR DESCRIPTION
Closes #462

## Summary
- add explicit OpenCode SDK package-boundary tests with a documented allowed import path list
- type cloud runtime and transport session events against the shared CloudSessionEventType contract
- add SDK-shaped event fixture tests that normalize into shared projection events and desktop SessionView state
- harden gateway package-boundary checks against runtime/DB dependencies and add a renderer regression proving gateway consumes normalized cloud events, not raw SDK envelopes
- document the SDK v2 boundary and upgrade checklist in the docs nav

## Verification
- pnpm build:shared && pnpm --filter @open-cowork/cloud-client build && pnpm --filter @open-cowork/gateway build
- node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/opencode-sdk-boundary.test.ts tests/opencode-sdk-event-projection.test.ts tests/cloud-opencode-runtime-adapter.test.ts tests/cloud-session-projection-contract.test.ts tests/gateway-package-boundary.test.ts tests/byok-runtime-injection.test.ts tests/byok-boundary-regression.test.ts
- node --no-warnings --experimental-strip-types --test apps/gateway/src/event-renderer.test.ts
- pnpm lint
- pnpm typecheck
- python3 -m mkdocs build --strict
- git diff --check
- pnpm test
