### PR TITLE
Harden desktop cloud sync

### DIFF
--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -118,8 +118,13 @@ export type CloudWorkspaceAdapterOptions = {
   cacheEncryptionFallback?: CloudWorkspaceCacheEncryptionFallback
 }
 
+const CLOUD_SYNC_SESSION_PAGE_SIZE = 100
+const CLOUD_SYNC_MAX_SESSION_PAGES = 5
+const CLOUD_SYNC_MAX_VIEW_REFRESHES = 100
+const CLOUD_SYNC_MAX_ARTIFACT_REFRESHES = 100
 const CLOUD_SYNC_VIEW_CONCURRENCY = 8
 const CLOUD_SYNC_ARTIFACT_CONCURRENCY = 4
+const CLOUD_SYNC_RETRY_BACKOFF_MS = 100
 
 function toSessionInfo(record: SessionRecord): SessionInfo {
   return {
@@ -177,12 +182,22 @@ async function settleWithConcurrency<T>(
   return results
 }
 
+async function retrySyncRefresh(task: () => Promise<unknown>) {
+  try {
+    await task()
+  } catch {
+    await new Promise((resolve) => setTimeout(resolve, CLOUD_SYNC_RETRY_BACKOFF_MS))
+    await task()
+  }
+}
+
 export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
   private readonly transport: CloudTransportAdapter
   private readonly connection: CloudWorkspaceConnectionRecord
   private readonly cache: CloudWorkspaceCache | null
   private readonly inFlightSessionViews = new Map<string, Promise<SessionView>>()
   private readonly inFlightArtifactLists = new Map<string, Promise<SessionArtifact[]>>()
+  private syncGeneration = 0
 
   constructor(options: CloudWorkspaceAdapterOptions) {
     this.connection = options.connection
@@ -226,6 +241,55 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
       const cached = this.cache?.listSessions(cacheKey)
       if (cached) return cached
       throw error
+    }
+  }
+
+  private async listSessionsForSync(cacheKey: string, generation: number): Promise<{
+    viewRefreshCandidates: SessionInfo[]
+    artifactRefreshCandidates: SessionInfo[]
+  }> {
+    const cachedSessions = new Map((this.cache?.listSessions(cacheKey) || []).map((session) => [session.id, session]))
+    const cachedViews = new Set<string>()
+    const cachedArtifacts = new Set<string>()
+    for (const sessionId of cachedSessions.keys()) {
+      if (this.cache?.getSessionView(cacheKey, sessionId)) cachedViews.add(sessionId)
+      if (this.cache?.listArtifacts(cacheKey, sessionId)) cachedArtifacts.add(sessionId)
+    }
+    const sessions: SessionInfo[] = []
+    if (this.transport.listSessionsPage) {
+      let cursor: string | null = null
+      for (let page = 0; page < CLOUD_SYNC_MAX_SESSION_PAGES && generation === this.syncGeneration; page += 1) {
+        const result = await this.transport.listSessionsPage({
+          limit: CLOUD_SYNC_SESSION_PAGE_SIZE,
+          cursor,
+        })
+        sessions.push(...result.sessions.map(toSessionInfo))
+        if (!result.nextCursor || result.nextCursor === cursor) {
+          cursor = null
+          break
+        }
+        cursor = result.nextCursor
+      }
+      if (cursor === null) {
+        this.cache?.upsertSessionList(cacheKey, sessions)
+      } else {
+        for (const session of sessions) this.cache?.upsertSessionInfo(cacheKey, session)
+      }
+    } else {
+      sessions.push(...(await this.transport.listSessions()).map(toSessionInfo))
+      this.cache?.upsertSessionList(cacheKey, sessions)
+    }
+    const changedSessions = sessions.filter((session) => {
+      const cached = cachedSessions.get(session.id)
+      return !cached || cached.updatedAt !== session.updatedAt || !cachedViews.has(session.id)
+    })
+    const artifactSessions = sessions.filter((session) => {
+      const cached = cachedSessions.get(session.id)
+      return !cached || cached.updatedAt !== session.updatedAt || !cachedArtifacts.has(session.id)
+    })
+    return {
+      viewRefreshCandidates: changedSessions.slice(0, CLOUD_SYNC_MAX_VIEW_REFRESHES),
+      artifactRefreshCandidates: artifactSessions.slice(0, CLOUD_SYNC_MAX_ARTIFACT_REFRESHES),
     }
   }
 
@@ -546,18 +610,26 @@ export class CloudWorkspaceAdapter implements CloudWorkspaceSessionAdapter {
   }
 
   async sync(): Promise<void> {
-    const sessions = await this.listSessions()
-    await settleWithConcurrency(sessions, CLOUD_SYNC_VIEW_CONCURRENCY, async (session) => {
-      await this.getSessionView(session.id)
+    const generation = ++this.syncGeneration
+    const cacheKey = cloudWorkspaceCacheKey(this.connection)
+    const plan = await this.listSessionsForSync(cacheKey, generation)
+    if (generation !== this.syncGeneration) return
+    await settleWithConcurrency(plan.viewRefreshCandidates, CLOUD_SYNC_VIEW_CONCURRENCY, async (session) => {
+      if (generation !== this.syncGeneration) return
+      await retrySyncRefresh(() => this.getSessionView(session.id))
     })
+    if (generation !== this.syncGeneration) return
     if (this.transport.listArtifacts) {
-      await settleWithConcurrency(sessions, CLOUD_SYNC_ARTIFACT_CONCURRENCY, async (session) => {
-        await this.listArtifacts(session.id)
+      await settleWithConcurrency(plan.artifactRefreshCandidates, CLOUD_SYNC_ARTIFACT_CONCURRENCY, async (session) => {
+        if (generation !== this.syncGeneration) return
+        await retrySyncRefresh(() => this.listArtifacts(session.id))
       })
     }
+    if (generation !== this.syncGeneration) return
     if (this.transport.listWorkflows) {
       await this.listWorkflows().catch(() => undefined)
     }
+    if (generation !== this.syncGeneration) return
     if (this.transport.listSettings) {
       await this.listSettings().catch(() => undefined)
     }

--- a/apps/desktop/src/main/e2e-remote-debugging.ts
+++ b/apps/desktop/src/main/e2e-remote-debugging.ts
@@ -182,7 +182,10 @@ export async function writeE2EWindowReadyProbe(
         if (!settings.effectiveProviderId || !settings.effectiveModel) return false;
         const provider = config.providers.available.find((entry) => entry.id === settings.effectiveProviderId);
         if (!provider) return false;
-        const providerCredentials = await api.settings.getProviderCredentials(provider.id);
+        const providerCredentials = await api.settings.getProviderCredentials(provider.id, {
+          workspaceId: 'local',
+          purpose: 'credential_editor',
+        });
         return provider.credentials.every((credential) => {
           if (credential.required === false) return true;
           const value = providerCredentials[credential.key];

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -1,4 +1,5 @@
 import electron from 'electron'
+import type { IpcMainInvokeEvent } from 'electron'
 import type { IpcHandlerContext } from './context.ts'
 import { objectArg, optionalObjectArg, registerIpcInvoke } from './schema.ts'
 import { validateChartSaveArtifactRequest, validateSettingsUpdate, validateWorkspaceOptions } from './object-validators.ts'
@@ -60,7 +61,7 @@ import type {
   EffectiveAppSettings,
   WorkspaceOptions,
 } from '@open-cowork/shared'
-import { readWorkspaceIdOption } from '../workspace-gateway.ts'
+import { LOCAL_WORKSPACE_ID, readWorkspaceIdOption } from '../workspace-gateway.ts'
 
 export {
   ensureRuntimeAfterAuthLogin,
@@ -144,6 +145,19 @@ function buildCloudEffectiveSettings(base: EffectiveAppSettings, value: Record<s
     effectiveModel: selectedModelId,
     effectiveSmallModel: selectedSmallModelId,
   }
+}
+
+function canReadLocalCredentialBag(
+  context: IpcHandlerContext,
+  event: IpcMainInvokeEvent,
+  options: unknown,
+) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) return false
+  if ((options as { purpose?: unknown }).purpose !== 'credential_editor') return false
+  const workspaceId = readWorkspaceIdOption(options)
+  if (workspaceId && workspaceId !== LOCAL_WORKSPACE_ID) return false
+  return context.workspaceGateway.activeWorkspaceId(event) === LOCAL_WORKSPACE_ID
+    && context.workspaceGateway.isLocalWorkspace(event, workspaceId)
 }
 
 const electronShell = (electron as { shell?: typeof import('electron').shell }).shell
@@ -302,17 +316,17 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     return buildCloudEffectiveSettings(base, setting?.value || {})
   })
 
-  context.ipcMain.handle('settings:get-provider-credentials', async (event, providerId: unknown) => {
+  context.ipcMain.handle('settings:get-provider-credentials', async (event, providerId: unknown, options: unknown) => {
     // Scoped opt-in for provider credential editor surfaces. Avoid
     // returning every stored provider and integration secret to any
     // renderer code that only needs one credential bag.
-    if (!context.workspaceGateway.isLocalWorkspace(event, null)) return {}
+    if (!canReadLocalCredentialBag(context, event, options)) return {}
     return getProviderCredentials(normalizeCredentialScopeId(providerId, 'Provider'))
   })
 
-  context.ipcMain.handle('settings:get-integration-credentials', async (event, integrationId: unknown) => {
+  context.ipcMain.handle('settings:get-integration-credentials', async (event, integrationId: unknown, options: unknown) => {
     // Same scoped read for integration/MCP credential editors.
-    if (!context.workspaceGateway.isLocalWorkspace(event, null)) return {}
+    if (!canReadLocalCredentialBag(context, event, options)) return {}
     return getIntegrationCredentials(normalizeCredentialScopeId(integrationId, 'Integration'))
   })
 

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -70,6 +70,7 @@ type CloudProjectionRefreshState = {
   publishedRevision: number
   failedAttempts: number
   nextAllowedAt: number
+  retryAfterFailure: boolean
 }
 
 const cloudProjectionRefreshes = new Map<string, CloudProjectionRefreshState>()
@@ -109,6 +110,7 @@ function queueCloudProjectionRefresh(input: {
     publishedRevision: 0,
     failedAttempts: 0,
     nextAllowedAt: 0,
+    retryAfterFailure: false,
   }
   state.latestSequence = Math.max(state.latestSequence, sequence)
   cloudProjectionRefreshes.set(key, state)
@@ -151,6 +153,9 @@ async function runQueuedCloudProjectionRefresh(input: {
   const requestedSequence = state.latestSequence
   try {
     const view = await context.workspaceGateway.getCloudSessionView(sourceEvent, sessionId, workspaceId)
+    if (view.revision < requestedSequence) {
+      throw new Error(`Cloud projection revision ${view.revision} is behind event sequence ${requestedSequence}.`)
+    }
     if (
       !win.isDestroyed()
       && cloudWorkspaceIsStillActive(context, sourceEvent, workspaceId)
@@ -161,6 +166,7 @@ async function runQueuedCloudProjectionRefresh(input: {
     }
     state.failedAttempts = 0
     state.nextAllowedAt = 0
+    state.retryAfterFailure = false
   } catch (error) {
     state.failedAttempts = Math.min(state.failedAttempts + 1, 8)
     const backoffMs = Math.min(
@@ -168,10 +174,12 @@ async function runQueuedCloudProjectionRefresh(input: {
       CLOUD_PROJECTION_REFRESH_BACKOFF_BASE_MS * 2 ** (state.failedAttempts - 1),
     )
     state.nextAllowedAt = Date.now() + backoffMs
+    state.retryAfterFailure = error instanceof Error && error.message.includes('behind event sequence')
     context.logHandlerError(`cloud session:view ${shortSessionId(sessionId)}`, error)
   } finally {
     state.inFlight = false
-    if (state.latestSequence > requestedSequence) {
+    if (state.latestSequence > requestedSequence || state.retryAfterFailure) {
+      state.retryAfterFailure = false
       if (state.timer) clearTimeout(state.timer)
       const delayMs = Math.max(CLOUD_PROJECTION_REFRESH_DEBOUNCE_MS, state.nextAllowedAt - Date.now())
       state.timer = setTimeout(() => {
@@ -250,7 +258,7 @@ function dispatchCloudWorkspaceSessionEvent(
       sourceEvent,
       sessionId,
       workspaceId,
-      sequence: event.sequence || Date.now(),
+      sequence: typeof event.sequence === 'number' && Number.isFinite(event.sequence) ? event.sequence : 0,
     })
   }
   const dispatchCloudRuntimeEvent = (runtimeEvent: Parameters<typeof dispatchRuntimeSessionEvent>[1]) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -317,8 +317,8 @@ const api: CoworkAPI = {
   },
   settings: {
     get: (options) => invoke('settings:get', options),
-    getProviderCredentials: (providerId) => invoke('settings:get-provider-credentials', providerId),
-    getIntegrationCredentials: (integrationId) => invoke('settings:get-integration-credentials', integrationId),
+    getProviderCredentials: (providerId, options) => invoke('settings:get-provider-credentials', providerId, options),
+    getIntegrationCredentials: (integrationId, options) => invoke('settings:get-integration-credentials', integrationId, options),
     set: (updates) => invoke('settings:set', updates),
   },
   mcp: {

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -147,7 +147,10 @@ describe('SetupScreen', () => {
     const apiKeyInput = await screen.findByPlaceholderText('sk-or-...')
     await waitFor(() => expect(apiKeyInput).toHaveValue('sk-or-scoped'))
     expect(get).toHaveBeenCalledTimes(1)
-    expect(getProviderCredentials).toHaveBeenCalledWith('openrouter')
+    expect(getProviderCredentials).toHaveBeenCalledWith('openrouter', {
+      workspaceId: 'local',
+      purpose: 'credential_editor',
+    })
   })
 
   it('surfaces initial setup settings load failures through the chat error channel and diagnostics', async () => {

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -4,6 +4,7 @@ import { t } from '../helpers/i18n'
 import { mergeFetchedProviderCredentials } from './provider/credential-merge'
 import { ProviderAuthControls } from './provider/ProviderAuthControls'
 import { useSessionStore } from '../stores/session'
+import { LOCAL_WORKSPACE_ID } from '../stores/session-workspace-keys'
 
 interface Props {
   brandName: string
@@ -100,7 +101,10 @@ export function SetupScreen({
           || initialProvider?.models[0]?.id
           || ''
       const initialCredentials = initialProviderId
-        ? await window.coworkApi.settings.getProviderCredentials(initialProviderId)
+        ? await window.coworkApi.settings.getProviderCredentials(initialProviderId, {
+            workspaceId: LOCAL_WORKSPACE_ID,
+            purpose: 'credential_editor',
+          })
         : {}
       if (cancelled) return
       if (!providerSelectionEdited.current) {
@@ -144,7 +148,10 @@ export function SetupScreen({
   useEffect(() => {
     if (!providerId || loadedCredentialProviders.has(providerId)) return
     let cancelled = false
-    window.coworkApi.settings.getProviderCredentials(providerId).then((credentials) => {
+    window.coworkApi.settings.getProviderCredentials(providerId, {
+      workspaceId: LOCAL_WORKSPACE_ID,
+      purpose: 'credential_editor',
+    }).then((credentials) => {
       if (cancelled) return
       mergeLoadedProviderCredentials(providerId, credentials)
       setLoadedCredentialProviders((current) => new Set(current).add(providerId))

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -436,7 +436,10 @@ describe('CapabilitiesPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Chart MCP' })).toBeInTheDocument()
     expect(api.tool).toHaveBeenCalledWith('charts', { sessionId: 'session-1' })
-    expect(api.getIntegrationCredentials).toHaveBeenCalledWith('charts')
+    expect(api.getIntegrationCredentials).toHaveBeenCalledWith('charts', {
+      workspaceId: 'local',
+      purpose: 'credential_editor',
+    })
     expect(screen.getByText('mcp__charts__line')).toBeInTheDocument()
 
     const apiKeyInput = screen.getByLabelText(/Charts API key/)

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -5,6 +5,7 @@ import { credentialFieldIsVisible } from '@open-cowork/shared'
 import type { CapabilityTool, RuntimeContextOptions } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import { useSessionStore } from '../../stores/session'
+import { LOCAL_WORKSPACE_ID } from '../../stores/session-workspace-keys'
 
 function describeCapabilityError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
@@ -163,7 +164,10 @@ export function ToolCredentialsCard({
 
   useEffect(() => {
     let cancelled = false
-    window.coworkApi.settings.getIntegrationCredentials(integrationId)
+    window.coworkApi.settings.getIntegrationCredentials(integrationId, {
+      workspaceId: LOCAL_WORKSPACE_ID,
+      purpose: 'credential_editor',
+    })
       .then((current) => {
         if (cancelled) return
         setStored(current)
@@ -225,7 +229,10 @@ export function ToolCredentialsCard({
           [integrationId]: patch,
         },
       })
-      const refreshed = await window.coworkApi.settings.getIntegrationCredentials(integrationId)
+      const refreshed = await window.coworkApi.settings.getIntegrationCredentials(integrationId, {
+        workspaceId: LOCAL_WORKSPACE_ID,
+        purpose: 'credential_editor',
+      })
       setStored(refreshed)
       setDrafts({})
       setSavedAt(Date.now())

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -144,7 +144,10 @@ export function SettingsPanel({
     const providerId = settings?.effectiveProviderId
     if (!providerId) return
     let cancelled = false
-    window.coworkApi.settings.getProviderCredentials(providerId).then((credentials) => {
+    window.coworkApi.settings.getProviderCredentials(providerId, {
+      workspaceId: LOCAL_WORKSPACE_ID,
+      purpose: 'credential_editor',
+    }).then((credentials) => {
       if (cancelled) return
       setSettings((current) => {
         if (!current || current.effectiveProviderId !== providerId) return current
@@ -235,7 +238,10 @@ export function SettingsPanel({
             ...savedSettings,
             providerCredentials: {
               ...savedSettings.providerCredentials,
-              [savedSettings.effectiveProviderId]: await window.coworkApi.settings.getProviderCredentials(savedSettings.effectiveProviderId),
+              [savedSettings.effectiveProviderId]: await window.coworkApi.settings.getProviderCredentials(savedSettings.effectiveProviderId, {
+                workspaceId: LOCAL_WORKSPACE_ID,
+                purpose: 'credential_editor',
+              }),
             },
           }
         } catch (error) {

--- a/apps/desktop/tests/settings-round-trip.smoke.test.ts
+++ b/apps/desktop/tests/settings-round-trip.smoke.test.ts
@@ -55,7 +55,10 @@ test('settings round-trip survives a full reload through safeStorage + disk', as
 
     // Credentials come back through a separate IPC so the plain
     // settings:get doesn't leak them to every renderer consumer.
-    const providerCredentials = await page.evaluate(async () => window.coworkApi.settings.getProviderCredentials('openrouter'))
+    const providerCredentials = await page.evaluate(async () => window.coworkApi.settings.getProviderCredentials('openrouter', {
+      workspaceId: 'local',
+      purpose: 'credential_editor',
+    }))
     assert.equal(
       providerCredentials.apiKey,
       'roundtrip-key',

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -624,7 +624,10 @@ async function bootstrapSmokeSettings(page: Page, appShellTimeoutMs = 30_000) {
     if (!settings.effectiveProviderId || !settings.effectiveModel) return false
     const provider = config.providers.available.find((entry) => entry.id === settings.effectiveProviderId)
     if (!provider) return false
-    const providerCredentials = await window.coworkApi.settings.getProviderCredentials(provider.id)
+    const providerCredentials = await window.coworkApi.settings.getProviderCredentials(provider.id, {
+      workspaceId: 'local',
+      purpose: 'credential_editor',
+    })
     return provider.credentials.every((credential) => {
       if (credential.required === false) return true
       const value = providerCredentials[credential.key]

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -232,8 +232,8 @@ export interface CoworkAPI {
     get: (options?: WorkspaceOptions) => Promise<EffectiveAppSettings>
     // Scoped unmasked reads for credential editor surfaces. The renderer
     // never receives the full effective settings object with every secret.
-    getProviderCredentials: (providerId: string) => Promise<Record<string, string>>
-    getIntegrationCredentials: (integrationId: string) => Promise<Record<string, string>>
+    getProviderCredentials: (providerId: string, options: WorkspaceOptions & { purpose: 'credential_editor' }) => Promise<Record<string, string>>
+    getIntegrationCredentials: (integrationId: string, options: WorkspaceOptions & { purpose: 'credential_editor' }) => Promise<Record<string, string>>
     set: (updates: WorkspaceScoped<Partial<AppSettings>>) => Promise<EffectiveAppSettings>
   }
   mcp: {

--- a/tests/cloud-workspace-adapter.test.ts
+++ b/tests/cloud-workspace-adapter.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 import { FileCloudWorkspaceCache } from '../apps/desktop/src/main/cloud-workspace-cache.ts'
 import type { CloudTransportAdapter } from '../apps/desktop/src/main/cloud/transport-adapter.ts'
-import type { WorkflowRun, WorkflowStatus } from '@open-cowork/shared'
+import type { SessionView, WorkflowRun, WorkflowStatus } from '@open-cowork/shared'
 
 function workflowSummary(status: WorkflowStatus = 'active') {
   return {
@@ -503,6 +503,34 @@ function sessionRecord(sessionId: string) {
   }
 }
 
+function cachedView(sessionId: string, revision = 1): SessionView {
+  return {
+    messages: [],
+    toolCalls: [],
+    taskRuns: [],
+    compactions: [],
+    pendingApprovals: [],
+    pendingQuestions: [],
+    artifacts: [],
+    errors: [],
+    todos: [],
+    executionPlan: [],
+    sessionCost: 0,
+    sessionTokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+    lastInputTokens: 0,
+    contextState: 'idle',
+    compactionCount: 0,
+    lastCompactedAt: null,
+    activeAgent: null,
+    lastItemWasTool: false,
+    revision,
+    lastEventAt: revision,
+    isGenerating: false,
+    isAwaitingPermission: false,
+    isAwaitingQuestion: false,
+  }
+}
+
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -631,6 +659,94 @@ test('cloud workspace adapter bounds sync hydration concurrency', async () => {
   assert.equal(artifactCalls, sessions.length)
   assert.ok(maxViews <= 8, `expected view concurrency <= 8, saw ${maxViews}`)
   assert.ok(maxArtifacts <= 4, `expected artifact concurrency <= 4, saw ${maxArtifacts}`)
+})
+
+test('cloud workspace adapter sync is page-aware and refreshes only changed cached sessions', async () => {
+  const base = transport()
+  const cache = new FileCloudWorkspaceCache({
+    path: join(mkdtempSync(join(tmpdir(), 'open-cowork-adapter-incremental-sync-')), 'cloud-workspace-cache.json'),
+    mode: 'full',
+    secretStorage: {
+      mode: 'plaintext',
+      encryptString: (plaintext) => Buffer.from(plaintext, 'utf-8'),
+      decryptString: (encrypted) => encrypted.toString('utf-8'),
+    },
+  })
+  const connection = {
+    id: 'cloud:test',
+    baseUrl: 'https://cloud.example.test',
+    label: 'Test Cloud',
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    lastSyncedAt: null,
+  }
+  const cacheKey = cloudWorkspaceCacheKey(connection)
+  const remoteSessions = Array.from({ length: 125 }, (_, index) => sessionRecord(`session-${index + 1}`))
+  const cachedSessions = remoteSessions.map((record) => ({
+    id: record.sessionId,
+    title: record.title || undefined,
+    directory: null,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    kind: 'interactive' as const,
+  }))
+  cache.upsertSessionList(cacheKey, cachedSessions)
+  for (const session of cachedSessions) {
+    cache.upsertSessionView(cacheKey, session.id, cachedView(session.id))
+    cache.upsertArtifactList(cacheKey, session.id, [{
+      id: `artifact-${session.id}`,
+      toolId: 'cloud-artifact',
+      toolName: 'cloud.artifact',
+      filePath: `cloud-artifact://${session.id}/result.txt`,
+      filename: 'result.txt',
+      order: 0,
+      source: 'cloud',
+      cloudArtifactId: `artifact-${session.id}`,
+      mime: 'text/plain',
+    }])
+  }
+  const updatedRemoteSessions = remoteSessions.map((session, index) => index < 3
+    ? { ...session, updatedAt: '2026-05-27T12:00:00.000Z' }
+    : session)
+  const cursors: Array<string | null | undefined> = []
+  let getSessionCount = 0
+  let artifactCount = 0
+  const adapter = new CloudWorkspaceAdapter({
+    connection,
+    cache,
+    transport: {
+      ...base,
+      listSessions: async () => {
+        throw new Error('sync should use paged session listing when available')
+      },
+      listSessionsPage: async (input = {}) => {
+        assert.equal(input.limit, 100)
+        cursors.push(input.cursor)
+        const start = input.cursor ? Number(input.cursor) : 0
+        const page = updatedRemoteSessions.slice(start, start + 100)
+        return {
+          sessions: page,
+          nextCursor: start + page.length < updatedRemoteSessions.length ? String(start + page.length) : null,
+          totalEstimate: updatedRemoteSessions.length,
+        }
+      },
+      getSession: async (sessionId) => {
+        getSessionCount += 1
+        return base.getSession(sessionId)
+      },
+      listArtifacts: async (sessionId) => {
+        artifactCount += 1
+        return base.listArtifacts?.(sessionId) as ReturnType<NonNullable<CloudTransportAdapter['listArtifacts']>>
+      },
+    },
+  })
+
+  await adapter.sync()
+
+  assert.deepEqual(cursors, [null, '100'])
+  assert.equal(getSessionCount, 3)
+  assert.equal(artifactCount, 3)
+  assert.equal(cache.listSessions(cacheKey)?.length, 125)
 })
 
 test('cloud workspace adapter coalesces concurrent session view refreshes', async () => {

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { CustomMcpConfig } from '@open-cowork/shared'
+import type { CustomMcpConfig, DesktopPairingPublicRecord } from '@open-cowork/shared'
 import type { IpcHandlerContext } from '../apps/desktop/src/main/ipc/context.ts'
 import { registerAppHandlers, resolveSafeSaveTextPath, saveTextExportFile } from '../apps/desktop/src/main/ipc/app-handlers.ts'
 import {
@@ -474,8 +474,8 @@ test('cloud session SSE publishes authoritative cloud projections instead of loc
         lastCompactedAt: null,
         activeAgent: null,
         lastItemWasTool: false,
-        revision: 7,
-        lastEventAt: 42,
+        revision: 43,
+        lastEventAt: 43,
         isGenerating: true,
         isAwaitingPermission: true,
         isAwaitingQuestion: false,
@@ -562,6 +562,80 @@ test('cloud session SSE publishes authoritative cloud projections instead of loc
   })
   await new Promise((resolve) => setTimeout(resolve, 80))
   assert.equal(sentViews.length, 1)
+})
+
+test('cloud session SSE waits for projection revision to catch up before publishing full views', async () => {
+  const { context, handlers, errors } = createBaseContext()
+  const sentViews: unknown[] = []
+  let subscribedEventHandler: ((event: any) => void) | null = null
+  let projectionFetches = 0
+  const adapter: CloudWorkspaceSessionAdapter = {
+    policy: async () => ({
+      features: { sessions: true },
+      allowedAgents: null,
+      allowedTools: null,
+      allowedMcps: null,
+      localFiles: 'disabled',
+      localStdioMcps: 'disabled',
+      machineRuntimeConfig: 'disabled',
+    }),
+    listSessions: async () => [],
+    createSession: async () => {
+      throw new Error('not used')
+    },
+    getSessionInfo: async () => null,
+    getSessionView: async () => {
+      projectionFetches += 1
+      return emptySessionView({
+        revision: projectionFetches === 1 ? 9 : 10,
+        lastEventAt: projectionFetches === 1 ? 9 : 10,
+      })
+    },
+    promptSession: async () => {},
+    abortSession: async () => {},
+    subscribeSessionEvents: (_sessionId, input) => {
+      subscribedEventHandler = input.onEvent
+      return { close: () => {} }
+    },
+  }
+  context.getMainWindow = () => ({
+    isDestroyed: () => false,
+    webContents: {
+      id: 204,
+      isDestroyed: () => false,
+      send: (channel: string, payload: unknown) => {
+        if (channel === 'session:view') sentViews.push(payload)
+      },
+    },
+  } as any)
+  installCloudWorkspace(context, adapter)
+
+  registerSessionHandlers(context)
+  const invokeEvent = { sender: { id: 204 } }
+  context.workspaceGateway.activate(invokeEvent, 'cloud:test')
+  await handlers.get('session:activate')?.(invokeEvent, 'cloud-session-stale')
+  assert.ok(subscribedEventHandler, 'expected cloud session event subscription')
+  projectionFetches = 0
+
+  subscribedEventHandler({
+    type: 'assistant.message',
+    sessionId: 'cloud-session-stale',
+    sequence: 10,
+    payload: { messageId: 'm1', content: 'fresh stream event' },
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 80))
+  assert.equal(sentViews.length, 0)
+  assert.equal(errors.some((entry) => entry.includes('behind event sequence 10')), true)
+
+  await new Promise((resolve) => setTimeout(resolve, 350))
+  assert.equal(projectionFetches, 2)
+  assert.equal(sentViews.length, 1)
+  assert.deepEqual(sentViews[0], {
+    sessionId: 'cloud-session-stale',
+    workspaceId: 'cloud:test',
+    view: emptySessionView({ revision: 10, lastEventAt: 10 }),
+  })
 })
 
 test('cloud projection refresh errors back off repeated full-view fetches', async () => {
@@ -1734,6 +1808,14 @@ test('settings handlers sync only portable settings for cloud workspaces', async
   context.workspaceGateway.activate(cloudEvent, 'cloud:test')
   assert.deepEqual(await handlers.get('settings:get-provider-credentials')?.(cloudEvent, 'openrouter'), {})
   assert.deepEqual(await handlers.get('settings:get-integration-credentials')?.(cloudEvent, 'github'), {})
+  assert.deepEqual(await handlers.get('settings:get-provider-credentials')?.(cloudEvent, 'openrouter', {
+    workspaceId: LOCAL_WORKSPACE_ID,
+    purpose: 'credential_editor',
+  }), {})
+  assert.deepEqual(await handlers.get('settings:get-integration-credentials')?.(cloudEvent, 'github', {
+    workspaceId: LOCAL_WORKSPACE_ID,
+    purpose: 'credential_editor',
+  }), {})
 
   const current = await handlers.get('settings:get')?.({}, { workspaceId: 'cloud:test' })
   assert.equal(current.selectedProviderId, 'anthropic')
@@ -1760,6 +1842,81 @@ test('settings handlers sync only portable settings for cloud workspaces', async
     'get:portable-settings',
     'set:portable-settings:openai',
   ])
+})
+
+test('raw credential IPC is unavailable from Gateway and Paired Desktop workspaces', async () => {
+  const { context, handlers } = createBaseContext()
+  const pairing: DesktopPairingPublicRecord = {
+    id: 'pairing-credentials',
+    label: 'Paired Desktop',
+    deviceName: 'Phone',
+    status: 'paired_online',
+    enabled: true,
+    brokerUrl: 'https://gateway.example.test',
+    allowedWorkspaceIds: ['local'],
+    allowedSessionIds: [],
+    policy: {
+      allowRemotePrompts: true,
+      allowRemoteAbort: true,
+      remoteApprovals: 'local_confirmation',
+      remoteQuestions: 'local_confirmation',
+      exposeArtifactBodies: false,
+      exposeLocalPaths: false,
+      exposeLocalMcpDetails: false,
+      allowRemoteAttachments: false,
+    },
+    lastConnectedAt: '2026-05-27T10:00:00.000Z',
+    lastHeartbeatAt: '2026-05-27T10:01:00.000Z',
+    lastCommandSequence: 1,
+    error: null,
+    createdAt: '2026-05-27T09:00:00.000Z',
+    updatedAt: '2026-05-27T10:01:00.000Z',
+    revokedAt: null,
+    credential: {
+      hasToken: true,
+      deviceId: 'device-credentials',
+      updatedAt: '2026-05-27T09:00:00.000Z',
+    },
+  }
+  context.workspaceGateway = createWorkspaceGateway({
+    cloudRegistry: null,
+    cloudCredentialStore: null,
+    gatewayRegistry: null,
+    gatewayCredentialStore: null,
+    desktopPairingProvider: () => [pairing],
+    workspaces: [{
+      id: 'gateway:test',
+      kind: 'gateway',
+      authority: 'gateway_standalone',
+      label: 'Gateway',
+      status: 'online',
+      baseUrl: 'https://gateway.example.test/admin',
+      lastSyncedAt: null,
+    }],
+  })
+
+  registerAppHandlers(context)
+  const gatewayEvent = { sender: { id: 701 } } as never
+  context.workspaceGateway.activate(gatewayEvent, 'gateway:test')
+  assert.deepEqual(await handlers.get('settings:get-provider-credentials')?.(gatewayEvent, 'openrouter', {
+    workspaceId: LOCAL_WORKSPACE_ID,
+    purpose: 'credential_editor',
+  }), {})
+  assert.deepEqual(await handlers.get('settings:get-integration-credentials')?.(gatewayEvent, 'github', {
+    workspaceId: LOCAL_WORKSPACE_ID,
+    purpose: 'credential_editor',
+  }), {})
+
+  const pairedEvent = { sender: { id: 702 } } as never
+  context.workspaceGateway.activate(pairedEvent, 'paired-desktop:pairing-credentials')
+  assert.deepEqual(await handlers.get('settings:get-provider-credentials')?.(pairedEvent, 'openrouter', {
+    workspaceId: LOCAL_WORKSPACE_ID,
+    purpose: 'credential_editor',
+  }), {})
+  assert.deepEqual(await handlers.get('settings:get-integration-credentials')?.(pairedEvent, 'github', {
+    workspaceId: LOCAL_WORKSPACE_ID,
+    purpose: 'credential_editor',
+  }), {})
 })
 
 test('custom MCP IPC rejects malformed nested records before persistence', async () => {


### PR DESCRIPTION
## Summary
- make Desktop Cloud `workspace.sync()` page-aware, incremental, bounded, and cancellable
- fence full cloud projection refreshes so stale snapshots cannot overwrite fresher streamed state
- require explicit local credential-editor intent for raw local credential IPC and block Cloud/Gateway/Paired workspaces
- update renderer/preload call sites and regression coverage for large-org sync, stale projection catch-up, and credential boundaries

Closes #601

## Validation
- `node scripts/run-node-tests.mjs tests/cloud-workspace-adapter.test.ts tests/ipc-handler-behavior.test.ts`
- `pnpm --filter @open-cowork/desktop test:renderer -- --run apps/desktop/src/renderer/components/SetupScreen.test.tsx apps/desktop/src/renderer/components/sidebar/SettingsPanel.test.tsx apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm perf:check`
- `pnpm test:e2e`
- `pnpm test`
- `pnpm test:cloud-continuation`
- `node scripts/run-node-tests.mjs tests/cloud-workspace-adapter.test.ts tests/ipc-handler-behavior.test.ts tests/ipc-handler-registration.test.ts`
- `git diff --check`