### PR TITLE
Add private beta launch package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,9 @@ jobs:
       - name: Run launch readiness validator
         run: pnpm deploy:launch:validate
 
+      - name: Run private beta launch package validator
+        run: pnpm deploy:private-beta:validate
+
   # Run the desktop smoke suite and package the app on macOS so
   # platform-specific regressions (IPC, renderer boot, native modules,
   # packaging hooks) surface on every PR instead of only when we cut a

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -92,7 +92,10 @@ Reusable observability assets live under `deploy/observability/`:
   delivery failures.
 
 See `docs/deployment-readiness.md` for the production checklist and
-`docs/runbooks/managed-byok-saas.md` for hosted BYOK operations.
+`docs/runbooks/managed-byok-saas.md` for hosted BYOK operations. For a managed
+BYOK private beta, use `docs/runbooks/private-beta-launch.md`,
+`docs/runbooks/private-beta-support.md`, and `deploy/private-beta/` before
+inviting design partners.
 
 ## Validation
 
@@ -100,6 +103,12 @@ Validate local manifests and Helm guardrails:
 
 ```bash
 pnpm deploy:validate
+```
+
+Validate the managed BYOK private beta launch package and OSS boundary:
+
+```bash
+pnpm deploy:private-beta:validate
 ```
 
 Smoke a running deployment:

--- a/deploy/private-beta/README.md
+++ b/deploy/private-beta/README.md
@@ -1,0 +1,56 @@
+# Private Beta Deployment Package
+
+This directory contains launch-package examples for managed BYOK private beta
+and OSS self-host deployment.
+
+Files:
+
+- `hosted-byok.config.example.json`: managed BYOK SaaS-style config with OIDC,
+  closed/invite signup posture, Desktop cloud connection, managed Gateway, stub
+  private beta billing, quotas, and placeholder secret refs.
+- `self-host-oss.config.example.json`: OSS self-host config with optional stub
+  billing, self-host Gateway, and placeholder secret refs.
+- `private-beta-plans.json`: plan and entitlement placeholders for private
+  beta. It intentionally carries no prices or commercial assumptions.
+
+These examples are provider-neutral. They use placeholder domains such as
+`cowork.example.com`, placeholder secret refs such as
+`env:OPEN_COWORK_CLOUD_DATABASE_URL`, and placeholder plan keys. Do not replace
+them with real provider project ids or customer values in the repository.
+
+## Hosted Managed BYOK
+
+The hosted path is for an operator-managed private beta:
+
+1. Deploy Cloud Web, worker, scheduler, Postgres, object storage, secret
+   adapter/KMS, observability, backups, and Gateway.
+2. Set Cloud role selection in Compose, Helm, or role-specific environment
+   variables. Keep the shared config examples focused on product policy and
+   launch posture.
+3. Set `cloud.auth.signupMode` to `closed` or `invite`.
+4. Keep `cloud.billing.provider` as `stub` or manual operational state until
+   self-serve billing is intentionally enabled.
+5. Configure BYOK and quotas per org.
+6. Preconfigure Desktop with the managed cloud URL.
+7. Store Gateway service tokens and channel credentials in platform secrets.
+
+## OSS Self-Host
+
+The self-host path must remain usable without managed-only services:
+
+1. Deploy Compose or Helm from this repo.
+2. Use `cloud.billing.provider=none` or `stub`.
+3. Bring your own Postgres, object storage, and secret manager/KMS.
+4. Run Gateway with a scoped cloud service token.
+5. Configure branding, OIDC, profiles, quotas, and providers without code
+   changes.
+
+Run:
+
+```bash
+pnpm deploy:private-beta:validate
+pnpm deploy:validate
+pnpm deploy:launch:validate
+```
+
+before inviting design partners.

