### PR TITLE
Add managed BYOK beta launch evidence templates

### DIFF
--- a/deploy/private-beta/README.md
+++ b/deploy/private-beta/README.md
@@ -12,6 +12,15 @@ Files:
   billing, self-host Gateway, and placeholder secret refs.
 - `private-beta-plans.json`: plan and entitlement placeholders for private
   beta. It intentionally carries no prices or commercial assumptions.
+- `private-beta-launch-profile.template.json`: launch-profile template covering
+  entitlements, allowed provider policy, gateway availability, support owners,
+  RPO/RTO, required launch evidence, and go/no-go placeholders.
+- `design-partner-onboarding.template.md`: repeatable 10-step onboarding
+  evidence template for invite, BYOK, Desktop, Web, Gateway, token lifecycle,
+  and redaction proof.
+- `go-no-go-report.template.md`: final managed BYOK launch decision template
+  for exact commit/artifacts, validation commands, load/soak, failover/restore,
+  security boundaries, risks, and sign-off.
 
 These examples are provider-neutral. They use placeholder domains such as
 `cowork.example.com`, placeholder secret refs such as
@@ -33,6 +42,8 @@ The hosted path is for an operator-managed private beta:
 5. Configure BYOK and quotas per org.
 6. Preconfigure Desktop with the managed cloud URL.
 7. Store Gateway service tokens and channel credentials in platform secrets.
+8. Copy the onboarding, launch-profile, and go/no-go templates into a private
+   operations tracker and fill them with real evidence there, not in this repo.
 
 ## OSS Self-Host
 
@@ -51,6 +62,7 @@ Run:
 pnpm deploy:private-beta:validate
 pnpm deploy:validate
 pnpm deploy:launch:validate
