### PR TITLE
Harden cloud client and event contract boundaries

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -1389,6 +1389,18 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
           error,
           { event_type: event.type },
         ))
+      }, {
+        onDroppedEvent(event) {
+          void observability?.metric({
+            name: 'open_cowork_cloud_opencode_events_dropped_total',
+            value: 1,
+            unit: '1',
+            attributes: {
+              sdk_event_type: event.sdkEventType || 'unknown',
+              reason: event.reason,
+            },
+          })
+        },
       })
     : null
   const stopWorkerLoop = worker

--- a/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/opencode-runtime-adapter.ts
@@ -23,8 +23,10 @@ import type { PathProvider } from './path-provider.ts'
 import {
   createSdkCloudRuntimeAdapter,
   type CloudRuntimeAdapter,
+  type CloudRuntimeDroppedEvent,
   type CloudRuntimeEvent,
   type CloudRuntimeEventListener,
+  type CloudRuntimeSubscribeOptions,
 } from './runtime-adapter.ts'
 
 type EventCapableClient = {
@@ -54,6 +56,11 @@ export type NodeOpencodeCloudRuntimeOptions = {
   opencodeBinPath?: string | null
   enableNativeWebSearch?: boolean
   onUnexpectedExit?: (event: ManagedOpencodeServerUnexpectedExit) => void
+}
+
+export type OpencodeRuntimeEventTranslation = {
+  events: CloudRuntimeEvent[]
+  dropped: CloudRuntimeDroppedEvent | null
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -307,12 +314,8 @@ function eventFromSessionStatus(properties: Record<string, unknown>): CloudRunti
   }]
 }
 