--- a/deploy/private-beta/hosted-byok.config.example.json
+++ b/deploy/private-beta/hosted-byok.config.example.json
@@ -1,0 +1,223 @@
+{
+  "$schema": "../../open-cowork.config.schema.json",
+  "allowedEnvPlaceholders": [
+    "OPEN_COWORK_CLOUD_DATABASE_URL",
+    "OPEN_COWORK_CLOUD_OBJECT_STORE_CREDENTIALS",
+    "OPEN_COWORK_CLOUD_COOKIE_SECRET",
+    "OPEN_COWORK_CLOUD_OIDC_CLIENT_SECRET",
+    "OPEN_COWORK_GATEWAY_SERVICE_TOKEN",
+    "OPEN_COWORK_GATEWAY_ADMIN_TOKEN"
+  ],
+  "branding": {
+    "name": "Open Cowork",
+    "appId": "com.example.open-cowork.privatebeta",
+    "dataDirName": "open-cowork-private-beta",
+    "helpUrl": "https://support.example.com/open-cowork",
+    "projectNamespace": "open-cowork-private-beta",
+    "sidebar": {
+      "top": {
+        "variant": "text",
+        "title": "Open Cowork",
+        "subtitle": "Private beta"
+      },
+      "lower": {
+        "text": "Managed BYOK private beta",
+        "linkLabel": "Support",
+        "linkUrl": "https://support.example.com/open-cowork"
+      }
+    }
+  },
+  "auth": {
+    "mode": "none"
+  },
+  "providers": {
+    "available": [],
+    "defaultProvider": null,
+    "defaultModel": null
+  },
+  "tools": [],
+  "skills": [],
+  "mcps": [],
+  "agents": [],
+  "permissions": {
+    "bash": "ask",
+    "fileWrite": "ask",
+    "task": "allow",
+    "web": "allow",
+    "webSearch": true
+  },
+  "cloud": {
+    "defaultProfile": "focused-agent",
+    "publicBranding": {
+      "productName": "Open Cowork Private Beta",
+      "shortName": "OC",
+      "logoUrl": "https://assets.example.com/open-cowork/logo.png",
+      "supportUrl": "https://support.example.com/open-cowork",
+      "privacyUrl": "https://legal.example.com/privacy",
+      "securityUrl": "https://security.example.com/open-cowork",
+      "legalUrl": "https://legal.example.com/terms",
+      "dashboard": {
+        "title": "Open Cowork private beta",
+        "subtitle": "Manage BYOK, desktop sync, and gateway access for your org.",
+        "byokDescription": "Add provider keys for your org. Keys are write-only from user surfaces.",
+        "connectionsDescription": "Issue scoped Desktop and API tokens for approved users.",
+        "gatewayDescription": "Connect approved channels through managed gateway bindings.",
+        "billingDescription": "Private beta billing is manual or stubbed until self-serve billing is enabled."
+      },
+      "managedOrgConnectionLabels": {
+        "desktopToken": "Desktop private beta token",
+        "gatewayToken": "Gateway private beta token",
+        "apiToken": "Private beta API token",
+        "cloudUrl": "Private beta cloud URL"
+      }
+    },
+    "auth": {
+      "mode": "oidc",
+      "issuerUrl": "https://idp.example.com",
+      "clientId": "open-cowork-private-beta",
+      "clientSecretRef": "env:OPEN_COWORK_CLOUD_OIDC_CLIENT_SECRET",
+      "cookieSecretRef": "env:OPEN_COWORK_CLOUD_COOKIE_SECRET",
+      "signupMode": "invite",
+      "allowSelfServiceSignup": false,
+      "allowedEmailDomains": ["example.com"]
+    },
+    "storage": {
+      "controlPlane": {
+        "kind": "postgres",
+        "urlRef": "env:OPEN_COWORK_CLOUD_DATABASE_URL"
+      },
+      "objectStore": {
+        "kind": "s3",
+        "bucket": "open-cowork-private-beta-artifacts",
+        "region": "us-east-1",
+        "prefix": "private-beta/",
+        "credentialsRef": "env:OPEN_COWORK_CLOUD_OBJECT_STORE_CREDENTIALS"
+      }
+    },
+    "runtime": {
+      "configSource": "app",
+      "launcher": "node",
+      "allowMachineRuntimeConfig": false,
+      "allowLocalStdioMcps": false,
+      "allowHostProjectDirectories": false,
+      "allowedLocalMcpNames": [],
+      "allowedHostProjectDirectories": []
+    },
+    "features": {
+      "chat": true,
+      "agents": true,
+      "artifacts": true,
+      "threadIndex": true,
+      "workflows": true,
+      "webhooks": true,
+      "settings": true,
+      "customSkills": true,
+      "customAgents": true,
+      "customMcps": false
+    },
+    "profiles": {
+      "focused-agent": {
+        "label": "Focused agent",
+        "description": "Private beta profile for one approved agent and cloud-safe tools.",
+        "agents": ["general"],
+        "tools": ["bash", "edit", "web"],
+        "mcps": [],
+        "runtime": {
+          "configSource": "app",
+          "launcher": "node",
+          "allowMachineRuntimeConfig": false,
+          "allowLocalStdioMcps": false,
+          "allowHostProjectDirectories": false,
+          "allowedLocalMcpNames": [],
+          "allowedHostProjectDirectories": []
+        }
+      }
+    },
+    "abuse": {
+      "enabled": true,
+      "maxConcurrentSessionsPerOrg": 12,
+      "maxActiveWorkersPerOrg": 4,
+      "maxPromptsPerHour": 240,
+      "maxGatewayDeliveriesPerHour": 600,
+      "maxArtifactBytesPerDay": 1073741824,
+      "httpRateLimit": {
+        "enabled": true,
+        "windowMs": 60000,
+        "maxRequests": 900
+      },
+      "authBackoff": {
+        "enabled": true,
+        "windowMs": 600000,
+        "maxFailures": 12,
+        "backoffMs": 300000
+      }
+    },
+    "billing": {
+      "enabled": true,
+      "provider": "stub",
+      "defaultPlanKey": "private-beta-design-partner",
+      "plans": {
+        "private-beta-design-partner": {
+          "label": "Private beta design partner",
+          "entitlements": {
+            "allowedProfiles": ["focused-agent"],
+            "allowedProviders": null,
+            "maxConcurrentSessionsPerOrg": 12,
+            "maxActiveWorkersPerOrg": 4,
+            "maxPromptsPerHour": 240,
+            "maxGatewayDeliveriesPerHour": 600,
+            "maxArtifactBytesPerDay": 1073741824,
+            "allowNewSessions": true,
+            "allowPrompts": true,
+            "allowWorkers": true
+          }
+        }
+      }
+    }
+  },
+  "cloudDesktop": {
+    "enabled": true,
+    "allowUserAddedConnections": false,
+    "preconfiguredConnections": [
+      {
+        "baseUrl": "https://cowork.example.com",
+        "label": "Open Cowork Private Beta"
+      }
+    ],
+    "requireManagedOrg": true,
+    "cacheMode": "metadata-only",
+    "cacheEncryptionFallback": "fail-startup"
+  },
+  "gateway": {
+    "branding": {
+      "productName": "Open Cowork Private Beta",
+      "shortName": "OC",
+      "supportUrl": "https://support.example.com/open-cowork",
+      "privacyUrl": "https://legal.example.com/privacy",
+      "securityUrl": "https://security.example.com/open-cowork",
+      "legalUrl": "https://legal.example.com/terms"
+    },
+    "cloud": {
+      "baseUrl": "https://cowork.example.com",
+      "serviceToken": "{env:OPEN_COWORK_GATEWAY_SERVICE_TOKEN}",
+      "allowInsecureHttp": false
+    },
+    "server": {
+      "host": "0.0.0.0",
+      "port": 8790,
+      "publicBaseUrl": "https://gateway.example.com",
+      "adminToken": "{env:OPEN_COWORK_GATEWAY_ADMIN_TOKEN}"
+    },
+    "mode": "managed",
+    "logging": {
+      "level": "info"
+    },
+    "metrics": {
+      "enabled": true
+    },
+    "diagnostics": {
+      "enabled": false
+    },
+    "providers": []
+  }
+}

--- a/deploy/private-beta/private-beta-plans.json
+++ b/deploy/private-beta/private-beta-plans.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "purpose": "private-beta-placeholder",
+  "billingMode": "manual-or-stub",
+  "currency": null,
+  "prices": [],
+  "plans": [
+    {
+      "planKey": "private-beta-design-partner",
+      "label": "Private beta design partner",
+      "billingMode": "manual",
+      "notes": "Manual invoice or no-charge design partner agreement. No token resale.",
+      "entitlements": {
+        "allowedProfiles": ["general", "focused-agent"],
+        "allowedProviders": null,
+        "maxConcurrentSessionsPerOrg": 12,
+        "maxActiveWorkersPerOrg": 4,
+        "maxPromptsPerHour": 240,
+        "maxGatewayDeliveriesPerHour": 600,
+        "maxArtifactBytesPerDay": 1073741824,
+        "allowNewSessions": true,
+        "allowPrompts": true,
+        "allowWorkers": true
+      }
+    },
+    {
+      "planKey": "private-beta-internal",
+      "label": "Private beta internal",
+      "billingMode": "stub",
+      "notes": "Internal dogfood or OSS self-host validation profile.",
+      "entitlements": {
+        "allowedProfiles": null,
+        "allowedProviders": null,
+        "maxConcurrentSessionsPerOrg": 24,
+        "maxActiveWorkersPerOrg": 8,
+        "maxPromptsPerHour": 600,
+        "maxGatewayDeliveriesPerHour": 1200,
+        "maxArtifactBytesPerDay": 2147483648,
+        "allowNewSessions": true,
+        "allowPrompts": true,
+        "allowWorkers": true
+      }
+    }
+  ]
+}

