### PR TITLE
Add launch evidence tier matrix

### DIFF
--- a/deploy/load/launch-evidence-matrix.json
+++ b/deploy/load/launch-evidence-matrix.json
@@ -1,0 +1,231 @@
+{
+  "schemaVersion": 1,
+  "purpose": "launch-evidence-tier-matrix",
+  "acceptedPublicTier": "local-self-host-beta",
+  "publicProductClaim": "Open Cowork is launch-ready for local/self-host beta evaluation through public Compose, Helm, Cloud Web, Desktop sync, Gateway, BYOK-stub/manual, validators, and CI gates. This does not claim managed public SaaS, GA, or enterprise-scale readiness.",
+  "privateEvidenceBoundary": "The public repo stores evidence contracts, public-safe templates, validators, and redacted summaries only. Real customer evidence, managed SaaS domains, cloud project ids, prices, support rosters, raw logs, screenshots, metrics exports, cost data, and incident evidence stay in private operations repositories.",
+  "tiers": {
+    "local-self-host-beta": {
+      "claimStatus": "accepted-public",
+      "description": "Public OSS/deployer beta for local and self-host reference deployments.",
+      "acceptedClaims": [
+        "self-host deployers can use public Compose and Helm templates without private SaaS patches",
+        "launch-readiness, deployment, private-beta, and operations validators are repeatable",
+        "Cloud Web, Desktop cloud sync, and Gateway continuation are covered by public tests and smoke scripts",
+        "public templates are placeholder-only and private-value scanned"
+      ],
+      "notClaimed": [
+        "managed public SaaS production readiness",
+        "general availability",
+        "enterprise-scale capacity",
+        "environment-specific SLO or cost guarantees"
+      ]
+    },
+    "private-beta": {
+      "claimStatus": "requires-private-ops-evidence",
+      "description": "Design-partner hosted BYOK rollout. Claim only after private environment load, soak, restore, failover, and support evidence is attached outside this public repo.",
+      "blockedBy": [
+        "production-like load and soak evidence",
+        "restore drill evidence",
+        "BYOK provider validation evidence",
+        "support/on-call ownership evidence"
+      ]
+    },
+    "public-beta": {
+      "claimStatus": "not-claimed",
+      "description": "Public hosted BYOK rollout after private-beta evidence, billing, quotas, abuse controls, and support process are proven.",
+      "blockedBy": [
+        "private-beta go/no-go approval",
+        "self-serve billing and entitlement evidence",
+        "public abuse-rate controls",
+        "public support and status-page readiness"
+      ]
+    },
+    "general-availability": {
+      "claimStatus": "not-claimed",
+      "description": "Stable hosted product claim after public beta burn-in, release packaging, security, restore, and support evidence are proven.",
+      "blockedBy": [
+        "public-beta burn-in evidence",
+        "signed release/update evidence",
+        "incident response exercises",
+        "documented support commitments"
+      ]
+    },
+    "enterprise-scale": {
+      "claimStatus": "not-claimed",
+      "description": "Large-organization readiness after lower tiers pass and enterprise capacity/SLO evidence exists.",
+      "blockedBy": [
+        "enterprise-scale load and soak evidence",
+        "multi-org isolation evidence under scale",
+        "large restore drill evidence",
+        "enterprise admin/audit/export evidence"
+      ]
+    }
+  },
+  "evidenceCategories": {
+    "loadAndSoak": {
+      "requiredForAcceptedTier": true,
+      "issue554BuildSection": "1. Load And Soak Evidence",
+      "publicArtifacts": [
+        "deploy/load/launch-readiness-targets.json",
+        "scripts/launch-readiness.mjs",
+        "docs/runbooks/launch-readiness.md",
+        "docs/runbooks/launch-readiness-report.md",
+        "tests/launch-readiness.test.ts"
+      ],
+      "requiredCommands": [
+        "pnpm deploy:load:plan",
+        "pnpm deploy:load",
+        "pnpm deploy:soak"
+      ],
+      "coveredSurfaces": [
+        "cloud session create/list/prompt/event replay",
+        "SSE fanout and reconnect",
+        "worker claim/retry/reaper paths",
+        "workflow due-run claims",
+        "Gateway delivery feed and render backpressure",
+        "artifact metadata/list/download paths",
+        "admin summary pagination",
+        "quota and entitlement denial paths",
+        "BYOK reveal failure and denial paths"
+      ],
+      "passCondition": "Plan generation is public-CI validated; environment-specific load and soak must be run in strict mode before claiming any hosted tier."
+    },
+    "failoverRecovery": {
+      "requiredForAcceptedTier": true,
+      "issue554BuildSection": "2. Failover And Recovery Evidence",
+      "publicArtifacts": [
+        "scripts/cloud-continuation-smoke.mjs",
+        "scripts/gateway-cloud-smoke.mjs",
+        "docs/runbooks/cloud-managed-operations.md",
+        "docs/runbooks/launch-readiness-report.md",
+        "deploy/managed-workers/worker-release-evidence.template.md"
+      ],
+      "requiredCommands": [
+        "pnpm deploy:continuation:smoke",
+        "pnpm deploy:gateway:smoke",
+        "pnpm ops:validate"
+      ],
+      "coveredSurfaces": [
+        "worker crash during pending command",
+        "lease expiry and stale-owner write rejection",
+        "scheduler restart with due workflow runs",
+        "Gateway restart with delivery cursor resume",
+        "Cloud Web/API restart with SSE reconnect",
+        "object-store transient failure",
+        "BYOK reveal failure"
+      ],
+      "passCondition": "Public tests and templates cover recovery contracts; managed tiers require private drill evidence from the target environment."
+    },
+    "backupRestore": {
+      "requiredForAcceptedTier": true,
+      "issue554BuildSection": "3. Backup And Restore Evidence",
+      "publicArtifacts": [
+        "docs/runbooks/backup-restore.md",
+        "docs/runbooks/restore-drill-report.md",
+        "deploy/managed-workers/worker-restore-drill.template.md",
+        "deploy/gcp/smoke/evidence.template.json"
+      ],
+      "requiredCommands": [
+        "pnpm ops:validate",
+        "pnpm deploy:gcp:preflight",
+        "pnpm deploy:gcp:smoke"
+      ],
+      "coveredSurfaces": [
+        "Postgres control-plane records",
+        "session events and projections",
+        "worker claims and terminal state",
+        "workflows and runs",
+        "Gateway channel bindings and deliveries",
+        "artifact metadata and object-store blobs",
+        "uploaded snapshots and checkpoints",
+        "BYOK secret references and reveal denial behavior",
+        "audit events"
+      ],
+      "passCondition": "Restore evidence templates and validators are public-safe; each real hosted environment must attach private restore-drill output."
+    },
+    "securityBoundary": {
+      "requiredForAcceptedTier": true,
+      "issue554BuildSection": "4. Security Boundary Evidence",
+      "publicArtifacts": [
+        "docs/security-model.md",
+        "docs/privacy.md",
+        "docs/runbooks/managed-byok-saas-boundary.md",
+        "deploy/private-beta/managed-byok-readiness-contract.template.json",
+        "tests/byok-boundary-regression.test.ts",
+        "tests/cloud-http-server.test.ts",
+        "tests/cloud-module-boundaries.test.ts"
+      ],
+      "requiredCommands": [
+        "pnpm test",
+        "pnpm deploy:private-beta:validate",
+        "pnpm deploy:validate"
+      ],
+      "coveredSurfaces": [
+        "no raw secrets in payloads/cache/logs/renderer/gateway/diagnostics/metrics",
+        "operator endpoints separate from tenant user APIs",
+        "API token TTL/scope/revocation behavior",
+        "public webhook ingress fails closed",
+        "trusted-header auth cannot imply admin without explicit trusted proof",
+        "CSP and browser client boundaries",
+        "OpenCode SDK and server-only package import boundaries",
+        "public templates contain no private values"
+      ],
+      "passCondition": "Security boundaries must be enforced by tests, validators, and docs before any higher launch tier is claimed."
+    },
+    "releasePackaging": {
+      "requiredForAcceptedTier": true,
+      "issue554BuildSection": "5. Release And Packaging Gates",
+      "publicArtifacts": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+        "docs/release-checklist.md",
+        "scripts/validate-deployment-configs.mjs",
+        "scripts/validate-private-beta-package.mjs",
+        "scripts/validate-launch-readiness.mjs"
+      ],
+      "requiredCommands": [
+        "pnpm lint",
+        "pnpm typecheck",
+        "pnpm test",
+        "pnpm docs:build",
+        "pnpm deploy:validate",
+        "pnpm deploy:launch:validate",
+        "pnpm deploy:private-beta:validate",
+        "pnpm ops:validate",
+        "git diff --check"
+      ],
+      "coveredSurfaces": [
+        "Desktop packaging smoke",
+        "Cloud Web build and browser smoke",
+        "Gateway image/package smoke",
+        "MCP package smoke",
+        "docs build",
+        "deployment validators",
+        "SBOM/notices/license checks",
+        "private-value scanning",
+        "script-contract tests",
+        "GCP/reference deployment smoke evidence"
+      ],
+      "passCondition": "CI and release checklists fail closed when a required surface-specific gate disappears."
+    },
+    "findingsWorkflow": {
+      "requiredForAcceptedTier": true,
+      "issue554BuildSection": "6. Findings Workflow",
+      "publicArtifacts": [
+        "docs/runbooks/launch-readiness.md",
+        "docs/runbooks/launch-readiness-report.md",
+        "docs/release-checklist.md"
+      ],
+      "requiredCommands": [
+        "pnpm deploy:launch:validate"
+      ],
+      "allowedDispositions": [
+        "immediate-fix",
+        "narrow-follow-up-issue",
+        "tier-scoped-out-of-scope"
+      ],
+      "passCondition": "Every failed launch gate is either fixed immediately, turned into a narrow issue with evidence/reproduction, or recorded as out-of-scope for the selected launch tier."
+    }
+  }
+}

