### PR TITLE
Harden managed BYOK SaaS readiness package

### DIFF
--- a/deploy/private-beta/README.md
+++ b/deploy/private-beta/README.md
@@ -15,6 +15,9 @@ Files:
 - `private-beta-launch-profile.template.json`: launch-profile template covering
   entitlements, allowed provider policy, gateway availability, support owners,
   RPO/RTO, required launch evidence, and go/no-go placeholders.
+- `managed-byok-readiness-contract.template.json`: machine-readable
+  public/private boundary, onboarding status/reason-code, billing, BYOK,
+  diagnostics, and validation contract.
 - `design-partner-onboarding.template.md`: repeatable 10-step onboarding
   evidence template for invite, BYOK, Desktop, Web, Gateway, token lifecycle,
   and redaction proof.
@@ -26,6 +29,9 @@ These examples are provider-neutral. They use placeholder domains such as
 `cowork.example.com`, placeholder secret refs such as
 `env:OPEN_COWORK_CLOUD_DATABASE_URL`, and placeholder plan keys. Do not replace
 them with real provider project ids or customer values in the repository.
+The public/private split is defined in
+`docs/runbooks/managed-byok-saas-boundary.md` and enforced by
+`managed-byok-readiness-contract.template.json`.
 
 ## Hosted Managed BYOK
 

--- a/deploy/private-beta/design-partner-onboarding.template.md
+++ b/deploy/private-beta/design-partner-onboarding.template.md
@@ -16,6 +16,14 @@ channel secrets, or support rosters.
 - Support owner:
 - Date:
 
+## Onboarding State
+
+- Status: `{not_started|invite_sent|auth_required|org_ready|byok_pending_validation|byok_active|desktop_ready|gateway_ready|billing_blocked|quota_blocked|support_review|ready|blocked|offboarded}`
+- Reason code:
+- User-facing message:
+- Operator note:
+- Last status change:
+
 ## Required Ten-Step Flow
 
 1. **Create or invite org owner**
@@ -96,7 +104,19 @@ local file contents are absent from:
 - [ ] Unsupported provider blocks execution with a clear policy message.
 - [ ] Missing BYOK state blocks execution with a clear setup message.
 - [ ] Quota pressure returns clear 429/402 responses without spawning workers.
+- [ ] Billing entitlement blocks return a machine-readable reason code.
+- [ ] Revoked/expired token states return a machine-readable reason code.
 - [ ] Cloud outage leaves local Desktop workspace usable.
+
+## Support Bundle Proof
+
+- [ ] Bundle contains app/build metadata, surface, workspace kind, redacted ids,
+      status, reason code, sanitized error summaries, and operational counters.
+- [ ] Bundle excludes raw BYOK, OAuth, Desktop, Gateway, API, cookie, internal,
+      operator, MCP, channel, database, and signed object-store secrets.
+- [ ] Bundle excludes full chat transcript bodies, local file contents,
+      unredacted home-directory paths, and customer identifiers in public
+      evidence.
 
 ## Final Onboarding Decision
 

--- a/deploy/private-beta/go-no-go-report.template.md
+++ b/deploy/private-beta/go-no-go-report.template.md
@@ -79,6 +79,19 @@ The public repo keeps the evidence shape only.
 - [ ] Tokens are show-once, scoped, expiring by default, and revocable.
 - [ ] No real project ids, customer names, domains, prices, provider keys,
       billing ids, or cloud account ids are copied into public repo artifacts.
+- [ ] Public/private boundary was checked against
+      `deploy/private-beta/managed-byok-readiness-contract.template.json`.
+- [ ] Support bundle sample follows the allowed/forbidden diagnostics contract.
+- [ ] Onboarding failures preserve machine-readable status and reason codes.
+
+## Public/Private Boundary Evidence
+
+- Public template validation:
+- Private ops evidence location:
+- Redaction reviewer:
+- Public repo scanner result:
+- Support bundle redaction proof:
+- Onboarding status/reason-code sample:
 
 ## Known Risks And Mitigations
 

