### PR TITLE
Build cloud web runtime parity

### DIFF
--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -2540,6 +2540,7 @@ export class CloudSessionService {
       payload: {
         commandId: command.commandId,
         requestId: payload.requestId,
+        answers: payload.answers,
       },
       leaseToken: lease.leaseToken,
     })

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -12,6 +12,14 @@ export type CloudWebEndpointId =
   | 'billingSubscription'
   | 'usageEvents'
   | 'sessions'
+  | 'sessionView'
+  | 'sessionEvents'
+  | 'sessionPrompt'
+  | 'sessionPermissionRespond'
+  | 'sessionQuestionReply'
+  | 'sessionQuestionReject'
+  | 'sessionArtifacts'
+  | 'sessionArtifact'
   | 'projectSourceValidate'
   | 'projectSnapshots'
 
@@ -44,6 +52,14 @@ export type CloudWebClientStateContract = {
   selectedSessionId: string | null
   sessions: unknown[]
   sessionViews: Record<string, unknown>
+  runtimeActions: Record<string, boolean>
+  artifactPanel: {
+    sessionId: string | null
+    artifactId: string | null
+    metadata: Record<string, unknown> | null
+    status: 'idle' | 'loading' | 'error'
+    error: string | null
+  }
   workspaceEvents: {
     status: CloudWebConnectionStatus
     cursor: number
@@ -116,6 +132,54 @@ export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
     id: 'sessions',
     method: 'GET',
     path: '/api/sessions',
+    csrf: false,
+  },
+  {
+    id: 'sessionView',
+    method: 'GET',
+    path: '/api/sessions/:sessionId/view',
+    csrf: false,
+  },
+  {
+    id: 'sessionEvents',
+    method: 'GET',
+    path: '/api/sessions/:sessionId/events',
+    csrf: false,
+  },
+  {
+    id: 'sessionPrompt',
+    method: 'POST',
+    path: '/api/sessions/:sessionId/prompt',
+    csrf: true,
+  },
+  {
+    id: 'sessionPermissionRespond',
+    method: 'POST',
+    path: '/api/sessions/:sessionId/permission-respond',
+    csrf: true,
+  },
+  {
+    id: 'sessionQuestionReply',
+    method: 'POST',
+    path: '/api/sessions/:sessionId/question-reply',
+    csrf: true,
+  },
+  {
+    id: 'sessionQuestionReject',
+    method: 'POST',
+    path: '/api/sessions/:sessionId/question-reject',
+    csrf: true,
+  },
+  {
+    id: 'sessionArtifacts',
+    method: 'GET',
+    path: '/api/sessions/:sessionId/artifacts',
+    csrf: false,
+  },
+  {
+    id: 'sessionArtifact',
+    method: 'GET',
+    path: '/api/sessions/:sessionId/artifacts/:artifactId',
     csrf: false,
   },
   {

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -9,6 +9,13 @@ import {
   cloudWebThreadStatus,
   filterCloudWebThreads,
 } from './thread-workbench.ts'
+import {
+  CLOUD_WEB_RUNTIME_ENTITY_CLASSES,
+  cloudWebErrorCategory,
+  cloudWebRuntimeCounts,
+  cloudWebRuntimeOrder,
+  cloudWebSafeArtifactMetadata,
+} from './runtime-workbench.ts'
 
 const html = cloudWebsiteHtml({
   role: 'web',
@@ -60,6 +67,14 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
     selectedSessionId: null,
     sessions: [],
     sessionViews: {},
+    runtimeActions: {},
+    artifactPanel: {
+      sessionId: null,
+      artifactId: null,
+      metadata: null,
+      status: 'idle',
+      error: null,
+    },
     workspaceEvents: {
       status: 'idle',
       cursor: 0,
@@ -74,6 +89,11 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
   }
   assert.equal(stateContract.workspaceEvents.status, 'idle')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessions')?.path, '/api/sessions')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessionView')?.path, '/api/sessions/:sessionId/view')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessionPermissionRespond')?.path, '/api/sessions/:sessionId/permission-respond')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessionQuestionReply')?.path, '/api/sessions/:sessionId/question-reply')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessionQuestionReject')?.path, '/api/sessions/:sessionId/question-reject')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessionArtifact')?.path, '/api/sessions/:sessionId/artifacts/:artifactId')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'projectSourceValidate')?.path, '/api/project-sources/validate')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'projectSnapshots')?.path, '/api/project-sources/snapshots')
 })
