### PR TITLE
Harden release packaged smoke gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Performance gate
         run: pnpm perf:check
 
-      - name: Build all (shared → MCPs → desktop)
+      - name: Build all (packages, MCPs, gateway, website, desktop)
         run: pnpm build
 
   cloud-gates:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         run: pnpm perf:check
 
       - name: Strict docs build
-        run: mkdocs build --strict
+        run: pnpm docs:build
 
       - name: Whitespace check
         run: git diff --check

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "test:coverage:renderer": "pnpm --dir ../.. build:shared && vitest run --config vitest.renderer.config.ts --coverage",
     "test:e2e": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && node ../../scripts/run-desktop-smoke-tests.mjs --pattern \"tests/*.smoke.test.ts\" --timeout=120000 --retries=1",
     "test:e2e:packaged": "node ../../scripts/require-packaged-executable.mjs && node ../../scripts/run-desktop-smoke-tests.mjs --pattern \"tests/*.packaged.test.ts\" --timeout=240000 --retries=1",
+    "test:e2e:packaged:optional": "node ../../scripts/run-desktop-smoke-tests.mjs --pattern \"tests/*.packaged.test.ts\" --timeout=240000 --retries=1",
     "screenshots": "pnpm --dir ../.. build:shared && pnpm build && pnpm build:electron && node --no-warnings --experimental-strip-types tests/screenshots.ts",
     "dist": "node ../../scripts/desktop-dist.mjs",
     "dist:ci": "node ../../scripts/desktop-dist.mjs --mac zip --x64 --arm64 --publish never",

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -52,8 +52,9 @@ The repository includes:
   - Linux packaging validation
   - typecheck
   - perf gate
-  - dependency audit at `high` severity
-  - docs build
+  - production dependency audit at `moderate` severity
+  - full dependency audit at `critical` severity
+  - docs build through `pnpm docs:build`
 
 - `docs.yml`
   - builds MkDocs with `--strict`