--- a/deploy/private-beta/self-host-oss.config.example.json
+++ b/deploy/private-beta/self-host-oss.config.example.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "../../open-cowork.config.schema.json",
+  "allowedEnvPlaceholders": [
+    "OPEN_COWORK_CLOUD_DATABASE_URL",
+    "OPEN_COWORK_CLOUD_OBJECT_STORE_CREDENTIALS",
+    "OPEN_COWORK_CLOUD_COOKIE_SECRET",
+    "OPEN_COWORK_GATEWAY_SERVICE_TOKEN",
+    "OPEN_COWORK_GATEWAY_ADMIN_TOKEN",
+    "OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET"
+  ],
+  "branding": {
+    "name": "Open Cowork Self Host",
+    "appId": "com.example.open-cowork.selfhost",
+    "dataDirName": "open-cowork-self-host",
+    "helpUrl": "https://support.example.com/open-cowork",
+    "projectNamespace": "open-cowork-self-host"
+  },
+  "auth": {
+    "mode": "none"
+  },
+  "providers": {
+    "available": [],
+    "defaultProvider": null,
+    "defaultModel": null
+  },
+  "tools": [],
+  "skills": [],
+  "mcps": [],
+  "agents": [],
+  "permissions": {
+    "bash": "ask",
+    "fileWrite": "ask",
+    "task": "allow",
+    "web": "allow",
+    "webSearch": true
+  },
+  "cloud": {
+    "defaultProfile": "general",
+    "publicBranding": {
+      "productName": "Open Cowork Self Host",
+      "shortName": "OC",
+      "supportUrl": "https://support.example.com/open-cowork",
+      "privacyUrl": "https://legal.example.com/privacy",
+      "securityUrl": "https://security.example.com/open-cowork",
+      "legalUrl": "https://legal.example.com/terms"
+    },
+    "auth": {
+      "mode": "oidc",
+      "issuerUrl": "https://idp.example.com",
+      "clientId": "open-cowork-self-host",
+      "cookieSecretRef": "env:OPEN_COWORK_CLOUD_COOKIE_SECRET",
+      "signupMode": "domain",
+      "allowSelfServiceSignup": false,
+      "allowedEmailDomains": ["example.com"]
+    },
+    "storage": {
+      "controlPlane": {
+        "kind": "postgres",
+        "urlRef": "env:OPEN_COWORK_CLOUD_DATABASE_URL"
+      },
+      "objectStore": {
+        "kind": "s3",
+        "bucket": "open-cowork-self-host-artifacts",
+        "region": "us-east-1",
+        "prefix": "self-host/",
+        "credentialsRef": "env:OPEN_COWORK_CLOUD_OBJECT_STORE_CREDENTIALS"
+      }
+    },
+    "runtime": {
+      "configSource": "app",
+      "launcher": "node",
+      "allowMachineRuntimeConfig": false,
+      "allowLocalStdioMcps": false,
+      "allowHostProjectDirectories": false,
+      "allowedLocalMcpNames": [],
+      "allowedHostProjectDirectories": []
+    },
+    "features": {
+      "chat": true,
+      "agents": true,
+      "artifacts": true,
+      "threadIndex": true,
+      "workflows": true,
+      "webhooks": true,
+      "settings": true,
+      "customSkills": true,
+      "customAgents": true,
+      "customMcps": true
+    },
+    "profiles": {
+      "general": {
+        "label": "General",
+        "description": "Self-host profile controlled by the downstream deployer.",
+        "agents": ["general"],
+        "tools": [],
+        "mcps": []
+      }
+    },
+    "abuse": {
+      "enabled": true,
+      "maxConcurrentSessionsPerOrg": 24,
+      "maxActiveWorkersPerOrg": 8,
+      "maxPromptsPerHour": 600,
+      "maxGatewayDeliveriesPerHour": 1200,
+      "maxArtifactBytesPerDay": 2147483648
+    },
+    "billing": {
+      "enabled": false,
+      "provider": "none",
+      "defaultPlanKey": "self-host"
+    }
+  },
+  "cloudDesktop": {
+    "enabled": true,
+    "allowUserAddedConnections": true,
+    "preconfiguredConnections": [
+      {
+        "baseUrl": "https://cowork.example.com",
+        "label": "Self-host Open Cowork"
+      }
+    ],
+    "requireManagedOrg": false,
+    "cacheMode": "full",
+    "cacheEncryptionFallback": "metadata-only"
+  },
+  "gateway": {
+    "branding": {
+      "productName": "Open Cowork Self Host",
+      "shortName": "OC",
+      "supportUrl": "https://support.example.com/open-cowork"
+    },
+    "cloud": {
+      "baseUrl": "https://cowork.example.com",
+      "serviceToken": "{env:OPEN_COWORK_GATEWAY_SERVICE_TOKEN}",
+      "allowInsecureHttp": false
+    },
+    "server": {
+      "host": "0.0.0.0",
+      "port": 8790,
+      "publicBaseUrl": "https://gateway.example.com",
+      "adminToken": "{env:OPEN_COWORK_GATEWAY_ADMIN_TOKEN}"
+    },
+    "mode": "self-host",
+    "metrics": {
+      "enabled": true
+    },
+    "diagnostics": {
+      "enabled": false
+    },
+    "providers": [
+      {
+        "id": "self-host-webhook",
+        "kind": "webhook",
+        "channelBindingId": "self-host-webhook",
+        "credentials": {
+          "sharedSecret": "{env:OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET}"
+        },
+        "settings": {
+          "deliveryUrl": "https://bridge.example.com/open-cowork/inbound"
+        }
+      }
+    ]
+  }
+}

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -43,6 +43,10 @@ roles and shared Postgres/object storage.
 - Use `cloud.billing.provider=none` or `stub` for OSS self-host deployments.
   Stripe or future billing adapters are managed-hosting configuration, not a
   core runtime dependency.
+- For managed BYOK private beta, use
+  `docs/runbooks/private-beta-launch.md`, `docs/runbooks/private-beta-support.md`,
+  and `deploy/private-beta/` to keep onboarding, support, plan placeholders,
+  and OSS self-host boundaries explicit before inviting design partners.
 - Run schema and semantic validation for downstream configs before rollout:
   `node --no-warnings --experimental-strip-types --test tests/config-schema-validation.test.ts`.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -19,6 +19,7 @@ Reference workflows in the repository root:
 - [ ] `pnpm lint`
 - [ ] `pnpm perf:check`
 - [ ] `pnpm deploy:launch:validate`
+- [ ] `pnpm deploy:private-beta:validate`
 - [ ] perf baseline environment is intentional; refresh
       the environment-specific `benchmarks/perf-baseline.*.json` on the
       target CI runner with `pnpm perf:baseline` after Node, runner OS,
