### PR TITLE
Harden gateway appliance readiness

### DIFF
--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -684,6 +684,59 @@ test('gateway runtime retries transient deliveries and marks permanent failures 
   }
 })
 
+test('gateway runtime drains in-flight deliveries before provider shutdown', async () => {
+  let onDelivery: ((delivery: unknown) => void) | null = null
+  const acks: Array<{ deliveryId: string, input: Record<string, unknown> }> = []
+  const cloud = {
+    subscribeDeliveries(input: { onDelivery: (delivery: unknown) => void }) {
+      onDelivery = input.onDelivery
+      return { close() {} }
+    },
+    async ackDelivery(deliveryId: string, input: Record<string, unknown>) {
+      acks.push({ deliveryId, input })
+      return { deliveryId, ...input } as never
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud)
+  const provider = runtime.providers.get('fake')?.provider
+  assert.ok(provider)
+  const originalSendText = provider.sendText.bind(provider)
+  let releaseSend: (() => void) | null = null
+  provider.sendText = async (...args) => {
+    await new Promise<void>((resolve) => {
+      releaseSend = resolve
+    })
+    return originalSendText(...args)
+  }
+
+  await runtime.start()
+  onDelivery?.(deliveryRecord({ deliveryId: 'delivery-drain', attemptCount: 1 }))
+  await waitFor(() => runtime.metrics.deliveriesReceived === 1)
+  let stopped = false
+  const stopPromise = runtime.stop().then(() => {
+    stopped = true
+  })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(stopped, false)
+  assert.equal(acks.length, 0)
+
+  releaseSend?.()
+  await stopPromise
+  assert.equal(stopped, true)
+  assert.equal(acks[0]?.deliveryId, 'delivery-drain')
+  assert.equal(acks[0]?.input.status, 'sent')
+})
+
 function deliveryRecord(overrides: Partial<{
   deliveryId: string
   attemptCount: number

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -39,6 +39,7 @@ export function createGatewayRuntime(
   const metrics = createGatewayMetrics()
   const streams = createGatewaySessionStreamManager(cloud, metrics)
   const deliverySubscriptions: Array<{ close(): void }> = []
+  const inFlightDeliveries = new Set<Promise<void>>()
   let started = false
 
   const runtime: GatewayRuntime = {
@@ -53,7 +54,11 @@ export function createGatewayRuntime(
         deliverySubscriptions.push(cloud.subscribeDeliveries({
           claimedBy: `gateway:${config.mode}`,
           onDelivery: (delivery) => {
-            void handleDelivery(delivery, providers, cloud, metrics)
+            const task = handleDelivery(delivery, providers, cloud, metrics)
+              .finally(() => {
+                inFlightDeliveries.delete(task)
+              })
+            inFlightDeliveries.add(task)
           },
           onError: () => {
             metrics.cloudSubscriptionErrors += 1
@@ -63,8 +68,11 @@ export function createGatewayRuntime(
       }
     },
     async stop() {
-      streams.closeAll()
       for (const subscription of deliverySubscriptions.splice(0)) subscription.close()
+      streams.closeAll()
+      if (inFlightDeliveries.size > 0) {
+        await Promise.allSettled([...inFlightDeliveries])
+      }
       await providers.stop()
       started = false
     },

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -59,6 +59,12 @@ export {
   type GatewayProviderRegistry,
 } from './provider-registry.js'
 export {
+  findGatewayProviderReadiness,
+  GATEWAY_PROVIDER_READINESS_MATRIX,
+  type GatewayProviderReadinessEntry,
+  type GatewayProviderReadinessTier,
+} from './provider-readiness.js'
+export {
   createGatewaySessionStreamManager,
   type GatewaySessionStreamManager,
 } from './session-stream-manager.js'

--- a/apps/gateway/src/provider-readiness.test.ts
+++ b/apps/gateway/src/provider-readiness.test.ts
@@ -1,0 +1,169 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import type { ChannelCapabilities } from '@open-cowork/gateway-channel'
+
+import {
+  createGatewayProviderRegistry,
+  GATEWAY_PROVIDER_READINESS_MATRIX,
+  resolveGatewayConfig,
+} from '../dist/index.js'
+
+const capabilityKeys: Array<keyof ChannelCapabilities> = [
+  'threads',
+  'messageEditing',
+  'inlineButtons',
+  'fileUploads',
+  'fileDownloads',
+  'typingIndicator',
+  'maxTextLength',
+  'preferredParseMode',
+  'maxButtonsPerMessage',
+  'maxButtonRowsPerMessage',
+  'maxButtonTokenBytes',
+  'maxFileBytes',
+  'supportsEphemeralResponses',
+]
+
+test('gateway provider readiness matrix covers every provider tier', () => {
+  const entries = [...GATEWAY_PROVIDER_READINESS_MATRIX]
+  assert.deepEqual(entries.map((entry) => entry.kind).sort(), [
+    'cli',
+    'discord',
+    'email',
+    'fake',
+    'signal',
+    'slack',
+    'telegram',
+    'webhook',
+    'whatsapp',
+  ])
+  assert.deepEqual(entries.filter((entry) => entry.tier === 1).map((entry) => entry.kind).sort(), ['email', 'slack', 'telegram'])
+  assert.deepEqual(entries.filter((entry) => entry.tier === 2).map((entry) => entry.kind).sort(), ['cli', 'webhook'])
+  assert.deepEqual(entries.filter((entry) => entry.tier === 3).map((entry) => entry.kind).sort(), ['discord', 'signal', 'whatsapp'])
+  assert.deepEqual(entries.filter((entry) => entry.tier === 'demo').map((entry) => entry.kind), ['fake'])
+
+  for (const entry of entries) {
+    assert.ok(entry.displayName, `${entry.kind} has display name`)
+    assert.ok(entry.intendedUse, `${entry.kind} has intended use`)
+    assert.ok(entry.authRequirements.length > 0, `${entry.kind} has auth requirements`)
+    assert.ok(entry.ingressModes.length > 0, `${entry.kind} has ingress modes`)
+    assert.ok(entry.rateLimitBehavior, `${entry.kind} has rate-limit behavior`)
+    assert.ok(entry.liveSmoke, `${entry.kind} has live smoke instructions`)
+    assert.ok(entry.localContractTests.length > 0, `${entry.kind} has local contract tests`)
+    for (const testPath of entry.localContractTests.filter((candidatePath) => candidatePath.endsWith('.ts'))) {
+      assert.ok(existsSync(fileURLToPath(new URL(`../../../${testPath}`, import.meta.url))), `${entry.kind} test path exists: ${testPath}`)
+    }
+  }
+})
+
+test('gateway provider readiness matrix matches actual provider capabilities and docs', () => {
+  const registry = createGatewayProviderRegistry(resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }, {
+      id: 'telegram',
+      kind: 'telegram',
+      channelBindingId: 'telegram-binding',
+      credentials: { botToken: 'telegram-token' },
+    }, {
+      id: 'slack',
+      kind: 'slack',
+      channelBindingId: 'slack-binding',
+      credentials: {
+        botToken: 'xoxb-slack-token',
+        signingSecret: 'slack-signing-secret',
+      },
+    }, {
+      id: 'email',
+      kind: 'email',
+      channelBindingId: 'email-binding',
+      credentials: {
+        inboundSecret: 'email-inbound-secret',
+      },
+      settings: {
+        from: 'agent@example.test',
+        smtpHost: 'smtp.example.test',
+      },
+    }, {
+      id: 'webhook',
+      kind: 'webhook',
+      channelBindingId: 'webhook-binding',
+      credentials: {
+        sharedSecret: 'webhook-secret',
+      },
+      settings: {
+        deliveryUrl: 'https://bridge.example.test/outbound',
+      },
+    }, {
+      id: 'discord',
+      kind: 'discord',
+      channelBindingId: 'discord-binding',
+      credentials: {
+        sharedSecret: 'discord-secret',
+      },
+      settings: {
+        deliveryUrl: 'https://bridge.example.test/discord',
+      },
+    }, {
+      id: 'whatsapp',
+      kind: 'whatsapp',
+      channelBindingId: 'whatsapp-binding',
+      credentials: {
+        sharedSecret: 'whatsapp-secret',
+      },
+      settings: {
+        deliveryUrl: 'https://bridge.example.test/whatsapp',
+      },
+    }, {
+      id: 'signal',
+      kind: 'signal',
+      channelBindingId: 'signal-binding',
+      credentials: {
+        sharedSecret: 'signal-secret',
+      },
+      settings: {
+        deliveryUrl: 'https://bridge.example.test/signal',
+      },
+    }, {
+      id: 'cli',
+      kind: 'cli',
+      channelBindingId: 'cli-binding',
+    }],
+  }))
+  const doc = readFileSync(fileURLToPath(new URL('../../../docs/gateway-provider-readiness.md', import.meta.url)), 'utf8')
+  assert.match(doc, /Provider Readiness Matrix/)
+
+  for (const entry of GATEWAY_PROVIDER_READINESS_MATRIX) {
+    const registration = registry.registrations.find((candidate) => candidate.config.kind === entry.kind)
+    assert.ok(registration, `provider registry has ${entry.kind}`)
+    assert.deepEqual(pickCapabilities(registration.provider.capabilities), entry.capabilities, `${entry.kind} capabilities match matrix`)
+    assert.match(doc, new RegExp('`' + entry.kind + '`'), `docs include ${entry.kind}`)
+    assert.match(doc, new RegExp(`Tier ${entry.tier}`), `docs include tier ${entry.tier}`)
+    for (const path of entry.localContractTests) {
+      assert.match(doc, new RegExp(escapeRegExp(path)), `docs include ${entry.kind} test ${path}`)
+    }
+  }
+})
+
+function pickCapabilities(capabilities: ChannelCapabilities) {
+  const picked: Partial<ChannelCapabilities> = {}
+  for (const key of capabilityKeys) {
+    if (capabilities[key] !== undefined) {
+      picked[key] = capabilities[key] as never
+    }
+  }
+  return picked
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/apps/gateway/src/provider-readiness.ts
+++ b/apps/gateway/src/provider-readiness.ts
@@ -1,0 +1,335 @@
+import type { ChannelCapabilities } from '@open-cowork/gateway-channel'
+
+import type { GatewayProviderKind } from './config.js'
+
+type GatewayCapabilitySummary = Pick<
+  ChannelCapabilities,
+  | 'threads'
+  | 'messageEditing'
+  | 'inlineButtons'
+  | 'fileUploads'
+  | 'fileDownloads'
+  | 'typingIndicator'
+  | 'maxTextLength'
+  | 'preferredParseMode'
+  | 'maxButtonsPerMessage'
+  | 'maxButtonRowsPerMessage'
+  | 'maxButtonTokenBytes'
+  | 'maxFileBytes'
+  | 'supportsEphemeralResponses'
+>
+
+export type GatewayProviderReadinessTier = 1 | 2 | 3 | 'demo'
+
+export type GatewayProviderReadinessEntry = {
+  kind: GatewayProviderKind
+  displayName: string
+  tier: GatewayProviderReadinessTier
+  status: 'launch' | 'utility' | 'later' | 'demo'
+  intendedUse: string
+  capabilities: GatewayCapabilitySummary
+  authRequirements: string[]
+  ingressModes: string[]
+  approvalMode: 'inline-buttons' | 'token-fallback' | 'inline-or-token'
+  fileSupport: string
+  rateLimitBehavior: string
+  localContractTests: string[]
+  liveSmoke: string
+}
+
+export const GATEWAY_PROVIDER_READINESS_MATRIX: GatewayProviderReadinessEntry[] = [
+  {
+    kind: 'telegram',
+    displayName: 'Telegram',
+    tier: 1,
+    status: 'launch',
+    intendedUse: 'Launch-ready direct-message and group-topic bot for self-hosted and managed Gateway installs.',
+    capabilities: {
+      threads: true,
+      messageEditing: true,
+      inlineButtons: true,
+      fileUploads: true,
+      fileDownloads: true,
+      typingIndicator: true,
+      maxTextLength: 4096,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 8,
+      maxButtonRowsPerMessage: 4,
+      maxButtonTokenBytes: 64,
+      maxFileBytes: 20 * 1024 * 1024,
+      supportsEphemeralResponses: true,
+    },
+    authRequirements: ['bot token', 'webhook secret when webhook mode is enabled'],
+    ingressModes: ['polling', 'webhook'],
+    approvalMode: 'inline-or-token',
+    fileSupport: 'Uploads and downloads are supported within Telegram file-size limits.',
+    rateLimitBehavior: 'Provider uses bounded Telegram retry/backoff for transient API and rate-limit responses.',
+    localContractTests: [
+      'packages/gateway-provider-telegram/src/telegram-provider.test.ts',
+      'packages/gateway-provider-telegram/src/telegram-retry.test.ts',
+      'apps/gateway/src/daemon.test.ts',
+    ],
+    liveSmoke: 'Use polling for private installs; webhook smoke requires HTTPS public URL plus Telegram webhook secret.',
+  },
+  {
+    kind: 'slack',
+    displayName: 'Slack',
+    tier: 1,
+    status: 'launch',
+    intendedUse: 'Launch-ready team workspace channel with signed webhook ingress, Block Kit approvals, threads, and files.',
+    capabilities: {
+      threads: true,
+      messageEditing: true,
+      inlineButtons: true,
+      fileUploads: true,
+      fileDownloads: true,
+      typingIndicator: false,
+      maxTextLength: 3000,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 10,
+      maxButtonRowsPerMessage: 5,
+      maxButtonTokenBytes: 2000,
+      maxFileBytes: 20 * 1024 * 1024,
+      supportsEphemeralResponses: false,
+    },
+    authRequirements: ['bot token', 'signing secret'],
+    ingressModes: ['webhook'],
+    approvalMode: 'inline-or-token',
+    fileSupport: 'Uploads and downloads are supported through Slack API file endpoints.',
+    rateLimitBehavior: 'Provider surfaces Slack API failures to Gateway delivery retry/dead-letter policy.',
+    localContractTests: [
+      'packages/gateway-provider-slack/src/slack-provider.test.ts',
+      'apps/gateway/src/daemon.test.ts',
+    ],
+    liveSmoke: 'Create a Slack app with Events and Interactivity pointed at /webhooks/slack; verify signed events and button callbacks.',
+  },
+  {
+    kind: 'email',
+    displayName: 'Email',
+    tier: 1,
+    status: 'launch',
+    intendedUse: 'Launch-ready async channel for prompt-by-email and delayed workflow replies.',
+    capabilities: {
+      threads: true,
+      messageEditing: false,
+      inlineButtons: false,
+      fileUploads: true,
+      fileDownloads: false,
+      typingIndicator: false,
+      maxTextLength: 20_000,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 0,
+      maxButtonRowsPerMessage: 0,
+      maxButtonTokenBytes: 0,
+      maxFileBytes: 15 * 1024 * 1024,
+      supportsEphemeralResponses: false,
+    },
+    authRequirements: ['inbound webhook shared secret', 'SMTP credentials when SMTP auth is required'],
+    ingressModes: ['webhook'],
+    approvalMode: 'token-fallback',
+    fileSupport: 'Inbound attachments are accepted; outbound artifacts should render as links.',
+    rateLimitBehavior: 'SMTP and inbound webhook failures flow through Gateway delivery retry/dead-letter policy.',
+    localContractTests: [
+      'packages/gateway-provider-email/src/email-provider.test.ts',
+      'apps/gateway/src/event-renderer.test.ts',
+    ],
+    liveSmoke: 'Send an inbound provider webhook or email fixture and verify the threaded reply path.',
+  },
+  {
+    kind: 'webhook',
+    displayName: 'Generic Webhook',
+    tier: 2,
+    status: 'utility',
+    intendedUse: 'Local and integration bridge for custom systems that can sign Gateway ingress and accept signed delivery callbacks.',
+    capabilities: {
+      threads: true,
+      messageEditing: true,
+      inlineButtons: true,
+      fileUploads: true,
+      fileDownloads: false,
+      typingIndicator: true,
+      maxTextLength: 4096,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 8,
+      maxButtonRowsPerMessage: 4,
+      maxButtonTokenBytes: 64,
+      maxFileBytes: 25 * 1024 * 1024,
+      supportsEphemeralResponses: false,
+    },
+    authRequirements: ['shared secret for HMAC/timestamp ingress and outbound delivery signing'],
+    ingressModes: ['webhook'],
+    approvalMode: 'inline-or-token',
+    fileSupport: 'Inbound files may be carried inline; outbound file downloads should be represented by links.',
+    rateLimitBehavior: 'Bridge delivery uses bounded retry/backoff for transient HTTP failures.',
+    localContractTests: [
+      'packages/gateway-provider-webhook/src/webhook-provider.test.ts',
+      'apps/gateway/src/daemon.test.ts',
+    ],
+    liveSmoke: 'Use a signed bridge fixture; public ingress must reject unsigned, stale, and replayed requests.',
+  },
+  {
+    kind: 'cli',
+    displayName: 'CLI',
+    tier: 2,
+    status: 'utility',
+    intendedUse: 'Local integration and smoke-test channel; not a public webhook surface.',
+    capabilities: {
+      threads: true,
+      messageEditing: false,
+      inlineButtons: false,
+      fileUploads: true,
+      fileDownloads: false,
+      typingIndicator: false,
+      maxTextLength: 12_000,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 0,
+      maxButtonRowsPerMessage: 0,
+      maxButtonTokenBytes: 0,
+      maxFileBytes: 10 * 1024 * 1024,
+      supportsEphemeralResponses: false,
+    },
+    authRequirements: ['local process boundary; no public HTTP ingress'],
+    ingressModes: ['stdio'],
+    approvalMode: 'token-fallback',
+    fileSupport: 'Inbound file metadata can be represented; outbound artifacts should render as links.',
+    rateLimitBehavior: 'No provider-side rate limit; Gateway delivery retry/dead-letter still applies to cloud delivery records.',
+    localContractTests: [
+      'packages/gateway-provider-cli/src/cli-provider.test.ts',
+      'scripts/gateway-cloud-smoke.mjs',
+    ],
+    liveSmoke: 'Use only on trusted local hosts or CI smoke environments.',
+  },
+  {
+    kind: 'discord',
+    displayName: 'Discord',
+    tier: 3,
+    status: 'later',
+    intendedUse: 'Bridge-backed provider for later live-provider hardening.',
+    capabilities: {
+      threads: true,
+      messageEditing: true,
+      inlineButtons: true,
+      fileUploads: true,
+      fileDownloads: true,
+      typingIndicator: true,
+      maxTextLength: 2000,
+      preferredParseMode: 'markdown',
+      maxButtonsPerMessage: 25,
+      maxButtonRowsPerMessage: 5,
+      maxButtonTokenBytes: 64,
+      maxFileBytes: 8 * 1024 * 1024,
+      supportsEphemeralResponses: true,
+    },
+    authRequirements: ['bridge shared secret'],
+    ingressModes: ['signed bridge webhook'],
+    approvalMode: 'inline-or-token',
+    fileSupport: 'Bridge advertises upload and download support within Discord-like limits.',
+    rateLimitBehavior: 'Bridge delivery uses bounded webhook retry/backoff; live Discord app rate-limit behavior remains hardening work.',
+    localContractTests: [
+      'packages/gateway-provider-discord/src/discord-provider.test.ts',
+      'packages/gateway-provider-webhook/src/webhook-provider.test.ts',
+    ],
+    liveSmoke: 'Deferred until a first-party Discord app adapter is promoted from bridge mode.',
+  },
+  {
+    kind: 'whatsapp',
+    displayName: 'WhatsApp',
+    tier: 3,
+    status: 'later',
+    intendedUse: 'Bridge-backed provider for later WhatsApp Cloud API or Twilio hardening.',
+    capabilities: {
+      threads: false,
+      messageEditing: false,
+      inlineButtons: true,
+      fileUploads: true,
+      fileDownloads: true,
+      typingIndicator: true,
+      maxTextLength: 4096,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 3,
+      maxButtonRowsPerMessage: 1,
+      maxButtonTokenBytes: 64,
+      maxFileBytes: 16 * 1024 * 1024,
+      supportsEphemeralResponses: false,
+    },
+    authRequirements: ['bridge shared secret'],
+    ingressModes: ['signed bridge webhook'],
+    approvalMode: 'inline-or-token',
+    fileSupport: 'Bridge advertises media upload and download support within WhatsApp-like limits.',
+    rateLimitBehavior: 'Bridge delivery uses bounded webhook retry/backoff; live WhatsApp rate-limit behavior remains hardening work.',
+    localContractTests: [
+      'packages/gateway-provider-whatsapp/src/whatsapp-provider.test.ts',
+      'packages/gateway-provider-webhook/src/webhook-provider.test.ts',
+    ],
+    liveSmoke: 'Deferred until a first-party WhatsApp Cloud API or Twilio adapter is promoted from bridge mode.',
+  },
+  {
+    kind: 'signal',
+    displayName: 'Signal',
+    tier: 3,
+    status: 'later',
+    intendedUse: 'Bridge-backed provider for later signal-cli hardening.',
+    capabilities: {
+      threads: false,
+      messageEditing: false,
+      inlineButtons: false,
+      fileUploads: true,
+      fileDownloads: true,
+      typingIndicator: true,
+      maxTextLength: 4096,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 8,
+      maxButtonRowsPerMessage: 4,
+      maxButtonTokenBytes: 64,
+      maxFileBytes: 100 * 1024 * 1024,
+      supportsEphemeralResponses: false,
+    },
+    authRequirements: ['bridge shared secret'],
+    ingressModes: ['signed bridge webhook'],
+    approvalMode: 'token-fallback',
+    fileSupport: 'Bridge advertises large media upload and download support; approvals use command-token fallback.',
+    rateLimitBehavior: 'Bridge delivery uses bounded webhook retry/backoff; live signal-cli rate-limit behavior remains hardening work.',
+    localContractTests: [
+      'packages/gateway-provider-signal/src/signal-provider.test.ts',
+      'packages/gateway-provider-webhook/src/webhook-provider.test.ts',
+    ],
+    liveSmoke: 'Deferred until a signal-cli bridge deployment recipe is promoted.',
+  },
+  {
+    kind: 'fake',
+    displayName: 'Fake',
+    tier: 'demo',
+    status: 'demo',
+    intendedUse: 'Explicit loopback-only local/demo and CI smoke provider.',
+    capabilities: {
+      threads: false,
+      messageEditing: true,
+      inlineButtons: true,
+      fileUploads: true,
+      fileDownloads: true,
+      typingIndicator: false,
+      maxTextLength: 4096,
+      preferredParseMode: 'plain',
+      maxButtonsPerMessage: 8,
+      maxButtonRowsPerMessage: 4,
+      maxButtonTokenBytes: 128,
+      maxFileBytes: 25 * 1024 * 1024,
+      supportsEphemeralResponses: true,
+    },
+    authRequirements: ['explicit OPEN_COWORK_GATEWAY_ENABLE_FAKE_PROVIDER=true', 'loopback bind by default'],
+    ingressModes: ['local fake webhook'],
+    approvalMode: 'inline-or-token',
+    fileSupport: 'In-memory fake file behavior for deterministic tests only.',
+    rateLimitBehavior: 'No provider-side rate limits; not for production ingress.',
+    localContractTests: [
+      'packages/gateway-testing/src/fake-channel.test.ts',
+      'apps/gateway/src/daemon.test.ts',
+      'scripts/gateway-cloud-smoke.mjs',
+    ],
+    liveSmoke: 'Allowed only for local loopback and CI smoke tests; public exposure requires an explicit demo override.',
+  },
+]
+
+export function findGatewayProviderReadiness(kind: GatewayProviderKind) {
+  return GATEWAY_PROVIDER_READINESS_MATRIX.find((entry) => entry.kind === kind) || null
+}

--- a/docs/gateway-appliance.md
+++ b/docs/gateway-appliance.md
@@ -14,6 +14,9 @@ provider-specific rendering, approvals, questions, and delivery retries. Cloud
 owns tenancy, sessions, commands, projections, workflows, artifacts, and
 OpenCode execution.
 
+Provider tiers, capabilities, signing requirements, and test expectations are
+tracked in [Gateway Provider Readiness](gateway-provider-readiness.md).
+
 ## Supported Modes
 
 ### Remote Cloud
@@ -124,6 +127,15 @@ macOS and Mac mini:
 - Rotate Telegram bot tokens and Cloud service tokens after exposure.
 - Restrict inbound firewall rules to HTTPS and SSH management.
 - Keep env files out of git and command history.
+
+## Delivery Drain And Local State
+
+Gateway keeps Cloud as the authoritative store for channel bindings, cursors,
+deliveries, sessions, workflows, and audit events. The appliance does not need
+a local database for production state. On shutdown, Gateway closes new Cloud
+delivery subscriptions, drains in-flight delivery sends, acknowledges completed
+deliveries, then stops providers. A restart resumes from Cloud-owned cursors
+and delivery records.
 
 ## Upgrade And Rollback
 

--- a/docs/gateway-provider-readiness.md
+++ b/docs/gateway-provider-readiness.md
@@ -1,0 +1,90 @@
+---
+title: Gateway Provider Readiness
+description: Production readiness tiers, capabilities, authentication, and test expectations for Open Cowork Gateway channel providers.
+---
+
+# Gateway Provider Readiness
+
+Gateway providers are channel adapters. They never own OpenCode execution,
+sessions, workflow scheduling, or Cloud control-plane state. Every provider
+normalizes channel input into Cloud channel APIs and renders Cloud session
+events back to the channel.
+
+The typed source of truth is
+`apps/gateway/src/provider-readiness.ts`. The Gateway test suite verifies that
+this page, the matrix, and actual provider capabilities stay aligned.
+
+## Provider Readiness Matrix
+
+| Provider | Tier | Status | Modes | Auth / signing | Approvals | Files | Contract tests |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `telegram` | Tier 1 | Launch | polling, webhook | Bot token; webhook secret when webhook mode is enabled | Inline buttons plus token fallback | Upload/download | `packages/gateway-provider-telegram/src/telegram-provider.test.ts`, `packages/gateway-provider-telegram/src/telegram-retry.test.ts`, `apps/gateway/src/daemon.test.ts` |
+| `slack` | Tier 1 | Launch | webhook | Bot token and Slack signing secret | Inline buttons plus token fallback | Upload/download | `packages/gateway-provider-slack/src/slack-provider.test.ts`, `apps/gateway/src/daemon.test.ts` |
+| `email` | Tier 1 | Launch | webhook | Inbound shared secret; SMTP credentials where required | Token fallback | Inbound uploads; outbound artifact links | `packages/gateway-provider-email/src/email-provider.test.ts`, `apps/gateway/src/event-renderer.test.ts` |
+| `webhook` | Tier 2 | Utility | webhook | HMAC/timestamp shared secret for ingress and signed delivery | Inline buttons if bridge supports them; token fallback otherwise | Inline inbound files; outbound links | `packages/gateway-provider-webhook/src/webhook-provider.test.ts`, `apps/gateway/src/daemon.test.ts` |
+| `cli` | Tier 2 | Utility | stdio | Trusted local process boundary; no public HTTP ingress | Token fallback | Inbound metadata; outbound links | `packages/gateway-provider-cli/src/cli-provider.test.ts`, `scripts/gateway-cloud-smoke.mjs` |
+| `discord` | Tier 3 | Later hardening | signed bridge webhook | Bridge shared secret | Inline buttons plus token fallback | Upload/download through bridge | `packages/gateway-provider-discord/src/discord-provider.test.ts`, `packages/gateway-provider-webhook/src/webhook-provider.test.ts` |
+| `whatsapp` | Tier 3 | Later hardening | signed bridge webhook | Bridge shared secret | Inline buttons plus token fallback | Upload/download through bridge | `packages/gateway-provider-whatsapp/src/whatsapp-provider.test.ts`, `packages/gateway-provider-webhook/src/webhook-provider.test.ts` |
+| `signal` | Tier 3 | Later hardening | signed bridge webhook | Bridge shared secret | Token fallback | Upload/download through bridge | `packages/gateway-provider-signal/src/signal-provider.test.ts`, `packages/gateway-provider-webhook/src/webhook-provider.test.ts` |
+| `fake` | Tier demo | Demo only | local fake webhook | Explicit `OPEN_COWORK_GATEWAY_ENABLE_FAKE_PROVIDER=true`; loopback by default | Inline buttons plus token fallback | In-memory test files | `packages/gateway-testing/src/fake-channel.test.ts`, `apps/gateway/src/daemon.test.ts`, `scripts/gateway-cloud-smoke.mjs` |
+
+## Tier Policy
+
+Tier 1 providers are the launch target. They must have local provider contract
+tests, Gateway daemon wiring tests, signed ingress where public, approval
+round-trips, file behavior where advertised, and documented live-provider smoke
+instructions.
+
+Tier 2 providers are local or integration utilities. They are production-safe
+only inside their intended boundary: signed webhook bridges for `webhook`, and
+trusted local process boundaries for `cli`.
+
+Tier 3 providers are bridge-backed adapters for later live-provider hardening.
+They are useful for downstream experiments, but public launch does not depend
+on them until a live provider recipe and smoke path are promoted.
+
+The `fake` provider is not a real channel. It exists for local demos and CI
+smokes only. Public exposure is blocked unless a deployer explicitly opts into
+the demo override.
+
+## Capability Expectations
+
+- Inline approvals must use provider-native buttons when `inlineButtons` is
+  true.
+- Channels without buttons must render `/approve`, `/deny`, `/answer`, or
+  `/reject` token fallback commands.
+- Channels with message editing may update streaming assistant output in place.
+- Channels without message editing must chunk or buffer output.
+- Files are only sent as provider files when the provider advertises download
+  support and the artifact fits provider limits.
+- Otherwise, artifacts render as Cloud artifact links.
+- Typing indicators are best-effort and must never block prompt execution.
+
+## Security Expectations
+
+- Public webhook providers must fail closed without signing/HMAC/shared-secret
+  verification.
+- Gateway service-token authority is separate from inbound actor authority.
+  Cloud resolves the channel actor and enforces approval authority.
+- Diagnostics, logs, provider health, delivery summaries, and metrics must not
+  expose raw provider tokens, webhook secrets, API tokens, local paths, or
+  signed artifact URLs.
+- Local/demo providers must remain loopback-only by default.
+
+## Live Smoke Instructions
+
+Use `pnpm deploy:gateway:smoke` against a real Cloud URL when validating a
+deployed appliance. The smoke creates an ephemeral gateway-scoped token,
+proves prompt-to-session continuation, exercises approval fallback, creates an
+async delivery, verifies delivery acknowledgement, and revokes the token.
+
+Provider-specific live checks:
+
+- Telegram: start with polling for private installs; webhook mode requires an
+  HTTPS public URL and webhook secret.
+- Slack: configure Events and Interactivity to POST to `/webhooks/slack`; verify
+  signed events and button callbacks.
+- Email: send an inbound webhook/mail fixture and verify the threaded reply.
+- Webhook: send signed bridge payloads and verify unsigned, stale, and replayed
+  requests fail.
+- CLI: use only for trusted local smoke and never expose it over public HTTP.

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -166,6 +166,8 @@ loopback by default. The Cloud + Gateway compose file runs a local all-in-one
 Cloud control plane, Postgres, MinIO, and Gateway on one host. See
 `docs/gateway-appliance.md` for VPS, Mac mini, Raspberry Pi, systemd, launchd,
 Telegram webhook, TLS, firewall, upgrade, and rollback guidance.
+Provider launch tiers and contract tests are tracked in
+`docs/gateway-provider-readiness.md`.
 
 Use the split-role reference when testing the scalable topology:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Architecture: architecture.md
       - Product Contract: product-contract.md
       - Cloud Web Workbench: cloud-web-workbench.md
+      - Gateway Provider Readiness: gateway-provider-readiness.md
       - Downstream Customization: downstream.md
       - OpenCode SDK Boundary: opencode-sdk-v2-boundary.md
       - Development Environment: development-environment.md

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -423,6 +423,7 @@ function validateDocs() {
     'docs/runbooks/restore-drill-report.md',
     'docs/runbooks/managed-byok-saas.md',
     'docs/gateway-appliance.md',
+    'docs/gateway-provider-readiness.md',
     'docs/runbooks/private-beta-launch.md',
     'docs/runbooks/private-beta-support.md',
     'deploy/gateway-appliance/README.md',
@@ -827,10 +828,33 @@ function validateDocs() {
     'docker-compose.gateway-remote.yml',
     'docker-compose.cloud-gateway.yml',
     'not an OpenCode runtime',
+    'Gateway Provider Readiness',
+    'Delivery Drain And Local State',
     'Upgrade And Rollback',
   ]) {
     if (!gatewayAppliance.includes(phrase)) {
       throw new Error(`docs/gateway-appliance.md must include ${phrase}`)
+    }
+  }
+
+  const gatewayProviderReadiness = read('docs/gateway-provider-readiness.md')
+  for (const phrase of [
+    'Provider Readiness Matrix',
+    '`telegram` | Tier 1',
+    '`slack` | Tier 1',
+    '`email` | Tier 1',
+    '`webhook` | Tier 2',
+    '`cli` | Tier 2',
+    '`discord` | Tier 3',
+    '`whatsapp` | Tier 3',
+    '`signal` | Tier 3',
+    '`fake` | Tier demo',
+    'apps/gateway/src/provider-readiness.ts',
+    'Public webhook providers must fail closed',
+    'pnpm deploy:gateway:smoke',
+  ]) {
+    if (!gatewayProviderReadiness.includes(phrase)) {
+      throw new Error(`docs/gateway-provider-readiness.md must include ${phrase}`)
     }
   }
 


### PR DESCRIPTION
Closes #550.

## Summary
- add a typed Gateway provider readiness matrix and docs that lock launch tiers, capabilities, auth requirements, tests, and live smoke expectations
- verify readiness metadata against the actual provider registry and documentation
- drain in-flight delivery sends before Gateway provider shutdown so completed deliveries are acked before process exit
- extend deployment validation to require the readiness docs and shutdown/local-state guidance

## Validation
- pnpm --filter @open-cowork/gateway test
- pnpm typecheck:gateway
- pnpm deploy:validate
- pnpm docs:build
- git diff --check
- pnpm lint
- pnpm typecheck
- pnpm test

Not run locally: pnpm deploy:gateway:smoke, because it requires a live Cloud smoke URL and admin token.