### PR TITLE
Add OpenCode-native GitHub Copilot provider

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -545,11 +545,19 @@ function defaultCloudRuntimeFactory(input: CloudRoleRuntimeFactoryInput) {
   })
 }
 
-function listConfiguredByokProviderIds(config: OpenCoworkConfig) {
-  const providerIds = (config.providers.available || [])
+export function listConfiguredByokProviderIds(config: OpenCoworkConfig) {
+  const configuredProviderIds = (config.providers.available || [])
     .map((providerId) => providerId.trim().toLowerCase())
     .filter(Boolean)
-  return providerIds.length > 0 ? Array.from(new Set(providerIds)) : null
+  const providerIds = configuredProviderIds
+    .filter((providerId) => {
+      const descriptor = config.providers.descriptors?.[providerId]
+      const custom = config.providers.custom?.[providerId]
+      const credentials = descriptor?.credentials || custom?.credentials || []
+      return credentials.some((credential) => credential.secret)
+    })
+  if (providerIds.length > 0) return Array.from(new Set(providerIds))
+  return configuredProviderIds.length > 0 ? [] : null
 }
 
 function readHeader(req: IncomingMessage, name: string) {

--- a/apps/desktop/src/main/cloud/byok-runtime-config.ts
+++ b/apps/desktop/src/main/cloud/byok-runtime-config.ts
@@ -78,7 +78,7 @@ async function resolveProviderPolicy(input: {
   const allowedProviderIds = input.policy?.allowedProviderIds
     ? new Set(input.policy.allowedProviderIds.map((id) => id.trim().toLowerCase()).filter(Boolean))
     : null
-  if (allowedProviderIds?.size && !allowedProviderIds.has(input.providerId.trim().toLowerCase())) {
+  if (allowedProviderIds && !allowedProviderIds.has(input.providerId.trim().toLowerCase())) {
     return { allowed: false, code: 'provider_not_allowed' as const }
   }
   const entitlement = await input.policy?.checkEntitlement?.({

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -3855,7 +3855,7 @@ export class CloudSessionService {
     const allowedProviderIds = this.byokPolicy.allowedProviderIds
       ? new Set(this.byokPolicy.allowedProviderIds.map((id) => id.trim().toLowerCase()).filter(Boolean))
       : null
-    if (allowedProviderIds?.size && !allowedProviderIds.has(providerId)) {
+    if (allowedProviderIds && !allowedProviderIds.has(providerId)) {
       throw new CloudServiceError(403, `Provider "${providerId}" is not enabled for BYOK in this cloud profile.`)
     }
     await this.assertBillingAllowed({

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -142,6 +142,7 @@ export type ConfiguredModelInfo = {
 
 export type ConfiguredProviderDescriptor = {
   runtime?: 'builtin' | 'custom'
+  runtimeActivation?: 'implicit' | 'config'
   name: string
   description: string
   defaultModel?: string

--- a/apps/desktop/src/main/runtime-config-builder.ts
+++ b/apps/desktop/src/main/runtime-config-builder.ts
@@ -172,13 +172,19 @@ export function buildConfiguredDescriptorProviderRuntimeConfig(
   const models = buildDescriptorModelRuntimeConfig(descriptor.models)
   const hasOptions = Object.keys(options).length > 0
 
-  // For OpenCode-native providers such as OpenAI, Anthropic, and
-  // downstream providers like GitHub Copilot, omit the provider override
-  // entirely unless Cowork actually has options, API-key credentials, or
-  // model overrides to contribute. Passing a name-only provider object
-  // shadows OpenCode's built-in provider metadata and can make the
-  // runtime choose the API-key auth path even after browser login.
-  if (!hasOptions && !models) return null
+  // Most OpenCode-native providers such as OpenAI should be omitted
+  // unless Cowork has options, API-key credentials, or model overrides to
+  // contribute. Passing a name-only provider object can shadow OpenCode's
+  // built-in metadata and make the runtime choose the API-key auth path
+  // even after browser login. Some dormant OpenCode-native providers,
+  // including GitHub Copilot in the pinned runtime, only appear after a
+  // minimal provider config entry exists; those descriptors opt into
+  // runtimeActivation: "config".
+  if (!hasOptions && !models) {
+    return descriptor.runtimeActivation === 'config'
+      ? { name: descriptor.name }
+      : null
+  }
 
   return {
     name: descriptor.name,

--- a/apps/desktop/src/main/runtime-home-bridge.ts
+++ b/apps/desktop/src/main/runtime-home-bridge.ts
@@ -5,7 +5,7 @@ import { getRuntimeHomeDir } from './runtime-paths.ts'
 
 // Keep OpenCode's HOME sandbox self-contained while still exposing the
 // standard developer-tool config that runtime-invoked commands expect.
-// Deliberately omit any OpenCode / Claude / agent compatibility roots.
+// Deliberately omit any OpenCode / Claude / Copilot / agent compatibility roots.
 const DEFAULT_TOOLING_BRIDGE_ENTRIES = [
   '.gitconfig',
   '.gitignore',
@@ -23,11 +23,14 @@ const DEFAULT_TOOLING_BRIDGE_ENTRIES = [
   '.kube',
   '.config/git',
   '.config/gh',
-  '.config/gh-copilot',
   '.config/gcloud',
   '.config/npm',
   '.config/yarn',
   '.config/pnpm',
+] as const
+
+const SENSITIVE_UNBRIDGED_ENTRIES = [
+  '.config/gh-copilot',
 ] as const
 
 export function getRuntimeHomeToolingBridgeEntries() {
@@ -81,6 +84,10 @@ export function syncRuntimeHomeToolingBridge(options?: {
   const realHome = options?.realHome || homedir()
   const entries = options?.entries || getRuntimeHomeToolingBridgeEntries()
   const enabled = options?.enabled !== false
+
+  for (const relativePath of SENSITIVE_UNBRIDGED_ENTRIES) {
+    removeLinkedTargetIfPresent(join(runtimeHome, relativePath), join(realHome, relativePath))
+  }
 
   for (const relativePath of entries) {
     const source = join(realHome, relativePath)

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -68,6 +68,18 @@ const providers: ProviderDescriptor[] = [
   },
 ]
 
+const providersWithCopilot: ProviderDescriptor[] = [
+  ...providers,
+  {
+    id: 'github-copilot',
+    name: 'GitHub Copilot',
+    description: 'OpenCode-native Copilot login',
+    connected: false,
+    credentials: [],
+    models: [],
+  },
+]
+
 function resetSessionStore() {
   useSessionStore.setState({
     sessions: [],
@@ -248,5 +260,82 @@ describe('SetupScreen', () => {
         openrouter: expect.objectContaining({ apiKey: 'sk-or-scoped' }),
       },
     }))
+  })
+
+  it('uses OpenCode runtime catalog defaults after credentialless provider auth', async () => {
+    const user = userEvent.setup()
+    const set = vi.fn(async (updates: Partial<EffectiveAppSettings>) => settings({
+      ...updates,
+      effectiveProviderId: updates.selectedProviderId || 'github-copilot',
+      effectiveModel: updates.selectedModelId || null,
+    }))
+    const restart = vi.fn(async () => ({ ready: true, error: null }))
+    const onComplete = vi.fn()
+    installRendererTestCoworkApi({
+      provider: {
+        authMethods: vi.fn(async () => ({
+          'github-copilot': [{ type: 'oauth', label: 'GitHub Copilot' }],
+        })),
+        authorize: vi.fn(async () => ({
+          url: 'https://github.com/login/device',
+          method: 'auto',
+          instructions: 'Enter code ABCD 1234 at https://github.com/login/device',
+        })),
+        callback: vi.fn(async () => true),
+        list: vi.fn(async () => [{
+          id: 'github-copilot',
+          name: 'GitHub Copilot',
+          connected: true,
+          defaultModel: 'gpt-5.4',
+          models: { 'gpt-5.4': {} },
+        }]),
+      },
+      settings: {
+        get: vi.fn(async () => settings({
+          selectedProviderId: 'github-copilot',
+          selectedModelId: null,
+          effectiveProviderId: 'github-copilot',
+          effectiveModel: null,
+        })),
+        getProviderCredentials: vi.fn(async () => ({})),
+        set,
+      },
+      runtime: {
+        restart,
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providersWithCopilot}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={onComplete}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Sign in with GitHub Copilot' }))
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      selectedProviderId: 'github-copilot',
+      selectedModelId: '',
+      providerCredentials: {
+        'github-copilot': {},
+      },
+    })))
+    await user.click(screen.getByRole('button', { name: "I've finished signing in" }))
+    await waitFor(() => expect(screen.getByPlaceholderText('Model ID')).toHaveValue('gpt-5.4'))
+
+    await user.click(screen.getByRole('button', { name: 'Get Started' }))
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    expect(set).toHaveBeenLastCalledWith(expect.objectContaining({
+      selectedProviderId: 'github-copilot',
+      selectedModelId: 'gpt-5.4',
+      providerCredentials: {
+        'github-copilot': {},
+      },
+    }))
+    expect(restart).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -30,6 +30,21 @@ function reportSetupLoadError(error: unknown, scope: string) {
   }
 }
 
+async function resolveRuntimeProviderDefaultModel(providerId: string | null) {
+  if (!providerId) return ''
+  const providers = await window.coworkApi.provider.list()
+  const provider = providers.find((entry) => entry.id === providerId || entry.name === providerId)
+  const defaultModel = provider?.defaultModel?.trim()
+  if (defaultModel) {
+    const prefix = `${providerId}/`
+    return defaultModel.startsWith(prefix) ? defaultModel.slice(prefix.length) : defaultModel
+  }
+  const models = provider?.models && typeof provider.models === 'object'
+    ? Object.keys(provider.models)
+    : []
+  return models[0] || ''
+}
+
 export function SetupScreen({
   brandName,
   email,
@@ -75,9 +90,14 @@ export function SetupScreen({
         ? settings.selectedProviderId
         : settings.effectiveProviderId || defaultProviderId
       const initialProvider = providers.find((provider) => provider.id === initialProviderId) || null
+      const savedEffectiveModel = settings.effectiveProviderId === initialProviderId ? settings.effectiveModel : null
       const initialModelId = initialProvider?.models.some((model) => model.id === settings.selectedModelId)
         ? settings.selectedModelId || ''
-        : settings.effectiveModel || initialProvider?.defaultModel || defaultModelId || initialProvider?.models[0]?.id || ''
+        : savedEffectiveModel
+          || initialProvider?.defaultModel
+          || (initialProviderId === defaultProviderId ? defaultModelId : '')
+          || initialProvider?.models[0]?.id
+          || ''
       const initialCredentials = initialProviderId
         ? await window.coworkApi.settings.getProviderCredentials(initialProviderId)
         : {}
@@ -107,9 +127,14 @@ export function SetupScreen({
   useEffect(() => {
     if (!selectedProvider) return
     if (!modelId) {
-      setModelId(selectedProvider.defaultModel || selectedProvider.models[0]?.id || defaultModelId || '')
+      setModelId(
+        selectedProvider.defaultModel
+        || selectedProvider.models[0]?.id
+        || (selectedProvider.id === defaultProviderId ? defaultModelId : '')
+        || '',
+      )
     }
-  }, [selectedProvider, modelId, defaultModelId])
+  }, [selectedProvider, modelId, defaultModelId, defaultProviderId])
 
   useEffect(() => {
     if (!providerId || loadedCredentialProviders.has(providerId)) return
@@ -238,7 +263,9 @@ export function SetupScreen({
                 disabled={!providerId || saving}
                 onBeforeAuthorize={async () => persistSelectionAndRestart(undefined, { allowMissingModel: true })}
                 onAuthUpdated={async () => {
-                  const authModelId = selectedProvider.defaultModel || modelId
+                  const authModelId = selectedProvider.defaultModel
+                    || await resolveRuntimeProviderDefaultModel(providerId)
+                    || modelId
                   setModelId(authModelId)
                 }}
               />

--- a/apps/desktop/src/renderer/components/sidebar/SettingsModelsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsModelsPanel.tsx
@@ -102,6 +102,14 @@ export function ModelsPanel({
     effectiveSmallModel: mainModelId || null,
   })
 
+  const persistBeforeProviderAuth = async () => {
+    const persisted = await onPersistSettings()
+    if (!persisted) return false
+    if (!provider || provider.models.length > 0 || mainModelId.trim()) return true
+    const status = await window.coworkApi.runtime.restart()
+    return status.ready
+  }
+
   return (
     <div className="flex flex-col gap-5">
       {config.auth.enabled ? (
@@ -171,7 +179,7 @@ export function ModelsPanel({
             providerId={provider.id}
             providerName={provider.name}
             connected={provider.connected}
-            onBeforeAuthorize={onPersistSettings}
+            onBeforeAuthorize={persistBeforeProviderAuth}
             onAuthUpdated={async () => {
               const nextConfig = await window.coworkApi.app.config()
               onConfigRefreshed(nextConfig)

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx
@@ -392,6 +392,92 @@ describe('SettingsPanel', () => {
     expect(apiKeyInput).toHaveValue('sk-or-user-edit')
   })
 
+  it('restarts runtime before credentialless OpenCode-native provider auth and adopts the live default model', async () => {
+    const user = userEvent.setup()
+    const copilotProvider = {
+      id: 'github-copilot',
+      name: 'GitHub Copilot',
+      description: 'OpenCode-native Copilot login',
+      connected: false,
+      credentials: [],
+      models: [],
+    }
+    const configWithCopilot: PublicAppConfig = {
+      ...config,
+      providers: {
+        ...config.providers,
+        available: [...config.providers.available, copilotProvider],
+      },
+    }
+    const refreshedConfig: PublicAppConfig = {
+      ...configWithCopilot,
+      providers: {
+        ...configWithCopilot.providers,
+        available: configWithCopilot.providers.available.map((provider) => provider.id === 'github-copilot'
+          ? {
+              ...provider,
+              connected: true,
+              defaultModel: 'gpt-5.4',
+              models: [{ id: 'gpt-5.4', name: 'GPT-5.4' }],
+            }
+          : provider),
+      },
+    }
+    const settingsSet = vi.fn(async (updates: Partial<EffectiveAppSettings>) => settings({
+      ...updates,
+      effectiveProviderId: updates.selectedProviderId || 'github-copilot',
+      effectiveModel: updates.selectedModelId || null,
+    }))
+    const runtimeRestart = vi.fn(async () => ({ ready: true, running: true, sessions: 0, uptimeMs: 0 }))
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn()
+          .mockResolvedValueOnce(configWithCopilot)
+          .mockResolvedValue(refreshedConfig),
+      },
+      provider: {
+        authMethods: vi.fn(async () => ({
+          'github-copilot': [{ type: 'oauth', label: 'GitHub Copilot' }],
+        })),
+        authorize: vi.fn(async () => ({
+          url: 'https://github.com/login/device',
+          method: 'auto',
+          instructions: 'Enter code ABCD 1234 at https://github.com/login/device',
+        })),
+        callback: vi.fn(async () => true),
+        list: vi.fn(async () => [{
+          id: 'github-copilot',
+          name: 'GitHub Copilot',
+          connected: true,
+        }]),
+      },
+      runtime: {
+        restart: runtimeRestart,
+      },
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(async () => ({})),
+        set: settingsSet,
+      },
+    })
+
+    render(<SettingsPanel onClose={vi.fn()} />)
+
+    await screen.findByText('Settings')
+    await user.click(screen.getByRole('button', { name: /Models/ }))
+    await user.click(screen.getByRole('button', { name: /GitHub Copilot/ }))
+    await user.click(await screen.findByRole('button', { name: 'Sign in with GitHub Copilot' }))
+
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledWith(expect.objectContaining({
+      selectedProviderId: 'github-copilot',
+      selectedModelId: '',
+    })))
+    expect(runtimeRestart).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: "I've finished signing in" }))
+    await screen.findByRole('button', { name: /GPT-5\.4/ })
+  })
+
   it('does not bind masked credential sentinels to editable inputs', async () => {
     const credentialLoad = deferred<Record<string, string>>()
     const user = userEvent.setup()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -383,6 +383,47 @@ same way — OpenRouter is just an example. Downstream distributions can
 keep `models[]` only (strict static behavior) or add a `dynamicCatalog`
 for discovery, without touching code.
 
+Some OpenCode-native providers are dormant until the runtime receives a
+minimal provider config entry. GitHub Copilot is one example in the pinned
+OpenCode runtime. Use `runtimeActivation: "config"` for those providers:
+
+```json
+{
+  "providers": {
+    "available": ["openrouter", "openai", "github-copilot"],
+    "descriptors": {
+      "github-copilot": {
+        "runtime": "builtin",
+        "runtimeActivation": "config",
+        "name": "GitHub Copilot",
+        "description": "Use GitHub Copilot through OpenCode's native Copilot login flow.",
+        "credentials": [],
+        "models": []
+      }
+    }
+  }
+}
+```
+
+`runtimeActivation: "config"` does not add a credential path. It only causes
+Open Cowork to pass `{ provider: { "github-copilot": { "name": "GitHub
+Copilot" } } }` into the managed OpenCode runtime so OpenCode can expose its
+own provider catalog and OAuth/device-code prompts. Leave the field unset for
+providers such as OpenAI where OpenCode already exposes auth methods without a
+name-only config entry; unnecessary activation can change how OpenCode chooses
+between browser login and API-key auth.
+
+Cloud deployments must treat Copilot separately from normal BYOK API-key
+providers. The upstream cloud BYOK path only admits providers with declared
+secret credentials, so the default managed BYOK profile does not broker user
+Copilot credentials. A deployer-managed Copilot account or other hosted model
+requires an explicit cloud profile and policy decision outside this local
+desktop provider connection.
+
+Config layers merge by provider id. If a downstream build inherits an upstream
+provider descriptor but does not want runtime activation, set
+`runtimeActivation: "implicit"` explicitly in that downstream descriptor.
+
 ### Model Price And Context Overrides
 
 Open Cowork reads model pricing and context windows from OpenCode's native

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,9 +79,9 @@ instead of Cowork's generated in-app config.
 
 ### Default providers
 
-The upstream build ships with **OpenRouter** as the default provider, plus a
-direct **OpenAI Codex** entry for users who prefer provider-native credentials
-or ChatGPT Plus/Pro login.
+The upstream build ships with **OpenRouter** as the default provider, plus
+direct **OpenAI Codex** and **GitHub Copilot** entries for users who prefer
+OpenCode-native provider login.
 
 OpenRouter routes requests to many model backends (DeepSeek, Anthropic,
 OpenAI, others) through a single credential. The upstream default model is the
@@ -106,10 +106,18 @@ choose OpenAI before the runtime has started, type the model id you want to
 start with; once the runtime is connected, Settings -> Models shows the live
 provider catalog from OpenCode.
 
-The same mechanism works for downstream builds that enable another
-OpenCode-native provider, such as GitHub Copilot: declare the provider in
-config, keep `models: []` when you want OpenCode's catalog, and use the
-OpenCode login card if that provider exposes OAuth/auth methods.
+GitHub Copilot uses OpenCode's native Copilot auth flow. Open Cowork does not
+ask for, store, or broker a Copilot token. Select GitHub Copilot in Settings
+-> Models and use the OpenCode login card; Open Cowork saves the provider
+choice and restarts the managed runtime as needed so OpenCode can expose its
+Copilot catalog and login prompts. If you use GitHub Enterprise, OpenCode may
+ask for the enterprise URL as part of that provider-owned flow.
+
+The same mechanism works for downstream builds that enable another dormant
+OpenCode-native provider: declare the provider in config, keep `models: []`
+when you want OpenCode's catalog, set `runtimeActivation: "config"` only when
+the pinned OpenCode runtime requires a minimal provider config entry, and use
+the OpenCode login card if that provider exposes OAuth/auth methods.
 
 API keys typed into Open Cowork are stored in the app's local settings
 (encrypted via Electron's `safeStorage` when the OS supports it) and are never
@@ -117,8 +125,8 @@ written to the config file or to `process.env`.
 
 ### Using a different provider
 
-If you want a different provider (Anthropic direct, GitHub Copilot, a local
-gateway, an internal proxy), you have two paths:
+If you want a different provider (Anthropic direct, a local gateway, an
+internal proxy), you have two paths:
 
 - **Add a custom provider** by editing `open-cowork.config.json` — see
   [Configuration](configuration.md#providers).

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -661,6 +661,14 @@ them through `/api/byok`; records remain `pending_validation` until a provider
 validator passes, or an org admin uses the audited override endpoint with a
 redacted reason.
 
+Credentialless OpenCode-native desktop providers, including GitHub Copilot, are
+not normal Cloud BYOK providers. The upstream managed BYOK path admits only
+provider descriptors with declared secret credential fields, so Copilot is
+blocked by default for cloud workers and gateway sessions unless a deployer adds
+an explicit cloud-safe profile and policy for it. Do not route Copilot OAuth or
+device-code tokens through gateway providers, renderer state, cache, logs, or
+BYOK payloads.
+
 Gateway variables:
 
 | Variable | Meaning |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -34,7 +34,7 @@ runtime work:
 - Provider model-catalog refreshes for providers that expose a dynamic
   catalog, such as OpenRouter.
 - OpenCode provider-auth browser flows when the user explicitly signs in
-  to a provider such as OpenAI from setup or Settings.
+  to a provider such as OpenAI or GitHub Copilot from setup or Settings.
 - GitHub links opened by the user in their browser.
 
 ## Local, cloud, and gateway data boundaries

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -252,6 +252,11 @@ machine-local OpenCode install. Advanced users can enable native OpenCode
 auth sharing from Settings → Permissions; that opt-in links OpenCode's
 native `auth.json` into the managed runtime and requires a runtime restart
 before newly spawned OpenCode processes use the changed auth boundary.
+Credentialless OpenCode-native providers such as GitHub Copilot still follow
+this boundary: Open Cowork may activate the provider in runtime config, but
+OpenCode owns the login/device-code flow and token storage. Copilot tokens are
+not entered into Open Cowork settings, copied into cloud sync payloads, or
+forwarded to the gateway.
 
 ## Chart frame isolation
 

--- a/open-cowork.config.json
+++ b/open-cowork.config.json
@@ -13,7 +13,7 @@
     "mode": "none"
   },
   "providers": {
-    "available": ["openrouter", "openai"],
+    "available": ["openrouter", "openai", "github-copilot"],
     "descriptors": {
       "openrouter": {
         "runtime": "builtin",
@@ -62,6 +62,14 @@
             "env": "OPENAI_API_KEY"
           }
         ],
+        "models": []
+      },
+      "github-copilot": {
+        "runtime": "builtin",
+        "runtimeActivation": "config",
+        "name": "GitHub Copilot",
+        "description": "Use GitHub Copilot through OpenCode's native Copilot login flow. No Copilot token is entered in Open Cowork.",
+        "credentials": [],
         "models": []
       }
     },

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -1057,6 +1057,10 @@
           "type": "string",
           "enum": ["builtin", "custom"]
         },
+        "runtimeActivation": {
+          "type": "string",
+          "enum": ["implicit", "config"]
+        },
         "name": { "type": "string" },
         "description": { "type": "string" },
         "defaultModel": { "type": "string" },

--- a/tests/cloud-app.test.ts
+++ b/tests/cloud-app.test.ts
@@ -18,12 +18,14 @@ import {
   resolveCloudInternalToken,
   resolveCloudOidcClientSecret,
   resolveCloudPublicBranding,
+  listConfiguredByokProviderIds,
   signHeaderCloudAuthRequest,
   shouldRunCloudScheduler,
   shouldRunCloudWeb,
   shouldRunCloudWorker,
   startCloudApp,
 } from '../apps/desktop/src/main/cloud/app.ts'
+import { getAppConfig } from '../apps/desktop/src/main/config-loader.ts'
 import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
 import { createInMemoryObjectStore } from '../apps/desktop/src/main/cloud/object-store.ts'
 import { createCloudPathProvider } from '../apps/desktop/src/main/cloud/path-provider.ts'
@@ -112,6 +114,22 @@ class FakeRuntime implements CloudRuntimeAdapter {
     this.closed = true
   }
 }
+
+test('cloud BYOK defaults include only provider descriptors with secret credentials', () => {
+  const appConfig = getAppConfig()
+  const providerIds = new Set(listConfiguredByokProviderIds(appConfig) || [])
+
+  assert.equal(providerIds.has('openrouter'), true)
+  assert.equal(providerIds.has('openai'), true)
+  assert.equal(providerIds.has('github-copilot'), false)
+  assert.deepEqual(listConfiguredByokProviderIds({
+    ...appConfig,
+    providers: {
+      ...appConfig.providers,
+      available: ['github-copilot'],
+    },
+  }), [])
+})
 
 async function readJson(response: Response) {
   return JSON.parse(await response.text()) as Record<string, unknown>

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -937,6 +937,27 @@ test('cloud HTTP BYOK APIs enforce provider availability and org entitlement pol
   }
 })
 
+test('cloud HTTP BYOK APIs treat an empty provider allowlist as deny-all', async () => {
+  const fixture = createFixture({
+    byokPolicy: {
+      allowedProviderIds: [],
+    },
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const response = await fetch(`${baseUrl}/api/byok/anthropic`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ apiKey: ['credential', 'empty', 'allowlist', '1234567890'].join('-') }),
+    })
+
+    assert.equal(response.status, 403)
+    assert.match(JSON.stringify(await readJson(response)), /not enabled/)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP BYOK override activates an unvalidated provider with audited reason', async () => {
   const rawKey = 'credential-http-override-1234567890'
   const fixture = createFixture({

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -35,11 +35,32 @@ test('open core ships with built-in tools, skills, mcps, and agents configured b
   assert.equal(getConfiguredToolAskPatterns(tools.find((tool) => tool.id === 'clock')!).length, 0)
   assert.equal(tools.find((tool) => tool.id === 'clock')?.defaultAccess, true)
   const providers = getProviderDescriptors()
-  assert.equal(providers.map((provider) => provider.id).join(','), 'openrouter,openai')
+  assert.equal(providers.map((provider) => provider.id).join(','), 'openrouter,openai,github-copilot')
   assert.equal(providers.find((provider) => provider.id === 'openrouter')?.defaultModel, 'deepseek/deepseek-v4-flash:free')
+  const copilot = providers.find((provider) => provider.id === 'github-copilot')
+  assert.equal(copilot?.credentials.length, 0)
+  assert.equal(copilot?.models.length, 0)
   assert.equal(getAppConfig().permissions.bash, 'allow')
   assert.equal(getAppConfig().permissions.fileWrite, 'allow')
   assert.equal(getAppConfig().permissions.webSearch, true)
+})
+
+test('GitHub Copilot provider descriptor matches pinned OpenCode runtime discovery fixture', () => {
+  const fixture = JSON.parse(readFileSync('tests/fixtures/opencode-provider-auth.github-copilot.json', 'utf-8'))
+  const descriptor = getAppConfig().providers.descriptors?.['github-copilot']
+
+  assert.equal(fixture.providerId, 'github-copilot')
+  assert.equal(fixture.activation.required, true)
+  assert.equal(descriptor?.runtime, 'builtin')
+  assert.equal(descriptor?.runtimeActivation, 'config')
+  assert.deepEqual(descriptor?.credentials, [])
+  assert.deepEqual(descriptor?.models, [])
+  assert.equal(fixture.authMethods[0]?.type, 'oauth')
+  assert.equal(fixture.models.hardcodedInOpenCowork, false)
+  assert.equal(fixture.models.defaultModel, 'claude-sonnet-4.6')
+  assert.equal(fixture.models.discoveredCount > 0, true)
+  assert.equal(fixture.secretBoundary.openCoworkCredentials.length, 0)
+  assert.equal(fixture.secretBoundary.cloudByokDefault, 'blocked')
 })
 
 test('invalid config fails fast with a readable validation error', () => {

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -549,3 +549,12 @@ test('provider dynamic catalogs require https URLs and valid SHA-256 pins', () =
   }
   assert.doesNotThrow(() => validateResolvedConfig(config, 'provider catalog config'))
 })
+
+test('provider descriptors validate runtime activation modes', () => {
+  const config = cloneConfig()
+  config.providers.descriptors['github-copilot'].runtimeActivation = 'config'
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'provider runtime activation config'))
+
+  config.providers.descriptors['github-copilot'].runtimeActivation = 'always'
+  assert.throws(() => validateResolvedConfig(config, 'provider runtime activation config'), /providers/)
+})

--- a/tests/fixtures/opencode-provider-auth.github-copilot.json
+++ b/tests/fixtures/opencode-provider-auth.github-copilot.json
@@ -1,0 +1,74 @@
+{
+  "source": "Pinned OpenCode 1.15.12 runtime discovery",
+  "discoveryCommand": "OPENCODE_CONFIG_CONTENT='{\"provider\":{\"github-copilot\":{\"name\":\"GitHub Copilot\"}},\"model\":\"github-copilot\"}' opencode serve --hostname=127.0.0.1 --port=0; curl /provider/auth; curl /provider",
+  "providerId": "github-copilot",
+  "activation": {
+    "required": true,
+    "runtimeConfig": {
+      "provider": {
+        "github-copilot": {
+          "name": "GitHub Copilot"
+        }
+      },
+      "model": "github-copilot"
+    }
+  },
+  "authMethods": [
+    {
+      "type": "oauth",
+      "label": "Login with GitHub Copilot",
+      "prompts": [
+        {
+          "type": "select",
+          "key": "deploymentType",
+          "message": "Select GitHub deployment type",
+          "options": [
+            {
+              "label": "GitHub.com",
+              "value": "github.com",
+              "hint": "Public"
+            },
+            {
+              "label": "GitHub Enterprise",
+              "value": "enterprise",
+              "hint": "Data residency or self-hosted"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "key": "enterpriseUrl",
+          "message": "Enter your GitHub Enterprise URL or domain",
+          "placeholder": "company.ghe.com or https://company.ghe.com",
+          "when": {
+            "key": "deploymentType",
+            "op": "eq",
+            "value": "enterprise"
+          }
+        }
+      ]
+    }
+  ],
+  "models": {
+    "source": "runtime-owned",
+    "hardcodedInOpenCowork": false,
+    "defaultModel": "claude-sonnet-4.6",
+    "discoveredCount": 21,
+    "sampleIds": [
+      "gpt-5-mini",
+      "gpt-4o",
+      "gpt-5.2",
+      "claude-sonnet-4.6",
+      "gpt-5.4",
+      "gemini-3-flash-preview",
+      "gpt-5.5",
+      "claude-opus-4.5"
+    ]
+  },
+  "secretBoundary": {
+    "opencodeOwnsAuth": true,
+    "openCoworkCredentials": [],
+    "rendererReceivesTokens": false,
+    "cloudByokDefault": "blocked"
+  }
+}

--- a/tests/runtime-config-builder.test.ts
+++ b/tests/runtime-config-builder.test.ts
@@ -936,6 +936,7 @@ test('buildRuntimeConfig supports downstream OpenCode-native providers with runt
       descriptors: {
         'github-copilot': {
           runtime: 'builtin',
+          runtimeActivation: 'implicit',
           name: 'GitHub Copilot',
           description: 'Use GitHub Copilot through OpenCode.',
           credentials: [],
@@ -961,6 +962,60 @@ test('buildRuntimeConfig supports downstream OpenCode-native providers with runt
       runtimeConfig.provider?.['github-copilot'],
       undefined,
       'downstream OpenCode-native providers should keep OpenCode-owned auth/model metadata intact',
+    )
+  } finally {
+    saveSettings(originalSettings)
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('buildRuntimeConfig can activate dormant OpenCode-native providers without credentials', () => {
+  const tempRoot = testTempDir('opencowork-runtime-activated-provider-')
+  const configDir = join(tempRoot, 'downstream')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const originalSettings = loadSettings()
+
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.json'), JSON.stringify({
+    providers: {
+      available: ['github-copilot'],
+      defaultProvider: 'github-copilot',
+      defaultModel: null,
+      descriptors: {
+        'github-copilot': {
+          runtime: 'builtin',
+          runtimeActivation: 'config',
+          name: 'GitHub Copilot',
+          description: 'Use GitHub Copilot through OpenCode.',
+          credentials: [],
+          models: [],
+        },
+      },
+    },
+  }))
+
+  try {
+    process.env.OPEN_COWORK_CONFIG_DIR = configDir
+    clearConfigCaches()
+    saveSettings({
+      selectedProviderId: 'github-copilot',
+      selectedModelId: '',
+      providerCredentials: {},
+    })
+
+    const runtimeConfig = buildRuntimeConfig() as Record<string, any>
+    assert.equal(runtimeConfig.model, 'github-copilot')
+    assert.equal(runtimeConfig.small_model, 'github-copilot')
+    assert.deepEqual(runtimeConfig.provider?.['github-copilot'], {
+      name: 'GitHub Copilot',
+    })
+    assert.equal(
+      JSON.stringify(runtimeConfig).includes('apiKey'),
+      false,
+      'GitHub Copilot activation must not invent an API-key credential path',
     )
   } finally {
     saveSettings(originalSettings)

--- a/tests/runtime-home-bridge.test.ts
+++ b/tests/runtime-home-bridge.test.ts
@@ -23,6 +23,8 @@ test('runtime home tooling bridge mirrors curated tool config but not agent comp
   writeFileSync(join(realHome, '.agents', 'skills', 'rogue-skill', 'SKILL.md'), '# Rogue\n')
   mkdirSync(join(realHome, '.config', 'opencode', 'skills', 'rogue-skill'), { recursive: true })
   writeFileSync(join(realHome, '.config', 'opencode', 'skills', 'rogue-skill', 'SKILL.md'), '# Native Rogue\n')
+  mkdirSync(join(realHome, '.config', 'gh-copilot'), { recursive: true })
+  writeFileSync(join(realHome, '.config', 'gh-copilot', 'hosts.json'), '{"token":"native-copilot-token"}\n')
   mkdirSync(join(realHome, '.opencode', 'skills', 'legacy-rogue'), { recursive: true })
   writeFileSync(join(realHome, '.opencode', 'skills', 'legacy-rogue', 'SKILL.md'), '# Legacy Rogue\n')
 
@@ -33,9 +35,31 @@ test('runtime home tooling bridge mirrors curated tool config but not agent comp
     assert.equal(readLinkedTarget(join(runtimeHome, '.ssh')), join(realHome, '.ssh'))
     assert.equal(existsSync(join(runtimeHome, '.agents')), false)
     assert.equal(existsSync(join(runtimeHome, '.config', 'opencode')), false)
+    assert.equal(existsSync(join(runtimeHome, '.config', 'gh-copilot')), false)
     assert.equal(existsSync(join(runtimeHome, '.opencode')), false)
   } catch (error) {
     // fall through to explicit assertions below
+    assert.fail(error instanceof Error ? error.message : String(error))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('runtime home tooling bridge removes stale Copilot config links from older builds', () => {
+  const root = mkdtempSync(join(tmpdir(), 'opencowork-runtime-home-copilot-cleanup-'))
+  const realHome = join(root, 'real-home')
+  const runtimeHome = join(root, 'runtime-home')
+  mkdirSync(join(realHome, '.config', 'gh-copilot'), { recursive: true })
+  mkdirSync(join(runtimeHome, '.config'), { recursive: true })
+
+  const source = join(realHome, '.config', 'gh-copilot')
+  const target = join(runtimeHome, '.config', 'gh-copilot')
+  symlinkSync(source, target)
+
+  try {
+    syncRuntimeHomeToolingBridge({ runtimeHome, realHome })
+    assert.equal(existsSync(target), false)
+  } catch (error) {
     assert.fail(error instanceof Error ? error.message : String(error))
   } finally {
     rmSync(root, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Closes #470.

Adds GitHub Copilot as an OpenCode-native provider connection without making Open Cowork a Copilot token broker or runtime implementation.

## What Changed

- Adds `github-copilot` to the upstream provider catalog with `runtimeActivation: "config"` so the pinned OpenCode runtime can expose its native Copilot provider/auth flow.
- Extends provider config schema/types for explicit runtime activation of dormant OpenCode-native providers.
- Updates first-run setup and Settings -> Models so credentialless providers can persist selection, restart the managed runtime, run OpenCode-native auth, and adopt the live runtime default model.
- Keeps cloud/gateway safe by excluding credentialless providers from default BYOK allowlists and treating empty provider allowlists as deny-all.
- Removes `.config/gh-copilot` from the default runtime-home tooling bridge and cleans up stale symlinks from older builds.
- Adds a pinned-runtime discovery fixture for OpenCode 1.15.12 provider/auth shape.
- Updates Desktop, Cloud, privacy, security, and downstream config docs.

## Review Notes

- Open Cowork does not ask for, store, or forward Copilot tokens.
- Gateway remains a Cloud client only; no provider auth or OpenCode SDK ownership is added.
- Cloud Copilot remains blocked by default for managed BYOK unless a deployer adds an explicit cloud-safe profile/auth model.
- OpenCode runtime discovery was refreshed locally with `pnpm exec opencode --version` and an `opencode serve` provider/auth probe; current runtime reported `1.15.12`, provider id `github-copilot`, OAuth prompts, default model `claude-sonnet-4.6`, and runtime-owned models.

## Validation

- `node --no-warnings --experimental-strip-types --test tests/config-elements.test.ts tests/runtime-config-builder.test.ts tests/config-schema-validation.test.ts tests/runtime-home-bridge.test.ts tests/cloud-app.test.ts tests/cloud-http-server.test.ts tests/byok-runtime-injection.test.ts`
- `pnpm -C apps/desktop exec vitest run --config vitest.renderer.config.ts src/renderer/components/SetupScreen.test.tsx src/renderer/components/sidebar/SettingsPanel.test.tsx src/renderer/components/provider/ProviderAuthControls.test.tsx`
- `pnpm lint`
- `pnpm typecheck`
- `python3 -m mkdocs build --strict`
- `pnpm test`
- `node --no-warnings --experimental-strip-types --test tests/config-elements.test.ts`
- `git diff --check`
