### PR TITLE
Add hybrid security gates

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -55,6 +55,13 @@ The machine-readable profile contract lives in
 `deploy/topologies/README.md` and the docs page in
 `docs/deployment-topologies.md`.
 
+Each topology must also pass its matching hybrid security gate before it is
+exposed to users or public callbacks. The gate contract lives in
+`deploy/security/hybrid-security-gates.json`, with the operator docs in
+`docs/hybrid-security-gates.md`. These gates define per-mode auth, revocation,
+approval/question policy, audit events, quotas/rate limits, durability,
+backup/restore, redaction, and fail-closed behavior.
+
 | Profile | Use case | Execution authority | Reference assets |
 | --- | --- | --- | --- |
 | `desktop-only` | private local Desktop with no Cloud dependency | Desktop Local | `docs/desktop-app.md` |

--- a/deploy/security/hybrid-security-gates.json
+++ b/deploy/security/hybrid-security-gates.json
@@ -1,0 +1,512 @@
+{
+  "schemaVersion": 1,
+  "purpose": "open-cowork-hybrid-security-gates",
+  "summary": "Mode-aware production security gates for Desktop, Gateway, Cloud, and hybrid Open Cowork deployments. These gates compose the topology profiles and must pass before exposing hybrid connectors to company users, customers, or public channel callbacks.",
+  "globalRules": [
+    "OpenCode owns execution. Open Cowork owns composition, policy, projection, audit, and deployability.",
+    "Every workspace has one execution authority at a time: desktop_local, gateway_standalone, or cloud_worker.",
+    "Gateway service tokens authenticate gateway processes only; they do not grant channel actors approval authority.",
+    "Remote approvals default to local_confirmation for Desktop-owned execution. remote_allowed is opt-in, scoped, and audited.",
+    "Provider ingress must use provider signing, HMAC, or equivalent shared-secret verification before Gateway or Cloud acts.",
+    "Production public endpoints fail closed without TLS, admin token, durable stores, backups, and redaction posture."
+  ],
+  "gates": [
+    {
+      "id": "desktop-local",
+      "label": "Desktop Local Execution",
+      "topologyProfiles": ["desktop-only"],
+      "authority": "desktop_local",
+      "scope": "Local Desktop sessions, local projects, local custom MCPs, local workflows, and local credentials.",
+      "auth": [
+        "Renderer access is limited to the preload coworkApi whitelist.",
+        "Local filesystem authority comes from main-process project grants, not renderer-provided paths.",
+        "Credentials stay in OS secure storage or fail closed when secure storage is unavailable in packaged builds."
+      ],
+      "revocation": [
+        "Users can remove cloud connections and local credentials independently.",
+        "Local directory grants are scoped to Cowork-owned session, workflow, or picker records.",
+        "Deleting local sessions remains local and does not revoke or mutate cloud sessions."
+      ],
+      "approvalPolicy": [
+        "OpenCode owns tool approval semantics.",
+        "Open Cowork only composes typed policy and does not mirror tool execution.",
+        "No remote user can approve Desktop-owned risky actions in desktop-only mode."
+      ],
+      "questionPolicy": [
+        "Questions are answered by the local Desktop user.",
+        "No remote question reply path is enabled without an explicit pairing connector."
+      ],
+      "auditEvents": [
+        "credential.updated",
+        "credential.deleted",
+        "session.created",
+        "workflow.run.created",
+        "custom_mcp.saved"
+      ],
+      "rateLimits": [
+        "Local Desktop is not exposed as a public network service.",
+        "Renderer IPC remains bounded by typed handlers and local process policy."
+      ],
+      "durability": [
+        "Desktop app data",
+        "Local session registry",
+        "Local workflow SQLite",
+        "OS secure storage where available"
+      ],
+      "backupRestore": [
+        "Desktop data backup is user/operator owned.",
+        "No cloud backup promise exists for desktop-only local data."
+      ],
+      "redaction": [
+        "Renderer sees masked credential metadata by default.",
+        "Logs redact provider keys, OAuth tokens, local sensitive paths, and full session identifiers."
+      ],
+      "failClosedChecks": [
+        "Cloud workspace URLs require HTTPS except localhost.",
+        "Packaged builds refuse plaintext credential persistence.",
+        "Local host paths never enter Cloud workspaces implicitly."
+      ],
+      "validationEvidence": [
+        "pnpm lint",
+        "pnpm typecheck",
+        "pnpm test",
+        "pnpm test:e2e"
+      ]
+    },
+    {
+      "id": "desktop-pairing",
+      "label": "Desktop Outbound Pairing",
+      "topologyProfiles": ["desktop-gateway"],
+      "authority": "desktop_local",
+      "scope": "Opt-in outbound broker connection that lets a trusted remote surface reach Desktop-owned Local workspaces without opening a Desktop or OpenCode listener.",
+      "auth": [
+        "Desktop initiates outbound transport to the broker.",
+        "Broker commands require bearer pairing token plus pairing id and device id headers.",
+        "Non-loopback broker URLs require HTTPS."
+      ],
+      "revocation": [
+        "Pairing can be disabled or revoked from Desktop.",
+        "Broker command leases expire and include fencing tokens.",
+        "Revoked pairings stop accepting prompts, approvals, questions, and remote event publishes."
+      ],
+      "approvalPolicy": [
+        "Default remote approval policy is local_confirmation.",
+        "Desktop returns requires_local_confirmation until a local user confirms the permission.",
+        "remote_allowed is allowed only by explicit pairing policy, scoped workspace/session/actor rules, and audit.",
+        "Policy-denied actions return blocked_by_policy."
+      ],
+      "questionPolicy": [
+        "Default remote question policy is local_confirmation.",
+        "Remote question replies require local confirmation unless the pairing explicitly allows remote_allowed for that actor and workspace.",
+        "Question rejects and replies are auditable commands."
+      ],
+      "auditEvents": [
+        "pairing.created",
+        "pairing.updated",
+        "pairing.enabled",
+        "pairing.disabled",
+        "pairing.connected",
+        "pairing.offline",
+        "pairing.revoked",
+        "command.accepted",
+        "command.completed",
+        "command.failed",
+        "command.blocked",
+        "remote.event.published"
+      ],
+      "rateLimits": [
+        "Broker enforces per-pairing command rate limits.",
+        "Desktop enforces command lease freshness and ignores stale commands.",
+        "Remote prompt floods should surface Retry-After semantics at the broker boundary."
+      ],
+      "durability": [
+        "Desktop pairing records",
+        "Broker command log",
+        "Broker event cursor",
+        "Local audit log"
+      ],
+      "backupRestore": [
+        "Desktop local store backup remains local/operator owned.",
+        "Broker command and cursor state must be restorable before pairing is advertised as production."
+      ],
+      "redaction": [
+        "Local paths, local MCP details, artifact bodies, provider keys, OAuth tokens, and MCP secrets redact by default.",
+        "Remote event payloads expose metadata unless policy explicitly allows richer fields."
+      ],
+      "failClosedChecks": [
+        "No public Desktop port.",
+        "No public OpenCode port.",
+        "Non-loopback broker URLs require HTTPS.",
+        "Pairing token and device identity are required before any command is accepted.",
+        "Missing policy defaults to local_confirmation or blocked_by_policy, never remote_allowed."
+      ],
+      "validationEvidence": [
+        "pnpm test",
+        "pnpm test:e2e",
+        "pnpm deploy:validate"
+      ]
+    },
+    {
+      "id": "standalone-gateway",
+      "label": "Standalone Gateway Execution",
+      "topologyProfiles": ["gateway-only"],
+      "authority": "gateway_standalone",
+      "scope": "Gateway owns private OpenCode execution for channel-first deployments without Open Cowork Cloud.",
+      "auth": [
+        "Operator endpoints require an admin token.",
+        "OpenCode endpoint must be loopback or private network only.",
+        "Provider webhooks require shared secret or HMAC verification before dispatch."
+      ],
+      "revocation": [
+        "Admin token rotation blocks operator access immediately after process reload.",
+        "Provider tokens and shared secrets can be removed from deployment secrets.",
+        "Channel identities and session bindings can be disabled in Gateway Postgres."
+      ],
+      "approvalPolicy": [
+        "Channel actor RBAC decides who may answer approval prompts.",
+        "Gateway approval tokens are single-use and mapped to the originating provider actor.",
+        "A service/operator token alone cannot approve runtime permissions for arbitrary users."
+      ],
+      "questionPolicy": [
+        "Question replies require a resolved channel actor with session access.",
+        "Button-less providers use token or magic-link flows with replay protection."
+      ],
+      "auditEvents": [
+        "provider.ingress.accepted",
+        "provider.ingress.rejected",
+        "session.bound",
+        "prompt.accepted",
+        "permission.requested",
+        "permission.responded",
+        "question.asked",
+        "question.replied",
+        "artifact.accessed",
+        "operator.login.failed"
+      ],
+      "rateLimits": [
+        "Per-provider ingress rate limits.",
+        "Per-channel actor prompt limits.",
+        "Operator endpoint rate limits with Retry-After on 429."
+      ],
+      "durability": [
+        "Gateway Postgres",
+        "Gateway artifact storage",
+        "Channel credential secret storage",
+        "Delivery cursors and dead letters"
+      ],
+      "backupRestore": [
+        "Postgres backups are required.",
+        "Artifact backups are required when file ingress or generated artifacts are enabled.",
+        "Restore drill must prove channel session binding and approval-token recovery behavior."
+      ],
+      "redaction": [
+        "Channel secrets, provider tokens, OpenCode auth tokens, local server URLs, file paths, and raw payload secrets are redacted from logs and diagnostics."
+      ],
+      "failClosedChecks": [
+        "Public OpenCode endpoints rejected.",
+        "Missing admin token rejected except explicit loopback-only development bypass.",
+        "Fake provider is explicit local/demo-only.",
+        "Webhook provider requires authenticated webhook ingress.",
+        "File ingress cannot advertise sizes above daemon body limits."
+      ],
+      "validationEvidence": [
+        "pnpm deploy:standalone-gateway:validate",
+        "pnpm deploy:standalone-gateway:smoke",
+        "pnpm deploy:validate"
+      ]
+    },
+    {
+      "id": "cloud-worker",
+      "label": "Cloud Worker Execution",
+      "topologyProfiles": ["cloud-only"],
+      "authority": "cloud_worker",
+      "scope": "Open Cowork Cloud web, worker, scheduler, Postgres, object store, BYOK, workflows, projections, and browser workbench.",
+      "auth": [
+        "Public cloud uses OIDC, signed trusted header auth, cookie auth, or scoped API tokens.",
+        "header auth requires a trusted proxy proof and shared signature secret.",
+        "Mutating APIs require tenant membership and policy checks."
+      ],
+      "revocation": [
+        "API tokens can be revoked.",
+        "Membership revocation blocks session and workflow mutations.",
+        "BYOK secret rotation changes the worker-side runtime config for new work."
+      ],
+      "approvalPolicy": [
+        "Cloud approvals are tied to authenticated user, tenant membership, and runtime policy.",
+        "Worker leases fence stale projection writes.",
+        "Remembered approvals are scoped by user, tenant, profile, and policy."
+      ],
+      "questionPolicy": [
+        "Questions are stored in durable projection state.",
+        "Replies require authenticated user authority and tenant membership.",
+        "Late join clients hydrate pending questions from session snapshots."
+      ],
+      "auditEvents": [
+        "org.created",
+        "membership.created",
+        "api_token.created",
+        "api_token.revoked",
+        "byok.secret.updated",
+        "session.created",
+        "prompt.enqueued",
+        "permission.responded",
+        "question.replied",
+        "workflow.run.created",
+        "artifact.accessed",
+        "quota.rejected"
+      ],
+      "rateLimits": [
+        "Per-IP, per-token, per-user, per-org, and per-workspace limits.",
+        "Quota denials return 402 or 429 with Retry-After where applicable.",
+        "Worker spawn and command claim paths enforce subscription and quota state."
+      ],
+      "durability": [
+        "Cloud Postgres",
+        "Provider-backed object storage",
+        "Secret adapter/KMS or secret-manager refs",
+        "Worker checkpoints",
+        "Event logs and session projections"
+      ],
+      "backupRestore": [
+        "Postgres backup and point-in-time recovery.",
+        "Object-store artifact/checkpoint backup.",
+        "Secret/KMS reference restore proof.",
+        "Restore drill proves session projection parity, worker recovery, scheduler recovery, and redaction."
+      ],
+      "redaction": [
+        "BYOK plaintext only appears inside worker runtime config.",
+        "HTTP payloads, renderer state, logs, diagnostics, caches, and audit rows never include raw provider keys, OAuth tokens, MCP secrets, channel secrets, or sensitive local paths."
+      ],
+      "failClosedChecks": [
+        "public_production requires Postgres.",
+        "public_production requires provider-backed object storage.",
+        "public_production rejects weak inline secrets.",
+        "public auth mode none is rejected unless explicit insecure local/demo override is set.",
+        "Worker scale-out requires checkpoints and shared object storage."
+      ],
+      "validationEvidence": [
+        "pnpm deploy:validate",
+        "pnpm deploy:launch:validate",
+        "pnpm ops:validate",
+        "pnpm test:cloud-web",
+        "pnpm test:cloud-continuation"
+      ]
+    },
+    {
+      "id": "cloud-channel-gateway",
+      "label": "Cloud Channel Gateway",
+      "topologyProfiles": ["cloud-channel-gateway"],
+      "authority": "cloud_worker",
+      "scope": "Gateway is a channel adapter and Cloud client for Cloud-owned workspaces. Cloud workers own OpenCode execution.",
+      "auth": [
+        "Gateway process authenticates to Cloud with a scoped gateway service token.",
+        "Inbound provider actor identity is resolved separately from the gateway token.",
+        "Provider ingress requires provider signing, HMAC, shared secret, or provider-native signature verification.",
+        "Operator endpoints require an admin token."
+      ],
+      "revocation": [
+        "Gateway service token revocation stops Cloud API access.",
+        "Channel binding revocation stops routing for a provider workspace/thread.",
+        "Delivery cursor state prevents replay across gateway restarts."
+      ],
+      "approvalPolicy": [
+        "Gateway service token does not grant actor approval authority.",
+        "Approval authority is checked against resolved channel actor membership, RBAC, profile, and policy.",
+        "Inline approval buttons and token fallbacks are single-use and replay protected."
+      ],
+      "questionPolicy": [
+        "Question replies require resolved channel actor authority.",
+        "Button-less channels use token or magic-link fallback with replay protection.",
+        "Cloud snapshots remain source of truth for pending questions."
+      ],
+      "auditEvents": [
+        "gateway.registered",
+        "gateway.revoked",
+        "channel.binding.created",
+        "channel.binding.revoked",
+        "provider.ingress.accepted",
+        "provider.ingress.rejected",
+        "delivery.sent",
+        "delivery.dead_lettered",
+        "permission.responded",
+        "question.replied"
+      ],
+      "rateLimits": [
+        "Per-provider ingress limits.",
+        "Per-channel actor prompt limits.",
+        "Per-gateway delivery retry and dead-letter limits.",
+        "Cloud returns Retry-After on rate-limit responses."
+      ],
+      "durability": [
+        "Cloud Postgres for channel bindings, identities, interactions, deliveries, and cursors.",
+        "Cloud object store for artifacts.",
+        "Gateway process state is disposable except provider long-poll/webhook connections."
+      ],
+      "backupRestore": [
+        "Cloud backup covers channel bindings, delivery backlog, and event cursors.",
+        "Gateway redeploy with the same service token and provider credentials resumes from Cloud cursors."
+      ],
+      "redaction": [
+        "Channel secrets never reach renderer state.",
+        "Provider payload secrets, actor private metadata, raw channel files, and artifact private URLs are redacted in diagnostics."
+      ],
+      "failClosedChecks": [
+        "Gateway has no @opencode-ai/sdk dependency.",
+        "Gateway has no direct Postgres access for Cloud control-plane state.",
+        "Missing admin token blocks metrics, diagnostics, and delivery operator endpoints.",
+        "Replica count above one is blocked unless distributed ownership is explicit.",
+        "Fake provider remains local/demo-only."
+      ],
+      "validationEvidence": [
+        "pnpm deploy:validate",
+        "pnpm ops:validate",
+        "pnpm deploy:gateway:smoke",
+        "pnpm deploy:continuation:smoke"
+      ]
+    },
+    {
+      "id": "cloud-gateway-edge",
+      "label": "Cloud With Registered Edge Gateway",
+      "topologyProfiles": ["cloud-gateway-edge"],
+      "authority": "cloud_worker,gateway_standalone",
+      "scope": "Cloud registers an external Gateway or edge worker as a separate authority with explicit trust, metadata boundaries, and fencing.",
+      "auth": [
+        "Edge registration uses scoped API tokens and gateway identity records.",
+        "Cloud never trusts raw Gateway database state or raw OpenCode runtime homes.",
+        "External workspace metadata is tenant-scoped and explicitly registered."
+      ],
+      "revocation": [
+        "Gateway registration can be revoked from Cloud.",
+        "Edge worker leases expire and stale writes are rejected.",
+        "Registered external workspace visibility can be disabled without deleting Gateway-owned state."
+      ],
+      "approvalPolicy": [
+        "Cloud approval authority applies only to Cloud-owned sessions.",
+        "Gateway-owned approvals remain in Gateway authority unless an explicit import/export or edge execution policy allows the bridge.",
+        "customer_hosted_managed_saas_deferred remains a trust boundary until contractual controls exist."
+      ],
+      "questionPolicy": [
+        "Cloud questions and Gateway questions remain scoped to their execution authority.",
+        "Cross-authority question relay requires explicit policy, actor identity, and audit on both sides."
+      ],
+      "auditEvents": [
+        "gateway.registration.created",
+        "gateway.registration.heartbeat",
+        "gateway.registration.revoked",
+        "gateway.edge.lease_claimed",
+        "gateway.edge.write_fenced_output",
+        "external_workspace.visible",
+        "external_workspace.hidden"
+      ],
+      "rateLimits": [
+        "Per-registration heartbeat limits.",
+        "Per-edge worker command and write limits.",
+        "Cloud API returns Retry-After for registration and edge-write throttles."
+      ],
+      "durability": [
+        "Cloud registration records",
+        "Gateway Postgres where Gateway owns execution",
+        "Audit records on both authorities",
+        "Fenced event cursor state"
+      ],
+      "backupRestore": [
+        "Cloud restore must preserve gateway registration and revocation state.",
+        "Gateway restore remains Gateway/operator owned.",
+        "Cross-authority restore drills must prove no unfenced duplicate output."
+      ],
+      "redaction": [
+        "No raw Gateway runtime home, raw local paths, raw provider keys, raw channel secrets, or gateway private files in Cloud registration payloads."
+      ],
+      "failClosedChecks": [
+        "external workspace mode cannot sync raw Gateway runtime state.",
+        "Edge execution disabled unless explicit policy allows it.",
+        "Fenced writes require current lease token.",
+        "customer_hosted_managed_saas_deferred requires operator review before managed SaaS claims."
+      ],
+      "validationEvidence": [
+        "pnpm deploy:validate",
+        "pnpm ops:validate",
+        "pnpm deploy:gateway:smoke",
+        "pnpm test"
+      ]
+    },
+    {
+      "id": "full-hybrid",
+      "label": "Full Hybrid Enterprise Composition",
+      "topologyProfiles": ["full-hybrid"],
+      "authority": "desktop_local,cloud_worker,gateway_standalone",
+      "scope": "Enterprise composition of Desktop Local, Cloud workspaces, Cloud Channel Gateway, Standalone Gateway, and optional Desktop pairing.",
+      "auth": [
+        "Every connector uses its own explicit auth boundary.",
+        "Desktop pairing, Gateway service tokens, Cloud OIDC/header/API-token auth, and provider signing are independent.",
+        "No connector inherits authority from another connector without an explicit policy decision."
+      ],
+      "revocation": [
+        "Each authority has an independent revocation path.",
+        "Workspace movement across authorities is explicit import, sync, registration, or pairing.",
+        "Revocation state is included in restore and incident-response evidence."
+      ],
+      "approvalPolicy": [
+        "Every workspace declares one execution authority.",
+        "Remote approvals follow the owning authority policy.",
+        "Desktop-owned risky actions require local_confirmation unless explicitly remote_allowed by scoped policy.",
+        "Cloud-owned approvals require tenant membership and policy.",
+        "Gateway-owned approvals require channel RBAC."
+      ],
+      "questionPolicy": [
+        "Questions route through the owning authority projection.",
+        "Cross-client question replies are allowed only when the client is authorized for that workspace and authority."
+      ],
+      "auditEvents": [
+        "authority.transition.requested",
+        "authority.transition.completed",
+        "authority.transition.rejected",
+        "workspace.policy.updated",
+        "pairing.revoked",
+        "gateway.revoked",
+        "api_token.revoked",
+        "permission.responded",
+        "question.replied",
+        "artifact.accessed",
+        "workflow.run.created"
+      ],
+      "rateLimits": [
+        "Per-authority limits compose; the strictest applicable quota wins.",
+        "Public Cloud, Gateway, and broker endpoints use Retry-After for throttles.",
+        "Org-level abuse controls can disable new execution without deleting local data."
+      ],
+      "durability": [
+        "Cloud Postgres and object storage",
+        "Gateway Postgres where Gateway owns execution",
+        "Desktop local store where Desktop owns execution",
+        "Audit logs and restore evidence for every enabled authority"
+      ],
+      "backupRestore": [
+        "Cloud restore, Gateway restore, and Desktop local backup boundaries are documented separately.",
+        "Hybrid restore drill proves authority boundaries and no implicit local-to-cloud upload.",
+        "Restore evidence must include redaction review."
+      ],
+      "redaction": [
+        "Secrets never cross renderer, cache, log, audit, diagnostics, or channel boundaries.",
+        "Local paths and local file bodies are never uploaded implicitly.",
+        "Cross-authority dashboards show metadata and policy verdicts, not raw private state."
+      ],
+      "failClosedChecks": [
+        "All smaller gates must pass before claiming full-hybrid production readiness.",
+        "Workspace support matrix must not overclaim capabilities.",
+        "Authority transitions require explicit user or admin action.",
+        "One execution authority per thread is enforced before command dispatch."
+      ],
+      "validationEvidence": [
+        "pnpm lint",
+        "pnpm typecheck",
+        "pnpm test",
+        "pnpm test:e2e",
+        "pnpm deploy:validate",
+        "pnpm deploy:launch:validate",
+        "pnpm ops:validate",
+        "pnpm test:cloud-continuation"
+      ]
+    }
+  ]
+}

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -29,6 +29,14 @@ The topology profile contract lives in
 `deploy/topologies/README.md`; the docs overview is
 [Deployment Topologies](deployment-topologies.md).
 
