### PR TITLE
Promote instance-aware gateway providers

### DIFF
--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -477,7 +477,14 @@ function readEnum<T extends string>(value: unknown, allowed: readonly T[]): T | 
 }
 
 function readChannelProvider(value: unknown): ChannelProviderId | undefined {
-  return readEnum(value, ['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'] as const)
+  const provider = readString(value)
+  if (!provider) return undefined
+  if (['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(provider)) {
+    return provider as ChannelProviderId
+  }
+  return /^[a-z][a-z0-9_-]{1,63}$/.test(provider) && provider.includes('-')
+    ? provider as ChannelProviderId
+    : undefined
 }
 
 function parseTagIds(url: URL) {

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -63,7 +63,8 @@ export type ControlPlaneCommandKind = 'prompt' | 'abort' | 'permission.respond' 
 export type ControlPlaneCommandStatus = 'pending' | 'running' | 'acked' | 'failed'
 export type WorkerRole = 'all-in-one' | 'web' | 'worker' | 'scheduler'
 export type WorkReaperAction = 'retried' | 'failed' | 'released'
-export type ChannelProviderId = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
+export type ChannelProviderKind = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
+export type ChannelProviderId = ChannelProviderKind | `${ChannelProviderKind}-${string}` | `${string}-${string}`
 export type HeadlessAgentStatus = 'active' | 'disabled'
 export type ChannelBindingStatus = 'active' | 'disabled' | 'auth_required' | 'error'
 export type ChannelIdentityRole = ControlPlaneRole | 'approver' | 'viewer'
@@ -1469,17 +1470,18 @@ function normalizePositiveInteger(value: unknown, label: string) {
 function windowStart(nowMs: number, windowMs: number) {
   return Math.floor(nowMs / windowMs) * windowMs
 }
-
 function quotaRetryAfterMs(nowMs: number, startedAtMs: number, windowMs: number) {
   return Math.max(1, startedAtMs + windowMs - nowMs)
 }
 
 function normalizeProvider(value: unknown): ChannelProviderId {
-  const provider = normalizeText(value, 32, 'Channel provider') as ChannelProviderId
-  if (!['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(provider)) {
-    throw new Error(`Unsupported channel provider ${provider}.`)
-  }
-  return provider
+  const provider = normalizeText(value, 64, 'Channel provider') as ChannelProviderId
+  if (isChannelProviderId(provider)) return provider
+  throw new Error(`Unsupported channel provider ${provider}.`)
+}
+function isChannelProviderId(value: string): value is ChannelProviderId {
+  return ['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(value)
+    || (/^[a-z][a-z0-9_-]{1,63}$/.test(value) && value.includes('-'))
 }
 
 function normalizeBillingStatus(value: unknown): BillingSubscriptionStatus {

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -291,11 +291,16 @@ function retryAfterMs(nowMs: number, windowStartedAtMs: number, windowMs: number
 }
 
 function normalizeProvider(value: unknown): ChannelProviderId {
-  const provider = normalizeText(value, 32, 'Channel provider') as ChannelProviderId
-  if (!['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(provider)) {
+  const provider = normalizeText(value, 64, 'Channel provider') as ChannelProviderId
+  if (!isChannelProviderId(provider)) {
     throw new Error(`Unsupported channel provider ${provider}.`)
   }
   return provider
+}
+
+function isChannelProviderId(value: string): value is ChannelProviderId {
+  if (['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(value)) return true
+  return /^[a-z][a-z0-9_-]{1,63}$/.test(value) && value.includes('-')
 }
 
 function normalizeByokProviderId(value: unknown) {

--- a/apps/gateway/src/config.test.ts
+++ b/apps/gateway/src/config.test.ts
@@ -697,6 +697,63 @@ test('gateway config loads Slack, email, Telegram, webhook, bridge, and CLI prov
   assert.equal(config.providers.find((provider) => provider.kind === 'discord')?.credentials.sharedSecret, 'discord-secret')
 })
 
+test('gateway config supports multiple instance ids for one provider kind', () => {
+  const config = resolveGatewayConfig({
+    providers: [{
+      id: 'webhook-ci',
+      kind: 'webhook',
+      channelBindingId: 'webhook-ci-binding',
+      credentials: { sharedSecret: 'ci-secret' },
+      settings: { deliveryUrl: 'https://bridge.example.test/ci' },
+    }, {
+      id: 'webhook-prod',
+      kind: 'webhook',
+      channelBindingId: 'webhook-prod-binding',
+      credentials: { sharedSecret: 'prod-secret' },
+      settings: { deliveryUrl: 'https://bridge.example.test/prod' },
+    }],
+  }, operatorEnv)
+
+  assert.deepEqual(config.providers.map((provider) => ({
+    id: provider.id,
+    kind: provider.kind,
+    channelBindingId: provider.channelBindingId,
+  })), [{
+    id: 'webhook-ci',
+    kind: 'webhook',
+    channelBindingId: 'webhook-ci-binding',
+  }, {
+    id: 'webhook-prod',
+    kind: 'webhook',
+    channelBindingId: 'webhook-prod-binding',
+  }])
+
+  assert.throws(() => resolveGatewayConfig({
+    providers: [{
+      id: 'webhook-ci',
+      kind: 'webhook',
+      channelBindingId: 'webhook-ci-a',
+      credentials: { sharedSecret: 'ci-secret' },
+      settings: { deliveryUrl: 'https://bridge.example.test/ci' },
+    }, {
+      id: 'webhook-ci',
+      kind: 'webhook',
+      channelBindingId: 'webhook-ci-b',
+      credentials: { sharedSecret: 'ci-secret' },
+      settings: { deliveryUrl: 'https://bridge.example.test/ci' },
+    }],
+  }, operatorEnv), /Duplicate gateway provider id webhook-ci/)
+  assert.throws(() => resolveGatewayConfig({
+    providers: [{
+      id: 'bad id',
+      kind: 'webhook',
+      channelBindingId: 'webhook-ci',
+      credentials: { sharedSecret: 'ci-secret' },
+      settings: { deliveryUrl: 'https://bridge.example.test/ci' },
+    }],
+  }, operatorEnv), /safe legacy provider id/)
+})
+
 test('gateway config loads the shared open-cowork config gateway section with allowlisted env placeholders', () => {
   const tempRoot = mkdtempSync(join(tmpdir(), 'open-cowork-gateway-config-'))
   try {

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import type { ChannelProviderId } from '@open-cowork/gateway-channel'
+import { isChannelProviderKind, normalizeChannelProviderIdentity, type ChannelProviderKind } from '@open-cowork/gateway-channel'
 import { jsonConfigCandidates, parseJsoncText, resolveGatewayProductMode } from '@open-cowork/shared'
 import type { GatewayDeploymentConfig, GatewayProductMode, PublicBrandingConfig } from '@open-cowork/shared'
 
@@ -9,7 +9,7 @@ export type { GatewayProductMode } from '@open-cowork/shared'
 
 export type GatewayMode = 'self-host' | 'managed'
 export type GatewayLogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'
-export type GatewayProviderKind = ChannelProviderId | 'fake'
+export type GatewayProviderKind = ChannelProviderKind | 'fake'
 
 export type GatewayConfig = {
   branding: PublicBrandingConfig
@@ -46,9 +46,7 @@ export type GatewayConfig = {
   providers: GatewayProviderConfig[]
 }
 
-export type GatewayCloudConnectionConfig = GatewayConfig['cloud'] & {
-  requestTimeoutMs: number
-}
+export type GatewayCloudConnectionConfig = GatewayConfig['cloud'] & { requestTimeoutMs: number }
 
 export type GatewayProviderConfig = {
   id: string
@@ -441,6 +439,7 @@ function normalizeProviders(rawProviders: GatewayRawConfig['providers'], env: Ga
     : readBoolean(env.OPEN_COWORK_GATEWAY_ENABLE_FAKE_PROVIDER, false)
       ? [defaultFakeProvider(env)]
       : []
+  assertUniqueProviderIds(normalized)
   const enabled = normalized.filter((provider) => provider.enabled)
   if (enabled.length === 0) {
     throw new Error('At least one gateway provider must be enabled. Set OPEN_COWORK_GATEWAY_PROVIDERS, configure Telegram/webhook credentials, or explicitly enable the local fake provider with OPEN_COWORK_GATEWAY_ENABLE_FAKE_PROVIDER=true.')
@@ -623,7 +622,8 @@ function defaultFakeProvider(env: GatewayEnv): GatewayProviderConfig {
 
 function normalizeProvider(raw: Partial<GatewayProviderConfig> & { kind: GatewayProviderKind }, index: number, gatewayPublicBaseUrl?: string | null, maxRequestBody = defaultMaxRequestBodyBytes): GatewayProviderConfig {
   const kind = readProviderKind(raw.kind)
-  const id = readString(raw.id) || `${kind}-${index + 1}`
+  const requestedId = readString(raw.id) || `${kind}-${index + 1}`
+  const id = kind === 'fake' ? requestedId : normalizeChannelProviderIdentity(kind, requestedId).providerId
   const channelBindingId = readString(raw.channelBindingId)
   if (!channelBindingId) throw new Error(`Gateway provider ${id} requires channelBindingId.`)
   const credentials = cleanStringRecord(raw.credentials)
@@ -683,10 +683,18 @@ function normalizeProvider(raw: Partial<GatewayProviderConfig> & { kind: Gateway
 
 function readProviderKind(value: unknown): GatewayProviderKind {
   const kind = readString(value)
-  if (kind === 'fake' || kind === 'telegram' || kind === 'slack' || kind === 'email' || kind === 'webhook' || kind === 'discord' || kind === 'whatsapp' || kind === 'signal' || kind === 'cli') {
+  if (kind === 'fake' || isChannelProviderKind(kind)) {
     return kind
   }
   throw new Error(`Unsupported gateway provider kind: ${kind || String(value)}`)
+}
+
+function assertUniqueProviderIds(providers: GatewayProviderConfig[]) {
+  const seen = new Set<string>()
+  for (const provider of providers) {
+    if (seen.has(provider.id)) throw new Error(`Duplicate gateway provider id ${provider.id}.`)
+    seen.add(provider.id)
+  }
 }
 
 function normalizeBaseUrl(value: string, allowInsecureHttp: boolean) {

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -342,45 +342,96 @@ test('gateway provider registry wires fake, first-party, bridge, and CLI provide
     id: registration.config.id,
     kind: registration.config.kind,
     provider: registration.provider.id,
+    providerKind: registration.provider.kind,
   })), [{
     id: 'fake',
     kind: 'fake',
     provider: 'cli',
+    providerKind: 'cli',
   }, {
     id: 'telegram',
     kind: 'telegram',
     provider: 'telegram',
+    providerKind: 'telegram',
   }, {
     id: 'slack',
     kind: 'slack',
     provider: 'slack',
+    providerKind: 'slack',
   }, {
     id: 'email',
     kind: 'email',
     provider: 'email',
+    providerKind: 'email',
   }, {
     id: 'webhook',
     kind: 'webhook',
     provider: 'webhook',
+    providerKind: 'webhook',
   }, {
     id: 'discord',
     kind: 'discord',
     provider: 'discord',
+    providerKind: 'discord',
   }, {
     id: 'whatsapp',
     kind: 'whatsapp',
     provider: 'whatsapp',
+    providerKind: 'whatsapp',
   }, {
     id: 'signal',
     kind: 'signal',
     provider: 'signal',
+    providerKind: 'signal',
   }, {
     id: 'cli',
     kind: 'cli',
     provider: 'cli',
+    providerKind: 'cli',
   }])
   assert.equal(registry.registrations.find((entry) => entry.config.kind === 'whatsapp')?.provider.capabilities.inlineButtons, true)
   assert.equal(registry.registrations.find((entry) => entry.config.kind === 'signal')?.provider.capabilities.inlineButtons, false)
+})
+
+test('gateway provider registry keeps same-kind provider instances isolated', () => {
+  const registry = createGatewayProviderRegistry(resolveGatewayConfig({
+    cloud: {
+      baseUrl: 'https://cloud.example.test',
+      serviceToken: 'service-token',
+    },
+    server: {
+      adminToken: 'admin-token',
+    },
+    providers: [{
+      id: 'webhook-ci',
+      kind: 'webhook',
+      channelBindingId: 'webhook-ci-binding',
+      credentials: { sharedSecret: 'ci-secret' },
+      settings: { deliveryUrl: 'https://bridge.example.test/ci' },
+    }, {
+      id: 'webhook-prod',
+      kind: 'webhook',
+      channelBindingId: 'webhook-prod-binding',
+      credentials: { sharedSecret: 'prod-secret' },
+      settings: { deliveryUrl: 'https://bridge.example.test/prod' },
+    }],
+  }))
+
+  assert.deepEqual(registry.registrations.map((registration) => ({
+    id: registration.config.id,
+    kind: registration.provider.kind,
+    provider: registration.provider.id,
+  })), [{
+    id: 'webhook-ci',
+    kind: 'webhook',
+    provider: 'webhook-ci',
+  }, {
+    id: 'webhook-prod',
+    kind: 'webhook',
+    provider: 'webhook-prod',
+  }])
+  assert.equal(registry.get('webhook-ci')?.provider.id, 'webhook-ci')
+  assert.equal(registry.get('webhook-prod')?.provider.id, 'webhook-prod')
 })
 
 test('gateway daemon accepts signed Slack webhook verification payloads', async () => {

--- a/apps/gateway/src/event-renderer.ts
+++ b/apps/gateway/src/event-renderer.ts
@@ -1,5 +1,4 @@
 import type {
-  ChannelProviderId,
   ChannelProvider,
   ChannelTarget,
 } from '@open-cowork/gateway-channel'
@@ -41,7 +40,7 @@ export const GATEWAY_RENDERED_SESSION_EVENT_TYPES = [
 export async function renderGatewaySessionEvent(
   input: RenderGatewaySessionEventInput,
 ): Promise<RenderGatewaySessionEventResult> {
-  const target = targetForBinding(input.binding, input.provider.id)
+  const target = targetForBinding(input.binding, input.provider)
   if (input.event.type === 'assistant.message') {
     return renderAssistantStream({
       provider: input.provider,
@@ -76,9 +75,10 @@ export async function renderGatewaySessionEvent(
   return { handled: false }
 }
 
-function targetForBinding(binding: ChannelSessionBindingRecord, provider: ChannelProviderId): ChannelTarget {
+function targetForBinding(binding: ChannelSessionBindingRecord, provider: Pick<ChannelProvider, 'id' | 'kind'>): ChannelTarget {
   return {
-    provider,
+    provider: provider.id,
+    providerKind: provider.kind,
     chatId: binding.externalChatId,
     threadId: binding.externalThreadId,
     messageId: binding.lastChatMessageId,

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -208,7 +208,7 @@ async function handleDelivery(
 }
 
 async function sendDelivery(provider: ChannelProvider, delivery: ChannelDeliveryRecord): Promise<SentMessage> {
-  const target = readDeliveryTarget(delivery)
+  const target = readDeliveryTarget(delivery, provider)
   const text = typeof delivery.payload.text === 'string'
     ? delivery.payload.text
     : typeof delivery.payload.message === 'string'
@@ -231,10 +231,11 @@ function findDeliveryProvider(providers: GatewayProviderRegistry, delivery: Chan
   return providers.registrations.find((entry) => entry.config.channelBindingId === delivery.channelBindingId) || null
 }
 
-function readDeliveryTarget(delivery: ChannelDeliveryRecord): ChannelTarget {
+function readDeliveryTarget(delivery: ChannelDeliveryRecord, provider: Pick<ChannelProvider, 'id' | 'kind'>): ChannelTarget {
   const target = delivery.target
   return {
-    provider: delivery.provider as ChannelTarget['provider'],
+    provider: provider.id,
+    providerKind: provider.kind,
     chatId: stringField(target.externalChatId) || stringField(target.chatId) || 'unknown',
     threadId: stringField(target.externalThreadId) || stringField(target.threadId),
     messageId: stringField(target.lastChatMessageId) || stringField(target.messageId),

--- a/apps/gateway/src/provider-registry.ts
+++ b/apps/gateway/src/provider-registry.ts
@@ -3,6 +3,8 @@ import type { IncomingHttpHeaders } from 'node:http'
 import type {
   ChannelInteraction,
   ChannelProvider,
+  ChannelProviderId,
+  ChannelProviderKind,
   ChannelTarget,
   IncomingChannelMessage,
 } from '@open-cowork/gateway-channel'
@@ -127,7 +129,7 @@ export function createGatewayProviderRegistry(config: GatewayConfig): GatewayPro
         return
       }
       if (registration.config.kind === 'fake') {
-        await (registration.provider as FakeChannelProvider).emit(fakeMessage(registration.provider.id, payload))
+        await (registration.provider as FakeChannelProvider).emit(fakeMessage(registration.provider, payload))
         return
       }
       throw new Error(`Gateway provider ${id} does not expose a webhook endpoint.`)
@@ -135,7 +137,7 @@ export function createGatewayProviderRegistry(config: GatewayConfig): GatewayPro
     async emitFake(id, input) {
       const registration = this.get(id)
       if (!registration || registration.config.kind !== 'fake') throw new Error(`Unknown fake gateway provider ${id}.`)
-      await (registration.provider as FakeChannelProvider).emit(fakeMessage(registration.provider.id, input))
+      await (registration.provider as FakeChannelProvider).emit(fakeMessage(registration.provider, input))
     },
   }
 }
@@ -153,6 +155,7 @@ function createProvider(config: GatewayProviderConfig, gateway: GatewayConfig): 
 
   if (config.kind === 'webhook') {
     return new WebhookProvider({
+      providerId: channelProviderConfigId(config),
       deliveryUrl: requiredSetting(config, 'deliveryUrl'),
       sharedSecret: config.credentials.sharedSecret,
       maxAttachmentBytes: optionalNumber(config.settings.maxAttachmentBytes) || optionalNumberString(config.settings.maxAttachmentBytes) || gateway.server.maxRequestBodyBytes,
@@ -170,6 +173,7 @@ function createProvider(config: GatewayProviderConfig, gateway: GatewayConfig): 
   if (config.kind === 'telegram') {
     const mode = settingString(config, 'mode') === 'webhook' ? 'webhook' : 'polling'
     return new TelegramProvider({
+      providerId: channelProviderConfigId(config),
       botToken: requiredCredential(config, 'botToken'),
       mode,
       webhook: mode === 'webhook'
@@ -186,6 +190,7 @@ function createProvider(config: GatewayProviderConfig, gateway: GatewayConfig): 
 
   if (config.kind === 'slack') {
     return new SlackProvider({
+      providerId: channelProviderConfigId(config),
       botToken: requiredCredential(config, 'botToken'),
       signingSecret: requiredCredential(config, 'signingSecret'),
       apiBaseUrl: settingString(config, 'apiBaseUrl') || undefined,
@@ -195,6 +200,7 @@ function createProvider(config: GatewayProviderConfig, gateway: GatewayConfig): 
 
   if (config.kind === 'email') {
     return new EmailProvider({
+      providerId: channelProviderConfigId(config),
       from: requiredSetting(config, 'from'),
       inboundSecret: requiredCredential(config, 'inboundSecret'),
       maxAttachmentBytes: optionalNumber(config.settings.maxAttachmentBytes) || optionalNumberString(config.settings.maxAttachmentBytes) || gateway.server.maxRequestBodyBytes,
@@ -209,7 +215,7 @@ function createProvider(config: GatewayProviderConfig, gateway: GatewayConfig): 
     })
   }
 
-  if (config.kind === 'cli') return new CliProvider()
+  if (config.kind === 'cli') return new CliProvider({ providerId: channelProviderConfigId(config) })
 
   throw new Error(`Provider kind ${config.kind} is not implemented by the gateway app yet.`)
 }
@@ -220,6 +226,7 @@ function isBridgeWebhookProviderKind(kind: GatewayProviderConfig['kind']): kind 
 
 function bridgeProviderConfig(config: GatewayProviderConfig, gateway: GatewayConfig) {
   return {
+    providerId: channelProviderConfigId(config),
     deliveryUrl: requiredSetting(config, 'deliveryUrl'),
     sharedSecret: requiredCredential(config, 'sharedSecret'),
     maxAttachmentBytes: optionalNumber(config.settings.maxAttachmentBytes) || optionalNumberString(config.settings.maxAttachmentBytes) || gateway.server.maxRequestBodyBytes,
@@ -227,7 +234,11 @@ function bridgeProviderConfig(config: GatewayProviderConfig, gateway: GatewayCon
   }
 }
 
-function fakeMessage(provider: ChannelProvider['id'], payload: unknown): IncomingChannelMessage {
+function channelProviderConfigId(config: GatewayProviderConfig): ChannelProviderId {
+  return config.id as ChannelProviderId
+}
+
+function fakeMessage(provider: Pick<ChannelProvider, 'id' | 'kind'>, payload: unknown): IncomingChannelMessage {
   const record = payload && typeof payload === 'object' && !Array.isArray(payload)
     ? payload as Record<string, unknown>
     : {}
@@ -237,14 +248,19 @@ function fakeMessage(provider: ChannelProvider['id'], payload: unknown): Incomin
   const userId = typeof record.userId === 'string' && record.userId ? record.userId : 'fake-user'
   const interaction = readFakeInteraction(record)
   const target: ChannelTarget = {
-    provider,
+    provider: provider.id,
+    providerKind: provider.kind as ChannelProviderKind,
     chatId,
     threadId,
     userId,
   }
   return {
     id: typeof record.id === 'string' && record.id ? record.id : `fake-${Date.now()}`,
-    provider,
+    providerInstanceId: provider.id,
+    providerEventId: typeof record.id === 'string' && record.id ? record.id : `fake-${Date.now()}`,
+    providerMessageId: typeof record.id === 'string' && record.id ? record.id : null,
+    provider: provider.id,
+    providerKind: provider.kind,
     target,
     sender: {
       providerUserId: userId,

--- a/docs/gateway-provider-readiness.md
+++ b/docs/gateway-provider-readiness.md
@@ -18,6 +18,28 @@ The typed source of truth is
 `apps/gateway/src/provider-readiness.ts`. The Gateway test suite verifies that
 this page, the matrix, and actual provider capabilities stay aligned.
 
+## Provider Identity Contract
+
+Gateway provider configuration separates provider kind from provider instance:
+
+- `kind` is the adapter implementation, such as `telegram`, `slack`, `email`,
+  or `webhook`.
+- `id` is the configured provider instance, such as `telegram-main`,
+  `telegram-support`, `slack-work`, or `webhook-ci`.
+- `channelBindingId` is the Cloud control-plane binding that maps the provider
+  instance to a headless agent and delivery route.
+
+Kind-only ids such as `telegram` remain supported for existing self-hosted
+configs. New production configs should use explicit instance ids so multiple
+providers of the same kind can coexist without sharing cursors, health,
+deliveries, or channel-thread bindings. Legacy downstream ids such as
+`acme-telegram` are accepted for compatibility, but kind-prefixed ids are the
+recommended convention for new deployments.
+
+Every provider exposes `id`, `kind`, and capabilities, and may expose runtime
+health. Provider readiness and diagnostics use the instance id for routing and
+the kind for capability/policy decisions.
+
 ## Provider Readiness Matrix
 
 | Provider | Tier | Status | Modes | Auth / signing | Approvals | Files | Contract tests |

--- a/packages/cloud-client/src/adapter.ts
+++ b/packages/cloud-client/src/adapter.ts
@@ -66,7 +66,8 @@ function cloudArtifactIdFromFilePath(filePath: string) {
 export type CloudClientSessionStatus = 'idle' | 'running' | 'closed' | 'errored'
 export type CloudClientCommandKind = 'prompt' | 'abort' | 'permission.respond' | 'question.reply' | 'question.reject'
 export type CloudClientCommandStatus = 'pending' | 'running' | 'acked' | 'failed'
-export type CloudChannelProviderId = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
+export type CloudChannelProviderKind = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
+export type CloudChannelProviderId = CloudChannelProviderKind | `${CloudChannelProviderKind}-${string}` | `${string}-${string}`
 export type CloudChannelIdentityRole = 'owner' | 'admin' | 'member' | 'approver' | 'viewer'
 export type CloudChannelIdentityStatus = 'active' | 'disabled' | 'pending'
 export type CloudChannelDeliveryStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead'

--- a/packages/cloud-client/src/domains/channels.ts
+++ b/packages/cloud-client/src/domains/channels.ts
@@ -9,6 +9,7 @@ export type {
   CloudChannelIdentityRole,
   CloudChannelIdentityStatus,
   CloudChannelProviderId,
+  CloudChannelProviderKind,
   HeadlessAgentRecord,
   IssuedChannelInteractionRecord,
 } from '../adapter.js'

--- a/packages/gateway-channel/src/channel-provider.test.ts
+++ b/packages/gateway-channel/src/channel-provider.test.ts
@@ -2,12 +2,16 @@ import { describe, it } from "node:test";
 import { expect } from "../../../tests/gateway-test-expect.ts";
 import {
   buildScopeKey,
+  channelProviderKindFromId,
   chunkText,
   createProviderToken,
   fitText,
   isChannelProviderId,
+  isChannelProviderInstanceIdForKind,
+  isChannelProviderKind,
   isSafeScopeKey,
-  isValidProviderToken
+  isValidProviderToken,
+  normalizeChannelCapabilities
 } from "@open-cowork/gateway-channel";
 
 describe("channel provider utilities", () => {
@@ -116,8 +120,31 @@ describe("channel provider utilities", () => {
 
   it("recognizes supported provider ids", () => {
     expect(isChannelProviderId("telegram")).toBe(true);
+    expect(isChannelProviderKind("telegram")).toBe(true);
+    expect(isChannelProviderId("telegram-main")).toBe(true);
+    expect(isChannelProviderInstanceIdForKind("telegram-main", "telegram")).toBe(true);
+    expect(channelProviderKindFromId("slack-work")).toBe("slack");
+    expect(isChannelProviderId("acme-telegram")).toBe(true);
+    expect(channelProviderKindFromId("acme-telegram")).toBe(null);
     expect(isChannelProviderId("whatsapp")).toBe(true);
     expect(isChannelProviderId("matrix")).toBe(false);
+    expect(isChannelProviderId("Matrix-main")).toBe(false);
+  });
+
+  it("derives inbound and outbound file modes from legacy file capability flags", () => {
+    const capabilities = normalizeChannelCapabilities({
+      threads: false,
+      messageEditing: false,
+      inlineButtons: false,
+      fileUploads: true,
+      fileDownloads: false,
+      typingIndicator: false,
+      maxTextLength: 100,
+      preferredParseMode: "plain"
+    });
+
+    expect(capabilities.inboundFileModes).toEqual([]);
+    expect(capabilities.outboundFileModes).toEqual(["local_path", "inline_buffer"]);
   });
 });
 

--- a/packages/gateway-channel/src/conformance.ts
+++ b/packages/gateway-channel/src/conformance.ts
@@ -1,0 +1,342 @@
+import {
+  isChannelProviderId,
+  isChannelProviderKind,
+  normalizeChannelCapabilities,
+  validateOutgoingFilePayload,
+  type ChannelAttachment,
+  type ChannelProvider,
+  type ChannelTarget,
+  type IncomingChannelMessage,
+  type SentMessage,
+} from "./provider.js";
+import { createProviderToken } from "./tokens.js";
+
+export interface ChannelProviderInboundExpectation {
+  text?: string;
+  chatId?: string;
+  threadId?: string | null;
+  isDirect?: boolean;
+  command?: string;
+  interactionToken?: string;
+  attachmentCount?: number;
+}
+
+export interface ChannelProviderInboundCase {
+  name: string;
+  emit: () => Promise<void>;
+  expected?: ChannelProviderInboundExpectation;
+}
+
+export interface ChannelProviderConformanceInput {
+  provider: ChannelProvider;
+  target: ChannelTarget;
+  inbound?: ChannelProviderInboundCase[];
+  downloadableAttachment?: ChannelAttachment;
+}
+
+export interface ChannelProviderConformanceViolation {
+  check: string;
+  message: string;
+}
+
+export interface ChannelProviderConformanceReport {
+  providerId: string;
+  providerKind: string;
+  checks: string[];
+  violations: ChannelProviderConformanceViolation[];
+  passed: boolean;
+}
+
+export async function runChannelProviderConformance(
+  input: ChannelProviderConformanceInput,
+): Promise<ChannelProviderConformanceReport> {
+  const checks: string[] = [];
+  const violations: ChannelProviderConformanceViolation[] = [];
+  const received: IncomingChannelMessage[] = [];
+  const provider = input.provider;
+
+  const check = async (name: string, operation: () => Promise<void> | void): Promise<void> => {
+    checks.push(name);
+    try {
+      await operation();
+    } catch (error) {
+      violations.push({ check: name, message: errorMessage(error) });
+    }
+  };
+
+  await check("provider identity", () => {
+    if (!isChannelProviderKind(provider.kind)) {
+      throw new Error(`provider kind is invalid: ${String(provider.kind)}`);
+    }
+    if (!isChannelProviderId(provider.id)) {
+      throw new Error(`provider id is invalid: ${String(provider.id)}`);
+    }
+    if (input.target.provider !== provider.id) {
+      throw new Error(`sample target provider ${input.target.provider} does not match ${provider.id}`);
+    }
+    if (input.target.providerKind !== provider.kind) {
+      throw new Error(`sample target kind ${input.target.providerKind ?? "(missing)"} does not match ${provider.kind}`);
+    }
+  });
+
+  await check("provider capabilities", () => {
+    validateProviderCapabilities(provider);
+  });
+
+  await check("provider start", async () => {
+    await provider.start(async (message) => {
+      received.push(message);
+    });
+  });
+
+  for (const inbound of input.inbound ?? []) {
+    await check(`inbound normalization: ${inbound.name}`, async () => {
+      const before = received.length;
+      await inbound.emit();
+      const emitted = received.slice(before);
+      if (emitted.length !== 1) {
+        throw new Error(`expected one normalized message, got ${emitted.length}`);
+      }
+      validateIncomingChannelMessage(emitted[0]!, provider);
+      validateInboundExpectation(emitted[0]!, inbound.expected);
+    });
+  }
+
+  await check("send text", async () => {
+    const sent = await provider.sendText(input.target, "provider conformance text", {
+      deliveryId: "provider-conformance-text",
+    });
+    validateSentMessage(sent, input.target, provider);
+  });
+
+  if (provider.capabilities.messageEditing) {
+    await check("edit text", async () => {
+      await provider.editText(input.target, input.target.messageId ?? "1", "provider conformance edit");
+    });
+  }
+
+  if (provider.capabilities.inlineButtons) {
+    await check("send buttons", async () => {
+      const sent = await provider.sendButtons(input.target, "provider conformance buttons", [
+        [{ label: "Approve", token: createProviderToken("p") }],
+        [{ label: "Deny", token: createProviderToken("p"), style: "danger" }],
+      ], {
+        deliveryId: "provider-conformance-buttons",
+      });
+      validateSentMessage(sent, input.target, provider);
+    });
+  }
+
+  if (provider.capabilities.interactionAcknowledgement !== "none") {
+    await check("answer interaction", async () => {
+      if (!provider.answerInteraction) {
+        throw new Error("provider advertises interaction acknowledgement but does not implement answerInteraction");
+      }
+      await provider.answerInteraction("provider-conformance-interaction", "ok", false);
+    });
+  }
+
+  if (provider.capabilities.fileUploads) {
+    await check("send file", async () => {
+      const file = {
+        filename: "provider-conformance.txt",
+        mimeType: "text/plain",
+        data: new TextEncoder().encode("provider conformance file"),
+      };
+      const fileViolations = validateOutgoingFilePayload(file);
+      if (fileViolations.length > 0) {
+        throw new Error(fileViolations.join("; "));
+      }
+      const sent = await provider.sendFile(input.target, file);
+      validateSentMessage(sent, input.target, provider);
+    });
+  }
+
+  if (provider.capabilities.fileDownloads) {
+    await check("download attachment", async () => {
+      if (!provider.downloadAttachment) {
+        throw new Error("provider advertises file downloads but does not implement downloadAttachment");
+      }
+      if (!input.downloadableAttachment) {
+        throw new Error("file-download providers require a downloadableAttachment conformance sample");
+      }
+      const bytes = await provider.downloadAttachment(input.downloadableAttachment, { maxBytes: 1024 * 1024 });
+      if (!(bytes instanceof Uint8Array) || bytes.byteLength === 0) {
+        throw new Error("downloadAttachment must return non-empty Uint8Array data");
+      }
+    });
+  }
+
+  if (provider.capabilities.typingIndicator) {
+    await check("typing indicator", async () => {
+      if (!provider.setTyping) {
+        throw new Error("provider advertises typing indicators but does not implement setTyping");
+      }
+      await provider.setTyping(input.target);
+    });
+  }
+
+  await check("provider stop", async () => {
+    await provider.stop();
+  });
+
+  return {
+    providerId: String(provider.id),
+    providerKind: provider.kind,
+    checks,
+    violations,
+    passed: violations.length === 0,
+  };
+}
+
+export function validateIncomingChannelMessage(
+  message: IncomingChannelMessage,
+  provider: Pick<ChannelProvider, "id" | "kind">,
+): void {
+  const violations: string[] = [];
+  if (!message.id) violations.push("message id is required");
+  if ((message.providerInstanceId ?? message.provider) !== provider.id) {
+    violations.push(`message providerInstanceId ${message.providerInstanceId ?? "(missing)"} does not match ${provider.id}`);
+  }
+  if (message.provider !== provider.id) {
+    violations.push(`message provider ${message.provider} does not match ${provider.id}`);
+  }
+  if (message.providerKind !== provider.kind) {
+    violations.push(`message providerKind ${message.providerKind ?? "(missing)"} does not match ${provider.kind}`);
+  }
+  if (message.target.provider !== provider.id) {
+    violations.push(`target provider ${message.target.provider} does not match ${provider.id}`);
+  }
+  if (message.target.providerKind !== provider.kind) {
+    violations.push(`target providerKind ${message.target.providerKind ?? "(missing)"} does not match ${provider.kind}`);
+  }
+  if (!message.target.chatId) violations.push("target chatId is required");
+  if (!message.sender.providerUserId) violations.push("sender providerUserId is required");
+  if (typeof message.text !== "string") violations.push("message text must be a string");
+  if (typeof message.rawText !== "string") violations.push("message rawText must be a string");
+  if (message.isCommand && !message.command) violations.push("command messages must include command");
+  if (!message.providerEventId) violations.push("providerEventId is required");
+  if (message.providerMessageId !== undefined &&
+    message.providerMessageId !== null &&
+    (typeof message.providerMessageId !== "string" || message.providerMessageId.length === 0)) {
+    violations.push("providerMessageId must be a non-empty string or null when present");
+  }
+  if (!Array.isArray(message.attachments)) {
+    violations.push("attachments must be an array");
+  } else {
+    for (const attachment of message.attachments) validateAttachment(attachment, violations);
+  }
+  if (!(message.receivedAt instanceof Date) || Number.isNaN(message.receivedAt.getTime())) {
+    violations.push("receivedAt must be a valid Date");
+  }
+  if (message.interaction) {
+    if (!message.interaction.id) violations.push("interaction id is required");
+    if (!message.interaction.token) violations.push("interaction token is required");
+    if (Buffer.byteLength(message.interaction.token, "utf8") > 64) {
+      violations.push("interaction token cannot exceed 64 bytes");
+    }
+    if (message.interaction.kind !== "button" && message.interaction.kind !== "command") {
+      violations.push("interaction kind must be button or command");
+    }
+  }
+  if (violations.length > 0) throw new Error(violations.join("; "));
+}
+
+export function validateSentMessage(
+  sent: SentMessage,
+  target: ChannelTarget,
+  provider: Pick<ChannelProvider, "id" | "kind">,
+): void {
+  const violations: string[] = [];
+  if (sent.provider !== provider.id) violations.push(`sent provider ${sent.provider} does not match ${provider.id}`);
+  if (sent.providerKind !== provider.kind) {
+    violations.push(`sent providerKind ${sent.providerKind ?? "(missing)"} does not match ${provider.kind}`);
+  }
+  if (sent.chatId !== target.chatId) violations.push(`sent chatId ${sent.chatId} does not match target ${target.chatId}`);
+  if ((sent.threadId ?? null) !== (target.threadId ?? null)) {
+    violations.push(`sent threadId ${sent.threadId ?? "(none)"} does not match target ${target.threadId ?? "(none)"}`);
+  }
+  if (!sent.messageId) violations.push("sent messageId is required");
+  if (!(sent.sentAt instanceof Date) || Number.isNaN(sent.sentAt.getTime())) {
+    violations.push("sentAt must be a valid Date");
+  }
+  if (violations.length > 0) throw new Error(violations.join("; "));
+}
+
+function validateProviderCapabilities(provider: ChannelProvider): void {
+  const capabilities = normalizeChannelCapabilities(provider.capabilities);
+  const violations: string[] = [];
+  for (const field of ["threads", "messageEditing", "inlineButtons", "fileUploads", "fileDownloads", "typingIndicator"] as const) {
+    if (typeof capabilities[field] !== "boolean") violations.push(`capabilities.${field} must be boolean`);
+  }
+  for (const [field, allowZero] of [
+    ["maxTextLength", false],
+    ["maxButtonsPerMessage", !capabilities.inlineButtons],
+    ["maxButtonRowsPerMessage", !capabilities.inlineButtons],
+    ["maxButtonTokenBytes", !capabilities.inlineButtons],
+    ["maxFileSizeBytes", false],
+  ] as const) {
+    const value = capabilities[field] ?? 0;
+    if (!Number.isInteger(value) || value < (allowZero ? 0 : 1)) {
+      violations.push(`capabilities.${field} must be a ${allowZero ? "non-negative" : "positive"} integer`);
+    }
+  }
+  if (!Array.isArray(capabilities.inboundFileModes)) violations.push("capabilities.inboundFileModes must be an array");
+  if (!Array.isArray(capabilities.outboundFileModes)) violations.push("capabilities.outboundFileModes must be an array");
+  if (!["none", "text", "message"].includes(capabilities.editSemantics ?? "none")) {
+    violations.push("capabilities.editSemantics must be none, text, or message");
+  }
+  if (!["none", "optional", "required"].includes(capabilities.interactionAcknowledgement ?? "none")) {
+    violations.push("capabilities.interactionAcknowledgement must be none, optional, or required");
+  }
+  if (!["none", "retry_after", "fixed_backoff"].includes(capabilities.rateLimitStrategy ?? "none")) {
+    violations.push("capabilities.rateLimitStrategy must be none, retry_after, or fixed_backoff");
+  }
+  if (!["plain", "markdown", "html"].includes(capabilities.preferredParseMode)) {
+    violations.push("capabilities.preferredParseMode must be plain, markdown, or html");
+  }
+  if (violations.length > 0) throw new Error(violations.join("; "));
+}
+
+function validateInboundExpectation(message: IncomingChannelMessage, expected: ChannelProviderInboundExpectation | undefined): void {
+  if (!expected) return;
+  const violations: string[] = [];
+  if (expected.text !== undefined && message.text !== expected.text) violations.push(`expected text ${expected.text}, got ${message.text}`);
+  if (expected.chatId !== undefined && message.target.chatId !== expected.chatId) violations.push(`expected chatId ${expected.chatId}, got ${message.target.chatId}`);
+  if (expected.threadId !== undefined && (message.target.threadId ?? null) !== expected.threadId) {
+    violations.push(`expected threadId ${expected.threadId ?? "(none)"}, got ${message.target.threadId ?? "(none)"}`);
+  }
+  if (expected.isDirect !== undefined && message.target.isDirect !== expected.isDirect) {
+    violations.push(`expected isDirect ${String(expected.isDirect)}, got ${String(message.target.isDirect)}`);
+  }
+  if (expected.command !== undefined && message.command !== expected.command) {
+    violations.push(`expected command ${expected.command}, got ${message.command ?? "(none)"}`);
+  }
+  if (expected.interactionToken !== undefined && message.interaction?.token !== expected.interactionToken) {
+    violations.push(`expected interaction token ${expected.interactionToken}, got ${message.interaction?.token ?? "(none)"}`);
+  }
+  if (expected.attachmentCount !== undefined && message.attachments.length !== expected.attachmentCount) {
+    violations.push(`expected ${expected.attachmentCount} attachments, got ${message.attachments.length}`);
+  }
+  if (violations.length > 0) throw new Error(violations.join("; "));
+}
+
+function validateAttachment(attachment: ChannelAttachment, violations: string[]): void {
+  if (!attachment.filename.trim()) violations.push("attachment filename is required");
+  if (attachment.providerFileId !== undefined && typeof attachment.providerFileId !== "string") {
+    violations.push("attachment providerFileId must be a string");
+  }
+  if (attachment.downloadUrl !== undefined && typeof attachment.downloadUrl !== "string") {
+    violations.push("attachment downloadUrl must be a string");
+  }
+  if (attachment.buffer && !(attachment.buffer instanceof Uint8Array)) {
+    violations.push("attachment buffer must be a Uint8Array");
+  }
+  if (attachment.sizeBytes !== undefined && (!Number.isInteger(attachment.sizeBytes) || attachment.sizeBytes < 0)) {
+    violations.push("attachment sizeBytes must be a non-negative integer");
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/gateway-channel/src/index.ts
+++ b/packages/gateway-channel/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./conformance.js";
 export * from "./provider.js";
 export * from "./scope.js";
 export * from "./text.js";

--- a/packages/gateway-channel/src/provider.ts
+++ b/packages/gateway-channel/src/provider.ts
@@ -1,4 +1,4 @@
-export type ChannelProviderId =
+export type ChannelProviderKind =
   | "telegram"
   | "slack"
   | "email"
@@ -8,8 +8,45 @@ export type ChannelProviderId =
   | "webhook"
   | "cli";
 
-export function isChannelProviderId(value: string): value is ChannelProviderId {
-  return [
+export type ChannelProviderInstanceId = `${ChannelProviderKind}-${string}`;
+export type ChannelProviderLegacyInstanceId = `${string}-${string}`;
+export type ChannelProviderId = ChannelProviderKind | ChannelProviderInstanceId | ChannelProviderLegacyInstanceId;
+export type ChannelFileInputMode = "provider_file_id" | "download_url" | "inline_buffer";
+export type ChannelFileOutputMode = "local_path" | "inline_buffer" | "provider_file_id";
+export type ChannelParseMode = "plain" | "markdown" | "html";
+export type ChannelEditSemantics = "none" | "text" | "message";
+export type ChannelInteractionAcknowledgement = "none" | "optional" | "required";
+export type ChannelRateLimitStrategy = "none" | "retry_after" | "fixed_backoff";
+export type ChannelProviderLifecycleState = "starting" | "ready" | "degraded" | "failed" | "stopping" | "stopped";
+
+export interface ChannelProviderRetryState {
+  active: boolean;
+  attempt: number;
+  nextRetryAt: string | null;
+  backoffMs: number | null;
+}
+
+export interface ChannelProviderHealthPatch {
+  state?: ChannelProviderLifecycleState;
+  retry?: ChannelProviderRetryState;
+}
+
+export interface ChannelProviderHealth {
+  ok: boolean;
+  state?: ChannelProviderLifecycleState;
+  error?: string | null;
+}
+
+export interface ChannelProviderHealthReporter {
+  ready(patch?: ChannelProviderHealthPatch): void;
+  degraded(error: unknown, patch?: ChannelProviderHealthPatch): void;
+  failed(error: unknown, patch?: ChannelProviderHealthPatch): void;
+  retrying(error: unknown, patch?: ChannelProviderHealthPatch): void;
+  inbound(): void;
+  outbound(): void;
+}
+
+const channelProviderKinds = [
     "telegram",
     "slack",
     "email",
@@ -18,7 +55,60 @@ export function isChannelProviderId(value: string): value is ChannelProviderId {
     "signal",
     "webhook",
     "cli"
-  ].includes(value);
+] as const satisfies readonly ChannelProviderKind[];
+
+export function isChannelProviderKind(value: unknown): value is ChannelProviderKind {
+  return typeof value === "string" && (channelProviderKinds as readonly string[]).includes(value);
+}
+
+export function isChannelProviderInstanceId(value: unknown): value is ChannelProviderInstanceId {
+  return typeof value === "string" &&
+    /^[a-z][a-z0-9_-]{0,63}$/.test(value) &&
+    value.includes("-") &&
+    !isChannelProviderKind(value) &&
+    channelProviderKindFromId(value) !== null;
+}
+
+export function isChannelProviderId(value: unknown): value is ChannelProviderId {
+  return isChannelProviderKind(value) || isSafeChannelProviderInstanceId(value);
+}
+
+export function isChannelProviderInstanceIdForKind(
+  value: unknown,
+  kind: unknown,
+): value is ChannelProviderInstanceId {
+  return isChannelProviderInstanceId(value) &&
+    isChannelProviderKind(kind) &&
+    value.startsWith(`${kind}-`);
+}
+
+export function channelProviderKindFromId(value: unknown): ChannelProviderKind | null {
+  if (isChannelProviderKind(value)) return value;
+  if (typeof value !== "string") return null;
+  const match = /^([a-z][a-z0-9]*)-/.exec(value);
+  const kind = match?.[1];
+  return isChannelProviderKind(kind) ? kind : null;
+}
+
+export function normalizeChannelProviderIdentity(
+  kind: ChannelProviderKind,
+  providerId?: string | null,
+): { providerId: ChannelProviderId; providerKind: ChannelProviderKind; legacyKindId: boolean } {
+  const id = providerId?.trim() || kind;
+  if (id === kind) {
+    return { providerId: kind, providerKind: kind, legacyKindId: true };
+  }
+  if (!isChannelProviderInstanceIdForKind(id, kind)) {
+    if (isSafeChannelProviderInstanceId(id)) {
+      return { providerId: id, providerKind: kind, legacyKindId: true };
+    }
+    throw new Error(`Channel provider id ${id} must equal ${kind}, start with ${kind}-, or be a safe legacy provider id.`);
+  }
+  return { providerId: id, providerKind: kind, legacyKindId: false };
+}
+
+function isSafeChannelProviderInstanceId(value: unknown): value is ChannelProviderLegacyInstanceId {
+  return typeof value === "string" && /^[a-z][a-z0-9_-]{1,63}$/.test(value) && value.includes("-");
 }
 
 export interface ChannelCapabilities {
@@ -35,11 +125,18 @@ export interface ChannelCapabilities {
   maxButtonRowsPerMessage?: number;
   maxButtonTokenBytes?: number;
   maxFileBytes?: number;
+  maxFileSizeBytes?: number;
+  inboundFileModes?: ChannelFileInputMode[];
+  outboundFileModes?: ChannelFileOutputMode[];
+  editSemantics?: ChannelEditSemantics;
+  interactionAcknowledgement?: ChannelInteractionAcknowledgement;
+  rateLimitStrategy?: ChannelRateLimitStrategy;
   supportsEphemeralResponses?: boolean;
 }
 
 export interface ChannelTarget {
   provider: ChannelProviderId;
+  providerKind?: ChannelProviderKind;
   chatId: string;
   isDirect?: boolean;
   threadId?: string | null;
@@ -49,6 +146,7 @@ export interface ChannelTarget {
 
 export interface ChannelAttachment {
   providerFileId?: string;
+  downloadUrl?: string;
   filename: string;
   mimeType?: string;
   sizeBytes?: number;
@@ -64,7 +162,11 @@ export interface ChannelInteraction {
 
 export interface IncomingChannelMessage {
   id: string;
+  providerInstanceId?: ChannelProviderId;
+  providerEventId?: string;
+  providerMessageId?: string | null;
   provider: ChannelProviderId;
+  providerKind?: ChannelProviderKind;
   target: ChannelTarget;
   sender: {
     providerUserId: string;
@@ -93,27 +195,36 @@ export interface SendOptions {
   replyToMessageId?: string;
   parseMode?: "plain" | "markdown" | "html";
   disableNotification?: boolean;
+  deliveryId?: string;
 }
 
 export interface SentMessage {
   provider: ChannelProviderId;
+  providerKind?: ChannelProviderKind;
   chatId: string;
   messageId: string;
   threadId?: string | null;
+  providerDeliveryId?: string;
   sentAt: Date;
 }
 
 export interface OutgoingFile {
   filename: string;
   mimeType?: string;
+  localPath?: string;
+  /**
+   * @deprecated Use localPath. Kept for compatibility with existing callers.
+   */
   path?: string;
   data?: Uint8Array;
 }
 
 export interface ChannelProvider {
   readonly id: ChannelProviderId;
+  readonly kind: ChannelProviderKind;
   readonly capabilities: ChannelCapabilities;
-  health?(): { ok: boolean; error?: string | null };
+  health?(): ChannelProviderHealth;
+  setHealthReporter?(reporter: ChannelProviderHealthReporter): void;
 
   start(handler: (message: IncomingChannelMessage) => Promise<void>): Promise<void>;
   stop(): Promise<void>;
@@ -130,8 +241,84 @@ export interface ChannelProvider {
     target: ChannelTarget,
     text: string,
     buttons: ChannelButton[][],
+    options?: SendOptions,
   ): Promise<SentMessage>;
-  downloadAttachment?(attachment: ChannelAttachment): Promise<Uint8Array>;
+  downloadAttachment?(attachment: ChannelAttachment, options?: { maxBytes?: number }): Promise<Uint8Array | undefined>;
   answerInteraction?(interactionId: string, text?: string, alert?: boolean): Promise<void>;
   setTyping?(target: ChannelTarget): Promise<void>;
+}
+
+export interface OutgoingFileSource {
+  data?: Uint8Array;
+  localPath?: string;
+}
+
+export function normalizeChannelCapabilities(capabilities: ChannelCapabilities): ChannelCapabilities {
+  const maxFileBytes = positiveInteger(capabilities.maxFileBytes ?? capabilities.maxFileSizeBytes ?? 25 * 1024 * 1024, "maxFileBytes");
+  const preferredParseMode = parseMode(capabilities.preferredParseMode);
+  const parseModes = capabilities.parseModes?.length
+    ? Array.from(new Set(capabilities.parseModes.map(parseMode)))
+    : [preferredParseMode];
+  if (!parseModes.includes(preferredParseMode)) parseModes.unshift(preferredParseMode);
+  return {
+    ...capabilities,
+    preferredParseMode,
+    parseModes,
+    maxButtonsPerMessage: nonNegativeInteger(capabilities.maxButtonsPerMessage ?? (capabilities.inlineButtons ? 8 : 0), "maxButtonsPerMessage"),
+    maxButtonRowsPerMessage: nonNegativeInteger(capabilities.maxButtonRowsPerMessage ?? (capabilities.inlineButtons ? 4 : 0), "maxButtonRowsPerMessage"),
+    maxButtonTokenBytes: nonNegativeInteger(capabilities.maxButtonTokenBytes ?? (capabilities.inlineButtons ? 64 : 0), "maxButtonTokenBytes"),
+    maxFileBytes,
+    maxFileSizeBytes: maxFileBytes,
+    inboundFileModes: capabilities.inboundFileModes ?? (capabilities.fileDownloads ? ["provider_file_id", "download_url", "inline_buffer"] : []),
+    outboundFileModes: capabilities.outboundFileModes ?? (capabilities.fileUploads ? ["local_path", "inline_buffer"] : []),
+    editSemantics: capabilities.editSemantics ?? (capabilities.messageEditing ? "message" : "none"),
+    interactionAcknowledgement: capabilities.interactionAcknowledgement ?? (capabilities.inlineButtons ? "optional" : "none"),
+    rateLimitStrategy: capabilities.rateLimitStrategy ?? "fixed_backoff",
+    supportsEphemeralResponses: capabilities.supportsEphemeralResponses ?? false
+  };
+}
+
+export function validateOutgoingFilePayload(file: OutgoingFile): string[] {
+  const violations: string[] = [];
+  const filename = file.filename.trim();
+  const localPath = file.localPath ?? file.path;
+  if (!filename) violations.push("outgoing file filename is required");
+  if (file.localPath && file.path && file.localPath !== file.path) {
+    violations.push("outgoing file cannot set both localPath and path to different values");
+  }
+  if (file.data && localPath) {
+    violations.push("outgoing file cannot set both inline data and a local path");
+  }
+  if (!file.data && !localPath) {
+    violations.push("outgoing file requires inline data or localPath");
+  }
+  if (file.data && !(file.data instanceof Uint8Array)) {
+    violations.push("outgoing file data must be a Uint8Array");
+  }
+  return violations;
+}
+
+export function resolveOutgoingFileSource(file: OutgoingFile): OutgoingFileSource {
+  const violations = validateOutgoingFilePayload(file);
+  if (violations.length > 0) throw new Error(violations.join("; "));
+  return {
+    data: file.data,
+    localPath: file.localPath ?? file.path
+  };
+}
+
+function parseMode(value: unknown): ChannelParseMode {
+  return value === "markdown" || value === "html" ? value : "plain";
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  const number = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(number) || number < 1) throw new Error(`${label} must be a positive integer`);
+  return number;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  const number = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(number) || number < 0) throw new Error(`${label} must be a non-negative integer`);
+  return number;
 }

--- a/packages/gateway-channel/src/scope.ts
+++ b/packages/gateway-channel/src/scope.ts
@@ -19,7 +19,7 @@ export function buildScopeKey(target: ChannelTarget): string {
 }
 
 export function isSafeScopeKey(scopeKey: string): boolean {
-  return /^[a-z]+:(dm|chat):[-_a-zA-Z0-9:]+$/.test(scopeKey);
+  return /^[a-z][a-z0-9_-]*:(dm|chat):[-_a-zA-Z0-9:]+$/.test(scopeKey);
 }
 
 function scopeComponent(value: string): string {

--- a/packages/gateway-provider-cli/src/cli-provider.ts
+++ b/packages/gateway-provider-cli/src/cli-provider.ts
@@ -6,14 +6,18 @@ import type {
   ChannelAttachment,
   ChannelButton,
   ChannelCapabilities,
+  ChannelProviderId,
+  ChannelProviderKind,
   ChannelProvider,
   ChannelTarget,
   IncomingChannelMessage,
   SendOptions,
   SentMessage
 } from "@open-cowork/gateway-channel";
+import { normalizeChannelCapabilities, normalizeChannelProviderIdentity } from "@open-cowork/gateway-channel";
 
 export interface CliProviderConfig {
+  providerId?: ChannelProviderId;
   input?: Readable;
   output?: Writable;
   now?: () => Date;
@@ -42,8 +46,10 @@ export interface CliIncomingPayload {
 }
 
 export class CliProvider implements ChannelProvider {
-  readonly id = "cli" as const;
-  readonly capabilities: ChannelCapabilities = {
+  readonly kind: ChannelProviderKind = "cli";
+  readonly id: ChannelProviderId;
+  readonly capabilities: ChannelCapabilities;
+  private readonly baseCapabilities: ChannelCapabilities = {
     threads: true,
     messageEditing: false,
     inlineButtons: false,
@@ -57,6 +63,12 @@ export class CliProvider implements ChannelProvider {
     maxButtonRowsPerMessage: 0,
     maxButtonTokenBytes: 0,
     maxFileBytes: 10 * 1024 * 1024,
+    maxFileSizeBytes: 10 * 1024 * 1024,
+    inboundFileModes: ["inline_buffer"],
+    outboundFileModes: [],
+    editSemantics: "none",
+    interactionAcknowledgement: "none",
+    rateLimitStrategy: "none",
     supportsEphemeralResponses: false
   };
 
@@ -67,6 +79,8 @@ export class CliProvider implements ChannelProvider {
   private reader: Interface | null = null;
 
   constructor(config: CliProviderConfig = {}) {
+    this.id = normalizeChannelProviderIdentity(this.kind, config.providerId).providerId;
+    this.capabilities = normalizeChannelCapabilities(this.baseCapabilities);
     this.input = config.input ?? process.stdin;
     this.output = config.output ?? process.stdout;
     this.now = config.now ?? (() => new Date());
@@ -120,7 +134,7 @@ export class CliProvider implements ChannelProvider {
       const payload = trimmed.startsWith("{")
         ? JSON.parse(trimmed) as unknown
         : { text: trimmed };
-      await handler(mapCliPayload(payload, this.now()));
+      await handler(mapCliPayload(payload, this.now(), this.id));
     } catch (error) {
       this.writeJson({
         type: "error",
@@ -140,7 +154,8 @@ export class CliProvider implements ChannelProvider {
       ...payload
     });
     return {
-      provider: "cli",
+      provider: target.provider,
+      providerKind: target.providerKind ?? this.kind,
       chatId: target.chatId,
       threadId: target.threadId,
       messageId,
@@ -149,22 +164,28 @@ export class CliProvider implements ChannelProvider {
   }
 
   private writeJson(payload: Record<string, unknown>): void {
-    this.output.write(`${JSON.stringify({ provider: "cli", ...payload })}\n`);
+    this.output.write(`${JSON.stringify({ provider: this.id, providerKind: this.kind, ...payload })}\n`);
   }
 }
 
-export function mapCliPayload(payload: unknown, now = new Date()): IncomingChannelMessage {
+export function mapCliPayload(payload: unknown, now = new Date(), providerId: ChannelProviderId = "cli"): IncomingChannelMessage {
   const record = isRecord(payload) ? payload as CliIncomingPayload : { text: String(payload ?? "") };
   const text = cleanString(record.text) ?? "";
   const rawText = cleanString(record.rawText) ?? text;
   const chatId = cleanString(record.chatId) ?? "local-cli";
   const userId = cleanString(record.userId) ?? "cli-user";
   const command = parseCommand(text);
+  const id = cleanString(record.id) ?? randomUUID();
   return {
-    id: cleanString(record.id) ?? randomUUID(),
-    provider: "cli",
+    id,
+    providerInstanceId: providerId,
+    providerEventId: id,
+    providerMessageId: id,
+    provider: providerId,
+    providerKind: "cli",
     target: {
-      provider: "cli",
+      provider: providerId,
+      providerKind: "cli",
       chatId,
       isDirect: true,
       threadId: cleanString(record.threadId) ?? null,
@@ -188,11 +209,12 @@ export function mapCliPayload(payload: unknown, now = new Date()): IncomingChann
 }
 
 function normalizeTarget(target: ChannelTarget): ChannelTarget {
-  if (target.provider !== "cli") {
+  if (target.providerKind !== "cli" && target.provider !== "cli" && !String(target.provider).startsWith("cli-")) {
     throw new Error(`CLI provider cannot deliver target for provider ${target.provider}.`);
   }
   return {
-    provider: "cli",
+    provider: target.provider,
+    providerKind: "cli",
     chatId: cleanRequired(target.chatId, "CLI target.chatId"),
     isDirect: target.isDirect === true,
     threadId: cleanString(target.threadId) ?? null,

--- a/packages/gateway-provider-discord/src/discord-provider.ts
+++ b/packages/gateway-provider-discord/src/discord-provider.ts
@@ -1,7 +1,7 @@
 import type { ChannelCapabilities } from "@open-cowork/gateway-channel";
 import { WebhookProvider, type WebhookProviderConfig } from "@open-cowork/gateway-provider-webhook";
 
-export type DiscordProviderConfig = Omit<WebhookProviderConfig, "providerId" | "capabilities" | "sharedSecret"> & {
+export type DiscordProviderConfig = Omit<WebhookProviderConfig, "providerKind" | "capabilities" | "sharedSecret"> & {
   sharedSecret: string;
 };
 
@@ -19,6 +19,12 @@ export const discordCapabilities: ChannelCapabilities = {
   maxButtonRowsPerMessage: 5,
   maxButtonTokenBytes: 64,
   maxFileBytes: 8 * 1024 * 1024,
+  maxFileSizeBytes: 8 * 1024 * 1024,
+  inboundFileModes: ["provider_file_id", "download_url", "inline_buffer"],
+  outboundFileModes: ["inline_buffer"],
+  editSemantics: "message",
+  interactionAcknowledgement: "optional",
+  rateLimitStrategy: "fixed_backoff",
   supportsEphemeralResponses: true
 };
 
@@ -29,7 +35,8 @@ export class DiscordProvider extends WebhookProvider {
     }
     super({
       ...config,
-      providerId: "discord",
+      providerKind: "discord",
+      providerId: config.providerId ?? "discord",
       capabilities: discordCapabilities
     });
   }

--- a/packages/gateway-provider-email/src/email-provider.ts
+++ b/packages/gateway-provider-email/src/email-provider.ts
@@ -6,14 +6,18 @@ import type {
   ChannelAttachment,
   ChannelButton,
   ChannelCapabilities,
+  ChannelProviderId,
+  ChannelProviderKind,
   ChannelProvider,
   ChannelTarget,
   IncomingChannelMessage,
   SendOptions,
   SentMessage
 } from "@open-cowork/gateway-channel";
+import { normalizeChannelCapabilities, normalizeChannelProviderIdentity } from "@open-cowork/gateway-channel";
 
 export interface EmailProviderConfig {
+  providerId?: ChannelProviderId;
   from: string;
   inboundSecret: string;
   smtp?: SmtpEmailTransportConfig;
@@ -91,23 +95,31 @@ const emailCapabilities: ChannelCapabilities = {
   maxButtonRowsPerMessage: 0,
   maxButtonTokenBytes: 0,
   maxFileBytes: 15 * 1024 * 1024,
+  maxFileSizeBytes: 15 * 1024 * 1024,
+  inboundFileModes: ["inline_buffer"],
+  outboundFileModes: [],
+  editSemantics: "none",
+  interactionAcknowledgement: "none",
+  rateLimitStrategy: "fixed_backoff",
   supportsEphemeralResponses: false
 };
 
 export class EmailProvider implements ChannelProvider {
-  readonly id = "email" as const;
+  readonly kind: ChannelProviderKind = "email";
+  readonly id: ChannelProviderId;
   readonly capabilities: ChannelCapabilities;
 
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
   private readonly transport: EmailTransport;
 
   constructor(private readonly config: EmailProviderConfig) {
+    this.id = normalizeChannelProviderIdentity(this.kind, config.providerId).providerId;
     if (!emailAddress(config.from)) throw new Error("Email provider requires a valid from address.");
     if (!config.inboundSecret.trim()) throw new Error("Email inbound secret is required.");
-    this.capabilities = {
+    this.capabilities = normalizeChannelCapabilities({
       ...emailCapabilities,
       maxFileBytes: Math.min(emailCapabilities.maxFileBytes!, normalizeAttachmentLimit(config.maxAttachmentBytes) ?? emailCapabilities.maxFileBytes!)
-    };
+    });
     this.transport = config.transport || new SmtpEmailTransport(config.smtp || missingSmtpConfig());
   }
 
@@ -122,7 +134,7 @@ export class EmailProvider implements ChannelProvider {
   async handleWebhookPayload(payload: unknown, auth: EmailWebhookAuth): Promise<void> {
     if (!this.handler) throw new Error("Email provider is not started.");
     this.assertWebhookAuthorized(auth);
-    const message = mapEmailPayload(payload, this.config.now?.() ?? new Date(), this.capabilities.maxFileBytes);
+    const message = mapEmailPayload(payload, this.config.now?.() ?? new Date(), this.capabilities.maxFileBytes, this.id);
     if (message) await this.handler(message);
   }
 
@@ -138,7 +150,8 @@ export class EmailProvider implements ChannelProvider {
       references: target.threadId ? [target.threadId] : null
     });
     return {
-      provider: "email",
+      provider: target.provider,
+      providerKind: target.providerKind ?? "email",
       chatId: target.chatId,
       threadId: target.threadId || messageId,
       messageId: result?.messageId || messageId,
@@ -209,7 +222,7 @@ export class SmtpEmailTransport implements EmailTransport {
   }
 }
 
-function mapEmailPayload(payload: unknown, now: Date, maxAttachmentBytes: number | undefined): IncomingChannelMessage | null {
+function mapEmailPayload(payload: unknown, now: Date, maxAttachmentBytes: number | undefined, providerId: ChannelProviderId = "email"): IncomingChannelMessage | null {
   const input = objectRecord(payload) as EmailIncomingPayload;
   const from = emailAddress(input.from) || emailAddress(input.sender);
   if (!from) return null;
@@ -221,9 +234,14 @@ function mapEmailPayload(payload: unknown, now: Date, maxAttachmentBytes: number
     || messageId;
   return {
     id: messageId,
-    provider: "email",
+    providerInstanceId: providerId,
+    providerEventId: messageId,
+    providerMessageId: messageId,
+    provider: providerId,
+    providerKind: "email",
     target: {
-      provider: "email",
+      provider: providerId,
+      providerKind: "email",
       chatId: from,
       threadId,
       userId: from,

--- a/packages/gateway-provider-signal/src/signal-provider.ts
+++ b/packages/gateway-provider-signal/src/signal-provider.ts
@@ -1,7 +1,7 @@
 import type { ChannelCapabilities } from "@open-cowork/gateway-channel";
 import { WebhookProvider, type WebhookProviderConfig } from "@open-cowork/gateway-provider-webhook";
 
-export type SignalProviderConfig = Omit<WebhookProviderConfig, "providerId" | "capabilities" | "sharedSecret"> & {
+export type SignalProviderConfig = Omit<WebhookProviderConfig, "providerKind" | "capabilities" | "sharedSecret"> & {
   sharedSecret: string;
 };
 
@@ -16,6 +16,12 @@ export const signalCapabilities: ChannelCapabilities = {
   preferredParseMode: "plain",
   parseModes: ["plain"],
   maxFileBytes: 100 * 1024 * 1024,
+  maxFileSizeBytes: 100 * 1024 * 1024,
+  inboundFileModes: ["provider_file_id", "download_url", "inline_buffer"],
+  outboundFileModes: ["inline_buffer"],
+  editSemantics: "none",
+  interactionAcknowledgement: "none",
+  rateLimitStrategy: "fixed_backoff",
   supportsEphemeralResponses: false
 };
 
@@ -26,7 +32,8 @@ export class SignalProvider extends WebhookProvider {
     }
     super({
       ...config,
-      providerId: "signal",
+      providerKind: "signal",
+      providerId: config.providerId ?? "signal",
       capabilities: signalCapabilities
     });
   }

--- a/packages/gateway-provider-slack/src/slack-provider.ts
+++ b/packages/gateway-provider-slack/src/slack-provider.ts
@@ -5,6 +5,8 @@ import type {
   ChannelAttachment,
   ChannelButton,
   ChannelCapabilities,
+  ChannelProviderId,
+  ChannelProviderKind,
   ChannelProvider,
   ChannelTarget,
   IncomingChannelMessage,
@@ -12,8 +14,10 @@ import type {
   SendOptions,
   SentMessage
 } from "@open-cowork/gateway-channel";
+import { normalizeChannelCapabilities, normalizeChannelProviderIdentity } from "@open-cowork/gateway-channel";
 
 export interface SlackProviderConfig {
+  providerId?: ChannelProviderId;
   botToken: string;
   signingSecret: string;
   apiBaseUrl?: string;
@@ -53,8 +57,10 @@ const defaultMaxSignatureAgeMs = 5 * 60 * 1000;
 const defaultSlackRequestTimeoutMs = 15_000;
 
 export class SlackProvider implements ChannelProvider {
-  readonly id = "slack" as const;
-  readonly capabilities: ChannelCapabilities = {
+  readonly kind: ChannelProviderKind = "slack";
+  readonly id: ChannelProviderId;
+  readonly capabilities: ChannelCapabilities;
+  private readonly baseCapabilities: ChannelCapabilities = {
     threads: true,
     messageEditing: true,
     inlineButtons: true,
@@ -68,12 +74,20 @@ export class SlackProvider implements ChannelProvider {
     maxButtonRowsPerMessage: 5,
     maxButtonTokenBytes: 2000,
     maxFileBytes: 20 * 1024 * 1024,
+    maxFileSizeBytes: 20 * 1024 * 1024,
+    inboundFileModes: ["download_url", "provider_file_id"],
+    outboundFileModes: ["local_path", "inline_buffer"],
+    editSemantics: "message",
+    interactionAcknowledgement: "optional",
+    rateLimitStrategy: "retry_after",
     supportsEphemeralResponses: false
   };
 
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
 
   constructor(private readonly config: SlackProviderConfig) {
+    this.id = normalizeChannelProviderIdentity(this.kind, config.providerId).providerId;
+    this.capabilities = normalizeChannelCapabilities(this.baseCapabilities);
     if (!config.botToken.trim()) throw new Error("Slack bot token is required.");
     if (!config.signingSecret.trim()) throw new Error("Slack signing secret is required.");
   }
@@ -95,7 +109,7 @@ export class SlackProvider implements ChannelProvider {
     }
 
     if (!this.handler) throw new Error("Slack provider is not started.");
-    const message = mapSlackPayload(record, this.config.now?.() ?? new Date());
+    const message = mapSlackPayload(record, this.config.now?.() ?? new Date(), this.id);
     if (message) await this.handler(message);
     return undefined;
   }
@@ -122,7 +136,8 @@ export class SlackProvider implements ChannelProvider {
   }
 
   async sendFile(target: ChannelTarget, file: OutgoingFile): Promise<SentMessage> {
-    const data = file.data || (file.path ? new Uint8Array(await readFile(file.path)) : new Uint8Array());
+    const filePath = file.localPath ?? file.path;
+    const data = file.data || (filePath ? new Uint8Array(await readFile(filePath)) : new Uint8Array());
     if (data.byteLength === 0) throw new Error("Slack file upload requires file data.");
     if (data.byteLength > this.capabilities.maxFileBytes!) {
       throw new Error(`Slack file exceeds maxFileBytes ${this.capabilities.maxFileBytes}.`);
@@ -258,17 +273,17 @@ function normalizeRequestTimeoutMs(value: number | undefined): number {
   return Math.min(120_000, Math.max(100, Math.floor(value)));
 }
 
-function mapSlackPayload(payload: Record<string, unknown>, now: Date): IncomingChannelMessage | null {
+function mapSlackPayload(payload: Record<string, unknown>, now: Date, providerId: ChannelProviderId = "slack"): IncomingChannelMessage | null {
   if (payload.type === "event_callback") {
-    return mapSlackEvent(objectRecord(payload.event), payload, now);
+    return mapSlackEvent(objectRecord(payload.event), payload, now, providerId);
   }
   if (payload.type === "block_actions") {
-    return mapSlackInteraction(payload, now);
+    return mapSlackInteraction(payload, now, providerId);
   }
   return null;
 }
 
-function mapSlackEvent(event: Record<string, unknown>, envelope: Record<string, unknown>, now: Date): IncomingChannelMessage | null {
+function mapSlackEvent(event: Record<string, unknown>, envelope: Record<string, unknown>, now: Date, providerId: ChannelProviderId): IncomingChannelMessage | null {
   if (event.type !== "message" || event.subtype === "bot_message" || stringField(event, "bot_id")) return null;
   const user = stringField(event, "user");
   const channel = stringField(event, "channel");
@@ -278,9 +293,14 @@ function mapSlackEvent(event: Record<string, unknown>, envelope: Record<string, 
   const teamId = stringField(envelope, "team_id") || stringField(event, "team");
   return {
     id: stringField(event, "client_msg_id") || `slack-${teamId || "team"}-${channel}-${ts}`,
-    provider: "slack",
+    providerInstanceId: providerId,
+    providerEventId: stringField(envelope, "event_id") || stringField(event, "client_msg_id") || `${channel}:${ts}`,
+    providerMessageId: ts,
+    provider: providerId,
+    providerKind: "slack",
     target: {
-      provider: "slack",
+      provider: providerId,
+      providerKind: "slack",
       chatId: channel,
       threadId: stringField(event, "thread_ts") || ts,
       userId: user,
@@ -304,7 +324,7 @@ function mapSlackEvent(event: Record<string, unknown>, envelope: Record<string, 
   };
 }
 
-function mapSlackInteraction(payload: Record<string, unknown>, now: Date): IncomingChannelMessage | null {
+function mapSlackInteraction(payload: Record<string, unknown>, now: Date, providerId: ChannelProviderId): IncomingChannelMessage | null {
   const user = objectRecord(payload.user);
   const channel = objectRecord(payload.channel);
   const message = objectRecord(payload.message);
@@ -315,11 +335,17 @@ function mapSlackInteraction(payload: Record<string, unknown>, now: Date): Incom
   const channelId = stringField(channel, "id");
   const messageTs = stringField(message, "thread_ts") || stringField(message, "ts") || stringField(payload, "message_ts");
   if (!token || !userId || !channelId) return null;
+  const id = stringField(payload, "trigger_id") || stringField(action, "action_ts") || randomUUID();
   return {
-    id: stringField(payload, "trigger_id") || stringField(action, "action_ts") || randomUUID(),
-    provider: "slack",
+    id,
+    providerInstanceId: providerId,
+    providerEventId: id,
+    providerMessageId: stringField(message, "ts") ?? null,
+    provider: providerId,
+    providerKind: "slack",
     target: {
-      provider: "slack",
+      provider: providerId,
+      providerKind: "slack",
       chatId: channelId,
       threadId: messageTs,
       userId,
@@ -366,7 +392,8 @@ function validateSlackButtons(buttons: ChannelButton[][]): void {
 
 function sentMessage(target: ChannelTarget, messageId: string): SentMessage {
   return {
-    provider: "slack",
+    provider: target.provider,
+    providerKind: target.providerKind ?? "slack",
     chatId: target.chatId,
     threadId: target.threadId || messageId,
     messageId,

--- a/packages/gateway-provider-telegram/src/telegram-provider.ts
+++ b/packages/gateway-provider-telegram/src/telegram-provider.ts
@@ -2,6 +2,8 @@ import type {
   ChannelAttachment,
   ChannelButton,
   ChannelCapabilities,
+  ChannelProviderId,
+  ChannelProviderKind,
   ChannelProvider,
   ChannelTarget,
   IncomingChannelMessage,
@@ -9,12 +11,14 @@ import type {
   SendOptions,
   SentMessage
 } from "@open-cowork/gateway-channel";
+import { normalizeChannelCapabilities, normalizeChannelProviderIdentity } from "@open-cowork/gateway-channel";
 import { Bot, InlineKeyboard, InputFile, type Context } from "grammy";
 import { timingSafeEqual } from "node:crypto";
 import type { Update } from "grammy/types";
 import { withTelegramRetry, type TelegramRateLimitEvent } from "./telegram-retry.js";
 
 export interface TelegramProviderConfig {
+  providerId?: ChannelProviderId;
   botToken: string;
   mode: "polling" | "webhook";
   fetch?: typeof globalThis.fetch;
@@ -41,8 +45,10 @@ export interface TelegramWebhookAuth {
 }
 
 export class TelegramProvider implements ChannelProvider {
-  readonly id = "telegram" as const;
-  readonly capabilities: ChannelCapabilities = {
+  readonly kind: ChannelProviderKind = "telegram";
+  readonly id: ChannelProviderId;
+  readonly capabilities: ChannelCapabilities;
+  private readonly baseCapabilities: ChannelCapabilities = {
     threads: true,
     messageEditing: true,
     inlineButtons: true,
@@ -56,6 +62,12 @@ export class TelegramProvider implements ChannelProvider {
     maxButtonRowsPerMessage: 4,
     maxButtonTokenBytes: 64,
     maxFileBytes: 20 * 1024 * 1024,
+    maxFileSizeBytes: 20 * 1024 * 1024,
+    inboundFileModes: ["provider_file_id"],
+    outboundFileModes: ["local_path", "inline_buffer"],
+    editSemantics: "message",
+    interactionAcknowledgement: "required",
+    rateLimitStrategy: "retry_after",
     supportsEphemeralResponses: true
   };
 
@@ -68,6 +80,8 @@ export class TelegramProvider implements ChannelProvider {
   private identity?: TelegramBotIdentity;
 
   constructor(private readonly config: TelegramProviderConfig) {
+    this.id = normalizeChannelProviderIdentity(this.kind, config.providerId).providerId;
+    this.capabilities = normalizeChannelCapabilities(this.baseCapabilities);
     this.bot = new Bot(config.botToken);
   }
 
@@ -87,7 +101,7 @@ export class TelegramProvider implements ChannelProvider {
         if (!this.handler || !this.identity) {
           return;
         }
-        const message = mapTelegramMessage(ctx, this.config, this.identity);
+        const message = mapTelegramMessage(ctx, this.config, this.identity, this.id);
         if (message) {
           await this.handler(message);
         }
@@ -97,7 +111,7 @@ export class TelegramProvider implements ChannelProvider {
         if (!this.handler) {
           return;
         }
-        const message = mapTelegramCallback(ctx);
+        const message = mapTelegramCallback(ctx, this.id);
         if (message) {
           await this.handler(message);
         }
@@ -173,7 +187,8 @@ export class TelegramProvider implements ChannelProvider {
   }
 
   async sendFile(target: ChannelTarget, file: OutgoingFile): Promise<SentMessage> {
-    const inputFile = file.path ? new InputFile(file.path, file.filename) : new InputFile(file.data ?? new Uint8Array(), file.filename);
+    const filePath = file.localPath ?? file.path;
+    const inputFile = filePath ? new InputFile(filePath, file.filename) : new InputFile(file.data ?? new Uint8Array(), file.filename);
     const sent = await this.retry(() => this.bot.api.sendDocument(toChatId(target.chatId), inputFile, {
       message_thread_id: toThreadId(target.threadId)
     }));
@@ -270,6 +285,7 @@ export function mapTelegramMessage(
   ctx: Context,
   config: TelegramProviderConfig,
   identity: TelegramBotIdentity,
+  providerId: ChannelProviderId = "telegram",
 ): IncomingChannelMessage | null {
   const message = ctx.message;
   const from = message?.from;
@@ -290,9 +306,14 @@ export function mapTelegramMessage(
 
   return {
     id: String(message.message_id),
-    provider: "telegram",
+    providerInstanceId: providerId,
+    providerEventId: String(message.message_id),
+    providerMessageId: String(message.message_id),
+    provider: providerId,
+    providerKind: "telegram",
     target: {
-      provider: "telegram",
+      provider: providerId,
+      providerKind: "telegram",
       chatId: String(chat.id),
       isDirect: chat.type === "private",
       threadId,
@@ -316,7 +337,7 @@ export function mapTelegramMessage(
   };
 }
 
-export function mapTelegramCallback(ctx: Context): IncomingChannelMessage | null {
+export function mapTelegramCallback(ctx: Context, providerId: ChannelProviderId = "telegram"): IncomingChannelMessage | null {
   const query = ctx.callbackQuery;
   const from = query?.from;
   const data = query?.data;
@@ -333,9 +354,14 @@ export function mapTelegramCallback(ctx: Context): IncomingChannelMessage | null
 
   return {
     id: query.id,
-    provider: "telegram",
+    providerInstanceId: providerId,
+    providerEventId: query.id,
+    providerMessageId: String(message.message_id),
+    provider: providerId,
+    providerKind: "telegram",
     target: {
-      provider: "telegram",
+      provider: providerId,
+      providerKind: "telegram",
       chatId: String(chat.id),
       isDirect: chat.type === "private",
       threadId,
@@ -497,7 +523,8 @@ function toThreadId(threadId: string | null | undefined): number | undefined {
 
 function toSentMessage(target: ChannelTarget, messageId: number): SentMessage {
   return {
-    provider: "telegram",
+    provider: target.provider,
+    providerKind: target.providerKind ?? "telegram",
     chatId: target.chatId,
     threadId: target.threadId,
     messageId: String(messageId),

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -3,6 +3,7 @@ import type {
   ChannelAttachment,
   ChannelButton,
   ChannelCapabilities,
+  ChannelProviderKind,
   ChannelProviderId,
   ChannelProvider,
   ChannelTarget,
@@ -11,9 +12,11 @@ import type {
   SendOptions,
   SentMessage
 } from "@open-cowork/gateway-channel";
+import { channelProviderKindFromId, normalizeChannelCapabilities, normalizeChannelProviderIdentity } from "@open-cowork/gateway-channel";
 
 export interface WebhookProviderConfig {
   providerId?: ChannelProviderId;
+  providerKind?: ChannelProviderKind;
   deliveryUrl: string;
   sharedSecret?: string;
   capabilities?: Partial<ChannelCapabilities>;
@@ -78,6 +81,7 @@ export interface MapWebhookPayloadOptions {
 }
 
 export class WebhookProvider implements ChannelProvider {
+  readonly kind: ChannelProviderKind;
   readonly id: ChannelProviderId;
   readonly capabilities: ChannelCapabilities;
 
@@ -89,18 +93,23 @@ export class WebhookProvider implements ChannelProvider {
     if (config.sharedSecret !== undefined) {
       validateHeaderValue(config.sharedSecret, "Webhook shared secret");
     }
-    this.id = config.providerId ?? "webhook";
+    const identity = normalizeChannelProviderIdentity(
+      config.providerKind ?? channelProviderKindFromId(config.providerId) ?? "webhook",
+      config.providerId,
+    );
+    this.kind = identity.providerKind;
+    this.id = identity.providerId;
     const configuredMaxAttachmentBytes = normalizeTimeoutOrByteLimit(config.maxAttachmentBytes);
     const mergedCapabilities = {
       ...defaultWebhookCapabilities,
       ...config.capabilities
     };
-    this.capabilities = {
+    this.capabilities = normalizeChannelCapabilities({
       ...mergedCapabilities,
       maxFileBytes: configuredMaxAttachmentBytes
         ? Math.min(mergedCapabilities.maxFileBytes ?? configuredMaxAttachmentBytes, configuredMaxAttachmentBytes)
         : mergedCapabilities.maxFileBytes
-    };
+    });
   }
 
   async start(handler: (message: IncomingChannelMessage) => Promise<void>): Promise<void> {
@@ -116,7 +125,7 @@ export class WebhookProvider implements ChannelProvider {
       throw new Error("Webhook provider is not started");
     }
     this.assertIngressAuthorized(auth);
-    await this.handler(mapWebhookPayload(payload, this.config.now?.() ?? new Date(), this.id, {
+    await this.handler(mapWebhookPayload(payload, this.config.now?.() ?? new Date(), this.id, this.kind, {
       maxAttachmentBytes: this.config.maxAttachmentBytes
     }));
   }
@@ -204,11 +213,11 @@ export class WebhookProvider implements ChannelProvider {
     if (payload.target && payload.target.provider !== this.id) {
       throw new Error(`Webhook bridge ${this.id} cannot deliver target for provider ${payload.target.provider}`);
     }
-    const normalizedTarget = payload.target ? normalizeOutboundTarget(payload.target, this.id) : undefined;
+    const normalizedTarget = payload.target ? normalizeOutboundTarget(payload.target, this.id, this.kind) : undefined;
     const normalizedPayload = normalizedTarget ? { ...payload, target: normalizedTarget } : payload;
     const fetchImpl = this.config.fetch ?? globalThis.fetch;
     const deliveryId = randomUUID();
-    const body = JSON.stringify({ deliveryId, provider: this.id, ...normalizedPayload });
+    const body = JSON.stringify({ deliveryId, provider: this.id, providerKind: this.kind, ...normalizedPayload });
     const response = await withWebhookRetry(async () => {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), normalizeDeliveryTimeoutMs(this.config.deliveryTimeoutMs));
@@ -249,9 +258,11 @@ export class WebhookProvider implements ChannelProvider {
     const messageId = cleanOptionalString(responseBody.messageId, "Webhook delivery response.messageId", 512) ?? randomUUID();
     return {
       provider: this.id,
+      providerKind: this.kind,
       chatId: target?.chatId ?? "",
       threadId: target?.threadId,
       messageId,
+      providerDeliveryId: deliveryId,
       sentAt: new Date()
     };
   }
@@ -316,6 +327,12 @@ export const defaultWebhookCapabilities: ChannelCapabilities = {
   maxButtonRowsPerMessage: 4,
   maxButtonTokenBytes: 64,
   maxFileBytes: 25 * 1024 * 1024,
+  maxFileSizeBytes: 25 * 1024 * 1024,
+  inboundFileModes: ["inline_buffer"],
+  outboundFileModes: ["inline_buffer"],
+  editSemantics: "message",
+  interactionAcknowledgement: "optional",
+  rateLimitStrategy: "fixed_backoff",
   supportsEphemeralResponses: false
 };
 
@@ -387,8 +404,13 @@ export function mapWebhookPayload(
   payload: unknown,
   now = new Date(),
   providerId: ChannelProviderId = "webhook",
+  providerKindOrOptions: ChannelProviderKind | MapWebhookPayloadOptions = channelProviderKindFromId(providerId) ?? "webhook",
   options: MapWebhookPayloadOptions = {},
 ): IncomingChannelMessage {
+  const providerKind = typeof providerKindOrOptions === "string"
+    ? providerKindOrOptions
+    : channelProviderKindFromId(providerId) ?? "webhook";
+  const resolvedOptions = typeof providerKindOrOptions === "string" ? options : providerKindOrOptions;
   const record = requireRecord(payload, "Webhook payload");
   const target = normalizeTarget(record.target);
   const sender = normalizeSender(record.sender);
@@ -396,11 +418,17 @@ export function mapWebhookPayload(
   const text = optionalString(record.text) ?? interaction?.token ?? "";
   const rawText = optionalString(record.rawText) ?? text;
   const command = parseWebhookCommand(text);
+  const eventId = optionalString(record.id) ?? randomUUID();
   return {
-    id: optionalString(record.id) ?? randomUUID(),
+    id: eventId,
+    providerInstanceId: providerId,
+    providerEventId: eventId,
+    providerMessageId: eventId,
     provider: providerId,
+    providerKind,
     target: {
       provider: providerId,
+      providerKind,
       chatId: target.chatId,
       isDirect: target.isDirect,
       threadId: target.threadId,
@@ -413,7 +441,7 @@ export function mapWebhookPayload(
     isCommand: command !== null,
     command: command?.command,
     commandArgs: command?.args,
-    attachments: normalizeAttachments(record.attachments, options),
+    attachments: normalizeAttachments(record.attachments, resolvedOptions),
     interaction,
     receivedAt: parseReceivedAt(record.receivedAt, now),
     raw: payload
@@ -449,13 +477,14 @@ function validateWebhookText(text: string, capabilities: Pick<ChannelCapabilitie
   }
 }
 
-function normalizeOutboundTarget(target: ChannelTarget, provider: ChannelProviderId): ChannelTarget {
+function normalizeOutboundTarget(target: ChannelTarget, provider: ChannelProviderId, providerKind: ChannelProviderKind): ChannelTarget {
   const chatId = cleanRequiredString(target.chatId, "Webhook delivery target.chatId", 512);
   if (!chatId) {
     throw new Error("Webhook delivery target.chatId is required");
   }
   return {
     provider,
+    providerKind,
     chatId,
     isDirect: target.isDirect === true,
     threadId: cleanOptionalString(target.threadId, "Webhook delivery target.threadId", 512) ?? null,

--- a/packages/gateway-provider-whatsapp/src/whatsapp-provider.ts
+++ b/packages/gateway-provider-whatsapp/src/whatsapp-provider.ts
@@ -1,7 +1,7 @@
 import type { ChannelCapabilities } from "@open-cowork/gateway-channel";
 import { WebhookProvider, type WebhookProviderConfig } from "@open-cowork/gateway-provider-webhook";
 
-export type WhatsAppProviderConfig = Omit<WebhookProviderConfig, "providerId" | "capabilities" | "sharedSecret"> & {
+export type WhatsAppProviderConfig = Omit<WebhookProviderConfig, "providerKind" | "capabilities" | "sharedSecret"> & {
   sharedSecret: string;
 };
 
@@ -19,6 +19,12 @@ export const whatsappCapabilities: ChannelCapabilities = {
   maxButtonRowsPerMessage: 1,
   maxButtonTokenBytes: 64,
   maxFileBytes: 16 * 1024 * 1024,
+  maxFileSizeBytes: 16 * 1024 * 1024,
+  inboundFileModes: ["provider_file_id", "download_url", "inline_buffer"],
+  outboundFileModes: ["inline_buffer"],
+  editSemantics: "none",
+  interactionAcknowledgement: "optional",
+  rateLimitStrategy: "fixed_backoff",
   supportsEphemeralResponses: false
 };
 
@@ -29,7 +35,8 @@ export class WhatsAppProvider extends WebhookProvider {
     }
     super({
       ...config,
-      providerId: "whatsapp",
+      providerKind: "whatsapp",
+      providerId: config.providerId ?? "whatsapp",
       capabilities: whatsappCapabilities
     });
   }

--- a/packages/gateway-testing/src/fake-channel.test.ts
+++ b/packages/gateway-testing/src/fake-channel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import { expect } from "../../../tests/gateway-test-expect.ts";
+import { runChannelProviderConformance } from "@open-cowork/gateway-channel";
 import {
   createButtonCapableFakeProvider,
   createButtonlessFakeProvider,
@@ -9,6 +10,56 @@ import {
 } from "@open-cowork/gateway-testing";
 
 describe("FakeChannelProvider", () => {
+  it("passes the provider conformance suite with an instance-aware id", async () => {
+    const provider = new FakeChannelProvider({ id: "cli-main" });
+    const target = {
+      provider: "cli-main" as const,
+      providerKind: "cli" as const,
+      chatId: "local-test",
+      threadId: "thread-1",
+      messageId: "1"
+    };
+
+    const report = await runChannelProviderConformance({
+      provider,
+      target,
+      downloadableAttachment: {
+        filename: "input.txt",
+        buffer: new TextEncoder().encode("input")
+      },
+      inbound: [{
+        name: "text",
+        emit: () => provider.emit({
+          id: "msg-1",
+          providerInstanceId: "cli-main",
+          providerEventId: "event-1",
+          providerMessageId: "msg-1",
+          provider: "cli-main",
+          providerKind: "cli",
+          target,
+          sender: { providerUserId: "user-1" },
+          text: "/approve ok",
+          rawText: "/approve ok",
+          isCommand: true,
+          command: "approve",
+          commandArgs: "ok",
+          attachments: [],
+          receivedAt: new Date("2026-05-27T12:00:00.000Z"),
+          raw: {}
+        }),
+        expected: {
+          text: "/approve ok",
+          command: "approve",
+          chatId: "local-test",
+          threadId: "thread-1"
+        }
+      }]
+    });
+
+    expect(report).toMatchObject({ passed: true, providerId: "cli-main", providerKind: "cli" });
+    expect(report.violations).toEqual([]);
+  });
+
   it("records sent text, files, and buttons for gateway e2e tests", async () => {
     const provider = new FakeChannelProvider();
     const target = {

--- a/packages/gateway-testing/src/fake-channel.ts
+++ b/packages/gateway-testing/src/fake-channel.ts
@@ -1,6 +1,7 @@
 import type {
   ChannelButton,
   ChannelCapabilities,
+  ChannelProviderKind,
   ChannelProvider,
   ChannelProviderId,
   ChannelTarget,
@@ -10,6 +11,7 @@ import type {
   SendOptions,
   SentMessage
 } from "@open-cowork/gateway-channel";
+import { normalizeChannelCapabilities, normalizeChannelProviderIdentity } from "@open-cowork/gateway-channel";
 
 export type FakeChannelSentEntry = {
   kind: "text" | "edit" | "buttons" | "file";
@@ -41,10 +43,17 @@ const defaultFakeCapabilities: ChannelCapabilities = {
   maxButtonRowsPerMessage: 4,
   maxButtonTokenBytes: 128,
   maxFileBytes: 25 * 1024 * 1024,
+  maxFileSizeBytes: 25 * 1024 * 1024,
+  inboundFileModes: ["inline_buffer"],
+  outboundFileModes: ["inline_buffer"],
+  editSemantics: "message",
+  interactionAcknowledgement: "optional",
+  rateLimitStrategy: "none",
   supportsEphemeralResponses: true
 };
 
 export class FakeChannelProvider implements ChannelProvider {
+  readonly kind: ChannelProviderKind;
   readonly id: ChannelProviderId;
   readonly capabilities: ChannelCapabilities;
 
@@ -55,11 +64,13 @@ export class FakeChannelProvider implements ChannelProvider {
   private readonly now: () => Date;
 
   constructor(options: FakeChannelProviderOptions = {}) {
-    this.id = options.id ?? "cli";
-    this.capabilities = {
+    const identity = normalizeChannelProviderIdentity("cli", options.id ?? "cli");
+    this.kind = identity.providerKind;
+    this.id = identity.providerId;
+    this.capabilities = normalizeChannelCapabilities({
       ...defaultFakeCapabilities,
       ...options.capabilities
-    };
+    });
     this.now = options.now ?? (() => new Date());
   }
 
@@ -140,6 +151,7 @@ export class FakeChannelProvider implements ChannelProvider {
 function sent(target: ChannelTarget, id: number, sentAt: Date): SentMessage {
   return {
     provider: target.provider,
+    providerKind: target.providerKind,
     chatId: target.chatId,
     threadId: target.threadId,
     messageId: String(id),

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -1223,6 +1223,88 @@ test('cloud control plane stores headless channel bindings, interactions, cursor
   assert.equal(resolvedWithCommand?.command.kind, 'question.reply')
 })
 
+test('cloud control plane treats provider instance ids as routing namespaces', () => {
+  const store = seededStore()
+  const org = store.ensureOrgForTenant({ tenantId: 'tenant-1', name: 'Acme' })
+  const agent = store.createHeadlessAgent({
+    agentId: 'agent-1',
+    orgId: org.orgId,
+    tenantId: 'tenant-1',
+    profileName: 'data-analyst',
+    name: 'Data analyst',
+    createdByAccountId: 'user-1',
+  })
+  const prod = store.createChannelBinding({
+    bindingId: 'telegram-prod-binding',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    provider: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    displayName: 'Telegram prod',
+  })
+  const support = store.createChannelBinding({
+    bindingId: 'telegram-support-binding',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    provider: 'telegram-support',
+    externalWorkspaceId: 'bot-1',
+    displayName: 'Telegram support',
+  })
+  store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-prod',
+    opencodeSessionId: 'oc-session-prod',
+    profileName: 'data-analyst',
+  })
+  store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-support',
+    opencodeSessionId: 'oc-session-support',
+    profileName: 'data-analyst',
+  })
+
+  const prodSession = store.bindChannelSession({
+    bindingId: 'telegram-prod-session',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    channelBindingId: prod.bindingId,
+    provider: prod.provider,
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+    sessionId: 'session-prod',
+  })
+  const supportSession = store.bindChannelSession({
+    bindingId: 'telegram-support-session',
+    orgId: org.orgId,
+    agentId: agent.agentId,
+    channelBindingId: support.bindingId,
+    provider: support.provider,
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+    sessionId: 'session-support',
+  })
+
+  assert.notEqual(prodSession.bindingId, supportSession.bindingId)
+  assert.equal(store.findChannelSessionBindingByThread({
+    orgId: org.orgId,
+    provider: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+  })?.sessionId, 'session-prod')
+  assert.equal(store.findChannelSessionBindingByThread({
+    orgId: org.orgId,
+    provider: 'telegram-support',
+    externalWorkspaceId: 'bot-1',
+    externalChatId: 'chat-1',
+    externalThreadId: 'thread-1',
+  })?.sessionId, 'session-support')
+})
+
 test('cloud control plane persists tenant-scoped thread tags and session links', () => {
   const store = seededStore()
   const tag = store.createThreadTag({


### PR DESCRIPTION
## Summary

Closes #578.

Promotes the gateway channel contract from provider-kind ids to an instance-aware provider platform:

- adds shared provider `kind` vs configured `id` types, lifecycle/health types, richer capability fields, delivery ids, file-mode metadata, and provider conformance helpers in `@open-cowork/gateway-channel`
- wires Telegram, Slack, email, CLI, webhook, Discord, WhatsApp, Signal, and fake/testing providers to expose normalized instance ids while preserving kind-only and safe legacy downstream ids
- updates gateway config/registry/runtime/rendering so same-kind provider instances route independently by instance id and still use kind for capability/policy decisions
- extends cloud client/control-plane provider id validation so `telegram-prod` and `telegram-support` are durable routing namespaces
- documents the provider identity contract and adds conformance/registry/control-plane coverage

## Validation

- `PATH="/opt/homebrew/bin:$PATH" pnpm test`
- `PATH="/opt/homebrew/bin:$PATH" pnpm typecheck`
- `PATH="/opt/homebrew/bin:$PATH" pnpm lint`
- `PATH="/opt/homebrew/bin:$PATH" pnpm deploy:validate` (Docker/Helm unavailable locally; static checks passed)
- `python3 -m mkdocs build --strict`
- `git diff --check`
