### PR TITLE
Add deployment readiness gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,9 @@ jobs:
           test -s /tmp/open-cowork-gateway-rendered.yaml
           grep -q "OPEN_COWORK_GATEWAY_SERVICE_TOKEN" /tmp/open-cowork-gateway-rendered.yaml
 
+      - name: Run deployment readiness validator
+        run: pnpm deploy:validate -- --require-tools
+
   # Run the desktop smoke suite and package the app on macOS so
   # platform-specific regressions (IPC, renderer boot, native modules,
   # packaging hooks) surface on every PR instead of only when we cut a

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -32,8 +32,9 @@ The current suite measures:
 ## Usage Notes
 
 - Run `pnpm perf:check` on an otherwise idle machine or at least not in parallel with `test`, `typecheck`, or `build`.
-- The gate uses relative thresholds plus small absolute floors so sub-millisecond
-  benchmarks do not fail on hosted-runner timer noise.
+- The gate uses relative thresholds plus small absolute floors and a 0.05 ms
+  jitter allowance so low-millisecond benchmarks do not fail on hosted-runner
+  timer noise.
 - Baselines are environment-specific. CI uses `perf-baseline.linux-x64-node22.json`;
   local runs prefer a matching `perf-baseline.<platform>-<arch>-node<major>.json`
   before falling back to another baseline from the same platform and architecture,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,7 +23,55 @@ Use these invariants across every provider:
   pilots unless the platform gives workers predictable long-running CPU.
 - Enable `OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED=true` before scaling worker
   replicas beyond one.
+- Keep billing optional for self-hosted OSS deployments. Use no billing
+  provider or the stub billing provider unless you are operating managed SaaS.
+- Run `pnpm deploy:validate` before release and `pnpm deploy:smoke` against a
+  live deployment after rollout.
 
 The canonical scalable manifest is the provider-neutral Helm chart in
 `helm/open-cowork-cloud`; the gateway chart lives in `helm/open-cowork-gateway`
 and can also be enabled as the cloud chart's optional gateway dependency.
+
+## Required Production Inputs
+
+Provider recipes are deployment wiring documents. They should resolve the same
+runtime inputs through provider-native services without changing core code.
+
+Every provider recipe should resolve the same inputs through provider-native
+infrastructure:
+
+| Input | Expected source |
+| --- | --- |
+| Images | `open-cowork-cloud` and `open-cowork-gateway` OCI images |
+| Public origins | HTTPS cloud URL and optional HTTPS gateway URL |
+| Auth | OIDC or trusted header auth with signed proxy headers |
+| Control plane | Managed Postgres connection string |
+| Object store | Bucket/container plus adapter-specific endpoint/region |
+| Secrets | Provider secret manager or KMS-backed secret adapter |
+| Runtime keys | BYOK status APIs plus worker-only plaintext reveal |
+| Gateway | Scoped service token and provider signing secrets |
+| Scaling | Split web/worker/scheduler roles and checkpoint-enabled workers |
+| Observability | JSON logs, OTLP endpoint, metrics, and redaction policy |
+| Recovery | Postgres and object-store backup/restore process |
+
+See `docs/deployment-readiness.md` for the production checklist and
+`docs/runbooks/managed-byok-saas.md` for hosted BYOK operations.
+
+## Validation
+
+Validate local manifests and Helm guardrails:
+
+```bash
+pnpm deploy:validate
+```
+
+Smoke a running deployment:
+
+```bash
+OPEN_COWORK_SMOKE_CLOUD_URL=https://cowork.example.com \
+OPEN_COWORK_SMOKE_GATEWAY_URL=https://gateway.example.com \
+pnpm deploy:smoke
+```
+
+The same smoke command works for local Compose, Kubernetes/Helm, and the cloud
+provider recipes once traffic is routed to the chosen endpoints.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -12,6 +12,8 @@ these services:
 | Control plane | RDS for PostgreSQL |
 | Object store | S3 |
 | Secrets | Secrets Manager or SSM Parameter Store for cloud keys, gateway tokens, and channel credentials |
+| Observability | CloudWatch Logs plus OTLP exporter or collector |
+| Backups | RDS PITR plus S3 versioning/lifecycle |
 
 For Kubernetes-first deployments, install the provider-neutral Helm chart on
 EKS and connect it to RDS, S3, and Secrets Manager through External Secrets or
@@ -54,3 +56,20 @@ object-store settings, secret key, and checkpoint settings.
 When the envelope key is read directly by the app, set
 `OPEN_COWORK_CLOUD_SECRET_KEY_REF` to an AWS Secrets Manager URI such as
 `aws-sm://open-cowork/cloud-secret-key?region=REGION`.
+
+## Production Notes
+
+- Configure `OPEN_COWORK_CLOUD_PUBLIC_URL` and
+  `OPEN_COWORK_GATEWAY_PUBLIC_URL` with HTTPS ALB, CloudFront, or ingress
+  origins.
+- Store cookie secret, internal token, database URL, BYOK envelope key,
+  gateway service token, and provider webhook signing secrets in Secrets
+  Manager or SSM.
+- Keep cloud billing disabled/stubbed for OSS self-host. Managed SaaS should
+  configure billing through the billing adapter and signed billing webhooks.
+- Prefer IRSA or task roles for S3 access over long-lived static keys.
+- Run `pnpm deploy:smoke` after rollout with the deployed cloud and gateway
+  URLs.
+
+AWS configuration is adapter wiring only. Do not add AWS branches to cloud
+sessions, gateway rendering, OpenCode runtime startup, or BYOK core code.

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -12,6 +12,8 @@ with these services:
 | Control plane | Azure Database for PostgreSQL |
 | Object store | Azure Blob Storage |
 | Secrets | Key Vault for cloud keys, gateway tokens, and channel credentials |
+| Observability | Azure Monitor/Application Insights plus OTLP exporter or collector |
+| Backups | Azure PostgreSQL PITR plus Blob versioning/lifecycle |
 
 For scalable deployments, install the provider-neutral Helm chart on AKS and
 connect it to Azure Database for PostgreSQL, Blob Storage, and Key Vault
@@ -53,3 +55,20 @@ but keep split roles and checkpointing enabled before adding worker replicas.
 When the envelope key is read directly by the app, set
 `OPEN_COWORK_CLOUD_SECRET_KEY_REF` to a Key Vault URI such as
 `azure-kv://VAULT_NAME/secrets/open-cowork-cloud-key/VERSION`.
+
+## Production Notes
+
+- Configure `OPEN_COWORK_CLOUD_PUBLIC_URL` and
+  `OPEN_COWORK_GATEWAY_PUBLIC_URL` with HTTPS Container Apps ingress,
+  Application Gateway, Front Door, or AKS ingress.
+- Store cookie secret, internal token, database URL, BYOK envelope key,
+  gateway service token, and provider webhook signing secrets in Key Vault.
+- Keep cloud billing disabled/stubbed for OSS self-host. Managed SaaS should
+  configure billing through the billing adapter and signed billing webhooks.
+- Prefer workload identity for Blob and Key Vault access over long-lived static
+  keys.
+- Run `pnpm deploy:smoke` after rollout with the deployed cloud and gateway
+  URLs.
+
+Azure configuration is adapter wiring only. Do not add Azure branches to cloud
+sessions, gateway rendering, OpenCode runtime startup, or BYOK core code.

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -12,6 +12,8 @@ DigitalOcean with these services:
 | Control plane | Managed PostgreSQL |
 | Object store | Spaces |
 | Secrets | App Platform or Kubernetes secrets, preferably External Secrets |