-export function translateOpencodeRuntimeEvent(raw: unknown): CloudRuntimeEvent[] {
-  const event = normalizeRuntimeEventEnvelope(raw)
-  if (!event) return []
-  const properties = event.properties || {}
-
-  switch (event.type) {
+function knownOpencodeRuntimeEvents(eventType: string, properties: Record<string, unknown>): CloudRuntimeEvent[] | null {
+  switch (eventType) {
     case 'message.part.updated':
       return eventFromMessagePartUpdated(properties)
     case 'message.updated':
@@ -352,16 +355,54 @@ export function translateOpencodeRuntimeEvent(raw: unknown): CloudRuntimeEvent[]
     case 'todos.updated':
       return eventsFromTodosUpdated(properties)
     default:
-      return []
+      return null
   }
+}
+
+export function translateOpencodeRuntimeEventWithDiagnostics(raw: unknown): OpencodeRuntimeEventTranslation {
+  const event = normalizeRuntimeEventEnvelope(raw)
+  if (!event) {
+    return {
+      events: [],
+      dropped: {
+        sdkEventType: null,
+        reason: 'invalid-envelope',
+      },
+    }
+  }
+  const properties = event.properties || {}
+  const translated = knownOpencodeRuntimeEvents(event.type, properties)
+  if (!translated) {
+    return {
+      events: [],
+      dropped: {
+        sdkEventType: event.type,
+        reason: 'unknown-event-type',
+      },
+    }
+  }
+  return {
+    events: translated,
+    dropped: translated.length === 0
+      ? {
+          sdkEventType: event.type,
+          reason: 'no-projected-events',
+        }
+      : null,
+  }
+}
+
+export function translateOpencodeRuntimeEvent(raw: unknown): CloudRuntimeEvent[] {
+  return translateOpencodeRuntimeEventWithDiagnostics(raw).events
 }
 
 export function subscribeToOpencodeCloudRuntimeEvents(
   client: EventCapableClient,
   listener: CloudRuntimeEventListener,
-  options: { signal?: AbortSignal, onError?: (error: unknown) => void } = {},
+  options: CloudRuntimeSubscribeOptions = {},
 ) {
   if (!client.event?.subscribe) return () => undefined
+  if (options.signal?.aborted) return () => undefined
   const controller = new AbortController()
   const abort = () => controller.abort()
   options.signal?.addEventListener('abort', abort, { once: true })
@@ -370,7 +411,10 @@ export function subscribeToOpencodeCloudRuntimeEvents(
     try {
       const result = await client.event!.subscribe({}, { signal: controller.signal })
       for await (const raw of result.stream) {
-        for (const event of translateOpencodeRuntimeEvent(raw)) {
+        if (controller.signal.aborted) break
+        const translation = translateOpencodeRuntimeEventWithDiagnostics(raw)
+        if (translation.dropped) options.onDroppedEvent?.(translation.dropped)
+        for (const event of translation.events) {
           listener(event)
         }
       }

--- a/apps/desktop/src/main/cloud/runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/runtime-adapter.ts
@@ -19,6 +19,17 @@ export type CloudRuntimeEvent = {
 
 export type CloudRuntimeEventListener = (event: CloudRuntimeEvent) => void | Promise<void>
 
+export type CloudRuntimeDroppedEvent = {
+  sdkEventType: string | null
+  reason: 'invalid-envelope' | 'unknown-event-type' | 'no-projected-events'
+}
+
+export type CloudRuntimeSubscribeOptions = {
+  signal?: AbortSignal
+  onError?: (error: unknown) => void
+  onDroppedEvent?: (event: CloudRuntimeDroppedEvent) => void
+}
+
 export type CloudPromptResult = {
   events?: CloudRuntimeEvent[]
 }
@@ -44,7 +55,7 @@ export type CloudRuntimeAdapter = {
   respondToPermission?(input: { permissionId: string, allowed: boolean, context?: CloudRuntimeExecutionContext | null }): Promise<void>
   subscribeEvents?: (
     listener: CloudRuntimeEventListener,
-    options?: { signal?: AbortSignal, onError?: (error: unknown) => void },
+    options?: CloudRuntimeSubscribeOptions,
   ) => Promise<() => void> | (() => void)
   close?: () => Promise<void> | void
 }

--- a/apps/desktop/src/main/cloud/services/api-token-policy.ts
+++ b/apps/desktop/src/main/cloud/services/api-token-policy.ts
@@ -1,0 +1,78 @@
+import type { ApiTokenRecord, ApiTokenScope } from '../control-plane-store.ts'
+import { CloudServiceError } from '../cloud-service-error.ts'
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+const DEFAULT_API_TOKEN_TTL_MS = 90 * DAY_MS
+const MAX_API_TOKEN_TTL_MS = 365 * DAY_MS
+const DEFAULT_API_TOKEN_ALLOWED_SCOPES = new Set<ApiTokenScope>(['desktop', 'gateway', 'admin', 'operator'])
+
+export type PublicApiTokenRecord = Omit<ApiTokenRecord, 'tokenHash'>
+
+export type CloudIdentityPolicy = {
+  allowSelfServiceSignup: boolean
+  signupMode?: 'disabled' | 'closed' | 'invite' | 'domain' | 'open'
+  allowedEmailDomains?: readonly string[]
+  apiTokenDefaultTtlMs?: number | null
+  apiTokenMaxTtlMs?: number | null
+  apiTokenAllowedScopes?: readonly string[] | null
+}
+
+export function publicApiToken(token: ApiTokenRecord): PublicApiTokenRecord {
+  const { tokenHash: _tokenHash, ...publicToken } = token
+  return publicToken
+}
+
+export function resolvedSignupMode(policy: CloudIdentityPolicy): 'disabled' | 'closed' | 'invite' | 'domain' | 'open' {
+  if (policy.signupMode === 'closed') return 'disabled'
+  if (policy.signupMode) return policy.signupMode
+  if (!policy.allowSelfServiceSignup) return 'invite'
+  return policy.allowedEmailDomains?.length ? 'domain' : 'open'
+}
+
+export function normalizeApiTokenScopes(scopes: ApiTokenScope[] | undefined | null): ApiTokenScope[] {
+  const allowed = new Set<ApiTokenScope>(['desktop', 'gateway', 'admin', 'operator', 'worker-internal'])
+  if ((scopes || []).some((scope) => !allowed.has(scope))) {
+    throw new CloudServiceError(400, 'API token includes an unsupported scope.')
+  }
+  const normalized = [...new Set(scopes || [])]
+  if (normalized.length === 0) throw new CloudServiceError(400, 'API token requires at least one valid scope.')
+  return normalized
+}
+
+function positivePolicyMs(value: number | null | undefined, fallback: number) {
+  return Number.isFinite(value) && Number(value) > 0 ? Math.floor(Number(value)) : fallback
+}
+
+export function normalizeApiTokenExpiresAt(input: Date | null | undefined, policy: CloudIdentityPolicy, now = new Date()) {
+  const defaultTtlMs = positivePolicyMs(policy.apiTokenDefaultTtlMs, DEFAULT_API_TOKEN_TTL_MS)
+  const maxTtlMs = positivePolicyMs(policy.apiTokenMaxTtlMs, MAX_API_TOKEN_TTL_MS)
+  if (defaultTtlMs > maxTtlMs) {
+    throw new CloudServiceError(500, 'API token default TTL cannot exceed the max TTL policy.')
+  }
+  const expiresAt = input || new Date(now.getTime() + defaultTtlMs)
+  if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= now.getTime()) {
+    throw new CloudServiceError(400, 'API token expiration must be in the future.')
+  }
+  if (expiresAt.getTime() - now.getTime() > maxTtlMs) {
+    throw new CloudServiceError(400, `API token expiration cannot be more than ${Math.floor(maxTtlMs / DAY_MS)} days in the future.`)
+  }
+  return expiresAt
+}
+
+function normalizeAllowedApiTokenScopePolicy(policy: CloudIdentityPolicy) {
+  const configured = policy.apiTokenAllowedScopes?.length
+    ? policy.apiTokenAllowedScopes
+    : [...DEFAULT_API_TOKEN_ALLOWED_SCOPES]
+  const normalized = normalizeApiTokenScopes(configured as ApiTokenScope[])
+  return new Set<ApiTokenScope>(normalized)
+}
+
+export function enforceApiTokenScopePolicy(scopes: ApiTokenScope[], policy: CloudIdentityPolicy) {
+  const allowed = normalizeAllowedApiTokenScopePolicy(policy)
+  const denied = scopes.filter((scope) => !allowed.has(scope))
+  if (denied.length > 0) {
+    throw new CloudServiceError(403, `API token scope is disabled by cloud policy: ${denied.join(', ')}.`)
+  }
+  return scopes
+}

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -32,7 +32,6 @@ import {
   listCapabilityTools,
 } from '../capability-catalog.ts'
 import type {
-  ApiTokenRecord,
   ApiTokenScope,
   BillingSubscriptionRecord,
   ChannelBindingRecord,
@@ -113,6 +112,15 @@ import {
   type QuestionRejectPayload,
   type QuestionReplyPayload,
 } from './services/session-command-service.ts'
+import {
+  enforceApiTokenScopePolicy,
+  normalizeApiTokenExpiresAt,
+  normalizeApiTokenScopes,
+  publicApiToken,
+  resolvedSignupMode,
+  type CloudIdentityPolicy,
+  type PublicApiTokenRecord,
+} from './services/api-token-policy.ts'
 import {
   CloudManagedWorkerService,
   type CreateManagedWorkerPoolRequest,
@@ -304,7 +312,7 @@ export type CloudDiagnosticsBundle = {
   }
 }
 
-export type PublicApiTokenRecord = Omit<ApiTokenRecord, 'tokenHash'>
+export type { CloudIdentityPolicy, PublicApiTokenRecord } from './services/api-token-policy.ts'
 export type { PublicChannelBindingRecord, PublicChannelDeliveryRecord } from './public-channel-records.ts'
 
 export type IssuedPublicApiTokenRecord = {
@@ -340,15 +348,6 @@ export type ByokManagementPolicy = {
   checkEntitlement?: ByokEntitlementChecker | null
   checkRuntimeEntitlement?: ByokRuntimeEntitlementChecker | null
   kmsRefs?: ByokKmsRefPolicy | null
-}
-
-export type CloudIdentityPolicy = {
-  allowSelfServiceSignup: boolean
-  signupMode?: 'disabled' | 'closed' | 'invite' | 'domain' | 'open'
-  allowedEmailDomains?: readonly string[]
-  apiTokenDefaultTtlMs?: number | null
-  apiTokenMaxTtlMs?: number | null
-  apiTokenAllowedScopes?: readonly string[] | null
 }
 
 export { CloudServiceError } from './cloud-service-error.ts'
@@ -404,9 +403,6 @@ const WEBHOOK_SIGNATURE_REPLAY_WINDOW_MS = 5 * 60 * 1000
 const WEBHOOK_SIGNATURE_REPLAY_CACHE_LIMIT = 512
 const HOUR_MS = 60 * 60 * 1000
 const DAY_MS = 24 * HOUR_MS
-const DEFAULT_API_TOKEN_TTL_MS = 90 * DAY_MS
-const MAX_API_TOKEN_TTL_MS = 365 * DAY_MS
-const DEFAULT_API_TOKEN_ALLOWED_SCOPES = new Set<ApiTokenScope>(['desktop', 'gateway', 'admin', 'operator'])
 
 const DISABLED_ABUSE_POLICY: CloudAbuseConfig = {
   enabled: false,
@@ -514,65 +510,6 @@ function principalCanManageOrg(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
   return principal.role === 'owner' || principal.role === 'admin'
-}
-
-function publicApiToken(token: ApiTokenRecord): PublicApiTokenRecord {
-  const { tokenHash: _tokenHash, ...publicToken } = token
-  return publicToken
-}
-
-function resolvedSignupMode(policy: CloudIdentityPolicy): 'disabled' | 'closed' | 'invite' | 'domain' | 'open' {
-  if (policy.signupMode === 'closed') return 'disabled'
-  if (policy.signupMode) return policy.signupMode
-  if (!policy.allowSelfServiceSignup) return 'invite'
-  return policy.allowedEmailDomains?.length ? 'domain' : 'open'
-}
-
-function normalizeApiTokenScopes(scopes: ApiTokenScope[] | undefined | null): ApiTokenScope[] {
-  const allowed = new Set<ApiTokenScope>(['desktop', 'gateway', 'admin', 'operator', 'worker-internal'])
-  if ((scopes || []).some((scope) => !allowed.has(scope))) {
-    throw new CloudServiceError(400, 'API token includes an unsupported scope.')
-  }
-  const normalized = [...new Set(scopes || [])]
-  if (normalized.length === 0) throw new CloudServiceError(400, 'API token requires at least one valid scope.')
-  return normalized
-}
-
-function positivePolicyMs(value: number | null | undefined, fallback: number) {
-  return Number.isFinite(value) && Number(value) > 0 ? Math.floor(Number(value)) : fallback
-}
-
-function normalizeApiTokenExpiresAt(input: Date | null | undefined, policy: CloudIdentityPolicy, now = new Date()) {
-  const defaultTtlMs = positivePolicyMs(policy.apiTokenDefaultTtlMs, DEFAULT_API_TOKEN_TTL_MS)
-  const maxTtlMs = positivePolicyMs(policy.apiTokenMaxTtlMs, MAX_API_TOKEN_TTL_MS)
-  if (defaultTtlMs > maxTtlMs) {
-    throw new CloudServiceError(500, 'API token default TTL cannot exceed the max TTL policy.')
-  }
-  const expiresAt = input || new Date(now.getTime() + defaultTtlMs)
-  if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= now.getTime()) {
-    throw new CloudServiceError(400, 'API token expiration must be in the future.')
-  }
-  if (expiresAt.getTime() - now.getTime() > maxTtlMs) {
-    throw new CloudServiceError(400, `API token expiration cannot be more than ${Math.floor(maxTtlMs / DAY_MS)} days in the future.`)
-  }
-  return expiresAt
-}
-
-function normalizeAllowedApiTokenScopePolicy(policy: CloudIdentityPolicy) {
-  const configured = policy.apiTokenAllowedScopes?.length
-    ? policy.apiTokenAllowedScopes
-    : [...DEFAULT_API_TOKEN_ALLOWED_SCOPES]
-  const normalized = normalizeApiTokenScopes(configured as ApiTokenScope[])
-  return new Set<ApiTokenScope>(normalized)
-}
-
-function enforceApiTokenScopePolicy(scopes: ApiTokenScope[], policy: CloudIdentityPolicy) {
-  const allowed = normalizeAllowedApiTokenScopePolicy(policy)
-  const denied = scopes.filter((scope) => !allowed.has(scope))
-  if (denied.length > 0) {
-    throw new CloudServiceError(403, `API token scope is disabled by cloud policy: ${denied.join(', ')}.`)
-  }
-  return scopes
 }
 
 function normalizeByokProviderIdForPolicy(value: string) {

--- a/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
@@ -11,6 +11,7 @@ import type { PathProvider } from './path-provider.ts'
 import { createCloudSessionPathProvider } from './path-provider.ts'
 import type {
   CloudRuntimeAdapter,
+  CloudRuntimeDroppedEvent,
   CloudRuntimeEvent,
   CloudRuntimeEventListener,
   CloudRuntimeExecutionContext,
@@ -51,6 +52,11 @@ type RuntimeEntry = {
   lastUsedAt: number
 }
 
+type RuntimeEventSubscription = {
+  onError?: (error: unknown) => void
+  onDroppedEvent?: (event: CloudRuntimeDroppedEvent) => void
+}
+
 const DEFAULT_MAX_RUNTIME_ENTRIES = 100
 const DEFAULT_RUNTIME_IDLE_TTL_MS = 30 * 60 * 1000
 
@@ -79,7 +85,7 @@ function mapRuntimeEventToCoworkSession(context: CloudRuntimeExecutionContext, e
 
 export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAdapterOptions): CloudRuntimeAdapter {
   const runtimes = new Map<string, RuntimeEntry>()
-  const listeners = new Map<CloudRuntimeEventListener, { onError?: (error: unknown) => void }>()
+  const listeners = new Map<CloudRuntimeEventListener, RuntimeEventSubscription>()
   const maxRuntimeEntries = Math.max(1, Math.floor(options.maxRuntimeEntries || DEFAULT_MAX_RUNTIME_ENTRIES))
   const runtimeIdleTtlMs = Math.max(1, Math.floor(options.runtimeIdleTtlMs || DEFAULT_RUNTIME_IDLE_TTL_MS))
 
@@ -95,6 +101,9 @@ export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAda
       {
         onError(error) {
           for (const entry of listeners.values()) entry.onError?.(error)
+        },
+        onDroppedEvent(event) {
+          for (const entry of listeners.values()) entry.onDroppedEvent?.(event)
         },
       },
     )
@@ -257,15 +266,22 @@ export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAda
       })
     },
     async subscribeEvents(listener, subscribeOptions) {
-      listeners.set(listener, { onError: subscribeOptions?.onError })
+      if (subscribeOptions?.signal?.aborted) return () => undefined
+      listeners.set(listener, {
+        onError: subscribeOptions?.onError,
+        onDroppedEvent: subscribeOptions?.onDroppedEvent,
+      })
+      const unsubscribeListener = () => {
+        subscribeOptions?.signal?.removeEventListener('abort', unsubscribeListener)
+        listeners.delete(listener)
+      }
+      subscribeOptions?.signal?.addEventListener('abort', unsubscribeListener, { once: true })
       for (const [key, entry] of runtimes.entries()) {
         if (entry.unsubscribe) continue
         const [tenantId, sessionId] = key.split('\0')
         entry.unsubscribe = await subscribeRuntimeEvents({ tenantId, sessionId }, entry.adapter)
       }
-      return () => {
-        listeners.delete(listener)
-      }
+      return unsubscribeListener
     },
     async close() {
       for (const [key, entry] of Array.from(runtimes.entries())) {

--- a/docs/cloud-client.md
+++ b/docs/cloud-client.md
@@ -1,0 +1,100 @@
+---
+title: Cloud Client SDK
+description: Public package contract for the typed Open Cowork Cloud HTTP and SSE client.
+---
+
+# Cloud Client SDK
+
+`@open-cowork/cloud-client` is the supported typed client for Open Cowork Cloud.
+Desktop cloud workspaces, Cloud Web, Gateway, and downstream clients should use
+this package instead of importing Cloud control-plane internals.
+
+## Contract
+
+- The client talks to Open Cowork Cloud product APIs over HTTP and SSE.
+- It does not import Electron, Desktop main-process modules, control-plane
+  stores, Postgres modules, or `@opencode-ai/sdk`.
+- It may depend on `@open-cowork/shared`, which is the public package for
+  shared Open Cowork product and wire types.
+- OpenCode still owns execution. The client only creates sessions, sends
+  product commands, reads projections, subscribes to events, and manages
+  product surfaces such as workflows, artifacts, BYOK metadata, and channel
+  deliveries.
+- While Open Cowork is pre-1.0, typed API changes can happen in minor releases.
+  Breaking changes after `1.0.0` require a major version.
+
+## Entry Points
+
+```ts
+import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
+import type { CloudTransportAdapter } from '@open-cowork/cloud-client/adapter'
+import type { SessionListPage } from '@open-cowork/cloud-client/domains/sessions'
+```
+
+The package exports only compiled `dist` entry points:
+
+- `@open-cowork/cloud-client`
+- `@open-cowork/cloud-client/adapter`
+- `@open-cowork/cloud-client/domains/artifacts`
+- `@open-cowork/cloud-client/domains/billing`
+- `@open-cowork/cloud-client/domains/byok`
+- `@open-cowork/cloud-client/domains/capabilities`
+- `@open-cowork/cloud-client/domains/channels`
+- `@open-cowork/cloud-client/domains/config`
+- `@open-cowork/cloud-client/domains/identity`
+- `@open-cowork/cloud-client/domains/sessions`
+- `@open-cowork/cloud-client/domains/settings`
+- `@open-cowork/cloud-client/domains/threads`
+- `@open-cowork/cloud-client/domains/transport`
+- `@open-cowork/cloud-client/domains/workflows`
+
+## Node Or Daemon Client
+
+```ts
+import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
+
+const client = createHttpSseCloudTransportAdapter({
+  baseUrl: 'https://cowork.example.com',
+  headers: { authorization: `Bearer ${token}` },
+  requestTimeoutMs: 30_000,
+})
+
+const session = await client.createSession({ profileName: 'default' })
+await client.promptSession(session.session.sessionId, { text: 'Run the release checks' })
+```
+
+## Browser Client
+
+```ts
+const client = createHttpSseCloudTransportAdapter({
+  baseUrl: window.location.origin,
+  credentials: 'include',
+  csrfToken: bootstrap.csrfToken,
+})
+```
+
+## Timeouts And Cancellation
+
+`requestTimeoutMs` defaults to 30 seconds. Use `signal` to cancel in-flight HTTP
+requests and SSE subscriptions:
+
+```ts
+const controller = new AbortController()
+const client = createHttpSseCloudTransportAdapter({
+  baseUrl: 'https://cowork.example.com',
+  headers: { authorization: `Bearer ${token}` },
+  signal: controller.signal,
+})
+
+controller.abort()
+```
+
+The client does not retry automatically. Callers should choose retries per
+operation because mutating Cloud commands are durable and may be idempotency
+aware on the server.
+
+## SSE Authentication
+
+Bearer-token clients use fetch-based SSE so the `Authorization` header is sent
+with stream requests. Cookie-authenticated browser clients use `EventSource`
+when no custom headers are configured.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -102,6 +102,10 @@ The following are treated as breaking and bump the major version:
 - **Preload API** — removing a method from `window.coworkApi`, or
   changing the shape of an existing method's parameters or return
   type.
+- **Published package API** — removing or renaming a public export from
+  `@open-cowork/cloud-client` or `@open-cowork/shared`, changing a
+  documented cloud-client domain entry point, or changing exported wire
+  types in a way that breaks downstream TypeScript consumers.
 - **IPC channels** — removing a handler, or changing the shape of
   the request / response payload for an existing channel.
 - **Branded data-directory layout** — changing where `sessions.json`

--- a/knip.json
+++ b/knip.json
@@ -65,6 +65,16 @@
         "src/**/*.ts"
       ]
     },
+    "packages/cloud-client": {
+      "entry": [
+        "src/index.ts",
+        "test/public-import-smoke.mjs"
+      ],
+      "project": [
+        "src/**/*.ts",
+        "test/**/*.mjs"
+      ]
+    },
     "mcps/charts": {
       "entry": [
         "src/index.ts"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Architecture: architecture.md
       - Product Contract: product-contract.md
       - Cloud Web Workbench: cloud-web-workbench.md
+      - Cloud Client SDK: cloud-client.md
       - Gateway Provider Readiness: gateway-provider-readiness.md
       - Downstream Customization: downstream.md
       - Downstream Contract: downstream-contract.md

--- a/packages/cloud-client/README.md
+++ b/packages/cloud-client/README.md
@@ -1,0 +1,74 @@
+# @open-cowork/cloud-client
+
+Typed HTTP and SSE client for Open Cowork Cloud.
+
+## Support Status
+
+`@open-cowork/cloud-client` is a supported public package surface for Open
+Cowork clients and downstream deployers. The package is still versioned with
+the repository while Open Cowork is pre-1.0, so typed API changes may occur in
+minor releases until `1.0.0`. Runtime execution remains owned by OpenCode; this
+client only talks to Open Cowork Cloud product APIs.
+
+## Entry Points
+
+- `@open-cowork/cloud-client`
+- `@open-cowork/cloud-client/adapter`
+- `@open-cowork/cloud-client/domains/artifacts`
+- `@open-cowork/cloud-client/domains/billing`
+- `@open-cowork/cloud-client/domains/byok`
+- `@open-cowork/cloud-client/domains/capabilities`
+- `@open-cowork/cloud-client/domains/channels`
+- `@open-cowork/cloud-client/domains/config`
+- `@open-cowork/cloud-client/domains/identity`
+- `@open-cowork/cloud-client/domains/sessions`
+- `@open-cowork/cloud-client/domains/settings`
+- `@open-cowork/cloud-client/domains/threads`
+- `@open-cowork/cloud-client/domains/transport`
+- `@open-cowork/cloud-client/domains/workflows`
+
+The package must not import Electron, Desktop main-process modules,
+control-plane stores, or `@opencode-ai/sdk`. Its only Open Cowork package
+dependency is the public `@open-cowork/shared` wire-type package.
+
+## Basic Usage
+
+```ts
+import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
+
+const client = createHttpSseCloudTransportAdapter({
+  baseUrl: 'https://cowork.example.com',
+  headers: { authorization: `Bearer ${token}` },
+  requestTimeoutMs: 30_000,
+})
+
+const session = await client.createSession({ profileName: 'default' })
+await client.promptSession(session.session.sessionId, { text: 'Run the checks' })
+```
+
+## Browser Cookie Usage
+
+```ts
+import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
+
+const client = createHttpSseCloudTransportAdapter({
+  baseUrl: window.location.origin,
+  credentials: 'include',
+  csrfToken: bootstrap.csrfToken,
+})
+```
+
+## Timeouts, Cancellation, And Retries
+
+- `requestTimeoutMs` defaults to 30 seconds and is clamped to a safe maximum.
+- `signal` cancels all HTTP requests and SSE subscriptions created from the
+  client.
+- The client does not retry automatically. Callers should decide retries per
+  command because some mutating operations are intentionally durable and
+  idempotency-aware on the server.
+
+## SSE Authentication
+
+When `headers` are configured, SSE subscriptions use fetch-based SSE so bearer
+tokens are sent with the stream request. Without headers, the browser
+`EventSource` path is used for cookie-authenticated deployments.

--- a/packages/cloud-client/package.json
+++ b/packages/cloud-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-cowork/cloud-client",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "description": "Typed Open Cowork Cloud HTTP and SSE client",
   "author": "Joe Broadhead",
   "license": "MIT",
@@ -13,9 +13,77 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./adapter": {
+      "types": "./dist/adapter.d.ts",
+      "import": "./dist/adapter.js"
+    },
+    "./domains/artifacts": {
+      "types": "./dist/domains/artifacts.d.ts",
+      "import": "./dist/domains/artifacts.js"
+    },
+    "./domains/billing": {
+      "types": "./dist/domains/billing.d.ts",
+      "import": "./dist/domains/billing.js"
+    },
+    "./domains/byok": {
+      "types": "./dist/domains/byok.d.ts",
+      "import": "./dist/domains/byok.js"
+    },
+    "./domains/capabilities": {
+      "types": "./dist/domains/capabilities.d.ts",
+      "import": "./dist/domains/capabilities.js"
+    },
+    "./domains/channels": {
+      "types": "./dist/domains/channels.d.ts",
+      "import": "./dist/domains/channels.js"
+    },
+    "./domains/config": {
+      "types": "./dist/domains/config.d.ts",
+      "import": "./dist/domains/config.js"
+    },
+    "./domains/identity": {
+      "types": "./dist/domains/identity.d.ts",
+      "import": "./dist/domains/identity.js"
+    },
+    "./domains/sessions": {
+      "types": "./dist/domains/sessions.d.ts",
+      "import": "./dist/domains/sessions.js"
+    },
+    "./domains/settings": {
+      "types": "./dist/domains/settings.d.ts",
+      "import": "./dist/domains/settings.js"
+    },
+    "./domains/threads": {
+      "types": "./dist/domains/threads.d.ts",
+      "import": "./dist/domains/threads.js"
+    },
+    "./domains/transport": {
+      "types": "./dist/domains/transport.d.ts",
+      "import": "./dist/domains/transport.js"
+    },
+    "./domains/workflows": {
+      "types": "./dist/domains/workflows.d.ts",
+      "import": "./dist/domains/workflows.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "pnpm --filter @open-cowork/shared build && pnpm --filter @open-cowork/cloud-client build && node test/public-import-smoke.mjs"
   },
   "dependencies": {
     "@open-cowork/shared": "workspace:*"

--- a/packages/cloud-client/src/adapter.ts
+++ b/packages/cloud-client/src/adapter.ts
@@ -519,6 +519,7 @@ export type CloudTransportAdapterOptions = {
   credentials?: 'include'
   headers?: Record<string, string>
   requestTimeoutMs?: number
+  signal?: AbortSignal
 }
 
 export type CloudTransportSubscription = {
@@ -940,20 +941,32 @@ function subscribeEventSource(
     credentials?: 'include'
     onEvent: (event: CloudTransportWorkspaceEvent) => void
     onError?: (error: unknown) => void
+    signal?: AbortSignal
   },
 ) {
   const source = new EventSourceImpl(url, {
     withCredentials: input.credentials === 'include',
   })
+  let closed = false
   const onEvent = (event: { data: string }) => {
     const parsed = JSON.parse(event.data) as CloudTransportWorkspaceEvent
     input.onEvent(parsed)
   }
   source.onmessage = onEvent
   for (const type of CLOUD_SESSION_EVENT_TYPES) source.addEventListener(type, onEvent)
-  source.onerror = (error) => input.onError?.(error)
+  source.onerror = (error) => {
+    if (!closed) input.onError?.(error)
+  }
+  const abort = () => {
+    closed = true
+    source.close()
+  }
+  if (input.signal?.aborted) abort()
+  else input.signal?.addEventListener('abort', abort, { once: true })
   return {
     close() {
+      closed = true
+      input.signal?.removeEventListener('abort', abort)
       source.close()
     },
   }
@@ -967,10 +980,14 @@ function subscribeFetchSse(
     credentials?: 'include'
     onEvent: (event: CloudTransportWorkspaceEvent) => void
     onError?: (error: unknown) => void
+    signal?: AbortSignal
   },
 ) {
   const controller = new AbortController()
   let closed = false
+  const detachAbortSignal = attachAbortSignal(controller, input.signal, () => {
+    closed = true
+  })
 
   const dispatch = (dataLines: string[]) => {
     if (dataLines.length === 0) return
@@ -979,60 +996,64 @@ function subscribeFetchSse(
   }
 
   void (async () => {
-    const response = await fetcher(url, {
-      method: 'GET',
-      headers: {
-        ...(input.headers || {}),
-        accept: 'text/event-stream',
-      },
-      credentials: input.credentials,
-      signal: controller.signal,
-    })
-    if (!response.ok) {
-      throw new Error(`Cloud transport SSE subscription failed with HTTP ${response.status}: ${url}`)
-    }
-    if (!response.body) {
-      throw new Error('Cloud transport SSE response did not include a readable stream.')
-    }
-
-    const reader = response.body.getReader()
-    const decoder = new TextDecoder()
-    let buffered = ''
-    let dataLines: string[] = []
-
-    const processLine = (rawLine: string) => {
-      const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
-      if (line === '') {
-        dispatch(dataLines)
-        dataLines = []
-        return
-      }
-      if (line.startsWith(':')) return
-      const delimiter = line.indexOf(':')
-      const field = delimiter === -1 ? line : line.slice(0, delimiter)
-      const value = delimiter === -1
-        ? ''
-        : line.slice(delimiter + 1).replace(/^ /, '')
-      if (field === 'data') dataLines.push(value)
-    }
-
     try {
-      while (!closed) {
-        const chunk = await reader.read()
-        if (chunk.done) break
-        buffered += decoder.decode(chunk.value, { stream: true })
-        let newlineIndex = buffered.indexOf('\n')
-        while (newlineIndex >= 0) {
-          processLine(buffered.slice(0, newlineIndex))
-          buffered = buffered.slice(newlineIndex + 1)
-          newlineIndex = buffered.indexOf('\n')
-        }
+      const response = await fetcher(url, {
+        method: 'GET',
+        headers: {
+          ...(input.headers || {}),
+          accept: 'text/event-stream',
+        },
+        credentials: input.credentials,
+        signal: controller.signal,
+      })
+      if (!response.ok) {
+        throw new Error(`Cloud transport SSE subscription failed with HTTP ${response.status}: ${url}`)
       }
-      buffered += decoder.decode()
-      if (buffered) processLine(buffered)
-      dispatch(dataLines)
+      if (!response.body) {
+        throw new Error('Cloud transport SSE response did not include a readable stream.')
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffered = ''
+      let dataLines: string[] = []
+
+      const processLine = (rawLine: string) => {
+        const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+        if (line === '') {
+          dispatch(dataLines)
+          dataLines = []
+          return
+        }
+        if (line.startsWith(':')) return
+        const delimiter = line.indexOf(':')
+        const field = delimiter === -1 ? line : line.slice(0, delimiter)
+        const value = delimiter === -1
+          ? ''
+          : line.slice(delimiter + 1).replace(/^ /, '')
+        if (field === 'data') dataLines.push(value)
+      }
+
+      try {
+        while (!closed) {
+          const chunk = await reader.read()
+          if (chunk.done) break
+          buffered += decoder.decode(chunk.value, { stream: true })
+          let newlineIndex = buffered.indexOf('\n')
+          while (newlineIndex >= 0) {
+            processLine(buffered.slice(0, newlineIndex))
+            buffered = buffered.slice(newlineIndex + 1)
+            newlineIndex = buffered.indexOf('\n')
+          }
+        }
+        buffered += decoder.decode()
+        if (buffered) processLine(buffered)
+        dispatch(dataLines)
+      } finally {
+        reader.releaseLock()
+      }
     } finally {
-      reader.releaseLock()
+      detachAbortSignal()
     }
   })().catch((error) => {
     if (!closed) input.onError?.(error)
@@ -1041,6 +1062,7 @@ function subscribeFetchSse(
   return {
     close() {
       closed = true
+      detachAbortSignal()
       controller.abort()
     },
   }
@@ -1075,6 +1097,24 @@ function cloudApiRequestUrl(baseUrl: string, path: string) {
     throw new Error('Cloud transport path must target an API route.')
   }
   return `${baseUrl}${path}`
+}
+
+function attachAbortSignal(
+  controller: AbortController,
+  signal: AbortSignal | null | undefined,
+  onAbort?: () => void,
+) {
+  if (!signal) return () => undefined
+  const abort = () => {
+    onAbort?.()
+    controller.abort(signal.reason)
+  }
+  if (signal.aborted) {
+    abort()
+    return () => undefined
+  }
+  signal.addEventListener('abort', abort, { once: true })
+  return () => signal.removeEventListener('abort', abort)
 }
 
 async function parseJson<T>(response: Awaited<ReturnType<CloudTransportFetch>>, url: string): Promise<T> {
@@ -1114,6 +1154,7 @@ export function createHttpSseCloudTransportAdapter(
     }
     const requestUrl = cloudApiRequestUrl(baseUrl, path)
     const controller = new AbortController()
+    const detachAbortSignal = attachAbortSignal(controller, options.signal)
     const timeout = requestTimeoutMs > 0
       ? setTimeout(() => controller.abort(), requestTimeoutMs)
       : null
@@ -1131,6 +1172,7 @@ export function createHttpSseCloudTransportAdapter(
       return parseJson<T>(response, path)
     } finally {
       if (timeout) clearTimeout(timeout)
+      detachAbortSignal()
     }
   }
 
@@ -1605,6 +1647,7 @@ export function createHttpSseCloudTransportAdapter(
         return subscribeFetchSse(fetcher, url, {
           headers,
           credentials: options.credentials,
+          signal: options.signal,
           onEvent,
           onError: input.onError,
         })
@@ -1613,6 +1656,7 @@ export function createHttpSseCloudTransportAdapter(
       if (!EventSourceImpl) throw new Error('EventSource is not available for cloud delivery subscriptions.')
       return subscribeEventSource(EventSourceImpl, url, {
         credentials: options.credentials,
+        signal: options.signal,
         onEvent,
         onError: input.onError,
       })
@@ -1628,6 +1672,7 @@ export function createHttpSseCloudTransportAdapter(
         return subscribeFetchSse(fetcher, workspaceEventUrl(baseUrl, input.afterSequence), {
           headers,
           credentials: options.credentials,
+          signal: options.signal,
           onEvent: input.onEvent,
           onError: input.onError,
         })
@@ -1636,6 +1681,7 @@ export function createHttpSseCloudTransportAdapter(
       if (!EventSourceImpl) throw new Error('EventSource is not available for cloud transport subscriptions.')
       return subscribeEventSource(EventSourceImpl, workspaceEventUrl(baseUrl, input.afterSequence), {
         credentials: options.credentials,
+        signal: options.signal,
         onEvent: input.onEvent,
         onError: input.onError,
       })
@@ -1645,6 +1691,7 @@ export function createHttpSseCloudTransportAdapter(
         return subscribeFetchSse(fetcher, eventUrl(baseUrl, sessionId, input.afterSequence), {
           headers,
           credentials: options.credentials,
+          signal: options.signal,
           onEvent: input.onEvent,
           onError: input.onError,
         })
@@ -1653,6 +1700,7 @@ export function createHttpSseCloudTransportAdapter(
       if (!EventSourceImpl) throw new Error('EventSource is not available for cloud transport subscriptions.')
       return subscribeEventSource(EventSourceImpl, eventUrl(baseUrl, sessionId, input.afterSequence), {
         credentials: options.credentials,
+        signal: options.signal,
         onEvent: input.onEvent,
         onError: input.onError,
       })

--- a/packages/cloud-client/test/public-import-smoke.mjs
+++ b/packages/cloud-client/test/public-import-smoke.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+
+const root = await import('@open-cowork/cloud-client')
+const adapter = await import('@open-cowork/cloud-client/adapter')
+const domains = [
+  'artifacts',
+  'billing',
+  'byok',
+  'capabilities',
+  'channels',
+  'config',
+  'identity',
+  'sessions',
+  'settings',
+  'threads',
+  'transport',
+  'workflows',
+]
+
+assert.equal(typeof root.createHttpSseCloudTransportAdapter, 'function')
+assert.equal(typeof adapter.createHttpSseCloudTransportAdapter, 'function')
+
+for (const domain of domains) {
+  const imported = await import(`@open-cowork/cloud-client/domains/${domain}`)
+  assert.equal(typeof imported, 'object', domain)
+}
+
+await assert.rejects(
+  import('@open-cowork/cloud-client/src/adapter.ts'),
+  /Package subpath|Cannot find package|not defined by "exports"/,
+)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@open-cowork/shared",
   "version": "0.0.0",
-  "private": true,
-  "description": "Shared Open Cowork preload and renderer types",
+  "private": false,
+  "description": "Shared Open Cowork product and wire types",
   "author": "Joe Broadhead",
   "license": "MIT",
   "repository": {
@@ -13,6 +13,20 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "node ../../scripts/clean-shared-dist.mjs && tsc && node ../../scripts/check-shared-dist.mjs",
     "typecheck": "tsc --noEmit"

--- a/tests/cloud-api-token-policy.test.ts
+++ b/tests/cloud-api-token-policy.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  enforceApiTokenScopePolicy,
+  normalizeApiTokenExpiresAt,
+  normalizeApiTokenScopes,
+  resolvedSignupMode,
+} from '../apps/desktop/src/main/cloud/services/api-token-policy.ts'
+import { CloudServiceError } from '../apps/desktop/src/main/cloud/cloud-service-error.ts'
+
+test('cloud API token policy normalizes TTL, scope, and signup policy outside session service', () => {
+  assert.deepEqual(normalizeApiTokenScopes(['desktop', 'desktop', 'gateway']), ['desktop', 'gateway'])
+  assert.deepEqual(enforceApiTokenScopePolicy(['desktop'], {
+    allowSelfServiceSignup: true,
+    apiTokenAllowedScopes: ['desktop'],
+  }), ['desktop'])
+  assert.equal(resolvedSignupMode({ allowSelfServiceSignup: false }), 'invite')
+  assert.equal(resolvedSignupMode({ allowSelfServiceSignup: true, allowedEmailDomains: ['example.com'] }), 'domain')
+
+  const now = new Date('2026-05-31T12:00:00.000Z')
+  assert.equal(
+    normalizeApiTokenExpiresAt(null, {
+      allowSelfServiceSignup: true,
+      apiTokenDefaultTtlMs: 1000,
+      apiTokenMaxTtlMs: 2000,
+    }, now).toISOString(),
+    '2026-05-31T12:00:01.000Z',
+  )
+})
+
+test('cloud API token policy rejects unsupported or disabled scopes', () => {
+  assert.throws(() => normalizeApiTokenScopes(['unsupported' as never]), CloudServiceError)
+  assert.throws(() => normalizeApiTokenScopes([]), CloudServiceError)
+  assert.throws(() => enforceApiTokenScopePolicy(['admin'], {
+    allowSelfServiceSignup: true,
+    apiTokenAllowedScopes: ['desktop'],
+  }), /disabled by cloud policy/)
+})

--- a/tests/cloud-client-boundary.test.ts
+++ b/tests/cloud-client-boundary.test.ts
@@ -7,13 +7,78 @@ test('cloud client package is standalone and desktop transport is a compatibilit
   const root = process.cwd()
   const packageJson = JSON.parse(readFileSync(join(root, 'packages/cloud-client/package.json'), 'utf8')) as {
     name?: string
+    private?: boolean
+    exports?: Record<string, unknown>
+    files?: string[]
+    sideEffects?: boolean
+    dependencies?: Record<string, string>
+  }
+  const sharedPackageJson = JSON.parse(readFileSync(join(root, 'packages/shared/package.json'), 'utf8')) as {
+    name?: string
+    private?: boolean
+    exports?: Record<string, unknown>
+    files?: string[]
+    sideEffects?: boolean
   }
   const clientSource = clientSources(join(root, 'packages/cloud-client/src')).join('\n')
   const desktopTransport = readFileSync(join(root, 'apps/desktop/src/main/cloud/transport-adapter.ts'), 'utf8')
+  const readme = readFileSync(join(root, 'packages/cloud-client/README.md'), 'utf8')
+  const docs = readFileSync(join(root, 'docs/cloud-client.md'), 'utf8')
 
   assert.equal(packageJson.name, '@open-cowork/cloud-client')
-  assert.doesNotMatch(clientSource, /apps\/desktop|control-plane-store|session-service/)
+  assert.equal(packageJson.private, false)
+  assert.equal(packageJson.sideEffects, false)
+  assert.deepEqual(packageJson.files, ['dist', 'README.md'])
+  const publicExports = [
+    '.',
+    './adapter',
+    './domains/artifacts',
+    './domains/billing',
+    './domains/byok',
+    './domains/capabilities',
+    './domains/channels',
+    './domains/config',
+    './domains/identity',
+    './domains/sessions',
+    './domains/settings',
+    './domains/threads',
+    './domains/transport',
+    './domains/workflows',
+    './package.json',
+  ].sort()
+  assert.deepEqual(Object.keys(packageJson.exports || {}).sort(), publicExports)
+  assert.equal(sharedPackageJson.name, '@open-cowork/shared')
+  assert.equal(sharedPackageJson.private, false)
+  assert.deepEqual(Object.keys(sharedPackageJson.exports || {}).sort(), ['.', './package.json'])
+  assert.deepEqual(sharedPackageJson.files, ['dist'])
+  assert.equal(sharedPackageJson.sideEffects, false)
+  for (const dependencyName of Object.keys(packageJson.dependencies || {})) {
+    if (!dependencyName.startsWith('@open-cowork/')) continue
+    const dependencyPackage = JSON.parse(readFileSync(join(root, `packages/${dependencyName.replace('@open-cowork/', '')}/package.json`), 'utf8')) as { private?: boolean }
+    assert.equal(dependencyPackage.private, false, `${dependencyName} must be publishable because cloud-client is public`)
+  }
+  assert.doesNotMatch(clientSource, /apps\/desktop|control-plane-store|session-service|@opencode-ai\/sdk/)
   assert.equal(desktopTransport.trim(), "export * from '../../../../../packages/cloud-client/src/index.ts'")
+  for (const document of [readme, docs]) {
+    assert.match(document, /supported public package|supported typed client/i)
+    assert.match(document, /pre-1\.0|SemVer|semver/i)
+    assert.match(document, /requestTimeoutMs/i)
+    assert.match(document, /signal/i)
+    assert.match(document, /does not retry automatically/i)
+  }
+})
+
+test('cloud API token policy is extracted from the monolithic session service', () => {
+  const root = process.cwd()
+  const policySource = readFileSync(join(root, 'apps/desktop/src/main/cloud/services/api-token-policy.ts'), 'utf8')
+  const sessionService = readFileSync(join(root, 'apps/desktop/src/main/cloud/session-service.ts'), 'utf8')
+
+  assert.match(policySource, /export function normalizeApiTokenScopes/)
+  assert.match(policySource, /export function normalizeApiTokenExpiresAt/)
+  assert.match(policySource, /export function enforceApiTokenScopePolicy/)
+  assert.doesNotMatch(sessionService, /function normalizeApiTokenScopes/)
+  assert.doesNotMatch(sessionService, /function normalizeApiTokenExpiresAt/)
+  assert.doesNotMatch(sessionService, /function enforceApiTokenScopePolicy/)
 })
 
 function clientSources(directory: string): string[] {

--- a/tests/cloud-opencode-runtime-adapter.test.ts
+++ b/tests/cloud-opencode-runtime-adapter.test.ts
@@ -11,6 +11,7 @@ import {
   createNodeOpencodeCloudRuntimeAdapter,
   subscribeToOpencodeCloudRuntimeEvents,
   translateOpencodeRuntimeEvent,
+  translateOpencodeRuntimeEventWithDiagnostics,
 } from '../apps/desktop/src/main/cloud/opencode-runtime-adapter.ts'
 
 function writeExecutable(root: string, name: string, source: string) {
@@ -88,7 +89,7 @@ test('cloud OpenCode event translator maps SDK message, status, idle, and error 
 })
 
 test('cloud OpenCode event translator ignores user text echoes', () => {
-  assert.deepEqual(translateOpencodeRuntimeEvent({
+  const raw = {
     payload: {
       type: 'message.part.updated.1',
       data: {
@@ -102,7 +103,37 @@ test('cloud OpenCode event translator ignores user text echoes', () => {
         },
       },
     },
-  }), [])
+  }
+  assert.deepEqual(translateOpencodeRuntimeEvent(raw), [])
+  assert.deepEqual(translateOpencodeRuntimeEventWithDiagnostics(raw).dropped, {
+    sdkEventType: 'message.part.updated',
+    reason: 'no-projected-events',
+  })
+})
+
+test('cloud OpenCode event translator reports unknown and invalid SDK events', () => {
+  assert.deepEqual(translateOpencodeRuntimeEventWithDiagnostics({
+    payload: {
+      type: 'sdk.future.event',
+      properties: { sessionID: 'session-1' },
+    },
+  }), {
+    events: [],
+    dropped: {
+      sdkEventType: 'sdk.future.event',
+      reason: 'unknown-event-type',
+    },
+  })
+
+  assert.deepEqual(translateOpencodeRuntimeEventWithDiagnostics({
+    payload: { data: { sessionID: 'session-1' } },
+  }), {
+    events: [],
+    dropped: {
+      sdkEventType: null,
+      reason: 'invalid-envelope',
+    },
+  })
 })
 
 test('cloud OpenCode event translator preserves projection-critical runtime events', () => {
@@ -211,6 +242,7 @@ test('cloud OpenCode event translator preserves projection-critical runtime even
 test('cloud OpenCode runtime subscription translates stream events and reports failures', async () => {
   const delivered: unknown[] = []
   const errors: unknown[] = []
+  const dropped: unknown[] = []
   const client = {
     event: {
       async subscribe() {
@@ -230,6 +262,14 @@ test('cloud OpenCode runtime subscription translates stream events and reports f
                 },
               },
             }
+            yield {
+              payload: {
+                type: 'sdk.future.event',
+                properties: {
+                  sessionID: 'session-1',
+                },
+              },
+            }
           })(),
         }
       },
@@ -239,10 +279,13 @@ test('cloud OpenCode runtime subscription translates stream events and reports f
   subscribeToOpencodeCloudRuntimeEvents(
     client,
     (event) => delivered.push(event),
-    { onError: (error) => errors.push(error) },
+    {
+      onError: (error) => errors.push(error),
+      onDroppedEvent: (event) => dropped.push(event),
+    },
   )
 
-  for (let attempt = 0; delivered.length === 0 && attempt < 20; attempt += 1) {
+  for (let attempt = 0; (delivered.length === 0 || dropped.length === 0) && attempt < 20; attempt += 1) {
     await delay(10)
   }
 
@@ -254,7 +297,32 @@ test('cloud OpenCode runtime subscription translates stream events and reports f
       content: 'streamed answer',
     },
   }])
+  assert.deepEqual(dropped, [{
+    sdkEventType: 'sdk.future.event',
+    reason: 'unknown-event-type',
+  }])
   assert.deepEqual(errors, [])
+})
+
+test('cloud OpenCode runtime subscription does not subscribe after caller cancellation', () => {
+  const controller = new AbortController()
+  controller.abort()
+  let subscribed = false
+  const unsubscribe = subscribeToOpencodeCloudRuntimeEvents(
+    {
+      event: {
+        async subscribe() {
+          subscribed = true
+          return { stream: [] }
+        },
+      },
+    },
+    () => undefined,
+    { signal: controller.signal },
+  )
+
+  unsubscribe()
+  assert.equal(subscribed, false)
 })
 
 test('cloud Node OpenCode runtime adapter starts with managed env and client auth', async () => {

--- a/tests/cloud-transport-adapter.test.ts
+++ b/tests/cloud-transport-adapter.test.ts
@@ -509,3 +509,105 @@ test('cloud transport adapter authenticates SSE subscriptions with bearer header
   assert.equal(requests[0]?.init?.headers?.accept, 'text/event-stream')
   assert.equal(requests[0]?.init?.credentials, 'include')
 })
+
+test('cloud transport adapter applies request timeout and caller cancellation signals', async () => {
+  const timeoutTransport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    requestTimeoutMs: 10,
+    fetch: (_url, init) => new Promise((resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new Error('request aborted by timeout')), { once: true })
+      setTimeout(() => resolve(jsonResponse({ role: 'web' })), 100)
+    }),
+  })
+
+  await assert.rejects(timeoutTransport.getConfig(), /request aborted by timeout/)
+
+  const controller = new AbortController()
+  const cancelledTransport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    signal: controller.signal,
+    fetch: (_url, init) => new Promise((resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new Error('request aborted by caller')), { once: true })
+      setTimeout(() => resolve(jsonResponse({ role: 'web' })), 100)
+    }),
+  })
+  const request = cancelledTransport.getConfig()
+  controller.abort()
+  await assert.rejects(request, /request aborted by caller/)
+})
+
+test('cloud transport adapter closes EventSource SSE subscriptions on caller cancellation', () => {
+  const controller = new AbortController()
+  const errors: unknown[] = []
+  const instances: Array<{
+    closed: boolean
+    onerror: ((event: unknown) => void) | null
+  }> = []
+  const EventSourceImpl: CloudTransportEventSource = class {
+    closed = false
+    onmessage = null
+    onerror: ((event: unknown) => void) | null = null
+    constructor() {
+      instances.push(this)
+    }
+    close() {
+      this.closed = true
+    }
+    addEventListener() {}
+  }
+  const transport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    eventSource: EventSourceImpl,
+    signal: controller.signal,
+  })
+
+  transport.subscribeSessionEvents('session-1', {
+    onEvent() {},
+    onError(error) {
+      errors.push(error)
+    },
+  })
+  controller.abort()
+  instances[0]?.onerror?.(new Error('closed stream'))
+
+  assert.equal(instances[0]?.closed, true)
+  assert.deepEqual(errors, [])
+})
+
+test('cloud transport adapter aborts fetch SSE subscriptions on caller cancellation without surfacing errors', async () => {
+  const controller = new AbortController()
+  const errors: unknown[] = []
+  const aborts: string[] = []
+  const fetcher: CloudTransportFetch = async (_url, init) => new Promise((resolve, reject) => {
+    init?.signal?.addEventListener('abort', () => {
+      aborts.push('aborted')
+      reject(new Error('fetch SSE aborted'))
+    }, { once: true })
+    setTimeout(() => resolve({
+      ok: true,
+      status: 200,
+      async text() {
+        return ''
+      },
+      body: new ReadableStream<Uint8Array>(),
+    }), 100)
+  })
+  const transport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    fetch: fetcher,
+    signal: controller.signal,
+    headers: { authorization: 'Bearer cloud-token' },
+  })
+
+  transport.subscribeWorkspaceEvents({
+    onEvent() {},
+    onError(error) {
+      errors.push(error)
+    },
+  })
+  controller.abort()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.deepEqual(aborts, ['aborted'])
+  assert.deepEqual(errors, [])
+})

--- a/tests/fixtures/opencode-sdk-v2-events.json
+++ b/tests/fixtures/opencode-sdk-v2-events.json
@@ -1,0 +1,266 @@
+{
+  "sdkEvents": [
+    {
+      "name": "assistant-text",
+      "expectedTypes": ["assistant.message"],
+      "raw": {
+        "payload": {
+          "type": "message.part.updated",
+          "data": {
+            "sessionID": "session-1",
+            "messageID": "assistant-message-1",
+            "role": "assistant",
+            "part": {
+              "id": "part-1",
+              "type": "text",
+              "text": "normalized assistant text"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "tool-completed",
+      "expectedTypes": ["tool.call"],
+      "raw": {
+        "payload": {
+          "type": "message.part.updated",
+          "data": {
+            "sessionID": "session-1",
+            "part": {
+              "id": "part-2",
+              "callID": "tool-call-1",
+              "type": "tool",
+              "tool": "bash",
+              "state": {
+                "input": { "command": "pnpm test" },
+                "status": "completed",
+                "output": "ok"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "permission-requested",
+      "expectedTypes": ["permission.requested"],
+      "raw": {
+        "payload": {
+          "type": "permission.asked",
+          "properties": {
+            "sessionID": "session-1",
+            "permission": {
+              "id": "permission-1",
+              "tool": "bash",
+              "input": { "command": "pnpm test" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "question-asked",
+      "expectedTypes": ["question.asked"],
+      "raw": {
+        "payload": {
+          "type": "question.asked",
+          "properties": {
+            "sessionID": "session-1",
+            "id": "question-1",
+            "questions": [
+              {
+                "header": "Scope",
+                "question": "Run all checks?",
+                "options": [
+                  { "label": "Yes", "description": "Run the full suite" }
+                ]
+              }
+            ],
+            "tool": { "messageID": "assistant-message-1", "callID": "tool-call-1" }
+          }
+        }
+      }
+    },
+    {
+      "name": "todos-updated",
+      "expectedTypes": ["todos.updated"],
+      "raw": {
+        "payload": {
+          "type": "todo.updated",
+          "properties": {
+            "sessionID": "session-1",
+            "todos": [
+              {
+                "id": "todo-1",
+                "content": "Harden SDK boundary",
+                "status": "in_progress",
+                "priority": "high"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "status-idle",
+      "expectedTypes": ["session.status"],
+      "raw": {
+        "payload": {
+          "type": "session.status",
+          "properties": {
+            "sessionID": "session-1",
+            "status": { "type": "idle" }
+          }
+        }
+      }
+    },
+    {
+      "name": "step-cost",
+      "expectedTypes": ["cost.updated"],
+      "raw": {
+        "payload": {
+          "type": "message.part.updated",
+          "data": {
+            "sessionID": "session-1",
+            "messageID": "assistant-message-1",
+            "part": {
+              "id": "step-1",
+              "type": "step-finish",
+              "cost": 0.42,
+              "tokens": {
+                "input": 10,
+                "output": 20,
+                "reasoning": 3,
+                "cache": { "read": 4, "write": 5 }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "runtime-error",
+      "expectedTypes": ["runtime.error"],
+      "raw": {
+        "payload": {
+          "type": "session.error",
+          "properties": {
+            "sessionID": "session-1",
+            "error": { "message": "provider failed" }
+          }
+        }
+      }
+    }
+  ],
+  "resolutionEvents": [
+    {
+      "name": "permission-resolved",
+      "expectedTypes": ["permission.resolved"],
+      "raw": {
+        "payload": {
+          "type": "permission.resolved",
+          "properties": {
+            "sessionID": "session-1",
+            "permission": { "id": "permission-1" }
+          }
+        }
+      }
+    },
+    {
+      "name": "question-resolved",
+      "expectedTypes": ["question.resolved"],
+      "raw": {
+        "payload": {
+          "type": "question.resolved",
+          "properties": {
+            "sessionID": "session-1",
+            "id": "question-1"
+          }
+        }
+      }
+    }
+  ],
+  "dropEvents": [
+    {
+      "name": "user-text-echo",
+      "expectedDropped": {
+        "sdkEventType": "message.part.updated",
+        "reason": "no-projected-events"
+      },
+      "raw": {
+        "payload": {
+          "type": "message.part.updated",
+          "data": {
+            "sessionID": "session-1",
+            "messageID": "user-message-1",
+            "role": "user",
+            "part": {
+              "id": "user-part-1",
+              "type": "text",
+              "text": "user echo"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "unknown-sdk-event",
+      "expectedDropped": {
+        "sdkEventType": "mcp.unrecognized",
+        "reason": "unknown-event-type"
+      },
+      "raw": {
+        "payload": {
+          "type": "mcp.unrecognized",
+          "properties": {
+            "sessionID": "session-1"
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid-envelope",
+      "expectedDropped": {
+        "sdkEventType": null,
+        "reason": "invalid-envelope"
+      },
+      "raw": {
+        "payload": {
+          "data": {
+            "sessionID": "session-1"
+          }
+        }
+      }
+    }
+  ],
+  "directCloudEvents": [
+    {
+      "name": "task-run",
+      "event": {
+        "type": "task.run",
+        "payload": {
+          "taskRunId": "task-1",
+          "title": "Delegated release check",
+          "agent": "reviewer",
+          "status": "running",
+          "sourceSessionId": "child-session-1"
+        }
+      }
+    },
+    {
+      "name": "artifact-created",
+      "event": {
+        "type": "artifact.created",
+        "payload": {
+          "artifactId": "artifact-1",
+          "filename": "report.md",
+          "mime": "text/markdown",
+          "toolId": "tool-call-1",
+          "toolName": "write",
+          "taskRunId": "task-1"
+        }
+      }
+    }
+  ]
+}

--- a/tests/opencode-sdk-event-projection.test.ts
+++ b/tests/opencode-sdk-event-projection.test.ts
@@ -1,13 +1,52 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
-import { translateOpencodeRuntimeEvent } from '../apps/desktop/src/main/cloud/opencode-runtime-adapter.ts'
+import {
+  translateOpencodeRuntimeEvent,
+  translateOpencodeRuntimeEventWithDiagnostics,
+} from '../apps/desktop/src/main/cloud/opencode-runtime-adapter.ts'
 import {
   CLOUD_SESSION_EVENT_TYPES,
   cloudSessionViewToSessionView,
   createCloudSessionProjectionView,
   reduceCloudSessionProjectionEvent,
 } from '../packages/shared/dist/cloud-session-projection.js'
+
+type SdkFixture = {
+  name: string
+  raw: unknown
+  expectedTypes: string[]
+}
+
+type DropFixture = {
+  name: string
+  raw: unknown
+  expectedDropped: {
+    sdkEventType: string | null
+    reason: string
+  }
+}
+
+type DirectCloudEventFixture = {
+  name: string
+  event: {
+    type: string
+    payload: Record<string, unknown>
+  }
+}
+
+type EventFixtures = {
+  sdkEvents: SdkFixture[]
+  resolutionEvents: SdkFixture[]
+  dropEvents: DropFixture[]
+  directCloudEvents: DirectCloudEventFixture[]
+}
+
+function loadFixtures(): EventFixtures {
+  return JSON.parse(readFileSync(join(process.cwd(), 'tests/fixtures/opencode-sdk-v2-events.json'), 'utf8')) as EventFixtures
+}
 
 function sessionRecord() {
   return {
@@ -31,86 +70,18 @@ function eventRecord(sequence: number, event: { type: string, payload: Record<st
 }
 
 test('SDK v2 event fixtures normalize into the shared cloud projection contract', () => {
-  const rawSdkEvents = [
-    {
-      payload: {
-        type: 'message.part.updated',
-        data: {
-          sessionID: 'session-1',
-          messageID: 'assistant-message-1',
-          role: 'assistant',
-          part: { id: 'part-1', type: 'text', text: 'normalized assistant text' },
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'message.part.updated',
-        data: {
-          sessionID: 'session-1',
-          part: {
-            id: 'part-2',
-            callID: 'tool-call-1',
-            type: 'tool',
-            tool: 'bash',
-            state: {
-              input: { command: 'pnpm test' },
-              status: 'completed',
-              output: 'ok',
-            },
-          },
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'permission.asked',
-        properties: {
-          sessionID: 'session-1',
-          permission: {
-            id: 'permission-1',
-            tool: 'bash',
-            input: { command: 'pnpm test' },
-          },
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'question.asked',
-        properties: {
-          sessionID: 'session-1',
-          id: 'question-1',
-          questions: [{
-            header: 'Scope',
-            question: 'Run all checks?',
-            options: [{ label: 'Yes', description: 'Run the full suite' }],
-          }],
-          tool: { messageID: 'assistant-message-1', callID: 'tool-call-1' },
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'todo.updated',
-        properties: {
-          sessionID: 'session-1',
-          todos: [{ id: 'todo-1', content: 'Harden SDK boundary', status: 'in_progress', priority: 'high' }],
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'session.status',
-        properties: {
-          sessionID: 'session-1',
-          status: { type: 'idle' },
-        },
-      },
-    },
-  ]
+  const fixtures = loadFixtures()
+  const runtimeFixtures = fixtures.sdkEvents.filter((fixture) => fixture.name !== 'runtime-error')
 
-  const normalized = rawSdkEvents.flatMap(translateOpencodeRuntimeEvent)
+  for (const fixture of runtimeFixtures) {
+    assert.deepEqual(
+      translateOpencodeRuntimeEvent(fixture.raw).map((event) => event.type),
+      fixture.expectedTypes,
+      fixture.name,
+    )
+  }
+
+  const normalized = runtimeFixtures.flatMap((fixture) => translateOpencodeRuntimeEvent(fixture.raw))
   assert.deepEqual(normalized.map((event) => event.type), [
     'assistant.message',
     'tool.call',
@@ -118,12 +89,16 @@ test('SDK v2 event fixtures normalize into the shared cloud projection contract'
     'question.asked',
     'todos.updated',
     'session.status',
+    'cost.updated',
   ])
 
   const session = sessionRecord()
   let projection = createCloudSessionProjectionView(session)
-  normalized.forEach((event, index) => {
-    assert.equal(CLOUD_SESSION_EVENT_TYPES.includes(event.type), true, `${event.type} must be a shared cloud event`)
+  ;[
+    ...normalized,
+    ...fixtures.directCloudEvents.map((fixture) => fixture.event),
+  ].forEach((event, index) => {
+    assert.equal((CLOUD_SESSION_EVENT_TYPES as readonly string[]).includes(event.type), true, `${event.type} must be a shared cloud event`)
     projection = reduceCloudSessionProjectionEvent(session, projection, eventRecord(index + 1, event))
   })
 
@@ -135,6 +110,10 @@ test('SDK v2 event fixtures normalize into the shared cloud projection contract'
   assert.equal(projection.pendingQuestions[0]?.tool?.callId, 'tool-call-1')
   assert.deepEqual(projection.todos.map((todo) => todo.content), ['Harden SDK boundary'])
   assert.equal(projection.status, 'idle')
+  assert.equal(projection.sessionCost, 0.42)
+  assert.equal(projection.sessionTokens.input, 10)
+  assert.equal(projection.taskRuns[0]?.id, 'task-1')
+  assert.equal(projection.artifacts[0]?.cloudArtifactId, 'artifact-1')
 
   const desktopView = cloudSessionViewToSessionView({
     session,
@@ -153,54 +132,29 @@ test('SDK v2 event fixtures normalize into the shared cloud projection contract'
 
 test('SDK v2 permission and question resolution fixtures clear shared pending state', () => {
   const session = sessionRecord()
+  const fixtures = loadFixtures()
   const rawSdkEvents = [
-    {
-      payload: {
-        type: 'permission.asked',
-        properties: {
-          sessionID: 'session-1',
-          permission: { id: 'permission-1', tool: 'bash', input: { command: 'pwd' } },
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'question.asked',
-        properties: {
-          sessionID: 'session-1',
-          id: 'question-1',
-          questions: [{ question: 'Continue?', options: [] }],
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'permission.resolved',
-        properties: {
-          sessionID: 'session-1',
-          permission: { id: 'permission-1' },
-        },
-      },
-    },
-    {
-      payload: {
-        type: 'question.resolved',
-        properties: {
-          sessionID: 'session-1',
-          id: 'question-1',
-        },
-      },
-    },
-  ]
+    fixtures.sdkEvents.find((fixture) => fixture.name === 'permission-requested'),
+    fixtures.sdkEvents.find((fixture) => fixture.name === 'question-asked'),
+    ...fixtures.resolutionEvents,
+  ].filter((fixture): fixture is SdkFixture => Boolean(fixture))
 
   let projection = createCloudSessionProjectionView(session)
   rawSdkEvents
-    .flatMap(translateOpencodeRuntimeEvent)
+    .flatMap((fixture) => translateOpencodeRuntimeEvent(fixture.raw))
     .forEach((event, index) => {
-      assert.equal(CLOUD_SESSION_EVENT_TYPES.includes(event.type), true, `${event.type} must be a shared cloud event`)
+      assert.equal((CLOUD_SESSION_EVENT_TYPES as readonly string[]).includes(event.type), true, `${event.type} must be a shared cloud event`)
       projection = reduceCloudSessionProjectionEvent(session, projection, eventRecord(index + 1, event))
     })
 
   assert.equal(projection.pendingApprovals.length, 0)
   assert.equal(projection.pendingQuestions.length, 0)
+})
+
+test('SDK v2 unknown and intentionally dropped events are observable', () => {
+  for (const fixture of loadFixtures().dropEvents) {
+    const translation = translateOpencodeRuntimeEventWithDiagnostics(fixture.raw)
+    assert.deepEqual(translation.events, [], fixture.name)
+    assert.deepEqual(translation.dropped, fixture.expectedDropped, fixture.name)
+  }
 })


### PR DESCRIPTION
## Summary
- make @open-cowork/cloud-client a documented public package with explicit exports, cancellation semantics, import smoke coverage, and a publishable shared wire-type dependency
- add fixture-backed OpenCode SDK v2 event projection tests plus observable dropped-event diagnostics for unknown or intentionally ignored runtime events
- extract API token policy helpers from the monolithic cloud session service into a focused service module

## Verification
- pnpm --filter @open-cowork/cloud-client test
- node scripts/run-node-tests.mjs tests/cloud-transport-adapter.test.ts tests/cloud-client-boundary.test.ts tests/cloud-api-token-policy.test.ts tests/cloud-opencode-runtime-adapter.test.ts tests/opencode-sdk-event-projection.test.ts
- pnpm typecheck
- pnpm lint
- pnpm docs:build
- pnpm --dir packages/cloud-client pack --dry-run
- pnpm --dir packages/shared pack --dry-run
- pnpm test

Closes #569