### PR TITLE
Harden cloud and gateway security gates

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -196,6 +196,8 @@ export function resolveCloudAuthConfig(config: OpenCoworkConfig, env: Env = proc
   const mode = requestedMode === 'oidc' || requestedMode === 'header' || requestedMode === 'none'
     ? requestedMode
     : config.cloud.auth.mode
+  const requestedSelfService = envValue(env, 'OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP')
+  const envSwitchedToOidc = mode === 'oidc' && requestedMode === 'oidc' && config.cloud.auth.mode !== 'oidc'
   return {
     ...config.cloud.auth,
     mode,
@@ -208,9 +210,11 @@ export function resolveCloudAuthConfig(config: OpenCoworkConfig, env: Env = proc
     callbackPath: envValue(env, 'OPEN_COWORK_CLOUD_OIDC_CALLBACK_PATH') || config.cloud.auth.callbackPath,
     cookieSecretRef: envValue(env, 'OPEN_COWORK_CLOUD_COOKIE_SECRET_REF') || config.cloud.auth.cookieSecretRef,
     allowedEmailDomains: parseCsv(envValue(env, 'OPEN_COWORK_CLOUD_ALLOWED_EMAIL_DOMAINS')) || config.cloud.auth.allowedEmailDomains,
-    allowSelfServiceSignup: envValue(env, 'OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP')
-      ? parseBoolean(envValue(env, 'OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP'), false)
-      : config.cloud.auth.allowSelfServiceSignup ?? mode !== 'oidc',
+    allowSelfServiceSignup: requestedSelfService
+      ? parseBoolean(requestedSelfService, false)
+      : envSwitchedToOidc
+        ? false
+        : config.cloud.auth.allowSelfServiceSignup ?? mode !== 'oidc',
   }
 }
 

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -663,15 +663,20 @@ export class CloudSessionService {
   }
 
   async ensurePrincipal(principal: CloudPrincipal) {
+    const existingMembership = await this.store.resolvePrincipalMembership({
+      tenantId: principal.tenantId,
+      accountId: principal.accountId || principal.userId,
+      idpSubject: principal.userId,
+      email: principal.email,
+    })
+    if (principal.authSource === 'user' && !this.identityPolicy.allowSelfServiceSignup) {
+      if (!existingMembership || existingMembership.membership.status !== 'active') {
+        throw new CloudServiceError(403, 'Cloud membership is not active.')
+      }
+    }
     await this.store.createTenant({
       tenantId: principal.tenantId,
       name: principal.tenantName || principal.tenantId,
-    })
-    const user = await this.store.ensureUser({
-      tenantId: principal.tenantId,
-      userId: principal.userId,
-      email: principal.email,
-      role: principal.role || 'member',
     })
     const org = await this.store.ensureOrgForTenant({
       tenantId: principal.tenantId,
@@ -682,6 +687,13 @@ export class CloudSessionService {
       accountId: principal.accountId || principal.userId,
       idpSubject: principal.userId,
       email: principal.email,
+    })
+    const role = existingMembership?.membership.role || principal.role || 'member'
+    const user = await this.store.ensureUser({
+      tenantId: principal.tenantId,
+      userId: principal.userId,
+      email: principal.email,
+      role,
     })
     const membership = await this.store.resolvePrincipalMembership({
       tenantId: principal.tenantId,
@@ -700,7 +712,7 @@ export class CloudSessionService {
         actor: { actorType: 'system', actorId: 'principal.bootstrap' },
       })
     } else if (membership.membership.status !== 'active') {
-      throw new Error('Cloud membership is not active.')
+      throw new CloudServiceError(403, 'Cloud membership is not active.')
     }
   }
 
@@ -1484,6 +1496,26 @@ export class CloudSessionService {
       command,
     })
     if (!resolved) throw new CloudServiceError(409, 'Channel interaction was already resolved.')
+    await this.store.recordAuditEvent({
+      orgId: this.principalOrgId(principal),
+      accountId: actor.accountId,
+      actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+      actorId: principal.tokenId || principal.userId,
+      eventType: resolved.command.kind === 'permission.respond'
+        ? 'channel_interaction.permission.responded'
+        : resolved.command.kind === 'question.reject'
+          ? 'channel_interaction.question.rejected'
+          : 'channel_interaction.question.replied',
+      targetType: 'channel_interaction',
+      targetId: resolved.interaction.interactionId,
+      metadata: {
+        identityId: actor.identityId,
+        provider: actor.provider,
+        sessionId: resolved.interaction.sessionId,
+        targetId: resolved.interaction.targetId,
+        commandId: resolved.command.commandId,
+      },
+    })
     return resolved
   }
 