+| Observability | App Platform logs, Kubernetes logs, and OTLP exporter or collector |
+| Backups | Managed PostgreSQL backups plus Spaces versioning/lifecycle |
 
 For scalable deployments, install the provider-neutral Helm chart on DOKS and
 connect it to Managed PostgreSQL and Spaces.
@@ -48,3 +50,21 @@ needs inbound callbacks.
 
 App Platform all-in-one is acceptable for demos and focused-agent pilots.
 Production worker execution should use DOKS split roles.
+
+## Production Notes
+
+- Configure `OPEN_COWORK_CLOUD_PUBLIC_URL` and
+  `OPEN_COWORK_GATEWAY_PUBLIC_URL` with HTTPS App Platform or DOKS ingress
+  origins.
+- Store cookie secret, internal token, database URL, BYOK envelope key,
+  gateway service token, and provider webhook signing secrets in App Platform
+  secrets, Kubernetes secrets, or External Secrets.
+- Keep cloud billing disabled/stubbed for OSS self-host. Managed SaaS should
+  configure billing through the billing adapter and signed billing webhooks.
+- Use Spaces access keys with the smallest bucket/prefix scope available.
+- Run `pnpm deploy:smoke` after rollout with the deployed cloud and gateway
+  URLs.
+
+DigitalOcean configuration is adapter wiring only. Do not add DigitalOcean
+branches to cloud sessions, gateway rendering, OpenCode runtime startup, or
+BYOK core code.

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -12,6 +12,8 @@ these services:
 | Control plane | Cloud SQL for PostgreSQL |
 | Object store | Cloud Storage |
 | Secrets | Secret Manager for cloud keys, gateway tokens, and channel credentials |
+| Observability | Cloud Logging plus OTLP exporter or managed collector |
+| Backups | Cloud SQL PITR plus Cloud Storage bucket versioning/lifecycle |
 
 For scalable deployments, install the provider-neutral Helm chart on GKE and
 wire it to Cloud SQL, Cloud Storage, and Secret Manager through External
@@ -54,3 +56,20 @@ as `gcp-sm://projects/PROJECT/secrets/open-cowork-cloud-key/versions/latest`.
 Cloud Run all-in-one is useful for demos and focused-agent pilots, but
 production worker execution should run on GKE so OpenCode processes have stable
 CPU and lifetime.
