### PR TITLE
Harden Cloud Web scale and route contracts

### DIFF
--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -1,1 +1,7 @@
+export {
+  decodeSessionPageCursor,
+  encodeSessionPageCursor,
+  InvalidSessionPageCursorError,
+} from './session-page-cursor.ts'
+export type { SessionPageCursorScope } from './session-page-cursor.ts'
 export * from './in-memory-control-plane-store.ts'

--- a/apps/desktop/src/main/cloud/http-routes/api-tokens.ts
+++ b/apps/desktop/src/main/cloud/http-routes/api-tokens.ts
@@ -4,7 +4,11 @@ export async function handleApiTokensApiRoute(input: CloudApiRouteInput): Promis
   const { req, res, options, context, itemId, action, tools } = input
 
   if (!itemId && req.method === 'GET') {
-    tools.writeJson(res, 200, { tokens: await options.service.listApiTokens(context.principal) }, options.corsOrigin)
+    tools.writeJson(res, 200, {
+      tokens: await options.service.listApiTokens(context.principal, {
+        limit: tools.parseLimit(context.url),
+      }),
+    }, options.corsOrigin)
     return true
   }
 

--- a/apps/desktop/src/main/cloud/http-routes/channels.ts
+++ b/apps/desktop/src/main/cloud/http-routes/channels.ts
@@ -51,7 +51,11 @@ export async function handleChannelsApiRoute(input: {
 
   if (collection === 'agents') {
     if (!itemId && req.method === 'GET') {
-      tools.writeJson(res, 200, { agents: await options.service.listHeadlessAgents(context.principal) }, options.corsOrigin)
+      tools.writeJson(res, 200, {
+        agents: await options.service.listHeadlessAgents(context.principal, {
+          limit: tools.readNonNegativeInteger(context.url.searchParams.get('limit'), 100),
+        }),
+      }, options.corsOrigin)
       return true
     }
     if (!itemId && req.method === 'POST') {
@@ -91,7 +95,9 @@ export async function handleChannelsApiRoute(input: {
   if (collection === 'bindings') {
     if (!itemId && req.method === 'GET') {
       tools.writeJson(res, 200, {
-        bindings: await options.service.listChannelBindings(context.principal, context.url.searchParams.get('agentId')),
+        bindings: await options.service.listChannelBindings(context.principal, context.url.searchParams.get('agentId'), {
+          limit: tools.readNonNegativeInteger(context.url.searchParams.get('limit'), 100),
+        }),
       }, options.corsOrigin)
       return true
     }

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -453,9 +453,11 @@ function parseLimit(url: URL) {
 }
 
 function parseSessionStatus(value: string | null): ControlPlaneSessionStatus | null {
-  return value === 'idle' || value === 'running' || value === 'closed' || value === 'errored'
-    ? value
-    : null
+  if (!value) return null
+  if (value === 'idle' || value === 'running' || value === 'closed' || value === 'errored') return value
+  throw new CloudServiceError(400, 'Unsupported session status filter.', {
+    policyCode: 'sessions.status.invalid',
+  })
 }
 
 function readNonNegativeInteger(value: unknown, fallback = 0) {
@@ -1251,7 +1253,9 @@ async function handleApiRequest(
     const workflowAction = action
 
     if (!workflowId && req.method === 'GET') {
-      writeJson(res, 200, await options.service.listWorkflows(context.principal), options.corsOrigin)
+      writeJson(res, 200, await options.service.listWorkflows(context.principal, {
+        limit: parseLimit(context.url),
+      }), options.corsOrigin)
       return
     }
 

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -30,6 +30,10 @@ import { InMemoryManagedWorkersDomain } from './in-memory-domains/workers.ts'
 import { InMemoryQuotaDomain } from './in-memory-domains/quotas.ts'
 import { redactAuditMetadata } from './audit-redaction.ts'
 import { generateChannelInteractionToken, generateCloudApiToken, hashChannelInteractionToken, hashCloudApiToken } from './control-plane-tokens.ts'
+import {
+  decodeSessionPageCursor,
+  encodeSessionPageCursor,
+} from './session-page-cursor.ts'
 export { ControlPlaneQuotaExceededError, publicQuotaMessage } from './control-plane-errors.ts'
 export type { QuotaPolicyCode } from './control-plane-errors.ts'
 export type {
@@ -1321,31 +1325,6 @@ function nowIso(now: Date | undefined) {
 function normalizeListLimit(value: number | null | undefined, fallback = 100, max = 500) {
   if (!Number.isFinite(value)) return fallback
   return Math.max(1, Math.min(max, Math.floor(value || fallback)))
-}
-
-export function encodeSessionPageCursor(session: Pick<SessionRecord, 'updatedAt' | 'sessionId'>) {
-  return Buffer.from(JSON.stringify({
-    updatedAt: session.updatedAt,
-    sessionId: session.sessionId,
-  }), 'utf8').toString('base64url')
-}
-
-export function decodeSessionPageCursor(cursor: string | null | undefined): { updatedAt: string, sessionId: string } | null {
-  if (!cursor) return null
-  try {
-    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
-    if (
-      parsed
-      && typeof parsed === 'object'
-      && typeof parsed.updatedAt === 'string'
-      && typeof parsed.sessionId === 'string'
-    ) {
-      return { updatedAt: parsed.updatedAt, sessionId: parsed.sessionId }
-    }
-  } catch {
-    return null
-  }
-  return null
 }
 
 function stableId(prefix: string, ...parts: string[]) {
@@ -2976,7 +2955,7 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   listSessionsPage(input: ListSessionsPageInput): ListSessionsPageRecord {
     this.requireTenantUser(input.tenantId, input.userId)
     const limit = normalizeListLimit(input.limit)
-    const cursor = decodeSessionPageCursor(input.cursor)
+    const cursor = decodeSessionPageCursor(input.cursor, input)
     const query = input.query?.trim().toLowerCase() || null
     const filtered = Array.from(this.sessions.values())
       .map((session) => session.record)
@@ -3000,7 +2979,7 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const hasMore = filtered.length > limit
     return {
       items: page.map((session) => clone(session)),
-      nextCursor: hasMore && page.length > 0 ? encodeSessionPageCursor(page[page.length - 1]!) : null,
+      nextCursor: hasMore && page.length > 0 ? encodeSessionPageCursor(page[page.length - 1]!, input) : null,
       totalEstimate: filtered.length,
     }
   }

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -2119,7 +2119,7 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   async listSessionsPage(input: ListSessionsPageInput) {
     await this.requireTenantUser(input.tenantId, input.userId)
     const limit = Math.max(1, Math.min(500, Math.floor(input.limit ?? 100)))
-    const cursor = decodeSessionPageCursor(input.cursor)
+    const cursor = decodeSessionPageCursor(input.cursor, input)
     const params: unknown[] = [input.tenantId, input.userId]
     const where = ['tenant_id = $1', 'user_id = $2']
     if (input.status) {
@@ -2158,7 +2158,7 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     const items = rows.slice(0, limit)
     return {
       items,
-      nextCursor: rows.length > limit && items.length > 0 ? encodeSessionPageCursor(items[items.length - 1]!) : null,
+      nextCursor: rows.length > limit && items.length > 0 ? encodeSessionPageCursor(items[items.length - 1]!, input) : null,
       totalEstimate: rows.length > limit ? limit + 1 : rows.length,
     }
   }

--- a/apps/desktop/src/main/cloud/session-page-cursor.ts
+++ b/apps/desktop/src/main/cloud/session-page-cursor.ts
@@ -1,0 +1,75 @@
+import { createHash } from 'node:crypto'
+
+export class InvalidSessionPageCursorError extends Error {
+  constructor(message = 'Session list cursor is invalid.') {
+    super(message)
+    this.name = 'InvalidSessionPageCursorError'
+  }
+}
+
+export type SessionPageCursorScope = {
+  tenantId: string
+  userId: string
+  status?: string | null
+  profileName?: string | null
+  query?: string | null
+}
+
+function normalizedSessionPageCursorScope(scope: SessionPageCursorScope) {
+  return {
+    tenantId: scope.tenantId,
+    userId: scope.userId,
+    status: scope.status || null,
+    profileName: scope.profileName || null,
+    query: scope.query?.trim().toLowerCase() || null,
+  }
+}
+
+function sessionPageCursorScopeHash(scope: SessionPageCursorScope) {
+  return createHash('sha256')
+    .update(JSON.stringify(normalizedSessionPageCursorScope(scope)))
+    .digest('base64url')
+}
+
+export function encodeSessionPageCursor(
+  session: { updatedAt: string, sessionId: string },
+  scope?: SessionPageCursorScope,
+) {
+  const payload: Record<string, unknown> = {
+    v: 1,
+    updatedAt: session.updatedAt,
+    sessionId: session.sessionId,
+  }
+  if (scope) {
+    payload.scopeHash = sessionPageCursorScopeHash(scope)
+  }
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
+}
+
+export function decodeSessionPageCursor(
+  cursor: string | null | undefined,
+  expectedScope?: SessionPageCursorScope,
+): { updatedAt: string, sessionId: string } | null {
+  if (!cursor) return null
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
+    if (
+      parsed
+      && typeof parsed === 'object'
+      && typeof parsed.updatedAt === 'string'
+      && typeof parsed.sessionId === 'string'
+    ) {
+      if (expectedScope) {
+        const expectedHash = sessionPageCursorScopeHash(expectedScope)
+        if (typeof parsed.scopeHash !== 'string' || parsed.scopeHash !== expectedHash) {
+          throw new InvalidSessionPageCursorError('Session list cursor does not match the requested scope.')
+        }
+      }
+      return { updatedAt: parsed.updatedAt, sessionId: parsed.sessionId }
+    }
+  } catch (error) {
+    if (error instanceof InvalidSessionPageCursorError) throw error
+    throw new InvalidSessionPageCursorError()
+  }
+  throw new InvalidSessionPageCursorError()
+}

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -31,6 +31,7 @@ import {
   listCapabilitySkills,
   listCapabilityTools,
 } from '../capability-catalog.ts'
+import { InvalidSessionPageCursorError } from './control-plane-store.ts'
 import type {
   ApiTokenScope,
   BillingSubscriptionRecord,
@@ -618,6 +619,11 @@ function boundedImportText(value: unknown, label: string, maxLength = SESSION_IM
   if (typeof value !== 'string') return ''
   if (value.length > maxLength) throw new CloudServiceError(400, `${label} exceeds ${maxLength} characters.`)
   return value
+}
+
+function normalizedCloudListLimit(value: number | null | undefined, fallback = 100, max = 500) {
+  if (!Number.isFinite(value)) return fallback
+  return Math.max(1, Math.min(max, Math.floor(value || fallback)))
 }
 
 function importAuditActor(principal: CloudPrincipal): { actorType: 'user' | 'api_token', actorId: string, accountId: string | null } {
@@ -1295,11 +1301,20 @@ export class CloudSessionService {
     input: Omit<ListSessionsPageInput, 'tenantId' | 'userId'> = {},
   ): Promise<ListSessionsPageRecord> {
     await this.ensurePrincipal(principal)
-    return this.store.listSessionsPage({
-      ...input,
-      tenantId: principal.tenantId,
-      userId: principal.userId,
-    })
+    try {
+      return await this.store.listSessionsPage({
+        ...input,
+        tenantId: principal.tenantId,
+        userId: principal.userId,
+      })
+    } catch (error) {
+      if (error instanceof InvalidSessionPageCursorError) {
+        throw new CloudServiceError(400, 'Session list cursor is invalid.', {
+          policyCode: 'sessions.cursor.invalid',
+        })
+      }
+      throw error
+    }
   }
 
   async getSessionView(principal: CloudPrincipal, sessionId: string): Promise<CloudSessionView> {
@@ -1431,10 +1446,11 @@ export class CloudSessionService {
     })
   }
 
-  async listHeadlessAgents(principal: CloudPrincipal): Promise<HeadlessAgentRecord[]> {
+  async listHeadlessAgents(principal: CloudPrincipal, input: { limit?: number | null } = {}): Promise<HeadlessAgentRecord[]> {
     await this.ensurePrincipal(principal)
     this.assertChannelSetupAllowed(principal)
-    return this.store.listHeadlessAgents(this.principalOrgId(principal))
+    return (await this.store.listHeadlessAgents(this.principalOrgId(principal)))
+      .slice(0, normalizedCloudListLimit(input.limit))
   }
 
   async createHeadlessAgent(
@@ -1494,10 +1510,16 @@ export class CloudSessionService {
     })
   }
 
-  async listChannelBindings(principal: CloudPrincipal, agentId?: string | null): Promise<PublicChannelBindingRecord[]> {
+  async listChannelBindings(
+    principal: CloudPrincipal,
+    agentId?: string | null,
+    input: { limit?: number | null } = {},
+  ): Promise<PublicChannelBindingRecord[]> {
     await this.ensurePrincipal(principal)
     this.assertChannelSetupAllowed(principal)
-    return (await this.store.listChannelBindings(this.principalOrgId(principal), agentId)).map(publicChannelBinding)
+    return (await this.store.listChannelBindings(this.principalOrgId(principal), agentId))
+      .slice(0, normalizedCloudListLimit(input.limit))
+      .map(publicChannelBinding)
   }
 
   async createChannelBinding(
@@ -2344,10 +2366,11 @@ export class CloudSessionService {
     return this.store.deleteThreadSmartFilter(principal.tenantId, filterId)
   }
 
-  async listWorkflows(principal: CloudPrincipal): Promise<WorkflowListPayload> {
+  async listWorkflows(principal: CloudPrincipal, input: { limit?: number | null } = {}): Promise<WorkflowListPayload> {
     await this.ensurePrincipal(principal)
     this.assertWorkflowsEnabled()
-    const workflows = await this.store.listWorkflows(principal.tenantId, principal.userId)
+    const workflows = (await this.store.listWorkflows(principal.tenantId, principal.userId))
+      .slice(0, normalizedCloudListLimit(input.limit))
     const runs = (await Promise.all(workflows.map((workflow) => (
       this.store.listWorkflowRuns(principal.tenantId, workflow.id, 25)
     )))).flat()
@@ -2762,10 +2785,11 @@ export class CloudSessionService {
     }
   }
 
-  async listApiTokens(principal: CloudPrincipal): Promise<PublicApiTokenRecord[]> {
+  async listApiTokens(principal: CloudPrincipal, input: { limit?: number | null } = {}): Promise<PublicApiTokenRecord[]> {
     await this.ensurePrincipal(principal)
     this.assertApiTokenAdmin(principal)
-    const tokens = await this.store.listApiTokens(this.principalOrgId(principal))
+    const tokens = (await this.store.listApiTokens(this.principalOrgId(principal)))
+      .slice(0, normalizedCloudListLimit(input.limit))
     return tokens.map(publicApiToken)
   }
 

--- a/apps/website/src/browser-e2e.test.ts
+++ b/apps/website/src/browser-e2e.test.ts
@@ -91,14 +91,75 @@ test('cloud web browser pages cloud threads through backend cursors without losi
     assert.match(harness.document.querySelector('#thread-list')?.textContent || '', /Cloud thread 1000/)
     assert.match(harness.document.querySelector('#thread-limit-status')?.textContent || '', /1000 of 1000 loaded of about 1001 total/)
     assert.ok(harness.lastRequest((request) => request.method === 'GET' && request.path.includes('cursor=offset%3A800')))
+    assert.equal((loadMore as HTMLElement).hidden, false)
+
+    const laterPageRow = [...harness.document.querySelectorAll('#thread-list [role="row"]')]
+      .find((row) => row.textContent?.includes('Cloud thread 1000'))
+    assert.ok(laterPageRow)
+    ;(laterPageRow.querySelector('button') as HTMLButtonElement).click()
+    await waitFor(() => assert.match(harness.document.querySelector('#chat-session-title')?.textContent || '', /Cloud thread 1000/))
 
     const workspaceSource = harness.eventSources.find((source) => source.url === '/api/events')
     assert.ok(workspaceSource)
     workspaceSource.emit('snapshot.required', { type: 'snapshot.required', sequence: 0 })
     await waitFor(() => {
-      assert.equal(harness.document.querySelectorAll('#thread-list [role="row"]').length, 1000)
+      const rows = [...harness.document.querySelectorAll('#thread-list [role="row"]')]
+      assert.equal(rows.length, 1000)
+      assert.equal(new Set(rows.map((row) => row.textContent || '')).size, rows.length)
       assert.match(harness.document.querySelector('#thread-list')?.textContent || '', /Cloud thread 1000/)
+      assert.match(harness.document.querySelector('#chat-session-title')?.textContent || '', /Cloud thread 1000/)
+      assert.match(harness.document.querySelector('#thread-list [data-selected="true"]')?.textContent || '', /Cloud thread 1000/)
+      assert.equal((loadMore as HTMLElement).hidden, false)
     })
+  } finally {
+    harness.close()
+  }
+})
+
+test('cloud web browser bounds large admin surfaces and redacts unsafe operational details', async () => {
+  const harness = await createCloudWebBrowserHarness({
+    role: 'admin',
+    memberCount: 150,
+    tokenCount: 140,
+    deliveryCount: 80,
+    workflowCount: 140,
+    workerCount: 120,
+    auditCount: 130,
+    usageCount: 40,
+    artifactCount: 140,
+  }).start()
+  try {
+    await waitFor(() => assert.equal(harness.document.body.dataset.auth, 'signed-in'))
+
+    assert.equal(harness.document.querySelectorAll('#member-list .member-row').length, 100)
+    assert.equal(harness.document.querySelectorAll('#token-list > .row').length, 100)
+    assert.equal(harness.document.querySelectorAll('#delivery-list > .row').length, 50)
+    assert.equal(harness.document.querySelectorAll('#workflow-list [role="row"]').length, 100)
+    assert.equal(harness.document.querySelectorAll('#audit-list > .row').length, 100)
+    assert.equal(harness.document.querySelectorAll('#artifact-list .artifact-card').length, 100)
+    assert.ok(harness.document.querySelectorAll('#usage-list > .row').length <= 12)
+    assert.ok(harness.document.querySelectorAll('#admin-worker-summary > .row').length <= 11)
+
+    assert.ok(harness.lastRequest((request) => request.path === '/api/admin/members?limit=100'))
+    assert.ok(harness.lastRequest((request) => request.path === '/api/api-tokens?limit=100'))
+    assert.ok(harness.lastRequest((request) => request.path === '/api/channels/agents?limit=100'))
+    assert.ok(harness.lastRequest((request) => request.path === '/api/channels/bindings?limit=100'))
+    assert.ok(harness.lastRequest((request) => request.path === '/api/channels/deliveries?limit=50'))
+    assert.ok(harness.lastRequest((request) => request.path === '/api/workflows?limit=100'))
+
+    const auditText = harness.document.querySelector('#audit-list')?.textContent || ''
+    assert.doesNotMatch(auditText, /leaked-secret|signed\?token=/)
+    assert.match(auditText, /\[redacted\]/)
+
+    const deliveryText = harness.document.querySelector('#delivery-list')?.textContent || ''
+    assert.doesNotMatch(deliveryText, /leaked-secret|signed\?token=/)
+
+    const artifactText = harness.document.querySelector('#artifact-list')?.textContent || ''
+    assert.doesNotMatch(artifactText, /signed\?token=|objectKey/)
+
+    harness.clickText('#diagnostics button', 'Prepare bundle')
+    await waitFor(() => assert.match(harness.document.querySelector('#diagnostics-bundle')?.textContent || '', /secrets-redacted/))
+    assert.doesNotMatch(harness.document.querySelector('#diagnostics-bundle')?.textContent || '', /leaked-secret|signed\?token=/)
   } finally {
     harness.close()
   }
@@ -124,7 +185,7 @@ test('cloud web browser handles approvals, questions, artifacts, and workflow ru
       assert.equal(harness.document.body.dataset.route, 'artifacts')
       assert.match(harness.document.querySelector('#artifact-detail')?.textContent || '', /Artifact metadata/)
     })
-    assert.ok(harness.lastRequest((request) => request.method === 'GET' && /\/artifacts$/.test(request.path)))
+    assert.ok(harness.lastRequest((request) => request.method === 'GET' && /\/artifacts(?:\?|$)/.test(request.path)))
 
     harness.clickText('.artifact-card button', 'Download')
     await waitFor(() => assert.ok(harness.lastRequest((request) => request.method === 'GET' && /\/artifacts\/session-1-artifact$/.test(request.path))))

--- a/apps/website/src/browser-test-fixtures.ts
+++ b/apps/website/src/browser-test-fixtures.ts
@@ -1,0 +1,160 @@
+export function iso(index = 0) {
+  return new Date(Date.UTC(2026, 0, 1, 12, 0, index)).toISOString()
+}
+
+export function makeSession(index: number) {
+  const status = index % 37 === 0 ? 'running' : 'idle'
+  return {
+    sessionId: `session-${index}`,
+    title: `Cloud thread ${index}`,
+    profileName: index % 3 === 0 ? 'data-analyst' : 'default',
+    status,
+    updatedAt: iso(index % 60),
+    tags: index % 5 === 0 ? ['finance'] : [],
+    smartFilters: index % 7 === 0 ? ['recent'] : [],
+  }
+}
+
+export function makeSessionView(session: ReturnType<typeof makeSession>, sequence = 10, artifactCount = 1): any {
+  return {
+    session,
+    projection: {
+      sequence,
+      view: {
+        title: session.title,
+        profileName: session.profileName,
+        status: session.status,
+        updatedAt: session.updatedAt,
+        messages: [
+          { id: `${session.sessionId}-user`, role: 'user', content: 'Summarize the workspace.', order: 1 },
+          { id: `${session.sessionId}-assistant`, role: 'assistant', content: `Workspace summary for ${session.title}.`, order: 2 },
+        ],
+        toolCalls: [
+          { id: `${session.sessionId}-tool`, name: 'repo.search', status: 'completed', input: { query: 'todo' }, output: { matches: 2 }, order: 3 },
+        ],
+        taskRuns: [
+          { id: `${session.sessionId}-task`, title: 'Analysis task', agent: 'data-analyst', status: 'completed', content: 'Checked repository context.', order: 4 },
+        ],
+        pendingApprovals: [
+          { id: `${session.sessionId}-approval`, tool: 'shell', description: 'Run read-only tests', input: { command: 'pnpm test' }, order: 5 },
+        ],
+        pendingQuestions: [
+          {
+            id: `${session.sessionId}-question`,
+            questions: [{ header: 'Scope', question: 'Continue with deployment smoke?', options: [{ label: 'Yes' }, { label: 'No' }] }],
+            order: 6,
+          },
+        ],
+        resolvedApprovals: [],
+        resolvedQuestions: [],
+        artifacts: Array.from({ length: artifactCount }, (_, index) => ({
+          artifactId: index === 0 ? `${session.sessionId}-artifact` : `${session.sessionId}-artifact-${index + 1}`,
+          filename: index === 0 ? 'summary.txt' : `artifact-${index + 1}.txt`,
+          contentType: 'text/plain',
+          size: 24 + index,
+          order: 7 + index,
+          signedUrl: index === 0 ? 'https://object.example.test/signed?token=leaked-secret' : undefined,
+          objectKey: `tenant/session/${session.sessionId}/artifact-${index + 1}`,
+        })),
+        todos: [{ id: 'todo-1', content: 'Verify browser workbench', status: 'done', priority: 'high' }],
+        errors: [],
+        sessionCost: 0.0123,
+        sessionTokens: { input: 1000, output: 250, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+        contextState: 'idle',
+        compactionCount: 0,
+        projectSource: session.sessionId.endsWith('0')
+          ? { kind: 'git', repositoryUrl: 'https://github.com/example/repo.git' }
+          : null,
+        tags: session.tags,
+        smartFilters: session.smartFilters,
+      },
+    },
+  }
+}
+
+export function makeMembers(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    accountId: `acct-${index + 1}`,
+    email: index === 0 ? 'owner@example.test' : index === 1 ? 'member@example.test' : `member-${index + 1}@example.test`,
+    role: index === 0 ? 'owner' : index % 5 === 0 ? 'admin' : 'member',
+    status: index % 13 === 0 && index !== 0 ? 'invited' : 'active',
+    updatedAt: iso(index + 1),
+  }))
+}
+
+export function makeTokens(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    tokenId: `token-${index + 1}`,
+    name: index === 0 ? 'Desktop connection' : `Connection ${index + 1}`,
+    last4: String(index + 1000).slice(-4),
+    scopes: [index % 2 === 0 ? 'desktop' : 'gateway'],
+    lastUsedAt: null,
+    revokedAt: null,
+  }))
+}
+
+export function makeDeliveries(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    deliveryId: `delivery-${index + 1}`,
+    provider: index % 2 === 0 ? 'telegram' : 'slack',
+    channelBindingId: 'binding-1',
+    status: index % 3 === 0 ? 'failed' : 'pending',
+    eventType: 'session.completed',
+    attemptCount: index % 4,
+    lastError: index === 0 ? 'failed with token=leaked-secret' : null,
+    nextAttemptAt: iso(index + 3),
+    target: { chatId: `chat-${index + 1}`, token: 'leaked-secret' },
+    payload: { text: 'delivery payload', signedUrl: 'https://object.example.test/signed?token=leaked-secret' },
+  }))
+}
+
+export function makeWorkers(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    workerId: `worker-${index + 1}`,
+    poolId: 'pool-1',
+    displayName: index === 0 ? 'Worker one' : `Worker ${index + 1}`,
+    status: index % 5 === 0 && index !== 0 ? 'paused' : 'active',
+    version: 'test',
+    currentLoad: index % 3,
+    lastHeartbeatAt: iso(index + 5),
+    lastErrorCode: null,
+    lastErrorSummary: null,
+  }))
+}
+
+export function makeWorkflows(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `workflow-${index + 1}`,
+    title: index === 0 ? 'Daily review' : `Workflow ${index + 1}`,
+    instructions: 'Review changed work.',
+    agentName: 'build',
+    status: index % 7 === 0 && index !== 0 ? 'paused' : 'active',
+    latestRunStatus: index % 3 === 0 ? 'completed' : 'queued',
+    triggers: [{ type: 'manual', enabled: true }],
+    updatedAt: iso(index + 5),
+  }))
+}
+
+export function makeAuditEvents(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    eventId: `audit-${index + 1}`,
+    eventType: index === 0 ? 'byok.updated' : 'session.prompted',
+    actorType: 'user',
+    actorId: 'user-1',
+    targetType: index === 0 ? 'byok' : 'session',
+    targetId: index === 0 ? 'anthropic' : `session-${index + 1}`,
+    metadata: { token: 'leaked-secret', signedUrl: 'https://object.example.test/signed?token=leaked-secret', safe: `event-${index + 1}` },
+    createdAt: iso(index + 8),
+  }))
+}
+
+export function makeUsageEvents(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    eventId: `usage-${index + 1}`,
+    eventType: 'prompt',
+    quantity: 1,
+    unit: 'count',
+    createdAt: iso(index + 7),
+    metadata: { token: 'leaked-secret' },
+  }))
+}

