### PR TITLE
Add managed worker identity lifecycle control plane

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -700,6 +700,30 @@ export function createApiTokenCloudAuthResolver(store: ControlPlaneStore): Cloud
   }
 }
 
+export function createManagedWorkerCloudAuthResolver(store: ControlPlaneStore): CloudAuthResolver {
+  return async (req) => {
+    const token = readBearerToken(req)
+    if (!token) throw new CloudHttpError(401, 'Managed worker authorization is required.')
+    if (!token.startsWith('ocw_')) throw new CloudHttpError(401, 'Managed worker authorization is required.')
+    const resolved = await store.findManagedWorkerCredentialByPlaintext(token)
+    if (!resolved) throw new CloudHttpError(401, 'Managed worker credential is invalid or expired.')
+    return {
+      tenantId: resolved.worker.tenantId || resolved.pool.tenantId || resolved.pool.orgId,
+      orgId: resolved.pool.orgId,
+      tenantName: resolved.pool.name,
+      userId: resolved.worker.workerId,
+      accountId: resolved.worker.workerId,
+      email: `${resolved.worker.workerId}@workers.open-cowork.local`,
+      role: 'member',
+      authSource: 'worker',
+      workerId: resolved.worker.workerId,
+      workerPoolId: resolved.pool.poolId,
+      workerCredentialId: resolved.credential.credentialId,
+      workerScopes: resolved.credential.scopes,
+    }
+  }
+}
+
 export function createCompositeCloudAuthResolver(...resolvers: CloudAuthResolver[]): CloudAuthResolver {
   return async (req) => {
     let lastError: unknown = null
@@ -1152,6 +1176,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
         browserAuth,
         desktopAuth: createCloudDesktopAuthConfig(authConfig),
         auth: options.auth || createCompositeCloudAuthResolver(
+          createManagedWorkerCloudAuthResolver(store),
           createApiTokenCloudAuthResolver(store),
           createCloudAuthResolverForConfig(resolvedAuthConfig),
         ),

--- a/apps/desktop/src/main/cloud/byok-secret-store.ts
+++ b/apps/desktop/src/main/cloud/byok-secret-store.ts
@@ -143,6 +143,7 @@ function redactSecretLikeText(value: string, exactSecrets: readonly string[] = [
   return redacted
     .replace(/\b(sk-[A-Za-z0-9._-]{6,})\b/g, '[redacted]')
     .replace(/\b(occ_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b(ocw_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
     .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
 }
 

--- a/apps/desktop/src/main/cloud/cloud-service-error.ts
+++ b/apps/desktop/src/main/cloud/cloud-service-error.ts
@@ -1,0 +1,17 @@
+export class CloudServiceError extends Error {
+  readonly status: number
+  readonly publicMessage: string
+  readonly policyCode: string | null
+  readonly retryAfterMs: number | null
+
+  constructor(status: number, message: string, details: {
+    policyCode?: string | null
+    retryAfterMs?: number | null
+  } = {}) {
+    super(message)
+    this.status = status
+    this.publicMessage = message
+    this.policyCode = details.policyCode || null
+    this.retryAfterMs = details.retryAfterMs || null
+  }
+}

--- a/apps/desktop/src/main/cloud/control-plane-domains/index.ts
+++ b/apps/desktop/src/main/cloud/control-plane-domains/index.ts
@@ -1,4 +1,5 @@
 export type { IdentityControlPlaneStore, ApiTokenControlPlaneStore } from './identity.ts'
+export type { ManagedWorkersControlPlaneStore } from './workers.ts'
 export type { BillingControlPlaneStore, UsageControlPlaneStore, QuotaControlPlaneStore } from './billing.ts'
 export type { ByokControlPlaneStore } from './byok.ts'
 export type { ChannelControlPlaneStore } from './channels.ts'

--- a/apps/desktop/src/main/cloud/control-plane-domains/workers.ts
+++ b/apps/desktop/src/main/cloud/control-plane-domains/workers.ts
@@ -1,0 +1,19 @@
+import type { ControlPlaneStore } from '../control-plane-store.ts'
+
+export type ManagedWorkersControlPlaneStore = Pick<ControlPlaneStore,
+  | 'createManagedWorkerPool'
+  | 'updateManagedWorkerPool'
+  | 'getManagedWorkerPool'
+  | 'listManagedWorkerPools'
+  | 'registerManagedWorker'
+  | 'updateManagedWorkerStatus'
+  | 'getManagedWorker'
+  | 'listManagedWorkers'
+  | 'issueManagedWorkerCredential'
+  | 'listManagedWorkerCredentials'
+  | 'findManagedWorkerCredentialByPlaintext'
+  | 'revokeManagedWorkerCredential'
+  | 'recordManagedWorkerHeartbeat'
+  | 'listManagedWorkerHeartbeats'
+  | 'recordAuditEvent'
+>

--- a/apps/desktop/src/main/cloud/control-plane-store-domains.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store-domains.ts
@@ -1,6 +1,7 @@
 import type { ControlPlaneStore } from './control-plane-store.ts'
 
 export type { IdentityControlPlaneStore, ApiTokenControlPlaneStore } from './control-plane-domains/identity.ts'
+export type { ManagedWorkersControlPlaneStore } from './control-plane-domains/workers.ts'
 export type { BillingControlPlaneStore, UsageControlPlaneStore, QuotaControlPlaneStore } from './control-plane-domains/billing.ts'
 export type { ByokControlPlaneStore } from './control-plane-domains/byok.ts'
 export type { ChannelControlPlaneStore } from './control-plane-domains/channels.ts'

--- a/apps/desktop/src/main/cloud/http-routes/access-policy.ts
+++ b/apps/desktop/src/main/cloud/http-routes/access-policy.ts
@@ -17,10 +17,15 @@ export function principalHasGatewayAccess(principal: CloudPrincipal) {
 }
 
 export function principalHasDesktopApiAccess(principal: CloudPrincipal) {
+  if (principal.authSource === 'worker') return false
   if (principal.authSource === 'api_token') {
     return principal.tokenScopes?.includes('desktop') || principal.tokenScopes?.includes('admin') || false
   }
   return true
+}
+
+export function routeAllowsWorkerCredential(input: GatewayRouteAccessInput) {
+  return input.resource === 'workers' && Boolean(input.sessionId) && input.action === 'heartbeat'
 }
 
 export function routeAllowsGatewayOnlyToken(input: GatewayRouteAccessInput) {

--- a/apps/desktop/src/main/cloud/http-routes/admin.ts
+++ b/apps/desktop/src/main/cloud/http-routes/admin.ts
@@ -1,4 +1,4 @@
-import type { ControlPlaneMembershipStatus, ControlPlaneRole } from '../control-plane-store.ts'
+import type { ControlPlaneMembershipStatus, ControlPlaneRole, ManagedWorkerStatus } from '../control-plane-store.ts'
 import type { CloudApiRouteInput } from './types.ts'
 
 function memberRole(value: unknown): ControlPlaneRole | null {
@@ -9,8 +9,36 @@ function memberStatus(value: unknown): ControlPlaneMembershipStatus | null {
   return value === 'active' || value === 'invited' || value === 'disabled' ? value : null
 }
 
+function poolMode(value: unknown) {
+  return value === 'saas_operated' || value === 'self_hosted'
+    ? value
+    : null
+}
+
+function poolStatus(value: unknown) {
+  return value === 'active' || value === 'paused' || value === 'retired' ? value : null
+}
+
+function workerStatus(value: unknown) {
+  return value === 'pending'
+    || value === 'active'
+    || value === 'draining'
+    || value === 'paused'
+    || value === 'retired'
+    || value === 'revoked'
+    || value === 'unhealthy'
+    ? value
+    : null
+}
+
+function nullableNumber(value: unknown) {
+  if (value === undefined || value === null || value === '') return null
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
+}
+
 export async function handleAdminApiRoute(input: CloudApiRouteInput): Promise<boolean> {
-  const { req, res, options, context, itemId, action, tools } = input
+  const { req, res, options, context, itemId, action, artifactId, tools } = input
 
   if (!itemId && req.method === 'GET') {
     tools.writeJson(res, 200, {
@@ -69,6 +97,149 @@ export async function handleAdminApiRoute(input: CloudApiRouteInput): Promise<bo
       }),
     }, options.corsOrigin)
     return true
+  }
+
+  if (itemId === 'worker-pools') {
+    if (!action && req.method === 'GET') {
+      tools.writeJson(res, 200, {
+        pools: await options.service.listManagedWorkerPools(context.principal, {
+          status: poolStatus(context.url.searchParams.get('status')),
+          limit: tools.parseLimit(context.url),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (!action && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const name = tools.readString(body.name)
+      const mode = poolMode(body.mode)
+      if (!name || !mode) {
+        tools.writeError(res, 400, 'Managed worker pool requires name and supported mode.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 201, {
+        pool: await options.service.createManagedWorkerPool(context.principal, {
+          poolId: tools.readString(body.poolId) || undefined,
+          name,
+          mode,
+          status: poolStatus(body.status) || undefined,
+          tenantId: tools.readString(body.tenantId),
+          region: tools.readString(body.region),
+          capabilities: tools.readRecord(body.capabilities) || undefined,
+          maxWorkers: nullableNumber(body.maxWorkers),
+          maxConcurrentWork: nullableNumber(body.maxConcurrentWork),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (action && artifactId === 'update' && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const pool = await options.service.updateManagedWorkerPool(context.principal, action, {
+        name: tools.readString(body.name) || undefined,
+        status: poolStatus(body.status) || undefined,
+        region: Object.prototype.hasOwnProperty.call(body, 'region') ? tools.readString(body.region) : undefined,
+        capabilities: tools.readRecord(body.capabilities) || undefined,
+        maxWorkers: Object.prototype.hasOwnProperty.call(body, 'maxWorkers') ? nullableNumber(body.maxWorkers) : undefined,
+        maxConcurrentWork: Object.prototype.hasOwnProperty.call(body, 'maxConcurrentWork') ? nullableNumber(body.maxConcurrentWork) : undefined,
+      })
+      tools.writeJson(res, pool ? 200 : 404, { pool }, options.corsOrigin)
+      return true
+    }
+  }
+
+  if (itemId === 'workers') {
+    if (!action && req.method === 'GET') {
+      tools.writeJson(res, 200, {
+        workers: await options.service.listManagedWorkers(context.principal, {
+          poolId: context.url.searchParams.get('poolId'),
+          status: workerStatus(context.url.searchParams.get('status')),
+          limit: tools.parseLimit(context.url),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (!action && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const poolId = tools.readString(body.poolId)
+      const displayName = tools.readString(body.displayName)
+      if (!poolId || !displayName) {
+        tools.writeError(res, 400, 'Managed worker registration requires poolId and displayName.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 201, {
+        worker: await options.service.registerManagedWorker(context.principal, {
+          workerId: tools.readString(body.workerId) || undefined,
+          poolId,
+          tenantId: tools.readString(body.tenantId),
+          displayName,
+          status: workerStatus(body.status) || undefined,
+          version: tools.readString(body.version),
+          capabilities: tools.readRecord(body.capabilities) || undefined,
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (action && !artifactId && req.method === 'GET') {
+      const worker = await options.service.getManagedWorker(context.principal, action)
+      tools.writeJson(res, worker ? 200 : 404, { worker }, options.corsOrigin)
+      return true
+    }
+    if (action && ['activate', 'pause', 'resume', 'drain', 'retire', 'revoke', 'unhealthy'].includes(String(artifactId)) && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const lifecycleStatus = artifactId === 'activate'
+        ? 'active'
+        : artifactId === 'resume'
+          ? 'active'
+          : artifactId === 'drain'
+            ? 'draining'
+            : artifactId === 'revoke'
+              ? 'revoked'
+              : artifactId
+      const worker = await options.service.updateManagedWorkerLifecycle(context.principal, action, lifecycleStatus as ManagedWorkerStatus, {
+        reason: tools.readString(body.reason),
+      })
+      tools.writeJson(res, worker ? 200 : 404, { worker }, options.corsOrigin)
+      return true
+    }
+    if (action && artifactId === 'credentials' && !context.segments[5] && req.method === 'GET') {
+      tools.writeJson(res, 200, {
+        credentials: await options.service.listManagedWorkerCredentials(context.principal, action),
+      }, options.corsOrigin)
+      return true
+    }
+    if (action && artifactId === 'credentials' && !context.segments[5] && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      tools.writeJson(res, 201, {
+        credential: await options.service.issueManagedWorkerCredential(context.principal, action, {
+          scopes: tools.readStringArray(body.scopes),
+          expiresAt: tools.readOptionalDate(body.expiresAt),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (action && artifactId === 'credentials' && context.segments[5] && context.segments[6] === 'rotate' && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      tools.writeJson(res, 201, {
+        credential: await options.service.rotateManagedWorkerCredential(context.principal, action, context.segments[5], {
+          expiresAt: tools.readOptionalDate(body.expiresAt),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
+    if (action && artifactId === 'credentials' && context.segments[5] && context.segments[6] === 'revoke' && req.method === 'POST') {
+      const credential = await options.service.revokeManagedWorkerCredential(context.principal, action, context.segments[5])
+      tools.writeJson(res, credential ? 200 : 404, { credential }, options.corsOrigin)
+      return true
+    }
+    if (action && artifactId === 'heartbeats' && req.method === 'GET') {
+      tools.writeJson(res, 200, {
+        heartbeats: await options.service.listManagedWorkerHeartbeats(context.principal, {
+          workerId: action,
+          limit: tools.parseLimit(context.url),
+        }),
+      }, options.corsOrigin)
+      return true
+    }
   }
 
   tools.writeError(res, 404, 'Not found.', options.corsOrigin)

--- a/apps/desktop/src/main/cloud/http-routes/workspace.ts
+++ b/apps/desktop/src/main/cloud/http-routes/workspace.ts
@@ -1,5 +1,11 @@
 import type { CloudApiRouteInput } from './types.ts'
 
+function readNonNegativeInteger(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined
+}
+
 export async function handleWorkspaceApiRoute(input: CloudApiRouteInput): Promise<boolean> {
   const { req, res, options, context, resource, itemId, action, tools } = input
 
@@ -39,6 +45,22 @@ export async function handleWorkspaceApiRoute(input: CloudApiRouteInput): Promis
   if (resource === 'workers' && itemId === 'heartbeats' && !action && req.method === 'GET') {
     tools.writeJson(res, 200, {
       heartbeats: await options.service.listWorkerHeartbeats(context.principal),
+    }, options.corsOrigin)
+    return true
+  }
+
+  if (resource === 'workers' && itemId && action === 'heartbeat' && req.method === 'POST') {
+    const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+    tools.writeJson(res, 200, {
+      heartbeat: await options.service.recordManagedWorkerHeartbeat(context.principal, itemId, {
+        version: tools.readString(body.version),
+        capabilities: tools.readRecord(body.capabilities) || undefined,
+        currentLoad: readNonNegativeInteger(body.currentLoad),
+        activeWorkIds: tools.readStringArray(body.activeWorkIds) || undefined,
+        lastErrorCode: tools.readString(body.lastErrorCode),
+        lastErrorSummary: tools.readString(body.lastErrorSummary),
+        heartbeatSequence: readNonNegativeInteger(body.heartbeatSequence) ?? null,
+      }),
     }, options.corsOrigin)
     return true
   }

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -17,6 +17,7 @@ import {
   principalHasDesktopApiAccess,
   principalHasGatewayAccess,
   routeAllowsGatewayOnlyToken,
+  routeAllowsWorkerCredential,
 } from './http-routes/access-policy.ts'
 import { handleAdminApiRoute } from './http-routes/admin.ts'
 import { handleApiTokensApiRoute } from './http-routes/api-tokens.ts'
@@ -968,6 +969,12 @@ async function handleApiRequest(
   }
 
   if (!principalHasDesktopApiAccess(context.principal) && !routeAllowsGatewayOnlyToken({
+    resource,
+    action,
+    method: req.method,
+    sessionId,
+    artifactId,
+  }) && !routeAllowsWorkerCredential({
     resource,
     action,
     method: req.method,

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -8,6 +8,44 @@ import type {
   WorkflowTriggerType,
 } from '@open-cowork/shared'
 import type { CloudBillingEntitlements, CloudSubscriptionStatus } from '../config-types.ts'
+import type {
+  CreateManagedWorkerPoolInput,
+  IssueManagedWorkerCredentialInput,
+  IssuedManagedWorkerCredentialRecord,
+  ManagedWorkerCredentialRecord,
+  ManagedWorkerHeartbeatRecord,
+  ManagedWorkerPoolRecord,
+  ManagedWorkerPoolStatus,
+  ManagedWorkerRecord,
+  ManagedWorkerStatus,
+  RecordManagedWorkerHeartbeatInput,
+  RegisterManagedWorkerInput,
+  ResolvedManagedWorkerCredentialRecord,
+  RevokeManagedWorkerCredentialInput,
+  UpdateManagedWorkerPoolInput,
+  UpdateManagedWorkerStatusInput,
+} from './managed-worker-types.ts'
+import { InMemoryManagedWorkersDomain } from './in-memory-domains/workers.ts'
+export type {
+  CreateManagedWorkerPoolInput,
+  IssueManagedWorkerCredentialInput,
+  IssuedManagedWorkerCredentialRecord,
+  ManagedWorkerCredentialRecord,
+  ManagedWorkerCredentialScope,
+  ManagedWorkerHeartbeatRecord,
+  ManagedWorkerPoolMode,
+  ManagedWorkerPoolRecord,
+  ManagedWorkerPoolStatus,
+  ManagedWorkerRecord,
+  ManagedWorkerStatus,
+  RecordManagedWorkerHeartbeatInput,
+  RegisterManagedWorkerInput,
+  ResolvedManagedWorkerCredentialRecord,
+  RevokeManagedWorkerCredentialInput,
+  UpdateManagedWorkerPoolInput,
+  UpdateManagedWorkerStatusInput,
+} from './managed-worker-types.ts'
+export { generateManagedWorkerCredential, hashManagedWorkerCredential } from './in-memory-domains/workers.ts'
 
 export type ControlPlaneRole = 'owner' | 'admin' | 'member'
 export type ControlPlaneMembershipStatus = 'active' | 'invited' | 'disabled'
@@ -1021,6 +1059,24 @@ export type ControlPlaneStore = {
   listApiTokens(orgId: string): MaybePromise<ApiTokenRecord[]>
   findApiTokenByPlaintext(plaintext: string, now?: Date): MaybePromise<ApiTokenRecord | null>
   revokeApiToken(input: RevokeApiTokenInput): MaybePromise<ApiTokenRecord | null>
+  createManagedWorkerPool(input: CreateManagedWorkerPoolInput): MaybePromise<ManagedWorkerPoolRecord>
+  updateManagedWorkerPool(input: UpdateManagedWorkerPoolInput): MaybePromise<ManagedWorkerPoolRecord | null>
+  getManagedWorkerPool(orgId: string, poolId: string): MaybePromise<ManagedWorkerPoolRecord | null>
+  listManagedWorkerPools(orgId: string, input?: { status?: ManagedWorkerPoolStatus | null, limit?: number | null }): MaybePromise<ManagedWorkerPoolRecord[]>
+  registerManagedWorker(input: RegisterManagedWorkerInput): MaybePromise<ManagedWorkerRecord>
+  updateManagedWorkerStatus(input: UpdateManagedWorkerStatusInput): MaybePromise<ManagedWorkerRecord | null>
+  getManagedWorker(orgId: string, workerId: string): MaybePromise<ManagedWorkerRecord | null>
+  listManagedWorkers(orgId: string, input?: {
+    poolId?: string | null
+    status?: ManagedWorkerStatus | null
+    limit?: number | null
+  }): MaybePromise<ManagedWorkerRecord[]>
+  issueManagedWorkerCredential(input: IssueManagedWorkerCredentialInput): MaybePromise<IssuedManagedWorkerCredentialRecord>
+  listManagedWorkerCredentials(orgId: string, workerId: string): MaybePromise<ManagedWorkerCredentialRecord[]>
+  findManagedWorkerCredentialByPlaintext(plaintext: string, now?: Date): MaybePromise<ResolvedManagedWorkerCredentialRecord | null>
+  revokeManagedWorkerCredential(input: RevokeManagedWorkerCredentialInput): MaybePromise<ManagedWorkerCredentialRecord | null>
+  recordManagedWorkerHeartbeat(input: RecordManagedWorkerHeartbeatInput): MaybePromise<ManagedWorkerHeartbeatRecord>
+  listManagedWorkerHeartbeats(orgId: string, input?: { workerId?: string | null, limit?: number | null }): MaybePromise<ManagedWorkerHeartbeatRecord[]>
   recordAuditEvent(input: RecordAuditEventInput): MaybePromise<AuditEventRecord>
   listAuditEvents(orgId: string, limit?: number): MaybePromise<AuditEventRecord[]>
   consumeUsageQuota(input: ConsumeUsageQuotaInput): MaybePromise<QuotaConsumptionRecord>
@@ -1328,6 +1384,7 @@ function redactOperationalText(value: unknown, maxLength: number, label: string)
     .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
     .replace(/\b(sk-[A-Za-z0-9._-]{6,})\b/g, '[redacted]')
     .replace(/\b(occ_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b(ocw_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
     .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
 }
 
@@ -1490,6 +1547,11 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly threadSmartFilters = new Map<string, ThreadSmartFilterRecord>()
   private readonly migrations = new Map<string, SchemaMigrationRecord>()
   private readonly workspaceEvents = new Map<string, { nextSequence: number, events: WorkspaceEventRecord[] }>()
+  private readonly managedWorkersDomain = new InMemoryManagedWorkersDomain({
+    orgTenantId: (orgId) => this.orgs.get(orgId)?.tenantId || null,
+    hasTenant: (tenantId) => this.tenants.has(tenantId),
+    recordAuditEvent: (input) => this.recordAuditEvent(input),
+  })
 
   createTenant(input: { tenantId: string, name: string, createdAt?: Date }): TenantRecord {
     const existing = this.tenants.get(input.tenantId)
@@ -1764,6 +1826,62 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       createdAt: input.revokedAt,
     })
     return clone(existing)
+  }
+
+  createManagedWorkerPool(input: CreateManagedWorkerPoolInput): ManagedWorkerPoolRecord {
+    return this.managedWorkersDomain.createPool(input)
+  }
+
+  updateManagedWorkerPool(input: UpdateManagedWorkerPoolInput): ManagedWorkerPoolRecord | null {
+    return this.managedWorkersDomain.updatePool(input)
+  }
+
+  getManagedWorkerPool(orgId: string, poolId: string): ManagedWorkerPoolRecord | null {
+    return this.managedWorkersDomain.getPool(orgId, poolId)
+  }
+
+  listManagedWorkerPools(orgId: string, input: { status?: ManagedWorkerPoolStatus | null, limit?: number | null } = {}): ManagedWorkerPoolRecord[] {
+    return this.managedWorkersDomain.listPools(orgId, input)
+  }
+
+  registerManagedWorker(input: RegisterManagedWorkerInput): ManagedWorkerRecord {
+    return this.managedWorkersDomain.registerWorker(input)
+  }
+
+  updateManagedWorkerStatus(input: UpdateManagedWorkerStatusInput): ManagedWorkerRecord | null {
+    return this.managedWorkersDomain.updateWorkerStatus(input)
+  }
+
+  getManagedWorker(orgId: string, workerId: string): ManagedWorkerRecord | null {
+    return this.managedWorkersDomain.getWorker(orgId, workerId)
+  }
+
+  listManagedWorkers(orgId: string, input: { poolId?: string | null, status?: ManagedWorkerStatus | null, limit?: number | null } = {}): ManagedWorkerRecord[] {
+    return this.managedWorkersDomain.listWorkers(orgId, input)
+  }
+
+  issueManagedWorkerCredential(input: IssueManagedWorkerCredentialInput): IssuedManagedWorkerCredentialRecord {
+    return this.managedWorkersDomain.issueCredential(input)
+  }
+
+  listManagedWorkerCredentials(orgId: string, workerId: string): ManagedWorkerCredentialRecord[] {
+    return this.managedWorkersDomain.listCredentials(orgId, workerId)
+  }
+
+  findManagedWorkerCredentialByPlaintext(plaintext: string, now = new Date()): ResolvedManagedWorkerCredentialRecord | null {
+    return this.managedWorkersDomain.findCredentialByPlaintext(plaintext, now)
+  }
+
+  revokeManagedWorkerCredential(input: RevokeManagedWorkerCredentialInput): ManagedWorkerCredentialRecord | null {
+    return this.managedWorkersDomain.revokeCredential(input)
+  }
+
+  recordManagedWorkerHeartbeat(input: RecordManagedWorkerHeartbeatInput): ManagedWorkerHeartbeatRecord {
+    return this.managedWorkersDomain.recordHeartbeat(input)
+  }
+
+  listManagedWorkerHeartbeats(orgId: string, input: { workerId?: string | null, limit?: number | null } = {}): ManagedWorkerHeartbeatRecord[] {
+    return this.managedWorkersDomain.listHeartbeats(orgId, input)
   }
 
   recordAuditEvent(input: RecordAuditEventInput): AuditEventRecord {

--- a/apps/desktop/src/main/cloud/in-memory-domains/workers.ts
+++ b/apps/desktop/src/main/cloud/in-memory-domains/workers.ts
@@ -1,0 +1,540 @@
+import { createHash, randomBytes, scryptSync, timingSafeEqual } from 'node:crypto'
+import type {
+  CreateManagedWorkerPoolInput,
+  IssueManagedWorkerCredentialInput,
+  ManagedWorkerCredentialRecord,
+  ManagedWorkerCredentialScope,
+  ManagedWorkerHeartbeatRecord,
+  ManagedWorkerPoolMode,
+  ManagedWorkerPoolRecord,
+  ManagedWorkerPoolStatus,
+  ManagedWorkerRecord,
+  ManagedWorkerStatus,
+  RecordAuditEventInput,
+  RecordManagedWorkerHeartbeatInput,
+  RegisterManagedWorkerInput,
+  ResolvedManagedWorkerCredentialRecord,
+  RevokeManagedWorkerCredentialInput,
+  UpdateManagedWorkerPoolInput,
+  UpdateManagedWorkerStatusInput,
+} from '../control-plane-store.ts'
+
+const MANAGED_WORKER_TEXT_MAX_LENGTH = 256
+const MANAGED_WORKER_METADATA_MAX_BYTES = 16_384
+const MANAGED_WORKER_DEFAULT_CREDENTIAL_TTL_MS = 90 * 24 * 60 * 60 * 1000
+const MANAGED_WORKER_SUPPORTED_POOL_MODES = new Set<ManagedWorkerPoolMode>(['saas_operated', 'self_hosted'])
+
+type ManagedWorkersDomainHost = {
+  orgTenantId(orgId: string): string | null
+  hasTenant(tenantId: string): boolean
+  recordAuditEvent(input: RecordAuditEventInput): unknown
+}
+
+export class InMemoryManagedWorkersDomain {
+  private readonly pools = new Map<string, ManagedWorkerPoolRecord>()
+  private readonly workers = new Map<string, ManagedWorkerRecord>()
+  private readonly credentials = new Map<string, ManagedWorkerCredentialRecord>()
+  private readonly heartbeats = new Map<string, ManagedWorkerHeartbeatRecord>()
+  private readonly host: ManagedWorkersDomainHost
+
+  constructor(host: ManagedWorkersDomainHost) {
+    this.host = host
+  }
+
+  createPool(input: CreateManagedWorkerPoolInput): ManagedWorkerPoolRecord {
+    const orgTenantId = this.host.orgTenantId(input.orgId)
+    if (!orgTenantId) throw new Error(`Unknown org ${input.orgId}.`)
+    if (input.tenantId && !this.host.hasTenant(input.tenantId)) throw new Error(`Unknown tenant ${input.tenantId}.`)
+    const now = nowIso(input.createdAt)
+    const record: ManagedWorkerPoolRecord = {
+      poolId: input.poolId || stableId('mwp', input.orgId, input.name, now),
+      orgId: input.orgId,
+      tenantId: input.tenantId === undefined ? orgTenantId : input.tenantId,
+      name: normalizeText(input.name, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool name'),
+      mode: normalizePoolMode(input.mode),
+      status: normalizePoolStatus(input.status),
+      region: normalizeNullableText(input.region, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool region'),
+      capabilities: normalizeMetadata(input.capabilities, 'Managed worker pool capabilities'),
+      maxWorkers: normalizeNullablePositiveInteger(input.maxWorkers, 'Managed worker max workers'),
+      maxConcurrentWork: normalizeNullablePositiveInteger(input.maxConcurrentWork, 'Managed worker max concurrent work'),
+      createdAt: now,
+      updatedAt: now,
+    }
+    const existing = this.pools.get(record.poolId)
+    if (existing) return clone(existing)
+    this.pools.set(record.poolId, record)
+    this.host.recordAuditEvent({
+      orgId: record.orgId,
+      accountId: input.actor?.accountId || null,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: 'managed_worker_pool.created',
+      targetType: 'managed_worker_pool',
+      targetId: record.poolId,
+      metadata: { name: record.name, mode: record.mode, status: record.status, region: record.region },
+      createdAt: input.createdAt,
+    })
+    return clone(record)
+  }
+
+  updatePool(input: UpdateManagedWorkerPoolInput): ManagedWorkerPoolRecord | null {
+    const existing = this.pools.get(input.poolId)
+    if (!existing || existing.orgId !== input.orgId) return null
+    const updatedAt = nowIso(input.updatedAt)
+    existing.name = input.name === undefined
+      ? existing.name
+      : normalizeText(input.name, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool name')
+    existing.status = input.status === undefined
+      ? existing.status
+      : normalizePoolStatus(input.status)
+    existing.region = input.region === undefined
+      ? existing.region
+      : normalizeNullableText(input.region, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool region')
+    existing.capabilities = input.capabilities === undefined
+      ? existing.capabilities
+      : normalizeMetadata(input.capabilities, 'Managed worker pool capabilities')
+    existing.maxWorkers = input.maxWorkers === undefined
+      ? existing.maxWorkers
+      : normalizeNullablePositiveInteger(input.maxWorkers, 'Managed worker max workers')
+    existing.maxConcurrentWork = input.maxConcurrentWork === undefined
+      ? existing.maxConcurrentWork
+      : normalizeNullablePositiveInteger(input.maxConcurrentWork, 'Managed worker max concurrent work')
+    existing.updatedAt = updatedAt
+    this.host.recordAuditEvent({
+      orgId: existing.orgId,
+      accountId: input.actor?.accountId || null,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: 'managed_worker_pool.updated',
+      targetType: 'managed_worker_pool',
+      targetId: existing.poolId,
+      metadata: { name: existing.name, status: existing.status },
+      createdAt: input.updatedAt,
+    })
+    return clone(existing)
+  }
+
+  getPool(orgId: string, poolId: string): ManagedWorkerPoolRecord | null {
+    const pool = this.pools.get(poolId)
+    return pool && pool.orgId === orgId ? clone(pool) : null
+  }
+
+  listPools(orgId: string, input: { status?: ManagedWorkerPoolStatus | null, limit?: number | null } = {}): ManagedWorkerPoolRecord[] {
+    return Array.from(this.pools.values())
+      .filter((pool) => pool.orgId === orgId)
+      .filter((pool) => !input.status || pool.status === input.status)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, normalizeListLimit(input.limit, 100, 500))
+      .map((pool) => clone(pool))
+  }
+
+  registerWorker(input: RegisterManagedWorkerInput): ManagedWorkerRecord {
+    const pool = this.pools.get(input.poolId)
+    if (!pool || pool.orgId !== input.orgId) throw new Error(`Unknown managed worker pool ${input.poolId}.`)
+    const now = nowIso(input.createdAt)
+    const record: ManagedWorkerRecord = {
+      workerId: input.workerId || stableId('mworker', input.orgId, input.poolId, input.displayName, now),
+      orgId: input.orgId,
+      tenantId: input.tenantId === undefined ? pool.tenantId : input.tenantId,
+      poolId: input.poolId,
+      displayName: normalizeText(input.displayName, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker display name'),
+      status: normalizeWorkerStatus(input.status),
+      version: normalizeNullableText(input.version, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker version'),
+      capabilities: normalizeMetadata(input.capabilities, 'Managed worker capabilities'),
+      lastHeartbeatAt: null,
+      lastErrorCode: null,
+      lastErrorSummary: null,
+      currentLoad: 0,
+      createdAt: now,
+      updatedAt: now,
+      revokedAt: input.status === 'revoked' ? now : null,
+    }
+    const existing = this.workers.get(record.workerId)
+    if (existing) return clone(existing)
+    this.workers.set(record.workerId, record)
+    this.host.recordAuditEvent({
+      orgId: record.orgId,
+      accountId: input.actor?.accountId || null,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: 'managed_worker.registered',
+      targetType: 'managed_worker',
+      targetId: record.workerId,
+      metadata: { poolId: record.poolId, status: record.status, displayName: record.displayName },
+      createdAt: input.createdAt,
+    })
+    return clone(record)
+  }
+
+  updateWorkerStatus(input: UpdateManagedWorkerStatusInput): ManagedWorkerRecord | null {
+    const worker = this.workers.get(input.workerId)
+    if (!worker || worker.orgId !== input.orgId) return null
+    const status = normalizeWorkerStatus(input.status)
+    assertWorkerStatusTransition(worker.status, status)
+    const updatedAt = nowIso(input.updatedAt)
+    worker.status = status
+    worker.updatedAt = updatedAt
+    if (status === 'revoked') worker.revokedAt = worker.revokedAt || updatedAt
+    this.host.recordAuditEvent({
+      orgId: worker.orgId,
+      accountId: input.actor?.accountId || null,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: `managed_worker.${status}`,
+      targetType: 'managed_worker',
+      targetId: worker.workerId,
+      metadata: { poolId: worker.poolId, status, reason: input.reason || null },
+      createdAt: input.updatedAt,
+    })
+    return clone(worker)
+  }
+
+  getWorker(orgId: string, workerId: string): ManagedWorkerRecord | null {
+    const worker = this.workers.get(workerId)
+    return worker && worker.orgId === orgId ? clone(worker) : null
+  }
+
+  listWorkers(orgId: string, input: { poolId?: string | null, status?: ManagedWorkerStatus | null, limit?: number | null } = {}): ManagedWorkerRecord[] {
+    return Array.from(this.workers.values())
+      .filter((worker) => worker.orgId === orgId)
+      .filter((worker) => !input.poolId || worker.poolId === input.poolId)
+      .filter((worker) => !input.status || worker.status === input.status)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, normalizeListLimit(input.limit, 100, 500))
+      .map((worker) => clone(worker))
+  }
+
+  issueCredential(input: IssueManagedWorkerCredentialInput): { credential: ManagedWorkerCredentialRecord, plaintext: string } {
+    const worker = this.workers.get(input.workerId)
+    if (!worker || worker.orgId !== input.orgId) throw new Error(`Unknown managed worker ${input.workerId}.`)
+    if (worker.status === 'revoked' || worker.status === 'retired') throw new Error('Cannot issue credentials for a terminal managed worker.')
+    const generated = generateManagedWorkerCredential(input)
+    const createdAt = input.createdAt || new Date()
+    const now = createdAt.toISOString()
+    const expiresAt = input.expiresAt || new Date(createdAt.getTime() + MANAGED_WORKER_DEFAULT_CREDENTIAL_TTL_MS)
+    if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= createdAt.getTime()) {
+      throw new Error('Managed worker credential expiration must be in the future.')
+    }
+    const record: ManagedWorkerCredentialRecord = {
+      credentialId: generated.credentialId,
+      orgId: worker.orgId,
+      workerId: worker.workerId,
+      poolId: worker.poolId,
+      tokenHash: hashManagedWorkerCredential(generated.plaintext),
+      scopes: normalizeCredentialScopes(input.scopes),
+      last4: generated.plaintext.slice(-4),
+      expiresAt: expiresAt.toISOString(),
+      revokedAt: null,
+      lastUsedAt: null,
+      rotatedFromCredentialId: input.rotatedFromCredentialId || null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.credentials.set(record.credentialId, record)
+    this.host.recordAuditEvent({
+      orgId: record.orgId,
+      accountId: input.actor?.accountId || null,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: input.rotatedFromCredentialId ? 'managed_worker_credential.rotated' : 'managed_worker_credential.issued',
+      targetType: 'managed_worker_credential',
+      targetId: record.credentialId,
+      metadata: { workerId: record.workerId, scopes: record.scopes, last4: record.last4 },
+      createdAt: input.createdAt,
+    })
+    return { credential: clone(record), plaintext: generated.plaintext }
+  }
+
+  listCredentials(orgId: string, workerId: string): ManagedWorkerCredentialRecord[] {
+    return Array.from(this.credentials.values())
+      .filter((credential) => credential.orgId === orgId && credential.workerId === workerId)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .map((credential) => clone(credential))
+  }
+
+  findCredentialByPlaintext(plaintext: string, now = new Date()): ResolvedManagedWorkerCredentialRecord | null {
+    const tokenHash = hashManagedWorkerCredential(plaintext)
+    for (const credential of this.credentials.values()) {
+      if (!constantTimeStringEquals(credential.tokenHash, tokenHash)) continue
+      if (credential.revokedAt) {
+        this.recordHeartbeatRejected(credential, 'credential_revoked', now)
+        return null
+      }
+      if (new Date(credential.expiresAt).getTime() <= now.getTime()) {
+        this.recordHeartbeatRejected(credential, 'credential_expired', now)
+        return null
+      }
+      const worker = this.workers.get(credential.workerId)
+      const pool = this.pools.get(credential.poolId)
+      if (!worker || !pool || worker.orgId !== credential.orgId || worker.poolId !== pool.poolId) {
+        this.recordHeartbeatRejected(credential, 'worker_missing', now)
+        return null
+      }
+      if (worker.status === 'revoked' || worker.status === 'retired') {
+        this.recordHeartbeatRejected(credential, `worker_${worker.status}`, now)
+        return null
+      }
+      credential.lastUsedAt = now.toISOString()
+      credential.updatedAt = credential.lastUsedAt
+      return { credential: clone(credential), worker: clone(worker), pool: clone(pool) }
+    }
+    return null
+  }
+
+  revokeCredential(input: RevokeManagedWorkerCredentialInput): ManagedWorkerCredentialRecord | null {
+    const credential = this.credentials.get(input.credentialId)
+    if (!credential || credential.orgId !== input.orgId) return null
+    if (input.workerId && credential.workerId !== input.workerId) return null
+    const revokedAt = nowIso(input.revokedAt)
+    credential.revokedAt = credential.revokedAt || revokedAt
+    credential.updatedAt = revokedAt
+    this.host.recordAuditEvent({
+      orgId: credential.orgId,
+      accountId: input.actor?.accountId || null,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: 'managed_worker_credential.revoked',
+      targetType: 'managed_worker_credential',
+      targetId: credential.credentialId,
+      metadata: { workerId: credential.workerId, last4: credential.last4 },
+      createdAt: input.revokedAt,
+    })
+    return clone(credential)
+  }
+
+  recordHeartbeat(input: RecordManagedWorkerHeartbeatInput): ManagedWorkerHeartbeatRecord {
+    const worker = this.workers.get(input.workerId)
+    const credential = this.credentials.get(input.credentialId)
+    if (!worker || worker.orgId !== input.orgId || !credential || credential.workerId !== worker.workerId) {
+      throw new Error(`Managed worker ${input.workerId} is not registered.`)
+    }
+    if (credential.revokedAt) throw new Error('Managed worker credential is revoked.')
+    if (new Date(credential.expiresAt).getTime() <= (input.now || new Date()).getTime()) {
+      throw new Error('Managed worker credential is expired.')
+    }
+    if (worker.status === 'revoked' || worker.status === 'retired') {
+      throw new Error(`Managed worker ${worker.workerId} cannot heartbeat while ${worker.status}.`)
+    }
+    const now = nowIso(input.now)
+    worker.version = input.version === undefined
+      ? worker.version
+      : normalizeNullableText(input.version, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker version')
+    worker.capabilities = input.capabilities === undefined
+      ? worker.capabilities
+      : normalizeMetadata(input.capabilities, 'Managed worker capabilities')
+    worker.currentLoad = normalizeNonNegativeInteger(input.currentLoad || 0, 'Managed worker current load')
+    worker.lastErrorCode = input.lastErrorCode === undefined
+      ? worker.lastErrorCode
+      : normalizeNullableText(input.lastErrorCode, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker error code')
+    worker.lastErrorSummary = input.lastErrorSummary === undefined
+      ? worker.lastErrorSummary
+      : input.lastErrorSummary
+        ? redactOperationalText(input.lastErrorSummary, 1024, 'Managed worker error summary')
+        : null
+    worker.lastHeartbeatAt = now
+    worker.updatedAt = now
+    credential.lastUsedAt = now
+    credential.updatedAt = now
+    const record: ManagedWorkerHeartbeatRecord = {
+      workerId: worker.workerId,
+      orgId: worker.orgId,
+      tenantId: worker.tenantId,
+      poolId: worker.poolId,
+      version: worker.version,
+      capabilities: clone(worker.capabilities),
+      currentLoad: worker.currentLoad,
+      activeWorkIds: normalizeIdList(input.activeWorkIds || [], 'Managed worker active work ids', 500),
+      lastErrorCode: worker.lastErrorCode,
+      lastErrorSummary: worker.lastErrorSummary,
+      heartbeatSequence: input.heartbeatSequence === undefined || input.heartbeatSequence === null
+        ? null
+        : normalizeNonNegativeInteger(input.heartbeatSequence, 'Managed worker heartbeat sequence'),
+      receivedAt: now,
+    }
+    this.heartbeats.set(worker.workerId, record)
+    return clone(record)
+  }
+
+  listHeartbeats(orgId: string, input: { workerId?: string | null, limit?: number | null } = {}): ManagedWorkerHeartbeatRecord[] {
+    return Array.from(this.heartbeats.values())
+      .filter((heartbeat) => heartbeat.orgId === orgId)
+      .filter((heartbeat) => !input.workerId || heartbeat.workerId === input.workerId)
+      .sort((left, right) => right.receivedAt.localeCompare(left.receivedAt))
+      .slice(0, normalizeListLimit(input.limit, 100, 500))
+      .map((heartbeat) => clone(heartbeat))
+  }
+
+  private recordHeartbeatRejected(
+    credential: ManagedWorkerCredentialRecord,
+    reason: string,
+    now: Date,
+  ) {
+    this.host.recordAuditEvent({
+      orgId: credential.orgId,
+      actorType: 'system',
+      actorId: credential.workerId,
+      eventType: 'managed_worker_heartbeat.rejected',
+      targetType: 'managed_worker',
+      targetId: credential.workerId,
+      metadata: {
+        credentialId: credential.credentialId,
+        poolId: credential.poolId,
+        reason,
+        last4: credential.last4,
+      },
+      createdAt: now,
+    })
+  }
+}
+
+export function hashManagedWorkerCredential(plaintext: string) {
+  return `scrypt:${scryptSync(plaintext, 'open-cowork-managed-worker-credential-v1', 32).toString('base64url')}`
+}
+
+export function generateManagedWorkerCredential(input: { credentialId?: string, secret?: string } = {}) {
+  const credentialId = input.credentialId || `mwcred_${randomBytes(12).toString('base64url')}`
+  const secret = input.secret || randomBytes(32).toString('base64url')
+  return {
+    credentialId,
+    plaintext: `ocw_${credentialId}_${secret}`,
+  }
+}
+
+function nowIso(now: Date | undefined) {
+  return (now || new Date()).toISOString()
+}
+
+function stableId(prefix: string, ...parts: string[]) {
+  return `${prefix}_${createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32)}`
+}
+
+function normalizeListLimit(value: number | null | undefined, fallback = 100, max = 500) {
+  if (!Number.isFinite(value)) return fallback
+  return Math.max(1, Math.min(max, Math.floor(value || fallback)))
+}
+
+function normalizeNullablePositiveInteger(value: number | null | undefined, label: string): number | null {
+  if (value === undefined || value === null) return null
+  if (!Number.isInteger(value) || value < 0) throw new Error(`${label} must be a non-negative integer.`)
+  return value
+}
+
+function normalizePoolMode(value: ManagedWorkerPoolMode): ManagedWorkerPoolMode {
+  if (!MANAGED_WORKER_SUPPORTED_POOL_MODES.has(value)) {
+    throw new Error(`Managed worker pool mode ${value} is not supported in v1.`)
+  }
+  return value
+}
+
+function normalizePoolStatus(value: ManagedWorkerPoolStatus | undefined): ManagedWorkerPoolStatus {
+  if (!value) return 'active'
+  if (value === 'active' || value === 'paused' || value === 'retired') return value
+  throw new Error(`Unsupported managed worker pool status ${String(value)}.`)
+}
+
+function normalizeWorkerStatus(value: ManagedWorkerStatus | undefined): ManagedWorkerStatus {
+  if (!value) return 'pending'
+  if (
+    value === 'pending'
+    || value === 'active'
+    || value === 'draining'
+    || value === 'paused'
+    || value === 'retired'
+    || value === 'revoked'
+    || value === 'unhealthy'
+  ) return value
+  throw new Error(`Unsupported managed worker status ${String(value)}.`)
+}
+
+function assertWorkerStatusTransition(from: ManagedWorkerStatus, to: ManagedWorkerStatus) {
+  if (from === to) return
+  const allowed: Record<ManagedWorkerStatus, ManagedWorkerStatus[]> = {
+    pending: ['active', 'revoked'],
+    active: ['draining', 'paused', 'unhealthy', 'retired', 'revoked'],
+    draining: ['active', 'retired', 'revoked', 'unhealthy'],
+    paused: ['active', 'retired', 'revoked'],
+    unhealthy: ['active', 'draining', 'retired', 'revoked'],
+    retired: [],
+    revoked: [],
+  }
+  if (!allowed[from].includes(to)) throw new Error(`Invalid managed worker transition from ${from} to ${to}.`)
+}
+
+function normalizeCredentialScopes(scopes: ManagedWorkerCredentialScope[] | undefined): ManagedWorkerCredentialScope[] {
+  const normalized = [...new Set(scopes?.length ? scopes : ['heartbeat'])]
+  if (normalized.some((scope) => scope !== 'heartbeat')) throw new Error('Managed worker credential scope is unsupported.')
+  return normalized as ManagedWorkerCredentialScope[]
+}
+
+function normalizeMetadata(value: Record<string, unknown> | undefined, label: string) {
+  return normalizeRecord(value || {}, label, MANAGED_WORKER_METADATA_MAX_BYTES)
+}
+
+function normalizeIdList(values: readonly unknown[], label: string, maxLength: number) {
+  if (!Array.isArray(values)) throw new Error(`${label} must be an array.`)
+  if (values.length > maxLength) throw new Error(`${label} exceeds ${maxLength} entries.`)
+  return [...new Set(values.map((value) => normalizeText(value, 256, label)))]
+}
+
+function normalizeRecord(value: unknown, label: string, maxBytes: number): Record<string, unknown> {
+  const record = value && typeof value === 'object' && !Array.isArray(value)
+    ? clone(value as Record<string, unknown>)
+    : {}
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function normalizeText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (normalized.length > maxLength) {
+    throw new Error(`${label} exceeds ${maxLength} characters.`)
+  }
+  return normalized
+}
+
+function normalizeNullableText(value: unknown, maxLength: number, label: string): string | null {
+  if (value === undefined || value === null || value === '') return null
+  return normalizeText(value, maxLength, label)
+}
+
+function normalizeNonNegativeInteger(value: unknown, label: string) {
+  const parsed = Number(value ?? 0)
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${label} must be a non-negative integer.`)
+  return parsed
+}
+
+function redactOperationalText(value: unknown, maxLength: number, label: string) {
+  return normalizeText(value, maxLength, label)
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password|authorization)=([^\s&]+)/gi, '$1=[redacted]')
+    .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
+    .replace(/\b(sk-[A-Za-z0-9._-]{6,})\b/g, '[redacted]')
+    .replace(/\b(occ_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b(ocw_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([field, entry]) => `${JSON.stringify(field)}:${stableJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function constantTimeStringEquals(left: string, right: string) {
+  const leftBytes = Buffer.from(left)
+  const rightBytes = Buffer.from(right)
+  return leftBytes.byteLength === rightBytes.byteLength && timingSafeEqual(leftBytes, rightBytes)
+}

--- a/apps/desktop/src/main/cloud/managed-worker-types.ts
+++ b/apps/desktop/src/main/cloud/managed-worker-types.ts
@@ -1,0 +1,169 @@
+export type ManagedWorkerPoolMode = 'saas_operated' | 'self_hosted' | 'customer_hosted' | 'hybrid'
+export type ManagedWorkerPoolStatus = 'active' | 'paused' | 'retired'
+export type ManagedWorkerStatus = 'pending' | 'active' | 'draining' | 'paused' | 'retired' | 'revoked' | 'unhealthy'
+export type ManagedWorkerCredentialScope = 'heartbeat'
+
+export type ManagedWorkerPoolRecord = {
+  poolId: string
+  orgId: string
+  tenantId: string | null
+  name: string
+  mode: ManagedWorkerPoolMode
+  status: ManagedWorkerPoolStatus
+  region: string | null
+  capabilities: Record<string, unknown>
+  maxWorkers: number | null
+  maxConcurrentWork: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ManagedWorkerRecord = {
+  workerId: string
+  orgId: string
+  tenantId: string | null
+  poolId: string
+  displayName: string
+  status: ManagedWorkerStatus
+  version: string | null
+  capabilities: Record<string, unknown>
+  lastHeartbeatAt: string | null
+  lastErrorCode: string | null
+  lastErrorSummary: string | null
+  currentLoad: number
+  createdAt: string
+  updatedAt: string
+  revokedAt: string | null
+}
+
+export type ManagedWorkerCredentialRecord = {
+  credentialId: string
+  orgId: string
+  workerId: string
+  poolId: string
+  tokenHash: string
+  scopes: ManagedWorkerCredentialScope[]
+  last4: string
+  expiresAt: string
+  revokedAt: string | null
+  lastUsedAt: string | null
+  rotatedFromCredentialId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type IssuedManagedWorkerCredentialRecord = {
+  credential: ManagedWorkerCredentialRecord
+  plaintext: string
+}
+
+export type ResolvedManagedWorkerCredentialRecord = {
+  credential: ManagedWorkerCredentialRecord
+  worker: ManagedWorkerRecord
+  pool: ManagedWorkerPoolRecord
+}
+
+export type ManagedWorkerHeartbeatRecord = {
+  workerId: string
+  orgId: string
+  tenantId: string | null
+  poolId: string
+  version: string | null
+  capabilities: Record<string, unknown>
+  currentLoad: number
+  activeWorkIds: string[]
+  lastErrorCode: string | null
+  lastErrorSummary: string | null
+  heartbeatSequence: number | null
+  receivedAt: string
+}
+
+type ManagedWorkerActorInput = {
+  actorType?: 'user' | 'api_token' | 'system'
+  actorId?: string | null
+  accountId?: string | null
+}
+
+export type CreateManagedWorkerPoolInput = {
+  poolId?: string
+  orgId: string
+  tenantId?: string | null
+  name: string
+  mode: ManagedWorkerPoolMode
+  status?: ManagedWorkerPoolStatus
+  region?: string | null
+  capabilities?: Record<string, unknown>
+  maxWorkers?: number | null
+  maxConcurrentWork?: number | null
+  createdAt?: Date
+  actor?: ManagedWorkerActorInput
+}
+
+export type UpdateManagedWorkerPoolInput = {
+  orgId: string
+  poolId: string
+  name?: string
+  status?: ManagedWorkerPoolStatus
+  region?: string | null
+  capabilities?: Record<string, unknown>
+  maxWorkers?: number | null
+  maxConcurrentWork?: number | null
+  updatedAt?: Date
+  actor?: ManagedWorkerActorInput
+}
+
+export type RegisterManagedWorkerInput = {
+  workerId?: string
+  orgId: string
+  poolId: string
+  tenantId?: string | null
+  displayName: string
+  status?: ManagedWorkerStatus
+  version?: string | null
+  capabilities?: Record<string, unknown>
+  createdAt?: Date
+  actor?: ManagedWorkerActorInput
+}
+
+export type UpdateManagedWorkerStatusInput = {
+  orgId: string
+  workerId: string
+  status: ManagedWorkerStatus
+  reason?: string | null
+  updatedAt?: Date
+  actor?: ManagedWorkerActorInput
+}
+
+export type IssueManagedWorkerCredentialInput = {
+  orgId: string
+  workerId: string
+  scopes?: ManagedWorkerCredentialScope[]
+  expiresAt?: Date
+  credentialId?: string
+  secret?: string
+  rotatedFromCredentialId?: string | null
+  createdAt?: Date
+  actor?: ManagedWorkerActorInput
+}
+
+export type RevokeManagedWorkerCredentialInput = {
+  orgId: string
+  credentialId: string
+  workerId?: string | null
+  revokedAt?: Date
+  actor?: ManagedWorkerActorInput
+}
+
+export type RecordManagedWorkerHeartbeatInput = {
+  orgId: string
+  workerId: string
+  credentialId: string
+  version?: string | null
+  capabilities?: Record<string, unknown>
+  currentLoad?: number
+  activeWorkIds?: string[]
+  lastErrorCode?: string | null
+  lastErrorSummary?: string | null
+  heartbeatSequence?: number | null
+  now?: Date
+}

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -46,16 +46,26 @@ import type {
   FindChannelInteractionInput,
   IssuedApiTokenRecord,
   IssuedChannelInteractionRecord,
+  IssuedManagedWorkerCredentialRecord,
   IssueApiTokenInput,
   ListSessionsPageInput,
+  ManagedWorkerCredentialRecord,
+  ManagedWorkerHeartbeatRecord,
+  ManagedWorkerPoolRecord,
+  ManagedWorkerPoolStatus,
+  ManagedWorkerRecord,
+  ManagedWorkerStatus,
   ListChannelDeliveriesInput,
   OrgMemberRecord,
   PrincipalMembershipRecord,
+  RecordManagedWorkerHeartbeatInput,
   RecordAuditEventInput,
   RecordByokSecretValidationInput,
   RecordCloudAuthFailureInput,
   RecordUsageEventInput,
   RevokeApiTokenInput,
+  RevokeManagedWorkerCredentialInput,
+  ResolvedManagedWorkerCredentialRecord,
   ResolveChannelInteractionInput,
   ResolveChannelInteractionWithCommandInput,
   SessionCommandRecord,
@@ -67,6 +77,8 @@ import type {
   UpdateChannelBindingInput,
   UpdateChannelCursorInput,
   UpdateHeadlessAgentInput,
+  UpdateManagedWorkerPoolInput,
+  UpdateManagedWorkerStatusInput,
   UpdateWorkflowStatusInput,
   UpdateThreadSmartFilterInput,
   UpdateThreadTagInput,
@@ -76,6 +88,9 @@ import type {
   WorkerLeaseRecord,
   WorkerRole,
   WorkspaceEventRecord,
+  CreateManagedWorkerPoolInput,
+  RegisterManagedWorkerInput,
+  IssueManagedWorkerCredentialInput,
 } from './control-plane-store.ts'
 import type {
   WorkflowWebhookReplayClaim,
@@ -120,6 +135,7 @@ import { iso, jsonRecord, numberValue, type QueryResult, type QueryRow } from '.
 import { threadSmartFilterFromRow, threadTagFromRow } from './postgres-domains/thread-index.ts'
 import { webhookAuthFailureFromRow } from './postgres-domains/webhooks.ts'
 import { workflowFromRow, workflowRunFromRow } from './postgres-domains/workflows.ts'
+import { PostgresManagedWorkersRepository } from './postgres-store-domains/workers.ts'
 
 type PgExecutor = {
   query<Row extends QueryRow = QueryRow>(text: string, values?: unknown[]): Promise<QueryResult<Row>>
@@ -150,7 +166,6 @@ const CHANNEL_METADATA_MAX_BYTES = 16_384
 const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
 const BYOK_PROVIDER_ID_MAX_LENGTH = 64
 const BYOK_SECRET_TEXT_MAX_LENGTH = 4096
-
 function loadPgPool(connectionString: string): PgPool {
   const pg = require('pg') as {
     Pool: new (options: { connectionString: string }) => PgPool
@@ -197,6 +212,7 @@ function redactOperationalText(value: unknown, maxLength: number, label: string)
     .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
     .replace(/\b(sk-[A-Za-z0-9._-]{6,})\b/g, '[redacted]')
     .replace(/\b(occ_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b(ocw_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
     .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
 }
 
@@ -293,10 +309,16 @@ function redactAuditMetadata(value: Record<string, unknown> | undefined): Record
 export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWebhookSecurityStore {
   private readonly pool: PgPool
   private readonly ownsPool: boolean
+  private readonly managedWorkers: PostgresManagedWorkersRepository
 
   private constructor(pool: PgPool, ownsPool: boolean) {
     this.pool = pool
     this.ownsPool = ownsPool
+    this.managedWorkers = new PostgresManagedWorkersRepository({
+      pool: this.pool,
+      withTransaction: (fn) => this.withTransaction(fn),
+      recordAuditEvent: (executor, input) => this.recordAuditEventWithExecutor(executor, input),
+    })
   }
 
   static async connect(options: PostgresControlPlaneStoreOptions) {
@@ -676,6 +698,62 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       })
       return token
     })
+  }
+
+  async createManagedWorkerPool(input: CreateManagedWorkerPoolInput): Promise<ManagedWorkerPoolRecord> {
+    return this.managedWorkers.createPool(input)
+  }
+
+  async updateManagedWorkerPool(input: UpdateManagedWorkerPoolInput): Promise<ManagedWorkerPoolRecord | null> {
+    return this.managedWorkers.updatePool(input)
+  }
+
+  async getManagedWorkerPool(orgId: string, poolId: string) {
+    return this.managedWorkers.getPool(orgId, poolId)
+  }
+
+  async listManagedWorkerPools(orgId: string, input: { status?: ManagedWorkerPoolStatus | null, limit?: number | null } = {}) {
+    return this.managedWorkers.listPools(orgId, input)
+  }
+
+  async registerManagedWorker(input: RegisterManagedWorkerInput): Promise<ManagedWorkerRecord> {
+    return this.managedWorkers.registerWorker(input)
+  }
+
+  async updateManagedWorkerStatus(input: UpdateManagedWorkerStatusInput): Promise<ManagedWorkerRecord | null> {
+    return this.managedWorkers.updateWorkerStatus(input)
+  }
+
+  async getManagedWorker(orgId: string, workerId: string) {
+    return this.managedWorkers.getWorker(orgId, workerId)
+  }
+
+  async listManagedWorkers(orgId: string, input: { poolId?: string | null, status?: ManagedWorkerStatus | null, limit?: number | null } = {}) {
+    return this.managedWorkers.listWorkers(orgId, input)
+  }
+
+  async issueManagedWorkerCredential(input: IssueManagedWorkerCredentialInput): Promise<IssuedManagedWorkerCredentialRecord> {
+    return this.managedWorkers.issueCredential(input)
+  }
+
+  async listManagedWorkerCredentials(orgId: string, workerId: string) {
+    return this.managedWorkers.listCredentials(orgId, workerId)
+  }
+
+  async findManagedWorkerCredentialByPlaintext(plaintext: string, now = new Date()): Promise<ResolvedManagedWorkerCredentialRecord | null> {
+    return this.managedWorkers.findCredentialByPlaintext(plaintext, now)
+  }
+
+  async revokeManagedWorkerCredential(input: RevokeManagedWorkerCredentialInput): Promise<ManagedWorkerCredentialRecord | null> {
+    return this.managedWorkers.revokeCredential(input)
+  }
+
+  async recordManagedWorkerHeartbeat(input: RecordManagedWorkerHeartbeatInput): Promise<ManagedWorkerHeartbeatRecord> {
+    return this.managedWorkers.recordHeartbeat(input)
+  }
+
+  async listManagedWorkerHeartbeats(orgId: string, input: { workerId?: string | null, limit?: number | null } = {}) {
+    return this.managedWorkers.listHeartbeats(orgId, input)
   }
 
   async recordAuditEvent(input: RecordAuditEventInput) {
@@ -3411,6 +3489,10 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   }
 
   async clear() {
+    await this.pool.query('DELETE FROM cloud_managed_worker_heartbeats')
+    await this.pool.query('DELETE FROM cloud_worker_credentials')
+    await this.pool.query('DELETE FROM cloud_managed_workers')
+    await this.pool.query('DELETE FROM cloud_worker_pools')
     await this.pool.query('DELETE FROM cloud_subscriptions')
     await this.pool.query('DELETE FROM cloud_auth_failures')
     await this.pool.query('DELETE FROM cloud_rate_limits')

--- a/apps/desktop/src/main/cloud/postgres-domains/workers.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/workers.ts
@@ -1,0 +1,83 @@
+import type {
+  ManagedWorkerCredentialRecord,
+  ManagedWorkerHeartbeatRecord,
+  ManagedWorkerPoolRecord,
+  ManagedWorkerRecord,
+} from '../control-plane-store.ts'
+import { iso, isoOrNull, jsonRecord, jsonStringArray, numberValue, stringOrNull, type QueryRow } from './shared.ts'
+
+export function managedWorkerPoolFromRow(row: QueryRow): ManagedWorkerPoolRecord {
+  return {
+    poolId: String(row.pool_id),
+    orgId: String(row.org_id),
+    tenantId: stringOrNull(row.tenant_id),
+    name: String(row.name),
+    mode: String(row.mode) as ManagedWorkerPoolRecord['mode'],
+    status: String(row.status) as ManagedWorkerPoolRecord['status'],
+    region: stringOrNull(row.region),
+    capabilities: jsonRecord(row.capabilities),
+    maxWorkers: row.max_workers === null || row.max_workers === undefined ? null : numberValue(row.max_workers),
+    maxConcurrentWork: row.max_concurrent_work === null || row.max_concurrent_work === undefined
+      ? null
+      : numberValue(row.max_concurrent_work),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function managedWorkerFromRow(row: QueryRow): ManagedWorkerRecord {
+  return {
+    workerId: String(row.worker_id),
+    orgId: String(row.org_id),
+    tenantId: stringOrNull(row.tenant_id),
+    poolId: String(row.pool_id),
+    displayName: String(row.display_name),
+    status: String(row.status) as ManagedWorkerRecord['status'],
+    version: stringOrNull(row.version),
+    capabilities: jsonRecord(row.capabilities),
+    lastHeartbeatAt: isoOrNull(row.last_heartbeat_at),
+    lastErrorCode: stringOrNull(row.last_error_code),
+    lastErrorSummary: stringOrNull(row.last_error_summary),
+    currentLoad: numberValue(row.current_load),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+    revokedAt: isoOrNull(row.revoked_at),
+  }
+}
+
+export function managedWorkerCredentialFromRow(row: QueryRow): ManagedWorkerCredentialRecord {
+  return {
+    credentialId: String(row.credential_id),
+    orgId: String(row.org_id),
+    workerId: String(row.worker_id),
+    poolId: String(row.pool_id),
+    tokenHash: String(row.token_hash),
+    scopes: jsonStringArray(row.scopes) as ManagedWorkerCredentialRecord['scopes'],
+    last4: String(row.last4),
+    expiresAt: iso(row.expires_at),
+    revokedAt: isoOrNull(row.revoked_at),
+    lastUsedAt: isoOrNull(row.last_used_at),
+    rotatedFromCredentialId: stringOrNull(row.rotated_from_credential_id),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function managedWorkerHeartbeatFromRow(row: QueryRow): ManagedWorkerHeartbeatRecord {
+  return {
+    workerId: String(row.worker_id),
+    orgId: String(row.org_id),
+    tenantId: stringOrNull(row.tenant_id),
+    poolId: String(row.pool_id),
+    version: stringOrNull(row.version),
+    capabilities: jsonRecord(row.capabilities),
+    currentLoad: numberValue(row.current_load),
+    activeWorkIds: jsonStringArray(row.active_work_ids),
+    lastErrorCode: stringOrNull(row.last_error_code),
+    lastErrorSummary: stringOrNull(row.last_error_summary),
+    heartbeatSequence: row.heartbeat_sequence === null || row.heartbeat_sequence === undefined
+      ? null
+      : numberValue(row.heartbeat_sequence),
+    receivedAt: iso(row.received_at),
+  }
+}

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -562,6 +562,81 @@ export const CLOUD_CONTROL_PLANE_SCALE_FOUNDATION_STATEMENTS = [
     ON cloud_worker_leases (tenant_id, session_id, lease_expires_at_ms)`,
 ] as const
 
+export const CLOUD_CONTROL_PLANE_MANAGED_WORKERS_MIGRATION_ID = '008_managed_workers'
+
+export const CLOUD_CONTROL_PLANE_MANAGED_WORKERS_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS cloud_worker_pools (
+    pool_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    tenant_id text REFERENCES cloud_tenants(tenant_id) ON DELETE CASCADE,
+    name text NOT NULL,
+    mode text NOT NULL,
+    status text NOT NULL,
+    region text,
+    capabilities jsonb NOT NULL,
+    max_workers integer,
+    max_concurrent_work integer,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_worker_pools_org_idx
+    ON cloud_worker_pools (org_id, updated_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS cloud_managed_workers (
+    worker_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    tenant_id text REFERENCES cloud_tenants(tenant_id) ON DELETE CASCADE,
+    pool_id text NOT NULL REFERENCES cloud_worker_pools(pool_id) ON DELETE CASCADE,
+    display_name text NOT NULL,
+    status text NOT NULL,
+    version text,
+    capabilities jsonb NOT NULL,
+    last_heartbeat_at timestamptz,
+    last_error_code text,
+    last_error_summary text,
+    current_load integer NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    revoked_at timestamptz
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_managed_workers_org_pool_idx
+    ON cloud_managed_workers (org_id, pool_id, updated_at DESC)`,
+  `CREATE INDEX IF NOT EXISTS cloud_managed_workers_org_status_idx
+    ON cloud_managed_workers (org_id, status, updated_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS cloud_worker_credentials (
+    credential_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    worker_id text NOT NULL REFERENCES cloud_managed_workers(worker_id) ON DELETE CASCADE,
+    pool_id text NOT NULL REFERENCES cloud_worker_pools(pool_id) ON DELETE CASCADE,
+    token_hash text UNIQUE NOT NULL,
+    scopes jsonb NOT NULL,
+    last4 text NOT NULL,
+    expires_at timestamptz NOT NULL,
+    revoked_at timestamptz,
+    last_used_at timestamptz,
+    rotated_from_credential_id text REFERENCES cloud_worker_credentials(credential_id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_worker_credentials_worker_idx
+    ON cloud_worker_credentials (org_id, worker_id, created_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS cloud_managed_worker_heartbeats (
+    worker_id text PRIMARY KEY REFERENCES cloud_managed_workers(worker_id) ON DELETE CASCADE,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    tenant_id text REFERENCES cloud_tenants(tenant_id) ON DELETE CASCADE,
+    pool_id text NOT NULL REFERENCES cloud_worker_pools(pool_id) ON DELETE CASCADE,
+    version text,
+    capabilities jsonb NOT NULL,
+    current_load integer NOT NULL,
+    active_work_ids jsonb NOT NULL,
+    last_error_code text,
+    last_error_summary text,
+    heartbeat_sequence bigint,
+    received_at timestamptz NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS cloud_managed_worker_heartbeats_org_idx
+    ON cloud_managed_worker_heartbeats (org_id, received_at DESC)`,
+] as const
+
 export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration[] = [
   {
     id: CLOUD_CONTROL_PLANE_MIGRATION_ID,
@@ -590,5 +665,9 @@ export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration
   {
     id: CLOUD_CONTROL_PLANE_SCALE_FOUNDATION_MIGRATION_ID,
     statements: CLOUD_CONTROL_PLANE_SCALE_FOUNDATION_STATEMENTS,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_MANAGED_WORKERS_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_MANAGED_WORKERS_STATEMENTS,
   },
 ] as const

--- a/apps/desktop/src/main/cloud/postgres-store-domains/workers.ts
+++ b/apps/desktop/src/main/cloud/postgres-store-domains/workers.ts
@@ -1,0 +1,670 @@
+import {
+  generateManagedWorkerCredential,
+  hashManagedWorkerCredential,
+} from '../in-memory-domains/workers.ts'
+import type {
+  CreateManagedWorkerPoolInput,
+  IssueManagedWorkerCredentialInput,
+  IssuedManagedWorkerCredentialRecord,
+  ManagedWorkerCredentialRecord,
+  ManagedWorkerCredentialScope,
+  ManagedWorkerHeartbeatRecord,
+  ManagedWorkerPoolMode,
+  ManagedWorkerPoolRecord,
+  ManagedWorkerPoolStatus,
+  ManagedWorkerRecord,
+  ManagedWorkerStatus,
+  RecordAuditEventInput,
+  RecordManagedWorkerHeartbeatInput,
+  RegisterManagedWorkerInput,
+  ResolvedManagedWorkerCredentialRecord,
+  RevokeManagedWorkerCredentialInput,
+  UpdateManagedWorkerPoolInput,
+  UpdateManagedWorkerStatusInput,
+} from '../control-plane-store.ts'
+import {
+  managedWorkerCredentialFromRow,
+  managedWorkerFromRow,
+  managedWorkerHeartbeatFromRow,
+  managedWorkerPoolFromRow,
+} from '../postgres-domains/workers.ts'
+import { jsonRecord, type QueryResult, type QueryRow } from '../postgres-domains/shared.ts'
+
+type PgExecutor = {
+  query<Row extends QueryRow = QueryRow>(text: string, values?: unknown[]): Promise<QueryResult<Row>>
+}
+type PgClient = PgExecutor & { release: () => void }
+
+type PostgresManagedWorkersRepositoryOptions = {
+  pool: PgExecutor
+  withTransaction<T>(fn: (client: PgClient) => Promise<T>): Promise<T>
+  recordAuditEvent(executor: PgExecutor, input: RecordAuditEventInput): Promise<unknown>
+}
+
+const MANAGED_WORKER_TEXT_MAX_LENGTH = 256
+const MANAGED_WORKER_METADATA_MAX_BYTES = 16_384
+const MANAGED_WORKER_DEFAULT_CREDENTIAL_TTL_MS = 90 * 24 * 60 * 60 * 1000
+const MANAGED_WORKER_SUPPORTED_POOL_MODES = new Set<ManagedWorkerPoolMode>(['saas_operated', 'self_hosted'])
+
+export class PostgresManagedWorkersRepository {
+  private readonly options: PostgresManagedWorkersRepositoryOptions
+
+  constructor(options: PostgresManagedWorkersRepositoryOptions) {
+    this.options = options
+  }
+
+  async createPool(input: CreateManagedWorkerPoolInput): Promise<ManagedWorkerPoolRecord> {
+    const now = nowIso(input.createdAt)
+    const org = await this.maybeOne(`SELECT * FROM cloud_orgs WHERE org_id = $1`, [input.orgId])
+    if (!org) throw new Error(`Unknown org ${input.orgId}.`)
+    const poolId = input.poolId || `mwp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+    return this.options.withTransaction(async (client) => {
+      const result = await client.query(
+        `INSERT INTO cloud_worker_pools (
+          pool_id, org_id, tenant_id, name, mode, status, region, capabilities,
+          max_workers, max_concurrent_work, created_at, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $11)
+         ON CONFLICT (pool_id) DO NOTHING
+         RETURNING *`,
+        [
+          poolId,
+          input.orgId,
+          input.tenantId === undefined ? org.tenant_id : input.tenantId,
+          normalizeText(input.name, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool name'),
+          normalizePoolMode(input.mode),
+          normalizePoolStatus(input.status),
+          normalizeNullableText(input.region, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool region'),
+          JSON.stringify(normalizeMetadata(input.capabilities, 'Managed worker pool capabilities')),
+          normalizeNullablePositiveInteger(input.maxWorkers, 'Managed worker max workers'),
+          normalizeNullablePositiveInteger(input.maxConcurrentWork, 'Managed worker max concurrent work'),
+          now,
+        ],
+      )
+      const pool = result.rows[0]
+        ? managedWorkerPoolFromRow(result.rows[0])
+        : managedWorkerPoolFromRow(await this.one(`SELECT * FROM cloud_worker_pools WHERE pool_id = $1`, [poolId], client))
+      await this.options.recordAuditEvent(client, {
+        orgId: pool.orgId,
+        accountId: input.actor?.accountId || null,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: 'managed_worker_pool.created',
+        targetType: 'managed_worker_pool',
+        targetId: pool.poolId,
+        metadata: { name: pool.name, mode: pool.mode, status: pool.status, region: pool.region },
+        createdAt: input.createdAt,
+      })
+      return pool
+    })
+  }
+
+  async updatePool(input: UpdateManagedWorkerPoolInput): Promise<ManagedWorkerPoolRecord | null> {
+    const existing = await this.getPool(input.orgId, input.poolId)
+    if (!existing) return null
+    const updatedAt = nowIso(input.updatedAt)
+    return this.options.withTransaction(async (client) => {
+      const result = await client.query(
+        `UPDATE cloud_worker_pools
+         SET name = COALESCE($3, name),
+             status = COALESCE($4, status),
+             region = $5,
+             capabilities = COALESCE($6::jsonb, capabilities),
+             max_workers = $7,
+             max_concurrent_work = $8,
+             updated_at = $9
+         WHERE org_id = $1 AND pool_id = $2
+         RETURNING *`,
+        [
+          input.orgId,
+          input.poolId,
+          input.name === undefined ? null : normalizeText(input.name, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool name'),
+          input.status === undefined ? null : normalizePoolStatus(input.status),
+          input.region === undefined ? existing.region : normalizeNullableText(input.region, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool region'),
+          input.capabilities === undefined ? null : JSON.stringify(normalizeMetadata(input.capabilities, 'Managed worker pool capabilities')),
+          input.maxWorkers === undefined ? existing.maxWorkers : normalizeNullablePositiveInteger(input.maxWorkers, 'Managed worker max workers'),
+          input.maxConcurrentWork === undefined ? existing.maxConcurrentWork : normalizeNullablePositiveInteger(input.maxConcurrentWork, 'Managed worker max concurrent work'),
+          updatedAt,
+        ],
+      )
+      if (!result.rows[0]) return null
+      const pool = managedWorkerPoolFromRow(result.rows[0])
+      await this.options.recordAuditEvent(client, {
+        orgId: pool.orgId,
+        accountId: input.actor?.accountId || null,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: 'managed_worker_pool.updated',
+        targetType: 'managed_worker_pool',
+        targetId: pool.poolId,
+        metadata: { name: pool.name, status: pool.status },
+        createdAt: input.updatedAt,
+      })
+      return pool
+    })
+  }
+
+  async getPool(orgId: string, poolId: string) {
+    const row = await this.maybeOne(`SELECT * FROM cloud_worker_pools WHERE org_id = $1 AND pool_id = $2`, [orgId, poolId])
+    return row ? managedWorkerPoolFromRow(row) : null
+  }
+
+  async listPools(orgId: string, input: { status?: ManagedWorkerPoolStatus | null, limit?: number | null } = {}) {
+    const result = await this.options.pool.query(
+      `SELECT * FROM cloud_worker_pools
+       WHERE org_id = $1 AND ($2::text IS NULL OR status = $2)
+       ORDER BY updated_at DESC, pool_id ASC
+       LIMIT $3`,
+      [orgId, input.status || null, normalizeListLimit(input.limit, 100, 500)],
+    )
+    return result.rows.map(managedWorkerPoolFromRow)
+  }
+
+  async registerWorker(input: RegisterManagedWorkerInput): Promise<ManagedWorkerRecord> {
+    const pool = await this.getPool(input.orgId, input.poolId)
+    if (!pool) throw new Error(`Unknown managed worker pool ${input.poolId}.`)
+    const now = nowIso(input.createdAt)
+    const workerId = input.workerId || `mworker_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+    return this.options.withTransaction(async (client) => {
+      const result = await client.query(
+        `INSERT INTO cloud_managed_workers (
+          worker_id, org_id, tenant_id, pool_id, display_name, status, version,
+          capabilities, last_heartbeat_at, last_error_code, last_error_summary,
+          current_load, created_at, updated_at, revoked_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, NULL, NULL, NULL, 0, $9, $9, $10)
+         ON CONFLICT (worker_id) DO NOTHING
+         RETURNING *`,
+        [
+          workerId,
+          input.orgId,
+          input.tenantId === undefined ? pool.tenantId : input.tenantId,
+          input.poolId,
+          normalizeText(input.displayName, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker display name'),
+          normalizeWorkerStatus(input.status),
+          normalizeNullableText(input.version, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker version'),
+          JSON.stringify(normalizeMetadata(input.capabilities, 'Managed worker capabilities')),
+          now,
+          input.status === 'revoked' ? now : null,
+        ],
+      )
+      const worker = result.rows[0]
+        ? managedWorkerFromRow(result.rows[0])
+        : managedWorkerFromRow(await this.one(`SELECT * FROM cloud_managed_workers WHERE worker_id = $1`, [workerId], client))
+      await this.options.recordAuditEvent(client, {
+        orgId: worker.orgId,
+        accountId: input.actor?.accountId || null,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: 'managed_worker.registered',
+        targetType: 'managed_worker',
+        targetId: worker.workerId,
+        metadata: { poolId: worker.poolId, status: worker.status, displayName: worker.displayName },
+        createdAt: input.createdAt,
+      })
+      return worker
+    })
+  }
+
+  async updateWorkerStatus(input: UpdateManagedWorkerStatusInput): Promise<ManagedWorkerRecord | null> {
+    const existing = await this.getWorker(input.orgId, input.workerId)
+    if (!existing) return null
+    const status = normalizeWorkerStatus(input.status)
+    assertWorkerStatusTransition(existing.status, status)
+    const updatedAt = nowIso(input.updatedAt)
+    return this.options.withTransaction(async (client) => {
+      const result = await client.query(
+        `UPDATE cloud_managed_workers
+         SET status = $3,
+             updated_at = $4,
+             revoked_at = CASE WHEN $3 = 'revoked' THEN COALESCE(revoked_at, $4) ELSE revoked_at END
+         WHERE org_id = $1 AND worker_id = $2
+         RETURNING *`,
+        [input.orgId, input.workerId, status, updatedAt],
+      )
+      if (!result.rows[0]) return null
+      const worker = managedWorkerFromRow(result.rows[0])
+      await this.options.recordAuditEvent(client, {
+        orgId: worker.orgId,
+        accountId: input.actor?.accountId || null,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: `managed_worker.${status}`,
+        targetType: 'managed_worker',
+        targetId: worker.workerId,
+        metadata: { poolId: worker.poolId, status, reason: input.reason || null },
+        createdAt: input.updatedAt,
+      })
+      return worker
+    })
+  }
+
+  async getWorker(orgId: string, workerId: string) {
+    const row = await this.maybeOne(`SELECT * FROM cloud_managed_workers WHERE org_id = $1 AND worker_id = $2`, [orgId, workerId])
+    return row ? managedWorkerFromRow(row) : null
+  }
+
+  async listWorkers(orgId: string, input: { poolId?: string | null, status?: ManagedWorkerStatus | null, limit?: number | null } = {}) {
+    const result = await this.options.pool.query(
+      `SELECT * FROM cloud_managed_workers
+       WHERE org_id = $1
+         AND ($2::text IS NULL OR pool_id = $2)
+         AND ($3::text IS NULL OR status = $3)
+       ORDER BY updated_at DESC, worker_id ASC
+       LIMIT $4`,
+      [orgId, input.poolId || null, input.status || null, normalizeListLimit(input.limit, 100, 500)],
+    )
+    return result.rows.map(managedWorkerFromRow)
+  }
+
+  async issueCredential(input: IssueManagedWorkerCredentialInput): Promise<IssuedManagedWorkerCredentialRecord> {
+    const worker = await this.getWorker(input.orgId, input.workerId)
+    if (!worker) throw new Error(`Unknown managed worker ${input.workerId}.`)
+    if (worker.status === 'revoked' || worker.status === 'retired') throw new Error('Cannot issue credentials for a terminal managed worker.')
+    const generated = generateManagedWorkerCredential(input)
+    const createdAt = input.createdAt || new Date()
+    const now = createdAt.toISOString()
+    const expiresAt = input.expiresAt || new Date(createdAt.getTime() + MANAGED_WORKER_DEFAULT_CREDENTIAL_TTL_MS)
+    if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= createdAt.getTime()) {
+      throw new Error('Managed worker credential expiration must be in the future.')
+    }
+    return this.options.withTransaction(async (client) => {
+      const result = await client.query(
+        `INSERT INTO cloud_worker_credentials (
+          credential_id, org_id, worker_id, pool_id, token_hash, scopes, last4,
+          expires_at, revoked_at, last_used_at, rotated_from_credential_id, created_at, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, NULL, NULL, $9, $10, $10)
+         RETURNING *`,
+        [
+          generated.credentialId,
+          worker.orgId,
+          worker.workerId,
+          worker.poolId,
+          hashManagedWorkerCredential(generated.plaintext),
+          JSON.stringify(normalizeCredentialScopes(input.scopes)),
+          generated.plaintext.slice(-4),
+          expiresAt.toISOString(),
+          input.rotatedFromCredentialId || null,
+          now,
+        ],
+      )
+      const credential = managedWorkerCredentialFromRow(result.rows[0])
+      await this.options.recordAuditEvent(client, {
+        orgId: credential.orgId,
+        accountId: input.actor?.accountId || null,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: input.rotatedFromCredentialId ? 'managed_worker_credential.rotated' : 'managed_worker_credential.issued',
+        targetType: 'managed_worker_credential',
+        targetId: credential.credentialId,
+        metadata: { workerId: credential.workerId, scopes: credential.scopes, last4: credential.last4 },
+        createdAt: input.createdAt,
+      })
+      return { credential, plaintext: generated.plaintext }
+    })
+  }
+
+  async listCredentials(orgId: string, workerId: string) {
+    const result = await this.options.pool.query(
+      `SELECT * FROM cloud_worker_credentials
+       WHERE org_id = $1 AND worker_id = $2
+       ORDER BY created_at DESC`,
+      [orgId, workerId],
+    )
+    return result.rows.map(managedWorkerCredentialFromRow)
+  }
+
+  async findCredentialByPlaintext(plaintext: string, now = new Date()): Promise<ResolvedManagedWorkerCredentialRecord | null> {
+    const tokenHash = hashManagedWorkerCredential(plaintext)
+    return this.options.withTransaction(async (client) => {
+      const nowText = nowIso(now)
+      const result = await client.query(
+        `SELECT * FROM cloud_worker_credentials WHERE token_hash = $1`,
+        [tokenHash],
+      )
+      if (!result.rows[0]) return null
+      const credential = managedWorkerCredentialFromRow(result.rows[0])
+      if (credential.revokedAt) {
+        await this.recordHeartbeatRejected(client, credential, 'credential_revoked', now)
+        return null
+      }
+      if (new Date(credential.expiresAt).getTime() <= now.getTime()) {
+        await this.recordHeartbeatRejected(client, credential, 'credential_expired', now)
+        return null
+      }
+      const workerRow = await this.maybeOne(
+        `SELECT * FROM cloud_managed_workers
+         WHERE org_id = $1 AND worker_id = $2 AND status NOT IN ('retired', 'revoked')`,
+        [credential.orgId, credential.workerId],
+        client,
+      )
+      if (!workerRow) {
+        const terminalWorker = await this.maybeOne(
+          `SELECT * FROM cloud_managed_workers
+           WHERE org_id = $1 AND worker_id = $2`,
+          [credential.orgId, credential.workerId],
+          client,
+        )
+        await this.recordHeartbeatRejected(
+          client,
+          credential,
+          terminalWorker ? `worker_${String(terminalWorker.status)}` : 'worker_missing',
+          now,
+        )
+        return null
+      }
+      const poolRow = await this.maybeOne(
+        `SELECT * FROM cloud_worker_pools WHERE org_id = $1 AND pool_id = $2`,
+        [credential.orgId, credential.poolId],
+        client,
+      )
+      if (!poolRow) {
+        await this.recordHeartbeatRejected(client, credential, 'pool_missing', now)
+        return null
+      }
+      const updatedCredentialRow = await client.query(
+        `UPDATE cloud_worker_credentials
+         SET last_used_at = $2, updated_at = $2
+         WHERE credential_id = $1
+         RETURNING *`,
+        [credential.credentialId, nowText],
+      )
+      return {
+        credential: managedWorkerCredentialFromRow(updatedCredentialRow.rows[0]),
+        worker: managedWorkerFromRow(workerRow),
+        pool: managedWorkerPoolFromRow(poolRow),
+      }
+    })
+  }
+
+  async revokeCredential(input: RevokeManagedWorkerCredentialInput): Promise<ManagedWorkerCredentialRecord | null> {
+    return this.options.withTransaction(async (client) => {
+      const now = nowIso(input.revokedAt)
+      const result = await client.query(
+        `UPDATE cloud_worker_credentials
+         SET revoked_at = COALESCE(revoked_at, $3), updated_at = $3
+         WHERE org_id = $1
+           AND credential_id = $2
+           AND ($4::text IS NULL OR worker_id = $4)
+         RETURNING *`,
+        [input.orgId, input.credentialId, now, input.workerId || null],
+      )
+      if (!result.rows[0]) return null
+      const credential = managedWorkerCredentialFromRow(result.rows[0])
+      await this.options.recordAuditEvent(client, {
+        orgId: credential.orgId,
+        accountId: input.actor?.accountId || null,
+        actorType: input.actor?.actorType || 'system',
+        actorId: input.actor?.actorId || null,
+        eventType: 'managed_worker_credential.revoked',
+        targetType: 'managed_worker_credential',
+        targetId: credential.credentialId,
+        metadata: { workerId: credential.workerId, last4: credential.last4 },
+        createdAt: input.revokedAt,
+      })
+      return credential
+    })
+  }
+
+  async recordHeartbeat(input: RecordManagedWorkerHeartbeatInput): Promise<ManagedWorkerHeartbeatRecord> {
+    const now = nowIso(input.now)
+    const worker = await this.getWorker(input.orgId, input.workerId)
+    if (!worker) throw new Error(`Managed worker ${input.workerId} is not registered.`)
+    const credential = await this.maybeOne(
+      `SELECT * FROM cloud_worker_credentials
+       WHERE org_id = $1 AND worker_id = $2 AND credential_id = $3
+         AND revoked_at IS NULL AND expires_at > $4`,
+      [input.orgId, input.workerId, input.credentialId, now],
+    )
+    if (!credential) throw new Error('Managed worker credential is invalid, expired, or revoked.')
+    if (worker.status === 'revoked' || worker.status === 'retired') {
+      throw new Error(`Managed worker ${worker.workerId} cannot heartbeat while ${worker.status}.`)
+    }
+    const version = input.version === undefined
+      ? worker.version
+      : normalizeNullableText(input.version, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker version')
+    const capabilities = input.capabilities === undefined
+      ? worker.capabilities
+      : normalizeMetadata(input.capabilities, 'Managed worker capabilities')
+    const currentLoad = normalizeNonNegativeInteger(input.currentLoad || 0, 'Managed worker current load')
+    const lastErrorCode = input.lastErrorCode === undefined
+      ? worker.lastErrorCode
+      : normalizeNullableText(input.lastErrorCode, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker error code')
+    const lastErrorSummary = input.lastErrorSummary === undefined
+      ? worker.lastErrorSummary
+      : input.lastErrorSummary
+        ? redactOperationalText(input.lastErrorSummary, 1024, 'Managed worker error summary')
+        : null
+    const activeWorkIds = normalizeIdList(input.activeWorkIds || [], 'Managed worker active work ids', 500)
+    const heartbeatSequence = input.heartbeatSequence === undefined || input.heartbeatSequence === null
+      ? null
+      : normalizeNonNegativeInteger(input.heartbeatSequence, 'Managed worker heartbeat sequence')
+    return this.options.withTransaction(async (client) => {
+      await client.query(
+        `UPDATE cloud_managed_workers
+         SET version = $3,
+             capabilities = $4::jsonb,
+             current_load = $5,
+             last_error_code = $6,
+             last_error_summary = $7,
+             last_heartbeat_at = $8,
+             updated_at = $8
+         WHERE org_id = $1 AND worker_id = $2`,
+        [input.orgId, input.workerId, version, JSON.stringify(capabilities), currentLoad, lastErrorCode, lastErrorSummary, now],
+      )
+      await client.query(
+        `UPDATE cloud_worker_credentials
+         SET last_used_at = $3, updated_at = $3
+         WHERE org_id = $1 AND credential_id = $2`,
+        [input.orgId, input.credentialId, now],
+      )
+      const result = await client.query(
+        `INSERT INTO cloud_managed_worker_heartbeats (
+          worker_id, org_id, tenant_id, pool_id, version, capabilities, current_load,
+          active_work_ids, last_error_code, last_error_summary, heartbeat_sequence, received_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9, $10, $11, $12)
+         ON CONFLICT (worker_id) DO UPDATE
+         SET version = EXCLUDED.version,
+             capabilities = EXCLUDED.capabilities,
+             current_load = EXCLUDED.current_load,
+             active_work_ids = EXCLUDED.active_work_ids,
+             last_error_code = EXCLUDED.last_error_code,
+             last_error_summary = EXCLUDED.last_error_summary,
+             heartbeat_sequence = EXCLUDED.heartbeat_sequence,
+             received_at = EXCLUDED.received_at
+         RETURNING *`,
+        [
+          input.workerId,
+          input.orgId,
+          worker.tenantId,
+          worker.poolId,
+          version,
+          JSON.stringify(capabilities),
+          currentLoad,
+          JSON.stringify(activeWorkIds),
+          lastErrorCode,
+          lastErrorSummary,
+          heartbeatSequence,
+          now,
+        ],
+      )
+      return managedWorkerHeartbeatFromRow(result.rows[0])
+    })
+  }
+
+  async listHeartbeats(orgId: string, input: { workerId?: string | null, limit?: number | null } = {}) {
+    const result = await this.options.pool.query(
+      `SELECT * FROM cloud_managed_worker_heartbeats
+       WHERE org_id = $1 AND ($2::text IS NULL OR worker_id = $2)
+       ORDER BY received_at DESC
+       LIMIT $3`,
+      [orgId, input.workerId || null, normalizeListLimit(input.limit, 100, 500)],
+    )
+    return result.rows.map(managedWorkerHeartbeatFromRow)
+  }
+
+  private async one<Row extends QueryRow = QueryRow>(
+    text: string,
+    values?: unknown[],
+    executor: PgExecutor = this.options.pool,
+  ) {
+    const result = await executor.query<Row>(text, values)
+    if (!result.rows[0]) throw new Error('Expected query to return a row.')
+    return result.rows[0]
+  }
+
+  private async maybeOne<Row extends QueryRow = QueryRow>(
+    text: string,
+    values?: unknown[],
+    executor: PgExecutor = this.options.pool,
+  ) {
+    const result = await executor.query<Row>(text, values)
+    return result.rows[0] || null
+  }
+
+  private async recordHeartbeatRejected(
+    executor: PgExecutor,
+    credential: ManagedWorkerCredentialRecord,
+    reason: string,
+    now: Date,
+  ) {
+    await this.options.recordAuditEvent(executor, {
+      orgId: credential.orgId,
+      actorType: 'system',
+      actorId: credential.workerId,
+      eventType: 'managed_worker_heartbeat.rejected',
+      targetType: 'managed_worker',
+      targetId: credential.workerId,
+      metadata: {
+        credentialId: credential.credentialId,
+        poolId: credential.poolId,
+        reason,
+        last4: credential.last4,
+      },
+      createdAt: now,
+    })
+  }
+}
+
+function nowIso(now: Date | undefined) {
+  return (now || new Date()).toISOString()
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([field, entry]) => `${JSON.stringify(field)}:${stableJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function normalizeListLimit(value: number | null | undefined, fallback = 100, max = 500) {
+  if (!Number.isFinite(value)) return fallback
+  return Math.max(1, Math.min(max, Math.floor(value || fallback)))
+}
+
+function normalizeNullablePositiveInteger(value: number | null | undefined, label: string): number | null {
+  if (value === undefined || value === null) return null
+  if (!Number.isInteger(value) || value < 0) throw new Error(`${label} must be a non-negative integer.`)
+  return value
+}
+
+function normalizePoolMode(value: ManagedWorkerPoolMode): ManagedWorkerPoolMode {
+  if (!MANAGED_WORKER_SUPPORTED_POOL_MODES.has(value)) {
+    throw new Error(`Managed worker pool mode ${value} is not supported in v1.`)
+  }
+  return value
+}
+
+function normalizePoolStatus(value: ManagedWorkerPoolStatus | undefined): ManagedWorkerPoolStatus {
+  if (!value) return 'active'
+  if (value === 'active' || value === 'paused' || value === 'retired') return value
+  throw new Error(`Unsupported managed worker pool status ${String(value)}.`)
+}
+
+function normalizeWorkerStatus(value: ManagedWorkerStatus | undefined): ManagedWorkerStatus {
+  if (!value) return 'pending'
+  if (
+    value === 'pending'
+    || value === 'active'
+    || value === 'draining'
+    || value === 'paused'
+    || value === 'retired'
+    || value === 'revoked'
+    || value === 'unhealthy'
+  ) return value
+  throw new Error(`Unsupported managed worker status ${String(value)}.`)
+}
+
+function assertWorkerStatusTransition(from: ManagedWorkerStatus, to: ManagedWorkerStatus) {
+  if (from === to) return
+  const allowed: Record<ManagedWorkerStatus, ManagedWorkerStatus[]> = {
+    pending: ['active', 'revoked'],
+    active: ['draining', 'paused', 'unhealthy', 'retired', 'revoked'],
+    draining: ['active', 'retired', 'revoked', 'unhealthy'],
+    paused: ['active', 'retired', 'revoked'],
+    unhealthy: ['active', 'draining', 'retired', 'revoked'],
+    retired: [],
+    revoked: [],
+  }
+  if (!allowed[from].includes(to)) throw new Error(`Invalid managed worker transition from ${from} to ${to}.`)
+}
+
+function normalizeCredentialScopes(scopes: ManagedWorkerCredentialScope[] | undefined): ManagedWorkerCredentialScope[] {
+  const normalized = [...new Set(scopes?.length ? scopes : ['heartbeat'])]
+  if (normalized.some((scope) => scope !== 'heartbeat')) throw new Error('Managed worker credential scope is unsupported.')
+  return normalized as ManagedWorkerCredentialScope[]
+}
+
+function normalizeMetadata(value: Record<string, unknown> | undefined, label: string) {
+  return normalizeRecord(value || {}, label, MANAGED_WORKER_METADATA_MAX_BYTES)
+}
+
+function normalizeRecord(value: unknown, label: string, maxBytes: number): Record<string, unknown> {
+  const record = jsonRecord(value)
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function normalizeText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (normalized.length > maxLength) throw new Error(`${label} exceeds ${maxLength} characters.`)
+  return normalized
+}
+
+function normalizeNullableText(value: unknown, maxLength: number, label: string): string | null {
+  if (value === undefined || value === null || value === '') return null
+  return normalizeText(value, maxLength, label)
+}
+
+function normalizeNonNegativeInteger(value: unknown, label: string) {
+  const parsed = Number(value ?? 0)
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${label} must be a non-negative integer.`)
+  return parsed
+}
+
+function normalizeIdList(values: readonly unknown[], label: string, maxLength: number) {
+  if (!Array.isArray(values)) throw new Error(`${label} must be an array.`)
+  if (values.length > maxLength) throw new Error(`${label} exceeds ${maxLength} entries.`)
+  return [...new Set(values.map((value) => normalizeText(value, 256, label)))]
+}
+
+function redactOperationalText(value: unknown, maxLength: number, label: string) {
+  return normalizeText(value, maxLength, label)
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password|authorization)=([^\s&]+)/gi, '$1=[redacted]')
+    .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
+    .replace(/\b(sk-[A-Za-z0-9._-]{6,})\b/g, '[redacted]')
+    .replace(/\b(occ_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b(ocw_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
+}

--- a/apps/desktop/src/main/cloud/services/index.ts
+++ b/apps/desktop/src/main/cloud/services/index.ts
@@ -12,6 +12,16 @@ export { CloudWorkflowService } from './workflow-service.ts'
 export type { CloudWorkflowServiceDelegate } from './workflow-service.ts'
 export { CloudProjectionService } from './projection-service.ts'
 export type { AppendProjectedEventInput } from './projection-service.ts'
+export { CloudManagedWorkerService } from './managed-worker-service.ts'
+export type {
+  CreateManagedWorkerPoolRequest,
+  IssuedPublicManagedWorkerCredentialRecord,
+  ListManagedWorkersRequest,
+  ManagedWorkerHeartbeatRequest,
+  PublicManagedWorkerCredentialRecord,
+  RegisterManagedWorkerRequest,
+  UpdateManagedWorkerPoolRequest,
+} from './managed-worker-service.ts'
 export {
   normalizePermissionPayload,
   normalizePromptPayload,

--- a/apps/desktop/src/main/cloud/services/managed-worker-service.ts
+++ b/apps/desktop/src/main/cloud/services/managed-worker-service.ts
@@ -1,0 +1,319 @@
+import type {
+  ControlPlaneStore,
+  ApiTokenScope,
+  ManagedWorkerCredentialRecord,
+  ManagedWorkerHeartbeatRecord,
+  ManagedWorkerPoolMode,
+  ManagedWorkerPoolRecord,
+  ManagedWorkerPoolStatus,
+  ManagedWorkerRecord,
+  ManagedWorkerStatus,
+} from '../control-plane-store.ts'
+import { CloudServiceError } from '../cloud-service-error.ts'
+import type { CloudPrincipal } from '../session-service.ts'
+
+export type PublicManagedWorkerCredentialRecord = Omit<ManagedWorkerCredentialRecord, 'tokenHash'>
+
+export type IssuedPublicManagedWorkerCredentialRecord = {
+  credential: PublicManagedWorkerCredentialRecord
+  plaintext: string
+}
+
+export type CreateManagedWorkerPoolRequest = {
+  poolId?: string
+  name: string
+  mode: ManagedWorkerPoolMode
+  status?: ManagedWorkerPoolStatus
+  tenantId?: string | null
+  region?: string | null
+  capabilities?: Record<string, unknown>
+  maxWorkers?: number | null
+  maxConcurrentWork?: number | null
+}
+
+export type UpdateManagedWorkerPoolRequest = {
+  name?: string
+  status?: ManagedWorkerPoolStatus
+  region?: string | null
+  capabilities?: Record<string, unknown>
+  maxWorkers?: number | null
+  maxConcurrentWork?: number | null
+}
+
+export type RegisterManagedWorkerRequest = {
+  workerId?: string
+  poolId: string
+  tenantId?: string | null
+  displayName: string
+  status?: ManagedWorkerStatus
+  version?: string | null
+  capabilities?: Record<string, unknown>
+}
+
+export type ListManagedWorkersRequest = {
+  poolId?: string | null
+  status?: ManagedWorkerStatus | null
+  limit?: number | null
+}
+
+export type ManagedWorkerHeartbeatRequest = {
+  version?: string | null
+  capabilities?: Record<string, unknown>
+  currentLoad?: number
+  activeWorkIds?: string[]
+  lastErrorCode?: string | null
+  lastErrorSummary?: string | null
+  heartbeatSequence?: number | null
+}
+
+export class CloudManagedWorkerService {
+  private readonly store: ControlPlaneStore
+  private readonly ensurePrincipal: (principal: CloudPrincipal) => Promise<void>
+
+  constructor(
+    store: ControlPlaneStore,
+    ensurePrincipal: (principal: CloudPrincipal) => Promise<void>,
+  ) {
+    this.store = store
+    this.ensurePrincipal = ensurePrincipal
+  }
+
+  async createPool(
+    principal: CloudPrincipal,
+    input: CreateManagedWorkerPoolRequest,
+  ): Promise<ManagedWorkerPoolRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return this.store.createManagedWorkerPool({
+      ...input,
+      orgId: principalOrgId(principal),
+      actor: auditActor(principal),
+    })
+  }
+
+  async updatePool(
+    principal: CloudPrincipal,
+    poolId: string,
+    input: UpdateManagedWorkerPoolRequest,
+  ): Promise<ManagedWorkerPoolRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return this.store.updateManagedWorkerPool({
+      ...input,
+      orgId: principalOrgId(principal),
+      poolId,
+      actor: auditActor(principal),
+    })
+  }
+
+  async listPools(
+    principal: CloudPrincipal,
+    input: { status?: ManagedWorkerPoolStatus | null, limit?: number | null } = {},
+  ): Promise<ManagedWorkerPoolRecord[]> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return this.store.listManagedWorkerPools(principalOrgId(principal), input)
+  }
+
+  async registerWorker(
+    principal: CloudPrincipal,
+    input: RegisterManagedWorkerRequest,
+  ): Promise<ManagedWorkerRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return this.store.registerManagedWorker({
+      ...input,
+      orgId: principalOrgId(principal),
+      actor: auditActor(principal),
+    })
+  }
+
+  async listWorkers(
+    principal: CloudPrincipal,
+    input: ListManagedWorkersRequest = {},
+  ): Promise<ManagedWorkerRecord[]> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return this.store.listManagedWorkers(principalOrgId(principal), input)
+  }
+
+  async getWorker(principal: CloudPrincipal, workerId: string): Promise<ManagedWorkerRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return this.store.getManagedWorker(principalOrgId(principal), workerId)
+  }
+
+  async updateWorkerLifecycle(
+    principal: CloudPrincipal,
+    workerId: string,
+    status: ManagedWorkerStatus,
+    input: { reason?: string | null } = {},
+  ): Promise<ManagedWorkerRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    try {
+      return await this.store.updateManagedWorkerStatus({
+        orgId: principalOrgId(principal),
+        workerId,
+        status,
+        reason: input.reason || null,
+        actor: auditActor(principal),
+      })
+    } catch (error) {
+      if (error instanceof Error && /Invalid managed worker transition/.test(error.message)) {
+        throw new CloudServiceError(400, error.message)
+      }
+      throw error
+    }
+  }
+
+  async issueCredential(
+    principal: CloudPrincipal,
+    workerId: string,
+    input: { scopes?: string[] | null, expiresAt?: Date | null } = {},
+  ): Promise<IssuedPublicManagedWorkerCredentialRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    const issued = await this.store.issueManagedWorkerCredential({
+      orgId: principalOrgId(principal),
+      workerId,
+      scopes: normalizeCredentialScopes(input.scopes),
+      expiresAt: input.expiresAt || undefined,
+      actor: auditActor(principal),
+    })
+    return {
+      credential: publicCredential(issued.credential),
+      plaintext: issued.plaintext,
+    }
+  }
+
+  async listCredentials(
+    principal: CloudPrincipal,
+    workerId: string,
+  ): Promise<PublicManagedWorkerCredentialRecord[]> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return (await this.store.listManagedWorkerCredentials(principalOrgId(principal), workerId))
+      .map(publicCredential)
+  }
+
+  async rotateCredential(
+    principal: CloudPrincipal,
+    workerId: string,
+    credentialId: string,
+    input: { expiresAt?: Date | null } = {},
+  ): Promise<IssuedPublicManagedWorkerCredentialRecord> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    const orgId = principalOrgId(principal)
+    const previous = await this.store.revokeManagedWorkerCredential({
+      orgId,
+      workerId,
+      credentialId,
+      actor: auditActor(principal),
+    })
+    if (!previous) throw new CloudServiceError(404, 'Managed worker credential was not found.')
+    const issued = await this.store.issueManagedWorkerCredential({
+      orgId,
+      workerId,
+      scopes: previous.scopes,
+      expiresAt: input.expiresAt || undefined,
+      rotatedFromCredentialId: previous.credentialId,
+      actor: auditActor(principal),
+    })
+    return {
+      credential: publicCredential(issued.credential),
+      plaintext: issued.plaintext,
+    }
+  }
+
+  async revokeCredential(
+    principal: CloudPrincipal,
+    workerId: string,
+    credentialId: string,
+  ): Promise<PublicManagedWorkerCredentialRecord | null> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    const credential = await this.store.revokeManagedWorkerCredential({
+      orgId: principalOrgId(principal),
+      workerId,
+      credentialId,
+      actor: auditActor(principal),
+    })
+    return credential ? publicCredential(credential) : null
+  }
+
+  async recordHeartbeat(
+    principal: CloudPrincipal,
+    workerId: string,
+    input: ManagedWorkerHeartbeatRequest = {},
+  ): Promise<ManagedWorkerHeartbeatRecord> {
+    if (!principalCanHeartbeatWorker(principal, workerId)) {
+      throw new CloudServiceError(403, 'Managed worker heartbeat requires this worker credential.')
+    }
+    return this.store.recordManagedWorkerHeartbeat({
+      orgId: principalOrgId(principal),
+      workerId,
+      credentialId: principal.workerCredentialId || '',
+      ...input,
+    })
+  }
+
+  async listHeartbeats(
+    principal: CloudPrincipal,
+    input: { workerId?: string | null, limit?: number | null } = {},
+  ): Promise<ManagedWorkerHeartbeatRecord[]> {
+    await this.ensurePrincipal(principal)
+    this.assertWorkerAdmin(principal)
+    return this.store.listManagedWorkerHeartbeats(principalOrgId(principal), input)
+  }
+
+  private assertWorkerAdmin(principal: CloudPrincipal) {
+    if (!principalCanManageWorkers(principal)) {
+      throw new CloudServiceError(403, 'Managed worker administration requires an org admin, operator, or admin-scoped API token.')
+    }
+  }
+}
+
+function hasTokenScope(principal: CloudPrincipal, scope: ApiTokenScope) {
+  return principal.tokenScopes?.includes(scope) || principal.tokenScopes?.includes('admin') || false
+}
+
+function principalCanManageWorkers(principal: CloudPrincipal) {
+  if (principal.authSource === 'local') return true
+  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin') || hasTokenScope(principal, 'operator')
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
+function principalCanHeartbeatWorker(principal: CloudPrincipal, workerId: string) {
+  return principal.authSource === 'worker'
+    && principal.workerId === workerId
+    && (principal.workerScopes || []).includes('heartbeat')
+}
+
+function principalOrgId(principal: CloudPrincipal) {
+  return principal.orgId || principal.tenantId
+}
+
+function auditActor(principal: CloudPrincipal) {
+  return {
+    actorType: principal.authSource === 'api_token' ? 'api_token' as const : 'user' as const,
+    actorId: principal.tokenId || principal.userId,
+    accountId: principal.accountId || principal.userId,
+  }
+}
+
+function normalizeCredentialScopes(scopes: string[] | null | undefined): Array<'heartbeat'> {
+  const normalized = [...new Set(scopes?.length ? scopes : ['heartbeat'])]
+  if (normalized.some((scope) => scope !== 'heartbeat')) {
+    throw new CloudServiceError(400, 'Managed worker credential scope is unsupported.')
+  }
+  return normalized as Array<'heartbeat'>
+}
+
+function publicCredential(
+  credential: ManagedWorkerCredentialRecord,
+): PublicManagedWorkerCredentialRecord {
+  const { tokenHash: _tokenHash, ...publicCredentialRecord } = credential
+  return publicCredentialRecord
+}

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -50,6 +50,8 @@ import type {
   ControlPlaneStore,
   HeadlessAgentRecord,
   IssuedChannelInteractionRecord,
+  ManagedWorkerPoolStatus,
+  ManagedWorkerStatus,
   OrgMemberRecord,
   QuotaPolicyCode,
   SessionCommandRecord,
@@ -63,6 +65,7 @@ import type {
   UsageEventRecord,
   WorkerLeaseRecord,
 } from './control-plane-store.ts'
+import { CloudServiceError } from './cloud-service-error.ts'
 import {
   BillingAdapterError,
   evaluateBillingEntitlement,
@@ -104,6 +107,14 @@ import {
   type QuestionRejectPayload,
   type QuestionReplyPayload,
 } from './services/session-command-service.ts'
+import {
+  CloudManagedWorkerService,
+  type CreateManagedWorkerPoolRequest,
+  type ListManagedWorkersRequest,
+  type ManagedWorkerHeartbeatRequest,
+  type RegisterManagedWorkerRequest,
+  type UpdateManagedWorkerPoolRequest,
+} from './services/managed-worker-service.ts'
 import { computeNextWorkflowRunAt, validateWorkflowSchedule } from '../workflow/workflow-schedule.ts'
 import {
   verifyWorkflowWebhookAuth,
@@ -121,9 +132,13 @@ export type CloudPrincipal = {
   orgId?: string
   accountId?: string
   role?: 'owner' | 'admin' | 'member'
-  authSource?: 'user' | 'api_token' | 'local' | 'header'
+  authSource?: 'user' | 'api_token' | 'local' | 'header' | 'worker'
   tokenId?: string
   tokenScopes?: ApiTokenScope[]
+  workerId?: string
+  workerPoolId?: string
+  workerCredentialId?: string
+  workerScopes?: string[]
 }
 
 export type CloudWorkspaceOverview = {
@@ -325,23 +340,7 @@ export type CloudIdentityPolicy = {
   allowedEmailDomains?: readonly string[]
 }
 
-export class CloudServiceError extends Error {
-  readonly status: number
-  readonly publicMessage: string
-  readonly policyCode: string | null
-  readonly retryAfterMs: number | null
-
-  constructor(status: number, message: string, details: {
-    policyCode?: string | null
-    retryAfterMs?: number | null
-  } = {}) {
-    super(message)
-    this.status = status
-    this.publicMessage = message
-    this.policyCode = details.policyCode || null
-    this.retryAfterMs = details.retryAfterMs || null
-  }
-}
+export { CloudServiceError } from './cloud-service-error.ts'
 
 export type { CloudSessionMessage, CloudSessionProjectionView }
 
@@ -653,6 +652,7 @@ export class CloudSessionService {
   private readonly billingAdapter: BillingAdapter | null
   private readonly identityPolicy: CloudIdentityPolicy
   private readonly projectSources: CloudProjectSourceService | null
+  private readonly managedWorkerService: CloudManagedWorkerService
 
   constructor(
     store: ControlPlaneStore,
@@ -683,6 +683,7 @@ export class CloudSessionService {
     this.billingAdapter = billingAdapter
     this.identityPolicy = identityPolicy
     this.projectSources = projectSources
+    this.managedWorkerService = new CloudManagedWorkerService(store, (principal) => this.ensurePrincipal(principal))
   }
 
   get eventBus() {
@@ -1106,6 +1107,58 @@ export class CloudSessionService {
     await this.ensurePrincipal(principal)
     this.assertOrgAdmin(principal)
     return this.store.listAuditEvents(this.principalOrgId(principal), input.limit || 100)
+  }
+
+  createManagedWorkerPool(principal: CloudPrincipal, input: CreateManagedWorkerPoolRequest) {
+    return this.managedWorkerService.createPool(principal, input)
+  }
+
+  updateManagedWorkerPool(principal: CloudPrincipal, poolId: string, input: UpdateManagedWorkerPoolRequest) {
+    return this.managedWorkerService.updatePool(principal, poolId, input)
+  }
+
+  listManagedWorkerPools(principal: CloudPrincipal, input: { status?: ManagedWorkerPoolStatus | null, limit?: number | null } = {}) {
+    return this.managedWorkerService.listPools(principal, input)
+  }
+
+  registerManagedWorker(principal: CloudPrincipal, input: RegisterManagedWorkerRequest) {
+    return this.managedWorkerService.registerWorker(principal, input)
+  }
+
+  listManagedWorkers(principal: CloudPrincipal, input: ListManagedWorkersRequest = {}) {
+    return this.managedWorkerService.listWorkers(principal, input)
+  }
+
+  getManagedWorker(principal: CloudPrincipal, workerId: string) {
+    return this.managedWorkerService.getWorker(principal, workerId)
+  }
+
+  updateManagedWorkerLifecycle(principal: CloudPrincipal, workerId: string, status: ManagedWorkerStatus, input: { reason?: string | null } = {}) {
+    return this.managedWorkerService.updateWorkerLifecycle(principal, workerId, status, input)
+  }
+
+  issueManagedWorkerCredential(principal: CloudPrincipal, workerId: string, input: { scopes?: string[] | null, expiresAt?: Date | null } = {}) {
+    return this.managedWorkerService.issueCredential(principal, workerId, input)
+  }
+
+  listManagedWorkerCredentials(principal: CloudPrincipal, workerId: string) {
+    return this.managedWorkerService.listCredentials(principal, workerId)
+  }
+
+  rotateManagedWorkerCredential(principal: CloudPrincipal, workerId: string, credentialId: string, input: { expiresAt?: Date | null } = {}) {
+    return this.managedWorkerService.rotateCredential(principal, workerId, credentialId, input)
+  }
+
+  revokeManagedWorkerCredential(principal: CloudPrincipal, workerId: string, credentialId: string) {
+    return this.managedWorkerService.revokeCredential(principal, workerId, credentialId)
+  }
+
+  recordManagedWorkerHeartbeat(principal: CloudPrincipal, workerId: string, input: ManagedWorkerHeartbeatRequest = {}) {
+    return this.managedWorkerService.recordHeartbeat(principal, workerId, input)
+  }
+
+  listManagedWorkerHeartbeats(principal: CloudPrincipal, input: { workerId?: string | null, limit?: number | null } = {}) {
+    return this.managedWorkerService.listHeartbeats(principal, input)
   }
 
   async createSession(principal: CloudPrincipal, input: {
@@ -3840,6 +3893,10 @@ export class CloudSessionService {
       'maxActiveWorkersPerOrg',
     ))
     return limit ? { orgId: org.orgId, limit } : null
+  }
+
+  private auditActor(principal: CloudPrincipal) {
+    return importAuditActor(principal)
   }
 
   private byokAuditActor(principal: CloudPrincipal) {

--- a/docs/managed-workers.md
+++ b/docs/managed-workers.md
@@ -171,6 +171,40 @@ Worker credentials are:
 The worker principal contains `workerId`, `poolId`, tenant scope, credential
 id, scopes, expiry, and status. It does not inherit user/admin authority.
 
+### Phase 1 Control Plane Surface
+
+Phase 1 implements worker identity and lifecycle only. It intentionally does
+not implement work claiming or execution routing.
+
+Admin-managed endpoints:
+
+- `GET /api/admin/worker-pools`
+- `POST /api/admin/worker-pools`
+- `POST /api/admin/worker-pools/{poolId}/update`
+- `GET /api/admin/workers`
+- `POST /api/admin/workers`
+- `GET /api/admin/workers/{workerId}`
+- `POST /api/admin/workers/{workerId}/activate`
+- `POST /api/admin/workers/{workerId}/pause`
+- `POST /api/admin/workers/{workerId}/resume`
+- `POST /api/admin/workers/{workerId}/drain`
+- `POST /api/admin/workers/{workerId}/retire`
+- `POST /api/admin/workers/{workerId}/revoke`
+- `GET /api/admin/workers/{workerId}/credentials`
+- `POST /api/admin/workers/{workerId}/credentials`
+- `POST /api/admin/workers/{workerId}/credentials/{credentialId}/rotate`
+- `POST /api/admin/workers/{workerId}/credentials/{credentialId}/revoke`
+- `GET /api/admin/workers/{workerId}/heartbeats`
+
+Worker self endpoint:
+
+- `POST /api/workers/{workerId}/heartbeat`
+
+Worker credentials authenticate only the worker self endpoint. They cannot call
+tenant admin APIs, Desktop APIs, Gateway APIs, BYOK APIs, billing APIs, or
+work-claim APIs. Raw worker credential values are returned once at issuance and
+are never returned by list/detail APIs.
+
 ## Lease And Fencing Contract
 
 Every claimable work unit must carry or reference:

--- a/tests/cloud-control-plane-store-contracts.test.ts
+++ b/tests/cloud-control-plane-store-contracts.test.ts
@@ -128,6 +128,66 @@ function runControlPlaneDomainContracts(
       assert.equal(runnableClaim.pendingSessionCount >= 1, true)
       assert.equal(runnableClaim.leases.some((lease) => lease.sessionId === sessionId), true)
 
+      const workerPool = await store.createManagedWorkerPool({
+        poolId: `${prefix}-pool`,
+        orgId: org.orgId,
+        tenantId,
+        name: 'Managed pool',
+        mode: 'self_hosted',
+        capabilities: { profiles: ['default'] },
+        actor: { actorType: 'user', actorId: accountId, accountId },
+      })
+      assert.equal(workerPool.status, 'active')
+      const managedWorker = await store.registerManagedWorker({
+        workerId: `${prefix}-managed-worker`,
+        orgId: org.orgId,
+        poolId: workerPool.poolId,
+        displayName: 'Managed worker',
+        capabilities: { runtime: 'opencode' },
+        actor: { actorType: 'user', actorId: accountId, accountId },
+      })
+      assert.equal(managedWorker.status, 'pending')
+      await store.updateManagedWorkerStatus({
+        orgId: org.orgId,
+        workerId: managedWorker.workerId,
+        status: 'active',
+        actor: { actorType: 'user', actorId: accountId, accountId },
+      })
+      const issuedWorkerCredential = await store.issueManagedWorkerCredential({
+        orgId: org.orgId,
+        workerId: managedWorker.workerId,
+        secret: `${prefix}-worker-secret`,
+        actor: { actorType: 'user', actorId: accountId, accountId },
+      })
+      assert.match(issuedWorkerCredential.plaintext, /^ocw_/)
+      assert.notEqual(issuedWorkerCredential.credential.tokenHash, issuedWorkerCredential.plaintext)
+      const resolvedWorkerCredential = await store.findManagedWorkerCredentialByPlaintext(issuedWorkerCredential.plaintext)
+      assert.equal(resolvedWorkerCredential?.worker.workerId, managedWorker.workerId)
+      const heartbeat = await store.recordManagedWorkerHeartbeat({
+        orgId: org.orgId,
+        workerId: managedWorker.workerId,
+        credentialId: issuedWorkerCredential.credential.credentialId,
+        version: 'test-version',
+        currentLoad: 1,
+        activeWorkIds: ['work-1', 'work-1'],
+      })
+      assert.deepEqual(heartbeat.activeWorkIds, ['work-1'])
+      assert.equal((await store.listManagedWorkerHeartbeats(org.orgId, { workerId: managedWorker.workerId })).length, 1)
+      const revokedWorkerCredential = await store.revokeManagedWorkerCredential({
+        orgId: org.orgId,
+        workerId: managedWorker.workerId,
+        credentialId: issuedWorkerCredential.credential.credentialId,
+        actor: { actorType: 'user', actorId: accountId, accountId },
+      })
+      assert.equal(revokedWorkerCredential?.revokedAt !== null, true)
+      assert.equal(await store.findManagedWorkerCredentialByPlaintext(issuedWorkerCredential.plaintext), null)
+      const heartbeatRejectionAudit = await store.listAuditEvents(org.orgId, 20)
+      assert.equal(heartbeatRejectionAudit.some((auditEvent) => (
+        auditEvent.eventType === 'managed_worker_heartbeat.rejected'
+        && auditEvent.metadata.reason === 'credential_revoked'
+      )), true)
+      assert.equal(JSON.stringify(heartbeatRejectionAudit).includes(issuedWorkerCredential.plaintext), false)
+
       await store.createHeadlessAgent({
         orgId: org.orgId,
         tenantId,

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -683,6 +683,105 @@ test('cloud control plane resolves org accounts memberships, tokens, and audit e
   assert.equal(store.listAuditEvents(org.orgId).some((event) => event.eventType === 'api_token.created'), true)
 })
 
+test('cloud control plane manages worker lifecycle credentials and heartbeats', () => {
+  const store = seededStore()
+  const org = store.ensureOrgForTenant({ tenantId: 'tenant-1', orgId: 'org-1', name: 'Acme' })
+
+  assert.throws(
+    () => store.createManagedWorkerPool({
+      orgId: org.orgId,
+      name: 'External pool',
+      mode: 'customer_hosted',
+    }),
+    /not supported in v1/,
+  )
+
+  const pool = store.createManagedWorkerPool({
+    poolId: 'pool-1',
+    orgId: org.orgId,
+    name: 'Internal pool',
+    mode: 'self_hosted',
+    maxWorkers: 3,
+    maxConcurrentWork: 6,
+    actor: { actorType: 'user', actorId: 'user-1', accountId: 'user-1' },
+  })
+  assert.equal(pool.status, 'active')
+  assert.equal(store.listManagedWorkerPools(org.orgId)[0]?.poolId, 'pool-1')
+
+  const worker = store.registerManagedWorker({
+    workerId: 'worker-1',
+    orgId: org.orgId,
+    poolId: pool.poolId,
+    displayName: 'Worker one',
+  })
+  assert.equal(worker.status, 'pending')
+  assert.throws(
+    () => store.updateManagedWorkerStatus({ orgId: org.orgId, workerId: worker.workerId, status: 'draining' }),
+    /Invalid managed worker transition/,
+  )
+  assert.equal(store.updateManagedWorkerStatus({ orgId: org.orgId, workerId: worker.workerId, status: 'active' })?.status, 'active')
+  assert.equal(store.updateManagedWorkerStatus({ orgId: org.orgId, workerId: worker.workerId, status: 'paused' })?.status, 'paused')
+  assert.equal(store.updateManagedWorkerStatus({ orgId: org.orgId, workerId: worker.workerId, status: 'active' })?.status, 'active')
+
+  assert.throws(
+    () => store.issueManagedWorkerCredential({
+      orgId: org.orgId,
+      workerId: worker.workerId,
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+      expiresAt: new Date('2026-01-01T00:00:00.000Z'),
+    }),
+    /expiration must be in the future/,
+  )
+
+  const issued = store.issueManagedWorkerCredential({
+    orgId: org.orgId,
+    workerId: worker.workerId,
+    secret: 'managed-worker-secret',
+  })
+  assert.match(issued.plaintext, /^ocw_/)
+  assert.equal(store.listManagedWorkerCredentials(org.orgId, worker.workerId)[0]?.tokenHash.includes(issued.plaintext), false)
+  assert.equal(store.findManagedWorkerCredentialByPlaintext(issued.plaintext)?.worker.workerId, worker.workerId)
+
+  const heartbeat = store.recordManagedWorkerHeartbeat({
+    orgId: org.orgId,
+    workerId: worker.workerId,
+    credentialId: issued.credential.credentialId,
+    version: '1.0.0',
+    currentLoad: 2,
+    activeWorkIds: ['run-1', 'run-1'],
+    lastErrorSummary: 'token=secret should redact',
+    heartbeatSequence: 7,
+  })
+  assert.deepEqual(heartbeat.activeWorkIds, ['run-1'])
+  assert.equal(heartbeat.currentLoad, 2)
+  assert.equal(JSON.stringify(heartbeat).includes('secret'), false)
+
+  const revokedCredential = store.revokeManagedWorkerCredential({
+    orgId: org.orgId,
+    workerId: worker.workerId,
+    credentialId: issued.credential.credentialId,
+  })
+  assert.equal(revokedCredential?.revokedAt !== null, true)
+  assert.equal(store.findManagedWorkerCredentialByPlaintext(issued.plaintext), null)
+  const heartbeatRejectionAudit = store.listAuditEvents(org.orgId, 20)
+  assert.equal(heartbeatRejectionAudit.some((event) => (
+    event.eventType === 'managed_worker_heartbeat.rejected'
+    && event.metadata.reason === 'credential_revoked'
+  )), true)
+  assert.equal(JSON.stringify(heartbeatRejectionAudit).includes(issued.plaintext), false)
+  assert.throws(
+    () => store.recordManagedWorkerHeartbeat({
+      orgId: org.orgId,
+      workerId: worker.workerId,
+      credentialId: issued.credential.credentialId,
+    }),
+    /revoked/,
+  )
+
+  assert.equal(store.updateManagedWorkerStatus({ orgId: org.orgId, workerId: worker.workerId, status: 'revoked' })?.status, 'revoked')
+  assert.equal(store.listAuditEvents(org.orgId).some((event) => event.eventType === 'managed_worker.revoked'), true)
+})
+
 test('cloud control plane stores headless channel bindings, interactions, cursors, and deliveries', () => {
   const store = seededStore()
   const org = store.ensureOrgForTenant({ tenantId: 'tenant-1', name: 'Acme' })

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import { DEFAULT_CONFIG, type CloudAbuseConfig, type CloudBillingConfig } from '../apps/desktop/src/main/config-types.ts'
 import { CloudArtifactService } from '../apps/desktop/src/main/cloud/artifact-service.ts'
 import type { BillingAdapter } from '../apps/desktop/src/main/cloud/billing-adapter.ts'
-import { createApiTokenCloudAuthResolver } from '../apps/desktop/src/main/cloud/app.ts'
+import { createApiTokenCloudAuthResolver, createManagedWorkerCloudAuthResolver } from '../apps/desktop/src/main/cloud/app.ts'
 import { createByokSecretStore, type ByokSecretStoreOptions } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
 import { resolveCloudRuntimePolicy, type CloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
 import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/control-plane-store.ts'
@@ -122,6 +122,7 @@ function createFixture(options: {
     randomUUID: () => `artifact-${nextId += 1}`,
   })
   const worker = new CloudWorker(store, service, 'worker-1', 30_000, {}, options.abuse || null, options.observability || null)
+  const workerAuth = createManagedWorkerCloudAuthResolver(store)
   const server = createCloudHttpServer({
     service,
     artifacts,
@@ -135,16 +136,20 @@ function createFixture(options: {
       desktopAuth: options.desktopAuth,
       observability: options.observability,
       internalToken: options.internalToken,
-      auth: options.auth || (() => ({
-      tenantId: 'tenant-1',
-      tenantName: 'Tenant 1',
-      orgId: 'tenant-1',
-      userId: 'user-1',
-      accountId: 'user-1',
-      email: 'user@example.test',
-      role: 'owner',
-      authSource: 'local',
-    })),
+      auth: options.auth || (async (req) => {
+        const authorization = String(req.headers.authorization || '')
+        if (authorization.startsWith('Bearer ocw_')) return workerAuth(req)
+        return {
+          tenantId: 'tenant-1',
+          tenantName: 'Tenant 1',
+          orgId: 'tenant-1',
+          userId: 'user-1',
+          accountId: 'user-1',
+          email: 'user@example.test',
+          role: 'owner',
+          authSource: 'local',
+        }
+      }),
   })
   return { runtime, store, objectStore, policy, service, artifacts, worker, server }
 }
@@ -1877,6 +1882,111 @@ test('cloud HTTP admin APIs manage invited members and expose redacted audit', a
     assert.match(auditText, /membership\.updated/)
     assert.equal(auditText.includes('occ_'), false)
     assert.equal(auditText.includes('sk-'), false)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP admin APIs manage managed worker lifecycle and worker heartbeat auth', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  try {
+    await readJson(await fetch(`${baseUrl}/api/workspace`))
+
+    const poolResponse = await fetch(`${baseUrl}/api/admin/worker-pools`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        poolId: 'pool-1',
+        name: 'Internal pool',
+        mode: 'self_hosted',
+        capabilities: { profiles: ['default'] },
+        maxWorkers: 2,
+      }),
+    })
+    assert.equal(poolResponse.status, 201)
+    assert.equal(asRecord(asRecord(await readJson(poolResponse)).pool).poolId, 'pool-1')
+
+    const unsupportedPool = await fetch(`${baseUrl}/api/admin/worker-pools`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'External pool', mode: 'customer_hosted' }),
+    })
+    assert.equal(unsupportedPool.status, 400)
+
+    const workerResponse = await fetch(`${baseUrl}/api/admin/workers`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        workerId: 'worker-1',
+        poolId: 'pool-1',
+        displayName: 'Worker one',
+      }),
+    })
+    assert.equal(workerResponse.status, 201)
+    assert.equal(asRecord(asRecord(await readJson(workerResponse)).worker).status, 'pending')
+
+    const invalidDrain = await fetch(`${baseUrl}/api/admin/workers/worker-1/drain`, { method: 'POST' })
+    assert.equal(invalidDrain.status, 400)
+
+    const active = await fetch(`${baseUrl}/api/admin/workers/worker-1/activate`, { method: 'POST' })
+    assert.equal(active.status, 200)
+    assert.equal(asRecord(asRecord(await readJson(active)).worker).status, 'active')
+
+    const credentialResponse = await fetch(`${baseUrl}/api/admin/workers/worker-1/credentials`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ scopes: ['heartbeat'] }),
+    })
+    assert.equal(credentialResponse.status, 201)
+    const issued = asRecord(asRecord(await readJson(credentialResponse)).credential)
+    const credential = asRecord(issued.credential)
+    const plaintext = String(issued.plaintext)
+    assert.match(plaintext, /^ocw_/)
+    assert.equal(JSON.stringify(credential).includes('tokenHash'), false)
+
+    const heartbeatResponse = await fetch(`${baseUrl}/api/workers/worker-1/heartbeat`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${plaintext}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        version: '1.0.0',
+        currentLoad: 1,
+        activeWorkIds: ['cmd-1'],
+      }),
+    })
+    assert.equal(heartbeatResponse.status, 200)
+    assert.equal(asRecord(asRecord(await readJson(heartbeatResponse)).heartbeat).currentLoad, 1)
+
+    const blockedAdmin = await fetch(`${baseUrl}/api/admin/worker-pools`, {
+      headers: { authorization: `Bearer ${plaintext}` },
+    })
+    assert.equal(blockedAdmin.status, 403)
+
+    const listedHeartbeats = asArray((await readJson(await fetch(`${baseUrl}/api/admin/workers/worker-1/heartbeats`))).heartbeats)
+    assert.equal(listedHeartbeats.length, 1)
+
+    const revokeCredential = await fetch(`${baseUrl}/api/admin/workers/worker-1/credentials/${encodeURIComponent(String(credential.credentialId))}/revoke`, {
+      method: 'POST',
+    })
+    assert.equal(revokeCredential.status, 200)
+    const rejectedHeartbeat = await fetch(`${baseUrl}/api/workers/worker-1/heartbeat`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${plaintext}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ version: '1.0.1' }),
+    })
+    assert.equal(rejectedHeartbeat.status, 401)
+
+    const audit = asArray((await readJson(await fetch(`${baseUrl}/api/admin/audit?limit=100`))).events)
+    const auditText = JSON.stringify(audit)
+    assert.match(auditText, /managed_worker_pool\.created/)
+    assert.match(auditText, /managed_worker_credential\.revoked/)
+    assert.equal(auditText.includes(plaintext), false)
   } finally {
     await fixture.server.close()
   }

--- a/tests/cloud-modularity-boundaries.test.ts
+++ b/tests/cloud-modularity-boundaries.test.ts
@@ -41,6 +41,7 @@ test('cloud core has enforceable domain module boundaries', () => {
     'shared.ts',
     'thread-index.ts',
     'webhooks.ts',
+    'workers.ts',
     'workflows.ts',
   ]
   for (const file of expectedPostgresDomains) {
@@ -70,6 +71,7 @@ test('cloud core has enforceable domain module boundaries', () => {
     'channel-service.ts',
     'workflow-service.ts',
     'projection-service.ts',
+    'managed-worker-service.ts',
     'session-command-service.ts',
   ]
   for (const file of expectedServices) {
@@ -133,6 +135,7 @@ test('postgres store delegates row mapping to domain modules', () => {
   assert.match(source, /postgres-domains\/identity\.ts/)
   assert.match(source, /postgres-domains\/sessions\.ts/)
   assert.match(source, /postgres-domains\/channels\.ts/)
+  assert.match(source, /postgres-store-domains\/workers\.ts/)
   assert.match(source, /postgres-domains\/workflows\.ts/)
 
   for (const file of sourceFiles(join(cloudRoot, 'postgres-domains'))) {

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -95,6 +95,7 @@ test('real Postgres cloud store serializes concurrent schema migrations', {
         '005_usage_quotas_rate_limits',
         '006_billing_subscriptions',
         '007_scale_foundation',
+        '008_managed_workers',
       ])
     } finally {
       await Promise.all(stores.map((store) => store.close?.()))


### PR DESCRIPTION
Closes #533.

## Summary
- add managed worker pools, workers, credentials, heartbeat records, lifecycle transitions, and audit events to the cloud control plane
- expose operator/admin HTTP APIs for pool and worker lifecycle plus a scoped worker heartbeat API
- authenticate managed worker bearer credentials without granting desktop/admin API access
- split the worker domain into focused in-memory, Postgres, route, service, and mapper modules to keep cloud boundaries enforceable
- document the Phase 1 managed-worker contract and add contract/HTTP/modularity coverage

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- python3 -m mkdocs build --strict
- node --no-warnings --experimental-strip-types --test tests/cloud-control-plane-store.test.ts tests/cloud-control-plane-store-contracts.test.ts tests/cloud-http-server.test.ts tests/cloud-modularity-boundaries.test.ts tests/managed-worker-architecture.test.ts tests/opencode-sdk-boundary.test.ts
- git diff --check