+pnpm ops:validate
 ```
 
 before inviting design partners.

--- a/deploy/private-beta/design-partner-onboarding.template.md
+++ b/deploy/private-beta/design-partner-onboarding.template.md
@@ -1,0 +1,107 @@
+# Managed BYOK Design-Partner Onboarding Template
+
+Use this template in a private operations tracker for each design partner.
+Keep this public file generic: do not commit real org ids, customer names,
+domains, prices, cloud account ids, project ids, provider keys, token values,
+channel secrets, or support rosters.
+
+## Partner Record
+
+- Private ops ticket:
+- Launch profile template: `deploy/private-beta/private-beta-launch-profile.template.json`
+- Launch readiness target: `private-beta`
+- Release artifact:
+- Commit:
+- Operator:
+- Support owner:
+- Date:
+
+## Required Ten-Step Flow
+
+1. **Create or invite org owner**
+   - Evidence: owner account exists in invite/closed signup mode.
+   - Audit event:
+
+2. **Verify org membership and role**
+   - Evidence: owner/admin/member roles match the approved plan.
+   - Audit event:
+
+3. **Configure BYOK provider key through write-only endpoint**
+   - Evidence: POST/write path accepted key material.
+   - Redaction check: GET/read payload returns status, provider, last4, or
+     fingerprint only.
+
+4. **Run provider validation or audited override**
+   - Evidence: bounded worker-role validation succeeded, or override is linked.
+   - Provider id:
+   - Validation result:
+
+5. **Issue Desktop token or managed Desktop connection config**
+   - Evidence: token is show-once, scoped, expiring, and revocable.
+   - Expiry:
+   - Scope:
+
+6. **Issue Gateway service token and channel binding when enabled**
+   - Evidence: gateway token is scoped to gateway service use only.
+   - Channel provider:
+   - Signing/HMAC proof:
+
+7. **Confirm Cloud Web workbench bootstrap and admin surface**
+   - Evidence: `/`, `/api/config`, `/api/workspace`, admin policy, audit,
+     BYOK, billing/usage, and gateway ops surfaces load with expected role
+     checks.
+
+8. **Run first synced cloud thread from Web**
+   - Evidence: session create, prompt enqueue, SSE/projection update, artifact
+     or tool event when available.
+   - Session id:
+
+9. **Continue same thread from Desktop**
+   - Evidence: Desktop activates the cloud workspace, hydrates the same session
+     projection, sends or receives an update, and local workspace remains
+     available offline.
+
+10. **Continue or notify through Gateway**
+    - Evidence: gateway binds or resumes the same session, renders output,
+      resolves a permission/question when present, and advances delivery
+      cursor.
+
+## Token Lifecycle Proof
+
+- [ ] Desktop token show-once behavior captured.
+- [ ] Desktop token expiry captured.
+- [ ] Desktop token revocation blocks next request or SSE reconnect.
+- [ ] Gateway service token show-once behavior captured.
+- [ ] Gateway service token expiry captured.
+- [ ] Gateway service token revocation blocks next request or delivery stream.
+- [ ] Revoked/expired token attempts are audited and secret-redacted.
+
+## Secret Redaction Proof
+
+Confirm raw BYOK keys, OAuth refresh/access tokens, API tokens, MCP secrets,
+channel secrets, cookie secrets, database URLs, signed object-store URLs, and
+local file contents are absent from:
+
+- [ ] GET API payloads.
+- [ ] Cloud logs.
+- [ ] audit exports.
+- [ ] browser state.
+- [ ] Desktop cloud cache.
+- [ ] Gateway logs.
+- [ ] diagnostics bundles.
+- [ ] launch reports.
+
+## Blocking Behavior Proof
+
+- [ ] Unsupported provider blocks execution with a clear policy message.
+- [ ] Missing BYOK state blocks execution with a clear setup message.
+- [ ] Quota pressure returns clear 429/402 responses without spawning workers.
+- [ ] Cloud outage leaves local Desktop workspace usable.
+
+## Final Onboarding Decision
+
+- Decision: `{ready|conditional|blocked}`
+- Conditions:
+- Follow-up issues:
+- Support owner:
+- Next review date:

--- a/deploy/private-beta/go-no-go-report.template.md
+++ b/deploy/private-beta/go-no-go-report.template.md
@@ -1,0 +1,97 @@
+# Managed BYOK Private-Beta Go/No-Go Report Template
+
+Use this template for a release candidate or design-partner launch decision.
+Store completed reports in a private operations repository or ticket system.
+The public repo keeps the evidence shape only.
+
+## Launch Profile And Environment
+
+- Launch profile template:
+- Target environment:
+- Launch readiness target: `private-beta`
+- Org/onboarding tracker:
+- Cloud URL:
+- Gateway URL:
+- Region(s):
+- Support owner:
+- Incident channel:
+
+## Exact Commit And Release Artifact
+
+- Commit SHA:
+- Release tag:
+- Cloud image digest:
+- Gateway image digest:
+- Desktop build identifier:
+- Helm/Compose/Terraform revision:
+- Config revision:
+
+## Validation Commands With Timestamps
+
+| Command | Timestamp | Operator | Result | Evidence |
+| --- | --- | --- | --- | --- |
+| `pnpm deploy:validate` | | | | |
+| `pnpm deploy:launch:validate` | | | | |
+| `pnpm deploy:private-beta:validate` | | | | |
+| `pnpm ops:validate` | | | | |
+| `pnpm test:cloud-continuation` | | | | |
+| `pnpm test:cloud-web` | | | | |
+| BYOK security tests | | | | |
+| billing entitlement tests | | | | |
+| `git diff --check` | | | | |
+
+## Load And Soak Summary
+
+- Load profile: `private-beta`
+- Load report:
+- Soak profile: `private-beta`
+- Soak report:
+- p95 read latency:
+- p95 mutation latency:
+- p95 gateway latency:
+- max projection lag:
+- max command age:
+- SSE reconnects:
+- gateway retries:
+- gateway dead letters:
+- quota rejections:
+- billing gate denials:
+
+## Failover And Restore Summary
+
+- Worker restart/failover with pending commands:
+- Gateway restart with pending deliveries:
+- Backup restore drill:
+- Postgres restore proof:
+- object-store artifact download after restore:
+- BYOK provider call after worker restart:
+- scheduler recovery:
+- diagnostics redaction sample:
+
+## Security Boundary Checklist
+
+- [ ] BYOK plaintext absent from read APIs, logs, diagnostics, launch reports,
+      renderer state, Desktop cache, and Gateway logs.
+- [ ] Desktop local workspaces stay local and are not uploaded implicitly.
+- [ ] Gateway is a channel client and delivery adapter, not an execution runtime.
+- [ ] Public gateway ingress is signed or HMAC-authenticated.
+- [ ] Public Cloud auth uses OIDC or signed trusted-header auth.
+- [ ] Tokens are show-once, scoped, expiring by default, and revocable.
+- [ ] No real project ids, customer names, domains, prices, provider keys,
+      billing ids, or cloud account ids are copied into public repo artifacts.
+
+## Known Risks And Mitigations
+
+| Risk | Impact | Mitigation | Owner | Follow-up |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Decision
+
+- Decision: `{go|conditional-go|no-go}`
+- Decision owner:
+- Reviewers:
+- Support owner:
+- Conditions:
+- Follow-up issues:
+- Next review date:

--- a/deploy/private-beta/private-beta-launch-profile.template.json
+++ b/deploy/private-beta/private-beta-launch-profile.template.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": 1,
+  "purpose": "managed-byok-private-beta-launch-profile-template",
+  "evidenceBoundary": {
+    "publicRepo": "Template only. Keep real org ids, project ids, customer names, domains, prices, cloud account ids, provider keys, token values, support rosters, and launch evidence in private operations.",
+    "privateOpsRecord": "{private-ops-ticket-or-runbook-url}",
+    "redactionRequiredBeforeSharing": true
+  },
+  "profile": {
+    "profileKey": "private-beta-design-partner",
+    "planKey": "private-beta-design-partner",
+    "targetEnvironment": "{production-like-environment-name}",
+    "launchReadinessTarget": "private-beta",
+    "billingMode": "manual-or-stub",
+    "signupMode": "invite",
+    "support": {
+      "primaryOwner": "{support-owner}",
+      "secondaryOwner": "{secondary-support-owner}",
+      "escalationChannel": "{private-ops-channel}",
+      "supportHours": "{support-hours-and-timezone}",
+      "responseTargets": {
+        "sev1Minutes": 30,
+        "sev2BusinessHours": 4,
+        "sev3BusinessDays": 2
+      }
+    },
+    "entitlements": {
+      "maxSeatsPerOrg": 10,
+      "maxConcurrentSessionsPerOrg": 12,
+      "maxActiveWorkersPerOrg": 4,
+      "maxPromptsPerHour": 240,
+      "maxApiRequestsPerMinute": 600,
+      "maxWorkerMinutesPerHour": 720,
+      "maxGatewayDeliveriesPerHour": 600,
+      "maxGatewayChannelBindingsPerOrg": 10,
+      "maxArtifactBytesPerDay": 1073741824,
+      "allowNewSessions": true,
+      "allowPrompts": true,
+      "allowWorkers": true
+    },
+    "allowedProviderPolicy": {
+      "providerIds": ["anthropic", "openai"],
+      "validation": "required-before-first-run-or-audited-override",
+      "runtimeInjection": "provider-options-only",
+      "blockedByDefault": ["github-copilot"],
+      "plaintextReadbackAllowed": false
+    },
+    "gatewayProviderAvailability": [
+      {
+        "provider": "telegram",
+        "status": "enabled",
+        "requirements": ["service-token", "channel-identity-rbac", "provider-signing-or-managed-secret"]
+      },
+      {
+        "provider": "slack",
+        "status": "pilot",
+        "requirements": ["signing-secret", "channel-identity-rbac", "inline-approval-buttons"]
+      },
+      {
+        "provider": "email",
+        "status": "pilot",
+        "requirements": ["inbound-shared-secret", "threaded-replies", "token-approval-fallback"]
+      },
+      {
+        "provider": "webhook",
+        "status": "enabled-for-testing",
+        "requirements": ["timestamped-hmac", "no-public-unsigned-ingress"]
+      }
+    ],
+    "rpoRto": {
+      "postgresRpoMinutes": 15,
+      "objectStoreRpoMinutes": 15,
+      "secretManagerRpoMinutes": 60,
+      "targetRtoMinutes": 60,
+      "restoreDrillRequired": true
+    },
+    "requiredEvidence": {
+      "launchReadinessDryRun": true,
+      "loadRunProfile": "private-beta",
+      "soakRunProfile": "private-beta",
+      "workerFailoverWithPendingCommands": true,
+      "gatewayRestartWithPendingDeliveries": true,
+      "backupRestoreDrill": true,
+      "objectStoreArtifactAfterRestore": true,
+      "byokProviderCallAfterWorkerRestart": true,
+      "desktopWebGatewayContinuation": true,
+      "tokenRevocationProof": true,
+      "diagnosticsRedactionProof": true
+    },
+    "requiredSmokeCommands": [
+      "pnpm deploy:private-beta:validate",
+      "pnpm deploy:launch:validate",
+      "pnpm ops:validate",
+      "pnpm deploy:smoke",
+      "pnpm deploy:desktop:smoke",
+      "pnpm deploy:gateway:smoke",
+      "pnpm deploy:continuation:smoke",
+      "pnpm deploy:load",
+      "pnpm deploy:soak"
+    ],
+    "securityBoundaries": {
+      "byokPlaintextReadApis": "forbidden",
+      "desktopLocalThreadUpload": "explicit-copy-only",
+      "gatewayExecutionAuthority": "cloud-control-plane-only",
+      "publicWebhookIngress": "signed-only",
+      "diagnostics": "redacted-before-support",
+      "publicRepoEvidence": "templates-only"
+    },
+    "goNoGo": {
+      "decision": "{go|conditional-go|no-go}",
+      "decisionOwner": "{decision-owner}",
+      "supportOwner": "{support-owner}",
+      "knownRiskItems": ["{known risk and mitigation}"],
+      "signoffRequired": true
+    }
+  }
+}

--- a/docs/runbooks/private-beta-launch.md
+++ b/docs/runbooks/private-beta-launch.md
@@ -35,6 +35,20 @@ Private beta includes:
 - BYOK setup and status,
 - quotas, usage summaries, audit logs, diagnostics, and support workflow.
 
+The public repository owns the reusable launch package:
+
+- `deploy/private-beta/private-beta-launch-profile.template.json` defines the
+  generic launch profile, entitlements, provider policy, gateway availability,
+  RPO/RTO, required evidence, and security-boundary placeholders.
+- `deploy/private-beta/design-partner-onboarding.template.md` defines the
+  repeatable design-partner onboarding evidence checklist.
+- `deploy/private-beta/go-no-go-report.template.md` defines the final decision
+  record.
+
+Completed copies belong in a private operations repository or ticket system.
+Do not commit real org ids, project ids, customer names, domains, prices,
+provider keys, cloud account ids, token values, or launch evidence here.
+
 Private beta excludes:
 
 - public self-serve signup,
@@ -60,6 +74,17 @@ Before inviting a design partner, the operator must be able to demonstrate:
 ## Managed BYOK Onboarding Checklist
 
 Complete each item for every design partner.
+
+The private onboarding record must cover this exact 10-step flow: create or
+invite org owner, verify membership and role, configure BYOK through the
+write-only endpoint, run provider validation or audited override, issue Desktop
+token or managed connection config, issue Gateway service token and channel
+binding when enabled, confirm Cloud Web bootstrap and admin surface, run the
+first synced cloud thread from Web, continue the same thread from Desktop, and
+continue or notify through Gateway.
+
+The onboarding evidence record should preserve these checkpoint names: create or invite org owner;
+verify membership and role; write-only endpoint; continue the same thread from Desktop.
 
 ### 1. Account And Org
 
@@ -227,6 +252,12 @@ Private beta is a **go** only when:
 - support runbook is current,
 - known limits are documented,
 - there is an owner for every launch-day alert.
+
+The final go/no-go report must record the launch profile and target
+environment, exact commit and release artifacts, validation commands with timestamps,
+load and soak summaries, restore drill summary, security-boundary checklist,
+support owner, known risks with mitigations, and the explicit `go`, `conditional-go`,
+or `no-go` decision.
 
 If any required smoke, security, support, or recovery evidence is missing, the
 launch remains conditional and should not invite new design partners.

--- a/docs/runbooks/private-beta-support.md
+++ b/docs/runbooks/private-beta-support.md
@@ -77,6 +77,38 @@ For user/provider key issues:
    to revoke the provider key with the provider, rotate cloud envelope/KMS
    material if needed, and follow `docs/runbooks/managed-byok-saas.md`.
 
+## Incident Checklists
+
+### Suspected Key Exposure
+
+1. Stop new worker claims for the affected org or provider profile.
+2. Revoke or disable the affected BYOK secret metadata record.
+3. Ask the customer to revoke the provider key with the upstream provider.
+4. Rotate envelope/KMS material if ciphertext handling is in doubt.
+5. Review logs, diagnostics, audit exports, Desktop cache artifacts, Gateway
+   logs, and launch reports for plaintext exposure.
+6. Record the incident timeline, affected orgs, mitigation, and follow-up
+   tests in the private incident tracker.
+
+### Token Compromise
+
+1. Revoke the suspected Desktop, Gateway, API, or operator token.
+2. Verify the token cannot authenticate on the next request or SSE reconnect.
+3. Rotate related service credentials when scope is uncertain.
+4. Review audit events for unexpected org, BYOK, gateway, billing, or admin
+   actions.
+5. Issue replacement scoped tokens only after the actor identity is verified.
+
+### Channel Identity Misbinding
+
+1. Pause the affected channel binding or headless agent.
+2. Verify inbound actor identity separately from gateway service-token auth.
+3. Check `cloud_channel_identities`, session bindings, interaction tokens, and
+   delivery cursors for the affected provider/thread.
+4. Rebind the channel only after owner/admin confirmation.
+5. Audit whether approvals/questions were resolved by the wrong actor and
+   record remediation.
+
 ## Gateway Issue Handling
 
 For channel issues:
@@ -102,6 +134,21 @@ For Desktop cloud workspace issues:
 5. Confirm local workspace remains usable if cloud is offline.
 6. If cache corruption is suspected, ask the user to export diagnostics first,
    then clear the cloud cache for that workspace only.
+
+## Customer Offboarding
+
+Use offboarding when a private-beta partner leaves, a trial ends, or an
+incident requires org shutdown:
+
+1. Disable new execution by pausing entitlement/profile access.
+2. Revoke Desktop, Gateway, API, and operator-issued tokens.
+3. Disable BYOK secret metadata and confirm no worker can reveal plaintext.
+4. Remove or pause channel bindings and delivery streams.
+5. Export customer-owned data according to the agreed retention policy.
+6. Remove or quarantine object-store prefixes after export and retention review.
+7. Preserve audit logs for the agreed retention period.
+8. Confirm support can no longer access the org except through approved audit
+   retention workflows.
 
 ## Escalation Evidence
 

--- a/scripts/validate-private-beta-package.mjs
+++ b/scripts/validate-private-beta-package.mjs
@@ -27,6 +27,18 @@ function assertPositiveInteger(value, label) {
   if (!Number.isInteger(value) || value <= 0) throw new Error(`${label} must be a positive integer`)
 }
 
+function assertNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`)
+  }
+}
+
+function assertArrayIncludes(value, expected, label) {
+  if (!Array.isArray(value) || !value.includes(expected)) {
+    throw new Error(`${label} must include ${expected}`)
+  }
+}
+
 function log(message) {
   process.stdout.write(`[private-beta-validate] ${message}\n`)
 }