@@ -81,6 +82,9 @@ Reference workflows in the repository root:
 
 - [ ] `pnpm deploy:load:plan` has been reviewed for the selected
       `private-beta` or `public-beta` target profile.
+- [ ] for managed BYOK private beta, `pnpm deploy:private-beta:validate`
+      passed and `docs/runbooks/private-beta-launch.md` has an owner,
+      design-partner checklist, support path, and known limits.
 - [ ] `pnpm deploy:load` passed in strict mode against the production-like
       Cloud/Gateway deployment.
 - [ ] `pnpm deploy:soak` passed in strict mode against the production-like

--- a/docs/runbooks/managed-byok-saas.md
+++ b/docs/runbooks/managed-byok-saas.md
@@ -138,6 +138,9 @@ new key as failed metadata only when that is safe for the provider.
 Private beta can run with manual billing, closed/invite org signup mode, and a
 small number of managed gateway channels. Public self-serve requires:
 
+- the private beta launch package in `docs/runbooks/private-beta-launch.md`
+  and `deploy/private-beta/` has been validated with
+  `pnpm deploy:private-beta:validate`,
 - signup mode explicitly set,
 - token TTLs enforced,
 - invite/domain controls documented,

--- a/docs/runbooks/private-beta-launch.md
+++ b/docs/runbooks/private-beta-launch.md
@@ -1,0 +1,232 @@
+---
+title: Private Beta Launch Package
+description: Managed BYOK private beta checklist for Open Cowork Cloud, Desktop sync, and Gateway.
+---
+
+# Private Beta Launch Package
+
+Use this runbook to onboard design partners onto a managed BYOK Open Cowork
+private beta while keeping the OSS self-host path first-class. It turns the
+deployment, security, launch-readiness, and support runbooks into one operator
+checklist.
+
+Private beta is a managed service posture, not a different product fork:
+
+- Desktop local workspaces stay local.
+- Desktop cloud workspaces sync through Open Cowork Cloud.
+- Cloud Web, Desktop cloud workspaces, and Gateway all continue the same cloud
+  sessions through the shared control plane.
+- Gateway is a channel client and delivery adapter, not an OpenCode runtime.
+- Users bring provider keys. Open Cowork does not resell model tokens.
+- Billing can be manual or stubbed during private beta.
+- OSS self-hosters can run Cloud and Gateway without Stripe or managed-only
+  dependencies.
+
+## Launch Scope
+
+Private beta includes:
+
+- managed Open Cowork Cloud Web and API,
+- split web, worker, and scheduler roles,
+- managed object storage, Postgres, secret adapter/KMS, observability, backups,
+  and restore process,
+- Desktop cloud workspace connection,
+- Gateway for approved channels,
+- BYOK setup and status,
+- quotas, usage summaries, audit logs, diagnostics, and support workflow.
+
+Private beta excludes:
+
+- public self-serve signup,
+- public self-serve Stripe checkout as a launch blocker,
+- enterprise compliance certification,
+- implicit migration of local Desktop threads or local project files,
+- arbitrary local stdio MCPs, host paths, or machine OpenCode config in cloud.
+
+## Product Promise
+
+Before inviting a design partner, the operator must be able to demonstrate:
+
+1. Create a cloud thread in Cloud Web.
+2. Continue that thread from Desktop cloud workspace.
+3. Continue or receive updates through Gateway.
+4. Submit a BYOK provider key and see only status metadata after save.
+5. Trigger approval/question flow from one surface and resolve from another.
+6. Upload or create an artifact in cloud and retrieve it from another surface.
+7. Revoke a Desktop or Gateway token and see access stop on the next request or
+   SSE reconnect.
+8. Keep a local Desktop workspace usable while the cloud workspace is offline.
+
+## Managed BYOK Onboarding Checklist
+
+Complete each item for every design partner.
+
+### 1. Account And Org
+
+- [ ] Confirm the partner has accepted private beta terms and the support path.
+- [ ] Create or approve the org in `closed` or `invite` signup mode.
+- [ ] Assign one owner and at least one admin/member as appropriate.
+- [ ] Confirm IdP email domain, role mapping, and membership are correct.
+- [ ] Record org id, owner email, plan key, support contact, and launch date in
+      the private operations tracker.
+- [ ] Confirm audit events are written for membership, token, BYOK, billing,
+      gateway, and support-sensitive actions.
+
+### 2. BYOK Setup
+
+- [ ] Explain that provider usage is billed by the provider to the user's key.
+- [ ] Save the provider key through the BYOK endpoint or dashboard.
+- [ ] Confirm read APIs return only provider, status, last4/fingerprint,
+      health, and timestamps.
+- [ ] Run bounded provider validation from the worker role.
+- [ ] Confirm no raw key material appears in logs, diagnostics, browser state,
+      Desktop cache, Gateway logs, or launch reports.
+- [ ] Document the provider id and status. Do not record the plaintext key.
+
+### 3. Desktop Connection
+
+- [ ] Issue a scoped Desktop token or complete OIDC Desktop login.
+- [ ] Confirm Desktop connects to the managed cloud URL over HTTPS.
+- [ ] Confirm session list, create, prompt, abort, SSE, cache hydration, and
+      offline read-only behavior.
+- [ ] Confirm local workspace remains available with no cloud dependency.
+- [ ] Revoke the test token and prove it stops working.
+
+### 4. Gateway And Channels
+
+- [ ] Create a headless agent/channel binding for the org.
+- [ ] Store channel credentials in the gateway secret store or platform secret
+      manager.
+- [ ] Confirm public channel webhooks require provider signatures or
+      timestamped HMAC/shared-secret auth.
+- [ ] Confirm fake provider is disabled outside local/demo contexts.
+- [ ] Send a message through the channel, bind or create a cloud session, and
+      verify SSE rendering back to the channel.
+- [ ] Resolve a permission approval or question from the channel.
+- [ ] Verify async/proactive delivery and retry/dead-letter visibility.
+
+### 5. Billing And Quotas
+
+- [ ] Assign a private beta plan key from
+      `deploy/private-beta/private-beta-plans.json`.
+- [ ] Keep billing mode manual or stubbed unless a signed billing adapter is
+      intentionally enabled.
+- [ ] Confirm subscription or entitlement state allows intended beta usage.
+- [ ] Configure quota caps for concurrent sessions, workers, prompts, gateway
+      deliveries, and artifact bytes.
+- [ ] Run the ordinary launch-readiness gate with zero unexpected quota
+      rejections.
+- [ ] Run a deliberate quota-pressure pass and confirm clear 429/402 responses
+      without 5xx spikes.
+
+### 6. Final Smoke
+
+Run the same deployment:
+
+```bash
+pnpm deploy:smoke
+pnpm deploy:desktop:smoke
+pnpm deploy:gateway:smoke
+pnpm deploy:continuation:smoke
+pnpm deploy:load
+pnpm deploy:soak
+```
+
+Attach the generated load/soak reports and final Web/Desktop/Gateway smoke
+evidence to the private operations tracker. Keep project ids, bucket names,
+secrets, tokens, BYOK values, and customer identifiers out of committed
+reports.
+
+## Hosted BYOK Setup Flow
+
+The design partner path should be documented and repeatable without engineering
+tribal knowledge:
+
+1. Operator creates or approves the org.
+2. User signs in through the configured IdP.
+3. User or operator adds BYOK provider key.
+4. Operator validates BYOK status and quotas.
+5. User connects Desktop to the managed cloud URL.
+6. Operator creates Gateway channel binding or gives user a scoped Gateway
+   setup token.
+7. User validates Web, Desktop, and Gateway continuation.
+8. Operator records support contact, known limits, and expected response time.
+
+## OSS Self-Host Equivalent
+
+Self-hosters must be able to run the same product without commercial services:
+
+- Compose: `docker-compose.cloud.yml`, `docker-compose.cloud.split.yml`, and
+  `docker-compose.cloud-gateway.yml`.
+- Helm: `helm/open-cowork-cloud` and `helm/open-cowork-gateway`.
+- Billing: `cloud.billing.provider=none` or `stub`.
+- Secrets: self-managed platform secrets, environment refs, KMS refs, or local
+  secret adapter choices.
+- Object storage: S3, GCS, Azure Blob, DigitalOcean Spaces, compatible S3, or
+  local filesystem for single-node demos.
+- Gateway: self-hosted process with a scoped cloud service token and provider
+  webhook secrets.
+- Support: self-owned unless a managed support agreement exists.
+
+Self-hosting must not require Stripe, a managed dashboard account, a hosted
+gateway, or a provider-specific cloud project in core code.
+
+## Managed Vs Self-Host Responsibilities
+
+| Area | Managed private beta | OSS self-host |
+| --- | --- | --- |
+| Cloud hosting | Operator runs web, worker, scheduler, Postgres, object storage, secrets, backups, and observability. | Deployer runs the same components on their own infrastructure. |
+| BYOK | User supplies keys; operator stores encrypted metadata and validates status. | Deployer chooses secret adapter/KMS and owns provider-key handling. |
+| Billing | Manual or stubbed private beta plan is acceptable. | Disabled/stub billing is supported and should not block product usage. |
+| Gateway | Operator may run managed channel bindings. | Deployer runs gateway with their own tokens and channel credentials. |
+| Support | Operator triages sync, BYOK, gateway, quota, and account issues. | Deployer owns local operations unless they buy support. |
+| Data retention | Operator documents retention and deletion process. | Deployer owns retention policy. |
+| Branding | Hosted product uses operator branding and support links. | Downstream can configure name, logo, legal links, support links, and profiles. |
+
+## Security Posture
+
+- BYOK plaintext is write-only from user surfaces and reveal-only inside the
+  worker role.
+- Raw provider keys, OAuth refresh tokens, API tokens, MCP secrets, channel
+  credentials, signed object-store URLs, and cookie secrets must not appear in
+  payloads, cache, logs, diagnostics, launch reports, or renderer state.
+- Tenant isolation is enforced through org membership, token scopes, durable
+  store filters, object-store prefixes, audit rows, and gateway identity
+  resolution.
+- Public cloud uses OIDC or signed trusted header auth behind a trusted proxy.
+- Public gateway ingress requires provider signatures or timestamped HMAC.
+- Diagnostics bundles are redacted before sharing with support.
+- Local Desktop threads, local files, local stdio MCPs, and machine runtime
+  config are never uploaded implicitly.
+
+## Known Private Beta Constraints
+
+Document the exact constraints for each design partner. At minimum:
+
+- accepted provider ids,
+- accepted cloud project-source types,
+- supported Gateway providers,
+- quota caps,
+- billing/manual invoice state,
+- support hours and escalation path,
+- restore-point objective and restore-time objective,
+- whether managed channel bindings are shared or dedicated,
+- what data retention and deletion process applies.
+
+## Go/No-Go
+
+Private beta is a **go** only when:
+
+- `pnpm deploy:private-beta:validate` passes,
+- `pnpm deploy:launch:validate` passes,
+- docs build strictly,
+- hosted and self-host package examples validate,
+- Web/Desktop/Gateway smoke passes against the same deployment,
+- load and soak gates pass for `private-beta`,
+- BYOK redaction checks pass,
+- support runbook is current,
+- known limits are documented,
+- there is an owner for every launch-day alert.
+
+If any required smoke, security, support, or recovery evidence is missing, the
+launch remains conditional and should not invite new design partners.

