### PR TITLE
Build cloud web admin console

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -191,16 +191,48 @@ function parseCsv(value: string | null) {
   return value?.split(',').map((entry) => entry.trim()).filter(Boolean) || null
 }
 
+function parseSignupMode(value: string | null | undefined) {
+  if (value === 'closed' || value === 'invite' || value === 'domain' || value === 'open') return value
+  return null
+}
+
+function inferSignupMode(input: {
+  requestedSignupMode?: 'closed' | 'invite' | 'domain' | 'open' | null
+  allowSelfServiceSignup: boolean
+  allowedEmailDomains?: string[] | null
+}) {
+  if (input.requestedSignupMode) return input.requestedSignupMode
+  if (!input.allowSelfServiceSignup) return 'invite'
+  return input.allowedEmailDomains?.length ? 'domain' : 'open'
+}
+
 export function resolveCloudAuthConfig(config: OpenCoworkConfig, env: Env = process.env): CloudAuthConfig {
   const requestedMode = envValue(env, 'OPEN_COWORK_CLOUD_AUTH_MODE')
   const mode = requestedMode === 'oidc' || requestedMode === 'header' || requestedMode === 'none'
     ? requestedMode
     : config.cloud.auth.mode
   const requestedSelfService = envValue(env, 'OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP')
+  const allowedEmailDomains = parseCsv(envValue(env, 'OPEN_COWORK_CLOUD_ALLOWED_EMAIL_DOMAINS')) || config.cloud.auth.allowedEmailDomains
   const envSwitchedToOidc = mode === 'oidc' && requestedMode === 'oidc' && config.cloud.auth.mode !== 'oidc'
+  const requestedSignupMode = parseSignupMode(envValue(env, 'OPEN_COWORK_CLOUD_SIGNUP_MODE'))
+    || (envSwitchedToOidc ? null : parseSignupMode(config.cloud.auth.signupMode))
+  const allowSelfServiceSignup = requestedSelfService
+    ? parseBoolean(requestedSelfService, false)
+    : requestedSignupMode === 'open' || requestedSignupMode === 'domain'
+      ? true
+      : requestedSignupMode === 'closed' || requestedSignupMode === 'invite'
+        ? false
+        : envSwitchedToOidc
+          ? false
+          : config.cloud.auth.allowSelfServiceSignup ?? mode !== 'oidc'
   return {
     ...config.cloud.auth,
     mode,
+    signupMode: inferSignupMode({
+      requestedSignupMode,
+      allowSelfServiceSignup,
+      allowedEmailDomains,
+    }),
     headerSecret: envValue(env, 'OPEN_COWORK_CLOUD_HEADER_AUTH_SECRET')
       || resolveEnvRef(envValue(env, 'OPEN_COWORK_CLOUD_HEADER_AUTH_SECRET_REF') || undefined, env)
       || config.cloud.auth.headerSecret,
@@ -209,12 +241,8 @@ export function resolveCloudAuthConfig(config: OpenCoworkConfig, env: Env = proc
     clientSecretRef: envValue(env, 'OPEN_COWORK_CLOUD_OIDC_CLIENT_SECRET_REF') || config.cloud.auth.clientSecretRef,
     callbackPath: envValue(env, 'OPEN_COWORK_CLOUD_OIDC_CALLBACK_PATH') || config.cloud.auth.callbackPath,
     cookieSecretRef: envValue(env, 'OPEN_COWORK_CLOUD_COOKIE_SECRET_REF') || config.cloud.auth.cookieSecretRef,
-    allowedEmailDomains: parseCsv(envValue(env, 'OPEN_COWORK_CLOUD_ALLOWED_EMAIL_DOMAINS')) || config.cloud.auth.allowedEmailDomains,
-    allowSelfServiceSignup: requestedSelfService
-      ? parseBoolean(requestedSelfService, false)
-      : envSwitchedToOidc
-        ? false
-        : config.cloud.auth.allowSelfServiceSignup ?? mode !== 'oidc',
+    allowedEmailDomains,
+    allowSelfServiceSignup,
   }
 }
 
@@ -827,7 +855,11 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
     abuseConfig,
     billingConfig,
     billingAdapter,
-    { allowSelfServiceSignup: authConfig.allowSelfServiceSignup ?? authConfig.mode !== 'oidc' },
+    {
+      allowSelfServiceSignup: authConfig.allowSelfServiceSignup ?? authConfig.mode !== 'oidc',
+      signupMode: authConfig.signupMode,
+      allowedEmailDomains: authConfig.allowedEmailDomains || [],
+    },
     projectSources,
   )
   const artifacts = new CloudArtifactService(service, objectStore)

--- a/apps/desktop/src/main/cloud/control-plane-domains/identity.ts
+++ b/apps/desktop/src/main/cloud/control-plane-domains/identity.ts
@@ -8,6 +8,7 @@ export type IdentityControlPlaneStore = Pick<ControlPlaneStore,
   | 'findAccountBySubject'
   | 'findAccountByEmail'
   | 'upsertMembership'
+  | 'listOrgMembers'
   | 'listMembershipsForAccount'
   | 'resolvePrincipalMembership'
   | 'recordAuditEvent'

