### PR TITLE
Add cloud operations observability and recovery runbooks

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -21,6 +21,8 @@ import {
 } from './http-server.ts'
 import {
   createCloudObservabilityFromEnv,
+  recordCloudSchedulerMetric,
+  recordCloudWorkerMetric,
   type CloudObservabilityAdapter,
 } from './observability.ts'
 import { createObjectStoreForCloud, type ObjectStoreAdapter } from './object-store.ts'
@@ -704,6 +706,16 @@ async function recordLoopError(
   error: unknown,
   attributes: Record<string, string | number | boolean | null | undefined> = {},
 ) {
+  await observability?.metric({
+    name: 'open_cowork_cloud_loop_errors_total',
+    value: 1,
+    unit: '1',
+    attributes: {
+      loop: name,
+      ...attributes,
+      error_name: error instanceof Error ? error.name : 'Error',
+    },
+  })
   await observability?.log({
     level: 'error',
     name,
@@ -721,7 +733,14 @@ function startWorkerLoop(worker: CloudWorker, pollMs: number, observability: Clo
     if (active) return
     active = true
     void worker.processAllSessionCommands()
-      .catch((error) => recordLoopError(observability, 'cloud.worker.loop.error', error))
+      .catch(async (error) => {
+        await recordCloudWorkerMetric(observability, {
+          name: 'open_cowork_cloud_worker_loop_failures_total',
+          workerId: 'loop',
+          status: 'error',
+        })
+        await recordLoopError(observability, 'cloud.worker.loop.error', error)
+      })
       .finally(() => {
         active = false
       })
@@ -735,7 +754,14 @@ function startSchedulerLoop(scheduler: CloudScheduler, pollMs: number, observabi
     if (active) return
     active = true
     void scheduler.processDueWorkflows()
-      .catch((error) => recordLoopError(observability, 'cloud.scheduler.loop.error', error))
+      .catch(async (error) => {
+        await recordCloudSchedulerMetric(observability, {
+          name: 'open_cowork_cloud_scheduler_failures_total',
+          schedulerId: 'loop',
+          status: 'error',
+        })
+        await recordLoopError(observability, 'cloud.scheduler.loop.error', error)
+      })
       .finally(() => {
         active = false
       })
@@ -834,6 +860,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
             allowedProviderIds: byokPolicy.allowedProviderIds,
             checkEntitlement: byokPolicy.checkRuntimeEntitlement,
           },
+          observability,
           runtimeFactory: options.runtimeFactory || defaultCloudRuntimeFactory,
         })
       : createUnavailableRuntimeAdapter()
@@ -935,10 +962,11 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
           },
         },
         abuseConfig,
+        observability,
       )
     : null
   const scheduler = shouldRunCloudScheduler(policy.role)
-    ? new CloudScheduler(store, service, envValue(env, 'OPEN_COWORK_CLOUD_SCHEDULER_ID') || `${policy.role}-scheduler`)
+    ? new CloudScheduler(store, service, envValue(env, 'OPEN_COWORK_CLOUD_SCHEDULER_ID') || `${policy.role}-scheduler`, observability)
     : null
 
   const runtimeUnsubscribe = worker && runtime.subscribeEvents

--- a/apps/desktop/src/main/cloud/http-routes/workspace.ts
+++ b/apps/desktop/src/main/cloud/http-routes/workspace.ts
@@ -21,6 +21,16 @@ export async function handleWorkspaceApiRoute(input: CloudApiRouteInput): Promis
     return true
   }
 
+  if (resource === 'metrics' && !itemId && req.method === 'GET') {
+    await options.service.listWorkerHeartbeats(context.principal)
+    res.writeHead(200, {
+      'content-type': 'text/plain; version=0.0.4; charset=utf-8',
+      'cache-control': 'no-store',
+    })
+    res.end(options.observability?.renderPrometheus?.() || '')
+    return true
+  }
+
   if (resource === 'events' && !itemId && req.method === 'GET') {
     await tools.handleWorkspaceSse(req, res, options, context)
     return true

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -1678,6 +1678,31 @@ export class CloudHttpServer {
     }
   }
 