+After choosing a topology, apply the matching security gate from
+[Hybrid Security Gates](hybrid-security-gates.md). The gate contract lives in
+`deploy/security/hybrid-security-gates.json` and defines the required auth,
+revocation, approval/question policy, audit events, quotas/rate limits,
+durability, backup/restore, redaction, and fail-closed checks for
+`desktop-local`, `desktop-pairing`, `standalone-gateway`, `cloud-worker`,
+`cloud-channel-gateway`, `cloud-gateway-edge`, and `full-hybrid`.
+
 Production Cloud deployments should run these processes separately:
 
 - cloud `web`: stateless HTTP, browser dashboard, API, SSE, auth, and durable

--- a/docs/hybrid-security-gates.md
+++ b/docs/hybrid-security-gates.md
@@ -1,0 +1,205 @@
+---
+title: Hybrid Security Gates
+description: Mode-aware security, policy, audit, quota, and restore gates for Desktop, Gateway, Cloud, and hybrid Open Cowork deployments.
+---
+
+# Hybrid Security Gates
+
+Open Cowork can now run as Desktop, Cloud Web, Standalone Gateway, Cloud
+Channel Gateway, Desktop pairing, or a full hybrid of those surfaces. This page
+defines the production security gates for those modes. It complements
+[Deployment Topologies](deployment-topologies.md): topologies say what you are
+deploying; security gates say which auth, policy, audit, quota, redaction, and
+restore behavior must be true before that topology is exposed to users.
+
+The machine-readable contract lives at
+`deploy/security/hybrid-security-gates.json`. `pnpm deploy:validate` and
+`pnpm ops:validate` verify that the contract, docs, and code evidence stay in
+sync.
+
+## Non-Negotiable Rules
+
+- Open Cowork is a product layer on top of OpenCode, not a second runtime.
+- Every thread has one execution authority at a time: `desktop_local`,
+  `cloud_worker`, or `gateway_standalone`.
+- The Gateway is either a standalone execution owner or a Cloud channel adapter;
+  it must not silently switch roles.
+- Remote approvals for Desktop-owned execution default to `local_confirmation`.
+- `remote_allowed` is an explicit, scoped policy decision. Missing policy falls
+  back to `requires_local_confirmation` or `blocked_by_policy`, never remote
+  approval.
+- A Gateway service token authenticates the Gateway process only. It does not
+  grant the channel actor approval authority.
+- Public provider callbacks require provider signing, HMAC, or equivalent
+  shared-secret verification.
+- Production modes fail closed without TLS, admin token, durable stores,
+  backup/restore posture, and redaction posture.
+
+## Gate Matrix
+
+| Gate | Topology profile | Execution authority | Production boundary |
+| --- | --- | --- | --- |
+| `desktop-local` | `desktop-only` | `desktop_local` | Local Desktop owns OpenCode execution and local data. |
+| `desktop-pairing` | `desktop-gateway` | `desktop_local` | Desktop opens an outbound connector; no Desktop or OpenCode port is public. |
+| `standalone-gateway` | `gateway-only` | `gateway_standalone` | Gateway owns private OpenCode and private Gateway Postgres. |
+| `cloud-worker` | `cloud-only` | `cloud_worker` | Cloud web/worker/scheduler own Cloud workspaces through Postgres/object store. |
+| `cloud-channel-gateway` | `cloud-channel-gateway` | `cloud_worker` | Gateway is a Cloud client and channel adapter; Cloud workers execute. |
+| `cloud-gateway-edge` | `cloud-gateway-edge` | `cloud_worker`, `gateway_standalone` | Cloud registers external Gateway state without taking implicit execution ownership. |
+| `full-hybrid` | `full-hybrid` | per workspace | All smaller gates pass and each workspace declares one execution authority. |
+
+## Approval And Question Policy
+
+Approval and question behavior follows the execution authority that owns the
+thread.
+
+For `desktop-local`, there is no remote approval path. The local Desktop user
+answers OpenCode approvals and questions.
+
+For `desktop-pairing`, Desktop remains the authority. The default remote
+approval and question policy is `local_confirmation`. A remote client may send a
+prompt or response request, but Desktop returns `requires_local_confirmation`
+until a local user confirms it. `remote_allowed` may be used only when all of
+these are true:
+
+- the pairing policy explicitly enables it;
+- the actor, workspace, session, and action risk are in scope;
+- revocation and lease fencing are active;
+- the action is written to the local audit log;
+- redaction still blocks raw provider keys, local paths, local MCP details, and
+  artifact bodies unless policy explicitly allows them.
+
+For `cloud-worker`, Cloud membership, role, profile policy, subscription/quota
+state, and runtime policy decide approval and question authority. Pending
+permissions and questions must be present in durable projection state so late
+join clients can recover after restart.
+
+For `standalone-gateway`, the channel actor must resolve to Gateway RBAC before
+approvals or questions can be answered. Approval tokens are single-use and
+replay protected.
+
+For `cloud-channel-gateway`, the Gateway service token proves the process is
+allowed to call Cloud APIs. It does not prove that the human or channel actor is
+allowed to approve a permission. Cloud must resolve provider identity and check
+membership/RBAC before accepting approval or question replies.
+
+## Auth And Revocation
+
+Every connector has an explicit auth and revocation contract:
+
+- Desktop local: preload whitelist plus main-process project grants.
+- Desktop pairing: bearer pairing token, pairing id, device id, command leases,
+  and pairing revocation.
+- Standalone Gateway: admin token for operator endpoints, private OpenCode
+  endpoint, provider signing or HMAC for public ingress, and provider credential
+  rotation.
+- Cloud worker: OIDC, signed trusted header auth, cookie auth, or scoped API
+  token; membership and API-token revocation block new mutations.
+- Cloud Channel Gateway: scoped gateway service token plus separate inbound
+  actor identity resolution; channel binding and token revocation stop routing.
+- Cloud Gateway Edge: registration tokens, heartbeat, lease fencing, and
+  explicit `customer_hosted_managed_saas_deferred` review before managed SaaS
+  claims are made.
+
+## Audit Taxonomy
+
+Security-sensitive actions must be auditable in the authority that owns them.
+The gate contract lists the minimum audit events for each mode. The taxonomy
+includes:
+
+- pairing lifecycle: `pairing.created`, `pairing.updated`,
+  `pairing.enabled`, `pairing.disabled`, `pairing.connected`,
+  `pairing.offline`, `pairing.revoked`;
+- remote commands: `command.accepted`, `command.completed`,
+  `command.failed`, `command.blocked`, `remote.event.published`;
+- provider ingress: `provider.ingress.accepted`,
+  `provider.ingress.rejected`;
+- approvals and questions: `permission.requested`,
+  `permission.responded`, `question.asked`, `question.replied`;
+- Cloud control plane: `org.created`, `membership.created`,
+  `api_token.created`, `api_token.revoked`, `byok.secret.updated`,
+  `quota.rejected`;
+- channel operations: `gateway.registered`, `gateway.revoked`,
+  `channel.binding.created`, `channel.binding.revoked`,
+  `delivery.sent`, `delivery.dead_lettered`;
+- edge operations: `gateway.registration.heartbeat`,
+  `gateway.edge.write_fenced_output`.
+
+Audit rows must not contain raw provider keys, OAuth tokens, MCP secrets,
+channel secrets, local file contents, or sensitive local paths.
+
+## Quotas And Rate Limits
+
+Production deployments must apply rate limits at every public or remotely
+reachable boundary:
+
+- Cloud: IP, token, user, org, workspace, worker-spawn, prompt, and workflow
+  limits.
+- Gateway: provider ingress, channel actor, delivery retry, dead-letter, and
+  operator endpoint limits.
+- Desktop pairing: pairing command, broker command lease, and remote event
+  publish limits.
+- Edge registration: heartbeat, command, and fenced write limits.
+
+Where the protocol supports it, throttles return `Retry-After`. Quota denials
+should be clear: `402` for billing/entitlement failures and `429` for rate
+limits.
+
+## Durability, Backup, And Restore
+
+Production security posture includes recovery posture:
+
+- Cloud requires Postgres, provider-backed object storage, secret-manager/KMS
+  references, worker checkpoints, event logs, and session projections.
+- Standalone Gateway requires Gateway Postgres, artifact storage where file
+  ingress is enabled, channel credential secret storage, delivery cursors, and
+  dead-letter retention.
+- Desktop pairing requires Desktop pairing records, broker command log, broker
+  event cursor, and local audit records.
+- Full hybrid restore drills prove that authority boundaries survive restore
+  and that no local data is uploaded implicitly.
+
+Restore evidence must include redaction review. Use
+[Backup and Restore](runbooks/backup-restore.md) and
+[Restore Drill Report](runbooks/restore-drill-report.md) as the operator
+templates.
+
+## Redaction Requirements
+
+Diagnostics, logs, caches, dashboards, audit rows, and channel messages must
+redact:
+
+- raw provider keys and BYOK plaintext;
+- OAuth access and refresh tokens;
+- MCP secrets;
+- channel provider secrets and signing tokens;
+- private artifact URLs unless the actor is authorized;
+- local host paths and local file bodies unless explicitly uploaded through a
+  Cloud-safe artifact flow;
+- raw Gateway database state, raw OpenCode runtime homes, and gateway private
+  files in Cloud registration payloads.
+
+The default posture is metadata over contents. If a deployment chooses to
+expose richer fields, that exposure must be explicit in policy and covered by
+audit.
+
+## Fail-Closed Validation
+
+`pnpm deploy:validate` checks the gate contract and cross-references code
+evidence for the following fail-closed behavior:
+
+- Desktop pairing defaults to `local_confirmation`.
+- Desktop pairing can return `requires_local_confirmation` and
+  `blocked_by_policy`.
+- Public Cloud does not trust unsigned header auth.
+- Public Cloud fails closed without Postgres, provider-backed object storage,
+  production secrets, auth, and worker checkpoints.
+- Gateway operator endpoints require an admin token.
+- Gateway webhook ingress requires provider signing, HMAC, or a shared secret.
+- Gateway fake provider is local/demo-only.
+- Gateway rejects public OpenCode endpoints.
+- Cloud and Gateway throttles expose `Retry-After`.
+- Full hybrid requires one execution authority per thread.
+
+`pnpm ops:validate` checks that the operations artifacts include the gate
+contract, backup/restore posture, topology docs, observability assets, and
+mode-aware runbook references.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -95,6 +95,18 @@ an `Authorization: Bearer <secret>` header or the signed
 `X-Open-Cowork-Timestamp` / `X-Open-Cowork-Signature` HMAC headers. Rotating a
 webhook secret keeps the local URL stable and invalidates old headers.
 