--- a/deploy/private-beta/managed-byok-readiness-contract.template.json
+++ b/deploy/private-beta/managed-byok-readiness-contract.template.json
@@ -1,0 +1,197 @@
+{
+  "contractVersion": 1,
+  "purpose": "managed-byok-saas-readiness-contract",
+  "scope": "public-template-only",
+  "publicPrivateBoundary": {
+    "publicRepoAllowed": [
+      "provider-neutral billing adapter interfaces",
+      "stub billing adapter and local validators",
+      "Stripe adapter code without live account ids, prices, webhook secrets, or customer data",
+      "BYOK status APIs, secret-store interfaces, and worker-role runtime injection code",
+      "placeholder deployment configs and launch checklist templates",
+      "self-host documentation and billing-free deployment paths",
+      "support and diagnostics redaction contracts",
+      "security, privacy, and disclosure documentation"
+    ],
+    "privateOpsOnly": [
+      "real cloud project ids, account ids, subscription ids, and regions tied to a managed service",
+      "real managed SaaS domains before intentional public launch",
+      "real plan packaging, prices, coupon ids, Stripe product ids, or Stripe price ids before intentional public launch",
+      "customer names, emails, org slugs, channel identifiers, support tickets, onboarding records, or launch evidence",
+      "production secret refs when they reveal provider, account, customer, tenant, or environment identity",
+      "production support rosters, on-call schedules, incident channels, and escalation phone numbers",
+      "raw diagnostics bundles, logs, database exports, object-store listings, or audit exports from managed customers"
+    ],
+    "publicAfterLaunchOnly": [
+      "published pricing table",
+      "public SaaS marketing domain",
+      "public support mailbox or disclosure alias",
+      "public status page URL"
+    ],
+    "forbiddenPublicPatterns": [
+      "provider API keys",
+      "OAuth refresh or access tokens",
+      "Desktop or Gateway API tokens",
+      "channel bot tokens or signing secrets",
+      "database URLs",
+      "signed object-store URLs",
+      "private key blocks",
+      "real Stripe price, product, account, customer, or subscription ids"
+    ]
+  },
+  "onboardingContract": {
+    "statuses": [
+      "not_started",
+      "invite_sent",
+      "auth_required",
+      "org_ready",
+      "byok_pending_validation",
+      "byok_active",
+      "desktop_ready",
+      "gateway_ready",
+      "billing_blocked",
+      "quota_blocked",
+      "support_review",
+      "ready",
+      "blocked",
+      "offboarded"
+    ],
+    "reasonCodes": [
+      "auth.invite_required",
+      "auth.membership_missing",
+      "auth.role_insufficient",
+      "auth.token_expired",
+      "auth.token_revoked",
+      "byok.key_missing",
+      "byok.provider_disabled",
+      "byok.validation_failed",
+      "byok.unsupported_provider",
+      "billing.subscription_required",
+      "billing.subscription_inactive",
+      "quota.prompt_limit_exceeded",
+      "quota.worker_limit_exceeded",
+      "gateway.channel_not_bound",
+      "gateway.identity_not_allowed",
+      "gateway.signature_required",
+      "desktop.managed_org_required",
+      "support.diagnostics_redaction_required"
+    ],
+    "requiredFlow": [
+      "create_or_invite_org_owner",
+      "verify_membership_and_role",
+      "configure_byok_write_only",
+      "validate_provider_or_audited_override",
+      "issue_desktop_connection",
+      "issue_gateway_service_token_and_binding",
+      "verify_cloud_web_admin_surface",
+      "run_first_thread_from_web",
+      "continue_same_thread_from_desktop",
+      "continue_or_notify_through_gateway"
+    ]
+  },
+  "billingEntitlementContract": {
+    "selfHostAllowedProviders": [
+      "none",
+      "stub"
+    ],
+    "managedPrivateBetaAllowedProviders": [
+      "stub",
+      "manual"
+    ],
+    "requiredGates": [
+      "subscription state overlays runtime policy",
+      "past_due, canceled, disabled, and inactive states block new paid execution",
+      "expensive managed work is blocked before worker spawn or lease claim where possible",
+      "read/export and offboarding paths remain available unless abuse policy requires suspension",
+      "billing webhook ingress requires provider signature verification and replay protection",
+      "self-host mode must not require Stripe or any commercial billing adapter"
+    ],
+    "machineReadablePolicyCodes": [
+      "billing.subscription_required",
+      "billing.subscription_inactive",
+      "billing.provider_unavailable",
+      "quota.prompt_limit_exceeded",
+      "quota.worker_limit_exceeded",
+      "quota.gateway_delivery_limit_exceeded"
+    ]
+  },
+  "byokSecurityContract": {
+    "plaintextReadbackAllowed": false,
+    "workerRevealOnly": true,
+    "runtimeInjection": "provider-options-only",
+    "requiredRedactionSurfaces": [
+      "HTTP read payloads",
+      "audit exports",
+      "logs",
+      "diagnostics bundles",
+      "launch reports",
+      "renderer state",
+      "Desktop cloud cache",
+      "Gateway logs",
+      "SSE events",
+      "billing payloads"
+    ],
+    "statusOnlyFields": [
+      "provider",
+      "last4",
+      "fingerprint",
+      "status",
+      "health",
+      "lastValidatedAt",
+      "validationSource"
+    ]
+  },
+  "supportBundleContract": {
+    "allowedFields": [
+      "app version, build id, commit, and feature flags",
+      "surface and workspace kind",
+      "redacted org id, session id, workflow id, run id, artifact id, request id, and delivery id",
+      "status and reason code",
+      "sanitized error summaries",
+      "timing, retry, reconnect, queue depth, projection lag, quota, and worker heartbeat summaries",
+      "BYOK provider id and status metadata without plaintext",
+      "billing plan key, subscription status, and entitlement verdict without provider customer data",
+      "gateway provider kind, delivery status, and dead-letter counts without channel secrets"
+    ],
+    "forbiddenFields": [
+      "raw BYOK keys",
+      "OAuth refresh or access tokens",
+      "Desktop, Gateway, API, cookie, internal, or operator tokens",
+      "MCP secrets",
+      "channel bot tokens or signing secrets",
+      "database URLs",
+      "signed object-store URLs",
+      "full chat transcript bodies unless explicitly attached by the user",
+      "local file contents",
+      "unredacted local home-directory paths",
+      "customer names, emails, phone numbers, or channel handles in public evidence"
+    ],
+    "retentionDefault": "private operations evidence only; keep public repo templates generic"
+  },
+  "launchPackageContract": {
+    "requiredPublicArtifacts": [
+      "docs/runbooks/managed-byok-saas.md",
+      "docs/runbooks/managed-byok-saas-boundary.md",
+      "docs/runbooks/private-beta-launch.md",
+      "docs/runbooks/private-beta-support.md",
+      "deploy/private-beta/managed-byok-readiness-contract.template.json",
+      "deploy/private-beta/hosted-byok.config.example.json",
+      "deploy/private-beta/self-host-oss.config.example.json",
+      "deploy/private-beta/private-beta-plans.json",
+      "deploy/private-beta/private-beta-launch-profile.template.json",
+      "deploy/private-beta/design-partner-onboarding.template.md",
+      "deploy/private-beta/go-no-go-report.template.md"
+    ],
+    "requiredValidationCommands": [
+      "pnpm deploy:private-beta:validate",
+      "pnpm deploy:validate",
+      "pnpm deploy:launch:validate",
+      "pnpm ops:validate",
+      "pnpm test",
+      "pnpm typecheck",
+      "pnpm lint",
+      "pnpm docs:build",
+      "git diff --check"
+    ]
+  }
+}