+
+## Production Notes
+
+- Configure `OPEN_COWORK_CLOUD_PUBLIC_URL` and
+  `OPEN_COWORK_GATEWAY_PUBLIC_URL` with HTTPS load balancer or Cloud Run URLs.
+- Store cookie secret, internal token, database URL, BYOK envelope key,
+  gateway service token, and provider webhook signing secrets in Secret
+  Manager.
+- Keep cloud billing disabled/stubbed for OSS self-host. Managed SaaS should
+  configure billing through the billing adapter and signed billing webhooks.
+- Use Workload Identity or External Secrets rather than static object-store
+  credentials where possible.
+- Run `pnpm deploy:smoke` after rollout with the deployed cloud and gateway
+  URLs.
+
+GCP configuration is adapter wiring only. Do not add GCP branches to cloud
+sessions, gateway rendering, OpenCode runtime startup, or BYOK core code.

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -1,0 +1,220 @@
+---
+title: Deployment Readiness
+description: Production checklist for self-hosted and managed Open Cowork Cloud plus Gateway deployments.
+---
+
+# Deployment Readiness
+
+Use this checklist before exposing Open Cowork Cloud or the headless gateway to
+company users, customers, or public channel webhooks. The deployment should be
+the same product on every provider: configure adapters and infrastructure, do
+not add provider-specific branches to core app code.
+
+## Required Topology
+
+Production deployments should run these processes separately:
+
+- cloud `web`: stateless HTTP, browser dashboard, API, SSE, auth, and durable
+  projections.
+- cloud `worker`: OpenCode execution, command processing, checkpoints, and
+  artifact generation.
+- cloud `scheduler`: durable workflow claims and scheduled run creation.
+- gateway: channel I/O, provider webhooks or polling, channel rendering, and
+  delivery retries.
+
+Local Compose may run `all-in-one` cloud for speed. Provider demos may use
+all-in-one for a focused pilot. Shared or hosted deployments should use split
+roles and shared Postgres/object storage.
+
+## Production Checklist
+
+### Auth
+
+- Public cloud uses OIDC or trusted `header` auth behind a signed, trusted
+  identity proxy.
+- `OPEN_COWORK_CLOUD_AUTH_MODE=none` is allowed only for local/demo installs
+  with explicit insecure overrides.
+- Header auth includes `OPEN_COWORK_CLOUD_HEADER_AUTH_SECRET` or
+  `OPEN_COWORK_CLOUD_HEADER_AUTH_SECRET_REF`; identity headers from arbitrary
+  clients are never trusted directly.
+- Public dashboard traffic uses HTTPS and a stable `OPEN_COWORK_CLOUD_PUBLIC_URL`.
+
+### Cookie Secret
+
+- Set a high-entropy cookie secret through `OPEN_COWORK_CLOUD_COOKIE_SECRET` or
+  `OPEN_COWORK_CLOUD_COOKIE_SECRET_REF`.
+- Keep `OPEN_COWORK_CLOUD_COOKIE_SECURE=true` for HTTPS deployments.
+- Rotate the cookie secret during a maintenance window because browser
+  sessions may be invalidated.
+
+### Postgres
+
+- Use managed Postgres or a highly available cluster for the control plane.
+- Enable automated backups and point-in-time recovery.
+- Size connection limits for web replicas, workers, scheduler replicas, and
+  dashboard/gateway API traffic.
+- Run the real Postgres concurrency tests before changing schema, lease,
+  command, delivery, or quota behavior.
+
+### Object Store
+
+- Configure object storage for artifacts, uploads, exports, runtime
+  checkpoints, workspace snapshots, and diagnostics bundles.
+- Use provider-native object storage through adapter configuration: S3, GCS,
+  Azure Blob, DigitalOcean Spaces, or compatible S3 endpoints.
+- Do not rely on local filesystem object storage for scaled workers.
+- Confirm object-store read/write with a smoke artifact or checkpoint-enabled
+  session before enabling multiple workers.
+
+### Secret Adapter/KMS
+
+- Store envelope keys, BYOK material, channel credentials, database URLs,
+  object-store credentials, gateway service tokens, and billing secrets in a
+  provider secret manager or KMS-backed secret adapter.
+- Use `OPEN_COWORK_CLOUD_SECRET_KEY_REF` where possible:
+  `gcp-sm://...`, `aws-sm://...`, `azure-kv://...`, or `env:...` for
+  platform-injected secrets.
+- BYOK plaintext is only revealed in the worker role and only long enough to
+  build provider runtime config.
+
+### Public URL/HTTPS
+
+- Set `OPEN_COWORK_CLOUD_PUBLIC_URL` to the canonical HTTPS origin.
+- Set `OPEN_COWORK_GATEWAY_PUBLIC_URL` when providers require webhook
+  callbacks.
+- Terminate TLS at ingress, load balancer, Cloud Run/App Platform, or the
+  service mesh; internal pod/service traffic may remain private.
+- Do not send desktop bearer tokens, gateway service tokens, cookies, or BYOK
+  setup requests over non-loopback HTTP.
+
+### Worker/Scheduler Scaling
+
+- Enable `OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED=true` before scaling worker
+  replicas beyond one.
+- Keep worker runtime roots ephemeral for horizontally scaled Kubernetes
+  workers unless a single-worker persistent root is intentionally configured.
+- Run at least one scheduler. Multiple schedulers are safe when they use
+  database claims.
+- Monitor worker heartbeat age, scheduler heartbeat age, command latency,
+  projection lag, and lease reclaim counts.
+
+### Gateway Service Token
+
+- Run the gateway as a separate deployment with a scoped service/API token.
+- Store `OPEN_COWORK_GATEWAY_SERVICE_TOKEN` in the platform secret manager.
+- Rotate gateway tokens by issuing a new token, updating the deployment secret,
+  restarting the gateway, then revoking the old token.
+- The gateway token authenticates the gateway process only; inbound channel
+  actor identity and approval authority are resolved separately by cloud.
+
+### Provider Webhook Signing
+
+- Public webhook providers require provider signing secrets or shared secrets.
+- Slack uses its signing secret, email uses an inbound shared secret, and the
+  generic webhook provider uses `OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET`.
+- The fake provider is local/demo-only and must not be exposed publicly.
+- Gateway metrics and diagnostics on `0.0.0.0` require an admin token or
+  private networking.
+
+### Quotas/Rate Limits
+
+- Configure per-org session, worker, prompt, API, and gateway delivery limits
+  before public hosting.
+- Keep billing disabled or stubbed for OSS self-host; self-hosted use should
+  work with no billing provider or the stub billing provider.
+- Hosted SaaS should gate new execution on subscription state while preserving
+  read access and export paths.
+- Rate limits should return clear 429 responses with `Retry-After`; billing
+  gates should return clear 402 responses.
+
+### OTLP/Logging
+
+- Use JSON logs in production.
+- Configure `OPEN_COWORK_CLOUD_OTLP_ENDPOINT` and gateway metrics scraping
+  where available.
+- Include request ids, org ids, session ids, run ids, worker ids, scheduler ids,
+  and gateway delivery ids.
+- Redact BYOK keys, API tokens, cookies, OAuth tokens, webhook secrets,
+  database URLs, object-store signed URLs, and local paths.
+
+### Backups/Restore
+
+- Back up Postgres and object storage on the same retention policy.
+- Restore Postgres first, then object-store artifacts/checkpoints for the same
+  point in time.
+- Start web with workers at zero, verify projections and session lists, start
+  one worker, run a smoke prompt, then start scheduler and gateway.
+- Verify channel deliveries resume from durable cursors without duplicates.
+
+## Deployment Validation
+
+Run static and tool-backed configuration checks:
+
+```bash
+pnpm deploy:validate
+```
+
+In CI or release qualification, require Docker and Helm:
+
+```bash
+pnpm deploy:validate -- --require-tools
+```
+
+The validator checks:
+
+- Compose config for `docker-compose.cloud.yml`,
+  `docker-compose.cloud.split.yml`, and `docker-compose.cloud-gateway.yml`.
+- Helm lint/render for cloud and gateway charts.
+- Helm fail-closed behavior for unsafe public cloud auth, public gateway
+  metrics without admin auth, and generic webhook ingress without a shared
+  secret.
+- Presence of provider recipes, this checklist, and the managed BYOK SaaS
+  runbook.
+
+## Runtime Smoke Checks
+
+For a local Compose deployment:
+
+```bash
+pnpm cloud:smoke:compose
+```
+
+For any already-running provider deployment:
+
+```bash
+OPEN_COWORK_SMOKE_CLOUD_URL=https://cowork.example.com \
+OPEN_COWORK_SMOKE_GATEWAY_URL=https://gateway.example.com \
+pnpm deploy:smoke
+```
+
+For operator-only readiness checks:
+
+```bash
+OPEN_COWORK_SMOKE_OPERATOR_CHECKS=true \
+OPEN_COWORK_SMOKE_CLOUD_TOKEN=... \
+OPEN_COWORK_SMOKE_GATEWAY_ADMIN_TOKEN=... \
+pnpm deploy:smoke
+```
+
+The smoke script validates cloud `/healthz`, gateway `/health`, and gateway
+`/ready`. Operator mode also checks cloud runtime/heartbeat endpoints and
+gateway metrics when tokens are provided.
+
+## Provider Recipe Contract
+
+Provider recipes under `deploy/gcp`, `deploy/aws`, `deploy/azure`, and
+`deploy/digitalocean` must stay thin. They should define:
+
+- image repository and tag,
+- public HTTPS origins,
+- OIDC or trusted header auth,
+- Postgres control-plane URL,
+- object-store adapter settings,
+- secret manager/KMS references,
+- worker/scheduler replica counts,
+- gateway service token and provider signing secrets,
+- OTLP/logging endpoints,
+- backup/restore ownership.
+
+They must not require changes to session, runtime, projection, gateway,
+OpenCode SDK, billing, or BYOK core code.

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -331,6 +331,32 @@ form can point at `env:NAME`, GCP Secret Manager
 Secrets Manager (`aws-sm://{secret-id}?region={region}`), or Azure Key Vault
 (`azure-kv://{vault}/secrets/{secret}/{version}`).
 
+## Production Readiness
+
+Before exposing cloud or gateway publicly, use the deployment checklist in
+`deployment-readiness.md`. It covers auth, cookie secrets, Postgres, object
+storage, secret adapter/KMS references, public HTTPS origins, worker/scheduler
+scaling, gateway service tokens, provider webhook signing, quotas/rate limits,
+OTLP/logging, backups, and restore.
+
+Managed BYOK operators should also follow `runbooks/managed-byok-saas.md`.
+That runbook covers org signup mode, token TTLs, invite/domain controls,
+billing setup, BYOK validation, gateway operations, and incident response.
+
+Run deployment manifest validation before rollout:
+
+```bash
+pnpm deploy:validate
+```
+
+Smoke a running deployment after traffic is routed:
+
+```bash
+OPEN_COWORK_SMOKE_CLOUD_URL=https://cowork.example.com \
+OPEN_COWORK_SMOKE_GATEWAY_URL=https://gateway.example.com \
+pnpm deploy:smoke
+```
+
 ## Validation
 
 The regular `pnpm test` suite covers the in-memory control-plane adapter and

