### PR TITLE
Polish cloud client SDK contract

### DIFF
--- a/docs/cloud-client.md
+++ b/docs/cloud-client.md
@@ -22,6 +22,9 @@ this package instead of importing Cloud control-plane internals.
   deliveries.
 - While Open Cowork is pre-1.0, typed API changes can happen in minor releases.
   Breaking changes after `1.0.0` require a major version.
+- Modules outside the documented entry points are internal. Do not import
+  Desktop Cloud server files, control-plane stores, runtime adapters, or source
+  files from first-party clients or downstream deployments.
 
 ## Entry Points
 
@@ -48,20 +51,47 @@ The package exports only compiled `dist` entry points:
 - `@open-cowork/cloud-client/domains/transport`
 - `@open-cowork/cloud-client/domains/workflows`
 
-## Node Or Daemon Client
+## Desktop Bearer Client
 
 ```ts
 import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
 
 const client = createHttpSseCloudTransportAdapter({
   baseUrl: 'https://cowork.example.com',
-  headers: { authorization: `Bearer ${token}` },
+  headers: { authorization: `Bearer ${oidcAccessToken}` },
   requestTimeoutMs: 30_000,
 })
 
 const session = await client.createSession({ profileName: 'default' })
 await client.promptSession(session.session.sessionId, { text: 'Run the release checks' })
 ```
+
+Desktop should create this client in the main process. The renderer should
+receive workspace views and status, not refresh tokens, provider keys, or raw
+cloud credentials.
+
+## Gateway Service-Token Client
+
+```ts
+import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
+
+const gatewayClient = createHttpSseCloudTransportAdapter({
+  baseUrl: 'https://cowork.example.com',
+  headers: { authorization: `Bearer ${gatewayServiceToken}` },
+  requestTimeoutMs: 30_000,
+})
+
+gatewayClient.subscribeChannelDeliveries?.({
+  claimedBy: 'gateway-shard-a',
+  onDelivery(delivery) {
+    deliverToChannel(delivery)
+  },
+})
+```
+
+The service token authenticates the gateway process. The channel actor still
+needs to be resolved through Cloud identity/RBAC APIs before the gateway can
+prompt, approve, answer questions, or mutate channel state.
 
 ## Browser Client
 
@@ -73,9 +103,24 @@ const client = createHttpSseCloudTransportAdapter({
 })
 ```
 
+Browser clients use cookie auth and CSRF for mutating requests. Operator-only
+APIs should remain behind operator auth or private networking and must not be
+called from ordinary browser workbench code.
+
+## Auth Modes
+
+| Mode | Caller | Transport |
+| --- | --- | --- |
+| Cookie | Cloud Web browser | `credentials: 'include'` plus CSRF token |
+| Bearer | Desktop main process | `Authorization: Bearer <OIDC access token>` |
+| Service token | Gateway daemon or automation | `Authorization: Bearer <scoped API token>` |
+| Operator | Deployment/operator tooling only | Operator token or private network gate |
+
 ## Timeouts And Cancellation
 
-`requestTimeoutMs` defaults to 30 seconds. Use `signal` to cancel in-flight HTTP
+`requestTimeoutMs` defaults to 30 seconds and is clamped to
+`100ms..120000ms`. `0` disables HTTP timeouts and should only be used in tests
+or explicitly controlled deployments. Use `signal` to cancel in-flight HTTP
 requests and SSE subscriptions:
 
 ```ts