--- a/apps/gateway/src/event-renderer.test.ts
+++ b/apps/gateway/src/event-renderer.test.ts
@@ -229,7 +229,7 @@ test('event renderer keeps tool progress compact and redacts failure details', a
         id: 'tool-1',
         name: 'bash',
         status: 'error',
-        error: 'failed with token=super-secret-token',
+        error: 'failed in /Users/alice/acme-private with token=super-secret-token',
       },
     },
   })
@@ -244,7 +244,7 @@ test('event renderer keeps tool progress compact and redacts failure details', a
     messageId: undefined,
   }, {
     kind: 'edit',
-    text: 'Tool failed: bash\nfailed with token=[redacted]',
+    text: 'Tool failed: bash\nfailed in /Users/[redacted] with token=[redacted]',
     messageId: '1',
   }])
 })

--- a/apps/gateway/src/provider-registry.ts
+++ b/apps/gateway/src/provider-registry.ts
@@ -111,7 +111,7 @@ export function createGatewayProviderRegistry(config: GatewayConfig): GatewayPro
       if (registration.config.kind === 'webhook') {
         await (registration.provider as WebhookProvider).handleWebhookPayload(payload, {
           headers,
-          sharedSecret: registration.config.credentials.sharedSecret || null,
+          rawBody,
         })
         return
       }

--- a/apps/gateway/src/render/sanitize.ts
+++ b/apps/gateway/src/render/sanitize.ts
@@ -4,6 +4,12 @@ const secretPatterns = [
   /(sk-[A-Za-z0-9_-]{12,})/g,
 ]
 
