### PR TITLE
Modularize cloud core boundaries

### DIFF
--- a/apps/desktop/src/main/cloud/http-routes/capabilities.ts
+++ b/apps/desktop/src/main/cloud/http-routes/capabilities.ts
@@ -1,0 +1,59 @@
+import type { CloudApiRouteInput } from './types.ts'
+
+export async function handleCapabilitiesApiRoute(input: CloudApiRouteInput): Promise<boolean> {
+  const { req, res, options, context, itemId: collection, action: itemId, artifactId: itemAction, tools } = input
+
+  if (!options.policy.features.agents && !options.policy.features.customSkills && !options.policy.features.customMcps) {
+    tools.writePolicyError(res, 403, 'Capabilities are disabled for this cloud profile.', 'capabilities.disabled', options.corsOrigin)
+    return true
+  }
+
+  if (!collection && req.method === 'GET') {
+    tools.writeJson(res, 200, await options.service.listCapabilityCatalog(context.principal), options.corsOrigin)
+    return true
+  }
+
+  if (collection === 'tools') {
+    if (!itemId && req.method === 'GET') {
+      tools.writeJson(res, 200, { tools: await options.service.listCapabilityTools(context.principal) }, options.corsOrigin)
+      return true
+    }
+    if (itemId && !itemAction && req.method === 'GET') {
+      const tool = await options.service.getCapabilityTool(context.principal, itemId)
+      if (!tool) {
+        tools.writeError(res, 404, 'Capability tool was not found.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 200, { tool }, options.corsOrigin)
+      return true
+    }
+  }
+
+  if (collection === 'skills') {
+    if (!itemId && req.method === 'GET') {
+      tools.writeJson(res, 200, { skills: await options.service.listCapabilitySkills(context.principal) }, options.corsOrigin)
+      return true
+    }
+    if (itemId && !itemAction && req.method === 'GET') {
+      const skill = await options.service.getCapabilitySkill(context.principal, itemId)
+      if (!skill) {
+        tools.writeError(res, 404, 'Capability skill was not found.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 200, { skill }, options.corsOrigin)
+      return true
+    }
+    if (itemId && itemAction === 'bundle' && req.method === 'GET') {
+      const bundle = await options.service.getCapabilitySkillBundle(context.principal, itemId)
+      if (!bundle) {
+        tools.writeError(res, 404, 'Capability skill bundle was not found.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 200, { bundle }, options.corsOrigin)
+      return true
+    }
+  }
+
+  tools.writeError(res, 404, 'Not found.', options.corsOrigin)
+  return true
+}

--- a/apps/desktop/src/main/cloud/http-routes/settings.ts
+++ b/apps/desktop/src/main/cloud/http-routes/settings.ts
@@ -1,0 +1,45 @@
+import type { CloudApiRouteInput } from './types.ts'
+
+export async function handleSettingsApiRoute(input: CloudApiRouteInput): Promise<boolean> {
+  const { req, res, options, context, itemId: settingId, tools } = input
+
+  if (!options.policy.features.settings) {
+    tools.writePolicyError(res, 403, 'Settings are disabled for this cloud profile.', 'settings.disabled', options.corsOrigin)
+    return true
+  }
+
+  const settingKey = settingId ? decodeURIComponent(settingId) : null
+  if (!settingKey && req.method === 'GET') {
+    tools.writeJson(res, 200, {
+      settings: await options.service.listSettingMetadata(context.principal),
+    }, options.corsOrigin)
+    return true
+  }
+
+  if (settingKey && req.method === 'GET') {
+    tools.writeJson(res, 200, {
+      setting: await options.service.getSettingMetadata(context.principal, settingKey),
+    }, options.corsOrigin)
+    return true
+  }
+
+  if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
+    const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+    const keyName = settingKey || tools.readString(body.key)
+    const value = tools.readRecord(body.value)
+    if (!keyName || !value) {
+      tools.writeError(res, 400, 'Setting key and object value are required.', options.corsOrigin)
+      return true
+    }
+    tools.writeJson(res, 200, {
+      setting: await options.service.setSettingMetadata(context.principal, {
+        key: keyName,
+        value,
+      }),
+    }, options.corsOrigin)
+    return true
+  }
+
+  tools.writeError(res, 405, 'Method not allowed.', options.corsOrigin)
+  return true
+}

--- a/apps/desktop/src/main/cloud/http-routes/threads.ts
+++ b/apps/desktop/src/main/cloud/http-routes/threads.ts
@@ -1,0 +1,118 @@
+import type { CloudApiRouteInput } from './types.ts'
+
+export async function handleThreadsApiRoute(input: CloudApiRouteInput): Promise<boolean> {
+  const { req, res, options, context, itemId: collection, action: itemId, artifactId: itemAction, tools } = input
+
+  if (!options.policy.features.threadIndex) {
+    tools.writePolicyError(res, 403, 'Thread index is disabled for this cloud profile.', 'thread_index.disabled', options.corsOrigin)
+    return true
+  }
+
+  if (!collection && req.method === 'GET') {
+    tools.writeJson(res, 200, {
+      threads: await options.service.listThreadMetadata(context.principal, {
+        tagIds: tools.parseTagIds(context.url),
+        limit: tools.parseLimit(context.url),
+      }),
+    }, options.corsOrigin)
+    return true
+  }
+
+  if (collection === 'tags') {
+    if (!itemId && req.method === 'GET') {
+      tools.writeJson(res, 200, { tags: await options.service.listThreadTags(context.principal) }, options.corsOrigin)
+      return true
+    }
+    if (!itemId && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const name = tools.readString(body.name)
+      if (!name) {
+        tools.writeError(res, 400, 'Tag name is required.', options.corsOrigin)
+        return true
+      }
+      const tag = await options.service.createThreadTag(context.principal, {
+        name,
+        color: tools.readString(body.color),
+      })
+      tools.writeJson(res, 201, { tag }, options.corsOrigin)
+      return true
+    }
+    if (itemId && !itemAction && req.method === 'PATCH') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const tag = await options.service.updateThreadTag(context.principal, itemId, {
+        name: body.name === undefined ? undefined : tools.readString(body.name) || '',
+        color: body.color === undefined ? undefined : tools.readString(body.color),
+      })
+      if (!tag) {
+        tools.writeError(res, 404, 'Thread tag was not found.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 200, { tag }, options.corsOrigin)
+      return true
+    }
+    if (itemId && !itemAction && req.method === 'DELETE') {
+      tools.writeJson(res, 200, {
+        deleted: await options.service.deleteThreadTag(context.principal, itemId),
+      }, options.corsOrigin)
+      return true
+    }
+    if (itemId && (itemAction === 'apply' || itemAction === 'remove') && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const sessionIds = tools.readStringArray(body.sessionIds)
+      if (!sessionIds) {
+        tools.writeError(res, 400, 'sessionIds must be an array of strings.', options.corsOrigin)
+        return true
+      }
+      if (itemAction === 'apply') {
+        await options.service.applyThreadTag(context.principal, itemId, sessionIds)
+      } else {
+        await options.service.removeThreadTag(context.principal, itemId, sessionIds)
+      }
+      tools.writeJson(res, 200, { ok: true }, options.corsOrigin)
+      return true
+    }
+  }
+
+  if (collection === 'smart-filters') {
+    if (!itemId && req.method === 'GET') {
+      tools.writeJson(res, 200, {
+        filters: await options.service.listThreadSmartFilters(context.principal),
+      }, options.corsOrigin)
+      return true
+    }
+    if (!itemId && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const name = tools.readString(body.name)
+      const query = tools.readRecord(body.query)
+      if (!name || !query) {
+        tools.writeError(res, 400, 'Smart filter name and query are required.', options.corsOrigin)
+        return true
+      }
+      const filter = await options.service.createThreadSmartFilter(context.principal, { name, query })
+      tools.writeJson(res, 201, { filter }, options.corsOrigin)
+      return true
+    }
+    if (itemId && !itemAction && req.method === 'PATCH') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const filter = await options.service.updateThreadSmartFilter(context.principal, itemId, {
+        name: body.name === undefined ? undefined : tools.readString(body.name) || '',
+        query: body.query === undefined ? undefined : tools.readRecord(body.query) || {},
+      })
+      if (!filter) {
+        tools.writeError(res, 404, 'Smart filter was not found.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 200, { filter }, options.corsOrigin)
+      return true
+    }
+    if (itemId && !itemAction && req.method === 'DELETE') {
+      tools.writeJson(res, 200, {
+        deleted: await options.service.deleteThreadSmartFilter(context.principal, itemId),
+      }, options.corsOrigin)
+      return true
+    }
+  }
+
+  tools.writeError(res, 404, 'Not found.', options.corsOrigin)
+  return true
+}

--- a/apps/desktop/src/main/cloud/http-routes/types.ts
+++ b/apps/desktop/src/main/cloud/http-routes/types.ts
@@ -17,10 +17,12 @@ export type CloudApiRouteTools = {
   readJsonBody(req: IncomingMessage, maxBodyBytes: number): Promise<Record<string, unknown>>
   readString(value: unknown): string | null
   readRecord(value: unknown): Record<string, unknown> | null
+  readStringArray(value: unknown): string[] | null
   readOptionalDate(value: unknown): Date | null
   readApiTokenScopes(value: unknown): ApiTokenScope[] | null
   readOptionalCloudProjectSource(body: Record<string, unknown>): CloudProjectSourceInput | null | undefined
   parseLimit(url: URL): number | undefined
+  parseTagIds(url: URL): string[]
   writeJson(res: ServerResponse, status: number, body: unknown, origin?: string | null): void
   writeError(res: ServerResponse, status: number, message: string, origin?: string | null): void
   writePolicyError(res: ServerResponse, status: number, message: string, policyCode: string, origin?: string | null): void

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -22,8 +22,11 @@ import { handleAdminApiRoute } from './http-routes/admin.ts'
 import { handleApiTokensApiRoute } from './http-routes/api-tokens.ts'
 import { handleBillingApiRoute } from './http-routes/billing.ts'
 import { handleByokApiRoute } from './http-routes/byok.ts'
+import { handleCapabilitiesApiRoute } from './http-routes/capabilities.ts'
 import { handleChannelsApiRoute } from './http-routes/channels.ts'
 import { handleProjectSourcesApiRoute } from './http-routes/project-sources.ts'
+import { handleSettingsApiRoute } from './http-routes/settings.ts'
+import { handleThreadsApiRoute } from './http-routes/threads.ts'
 import { handleWorkspaceApiRoute } from './http-routes/workspace.ts'
 import { CloudServiceError, type CloudPrincipal, type CloudSessionService } from './session-service.ts'
 import { cloudSessionViewToSessionView } from './session-view-contract.ts'
@@ -473,8 +476,7 @@ function readChannelProvider(value: unknown): ChannelProviderId | undefined {
 function parseTagIds(url: URL) {
   const repeated = url.searchParams.getAll('tagId')
   const csv = url.searchParams.get('tagIds')?.split(',') || []
-  const values = [...repeated, ...csv].map((value) => value.trim()).filter(Boolean)
-  return values.length > 0 ? values : undefined
+  return [...repeated, ...csv].map((value) => value.trim()).filter(Boolean)
 }
 
 function firstHeader(value: string | string[] | undefined) {
@@ -980,10 +982,12 @@ async function handleApiRequest(
     readJsonBody,
     readString,
     readRecord,
+    readStringArray,
     readOptionalDate,
     readApiTokenScopes,
     readOptionalCloudProjectSource,
     parseLimit,
+    parseTagIds,
     writeJson,
     writeError,
     writePolicyError,
@@ -1078,213 +1082,47 @@ async function handleApiRequest(
   }
 
   if (resource === 'capabilities') {
-    if (!options.policy.features.agents && !options.policy.features.customSkills && !options.policy.features.customMcps) {
-      writePolicyError(res, 403, 'Capabilities are disabled for this cloud profile.', 'capabilities.disabled', options.corsOrigin)
-      return
-    }
-    const collection = sessionId
-    const itemId = action
-    const itemAction = artifactId
-    if (!collection && req.method === 'GET') {
-      writeJson(res, 200, await options.service.listCapabilityCatalog(context.principal), options.corsOrigin)
-      return
-    }
-    if (collection === 'tools') {
-      if (!itemId && req.method === 'GET') {
-        writeJson(res, 200, { tools: await options.service.listCapabilityTools(context.principal) }, options.corsOrigin)
-        return
-      }
-      if (itemId && !itemAction && req.method === 'GET') {
-        const tool = await options.service.getCapabilityTool(context.principal, itemId)
-        if (!tool) {
-          writeError(res, 404, 'Capability tool was not found.', options.corsOrigin)
-          return
-        }
-        writeJson(res, 200, { tool }, options.corsOrigin)
-        return
-      }
-    }
-    if (collection === 'skills') {
-      if (!itemId && req.method === 'GET') {
-        writeJson(res, 200, { skills: await options.service.listCapabilitySkills(context.principal) }, options.corsOrigin)
-        return
-      }
-      if (itemId && !itemAction && req.method === 'GET') {
-        const skill = await options.service.getCapabilitySkill(context.principal, itemId)
-        if (!skill) {
-          writeError(res, 404, 'Capability skill was not found.', options.corsOrigin)
-          return
-        }
-        writeJson(res, 200, { skill }, options.corsOrigin)
-        return
-      }
-      if (itemId && itemAction === 'bundle' && req.method === 'GET') {
-        const bundle = await options.service.getCapabilitySkillBundle(context.principal, itemId)
-        if (!bundle) {
-          writeError(res, 404, 'Capability skill bundle was not found.', options.corsOrigin)
-          return
-        }
-        writeJson(res, 200, { bundle }, options.corsOrigin)
-        return
-      }
-    }
-    writeError(res, 404, 'Not found.', options.corsOrigin)
+    await handleCapabilitiesApiRoute({
+      req,
+      res,
+      options,
+      context,
+      resource,
+      itemId: sessionId,
+      action,
+      artifactId,
+      tools: routeTools,
+    })
     return
   }
 
   if (resource === 'settings') {
-    if (!options.policy.features.settings) {
-      writePolicyError(res, 403, 'Settings are disabled for this cloud profile.', 'settings.disabled', options.corsOrigin)
-      return
-    }
-    const settingKey = sessionId ? decodeURIComponent(sessionId) : null
-    if (!settingKey && req.method === 'GET') {
-      writeJson(res, 200, {
-        settings: await options.service.listSettingMetadata(context.principal),
-      }, options.corsOrigin)
-      return
-    }
-    if (settingKey && req.method === 'GET') {
-      writeJson(res, 200, {
-        setting: await options.service.getSettingMetadata(context.principal, settingKey),
-      }, options.corsOrigin)
-      return
-    }
-    if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
-      const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
-      const keyName = settingKey || readString(body.key)
-      const value = readRecord(body.value)
-      if (!keyName || !value) {
-        writeError(res, 400, 'Setting key and object value are required.', options.corsOrigin)
-        return
-      }
-      writeJson(res, 200, {
-        setting: await options.service.setSettingMetadata(context.principal, {
-          key: keyName,
-          value,
-        }),
-      }, options.corsOrigin)
-      return
-    }
-    writeError(res, 405, 'Method not allowed.', options.corsOrigin)
+    await handleSettingsApiRoute({
+      req,
+      res,
+      options,
+      context,
+      resource,
+      itemId: sessionId,
+      action,
+      artifactId,
+      tools: routeTools,
+    })
     return
   }
 
   if (resource === 'threads') {
-    if (!options.policy.features.threadIndex) {
-      writePolicyError(res, 403, 'Thread index is disabled for this cloud profile.', 'thread_index.disabled', options.corsOrigin)
-      return
-    }
-    const collection = sessionId
-    const itemId = action
-    const itemAction = artifactId
-
-    if (!collection && req.method === 'GET') {
-      writeJson(res, 200, {
-        threads: await options.service.listThreadMetadata(context.principal, {
-          tagIds: parseTagIds(context.url),
-          limit: parseLimit(context.url),
-        }),
-      }, options.corsOrigin)
-      return
-    }
-
-    if (collection === 'tags') {
-      if (!itemId && req.method === 'GET') {
-        writeJson(res, 200, { tags: await options.service.listThreadTags(context.principal) }, options.corsOrigin)
-        return
-      }
-      if (!itemId && req.method === 'POST') {
-        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
-        const name = readString(body.name)
-        if (!name) {
-          writeError(res, 400, 'Tag name is required.', options.corsOrigin)
-          return
-        }
-        const tag = await options.service.createThreadTag(context.principal, {
-          name,
-          color: readString(body.color),
-        })
-        writeJson(res, 201, { tag }, options.corsOrigin)
-        return
-      }
-      if (itemId && !itemAction && req.method === 'PATCH') {
-        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
-        const tag = await options.service.updateThreadTag(context.principal, itemId, {
-          name: body.name === undefined ? undefined : readString(body.name) || '',
-          color: body.color === undefined ? undefined : readString(body.color),
-        })
-        if (!tag) {
-          writeError(res, 404, 'Thread tag was not found.', options.corsOrigin)
-          return
-        }
-        writeJson(res, 200, { tag }, options.corsOrigin)
-        return
-      }
-      if (itemId && !itemAction && req.method === 'DELETE') {
-        writeJson(res, 200, {
-          deleted: await options.service.deleteThreadTag(context.principal, itemId),
-        }, options.corsOrigin)
-        return
-      }
-      if (itemId && (itemAction === 'apply' || itemAction === 'remove') && req.method === 'POST') {
-        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
-        const sessionIds = readStringArray(body.sessionIds)
-        if (!sessionIds) {
-          writeError(res, 400, 'sessionIds must be an array of strings.', options.corsOrigin)
-          return
-        }
-        if (itemAction === 'apply') {
-          await options.service.applyThreadTag(context.principal, itemId, sessionIds)
-        } else {
-          await options.service.removeThreadTag(context.principal, itemId, sessionIds)
-        }
-        writeJson(res, 200, { ok: true }, options.corsOrigin)
-        return
-      }
-    }
-
-    if (collection === 'smart-filters') {
-      if (!itemId && req.method === 'GET') {
-        writeJson(res, 200, {
-          filters: await options.service.listThreadSmartFilters(context.principal),
-        }, options.corsOrigin)
-        return
-      }
-      if (!itemId && req.method === 'POST') {
-        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
-        const name = readString(body.name)
-        const query = readRecord(body.query)
-        if (!name || !query) {
-          writeError(res, 400, 'Smart filter name and query are required.', options.corsOrigin)
-          return
-        }
-        const filter = await options.service.createThreadSmartFilter(context.principal, { name, query })
-        writeJson(res, 201, { filter }, options.corsOrigin)
-        return
-      }
-      if (itemId && !itemAction && req.method === 'PATCH') {
-        const body = await readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
-        const filter = await options.service.updateThreadSmartFilter(context.principal, itemId, {
-          name: body.name === undefined ? undefined : readString(body.name) || '',
-          query: body.query === undefined ? undefined : readRecord(body.query) || {},
-        })
-        if (!filter) {
-          writeError(res, 404, 'Smart filter was not found.', options.corsOrigin)
-          return
-        }
-        writeJson(res, 200, { filter }, options.corsOrigin)
-        return
-      }
-      if (itemId && !itemAction && req.method === 'DELETE') {
-        writeJson(res, 200, {
-          deleted: await options.service.deleteThreadSmartFilter(context.principal, itemId),
-        }, options.corsOrigin)
-        return
-      }
-    }
-
-    writeError(res, 404, 'Not found.', options.corsOrigin)
+    await handleThreadsApiRoute({
+      req,
+      res,
+      options,
+      context,
+      resource,
+      itemId: sessionId,
+      action,
+      artifactId,
+      tools: routeTools,
+    })
     return
   }
 

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -11,35 +11,23 @@ import {
 import type {
   WorkflowRunStatus,
   WorkflowStatus,
-  WorkflowTrigger,
-  WorkflowTriggerType,
 } from '@open-cowork/shared'
 import type {
   AttachWorkflowRunSessionInput,
   AppendWorkspaceEventInput,
-  AccountRecord,
-  ApiTokenRecord,
   AuditEventRecord,
   AckChannelDeliveryInput,
   BindChannelSessionInput,
-  BillingSubscriptionRecord,
   ByokSecretRecord,
-  ChannelBindingRecord,
-  ChannelDeliveryRecord,
-  ChannelIdentityRecord,
-  ChannelInteractionRecord,
   ChannelProviderId,
-  ChannelSessionBindingRecord,
   ClaimDueWorkflowRunInput,
   ClaimChannelDeliveryInput,
   ClaimRateLimitInput,
   ClaimedWorkflowRunRecord,
-  CloudAuthBackoffRecord,
   CloudWorkflowRecord,
   CloudWorkflowRunRecord,
   ConsumeUsageQuotaInput,
   CompleteWorkflowRunInput,
-  ControlPlaneCommandStatus,
   ControlPlaneRole,
   ControlPlaneSessionStatus,
   ControlPlaneStore,
@@ -56,15 +44,12 @@ import type {
   DisableByokSecretInput,
   FailWorkflowRunInput,
   FindChannelInteractionInput,
-  HeadlessAgentRecord,
   IssuedApiTokenRecord,
   IssuedChannelInteractionRecord,
   IssueApiTokenInput,
   ListSessionsPageInput,
   ListChannelDeliveriesInput,
-  MembershipRecord,
   OrgMemberRecord,
-  OrgRecord,
   PrincipalMembershipRecord,
   RecordAuditEventInput,
   RecordByokSecretValidationInput,
@@ -73,17 +58,10 @@ import type {
   RevokeApiTokenInput,
   ResolveChannelInteractionInput,
   ResolveChannelInteractionWithCommandInput,
-  SchemaMigrationRecord,
   SessionCommandRecord,
   SessionEventRecord,
-  SessionProjectionRecord,
-  SessionRecord,
-  SettingMetadataRecord,
-  TenantRecord,
   ThreadMetadataRecord,
-  ThreadSmartFilterRecord,
   ThreadTagLinkInput,
-  ThreadTagRecord,
   UsageEventRecord,
   UsageQuotaCounterRecord,
   UpdateChannelBindingInput,
@@ -95,14 +73,11 @@ import type {
   UpsertBillingSubscriptionInput,
   UpsertChannelIdentityInput,
   UpsertMembershipInput,
-  UserRecord,
-  WorkerHeartbeatRecord,
   WorkerLeaseRecord,
   WorkerRole,
   WorkspaceEventRecord,
 } from './control-plane-store.ts'
 import type {
-  WebhookAuthFailureRecord,
   WorkflowWebhookReplayClaim,
   WorkflowWebhookSecurityStore,
 } from '../workflow/workflow-webhook-server.ts'
@@ -110,9 +85,42 @@ import {
   CLOUD_CONTROL_PLANE_MIGRATION_ADVISORY_LOCK_KEYS,
   CLOUD_CONTROL_PLANE_MIGRATIONS,
 } from './postgres-schema.ts'
+import { usageEventFromRow, billingSubscriptionFromRow } from './postgres-domains/billing.ts'
+import { byokSecretFromRow } from './postgres-domains/byok.ts'
+import {
+  channelBindingFromRow,
+  channelDeliveryFromRow,
+  channelIdentityFromRow,
+  channelInteractionFromRow,
+  channelSessionBindingFromRow,
+  headlessAgentFromRow,
+} from './postgres-domains/channels.ts'
+import {
+  accountFromRow,
+  apiTokenFromRow,
+  auditEventFromRow,
+  cloudAuthBackoffFromRow,
+  membershipFromRow,
+  orgFromRow,
+  tenantFromRow,
+  userFromRow,
+} from './postgres-domains/identity.ts'
+import { migrationFromRow } from './postgres-domains/schema.ts'
+import {
+  commandFromRow,
+  eventFromRow,
+  heartbeatFromRow,
+  leaseFromRow,
+  projectionFromRow,
+  sessionFromRow,
+  settingFromRow,
+  workspaceEventFromRow,
+} from './postgres-domains/sessions.ts'
+import { iso, jsonRecord, numberValue, type QueryResult, type QueryRow } from './postgres-domains/shared.ts'
+import { threadSmartFilterFromRow, threadTagFromRow } from './postgres-domains/thread-index.ts'
+import { webhookAuthFailureFromRow } from './postgres-domains/webhooks.ts'
+import { workflowFromRow, workflowRunFromRow } from './postgres-domains/workflows.ts'
 
-type QueryRow = Record<string, unknown>
-type QueryResult<Row extends QueryRow = QueryRow> = { rows: Row[] }
 type PgExecutor = {
   query<Row extends QueryRow = QueryRow>(text: string, values?: unknown[]): Promise<QueryResult<Row>>
 }
@@ -173,44 +181,6 @@ function workspaceOperationFromType(type: string) {
 
 function optionalTrimmedText(value: unknown) {
   return typeof value === 'string' && value.trim() ? value.trim() : null
-}
-
-function iso(value: unknown) {
-  if (value instanceof Date) return value.toISOString()
-  if (typeof value === 'string') return new Date(value).toISOString()
-  throw new Error('Expected a timestamp column.')
-}
-
-function numberValue(value: unknown) {
-  const parsed = Number(value)
-  if (!Number.isFinite(parsed)) throw new Error('Expected a numeric column.')
-  return parsed
-}
-
-function stringOrNull(value: unknown) {
-  return typeof value === 'string' ? value : null
-}
-
-function isoOrNull(value: unknown) {
-  return value ? iso(value) : null
-}
-
-function jsonRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : {}
-}
-
-function jsonStringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === 'string')
-    : []
-}
-
-function workflowTriggers(value: unknown): WorkflowTrigger[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is WorkflowTrigger => Boolean(entry && typeof entry === 'object' && !Array.isArray(entry)))
-    : []
 }
 
 function normalizeText(value: unknown, maxLength: number, label: string) {
@@ -318,447 +288,6 @@ function redactAuditMetadata(value: Record<string, unknown> | undefined): Record
     }
   }
   return redacted
-}
-
-function tenantFromRow(row: QueryRow): TenantRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    name: String(row.name),
-    createdAt: iso(row.created_at),
-  }
-}
-
-function userFromRow(row: QueryRow): UserRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    userId: String(row.user_id),
-    email: String(row.email),
-    role: String(row.role) as ControlPlaneRole,
-    createdAt: iso(row.created_at),
-  }
-}
-
-function orgFromRow(row: QueryRow): OrgRecord {
-  return {
-    orgId: String(row.org_id),
-    tenantId: String(row.tenant_id),
-    name: String(row.name),
-    planKey: stringOrNull(row.plan_key),
-    status: String(row.status),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function accountFromRow(row: QueryRow): AccountRecord {
-  return {
-    accountId: String(row.account_id),
-    idpSubject: stringOrNull(row.idp_subject),
-    email: String(row.email),
-    displayName: stringOrNull(row.display_name),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function membershipFromRow(row: QueryRow): MembershipRecord {
-  return {
-    orgId: String(row.org_id),
-    accountId: String(row.account_id),
-    role: String(row.role) as ControlPlaneRole,
-    status: String(row.status) as MembershipRecord['status'],
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function apiTokenFromRow(row: QueryRow): ApiTokenRecord {
-  return {
-    tokenId: String(row.token_id),
-    orgId: String(row.org_id),
-    accountId: stringOrNull(row.account_id),
-    name: String(row.name),
-    tokenHash: String(row.token_hash),
-    scopes: jsonStringArray(row.scopes) as ApiTokenRecord['scopes'],
-    last4: String(row.last4),
-    expiresAt: isoOrNull(row.expires_at),
-    revokedAt: isoOrNull(row.revoked_at),
-    lastUsedAt: isoOrNull(row.last_used_at),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function auditEventFromRow(row: QueryRow): AuditEventRecord {
-  return {
-    eventId: String(row.event_id),
-    orgId: String(row.org_id),
-    accountId: stringOrNull(row.account_id),
-    actorType: String(row.actor_type) as AuditEventRecord['actorType'],
-    actorId: stringOrNull(row.actor_id),
-    eventType: String(row.event_type),
-    targetType: stringOrNull(row.target_type),
-    targetId: stringOrNull(row.target_id),
-    metadata: jsonRecord(row.metadata),
-    createdAt: iso(row.created_at),
-  }
-}
-
-function usageEventFromRow(row: QueryRow): UsageEventRecord {
-  return {
-    eventId: String(row.event_id),
-    orgId: String(row.org_id),
-    accountId: stringOrNull(row.account_id),
-    eventType: String(row.event_type),
-    quantity: numberValue(row.quantity),
-    unit: String(row.unit),
-    metadata: jsonRecord(row.metadata),
-    createdAt: iso(row.created_at),
-  }
-}
-
-function byokSecretFromRow(row: QueryRow): ByokSecretRecord {
-  return {
-    secretId: String(row.secret_id),
-    orgId: String(row.org_id),
-    providerId: String(row.provider_id),
-    status: String(row.status) as ByokSecretRecord['status'],
-    ciphertext: stringOrNull(row.ciphertext),
-    kmsRef: stringOrNull(row.kms_ref),
-    last4: String(row.last4),
-    keyFingerprint: String(row.key_fingerprint),
-    createdByAccountId: stringOrNull(row.created_by_account_id),
-    rotatedFromSecretId: stringOrNull(row.rotated_from_secret_id),
-    lastValidatedAt: isoOrNull(row.last_validated_at),
-    validationError: stringOrNull(row.validation_error),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function headlessAgentFromRow(row: QueryRow): HeadlessAgentRecord {
-  return {
-    agentId: String(row.agent_id),
-    orgId: String(row.org_id),
-    tenantId: String(row.tenant_id),
-    profileName: String(row.profile_name),
-    name: String(row.name),
-    status: String(row.status) as HeadlessAgentRecord['status'],
-    managed: row.managed === true,
-    createdByAccountId: stringOrNull(row.created_by_account_id),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function channelBindingFromRow(row: QueryRow): ChannelBindingRecord {
-  return {
-    bindingId: String(row.binding_id),
-    orgId: String(row.org_id),
-    agentId: String(row.agent_id),
-    provider: String(row.provider) as ChannelProviderId,
-    externalWorkspaceId: stringOrNull(row.external_workspace_id),
-    displayName: String(row.display_name),
-    status: String(row.status) as ChannelBindingRecord['status'],
-    credentialRef: stringOrNull(row.credential_ref),
-    settings: jsonRecord(row.settings),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function channelIdentityFromRow(row: QueryRow): ChannelIdentityRecord {
-  return {
-    identityId: String(row.identity_id),
-    orgId: String(row.org_id),
-    provider: String(row.provider) as ChannelProviderId,
-    externalWorkspaceId: stringOrNull(row.external_workspace_id),
-    externalUserId: String(row.external_user_id),
-    accountId: stringOrNull(row.account_id),
-    role: String(row.role) as ChannelIdentityRecord['role'],
-    status: String(row.status) as ChannelIdentityRecord['status'],
-    metadata: jsonRecord(row.metadata),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function channelSessionBindingFromRow(row: QueryRow): ChannelSessionBindingRecord {
-  return {
-    bindingId: String(row.binding_id),
-    orgId: String(row.org_id),
-    agentId: String(row.agent_id),
-    channelBindingId: String(row.channel_binding_id),
-    provider: String(row.provider) as ChannelProviderId,
-    externalWorkspaceId: stringOrNull(row.external_workspace_id),
-    externalThreadId: String(row.external_thread_id),
-    externalChatId: String(row.external_chat_id),
-    sessionId: String(row.session_id),
-    lastEventSequence: numberValue(row.last_event_sequence),
-    lastWorkspaceSequence: numberValue(row.last_workspace_sequence),
-    lastChatMessageId: stringOrNull(row.last_chat_message_id),
-    status: String(row.status) as ChannelSessionBindingRecord['status'],
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function channelInteractionFromRow(row: QueryRow): ChannelInteractionRecord {
-  return {
-    interactionId: String(row.interaction_id),
-    orgId: String(row.org_id),
-    agentId: String(row.agent_id),
-    sessionId: String(row.session_id),
-    provider: String(row.provider) as ChannelProviderId,
-    externalInteractionId: stringOrNull(row.external_interaction_id),
-    tokenHash: String(row.token_hash),
-    kind: String(row.kind) as ChannelInteractionRecord['kind'],
-    targetId: String(row.target_id),
-    status: String(row.status) as ChannelInteractionRecord['status'],
-    createdByIdentityId: stringOrNull(row.created_by_identity_id),
-    expiresAt: iso(row.expires_at),
-    usedAt: isoOrNull(row.used_at),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function billingSubscriptionFromRow(row: QueryRow): BillingSubscriptionRecord {
-  return {
-    orgId: String(row.org_id),
-    planKey: String(row.plan_key),
-    providerId: String(row.provider_id),
-    providerCustomerId: stringOrNull(row.provider_customer_id),
-    providerSubscriptionId: stringOrNull(row.provider_subscription_id),
-    status: String(row.status) as BillingSubscriptionRecord['status'],
-    seats: numberValue(row.seats),
-    entitlements: jsonRecord(row.entitlements) as BillingSubscriptionRecord['entitlements'],
-    currentPeriodEnd: isoOrNull(row.current_period_end),
-    cancelAtPeriodEnd: row.cancel_at_period_end === true,
-    metadata: jsonRecord(row.metadata),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function channelDeliveryFromRow(row: QueryRow): ChannelDeliveryRecord {
-  return {
-    deliveryId: String(row.delivery_id),
-    orgId: String(row.org_id),
-    agentId: String(row.agent_id),
-    channelBindingId: String(row.channel_binding_id),
-    sessionBindingId: stringOrNull(row.session_binding_id),
-    provider: String(row.provider) as ChannelProviderId,
-    target: jsonRecord(row.target),
-    eventType: String(row.event_type),
-    payload: jsonRecord(row.payload),
-    status: String(row.status) as ChannelDeliveryRecord['status'],
-    attemptCount: numberValue(row.attempt_count),
-    claimedBy: stringOrNull(row.claimed_by),
-    claimExpiresAt: isoOrNull(row.claim_expires_at),
-    nextAttemptAt: iso(row.next_attempt_at),
-    lastError: stringOrNull(row.last_error),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function sessionFromRow(row: QueryRow): SessionRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    userId: String(row.user_id),
-    sessionId: String(row.session_id),
-    opencodeSessionId: String(row.opencode_session_id),
-    profileName: String(row.profile_name),
-    status: String(row.status) as ControlPlaneSessionStatus,
-    title: stringOrNull(row.title),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function eventFromRow(row: QueryRow): SessionEventRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    sessionId: String(row.session_id),
-    eventId: String(row.event_id),
-    sequence: numberValue(row.sequence),
-    type: String(row.type),
-    payload: jsonRecord(row.payload),
-    createdAt: iso(row.created_at),
-  }
-}
-
-function workspaceEventFromRow(row: QueryRow): WorkspaceEventRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    userId: String(row.user_id),
-    sessionId: stringOrNull(row.session_id),
-    eventId: String(row.event_id),
-    sequence: numberValue(row.sequence),
-    entityType: String(row.entity_type),
-    entityId: String(row.entity_id),
-    operation: String(row.operation),
-    projectionVersion: numberValue(row.projection_version),
-    type: String(row.type),
-    payload: jsonRecord(row.payload),
-    createdAt: iso(row.created_at),
-  }
-}
-
-function projectionFromRow(row: QueryRow): SessionProjectionRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    sessionId: String(row.session_id),
-    sequence: numberValue(row.sequence),
-    view: jsonRecord(row.view),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function leaseFromRow(row: QueryRow): WorkerLeaseRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    sessionId: String(row.session_id),
-    leasedBy: String(row.leased_by),
-    leaseToken: String(row.lease_token),
-    leaseExpiresAt: numberValue(row.lease_expires_at_ms),
-    checkpointVersion: numberValue(row.checkpoint_version),
-  }
-}
-
-function commandFromRow(row: QueryRow): SessionCommandRecord {
-  return {
-    commandId: String(row.command_id),
-    tenantId: String(row.tenant_id),
-    userId: String(row.user_id),
-    sessionId: String(row.session_id),
-    kind: String(row.kind) as SessionCommandRecord['kind'],
-    payload: jsonRecord(row.payload),
-    targetLeaseToken: stringOrNull(row.target_lease_token),
-    createdSequence: numberValue(row.created_sequence),
-    createdAt: iso(row.created_at),
-    status: String(row.status) as ControlPlaneCommandStatus,
-    claimedBy: stringOrNull(row.claimed_by),
-    claimedLeaseToken: stringOrNull(row.claimed_lease_token),
-    ackedAt: row.acked_at ? iso(row.acked_at) : null,
-    error: stringOrNull(row.error),
-  }
-}
-
-function heartbeatFromRow(row: QueryRow): WorkerHeartbeatRecord {
-  return {
-    workerId: String(row.worker_id),
-    role: String(row.role) as WorkerRole,
-    activeSessionIds: Array.isArray(row.active_session_ids)
-      ? row.active_session_ids.map(String)
-      : [],
-    lastSeenAt: iso(row.last_seen_at),
-  }
-}
-
-function settingFromRow(row: QueryRow): SettingMetadataRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    userId: stringOrNull(row.user_id),
-    key: String(row.key),
-    value: jsonRecord(row.value),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function workflowFromRow(row: QueryRow): CloudWorkflowRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    userId: String(row.user_id),
-    id: String(row.workflow_id),
-    title: String(row.title),
-    instructions: String(row.instructions),
-    agentName: String(row.agent_name || 'build'),
-    skillNames: jsonStringArray(row.skill_names),
-    toolIds: jsonStringArray(row.tool_ids),
-    status: String(row.status) as WorkflowStatus,
-    projectDirectory: stringOrNull(row.project_directory),
-    draftSessionId: stringOrNull(row.draft_session_id),
-    triggers: workflowTriggers(row.triggers),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-    nextRunAt: isoOrNull(row.next_run_at),
-    lastRunAt: isoOrNull(row.last_run_at),
-    latestRunId: stringOrNull(row.latest_run_id),
-    latestRunStatus: row.latest_run_status ? String(row.latest_run_status) as WorkflowRunStatus : null,
-    latestRunSessionId: stringOrNull(row.latest_run_session_id),
-    latestRunSummary: stringOrNull(row.latest_run_summary),
-    webhookUrl: null,
-  }
-}
-
-function workflowRunFromRow(row: QueryRow): CloudWorkflowRunRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    userId: String(row.user_id),
-    id: String(row.run_id),
-    workflowId: String(row.workflow_id),
-    sessionId: stringOrNull(row.session_id),
-    triggerType: String(row.trigger_type) as WorkflowTriggerType,
-    triggerPayload: row.trigger_payload ? jsonRecord(row.trigger_payload) : null,
-    status: String(row.status) as WorkflowRunStatus,
-    title: String(row.title),
-    summary: stringOrNull(row.summary),
-    error: stringOrNull(row.error),
-    createdAt: iso(row.created_at),
-    startedAt: isoOrNull(row.started_at),
-    finishedAt: isoOrNull(row.finished_at),
-  }
-}
-
-function threadTagFromRow(row: QueryRow): ThreadTagRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    tagId: String(row.tag_id),
-    name: String(row.name),
-    color: String(row.color),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function threadSmartFilterFromRow(row: QueryRow): ThreadSmartFilterRecord {
-  return {
-    tenantId: String(row.tenant_id),
-    filterId: String(row.filter_id),
-    name: String(row.name),
-    query: jsonRecord(row.query),
-    createdAt: iso(row.created_at),
-    updatedAt: iso(row.updated_at),
-  }
-}
-
-function migrationFromRow(row: QueryRow): SchemaMigrationRecord {
-  return {
-    id: String(row.id),
-    appliedAt: iso(row.applied_at),
-  }
-}
-
-function webhookAuthFailureFromRow(row: QueryRow): WebhookAuthFailureRecord {
-  return {
-    authWindowStartedAt: numberValue(row.auth_window_started_at_ms),
-    authFailureCount: numberValue(row.auth_failure_count),
-    blockedUntil: numberValue(row.blocked_until_ms),
-  }
-}
-
-function cloudAuthBackoffFromRow(row: QueryRow, nowMs: number): CloudAuthBackoffRecord {
-  const blockedUntilMs = numberValue(row.blocked_until_ms)
-  return {
-    allowed: blockedUntilMs <= nowMs,
-    scope: String(row.scope),
-    source: String(row.source),
-    failureCount: numberValue(row.auth_failure_count),
-    blockedUntilMs,
-    retryAfterMs: Math.max(0, blockedUntilMs - nowMs),
-  }
 }
 
 export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWebhookSecurityStore {

--- a/apps/desktop/src/main/cloud/postgres-domains/billing.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/billing.ts
@@ -1,0 +1,33 @@
+import type { BillingSubscriptionRecord, UsageEventRecord } from '../control-plane-store.ts'
+import { iso, isoOrNull, jsonRecord, numberValue, stringOrNull, type QueryRow } from './shared.ts'
+
+export function usageEventFromRow(row: QueryRow): UsageEventRecord {
+  return {
+    eventId: String(row.event_id),
+    orgId: String(row.org_id),
+    accountId: stringOrNull(row.account_id),
+    eventType: String(row.event_type),
+    quantity: numberValue(row.quantity),
+    unit: String(row.unit),
+    metadata: jsonRecord(row.metadata),
+    createdAt: iso(row.created_at),
+  }
+}
+
+export function billingSubscriptionFromRow(row: QueryRow): BillingSubscriptionRecord {
+  return {
+    orgId: String(row.org_id),
+    planKey: String(row.plan_key),
+    providerId: String(row.provider_id),
+    providerCustomerId: stringOrNull(row.provider_customer_id),
+    providerSubscriptionId: stringOrNull(row.provider_subscription_id),
+    status: String(row.status) as BillingSubscriptionRecord['status'],
+    seats: numberValue(row.seats),
+    entitlements: jsonRecord(row.entitlements) as BillingSubscriptionRecord['entitlements'],
+    currentPeriodEnd: isoOrNull(row.current_period_end),
+    cancelAtPeriodEnd: row.cancel_at_period_end === true,
+    metadata: jsonRecord(row.metadata),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/byok.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/byok.ts
@@ -1,0 +1,21 @@
+import type { ByokSecretRecord } from '../control-plane-store.ts'
+import { iso, isoOrNull, stringOrNull, type QueryRow } from './shared.ts'
+
+export function byokSecretFromRow(row: QueryRow): ByokSecretRecord {
+  return {
+    secretId: String(row.secret_id),
+    orgId: String(row.org_id),
+    providerId: String(row.provider_id),
+    ciphertext: stringOrNull(row.ciphertext),
+    kmsRef: stringOrNull(row.kms_ref),
+    keyFingerprint: String(row.key_fingerprint),
+    last4: String(row.last4),
+    createdByAccountId: stringOrNull(row.created_by_account_id),
+    rotatedFromSecretId: stringOrNull(row.rotated_from_secret_id),
+    lastValidatedAt: isoOrNull(row.last_validated_at),
+    validationError: stringOrNull(row.validation_error),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+    status: String(row.status) as ByokSecretRecord['status'],
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/channels.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/channels.ts
@@ -1,0 +1,119 @@
+import type {
+  ChannelBindingRecord,
+  ChannelDeliveryRecord,
+  ChannelIdentityRecord,
+  ChannelInteractionRecord,
+  ChannelProviderId,
+  ChannelSessionBindingRecord,
+  HeadlessAgentRecord,
+} from '../control-plane-store.ts'
+import { iso, isoOrNull, jsonRecord, numberValue, stringOrNull, type QueryRow } from './shared.ts'
+
+export function headlessAgentFromRow(row: QueryRow): HeadlessAgentRecord {
+  return {
+    agentId: String(row.agent_id),
+    orgId: String(row.org_id),
+    tenantId: String(row.tenant_id),
+    profileName: String(row.profile_name),
+    name: String(row.name),
+    status: String(row.status) as HeadlessAgentRecord['status'],
+    managed: row.managed === true,
+    createdByAccountId: stringOrNull(row.created_by_account_id),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function channelBindingFromRow(row: QueryRow): ChannelBindingRecord {
+  return {
+    bindingId: String(row.binding_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalWorkspaceId: stringOrNull(row.external_workspace_id),
+    displayName: String(row.display_name),
+    status: String(row.status) as ChannelBindingRecord['status'],
+    credentialRef: stringOrNull(row.credential_ref),
+    settings: jsonRecord(row.settings),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function channelIdentityFromRow(row: QueryRow): ChannelIdentityRecord {
+  return {
+    identityId: String(row.identity_id),
+    orgId: String(row.org_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalWorkspaceId: stringOrNull(row.external_workspace_id),
+    externalUserId: String(row.external_user_id),
+    accountId: stringOrNull(row.account_id),
+    role: String(row.role) as ChannelIdentityRecord['role'],
+    status: String(row.status) as ChannelIdentityRecord['status'],
+    metadata: jsonRecord(row.metadata),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function channelSessionBindingFromRow(row: QueryRow): ChannelSessionBindingRecord {
+  return {
+    bindingId: String(row.binding_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    channelBindingId: String(row.channel_binding_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalWorkspaceId: stringOrNull(row.external_workspace_id),
+    externalThreadId: String(row.external_thread_id),
+    externalChatId: String(row.external_chat_id),
+    sessionId: String(row.session_id),
+    lastEventSequence: numberValue(row.last_event_sequence),
+    lastWorkspaceSequence: numberValue(row.last_workspace_sequence),
+    lastChatMessageId: stringOrNull(row.last_chat_message_id),
+    status: String(row.status) as ChannelSessionBindingRecord['status'],
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function channelInteractionFromRow(row: QueryRow): ChannelInteractionRecord {
+  return {
+    interactionId: String(row.interaction_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    sessionId: String(row.session_id),
+    provider: String(row.provider) as ChannelProviderId,
+    externalInteractionId: stringOrNull(row.external_interaction_id),
+    tokenHash: String(row.token_hash),
+    kind: String(row.kind) as ChannelInteractionRecord['kind'],
+    targetId: String(row.target_id),
+    status: String(row.status) as ChannelInteractionRecord['status'],
+    createdByIdentityId: stringOrNull(row.created_by_identity_id),
+    expiresAt: iso(row.expires_at),
+    usedAt: isoOrNull(row.used_at),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function channelDeliveryFromRow(row: QueryRow): ChannelDeliveryRecord {
+  return {
+    deliveryId: String(row.delivery_id),
+    orgId: String(row.org_id),
+    agentId: String(row.agent_id),
+    channelBindingId: String(row.channel_binding_id),
+    sessionBindingId: stringOrNull(row.session_binding_id),
+    provider: String(row.provider) as ChannelProviderId,
+    target: jsonRecord(row.target),
+    eventType: String(row.event_type),
+    payload: jsonRecord(row.payload),
+    status: String(row.status) as ChannelDeliveryRecord['status'],
+    attemptCount: numberValue(row.attempt_count),
+    claimedBy: stringOrNull(row.claimed_by),
+    claimExpiresAt: isoOrNull(row.claim_expires_at),
+    nextAttemptAt: iso(row.next_attempt_at),
+    lastError: stringOrNull(row.last_error),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/identity.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/identity.ts
@@ -1,0 +1,108 @@
+import type {
+  AccountRecord,
+  ApiTokenRecord,
+  AuditEventRecord,
+  CloudAuthBackoffRecord,
+  ControlPlaneRole,
+  MembershipRecord,
+  OrgRecord,
+  TenantRecord,
+  UserRecord,
+} from '../control-plane-store.ts'
+import { iso, isoOrNull, jsonRecord, jsonStringArray, numberValue, stringOrNull, type QueryRow } from './shared.ts'
+
+export function tenantFromRow(row: QueryRow): TenantRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    name: String(row.name),
+    createdAt: iso(row.created_at),
+  }
+}
+
+export function userFromRow(row: QueryRow): UserRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    userId: String(row.user_id),
+    email: String(row.email),
+    role: String(row.role) as ControlPlaneRole,
+    createdAt: iso(row.created_at),
+  }
+}
+
+export function orgFromRow(row: QueryRow): OrgRecord {
+  return {
+    orgId: String(row.org_id),
+    tenantId: String(row.tenant_id),
+    name: String(row.name),
+    planKey: stringOrNull(row.plan_key),
+    status: String(row.status),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function accountFromRow(row: QueryRow): AccountRecord {
+  return {
+    accountId: String(row.account_id),
+    idpSubject: stringOrNull(row.idp_subject),
+    email: String(row.email),
+    displayName: stringOrNull(row.display_name),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function membershipFromRow(row: QueryRow): MembershipRecord {
+  return {
+    orgId: String(row.org_id),
+    accountId: String(row.account_id),
+    role: String(row.role) as ControlPlaneRole,
+    status: String(row.status) as MembershipRecord['status'],
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function apiTokenFromRow(row: QueryRow): ApiTokenRecord {
+  return {
+    tokenId: String(row.token_id),
+    orgId: String(row.org_id),
+    accountId: stringOrNull(row.account_id),
+    name: String(row.name),
+    tokenHash: String(row.token_hash),
+    scopes: jsonStringArray(row.scopes) as ApiTokenRecord['scopes'],
+    last4: String(row.last4),
+    expiresAt: isoOrNull(row.expires_at),
+    revokedAt: isoOrNull(row.revoked_at),
+    lastUsedAt: isoOrNull(row.last_used_at),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function auditEventFromRow(row: QueryRow): AuditEventRecord {
+  return {
+    eventId: String(row.event_id),
+    orgId: String(row.org_id),
+    accountId: stringOrNull(row.account_id),
+    eventType: String(row.event_type),
+    actorType: String(row.actor_type) as AuditEventRecord['actorType'],
+    actorId: stringOrNull(row.actor_id),
+    targetType: stringOrNull(row.target_type),
+    targetId: stringOrNull(row.target_id),
+    metadata: jsonRecord(row.metadata),
+    createdAt: iso(row.created_at),
+  }
+}
+
+export function cloudAuthBackoffFromRow(row: QueryRow, nowMs: number): CloudAuthBackoffRecord {
+  const blockedUntilMs = numberValue(row.blocked_until_ms)
+  return {
+    allowed: blockedUntilMs <= nowMs,
+    scope: String(row.scope),
+    source: String(row.source),
+    failureCount: numberValue(row.auth_failure_count),
+    blockedUntilMs,
+    retryAfterMs: Math.max(0, blockedUntilMs - nowMs),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/schema.ts
@@ -1,0 +1,9 @@
+import type { SchemaMigrationRecord } from '../control-plane-store.ts'
+import { iso, type QueryRow } from './shared.ts'
+
+export function migrationFromRow(row: QueryRow): SchemaMigrationRecord {
+  return {
+    id: String(row.id),
+    appliedAt: iso(row.applied_at),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/sessions.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/sessions.ts
@@ -1,0 +1,118 @@
+import type {
+  ControlPlaneSessionStatus,
+  ControlPlaneCommandStatus,
+  SessionCommandRecord,
+  SessionEventRecord,
+  SessionProjectionRecord,
+  SessionRecord,
+  SettingMetadataRecord,
+  WorkerHeartbeatRecord,
+  WorkerLeaseRecord,
+  WorkerRole,
+  WorkspaceEventRecord,
+} from '../control-plane-store.ts'
+import { iso, jsonRecord, numberValue, stringOrNull, type QueryRow } from './shared.ts'
+
+export function sessionFromRow(row: QueryRow): SessionRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    userId: String(row.user_id),
+    sessionId: String(row.session_id),
+    opencodeSessionId: String(row.opencode_session_id),
+    profileName: String(row.profile_name),
+    title: stringOrNull(row.title),
+    status: String(row.status) as ControlPlaneSessionStatus,
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function eventFromRow(row: QueryRow): SessionEventRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    sessionId: String(row.session_id),
+    eventId: String(row.event_id),
+    sequence: numberValue(row.sequence),
+    type: String(row.type),
+    payload: jsonRecord(row.payload),
+    createdAt: iso(row.created_at),
+  }
+}
+
+export function workspaceEventFromRow(row: QueryRow): WorkspaceEventRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    userId: String(row.user_id),
+    sessionId: stringOrNull(row.session_id),
+    eventId: String(row.event_id),
+    sequence: numberValue(row.sequence),
+    operation: String(row.operation) as WorkspaceEventRecord['operation'],
+    entityType: String(row.entity_type),
+    entityId: String(row.entity_id),
+    projectionVersion: numberValue(row.projection_version),
+    type: String(row.type),
+    payload: jsonRecord(row.payload),
+    createdAt: iso(row.created_at),
+  }
+}
+
+export function projectionFromRow(row: QueryRow): SessionProjectionRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    sessionId: String(row.session_id),
+    sequence: numberValue(row.sequence),
+    view: jsonRecord(row.view),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function leaseFromRow(row: QueryRow): WorkerLeaseRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    sessionId: String(row.session_id),
+    leasedBy: String(row.leased_by),
+    leaseToken: String(row.lease_token),
+    leaseExpiresAt: numberValue(row.lease_expires_at_ms),
+    checkpointVersion: numberValue(row.checkpoint_version),
+  }
+}
+
+export function commandFromRow(row: QueryRow): SessionCommandRecord {
+  return {
+    commandId: String(row.command_id),
+    tenantId: String(row.tenant_id),
+    userId: String(row.user_id),
+    sessionId: String(row.session_id),
+    kind: String(row.kind) as SessionCommandRecord['kind'],
+    payload: jsonRecord(row.payload),
+    targetLeaseToken: stringOrNull(row.target_lease_token),
+    createdSequence: numberValue(row.created_sequence),
+    createdAt: iso(row.created_at),
+    status: String(row.status) as ControlPlaneCommandStatus,
+    claimedBy: stringOrNull(row.claimed_by),
+    claimedLeaseToken: stringOrNull(row.claimed_lease_token),
+    ackedAt: row.acked_at ? iso(row.acked_at) : null,
+    error: stringOrNull(row.error),
+  }
+}
+
+export function heartbeatFromRow(row: QueryRow): WorkerHeartbeatRecord {
+  return {
+    workerId: String(row.worker_id),
+    role: String(row.role) as WorkerRole,
+    activeSessionIds: Array.isArray(row.active_session_ids)
+      ? row.active_session_ids.map(String)
+      : [],
+    lastSeenAt: iso(row.last_seen_at),
+  }
+}
+
+export function settingFromRow(row: QueryRow): SettingMetadataRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    userId: stringOrNull(row.user_id),
+    key: String(row.key),
+    value: jsonRecord(row.value),
+    updatedAt: iso(row.updated_at),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/shared.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/shared.ts
@@ -1,0 +1,34 @@
+export type QueryRow = Record<string, unknown>
+export type QueryResult<Row extends QueryRow = QueryRow> = { rows: Row[] }
+
+export function iso(value: unknown) {
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string') return new Date(value).toISOString()
+  throw new Error('Expected a timestamp column.')
+}
+
+export function numberValue(value: unknown) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) throw new Error('Expected a numeric column.')
+  return parsed
+}
+
+export function stringOrNull(value: unknown) {
+  return typeof value === 'string' ? value : null
+}
+
+export function isoOrNull(value: unknown) {
+  return value ? iso(value) : null
+}
+
+export function jsonRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+export function jsonStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : []
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/thread-index.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/thread-index.ts
@@ -1,0 +1,24 @@
+import type { ThreadSmartFilterRecord, ThreadTagRecord } from '../control-plane-store.ts'
+import { iso, jsonRecord, type QueryRow } from './shared.ts'
+
+export function threadTagFromRow(row: QueryRow): ThreadTagRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    tagId: String(row.tag_id),
+    name: String(row.name),
+    color: String(row.color),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function threadSmartFilterFromRow(row: QueryRow): ThreadSmartFilterRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    filterId: String(row.filter_id),
+    name: String(row.name),
+    query: jsonRecord(row.query),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/webhooks.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/webhooks.ts
@@ -1,0 +1,10 @@
+import type { WebhookAuthFailureRecord } from '../../workflow/workflow-webhook-server.ts'
+import { numberValue, type QueryRow } from './shared.ts'
+
+export function webhookAuthFailureFromRow(row: QueryRow): WebhookAuthFailureRecord {
+  return {
+    authWindowStartedAt: numberValue(row.auth_window_started_at_ms),
+    authFailureCount: numberValue(row.auth_failure_count),
+    blockedUntil: numberValue(row.blocked_until_ms),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-domains/workflows.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/workflows.ts
@@ -1,0 +1,59 @@
+import type {
+  WorkflowRunStatus,
+  WorkflowStatus,
+  WorkflowTrigger,
+  WorkflowTriggerType,
+} from '@open-cowork/shared'
+import type { CloudWorkflowRecord, CloudWorkflowRunRecord } from '../control-plane-store.ts'
+import { iso, isoOrNull, jsonRecord, jsonStringArray, stringOrNull, type QueryRow } from './shared.ts'
+
+function workflowTriggers(value: unknown): WorkflowTrigger[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is WorkflowTrigger => Boolean(entry && typeof entry === 'object' && !Array.isArray(entry)))
+    : []
+}
+
+export function workflowFromRow(row: QueryRow): CloudWorkflowRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    userId: String(row.user_id),
+    id: String(row.workflow_id),
+    title: String(row.title),
+    instructions: String(row.instructions),
+    agentName: String(row.agent_name || 'build'),
+    skillNames: jsonStringArray(row.skill_names),
+    toolIds: jsonStringArray(row.tool_ids),
+    projectDirectory: stringOrNull(row.project_directory),
+    draftSessionId: stringOrNull(row.draft_session_id),
+    triggers: workflowTriggers(row.triggers),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+    nextRunAt: isoOrNull(row.next_run_at),
+    lastRunAt: isoOrNull(row.last_run_at),
+    latestRunId: stringOrNull(row.latest_run_id),
+    latestRunStatus: row.latest_run_status ? String(row.latest_run_status) as WorkflowRunStatus : null,
+    latestRunSessionId: stringOrNull(row.latest_run_session_id),
+    latestRunSummary: stringOrNull(row.latest_run_summary),
+    status: String(row.status) as WorkflowStatus,
+    webhookUrl: null,
+  }
+}
+
+export function workflowRunFromRow(row: QueryRow): CloudWorkflowRunRecord {
+  return {
+    tenantId: String(row.tenant_id),
+    userId: String(row.user_id),
+    id: String(row.run_id),
+    workflowId: String(row.workflow_id),
+    sessionId: stringOrNull(row.session_id),
+    triggerType: String(row.trigger_type) as WorkflowTriggerType,
+    triggerPayload: row.trigger_payload ? jsonRecord(row.trigger_payload) : null,
+    status: String(row.status) as WorkflowRunStatus,
+    title: String(row.title),
+    summary: stringOrNull(row.summary),
+    error: stringOrNull(row.error),
+    createdAt: iso(row.created_at),
+    startedAt: isoOrNull(row.started_at),
+    finishedAt: isoOrNull(row.finished_at),
+  }
+}

--- a/apps/desktop/src/main/cloud/services/index.ts
+++ b/apps/desktop/src/main/cloud/services/index.ts
@@ -12,3 +12,15 @@ export { CloudWorkflowService } from './workflow-service.ts'
 export type { CloudWorkflowServiceDelegate } from './workflow-service.ts'
 export { CloudProjectionService } from './projection-service.ts'
 export type { AppendProjectedEventInput } from './projection-service.ts'
+export {
+  normalizePermissionPayload,
+  normalizePromptPayload,
+  normalizeQuestionRejectPayload,
+  normalizeQuestionReplyPayload,
+} from './session-command-service.ts'
+export type {
+  PermissionRespondPayload,
+  PromptCommandPayload,
+  QuestionRejectPayload,
+  QuestionReplyPayload,
+} from './session-command-service.ts'

--- a/apps/desktop/src/main/cloud/services/session-command-service.ts
+++ b/apps/desktop/src/main/cloud/services/session-command-service.ts
@@ -1,0 +1,49 @@
+export type PromptCommandPayload = {
+  text: string
+  agent: string
+}
+
+export type QuestionReplyPayload = {
+  requestId: string
+  answers: unknown[]
+}
+
+export type QuestionRejectPayload = {
+  requestId: string
+}
+
+export type PermissionRespondPayload = {
+  permissionId: string
+  response: unknown
+}
+
+function readString(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value : fallback
+}
+
+export function normalizePromptPayload(payload: Record<string, unknown>): PromptCommandPayload {
+  return {
+    text: readString(payload.text),
+    agent: readString(payload.agent, 'build'),
+  }
+}
+
+export function normalizeQuestionReplyPayload(payload: Record<string, unknown>): QuestionReplyPayload {
+  return {
+    requestId: readString(payload.requestId),
+    answers: Array.isArray(payload.answers) ? payload.answers : [],
+  }
+}
+
+export function normalizeQuestionRejectPayload(payload: Record<string, unknown>): QuestionRejectPayload {
+  return {
+    requestId: readString(payload.requestId),
+  }
+}
+
+export function normalizePermissionPayload(payload: Record<string, unknown>): PermissionRespondPayload {
+  return {
+    permissionId: readString(payload.permissionId),
+    response: payload.response ?? null,
+  }
+}

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -95,6 +95,15 @@ import {
   CloudSessionProjectionService,
   type AppendProjectedEventInput,
 } from './session-projection-service.ts'
+import {
+  normalizePermissionPayload,
+  normalizePromptPayload,
+  normalizeQuestionRejectPayload,
+  normalizeQuestionReplyPayload,
+  type PermissionRespondPayload,
+  type QuestionRejectPayload,
+  type QuestionReplyPayload,
+} from './services/session-command-service.ts'
 import { computeNextWorkflowRunAt, validateWorkflowSchedule } from '../workflow/workflow-schedule.ts'
 import {
   verifyWorkflowWebhookAuth,
@@ -359,25 +368,6 @@ export type CloudWorkflowStartResult = {
   command: SessionCommandRecord
 }
 
-type PromptCommandPayload = {
-  text: string
-  agent: string
-}
-
-type QuestionReplyPayload = {
-  requestId: string
-  answers: unknown[]
-}
-
-type QuestionRejectPayload = {
-  requestId: string
-}
-
-type PermissionRespondPayload = {
-  permissionId: string
-  response: unknown
-}
-
 type ChannelActorInput = {
   identityId?: string | null
   provider?: ChannelProviderId | null
@@ -621,33 +611,6 @@ function workflowRunTerminal(status: WorkflowRun['status']) {
 function workflowWebhookReplayKey(workflowId: string, auth: Extract<WorkflowWebhookAuth, { kind: 'signature' }>) {
   const workflowKey = createHash('sha256').update(workflowId).digest('hex').slice(0, 16)
   return `${workflowKey}:${auth.timestamp}:${auth.signature}`
-}
-
-function normalizePromptPayload(payload: Record<string, unknown>): PromptCommandPayload {
-  return {
-    text: readString(payload.text),
-    agent: readString(payload.agent, 'build'),
-  }
-}
-
-function normalizeQuestionReplyPayload(payload: Record<string, unknown>): QuestionReplyPayload {
-  return {
-    requestId: readString(payload.requestId),
-    answers: Array.isArray(payload.answers) ? payload.answers : [],
-  }
-}
-
-function normalizeQuestionRejectPayload(payload: Record<string, unknown>): QuestionRejectPayload {
-  return {
-    requestId: readString(payload.requestId),
-  }
-}
-
-function normalizePermissionPayload(payload: Record<string, unknown>): PermissionRespondPayload {
-  return {
-    permissionId: readString(payload.permissionId),
-    response: payload.response ?? null,
-  }
 }
 
 function normalizeImportCounts(value: Partial<SessionImportItemCounts> | undefined): SessionImportItemCounts {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,20 +133,25 @@ Cloud code is split by domain before it is split by provider. The public store
 surface stays available from `control-plane-store.ts`, but narrow domain
 contracts live under `control-plane-domains/` so identity, sessions,
 workflows, channels, BYOK, billing, settings, and thread index code can be
-tested independently. HTTP routes live under `http-routes/`, and the
+tested independently. Postgres row mappers live under `postgres-domains/`
+so SQL result shapes are owned beside their domain instead of being embedded
+in the compatibility store facade. HTTP routes live under `http-routes/`, and the
 `@open-cowork/cloud-client` package exposes both the backward-compatible
 top-level barrel and domain barrels under `src/domains/`.
 
 Cloud source files should stay below 2,000 lines. Current documented
-exceptions are implementation backlogs, not target architecture:
+exceptions have explicit budgets and are implementation backlogs, not target
+architecture:
 
-- `in-memory-control-plane-store.ts`: compatibility implementation for the
-  full domain store contract.
-- `postgres-control-plane-store.ts`: compatibility implementation for the
-  full Postgres-backed store plus webhook security store.
-- `session-service.ts`: compatibility orchestration facade around runtime
-  execution, workflows, quotas, channel coordination, BYOK, billing, and
-  projection services.
+- `in-memory-control-plane-store.ts` (budget 3,900 lines): compatibility
+  implementation for the full domain store contract.
+- `postgres-control-plane-store.ts` (budget 4,000 lines): compatibility
+  implementation for the full Postgres-backed store plus webhook security
+  store. Domain row mappers belong in `postgres-domains/`.
+- `session-service.ts` (budget 4,100 lines): compatibility orchestration
+  facade around runtime execution, workflows, quotas, channel coordination,
+  BYOK, billing, projection services, and the focused command payload service
+  under `services/session-command-service.ts`.
 
 New cloud domains should not be added to those exception files. Add a domain
 contract, service, route module, or client domain module first, then wire the

--- a/tests/cloud-modularity-boundaries.test.ts
+++ b/tests/cloud-modularity-boundaries.test.ts
@@ -9,10 +9,10 @@ const cloudClientRoot = join(root, 'packages/cloud-client/src')
 const architectureDoc = readFileSync(join(root, 'docs/architecture.md'), 'utf8')
 
 const lineThreshold = 2_000
-const documentedLargeFileExceptions = new Set([
-  'apps/desktop/src/main/cloud/in-memory-control-plane-store.ts',
-  'apps/desktop/src/main/cloud/postgres-control-plane-store.ts',
-  'apps/desktop/src/main/cloud/session-service.ts',
+const documentedLargeFileBudgets = new Map([
+  ['apps/desktop/src/main/cloud/in-memory-control-plane-store.ts', 3_900],
+  ['apps/desktop/src/main/cloud/postgres-control-plane-store.ts', 4_000],
+  ['apps/desktop/src/main/cloud/session-service.ts', 4_100],
 ])
 
 test('cloud core has enforceable domain module boundaries', () => {
@@ -31,12 +31,31 @@ test('cloud core has enforceable domain module boundaries', () => {
     assert.equal(existsSync(join(cloudRoot, 'control-plane-domains', file)), true, `${file} domain store contract is missing`)
   }
 
+  const expectedPostgresDomains = [
+    'billing.ts',
+    'byok.ts',
+    'channels.ts',
+    'identity.ts',
+    'schema.ts',
+    'sessions.ts',
+    'shared.ts',
+    'thread-index.ts',
+    'webhooks.ts',
+    'workflows.ts',
+  ]
+  for (const file of expectedPostgresDomains) {
+    assert.equal(existsSync(join(cloudRoot, 'postgres-domains', file)), true, `${file} Postgres domain mapper is missing`)
+  }
+
   const expectedRoutes = [
     'api-tokens.ts',
     'billing.ts',
     'byok.ts',
+    'capabilities.ts',
     'channels.ts',
     'project-sources.ts',
+    'settings.ts',
+    'threads.ts',
     'workspace.ts',
   ]
   for (const file of expectedRoutes) {
@@ -51,6 +70,7 @@ test('cloud core has enforceable domain module boundaries', () => {
     'channel-service.ts',
     'workflow-service.ts',
     'projection-service.ts',
+    'session-command-service.ts',
   ]
   for (const file of expectedServices) {
     assert.equal(existsSync(join(cloudRoot, 'services', file)), true, `${file} domain service is missing`)
@@ -88,16 +108,57 @@ test('large cloud source files are documented exceptions', () => {
       const relativePath = relative(root, file)
       const lineCount = readFileSync(file, 'utf8').split('\n').length
       if (lineCount <= lineThreshold) continue
+      const budget = documentedLargeFileBudgets.get(relativePath)
       assert.equal(
-        documentedLargeFileExceptions.has(relativePath),
-        true,
-        `${relativePath} has ${lineCount} lines and needs a documented modularity exception or further splitting`,
+        typeof budget,
+        'number',
+        `${relativePath} has ${lineCount} lines and needs a documented modularity budget or further splitting`,
+      )
+      assert.ok(
+        lineCount <= budget!,
+        `${relativePath} has ${lineCount} lines and exceeds its modularity budget of ${budget}`,
       )
       assert.match(
         architectureDoc,
         new RegExp(relativePath.split('/').at(-1)!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
         `${relativePath} is a large-file exception but is not documented in docs/architecture.md`,
       )
+    }
+  }
+})
+
+test('postgres store delegates row mapping to domain modules', () => {
+  const source = readFileSync(join(cloudRoot, 'postgres-control-plane-store.ts'), 'utf8')
+  assert.doesNotMatch(source, /function \w+FromRow\(/, 'Postgres row mappers belong in postgres-domains/*')
+  assert.match(source, /postgres-domains\/identity\.ts/)
+  assert.match(source, /postgres-domains\/sessions\.ts/)
+  assert.match(source, /postgres-domains\/channels\.ts/)
+  assert.match(source, /postgres-domains\/workflows\.ts/)
+
+  for (const file of sourceFiles(join(cloudRoot, 'postgres-domains'))) {
+    const relativePath = relative(root, file)
+    const lineCount = readFileSync(file, 'utf8').split('\n').length
+    assert.ok(lineCount <= 250, `${relativePath} has ${lineCount} lines; Postgres domain mappers should stay narrow`)
+  }
+})
+
+test('session service delegates command payload parsing to command service module', () => {
+  const source = readFileSync(join(cloudRoot, 'session-service.ts'), 'utf8')
+  assert.doesNotMatch(source, /function normalize(Prompt|QuestionReply|QuestionReject|Permission)Payload\(/)
+  assert.match(source, /services\/session-command-service\.ts/)
+})
+
+test('cloud route and service modules stay behind store and runtime boundaries', () => {
+  const checkedRoots = [
+    join(cloudRoot, 'http-routes'),
+    join(cloudRoot, 'services'),
+  ]
+  for (const checkedRoot of checkedRoots) {
+    for (const file of sourceFiles(checkedRoot)) {
+      const relativePath = relative(root, file)
+      const source = readFileSync(file, 'utf8')
+      assert.doesNotMatch(source, /postgres-control-plane-store/, `${relativePath} must not import concrete Postgres stores`)
+      assert.doesNotMatch(source, /@opencode-ai\/sdk/, `${relativePath} must not import OpenCode runtime surfaces`)
     }
   }
 })


### PR DESCRIPTION
## Summary
- extract Postgres row mapping into bounded cloud domain modules
- move capability, settings, and thread HTTP routes into route modules
- move session command payload parsing into a focused cloud service module
- document/enforce cloud modularity budgets and boundaries

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:cloud-continuation
- pnpm test:cloud-web
- node scripts/run-node-tests.mjs tests/cloud-modularity-boundaries.test.ts tests/cloud-control-plane-domain-contracts.test.ts tests/cloud-domain-services.test.ts
- node scripts/run-node-tests.mjs tests/cloud-http-server.test.ts
- git diff --check

Real Postgres suites were skipped locally because OPEN_COWORK_TEST_POSTGRES_URL is not set.

Closes #525