--- a/docs/runbooks/private-beta-support.md
+++ b/docs/runbooks/private-beta-support.md
@@ -1,0 +1,121 @@
+---
+title: Private Beta Support Runbook
+description: Support workflow for managed BYOK private beta onboarding and incidents.
+---
+
+# Private Beta Support Runbook
+
+Use this runbook for managed BYOK private beta support. It is intentionally
+designed to work without asking users to expose secrets.
+
+## Support Intake
+
+Collect:
+
+- org id or org slug,
+- user email or channel identity,
+- surface: Cloud Web, Desktop cloud workspace, local Desktop workspace, Gateway,
+  BYOK, billing/quota, or admin dashboard,
+- session id, run id, workflow id, artifact id, or channel delivery id when
+  available,
+- timestamp and timezone,
+- expected behavior and observed behavior,
+- whether the issue blocks all work or one surface,
+- redacted diagnostics bundle or launch-readiness report if available.
+
+Do not request:
+
+- provider API keys,
+- OAuth refresh/access tokens,
+- Desktop cloud tokens,
+- Gateway service tokens,
+- channel signing secrets,
+- cookie secrets,
+- database URLs,
+- object-store signed URLs,
+- full local filesystem paths unless the user intentionally shares a redacted
+  path for a local-only issue.
+
+## Triage Matrix
+
+| Symptom | First checks | Escalation |
+| --- | --- | --- |
+| Cannot sign in | IdP status, org membership, signup mode, cookie settings, clock skew, audit event. | Cloud auth owner. |
+| BYOK validation fails | Provider status, key fingerprint, worker role logs, quota/provider error code, redaction. | Worker/BYOK owner. |
+| Desktop does not sync | Token status, workspace URL, SSE reconnects, local vs cloud workspace id, cache status. | Desktop sync owner. |
+| Gateway does not reply | Gateway health/readiness, provider webhook signature, channel binding, delivery backlog, dead letters. | Gateway owner. |
+| Approvals/questions stuck | Session projection pending state, command queue age, gateway interaction token, actor RBAC. | Projection/runtime owner. |
+| Artifacts missing | Projection metadata, object-store read/write, signed URL redaction, restore status. | Object-store owner. |
+| Quota/billing blocked | Subscription state, entitlement overlay, quota counters, expected 402/429 response. | SaaS operations owner. |
+| Admin panel inconsistent | API bootstrap, role membership, audit rows, cache-control, browser console redaction. | Cloud Web owner. |
+
+## Diagnostics Workflow
+
+1. Ask the user for a redacted diagnostics bundle or reproduce from operator
+   logs using org/session ids.
+2. Verify the bundle contains no raw BYOK, API token, OAuth token, channel
+   secret, cookie, database URL, or signed object-store URL.
+3. Correlate request id, org id, session id, run id, worker id, scheduler id,
+   and gateway delivery id.
+4. Check Cloud metrics first: command age, projection lag, worker heartbeats,
+   quota rejections, BYOK failures, and HTTP error rate.
+5. Check Gateway metrics next: stream reconnects, delivery retries, dead
+   letters, provider status, and session-stream count.
+6. Check object-store and Postgres health for artifact, checkpoint, or replay
+   issues.
+7. Record outcome, mitigation, owner, and follow-up test.
+
+## BYOK Issue Handling
+
+For user/provider key issues:
+
+1. Confirm the provider id is enabled in the org profile and plan.
+2. Confirm the BYOK status endpoint shows configured or active metadata only.
+3. Run the bounded provider validation path from the worker role.
+4. Check provider-side errors without logging plaintext key material.
+5. If compromise is suspected, stop new worker claims for the org, ask the user
+   to revoke the provider key with the provider, rotate cloud envelope/KMS
+   material if needed, and follow `docs/runbooks/managed-byok-saas.md`.
+
+## Gateway Issue Handling
+
+For channel issues:
+
+1. Confirm the gateway service token is valid and scoped.
+2. Confirm inbound actor identity resolves separately from gateway service
+   auth.
+3. Confirm webhook signatures or shared-secret/HMAC headers are present.
+4. Confirm the channel binding maps to the expected org, headless agent, and
+   cloud profile.
+5. Check the durable delivery cursor and dead-letter queue.
+6. Retry dead-lettered deliveries only after reviewing the event body and
+   provider error.
+
+## Desktop Sync Issue Handling
+
+For Desktop cloud workspace issues:
+
+1. Confirm the user is in the cloud workspace, not the local workspace.
+2. Confirm the configured cloud URL is HTTPS and matches the managed org.
+3. Confirm token refresh/revocation status.
+4. Confirm session list and full projection hydrate before cursor resume.
+5. Confirm local workspace remains usable if cloud is offline.
+6. If cache corruption is suspected, ask the user to export diagnostics first,
+   then clear the cloud cache for that workspace only.
+
+## Escalation Evidence
+
+Every escalation should include:
+
+- issue title and severity,
+- org id,
+- affected surface,
+- affected session/channel/workflow/artifact ids,
+- request ids,
+- first bad timestamp,
+- last known good timestamp,
+- redacted logs or diagnostics path,
+- metrics screenshot or report,
+- whether there is a rollback or mitigation.
+
+Never attach raw secrets to issues, support tickets, chat, or release evidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,8 @@ nav:
       - Deployment Readiness: deployment-readiness.md
       - Launch Readiness Gates: runbooks/launch-readiness.md
       - Launch Readiness Report: runbooks/launch-readiness-report.md
