### PR TITLE
Build cloud web workbench shell

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Open Cowork Cloud hosted website and onboarding dashboard",
+  "description": "Open Cowork Cloud hosted website and web workbench",
   "main": "dist/render.js",
   "types": "dist/render.d.ts",
   "scripts": {

--- a/apps/website/src/app-shell.ts
+++ b/apps/website/src/app-shell.ts
@@ -1,0 +1,188 @@
+export type CloudWebSurface = 'workbench' | 'admin'
+
+export type CloudWebRouteId =
+  | 'threads'
+  | 'chat'
+  | 'agents'
+  | 'capabilities'
+  | 'workflows'
+  | 'artifacts'
+  | 'org'
+  | 'members'
+  | 'policy'
+  | 'byok'
+  | 'connections'
+  | 'billing'
+  | 'gateway'
+  | 'audit'
+  | 'usage'
+  | 'diagnostics'
+
+export type CloudWebRoute = {
+  id: CloudWebRouteId
+  label: string
+  surface: CloudWebSurface
+  requiresAuth: boolean
+  requiresAdmin: boolean
+  summary: string
+}
+
+export type CloudWebRouteGroup = {
+  id: CloudWebSurface
+  label: string
+  routes: CloudWebRoute[]
+}
+
+export const DEFAULT_CLOUD_WEB_ROUTE: CloudWebRouteId = 'threads'
+
+export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
+  {
+    id: 'threads',
+    label: 'Threads',
+    surface: 'workbench',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Cloud threads from web, desktop, and gateway.',
+  },
+  {
+    id: 'chat',
+    label: 'Chat',
+    surface: 'workbench',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Selected cloud session timeline and composer.',
+  },
+  {
+    id: 'agents',
+    label: 'Agents',
+    surface: 'workbench',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Profile-allowed agents and runtime capability status.',
+  },
+  {
+    id: 'capabilities',
+    label: 'Tools & Skills',
+    surface: 'workbench',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Allowed tools, skills, and MCP capability verdicts.',
+  },
+  {
+    id: 'workflows',
+    label: 'Workflows',
+    surface: 'workbench',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Workflow definitions, runs, and status.',
+  },
+  {
+    id: 'artifacts',
+    label: 'Artifacts',
+    surface: 'workbench',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Cloud artifact metadata and downloads.',
+  },
+  {
+    id: 'org',
+    label: 'Org',
+    surface: 'admin',
+    requiresAuth: false,
+    requiresAdmin: false,
+    summary: 'Organization profile, role, and deployment policy.',
+  },
+  {
+    id: 'members',
+    label: 'Members',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: true,
+    summary: 'Member, invite, and role administration.',
+  },
+  {
+    id: 'policy',
+    label: 'Profiles & Policy',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Runtime profile and feature verdicts.',
+  },
+  {
+    id: 'byok',
+    label: 'BYOK',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: true,
+    summary: 'Write-only provider key status and rotation.',
+  },
+  {
+    id: 'connections',
+    label: 'Connections',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: true,
+    summary: 'Scoped API tokens for desktop and gateway clients.',
+  },
+  {
+    id: 'billing',
+    label: 'Billing',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: true,
+    summary: 'Subscription and entitlement state.',
+  },
+  {
+    id: 'gateway',
+    label: 'Gateway',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: true,
+    summary: 'Headless agents and channel bindings.',
+  },
+  {
+    id: 'audit',
+    label: 'Audit',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: true,
+    summary: 'Redacted audit events for sensitive actions.',
+  },
+  {
+    id: 'usage',
+    label: 'Usage',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: 'Recent metering and quota events.',
+  },
+  {
+    id: 'diagnostics',
+    label: 'Diagnostics',
+    surface: 'admin',
+    requiresAuth: true,
+    requiresAdmin: true,
+    summary: 'Redacted health and support data.',
+  },
+]
+
+export const CLOUD_WEB_ROUTE_GROUPS: CloudWebRouteGroup[] = [
+  {
+    id: 'workbench',
+    label: 'Workbench',
+    routes: CLOUD_WEB_ROUTES.filter((route) => route.surface === 'workbench'),
+  },
+  {
+    id: 'admin',
+    label: 'Admin',
+    routes: CLOUD_WEB_ROUTES.filter((route) => route.surface === 'admin'),
+  },
+]
+
+export function findCloudWebRoute(routeId: string | null | undefined) {
+  return CLOUD_WEB_ROUTES.find((route) => route.id === routeId) || null
+}
+
+export function cloudWebRoutesForSurface(surface: CloudWebSurface) {
+  return CLOUD_WEB_ROUTES.filter((route) => route.surface === surface)
+}

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -1,0 +1,102 @@
+import type { PublicBrandingConfig } from '@open-cowork/shared'
+import type { CloudWebRoute, CloudWebRouteId } from './app-shell.ts'
+
+export type CloudWebEndpointId =
+  | 'authMe'
+  | 'config'
+  | 'workspace'
+  | 'byok'
+  | 'apiTokens'
+  | 'channelAgents'
+  | 'channelBindings'
+  | 'billingSubscription'
+  | 'usageEvents'
+
+export type CloudWebEndpoint = {
+  id: CloudWebEndpointId
+  method: 'GET' | 'POST' | 'DELETE'
+  path: string
+  csrf: boolean
+}
+
+export type CloudWebClientBootstrap = {
+  role: string
+  profileName: string
+  features: Record<string, boolean>
+  publicBranding: PublicBrandingConfig
+  routes: CloudWebRoute[]
+  defaultRoute: string
+  api: CloudWebEndpoint[]
+}
+
+export type CloudWebAuthStatus = 'loading' | 'signed-out' | 'signed-in'
+export type CloudWebConnectionStatus = 'idle' | 'connecting' | 'open' | 'retrying' | 'closed' | 'error'
+
+export type CloudWebClientStateContract = {
+  authStatus: CloudWebAuthStatus
+  activeRoute: CloudWebRouteId
+  workspace: unknown | null
+  csrfToken: string | null
+  workspaceEvents: {
+    status: CloudWebConnectionStatus
+    cursor: string | null
+    error: string | null
+  }
+}
+
+export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
+  {
+    id: 'authMe',
+    method: 'GET',
+    path: '/auth/me',
+    csrf: false,
+  },
+  {
+    id: 'config',
+    method: 'GET',
+    path: '/api/config',
+    csrf: false,
+  },
+  {
+    id: 'workspace',
+    method: 'GET',
+    path: '/api/workspace',
+    csrf: false,
+  },
+  {
+    id: 'byok',
+    method: 'GET',
+    path: '/api/byok',
+    csrf: false,
+  },
+  {
+    id: 'apiTokens',
+    method: 'GET',
+    path: '/api/api-tokens',
+    csrf: false,
+  },
+  {
+    id: 'channelAgents',
+    method: 'GET',
+    path: '/api/channels/agents',
+    csrf: false,
+  },
+  {
+    id: 'channelBindings',
+    method: 'GET',
+    path: '/api/channels/bindings',
+    csrf: false,
+  },
+  {
+    id: 'billingSubscription',
+    method: 'GET',
+    path: '/api/billing/subscription',
+    csrf: false,
+  },
+  {
+    id: 'usageEvents',
+    method: 'GET',
+    path: '/api/usage/events?limit=20',
+    csrf: false,
+  },
+]

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -1,5 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { CLOUD_WEB_ROUTE_GROUPS, DEFAULT_CLOUD_WEB_ROUTE, findCloudWebRoute } from './app-shell.ts'
+import { CLOUD_WEB_CLIENT_ENDPOINTS, type CloudWebClientStateContract } from './client-contract.ts'
 import { cloudWebsiteClientScript, cloudWebsiteHtml } from './render.ts'
 import { canManageOrg } from './roles.ts'
 
