### PR TITLE
Add desktop cloud UX parity gates

### DIFF
--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -52,6 +52,7 @@ export type CloudPromptInput = {
 
 export type CloudWorkspaceSessionAdapter = {
   policy(): Promise<WorkspacePolicy>
+  sync?(): Promise<void>
   listSessions(): Promise<SessionInfo[]>
   createSession(input?: { projectSource?: CloudProjectSourceInput | null }): Promise<SessionInfo>
   validateProjectSource?(input: CloudProjectSourceInput): Promise<CloudProjectSourcePolicyVerdict>
@@ -487,7 +488,7 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
     return setting
   }
 
-  private async refreshWorkspaceSnapshot(): Promise<void> {
+  async sync(): Promise<void> {
     const sessions = await this.listSessions()
     await Promise.allSettled(sessions.map((session) => this.getSessionView(session.id)))
     if (this.transport.listArtifacts) {
@@ -516,7 +517,7 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
         void (async () => {
           try {
             if (event.type === 'snapshot.required') {
-              await this.refreshWorkspaceSnapshot()
+              await this.sync()
               this.cache?.resetEventCursor(cacheKey, 'workspace', 0)
               input.onEvent(event)
               return

--- a/apps/desktop/src/main/ipc/workspace-handlers.ts
+++ b/apps/desktop/src/main/ipc/workspace-handlers.ts
@@ -88,6 +88,19 @@ export function registerWorkspaceHandlers(context: IpcHandlerContext) {
     const result = await context.workspaceGateway.sync(event, workspaceId)
     const activeWorkspaceId = workspaceId || context.workspaceGateway.activeWorkspaceId(event)
     await subscribeWorkspaceUpdates(context, event, activeWorkspaceId)
+    const workspace = context.workspaceGateway.list(event).find((entry) => entry.id === activeWorkspaceId)
+    if (workspace?.kind === 'cloud' && workspace.status === 'online') {
+      const sessions = await context.workspaceGateway.listCloudSessions(event, activeWorkspaceId)
+      const sender = event.sender as { isDestroyed?: () => boolean, send?: (channel: string, payload: unknown) => void }
+      if (!sender.isDestroyed?.()) {
+        sender.send?.('workspace:sessions-updated', {
+          workspaceId: activeWorkspaceId,
+          sessions,
+          lastEventSequence: null,
+          syncedAt: result.syncedAt,
+        })
+      }
+    }
     return result
   })
 }

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -84,6 +84,9 @@ export type WorkspaceGatewayOptions = {
   cloudAdapterFactory?: (connection: CloudWorkspaceConnectionRecord, accessToken?: string | null) => CloudWorkspaceSessionAdapter
   cloudLogin?: (connection: CloudWorkspaceConnectionRecord) => Promise<CloudWorkspaceLoginResult>
   cloudRefresh?: (connection: CloudWorkspaceConnectionRecord, refreshToken: string) => Promise<CloudWorkspaceLoginResult>
+  cloudReconnectBaseMs?: number
+  cloudReconnectMaxMs?: number
+  cloudReconnectMaxAttempts?: number
 }
 
 const LOCAL_WORKSPACE: WorkspaceRegistration = {
@@ -147,6 +150,7 @@ const WORKSPACE_SUPPORT_APIS = [
   'artifacts.list',
   'artifacts.upload',
   'artifacts.download',
+  'artifacts.reveal',
   'settings.portable',
   'customContent.agents',
   'customContent.skills',
@@ -236,6 +240,7 @@ export class WorkspaceGateway {
   private readonly cloudAdapters = new Map<string, CloudWorkspaceSessionAdapter>()
   private readonly cloudSessionSubscriptions = new Map<string, CloudTransportSubscription>()
   private readonly cloudWorkspaceSubscriptions = new Map<string, CloudTransportSubscription>()
+  private readonly cloudSubscriptionRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly managedCloudWorkspaceIds = new Set<string>()
   private readonly activeBySender = new Map<number, string>()
   private readonly syncedAtByWorkspace = new Map<string, string>()
@@ -246,6 +251,9 @@ export class WorkspaceGateway {
   private readonly cloudAdapterFactory: (connection: CloudWorkspaceConnectionRecord, accessToken?: string | null) => CloudWorkspaceSessionAdapter
   private readonly cloudLogin: (connection: CloudWorkspaceConnectionRecord) => Promise<CloudWorkspaceLoginResult>
   private readonly cloudRefresh: (connection: CloudWorkspaceConnectionRecord, refreshToken: string) => Promise<CloudWorkspaceLoginResult>
+  private readonly cloudReconnectBaseMs: number
+  private readonly cloudReconnectMaxMs: number
+  private readonly cloudReconnectMaxAttempts: number
 
   constructor(options: WorkspaceGatewayOptions = {}) {
     this.cloudDesktopConfig = options.cloudDesktop || DEFAULT_CONFIG.cloudDesktop
@@ -260,6 +268,9 @@ export class WorkspaceGateway {
     const authenticator = createCloudWorkspaceDesktopAuthenticator()
     this.cloudLogin = options.cloudLogin || ((connection) => authenticator.login(connection))
     this.cloudRefresh = options.cloudRefresh || ((connection, refreshToken) => authenticator.refresh(connection, refreshToken))
+    this.cloudReconnectBaseMs = Math.max(0, options.cloudReconnectBaseMs ?? 500)
+    this.cloudReconnectMaxMs = Math.max(this.cloudReconnectBaseMs, options.cloudReconnectMaxMs ?? 10_000)
+    this.cloudReconnectMaxAttempts = Math.max(0, options.cloudReconnectMaxAttempts ?? 8)
     this.registerWorkspace(LOCAL_WORKSPACE)
     if (!this.cloudDesktopConfig.enabled) return
     const persistedConnections = new Map((this.cloudRegistry?.list() || []).map((connection) => [connection.id, connection]))
@@ -473,6 +484,7 @@ export class WorkspaceGateway {
       supportedIf('artifacts.list', feature('artifacts'), 'Cloud artifacts are disabled by this workspace policy.'),
       supportedIf('artifacts.upload', feature('artifacts'), 'Cloud artifacts are disabled by this workspace policy.'),
       supportedIf('artifacts.download', feature('artifacts'), 'Cloud artifacts are disabled by this workspace policy.'),
+      cloudSupport('artifacts.reveal', 'not_supported', 'Cloud artifacts cannot be revealed in the local filesystem. Export the artifact instead.'),
       supportedIf('settings.portable', feature('settings'), 'Cloud portable settings are disabled by this workspace policy.'),
       supportedIf('customContent.agents', feature('customAgents'), 'Cloud custom agents are disabled by this workspace policy.'),
       supportedIf('customContent.skills', feature('customSkills'), 'Cloud custom skills are disabled by this workspace policy.'),
@@ -487,7 +499,12 @@ export class WorkspaceGateway {
   async sync(event: WorkspaceEventLike, workspaceIdInput?: string | null): Promise<WorkspaceSyncResult> {
     const workspace = this.resolveWorkspace(event, workspaceIdInput)
     if (workspace.kind === 'cloud') {
-      await this.requireCloudAdapter(workspace)
+      const adapter = await this.requireCloudAdapter(workspace)
+      if (adapter.sync) {
+        await adapter.sync()
+      } else {
+        await adapter.listSessions()
+      }
     }
     const syncedAt = new Date().toISOString()
     this.syncedAtByWorkspace.set(workspace.id, syncedAt)
@@ -983,30 +1000,65 @@ export class WorkspaceGateway {
     },
   ): Promise<void> {
     const workspace = this.resolveWorkspace(event, input.workspaceId)
-    const adapter = await this.requireCloudAdapter(workspace)
-    if (!adapter.subscribeSessionEvents) return
     const key = this.cloudSessionSubscriptionKey(workspace.id, sessionId)
     if (this.cloudSessionSubscriptions.has(key)) return
-    let subscription: CloudTransportSubscription | null = null
-    let failedDuringSubscribe = false
-    const onError = (error: unknown) => {
-      failedDuringSubscribe = true
-      if (subscription && this.cloudSessionSubscriptions.get(key) === subscription) {
-        this.cloudSessionSubscriptions.delete(key)
-        try { subscription.close() } catch { /* best effort */ }
+
+    let retryAttempt = 0
+    let lastSequence = input.afterSequence
+    const retryKey = `session:${key}`
+    const subscribe = async (afterSequence?: number) => {
+      const latestWorkspace = this.workspaces.get(workspace.id)
+      if (!latestWorkspace) return
+      let adapter: CloudWorkspaceSessionAdapter
+      try {
+        adapter = await this.requireCloudAdapter(latestWorkspace)
+      } catch (error) {
+        input.onError?.(error)
+        this.scheduleCloudSubscriptionRetry(retryKey, key, this.cloudSessionSubscriptions, retryAttempt++, () => {
+          void subscribe(lastSequence)
+        })
+        return
       }
-      input.onError?.(error)
+      if (!adapter.subscribeSessionEvents) return
+      if (this.cloudSessionSubscriptions.has(key)) return
+      let subscription: CloudTransportSubscription | null = null
+      let failedDuringSubscribe = false
+      const onError = (error: unknown) => {
+        failedDuringSubscribe = true
+        if (subscription && this.cloudSessionSubscriptions.get(key) === subscription) {
+          this.cloudSessionSubscriptions.delete(key)
+          try { subscription.close() } catch { /* best effort */ }
+        }
+        input.onError?.(error)
+        this.scheduleCloudSubscriptionRetry(retryKey, key, this.cloudSessionSubscriptions, retryAttempt++, () => {
+          void subscribe(lastSequence)
+        })
+      }
+      try {
+        subscription = adapter.subscribeSessionEvents(sessionId, {
+          afterSequence,
+          onEvent: (cloudEvent) => {
+            retryAttempt = 0
+            lastSequence = cloudEvent.sequence
+            input.onEvent(cloudEvent)
+          },
+          onError,
+        })
+      } catch (error) {
+        input.onError?.(error)
+        this.scheduleCloudSubscriptionRetry(retryKey, key, this.cloudSessionSubscriptions, retryAttempt++, () => {
+          void subscribe(lastSequence)
+        })
+        return
+      }
+      if (failedDuringSubscribe) {
+        try { subscription.close() } catch { /* best effort */ }
+        return
+      }
+      this.clearCloudSubscriptionRetry(retryKey)
+      this.cloudSessionSubscriptions.set(key, subscription)
     }
-    subscription = adapter.subscribeSessionEvents(sessionId, {
-      afterSequence: input.afterSequence,
-      onEvent: input.onEvent,
-      onError,
-    })
-    if (failedDuringSubscribe) {
-      try { subscription.close() } catch { /* best effort */ }
-      return
-    }
-    this.cloudSessionSubscriptions.set(key, subscription)
+    await subscribe(input.afterSequence)
   }
 
   async subscribeCloudWorkspaceEvents(
@@ -1019,30 +1071,65 @@ export class WorkspaceGateway {
     },
   ): Promise<void> {
     const workspace = this.resolveWorkspace(event, input.workspaceId)
-    const adapter = await this.requireCloudAdapter(workspace)
-    if (!adapter.subscribeWorkspaceEvents) return
     const key = this.cloudWorkspaceSubscriptionKey(workspace.id, senderKey(event))
     if (this.cloudWorkspaceSubscriptions.has(key)) return
-    let subscription: CloudTransportSubscription | null = null
-    let failedDuringSubscribe = false
-    const onError = (error: unknown) => {
-      failedDuringSubscribe = true
-      if (subscription && this.cloudWorkspaceSubscriptions.get(key) === subscription) {
-        this.cloudWorkspaceSubscriptions.delete(key)
-        try { subscription.close() } catch { /* best effort */ }
+
+    let retryAttempt = 0
+    let lastSequence = input.afterSequence
+    const retryKey = `workspace:${key}`
+    const subscribe = async (afterSequence?: number) => {
+      const latestWorkspace = this.workspaces.get(workspace.id)
+      if (!latestWorkspace) return
+      let adapter: CloudWorkspaceSessionAdapter
+      try {
+        adapter = await this.requireCloudAdapter(latestWorkspace)
+      } catch (error) {
+        input.onError?.(error)
+        this.scheduleCloudSubscriptionRetry(retryKey, key, this.cloudWorkspaceSubscriptions, retryAttempt++, () => {
+          void subscribe(lastSequence)
+        })
+        return
       }
-      input.onError?.(error)
+      if (!adapter.subscribeWorkspaceEvents) return
+      if (this.cloudWorkspaceSubscriptions.has(key)) return
+      let subscription: CloudTransportSubscription | null = null
+      let failedDuringSubscribe = false
+      const onError = (error: unknown) => {
+        failedDuringSubscribe = true
+        if (subscription && this.cloudWorkspaceSubscriptions.get(key) === subscription) {
+          this.cloudWorkspaceSubscriptions.delete(key)
+          try { subscription.close() } catch { /* best effort */ }
+        }
+        input.onError?.(error)
+        this.scheduleCloudSubscriptionRetry(retryKey, key, this.cloudWorkspaceSubscriptions, retryAttempt++, () => {
+          void subscribe(lastSequence)
+        })
+      }
+      try {
+        subscription = adapter.subscribeWorkspaceEvents({
+          afterSequence,
+          onEvent: (cloudEvent) => {
+            retryAttempt = 0
+            lastSequence = cloudEvent.sequence
+            input.onEvent(cloudEvent)
+          },
+          onError,
+        })
+      } catch (error) {
+        input.onError?.(error)
+        this.scheduleCloudSubscriptionRetry(retryKey, key, this.cloudWorkspaceSubscriptions, retryAttempt++, () => {
+          void subscribe(lastSequence)
+        })
+        return
+      }
+      if (failedDuringSubscribe) {
+        try { subscription.close() } catch { /* best effort */ }
+        return
+      }
+      this.clearCloudSubscriptionRetry(retryKey)
+      this.cloudWorkspaceSubscriptions.set(key, subscription)
     }
-    subscription = adapter.subscribeWorkspaceEvents({
-      afterSequence: input.afterSequence,
-      onEvent: input.onEvent,
-      onError,
-    })
-    if (failedDuringSubscribe) {
-      try { subscription.close() } catch { /* best effort */ }
-      return
-    }
-    this.cloudWorkspaceSubscriptions.set(key, subscription)
+    await subscribe(input.afterSequence)
   }
 
   private resolveWorkspace(event: WorkspaceEventLike, workspaceIdInput?: string | null): WorkspaceRegistration {
@@ -1162,7 +1249,43 @@ export class WorkspaceGateway {
     return `${workspaceId}:${senderId}`
   }
 
+  private cloudSubscriptionRetryDelayMs(attempt: number) {
+    if (this.cloudReconnectMaxAttempts === 0) return null
+    if (attempt >= this.cloudReconnectMaxAttempts) return null
+    return Math.min(this.cloudReconnectMaxMs, this.cloudReconnectBaseMs * 2 ** Math.max(0, attempt))
+  }
+
+  private scheduleCloudSubscriptionRetry(
+    retryKey: string,
+    subscriptionKey: string,
+    subscriptions: Map<string, CloudTransportSubscription>,
+    attempt: number,
+    retry: () => void,
+  ) {
+    if (subscriptions.has(subscriptionKey) || this.cloudSubscriptionRetryTimers.has(retryKey)) return
+    const delay = this.cloudSubscriptionRetryDelayMs(attempt)
+    if (delay === null) return
+    const timer = setTimeout(() => {
+      this.cloudSubscriptionRetryTimers.delete(retryKey)
+      if (subscriptions.has(subscriptionKey)) return
+      retry()
+    }, delay)
+    this.cloudSubscriptionRetryTimers.set(retryKey, timer)
+  }
+
+  private clearCloudSubscriptionRetry(retryKey: string) {
+    const timer = this.cloudSubscriptionRetryTimers.get(retryKey)
+    if (!timer) return
+    clearTimeout(timer)
+    this.cloudSubscriptionRetryTimers.delete(retryKey)
+  }
+
   private closeCloudSubscriptionsForWorkspace(workspaceId: string) {
+    for (const [key, timer] of this.cloudSubscriptionRetryTimers.entries()) {
+      if (!key.startsWith(`session:${workspaceId}:`) && !key.startsWith(`workspace:${workspaceId}:`)) continue
+      clearTimeout(timer)
+      this.cloudSubscriptionRetryTimers.delete(key)
+    }
     for (const [key, subscription] of this.cloudSessionSubscriptions.entries()) {
       if (!key.startsWith(`${workspaceId}:`)) continue
       try { subscription.close() } catch { /* best effort */ }

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -132,12 +132,19 @@ export function App() {
     handleRuntimeRestart,
   } = useRuntimeHealth(loadSessions, reportAppError)
 
-  const createAndActivateSession = useCallback(async (directory?: string): Promise<SessionInfo | null> => {
+  const createAndActivateSession = useCallback(async (directory?: string, options?: SessionPromptOptions): Promise<SessionInfo | null> => {
     try {
-      const session = await window.coworkApi.session.create(directory)
+      const workspaceOptions = options?.workspaceId ? { workspaceId: options.workspaceId } : undefined
+      const session = workspaceOptions
+        ? await window.coworkApi.session.create(directory, workspaceOptions)
+        : await window.coworkApi.session.create(directory)
       addSession(session)
       setCurrentSession(session.id)
-      await window.coworkApi.session.activate(session.id)
+      if (workspaceOptions) {
+        await window.coworkApi.session.activate(session.id, workspaceOptions)
+      } else {
+        await window.coworkApi.session.activate(session.id)
+      }
       setView('chat')
       return session
     } catch (err) {
@@ -177,7 +184,7 @@ export function App() {
     agent?: string,
     options?: SessionPromptOptions,
   ) => {
-    const session = await createAndActivateSession()
+    const session = await createAndActivateSession(undefined, options)
     if (!session) return
     try {
       const files = attachments && attachments.length > 0

--- a/apps/desktop/src/renderer/components/HomePage.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { BrandingHomeConfig, SessionInfo, SessionPromptOptions } from '@open-cowork/shared'
 import { useSessionStore } from '../stores/session'
+import { useActiveWorkspaceSupport } from '../stores/workspace-support'
+import { LOCAL_WORKSPACE_ID } from '../stores/session-workspace-keys'
 import { formatAgentLabel } from '../helpers/agent-label'
 import { formatDate, t } from '../helpers/i18n'
 import { summarizeMcpConnections } from '../helpers/mcp-status-summary'
@@ -108,12 +110,32 @@ function HomeEyebrow({ brandName }: { brandName: string }) {
   )
 }
 
-function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefillAgent }: {
+function HomeComposer({
+  onSubmit,
+  disabled,
+  placeholder,
+  specialistAgents,
+  prefillAgent,
+  workspaceOptions,
+  canPrompt = true,
+  sendDisabledReason = null,
+  attachmentsAllowed = true,
+  attachmentsDisabledReason = null,
+  modelControlsManaged = false,
+  modelControlsReason = null,
+}: {
   onSubmit: (text: string, attachments: Attachment[], agent?: string, options?: SessionPromptOptions) => void | Promise<void>
   disabled: boolean
   placeholder: string
   specialistAgents: MentionableAgent[]
   prefillAgent: { id: string; nonce: number } | null
+  workspaceOptions?: { workspaceId: string }
+  canPrompt?: boolean
+  sendDisabledReason?: string | null
+  attachmentsAllowed?: boolean
+  attachmentsDisabledReason?: string | null
+  modelControlsManaged?: boolean
+  modelControlsReason?: string | null
 }) {
   const [text, setText] = useState('')
   const [attachments, setAttachments] = useState<Attachment[]>([])
@@ -130,7 +152,9 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
   const agentMode = useSessionStore((s) => s.agentMode)
   const setAgentMode = useSessionStore((s) => s.setAgentMode)
   const addGlobalError = useSessionStore((s) => s.addGlobalError)
-  const { currentModel, setCurrentModel, provider, availableModels } = useChatRuntimeSelection()
+  const attachmentPolicyReason = attachmentsDisabledReason || t('chat.attachFileDisabled', 'File attachments are disabled by this workspace policy.')
+  const promptPolicyReason = sendDisabledReason || t('chat.sendDisabled', 'Prompting is disabled by this workspace policy.')
+  const { currentModel, setCurrentModel, provider, availableModels } = useChatRuntimeSelection(null, workspaceOptions)
   const reasoningSelection = useReasoningVariantSelection(provider, currentModel, availableModels)
 
   useEffect(() => {
@@ -148,9 +172,13 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
 
   const addFiles = useCallback(async (files: FileList | File[]) => {
     if (!files || files.length === 0) return
+    if (!attachmentsAllowed) {
+      addGlobalError(attachmentPolicyReason)
+      return
+    }
     const next = await filesToAttachments(files)
     setAttachments((current) => [...current, ...next])
-  }, [])
+  }, [addGlobalError, attachmentPolicyReason, attachmentsAllowed])
 
   useEffect(() => {
     if (!prefillAgent) return
@@ -172,21 +200,30 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
   const handleSubmit = useCallback(async () => {
     const trimmed = text.trim()
     if ((!trimmed && attachments.length === 0) || disabled) return
+    if (!canPrompt) {
+      addGlobalError(promptPolicyReason)
+      return
+    }
+    if (attachments.length > 0 && !attachmentsAllowed) {
+      addGlobalError(attachmentPolicyReason)
+      return
+    }
     const directInvocation = resolveDirectAgentInvocation(trimmed, specialistAgents)
     const promptText = directInvocation.text
     if (!promptText && attachments.length === 0) return
     const currentAttachments = [...attachments]
+    const promptAgent = directInvocation.agent || agentMode
+    const promptOptions = modelControlsManaged ? undefined : reasoningSelection.promptOptions
+    if (promptOptions) {
+      await onSubmit(promptText, currentAttachments, promptAgent, promptOptions)
+    } else {
+      await onSubmit(promptText, currentAttachments, promptAgent)
+    }
     setText('')
     setAttachments([])
     setInlinePicker(null)
     autosize()
-    const promptAgent = directInvocation.agent || agentMode
-    if (reasoningSelection.promptOptions) {
-      await onSubmit(promptText, currentAttachments, promptAgent, reasoningSelection.promptOptions)
-    } else {
-      await onSubmit(promptText, currentAttachments, promptAgent)
-    }
-  }, [text, attachments, disabled, onSubmit, specialistAgents, agentMode, reasoningSelection.promptOptions])
+  }, [text, attachments, disabled, canPrompt, attachmentsAllowed, specialistAgents, agentMode, modelControlsManaged, reasoningSelection.promptOptions, onSubmit, addGlobalError, promptPolicyReason, attachmentPolicyReason])
 
   const inlineSuggestions = useMemo(() => {
     if (!inlinePicker) return []
@@ -241,7 +278,12 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
   const restBorder = '1px solid rgba(148, 148, 172, 0.18)'
   const dropBorder = '1px solid var(--color-accent)'
   const currentModelLabel = (availableModels[provider] || []).find((model) => model.id === currentModel)?.label || currentModel || t('chat.modelFallback', 'Model')
-  const canSend = !disabled && (text.trim() || attachments.length > 0)
+  const policyBlockedReason = !canPrompt
+    ? promptPolicyReason
+    : attachments.length > 0 && !attachmentsAllowed
+      ? attachmentPolicyReason
+      : null
+  const canSend = !disabled && !policyBlockedReason && (text.trim() || attachments.length > 0)
   const inlineMenuWidth = 260
   const chromeRect = inputChromeRef.current?.getBoundingClientRect()
   const anchorRect = chromeRect || textareaRef.current?.getBoundingClientRect() || null
@@ -406,13 +448,21 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
           isAwaitingPermission={false}
           isAwaitingQuestion={false}
           canSend={!!canSend}
+          sendDisabledReason={policyBlockedReason}
           onAddFiles={addFiles}
+          attachmentsAllowed={attachmentsAllowed}
+          attachmentsDisabledReason={attachmentPolicyReason}
+          modelControlsManaged={modelControlsManaged}
+          modelControlsReason={modelControlsReason}
+          reasoningControlsManaged={modelControlsManaged}
           onToggleModelMenu={() => {
+            if (modelControlsManaged) return
             setInlinePicker(null)
             setShowReasoningMenu(false)
             setShowModelMenu(!showModelMenu)
           }}
           onToggleReasoningMenu={() => {
+            if (modelControlsManaged) return
             setInlinePicker(null)
             setShowModelMenu(false)
             setShowReasoningMenu(!showReasoningMenu)
@@ -438,6 +488,7 @@ function HomeComposer({ onSubmit, disabled, placeholder, specialistAgents, prefi
         currentModel={currentModel}
         onClose={() => setShowModelMenu(false)}
         onSelect={async (modelId) => {
+          if (modelControlsManaged) return
           const previousModel = currentModel
           setCurrentModel(modelId)
           setShowModelMenu(false)
@@ -559,7 +610,13 @@ export function HomePage({ brandName, homeBranding, onStartThread, onOpenThread 
   const sessions = useSessionStore((s) => s.sessions)
   const [submitting, setSubmitting] = useState(false)
   const [agentPrefill, setAgentPrefill] = useState<{ id: string; nonce: number } | null>(null)
-  const specialistAgents = useMentionableAgents(null)
+  const workspaceSupport = useActiveWorkspaceSupport()
+  const activeWorkspaceIsLocal = workspaceSupport.workspaceId === LOCAL_WORKSPACE_ID
+  const workspaceOptions = useMemo(
+    () => activeWorkspaceIsLocal ? undefined : { workspaceId: workspaceSupport.workspaceId },
+    [activeWorkspaceIsLocal, workspaceSupport.workspaceId],
+  )
+  const specialistAgents = useMentionableAgents(null, workspaceOptions)
 
   const suggestedAgents = useMemo(() => {
     return specialistAgents
@@ -578,17 +635,24 @@ export function HomePage({ brandName, homeBranding, onStartThread, onOpenThread 
 
   const handleSubmit = useCallback(async (text: string, attachments: Attachment[], agent?: string, options?: SessionPromptOptions) => {
     if (submitting) return
+    if (attachments.length > 0 && !workspaceSupport.flags.canAttachFiles) {
+      useSessionStore.getState().addGlobalError(workspaceSupport.flags.reasons.attachFiles)
+      return
+    }
     setSubmitting(true)
     try {
-      if (options) {
-        await onStartThread(text, attachments, agent, options)
+      const scopedOptions = activeWorkspaceIsLocal
+        ? options
+        : { ...(options || {}), workspaceId: workspaceSupport.workspaceId }
+      if (scopedOptions) {
+        await onStartThread(text, attachments, agent, scopedOptions)
       } else {
         await onStartThread(text, attachments, agent)
       }
     } finally {
       setSubmitting(false)
     }
-  }, [onStartThread, submitting])
+  }, [activeWorkspaceIsLocal, onStartThread, submitting, workspaceSupport.flags, workspaceSupport.workspaceId])
 
   const handlePickAgent = useCallback((agentId: string) => {
     setAgentPrefill({ id: agentId, nonce: Date.now() })
@@ -634,6 +698,13 @@ export function HomePage({ brandName, homeBranding, onStartThread, onOpenThread 
             placeholder={composerPlaceholder}
             specialistAgents={specialistAgents}
             prefillAgent={agentPrefill}
+            workspaceOptions={workspaceOptions}
+            canPrompt={workspaceSupport.flags.canPrompt}
+            sendDisabledReason={workspaceSupport.flags.reasons.prompt}
+            attachmentsAllowed={workspaceSupport.flags.canAttachFiles}
+            attachmentsDisabledReason={workspaceSupport.flags.reasons.attachFiles}
+            modelControlsManaged={!workspaceSupport.flags.canUseMachineRuntimeConfig}
+            modelControlsReason={workspaceSupport.flags.reasons.machineRuntimeConfig}
           />
         </div>
 

--- a/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
@@ -2,13 +2,21 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { useSessionStore } from '../../stores/session'
+import { WORKSPACE_SUPPORT_APIS, useWorkspaceSupportStore } from '../../stores/workspace-support'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { ChatInput } from './ChatInput'
 
 const HISTORY_KEY = 'open-cowork-prompt-history'
 
 function seedCurrentSession() {
+  useWorkspaceSupportStore.setState({
+    supportByWorkspace: {},
+    loadedByWorkspace: {},
+    loadingByWorkspace: {},
+    errorByWorkspace: {},
+  })
   useSessionStore.setState({
+    activeWorkspaceId: 'local',
     globalErrors: [],
     busySessions: new Set(),
     awaitingPermissionSessions: new Set(),
@@ -26,6 +34,57 @@ function seedCurrentSession() {
     },
   ])
   useSessionStore.getState().setCurrentSession('session-1')
+}
+
+function seedCloudSession() {
+  useSessionStore.setState({
+    activeWorkspaceId: 'cloud:test',
+    sessionsByWorkspace: {
+      'cloud:test': [{
+        id: 'session-1',
+        title: 'Cloud session',
+        directory: null,
+        createdAt: '2026-04-29T00:00:00.000Z',
+        updatedAt: '2026-04-29T00:00:00.000Z',
+      }],
+    },
+    sessions: [{
+      id: 'session-1',
+      title: 'Cloud session',
+      directory: null,
+      createdAt: '2026-04-29T00:00:00.000Z',
+      updatedAt: '2026-04-29T00:00:00.000Z',
+    }],
+    currentSessionId: 'session-1',
+    globalErrors: [],
+    busySessions: new Set(),
+    awaitingPermissionSessions: new Set(),
+    awaitingQuestionSessions: new Set(),
+    sessionStateById: {},
+    chartArtifactsBySession: {},
+  })
+  useWorkspaceSupportStore.setState({
+    supportByWorkspace: {
+      'cloud:test': WORKSPACE_SUPPORT_APIS.map((api) => {
+        if (api === 'localFiles' || api === 'machineRuntimeConfig' || api === 'artifacts.reveal') {
+          return {
+            api,
+            status: 'not_supported',
+            verdict: {
+              allowed: false,
+              reason: api === 'localFiles'
+                ? 'Cloud workspaces do not implicitly upload local files.'
+                : 'This cloud profile manages runtime configuration.',
+            },
+          }
+        }
+        return { api, status: 'supported', verdict: { allowed: true, reason: null } }
+      }),
+    },
+    loadedByWorkspace: { 'cloud:test': true },
+    loadingByWorkspace: {},
+    errorByWorkspace: {},
+  })
 }
 
 function installModelRuntime() {
@@ -264,6 +323,31 @@ describe('ChatInput', () => {
       expect(api.session.setComposerPreferences).toHaveBeenCalledWith('session-a', { modelId: 'model-a' })
     })
     expect(api.settings.set).not.toHaveBeenCalled()
+  })
+
+  it('gates cloud composer controls and sends prompts with workspace scope', async () => {
+    const api = installModelRuntime()
+    seedCloudSession()
+
+    render(<ChatInput />)
+
+    expect(await screen.findByRole('button', { name: /Model A/ })).toBeDisabled()
+    expect(screen.getByTitle('Cloud workspaces do not implicitly upload local files.')).toBeDisabled()
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Continue in cloud' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(api.session.prompt).toHaveBeenCalledWith(
+        'session-1',
+        'Continue in cloud',
+        undefined,
+        'build',
+        { workspaceId: 'cloud:test' },
+      )
+    })
+    expect(api.session.setComposerPreferences).not.toHaveBeenCalled()
   })
 
   it('does not let a stale failed composer save roll back the latest reasoning choice', async () => {

--- a/apps/desktop/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.tsx
@@ -1,5 +1,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { useSessionStore, type Session } from '../../stores/session'
+import { useActiveWorkspaceSupport } from '../../stores/workspace-support'
+import { LOCAL_WORKSPACE_ID } from '../../stores/session-workspace-keys'
 import { t } from '../../helpers/i18n'
 import { ChatInputAttachments } from './ChatInputAttachments'
 import { ChatInputInlinePicker } from './ChatInputInlinePicker'
@@ -84,6 +86,14 @@ export function ChatInput() {
   const [showReasoningMenu, setShowReasoningMenu] = useState(false)
   const [inlinePicker, setInlinePicker] = useState<InlinePickerState | null>(null)
   const { navigate, recordPrompt } = usePromptHistory()
+  const workspaceSupport = useActiveWorkspaceSupport()
+  const workspaceOptions = useMemo(
+    () => workspaceSupport.workspaceId === LOCAL_WORKSPACE_ID
+      ? undefined
+      : { workspaceId: workspaceSupport.workspaceId },
+    [workspaceSupport.workspaceId],
+  )
+  const runtimeControlsManaged = !workspaceSupport.flags.canUseMachineRuntimeConfig
   const currentProjectDirectory = useMemo(
     () => sessions.find((session) => session.id === currentSessionId)?.directory || null,
     [currentSessionId, sessions],
@@ -93,9 +103,13 @@ export function ChatInput() {
     [currentSessionId, sessions],
   )
   const setSessionComposerPreferences = useSessionStore((s) => s.setSessionComposerPreferences)
-  const { currentModel, setCurrentModel, provider, availableModels } = useChatRuntimeSelection(currentSession)
+  const { currentModel, setCurrentModel, provider, availableModels } = useChatRuntimeSelection(currentSession, workspaceOptions)
   const saveComposerPreferences = useCallback((preferences: ComposerPreferencePatch) => {
     if (!currentSessionId) return
+    if (runtimeControlsManaged) {
+      addGlobalError(workspaceSupport.flags.reasons.machineRuntimeConfig)
+      return
+    }
     const sessionsBeforeSave = useSessionStore.getState().sessions
     const sessionBeforeSave = sessionsBeforeSave.find((session) => session.id === currentSessionId)
     const saveVersions = new Map<string, number>()
@@ -129,12 +143,12 @@ export function ChatInput() {
         addGlobalError,
       )
     })
-  }, [addGlobalError, currentSessionId, setSessionComposerPreferences])
+  }, [addGlobalError, currentSessionId, runtimeControlsManaged, setSessionComposerPreferences, workspaceSupport.flags.reasons.machineRuntimeConfig])
   const reasoningSelection = useReasoningVariantSelection(provider, currentModel, availableModels, {
     selectedVariant: currentSession?.composerReasoningVariant ?? null,
     onVariantChange: (variant) => saveComposerPreferences({ reasoningVariant: variant }),
   })
-  const specialistAgents = useMentionableAgents(currentProjectDirectory)
+  const specialistAgents = useMentionableAgents(currentProjectDirectory, workspaceOptions)
 
   const resizeComposerTextarea = useCallback((element = textareaRef.current) => {
     if (!element) return
@@ -143,6 +157,10 @@ export function ChatInput() {
   }, [])
 
   const addFiles = async (files: FileList | File[]) => {
+    if (!workspaceSupport.flags.canAttachFiles) {
+      addGlobalError(workspaceSupport.flags.reasons.attachFiles)
+      return
+    }
     const newAttachments = await filesToAttachments(files)
     setAttachments(prev => [...prev, ...newAttachments])
   }
@@ -150,6 +168,14 @@ export function ChatInput() {
   const handleSubmit = useCallback(async () => {
     const text = input.trim()
     if ((!text && attachments.length === 0) || !currentSessionId) return
+    if (!workspaceSupport.flags.canPrompt) {
+      addGlobalError(workspaceSupport.flags.reasons.prompt)
+      return
+    }
+    if (attachments.length > 0 && !workspaceSupport.flags.canAttachFiles) {
+      addGlobalError(workspaceSupport.flags.reasons.attachFiles)
+      return
+    }
     const directInvocation = resolveDirectAgentInvocation(text, specialistAgents)
     const promptText = directInvocation.text
     setInlinePicker(null)
@@ -157,10 +183,6 @@ export function ChatInput() {
     recordPrompt(text)
 
     const currentAttachments = [...attachments]
-    setInput('')
-    setAttachments([])
-    if (textareaRef.current) textareaRef.current.style.height = 'auto'
-
     try {
       const files = currentAttachments.map(a => ({ mime: a.mime, url: a.url, filename: a.filename }))
       if (!promptText && files.length === 0) {
@@ -168,11 +190,17 @@ export function ChatInput() {
       }
       const message = promptText || 'Describe this image.'
       const promptAgent = directInvocation.agent || agentMode
-      if (reasoningSelection.promptOptions) {
-        await window.coworkApi.session.prompt(currentSessionId, message, files.length > 0 ? files : undefined, promptAgent, reasoningSelection.promptOptions)
+      const promptOptions = runtimeControlsManaged
+        ? workspaceOptions
+        : { ...(reasoningSelection.promptOptions || {}), ...(workspaceOptions || {}) }
+      if (Object.keys(promptOptions || {}).length > 0) {
+        await window.coworkApi.session.prompt(currentSessionId, message, files.length > 0 ? files : undefined, promptAgent, promptOptions)
       } else {
         await window.coworkApi.session.prompt(currentSessionId, message, files.length > 0 ? files : undefined, promptAgent)
       }
+      setInput('')
+      setAttachments([])
+      if (textareaRef.current) textareaRef.current.style.height = 'auto'
     } catch (err) {
       reportComposerError(
         t('chat.promptFailed', 'Could not send the prompt. Please try again.'),
@@ -181,7 +209,7 @@ export function ChatInput() {
         addGlobalError,
       )
     }
-  }, [input, attachments, currentSessionId, agentMode, specialistAgents, addGlobalError, reasoningSelection.promptOptions])
+  }, [input, attachments, currentSessionId, workspaceSupport.flags, specialistAgents, recordPrompt, agentMode, runtimeControlsManaged, workspaceOptions, reasoningSelection.promptOptions, addGlobalError])
 
   const inlineSuggestions = useMemo(() => {
     if (!inlinePicker) return []
@@ -239,6 +267,8 @@ export function ChatInput() {
     setInput,
     setAttachments,
     setInlinePicker,
+    attachmentsAllowed: workspaceSupport.flags.canAttachFiles,
+    onBlockedAttachment: () => addGlobalError(workspaceSupport.flags.reasons.attachFiles),
   })
 
   // Global Shift+Tab to toggle agent mode — works even when textarea loses focus
@@ -272,7 +302,11 @@ export function ChatInput() {
   const handleStop = useCallback(async () => {
     if (!currentSessionId) return
     try {
-      await window.coworkApi.session.abort(currentSessionId)
+      if (workspaceOptions) {
+        await window.coworkApi.session.abort(currentSessionId, workspaceOptions)
+      } else {
+        await window.coworkApi.session.abort(currentSessionId)
+      }
     } catch (err) {
       reportComposerError(
         t('chat.abortFailed', 'Could not stop generation. Please try again.'),
@@ -281,7 +315,7 @@ export function ChatInput() {
         addGlobalError,
       )
     }
-  }, [currentSessionId, addGlobalError])
+  }, [currentSessionId, workspaceOptions, addGlobalError])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (inlinePicker && inlineSuggestions.length > 0) {
@@ -359,6 +393,10 @@ export function ChatInput() {
     }
     if (files.length > 0) {
       e.preventDefault()
+      if (!workspaceSupport.flags.canAttachFiles) {
+        addGlobalError(workspaceSupport.flags.reasons.attachFiles)
+        return
+      }
       await addFiles(files)
     }
   }
@@ -367,11 +405,20 @@ export function ChatInput() {
     e.preventDefault()
     setDragOver(false)
     if (e.dataTransfer.files.length > 0) {
+      if (!workspaceSupport.flags.canAttachFiles) {
+        addGlobalError(workspaceSupport.flags.reasons.attachFiles)
+        return
+      }
       await addFiles(e.dataTransfer.files)
     }
   }
 
-  const canSend = (input.trim() || attachments.length > 0) && currentSessionId && !isGenerating && !isAwaitingPermission && !isAwaitingQuestion
+  const sendBlockedReason = !workspaceSupport.flags.canPrompt
+    ? workspaceSupport.flags.reasons.prompt
+    : attachments.length > 0 && !workspaceSupport.flags.canAttachFiles
+      ? workspaceSupport.flags.reasons.attachFiles
+      : null
+  const canSend = (input.trim() || attachments.length > 0) && currentSessionId && !isGenerating && !isAwaitingPermission && !isAwaitingQuestion && !sendBlockedReason
   const currentModelLabel = (availableModels[provider] || []).find((model) => model.id === currentModel)?.label || currentModel
   const inlineMenuWidth = 260
   // Anchor the menu to the outer input chrome (the whole composer block)
@@ -459,13 +506,21 @@ export function ChatInput() {
             isAwaitingPermission={isAwaitingPermission}
             isAwaitingQuestion={isAwaitingQuestion}
             canSend={!!canSend}
+            sendDisabledReason={sendBlockedReason}
+            attachmentsAllowed={workspaceSupport.flags.canAttachFiles}
+            attachmentsDisabledReason={workspaceSupport.flags.reasons.attachFiles}
+            modelControlsManaged={runtimeControlsManaged}
+            modelControlsReason={workspaceSupport.flags.reasons.machineRuntimeConfig}
+            reasoningControlsManaged={runtimeControlsManaged}
             onAddFiles={addFiles}
             onToggleModelMenu={() => {
+              if (runtimeControlsManaged) return
               setInlinePicker(null)
               setShowReasoningMenu(false)
               setShowModelMenu(!showModelMenu)
             }}
             onToggleReasoningMenu={() => {
+              if (runtimeControlsManaged) return
               setInlinePicker(null)
               setShowModelMenu(false)
               setShowReasoningMenu(!showReasoningMenu)
@@ -478,7 +533,7 @@ export function ChatInput() {
                 const store = useSessionStore.getState()
                 store.addSession(forked)
                 store.setCurrentSession(forked.id)
-                await window.coworkApi.session.activate(forked.id, { force: true })
+                await window.coworkApi.session.activate(forked.id, { force: true, ...(workspaceOptions || {}) })
               }
             }}
             onStop={handleStop}
@@ -503,6 +558,7 @@ export function ChatInput() {
         currentModel={currentModel}
         onClose={() => setShowModelMenu(false)}
         onSelect={async (modelId) => {
+          if (runtimeControlsManaged) return
           setCurrentModel(modelId)
           setShowModelMenu(false)
           saveComposerPreferences({ modelId })

--- a/apps/desktop/src/renderer/components/chat/ChatInputToolbar.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputToolbar.tsx
@@ -15,6 +15,12 @@ type ChatInputToolbarProps = {
   isAwaitingPermission: boolean
   isAwaitingQuestion: boolean
   canSend: boolean
+  sendDisabledReason?: string | null
+  attachmentsAllowed?: boolean
+  attachmentsDisabledReason?: string | null
+  modelControlsManaged?: boolean
+  modelControlsReason?: string | null
+  reasoningControlsManaged?: boolean
   onAddFiles: (files: FileList | File[]) => Promise<void> | void
   onToggleModelMenu: () => void
   onToggleReasoningMenu?: () => void
@@ -38,6 +44,12 @@ export function ChatInputToolbar({
   isAwaitingPermission,
   isAwaitingQuestion,
   canSend,
+  sendDisabledReason,
+  attachmentsAllowed = true,
+  attachmentsDisabledReason,
+  modelControlsManaged = false,
+  modelControlsReason,
+  reasoningControlsManaged = false,
   onAddFiles,
   onToggleModelMenu,
   onToggleReasoningMenu,
@@ -50,9 +62,13 @@ export function ChatInputToolbar({
     <div className="flex items-center justify-between px-3 pb-2.5 pt-0.5">
       <div className="flex items-center gap-1">
         <button
-          onClick={() => fileInputRef.current?.click()}
-          className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-colors cursor-pointer"
-          title={t('chat.attachFile', 'Attach file')}
+          onClick={() => {
+            if (!attachmentsAllowed) return
+            fileInputRef.current?.click()
+          }}
+          disabled={!attachmentsAllowed}
+          className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          title={attachmentsAllowed ? t('chat.attachFile', 'Attach file') : attachmentsDisabledReason || t('chat.attachFileDisabled', 'File attachments are disabled by this workspace policy.')}
         >
           <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
             <line x1="7.5" y1="3" x2="7.5" y2="12" />
@@ -74,9 +90,11 @@ export function ChatInputToolbar({
 
         <div>
           <button
-            ref={modelButtonRef}
-            onClick={onToggleModelMenu}
-            className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer flex items-center gap-1"
+          ref={modelButtonRef}
+            onClick={modelControlsManaged ? undefined : onToggleModelMenu}
+            disabled={modelControlsManaged}
+            title={modelControlsManaged ? modelControlsReason || t('chat.modelManagedByPolicy', 'This workspace manages model selection.') : undefined}
+            className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer flex items-center gap-1 disabled:opacity-60 disabled:cursor-not-allowed"
           >
             {modelLabel}
             <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.2">
@@ -88,9 +106,10 @@ export function ChatInputToolbar({
         {showReasoningControl && onToggleReasoningMenu ? (
           <button
             ref={reasoningButtonRef}
-            onClick={onToggleReasoningMenu}
-            className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer flex items-center gap-1"
-            title={t('chat.reasoningDescription', 'Reasoning mode for models that expose OpenCode variants')}
+            onClick={reasoningControlsManaged ? undefined : onToggleReasoningMenu}
+            disabled={reasoningControlsManaged}
+            className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer flex items-center gap-1 disabled:opacity-60 disabled:cursor-not-allowed"
+            title={reasoningControlsManaged ? modelControlsReason || t('chat.reasoningManagedByPolicy', 'This workspace manages reasoning settings.') : t('chat.reasoningDescription', 'Reasoning mode for models that expose OpenCode variants')}
           >
             {t('chat.reasoningChip', 'Think')} {reasoningLabel || t('chat.reasoningAuto', 'Auto')}
             <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.2">
@@ -186,6 +205,7 @@ export function ChatInputToolbar({
         <button
           onClick={() => void (isGenerating ? onStop() : onSubmit())}
           disabled={!canSend && !isGenerating}
+          title={!canSend && !isGenerating ? sendDisabledReason || undefined : undefined}
           className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all cursor-pointer ${
             isGenerating
               ? 'bg-transparent text-text-muted hover:text-red'

--- a/apps/desktop/src/renderer/components/chat/SessionArtifactList.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionArtifactList.tsx
@@ -18,12 +18,22 @@ function isPreviewableArtifact(artifact: SessionArtifact) {
   return extension ? IMAGE_ARTIFACT_EXTENSIONS.has(extension) : false
 }
 
+function artifactWorkspaceScope(workspaceId?: string) {
+  return workspaceId ? { workspaceId } : {}
+}
+
 export function SessionArtifactList({
   sessionId,
   artifacts,
+  workspaceId,
+  canRevealArtifact = true,
+  revealDisabledReason = 'Cloud artifacts cannot be revealed in the local filesystem.',
 }: {
   sessionId: string
   artifacts: ReturnType<typeof listSessionArtifacts>
+  workspaceId?: string
+  canRevealArtifact?: boolean
+  revealDisabledReason?: string
 }) {
   const [exportingId, setExportingId] = useState<string | null>(null)
   const [composerAction, setComposerAction] = useState<{
@@ -69,6 +79,7 @@ export function SessionArtifactList({
       void window.coworkApi.artifact.readAttachment({
         sessionId,
         filePath: artifact.filePath,
+        ...artifactWorkspaceScope(workspaceId),
       }).then((payload) => {
         if (cancelled) return
         if (!payload.mime.startsWith('image/')) {
@@ -150,6 +161,7 @@ export function SessionArtifactList({
                     const payload = await window.coworkApi.artifact.readAttachment({
                       sessionId,
                       filePath: artifact.filePath,
+                      ...artifactWorkspaceScope(workspaceId),
                     })
                     dispatchComposerCompose({
                       attachments: [attachmentFromArtifact(payload)],
@@ -171,6 +183,7 @@ export function SessionArtifactList({
                       const payload = await window.coworkApi.artifact.readAttachment({
                         sessionId,
                         filePath: artifact.filePath,
+                        ...artifactWorkspaceScope(workspaceId),
                       })
                       dispatchComposerCompose({
                         text: buildChartRerenderPrompt(payload.chart || artifact.chart!),
@@ -186,17 +199,24 @@ export function SessionArtifactList({
                 </button>
               ) : null}
 
-              <button
-                onClick={async () => {
-                  await window.coworkApi.artifact.reveal({
-                    sessionId,
-                    filePath: artifact.filePath,
-                  })
-                }}
-                className="px-2.5 py-1.5 rounded-lg border border-border-subtle text-[11px] text-text-secondary hover:text-text hover:bg-surface-hover transition-colors cursor-pointer whitespace-nowrap"
-              >
-                Reveal
-              </button>
+              {canRevealArtifact && artifact.source !== 'cloud' ? (
+                <button
+                  onClick={async () => {
+                    await window.coworkApi.artifact.reveal({
+                      sessionId,
+                      filePath: artifact.filePath,
+                      ...artifactWorkspaceScope(workspaceId),
+                    })
+                  }}
+                  className="px-2.5 py-1.5 rounded-lg border border-border-subtle text-[11px] text-text-secondary hover:text-text hover:bg-surface-hover transition-colors cursor-pointer whitespace-nowrap"
+                >
+                  Reveal
+                </button>
+              ) : (
+                <span className="px-2.5 py-1.5 text-[11px] text-text-muted" title={revealDisabledReason}>
+                  {artifact.source === 'cloud' ? 'Cloud artifact' : 'Reveal disabled'}
+                </span>
+              )}
 
               <button
                 onClick={async () => {
@@ -206,6 +226,7 @@ export function SessionArtifactList({
                       sessionId,
                       filePath: artifact.filePath,
                       suggestedName: artifact.filename,
+                      ...artifactWorkspaceScope(workspaceId),
                     })
                   } finally {
                     setExportingId(null)

--- a/apps/desktop/src/renderer/components/chat/SessionInspector.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionInspector.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ModelInfoSnapshot, SessionView, TaskRun } from '@open-cowork/shared'
 import { useSessionStore, type Message } from '../../stores/session'
-import { sessionWorkspaceKey } from '../../stores/session-workspace-keys'
+import { LOCAL_WORKSPACE_ID, sessionWorkspaceKey } from '../../stores/session-workspace-keys'
+import { useActiveWorkspaceSupport } from '../../stores/workspace-support'
 import { t } from '../../helpers/i18n'
 import { listSessionArtifacts } from './session-artifacts'
 import { SessionArtifactList } from './SessionArtifactList'
@@ -29,6 +30,10 @@ type RuntimeModelState = {
   providerId: string | null
   modelId: string | null
   contextLimit: number | null
+}
+
+function artifactsContainCloud(view: SessionView) {
+  return (view.artifacts || []).some((artifact) => artifact.source === 'cloud')
 }
 
 function Stat({ label, value }: { label: string; value: string }) {
@@ -149,6 +154,7 @@ export function SessionInspector({ onClose }: InspectorProps) {
   const activeWorkspaceId = useSessionStore((state) => state.activeWorkspaceId)
   const sessions = useSessionStore((state) => state.sessions)
   const currentView = useSessionStore((state) => state.currentView)
+  const workspaceSupport = useActiveWorkspaceSupport()
   // Subscribe to the whole map so the selector returns a stable
   // reference (zustand uses Object.is by default; returning `[]` from
   // a selector on every call triggers infinite re-renders). Slice
@@ -178,7 +184,8 @@ export function SessionInspector({ onClose }: InspectorProps) {
   // Chart PNGs live outside the session dir under appData, so they're
   // available in both modes — keep the tab when either kind is
   // present.
-  const showArtifactsTab = !currentSession?.directory || chartArtifacts.length > 0
+  const activeWorkspaceIsLocal = activeWorkspaceId === LOCAL_WORKSPACE_ID
+  const showArtifactsTab = (!currentSession?.directory && activeWorkspaceIsLocal) || chartArtifacts.length > 0 || artifactsContainCloud(currentView)
 
   useEffect(() => {
     let cancelled = false
@@ -186,7 +193,7 @@ export function SessionInspector({ onClose }: InspectorProps) {
     async function loadRuntimeModel() {
       try {
         const [settings, info] = await Promise.all([
-          window.coworkApi.settings.get(),
+          window.coworkApi.settings.get(activeWorkspaceId === LOCAL_WORKSPACE_ID ? undefined : { workspaceId: activeWorkspaceId }),
           window.coworkApi.model.info(),
         ])
         if (cancelled) return
@@ -215,7 +222,7 @@ export function SessionInspector({ onClose }: InspectorProps) {
     return () => {
       cancelled = true
     }
-  }, [currentSessionId])
+  }, [activeWorkspaceId, currentSessionId])
 
   useEffect(() => {
     if (tab === 'artifacts' && !showArtifactsTab) {
@@ -379,9 +386,17 @@ export function SessionInspector({ onClose }: InspectorProps) {
 
         {tab === 'artifacts' && currentSessionId && (
           <div>
-            <div className="text-[10px] uppercase tracking-[0.08em] text-text-muted">Sandbox Artifacts</div>
+            <div className="text-[10px] uppercase tracking-[0.08em] text-text-muted">
+              {activeWorkspaceIsLocal ? 'Sandbox Artifacts' : 'Cloud Artifacts'}
+            </div>
             <div className="mt-3">
-              <SessionArtifactList sessionId={currentSessionId} artifacts={artifacts} />
+              <SessionArtifactList
+                sessionId={currentSessionId}
+                artifacts={artifacts}
+                workspaceId={activeWorkspaceIsLocal ? undefined : activeWorkspaceId}
+                canRevealArtifact={workspaceSupport.flags.canRevealArtifact}
+                revealDisabledReason={workspaceSupport.flags.reasons.revealArtifact}
+              />
             </div>
           </div>
         )}

--- a/apps/desktop/src/renderer/components/chat/ToolTrace.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolTrace.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { DEFAULT_TOOL_TRACE_RULES, type ToolTraceRule } from '@open-cowork/shared'
 import type { ToolCall } from '../../stores/session'
 import { useSessionStore } from '../../stores/session'
+import { LOCAL_WORKSPACE_ID } from '../../stores/session-workspace-keys'
 import { t } from '../../helpers/i18n'
 import { TOOL_TRACE_RULES_CHANGED_EVENT } from '../../helpers/tool-trace-events'
 import { MermaidChart } from './MermaidChart'
@@ -103,6 +104,10 @@ function toolAttachmentKey(attachment: ToolAttachment, seen: Map<string, number>
   return occurrence === 0 ? base : `${base}:${occurrence + 1}`
 }
 
+function artifactWorkspaceScope(workspaceId?: string) {
+  return workspaceId ? { workspaceId } : {}
+}
+
 interface Props {
   tools: ToolCall[]
   compact?: boolean
@@ -164,6 +169,7 @@ function ArtifactCard({
 export function ToolTrace({ tools, compact = false }: Props) {
   const activeAgent = useSessionStore((s) => s.currentView.activeAgent)
   const currentSessionId = useSessionStore((s) => s.currentSessionId)
+  const activeWorkspaceId = useSessionStore((s) => s.activeWorkspaceId)
   const sessions = useSessionStore((s) => s.sessions)
   const allDone = tools.every((tool) => tool.status === 'complete' || tool.status === 'error')
   const [expanded, setExpanded] = useState(!allDone)
@@ -173,7 +179,8 @@ export function ToolTrace({ tools, compact = false }: Props) {
 
   const currentSession = sessions.find((session) => session.id === currentSessionId) || null
   const toolTraceRules = useToolTraceRules(currentSession?.directory)
-  const privateWorkspace = !currentSession?.directory
+  const privateWorkspace = activeWorkspaceId === LOCAL_WORKSPACE_ID && !currentSession?.directory
+  const workspaceIdForArtifact = activeWorkspaceId === LOCAL_WORKSPACE_ID ? undefined : activeWorkspaceId
   const artifacts = privateWorkspace ? listArtifactsForTools(tools) : []
 
   // Auto-expand while running so user sees progress
@@ -194,6 +201,7 @@ export function ToolTrace({ tools, compact = false }: Props) {
       const payload = await window.coworkApi.artifact.readAttachment({
         sessionId: currentSessionId,
         filePath: artifact.filePath,
+        ...artifactWorkspaceScope(workspaceIdForArtifact),
       })
       dispatchComposerCompose({
         attachments: [attachmentFromArtifact(payload)],
@@ -298,6 +306,7 @@ export function ToolTrace({ tools, compact = false }: Props) {
                 sessionId: currentSessionId,
                 filePath: artifact.filePath,
                 suggestedName: artifact.filename,
+                ...artifactWorkspaceScope(workspaceIdForArtifact),
               })
             } finally {
               setExportingArtifactId(null)
@@ -307,6 +316,7 @@ export function ToolTrace({ tools, compact = false }: Props) {
             await window.coworkApi.artifact.reveal({
               sessionId: currentSessionId,
               filePath: artifact.filePath,
+              ...artifactWorkspaceScope(workspaceIdForArtifact),
             })
           }}
         />

--- a/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
+++ b/apps/desktop/src/renderer/components/chat/useChatInputRuntime.ts
@@ -2,6 +2,7 @@ import { type Dispatch, type RefObject, type SetStateAction, useEffect, useMemo,
 import { t } from '../../helpers/i18n'
 import { useSessionStore } from '../../stores/session'
 import type { Session } from '../../stores/session'
+import type { WorkspaceOptions } from '@open-cowork/shared'
 import type { Attachment, ChatInputModelEntry, InlinePickerState, MentionableAgent } from './chat-input-types'
 import { formatAgentLabel } from '../../helpers/agent-label.ts'
 import { ensureAttachmentId } from './chat-input-utils.ts'
@@ -42,7 +43,7 @@ function reportChatSettingsError(error: unknown) {
   }
 }
 
-export function useChatRuntimeSelection(session?: Session | null) {
+export function useChatRuntimeSelection(session?: Session | null, workspaceOptions?: WorkspaceOptions) {
   const [settingsModel, setSettingsModel] = useState('')
   const [localModelOverride, setLocalModelOverride] = useState<string | null>(null)
   const [provider, setProvider] = useState('')
@@ -54,7 +55,10 @@ export function useChatRuntimeSelection(session?: Session | null) {
   useEffect(() => {
     let disposed = false
     const refreshRuntimeSelection = () => {
-      Promise.all([window.coworkApi.settings.get(), window.coworkApi.app.config()]).then(([settings, config]) => {
+      const settingsRequest = workspaceOptions?.workspaceId
+        ? window.coworkApi.settings.get(workspaceOptions)
+        : window.coworkApi.settings.get()
+      Promise.all([settingsRequest, window.coworkApi.app.config()]).then(([settings, config]) => {
         if (disposed) return
         setSettingsModel(settings.effectiveModel || settings.selectedModelId || '')
         setProvider(settings.effectiveProviderId || '')
@@ -83,7 +87,7 @@ export function useChatRuntimeSelection(session?: Session | null) {
       disposed = true
       unsubscribe()
     }
-  }, [addGlobalError])
+  }, [addGlobalError, workspaceOptions?.workspaceId])
 
   useEffect(() => {
     setLocalModelOverride(null)
@@ -142,22 +146,26 @@ export function useReasoningVariantSelection(
   }
 }
 
-export function useMentionableAgents(currentProjectDirectory: string | null) {
-  const cacheKey = currentProjectDirectory || ''
+export function useMentionableAgents(currentProjectDirectory: string | null, workspaceOptions?: WorkspaceOptions) {
+  const cacheKey = `${workspaceOptions?.workspaceId || 'local'}:${currentProjectDirectory || ''}`
   const [specialistAgents, setSpecialistAgents] = useState<MentionableAgent[]>(() =>
     mentionableAgentCache.get(cacheKey)?.value || [])
 
   useEffect(() => {
     let disposed = false
     let cancelIdle: (() => void) | null = null
-    const nextCacheKey = currentProjectDirectory || ''
+    const nextCacheKey = `${workspaceOptions?.workspaceId || 'local'}:${currentProjectDirectory || ''}`
     const cached = mentionableAgentCache.get(nextCacheKey)?.value
     if (cached) setSpecialistAgents(cached)
 
     const loadMentionableAgents = () => {
       const existing = mentionableAgentCache.get(nextCacheKey)
       if (existing?.promise) return existing.promise
-      const context = currentProjectDirectory ? { directory: currentProjectDirectory } : undefined
+      const context = workspaceOptions?.workspaceId
+        ? workspaceOptions
+        : currentProjectDirectory
+          ? { directory: currentProjectDirectory }
+          : undefined
       const promise = Promise.all([
         window.coworkApi.app.builtinAgents(),
         window.coworkApi.agents.list(context),
@@ -211,7 +219,7 @@ export function useMentionableAgents(currentProjectDirectory: string | null) {
       cancelIdle?.()
       unsubscribe()
     }
-  }, [currentProjectDirectory])
+  }, [currentProjectDirectory, workspaceOptions?.workspaceId])
 
   return specialistAgents
 }
@@ -222,12 +230,16 @@ export function useComposerExternalEvents({
   setInput,
   setAttachments,
   setInlinePicker,
+  attachmentsAllowed = true,
+  onBlockedAttachment,
 }: {
   textareaRef: RefObject<HTMLTextAreaElement | null>
   resizeComposerTextarea: ResizeComposerTextarea
   setInput: Dispatch<SetStateAction<string>>
   setAttachments: Dispatch<SetStateAction<Attachment[]>>
   setInlinePicker: Dispatch<SetStateAction<InlinePickerState | null>>
+  attachmentsAllowed?: boolean
+  onBlockedAttachment?: () => void
 }) {
   useEffect(() => {
     const focusComposer = (cursor?: number) => {
@@ -276,7 +288,12 @@ export function useComposerExternalEvents({
 
       setInlinePicker(null)
       if (nextAttachments.length > 0) {
-        setAttachments((current) => [...current, ...nextAttachments])
+        if (!attachmentsAllowed) {
+          onBlockedAttachment?.()
+          if (!nextText.trim()) return
+        } else {
+          setAttachments((current) => [...current, ...nextAttachments])
+        }
       }
 
       if (nextText.trim()) {
@@ -299,5 +316,5 @@ export function useComposerExternalEvents({
       window.removeEventListener(COMPOSER_INSERT_EVENT, insertHandler as EventListener)
       window.removeEventListener(COMPOSER_COMPOSE_EVENT, composeHandler as EventListener)
     }
-  }, [resizeComposerTextarea, setAttachments, setInlinePicker, setInput, textareaRef])
+  }, [attachmentsAllowed, onBlockedAttachment, resizeComposerTextarea, setAttachments, setInlinePicker, setInput, textareaRef])
 }

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -1,9 +1,19 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Sidebar } from './Sidebar'
 import { installRendererTestCoworkApi } from '../../test/setup'
+import { useWorkspaceSupportStore } from '../../stores/workspace-support'
 
 describe('Sidebar', () => {
+  beforeEach(() => {
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: {},
+      loadedByWorkspace: {},
+      loadingByWorkspace: {},
+      errorByWorkspace: {},
+    })
+  })
+
   it('keeps the upstream sidebar layout when no branding config is provided', () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import { NewThreadButton } from '../sidebar/NewThreadButton'
 import { t } from '../../helpers/i18n'
 import type { AppView } from '../../app-types'
 import { useSessionStore } from '../../stores/session'
+import { useWorkspaceSupportStore } from '../../stores/workspace-support'
 
 interface Props {
   currentView: AppView
@@ -289,23 +290,16 @@ function WorkspaceSwitcher() {
   const setCurrentSession = useSessionStore((state) => state.setCurrentSession)
   const setActiveWorkspace = useSessionStore((state) => state.setActiveWorkspace)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
+  const supportByWorkspace = useWorkspaceSupportStore((state) => state.supportByWorkspace)
+  const loadWorkspaceSupport = useWorkspaceSupportStore((state) => state.loadWorkspaceSupport)
   const [workspaces, setWorkspaces] = useState<WorkspaceInfo[]>([LOCAL_WORKSPACE_FALLBACK])
-  const [supportByWorkspace, setSupportByWorkspace] = useState<Record<string, WorkspaceApiSupport[]>>({})
   const [open, setOpen] = useState(false)
 
   const activeWorkspace = workspaces.find((workspace) => workspace.active) || workspaces[0] || LOCAL_WORKSPACE_FALLBACK
 
   const refreshSupport = async (listedWorkspaces: WorkspaceInfo[], cancelled: () => boolean) => {
-    const workspaceApi = window.coworkApi?.workspace
-    if (!workspaceApi?.support) return
-    const entries = await Promise.all(listedWorkspaces.map(async (workspace) => {
-      try {
-        return [workspace.id, await workspaceApi.support(workspace.id)] as const
-      } catch {
-        return [workspace.id, []] as const
-      }
-    }))
-    if (!cancelled()) setSupportByWorkspace(Object.fromEntries(entries))
+    await Promise.all(listedWorkspaces.map((workspace) => loadWorkspaceSupport(workspace.id, { force: true }).catch(() => [])))
+    if (cancelled()) return
   }
 
   useEffect(() => {
@@ -333,7 +327,7 @@ function WorkspaceSwitcher() {
     return () => {
       cancelled = true
     }
-  }, [setActiveWorkspace, setSessions])
+  }, [loadWorkspaceSupport, setActiveWorkspace, setSessions])
 
   const activateWorkspace = async (workspace: WorkspaceInfo) => {
     const previousId = activeWorkspace.id

--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type {
   CloudProjectSnapshotInventory,
   CloudProjectSourceInput,
-  WorkspaceApiSupport,
 } from '@open-cowork/shared'
 import { useSessionStore } from '../../stores/session'
 import { LOCAL_WORKSPACE_ID, normalizeWorkspaceId } from '../../stores/session-workspace-keys'
+import { supportEntry, supportAllows, useActiveWorkspaceSupport } from '../../stores/workspace-support'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
 import { t } from '../../helpers/i18n'
 
@@ -27,15 +27,6 @@ function reportThreadError(error: unknown, view: string) {
   }
 }
 
-function supportEntry(support: WorkspaceApiSupport[], api: string) {
-  return support.find((entry) => entry.api === api)
-}
-
-function supportAllows(entry: WorkspaceApiSupport | undefined) {
-  if (!entry) return true
-  return entry.status === 'supported' || entry.status === 'read_only' || entry.verdict?.allowed === true
-}
-
 export function NewThreadButton({ onClick }: { onClick?: () => void }) {
   const addSession = useSessionStore((s) => s.addSession)
   const setCurrentSession = useSessionStore((s) => s.setCurrentSession)
@@ -52,21 +43,11 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
   const [snapshotInventory, setSnapshotInventory] = useState<CloudProjectSnapshotInventory | null>(null)
   const [projectBusy, setProjectBusy] = useState(false)
   const [projectError, setProjectError] = useState<string | null>(null)
-  const [workspaceSupportState, setWorkspaceSupportState] = useState<{
-    workspaceId: string
-    entries: WorkspaceApiSupport[]
-    loaded: boolean
-    error: string | null
-  }>({
-    workspaceId: 'local',
-    entries: [],
-    loaded: false,
-    error: null,
-  })
+  const workspaceSupportState = useActiveWorkspaceSupport()
 
   const normalizedWorkspaceId = normalizeWorkspaceId(activeWorkspaceId)
   const activeWorkspaceIsLocal = normalizedWorkspaceId === LOCAL_WORKSPACE_ID
-  const workspaceSupport = workspaceSupportState.workspaceId === normalizedWorkspaceId ? workspaceSupportState.entries : []
+  const workspaceSupport = workspaceSupportState.workspaceId === normalizedWorkspaceId ? workspaceSupportState.support : []
   const workspaceSupportLoaded = workspaceSupportState.workspaceId === normalizedWorkspaceId && workspaceSupportState.loaded
   const workspaceSupportError = workspaceSupportState.workspaceId === normalizedWorkspaceId ? workspaceSupportState.error : null
   const createSupport = supportEntry(workspaceSupport, 'sessions.create')
@@ -76,9 +57,9 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
       ? t('newThread.policyChecking', 'Checking cloud workspace policy.')
       : createSupport?.verdict?.reason || t('newThread.createBlocked', 'Thread creation is disabled by this workspace policy.'))
   const localFilesReason = localFilesSupport?.verdict?.reason || t('newThread.localFilesBlocked', 'Cloud workspaces do not implicitly upload local files.')
-  const blankDisabled = (!activeWorkspaceIsLocal && (!workspaceSupportLoaded || Boolean(workspaceSupportError))) || !supportAllows(createSupport)
+  const blankDisabled = (!activeWorkspaceIsLocal && (!workspaceSupportLoaded || Boolean(workspaceSupportError))) || !supportAllows(createSupport, { mutation: true })
   const projectDisabled = activeWorkspaceIsLocal
-    ? blankDisabled || !supportAllows(localFilesSupport)
+    ? blankDisabled || !supportAllows(localFilesSupport, { mutation: true })
     : blankDisabled
   const projectDisabledReason = blankDisabled
     ? cloudCreateReason
@@ -93,40 +74,6 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
     : activeWorkspaceIsLocal
       ? t('newThread.projectHint', 'Local-only action - choose a directory the agent can read and edit')
       : t('newThread.cloudProjectHint', 'Cloud-safe action - choose Git or upload an explicit snapshot')
-
-  useEffect(() => {
-    let cancelled = false
-    setWorkspaceSupportState({
-      workspaceId: normalizedWorkspaceId,
-      entries: [],
-      loaded: false,
-      error: null,
-    })
-    window.coworkApi.workspace.support(normalizedWorkspaceId)
-      .then((support) => {
-        if (!cancelled) {
-          setWorkspaceSupportState({
-            workspaceId: normalizedWorkspaceId,
-            entries: support,
-            loaded: true,
-            error: null,
-          })
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setWorkspaceSupportState({
-            workspaceId: normalizedWorkspaceId,
-            entries: [],
-            loaded: true,
-            error: t('newThread.policyUnavailable', 'Could not load this workspace policy.'),
-          })
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [normalizedWorkspaceId])
 
   const closeProjectDialog = () => {
     setShowCloudProjectDialog(false)

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SMALL_MODEL_USE_MAIN, type EffectiveAppSettings, type PublicAppConfig } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { useSessionStore } from '../../stores/session'
+import { WORKSPACE_SUPPORT_APIS, useWorkspaceSupportStore } from '../../stores/workspace-support'
 import { SettingsPanel } from './SettingsPanel'
 
 function settings(overrides: Partial<EffectiveAppSettings> = {}): EffectiveAppSettings {
@@ -92,12 +93,19 @@ function deferred<T>() {
 beforeEach(() => {
   vi.clearAllMocks()
   useSessionStore.setState({
+    activeWorkspaceId: 'local',
     globalErrors: [],
     busySessions: new Set(),
     awaitingPermissionSessions: new Set(),
     awaitingQuestionSessions: new Set(),
     sessionStateById: {},
     chartArtifactsBySession: {},
+  })
+  useWorkspaceSupportStore.setState({
+    supportByWorkspace: {},
+    loadedByWorkspace: {},
+    loadingByWorkspace: {},
+    errorByWorkspace: {},
   })
 })
 
@@ -296,6 +304,66 @@ describe('SettingsPanel', () => {
 
     expect(screen.queryByRole('switch', { name: 'Improvement proposals' })).not.toBeInTheDocument()
     expect(screen.queryByRole('switch', { name: 'Scheduled consolidation' })).not.toBeInTheDocument()
+  })
+
+  it('limits cloud settings to portable policy-managed fields', async () => {
+    const user = userEvent.setup()
+    const settingsSet = vi.fn(async (updates: Partial<EffectiveAppSettings>) => settings(updates))
+    const getProviderCredentials = vi.fn(async () => ({ apiKey: 'should-not-load' }))
+    useSessionStore.setState({ activeWorkspaceId: 'cloud:test' })
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: {
+        'cloud:test': WORKSPACE_SUPPORT_APIS.map((api) => ({
+          api,
+          status: api === 'settings.portable' ? 'supported' : 'not_supported',
+          verdict: {
+            allowed: api === 'settings.portable',
+            reason: api === 'settings.portable' ? null : 'Blocked by cloud policy.',
+          },
+        })),
+      },
+      loadedByWorkspace: { 'cloud:test': true },
+      loadingByWorkspace: {},
+      errorByWorkspace: {},
+    })
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => config),
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials,
+        set: settingsSet,
+      },
+      artifact: {
+        storageStats: vi.fn(async () => {
+          throw new Error('local storage must not load for cloud settings')
+        }),
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await user.click(screen.getByRole('button', { name: /Models/ }))
+
+    expect(screen.getByText('Cloud profile runtime')).toBeInTheDocument()
+    expect(screen.queryByText('Permissions')).not.toBeInTheDocument()
+    expect(screen.queryByText('Storage')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('sk-or-...')).not.toBeInTheDocument()
+    expect(getProviderCredentials).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }))
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1))
+    expect(settingsSet.mock.calls[0]?.[0]).toEqual({
+      workspaceId: 'cloud:test',
+      selectedProviderId: 'openrouter',
+      selectedModelId: 'anthropic/claude-sonnet-4',
+      selectedSmallModelId: null,
+      workflowDesktopNotifications: true,
+      workflowQuietHoursStart: null,
+      workflowQuietHoursEnd: null,
+    })
   })
 
   it('does not overwrite credential edits when scoped provider credentials resolve late', async () => {

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -12,6 +12,8 @@ import {
   type AppearancePreferences,
 } from '../../helpers/theme'
 import { useSessionStore } from '../../stores/session'
+import { useActiveWorkspaceSupport } from '../../stores/workspace-support'
+import { LOCAL_WORKSPACE_ID } from '../../stores/session-workspace-keys'
 import { mergeFetchedProviderCredentials, stripMaskedProviderCredentials } from '../provider/credential-merge'
 import { AppearancePreview } from './SettingsAppearancePanel'
 import { WorkflowSettingsPanel } from './SettingsWorkflowsPanel'
@@ -46,6 +48,44 @@ function stripMaskedSettingsCredentials(settings: EffectiveAppSettings): Effecti
   }
 }
 
+function CloudModelsPolicyPanel({ settings }: { settings: EffectiveAppSettings }) {
+  const provider = settings.effectiveProviderId || settings.selectedProviderId || 'Profile default'
+  const model = settings.effectiveModel || settings.selectedModelId || 'Profile default'
+  const smallModel = settings.effectiveSmallModel || settings.selectedSmallModelId || 'Profile default'
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-2xl border border-border-subtle bg-surface px-4 py-4">
+        <div className="text-[12px] font-semibold text-text">{t('settings.cloudModels.title', 'Cloud profile runtime')}</div>
+        <div className="mt-1 text-[11px] leading-relaxed text-text-muted">
+          {t('settings.cloudModels.description', 'This cloud workspace resolves providers, models, credentials, and runtime config through its cloud profile. Desktop shows policy-managed metadata only and never receives raw provider keys.')}
+        </div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {[
+          { label: t('settings.cloudModels.provider', 'Provider'), value: provider },
+          { label: t('settings.cloudModels.model', 'Model'), value: model },
+          { label: t('settings.cloudModels.smallModel', 'Small model'), value: smallModel },
+        ].map((entry) => (
+          <div key={entry.label} className="rounded-2xl border border-border-subtle bg-elevated px-3 py-3">
+            <div className="text-[10px] uppercase tracking-[0.08em] text-text-muted">{entry.label}</div>
+            <div className="mt-1 truncate text-[12px] font-semibold text-text" title={entry.value}>{entry.value}</div>
+            <div className="mt-1 text-[10px] text-text-muted">{t('settings.cloudModels.managed', 'Policy managed')}</div>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-2xl border border-border-subtle bg-surface px-4 py-4">
+        <div className="text-[12px] font-semibold text-text">{t('settings.cloudModels.credentials', 'Credential status')}</div>
+        <div className="mt-2 grid gap-2 text-[11px] text-text-muted">
+          <div>{t('settings.cloudModels.adminManaged', 'admin_managed: configured by the organisation and hidden from clients.')}</div>
+          <div>{t('settings.cloudModels.configured', 'configured: a cloud BYOK secret exists, but plaintext is never synced to desktop.')}</div>
+          <div>{t('settings.cloudModels.missing', 'missing: the workspace cannot execute until an admin adds the required key.')}</div>
+          <div>{t('settings.cloudModels.expired', 'expired: the cloud credential needs to be refreshed or replaced.')}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function SettingsPanel({
   onClose,
 }: {
@@ -61,6 +101,9 @@ export function SettingsPanel({
   const [runningCleanup, setRunningCleanup] = useState<SandboxCleanupResult['mode'] | null>(null)
   const [lastCleanup, setLastCleanup] = useState<SandboxCleanupResult | null>(null)
   const addGlobalError = useSessionStore((state) => state.addGlobalError)
+  const workspaceSupport = useActiveWorkspaceSupport()
+  const activeWorkspaceIsLocal = workspaceSupport.workspaceId === LOCAL_WORKSPACE_ID
+  const workspaceOptions = activeWorkspaceIsLocal ? undefined : { workspaceId: workspaceSupport.workspaceId }
   const dirtyProviderCredentialKeys = useRef<Record<string, Set<string>>>({})
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -77,9 +120,9 @@ export function SettingsPanel({
     // tab fetches only the active provider's real credential bag below.
     let cancelled = false
     Promise.all([
-      window.coworkApi.settings.get(),
+      activeWorkspaceIsLocal ? window.coworkApi.settings.get() : window.coworkApi.settings.get(workspaceOptions),
       window.coworkApi.app.config(),
-      window.coworkApi.artifact.storageStats(),
+      activeWorkspaceIsLocal ? window.coworkApi.artifact.storageStats() : Promise.resolve(null),
     ])
       .then(([nextSettings, nextConfig, nextStorage]) => {
         if (cancelled) return
@@ -93,9 +136,10 @@ export function SettingsPanel({
         reportSettingsPanelError(err, 'Failed to load settings panel')
       })
     return () => { cancelled = true }
-  }, [addGlobalError])
+  }, [activeWorkspaceIsLocal, addGlobalError, workspaceOptions?.workspaceId])
 
   useEffect(() => {
+    if (!activeWorkspaceIsLocal) return
     const providerId = settings?.effectiveProviderId
     if (!providerId) return
     let cancelled = false
@@ -121,7 +165,7 @@ export function SettingsPanel({
       reportSettingsPanelError(err, `Failed to load provider credentials for ${providerId}`)
     })
     return () => { cancelled = true }
-  }, [addGlobalError, settings?.effectiveProviderId])
+  }, [activeWorkspaceIsLocal, addGlobalError, settings?.effectiveProviderId])
 
   useEffect(() => {
     return () => {
@@ -136,39 +180,54 @@ export function SettingsPanel({
     () => [
         { id: 'appearance' as const, label: t('settings.tab.appearance', 'Appearance'), description: t('settings.tab.appearanceDescription', 'Theme, color scheme, and fonts') },
         { id: 'models' as const, label: t('settings.tab.models', 'Models'), description: t('settings.tab.modelsDescription', 'Provider, model, and credentials') },
-        { id: 'permissions' as const, label: t('settings.tab.permissions', 'Permissions'), description: t('settings.tab.permissionsDescription', 'Local tool access') },
+        ...(activeWorkspaceIsLocal ? [{ id: 'permissions' as const, label: t('settings.tab.permissions', 'Permissions'), description: t('settings.tab.permissionsDescription', 'Local tool access') }] : []),
         { id: 'workflows' as const, label: t('settings.tab.workflows', 'Workflows'), description: t('settings.tab.workflowsDescription', 'Run behavior and notifications') },
-        { id: 'storage' as const, label: t('settings.tab.storage', 'Storage'), description: t('settings.tab.storageDescription', 'Sandbox artifacts and cleanup') },
+        ...(activeWorkspaceIsLocal ? [{ id: 'storage' as const, label: t('settings.tab.storage', 'Storage'), description: t('settings.tab.storageDescription', 'Sandbox artifacts and cleanup') }] : []),
       ],
-    [],
+    [activeWorkspaceIsLocal],
   )
+
+  useEffect(() => {
+    if (tabs.some((entry) => entry.id === tab)) return
+    setTab('appearance')
+  }, [tab, tabs])
 
   const persistSettings = async (options: { showSaved?: boolean } = {}) => {
     if (!settings) return false
     const { showSaved = true } = options
     setSaveError(null)
     try {
-      const savedSettings = await window.coworkApi.settings.set({
-        selectedProviderId: settings.selectedProviderId,
-        selectedModelId: settings.selectedModelId,
-        selectedSmallModelId: settings.selectedSmallModelId ?? null,
-        providerCredentials: settings.providerCredentials,
-        integrationCredentials: settings.integrationCredentials,
-        bashPermission: settings.bashPermission,
-        fileWritePermission: settings.fileWritePermission,
-        enableBash: settings.enableBash,
-        enableFileWrite: settings.enableFileWrite,
-        runtimeConfigSource: settings.runtimeConfigSource,
-        runtimeToolingBridgeEnabled: settings.runtimeToolingBridgeEnabled,
-        workflowLaunchAtLogin: settings.workflowLaunchAtLogin,
-        workflowRunInBackground: settings.workflowRunInBackground,
-        workflowDesktopNotifications: settings.workflowDesktopNotifications,
-        workflowQuietHoursStart: settings.workflowQuietHoursStart,
-        workflowQuietHoursEnd: settings.workflowQuietHoursEnd,
-      })
+      const savedSettings = await window.coworkApi.settings.set(activeWorkspaceIsLocal
+        ? {
+            selectedProviderId: settings.selectedProviderId,
+            selectedModelId: settings.selectedModelId,
+            selectedSmallModelId: settings.selectedSmallModelId ?? null,
+            providerCredentials: settings.providerCredentials,
+            integrationCredentials: settings.integrationCredentials,
+            bashPermission: settings.bashPermission,
+            fileWritePermission: settings.fileWritePermission,
+            enableBash: settings.enableBash,
+            enableFileWrite: settings.enableFileWrite,
+            runtimeConfigSource: settings.runtimeConfigSource,
+            runtimeToolingBridgeEnabled: settings.runtimeToolingBridgeEnabled,
+            workflowLaunchAtLogin: settings.workflowLaunchAtLogin,
+            workflowRunInBackground: settings.workflowRunInBackground,
+            workflowDesktopNotifications: settings.workflowDesktopNotifications,
+            workflowQuietHoursStart: settings.workflowQuietHoursStart,
+            workflowQuietHoursEnd: settings.workflowQuietHoursEnd,
+          }
+        : {
+            workspaceId: workspaceSupport.workspaceId,
+            selectedProviderId: settings.selectedProviderId,
+            selectedModelId: settings.selectedModelId,
+            selectedSmallModelId: settings.selectedSmallModelId ?? null,
+            workflowDesktopNotifications: settings.workflowDesktopNotifications,
+            workflowQuietHoursStart: settings.workflowQuietHoursStart,
+            workflowQuietHoursEnd: settings.workflowQuietHoursEnd,
+          })
       dirtyProviderCredentialKeys.current = {}
       let next = savedSettings
-      if (savedSettings.effectiveProviderId) {
+      if (activeWorkspaceIsLocal && savedSettings.effectiveProviderId) {
         try {
           next = {
             ...savedSettings,
@@ -214,6 +273,7 @@ export function SettingsPanel({
   const runCleanup = async (mode: SandboxCleanupResult['mode']) => {
     try {
       setRunningCleanup(mode)
+      if (!activeWorkspaceIsLocal) return
       const result = await window.coworkApi.artifact.cleanup(mode)
       setLastCleanup(result)
       setStorageStats(await window.coworkApi.artifact.storageStats())
@@ -246,7 +306,11 @@ export function SettingsPanel({
       <div className="flex items-center justify-between px-5 py-4 border-b border-border-subtle">
         <div>
           <div className="text-[14px] font-semibold text-text">{t('settings.title', 'Settings')}</div>
-          <div className="text-[11px] text-text-muted mt-0.5">{t('settings.subtitle', 'Tune the shell, model runtime, and local permissions.')}</div>
+          <div className="text-[11px] text-text-muted mt-0.5">
+            {activeWorkspaceIsLocal
+              ? t('settings.subtitle', 'Tune the shell, model runtime, and local permissions.')
+              : t('settings.cloudSubtitle', 'Tune portable cloud workspace preferences. Runtime and credentials are policy-managed.')}
+          </div>
         </div>
         <button onClick={onClose} className="text-[11px] text-text-muted hover:text-text-secondary cursor-pointer transition-colors">{t('settings.done', 'Done')}</button>
       </div>
@@ -278,14 +342,18 @@ export function SettingsPanel({
               </div>
             )}
             {tab === 'models' && (
-              <ModelsPanel
-                config={config}
-                settings={settings}
-                update={update}
-                updateProviderCredential={updateProviderCredential}
-                onConfigRefreshed={setConfig}
-                onPersistSettings={() => persistSettings({ showSaved: false })}
-              />
+              activeWorkspaceIsLocal ? (
+                <ModelsPanel
+                  config={config}
+                  settings={settings}
+                  update={update}
+                  updateProviderCredential={updateProviderCredential}
+                  onConfigRefreshed={setConfig}
+                  onPersistSettings={() => persistSettings({ showSaved: false })}
+                />
+              ) : (
+                <CloudModelsPolicyPanel settings={settings} />
+              )
             )}
             {tab === 'permissions' && (
               <PermissionsPanel permissions={config.permissions} settings={settings} update={update} />
@@ -307,6 +375,9 @@ export function SettingsPanel({
             <div className="text-[11px]">
               <div className="text-text-muted">
                 {t('settings.saveHint', 'Appearance changes apply immediately. Provider and permission changes restart the runtime when needed.')}
+                {!activeWorkspaceIsLocal
+                  ? ` ${t('settings.cloudSaveHint', 'Only portable cloud preferences are saved for this workspace.')}`
+                  : ''}
               </div>
               {saveError ? (
                 <div className="mt-1" style={{ color: 'var(--color-red)' }}>

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CoworkAPI, EffectiveAppSettings, WorkflowListPayload } from '@open-cowork/shared'
 import { WorkflowsPage } from './WorkflowsPage'
+import { useSessionStore } from '../../stores/session'
+import { WORKSPACE_SUPPORT_APIS, useWorkspaceSupportStore } from '../../stores/workspace-support'
 
 function payload(overrides: Partial<WorkflowListPayload> = {}): WorkflowListPayload {
   return {
@@ -99,6 +101,16 @@ function installApi(
 }
 
 describe('WorkflowsPage', () => {
+  beforeEach(() => {
+    useSessionStore.setState({ activeWorkspaceId: 'local' })
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: {},
+      loadedByWorkspace: {},
+      loadingByWorkspace: {},
+      errorByWorkspace: {},
+    })
+  })
+
   it('starts workflow creation in a setup thread', async () => {
     const { api } = installApi(payload({ workflows: [] }))
     const onOpenThread = vi.fn()
@@ -136,6 +148,38 @@ describe('WorkflowsPage', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Run' }))
 
     expect(api.workflows?.runNow).toHaveBeenCalledWith('workflow-1')
+    await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith('ses_run'))
+  })
+
+  it('uses cloud workflow APIs and hides local webhook mutation controls', async () => {
+    useSessionStore.setState({ activeWorkspaceId: 'cloud:test' })
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: {
+        'cloud:test': WORKSPACE_SUPPORT_APIS.map((api) => ({
+          api,
+          status: api === 'workflows.list' || api === 'workflows.run' ? 'supported' : 'not_supported',
+          verdict: {
+            allowed: api === 'workflows.list' || api === 'workflows.run',
+            reason: api.startsWith('workflows') ? null : 'Blocked by cloud policy.',
+          },
+        })),
+      },
+      loadedByWorkspace: { 'cloud:test': true },
+      loadingByWorkspace: {},
+      errorByWorkspace: {},
+    })
+    const { api } = installApi()
+    const onOpenThread = vi.fn()
+
+    render(<WorkflowsPage onOpenThread={onOpenThread} />)
+
+    expect(await screen.findByText('Inbox summary')).toBeInTheDocument()
+    expect(api.workflows?.list).toHaveBeenCalledWith({ workspaceId: 'cloud:test' })
+    expect(screen.queryByRole('button', { name: 'Regenerate' })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    expect(api.workflows?.runNow).toHaveBeenCalledWith('workflow-1', { workspaceId: 'cloud:test' })
     await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith('ses_run'))
   })
 

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { EffectiveAppSettings, WorkflowListPayload, WorkflowRun, WorkflowSummary, WorkflowTrigger } from '@open-cowork/shared'
 import { formatDate as formatLocalizedDate } from '../../helpers/i18n'
+import { useActiveWorkspaceSupport } from '../../stores/workspace-support'
+import { LOCAL_WORKSPACE_ID } from '../../stores/session-workspace-keys'
 
 type Props = {
   onOpenThread: (sessionId: string) => void
@@ -80,6 +82,9 @@ export function WorkflowsPage({ onOpenThread }: Props) {
   const [feedback, setFeedback] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [runtimeConfigSource, setRuntimeConfigSource] = useState<EffectiveAppSettings['runtimeConfigSource']>('app')
+  const workspaceSupport = useActiveWorkspaceSupport()
+  const activeWorkspaceIsLocal = workspaceSupport.workspaceId === LOCAL_WORKSPACE_ID
+  const workspaceOptions = activeWorkspaceIsLocal ? undefined : { workspaceId: workspaceSupport.workspaceId }
 
   const activeWorkflows = useMemo(
     () => payload.workflows.filter((workflow) => workflow.status !== 'archived'),
@@ -90,7 +95,9 @@ export function WorkflowsPage({ onOpenThread }: Props) {
   const refresh = async () => {
     setLoading(true)
     try {
-      setPayload(await window.coworkApi.workflows.list())
+      setPayload(activeWorkspaceIsLocal
+        ? await window.coworkApi.workflows.list()
+        : await window.coworkApi.workflows.list(workspaceOptions))
     } finally {
       setLoading(false)
     }
@@ -98,7 +105,10 @@ export function WorkflowsPage({ onOpenThread }: Props) {
 
   useEffect(() => {
     void refresh()
-    void window.coworkApi.settings.get().then((settings) => {
+    const settingsRequest = activeWorkspaceIsLocal
+      ? window.coworkApi.settings.get()
+      : window.coworkApi.settings.get(workspaceOptions)
+    void settingsRequest.then((settings) => {
       setRuntimeConfigSource(settings.runtimeConfigSource === 'machine' ? 'machine' : 'app')
     }).catch(() => {
       setRuntimeConfigSource('app')
@@ -106,13 +116,19 @@ export function WorkflowsPage({ onOpenThread }: Props) {
     return window.coworkApi.on.workflowUpdated(() => {
       void refresh()
     })
-  }, [])
-  const workflowDraftBlocked = runtimeConfigSource === 'machine'
+  }, [workspaceOptions?.workspaceId])
+  const workflowDraftBlocked = !activeWorkspaceIsLocal || runtimeConfigSource === 'machine'
+  const workflowActionBlocked = !workspaceSupport.flags.canRunWorkflow
+  const workflowActionReason = workflowActionBlocked ? workspaceSupport.flags.reasons.runWorkflow : null
 
   const runAction = async (workflowId: string, action: () => Promise<unknown>, message: string) => {
     setBusyId(workflowId)
     setFeedback(null)
     try {
+      if (workflowActionBlocked) {
+        setFeedback(workflowActionReason || 'Workflow runs are disabled by this workspace policy.')
+        return
+      }
       const result = await action()
       setFeedback(message)
       if (result && typeof result === 'object' && 'sessionId' in result) {
@@ -128,6 +144,10 @@ export function WorkflowsPage({ onOpenThread }: Props) {
   }
 
   const startDraft = async () => {
+    if (!activeWorkspaceIsLocal) {
+      setFeedback('Cloud workflow creation is managed by the cloud workspace. Existing cloud workflows can be run when policy allows it.')
+      return
+    }
     if (workflowDraftBlocked) {
       setFeedback('Switch OpenCode config source to In app before adding workflows. Workflow setup uses Cowork’s Workflow Designer agent and Workflows tool.')
       return
@@ -135,7 +155,9 @@ export function WorkflowsPage({ onOpenThread }: Props) {
     setBusyId('new')
     setFeedback(null)
     try {
-      const session = await window.coworkApi.workflows.startDraft()
+      const session = activeWorkspaceIsLocal
+        ? await window.coworkApi.workflows.startDraft()
+        : await window.coworkApi.workflows.startDraft(null, workspaceOptions)
       onOpenThread(session.id)
       await refresh()
     } catch (error) {
@@ -171,7 +193,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
             className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-60"
               onClick={() => void startDraft()}
               disabled={busyId === 'new' || workflowDraftBlocked}
-              title={workflowDraftBlocked ? 'Workflow setup requires the in-app OpenCode config source.' : undefined}
+              title={!activeWorkspaceIsLocal ? 'Cloud workflow creation is managed by this cloud workspace.' : workflowDraftBlocked ? 'Workflow setup requires the in-app OpenCode config source.' : undefined}
             >
             {busyId === 'new' ? 'Starting...' : 'Add workflow'}
           </button>
@@ -192,7 +214,9 @@ export function WorkflowsPage({ onOpenThread }: Props) {
               <h2 className="text-lg font-semibold text-primary">No workflows yet</h2>
               <p className="mt-2 max-w-md text-sm text-muted">
                 {workflowDraftBlocked
-                  ? 'Workflow setup requires the in-app OpenCode config source because it uses Cowork’s Workflow Designer agent and Workflows tool.'
+                  ? activeWorkspaceIsLocal
+                    ? 'Workflow setup requires the in-app OpenCode config source because it uses Cowork’s Workflow Designer agent and Workflows tool.'
+                    : 'Cloud workflow creation is managed by the cloud workspace. Existing workflows will appear here when available.'
                   : 'Start with a thread. The Workflow Designer agent will help clarify the task, tools, skills, agent, schedule, and webhook trigger before saving anything.'}
               </p>
               <button
@@ -200,7 +224,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
                 className="mt-5 rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-60"
                 onClick={() => void startDraft()}
                 disabled={workflowDraftBlocked}
-                title={workflowDraftBlocked ? 'Workflow setup requires the in-app OpenCode config source.' : undefined}
+                title={!activeWorkspaceIsLocal ? 'Cloud workflow creation is managed by this cloud workspace.' : workflowDraftBlocked ? 'Workflow setup requires the in-app OpenCode config source.' : undefined}
               >
                 Add workflow
               </button>
@@ -234,21 +258,38 @@ export function WorkflowsPage({ onOpenThread }: Props) {
                     <button
                       type="button"
                       className="rounded-md border border-border px-3 py-1.5 text-sm text-secondary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-                      disabled={busyId === workflow.id || workflow.status === 'running'}
-                      onClick={() => void runAction(workflow.id, () => window.coworkApi.workflows.runNow(workflow.id), 'Workflow run started.')}
+                      disabled={busyId === workflow.id || workflow.status === 'running' || workflowActionBlocked}
+                      title={workflowActionReason || undefined}
+                      onClick={() => void runAction(workflow.id, () => (
+                        activeWorkspaceIsLocal
+                          ? window.coworkApi.workflows.runNow(workflow.id)
+                          : window.coworkApi.workflows.runNow(workflow.id, workspaceOptions)
+                      ), 'Workflow run started.')}
                     >
                       Run
                     </button>
                     {workflow.status === 'paused' ? (
-                      <button type="button" className="rounded-md border border-border px-3 py-1.5 text-sm text-secondary hover:bg-muted" onClick={() => void runAction(workflow.id, () => window.coworkApi.workflows.resume(workflow.id), 'Workflow resumed.')}>
+                      <button type="button" className="rounded-md border border-border px-3 py-1.5 text-sm text-secondary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60" disabled={workflowActionBlocked} title={workflowActionReason || undefined} onClick={() => void runAction(workflow.id, () => (
+                        activeWorkspaceIsLocal
+                          ? window.coworkApi.workflows.resume(workflow.id)
+                          : window.coworkApi.workflows.resume(workflow.id, workspaceOptions)
+                      ), 'Workflow resumed.')}>
                         Resume
                       </button>
                     ) : (
-                      <button type="button" className="rounded-md border border-border px-3 py-1.5 text-sm text-secondary hover:bg-muted" onClick={() => void runAction(workflow.id, () => window.coworkApi.workflows.pause(workflow.id), 'Workflow paused.')}>
+                      <button type="button" className="rounded-md border border-border px-3 py-1.5 text-sm text-secondary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60" disabled={workflowActionBlocked} title={workflowActionReason || undefined} onClick={() => void runAction(workflow.id, () => (
+                        activeWorkspaceIsLocal
+                          ? window.coworkApi.workflows.pause(workflow.id)
+                          : window.coworkApi.workflows.pause(workflow.id, workspaceOptions)
+                      ), 'Workflow paused.')}>
                         Pause
                       </button>
                     )}
-                    <button type="button" className="rounded-md border border-red-400/30 px-3 py-1.5 text-sm text-red-200 hover:bg-red-500/10" onClick={() => void runAction(workflow.id, () => window.coworkApi.workflows.archive(workflow.id), 'Workflow archived.')}>
+                    <button type="button" className="rounded-md border border-red-400/30 px-3 py-1.5 text-sm text-red-200 hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60" disabled={workflowActionBlocked} title={workflowActionReason || undefined} onClick={() => void runAction(workflow.id, () => (
+                      activeWorkspaceIsLocal
+                        ? window.coworkApi.workflows.archive(workflow.id)
+                        : window.coworkApi.workflows.archive(workflow.id, workspaceOptions)
+                    ), 'Workflow archived.')}>
                       Archive
                     </button>
                   </div>
@@ -288,9 +329,11 @@ export function WorkflowsPage({ onOpenThread }: Props) {
                     <button type="button" className="rounded-md border border-border px-3 py-1.5 text-xs text-secondary hover:bg-muted" onClick={() => void copyWebhook(workflow)}>
                       Copy curl
                     </button>
-                    <button type="button" className="rounded-md border border-border px-3 py-1.5 text-xs text-secondary hover:bg-muted" onClick={() => void runAction(workflow.id, () => window.coworkApi.workflows.regenerateWebhookSecret(workflow.id), 'Webhook secret regenerated.')}>
-                      Regenerate
-                    </button>
+                    {activeWorkspaceIsLocal ? (
+                      <button type="button" className="rounded-md border border-border px-3 py-1.5 text-xs text-secondary hover:bg-muted" onClick={() => void runAction(workflow.id, () => window.coworkApi.workflows.regenerateWebhookSecret(workflow.id), 'Webhook secret regenerated.')}>
+                        Regenerate
+                      </button>
+                    ) : null}
                   </div>
                 ) : null}
               </article>

--- a/apps/desktop/src/renderer/stores/workspace-support.ts
+++ b/apps/desktop/src/renderer/stores/workspace-support.ts
@@ -1,0 +1,213 @@
+import { useEffect, useMemo } from 'react'
+import { create } from 'zustand'
+import type { WorkspaceApiSupport, WorkspaceApiSupportStatus } from '@open-cowork/shared'
+import { useSessionStore } from './session'
+import { LOCAL_WORKSPACE_ID, normalizeWorkspaceId } from './session-workspace-keys'
+
+export const WORKSPACE_SUPPORT_APIS = [
+  'sessions.list',
+  'sessions.create',
+  'sessions.activate',
+  'sessions.get',
+  'sessions.prompt',
+  'sessions.abort',
+  'sessions.fileSnippet',
+  'sessions.diff',
+  'threads.search',
+  'threads.tags',
+  'threads.smartFilters',
+  'workflows.list',
+  'workflows.run',
+  'artifacts.list',
+  'artifacts.upload',
+  'artifacts.download',
+  'artifacts.reveal',
+  'settings.portable',
+  'customContent.agents',
+  'customContent.skills',
+  'customContent.mcps',
+  'capabilities.catalog',
+  'localFiles',
+  'localStdioMcps',
+  'machineRuntimeConfig',
+] as const
+
+const LOCAL_SUPPORT: WorkspaceApiSupport[] = WORKSPACE_SUPPORT_APIS.map((api) => ({
+  api,
+  status: 'supported',
+  verdict: { allowed: true, reason: null },
+}))
+
+type WorkspaceSupportState = {
+  supportByWorkspace: Record<string, WorkspaceApiSupport[]>
+  loadedByWorkspace: Record<string, boolean>
+  loadingByWorkspace: Record<string, boolean>
+  errorByWorkspace: Record<string, string | null>
+  setWorkspaceSupport: (workspaceId: string, support: WorkspaceApiSupport[]) => void
+  loadWorkspaceSupport: (workspaceId: string, options?: { force?: boolean }) => Promise<WorkspaceApiSupport[]>
+}
+
+function describeSupportError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function supportEntry(support: WorkspaceApiSupport[] | undefined, api: string) {
+  return (support || []).find((entry) => entry.api === api)
+}
+
+export function supportAllows(entry: WorkspaceApiSupport | undefined, options: { mutation?: boolean } = {}) {
+  if (!entry) return true
+  if (options.mutation && entry.status !== 'supported') return false
+  return entry.status === 'supported' || entry.status === 'read_only' || entry.verdict?.allowed === true
+}
+
+export function supportReason(
+  support: WorkspaceApiSupport[] | undefined,
+  api: string,
+  fallback = 'This action is disabled by this workspace policy.',
+) {
+  return supportEntry(support, api)?.verdict?.reason || fallback
+}
+
+function statusIsUnavailable(status?: WorkspaceApiSupportStatus) {
+  return status === 'blocked_by_policy' || status === 'not_supported' || status === 'deferred'
+}
+
+export function deriveWorkspaceSupportFlags(support: WorkspaceApiSupport[] | undefined) {
+  const entry = (api: string) => supportEntry(support, api)
+  const mutation = (api: string) => supportAllows(entry(api), { mutation: true })
+  const readable = (api: string) => supportAllows(entry(api))
+  const localFiles = entry('localFiles')
+  const reveal = entry('artifacts.reveal')
+  const machineRuntimeConfig = entry('machineRuntimeConfig')
+  const cloudProfileReason = supportReason(
+    support,
+    'machineRuntimeConfig',
+    'This cloud profile manages model and runtime configuration.',
+  )
+
+  return {
+    canCreateSession: mutation('sessions.create'),
+    canPrompt: mutation('sessions.prompt'),
+    canAbort: mutation('sessions.abort'),
+    canAttachFiles: mutation('localFiles'),
+    canUseLocalFiles: readable('localFiles'),
+    canListWorkflows: readable('workflows.list'),
+    canRunWorkflow: mutation('workflows.run'),
+    canDownloadArtifact: readable('artifacts.download'),
+    canRevealArtifact: mutation('artifacts.reveal') || mutation('localFiles'),
+    canUseMachineRuntimeConfig: readable('machineRuntimeConfig') && !statusIsUnavailable(machineRuntimeConfig?.status),
+    canUsePortableSettings: readable('settings.portable'),
+    reasons: {
+      createSession: supportReason(support, 'sessions.create', 'Thread creation is disabled by this workspace policy.'),
+      prompt: supportReason(support, 'sessions.prompt', 'Prompting is disabled by this workspace policy.'),
+      attachFiles: localFiles?.verdict?.reason || 'This workspace does not implicitly upload local files.',
+      runWorkflow: supportReason(support, 'workflows.run', 'Workflow runs are disabled by this workspace policy.'),
+      listWorkflows: supportReason(support, 'workflows.list', 'Workflows are disabled by this workspace policy.'),
+      downloadArtifact: supportReason(support, 'artifacts.download', 'Artifact downloads are disabled by this workspace policy.'),
+      revealArtifact: reveal?.verdict?.reason || localFiles?.verdict?.reason || 'Cloud artifacts cannot be revealed in the local filesystem.',
+      machineRuntimeConfig: cloudProfileReason,
+      settingsPortable: supportReason(support, 'settings.portable', 'Portable cloud settings are disabled by this workspace policy.'),
+    },
+  }
+}
+
+export const useWorkspaceSupportStore = create<WorkspaceSupportState>((set, get) => ({
+  supportByWorkspace: { [LOCAL_WORKSPACE_ID]: LOCAL_SUPPORT },
+  loadedByWorkspace: { [LOCAL_WORKSPACE_ID]: true },
+  loadingByWorkspace: {},
+  errorByWorkspace: {},
+  setWorkspaceSupport: (workspaceId, support) => set((state) => {
+    const normalized = normalizeWorkspaceId(workspaceId)
+    return {
+      supportByWorkspace: { ...state.supportByWorkspace, [normalized]: support },
+      loadedByWorkspace: { ...state.loadedByWorkspace, [normalized]: true },
+      loadingByWorkspace: { ...state.loadingByWorkspace, [normalized]: false },
+      errorByWorkspace: { ...state.errorByWorkspace, [normalized]: null },
+    }
+  }),
+  loadWorkspaceSupport: async (workspaceId, options) => {
+    const normalized = normalizeWorkspaceId(workspaceId)
+    if (normalized === LOCAL_WORKSPACE_ID) {
+      get().setWorkspaceSupport(normalized, LOCAL_SUPPORT)
+      return LOCAL_SUPPORT
+    }
+    const state = get()
+    if (!options?.force && state.loadedByWorkspace[normalized] && state.supportByWorkspace[normalized]) {
+      return state.supportByWorkspace[normalized]
+    }
+    if (!options?.force && state.loadingByWorkspace[normalized] && state.supportByWorkspace[normalized]) {
+      return state.supportByWorkspace[normalized]
+    }
+    set((current) => ({
+      loadingByWorkspace: { ...current.loadingByWorkspace, [normalized]: true },
+      errorByWorkspace: { ...current.errorByWorkspace, [normalized]: null },
+    }))
+    try {
+      const support = await window.coworkApi.workspace.support(normalized)
+      get().setWorkspaceSupport(normalized, support)
+      return support
+    } catch (error) {
+      set((current) => ({
+        loadedByWorkspace: { ...current.loadedByWorkspace, [normalized]: true },
+        loadingByWorkspace: { ...current.loadingByWorkspace, [normalized]: false },
+        errorByWorkspace: { ...current.errorByWorkspace, [normalized]: describeSupportError(error) },
+      }))
+      return []
+    }
+  },
+}))
+
+export function useActiveWorkspaceSupport() {
+  const activeWorkspaceId = useSessionStore((state) => normalizeWorkspaceId(state.activeWorkspaceId))
+  const support = useWorkspaceSupportStore((state) => state.supportByWorkspace[activeWorkspaceId])
+  const loaded = useWorkspaceSupportStore((state) => state.loadedByWorkspace[activeWorkspaceId] === true)
+  const loading = useWorkspaceSupportStore((state) => state.loadingByWorkspace[activeWorkspaceId] === true)
+  const error = useWorkspaceSupportStore((state) => state.errorByWorkspace[activeWorkspaceId] || null)
+  const loadWorkspaceSupport = useWorkspaceSupportStore((state) => state.loadWorkspaceSupport)
+
+  useEffect(() => {
+    void loadWorkspaceSupport(activeWorkspaceId)
+  }, [activeWorkspaceId, loadWorkspaceSupport])
+
+  const flags = useMemo(() => {
+    const next = deriveWorkspaceSupportFlags(support)
+    if (activeWorkspaceId === LOCAL_WORKSPACE_ID || loaded) return next
+    const checkingReason = 'Checking cloud workspace policy.'
+    return {
+      ...next,
+      canCreateSession: false,
+      canPrompt: false,
+      canAbort: false,
+      canAttachFiles: false,
+      canUseLocalFiles: false,
+      canListWorkflows: false,
+      canRunWorkflow: false,
+      canDownloadArtifact: false,
+      canRevealArtifact: false,
+      canUseMachineRuntimeConfig: false,
+      canUsePortableSettings: false,
+      reasons: {
+        ...next.reasons,
+        createSession: checkingReason,
+        prompt: checkingReason,
+        attachFiles: checkingReason,
+        runWorkflow: checkingReason,
+        downloadArtifact: checkingReason,
+        revealArtifact: checkingReason,
+        machineRuntimeConfig: checkingReason,
+        settingsPortable: checkingReason,
+      },
+    }
+  }, [activeWorkspaceId, loaded, support])
+
+  return {
+    workspaceId: activeWorkspaceId,
+    support: support || (activeWorkspaceId === LOCAL_WORKSPACE_ID ? LOCAL_SUPPORT : []),
+    loaded,
+    loading,
+    error,
+    flags,
+    isLocal: activeWorkspaceId === LOCAL_WORKSPACE_ID,
+  }
+}

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -173,6 +173,7 @@ test('workspace gateway marks local desktop-only capabilities as local supported
 
   assert.equal(supportStatus(support, 'sessions.fileSnippet').status, 'supported')
   assert.equal(supportStatus(support, 'sessions.diff').status, 'supported')
+  assert.equal(supportStatus(support, 'artifacts.reveal').status, 'supported')
   assert.equal(supportStatus(support, 'localFiles').status, 'supported')
   assert.equal(supportStatus(support, 'localStdioMcps').status, 'supported')
   assert.equal(supportStatus(support, 'machineRuntimeConfig').status, 'supported')
@@ -191,6 +192,7 @@ test('workspace gateway registers cloud connections without enabling unauthentic
   const support = await gateway.supportMatrix(event(1), workspace.id)
   assert.equal(support.find((entry) => entry.api === 'sessions.prompt')?.status, 'blocked_by_policy')
   assert.equal(support.find((entry) => entry.api === 'localFiles')?.status, 'not_supported')
+  assert.equal(support.find((entry) => entry.api === 'artifacts.reveal')?.status, 'not_supported')
   await assert.rejects(() => gateway.sync(event(1), workspace.id), /Sign in|not available/)
 })
 
@@ -286,6 +288,8 @@ test('workspace gateway keeps host paths, local stdio MCPs, and machine config o
   assert.match(supportStatus(support, 'localStdioMcps').verdict?.reason || '', /local stdio MCPs/)
   assert.equal(supportStatus(support, 'machineRuntimeConfig').status, 'not_supported')
   assert.match(supportStatus(support, 'machineRuntimeConfig').verdict?.reason || '', /machine-native runtime config/)
+  assert.equal(supportStatus(support, 'artifacts.reveal').status, 'not_supported')
+  assert.match(supportStatus(support, 'artifacts.reveal').verdict?.reason || '', /local filesystem/)
 })
 
 test('workspace gateway loads and removes persisted cloud connections', () => {
@@ -688,6 +692,81 @@ test('workspace gateway routes online cloud session calls through the cloud adap
     'settings:get:portable-settings',
     'settings:set:portable-settings:openai',
   ])
+})
+
+test('workspace gateway cloud sync refreshes adapter snapshot and persists sync time', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'open-cowork-workspace-sync-'))
+  const registry = new FileCloudWorkspaceRegistry(join(root, 'cloud-workspaces.json'))
+  const persisted = registry.upsert({ baseUrl: 'https://cloud.example.test', label: 'Acme' })
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(root, 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  credentials.save({
+    workspaceId: persisted.id,
+    accessToken: 'cloud-access-token',
+    expiresAt: '2030-05-27T12:00:00.000Z',
+  })
+  let syncCalls = 0
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    sync: async () => { syncCalls += 1 },
+    listSessions: async () => [],
+    createSession: async () => ({
+      id: 'cloud-session-1',
+      title: 'Cloud session',
+      directory: null,
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }),
+    getSessionInfo: async () => null,
+    getSessionView: async () => ({
+      messages: [],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      lastInputTokens: 0,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 0,
+      lastEventAt: 0,
+      isGenerating: false,
+      isAwaitingPermission: false,
+      isAwaitingQuestion: false,
+    }),
+    promptSession: async () => undefined,
+    abortSession: async () => undefined,
+  }
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: registry,
+    cloudCredentialStore: credentials,
+    cloudAdapterFactory: () => adapter,
+  })
+
+  const result = await gateway.sync(event(1), persisted.id)
+
+  assert.equal(syncCalls, 1)
+  assert.equal(result.ok, true)
+  assert.equal(registry.list().find((entry) => entry.id === persisted.id)?.lastSyncedAt, result.syncedAt)
+  assert.equal(gateway.list(event(1)).find((workspace) => workspace.id === persisted.id)?.lastSyncedAt, result.syncedAt)
 })
 
 test('workspace gateway subscribes cloud workspace events once per sender', async () => {


### PR DESCRIPTION
## Summary
- add a shared renderer workspace-support store and route desktop cloud policy verdicts through composer, Home, settings, workflows, and artifact controls
- scope cloud prompts, aborts, settings, agents, workflows, and artifact operations by workspace while preserving local call shapes
- add cloud sync refresh/reconnect handling and expose cloud artifact reveal as explicitly unsupported

## Verification
- pnpm lint
- pnpm --filter @open-cowork/desktop typecheck
- pnpm --filter @open-cowork/desktop test:renderer
- node scripts/run-node-tests.mjs tests/workspace-gateway.test.ts
- pnpm --filter @open-cowork/desktop build:electron
- pnpm typecheck
- pnpm test
- git diff --check

Closes #516