### PR TITLE
Add desktop cloud sync deployment smoke

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,6 +78,18 @@ pnpm deploy:smoke
 The same smoke command works for local Compose, Kubernetes/Helm, and the cloud
 provider recipes once traffic is routed to the chosen endpoints.
 
+Validate Desktop cloud workspace sync against the same deployment:
+
+```bash
+OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL=https://cowork.example.com \
+OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN=... \
+pnpm deploy:desktop:smoke
+```
+
+Keep Desktop smoke tokens in environment variables or a private secret store;
+the script intentionally does not accept token values as command-line
+arguments.
+
 GCP adds a provider-specific infra smoke:
 
 ```bash

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -180,6 +180,26 @@ they must not be injected as process env vars.
     pnpm deploy:gcp:smoke
     ```
 
+13. Run the Desktop cloud-sync smoke with an admin-scoped token so the script
+    can issue and revoke an ephemeral Desktop token. Keep tokens in the shell
+    environment or your private deployment repo secret store; do not pass them
+    on the command line:
+
+    ```bash
+    OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL=https://cowork.example.com \
+    OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN=... \
+    pnpm deploy:desktop:smoke
+    ```
+
+    This is the #496 gate for deployed GCP environments. It validates the same
+    Desktop cloud adapter/cache path used by Electron, including Desktop OIDC
+    metadata when OIDC auth is configured, bearer-auth HTTP/SSE, Desktop-created and Web-created cloud
+    sessions, prompt/abort routing, read-only offline cache fallback, local
+    workspace isolation, and token revocation. Set
+    `OPEN_COWORK_DESKTOP_SMOKE_SKIP_PROMPT=true` only for pre-worker surface
+    checks; the full #496 acceptance gate should run prompts against a worker
+    with BYOK/model credentials configured.
+
 For quick Helm overrides, keep the same provider-neutral keys used by the
 other recipes:
 
@@ -246,6 +266,7 @@ Rollback order:
 - `OPEN_COWORK_GCP_REGION=... pnpm deploy:gcp:preflight`
 - `OPEN_COWORK_SMOKE_CLOUD_URL=https://... pnpm deploy:smoke -- --skip-gateway`
 - `OPEN_COWORK_GCP_PROJECT=... OPEN_COWORK_GCP_BUCKET=... pnpm deploy:gcp:smoke`
+- `OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL=https://... OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN=... pnpm deploy:desktop:smoke`
 - Cloud logs contain no raw database URLs, BYOK keys, API tokens, OAuth tokens,
   channel credentials, or signed object URLs.
 

--- a/deploy/gcp/smoke/README.md
+++ b/deploy/gcp/smoke/README.md
@@ -46,3 +46,21 @@ pnpm deploy:gcp:smoke
 The GCP smoke runs the Cloud Web smoke, writes/reads/deletes a temporary object
 in Cloud Storage, and resolves a Secret Manager reference without printing the
 secret value.
