### PR TITLE
Add shared cloud projection contract

### DIFF
--- a/apps/desktop/src/main/cloud/services/byok-service.ts
+++ b/apps/desktop/src/main/cloud/services/byok-service.ts
@@ -1,51 +1,252 @@
-import type { ByokSecretMetadata } from '../byok-secret-store.ts'
+import type { BillingAction } from '../billing-adapter.ts'
+import type {
+  ByokSecretMetadata,
+  ByokSecretStore,
+} from '../byok-secret-store.ts'
+import { CloudServiceError } from '../cloud-service-error.ts'
 import type { CloudPrincipal } from '../session-service.ts'
 
-export type CloudByokServiceDelegate = {
-  listByokSecrets(principal: CloudPrincipal): Promise<ByokSecretMetadata[]>
-  getByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null>
-  setByokSecret(principal: CloudPrincipal, input: {
-    providerId: string
-    plaintext?: string | null
-    kmsRef?: string | null
-  }): Promise<ByokSecretMetadata>
-  validateByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null>
-  overrideByokSecretValidation(principal: CloudPrincipal, providerId: string, reason: string): Promise<ByokSecretMetadata | null>
-  disableByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null>
+export type ByokEntitlementVerdict = {
+  allowed: boolean
+  status?: number
+  reason?: string | null
+}
+
+export type ByokEntitlementChecker = (input: {
+  principal: CloudPrincipal
+  orgId: string
+  providerId: string
+}) => Promise<ByokEntitlementVerdict> | ByokEntitlementVerdict
+
+export type ByokRuntimeEntitlementChecker = (input: {
+  orgId: string
+  providerId: string
+}) => Promise<ByokEntitlementVerdict> | ByokEntitlementVerdict
+
+export type ByokKmsRefPolicy = {
+  enabled?: boolean
+  allowedPrefixes?: readonly string[] | null
+  allowEnvRefs?: boolean
+}
+
+export type ByokManagementPolicy = {
+  allowedProviderIds?: readonly string[] | null
+  checkEntitlement?: ByokEntitlementChecker | null
+  checkRuntimeEntitlement?: ByokRuntimeEntitlementChecker | null
+  kmsRefs?: ByokKmsRefPolicy | null
+}
+
+export type ByokPolicyOverview = {
+  allowedProviderIds: string[] | null
+  kmsRefsEnabled: boolean
+  kmsRefPrefixesConfigured: boolean
+  envRefsEnabled: boolean
+}
+
+export type CloudByokServiceOptions = {
+  ensurePrincipal: (principal: CloudPrincipal) => Promise<unknown> | unknown
+  principalOrgId: (principal: CloudPrincipal) => string
+  byokSecrets: ByokSecretStore | null
+  byokPolicy?: ByokManagementPolicy
+  assertBillingAllowed: (input: {
+    orgId: string
+    action: BillingAction
+    profileName?: string | null
+    providerId?: string | null
+  }) => Promise<void> | void
+}
+
+function hasAdminTokenScope(principal: CloudPrincipal) {
+  return principal.tokenScopes?.includes('admin') || false
+}
+
+function principalCanManageByok(principal: CloudPrincipal) {
+  if (principal.authSource === 'local') return true
+  if (principal.authSource === 'api_token') return hasAdminTokenScope(principal)
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
+function normalizeByokProviderIdForPolicy(value: string) {
+  const providerId = value.trim().toLowerCase()
+  if (!providerId || providerId.length > 64 || !/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) {
+    throw new CloudServiceError(400, `Unsupported BYOK provider id ${providerId || '<empty>'}.`)
+  }
+  return providerId
+}
+
+function byokAuditActor(principal: CloudPrincipal) {
+  return {
+    actorType: principal.authSource === 'api_token' ? 'api_token' as const : 'user' as const,
+    actorId: principal.tokenId || principal.userId,
+    accountId: principal.accountId || principal.userId,
+  }
 }
 
 export class CloudByokService {
-  private readonly delegate: CloudByokServiceDelegate
+  private readonly ensurePrincipal: CloudByokServiceOptions['ensurePrincipal']
+  private readonly principalOrgId: CloudByokServiceOptions['principalOrgId']
+  private readonly byokSecrets: ByokSecretStore | null
+  private readonly byokPolicy: ByokManagementPolicy
+  private readonly assertBillingAllowed: CloudByokServiceOptions['assertBillingAllowed']
 
-  constructor(delegate: CloudByokServiceDelegate) {
-    this.delegate = delegate
+  constructor(options: CloudByokServiceOptions) {
+    this.ensurePrincipal = options.ensurePrincipal
+    this.principalOrgId = options.principalOrgId
+    this.byokSecrets = options.byokSecrets
+    this.byokPolicy = options.byokPolicy || {}
+    this.assertBillingAllowed = options.assertBillingAllowed
   }
 
-  listSecrets(principal: CloudPrincipal) {
-    return this.delegate.listByokSecrets(principal)
+  getPolicyOverview(): ByokPolicyOverview {
+    return {
+      allowedProviderIds: this.byokPolicy.allowedProviderIds
+        ? [...this.byokPolicy.allowedProviderIds].map((id) => id.trim().toLowerCase()).filter(Boolean)
+        : null,
+      kmsRefsEnabled: this.byokPolicy.kmsRefs?.enabled === true,
+      kmsRefPrefixesConfigured: Boolean(this.byokPolicy.kmsRefs?.allowedPrefixes?.length),
+      envRefsEnabled: this.byokPolicy.kmsRefs?.allowEnvRefs === true,
+    }
   }
 
-  getSecret(principal: CloudPrincipal, providerId: string) {
-    return this.delegate.getByokSecret(principal, providerId)
+  async listSecretMetadataForOrg(orgId: string): Promise<ByokSecretMetadata[]> {
+    return this.byokSecrets ? this.byokSecrets.listMetadata(orgId) : []
   }
 
-  setSecret(principal: CloudPrincipal, input: {
-    providerId: string
-    plaintext?: string | null
-    kmsRef?: string | null
-  }) {
-    return this.delegate.setByokSecret(principal, input)
+  async listSecrets(principal: CloudPrincipal): Promise<ByokSecretMetadata[]> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    return this.requireByokSecrets().listMetadata(this.principalOrgId(principal))
   }
 
-  validateSecret(principal: CloudPrincipal, providerId: string) {
-    return this.delegate.validateByokSecret(principal, providerId)
+  async getSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
+    return this.requireByokSecrets().getMetadata(this.principalOrgId(principal), normalizedProviderId)
   }
 
-  overrideValidation(principal: CloudPrincipal, providerId: string, reason: string) {
-    return this.delegate.overrideByokSecretValidation(principal, providerId, reason)
+  async setSecret(
+    principal: CloudPrincipal,
+    input: { providerId: string, plaintext?: string | null, kmsRef?: string | null },
+  ): Promise<ByokSecretMetadata> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    const providerId = this.assertByokProviderConfigured(input.providerId)
+    this.assertByokKmsRefAllowed(providerId, input.kmsRef)
+    await this.assertByokProviderEntitled(principal, providerId)
+    return this.requireByokSecrets().setSecret({
+      orgId: this.principalOrgId(principal),
+      providerId,
+      plaintext: input.plaintext,
+      kmsRef: input.kmsRef,
+      createdByAccountId: principal.accountId || principal.userId,
+      actor: byokAuditActor(principal),
+    })
   }
 
-  disableSecret(principal: CloudPrincipal, providerId: string) {
-    return this.delegate.disableByokSecret(principal, providerId)
+  async validateSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
+    return this.requireByokSecrets().validateActiveSecret({
+      orgId: this.principalOrgId(principal),
+      providerId: normalizedProviderId,
+      actor: byokAuditActor(principal),
+    })
+  }
+
+  async overrideValidation(
+    principal: CloudPrincipal,
+    providerId: string,
+    reason: string,
+  ): Promise<ByokSecretMetadata | null> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
+    return this.requireByokSecrets().activateWithoutValidation({
+      orgId: this.principalOrgId(principal),
+      providerId: normalizedProviderId,
+      reason,
+      actor: byokAuditActor(principal),
+    })
+  }
+
+  async disableSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
+    await this.ensurePrincipal(principal)
+    this.assertByokAllowed(principal)
+    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
+    return this.requireByokSecrets().disableSecret({
+      orgId: this.principalOrgId(principal),
+      providerId: normalizedProviderId,
+      actor: byokAuditActor(principal),
+    })
+  }
+
+  private assertByokAllowed(principal: CloudPrincipal) {
+    if (!principalCanManageByok(principal)) {
+      throw new CloudServiceError(403, 'BYOK credential administration requires an org admin or admin-scoped API token.')
+    }
+  }
+
+  private async assertByokProviderAllowed(principal: CloudPrincipal, providerIdInput: string) {
+    const providerId = this.assertByokProviderConfigured(providerIdInput)
+    await this.assertByokProviderEntitled(principal, providerId)
+    return providerId
+  }
+
+  private assertByokProviderConfigured(providerIdInput: string) {
+    const providerId = normalizeByokProviderIdForPolicy(providerIdInput)
+    const allowedProviderIds = this.byokPolicy.allowedProviderIds
+      ? new Set(this.byokPolicy.allowedProviderIds.map((id) => id.trim().toLowerCase()).filter(Boolean))
+      : null
+    if (allowedProviderIds && !allowedProviderIds.has(providerId)) {
+      throw new CloudServiceError(403, `Provider "${providerId}" is not enabled for BYOK in this cloud profile.`)
+    }
+    return providerId
+  }
+
+  private async assertByokProviderEntitled(principal: CloudPrincipal, providerId: string) {
+    await this.assertBillingAllowed({
+      orgId: this.principalOrgId(principal),
+      action: 'byok.provider',
+      providerId,
+    })
+    const entitlement = await this.byokPolicy.checkEntitlement?.({
+      principal,
+      orgId: this.principalOrgId(principal),
+      providerId,
+    })
+    if (entitlement && !entitlement.allowed) {
+      throw new CloudServiceError(
+        entitlement.status || 402,
+        entitlement.reason || `Provider "${providerId}" is not available for this org entitlement.`,
+      )
+    }
+  }
+
+  private assertByokKmsRefAllowed(providerId: string, kmsRefInput: string | null | undefined) {
+    const kmsRef = typeof kmsRefInput === 'string' ? kmsRefInput.trim() : ''
+    if (!kmsRef) return
+    const policy = this.byokPolicy.kmsRefs
+    if (!policy?.enabled) {
+      throw new CloudServiceError(403, 'KMS-backed BYOK references are disabled for this cloud deployment.')
+    }
+    if (kmsRef.startsWith('env:') && !policy.allowEnvRefs) {
+      throw new CloudServiceError(403, 'Environment-backed BYOK references are not enabled for user-managed KMS refs.')
+    }
+    const allowedPrefixes = (policy.allowedPrefixes || [])
+      .map((prefix) => prefix.trim())
+      .filter(Boolean)
+    if (allowedPrefixes.length === 0) {
+      throw new CloudServiceError(403, 'KMS-backed BYOK references require deployer-configured allowed prefixes.')
+    }
+    if (!allowedPrefixes.some((prefix) => kmsRef.startsWith(prefix))) {
+      throw new CloudServiceError(403, `KMS-backed BYOK reference is not allowed for provider "${providerId}".`)
+    }
+  }
+
+  private requireByokSecrets() {
+    if (!this.byokSecrets) throw new CloudServiceError(503, 'BYOK secret storage is not configured.')
+    return this.byokSecrets
   }
 }

--- a/apps/desktop/src/main/cloud/services/index.ts
+++ b/apps/desktop/src/main/cloud/services/index.ts
@@ -1,7 +1,15 @@
 export { CloudIdentityService } from './identity-service.ts'
 export type { CloudIdentityServiceDelegate } from './identity-service.ts'
 export { CloudByokService } from './byok-service.ts'
-export type { CloudByokServiceDelegate } from './byok-service.ts'
+export type {
+  ByokEntitlementChecker,
+  ByokEntitlementVerdict,
+  ByokKmsRefPolicy,
+  ByokManagementPolicy,
+  ByokPolicyOverview,
+  ByokRuntimeEntitlementChecker,
+  CloudByokServiceOptions,
+} from './byok-service.ts'
 export { CloudBillingService } from './billing-service.ts'
 export type { CloudBillingServiceDelegate } from './billing-service.ts'
 export { CloudQuotaService } from './quota-service.ts'

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -105,6 +105,10 @@ import {
   type AppendProjectedEventInput,
 } from './session-projection-service.ts'
 import {
+  CloudByokService,
+  type ByokManagementPolicy,
+} from './services/byok-service.ts'
+import {
   normalizePermissionPayload,
   normalizePromptPayload,
   normalizeQuestionRejectPayload,
@@ -321,35 +325,13 @@ export type IssuedPublicApiTokenRecord = {
   plaintext: string
 }
 
-export type ByokEntitlementVerdict = {
-  allowed: boolean
-  status?: number
-  reason?: string | null
-}
-
-export type ByokEntitlementChecker = (input: {
-  principal: CloudPrincipal
-  orgId: string
-  providerId: string
-}) => Promise<ByokEntitlementVerdict> | ByokEntitlementVerdict
-
-export type ByokRuntimeEntitlementChecker = (input: {
-  orgId: string
-  providerId: string
-}) => Promise<ByokEntitlementVerdict> | ByokEntitlementVerdict
-
-export type ByokKmsRefPolicy = {
-  enabled?: boolean
-  allowedPrefixes?: readonly string[] | null
-  allowEnvRefs?: boolean
-}
-
-export type ByokManagementPolicy = {
-  allowedProviderIds?: readonly string[] | null
-  checkEntitlement?: ByokEntitlementChecker | null
-  checkRuntimeEntitlement?: ByokRuntimeEntitlementChecker | null
-  kmsRefs?: ByokKmsRefPolicy | null
-}
+export type {
+  ByokEntitlementChecker,
+  ByokEntitlementVerdict,
+  ByokKmsRefPolicy,
+  ByokManagementPolicy,
+  ByokRuntimeEntitlementChecker,
+} from './services/byok-service.ts'
 
 export { CloudServiceError } from './cloud-service-error.ts'
 
@@ -489,12 +471,6 @@ function principalCanManageChannels(principal: CloudPrincipal) {
   return principal.role === 'owner' || principal.role === 'admin'
 }
 
-function principalCanManageByok(principal: CloudPrincipal) {
-  if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
-  return principal.role === 'owner' || principal.role === 'admin'
-}
-
 function principalCanManageBilling(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
@@ -511,14 +487,6 @@ function principalCanManageOrg(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
   if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
   return principal.role === 'owner' || principal.role === 'admin'
-}
-
-function normalizeByokProviderIdForPolicy(value: string) {
-  const providerId = value.trim().toLowerCase()
-  if (!providerId || providerId.length > 64 || !/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) {
-    throw new CloudServiceError(400, `Unsupported BYOK provider id ${providerId || '<empty>'}.`)
-  }
-  return providerId
 }
 
 function principalEmailDomain(email: string | null | undefined) {
@@ -642,8 +610,7 @@ export class CloudSessionService {
   private readonly workspaceEvents: CloudWorkspaceEventBus
   private readonly projections: CloudSessionProjectionService
   private readonly ids: { randomUUID: () => string }
-  private readonly byokSecrets: ByokSecretStore | null
-  private readonly byokPolicy: ByokManagementPolicy
+  private readonly byokService: CloudByokService
   private readonly abuse: CloudAbuseConfig
   private readonly billingConfig: CloudBillingConfig | null
   private readonly billingAdapter: BillingAdapter | null
@@ -674,8 +641,13 @@ export class CloudSessionService {
     this.workspaceEvents = workspaceEvents
     this.projections = new CloudSessionProjectionService(store, events, workspaceEvents)
     this.ids = ids
-    this.byokSecrets = byokSecrets
-    this.byokPolicy = byokPolicy
+    this.byokService = new CloudByokService({
+      ensurePrincipal: (principal) => this.ensurePrincipal(principal),
+      principalOrgId: (principal) => this.principalOrgId(principal),
+      byokSecrets,
+      byokPolicy,
+      assertBillingAllowed: (input) => this.assertBillingAllowed(input),
+    })
     this.abuse = abuse
     this.billingConfig = billingConfig
     this.billingAdapter = billingAdapter
@@ -900,14 +872,7 @@ export class CloudSessionService {
         channelsEnabled: this.policy.features.agents !== false,
         webhooksEnabled: this.policy.features.webhooks !== false,
       },
-      byok: {
-        allowedProviderIds: this.byokPolicy.allowedProviderIds
-          ? [...this.byokPolicy.allowedProviderIds].map((id) => id.trim().toLowerCase()).filter(Boolean)
-          : null,
-        kmsRefsEnabled: this.byokPolicy.kmsRefs?.enabled === true,
-        kmsRefPrefixesConfigured: Boolean(this.byokPolicy.kmsRefs?.allowedPrefixes?.length),
-        envRefsEnabled: this.byokPolicy.kmsRefs?.allowEnvRefs === true,
-      },
+      byok: this.byokService.getPolicyOverview(),
     }
   }
 
@@ -1378,56 +1343,26 @@ export class CloudSessionService {
   }
 
   async listByokSecrets(principal: CloudPrincipal): Promise<ByokSecretMetadata[]> {
-    await this.ensurePrincipal(principal)
-    this.assertByokAllowed(principal)
-    return this.requireByokSecrets().listMetadata(this.principalOrgId(principal))
+    return this.byokService.listSecrets(principal)
   }
 
   async getByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
-    await this.ensurePrincipal(principal)
-    this.assertByokAllowed(principal)
-    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
-    return this.requireByokSecrets().getMetadata(this.principalOrgId(principal), normalizedProviderId)
+    return this.byokService.getSecret(principal, providerId)
   }
 
   async setByokSecret(
     principal: CloudPrincipal,
     input: { providerId: string, plaintext?: string | null, kmsRef?: string | null },
   ): Promise<ByokSecretMetadata> {
-    await this.ensurePrincipal(principal)
-    this.assertByokAllowed(principal)
-    const providerId = await this.assertByokProviderAllowed(principal, input.providerId)
-    this.assertByokKmsRefAllowed(providerId, input.kmsRef)
-    return this.requireByokSecrets().setSecret({
-      orgId: this.principalOrgId(principal),
-      providerId,
-      plaintext: input.plaintext,
-      kmsRef: input.kmsRef,
-      createdByAccountId: principal.accountId || principal.userId,
-      actor: this.byokAuditActor(principal),
-    })
+    return this.byokService.setSecret(principal, input)
   }
 
   async disableByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
-    await this.ensurePrincipal(principal)
-    this.assertByokAllowed(principal)
-    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
-    return this.requireByokSecrets().disableSecret({
-      orgId: this.principalOrgId(principal),
-      providerId: normalizedProviderId,
-      actor: this.byokAuditActor(principal),
-    })
+    return this.byokService.disableSecret(principal, providerId)
   }
 
   async validateByokSecret(principal: CloudPrincipal, providerId: string): Promise<ByokSecretMetadata | null> {
-    await this.ensurePrincipal(principal)
-    this.assertByokAllowed(principal)
-    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
-    return this.requireByokSecrets().validateActiveSecret({
-      orgId: this.principalOrgId(principal),
-      providerId: normalizedProviderId,
-      actor: this.byokAuditActor(principal),
-    })
+    return this.byokService.validateSecret(principal, providerId)
   }
 
   async overrideByokSecretValidation(
@@ -1435,15 +1370,7 @@ export class CloudSessionService {
     providerId: string,
     reason: string,
   ): Promise<ByokSecretMetadata | null> {
-    await this.ensurePrincipal(principal)
-    this.assertByokAllowed(principal)
-    const normalizedProviderId = await this.assertByokProviderAllowed(principal, providerId)
-    return this.requireByokSecrets().activateWithoutValidation({
-      orgId: this.principalOrgId(principal),
-      providerId: normalizedProviderId,
-      reason,
-      actor: this.byokAuditActor(principal),
-    })
+    return this.byokService.overrideValidation(principal, providerId, reason)
   }
 
   async listHeadlessAgents(principal: CloudPrincipal, input: { limit?: number | null } = {}): Promise<HeadlessAgentRecord[]> {
@@ -2711,7 +2638,7 @@ export class CloudSessionService {
     const [billing, usage, byok, heartbeats, agents, deliveries] = await Promise.all([
       this.getBillingSubscription(principal),
       this.getUsageSummary(principal, 200),
-      this.byokSecrets ? this.byokSecrets.listMetadata(orgId) : Promise.resolve([]),
+      this.byokService.listSecretMetadataForOrg(orgId),
       this.store.listWorkerHeartbeats(),
       this.store.listHeadlessAgents(orgId),
       this.store.listChannelDeliveries({ orgId, limit: deliverySampleLimit }),
@@ -3837,12 +3764,6 @@ export class CloudSessionService {
     }
   }
 
-  private assertByokAllowed(principal: CloudPrincipal) {
-    if (!principalCanManageByok(principal)) {
-      throw new CloudServiceError(403, 'BYOK credential administration requires an org admin or admin-scoped API token.')
-    }
-  }
-
   private assertBillingAdmin(principal: CloudPrincipal) {
     if (!principalCanManageBilling(principal)) {
       throw new CloudServiceError(403, 'Billing administration requires an org admin or admin-scoped API token.')
@@ -3950,67 +3871,6 @@ export class CloudSessionService {
 
   private auditActor(principal: CloudPrincipal) {
     return importAuditActor(principal)
-  }
-
-  private byokAuditActor(principal: CloudPrincipal) {
-    return {
-      actorType: principal.authSource === 'api_token' ? 'api_token' as const : 'user' as const,
-      actorId: principal.tokenId || principal.userId,
-      accountId: principal.accountId || principal.userId,
-    }
-  }
-
-  private async assertByokProviderAllowed(principal: CloudPrincipal, providerIdInput: string) {
-    const providerId = normalizeByokProviderIdForPolicy(providerIdInput)
-    const allowedProviderIds = this.byokPolicy.allowedProviderIds
-      ? new Set(this.byokPolicy.allowedProviderIds.map((id) => id.trim().toLowerCase()).filter(Boolean))
-      : null
-    if (allowedProviderIds && !allowedProviderIds.has(providerId)) {
-      throw new CloudServiceError(403, `Provider "${providerId}" is not enabled for BYOK in this cloud profile.`)
-    }
-    await this.assertBillingAllowed({
-      orgId: this.principalOrgId(principal),
-      action: 'byok.provider',
-      providerId,
-    })
-    const entitlement = await this.byokPolicy.checkEntitlement?.({
-      principal,
-      orgId: this.principalOrgId(principal),
-      providerId,
-    })
-    if (entitlement && !entitlement.allowed) {
-      throw new CloudServiceError(
-        entitlement.status || 402,
-        entitlement.reason || `Provider "${providerId}" is not available for this org entitlement.`,
-      )
-    }
-    return providerId
-  }
-
-  private assertByokKmsRefAllowed(providerId: string, kmsRefInput: string | null | undefined) {
-    const kmsRef = typeof kmsRefInput === 'string' ? kmsRefInput.trim() : ''
-    if (!kmsRef) return
-    const policy = this.byokPolicy.kmsRefs
-    if (!policy?.enabled) {
-      throw new CloudServiceError(403, 'KMS-backed BYOK references are disabled for this cloud deployment.')
-    }
-    if (kmsRef.startsWith('env:') && !policy.allowEnvRefs) {
-      throw new CloudServiceError(403, 'Environment-backed BYOK references are not enabled for user-managed KMS refs.')
-    }
-    const allowedPrefixes = (policy.allowedPrefixes || [])
-      .map((prefix) => prefix.trim())
-      .filter(Boolean)
-    if (allowedPrefixes.length === 0) {
-      throw new CloudServiceError(403, 'KMS-backed BYOK references require deployer-configured allowed prefixes.')
-    }
-    if (!allowedPrefixes.some((prefix) => kmsRef.startsWith(prefix))) {
-      throw new CloudServiceError(403, `KMS-backed BYOK reference is not allowed for provider "${providerId}".`)
-    }
-  }
-
-  private requireByokSecrets() {
-    if (!this.byokSecrets) throw new CloudServiceError(503, 'BYOK secret storage is not configured.')
-    return this.byokSecrets
   }
 
   private assertGatewayAccess(principal: CloudPrincipal) {

--- a/apps/gateway/src/event-renderer.test.ts
+++ b/apps/gateway/src/event-renderer.test.ts
@@ -9,6 +9,8 @@ import {
 } from '@open-cowork/gateway-testing'
 import {
   CLOUD_SESSION_EVENT_TYPES,
+  CLOUD_SESSION_EVENT_CONTRACT,
+  cloudSessionEventIsChannelRenderable,
   isCloudSessionEventType,
 } from '@open-cowork/shared'
 
@@ -81,6 +83,10 @@ test('event renderer edits streaming assistant output for button-capable provide
 })
 
 test('event renderer handles only canonical shared cloud session events', () => {
+  const channelRenderableTypes = CLOUD_SESSION_EVENT_CONTRACT
+    .filter((entry) => entry.channelRenderable)
+    .map((entry) => entry.type)
+    .sort()
   assert.deepEqual([...GATEWAY_RENDERED_SESSION_EVENT_TYPES].sort(), [
     'artifact.created',
     'assistant.message',
@@ -88,11 +94,14 @@ test('event renderer handles only canonical shared cloud session events', () => 
     'question.asked',
     'tool.call',
   ])
+  assert.deepEqual([...GATEWAY_RENDERED_SESSION_EVENT_TYPES].sort(), channelRenderableTypes)
 
   for (const type of GATEWAY_RENDERED_SESSION_EVENT_TYPES) {
     assert.equal(CLOUD_SESSION_EVENT_TYPES.includes(type), true)
     assert.equal(isCloudSessionEventType(type), true, `${type} must stay in the shared cloud event contract`)
+    assert.equal(cloudSessionEventIsChannelRenderable(type), true, `${type} must stay declared as channel-renderable`)
   }
+  assert.equal(cloudSessionEventIsChannelRenderable('permission.resolved'), false)
   assert.equal(isCloudSessionEventType('permission.asked'), false, 'raw SDK events must not become gateway-rendered cloud events')
 })
 

--- a/docs/session-projection-contract.md
+++ b/docs/session-projection-contract.md
@@ -1,0 +1,94 @@
+# Session Projection Contract
+
+Open Cowork syncs product state through shared Cloud session event and
+projection record types. The contract is versioned in
+`packages/shared/src/cloud-session-contract.ts` and consumed by Desktop, Cloud
+Web, and Gateway. OpenCode still owns runtime execution; Open Cowork only
+normalizes runtime output into durable product events.
+
+## Version
+
+Current contract version: `1`.
+
+Public shared types:
+
+- `CloudSessionEventRecord`
+- `CloudSessionProjectionEventRecord`
+- `CloudSessionEventType`
+- `CloudProjectedSessionEventType`
+
+Changing the meaning of an existing event or projection field requires a
+version bump, a migration or compatibility path for stored projections, and
+tests proving older snapshots still hydrate safely. Adding a new event type is
+allowed without a version bump only when older clients can ignore it without
+losing required chat state.
+
+## Event Flow
+
+```mermaid
+flowchart LR
+  OpenCode["OpenCode runtime events"] --> Adapter["Cloud runtime adapter"]
+  Adapter --> Events["CloudSessionEvent contract"]
+  Events --> Store["Durable event log"]
+  Store --> Reducer["Shared projection reducer"]
+  Reducer --> View["SessionView"]
+  View --> Desktop["Desktop"]
+  View --> Web["Cloud Web"]
+  Events --> Gateway["Gateway renderer"]
+```
+
+Rules:
+
+- Raw OpenCode SDK events stop at the runtime adapter.
+- Cloud workers append only canonical `CloudSessionEventType` values.
+- Projection reducers live in shared code and produce the `SessionView` shape
+  Desktop already consumes.
+- Gateway renders only event types marked `channelRenderable` in the shared
+  contract.
+- `snapshot.required` and `channel.delivery` are control events, not projected
+  session state.
+
+## Projected Event Vocabulary
+
+Projected events update durable session state:
+
+- `session.created`
+- `session.imported`
+- `session.project_source.bound`
+- `prompt.submitted`
+- `assistant.message`
+- `tool.call`
+- `task.run`
+- `permission.requested`
+- `permission.resolved`
+- `question.asked`
+- `question.resolved`
+- `todos.updated`
+- `cost.updated`
+- `artifact.created`
+- `session.status`
+- `session.idle`
+- `session.aborted`
+- `runtime.error`
+
+Control events are delivered over Cloud APIs but do not update the session
+projection:
+
+- `snapshot.required`
+- `channel.delivery`
+
+## Extension Rules
+
+When adding an event:
+
+1. Add it to `CLOUD_SESSION_EVENT_CONTRACT` with facets, producers, consumers,
+   channel renderability, and a short description.
+2. If it is projected, update `reduceCloudSessionProjectionEvent`.
+3. Add SDK normalization fixtures when it comes from OpenCode.
+4. Add Desktop/Web/Gateway tests for every surface that consumes it.
+5. Keep the Gateway renderer on canonical Cloud events. Do not render raw SDK
+   event names in channel providers.
+
+This contract is the compatibility boundary between synced product surfaces.
+It should grow through typed events and tests, not through surface-specific
+parsing of runtime internals.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Architecture: architecture.md
       - Product Contract: product-contract.md
       - Coordination Model: coordination-model.md
+      - Session Projection Contract: session-projection-contract.md
       - Desktop Outbound Pairing: desktop-outbound-pairing.md
       - Cloud Web Workbench: cloud-web-workbench.md
       - Cloud Client SDK: cloud-client.md

--- a/packages/shared/src/cloud-session-contract.ts
+++ b/packages/shared/src/cloud-session-contract.ts
@@ -1,0 +1,282 @@
+export const CLOUD_SESSION_PROJECTION_CONTRACT_VERSION = 1
+
+export type CloudSessionProjectionFacet =
+  | 'messages'
+  | 'toolCalls'
+  | 'taskRuns'
+  | 'approvals'
+  | 'questions'
+  | 'artifacts'
+  | 'todos'
+  | 'cost'
+  | 'status'
+  | 'errors'
+  | 'origin'
+  | 'projectSource'
+  | 'workspace'
+  | 'control'
+
+export type CloudSessionProjectionProducer =
+  | 'cloud-runtime'
+  | 'cloud-service'
+  | 'cloud-gateway'
+
+export type CloudSessionProjectionConsumer =
+  | 'desktop'
+  | 'cloud-web'
+  | 'gateway'
+  | 'worker'
+
+export type CloudSessionEventContractEntry = {
+  type: string
+  projected: boolean
+  facets: readonly CloudSessionProjectionFacet[]
+  producers: readonly CloudSessionProjectionProducer[]
+  consumers: readonly CloudSessionProjectionConsumer[]
+  channelRenderable: boolean
+  description: string
+}
+
+export const CLOUD_SESSION_EVENT_CONTRACT = [
+  {
+    type: 'session.created',
+    projected: true,
+    facets: ['status', 'workspace'],
+    producers: ['cloud-service'],
+    consumers: ['desktop', 'cloud-web'],
+    channelRenderable: false,
+    description: 'Cloud session metadata was created and is ready to project.',
+  },
+  {
+    type: 'session.imported',
+    projected: true,
+    facets: ['origin', 'status', 'workspace'],
+    producers: ['cloud-service'],
+    consumers: ['desktop', 'cloud-web'],
+    channelRenderable: false,
+    description: 'A redacted local session import completed into a cloud workspace.',
+  },
+  {
+    type: 'session.project_source.bound',
+    projected: true,
+    facets: ['projectSource', 'workspace'],
+    producers: ['cloud-service'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'A cloud-safe project source or snapshot was attached to a session.',
+  },
+  {
+    type: 'prompt.submitted',
+    projected: true,
+    facets: ['messages', 'status'],
+    producers: ['cloud-service', 'cloud-gateway'],
+    consumers: ['desktop', 'cloud-web', 'gateway', 'worker'],
+    channelRenderable: false,
+    description: 'A user or channel prompt was accepted by the cloud control plane.',
+  },
+  {
+    type: 'assistant.message',
+    projected: true,
+    facets: ['messages'],
+    producers: ['cloud-runtime'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: true,
+    description: 'Assistant text emitted by the OpenCode runtime after cloud normalization.',
+  },
+  {
+    type: 'tool.call',
+    projected: true,
+    facets: ['toolCalls', 'taskRuns', 'status'],
+    producers: ['cloud-runtime'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: true,
+    description: 'Normalized tool-call progress or completion from the OpenCode runtime.',
+  },
+  {
+    type: 'task.run',
+    projected: true,
+    facets: ['taskRuns'],
+    producers: ['cloud-runtime', 'cloud-service'],
+    consumers: ['desktop', 'cloud-web'],
+    channelRenderable: false,
+    description: 'Projected child-task or delegated run state.',
+  },
+  {
+    type: 'permission.requested',
+    projected: true,
+    facets: ['approvals', 'status'],
+    producers: ['cloud-runtime'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: true,
+    description: 'A runtime permission request that requires a human decision.',
+  },
+  {
+    type: 'permission.resolved',
+    projected: true,
+    facets: ['approvals'],
+    producers: ['cloud-runtime', 'cloud-service', 'cloud-gateway'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'A runtime permission request was allowed or denied.',
+  },
+  {
+    type: 'question.asked',
+    projected: true,
+    facets: ['questions', 'status'],
+    producers: ['cloud-runtime'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: true,
+    description: 'A runtime question that requires a human answer.',
+  },
+  {
+    type: 'question.resolved',
+    projected: true,
+    facets: ['questions'],
+    producers: ['cloud-runtime', 'cloud-service', 'cloud-gateway'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'A runtime question was answered or rejected.',
+  },
+  {
+    type: 'todos.updated',
+    projected: true,
+    facets: ['todos'],
+    producers: ['cloud-runtime'],
+    consumers: ['desktop', 'cloud-web'],
+    channelRenderable: false,
+    description: 'Runtime todo state was replaced with the latest canonical list.',
+  },
+  {
+    type: 'cost.updated',
+    projected: true,
+    facets: ['cost'],
+    producers: ['cloud-runtime'],
+    consumers: ['desktop', 'cloud-web'],
+    channelRenderable: false,
+    description: 'Cost and token usage changed for the cloud session.',
+  },
+  {
+    type: 'artifact.created',
+    projected: true,
+    facets: ['artifacts'],
+    producers: ['cloud-runtime', 'cloud-service'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: true,
+    description: 'A cloud artifact became available through object storage.',
+  },
+  {
+    type: 'session.status',
+    projected: true,
+    facets: ['status'],
+    producers: ['cloud-runtime', 'cloud-service'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'Runtime session status changed without closing the session.',
+  },
+  {
+    type: 'session.idle',
+    projected: true,
+    facets: ['status'],
+    producers: ['cloud-runtime', 'cloud-service'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'Runtime execution settled and the session is idle.',
+  },
+  {
+    type: 'session.aborted',
+    projected: true,
+    facets: ['status'],
+    producers: ['cloud-service', 'cloud-runtime'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'Cloud execution was aborted for the session.',
+  },
+  {
+    type: 'runtime.error',
+    projected: true,
+    facets: ['errors', 'status'],
+    producers: ['cloud-runtime', 'cloud-service'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'Runtime or worker execution failed after cloud redaction.',
+  },
+  {
+    type: 'snapshot.required',
+    projected: false,
+    facets: ['control'],
+    producers: ['cloud-service'],
+    consumers: ['desktop', 'cloud-web', 'gateway'],
+    channelRenderable: false,
+    description: 'A client must hydrate a fresh snapshot before resuming events.',
+  },
+  {
+    type: 'channel.delivery',
+    projected: false,
+    facets: ['control'],
+    producers: ['cloud-gateway', 'cloud-service'],
+    consumers: ['gateway', 'cloud-web'],
+    channelRenderable: false,
+    description: 'A channel delivery changed state; not part of session projection.',
+  },
+] as const satisfies readonly CloudSessionEventContractEntry[]
+
+type CloudSessionEventContract = typeof CLOUD_SESSION_EVENT_CONTRACT[number]
+type CloudProjectedSessionEventContract = Extract<CloudSessionEventContract, { projected: true }>
+
+export type CloudProjectedSessionEventType = CloudProjectedSessionEventContract['type']
+export type CloudSessionEventType = CloudSessionEventContract['type']
+
+export type CloudSessionEventRecord<Type extends string = CloudSessionEventType> = {
+  eventId?: string
+  tenantId?: string
+  sessionId?: string
+  sequence: number
+  type: Type
+  payload: Record<string, unknown>
+  createdAt: string
+  entityType?: string
+  entityId?: string
+  operation?: string
+  projectionVersion?: number
+}
+
+export type CloudSessionProjectionEventRecord<Type extends string = CloudProjectedSessionEventType> =
+  CloudSessionEventRecord<Type>
+
+function projectedEntry(entry: CloudSessionEventContract): entry is CloudProjectedSessionEventContract {
+  return entry.projected
+}
+
+export const CLOUD_PROJECTED_SESSION_EVENT_TYPES = CLOUD_SESSION_EVENT_CONTRACT
+  .filter(projectedEntry)
+  .map((entry) => entry.type) as readonly CloudProjectedSessionEventType[]
+
+export const CLOUD_SESSION_EVENT_TYPES = CLOUD_SESSION_EVENT_CONTRACT
+  .map((entry) => entry.type) as readonly CloudSessionEventType[]
+
+const CLOUD_PROJECTED_SESSION_EVENT_TYPE_SET = new Set<string>(CLOUD_PROJECTED_SESSION_EVENT_TYPES)
+const CLOUD_SESSION_EVENT_TYPE_SET = new Set<string>(CLOUD_SESSION_EVENT_TYPES)
+const CLOUD_SESSION_EVENT_CONTRACT_BY_TYPE = new Map<string, CloudSessionEventContract>(
+  CLOUD_SESSION_EVENT_CONTRACT.map((entry) => [entry.type, entry]),
+)
+
+export function isCloudProjectedSessionEventType(value: string): value is CloudProjectedSessionEventType {
+  return CLOUD_PROJECTED_SESSION_EVENT_TYPE_SET.has(value)
+}
+
+export function isCloudSessionEventType(value: string): value is CloudSessionEventType {
+  return CLOUD_SESSION_EVENT_TYPE_SET.has(value)
+}
+
+export function cloudSessionEventContractFor(type: string): CloudSessionEventContract | null {
+  return CLOUD_SESSION_EVENT_CONTRACT_BY_TYPE.get(type) || null
+}
+
+export function cloudSessionEventHasFacet(type: string, facet: CloudSessionProjectionFacet) {
+  const facets = cloudSessionEventContractFor(type)?.facets as readonly CloudSessionProjectionFacet[] | undefined
+  return facets?.includes(facet) || false
+}
+
+export function cloudSessionEventIsChannelRenderable(type: string) {
+  return cloudSessionEventContractFor(type)?.channelRenderable === true
+}

--- a/packages/shared/src/cloud-session-projection.ts
+++ b/packages/shared/src/cloud-session-projection.ts
@@ -15,6 +15,28 @@ import {
   normalizeCloudProjectSource,
   type CloudProjectSource,
 } from './project-source.js'
+import type { CloudSessionProjectionEventRecord } from './cloud-session-contract.js'
+export {
+  CLOUD_PROJECTED_SESSION_EVENT_TYPES,
+  CLOUD_SESSION_EVENT_CONTRACT,
+  CLOUD_SESSION_EVENT_TYPES,
+  CLOUD_SESSION_PROJECTION_CONTRACT_VERSION,
+  cloudSessionEventContractFor,
+  cloudSessionEventHasFacet,
+  cloudSessionEventIsChannelRenderable,
+  isCloudProjectedSessionEventType,
+  isCloudSessionEventType,
+} from './cloud-session-contract.js'
+export type {
+  CloudProjectedSessionEventType,
+  CloudSessionEventContractEntry,
+  CloudSessionEventRecord,
+  CloudSessionEventType,
+  CloudSessionProjectionEventRecord,
+  CloudSessionProjectionConsumer,
+  CloudSessionProjectionFacet,
+  CloudSessionProjectionProducer,
+} from './cloud-session-contract.js'
 
 export type CloudSessionMessage = {
   id: string
@@ -55,47 +77,6 @@ export type CloudResolvedQuestion = {
   resolvedAt: string
 }
 
-export const CLOUD_PROJECTED_SESSION_EVENT_TYPES = [
-  'session.created',
-  'session.imported',
-  'session.project_source.bound',
-  'prompt.submitted',
-  'assistant.message',
-  'tool.call',
-  'task.run',
-  'permission.requested',
-  'permission.resolved',
-  'question.asked',
-  'question.resolved',
-  'todos.updated',
-  'cost.updated',
-  'artifact.created',
-  'session.status',
-  'session.idle',
-  'session.aborted',
-  'runtime.error',
-] as const
-
-export const CLOUD_SESSION_EVENT_TYPES = [
-  ...CLOUD_PROJECTED_SESSION_EVENT_TYPES,
-  'snapshot.required',
-  'channel.delivery',
-] as const
-
-export type CloudProjectedSessionEventType = typeof CLOUD_PROJECTED_SESSION_EVENT_TYPES[number]
-export type CloudSessionEventType = typeof CLOUD_SESSION_EVENT_TYPES[number]
-
-const CLOUD_PROJECTED_SESSION_EVENT_TYPE_SET = new Set<string>(CLOUD_PROJECTED_SESSION_EVENT_TYPES)
-const CLOUD_SESSION_EVENT_TYPE_SET = new Set<string>(CLOUD_SESSION_EVENT_TYPES)
-
-export function isCloudProjectedSessionEventType(value: string): value is CloudProjectedSessionEventType {
-  return CLOUD_PROJECTED_SESSION_EVENT_TYPE_SET.has(value)
-}
-
-export function isCloudSessionEventType(value: string): value is CloudSessionEventType {
-  return CLOUD_SESSION_EVENT_TYPE_SET.has(value)
-}
-
 export type CloudSessionProjectionView = {
   sessionId: string
   title: string
@@ -131,12 +112,7 @@ export type CloudProjectionSessionRecord = {
   updatedAt: string
 }
 
-export type CloudProjectionEventRecord = {
-  sequence: number
-  type: string
-  payload: Record<string, unknown>
-  createdAt: string
-}
+export type CloudProjectionEventRecord = CloudSessionProjectionEventRecord<string>
 
 export type CloudSessionProjectionRecord = {
   tenantId?: string
@@ -467,10 +443,9 @@ function addMessage(
   view: CloudSessionProjectionView,
   message: CloudSessionMessage,
 ): CloudSessionProjectionView {
-  if (view.messages.some((entry) => entry.id === message.id)) return view
   return {
     ...view,
-    messages: [...view.messages, message],
+    messages: upsertById(view.messages, message),
   }
 }
 

--- a/tests/cloud-control-plane-modularity.test.ts
+++ b/tests/cloud-control-plane-modularity.test.ts
@@ -1,0 +1,172 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { extname, join, relative } from 'node:path'
+
+const root = process.cwd()
+
+const ignoredDirectories = new Set([
+  '.git',
+  'coverage',
+  'dist',
+  'node_modules',
+  'release',
+  'site',
+])
+
+test('cloud control-plane facade files stay within documented compatibility budgets', () => {
+  const budgets = [
+    { path: 'apps/desktop/src/main/cloud/http-server.ts', maxLines: 2_000 },
+    { path: 'apps/desktop/src/main/cloud/in-memory-control-plane-store.ts', maxLines: 4_200 },
+    { path: 'apps/desktop/src/main/cloud/postgres-control-plane-store.ts', maxLines: 4_400 },
+    { path: 'apps/desktop/src/main/cloud/session-service.ts', maxLines: 4_200 },
+  ]
+
+  for (const budget of budgets) {
+    const lines = lineCount(join(root, budget.path))
+    assert.equal(
+      lines <= budget.maxLines,
+      true,
+      `${budget.path} has ${lines} lines and must stay <= ${budget.maxLines}; extract a domain module instead of growing the facade`,
+    )
+  }
+})
+
+test('cloud route, service, client-domain, and gateway source modules stay bounded', () => {
+  const budgets = [
+    { directory: 'apps/desktop/src/main/cloud/http-routes', maxLines: 500 },
+    { directory: 'apps/desktop/src/main/cloud/services', maxLines: 450 },
+    { directory: 'packages/cloud-client/src/domains', maxLines: 120 },
+    { directory: 'apps/gateway/src', maxLines: 900 },
+  ]
+
+  for (const budget of budgets) {
+    for (const filePath of sourceFiles(join(root, budget.directory))) {
+      if (filePath.endsWith('.test.ts')) continue
+      const lines = lineCount(filePath)
+      assert.equal(
+        lines <= budget.maxLines,
+        true,
+        `${relative(root, filePath)} has ${lines} lines and must stay <= ${budget.maxLines}`,
+      )
+    }
+  }
+})
+
+test('client surfaces do not import server-only cloud control-plane internals', () => {
+  const clientRoots = [
+    'apps/desktop/src/preload',
+    'apps/desktop/src/renderer',
+    'apps/gateway/src',
+    'apps/website/src',
+    'packages/cloud-client/src',
+  ]
+  const forbidden = [
+    /@opencode-ai\/sdk/,
+    /main\/cloud\/(?:app|http-server|session-service|control-plane-store|postgres-control-plane-store|in-memory-control-plane-store|runtime-adapter|opencode-runtime-adapter|secret-adapter|object-store|worker)(?:\.ts)?/,
+    /(?:^|\/)apps\/desktop\/src\/main\/cloud\/(?:app|http-server|session-service|control-plane-store|postgres-control-plane-store|in-memory-control-plane-store|runtime-adapter|opencode-runtime-adapter|secret-adapter|object-store|worker)(?:\.ts)?/,
+  ]
+
+  for (const clientRoot of clientRoots) {
+    for (const filePath of sourceFiles(join(root, clientRoot))) {
+      const source = readFileSync(filePath, 'utf8')
+      for (const pattern of forbidden) {
+        assert.doesNotMatch(
+          source,
+          pattern,
+          `${relative(root, filePath)} imports server-only Cloud internals instead of @open-cowork/cloud-client or shared contracts`,
+        )
+      }
+    }
+  }
+})
+
+test('cloud route and service modules do not reach below their domain seams', () => {
+  const routeForbidden = [
+    /@opencode-ai\/sdk/,
+    /postgres-control-plane-store/,
+    /in-memory-control-plane-store/,
+    /opencode-runtime-adapter/,
+    /worker-scoped-runtime-adapter/,
+  ]
+  const serviceForbidden = [
+    /@opencode-ai\/sdk/,
+    /from ['"]node:http['"]/,
+    /from ['"]node:net['"]/,
+    /postgres-control-plane-store/,
+    /in-memory-control-plane-store/,
+    /opencode-runtime-adapter/,
+  ]
+
+  for (const filePath of sourceFiles(join(root, 'apps/desktop/src/main/cloud/http-routes'))) {
+    const source = readFileSync(filePath, 'utf8')
+    for (const pattern of routeForbidden) {
+      assert.doesNotMatch(source, pattern, `${relative(root, filePath)} bypasses service/store seams`)
+    }
+  }
+  for (const filePath of sourceFiles(join(root, 'apps/desktop/src/main/cloud/services'))) {
+    const source = readFileSync(filePath, 'utf8')
+    for (const pattern of serviceForbidden) {
+      assert.doesNotMatch(source, pattern, `${relative(root, filePath)} bypasses store/runtime seams`)
+    }
+  }
+})
+
+test('BYOK orchestration stays outside the CloudSessionService facade', () => {
+  const sessionServiceSource = readFileSync(join(root, 'apps/desktop/src/main/cloud/session-service.ts'), 'utf8')
+  const byokServiceSource = readFileSync(join(root, 'apps/desktop/src/main/cloud/services/byok-service.ts'), 'utf8')
+
+  const extractedByokHelpers = [
+    'private async assertByokProviderAllowed',
+    'private assertByokKmsRefAllowed',
+    'private requireByokSecrets',
+    'function normalizeByokProviderIdForPolicy',
+    'function principalCanManageByok',
+  ]
+  for (const helper of extractedByokHelpers) {
+    assert.equal(
+      sessionServiceSource.includes(helper),
+      false,
+      `CloudSessionService should delegate ${helper} to services/byok-service.ts`,
+    )
+  }
+
+  const forbiddenByokServiceImports = [
+    /http-server/,
+    /postgres-control-plane-store/,
+    /in-memory-control-plane-store/,
+    /opencode-runtime-adapter/,
+    /@opencode-ai\/sdk/,
+  ]
+  for (const pattern of forbiddenByokServiceImports) {
+    assert.doesNotMatch(byokServiceSource, pattern, 'BYOK service should remain a policy/store seam, not an HTTP/runtime module')
+  }
+})
+
+function lineCount(path: string) {
+  return readFileSync(path, 'utf8').split(/\r?\n/).length
+}
+
+function sourceFiles(directory: string): string[] {
+  const files: string[] = []
+  for (const entry of safeReadDirectory(directory)) {
+    if (ignoredDirectories.has(entry.name)) continue
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...sourceFiles(path))
+    else if (entry.isFile() && sourceExtension(path)) files.push(path)
+  }
+  return files
+}
+
+function safeReadDirectory(directory: string) {
+  try {
+    return readdirSync(directory, { withFileTypes: true })
+  } catch (error) {
+    if ((error as { code?: string }).code === 'ENOENT') return []
+    throw error
+  }
+}
+
+function sourceExtension(path: string) {
+  return ['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(extname(path))
+}

--- a/tests/cloud-domain-services.test.ts
+++ b/tests/cloud-domain-services.test.ts
@@ -9,6 +9,8 @@ import {
   CloudQuotaService,
   CloudWorkflowService,
 } from '../apps/desktop/src/main/cloud/services/index.ts'
+import { CloudServiceError } from '../apps/desktop/src/main/cloud/cloud-service-error.ts'
+import type { ByokSecretMetadata, ByokSecretStore } from '../apps/desktop/src/main/cloud/byok-secret-store.ts'
 import type { CloudPrincipal } from '../apps/desktop/src/main/cloud/session-service.ts'
 
 const principal: CloudPrincipal = {
@@ -20,6 +22,35 @@ const principal: CloudPrincipal = {
   accountId: 'account-1',
   role: 'owner',
   authSource: 'local',
+}
+
+function metadata(providerId = 'anthropic'): ByokSecretMetadata {
+  return {
+    secretId: `sec_${providerId}`,
+    providerId,
+    status: 'active',
+    credentialKind: 'plaintext',
+    last4: '1234',
+    keyFingerprint: 'fp',
+    lastValidatedAt: null,
+    validationError: null,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  }
+}
+
+function byokStore(overrides: Partial<ByokSecretStore> = {}): ByokSecretStore {
+  return {
+    async listMetadata() { return [] },
+    async getMetadata() { return null },
+    async setSecret(input) { return metadata(input.providerId) },
+    async disableSecret(_input) { return metadata(_input.providerId) },
+    async recordValidation() { return null },
+    async activateWithoutValidation(input) { return metadata(input.providerId) },
+    async validateActiveSecret(input) { return metadata(input.providerId) },
+    async revealActiveSecret() { return 'plaintext-key' },
+    ...overrides,
+  }
 }
 
 test('cloud domain services expose testable seams without an HTTP server', async () => {
@@ -83,42 +114,15 @@ test('cloud domain services expose testable seams without an HTTP server', async
   })
 
   const byok = new CloudByokService({
-    async listByokSecrets() {
-      calls.push('byok.list')
-      return []
-    },
-    async getByokSecret() {
-      calls.push('byok.get')
-      return null
-    },
-    async setByokSecret() {
-      calls.push('byok.set')
-      return {
-        secretId: 'sec_1',
-        orgId: 'org-1',
-        providerId: 'anthropic',
-        status: 'active',
-        last4: '1234',
-        keyFingerprint: 'fp',
-        kmsRef: null,
-        lastValidatedAt: null,
-        validationError: null,
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      }
-    },
-    async validateByokSecret() {
-      calls.push('byok.validate')
-      return null
-    },
-    async overrideByokSecretValidation() {
-      calls.push('byok.override')
-      return null
-    },
-    async disableByokSecret() {
-      calls.push('byok.disable')
-      return null
-    },
+    ensurePrincipal: async (input) => input,
+    principalOrgId: (input) => input.orgId || input.tenantId,
+    byokSecrets: byokStore({
+      async listMetadata() {
+        calls.push('byok.list')
+        return []
+      },
+    }),
+    assertBillingAllowed: async () => {},
   })
 
   const billing = new CloudBillingService({
@@ -207,4 +211,124 @@ test('cloud domain services expose testable seams without an HTTP server', async
     'channel.deliveries',
     'workflow.list',
   ])
+})
+
+test('cloud BYOK service enforces storage, provider, KMS, billing, and audit boundaries', async () => {
+  const calls: unknown[] = []
+  const apiTokenPrincipal: CloudPrincipal = {
+    ...principal,
+    authSource: 'api_token',
+    tokenId: 'tok_admin',
+    tokenScopes: ['admin'],
+  }
+  const service = new CloudByokService({
+    ensurePrincipal: async (input) => {
+      calls.push('ensure')
+      return input
+    },
+    principalOrgId: (input) => input.orgId || input.tenantId,
+    byokSecrets: byokStore({
+      async setSecret(input) {
+        calls.push({
+          kind: 'setSecret',
+          orgId: input.orgId,
+          providerId: input.providerId,
+          kmsRef: input.kmsRef,
+          actor: input.actor,
+          createdByAccountId: input.createdByAccountId,
+        })
+        return metadata(input.providerId)
+      },
+    }),
+    byokPolicy: {
+      allowedProviderIds: ['anthropic'],
+      kmsRefs: {
+        enabled: true,
+        allowEnvRefs: false,
+        allowedPrefixes: ['gcp-sm://projects/test/secrets/'],
+      },
+      checkEntitlement: async (input) => {
+        calls.push({ kind: 'entitlement', orgId: input.orgId, providerId: input.providerId })
+        return { allowed: true }
+      },
+    },
+    assertBillingAllowed: async (input) => {
+      calls.push({ kind: 'billing', orgId: input.orgId, action: input.action, providerId: input.providerId })
+    },
+  })
+
+  await assert.rejects(
+    () => new CloudByokService({
+      ensurePrincipal: async (input) => input,
+      principalOrgId: (input) => input.orgId || input.tenantId,
+      byokSecrets: null,
+      assertBillingAllowed: async () => {},
+    }).listSecrets(principal),
+    /BYOK secret storage is not configured/,
+  )
+  await assert.rejects(
+    () => service.setSecret(apiTokenPrincipal, { providerId: 'openai', plaintext: 'sk-test' }),
+    /not enabled for BYOK/,
+  )
+  await assert.rejects(
+    () => service.setSecret(apiTokenPrincipal, { providerId: 'anthropic', kmsRef: 'env:ANTHROPIC_API_KEY' }),
+    /Environment-backed BYOK references are not enabled/,
+  )
+  await assert.rejects(
+    () => service.setSecret(apiTokenPrincipal, { providerId: 'anthropic', kmsRef: 'aws-sm://secret' }),
+    /KMS-backed BYOK reference is not allowed/,
+  )
+
+  const result = await service.setSecret(apiTokenPrincipal, {
+    providerId: 'Anthropic',
+    kmsRef: 'gcp-sm://projects/test/secrets/anthropic-key',
+  })
+
+  assert.equal(result.providerId, 'anthropic')
+  assert.deepEqual(calls, [
+    'ensure',
+    'ensure',
+    'ensure',
+    'ensure',
+    { kind: 'billing', orgId: 'org-1', action: 'byok.provider', providerId: 'anthropic' },
+    { kind: 'entitlement', orgId: 'org-1', providerId: 'anthropic' },
+    {
+      kind: 'setSecret',
+      orgId: 'org-1',
+      providerId: 'anthropic',
+      kmsRef: 'gcp-sm://projects/test/secrets/anthropic-key',
+      actor: {
+        actorType: 'api_token',
+        actorId: 'tok_admin',
+        accountId: 'account-1',
+      },
+      createdByAccountId: 'account-1',
+    },
+  ])
+})
+
+test('cloud BYOK service rejects non-admin principals before billing or mutation', async () => {
+  const calls: string[] = []
+  const service = new CloudByokService({
+    ensurePrincipal: async (input) => input,
+    principalOrgId: (input) => input.orgId || input.tenantId,
+    byokSecrets: byokStore({
+      async setSecret(input) {
+        calls.push(`set:${input.providerId}`)
+        return metadata(input.providerId)
+      },
+    }),
+    assertBillingAllowed: async () => {
+      calls.push('billing')
+    },
+  })
+  const member: CloudPrincipal = { ...principal, authSource: 'user', role: 'member' }
+
+  await assert.rejects(
+    () => service.setSecret(member, { providerId: 'anthropic', plaintext: 'sk-test' }),
+    (error) => error instanceof CloudServiceError
+      && error.status === 403
+      && /BYOK credential administration/.test(error.message),
+  )
+  assert.deepEqual(calls, [])
 })

--- a/tests/cloud-session-projection-contract.test.ts
+++ b/tests/cloud-session-projection-contract.test.ts
@@ -2,7 +2,12 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  CLOUD_PROJECTED_SESSION_EVENT_TYPES,
+  CLOUD_SESSION_EVENT_CONTRACT,
   CLOUD_SESSION_EVENT_TYPES,
+  CLOUD_SESSION_PROJECTION_CONTRACT_VERSION,
+  cloudSessionEventContractFor,
+  cloudSessionEventHasFacet,
   cloudSessionViewToSessionView,
   createCloudSessionProjectionView,
   emptySessionView,
@@ -32,6 +37,82 @@ function event(sequence: number, type: string, payload: Record<string, unknown> 
     createdAt: `2026-05-28T10:${String(sequence).padStart(2, '0')}:00.000Z`,
   }
 }
+
+function minimalPayloadFor(type: string): Record<string, unknown> {
+  switch (type) {
+    case 'session.created':
+      return { title: 'Contract session' }
+    case 'session.imported':
+      return {
+        sourceFingerprint: 'sha256:source',
+        importedAt: '2026-05-28T10:00:00.000Z',
+        itemCounts: { messages: 1 },
+      }
+    case 'session.project_source.bound':
+      return { projectSource: { kind: 'snapshot', snapshotId: 'snapshot-1' } }
+    case 'prompt.submitted':
+      return { messageId: 'user-1', text: 'run checks' }
+    case 'assistant.message':
+      return { messageId: 'assistant-1', content: 'ok' }
+    case 'tool.call':
+      return { id: 'tool-1', name: 'bash', status: 'running' }
+    case 'task.run':
+      return { id: 'task-1', title: 'Task', status: 'running' }
+    case 'permission.requested':
+      return { permissionId: 'permission-1', tool: 'bash', description: 'Approve' }
+    case 'permission.resolved':
+      return { permissionId: 'permission-1', allowed: true }
+    case 'question.asked':
+      return { requestId: 'question-1', questions: [{ question: 'Continue?' }] }
+    case 'question.resolved':
+      return { requestId: 'question-1', answers: ['Yes'] }
+    case 'todos.updated':
+      return { todos: [{ id: 'todo-1', content: 'Ship it' }] }
+    case 'cost.updated':
+      return { cost: 0.01, tokens: { input: 1, output: 2 } }
+    case 'artifact.created':
+      return { artifactId: 'artifact-1', filename: 'result.txt' }
+    case 'session.status':
+      return { statusType: 'running' }
+    case 'runtime.error':
+      return { message: 'Runtime failed' }
+    default:
+      return {}
+  }
+}
+
+test('cloud session event vocabulary is versioned and reducer-backed', () => {
+  assert.equal(CLOUD_SESSION_PROJECTION_CONTRACT_VERSION, 1)
+  assert.deepEqual(CLOUD_SESSION_EVENT_CONTRACT.map((entry) => entry.type), [...CLOUD_SESSION_EVENT_TYPES])
+  assert.deepEqual(
+    CLOUD_SESSION_EVENT_CONTRACT.filter((entry) => entry.projected).map((entry) => entry.type),
+    [...CLOUD_PROJECTED_SESSION_EVENT_TYPES],
+  )
+
+  for (const entry of CLOUD_SESSION_EVENT_CONTRACT) {
+    assert.equal(entry.description.length > 0, true, `${entry.type} must be documented`)
+    assert.equal(entry.facets.length > 0, true, `${entry.type} must declare projection facets`)
+    assert.equal(entry.consumers.length > 0, true, `${entry.type} must declare consumers`)
+    assert.equal(entry.producers.length > 0, true, `${entry.type} must declare producers`)
+    assert.deepEqual(cloudSessionEventContractFor(entry.type), entry)
+  }
+
+  const session = baseSession()
+  for (const type of CLOUD_PROJECTED_SESSION_EVENT_TYPES) {
+    const reduced = reduceCloudSessionProjectionEvent(
+      session,
+      createCloudSessionProjectionView(session),
+      event(1, type, minimalPayloadFor(type)),
+    )
+    assert.equal(reduced.updatedAt, '2026-05-28T10:01:00.000Z', `${type} must be handled by the shared reducer`)
+  }
+
+  assert.equal(cloudSessionEventHasFacet('permission.requested', 'approvals'), true)
+  assert.equal(cloudSessionEventHasFacet('question.asked', 'questions'), true)
+  assert.equal(cloudSessionEventHasFacet('artifact.created', 'artifacts'), true)
+  assert.equal(cloudSessionEventHasFacet('assistant.message', 'messages'), true)
+  assert.equal(cloudSessionEventHasFacet('snapshot.required', 'control'), true)
+})
 
 test('shared cloud projection reducer feeds desktop SessionView contract', () => {
   const session = baseSession()
@@ -90,6 +171,35 @@ test('shared cloud projection reducer feeds desktop SessionView contract', () =>
   assert.equal(sessionView.pendingApprovals[0]?.id, 'permission-1')
   assert.equal(sessionView.isAwaitingPermission, true)
   assert.equal(sessionView.isGenerating, false)
+})
+
+test('assistant message events update existing streamed content by message id', () => {
+  const session = baseSession()
+  let view = createCloudSessionProjectionView(session)
+  view = reduceCloudSessionProjectionEvent(session, view, event(1, 'assistant.message', {
+    messageId: 'assistant-stream-1',
+    content: 'Hel',
+  }))
+  view = reduceCloudSessionProjectionEvent(session, view, event(2, 'assistant.message', {
+    messageId: 'assistant-stream-1',
+    content: 'Hello',
+  }))
+
+  assert.equal(view.messages.length, 1)
+  assert.equal(view.messages[0]?.content, 'Hello')
+  assert.equal(view.messages[0]?.createdAt, '2026-05-28T10:02:00.000Z')
+
+  const sessionView = cloudSessionViewToSessionView({
+    session,
+    projection: {
+      tenantId: session.tenantId,
+      sessionId: session.sessionId,
+      sequence: 2,
+      view,
+      updatedAt: '2026-05-28T10:02:00.000Z',
+    },
+  })
+  assert.deepEqual(sessionView.messages.map((message) => message.content), ['Hello'])
 })
 
 test('cloud projection reducer covers durable runtime event state transitions', () => {


### PR DESCRIPTION
Closes #602

## Summary
- add a versioned shared cloud session event/projection contract in `@open-cowork/shared`
- route projection event type exports through the shared contract and fix streamed assistant message upserts by message id
- tie gateway rendered event coverage to the canonical channel-renderable event metadata
- extract BYOK management orchestration into `CloudByokService` and leave `CloudSessionService` as a facade
- add modularity boundary tests and projection contract docs

## Validation
- `pnpm build:shared`
- `node scripts/run-node-tests.mjs tests/cloud-session-projection-contract.test.ts tests/opencode-sdk-event-projection.test.ts tests/cloud-control-plane-domain-contracts.test.ts tests/cloud-control-plane-store-contracts.test.ts tests/cloud-control-plane-modularity.test.ts tests/cloud-domain-services.test.ts`
- `pnpm --filter @open-cowork/gateway build`
- `pnpm --filter @open-cowork/gateway test`
- `pnpm typecheck`
- `pnpm lint`
- `python3 -m mkdocs build --strict`
- `pnpm test`
- `pnpm test:cloud-continuation`
- `node scripts/run-node-tests.mjs tests/cloud-control-plane-domain-contracts.test.ts tests/cloud-control-plane-store-contracts.test.ts tests/session-history-projector.test.ts`
- `pnpm perf:check`
- `git diff --check`