### PR TITLE
Document OSS packaging and gateway migration strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 It brings the power of OpenCode into a desktop experience that developers love and less technical teams can actually use.
 
-[Docs](https://joe-broadhead.github.io/open-cowork/) • [Getting Started](docs/getting-started.md) • [Workflows](docs/workflows.md) • [Configuration](docs/configuration.md) • [Open Cowork Cloud](docs/open-cowork-cloud.md) • [Downstream](docs/downstream.md) • [Roadmap](docs/roadmap.md)
+[Docs](https://joe-broadhead.github.io/open-cowork/) • [Getting Started](docs/getting-started.md) • [Workflows](docs/workflows.md) • [Configuration](docs/configuration.md) • [Open Cowork Cloud](docs/open-cowork-cloud.md) • [Packaging & Migration](docs/oss-packaging-migration.md) • [Downstream](docs/downstream.md) • [Roadmap](docs/roadmap.md)
 
 </div>
 
@@ -78,6 +78,10 @@ Local threads stay local. Open Cowork does not upload local projects, local
 stdio MCPs, machine runtime config, provider keys, or local-only artifacts just
 because a user connects a cloud org. Cloud-safe actions are explicit, policy
 gated, and reported through the workspace support matrix.
+
+The public product names, OCI image names, Gateway mode split, and migration
+path from the historical `opencode-agent-gateway` prototype are documented in
+[OSS Packaging and Gateway Migration](docs/oss-packaging-migration.md).
 
 ## Why it exists
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,6 +4,8 @@ These recipes are thin provider-specific compositions of the same
 `open-cowork-cloud` and `open-cowork-gateway` images, roles, and adapters.
 Provider behavior should stay in deployment configuration, cloud services, and
 adapter wiring rather than in core runtime/session logic.
+Product names, image/package naming, release channels, and legacy Gateway
+migration policy are defined in `docs/oss-packaging-migration.md`.
 
 Use these invariants across every provider:
 

--- a/deploy/standalone-gateway/README.md
+++ b/deploy/standalone-gateway/README.md
@@ -10,6 +10,10 @@ This is the `gateway-only` topology profile from
 Cloud Channel Gateway, Desktop pairing, edge registration, and full-hybrid
 deployments.
 
+For product naming, release channels, and migration from the historical
+`opencode-agent-gateway` prototype, see
+`docs/oss-packaging-migration.md`.
+
 Standalone Gateway owns private OpenCode execution and Gateway Postgres. It
 does not require Open Cowork Cloud.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,12 +4,13 @@
 
 Open Cowork is not a second runtime.
 
-It is a desktop product layer built on top of OpenCode.
+It is a product layer built on top of OpenCode across Desktop, Cloud, and
+Gateway surfaces.
 
 The clean architectural split is:
 
 - **OpenCode owns execution**
-- **Open Cowork owns composition, packaging, and UI**
+- **Open Cowork owns composition, packaging, UI, sync, policy, and channel adapters**
 
 ## At a glance
 
@@ -105,6 +106,8 @@ The canonical contract for workspace ownership, surface support, sync rules,
 status/reason vocabulary, and downstream boundaries lives in
 [Product Contract](product-contract.md). This section summarizes the
 architectural boundary.
+The canonical naming, packaging, release-channel, and legacy Gateway migration
+contract lives in [OSS Packaging and Gateway Migration](oss-packaging-migration.md).
 
 Open Cowork exposes Desktop, Cloud Web, and Gateway surfaces through explicit
 workspace authorities:

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -11,6 +11,10 @@ understand and that map cleanly onto OpenCode:
 - `Tools & Skills` — MCP tools, OpenCode skills, credentials, and capability relationships
 - `Settings` — appearance, models, permissions, storage, and workflow run behavior
 
+Desktop is one Open Cowork surface. Cloud, Gateway, Standalone Gateway, Mobile,
+and Teams naming and package boundaries are defined in
+[OSS Packaging and Gateway Migration](oss-packaging-migration.md).
+
 Team dashboards, incident-control dashboards, and unsupervised autonomous
 learning controls are not part of the active app surface. User-invoked
 improvement work still belongs in Chat through the bundled `autoresearch`

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -11,6 +11,9 @@ This page is the reference for that model.
 The workspace ownership, sync, status/reason, and non-sync guarantees that
 downstream builds must preserve are defined in
 [Product Contract](product-contract.md).
+The public product names, package/image names, release-channel language, and
+legacy Gateway migration policy are defined in
+[OSS Packaging and Gateway Migration](oss-packaging-migration.md).
 The versioned downstream configuration, branding, packaging, template hygiene,
 and extension contract is defined in
 [Downstream Contract](downstream-contract.md). Current public config files use

--- a/docs/gateway-appliance.md
+++ b/docs/gateway-appliance.md
@@ -33,6 +33,9 @@ through this daemon.
 
 Provider tiers, capabilities, signing requirements, and test expectations are
 tracked in [Gateway Provider Readiness](gateway-provider-readiness.md).
+Product naming, historical `opencode-agent-gateway` migration, and compatibility
+alias policy are tracked in
+[OSS Packaging and Gateway Migration](oss-packaging-migration.md).
 
 ## Product Modes
 
@@ -175,6 +178,11 @@ Existing deployments that use only `OPEN_COWORK_GATEWAY_MODE=self-host` or
 `managed` continue to behave as Cloud Channel Gateway deployments. New configs
 should add `OPEN_COWORK_GATEWAY_PRODUCT_MODE=cloud_channel` or
 `"productMode": "cloud_channel"` for clarity.
+
+If you are migrating from the historical `opencode-agent-gateway` prototype,
+read [OSS Packaging and Gateway Migration](oss-packaging-migration.md) before
+moving state. The old Gateway-owned Postgres and OpenCode runtime state is not
+safe to import into Cloud automatically.
 
 Do not set `standalone` on this daemon. Standalone Team Gateway uses a separate
 app/package layout at `apps/standalone-gateway` so it can own private

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,27 @@
 - pnpm `>=10`
 - Python `>=3.11` for documentation work
 
+## Choose the product surface
+
+Open Cowork has one source tree and several deployable surfaces:
+
+- **Open Cowork Desktop** for local desktop work and optional Cloud
+  workspace sync.
+- **Open Cowork Cloud** for shared browser, Desktop, and Gateway cloud
+  workspaces.
+- **Open Cowork Gateway** for headless Telegram, Slack, email, webhook, and
+  other channel access to Cloud.
+- **Open Cowork Standalone Gateway** for Gateway-only private appliances that
+  own their own private OpenCode runtime.
+
+Start with Desktop if you are evaluating the product personally. Start with
+Cloud plus Cloud Channel Gateway if you need synced Desktop/Web/chat sessions.
+Start with Standalone Gateway only when you intentionally want a chat-first
+private appliance with no Cloud dependency.
+
+The naming, package, image, release-channel, and legacy Gateway migration
+contract is in [OSS Packaging and Gateway Migration](oss-packaging-migration.md).
+
 ## Verify toolchain first
 
 Before installing dependencies, verify Node and install `pnpm` via Corepack:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Open Cowork
-description: Desktop AI workspace built on top of OpenCode — composable, brandable, workflow-ready.
+description: OpenCode product layer for Desktop, Cloud, Gateway, and branded downstream deployments.
 hide:
   - navigation
   - toc
@@ -8,7 +8,7 @@ hide:
 
 # Open Cowork
 
-<p class="subtitle">A desktop AI workspace built on OpenCode. Configurable, brandable, workflow-ready, and engineered like a public product — not a demo.</p>
+<p class="subtitle">An OpenCode product layer for Desktop, Cloud, Gateway, and branded downstream deployments. Configurable, sync-aware, and engineered like a public product, not a demo.</p>
 
 [Get started :material-arrow-right:](getting-started.md){ .md-button .md-button--primary }
 [Why this exists :material-arrow-right:](architecture.md){ .md-button }
@@ -39,12 +39,12 @@ hide:
 
 ## What it is
 
-Open Cowork is the **desktop product layer** built on top of OpenCode.
+Open Cowork is the **product layer** built on top of OpenCode.
 
 The split is deliberate and load-bearing:
 
 - :material-engine: **OpenCode executes** — sessions, agents, approvals, MCP calls, tool semantics, event streams.
-- :material-palette: **Open Cowork composes** — UI, branding, packaging, workflows, sandbox UX, downstream config.
+- :material-palette: **Open Cowork composes** — Desktop, Cloud, Gateway, UI, branding, packaging, workflows, sync, policy, and downstream config.
 
 That boundary is what lets you embed the same battle-tested runtime that
 the OpenCode CLI uses, while still shipping a distinct product with your
@@ -122,9 +122,19 @@ own branding, providers, skills, and workflows.
 
     Rebrand and reconfigure without forking. Three env vars rename the
     app; a config overlay ships your providers, skills, MCPs, and
-    permissions. Same binary, distinct product.
+    permissions. Same source, distinct product.
 
     [:octicons-arrow-right-24: Downstream Customization](downstream.md)
+
+-   :material-server-network:{ .lg } **Cloud and Gateway surfaces**
+
+    ---
+
+    Cloud is the durable source of truth for shared workspaces. Gateway is
+    the headless channel client for Telegram, Slack, email, webhooks, and
+    future channels. Standalone Gateway remains a separate appliance mode.
+
+    [:octicons-arrow-right-24: OSS Packaging and Gateway Migration](oss-packaging-migration.md)
 
 </div>
 
@@ -138,7 +148,7 @@ own branding, providers, skills, and workflows.
 | **Power user** | Schedule recurring work, build skills | [Workflows](workflows.md) → [Workflow Recipes](workflow-recipes.md) |
 | **Downstream distributor** | Ship a branded internal build | [Configuration](configuration.md) → [Downstream Customization](downstream.md) |
 | **Contributor** | Land my first PR | [First Contribution](first-contribution.md) → [Architecture](architecture.md) |
-| **Operator / release manager** | Cut a release, run the gates | [Packaging and Releases](packaging-and-releases.md) → [Release Checklist](release-checklist.md) |
+| **Operator / release manager** | Cut a release, run the gates | [OSS Packaging and Gateway Migration](oss-packaging-migration.md) → [Packaging and Releases](packaging-and-releases.md) |
 | **Security reviewer** | Confirm the threat model holds | [Security Model](security-model.md) → [Telemetry and Privacy](privacy.md) |
 
 </div>
@@ -233,13 +243,15 @@ own branding, providers, skills, and workflows.
 
 | ✅ This is | ❌ This isn't |
 |---|---|
-| A polished desktop product layer on top of OpenCode | A second AI runtime |
-| A configurable, brandable shell for internal builds | A SaaS — everything runs locally |
-| A durable scheduler around Workflow Designer setup threads and OpenCode run agents | A new agent framework |
-| A fork-friendly source you can rebrand without touching the code | A black box |
+| A polished product layer on top of OpenCode | A second AI runtime |
+| A configurable, brandable source for Desktop, Cloud, and Gateway deployments | Lock-in to one hosted service |
+| A durable control plane around OpenCode sessions, projections, workflows, and channels | A new agent framework |
+| A fork-friendly source you can rebrand without touching the code | An implicit sync engine for local files, secrets, or host paths |
 
 ## Read next
 
 - [Glossary](glossary.md) — every term that shows up across these docs.
 - [Getting Started](getting-started.md) — install, sign in, run a session.
 - [Architecture](architecture.md) — the layers, the invariants, and why they're invariants.
+- [OSS Packaging and Gateway Migration](oss-packaging-migration.md) — product
+  names, package boundaries, release channels, and gateway migration policy.

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -14,6 +14,9 @@ Choose a deployment topology before choosing a cloud provider. Cloud-only,
 Cloud Channel Gateway, Cloud Gateway edge, and full-hybrid deployments are
 defined in [Deployment Topologies](deployment-topologies.md) and the
 machine-readable `deploy/topologies/topology-profiles.json` contract.
+Product naming, release channels, image names, and legacy Gateway migration
+policy are defined in
+[OSS Packaging and Gateway Migration](oss-packaging-migration.md).
 
 The cloud entrypoint is one OCI image with role-based behavior:
 

--- a/docs/oss-packaging-migration.md
+++ b/docs/oss-packaging-migration.md
@@ -1,0 +1,217 @@
+---
+title: OSS Packaging and Gateway Migration
+description: Product names, package boundaries, release channels, and migration guidance for Open Cowork Desktop, Cloud, and Gateway.
+---
+
+# OSS Packaging and Gateway Migration
+
+Open Cowork is one open-source product family with multiple deployable
+surfaces. The names below are the public names to use in docs, releases,
+support, and downstream builds.
+
+The most important rule is unchanged: Open Cowork is a product layer on top of
+OpenCode. It should not become a second OpenCode runtime.
+
+## Product Names
+
+| Public name | Status | Owning code | Release artifact |
+| --- | --- | --- | --- |
+| Open Cowork Desktop | Supported | `apps/desktop` | macOS `.dmg`/`.zip`, Linux `.AppImage`/`.deb` |
+| Open Cowork Cloud | Supported for self-host beta and private hosted beta | cloud role code under `apps/desktop/src/main/cloud`, browser app under `apps/website` | `open-cowork-cloud` OCI image and Helm/Compose assets |
+| Open Cowork Gateway | Supported as a cloud channel adapter | `apps/gateway`, `packages/gateway-*` | `open-cowork-gateway` OCI image and Helm/Compose assets |
+| Open Cowork Standalone Gateway | Supported as a Gateway-only execution appliance | `apps/standalone-gateway` | source package and `open-cowork-gateway-standalone` CLI; OCI image can be added after the release gate exists |
+| Open Cowork Mobile | Reserved | none yet | no artifact |
+| Open Cowork Teams | Reserved product/edition name | team and org policy surfaces across Cloud/Gateway | no separate runtime |
+
+Use **Open Cowork Gateway** as the user-facing umbrella. Be precise in
+operator docs:
+
+- **Cloud Channel Gateway** means `apps/gateway`: it connects chat providers
+  to Open Cowork Cloud through HTTP/SSE and never spawns OpenCode.
+- **Standalone Gateway** means `apps/standalone-gateway`: it owns a private
+  OpenCode runtime and Gateway Postgres for Gateway-only deployments.
+
+Do not use `OpenCode Gateway` for new Open Cowork docs except when describing
+the historical standalone prototype.
+
+## Package and Image Names
+
+| Surface | Package or image | Stability |
+| --- | --- | --- |
+| Desktop app | `@open-cowork/desktop` workspace package | internal workspace package |
+| Cloud image | `ghcr.io/<owner>/open-cowork-cloud:<tag>` | release image |
+| Cloud Helm chart | `helm/open-cowork-cloud` | release/deployment asset |
+| Cloud Channel Gateway app | `@open-cowork/gateway` workspace package | internal workspace package |
+| Cloud Channel Gateway image | `ghcr.io/<owner>/open-cowork-gateway:<tag>` | release image |
+| Cloud Channel Gateway Helm chart | `helm/open-cowork-gateway` | release/deployment asset |
+| Standalone Gateway app | `@open-cowork/standalone-gateway` workspace package | internal workspace package |
+| Standalone Gateway CLI | `open-cowork-gateway-standalone` | source-built CLI |
+| Shared API client | `@open-cowork/cloud-client` | workspace SDK; public SDK packaging requires its own release checklist |
+| Shared contracts | `@open-cowork/shared` | internal/shared workspace package |
+
+The release workflow publishes Desktop artifacts plus Cloud and Gateway OCI
+images. Workspace packages are not automatically public npm packages. If a
+package is promoted to a public SDK, it needs semver, API stability docs,
+README examples, changelog entries, and package-level provenance.
+
+## Compatibility Alias Policy
+
+Historical names may remain only as explicit compatibility aliases:
+
+| Historical name | Policy |
+| --- | --- |
+| `opencode-agent-gateway` repository | Historical prototype source. New users should use this `open-cowork` repo. |
+| `opencode-gateway` npm package | Legacy name. If republished, it must be a thin compatibility wrapper that points to Open Cowork Gateway or Standalone Gateway and warns clearly. |
+| `ghcr.io/<owner>/opencode-gateway` image | Legacy image name. Do not publish new primary releases there unless it is an explicit alias to the matching Open Cowork image digest. |
+| `gateway.config.yaml` | Legacy standalone config name. Keep readable in migration docs, but new Open Cowork deployments should use `open-cowork.config.json` plus environment or secret-manager values. |
+| legacy unhyphenated Open Cowork spelling | Back-compat only for existing app ids, on-disk namespaces, or migration notes. New public docs should use `open-cowork`. |
+
+Compatibility aliases must not hide a product-mode change. A user moving from
+the old standalone prototype to Cloud Channel Gateway is moving from a
+Gateway-owned runtime to Cloud-owned execution. That requires an explicit
+deployment decision.
+
+## Product Modes
+
+| Mode | User promise | Execution authority | Best for |
+| --- | --- | --- | --- |
+| Desktop local | Private local OpenCode workspace | Desktop-managed local runtime | individual desktop use, offline/local projects |
+| Cloud workspace | Synced browser/desktop/gateway cloud sessions | Cloud workers | team sync, managed BYOK, web workbench |
+| Cloud Channel Gateway | Chat access to Cloud workspaces | Cloud workers; Gateway is a client | Telegram/Slack/email access to Cloud |
+| Standalone Gateway | Chat-first private appliance | Standalone Gateway plus private OpenCode | VPS, private server, no Cloud dependency |
+| Full hybrid | Desktop local plus Cloud plus Gateway | per-thread authority | organizations that want local privacy and cloud collaboration |
+
+The same product may expose multiple modes, but one thread has exactly one
+execution authority. Local threads stay local. Cloud threads sync through
+Cloud. Gateway messages belong either to a Cloud Channel Gateway session or to
+a Standalone Gateway session; they should not be merged implicitly.
+
+## Migration From `opencode-agent-gateway`
+
+The old gateway prototype has useful concepts and configuration, but its
+durable state is not the same as Open Cowork Cloud state.
+
+### Choose the destination first
+
+| If the old deployment was... | Recommended destination |
+| --- | --- |
+| A Telegram or webhook bot running its own OpenCode server and Postgres | Open Cowork Standalone Gateway |
+| A bot that should share sessions with Desktop and Web | Open Cowork Cloud plus Cloud Channel Gateway |
+| A local development mock or provider contract test bed | Cloud Channel Gateway with fake provider in explicit loopback demo mode, or provider package tests |
+| A manager/team orchestration prototype | Keep as Standalone Gateway until the Cloud team-orchestration contract is implemented |
+
+### Configuration inventory
+
+Before switching, inventory these values from the old deployment:
+
+- provider tokens and webhook secrets
+- allowed users, admins, chats, and provider subject ids
+- workspace roots and worktree roots
+- OpenCode server URL and auth
+- database URL
+- upload/artifact storage path
+- backup and retention policy
+- scheduler/background job settings
+- admin dashboard token and exposure policy
+
+Do not paste old secrets into docs, issue comments, screenshots, or the public
+repo. Move them through environment variables or a secret manager.
+
+### Config mapping
+
+| Old prototype concept | Cloud Channel Gateway | Standalone Gateway |
+| --- | --- | --- |
+| `providers.telegram.instances[].botTokenEnv` | `OPEN_COWORK_GATEWAY_TELEGRAM_BOT_TOKEN` or `gateway.providers.telegram[]` with env placeholders | `OPEN_COWORK_STANDALONE_GATEWAY_TELEGRAM_BOT_TOKEN` |
+| signed bridge provider | `OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET` or gateway provider config | standalone webhook provider secret |
+| `admin.tokenEnv` | `OPEN_COWORK_GATEWAY_ADMIN_TOKEN` for operator routes | `OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN` |
+| `database.urlEnv` | not used by `apps/gateway`; Cloud owns Postgres | `OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL` |
+| `opencode.*` | not used by `apps/gateway`; Cloud workers own OpenCode | `OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL` |
+| workspace/worktree roots | Cloud project sources and uploaded snapshots | standalone workspace/worktree policy |
+| scheduler/background jobs | Cloud workflows and deliveries | standalone scheduler/background jobs |
+| dashboard | Cloud Web admin or Gateway operator endpoints | standalone dashboard |
+
+### State migration policy
+
+There is no safe automatic database migration from the old
+`opencode-agent-gateway` Postgres schema into Open Cowork Cloud. The old schema
+owned runtime, conversation, workspace, job, and OpenCode session state. Cloud
+uses tenant-scoped sessions, commands, events, projections, artifacts,
+workflows, policies, BYOK refs, and channel bindings.
+
+Supported migration path:
+
+1. Export old transcripts, audit records, and artifact manifests for archive.
+2. Stand up Open Cowork Cloud or Standalone Gateway with fresh durable state.
+3. Recreate provider bindings and allowlists from the inventory.
+4. Recreate scheduled workflows or standalone jobs explicitly.
+5. Reconnect users to new sessions.
+6. Keep the old database read-only until the retention window expires.
+
+Do not import old OpenCode runtime homes, provider keys, local project paths, or
+stdio MCP command definitions into Cloud automatically. Cloud-safe equivalents
+must be expressed as project sources, secret refs, remote MCPs, profile policy,
+or explicit artifact uploads.
+
+## Release Channels
+
+| Channel | Meaning | Required evidence |
+| --- | --- | --- |
+| `master` source | Latest merged source. Not a release channel. | CI on `master` |
+| `v0.x` preview | Public OSS preview. APIs and packaging may still move. | CI, docs, checksums, SBOM/provenance, explicit unsigned macOS notice while applicable |
+| private hosted beta | Managed BYOK beta for design partners. May use private ops evidence outside this repo. | private beta evidence, launch evidence manifest, BYOK redaction, restore/failover drills |
+| public beta | Public hosted BYOK. No enterprise promise yet. | load/soak, supply-chain, abuse, billing, support, and deployment evidence |
+| `v1.x` stable | Broad OSS release baseline. | signed/notarized macOS or explicit platform policy, stable docs, migration notes, release gates |
+| enterprise-ready | Downstream/internal enterprise deployments. | SSO/OIDC, audit/export, backup/restore, operator runbooks, support SLA, tenant isolation evidence |
+
+Cloud and Gateway images must use the same release tag as the source release
+and should be deployed by digest from the image evidence files. Do not deploy
+`latest` for shared, beta, or production environments.
+
+## Support Policy
+
+| Deployment | Support expectation |
+| --- | --- |
+| OSS local desktop | GitHub issues, docs, and community best effort. |
+| OSS self-host Cloud/Gateway | GitHub issues plus deployment readiness docs. Operators own their infrastructure, secrets, backups, and cloud bills. |
+| Internal enterprise downstream | The downstream owner controls branding, OIDC, infra, private config, and support process. Keep private values outside the public repo. |
+| Managed BYOK SaaS | Commercial operator owns uptime, billing, incident response, backup/restore, token handling, customer support, and private launch evidence. |
+| Security issues | Use `SECURITY.md`; do not file public issues with exploit details or secrets. |
+
+Support docs must be honest about launch tier. The public repo can claim local
+self-host beta evidence. Managed SaaS or enterprise claims need private
+operations evidence before being marketed as GA.
+
+## Release Checklist Additions
+
+Before a release that touches Desktop, Cloud, Gateway, packaging, or docs:
+
+- Product names in README, docs, release notes, images, and Helm/Compose
+  examples match this page.
+- Cloud Channel Gateway and Standalone Gateway are not described as the same
+  product mode.
+- Any compatibility alias points to the matching Open Cowork artifact digest or
+  package version and warns about legacy status.
+- Gateway migration notes are current for the old `opencode-agent-gateway`
+  concepts.
+- `open-cowork.config.json` and deploy examples use placeholders for private
+  domains, project ids, customer names, prices, and secrets.
+- Release notes state the accepted launch tier: preview, private hosted beta,
+  public beta, stable, or enterprise-ready.
+
+## Validation
+
+Run these checks after editing packaging, naming, migration, or release docs:
+
+```bash
+pnpm docs:build
+python3 -m mkdocs build --strict
+git diff --check
+```
+
+For release-sensitive edits, also run:
+
+```bash
+pnpm deploy:validate
+pnpm deploy:launch:validate
+pnpm ops:validate
+```

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -4,6 +4,23 @@
 
 Open Cowork packages desktop artifacts with Electron Builder.
 
+Product naming, compatibility aliases, Gateway migration policy, and support
+channels are defined in
+[OSS Packaging and Gateway Migration](oss-packaging-migration.md). Treat that
+page as the source of truth when changing public artifact names, OCI image
+names, Helm chart names, or Gateway mode language.
+
+## Product Artifacts
+
+| Product surface | Release artifact |
+| --- | --- |
+| Open Cowork Desktop | macOS `.dmg`/`.zip`, Linux `.AppImage`/`.deb` |
+| Open Cowork Cloud | `open-cowork-cloud` OCI image, Helm chart, Compose references |
+| Open Cowork Gateway | `open-cowork-gateway` OCI image, Helm chart, Compose references |
+| Open Cowork Standalone Gateway | source-built `open-cowork-gateway-standalone` CLI; no public image until the image release gate exists |
+| Open Cowork Mobile | reserved name; no artifact |
+| Open Cowork Teams | reserved product/edition name; no separate runtime |
+
 Current release targets:
 
 ### macOS

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -41,6 +41,9 @@ Reference workflows in the repository root:
 - [ ] README matches current product behavior
 - [ ] config docs match `open-cowork.config.json`
 - [ ] packaging and release docs match the workflows
+- [ ] [OSS Packaging and Gateway Migration](oss-packaging-migration.md) matches
+      the current Desktop, Cloud, Gateway, Standalone Gateway, image, package,
+      and compatibility-alias behavior
 - [ ] if a primary UI route changed, `pnpm screenshots` has regenerated
       `docs/assets/auto/` and the changed screenshots were reviewed before
       release
@@ -67,6 +70,12 @@ Reference workflows in the repository root:
 - [ ] repository metadata and remotes point at the intended public `open-cowork` repo
 - [ ] first public release history-reset/squash decision is complete before making the repo public
 - [ ] release workflows point at the correct package names and scripts
+- [ ] release notes state the accepted launch tier: `v0.x` preview, private
+      hosted beta, public beta, stable, or enterprise-ready
+- [ ] Cloud Channel Gateway and Standalone Gateway are not described as the
+      same product mode in release notes, docs, or deployment assets
+- [ ] any `opencode-gateway` or `opencode-agent-gateway` compatibility alias
+      points at the matching Open Cowork artifact and is marked as legacy
 - [ ] macOS and Linux packaging scripts still match Electron Builder config
 - [ ] release workflow is still tag-driven only
 - [ ] release tag will be an annotated signed tag and GitHub shows it as verified

--- a/docs/standalone-gateway.md
+++ b/docs/standalone-gateway.md
@@ -14,6 +14,10 @@ Use the `gateway-only` topology profile for this deployment path. The profile
 is documented in [Deployment Topologies](deployment-topologies.md) and in
 `deploy/topologies/topology-profiles.json`.
 
+Product naming, historical `opencode-agent-gateway` migration, release-channel
+policy, and compatibility aliases are documented in
+[OSS Packaging and Gateway Migration](oss-packaging-migration.md).
+
 This is not the Cloud Channel Gateway. Cloud Channel Gateway is a Cloud client.
 Standalone Gateway is an execution authority.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,6 +20,10 @@ Downstream builds that keep workflows enabled should keep that agent in
 their app config, or intentionally update the workflow setup policy in code
 and config together.
 
+Workflows appear across Desktop, Cloud, and Gateway deployments according to
+the product mode. The release and packaging names for those modes are defined
+in [OSS Packaging and Gateway Migration](oss-packaging-migration.md).
+
 The product rule is simple:
 
 - **OpenCode executes** sessions, agents, approvals, tools, skills, and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Telemetry and Privacy: privacy.md
   - Operate:
       - Open Cowork Cloud: open-cowork-cloud.md
+      - OSS Packaging and Gateway Migration: oss-packaging-migration.md
       - Managed Workers: managed-workers.md
       - Cloud Gateway Registration: cloud-gateway-registration.md
       - Deployment Topologies: deployment-topologies.md


### PR DESCRIPTION
Closes #587.\n\n## Summary\n- add a canonical OSS packaging and Gateway migration guide for Desktop, Cloud, Gateway, Standalone Gateway, reserved Mobile/Teams names, release channels, support policy, and legacy alias rules\n- link the strategy from README, docs home, getting started, architecture, downstream, Cloud, Gateway, Standalone Gateway, packaging, and release checklist docs\n- clarify that old opencode-agent-gateway state is not automatically migratable into Cloud and that Cloud Channel Gateway and Standalone Gateway are separate product modes\n\n## Validation\n- pnpm docs:build\n- python3 -m mkdocs build --strict\n- git diff --check\n- pnpm deploy:validate\n- pnpm deploy:launch:validate\n- pnpm ops:validate