### PR TITLE
Harden desktop cloud sync

### DIFF
--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -118,6 +118,9 @@ export type CloudWorkspaceAdapterOptions = {
   cacheEncryptionFallback?: CloudWorkspaceCacheEncryptionFallback
 }
 
+const CLOUD_SYNC_VIEW_CONCURRENCY = 8
+const CLOUD_SYNC_ARTIFACT_CONCURRENCY = 4
+
 function toSessionInfo(record: SessionRecord): SessionInfo {
   return {
     id: record.sessionId,
@@ -151,10 +154,35 @@ export function cloudWorkspaceCacheKey(connection: CloudWorkspaceConnectionRecor
   ].join('|')
 }
 
+async function settleWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T, index: number) => Promise<void>,
+): Promise<PromiseSettledResult<void>[]> {
+  const results: PromiseSettledResult<void>[] = new Array(items.length)
+  let nextIndex = 0
+  const workerCount = Math.min(Math.max(1, concurrency), items.length)
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex
+      nextIndex += 1
+      try {
+        await task(items[index], index)
+        results[index] = { status: 'fulfilled', value: undefined }
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason }
+      }
+    }
+  }))
+  return results
+}
+
 export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
   private readonly transport: CloudTransportAdapter
   private readonly connection: CloudWorkspaceConnectionRecord
   private readonly cache: CloudWorkspaceCache | null