+      - Private Beta Launch: runbooks/private-beta-launch.md
+      - Private Beta Support: runbooks/private-beta-support.md
       - Cloud Managed Operations: runbooks/cloud-managed-operations.md
       - Backup and Restore: runbooks/backup-restore.md
       - Restore Drill Report: runbooks/restore-drill-report.md

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "deploy:load": "node scripts/launch-readiness.mjs --mode load",
     "deploy:soak": "node scripts/launch-readiness.mjs --mode soak",
     "deploy:launch:validate": "node scripts/validate-launch-readiness.mjs",
+    "deploy:private-beta:validate": "node scripts/validate-private-beta-package.mjs",
     "ops:validate": "node scripts/validate-ops-readiness.mjs",
     "notices": "node scripts/generate-third-party-notices.mjs",
     "proof:cloud:opencode-portability": "node --no-warnings --experimental-strip-types scripts/opencode-portability-proof.ts",

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -266,6 +266,12 @@ function validateDocs() {
     'docs/runbooks/backup-restore.md',
     'docs/runbooks/restore-drill-report.md',
     'docs/runbooks/managed-byok-saas.md',
+    'docs/runbooks/private-beta-launch.md',
+    'docs/runbooks/private-beta-support.md',
+    'deploy/private-beta/README.md',
+    'deploy/private-beta/private-beta-plans.json',
+    'deploy/private-beta/hosted-byok.config.example.json',
+    'deploy/private-beta/self-host-oss.config.example.json',
     'deploy/README.md',
     'deploy/observability/metrics-catalog.json',
     'deploy/observability/prometheus-alerts.yaml',
@@ -328,6 +334,36 @@ function validateDocs() {
   ]) {
     if (!byok.includes(phrase)) {
       throw new Error(`docs/runbooks/managed-byok-saas.md must include ${phrase}`)
+    }
+  }
+
+  const privateBeta = read('docs/runbooks/private-beta-launch.md')
+  for (const phrase of [
+    'Managed BYOK Onboarding Checklist',
+    'Hosted BYOK Setup Flow',
+    'OSS Self-Host Equivalent',
+    'Managed Vs Self-Host Responsibilities',
+    'Security Posture',
+    'Known Private Beta Constraints',
+    'Open Cowork does not resell model tokens',
+  ]) {
+    if (!privateBeta.includes(phrase)) {
+      throw new Error(`docs/runbooks/private-beta-launch.md must include ${phrase}`)
+    }
+  }
+
+  const privateBetaSupport = read('docs/runbooks/private-beta-support.md')
+  for (const phrase of [
+    'Support Intake',
+    'Triage Matrix',
+    'Diagnostics Workflow',
+    'BYOK Issue Handling',
+    'Gateway Issue Handling',
+    'Desktop Sync Issue Handling',
+    'Never attach raw secrets',
+  ]) {
+    if (!privateBetaSupport.includes(phrase)) {
+      throw new Error(`docs/runbooks/private-beta-support.md must include ${phrase}`)
     }
   }
 