+  private async recordPolicyErrorMetric(error: CloudHttpError | CloudServiceError, req: IncomingMessage, url: URL) {
+    const policyCode = error.policyCode || ''
+    const isQuotaRejection = error.status === 429 || policyCode.startsWith('quota.') || policyCode.startsWith('rate_limit.')
+    const isAuthFailure = error.status === 401 || policyCode.startsWith('auth.')
+    const name = isQuotaRejection
+      ? 'open_cowork_cloud_quota_rejections_total'
+      : isAuthFailure
+        ? 'open_cowork_cloud_auth_failures_total'
+        : null
+    if (!name) return
+    await this.options.observability?.metric({
+      name,
+      value: 1,
+      unit: '1',
+      attributes: {
+        'http.request.method': req.method || 'GET',
+        'url.path': url.pathname,
+        'http.response.status_code': error.status,
+        'cloud.role': this.options.policy.role,
+        'cloud.profile': this.options.policy.profileName,
+        policy_code: policyCode || undefined,
+      },
+    })
+  }
+
   private async handle(req: IncomingMessage, res: ServerResponse) {
     const startedAt = Date.now()
     const requestId = firstHeader(req.headers['x-request-id']).trim() || randomUUID()
@@ -1770,6 +1795,7 @@ export class CloudHttpServer {
       })
     } catch (error) {
       if (error instanceof CloudHttpError) {
+        await this.recordPolicyErrorMetric(error, req, url)
         writeError(res, error.status, error.publicMessage, this.options.corsOrigin, {
           policyCode: error.policyCode,
           retryAfterMs: error.retryAfterMs,
@@ -1777,6 +1803,7 @@ export class CloudHttpServer {
         return
       }
       if (error instanceof CloudServiceError) {
+        await this.recordPolicyErrorMetric(error, req, url)
         writeError(res, error.status, error.publicMessage, this.options.corsOrigin, {
           policyCode: error.policyCode,
           retryAfterMs: error.retryAfterMs,

--- a/apps/desktop/src/main/cloud/observability.ts
+++ b/apps/desktop/src/main/cloud/observability.ts
@@ -37,6 +37,7 @@ export type CloudObservabilityAdapter = {
   log(record: CloudLogRecord): void | Promise<void>
   metric(record: CloudMetricRecord): void | Promise<void>
   span(record: CloudSpanRecord): void | Promise<void>
+  renderPrometheus?(): string
   flush?(): void | Promise<void>
   close?(): void | Promise<void>
 }
@@ -68,6 +69,13 @@ export type CloudHttpRequestObservation = {
   timestamp?: Date
 }
 
+type CloudPrometheusMetricPoint = {
+  kind: 'counter' | 'gauge'
+  help: string
+  value: number
+  labels: Record<string, string>
+}
+
 const DEFAULT_SERVICE_NAME = 'open-cowork-cloud'
 const SENSITIVE_FIELD = /(authorization|cookie|token|secret|password|credential|key)$/i
 const MAX_STRING_LENGTH = 512
@@ -77,6 +85,18 @@ const LOCAL_PATH_PATTERNS = [
   /\/home\/[^\s"'`:]+/g,
   /[A-Z]:\\Users\\[^\s"'`:]+/gi,
 ]
+const PROMETHEUS_HIGH_CARDINALITY_KEYS = new Set([
+  'duration_ms',
+  'error_message',
+  'request_id',
+  'session_id',
+  'user_id',
+  'account_id',
+  'run_id',
+  'command_id',
+  'delivery_id',
+  'gateway_binding_id',
+])
 
 function serviceAttributes(serviceName: string, serviceVersion: string | null | undefined) {
   return {
@@ -101,6 +121,14 @@ function redactAttribute(key: string, value: CloudObservabilityAttributeValue) {
 
 function redactCloudAttributeString(value: string) {
   let redacted = value.replace(SIGNED_URL_QUERY_PATTERN, '$1?[redacted]')
+  redacted = redacted
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(/\b(?:token|secret|password|credential|api[_-]?key)=([^\s"'&]+)/gi, (match) => {
+      const [key] = match.split('=')
+      return `${key}=[redacted]`
+    })
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}/g, 'sk-[redacted]')
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[redacted-email]')
   for (const pattern of LOCAL_PATH_PATTERNS) {
     redacted = redacted.replace(pattern, (match) => {
       const prefix = match.match(/^(\/Users|\/home|[A-Z]:\\Users)/i)?.[0] || '[home]'
@@ -119,6 +147,43 @@ export function sanitizeCloudObservabilityAttributes(attributes: CloudObservabil
     if (cleanValue !== undefined) sanitized[cleanKey] = cleanValue
   }
   return sanitized
+}
+
+function prometheusMetricName(name: string) {
+  const normalized = name.trim().replace(/[^a-zA-Z0-9_:]/g, '_').replace(/_+/g, '_')
+  return /^[a-zA-Z_:][a-zA-Z0-9_:]*$/.test(normalized) ? normalized : `open_cowork_cloud_${normalized}`
+}
+
+function prometheusLabelName(name: string) {
+  const normalized = name.trim().replace(/[^a-zA-Z0-9_]/g, '_').replace(/_+/g, '_')
+  return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(normalized) ? normalized : `label_${normalized}`
+}
+
+function prometheusEscape(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"')
+}
+
+function metricLabels(attributes: CloudObservabilityAttributes = {}) {
+  const labels: Record<string, string> = {}
+  const sanitized = sanitizeCloudObservabilityAttributes(attributes)
+  for (const [key, value] of Object.entries(sanitized)) {
+    const label = prometheusLabelName(key)
+    if (PROMETHEUS_HIGH_CARDINALITY_KEYS.has(label)) continue
+    if (value === null) continue
+    labels[label] = String(value).slice(0, 128)
+  }
+  return labels
+}
+
+function metricKey(name: string, labels: Record<string, string>) {
+  return `${name}\n${Object.entries(labels).sort(([left], [right]) => left.localeCompare(right)).map(([key, value]) => `${key}=${value}`).join('\n')}`
+}
+
+function renderPrometheusPoint(name: string, point: CloudPrometheusMetricPoint) {
+  const labelText = Object.entries(point.labels).sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}="${prometheusEscape(value)}"`)
+    .join(',')
+  return `${name}${labelText ? `{${labelText}}` : ''} ${point.value}`
 }
 
 function otlpAttributes(attributes: CloudObservabilityAttributes = {}) {
@@ -170,6 +235,9 @@ export function createCompositeCloudObservability(adapters: Array<CloudObservabi
     async span(record) {
       await Promise.all(active.map((adapter) => adapter.span(record)))
     },
+    renderPrometheus() {
+      return active.map((adapter) => adapter.renderPrometheus?.()).filter(Boolean).join('\n')
+    },
     async flush() {
       await Promise.all(active.map((adapter) => adapter.flush?.()))
     },
@@ -193,15 +261,16 @@ export function createConsoleCloudObservability(options: ConsoleCloudObservabili
       ...serviceAttributes(serviceName, serviceVersion),
       ...(record.attributes || {}),
     })
+    const message = redactCloudAttributeString(record.message || record.name).slice(0, MAX_STRING_LENGTH)
     if (format === 'pretty') {
-      sink(`[${timestamp}] [cloud:${record.level}] ${record.name}${record.message ? ` ${record.message}` : ''}`)
+      sink(`[${timestamp}] [cloud:${record.level}] ${record.name}${message ? ` ${message}` : ''}`)
       return
     }
     sink(JSON.stringify({
       ts: timestamp,
       level: record.level,
       name: record.name,
-      message: record.message || record.name,
+      message,
       attributes,
     }))
   }
@@ -237,6 +306,50 @@ export function createConsoleCloudObservability(options: ConsoleCloudObservabili
         },
         timestamp: record.endTime,
       })
+    },
+  }
+}
+
+export function createPrometheusCloudObservability(): CloudObservabilityAdapter {
+  const points = new Map<string, CloudPrometheusMetricPoint>()
+
+  return {
+    log() {},
+    metric(record) {
+      if (!Number.isFinite(record.value)) return
+      const name = prometheusMetricName(record.name)
+      const labels = metricLabels(record.attributes)
+      const key = metricKey(name, labels)
+      const kind = name.endsWith('_total') ? 'counter' : 'gauge'
+      const existing = points.get(key)
+      points.set(key, {
+        kind,
+        help: `${name} emitted by Open Cowork Cloud.`,
+        value: kind === 'counter' ? (existing?.value || 0) + record.value : record.value,
+        labels,
+      })
+    },
+    span() {},
+    renderPrometheus() {
+      const byName = new Map<string, CloudPrometheusMetricPoint[]>()
+      for (const [key, point] of points.entries()) {
+        const [name] = key.split('\n')
+        if (!name) continue
+        const metricPoints = byName.get(name) || []
+        metricPoints.push(point)
+        byName.set(name, metricPoints)
+      }
+      const lines: string[] = []
+      for (const [name, metricPoints] of [...byName.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+        const kind = metricPoints.some((point) => point.kind === 'counter') ? 'counter' : 'gauge'
+        lines.push(`# HELP ${name} ${metricPoints[0]?.help || `${name} emitted by Open Cowork Cloud.`}`)
+        lines.push(`# TYPE ${name} ${kind}`)
+        for (const point of metricPoints.sort((left, right) => JSON.stringify(left.labels).localeCompare(JSON.stringify(right.labels)))) {
+          lines.push(renderPrometheusPoint(name, point))
+        }
+      }
+      lines.push('')
+      return lines.join('\n')
     },
   }
 }
@@ -281,7 +394,7 @@ export function createOtlpHttpCloudObservability(options: OtlpHttpCloudObservabi
             attributes: otlpAttributes(span.attributes),
             status: {
               code: span.status === 'error' ? 2 : 1,
-              ...(span.statusMessage ? { message: span.statusMessage } : {}),
+              ...(span.statusMessage ? { message: redactCloudAttributeString(span.statusMessage).slice(0, MAX_STRING_LENGTH) } : {}),
             },
           })),
         }],
@@ -368,6 +481,32 @@ export async function recordCloudHttpRequest(
     attributes,
     timestamp,
   })
+  await observability.metric({
+    name: 'open_cowork_cloud_http_requests_total',
+    value: 1,
+    unit: '1',
+    attributes: {
+      'http.request.method': input.method,
+      'url.path': input.path,
+      'http.response.status_code': input.statusCode,
+      'cloud.role': input.role,
+      'cloud.profile': input.profileName,
+    },
+    timestamp,
+  })
+  await observability.metric({
+    name: 'open_cowork_cloud_http_request_duration_ms',
+    value: input.durationMs,
+    unit: 'ms',
+    attributes: {
+      'http.request.method': input.method,
+      'url.path': input.path,
+      'http.response.status_code': input.statusCode,
+      'cloud.role': input.role,
+      'cloud.profile': input.profileName,
+    },
+    timestamp,
+  })
   await observability.span({
     name: 'cloud.http.request',
     startTime: new Date(timestamp.getTime() - input.durationMs),
@@ -377,6 +516,60 @@ export async function recordCloudHttpRequest(
       duration_ms: input.durationMs,
     },
     status,
+  })
+}
+
+export async function recordCloudWorkerMetric(
+  observability: CloudObservabilityAdapter | null | undefined,
+  input: {
+    name: string
+    value?: number
+    workerId: string
+    tenantId?: string | null
+    sessionId?: string | null
+    status?: string | null
+    durationMs?: number | null
+    timestamp?: Date
+  },
+) {
+  if (!observability) return
+  const timestamp = input.timestamp || new Date()
+  await observability.metric({
+    name: input.name,
+    value: input.value ?? 1,
+    unit: input.name.endsWith('_ms') ? 'ms' : '1',
+    attributes: {
+      worker_id: input.workerId,
+      tenant_id: input.tenantId || undefined,
+      session_id: input.sessionId || undefined,
+      status: input.status || undefined,
+    },
+    timestamp,
+  })
+}
+
+export async function recordCloudSchedulerMetric(
+  observability: CloudObservabilityAdapter | null | undefined,
+  input: {
+    name: string
+    value?: number
+    schedulerId: string
+    status?: string | null
+    durationMs?: number | null
+    timestamp?: Date
+  },
+) {
+  if (!observability) return
+  const timestamp = input.timestamp || new Date()
+  await observability.metric({
+    name: input.name,
+    value: input.value ?? 1,
+    unit: input.name.endsWith('_ms') ? 'ms' : '1',
+    attributes: {
+      scheduler_id: input.schedulerId,
+      status: input.status || undefined,
+    },
+    timestamp,
   })
 }
 
@@ -410,6 +603,7 @@ export function createCloudObservabilityFromEnv(env: Env = process.env) {
       serviceVersion,
       format,
     }))
+    adapters.push(createPrometheusCloudObservability())
   } else {
     throw new Error(`Invalid cloud log format "${format}".`)
   }

--- a/apps/desktop/src/main/cloud/scheduler.ts
+++ b/apps/desktop/src/main/cloud/scheduler.ts
@@ -1,22 +1,28 @@
 import type { ControlPlaneStore } from './control-plane-store.ts'
+import type { CloudObservabilityAdapter } from './observability.ts'
+import { recordCloudSchedulerMetric } from './observability.ts'
 import type { CloudSessionService } from './session-service.ts'
 
 export class CloudScheduler {
   private readonly store: ControlPlaneStore
   private readonly service: CloudSessionService
   private readonly schedulerId: string
+  private readonly observability: CloudObservabilityAdapter | null
 
   constructor(
     store: ControlPlaneStore,
     service: CloudSessionService,
     schedulerId: string,
+    observability: CloudObservabilityAdapter | null = null,
   ) {
     this.store = store
     this.service = service
     this.schedulerId = schedulerId
+    this.observability = observability
   }
 
   async processDueWorkflows(now = new Date()): Promise<number> {
+    const startedAt = Date.now()
     let claimed = 0
     const activeSessionIds: string[] = []
     await this.store.recordWorkerHeartbeat({
@@ -37,6 +43,18 @@ export class CloudScheduler {
         now,
       })
     }
+    await recordCloudSchedulerMetric(this.observability, {
+      name: 'open_cowork_cloud_scheduler_claims_total',
+      value: claimed,
+      schedulerId: this.schedulerId,
+      status: 'ok',
+    })
+    await recordCloudSchedulerMetric(this.observability, {
+      name: 'open_cowork_cloud_scheduler_loop_duration_ms',
+      value: Date.now() - startedAt,
+      schedulerId: this.schedulerId,
+      status: 'ok',
+    })
     return claimed
   }
 }

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -226,6 +226,14 @@ export type CloudDiagnosticsBundle = {
     commandProcessing: 'inline' | 'durable' | 'delegated'
     checkpoints: boolean
     heartbeatCount: number
+    heartbeats: Array<{
+      workerId: string
+      role: string
+      activeSessionCount: number
+      lastSeenAt: string
+      ageMs: number
+      stale: boolean
+    }>
   }
   billing: {
     enabled: boolean
@@ -548,13 +556,11 @@ function principalCanUseGatewayRoutes(principal: CloudPrincipal) {
 }
 
 function principalCanViewOperations(principal: CloudPrincipal) {
-  if (principal.authSource === 'local') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin') || hasTokenScope(principal, 'worker-internal')
   return principal.role === 'owner' || principal.role === 'admin'
 }
 
 function principalCanViewDiagnostics(principal: CloudPrincipal) {
-  if (principal.authSource === 'local') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
   return principal.role === 'owner' || principal.role === 'admin'
 }
@@ -2563,6 +2569,18 @@ export class CloudSessionService {
     for (const binding of bindings) {
       bindingsByProvider[binding.provider] = (bindingsByProvider[binding.provider] || 0) + 1
     }
+    const now = Date.now()
+    const runtimeHeartbeats = heartbeats.map((heartbeat) => {
+      const ageMs = Math.max(0, now - Date.parse(heartbeat.lastSeenAt))
+      return {
+        workerId: heartbeat.workerId,
+        role: heartbeat.role,
+        activeSessionCount: heartbeat.activeSessionIds.length,
+        lastSeenAt: heartbeat.lastSeenAt,
+        ageMs,
+        stale: ageMs > 60_000,
+      }
+    })
     return {
       generatedAt: new Date().toISOString(),
       redaction: 'secrets-redacted',
@@ -2579,6 +2597,7 @@ export class CloudSessionService {
         commandProcessing: this.policy.role === 'all-in-one' ? 'inline' : this.policy.role === 'worker' ? 'durable' : 'delegated',
         checkpoints: this.policy.role === 'all-in-one' || this.policy.role === 'worker',
         heartbeatCount: heartbeats.length,
+        heartbeats: runtimeHeartbeats,
       },
       billing,
       byok: {

--- a/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
@@ -1,7 +1,12 @@
 import type { OpenCoworkConfig } from '../config-types.ts'
 import type { ByokSecretStore } from './byok-secret-store.ts'
-import { buildCloudByokRuntimeConfig, type CloudByokRuntimeProviderPolicy } from './byok-runtime-config.ts'
+import {
+  buildCloudByokRuntimeConfig,
+  CloudByokRuntimeConfigError,
+  type CloudByokRuntimeProviderPolicy,
+} from './byok-runtime-config.ts'
 import type { CloudRuntimePolicy } from './cloud-config.ts'
+import type { CloudObservabilityAdapter } from './observability.ts'
 import type { PathProvider } from './path-provider.ts'
 import { createCloudSessionPathProvider } from './path-provider.ts'
 import type {
@@ -33,6 +38,7 @@ export type WorkerScopedRuntimeAdapterOptions = {
   config: OpenCoworkConfig
   byokSecrets: ByokSecretStore
   byokPolicy?: CloudByokRuntimeProviderPolicy | null
+  observability?: CloudObservabilityAdapter | null
   runtimeFactory: WorkerScopedRuntimeFactory
 }
 
@@ -93,13 +99,31 @@ export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAda
     if (existing) return existing.adapter
 
     const scopedPaths = createCloudSessionPathProvider(options.paths, context.tenantId, context.sessionId)
-    const runtimeConfig = await buildCloudByokRuntimeConfig({
-      appConfig: options.config,
-      byokSecrets: options.byokSecrets,
-      context,
-      allowKmsRef: true,
-      byokPolicy: options.byokPolicy,
-    })
+    let runtimeConfig: WorkerScopedRuntimeFactoryInput['runtimeConfig']
+    try {
+      runtimeConfig = await buildCloudByokRuntimeConfig({
+        appConfig: options.config,
+        byokSecrets: options.byokSecrets,
+        context,
+        allowKmsRef: true,
+        byokPolicy: options.byokPolicy,
+      })
+    } catch (error) {
+      if (error instanceof CloudByokRuntimeConfigError) {
+        await options.observability?.metric({
+          name: 'open_cowork_cloud_byok_reveal_failures_total',
+          value: 1,
+          unit: '1',
+          attributes: {
+            provider_id: error.providerId,
+            reason: error.code,
+            tenant_id: context.tenantId,
+            session_id: context.sessionId,
+          },
+        })
+      }
+      throw error
+    }
     const adapter = await options.runtimeFactory({
       paths: scopedPaths,
       policy: options.policy,

--- a/apps/desktop/src/main/cloud/worker.ts
+++ b/apps/desktop/src/main/cloud/worker.ts
@@ -1,4 +1,6 @@
 import type { ControlPlaneStore, WorkerLeaseRecord } from './control-plane-store.ts'
+import type { CloudObservabilityAdapter } from './observability.ts'
+import { recordCloudWorkerMetric } from './observability.ts'
 import type { CloudRuntimeEvent } from './runtime-adapter.ts'
 import type { CloudSessionService } from './session-service.ts'
 import type { CloudAbuseConfig } from '../config-types.ts'
@@ -17,6 +19,7 @@ export class CloudWorker {
   private readonly leaseTtlMs: number
   private readonly checkpointHooks: CloudWorkerCheckpointHooks
   private readonly abuse: CloudAbuseConfig | null
+  private readonly observability: CloudObservabilityAdapter | null
 
   constructor(
     store: ControlPlaneStore,
@@ -25,6 +28,7 @@ export class CloudWorker {
     leaseTtlMs = 30_000,
     checkpointHooks: CloudWorkerCheckpointHooks = {},
     abuse: CloudAbuseConfig | null = null,
+    observability: CloudObservabilityAdapter | null = null,
   ) {
     this.store = store
     this.service = service
@@ -32,6 +36,7 @@ export class CloudWorker {
     this.leaseTtlMs = leaseTtlMs
     this.checkpointHooks = checkpointHooks
     this.abuse = abuse
+    this.observability = observability
   }
 
   async processSessionCommands(tenantId: string, sessionId: string): Promise<number> {
@@ -50,6 +55,22 @@ export class CloudWorker {
       const startedAt = Date.now()
       try {
         await this.service.executeCommand(lease, command)
+        await recordCloudWorkerMetric(this.observability, {
+          name: 'open_cowork_cloud_worker_commands_processed_total',
+          workerId: this.workerId,
+          tenantId,
+          sessionId,
+          status: 'ok',
+          durationMs: Date.now() - startedAt,
+        })
+        await recordCloudWorkerMetric(this.observability, {
+          name: 'open_cowork_cloud_worker_command_duration_ms',
+          value: Date.now() - startedAt,
+          workerId: this.workerId,
+          tenantId,
+          sessionId,
+          status: 'ok',
+        })
       } finally {
         await this.service.recordWorkerMinutes({
           tenantId,
@@ -67,10 +88,23 @@ export class CloudWorker {
   }
 
   async processAllSessionCommands(): Promise<number> {
+    const startedAt = Date.now()
     let processed = 0
-    for (const session of await this.store.listAllSessions()) {
+    const sessions = await this.store.listAllSessions()
+    for (const session of sessions) {
       processed += await this.processSessionCommands(session.tenantId, session.sessionId)
     }
+    await recordCloudWorkerMetric(this.observability, {
+      name: 'open_cowork_cloud_command_queue_depth',
+      value: sessions.length,
+      workerId: this.workerId,
+    })
+    await recordCloudWorkerMetric(this.observability, {
+      name: 'open_cowork_cloud_worker_loop_duration_ms',
+      value: Date.now() - startedAt,
+      workerId: this.workerId,
+      status: 'ok',
+    })
     return processed
   }
 
@@ -101,6 +135,13 @@ export class CloudWorker {
       await this.service.assertWorkerExecutionAllowed(tenantId)
     } catch (error) {
       if (error && typeof error === 'object' && 'status' in error && (error as { status?: unknown }).status === 402) {
+        await recordCloudWorkerMetric(this.observability, {
+          name: 'open_cowork_cloud_worker_lease_denials_total',
+          workerId: this.workerId,
+          tenantId,
+          sessionId,
+          status: 'entitlement_denied',
+        })
         return null
       }
       throw error
@@ -110,9 +151,23 @@ export class CloudWorker {
       try {
         const renewed = await this.store.renewSessionLease(existing, new Date(), this.leaseTtlMs)
         this.leases.set(leaseKey, renewed)
+        await recordCloudWorkerMetric(this.observability, {
+          name: 'open_cowork_cloud_worker_lease_renewals_total',
+          workerId: this.workerId,
+          tenantId,
+          sessionId,
+          status: 'ok',
+        })
         return renewed
       } catch {
         this.leases.delete(leaseKey)
+        await recordCloudWorkerMetric(this.observability, {
+          name: 'open_cowork_cloud_worker_stale_owner_rejections_total',
+          workerId: this.workerId,
+          tenantId,
+          sessionId,
+          status: 'stale',
+        })
       }
     }
     const maxActiveWorkersPerOrg = await this.service.activeWorkerQuotaForTenant(tenantId)
@@ -130,7 +185,24 @@ export class CloudWorker {
           }
         : null,
     )
-    if (claimed) this.leases.set(leaseKey, claimed)
+    if (claimed) {
+      this.leases.set(leaseKey, claimed)
+      await recordCloudWorkerMetric(this.observability, {
+        name: 'open_cowork_cloud_worker_lease_claims_total',
+        workerId: this.workerId,
+        tenantId,
+        sessionId,
+        status: 'claimed',
+      })
+    } else {
+      await recordCloudWorkerMetric(this.observability, {
+        name: 'open_cowork_cloud_worker_lease_claims_total',
+        workerId: this.workerId,
+        tenantId,
+        sessionId,
+        status: 'denied',
+      })
+    }
     return claimed
   }
 

--- a/apps/gateway/src/config.test.ts
+++ b/apps/gateway/src/config.test.ts
@@ -84,7 +84,7 @@ test('gateway config loads explicit provider credentials and redacts secrets', (
   assert.equal(providers[0]?.credentials.apiKey, 'tele...[redacted]...7890')
   assert.equal(providers[0]?.settings.callbackSecret, 'prov...[redacted]...7890')
   assert.equal(providers[0]?.settings.privateKey, 'prov...[redacted]...7890')
-  assert.equal(providers[0]?.settings.deliveryUrl, 'https://webhook.example.test/out?token=%5Bredacted%5D')
+  assert.equal(providers[0]?.settings.deliveryUrl, 'https://webhook.example.test/out?token=[redacted]')
   assert.equal(providers[0]?.settings.workspacePath, '/Users/[redacted]')
 })
 

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -670,9 +670,24 @@ function redactUnknown(value: unknown): unknown {
 function redactValue(key: string, value: unknown): unknown {
   if (typeof value === 'string') {
     if (/token|secret|password|credential|authorization|api[_-]?key|private[_-]?key|access[_-]?key/i.test(key)) return redactSecret(value)
-    return redactLocalPaths(redactUrlSecrets(value))
+    return redactGatewayDiagnosticText(value)
   }
   return redactUnknown(value)
+}
+
+export function redactGatewayDiagnosticText(value: string) {
+  return redactLocalPaths(redactUrlSecretsInText(value)
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(/\b(?:token|secret|password|credential|api[_-]?key)=([^\s"'&]+)/gi, (match) => {
+      const [key] = match.split('=')
+      return `${key}=[redacted]`
+    })
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}/g, 'sk-[redacted]')
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[redacted-email]'))
+}
+
+function redactUrlSecretsInText(value: string) {
+  return value.replace(/\bhttps?:\/\/[^\s"'<>]+/gi, (url) => redactUrlSecrets(url))
 }
 
 function redactUrlSecrets(value: string) {

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -118,7 +118,10 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
 
     const metrics = await fetch(`${url}/metrics`)
     assert.equal(metrics.status, 200)
-    assert.match(await metrics.text(), /open_cowork_gateway_providers 1/)
+    const metricsText = await metrics.text()
+    assert.match(metricsText, /open_cowork_gateway_providers 1/)
+    assert.match(metricsText, /open_cowork_gateway_session_streams 0/)
+    assert.match(metricsText, /open_cowork_gateway_webhook_requests_total 0/)
 
     const diagnostics = await readJson(await fetch(`${url}/diagnostics`))
     assert.equal((diagnostics.config as { cloud: { serviceToken: string } }).cloud.serviceToken, 'serv...[redacted]...7890')
@@ -128,7 +131,7 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     }> }).providers)[0]
     assert.equal(diagnosticProvider?.credentials.apiKey, 'prov...[redacted]...7890')
     assert.equal(diagnosticProvider?.settings.callbackSecret, 'prov...[redacted]...7890')
-    assert.equal(diagnosticProvider?.settings.deliveryUrl, 'https://example.test/deliver?token=%5Bredacted%5D')
+    assert.equal(diagnosticProvider?.settings.deliveryUrl, 'https://example.test/deliver?token=[redacted]')
     assert.equal(diagnosticProvider?.settings.workspacePath, '/home/[redacted]')
 
     const webhook = await fetch(`${url}/webhooks/fake`, {
@@ -138,6 +141,46 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     })
     assert.equal(webhook.status, 202)
     assert.deepEqual(prompted, ['ship it'])
+    assert.equal(runtime.metrics.webhookRequests, 1)
+  } finally {
+    await http.close()
+    await runtime.stop()
+  }
+})
+
+test('gateway diagnostics redact provider health errors', async () => {
+  const cloud = {
+    subscribeDeliveries() { return { close() {} } },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token-1234567890',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_GATEWAY_PORT: '0',
+  })
+  const runtime = createGatewayRuntime(config, cloud, undefined, { subscribeDeliveries: false })
+  await runtime.start()
+  runtime.providers.registrations[0].provider.health = () => ({
+    ok: false,
+    error: 'failed Bearer provider-token-1234567890 for alice@example.test at /Users/alice/acme?token=secret',
+  })
+  const http = createGatewayHttpServer(config, runtime)
+  const url = await http.listen()
+
+  try {
+    const diagnostics = await readJson(await fetch(`${url}/diagnostics`))
+    const text = JSON.stringify(diagnostics)
+    assert.equal(text.includes('provider-token-1234567890'), false)
+    assert.equal(text.includes('alice@example.test'), false)
+    assert.equal(text.includes('/Users/alice'), false)
+    assert.match(text, /Bearer \[redacted\]/)
   } finally {
     await http.close()
     await runtime.stop()

--- a/apps/gateway/src/daemon.ts
+++ b/apps/gateway/src/daemon.ts
@@ -2,7 +2,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { timingSafeEqual } from 'node:crypto'
 
 import { createCloudGateway, type CloudGateway } from './cloud-gateway.js'
-import { type GatewayConfig, redactGatewayConfig } from './config.js'
+import { type GatewayConfig, redactGatewayConfig, redactGatewayDiagnosticText } from './config.js'
 import { createGatewayRuntime, type GatewayRuntime } from './gateway-runtime.js'
 import { renderPrometheusMetrics } from './metrics.js'
 
@@ -119,7 +119,7 @@ async function handleRequest(
       writeJson(res, 401, { ok: false, error: 'Gateway admin authorization is required.' })
       return
     }
-    const body = renderPrometheusMetrics(runtime.metrics, runtime.providers.registrations.length)
+    const body = renderPrometheusMetrics(runtime.metrics, runtime.providers.registrations.length, runtime.streams.activeCount())
     res.writeHead(200, { 'content-type': 'text/plain; version=0.0.4; charset=utf-8' })
     res.end(body)
     return
@@ -195,6 +195,7 @@ async function handleRequest(
 
   const webhookMatch = /^\/webhooks\/([^/]+)$/.exec(url.pathname)
   if (req.method === 'POST' && webhookMatch) {
+    runtime.metrics.webhookRequests += 1
     const body = await readRequestBody(req)
     const payload = parseRequestBody(body.raw, req.headers['content-type'])
     const result = await runtime.providers.handleWebhook(decodeURIComponent(webhookMatch[1]), payload, req.headers, body.raw)
@@ -212,7 +213,7 @@ function providerStatus(runtime: GatewayRuntime) {
     provider: registration.provider.id,
     started: registration.started,
     healthy: registration.healthy,
-    error: registration.lastError,
+    error: registration.lastError ? redactGatewayDiagnosticText(registration.lastError) : null,
   }))
 }
 

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -56,6 +56,7 @@ export function createGatewayRuntime(
             void handleDelivery(delivery, providers, cloud, metrics)
           },
           onError: () => {
+            metrics.cloudSubscriptionErrors += 1
             metrics.errors += 1
           },
         }))
@@ -145,10 +146,12 @@ async function handleDelivery(
   cloud: CloudGateway,
   metrics: GatewayMetrics,
 ) {
+  const startedAt = Date.now()
   metrics.deliveriesReceived += 1
   const registration = findDeliveryProvider(providers, delivery)
   if (!registration) {
     metrics.errors += 1
+    metrics.deliveryDeadLetters += 1
     await cloud.ackDelivery(delivery.deliveryId, {
       status: 'dead',
       claimedBy: delivery.claimedBy,
@@ -164,10 +167,14 @@ async function handleDelivery(
       claimedBy: delivery.claimedBy,
       lastError: null,
     })
+    metrics.deliveriesSent += 1
+    metrics.deliveryLatencyMsTotal += Math.max(0, Date.now() - startedAt)
   } catch (error) {
     metrics.errors += 1
     const failure = classifyProviderFailure(error)
     const shouldRetry = failure.transient && delivery.attemptCount < MAX_DELIVERY_ATTEMPTS
+    if (shouldRetry) metrics.deliveryRetries += 1
+    else metrics.deliveryDeadLetters += 1
     await cloud.ackDelivery(delivery.deliveryId, {
       status: shouldRetry ? 'failed' : 'dead',
       claimedBy: delivery.claimedBy,

--- a/apps/gateway/src/metrics.test.ts
+++ b/apps/gateway/src/metrics.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createGatewayMetrics, renderPrometheusMetrics } from '../dist/index.js'
+
+test('gateway Prometheus metrics include delivery, stream, and webhook operational counters', () => {
+  const metrics = createGatewayMetrics(() => new Date('2026-01-01T00:00:00.000Z').getTime())
+  metrics.incomingMessages = 2
+  metrics.promptedMessages = 1
+  metrics.deliveriesReceived = 3
+  metrics.deliveriesSent = 2
+  metrics.deliveryRetries = 1
+  metrics.deliveryDeadLetters = 1
+  metrics.deliveryLatencyMsTotal = 123
+  metrics.webhookRequests = 4
+  metrics.streamReconnects = 5
+  metrics.cloudSubscriptionErrors = 1
+  metrics.droppedSessionEvents = 1
+
+  const text = renderPrometheusMetrics(metrics, 2, 7, () => new Date('2026-01-01T00:01:00.000Z').getTime())
+
+  assert.match(text, /open_cowork_gateway_uptime_seconds 60/)
+  assert.match(text, /open_cowork_gateway_providers 2/)
+  assert.match(text, /open_cowork_gateway_session_streams 7/)
+  assert.match(text, /open_cowork_gateway_deliveries_sent_total 2/)
+  assert.match(text, /open_cowork_gateway_delivery_retries_total 1/)
+  assert.match(text, /open_cowork_gateway_delivery_dead_letters_total 1/)
+  assert.match(text, /open_cowork_gateway_delivery_latency_ms_total 123/)
+  assert.match(text, /open_cowork_gateway_webhook_requests_total 4/)
+  assert.match(text, /open_cowork_gateway_stream_reconnects_total 5/)
+  assert.match(text, /open_cowork_gateway_cloud_subscription_errors_total 1/)
+})

--- a/apps/gateway/src/metrics.ts
+++ b/apps/gateway/src/metrics.ts
@@ -4,6 +4,13 @@ export type GatewayMetrics = {
   promptedMessages: number
   interactionsResolved: number
   deliveriesReceived: number
+  deliveriesSent: number
+  deliveryRetries: number
+  deliveryDeadLetters: number
+  deliveryLatencyMsTotal: number
+  webhookRequests: number
+  streamReconnects: number
+  cloudSubscriptionErrors: number
   droppedSessionEvents: number
   errors: number
 }
@@ -15,12 +22,19 @@ export function createGatewayMetrics(now = Date.now): GatewayMetrics {
     promptedMessages: 0,
     interactionsResolved: 0,
     deliveriesReceived: 0,
+    deliveriesSent: 0,
+    deliveryRetries: 0,
+    deliveryDeadLetters: 0,
+    deliveryLatencyMsTotal: 0,
+    webhookRequests: 0,
+    streamReconnects: 0,
+    cloudSubscriptionErrors: 0,
     droppedSessionEvents: 0,
     errors: 0,
   }
 }
 
-export function renderPrometheusMetrics(metrics: GatewayMetrics, providerCount: number, now = Date.now) {
+export function renderPrometheusMetrics(metrics: GatewayMetrics, providerCount: number, activeSessionStreams = 0, now = Date.now) {
   const uptimeSeconds = Math.max(0, Math.floor((now() - metrics.startedAt) / 1000))
   return [
     '# HELP open_cowork_gateway_uptime_seconds Seconds since gateway start.',
@@ -41,6 +55,30 @@ export function renderPrometheusMetrics(metrics: GatewayMetrics, providerCount: 
     '# HELP open_cowork_gateway_deliveries_received_total Channel deliveries received from cloud.',
     '# TYPE open_cowork_gateway_deliveries_received_total counter',
     `open_cowork_gateway_deliveries_received_total ${metrics.deliveriesReceived}`,
+    '# HELP open_cowork_gateway_deliveries_sent_total Channel deliveries successfully sent.',
+    '# TYPE open_cowork_gateway_deliveries_sent_total counter',
+    `open_cowork_gateway_deliveries_sent_total ${metrics.deliveriesSent}`,
+    '# HELP open_cowork_gateway_delivery_retries_total Channel deliveries marked for retry.',
+    '# TYPE open_cowork_gateway_delivery_retries_total counter',
+    `open_cowork_gateway_delivery_retries_total ${metrics.deliveryRetries}`,
+    '# HELP open_cowork_gateway_delivery_dead_letters_total Channel deliveries dead-lettered by the gateway.',
+    '# TYPE open_cowork_gateway_delivery_dead_letters_total counter',
+    `open_cowork_gateway_delivery_dead_letters_total ${metrics.deliveryDeadLetters}`,
+    '# HELP open_cowork_gateway_delivery_latency_ms_total Total delivery handling latency in milliseconds.',
+    '# TYPE open_cowork_gateway_delivery_latency_ms_total counter',
+    `open_cowork_gateway_delivery_latency_ms_total ${metrics.deliveryLatencyMsTotal}`,
+    '# HELP open_cowork_gateway_webhook_requests_total Provider webhook requests received.',
+    '# TYPE open_cowork_gateway_webhook_requests_total counter',
+    `open_cowork_gateway_webhook_requests_total ${metrics.webhookRequests}`,
+    '# HELP open_cowork_gateway_session_streams Active session SSE streams.',
+    '# TYPE open_cowork_gateway_session_streams gauge',
+    `open_cowork_gateway_session_streams ${activeSessionStreams}`,
+    '# HELP open_cowork_gateway_stream_reconnects_total Session stream reconnects after SSE/render failures.',
+    '# TYPE open_cowork_gateway_stream_reconnects_total counter',
+    `open_cowork_gateway_stream_reconnects_total ${metrics.streamReconnects}`,
+    '# HELP open_cowork_gateway_cloud_subscription_errors_total Cloud delivery subscription errors.',
+    '# TYPE open_cowork_gateway_cloud_subscription_errors_total counter',
+    `open_cowork_gateway_cloud_subscription_errors_total ${metrics.cloudSubscriptionErrors}`,
     '# HELP open_cowork_gateway_errors_total Gateway errors.',
     '# TYPE open_cowork_gateway_errors_total counter',
     `open_cowork_gateway_errors_total ${metrics.errors}`,

--- a/apps/gateway/src/session-stream-manager.test.ts
+++ b/apps/gateway/src/session-stream-manager.test.ts
@@ -271,6 +271,7 @@ test('session stream manager reconnects from the last persisted cursor', async (
   await waitFor(() => subscriptions.length === 2)
 
   assert.equal(metrics.errors, 1)
+  assert.equal(metrics.streamReconnects, 1)
   assert.equal(subscriptions[1].afterSequence, 9)
   manager.closeAll()
 })
@@ -446,6 +447,7 @@ test('session stream manager leaves failed provider sends retryable', async () =
   }
   subscriptions[0].onEvent(event)
   await waitFor(() => metrics.errors === 1)
+  assert.equal(metrics.streamReconnects, 1)
   assert.equal(cursorUpdates.length, 0)
   await waitFor(() => subscriptions.length === 2)
 

--- a/apps/gateway/src/session-stream-manager.ts
+++ b/apps/gateway/src/session-stream-manager.ts
@@ -106,6 +106,7 @@ export function createGatewaySessionStreamManager(
       },
       onError: () => {
         metrics.errors += 1
+        metrics.streamReconnects += 1
         state.subscription?.close()
         state.subscription = null
         scheduleRetry(state)
@@ -165,6 +166,7 @@ export function createGatewaySessionStreamManager(
       state.renderFailures.set(event.sequence, attempts)
       const failure = classifyProviderFailure(error)
       if (failure.transient && attempts < maxRenderAttempts) {
+        metrics.streamReconnects += 1
         state.subscription?.close()
         state.subscription = null
         scheduleRetry(state)
@@ -174,6 +176,7 @@ export function createGatewaySessionStreamManager(
         await skipFailedEvent(state, event)
       } catch {
         metrics.errors += 1
+        metrics.streamReconnects += 1
         state.subscription?.close()
         state.subscription = null
         scheduleRetry(state)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -81,6 +81,16 @@ infrastructure:
 | Observability | JSON logs, OTLP endpoint, metrics, and redaction policy |
 | Recovery | Postgres and object-store backup/restore process |
 
+Reusable observability assets live under `deploy/observability/`:
+
+- `metrics-catalog.json` defines the Cloud and Gateway metric contract.
+- `grafana-open-cowork-overview.json` provides a provider-neutral dashboard
+  starting point for web, worker, scheduler, Gateway, auth, BYOK, quotas, and
+  delivery health.
+- `prometheus-alerts.yaml` defines launch-blocking alerts for user-impacting
+  errors, backlog, projection lag, auth abuse, BYOK failures, and Gateway
+  delivery failures.
+
 See `docs/deployment-readiness.md` for the production checklist and
 `docs/runbooks/managed-byok-saas.md` for hosted BYOK operations.
 

--- a/deploy/observability/grafana-open-cowork-overview.json
+++ b/deploy/observability/grafana-open-cowork-overview.json
@@ -1,0 +1,122 @@
+{
+  "title": "Open Cowork Cloud Overview",
+  "uid": "open-cowork-cloud-overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "tags": ["open-cowork", "cloud", "gateway"],
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Cloud HTTP rate and errors",
+      "targets": [
+        { "expr": "sum(rate(open_cowork_cloud_http_requests_total[5m])) by (cloud_role, http_response_status_code)" },
+        { "expr": "sum(rate(open_cowork_cloud_http_requests_total{http_response_status_code=~\"5..\"}[5m]))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cloud request latency",
+      "targets": [
+        { "expr": "max(open_cowork_cloud_http_request_duration_ms) by (cloud_role, url_path)" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cloud session and prompt latency",
+      "targets": [
+        { "expr": "max(open_cowork_cloud_session_create_duration_ms) by (profile_name)" },
+        { "expr": "max(open_cowork_cloud_prompt_enqueue_duration_ms) by (profile_name)" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Worker backlog and leases",
+      "targets": [
+        { "expr": "max(open_cowork_cloud_command_queue_depth)" },
+        { "expr": "max(open_cowork_cloud_command_oldest_age_ms)" },
+        { "expr": "sum(rate(open_cowork_cloud_worker_lease_claims_total[5m])) by (status)" },
+        { "expr": "sum(rate(open_cowork_cloud_worker_lease_renewals_total[5m])) by (status)" },
+        { "expr": "sum(rate(open_cowork_cloud_worker_stale_owner_rejections_total[5m]))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scheduler claims and failures",
+      "targets": [
+        { "expr": "sum(rate(open_cowork_cloud_scheduler_claims_total[5m]))" },
+        { "expr": "sum(rate(open_cowork_cloud_scheduler_failures_total[5m]))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Projection and SSE health",
+      "targets": [
+        { "expr": "max(open_cowork_cloud_projection_lag_events)" },
+        { "expr": "max(open_cowork_cloud_sse_connections)" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Auth, quota, and BYOK failures",
+      "targets": [
+        { "expr": "sum(rate(open_cowork_cloud_auth_failures_total[5m]))" },
+        { "expr": "sum(rate(open_cowork_cloud_quota_rejections_total[5m]))" },
+        { "expr": "sum(rate(open_cowork_cloud_byok_reveal_failures_total[5m]))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Postgres connections",
+      "targets": [
+        { "expr": "pg_up" },
+        { "expr": "pg_stat_activity_count" },
+        { "expr": "pg_settings_max_connections" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Object-store errors",
+      "targets": [
+        { "expr": "sum(rate(open_cowork_object_store_errors_total[5m])) by (kind, operation)" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Gateway delivery health",
+      "targets": [
+        { "expr": "sum(rate(open_cowork_gateway_incoming_messages_total[5m]))" },
+        { "expr": "sum(rate(open_cowork_gateway_deliveries_received_total[5m]))" },
+        { "expr": "sum(rate(open_cowork_gateway_deliveries_sent_total[5m]))" },
+        { "expr": "sum(rate(open_cowork_gateway_delivery_retries_total[5m]))" },
+        { "expr": "sum(rate(open_cowork_gateway_delivery_dead_letters_total[5m]))" },
+        { "expr": "max(open_cowork_gateway_delivery_latency_ms_total)" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Gateway active providers and streams",
+      "targets": [
+        { "expr": "open_cowork_gateway_providers" },
+        { "expr": "open_cowork_gateway_session_streams" },
+        { "expr": "sum(rate(open_cowork_gateway_stream_reconnects_total[5m]))" }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "Correlated structured logs",
+      "targets": [
+        { "expr": "{service_name=~\"open-cowork-cloud|open-cowork-gateway\"} | json | request_id != \"\"" }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "org",
+        "type": "query",
+        "query": "label_values(org_id)",
+        "hide": 0
+      }
+    ]
+  }
+}

--- a/deploy/observability/metrics-catalog.json
+++ b/deploy/observability/metrics-catalog.json
@@ -1,0 +1,180 @@
+{
+  "version": 1,
+  "description": "Provider-neutral Open Cowork Cloud and Gateway operational metric contract.",
+  "metrics": [
+    {
+      "name": "open_cowork_cloud_http_requests_total",
+      "type": "counter",
+      "owner": "cloud-web",
+      "description": "HTTP request rate and error basis by role, route, method, and status."
+    },
+    {
+      "name": "open_cowork_cloud_http_request_duration_ms",
+      "type": "gauge",
+      "owner": "cloud-web",
+      "description": "Cloud HTTP request latency in milliseconds."
+    },
+    {
+      "name": "open_cowork_cloud_session_create_duration_ms",
+      "type": "gauge",
+      "owner": "cloud-control-plane",
+      "description": "Session creation latency. Emit from Cloud session service or derive from request/span data."
+    },
+    {
+      "name": "open_cowork_cloud_prompt_enqueue_duration_ms",
+      "type": "gauge",
+      "owner": "cloud-control-plane",
+      "description": "Prompt command enqueue latency. Emit from prompt enqueue paths or derive from request/span data."
+    },
+    {
+      "name": "open_cowork_cloud_command_queue_depth",
+      "type": "gauge",
+      "owner": "cloud-worker",
+      "description": "Sessions scanned by worker command loop; pair with DB queue-age queries for backlog."
+    },
+    {
+      "name": "open_cowork_cloud_command_oldest_age_ms",
+      "type": "gauge",
+      "owner": "cloud-worker",
+      "description": "Oldest pending command age. May be emitted by DB collector or dashboard SQL."
+    },
+    {
+      "name": "open_cowork_cloud_worker_lease_claims_total",
+      "type": "counter",
+      "owner": "cloud-worker",
+      "description": "Worker lease claim attempts by status."
+    },
+    {
+      "name": "open_cowork_cloud_worker_lease_renewals_total",
+      "type": "counter",
+      "owner": "cloud-worker",
+      "description": "Successful worker lease renewals."
+    },
+    {
+      "name": "open_cowork_cloud_worker_stale_owner_rejections_total",
+      "type": "counter",
+      "owner": "cloud-worker",
+      "description": "Stale worker ownership or checkpoint/projection rejection signals."
+    },
+    {
+      "name": "open_cowork_cloud_worker_loop_duration_ms",
+      "type": "gauge",
+      "owner": "cloud-worker",
+      "description": "Worker command loop duration."
+    },
+    {
+      "name": "open_cowork_cloud_scheduler_claims_total",
+      "type": "counter",
+      "owner": "cloud-scheduler",
+      "description": "Due workflow claims by scheduler."
+    },
+    {
+      "name": "open_cowork_cloud_scheduler_failures_total",
+      "type": "counter",
+      "owner": "cloud-scheduler",
+      "description": "Scheduler loop failures."
+    },
+    {
+      "name": "open_cowork_cloud_projection_lag_events",
+      "type": "gauge",
+      "owner": "cloud-control-plane",
+      "description": "Difference between latest durable event sequence and projected session sequence."
+    },
+    {
+      "name": "open_cowork_cloud_sse_connections",
+      "type": "gauge",
+      "owner": "cloud-web",
+      "description": "Active cloud workspace/session SSE connections."
+    },
+    {
+      "name": "open_cowork_cloud_quota_rejections_total",
+      "type": "counter",
+      "owner": "cloud-control-plane",
+      "description": "Quota or rate-limit denials by policy code."
+    },
+    {
+      "name": "open_cowork_cloud_auth_failures_total",
+      "type": "counter",
+      "owner": "cloud-web",
+      "description": "Authentication failures and backoff claims by auth source."
+    },
+    {
+      "name": "open_cowork_cloud_byok_reveal_failures_total",
+      "type": "counter",
+      "owner": "cloud-worker",
+      "description": "BYOK plaintext reveal failures without including secret material."
+    },
+    {
+      "name": "open_cowork_object_store_errors_total",
+      "type": "counter",
+      "owner": "object-store-adapter",
+      "description": "Object-store read/write/list/delete failures by adapter kind and operation."
+    },
+    {
+      "name": "pg_up",
+      "type": "gauge",
+      "owner": "postgres-exporter",
+      "description": "Postgres exporter availability. Provided by the deployer's managed database exporter."
+    },
+    {
+      "name": "pg_stat_activity_count",
+      "type": "gauge",
+      "owner": "postgres-exporter",
+      "description": "Postgres active connection count. Provided by the deployer's managed database exporter."
+    },
+    {
+      "name": "pg_settings_max_connections",
+      "type": "gauge",
+      "owner": "postgres-exporter",
+      "description": "Postgres maximum connection setting. Provided by the deployer's managed database exporter."
+    },
+    {
+      "name": "open_cowork_gateway_incoming_messages_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Inbound channel messages handled."
+    },
+    {
+      "name": "open_cowork_gateway_deliveries_received_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Cloud channel deliveries received by gateway."
+    },
+    {
+      "name": "open_cowork_gateway_deliveries_sent_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Cloud channel deliveries sent to provider."
+    },
+    {
+      "name": "open_cowork_gateway_delivery_retries_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Channel deliveries scheduled for retry."
+    },
+    {
+      "name": "open_cowork_gateway_delivery_dead_letters_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Channel deliveries dead-lettered."
+    },
+    {
+      "name": "open_cowork_gateway_delivery_latency_ms_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Total gateway delivery handling latency in milliseconds."
+    },
+    {
+      "name": "open_cowork_gateway_session_streams",
+      "type": "gauge",
+      "owner": "gateway",
+      "description": "Active gateway session event streams."
+    },
+    {
+      "name": "open_cowork_gateway_stream_reconnects_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Gateway stream reconnects after cloud SSE or render failures."
+    }
+  ]
+}

--- a/deploy/observability/prometheus-alerts.yaml
+++ b/deploy/observability/prometheus-alerts.yaml
@@ -1,0 +1,122 @@
+groups:
+  - name: open-cowork-cloud
+    rules:
+      - alert: OpenCoworkCloudHighHttpErrorRate
+        expr: sum(rate(open_cowork_cloud_http_requests_total{http_response_status_code=~"5.."}[5m])) / clamp_min(sum(rate(open_cowork_cloud_http_requests_total[5m])), 1) > 0.05
+        for: 10m
+        labels:
+          severity: page
+          surface: cloud
+        annotations:
+          summary: Open Cowork Cloud HTTP 5xx rate is above 5%.
+          runbook: docs/runbooks/cloud-managed-operations.md#web-unavailable-or-erroring
+      - alert: OpenCoworkWorkerBacklogGrowing
+        expr: max(open_cowork_cloud_command_queue_depth) > 100 or max(open_cowork_cloud_command_oldest_age_ms) > 300000
+        for: 15m
+        labels:
+          severity: page
+          surface: worker
+        annotations:
+          summary: Worker command backlog is large or old.
+          runbook: docs/runbooks/cloud-managed-operations.md#worker-backlog
+      - alert: OpenCoworkSchedulerStalled
+        expr: absent(rate(open_cowork_cloud_scheduler_claims_total[30m])) and max(open_cowork_cloud_scheduler_loop_duration_ms) == 0
+        for: 30m
+        labels:
+          severity: ticket
+          surface: scheduler
+        annotations:
+          summary: Scheduler has not claimed due workflow work recently.
+          runbook: docs/runbooks/cloud-managed-operations.md#scheduler-stalled
+      - alert: OpenCoworkProjectionLag
+        expr: max(open_cowork_cloud_projection_lag_events) > 25
+        for: 10m
+        labels:
+          severity: page
+          surface: projection
+        annotations:
+          summary: Durable event projection lag is above threshold.
+          runbook: docs/runbooks/cloud-managed-operations.md#worker-backlog
+      - alert: OpenCoworkAuthFailuresSpike
+        expr: sum(rate(open_cowork_cloud_auth_failures_total[5m])) > 10
+        for: 5m
+        labels:
+          severity: ticket
+          surface: auth
+        annotations:
+          summary: Cloud authentication failures are spiking.
+          runbook: docs/runbooks/cloud-managed-operations.md#oidc-outage
+      - alert: OpenCoworkQuotaAbuse
+        expr: sum(rate(open_cowork_cloud_quota_rejections_total[5m])) > 20
+        for: 10m
+        labels:
+          severity: ticket
+          surface: abuse
+        annotations:
+          summary: Quota or rate-limit rejections are elevated.
+          runbook: docs/runbooks/cloud-managed-operations.md#webhook-abuse
+      - alert: OpenCoworkByokRevealFailures
+        expr: sum(rate(open_cowork_cloud_byok_reveal_failures_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: page
+          surface: byok
+        annotations:
+          summary: BYOK plaintext reveal failed in worker runtime path.
+          runbook: docs/runbooks/cloud-managed-operations.md#byok-provider-key-failure
+      - alert: OpenCoworkObjectStoreErrors
+        expr: sum(rate(open_cowork_object_store_errors_total[5m])) > 0
+        for: 10m
+        labels:
+          severity: page
+          surface: object-store
+        annotations:
+          summary: Object-store adapter is failing artifact or checkpoint operations.
+          runbook: docs/runbooks/cloud-managed-operations.md#object-store-errors
+      - alert: OpenCoworkPostgresUnavailable
+        expr: pg_up == 0
+        for: 5m
+        labels:
+          severity: page
+          surface: postgres
+        annotations:
+          summary: Postgres exporter reports database unavailable.
+          runbook: docs/runbooks/cloud-managed-operations.md#postgres-connection-exhaustion
+      - alert: OpenCoworkPostgresConnectionPressure
+        expr: max(pg_stat_activity_count) > 0.8 * max(pg_settings_max_connections)
+        for: 10m
+        labels:
+          severity: ticket
+          surface: postgres
+        annotations:
+          summary: Postgres connection usage is above 80% of max connections.
+          runbook: docs/runbooks/cloud-managed-operations.md#postgres-connection-exhaustion
+  - name: open-cowork-gateway
+    rules:
+      - alert: OpenCoworkGatewayDeliveryBacklog
+        expr: sum(rate(open_cowork_gateway_delivery_retries_total[10m])) > 1 or sum(rate(open_cowork_gateway_delivery_dead_letters_total[10m])) > 0
+        for: 10m
+        labels:
+          severity: page
+          surface: gateway
+        annotations:
+          summary: Gateway deliveries are retrying or dead-lettering.
+          runbook: docs/runbooks/cloud-managed-operations.md#gateway-provider-outage
+      - alert: OpenCoworkGatewayStreamReconnects
+        expr: sum(rate(open_cowork_gateway_stream_reconnects_total[5m])) > 5
+        for: 10m
+        labels:
+          severity: ticket
+          surface: gateway
+        annotations:
+          summary: Gateway session streams are reconnecting repeatedly.
+          runbook: docs/runbooks/cloud-managed-operations.md#gateway-backlog
+      - alert: OpenCoworkGatewayNoProviders
+        expr: open_cowork_gateway_providers < 1
+        for: 5m
+        labels:
+          severity: page
+          surface: gateway
+        annotations:
+          summary: Gateway is running without any active channel providers.
+          runbook: docs/runbooks/cloud-managed-operations.md#gateway-provider-outage

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -181,12 +181,15 @@ roles and shared Postgres/object storage.
 ### OTLP/Logging
 
 - Use JSON logs in production.
-- Configure `OPEN_COWORK_CLOUD_OTLP_ENDPOINT` and gateway metrics scraping
-  where available.
+- Configure `OPEN_COWORK_CLOUD_OTLP_ENDPOINT`, scrape authenticated
+  `GET /api/metrics` for Cloud where Prometheus is used, and scrape Gateway
+  `/metrics` with the Gateway admin token.
 - Include request ids, org ids, session ids, run ids, worker ids, scheduler ids,
   and gateway delivery ids.
 - Redact BYOK keys, API tokens, cookies, OAuth tokens, webhook secrets,
   database URLs, object-store signed URLs, and local paths.
+- Keep deployable metric, dashboard, and alert assets under
+  `deploy/observability/` in sync with the production SLOs.
 
 ### Backups/Restore
 
@@ -196,6 +199,9 @@ roles and shared Postgres/object storage.
 - Start web with workers at zero, verify projections and session lists, start
   one worker, run a smoke prompt, then start scheduler and gateway.
 - Verify channel deliveries resume from durable cursors without duplicates.
+- Follow `docs/runbooks/backup-restore.md` and keep the latest redacted drill
+  evidence in `docs/runbooks/restore-drill-report.md` or a downstream private
+  operations repository.
 
 ## Deployment Validation
 
@@ -320,7 +326,8 @@ pnpm deploy:smoke
 The smoke script validates cloud `/healthz`, the Cloud Web Workbench at `GET /`,
 workbench CSP/bootstrap markers, cloud API bootstrap endpoint reachability,
 gateway `/health`, and gateway `/ready`. Operator mode also checks cloud
-runtime/heartbeat endpoints and gateway metrics when tokens are provided.
+runtime/heartbeat/metrics endpoints and gateway metrics when tokens are
+provided.
 
 ## Provider Recipe Contract
 

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -790,6 +790,9 @@ browser is not the only protection.
   or by durable worker polling.
 - `GET /api/workers/heartbeats` exposes worker and scheduler heartbeat state
   for authenticated operators.
+- `GET /api/metrics` exposes operator-scoped Prometheus metrics from the
+  in-process cloud observability adapter. Use OTLP for provider-managed
+  tracing/metrics and this endpoint for scrape-based dashboards.
 - Cloud HTTP requests emit structured request logs with request ids, role,
   profile, status, and duration. When `OPEN_COWORK_CLOUD_OTLP_ENDPOINT` is
   set, the same request observations are exported as OTLP HTTP traces and

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,148 @@
+---
+title: Backup and Restore Runbook
+description: Executable backup, restore, and recovery drill procedure for Open Cowork Cloud.
+---
+
+# Backup and Restore Runbook
+
+This runbook covers provider-neutral recovery for Open Cowork Cloud, workers,
+scheduler, and Gateway channel delivery state. It assumes Postgres is the
+control-plane source of truth and object storage holds artifacts, uploads,
+exports, workspace snapshots, runtime checkpoints, and diagnostics bundles.
+
+## Recovery Objectives
+
+Set these explicitly per environment:
+
+| Environment | Postgres retention | Object-store retention | RPO | RTO |
+| --- | --- | --- | --- | --- |
+| Internal/dev | daily snapshot, 7 days | versioned, 7 days | 24h | 4h |
+| Private beta | PITR, 7-14 days | versioned, 14 days | 15m | 2h |
+| Managed production | PITR, 30 days | versioned, 30 days | 5m | 1h |
+
+Use the same retention window for Postgres and object storage. Restoring
+Postgres to a point in time while restoring object storage to a different point
+can produce missing artifacts, stale checkpoint references, or duplicate channel
+deliveries.
+
+## What Must Be Protected
+
+- Postgres control plane: orgs, accounts, memberships, API tokens, sessions,
+  commands, events, projections, leases, workflows, worker heartbeats, BYOK
+  metadata, billing/usage rows, channel bindings, interactions, deliveries, and
+  audit events.
+- Object storage: cloud artifacts, uploads, exports, workspace snapshots,
+  runtime/XDG checkpoints, generated runtime content, and diagnostics bundles.
+- Secret manager/KMS references: Open Cowork secret adapter keys, cookie
+  secrets, OIDC client secret, object-store credentials, gateway service tokens,
+  channel provider credentials, and billing webhook secrets.
+
+Raw BYOK/provider keys should not be dumped to local files. BYOK ciphertext or
+KMS refs are part of Postgres; plaintext exists only in the worker runtime path.
+
+## Backup Schedule
+
+Postgres:
+
+```bash
+# Managed providers should use PITR first. This logical dump is the portable
+# break-glass backup and local drill input.
+pg_dump "$OPEN_COWORK_DATABASE_URL" \
+  --format=custom \
+  --no-owner \
+  --no-acl \
+  --file "$OPEN_COWORK_BACKUP_DIR/postgres/open-cowork-$(date -u +%Y%m%dT%H%M%SZ).dump"
+```
+
+Object storage:
+
+```bash
+# S3-compatible stores, including DigitalOcean Spaces.
+aws s3 sync "$OPEN_COWORK_OBJECT_STORE_URI" \
+  "$OPEN_COWORK_BACKUP_DIR/object-store/" \
+  --only-show-errors
+
+# GCS.
+gcloud storage rsync --recursive \
+  "$OPEN_COWORK_OBJECT_STORE_URI" \
+  "$OPEN_COWORK_BACKUP_DIR/object-store/"
+
+# Azure Blob.
+az storage blob sync \
+  --source "$OPEN_COWORK_OBJECT_STORE_URI" \
+  --destination "$OPEN_COWORK_BACKUP_DIR/object-store/"
+```
+
+Secrets:
+
+- Prefer platform-managed versioning and rotation history.
+- Export only secret names, versions, KMS refs, and rotation timestamps to the
+  drill report.
+- Never export provider keys, OAuth refresh tokens, API tokens, cookie secrets,
+  channel credentials, or billing webhook secrets as plaintext.
+
+## Restore Procedure
+
+1. Freeze writes by removing public traffic or scaling web to read-only
+   maintenance mode.
+2. Scale workers, scheduler, and Gateway to zero. Do not let workers claim
+   sessions during restore.
+3. Restore Postgres first:
+
+```bash
+createdb "$OPEN_COWORK_RESTORE_DATABASE_NAME"
+pg_restore \
+  --dbname "$OPEN_COWORK_RESTORE_DATABASE_URL" \
+  --clean \
+  --if-exists \
+  --no-owner \
+  --no-acl \
+  "$OPEN_COWORK_POSTGRES_BACKUP_FILE"
+```
+
+4. Restore object storage to the same point in time:
+
+```bash
+aws s3 sync "$OPEN_COWORK_BACKUP_DIR/object-store/" "$OPEN_COWORK_RESTORE_OBJECT_STORE_URI" --only-show-errors
+gcloud storage rsync --recursive "$OPEN_COWORK_BACKUP_DIR/object-store/" "$OPEN_COWORK_RESTORE_OBJECT_STORE_URI"
+az storage blob sync --source "$OPEN_COWORK_BACKUP_DIR/object-store/" --destination "$OPEN_COWORK_RESTORE_OBJECT_STORE_URI"
+```
+
+5. Start only the cloud web role.
+6. Verify `GET /healthz`, `GET /api/workspace`, `GET /api/diagnostics`, and
+   `GET /api/metrics` with an operator token.
+7. Verify session lists, durable projections, artifact metadata, BYOK metadata,
+   billing state, workflow definitions, channel bindings, and delivery cursors.
+8. Start one worker and run a bounded smoke prompt.
+9. Start scheduler and confirm due workflow claims.
+10. Start Gateway and confirm channel deliveries resume from stored cursors
+    without duplicate sends.
+11. Resume traffic after the restore drill report is complete.
+
+## Restore Drill Report Requirements
+
+Each drill must record:
+
+- environment name, restore target, and timestamp,
+- Postgres backup source and restore timestamp,
+- object-store snapshot/version used,
+- secret manager/KMS version references,
+- counts for sessions, projections, artifacts, workflows, channel bindings, and
+  pending/failed/dead deliveries before and after restore,
+- smoke commands run and their results,
+- any data that was intentionally excluded,
+- follow-up fixes and owner.
+
+Keep reports under `docs/runbooks/restore-drill-report.md` for the latest drill
+or a dated operations folder in downstream private repos. Do not include
+customer data, raw credentials, local paths, signed URLs, or provider keys.
+
+## Recovery Boundaries
+
+- Do not hand-edit sessions, projections, or delivery cursors during normal
+  recovery. Use service APIs and retry/dead-letter controls.
+- Do not drop additive schema columns as part of rollback. Ship a forward fix.
+- Do not resume workers until object storage is restored or checkpoint restores
+  will fail and workers may regenerate divergent state.
+- Do not restore local Desktop threads into cloud automatically. Local Desktop
+  workspaces remain local unless users explicitly import/upload content.

--- a/docs/runbooks/cloud-managed-operations.md
+++ b/docs/runbooks/cloud-managed-operations.md
@@ -73,6 +73,146 @@ Gateway delivery lag is operationally separate from cloud execution lag.
 5. For bad provider credentials, rotate the channel secret and restart only the
    affected gateway deployment.
 
+## Web Unavailable Or Erroring
+
+Use this when `GET /healthz` fails, Cloud Web returns elevated 5xx responses,
+or users cannot load the Cloud Web Workbench.
+
+1. Check ingress/load-balancer health and TLS certificate status.
+2. Check `open_cowork_cloud_http_requests_total` by status and role.
+3. Check structured logs by `request_id` for the failing route.
+4. Verify Postgres connectivity from the web role.
+5. Verify cookie/OIDC configuration if only authenticated routes fail.
+6. Scale web replicas up only after the dependency error is understood.
+7. If a new image caused the failure, roll back web first; keep workers running
+   only if command processing remains healthy.
+
+## Worker Backlog
+
+Use this when prompt latency rises, commands remain pending, or projection lag
+grows.
+
+1. Check `open_cowork_cloud_command_queue_depth`,
+   `open_cowork_cloud_command_oldest_age_ms`, and
+   `open_cowork_cloud_worker_loop_duration_ms`.
+2. Check worker heartbeats and active sessions in `GET /api/workers/heartbeats`.
+3. Check lease signals: `open_cowork_cloud_worker_lease_claims_total`,
+   `open_cowork_cloud_worker_lease_renewals_total`, and
+   `open_cowork_cloud_worker_stale_owner_rejections_total`.
+4. Check BYOK reveal failures and provider errors before scaling workers.
+5. Scale workers horizontally only when Postgres connection pool and provider
+   quota have headroom.
+6. If one session is poisoning the queue, use session abort/retry controls
+   rather than direct database edits.
+
+## Scheduler Stalled
+
+Use this when scheduled workflows do not start or heartbeat age exceeds the
+alert threshold.
+
+1. Check scheduler heartbeat freshness.
+2. Check `open_cowork_cloud_scheduler_claims_total` and
+   `open_cowork_cloud_scheduler_failures_total`.
+3. Confirm exactly one scheduler deployment group is active for the environment.
+4. Confirm database time and application time are not drifting.
+5. Restart scheduler only after checking logs for claim transaction failures.
+6. Verify one due workflow claim after restart and confirm no double-fire.
+
+## Postgres Connection Exhaustion
+
+Use this when web, worker, scheduler, or Gateway routes fail with database pool
+or timeout errors.
+
+1. Check managed database connection count, wait events, slow queries, and CPU.
+2. Temporarily scale workers down before web if user reads must remain
+   available.
+3. Check queue depth and scheduler claims; high worker concurrency may be
+   exhausting the pool.
+4. Confirm migrations are not running repeatedly.
+5. Add pool capacity or a connection pooler only after bounding worker replicas.
+6. Do not increase all role replicas at the same time.
+
+## Object-Store Errors
+
+Use this when artifacts, uploads, exports, or checkpoint restore/save fails.
+
+1. Check object-store service health and credentials/workload identity.
+2. Verify bucket/container/prefix exists and has versioning enabled.
+3. Check checkpoint restore logs before allowing workers to resume failed
+   sessions.
+4. For transient object-store failures, keep web reads available and pause
+   worker scale-up.
+5. For permission failures, rotate or repair object-store credentials and run
+   one artifact read/write smoke.
+
+## KMS Or Secret Adapter Errors
+
+Use this when BYOK metadata exists but runtime reveal, cookie secret, OIDC
+secret, channel credential, or envelope decryption fails.
+
+1. Check secret manager/KMS availability and IAM on the runtime service account.
+2. Confirm `OPEN_COWORK_CLOUD_SECRET_KEY_REF`,
+   `OPEN_COWORK_CLOUD_COOKIE_SECRET_REF`, OIDC refs, and gateway secret refs
+   point to current versions.
+3. Do not copy plaintext secrets into environment variables as a workaround in
+   managed deployments.
+4. If a KMS key was rotated, verify old ciphertext can still be revealed before
+   disabling old key material.
+5. Run BYOK metadata and worker validation smoke after repair.
+
+## OIDC Outage
+
+Use this when sign-in, token refresh, or browser callback handling fails.
+
+1. Check IdP status and OIDC discovery document.
+2. Check `OPEN_COWORK_CLOUD_PUBLIC_URL`, callback path, client id, and client
+   secret reference.
+3. Check auth failure rate and backoff state.
+4. Keep existing authenticated sessions unless cookie secret rotation is part of
+   the incident.
+5. Do not switch public deployments to `auth.mode=none`.
+6. If emergency admin access is needed, use a scoped API token through private
+   networking and audit the action.
+
+## Gateway Provider Outage
+
+Use this when Telegram, Slack, email, webhook, or another channel provider
+fails while cloud sessions still execute.
+
+1. Check gateway `/ready` provider status and
+   `open_cowork_gateway_delivery_retries_total`.
+2. Keep cloud workers running; failed channel delivery should retry or
+   dead-letter without blocking execution.
+3. Rotate only the affected channel credential if provider auth failed.
+4. Use `/deliveries?status=failed` and retry/dead-letter controls after the
+   provider recovers.
+5. Notify users that desktop and web remain authoritative while chat delivery is
+   degraded.
+
+## Webhook Abuse
+
+Use this when webhook auth failures, replay rejections, or rate-limit denials
+spike.
+
+1. Confirm public webhook routes require HMAC/shared-secret signatures.
+2. Check replay and auth-failure counters by source.
+3. Rotate the affected webhook secret if a signing secret may be exposed.
+4. Tighten rate limits or temporarily disable the affected channel binding.
+5. Preserve audit and redacted diagnostics for incident review.
+
+## BYOK Provider Key Failure
+
+Use this when model calls fail because a user provider key is missing, expired,
+revoked, or rejected by provider policy.
+
+1. Confirm read APIs expose metadata only: provider, last4/fingerprint, status,
+   and health.
+2. Check `open_cowork_cloud_byok_reveal_failures_total` without logging
+   plaintext.
+3. Mark the provider credential invalid/expired through BYOK metadata.
+4. Ask the org owner/admin to rotate the provider key.
+5. Resume worker execution only after a bounded validation succeeds.
+
 ## Secret Rotation
 
 Rotate secrets without moving them through logs, chat, issue comments, or

--- a/docs/runbooks/restore-drill-report.md
+++ b/docs/runbooks/restore-drill-report.md
@@ -1,0 +1,61 @@
+---
+title: Restore Drill Report
+description: Non-production restore drill evidence for Open Cowork Cloud operations.
+---
+
+# Restore Drill Report
+
+This report is the repository-owned template and baseline drill evidence for
+issue #500. Downstream operators should copy it into their private operations
+repo for environment-specific drills and replace placeholders with their own
+non-secret values.
+
+## Drill Metadata
+
+| Field | Value |
+| --- | --- |
+| Drill type | Non-production provider-neutral restore rehearsal |
+| Scope | Postgres control plane, object-store artifacts/checkpoints, Gateway delivery cursors |
+| Restore mode | Web-first, workers/scheduler/Gateway held at zero until validation |
+| Report owner | Open Cowork operator |
+| Secret handling | Secret names and versions only; no plaintext |
+
+## Required Restore Evidence
+
+The drill is considered passing only when all rows are satisfied.
+
+| Check | Evidence to collect | Pass condition |
+| --- | --- | --- |
+| Postgres restore | `pg_restore` output and table-count summary | sessions, events, projections, workflows, channel bindings, BYOK metadata, billing/usage, and audit rows are present |
+| Object-store restore | provider copy/sync output and prefix-count summary | artifact metadata points at restored blobs; checkpoint manifests are present |
+| Secret/KMS references | secret manager version list | cloud secret adapter, OIDC, cookie, gateway, and channel secret refs exist; no plaintext exported |
+| Web-only boot | `GET /healthz`, `GET /api/workspace`, `GET /api/diagnostics`, `GET /api/metrics` | all operator reads succeed while workers are still scaled to zero |
+| Session projection parity | restored session list and one session projection | latest projection sequence is at least the restored event sequence for the sampled session |
+| Artifact metadata | restored artifact list and one download/read check | metadata and blob are both available |
+| Worker recovery | one worker enabled and one bounded smoke prompt | worker claims a lease, executes command, writes projection, and saves checkpoint |
+| Scheduler recovery | scheduler enabled after worker check | due workflow claim emits a run without double-firing |
+| Gateway recovery | Gateway enabled last | delivery cursor resumes without duplicate sends; retry/dead-letter controls work |
+| Redaction | diagnostics/log sample | no API token, BYOK plaintext, OAuth token, channel credential, signed URL query, email, or local host path appears |
+
+## Baseline Drill Result
+
+The repository baseline is a dry-runable drill contract, not a live customer
+restore. It is verified by:
+
+```bash
+pnpm ops:validate
+pnpm deploy:validate
+```
+
+Environment-specific drills must additionally run the commands from
+`docs/runbooks/backup-restore.md` against a non-production restore target and
+attach their redacted command output to the private drill report.
+
+## Follow-Up Template
+
+| Finding | Owner | Severity | Due date | Status |
+| --- | --- | --- | --- | --- |
+| Example: object-store lifecycle retention shorter than Postgres PITR | Platform | High | YYYY-MM-DD | Open |
+
+Do not merge a managed production launch if a high-severity restore finding is
+still open.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,8 @@ nav:
       - Open Cowork Cloud: open-cowork-cloud.md
       - Deployment Readiness: deployment-readiness.md
       - Cloud Managed Operations: runbooks/cloud-managed-operations.md
+      - Backup and Restore: runbooks/backup-restore.md
+      - Restore Drill Report: runbooks/restore-drill-report.md
       - Managed BYOK SaaS: runbooks/managed-byok-saas.md
       - Branch Protection: branch-protection.md
       - Packaging and Releases: packaging-and-releases.md

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "deploy:continuation:smoke": "pnpm build:gateway && pnpm build:shared && node --no-warnings --experimental-strip-types scripts/cloud-continuation-smoke.mjs",
     "deploy:gcp:preflight": "node scripts/gcp-reference-preflight.mjs",
     "deploy:gcp:smoke": "node scripts/gcp-reference-smoke.mjs",
+    "ops:validate": "node scripts/validate-ops-readiness.mjs",
     "notices": "node scripts/generate-third-party-notices.mjs",
     "proof:cloud:opencode-portability": "node --no-warnings --experimental-strip-types scripts/opencode-portability-proof.ts",
     "perf:bench": "node --no-warnings --experimental-sqlite --experimental-strip-types scripts/perf-benchmark.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ pnpm deploy:gateway:smoke
 pnpm deploy:continuation:smoke
 pnpm deploy:gcp:preflight
 pnpm deploy:gcp:smoke
+pnpm ops:validate
 pnpm notices
 pnpm --dir apps/desktop dist:ci
 ```
@@ -51,6 +52,13 @@ reachability, and gateway readiness endpoints. Override
 `OPEN_COWORK_SMOKE_CLOUD_URL` and `OPEN_COWORK_SMOKE_GATEWAY_URL` for provider
 deployments, or use `--skip-cloud` / `--skip-gateway` when checking one
 surface.
+Set `OPEN_COWORK_SMOKE_OPERATOR_CHECKS=true` and provide operator tokens to
+also validate cloud runtime status, worker heartbeats, cloud `/api/metrics`,
+and Gateway `/metrics`.
+
+`pnpm ops:validate` statically validates the production operations bundle:
+metric catalog, Grafana dashboard, Prometheus alert rules, incident runbooks,
+backup/restore instructions, and restore drill report requirements.
 
 `pnpm deploy:desktop:smoke` validates the Desktop cloud-workspace path against
 a running cloud deployment. It uses the same main-process cloud adapter and

--- a/scripts/smoke-deployment.mjs
+++ b/scripts/smoke-deployment.mjs
@@ -73,6 +73,24 @@ async function checkReachableJson(url, options = {}) {
   }
 }
 
+async function checkText(url, options = {}) {
+  const response = await fetch(url, {
+    headers: options.token ? { Authorization: `Bearer ${options.token}` } : undefined,
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}: ${text.slice(0, 400)}`)
+  }
+  for (const marker of options.markers || []) {
+    if (!text.includes(marker)) throw new Error(`${url} missing expected marker: ${marker}`)
+  }
+  return {
+    status: response.status,
+    contentType: response.headers.get('content-type') || '',
+    markers: options.markers || [],
+  }
+}
+
 async function checkHtml(url, options = {}) {
   const response = await fetch(url, {
     headers: options.token ? { Authorization: `Bearer ${options.token}` } : undefined,
@@ -151,6 +169,14 @@ async function main() {
         url: `${cloudUrl}/api/workers/heartbeats`,
         result: await checkJson(`${cloudUrl}/api/workers/heartbeats`, { token: cloudToken }),
       })
+      results.push({
+        check: 'cloud metrics',
+        url: `${cloudUrl}/api/metrics`,
+        result: await checkText(`${cloudUrl}/api/metrics`, {
+          token: cloudToken,
+          markers: ['open_cowork_cloud_http_requests_total'],
+        }),
+      })
     }
   }
 
@@ -169,7 +195,10 @@ async function main() {
       results.push({
         check: 'gateway metrics',
         url: `${gatewayUrl}/metrics`,
-        result: await checkJson(`${gatewayUrl}/metrics`, { token: gatewayAdminToken }),
+        result: await checkText(`${gatewayUrl}/metrics`, {
+          token: gatewayAdminToken,
+          markers: ['open_cowork_gateway_providers'],
+        }),
       })
     }
   }

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -256,8 +256,14 @@ function validateHelm() {
 function validateDocs() {
   const requiredDocs = [
     'docs/deployment-readiness.md',
+    'docs/runbooks/cloud-managed-operations.md',
+    'docs/runbooks/backup-restore.md',
+    'docs/runbooks/restore-drill-report.md',
     'docs/runbooks/managed-byok-saas.md',
     'deploy/README.md',
+    'deploy/observability/metrics-catalog.json',
+    'deploy/observability/prometheus-alerts.yaml',
+    'deploy/observability/grafana-open-cowork-overview.json',
     'deploy/gcp/README.md',
     'deploy/aws/README.md',
     'deploy/azure/README.md',
@@ -294,6 +300,9 @@ function validateDocs() {
     'cloud.billing.provider=none',
     'otlp/logging',
     'backups/restore',
+    'deploy/observability/',
+    'docs/runbooks/backup-restore.md',
+    'docs/runbooks/restore-drill-report.md',
     'no billing provider or the stub billing provider',
   ]) {
     if (!readiness.includes(phrase)) {
@@ -313,6 +322,67 @@ function validateDocs() {
   ]) {
     if (!byok.includes(phrase)) {
       throw new Error(`docs/runbooks/managed-byok-saas.md must include ${phrase}`)
+    }
+  }
+
+  const operations = read('docs/runbooks/cloud-managed-operations.md')
+  for (const phrase of [
+    'Web Unavailable Or Erroring',
+    'Worker Backlog',
+    'Scheduler Stalled',
+    'Postgres Connection Exhaustion',
+    'Object-Store Errors',
+    'KMS Or Secret Adapter Errors',
+    'OIDC Outage',
+    'Gateway Provider Outage',
+    'Webhook Abuse',
+    'BYOK Provider Key Failure',
+  ]) {
+    if (!operations.includes(phrase)) {
+      throw new Error(`docs/runbooks/cloud-managed-operations.md must include ${phrase}`)
+    }
+  }
+
+  const metricsCatalog = read('deploy/observability/metrics-catalog.json')
+  for (const metric of [
+    'open_cowork_cloud_http_requests_total',
+    'open_cowork_cloud_command_queue_depth',
+    'open_cowork_cloud_worker_lease_claims_total',
+    'open_cowork_cloud_scheduler_claims_total',
+    'open_cowork_cloud_projection_lag_events',
+    'open_cowork_cloud_byok_reveal_failures_total',
+    'open_cowork_object_store_errors_total',
+    'pg_up',
+    'pg_stat_activity_count',
+    'open_cowork_gateway_delivery_retries_total',
+    'open_cowork_gateway_delivery_dead_letters_total',
+    'open_cowork_gateway_session_streams',
+  ]) {
+    if (!metricsCatalog.includes(metric)) {
+      throw new Error(`deploy/observability/metrics-catalog.json must include ${metric}`)
+    }
+  }
+
+  for (const path of ['deploy/observability/prometheus-alerts.yaml', 'deploy/observability/grafana-open-cowork-overview.json']) {
+    const artifact = read(path)
+    for (const phrase of ['Worker', 'Gateway', 'BYOK', 'projection']) {
+      if (!artifact.toLowerCase().includes(phrase.toLowerCase())) {
+        throw new Error(`${path} must include ${phrase}`)
+      }
+    }
+  }
+
+  const backupRestore = read('docs/runbooks/backup-restore.md')
+  for (const phrase of ['pg_dump', 'pg_restore', 'aws s3 sync', 'gcloud storage rsync', 'az storage blob sync']) {
+    if (!backupRestore.includes(phrase)) {
+      throw new Error(`docs/runbooks/backup-restore.md must include ${phrase}`)
+    }
+  }
+
+  const restoreDrill = read('docs/runbooks/restore-drill-report.md')
+  for (const phrase of ['Postgres restore', 'Object-store restore', 'Session projection parity', 'Gateway recovery', 'Redaction']) {
+    if (!restoreDrill.includes(phrase)) {
+      throw new Error(`docs/runbooks/restore-drill-report.md must include ${phrase}`)
     }
   }
 

--- a/scripts/validate-ops-readiness.mjs
+++ b/scripts/validate-ops-readiness.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs'
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function parseJson(path) {
+  return JSON.parse(read(path))
+}
+
+function assertFile(path) {
+  if (!existsSync(path)) throw new Error(`${path} is required`)
+}
+
+function assertIncludes(path, text) {
+  const contents = read(path)
+  if (!contents.includes(text)) throw new Error(`${path} must include ${text}`)
+}
+
+function log(message) {
+  process.stdout.write(`[ops-validate] ${message}\n`)
+}
+
+const metricCatalogPath = 'deploy/observability/metrics-catalog.json'
+const alertsPath = 'deploy/observability/prometheus-alerts.yaml'
+const dashboardPath = 'deploy/observability/grafana-open-cowork-overview.json'
+const operationsRunbookPath = 'docs/runbooks/cloud-managed-operations.md'
+const backupRunbookPath = 'docs/runbooks/backup-restore.md'
+const drillReportPath = 'docs/runbooks/restore-drill-report.md'
+
+for (const path of [
+  metricCatalogPath,
+  alertsPath,
+  dashboardPath,
+  operationsRunbookPath,
+  backupRunbookPath,
+  drillReportPath,
+]) {
+  assertFile(path)
+}
+
+const requiredMetrics = [
+  'open_cowork_cloud_http_requests_total',
+  'open_cowork_cloud_http_request_duration_ms',
+  'open_cowork_cloud_session_create_duration_ms',
+  'open_cowork_cloud_prompt_enqueue_duration_ms',
+  'open_cowork_cloud_command_queue_depth',
+  'open_cowork_cloud_command_oldest_age_ms',
+  'open_cowork_cloud_worker_lease_claims_total',
+  'open_cowork_cloud_worker_lease_renewals_total',
+  'open_cowork_cloud_worker_stale_owner_rejections_total',
+  'open_cowork_cloud_scheduler_claims_total',
+  'open_cowork_cloud_projection_lag_events',
+  'open_cowork_cloud_sse_connections',
+  'open_cowork_cloud_quota_rejections_total',
+  'open_cowork_cloud_auth_failures_total',
+  'open_cowork_cloud_byok_reveal_failures_total',
+  'open_cowork_object_store_errors_total',
+  'pg_up',
+  'pg_stat_activity_count',
+  'pg_settings_max_connections',
+  'open_cowork_gateway_incoming_messages_total',
+  'open_cowork_gateway_deliveries_received_total',
+  'open_cowork_gateway_deliveries_sent_total',
+  'open_cowork_gateway_delivery_retries_total',
+  'open_cowork_gateway_delivery_dead_letters_total',
+  'open_cowork_gateway_session_streams',
+  'open_cowork_gateway_stream_reconnects_total',
+]
+
+const requiredAlertMetrics = [
+  'open_cowork_cloud_http_requests_total',
+  'open_cowork_cloud_command_queue_depth',
+  'open_cowork_cloud_command_oldest_age_ms',
+  'open_cowork_cloud_scheduler_claims_total',
+  'open_cowork_cloud_projection_lag_events',
+  'open_cowork_cloud_quota_rejections_total',
+  'open_cowork_cloud_auth_failures_total',
+  'open_cowork_cloud_byok_reveal_failures_total',
+  'open_cowork_object_store_errors_total',
+  'pg_up',
+  'pg_stat_activity_count',
+  'pg_settings_max_connections',
+  'open_cowork_gateway_delivery_retries_total',
+  'open_cowork_gateway_delivery_dead_letters_total',
+  'open_cowork_gateway_stream_reconnects_total',
+]
+
+const catalog = parseJson(metricCatalogPath)
+const catalogNames = new Set((catalog.metrics || []).map((metric) => metric.name))
+for (const metric of requiredMetrics) {
+  if (!catalogNames.has(metric)) throw new Error(`${metricCatalogPath} is missing ${metric}`)
+  assertIncludes(dashboardPath, metric)
+}
+for (const metric of requiredAlertMetrics) {
+  assertIncludes(alertsPath, metric)
+}
+
+const dashboard = parseJson(dashboardPath)
+if (!Array.isArray(dashboard.panels) || dashboard.panels.length < 8) {
+  throw new Error(`${dashboardPath} must define a useful operations dashboard`)
+}
+
+for (const phrase of [
+  'Web Unavailable Or Erroring',
+  'Worker Backlog',
+  'Scheduler Stalled',
+  'Postgres Connection Exhaustion',
+  'Object-Store Errors',
+  'KMS Or Secret Adapter Errors',
+  'OIDC Outage',
+  'Gateway Provider Outage',
+  'Webhook Abuse',
+  'BYOK Provider Key Failure',
+  'Diagnostics',
+  'Restore Check',
+]) {
+  assertIncludes(operationsRunbookPath, phrase)
+}
+
+for (const phrase of [
+  'pg_dump',
+  'pg_restore',
+  'gcloud storage rsync',
+  'aws s3 sync',
+  'az storage blob sync',
+  'Postgres control plane',
+  'Object storage',
+  'Secret manager/KMS',
+  'Restore Drill Report Requirements',
+]) {
+  assertIncludes(backupRunbookPath, phrase)
+}
+
+for (const phrase of [
+  'Postgres restore',
+  'Object-store restore',
+  'Secret/KMS references',
+  'Web-only boot',
+  'Session projection parity',
+  'Worker recovery',
+  'Scheduler recovery',
+  'Gateway recovery',
+  'Redaction',
+]) {
+  assertIncludes(drillReportPath, phrase)
+}
+
+log('operations readiness artifacts validated')

--- a/tests/byok-runtime-injection.test.ts
+++ b/tests/byok-runtime-injection.test.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CONFIG, type OpenCoworkConfig } from '../apps/desktop/src/main/
 import { createByokSecretStore } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
 import { resolveCloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
 import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
+import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
 import { createCloudPathProvider } from '../apps/desktop/src/main/cloud/path-provider.ts'
 import type {
   CloudRuntimeAdapter,
@@ -248,6 +249,12 @@ test('worker-scoped BYOK runtime enforces provider policy before revealing activ
   })
   await byokSecrets.setSecret({ orgId: 'tenant-a', providerId: 'openrouter', plaintext: KEY_A })
   let factoryCalls = 0
+  const metrics: unknown[] = []
+  const observability: CloudObservabilityAdapter = {
+    log() {},
+    metric(record) { metrics.push(record) },
+    span() {},
+  }
   const runtime = createWorkerScopedRuntimeAdapter({
     paths: createCloudPathProvider(root),
     policy: resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
@@ -260,6 +267,7 @@ test('worker-scoped BYOK runtime enforces provider policy before revealing activ
         throw new Error('entitlement checker should not run for an unavailable provider')
       },
     },
+    observability,
     runtimeFactory() {
       factoryCalls += 1
       throw new Error('runtime factory should not be called')
@@ -284,6 +292,10 @@ test('worker-scoped BYOK runtime enforces provider policy before revealing activ
       /not available for cloud BYOK execution/,
     )
     assert.equal(factoryCalls, 0)
+    assert.equal(metrics.some((metric) => (
+      (metric as Record<string, unknown>).name === 'open_cowork_cloud_byok_reveal_failures_total'
+      && (((metric as Record<string, unknown>).attributes as Record<string, unknown>)?.reason === 'provider_not_allowed')
+    )), true)
   } finally {
     await runtime.close?.()
     rmSync(root, { recursive: true, force: true })
@@ -300,12 +312,19 @@ test('missing or disabled required BYOK key fails before runtime spawn', async (
   await byokSecrets.setSecret({ orgId: 'tenant-a', providerId: 'openrouter', plaintext: KEY_A })
   await byokSecrets.disableSecret({ orgId: 'tenant-a', providerId: 'openrouter' })
   let factoryCalls = 0
+  const metrics: unknown[] = []
+  const observability: CloudObservabilityAdapter = {
+    log() {},
+    metric(record) { metrics.push(record) },
+    span() {},
+  }
   const runtime = createWorkerScopedRuntimeAdapter({
     paths: createCloudPathProvider(root),
     policy: resolveCloudRuntimePolicy(BYOK_TEST_CONFIG, { OPEN_COWORK_CLOUD_ROLE: 'worker', OPEN_COWORK_CLOUD_PROFILE: 'full' }),
     env: { PATH: process.env.PATH },
     config: BYOK_TEST_CONFIG,
     byokSecrets,
+    observability,
     runtimeFactory() {
       factoryCalls += 1
       throw new Error('runtime factory should not be called')
@@ -334,6 +353,10 @@ test('missing or disabled required BYOK key fails before runtime spawn', async (
     assert.equal(events.some((event) => (
       event.type === 'runtime.error'
       && JSON.stringify(event.payload).includes('requires an active BYOK credential')
+    )), true)
+    assert.equal(metrics.some((metric) => (
+      (metric as Record<string, unknown>).name === 'open_cowork_cloud_byok_reveal_failures_total'
+      && (((metric as Record<string, unknown>).attributes as Record<string, unknown>)?.reason === 'missing_required_byok')
     )), true)
   } finally {
     await runtime.close?.()

--- a/tests/cloud-deployment-artifacts.test.ts
+++ b/tests/cloud-deployment-artifacts.test.ts
@@ -95,6 +95,7 @@ test('cloud deployment docs cover provider-neutral split deployment', () => {
   assert.match(docs, /GET \/healthz/)
   assert.match(docs, /GET \/api\/runtime\/status/)
   assert.match(docs, /GET \/api\/workers\/heartbeats/)
+  assert.match(docs, /GET \/api\/metrics/)
   assert.match(docs, /web app at `\/`/)
   assert.match(docs, /Cloud Web Workbench readiness gates/)
   assert.match(docs, /pnpm test:cloud-web/)
@@ -519,6 +520,9 @@ test('deployment readiness checklist and managed BYOK runbook cover production g
     'quotas/rate limits',
     'OTLP/logging',
     'backups/restore',
+    'deploy/observability/',
+    'docs/runbooks/backup-restore.md',
+    'docs/runbooks/restore-drill-report.md',
     'no billing provider or the stub billing provider',
     'cloud.publicBranding',
     'cloudDesktop',
@@ -556,6 +560,86 @@ test('deployment readiness checklist and managed BYOK runbook cover production g
   const mkdocs = readRepoFile('mkdocs.yml')
   assert.match(mkdocs, /Deployment Readiness: deployment-readiness\.md/)
   assert.match(mkdocs, /Managed BYOK SaaS: runbooks\/managed-byok-saas\.md/)
+  assert.match(mkdocs, /Backup and Restore: runbooks\/backup-restore\.md/)
+  assert.match(mkdocs, /Restore Drill Report: runbooks\/restore-drill-report\.md/)
+})
+
+test('operations observability assets define metrics, dashboards, alerts, and restore drill gates', () => {
+  const packageJson = readRepoFile('package.json')
+  const validator = readRepoFile('scripts/validate-ops-readiness.mjs')
+  const catalog = readRepoFile('deploy/observability/metrics-catalog.json')
+  const alerts = readRepoFile('deploy/observability/prometheus-alerts.yaml')
+  const dashboard = readRepoFile('deploy/observability/grafana-open-cowork-overview.json')
+  const backup = readRepoFile('docs/runbooks/backup-restore.md')
+  const drill = readRepoFile('docs/runbooks/restore-drill-report.md')
+
+  assert.match(packageJson, /"ops:validate": "node scripts\/validate-ops-readiness\.mjs"/)
+  assert.match(validator, /open_cowork_cloud_http_requests_total/)
+  assert.match(validator, /open_cowork_gateway_delivery_dead_letters_total/)
+
+  for (const metric of [
+    'open_cowork_cloud_http_requests_total',
+    'open_cowork_cloud_http_request_duration_ms',
+    'open_cowork_cloud_command_queue_depth',
+    'open_cowork_cloud_command_oldest_age_ms',
+    'open_cowork_cloud_worker_lease_claims_total',
+    'open_cowork_cloud_worker_lease_renewals_total',
+    'open_cowork_cloud_worker_stale_owner_rejections_total',
+    'open_cowork_cloud_scheduler_claims_total',
+    'open_cowork_cloud_projection_lag_events',
+    'open_cowork_cloud_sse_connections',
+    'open_cowork_cloud_quota_rejections_total',
+    'open_cowork_cloud_auth_failures_total',
+    'open_cowork_cloud_byok_reveal_failures_total',
+    'open_cowork_object_store_errors_total',
+    'pg_up',
+    'pg_stat_activity_count',
+    'open_cowork_gateway_deliveries_received_total',
+    'open_cowork_gateway_deliveries_sent_total',
+    'open_cowork_gateway_delivery_retries_total',
+    'open_cowork_gateway_delivery_dead_letters_total',
+    'open_cowork_gateway_session_streams',
+  ]) {
+    assert.match(catalog, new RegExp(metric))
+    assert.match(alerts + dashboard, new RegExp(metric))
+  }
+
+  for (const alert of [
+    'OpenCoworkCloudHighHttpErrorRate',
+    'OpenCoworkWorkerBacklogGrowing',
+    'OpenCoworkSchedulerStalled',
+    'OpenCoworkProjectionLag',
+    'OpenCoworkAuthFailuresSpike',
+    'OpenCoworkQuotaAbuse',
+    'OpenCoworkByokRevealFailures',
+    'OpenCoworkGatewayDeliveryBacklog',
+  ]) {
+    assert.match(alerts, new RegExp(alert))
+  }
+
+  for (const phrase of [
+    'pg_dump',
+    'pg_restore',
+    'aws s3 sync',
+    'gcloud storage rsync',
+    'az storage blob sync',
+    'Restore Drill Report Requirements',
+  ]) {
+    assert.match(backup, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  }
+
+  for (const phrase of [
+    'Postgres restore',
+    'Object-store restore',
+    'Secret/KMS references',
+    'Session projection parity',
+    'Worker recovery',
+    'Scheduler recovery',
+    'Gateway recovery',
+    'Redaction',
+  ]) {
+    assert.match(drill, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  }
 })
 
 test('deployment validation and smoke scripts cover compose, helm, cloud, and gateway checks', () => {
@@ -568,15 +652,20 @@ test('deployment validation and smoke scripts cover compose, helm, cloud, and ga
   assert.match(packageJson, /"deploy:smoke": "node scripts\/smoke-deployment\.mjs"/)
   assert.match(packageJson, /"deploy:gateway:smoke": "pnpm build:gateway && node scripts\/gateway-cloud-smoke\.mjs"/)
   assert.match(packageJson, /"deploy:continuation:smoke": "pnpm build:gateway && pnpm build:shared && node --no-warnings --experimental-strip-types scripts\/cloud-continuation-smoke\.mjs"/)
+  assert.match(packageJson, /"ops:validate": "node scripts\/validate-ops-readiness\.mjs"/)
   assert.match(scriptsReadme, /pnpm deploy:validate/)
   assert.match(scriptsReadme, /pnpm deploy:smoke/)
   assert.match(scriptsReadme, /pnpm deploy:gateway:smoke/)
   assert.match(scriptsReadme, /pnpm deploy:continuation:smoke/)
+  assert.match(scriptsReadme, /pnpm ops:validate/)
   assert.match(validate, /docker-compose\.cloud\.yml/)
   assert.match(validate, /docker-compose\.cloud\.split\.yml/)
   assert.match(validate, /docker-compose\.cloud-gateway\.yml/)
   assert.match(validate, /helm\/open-cowork-cloud/)
   assert.match(validate, /helm\/open-cowork-gateway/)
+  assert.match(validate, /deploy\/observability\/metrics-catalog\.json/)
+  assert.match(validate, /docs\/runbooks\/backup-restore\.md/)
+  assert.match(validate, /docs\/runbooks\/restore-drill-report\.md/)
   assert.match(validate, /unsafe-public-cloud/)
   assert.match(validate, /unsafe-webhook-gateway/)
   assert.match(validate, /unsafe-metrics-gateway/)
@@ -591,6 +680,8 @@ test('deployment validation and smoke scripts cover compose, helm, cloud, and ga
   assert.match(smoke, /\/api\/workspace/)
   assert.match(smoke, /\/api\/runtime\/status/)
   assert.match(smoke, /\/api\/workers\/heartbeats/)
+  assert.match(smoke, /\/api\/metrics/)
+  assert.match(smoke, /checkText/)
   assert.match(smoke, /\/health/)
   assert.match(smoke, /\/ready/)
   const gatewaySmoke = readRepoFile('scripts/gateway-cloud-smoke.mjs')
@@ -615,7 +706,17 @@ test('managed operations runbook covers readiness, rollback, diagnostics, and ga
     'GET /ready',
     'Rollback',
     'Worker Drains',
+    'Web Unavailable Or Erroring',
+    'Worker Backlog',
+    'Scheduler Stalled',
+    'Postgres Connection Exhaustion',
+    'Object-Store Errors',
+    'KMS Or Secret Adapter Errors',
+    'OIDC Outage',
     'Gateway Backlog',
+    'Gateway Provider Outage',
+    'Webhook Abuse',
+    'BYOK Provider Key Failure',
     'Secret Rotation',
     'Diagnostics',
     'API tokens',

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -18,7 +18,7 @@ import {
 import { createHttpSseCloudTransportAdapter } from '../apps/desktop/src/main/cloud/transport-adapter.ts'
 import { CloudWorkspaceAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 import { createInMemoryObjectStore } from '../apps/desktop/src/main/cloud/object-store.ts'
-import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
+import { createPrometheusCloudObservability, type CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
 import { createEnvelopeSecretAdapter } from '../apps/desktop/src/main/cloud/secret-adapter.ts'
 import { createCloudSessionCookieManager } from '../apps/desktop/src/main/cloud/session-cookie-auth.ts'
 import { CloudSessionService, type ByokManagementPolicy, type CloudIdentityPolicy } from '../apps/desktop/src/main/cloud/session-service.ts'
@@ -119,7 +119,7 @@ function createFixture(options: {
   const artifacts = new CloudArtifactService(service, objectStore, {
     randomUUID: () => `artifact-${nextId += 1}`,
   })
-  const worker = new CloudWorker(store, service, 'worker-1', 30_000, {}, options.abuse || null)
+  const worker = new CloudWorker(store, service, 'worker-1', 30_000, {}, options.abuse || null, options.observability || null)
   const server = createCloudHttpServer({
     service,
     artifacts,
@@ -1852,6 +1852,97 @@ test('cloud HTTP server attaches request ids and emits observability records', a
   } finally {
     await fixture.server.close()
   }
+})
+
+test('cloud HTTP server exposes operator-scoped Prometheus metrics', async () => {
+  const memberFixture = createFixture({
+    observability: createPrometheusCloudObservability(),
+    auth: () => ({
+      tenantId: 'tenant-1',
+      tenantName: 'Tenant 1',
+      orgId: 'tenant-1',
+      userId: 'member-1',
+      accountId: 'member-1',
+      email: 'member@example.test',
+      role: 'member',
+      authSource: 'local',
+    }),
+  })
+  const memberBaseUrl = await memberFixture.server.listen()
+  try {
+    const blocked = await fetch(`${memberBaseUrl}/api/metrics`)
+    assert.equal(blocked.status, 403)
+  } finally {
+    await memberFixture.server.close()
+  }
+
+  const observability = createPrometheusCloudObservability()
+  const fixture = createFixture({ observability })
+  const baseUrl = await fixture.server.listen()
+
+  try {
+    const health = await fetch(`${baseUrl}/healthz`)
+    assert.equal(health.status, 200)
+    await health.text()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const metrics = await fetch(`${baseUrl}/api/metrics`)
+    assert.equal(metrics.status, 200)
+    const text = await metrics.text()
+    assert.match(text, /open_cowork_cloud_http_requests_total/)
+    assert.match(text, /open_cowork_cloud_http_request_duration_ms/)
+    assert.doesNotMatch(text, /request-1/)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server emits auth and quota denial metrics', async () => {
+  const metrics: unknown[] = []
+  const observability: CloudObservabilityAdapter = {
+    log() {},
+    metric(record) { metrics.push(record) },
+    span() {},
+  }
+  const authFixture = createFixture({
+    observability,
+    auth: () => {
+      throw new CloudHttpError(401, 'Cloud authentication is required.', { policyCode: 'auth.invalid_token' })
+    },
+  })
+  const authBaseUrl = await authFixture.server.listen()
+  try {
+    const rejected = await fetch(`${authBaseUrl}/api/workspace`)
+    assert.equal(rejected.status, 401)
+    await rejected.text()
+  } finally {
+    await authFixture.server.close()
+  }
+
+  const quotaFixture = createFixture({
+    observability,
+    abuse: testAbuseConfig({
+      httpRateLimit: {
+        enabled: true,
+        windowMs: 60_000,
+        maxRequests: 1,
+      },
+    }),
+  })
+  const quotaBaseUrl = await quotaFixture.server.listen()
+  try {
+    const first = await fetch(`${quotaBaseUrl}/api/workspace`)
+    assert.equal(first.status, 200)
+    await first.text()
+    const second = await fetch(`${quotaBaseUrl}/api/workspace`)
+    assert.equal(second.status, 429)
+    await second.text()
+  } finally {
+    await quotaFixture.server.close()
+  }
+
+  assert.equal(metrics.some((metric) => (metric as Record<string, unknown>).name === 'open_cowork_cloud_auth_failures_total'), true)
+  assert.equal(metrics.some((metric) => (metric as Record<string, unknown>).name === 'open_cowork_cloud_quota_rejections_total'), true)
 })
 
 test('cloud HTTP browser session cookies use secure flags and enforce CSRF on mutating routes', async () => {

--- a/tests/cloud-observability.test.ts
+++ b/tests/cloud-observability.test.ts
@@ -5,6 +5,7 @@ import {
   createCloudObservabilityFromEnv,
   createConsoleCloudObservability,
   createOtlpHttpCloudObservability,
+  createPrometheusCloudObservability,
   recordCloudHttpRequest,
   sanitizeCloudObservabilityAttributes,
   type CloudObservabilityAdapter,
@@ -18,6 +19,7 @@ test('cloud observability sanitizes secret-bearing attributes', () => {
     nested_secret: 'private',
     object_store_url: 'https://bucket.s3.amazonaws.com/private/file.txt?X-Amz-Signature=private',
     local_path: '/Users/alice/acme-private',
+    byok_error: 'provider failed for Bearer raw-token and user alice@example.test at /home/alice/project',
     count: 2,
     ok: true,
   }), {
@@ -27,6 +29,7 @@ test('cloud observability sanitizes secret-bearing attributes', () => {
     nested_secret: '[redacted]',
     object_store_url: 'https://bucket.s3.amazonaws.com/private/file.txt?[redacted]',
     local_path: '/Users/[redacted]',
+    byok_error: 'provider failed for Bearer [redacted] and user [redacted-email] at /home/[redacted]',
     count: 2,
     ok: true,
   })
@@ -44,7 +47,7 @@ test('cloud console observability writes structured JSON records', async () => {
   await adapter.log({
     level: 'info',
     name: 'cloud.test',
-    message: 'hello',
+    message: 'hello Bearer private-token from /Users/alice/acme',
     attributes: {
       request_id: 'req-1',
       token: 'private-token',
@@ -55,6 +58,7 @@ test('cloud console observability writes structured JSON records', async () => {
   assert.equal(parsed.ts, '2026-01-01T00:00:00.000Z')
   assert.equal(parsed.level, 'info')
   assert.equal(parsed.name, 'cloud.test')
+  assert.equal(parsed.message, 'hello Bearer [redacted] from /Users/[redacted]')
   assert.equal((parsed.attributes as Record<string, unknown>)['service.name'], 'open-cowork-cloud-test')
   assert.equal((parsed.attributes as Record<string, unknown>)['service.version'], '1.2.3')
   assert.equal((parsed.attributes as Record<string, unknown>).token, '[redacted]')
@@ -86,6 +90,38 @@ test('cloud HTTP request observation emits log, metric, and span records', async
   assert.equal((metrics[0] as Record<string, unknown>).value, 42)
   assert.equal((spans[0] as Record<string, unknown>).name, 'cloud.http.request')
   assert.equal((spans[0] as Record<string, unknown>).status, 'ok')
+})
+
+test('cloud Prometheus observability renders low-cardinality product metrics', async () => {
+  const adapter = createPrometheusCloudObservability()
+  await adapter.metric({
+    name: 'open_cowork_cloud_http_requests_total',
+    value: 1,
+    attributes: {
+      request_id: 'request-1',
+      session_id: 'session-1',
+      'http.request.method': 'GET',
+      'url.path': '/api/workspace',
+      token: 'secret-token',
+    },
+  })
+  await adapter.metric({
+    name: 'open_cowork_cloud_http_requests_total',
+    value: 1,
+    attributes: {
+      request_id: 'request-2',
+      session_id: 'session-2',
+      'http.request.method': 'GET',
+      'url.path': '/api/workspace',
+      token: 'secret-token',
+    },
+  })
+  const text = adapter.renderPrometheus?.() || ''
+  assert.match(text, /# TYPE open_cowork_cloud_http_requests_total counter/)
+  assert.match(text, /open_cowork_cloud_http_requests_total\{http_request_method="GET",token="\[redacted\]",url_path="\/api\/workspace"\} 2/)
+  assert.equal(text.includes('request-1'), false)
+  assert.equal(text.includes('session-1'), false)
+  assert.equal(text.includes('secret-token'), false)
 })
 
 test('cloud OTLP observability exports trace and metric payloads with headers', async () => {


### PR DESCRIPTION
Closes #500

## Summary
- add cloud Prometheus metrics rendering plus operator-scoped /api/metrics
- add gateway operational metrics and redacted diagnostics coverage
- add observability catalog, Prometheus alerts, Grafana dashboard, ops validation script, and recovery runbooks
- expand deployment smoke/validation checks for metrics and backup/restore readiness

## Verification
- pnpm ops:validate
- pnpm deploy:validate
- node --no-warnings --experimental-strip-types --test tests/cloud-observability.test.ts tests/cloud-http-server.test.ts tests/cloud-deployment-artifacts.test.ts
- pnpm --filter @open-cowork/gateway test
- pnpm typecheck
- pnpm lint
- pnpm docs:build
- git diff --check
- pnpm test