--- a/docs/runbooks/managed-byok-saas.md
+++ b/docs/runbooks/managed-byok-saas.md
@@ -1,0 +1,148 @@
+---
+title: Managed BYOK SaaS Runbook
+description: Operating checklist for a hosted Open Cowork Cloud BYOK service.
+---
+
+# Managed BYOK SaaS Runbook
+
+This runbook covers the hosted service shape where users bring model/provider
+keys and the operator runs cloud sync, workers, object storage, dashboard, and
+gateway channel bindings.
+
+## Operating Model
+
+- Open Cowork sells hosted convenience, reliability, sync, and managed channel
+  operations.
+- Users bring provider keys. Open Cowork does not resell model tokens.
+- OSS self-host deployments must continue to work with no billing provider or
+  with the stub billing provider.
+- Billing, IdP, object store, secret manager, and gateway provider choices stay
+  behind adapters.
+
+## Org Signup Mode
+
+Choose one org signup mode per environment:
+
+- `closed`: operators create orgs manually. Use for private beta and internal
+  enterprise installs.
+- `invite`: users can join only with an invite token or approved membership
+  record. Use for design partners and paid trials.
+- `domain`: users can self-serve when their email domain is allowlisted.
+- `open`: public self-serve. Use only after quotas, billing, abuse controls,
+  and support processes are live.
+
+For public SaaS, record the chosen org signup mode in deployment config and
+audit changes. Do not auto-provision active orgs for arbitrary identities unless
+the environment is intentionally configured for open signup.
+
+## Token TTL And Client Access
+
+- Desktop API tokens should have a token TTL appropriate for user devices,
+  usually 30 to 90 days.
+- Gateway service tokens should be shorter lived where operationally possible,
+  usually 7 to 30 days, and scoped to the org/channel bindings they serve.
+- One-time token plaintext is shown only at creation.
+- Revocation must block desktop/gateway clients immediately on the next API
+  request or SSE reconnect.
+- Store token hashes only; never store or log raw token values after creation.
+
+## Invite/Domain Controls
+
+- Keep owner/admin membership changes audited.
+- For invite mode, expire unused invite tokens and rate-limit invite creation.
+- For domain mode, require verified email from the IdP and deny consumer email
+  domains unless they are explicitly part of the plan.
+- Removed org members should lose access to dashboard, desktop sync, gateway
+  approval authority, and future token creation.
+
+## Billing Setup
+
+- Configure the billing adapter through environment or secret references.
+- Keep Stripe or any future provider imports out of core cloud runtime code.
+- Webhook signing is mandatory for billing events.
+- Subscription states map to entitlements that overlay runtime policy:
+  active/trialing may start execution; past_due/canceled cannot start new
+  workers or new paid features.
+- Keep read/export paths available for canceled orgs unless legal or abuse
+  policy requires suspension.
+- Record usage events for prompt count, session starts, worker minutes, storage
+  usage, and gateway delivery volume.
+
+## BYOK Validation
+
+Before marking a provider key active:
+
+1. Store the key through the BYOK secret store using org/provider AAD.
+2. Reveal plaintext only inside the worker role validation path.
+3. Build provider runtime config as `provider.<id>.options`.
+4. Run a bounded model-call validation or provider metadata check.
+5. Confirm read APIs return only status, provider, last4/fingerprint, and
+   health.
+6. Confirm logs, diagnostics, HTTP payloads, renderer state, and cache contain
+   no raw key material.
+
+If validation fails, keep the previous active key if one exists and store the
+new key as failed metadata only when that is safe for the provider.
+
+## Gateway Operations
+
+- Gateway deployments use scoped service tokens, never user refresh tokens.
+- Channel credentials live in the gateway secret store or platform secret
+  manager.
+- Public webhook providers require signing secrets or shared secrets.
+- Fake provider is disabled in managed environments.
+- Gateway metrics and diagnostics require an admin token, VPN, private
+  networking, or equivalent operator access.
+- Delivery backlog is monitored separately from cloud command execution.
+- Poison deliveries are dead-lettered after retry exhaustion and can be
+  manually retried after operator review.
+
+## Incident Response
+
+### Suspected BYOK Exposure
+
+1. Disable new worker claims for the affected org.
+2. Rotate or revoke the affected provider key with the provider.
+3. Rotate cloud envelope/KMS material if ciphertext access may be compromised.
+4. Export redacted audit events and diagnostics.
+5. Patch the leak, add a regression test, and notify affected users according
+   to policy.
+
+### Billing Webhook Abuse
+
+1. Disable billing webhook ingress or rotate the webhook signing secret.
+2. Replay known-good events from the provider dashboard.
+3. Reconcile `cloud_subscriptions` and usage records.
+4. Confirm entitlement gates match the billing provider state.
+
+### Gateway Channel Compromise
+
+1. Rotate channel credentials in the provider.
+2. Rotate gateway service token.
+3. Restart only affected gateway deployments.
+4. Review channel interaction audit events for unauthorized approvals.
+5. Dead-letter suspicious outbound deliveries and require manual retry.
+
+### Cloud Data Restore
+
+1. Freeze writes for the affected org or environment.
+2. Restore Postgres and object storage to the same point in time.
+3. Start web with workers and gateway disabled.
+4. Verify sessions, projections, BYOK metadata, billing state, and channel
+   bindings.
+5. Start one worker, run a bounded smoke prompt, then re-enable scheduler and
+   gateway.
+
+## Launch Gates
+
+Private beta can run with manual billing, closed/invite org signup mode, and a
+small number of managed gateway channels. Public self-serve requires:
+
+- signup mode explicitly set,
+- token TTLs enforced,
+- invite/domain controls documented,
+- billing adapter and signed webhooks configured,
+- BYOK validation active,
+- gateway operations runbook exercised,
+- incident response contacts and escalation paths ready,
+- quotas, rate limits, backups, restore checks, and OTLP/logging verified.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,7 +120,9 @@ nav:
       - Telemetry and Privacy: privacy.md
   - Operate:
       - Open Cowork Cloud: open-cowork-cloud.md
+      - Deployment Readiness: deployment-readiness.md
       - Cloud Managed Operations: runbooks/cloud-managed-operations.md
+      - Managed BYOK SaaS: runbooks/managed-byok-saas.md
       - Branch Protection: branch-protection.md
       - Packaging and Releases: packaging-and-releases.md
       - Release Checklist: release-checklist.md

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "cloud:build": "node scripts/build-cloud.mjs",
     "cloud:start": "node apps/desktop/dist/cloud/open-cowork-cloud.mjs",
     "cloud:smoke:compose": "bash scripts/ci-cloud-compose-smoke.sh",
+    "deploy:validate": "node scripts/validate-deployment-configs.mjs",
+    "deploy:smoke": "node scripts/smoke-deployment.mjs",
     "notices": "node scripts/generate-third-party-notices.mjs",
     "proof:cloud:opencode-portability": "node --no-warnings --experimental-strip-types scripts/opencode-portability-proof.ts",
     "perf:bench": "node --no-warnings --experimental-sqlite --experimental-strip-types scripts/perf-benchmark.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,8 @@ pnpm cloud:dev
 pnpm cloud:build
 pnpm cloud:start
 pnpm cloud:smoke:compose