+## Hybrid security gates
+
+Desktop, Cloud, Gateway, and Desktop pairing modes have separate authority and
+audit boundaries. The production contract for those boundaries is documented in
+[Hybrid Security Gates](hybrid-security-gates.md) and enforced by
+`deploy/security/hybrid-security-gates.json` through `pnpm deploy:validate`.
+The core rules are that every thread has one execution authority, Desktop
+pairing defaults remote approvals and questions to `local_confirmation`, public
+Gateway ingress requires provider signing or HMAC, and production Cloud/Gateway
+deployments fail closed without durable stores, TLS, admin auth, backups, and
+redaction posture.
+
 ## Data at rest
 
 User data is stored under Electron's `userData` path, which is branded

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Managed Workers: managed-workers.md
       - Cloud Gateway Registration: cloud-gateway-registration.md
       - Deployment Topologies: deployment-topologies.md
+      - Hybrid Security Gates: hybrid-security-gates.md
       - Gateway Appliance: gateway-appliance.md
       - Standalone Gateway: standalone-gateway.md
       - Deployment Readiness: deployment-readiness.md

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -630,10 +630,152 @@ function validateTopologyProfiles() {
   }
 }
 
+function validateHybridSecurityGates() {
+  const gatesPath = 'deploy/security/hybrid-security-gates.json'
+  const gatesDocsPath = 'docs/hybrid-security-gates.md'
+  const readinessPath = 'docs/deployment-readiness.md'
+  const gatesDocument = parseJson(gatesPath)
+  const topologyProfiles = new Set(parseJson('deploy/topologies/topology-profiles.json').profiles.map((profile) => profile.id))
+  const packageScripts = parseJson('package.json').scripts ?? {}
+  const requiredGateIds = [
+    'desktop-local',
+    'desktop-pairing',
+    'standalone-gateway',
+    'cloud-worker',
+    'cloud-channel-gateway',
+    'cloud-gateway-edge',
+    'full-hybrid',
+  ]
+
+  if (gatesDocument.schemaVersion !== 1) {
+    throw new Error(`${gatesPath} must declare schemaVersion 1`)
+  }
+  if (gatesDocument.purpose !== 'open-cowork-hybrid-security-gates') {
+    throw new Error(`${gatesPath} must declare open-cowork-hybrid-security-gates purpose`)
+  }
+  if (!Array.isArray(gatesDocument.gates)) {
+    throw new Error(`${gatesPath} must contain a gates array`)
+  }
+
+  const gates = new Map(gatesDocument.gates.map((gate) => [gate.id, gate]))
+  for (const id of requiredGateIds) {
+    const gate = gates.get(id)
+    if (!gate) throw new Error(`${gatesPath} is missing gate ${id}`)
+    for (const field of ['label', 'authority', 'scope']) {
+      if (!gate[field] || typeof gate[field] !== 'string') {
+        throw new Error(`${gatesPath} gate ${id} must include string field ${field}`)
+      }
+    }
+    for (const field of [
+      'topologyProfiles',
+      'auth',
+      'revocation',
+      'approvalPolicy',
+      'questionPolicy',
+      'auditEvents',
+      'rateLimits',
+      'durability',
+      'backupRestore',
+      'redaction',
+      'failClosedChecks',
+      'validationEvidence',
+    ]) {
+      if (!Array.isArray(gate[field]) || gate[field].length === 0) {
+        throw new Error(`${gatesPath} gate ${id} must include non-empty array field ${field}`)
+      }
+    }
+    for (const profileId of gate.topologyProfiles) {
+      if (!topologyProfiles.has(profileId)) {
+        throw new Error(`${gatesPath} gate ${id} references unknown topology profile ${profileId}`)
+      }
+    }
+    for (const command of gate.validationEvidence) {
+      const match = /^pnpm\s+([^\s]+)/.exec(command)
+      if (!match) throw new Error(`${gatesPath} gate ${id} command must start with pnpm: ${command}`)
+      const scriptName = match[1]
+      if (scriptName.startsWith('--')) continue
+      if (!packageScripts[scriptName]) {
+        throw new Error(`${gatesPath} gate ${id} references missing package script: ${scriptName}`)
+      }
+    }
+    assertIncludes(gatesDocsPath, `\`${id}\``)
+    assertIncludes(readinessPath, `\`${id}\``)
+  }
+
+  const combinedGateText = `${JSON.stringify(gatesDocument)}\n${read(gatesDocsPath)}\n${read(readinessPath)}`
+  for (const phrase of [
+    'local_confirmation',
+    'remote_allowed',
+    'requires_local_confirmation',
+    'blocked_by_policy',
+    'Retry-After',
+    'admin token',
+    'provider signing',
+    'HMAC',
+    'audit',
+    'backup',
+    'restore',
+    'redact',
+    'customer_hosted_managed_saas_deferred',
+    'one execution authority',
+  ]) {
+    if (!combinedGateText.includes(phrase)) {
+      throw new Error(`${gatesPath} and ${gatesDocsPath} must include hybrid security phrase: ${phrase}`)
+    }
+  }
+
+  const desktopPairing = read('packages/shared/src/desktop-pairing.ts')
+  for (const phrase of [
+    "remoteApprovals: 'local_confirmation'",
+    "remoteQuestions: 'local_confirmation'",
+    'requires_local_confirmation',
+    'blocked_by_policy',
+    'remote_allowed',
+    'pairing.revoked',
+    'command.blocked',
+  ]) {
+    if (!desktopPairing.includes(phrase)) {
+      throw new Error(`packages/shared/src/desktop-pairing.ts must include ${phrase}`)
+    }
+  }
+
+  const gatewayConfig = read('apps/gateway/src/config.ts')
+  for (const phrase of [
+    'Gateway operator endpoints require OPEN_COWORK_GATEWAY_ADMIN_TOKEN',
+    'authenticated webhook ingress',
+    'signingSecret',
+    'webhookSecret',
+  ]) {
+    if (!gatewayConfig.includes(phrase)) {
+      throw new Error(`apps/gateway/src/config.ts must include ${phrase}`)
+    }
+  }
+
+  const standaloneNetworkPolicy = read('apps/standalone-gateway/src/network-policy.ts')
+  if (!standaloneNetworkPolicy.includes('public OpenCode endpoint')) {
+    throw new Error('apps/standalone-gateway/src/network-policy.ts must reject public OpenCode endpoint')
+  }
+
+  const cloudHttpServer = read('apps/desktop/src/main/cloud/http-server.ts')
+  for (const phrase of ['Retry-After', 'quota_rejections']) {
+    if (!cloudHttpServer.includes(phrase)) {
+      throw new Error(`apps/desktop/src/main/cloud/http-server.ts must include ${phrase}`)
+    }
+  }
+
+  const workspace = read('packages/shared/src/workspace.ts')
+  for (const phrase of ['OPENCODE_RUNTIME_AUTHORITIES', 'workspace.remote_approval_required']) {
+    if (!workspace.includes(phrase)) {
+      throw new Error(`packages/shared/src/workspace.ts must include ${phrase}`)
+    }
+  }
+}
+
 function validateDocs() {
   const requiredDocs = [
     'docs/deployment-readiness.md',
     'docs/deployment-topologies.md',
+    'docs/hybrid-security-gates.md',
     'docs/downstream-contract.md',
     'docs/runbooks/cloud-managed-operations.md',
     'docs/runbooks/backup-restore.md',
@@ -662,6 +804,7 @@ function validateDocs() {
     'deploy/README.md',
     'deploy/topologies/README.md',
     'deploy/topologies/topology-profiles.json',
+    'deploy/security/hybrid-security-gates.json',
     'deploy/observability/metrics-catalog.json',
     'deploy/observability/prometheus-alerts.yaml',
     'deploy/observability/grafana-open-cowork-overview.json',
@@ -697,6 +840,8 @@ function validateDocs() {
     'deploy/gcp/smoke/evidence.template.json',
     'deploy/topologies/README.md',
     'deploy/topologies/topology-profiles.json',
+    'deploy/security/hybrid-security-gates.json',
+    'docs/hybrid-security-gates.md',
     'deploy/observability/managed-worker-slo-template.json',
     'deploy/private-beta/hosted-byok.config.example.json',
     'deploy/private-beta/self-host-oss.config.example.json',
@@ -1557,6 +1702,7 @@ function validateReleaseSupplyChain() {
 validateCompose()
 validateHelm()
 validateTopologyProfiles()
+validateHybridSecurityGates()
 validateDocs()
 validateGcpReference()
 validateReleaseSupplyChain()

--- a/scripts/validate-ops-readiness.mjs
+++ b/scripts/validate-ops-readiness.mjs
@@ -35,6 +35,8 @@ const cloudGatewayRegistrationDocsPath = 'docs/cloud-gateway-registration.md'
 const coordinationModelDocsPath = 'docs/coordination-model.md'
 const deploymentTopologyDocsPath = 'docs/deployment-topologies.md'
 const deploymentTopologyProfilesPath = 'deploy/topologies/topology-profiles.json'
+const hybridSecurityDocsPath = 'docs/hybrid-security-gates.md'
+const hybridSecurityGatesPath = 'deploy/security/hybrid-security-gates.json'
 const managedWorkerDeployPath = 'deploy/managed-workers/README.md'
 const managedWorkerReleaseTemplatePath = 'deploy/managed-workers/worker-release-evidence.template.md'
 const managedWorkerRestoreTemplatePath = 'deploy/managed-workers/worker-restore-drill.template.md'
@@ -54,6 +56,8 @@ for (const path of [
   coordinationModelDocsPath,
   deploymentTopologyDocsPath,
   deploymentTopologyProfilesPath,
+  hybridSecurityDocsPath,
+  hybridSecurityGatesPath,
   managedWorkerDeployPath,
   managedWorkerReleaseTemplatePath,
   managedWorkerRestoreTemplatePath,
@@ -76,6 +80,44 @@ for (const profileId of [
     throw new Error(`${deploymentTopologyProfilesPath} is missing ${profileId}`)
   }
   assertIncludes(deploymentTopologyDocsPath, profileId)
+}
+
+const hybridSecurityGates = parseJson(hybridSecurityGatesPath)
+if (hybridSecurityGates.schemaVersion !== 1 || hybridSecurityGates.purpose !== 'open-cowork-hybrid-security-gates') {
+  throw new Error(`${hybridSecurityGatesPath} must declare the hybrid security gate contract`)
+}
+const requiredHybridGateProfiles = {
+  'desktop-local': 'desktop-only',
+  'desktop-pairing': 'desktop-gateway',
+  'standalone-gateway': 'gateway-only',
+  'cloud-worker': 'cloud-only',
+  'cloud-channel-gateway': 'cloud-channel-gateway',
+  'cloud-gateway-edge': 'cloud-gateway-edge',
+  'full-hybrid': 'full-hybrid',
+}
+for (const [gateId, topologyProfileId] of Object.entries(requiredHybridGateProfiles)) {
+  if (!(hybridSecurityGates.gates || []).some((gate) => gate.id === gateId)) {
+    throw new Error(`${hybridSecurityGatesPath} is missing ${gateId}`)
+  }
+  assertIncludes(hybridSecurityDocsPath, gateId)
+  assertIncludes(deploymentTopologyDocsPath, topologyProfileId)
+}
+for (const phrase of [
+  'local_confirmation',
+  'remote_allowed',
+  'requires_local_confirmation',
+  'blocked_by_policy',
+  'Retry-After',
+  'admin token',
+  'provider signing',
+  'HMAC',
+  'backup',
+  'restore',
+  'redaction',
+  'one execution authority',
+  'customer_hosted_managed_saas_deferred',
+]) {
+  assertIncludes(hybridSecurityDocsPath, phrase)
 }
 
 const requiredMetrics = [

--- a/tests/hybrid-security-gates.test.ts
+++ b/tests/hybrid-security-gates.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function read(relativePath: string) {
+  return readFileSync(join(root, relativePath), 'utf8')
+}
+
+function readJson(relativePath: string) {
+  return JSON.parse(read(relativePath))
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+test('hybrid security gate contract covers every production authority mode', () => {
+  const contract = readJson('deploy/security/hybrid-security-gates.json')
+  assert.equal(contract.schemaVersion, 1)
+  assert.equal(contract.purpose, 'open-cowork-hybrid-security-gates')
+
+  const gates = new Map(contract.gates.map((gate: { id: string }) => [gate.id, gate]))
+  for (const id of [
+    'desktop-local',
+    'desktop-pairing',
+    'standalone-gateway',
+    'cloud-worker',
+    'cloud-channel-gateway',
+    'cloud-gateway-edge',
+    'full-hybrid',
+  ]) {
+    assert.ok(gates.has(id), `missing hybrid security gate ${id}`)
+  }
+
+  const desktopPairing = gates.get('desktop-pairing') as Record<string, unknown>
+  assert.equal(desktopPairing.authority, 'desktop_local')
+  assert.match((desktopPairing.approvalPolicy as string[]).join('\n'), /local_confirmation/)
+  assert.match((desktopPairing.approvalPolicy as string[]).join('\n'), /remote_allowed/)
+  assert.match((desktopPairing.failClosedChecks as string[]).join('\n'), /HTTPS/)
+  assert.match((desktopPairing.auditEvents as string[]).join('\n'), /command\.blocked/)
+
+  const cloudGateway = gates.get('cloud-channel-gateway') as Record<string, unknown>
+  assert.equal(cloudGateway.authority, 'cloud_worker')
+  assert.match((cloudGateway.approvalPolicy as string[]).join('\n'), /service token does not grant actor approval authority/)
+  assert.match((cloudGateway.failClosedChecks as string[]).join('\n'), /no @opencode-ai\/sdk/)
+  assert.match((cloudGateway.failClosedChecks as string[]).join('\n'), /no direct Postgres access/)
+
+  const fullHybrid = gates.get('full-hybrid') as Record<string, unknown>
+  assert.match((fullHybrid.approvalPolicy as string[]).join('\n'), /one execution authority/)
+  assert.match((fullHybrid.failClosedChecks as string[]).join('\n'), /All smaller gates must pass/)
+})
+
+test('hybrid security docs and validators expose the gate contract', () => {
+  const contract = readJson('deploy/security/hybrid-security-gates.json')
+  const docs = read('docs/hybrid-security-gates.md')
+  const readiness = read('docs/deployment-readiness.md')
+  const securityModel = read('docs/security-model.md')
+  const deployReadme = read('deploy/README.md')
+  const deployValidator = read('scripts/validate-deployment-configs.mjs')
+  const opsValidator = read('scripts/validate-ops-readiness.mjs')
+  const mkdocs = read('mkdocs.yml')
+
+  for (const gate of contract.gates as Array<{ id: string }>) {
+    assert.match(docs, new RegExp(`\\\`${escapeRegExp(gate.id)}\\\``))
+    assert.match(readiness, new RegExp(`\\\`${escapeRegExp(gate.id)}\\\``))
+  }
+
+  for (const phrase of [
+    'deploy/security/hybrid-security-gates.json',
+    'local_confirmation',
+    'remote_allowed',
+    'requires_local_confirmation',
+    'blocked_by_policy',
+    'Retry-After',
+    'provider signing',
+    'HMAC',
+    'customer_hosted_managed_saas_deferred',
+    'one execution authority',
+  ]) {
+    assert.match(docs, new RegExp(escapeRegExp(phrase)))
+  }
+
+  assert.match(readiness, /hybrid-security-gates\.json/)
+  assert.match(securityModel, /Hybrid Security Gates/)
+  assert.match(deployReadme, /hybrid-security-gates\.json/)
+  assert.match(mkdocs, /hybrid-security-gates\.md/)
+  assert.match(deployValidator, /validateHybridSecurityGates/)
+  assert.match(opsValidator, /hybridSecurityGatesPath/)
+})
+
+test('hybrid security gate validation evidence references package scripts', () => {
+  const contract = readJson('deploy/security/hybrid-security-gates.json')
+  const scripts = readJson('package.json').scripts ?? {}
+
+  for (const gate of contract.gates as Array<{ id: string; validationEvidence: string[] }>) {
+    assert.ok(gate.validationEvidence.length > 0, `${gate.id} needs validation evidence`)
+    for (const command of gate.validationEvidence) {
+      const match = /^pnpm\s+([^\s]+)/.exec(command)
+      assert.ok(match, `${gate.id} command must start with pnpm: ${command}`)
+      const scriptName = match[1]
+      if (!scriptName.startsWith('--')) {
+        assert.ok(scripts[scriptName], `${gate.id} references missing script ${scriptName}`)
+      }
+    }
+  }
+})
+
+test('hybrid security contract is grounded in code-level fail-closed behavior', () => {
+  const pairing = read('packages/shared/src/desktop-pairing.ts')
+  assert.match(pairing, /remoteApprovals: 'local_confirmation'/)
+  assert.match(pairing, /remoteQuestions: 'local_confirmation'/)
+  assert.match(pairing, /requires_local_confirmation/)
+  assert.match(pairing, /blocked_by_policy/)
+
+  const workspace = read('packages/shared/src/workspace.ts')
+  assert.match(workspace, /OPENCODE_RUNTIME_AUTHORITIES/)
+  assert.match(workspace, /workspace\.remote_approval_required/)
+
+  const gatewayConfig = read('apps/gateway/src/config.ts')
+  assert.match(gatewayConfig, /Gateway operator endpoints require OPEN_COWORK_GATEWAY_ADMIN_TOKEN/)
+  assert.match(gatewayConfig, /authenticated webhook ingress/)
+  assert.match(gatewayConfig, /signingSecret/)
+  assert.match(gatewayConfig, /webhookSecret/)
+
+  const standaloneNetworkPolicy = read('apps/standalone-gateway/src/network-policy.ts')
+  assert.match(standaloneNetworkPolicy, /public OpenCode endpoint/)
+
+  const cloudHttpServer = read('apps/desktop/src/main/cloud/http-server.ts')
+  assert.match(cloudHttpServer, /Retry-After/)
+  assert.match(cloudHttpServer, /quota_rejections/)
+})


### PR DESCRIPTION
Closes #585.\n\n## Summary\n- Add a machine-readable hybrid security gate contract covering Desktop, Desktop pairing, Standalone Gateway, Cloud Worker, Cloud Channel Gateway, Cloud Gateway Edge, and full hybrid modes.\n- Document mode-aware auth, revocation, approval/question policy, audit, quotas, durability, backup/restore, redaction, and fail-closed behavior.\n- Wire deploy and ops validators plus node tests so the contract stays grounded in code and docs.\n\n## Validation\n- pnpm deploy:validate\n- pnpm ops:validate\n- node --no-warnings --experimental-strip-types --test tests/hybrid-security-gates.test.ts\n- python3 -m mkdocs build --strict\n- git diff --check\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm audit --prod --audit-level high