--- a/apps/website/src/browser-test-harness.ts
+++ b/apps/website/src/browser-test-harness.ts
@@ -4,6 +4,18 @@ import { setTimeout as delay } from 'node:timers/promises'
 import { CLOUD_WEB_CLIENT_ENDPOINTS } from './client-contract.ts'
 import { CLOUD_WEB_ROUTES, DEFAULT_CLOUD_WEB_ROUTE } from './app-shell.ts'
 import { cloudWebsiteHtml } from './render.ts'
+import {
+  iso,
+  makeAuditEvents,
+  makeDeliveries,
+  makeMembers,
+  makeSession,
+  makeSessionView,
+  makeTokens,
+  makeUsageEvents,
+  makeWorkers,
+  makeWorkflows,
+} from './browser-test-fixtures.ts'
 
 const require = createRequire(import.meta.url)
 const { JSDOM, VirtualConsole } = require('jsdom') as {
@@ -33,76 +45,16 @@ type BrowserHarnessOptions = {
   features?: Record<string, boolean>
   sessionCount?: number
   hydratedViewCount?: number
+  memberCount?: number
+  tokenCount?: number
+  deliveryCount?: number
+  workflowCount?: number
+  workerCount?: number
+  auditCount?: number
+  usageCount?: number
+  artifactCount?: number
   promptFailure?: { status: number, error: string, policyCode?: string }
   projectSourceDenied?: boolean
-}
-
-function iso(index = 0) {
-  return new Date(Date.UTC(2026, 0, 1, 12, 0, index)).toISOString()
-}
-
-function makeSession(index: number) {
-  const status = index % 37 === 0 ? 'running' : 'idle'
-  return {
-    sessionId: `session-${index}`,
-    title: `Cloud thread ${index}`,
-    profileName: index % 3 === 0 ? 'data-analyst' : 'default',
-    status,
-    updatedAt: iso(index % 60),
-    tags: index % 5 === 0 ? ['finance'] : [],
-    smartFilters: index % 7 === 0 ? ['recent'] : [],
-  }
-}
-
-function makeSessionView(session: ReturnType<typeof makeSession>, sequence = 10): any {
-  return {
-    session,
-    projection: {
-      sequence,
-      view: {
-        title: session.title,
-        profileName: session.profileName,
-        status: session.status,
-        updatedAt: session.updatedAt,
-        messages: [
-          { id: `${session.sessionId}-user`, role: 'user', content: 'Summarize the workspace.', order: 1 },
-          { id: `${session.sessionId}-assistant`, role: 'assistant', content: `Workspace summary for ${session.title}.`, order: 2 },
-        ],
-        toolCalls: [
-          { id: `${session.sessionId}-tool`, name: 'repo.search', status: 'completed', input: { query: 'todo' }, output: { matches: 2 }, order: 3 },
-        ],
-        taskRuns: [
-          { id: `${session.sessionId}-task`, title: 'Analysis task', agent: 'data-analyst', status: 'completed', content: 'Checked repository context.', order: 4 },
-        ],
-        pendingApprovals: [
-          { id: `${session.sessionId}-approval`, tool: 'shell', description: 'Run read-only tests', input: { command: 'pnpm test' }, order: 5 },
-        ],
-        pendingQuestions: [
-          {
-            id: `${session.sessionId}-question`,
-            questions: [{ header: 'Scope', question: 'Continue with deployment smoke?', options: [{ label: 'Yes' }, { label: 'No' }] }],
-            order: 6,
-          },
-        ],
-        resolvedApprovals: [],
-        resolvedQuestions: [],
-        artifacts: [
-          { artifactId: `${session.sessionId}-artifact`, filename: 'summary.txt', contentType: 'text/plain', size: 24, order: 7 },
-        ],
-        todos: [{ id: 'todo-1', content: 'Verify browser workbench', status: 'done', priority: 'high' }],
-        errors: [],
-        sessionCost: 0.0123,
-        sessionTokens: { input: 1000, output: 250, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
-        contextState: 'idle',
-        compactionCount: 0,
-        projectSource: session.sessionId.endsWith('0')
-          ? { kind: 'git', repositoryUrl: 'https://github.com/example/repo.git' }
-          : null,
-        tags: session.tags,
-        smartFilters: session.smartFilters,
-      },
-    },
-  }
 }
 
 function parseJsonBody(value: unknown) {
@@ -173,8 +125,9 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
 
   const sessions = Array.from({ length: options.sessionCount || 1 }, (_, index) => makeSession(index + 1))
   const hydratedViewCount = options.hydratedViewCount ?? sessions.length
+  const artifactCount = options.artifactCount || 1
   const views: Record<string, any> = Object.fromEntries(
-    sessions.slice(0, hydratedViewCount).map((session, index) => [session.sessionId, makeSessionView(session, index + 10)]),
+    sessions.slice(0, hydratedViewCount).map((session, index) => [session.sessionId, makeSessionView(session, index + 10, artifactCount)]),
   )
   const requests: MockRequest[] = []
   const eventSources: MockEventSource[] = []
@@ -182,38 +135,35 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
     byok: [
       { providerId: 'anthropic', credentialKind: 'kms_ref', last4: '1234', status: 'active', updatedAt: iso(1), lastValidatedAt: null },
     ],
-    tokens: [
-      { tokenId: 'token-1', name: 'Desktop connection', last4: 'abcd', scopes: ['desktop'], lastUsedAt: null, revokedAt: null },
-    ],
-    members: [
-      { accountId: 'acct-1', email: 'owner@example.test', role: 'owner', status: 'active', updatedAt: iso(1) },
-      { accountId: 'acct-2', email: 'member@example.test', role: 'member', status: 'active', updatedAt: iso(2) },
-    ],
+    tokens: makeTokens(options.tokenCount || 1),
+    members: makeMembers(options.memberCount || 2),
     agents: [
       { agentId: 'agent-1', name: 'On-call coding agent', profileName: 'default', status: 'active' },
     ],
     bindings: [
       { bindingId: 'binding-1', agentId: 'agent-1', provider: 'telegram', displayName: 'Team Telegram', status: 'active', settings: { defaultChatId: 'chat-1' } },
     ],
-    deliveries: [
-      { deliveryId: 'delivery-1', provider: 'telegram', channelBindingId: 'binding-1', status: 'failed', eventType: 'session.completed', attemptCount: 1, lastError: '[redacted]', nextAttemptAt: iso(3) },
-    ],
+    deliveries: makeDeliveries(options.deliveryCount || 1),
     workerPools: [
       { poolId: 'pool-1', name: 'Primary worker pool', mode: 'self_hosted', status: 'active', region: 'test-region', maxWorkers: 3, maxConcurrentWork: 6, updatedAt: iso(4) },
     ],
-    workers: [
-      { workerId: 'worker-1', poolId: 'pool-1', displayName: 'Worker one', status: 'active', version: 'test', currentLoad: 1, lastHeartbeatAt: iso(5), lastErrorCode: null, lastErrorSummary: null },
-      { workerId: 'worker-2', poolId: 'pool-1', displayName: 'Worker two', status: 'paused', version: 'test', currentLoad: 0, lastHeartbeatAt: null, lastErrorCode: null, lastErrorSummary: null },
-    ],
+    workers: makeWorkers(options.workerCount || 2),
     workerHeartbeats: [
       { workerId: 'worker-1', poolId: 'pool-1', version: 'test', currentLoad: 1, activeWorkIds: ['session-1'], receivedAt: iso(5) },
     ],
-    workflows: [
-      { id: 'workflow-1', title: 'Daily review', instructions: 'Review changed work.', agentName: 'build', status: 'active', latestRunStatus: 'completed', triggers: [{ type: 'manual', enabled: true }], updatedAt: iso(5) },
-    ],
-    runs: [
-      { id: 'run-1', workflowId: 'workflow-1', title: 'Daily review run', status: 'completed', sessionId: 'session-1', triggerType: 'manual', createdAt: iso(6), summary: 'Done' },
-    ],
+    workflows: makeWorkflows(options.workflowCount || 1),
+    runs: Array.from({ length: Math.min(options.workflowCount || 1, 60) }, (_, index) => ({
+      id: `run-${index + 1}`,
+      workflowId: `workflow-${index + 1}`,
+      title: index === 0 ? 'Daily review run' : `Workflow run ${index + 1}`,
+      status: 'completed',
+      sessionId: 'session-1',
+      triggerType: 'manual',
+      createdAt: iso(index + 6),
+      summary: 'Done',
+    })),
+    auditEvents: makeAuditEvents(options.auditCount || 1),
+    usageEvents: makeUsageEvents(options.usageCount || 1),
   }
 
   const makeRequestRecord = (input: string | URL | Request, init: RequestInit = {}) => {
@@ -227,6 +177,12 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
       body: parseJsonBody(init.body),
       headers: Object.fromEntries(headers.entries()),
     }
+  }
+
+  const limitFromRequest = (request: ReturnType<typeof makeRequestRecord>, fallback: number, max = 500) => {
+    const params = new URL(request.path, 'https://cloud.example.test').searchParams
+    const parsed = Number(params.get('limit') || fallback)
+    return Math.min(Math.max(Math.floor(Number.isFinite(parsed) ? parsed : fallback), 1), max)
   }
 
   async function handleFetch(input: string | URL | Request, init: RequestInit = {}) {
@@ -274,7 +230,7 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
       state.byok = state.byok.map((secret: any) => secret.providerId === providerId ? { ...secret, status: 'disabled', disabledAt: iso(12) } : secret)
       return jsonResponse({ ok: true })
     }
-    if (request.method === 'GET' && request.pathname === '/api/api-tokens') return jsonResponse({ tokens: state.tokens })
+    if (request.method === 'GET' && request.pathname === '/api/api-tokens') return jsonResponse({ tokens: state.tokens.slice(0, limitFromRequest(request, 100)) })
     if (request.method === 'POST' && request.pathname === '/api/api-tokens') {
       const token = {
         tokenId: `token-${state.tokens.length + 1}`,
@@ -307,7 +263,7 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
       return jsonResponse({ url: 'https://billing.example.test/checkout' })
     }
     if (request.method === 'GET' && request.pathname === '/api/usage/events') {
-      return jsonResponse({ events: [{ eventId: 'usage-1', eventType: 'prompt', quantity: 1, unit: 'count', createdAt: iso(7) }] })
+      return jsonResponse({ events: state.usageEvents.slice(0, limitFromRequest(request, 20)) })
     }
     if (request.method === 'GET' && request.pathname === '/api/usage/summary') {
       return jsonResponse({
@@ -333,7 +289,7 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
         },
       })
     }
-    if (request.method === 'GET' && request.pathname === '/api/admin/members') return jsonResponse({ members: state.members })
+    if (request.method === 'GET' && request.pathname === '/api/admin/members') return jsonResponse({ members: state.members.slice(0, limitFromRequest(request, 100)) })
     if (request.method === 'POST' && request.pathname === '/api/admin/members') {
       state.members = [{ accountId: `acct-${state.members.length + 1}`, email: (request.body as Record<string, unknown>)?.email, role: (request.body as Record<string, unknown>)?.role || 'member', status: 'invited', updatedAt: iso(9) }, ...state.members]
       return jsonResponse({ member: state.members[0] })
@@ -345,28 +301,28 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
       return jsonResponse({ member: state.members.find((member: any) => member.accountId === accountId) })
     }
     if (request.method === 'GET' && request.pathname === '/api/admin/audit') {
-      return jsonResponse({ events: [{ eventId: 'audit-1', eventType: 'byok.updated', actorType: 'user', actorId: 'user-1', targetType: 'byok', targetId: 'anthropic', metadata: { token: '[redacted]' }, createdAt: iso(8) }] })
+      return jsonResponse({ events: state.auditEvents.slice(0, limitFromRequest(request, 100)) })
     }
-    if (request.method === 'GET' && request.pathname === '/api/admin/worker-pools') return jsonResponse({ pools: state.workerPools })
-    if (request.method === 'GET' && request.pathname === '/api/admin/workers') return jsonResponse({ workers: state.workers })
+    if (request.method === 'GET' && request.pathname === '/api/admin/worker-pools') return jsonResponse({ pools: state.workerPools.slice(0, limitFromRequest(request, 100)) })
+    if (request.method === 'GET' && request.pathname === '/api/admin/workers') return jsonResponse({ workers: state.workers.slice(0, limitFromRequest(request, 100)) })
     const workerHeartbeatsMatch = request.pathname.match(/^\/api\/admin\/workers\/([^/]+)\/heartbeats$/)
     if (request.method === 'GET' && workerHeartbeatsMatch) {
       const workerId = decodeURIComponent(workerHeartbeatsMatch[1])
       return jsonResponse({ heartbeats: state.workerHeartbeats.filter((heartbeat: any) => heartbeat.workerId === workerId) })
     }
-    if (request.method === 'GET' && request.pathname === '/api/channels/agents') return jsonResponse({ agents: state.agents })
+    if (request.method === 'GET' && request.pathname === '/api/channels/agents') return jsonResponse({ agents: state.agents.slice(0, limitFromRequest(request, 100)) })
     if (request.method === 'POST' && request.pathname === '/api/channels/agents') {
       const agent = { agentId: `agent-${state.agents.length + 1}`, name: (request.body as Record<string, unknown>)?.name || 'Agent', profileName: (request.body as Record<string, unknown>)?.profileName || 'default', status: 'active' }
       state.agents = [agent, ...state.agents]
       return jsonResponse({ agent })
     }
-    if (request.method === 'GET' && request.pathname === '/api/channels/bindings') return jsonResponse({ bindings: state.bindings })
+    if (request.method === 'GET' && request.pathname === '/api/channels/bindings') return jsonResponse({ bindings: state.bindings.slice(0, limitFromRequest(request, 100)) })
     if (request.method === 'POST' && request.pathname === '/api/channels/bindings') {
       const binding = { bindingId: `binding-${state.bindings.length + 1}`, ...(request.body as Record<string, unknown>), status: 'auth_required' }
       state.bindings = [binding, ...state.bindings]
       return jsonResponse({ binding })
     }
-    if (request.method === 'GET' && request.pathname === '/api/channels/deliveries') return jsonResponse({ deliveries: state.deliveries })
+    if (request.method === 'GET' && request.pathname === '/api/channels/deliveries') return jsonResponse({ deliveries: state.deliveries.slice(0, limitFromRequest(request, 50)) })
     if (request.method === 'POST' && request.pathname.includes('/retry')) {
       state.deliveries = state.deliveries.map((delivery: any) => ({ ...delivery, status: delivery.deliveryId === request.pathname.split('/')[4] ? 'pending' : delivery.status }))
       return jsonResponse({ delivery: state.deliveries[0] })
@@ -381,7 +337,8 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
         redaction: 'secrets-redacted',
         runtime: { role: 'web', commandProcessing: 'disabled', heartbeatCount: 2 },
         byok: { configuredProviders: 1 },
-        gateway: { agents: { total: state.agents.length }, deliverySampleLimit: 200 },
+        gateway: { agents: { total: state.agents.length }, deliverySampleLimit: 200, token: 'leaked-secret' },
+        objectStore: { signedUrl: 'https://object.example.test/signed?token=leaked-secret' },
       })
     }
     if (request.method === 'GET' && request.pathname === '/api/capabilities') {
@@ -396,7 +353,7 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
         ],
       })
     }
