### PR TITLE
Add canonical product contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,11 @@ checklist live in [OpenCode SDK v2 Boundary](opencode-sdk-v2-boundary.md).
 
 ## Product surface contract
 
+The canonical contract for workspace ownership, surface support, sync rules,
+status/reason vocabulary, and downstream boundaries lives in
+[Product Contract](product-contract.md). This section summarizes the
+architectural boundary.
+
 Open Cowork exposes three product surfaces without changing the execution
 owner:
 

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -8,6 +8,10 @@ files.
 
 This page is the reference for that model.
 
+The workspace ownership, sync, status/reason, and non-sync guarantees that
+downstream builds must preserve are defined in
+[Product Contract](product-contract.md).
+
 ## Distribution modes
 
 Downstream operators should choose the product surface intentionally:

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -37,6 +37,10 @@ public deployment templates live under `deploy/managed-workers/`.
 
 ## Workspace sync contract
 
+The full cross-surface contract is documented in
+[Product Contract](product-contract.md). Cloud implements the cloud-workspace
+side of that contract.
+
 Cloud is the source of truth only for cloud workspaces. A user can start a
 cloud thread in desktop, continue it in the browser, and interact with the same
 thread through a gateway channel because all three clients read and write the

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -1,0 +1,318 @@
+# Product Contract
+
+Open Cowork has three user-facing surfaces over one OpenCode-backed product
+model:
+
+- Desktop
+- Cloud Web
+- Gateway
+
+The contract is workspace-scoped product sync. It is not peer-to-peer desktop
+sync and it is not OpenCode runtime-home replication. OpenCode owns execution.
+Open Cowork owns composition, workspace routing, projection, policy, artifacts,
+workflows, Gateway adapters, and deployer ergonomics.
+
+## Workspace Ownership
+
+A thread belongs to exactly one workspace.
+
+| Workspace | Execution authority | Source of truth | Sync behavior |
+|---|---|---|---|
+| Desktop Local | Desktop main process and local OpenCode runtime | Local app data, local registry, local settings, local runtime state | Private to that device. Never syncs implicitly. |
+| Desktop Cloud | Cloud worker and OpenCode runtime owned by Cloud | Tenant-scoped Cloud control plane | Syncs with Cloud Web and Gateway through Cloud sessions, events, projections, artifacts, workflows, settings metadata, and policy. |
+| Cloud Web | Cloud worker and OpenCode runtime owned by Cloud | Tenant-scoped Cloud control plane | Same Cloud workspace as Desktop Cloud and Gateway. |
+| Gateway Channel | Cloud worker and OpenCode runtime owned by Cloud | Tenant-scoped Cloud control plane plus channel binding/delivery records | Cloud-only headless access to bound Cloud sessions. |
+
+Local Desktop threads, host paths, local stdio MCPs, machine-native runtime
+config, local provider credentials, OAuth tokens, and local-only artifacts stay
+local unless a user explicitly starts a cloud-safe import or upload flow.
+
+## Product Surfaces
+
+### Desktop Local
+
+Desktop Local is the current private desktop behavior:
+
+- local OpenCode runtime ownership
+- local project directories and sandbox workspaces
+- local stdio MCPs allowed by local policy
+- local settings and encrypted credentials
+- local session registry and local thread index
+- local artifacts and explicit local filesystem reveal/export actions
+
+Cloud configuration is not required for Desktop Local. Cloud failures must not
+block local chat, agents, tools, skills, workflows, or thread history.
+
+### Desktop Cloud
+
+Desktop Cloud uses the Desktop renderer with a Cloud workspace selected. The
+Desktop main process owns auth tokens, routing, cache, and security policy.
+Cloud workers own OpenCode execution.
+
+Desktop Cloud can:
+
+- list, create, activate, prompt, abort, and hydrate Cloud sessions
+- consume Cloud projections and SSE events
+- answer Cloud approvals and questions
+- show Cloud artifacts and download/export through Cloud APIs
+- use Cloud workflows, tags, filters, capabilities, settings metadata, and
+  custom content when policy allows it
+- render cached Cloud state while offline
+
+Desktop Cloud must not:
+
+- open a local project picker as implicit context for a Cloud thread
+- send local host paths to Cloud APIs
+- expose local stdio MCP process commands to Cloud
+- use machine-native OpenCode config
+- upload local files, local artifacts, local credentials, or MCP secrets without
+  an explicit cloud-safe import/upload action
+
+### Cloud Web
+
+Cloud Web is a browser client for the same Cloud control plane. It does not
+import server-only stores, secret adapters, runtime adapters, or the OpenCode
+SDK.
+
+Cloud Web can:
+
+- start and continue Cloud threads
+- render the full Cloud projection contract
+- send prompts through durable Cloud commands
+- answer approvals and questions through Cloud command routes
+- browse artifacts and fetch artifact bodies only on explicit user action
+- run Cloud workflows when policy allows
+- show profile, capability, settings, BYOK status, billing, usage, Gateway,
+  member, audit, and diagnostic surfaces according to role
+
+Browser disabled controls are ergonomic hints only. Cloud APIs remain the
+authorization boundary.
+
+### Gateway Channel
+
+Gateway is a headless Cloud client/channel adapter. It can run on a VPS, Mac
+mini, Raspberry Pi, internal server, Kubernetes, or managed infrastructure.
+
+Gateway owns:
+
+- channel I/O
+- provider-specific signing/webhook or polling behavior
+- chat-side identity resolution
+- channel-specific rendering
+- approval/question interaction UX
+- delivery retry and diagnostics
+
+Cloud owns:
+
+- tenants, users, memberships, profiles, and policy
+- sessions, commands, events, projections, workflows, and artifacts
+- worker leases and OpenCode execution
+- channel binding/delivery records
+- approval and question authority
+
+Gateway can only participate in synced work through Cloud workspaces. Gateway
+must not import `@opencode-ai/sdk`, spawn OpenCode, or own control-plane
+Postgres state.
+
+## Active Workspace And Routing
+
+`workspaceId` scopes every workspace-owned API. When omitted, clients use the
+active workspace for that surface.
+
+Desktop starts with the Local workspace active on fresh installs. Selecting a
+Cloud workspace changes the visible sessions, settings, custom content,
+artifacts, workflow state, and policy scope. Switching back to Local restores
+local behavior without Cloud dependency.
+
+Workspace switching must not merge or leak:
+
+- sessions or projections
+- thread tags and smart filters
+- workflow definitions or runs
+- artifacts
+- settings metadata
+- custom agents, skills, or MCP metadata
+- cached Cloud cursors
+- errors or status banners
+
+## Cloud Offline And Degraded Behavior
+
+Cloud cache is a read-only fallback in v1.
+
+When a Cloud workspace is offline or degraded, clients may render cached
+metadata and projections, but must block Cloud mutations such as prompts,
+workflow runs, custom content writes, artifact uploads, and settings changes.
+Local Desktop remains fully usable.
+
+Cloud cache may store:
+
+- Cloud event cursors
+- session projections and session lists
+- thread metadata, tags, and filters
+- workflow lists and run summaries
+- settings/custom-content/artifact metadata
+
+Cloud cache must not store:
+
+- raw provider keys
+- OAuth access or refresh tokens
+- API tokens
+- MCP secrets
+- channel secrets
+- local file contents outside an explicit upload/cache contract
+- signed object-store URLs or raw object-store keys as long-lived state
+
+## Artifacts
+
+Artifact ownership follows the workspace:
+
+| Artifact source | Visible in | Body access | Reveal/export |
+|---|---|---|---|
+| Local Desktop artifact | Desktop Local | Local app data or local sandbox | Local-only reveal/export. No implicit Cloud upload. |
+| Cloud artifact | Desktop Cloud, Cloud Web, Gateway when channel supports files | Cloud artifact API/object store | Download/export through Cloud policy. No raw object keys in clients. |
+| Imported artifact | Target Cloud workspace after explicit import | Cloud artifact API/object store | Same as Cloud artifact after validation. |
+
+Cloud artifact metadata may sync. Artifact bodies are fetched only after an
+explicit user or channel action.
+
+## Workflows
+
+Workflows are an Open Cowork control-plane layer around OpenCode-native
+execution.
+
+| Workspace | Workflow owner | Execution path |
+|---|---|---|
+| Desktop Local | Local workflow store | Desktop creates a run thread and prompts local OpenCode. |
+| Cloud | Cloud control plane | Cloud scheduler/API creates a run command and a Cloud worker prompts OpenCode. |
+| Gateway | Cloud control plane | Gateway requests or receives Cloud workflow activity through Cloud APIs and delivery records. |
+
+Workflow state must be durable and transactional in its owning workspace. It
+must not be reconstructed from transient renderer state.
+
+## Settings And Custom Content
+
+Only portable Cloud workspace metadata syncs:
+
+- appearance and composer preferences where supported
+- selected Cloud profile and non-secret defaults
+- custom agent/skill/MCP metadata that is Cloud-safe
+- capability catalog and policy verdicts
+- provider credential status such as missing, configured, expired, or
+  admin-managed
+
+Raw credentials never sync. Local stdio MCPs, host paths, local shell bridges,
+machine-native config, and local project-source assumptions are blocked in
+Cloud unless a deployer maps them to a Cloud-safe remote MCP, package, endpoint,
+or explicit uploaded snapshot.
+
+Policy-blocked custom content should remain visible when useful, with explicit
+disabled reasons. It should not silently disappear when the user needs to
+understand why a Cloud workspace cannot run it.
+
+## Local-To-Cloud Copy And Import
+
+Local-to-Cloud movement is always explicit.
+
+A valid import flow must:
+
+- require a user action such as Copy to Cloud
+- preview included messages, attachments, artifacts, project-source data, and
+  excluded items
+- exclude local host paths and project roots by default
+- validate payloads before Cloud submission
+- reject local paths, secret-like values, raw tokens, and local MCP process
+  details
+- create a new Cloud thread or artifact records in the target Cloud workspace
+
+Import does not change the original Local thread's ownership.
+
+## Shared Status Vocabulary
+
+Workspace capability support uses the shared status vocabulary from
+`packages/shared/src/workspace.ts`.
+
+Shared surface identifiers:
+
+| Surface id | Surface |
+|---|---|
+| `desktop_local` | Desktop Local |
+| `desktop_cloud` | Desktop Cloud |
+| `cloud_web` | Cloud Web |
+| `gateway_channel` | Gateway Channel |
+| `admin_operator` | Admin/Operator |
+
+| Status | Meaning |
+|---|---|
+| `supported` | The action is available in this workspace and current state. |
+| `read_only` | The surface may render state but cannot mutate it now. |
+| `blocked_by_policy` | The action is implemented but disallowed by profile, role, quota, billing, or deployer policy. |
+| `not_supported` | The action is intentionally unavailable for this workspace or surface. |
+| `deferred` | The product contract reserves the capability, but it is not implemented yet. |
+
+Stable contract reason codes:
+
+| Reason code | Use |
+|---|---|
+| `workspace.auth_required` | User must authenticate before the Cloud action can run. |
+| `workspace.offline_read_only` | Cloud state is cached/read-only because live Cloud access is unavailable. |
+| `workspace.local_only` | Action is valid only in Desktop Local. |
+| `workspace.cloud_only` | Action is valid only in a Cloud workspace. |
+| `workspace.policy_disabled` | Profile, role, or deployer policy disabled the action. |
+| `workspace.quota_denied` | Quota prevented the action. |
+| `workspace.capacity_denied` | Worker or system capacity prevented the action. |
+| `workspace.billing_denied` | Billing or entitlement state prevented the action. |
+| `workspace.not_supported` | The action is outside the surface contract. |
+| `workspace.deferred` | The action is planned but not available. |
+
+Domain-specific policy codes may be more precise, such as
+`quota.prompts_per_hour_exceeded`, `billing.subscription_inactive`, or
+`project_source.git.host_denied`. They should still map cleanly to one of the
+contract reason categories for UI and channel copy.
+
+## Surface Support Matrix
+
+| Capability | Desktop Local | Desktop Cloud | Cloud Web | Gateway Channel | Admin/Operator |
+|---|---|---|---|---|---|
+| Direct chat prompt | `supported` | `supported` when online/authenticated | `supported` when online/authenticated | `supported` through bound Cloud session | `not_supported` |
+| Session list and hydrate | `supported` | `supported`; `read_only` from cache offline | `supported` | `supported` only for bound channel sessions | `supported` for scoped admin views |
+| Local project picker | `supported` | `not_supported` | `not_supported` | `not_supported` | `not_supported` |
+| Cloud Git source | `not_supported` | `supported` by policy | `supported` by policy | `supported` through binding/default project source | `supported` for policy setup |
+| Uploaded snapshot | `not_supported` unless importing | `supported` by explicit upload | `supported` by explicit upload | `deferred` except provider file upload flows | `supported` for policy setup |
+| Local stdio MCP | `supported` by local policy | `not_supported` | `not_supported` | `not_supported` | `blocked_by_policy` unless mapped to Cloud-safe alternative |
+| Remote MCP metadata | `supported` by local config | `supported` by Cloud policy | `supported` by Cloud policy | `supported` through Cloud session policy | `supported` for policy setup |
+| Machine runtime config | `supported` only as explicit desktop escape hatch | `not_supported` | `not_supported` | `not_supported` | `not_supported` |
+| Artifact metadata | `supported` | `supported`; cached read-only offline | `supported` | `supported` where channel can render/link | `supported` for summaries |
+| Artifact body download | `supported` | `supported` by Cloud policy | `supported` by Cloud policy | `supported` as file or link by channel capability | `supported` for support only when authorized |
+| Workflow run | `supported` | `supported` by Cloud policy | `supported` by Cloud policy | `supported` through Cloud command/delivery flow | `supported` for operations visibility |
+| BYOK key entry | `not_supported` | `not_supported` from Desktop renderer | `supported` for admins only | `not_supported` | `supported` for admins/operators |
+| Gateway delivery retry | `not_supported` | `not_supported` | `supported` for admins | `supported` internally by Gateway | `supported` for admins/operators |
+| Diagnostics export | `supported` redacted | `supported` redacted | `supported` redacted for admins | `supported` redacted | `supported` redacted/operator-scoped |
+
+## Downstream Configuration Boundaries
+
+Downstream deployers may configure:
+
+- branding and public copy
+- default Cloud connections
+- auth and IdP metadata references
+- feature flags and launch tier
+- provider profiles and allowed models/tools/MCPs
+- storage/object-store adapters
+- secret/KMS adapters
+- billing mode and entitlement adapter
+- Gateway provider bindings
+- worker pool mode and capacity policy
+- legal/support/privacy/security links
+
+Downstream deployers must not use config to bypass the workspace contract:
+
+- no implicit local thread upload
+- no raw secret sync through config
+- no local host path execution in Cloud
+- no local stdio MCP execution in Cloud
+- no Gateway-owned OpenCode runtime
+- no provider-specific branches in core product code
+
+Private managed SaaS values such as real project ids, account ids, domains,
+prices, customer data, support rosters, and secrets belong in downstream/private
+repos or provider secret managers, not in this public repo.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-05-29.
+Last updated: 2026-05-31.
 
 Open Cowork is now planned and verified as a three-surface product over one
 OpenCode-backed control plane:
@@ -67,121 +67,127 @@ source product remains deployable without commercial lock-in.
 
 ## Strategic Roadmap
 
-The three-surface roadmap is tracked by
-[issue #448](https://github.com/joe-broadhead/open-cowork/issues/448). The child
-issues below are the source of truth for implementation scope and acceptance.
+The active launch roadmap is tracked by
+[issue #547](https://github.com/joe-broadhead/open-cowork/issues/547). The
+child issues below are the source of truth for remaining implementation scope
+and acceptance.
 
 ### Phase 1: Product Contract And UX Semantics
 
-Make the three-surface model explicit in docs, UI language, API support
-matrices, and tests.
+Make the three-surface model explicit in one canonical contract, shared status
+vocabulary, docs links, and regression tests.
 
-Tracked by #449.
+Tracked by [#548](https://github.com/joe-broadhead/open-cowork/issues/548).
 
 Acceptance:
 
-- Desktop, cloud, and gateway are described as coordinated surfaces over one
-  OpenCode-backed control plane.
+- [Product Contract](product-contract.md) defines Desktop Local, Desktop Cloud,
+  Cloud Web, Gateway Channel, and Admin/Operator behavior.
 - Workspace state is clearly scoped as local or cloud.
-- Local-only and cloud-safe actions are distinct in UI and docs.
+- Local-only and cloud-safe actions are distinct in UI, docs, and support
+  verdicts.
 - OpenCode/Open Cowork ownership boundaries are documented and tested.
 
-### Phase 2: Seamless Cloud Continuation
+### Phase 2: Cloud Web Workbench Completion
 
-Prove the flagship flow: start or continue a cloud thread from desktop, web,
-and gateway with live state, approvals, questions, tools, and artifacts intact.
+Complete Cloud Web as a production end-user and admin workbench, including
+browser quality and route/API evidence.
 
-Tracked by #456.
-
-Acceptance:
-
-- A desktop-created cloud thread is visible in web.
-- A gateway prompt continues the same cloud thread.
-- Permission/question events round-trip through the shared cloud event contract.
-- Desktop can restart and hydrate from durable cloud projections without
-  corrupting cached cursors.
-
-### Phase 3: Explicit Local-To-Cloud Import
-
-Add a safe, consent-driven import/copy flow for selected local session state and
-artifacts. No implicit upload.
-
-Tracked by #457.
+Tracked by [#549](https://github.com/joe-broadhead/open-cowork/issues/549).
 
 Acceptance:
 
-- The user must choose **Copy to Cloud** explicitly from a local thread.
-- The UI previews message, attachment, artifact, project-source, and excluded
-  counts before upload.
-- Local project source and host paths are excluded by default.
-- Import payload validation rejects raw local paths and secret-like values.
+- Cloud threads can be started and continued from Web, Desktop Cloud, and
+  Gateway where a channel is bound.
+- SessionView parity covers messages, tool traces, approvals, questions,
+  artifacts, todos, cost/status/errors, and reload hydration.
+- Admin surfaces cover members, policy, BYOK, quotas, workers, Gateway, audit,
+  usage, and diagnostics with role checks and redaction.
+- Browser E2E, accessibility, and performance gates pass.
 
-### Phase 4: Cloud Project Context
+### Phase 3: Gateway Appliance v1
 
-Make cloud coding useful by giving workers a safe project source: git checkout,
-uploaded workspace snapshot, or managed object-store workspace.
+Make Gateway a production-grade headless Cloud client for self-hosted and
+managed channel deployments.
 
-Tracked by #458.
+Tracked by [#550](https://github.com/joe-broadhead/open-cowork/issues/550).
 
 Acceptance:
 
-- Cloud thread creation can use a configured Git source or explicit uploaded
-  snapshot.
-- Snapshot inventory shows included/excluded files and size limits.
-- Workers restore project context through cloud-safe storage.
-- Local files are never uploaded implicitly.
+- Gateway can self-host on a VPS/internal host with scoped service-token auth.
+- Telegram, Slack, Email, Webhook, CLI, and later providers share one
+  capability-driven rendering model.
+- Approvals/questions work through inline controls where supported and
+  token/link fallback where not.
+- Gateway has no OpenCode SDK imports and no direct control-plane database
+  ownership.
 
-### Phase 5: Downstream And Managed Productization
+### Phase 4: Downstream Distribution Contract
 
-Unify branding/configuration across desktop, cloud, and gateway, then harden
-SaaS BYOK and self-host deployment recipes.
+Freeze the configuration, branding, packaging, and extension contracts that
+let organizations ship internal or managed distributions without source
+patches.
 
-Tracked by #459 and #463.
+Tracked by [#551](https://github.com/joe-broadhead/open-cowork/issues/551).
 
 Acceptance:
 
 - A downstream organization can configure product name, logo, cloud URL, auth,
-  profiles, tools, agents, MCPs, object store, secret adapter, quotas, and
-  gateway providers without source patches.
-- Docker Compose and Helm deployments cover cloud and gateway.
-- Cloud deployment references cover provider-neutral storage and secrets.
-- Managed BYOK SaaS flows expose key status only; raw keys never leave the
-  write path or worker runtime config boundary.
+  profiles, tools, agents, MCPs, object store, secret adapter, quotas, billing
+  mode, and Gateway providers without core source patches.
+- Public examples use placeholders only.
+- Extension docs map each seam to concrete modules and forbidden imports.
+- Validators catch private-value leakage and branding regressions.
 
-### Phase 6: Gateway Expansion
+### Phase 5: Reference Deployments
 
-Promote gateway from Telegram/webhook foundation to a real headless product with
-Slack and email first, then additional channels.
+Prove provider-neutral deployment with GCP first, while keeping real project
+values outside the public repo.
 
-Tracked by #460.
-
-Acceptance:
-
-- Gateway is a cloud client/channel adapter, not an OpenCode runtime owner.
-- Telegram, Slack, email, and webhook providers share one capability-driven
-  rendering model.
-- Approvals/questions work through inline controls where supported and token or
-  link fallback where not.
-- Gateway can self-host on a VPS with service-token auth and no direct
-  control-plane database ownership.
-
-### Phase 7: Production Refactor And Security Gates
-
-Reduce cloud core coupling, harden OpenCode SDK boundaries, and add global
-privacy/security/concurrency gates.
-
-Tracked by #461, #462, and #464.
+Tracked by [#552](https://github.com/joe-broadhead/open-cowork/issues/552).
 
 Acceptance:
 
-- Gateway and client packages have zero direct OpenCode SDK imports.
-- Only cloud worker/runtime code imports OpenCode SDK runtime surfaces.
-- Raw provider keys, OAuth refresh tokens, MCP secrets, local file contents, and
-  machine paths are absent from read APIs, renderer state, logs, diagnostics,
-  and gateway payloads.
-- Cloud control-plane domains are split behind service/store boundaries.
-- Postgres concurrency gates cover leases, commands, events, deliveries,
-  quotas, and scheduler claims.
+- GCP deploys from a clean tmp/private repo using public templates.
+- No real GCP project ids, account ids, private domains, customer names,
+  prices, or secrets are committed.
+- Cloud, Desktop connection, Gateway, worker, artifact, workflow, and restore
+  smoke checks have a shared contract.
+- AWS, Azure, DigitalOcean, Kubernetes, and VPS recipes stay adapter/config
+  differences only.
+
+### Phase 6: Managed BYOK SaaS Readiness
+
+Prepare the open-source/public pieces needed by a downstream managed BYOK SaaS
+repo without mixing private values into this repo.
+
+Tracked by [#553](https://github.com/joe-broadhead/open-cowork/issues/553).
+
+Acceptance:
+
+- Self-host deployments work with billing disabled or stubbed.
+- BYOK plaintext is never readable over HTTP and is revealed only in the
+  worker/runtime role as allowed.
+- Billing and entitlement gates block expensive managed execution before worker
+  spawn/claim where possible.
+- Public/private boundaries for onboarding, billing, support, evidence, and
+  private launch values are documented and validated.
+
+### Phase 7: Launch Evidence
+
+Back launch claims with repeatable load, soak, failover, restore, security,
+release, browser, Gateway, deployment, and private-value evidence.
+
+Tracked by [#554](https://github.com/joe-broadhead/open-cowork/issues/554).
+
+Acceptance:
+
+- Evidence states which launch tier is proven: local/self-host beta, private
+  hosted beta, public hosted beta, general availability, or enterprise-scale.
+- Release gates fail closed when a surface-specific check is missing.
+- Load/failover/restore/security findings create narrow follow-up issues.
+- Public evidence templates contain no real project ids, domains, customers,
+  prices, support rosters, or secrets.
 
 ## Core Product Loop
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - Configuration: configuration.md
   - Build & Extend:
       - Architecture: architecture.md
+      - Product Contract: product-contract.md
       - Downstream Customization: downstream.md
       - OpenCode SDK Boundary: opencode-sdk-v2-boundary.md
       - Development Environment: development-environment.md

--- a/packages/shared/src/workspace.ts
+++ b/packages/shared/src/workspace.ts
@@ -2,6 +2,41 @@ export type WorkspaceKind = 'local' | 'cloud'
 
 export type WorkspaceStatus = 'online' | 'offline' | 'auth_required' | 'disabled' | 'error'
 
+export const WORKSPACE_API_SUPPORT_STATUSES = [
+  'supported',
+  'read_only',
+  'blocked_by_policy',
+  'not_supported',
+  'deferred',
+] as const
+
+export type WorkspaceApiSupportStatus = typeof WORKSPACE_API_SUPPORT_STATUSES[number]
+
+export const WORKSPACE_PRODUCT_SURFACES = [
+  'desktop_local',
+  'desktop_cloud',
+  'cloud_web',
+  'gateway_channel',
+  'admin_operator',
+] as const
+
+export type WorkspaceProductSurface = typeof WORKSPACE_PRODUCT_SURFACES[number]
+
+export const WORKSPACE_CONTRACT_REASON_CODES = [
+  'workspace.auth_required',
+  'workspace.offline_read_only',
+  'workspace.local_only',
+  'workspace.cloud_only',
+  'workspace.policy_disabled',
+  'workspace.quota_denied',
+  'workspace.capacity_denied',
+  'workspace.billing_denied',
+  'workspace.not_supported',
+  'workspace.deferred',
+] as const
+
+export type WorkspaceContractReasonCode = typeof WORKSPACE_CONTRACT_REASON_CODES[number]
+
 export type WorkspaceInfo = {
   id: string
   kind: WorkspaceKind
@@ -42,20 +77,21 @@ export type WorkspacePolicy = {
 export type WorkspaceActionVerdict = {
   allowed: boolean
   reason: string | null
-  policyCode?: string
+  policyCode?: WorkspaceContractReasonCode | string
 }
-
-export type WorkspaceApiSupportStatus =
-  | 'supported'
-  | 'read_only'
-  | 'blocked_by_policy'
-  | 'not_supported'
-  | 'deferred'
 
 export type WorkspaceApiSupport = {
   api: string
   status: WorkspaceApiSupportStatus
   verdict?: WorkspaceActionVerdict
+}
+
+export type WorkspaceSurfaceSupport = {
+  surface: WorkspaceProductSurface
+  api: string
+  status: WorkspaceApiSupportStatus
+  reasonCode?: WorkspaceContractReasonCode | string
+  notes?: string
 }
 
 export type AddCloudWorkspaceInput = {

--- a/tests/product-contract.test.ts
+++ b/tests/product-contract.test.ts
@@ -1,0 +1,97 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  WORKSPACE_API_SUPPORT_STATUSES,
+  WORKSPACE_CONTRACT_REASON_CODES,
+  WORKSPACE_PRODUCT_SURFACES,
+} from '../packages/shared/src/workspace.ts'
+
+const root = process.cwd()
+
+function read(relativePath: string) {
+  return readFileSync(join(root, relativePath), 'utf8')
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const productContract = read('docs/product-contract.md')
+
+test('product contract is the canonical linked three-surface contract', () => {
+  for (const phrase of [
+    'workspace-scoped product sync',
+    'Desktop Local',
+    'Desktop Cloud',
+    'Cloud Web',
+    'Gateway Channel',
+    'Active Workspace And Routing',
+    'Cloud Offline And Degraded Behavior',
+    'Artifacts',
+    'Workflows',
+    'Settings And Custom Content',
+    'Local-To-Cloud Copy And Import',
+    'Downstream Configuration Boundaries',
+    'Gateway can only participate in synced work through Cloud workspaces',
+    'must not import `@opencode-ai/sdk`, spawn OpenCode',
+    'Local Desktop threads, host paths, local stdio MCPs, machine-native runtime',
+  ]) {
+    assert.match(productContract, new RegExp(escapeRegex(phrase)), `Product Contract must document ${phrase}`)
+  }
+
+  const linkedDocs = [
+    'docs/architecture.md',
+    'docs/open-cowork-cloud.md',
+    'docs/downstream.md',
+    'docs/roadmap.md',
+    'mkdocs.yml',
+  ]
+  for (const relativePath of linkedDocs) {
+    assert.match(read(relativePath), /product-contract\.md/, `${relativePath} must link the canonical Product Contract`)
+  }
+})
+
+test('product contract documents the shared workspace status and reason vocabulary', () => {
+  for (const surface of WORKSPACE_PRODUCT_SURFACES) {
+    assert.match(productContract, new RegExp('`' + escapeRegex(surface) + '`'), `Product Contract must document surface ${surface}`)
+  }
+  for (const status of WORKSPACE_API_SUPPORT_STATUSES) {
+    assert.match(productContract, new RegExp('`' + escapeRegex(status) + '`'), `Product Contract must document status ${status}`)
+  }
+  for (const reasonCode of WORKSPACE_CONTRACT_REASON_CODES) {
+    assert.match(productContract, new RegExp('`' + escapeRegex(reasonCode) + '`'), `Product Contract must document reason code ${reasonCode}`)
+  }
+})
+
+test('active roadmap points to launch issues instead of the older completed roadmap', () => {
+  const roadmap = read('docs/roadmap.md')
+
+  assert.match(roadmap, /issue #547/)
+  for (const issue of [548, 549, 550, 551, 552, 553, 554]) {
+    assert.match(roadmap, new RegExp(`#${issue}\\b`), `roadmap must reference #${issue}`)
+    assert.match(roadmap, new RegExp(`/issues/${issue}\\)`), `roadmap must link #${issue}`)
+  }
+
+  for (const oldIssue of [448, 449, 456, 457, 458, 459, 460, 461, 462, 463, 464]) {
+    assert.doesNotMatch(roadmap, new RegExp(`/issues/${oldIssue}\\)`), `roadmap must not point at older issue #${oldIssue}`)
+    assert.doesNotMatch(roadmap, new RegExp(`#${oldIssue}\\b`), `roadmap must not list older issue #${oldIssue} as active`)
+  }
+})
+
+test('product contract keeps local and cloud workspace ownership separate', () => {
+  for (const phrase of [
+    'A thread belongs to exactly one workspace.',
+    'Cloud cache is a read-only fallback in v1.',
+    'Local-to-Cloud movement is always explicit.',
+    "Import does not change the original Local thread's ownership.",
+    'no implicit local thread upload',
+    'no raw secret sync through config',
+    'no local host path execution in Cloud',
+    'no local stdio MCP execution in Cloud',
+    'no Gateway-owned OpenCode runtime',
+  ]) {
+    assert.match(productContract, new RegExp(escapeRegex(phrase)), `Product Contract must preserve boundary: ${phrase}`)
+  }
+})


### PR DESCRIPTION
Closes #548.

## Summary
- add a canonical Product Contract for Desktop Local, Desktop Cloud, Cloud Web, Gateway Channel, and Admin/Operator surfaces
- add shared workspace support statuses, product surface ids, and contract reason-code constants/types
- link the contract from architecture, cloud, downstream, roadmap, and MkDocs nav
- refresh the active roadmap to #547 and child issues #548-#554
- add regression coverage for the contract links, vocabulary, roadmap issue set, and local/cloud non-sync boundaries

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:cloud-continuation
- pnpm deploy:validate
- pnpm docs:build
- git diff --check