--- a/docs/runbooks/managed-byok-saas-boundary.md
+++ b/docs/runbooks/managed-byok-saas-boundary.md
@@ -1,0 +1,160 @@
+---
+title: Managed BYOK SaaS Boundary
+description: Public/private split, onboarding status contract, support bundle limits, and launch package rules for managed BYOK deployments.
+---
+
+# Managed BYOK SaaS Boundary
+
+This page is the public contract for turning Open Cowork into a managed BYOK
+service without making the upstream repository depend on private SaaS values.
+The machine-readable version lives in
+`deploy/private-beta/managed-byok-readiness-contract.template.json`.
+
+The goal is simple: the public repo contains provider-neutral product code,
+self-hostable defaults, and launch templates. A downstream managed SaaS repo or
+private operations system contains real customers, real infrastructure, real
+commercial values, and live launch evidence.
+
+## Public/Private Boundary
+
+Keep these artifacts in the public `open-cowork` repo:
+
+| Area | Public repo may contain | Private/downstream only |
+| --- | --- | --- |
+| Billing | Billing adapter interfaces, stub adapter, provider-neutral entitlement hooks, Stripe adapter code without live ids. | Real Stripe account ids, products, prices, customer ids, coupon ids, invoices, checkout links, and commercial packaging before intentional public launch. |
+| BYOK | Secret-store interfaces, status APIs, worker-role reveal contract, runtime config injection code, redaction tests. | Real provider keys, customer provider accounts, validation evidence with identifiable customers, and production secret-manager paths that reveal tenant/account identity. |
+| Deployments | Compose/Helm/GCP templates with placeholder refs, self-host docs, validation scripts. | Real project ids, account ids, domains, regions, VPCs, database urls, object-store buckets, KMS refs, and operator credentials. |
+| Onboarding | Generic design-partner checklist, status and reason-code taxonomy, launch templates. | Customer names, org slugs, emails, channel handles, support tickets, completed onboarding records, and customer-specific decisions. |
+| Support | Redaction rules, intake workflow, diagnostics schema, incident checklist shapes. | Raw diagnostics bundles, logs, database exports, object-store listings, audit exports, support rosters, on-call rotations, private incident channels, and customer communications. |
+| Evidence | Required evidence names and public-safe go/no-go shape. | Screenshots, logs, command output, smoke reports, metrics exports, and restore evidence from managed customers or real production-like environments. |
+
+Public-after-launch items such as a marketing domain, public pricing table,
+public status page, or public support alias must be intentionally added as
+public product material. Until then, keep them private or placeholder-only.
+
+## Onboarding Status Contract
+
+Managed onboarding records should expose stable machine-readable statuses so
+Desktop, Cloud Web, Gateway, support, and private operations can describe the
+same state without leaking sensitive details.
+
+Required statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `not_started` | No private ops onboarding record has begun. |
+| `invite_sent` | Owner invite or membership bootstrap has been created. |
+| `auth_required` | User must finish login, invite acceptance, or device authorization. |
+| `org_ready` | Org, owner, membership, and base policy are ready. |
+| `byok_pending_validation` | BYOK metadata exists but worker-role validation has not activated it. |
+| `byok_active` | BYOK key is active for at least one allowed provider. |
+| `desktop_ready` | Desktop connection or token is issued and validated. |
+| `gateway_ready` | Gateway service token and at least one channel binding are validated. |
+| `billing_blocked` | Entitlement policy blocks paid or managed execution. |
+| `quota_blocked` | Quota policy blocks new work. |
+| `support_review` | Operator review is required before launch or continuation. |
+| `ready` | The org passed onboarding and smoke evidence. |
+| `blocked` | The org cannot proceed without an explicit fix or decision. |
+| `offboarded` | Access and execution are disabled for exit or incident handling. |
+
+Required reason codes:
+
+| Code | Use |
+| --- | --- |
+| `auth.invite_required` | No accepted invite or allowed signup path. |
+| `auth.membership_missing` | Identity is known but lacks org membership. |
+| `auth.role_insufficient` | Actor lacks owner/admin/member role for the action. |
+| `auth.token_expired` | Desktop, Gateway, API, or operator token expired. |
+| `auth.token_revoked` | Token was revoked and must not be retried silently. |
+| `byok.key_missing` | No usable BYOK key exists for the required provider. |
+| `byok.provider_disabled` | Provider is disabled by profile, policy, or plan. |
+| `byok.validation_failed` | Worker-role provider validation failed. |
+| `byok.unsupported_provider` | Provider has no supported managed BYOK path. |
+| `billing.subscription_required` | Managed execution requires an active entitlement. |
+| `billing.subscription_inactive` | Subscription or manual entitlement is inactive, past due, canceled, or disabled. |
+| `quota.prompt_limit_exceeded` | Prompt rate or prompt quota is exhausted. |
+| `quota.worker_limit_exceeded` | Worker/session capacity is exhausted. |
+| `gateway.channel_not_bound` | Channel thread is not bound to an allowed headless agent/session. |
+| `gateway.identity_not_allowed` | Channel actor failed membership or channel RBAC. |
+| `gateway.signature_required` | Public webhook/channel ingress lacks required signing proof. |
+| `desktop.managed_org_required` | Desktop must connect to a managed org and cannot use arbitrary cloud connections. |
+| `support.diagnostics_redaction_required` | Evidence or diagnostics must be redacted before support can attach it. |
+
+User-facing copy can be friendlier, but APIs, dashboards, diagnostics, and
+support records should retain these codes so failures remain searchable and
+testable.
+
+## Billing And Entitlement Boundary
+
+Self-host deployments must keep working with `cloud.billing.provider=none` or
+the stub billing adapter. Commercial billing must be optional and swappable.
+
+Managed private beta can run on manual or stub billing while operators prove
+the product flow. Public self-serve must not launch until billing webhooks,
+replay protection, rate limits, quotas, and entitlement gates are proven.
+
+Required gates:
+
+- Subscription or manual entitlement state overlays runtime policy.
+- `past_due`, `canceled`, `disabled`, and `inactive` states block new paid
+  execution.
+- Expensive managed work is blocked before worker spawn or lease claim where
+  possible.
+- Read, export, and offboarding paths stay available unless abuse policy
+  requires suspension.
+- Billing webhook ingress requires provider signature verification and replay
+  protection.
+- Billing provider imports stay outside core runtime and self-host paths.
+
+## BYOK Boundary
+
+BYOK plaintext is never readable over HTTP. It is revealed only inside the
+worker-role runtime or validation path, scoped by org/provider/session, and
+injected through `provider.<id>.options`. It must not be placed in
+`process.env`, logs, diagnostics, SSE payloads, renderer state, Desktop cache,
+Gateway payloads, billing payloads, or public launch evidence.
+
+Read APIs can return only status-style fields: provider id, last4, fingerprint,
+health, status, validation source, and last validation time.
+
+## Support Bundle Contract
+
+A support bundle may include:
+
+- app version, build id, commit, feature flags, surface, and workspace kind,
+- redacted org/session/workflow/run/artifact/request/delivery ids,
+- status and reason code,
+- sanitized error summaries,
+- timing, retry, reconnect, queue depth, projection lag, quota, and worker
+  heartbeat summaries,
+- BYOK provider id and status metadata without plaintext,
+- billing plan key, subscription status, and entitlement verdict without
+  provider customer data,
+- Gateway provider kind, delivery status, and dead-letter counts without
+  channel secrets.
+
+A support bundle must not include raw BYOK keys, OAuth tokens, Desktop or
+Gateway tokens, API tokens, cookie/internal/operator tokens, MCP secrets,
+channel bot tokens, signing secrets, database URLs, signed object-store URLs,
+full chat transcript bodies unless explicitly attached by the user, local file
+contents, unredacted home-directory paths, or customer identifiers in public
+evidence.
+
+## Launch Package Rules
+
+Before inviting managed BYOK users, run:
+
+```bash
+pnpm deploy:private-beta:validate
+pnpm deploy:validate
+pnpm deploy:launch:validate
+pnpm ops:validate
+pnpm test
+pnpm typecheck
+pnpm lint
+pnpm docs:build
+git diff --check
+```
+
+Completed launch evidence belongs in a private operations repository or ticket
+system. The public repo keeps only templates and redacted examples.