--- a/apps/desktop/src/main/cloud/http-routes/admin.ts
+++ b/apps/desktop/src/main/cloud/http-routes/admin.ts
@@ -1,0 +1,76 @@
+import type { ControlPlaneMembershipStatus, ControlPlaneRole } from '../control-plane-store.ts'
+import type { CloudApiRouteInput } from './types.ts'
+
+function memberRole(value: unknown): ControlPlaneRole | null {
+  return value === 'owner' || value === 'admin' || value === 'member' ? value : null
+}
+
+function memberStatus(value: unknown): ControlPlaneMembershipStatus | null {
+  return value === 'active' || value === 'invited' || value === 'disabled' ? value : null
+}
+
+export async function handleAdminApiRoute(input: CloudApiRouteInput): Promise<boolean> {
+  const { req, res, options, context, itemId, action, tools } = input
+
+  if (!itemId && req.method === 'GET') {
+    tools.writeJson(res, 200, {
+      policy: await options.service.getAdminPolicyOverview(context.principal),
+    }, options.corsOrigin)
+    return true
+  }
+
+  if (itemId === 'policy' && !action && req.method === 'GET') {
+    tools.writeJson(res, 200, {
+      policy: await options.service.getAdminPolicyOverview(context.principal),
+    }, options.corsOrigin)
+    return true
+  }
+
+  if (itemId === 'members') {
+    if (!action && req.method === 'GET') {
+      tools.writeJson(res, 200, {
+        members: await options.service.listOrgMembers(context.principal, {
+          query: context.url.searchParams.get('q'),
+          limit: tools.parseLimit(context.url),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (!action && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const email = tools.readString(body.email)
+      const role = memberRole(body.role) || 'member'
+      if (!email) {
+        tools.writeError(res, 400, 'Member invite requires an email address.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 201, {
+        member: await options.service.inviteOrgMember(context.principal, { email, role }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (action && input.artifactId === 'update' && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      tools.writeJson(res, 200, {
+        member: await options.service.updateOrgMember(context.principal, action, {
+          role: memberRole(body.role),
+          status: memberStatus(body.status),
+          confirm: tools.readString(body.confirm),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+  }
+
+  if (itemId === 'audit' && !action && req.method === 'GET') {
+    tools.writeJson(res, 200, {
+      events: await options.service.listAuditEvents(context.principal, {
+        limit: tools.parseLimit(context.url),
+      }),
+    }, options.corsOrigin)
+    return true
+  }
+
+  tools.writeError(res, 404, 'Not found.', options.corsOrigin)
+  return true
+}

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -13,6 +13,7 @@ import {
 } from '@open-cowork/shared'
 import type { CloudArtifactService } from './artifact-service.ts'
 import { cloudBrowserAppHtml } from './browser-app.ts'
+import { handleAdminApiRoute } from './http-routes/admin.ts'
 import { handleApiTokensApiRoute } from './http-routes/api-tokens.ts'
 import { handleBillingApiRoute } from './http-routes/billing.ts'
 import { handleByokApiRoute } from './http-routes/byok.ts'
@@ -874,6 +875,21 @@ async function handleApiRequest(
 
   if (resource === 'project-sources') {
     await handleProjectSourcesApiRoute({
+      req,
+      res,
+      options,
+      context,
+      resource,
+      itemId: sessionId,
+      action,
+      artifactId,
+      tools: routeTools,
+    })
+    return
+  }
+
+  if (resource === 'admin') {
+    await handleAdminApiRoute({
       req,
       res,
       options,

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -173,6 +173,17 @@ export type MembershipRecord = {
   updatedAt: string
 }
 
+export type OrgMemberRecord = {
+  orgId: string
+  accountId: string
+  email: string
+  displayName: string | null
+  role: ControlPlaneRole
+  status: ControlPlaneMembershipStatus
+  createdAt: string
+  updatedAt: string
+}
+
 export type PrincipalMembershipRecord = {
   org: OrgRecord
   account: AccountRecord
@@ -961,6 +972,7 @@ export type ControlPlaneStore = {
   findAccountBySubject(idpSubject: string): MaybePromise<AccountRecord | null>
   findAccountByEmail(email: string): MaybePromise<AccountRecord | null>
   upsertMembership(input: UpsertMembershipInput): MaybePromise<MembershipRecord>
+  listOrgMembers(orgId: string, input?: { query?: string | null, limit?: number | null }): MaybePromise<OrgMemberRecord[]>
   listMembershipsForAccount(accountId: string): MaybePromise<MembershipRecord[]>
   resolvePrincipalMembership(input: { tenantId: string, userId?: string | null, accountId?: string | null, idpSubject?: string | null, email?: string | null }): MaybePromise<PrincipalMembershipRecord | null>
   issueApiToken(input: IssueApiTokenInput): MaybePromise<IssuedApiTokenRecord>
@@ -1469,7 +1481,20 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const bySubject = input.idpSubject ? this.accountsBySubject.get(input.idpSubject) : null
     const byEmail = this.accountsByEmail.get(input.email.toLowerCase())
     const existing = this.accounts.get(bySubject || byEmail || input.accountId)
-    if (existing) return clone(existing)
+    if (existing) {
+      let changed = false
+      if (input.idpSubject && !existing.idpSubject) {
+        existing.idpSubject = input.idpSubject
+        this.accountsBySubject.set(input.idpSubject, existing.accountId)
+        changed = true
+      }
+      if (input.displayName && !existing.displayName) {
+        existing.displayName = input.displayName
+        changed = true
+      }
+      if (changed) existing.updatedAt = nowIso(input.createdAt)
+      return clone(existing)
+    }
     const createdAt = nowIso(input.createdAt)
     const record: AccountRecord = {
       accountId: input.accountId,
@@ -1523,6 +1548,42 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       createdAt: input.updatedAt,
     })
     return clone(record)
+  }
+
+  listOrgMembers(orgId: string, input: { query?: string | null, limit?: number | null } = {}): OrgMemberRecord[] {
+    if (!this.orgs.has(orgId)) throw new Error(`Unknown org ${orgId}.`)
+    const queryText = input.query?.trim().toLowerCase() || ''
+    const limit = Math.max(1, Math.min(input.limit || 100, 500))
+    return Array.from(this.memberships.values())
+      .filter((membership) => membership.orgId === orgId)
+      .map((membership) => {
+        const account = this.accounts.get(membership.accountId)
+        if (!account) return null
+        return {
+          orgId: membership.orgId,
+          accountId: membership.accountId,
+          email: account.email,
+          displayName: account.displayName,
+          role: membership.role,
+          status: membership.status,
+          createdAt: membership.createdAt,
+          updatedAt: membership.updatedAt,
+        } satisfies OrgMemberRecord
+      })
+      .filter((member): member is OrgMemberRecord => Boolean(member))
+      .filter((member) => {
+        if (!queryText) return true
+        return [
+          member.accountId,
+          member.email,
+          member.displayName,
+          member.role,
+          member.status,
+        ].filter(Boolean).join(' ').toLowerCase().includes(queryText)
+      })
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.email.localeCompare(right.email))
+      .slice(0, limit)
+      .map((member) => clone(member))
   }
 
   listMembershipsForAccount(accountId: string): MembershipRecord[] {

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -60,6 +60,7 @@ import type {
   IssueApiTokenInput,
   ListChannelDeliveriesInput,
   MembershipRecord,
+  OrgMemberRecord,
   OrgRecord,
   PrincipalMembershipRecord,
   RecordAuditEventInput,
@@ -850,6 +851,33 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
 
   async createAccount(input: CreateAccountInput) {
     const now = nowIso(input.createdAt)
+    const existing = await this.maybeOne(
+      `SELECT * FROM cloud_accounts
+       WHERE ($1::text IS NOT NULL AND idp_subject = $1)
+          OR lower(email) = lower($2)
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      [input.idpSubject || null, input.email],
+    )
+    if (existing) {
+      const result = await this.pool.query(
+        `UPDATE cloud_accounts
+         SET idp_subject = COALESCE(cloud_accounts.idp_subject, $2),
+             email = lower($3),
+             display_name = COALESCE($4, cloud_accounts.display_name),
+             updated_at = $5
+         WHERE account_id = $1
+         RETURNING *`,
+        [
+          existing.account_id,
+          input.idpSubject || null,
+          input.email,
+          input.displayName || null,
+          now,
+        ],
+      )
+      return accountFromRow(result.rows[0])
+    }
     const result = await this.pool.query(
       `INSERT INTO cloud_accounts (account_id, idp_subject, email, display_name, created_at, updated_at)
        VALUES ($1, $2, lower($3), $4, $5, $5)
@@ -905,6 +933,45 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       })
       return membershipFromRow(result.rows[0])
     })
+  }
+
+  async listOrgMembers(orgId: string, input: { query?: string | null, limit?: number | null } = {}) {
+    const queryText = input.query?.trim() || null
+    const result = await this.pool.query(
+      `SELECT
+         m.org_id,
+         m.account_id,
+         a.email,
+         a.display_name,
+         m.role,
+         m.status,
+         m.created_at,
+         m.updated_at
+       FROM cloud_memberships m
+       JOIN cloud_accounts a ON a.account_id = m.account_id
+       WHERE m.org_id = $1
+         AND (
+           $2::text IS NULL
+           OR m.account_id ILIKE '%' || $2 || '%'
+           OR a.email ILIKE '%' || $2 || '%'
+           OR COALESCE(a.display_name, '') ILIKE '%' || $2 || '%'
+           OR m.role ILIKE '%' || $2 || '%'
+           OR m.status ILIKE '%' || $2 || '%'
+         )
+       ORDER BY m.updated_at DESC, a.email ASC
+       LIMIT $3`,
+      [orgId, queryText, Math.max(1, Math.min(input.limit || 100, 500))],
+    )
+    return result.rows.map((row): OrgMemberRecord => ({
+      orgId: String(row.org_id),
+      accountId: String(row.account_id),
+      email: String(row.email),
+      displayName: row.display_name ? String(row.display_name) : null,
+      role: row.role as OrgMemberRecord['role'],
+      status: row.status as OrgMemberRecord['status'],
+      createdAt: iso(row.created_at),
+      updatedAt: iso(row.updated_at),
+    }))
   }
 
   async listMembershipsForAccount(accountId: string) {

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -45,9 +45,12 @@ import type {
   ClaimedWorkflowRunRecord,
   CloudWorkflowRecord,
   CloudWorkflowRunRecord,
+  ControlPlaneMembershipStatus,
+  ControlPlaneRole,
   ControlPlaneStore,
   HeadlessAgentRecord,
   IssuedChannelInteractionRecord,
+  OrgMemberRecord,
   QuotaPolicyCode,
   SessionCommandRecord,
   SessionEventRecord,
@@ -133,6 +136,44 @@ export type CloudWorkspaceOverview = {
   }
 }
 
+export type PublicOrgMemberRecord = OrgMemberRecord
+
+export type CloudAdminPolicyOverview = {
+  org: {
+    orgId: string
+    tenantId: string
+    name: string
+    planKey: string | null
+    status: string
+  }
+  signup: {
+    mode: 'closed' | 'invite' | 'domain' | 'open'
+    allowSelfServiceSignup: boolean
+    allowedEmailDomains: string[]
+    invitesEnabled: boolean
+  }
+  profile: {
+    name: string
+    label: string | null
+    description: string | null
+  }
+  features: Record<string, boolean>
+  allowedAgents: string[] | null
+  allowedTools: string[] | null
+  allowedMcps: string[] | null
+  runtime: {
+    configSource: 'app'
+    machineRuntimeConfig: 'disabled' | 'allowlisted'
+    localStdioMcps: 'disabled' | 'allowlisted'
+    hostProjectDirectories: 'disabled' | 'allowlisted'
+  }
+  projectSources: CloudRuntimePolicy['projectSources']
+  gateway: {
+    channelsEnabled: boolean
+    webhooksEnabled: boolean
+  }
+}
+
 export type PublicApiTokenRecord = Omit<ApiTokenRecord, 'tokenHash'>
 
 export type IssuedPublicApiTokenRecord = {
@@ -172,6 +213,8 @@ export type ByokManagementPolicy = {
 
 export type CloudIdentityPolicy = {
   allowSelfServiceSignup: boolean
+  signupMode?: 'closed' | 'invite' | 'domain' | 'open'
+  allowedEmailDomains?: readonly string[]
 }
 
 export class CloudServiceError extends Error {
@@ -298,6 +341,27 @@ function readNullableString(value: unknown) {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
+function normalizeEmailAddress(value: unknown) {
+  const email = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (!email || email.length > 254 || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    throw new CloudServiceError(400, 'A valid member email address is required.')
+  }
+  return email
+}
+
+function normalizeControlPlaneRole(value: unknown, fallback: ControlPlaneRole = 'member'): ControlPlaneRole {
+  if (value === 'owner' || value === 'admin' || value === 'member') return value
+  return fallback
+}
+
+function normalizeMembershipStatus(
+  value: unknown,
+  fallback: ControlPlaneMembershipStatus = 'active',
+): ControlPlaneMembershipStatus {
+  if (value === 'active' || value === 'invited' || value === 'disabled') return value
+  return fallback
+}
+
 function channelRoleCanPrompt(role: ChannelIdentityRole) {
   return role === 'owner' || role === 'admin' || role === 'member'
 }
@@ -338,9 +402,21 @@ function principalCanManageApiTokens(principal: CloudPrincipal) {
   return principal.role === 'owner' || principal.role === 'admin'
 }
 
+function principalCanManageOrg(principal: CloudPrincipal) {
+  if (principal.authSource === 'local') return true
+  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
 function publicApiToken(token: ApiTokenRecord): PublicApiTokenRecord {
   const { tokenHash: _tokenHash, ...publicToken } = token
   return publicToken
+}
+
+function resolvedSignupMode(policy: CloudIdentityPolicy): 'closed' | 'invite' | 'domain' | 'open' {
+  if (policy.signupMode) return policy.signupMode
+  if (!policy.allowSelfServiceSignup) return 'invite'
+  return policy.allowedEmailDomains?.length ? 'domain' : 'open'
 }
 
 function normalizeApiTokenScopes(scopes: ApiTokenScope[] | undefined | null): ApiTokenScope[] {
@@ -663,14 +739,23 @@ export class CloudSessionService {
   }
 
   async ensurePrincipal(principal: CloudPrincipal) {
+    const signupMode = resolvedSignupMode(this.identityPolicy)
     const existingMembership = await this.store.resolvePrincipalMembership({
       tenantId: principal.tenantId,
       accountId: principal.accountId || principal.userId,
       idpSubject: principal.userId,
       email: principal.email,
     })
-    if (principal.authSource === 'user' && !this.identityPolicy.allowSelfServiceSignup) {
-      if (!existingMembership || existingMembership.membership.status !== 'active') {
+    const requiresExistingMembership = principal.authSource === 'user'
+      && (!this.identityPolicy.allowSelfServiceSignup || signupMode === 'closed' || signupMode === 'invite')
+    if (requiresExistingMembership) {
+      const acceptableStatuses: ControlPlaneMembershipStatus[] = signupMode === 'invite'
+        ? ['active', 'invited']
+        : ['active']
+      if (
+        !existingMembership
+        || !acceptableStatuses.includes(existingMembership.membership.status)
+      ) {
         throw new CloudServiceError(403, 'Cloud membership is not active.')
       }
     }
@@ -684,7 +769,7 @@ export class CloudSessionService {
       orgId: principal.orgId,
     })
     const account = await this.store.createAccount({
-      accountId: principal.accountId || principal.userId,
+      accountId: existingMembership?.account.accountId || principal.accountId || principal.userId,
       idpSubject: principal.userId,
       email: principal.email,
     })
@@ -701,7 +786,7 @@ export class CloudSessionService {
       email: account.email,
     })
     if (!membership) {
-      if (principal.authSource === 'user' && !this.identityPolicy.allowSelfServiceSignup) {
+      if (requiresExistingMembership) {
         throw new CloudServiceError(403, 'Cloud membership is not active.')
       }
       await this.store.upsertMembership({
@@ -710,6 +795,14 @@ export class CloudSessionService {
         role: principal.role || user.role,
         status: 'active',
         actor: { actorType: 'system', actorId: 'principal.bootstrap' },
+      })
+    } else if (membership.membership.status === 'invited' && principal.authSource === 'user' && signupMode === 'invite') {
+      await this.store.upsertMembership({
+        orgId: org.orgId,
+        accountId: account.accountId,
+        role: membership.membership.role,
+        status: 'active',
+        actor: { actorType: 'system', actorId: 'membership.invite.accepted' },
       })
     } else if (membership.membership.status !== 'active') {
       throw new CloudServiceError(403, 'Cloud membership is not active.')
@@ -744,6 +837,177 @@ export class CloudSessionService {
         machineRuntimeConfig: 'disabled',
       },
     }
+  }
+
+  async getAdminPolicyOverview(principal: CloudPrincipal): Promise<CloudAdminPolicyOverview> {
+    await this.ensurePrincipal(principal)
+    const membership = await this.store.resolvePrincipalMembership({
+      tenantId: principal.tenantId,
+      accountId: principal.accountId || principal.userId,
+      email: principal.email,
+    })
+    if (!membership) throw new CloudServiceError(403, 'Cloud membership is not active.')
+    const signupMode = resolvedSignupMode(this.identityPolicy)
+    return {
+      org: {
+        orgId: membership.org.orgId,
+        tenantId: membership.org.tenantId,
+        name: membership.org.name,
+        planKey: membership.org.planKey,
+        status: membership.org.status,
+      },
+      signup: {
+        mode: signupMode,
+        allowSelfServiceSignup: this.identityPolicy.allowSelfServiceSignup,
+        allowedEmailDomains: [...(this.identityPolicy.allowedEmailDomains || [])],
+        invitesEnabled: signupMode === 'invite',
+      },
+      profile: {
+        name: this.policy.profileName,
+        label: this.policy.profile.label || null,
+        description: this.policy.profile.description || null,
+      },
+      features: this.policy.features,
+      allowedAgents: this.policy.allowedAgents,
+      allowedTools: this.policy.allowedTools,
+      allowedMcps: this.policy.allowedMcps,
+      runtime: {
+        configSource: 'app',
+        machineRuntimeConfig: this.policy.allowMachineRuntimeConfig ? 'allowlisted' : 'disabled',
+        localStdioMcps: this.policy.allowLocalStdioMcps || this.policy.allowedLocalMcpNames.length ? 'allowlisted' : 'disabled',
+        hostProjectDirectories: this.policy.allowHostProjectDirectories || this.policy.allowedHostProjectDirectories.length ? 'allowlisted' : 'disabled',
+      },
+      projectSources: this.policy.projectSources,
+      gateway: {
+        channelsEnabled: this.policy.features.agents !== false,
+        webhooksEnabled: this.policy.features.webhooks !== false,
+      },
+    }
+  }
+
+  async listOrgMembers(
+    principal: CloudPrincipal,
+    input: { query?: string | null, limit?: number | null } = {},
+  ): Promise<PublicOrgMemberRecord[]> {
+    await this.ensurePrincipal(principal)
+    this.assertOrgAdmin(principal)
+    return this.store.listOrgMembers(this.principalOrgId(principal), {
+      query: input.query || null,
+      limit: input.limit || 100,
+    })
+  }
+
+  async inviteOrgMember(
+    principal: CloudPrincipal,
+    input: { email: string, role?: ControlPlaneRole | null },
+  ): Promise<PublicOrgMemberRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertOrgAdmin(principal)
+    const signupMode = resolvedSignupMode(this.identityPolicy)
+    if (signupMode !== 'invite') {
+      throw new CloudServiceError(403, 'Member invites are available only when cloud signup mode is invite.')
+    }
+    const email = normalizeEmailAddress(input.email)
+    const role = normalizeControlPlaneRole(input.role || 'member')
+    if (role === 'owner' && principal.role !== 'owner' && principal.authSource !== 'local') {
+      throw new CloudServiceError(403, 'Only org owners can invite another owner.')
+    }
+    const orgId = this.principalOrgId(principal)
+    const account = await this.store.createAccount({
+      accountId: stableCloudId('account', orgId, email),
+      email,
+      idpSubject: null,
+    })
+    const membership = await this.store.upsertMembership({
+      orgId,
+      accountId: account.accountId,
+      role,
+      status: 'invited',
+      actor: {
+        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+        actorId: principal.tokenId || principal.userId,
+        accountId: principal.accountId || principal.userId,
+      },
+    })
+    return {
+      orgId,
+      accountId: account.accountId,
+      email: account.email,
+      displayName: account.displayName,
+      role: membership.role,
+      status: membership.status,
+      createdAt: membership.createdAt,
+      updatedAt: membership.updatedAt,
+    }
+  }
+
+  async updateOrgMember(
+    principal: CloudPrincipal,
+    accountId: string,
+    input: {
+      role?: ControlPlaneRole | null
+      status?: ControlPlaneMembershipStatus | null
+      confirm?: string | null
+    },
+  ): Promise<PublicOrgMemberRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertOrgAdmin(principal)
+    const orgId = this.principalOrgId(principal)
+    const members = await this.store.listOrgMembers(orgId, { limit: 500 })
+    const existing = members.find((member) => member.accountId === accountId)
+    if (!existing) throw new CloudServiceError(404, 'Org member was not found.')
+    const nextRole = input.role ? normalizeControlPlaneRole(input.role, existing.role) : existing.role
+    const nextStatus = input.status ? normalizeMembershipStatus(input.status, existing.status) : existing.status
+    if (nextRole === 'owner' && principal.role !== 'owner' && principal.authSource !== 'local') {
+      throw new CloudServiceError(403, 'Only org owners can promote another owner.')
+    }
+    if (existing.role === 'owner' && principal.role !== 'owner' && principal.authSource !== 'local') {
+      throw new CloudServiceError(403, 'Only org owners can change another owner.')
+    }
+    const currentActorAccountId = principal.accountId || principal.userId
+    if (accountId === currentActorAccountId && nextRole !== existing.role) {
+      throw new CloudServiceError(400, 'You cannot change your own org role.')
+    }
+    if (accountId === currentActorAccountId && nextStatus !== 'active') {
+      throw new CloudServiceError(400, 'You cannot disable your own active membership.')
+    }
+    if (nextStatus === 'disabled' && input.confirm !== accountId) {
+      throw new CloudServiceError(400, 'Disabling a member requires confirmation.')
+    }
+    const activeOwnerCount = members.filter((member) => member.role === 'owner' && member.status === 'active').length
+    if (existing.role === 'owner' && existing.status === 'active' && (nextRole !== 'owner' || nextStatus !== 'active') && activeOwnerCount <= 1) {
+      throw new CloudServiceError(400, 'Cannot remove or demote the last active owner.')
+    }
+    const updated = await this.store.upsertMembership({
+      orgId,
+      accountId,
+      role: nextRole,
+      status: nextStatus,
+      actor: {
+        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+        actorId: principal.tokenId || principal.userId,
+        accountId: currentActorAccountId,
+      },
+    })
+    return {
+      orgId,
+      accountId: existing.accountId,
+      email: existing.email,
+      displayName: existing.displayName,
+      role: updated.role,
+      status: updated.status,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+    }
+  }
+
+  async listAuditEvents(
+    principal: CloudPrincipal,
+    input: { limit?: number | null } = {},
+  ) {
+    await this.ensurePrincipal(principal)
+    this.assertOrgAdmin(principal)
+    return this.store.listAuditEvents(this.principalOrgId(principal), input.limit || 100)
   }
 
   async createSession(principal: CloudPrincipal, input: {
@@ -3033,6 +3297,12 @@ export class CloudSessionService {
   private assertApiTokenAdmin(principal: CloudPrincipal) {
     if (!principalCanManageApiTokens(principal)) {
       throw new CloudServiceError(403, 'API token administration requires an org admin or admin-scoped API token.')
+    }
+  }
+
+  private assertOrgAdmin(principal: CloudPrincipal) {
+    if (!principalCanManageOrg(principal)) {
+      throw new CloudServiceError(403, 'Org administration requires an org admin or admin-scoped API token.')
     }
   }
 

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -259,6 +259,7 @@ export type CloudProfileConfig = {
 
 export type CloudAuthConfig = {
   mode: 'none' | 'header' | 'oidc'
+  signupMode?: 'closed' | 'invite' | 'domain' | 'open'
   headerSecret?: string
   issuerUrl?: string
   clientId?: string
@@ -644,6 +645,7 @@ export const DEFAULT_CONFIG: OpenCoworkConfig = {
     publicBranding: DEFAULT_CLOUD_PUBLIC_BRANDING,
     auth: {
       mode: 'none',
+      signupMode: 'open',
       allowSelfServiceSignup: true,
     },
     storage: {

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -31,6 +31,11 @@ export type CloudWebEndpointId =
   | 'workflowArchive'
   | 'projectSourceValidate'
   | 'projectSnapshots'
+  | 'adminPolicy'
+  | 'adminMembers'
+  | 'adminMemberInvite'
+  | 'adminMemberUpdate'
+  | 'adminAudit'
 
 export type CloudWebEndpoint = {
   id: CloudWebEndpointId
@@ -77,6 +82,12 @@ export type CloudWebClientStateContract = {
   workflows: {
     workflows: unknown[]
     runs: unknown[]
+    error: string | null
+  }
+  admin: {
+    policy: unknown | null
+    members: unknown[]
+    auditEvents: unknown[]
     error: string | null
   }
   selectedWorkflowId: string | null
@@ -267,5 +278,35 @@ export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
     method: 'POST',
     path: '/api/project-sources/snapshots',
     csrf: true,
+  },
+  {
+    id: 'adminPolicy',
+    method: 'GET',
+    path: '/api/admin/policy',
+    csrf: false,
+  },
+  {
+    id: 'adminMembers',
+    method: 'GET',
+    path: '/api/admin/members',
+    csrf: false,
+  },
+  {
+    id: 'adminMemberInvite',
+    method: 'POST',
+    path: '/api/admin/members',
+    csrf: true,
+  },
+  {
+    id: 'adminMemberUpdate',
+    method: 'POST',
+    path: '/api/admin/members/:accountId/update',
+    csrf: true,
+  },
+  {
+    id: 'adminAudit',
+    method: 'GET',
+    path: '/api/admin/audit?limit=100',
+    csrf: false,
   },
 ]

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -91,6 +91,12 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
       runs: [],
       error: null,
     },
+    admin: {
+      policy: null,
+      members: [],
+      auditEvents: [],
+      error: null,
+    },
     selectedWorkflowId: null,
     workspaceEvents: {
       status: 'idle',
@@ -116,6 +122,11 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workflowRun')?.path, '/api/workflows/:workflowId/run')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'projectSourceValidate')?.path, '/api/project-sources/validate')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'projectSnapshots')?.path, '/api/project-sources/snapshots')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminPolicy')?.path, '/api/admin/policy')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMembers')?.path, '/api/admin/members')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMemberInvite')?.method, 'POST')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMemberUpdate')?.path, '/api/admin/members/:accountId/update')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminAudit')?.path, '/api/admin/audit?limit=100')
 })
 
 test('cloud website keeps existing admin dashboard surfaces available', () => {
@@ -238,6 +249,11 @@ test('cloud website binds actions through the client script', () => {
   assert.match(cloudWebsiteClientScript(), /setRoute/)
   assert.match(cloudWebsiteClientScript(), /providerSettingsFromForm/)
   assert.match(cloudWebsiteClientScript(), /updateBindingProviderFields/)
+  assert.match(cloudWebsiteClientScript(), /renderMembers/)
+  assert.match(cloudWebsiteClientScript(), /renderAdminPolicy/)
+  assert.match(cloudWebsiteClientScript(), /renderAudit/)
+  assert.match(cloudWebsiteClientScript(), /inviteMember/)
+  assert.match(cloudWebsiteClientScript(), /updateMember/)
 })
 
 test('cloud website renders cloud thread controls without local host path affordances', () => {
@@ -257,6 +273,11 @@ test('cloud website renders cloud thread controls without local host path afford
   assert.match(html, /id="artifact-list"/)
   assert.match(html, /id="artifact-history"/)
   assert.match(html, /id="artifact-detail"/)
+  assert.match(html, /id="member-list"/)
+  assert.match(html, /id="member-invite-form"/)
+  assert.match(html, /id="admin-policy-overview"/)
+  assert.match(html, /id="admin-project-policy"/)
+  assert.match(html, /id="audit-list"/)
   assert.doesNotMatch(html, /\/Users\//)
   assert.doesNotMatch(html, /local stdio MCP/i)
 })

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -233,6 +233,14 @@ const state = {
     runs: [],
     error: null,
   },
+  admin: {
+    policy: null,
+    members: [],
+    auditEvents: [],
+    error: null,
+  },
+  memberFilter: '',
+  auditFilter: '',
   selectedWorkflowId: null,
   workflowFilter: '',
   revealToken: null,
@@ -283,6 +291,7 @@ function routeById(routeId) {
 function canViewRoute(route) {
   if (!route) return false;
   if (route.requiresAuth && !state.workspace) return false;
+  if (route.requiresAdmin && adminLocked()) return false;
   return true;
 }
 
@@ -415,6 +424,14 @@ function renderSignedOut() {
     runs: [],
     error: null,
   };
+  state.admin = {
+    policy: null,
+    members: [],
+    auditEvents: [],
+    error: null,
+  };
+  state.memberFilter = '';
+  state.auditFilter = '';
   state.selectedWorkflowId = null;
   state.sessionEvents = {
     source: null,
@@ -683,6 +700,52 @@ function workflowPillKind(status) {
   return '';
 }
 
+function membershipPillKind(status) {
+  if (status === 'active') return 'ok';
+  if (status === 'invited') return 'warn';
+  return 'warn';
+}
+
+function filteredMembers() {
+  const tokens = state.memberFilter.toLowerCase().trim().split(/\s+/).filter(Boolean);
+  const members = [...normalizeList(state.admin.members)]
+    .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')) || String(left.email || '').localeCompare(String(right.email || '')));
+  if (!tokens.length) return members;
+  return members.filter((member) => {
+    const haystack = [
+      member.accountId,
+      member.email,
+      member.displayName,
+      member.role,
+      member.status,
+    ].filter(Boolean).join(' ').toLowerCase();
+    return tokens.every((token) => haystack.includes(token));
+  });
+}
+
+function filteredAuditEvents() {
+  const tokens = state.auditFilter.toLowerCase().trim().split(/\s+/).filter(Boolean);
+  const events = [...normalizeList(state.admin.auditEvents)]
+    .sort((left, right) => String(right.createdAt || '').localeCompare(String(left.createdAt || '')));
+  if (!tokens.length) return events;
+  return events.filter((event) => {
+    const haystack = [
+      event.eventId,
+      event.actorType,
+      event.actorId,
+      event.eventType,
+      event.targetType,
+      event.targetId,
+      compactJson(event.metadata),
+    ].filter(Boolean).join(' ').toLowerCase();
+    return tokens.every((token) => haystack.includes(token));
+  });
+}
+
+function policyListLabel(values) {
+  return Array.isArray(values) && values.length ? values.join(', ') : 'all profile defaults';
+}
+
 function workbenchAgentSurfaces() {
   const surfaces = [];
   if (bootstrap.features?.chat !== false) surfaces.push('Web');
@@ -739,6 +802,240 @@ function renderWorkspace() {
     element.dataset.locked = locked ? 'true' : 'false';
   });
   renderRoutes();
+}
+
+function renderMembers() {
+  const list = qs('#member-list');
+  const count = qs('#member-count');
+  const inviteForm = qs('#member-invite-form');
+  const inviteNotice = qs('#member-invite-notice');
+  if (!list) return;
+  const policy = state.admin.policy;
+  const signup = policy?.signup || {};
+  if (inviteForm) {
+    qsa('button, input, select', inviteForm).forEach((element) => {
+      const locked = adminLocked() || signup.mode !== 'invite';
+      element.disabled = locked;
+      element.dataset.locked = locked ? 'true' : 'false';
+    });
+  }
+  if (inviteNotice) {
+    inviteNotice.textContent = signup.mode === 'invite'
+      ? 'Invite mode is enabled. Invited users activate on first verified sign-in.'
+      : 'Invite creation is disabled because this deployment signup mode is ' + (signup.mode || 'unknown') + '.';
+  }
+  const members = filteredMembers();
+  if (count) count.textContent = String(members.length);
+  removeChildren(list);
+  if (state.admin.error) {
+    const row = document.createElement('div');
+    row.className = 'table-row empty-row';
+    row.setAttribute('role', 'row');
+    [state.admin.error, '-', '-', '-'].forEach((value) => {
+      const cell = document.createElement('span');
+      cell.setAttribute('role', 'cell');
+      cell.textContent = value;
+      row.appendChild(cell);
+    });
+    list.appendChild(row);
+    return;
+  }
+  if (!members.length) {
+    const row = document.createElement('div');
+    row.className = 'table-row empty-row';
+    row.setAttribute('role', 'row');
+    ['No members loaded.', '-', '-', '-'].forEach((value) => {
+      const cell = document.createElement('span');
+      cell.setAttribute('role', 'cell');
+      cell.textContent = value;
+      row.appendChild(cell);
+    });
+    list.appendChild(row);
+    return;
+  }
+  for (const member of members) {
+    const row = document.createElement('div');
+    row.className = 'table-row member-row';
+    row.setAttribute('role', 'row');
+    const identity = document.createElement('span');
+    identity.setAttribute('role', 'cell');
+    identity.textContent = [member.email, member.displayName].filter(Boolean).join(' - ');
+    const role = document.createElement('span');
+    role.setAttribute('role', 'cell');
+    role.appendChild(pill(member.role || 'member', member.role === 'owner' ? 'ok' : ''));
+    const status = document.createElement('span');
+    status.setAttribute('role', 'cell');
+    status.appendChild(pill(member.status || 'unknown', membershipPillKind(member.status)));
+    const actions = document.createElement('span');
+    actions.setAttribute('role', 'cell');
+    actions.className = 'row-actions';
+    actions.appendChild(actionButton('Make admin', () => updateMember(member.accountId, { role: 'admin' }), 'secondary', adminLocked() || member.role === 'admin' || member.status === 'disabled'));
+    actions.appendChild(actionButton('Make member', () => updateMember(member.accountId, { role: 'member' }), 'secondary', adminLocked() || member.role === 'member' || member.status === 'disabled'));
+    if (member.status === 'invited') {
+      actions.appendChild(actionButton('Activate', () => updateMember(member.accountId, { status: 'active' }), 'primary', adminLocked()));
+      actions.appendChild(actionButton('Revoke', () => disableMember(member.accountId), 'danger', adminLocked()));
+    } else if (member.status !== 'disabled') {
+      actions.appendChild(actionButton('Suspend', () => disableMember(member.accountId), 'danger', adminLocked()));
+    }
+    row.appendChild(identity);
+    row.appendChild(role);
+    row.appendChild(status);
+    row.appendChild(actions);
+    list.appendChild(row);
+  }
+}
+
+function renderAdminPolicy() {
+  const overview = qs('#admin-policy-overview');
+  const features = qs('#admin-policy-features');
+  const project = qs('#admin-project-policy');
+  const runtime = qs('#admin-runtime-policy');
+  const policy = state.admin.policy;
+  if (overview) {
+    removeChildren(overview);
+    if (!policy) {
+      const empty = document.createElement('p');
+      empty.className = 'empty';
+      empty.textContent = state.admin.error || 'No policy loaded.';
+      overview.appendChild(empty);
+    } else {
+      const rows = [
+        ['Org', policy.org?.name || policy.org?.orgId || 'unknown'],
+        ['Signup mode', policy.signup?.mode || 'unknown'],
+        ['Profile', [policy.profile?.name, policy.profile?.label].filter(Boolean).join(' - ')],
+        ['Allowed agents', policyListLabel(policy.allowedAgents)],
+        ['Allowed tools', policyListLabel(policy.allowedTools)],
+        ['Allowed MCPs', policyListLabel(policy.allowedMcps)],
+      ];
+      for (const [label, value] of rows) {
+        const row = document.createElement('div');
+        row.className = 'row compact';
+        const strong = document.createElement('strong');
+        strong.textContent = label;
+        const span = document.createElement('span');
+        span.textContent = value || 'not configured';
+        row.appendChild(strong);
+        row.appendChild(span);
+        overview.appendChild(row);
+      }
+      if (normalizeList(policy.signup?.allowedEmailDomains).length) {
+        const row = document.createElement('div');
+        row.className = 'row compact';
+        const strong = document.createElement('strong');
+        strong.textContent = 'Allowed domains';
+        const span = document.createElement('span');
+        span.textContent = policy.signup.allowedEmailDomains.join(', ');
+        row.appendChild(strong);
+        row.appendChild(span);
+        overview.appendChild(row);
+      }
+    }
+  }
+  if (features) {
+    removeChildren(features);
+    const entries = Object.entries(safeObject(policy?.features || bootstrap.features)).sort(([left], [right]) => left.localeCompare(right));
+    for (const [name, enabled] of entries) {
+      const row = document.createElement('div');
+      row.className = 'row compact';
+      const strong = document.createElement('strong');
+      strong.textContent = name;
+      const status = pill(enabled ? 'enabled' : 'disabled', enabled ? 'ok' : 'warn');
+      row.appendChild(strong);
+      row.appendChild(status);
+      features.appendChild(row);
+    }
+  }
+  if (project) {
+    removeChildren(project);
+    const sources = safeObject(policy?.projectSources);
+    const rows = [
+      ['Git hosts', policyListLabel(normalizeList(sources.git?.allowedHosts))],
+      ['Git repositories', policyListLabel(normalizeList(sources.git?.allowedRepositories))],
+      ['Git file URLs', sources.git?.allowFileUrls ? 'allowed' : 'disabled'],
+      ['Uploaded snapshots', sources.uploadedSnapshots?.enabled ? 'enabled' : 'disabled'],
+      ['Snapshot max files', sources.uploadedSnapshots?.maxFiles ?? 'not configured'],
+      ['Snapshot max bytes', sources.uploadedSnapshots?.maxBytes ?? 'not configured'],
+      ['Managed workspaces', sources.managedWorkspaces?.enabled ? 'enabled' : 'disabled'],
+    ];
+    for (const [label, value] of rows) {
+      const row = document.createElement('div');
+      row.className = 'row compact';
+      const strong = document.createElement('strong');
+      strong.textContent = label;
+      const span = document.createElement('span');
+      span.textContent = String(value);
+      row.appendChild(strong);
+      row.appendChild(span);
+      project.appendChild(row);
+    }
+  }
+  if (runtime) {
+    removeChildren(runtime);
+    const rows = [
+      ['Machine runtime config', policy?.runtime?.machineRuntimeConfig || 'disabled'],
+      ['Stdio MCP processes', policy?.runtime?.localStdioMcps || 'disabled'],
+      ['Host project directories', policy?.runtime?.hostProjectDirectories || 'disabled'],
+      ['Gateway channels', policy?.gateway?.channelsEnabled ? 'enabled' : 'disabled'],
+      ['Gateway webhooks', policy?.gateway?.webhooksEnabled ? 'enabled' : 'disabled'],
+    ];
+    for (const [label, value] of rows) {
+      const row = document.createElement('div');
+      row.className = 'row compact';
+      const strong = document.createElement('strong');
+      strong.textContent = label;
+      const span = document.createElement('span');
+      span.textContent = String(value);
+      row.appendChild(strong);
+      row.appendChild(span);
+      runtime.appendChild(row);
+    }
+  }
+}
+
+function renderAudit() {
+  const list = qs('#audit-list');
+  const count = qs('#audit-count');
+  if (!list) return;
+  const events = filteredAuditEvents();
+  if (count) count.textContent = String(events.length);
+  removeChildren(list);
+  if (state.admin.error) {
+    const empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = state.admin.error;
+    list.appendChild(empty);
+    return;
+  }
+  if (!events.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = 'No audit events loaded.';
+    list.appendChild(empty);
+    return;
+  }
+  for (const event of events.slice(0, 100)) {
+    const row = document.createElement('div');
+    row.className = 'row';
+    const main = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = event.eventType || event.eventId || 'audit event';
+    main.appendChild(title);
+    const meta = document.createElement('small');
+    meta.textContent = [
+      event.actorType ? event.actorType + ':' + (event.actorId || 'unknown') : null,
+      event.targetType ? event.targetType + ':' + (event.targetId || 'unknown') : null,
+      formatDate(event.createdAt),
+    ].filter(Boolean).join(' - ');
+    main.appendChild(document.createElement('br'));
+    main.appendChild(meta);
+    const actions = document.createElement('div');
+    actions.className = 'row-actions';
+    actions.appendChild(pill(event.actorType || 'system'));
+    row.appendChild(main);
+    row.appendChild(actions);
+    appendDetails(row, 'Redacted metadata', event.metadata || {});
+    list.appendChild(row);
+  }
 }
 
 function renderByok() {
@@ -2216,6 +2513,9 @@ async function inspectArtifact(artifactIdValue) {
 
 function renderAll() {
   renderWorkspace();
+  renderMembers();
+  renderAdminPolicy();
+  renderAudit();
   renderByok();
   renderTokens();
   renderGateway();
@@ -2281,6 +2581,54 @@ async function loadWorkflows() {
   renderWorkflows();
 }
 
+async function loadAdminSurfaces() {
+  let adminError = null;
+  const setAdminError = (error) => {
+    if (error && !adminError) adminError = error;
+  };
+  if (!canManage(state.workspace?.role)) {
+    const policy = await optionalSurfaceLoad(
+      () => api(endpoint('adminPolicy', '/api/admin/policy')).then((body) => body.policy || null),
+      null,
+      setAdminError,
+    );
+    state.admin = {
+      policy,
+      members: [],
+      auditEvents: [],
+      error: adminError,
+    };
+    renderAdminPolicy();
+    renderMembers();
+    renderAudit();
+    return;
+  }
+  const [policy, members, auditEvents] = await Promise.all([
+    optionalSurfaceLoad(
+      () => api(endpoint('adminPolicy', '/api/admin/policy')).then((body) => body.policy || null),
+      null,
+      setAdminError,
+    ),
+    optionalSurfaceLoad(
+      () => api(endpoint('adminMembers', '/api/admin/members')).then((body) => body.members || []),
+      [],
+      setAdminError,
+    ),
+    optionalSurfaceLoad(
+      () => api(endpoint('adminAudit', '/api/admin/audit?limit=100')).then((body) => body.events || []),
+      [],
+      setAdminError,
+    ),
+  ]);
+  state.admin.policy = policy;
+  state.admin.members = normalizeList(members);
+  state.admin.auditEvents = normalizeList(auditEvents);
+  state.admin.error = adminError;
+  renderMembers();
+  renderAdminPolicy();
+  renderAudit();
+}
+
 async function refreshDashboard() {
   const me = await optionalLoad(() => api(endpoint('authMe', '/auth/me')), null);
   if (!me) return;
@@ -2307,6 +2655,7 @@ async function refreshDashboard() {
   setRoute(window.location.hash.replace(/^#/, '') || state.activeRoute || defaultRoute(), true);
   renderAll();
   await Promise.all([
+    loadAdminSurfaces(),
     loadCapabilities(),
     loadWorkflows(),
     loadSessions({ keepSelection: true }),
@@ -2395,6 +2744,47 @@ async function revokeToken(tokenId) {
   await api('/api/api-tokens/' + encodeURIComponent(tokenId), { method: 'DELETE' });
   if (state.revealToken) state.revealToken = null;
   await refreshDashboard();
+}
+
+async function inviteMember(formData) {
+  await api(endpoint('adminMemberInvite', '/api/admin/members'), {
+    method: 'POST',
+    body: JSON.stringify({
+      email: String(formData.get('email') || '').trim(),
+      role: String(formData.get('role') || 'member').trim(),
+    }),
+  });
+  await loadAdminSurfaces();
+}
+
+async function updateMember(accountId, input) {
+  await api(endpointPath('adminMemberUpdate', '/api/admin/members/:accountId/update', { accountId }), {
+    method: 'POST',
+    body: JSON.stringify(input || {}),
+  });
+  await loadAdminSurfaces();
+}
+
+async function disableMember(accountId) {
+  const confirmed = window.prompt('Type the account id to confirm member suspension or invite revocation: ' + accountId);
+  if (confirmed !== accountId) throw new Error('Confirmation did not match the account id.');
+  await updateMember(accountId, { status: 'disabled', confirm: accountId });
+}
+
+function exportAuditEvents() {
+  const events = filteredAuditEvents();
+  const blob = new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), events }, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'open-cowork-audit-events.json';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
 }
 
 async function createAgent(formData) {
@@ -2565,6 +2955,20 @@ function bindForms() {
     event.preventDefault();
     submitForm(event.currentTarget, issueToken);
   });
+  qs('#member-filter').addEventListener('input', (event) => {
+    state.memberFilter = event.currentTarget.value;
+    renderMembers();
+  });
+  qs('#member-invite-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    submitScopedForm(event.currentTarget, inviteMember, { refresh: false });
+  });
+  qs('#refresh-admin').addEventListener('click', () => loadAdminSurfaces().catch((error) => setStatus(error.message, 'error')));
+  qs('#audit-filter').addEventListener('input', (event) => {
+    state.auditFilter = event.currentTarget.value;
+    renderAudit();
+  });
+  qs('#export-audit').addEventListener('click', () => exportAuditEvents());
   qs('#desktop-token').addEventListener('click', () => quickToken(connectionLabel('desktopToken', 'Desktop token') + ' connection token', 'desktop').catch((error) => setStatus(error.message, 'error')));
   qs('#gateway-token').addEventListener('click', () => quickToken(connectionLabel('gatewayToken', 'Gateway token') + ' service token', 'gateway').catch((error) => setStatus(error.message, 'error')));
   qs('#agent-form').addEventListener('submit', (event) => {
@@ -3498,9 +3902,46 @@ ${publicBrandingCss(branding)}
               <h2>Members</h2>
               <div class="meta">Roles and invites</div>
             </div>
+            <div class="row-actions">
+              <label><span>Filter</span><input id="member-filter" autocomplete="off" placeholder="email, role, status" data-admin-control="true"></label>
+              <button id="refresh-admin" type="button" data-admin-control="true">Refresh admin</button>
+            </div>
           </div>
-          <div class="panel">
-            <p class="empty">No member records loaded.</p>
+          <div class="workbench-split">
+            <div class="panel">
+              <div class="section-header">
+                <h3>Org members</h3>
+                <div class="meta"><span id="member-count">0</span> member(s)</div>
+              </div>
+              <div class="table-shell" role="table" aria-label="Org members">
+                <div class="table-row table-head" role="row">
+                  <span role="columnheader">Member</span>
+                  <span role="columnheader">Role</span>
+                  <span role="columnheader">Status</span>
+                  <span role="columnheader">Actions</span>
+                </div>
+                <div id="member-list">
+                  <div class="table-row empty-row" role="row">
+                    <span role="cell">No member records loaded.</span>
+                    <span role="cell">-</span>
+                    <span role="cell">-</span>
+                    <span role="cell">-</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <form class="panel" id="member-invite-form">
+              <h3>Invite member</h3>
+              <p class="empty" id="member-invite-notice">Invite availability loads after sign-in.</p>
+              <div class="form-grid">
+                <label class="span"><span>Email</span><input name="email" type="email" autocomplete="off" placeholder="teammate@example.com" data-admin-control="true"></label>
+                <label><span>Role</span><select name="role" data-admin-control="true">
+                  <option value="member">Member</option>
+                  <option value="admin">Admin</option>
+                </select></label>
+                <button class="primary" type="submit" data-admin-control="true">Create invite</button>
+              </div>
+            </form>
           </div>
         </section>
 
@@ -3514,13 +3955,29 @@ ${publicBrandingCss(branding)}
           <div class="grid">
             <div class="panel">
               <h3>Runtime profile</h3>
-              <div class="row compact"><strong>Profile</strong><span>${escapeHtml(policy.profileName)}</span></div>
-              <div class="row compact"><strong>Role</strong><span>${escapeHtml(policy.role)}</span></div>
+              <div class="list" id="admin-policy-overview">
+                <div class="row compact"><strong>Profile</strong><span>${escapeHtml(policy.profileName)}</span></div>
+                <div class="row compact"><strong>Role</strong><span>${escapeHtml(policy.role)}</span></div>
+              </div>
             </div>
             <div class="panel">
               <h3>Features</h3>
-              <div class="row compact"><strong>Chat</strong><span>${policy.features.chat ? 'enabled' : 'disabled'}</span></div>
-              <div class="row compact"><strong>Workflows</strong><span>${policy.features.workflows ? 'enabled' : 'disabled'}</span></div>
+              <div class="list" id="admin-policy-features">
+                <div class="row compact"><strong>Chat</strong><span>${policy.features.chat ? 'enabled' : 'disabled'}</span></div>
+                <div class="row compact"><strong>Workflows</strong><span>${policy.features.workflows ? 'enabled' : 'disabled'}</span></div>
+              </div>
+            </div>
+            <div class="panel">
+              <h3>Project sources</h3>
+              <div class="list" id="admin-project-policy">
+                <p class="empty">Project-source policy loads after sign-in.</p>
+              </div>
+            </div>
+            <div class="panel">
+              <h3>Runtime and gateway</h3>
+              <div class="list" id="admin-runtime-policy">
+                <p class="empty">Runtime policy loads after sign-in.</p>
+              </div>
             </div>
           </div>
         </section>
@@ -3658,9 +4115,19 @@ ${publicBrandingCss(branding)}
               <h2>Audit</h2>
               <div class="meta">Redacted administrative events</div>
             </div>
+            <div class="row-actions">
+              <label><span>Search</span><input id="audit-filter" autocomplete="off" placeholder="actor, action, entity" data-admin-control="true"></label>
+              <button id="export-audit" type="button" data-admin-control="true">Export</button>
+            </div>
           </div>
           <div class="panel">
-            <p class="empty">No audit events loaded.</p>
+            <div class="section-header">
+              <h3>Events</h3>
+              <div class="meta"><span id="audit-count">0</span> event(s)</div>
+            </div>
+            <div class="list" id="audit-list">
+              <p class="empty">No audit events loaded.</p>
+            </div>
           </div>
         </section>
 

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -246,17 +246,23 @@ thread created in the browser appears to desktop and gateway clients through the
 same session list, projection, and SSE contracts.
 
 Signed-in member users can open the workbench and read allowed org/policy/usage
-state. Admin-only panels are rendered as read-only for members and all admin
-mutations remain server-authorized. Disabled controls in the browser are an
-ergonomic layer only.
+state. Admin-only panels are hidden for members and all admin mutations remain
+server-authorized. Disabled controls in the browser are an ergonomic layer only.
 
 Authenticated users land on an org-scoped dashboard backed by
 `GET /api/workspace`. That request also performs the configured first-login org
 bootstrap path. The workbench also bootstraps public deployment metadata from
 `GET /api/config`; both bootstrap responses are metadata-only and must not
 contain provider keys, OAuth tokens, API tokens, MCP secrets, or local host
-paths. Existing admin panels expose:
+paths. Admin panels expose:
 
+- member and invite operations through `/api/admin/members`, with owner/admin
+  RBAC enforced by the API and destructive member disable/revoke actions
+  requiring explicit confirmation,
+- runtime profile, feature, project-source, signup-mode, and gateway policy
+  visibility through `/api/admin/policy`,
+- redacted audit events through `/api/admin/audit`, with browser-side search
+  and export over the already redacted event payload,
 - BYOK provider status and key submission through metadata-only BYOK APIs,
 - one-time API token issuance and revocation for desktop and gateway clients,
 - headless gateway agent/channel setup through channel binding APIs,
@@ -509,6 +515,7 @@ Set these environment variables in every role:
 | `OPEN_COWORK_CLOUD_INTERNAL_TOKEN` | Internal-only token for operational endpoints such as scheduler tick probes. Keep it in a platform secret store. |
 | `OPEN_COWORK_CLOUD_INTERNAL_TOKEN_REF` | Optional env secret ref for the internal operational token. |
 | `OPEN_COWORK_CLOUD_OIDC_CALLBACK_PATH` | OIDC callback path; defaults to `/auth/callback`. |
+| `OPEN_COWORK_CLOUD_SIGNUP_MODE` | Optional explicit org signup mode: `closed`, `invite`, `domain`, or `open`. `invite` permits admin-created invited memberships; `domain` uses `OPEN_COWORK_CLOUD_ALLOWED_EMAIL_DOMAINS`; `closed` allows only existing active memberships. |
 | `OPEN_COWORK_CLOUD_ALLOWED_EMAIL_DOMAINS` | Optional comma-separated email domain allowlist for OIDC identities. |
 | `OPEN_COWORK_CLOUD_HEADER_AUTH_SECRET` / `OPEN_COWORK_CLOUD_HEADER_AUTH_SECRET_REF` | Required for public `header` auth; trusted proxies must provide the same value in `x-open-cowork-header-auth-secret`. |
 | `OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP` | Explicitly allows first-login OIDC org membership creation. Keep disabled for invite-only managed deployments. |

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -621,7 +621,8 @@
         "callbackPath": { "type": "string", "pattern": "^/[A-Za-z0-9/_-]*$" },
         "cookieSecretRef": { "type": "string", "maxLength": 512 },
         "allowedEmailDomains": { "$ref": "#/$defs/cloudStringList" },
-        "allowSelfServiceSignup": { "type": "boolean" }
+        "allowSelfServiceSignup": { "type": "boolean" },
+        "signupMode": { "type": "string", "enum": ["closed", "invite", "domain", "open"] }
       }
     },
     "cloudStorage": {

--- a/packages/cloud-client/src/adapter.ts
+++ b/packages/cloud-client/src/adapter.ts
@@ -296,6 +296,66 @@ export type CloudIssuedApiTokenRecord = {
   plaintext: string
 }
 
+export type CloudOrgMemberRecord = {
+  orgId: string
+  accountId: string
+  email: string
+  displayName: string | null
+  role: 'owner' | 'admin' | 'member'
+  status: 'active' | 'invited' | 'disabled'
+  createdAt: string
+  updatedAt: string
+}
+
+export type CloudAdminPolicyOverview = {
+  org: {
+    orgId: string
+    tenantId: string
+    name: string
+    planKey: string | null
+    status: string
+  }
+  signup: {
+    mode: 'closed' | 'invite' | 'domain' | 'open'
+    allowSelfServiceSignup: boolean
+    allowedEmailDomains: string[]
+    invitesEnabled: boolean
+  }
+  profile: {
+    name: string
+    label: string | null
+    description: string | null
+  }
+  features: Record<string, boolean>
+  allowedAgents: string[] | null
+  allowedTools: string[] | null
+  allowedMcps: string[] | null
+  runtime: {
+    configSource: 'app'
+    machineRuntimeConfig: 'disabled' | 'allowlisted'
+    localStdioMcps: 'disabled' | 'allowlisted'
+    hostProjectDirectories: 'disabled' | 'allowlisted'
+  }
+  projectSources: Record<string, unknown>
+  gateway: {
+    channelsEnabled: boolean
+    webhooksEnabled: boolean
+  }
+}
+
+export type CloudAuditEventRecord = {
+  eventId: string
+  orgId: string
+  actorType: string
+  actorId: string
+  accountId: string | null
+  eventType: string
+  targetType: string | null
+  targetId: string | null
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
 export type CloudBillingSubscriptionRecord = {
   orgId: string
   providerId: string
@@ -478,6 +538,15 @@ export type CloudTransportAdapter = {
     expiresAt?: string | null
   }): Promise<CloudIssuedApiTokenRecord>
   revokeApiToken?(tokenId: string): Promise<CloudApiTokenRecord | null>
+  getAdminPolicy?(): Promise<CloudAdminPolicyOverview>
+  listOrgMembers?(input?: { query?: string | null, limit?: number | null }): Promise<CloudOrgMemberRecord[]>
+  inviteOrgMember?(input: { email: string, role?: 'owner' | 'admin' | 'member' | null }): Promise<CloudOrgMemberRecord>
+  updateOrgMember?(accountId: string, input: {
+    role?: 'owner' | 'admin' | 'member' | null
+    status?: 'active' | 'invited' | 'disabled' | null
+    confirm?: string | null
+  }): Promise<CloudOrgMemberRecord>
+  listAdminAuditEvents?(limit?: number): Promise<CloudAuditEventRecord[]>
   getBillingSubscription?(): Promise<CloudBillingSubscriptionPayload>
   createBillingCheckout?(input?: {
     planKey?: string | null
@@ -1249,6 +1318,34 @@ export function createHttpSseCloudTransportAdapter(
       return (await request<{ token: CloudApiTokenRecord | null }>(`/api/api-tokens/${encodePath(tokenId)}`, {
         method: 'DELETE',
       })).token
+    },
+    async getAdminPolicy() {
+      return (await request<{ policy: CloudAdminPolicyOverview }>('/api/admin/policy')).policy
+    },
+    async listOrgMembers(input = {}) {
+      return (await request<{ members: CloudOrgMemberRecord[] }>(
+        `/api/admin/members${queryString({ q: input.query, limit: input.limit })}`,
+      )).members
+    },
+    async inviteOrgMember(input) {
+      return (await request<{ member: CloudOrgMemberRecord }>('/api/admin/members', {
+        method: 'POST',
+        body: input,
+      })).member
+    },
+    async updateOrgMember(accountId, input) {
+      return (await request<{ member: CloudOrgMemberRecord }>(
+        `/api/admin/members/${encodePath(accountId)}/update`,
+        {
+          method: 'POST',
+          body: input,
+        },
+      )).member
+    },
+    async listAdminAuditEvents(limit) {
+      return (await request<{ events: CloudAuditEventRecord[] }>(
+        `/api/admin/audit${queryString({ limit })}`,
+      )).events
     },
     getBillingSubscription() {
       return request<CloudBillingSubscriptionPayload>('/api/billing/subscription')

--- a/packages/cloud-client/src/domains/identity.ts
+++ b/packages/cloud-client/src/domains/identity.ts
@@ -1,5 +1,8 @@
 export type {
+  CloudAdminPolicyOverview,
   CloudApiTokenRecord,
   CloudApiTokenScope,
+  CloudAuditEventRecord,
   CloudIssuedApiTokenRecord,
+  CloudOrgMemberRecord,
 } from '../adapter.js'

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -312,6 +312,7 @@ test('cloud auth config resolves OIDC deployment settings from env', () => {
   assert.equal(resolved.cookieSecretRef, 'env:COOKIE_SECRET')
   assert.deepEqual(resolved.allowedEmailDomains, ['example.test', 'example.org'])
   assert.equal(resolved.allowSelfServiceSignup, false)
+  assert.equal(resolved.signupMode, 'invite')
 })
 
 test('cloud auth config requires explicit self-service opt-in for managed OIDC signup', () => {
@@ -320,8 +321,24 @@ test('cloud auth config requires explicit self-service opt-in for managed OIDC s
   }).allowSelfServiceSignup, false)
   assert.equal(resolveCloudAuthConfig(DEFAULT_CONFIG, {
     OPEN_COWORK_CLOUD_AUTH_MODE: 'oidc',
+  }).signupMode, 'invite')
+  assert.equal(resolveCloudAuthConfig(DEFAULT_CONFIG, {
+    OPEN_COWORK_CLOUD_AUTH_MODE: 'oidc',
     OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP: 'true',
   }).allowSelfServiceSignup, true)
+  assert.equal(resolveCloudAuthConfig(DEFAULT_CONFIG, {
+    OPEN_COWORK_CLOUD_AUTH_MODE: 'oidc',
+    OPEN_COWORK_CLOUD_ALLOWED_EMAIL_DOMAINS: 'example.test',
+    OPEN_COWORK_CLOUD_ALLOW_SELF_SERVICE_SIGNUP: 'true',
+  }).signupMode, 'domain')
+  assert.equal(resolveCloudAuthConfig(DEFAULT_CONFIG, {
+    OPEN_COWORK_CLOUD_AUTH_MODE: 'oidc',
+    OPEN_COWORK_CLOUD_SIGNUP_MODE: 'closed',
+  }).allowSelfServiceSignup, false)
+  assert.equal(resolveCloudAuthConfig(DEFAULT_CONFIG, {
+    OPEN_COWORK_CLOUD_AUTH_MODE: 'oidc',
+    OPEN_COWORK_CLOUD_SIGNUP_MODE: 'closed',
+  }).signupMode, 'closed')
 
   const explicitConfig = {
     ...DEFAULT_CONFIG,

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -1123,6 +1123,20 @@ test('cloud HTTP self-service mode requires an active invited membership when di
       orgId: org.orgId,
       accountId: 'invited-1',
       role: 'member',
+      status: 'invited',
+    })
+    const invitedAccepted = await readJson(await fetch(`${baseUrl}/api/workspace`))
+    assert.equal(invitedAccepted.orgId, 'tenant-1')
+    assert.equal(invitedAccepted.accountId, 'invited-1')
+    assert.equal(fixture.store.resolvePrincipalMembership({
+      tenantId: 'tenant-1',
+      accountId: 'invited-1',
+    })?.membership.status, 'active')
+
+    fixture.store.upsertMembership({
+      orgId: org.orgId,
+      accountId: 'invited-1',
+      role: 'member',
       status: 'active',
     })
     const accepted = await readJson(await fetch(`${baseUrl}/api/workspace`))
@@ -1256,6 +1270,141 @@ test('cloud HTTP server prevents member-only users from API token administration
       body: JSON.stringify({ name: 'Blocked token', scopes: ['desktop'] }),
     })
     assert.equal(response.status, 403)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP admin APIs manage invited members and expose redacted audit', async () => {
+  const fixture = createFixture({
+    identityPolicy: {
+      allowSelfServiceSignup: false,
+      signupMode: 'invite',
+      allowedEmailDomains: ['example.test'],
+    },
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const policy = asRecord((await readJson(await fetch(`${baseUrl}/api/admin/policy`))).policy)
+    assert.equal(asRecord(policy.signup).mode, 'invite')
+    assert.deepEqual(asRecord(policy.signup).allowedEmailDomains, ['example.test'])
+    assert.equal(asRecord(policy.runtime).machineRuntimeConfig, 'disabled')
+
+    const initialMembers = asArray((await readJson(await fetch(`${baseUrl}/api/admin/members`))).members)
+    assert.equal(initialMembers.some((entry) => asRecord(entry).email === 'user@example.test'), true)
+
+    const invitedResponse = await fetch(`${baseUrl}/api/admin/members`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'invitee@example.test', role: 'admin' }),
+    })
+    assert.equal(invitedResponse.status, 201)
+    const invited = asRecord((await readJson(invitedResponse)).member)
+    assert.equal(invited.email, 'invitee@example.test')
+    assert.equal(invited.role, 'admin')
+    assert.equal(invited.status, 'invited')
+
+    const listed = asArray((await readJson(await fetch(`${baseUrl}/api/admin/members?q=invitee`))).members)
+    assert.equal(listed.length, 1)
+
+    const accountId = String(invited.accountId)
+    const missingConfirm = await fetch(`${baseUrl}/api/admin/members/${encodeURIComponent(accountId)}/update`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'disabled' }),
+    })
+    assert.equal(missingConfirm.status, 400)
+
+    const disabled = await readJson(await fetch(`${baseUrl}/api/admin/members/${encodeURIComponent(accountId)}/update`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'disabled', confirm: accountId }),
+    }))
+    assert.equal(asRecord(disabled.member).status, 'disabled')
+
+    const audit = asArray((await readJson(await fetch(`${baseUrl}/api/admin/audit?limit=50`))).events)
+    const auditText = JSON.stringify(audit)
+    assert.match(auditText, /membership\.created/)
+    assert.match(auditText, /membership\.updated/)
+    assert.equal(auditText.includes('occ_'), false)
+    assert.equal(auditText.includes('sk-'), false)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP admin APIs reject member-only users while preserving read-only policy', async () => {
+  const memberPrincipal = {
+    tenantId: 'tenant-1',
+    orgId: 'tenant-1',
+    tenantName: 'Tenant 1',
+    userId: 'member-1',
+    accountId: 'member-1',
+    email: 'member@example.test',
+    role: 'member' as const,
+    authSource: 'user' as const,
+  }
+  const fixture = createFixture({ auth: () => memberPrincipal })
+  const baseUrl = await fixture.server.listen()
+  try {
+    await readJson(await fetch(`${baseUrl}/api/workspace`))
+    const policy = await fetch(`${baseUrl}/api/admin/policy`)
+    assert.equal(policy.status, 200)
+    const members = await fetch(`${baseUrl}/api/admin/members`)
+    assert.equal(members.status, 403)
+    const audit = await fetch(`${baseUrl}/api/admin/audit`)
+    assert.equal(audit.status, 403)
+    const invite = await fetch(`${baseUrl}/api/admin/members`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'blocked@example.test', role: 'member' }),
+    })
+    assert.equal(invite.status, 403)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP admin APIs protect owner membership changes', async () => {
+  const adminPrincipal = {
+    tenantId: 'tenant-1',
+    orgId: 'tenant-1',
+    tenantName: 'Tenant 1',
+    userId: 'admin-1',
+    accountId: 'admin-1',
+    email: 'admin@example.test',
+    role: 'admin' as const,
+    authSource: 'user' as const,
+  }
+  const fixture = createFixture({ auth: () => adminPrincipal })
+  const baseUrl = await fixture.server.listen()
+  try {
+    await readJson(await fetch(`${baseUrl}/api/workspace`))
+    fixture.store.createAccount({
+      accountId: 'owner-1',
+      idpSubject: 'owner-subject',
+      email: 'owner@example.test',
+    })
+    fixture.store.upsertMembership({
+      orgId: 'tenant-1',
+      accountId: 'owner-1',
+      role: 'owner',
+      status: 'active',
+    })
+
+    const demoteOwner = await fetch(`${baseUrl}/api/admin/members/owner-1/update`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'member' }),
+    })
+    assert.equal(demoteOwner.status, 403)
+
+    const selfDemote = await fetch(`${baseUrl}/api/admin/members/admin-1/update`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'member' }),
+    })
+    assert.equal(selfDemote.status, 400)
   } finally {
     await fixture.server.close()
   }

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -156,6 +156,7 @@ test('cloud deployment config validates role, profile, storage, and runtime poli
       clientId: 'open-cowork-cloud',
       clientSecretRef: 'secret/oidc-client',
       cookieSecretRef: 'secret/cookie',
+      signupMode: 'domain',
       allowedEmailDomains: ['example.test'],
     },
     storage: {


### PR DESCRIPTION
## Summary
- adds cloud admin APIs for policy, members/invites, membership updates, and redacted audit events
- adds Cloud Web admin console panels for member management, policy visibility, audit search/export, and guarded admin actions
- adds signup-mode config/schema/docs and typed cloud-client admin methods

## Verification
- pnpm typecheck
- pnpm lint
- pnpm docs:build
- pnpm test
- node scripts/run-node-tests.mjs tests/cloud-http-server.test.ts tests/cloud-app.test.ts
- pnpm --filter @open-cowork/website test
- pnpm --filter @open-cowork/website typecheck
- pnpm --filter @open-cowork/cloud-client build
- git diff --check

Closes #483