@@ -44,6 +56,9 @@ const requiredFiles = [
   'deploy/private-beta/hosted-byok.config.example.json',
   'deploy/private-beta/self-host-oss.config.example.json',
   'deploy/private-beta/private-beta-plans.json',
+  'deploy/private-beta/private-beta-launch-profile.template.json',
+  'deploy/private-beta/design-partner-onboarding.template.md',
+  'deploy/private-beta/go-no-go-report.template.md',
   'mkdocs.yml',
   'package.json',
 ]
@@ -60,6 +75,12 @@ for (const phrase of [
   'Open Cowork does not resell model tokens',
   'Desktop local workspaces stay local',
   'Gateway is a channel client and delivery adapter',
+  'create or invite org owner',
+  'verify membership and role',
+  'write-only endpoint',
+  'continue the same thread from Desktop',
+  'validation commands with timestamps',
+  'support owner',
   'cloud.billing.provider=none',
   'pnpm deploy:private-beta:validate',
   'pnpm deploy:continuation:smoke',
@@ -76,6 +97,11 @@ for (const phrase of [
   'BYOK Issue Handling',
   'Gateway Issue Handling',
   'Desktop Sync Issue Handling',
+  'Incident Checklists',
+  'Suspected Key Exposure',
+  'Token Compromise',
+  'Channel Identity Misbinding',
+  'Customer Offboarding',
   'Never attach raw secrets',
 ]) {
   assertIncludes('docs/runbooks/private-beta-support.md', phrase)
@@ -85,9 +111,13 @@ for (const phrase of [
   'hosted-byok.config.example.json',
   'self-host-oss.config.example.json',
   'private-beta-plans.json',
+  'private-beta-launch-profile.template.json',
+  'design-partner-onboarding.template.md',
+  'go-no-go-report.template.md',
   'provider-neutral',
   'cloud.billing.provider=none',
   'pnpm deploy:private-beta:validate',
+  'pnpm ops:validate',
 ]) {
   assertIncludes('deploy/private-beta/README.md', phrase)
 }
@@ -157,6 +187,109 @@ for (const plan of plans.plans) {
   }
 }
 
+const launchProfile = readJson('deploy/private-beta/private-beta-launch-profile.template.json')
+if (launchProfile.purpose !== 'managed-byok-private-beta-launch-profile-template') {
+  throw new Error('private beta launch profile template must declare its purpose')
+}
+assertIncludes('deploy/private-beta/private-beta-launch-profile.template.json', '{private-ops-ticket-or-runbook-url}')
+assertIncludes('deploy/private-beta/private-beta-launch-profile.template.json', '{production-like-environment-name}')
+if (launchProfile.evidenceBoundary?.redactionRequiredBeforeSharing !== true) {
+  throw new Error('launch profile must require redaction before sharing evidence')
+}
+const profile = launchProfile.profile
+if (profile?.launchReadinessTarget !== 'private-beta') {
+  throw new Error('launch profile must target private-beta')
+}
+if (profile?.billingMode !== 'manual-or-stub') {
+  throw new Error('launch profile must keep private beta billing manual or stubbed')
+}
+assertNonEmptyString(profile?.support?.primaryOwner, 'launchProfile.support.primaryOwner')
+assertNonEmptyString(profile?.support?.escalationChannel, 'launchProfile.support.escalationChannel')
+assertPositiveInteger(profile?.support?.responseTargets?.sev1Minutes, 'launchProfile.support.responseTargets.sev1Minutes')
+assertPositiveInteger(profile?.entitlements?.maxSeatsPerOrg, 'launchProfile.entitlements.maxSeatsPerOrg')
+assertPositiveInteger(profile?.entitlements?.maxConcurrentSessionsPerOrg, 'launchProfile.entitlements.maxConcurrentSessionsPerOrg')
+assertPositiveInteger(profile?.entitlements?.maxActiveWorkersPerOrg, 'launchProfile.entitlements.maxActiveWorkersPerOrg')
+assertPositiveInteger(profile?.entitlements?.maxPromptsPerHour, 'launchProfile.entitlements.maxPromptsPerHour')
+assertPositiveInteger(profile?.entitlements?.maxApiRequestsPerMinute, 'launchProfile.entitlements.maxApiRequestsPerMinute')
+if (profile?.allowedProviderPolicy?.validation !== 'required-before-first-run-or-audited-override') {
+  throw new Error('launch profile must require provider validation or an audited override')
+}
+if (profile?.allowedProviderPolicy?.runtimeInjection !== 'provider-options-only') {
+  throw new Error('launch profile must require provider-options-only runtime injection')
+}
+if (profile?.allowedProviderPolicy?.plaintextReadbackAllowed !== false) {
+  throw new Error('launch profile must forbid BYOK plaintext readback')
+}
+assertArrayIncludes(profile?.allowedProviderPolicy?.providerIds, 'anthropic', 'launchProfile.allowedProviderPolicy.providerIds')
+assertArrayIncludes(profile?.allowedProviderPolicy?.blockedByDefault, 'github-copilot', 'launchProfile.allowedProviderPolicy.blockedByDefault')
+for (const provider of ['telegram', 'slack', 'email', 'webhook']) {
+  if (!profile?.gatewayProviderAvailability?.some((entry) => entry.provider === provider)) {
+    throw new Error(`launch profile must document ${provider} gateway availability`)
+  }
+}
+assertPositiveInteger(profile?.rpoRto?.postgresRpoMinutes, 'launchProfile.rpoRto.postgresRpoMinutes')
+assertPositiveInteger(profile?.rpoRto?.objectStoreRpoMinutes, 'launchProfile.rpoRto.objectStoreRpoMinutes')
+assertPositiveInteger(profile?.rpoRto?.targetRtoMinutes, 'launchProfile.rpoRto.targetRtoMinutes')
+for (const evidence of [
+  'launchReadinessDryRun',
+  'workerFailoverWithPendingCommands',
+  'gatewayRestartWithPendingDeliveries',
+  'backupRestoreDrill',
+  'objectStoreArtifactAfterRestore',
+  'byokProviderCallAfterWorkerRestart',
+  'desktopWebGatewayContinuation',
+  'tokenRevocationProof',
+  'diagnosticsRedactionProof',
+]) {
+  if (profile?.requiredEvidence?.[evidence] !== true) {
+    throw new Error(`launch profile must require ${evidence}`)
+  }
+}
+for (const command of [
+  'pnpm deploy:private-beta:validate',
+  'pnpm deploy:launch:validate',
+  'pnpm ops:validate',
+  'pnpm deploy:continuation:smoke',
+  'pnpm deploy:load',
+  'pnpm deploy:soak',
+]) {
+  assertArrayIncludes(profile?.requiredSmokeCommands, command, 'launchProfile.requiredSmokeCommands')
+}
+
+for (const phrase of [
+  'Required Ten-Step Flow',
+  'Create or invite org owner',
+  'Verify org membership and role',
+  'Configure BYOK provider key through write-only endpoint',
+  'Run provider validation or audited override',
+  'Issue Desktop token or managed Desktop connection config',
+  'Issue Gateway service token and channel binding',
+  'Confirm Cloud Web workbench bootstrap and admin surface',
+  'Run first synced cloud thread from Web',
+  'Continue same thread from Desktop',
+  'Continue or notify through Gateway',
+  'Token Lifecycle Proof',
+  'Secret Redaction Proof',
+  'Blocking Behavior Proof',
+]) {
+  assertIncludes('deploy/private-beta/design-partner-onboarding.template.md', phrase)
+}
+
+for (const phrase of [
+  'Launch Profile And Environment',
+  'Exact Commit And Release Artifact',
+  'Validation Commands With Timestamps',
+  'Load And Soak Summary',
+  'Failover And Restore Summary',
+  'Security Boundary Checklist',
+  'Known Risks And Mitigations',
+  'Decision',
+  'BYOK plaintext absent',
+  'Gateway is a channel client and delivery adapter',
+]) {
+  assertIncludes('deploy/private-beta/go-no-go-report.template.md', phrase)
+}
+
 for (const path of [
   'docs/runbooks/private-beta-launch.md',
   'docs/runbooks/private-beta-support.md',
@@ -164,6 +297,9 @@ for (const path of [
   'deploy/private-beta/hosted-byok.config.example.json',
   'deploy/private-beta/self-host-oss.config.example.json',
   'deploy/private-beta/private-beta-plans.json',
+  'deploy/private-beta/private-beta-launch-profile.template.json',
+  'deploy/private-beta/design-partner-onboarding.template.md',
+  'deploy/private-beta/go-no-go-report.template.md',
 ]) {
   for (const forbidden of [
     '/Users/joe',
@@ -172,6 +308,7 @@ for (const path of [
     'sk-',
     'ghp_',
     'xoxb-',
+    'AIza',
   ]) {
     assertNotIncludes(path, forbidden)
   }

--- a/tests/private-beta-package.test.ts
+++ b/tests/private-beta-package.test.ts
@@ -24,6 +24,11 @@ test('private beta launch package documents managed and self-host promises', () 
     'Open Cowork does not resell model tokens',
     'Desktop local workspaces stay local',
     'Gateway is a channel client and delivery adapter',
+    'create or invite org owner',
+    'verify membership and role',
+    'write-only endpoint',
+    'continue the same thread from Desktop',
+    'validation commands with timestamps',
     'cloud.billing.provider=none',
     'pnpm deploy:private-beta:validate',
     'pnpm deploy:continuation:smoke',
@@ -39,9 +44,103 @@ test('private beta launch package documents managed and self-host promises', () 
     'BYOK Issue Handling',
     'Gateway Issue Handling',
     'Desktop Sync Issue Handling',
+    'Incident Checklists',
+    'Suspected Key Exposure',
+    'Token Compromise',
+    'Channel Identity Misbinding',
+    'Customer Offboarding',
     'Never attach raw secrets',
   ]) {
     assert.match(support, new RegExp(phrase))
+  }
+})
+
+test('private beta launch profile template captures launch decisions and evidence gates', () => {
+  const template = readJson('deploy/private-beta/private-beta-launch-profile.template.json')
+  assert.equal(template.purpose, 'managed-byok-private-beta-launch-profile-template')
+  assert.equal(template.evidenceBoundary.redactionRequiredBeforeSharing, true)
+  assert.match(template.evidenceBoundary.privateOpsRecord, /\{private-ops-ticket-or-runbook-url\}/)
+  assert.equal(template.profile.launchReadinessTarget, 'private-beta')
+  assert.equal(template.profile.billingMode, 'manual-or-stub')
+  assert.match(template.profile.targetEnvironment, /\{production-like-environment-name\}/)
+  assert.equal(template.profile.allowedProviderPolicy.validation, 'required-before-first-run-or-audited-override')
+  assert.equal(template.profile.allowedProviderPolicy.runtimeInjection, 'provider-options-only')
+  assert.equal(template.profile.allowedProviderPolicy.plaintextReadbackAllowed, false)
+  assert.ok(template.profile.allowedProviderPolicy.providerIds.includes('anthropic'))
+  assert.ok(template.profile.allowedProviderPolicy.blockedByDefault.includes('github-copilot'))
+  for (const provider of ['telegram', 'slack', 'email', 'webhook']) {
+    assert.ok(template.profile.gatewayProviderAvailability.some((entry: { provider: string }) => entry.provider === provider))
+  }
+  for (const key of [
+    'maxSeatsPerOrg',
+    'maxConcurrentSessionsPerOrg',
+    'maxActiveWorkersPerOrg',
+    'maxPromptsPerHour',
+    'maxApiRequestsPerMinute',
+  ]) {
+    assert.equal(typeof template.profile.entitlements[key], 'number')
+    assert.ok(template.profile.entitlements[key] > 0)
+  }
+  for (const evidence of [
+    'launchReadinessDryRun',
+    'workerFailoverWithPendingCommands',
+    'gatewayRestartWithPendingDeliveries',
+    'backupRestoreDrill',
+    'objectStoreArtifactAfterRestore',
+    'byokProviderCallAfterWorkerRestart',
+    'desktopWebGatewayContinuation',
+    'tokenRevocationProof',
+    'diagnosticsRedactionProof',
+  ]) {
+    assert.equal(template.profile.requiredEvidence[evidence], true)
+  }
+  for (const command of [
+    'pnpm deploy:private-beta:validate',
+    'pnpm deploy:launch:validate',
+    'pnpm ops:validate',
+    'pnpm deploy:continuation:smoke',
+    'pnpm deploy:load',
+    'pnpm deploy:soak',
+  ]) {
+    assert.ok(template.profile.requiredSmokeCommands.includes(command))
+  }
+})
+
+test('private beta onboarding and go/no-go templates force complete evidence records', () => {
+  const onboarding = readRepoFile('deploy/private-beta/design-partner-onboarding.template.md')
+  for (const phrase of [
+    'Required Ten-Step Flow',
+    'Create or invite org owner',
+    'Verify org membership and role',
+    'Configure BYOK provider key through write-only endpoint',
+    'Run provider validation or audited override',
+    'Issue Desktop token or managed Desktop connection config',
+    'Issue Gateway service token and channel binding',
+    'Confirm Cloud Web workbench bootstrap and admin surface',
+    'Run first synced cloud thread from Web',
+    'Continue same thread from Desktop',
+    'Continue or notify through Gateway',
+    'Token Lifecycle Proof',
+    'Secret Redaction Proof',
+    'Blocking Behavior Proof',
+  ]) {
+    assert.match(onboarding, new RegExp(phrase))
+  }
+
+  const report = readRepoFile('deploy/private-beta/go-no-go-report.template.md')
+  for (const phrase of [
+    'Launch Profile And Environment',
+    'Exact Commit And Release Artifact',
+    'Validation Commands With Timestamps',
+    'Load And Soak Summary',
+    'Failover And Restore Summary',
+    'Security Boundary Checklist',
+    'Known Risks And Mitigations',
+    'Decision',
+    'BYOK plaintext absent',
+    'Gateway is a channel client and delivery adapter',
+  ]) {
+    assert.match(report, new RegExp(phrase))
   }
 })
 


### PR DESCRIPTION
## Summary

- Adds a managed BYOK private-beta launch profile template with entitlements, provider policy, gateway availability, RPO/RTO targets, evidence requirements, and go/no-go placeholders.
- Adds design-partner onboarding and go/no-go report templates for repeatable private operations evidence without committing private values.
- Extends private-beta launch/support runbooks for the 10-step onboarding flow, incident handling, token compromise, channel identity misbinding, and customer offboarding.
- Strengthens `deploy:private-beta:validate` and tests so the launch package fails closed when required templates/evidence gates are missing.

Closes #527.

## Validation

- `pnpm deploy:private-beta:validate`
- `node --no-warnings --experimental-strip-types --test tests/private-beta-package.test.ts`
- `pnpm deploy:launch:validate`
- `pnpm ops:validate`
- `pnpm deploy:validate`
- `node --no-warnings --experimental-strip-types --test tests/byok-secret-store.test.ts tests/byok-boundary-regression.test.ts tests/byok-runtime-injection.test.ts tests/billing-adapter.test.ts`
- `pnpm docs:build`
- `pnpm test:cloud-continuation`
- `pnpm test:cloud-web`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (1412 pass, 12 expected skips for optional Postgres tests)
- `git diff --check`