--- a/docs/runbooks/managed-byok-saas.md
+++ b/docs/runbooks/managed-byok-saas.md
@@ -19,6 +19,22 @@ gateway channel bindings.
 - Billing, IdP, object store, secret manager, and gateway provider choices stay
   behind adapters.
 
+## Public/Private Boundary
+
+The upstream repository must stay safe for OSS self-hosters and downstream
+managed SaaS operators. Keep provider-neutral code, placeholder configs,
+redaction rules, and validation templates here. Keep real project ids, real
+domains, customer data, live prices, secret refs that identify production
+tenants, raw diagnostics, support rosters, and launch evidence in private
+operations.
+
+The full public/private split, onboarding status and reason-code contract,
+support bundle contract, and launch package rules live in
+[Managed BYOK SaaS Boundary](managed-byok-saas-boundary.md). The
+machine-readable contract is
+`deploy/private-beta/managed-byok-readiness-contract.template.json` and is
+validated by `pnpm deploy:private-beta:validate`.
+
 ## Org Signup Mode
 
 Choose one org signup mode per environment:

--- a/docs/runbooks/private-beta-launch.md
+++ b/docs/runbooks/private-beta-launch.md
@@ -40,6 +40,9 @@ The public repository owns the reusable launch package:
 - `deploy/private-beta/private-beta-launch-profile.template.json` defines the
   generic launch profile, entitlements, provider policy, gateway availability,
   RPO/RTO, required evidence, and security-boundary placeholders.
+- `deploy/private-beta/managed-byok-readiness-contract.template.json` defines
+  the public/private boundary, onboarding statuses, reason codes, billing/BYOK
+  invariants, support bundle limits, and required validation commands.
 - `deploy/private-beta/design-partner-onboarding.template.md` defines the
   repeatable design-partner onboarding evidence checklist.
 - `deploy/private-beta/go-no-go-report.template.md` defines the final decision
