### PR TITLE
Recover managed workflow starts safely

### DIFF
--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -3780,9 +3780,18 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const workflow = this.requireWorkflow(input.tenantId, input.workflowId)
     const run = this.workflowRuns.get(key(input.tenantId, input.runId))
     if (!run || run.workflowId !== input.workflowId) return null
+    if (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled') {
+      throw new Error('Workflow run is not attachable.')
+    }
+    if (run.status !== 'queued' && !(run.status === 'running' && run.sessionId === input.sessionId)) {
+      throw new Error('Workflow run is not attachable.')
+    }
+    if (run.sessionId && run.sessionId !== input.sessionId) throw new Error('Workflow run is already attached to another session.')
     if (run.claimToken) {
       if (run.claimToken !== (input.claimToken ?? null)) throw new Error('Workflow run claim is stale.')
       if (run.claimExpiresAt && Date.parse(run.claimExpiresAt) <= Date.now()) throw new Error('Workflow run claim is stale.')
+    } else if (input.claimToken) {
+      throw new Error('Workflow run claim is stale.')
     }
     const startedAt = nowIso(input.startedAt)
     run.sessionId = input.sessionId

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -3643,9 +3643,12 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const leaseTtlMs = Math.max(1, Math.floor(input.leaseTtlMs ?? 30_000))
     const retryRun = Array.from(this.workflowRuns.values())
       .filter((run) => (
-        run.triggerType === 'schedule'
-        && run.status === 'queued'
-        && run.sessionId === null
+        this.workflows.get(key(run.tenantId, run.workflowId))?.record.status === 'running'
+        &&
+        (
+          (run.status === 'queued' && run.sessionId === null)
+          || (run.status === 'running' && run.sessionId !== null && !this.sessionHasCommands(run.tenantId, run.sessionId))
+        )
         && run.claimToken === null
       ))
       .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id))[0]
@@ -3660,6 +3663,7 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       workflow.record.status = 'running'
       workflow.record.latestRunId = retryRun.id
       workflow.record.latestRunStatus = retryRun.status
+      workflow.record.latestRunSessionId = retryRun.sessionId
       workflow.record.updatedAt = claimedAt
       return {
         workflow: clone(workflow.record),
@@ -3722,7 +3726,10 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const reaped: ReapedWorkflowClaimRecord[] = []
     for (const run of this.workflowRuns.values()) {
       if (!run.claimToken || !run.claimExpiresAt || Date.parse(run.claimExpiresAt) > now.getTime()) continue
-      if (run.status !== 'queued' || run.sessionId) continue
+      if (
+        !(run.status === 'queued' && run.sessionId === null)
+        && !(run.status === 'running' && run.sessionId !== null && !this.sessionHasCommands(run.tenantId, run.sessionId))
+      ) continue
       const workflow = this.workflows.get(key(run.tenantId, run.workflowId))
       if (!workflow) continue
       const claimToken = run.claimToken
@@ -3747,9 +3754,12 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
         run.claimToken = null
         run.claimExpiresAt = null
         run.lastErrorCode = 'claim_expired'
-        run.lastErrorSummary = 'Workflow run claim expired before session attachment.'
+        run.lastErrorSummary = run.sessionId
+          ? 'Workflow run claim expired before command enqueue.'
+          : 'Workflow run claim expired before session attachment.'
         workflow.record.status = 'running'
-        workflow.record.latestRunStatus = 'queued'
+        workflow.record.latestRunStatus = run.status
+        workflow.record.latestRunSessionId = run.sessionId
       }
       workflow.record.latestRunId = run.id
       workflow.record.updatedAt = nowIsoValue
@@ -4095,6 +4105,11 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const command = session.commands.find((entry) => entry.commandId === commandId)
     if (!command) throw new Error(`Unknown command ${commandId}.`)
     return command
+  }
+
+  private sessionHasCommands(tenantId: string, sessionId: string) {
+    const session = this.sessions.get(key(tenantId, sessionId))
+    return Boolean(session?.commands.length)
   }
 
   private assertUniqueThreadTagName(tenantId: string, tagId: string, name: string) {

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -3409,11 +3409,20 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       )
       if (!runRow) return null
       const current = workflowRunFromRow(runRow)