@@ -174,6 +194,7 @@ test('cloud website client avoids persistent browser secret storage', () => {
 
 test('cloud website binds actions through the client script', () => {
   assert.equal(html.includes('onclick='), false)
+  assert.doesNotThrow(() => new Function(cloudWebsiteClientScript()))
   assert.match(cloudWebsiteClientScript(), /signin-inline/)
   assert.match(cloudWebsiteClientScript(), /\/api\/config/)
   assert.match(cloudWebsiteClientScript(), /\/api\/workspace/)
@@ -183,6 +204,11 @@ test('cloud website binds actions through the client script', () => {
   assert.match(cloudWebsiteClientScript(), /sessionEventTypes/)
   assert.match(cloudWebsiteClientScript(), /createCloudSessionFromForm/)
   assert.match(cloudWebsiteClientScript(), /promptSelectedSession/)
+  assert.match(cloudWebsiteClientScript(), /respondToPermission/)
+  assert.match(cloudWebsiteClientScript(), /answerQuestion/)
+  assert.match(cloudWebsiteClientScript(), /rejectQuestion/)
+  assert.match(cloudWebsiteClientScript(), /openArtifact/)
+  assert.match(cloudWebsiteClientScript(), /safeArtifactMetadata/)
   assert.match(cloudWebsiteClientScript(), /setRoute/)
   assert.match(cloudWebsiteClientScript(), /providerSettingsFromForm/)
   assert.match(cloudWebsiteClientScript(), /updateBindingProviderFields/)
@@ -195,8 +221,84 @@ test('cloud website renders cloud thread controls without local host path afford
   assert.match(html, /Uploaded snapshot/)
   assert.match(html, /id="prompt-form"/)
   assert.match(html, /id="chat-timeline"/)
+  assert.match(html, /id="artifact-list"/)
+  assert.match(html, /id="artifact-detail"/)
   assert.doesNotMatch(html, /\/Users\//)
   assert.doesNotMatch(html, /local stdio MCP/i)
+})
+
+test('cloud website runtime helper covers all runtime entity classes', () => {
+  assert.deepEqual(CLOUD_WEB_RUNTIME_ENTITY_CLASSES, [
+    'message',
+    'taskRun',
+    'toolCall',
+    'pendingApproval',
+    'resolvedApproval',
+    'pendingQuestion',
+    'resolvedQuestion',
+    'artifact',
+    'todo',
+    'error',
+    'usage',
+    'context',
+  ])
+  const counts = cloudWebRuntimeCounts({
+    messages: [{ id: 'message-1' }],
+    taskRuns: [{ id: 'task-1' }],
+    toolCalls: [{ id: 'tool-1' }],
+    pendingApprovals: [{ id: 'approval-1' }],
+    resolvedApprovals: [{ id: 'approval-1' }],
+    pendingQuestions: [{ id: 'question-1' }],
+    resolvedQuestions: [{ id: 'question-1' }],
+    artifacts: [{ artifactId: 'artifact-1' }],
+    todos: [{ id: 'todo-1' }],
+    errors: [{ id: 'error-1' }],
+    sessionCost: 0.13,
+    sessionTokens: { input: 10, output: 5, reasoning: 2, cacheRead: 1, cacheWrite: 1 },
+    contextState: 'measured',
+  })
+  assert.equal(counts.message, 1)
+  assert.equal(counts.taskRun, 1)
+  assert.equal(counts.toolCall, 1)
+  assert.equal(counts.pendingApproval, 1)
+  assert.equal(counts.resolvedApproval, 1)
+  assert.equal(counts.pendingQuestion, 1)
+  assert.equal(counts.resolvedQuestion, 1)
+  assert.equal(counts.artifact, 1)
+  assert.equal(counts.todo, 1)
+  assert.equal(counts.error, 1)
+  assert.equal(counts.usage, 1)
+  assert.equal(counts.context, 1)
+  assert.equal(cloudWebRuntimeCounts({ contextState: 'idle' }).context, 0)
+})
+
+test('cloud website runtime helper preserves order and classifies errors', () => {
+  assert.equal(cloudWebRuntimeOrder({ order: 42 }, 7), 42)
+  assert.equal(cloudWebRuntimeOrder({}, 7), 7)
+  assert.equal(cloudWebErrorCategory('Policy blocked by profile'), 'policy')
+  assert.equal(cloudWebErrorCategory('Unauthorized token'), 'auth')
+  assert.equal(cloudWebErrorCategory('Quota exceeded'), 'quota')
+  assert.equal(cloudWebErrorCategory('Billing subscription inactive'), 'billing')
+  assert.equal(cloudWebErrorCategory('Provider API key invalid'), 'provider')
+  assert.equal(cloudWebErrorCategory('Runtime crashed'), 'runtime')
+})
+
+test('cloud website artifact metadata redacts transient artifact bodies and URLs', () => {
+  assert.deepEqual(cloudWebSafeArtifactMetadata({
+    artifactId: 'artifact-1',
+    filename: 'result.txt',
+    dataBase64: 'YQ==',
+    signedUrl: 'https://object.example.test/signed?token=secret',
+    downloadUrl: 'https://object.example.test/download?token=secret',
+    key: 'tenant/session/artifact-1/result.txt',
+    bucket: 'open-cowork-prod-artifacts',
+    token: 'secret',
+  }), {
+    artifactId: 'artifact-1',
+    filename: 'result.txt',
+  })
+  assert.match(cloudWebsiteClientScript(), /URL\.createObjectURL/)
+  assert.match(cloudWebsiteClientScript(), /URL\.revokeObjectURL/)
 })
 
 test('cloud website thread helper handles status filters and thousands-sized lists', () => {

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -193,6 +193,7 @@ const state = {
   sessions: [],
   sessionViews: {},
   selectedSessionId: null,
+  runtimeActions: {},
   threadLimit: ${CLOUD_WEB_THREAD_PAGE_SIZE},
   threadFilters: {
     query: '',
@@ -211,6 +212,13 @@ const state = {
   workspaceEvents: {
     source: null,
     cursor: 0,
+    status: 'idle',
+    error: null,
+  },
+  artifactPanel: {
+    sessionId: null,
+    artifactId: null,
+    metadata: null,
     status: 'idle',
     error: null,
   },
@@ -327,6 +335,14 @@ function endpoint(id, fallback) {
   return entry?.path || fallback;
 }
 
+function endpointPath(id, fallback, params = {}) {
+  let path = endpoint(id, fallback);
+  for (const [key, value] of Object.entries(params)) {
+    path = path.replace(':' + key, encodeURIComponent(String(value)));
+  }
+  return path;
+}
+
 function headers(hasBody) {
   const next = hasBody ? { 'content-type': 'application/json' } : {};
   if (state.csrfToken) next['x-csrf-token'] = state.csrfToken;
@@ -365,6 +381,14 @@ function renderSignedOut() {
   state.sessions = [];
   state.sessionViews = {};
   state.selectedSessionId = null;
+  state.runtimeActions = {};
+  state.artifactPanel = {
+    sessionId: null,
+    artifactId: null,
+    metadata: null,
+    status: 'idle',
+    error: null,
+  };
   state.sessionEvents = {
     source: null,
     sessionId: null,
@@ -412,8 +436,111 @@ function actionButton(label, onClick, variant = '', disabled = false) {
   button.textContent = label;
   button.disabled = disabled;
   if (variant) button.className = variant;
-  button.addEventListener('click', onClick);
+  button.addEventListener('click', () => {
+    try {
+      const result = onClick();
+      if (result && typeof result.catch === 'function') result.catch((error) => setStatus(error.message || 'Action failed', 'error'));
+    } catch (error) {
+      setStatus(error.message || 'Action failed', 'error');
+    }
+  });
   return button;
+}
+
+function normalizeList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function safeObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function compactJson(value) {
+  try {
+    return JSON.stringify(value ?? {}, null, 2);
+  } catch {
+    return String(value ?? '');
+  }
+}
+
+function byteLabel(value) {
+  const bytes = typeof value === 'number' && Number.isFinite(value) ? value : 0;
+  if (bytes >= 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+  if (bytes >= 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return bytes + ' B';
+}
+
+function tokenNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function actionPending(key) {
+  return Boolean(state.runtimeActions[key]);
+}
+
+async function withRuntimeAction(key, action) {
+  if (state.runtimeActions[key]) return;
+  state.runtimeActions[key] = true;
+  renderChat();
+  renderArtifacts();
+  try {
+    await action();
+    await refreshSelectedSession();
+    await loadSessions({ keepSelection: true });
+  } finally {
+    delete state.runtimeActions[key];
+    renderChat();
+    renderArtifacts();
+  }
+}
+
+function runtimeViewFromCloudView(view) {
+  const sessionView = safeObject(view?.view);
+  const projection = projectionFromView(view);
+  return {
+    ...projection,
+    messages: normalizeList(sessionView.messages).length ? normalizeList(sessionView.messages) : projection.messages,
+    toolCalls: normalizeList(sessionView.toolCalls).length ? normalizeList(sessionView.toolCalls) : projection.toolCalls,
+    taskRuns: normalizeList(sessionView.taskRuns).length ? normalizeList(sessionView.taskRuns) : projection.taskRuns,
+    pendingApprovals: normalizeList(sessionView.pendingApprovals).length ? normalizeList(sessionView.pendingApprovals) : projection.pendingApprovals,
+    pendingQuestions: normalizeList(sessionView.pendingQuestions).length ? normalizeList(sessionView.pendingQuestions) : projection.pendingQuestions,
+    artifacts: normalizeList(sessionView.artifacts).length ? normalizeList(sessionView.artifacts) : projection.artifacts,
+    todos: normalizeList(sessionView.todos).length ? normalizeList(sessionView.todos) : projection.todos,
+    errors: normalizeList(sessionView.errors).length ? normalizeList(sessionView.errors) : projection.errors,
+    sessionCost: typeof sessionView.sessionCost === 'number' ? sessionView.sessionCost : projection.sessionCost,
+    sessionTokens: safeObject(sessionView.sessionTokens || projection.sessionTokens),
+    lastInputTokens: typeof sessionView.lastInputTokens === 'number' ? sessionView.lastInputTokens : projection.lastInputTokens,
+    contextState: sessionView.contextState || projection.contextState || 'idle',
+    compactionCount: tokenNumber(sessionView.compactionCount || projection.compactionCount),
+    lastCompactedAt: sessionView.lastCompactedAt || projection.lastCompactedAt || null,
+    isGenerating: Boolean(sessionView.isGenerating || projection.isGenerating),
+    isAwaitingPermission: Boolean(sessionView.isAwaitingPermission || projection.pendingApprovals.length),
+    isAwaitingQuestion: Boolean(sessionView.isAwaitingQuestion || projection.pendingQuestions.length),
+  };
+}
+
+function messageText(message) {
+  if (typeof message.content === 'string' && message.content) return message.content;
+  if (Array.isArray(message.segments)) return message.segments.map((segment) => segment.content || '').join('');
+  return '';
+}
+
+function runtimeOrder(item, fallback) {
+  return typeof item?.order === 'number' && Number.isFinite(item.order) ? item.order : fallback;
+}
+
+function artifactId(artifact) {
+  return artifact?.cloudArtifactId || artifact?.artifactId || artifact?.id || '';
+}
+
+function safeArtifactMetadata(artifact) {
+  const metadata = {};
+  for (const [key, value] of Object.entries(safeObject(artifact))) {
+    const normalized = key.toLowerCase();
+    if (['database64', 'url', 'downloadurl', 'signedurl', 'presignedurl', 'key', 'objectkey', 'storagekey', 'bucket', 'container', 'authorization', 'token'].includes(normalized)) continue;
+    metadata[key] = value;
+  }
+  return metadata;
 }
 
 function renderWorkspace() {
@@ -647,11 +774,18 @@ function projectionFromView(view) {
       taskRuns: [],
       pendingApprovals: [],
       pendingQuestions: [],
+      resolvedApprovals: [],
+      resolvedQuestions: [],
       artifacts: [],
       todos: [],
       errors: [],
       sessionCost: 0,
       sessionTokens: {},
+      lastInputTokens: 0,
+      isGenerating: false,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
       origin: null,
       projectSource: null,
       tags: [],
@@ -668,11 +802,18 @@ function projectionFromView(view) {
     taskRuns: Array.isArray(projection.taskRuns) ? projection.taskRuns : [],
     pendingApprovals: Array.isArray(projection.pendingApprovals) ? projection.pendingApprovals : [],
     pendingQuestions: Array.isArray(projection.pendingQuestions) ? projection.pendingQuestions : [],
+    resolvedApprovals: Array.isArray(projection.resolvedApprovals) ? projection.resolvedApprovals : [],
+    resolvedQuestions: Array.isArray(projection.resolvedQuestions) ? projection.resolvedQuestions : [],
     artifacts: Array.isArray(projection.artifacts) ? projection.artifacts : [],
     todos: Array.isArray(projection.todos) ? projection.todos : [],
     errors: Array.isArray(projection.errors) ? projection.errors : [],
     sessionCost: typeof projection.sessionCost === 'number' ? projection.sessionCost : 0,
     sessionTokens: projection.sessionTokens && typeof projection.sessionTokens === 'object' ? projection.sessionTokens : {},
+    lastInputTokens: typeof projection.lastInputTokens === 'number' ? projection.lastInputTokens : 0,
+    isGenerating: Boolean(projection.isGenerating),
+    contextState: projection.contextState || 'idle',
+    compactionCount: typeof projection.compactionCount === 'number' ? projection.compactionCount : 0,
+    lastCompactedAt: projection.lastCompactedAt || null,
     origin: projection.origin && typeof projection.origin === 'object' ? projection.origin : null,
     projectSource: projection.projectSource && typeof projection.projectSource === 'object' ? projection.projectSource : null,
     tags: Array.isArray(projection.tags) ? projection.tags : [],
@@ -739,6 +880,264 @@ function statusPillKind(status) {
   if (status === 'approval' || status === 'question') return 'warn';
   if (status === 'errored' || status === 'error') return 'warn';
   return '';
+}
+
+function errorCategory(message) {
+  const text = String(message || '').toLowerCase();
+  if (text.includes('policy') || text.includes('disabled') || text.includes('not allowed')) return 'policy';
+  if (text.includes('auth') || text.includes('token') || text.includes('forbidden') || text.includes('unauthorized')) return 'auth';
+  if (text.includes('quota') || text.includes('rate limit') || text.includes('too many')) return 'quota';
+  if (text.includes('billing') || text.includes('subscription') || text.includes('payment')) return 'billing';
+  if (text.includes('provider') || text.includes('model') || text.includes('api key')) return 'provider';
+  return 'runtime';
+}
+
+function appendDetails(parent, summaryText, value) {
+  const details = document.createElement('details');
+  details.className = 'runtime-detail';
+  const summary = document.createElement('summary');
+  summary.textContent = summaryText;
+  const pre = document.createElement('pre');
+  pre.textContent = compactJson(value);
+  details.appendChild(summary);
+  details.appendChild(pre);
+  parent.appendChild(details);
+}
+
+function renderRuntimeSummary(projection) {
+  const summary = document.createElement('section');
+  summary.className = 'runtime-summary';
+  summary.appendChild(pill(projection.status || 'idle', statusPillKind(projection.status)));
+  if (projection.isGenerating) summary.appendChild(pill('generating', 'ok'));
+  if (projection.isAwaitingPermission) summary.appendChild(pill('awaiting approval', 'warn'));
+  if (projection.isAwaitingQuestion) summary.appendChild(pill('awaiting answer', 'warn'));
+  summary.appendChild(pill('cost $' + Number(projection.sessionCost || 0).toFixed(4)));
+  const tokens = safeObject(projection.sessionTokens);
+  const tokenText = [
+    'in ' + tokenNumber(tokens.input),
+    'out ' + tokenNumber(tokens.output),
+    'reason ' + tokenNumber(tokens.reasoning),
+    'cache ' + (tokenNumber(tokens.cacheRead) + tokenNumber(tokens.cacheWrite)),
+  ].join(' / ');
+  summary.appendChild(pill(tokenText));
+  if (projection.contextState && projection.contextState !== 'idle') summary.appendChild(pill('context ' + projection.contextState));
+  if (projection.compactionCount) summary.appendChild(pill('compactions ' + projection.compactionCount));
+  return summary;
+}
+
+function renderApprovalCard(approval) {
+  const key = 'approval:' + approval.id;
+  const card = document.createElement('article');
+  card.className = 'runtime-card';
+  card.dataset.kind = 'approval';
+  const header = document.createElement('div');
+  header.className = 'runtime-card-header';
+  header.appendChild(pill('Approval', 'warn'));
+  const title = document.createElement('strong');
+  title.textContent = approval.description || approval.tool || 'Permission requested';
+  header.appendChild(title);
+  card.appendChild(header);
+  const meta = document.createElement('small');
+  meta.textContent = [approval.tool, approval.taskRunId ? 'task ' + approval.taskRunId : null].filter(Boolean).join(' - ');
+  card.appendChild(meta);
+  appendDetails(card, 'Permission input', approval.input || {});
+  const actions = document.createElement('div');
+  actions.className = 'row-actions';
+  actions.appendChild(actionButton('Allow', () => respondToPermission(approval.id, true), 'primary', actionPending(key)));
+  actions.appendChild(actionButton('Deny', () => respondToPermission(approval.id, false), 'danger', actionPending(key)));
+  card.appendChild(actions);
+  return card;
+}
+
+function renderQuestionCard(question) {
+  const key = 'question:' + question.id;
+  const card = document.createElement('article');
+  card.className = 'runtime-card';
+  card.dataset.kind = 'question';
+  const header = document.createElement('div');
+  header.className = 'runtime-card-header';
+  header.appendChild(pill('Question', 'warn'));
+  const title = document.createElement('strong');
+  title.textContent = question.questions?.[0]?.question || 'Question requested';
+  header.appendChild(title);
+  card.appendChild(header);
+  for (const prompt of normalizeList(question.questions)) {
+    const block = document.createElement('div');
+    block.className = 'question-block';
+    if (prompt.header) {
+      const heading = document.createElement('strong');
+      heading.textContent = prompt.header;
+      block.appendChild(heading);
+    }
+    const text = document.createElement('p');
+    text.textContent = prompt.question || '';
+    block.appendChild(text);
+    if (Array.isArray(prompt.options) && prompt.options.length) {
+      const choices = document.createElement('div');
+      choices.className = 'choice-row';
+      for (const option of prompt.options) {
+        choices.appendChild(actionButton(option.label || option.description || 'Select', () => answerQuestion(question.id, [option.label || option.description || '']), 'secondary', actionPending(key)));
+      }
+      block.appendChild(choices);
+    }
+    card.appendChild(block);
+  }
+  const input = document.createElement('textarea');
+  input.placeholder = 'Answer';
+  input.rows = 3;
+  input.dataset.questionAnswer = question.id;
+  input.disabled = actionPending(key);
+  card.appendChild(input);
+  const actions = document.createElement('div');
+  actions.className = 'row-actions';
+  actions.appendChild(actionButton('Send answer', () => answerQuestion(question.id, [input.value.trim()].filter(Boolean)), 'primary', actionPending(key)));
+  actions.appendChild(actionButton('Reject', () => rejectQuestion(question.id), 'danger', actionPending(key)));
+  card.appendChild(actions);
+  return card;
+}
+
+function renderResolvedCard(kind, item) {
+  const row = document.createElement('div');
+  row.className = 'activity-row';
+  if (kind === 'approval') {
+    row.appendChild(pill(item.allowed ? 'approved' : 'denied', item.allowed ? 'ok' : 'warn'));
+    const text = document.createElement('span');
+    text.textContent = item.description || item.tool || item.id;
+    row.appendChild(text);
+  } else {
+    row.appendChild(pill(item.rejected ? 'question rejected' : 'answered', item.rejected ? 'warn' : 'ok'));
+    const text = document.createElement('span');
+    const prompt = item.questions?.[0]?.question || item.id;
+    const answers = item.answers?.length ? ': ' + item.answers.join(', ') : '';
+    text.textContent = prompt + answers;
+    row.appendChild(text);
+  }
+  return row;
+}
+
+function renderMessageBubble(message) {
+  const bubble = document.createElement('article');
+  bubble.className = 'message-bubble';
+  bubble.dataset.role = message.role;
+  const heading = document.createElement('div');
+  heading.className = 'message-heading';
+  heading.textContent = message.role === 'user' ? 'You' : 'Assistant';
+  const body = document.createElement('p');
+  body.textContent = messageText(message);
+  bubble.appendChild(heading);
+  bubble.appendChild(body);
+  if (Array.isArray(message.attachments) && message.attachments.length) {
+    appendDetails(bubble, 'Attachments', message.attachments);
+  }
+  return bubble;
+}
+
+function renderToolTrace(tool) {
+  const details = document.createElement('details');
+  details.className = 'runtime-detail tool-trace';
+  const summary = document.createElement('summary');
+  summary.appendChild(pill(tool.status || 'tool', statusPillKind(tool.status)));
+  const title = document.createElement('span');
+  title.textContent = tool.name || tool.id || 'Tool call';
+  summary.appendChild(title);
+  details.appendChild(summary);
+  appendDetails(details, 'Input', tool.input || {});
+  if (tool.output !== undefined) appendDetails(details, 'Output', tool.output);
+  if (Array.isArray(tool.attachments) && tool.attachments.length) appendDetails(details, 'Attachments', tool.attachments);
+  return details;
+}
+
+function renderTaskRun(task) {
+  const details = document.createElement('details');
+  details.className = 'runtime-detail task-run';
+  const summary = document.createElement('summary');
+  summary.appendChild(pill(task.status || 'task', statusPillKind(task.status)));
+  const title = document.createElement('span');
+  title.textContent = task.title || task.agent || task.id || 'Task run';
+  summary.appendChild(title);
+  details.appendChild(summary);
+  if (task.content) {
+    const body = document.createElement('p');
+    body.textContent = task.content;
+    details.appendChild(body);
+  }
+  if (task.agent) details.appendChild(pill('agent ' + task.agent));
+  if (task.error) {
+    const error = document.createElement('p');
+    error.className = 'notice';
+    error.textContent = task.error;
+    details.appendChild(error);
+  }
+  for (const tool of normalizeList(task.toolCalls)) {
+    details.appendChild(renderToolTrace(tool));
+  }
+  if (normalizeList(task.todos).length) appendDetails(details, 'Task todos', task.todos);
+  return details;
+}
+
+function renderArtifactCard(artifact) {
+  const id = artifactId(artifact);
+  const card = document.createElement('article');
+  card.className = 'runtime-card artifact-card';
+  card.dataset.kind = 'artifact';
+  const header = document.createElement('div');
+  header.className = 'runtime-card-header';
+  header.appendChild(pill('Artifact', 'ok'));
+  const title = document.createElement('strong');
+  title.textContent = artifact.filename || artifact.name || id || 'Artifact';
+  header.appendChild(title);
+  card.appendChild(header);
+  const meta = document.createElement('small');
+  meta.textContent = [
+    artifact.mime || artifact.contentType || 'unknown type',
+    artifact.size !== undefined ? byteLabel(artifact.size) : null,
+    artifact.taskRunId ? 'task ' + artifact.taskRunId : null,
+    artifact.toolName || artifact.toolId || null,
+  ].filter(Boolean).join(' - ');
+  card.appendChild(meta);
+  appendDetails(card, 'Metadata', safeArtifactMetadata({
+    id,
+    filePath: artifact.filePath || null,
+    toolId: artifact.toolId || null,
+    toolName: artifact.toolName || null,
+    taskRunId: artifact.taskRunId || null,
+    createdAt: artifact.createdAt || null,
+  }));
+  const actions = document.createElement('div');
+  actions.className = 'row-actions';
+  actions.appendChild(actionButton('View', () => openArtifact(id, 'view'), 'secondary', !id || actionPending('artifact:' + id)));
+  actions.appendChild(actionButton('Download', () => openArtifact(id, 'download'), 'primary', !id || actionPending('artifact:' + id)));
+  actions.appendChild(actionButton('Inspect', () => inspectArtifact(id), 'secondary', !id));
+  card.appendChild(actions);
+  return card;
+}
+
+function renderTodoList(todos) {
+  const list = document.createElement('section');
+  list.className = 'activity-block';
+  const heading = document.createElement('h4');
+  heading.textContent = 'Todos';
+  list.appendChild(heading);
+  for (const todo of todos) {
+    const row = document.createElement('div');
+    row.className = 'activity-row';
+    row.appendChild(pill(todo.status || 'todo'));
+    const text = document.createElement('span');
+    text.textContent = [todo.content, todo.priority ? '(' + todo.priority + ')' : null].filter(Boolean).join(' ');
+    row.appendChild(text);
+    list.appendChild(row);
+  }
+  return list;
+}
+
+function renderRuntimeError(error) {
+  const item = document.createElement('div');
+  item.className = 'notice runtime-error';
+  item.appendChild(pill(errorCategory(error.message), 'warn'));
+  const text = document.createElement('span');
+  text.textContent = error.message || 'Runtime error';
+  item.appendChild(text);
+  return item;
 }
 
 function renderThreadList() {
@@ -810,7 +1209,7 @@ function renderChat() {
   const composer = qs('#prompt-form');
   const eventStatus = qs('#chat-event-status');
   const view = state.selectedSessionId ? state.sessionViews[state.selectedSessionId] : null;
-  const projection = projectionFromView(view);
+  const projection = runtimeViewFromCloudView(view);
   if (title) title.textContent = view ? sessionTitle(view.session) : 'No thread selected';
   if (meta) {
     const details = view
@@ -820,6 +1219,7 @@ function renderChat() {
           projection.messages.length + ' message(s)',
           projection.toolCalls.length + ' tool call(s)',
           projection.taskRuns.length + ' task run(s)',
+          projection.artifacts.length + ' artifact(s)',
         ]
       : ['Select a cloud thread'];
     meta.textContent = details.filter(Boolean).join(' - ');
@@ -844,88 +1244,97 @@ function renderChat() {
     timeline.appendChild(empty);
     return;
   }
-  const waits = [
-    ...projection.pendingApprovals.map((approval) => ({ kind: 'Approval', text: approval.description || approval.tool })),
-    ...projection.pendingQuestions.map((question) => ({ kind: 'Question', text: question.questions?.[0]?.question || 'Question requested' })),
-  ];
-  for (const wait of waits) {
-    const item = document.createElement('div');
-    item.className = 'wait-banner';
-    item.appendChild(pill(wait.kind, 'warn'));
-    const text = document.createElement('span');
-    text.textContent = wait.text;
-    item.appendChild(text);
-    timeline.appendChild(item);
+
+  timeline.appendChild(renderRuntimeSummary(projection));
+
+  for (const approval of projection.pendingApprovals) {
+    timeline.appendChild(renderApprovalCard(approval));
   }
-  for (const message of projection.messages) {
-    const bubble = document.createElement('article');
-    bubble.className = 'message-bubble';
-    bubble.dataset.role = message.role;
-    const heading = document.createElement('div');
-    heading.className = 'message-heading';
-    heading.textContent = message.role === 'user' ? 'You' : 'Assistant';
-    const body = document.createElement('p');
-    body.textContent = message.content || '';
-    bubble.appendChild(heading);
-    bubble.appendChild(body);
-    timeline.appendChild(bubble);
+  for (const question of projection.pendingQuestions) {
+    timeline.appendChild(renderQuestionCard(question));
   }
-  if (projection.taskRuns.length || projection.toolCalls.length || projection.artifacts.length || projection.todos.length) {
+
+  const resolved = [
+    ...projection.resolvedApprovals.map((item) => ({ kind: 'approval', item, order: runtimeOrder(item, 0) })),
+    ...projection.resolvedQuestions.map((item) => ({ kind: 'question', item, order: runtimeOrder(item, 0) })),
+  ].sort((a, b) => a.order - b.order);
+  if (resolved.length) {
     const activity = document.createElement('section');
     activity.className = 'activity-block';
     const heading = document.createElement('h4');
-    heading.textContent = 'Activity';
+    heading.textContent = 'Resolved waits';
     activity.appendChild(heading);
-    for (const task of projection.taskRuns.slice(-8)) {
-      const row = document.createElement('div');
-      row.className = 'activity-row';
-      row.appendChild(pill(task.status || 'task'));
-      const text = document.createElement('span');
-      text.textContent = task.title || task.agent || task.id || 'Task run';
-      row.appendChild(text);
-      activity.appendChild(row);
-    }
-    for (const tool of projection.toolCalls.slice(-8)) {
-      const row = document.createElement('div');
-      row.className = 'activity-row';
-      row.appendChild(pill(tool.status || 'tool'));
-      const text = document.createElement('span');
-      text.textContent = tool.name || tool.id || 'Tool call';
-      row.appendChild(text);
-      activity.appendChild(row);
-    }
-    for (const artifact of projection.artifacts.slice(-8)) {
-      const row = document.createElement('div');
-      row.className = 'activity-row';
-      row.appendChild(pill('artifact', 'ok'));
-      const text = document.createElement('span');
-      text.textContent = artifact.filename || artifact.name || artifact.artifactId || 'Artifact';
-      row.appendChild(text);
-      activity.appendChild(row);
-    }
-    if (projection.todos.length) {
-      const row = document.createElement('div');
-      row.className = 'activity-row';
-      row.appendChild(pill('todos'));
-      const text = document.createElement('span');
-      text.textContent = projection.todos.length + ' todo(s)';
-      row.appendChild(text);
-      activity.appendChild(row);
+    for (const entry of resolved.slice(-12)) {
+      activity.appendChild(renderResolvedCard(entry.kind, entry.item));
     }
     timeline.appendChild(activity);
   }
-  for (const error of projection.errors) {
-    const item = document.createElement('div');
-    item.className = 'notice';
-    item.textContent = error.message || 'Runtime error';
-    timeline.appendChild(item);
+
+  const timelineItems = [
+    ...projection.messages.map((item, index) => ({ kind: 'message', item, order: runtimeOrder(item, index + 1) })),
+    ...projection.taskRuns.map((item, index) => ({ kind: 'task', item, order: runtimeOrder(item, 5000 + index) })),
+    ...projection.toolCalls.map((item, index) => ({ kind: 'tool', item, order: runtimeOrder(item, 6000 + index) })),
+    ...projection.artifacts.map((item, index) => ({ kind: 'artifact', item, order: runtimeOrder(item, 7000 + index) })),
+    ...projection.errors.map((item, index) => ({ kind: 'error', item, order: runtimeOrder(item, 8000 + index) })),
+  ].sort((a, b) => a.order - b.order);
+
+  for (const entry of timelineItems) {
+    if (entry.kind === 'message') timeline.appendChild(renderMessageBubble(entry.item));
+    if (entry.kind === 'task') timeline.appendChild(renderTaskRun(entry.item));
+    if (entry.kind === 'tool') timeline.appendChild(renderToolTrace(entry.item));
+    if (entry.kind === 'artifact') timeline.appendChild(renderArtifactCard(entry.item));
+    if (entry.kind === 'error') timeline.appendChild(renderRuntimeError(entry.item));
   }
-  if (!projection.messages.length && !waits.length && !projection.errors.length) {
+
+  if (projection.todos.length) {
+    timeline.appendChild(renderTodoList(projection.todos));
+  }
+  if (!timelineItems.length && !projection.pendingApprovals.length && !projection.pendingQuestions.length && !resolved.length && !projection.todos.length) {
     const empty = document.createElement('p');
     empty.className = 'empty';
     empty.textContent = 'No messages yet.';
     timeline.appendChild(empty);
   }
+}
+
+function renderArtifacts() {
+  const panel = qs('#artifact-list');
+  const detail = qs('#artifact-detail');
+  if (!panel) return;
+  removeChildren(panel);
+  const view = state.selectedSessionId ? state.sessionViews[state.selectedSessionId] : null;
+  const projection = runtimeViewFromCloudView(view);
+  if (!view || !projection.artifacts.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = view ? 'No artifacts for the selected thread.' : 'Select a cloud thread to inspect artifacts.';
+    panel.appendChild(empty);
+  } else {
+    for (const artifact of projection.artifacts) {
+      panel.appendChild(renderArtifactCard(artifact));
+    }
+  }
+  if (!detail) return;
+  removeChildren(detail);
+  if (state.artifactPanel.status === 'loading') {
+    detail.appendChild(pill('loading', 'warn'));
+    return;
+  }
+  if (state.artifactPanel.error) {
+    const error = document.createElement('p');
+    error.className = 'notice';
+    error.textContent = state.artifactPanel.error;
+    detail.appendChild(error);
+    return;
+  }
+  if (!state.artifactPanel.metadata) {
+    const empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = 'Choose Inspect on an artifact to load metadata. Artifact bodies are fetched only for explicit view or download actions.';
+    detail.appendChild(empty);
+    return;
+  }
+  appendDetails(detail, 'Artifact metadata', state.artifactPanel.metadata);
 }
 
 function closeEventSource(entry) {
@@ -970,7 +1379,7 @@ function openSessionEvents(sessionId, afterSequence = 0) {
     renderChat();
     return;
   }
-  const source = new EventSource(sseUrl('/api/sessions/' + encodeURIComponent(sessionId) + '/events', afterSequence), { withCredentials: true });
+  const source = new EventSource(sseUrl(endpointPath('sessionEvents', '/api/sessions/:sessionId/events', { sessionId }), afterSequence), { withCredentials: true });
   state.sessionEvents.source = source;
   source.onopen = () => {
     state.sessionEvents.status = 'open';
@@ -1035,11 +1444,12 @@ async function loadSessions(options = {}) {
 }
 
 async function loadSessionView(sessionId, options = {}) {
-  const view = await api('/api/sessions/' + encodeURIComponent(sessionId) + '/view');
+  const view = await api(endpointPath('sessionView', '/api/sessions/:sessionId/view', { sessionId }));
   state.sessionViews[sessionId] = view;
   if (options.render !== false) {
     renderThreadList();
     renderChat();
+    renderArtifacts();
   }
   return view;
 }
@@ -1052,6 +1462,7 @@ async function selectSession(sessionId) {
   setRoute('chat', true);
   renderThreadList();
   renderChat();
+  renderArtifacts();
 }
 
 async function readFileAsBase64(file) {
@@ -1135,13 +1546,110 @@ async function promptSelectedSession(formData) {
   const text = String(formData.get('text') || '').trim();
   if (!text) throw new Error('Prompt text is required.');
   const agent = String(formData.get('agent') || '').trim() || null;
-  const result = await api('/api/sessions/' + encodeURIComponent(state.selectedSessionId) + '/prompt', {
+  const result = await api(endpointPath('sessionPrompt', '/api/sessions/:sessionId/prompt', { sessionId: state.selectedSessionId }), {
     method: 'POST',
     body: JSON.stringify({ text, agent }),
   });
   if (result?.view) state.sessionViews[state.selectedSessionId] = result.view;
   await loadSessions({ keepSelection: true });
   await refreshSelectedSession();
+}
+
+async function respondToPermission(permissionId, allowed) {
+  if (!state.selectedSessionId) throw new Error('Select a thread first.');
+  await withRuntimeAction('approval:' + permissionId, async () => {
+    await api(endpointPath('sessionPermissionRespond', '/api/sessions/:sessionId/permission-respond', { sessionId: state.selectedSessionId }), {
+      method: 'POST',
+      body: JSON.stringify({ permissionId, response: { allowed } }),
+    });
+  });
+}
+
+async function answerQuestion(requestId, answers) {
+  if (!state.selectedSessionId) throw new Error('Select a thread first.');
+  const normalized = normalizeList(answers).map((answer) => String(answer || '').trim()).filter(Boolean);
+  if (!normalized.length) throw new Error('Question answer is required.');
+  await withRuntimeAction('question:' + requestId, async () => {
+    await api(endpointPath('sessionQuestionReply', '/api/sessions/:sessionId/question-reply', { sessionId: state.selectedSessionId }), {
+      method: 'POST',
+      body: JSON.stringify({ requestId, answers: normalized }),
+    });
+  });
+}
+
+async function rejectQuestion(requestId) {
+  if (!state.selectedSessionId) throw new Error('Select a thread first.');
+  await withRuntimeAction('question:' + requestId, async () => {
+    await api(endpointPath('sessionQuestionReject', '/api/sessions/:sessionId/question-reject', { sessionId: state.selectedSessionId }), {
+      method: 'POST',
+      body: JSON.stringify({ requestId }),
+    });
+  });
+}
+
+function decodeBase64(dataBase64, contentType) {
+  const binary = atob(String(dataBase64 || ''));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return new Blob([bytes], { type: contentType || 'application/octet-stream' });
+}
+
+async function readArtifact(artifactIdValue) {
+  if (!state.selectedSessionId) throw new Error('Select a thread first.');
+  if (!artifactIdValue) throw new Error('Artifact id is required.');
+  const body = await api(endpointPath('sessionArtifact', '/api/sessions/:sessionId/artifacts/:artifactId', {
+    sessionId: state.selectedSessionId,
+    artifactId: artifactIdValue,
+  }));
+  return body.artifact || {};
+}
+
+async function openArtifact(artifactIdValue, mode) {
+  await withRuntimeAction('artifact:' + artifactIdValue, async () => {
+    const artifact = await readArtifact(artifactIdValue);
+    const blob = decodeBase64(artifact.dataBase64, artifact.contentType || artifact.mime);
+    const url = URL.createObjectURL(blob);
+    try {
+      if (mode === 'download') {
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = artifact.filename || 'artifact';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      } else {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      }
+    } finally {
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    }
+  });
+}
+
+async function inspectArtifact(artifactIdValue) {
+  if (!state.selectedSessionId) throw new Error('Select a thread first.');
+  state.artifactPanel = {
+    sessionId: state.selectedSessionId,
+    artifactId: artifactIdValue,
+    metadata: null,
+    status: 'loading',
+    error: null,
+  };
+  renderArtifacts();
+  try {
+    const artifacts = await api(endpointPath('sessionArtifacts', '/api/sessions/:sessionId/artifacts', { sessionId: state.selectedSessionId }))
+      .then((body) => normalizeList(body.artifacts));
+    const metadata = artifacts.find((artifact) => artifactId(artifact) === artifactIdValue) || { artifactId: artifactIdValue };
+    state.artifactPanel.metadata = safeArtifactMetadata(metadata);
+    state.artifactPanel.status = 'idle';
+    state.artifactPanel.error = null;
+    setRoute('artifacts', true);
+  } catch (error) {
+    state.artifactPanel.status = 'error';
+    state.artifactPanel.error = error.message || 'Artifact metadata failed to load';
+  } finally {
+    renderArtifacts();
+  }
 }
 
 function renderAll() {
@@ -1153,6 +1661,7 @@ function renderAll() {
   renderUsage();
   renderThreadList();
   renderChat();
+  renderArtifacts();
   renderRoutes();
 }
 
@@ -1871,6 +2380,85 @@ ${publicBrandingCss(branding)}
       padding: 10px 12px;
       font-size: 13px;
     }
+    .runtime-summary {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 7px;
+      align-items: center;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      padding: 8px 10px;
+    }
+    .runtime-card {
+      display: grid;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      padding: 10px 12px;
+      max-width: 880px;
+      min-width: 0;
+    }
+    .runtime-card[data-kind="approval"], .runtime-card[data-kind="question"] {
+      border-color: #dfc48f;
+      background: #fffdf6;
+    }
+    .runtime-card-header {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+    }
+    .runtime-card-header strong {
+      overflow-wrap: anywhere;
+    }
+    .question-block {
+      display: grid;
+      gap: 6px;
+    }
+    .question-block p {
+      margin: 0;
+      line-height: 1.45;
+    }
+    .choice-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 7px;
+    }
+    .runtime-detail {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      padding: 8px 10px;
+      max-width: 880px;
+      min-width: 0;
+    }
+    .runtime-detail summary {
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 28px;
+    }
+    .runtime-detail pre {
+      overflow: auto;
+      margin: 8px 0 0;
+      padding: 8px;
+      border-radius: 6px;
+      background: var(--muted-surface);
+      color: var(--text);
+      font-size: 12px;
+      line-height: 1.45;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+    .runtime-error {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      max-width: 880px;
+    }
     .empty {
       margin: 0;
       color: var(--muted);
@@ -2184,8 +2772,19 @@ ${publicBrandingCss(branding)}
               <div class="meta">Cloud artifact metadata</div>
             </div>
           </div>
-          <div class="panel">
-            <p class="empty">No artifacts loaded.</p>
+          <div class="grid">
+            <div class="panel">
+              <h3>Selected thread artifacts</h3>
+              <div class="list" id="artifact-list">
+                <p class="empty">No artifacts loaded.</p>
+              </div>
+            </div>
+            <div class="panel">
+              <h3>Inspector</h3>
+              <div class="list" id="artifact-detail">
+                <p class="empty">Choose Inspect on an artifact to load metadata.</p>
+              </div>
+            </div>
           </div>
         </section>
 

--- a/apps/website/src/runtime-workbench.ts
+++ b/apps/website/src/runtime-workbench.ts
@@ -1,0 +1,96 @@
+export const CLOUD_WEB_RUNTIME_ENTITY_CLASSES = [
+  'message',
+  'taskRun',
+  'toolCall',
+  'pendingApproval',
+  'resolvedApproval',
+  'pendingQuestion',
+  'resolvedQuestion',
+  'artifact',
+  'todo',
+  'error',
+  'usage',
+  'context',
+] as const
+
+export type CloudWebRuntimeEntityClass = typeof CLOUD_WEB_RUNTIME_ENTITY_CLASSES[number]
+
+export type CloudWebRuntimeCounts = Record<CloudWebRuntimeEntityClass, number>
+
+function list(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function numberValue(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+export function cloudWebRuntimeCounts(projection: unknown): CloudWebRuntimeCounts {
+  const record = asRecord(projection)
+  const tokens = asRecord(record.sessionTokens)
+  return {
+    message: list(record.messages).length,
+    taskRun: list(record.taskRuns).length,
+    toolCall: list(record.toolCalls).length,
+    pendingApproval: list(record.pendingApprovals).length,
+    resolvedApproval: list(record.resolvedApprovals).length,
+    pendingQuestion: list(record.pendingQuestions).length,
+    resolvedQuestion: list(record.resolvedQuestions).length,
+    artifact: list(record.artifacts).length,
+    todo: list(record.todos).length,
+    error: list(record.errors).length + (typeof record.lastError === 'string' && record.lastError ? 1 : 0),
+    usage: numberValue(record.sessionCost) > 0
+      || numberValue(tokens.input) > 0
+      || numberValue(tokens.output) > 0
+      || numberValue(tokens.reasoning) > 0
+      || numberValue(tokens.cacheRead) > 0
+      || numberValue(tokens.cacheWrite) > 0
+      ? 1
+      : 0,
+    context: (typeof record.contextState === 'string' && record.contextState && record.contextState !== 'idle')
+      || numberValue(record.compactionCount) > 0
+      || Boolean(record.lastCompactedAt)
+      ? 1
+      : 0,
+  }
+}
+
+export type CloudWebErrorCategory = 'policy' | 'auth' | 'quota' | 'billing' | 'provider' | 'runtime'
+
+export function cloudWebErrorCategory(message: unknown): CloudWebErrorCategory {
+  const text = String(message || '').toLowerCase()
+  if (text.includes('policy') || text.includes('disabled') || text.includes('not allowed')) return 'policy'
+  if (text.includes('auth') || text.includes('token') || text.includes('forbidden') || text.includes('unauthorized')) return 'auth'
+  if (text.includes('quota') || text.includes('rate limit') || text.includes('too many')) return 'quota'
+  if (text.includes('billing') || text.includes('subscription') || text.includes('payment')) return 'billing'
+  if (text.includes('provider') || text.includes('model') || text.includes('api key')) return 'provider'
+  return 'runtime'
+}
+
+export function cloudWebRuntimeOrder(item: unknown, fallback: number) {
+  const order = asRecord(item).order
+  return typeof order === 'number' && Number.isFinite(order) ? order : fallback
+}
+
+export function cloudWebSafeArtifactMetadata(artifact: unknown): Record<string, unknown> {
+  const record = asRecord(artifact)
+  return Object.fromEntries(Object.entries(record).filter(([key]) => {
+    const normalized = key.toLowerCase()
+    return normalized !== 'database64'
+      && normalized !== 'url'
+      && normalized !== 'downloadurl'
+      && normalized !== 'signedurl'
+      && normalized !== 'presignedurl'
+      && normalized !== 'key'
+      && normalized !== 'objectkey'
+      && normalized !== 'storagekey'
+      && normalized !== 'bucket'
+      && normalized !== 'container'
+      && normalized !== 'authorization'
+      && normalized !== 'token'
+  }))
+}

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -191,6 +191,24 @@ The Threads and Chat panels are the first interactive workbench surfaces:
   and thread list live through SSE, resuming from durable event sequences after
   reconnect.
 
+The Chat panel renders the full cloud runtime projection contract rather than a
+minimal message list. It includes user and assistant messages, streaming-safe
+assistant snapshots, task runs, compact tool traces, pending and resolved
+permission approvals, pending and resolved questions, artifacts, todos, cost and
+token totals, context/compaction state, and categorized errors. Browser approval
+and question actions call the same durable command routes used by desktop and
+gateway clients:
+
+- `POST /api/sessions/:id/permission-respond`
+- `POST /api/sessions/:id/question-reply`
+- `POST /api/sessions/:id/question-reject`
+
+Artifact metadata is listed from the durable projection and
+`GET /api/sessions/:id/artifacts`. Artifact bodies are fetched only for explicit
+View or Download actions through `GET /api/sessions/:id/artifacts/:artifactId`;
+the browser does not keep artifact bodies, signed object-store URLs, bucket
+names, or object keys in long-lived state.
+
 Thread list filtering is client-side over the current durable session snapshot:
 search text, status, profile, project kind, and tag/smart-filter metadata are
 supported. The browser paginates large org thread lists in fixed batches so a

--- a/packages/shared/src/cloud-session-projection.ts
+++ b/packages/shared/src/cloud-session-projection.ts
@@ -33,6 +33,28 @@ export type CloudSessionProjectionOrigin = {
   itemCounts: Record<string, number>
 }
 
+export type CloudResolvedApproval = {
+  id: string
+  sessionId: string
+  taskRunId?: string | null
+  tool: string
+  description: string
+  allowed: boolean
+  order: number
+  resolvedAt: string
+}
+
+export type CloudResolvedQuestion = {
+  id: string
+  sessionId: string
+  sourceSessionId?: string | null
+  questions: PendingQuestion['questions']
+  answers: unknown[]
+  rejected: boolean
+  order: number
+  resolvedAt: string
+}
+
 export const CLOUD_SESSION_EVENT_TYPES = [
   'session.created',
   'session.imported',
@@ -69,6 +91,8 @@ export type CloudSessionProjectionView = {
   taskRuns: TaskRun[]
   pendingApprovals: PendingApproval[]
   pendingQuestions: PendingQuestion[]
+  resolvedApprovals: CloudResolvedApproval[]
+  resolvedQuestions: CloudResolvedQuestion[]
   artifacts: SessionArtifact[]
   todos: TodoItem[]
   errors: SessionError[]
@@ -314,6 +338,42 @@ function normalizePendingApproval(value: unknown): PendingApproval | null {
   }
 }
 
+function normalizeResolvedApproval(value: unknown): CloudResolvedApproval | null {
+  const record = asRecord(value)
+  const id = readString(record.id)
+  const sessionId = readString(record.sessionId)
+  if (!id || !sessionId) return null
+  return {
+    id,
+    sessionId,
+    taskRunId: readNullableString(record.taskRunId),
+    tool: readString(record.tool, 'permission'),
+    description: readString(record.description, 'Permission resolved'),
+    allowed: record.allowed === true,
+    order: readNumber(record.order),
+    resolvedAt: readString(record.resolvedAt),
+  }
+}
+
+function normalizeResolvedQuestion(value: unknown): CloudResolvedQuestion | null {
+  const record = asRecord(value)
+  const id = readString(record.id)
+  const sessionId = readString(record.sessionId)
+  if (!id || !sessionId) return null
+  return {
+    id,
+    sessionId,
+    sourceSessionId: readNullableString(record.sourceSessionId),
+    questions: Array.isArray(record.questions)
+      ? record.questions.map(normalizeQuestionPrompt).filter((entry): entry is PendingQuestion['questions'][number] => Boolean(entry))
+      : [],
+    answers: Array.isArray(record.answers) ? record.answers : [],
+    rejected: record.rejected === true,
+    order: readNumber(record.order),
+    resolvedAt: readString(record.resolvedAt),
+  }
+}
+
 function normalizeSessionError(value: unknown): SessionError | null {
   const record = asRecord(value)
   const id = readString(record.id)
@@ -538,6 +598,8 @@ export function createCloudSessionProjectionView(session: CloudProjectionSession
     taskRuns: [],
     pendingApprovals: [],
     pendingQuestions: [],
+    resolvedApprovals: [],
+    resolvedQuestions: [],
     artifacts: [],
     todos: [],
     errors: [],
@@ -578,6 +640,12 @@ export function normalizeCloudSessionProjectionView(
       : [],
     pendingQuestions: Array.isArray(record.pendingQuestions)
       ? record.pendingQuestions.map(normalizePendingQuestion).filter((entry): entry is PendingQuestion => Boolean(entry))
+      : [],
+    resolvedApprovals: Array.isArray(record.resolvedApprovals)
+      ? record.resolvedApprovals.map(normalizeResolvedApproval).filter((entry): entry is CloudResolvedApproval => Boolean(entry))
+      : [],
+    resolvedQuestions: Array.isArray(record.resolvedQuestions)
+      ? record.resolvedQuestions.map(normalizeResolvedQuestion).filter((entry): entry is CloudResolvedQuestion => Boolean(entry))
       : [],
     artifacts: Array.isArray(record.artifacts)
       ? record.artifacts.map((entry, index) => normalizeSessionArtifact(entry, index)).filter((entry): entry is SessionArtifact => Boolean(entry))
@@ -695,9 +763,21 @@ export function reduceCloudSessionProjectionEvent(
       }
     case 'permission.resolved': {
       const permissionId = eventPayloadId(payload, ['permissionId', 'id', 'requestId', 'requestID'], '')
+      const pendingApproval = current.pendingApprovals.find((entry) => entry.id === permissionId)
+      const resolvedApproval = permissionId ? normalizeResolvedApproval({
+        id: permissionId,
+        sessionId: session.sessionId,
+        taskRunId: pendingApproval?.taskRunId ?? readNullableString(payload.taskRunId),
+        tool: pendingApproval?.tool || readString(payload.tool, 'permission'),
+        description: pendingApproval?.description || readString(payload.description, 'Permission resolved'),
+        allowed: payload.allowed === true || payload.response === true || payload.response === 'allow' || payload.response === 'once',
+        order: event.sequence,
+        resolvedAt: eventTime,
+      }) : null
       return {
         ...current,
         pendingApprovals: permissionId ? removeById(current.pendingApprovals, permissionId) : current.pendingApprovals,
+        resolvedApprovals: resolvedApproval ? upsertById(current.resolvedApprovals, resolvedApproval) : current.resolvedApprovals,
         isGenerating: false,
         updatedAt: eventTime,
       }
@@ -712,9 +792,21 @@ export function reduceCloudSessionProjectionEvent(
       }
     case 'question.resolved': {
       const questionId = eventPayloadId(payload, ['requestId', 'requestID', 'id'], '')
+      const pendingQuestion = current.pendingQuestions.find((entry) => entry.id === questionId)
+      const resolvedQuestion = questionId ? normalizeResolvedQuestion({
+        id: questionId,
+        sessionId: session.sessionId,
+        sourceSessionId: pendingQuestion?.sourceSessionId ?? readNullableString(payload.sourceSessionId),
+        questions: pendingQuestion?.questions || [],
+        answers: Array.isArray(payload.answers) ? payload.answers : [],
+        rejected: payload.rejected === true,
+        order: event.sequence,
+        resolvedAt: eventTime,
+      }) : null
       return {
         ...current,
         pendingQuestions: questionId ? removeById(current.pendingQuestions, questionId) : current.pendingQuestions,
+        resolvedQuestions: resolvedQuestion ? upsertById(current.resolvedQuestions, resolvedQuestion) : current.resolvedQuestions,
         isGenerating: false,
         updatedAt: eventTime,
       }
@@ -837,6 +929,24 @@ function isPendingQuestion(value: unknown): value is PendingQuestion {
     && Array.isArray(record.questions)
 }
 
+function isResolvedApproval(value: unknown): value is CloudResolvedApproval {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<CloudResolvedApproval>
+  return typeof record.id === 'string'
+    && typeof record.sessionId === 'string'
+    && typeof record.tool === 'string'
+    && typeof record.allowed === 'boolean'
+}
+
+function isResolvedQuestion(value: unknown): value is CloudResolvedQuestion {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Partial<CloudResolvedQuestion>
+  return typeof record.id === 'string'
+    && typeof record.sessionId === 'string'
+    && Array.isArray(record.questions)
+    && typeof record.rejected === 'boolean'
+}
+
 function isTodoItem(value: unknown): value is TodoItem {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   const record = value as Partial<TodoItem>
@@ -888,6 +998,8 @@ export function readCloudSessionProjection<Session extends CloudProjectionSessio
     taskRuns: Array.isArray(record.taskRuns) ? record.taskRuns.filter(isTaskRun) : [],
     pendingApprovals: Array.isArray(record.pendingApprovals) ? record.pendingApprovals.filter(isPendingApproval) : [],
     pendingQuestions: Array.isArray(record.pendingQuestions) ? record.pendingQuestions.filter(isPendingQuestion) : [],
+    resolvedApprovals: Array.isArray(record.resolvedApprovals) ? record.resolvedApprovals.filter(isResolvedApproval) : [],
+    resolvedQuestions: Array.isArray(record.resolvedQuestions) ? record.resolvedQuestions.filter(isResolvedQuestion) : [],
     artifacts: Array.isArray(record.artifacts) ? record.artifacts.filter(isSessionArtifact) : [],
     todos: Array.isArray(record.todos) ? record.todos.filter(isTodoItem) : [],
     errors: Array.isArray(record.errors) ? record.errors.filter(isSessionError) : [],

--- a/tests/cloud-session-projection-contract.test.ts
+++ b/tests/cloud-session-projection-contract.test.ts
@@ -140,8 +140,10 @@ test('cloud projection reducer covers durable runtime event state transitions', 
   assert.equal(view.pendingApprovals.length, 1)
   assert.equal(view.isGenerating, false)
 
-  view = reduceCloudSessionProjectionEvent(session, view, event(6, 'permission.resolved', { requestID: 'permission-1' }))
+  view = reduceCloudSessionProjectionEvent(session, view, event(6, 'permission.resolved', { requestID: 'permission-1', allowed: false }))
   assert.equal(view.pendingApprovals.length, 0)
+  assert.equal(view.resolvedApprovals[0]?.id, 'permission-1')
+  assert.equal(view.resolvedApprovals[0]?.allowed, false)
 
   view = reduceCloudSessionProjectionEvent(session, view, event(7, 'question.asked', {
     requestID: 'question-1',
@@ -158,8 +160,10 @@ test('cloud projection reducer covers durable runtime event state transitions', 
   assert.equal(view.pendingQuestions[0]?.tool?.callId, 'call-1')
   assert.equal(view.pendingQuestions[0]?.questions[0]?.multiple, true)
 
-  view = reduceCloudSessionProjectionEvent(session, view, event(8, 'question.resolved', { requestID: 'question-1' }))
+  view = reduceCloudSessionProjectionEvent(session, view, event(8, 'question.resolved', { requestID: 'question-1', answers: ['Tests'] }))
   assert.equal(view.pendingQuestions.length, 0)
+  assert.equal(view.resolvedQuestions[0]?.id, 'question-1')
+  assert.deepEqual(view.resolvedQuestions[0]?.answers, ['Tests'])
 
   view = reduceCloudSessionProjectionEvent(session, view, event(9, 'todos.updated', {
     todos: [

--- a/tests/cloud-session-projection.test.ts
+++ b/tests/cloud-session-projection.test.ts
@@ -138,16 +138,20 @@ test('cloud session projection persists approvals questions tools todos costs an
 
   await service.appendProductEvent(principal, sessionId, {
     type: 'permission.resolved',
-    payload: { permissionId: 'permission-1' },
+    payload: { permissionId: 'permission-1', allowed: true },
   })
   await service.appendProductEvent(principal, sessionId, {
     type: 'question.resolved',
-    payload: { requestId: 'question-1' },
+    payload: { requestId: 'question-1', answers: ['Yes'] },
   })
 
   const resolved = asRecord(asRecord((await service.getSessionView(principal, sessionId)).projection).view)
   assert.equal(asArray(resolved.pendingApprovals).length, 0)
   assert.equal(asArray(resolved.pendingQuestions).length, 0)
+  assert.equal(asRecord(asArray(resolved.resolvedApprovals)[0]).allowed, true)
+  assert.equal(asRecord(asArray(resolved.resolvedApprovals)[0]).description, 'Run git status')
+  assert.equal(asRecord(asArray(resolved.resolvedQuestions)[0]).rejected, false)
+  assert.deepEqual(asArray(asRecord(asArray(resolved.resolvedQuestions)[0]).answers), ['Yes'])
 })
 
 test('cloud assistant chunks keep projection running until explicit idle event', async () => {


### PR DESCRIPTION
## Summary
- render full cloud runtime projection state in the Web Workbench, including approvals, questions, task/tool traces, artifacts, todos, usage, context, and categorized errors
- add browser actions for permission responses, question replies/rejections, and explicit artifact view/download/inspect flows
- persist resolved approval/question history in the shared cloud projection contract and document artifact metadata redaction

Closes #481

## Verification
- pnpm --filter @open-cowork/website test
- pnpm --filter @open-cowork/website typecheck
- pnpm --filter @open-cowork/shared typecheck
- node scripts/run-node-tests.mjs tests/cloud-session-projection.test.ts tests/cloud-session-projection-contract.test.ts tests/cloud-http-server.test.ts
- pnpm lint
- pnpm typecheck
- pnpm docs:build
- pnpm test
- git diff --check