+pnpm deploy:validate
+pnpm deploy:smoke
 pnpm notices
 pnpm --dir apps/desktop dist:ci
 ```
@@ -29,3 +31,14 @@ starts the role selected by `OPEN_COWORK_CLOUD_ROLE` from that bundle. Use
 `docker-compose.cloud.split.yml` for web/worker/scheduler topology checks.
 `pnpm cloud:smoke:compose` starts the split-role compose topology, waits
 for `/healthz`, and prints service logs if the smoke fails.
+
+`pnpm deploy:validate` checks local Compose files, Helm chart guardrails, and
+deployment readiness docs. It runs `docker compose config` and Helm
+lint/template checks when those tools are installed; set
+`OPEN_COWORK_DEPLOY_REQUIRE_TOOLS=true` or pass `--require-tools` in CI to fail
+instead of falling back to static validation.
+
+`pnpm deploy:smoke` validates a running deployment through HTTP health and
+readiness endpoints. Override `OPEN_COWORK_SMOKE_CLOUD_URL` and
+`OPEN_COWORK_SMOKE_GATEWAY_URL` for provider deployments, or use
+`--skip-cloud` / `--skip-gateway` when checking one surface.

--- a/scripts/perf/compare.ts
+++ b/scripts/perf/compare.ts
@@ -18,6 +18,7 @@ export function compareReports(current: BenchmarkReport, baseline: BenchmarkRepo
   const baselineByName = new Map(baseline.benchmarks.map((entry) => [entry.name, entry]))
   const avgMultiplier = baseline.regressionThresholds?.avgMultiplier || DEFAULT_THRESHOLDS.avgMultiplier
   const p95Multiplier = baseline.regressionThresholds?.p95Multiplier || DEFAULT_THRESHOLDS.p95Multiplier
+  const jitterAllowanceMs = baseline.regressionThresholds?.jitterAllowanceMs ?? DEFAULT_THRESHOLDS.jitterAllowanceMs
   const comparableEnvironment = hasComparableEnvironment(current, baseline)
   const avgAbsoluteFloorMs = comparableEnvironment
     ? baseline.regressionThresholds?.avgAbsoluteFloorMs || DEFAULT_THRESHOLDS.avgAbsoluteFloorMs
@@ -39,11 +40,11 @@ export function compareReports(current: BenchmarkReport, baseline: BenchmarkRepo
     const avgLimit = round(Math.max(
       baselineEntry.avgMs * avgMultiplier,
       baselineEntry.avgMs + avgAbsoluteFloorMs,
-    ))
+    ) + jitterAllowanceMs)
     const p95Limit = round(Math.max(
       baselineEntry.p95Ms * p95Multiplier,
       baselineEntry.p95Ms + p95AbsoluteFloorMs,
-    ))
+    ) + jitterAllowanceMs)
 
     if (currentEntry.avgMs > avgLimit) {
       failures.push(`${currentEntry.name} avg ${currentEntry.avgMs} ms exceeds baseline limit ${avgLimit} ms`)

--- a/scripts/perf/thresholds.ts
+++ b/scripts/perf/thresholds.ts
@@ -3,6 +3,7 @@ export const DEFAULT_THRESHOLDS = {
   p95Multiplier: 1.25,
   avgAbsoluteFloorMs: 0.5,
   p95AbsoluteFloorMs: 0.8,
+  jitterAllowanceMs: 0.05,
 }
 
 export const CROSS_ENVIRONMENT_FLOORS = {

--- a/scripts/perf/types.ts
+++ b/scripts/perf/types.ts
@@ -21,6 +21,7 @@ export type BenchmarkReport = {
     p95Multiplier: number
     avgAbsoluteFloorMs: number
     p95AbsoluteFloorMs: number
+    jitterAllowanceMs?: number
   }
   benchmarks: BenchmarkResult[]
 }

--- a/scripts/smoke-deployment.mjs
+++ b/scripts/smoke-deployment.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+const args = new Map()
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index]
+  if (arg === '--') {
+    continue
+  }
+  if (!arg.startsWith('--')) {
+    continue
+  }
+  const key = arg.slice(2)
+  const next = process.argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    args.set(key, 'true')
+  } else {
+    args.set(key, next)
+    index += 1
+  }
+}
+
+const cloudUrl = normalizeUrl(args.get('cloud-url') ?? process.env.OPEN_COWORK_SMOKE_CLOUD_URL ?? 'http://127.0.0.1:8787')
+const gatewayUrl = normalizeUrl(args.get('gateway-url') ?? process.env.OPEN_COWORK_SMOKE_GATEWAY_URL ?? 'http://127.0.0.1:8790')
+const cloudToken = args.get('cloud-token') ?? process.env.OPEN_COWORK_SMOKE_CLOUD_TOKEN ?? ''
+const gatewayAdminToken =
+  args.get('gateway-admin-token') ?? process.env.OPEN_COWORK_SMOKE_GATEWAY_ADMIN_TOKEN ?? ''
+const skipCloud = args.has('skip-cloud') || process.env.OPEN_COWORK_SMOKE_SKIP_CLOUD === 'true'
+const skipGateway = args.has('skip-gateway') || process.env.OPEN_COWORK_SMOKE_SKIP_GATEWAY === 'true'
+const includeOperatorChecks =
+  args.has('operator') || process.env.OPEN_COWORK_SMOKE_OPERATOR_CHECKS === 'true'
+
+function normalizeUrl(value) {
+  return value.replace(/\/+$/, '')
+}
+
+async function checkJson(url, options = {}) {
+  const response = await fetch(url, {
+    headers: options.token ? { Authorization: `Bearer ${options.token}` } : undefined,
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}: ${text.slice(0, 400)}`)
+  }
+  try {
+    return text ? JSON.parse(text) : null
+  } catch {
+    return text
+  }
+}
+
+async function main() {
+  const results = []
+  if (!skipCloud) {
+    results.push({ check: 'cloud health', url: `${cloudUrl}/healthz`, result: await checkJson(`${cloudUrl}/healthz`) })
+    if (includeOperatorChecks) {
+      results.push({
+        check: 'cloud runtime status',
+        url: `${cloudUrl}/api/runtime/status`,
+        result: await checkJson(`${cloudUrl}/api/runtime/status`, { token: cloudToken }),
+      })
+      results.push({
+        check: 'cloud worker heartbeats',
+        url: `${cloudUrl}/api/workers/heartbeats`,
+        result: await checkJson(`${cloudUrl}/api/workers/heartbeats`, { token: cloudToken }),
+      })
+    }
+  }
+
+  if (!skipGateway) {
+    results.push({
+      check: 'gateway health',
+      url: `${gatewayUrl}/health`,
+      result: await checkJson(`${gatewayUrl}/health`),
+    })
+    results.push({
+      check: 'gateway readiness',
+      url: `${gatewayUrl}/ready`,
+      result: await checkJson(`${gatewayUrl}/ready`),
+    })
+    if (includeOperatorChecks && gatewayAdminToken) {
+      results.push({
+        check: 'gateway metrics',
+        url: `${gatewayUrl}/metrics`,
+        result: await checkJson(`${gatewayUrl}/metrics`, { token: gatewayAdminToken }),
+      })
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify({ ok: true, results }, null, 2)}\n`)
+}
+
+main().catch((error) => {
+  process.stderr.write(`[deploy-smoke] ${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+})

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from 'node:child_process'
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const requireTools =
+  process.argv.includes('--require-tools') || process.env.OPEN_COWORK_DEPLOY_REQUIRE_TOOLS === 'true'
+
+const composeFiles = [
+  'docker-compose.cloud.yml',
+  'docker-compose.cloud.split.yml',
+  'docker-compose.cloud-gateway.yml',
+]
+
+function log(message) {
+  process.stdout.write(`[deploy-validate] ${message}\n`)
+}
+
+function commandExists(command, args = ['--version']) {
+  const result = spawnSync(command, args, { stdio: 'ignore' })
+  return result.status === 0
+}
+
+function run(command, args, options = {}) {
+  log(`${command} ${args.join(' ')}`)
+  execFileSync(command, args, { stdio: 'inherit', ...options })
+}
+
+function expectFailure(command, args, expectedText, options = {}) {
+  log(`expect failure: ${command} ${args.join(' ')}`)
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options })
+  if (result.status === 0) {
+    throw new Error(`Expected command to fail: ${command} ${args.join(' ')}`)
+  }
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+  if (!output.includes(expectedText)) {
+    throw new Error(`Expected failure to include "${expectedText}". Output:\n${output}`)
+  }
+}
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function assertIncludes(path, text) {
+  const contents = read(path)
+  if (!contents.includes(text)) {
+    throw new Error(`${path} must include ${text}`)
+  }
+}
+
+function staticComposeChecks() {
+  for (const file of composeFiles) {
+    assertIncludes(file, 'services:')
+    assertIncludes(file, 'postgres:')
+  }
+  assertIncludes('docker-compose.cloud.yml', 'minio:')
+  assertIncludes('docker-compose.cloud.split.yml', 'open-cowork-cloud-web:')
+  assertIncludes('docker-compose.cloud.split.yml', 'open-cowork-cloud-worker:')
+  assertIncludes('docker-compose.cloud.split.yml', 'open-cowork-cloud-scheduler:')
+  assertIncludes('docker-compose.cloud-gateway.yml', 'open-cowork-gateway:')
+  assertIncludes('docker-compose.cloud-gateway.yml', 'OPEN_COWORK_GATEWAY_ENABLE_FAKE_PROVIDER')
+}
+
+function validateCompose() {
+  staticComposeChecks()
+  if (!commandExists('docker')) {
+    if (requireTools) {
+      throw new Error('docker is required for deployment validation')
+    }
+    log('docker not found; static Compose checks passed')
+    return
+  }
+
+  const composeAvailable = spawnSync('docker', ['compose', 'version'], { stdio: 'ignore' }).status === 0
+  if (!composeAvailable) {
+    if (requireTools) {
+      throw new Error('docker compose is required for deployment validation')
+    }
+    log('docker compose not found; static Compose checks passed')
+    return
+  }
+
+  for (const file of composeFiles) {
+    run('docker', ['compose', '-f', file, 'config', '--quiet'])
+  }
+}
+
+function staticHelmChecks() {
+  assertIncludes('helm/open-cowork-cloud/templates/deployment.yaml', 'cloud.auth.mode=none requires explicit cloud.allowInsecureAuth=true')
+  assertIncludes('helm/open-cowork-cloud/templates/deployment.yaml', 'cloud.auth.mode=none with public service or ingress requires explicit cloud.allowInsecurePublicAuth=true')
+  assertIncludes('helm/open-cowork-gateway/templates/deployment.yaml', 'gateway.serviceToken or gateway.existingSecret is required')
+  assertIncludes('helm/open-cowork-gateway/templates/deployment.yaml', 'gateway.webhook.sharedSecret or gateway.existingSecret is required')
+  assertIncludes('helm/open-cowork-gateway/templates/deployment.yaml', 'gateway.adminToken or gateway.existingSecret is required when gateway metrics are enabled on a public bind')
+}
+
+function validateHelm() {
+  staticHelmChecks()
+  if (!commandExists('helm', ['version', '--short'])) {
+    if (requireTools) {
+      throw new Error('helm is required for deployment validation')
+    }
+    log('helm not found; static Helm guard checks passed')
+    return
+  }
+
+  const tempRoot = mkdtempSync(join(tmpdir(), 'open-cowork-deploy-helm-'))
+  try {
+    cpSync('helm', join(tempRoot, 'helm'), { recursive: true })
+    const cloudChart = join(tempRoot, 'helm/open-cowork-cloud')
+    const gatewayChart = join(tempRoot, 'helm/open-cowork-gateway')
+
+    run('helm', ['dependency', 'build', cloudChart])
+    run('helm', [
+      'lint',
+      cloudChart,
+      '--set',
+      'cloud.auth.mode=oidc',
+      '--set',
+      'cloud.auth.oidcIssuerUrl=https://issuer.example.com',
+      '--set',
+      'cloud.auth.oidcClientId=open-cowork-cloud-ci',
+    ])
+    run('helm', [
+      'template',
+      'open-cowork-cloud',
+      cloudChart,
+      '--set',
+      'image.repository=example.com/open-cowork-cloud',
+      '--set',
+      'image.tag=ci',
+      '--set',
+      'cloud.auth.mode=oidc',
+      '--set',
+      'cloud.auth.oidcIssuerUrl=https://issuer.example.com',
+      '--set',
+      'cloud.auth.oidcClientId=open-cowork-cloud-ci',
+      '--set',
+      'cloud.controlPlaneUrl=postgres://postgres:postgres@postgres:5432/open_cowork_cloud',
+      '--set',
+      'cloud.secretKey=ci-secret-key',
+      '--set',
+      'cloud.cookieSecret=ci-cookie-secret',
+      '--set',
+      'cloud.objectStore.kind=s3',
+      '--set',
+      'cloud.objectStore.bucket=open-cowork-ci',
+    ])
+    expectFailure(
+      'helm',
+      [
+        'template',
+        'unsafe-public-cloud',
+        cloudChart,
+        '--set',
+        'cloud.auth.mode=none',
+        '--set',
+        'cloud.allowInsecureAuth=true',
+        '--set',
+        'ingress.enabled=true',
+      ],
+      'cloud.auth.mode=none with public service or ingress requires explicit cloud.allowInsecurePublicAuth=true'
+    )
+
+    run('helm', [
+      'lint',
+      gatewayChart,
+      '--set',
+      'gateway.cloudBaseUrl=https://cloud.example.com',
+      '--set',
+      'gateway.serviceToken=ci-gateway-token',
+      '--set',
+      'gateway.telegram.botToken=ci-telegram-token',
+    ])
+    run('helm', [
+      'template',
+      'open-cowork-gateway',
+      gatewayChart,
+      '--set',
+      'image.repository=example.com/open-cowork-gateway',
+      '--set',
+      'image.tag=ci',
+      '--set',
+      'gateway.cloudBaseUrl=https://cloud.example.com',
+      '--set',
+      'gateway.serviceToken=ci-gateway-token',
+      '--set',
+      'gateway.telegram.botToken=ci-telegram-token',
+    ])
+    expectFailure(
+      'helm',
+      [
+        'template',
+        'unsafe-webhook-gateway',
+        gatewayChart,
+        '--set',
+        'gateway.cloudBaseUrl=https://cloud.example.com',
+        '--set',
+        'gateway.serviceToken=ci-gateway-token',
+        '--set',
+        'gateway.webhook.deliveryUrl=https://bridge.example.com/inbound',
+      ],
+      'gateway.webhook.sharedSecret or gateway.existingSecret is required'
+    )
+    expectFailure(
+      'helm',
+      [
+        'template',
+        'unsafe-metrics-gateway',
+        gatewayChart,
+        '--set',
+        'gateway.cloudBaseUrl=https://cloud.example.com',
+        '--set',
+        'gateway.serviceToken=ci-gateway-token',
+        '--set',
+        'gateway.telegram.botToken=ci-telegram-token',
+        '--set',
+        'gateway.metrics.enabled=true',
+      ],
+      'gateway.adminToken or gateway.existingSecret is required when gateway metrics are enabled on a public bind'
+    )
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+function validateDocs() {
+  const requiredDocs = [
+    'docs/deployment-readiness.md',
+    'docs/runbooks/managed-byok-saas.md',
+    'deploy/README.md',
+    'deploy/gcp/README.md',
+    'deploy/aws/README.md',
+    'deploy/azure/README.md',
+    'deploy/digitalocean/README.md',
+  ]
+  for (const path of requiredDocs) {
+    if (!existsSync(path)) {
+      throw new Error(`${path} is required`)
+    }
+  }
+
+  const readiness = read('docs/deployment-readiness.md').toLowerCase()
+  for (const phrase of [
+    'auth',
+    'cookie secret',
+    'postgres',
+    'object store',
+    'secret adapter/kms',
+    'public url/https',
+    'worker/scheduler scaling',
+    'gateway service token',
+    'provider webhook signing',
+    'quotas/rate limits',
+    'otlp/logging',
+    'backups/restore',
+    'no billing provider or the stub billing provider',
+  ]) {
+    if (!readiness.includes(phrase)) {
+      throw new Error(`docs/deployment-readiness.md must include ${phrase}`)
+    }
+  }
+
+  const byok = read('docs/runbooks/managed-byok-saas.md').toLowerCase()
+  for (const phrase of [
+    'org signup mode',
+    'token ttl',
+    'invite/domain controls',
+    'billing setup',
+    'byok validation',
+    'gateway operations',
+    'incident response',
+  ]) {
+    if (!byok.includes(phrase)) {
+      throw new Error(`docs/runbooks/managed-byok-saas.md must include ${phrase}`)
+    }
+  }
+}
+
+validateCompose()
+validateHelm()
+validateDocs()
+log('deployment configuration validation passed')

--- a/tests/cloud-deployment-artifacts.test.ts
+++ b/tests/cloud-deployment-artifacts.test.ts
@@ -92,6 +92,10 @@ test('cloud deployment docs cover provider-neutral split deployment', () => {
   assert.match(docs, /OPEN_COWORK_GATEWAY_DIAGNOSTICS_ENABLED/)
   assert.match(docs, /helm\/open-cowork-gateway/)
   assert.match(docs, /cloud-managed-operations\.md/)
+  assert.match(docs, /deployment-readiness\.md/)
+  assert.match(docs, /runbooks\/managed-byok-saas\.md/)
+  assert.match(docs, /pnpm deploy:validate/)
+  assert.match(docs, /pnpm deploy:smoke/)
 })
 
 test('cloud Helm chart keeps provider-neutral role wiring explicit', () => {
@@ -276,12 +280,17 @@ test('cloud provider recipes stay thin compositions of the shared image and adap
   assert.match(index, /open-cowork-gateway/)
   assert.match(index, /Postgres/)
   assert.match(index, /OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED=true/)
+  assert.match(index, /no billing/)
+  assert.match(index, /stub billing provider/)
+  assert.match(index, /pnpm deploy:validate/)
+  assert.match(index, /pnpm deploy:smoke/)
+  assert.match(index, /Provider recipes/)
 
   const recipes = {
-    gcp: ['Cloud SQL for PostgreSQL', 'Cloud Storage', 'Secret Manager', 'GKE', 'open-cowork-gateway'],
-    aws: ['RDS for PostgreSQL', 'S3', 'Secrets Manager', 'EKS', 'open-cowork-gateway'],
-    azure: ['Azure Database for PostgreSQL', 'Azure Blob Storage', 'Key Vault', 'AKS', 'open-cowork-gateway'],
-    digitalocean: ['Managed PostgreSQL', 'Spaces', 'DOKS', 'App Platform', 'open-cowork-gateway'],
+    gcp: ['Cloud SQL for PostgreSQL', 'Cloud Storage', 'Secret Manager', 'GKE', 'open-cowork-gateway', 'Cloud Logging', 'Cloud SQL PITR'],
+    aws: ['RDS for PostgreSQL', 'S3', 'Secrets Manager', 'EKS', 'open-cowork-gateway', 'CloudWatch Logs', 'RDS PITR'],
+    azure: ['Azure Database for PostgreSQL', 'Azure Blob Storage', 'Key Vault', 'AKS', 'open-cowork-gateway', 'Azure Monitor', 'Azure PostgreSQL PITR'],
+    digitalocean: ['Managed PostgreSQL', 'Spaces', 'DOKS', 'App Platform', 'open-cowork-gateway', 'App Platform logs', 'Managed PostgreSQL backups'],
   }
 
   for (const [provider, expected] of Object.entries(recipes)) {
@@ -291,10 +300,87 @@ test('cloud provider recipes stay thin compositions of the shared image and adap
     assert.match(readme, /helm upgrade --install open-cowork-cloud/)
     assert.match(readme, /helm upgrade --install open-cowork-gateway/)
     assert.match(readme, /gateway.existingSecret=open-cowork-gateway-secrets/)
+    assert.match(readme, /OPEN_COWORK_CLOUD_PUBLIC_URL/)
+    assert.match(readme, /OPEN_COWORK_GATEWAY_PUBLIC_URL/)
+    assert.match(readme, /provider webhook signing secrets/)
+    assert.match(readme, /billing disabled\/stubbed/)
+    assert.match(readme, /pnpm deploy:smoke/)
+    assert.match(readme, /adapter wiring only/)
     for (const phrase of expected) {
       assert.match(readme, new RegExp(phrase))
     }
   }
+})
+
+test('deployment readiness checklist and managed BYOK runbook cover production gates', () => {
+  const readiness = readRepoFile('docs/deployment-readiness.md')
+  for (const phrase of [
+    'Required Topology',
+    'Auth',
+    'cookie secret',
+    'Postgres',
+    'object store',
+    'secret adapter/KMS',
+    'public URL/HTTPS',
+    'worker/scheduler scaling',
+    'gateway service token',
+    'provider webhook signing',
+    'quotas/rate limits',
+    'OTLP/logging',
+    'backups/restore',
+    'no billing provider or the stub billing provider',
+    'pnpm deploy:validate',
+    'pnpm deploy:smoke',
+    'Provider Recipe Contract',
+  ]) {
+    assert.match(readiness, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'))
+  }
+
+  const byok = readRepoFile('docs/runbooks/managed-byok-saas.md')
+  for (const phrase of [
+    'org signup mode',
+    'token TTL',
+    'invite/domain controls',
+    'billing setup',
+    'BYOK validation',
+    'gateway operations',
+    'incident response',
+    'no billing provider',
+    'Launch Gates',
+  ]) {
+    assert.match(byok, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'))
+  }
+
+  const mkdocs = readRepoFile('mkdocs.yml')
+  assert.match(mkdocs, /Deployment Readiness: deployment-readiness\.md/)
+  assert.match(mkdocs, /Managed BYOK SaaS: runbooks\/managed-byok-saas\.md/)
+})
+
+test('deployment validation and smoke scripts cover compose, helm, cloud, and gateway checks', () => {
+  const packageJson = readRepoFile('package.json')
+  const scriptsReadme = readRepoFile('scripts/README.md')
+  const validate = readRepoFile('scripts/validate-deployment-configs.mjs')
+  const smoke = readRepoFile('scripts/smoke-deployment.mjs')
+
+  assert.match(packageJson, /"deploy:validate": "node scripts\/validate-deployment-configs\.mjs"/)
+  assert.match(packageJson, /"deploy:smoke": "node scripts\/smoke-deployment\.mjs"/)
+  assert.match(scriptsReadme, /pnpm deploy:validate/)
+  assert.match(scriptsReadme, /pnpm deploy:smoke/)
+  assert.match(validate, /docker-compose\.cloud\.yml/)
+  assert.match(validate, /docker-compose\.cloud\.split\.yml/)
+  assert.match(validate, /docker-compose\.cloud-gateway\.yml/)
+  assert.match(validate, /helm\/open-cowork-cloud/)
+  assert.match(validate, /helm\/open-cowork-gateway/)
+  assert.match(validate, /unsafe-public-cloud/)
+  assert.match(validate, /unsafe-webhook-gateway/)
+  assert.match(validate, /unsafe-metrics-gateway/)
+  assert.match(smoke, /OPEN_COWORK_SMOKE_CLOUD_URL/)
+  assert.match(smoke, /OPEN_COWORK_SMOKE_GATEWAY_URL/)
+  assert.match(smoke, /\/healthz/)
+  assert.match(smoke, /\/api\/runtime\/status/)
+  assert.match(smoke, /\/api\/workers\/heartbeats/)
+  assert.match(smoke, /\/health/)
+  assert.match(smoke, /\/ready/)
 })
 
 test('managed operations runbook covers readiness, rollback, diagnostics, and gateway backlog', () => {
@@ -341,6 +427,7 @@ test('CI enforces cloud portability, concurrency, and deployment gates', () => {
   assert.match(workflow, /OPEN_COWORK_GATEWAY_SERVICE_TOKEN/)
   assert.match(workflow, /helm lint helm\/open-cowork-gateway/)
   assert.match(workflow, /helm template open-cowork-gateway helm\/open-cowork-gateway/)
+  assert.match(workflow, /pnpm deploy:validate -- --require-tools/)
 
   const smoke = readRepoFile('scripts/ci-cloud-compose-smoke.sh')
   assert.match(smoke, /docker compose -p "\$\{project_name\}" -f "\$\{compose_file\}" up --build -d/)

--- a/tests/perf-compare.test.ts
+++ b/tests/perf-compare.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { compareReports } from '../scripts/perf/compare.ts'
+import type { BenchmarkReport } from '../scripts/perf/types.ts'
+
+function makeReport(avgMs: number, p95Ms: number): BenchmarkReport {
+  return {
+    generatedAt: '2026-05-29T00:00:00.000Z',
+    environment: {
+      platform: 'linux',
+      arch: 'x64',
+      node: 'v22.12.0',
+    },
+    suiteRuns: 5,
+    regressionThresholds: {
+      avgMultiplier: 1.2,
+      p95Multiplier: 1.25,
+      avgAbsoluteFloorMs: 0.5,
+      p95AbsoluteFloorMs: 0.8,
+      jitterAllowanceMs: 0.05,
+    },
+    benchmarks: [
+      {
+        name: 'engine.stream.mixed',
+        iterations: 20,
+        minMs: avgMs,
+        maxMs: p95Ms,
+        avgMs,
+        p50Ms: avgMs,
+        p95Ms,
+      },
+    ],
+  }
+}
+
+test('compareReports tolerates tiny hosted-runner timer jitter', () => {
+  const baseline = makeReport(1.5, 0.94)
+  const current = makeReport(2.04, 1.79)
+
+  assert.deepEqual(compareReports(current, baseline), [])
+})
+
+test('compareReports still fails material regressions beyond jitter allowance', () => {
+  const baseline = makeReport(1.5, 0.94)
+  const current = makeReport(2.06, 1.81)
+
+  assert.deepEqual(compareReports(current, baseline), [
+    'engine.stream.mixed avg 2.06 ms exceeds baseline limit 2.05 ms',
+    'engine.stream.mixed p95 1.81 ms exceeds baseline limit 1.79 ms',
+  ])
+})


### PR DESCRIPTION
## Summary

Closes #463.

- Adds a production deployment readiness checklist for Cloud + Gateway self-host and managed deployments.
- Adds a managed BYOK SaaS runbook covering org signup mode, token TTLs, invite/domain controls, billing setup, BYOK validation, gateway operations, and incident response.
- Adds provider-neutral deployment validation and smoke scripts, package commands, CI coverage, and docs/tests pinning provider recipes to adapter-only deployment wiring.
- Expands GCP, AWS, Azure, and DigitalOcean recipes with production inputs for public URLs, secrets, billing/stub mode, observability, backups, provider signing, and post-rollout smoke checks.

## Verification

- `pnpm deploy:validate`
- `node scripts/smoke-deployment.mjs -- --skip-cloud --skip-gateway`
- `node --no-warnings --experimental-strip-types --test tests/cloud-deployment-artifacts.test.ts`
- `node --no-warnings --experimental-strip-types --test tests/package-scripts.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `git diff --check`
- docs build via isolated temp venv: `python3 -m venv ... && pip install -r docs/requirements.txt && mkdocs build --strict`

Note: local `helm` is not installed, so `pnpm deploy:validate` used static Helm guard checks locally. CI runs the same validator with `--require-tools` after installing Helm.