+      if (current.status === 'completed' || current.status === 'failed' || current.status === 'cancelled') {
+        throw new Error('Workflow run is not attachable.')
+      }
+      if (current.status !== 'queued' && !(current.status === 'running' && current.sessionId === input.sessionId)) {
+        throw new Error('Workflow run is not attachable.')
+      }
+      if (current.sessionId && current.sessionId !== input.sessionId) throw new Error('Workflow run is already attached to another session.')
       if (current.claimToken) {
         if (current.claimToken !== (input.claimToken ?? null)) throw new Error('Workflow run claim is stale.')
         if (current.claimExpiresAt && Date.parse(current.claimExpiresAt) <= Date.now()) {
           throw new Error('Workflow run claim is stale.')
         }
+      } else if (input.claimToken) {
+        throw new Error('Workflow run claim is stale.')
       }
       const startedAt = nowIso(input.startedAt)
       const result = await client.query(

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -3177,10 +3177,20 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
          JOIN cloud_workflows workflows
            ON workflows.tenant_id = runs.tenant_id
           AND workflows.workflow_id = runs.workflow_id
-         WHERE runs.trigger_type = 'schedule'
-           AND runs.status = 'queued'
-           AND runs.session_id IS NULL
-           AND runs.claim_token IS NULL
+         WHERE runs.claim_token IS NULL
+           AND (
+             (runs.status = 'queued' AND runs.session_id IS NULL)
+             OR (
+               runs.status = 'running'
+               AND runs.session_id IS NOT NULL
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM cloud_session_commands commands
+                 WHERE commands.tenant_id = runs.tenant_id
+                   AND commands.session_id = runs.session_id
+               )
+             )
+           )
            AND workflows.status = 'running'
          ORDER BY runs.created_at ASC, runs.run_id
          FOR UPDATE OF runs, workflows SKIP LOCKED
@@ -3192,6 +3202,8 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
         const runId = String(retryRow.run_id)
         const tenantId = String(retryRow.tenant_id)
         const workflowId = String(retryRow.workflow_id)