@@ -48,6 +51,16 @@ The public repository owns the reusable launch package:
 Completed copies belong in a private operations repository or ticket system.
 Do not commit real org ids, project ids, customer names, domains, prices,
 provider keys, cloud account ids, token values, or launch evidence here.
+
+## Public/Private Boundary
+
+Use [Managed BYOK SaaS Boundary](managed-byok-saas-boundary.md) as the source
+of truth for what can live in the public repository. Public files may include
+provider-neutral code, placeholder configs, support redaction rules, launch
+templates, self-host docs, and validation scripts. Private operations must hold
+real customer records, production project/account ids, live prices, real
+domains before public launch, support rosters, incident channels, raw
+diagnostics, and completed launch evidence.
 
 Private beta excludes:
 

--- a/docs/runbooks/private-beta-support.md
+++ b/docs/runbooks/private-beta-support.md
@@ -65,6 +65,43 @@ Do not request:
    issues.
 7. Record outcome, mitigation, owner, and follow-up test.
 
+## Support Bundle Contract
+
+Support bundles should follow the public contract in
+[Managed BYOK SaaS Boundary](managed-byok-saas-boundary.md). They may include
+app/build metadata, surface, workspace kind, redacted org/session/workflow/run/
+artifact/request/delivery ids, status and reason code, sanitized error
+summaries, timing/retry/reconnect/queue/projection/quota summaries, BYOK status
+metadata, billing entitlement verdicts, and Gateway delivery counts.
+
+They must not include raw BYOK keys, OAuth tokens, Desktop or Gateway tokens,
+API tokens, cookie/internal/operator tokens, MCP secrets, channel bot tokens,
+signing secrets, database URLs, signed object-store URLs, full chat transcript
+bodies unless explicitly attached by the user, local file contents, unredacted
+home-directory paths, or customer identifiers in public evidence.
+
+## Onboarding Status And Reason Codes
+
+Support, Cloud Web, Desktop, Gateway, and private operations should use the same
+machine-readable status and reason-code taxonomy. The canonical list is in
+`deploy/private-beta/managed-byok-readiness-contract.template.json`; common
+examples are:
+
+- `auth.invite_required`
+- `auth.membership_missing`
+- `auth.token_expired`
+- `auth.token_revoked`
+- `byok.key_missing`
+- `byok.validation_failed`
+- `billing.subscription_inactive`
+- `quota.worker_limit_exceeded`
+- `gateway.identity_not_allowed`
+- `support.diagnostics_redaction_required`
+
+Do not replace these with provider-specific or customer-specific text in public
+artifacts. User-facing messages may be friendlier, but retain the code in logs,
+diagnostics, audit exports, and support records.
+
 ## BYOK Issue Handling
 
 For user/provider key issues:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
       - Backup and Restore: runbooks/backup-restore.md
       - Restore Drill Report: runbooks/restore-drill-report.md
       - Managed BYOK SaaS: runbooks/managed-byok-saas.md
+      - Managed BYOK Boundary: runbooks/managed-byok-saas-boundary.md
       - Branch Protection: branch-protection.md
       - Packaging and Releases: packaging-and-releases.md
       - Release Checklist: release-checklist.md