-    if (request.method === 'GET' && request.pathname === '/api/workflows') return jsonResponse({ workflows: state.workflows, runs: state.runs })
+    if (request.method === 'GET' && request.pathname === '/api/workflows') return jsonResponse({ workflows: state.workflows.slice(0, limitFromRequest(request, 100)), runs: state.runs.slice(0, 50) })
     const workflowRunMatch = request.pathname.match(/^\/api\/workflows\/([^/]+)\/run$/)
     if (request.method === 'POST' && workflowRunMatch) {
       const workflow = state.workflows.find((entry: any) => entry.id === workflowRunMatch[1]) || state.workflows[0]
@@ -438,7 +395,14 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
       return jsonResponse(views[session.sessionId])
     }
     const sessionViewMatch = request.pathname.match(/^\/api\/sessions\/([^/]+)\/view$/)
-    if (request.method === 'GET' && sessionViewMatch) return jsonResponse(views[decodeURIComponent(sessionViewMatch[1])])
+    if (request.method === 'GET' && sessionViewMatch) {
+      const sessionId = decodeURIComponent(sessionViewMatch[1])
+      if (!views[sessionId]) {
+        const session = sessions.find((entry) => entry.sessionId === sessionId)
+        if (session) views[sessionId] = makeSessionView(session, 10, artifactCount)
+      }
+      return jsonResponse(views[sessionId] || { error: 'Not found' }, views[sessionId] ? 200 : 404)
+    }
     const sessionEventsMatch = request.pathname.match(/^\/api\/sessions\/([^/]+)\/events$/)
     if (request.method === 'GET' && sessionEventsMatch) return jsonResponse({ ok: true })
     const promptMatch = request.pathname.match(/^\/api\/sessions\/([^/]+)\/prompt$/)