--- a/scripts/validate-private-beta-package.mjs
+++ b/scripts/validate-private-beta-package.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs'
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function readJson(path) {
+  return JSON.parse(read(path))
+}
+
+function assertFile(path) {
+  if (!existsSync(path)) throw new Error(`${path} is required`)
+}
+
+function assertIncludes(path, text) {
+  const contents = read(path)
+  if (!contents.includes(text)) throw new Error(`${path} must include ${text}`)
+}
+
+function assertNotIncludes(path, text) {
+  const contents = read(path)
+  if (contents.includes(text)) throw new Error(`${path} must not include ${text}`)
+}
+
+function assertPositiveInteger(value, label) {
+  if (!Number.isInteger(value) || value <= 0) throw new Error(`${label} must be a positive integer`)
+}
+
+function log(message) {
+  process.stdout.write(`[private-beta-validate] ${message}\n`)
+}
+
+const requiredFiles = [
+  'docs/runbooks/private-beta-launch.md',
+  'docs/runbooks/private-beta-support.md',
+  'docs/runbooks/managed-byok-saas.md',
+  'docs/runbooks/launch-readiness.md',
+  'docs/deployment-readiness.md',
+  'docs/security-model.md',
+  'docs/privacy.md',
+  'docs/release-checklist.md',
+  'deploy/private-beta/README.md',
+  'deploy/private-beta/hosted-byok.config.example.json',
+  'deploy/private-beta/self-host-oss.config.example.json',
+  'deploy/private-beta/private-beta-plans.json',
+  'mkdocs.yml',
+  'package.json',
+]
+
+for (const path of requiredFiles) assertFile(path)
+
+for (const phrase of [
+  'Managed BYOK Onboarding Checklist',
+  'Hosted BYOK Setup Flow',
+  'OSS Self-Host Equivalent',
+  'Managed Vs Self-Host Responsibilities',
+  'Security Posture',
+  'Known Private Beta Constraints',
+  'Open Cowork does not resell model tokens',
+  'Desktop local workspaces stay local',
+  'Gateway is a channel client and delivery adapter',
+  'cloud.billing.provider=none',
+  'pnpm deploy:private-beta:validate',
+  'pnpm deploy:continuation:smoke',
+  'pnpm deploy:load',
+  'pnpm deploy:soak',
+]) {
+  assertIncludes('docs/runbooks/private-beta-launch.md', phrase)
+}
+
+for (const phrase of [
+  'Support Intake',
+  'Triage Matrix',
+  'Diagnostics Workflow',
+  'BYOK Issue Handling',
+  'Gateway Issue Handling',
+  'Desktop Sync Issue Handling',
+  'Never attach raw secrets',
+]) {
+  assertIncludes('docs/runbooks/private-beta-support.md', phrase)
+}
+
+for (const phrase of [
+  'hosted-byok.config.example.json',
+  'self-host-oss.config.example.json',
+  'private-beta-plans.json',
+  'provider-neutral',
+  'cloud.billing.provider=none',
+  'pnpm deploy:private-beta:validate',
+]) {
+  assertIncludes('deploy/private-beta/README.md', phrase)
+}
+
+for (const phrase of [
+  'Private Beta Launch',
+  'Private Beta Support',
+]) {
+  assertIncludes('mkdocs.yml', phrase)
+}
+
+for (const phrase of [
+  'pnpm deploy:private-beta:validate',
+  'private beta',
+  'managed BYOK',
+]) {
+  assertIncludes('docs/release-checklist.md', phrase)
+}
+
+const packageJson = readJson('package.json')
+if (packageJson.scripts?.['deploy:private-beta:validate'] !== 'node scripts/validate-private-beta-package.mjs') {
+  throw new Error('package.json must expose deploy:private-beta:validate')
+}
+
+const hosted = readJson('deploy/private-beta/hosted-byok.config.example.json')
+if (hosted.cloud?.auth?.signupMode !== 'invite') throw new Error('hosted private beta config must use invite signup mode')
+if (hosted.cloud?.billing?.provider !== 'stub') throw new Error('hosted private beta config must keep billing stubbed')
+if (hosted.cloudDesktop?.requireManagedOrg !== true) throw new Error('hosted private beta config must require a managed org')
+if (hosted.gateway?.mode !== 'managed') throw new Error('hosted private beta config must declare managed gateway mode')
+if (hosted.gateway?.metrics?.enabled !== true) throw new Error('hosted private beta config must expose protected operator metrics')
+if (!hosted.gateway?.server?.adminToken) throw new Error('hosted private beta config must require gateway admin token')
+
+const selfHost = readJson('deploy/private-beta/self-host-oss.config.example.json')
+if (!['none', 'stub'].includes(selfHost.cloud?.billing?.provider)) {
+  throw new Error('self-host config must keep billing none or stub')
+}
+if (selfHost.cloudDesktop?.allowUserAddedConnections !== true) {
+  throw new Error('self-host config must allow user-added cloud connections')
+}
+if (selfHost.gateway?.mode !== 'self-host') throw new Error('self-host config must declare self-host gateway mode')
+if (!selfHost.gateway?.providers?.some((provider) => provider.kind === 'webhook' && provider.credentials?.sharedSecret)) {
+  throw new Error('self-host config must demonstrate signed webhook ingress')
+}
+
+const plans = readJson('deploy/private-beta/private-beta-plans.json')
+if (plans.billingMode !== 'manual-or-stub') throw new Error('private beta plans must be manual-or-stub')
+if (!Array.isArray(plans.prices) || plans.prices.length !== 0) {
+  throw new Error('private beta plan placeholders must not commit prices')
+}
+if (!Array.isArray(plans.plans) || plans.plans.length < 2) throw new Error('private beta plans must include hosted and internal placeholders')
+for (const plan of plans.plans) {
+  if (typeof plan.planKey !== 'string' || !plan.planKey.startsWith('private-beta-')) {
+    throw new Error('private beta plan keys must be placeholder private-beta-* keys')
+  }
+  if (!['manual', 'stub'].includes(plan.billingMode)) {
+    throw new Error(`${plan.planKey} must use manual or stub billing mode`)
+  }
+  assertPositiveInteger(plan.entitlements?.maxConcurrentSessionsPerOrg, `${plan.planKey}.maxConcurrentSessionsPerOrg`)
+  assertPositiveInteger(plan.entitlements?.maxActiveWorkersPerOrg, `${plan.planKey}.maxActiveWorkersPerOrg`)
+  assertPositiveInteger(plan.entitlements?.maxPromptsPerHour, `${plan.planKey}.maxPromptsPerHour`)
+  assertPositiveInteger(plan.entitlements?.maxGatewayDeliveriesPerHour, `${plan.planKey}.maxGatewayDeliveriesPerHour`)
+  assertPositiveInteger(plan.entitlements?.maxArtifactBytesPerDay, `${plan.planKey}.maxArtifactBytesPerDay`)
+  if (plan.entitlements?.allowWorkers !== true || plan.entitlements?.allowPrompts !== true) {
+    throw new Error(`${plan.planKey} must allow private beta execution`)
+  }
+}
+
+for (const path of [
+  'docs/runbooks/private-beta-launch.md',
+  'docs/runbooks/private-beta-support.md',
+  'deploy/private-beta/README.md',
+  'deploy/private-beta/hosted-byok.config.example.json',
+  'deploy/private-beta/self-host-oss.config.example.json',
+  'deploy/private-beta/private-beta-plans.json',
+]) {
+  for (const forbidden of [
+    '/Users/joe',
+    'OPEN_COWORK_GCP_PROJECT=',
+    'joe-broadhead/open-cowork-cloud',
+    'sk-',
+    'ghp_',
+    'xoxb-',
+  ]) {
+    assertNotIncludes(path, forbidden)
+  }
+}
+
+log('private beta launch package validated')

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -253,6 +253,17 @@ test('Acme downstream example validates against the public schema', () => {
   assert.doesNotThrow(() => validateConfigSemantics(config, 'examples/downstream/acme/open-cowork.config.json'))
 })
 
