### PR TITLE
Prove three-surface roadmap completion gates

### DIFF
--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -34,6 +34,7 @@ export const E2E_ALLOW_SETTINGS_MUTATION_KEY = 'OPEN_COWORK_E2E_ALLOW_SETTINGS_M
 const E2E_ARG_ENV_KEYS = new Set([
   'OPEN_COWORK_CHART_TIMEOUT_MS',
   'OPEN_COWORK_CONFIG_PATH',
+  E2E_ARG_ENV_ENABLE_KEY,
   E2E_ALLOW_SETTINGS_MUTATION_KEY,
   'HOME',
   'TMPDIR',
@@ -60,8 +61,26 @@ export function buildE2EArgEnvironment(env: Record<string, string>) {
     .map(([key, value]) => `${E2E_ENV_ARG_PREFIX}${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
 }
 
+function e2eArgEnvironmentIsEnabled(argv: readonly string[], env: NodeJS.ProcessEnv) {
+  if (env[E2E_ARG_ENV_ENABLE_KEY] === '1') return true
+  for (const arg of argv) {
+    if (!arg.startsWith(E2E_ENV_ARG_PREFIX)) continue
+    const encoded = arg.slice(E2E_ENV_ARG_PREFIX.length)
+    const separatorIndex = encoded.indexOf('=')
+    if (separatorIndex <= 0) continue
+    try {
+      const key = decodeURIComponent(encoded.slice(0, separatorIndex))
+      const value = decodeURIComponent(encoded.slice(separatorIndex + 1))
+      if (key === E2E_ARG_ENV_ENABLE_KEY && value === '1') return true
+    } catch {
+      continue
+    }
+  }
+  return false
+}
+
 export function applyE2EArgEnvironment(argv: readonly string[] = process.argv, env: NodeJS.ProcessEnv = process.env) {
-  if (env[E2E_ARG_ENV_ENABLE_KEY] !== '1') return
+  if (!e2eArgEnvironmentIsEnabled(argv, env)) return
   const appliedKeys = new Set<string>()
   for (const arg of argv) {
     if (!arg.startsWith(E2E_ENV_ARG_PREFIX)) continue

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SessionInfo, SessionView } from '@open-cowork/shared'
 import { useSessionStore } from '../../stores/session'
+import { installRendererTestCoworkApi } from '../../test/setup'
 import { ThreadList } from './ThreadList'
 
 vi.mock('../../helpers/loadSessionMessages', () => ({
@@ -128,5 +129,112 @@ describe('ThreadList', () => {
     expect(screen.queryByRole('menu', { name: 'Thread actions' })).not.toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: 'Rename' })).not.toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument()
+  })
+
+  it('requires an explicit Copy to Cloud preview before uploading local thread state', async () => {
+    const workspaceList = vi.fn(async () => [{
+      id: 'local',
+      kind: 'local' as const,
+      label: 'Local',
+      status: 'online' as const,
+      active: true,
+      lastSyncedAt: null,
+    }, {
+      id: 'cloud:acme',
+      kind: 'cloud' as const,
+      label: 'Acme Cloud',
+      status: 'online' as const,
+      active: false,
+      lastSyncedAt: null,
+    }])
+    const workspaceActivate = vi.fn(async () => ({
+      id: 'cloud:acme',
+      kind: 'cloud' as const,
+      label: 'Acme Cloud',
+      status: 'online' as const,
+      active: true,
+      lastSyncedAt: null,
+    }))
+    const importInventory = vi.fn(async () => ({
+      source: { kind: 'local-session' as const, fingerprint: 'sha256:session-1', title: 'Current thread' },
+      title: 'Current thread',
+      counts: { messages: 3, artifacts: 2, attachments: 1, projectSource: 4, excluded: 2 },
+      defaults: {
+        includeMessages: true,
+        includeArtifacts: false,
+        includeAttachments: false,
+        includeProjectSource: false,
+      },
+      warnings: [{ code: 'redacted-values', severity: 'warning' as const, message: 'Secret-like values were redacted before upload.' }],
+      excluded: [{ kind: 'project-source', count: 4, reason: 'Local project source and host paths are excluded in v1.' }],
+    }))
+    const copyToCloud = vi.fn(async () => ({
+      workspaceId: 'cloud:acme',
+      sessionId: 'cloud-session-1',
+      title: 'Current thread',
+      importedAt: '2026-01-01T00:00:00.000Z',
+      itemCounts: { messages: 3, artifacts: 2, attachments: 1, projectSource: 0, excluded: 2 },
+    }))
+    const listSessions = vi.fn(async () => [{
+      id: 'cloud-session-1',
+      title: 'Current thread',
+      directory: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }])
+
+    installRendererTestCoworkApi({
+      workspace: {
+        list: workspaceList,
+        activate: workspaceActivate,
+      },
+      session: {
+        importInventory,
+        copyToCloud,
+        list: listSessions,
+      },
+    })
+
+    render(<ThreadList />)
+
+    const row = screen.getByRole('button', { name: /Current thread/ })
+    fireEvent.keyDown(row, { key: 'ContextMenu' })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Copy to Cloud...' }))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Copy thread to cloud' })
+    expect(dialog).toHaveTextContent('Creates a new cloud thread. The local thread stays unchanged.')
+    expect(importInventory).toHaveBeenCalledWith('session-1')
+    expect(workspaceList).toHaveBeenCalled()
+
+    expect(screen.getByLabelText('Cloud workspace')).toHaveTextContent('Acme Cloud')
+    expect(dialog).toHaveTextContent('Messages')
+    expect(dialog).toHaveTextContent('3')
+    expect(dialog).toHaveTextContent('Artifacts')
+    expect(dialog).toHaveTextContent('2')
+    expect(dialog).toHaveTextContent('Attachments')
+    expect(dialog).toHaveTextContent('1')
+    expect(dialog).toHaveTextContent('Excluded')
+    expect(dialog).toHaveTextContent('2')
+    expect(dialog).toHaveTextContent('Secret-like values were redacted before upload.')
+    expect(dialog).toHaveTextContent('Local project source and host paths are excluded in v1.')
+    expect(screen.getByLabelText('Local project source and host paths are excluded in v1')).toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText('Copy data attachments already present in the thread'))
+    fireEvent.click(screen.getByLabelText('Upload selected Cowork artifacts to cloud object storage'))
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to Cloud' }))
+
+    await waitFor(() => expect(copyToCloud).toHaveBeenCalledWith('session-1', {
+      targetWorkspaceId: 'cloud:acme',
+      selection: {
+        includeMessages: true,
+        includeArtifacts: true,
+        includeAttachments: true,
+        includeProjectSource: false,
+      },
+    }))
+    expect(workspaceActivate).toHaveBeenCalledWith('cloud:acme')
+    expect(listSessions).toHaveBeenCalledWith({ workspaceId: 'cloud:acme' })
+    expect(useSessionStore.getState().activeWorkspaceId).toBe('cloud:acme')
+    expect(useSessionStore.getState().currentSessionId).toBe('cloud-session-1')
   })
 })

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -11,6 +11,10 @@ import {
   type ElectronApplication,
   type Page,
 } from 'playwright-core'
+import {
+  E2E_ARG_ENV_ENABLE_KEY,
+  buildE2EArgEnvironment,
+} from '../src/main/e2e-remote-debugging.ts'
 
 // Shared bootstrap for every Electron smoke test: launches the packaged
 // renderer bundle against an isolated HOME + XDG dirs so tests never
@@ -270,8 +274,10 @@ function getLaunchServicesEnvironment(paths: SmokePaths, overrides?: Record<stri
   const env = {
     ...getSmokeEnvironment(paths),
     ...overrides,
+    [E2E_ARG_ENV_ENABLE_KEY]: '1',
   }
   const keys = new Set([
+    E2E_ARG_ENV_ENABLE_KEY,
     'HOME',
     'TMPDIR',
     'XDG_CONFIG_HOME',
@@ -285,6 +291,7 @@ function getLaunchServicesEnvironment(paths: SmokePaths, overrides?: Record<stri
     'OPEN_COWORK_E2E',
     'OPEN_COWORK_E2E_PROBE_ACTION',
     'OPEN_COWORK_E2E_READY_FILE',
+    'OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT',
   ])
 
   return Object.fromEntries(
@@ -292,6 +299,10 @@ function getLaunchServicesEnvironment(paths: SmokePaths, overrides?: Record<stri
       .map((key) => [key, env[key]] as const)
       .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
   )
+}
+
+function getMacE2EArgEnvironment(paths: SmokePaths, overrides?: Record<string, string>) {
+  return buildE2EArgEnvironment(getLaunchServicesEnvironment(paths, overrides))
 }
 
 async function delay(ms: number) {
@@ -489,6 +500,8 @@ export async function launchPackagedMacProbe(
 
   try {
     return await withLaunchServicesEnvironment(launchEnvironment, async () => {
+      await runCommand('osascript', ['-e', 'tell application id "com.opencowork.desktop" to quit']).catch(() => {})
+      await delay(1_000)
       await runCommand('open', [
         '-n',
         '-g',
@@ -660,15 +673,16 @@ export async function launchSmokeSession(
 
   if (macAppBundlePath) {
     const port = await getAvailablePort()
-    const launchEnvironment = getLaunchServicesEnvironment(paths)
-    const envArgs = Object.entries(launchEnvironment).flatMap(([key, value]) => ['--env', `${key}=${value}`])
+    const e2eArgEnvironment = getMacE2EArgEnvironment(paths, {
+      OPEN_COWORK_E2E_REMOTE_DEBUGGING_PORT: String(port),
+    })
     await runCommand('open', [
       '-n',
       '-g',
       '-j',
-      ...envArgs,
       macAppBundlePath,
       '--args',
+      ...e2eArgEnvironment,
       `--remote-debugging-port=${port}`,
     ])
 

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -361,6 +361,62 @@ test('gateway daemon exposes admin delivery backlog controls', async () => {
   }
 })
 
+test('gateway daemon rejects delivery admin controls without the admin token', async () => {
+  const calls: string[] = []
+  const cloud = {
+    subscribeDeliveries() { return { close() {} } },
+    async listDeliveries() {
+      calls.push('list')
+      return []
+    },
+    async retryDelivery(deliveryId: string) {
+      calls.push(`retry:${deliveryId}`)
+      return deliveryRecord({ deliveryId })
+    },
+    async deadLetterDelivery(deliveryId: string) {
+      calls.push(`dead:${deliveryId}`)
+      return deliveryRecord({ deliveryId })
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    server: {
+      adminToken: 'admin-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+    OPEN_COWORK_GATEWAY_PORT: '0',
+  })
+  const runtime = createGatewayRuntime(config, cloud, undefined, { subscribeDeliveries: false })
+  await runtime.start()
+  const http = createGatewayHttpServer(config, runtime, cloud)
+  const url = await http.listen()
+
+  try {
+    const listed = await readJson(await fetch(`${url}/deliveries`))
+    assert.equal(listed.error, 'Gateway admin authorization is required.')
+
+    const retried = await readJson(await fetch(`${url}/deliveries/delivery-1/retry`, { method: 'POST' }))
+    assert.equal(retried.error, 'Gateway admin authorization is required.')
+
+    const dead = await readJson(await fetch(`${url}/deliveries/delivery-1/dead-letter`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lastError: 'operator stop' }),
+    }))
+    assert.equal(dead.error, 'Gateway admin authorization is required.')
+    assert.deepEqual(calls, [])
+  } finally {
+    await http.close()
+    await runtime.stop()
+  }
+})
+
 test('gateway runtime retries transient deliveries and marks permanent failures dead', async () => {
   let onDelivery: ((delivery: unknown) => void) | null = null
   const acks: Array<{ deliveryId: string, input: Record<string, unknown> }> = []

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,21 @@
 # Roadmap
 
-Last updated: 2026-05-18.
+Last updated: 2026-05-29.
 
-> **Status: focused roadmap.** Open Cowork is narrowing around the product
-> surfaces that create direct user value: Chat, Agents, Tools & Skills, and
-> Workflows. Non-core dashboards and self-directed meta-work loops are outside
-> the active product until the core loop is simple, reliable, and obvious.
+Open Cowork is now planned and verified as a three-surface product over one
+OpenCode-backed control plane:
+
+- **Desktop:** local-first Electron app with optional cloud workspaces.
+- **Cloud:** web app, API, worker, scheduler, control plane, BYOK, policy, and
+  object storage.
+- **Gateway:** headless channel adapter for Telegram, Slack, email, webhooks,
+  and later channels.
+
+The product promise is **workspace-scoped product sync**, not peer-to-peer sync
+and not runtime replication. Cloud workspaces sync across desktop, web, and
+gateway because every surface reads and writes the same tenant-scoped cloud
+control plane. Local desktop workspaces stay private unless the user explicitly
+copies selected state into cloud.
 
 ## First Principle
 
@@ -15,18 +25,167 @@ Open Cowork is a product layer on top of OpenCode, not a second runtime.
   approvals, questions, compaction, native skills, streaming events, tool
   semantics, and agent runtime behavior.
 - **Open Cowork owns composition:** desktop UI, packaging, branding,
-  configuration, capability curation, event projection, workflow state, and
-  user-facing ergonomics.
+  configuration, capability curation, event projection, workflow state,
+  workspaces, cloud control plane, gateway adapters, and user-facing
+  ergonomics.
 
 If a roadmap item starts to replace OpenCode runtime behavior, it should be
 simplified or removed.
 
 ## Product Thesis
 
-The app should help a teammate describe work, choose or build the right agent,
-connect approved tools and skills, and review the output.
+Open Cowork should be useful in three deployment modes:
 
-The stable loop is:
+- **Local desktop:** a user runs OpenCode locally through a polished desktop
+  product layer with no cloud dependency.
+- **Self-hosted cloud:** an organization runs desktop, cloud, and gateway on its
+  own infrastructure with its own branding, auth, storage, secrets, profiles,
+  tools, agents, MCPs, and gateway providers.
+- **Managed BYOK SaaS:** Open Cowork can be hosted as a service where customers
+  bring their own provider keys and pay for managed sync, cloud execution,
+  policy, gateway channels, reliability, and operations.
+
+The business value is hosted convenience and operational reliability. The open
+source product remains deployable without commercial lock-in.
+
+## Non-Negotiable Product Promises
+
+1. OpenCode owns execution. Open Cowork never becomes a second agent runtime.
+2. Cloud workspaces sync. Desktop cloud workspace, browser cloud app, and
+   gateway continue the same cloud sessions.
+3. Local stays local. Local desktop sessions, files, MCPs, and credentials are
+   never uploaded implicitly.
+4. Gateway is headless and cloud-backed. It can run on a VPS, but it does not
+   own session, runtime, or control-plane state.
+5. Downstream deployers can configure the product without forking core code:
+   branding, cloud URL, auth, profiles, tools, agents, MCPs, features, object
+   store, secrets, quotas, and gateway providers.
+6. Hosted SaaS stays BYOK. Managed Open Cowork can charge for hosted
+   cloud/gateway/sync while users bring their own provider keys.
+7. OSS self-host remains first-class. Billing and managed-service features must
+   not block self-hosted cloud/gateway deployments.
+
+## Strategic Roadmap
+
+The three-surface roadmap is tracked by
+[issue #448](https://github.com/joe-broadhead/open-cowork/issues/448). The child
+issues below are the source of truth for implementation scope and acceptance.
+
+### Phase 1: Product Contract And UX Semantics
+
+Make the three-surface model explicit in docs, UI language, API support
+matrices, and tests.
+
+Tracked by #449.
+
+Acceptance:
+
+- Desktop, cloud, and gateway are described as coordinated surfaces over one
+  OpenCode-backed control plane.
+- Workspace state is clearly scoped as local or cloud.
+- Local-only and cloud-safe actions are distinct in UI and docs.
+- OpenCode/Open Cowork ownership boundaries are documented and tested.
+
+### Phase 2: Seamless Cloud Continuation
+
+Prove the flagship flow: start or continue a cloud thread from desktop, web,
+and gateway with live state, approvals, questions, tools, and artifacts intact.
+
+Tracked by #456.
+
+Acceptance:
+
+- A desktop-created cloud thread is visible in web.
+- A gateway prompt continues the same cloud thread.
+- Permission/question events round-trip through the shared cloud event contract.
+- Desktop can restart and hydrate from durable cloud projections without
+  corrupting cached cursors.
+
+### Phase 3: Explicit Local-To-Cloud Import
+
+Add a safe, consent-driven import/copy flow for selected local session state and
+artifacts. No implicit upload.
+
+Tracked by #457.
+
+Acceptance:
+
+- The user must choose **Copy to Cloud** explicitly from a local thread.
+- The UI previews message, attachment, artifact, project-source, and excluded
+  counts before upload.
+- Local project source and host paths are excluded by default.
+- Import payload validation rejects raw local paths and secret-like values.
+
+### Phase 4: Cloud Project Context
+
+Make cloud coding useful by giving workers a safe project source: git checkout,
+uploaded workspace snapshot, or managed object-store workspace.
+
+Tracked by #458.
+
+Acceptance:
+
+- Cloud thread creation can use a configured Git source or explicit uploaded
+  snapshot.
+- Snapshot inventory shows included/excluded files and size limits.
+- Workers restore project context through cloud-safe storage.
+- Local files are never uploaded implicitly.
+
+### Phase 5: Downstream And Managed Productization
+
+Unify branding/configuration across desktop, cloud, and gateway, then harden
+SaaS BYOK and self-host deployment recipes.
+
+Tracked by #459 and #463.
+
+Acceptance:
+
+- A downstream organization can configure product name, logo, cloud URL, auth,
+  profiles, tools, agents, MCPs, object store, secret adapter, quotas, and
+  gateway providers without source patches.
+- Docker Compose and Helm deployments cover cloud and gateway.
+- Cloud deployment references cover provider-neutral storage and secrets.
+- Managed BYOK SaaS flows expose key status only; raw keys never leave the
+  write path or worker runtime config boundary.
+
+### Phase 6: Gateway Expansion
+
+Promote gateway from Telegram/webhook foundation to a real headless product with
+Slack and email first, then additional channels.
+
+Tracked by #460.
+
+Acceptance:
+
+- Gateway is a cloud client/channel adapter, not an OpenCode runtime owner.
+- Telegram, Slack, email, and webhook providers share one capability-driven
+  rendering model.
+- Approvals/questions work through inline controls where supported and token or
+  link fallback where not.
+- Gateway can self-host on a VPS with service-token auth and no direct
+  control-plane database ownership.
+
+### Phase 7: Production Refactor And Security Gates
+
+Reduce cloud core coupling, harden OpenCode SDK boundaries, and add global
+privacy/security/concurrency gates.
+
+Tracked by #461, #462, and #464.
+
+Acceptance:
+
+- Gateway and client packages have zero direct OpenCode SDK imports.
+- Only cloud worker/runtime code imports OpenCode SDK runtime surfaces.
+- Raw provider keys, OAuth refresh tokens, MCP secrets, local file contents, and
+  machine paths are absent from read APIs, renderer state, logs, diagnostics,
+  and gateway payloads.
+- Cloud control-plane domains are split behind service/store boundaries.
+- Postgres concurrency gates cover leases, commands, events, deliveries,
+  quotas, and scheduler claims.
+
+## Core Product Loop
+
+The desktop product loop remains:
 
 ```text
 intake -> setup thread -> agent/tool selection -> saved workflow -> run thread -> history
@@ -35,139 +194,45 @@ intake -> setup thread -> agent/tool selection -> saved workflow -> run thread -
 The stable vocabulary is:
 
 - **Chat** for direct work with OpenCode.
-- **Agents** for reusable workers.
+- **Agents** for reusable OpenCode-native workers.
 - **Tools & Skills** for scoped authority and repeatable know-how.
-- **Workflows** for reviewed recurring work.
+- **Workflows** for reviewed recurring work around OpenCode-native execution.
 - **Threads** for history and recall.
 - **Artifacts** for generated files, charts, reports, and saved outputs.
 
-Everything in primary navigation should support one of those concepts.
+Primary navigation should support one of those concepts or the workspace
+surface that chooses where those concepts execute.
 
-## Non-Goals For The Core Roadmap
+## Verification Gates
 
-These concepts are intentionally out of the active app surface:
+Completion of the strategic roadmap requires evidence from current code, tests,
+and deployment artifacts:
 
-- Team dashboards as first-class multi-agent management.
-- Specialized audit and incident-control dashboards.
-- Self-directed proposal loops that create work without a user-defined workflow.
-- A parallel work runtime outside OpenCode.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:e2e` when UI/runtime paths are touched
+- `pnpm perf:check` for renderer/runtime-sensitive work
+- `uv run mkdocs build --strict` or CI docs build when docs are touched
+- `git diff --check`
+- Real Postgres concurrency tests with `OPEN_COWORK_TEST_POSTGRES_URL`
+- Gateway provider/channel matrix tests
+- Desktop cloud continuation E2E tests
+- No-raw-secret boundary tests
+- Package boundary tests for OpenCode SDK imports
 
-They can return only if they are explained through the core concepts above and
-have a concrete user job that cannot be solved more simply.
-This does not exclude user-invoked improvement work through the bundled
-`autoresearch` skill and agent; the non-goal is an always-on autonomous
-learning surface that creates work without a user request.
+## Non-Goals
 
-## Phase 1: Make Chat Excellent
+These concepts remain outside the core product unless they collapse cleanly into
+Chat, Agents, Tools & Skills, Workflows, Threads, or Workspaces:
 
-Goal: make direct OpenCode work fast, transparent, and reliable.
+- a parallel agent runtime outside OpenCode
+- peer-to-peer runtime replication between desktop and cloud
+- implicit upload of local files, local MCPs, local credentials, or machine
+  runtime config
+- team dashboards that bypass thread/workflow review
+- self-directed proposal loops that create work without a user-defined workflow
 
-Scope:
-
-- model, provider, agent mode, reasoning, and attachment controls in both Home
-  and Chat
-- robust markdown, tables, charts, and artifact rendering
-- clear task cards for OpenCode-native delegated agents
-- reliable approval and question UX
-- fast thread switching and reload parity
-- simple session inspection without turning Chat into a dashboard
-
-Acceptance:
-
-- Home and Chat composer behavior match.
-- Rapid prompts, file attachments, and agent mentions are non-regressive.
-- Sub-agent runs are readable without exposing runtime internals.
-- Charts and markdown render consistently before and after streaming finishes.
-- Reloaded sessions preserve approvals, questions, tool calls, task runs, and
-  artifacts.
-
-## Phase 2: Make Agents Understandable
-
-Goal: let users build and trust the workers they delegate to.
-
-Scope:
-
-- a polished built-in/custom/runtime agent catalog
-- grounded agent cards showing real tools, skills, model, reasoning, and write
-  authority
-- search and filtering by job, skill, tool, and authority
-- shared validation between renderer and main process
-- sandbox testing for draft agents before saving
-- clearer links from an agent to the Tools & Skills it can use
-
-Acceptance:
-
-- Users can explain what an agent can do from its card.
-- Saving an agent never succeeds in the UI and fails in main validation.
-- Draft agents can be tested without disrupting normal runtime state.
-- Enabled/disabled state uses SDK-native configuration where possible.
-
-## Phase 3: Make Tools & Skills Concrete
-
-Goal: show the real capability graph behind agents and workflows.
-
-Scope:
-
-- group skills by linked tools
-- highlight which tools a skill may call
-- show which agents and workflows depend on each tool or skill
-- make credential and permission requirements visible
-- keep MCP and skill management deterministic and bounded
-
-Acceptance:
-
-- A user can answer “why can this agent do that?” from the UI.
-- Adding a skill or tool makes its downstream agent/workflow impact visible.
-- Skill import/save paths use the same validation and size limits everywhere.
-
-## Phase 4: Make Workflows Thread-Native
-
-Status: implemented in the current core product; keep polishing reliability,
-docs, and e2e coverage before adding new workflow surfaces.
-
-Goal: make recurring work feel like saved conversations, not a second product.
-
-Scope:
-
-- Add workflow opens a normal Workflow Designer setup thread.
-- The user talks through the task until the workflow is clear.
-- Workflow Designer previews the workflow with a bundled Workflows MCP tool.
-- Workflow Designer saves the workflow only after explicit user confirmation.
-- Workflows run manually, on a schedule, or from a local webhook.
-- The Workflows page stays a compact list of saved workflows, triggers, latest
-  run state, and setup/run thread links.
-
-Acceptance:
-
-- A non-technical teammate can add a repeatable task by talking to Workflow
-  Designer.
-- The saved workflow definition is inspectable from the setup thread and page.
-- Webhook payloads appear in the run prompt.
-- Workflows use OpenCode agents, tools, skills, approvals, and delegation
-  rather than a Cowork-owned execution loop.
-
-## Phase 5: Reconsider External Intake
-
-Only after Chat, Agents, Tools & Skills, and Workflows are simple and reliable,
-reassess whether external events belong in the app. The first version should
-create reviewed workflow drafts only; it must not introduce a separate product
-surface or bypass human review.
-
-## Phase 6: Reconsider Advanced Organizational Features
-
-Only after the core loop is excellent, reassess whether the app needs:
-
-- team templates
-- specialized audit dashboards
-- advanced agent-run summaries
-- proposal loops that are explicitly anchored to saved workflows
-
-The bar for reintroduction is high: each feature must collapse into Chat,
-Agents, Tools & Skills, Workflows, or Threads without adding a new mental model.
-
-## HR And Regulated Workflow Bar
-
-HR, finance, compliance, and other regulated workflows should wait until the
-core loop is proven: explicit setup threads, durable saved definitions,
-bounded tools and skills, clear outputs, and auditable thread history.
-Those teams need less surface area, not more.
+This does not exclude user-invoked improvement work through bundled skills and
+agents. The non-goal is an always-on autonomous work surface that creates work
+without a user request.

--- a/tests/e2e-remote-debugging.test.ts
+++ b/tests/e2e-remote-debugging.test.ts
@@ -119,6 +119,28 @@ test('e2e arg environment applies only smoke allowlisted keys', () => {
   })
 })
 
+test('e2e arg environment can be explicitly enabled by an allowlisted launch argument', () => {
+  const args = buildE2EArgEnvironment({
+    [E2E_ARG_ENV_ENABLE_KEY]: '1',
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
+    HOME: '/tmp/open-cowork-home',
+  })
+  const env: NodeJS.ProcessEnv = {}
+
+  applyE2EArgEnvironment([
+    'Open Cowork',
+    ...args,
+  ], env)
+
+  assert.deepEqual(env, {
+    [E2E_ARG_ENV_ENABLE_KEY]: '1',
+    OPEN_COWORK_E2E: '1',
+    OPEN_COWORK_E2E_READY_FILE: '/tmp/open-cowork/probe.json',
+    HOME: '/tmp/open-cowork-home',
+  })
+})
+
 test('e2e settings mutation requires explicit opt-in for packaged probes', () => {
   assert.equal(e2eSettingsMutationAllowed({ OPEN_COWORK_E2E: '1' }, { isPackaged: false }), true)
   assert.equal(e2eSettingsMutationAllowed({ OPEN_COWORK_E2E: '1' }, { isPackaged: true }), false)


### PR DESCRIPTION
## Summary

- refresh `docs/roadmap.md` so it reflects the completed three-surface Open Cowork product roadmap from #448
- add renderer coverage proving local threads require an explicit Copy to Cloud preview before upload
- add gateway coverage proving delivery admin controls reject unauthenticated requests
- harden the packaged macOS smoke probe to launch with per-process environment variables instead of global LaunchServices state

## Verification

- `pnpm test`
- `pnpm test:renderer`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm perf:check` (passed when run alone; a concurrent run with renderer tests was noisy and failed against local perf thresholds)
- `pnpm deploy:validate`
- `python3 -m mkdocs build --strict`
- `pnpm audit --prod --audit-level high`
- `git diff --check`

Note: local `pnpm --dir apps/desktop test:e2e` still cannot complete on this machine because the managed OpenCode supervisor exits before the smoke app shell is available. The GitHub macOS packaged smoke check is the relevant gate for the changed packaged probe path.

Closes #448 after CI is green and merged.