@@ -481,7 +445,7 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
     const artifactListMatch = request.pathname.match(/^\/api\/sessions\/([^/]+)\/artifacts$/)
     if (request.method === 'GET' && artifactListMatch) {
       const view = views[decodeURIComponent(artifactListMatch[1])]
-      return jsonResponse({ artifacts: view.projection.view.artifacts })
+      return jsonResponse({ artifacts: view.projection.view.artifacts.slice(0, limitFromRequest(request, 100)) })
     }
     const artifactMatch = request.pathname.match(/^\/api\/sessions\/([^/]+)\/artifacts\/([^/]+)$/)
     if (request.method === 'GET' && artifactMatch) {
@@ -550,13 +514,13 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
     window.eval(clientScript)
     await waitFor(() => {
       assert.notEqual(document.body.dataset.auth, 'loading')
-    })
+    }, 8000)
     if (document.body.dataset.auth === 'signed-in') {
       await waitFor(() => {
         assert.doesNotMatch(document.querySelector('#thread-list')?.textContent || '', /No cloud threads loaded/)
         assert.doesNotMatch(document.querySelector('#workbench-agent-list')?.textContent || '', /No profile-allowed agents loaded|No agents loaded/)
         assert.doesNotMatch(document.querySelector('#workflow-list')?.textContent || '', /No workflows loaded/)
-      })
+      }, 8000)
     }
     return harness
   }

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -160,19 +160,19 @@ export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
   {
     id: 'apiTokens',
     method: 'GET',
-    path: '/api/api-tokens',
+    path: '/api/api-tokens?limit=100',
     csrf: false,
   },
   {
     id: 'channelAgents',
     method: 'GET',
-    path: '/api/channels/agents',
+    path: '/api/channels/agents?limit=100',
     csrf: false,
   },
   {
     id: 'channelBindings',
     method: 'GET',
-    path: '/api/channels/bindings',
+    path: '/api/channels/bindings?limit=100',
     csrf: false,
   },
   {
@@ -304,7 +304,7 @@ export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
   {
     id: 'workflows',
     method: 'GET',
-    path: '/api/workflows',
+    path: '/api/workflows?limit=100',
     csrf: false,
   },
   {
@@ -358,7 +358,7 @@ export const CLOUD_WEB_CLIENT_ENDPOINTS: CloudWebEndpoint[] = [
   {
     id: 'adminMembers',
     method: 'GET',
-    path: '/api/admin/members',
+    path: '/api/admin/members?limit=100',
     csrf: false,
   },
   {

--- a/apps/website/src/client/admin-script.ts
+++ b/apps/website/src/client/admin-script.ts
@@ -312,7 +312,7 @@ function renderAudit() {
     actions.appendChild(pill(event.actorType || 'system'));
     row.appendChild(main);
     row.appendChild(actions);
-    appendDetails(row, 'Redacted metadata', event.metadata || {});
+    appendDetails(row, 'Redacted metadata', safeOperationalMetadata(event.metadata || {}));
     list.appendChild(row);
   }
 }`

--- a/apps/website/src/client/common-script.ts
+++ b/apps/website/src/client/common-script.ts
@@ -86,6 +86,24 @@ const state = {
   activeRoute: bootstrap.defaultRoute || 'threads',
 };
 
+const CLOUD_WEB_LIST_LIMITS = {
+  members: 100,
+  apiTokens: 100,
+  headlessAgents: 100,
+  channelBindings: 100,
+  channelDeliveries: 50,
+  auditEvents: 100,
+  usageEvents: 20,
+  usageQuotas: 100,
+  usageTotals: 100,
+  workerPools: 100,
+  workers: 100,
+  workflows: 100,
+  workflowRuns: 50,
+  sessionArtifacts: 100,
+  diagnosticsArrays: 50,
+};
+
 const qs = (selector, root = document) => root.querySelector(selector);
 const qsa = (selector, root = document) => Array.from(root.querySelectorAll(selector));
 
@@ -353,6 +371,15 @@ function actionButton(label, onClick, variant = '', disabled = false) {
 
 function normalizeList(value) {
   return Array.isArray(value) ? value : [];
+}
+
+function listLimit(key) {
+  const value = CLOUD_WEB_LIST_LIMITS[key];
+  return Number.isFinite(value) && value > 0 ? value : 100;
+}
+
+function boundedList(value, key) {
+  return normalizeList(value).slice(0, listLimit(key));
 }
 
 function safeObject(value) {
@@ -646,7 +673,7 @@ function filteredAuditEvents() {
       event.eventType,
       event.targetType,
       event.targetId,
-      compactJson(event.metadata),
+      compactJson(safeOperationalMetadata(event.metadata)),
     ].filter(Boolean).join(' ').toLowerCase();
     return tokens.every((token) => haystack.includes(token));
   });

--- a/apps/website/src/client/data-script.ts
+++ b/apps/website/src/client/data-script.ts
@@ -37,12 +37,12 @@ async function loadCapabilities() {
 
 async function loadWorkflows() {
   const payload = await optionalSurfaceLoad(
-    () => api(endpoint('workflows', '/api/workflows')),
+    () => api(withQuery(endpoint('workflows', '/api/workflows'), { limit: listLimit('workflows') })),
     { workflows: [], runs: [] },
     (error) => { state.workflows.error = error; },
   );
-  state.workflows.workflows = normalizeList(payload.workflows);
-  state.workflows.runs = normalizeList(payload.runs);
+  state.workflows.workflows = boundedList(payload.workflows, 'workflows');
+  state.workflows.runs = boundedList(payload.runs, 'workflowRuns');
   if (state.selectedWorkflowId && !state.workflows.workflows.some((workflow) => workflow.id === state.selectedWorkflowId)) {
     state.selectedWorkflowId = null;
   }
@@ -87,7 +87,7 @@ async function loadAdminSurfaces() {
       setAdminError,
     ),
     optionalSurfaceLoad(
-      () => api(endpoint('adminMembers', '/api/admin/members')).then((body) => body.members || []),
+      () => api(withQuery(endpoint('adminMembers', '/api/admin/members'), { limit: listLimit('members') })).then((body) => body.members || []),
       [],
       setAdminError,
     ),
@@ -108,10 +108,13 @@ async function loadAdminSurfaces() {
     ),
   ]);
   state.admin.policy = policy;
-  state.admin.members = normalizeList(members);
-  state.admin.workerPools = normalizeList(workerPools);
-  state.admin.workers = normalizeList(workers);
-  state.admin.auditEvents = normalizeList(auditEvents);
+  state.admin.members = boundedList(members, 'members');
+  state.admin.workerPools = boundedList(workerPools, 'workerPools');
+  state.admin.workers = boundedList(workers, 'workers');
+  state.admin.auditEvents = boundedList(auditEvents, 'auditEvents').map((event) => ({
+    ...event,
+    metadata: safeOperationalMetadata(event.metadata),
+  }));
   state.admin.error = adminError;
   state.admin.workerError = workerError;
   renderMembers();
@@ -122,19 +125,24 @@ async function loadAdminSurfaces() {
 
 async function loadGatewayOps() {
   const [agents, bindings, deliveries] = await Promise.all([
-    optionalLoad(() => api(endpoint('channelAgents', '/api/channels/agents')).then((body) => body.agents || []), []),
-    optionalLoad(() => api(endpoint('channelBindings', '/api/channels/bindings')).then((body) => body.bindings || []), []),
+    optionalLoad(() => api(withQuery(endpoint('channelAgents', '/api/channels/agents'), { limit: listLimit('headlessAgents') })).then((body) => body.agents || []), []),
+    optionalLoad(() => api(withQuery(endpoint('channelBindings', '/api/channels/bindings'), { limit: listLimit('channelBindings') })).then((body) => body.bindings || []), []),
     optionalLoad(() => api(endpoint('channelDeliveries', '/api/channels/deliveries?limit=50')).then((body) => body.deliveries || []), []),
   ]);
-  state.agents = normalizeList(agents);
-  state.bindings = normalizeList(bindings);
-  state.deliveries = normalizeList(deliveries);
+  state.agents = boundedList(agents, 'headlessAgents');
+  state.bindings = boundedList(bindings, 'channelBindings');
+  state.deliveries = boundedList(deliveries, 'channelDeliveries').map((delivery) => ({
+    ...delivery,
+    target: safeOperationalMetadata(delivery.target),
+    payload: safeOperationalMetadata(delivery.payload),
+    lastError: safeOperationalText(delivery.lastError),
+  }));
   renderGateway();
 }
 
 async function loadDiagnostics() {
   state.diagnosticsError = null;
-  state.diagnostics = await optionalSurfaceLoad(
+  const diagnostics = await optionalSurfaceLoad(
     () => api(endpoint('diagnostics', '/api/diagnostics')),
     null,
     (error) => {
@@ -142,6 +150,7 @@ async function loadDiagnostics() {
       if (error) setStatus(error, 'error');
     },
   );
+  state.diagnostics = diagnostics ? safeOperationalMetadata(diagnostics) : null;
   renderDiagnostics();
 }
 
@@ -154,16 +163,16 @@ async function refreshDashboard() {
   state.workspace = await api(endpoint('workspace', '/api/workspace'));
   const [byok, tokens, billing, usage, usageSummary] = await Promise.all([
     optionalLoad(() => api(endpoint('byok', '/api/byok')).then((body) => body.secrets || []), []),
-    optionalLoad(() => api(endpoint('apiTokens', '/api/api-tokens')).then((body) => body.tokens || []), []),
+    optionalLoad(() => api(withQuery(endpoint('apiTokens', '/api/api-tokens'), { limit: listLimit('apiTokens') })).then((body) => body.tokens || []), []),
     optionalLoad(() => api(endpoint('billingSubscription', '/api/billing/subscription')), { enabled: false }),
     optionalLoad(() => api(endpoint('usageEvents', '/api/usage/events?limit=20')).then((body) => body.events || []), []),
     optionalLoad(() => api(endpoint('usageSummary', '/api/usage/summary?limit=100')), null),
   ]);
-  state.byok = byok;
-  state.tokens = tokens;
+  state.byok = normalizeList(byok);
+  state.tokens = boundedList(tokens, 'apiTokens');
   state.billing = billing;
-  state.usage = usage;
-  state.usageSummary = usageSummary;
+  state.usage = boundedList(usage, 'usageEvents').map((event) => safeOperationalMetadata(event));
+  state.usageSummary = usageSummary ? safeOperationalMetadata(usageSummary) : null;
   document.body.dataset.auth = 'signed-in';
   setStatus('Workbench synced', 'ok');
   setRoute(window.location.hash.replace(/^#/, '') || state.activeRoute || defaultRoute(), true);
@@ -308,11 +317,18 @@ function downloadJson(filename, payload) {
 }
 
 function exportAuditEvents() {
-  downloadJson('open-cowork-audit-events.json', { exportedAt: new Date().toISOString(), events: filteredAuditEvents() });
+  downloadJson('open-cowork-audit-events.json', {
+    exportedAt: new Date().toISOString(),
+    events: filteredAuditEvents().map((event) => safeOperationalMetadata(event)),
+  });
 }
 
 function exportUsageEvents() {
-  downloadJson('open-cowork-usage-summary.json', { exportedAt: new Date().toISOString(), summary: state.usageSummary, events: state.usage });
+  downloadJson('open-cowork-usage-summary.json', {
+    exportedAt: new Date().toISOString(),
+    summary: safeOperationalMetadata(state.usageSummary),
+    events: state.usage.map((event) => safeOperationalMetadata(event)),
+  });
 }
 
 async function createAgent(formData) {

--- a/apps/website/src/client/ops-script.ts
+++ b/apps/website/src/client/ops-script.ts
@@ -181,10 +181,11 @@ function renderDiagnostics() {
     row.appendChild(span);
     health.appendChild(row);
   }
-  appendDetails(bundle, 'Redacted diagnostics JSON', diagnostics);
+  const redactedDiagnostics = safeOperationalMetadata(diagnostics);
+  appendDetails(bundle, 'Redacted diagnostics JSON', redactedDiagnostics);
   const actions = document.createElement('div');
   actions.className = 'row-actions';
-  actions.appendChild(actionButton('Download bundle', () => downloadJson('open-cowork-diagnostics.json', diagnostics), 'primary', false));
+  actions.appendChild(actionButton('Download bundle', () => downloadJson('open-cowork-diagnostics.json', redactedDiagnostics), 'primary', false));
   bundle.appendChild(actions);
 }`
 }

--- a/apps/website/src/client/workbench-script.ts
+++ b/apps/website/src/client/workbench-script.ts
@@ -573,7 +573,7 @@ function renderArtifacts() {
     empty.textContent = view ? 'No artifacts for the selected thread.' : 'Select a cloud thread to inspect artifacts.';
     panel.appendChild(empty);
   } else {
-    for (const artifact of projection.artifacts) {
+    for (const artifact of projection.artifacts.slice(0, listLimit('sessionArtifacts'))) {
       panel.appendChild(renderArtifactCard(artifact));
     }
   }
@@ -1013,7 +1013,7 @@ async function inspectArtifact(artifactIdValue) {
   };
   renderArtifacts();
   try {
-    const artifacts = await api(endpointPath('sessionArtifacts', '/api/sessions/:sessionId/artifacts', { sessionId: state.selectedSessionId }))
+    const artifacts = await api(withQuery(endpointPath('sessionArtifacts', '/api/sessions/:sessionId/artifacts', { sessionId: state.selectedSessionId }), { limit: listLimit('sessionArtifacts') }))
       .then((body) => normalizeList(body.artifacts));
     const metadata = artifacts.find((artifact) => artifactId(artifact) === artifactIdValue) || { artifactId: artifactIdValue };
     state.artifactPanel.metadata = safeArtifactMetadata(metadata);

--- a/apps/website/src/performance.test.ts
+++ b/apps/website/src/performance.test.ts
@@ -137,3 +137,37 @@ test('cloud web browser renders 10k session lists with bounded DOM work', async 
     harness.close()
   }
 })
+
+test('cloud web browser keeps large admin surfaces bounded across route transitions', async () => {
+  const start = performance.now()
+  const harness = await createCloudWebBrowserHarness({
+    role: 'admin',
+    memberCount: 1_000,
+    tokenCount: 1_000,
+    deliveryCount: 1_000,
+    workflowCount: 1_000,
+    workerCount: 1_000,
+    auditCount: 1_000,
+    usageCount: 1_000,
+    artifactCount: 1_000,
+  }).start()
+  try {
+    await waitFor(() => assert.equal(harness.document.querySelectorAll('#member-list .member-row').length, 100))
+    budget('browser bootstrap with large admin fixtures', performance.now() - start, 8000)
+
+    const routeStart = performance.now()
+    for (const label of ['Members', 'Connections', 'Gateway', 'Audit', 'Usage', 'Workflows', 'Artifacts']) {
+      harness.clickText('[data-route-link]', label)
+    }
+    budget('admin route transitions over large fixtures', performance.now() - routeStart, 1200)
+
+    assert.equal(harness.document.querySelectorAll('#member-list .member-row').length, 100)
+    assert.equal(harness.document.querySelectorAll('#token-list > .row').length, 100)
+    assert.equal(harness.document.querySelectorAll('#delivery-list > .row').length, 50)
+    assert.equal(harness.document.querySelectorAll('#workflow-list [role="row"]').length, 100)
+    assert.equal(harness.document.querySelectorAll('#audit-list > .row').length, 100)
+    assert.equal(harness.document.querySelectorAll('#artifact-list .artifact-card').length, 100)
+  } finally {
+    harness.close()
+  }
+})

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -75,7 +75,20 @@ test('cloud website route/API matrix covers every route and real endpoint id', (
     assert.ok(entry.states.loading && entry.states.empty && entry.states.error, `${entry.routeId} defines loading/empty/error states`)
     assert.ok(entry.disabledBehavior, `${entry.routeId} defines disabled behavior`)
     assert.ok(entry.pagination, `${entry.routeId} defines pagination/cursor behavior`)
+    assert.ok(entry.paginationContract, `${entry.routeId} defines structured pagination contract`)
+    assert.equal(typeof entry.paginationContract.implemented, 'boolean', `${entry.routeId} declares pagination implementation status`)
+    assert.ok(['cursor', 'bounded-page', 'local-bounded', 'not-applicable', 'deferred'].includes(entry.paginationContract.mode), `${entry.routeId} declares a known pagination mode`)
+    assert.ok(['implemented', 'not-applicable', 'deferred'].includes(entry.paginationContract.cursor), `${entry.routeId} declares cursor state`)
+    if (entry.paginationContract.mode === 'bounded-page' || entry.paginationContract.mode === 'local-bounded' || entry.paginationContract.limit !== null) {
+      assert.ok(
+        typeof entry.paginationContract.limit === 'number' && entry.paginationContract.limit > 0,
+        `${entry.routeId} declares a positive list limit`,
+      )
+    }
     assert.ok(entry.redaction, `${entry.routeId} defines redaction behavior`)
+    assert.ok(entry.redactionContract, `${entry.routeId} defines structured redaction contract`)
+    assert.equal(entry.redactionContract.rawSecretsAllowed, false, `${entry.routeId} forbids raw secrets`)
+    assert.ok(entry.redactionContract.browserSanitizer, `${entry.routeId} names the browser/server sanitizer boundary`)
     assert.ok(entry.tests.length > 0, `${entry.routeId} lists test coverage`)
     for (const endpointId of entry.endpointIds) {
       assert.ok(endpoints.has(endpointId), `${entry.routeId} references known endpoint ${endpointId}`)
@@ -89,6 +102,13 @@ test('cloud website route/API matrix covers every route and real endpoint id', (
   }
   assert.doesNotMatch(doc, /backend cursoring is deferred until the sessions API exposes cursors/)
   assert.match(CLOUD_WEB_ROUTE_API_MATRIX.find((entry) => entry.routeId === 'threads')?.pagination || '', /cursor pages/)
+  assert.equal(CLOUD_WEB_ROUTE_API_MATRIX.find((entry) => entry.routeId === 'threads')?.paginationContract.cursor, 'implemented')
+  for (const routeId of ['members', 'audit', 'usage', 'gateway', 'connections', 'policy', 'workflows', 'artifacts', 'diagnostics']) {
+    const entry = CLOUD_WEB_ROUTE_API_MATRIX.find((candidate) => candidate.routeId === routeId)
+    assert.ok(entry, `${routeId} has a route matrix entry`)
+    assert.ok(entry.paginationContract.limit === null || entry.paginationContract.limit <= 100, `${routeId} is browser-bounded`)
+    assert.equal(entry.redactionContract.rawSecretsAllowed, false, `${routeId} forbids raw secrets`)
+  }
 })
 
 test('cloud website bootstrap exposes typed client endpoint metadata', () => {
@@ -166,12 +186,13 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessionQuestionReject')?.path, '/api/sessions/:sessionId/question-reject')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'sessionArtifact')?.path, '/api/sessions/:sessionId/artifacts/:artifactId')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'capabilitiesCatalog')?.path, '/api/capabilities')
-  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workflows')?.path, '/api/workflows')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workflows')?.path, '/api/workflows?limit=100')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workflowRun')?.path, '/api/workflows/:workflowId/run')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'projectSourceValidate')?.path, '/api/project-sources/validate')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'projectSnapshots')?.path, '/api/project-sources/snapshots')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminPolicy')?.path, '/api/admin/policy')
-  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMembers')?.path, '/api/admin/members')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'apiTokens')?.path, '/api/api-tokens?limit=100')
+  assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMembers')?.path, '/api/admin/members?limit=100')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMemberInvite')?.method, 'POST')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminMemberUpdate')?.path, '/api/admin/members/:accountId/update')
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'adminAudit')?.path, '/api/admin/audit?limit=100')