+  private readonly inFlightSessionViews = new Map<string, Promise<SessionView>>()
+  private readonly inFlightArtifactLists = new Map<string, Promise<SessionArtifact[]>>()
 
   constructor(options: CloudWorkspaceAdapterOptions) {
     this.connection = options.connection
@@ -247,9 +275,24 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
   }
 
   async getSessionView(sessionId: string): Promise<SessionView> {
+    const inFlight = this.inFlightSessionViews.get(sessionId)
+    if (inFlight) return inFlight
+    const fetch = this.fetchSessionView(sessionId)
+      .finally(() => {
+        if (this.inFlightSessionViews.get(sessionId) === fetch) {
+          this.inFlightSessionViews.delete(sessionId)
+        }
+      })
+    this.inFlightSessionViews.set(sessionId, fetch)
+    return fetch
+  }
+
+  private async fetchSessionView(sessionId: string): Promise<SessionView> {
     const cacheKey = cloudWorkspaceCacheKey(this.connection)
     try {
       const view = cloudSessionViewToSessionView(await this.transport.getSession(sessionId))
+      const cached = this.cache?.getSessionView(cacheKey, sessionId)
+      if (cached && cached.revision > view.revision) return cached
       this.cache?.upsertSessionView(cacheKey, sessionId, view)
       return view
     } catch (error) {
@@ -395,6 +438,20 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
 
   async listArtifacts(sessionId: string): Promise<SessionArtifact[]> {
     if (!this.transport.listArtifacts) throw new Error('Cloud artifacts are not supported by this workspace.')
+    const inFlight = this.inFlightArtifactLists.get(sessionId)
+    if (inFlight) return inFlight
+    const fetch = this.fetchArtifactList(sessionId)
+      .finally(() => {
+        if (this.inFlightArtifactLists.get(sessionId) === fetch) {
+          this.inFlightArtifactLists.delete(sessionId)
+        }
+      })
+    this.inFlightArtifactLists.set(sessionId, fetch)
+    return fetch
+  }
+
+  private async fetchArtifactList(sessionId: string): Promise<SessionArtifact[]> {
+    if (!this.transport.listArtifacts) throw new Error('Cloud artifacts are not supported by this workspace.')
     const cacheKey = cloudWorkspaceCacheKey(this.connection)
     try {
       const artifacts = await this.transport.listArtifacts(sessionId)
@@ -490,9 +547,13 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
 
   async sync(): Promise<void> {
     const sessions = await this.listSessions()
-    await Promise.allSettled(sessions.map((session) => this.getSessionView(session.id)))
+    await settleWithConcurrency(sessions, CLOUD_SYNC_VIEW_CONCURRENCY, async (session) => {
+      await this.getSessionView(session.id)
+    })
     if (this.transport.listArtifacts) {
-      await Promise.allSettled(sessions.map((session) => this.listArtifacts(session.id)))
+      await settleWithConcurrency(sessions, CLOUD_SYNC_ARTIFACT_CONCURRENCY, async (session) => {
+        await this.listArtifacts(session.id)
+      })
     }
     if (this.transport.listWorkflows) {
       await this.listWorkflows().catch(() => undefined)

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -302,15 +302,17 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     return buildCloudEffectiveSettings(base, setting?.value || {})
   })
 
-  context.ipcMain.handle('settings:get-provider-credentials', async (_event, providerId: unknown) => {
+  context.ipcMain.handle('settings:get-provider-credentials', async (event, providerId: unknown) => {
     // Scoped opt-in for provider credential editor surfaces. Avoid
     // returning every stored provider and integration secret to any
     // renderer code that only needs one credential bag.
+    if (!context.workspaceGateway.isLocalWorkspace(event, null)) return {}
     return getProviderCredentials(normalizeCredentialScopeId(providerId, 'Provider'))
   })
 
-  context.ipcMain.handle('settings:get-integration-credentials', async (_event, integrationId: unknown) => {
+  context.ipcMain.handle('settings:get-integration-credentials', async (event, integrationId: unknown) => {
     // Same scoped read for integration/MCP credential editors.
+    if (!context.workspaceGateway.isLocalWorkspace(event, null)) return {}
     return getIntegrationCredentials(normalizeCredentialScopeId(integrationId, 'Integration'))
   })
 

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -5,7 +5,7 @@ import {
   type SessionChangeSummary,
   type SessionImportSelection,
 } from '@open-cowork/shared'
-import type { IpcMainInvokeEvent } from 'electron'
+import type { BrowserWindow, IpcMainInvokeEvent } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { closeSync, constants as fsConstants, fstatSync, openSync, readFileSync } from 'node:fs'
 import { getEffectiveSettings, getProviderCredentialValue } from '../settings.ts'
@@ -59,6 +59,138 @@ import {
   normalizeSessionId,
 } from './session-handler-validation.ts'
 
+const CLOUD_PROJECTION_REFRESH_DEBOUNCE_MS = 25
+const CLOUD_PROJECTION_REFRESH_BACKOFF_BASE_MS = 250
+const CLOUD_PROJECTION_REFRESH_BACKOFF_MAX_MS = 5_000
+
+type CloudProjectionRefreshState = {
+  timer: ReturnType<typeof setTimeout> | null
+  inFlight: boolean
+  latestSequence: number
+  publishedRevision: number
+  failedAttempts: number
+  nextAllowedAt: number
+}
+
+const cloudProjectionRefreshes = new Map<string, CloudProjectionRefreshState>()
+
+function cloudProjectionRefreshKey(workspaceId: string | null | undefined, sessionId: string) {
+  return `${workspaceId || 'local'}:${sessionId}`
+}
+
+function cloudWorkspaceIsStillActive(
+  context: IpcHandlerContext,
+  sourceEvent: IpcMainInvokeEvent | undefined,
+  workspaceId: string | null | undefined,
+) {
+  if (!sourceEvent || !workspaceId) return true
+  try {
+    return context.workspaceGateway.activeWorkspaceId(sourceEvent) === workspaceId
+  } catch {
+    return false
+  }
+}
+
+function queueCloudProjectionRefresh(input: {
+  context: IpcHandlerContext
+  win: BrowserWindow
+  sourceEvent?: IpcMainInvokeEvent
+  sessionId: string
+  workspaceId?: string | null
+  sequence: number
+}) {
+  const { context, win, sourceEvent, sessionId, workspaceId, sequence } = input
+  if (!cloudWorkspaceIsStillActive(context, sourceEvent, workspaceId)) return
+  const key = cloudProjectionRefreshKey(workspaceId, sessionId)
+  const state = cloudProjectionRefreshes.get(key) || {
+    timer: null,
+    inFlight: false,
+    latestSequence: 0,
+    publishedRevision: 0,
+    failedAttempts: 0,
+    nextAllowedAt: 0,
+  }
+  state.latestSequence = Math.max(state.latestSequence, sequence)
+  cloudProjectionRefreshes.set(key, state)
+  if (state.timer) clearTimeout(state.timer)
+  const delayMs = Math.max(CLOUD_PROJECTION_REFRESH_DEBOUNCE_MS, state.nextAllowedAt - Date.now())
+  state.timer = setTimeout(() => {
+    state.timer = null
+    void runQueuedCloudProjectionRefresh({
+      context,
+      win,
+      sourceEvent,
+      sessionId,
+      workspaceId,
+      key,
+      state,
+    })
+  }, delayMs)
+}
+
+async function runQueuedCloudProjectionRefresh(input: {
+  context: IpcHandlerContext
+  win: BrowserWindow
+  sourceEvent?: IpcMainInvokeEvent
+  sessionId: string
+  workspaceId?: string | null
+  key: string
+  state: CloudProjectionRefreshState
+}) {
+  const { context, win, sourceEvent, sessionId, workspaceId, key, state } = input
+  if (state.inFlight) return
+  if (win.isDestroyed()) {
+    cloudProjectionRefreshes.delete(key)
+    return
+  }
+  if (!cloudWorkspaceIsStillActive(context, sourceEvent, workspaceId)) {
+    cloudProjectionRefreshes.delete(key)
+    return
+  }
+  state.inFlight = true
+  const requestedSequence = state.latestSequence
+  try {
+    const view = await context.workspaceGateway.getCloudSessionView(sourceEvent, sessionId, workspaceId)
+    if (
+      !win.isDestroyed()
+      && cloudWorkspaceIsStillActive(context, sourceEvent, workspaceId)
+      && view.revision >= state.publishedRevision
+    ) {
+      state.publishedRevision = view.revision
+      win.webContents.send('session:view', { sessionId, workspaceId: workspaceId || undefined, view })
+    }
+    state.failedAttempts = 0
+    state.nextAllowedAt = 0
+  } catch (error) {
+    state.failedAttempts = Math.min(state.failedAttempts + 1, 8)
+    const backoffMs = Math.min(
+      CLOUD_PROJECTION_REFRESH_BACKOFF_MAX_MS,
+      CLOUD_PROJECTION_REFRESH_BACKOFF_BASE_MS * 2 ** (state.failedAttempts - 1),
+    )
+    state.nextAllowedAt = Date.now() + backoffMs
+    context.logHandlerError(`cloud session:view ${shortSessionId(sessionId)}`, error)
+  } finally {
+    state.inFlight = false
+    if (state.latestSequence > requestedSequence) {
+      if (state.timer) clearTimeout(state.timer)
+      const delayMs = Math.max(CLOUD_PROJECTION_REFRESH_DEBOUNCE_MS, state.nextAllowedAt - Date.now())
+      state.timer = setTimeout(() => {
+        state.timer = null
+        void runQueuedCloudProjectionRefresh(input)
+      }, delayMs)
+    } else if (!state.timer) {
+      const deleteDelayMs = Math.max(0, state.nextAllowedAt - Date.now())
+      if (deleteDelayMs > 0) {
+        state.timer = setTimeout(() => {
+          if (cloudProjectionRefreshes.get(key) === state) cloudProjectionRefreshes.delete(key)
+        }, deleteDelayMs)
+      } else {
+        cloudProjectionRefreshes.delete(key)
+      }
+    }
+  }
+}
+
 type PromptAttachment = ReturnType<typeof normalizePromptAttachments>[number]
 type PromptPart =
   | { type: 'file'; mime: string; url: string; filename?: string }
@@ -107,15 +239,19 @@ function dispatchCloudWorkspaceSessionEvent(
   if (!sessionId) return
   const win = context.getMainWindow()
   if (!win || win.isDestroyed()) return
+  if (!cloudWorkspaceIsStillActive(context, sourceEvent, workspaceId)) return
   const payload = event.payload || {}
   const eventAt = event.sequence || Date.now()
   let shouldRefreshCloudProjection = false
   const publishCloudProjection = () => {
-    void context.workspaceGateway.getCloudSessionView(sourceEvent, sessionId, workspaceId)
-      .then((view) => {
-        if (!win.isDestroyed()) win.webContents.send('session:view', { sessionId, workspaceId: workspaceId || undefined, view })
-      })
-      .catch((error) => context.logHandlerError(`cloud session:view ${shortSessionId(sessionId)}`, error))
+    queueCloudProjectionRefresh({
+      context,
+      win,
+      sourceEvent,
+      sessionId,
+      workspaceId,
+      sequence: event.sequence || Date.now(),
+    })
   }
   const dispatchCloudRuntimeEvent = (runtimeEvent: Parameters<typeof dispatchRuntimeSessionEvent>[1]) => {
     dispatchRuntimeSessionEvent(win, {

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -321,7 +321,17 @@ export class WorkspaceGateway {
 
   activate(event: WorkspaceEventLike, workspaceIdInput: string): WorkspaceInfo {
     const workspace = this.getWorkspace(workspaceIdInput)
-    this.activeBySender.set(senderKey(event), workspace.id)
+    const sender = senderKey(event)
+    const previousWorkspaceId = this.activeBySender.get(sender)
+    this.activeBySender.set(sender, workspace.id)
+    if (
+      previousWorkspaceId
+      && previousWorkspaceId !== workspace.id
+      && previousWorkspaceId !== LOCAL_WORKSPACE_ID
+      && !this.hasActiveSenderForWorkspace(previousWorkspaceId)
+    ) {
+      this.closeCloudSubscriptionsForWorkspace(previousWorkspaceId)
+    }
     return this.toInfo(workspace, true)
   }
 
@@ -1299,6 +1309,13 @@ export class WorkspaceGateway {
       try { subscription.close() } catch { /* best effort */ }
       this.cloudWorkspaceSubscriptions.delete(key)
     }
+  }
+
+  private hasActiveSenderForWorkspace(workspaceId: string) {
+    for (const activeWorkspaceId of this.activeBySender.values()) {
+      if (activeWorkspaceId === workspaceId) return true
+    }
+    return false
   }
 
   private async readCloudItemsSetting<T extends { name: string }>(

--- a/apps/desktop/src/renderer/helpers/loadSessionMessages.test.ts
+++ b/apps/desktop/src/renderer/helpers/loadSessionMessages.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { SessionView } from '@open-cowork/shared'
 import { installRendererTestCoworkApi } from '../test/setup'
 import { useSessionStore } from '../stores/session'
+import { LOCAL_WORKSPACE_ID, sessionWorkspaceKey } from '../stores/session-workspace-keys'
 import { switchToSession } from './loadSessionMessages'
 
 function resetSessionStore() {
@@ -14,6 +16,8 @@ function resetSessionStore() {
         updatedAt: '2026-05-08T00:00:00.000Z',
       },
     ],
+    activeWorkspaceId: LOCAL_WORKSPACE_ID,
+    sessionsByWorkspace: { [LOCAL_WORKSPACE_ID]: [] },
     currentSessionId: null,
     globalErrors: [],
     busySessions: new Set(),
@@ -42,12 +46,70 @@ describe('switchToSession', () => {
 
     await switchToSession('session-1')
 
-    expect(activate).toHaveBeenCalledWith('session-1', undefined)
+    expect(activate).toHaveBeenCalledWith('session-1', { workspaceId: LOCAL_WORKSPACE_ID })
     expect(useSessionStore.getState().currentSessionId).toBe('session-1')
     expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not load this thread. Try reopening it.')
     expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
       message: expect.stringContaining('activation ipc failed'),
       view: 'chat',
     }))
+  })
+
+  it('does not hydrate a session view after the active workspace changes', async () => {
+    let resolveActivate: (view: SessionView) => void = () => {
+      throw new Error('activate promise resolver was not initialized')
+    }
+    const activate = vi.fn(() => new Promise<SessionView>((resolve) => {
+      resolveActivate = resolve
+    }))
+    installRendererTestCoworkApi({
+      session: {
+        activate,
+      },
+    })
+    resetSessionStore()
+    useSessionStore.getState().setActiveWorkspace('cloud:one')
+
+    const loading = switchToSession('same-session-id')
+    useSessionStore.getState().setActiveWorkspace('cloud:two')
+    resolveActivate({
+      messages: [{
+        id: 'stale',
+        role: 'assistant',
+        content: 'stale cloud view',
+        timestamp: '2026-05-08T00:00:00.000Z',
+        order: 1,
+        segments: [{ id: 'stale:text', content: 'stale cloud view', order: 1 }],
+      }],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      artifacts: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      lastInputTokens: 0,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 1,
+      lastEventAt: 1,
+      isGenerating: false,
+      isAwaitingPermission: false,
+      isAwaitingQuestion: false,
+    })
+    await loading
+
+    expect(activate).toHaveBeenCalledWith('same-session-id', { workspaceId: 'cloud:one' })
+    expect(useSessionStore.getState().activeWorkspaceId).toBe('cloud:two')
+    expect(useSessionStore.getState().sessionStateById[sessionWorkspaceKey('cloud:two', 'same-session-id')]).toBeUndefined()
+    expect(useSessionStore.getState().sessionStateById[sessionWorkspaceKey('cloud:one', 'same-session-id')]?.hydrated).toBe(false)
+    expect(useSessionStore.getState().sessionStateById[sessionWorkspaceKey('cloud:one', 'same-session-id')]?.messageIds).toEqual([])
   })
 })

--- a/apps/desktop/src/renderer/helpers/loadSessionMessages.ts
+++ b/apps/desktop/src/renderer/helpers/loadSessionMessages.ts
@@ -1,5 +1,6 @@
 import { useSessionStore } from '../stores/session'
 import { t } from './i18n'
+import { normalizeWorkspaceId } from '../stores/session-workspace-keys'
 
 function describeSessionLoadError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
@@ -29,15 +30,20 @@ let activateToken = 0
 /**
  * Switch to a session and hydrate it from history on first load.
  */
-export async function switchToSession(sessionId: string, options?: { force?: boolean }) {
+export async function switchToSession(sessionId: string, options?: { force?: boolean; workspaceId?: string }) {
   const store = useSessionStore.getState()
+  const requestedWorkspaceId = normalizeWorkspaceId(options?.workspaceId || store.activeWorkspaceId)
   store.setCurrentSession(sessionId)
   const myToken = ++activateToken
 
   try {
-    const view = await window.coworkApi.session.activate(sessionId, options)
+    const view = await window.coworkApi.session.activate(sessionId, {
+      ...options,
+      workspaceId: requestedWorkspaceId,
+    })
     if (myToken !== activateToken) return
-    store.setSessionView(sessionId, view)
+    if (normalizeWorkspaceId(useSessionStore.getState().activeWorkspaceId) !== requestedWorkspaceId) return
+    store.setSessionView(sessionId, view, requestedWorkspaceId)
   } catch (err) {
     if (myToken !== activateToken) return
     reportSessionLoadError(sessionId, err)

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -834,7 +834,20 @@ blocks user-added cloud URLs. `cacheMode` controls the local cloud cache:
 When `cacheMode` is `full`, the desktop requires OS-backed encrypted storage or
 uses `cacheEncryptionFallback` to degrade to `metadata-only`, `disabled`, or
 fail startup. OAuth access and refresh tokens are stored in OS secure storage,
-not in the cloud cache.
+not in the cloud cache. The cache is keyed by cloud connection, tenant, user,
+profile, and workspace identity so two orgs cannot share cached projections or
+event cursors.
+
+Cloud workspace logout is an authentication boundary, not a data wipe. It
+removes the workspace access and refresh tokens, closes active cloud
+subscriptions, and leaves any existing cloud cache as a local read-only fallback
+until the user signs in again or removes the workspace. Removing a user-added
+cloud workspace is the wipe boundary: it removes the registry record,
+credentials, active subscriptions, and that workspace's cached metadata,
+cursors, artifact metadata, and encrypted projections. Managed preconfigured
+workspaces cannot be removed by the user; downstream builds that require a
+stronger wipe policy should configure `cacheMode: "disabled"` or expose an
+admin-managed cache clear flow.
 
 Every workspace-scoped API also has a typed support matrix exposed through
 `workspace.support()`. Cloud-only clients should use it to distinguish

--- a/tests/cloud-workspace-adapter.test.ts
+++ b/tests/cloud-workspace-adapter.test.ts
@@ -489,6 +489,24 @@ function failingTransport(): CloudTransportAdapter {
   }
 }
 
+function sessionRecord(sessionId: string) {
+  return {
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId,
+    opencodeSessionId: `opencode-${sessionId}`,
+    profileName: 'default',
+    status: 'idle' as const,
+    title: `Cloud ${sessionId}`,
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+  }
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 test('cloud workspace adapter maps cloud records to desktop session contracts', async () => {
   const adapter = new CloudWorkspaceAdapter({
     connection: {
@@ -564,6 +582,139 @@ test('cloud workspace adapter maps cloud records to desktop session contracts', 
   assert.equal((await adapter.listSettings())[0]?.key, 'portable-settings')
   assert.equal((await adapter.getSetting('portable-settings'))?.value.selectedProviderId, 'anthropic')
   assert.equal((await adapter.setSetting('portable-settings', { selectedProviderId: 'openai' })).value.selectedProviderId, 'openai')
+})
+
+test('cloud workspace adapter bounds sync hydration concurrency', async () => {
+  const base = transport()
+  const sessions = Array.from({ length: 25 }, (_, index) => sessionRecord(`session-${index + 1}`))
+  let activeViews = 0
+  let maxViews = 0
+  let activeArtifacts = 0
+  let maxArtifacts = 0
+  let viewCalls = 0
+  let artifactCalls = 0
+  const adapter = new CloudWorkspaceAdapter({
+    connection: {
+      id: 'cloud:test',
+      baseUrl: 'https://cloud.example.test',
+      label: 'Test Cloud',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+      lastSyncedAt: null,
+    },
+    cache: null,
+    transport: {
+      ...base,
+      listSessions: async () => sessions,
+      getSession: async (sessionId) => {
+        viewCalls += 1
+        activeViews += 1
+        maxViews = Math.max(maxViews, activeViews)
+        await delay(2)
+        activeViews -= 1
+        return base.getSession(sessionId)
+      },
+      listArtifacts: async (sessionId) => {
+        artifactCalls += 1
+        activeArtifacts += 1
+        maxArtifacts = Math.max(maxArtifacts, activeArtifacts)
+        await delay(2)
+        activeArtifacts -= 1
+        return base.listArtifacts?.(sessionId) as ReturnType<NonNullable<CloudTransportAdapter['listArtifacts']>>
+      },
+    },
+  })
+
+  await adapter.sync()
+
+  assert.equal(viewCalls, sessions.length)
+  assert.equal(artifactCalls, sessions.length)
+  assert.ok(maxViews <= 8, `expected view concurrency <= 8, saw ${maxViews}`)
+  assert.ok(maxArtifacts <= 4, `expected artifact concurrency <= 4, saw ${maxArtifacts}`)
+})
+
+test('cloud workspace adapter coalesces concurrent session view refreshes', async () => {
+  const base = transport()
+  let calls = 0
+  const adapter = new CloudWorkspaceAdapter({
+    connection: {
+      id: 'cloud:test',
+      baseUrl: 'https://cloud.example.test',
+      label: 'Test Cloud',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+      lastSyncedAt: null,
+    },
+    cache: null,
+    transport: {
+      ...base,
+      getSession: async (sessionId) => {
+        calls += 1
+        await delay(5)
+        return base.getSession(sessionId)
+      },
+    },
+  })
+
+  const [first, second] = await Promise.all([
+    adapter.getSessionView('session-1'),
+    adapter.getSessionView('session-1'),
+  ])
+
+  assert.equal(calls, 1)
+  assert.equal(first.revision, 7)
+  assert.equal(second.revision, 7)
+})
+
+test('cloud workspace adapter does not overwrite newer cached projections with stale responses', async () => {
+  const cache = new FileCloudWorkspaceCache({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-adapter-stale-view-')), 'cloud-workspace-cache.json'),
+    mode: 'full',
+    secretStorage: {
+      mode: 'plaintext',
+      encryptString: (plaintext) => Buffer.from(plaintext, 'utf-8'),
+      decryptString: (encrypted) => encrypted.toString('utf-8'),
+    },
+  })
+  const connection = {
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Test Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }
+  const cacheKey = cloudWorkspaceCacheKey(connection)
+  const seed = new CloudWorkspaceAdapter({
+    connection,
+    transport: transport(),
+    cache: null,
+  })
+  const fresh = {
+    ...await seed.getSessionView('session-1'),
+    revision: 99,
+    lastEventAt: 99,
+    messages: [{
+      id: 'fresh-message',
+      role: 'assistant' as const,
+      content: 'newer cached projection',
+      createdAt: '2026-05-27T10:02:00.000Z',
+      order: 1,
+      segments: [{ id: 'fresh-message:text', type: 'text' as const, text: 'newer cached projection' }],
+    }],
+  }
+  cache.upsertSessionView(cacheKey, 'session-1', fresh)
+  const adapter = new CloudWorkspaceAdapter({
+    connection,
+    transport: transport(),
+    cache,
+  })
+
+  const view = await adapter.getSessionView('session-1')
+
+  assert.equal(view.revision, 99)
+  assert.equal(view.messages[0]?.content, 'newer cached projection')
+  assert.equal(cache.getSessionView(cacheKey, 'session-1')?.revision, 99)
 })
 
 test('cloud workspace adapter blocks local attachments in cloud prompts', async () => {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -24,7 +24,7 @@ import { consumePendingPromptEcho } from '../apps/desktop/src/main/event-task-st
 import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { stopSessionStatusReconciliation } from '../apps/desktop/src/main/session-status-reconciler.ts'
 import { clearSessionRegistryCache, toSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
-import { createWorkspaceGateway } from '../apps/desktop/src/main/workspace-gateway.ts'
+import { LOCAL_WORKSPACE_ID, createWorkspaceGateway } from '../apps/desktop/src/main/workspace-gateway.ts'
 import type { CloudWorkspaceSessionAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 
 function createBaseContext() {
@@ -414,6 +414,7 @@ test('cloud session SSE publishes authoritative cloud projections instead of loc
   const { context, handlers } = createBaseContext()
   const sentViews: unknown[] = []
   let subscribedEventHandler: ((event: any) => void) | null = null
+  let projectionFetches = 0
   const adapter: CloudWorkspaceSessionAdapter = {
     policy: async () => ({
       features: { sessions: true },
@@ -429,43 +430,46 @@ test('cloud session SSE publishes authoritative cloud projections instead of loc
       throw new Error('not used')
     },
     getSessionInfo: async () => null,
-    getSessionView: async () => ({
-      messages: [{
-        id: 'cloud-projected-message',
-        role: 'assistant',
-        segments: [{ id: 'segment-1', kind: 'text', text: 'from cloud projection' }],
-        attachments: [],
-        createdAt: 1,
-      }],
-      toolCalls: [],
-      taskRuns: [],
-      compactions: [],
-      pendingApprovals: [{
-        id: 'permission-1',
-        taskRunId: null,
-        tool: 'read',
-        description: 'Read file',
-        input: {},
-        sourceSessionId: 'cloud-session-1',
-      }],
-      pendingQuestions: [],
-      errors: [],
-      todos: [],
-      executionPlan: [],
-      sessionCost: 0,
-      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
-      lastInputTokens: 0,
-      contextState: 'running',
-      compactionCount: 0,
-      lastCompactedAt: null,
-      activeAgent: null,
-      lastItemWasTool: false,
-      revision: 7,
-      lastEventAt: 42,
-      isGenerating: true,
-      isAwaitingPermission: true,
-      isAwaitingQuestion: false,
-    }),
+    getSessionView: async () => {
+      projectionFetches += 1
+      return {
+        messages: [{
+          id: 'cloud-projected-message',
+          role: 'assistant',
+          segments: [{ id: 'segment-1', kind: 'text', text: 'from cloud projection' }],
+          attachments: [],
+          createdAt: 1,
+        }],
+        toolCalls: [],
+        taskRuns: [],
+        compactions: [],
+        pendingApprovals: [{
+          id: 'permission-1',
+          taskRunId: null,
+          tool: 'read',
+          description: 'Read file',
+          input: {},
+          sourceSessionId: 'cloud-session-1',
+        }],
+        pendingQuestions: [],
+        errors: [],
+        todos: [],
+        executionPlan: [],
+        sessionCost: 0,
+        sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+        lastInputTokens: 0,
+        contextState: 'running',
+        compactionCount: 0,
+        lastCompactedAt: null,
+        activeAgent: null,
+        lastItemWasTool: false,
+        revision: 7,
+        lastEventAt: 42,
+        isGenerating: true,
+        isAwaitingPermission: true,
+        isAwaitingQuestion: false,
+      }
+    },
     promptSession: async () => {},
     abortSession: async () => {},
     subscribeSessionEvents: (_sessionId, input) => {
@@ -509,6 +513,7 @@ test('cloud session SSE publishes authoritative cloud projections instead of loc
   context.workspaceGateway.activate(invokeEvent, 'cloud:test')
   await handlers.get('session:activate')?.(invokeEvent, 'cloud-session-1')
   assert.ok(subscribedEventHandler, 'expected cloud session event subscription')
+  projectionFetches = 0
 
   subscribedEventHandler({
     type: 'permission.requested',
@@ -520,15 +525,103 @@ test('cloud session SSE publishes authoritative cloud projections instead of loc
       description: 'Read file',
     },
   })
+  subscribedEventHandler({
+    type: 'session.status',
+    sessionId: 'cloud-session-1',
+    sequence: 43,
+    payload: { statusType: 'running' },
+  })
 
-  await new Promise((resolve) => setTimeout(resolve, 25))
+  await new Promise((resolve) => setTimeout(resolve, 80))
 
   assert.equal(sentViews.length, 1)
+  assert.equal(projectionFetches, 1)
   assert.deepEqual(sentViews[0], {
     sessionId: 'cloud-session-1',
     workspaceId: 'cloud:test',
     view: await adapter.getSessionView('cloud-session-1'),
   })
+
+  context.workspaceGateway.activate(invokeEvent, LOCAL_WORKSPACE_ID)
+  subscribedEventHandler({
+    type: 'assistant.message',
+    sessionId: 'cloud-session-1',
+    sequence: 44,
+    payload: { messageId: 'm2', content: 'inactive event' },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 80))
+  assert.equal(sentViews.length, 1)
+})
+
+test('cloud projection refresh errors back off repeated full-view fetches', async () => {
+  const { context, handlers, errors } = createBaseContext()
+  let subscribedEventHandler: ((event: any) => void) | null = null
+  let projectionFetches = 0
+  let failProjectionRefresh = false
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      projectionFetches += 1
+      if (failProjectionRefresh) throw new Error('temporary projection outage')
+      return emptySessionView({ revision: 1, lastEventAt: 1 })
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    subscribeSessionEvents: (_sessionId, input) => {
+      subscribedEventHandler = input.onEvent
+      return { close: () => {} }
+    },
+  }
+  context.getMainWindow = () => ({
+    isDestroyed: () => false,
+    webContents: {
+      id: 203,
+      send: () => {},
+    },
+  } as any)
+  installCloudWorkspace(context, adapter)
+
+  registerSessionHandlers(context)
+  const invokeEvent = { sender: { id: 203 } }
+  context.workspaceGateway.activate(invokeEvent, 'cloud:test')
+  await handlers.get('session:activate')?.(invokeEvent, 'cloud-session-backoff')
+  assert.ok(subscribedEventHandler, 'expected cloud session event subscription')
+  projectionFetches = 0
+  failProjectionRefresh = true
+
+  subscribedEventHandler({
+    type: 'permission.requested',
+    sessionId: 'cloud-session-backoff',
+    sequence: 10,
+    payload: { permissionId: 'permission-1', tool: 'read' },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 80))
+
+  assert.equal(projectionFetches, 1)
+  assert.equal(errors.some((entry) => entry.includes('temporary projection outage')), true)
+
+  subscribedEventHandler({
+    type: 'session.status',
+    sessionId: 'cloud-session-backoff',
+    sequence: 11,
+    payload: { statusType: 'running' },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 80))
+
+  assert.equal(projectionFetches, 1)
 })
 
 test('session:prompt rejects too many attachments before runtime dispatch', async () => {
@@ -1626,6 +1719,10 @@ test('settings handlers sync only portable settings for cloud workspaces', async
   })
 
   registerAppHandlers(context)
+  const cloudEvent = { sender: { id: 1 } } as never
+  context.workspaceGateway.activate(cloudEvent, 'cloud:test')
+  assert.deepEqual(await handlers.get('settings:get-provider-credentials')?.(cloudEvent, 'openrouter'), {})
+  assert.deepEqual(await handlers.get('settings:get-integration-credentials')?.(cloudEvent, 'github'), {})
 
   const current = await handlers.get('settings:get')?.({}, { workspaceId: 'cloud:test' })
   assert.equal(current.selectedProviderId, 'anthropic')

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -871,6 +871,110 @@ test('workspace gateway subscribes cloud workspace events once per sender', asyn
   assert.deepEqual(calls, ['subscribe:cached', 'subscribe:5', 'close', 'close'])
 })
 
+test('workspace gateway closes inactive cloud subscriptions on workspace switch', async () => {
+  const credentials = new FileCloudWorkspaceCredentialStore({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-switch-events-')), 'cloud-workspace-credentials.json'),
+    secretStorage: encryptedStorage(),
+  })
+  for (const workspaceId of ['cloud:one', 'cloud:two']) {
+    credentials.save({
+      workspaceId,
+      accessToken: 'cloud-access-token',
+      expiresAt: '2030-05-27T12:00:00.000Z',
+    })
+  }
+  const calls: string[] = []
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => ({
+      id: 'cloud-session-1',
+      title: 'Cloud session',
+      directory: null,
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }),
+    getSessionInfo: async () => null,
+    getSessionView: async () => ({
+      messages: [],
+      toolCalls: [],
+      taskRuns: [],
+      compactions: [],
+      pendingApprovals: [],
+      pendingQuestions: [],
+      errors: [],
+      todos: [],
+      executionPlan: [],
+      sessionCost: 0,
+      sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      lastInputTokens: 0,
+      contextState: 'idle',
+      compactionCount: 0,
+      lastCompactedAt: null,
+      activeAgent: null,
+      lastItemWasTool: false,
+      revision: 0,
+      lastEventAt: 0,
+      isGenerating: false,
+      isAwaitingPermission: false,
+      isAwaitingQuestion: false,
+    }),
+    promptSession: async () => undefined,
+    abortSession: async () => undefined,
+    subscribeWorkspaceEvents: () => ({ close() { calls.push('close') } }),
+    subscribeSessionEvents: () => ({ close() { calls.push('session-close') } }),
+  }
+  const gateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: credentials,
+    workspaces: [
+      {
+        id: 'cloud:one',
+        kind: 'cloud',
+        label: 'Cloud One',
+        status: 'online',
+        baseUrl: 'https://one.example.test',
+        lastSyncedAt: null,
+      },
+      {
+        id: 'cloud:two',
+        kind: 'cloud',
+        label: 'Cloud Two',
+        status: 'online',
+        baseUrl: 'https://two.example.test',
+        lastSyncedAt: null,
+      },
+    ],
+    cloudAdapterFactory: () => adapter,
+  })
+
+  gateway.activate(event(1), 'cloud:one')
+  await gateway.subscribeCloudWorkspaceEvents(event(1), {
+    workspaceId: 'cloud:one',
+    onEvent: () => {},
+  })
+  await gateway.subscribeCloudSessionEvents(event(1), 'same-session-id', {
+    workspaceId: 'cloud:one',
+    onEvent: () => {},
+  })
+  gateway.activate(event(2), 'cloud:one')
+  gateway.activate(event(1), 'cloud:two')
+
+  assert.deepEqual(calls, [])
+
+  gateway.activate(event(2), 'cloud:two')
+
+  assert.deepEqual(calls, ['session-close', 'close'])
+})
+
 test('workspace gateway drops failed cloud event subscriptions before retry', async () => {
   const credentials = new FileCloudWorkspaceCredentialStore({
     path: join(mkdtempSync(join(tmpdir(), 'open-cowork-workspace-event-retry-')), 'cloud-workspace-credentials.json'),
@@ -1003,9 +1107,11 @@ test('workspace gateway marks persisted cloud workspaces online when a usable to
     expiresAt: '2030-05-27T12:00:00.000Z',
   }, new Date('2026-05-27T10:00:00.000Z'))
   let adapterToken: string | null | undefined
+  const removedCacheWorkspaceIds: string[] = []
   const gateway = createWorkspaceGateway({
     cloudRegistry: registry,
     cloudCredentialStore: credentials,
+    cloudCache: recordingCloudCache(removedCacheWorkspaceIds),
     cloudAdapterFactory: (_connection, accessToken) => {
       adapterToken = accessToken
       return {
@@ -1064,6 +1170,7 @@ test('workspace gateway marks persisted cloud workspaces online when a usable to
   gateway.logout(event(1), persisted.id)
   assert.equal(credentials.get(persisted.id), null)
   assert.equal(gateway.list(event(1)).find((entry) => entry.id === persisted.id)?.status, 'auth_required')
+  assert.deepEqual(removedCacheWorkspaceIds, [])
 })
 
 test('workspace gateway login stores cloud tokens without exposing them in workspace info', async () => {


### PR DESCRIPTION
## Summary

- Bound desktop cloud sync hydration for session views and artifact lists, with per-session request coalescing and stale projection cache guards.
- Coalesce cloud SSE projection refreshes in the main process, add active-workspace guards, and back off repeated projection refresh failures.
- Prevent cloud workspace switches from leaking stale session views or lingering inactive subscriptions, and restrict raw credential IPC reads to the local workspace.
- Document cloud desktop cache modes, safeStorage fallback, and logout/remove cache wipe semantics.

Closes #566.

## Validation

- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/ipc-handler-behavior.test.ts tests/cloud-workspace-adapter.test.ts tests/workspace-gateway.test.ts`
- `pnpm --filter @open-cowork/desktop build:electron && pnpm --filter @open-cowork/desktop typecheck`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:cloud-continuation`
- `python3 -m mkdocs build --strict`
- `git diff --check`