+        const retryStatus = String(retryRow.status)
+        const retrySessionId = retryRow.session_id ? String(retryRow.session_id) : null
         const claimToken = createWorkClaimToken(tenantId, runId, claimedBy)
         const updatedRun = await client.query(
           `UPDATE cloud_workflow_runs
@@ -3209,11 +3221,12 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
           `UPDATE cloud_workflows
            SET status = 'running',
                latest_run_id = $3,
-               latest_run_status = 'queued',
-               updated_at = $4
+               latest_run_status = $4,
+               latest_run_session_id = $5,
+               updated_at = $6
            WHERE tenant_id = $1 AND workflow_id = $2
            RETURNING *`,
-          [tenantId, workflowId, runId, claimedAt],
+          [tenantId, workflowId, runId, retryStatus, retrySessionId, claimedAt],
         )
         return {
           workflow: workflowFromRow(updatedWorkflow.rows[0]),
@@ -3289,8 +3302,19 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
          WHERE claim_token IS NOT NULL
            AND claim_expires_at IS NOT NULL
            AND claim_expires_at <= $1
-           AND status = 'queued'
-           AND session_id IS NULL
+           AND (
+             (status = 'queued' AND session_id IS NULL)
+             OR (
+               status = 'running'
+               AND session_id IS NOT NULL
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM cloud_session_commands commands
+                 WHERE commands.tenant_id = cloud_workflow_runs.tenant_id
+                   AND commands.session_id = cloud_workflow_runs.session_id
+               )
+             )
+           )
          ORDER BY claim_expires_at ASC, tenant_id, workflow_id, run_id
          FOR UPDATE SKIP LOCKED`,
         [nowIsoValue],
@@ -3337,18 +3361,26 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
                  claim_token = NULL,
                  claim_expires_at = NULL,
                  last_error_code = 'claim_expired',
-                 last_error_summary = 'Workflow run claim expired before session attachment.'
+                 last_error_summary = $4
              WHERE tenant_id = $1 AND workflow_id = $2 AND run_id = $3`,
-            [run.tenantId, run.workflowId, run.id],
+            [
+              run.tenantId,
+              run.workflowId,
+              run.id,
+              run.sessionId
+                ? 'Workflow run claim expired before command enqueue.'
+                : 'Workflow run claim expired before session attachment.',
+            ],
           )
           await client.query(
             `UPDATE cloud_workflows
              SET status = 'running',
                  latest_run_id = $3,
-                 latest_run_status = 'queued',
-                 updated_at = $4
+                 latest_run_status = $4,
+                 latest_run_session_id = $5,
+                 updated_at = $6
              WHERE tenant_id = $1 AND workflow_id = $2`,
-            [run.tenantId, run.workflowId, run.id, nowIsoValue],
+            [run.tenantId, run.workflowId, run.id, run.status, run.sessionId, nowIsoValue],
           )
         }
         reaped.push({

--- a/apps/desktop/src/main/cloud/services/workflow-service.ts
+++ b/apps/desktop/src/main/cloud/services/workflow-service.ts
@@ -19,7 +19,7 @@ export type CloudWorkflowServiceDelegate = {
     triggerType?: WorkflowTriggerType
     triggerPayload?: Record<string, unknown> | null
   }): Promise<CloudWorkflowStartResult>
-  claimAndStartDueWorkflow(now?: Date): Promise<CloudWorkflowStartResult | null>
+  claimAndStartDueWorkflow(now?: Date, claimedBy?: string | null): Promise<CloudWorkflowStartResult | null>
   runWorkflowWebhook(input: CloudWorkflowWebhookInput): Promise<CloudWorkflowStartResult>
 }
 
@@ -39,7 +39,7 @@ export class CloudWorkflowService {
   run(principal: CloudPrincipal, workflowId: string, input: { triggerType?: WorkflowTriggerType, triggerPayload?: Record<string, unknown> | null }) {
     return this.delegate.runWorkflow(principal, workflowId, input)
   }
-  claimAndStartDue(now?: Date) { return this.delegate.claimAndStartDueWorkflow(now) }
+  claimAndStartDue(now?: Date, claimedBy?: string | null) { return this.delegate.claimAndStartDueWorkflow(now, claimedBy) }
   runWebhook(input: CloudWorkflowWebhookInput) {
     return this.delegate.runWorkflowWebhook(input)
   }

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -2483,6 +2483,7 @@ export class CloudSessionService {
       runId: this.ids.randomUUID(),
       triggerType,
       triggerPayload: input.triggerPayload || null,
+      claimedBy: `workflow-api:${principal.userId}`,
     })
     return this.startWorkflowRun(workflow, run)
   }
@@ -2537,6 +2538,7 @@ export class CloudSessionService {
         runId: this.ids.randomUUID(),
         triggerType: 'webhook',
         triggerPayload: input.payload,
+        claimedBy: `workflow-webhook:${workflow.id}`,
       })
       const started = await this.startWorkflowRun(workflow, run)
       await replayClaim.accept()
@@ -3671,6 +3673,7 @@ export class CloudSessionService {
     const session = await this.createCloudSessionRecord({
       tenantId: workflow.tenantId,
       userId: workflow.userId,
+      sessionId: run.sessionId || undefined,
       profileName: this.policy.profileName,
       title: `Run ${workflow.title}`,
     })
@@ -3682,7 +3685,7 @@ export class CloudSessionService {
       claimToken: run.claimToken,
     })
     const command = await this.store.enqueueSessionCommand({
-      commandId: this.ids.randomUUID(),
+      commandId: this.workflowPromptCommandId(workflow, run),
       tenantId: workflow.tenantId,
       userId: workflow.userId,
       sessionId: session.sessionId,
@@ -3703,6 +3706,10 @@ export class CloudSessionService {
       sessionId: session.sessionId,
       command,
     }
+  }
+
+  private workflowPromptCommandId(workflow: CloudWorkflowRecord, run: CloudWorkflowRunRecord) {
+    return `workflow:${workflow.tenantId}:${workflow.id}:${run.id}:prompt`
   }
 
   private workflowSummaryFromRuntimeEvents(events: CloudRuntimeEvent[]) {

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -1447,6 +1447,93 @@ test('cloud control plane recovers expired webhook workflow start claims', () =>
   assert.notEqual(second?.run.claimToken, first.claimToken)
 })
 
+test('cloud control plane rejects stale workflow attaches after expired claims are cleared', () => {
+  const store = seededStore()
+  store.createWorkflow({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-stale-attach',
+    draft: {
+      title: 'Stale attach workflow',
+      instructions: 'Do not attach stale starters.',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+    },
+  })
+  const first = store.createWorkflowRun({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-stale-attach',
+    runId: 'stale-attach-run',
+    triggerType: 'manual',
+    claimedBy: 'workflow-api:user-1',
+    leaseTtlMs: 1,
+    createdAt: new Date('2030-01-01T09:00:00.000Z'),
+  })
+  assert.ok(first.claimToken)
+  assert.equal(store.reapExpiredWorkflowClaims({
+    maxAttempts: 2,
+    now: new Date('2030-01-01T09:00:00.002Z'),
+  })[0]?.action, 'retried')
+  assert.equal(store.getWorkflowRun('tenant-1', 'stale-attach-run')?.claimToken, null)
+  assert.throws(() => store.attachWorkflowRunSession({
+    tenantId: 'tenant-1',
+    workflowId: 'workflow-stale-attach',
+    runId: 'stale-attach-run',
+    sessionId: 'session-1',
+    claimToken: first.claimToken,
+  }), /stale/)
+
+  store.createWorkflow({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-terminal-stale-attach',
+    draft: {
+      title: 'Terminal stale attach workflow',
+      instructions: 'Do not attach failed runs.',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+    },
+  })
+  const terminal = store.createWorkflowRun({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-terminal-stale-attach',
+    runId: 'terminal-stale-attach-run',
+    triggerType: 'manual',
+    claimedBy: 'workflow-api:user-1',
+    leaseTtlMs: 1,
+    createdAt: new Date('2030-01-01T09:00:00.000Z'),
+  })
+  assert.ok(terminal.claimToken)
+  assert.equal(store.reapExpiredWorkflowClaims({
+    maxAttempts: 1,
+    now: new Date('2030-01-01T09:00:00.002Z'),
+  }).find((record) => record.runId === 'terminal-stale-attach-run')?.action, 'failed')
+  assert.equal(store.getWorkflowRun('tenant-1', 'terminal-stale-attach-run')?.status, 'failed')
+  assert.throws(() => store.attachWorkflowRunSession({
+    tenantId: 'tenant-1',
+    workflowId: 'workflow-terminal-stale-attach',
+    runId: 'terminal-stale-attach-run',
+    sessionId: 'session-1',
+    claimToken: terminal.claimToken,
+  }), /not attachable/)
+  assert.throws(() => store.attachWorkflowRunSession({
+    tenantId: 'tenant-1',
+    workflowId: 'workflow-terminal-stale-attach',
+    runId: 'terminal-stale-attach-run',
+    sessionId: 'session-1',
+  }), /not attachable/)
+})
+
 test('cloud control plane recovers workflow starts stranded after session attachment', () => {
   const store = seededStore()
   store.createWorkflow({

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -1202,6 +1202,77 @@ test('cloud control plane persists workflow runs and finalizes workflow state du
   assert.equal(store.listWorkflowRuns('tenant-1', 'workflow-1')[0]?.id, 'run-1')
 })
 
+test('cloud control plane fences workflow finalization by active worker lease', () => {
+  const store = seededStore()
+  store.createWorkflow({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-fenced-finalize',
+    draft: {
+      title: 'Fenced workflow',
+      instructions: 'Finalize once.',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+    },
+  })
+  store.createWorkflowRun({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-fenced-finalize',
+    runId: 'run-fenced-finalize',
+    triggerType: 'manual',
+  })
+  store.attachWorkflowRunSession({
+    tenantId: 'tenant-1',
+    workflowId: 'workflow-fenced-finalize',
+    runId: 'run-fenced-finalize',
+    sessionId: 'session-1',
+  })
+  const staleLease = store.claimSessionLease(
+    'tenant-1',
+    'session-1',
+    'worker-stale',
+    new Date('2030-01-01T09:00:00.000Z'),
+    1,
+  )
+  assert.ok(staleLease)
+  const currentLease = store.claimSessionLease(
+    'tenant-1',
+    'session-1',
+    'worker-current',
+    new Date('2030-01-01T09:00:00.002Z'),
+    30_000,
+  )
+  assert.ok(currentLease)
+
+  assert.throws(() => store.completeWorkflowRun({
+    tenantId: 'tenant-1',
+    workflowId: 'workflow-fenced-finalize',
+    runId: 'run-fenced-finalize',
+    summary: 'stale result',
+    nextStatus: 'active',
+    nextRunAt: null,
+    leaseToken: staleLease.leaseToken,
+  }), /stale/)
+  assert.equal(store.getWorkflowRun('tenant-1', 'run-fenced-finalize')?.status, 'running')
+
+  const completed = store.completeWorkflowRun({
+    tenantId: 'tenant-1',
+    workflowId: 'workflow-fenced-finalize',
+    runId: 'run-fenced-finalize',
+    summary: 'current result',
+    nextStatus: 'active',
+    nextRunAt: null,
+    leaseToken: currentLease.leaseToken,
+  })
+  assert.equal(completed?.status, 'completed')
+  assert.equal(completed?.summary, 'current result')
+})
+
 test('cloud control plane atomically claims a due scheduled workflow run once', () => {
   const store = seededStore()
   store.createWorkflow({
@@ -1319,4 +1390,122 @@ test('cloud control plane reaps and retries expired scheduled workflow claims', 
   assert.equal(failed[0]?.action, 'failed')
   assert.equal(store.getWorkflowForTenant('tenant-1', 'workflow-retry')?.status, 'failed')
   assert.equal(store.getWorkflowRun('tenant-1', 'workflow-run-retry')?.status, 'failed')
+})
+
+test('cloud control plane recovers expired webhook workflow start claims', () => {
+  const store = seededStore()
+  store.createWorkflow({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-webhook-retry',
+    draft: {
+      title: 'Webhook workflow',
+      instructions: 'Run from webhook.',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [{
+        id: 'webhook-1',
+        type: 'webhook',
+        enabled: true,
+        webhookSecret: 'secret',
+      }],
+    },
+  })
+
+  const first = store.createWorkflowRun({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-webhook-retry',
+    runId: 'webhook-run-retry',
+    triggerType: 'webhook',
+    triggerPayload: { source: 'test' },
+    claimedBy: 'workflow-webhook:workflow-webhook-retry',
+    leaseTtlMs: 1,
+    createdAt: new Date('2030-01-01T09:00:00.000Z'),
+  })
+  assert.equal(first.triggerType, 'webhook')
+  assert.ok(first.claimToken)
+
+  const retried = store.reapExpiredWorkflowClaims({
+    maxAttempts: 2,
+    now: new Date('2030-01-01T09:00:00.002Z'),
+  })
+  assert.equal(retried.length, 1)
+  assert.equal(retried[0]?.action, 'retried')
+
+  const second = store.claimDueWorkflowRun({
+    runId: 'unused-webhook-run',
+    claimedBy: 'scheduler-recovery',
+    now: new Date('2030-01-01T09:00:00.003Z'),
+  })
+  assert.equal(second?.run.id, 'webhook-run-retry')
+  assert.equal(second?.run.triggerType, 'webhook')
+  assert.equal(second?.run.attemptCount, 2)
+  assert.notEqual(second?.run.claimToken, first.claimToken)
+})
+
+test('cloud control plane recovers workflow starts stranded after session attachment', () => {
+  const store = seededStore()
+  store.createWorkflow({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-attached-retry',
+    draft: {
+      title: 'Attached retry workflow',
+      instructions: 'Recover command enqueue.',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+    },
+  })
+
+  const first = store.createWorkflowRun({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-attached-retry',
+    runId: 'attached-run-retry',
+    triggerType: 'manual',
+    triggerPayload: { source: 'test' },
+    claimedBy: 'workflow-api:user-1',
+    leaseTtlMs: 30_000,
+    createdAt: new Date('2030-01-01T09:00:00.000Z'),
+  })
+  assert.ok(first.claimToken)
+
+  store.attachWorkflowRunSession({
+    tenantId: 'tenant-1',
+    workflowId: 'workflow-attached-retry',
+    runId: 'attached-run-retry',
+    sessionId: 'session-1',
+    claimToken: first.claimToken,
+    startedAt: new Date('2030-01-01T09:00:00.001Z'),
+  })
+  assert.equal(store.getWorkflowRun('tenant-1', 'attached-run-retry')?.claimToken, null)
+
+  const claimed = store.claimDueWorkflowRun({
+    runId: 'unused-attached-run',
+    claimedBy: 'scheduler-recovery',
+    leaseTtlMs: 1,
+    now: new Date('2030-01-01T09:00:00.002Z'),
+  })
+  assert.equal(claimed?.run.id, 'attached-run-retry')
+  assert.equal(claimed?.run.status, 'running')
+  assert.equal(claimed?.run.sessionId, 'session-1')
+  assert.equal(claimed?.run.attemptCount, 2)
+  assert.ok(claimed?.run.claimToken)
+
+  const retried = store.reapExpiredWorkflowClaims({
+    maxAttempts: 3,
+    now: new Date('2030-01-01T09:00:00.004Z'),
+  })
+  assert.equal(retried.length, 1)
+  assert.equal(retried[0]?.action, 'retried')
+  assert.equal(store.getWorkflowRun('tenant-1', 'attached-run-retry')?.claimToken, null)
+  assert.equal(store.getWorkflowForTenant('tenant-1', 'workflow-attached-retry')?.latestRunStatus, 'running')
 })

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -3629,6 +3629,160 @@ test('cloud HTTP public workflow webhooks require HMAC signatures and reject rep
   }
 })
 
+test('cloud workflow webhooks enqueue managed worker execution without web auto-processing', async () => {
+  const basePolicy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
+  const fixture = createFixture({
+    autoProcessCommands: false,
+    policy: {
+      ...basePolicy,
+      features: {
+        ...basePolicy.features,
+        webhooks: true,
+      },
+    },
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const createResponse = await fetch(`${baseUrl}/api/workflows`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Webhook managed worker',
+        instructions: 'Run later from worker.',
+        agentName: 'data-analyst',
+        triggers: [{
+          id: 'webhook-1',
+          type: 'webhook',
+          enabled: true,
+          webhookSecret: 'cloud-webhook-secret',
+        }],
+      }),
+    })
+    assert.equal(createResponse.status, 201)
+    const workflowId = String(asRecord((await readJson(createResponse)).workflow).id)
+    const rawBody = JSON.stringify({ source: 'test-webhook' })
+    const timestamp = new Date().toISOString()
+    const signature = signWorkflowWebhookPayload('cloud-webhook-secret', rawBody, timestamp)
+
+    const accepted = await fetch(`${baseUrl}/webhooks/workflows/${workflowId}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-open-cowork-timestamp': timestamp,
+        'x-open-cowork-signature': signature,
+      },
+      body: rawBody,
+    })
+    assert.equal(accepted.status, 202)
+    const acceptedBody = await readJson(accepted)
+    assert.equal(acceptedBody.ok, true)
+    assert.equal(acceptedBody.processed, 0)
+    assert.equal(fixture.runtime.prompts.length, 0)
+
+    const sessionId = String(acceptedBody.sessionId)
+    const queuedWorkflow = asRecord((await readJson(await fetch(`${baseUrl}/api/workflows/${workflowId}`))).workflow)
+    assert.equal(queuedWorkflow.latestRunStatus, 'running')
+    assert.equal(queuedWorkflow.latestRunSessionId, sessionId)
+
+    assert.equal(await fixture.worker.processAllSessionCommands(), 1)
+    assert.equal(fixture.runtime.prompts.length, 1)
+    assert.equal(fixture.runtime.prompts[0]?.parts[0]?.type === 'text'
+      ? fixture.runtime.prompts[0].parts[0].text
+      : null, 'Run later from worker.')
+
+    const completedWorkflow = asRecord((await readJson(await fetch(`${baseUrl}/api/workflows/${workflowId}`))).workflow)
+    assert.equal(completedWorkflow.latestRunStatus, 'completed')
+    assert.equal(completedWorkflow.latestRunSummary, 'echo: Run later from worker.')
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud workflow recovery enqueues missing commands on attached runs without duplicating sessions', async () => {
+  const fixture = createFixture({ autoProcessCommands: false })
+  fixture.store.createTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
+  fixture.store.ensureUser({ tenantId: 'tenant-1', userId: 'user-1', email: 'user@example.test', role: 'owner' })
+  const workflow = fixture.store.createWorkflow({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: 'workflow-attached-recovery',
+    draft: {
+      title: 'Attached recovery',
+      instructions: 'Recover the missing command.',
+      agentName: 'data-analyst',
+      skillNames: [],
+      toolIds: [],
+      projectDirectory: null,
+      draftSessionId: null,
+      triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+    },
+  })
+  fixture.store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'workflow-stranded-session',
+    opencodeSessionId: '',
+    profileName: 'full',
+    title: 'Run Attached recovery',
+    createdAt: new Date('2030-01-01T09:00:00.000Z'),
+  })
+  const run = fixture.store.createWorkflowRun({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    workflowId: workflow.id,
+    runId: 'workflow-attached-recovery-run',
+    triggerType: 'manual',
+    triggerPayload: { source: 'test' },
+    claimedBy: 'workflow-api:user-1',
+    leaseTtlMs: 30_000,
+    createdAt: new Date('2030-01-01T09:00:00.001Z'),
+  })
+  assert.ok(run.claimToken)
+  fixture.store.attachWorkflowRunSession({
+    tenantId: 'tenant-1',
+    workflowId: workflow.id,
+    runId: run.id,
+    sessionId: 'workflow-stranded-session',
+    claimToken: run.claimToken,
+    startedAt: new Date('2030-01-01T09:00:00.002Z'),
+  })
+
+  const started = await fixture.service.claimAndStartDueWorkflow(
+    new Date('2030-01-01T09:00:00.003Z'),
+    'scheduler-recovery',
+  )
+  assert.equal(started?.run.id, run.id)
+  assert.equal(started?.sessionId, 'workflow-stranded-session')
+  assert.equal(started?.command.commandId, `workflow:tenant-1:${workflow.id}:${run.id}:prompt`)
+  assert.equal(fixture.runtime.prompts.length, 0)
+
+  assert.equal(await fixture.worker.processAllSessionCommands(), 1)
+  assert.equal(fixture.runtime.prompts.length, 1)
+  assert.equal(fixture.runtime.prompts[0]?.sessionId, 'oc-session-1')
+  assert.equal(fixture.runtime.prompts[0]?.parts[0]?.type === 'text'
+    ? fixture.runtime.prompts[0].parts[0].text
+    : null, 'Recover the missing command.')
+
+  const detail = await fixture.service.getWorkflow({
+    tenantId: 'tenant-1',
+    tenantName: 'Tenant 1',
+    orgId: 'tenant-1',
+    userId: 'user-1',
+    accountId: 'user-1',
+    email: 'user@example.test',
+    role: 'owner',
+    authSource: 'local',
+  }, workflow.id)
+  assert.equal(detail?.latestRunStatus, 'completed')
+  assert.equal(detail?.latestRunSessionId, 'workflow-stranded-session')
+
+  const second = await fixture.service.claimAndStartDueWorkflow(
+    new Date('2030-01-01T09:00:00.004Z'),
+    'scheduler-recovery',
+  )
+  assert.equal(second, null)
+})
+
 test('cloud HTTP rejects workflow APIs when the cloud profile disables them', async () => {
   const basePolicy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
   const fixture = createFixture({

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -710,6 +710,215 @@ test('real Postgres cloud store retries and fails expired workflow start claims'
   })
 })
 
+test('real Postgres cloud store fences workflow finalization by active worker lease', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const workflowId = `${ids.tenantId}-workflow-fenced-finalize`
+    const runId = `${ids.tenantId}-run-fenced-finalize`
+    await store.createWorkflow({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      draft: {
+        title: 'Fenced workflow',
+        instructions: 'Finalize once.',
+        agentName: 'data-analyst',
+        skillNames: [],
+        toolIds: [],
+        projectDirectory: null,
+        draftSessionId: null,
+        triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+      },
+    })
+    await store.createWorkflowRun({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      runId,
+      triggerType: 'manual',
+    })
+    await store.attachWorkflowRunSession({
+      tenantId: ids.tenantId,
+      workflowId,
+      runId,
+      sessionId: ids.sessionId,
+    })
+    const staleLease = await store.claimSessionLease(
+      ids.tenantId,
+      ids.sessionId,
+      'pg-worker-stale',
+      new Date('2030-01-01T09:00:00.000Z'),
+      1,
+    )
+    assert.ok(staleLease)
+    const currentLease = await store.claimSessionLease(
+      ids.tenantId,
+      ids.sessionId,
+      'pg-worker-current',
+      new Date('2030-01-01T09:00:00.002Z'),
+      30_000,
+    )
+    assert.ok(currentLease)
+
+    await assert.rejects(
+      () => store.completeWorkflowRun({
+        tenantId: ids.tenantId,
+        workflowId,
+        runId,
+        summary: 'stale result',
+        nextStatus: 'active',
+        nextRunAt: null,
+        leaseToken: staleLease.leaseToken,
+      }),
+      /stale/,
+    )
+    assert.equal((await store.getWorkflowRun(ids.tenantId, runId))?.status, 'running')
+
+    const completed = await store.completeWorkflowRun({
+      tenantId: ids.tenantId,
+      workflowId,
+      runId,
+      summary: 'current result',
+      nextStatus: 'active',
+      nextRunAt: null,
+      leaseToken: currentLease.leaseToken,
+    })
+    assert.equal(completed?.status, 'completed')
+    assert.equal(completed?.summary, 'current result')
+  })
+})
+
+test('real Postgres cloud store recovers expired webhook workflow start claims', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const workflowId = `${ids.tenantId}-webhook-workflow-claim-retry`
+    const retryRunId = `${ids.tenantId}-webhook-workflow-retry-run`
+    await store.createWorkflow({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      draft: {
+        title: 'Webhook claim retry',
+        instructions: 'Retry failed webhook starts.',
+        agentName: 'data-analyst',
+        skillNames: [],
+        toolIds: [],
+        projectDirectory: null,
+        draftSessionId: null,
+        triggers: [{
+          id: 'webhook-1',
+          type: 'webhook',
+          enabled: true,
+          webhookSecret: 'secret',
+        }],
+      },
+    })
+    const first = await store.createWorkflowRun({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      runId: retryRunId,
+      triggerType: 'webhook',
+      triggerPayload: { source: 'test' },
+      claimedBy: `workflow-webhook:${workflowId}`,
+      leaseTtlMs: 1,
+      createdAt: new Date('2030-01-01T09:00:00.000Z'),
+    })
+    assert.ok(first.claimToken)
+
+    const retried = (await store.reapExpiredWorkflowClaims({
+      maxAttempts: 2,
+      now: new Date('2030-01-01T09:00:00.002Z'),
+    })).find((record) => record.tenantId === ids.tenantId && record.runId === retryRunId)
+    assert.equal(retried?.action, 'retried')
+
+    let second: Awaited<ReturnType<typeof store.claimDueWorkflowRun>> = null
+    for (let attempt = 0; attempt < 5 && !second; attempt += 1) {
+      const candidate = await store.claimDueWorkflowRun({
+        runId: `${ids.tenantId}-unused-webhook-run-${attempt}`,
+        claimedBy: 'scheduler-recovery',
+        now: new Date('2030-01-01T09:00:00.003Z'),
+      })
+      if (candidate?.run.id === retryRunId) second = candidate
+    }
+    assert.equal(second?.run.id, retryRunId)
+    assert.equal(second?.run.triggerType, 'webhook')
+    assert.equal(second?.run.attemptCount, 2)
+    assert.notEqual(second?.run.claimToken, first.claimToken)
+  })
+})
+
+test('real Postgres cloud store recovers workflow starts stranded after session attachment', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const workflowId = `${ids.tenantId}-attached-workflow-claim-retry`
+    const retryRunId = `${ids.tenantId}-attached-workflow-retry-run`
+    await store.createWorkflow({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      draft: {
+        title: 'Attached claim retry',
+        instructions: 'Retry command enqueue after session attach.',
+        agentName: 'data-analyst',
+        skillNames: [],
+        toolIds: [],
+        projectDirectory: null,
+        draftSessionId: null,
+        triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+      },
+    })
+    const first = await store.createWorkflowRun({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      runId: retryRunId,
+      triggerType: 'manual',
+      triggerPayload: { source: 'test' },
+      claimedBy: `workflow-api:${ids.userId}`,
+      leaseTtlMs: 30_000,
+      createdAt: new Date('2030-01-01T09:00:00.000Z'),
+    })
+    assert.ok(first.claimToken)
+    await store.attachWorkflowRunSession({
+      tenantId: ids.tenantId,
+      workflowId,
+      runId: retryRunId,
+      sessionId: ids.sessionId,
+      claimToken: first.claimToken,
+      startedAt: new Date('2030-01-01T09:00:00.001Z'),
+    })
+    assert.equal((await store.getWorkflowRun(ids.tenantId, retryRunId))?.claimToken, null)
+
+    let claimed: Awaited<ReturnType<typeof store.claimDueWorkflowRun>> = null
+    for (let attempt = 0; attempt < 5 && !claimed; attempt += 1) {
+      const candidate = await store.claimDueWorkflowRun({
+        runId: `${ids.tenantId}-unused-attached-run-${attempt}`,
+        claimedBy: 'scheduler-recovery',
+        leaseTtlMs: 1,
+        now: new Date('2030-01-01T09:00:00.002Z'),
+      })
+      if (candidate?.run.id === retryRunId) claimed = candidate
+    }
+    assert.equal(claimed?.run.id, retryRunId)
+    assert.equal(claimed?.run.status, 'running')
+    assert.equal(claimed?.run.sessionId, ids.sessionId)
+    assert.equal(claimed?.run.attemptCount, 2)
+    assert.ok(claimed?.run.claimToken)
+
+    const retried = (await store.reapExpiredWorkflowClaims({
+      maxAttempts: 3,
+      now: new Date('2030-01-01T09:00:00.004Z'),
+    })).find((record) => record.tenantId === ids.tenantId && record.runId === retryRunId)
+    assert.equal(retried?.action, 'retried')
+    assert.equal((await store.getWorkflowRun(ids.tenantId, retryRunId))?.claimToken, null)
+    assert.equal((await store.getWorkflowForTenant(ids.tenantId, workflowId))?.latestRunStatus, 'running')
+  })
+})
+
 test('real Postgres webhook replay claims are atomic across public replicas', {
   skip: POSTGRES_SKIP,
 }, async () => {

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -850,6 +850,109 @@ test('real Postgres cloud store recovers expired webhook workflow start claims',
   })
 })
 
