### PR TITLE
Complete cloud web workbench matrix

### DIFF
--- a/apps/website/src/browser-e2e.test.ts
+++ b/apps/website/src/browser-e2e.test.ts
@@ -136,6 +136,10 @@ test('cloud web browser exercises BYOK, gateway, billing, diagnostics, and quota
 
     assert.match(harness.document.querySelector('#billing-summary')?.textContent || '', /active/)
     assert.match(harness.document.querySelector('#usage-quota-list')?.textContent || '', /Prompts\/hour/)
+    assert.match(harness.document.querySelector('#admin-worker-summary')?.textContent || '', /Primary worker pool/)
+    assert.match(harness.document.querySelector('#admin-worker-summary')?.textContent || '', /Worker one/)
+    assert.ok(harness.lastRequest((request) => request.method === 'GET' && request.path === '/api/admin/worker-pools?limit=100'))
+    assert.ok(harness.lastRequest((request) => request.method === 'GET' && request.path === '/api/admin/workers?limit=100'))
 
     harness.clickText('#diagnostics button', 'Prepare bundle')
     await waitFor(() => assert.match(harness.document.querySelector('#diagnostics-bundle')?.textContent || '', /secrets-redacted/))

--- a/apps/website/src/browser-test-harness.ts
+++ b/apps/website/src/browser-test-harness.ts
@@ -198,6 +198,16 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
     deliveries: [
       { deliveryId: 'delivery-1', provider: 'telegram', channelBindingId: 'binding-1', status: 'failed', eventType: 'session.completed', attemptCount: 1, lastError: '[redacted]', nextAttemptAt: iso(3) },
     ],
+    workerPools: [
+      { poolId: 'pool-1', name: 'Primary worker pool', mode: 'self_hosted', status: 'active', region: 'test-region', maxWorkers: 3, maxConcurrentWork: 6, updatedAt: iso(4) },
+    ],
+    workers: [
+      { workerId: 'worker-1', poolId: 'pool-1', displayName: 'Worker one', status: 'active', version: 'test', currentLoad: 1, lastHeartbeatAt: iso(5), lastErrorCode: null, lastErrorSummary: null },
+      { workerId: 'worker-2', poolId: 'pool-1', displayName: 'Worker two', status: 'paused', version: 'test', currentLoad: 0, lastHeartbeatAt: null, lastErrorCode: null, lastErrorSummary: null },
+    ],
+    workerHeartbeats: [
+      { workerId: 'worker-1', poolId: 'pool-1', version: 'test', currentLoad: 1, activeWorkIds: ['session-1'], receivedAt: iso(5) },
+    ],
     workflows: [
       { id: 'workflow-1', title: 'Daily review', instructions: 'Review changed work.', agentName: 'build', status: 'active', latestRunStatus: 'completed', triggers: [{ type: 'manual', enabled: true }], updatedAt: iso(5) },
     ],
@@ -336,6 +346,13 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
     }
     if (request.method === 'GET' && request.pathname === '/api/admin/audit') {
       return jsonResponse({ events: [{ eventId: 'audit-1', eventType: 'byok.updated', actorType: 'user', actorId: 'user-1', targetType: 'byok', targetId: 'anthropic', metadata: { token: '[redacted]' }, createdAt: iso(8) }] })
+    }
+    if (request.method === 'GET' && request.pathname === '/api/admin/worker-pools') return jsonResponse({ pools: state.workerPools })
+    if (request.method === 'GET' && request.pathname === '/api/admin/workers') return jsonResponse({ workers: state.workers })
+    const workerHeartbeatsMatch = request.pathname.match(/^\/api\/admin\/workers\/([^/]+)\/heartbeats$/)
+    if (request.method === 'GET' && workerHeartbeatsMatch) {
+      const workerId = decodeURIComponent(workerHeartbeatsMatch[1])
+      return jsonResponse({ heartbeats: state.workerHeartbeats.filter((heartbeat: any) => heartbeat.workerId === workerId) })
     }
     if (request.method === 'GET' && request.pathname === '/api/channels/agents') return jsonResponse({ agents: state.agents })
     if (request.method === 'POST' && request.pathname === '/api/channels/agents') {

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -1,5 +1,6 @@
 import type { PublicBrandingConfig } from '@open-cowork/shared'
 import type { CloudWebRoute, CloudWebRouteId } from './app-shell.ts'
+import type { CloudWebRouteApiMatrixEntry } from './route-api-matrix.ts'
 
 export type CloudWebEndpointId =
   | 'authMe'
@@ -13,6 +14,8 @@ export type CloudWebEndpointId =
   | 'usageEvents'
   | 'usageSummary'
   | 'diagnostics'
+  | 'runtimeStatus'
+  | 'workerHeartbeats'
   | 'sessions'
   | 'sessionView'
   | 'sessionEvents'
@@ -38,6 +41,9 @@ export type CloudWebEndpointId =
   | 'adminMemberInvite'
   | 'adminMemberUpdate'
   | 'adminAudit'
+  | 'adminWorkerPools'
+  | 'adminWorkers'
+  | 'adminWorkerHeartbeats'
   | 'channelDeliveries'
   | 'channelDeliveryRetry'
   | 'channelDeliveryDeadLetter'
@@ -57,6 +63,7 @@ export type CloudWebClientBootstrap = {
   routes: CloudWebRoute[]
   defaultRoute: string
   api: CloudWebEndpoint[]
+  routeMatrix: CloudWebRouteApiMatrixEntry[]
   sessionEventTypes: string[]
 }
 
@@ -92,11 +99,15 @@ export type CloudWebClientStateContract = {
   usageSummary: unknown | null
   deliveries: unknown[]
   diagnostics: unknown | null
+  diagnosticsError: string | null
   admin: {
     policy: unknown | null
     members: unknown[]
+    workerPools: unknown[]
+    workers: unknown[]
     auditEvents: unknown[]
     error: string | null
+    workerError: string | null
   }
   selectedWorkflowId: string | null
   workspaceEvents: {
@@ -195,6 +206,18 @@ export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
     id: 'diagnostics',
     method: 'GET',
     path: '/api/diagnostics',
+    csrf: false,
+  },
+  {
+    id: 'runtimeStatus',
+    method: 'GET',
+    path: '/api/runtime/status',
+    csrf: false,
+  },
+  {
+    id: 'workerHeartbeats',
+    method: 'GET',
+    path: '/api/workers/heartbeats',
     csrf: false,
   },
   {
@@ -345,6 +368,24 @@ export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
     id: 'adminAudit',
     method: 'GET',
     path: '/api/admin/audit?limit=100',
+    csrf: false,
+  },
+  {
+    id: 'adminWorkerPools',
+    method: 'GET',
+    path: '/api/admin/worker-pools?limit=100',
+    csrf: false,
+  },
+  {
+    id: 'adminWorkers',
+    method: 'GET',
+    path: '/api/admin/workers?limit=100',
+    csrf: false,
+  },
+  {
+    id: 'adminWorkerHeartbeats',
+    method: 'GET',
+    path: '/api/admin/workers/:workerId/heartbeats?limit=50',
     csrf: false,
   },
 ]

--- a/apps/website/src/client/admin-script.ts
+++ b/apps/website/src/client/admin-script.ts
@@ -118,6 +118,7 @@ function renderAdminPolicy() {
   const features = qs('#admin-policy-features');
   const project = qs('#admin-project-policy');
   const runtime = qs('#admin-runtime-policy');
+  const workerSummary = qs('#admin-worker-summary');
   const policy = state.admin.policy;
   if (overview) {
     removeChildren(overview);
@@ -216,6 +217,56 @@ function renderAdminPolicy() {
       row.appendChild(strong);
       row.appendChild(span);
       runtime.appendChild(row);
+    }
+  }
+  if (workerSummary) {
+    removeChildren(workerSummary);
+    if (state.admin.workerError) {
+      const empty = document.createElement('p');
+      empty.className = 'empty';
+      empty.textContent = state.admin.workerError;
+      workerSummary.appendChild(empty);
+    }
+    const pools = normalizeList(state.admin.workerPools);
+    const workers = normalizeList(state.admin.workers);
+    const activeWorkers = workers.filter((worker) => worker.status === 'active').length;
+    const totalLoad = workers.reduce((total, worker) => total + tokenNumber(worker.currentLoad), 0);
+    const summary = document.createElement('div');
+    summary.className = 'row compact';
+    const strong = document.createElement('strong');
+    strong.textContent = 'Org worker capacity';
+    const span = document.createElement('span');
+    span.textContent = pools.length + ' pool(s), ' + activeWorkers + ' active worker(s), load ' + totalLoad;
+    summary.appendChild(strong);
+    summary.appendChild(span);
+    workerSummary.appendChild(summary);
+    if (!pools.length && !workers.length && !state.admin.workerError) {
+      const empty = document.createElement('p');
+      empty.className = 'empty';
+      empty.textContent = 'No worker pools loaded.';
+      workerSummary.appendChild(empty);
+    }
+    for (const pool of pools.slice(0, 4)) {
+      const row = document.createElement('div');
+      row.className = 'row compact';
+      const label = document.createElement('strong');
+      label.textContent = pool.name || pool.poolId;
+      const meta = document.createElement('span');
+      meta.textContent = [pool.mode, pool.status, pool.region].filter(Boolean).join(' - ') || 'pool';
+      row.appendChild(label);
+      row.appendChild(meta);
+      workerSummary.appendChild(row);
+    }
+    for (const worker of workers.slice(0, 6)) {
+      const row = document.createElement('div');
+      row.className = 'row compact';
+      const label = document.createElement('strong');
+      label.textContent = worker.displayName || worker.workerId;
+      const meta = document.createElement('span');
+      meta.textContent = (worker.status || 'unknown') + ' - load ' + tokenNumber(worker.currentLoad) + ' - heartbeat ' + formatDate(worker.lastHeartbeatAt);
+      row.appendChild(label);
+      row.appendChild(meta);
+      workerSummary.appendChild(row);
     }
   }
 }

--- a/apps/website/src/client/common-script.ts
+++ b/apps/website/src/client/common-script.ts
@@ -16,6 +16,7 @@ const state = {
   usageSummary: null,
   deliveries: [],
   diagnostics: null,
+  diagnosticsError: null,
   sessions: [],
   sessionViews: {},
   selectedSessionId: null,
@@ -62,8 +63,11 @@ const state = {
   admin: {
     policy: null,
     members: [],
+    workerPools: [],
+    workers: [],
     auditEvents: [],
     error: null,
+    workerError: null,
   },
   memberFilter: '',
   auditFilter: '',
@@ -258,11 +262,15 @@ function renderSignedOut() {
   state.usageSummary = null;
   state.deliveries = [];
   state.diagnostics = null;
+  state.diagnosticsError = null;
   state.admin = {
     policy: null,
     members: [],
+    workerPools: [],
+    workers: [],
     auditEvents: [],
     error: null,
+    workerError: null,
   };
   state.memberFilter = '';
   state.auditFilter = '';

--- a/apps/website/src/client/data-script.ts
+++ b/apps/website/src/client/data-script.ts
@@ -64,8 +64,11 @@ async function loadAdminSurfaces() {
     state.admin = {
       policy,
       members: [],
+      workerPools: [],
+      workers: [],
       auditEvents: [],
       error: adminError,
+      workerError: adminError,
     };
     renderAdminPolicy();
     renderMembers();
@@ -73,7 +76,11 @@ async function loadAdminSurfaces() {
     renderByok();
     return;
   }
-  const [policy, members, auditEvents] = await Promise.all([
+  let workerError = null;
+  const setWorkerError = (error) => {
+    if (error && !workerError) workerError = error;
+  };
+  const [policy, members, auditEvents, workerPools, workers] = await Promise.all([
     optionalSurfaceLoad(
       () => api(endpoint('adminPolicy', '/api/admin/policy')).then((body) => body.policy || null),
       null,
@@ -89,11 +96,24 @@ async function loadAdminSurfaces() {
       [],
       setAdminError,
     ),
+    optionalSurfaceLoad(
+      () => api(endpoint('adminWorkerPools', '/api/admin/worker-pools?limit=100')).then((body) => body.pools || []),
+      [],
+      setWorkerError,
+    ),
+    optionalSurfaceLoad(
+      () => api(endpoint('adminWorkers', '/api/admin/workers?limit=100')).then((body) => body.workers || []),
+      [],
+      setWorkerError,
+    ),
   ]);
   state.admin.policy = policy;
   state.admin.members = normalizeList(members);
+  state.admin.workerPools = normalizeList(workerPools);
+  state.admin.workers = normalizeList(workers);
   state.admin.auditEvents = normalizeList(auditEvents);
   state.admin.error = adminError;
+  state.admin.workerError = workerError;
   renderMembers();
   renderAdminPolicy();
   renderAudit();
@@ -113,10 +133,12 @@ async function loadGatewayOps() {
 }
 
 async function loadDiagnostics() {
+  state.diagnosticsError = null;
   state.diagnostics = await optionalSurfaceLoad(
     () => api(endpoint('diagnostics', '/api/diagnostics')),
     null,
     (error) => {
+      state.diagnosticsError = error;
       if (error) setStatus(error, 'error');
     },
   );

--- a/apps/website/src/client/ops-script.ts
+++ b/apps/website/src/client/ops-script.ts
@@ -152,7 +152,8 @@ function renderDiagnostics() {
   if (!diagnostics) {
     const empty = document.createElement('p');
     empty.className = 'empty';
-    empty.textContent = adminLocked() ? 'Diagnostics require admin or operator privileges.' : 'Diagnostics have not been requested.';
+    empty.textContent = state.diagnosticsError
+      || (adminLocked() ? 'Diagnostics require admin or operator privileges.' : 'Diagnostics have not been requested.');
     health.appendChild(empty);
     return;
   }

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -1,7 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { CLOUD_WEB_ROUTE_GROUPS, DEFAULT_CLOUD_WEB_ROUTE, findCloudWebRoute } from './app-shell.ts'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { CLOUD_WEB_ROUTES, CLOUD_WEB_ROUTE_GROUPS, DEFAULT_CLOUD_WEB_ROUTE, findCloudWebRoute } from './app-shell.ts'
 import { CLOUD_WEB_CLIENT_ENDPOINTS, type CloudWebClientStateContract } from './client-contract.ts'
+import { CLOUD_WEB_ROUTE_API_MATRIX } from './route-api-matrix.ts'
 import { cloudWebsiteClientScript, cloudWebsiteHtml } from './render.ts'
 import { canManageOrg } from './roles.ts'
 import {
@@ -60,10 +63,37 @@ test('cloud website app shell exposes typed route metadata', () => {
   assert.equal(findCloudWebRoute('usage')?.requiresAdmin, false)
 })
 
+test('cloud website route/API matrix covers every route and real endpoint id', () => {
+  const routes = new Map(CLOUD_WEB_ROUTES.map((route) => [route.id, route]))
+  const endpoints = new Set(CLOUD_WEB_CLIENT_ENDPOINTS.map((endpoint) => endpoint.id))
+  assert.deepEqual(CLOUD_WEB_ROUTE_API_MATRIX.map((entry) => entry.routeId).sort(), CLOUD_WEB_ROUTES.map((route) => route.id).sort())
+  for (const entry of CLOUD_WEB_ROUTE_API_MATRIX) {
+    const route = routes.get(entry.routeId)
+    assert.ok(route, `route exists for matrix entry ${entry.routeId}`)
+    assert.equal(entry.surface, route.surface)
+    assert.ok(entry.endpointIds.length > 0, `${entry.routeId} lists backing endpoint ids`)
+    assert.ok(entry.states.loading && entry.states.empty && entry.states.error, `${entry.routeId} defines loading/empty/error states`)
+    assert.ok(entry.disabledBehavior, `${entry.routeId} defines disabled behavior`)
+    assert.ok(entry.pagination, `${entry.routeId} defines pagination/cursor behavior`)
+    assert.ok(entry.redaction, `${entry.routeId} defines redaction behavior`)
+    assert.ok(entry.tests.length > 0, `${entry.routeId} lists test coverage`)
+    for (const endpointId of entry.endpointIds) {
+      assert.ok(endpoints.has(endpointId), `${entry.routeId} references known endpoint ${endpointId}`)
+    }
+  }
+
+  const doc = readFileSync(fileURLToPath(new URL('../../../docs/cloud-web-workbench.md', import.meta.url)), 'utf8')
+  assert.match(doc, /Route\/API Matrix/)
+  for (const route of CLOUD_WEB_ROUTES) {
+    assert.match(doc, new RegExp('`' + route.id + '`'), `Cloud Web Workbench docs list ${route.id}`)
+  }
+})
+
 test('cloud website bootstrap exposes typed client endpoint metadata', () => {
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'config')?.path, '/api/config')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workspace')?.path, '/api/workspace')
   assert.match(html, /"api":/)
+  assert.match(html, /"routeMatrix":/)
   assert.match(cloudWebsiteClientScript(), /endpoint\(id, fallback\)/)
   const stateContract: CloudWebClientStateContract = {
     authStatus: 'loading',
@@ -94,11 +124,15 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
     usageSummary: null,
     deliveries: [],
     diagnostics: null,
+    diagnosticsError: null,
     admin: {
       policy: null,
       members: [],
+      workerPools: [],
+      workers: [],
       auditEvents: [],
       error: null,
+      workerError: null,
     },
     selectedWorkflowId: null,
     workspaceEvents: {
@@ -130,8 +164,13 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMemberInvite')?.method, 'POST')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMemberUpdate')?.path, '/api/admin/members/:accountId/update')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminAudit')?.path, '/api/admin/audit?limit=100')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminWorkerPools')?.path, '/api/admin/worker-pools?limit=100')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminWorkers')?.path, '/api/admin/workers?limit=100')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminWorkerHeartbeats')?.path, '/api/admin/workers/:workerId/heartbeats?limit=50')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'usageSummary')?.path, '/api/usage/summary?limit=100')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'diagnostics')?.path, '/api/diagnostics')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'runtimeStatus')?.path, '/api/runtime/status')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workerHeartbeats')?.path, '/api/workers/heartbeats')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'channelDeliveries')?.path, '/api/channels/deliveries?limit=50')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'channelDeliveryRetry')?.path, '/api/channels/deliveries/:deliveryId/retry')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'channelDeliveryDeadLetter')?.path, '/api/channels/deliveries/:deliveryId/dead-letter')
@@ -147,6 +186,7 @@ test('cloud website keeps existing admin dashboard surfaces available', () => {
   assert.match(html, /Recent totals/)
   assert.match(html, /id="billing-plan-select"/)
   assert.match(html, /id="diagnostics-health"/)
+  assert.match(html, /id="admin-worker-summary"/)
   assert.match(html, /Billing/)
   assert.match(html, /Usage/)
 })
@@ -267,6 +307,7 @@ test('cloud website binds actions through the client script', () => {
   assert.match(cloudWebsiteClientScript(), /updateBindingProviderFields/)
   assert.match(cloudWebsiteClientScript(), /renderMembers/)
   assert.match(cloudWebsiteClientScript(), /renderAdminPolicy/)
+  assert.match(cloudWebsiteClientScript(), /adminWorkerPools/)
   assert.match(cloudWebsiteClientScript(), /renderAudit/)
   assert.match(cloudWebsiteClientScript(), /inviteMember/)
   assert.match(cloudWebsiteClientScript(), /updateMember/)

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -5,6 +5,7 @@ import { DEFAULT_WEBSITE_PUBLIC_BRANDING, brandLinksMarkup, brandLogoMarkup, res
 import { cloudWebsiteClientScript } from './client-script.ts'
 import { escapeHtml, jsonScript } from './html-utils.ts'
 import { cloudWebsiteStyles } from './styles.ts'
+import { CLOUD_WEB_ROUTE_API_MATRIX } from './route-api-matrix.ts'
 import { CLOUD_SESSION_EVENT_TYPES, type PublicBrandingConfig } from '@open-cowork/shared'
 
 export { cloudWebsiteClientScript } from './client-script.ts'
@@ -49,6 +50,7 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
     routes: CLOUD_WEB_ROUTES,
     defaultRoute: DEFAULT_CLOUD_WEB_ROUTE,
     api: CLOUD_WEB_CLIENT_ENDPOINTS,
+    routeMatrix: CLOUD_WEB_ROUTE_API_MATRIX,
     sessionEventTypes: [...CLOUD_SESSION_EVENT_TYPES],
   }
   const adminDefault = canManageOrg(policy.role as WebsiteRole)
@@ -438,6 +440,12 @@ ${cloudWebsiteStyles(branding)}
               <h3>Runtime and gateway</h3>
               <div class="list" id="admin-runtime-policy">
                 <p class="empty">Runtime policy loads after sign-in.</p>
+              </div>
+            </div>
+            <div class="panel">
+              <h3>Worker health</h3>
+              <div class="list" id="admin-worker-summary">
+                <p class="empty">Worker summaries load after sign-in.</p>
               </div>
             </div>
           </div>

--- a/apps/website/src/route-api-matrix.ts
+++ b/apps/website/src/route-api-matrix.ts
@@ -1,0 +1,267 @@
+import type { CloudWebRouteId, CloudWebSurface } from './app-shell.ts'
+import type { CloudWebEndpointId } from './client-contract.ts'
+
+export type CloudWebRouteRequiredRole = 'public' | 'member' | 'admin' | 'operator'
+
+export type CloudWebRouteApiMatrixEntry = {
+  routeId: CloudWebRouteId
+  surface: CloudWebSurface
+  requiredRole: CloudWebRouteRequiredRole
+  endpointIds: CloudWebEndpointId[]
+  states: {
+    loading: string
+    empty: string
+    error: string
+  }
+  disabledBehavior: string
+  pagination: string
+  redaction: string
+  tests: string[]
+}
+
+export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
+  {
+    routeId: 'threads',
+    surface: 'workbench',
+    requiredRole: 'member',
+    endpointIds: ['sessions', 'sessionView', 'projectSourceValidate', 'projectSnapshots'],
+    states: {
+      loading: 'Thread list renders an empty table until /api/sessions returns.',
+      empty: 'No cloud threads loaded.',
+      error: 'Policy, quota, billing, and project-source denials render through the global status.',
+    },
+    disabledBehavior: 'Create controls are disabled when chat is unavailable or the user is signed out.',
+    pagination: 'Browser page size is bounded by CLOUD_WEB_THREAD_PAGE_SIZE with Load more for local rendering; backend pagination is deferred until the sessions API exposes cursors.',
+    redaction: 'Local host paths and local MCP process details are never accepted as cloud thread context.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts', 'performance.test.ts'],
+  },
+  {
+    routeId: 'chat',
+    surface: 'workbench',
+    requiredRole: 'member',
+    endpointIds: ['sessionView', 'sessionEvents', 'sessionPrompt', 'sessionPermissionRespond', 'sessionQuestionReply', 'sessionQuestionReject'],
+    states: {
+      loading: 'Selected session timeline hydrates from /api/sessions/:sessionId/view before SSE.',
+      empty: 'No thread selected.',
+      error: 'Composer and runtime action errors render stable policy/quota/billing messages.',
+    },
+    disabledBehavior: 'Composer is disabled until a cloud session is selected and chat policy is enabled.',
+    pagination: 'Session SSE resumes from the durable projection sequence; no browser-only projection model exists.',
+    redaction: 'Runtime details are rendered from Cloud projections and sanitized before browser display.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts', 'cloud-continuation-e2e.test.ts'],
+  },
+  {
+    routeId: 'agents',
+    surface: 'workbench',
+    requiredRole: 'member',
+    endpointIds: ['workspace', 'capabilitiesCatalog'],
+    states: {
+      loading: 'Agent list derives from workspace policy and capability metadata.',
+      empty: 'No agents loaded.',
+      error: 'Capability policy errors render as unavailable surface notes.',
+    },
+    disabledBehavior: 'Refresh is disabled when agent/skill/MCP features are disabled by profile policy.',
+    pagination: 'Capability filtering is local and performance-tested against hundreds of entries.',
+    redaction: 'Custom content is metadata-only; machine-local MCP commands and secrets are not exposed.',
+    tests: ['render.test.ts', 'performance.test.ts'],
+  },
+  {
+    routeId: 'capabilities',
+    surface: 'workbench',
+    requiredRole: 'member',
+    endpointIds: ['capabilitiesCatalog', 'capabilityTools', 'capabilitySkills'],
+    states: {
+      loading: 'Tools and skills render empty lists until capability metadata returns.',
+      empty: 'No tools loaded / No skills loaded.',
+      error: 'Profile-disabled capabilities show explicit unavailable-surface notes.',
+    },
+    disabledBehavior: 'Controls are disabled when all capability surfaces are policy-disabled.',
+    pagination: 'Local filtering is bounded and covered by performance tests; API cursoring is deferred.',
+    redaction: 'Machine-scoped MCPs are displayed as policy-limited metadata, not executable local commands.',
+    tests: ['render.test.ts', 'performance.test.ts'],
+  },
+  {
+    routeId: 'workflows',
+    surface: 'workbench',
+    requiredRole: 'member',
+    endpointIds: ['workflows', 'workflow', 'workflowRun', 'workflowPause', 'workflowResume', 'workflowArchive'],
+    states: {
+      loading: 'Workflow tables render empty rows until /api/workflows returns.',
+      empty: 'No workflows loaded.',
+      error: 'Disabled workflow policy and action failures render through the workflow panel/status.',
+    },
+    disabledBehavior: 'Workflow create/run controls are disabled when workflows are disabled by profile policy.',
+    pagination: 'The route consumes the current workflow summary payload; run-history cursoring is deferred.',
+    redaction: 'Workflow rows expose cloud metadata only, never worker credentials or local paths.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'artifacts',
+    surface: 'workbench',
+    requiredRole: 'member',
+    endpointIds: ['sessionArtifacts', 'sessionArtifact'],
+    states: {
+      loading: 'Artifact inspector starts idle until a selected session artifact is inspected.',
+      empty: 'No artifacts loaded.',
+      error: 'Artifact metadata/download errors stay in the artifact panel.',
+    },
+    disabledBehavior: 'Artifact body fetches happen only from explicit Inspect/Download actions.',
+    pagination: 'Selected-session artifact lists use the cloud artifact API; cross-session artifact browsing is deferred.',
+    redaction: 'Signed URLs, object keys, buckets, tokens, and raw object-store internals are stripped from metadata.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'org',
+    surface: 'admin',
+    requiredRole: 'public',
+    endpointIds: ['authMe', 'config', 'workspace'],
+    states: {
+      loading: 'Org route is the signed-out and bootstrap fallback while auth resolves.',
+      empty: 'Signed-out state shows sign-in copy.',
+      error: 'Auth errors route the shell to signed-out mode.',
+    },
+    disabledBehavior: 'Signed-in-only routes and controls are hidden while signed out.',
+    pagination: 'Not applicable.',
+    redaction: 'Bootstrap JSON carries public branding and feature metadata only.',
+    tests: ['browser-e2e.test.ts', 'accessibility.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'members',
+    surface: 'admin',
+    requiredRole: 'admin',
+    endpointIds: ['adminMembers', 'adminMemberInvite', 'adminMemberUpdate'],
+    states: {
+      loading: 'Member table renders empty rows until admin data returns.',
+      empty: 'No member records loaded.',
+      error: 'Admin API denial renders in the member table.',
+    },
+    disabledBehavior: 'Invite and role controls are disabled for members and when signup mode is not invite.',
+    pagination: 'Admin members endpoint accepts q and limit; the browser currently loads the first bounded page.',
+    redaction: 'Member rows expose identity and role/status only.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'policy',
+    surface: 'admin',
+    requiredRole: 'member',
+    endpointIds: ['adminPolicy', 'adminWorkerPools', 'adminWorkers', 'adminWorkerHeartbeats'],
+    states: {
+      loading: 'Policy and worker summaries load after sign-in.',
+      empty: 'No policy loaded / No worker pools loaded.',
+      error: 'Policy or worker summary errors render as explicit admin-surface messages.',
+    },
+    disabledBehavior: 'Mutating policy controls are not exposed in v1; summaries remain read-only.',
+    pagination: 'Worker pools and workers load bounded first pages with limit=100.',
+    redaction: 'Worker health summaries exclude credentials and heartbeat secrets.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'byok',
+    surface: 'admin',
+    requiredRole: 'admin',
+    endpointIds: ['byok'],
+    states: {
+      loading: 'Provider status metadata loads after sign-in.',
+      empty: 'No configured providers.',
+      error: 'Provider policy and validation failures render in status.',
+    },
+    disabledBehavior: 'Key entry, validation, and disable controls are admin-only.',
+    pagination: 'Not applicable; BYOK status is provider-scoped metadata.',
+    redaction: 'Plaintext provider keys are write-only and never re-rendered from state.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'connections',
+    surface: 'admin',
+    requiredRole: 'admin',
+    endpointIds: ['apiTokens'],
+    states: {
+      loading: 'Token list loads after sign-in.',
+      empty: 'No issued tokens.',
+      error: 'Token issue/revoke errors render in status.',
+    },
+    disabledBehavior: 'Token issue and revoke controls are admin-only and destructive actions require typed confirmation.',
+    pagination: 'API token list is bounded by server defaults; cursoring is deferred.',
+    redaction: 'Token plaintext is shown once only after creation and never persisted.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'billing',
+    surface: 'admin',
+    requiredRole: 'admin',
+    endpointIds: ['billingSubscription'],
+    states: {
+      loading: 'Subscription state loads with the dashboard bootstrap.',
+      empty: 'Self-host mode renders billing disabled.',
+      error: 'Checkout/portal errors render in status.',
+    },
+    disabledBehavior: 'Billing controls are disabled for self-host mode and non-admin users.',
+    pagination: 'Not applicable.',
+    redaction: 'Billing UI renders entitlement state, not provider secrets.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'gateway',
+    surface: 'admin',
+    requiredRole: 'admin',
+    endpointIds: ['channelAgents', 'channelBindings', 'channelDeliveries', 'channelDeliveryRetry', 'channelDeliveryDeadLetter'],
+    states: {
+      loading: 'Gateway agents, bindings, and delivery backlog load after sign-in.',
+      empty: 'No gateway agents, bindings, or deliveries loaded.',
+      error: 'Gateway API denial leaves explicit unavailable surface state.',
+    },
+    disabledBehavior: 'Gateway setup, binding, retry, and dead-letter actions are admin-only.',
+    pagination: 'Delivery backlog loads the first 50 rows; provider streams are handled by Gateway, not the browser.',
+    redaction: 'Channel credential refs are metadata only; channel secrets are not rendered.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'audit',
+    surface: 'admin',
+    requiredRole: 'admin',
+    endpointIds: ['adminAudit'],
+    states: {
+      loading: 'Audit list loads after admin bootstrap.',
+      empty: 'No audit events loaded.',
+      error: 'Admin denial renders in the audit list.',
+    },
+    disabledBehavior: 'Export is admin-only and exports redacted audit events.',
+    pagination: 'Audit endpoint loads the first 100 events; cursor export is deferred.',
+    redaction: 'Audit metadata is expected to be server-redacted before browser export.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'usage',
+    surface: 'admin',
+    requiredRole: 'member',
+    endpointIds: ['usageEvents', 'usageSummary'],
+    states: {
+      loading: 'Usage quota and totals load during dashboard refresh.',
+      empty: 'No usage events recorded yet.',
+      error: 'Usage API failures render through the global status.',
+    },
+    disabledBehavior: 'Usage is read-only; export is available for the visible redacted summary.',
+    pagination: 'Usage events load limit=20 and summaries load limit=100.',
+    redaction: 'Usage events contain metering dimensions only, not prompts or secrets.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
+    routeId: 'diagnostics',
+    surface: 'admin',
+    requiredRole: 'operator',
+    endpointIds: ['diagnostics', 'runtimeStatus', 'workerHeartbeats'],
+    states: {
+      loading: 'Diagnostics are loaded only after Prepare bundle.',
+      empty: 'Prepare a bundle to inspect redacted support data.',
+      error: 'Operator/admin boundary errors remain visible in the diagnostics panel.',
+    },
+    disabledBehavior: 'Diagnostics controls are hidden from non-admin users and may still require operator-token privileges.',
+    pagination: 'Diagnostics includes bounded worker heartbeat and gateway delivery samples.',
+    redaction: 'Diagnostics bundle is recursively redacted for tokens, cookies, API keys, object URLs, and credential refs.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+]
+
+export function findCloudWebRouteApiMatrix(routeId: CloudWebRouteId) {
+  return CLOUD_WEB_ROUTE_API_MATRIX.find((entry) => entry.routeId === routeId) || null
+}

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -1,0 +1,98 @@
+# Cloud Web Workbench
+
+Cloud Web is the browser workbench for cloud workspaces. It is a Cloud API
+client over the same tenant-scoped sessions, projections, workflows, artifacts,
+policy, and gateway records used by Desktop Cloud and Gateway. It must not
+import server-only stores, secret adapters, runtime adapters, or OpenCode SDK
+surfaces.
+
+The canonical workspace and sync promises live in
+[Product Contract](product-contract.md). This page is the release contract for
+the browser surface.
+
+## Route/API Matrix
+
+The typed source of truth is
+`apps/website/src/route-api-matrix.ts`. Every route must have a matrix entry
+with required role, backing endpoint ids, loading/empty/error states,
+disabled-state behavior, pagination or cursor notes, redaction requirements,
+and tests.
+
+| Route id | Surface | Required role | Backing endpoint ids | Pagination / cursor | Redaction and disabled behavior |
+|---|---|---|---|---|---|
+| `threads` | Workbench | Member | `sessions`, `sessionView`, `projectSourceValidate`, `projectSnapshots` | Browser list is bounded by `CLOUD_WEB_THREAD_PAGE_SIZE`; backend cursoring is deferred until the sessions API exposes cursors. | Chat controls disable when policy blocks chat. Local host paths and local MCP process details are never sent as thread context. |
+| `chat` | Workbench | Member | `sessionView`, `sessionEvents`, `sessionPrompt`, `sessionPermissionRespond`, `sessionQuestionReply`, `sessionQuestionReject` | Session SSE resumes from the durable Cloud projection sequence. | Composer disables until a Cloud thread is selected. Runtime state is rendered from Cloud projections, not a browser-only projection model. |
+| `agents` | Workbench | Member | `workspace`, `capabilitiesCatalog` | Capability filtering is local and performance-tested. | Agent metadata is cloud profile metadata only; local stdio MCP commands and secrets are not rendered. |
+| `capabilities` | Workbench | Member | `capabilitiesCatalog`, `capabilityTools`, `capabilitySkills` | Local capability filtering is bounded; API cursoring is deferred. | Machine-scoped MCPs are visible only as policy-limited metadata. |
+| `workflows` | Workbench | Member | `workflows`, `workflow`, `workflowRun`, `workflowPause`, `workflowResume`, `workflowArchive` | Workflow summary payload is bounded by the Cloud API; run-history cursoring is deferred. | Workflow controls disable when profile policy blocks workflows. Rows never expose worker credentials or local paths. |
+| `artifacts` | Workbench | Member | `sessionArtifacts`, `sessionArtifact` | Selected-session artifact lists use the Cloud artifact API. Cross-session artifact browsing is deferred. | Artifact bodies fetch only after explicit action. Signed URLs, object keys, buckets, tokens, and object-store internals are stripped from metadata. |
+| `org` | Admin | Public | `authMe`, `config`, `workspace` | Not applicable. | Signed-out state hides signed-in routes. Bootstrap JSON carries public branding, route metadata, endpoint metadata, and feature metadata only. |
+| `members` | Admin | Admin | `adminMembers`, `adminMemberInvite`, `adminMemberUpdate` | Members endpoint supports `q` and `limit`; the browser loads the first bounded page. | Member rows expose identity, role, and status only. Invite and role controls disable for non-admins and non-invite signup modes. |
+| `policy` | Admin | Member | `adminPolicy`, `adminWorkerPools`, `adminWorkers`, `adminWorkerHeartbeats` | Worker pools and workers load first pages with `limit=100`; heartbeat detail is worker-scoped. | Policy and worker health summaries are read-only in v1 and exclude credentials, heartbeat tokens, and worker secrets. |
+| `byok` | Admin | Admin | `byok` | Not applicable. | Provider keys are write-only. The browser only renders provider id, credential kind, last4/fingerprint/status, and validation timestamps. |
+| `connections` | Admin | Admin | `apiTokens` | API token list is bounded by server defaults; cursoring is deferred. | Token plaintext is shown once after creation and never stored in persistent browser storage. |
+| `billing` | Admin | Admin | `billingSubscription` | Not applicable. | Billing renders entitlement state and plan metadata only. Self-host mode disables managed billing controls. |
+| `gateway` | Admin | Admin | `channelAgents`, `channelBindings`, `channelDeliveries`, `channelDeliveryRetry`, `channelDeliveryDeadLetter` | Delivery backlog loads the first 50 rows. Provider streams are handled by Gateway, not the browser. | Channel credential refs are metadata only. Retry and dead-letter actions require admin controls and confirmation. |
+| `audit` | Admin | Admin | `adminAudit` | Audit endpoint loads the first 100 events. Cursor export is deferred. | Audit metadata must be server-redacted before browser display or export. |
+| `usage` | Admin | Member | `usageEvents`, `usageSummary` | Usage events load `limit=20`; summaries load `limit=100`. | Usage events include metering dimensions only, not prompts, provider keys, or tokens. |
+| `diagnostics` | Admin | Operator | `diagnostics`, `runtimeStatus`, `workerHeartbeats` | Diagnostics includes bounded worker heartbeat and gateway delivery samples. | Diagnostics are redacted recursively. Org admins may see the route, but the API may require operator-token privileges for global operational state. |
+
+## End-User Workbench Contract
+
+Cloud Web must keep parity with Desktop Cloud for cloud workspaces:
+
+- start and continue Cloud threads
+- hydrate from the full Cloud `SessionView` projection
+- render messages, task runs, tool calls, approvals, questions, todos,
+  artifacts, cost, status, and errors
+- send prompts through durable Cloud commands
+- answer approvals and questions through Cloud APIs
+- reconnect SSE from durable projection cursors
+- browse artifact metadata and fetch bodies only on explicit action
+- run workflows through the Cloud workflow API
+- show custom agent, skill, and MCP metadata with policy verdicts
+
+The browser must not create a second projection model. It consumes Cloud
+snapshots and events through the shared API contract.
+
+## Admin Contract
+
+Admin and operator surfaces must avoid direct database or shell access for
+normal operations:
+
+- members, invite mode, roles, and status
+- profile, capability, project-source, runtime, and gateway policy summaries
+- BYOK provider status and write-only key rotation
+- API tokens for Desktop and Gateway clients
+- billing and entitlement status
+- quota windows, usage totals, and usage event samples
+- org-scoped managed worker pools and worker health summaries
+- headless agents, channel bindings, and delivery backlog
+- redacted audit logs and diagnostics
+
+Sensitive mutations must be role-checked by the Cloud API and auditable. Browser
+disabled controls are only ergonomic hints; authorization remains server-side.
+
+## Browser Quality Gates
+
+Cloud Web changes should run:
+
+```bash
+pnpm test:cloud-web
+```
+
+For release-sensitive changes also run:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm test:cloud-continuation
+pnpm docs:build
+git diff --check
+```
+
+The Cloud Web gates cover browser workflow smoke, accessibility/keyboard
+behavior, responsive layout expectations, performance budgets for large thread
+and capability lists, route/API matrix coverage, and package-boundary checks
+that keep the browser out of server-only modules.

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -41,6 +41,9 @@ The full cross-surface contract is documented in
 [Product Contract](product-contract.md). Cloud implements the cloud-workspace
 side of that contract.
 
+The browser release contract and route/API matrix are documented in
+[Cloud Web Workbench](cloud-web-workbench.md).
+
 Cloud is the source of truth only for cloud workspaces. A user can start a
 cloud thread in desktop, continue it in the browser, and interact with the same
 thread through a gateway channel because all three clients read and write the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
   - Build & Extend:
       - Architecture: architecture.md
       - Product Contract: product-contract.md
+      - Cloud Web Workbench: cloud-web-workbench.md
       - Downstream Customization: downstream.md
       - OpenCode SDK Boundary: opencode-sdk-v2-boundary.md
       - Development Environment: development-environment.md


### PR DESCRIPTION
Closes #549.

## Summary
- add a typed Cloud Web route/API matrix and docs page covering route roles, endpoints, states, pagination/cursor behavior, redaction, and test ownership
- expose the route matrix through Cloud Web bootstrap metadata and guard it with render tests
- add org-scoped worker pool and worker health summaries to the Profiles & Policy admin surface using existing admin APIs
- improve diagnostics unavailable-state copy and extend the browser harness/e2e coverage for worker health

## Validation
- pnpm --filter @open-cowork/website test
- pnpm --filter @open-cowork/website typecheck
- pnpm test:cloud-web
- pnpm test:cloud-continuation
- pnpm deploy:validate
- pnpm docs:build
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check