+const localPathPatterns = [
+  /\/Users\/[^\s"'`:]+/g,
+  /\/home\/[^\s"'`:]+/g,
+  /[A-Z]:\\Users\\[^\s"'`:]+/gi,
+]
+
 export function sanitizeChannelText(value: string, maxLength = 512): string {
   let sanitized = value
   for (const pattern of secretPatterns) {
@@ -11,6 +17,12 @@ export function sanitizeChannelText(value: string, maxLength = 512): string {
       return left && /api|token|secret|password|credential/i.test(left)
         ? `${left}=[redacted]`
         : '[redacted]'
+    })
+  }
+  for (const pattern of localPathPatterns) {
+    sanitized = sanitized.replace(pattern, (match) => {
+      const prefix = match.match(/^(\/Users|\/home|[A-Z]:\\Users)/i)?.[0] || '[home]'
+      return `${prefix}/[redacted]`
     })
   }
   sanitized = sanitized

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -109,9 +109,13 @@ roles and shared Postgres/object storage.
 
 ### Provider Webhook Signing
 
-- Public webhook providers require provider signing secrets or shared secrets.
+- Public webhook providers require provider signing secrets or timestamped
+  HMAC signatures.
 - Slack uses its signing secret, email uses an inbound shared secret, and the
-  generic webhook provider uses `OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET`.
+  generic webhook provider signs the raw body with
+  `OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET` using
+  `x-open-cowork-gateway-webhook-timestamp` and
+  `x-open-cowork-gateway-webhook-signature`.
 - The fake provider is local/demo-only and must not be exposed publicly.
 - Gateway metrics and diagnostics on `0.0.0.0` require an admin token or
   private networking.

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -459,7 +459,7 @@ Gateway variables:
 | `OPEN_COWORK_GATEWAY_EMAIL_SMTP_HOST` / `OPEN_COWORK_GATEWAY_EMAIL_SMTP_PORT` / `OPEN_COWORK_GATEWAY_EMAIL_SMTP_SECURE` | SMTP transport settings for email replies. |
 | `OPEN_COWORK_GATEWAY_EMAIL_SMTP_USERNAME` / `OPEN_COWORK_GATEWAY_EMAIL_SMTP_PASSWORD` | Optional SMTP auth credentials. |
 | `OPEN_COWORK_GATEWAY_WEBHOOK_DELIVERY_URL` | Outbound URL for the generic webhook provider. |
-| `OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET` | Required shared secret for generic webhook ingress and outbound bridge signing. |
+| `OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET` | Required shared secret for generic webhook ingress HMAC signatures and outbound bridge authentication. Inbound generic webhook requests include `x-open-cowork-gateway-webhook-timestamp` and `x-open-cowork-gateway-webhook-signature` over the raw body. |
 
 Hosted/public deployments should keep abuse controls enabled. The defaults are
 conservative and can be tuned per deployment; set an individual numeric quota

--- a/packages/gateway-provider-webhook/src/webhook-provider.test.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.test.ts
@@ -1,8 +1,24 @@
 import { describe, it } from "node:test";
 import { expect } from "../../../tests/gateway-test-expect.ts";
-import { mapWebhookPayload, validateWebhookButtons, WebhookProvider } from "@open-cowork/gateway-provider-webhook";
+import {
+  mapWebhookPayload,
+  signWebhookIngressPayload,
+  validateWebhookButtons,
+  WebhookProvider
+} from "@open-cowork/gateway-provider-webhook";
 
 describe("WebhookProvider", () => {
+  function signedAuth(payload: unknown, sharedSecret = "secret", timestamp = "1772280000") {
+    const rawBody = JSON.stringify(payload);
+    return {
+      rawBody,
+      headers: {
+        "x-open-cowork-gateway-webhook-timestamp": timestamp,
+        "x-open-cowork-gateway-webhook-signature": signWebhookIngressPayload(rawBody, sharedSecret, timestamp)
+      }
+    };
+  }
+
   it("advertises only the attachment capabilities implemented by the generic bridge", () => {
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway"
@@ -442,30 +458,29 @@ describe("WebhookProvider", () => {
     const seen: string[] = [];
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
-      sharedSecret: "secret"
+      sharedSecret: "secret",
+      now: () => new Date("2026-02-28T12:00:00.000Z")
     });
     await provider.start(async (message) => {
       seen.push(message.text);
     });
-    await provider.handleWebhookPayload({
+    const payload = {
       target: { chatId: "team-chat" },
       sender: { userId: "alice" },
       text: "hello"
-    }, {
-      headers: {
-        "x-open-cowork-gateway-webhook-secret": "secret"
-      }
-    });
+    };
+    await provider.handleWebhookPayload(payload, signedAuth(payload));
     await provider.stop();
 
     expect(seen).toEqual(["hello"]);
   });
 
-  it("requires the configured ingress shared secret before dispatch", async () => {
+  it("requires signed timestamp ingress before dispatch", async () => {
     const seen: string[] = [];
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
-      sharedSecret: "secret"
+      sharedSecret: "secret",
+      now: () => new Date("2026-02-28T12:00:00.000Z")
     });
     await provider.start(async (message) => {
       seen.push(message.text);
@@ -477,16 +492,45 @@ describe("WebhookProvider", () => {
       text: "hello"
     };
     await expect(provider.handleWebhookPayload(payload, {})).rejects.toThrow(
-      "Webhook shared secret verification failed",
+      "Webhook timestamp signature is required for ingress",
     );
-    await expect(provider.handleWebhookPayload(payload, { sharedSecret: "wrong" })).rejects.toThrow(
-      "Webhook shared secret verification failed",
+    await expect(provider.handleWebhookPayload(payload, {
+      ...signedAuth(payload, "wrong"),
+    })).rejects.toThrow(
+      "Webhook signature verification failed",
     );
-    await provider.handleWebhookPayload(payload, {
-      headers: new Headers({ "x-open-cowork-gateway-webhook-secret": "secret" })
-    });
+    await provider.handleWebhookPayload(payload, signedAuth(payload));
 
     expect(seen).toEqual(["hello"]);
+    await provider.stop();
+  });
+
+  it("rejects stale or replayed signed ingress payloads", async () => {
+    const payload = {
+      target: { chatId: "team-chat" },
+      sender: { userId: "alice" },
+      text: "hello"
+    };
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      sharedSecret: "secret",
+      now: () => new Date("2026-02-28T12:00:00.000Z")
+    });
+    const seen: string[] = [];
+    await provider.start(async (message) => {
+      seen.push(message.id);
+    });
+
+    await expect(provider.handleWebhookPayload(payload, signedAuth(payload, "secret", "1772279000"))).rejects.toThrow(
+      "Webhook timestamp is outside the allowed window",
+    );
+
+    const auth = signedAuth(payload);
+    await provider.handleWebhookPayload(payload, auth);
+    await expect(provider.handleWebhookPayload(payload, auth)).rejects.toThrow(
+      "Webhook signature replay rejected",
+    );
+    expect(seen).toHaveLength(1);
     await provider.stop();
   });
 
@@ -630,6 +674,7 @@ describe("WebhookProvider", () => {
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
       sharedSecret: "secret",
+      now: () => new Date("2026-02-28T12:00:00.000Z"),
       maxAttachmentBytes: 4
     });
     const seen: string[] = [];
@@ -637,7 +682,7 @@ describe("WebhookProvider", () => {
       seen.push(message.id);
     });
 
-    await expect(provider.handleWebhookPayload({
+    const payload = {
       target: { chatId: "team-chat" },
       sender: { userId: "alice" },
       text: "see attached",
@@ -648,7 +693,8 @@ describe("WebhookProvider", () => {
           bufferBase64: Buffer.from("12345").toString("base64")
         }
       ]
-    }, { sharedSecret: "secret" })).rejects.toThrow("Webhook attachment exceeds max size of 4 bytes");
+    };
+    await expect(provider.handleWebhookPayload(payload, signedAuth(payload))).rejects.toThrow("Webhook attachment exceeds max size of 4 bytes");
     expect(seen).toEqual([]);
 
     await provider.stop();

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -1,4 +1,4 @@
-import { randomUUID, timingSafeEqual } from "node:crypto";
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import type {
   ChannelAttachment,
   ChannelButton,
@@ -16,6 +16,7 @@ export interface WebhookProviderConfig {
   providerId?: ChannelProviderId;
   deliveryUrl: string;
   sharedSecret?: string;
+  maxSignatureAgeMs?: number;
   maxAttachmentBytes?: number;
   fetch?: typeof globalThis.fetch;
   now?: () => Date;
@@ -59,11 +60,12 @@ export interface WebhookIncomingAttachment {
 
 export interface WebhookIngressAuth {
   headers?: Headers | Record<string, string | string[] | undefined>;
-  sharedSecret?: string | null;
+  rawBody?: string;
   verified?: boolean;
 }
 
 const maxWebhookAttachments = 20;
+const defaultMaxSignatureAgeMs = 5 * 60 * 1000;
 
 export interface MapWebhookPayloadOptions {
   maxAttachmentBytes?: number;
@@ -89,6 +91,7 @@ export class WebhookProvider implements ChannelProvider {
   };
 
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
+  private readonly seenIngressSignatures = new Map<string, number>();
 
   constructor(private readonly config: WebhookProviderConfig) {
     validateWebhookDeliveryUrl(config.deliveryUrl);
@@ -224,12 +227,45 @@ export class WebhookProvider implements ChannelProvider {
       throw new Error("Webhook shared secret is required for ingress");
     }
 
-    const providedSecret =
-      auth.sharedSecret ?? headerValue(auth.headers, "x-open-cowork-gateway-webhook-secret");
-    if (!constantTimeStringEqual(providedSecret, expectedSecret)) {
-      throw new Error("Webhook shared secret verification failed");
+    const timestamp = headerValue(auth.headers, "x-open-cowork-gateway-webhook-timestamp");
+    const signature = headerValue(auth.headers, "x-open-cowork-gateway-webhook-signature");
+    const rawBody = auth.rawBody || "";
+    if (!timestamp || !signature || !rawBody) {
+      throw new Error("Webhook timestamp signature is required for ingress");
+    }
+    const timestampSeconds = Number(timestamp);
+    if (!Number.isFinite(timestampSeconds)) {
+      throw new Error("Webhook timestamp is invalid");
+    }
+    const nowMs = this.config.now?.().getTime() ?? Date.now();
+    const maxAgeMs = this.config.maxSignatureAgeMs ?? defaultMaxSignatureAgeMs;
+    const timestampMs = timestampSeconds * 1000;
+    if (Math.abs(nowMs - timestampMs) > maxAgeMs) {
+      throw new Error("Webhook timestamp is outside the allowed window");
+    }
+
+    const expectedSignature = signWebhookIngressPayload(rawBody, expectedSecret, timestamp);
+    if (!constantTimeStringEqual(signature, expectedSignature)) {
+      throw new Error("Webhook signature verification failed");
+    }
+    this.purgeSeenIngressSignatures(nowMs);
+    const replayKey = `${timestamp}:${signature}`;
+    const existingExpiresAt = this.seenIngressSignatures.get(replayKey);
+    if (existingExpiresAt && existingExpiresAt > nowMs) {
+      throw new Error("Webhook signature replay rejected");
+    }
+    this.seenIngressSignatures.set(replayKey, nowMs + maxAgeMs);
+  }
+
+  private purgeSeenIngressSignatures(nowMs: number): void {
+    for (const [key, expiresAt] of this.seenIngressSignatures) {
+      if (expiresAt <= nowMs) this.seenIngressSignatures.delete(key);
     }
   }
+}
+
+export function signWebhookIngressPayload(rawBody: string, sharedSecret: string, timestamp: string): string {
+  return `v1=${createHmac("sha256", sharedSecret).update(`v1:${timestamp}:${rawBody}`).digest("hex")}`;
 }
 
 export interface WebhookRetryOptions {

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -311,6 +311,29 @@ test('cloud auth config resolves OIDC deployment settings from env', () => {
   assert.equal(resolved.callbackPath, '/auth/oidc/callback')
   assert.equal(resolved.cookieSecretRef, 'env:COOKIE_SECRET')
   assert.deepEqual(resolved.allowedEmailDomains, ['example.test', 'example.org'])
+  assert.equal(resolved.allowSelfServiceSignup, false)
+})
+
+test('cloud auth config requires explicit self-service opt-in for managed OIDC signup', () => {
+  assert.equal(resolveCloudAuthConfig(DEFAULT_CONFIG, {
+    OPEN_COWORK_CLOUD_AUTH_MODE: 'oidc',
+  }).allowSelfServiceSignup, false)
+  assert.equal(resolveCloudAuthConfig(DEFAULT_CONFIG, {
+    OPEN_COWORK_CLOUD_AUTH_MODE: 'oidc',
+    OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP: 'true',
+  }).allowSelfServiceSignup, true)
+
+  const explicitConfig = {
+    ...DEFAULT_CONFIG,
+    cloud: {
+      ...DEFAULT_CONFIG.cloud,
+      auth: {
+        mode: 'oidc' as const,
+        allowSelfServiceSignup: true,
+      },
+    },
+  }
+  assert.equal(resolveCloudAuthConfig(explicitConfig, {}).allowSelfServiceSignup, true)
 })
 
 test('cloud auth config supports explicit trusted header mode', async () => {

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -28,6 +28,123 @@ test('cloud control plane keeps tenant/user/session state isolated', () => {
   assert.throws(() => store.listSessions('tenant-2', 'user-1'), /Unknown tenant/)
 })
 
+test('cloud control plane keeps product domains isolated by tenant and org', () => {
+  const store = seededStore()
+  const org1 = store.ensureOrgForTenant({ tenantId: 'tenant-1', orgId: 'tenant-1', name: 'Acme' })
+  store.createTenant({ tenantId: 'tenant-2', name: 'Other' })
+  store.ensureUser({ tenantId: 'tenant-2', userId: 'user-2', email: 'b@example.com', role: 'owner' })
+  const org2 = store.ensureOrgForTenant({ tenantId: 'tenant-2', orgId: 'tenant-2', name: 'Other' })
+
+  assert.equal(store.getSessionForTenant('tenant-2', 'session-1'), null)
+  assert.equal(store.getSession('tenant-2', 'user-2', 'session-1'), null)
+
+  store.createWorkflow({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-1',
+    draft: {
+      title: 'Daily revenue',
+      instructions: 'Summarize revenue.',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+    },
+  })
+  assert.equal(store.getWorkflow('tenant-2', 'user-2', 'workflow-1'), null)
+  assert.throws(() => store.listWorkflowRuns('tenant-2', 'workflow-1'), /Unknown workflow/)
+
+  const agent = store.createHeadlessAgent({
+    agentId: 'agent-1',
+    orgId: org1.orgId,
+    tenantId: 'tenant-1',
+    profileName: 'full',
+    name: 'Agent',
+  })
+  const channelBinding = store.createChannelBinding({
+    bindingId: 'telegram-binding',
+    orgId: org1.orgId,
+    agentId: agent.agentId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    displayName: 'Telegram',
+  })
+  const identity = store.upsertChannelIdentity({
+    identityId: 'identity-1',
+    orgId: org1.orgId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    externalUserId: 'alice',
+    role: 'member',
+    status: 'active',
+  })
+  const sessionBinding = store.bindChannelSession({
+    bindingId: 'channel-session-1',
+    orgId: org1.orgId,
+    agentId: agent.agentId,
+    channelBindingId: channelBinding.bindingId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+    sessionId: 'session-1',
+  })
+  assert.equal(store.getChannelBinding(org2.orgId, channelBinding.bindingId), null)
+  assert.equal(store.getChannelIdentity(org2.orgId, identity.identityId), null)
+  assert.equal(store.getChannelSessionBinding(org2.orgId, sessionBinding.bindingId), null)
+  assert.equal(store.findChannelSessionBindingByThread({
+    orgId: org2.orgId,
+    provider: 'telegram',
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+  }), null)
+
+  store.createByokSecret({
+    secretId: 'secret-1',
+    orgId: org1.orgId,
+    providerId: 'anthropic',
+    ciphertext: 'ciphertext',
+    last4: '1234',
+    keyFingerprint: 'fingerprint',
+  })
+  assert.equal(store.getActiveByokSecret(org2.orgId, 'anthropic'), null)
+  assert.deepEqual(store.listByokSecrets(org2.orgId), [])
+
+  store.upsertBillingSubscription({
+    orgId: org1.orgId,
+    providerId: 'stub',
+    providerCustomerId: 'cus_1',
+    providerSubscriptionId: 'sub_1',
+    planKey: 'pro',
+    status: 'active',
+  })
+  assert.equal(store.getBillingSubscription(org2.orgId), null)
+
+  store.recordUsageEvent({
+    orgId: org1.orgId,
+    eventType: 'prompt.submitted',
+    metadata: { sessionId: 'session-1' },
+  })
+  assert.deepEqual(store.listUsageEvents(org2.orgId), [])
+  assert.equal(store.consumeUsageQuota({
+    orgId: org1.orgId,
+    quotaKey: 'prompts:hour',
+    limit: 1,
+    windowMs: 60_000,
+    now: new Date('2026-01-01T00:00:00.000Z'),
+  }).allowed, true)
+  assert.equal(store.consumeUsageQuota({
+    orgId: org2.orgId,
+    quotaKey: 'prompts:hour',
+    limit: 1,
+    windowMs: 60_000,
+    now: new Date('2026-01-01T00:00:00.000Z'),
+  }).allowed, true)
+})
+
 test('cloud control plane appends ordered idempotent session events', () => {
   const store = seededStore()
   const first = store.appendSessionEvent({

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -21,7 +21,7 @@ import { createInMemoryObjectStore } from '../apps/desktop/src/main/cloud/object
 import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
 import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secret-adapter.ts'
 import { createCloudSessionCookieManager } from '../apps/desktop/src/main/cloud/session-cookie-auth.ts'
-import { CloudSessionService, type ByokManagementPolicy } from '../apps/desktop/src/main/cloud/session-service.ts'
+import { CloudSessionService, type ByokManagementPolicy, type CloudIdentityPolicy } from '../apps/desktop/src/main/cloud/session-service.ts'
 import { createStubBillingAdapter } from '../apps/desktop/src/main/cloud/stub-billing-adapter.ts'
 import { CloudWorker } from '../apps/desktop/src/main/cloud/worker.ts'
 import type {
@@ -37,6 +37,8 @@ class FakeRuntimeAdapter implements CloudRuntimeAdapter {
   createdSessions: string[] = []
   aborted: string[] = []
   permissions: Array<{ permissionId: string, allowed: boolean }> = []
+  questionReplies: Array<{ requestId: string, answers: unknown[] }> = []
+  questionRejects: Array<{ requestId: string }> = []
   private nextSession = 0
 
   async createSession() {
@@ -77,6 +79,14 @@ class FakeRuntimeAdapter implements CloudRuntimeAdapter {
   async respondToPermission(input: { permissionId: string, allowed: boolean }) {
     this.permissions.push({ permissionId: input.permissionId, allowed: input.allowed })
   }
+
+  async replyToQuestion(input: { requestId: string, answers: unknown[] }) {
+    this.questionReplies.push({ requestId: input.requestId, answers: input.answers })
+  }
+
+  async rejectQuestion(input: { requestId: string }) {
+    this.questionRejects.push({ requestId: input.requestId })
+  }
 }
 
 function createFixture(options: {
@@ -93,6 +103,7 @@ function createFixture(options: {
     abuse?: CloudAbuseConfig
     billing?: CloudBillingConfig | null
     billingAdapter?: BillingAdapter | null
+    identityPolicy?: CloudIdentityPolicy
   } = {}) {
   const runtime = new FakeRuntimeAdapter()
   const store = new InMemoryControlPlaneStore()
@@ -104,7 +115,7 @@ function createFixture(options: {
   })
   const service = new CloudSessionService(store, runtime, policy, undefined, {
     randomUUID: () => `cmd-${nextId += 1}`,
-  }, undefined, byokSecrets, options.byokPolicy, options.abuse, options.billing || null, options.billingAdapter || null)
+  }, undefined, byokSecrets, options.byokPolicy, options.abuse, options.billing || null, options.billingAdapter || null, options.identityPolicy)
   const artifacts = new CloudArtifactService(service, objectStore, {
     randomUUID: () => `artifact-${nextId += 1}`,
   })
@@ -133,7 +144,7 @@ function createFixture(options: {
       authSource: 'local',
     })),
   })
-  return { runtime, store, objectStore, policy, service, worker, server }
+  return { runtime, store, objectStore, policy, service, artifacts, worker, server }
 }
 
 async function readJson(response: Response) {
@@ -1075,6 +1086,53 @@ test('cloud HTTP API token issuance applies default and maximum expirations', as
   }
 })
 
+test('cloud HTTP self-service mode requires an active invited membership when disabled', async () => {
+  const principal = {
+    tenantId: 'tenant-1',
+    orgId: 'tenant-1',
+    tenantName: 'Tenant 1',
+    userId: 'invited-1',
+    accountId: 'invited-1',
+    email: 'invited@example.test',
+    role: 'member' as const,
+    authSource: 'user' as const,
+  }
+  const fixture = createFixture({
+    auth: () => principal,
+    identityPolicy: { allowSelfServiceSignup: false },
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const missingInvite = await fetch(`${baseUrl}/api/workspace`)
+    assert.equal(missingInvite.status, 403)
+
+    fixture.store.createTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
+    const org = fixture.store.ensureOrgForTenant({ tenantId: 'tenant-1', orgId: 'tenant-1', name: 'Tenant 1' })
+    fixture.store.ensureUser({ tenantId: 'tenant-1', userId: 'invited-1', email: 'invited@example.test' })
+    fixture.store.createAccount({ accountId: 'invited-1', idpSubject: 'invited-1', email: 'invited@example.test' })
+    fixture.store.upsertMembership({
+      orgId: org.orgId,
+      accountId: 'invited-1',
+      role: 'member',
+      status: 'pending',
+    })
+    const pendingInvite = await fetch(`${baseUrl}/api/workspace`)
+    assert.equal(pendingInvite.status, 403)
+
+    fixture.store.upsertMembership({
+      orgId: org.orgId,
+      accountId: 'invited-1',
+      role: 'member',
+      status: 'active',
+    })
+    const accepted = await readJson(await fetch(`${baseUrl}/api/workspace`))
+    assert.equal(accepted.orgId, 'tenant-1')
+    assert.equal(accepted.accountId, 'invited-1')
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP worker status endpoints require operator privileges', async () => {
   const memberPrincipal = {
     tenantId: 'tenant-1',
@@ -1457,6 +1515,43 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     assert.equal(asRecord(approval.command).kind, 'permission.respond')
     assert.equal(approval.processed, 1)
     assert.deepEqual(runtime.permissions, [{ permissionId: 'permission-1', allowed: true }])
+
+    const questionInteractionResponse = await fetch(`${baseUrl}/api/channels/interactions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        interactionId: 'interaction-2',
+        agentId: 'agent-1',
+        sessionId: cloudSession.sessionId,
+        provider: 'telegram',
+        kind: 'question',
+        targetId: 'question-1',
+        tokenSecret: 'question-secret',
+      }),
+    })
+    assert.equal(questionInteractionResponse.status, 201)
+    const issuedQuestion = await readJson(questionInteractionResponse)
+    assert.equal(typeof issuedQuestion.plaintextToken, 'string')
+
+    const questionResponse = await fetch(`${baseUrl}/api/channels/interactions/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: identity.identityId,
+        token: issuedQuestion.plaintextToken,
+        answers: ['Ship it'],
+      }),
+    })
+    assert.equal(questionResponse.status, 202)
+    const question = await readJson(questionResponse)
+    assert.equal(asRecord(question.command).kind, 'question.reply')
+    assert.deepEqual(runtime.questionReplies, [{ requestId: 'question-1', answers: ['Ship it'] }])
+
+    const auditPayload = JSON.stringify(await store.listAuditEvents('tenant-1'))
+    assert.match(auditPayload, /channel_interaction\.permission\.responded/)
+    assert.match(auditPayload, /channel_interaction\.question\.replied/)
+    assert.equal(auditPayload.includes(String(issuedInteraction.plaintextToken)), false)
+    assert.equal(auditPayload.includes(String(issuedQuestion.plaintextToken)), false)
 
     const deliveryResponse = await fetch(`${baseUrl}/api/channels/deliveries`, {
       method: 'POST',
@@ -2547,6 +2642,17 @@ test('cloud HTTP artifacts use object storage and durable artifact events', asyn
     const read = await readJson(await fetch(`${baseUrl}/api/sessions/oc-session-1/artifacts/${uploaded.artifactId}`))
     const artifact = asRecord(read.artifact)
     assert.equal(Buffer.from(String(artifact.dataBase64), 'base64').toString('utf8'), 'cloud artifact')
+
+    await assert.rejects(() => fixture.artifacts.readSessionArtifact({
+      tenantId: 'tenant-2',
+      orgId: 'tenant-2',
+      tenantName: 'Tenant 2',
+      userId: 'user-2',
+      accountId: 'user-2',
+      email: 'user2@example.test',
+      role: 'owner' as const,
+      authSource: 'user' as const,
+    }, 'oc-session-1', String(uploaded.artifactId)), /Cloud session was not found|Unknown session|Unknown tenant/)
   } finally {
     await fixture.server.close()
   }


### PR DESCRIPTION
Closes #464.\n\n## Summary\n- require timestamped HMAC authentication and replay protection for generic gateway webhook ingress\n- harden managed OIDC self-service defaults and invite-only membership checks\n- add audit coverage for channel approvals/questions and expand tenant/privacy regression tests\n- redact local paths from gateway channel rendering and update deployment docs\n\n## Verification\n- pnpm --filter @open-cowork/gateway-provider-webhook test\n- pnpm --filter @open-cowork/gateway test\n- node scripts/run-node-tests.mjs tests/cloud-app.test.ts tests/cloud-http-server.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-distribution-redaction.test.ts tests/byok-boundary-regression.test.ts\n- pnpm typecheck\n- pnpm lint\n- pnpm test\n- pnpm audit --prod --audit-level high\n- git diff --check\n\nDocs build was attempted, but local docs tooling is unavailable in this environment: uv and mkdocs are not installed.