--- a/apps/website/src/route-api-matrix.ts
+++ b/apps/website/src/route-api-matrix.ts
@@ -2,6 +2,22 @@ import type { CloudWebRouteId, CloudWebSurface } from './app-shell.ts'
 import type { CloudWebEndpointId } from './client-contract.ts'
 
 export type CloudWebRouteRequiredRole = 'public' | 'member' | 'admin' | 'operator'
+export type CloudWebRoutePaginationMode = 'cursor' | 'bounded-page' | 'local-bounded' | 'not-applicable' | 'deferred'
+export type CloudWebRouteCursorState = 'implemented' | 'not-applicable' | 'deferred'
+export type CloudWebRouteRedactionSanitizer = 'server' | 'safeOperationalMetadata' | 'safeArtifactMetadata' | 'metadata-only'
+
+export type CloudWebRoutePaginationContract = {
+  mode: CloudWebRoutePaginationMode
+  cursor: CloudWebRouteCursorState
+  limit: number | null
+  implemented: boolean
+}
+
+export type CloudWebRouteRedactionContract = {
+  serverRedacted: boolean
+  browserSanitizer: CloudWebRouteRedactionSanitizer
+  rawSecretsAllowed: false
+}
 
 export type CloudWebRouteApiMatrixEntry = {
   routeId: CloudWebRouteId
@@ -15,8 +31,26 @@ export type CloudWebRouteApiMatrixEntry = {
   }
   disabledBehavior: string
   pagination: string
+  paginationContract: CloudWebRoutePaginationContract
   redaction: string
+  redactionContract: CloudWebRouteRedactionContract
   tests: string[]
+}
+
+function paginationContract(
+  mode: CloudWebRoutePaginationMode,
+  cursor: CloudWebRouteCursorState,
+  limit: number | null,
+  implemented = true,
+): CloudWebRoutePaginationContract {
+  return { mode, cursor, limit, implemented }
+}
+
+function redactionContract(
+  browserSanitizer: CloudWebRouteRedactionSanitizer,
+  serverRedacted = true,
+): CloudWebRouteRedactionContract {
+  return { browserSanitizer, serverRedacted, rawSecretsAllowed: false }
 }
 
 export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