+test('real Postgres cloud store rejects stale workflow attaches after expired claims are cleared', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const workflowId = `${ids.tenantId}-workflow-stale-attach`
+    const runId = `${ids.tenantId}-stale-attach-run`
+    await store.createWorkflow({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      draft: {
+        title: 'Stale attach workflow',
+        instructions: 'Do not attach stale starters.',
+        agentName: 'data-analyst',
+        skillNames: [],
+        toolIds: [],
+        projectDirectory: null,
+        draftSessionId: null,
+        triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+      },
+    })
+    const first = await store.createWorkflowRun({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId,
+      runId,
+      triggerType: 'manual',
+      claimedBy: `workflow-api:${ids.userId}`,
+      leaseTtlMs: 1,
+      createdAt: new Date('2030-01-01T09:00:00.000Z'),
+    })
+    assert.ok(first.claimToken)
+    assert.equal((await store.reapExpiredWorkflowClaims({
+      maxAttempts: 2,
+      now: new Date('2030-01-01T09:00:00.002Z'),
+    })).find((record) => record.tenantId === ids.tenantId && record.runId === runId)?.action, 'retried')
+    assert.equal((await store.getWorkflowRun(ids.tenantId, runId))?.claimToken, null)
+    await assert.rejects(
+      () => store.attachWorkflowRunSession({
+        tenantId: ids.tenantId,
+        workflowId,
+        runId,
+        sessionId: ids.sessionId,
+        claimToken: first.claimToken,
+      }),
+      /stale/,
+    )
+
+    const terminalWorkflowId = `${ids.tenantId}-workflow-terminal-stale-attach`
+    const terminalRunId = `${ids.tenantId}-terminal-stale-attach-run`
+    await store.createWorkflow({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId: terminalWorkflowId,
+      draft: {
+        title: 'Terminal stale attach workflow',
+        instructions: 'Do not attach failed runs.',
+        agentName: 'data-analyst',
+        skillNames: [],
+        toolIds: [],
+        projectDirectory: null,
+        draftSessionId: null,
+        triggers: [{ id: 'manual-1', type: 'manual', enabled: true }],
+      },
+    })
+    const terminal = await store.createWorkflowRun({
+      tenantId: ids.tenantId,
+      userId: ids.userId,
+      workflowId: terminalWorkflowId,
+      runId: terminalRunId,
+      triggerType: 'manual',
+      claimedBy: `workflow-api:${ids.userId}`,
+      leaseTtlMs: 1,
+      createdAt: new Date('2030-01-01T09:00:00.000Z'),
+    })
+    assert.ok(terminal.claimToken)
+    assert.equal((await store.reapExpiredWorkflowClaims({
+      maxAttempts: 1,
+      now: new Date('2030-01-01T09:00:00.002Z'),
+    })).find((record) => record.tenantId === ids.tenantId && record.runId === terminalRunId)?.action, 'failed')
+    assert.equal((await store.getWorkflowRun(ids.tenantId, terminalRunId))?.status, 'failed')
+    await assert.rejects(
+      () => store.attachWorkflowRunSession({
+        tenantId: ids.tenantId,
+        workflowId: terminalWorkflowId,
+        runId: terminalRunId,
+        sessionId: ids.sessionId,
+        claimToken: terminal.claimToken,
+      }),
+      /not attachable/,
+    )
+    await assert.rejects(
+      () => store.attachWorkflowRunSession({
+        tenantId: ids.tenantId,
+        workflowId: terminalWorkflowId,
+        runId: terminalRunId,
+        sessionId: ids.sessionId,
+      }),
+      /not attachable/,
+    )
+  })
+})
+
 test('real Postgres cloud store recovers workflow starts stranded after session attachment', {
   skip: POSTGRES_SKIP,
 }, async () => {


### PR DESCRIPTION
## Summary

- Route manual and webhook workflow starts through claim-owned run creation before session attach.
- Make workflow prompt commands deterministic and tenant-scoped so retrying a start is idempotent.
- Recover queued webhook/manual workflow starts and attached workflow runs that crashed before command enqueue, in both in-memory and Postgres stores.
- Add lease-fenced workflow finalization coverage so stale workers cannot complete a run after ownership changes.

Closes #535

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:cloud-continuation
- node --no-warnings --experimental-strip-types --test tests/cloud-control-plane-store.test.ts tests/cloud-http-server.test.ts
- OPEN_COWORK_TEST_POSTGRES_URL=postgres://postgres:postgres@127.0.0.1:55432/open_cowork_cloud_test node --no-warnings --experimental-strip-types --test tests/cloud-postgres-concurrency.test.ts
- git diff --check