--- a/scripts/validate-private-beta-package.mjs
+++ b/scripts/validate-private-beta-package.mjs
@@ -47,6 +47,7 @@ const requiredFiles = [
   'docs/runbooks/private-beta-launch.md',
   'docs/runbooks/private-beta-support.md',
   'docs/runbooks/managed-byok-saas.md',
+  'docs/runbooks/managed-byok-saas-boundary.md',
   'docs/runbooks/launch-readiness.md',
   'docs/deployment-readiness.md',
   'docs/security-model.md',
@@ -55,6 +56,7 @@ const requiredFiles = [
   'deploy/private-beta/README.md',
   'deploy/private-beta/hosted-byok.config.example.json',
   'deploy/private-beta/self-host-oss.config.example.json',
+  'deploy/private-beta/managed-byok-readiness-contract.template.json',
   'deploy/private-beta/private-beta-plans.json',
   'deploy/private-beta/private-beta-launch-profile.template.json',
   'deploy/private-beta/design-partner-onboarding.template.md',
@@ -75,6 +77,8 @@ for (const phrase of [
   'Open Cowork does not resell model tokens',
   'Desktop local workspaces stay local',
   'Gateway is a channel client and delivery adapter',
+  'Public/Private Boundary',
+  'managed-byok-readiness-contract.template.json',
   'create or invite org owner',
   'verify membership and role',
   'write-only endpoint',
@@ -103,13 +107,33 @@ for (const phrase of [
   'Channel Identity Misbinding',
   'Customer Offboarding',
   'Never attach raw secrets',
+  'Support Bundle Contract',
+  'Onboarding Status And Reason Codes',
+  'support.diagnostics_redaction_required',
 ]) {
   assertIncludes('docs/runbooks/private-beta-support.md', phrase)
 }
 
 for (const phrase of [
+  'Public/Private Boundary',
+  'Onboarding Status Contract',
+  'Billing And Entitlement Boundary',
+  'BYOK Boundary',
+  'Support Bundle Contract',
+  'Launch Package Rules',
+  'managed-byok-readiness-contract.template.json',
+  'billing.subscription_inactive',
+  'gateway.signature_required',
+  'support.diagnostics_redaction_required',
+  'cloud.billing.provider=none',
+]) {
+  assertIncludes('docs/runbooks/managed-byok-saas-boundary.md', phrase)
+}
+
+for (const phrase of [
   'hosted-byok.config.example.json',
   'self-host-oss.config.example.json',
+  'managed-byok-readiness-contract.template.json',
   'private-beta-plans.json',
   'private-beta-launch-profile.template.json',
   'design-partner-onboarding.template.md',
@@ -125,6 +149,7 @@ for (const phrase of [
 for (const phrase of [
   'Private Beta Launch',
   'Private Beta Support',
+  'Managed BYOK Boundary',
 ]) {
   assertIncludes('mkdocs.yml', phrase)
 }
@@ -258,8 +283,160 @@ for (const command of [
   assertArrayIncludes(profile?.requiredSmokeCommands, command, 'launchProfile.requiredSmokeCommands')
 }
 
+const readinessContract = readJson('deploy/private-beta/managed-byok-readiness-contract.template.json')
+if (readinessContract.contractVersion !== 1) throw new Error('managed BYOK readiness contract must declare contractVersion 1')
+if (readinessContract.purpose !== 'managed-byok-saas-readiness-contract') {
+  throw new Error('managed BYOK readiness contract must declare its purpose')
+}
+if (readinessContract.scope !== 'public-template-only') throw new Error('managed BYOK readiness contract must stay public-template-only')
+for (const entry of [
+  'provider-neutral billing adapter interfaces',
+  'stub billing adapter and local validators',
+  'BYOK status APIs, secret-store interfaces, and worker-role runtime injection code',
+  'self-host documentation and billing-free deployment paths',
+  'support and diagnostics redaction contracts',
+]) {
+  assertArrayIncludes(readinessContract.publicPrivateBoundary?.publicRepoAllowed, entry, 'readiness.publicRepoAllowed')
+}
+for (const entry of [
+  'real cloud project ids, account ids, subscription ids, and regions tied to a managed service',
+  'customer names, emails, org slugs, channel identifiers, support tickets, onboarding records, or launch evidence',
+  'production support rosters, on-call schedules, incident channels, and escalation phone numbers',
+  'raw diagnostics bundles, logs, database exports, object-store listings, or audit exports from managed customers',
+]) {
+  assertArrayIncludes(readinessContract.publicPrivateBoundary?.privateOpsOnly, entry, 'readiness.privateOpsOnly')
+}
+for (const pattern of [
+  'provider API keys',
+  'OAuth refresh or access tokens',
+  'Desktop or Gateway API tokens',
+  'database URLs',
+  'real Stripe price, product, account, customer, or subscription ids',
+]) {
+  assertArrayIncludes(readinessContract.publicPrivateBoundary?.forbiddenPublicPatterns, pattern, 'readiness.forbiddenPublicPatterns')
+}
+for (const status of [
+  'not_started',
+  'invite_sent',
+  'auth_required',
+  'org_ready',
+  'byok_pending_validation',
+  'byok_active',
+  'desktop_ready',
+  'gateway_ready',
+  'billing_blocked',
+  'quota_blocked',
+  'support_review',
+  'ready',
+  'blocked',
+  'offboarded',
+]) {
+  assertArrayIncludes(readinessContract.onboardingContract?.statuses, status, 'readiness.onboarding.statuses')
+}
+for (const code of [
+  'auth.invite_required',
+  'auth.membership_missing',
+  'auth.token_expired',
+  'auth.token_revoked',
+  'byok.key_missing',
+  'byok.validation_failed',
+  'billing.subscription_required',
+  'billing.subscription_inactive',
+  'quota.worker_limit_exceeded',
+  'gateway.identity_not_allowed',
+  'gateway.signature_required',
+  'desktop.managed_org_required',
+  'support.diagnostics_redaction_required',
+]) {
+  assertArrayIncludes(readinessContract.onboardingContract?.reasonCodes, code, 'readiness.onboarding.reasonCodes')
+}
+for (const step of [
+  'create_or_invite_org_owner',
+  'verify_membership_and_role',
+  'configure_byok_write_only',
+  'validate_provider_or_audited_override',
+  'issue_desktop_connection',
+  'issue_gateway_service_token_and_binding',
+  'verify_cloud_web_admin_surface',
+  'run_first_thread_from_web',
+  'continue_same_thread_from_desktop',
+  'continue_or_notify_through_gateway',
+]) {
+  assertArrayIncludes(readinessContract.onboardingContract?.requiredFlow, step, 'readiness.onboarding.requiredFlow')
+}
+for (const provider of ['none', 'stub']) {
+  assertArrayIncludes(readinessContract.billingEntitlementContract?.selfHostAllowedProviders, provider, 'readiness.selfHostAllowedProviders')
+}
+for (const gate of [
+  'subscription state overlays runtime policy',
+  'past_due, canceled, disabled, and inactive states block new paid execution',
+  'expensive managed work is blocked before worker spawn or lease claim where possible',
+  'billing webhook ingress requires provider signature verification and replay protection',
+  'self-host mode must not require Stripe or any commercial billing adapter',
+]) {
+  assertArrayIncludes(readinessContract.billingEntitlementContract?.requiredGates, gate, 'readiness.billing.requiredGates')
+}
+if (readinessContract.byokSecurityContract?.plaintextReadbackAllowed !== false) {
+  throw new Error('readiness BYOK contract must forbid plaintext readback')
+}
+if (readinessContract.byokSecurityContract?.workerRevealOnly !== true) {
+  throw new Error('readiness BYOK contract must require worker-only reveal')
+}
+if (readinessContract.byokSecurityContract?.runtimeInjection !== 'provider-options-only') {
+  throw new Error('readiness BYOK contract must require provider-options-only runtime injection')
+}
+for (const surface of [
+  'HTTP read payloads',
+  'diagnostics bundles',
+  'renderer state',
+  'Desktop cloud cache',
+  'Gateway logs',
+  'SSE events',
+]) {
+  assertArrayIncludes(readinessContract.byokSecurityContract?.requiredRedactionSurfaces, surface, 'readiness.byok.requiredRedactionSurfaces')
+}
+for (const field of [
+  'raw BYOK keys',
+  'OAuth refresh or access tokens',
+  'Desktop, Gateway, API, cookie, internal, or operator tokens',
+  'database URLs',
+  'signed object-store URLs',
+  'customer names, emails, phone numbers, or channel handles in public evidence',
+]) {
+  assertArrayIncludes(readinessContract.supportBundleContract?.forbiddenFields, field, 'readiness.support.forbiddenFields')
+}
+for (const artifact of [
+  'docs/runbooks/managed-byok-saas.md',
+  'docs/runbooks/managed-byok-saas-boundary.md',
+  'docs/runbooks/private-beta-launch.md',
+  'docs/runbooks/private-beta-support.md',
+  'deploy/private-beta/managed-byok-readiness-contract.template.json',
+  'deploy/private-beta/hosted-byok.config.example.json',
+  'deploy/private-beta/self-host-oss.config.example.json',
+  'deploy/private-beta/private-beta-plans.json',
+  'deploy/private-beta/private-beta-launch-profile.template.json',
+  'deploy/private-beta/design-partner-onboarding.template.md',
+  'deploy/private-beta/go-no-go-report.template.md',
+]) {
+  assertArrayIncludes(readinessContract.launchPackageContract?.requiredPublicArtifacts, artifact, 'readiness.launch.requiredPublicArtifacts')
+}
+for (const command of [
+  'pnpm deploy:private-beta:validate',
+  'pnpm deploy:validate',
+  'pnpm deploy:launch:validate',
+  'pnpm ops:validate',
+  'pnpm test',
+  'pnpm typecheck',
+  'pnpm lint',
+  'pnpm docs:build',
+  'git diff --check',
+]) {
+  assertArrayIncludes(readinessContract.launchPackageContract?.requiredValidationCommands, command, 'readiness.launch.requiredValidationCommands')
+}
+
 for (const phrase of [
   'Required Ten-Step Flow',
+  'Onboarding State',
   'Create or invite org owner',
   'Verify org membership and role',
   'Configure BYOK provider key through write-only endpoint',
@@ -273,6 +450,9 @@ for (const phrase of [
   'Token Lifecycle Proof',
   'Secret Redaction Proof',
   'Blocking Behavior Proof',
+  'Support Bundle Proof',
+  'billing_blocked',
+  'support_review',
 ]) {
   assertIncludes('deploy/private-beta/design-partner-onboarding.template.md', phrase)
 }
@@ -284,10 +464,13 @@ for (const phrase of [
   'Load And Soak Summary',
   'Failover And Restore Summary',
   'Security Boundary Checklist',
+  'Public/Private Boundary Evidence',
   'Known Risks And Mitigations',
   'Decision',
   'BYOK plaintext absent',
   'Gateway is a channel client and delivery adapter',
+  'managed-byok-readiness-contract.template.json',
+  'Onboarding failures preserve machine-readable status and reason codes',
 ]) {
   assertIncludes('deploy/private-beta/go-no-go-report.template.md', phrase)
 }
@@ -298,6 +481,7 @@ for (const path of [
   'deploy/private-beta/README.md',
   'deploy/private-beta/hosted-byok.config.example.json',
   'deploy/private-beta/self-host-oss.config.example.json',
+  'deploy/private-beta/managed-byok-readiness-contract.template.json',
   'deploy/private-beta/private-beta-plans.json',
   'deploy/private-beta/private-beta-launch-profile.template.json',
   'deploy/private-beta/design-partner-onboarding.template.md',
@@ -311,6 +495,14 @@ for (const path of [
     'ghp_',
     'xoxb-',
     'AIza',
+    'price_',
+    'prod_',
+    'acct_',
+    'cus_',
+    'sub_',
+    'OPEN_COWORK_CLOUD_DATABASE_URL=postgres://',
+    'OPEN_COWORK_CLOUD_COOKIE_SECRET=',
+    'OPEN_COWORK_GATEWAY_SERVICE_TOKEN=',
   ]) {
     assertNotIncludes(path, forbidden)
   }

--- a/tests/private-beta-package.test.ts
+++ b/tests/private-beta-package.test.ts
@@ -19,6 +19,7 @@ test('private beta launch package documents managed and self-host promises', () 
     'Hosted BYOK Setup Flow',
     'OSS Self-Host Equivalent',
     'Managed Vs Self-Host Responsibilities',
+    'Public/Private Boundary',
     'Security Posture',
     'Known Private Beta Constraints',
     'Open Cowork does not resell model tokens',
@@ -50,9 +51,76 @@ test('private beta launch package documents managed and self-host promises', () 
     'Channel Identity Misbinding',
     'Customer Offboarding',
     'Never attach raw secrets',
+    'Support Bundle Contract',
+    'Onboarding Status And Reason Codes',
+    'support.diagnostics_redaction_required',
   ]) {
     assert.match(support, new RegExp(phrase))
   }
+
+  const boundary = readRepoFile('docs/runbooks/managed-byok-saas-boundary.md')
+  for (const phrase of [
+    'Public/Private Boundary',
+    'Onboarding Status Contract',
+    'Billing And Entitlement Boundary',
+    'BYOK Boundary',
+    'Support Bundle Contract',
+    'Launch Package Rules',
+    'billing.subscription_inactive',
+    'gateway.signature_required',
+    'support.diagnostics_redaction_required',
+    'cloud.billing.provider=none',
+  ]) {
+    assert.match(boundary, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  }
+})
+
+test('managed BYOK readiness contract encodes public-private and support boundaries', () => {
+  const contract = readJson('deploy/private-beta/managed-byok-readiness-contract.template.json')
+  assert.equal(contract.contractVersion, 1)
+  assert.equal(contract.purpose, 'managed-byok-saas-readiness-contract')
+  assert.equal(contract.scope, 'public-template-only')
+  assert.ok(contract.publicPrivateBoundary.publicRepoAllowed.includes('self-host documentation and billing-free deployment paths'))
+  assert.ok(contract.publicPrivateBoundary.privateOpsOnly.includes('customer names, emails, org slugs, channel identifiers, support tickets, onboarding records, or launch evidence'))
+  assert.ok(contract.publicPrivateBoundary.privateOpsOnly.includes('production support rosters, on-call schedules, incident channels, and escalation phone numbers'))
+  assert.ok(contract.publicPrivateBoundary.forbiddenPublicPatterns.includes('real Stripe price, product, account, customer, or subscription ids'))
+  for (const status of [
+    'not_started',
+    'invite_sent',
+    'auth_required',
+    'org_ready',
+    'byok_pending_validation',
+    'byok_active',
+    'desktop_ready',
+    'gateway_ready',
+    'billing_blocked',
+    'quota_blocked',
+    'support_review',
+    'ready',
+    'blocked',
+    'offboarded',
+  ]) {
+    assert.ok(contract.onboardingContract.statuses.includes(status), status)
+  }
+  for (const reasonCode of [
+    'auth.invite_required',
+    'auth.token_revoked',
+    'byok.validation_failed',
+    'billing.subscription_inactive',
+    'quota.worker_limit_exceeded',
+    'gateway.signature_required',
+    'support.diagnostics_redaction_required',
+  ]) {
+    assert.ok(contract.onboardingContract.reasonCodes.includes(reasonCode), reasonCode)
+  }
+  assert.deepEqual(contract.billingEntitlementContract.selfHostAllowedProviders, ['none', 'stub'])
+  assert.equal(contract.byokSecurityContract.plaintextReadbackAllowed, false)
+  assert.equal(contract.byokSecurityContract.workerRevealOnly, true)
+  assert.equal(contract.byokSecurityContract.runtimeInjection, 'provider-options-only')
+  assert.ok(contract.supportBundleContract.forbiddenFields.includes('raw BYOK keys'))
+  assert.ok(contract.supportBundleContract.forbiddenFields.includes('Desktop, Gateway, API, cookie, internal, or operator tokens'))
+  assert.ok(contract.launchPackageContract.requiredPublicArtifacts.includes('docs/runbooks/managed-byok-saas-boundary.md'))
+  assert.ok(contract.launchPackageContract.requiredValidationCommands.includes('pnpm deploy:private-beta:validate'))
 })
 
 test('private beta launch profile template captures launch decisions and evidence gates', () => {
@@ -110,6 +178,7 @@ test('private beta onboarding and go/no-go templates force complete evidence rec
   const onboarding = readRepoFile('deploy/private-beta/design-partner-onboarding.template.md')
   for (const phrase of [
     'Required Ten-Step Flow',
+    'Onboarding State',
     'Create or invite org owner',
     'Verify org membership and role',
     'Configure BYOK provider key through write-only endpoint',
@@ -123,6 +192,8 @@ test('private beta onboarding and go/no-go templates force complete evidence rec
     'Token Lifecycle Proof',
     'Secret Redaction Proof',
     'Blocking Behavior Proof',
+    'Support Bundle Proof',
+    'billing_blocked',
   ]) {
     assert.match(onboarding, new RegExp(phrase))
   }
@@ -135,10 +206,13 @@ test('private beta onboarding and go/no-go templates force complete evidence rec
     'Load And Soak Summary',
     'Failover And Restore Summary',
     'Security Boundary Checklist',
+    'Public/Private Boundary Evidence',
     'Known Risks And Mitigations',
     'Decision',
     'BYOK plaintext absent',
     'Gateway is a channel client and delivery adapter',
+    'managed-byok-readiness-contract.template.json',
+    'Onboarding failures preserve machine-readable status and reason codes',
   ]) {
     assert.match(report, new RegExp(phrase))
   }


### PR DESCRIPTION
Closes #553

## Summary
- add a versioned managed BYOK SaaS readiness contract covering public/private boundaries, onboarding statuses, reason codes, billing/BYOK invariants, support bundles, and required launch gates
- add the Managed BYOK Boundary runbook and wire it into the docs nav and private beta launch/support docs
- extend private-beta onboarding and go/no-go templates plus validator/test coverage for the new contract

## Validation
- pnpm deploy:private-beta:validate
- node --no-warnings --experimental-strip-types --test tests/private-beta-package.test.ts
- pnpm deploy:validate
- pnpm deploy:launch:validate
- pnpm ops:validate
- pnpm docs:build
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check

Note: the first sandboxed pnpm test run hit EPERM on 127.0.0.1 listener tests; rerun with loopback permissions passed.