### PR TITLE
Harden downstream distribution contract

### DIFF
--- a/apps/desktop/src/main/cloud-workspace-auth.ts
+++ b/apps/desktop/src/main/cloud-workspace-auth.ts
@@ -40,6 +40,7 @@ export type CloudWorkspaceDesktopAuthenticatorOptions = {
   fetch?: CloudWorkspaceAuthFetch
   openExternal?: (url: string) => Promise<unknown> | unknown
   callbackTimeoutMs?: number
+  brandName?: string
 }
 
 type OidcDiscovery = {
@@ -49,6 +50,7 @@ type OidcDiscovery = {
 
 const DEFAULT_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
 const DEFAULT_SCOPE = 'openid email profile offline_access'
+const DEFAULT_BRAND_NAME = 'Open Cowork'
 
 function defaultFetch(): CloudWorkspaceAuthFetch {
   return (url, init) => globalThis.fetch(url, init as RequestInit) as Promise<CloudWorkspaceAuthResponse>
@@ -108,6 +110,19 @@ function tokenExpiresAt(record: Record<string, unknown>) {
   return new Date(Date.now() + ttlMs).toISOString()
 }
 
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function callbackPage(title: string, body = '') {
+  return `<!doctype html><html><body><h2>${escapeHtml(title)}</h2>${body ? `<p>${escapeHtml(body)}</p>` : ''}</body></html>`
+}
+
 function normalizeBaseUrl(baseUrl: string) {
   return baseUrl.replace(/\/+$/, '')
 }
@@ -119,7 +134,7 @@ async function closeServer(server: Server) {
   })
 }
 
-async function createLoopbackCallback(timeoutMs: number) {
+async function createLoopbackCallback(timeoutMs: number, brandName: string) {
   let resolveCallback: ((value: { code: string; state: string }) => void) | null = null
   let rejectCallback: ((error: Error) => void) | null = null
   const callbackPromise = new Promise<{ code: string; state: string }>((resolve, reject) => {
@@ -138,18 +153,18 @@ async function createLoopbackCallback(timeoutMs: number) {
     const state = url.searchParams.get('state')
     if (error) {
       res.writeHead(400, { 'content-type': 'text/html; charset=utf-8' })
-      res.end('<html><body><h2>Open Cowork Cloud login failed</h2></body></html>')
+      res.end(callbackPage(`${brandName} Cloud login failed`))
       rejectCallback?.(new Error(`Cloud OIDC login failed: ${error}.`))
       return
     }
     if (!code || !state) {
       res.writeHead(400, { 'content-type': 'text/html; charset=utf-8' })
-      res.end('<html><body><h2>Open Cowork Cloud login failed</h2></body></html>')
+      res.end(callbackPage(`${brandName} Cloud login failed`))
       rejectCallback?.(new Error('Cloud OIDC callback requires code and state.'))
       return
     }
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-    res.end('<html><body><h2>Open Cowork Cloud login complete</h2><p>You can return to Open Cowork.</p></body></html>')
+    res.end(callbackPage(`${brandName} Cloud login complete`, `You can return to ${brandName}.`))
     resolveCallback?.({ code, state })
   })
   await new Promise<void>((resolve, reject) => {
@@ -182,11 +197,13 @@ export class CloudWorkspaceDesktopAuthenticator {
   private readonly fetcher: CloudWorkspaceAuthFetch
   private readonly openExternal: (url: string) => Promise<unknown> | unknown
   private readonly callbackTimeoutMs: number
+  private readonly brandName: string
 
   constructor(options: CloudWorkspaceDesktopAuthenticatorOptions = {}) {
     this.fetcher = options.fetch || defaultFetch()
     this.openExternal = options.openExternal || defaultOpenExternal
     this.callbackTimeoutMs = options.callbackTimeoutMs || DEFAULT_CALLBACK_TIMEOUT_MS
+    this.brandName = options.brandName?.trim() || DEFAULT_BRAND_NAME
   }
 
   async login(connection: CloudWorkspaceConnectionRecord): Promise<CloudWorkspaceLoginResult> {
@@ -197,7 +214,7 @@ export class CloudWorkspaceDesktopAuthenticator {
     const state = base64Url(randomBytes(24))
     const nonce = base64Url(randomBytes(24))
     const verifier = base64Url(randomBytes(32))
-    const callback = await createLoopbackCallback(this.callbackTimeoutMs)
+    const callback = await createLoopbackCallback(this.callbackTimeoutMs, this.brandName)
     try {
       const authUrl = new URL(authorizationEndpoint)
       authUrl.searchParams.set('response_type', 'code')

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -1231,7 +1231,7 @@ export type ControlPlaneStore = {
   reapExpiredSessionLeases(input?: ReapExpiredSessionLeasesInput): MaybePromise<ReapedSessionLeaseRecord[]>
   assertSessionCommandQueueQuota(input: { tenantId: string, quota?: CommandQueueQuota | null, now?: Date }): MaybePromise<void>
   enqueueSessionCommand(input: EnqueueCommandInput): MaybePromise<SessionCommandRecord>
-  claimNextSessionCommand(lease: WorkerLeaseRecord): MaybePromise<SessionCommandRecord | null>
+  claimNextSessionCommand(lease: WorkerLeaseRecord, now?: Date): MaybePromise<SessionCommandRecord | null>
   ackSessionCommand(lease: WorkerLeaseRecord, commandId: string, now?: Date): MaybePromise<SessionCommandRecord>
   failSessionCommand(lease: WorkerLeaseRecord, commandId: string, error: string): MaybePromise<SessionCommandRecord>
   recordWorkerHeartbeat(input: {
@@ -3445,12 +3445,13 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     return clone(command)
   }
 
-  claimNextSessionCommand(lease: WorkerLeaseRecord): SessionCommandRecord | null {
+  claimNextSessionCommand(lease: WorkerLeaseRecord, now = new Date()): SessionCommandRecord | null {
     const session = this.requireSession(lease.tenantId, lease.sessionId)
-    this.assertCurrentLease(session, lease)
+    const nowMs = now.getTime()
+    this.assertCurrentLease(session, lease, nowMs)
     const command = session.commands.find((entry) => (
       (entry.status === 'pending'
-        && (!entry.availableAt || Date.parse(entry.availableAt) <= Date.now())
+        && (!entry.availableAt || Date.parse(entry.availableAt) <= nowMs)
         && (entry.targetLeaseToken === null || entry.targetLeaseToken === lease.leaseToken))
       || (entry.status === 'running'
         && entry.claimedLeaseToken !== lease.leaseToken
@@ -4181,11 +4182,8 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       .map((tag) => clone(tag))
   }
 
-  private assertCurrentLease(session: SessionState, lease: WorkerLeaseRecord) {
-    if (!session.lease || session.lease.leaseToken !== lease.leaseToken) {
-      throw new Error('Worker lease is stale.')
-    }
-    if (session.lease.leaseExpiresAt <= Date.now()) {
+  private assertCurrentLease(session: SessionState, lease: WorkerLeaseRecord, nowMs = Date.now()) {
+    if (!session.lease || session.lease.leaseToken !== lease.leaseToken || session.lease.leaseExpiresAt <= nowMs) {
       throw new Error('Worker lease is stale.')
     }
   }

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -2788,9 +2788,9 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     })
   }
 
-  async claimNextSessionCommand(lease: WorkerLeaseRecord) {
+  async claimNextSessionCommand(lease: WorkerLeaseRecord, now = new Date()) {
     return this.withTransaction(async (client) => {
-      await this.assertCurrentLease(lease, client)
+      await this.assertCurrentLease(lease, client, now.getTime())
       const selected = await this.maybeOne(
         `SELECT * FROM cloud_session_commands
          WHERE tenant_id = $1
@@ -2804,7 +2804,7 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
          ORDER BY created_sequence
          FOR UPDATE SKIP LOCKED
          LIMIT 1`,
-        [lease.tenantId, lease.sessionId, lease.leaseToken, new Date().toISOString()],
+        [lease.tenantId, lease.sessionId, lease.leaseToken, now.toISOString()],
         client,
       )
       if (!selected) return null
@@ -4185,9 +4185,9 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     return commandFromRow(row)
   }
 
-  private async assertCurrentLease(lease: WorkerLeaseRecord, executor: PgExecutor) {
+  private async assertCurrentLease(lease: WorkerLeaseRecord, executor: PgExecutor, nowMs = Date.now()) {
     const current = await this.getLease(lease.tenantId, lease.sessionId, executor, true)
-    if (!current || current.leaseToken !== lease.leaseToken || current.leaseExpiresAt <= Date.now()) {
+    if (!current || current.leaseToken !== lease.leaseToken || current.leaseExpiresAt <= nowMs) {
       throw new Error('Worker lease is stale.')
     }
     return current

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -66,7 +66,7 @@ const CLOUD_OBJECT_STORE_KINDS = new Set(['filesystem', 's3', 'gcs', 'azure-blob
 const PUBLIC_BRANDING_URL_KEYS = new Set(['logoUrl', 'supportUrl', 'privacyUrl', 'securityUrl', 'legalUrl'])
 const GATEWAY_MODES = new Set(['self-host', 'managed'])
 const GATEWAY_LOG_LEVELS = new Set(['debug', 'info', 'warn', 'error', 'silent'])
-const GATEWAY_PROVIDER_KINDS = new Set(['fake', 'telegram', 'slack', 'email', 'webhook'])
+const GATEWAY_PROVIDER_KINDS = new Set(['fake', 'telegram', 'slack', 'email', 'webhook', 'discord', 'whatsapp', 'signal', 'cli'])
 
 let configCache: OpenCoworkConfig | null = null
 let publicConfigCache: PublicAppConfig | null = null

--- a/apps/desktop/src/main/config-types.ts
+++ b/apps/desktop/src/main/config-types.ts
@@ -394,7 +394,10 @@ export type CloudConfig = {
   billing: CloudBillingConfig
 }
 
+export const OPEN_COWORK_CONFIG_CONTRACT_VERSION = 1
+
 export type OpenCoworkConfig = {
+  contractVersion: typeof OPEN_COWORK_CONFIG_CONTRACT_VERSION
   allowedEnvPlaceholders: string[]
   branding: BrandingConfig
   auth: {
@@ -645,6 +648,7 @@ const DEFAULT_GATEWAY_CONFIG: GatewayDeploymentConfig = {
 }
 
 export const DEFAULT_CONFIG: OpenCoworkConfig = {
+  contractVersion: OPEN_COWORK_CONFIG_CONTRACT_VERSION,
   allowedEnvPlaceholders: [],
   branding: {
     name: 'Cowork',

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -146,6 +146,7 @@ export function setupIpcHandlers(
   const destructiveConfirmations = createDestructiveConfirmationManager()
   const workspaceGateway = createWorkspaceGateway({
     cloudDesktop: getAppConfig().cloudDesktop,
+    cloudLoginBrandName: getAppConfig().branding.name,
   })
   const capabilityToolMethodCache = new Map<string, { expiresAt: number; entries: CapabilityToolEntry[] }>()
   const approvedSkillImportDirectories = new Map<string, string>()

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -84,6 +84,7 @@ export type WorkspaceGatewayOptions = {
   cloudAdapterFactory?: (connection: CloudWorkspaceConnectionRecord, accessToken?: string | null) => CloudWorkspaceSessionAdapter
   cloudLogin?: (connection: CloudWorkspaceConnectionRecord) => Promise<CloudWorkspaceLoginResult>
   cloudRefresh?: (connection: CloudWorkspaceConnectionRecord, refreshToken: string) => Promise<CloudWorkspaceLoginResult>
+  cloudLoginBrandName?: string
   cloudReconnectBaseMs?: number
   cloudReconnectMaxMs?: number
   cloudReconnectMaxAttempts?: number
@@ -265,7 +266,9 @@ export class WorkspaceGateway {
       cacheMode: this.cloudDesktopConfig.cacheMode,
       cacheEncryptionFallback: this.cloudDesktopConfig.cacheEncryptionFallback,
     }))
-    const authenticator = createCloudWorkspaceDesktopAuthenticator()
+    const authenticator = createCloudWorkspaceDesktopAuthenticator({
+      brandName: options.cloudLoginBrandName || DEFAULT_CONFIG.branding.name,
+    })
     this.cloudLogin = options.cloudLogin || ((connection) => authenticator.login(connection))
     this.cloudRefresh = options.cloudRefresh || ((connection, refreshToken) => authenticator.refresh(connection, refreshToken))
     this.cloudReconnectBaseMs = Math.max(0, options.cloudReconnectBaseMs ?? 500)

--- a/deploy/private-beta/hosted-byok.config.example.json
+++ b/deploy/private-beta/hosted-byok.config.example.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../open-cowork.config.schema.json",
+  "contractVersion": 1,
   "allowedEnvPlaceholders": [
     "OPEN_COWORK_CLOUD_DATABASE_URL",
     "OPEN_COWORK_CLOUD_OBJECT_STORE_CREDENTIALS",

--- a/deploy/private-beta/self-host-oss.config.example.json
+++ b/deploy/private-beta/self-host-oss.config.example.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../open-cowork.config.schema.json",
+  "contractVersion": 1,
   "allowedEnvPlaceholders": [
     "OPEN_COWORK_CLOUD_DATABASE_URL",
     "OPEN_COWORK_CLOUD_OBJECT_STORE_CREDENTIALS",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,10 +3,14 @@
 Open Cowork is configured through `open-cowork.config.json`.
 
 The file is validated against `open-cowork.config.schema.json` at runtime.
+Full resolved configs must also declare `contractVersion: 1`, the current
+versioned downstream distribution contract. Partial overlays may omit it
+because they merge over the built-in default.
 
 ## Top-level sections
 
 The default upstream config is organized into:
+- `contractVersion`
 - `allowedEnvPlaceholders`
 - `branding`
 - `auth`

--- a/docs/downstream-contract.md
+++ b/docs/downstream-contract.md
@@ -1,0 +1,147 @@
+---
+title: Downstream Contract
+description: Versioned configuration, branding, packaging, and extension contract for downstream Open Cowork distributions.
+---
+
+# Downstream Contract
+
+This page is the versioned contract for downstream distributions. It defines
+which customizations are supported through config, assets, deployment manifests,
+and adapters without source forks.
+
+Open Cowork remains a product layer on top of OpenCode:
+
+- OpenCode owns execution, runtime behavior, tools, permissions, questions,
+  MCP execution, sessions, and native skills.
+- Open Cowork owns Desktop, Cloud, Gateway, projection, policy, configuration,
+  branding, packaging, and deployment ergonomics.
+
+If a downstream customization requires patching OpenCode execution semantics or
+adding a second runtime/control plane in Gateway, it is outside this contract.
+
+## Contract Version
+
+`open-cowork.config.json` must declare:
+
+```json
+{
+  "contractVersion": 1
+}
+```
+
+Version `1` covers the supported Desktop, Cloud, and Gateway distribution
+surface in this repository. The JSON schema rejects unknown contract versions,
+and partial overlays may omit the field because they merge over the built-in
+default. Downstream packages should pin the repository release tag or commit
+that owns the schema they validate against.
+
+The contract version is for deployer-facing configuration compatibility. It is
+separate from app release version, database migration version, settings storage
+version, and OpenCode SDK/runtime version.
+
+## Configuration Classes
+
+Use the right supply path for each kind of value.
+
+| Class | Examples | Source of truth | Public repo rule |
+| --- | --- | --- | --- |
+| Runtime config | `branding`, `cloudDesktop`, `cloud.publicBranding`, `cloud.features`, `cloud.profiles`, `gateway.branding`, `gateway.providers`, `i18n`, `telemetry.enabled` | `open-cowork.config.json` and downstream overlays | Placeholders and generic examples only. No raw secrets. |
+| Packaging-time config | app id, bundle id, installer metadata, release source, icons, app resources, downstream skills/MCP bundles | package scripts, `branding` assets, CI/release overlays | Keep upstream back-compat ids unless deliberately creating a distinct downstream distribution. |
+| Infrastructure config | database URL refs, object-store adapter, secret/KMS refs, OIDC issuer/client refs, gateway public URL, worker replicas, checkpoints, PDBs, topology spread | Helm, Compose, cloud provider manifests, process manager env | Use env refs and placeholders. No project ids, account ids, customer domains, credentials, prices, or launch evidence. |
+| Private downstream config | real domains, customer/org data, SaaS pricing, Stripe ids, launch rosters, support rotations, incident evidence | private deployment or operations repo | Never committed to this public repo. |
+
+## Supported Fields
+
+The version 1 contract covers these deployer-owned surfaces.
+
+| Surface | Config key or artifact | Supported customization |
+| --- | --- | --- |
+| Product identity | `branding.name`, `branding.appId`, `branding.dataDirName`, `branding.helpUrl`, `branding.projectNamespace` | Desktop app identity and on-disk namespace. `opencowork` remains only for documented back-compat defaults. |
+| Desktop shell | `branding.sidebar`, `branding.home`, bundled `branding/` assets | Sidebar, first-run, home/composer copy, local image assets, theme selection. |
+| Legal and support links | `branding.helpUrl`, `cloud.publicBranding.*Url`, `gateway.branding.*Url` | HTTPS public links, with `mailto:` allowed only where explicitly documented. |
+| Cloud Desktop sync | `cloudDesktop` | Managed cloud orgs, user-added connection policy, cache mode, cache encryption fallback. |
+| Cloud Web branding | `cloud.publicBranding` | Workbench/admin product name, logo URL, public legal/support links, dashboard copy, token labels, and theme tokens. |
+| Cloud auth | `cloud.auth` | `none`, header demo/proxy mode with signed headers, or OIDC. Public deployments should use OIDC or signed trusted-proxy headers. |
+| Cloud storage | `cloud.storage` | Control-plane store and object-store adapter selection. Multi-worker deployments need shared object storage and checkpoints. |
+| Cloud profiles/policy | `cloud.defaultProfile`, `cloud.profiles`, `cloud.features`, `cloud.runtime`, `cloud.projectSources` | Agent/tool/MCP allowlists, product feature flags, runtime hardening, project source policy. |
+| Billing mode | `cloud.billing` | `none` and `stub` for OSS self-host; managed adapters such as Stripe behind provider-neutral billing interfaces. |
+| Abuse and quotas | `cloud.abuse` | Rate limits, prompt limits, worker/session caps, artifact byte caps, gateway delivery caps. |
+| Gateway identity | `gateway.branding` | Channel-facing product name, legal/support links, dashboard labels. |
+| Gateway cloud binding | `gateway.cloud` | Cloud URL, service token placeholder/ref, insecure HTTP policy for loopback only. |
+| Gateway process | `gateway.server`, `gateway.metrics`, `gateway.diagnostics`, `gateway.logging` | Host/port, public base URL, operator token, metrics/diagnostics exposure, log level. |
+| Gateway channels | `gateway.providers` | Provider enablement, channel binding ids, credentials via env placeholders, provider settings. |
+| Updates and telemetry | `updates`, `telemetry` | Optional release source and downstream-owned telemetry endpoint. Upstream defaults to local/no remote telemetry. |
+| Runtime content | downstream `skills/` and `mcps/` roots | Add or replace app-managed skill bundles and bundled MCP packages referenced by config. |
+
+Unsupported source-patch paths include editing renderer components for branding,
+hardcoding cloud URLs in code, adding provider credentials to checked-in config,
+adding Gateway runtime ownership, importing OpenCode SDK from clients, or
+branching core cloud code on one provider's project/account identifiers.
+
+## Branding Coverage
+
+Downstream branding must flow through config and assets:
+
+- Desktop renderer: `branding`, `branding.sidebar`, `branding.home`, local
+  `branding/` assets, and release packaging metadata.
+- Cloud Web: `cloud.publicBranding`, `cloud.publicBranding.dashboard`, and
+  public theme tokens.
+- Gateway: `gateway.branding`, provider display setup docs, and channel setup
+  labels where the provider supports them.
+- Docs/examples: downstream example files and docs should use public-safe
+  placeholder brands such as Acme Cowork.
+- Release artifacts: packager-supported names, icons, bundle ids, update feed
+  labels, and manual fallback URLs.
+
+Back-compat names such as `com.opencowork.desktop` and `.opencowork/` are
+allowed only where docs identify them as migration or bundle-id compatibility.
+
+## Extension Contracts
+
+Downstream extension work must start in the layer that owns the concept.
+
+| Extension point | Owning modules or artifacts | Required boundary |
+| --- | --- | --- |
+| Gateway channel providers | `packages/gateway-channel`, `packages/gateway-provider-*`, `apps/gateway/src/provider-registry.ts`, `apps/gateway/src/provider-readiness.ts` | Providers normalize channel I/O only. No OpenCode SDK imports, no direct control-plane DB access, no runtime ownership. |
+| Billing adapters | `apps/desktop/src/main/cloud/billing-adapter.ts`, `stub-billing-adapter.ts`, `stripe-billing-adapter.ts` | Core services consume provider-neutral subscription and entitlement records. Provider SDK imports stay behind adapters. |
+| Object-store adapters | `apps/desktop/src/main/cloud/object-store.ts` and deployment object-store config | Callers use object-store interfaces. Artifact, snapshot, and checkpoint code must not branch on cloud vendor ids. |
+| Secret/KMS adapters | `apps/desktop/src/main/cloud/secret-adapter.ts`, `byok-secret-store.ts`, secret ref resolvers | Secrets are refs or encrypted envelopes. Plaintext reveal is limited to the owning runtime role. |
+| Runtime profiles and policy packs | `cloud.profiles`, `cloud.runtime`, `cloud-config.ts`, `runtime-config-builder.ts` | Cloud profiles force app-managed runtime config by default and must not enable machine config or arbitrary local stdio MCPs without explicit policy. |
+| Worker pool modes | `docs/managed-workers.md`, `managed-worker-types.ts`, `services/managed-worker-service.ts`, deployment manifests | Add modes only with trust-model docs, lifecycle tests, and deployment gates. Customer-hosted workers remain deferred unless separately designed. |
+| Cloud Web modules and admin panels | `apps/website/src`, `docs/cloud-web-workbench.md`, route/API metadata tests | Web remains a cloud API client. It must not import stores, runtime adapters, secret adapters, or provider-specific internals. |
+| BYOK provider validation/injection | `byok-secret-store.ts`, `runtime-config-builder.ts`, `opencode-runtime-adapter.ts`, `cloud-config.ts` | Provider keys enter OpenCode runtime config as provider options, never process env, logs, renderer state, diagnostics, or cache. |
+| Deployment recipes | `deploy/`, `helm/`, `docker-compose*.yml`, deployment validators | Public recipes are provider-neutral templates. Real ids, domains, prices, credentials, signed URLs, and launch evidence stay private. |
+
+## Template Hygiene
+
+Public templates and docs may include placeholders such as `PROJECT`,
+`ACCOUNT_ID`, `REGION`, `VERSION`, `registry.example.com`, or
+`cowork.example.com`. They must not include:
+
+- provider keys, API tokens, cookie secrets, OAuth refresh/access tokens, MCP
+  secrets, webhook secrets, or BYOK plaintext
+- real cloud project ids, account ids, subscription ids, tenant ids, bucket
+  names, registry names, or provider-hosted URLs
+- real customer names, customer domains, support rosters, incident evidence, or
+  launch go/no-go values
+- Stripe price/product/account ids or private managed-SaaS price values
+- signed URL query strings or object keys that reveal private artifact paths
+- mutable production image tags such as `latest` or `stable`
+- branding changes that require source patches instead of config/assets
+
+Run `pnpm deploy:validate` and `pnpm lint` before publishing downstream-facing
+changes. When docs change, also run `pnpm docs:build`.
+
+## Completion Checklist
+
+A downstream distribution is inside the version 1 contract when:
+
+- `open-cowork.config.json` validates with `contractVersion: 1`
+- Desktop, Cloud Web, and Gateway branding come from config/assets
+- self-host installs can keep `cloud.billing.provider=none` or `stub`
+- secrets are supplied by env refs or the secret adapter, not committed config
+- Cloud profiles define allowed agents/tools/MCPs and runtime hardening
+- Gateway providers are explicit and signed where public
+- images are pinned by release tag or digest
+- public templates contain placeholders only
+- extension changes preserve the OpenCode execution boundary

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -11,6 +11,10 @@ This page is the reference for that model.
 The workspace ownership, sync, status/reason, and non-sync guarantees that
 downstream builds must preserve are defined in
 [Product Contract](product-contract.md).
+The versioned downstream configuration, branding, packaging, template hygiene,
+and extension contract is defined in
+[Downstream Contract](downstream-contract.md). Current public config files use
+`contractVersion: 1`.
 
 ## Distribution modes
 
@@ -59,8 +63,9 @@ see `examples/downstream/acme/`.
 Everything downstream-customizable goes through two layers:
 
 1. **Configuration** — a JSON file validated against
-   `open-cowork.config.schema.json`. The app merges the bundled config with up
-   to three additional layers in a fixed order.
+   `open-cowork.config.schema.json` and the versioned
+   `contractVersion: 1` downstream contract. The app merges the bundled config
+   with up to three additional layers in a fixed order.
 2. **Content** — skill bundles (`skills/<name>/SKILL.md`) and MCP packages
    (`mcps/<name>/dist/index.js`) that the config can reference. The app
    resolves these from a stack of roots, with the downstream root winning over
@@ -141,6 +146,10 @@ The public schema now covers the three product surfaces:
 | Cloud Web/control plane | `cloud.publicBranding`, `cloud.auth`, `cloud.storage`, `cloud.features`, `cloud.profiles`, `cloud.projectSources`, `cloud.abuse`, `cloud.billing` | Public dashboard name/logo/legal links, OIDC metadata, database/object-store/secret refs, profile allowlists, project-source policy, quotas, and self-host or managed billing mode. |
 | Gateway | `gateway.branding`, `gateway.cloud`, `gateway.server`, `gateway.providers`, `gateway.metrics`, `gateway.diagnostics` | Headless channel branding, cloud URL, service-token source, public gateway URL, provider bindings, and operator endpoints. |
 
+Use [Downstream Contract](downstream-contract.md) for the full field inventory
+and to distinguish runtime config, packaging-time config, infrastructure
+config, and private downstream config.
+
 Gateway can load the same central file as Desktop and Cloud through
 `OPEN_COWORK_CONFIG_PATH`, `OPEN_COWORK_CONFIG_DIR`, or
 `OPEN_COWORK_DOWNSTREAM_ROOT`. Gateway-specific env and
@@ -216,6 +225,9 @@ projection, channel adapters, and deployment ergonomics.
 | Object-store adapters | `apps/desktop/src/main/cloud/object-store.ts`, deployment object-store config | Add storage providers behind the object-store interface. Artifact, upload, snapshot, and checkpoint callers should not branch on cloud provider names. |
 | Secret adapters | `apps/desktop/src/main/cloud/secret-adapter.ts`, BYOK secret store, config refs | Resolve or protect secrets behind refs. Raw provider keys, OAuth tokens, cookies, channel secrets, and signed URLs must never enter renderer state, cache, diagnostics, or public templates. |
 | Worker pool modes | `docs/managed-workers.md`, `managed-worker-types.ts`, `services/managed-worker-service.ts` | Add worker modes only after the trust model is documented. Customer-hosted workers remain deferred until a separate review covers updates, liability, networking, and data residency. |
+| Runtime profiles and policy packs | `cloud.profiles`, `cloud.runtime`, `cloud-config.ts`, `runtime-config-builder.ts` | Cloud profiles own feature flags and allowlists. Machine runtime config, arbitrary local stdio MCPs, and host project directories stay disabled unless explicitly reviewed and allowlisted. |
+| Cloud Web feature modules and admin panels | `apps/website/src`, `docs/cloud-web-workbench.md`, route/API matrix tests | Cloud Web is a cloud API client. It must not import server-only stores, runtime adapters, secret adapters, or provider-specific internals. |
+| BYOK validation and injection hooks | `byok-secret-store.ts`, `runtime-config-builder.ts`, `opencode-runtime-adapter.ts`, `cloud-config.ts` | Provider keys enter OpenCode through runtime config provider options. They never enter process env, logs, renderer state, diagnostics, cache, or read APIs. |
 | Cloud event and projection contract | `packages/shared/src/cloud-session-projection.ts`, `opencode-runtime-adapter.ts`, `session-projection-service.ts`, gateway renderers | Runtime translation happens once at the worker/runtime boundary. Desktop, Web, and Gateway consume canonical Cloud events/projections rather than raw SDK events. |
 
 Module changes should stay narrow:
@@ -330,6 +342,7 @@ provider, one internal MCP, and one internal skill would look like:
 
 ```jsonc
 {
+  "contractVersion": 1,
   "allowedEnvPlaceholders": ["ACME_GATEWAY_URL", "ACME_GATEWAY_KEY"],
   "branding": {
     "name": "Acme Cowork",

--- a/examples/downstream/acme/README.md
+++ b/examples/downstream/acme/README.md
@@ -11,6 +11,9 @@ It includes:
 - `cloud-values.yaml`: Helm values for the Acme cloud control plane.
 - `gateway-values.yaml`: Helm values for the Acme headless gateway.
 
+The shared config declares `contractVersion: 1`, the current downstream
+distribution contract documented in `docs/downstream-contract.md`.
+
 The values pin images with an example release tag. Replace that tag with an
 immutable downstream release tag or digest in a private deployment repo; do not
 ship `latest`, `stable`, or another mutable registry alias.

--- a/examples/downstream/acme/open-cowork.config.json
+++ b/examples/downstream/acme/open-cowork.config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../../open-cowork.config.schema.json",
+  "contractVersion": 1,
   "allowedEnvPlaceholders": [
     "OPEN_COWORK_GATEWAY_SERVICE_TOKEN",
     "OPEN_COWORK_GATEWAY_ADMIN_TOKEN",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - Cloud Web Workbench: cloud-web-workbench.md
       - Gateway Provider Readiness: gateway-provider-readiness.md
       - Downstream Customization: downstream.md
+      - Downstream Contract: downstream-contract.md
       - OpenCode SDK Boundary: opencode-sdk-v2-boundary.md
       - Development Environment: development-environment.md
       - Performance: performance.md

--- a/open-cowork.config.json
+++ b/open-cowork.config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./open-cowork.config.schema.json",
+  "contractVersion": 1,
   "allowedEnvPlaceholders": [],
   "branding": {
     "name": "Open Cowork",

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -5,6 +5,11 @@
   "additionalProperties": false,
   "properties": {
     "$schema": { "type": "string" },
+    "contractVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Version of the supported downstream distribution contract. Version 1 covers Desktop, Cloud, and Gateway configuration surfaces."
+    },
     "allowedEnvPlaceholders": {
       "type": "array",
       "items": { "type": "string" }
@@ -251,7 +256,7 @@
       }
     }
   },
-  "required": ["allowedEnvPlaceholders", "branding", "auth", "providers", "tools", "skills", "mcps", "agents", "permissions"],
+  "required": ["contractVersion", "allowedEnvPlaceholders", "branding", "auth", "providers", "tools", "skills", "mcps", "agents", "permissions"],
   "$defs": {
     "httpsOrLocalhostUrl": {
       "type": "string",

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -48,6 +48,7 @@ const legacyNamingAllowlist = new Set([
   'docs/architecture.md',
   'docs/configuration.md',
   'docs/custom-mcps.md',
+  'docs/downstream-contract.md',
   'docs/downstream.md',
   'open-cowork.config.json',
   'scripts/desktop-dist.mjs',

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -70,7 +70,12 @@ function assertPublicTemplateSafe(path) {
     /\bAKIA[0-9A-Z]{16}\b/,
     /\bghp_[A-Za-z0-9_]{20,}\b/,
     /\bsk-[A-Za-z0-9]{20,}\b/,
+    /\bAIza[0-9A-Za-z_-]{20,}\b/,
+    /\b(?:price|prod|acct)_[0-9A-Za-z]{8,}\b/,
     /\b\d{12}\b/,
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i,
+    /gcp-sm:\/\/projects\/(?!PROJECT(?:\/|$))[a-z][a-z0-9-]{4,}[a-z0-9]\//i,
+    /[?&](?:X-Amz-Signature|X-Amz-Credential|X-Goog-Signature|X-Goog-Credential|AWSAccessKeyId|sig|signature)=/i,
     /customer\s+(?:name|email|domain)\s*:/i,
     /private\s+domain\s*:/i,
     /BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY/,
@@ -418,6 +423,7 @@ function validateHelm() {
 function validateDocs() {
   const requiredDocs = [
     'docs/deployment-readiness.md',
+    'docs/downstream-contract.md',
     'docs/runbooks/cloud-managed-operations.md',
     'docs/runbooks/backup-restore.md',
     'docs/runbooks/restore-drill-report.md',
@@ -468,6 +474,16 @@ function validateDocs() {
     'deploy/managed-workers/worker-release-evidence.template.md',
     'deploy/managed-workers/worker-restore-drill.template.md',
     'deploy/observability/managed-worker-slo-template.json',
+    'deploy/private-beta/hosted-byok.config.example.json',
+    'deploy/private-beta/self-host-oss.config.example.json',
+    'deploy/private-beta/private-beta-plans.json',
+    'deploy/private-beta/design-partner-onboarding.template.md',
+    'deploy/private-beta/go-no-go-report.template.md',
+    'deploy/private-beta/private-beta-launch-profile.template.json',
+    'examples/downstream/acme/README.md',
+    'examples/downstream/acme/open-cowork.config.json',
+    'examples/downstream/acme/cloud-values.yaml',
+    'examples/downstream/acme/gateway-values.yaml',
   ]) {
     assertPublicTemplateSafe(path)
   }
@@ -867,6 +883,8 @@ function validateDocs() {
 
   const downstream = read('docs/downstream.md')
   for (const phrase of [
+    'contractVersion: 1',
+    'Downstream Contract',
     'cloud.publicBranding',
     'cloudDesktop',
     'gateway.providers',
@@ -878,14 +896,41 @@ function validateDocs() {
     'PodDisruptionBudgets',
     'topology spread constraints',
     'billing-free path',
+    'Runtime profiles and policy packs',
+    'Cloud Web feature modules and admin panels',
+    'BYOK validation and injection hooks',
   ]) {
     if (!downstream.includes(phrase)) {
       throw new Error(`docs/downstream.md must include ${phrase}`)
     }
   }
 
+  const downstreamContract = read('docs/downstream-contract.md')
+  for (const phrase of [
+    'contractVersion',
+    'Version `1`',
+    'Runtime config',
+    'Packaging-time config',
+    'Infrastructure config',
+    'Private downstream config',
+    'Desktop shell',
+    'Cloud Web branding',
+    'Gateway channels',
+    'Runtime profiles and policy packs',
+    'Cloud Web modules and admin panels',
+    'BYOK provider validation/injection',
+    'Unsupported source-patch paths',
+    'Template Hygiene',
+    'latest',
+    'signed URL query strings',
+  ]) {
+    if (!downstreamContract.includes(phrase)) {
+      throw new Error(`docs/downstream-contract.md must include ${phrase}`)
+    }
+  }
+
   const acmeReadme = read('examples/downstream/acme/README.md')
-  for (const phrase of ['OPEN_COWORK_CONFIG_PATH', 'cloud.publicBranding', 'cloudDesktop', 'gateway.providers', 'immutable downstream release tag or digest', 'cloud.billing.provider=none']) {
+  for (const phrase of ['OPEN_COWORK_CONFIG_PATH', 'contractVersion: 1', 'docs/downstream-contract.md', 'cloud.publicBranding', 'cloudDesktop', 'gateway.providers', 'immutable downstream release tag or digest', 'cloud.billing.provider=none']) {
     if (!acmeReadme.includes(phrase)) {
       throw new Error(`examples/downstream/acme/README.md must include ${phrase}`)
     }
@@ -893,6 +938,7 @@ function validateDocs() {
 
   const acmeConfig = read('examples/downstream/acme/open-cowork.config.json')
   for (const phrase of [
+    '"contractVersion": 1',
     '"gateway"',
     '"providers"',
     'OPEN_COWORK_GATEWAY_SERVICE_TOKEN',

--- a/scripts/validate-private-beta-package.mjs
+++ b/scripts/validate-private-beta-package.mjs
@@ -143,6 +143,7 @@ if (packageJson.scripts?.['deploy:private-beta:validate'] !== 'node scripts/vali
 }
 
 const hosted = readJson('deploy/private-beta/hosted-byok.config.example.json')
+if (hosted.contractVersion !== 1) throw new Error('hosted private beta config must declare contractVersion 1')
 if (hosted.cloud?.auth?.signupMode !== 'invite') throw new Error('hosted private beta config must use invite signup mode')
 if (hosted.cloud?.billing?.provider !== 'stub') throw new Error('hosted private beta config must keep billing stubbed')
 if (hosted.cloudDesktop?.requireManagedOrg !== true) throw new Error('hosted private beta config must require a managed org')
@@ -151,6 +152,7 @@ if (hosted.gateway?.metrics?.enabled !== true) throw new Error('hosted private b
 if (!hosted.gateway?.server?.adminToken) throw new Error('hosted private beta config must require gateway admin token')
 
 const selfHost = readJson('deploy/private-beta/self-host-oss.config.example.json')
+if (selfHost.contractVersion !== 1) throw new Error('self-host config must declare contractVersion 1')
 if (!['none', 'stub'].includes(selfHost.cloud?.billing?.provider)) {
   throw new Error('self-host config must keep billing none or stub')
 }

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -435,6 +435,11 @@ test('cloud control plane fences status, runtime binding, and event writes by wo
 
 test('cloud control plane reaps expired session leases with bounded retries', async () => {
   const store = seededStore()
+  const firstLeaseStart = new Date('2030-01-01T00:00:00.000Z')
+  const firstLeaseExpired = new Date('2030-01-01T00:00:02.000Z')
+  const secondLeaseStart = new Date('2030-01-01T00:00:03.000Z')
+  const secondLeaseExpired = new Date('2030-01-01T00:00:05.000Z')
+
   store.enqueueSessionCommand({
     commandId: 'cmd-retry',
     tenantId: 'tenant-1',
@@ -444,22 +449,20 @@ test('cloud control plane reaps expired session leases with bounded retries', as
     payload: { text: 'retry me' },
   })
 
-  const firstLease = store.claimSessionLease('tenant-1', 'session-1', 'worker-a', new Date(), 20)
+  const firstLease = store.claimSessionLease('tenant-1', 'session-1', 'worker-a', firstLeaseStart, 1_000)
   assert.ok(firstLease)
-  assert.equal(store.claimNextSessionCommand(firstLease)?.attemptCount, 1)
-  await new Promise((resolve) => setTimeout(resolve, 30))
+  assert.equal(store.claimNextSessionCommand(firstLease, firstLeaseStart)?.attemptCount, 1)
 
-  const retried = store.reapExpiredSessionLeases({ maxCommandAttempts: 2 })
+  const retried = store.reapExpiredSessionLeases({ maxCommandAttempts: 2, now: firstLeaseExpired })
   assert.equal(retried.length, 1)
   assert.equal(retried[0]?.action, 'retried')
   assert.deepEqual(retried[0]?.retriedCommandIds, ['cmd-retry'])
 
-  const secondLease = store.claimSessionLease('tenant-1', 'session-1', 'worker-b', new Date(), 20)
+  const secondLease = store.claimSessionLease('tenant-1', 'session-1', 'worker-b', secondLeaseStart, 1_000)
   assert.ok(secondLease)
-  assert.equal(store.claimNextSessionCommand(secondLease)?.attemptCount, 2)
-  await new Promise((resolve) => setTimeout(resolve, 30))
+  assert.equal(store.claimNextSessionCommand(secondLease, secondLeaseStart)?.attemptCount, 2)
 
-  const failed = store.reapExpiredSessionLeases({ maxCommandAttempts: 2 })
+  const failed = store.reapExpiredSessionLeases({ maxCommandAttempts: 2, now: secondLeaseExpired })
   assert.equal(failed.length, 1)
   assert.equal(failed[0]?.action, 'failed')
   assert.deepEqual(failed[0]?.failedCommandIds, ['cmd-retry'])

--- a/tests/cloud-modularity-boundaries.test.ts
+++ b/tests/cloud-modularity-boundaries.test.ts
@@ -260,12 +260,16 @@ test('cloud and gateway OCI builds keep generated artifacts out of Docker contex
 test('downstream extension docs map extension points to owning modules', () => {
   for (const phrase of [
     'Extension Points And Ownership',
+    'Downstream Contract',
     'Gateway providers',
     'Deployment recipes',
     'Billing adapters',
     'Object-store adapters',
     'Secret adapters',
     'Worker pool modes',
+    'Runtime profiles and policy packs',
+    'Cloud Web feature modules and admin panels',
+    'BYOK validation and injection hooks',
     'Cloud event and projection contract',
     'Do not patch core execution code',
   ]) {

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -647,6 +647,11 @@ test('real Postgres cloud store reaps expired session leases with bounded retrie
   skip: POSTGRES_SKIP,
 }, async () => {
   await withPostgresStore(async (store, ids) => {
+    const firstLeaseStart = new Date('2030-01-01T00:00:00.000Z')
+    const firstLeaseExpired = new Date('2030-01-01T00:00:02.000Z')
+    const secondLeaseStart = new Date('2030-01-01T00:00:03.000Z')
+    const secondLeaseExpired = new Date('2030-01-01T00:00:05.000Z')
+
     await store.enqueueSessionCommand({
       commandId: `${ids.tenantId}-reap-cmd`,
       tenantId: ids.tenantId,
@@ -655,22 +660,20 @@ test('real Postgres cloud store reaps expired session leases with bounded retrie
       kind: 'prompt',
       payload: { text: 'retry this command' },
     })
-    const firstLease = await store.claimSessionLease(ids.tenantId, ids.sessionId, 'worker-reap-a', new Date(), 20)
+    const firstLease = await store.claimSessionLease(ids.tenantId, ids.sessionId, 'worker-reap-a', firstLeaseStart, 1_000)
     assert.ok(firstLease)
-    assert.equal((await store.claimNextSessionCommand(firstLease))?.attemptCount, 1)
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    assert.equal((await store.claimNextSessionCommand(firstLease, firstLeaseStart))?.attemptCount, 1)
 
-    const retried = (await store.reapExpiredSessionLeases({ maxCommandAttempts: 2 }))
+    const retried = (await store.reapExpiredSessionLeases({ maxCommandAttempts: 2, now: firstLeaseExpired }))
       .find((record) => record.tenantId === ids.tenantId && record.sessionId === ids.sessionId)
     assert.equal(retried?.action, 'retried')
     assert.deepEqual(retried?.retriedCommandIds, [`${ids.tenantId}-reap-cmd`])
 
-    const secondLease = await store.claimSessionLease(ids.tenantId, ids.sessionId, 'worker-reap-b', new Date(), 20)
+    const secondLease = await store.claimSessionLease(ids.tenantId, ids.sessionId, 'worker-reap-b', secondLeaseStart, 1_000)
     assert.ok(secondLease)
-    assert.equal((await store.claimNextSessionCommand(secondLease))?.attemptCount, 2)
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    assert.equal((await store.claimNextSessionCommand(secondLease, secondLeaseStart))?.attemptCount, 2)
 
-    const failed = (await store.reapExpiredSessionLeases({ maxCommandAttempts: 2 }))
+    const failed = (await store.reapExpiredSessionLeases({ maxCommandAttempts: 2, now: secondLeaseExpired }))
       .find((record) => record.tenantId === ids.tenantId && record.sessionId === ids.sessionId)
     assert.equal(failed?.action, 'failed')
     assert.deepEqual(failed?.failedCommandIds, [`${ids.tenantId}-reap-cmd`])

--- a/tests/cloud-workspace-auth.test.ts
+++ b/tests/cloud-workspace-auth.test.ts
@@ -71,9 +71,13 @@ test('cloud workspace desktop authenticator performs OIDC PKCE loopback login', 
       const state = parsed.searchParams.get('state')
       assert.ok(redirectUri)
       assert.ok(state)
-      await fetch(`${redirectUri}?code=code-1&state=${state}`)
+      const callbackResponse = await fetch(`${redirectUri}?code=code-1&state=${state}`)
+      const callbackHtml = await callbackResponse.text()
+      assert.match(callbackHtml, /Acme &lt;Cowork&gt; Cloud login complete/)
+      assert.match(callbackHtml, /You can return to Acme &lt;Cowork&gt;\./)
     },
     callbackTimeoutMs: 2000,
+    brandName: 'Acme <Cowork>',
   })
 
   const result = await authenticator.login({

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -171,6 +171,62 @@ test('config loader normalizes cloud defaults and focused profile overrides', ()
   }
 })
 
+test('config loader preserves every documented gateway provider kind', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-gateway-providers-'))
+  const configPath = join(tempRoot, 'open-cowork.config.json')
+  const previousOverride = process.env.OPEN_COWORK_CONFIG_PATH
+  const providerKinds = ['fake', 'telegram', 'slack', 'email', 'webhook', 'discord', 'whatsapp', 'signal', 'cli'] as const
+
+  writeFileSync(configPath, JSON.stringify({
+    gateway: {
+      server: {
+        host: '127.0.0.1',
+      },
+      providers: providerKinds.map((kind) => ({
+        kind,
+        channelBindingId: `${kind}-binding`,
+        credentials: kind === 'webhook'
+          ? { sharedSecret: `${kind}-secret` }
+          : kind === 'telegram'
+            ? { botToken: `${kind}-token`, webhookSecret: `${kind}-secret` }
+            : kind === 'slack'
+              ? { botToken: `${kind}-token`, signingSecret: `${kind}-secret` }
+              : kind === 'email'
+                ? { inboundSecret: `${kind}-secret` }
+                : kind === 'cli' || kind === 'fake'
+                  ? {}
+                  : { sharedSecret: `${kind}-secret` },
+        settings: kind === 'telegram'
+          ? { mode: 'polling' }
+          : kind === 'email'
+            ? { from: 'agent@example.test', smtpHost: 'smtp.example.test' }
+            : kind === 'cli' || kind === 'fake'
+              ? {}
+              : { deliveryUrl: `https://channels.example.test/${kind}` },
+      })),
+    },
+  }))
+
+  process.env.OPEN_COWORK_CONFIG_PATH = configPath
+  clearConfigCaches()
+
+  try {
+    assert.doesNotThrow(() => assertConfigValid())
+    assert.deepEqual(
+      getAppConfig().gateway.providers.map((provider) => provider.kind).sort(),
+      [...providerKinds].sort(),
+    )
+  } finally {
+    if (previousOverride === undefined) {
+      delete process.env.OPEN_COWORK_CONFIG_PATH
+    } else {
+      process.env.OPEN_COWORK_CONFIG_PATH = previousOverride
+    }
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('config loader accepts select and radio credential metadata for bundled MCPs', () => {
   const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-config-mcp-credentials-'))
   const configPath = join(tempRoot, 'open-cowork.config.json')

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -17,6 +17,18 @@ test('root open-cowork.config.json validates against the public schema', () => {
   assert.doesNotThrow(() => validateResolvedConfig(config, 'open-cowork.config.json'))
 })
 
+test('downstream contract version is required and fixed for this schema', () => {
+  const config = cloneConfig()
+  assert.equal(config.contractVersion, 1)
+
+  delete config.contractVersion
+  assert.throws(() => validateResolvedConfig(config, 'downstream config'), /contractVersion/)
+
+  const unsupported = cloneConfig()
+  unsupported.contractVersion = 2
+  assert.throws(() => validateResolvedConfig(unsupported, 'downstream config'), /contractVersion/)
+})
+
 test('branding sidebar and home overrides validate', () => {
   const config = cloneConfig()
   config.branding.sidebar = {

--- a/tests/private-beta-package.test.ts
+++ b/tests/private-beta-package.test.ts
@@ -146,6 +146,7 @@ test('private beta onboarding and go/no-go templates force complete evidence rec
 
 test('private beta examples keep hosted and OSS modes separate', () => {
   const hosted = readJson('deploy/private-beta/hosted-byok.config.example.json')
+  assert.equal(hosted.contractVersion, 1)
   assert.equal(hosted.cloud.auth.signupMode, 'invite')
   assert.equal(hosted.cloud.auth.allowSelfServiceSignup, false)
   assert.equal(hosted.cloud.billing.provider, 'stub')
@@ -157,6 +158,7 @@ test('private beta examples keep hosted and OSS modes separate', () => {
   assert.ok(hosted.gateway.server.adminToken)
 
   const selfHost = readJson('deploy/private-beta/self-host-oss.config.example.json')
+  assert.equal(selfHost.contractVersion, 1)
   assert.equal(selfHost.cloud.billing.provider, 'none')
   assert.equal(selfHost.cloudDesktop.allowUserAddedConnections, true)
   assert.equal(selfHost.cloudDesktop.requireManagedOrg, false)


### PR DESCRIPTION
Closes #551.

## Summary
- Adds a versioned downstream distribution contract (`contractVersion: 1`) to the public config schema, default config, examples, and private-beta templates.
- Documents the supported Desktop, Cloud, Gateway, packaging, template hygiene, and extension contracts in a dedicated Downstream Contract page.
- Extends deployment/private-template validators to catch more private values, signed URL leakage, mutable production tags, and source-patch-only branding regressions.
- Propagates downstream branding into the desktop cloud OIDC callback page and preserves every documented gateway provider kind through config loading.
- Makes command claiming accept the same injectable clock used by lease reaping, removing wall-clock sleeps from lease-reaper tests.

## Validation
- `node --no-warnings --experimental-strip-types --test tests/config-schema-validation.test.ts tests/config-elements.test.ts tests/cloud-workspace-auth.test.ts tests/cloud-modularity-boundaries.test.ts tests/private-beta-package.test.ts`
- `node --no-warnings --experimental-strip-types --test tests/config-schema-validation.test.ts tests/config-elements.test.ts tests/cloud-workspace-auth.test.ts tests/cloud-modularity-boundaries.test.ts tests/private-beta-package.test.ts tests/cloud-postgres-concurrency.test.ts`
- `node --no-warnings --experimental-strip-types --test tests/cloud-control-plane-store.test.ts tests/cloud-postgres-concurrency.test.ts`
- `pnpm deploy:validate`
- `pnpm deploy:private-beta:validate`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `python3 -m mkdocs build --strict` (`uv` is not installed in this local environment)

## Review Notes
- No raw deployment/project values were added. Public examples still use placeholders only.
- The only user-visible runtime behavior change is branding the OIDC loopback completion page from configured product branding.
- The store clock change is a small testability hardening: production callers keep the default current time, while concurrency tests can use one consistent injected time.