--- a/deploy/load/launch-readiness-targets.json
+++ b/deploy/load/launch-readiness-targets.json
@@ -1,6 +1,41 @@
 {
   "schemaVersion": 1,
   "profiles": {
+    "local-self-host-beta": {
+      "description": "OSS self-host and local reference deployment target. This proves the public templates, validators, local harnesses, and reference Compose/Helm paths are coherent; it is not a managed hosted SaaS claim.",
+      "durationMs": 120000,
+      "soakDurationMs": 1800000,
+      "concurrency": 4,
+      "requestRatePerSecond": 2,
+      "capacityTargets": {
+        "concurrentCloudUsers": 5,
+        "concurrentDesktopClients": 2,
+        "concurrentGatewayChannels": 1,
+        "concurrentSseStreams": 10,
+        "storedCloudThreads": 250,
+        "sessionCreatesPerMinute": 6,
+        "promptCommandsPerMinute": 12,
+        "activeWorkerSessions": 2,
+        "workflowRunsPerMinute": 2,
+        "gatewayInboundMessagesPerMinute": 12,
+        "gatewayOutboundDeliveriesPerMinute": 12,
+        "artifactUploadsPerMinute": 4,
+        "adminDashboardReadsPerMinute": 12
+      },
+      "thresholds": {
+        "maxOverallErrorRate": 0.02,
+        "maxOperationErrorRate": 0.05,
+        "p95ReadLatencyMs": 1200,
+        "p95MutationLatencyMs": 2500,
+        "p95GatewayLatencyMs": 1500,
+        "maxProjectionLagEvents": 50,
+        "maxCommandOldestAgeMs": 60000,
+        "maxUnexpectedQuotaRejections": 0,
+        "maxGatewayDeadLetters": 0,
+        "maxGatewayRetryRatePerMinute": 20,
+        "maxSseReconnectsPerMinute": 10
+      }
+    },
     "private-beta": {
       "description": "Initial managed BYOK private beta target for design partners and small internal teams.",
       "durationMs": 300000,

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -277,14 +277,23 @@ The validator checks:
 
 ## Load, Soak, And Launch Gates
 
-Before private-beta or public-beta rollout, define the exact launch profile and
-run the load/soak harness in strict mode. The committed target profiles are in
-`deploy/load/launch-readiness-targets.json`:
+Before local/self-host beta, private-beta, or public-beta rollout, define the
+exact launch profile and run the load/soak harness in strict mode. The
+committed target profiles are in `deploy/load/launch-readiness-targets.json`,
+and the current accepted public launch tier is recorded in
+`deploy/load/launch-evidence-matrix.json`:
 
+- `local-self-host-beta` for OSS self-host and local reference deployments. This
+  is the only launch tier the public repo currently claims.
 - `private-beta` for design-partner and internal managed BYOK rollout.
 - `public-beta` for the first broader hosted BYOK rollout.
 - `enterprise-scale` for large downstream or managed org readiness after
   public-beta evidence is green.
+
+Do not use public templates alone to claim private hosted beta, public hosted
+beta, general availability, or enterprise-scale readiness. Those tiers need
+environment-specific private operations evidence for load, soak, failover,
+restore, security, support, and cost/SLO behavior.
 
 Generate the planned route matrix:
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -82,7 +82,11 @@ Reference workflows in the repository root:
 ### Managed cloud launch readiness
 
 - [ ] `pnpm deploy:load:plan` has been reviewed for the selected
-      `private-beta` or `public-beta` target profile.
+      `local-self-host-beta`, `private-beta`, or `public-beta` target profile.
+- [ ] `deploy/load/launch-evidence-matrix.json` states the exact accepted
+      launch tier through `acceptedPublicTier`; the public repo currently
+      claims only `local-self-host-beta` unless private operations evidence
+      explicitly upgrades the tier.
 - [ ] managed worker release evidence has been completed from
       `deploy/managed-workers/worker-release-evidence.template.md` in the
       private operations repo.
@@ -107,7 +111,8 @@ Reference workflows in the repository root:
 - [ ] load and soak JSON/Markdown reports are attached to the release or
       downstream operations evidence.
 - [ ] `docs/runbooks/launch-readiness-report.md` has a completed Go/No-Go
-      decision, Known limits, Cost and scaling notes, and Final smoke status.
+      decision, Accepted Launch Tier, Known limits, Cost and scaling notes,
+      Final smoke status, and Findings Workflow.
 - [ ] final Cloud Web/Desktop/Gateway smoke gates passed after the soak run.
 
 ## Tagged release

--- a/docs/runbooks/launch-readiness-report.md
+++ b/docs/runbooks/launch-readiness-report.md
@@ -5,11 +5,11 @@ description: Go/no-go report template for Open Cowork Cloud, Desktop sync, and G
 
 # Launch Readiness Report
 
-Use this report as the release evidence record for each private-beta,
-public-beta, or managed rollout candidate. Generated harness output should be
-attached from `.open-cowork-test/launch-readiness/` or copied into a downstream
-private operations repository with secrets and project-specific identifiers
-redacted.
+Use this report as the release evidence record for each local/self-host beta,
+private-beta, public-beta, or managed rollout candidate. Generated harness
+output should be attached from `.open-cowork-test/launch-readiness/` or copied
+into a downstream private operations repository with secrets and project-specific
+identifiers redacted.
 
 ## Release Candidate
 
@@ -18,13 +18,19 @@ redacted.
 - Gateway URL:
 - Image tags:
 - Helm/Compose/Terraform revision:
-- Target profile: `private-beta`, `public-beta`, or `enterprise-scale`
+- Target profile: `local-self-host-beta`, `private-beta`, `public-beta`, or
+  `enterprise-scale`
+- Accepted Launch Tier:
+  `{local-self-host-beta|private-beta|public-beta|general-availability|enterprise-scale}`
+- Evidence matrix: `deploy/load/launch-evidence-matrix.json`
 - Report owner:
 - Date:
 
 ## Go/No-Go
 
 - Decision: `go`, `conditional-go`, or `no-go`
+- Public claim allowed by this report:
+- Claims explicitly not made:
 - Decision owner:
 - Reviewers:
 - Conditions or blockers:
@@ -99,6 +105,18 @@ Record:
 - [ ] `pnpm deploy:continuation:smoke`
 - [ ] provider-specific smoke such as `pnpm deploy:gcp:smoke` where applicable
 
+## Failover And Recovery Evidence
+
+- worker crash during pending command:
+- worker crash after runtime event before projection write:
+- lease expiry and stale-owner write rejection:
+- scheduler restart with due workflow runs:
+- Gateway restart with delivery cursor resume:
+- Cloud Web/API restart with SSE reconnect:
+- object-store transient failure:
+- BYOK reveal failure:
+- database restore/readiness validation:
+
 ## Quota And Abuse Evidence
 
 - prompt/hour quota pressure result:
@@ -121,6 +139,17 @@ Record:
 - scheduler recovery smoke:
 - gateway delivery cursor recovery smoke:
 - redaction sample reviewed:
+
+## Security Boundary Evidence
+
+- no raw secrets in payloads/cache/logs/renderer/gateway/diagnostics/metrics:
+- operator endpoints separate from tenant user APIs:
+- API-token TTL/scope/revocation:
+- public webhook ingress fails closed:
+- trusted-header auth cannot imply admin without signed trusted proof:
+- CSP/browser client boundary:
+- OpenCode SDK/server-only import boundary:
+- public template private-value scan:
 
 ## Public Repo Evidence Boundary
 
@@ -150,6 +179,14 @@ back into public docs.
 - artifact size/rate limit before next retest:
 - unavailable provider/channel features:
 - operational caveats:
+
+## Findings Workflow
+
+For every failed, skipped, conditional, or stale item above, choose one:
+
+| Finding | Evidence | Disposition | Follow-up issue | Tier impact |
+| --- | --- | --- | --- | --- |
+| | | `immediate-fix` / `narrow-follow-up-issue` / `tier-scoped-out-of-scope` | | |
 
 ## Rollback And Support
 

--- a/docs/runbooks/launch-readiness.md
+++ b/docs/runbooks/launch-readiness.md
@@ -6,16 +6,20 @@ description: Load, soak, go/no-go, and release evidence gates for Open Cowork Cl
 # Launch Readiness Gates
 
 Use these gates before treating a deployed Open Cowork Cloud plus Gateway stack
-as ready for private beta, public beta, or managed BYOK SaaS rollout. The same
-workflow applies to GCP, AWS, Azure, DigitalOcean, Kubernetes, or a downstream
-internal platform: supply the deployed URLs and tokens at runtime; do not encode
-provider project values in the repository.
+as ready for local/self-host beta, private beta, public beta, general
+availability, or enterprise-scale rollout. The same workflow applies to GCP,
+AWS, Azure, DigitalOcean, Kubernetes, or a downstream internal platform: supply
+the deployed URLs and tokens at runtime; do not encode provider project values
+in the repository.
 
 ## Target Profiles
 
 Capacity targets live in
 `deploy/load/launch-readiness-targets.json`.
 
+- `local-self-host-beta`: OSS self-host and local reference deployment target.
+  This is the only launch tier currently accepted by the public evidence
+  matrix.
 - `private-beta`: design-partner and internal managed BYOK rollout.
 - `public-beta`: first public hosted BYOK rollout.
 - `enterprise-scale`: large organization readiness target for downstream or
@@ -36,6 +40,24 @@ Private and public beta are launch gates. `enterprise-scale` is the production
 growth gate: run it only after the lower profiles are green and the deployment
 has enough database, object-store, worker, and gateway capacity to absorb the
 larger thread, SSE, and command queues.
+
+## Current Accepted Tier
+
+The current public launch-evidence matrix lives at
+`deploy/load/launch-evidence-matrix.json`. It accepts only
+`local-self-host-beta` as a public product claim:
+
+- public Compose, Helm, GCP reference templates, validators, and CI gates are
+  coherent enough for OSS/deployer beta evaluation,
+- Cloud Web, Desktop cloud sync, and Gateway continuation have public smoke and
+  test coverage,
+- private hosted beta, public hosted beta, general availability, and
+  enterprise-scale readiness are not claimed from public templates alone.
+
+Higher hosted tiers require private operations evidence from the exact target
+environment: load/soak reports, restore drills, failover drills, BYOK provider
+validation, billing/entitlement evidence, support ownership, and cost/SLO
+notes. Store that evidence outside this public repository.
 
 ## Required Environment
 
@@ -173,6 +195,39 @@ If a required token, mutation mode, SSE mode, operator mode, or gateway route is
 skipped, the result is at best **conditional-go** and must not be treated as a
 managed public launch approval.
 
+## Evidence Categories
+
+The launch evidence matrix requires every accepted tier to cover:
+
+- load and soak behavior for Cloud sessions, SSE, workers, workflows, Gateway,
+  artifacts, admin pagination, quotas/entitlements, and BYOK denials,
+- failover and recovery for workers, scheduler, Gateway cursors, Cloud Web/API
+  restarts, object-store failures, and BYOK reveal failures,
+- backup and restore for Postgres records, events, projections, workflows,
+  Gateway bindings/deliveries, artifacts, snapshots/checkpoints, BYOK refs, and
+  audit events,
+- security boundaries for secret redaction, operator endpoint separation,
+  API-token TTL/scope/revocation, public webhook ingress, trusted-header auth,
+  CSP/browser boundaries, package import boundaries, and private-value scans,
+- release and packaging gates for Desktop, Cloud Web, Gateway, MCPs, docs,
+  deployment validators, SBOM/notices/license checks, private-value scanning,
+  script-contract tests, and reference deployment smoke evidence.
+
+## Findings Workflow
+
+Every failed launch-readiness check must have one disposition:
+
+- `immediate-fix`: fix it in the current scope when the failure is narrow and
+  safe,
+- `narrow-follow-up-issue`: open a focused issue with owner, reproduction,
+  evidence, launch tier, and blocking status,
+- `tier-scoped-out-of-scope`: explicitly record that the selected launch tier
+  does not claim the capability.
+
+Do not reopen broad completed roadmap phases for narrow findings. Do not claim a
+higher launch tier while a required category for that tier has missing,
+conditional, or private-only evidence.
+
 ## Validation
 
 Validate committed launch-readiness artifacts:
@@ -182,4 +237,5 @@ pnpm deploy:launch:validate
 ```
 
 This checks target profiles, harness coverage, required runbook wording, the
-report template, package scripts, and release-checklist links.
+launch evidence matrix, report template, package scripts, and release-checklist
+links.

--- a/scripts/validate-launch-readiness.mjs
+++ b/scripts/validate-launch-readiness.mjs
@@ -35,6 +35,7 @@ function log(message) {
 }
 
 const targetsPath = 'deploy/load/launch-readiness-targets.json'
+const evidenceMatrixPath = 'deploy/load/launch-evidence-matrix.json'
 const harnessPath = 'scripts/launch-readiness.mjs'
 const readinessDocPath = 'docs/deployment-readiness.md'
 const runbookPath = 'docs/runbooks/launch-readiness.md'
@@ -44,6 +45,7 @@ const packagePath = 'package.json'
 
 for (const path of [
   targetsPath,
+  evidenceMatrixPath,
   harnessPath,
   readinessDocPath,
   runbookPath,
@@ -55,7 +57,7 @@ for (const path of [
 }
 
 const targets = readJson(targetsPath)
-for (const profileName of ['private-beta', 'public-beta', 'enterprise-scale']) {
+for (const profileName of ['local-self-host-beta', 'private-beta', 'public-beta', 'enterprise-scale']) {
   const profile = targets.profiles?.[profileName]
   if (!profile) throw new Error(`${targetsPath} is missing ${profileName}`)
   assertPositiveNumber(profile.durationMs, `${profileName}.durationMs`)
@@ -101,6 +103,128 @@ for (const profileName of ['private-beta', 'public-beta', 'enterprise-scale']) {
   )
 }
 
+const evidenceMatrix = readJson(evidenceMatrixPath)
+if (evidenceMatrix.schemaVersion !== 1) throw new Error(`${evidenceMatrixPath} must declare schemaVersion 1`)
+if (evidenceMatrix.purpose !== 'launch-evidence-tier-matrix') {
+  throw new Error(`${evidenceMatrixPath} must declare purpose launch-evidence-tier-matrix`)
+}
+if (evidenceMatrix.acceptedPublicTier !== 'local-self-host-beta') {
+  throw new Error(`${evidenceMatrixPath} must accept only local-self-host-beta as the current public tier`)
+}
+assertIncludes(evidenceMatrixPath, 'does not claim managed public SaaS, GA, or enterprise-scale readiness')
+assertIncludes(evidenceMatrixPath, 'private operations repositories')
+
+for (const tier of [
+  'local-self-host-beta',
+  'private-beta',
+  'public-beta',
+  'general-availability',
+  'enterprise-scale',
+]) {
+  const record = evidenceMatrix.tiers?.[tier]
+  if (!record) throw new Error(`${evidenceMatrixPath} is missing tier ${tier}`)
+  if (tier === 'local-self-host-beta') {
+    if (record.claimStatus !== 'accepted-public') throw new Error(`${tier} must be the only accepted public tier`)
+  } else if (!['requires-private-ops-evidence', 'not-claimed'].includes(record.claimStatus)) {
+    throw new Error(`${tier} must not be accepted in public launch evidence`)
+  }
+}
+
+for (const category of [
+  'loadAndSoak',
+  'failoverRecovery',
+  'backupRestore',
+  'securityBoundary',
+  'releasePackaging',
+  'findingsWorkflow',
+]) {
+  const record = evidenceMatrix.evidenceCategories?.[category]
+  if (!record) throw new Error(`${evidenceMatrixPath} is missing evidence category ${category}`)
+  if (record.requiredForAcceptedTier !== true) throw new Error(`${category} must be required for the accepted tier`)
+  if (!Array.isArray(record.publicArtifacts) || record.publicArtifacts.length === 0) {
+    throw new Error(`${category} must list public evidence artifacts`)
+  }
+  if (!Array.isArray(record.requiredCommands) || record.requiredCommands.length === 0) {
+    throw new Error(`${category} must list required commands`)
+  }
+  if (typeof record.passCondition !== 'string' || record.passCondition.length < 20) {
+    throw new Error(`${category} must describe a concrete pass condition`)
+  }
+}
+
+for (const command of [
+  'pnpm deploy:load:plan',
+  'pnpm deploy:load',
+  'pnpm deploy:soak',
+  'pnpm deploy:continuation:smoke',
+  'pnpm deploy:gateway:smoke',
+  'pnpm deploy:gcp:preflight',
+  'pnpm deploy:gcp:smoke',
+  'pnpm test',
+  'pnpm docs:build',
+  'pnpm deploy:private-beta:validate',
+  'pnpm deploy:launch:validate',
+  'pnpm ops:validate',
+  'git diff --check',
+]) {
+  assertIncludes(evidenceMatrixPath, command)
+}
+
+for (const phrase of [
+  'cloud session create/list/prompt/event replay',
+  'SSE fanout and reconnect',
+  'worker claim/retry/reaper paths',
+  'workflow due-run claims',
+  'Gateway delivery feed and render backpressure',
+  'artifact metadata/list/download paths',
+  'admin summary pagination',
+  'quota and entitlement denial paths',
+  'BYOK reveal failure and denial paths',
+  'worker crash during pending command',
+  'lease expiry and stale-owner write rejection',
+  'scheduler restart with due workflow runs',
+  'Gateway restart with delivery cursor resume',
+  'Cloud Web/API restart with SSE reconnect',
+  'object-store transient failure',
+  'Postgres control-plane records',
+  'Gateway channel bindings and deliveries',
+  'BYOK secret references and reveal denial behavior',
+  'no raw secrets in payloads/cache/logs/renderer/gateway/diagnostics/metrics',
+  'operator endpoints separate from tenant user APIs',
+  'public webhook ingress fails closed',
+  'public templates contain no private values',
+  'Desktop packaging smoke',
+  'Cloud Web build and browser smoke',
+  'Gateway image/package smoke',
+  'MCP package smoke',
+  'script-contract tests',
+  'narrow-follow-up-issue',
+  'tier-scoped-out-of-scope',
+]) {
+  assertIncludes(evidenceMatrixPath, phrase)
+}
+
+for (const forbidden of [
+  '/Users/joe',
+  'OPEN_COWORK_GCP_PROJECT=',
+  'joe-broadhead/open-cowork-cloud',
+  'sk-',
+  'ghp_',
+  'xoxb-',
+  'AIza',
+  'price_',
+  'prod_',
+  'acct_',
+  'cus_',
+  'sub_',
+  'OPEN_COWORK_CLOUD_DATABASE_URL=postgres://',
+  'OPEN_COWORK_GATEWAY_SERVICE_TOKEN=',
+]) {
+  if (read(evidenceMatrixPath).includes(forbidden)) {
+    throw new Error(`${evidenceMatrixPath} must not include private value marker ${forbidden}`)
+  }
+}
+
 for (const route of [
   '/healthz',
   '/api/config',
@@ -130,6 +254,7 @@ for (const phrase of [
   'OPEN_COWORK_LOAD_BYOK_PROVIDER',
   'OPEN_COWORK_LOAD_EXPECT_QUOTA_REJECTIONS',
   'OPEN_COWORK_LOAD_STRICT',
+  'local-self-host-beta',
   'private-beta',
   'public-beta',
 ]) {
@@ -141,14 +266,19 @@ for (const phrase of [
   'Load Test Report',
   'Soak Test Report',
   'Go/No-Go',
+  'Accepted Launch Tier',
   'Known Limits',
   'Cost And Scaling Notes',
   'Final Smoke',
+  'Findings Workflow',
 ]) {
   assertIncludes(reportPath, phrase)
 }
 
 for (const phrase of [
+  'local-self-host-beta',
+  'acceptedPublicTier',
+  'launch-evidence-matrix.json',
   'pnpm deploy:load:plan',
   'pnpm deploy:load',
   'pnpm deploy:soak',

--- a/tests/launch-readiness.test.ts
+++ b/tests/launch-readiness.test.ts
@@ -9,6 +9,10 @@ import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 
+function readJsonFile(path: string) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
 function writeJson(res: ServerResponse, status: number, body: unknown) {
   res.writeHead(status, {
     'content-type': 'application/json',
@@ -203,6 +207,68 @@ test('launch readiness harness produces strict load report against cloud and gat
   } finally {
     await new Promise<void>((resolve) => cloud.server.close(() => resolve()))
     await new Promise<void>((resolve) => gateway.server.close(() => resolve()))
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('launch evidence matrix states the current accepted tier and required gates', () => {
+  const targets = readJsonFile('deploy/load/launch-readiness-targets.json')
+  assert.ok(targets.profiles['local-self-host-beta'])
+  assert.ok(targets.profiles['private-beta'])
+  assert.ok(targets.profiles['public-beta'])
+  assert.ok(targets.profiles['enterprise-scale'])
+
+  const matrix = readJsonFile('deploy/load/launch-evidence-matrix.json')
+  assert.equal(matrix.schemaVersion, 1)
+  assert.equal(matrix.purpose, 'launch-evidence-tier-matrix')
+  assert.equal(matrix.acceptedPublicTier, 'local-self-host-beta')
+  assert.equal(matrix.tiers['local-self-host-beta'].claimStatus, 'accepted-public')
+  for (const tier of ['private-beta', 'public-beta', 'general-availability', 'enterprise-scale']) {
+    assert.notEqual(matrix.tiers[tier].claimStatus, 'accepted-public')
+  }
+  for (const category of [
+    'loadAndSoak',
+    'failoverRecovery',
+    'backupRestore',
+    'securityBoundary',
+    'releasePackaging',
+    'findingsWorkflow',
+  ]) {
+    assert.equal(matrix.evidenceCategories[category].requiredForAcceptedTier, true, category)
+    assert.ok(matrix.evidenceCategories[category].publicArtifacts.length > 0, category)
+    assert.ok(matrix.evidenceCategories[category].requiredCommands.length > 0, category)
+    assert.match(matrix.evidenceCategories[category].passCondition, /\w/)
+  }
+  assert.ok(matrix.evidenceCategories.loadAndSoak.coveredSurfaces.includes('SSE fanout and reconnect'))
+  assert.ok(matrix.evidenceCategories.failoverRecovery.coveredSurfaces.includes('Gateway restart with delivery cursor resume'))
+  assert.ok(matrix.evidenceCategories.backupRestore.coveredSurfaces.includes('BYOK secret references and reveal denial behavior'))
+  assert.ok(matrix.evidenceCategories.securityBoundary.coveredSurfaces.includes('public webhook ingress fails closed'))
+  assert.ok(matrix.evidenceCategories.releasePackaging.coveredSurfaces.includes('Desktop packaging smoke'))
+  assert.ok(matrix.evidenceCategories.findingsWorkflow.allowedDispositions.includes('narrow-follow-up-issue'))
+})
+
+test('launch readiness plan supports the local self-host beta tier', async () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'open-cowork-launch-plan-'))
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      'scripts/launch-readiness.mjs',
+      '--mode',
+      'plan',
+      '--profile',
+      'local-self-host-beta',
+      '--output-dir',
+      outputDir,
+    ], { encoding: 'utf8' })
+    const parsed = JSON.parse(stdout)
+    assert.equal(parsed.ok, true)
+    assert.equal(parsed.mode, 'plan')
+    assert.equal(parsed.profileName, 'local-self-host-beta')
+    assert.ok(parsed.operations.includes('cloud-health'))
+    assert.ok(parsed.operations.includes('gateway-health'))
+    const plan = readFileSync(parsed.planPath, 'utf8')
+    assert.match(plan, /local-self-host-beta/)
+    assert.match(plan, /OSS self-host and local reference deployment target/)
+  } finally {
     rmSync(outputDir, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
Closes #554.

Summary:
- Add a launch evidence tier matrix that accepts only local-self-host-beta in the public repo.
- Add a local self-host beta load profile and strict validator coverage for required evidence categories.
- Update launch runbooks, release checklist, report template, and tests.

Validation:
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:cloud-web
- pnpm test:cloud-continuation
- pnpm deploy:launch:validate
- pnpm deploy:validate
- pnpm deploy:private-beta:validate
- pnpm ops:validate
- pnpm deploy:load:plan
- OPEN_COWORK_LOAD_PROFILE=local-self-host-beta pnpm deploy:load:plan
- pnpm docs:build
- git diff --check