@@ -12,12 +14,54 @@ const html = cloudWebsiteHtml({
   },
 })
 
-test('cloud website renders onboarding dashboard surfaces', () => {
+test('cloud website renders workbench and admin shell surfaces', () => {
   assert.match(html, /Open Cowork Cloud/)
+  assert.match(html, /Workbench/)
+  assert.match(html, /Threads/)
+  assert.match(html, /Chat/)
+  assert.match(html, /Tools &amp; Skills/)
+  assert.match(html, /Artifacts/)
+  assert.match(html, /Admin/)
+  assert.match(html, /Org/)
+  assert.match(html, /Members/)
   assert.match(html, /BYOK/)
   assert.match(html, /Desktop token/)
   assert.match(html, /Gateway token/)
   assert.match(html, /Headless gateway/)
+  assert.match(html, /Audit/)
+  assert.match(html, /Diagnostics/)
+  assert.match(html, /data-route-panel="threads"/)
+  assert.match(html, /data-route-panel="byok"/)
+})
+
+test('cloud website app shell exposes typed route metadata', () => {
+  assert.equal(DEFAULT_CLOUD_WEB_ROUTE, 'threads')
+  assert.deepEqual(CLOUD_WEB_ROUTE_GROUPS.map((group) => group.id), ['workbench', 'admin'])
+  assert.equal(findCloudWebRoute('threads')?.surface, 'workbench')
+  assert.equal(findCloudWebRoute('byok')?.requiresAdmin, true)
+  assert.equal(findCloudWebRoute('usage')?.requiresAdmin, false)
+})
+
+test('cloud website bootstrap exposes typed client endpoint metadata', () => {
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'config')?.path, '/api/config')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workspace')?.path, '/api/workspace')
+  assert.match(html, /"api":/)
+  assert.match(cloudWebsiteClientScript(), /endpoint\(id, fallback\)/)
+  const stateContract: CloudWebClientStateContract = {
+    authStatus: 'loading',
+    activeRoute: DEFAULT_CLOUD_WEB_ROUTE,
+    workspace: null,
+    csrfToken: null,
+    workspaceEvents: {
+      status: 'idle',
+      cursor: null,
+      error: null,
+    },
+  }
+  assert.equal(stateContract.workspaceEvents.status, 'idle')
+})
+
+test('cloud website keeps existing admin dashboard surfaces available', () => {
   assert.match(html, /Slack team ID/)
   assert.match(html, /Inbound address/)
   assert.match(html, /Webhook delivery URL/)
@@ -85,6 +129,25 @@ test('cloud website drops unsafe public branding URLs', () => {
   assert.doesNotMatch(branded, /mailto:privacy/)
 })
 
+test('cloud website serializes bootstrap JSON for raw script parsing', () => {
+  const branded = cloudWebsiteHtml({
+    role: 'owner',
+    profileName: 'default',
+    features: {
+      chat: true,
+      workflows: true,
+    },
+  }, {
+    productName: '</script><img src=x onerror=alert(1)>',
+    shortName: 'OC',
+  })
+
+  const match = branded.match(/<script[^>]+id="open-cowork-cloud-bootstrap"[^>]*>(.*?)<\/script>/s)
+  assert.ok(match)
+  assert.doesNotMatch(match[1], /<\/script>/i)
+  assert.equal(JSON.parse(match[1]).publicBranding.productName, '</script><img src=x onerror=alert(1)>')
+})
+
 test('cloud website client avoids persistent browser secret storage', () => {
   const script = cloudWebsiteClientScript()
   assert.equal(script.includes('localStorage'), false)
@@ -95,6 +158,9 @@ test('cloud website client avoids persistent browser secret storage', () => {
 test('cloud website binds actions through the client script', () => {
   assert.equal(html.includes('onclick='), false)
   assert.match(cloudWebsiteClientScript(), /signin-inline/)
+  assert.match(cloudWebsiteClientScript(), /\/api\/config/)
+  assert.match(cloudWebsiteClientScript(), /\/api\/workspace/)
+  assert.match(cloudWebsiteClientScript(), /setRoute/)
   assert.match(cloudWebsiteClientScript(), /providerSettingsFromForm/)
   assert.match(cloudWebsiteClientScript(), /updateBindingProviderFields/)
 })
@@ -103,6 +169,34 @@ test('cloud website disables dynamic admin actions for member roles', () => {
   const script = cloudWebsiteClientScript()
   assert.match(script, /Validate', \(\) => validateByok\(secret\.providerId\), 'secondary', adminLocked\(\)\)/)
   assert.match(script, /Revoke', \(\) => revokeToken\(token\.tokenId\), 'danger', adminLocked\(\)\)/)
+  assert.match(html, /data-requires-admin="true"/)
+})
+
+test('cloud website renders signed-out, member, admin, and policy-disabled states', () => {
+  const member = cloudWebsiteHtml({
+    role: 'member',
+    profileName: 'default',
+    features: {
+      chat: false,
+      workflows: false,
+    },
+  })
+  assert.match(member, /<strong id="role-name">member<\/strong>/)
+  assert.match(member, /Admin actions are disabled for this role/)
+  assert.match(member, /data-route-panel="members"[^>]+data-requires-admin="true"/)
+  assert.match(member, /<span class="pill" data-kind="warn">disabled<\/span>/)
+
+  const owner = cloudWebsiteHtml({
+    role: 'owner',
+    profileName: 'default',
+    features: {
+      chat: true,
+      workflows: true,
+    },
+  })
+  assert.match(owner, /<strong id="role-name">admin<\/strong>/)
+  assert.match(owner, /data-route-panel="diagnostics"/)
+  assert.match(owner, /signed-out-only/)
 })
 
 test('cloud website role helper gates admin controls', () => {

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -1,4 +1,6 @@
 import { canManageOrg, type WebsiteRole } from './roles.ts'
+import { CLOUD_WEB_ROUTE_GROUPS, CLOUD_WEB_ROUTES, DEFAULT_CLOUD_WEB_ROUTE, type CloudWebRoute } from './app-shell.ts'
+import { CLOUD_WEB_CLIENT_ENDPOINTS, type CloudWebClientBootstrap } from './client-contract.ts'
 import type { PublicBrandingConfig } from '@open-cowork/shared'
 
 export type WebsiteBootstrapPolicy = {
@@ -144,7 +146,33 @@ function escapeHtml(value: string) {
 }
 
 function jsonScript(value: unknown) {
-  return escapeHtml(JSON.stringify(value))
+  return JSON.stringify(value)
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+}
+
+function routeNavMarkup(route: CloudWebRoute) {
+  const authClass = route.requiresAuth ? ' signed-in-only' : ''
+  const adminClass = route.requiresAdmin ? ' admin-route' : ''
+  return `<a href="#${escapeHtml(route.id)}" data-route-link="${escapeHtml(route.id)}" data-route-surface="${escapeHtml(route.surface)}" data-requires-auth="${route.requiresAuth ? 'true' : 'false'}" data-requires-admin="${route.requiresAdmin ? 'true' : 'false'}" class="${authClass.trim()}${adminClass}">${escapeHtml(route.label)}</a>`
+}
+
+function routeGroupsMarkup() {
+  return CLOUD_WEB_ROUTE_GROUPS.map((group) => `<div class="nav-group" data-nav-group="${escapeHtml(group.id)}">
+          <div class="nav-heading">${escapeHtml(group.label)}</div>
+          <div class="nav-links">${group.routes.map(routeNavMarkup).join('')}</div>
+        </div>`).join('\n        ')
+}
+
+function routePanelAttrs(routeId: string, options: { signedIn?: boolean, admin?: boolean } = {}) {
+  const classes = ['section']
+  if (options.signedIn !== false) classes.push('signed-in-only')
+  if (options.admin) classes.push('admin-only-section')
+  const route = CLOUD_WEB_ROUTES.find((entry) => entry.id === routeId)
+  return `class="${classes.join(' ')}" id="${escapeHtml(routeId)}" data-route-panel="${escapeHtml(routeId)}" data-route-surface="${escapeHtml(route?.surface || 'workbench')}" data-requires-auth="${options.signedIn === false ? 'false' : 'true'}" data-requires-admin="${options.admin ? 'true' : 'false'}"`
 }
 
 export function cloudWebsiteClientScript() {
@@ -162,6 +190,7 @@ const state = {
   billing: null,
   usage: [],
   revealToken: null,
+  activeRoute: bootstrap.defaultRoute || 'threads',
 };
 
 const qs = (selector, root = document) => root.querySelector(selector);
@@ -193,6 +222,68 @@ function adminLocked() {
   return !canManage(state.workspace?.role);
 }
 
+function routeLinks() {
+  return qsa('[data-route-link]');
+}
+
+function routePanels() {
+  return qsa('[data-route-panel]');
+}
+
+function routeById(routeId) {
+  return (state.config?.routes || bootstrap.routes || []).find((route) => route.id === routeId) || null;
+}
+
+function canViewRoute(route) {
+  if (!route) return false;
+  if (route.requiresAuth && !state.workspace) return false;
+  return true;
+}
+
+function defaultRoute() {
+  const preferred = routeById(bootstrap.defaultRoute || 'threads');
+  if (canViewRoute(preferred)) return preferred.id;
+  const first = (state.config?.routes || bootstrap.routes || []).find(canViewRoute);
+  return first?.id || 'org';
+}
+
+function setRoute(routeId, replace = false) {
+  const route = routeById(routeId) || routeById(defaultRoute());
+  if (!canViewRoute(route)) {
+    state.activeRoute = defaultRoute();
+  } else {
+    state.activeRoute = route.id;
+  }
+  if (window.location.hash !== '#' + state.activeRoute) {
+    if (replace) window.history.replaceState(null, '', '#' + state.activeRoute);
+  }
+  renderRoutes();
+}
+
+function renderRoutes() {
+  const route = routeById(state.activeRoute) || routeById(defaultRoute());
+  routePanels().forEach((panel) => {
+    const isActive = panel.dataset.routePanel === route?.id;
+    panel.hidden = !isActive;
+    panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+  });
+  routeLinks().forEach((link) => {
+    const linkRoute = routeById(link.dataset.routeLink);
+    const visible = canViewRoute(linkRoute);
+    link.hidden = !visible;
+    link.dataset.active = linkRoute?.id === route?.id ? 'true' : 'false';
+    if (linkRoute?.requiresAdmin && adminLocked()) {
+      link.dataset.locked = 'true';
+      link.setAttribute('aria-label', linkRoute.label + ' - admin permissions required');
+    } else {
+      link.dataset.locked = 'false';
+      link.removeAttribute('aria-label');
+    }
+  });
+  document.body.dataset.route = route?.id || '';
+  document.body.dataset.surface = route?.surface || '';
+}
+
 function branding() {
   return state.config?.publicBranding || bootstrap.publicBranding || {};
 }
@@ -204,6 +295,11 @@ function brandName() {
 function connectionLabel(key, fallback) {
   const labels = branding().managedOrgConnectionLabels || {};
   return labels[key] || fallback;
+}
+
+function endpoint(id, fallback) {
+  const entry = (state.config?.api || bootstrap.api || []).find((candidate) => candidate.id === id);
+  return entry?.path || fallback;
 }
 
 function headers(hasBody) {
@@ -237,8 +333,11 @@ async function api(path, options = {}) {
 }
 
 function renderSignedOut() {
+  state.workspace = null;
+  state.principal = null;
   document.body.dataset.auth = 'signed-out';
   setStatus('Sign in required', 'warn');
+  setRoute(window.location.hash.replace(/^#/, '') || defaultRoute(), true);
 }
 
 function formatDate(value) {
@@ -288,6 +387,7 @@ function renderWorkspace() {
     element.disabled = adminLocked();
     element.dataset.locked = adminLocked() ? 'true' : 'false';
   });
+  renderRoutes();
 }
 
 function renderByok() {
@@ -484,6 +584,7 @@ function renderAll() {
   renderGateway();
   renderBilling();
   renderUsage();
+  renderRoutes();
 }
 
 async function optionalLoad(load, fallback) {
@@ -496,19 +597,19 @@ async function optionalLoad(load, fallback) {
 }
 
 async function refreshDashboard() {
-  const me = await optionalLoad(() => api('/auth/me'), null);
+  const me = await optionalLoad(() => api(endpoint('authMe', '/auth/me')), null);
   if (!me) return;
   state.principal = me.principal;
   state.csrfToken = me.csrfToken || null;
-  state.config = await api('/api/config');
-  state.workspace = await api('/api/workspace');
+  state.config = await api(endpoint('config', '/api/config'));
+  state.workspace = await api(endpoint('workspace', '/api/workspace'));
   const [byok, tokens, agents, bindings, billing, usage] = await Promise.all([
-    optionalLoad(() => api('/api/byok').then((body) => body.secrets || []), []),
-    optionalLoad(() => api('/api/api-tokens').then((body) => body.tokens || []), []),
-    optionalLoad(() => api('/api/channels/agents').then((body) => body.agents || []), []),
-    optionalLoad(() => api('/api/channels/bindings').then((body) => body.bindings || []), []),
-    optionalLoad(() => api('/api/billing/subscription'), { enabled: false }),
-    optionalLoad(() => api('/api/usage/events?limit=20').then((body) => body.events || []), []),
+    optionalLoad(() => api(endpoint('byok', '/api/byok')).then((body) => body.secrets || []), []),
+    optionalLoad(() => api(endpoint('apiTokens', '/api/api-tokens')).then((body) => body.tokens || []), []),
+    optionalLoad(() => api(endpoint('channelAgents', '/api/channels/agents')).then((body) => body.agents || []), []),
+    optionalLoad(() => api(endpoint('channelBindings', '/api/channels/bindings')).then((body) => body.bindings || []), []),
+    optionalLoad(() => api(endpoint('billingSubscription', '/api/billing/subscription')), { enabled: false }),
+    optionalLoad(() => api(endpoint('usageEvents', '/api/usage/events?limit=20')).then((body) => body.events || []), []),
   ]);
   state.byok = byok;
   state.tokens = tokens;
@@ -517,7 +618,8 @@ async function refreshDashboard() {
   state.billing = billing;
   state.usage = usage;
   document.body.dataset.auth = 'signed-in';
-  setStatus('Dashboard synced', 'ok');
+  setStatus('Workbench synced', 'ok');
+  setRoute(window.location.hash.replace(/^#/, '') || state.activeRoute || defaultRoute(), true);
   renderAll();
 }
 
@@ -676,6 +778,9 @@ async function openBillingPortal() {
 }
 
 function bindForms() {
+  window.addEventListener('hashchange', () => {
+    setRoute(window.location.hash.replace(/^#/, '') || defaultRoute(), true);
+  });
   qs('#signin').addEventListener('click', () => { window.location.href = '/auth/login'; });
   qs('#signin-inline').addEventListener('click', () => { window.location.href = '/auth/login'; });
   qs('#logout').addEventListener('click', async () => {
@@ -723,11 +828,14 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
   const branding = resolvePublicBranding(publicBranding || policy.publicBranding)
   const copy = branding.dashboard || DEFAULT_WEBSITE_PUBLIC_BRANDING.dashboard || {}
   const labels = branding.managedOrgConnectionLabels || DEFAULT_WEBSITE_PUBLIC_BRANDING.managedOrgConnectionLabels || {}
-  const bootstrap = {
+  const bootstrap: CloudWebClientBootstrap = {
     role: policy.role,
     profileName: policy.profileName,
     features: policy.features,
     publicBranding: branding,
+    routes: CLOUD_WEB_ROUTES,
+    defaultRoute: DEFAULT_CLOUD_WEB_ROUTE,
+    api: CLOUD_WEB_CLIENT_ENDPOINTS,
   }
   const adminDefault = canManageOrg(policy.role as WebsiteRole)
   return `<!doctype html>
@@ -861,6 +969,22 @@ ${publicBrandingCss(branding)}
       color: var(--muted);
       font-size: 12px;
     }
+    .nav-sections {
+      display: grid;
+      gap: 14px;
+    }
+    .nav-group {
+      display: grid;
+      gap: 6px;
+    }
+    .nav-heading {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 0 10px;
+    }
     .nav-links {
       display: grid;
       gap: 4px;
@@ -874,6 +998,14 @@ ${publicBrandingCss(branding)}
     .nav-links a:hover {
       background: var(--surface);
       text-decoration: none;
+    }
+    .nav-links a[data-active="true"] {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      box-shadow: 0 1px 0 rgba(24, 33, 28, 0.04);
+    }
+    .nav-links a[data-locked="true"] {
+      color: var(--muted);
     }
     .brand-links {
       margin-top: auto;
@@ -924,6 +1056,9 @@ ${publicBrandingCss(branding)}
       display: grid;
       gap: 12px;
     }
+    [data-route-panel][hidden], [data-route-link][hidden] {
+      display: none;
+    }
     .section:first-child {
       border-top: 0;
       padding-top: 0;
@@ -938,6 +1073,12 @@ ${publicBrandingCss(branding)}
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 12px;
+    }
+    .workbench-split {
+      display: grid;
+      grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.6fr);
+      gap: 12px;
+      align-items: start;
     }
     .panel {
       background: var(--surface);
@@ -984,6 +1125,36 @@ ${publicBrandingCss(branding)}
     .list {
       display: grid;
       gap: 8px;
+    }
+    .table-shell {
+      display: grid;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      background: #fff;
+    }
+    .table-row {
+      display: grid;
+      grid-template-columns: minmax(180px, 1.4fr) minmax(90px, 0.6fr) minmax(110px, 0.7fr) minmax(120px, 0.7fr);
+      gap: 10px;
+      min-height: 42px;
+      align-items: center;
+      padding: 0 12px;
+      border-top: 1px solid var(--line);
+      font-size: 13px;
+    }
+    .table-row:first-child {
+      border-top: 0;
+    }
+    .table-head {
+      min-height: 34px;
+      background: var(--muted-surface);
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .empty-row {
+      color: var(--muted);
     }
     .row {
       min-height: 52px;
@@ -1069,8 +1240,14 @@ ${publicBrandingCss(branding)}
         border-right: 0;
         border-bottom: 1px solid var(--line);
       }
-      .grid, .form-grid {
+      .grid, .form-grid, .workbench-split {
         grid-template-columns: 1fr;
+      }
+      .table-shell {
+        overflow-x: auto;
+      }
+      .table-row {
+        min-width: 620px;
       }
       .topbar {
         align-items: flex-start;
@@ -1098,13 +1275,8 @@ ${publicBrandingCss(branding)}
           <div class="meta" id="profile-name">${escapeHtml(policy.profileName)}</div>
         </div>
       </div>
-      <nav class="nav-links" aria-label="Dashboard sections">
-        <a href="#workspace">Workspace</a>
-        <a href="#byok">BYOK</a>
-        <a href="#connections">Connections</a>
-        <a href="#gateway">Gateway</a>
-        <a href="#billing">Billing</a>
-        <a href="#usage">Usage</a>
+      <nav class="nav-sections" aria-label="Cloud Web sections">
+        ${routeGroupsMarkup()}
       </nav>
       <div>
         <div class="meta">Role</div>
@@ -1128,7 +1300,131 @@ ${publicBrandingCss(branding)}
       <div class="content">
         <p class="notice" id="admin-notice" hidden>Admin actions are disabled for this role. Ask an org owner or admin to manage keys, tokens, billing, and channel setup.</p>
 
-        <section class="section" id="workspace">
+        <section ${routePanelAttrs('threads')}>
+          <div class="section-header">
+            <div>
+              <h2>Threads</h2>
+              <div class="meta">Cloud workspace threads</div>
+            </div>
+            <button class="primary" type="button" disabled data-policy-state="deferred">New thread</button>
+          </div>
+          <div class="panel">
+            <div class="table-shell" role="table" aria-label="Cloud threads">
+              <div class="table-row table-head" role="row">
+                <span role="columnheader">Thread</span>
+                <span role="columnheader">Status</span>
+                <span role="columnheader">Surface</span>
+                <span role="columnheader">Updated</span>
+              </div>
+              <div class="table-row empty-row" role="row">
+                <span role="cell">No cloud threads loaded.</span>
+                <span role="cell">-</span>
+                <span role="cell">-</span>
+                <span role="cell">-</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('chat')}>
+          <div class="section-header">
+            <div>
+              <h2>Chat</h2>
+              <div class="meta">Selected cloud session</div>
+            </div>
+            <span class="pill" data-kind="${policy.features.chat ? 'ok' : 'warn'}">${policy.features.chat ? 'enabled' : 'disabled'}</span>
+          </div>
+          <div class="workbench-split">
+            <div class="panel">
+              <h3>Timeline</h3>
+              <p class="empty">No thread selected.</p>
+            </div>
+            <form class="panel">
+              <h3>Composer</h3>
+              <label><span>Message</span><input disabled placeholder="Select a cloud thread"></label>
+              <button class="primary" type="button" disabled>Send</button>
+            </form>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('agents')}>
+          <div class="section-header">
+            <div>
+              <h2>Agents</h2>
+              <div class="meta">Profile-allowed execution choices</div>
+            </div>
+          </div>
+          <div class="grid">
+            <div class="panel">
+              <h3>Available agents</h3>
+              <p class="empty">No agents loaded.</p>
+            </div>
+            <div class="panel">
+              <h3>Policy</h3>
+              <div class="row compact"><strong>Profile</strong><span>${escapeHtml(policy.profileName)}</span></div>
+              <div class="row compact"><strong>Chat</strong><span>${policy.features.chat ? 'enabled' : 'disabled'}</span></div>
+            </div>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('capabilities')}>
+          <div class="section-header">
+            <div>
+              <h2>Tools & Skills</h2>
+              <div class="meta">Capability policy verdicts</div>
+            </div>
+          </div>
+          <div class="grid">
+            <div class="panel">
+              <h3>Tools</h3>
+              <p class="empty">No tools loaded.</p>
+            </div>
+            <div class="panel">
+              <h3>Skills and MCPs</h3>
+              <p class="empty">No skills loaded.</p>
+            </div>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('workflows')}>
+          <div class="section-header">
+            <div>
+              <h2>Workflows</h2>
+              <div class="meta">Definitions and runs</div>
+            </div>
+            <span class="pill" data-kind="${policy.features.workflows ? 'ok' : 'warn'}">${policy.features.workflows ? 'enabled' : 'disabled'}</span>
+          </div>
+          <div class="panel">
+            <div class="table-shell" role="table" aria-label="Cloud workflows">
+              <div class="table-row table-head" role="row">
+                <span role="columnheader">Workflow</span>
+                <span role="columnheader">Status</span>
+                <span role="columnheader">Last run</span>
+                <span role="columnheader">Next run</span>
+              </div>
+              <div class="table-row empty-row" role="row">
+                <span role="cell">No workflows loaded.</span>
+                <span role="cell">-</span>
+                <span role="cell">-</span>
+                <span role="cell">-</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('artifacts')}>
+          <div class="section-header">
+            <div>
+              <h2>Artifacts</h2>
+              <div class="meta">Cloud artifact metadata</div>
+            </div>
+          </div>
+          <div class="panel">
+            <p class="empty">No artifacts loaded.</p>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('org', { signedIn: false })}>
           <div class="section-header">
             <div>
               <h2>${escapeHtml(copy.title || 'Workspace')}</h2>
@@ -1150,7 +1446,40 @@ ${publicBrandingCss(branding)}
           </div>
         </section>
 
-        <section class="section signed-in-only" id="byok">
+        <section ${routePanelAttrs('members', { admin: true })}>
+          <div class="section-header">
+            <div>
+              <h2>Members</h2>
+              <div class="meta">Roles and invites</div>
+            </div>
+          </div>
+          <div class="panel">
+            <p class="empty">No member records loaded.</p>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('policy')}>
+          <div class="section-header">
+            <div>
+              <h2>Profiles & Policy</h2>
+              <div class="meta">Runtime profile and feature flags</div>
+            </div>
+          </div>
+          <div class="grid">
+            <div class="panel">
+              <h3>Runtime profile</h3>
+              <div class="row compact"><strong>Profile</strong><span>${escapeHtml(policy.profileName)}</span></div>
+              <div class="row compact"><strong>Role</strong><span>${escapeHtml(policy.role)}</span></div>
+            </div>
+            <div class="panel">
+              <h3>Features</h3>
+              <div class="row compact"><strong>Chat</strong><span>${policy.features.chat ? 'enabled' : 'disabled'}</span></div>
+              <div class="row compact"><strong>Workflows</strong><span>${policy.features.workflows ? 'enabled' : 'disabled'}</span></div>
+            </div>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('byok', { admin: true })}>
           <div class="section-header">
             <div>
               <h2>BYOK</h2>
@@ -1173,7 +1502,7 @@ ${publicBrandingCss(branding)}
           </div>
         </section>
 
-        <section class="section signed-in-only" id="connections">
+        <section ${routePanelAttrs('connections', { admin: true })}>
           <div class="section-header">
             <div>
               <h2>Connections</h2>
@@ -1202,7 +1531,7 @@ ${publicBrandingCss(branding)}
           </div>
         </section>
 
-        <section class="section signed-in-only" id="gateway">
+        <section ${routePanelAttrs('gateway', { admin: true })}>
           <div class="section-header">
             <div>
               <h2>Headless gateway</h2>
@@ -1253,7 +1582,7 @@ ${publicBrandingCss(branding)}
           </div>
         </section>
 
-        <section class="section signed-in-only" id="billing">
+        <section ${routePanelAttrs('billing', { admin: true })}>
           <div class="section-header">
             <div>
               <h2>Billing</h2>
@@ -1277,7 +1606,19 @@ ${publicBrandingCss(branding)}
           </div>
         </section>
 
-        <section class="section signed-in-only" id="usage">
+        <section ${routePanelAttrs('audit', { admin: true })}>
+          <div class="section-header">
+            <div>
+              <h2>Audit</h2>
+              <div class="meta">Redacted administrative events</div>
+            </div>
+          </div>
+          <div class="panel">
+            <p class="empty">No audit events loaded.</p>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('usage')}>
           <div class="section-header">
             <div>
               <h2>Usage</h2>
@@ -1286,6 +1627,25 @@ ${publicBrandingCss(branding)}
           </div>
           <div class="panel">
             <div class="list" id="usage-list"></div>
+          </div>
+        </section>
+
+        <section ${routePanelAttrs('diagnostics', { admin: true })}>
+          <div class="section-header">
+            <div>
+              <h2>Diagnostics</h2>
+              <div class="meta">Redacted operational state</div>
+            </div>
+          </div>
+          <div class="grid">
+            <div class="panel">
+              <h3>Health</h3>
+              <p class="empty">No diagnostics loaded.</p>
+            </div>
+            <div class="panel">
+              <h3>Support bundle</h3>
+              <button type="button" disabled data-admin-control="true">Prepare bundle</button>
+            </div>
           </div>
         </section>
       </div>

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -158,15 +158,37 @@ The typed `createHttpSseCloudTransportAdapter` wraps that HTTP/SSE contract for
 browser clients that need a `window.coworkApi`-style transport without Electron
 IPC.
 
-## Browser Dashboard
+## Cloud Web Workbench
 
-The cloud web role serves a browser dashboard at `/`. The dashboard is an API
-client for the same cloud control plane used by desktop sync and gateway
+The cloud web role serves the Cloud Web Workbench at `/`. The workbench is an
+API client for the same cloud control plane used by desktop sync and gateway
 clients; it does not access Postgres or secret storage directly.
+
+The browser app currently keeps a no-framework, server-rendered shell with an
+inline nonce-protected client script. That is intentional for the first cloud
+workbench build-out: it keeps the cloud image simple, preserves the existing
+CSP and cookie-auth path, and avoids introducing a separate asset build before
+the browser product surface needs richer interaction. The shell is still split
+around typed route metadata so the app can grow into a bundled browser client
+without changing the Cloud API contract.
+
+The information architecture is split into two surfaces:
+
+- Workbench: Threads, Chat, Agents, Tools & Skills, Workflows, and Artifacts.
+- Admin: Org, Members, Profiles & Policy, BYOK, Connections, Billing, Gateway,
+  Audit, Usage, and Diagnostics.
+
+Signed-in member users can open the workbench and read allowed org/policy/usage
+state. Admin-only panels are rendered as read-only for members and all admin
+mutations remain server-authorized. Disabled controls in the browser are an
+ergonomic layer only.
 
 Authenticated users land on an org-scoped dashboard backed by
 `GET /api/workspace`. That request also performs the configured first-login org
-bootstrap path. The dashboard exposes:
+bootstrap path. The workbench also bootstraps public deployment metadata from
+`GET /api/config`; both bootstrap responses are metadata-only and must not
+contain provider keys, OAuth tokens, API tokens, MCP secrets, or local host
+paths. Existing admin panels expose:
 
 - BYOK provider status and key submission through metadata-only BYOK APIs,
 - one-time API token issuance and revocation for desktop and gateway clients,


### PR DESCRIPTION
## Summary

- adds typed Cloud Web Workbench route metadata and client endpoint/bootstrap contracts
- turns the existing browser dashboard into a workbench/admin shell while preserving BYOK, token, gateway, billing, and usage flows
- documents the no-framework server-rendered web app decision and adds tests for role states, route metadata, no-secret browser storage, and raw-script JSON bootstrap safety

Closes #479

## Verification

- `pnpm --filter @open-cowork/website test`
- `pnpm --filter @open-cowork/website typecheck`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm docs:build`
- `git diff --check`
- `node scripts/run-node-tests.mjs tests/cloud-http-server.test.ts tests/content-security-policy.test.ts`
- `pnpm test`