+
+## Desktop Cloud Sync Smoke
+
+```bash
+OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL=https://cowork.example.com \
+OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN=... \
+pnpm deploy:desktop:smoke
+```
+
+This validates the deployed cloud from the Desktop client's point of view using
+the same main-process cloud adapter/cache code as Electron Desktop. With an
+admin-scoped token, the smoke issues a short-lived Desktop token, connects over
+bearer-auth HTTP/SSE, creates a Desktop-originated session, verifies Cloud Web
+API visibility, creates a Web-originated session, verifies Desktop visibility,
+prompts from both sides, sends an abort command, checks read-only offline cache
+fallback, verifies the local workspace remains independent, and revokes the
+ephemeral token. Use `OPEN_COWORK_DESKTOP_SMOKE_SKIP_PROMPT=true` only for
+early surface checks before workers/BYOK are ready.

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -238,6 +238,20 @@ OPEN_COWORK_SMOKE_CLOUD_URL=https://cowork.example.com \
 pnpm deploy:gcp:smoke
 ```
 
+For the Desktop cloud-sync gate against the same deployed Cloud environment:
+
+```bash
+OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL=https://cowork.example.com \
+OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN=... \
+pnpm deploy:desktop:smoke
+```
+
+This smoke uses the Desktop main-process cloud adapter and cache path, not a
+separate test-only client. It validates Desktop OIDC metadata when configured, bearer-auth
+HTTP/SSE, Desktop-to-Web and Web-to-Desktop session continuation, prompt/abort
+routing, read-only offline cache fallback, local workspace isolation, and
+ephemeral Desktop token revocation.
+
 For operator-only readiness checks:
 
 ```bash

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -487,6 +487,22 @@ OPEN_COWORK_SMOKE_GATEWAY_URL=https://gateway.example.com \
 pnpm deploy:smoke
 ```
 
+Validate the Desktop cloud-workspace path against that deployment before
+calling desktop sync production-ready:
+
+```bash
+OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL=https://cowork.example.com \
+OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN=... \
+pnpm deploy:desktop:smoke
+```
+
+The Desktop smoke uses the Electron main-process cloud adapter/cache code,
+issues a short-lived Desktop token when an admin token is provided, validates
+Desktop OIDC metadata when configured, exercises bearer-auth HTTP/SSE, checks Desktop-created
+and Web-created session continuation, verifies prompt/abort routing, confirms
+read-only offline cache behavior, proves the local workspace remains
+independent, and revokes the ephemeral token.
+
 ## Validation
 
 The regular `pnpm test` suite covers the in-memory control-plane adapter and

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "cloud:smoke:compose": "bash scripts/ci-cloud-compose-smoke.sh",
     "deploy:validate": "node scripts/validate-deployment-configs.mjs",
     "deploy:smoke": "node scripts/smoke-deployment.mjs",
+    "deploy:desktop:smoke": "pnpm build:shared && node --no-warnings --experimental-strip-types scripts/desktop-cloud-sync-smoke.mjs",
     "deploy:gcp:preflight": "node scripts/gcp-reference-preflight.mjs",
     "deploy:gcp:smoke": "node scripts/gcp-reference-smoke.mjs",
     "notices": "node scripts/generate-third-party-notices.mjs",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,6 +17,7 @@ pnpm cloud:start
 pnpm cloud:smoke:compose
 pnpm deploy:validate
 pnpm deploy:smoke
+pnpm deploy:desktop:smoke
 pnpm deploy:gcp:preflight
 pnpm deploy:gcp:smoke
 pnpm notices
@@ -48,6 +49,15 @@ reachability, and gateway readiness endpoints. Override
 `OPEN_COWORK_SMOKE_CLOUD_URL` and `OPEN_COWORK_SMOKE_GATEWAY_URL` for provider
 deployments, or use `--skip-cloud` / `--skip-gateway` when checking one
 surface.
+
+`pnpm deploy:desktop:smoke` validates the Desktop cloud-workspace path against
+a running cloud deployment. It uses the same main-process cloud adapter and
+cache code as Electron Desktop, verifies HTTPS/base URL handling, Desktop OIDC
+metadata when configured, bearer-auth HTTP/SSE, Desktop-created and Web-created session
+continuation, prompt/abort routing, read-only offline cache fallback, local
+workspace isolation, and token revocation when
+`OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN` is provided. Tokens are read from
+environment variables only, not command-line arguments.
 
 `pnpm deploy:gcp:preflight` is a read-only GCP check for the reference
 deployment. It verifies the active `gcloud` account/project, region, required

--- a/scripts/desktop-cloud-sync-smoke.mjs
+++ b/scripts/desktop-cloud-sync-smoke.mjs
@@ -1,0 +1,563 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createHttpSseCloudTransportAdapter } from '../packages/cloud-client/src/index.ts'
+import {
+  CloudWorkspaceAdapter,
+  cloudWorkspaceCacheKey,
+} from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
+import { FileCloudWorkspaceCache } from '../apps/desktop/src/main/cloud-workspace-cache.ts'
+import {
+  cloudWorkspaceIdForBaseUrl,
+  normalizeCloudWorkspaceBaseUrl,
+} from '../apps/desktop/src/main/cloud-workspace-registry.ts'
+import {
+  LOCAL_WORKSPACE_ID,
+  createWorkspaceGateway,
+} from '../apps/desktop/src/main/workspace-gateway.ts'
+
+const args = parseArgs(process.argv.slice(2))
+const debugEnabled = process.env.OPEN_COWORK_DESKTOP_SMOKE_DEBUG === 'true'
+
+function parseArgs(argv) {
+  const parsed = new Map()
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2)
+    const next = argv[index + 1]
+    if (!next || next.startsWith('--')) {
+      parsed.set(key, 'true')
+    } else {
+      parsed.set(key, next)
+      index += 1
+    }
+  }
+  return parsed
+}
+
+function argOrEnv(argName, envName, fallback = '') {
+  return args.get(argName) || process.env[envName] || fallback
+}
+
+function envOrFallback(primary, fallback) {
+  return process.env[primary] || process.env[fallback] || ''
+}
+
+function boolArg(argName, envName) {
+  return args.has(argName) || process.env[envName] === 'true'
+}
+
+function intArg(argName, envName, fallback) {
+  const raw = args.get(argName) || process.env[envName] || ''
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${envName} must be a positive integer.`)
+  }
+  return parsed
+}
+
+function tokenEnv(name) {
+  return typeof process.env[name] === 'string' && process.env[name].trim()
+    ? process.env[name].trim()
+    : ''
+}
+
+function debug(message) {
+  if (debugEnabled) process.stderr.write(`[desktop-cloud-smoke:debug] ${message}\n`)
+}
+
+function requireCloudUrl() {
+  const raw = argOrEnv('cloud-url', 'OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL')
+    || process.env.OPEN_COWORK_SMOKE_CLOUD_URL
+  if (!raw) {
+    throw new Error('Set OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL or pass --cloud-url for Desktop cloud sync smoke.')
+  }
+  return normalizeCloudWorkspaceBaseUrl(raw)
+}
+
+function transport(baseUrl, token) {
+  return createHttpSseCloudTransportAdapter({
+    baseUrl,
+    headers: { authorization: `Bearer ${token}` },
+  })
+}
+
+function encryptedStorage() {
+  return {
+    mode: 'plaintext',
+    encryptString: (plaintext) => Buffer.from(plaintext, 'utf8'),
+    decryptString: (encrypted) => encrypted.toString('utf8'),
+  }
+}
+
+function failingTransport(baseUrl) {
+  return new Proxy({}, {
+    get(_target, prop) {
+      if (prop === 'workspaceEventsUrl') return () => `${baseUrl}/api/events`
+      if (prop === 'sessionEventsUrl') return (sessionId) => `${baseUrl}/api/sessions/${encodeURIComponent(sessionId)}/events`
+      if (prop === 'subscribeWorkspaceEvents' || prop === 'subscribeSessionEvents') return () => ({ close() {} })
+      return async () => {
+        throw new Error('desktop cloud transport offline fixture')
+      }
+    },
+  })
+}
+
+function createDesktopAdapter({ baseUrl, token, connection, cache }) {
+  return new CloudWorkspaceAdapter({
+    connection,
+    transport: transport(baseUrl, token),
+    cache,
+  })
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function waitForEvent(setup, predicate, label, timeoutMs) {
+  let subscription = null
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try { subscription?.close() } catch { /* ignore close failures */ }
+      reject(new Error(`Timed out waiting for ${label}.`))
+    }, timeoutMs)
+    if (typeof timer.unref === 'function') timer.unref()
+
+    subscription = setup((event) => {
+      if (!predicate(event)) return
+      clearTimeout(timer)
+      try { subscription?.close() } catch { /* ignore close failures */ }
+      resolve(event)
+    }, (error) => {
+      clearTimeout(timer)
+      try { subscription?.close() } catch { /* ignore close failures */ }
+      reject(error)
+    })
+  })
+}
+
+async function waitForView(getter, predicate, label, timeoutMs) {
+  const startedAt = Date.now()
+  let latest = null
+  while (Date.now() - startedAt <= timeoutMs) {
+    latest = await getter()
+    if (predicate(latest)) return latest
+    await wait(100)
+  }
+  throw new Error(`Timed out waiting for ${label}. Latest revision: ${latest?.revision ?? 'unknown'}.`)
+}
+
+function projectionSequence(view) {
+  const projection = view && typeof view === 'object' ? view.projection : null
+  const sequence = projection && typeof projection === 'object' ? projection.sequence : null
+  return typeof sequence === 'number' && Number.isFinite(sequence) ? sequence : 0
+}
+
+function cloudSessionId(view) {
+  const session = view && typeof view === 'object' ? view.session : null
+  const sessionId = session && typeof session === 'object' ? session.sessionId : null
+  if (typeof sessionId !== 'string' || !sessionId.trim()) {
+    throw new Error('Cloud session response did not include a session id.')
+  }
+  return sessionId
+}
+
+function outputViewShape(view) {
+  return {
+    revision: view.revision || 0,
+    messages: Array.isArray(view.messages) ? view.messages.length : 0,
+    taskRuns: Array.isArray(view.taskRuns) ? view.taskRuns.length : 0,
+    toolCalls: Array.isArray(view.toolCalls) ? view.toolCalls.length : 0,
+    pendingApprovals: Array.isArray(view.pendingApprovals) ? view.pendingApprovals.length : 0,
+    pendingQuestions: Array.isArray(view.pendingQuestions) ? view.pendingQuestions.length : 0,
+    artifacts: Array.isArray(view.artifacts) ? view.artifacts.length : 0,
+    todos: Array.isArray(view.todos) ? view.todos.length : 0,
+    errors: Array.isArray(view.errors) ? view.errors.length : 0,
+  }
+}
+
+async function checkDesktopAuthConfig(baseUrl) {
+  if (boolArg('skip-auth-config', 'OPEN_COWORK_DESKTOP_SMOKE_SKIP_AUTH_CONFIG')) return { skipped: true }
+  const response = await fetch(`${baseUrl}/auth/desktop/config`)
+  const text = await response.text()
+  if (!response.ok) {
+    if (response.status === 404) {
+      return {
+        skipped: true,
+        reason: 'desktop auth metadata is not configured; continuing with API-token smoke',
+      }
+    }
+    throw new Error(`/auth/desktop/config returned ${response.status}: ${text.slice(0, 240)}`)
+  }
+  const body = text ? JSON.parse(text) : null
+  if (!body || body.mode !== 'oidc' || typeof body.issuerUrl !== 'string' || typeof body.clientId !== 'string') {
+    throw new Error('/auth/desktop/config must expose OIDC desktop login metadata.')
+  }
+  return {
+    mode: body.mode,
+    issuerConfigured: Boolean(body.issuerUrl),
+    clientConfigured: Boolean(body.clientId),
+    scopeConfigured: Boolean(body.scope),
+  }
+}
+
+async function maybeIssueDesktopToken(baseUrl) {
+  const adminToken = tokenEnv('OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN')
+  const providedDesktopToken = tokenEnv('OPEN_COWORK_DESKTOP_SMOKE_DESKTOP_TOKEN')
+    || envOrFallback('OPEN_COWORK_DESKTOP_SMOKE_CLOUD_TOKEN', 'OPEN_COWORK_SMOKE_CLOUD_TOKEN')
+
+  if (!adminToken && !providedDesktopToken) {
+    throw new Error('Set OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN for a full ephemeral-token smoke, or OPEN_COWORK_DESKTOP_SMOKE_DESKTOP_TOKEN for an existing desktop token.')
+  }
+  if (!adminToken) {
+    return {
+      adminClient: null,
+      desktopToken: providedDesktopToken,
+      issuedToken: null,
+      tokenSource: 'provided',
+    }
+  }
+
+  const adminClient = transport(baseUrl, adminToken)
+  const ttlSeconds = intArg('token-ttl-seconds', 'OPEN_COWORK_DESKTOP_SMOKE_TOKEN_TTL_SECONDS', 15 * 60)
+  const issued = await adminClient.issueApiToken({
+    name: `Desktop GCP sync smoke ${new Date().toISOString()}`,
+    scopes: ['desktop'],
+    expiresAt: new Date(Date.now() + ttlSeconds * 1000).toISOString(),
+  })
+  return {
+    adminClient,
+    desktopToken: issued.plaintext,
+    issuedToken: issued.token,
+    tokenSource: 'ephemeral',
+  }
+}
+
+function promptViewSucceeded(view) {
+  return outputViewShape(view).messages > 0
+}
+
+function promptViewErrors(view) {
+  return Array.isArray(view?.errors) ? view.errors : []
+}
+
+async function waitForSuccessfulPromptView(getter, beforeSequence, label, timeoutMs) {
+  return waitForView(
+    async () => {
+      const view = await getter()
+      const errors = promptViewErrors(view)
+      if (errors.length > 0) {
+        const message = errors
+          .map((error) => error?.message)
+          .filter(Boolean)
+          .join('; ')
+        throw new Error(`${label} reported cloud session errors: ${message || 'unknown error'}`)
+      }
+      return view
+    },
+    (view) => (view.revision || 0) > beforeSequence && promptViewSucceeded(view),
+    `${label} assistant output`,
+    timeoutMs,
+  )
+}
+
+async function revokeAndVerify({ adminClient, baseUrl, issuedToken, desktopToken }) {
+  if (!adminClient || !issuedToken) {
+    if (boolArg('require-revocation', 'OPEN_COWORK_DESKTOP_SMOKE_REQUIRE_REVOCATION')) {
+      throw new Error('Token revocation smoke requires OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN.')
+    }
+    return { skipped: true }
+  }
+  const revoked = await adminClient.revokeApiToken(issuedToken.tokenId)
+  if (!revoked?.revokedAt) {
+    throw new Error('Desktop smoke token was not revoked.')
+  }
+  const response = await fetch(`${baseUrl}/api/workspace`, {
+    headers: { authorization: `Bearer ${desktopToken}` },
+  })
+  if (response.status === 401 || response.status === 403) {
+    return {
+      tokenId: issuedToken.tokenId,
+      revokedAt: revoked.revokedAt,
+      rejected: true,
+    }
+  }
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Revocation verification returned ${response.status} instead of an auth failure: ${text.slice(0, 240)}`)
+  }
+  throw new Error('Revoked desktop token was still accepted by the cloud API.')
+}
+
+function assertLocalWorkspaceBoundary() {
+  const gateway = createWorkspaceGateway({
+    cloudDesktop: {
+      enabled: false,
+      allowUserAddedConnections: false,
+      preconfiguredConnections: [],
+      requireManagedOrg: false,
+      cacheMode: 'metadata-only',
+      cacheEncryptionFallback: 'metadata-only',
+    },
+    cloudRegistry: null,
+    cloudCredentialStore: null,
+    cloudCache: null,
+  })
+  const workspaces = gateway.list(null)
+  const local = workspaces.find((workspace) => workspace.id === LOCAL_WORKSPACE_ID)
+  if (!local || local.kind !== 'local' || local.status !== 'online') {
+    throw new Error('Local workspace boundary check failed.')
+  }
+  if (!gateway.isLocalWorkspace(null)) {
+    throw new Error('Local workspace must remain active without a cloud dependency.')
+  }
+  return {
+    workspaceId: local.id,
+    status: local.status,
+    localFiles: 'not uploaded',
+  }
+}
+
+async function runSmoke() {
+  const baseUrl = requireCloudUrl()
+  debug(`cloud url ${baseUrl}`)
+  const timeoutMs = intArg('timeout-ms', 'OPEN_COWORK_DESKTOP_SMOKE_TIMEOUT_MS', 30_000)
+  const promptText = argOrEnv(
+    'prompt',
+    'OPEN_COWORK_DESKTOP_SMOKE_PROMPT',
+    `Open Cowork Desktop cloud sync smoke ${new Date().toISOString()}`,
+  )
+  const agent = argOrEnv('agent', 'OPEN_COWORK_DESKTOP_SMOKE_AGENT') || null
+  const skipPrompt = boolArg('skip-prompt', 'OPEN_COWORK_DESKTOP_SMOKE_SKIP_PROMPT')
+  debug('checking desktop auth config')
+  const authConfig = await checkDesktopAuthConfig(baseUrl)
+  debug('issuing or loading desktop token')
+  const tokenState = await maybeIssueDesktopToken(baseUrl)
+  let tokenRevocationComplete = false
+  const webToken = tokenEnv('OPEN_COWORK_DESKTOP_SMOKE_WEB_TOKEN') || tokenState.desktopToken
+  const webClient = transport(baseUrl, webToken)
+  let tempRoot = null
+
+  try {
+    debug('loading workspace')
+    const workspace = await webClient.getWorkspace()
+    const connection = {
+      id: cloudWorkspaceIdForBaseUrl(baseUrl),
+      baseUrl,
+      label: new URL(baseUrl).host,
+      tenantId: workspace.tenantId,
+      userId: workspace.userId,
+      profileName: workspace.profileName,
+      lastSyncedAt: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    tempRoot = mkdtempSync(join(tmpdir(), 'open-cowork-desktop-cloud-smoke-'))
+    const cache = new FileCloudWorkspaceCache({
+      path: join(tempRoot, 'cloud-workspace-cache.json'),
+      mode: 'full',
+      secretStorage: encryptedStorage(),
+    })
+    const desktop = createDesktopAdapter({
+      baseUrl,
+      token: tokenState.desktopToken,
+      connection,
+      cache,
+    })
+
+    debug('loading desktop cloud policy')
+    const policy = await desktop.policy()
+    if (policy.localFiles !== 'disabled' || policy.localStdioMcps !== 'disabled' || policy.machineRuntimeConfig !== 'disabled') {
+      throw new Error('Cloud workspace policy must disable local files, local stdio MCPs, and machine runtime config.')
+    }
+
+    debug('creating desktop-originated session')
+    const desktopCreated = await desktop.createSession()
+    debug(`waiting for workspace SSE for ${desktopCreated.id}`)
+    const desktopCreatedEvent = await waitForEvent(
+      (onEvent, onError) => webClient.subscribeWorkspaceEvents({
+        afterSequence: 0,
+        onEvent,
+        onError,
+      }),
+      (event) => event.type === 'session.created' && event.sessionId === desktopCreated.id,
+      'workspace session.created SSE for Desktop-created session',
+      timeoutMs,
+    )
+    debug('listing sessions from web client')
+    const webSessions = await webClient.listSessions()
+    if (!webSessions.some((session) => session.sessionId === desktopCreated.id)) {
+      throw new Error('Cloud Web API could not see the Desktop-created cloud session.')
+    }
+
+    debug('creating web-originated session')
+    const webCreatedView = await webClient.createSession()
+    const webCreatedSessionId = cloudSessionId(webCreatedView)
+    const desktopSessionsAfterWebCreate = await desktop.listSessions()
+    if (!desktopSessionsAfterWebCreate.some((session) => session.id === webCreatedSessionId)) {
+      throw new Error('Desktop cloud adapter could not see the Web-created cloud session.')
+    }
+
+    const results = {
+      baseUrl,
+      authConfig,
+      workspace: {
+        tenantBound: Boolean(workspace.tenantId),
+        userBound: Boolean(workspace.userId),
+        profileName: workspace.profileName,
+      },
+      token: {
+        source: tokenState.tokenSource,
+        tokenId: tokenState.issuedToken?.tokenId || null,
+      },
+      policy: {
+        localFiles: policy.localFiles,
+        localStdioMcps: policy.localStdioMcps,
+        machineRuntimeConfig: policy.machineRuntimeConfig,
+      },
+      desktopCreated: {
+        sessionId: desktopCreated.id,
+        visibleToWeb: true,
+        workspaceSse: {
+          type: desktopCreatedEvent.type,
+          sequence: desktopCreatedEvent.sequence,
+        },
+      },
+      webCreated: {
+        sessionId: webCreatedSessionId,
+        visibleToDesktop: true,
+      },
+      prompt: { skipped: true },
+      cache: { skipped: true },
+      localWorkspace: assertLocalWorkspaceBoundary(),
+      tokenRevocation: { skipped: true },
+    }
+
+    if (!skipPrompt) {
+      debug('prompting from desktop')
+      const beforeDesktopPrompt = projectionSequence(await webClient.getSession(desktopCreated.id))
+      const desktopPromptEvent = waitForEvent(
+        (onEvent, onError) => webClient.subscribeSessionEvents(desktopCreated.id, {
+          afterSequence: beforeDesktopPrompt,
+          onEvent,
+          onError,
+        }),
+        (event) => event.sequence > beforeDesktopPrompt,
+        'session SSE after Desktop prompt',
+        timeoutMs,
+      )
+      await desktop.promptSession(desktopCreated.id, { text: promptText, agent })
+      const webObservedDesktopPrompt = await desktopPromptEvent
+      const desktopPromptView = await waitForSuccessfulPromptView(
+        () => desktop.getSessionView(desktopCreated.id),
+        beforeDesktopPrompt,
+        'Desktop projection after Desktop prompt',
+        timeoutMs,
+      )
+
+      debug('prompting from web')
+      const beforeWebPrompt = projectionSequence(await webClient.getSession(webCreatedSessionId))
+      const webPromptEvent = waitForEvent(
+        (onEvent, onError) => desktop.subscribeSessionEvents(webCreatedSessionId, {
+          afterSequence: beforeWebPrompt,
+          onEvent,
+          onError,
+        }),
+        (event) => event.sequence > beforeWebPrompt,
+        'Desktop bearer-auth SSE after Web prompt',
+        timeoutMs,
+      )
+      await webClient.promptSession(webCreatedSessionId, { text: `${promptText} from web`, agent })
+      const desktopObservedWebPrompt = await webPromptEvent
+      const webPromptView = await waitForSuccessfulPromptView(
+        () => desktop.getSessionView(webCreatedSessionId),
+        beforeWebPrompt,
+        'Desktop projection after Web prompt',
+        timeoutMs,
+      )
+
+      debug('sending desktop abort command')
+      await desktop.abortSession(webCreatedSessionId)
+      const artifacts = desktop.listArtifacts
+        ? await desktop.listArtifacts(desktopCreated.id).catch(() => [])
+        : []
+      debug('checking offline cache fallback')
+      const offline = new CloudWorkspaceAdapter({
+        connection,
+        transport: failingTransport(baseUrl),
+        cache,
+      })
+      const cachedSessions = await offline.listSessions()
+      if (!cachedSessions.some((session) => session.id === desktopCreated.id)) {
+        throw new Error('Offline Desktop cache did not retain cloud session list.')
+      }
+      const cachedView = await offline.getSessionView(desktopCreated.id)
+      await offline.promptSession(desktopCreated.id, { text: 'must not queue offline' })
+        .then(() => {
+          throw new Error('Offline Desktop cloud prompt unexpectedly succeeded.')
+        })
+        .catch((error) => {
+          if (!String(error instanceof Error ? error.message : error).includes('offline')) throw error
+        })
+
+      results.prompt = {
+        skipped: false,
+        desktopPromptObservedByWebSse: {
+          type: webObservedDesktopPrompt.type,
+          sequence: webObservedDesktopPrompt.sequence,
+        },
+        webPromptObservedByDesktopSse: {
+          type: desktopObservedWebPrompt.type,
+          sequence: desktopObservedWebPrompt.sequence,
+        },
+        desktopView: outputViewShape(desktopPromptView),
+        webViewOnDesktop: outputViewShape(webPromptView),
+        abortCommandAccepted: true,
+        artifactCount: Math.max(artifacts.length, Array.isArray(desktopPromptView.artifacts) ? desktopPromptView.artifacts.length : 0),
+        artifactEndpointCount: artifacts.length,
+      }
+      results.cache = {
+        skipped: false,
+        mode: cache.mode,
+        cachedSessions: cachedSessions.length,
+        cachedView: outputViewShape(cachedView),
+        offlineMutationsBlocked: true,
+        cacheKeyPresent: Boolean(cloudWorkspaceCacheKey(connection)),
+      }
+    }
+
+    debug('checking token revocation')
+    results.tokenRevocation = await revokeAndVerify({
+      adminClient: tokenState.adminClient,
+      baseUrl,
+      issuedToken: tokenState.issuedToken,
+      desktopToken: tokenState.desktopToken,
+    })
+    tokenRevocationComplete = true
+
+    return results
+  } finally {
+    if (!tokenRevocationComplete && tokenState.adminClient && tokenState.issuedToken) {
+      try {
+        await tokenState.adminClient.revokeApiToken(tokenState.issuedToken.tokenId)
+      } catch (error) {
+        process.stderr.write(`[desktop-cloud-smoke] Warning: failed to revoke ephemeral desktop token ${tokenState.issuedToken.tokenId}: ${error instanceof Error ? error.message : String(error)}\n`)
+      }
+    }
+    if (tempRoot) rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+runSmoke()
+  .then((results) => {
+    process.stdout.write(`${JSON.stringify({ ok: true, results }, null, 2)}\n`)
+  })
+  .catch((error) => {
+    process.stderr.write(`[desktop-cloud-smoke] ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  })

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -294,6 +294,7 @@ function validateGcpReference() {
     'deploy/gcp/smoke/README.md',
     'scripts/gcp-reference-preflight.mjs',
     'scripts/gcp-reference-smoke.mjs',
+    'scripts/desktop-cloud-sync-smoke.mjs',
   ]
   for (const path of requiredGcpFiles) {
     if (!existsSync(path)) {
@@ -311,6 +312,7 @@ function validateGcpReference() {
     'OPEN_COWORK_GCP_REGION',
     'pnpm deploy:gcp:preflight',
     'pnpm deploy:gcp:smoke',
+    'pnpm deploy:desktop:smoke',
     'kubectl apply -f deploy/gcp/gke/external-secret.example.yaml',
     'kubectl apply -f deploy/gcp/gke/managed-certificate.example.yaml',
     'OPEN_COWORK_CLOUD_TRUST_PROXY_HEADERS=true',
@@ -373,6 +375,22 @@ function validateGcpReference() {
   ]) {
     if (!cloudRun.includes(phrase)) {
       throw new Error(`deploy/gcp/cloud-run/all-in-one.service.yaml.example must include ${phrase}`)
+    }
+  }
+
+  const desktopSmoke = read('scripts/desktop-cloud-sync-smoke.mjs')
+  for (const phrase of [
+    'OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL',
+    'OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN',
+    'CloudWorkspaceAdapter',
+    'subscribeWorkspaceEvents',
+    'subscribeSessionEvents',
+    'offlineMutationsBlocked',
+    'revokeApiToken',
+    'LOCAL_WORKSPACE_ID',
+  ]) {
+    if (!desktopSmoke.includes(phrase)) {
+      throw new Error(`scripts/desktop-cloud-sync-smoke.mjs must include ${phrase}`)
     }
   }
 }

--- a/tests/cloud-deployment-artifacts.test.ts
+++ b/tests/cloud-deployment-artifacts.test.ts
@@ -98,6 +98,7 @@ test('cloud deployment docs cover provider-neutral split deployment', () => {
   assert.match(docs, /runbooks\/managed-byok-saas\.md/)
   assert.match(docs, /pnpm deploy:validate/)
   assert.match(docs, /pnpm deploy:smoke/)
+  assert.match(docs, /pnpm deploy:desktop:smoke/)
 })
 
 test('cloud Helm chart keeps provider-neutral role wiring explicit', () => {
@@ -187,6 +188,7 @@ test('GCP reference deployment defines split roles, Cloud Run demo, and smoke ga
   const smoke = readRepoFile('deploy/gcp/smoke/README.md')
   const preflightScript = readRepoFile('scripts/gcp-reference-preflight.mjs')
   const smokeScript = readRepoFile('scripts/gcp-reference-smoke.mjs')
+  const desktopSmokeScript = readRepoFile('scripts/desktop-cloud-sync-smoke.mjs')
 
   assert.match(readme, /GCP Reference Deployment/)
   assert.match(readme, /Cloud SQL for PostgreSQL/)
@@ -196,6 +198,8 @@ test('GCP reference deployment defines split roles, Cloud Run demo, and smoke ga
   assert.match(readme, /OPEN_COWORK_GCP_REGION/)
   assert.match(readme, /pnpm deploy:gcp:preflight/)
   assert.match(readme, /pnpm deploy:gcp:smoke/)
+  assert.match(readme, /pnpm deploy:desktop:smoke/)
+  assert.match(readme, /Desktop cloud-sync smoke/)
   assert.match(readme, /kubectl apply -f deploy\/gcp\/gke\/external-secret\.example\.yaml/)
   assert.match(readme, /kubectl apply -f deploy\/gcp\/gke\/managed-certificate\.example\.yaml/)
   assert.match(readme, /OPEN_COWORK_CLOUD_TRUST_PROXY_HEADERS=true/)
@@ -240,6 +244,8 @@ test('GCP reference deployment defines split roles, Cloud Run demo, and smoke ga
 
   assert.match(smoke, /OPEN_COWORK_GCP_BUCKET/)
   assert.match(smoke, /OPEN_COWORK_GCP_SECRET_REF/)
+  assert.match(smoke, /OPEN_COWORK_DESKTOP_SMOKE_CLOUD_URL/)
+  assert.match(smoke, /pnpm deploy:desktop:smoke/)
   assert.match(preflightScript, /requiredApis/)
   assert.match(preflightScript, /optionalApis/)
   assert.match(preflightScript, /^ {2}'iamcredentials\.googleapis\.com',$/m)
@@ -254,6 +260,14 @@ test('GCP reference deployment defines split roles, Cloud Run demo, and smoke ga
   assert.match(smokeScript, /'versions'/)
   assert.match(smokeScript, /'access'/)
   assert.equal(smokeScript.includes('--cloud-token'), false)
+  assert.match(desktopSmokeScript, /CloudWorkspaceAdapter/)
+  assert.match(desktopSmokeScript, /OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN/)
+  assert.match(desktopSmokeScript, /subscribeWorkspaceEvents/)
+  assert.match(desktopSmokeScript, /subscribeSessionEvents/)
+  assert.match(desktopSmokeScript, /revokeApiToken/)
+  assert.match(desktopSmokeScript, /offlineMutationsBlocked/)
+  assert.match(desktopSmokeScript, /LOCAL_WORKSPACE_ID/)
+  assert.equal(desktopSmokeScript.includes('--desktop-token'), false)
   assert.doesNotMatch(readme, /opencowork/)
 })
 

--- a/tests/desktop-cloud-sync-smoke.test.ts
+++ b/tests/desktop-cloud-sync-smoke.test.ts
@@ -1,0 +1,306 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+
+import { DEFAULT_CONFIG } from '../apps/desktop/src/main/config-types.ts'
+import { createApiTokenCloudAuthResolver } from '../apps/desktop/src/main/cloud/app.ts'
+import { resolveCloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
+import { createCloudHttpServer } from '../apps/desktop/src/main/cloud/http-server.ts'
+import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
+import type {
+  CloudRuntimeAdapter,
+  CloudRuntimeEvent,
+  CloudRuntimePromptPart,
+} from '../apps/desktop/src/main/cloud/runtime-adapter.ts'
+import { CloudSessionService } from '../apps/desktop/src/main/cloud/session-service.ts'
+import { CloudWorker } from '../apps/desktop/src/main/cloud/worker.ts'
+
+class DesktopSmokeRuntime implements CloudRuntimeAdapter {
+  prompts: Array<{ sessionId: string; text: string }> = []
+  private nextSession = 0
+  private readonly options: { failPrompt?: boolean }
+
+  constructor(options: { failPrompt?: boolean } = {}) {
+    this.options = options
+  }
+
+  async createSession() {
+    this.nextSession += 1
+    return {
+      id: `desktop-smoke-runtime-${this.nextSession}`,
+      title: `Desktop smoke runtime ${this.nextSession}`,
+      createdAt: '2026-05-30T10:00:00.000Z',
+      updatedAt: '2026-05-30T10:00:00.000Z',
+    }
+  }
+
+  async promptSession(input: { sessionId: string; parts: CloudRuntimePromptPart[] }) {
+    const text = input.parts
+      .filter((part): part is Extract<CloudRuntimePromptPart, { type: 'text' }> => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n')
+    this.prompts.push({ sessionId: input.sessionId, text })
+    const index = this.prompts.length
+    const taskRunId = `${input.sessionId}:task:${index}`
+    const permissionId = `${input.sessionId}:permission:${index}`
+    const questionId = `${input.sessionId}:question:${index}`
+    const artifactId = `${input.sessionId}:artifact:${index}`
+    if (this.options.failPrompt) {
+      return {
+        events: [{
+          type: 'runtime.error',
+          payload: {
+            sessionId: input.sessionId,
+            id: `${input.sessionId}:error:${index}`,
+            message: 'BYOK/model credentials are missing in the smoke fixture.',
+          },
+        }],
+      }
+    }
+    const events: CloudRuntimeEvent[] = [
+      {
+        type: 'session.status',
+        payload: { sessionId: input.sessionId, statusType: 'running' },
+      },
+      {
+        type: 'task.run',
+        payload: {
+          sessionId: input.sessionId,
+          id: taskRunId,
+          title: 'Desktop sync smoke',
+          status: 'running',
+        },
+      },
+      {
+        type: 'assistant.message',
+        payload: {
+          sessionId: input.sessionId,
+          messageId: `${input.sessionId}:assistant:${index}`,
+          content: `desktop smoke observed ${text}`,
+        },
+      },
+      {
+        type: 'permission.requested',
+        payload: {
+          sessionId: input.sessionId,
+          permissionId,
+          tool: 'shell',
+          input: { command: 'echo smoke' },
+          description: 'Desktop smoke permission fixture',
+        },
+      },
+      {
+        type: 'question.asked',
+        payload: {
+          sessionId: input.sessionId,
+          requestId: questionId,
+          questions: [{
+            header: 'Desktop',
+            question: 'Continue the deployed smoke?',
+            options: [{ label: 'Yes', description: 'Continue.' }],
+          }],
+        },
+      },
+      {
+        type: 'artifact.created',
+        payload: {
+          sessionId: input.sessionId,
+          taskRunId,
+          artifactId,
+          filename: 'desktop-sync-smoke.txt',
+          contentType: 'text/plain',
+          size: 12,
+        },
+      },
+      {
+        type: 'session.idle',
+        payload: { sessionId: input.sessionId },
+      },
+    ]
+    return { events }
+  }
+
+  async abortSession() {}
+}
+
+function runDesktopSmokeScript(baseUrl: string, adminToken: string, env: Record<string, string> = {}) {
+  return new Promise<{ status: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      '--no-warnings',
+      '--experimental-strip-types',
+      'scripts/desktop-cloud-sync-smoke.mjs',
+      '--cloud-url',
+      baseUrl,
+      '--timeout-ms',
+      '5000',
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        OPEN_COWORK_DESKTOP_SMOKE_ADMIN_TOKEN: adminToken,
+        OPEN_COWORK_DESKTOP_SMOKE_DEBUG: 'true',
+        OPEN_COWORK_DESKTOP_SMOKE_PROMPT: 'desktop deployed smoke fixture',
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`Desktop smoke script timed out.\nstdout:\n${stdout}\nstderr:\n${stderr}`))
+    }, 20_000)
+    if (typeof timer.unref === 'function') timer.unref()
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+function createDesktopSmokeFixture(input: {
+  runtime?: DesktopSmokeRuntime
+  desktopAuth?: Parameters<typeof createCloudHttpServer>[0]['desktopAuth']
+} = {}) {
+  const store = new InMemoryControlPlaneStore()
+  store.createTenant({ tenantId: 'tenant-desktop-smoke', name: 'Desktop Smoke Tenant' })
+  const org = store.ensureOrgForTenant({ tenantId: 'tenant-desktop-smoke', name: 'Desktop Smoke Tenant' })
+  const account = store.createAccount({
+    accountId: 'account-desktop-smoke',
+    idpSubject: 'subject-desktop-smoke',
+    email: 'owner@example.test',
+  })
+  store.ensureUser({
+    tenantId: 'tenant-desktop-smoke',
+    userId: account.accountId,
+    email: account.email,
+    role: 'admin',
+  })
+  store.upsertMembership({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    role: 'admin',
+    status: 'active',
+  })
+  const adminToken = store.issueApiToken({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    name: 'Desktop smoke admin token',
+    scopes: ['admin'],
+  }).plaintext
+  const runtime = input.runtime || new DesktopSmokeRuntime()
+  const policy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
+  const service = new CloudSessionService(store, runtime, policy)
+  const worker = new CloudWorker(store, service, 'desktop-smoke-worker')
+  const server = createCloudHttpServer({
+    service,
+    worker,
+    policy,
+    auth: createApiTokenCloudAuthResolver(store),
+    autoProcessCommands: true,
+    ssePollMs: 10,
+    desktopAuth: input.desktopAuth === undefined ? {
+      mode: 'oidc',
+      issuerUrl: 'https://issuer.example.test',
+      clientId: 'open-cowork-desktop',
+      scope: 'openid email profile offline_access',
+    } : input.desktopAuth,
+  })
+  return { store, runtime, server, adminToken, org }
+}
+
+test('desktop cloud sync smoke validates deployed-cloud desktop continuation path', async () => {
+  const { store, runtime, server, adminToken, org } = createDesktopSmokeFixture()
+  const baseUrl = await server.listen()
+
+  try {
+    const result = await runDesktopSmokeScript(baseUrl, adminToken)
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(result.stdout.includes(adminToken), false)
+    assert.equal(result.stderr.includes(adminToken), false)
+    const payload = JSON.parse(result.stdout) as {
+      ok: boolean
+      results: {
+        prompt: {
+          skipped: boolean
+          artifactCount: number
+          desktopPromptObservedByWebSse: { sequence: number }
+          webPromptObservedByDesktopSse: { sequence: number }
+        }
+        cache: { offlineMutationsBlocked: boolean; cachedSessions: number }
+        localWorkspace: { workspaceId: string; localFiles: string }
+        tokenRevocation: { rejected: boolean; revokedAt: string }
+      }
+    }
+    assert.equal(payload.ok, true)
+    assert.equal(payload.results.prompt.skipped, false)
+    assert.ok(payload.results.prompt.desktopPromptObservedByWebSse.sequence > 0)
+    assert.ok(payload.results.prompt.webPromptObservedByDesktopSse.sequence > 0)
+    assert.equal(payload.results.prompt.artifactCount, 1)
+    assert.equal(payload.results.cache.offlineMutationsBlocked, true)
+    assert.ok(payload.results.cache.cachedSessions >= 2)
+    assert.equal(payload.results.localWorkspace.workspaceId, 'local')
+    assert.equal(payload.results.localWorkspace.localFiles, 'not uploaded')
+    assert.equal(payload.results.tokenRevocation.rejected, true)
+    assert.ok(payload.results.tokenRevocation.revokedAt)
+    assert.equal(runtime.prompts.length, 2)
+    assert.ok(runtime.prompts.some((prompt) => prompt.text === 'desktop deployed smoke fixture'))
+    assert.ok(runtime.prompts.some((prompt) => prompt.text === 'desktop deployed smoke fixture from web'))
+    const smokeTokens = store.listApiTokens(org.orgId)
+      .filter((token) => token.name.startsWith('Desktop GCP sync smoke'))
+    assert.equal(smokeTokens.length, 1)
+    assert.ok(smokeTokens[0]?.revokedAt)
+  } finally {
+    await server.close()
+  }
+})
+
+test('desktop cloud sync smoke revokes ephemeral token when prompt validation fails', async () => {
+  const runtime = new DesktopSmokeRuntime({ failPrompt: true })
+  const { store, server, adminToken, org } = createDesktopSmokeFixture({ runtime })
+  const baseUrl = await server.listen()
+
+  try {
+    const result = await runDesktopSmokeScript(baseUrl, adminToken)
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /reported cloud session errors/)
+    const smokeTokens = store.listApiTokens(org.orgId)
+      .filter((token) => token.name.startsWith('Desktop GCP sync smoke'))
+    assert.equal(smokeTokens.length, 1)
+    assert.ok(smokeTokens[0]?.revokedAt)
+  } finally {
+    await server.close()
+  }
+})
+
+test('desktop cloud sync smoke skips OIDC metadata when deployed auth does not expose desktop config', async () => {
+  const { server, adminToken } = createDesktopSmokeFixture({ desktopAuth: null })
+  const baseUrl = await server.listen()
+
+  try {
+    const result = await runDesktopSmokeScript(baseUrl, adminToken, {
+      OPEN_COWORK_DESKTOP_SMOKE_SKIP_PROMPT: 'true',
+    })
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const payload = JSON.parse(result.stdout) as {
+      ok: boolean
+      results: { authConfig: { skipped?: boolean; reason?: string } }
+    }
+    assert.equal(payload.ok, true)
+    assert.equal(payload.results.authConfig.skipped, true)
+    assert.match(payload.results.authConfig.reason || '', /API-token smoke/)
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -79,6 +79,10 @@ test('root lint script runs all release gate checks', () => {
 test('root deployment scripts expose provider smoke gates', () => {
   assert.equal(requireScript('deploy:validate'), 'node scripts/validate-deployment-configs.mjs')
   assert.equal(requireScript('deploy:smoke'), 'node scripts/smoke-deployment.mjs')
+  assert.deepEqual(splitScriptSteps(requireScript('deploy:desktop:smoke')), [
+    'pnpm build:shared',
+    'node --no-warnings --experimental-strip-types scripts/desktop-cloud-sync-smoke.mjs',
+  ])
   assert.equal(requireScript('deploy:gcp:preflight'), 'node scripts/gcp-reference-preflight.mjs')
   assert.equal(requireScript('deploy:gcp:smoke'), 'node scripts/gcp-reference-smoke.mjs')
 })


### PR DESCRIPTION
Closes #496.

## Summary

- add `pnpm deploy:desktop:smoke` for deployed Desktop cloud-workspace validation
- exercise the Electron main-process cloud adapter/cache path against Cloud HTTP/SSE, session continuation, prompt/abort, offline cache fallback, local workspace isolation, and token revocation
- document the #496 GCP/Desktop smoke gate and add deployment artifact guards

## Verification

- `node --check scripts/desktop-cloud-sync-smoke.mjs`
- `node --no-warnings --experimental-strip-types --test tests/desktop-cloud-sync-smoke.test.ts`
- `node --no-warnings --experimental-strip-types --test tests/cloud-deployment-artifacts.test.ts tests/package-scripts.test.ts tests/desktop-cloud-sync-smoke.test.ts`
- `pnpm deploy:validate`
- `pnpm lint`
- `pnpm docs:build`
- `pnpm test:cloud-continuation`
- `git diff --check`

## Notes

- the smoke reads tokens only from environment variables, never CLI args
- smoke output is metadata-only for auth/workspace/cache and does not print token plaintext
- no concrete GCP project IDs, domains, accounts, or secret values are committed