@@ -32,7 +66,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Create controls are disabled when chat is unavailable or the user is signed out.',
     pagination: 'Browser page size is bounded by CLOUD_WEB_THREAD_PAGE_SIZE. Cloud Web consumes /api/sessions cursor pages with Load more, preserves loaded pages across workspace SSE refreshes, and only shows total estimates when the backend returns one.',
+    paginationContract: paginationContract('cursor', 'implemented', 200),
     redaction: 'Local host paths and local MCP process details are never accepted as cloud thread context.',
+    redactionContract: redactionContract('metadata-only'),
     tests: ['render.test.ts', 'browser-e2e.test.ts', 'performance.test.ts'],
   },
   {
@@ -47,7 +83,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Composer is disabled until a cloud session is selected and chat policy is enabled.',
     pagination: 'Session SSE resumes from the durable projection sequence; no browser-only projection model exists.',
+    paginationContract: paginationContract('cursor', 'implemented', null),
     redaction: 'Runtime details are rendered from Cloud projections and sanitized before browser display.',
+    redactionContract: redactionContract('safeOperationalMetadata'),
     tests: ['browser-e2e.test.ts', 'render.test.ts', 'cloud-continuation-e2e.test.ts'],
   },
   {
@@ -62,7 +100,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Refresh is disabled when agent/skill/MCP features are disabled by profile policy.',
     pagination: 'Capability filtering is local and performance-tested against hundreds of entries.',
+    paginationContract: paginationContract('local-bounded', 'not-applicable', 500),
     redaction: 'Custom content is metadata-only; machine-local MCP commands and secrets are not exposed.',
+    redactionContract: redactionContract('metadata-only'),
     tests: ['render.test.ts', 'performance.test.ts'],
   },
   {
@@ -77,7 +117,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Controls are disabled when all capability surfaces are policy-disabled.',
     pagination: 'Local filtering is bounded and covered by performance tests; API cursoring is deferred.',
+    paginationContract: paginationContract('local-bounded', 'deferred', 500),
     redaction: 'Machine-scoped MCPs are displayed as policy-limited metadata, not executable local commands.',
+    redactionContract: redactionContract('metadata-only'),
     tests: ['render.test.ts', 'performance.test.ts'],
   },
   {
@@ -92,7 +134,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Workflow create/run controls are disabled when workflows are disabled by profile policy.',
     pagination: 'The route consumes the current workflow summary payload; run-history cursoring is deferred.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 100),
     redaction: 'Workflow rows expose cloud metadata only, never worker credentials or local paths.',
+    redactionContract: redactionContract('metadata-only'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -107,7 +151,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Artifact body fetches happen only from explicit Inspect/Download actions.',
     pagination: 'Selected-session artifact lists use the cloud artifact API; cross-session artifact browsing is deferred.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 100),
     redaction: 'Signed URLs, object keys, buckets, tokens, and raw object-store internals are stripped from metadata.',
+    redactionContract: redactionContract('safeArtifactMetadata'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -122,7 +168,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Signed-in-only routes and controls are hidden while signed out.',
     pagination: 'Not applicable.',
+    paginationContract: paginationContract('not-applicable', 'not-applicable', null),
     redaction: 'Bootstrap JSON carries public branding and feature metadata only.',
+    redactionContract: redactionContract('server'),
     tests: ['browser-e2e.test.ts', 'accessibility.test.ts', 'render.test.ts'],
   },
   {
@@ -137,7 +185,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Invite and role controls are disabled for members and when signup mode is not invite.',
     pagination: 'Admin members endpoint accepts q and limit; the browser currently loads the first bounded page.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 100),
     redaction: 'Member rows expose identity and role/status only.',
+    redactionContract: redactionContract('metadata-only'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -152,7 +202,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Mutating policy controls are not exposed in v1; summaries remain read-only.',
     pagination: 'Worker pools and workers load bounded first pages with limit=100.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 100),
     redaction: 'Worker health summaries exclude credentials and heartbeat secrets.',
+    redactionContract: redactionContract('metadata-only'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -167,7 +219,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Key entry, validation, and disable controls are admin-only.',
     pagination: 'Not applicable; BYOK status is provider-scoped metadata.',
+    paginationContract: paginationContract('not-applicable', 'not-applicable', null),
     redaction: 'Plaintext provider keys are write-only and never re-rendered from state.',
+    redactionContract: redactionContract('server'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -182,7 +236,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Token issue and revoke controls are admin-only and destructive actions require typed confirmation.',
     pagination: 'API token list is bounded by server defaults; cursoring is deferred.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 100),
     redaction: 'Token plaintext is shown once only after creation and never persisted.',
+    redactionContract: redactionContract('server'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -197,7 +253,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Billing controls are disabled for self-host mode and non-admin users.',
     pagination: 'Not applicable.',
+    paginationContract: paginationContract('not-applicable', 'not-applicable', null),
     redaction: 'Billing UI renders entitlement state, not provider secrets.',
+    redactionContract: redactionContract('server'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -212,7 +270,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Gateway setup, binding, retry, and dead-letter actions are admin-only.',
     pagination: 'Delivery backlog loads the first 50 rows; provider streams are handled by Gateway, not the browser.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 50),
     redaction: 'Channel credential refs are metadata only; channel secrets are not rendered.',
+    redactionContract: redactionContract('safeOperationalMetadata'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -227,7 +287,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Export is admin-only and exports redacted audit events.',
     pagination: 'Audit endpoint loads the first 100 events; cursor export is deferred.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 100),
     redaction: 'Audit metadata is expected to be server-redacted before browser export.',
+    redactionContract: redactionContract('safeOperationalMetadata'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -242,7 +304,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Usage is read-only; export is available for the visible redacted summary.',
     pagination: 'Usage events load limit=20 and summaries load limit=100.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 20),
     redaction: 'Usage events contain metering dimensions only, not prompts or secrets.',
+    redactionContract: redactionContract('safeOperationalMetadata'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
@@ -257,7 +321,9 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     },
     disabledBehavior: 'Diagnostics controls are hidden from non-admin users and may still require operator-token privileges.',
     pagination: 'Diagnostics includes bounded worker heartbeat and gateway delivery samples.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 50),
     redaction: 'Diagnostics bundle is recursively redacted for tokens, cookies, API keys, object URLs, and credential refs.',
+    redactionContract: redactionContract('safeOperationalMetadata'),
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
 ]

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -16,7 +16,9 @@ The typed source of truth is
 `apps/website/src/route-api-matrix.ts`. Every route must have a matrix entry
 with required role, backing endpoint ids, loading/empty/error states,
 disabled-state behavior, pagination or cursor notes, redaction requirements,
-and tests.
+structured pagination/redaction contracts, and tests. The route matrix tests
+fail if a route omits its limit/cursor mode, raw-secret policy, or
+loading/empty/error state contract.
 
 | Route id | Surface | Required role | Backing endpoint ids | Pagination / cursor | Redaction and disabled behavior |
 |---|---|---|---|---|---|
@@ -24,18 +26,18 @@ and tests.
 | `chat` | Workbench | Member | `sessionView`, `sessionEvents`, `sessionPrompt`, `sessionPermissionRespond`, `sessionQuestionReply`, `sessionQuestionReject` | Session SSE resumes from the durable Cloud projection sequence. | Composer disables until a Cloud thread is selected. Runtime state is rendered from Cloud projections, not a browser-only projection model. |
 | `agents` | Workbench | Member | `workspace`, `capabilitiesCatalog` | Capability filtering is local and performance-tested. | Agent metadata is cloud profile metadata only; local stdio MCP commands and secrets are not rendered. |
 | `capabilities` | Workbench | Member | `capabilitiesCatalog`, `capabilityTools`, `capabilitySkills` | Local capability filtering is bounded; API cursoring is deferred. | Machine-scoped MCPs are visible only as policy-limited metadata. |
-| `workflows` | Workbench | Member | `workflows`, `workflow`, `workflowRun`, `workflowPause`, `workflowResume`, `workflowArchive` | Workflow summary payload is bounded by the Cloud API; run-history cursoring is deferred. | Workflow controls disable when profile policy blocks workflows. Rows never expose worker credentials or local paths. |
-| `artifacts` | Workbench | Member | `sessionArtifacts`, `sessionArtifact` | Selected-session artifact lists use the Cloud artifact API. Cross-session artifact browsing is deferred. | Artifact bodies fetch only after explicit action. Signed URLs, object keys, buckets, tokens, and object-store internals are stripped from metadata. |
+| `workflows` | Workbench | Member | `workflows`, `workflow`, `workflowRun`, `workflowPause`, `workflowResume`, `workflowArchive` | Workflow summary rendering is bounded to 100 workflows and 50 recent runs in the browser; run-history cursoring is deferred. | Workflow controls disable when profile policy blocks workflows. Rows never expose worker credentials or local paths. |
+| `artifacts` | Workbench | Member | `sessionArtifacts`, `sessionArtifact` | Selected-session artifact metadata rendering is bounded to 100 artifacts. Cross-session artifact browsing is deferred. | Artifact bodies fetch only after explicit action. Signed URLs, object keys, buckets, tokens, and object-store internals are stripped from metadata. |
 | `org` | Admin | Public | `authMe`, `config`, `workspace` | Not applicable. | Signed-out state hides signed-in routes. Bootstrap JSON carries public branding, route metadata, endpoint metadata, and feature metadata only. |
-| `members` | Admin | Admin | `adminMembers`, `adminMemberInvite`, `adminMemberUpdate` | Members endpoint supports `q` and `limit`; the browser loads the first bounded page. | Member rows expose identity, role, and status only. Invite and role controls disable for non-admins and non-invite signup modes. |
+| `members` | Admin | Admin | `adminMembers`, `adminMemberInvite`, `adminMemberUpdate` | Members endpoint supports `q` and `limit`; the browser requests `limit=100` and renders at most 100 rows. | Member rows expose identity, role, and status only. Invite and role controls disable for non-admins and non-invite signup modes. |
 | `policy` | Admin | Member | `adminPolicy`, `adminWorkerPools`, `adminWorkers`, `adminWorkerHeartbeats` | Worker pools and workers load first pages with `limit=100`; heartbeat detail is worker-scoped. | Policy and worker health summaries are read-only in v1 and exclude credentials, heartbeat tokens, and worker secrets. |
 | `byok` | Admin | Admin | `byok` | Not applicable. | Provider keys are write-only. The browser only renders provider id, credential kind, last4/fingerprint/status, and validation timestamps. |
-| `connections` | Admin | Admin | `apiTokens` | API token list is bounded by server defaults; cursoring is deferred. | Token plaintext is shown once after creation and never stored in persistent browser storage. |
+| `connections` | Admin | Admin | `apiTokens` | API token list requests `limit=100` and the browser renders at most 100 rows; cursoring is deferred. | Token plaintext is shown once after creation and never stored in persistent browser storage. |
 | `billing` | Admin | Admin | `billingSubscription` | Not applicable. | Billing renders entitlement state and plan metadata only. Self-host mode disables managed billing controls. |
-| `gateway` | Admin | Admin | `channelAgents`, `channelBindings`, `channelDeliveries`, `channelDeliveryRetry`, `channelDeliveryDeadLetter` | Delivery backlog loads the first 50 rows. Provider streams are handled by Gateway, not the browser. | Channel credential refs are metadata only. Retry and dead-letter actions require admin controls and confirmation. |
-| `audit` | Admin | Admin | `adminAudit` | Audit endpoint loads the first 100 events. Cursor export is deferred. | Audit metadata must be server-redacted before browser display or export. |
+| `gateway` | Admin | Admin | `channelAgents`, `channelBindings`, `channelDeliveries`, `channelDeliveryRetry`, `channelDeliveryDeadLetter` | Headless agents and bindings request `limit=100`; delivery backlog requests and renders the first 50 rows. Provider streams are handled by Gateway, not the browser. | Channel credential refs are metadata only. Delivery payloads are browser-sanitized before details render. Retry and dead-letter actions require admin controls and confirmation. |
+| `audit` | Admin | Admin | `adminAudit` | Audit endpoint loads the first 100 events. Cursor export is deferred. | Audit metadata must be server-redacted and is browser-sanitized again before display or export. |
 | `usage` | Admin | Member | `usageEvents`, `usageSummary` | Usage events load `limit=20`; summaries load `limit=100`. | Usage events include metering dimensions only, not prompts, provider keys, or tokens. |
-| `diagnostics` | Admin | Operator | `diagnostics`, `runtimeStatus`, `workerHeartbeats` | Diagnostics includes bounded worker heartbeat and gateway delivery samples. | Diagnostics are redacted recursively. Org admins may see the route, but the API may require operator-token privileges for global operational state. |
+| `diagnostics` | Admin | Operator | `diagnostics`, `runtimeStatus`, `workerHeartbeats` | Diagnostics includes bounded worker heartbeat and gateway delivery samples. Browser diagnostics arrays are recursively capped before rendering. | Diagnostics are redacted recursively. Org admins may see the route, but the API may require operator-token privileges for global operational state. |
 
 ## End-User Workbench Contract
 
@@ -54,6 +56,11 @@ Cloud Web must keep parity with Desktop Cloud for cloud workspaces:
 
 The browser must not create a second projection model. It consumes Cloud
 snapshots and events through the shared API contract.
+
+`/api/sessions` cursors are opaque, scoped to the authenticated tenant, user,
+and active filters, and invalid or mismatched cursors fail closed with `400`.
+Workspace SSE refreshes rehydrate the same number of loaded pages rather than
+collapsing a large thread list back to page one.
 
 ## Admin Contract
 
@@ -94,5 +101,5 @@ git diff --check
 
 The Cloud Web gates cover browser workflow smoke, accessibility/keyboard
 behavior, responsive layout expectations, performance budgets for large thread
-and capability lists, route/API matrix coverage, and package-boundary checks
-that keep the browser out of server-only modules.
+and admin lists, route/API matrix coverage, backend cursor validation, and
+package-boundary checks that keep the browser out of server-only modules.

--- a/tests/cloud-control-plane-store-contracts.test.ts
+++ b/tests/cloud-control-plane-store-contracts.test.ts
@@ -85,6 +85,29 @@ function runControlPlaneDomainContracts(
       const firstSessionPage = await store.listSessionsPage({ tenantId, userId, limit: 1 })
       assert.deepEqual(firstSessionPage.items.map((session) => session.sessionId), [sessionId])
       assert.equal(firstSessionPage.nextCursor, null)
+
+      const sameUpdatedAt = new Date('2026-01-02T00:00:00.000Z')
+      for (const suffix of ['a', 'b', 'c']) {
+        await store.createSession({
+          tenantId,
+          userId,
+          sessionId: `${prefix}-page-${suffix}`,
+          opencodeSessionId: `${prefix}-runtime-${suffix}`,
+          profileName: suffix === 'c' ? 'data-analyst' : 'default',
+          title: `cursor-contract ${suffix}`,
+          createdAt: sameUpdatedAt,
+        })
+      }
+      const cursorPageOne = await store.listSessionsPage({ tenantId, userId, limit: 2, query: 'cursor-contract' })
+      assert.deepEqual(cursorPageOne.items.map((session) => session.sessionId), [`${prefix}-page-a`, `${prefix}-page-b`])
+      assert.ok(cursorPageOne.nextCursor)
+      const cursorPageTwo = await store.listSessionsPage({ tenantId, userId, limit: 2, query: 'cursor-contract', cursor: cursorPageOne.nextCursor })
+      assert.deepEqual(cursorPageTwo.items.map((session) => session.sessionId), [`${prefix}-page-c`])
+      assert.equal(new Set([...cursorPageOne.items, ...cursorPageTwo.items].map((session) => session.sessionId)).size, 3)
+      await assert.rejects(
+        Promise.resolve().then(() => store.listSessionsPage({ tenantId, userId, limit: 2, query: 'changed-filter', cursor: cursorPageOne.nextCursor })),
+        /cursor/i,
+      )
       const event = await store.appendSessionEvent({
         tenantId,
         sessionId,

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -61,6 +61,14 @@ test('cloud control plane paginates and filters user session lists', () => {
   const second = store.listSessionsPage({ tenantId: 'tenant-1', userId: 'user-1', limit: 2, cursor: first.nextCursor })
   assert.deepEqual(second.items.map((session) => session.sessionId), ['session-1'])
   assert.equal(second.nextCursor, null)
+  assert.throws(
+    () => store.listSessionsPage({ tenantId: 'tenant-1', userId: 'user-1', limit: 2, status: 'closed', cursor: first.nextCursor }),
+    /cursor/i,
+  )
+  assert.throws(
+    () => store.listSessionsPage({ tenantId: 'tenant-1', userId: 'user-1', limit: 2, cursor: 'not-a-valid-cursor' }),
+    /cursor/i,
+  )
 
   assert.deepEqual(
     store.listSessionsPage({ tenantId: 'tenant-1', userId: 'user-1', status: 'closed' }).items.map((session) => session.sessionId),

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -351,6 +351,122 @@ test('cloud HTTP server exposes health, config, session create/list/get, prompt,
   }
 })
 
+test('cloud HTTP server paginates session lists with scoped cursors and filters', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  try {
+    const createdSessionIds: string[] = []
+    for (const [index, profileName] of ['default', 'data-analyst', 'default', 'default', 'default'].entries()) {
+      const created = await readJson(await fetch(`${baseUrl}/api/sessions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ profileName }),
+      }))
+      const sessionId = String(asRecord(created.session).sessionId)
+      createdSessionIds.push(sessionId)
+      fixture.store.updateSessionStatus({
+        tenantId: 'tenant-1',
+        sessionId,
+        status: index === 2 ? 'closed' : 'idle',
+        title: index === 1 ? 'Revenue model' : `Cursor contract ${index + 1}`,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+    }
+
+    const firstResponse = await fetch(`${baseUrl}/api/sessions?limit=2`)
+    assert.equal(firstResponse.status, 200)
+    const first = await readJson(firstResponse)
+    const firstItems = asArray(first.sessions).map((session) => String(asRecord(session).sessionId))
+    assert.deepEqual(firstItems, [createdSessionIds[0], createdSessionIds[1]])
+    assert.equal(first.totalEstimate, 5)
+    assert.equal(typeof first.nextCursor, 'string')
+
+    const secondResponse = await fetch(`${baseUrl}/api/sessions?limit=2&cursor=${encodeURIComponent(String(first.nextCursor))}`)
+    assert.equal(secondResponse.status, 200)
+    const second = await readJson(secondResponse)
+    const secondItems = asArray(second.sessions).map((session) => String(asRecord(session).sessionId))
+    assert.deepEqual(secondItems, [createdSessionIds[2], createdSessionIds[3]])
+    assert.equal(new Set([...firstItems, ...secondItems]).size, 4)
+
+    const statusFiltered = await readJson(await fetch(`${baseUrl}/api/sessions?status=closed`))
+    assert.deepEqual(asArray(statusFiltered.sessions).map((session) => String(asRecord(session).sessionId)), [createdSessionIds[2]])
+
+    const profileFiltered = await readJson(await fetch(`${baseUrl}/api/sessions?profileName=data-analyst`))
+    assert.deepEqual(asArray(profileFiltered.sessions).map((session) => String(asRecord(session).sessionId)), [createdSessionIds[1]])
+
+    const qFiltered = await readJson(await fetch(`${baseUrl}/api/sessions?q=revenue`))
+    assert.deepEqual(asArray(qFiltered.sessions).map((session) => String(asRecord(session).sessionId)), [createdSessionIds[1]])
+
+    const queryFiltered = await readJson(await fetch(`${baseUrl}/api/sessions?query=revenue`))
+    assert.deepEqual(asArray(queryFiltered.sessions).map((session) => String(asRecord(session).sessionId)), [createdSessionIds[1]])
+
+    const malformedCursor = await fetch(`${baseUrl}/api/sessions?cursor=not-a-valid-cursor`)
+    assert.equal(malformedCursor.status, 400)
+    assert.match(String((await readJson(malformedCursor)).error), /cursor/i)
+
+    const mismatchedFilterCursor = await fetch(`${baseUrl}/api/sessions?status=closed&cursor=${encodeURIComponent(String(first.nextCursor))}`)
+    assert.equal(mismatchedFilterCursor.status, 400)
+    assert.match(String((await readJson(mismatchedFilterCursor)).error), /cursor/i)
+
+    const unsupportedStatus = await fetch(`${baseUrl}/api/sessions?status=deleted`)
+    assert.equal(unsupportedStatus.status, 400)
+    assert.match(String((await readJson(unsupportedStatus)).error), /status/i)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP session list cursors are scoped to the authenticated tenant', async () => {
+  const tenant1Principal = {
+    tenantId: 'tenant-1',
+    tenantName: 'Tenant 1',
+    orgId: 'tenant-1',
+    userId: 'owner-1',
+    accountId: 'owner-1',
+    email: 'owner1@example.test',
+    role: 'owner' as const,
+    authSource: 'user' as const,
+  }
+  const tenant2Principal = {
+    tenantId: 'tenant-2',
+    tenantName: 'Tenant 2',
+    orgId: 'tenant-2',
+    userId: 'owner-2',
+    accountId: 'owner-2',
+    email: 'owner2@example.test',
+    role: 'owner' as const,
+    authSource: 'user' as const,
+  }
+  const fixture = createFixture({
+    auth: (req) => headerValue(req.headers['x-test-tenant']) === 'tenant-2' ? tenant2Principal : tenant1Principal,
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    await fixture.service.ensurePrincipal(tenant1Principal)
+    await fixture.service.ensurePrincipal(tenant2Principal)
+    for (let index = 0; index < 3; index += 1) {
+      await fetch(`${baseUrl}/api/sessions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+    }
+    const first = await readJson(await fetch(`${baseUrl}/api/sessions?limit=1`))
+    assert.equal(typeof first.nextCursor, 'string')
+
+    const tenantTwoList = await readJson(await fetch(`${baseUrl}/api/sessions`, { headers: { 'x-test-tenant': 'tenant-2' } }))
+    assert.deepEqual(asArray(tenantTwoList.sessions), [])
+
+    const tenantTwoCursor = await fetch(`${baseUrl}/api/sessions?cursor=${encodeURIComponent(String(first.nextCursor))}`, {
+      headers: { 'x-test-tenant': 'tenant-2' },
+    })
+    assert.equal(tenantTwoCursor.status, 400)
+    assert.match(String((await readJson(tenantTwoCursor)).error), /cursor/i)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP server imports a redacted local session snapshot and audits the copy', async () => {
   const fixture = createFixture()
   const baseUrl = await fixture.server.listen()


### PR DESCRIPTION
Closes #598.

## Summary
- add scoped, invalid-filter-aware Cloud session cursors and backend list limits for Cloud Web admin surfaces
- bound Cloud Web large-org rendering across threads, members, tokens, workflows, gateway deliveries, audit, usage, diagnostics, and artifacts
- make the route/API matrix enforce structured pagination and redaction contracts, with docs updated to match
- expand backend, browser, route-matrix, and performance tests for cursor scope, large orgs, bounded rendering, and redaction

## Verification
- `PATH="/opt/homebrew/bin:$PATH" pnpm test:cloud-web`
- `PATH="/opt/homebrew/bin:$PATH" node scripts/run-node-tests.mjs tests/cloud-http-server.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-control-plane-store-contracts.test.ts`
- `PATH="/opt/homebrew/bin:$PATH" pnpm typecheck`
- `python3 -m mkdocs build --strict`
- `git diff --check`