@@ -311,3 +312,10 @@ The packaged macOS smoke lane can be run locally after packaging with:
 pnpm --dir apps/desktop dist:ci:mac
 OPEN_COWORK_PACKAGED_EXECUTABLE="$(node scripts/find-macos-packaged-executable.mjs)" pnpm test:e2e:packaged
 ```
+
+`pnpm test:e2e:packaged` is the release gate and fails before smoke test
+discovery unless `OPEN_COWORK_PACKAGED_EXECUTABLE` points at an executable
+file or a macOS `.app` bundle with a resolvable executable under
+`Contents/MacOS`. Broad discovery jobs that intentionally allow packaged
+tests to skip can use `pnpm test:e2e:packaged:optional`; do not use the
+optional command in release or branch-protection gates.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -30,7 +30,7 @@ Reference workflows in the repository root:
 
 ### Documentation
 
-- [ ] `mkdocs build --strict`
+- [ ] `pnpm docs:build`
 - [ ] published docs site reflects the latest merged docs changes
 - [ ] README matches current product behavior
 - [ ] config docs match `open-cowork.config.json`

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:coverage:renderer": "pnpm --filter @open-cowork/desktop test:coverage:renderer",
     "test:e2e": "pnpm --filter @open-cowork/desktop test:e2e",
     "test:e2e:packaged": "pnpm --filter @open-cowork/desktop test:e2e:packaged",
+    "test:e2e:packaged:optional": "pnpm --filter @open-cowork/desktop test:e2e:packaged:optional",
     "screenshots": "pnpm --filter @open-cowork/desktop screenshots",
     "cloud:dev": "node --no-warnings --experimental-strip-types scripts/open-cowork-cloud.ts",
     "cloud:build": "node scripts/build-cloud.mjs",

--- a/scripts/require-packaged-executable.mjs
+++ b/scripts/require-packaged-executable.mjs
@@ -1,15 +1,59 @@
-import { accessSync, constants, statSync } from 'node:fs'
+import { accessSync, constants, readdirSync, statSync } from 'node:fs'
+import { basename, join } from 'node:path'
 
 const envName = 'OPEN_COWORK_PACKAGED_EXECUTABLE'
 const executablePath = process.env[envName]?.trim()
 
 function fail(message) {
-  console.error(message)
+  console.error(`${message}\n\nBuild a packaged desktop app first, then run the release smoke gate. Examples:\n  pnpm --dir apps/desktop dist:ci:mac\n  ${envName}="$(node scripts/find-macos-packaged-executable.mjs)" pnpm test:e2e:packaged\n\nFor Linux, run:\n  pnpm --dir apps/desktop dist:ci:linux\n  ${envName}=apps/desktop/release/linux-unpacked/<binary> pnpm test:e2e:packaged`)
   process.exit(1)
 }
 
 if (!executablePath) {
   fail(`${envName} must point at a packaged desktop executable before running packaged smoke tests.`)
+}
+
+function assertExecutableFile(path) {
+  const stats = statSync(path)
+  if (!stats.isFile()) {
+    fail(`${envName} must point at an executable file or a macOS .app bundle: ${path}`)
+  }
+  try {
+    accessSync(path, constants.X_OK)
+  } catch {
+    fail(`${envName} is not executable: ${path}`)
+  }
+  return path
+}
+
+function resolveMacAppExecutable(appPath) {
+  const appName = basename(appPath).replace(/\.app$/i, '')
+  const macOsDir = join(appPath, 'Contents', 'MacOS')
+  let entries
+  try {
+    entries = readdirSync(macOsDir)
+  } catch {
+    fail(`${envName} points at a .app bundle without Contents/MacOS: ${appPath}`)
+  }
+
+  const executableCandidates = entries
+    .map((entry) => join(macOsDir, entry))
+    .filter((candidate) => {
+      try {
+        const stats = statSync(candidate)
+        accessSync(candidate, constants.X_OK)
+        return stats.isFile()
+      } catch {
+        return false
+      }
+    })
+
+  const preferred = executableCandidates.find((candidate) => basename(candidate) === appName)
+  const resolved = preferred || (executableCandidates.length === 1 ? executableCandidates[0] : null)
+  if (!resolved) {
+    fail(`${envName} points at a .app bundle without one resolvable executable in Contents/MacOS: ${appPath}`)
+  }
+  return resolved
 }
 
 let stats
@@ -19,12 +63,8 @@ try {
   fail(`${envName} does not exist: ${executablePath}`)
 }
 
-if (!stats.isFile()) {
-  fail(`${envName} must point at an executable file: ${executablePath}`)
-}
-
-try {
-  accessSync(executablePath, constants.X_OK)
-} catch {
-  fail(`${envName} is not executable: ${executablePath}`)
+if (stats.isDirectory() && /\.app$/i.test(executablePath)) {
+  resolveMacAppExecutable(executablePath)
+} else {
+  assertExecutableFile(executablePath)
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,8 @@ Related suites:
 
 - `pnpm test:renderer` — Vitest/jsdom renderer component tests
 - `pnpm test:e2e` — Electron smoke tests in `apps/desktop/tests/`; each file gets one explicit retry before the command fails
-- `OPEN_COWORK_PACKAGED_EXECUTABLE="$(node scripts/find-macos-packaged-executable.mjs)" pnpm test:e2e:packaged` — packaged-app relaunch smoke test after a local packaged build, with the same file-level retry behavior
+- `OPEN_COWORK_PACKAGED_EXECUTABLE="$(node scripts/find-macos-packaged-executable.mjs)" pnpm test:e2e:packaged` — release-grade packaged-app relaunch smoke test after a local packaged build; the command fails before discovery when the executable is missing or invalid
+- `pnpm test:e2e:packaged:optional` — broad packaged-test discovery path that keeps file-level skips when no packaged executable is available; do not use this as a release gate
 
 Add the narrowest test that proves the behavior you changed. Runtime
 execution should remain OpenCode-owned; tests here should validate Open

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -9,6 +9,9 @@ type PackageJson = {
 const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as PackageJson
 const desktopPackageJson = JSON.parse(readFileSync(new URL('../apps/desktop/package.json', import.meta.url), 'utf8')) as PackageJson
 const websitePackageJson = JSON.parse(readFileSync(new URL('../apps/website/package.json', import.meta.url), 'utf8')) as PackageJson
+const ciWorkflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8')
+const releaseWorkflow = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8')
+const packagingDocs = readFileSync(new URL('../docs/packaging-and-releases.md', import.meta.url), 'utf8')
 
 function requireScript(name: string, source: PackageJson = packageJson): string {
   const script = source.scripts?.[name]
@@ -43,6 +46,14 @@ test('root node test scripts prepare generated shared artifacts before tests run
     'node scripts/run-node-tests.mjs --coverage',
     'node scripts/coverage-summary.mjs --check --node-only --no-write',
   ])
+
+  assert.deepEqual(splitScriptSteps(requireScript('test:coverage')), [
+    'pnpm test:coverage:node',
+    'pnpm test:coverage:renderer',
+    'node scripts/coverage-summary.mjs --check',
+  ])
+
+  assert.equal(requireScript('test:coverage:renderer'), 'pnpm --filter @open-cowork/desktop test:coverage:renderer')
 
   assert.deepEqual(splitScriptSteps(requireScript('test:cloud-web')), [
     'pnpm build:shared',
@@ -99,9 +110,12 @@ test('root deployment scripts expose provider smoke gates', () => {
   assert.equal(requireScript('deploy:soak'), 'node scripts/launch-readiness.mjs --mode soak')
   assert.equal(requireScript('deploy:launch:validate'), 'node scripts/validate-launch-readiness.mjs')
   assert.equal(requireScript('deploy:private-beta:validate'), 'node scripts/validate-private-beta-package.mjs')
+  assert.equal(requireScript('ops:validate'), 'node scripts/validate-ops-readiness.mjs')
 })
 
 test('root build and dist scripts preserve release build prerequisites', () => {
+  assert.equal(requireScript('build:desktop'), 'pnpm --filter @open-cowork/desktop build')
+  assert.equal(requireScript('build:mcps'), 'pnpm --filter=./mcps/* build')
   assert.equal(requireScript('build:packages'), 'pnpm --filter=./packages/* build')
   assert.equal(requireScript('build:gateway'), 'pnpm --filter @open-cowork/gateway build')
   assert.equal(requireScript('build:website'), 'pnpm --filter @open-cowork/website build')
@@ -120,7 +134,7 @@ test('root build and dist scripts preserve release build prerequisites', () => {
   ])
 })
 
-test('root typecheck script covers shared, MCP, and desktop packages', () => {
+test('root typecheck script covers package, MCP, gateway, website, and desktop surfaces', () => {
   assert.deepEqual(splitScriptSteps(requireScript('typecheck')), [
     'pnpm build:packages',
     'pnpm typecheck:mcps',
@@ -139,9 +153,64 @@ test('packaged e2e script fails before smoke discovery without a packaged execut
   assert.deepEqual(splitScriptSteps(requireScript('test:e2e:packaged')), [
     'pnpm --filter @open-cowork/desktop test:e2e:packaged',
   ])
+  assert.deepEqual(splitScriptSteps(requireScript('test:e2e:packaged:optional')), [
+    'pnpm --filter @open-cowork/desktop test:e2e:packaged:optional',
+  ])
 
   assert.deepEqual(splitScriptSteps(requireScript('test:e2e:packaged', desktopPackageJson)), [
     'node ../../scripts/require-packaged-executable.mjs',
     'node ../../scripts/run-desktop-smoke-tests.mjs --pattern "tests/*.packaged.test.ts" --timeout=240000 --retries=1',
   ])
+  assert.deepEqual(splitScriptSteps(requireScript('test:e2e:packaged:optional', desktopPackageJson)), [
+    'node ../../scripts/run-desktop-smoke-tests.mjs --pattern "tests/*.packaged.test.ts" --timeout=240000 --retries=1',
+  ])
+})
+
+test('ci and release workflows use canonical release gate scripts', () => {
+  for (const command of [
+    'pnpm lint',
+    'pnpm test',
+    'pnpm test:cloud-web',
+    'pnpm test:renderer',
+    'pnpm typecheck',
+    'pnpm perf:check',
+    'pnpm build',
+    'pnpm docs:build',
+    'pnpm deploy:validate -- --require-tools',
+    'pnpm deploy:launch:validate',
+    'pnpm deploy:private-beta:validate',
+    'pnpm ops:validate',
+    'pnpm audit --prod --audit-level moderate',
+    'pnpm audit --audit-level critical',
+  ]) {
+    assert.match(ciWorkflow, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `CI must run ${command}`)
+  }
+
+  for (const command of [
+    'pnpm lint',
+    'pnpm typecheck',
+    'pnpm test',
+    'pnpm test:renderer',
+    'pnpm perf:check',
+    'pnpm docs:build',
+    'pnpm --dir apps/desktop test:e2e:packaged',
+    'pnpm audit --prod --audit-level moderate',
+    'pnpm audit --audit-level critical',
+    'node scripts/verify-release-tag-signature.mjs',
+  ]) {
+    assert.match(releaseWorkflow, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `release workflow must run ${command}`)
+  }
+
+  for (const evidence of [
+    'Generate CycloneDX SBOM',
+    'Generate SPDX SBOM',
+    'Validate SBOMs',
+    'THIRD_PARTY_NOTICES.md',
+    'SHA256SUMS.txt',
+    'SHA256SUMS.txt.asc',
+  ]) {
+    assert.match(releaseWorkflow, new RegExp(evidence.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `release workflow must preserve ${evidence}`)
+  }
+
+  assert.match(packagingDocs, /gh attestation verify/)
 })

--- a/tests/packaged-executable-preflight.test.ts
+++ b/tests/packaged-executable-preflight.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptPath = fileURLToPath(new URL('../scripts/require-packaged-executable.mjs', import.meta.url))
+
+function runPreflight(path: string | null) {
+  const env = { ...process.env }
+  if (path === null) delete env.OPEN_COWORK_PACKAGED_EXECUTABLE
+  else env.OPEN_COWORK_PACKAGED_EXECUTABLE = path
+  return spawnSync(process.execPath, [scriptPath], {
+    cwd: fileURLToPath(new URL('..', import.meta.url)),
+    env,
+    encoding: 'utf8',
+  })
+}
+
+function withTempDir(callback: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), 'open-cowork-packaged-preflight-'))
+  try {
+    callback(dir)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+test('packaged executable preflight fails closed without an explicit executable', () => {
+  const result = runPreflight(null)
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /OPEN_COWORK_PACKAGED_EXECUTABLE must point at a packaged desktop executable/)
+  assert.match(result.stderr, /pnpm --dir apps\/desktop dist:ci:mac/)
+  assert.match(result.stderr, /node scripts\/find-macos-packaged-executable\.mjs/)
+})
+
+test('packaged executable preflight accepts executable files', () => {
+  withTempDir((dir) => {
+    const executable = join(dir, 'open-cowork')
+    writeFileSync(executable, '#!/bin/sh\nexit 0\n')
+    chmodSync(executable, 0o755)
+    const result = runPreflight(executable)
+    assert.equal(result.status, 0, result.stderr)
+  })
+})
+
+test('packaged executable preflight rejects non-executable files', () => {
+  withTempDir((dir) => {
+    const executable = join(dir, 'open-cowork')
+    writeFileSync(executable, '#!/bin/sh\nexit 0\n')
+    chmodSync(executable, 0o644)
+    const result = runPreflight(executable)
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /is not executable/)
+  })
+})
+
+test('packaged executable preflight accepts macOS app bundles', () => {
+  withTempDir((dir) => {
+    const appBundle = join(dir, 'Open Cowork.app')
+    const macOsDir = join(appBundle, 'Contents', 'MacOS')
+    mkdirSync(macOsDir, { recursive: true })
+    const executable = join(macOsDir, 'Open Cowork')
+    writeFileSync(executable, '#!/bin/sh\nexit 0\n')
+    chmodSync(executable, 0o755)
+    const result = runPreflight(appBundle)
+    assert.equal(result.status, 0, result.stderr)
+  })
+})
+
+test('packaged executable preflight rejects app bundles without a resolvable executable', () => {
+  withTempDir((dir) => {
+    const appBundle = join(dir, 'Open Cowork.app')
+    mkdirSync(join(appBundle, 'Contents', 'MacOS'), { recursive: true })
+    const result = runPreflight(appBundle)
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /without one resolvable executable/)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #526.

- Make the primary packaged e2e smoke command fail closed before discovery unless `OPEN_COWORK_PACKAGED_EXECUTABLE` resolves to an executable file or valid macOS `.app` bundle.
- Add an explicit optional packaged discovery command for broad skip-tolerant jobs.
- Lock release script, CI, release workflow, and supply-chain evidence contracts in tests and docs.
- Align release docs/checklists on canonical gate names and packaged smoke expectations.

## Validation

- `node scripts/run-node-tests.mjs tests/package-scripts.test.ts tests/packaged-executable-preflight.test.ts`
- Missing executable fail-closed check for `pnpm test:e2e:packaged`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm docs:build`
- `pnpm deploy:validate && pnpm deploy:launch:validate && pnpm deploy:private-beta:validate && pnpm ops:validate`
- `pnpm audit --prod --audit-level moderate`
- `pnpm audit --audit-level critical`
- `pnpm --dir apps/desktop dist:ci`
- `OPEN_COWORK_PACKAGED_EXECUTABLE="$(node scripts/find-macos-packaged-executable.mjs)" pnpm test:e2e:packaged`
- `git diff --check`

## Notes

`.clawpatch/findings` is ignored by the repository, but the local finding files for this issue are marked fixed with evidence.