+test('private beta deployment examples validate against the public schema', () => {
+  for (const path of [
+    'deploy/private-beta/hosted-byok.config.example.json',
+    'deploy/private-beta/self-host-oss.config.example.json',
+  ]) {
+    const config = JSON.parse(readFileSync(path, 'utf-8'))
+    assert.doesNotThrow(() => validateResolvedConfig(config, path))
+    assert.doesNotThrow(() => validateConfigSemantics(config, path))
+  }
+})
+
 test('gateway deployer config validates shared branding providers and safety semantics', () => {
   const config = cloneConfig()
   config.allowedEnvPlaceholders = [

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -98,6 +98,7 @@ test('root deployment scripts expose provider smoke gates', () => {
   assert.equal(requireScript('deploy:load'), 'node scripts/launch-readiness.mjs --mode load')
   assert.equal(requireScript('deploy:soak'), 'node scripts/launch-readiness.mjs --mode soak')
   assert.equal(requireScript('deploy:launch:validate'), 'node scripts/validate-launch-readiness.mjs')
+  assert.equal(requireScript('deploy:private-beta:validate'), 'node scripts/validate-private-beta-package.mjs')
 })
 
 test('root build and dist scripts preserve release build prerequisites', () => {

--- a/tests/private-beta-package.test.ts
+++ b/tests/private-beta-package.test.ts
@@ -1,0 +1,95 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function readRepoFile(path: string) {
+  return readFileSync(join(process.cwd(), path), 'utf8')
+}
+
+function readJson(path: string) {
+  return JSON.parse(readRepoFile(path))
+}
+
+test('private beta launch package documents managed and self-host promises', () => {
+  const launch = readRepoFile('docs/runbooks/private-beta-launch.md')
+  for (const phrase of [
+    'Managed BYOK Onboarding Checklist',
+    'Hosted BYOK Setup Flow',
+    'OSS Self-Host Equivalent',
+    'Managed Vs Self-Host Responsibilities',
+    'Security Posture',
+    'Known Private Beta Constraints',
+    'Open Cowork does not resell model tokens',
+    'Desktop local workspaces stay local',
+    'Gateway is a channel client and delivery adapter',
+    'cloud.billing.provider=none',
+    'pnpm deploy:private-beta:validate',
+    'pnpm deploy:continuation:smoke',
+  ]) {
+    assert.match(launch, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  }
+
+  const support = readRepoFile('docs/runbooks/private-beta-support.md')
+  for (const phrase of [
+    'Support Intake',
+    'Triage Matrix',
+    'Diagnostics Workflow',
+    'BYOK Issue Handling',
+    'Gateway Issue Handling',
+    'Desktop Sync Issue Handling',
+    'Never attach raw secrets',
+  ]) {
+    assert.match(support, new RegExp(phrase))
+  }
+})
+
+test('private beta examples keep hosted and OSS modes separate', () => {
+  const hosted = readJson('deploy/private-beta/hosted-byok.config.example.json')
+  assert.equal(hosted.cloud.auth.signupMode, 'invite')
+  assert.equal(hosted.cloud.auth.allowSelfServiceSignup, false)
+  assert.equal(hosted.cloud.billing.provider, 'stub')
+  assert.equal(hosted.cloud.billing.defaultPlanKey, 'private-beta-design-partner')
+  assert.equal(hosted.cloudDesktop.requireManagedOrg, true)
+  assert.equal(hosted.cloudDesktop.allowUserAddedConnections, false)
+  assert.equal(hosted.gateway.mode, 'managed')
+  assert.equal(hosted.gateway.metrics.enabled, true)
+  assert.ok(hosted.gateway.server.adminToken)
+
+  const selfHost = readJson('deploy/private-beta/self-host-oss.config.example.json')
+  assert.equal(selfHost.cloud.billing.provider, 'none')
+  assert.equal(selfHost.cloudDesktop.allowUserAddedConnections, true)
+  assert.equal(selfHost.cloudDesktop.requireManagedOrg, false)
+  assert.equal(selfHost.gateway.mode, 'self-host')
+  assert.equal(selfHost.gateway.providers[0].kind, 'webhook')
+  assert.ok(selfHost.gateway.providers[0].credentials.sharedSecret)
+})
+
+test('private beta plan placeholders do not commit prices or token resale assumptions', () => {
+  const plans = readJson('deploy/private-beta/private-beta-plans.json')
+  assert.equal(plans.billingMode, 'manual-or-stub')
+  assert.deepEqual(plans.prices, [])
+  assert.ok(plans.plans.length >= 2)
+  for (const plan of plans.plans) {
+    assert.match(plan.planKey, /^private-beta-/)
+    assert.match(plan.billingMode, /^(manual|stub)$/)
+    assert.equal(plan.entitlements.allowNewSessions, true)
+    assert.equal(plan.entitlements.allowPrompts, true)
+    assert.equal(plan.entitlements.allowWorkers, true)
+    assert.equal(typeof plan.entitlements.maxPromptsPerHour, 'number')
+    if (plan.billingMode === 'manual') {
+      assert.match(plan.notes, /No token resale/)
+    }
+  }
+})
+
+test('private beta validator runs from the package script', () => {
+  const packageJson = readJson('package.json')
+  assert.equal(packageJson.scripts['deploy:private-beta:validate'], 'node scripts/validate-private-beta-package.mjs')
+  const output = execFileSync(process.execPath, ['scripts/validate-private-beta-package.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  })
+  assert.match(output, /private beta launch package validated/)
+})


### PR DESCRIPTION
## Summary

- add managed BYOK private beta launch and support runbooks
- add provider-neutral hosted/self-host config examples and manual/stub plan placeholders
- add deploy:private-beta:validate, CI wiring, release/deployment docs, and regression tests

Closes #503

## Validation

- pnpm deploy:private-beta:validate
- node --no-warnings --experimental-strip-types --test tests/private-beta-package.test.ts tests/config-schema-validation.test.ts tests/package-scripts.test.ts
- pnpm deploy:validate
- pnpm deploy:launch:validate
- pnpm ops:validate
- pnpm docs:build
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check