@@ -89,6 +134,9 @@ const client = createHttpSseCloudTransportAdapter({
 controller.abort()
 ```
 
+SSE subscriptions are long-lived streams and are not governed by
+`requestTimeoutMs`.
+
 The client does not retry automatically. Callers should choose retries per
 operation because mutating Cloud commands are durable and may be idempotency
 aware on the server.
@@ -98,3 +146,68 @@ aware on the server.
 Bearer-token clients use fetch-based SSE so the `Authorization` header is sent
 with stream requests. Cookie-authenticated browser clients use `EventSource`
 when no custom headers are configured.
+
+SSE subscription URLs accept an `afterSequence` cursor. Clients should persist
+the highest processed sequence, resume with `afterSequence` after reconnect or
+process restart, and close subscriptions when the workspace/session/channel
+binding is no longer active.
+
+```ts
+import {
+  createHttpSseCloudTransportAdapter,
+  isCloudTransportError,
+} from '@open-cowork/cloud-client'
+
+const subscription = client.subscribeSessionEvents('session-id', {
+  afterSequence: lastSeenSequence,
+  onEvent(event) {
+    lastSeenSequence = Math.max(lastSeenSequence, event.sequence)
+  },
+  onError(error) {
+    if (isCloudTransportError(error) && error.kind === 'unauthorized') {
+      requestReauth()
+    }
+  },
+})
+
+subscription.close()
+```
+
+Reconnect and backoff policy belong to the caller because Desktop, Web, and
+Gateway have different UI and delivery semantics.
+
+## Error Taxonomy
+
+The client exports `CloudTransportError`, `CloudTransportErrorKind`, and
+`isCloudTransportError`. Clients should branch on typed fields instead of
+parsing strings.
+
+| Kind | Meaning |
+| --- | --- |
+| `unauthorized` | HTTP 401, expired or missing auth |
+| `forbidden` | HTTP 403, membership or policy denial |
+| `payment_required` | HTTP 402, subscription or entitlement gate |
+| `not_found` | HTTP 404 |
+| `conflict` | HTTP 409, stale projection or command conflict |
+| `rate_limited` | HTTP 429, `retryAfter` may be set |
+| `server` | HTTP 5xx |
+| `http` | Other non-2xx HTTP status |
+| `timeout` | Client request timeout |
+| `abort` | Caller cancellation |
+| `parse` | Invalid JSON response or SSE payload |
+| `sse` | EventSource/fetch-SSE startup or stream failure |
+| `network` | Fetch/network failure before an HTTP response |
+| `request` | Invalid client request construction |
+
+## Publish Checklist
+
+- Build shared first: `pnpm --filter @open-cowork/shared build`.
+- Build the SDK: `pnpm --filter @open-cowork/cloud-client build`.
+- Run transport and package-boundary tests.
+- Confirm package exports only the documented public entry points.
+- Update README and this page when auth, timeout, SSE, or error behavior
+  changes.
+- Keep examples free of private deployment URLs, org ids, tokens, provider keys,
+  and project-specific values.
+- Pre-1.0 typed breaks must be called out in release notes. After `1.0.0`,
+  breaking API changes require a SemVer major version.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:standalone-gateway": "pnpm --filter @open-cowork/standalone-gateway build",
     "build:website": "pnpm --filter @open-cowork/website build",
     "build:mcps": "pnpm --filter=./mcps/* build",
-    "build:packages": "pnpm --filter=./packages/* build",
+    "build:packages": "pnpm --workspace-concurrency=1 --filter=./packages/* build",
     "build:shared": "pnpm --filter @open-cowork/shared build",
     "docs:build": "node scripts/docs-build.mjs build",
     "docs:serve": "node scripts/docs-build.mjs serve",

--- a/packages/cloud-client/README.md
+++ b/packages/cloud-client/README.md
@@ -31,6 +31,10 @@ The package must not import Electron, Desktop main-process modules,
 control-plane stores, or `@opencode-ai/sdk`. Its only Open Cowork package
 dependency is the public `@open-cowork/shared` wire-type package.
 
+Modules outside the entry points above are internal implementation details.
+First-party clients and downstream deployers should not import source files,
+Desktop Cloud server files, control-plane stores, or runtime adapters directly.
+
 ## Basic Usage
 
 ```ts
@@ -46,6 +50,47 @@ const session = await client.createSession({ profileName: 'default' })
 await client.promptSession(session.session.sessionId, { text: 'Run the checks' })
 ```
 
+## Desktop Bearer Usage
+
+Desktop clients authenticate with an OIDC access token or scoped API token owned
+by the Desktop main process. The renderer must not receive refresh tokens or raw
+cloud secrets.
+
+```ts
+import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
+
+const desktopClient = createHttpSseCloudTransportAdapter({
+  baseUrl: 'https://cowork.example.com',
+  headers: { authorization: `Bearer ${accessToken}` },
+  requestTimeoutMs: 30_000,
+  signal: desktopAbortController.signal,
+})
+```
+
+## Gateway Service-Token Usage
+
+Gateway daemons authenticate with a scoped service token. The gateway token only
+authenticates the daemon; inbound channel users still need to be resolved
+through Cloud identity/RBAC APIs before prompts, approvals, or deliveries are
+accepted.
+
+```ts
+import { createHttpSseCloudTransportAdapter } from '@open-cowork/cloud-client'
+
+const gatewayClient = createHttpSseCloudTransportAdapter({
+  baseUrl: 'https://cowork.example.com',
+  headers: { authorization: `Bearer ${gatewayServiceToken}` },
+  requestTimeoutMs: 30_000,
+})
+
+gatewayClient.subscribeChannelDeliveries?.({
+  claimedBy: 'gateway-us-central1-a',
+  onDelivery(delivery) {
+    queueDeliveryForProvider(delivery)
+  },
+})
+```
+
 ## Browser Cookie Usage
 
 ```ts
@@ -58,17 +103,106 @@ const client = createHttpSseCloudTransportAdapter({
 })
 ```
 
+Browser clients use cookie auth plus CSRF protection for mutating requests.
+Operator-only APIs still require server-side authorization; do not expose admin
+or operator tokens to browser JavaScript.
+
+## Auth Modes
+
+| Mode | Caller | Transport |
+| --- | --- | --- |
+| Cookie | Cloud Web in browser | `credentials: 'include'` plus CSRF token |
+| Bearer | Desktop main process | `Authorization: Bearer <OIDC access token>` |
+| Service token | Gateway daemon and automation | `Authorization: Bearer <scoped API token>` |
+| Operator | Deployment/operator tooling only | Operator token or private network gate |
+
+Operator APIs are not general product APIs. Downstream deployments should expose
+them only behind private networking, operator authentication, or equivalent
+administrative controls.
+
 ## Timeouts, Cancellation, And Retries
 
-- `requestTimeoutMs` defaults to 30 seconds and is clamped to a safe maximum.
+- `requestTimeoutMs` defaults to 30 seconds.
+- Values are clamped to `100ms..120000ms`; `0` disables HTTP timeouts and should
+  be reserved for tests or explicitly controlled deployments.
 - `signal` cancels all HTTP requests and SSE subscriptions created from the
-  client.
+  client. Pass a new client-scoped `AbortController` when a workspace, account,
+  or daemon lifecycle ends.
+- SSE subscriptions are long-lived streams and are not governed by
+  `requestTimeoutMs`.
 - The client does not retry automatically. Callers should decide retries per
   command because some mutating operations are intentionally durable and
   idempotency-aware on the server.
+
+All non-SSE HTTP requests are bounded by the timeout unless timeout is explicitly
+disabled. Fetch, parse, timeout, abort, and HTTP failures are surfaced as
+`CloudTransportError` instances.
 
 ## SSE Authentication
 
 When `headers` are configured, SSE subscriptions use fetch-based SSE so bearer
 tokens are sent with the stream request. Without headers, the browser
 `EventSource` path is used for cookie-authenticated deployments.
+
+SSE URLs accept `afterSequence` cursors. Clients should persist the highest
+processed sequence and resume with `afterSequence` after reconnect or process
+restart. The returned subscription has a `close()` method; callers must close it
+when the workspace/session/gateway binding is no longer active. Reconnect policy
+belongs to the caller because Desktop, Web, and Gateway have different UI and
+delivery semantics.
+
+```ts
+import { isCloudTransportError } from '@open-cowork/cloud-client'
+
+const subscription = client.subscribeSessionEvents('session-id', {
+  afterSequence: lastSeenSequence,
+  onEvent(event) {
+    lastSeenSequence = Math.max(lastSeenSequence, event.sequence)
+  },
+  onError(error) {
+    if (isCloudTransportError(error) && error.kind === 'unauthorized') {
+      requestReauth()
+    }
+  },
+})
+
+subscription.close()
+```
+
+## Error Taxonomy
+
+The client exports `CloudTransportError`, `CloudTransportErrorKind`, and
+`isCloudTransportError`. Callers should branch on `kind`, `status`, and `code`
+rather than parsing human-readable messages.
+
+| Kind | Typical source |
+| --- | --- |
+| `unauthorized` | HTTP 401, expired or missing auth |
+| `forbidden` | HTTP 403, membership or policy denial |
+| `payment_required` | HTTP 402, inactive subscription or entitlement gate |
+| `not_found` | HTTP 404 |
+| `conflict` | HTTP 409, stale projection or command conflict |
+| `rate_limited` | HTTP 429, optional `retryAfter` available |
+| `server` | HTTP 5xx |
+| `http` | Other non-2xx HTTP status |
+| `timeout` | Client request timeout |
+| `abort` | Caller cancellation |
+| `parse` | Invalid JSON response or SSE payload |
+| `sse` | EventSource/fetch-SSE startup or stream failure |
+| `network` | Fetch/network failure before an HTTP response |
+| `request` | Invalid client request construction |
+
+## Release Checklist
+
+Before publishing or treating a release as a supported SDK update:
+
+- Run `pnpm --filter @open-cowork/shared build`.
+- Run `pnpm --filter @open-cowork/cloud-client build`.
+- Run the cloud transport and boundary tests.
+- Confirm `packages/cloud-client/package.json` exports only public entry points.
+- Confirm README and `docs/cloud-client.md` document new auth, timeout, SSE, and
+  error behavior.
+- Do not include private deployment URLs, tokens, org ids, or provider keys in
+  examples or fixtures.
+- For pre-1.0 releases, document typed API breaks in release notes. After
+  `1.0.0`, follow SemVer major-version rules for breaking changes.

--- a/packages/cloud-client/src/adapter.ts
+++ b/packages/cloud-client/src/adapter.ts
@@ -499,6 +499,7 @@ export type CloudTransportFetch = (
   ok: boolean
   status: number
   text(): Promise<string>
+  headers?: { get(name: string): string | null }
   body?: ReadableStream<Uint8Array> | null
 }>
 
@@ -769,6 +770,64 @@ export type CloudTransportAdapter = {
 
 type ApiErrorPayload = {
   error?: string
+  code?: string
+}
+
+export type CloudTransportErrorKind =
+  | 'unauthorized'
+  | 'forbidden'
+  | 'payment_required'
+  | 'not_found'
+  | 'conflict'
+  | 'rate_limited'
+  | 'server'
+  | 'http'
+  | 'network'
+  | 'abort'
+  | 'timeout'
+  | 'parse'
+  | 'sse'
+  | 'request'
+
+export type CloudTransportErrorOptions = {
+  kind: CloudTransportErrorKind
+  message: string
+  status?: number
+  method?: string
+  url?: string
+  retryAfter?: string | null
+  code?: string | null
+  body?: unknown
+  cause?: unknown
+}
+
+export class CloudTransportError extends Error {
+  readonly kind: CloudTransportErrorKind
+  readonly status?: number
+  readonly method?: string
+  readonly url?: string
+  readonly retryAfter?: string | null
+  readonly code?: string | null
+  readonly body?: unknown
+  readonly cause?: unknown
+
+  constructor(options: CloudTransportErrorOptions) {
+    super(options.message)
+    this.name = 'CloudTransportError'
+    this.kind = options.kind
+    this.status = options.status
+    this.method = options.method
+    this.url = options.url
+    this.retryAfter = options.retryAfter
+    this.code = options.code
+    this.body = options.body
+    this.cause = options.cause
+  }
+}
+
+export function isCloudTransportError(value: unknown): value is CloudTransportError {
+  return value instanceof CloudTransportError
+    || Boolean(value && typeof value === 'object' && (value as { name?: unknown }).name === 'CloudTransportError')
 }
 
 function normalizeBaseUrl(baseUrl: string | undefined) {
@@ -945,18 +1004,47 @@ function subscribeEventSource(
     signal?: AbortSignal
   },
 ) {
-  const source = new EventSourceImpl(url, {
-    withCredentials: input.credentials === 'include',
-  })
+  let source: InstanceType<CloudTransportEventSource>
+  try {
+    source = new EventSourceImpl(url, {
+      withCredentials: input.credentials === 'include',
+    })
+  } catch (error) {
+    throw new CloudTransportError({
+      kind: 'sse',
+      message: `Cloud transport EventSource subscription failed to start: ${url}`,
+      url,
+      cause: error,
+    })
+  }
   let closed = false
   const onEvent = (event: { data: string }) => {
-    const parsed = JSON.parse(event.data) as CloudTransportWorkspaceEvent
-    input.onEvent(parsed)
+    try {
+      const parsed = JSON.parse(event.data) as CloudTransportWorkspaceEvent
+      input.onEvent(parsed)
+    } catch (error) {
+      if (!closed) {
+        input.onError?.(new CloudTransportError({
+          kind: 'parse',
+          message: `Cloud transport EventSource payload was not valid JSON: ${url}`,
+          url,
+          body: event.data,
+          cause: error,
+        }))
+      }
+    }
   }
   source.onmessage = onEvent
   for (const type of CLOUD_SESSION_EVENT_TYPES) source.addEventListener(type, onEvent)
   source.onerror = (error) => {
-    if (!closed) input.onError?.(error)
+    if (!closed) {
+      input.onError?.(new CloudTransportError({
+        kind: 'sse',
+        message: `Cloud transport EventSource subscription failed: ${url}`,
+        url,
+        cause: error,
+      }))
+    }
   }
   const abort = () => {
     closed = true
@@ -992,7 +1080,19 @@ function subscribeFetchSse(
 
   const dispatch = (dataLines: string[]) => {
     if (dataLines.length === 0) return
-    const parsed = JSON.parse(dataLines.join('\n')) as CloudTransportWorkspaceEvent
+    const payload = dataLines.join('\n')
+    let parsed: CloudTransportWorkspaceEvent
+    try {
+      parsed = JSON.parse(payload) as CloudTransportWorkspaceEvent
+    } catch (error) {
+      throw new CloudTransportError({
+        kind: 'parse',
+        message: `Cloud transport SSE payload was not valid JSON: ${url}`,
+        url,
+        body: payload,
+        cause: error,
+      })
+    }
     input.onEvent(parsed)
   }
 
@@ -1008,10 +1108,27 @@ function subscribeFetchSse(
         signal: controller.signal,
       })
       if (!response.ok) {
-        throw new Error(`Cloud transport SSE subscription failed with HTTP ${response.status}: ${url}`)
+        const text = await response.text()
+        const body = parseApiErrorPayload(text)
+        throw new CloudTransportError({
+          kind: cloudTransportErrorKindForStatus(response.status),
+          message: apiErrorMessage(body, `Cloud transport SSE subscription failed with HTTP ${response.status}: ${url}`),
+          method: 'GET',
+          url,
+          status: response.status,
+          retryAfter: responseHeader(response, 'retry-after'),
+          code: apiErrorCode(body),
+          body,
+        })
       }
       if (!response.body) {
-        throw new Error('Cloud transport SSE response did not include a readable stream.')
+        throw new CloudTransportError({
+          kind: 'sse',
+          message: `Cloud transport SSE response did not include a readable stream: ${url}`,
+          method: 'GET',
+          url,
+          status: response.status,
+        })
       }
 
       const reader = response.body.getReader()
@@ -1057,7 +1174,14 @@ function subscribeFetchSse(
       detachAbortSignal()
     }
   })().catch((error) => {
-    if (!closed) input.onError?.(error)
+    if (!closed) {
+      input.onError?.(cloudTransportErrorFromUnknown(error, {
+        kind: 'sse',
+        message: `Cloud transport SSE subscription failed: ${url}`,
+        method: 'GET',
+        url,
+      }))
+    }
   })
 
   return {
@@ -1095,9 +1219,69 @@ function normalizeRequestTimeoutMs(value: number | null | undefined) {
 
 function cloudApiRequestUrl(baseUrl: string, path: string) {
   if (!path.startsWith('/api/')) {
-    throw new Error('Cloud transport path must target an API route.')
+    throw new CloudTransportError({
+      kind: 'request',
+      message: 'Cloud transport path must target an API route.',
+      url: path,
+    })
   }
   return `${baseUrl}${path}`
+}
+
+function cloudTransportErrorKindForStatus(status: number): CloudTransportErrorKind {
+  if (status === 401) return 'unauthorized'
+  if (status === 403) return 'forbidden'
+  if (status === 402) return 'payment_required'
+  if (status === 404) return 'not_found'
+  if (status === 409) return 'conflict'
+  if (status === 429) return 'rate_limited'
+  if (status >= 500) return 'server'
+  return 'http'
+}
+
+function responseHeader(response: Awaited<ReturnType<CloudTransportFetch>>, name: string) {
+  try {
+    return response.headers?.get(name) || response.headers?.get(name.toLowerCase()) || null
+  } catch {
+    return null
+  }
+}
+
+function errorMessageFromUnknown(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === 'string' && error.trim()) return error
+  return fallback
+}
+
+function cloudTransportErrorFromUnknown(error: unknown, fallback: CloudTransportErrorOptions) {
+  if (isCloudTransportError(error)) return error
+  return new CloudTransportError({
+    ...fallback,
+    cause: error,
+    message: fallback.message || errorMessageFromUnknown(error, 'Cloud transport request failed.'),
+  })
+}
+
+function parseApiErrorPayload(text: string): ApiErrorPayload | string | null {
+  if (!text) return null
+  try {
+    const parsed = JSON.parse(text) as unknown
+    return asRecord(parsed) as ApiErrorPayload
+  } catch {
+    return text
+  }
+}
+
+function apiErrorMessage(body: ApiErrorPayload | string | null, fallback: string) {
+  if (typeof body === 'string' && body.trim()) return body
+  if (body && typeof body !== 'string' && typeof body.error === 'string' && body.error.trim()) return body.error
+  return fallback
+}
+
+function apiErrorCode(body: ApiErrorPayload | string | null) {
+  return body && typeof body !== 'string' && typeof body.code === 'string' && body.code.trim()
+    ? body.code
+    : null
 }
 
 function attachAbortSignal(
@@ -1118,13 +1302,51 @@ function attachAbortSignal(
   return () => signal.removeEventListener('abort', abort)
 }
 
-async function parseJson<T>(response: Awaited<ReturnType<CloudTransportFetch>>, url: string): Promise<T> {
-  const text = await response.text()
-  const body = text ? JSON.parse(text) as T & ApiErrorPayload : {} as T & ApiErrorPayload
-  if (!response.ok) {
-    throw new Error(body.error || `Cloud transport request failed with HTTP ${response.status}: ${url}`)
+async function parseJson<T>(
+  response: Awaited<ReturnType<CloudTransportFetch>>,
+  url: string,
+  method: string,
+): Promise<T> {
+  let text: string
+  try {
+    text = await response.text()
+  } catch (error) {
+    throw new CloudTransportError({
+      kind: 'network',
+      message: `Cloud transport failed to read response body: ${method} ${url}`,
+      method,
+      url,
+      status: response.status,
+      cause: error,
+    })
   }
-  return body
+  if (!response.ok) {
+    const body = parseApiErrorPayload(text)
+    throw new CloudTransportError({
+      kind: cloudTransportErrorKindForStatus(response.status),
+      message: apiErrorMessage(body, `Cloud transport request failed with HTTP ${response.status}: ${method} ${url}`),
+      method,
+      url,
+      status: response.status,
+      retryAfter: responseHeader(response, 'retry-after'),
+      code: apiErrorCode(body),
+      body,
+    })
+  }
+  if (!text) return {} as T
+  try {
+    return JSON.parse(text) as T
+  } catch (error) {
+    throw new CloudTransportError({
+      kind: 'parse',
+      message: `Cloud transport response was not valid JSON: ${method} ${url}`,
+      method,
+      url,
+      status: response.status,
+      body: text,
+      cause: error,
+    })
+  }
 }
 
 export function createHttpSseCloudTransportAdapter(
@@ -1156,9 +1378,20 @@ export function createHttpSseCloudTransportAdapter(
     const requestUrl = cloudApiRequestUrl(baseUrl, path)
     const controller = new AbortController()
     const detachAbortSignal = attachAbortSignal(controller, options.signal)
+    let timedOut = false
     const timeout = requestTimeoutMs > 0
-      ? setTimeout(() => controller.abort(), requestTimeoutMs)
+      ? setTimeout(() => {
+        timedOut = true
+        controller.abort(new CloudTransportError({
+          kind: 'timeout',
+          message: `Cloud transport request timed out after ${requestTimeoutMs}ms: ${method} ${path}`,
+          method,
+          url: requestUrl,
+        }))
+      }, requestTimeoutMs)
       : null
+    const timeoutHandle = timeout as unknown as { unref?: () => void } | null
+    timeoutHandle?.unref?.()
     try {
       // This transport intentionally sends authenticated cloud API payloads, including
       // user-selected artifact uploads that callers validate and authorize upstream.
@@ -1170,7 +1403,34 @@ export function createHttpSseCloudTransportAdapter(
         credentials: options.credentials,
         signal: controller.signal,
       })
-      return parseJson<T>(response, path)
+      return parseJson<T>(response, requestUrl, method)
+    } catch (error) {
+      if (isCloudTransportError(error)) throw error
+      if (timedOut) {
+        throw new CloudTransportError({
+          kind: 'timeout',
+          message: `Cloud transport request timed out after ${requestTimeoutMs}ms: ${method} ${path}`,
+          method,
+          url: requestUrl,
+          cause: error,
+        })
+      }
+      if (options.signal?.aborted || controller.signal.aborted) {
+        throw new CloudTransportError({
+          kind: 'abort',
+          message: `Cloud transport request was aborted: ${method} ${path}`,
+          method,
+          url: requestUrl,
+          cause: error,
+        })
+      }
+      throw new CloudTransportError({
+        kind: 'network',
+        message: `Cloud transport network request failed: ${method} ${path}`,
+        method,
+        url: requestUrl,
+        cause: error,
+      })
     } finally {
       if (timeout) clearTimeout(timeout)
       detachAbortSignal()

--- a/packages/cloud-client/src/domains/transport.ts
+++ b/packages/cloud-client/src/domains/transport.ts
@@ -1,10 +1,17 @@
 export type {
   CloudTransportAdapter,
   CloudTransportAdapterOptions,
+  CloudTransportErrorKind,
+  CloudTransportErrorOptions,
   CloudTransportEventSource,
   CloudTransportFetch,
   CloudTransportResponse,
   CloudTransportSessionEvent,
   CloudTransportSubscription,
   CloudTransportWorkspaceEvent,
+} from '../adapter.js'
+
+export {
+  CloudTransportError,
+  isCloudTransportError,
 } from '../adapter.js'

--- a/tests/cloud-client-boundaries.test.ts
+++ b/tests/cloud-client-boundaries.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { extname, join, relative } from 'node:path'
 
 test('cloud client package is standalone and desktop transport is a compatibility re-export', () => {
   const root = process.cwd()
@@ -65,6 +65,45 @@ test('cloud client package is standalone and desktop transport is a compatibilit
     assert.match(document, /requestTimeoutMs/i)
     assert.match(document, /signal/i)
     assert.match(document, /does not retry automatically/i)
+    assert.match(document, /CloudTransportError|error taxonomy/i)
+    assert.match(document, /service-token|Gateway/i)
+    assert.match(document, /operator/i)
+    assert.match(document, /publish checklist|release checklist/i)
+  }
+})
+
+test('first-party client surfaces stay on public cloud-client/shared boundaries', () => {
+  const root = process.cwd()
+  const clientRoots = [
+    'apps/desktop/src/preload',
+    'apps/desktop/src/renderer',
+    'apps/gateway/src',
+    'apps/website/src',
+    'packages/cloud-client/src',
+  ]
+  const forbidden = [
+    /@opencode-ai\/sdk/,
+    /apps\/desktop\/src\/main\/cloud\/(?:app|http-server|session-service|control-plane-store|postgres-control-plane-store|in-memory-control-plane-store|runtime-adapter|opencode-runtime-adapter|secret-adapter|object-store|worker)/,
+    /\.\.\/.*main\/cloud\/(?:app|http-server|session-service|control-plane-store|postgres-control-plane-store|in-memory-control-plane-store|runtime-adapter|opencode-runtime-adapter|secret-adapter|object-store|worker)/,
+    /postgres-control-plane-store/,
+    /in-memory-control-plane-store/,
+    /control-plane-store/,
+    /session-service/,
+    /opencode-runtime-adapter/,
+  ]
+
+  for (const clientRoot of clientRoots) {
+    for (const filePath of sourceFiles(join(root, clientRoot))) {
+      if (filePath.endsWith('.test.ts') || filePath.endsWith('.test.tsx')) continue
+      const source = readFileSync(filePath, 'utf8')
+      for (const pattern of forbidden) {
+        assert.doesNotMatch(
+          source,
+          pattern,
+          `${relative(root, filePath)} imports server/runtime internals instead of @open-cowork/cloud-client or @open-cowork/shared`,
+        )
+      }
+    }
   }
 })
 
@@ -89,4 +128,15 @@ function clientSources(directory: string): string[] {
     else if (entry.isFile() && entry.name.endsWith('.ts')) sources.push(readFileSync(path, 'utf8'))
   }
   return sources
+}
+
+function sourceFiles(directory: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (['node_modules', 'dist'].includes(entry.name)) continue
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...sourceFiles(path))
+    else if (entry.isFile() && ['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(extname(path))) files.push(path)
+  }
+  return files
 }

--- a/tests/cloud-transport-adapter.test.ts
+++ b/tests/cloud-transport-adapter.test.ts
@@ -2,18 +2,40 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  CloudTransportError,
   createHttpSseCloudTransportAdapter,
+  isCloudTransportError,
   type CloudTransportEventSource,
   type CloudTransportFetch,
 } from '../apps/desktop/src/main/cloud/transport-adapter.ts'
 import { CLOUD_SESSION_EVENT_TYPES } from '../packages/shared/dist/cloud-session-projection.js'
 
-function jsonResponse(body: unknown, status = 200) {
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: {
+      get(name: string) {
+        return headers[name] || headers[name.toLowerCase()] || null
+      },
+    },
     async text() {
       return JSON.stringify(body)
+    },
+  }
+}
+
+function textResponse(text: string, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name: string) {
+        return headers[name] || headers[name.toLowerCase()] || null
+      },
+    },
+    async text() {
+      return text
     },
   }
 }
@@ -510,6 +532,127 @@ test('cloud transport adapter authenticates SSE subscriptions with bearer header
   assert.equal(requests[0]?.init?.credentials, 'include')
 })
 
+test('cloud transport adapter exposes typed HTTP error taxonomy', async () => {
+  const cases: Array<{ status: number, kind: CloudTransportError['kind'] }> = [
+    { status: 401, kind: 'unauthorized' },
+    { status: 403, kind: 'forbidden' },
+    { status: 402, kind: 'payment_required' },
+    { status: 404, kind: 'not_found' },
+    { status: 409, kind: 'conflict' },
+    { status: 429, kind: 'rate_limited' },
+    { status: 500, kind: 'server' },
+  ]
+
+  for (const testCase of cases) {
+    const transport = createHttpSseCloudTransportAdapter({
+      baseUrl: 'https://cloud.example.test',
+      fetch: async () => jsonResponse(
+        { error: `status ${testCase.status}`, code: `E_${testCase.status}` },
+        testCase.status,
+        { 'retry-after': '60' },
+      ),
+    })
+
+    await assert.rejects(
+      transport.getConfig(),
+      (error) => {
+        assert.equal(isCloudTransportError(error), true)
+        const transportError = error as CloudTransportError
+        assert.equal(transportError.kind, testCase.kind)
+        assert.equal(transportError.status, testCase.status)
+        assert.equal(transportError.code, `E_${testCase.status}`)
+        assert.equal(transportError.retryAfter, '60')
+        assert.match(transportError.url || '', /^https:\/\/cloud\.example\.test\/api\/config$/)
+        return true
+      },
+    )
+  }
+})
+
+test('cloud transport adapter exposes typed parse and network errors', async () => {
+  const parseTransport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    fetch: async () => textResponse('{not-json', 200),
+  })
+  await assert.rejects(
+    parseTransport.getConfig(),
+    (error) => {
+      assert.equal(isCloudTransportError(error), true)
+      assert.equal((error as CloudTransportError).kind, 'parse')
+      assert.equal((error as CloudTransportError).status, 200)
+      assert.equal((error as CloudTransportError).body, '{not-json')
+      return true
+    },
+  )
+
+  const networkTransport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    fetch: async () => {
+      throw new Error('socket closed')
+    },
+  })
+  await assert.rejects(
+    networkTransport.getConfig(),
+    (error) => {
+      assert.equal(isCloudTransportError(error), true)
+      assert.equal((error as CloudTransportError).kind, 'network')
+      assert.match((error as CloudTransportError).message, /network request failed/)
+      return true
+    },
+  )
+})
+
+test('cloud transport adapter reports typed fetch SSE failures', async () => {
+  const httpErrors: unknown[] = []
+  const failedTransport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    headers: { authorization: 'Bearer cloud-token' },
+    fetch: async () => jsonResponse({ error: 'expired token', code: 'TOKEN_EXPIRED' }, 401),
+  })
+  failedTransport.subscribeWorkspaceEvents({
+    onEvent() {},
+    onError(error) {
+      httpErrors.push(error)
+    },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(httpErrors.length, 1)
+  assert.equal(isCloudTransportError(httpErrors[0]), true)
+  assert.equal((httpErrors[0] as CloudTransportError).kind, 'unauthorized')
+  assert.equal((httpErrors[0] as CloudTransportError).code, 'TOKEN_EXPIRED')
+
+  const parseErrors: unknown[] = []
+  const parseTransport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    headers: { authorization: 'Bearer cloud-token' },
+    fetch: async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return ''
+      },
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {not-json\n\n'))
+          controller.close()
+        },
+      }),
+    }),
+  })
+  parseTransport.subscribeSessionEvents('session-1', {
+    onEvent() {},
+    onError(error) {
+      parseErrors.push(error)
+    },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(parseErrors.length, 1)
+  assert.equal(isCloudTransportError(parseErrors[0]), true)
+  assert.equal((parseErrors[0] as CloudTransportError).kind, 'parse')
+})
+
 test('cloud transport adapter applies request timeout and caller cancellation signals', async () => {
   const timeoutTransport = createHttpSseCloudTransportAdapter({
     baseUrl: 'https://cloud.example.test',
@@ -520,7 +663,15 @@ test('cloud transport adapter applies request timeout and caller cancellation si
     }),
   })
 
-  await assert.rejects(timeoutTransport.getConfig(), /request aborted by timeout/)
+  await assert.rejects(
+    timeoutTransport.getConfig(),
+    (error) => {
+      assert.equal(error instanceof CloudTransportError, true)
+      assert.equal((error as CloudTransportError).kind, 'timeout')
+      assert.match((error as CloudTransportError).message, /timed out/)
+      return true
+    },
+  )
 
   const controller = new AbortController()
   const cancelledTransport = createHttpSseCloudTransportAdapter({
@@ -533,7 +684,14 @@ test('cloud transport adapter applies request timeout and caller cancellation si
   })
   const request = cancelledTransport.getConfig()
   controller.abort()
-  await assert.rejects(request, /request aborted by caller/)
+  await assert.rejects(
+    request,
+    (error) => {
+      assert.equal(error instanceof CloudTransportError, true)
+      assert.equal((error as CloudTransportError).kind, 'abort')
+      return true
+    },
+  )
 })
 
 test('cloud transport adapter closes EventSource SSE subscriptions on caller cancellation', () => {

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -123,7 +123,7 @@ test('root deployment scripts expose provider smoke gates', () => {
 test('root build and dist scripts preserve release build prerequisites', () => {
   assert.equal(requireScript('build:desktop'), 'pnpm --filter @open-cowork/desktop build')
   assert.equal(requireScript('build:mcps'), 'pnpm --filter=./mcps/* build')
-  assert.equal(requireScript('build:packages'), 'pnpm --filter=./packages/* build')
+  assert.equal(requireScript('build:packages'), 'pnpm --workspace-concurrency=1 --filter=./packages/* build')
   assert.equal(requireScript('build:gateway'), 'pnpm --filter @open-cowork/gateway build')
   assert.equal(requireScript('build:standalone-gateway'), 'pnpm --filter @open-cowork/standalone-gateway build')
   assert.equal(requireScript('build:website'), 'pnpm --filter @open-cowork/website build')


### PR DESCRIPTION
Closes #603.

## Summary
- add typed `CloudTransportError` taxonomy for HTTP, timeout, abort, parse, network, request, and SSE failures
- document cloud-client public exports, auth modes, timeout/abort behavior, SSE cursor/close semantics, and publish checklist
- rename and expand the cloud-client boundary test plus transport tests for typed errors and SSE failure handling
- make root package builds deterministic to avoid concurrent package declaration races during `pnpm build`/CodeQL

## Verification
- `pnpm --filter @open-cowork/cloud-client build`
- `node scripts/run-node-tests.mjs tests/cloud-transport-adapter.test.ts tests/cloud-client-boundaries.test.ts`
- `pnpm --filter @open-cowork/cloud-client test`
- `pnpm typecheck`
- `pnpm lint`
- `python3 -m mkdocs build --strict`
- `pnpm test`
- `pnpm build`
- `git diff --check`