### PR TITLE
Add launch evidence metadata contract

### DIFF
--- a/deploy/private-beta/launch-evidence-record.template.json
+++ b/deploy/private-beta/launch-evidence-record.template.json
@@ -15,6 +15,11 @@
       "redacted summary",
       "checksum of private artifact",
       "command name without secret arguments",
+      "commit SHA",
+      "image digests",
+      "sanitized environment profile",
+      "dates and duration",
+      "pass/fail or go/no-go status",
       "follow-up issue id"
     ],
     "forbiddenPublicFields": [
@@ -31,6 +36,16 @@
     "private-pass",
     "private-fail",
     "not-applicable-with-rationale"
+  ],
+  "requiredReportFields": [
+    "command",
+    "commitSha",
+    "imageDigests",
+    "sanitizedEnvironmentProfile",
+    "startedAt",
+    "finishedAt",
+    "durationMs",
+    "status"
   ],
   "requiredEvidence": [
     {

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -377,6 +377,14 @@ beta, general availability, or enterprise-scale readiness. Those tiers need
 environment-specific private operations evidence for load, soak, failover,
 restore, security, support, and cost/SLO behavior.
 
+Set evidence metadata for every plan, load, soak, and failover drill run:
+
+```bash
+export OPEN_COWORK_EVIDENCE_COMMIT_SHA="$(git rev-parse HEAD)"
+export OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST=sha256:REPLACE_WITH_CLOUD_IMAGE_DIGEST
+export OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST=sha256:REPLACE_WITH_GATEWAY_IMAGE_DIGEST
+```
+
 Generate the planned route matrix:
 
 ```bash
@@ -425,8 +433,10 @@ The harness writes JSON and Markdown reports under
 `.open-cowork-test/launch-readiness/` by default. Attach those reports,
 dashboard evidence, cost notes, known limits, and final smoke results to
 `docs/runbooks/launch-readiness-report.md` or a downstream private operations
-repository. Use `pnpm deploy:launch:validate` to verify the committed gate
-artifacts stay in sync.
+repository. Each report records the command name, commit SHA, image digests,
+sanitized environment profile, dates, duration, and pass/fail or go/no-go
+status. Use `pnpm deploy:launch:validate` to verify the committed gate artifacts
+stay in sync.
 
 After the ordinary load and soak gates pass with zero unexpected quota
 rejections, run a deliberate quota-pressure pass with

--- a/docs/runbooks/launch-readiness-report.md
+++ b/docs/runbooks/launch-readiness-report.md
@@ -16,7 +16,12 @@ identifiers redacted.
 - Environment:
 - Cloud URL:
 - Gateway URL:
-- Image tags:
+- Image tags/digests:
+- Commit SHA:
+- Cloud image digest:
+- Gateway image digest:
+- Primary command(s):
+- Sanitized environment profile:
 - Helm/Compose/Terraform revision:
 - Target profile: `local-self-host-beta`, `private-beta`, `public-beta`, or
   `enterprise-scale`
@@ -75,6 +80,10 @@ OPEN_COWORK_LOAD_OPERATOR_CHECKS=true \
 pnpm deploy:load:strict
 ```
 
+The generated report must include the command name, commit SHA, Cloud and
+Gateway image digests, sanitized environment profile, dates, duration, and
+go/no-go status.
+
 Summarize:
 
 | Area | Target | Actual | Result | Notes |
@@ -104,6 +113,10 @@ OPEN_COWORK_LOAD_OPERATOR_CHECKS=true \
 pnpm deploy:soak:strict
 ```
 
+The generated report must include the command name, commit SHA, Cloud and
+Gateway image digests, sanitized environment profile, dates, duration, and
+go/no-go status.
+
 Record:
 
 - Duration:
@@ -128,8 +141,8 @@ Record:
 - [ ] `pnpm deploy:gateway:smoke`
 - [ ] `pnpm deploy:continuation:smoke`
 - [ ] `pnpm deploy:failover:drill` with Cloud/Gateway URLs, worker/scheduler/
-      gateway hooks, and hook execution enabled. Dry-run output is not launch
-      evidence.
+      gateway hooks, hook execution enabled, and evidence metadata populated.
+      Dry-run output is not launch evidence.
 - [ ] provider-specific smoke such as `pnpm deploy:gcp:smoke` where applicable
 
 ## Failover And Recovery Evidence

--- a/docs/runbooks/launch-readiness.md
+++ b/docs/runbooks/launch-readiness.md
@@ -73,6 +73,9 @@ export OPEN_COWORK_LOAD_INCLUDE_MUTATIONS=true
 export OPEN_COWORK_LOAD_INCLUDE_SSE=true
 export OPEN_COWORK_LOAD_OPERATOR_CHECKS=true
 export OPEN_COWORK_LOAD_STRICT=true
+export OPEN_COWORK_EVIDENCE_COMMIT_SHA="$(git rev-parse HEAD)"
+export OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST=sha256:REPLACE_WITH_CLOUD_IMAGE_DIGEST
+export OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST=sha256:REPLACE_WITH_GATEWAY_IMAGE_DIGEST
 ```
 
 Optional knobs:
@@ -89,6 +92,9 @@ Optional knobs:
 - `OPEN_COWORK_LOAD_EXPECT_QUOTA_REJECTIONS=true` for a deliberate
   quota-pressure run after the ordinary zero-unexpected-rejection gate passes
 - `OPEN_COWORK_LOAD_OUTPUT_DIR=.open-cowork-test/launch-readiness`
+- `OPEN_COWORK_EVIDENCE_COMMIT_SHA=...`
+- `OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST=sha256:...`
+- `OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST=sha256:...`
 
 Use short-lived scoped operator tokens. Never paste BYOK keys, OAuth refresh
 tokens, cookie secrets, gateway service tokens, provider webhook secrets, or
@@ -143,7 +149,8 @@ The harness checks:
 
 The output is a JSON report plus a Markdown report under
 `.open-cowork-test/launch-readiness/` unless `OPEN_COWORK_LOAD_OUTPUT_DIR` is
-set.
+set. Each report records the command name, commit SHA, image digests, sanitized
+environment profile, dates, duration, and pass/fail or go/no-go status.
 
 ## Soak Gate
 

--- a/scripts/launch-failover-drill.mjs
+++ b/scripts/launch-failover-drill.mjs
@@ -13,6 +13,9 @@ function parseArgs(argv) {
     workerHook: process.env.OPEN_COWORK_FAILOVER_WORKER_HOOK || '',
     schedulerHook: process.env.OPEN_COWORK_FAILOVER_SCHEDULER_HOOK || '',
     gatewayHook: process.env.OPEN_COWORK_FAILOVER_GATEWAY_HOOK || '',
+    commitSha: process.env.OPEN_COWORK_EVIDENCE_COMMIT_SHA || '',
+    cloudImageDigest: process.env.OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST || '',
+    gatewayImageDigest: process.env.OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST || '',
     executeHooks: process.env.OPEN_COWORK_FAILOVER_EXECUTE_HOOKS === 'true',
     dryRun: process.env.OPEN_COWORK_FAILOVER_DRY_RUN === 'true',
     redacted: process.env.OPEN_COWORK_REDACT_OUTPUT !== 'false',
@@ -45,6 +48,15 @@ function parseArgs(argv) {
     } else if (arg === '--gateway-hook') {
       args.gatewayHook = argv[index + 1]
       index += 1
+    } else if (arg === '--commit-sha') {
+      args.commitSha = argv[index + 1]
+      index += 1
+    } else if (arg === '--cloud-image-digest') {
+      args.cloudImageDigest = argv[index + 1]
+      index += 1
+    } else if (arg === '--gateway-image-digest') {
+      args.gatewayImageDigest = argv[index + 1]
+      index += 1
     } else if (arg === '--execute-hooks') {
       args.executeHooks = true
     } else if (arg === '--dry-run') {
@@ -59,6 +71,36 @@ function parseArgs(argv) {
     }
   }
   return args
+}
+
+function currentCommitSha() {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const PRIVATE_EVIDENCE_PATTERNS = [
+  /(?:sk|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}/i,
+  /\bAKIA[0-9A-Z]{16}\b/,
+  /ya29\.[A-Za-z0-9_-]{8,}/i,
+  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
+  /(?:postgres(?:ql)?|mysql|mongodb):\/\//i,
+  /bearer\s+[A-Za-z0-9._-]{8,}/i,
+  /(?:token|secret|password|api[_-]?key)=/i,
+]
+
+function safeEvidenceText(value, fallback = 'not-provided') {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (!text) return fallback
+  if (PRIVATE_EVIDENCE_PATTERNS.some((pattern) => pattern.test(text))) {
+    return 'redacted-private-value'
+  }
+  return text.replace(/\s+/g, ' ').slice(0, 512)
 }
 
 function redactedUrl(url, redacted) {
@@ -118,6 +160,7 @@ function runHook(name, command, executeHooks, redacted, dryRun) {
 }
 
 const args = parseArgs(process.argv.slice(2))
+const startedMs = Date.now()
 const startedAt = new Date().toISOString()
 const preflight = [
   await probe('cloud-health-before', args.cloudUrl, args.cloudToken, '/healthz', args.redacted, args.dryRun),
@@ -135,13 +178,40 @@ const postflight = [
   await probe('gateway-metrics-after', args.gatewayUrl, args.gatewayAdminToken, '/metrics', args.redacted, args.dryRun),
 ]
 const failed = [...preflight, ...hooks, ...postflight].filter((item) => item.status === 'fail')
+const result = failed.length === 0 ? (args.dryRun ? 'dry-run' : 'pass') : 'fail'
+const finishedAt = new Date().toISOString()
+const durationMs = Date.now() - startedMs
 const report = {
   schemaVersion: 1,
   purpose: 'open-cowork-launch-failover-drill-evidence',
   redacted: args.redacted,
   startedAt,
-  finishedAt: new Date().toISOString(),
-  result: failed.length === 0 ? (args.dryRun ? 'dry-run' : 'pass') : 'fail',
+  finishedAt,
+  durationMs,
+  result,
+  evidence: {
+    command: args.dryRun ? 'pnpm deploy:failover:drill:dry-run' : 'pnpm deploy:failover:drill',
+    commitSha: safeEvidenceText(args.commitSha || currentCommitSha(), 'unknown'),
+    startedAt,
+    finishedAt,
+    durationMs,
+    status: result,
+    imageDigests: {
+      cloud: safeEvidenceText(args.cloudImageDigest),
+      gateway: safeEvidenceText(args.gatewayImageDigest),
+    },
+    environmentProfile: {
+      cloudUrl: redactedUrl(args.cloudUrl, args.redacted),
+      gatewayUrl: redactedUrl(args.gatewayUrl, args.redacted),
+      cloudTokenProvided: Boolean(args.cloudToken),
+      gatewayAdminTokenProvided: Boolean(args.gatewayAdminToken),
+      workerHookConfigured: Boolean(args.workerHook),
+      schedulerHookConfigured: Boolean(args.schedulerHook),
+      gatewayHookConfigured: Boolean(args.gatewayHook),
+      executeHooks: args.executeHooks,
+      dryRun: args.dryRun,
+    },
+  },
   executeHooks: args.executeHooks,
   dryRun: args.dryRun,
   targets: {

--- a/scripts/launch-readiness.mjs
+++ b/scripts/launch-readiness.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execFileSync } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
@@ -72,6 +73,67 @@ function safeUrl(url) {
     return parsed.toString().replace(/\/$/, '')
   } catch {
     return url ? '[invalid-url]' : ''
+  }
+}
+
+function currentCommitSha() {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const PRIVATE_EVIDENCE_PATTERNS = [
+  /(?:sk|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}/i,
+  /\bAKIA[0-9A-Z]{16}\b/,
+  /ya29\.[A-Za-z0-9_-]{8,}/i,
+  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
+  /(?:postgres(?:ql)?|mysql|mongodb):\/\//i,
+  /bearer\s+[A-Za-z0-9._-]{8,}/i,
+  /(?:token|secret|password|api[_-]?key)=/i,
+]
+
+function safeEvidenceText(value, fallback = 'not-provided') {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (!text) return fallback
+  if (PRIVATE_EVIDENCE_PATTERNS.some((pattern) => pattern.test(text))) {
+    return 'redacted-private-value'
+  }
+  return text.replace(/\s+/g, ' ').slice(0, 512)
+}
+
+function commandNameFor(options) {
+  if (options.mode === 'plan') return 'pnpm deploy:load:plan'
+  if (options.mode === 'soak') return options.strict ? 'pnpm deploy:soak:strict' : 'pnpm deploy:soak'
+  return options.strict ? 'pnpm deploy:load:strict' : 'pnpm deploy:load'
+}
+
+function createEvidenceMetadata(options, status = 'plan') {
+  return {
+    command: commandNameFor(options),
+    commitSha: safeEvidenceText(options.commitSha, 'unknown'),
+    imageDigests: {
+      cloud: safeEvidenceText(options.cloudImageDigest),
+      gateway: safeEvidenceText(options.gatewayImageDigest),
+    },
+    environmentProfile: {
+      profileName: options.profileName,
+      mode: options.mode,
+      strict: options.strict,
+      cloudUrl: options.skipCloud ? 'skipped' : safeUrl(options.cloudUrl),
+      gatewayUrl: options.skipGateway ? 'skipped' : safeUrl(options.gatewayUrl),
+      cloudTokenProvided: Boolean(options.cloudToken),
+      gatewayAdminTokenProvided: Boolean(options.gatewayAdminToken),
+      includeMutations: options.includeMutations,
+      includeSse: options.includeSse,
+      includeOperator: options.includeOperator,
+      byokProvider: safeEvidenceText(options.byokProvider),
+    },
+    status,
   }
 }
 
@@ -867,8 +929,16 @@ function createPlanMarkdown(options, operations) {
   return `# Open Cowork Launch Readiness Plan
 
 Profile: \`${options.profileName}\`
+Command: \`${commandNameFor(options)}\`
+Commit SHA: \`${safeEvidenceText(options.commitSha, 'unknown')}\`
 
 ${options.profile.description}
+
+## Evidence Metadata
+
+\`\`\`json
+${JSON.stringify(createEvidenceMetadata(options), null, 2)}
+\`\`\`
 
 ## Capacity Targets
 
@@ -918,6 +988,23 @@ Generated at: ${report.generatedAt}
 Mode: \`${report.mode}\`
 Profile: \`${report.profileName}\`
 Result: **${report.gates.overall}**
+
+## Evidence Metadata
+
+- Command: \`${report.evidence.command}\`
+- Commit SHA: \`${report.evidence.commitSha}\`
+- Cloud image digest: \`${report.evidence.imageDigests.cloud}\`
+- Gateway image digest: \`${report.evidence.imageDigests.gateway}\`
+- Started at: \`${report.evidence.startedAt}\`
+- Finished at: \`${report.evidence.finishedAt}\`
+- Duration: \`${report.evidence.durationMs}ms\`
+- Status: \`${report.evidence.status}\`
+
+Sanitized environment profile:
+
+\`\`\`json
+${JSON.stringify(report.evidence.environmentProfile, null, 2)}
+\`\`\`
 
 ## Targets
 
@@ -982,6 +1069,9 @@ async function main() {
     gatewayUrl: normalizeUrl(argOrEnv('gateway-url', 'OPEN_COWORK_LOAD_GATEWAY_URL', process.env.OPEN_COWORK_SMOKE_GATEWAY_URL || 'http://127.0.0.1:8790')),
     cloudToken: argOrEnv('cloud-token', 'OPEN_COWORK_LOAD_CLOUD_TOKEN', process.env.OPEN_COWORK_SMOKE_CLOUD_TOKEN || ''),
     gatewayAdminToken: argOrEnv('gateway-admin-token', 'OPEN_COWORK_LOAD_GATEWAY_ADMIN_TOKEN', process.env.OPEN_COWORK_SMOKE_GATEWAY_ADMIN_TOKEN || ''),
+    commitSha: argOrEnv('commit-sha', 'OPEN_COWORK_EVIDENCE_COMMIT_SHA', currentCommitSha()),
+    cloudImageDigest: argOrEnv('cloud-image-digest', 'OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST', ''),
+    gatewayImageDigest: argOrEnv('gateway-image-digest', 'OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST', ''),
     durationMs: intArg('duration-ms', 'OPEN_COWORK_LOAD_DURATION_MS', mode === 'soak' ? profile.soakDurationMs : profile.durationMs),
     concurrency: intArg('concurrency', 'OPEN_COWORK_LOAD_CONCURRENCY', profile.concurrency),
     requestRatePerSecond: floatArg('request-rate', 'OPEN_COWORK_LOAD_REQUEST_RATE', profile.requestRatePerSecond),
@@ -1036,6 +1126,12 @@ async function main() {
     generatedAt,
     mode,
     profileName,
+    evidence: {
+      ...createEvidenceMetadata(options, gates.overall),
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt,
+      durationMs: run.durationMs,
+    },
     targets: {
       cloudUrl: options.skipCloud ? null : safeUrl(options.cloudUrl),
       gatewayUrl: options.skipGateway ? null : safeUrl(options.gatewayUrl),

--- a/scripts/validate-launch-evidence-manifest.mjs
+++ b/scripts/validate-launch-evidence-manifest.mjs
@@ -30,6 +30,26 @@ const statusValues = new Set([
   'not-applicable-with-rationale',
 ])
 
+const requiredReportFields = [
+  'command',
+  'commitSha',
+  'imageDigests',
+  'sanitizedEnvironmentProfile',
+  'startedAt',
+  'finishedAt',
+  'durationMs',
+  'status',
+]
+
+const requiredPublicAllowedFields = [
+  'command name without secret arguments',
+  'commit SHA',
+  'image digests',
+  'sanitized environment profile',
+  'dates and duration',
+  'pass/fail or go/no-go status',
+]
+
 const publicForbiddenMarkers = [
   '/Users/joe',
   'OPEN_COWORK_GCP_PROJECT=',
@@ -127,6 +147,13 @@ function assertChecksum(value, itemId) {
   throw new Error(`${itemId}.checksum must be sha256:<64 hex> or artifact:<immutable id>`)
 }
 
+function assertArrayContainsAll(values, required, label) {
+  if (!Array.isArray(values)) throw new Error(`${label} must be an array`)
+  for (const value of required) {
+    if (!values.includes(value)) throw new Error(`${label} must include ${value}`)
+  }
+}
+
 const args = parseArgs(process.argv.slice(2))
 for (const path of [matrixPath, defaultManifestPath, publicSummaryPath, packagePath, args.manifest]) assertFile(path)
 
@@ -182,6 +209,12 @@ if (manifest.currentPublicTier !== 'local-self-host-beta') {
 if (manifest.publicPrivateBoundary?.publicSummaryStorage !== publicSummaryPath) {
   throw new Error(`${args.manifest} must point to ${publicSummaryPath}`)
 }
+assertArrayContainsAll(
+  manifest.publicPrivateBoundary?.allowedPublicFields,
+  requiredPublicAllowedFields,
+  `${args.manifest}.publicPrivateBoundary.allowedPublicFields`,
+)
+assertArrayContainsAll(manifest.requiredReportFields, requiredReportFields, `${args.manifest}.requiredReportFields`)
 
 const manifestItems = manifest.requiredEvidence
 if (!Array.isArray(manifestItems)) throw new Error(`${args.manifest} must list requiredEvidence`)

--- a/scripts/validate-launch-readiness.mjs
+++ b/scripts/validate-launch-readiness.mjs
@@ -328,6 +328,9 @@ for (const phrase of [
   'OPEN_COWORK_LOAD_BYOK_PROVIDER',
   'OPEN_COWORK_LOAD_EXPECT_QUOTA_REJECTIONS',
   'OPEN_COWORK_LOAD_STRICT',
+  'OPEN_COWORK_EVIDENCE_COMMIT_SHA',
+  'OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST',
+  'OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST',
   'local-self-host-beta',
   'private-beta',
   'public-beta',
@@ -348,8 +351,42 @@ for (const phrase of [
   'Launch Evidence Register',
   'deploy/private-beta/launch-evidence-record.template.json',
   'pnpm deploy:failover:drill',
+  'Commit SHA',
+  'Cloud image digest',
+  'Gateway image digest',
+  'Sanitized environment profile',
 ]) {
   assertIncludes(reportPath, phrase)
+}
+
+for (const phrase of [
+  'createEvidenceMetadata',
+  'OPEN_COWORK_EVIDENCE_COMMIT_SHA',
+  'OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST',
+  'OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST',
+]) {
+  assertIncludes(harnessPath, phrase)
+}
+
+for (const phrase of [
+  'OPEN_COWORK_EVIDENCE_COMMIT_SHA',
+  'OPEN_COWORK_EVIDENCE_CLOUD_IMAGE_DIGEST',
+  'OPEN_COWORK_EVIDENCE_GATEWAY_IMAGE_DIGEST',
+  'durationMs',
+  'environmentProfile',
+]) {
+  assertIncludes(failoverDrillPath, phrase)
+}
+
+for (const phrase of [
+  'requiredReportFields',
+  'commitSha',
+  'imageDigests',
+  'sanitizedEnvironmentProfile',
+  'dates and duration',
+  'durationMs',
+]) {
+  assertIncludes(evidenceRecordPath, phrase)
 }
 
 for (const phrase of [

--- a/tests/launch-readiness.test.ts
+++ b/tests/launch-readiness.test.ts
@@ -8,6 +8,10 @@ import { join } from 'node:path'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
+const evidenceCommitSha = 'abcdef1234567890abcdef1234567890abcdef12'
+const cloudImageDigest = `sha256:${'1'.repeat(64)}`
+const gatewayImageDigest = `sha256:${'2'.repeat(64)}`
+const unsafeEvidenceValue = ['github', 'pat', 'privatevalue1234567890'].join('_')
 
 function readJsonFile(path: string) {
   return JSON.parse(readFileSync(path, 'utf8'))
@@ -179,6 +183,12 @@ test('launch readiness harness produces strict load report against cloud and gat
       '--include-sse',
       '--operator',
       '--strict',
+      '--commit-sha',
+      evidenceCommitSha,
+      '--cloud-image-digest',
+      cloudImageDigest,
+      '--gateway-image-digest',
+      gatewayImageDigest,
       '--output-dir',
       outputDir,
     ], { encoding: 'utf8' })
@@ -194,6 +204,18 @@ test('launch readiness harness produces strict load report against cloud and gat
     assert.ok(markdownReport)
     const report = JSON.parse(readFileSync(join(outputDir, jsonReport), 'utf8'))
     assert.equal(report.gates.overall, 'go')
+    assert.equal(report.evidence.command, 'pnpm deploy:load:strict')
+    assert.equal(report.evidence.commitSha, evidenceCommitSha)
+    assert.equal(report.evidence.imageDigests.cloud, cloudImageDigest)
+    assert.equal(report.evidence.imageDigests.gateway, gatewayImageDigest)
+    assert.equal(report.evidence.environmentProfile.profileName, 'private-beta')
+    assert.equal(report.evidence.environmentProfile.mode, 'load')
+    assert.equal(report.evidence.environmentProfile.cloudTokenProvided, true)
+    assert.equal(report.evidence.environmentProfile.gatewayAdminTokenProvided, true)
+    assert.equal(report.evidence.startedAt, report.run.startedAt)
+    assert.equal(report.evidence.finishedAt, report.run.finishedAt)
+    assert.equal(report.evidence.durationMs, report.run.durationMs)
+    assert.doesNotMatch(JSON.stringify(report), /cloud-token|gateway-admin-token/)
     assert.equal(report.summary.operations['cloud-session-create'].failures, 0)
     assert.equal(report.summary.operations['cloud-prompt-enqueue'].failures, 0)
     assert.equal(report.summary.operations['cloud-workspace-sse'].failures, 0)
@@ -203,7 +225,10 @@ test('launch readiness harness produces strict load report against cloud and gat
     assert.equal(report.summary.operations['cloud-byok-provider-validate'].failures, 0)
     assert.equal(report.metrics.delta.open_cowork_gateway_delivery_dead_letters_total, 0)
     assert.equal(report.metrics.delta.open_cowork_gateway_stream_reconnects_total, 0)
-    assert.match(readFileSync(join(outputDir, markdownReport), 'utf8'), /Open Cowork Launch Readiness Report/)
+    const markdown = readFileSync(join(outputDir, markdownReport), 'utf8')
+    assert.match(markdown, /Open Cowork Launch Readiness Report/)
+    assert.match(markdown, /Evidence Metadata/)
+    assert.match(markdown, new RegExp(evidenceCommitSha))
   } finally {
     await new Promise<void>((resolve) => cloud.server.close(() => resolve()))
     await new Promise<void>((resolve) => gateway.server.close(() => resolve()))
@@ -277,6 +302,16 @@ test('launch evidence manifest validator accepts template and completed private 
   const outputDir = mkdtempSync(join(tmpdir(), 'open-cowork-launch-evidence-'))
   try {
     const manifest = readJsonFile('deploy/private-beta/launch-evidence-record.template.json')
+    assert.deepEqual(manifest.requiredReportFields, [
+      'command',
+      'commitSha',
+      'imageDigests',
+      'sanitizedEnvironmentProfile',
+      'startedAt',
+      'finishedAt',
+      'durationMs',
+      'status',
+    ])
     for (const item of manifest.requiredEvidence) {
       item.status = 'private-pass'
       item.privateEvidenceRef = `private://evidence/${item.id}`
@@ -361,6 +396,12 @@ test('launch failover drill emits redacted dry-run evidence without executing ho
       'exit 1',
       '--gateway-hook',
       'exit 1',
+      '--commit-sha',
+      evidenceCommitSha,
+      '--cloud-image-digest',
+      cloudImageDigest,
+      '--gateway-image-digest',
+      gatewayImageDigest,
       '--output-dir',
       outputDir,
     ], { encoding: 'utf8' })
@@ -368,6 +409,16 @@ test('launch failover drill emits redacted dry-run evidence without executing ho
     assert.equal(parsed.ok, true)
     assert.equal(parsed.report.redacted, true)
     assert.equal(parsed.report.result, 'dry-run')
+    assert.equal(parsed.report.evidence.command, 'pnpm deploy:failover:drill:dry-run')
+    assert.equal(parsed.report.evidence.commitSha, evidenceCommitSha)
+    assert.equal(parsed.report.evidence.imageDigests.cloud, cloudImageDigest)
+    assert.equal(parsed.report.evidence.imageDigests.gateway, gatewayImageDigest)
+    assert.equal(parsed.report.evidence.environmentProfile.cloudTokenProvided, false)
+    assert.equal(parsed.report.evidence.environmentProfile.workerHookConfigured, true)
+    assert.equal(parsed.report.evidence.startedAt, parsed.report.startedAt)
+    assert.equal(parsed.report.evidence.finishedAt, parsed.report.finishedAt)
+    assert.equal(parsed.report.evidence.durationMs, parsed.report.durationMs)
+    assert.equal(typeof parsed.report.durationMs, 'number')
     assert.equal(parsed.report.targets.cloudUrl, 'http://REDACTED_HOST')
     assert.equal(parsed.report.hooks[0].status, 'dry-run')
     assert.ok(parsed.report.evidenceItems.includes('workerFailover'))
@@ -389,6 +440,12 @@ test('launch readiness plan supports the local self-host beta tier', async () =>
       'plan',
       '--profile',
       'local-self-host-beta',
+      '--commit-sha',
+      evidenceCommitSha,
+      '--cloud-image-digest',
+      cloudImageDigest,
+      '--gateway-image-digest',
+      unsafeEvidenceValue,
       '--output-dir',
       outputDir,
     ], { encoding: 'utf8' })
@@ -402,6 +459,10 @@ test('launch readiness plan supports the local self-host beta tier', async () =>
     const plan = readFileSync(parsed.planPath, 'utf8')
     assert.match(plan, /local-self-host-beta/)
     assert.match(plan, /OSS self-host and local reference deployment target/)
+    assert.match(plan, /Evidence Metadata/)
+    assert.match(plan, new RegExp(evidenceCommitSha))
+    assert.match(plan, /redacted-private-value/)
+    assert.doesNotMatch(plan, new RegExp(unsafeEvidenceValue))
   } finally {
     rmSync(outputDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- add command, commit SHA, image digest, sanitized environment profile, timing, and status metadata to launch readiness reports
- add matching evidence metadata to failover drill output
- update private-beta evidence manifest validation, launch docs, and tests for the evidence-report contract

Fixes #606.

## Validation
- node scripts/run-node-tests.mjs tests/launch-readiness.test.ts tests/package-scripts.test.ts
- node scripts/validate-launch-readiness.mjs
- node scripts/validate-launch-evidence-manifest.mjs
- node scripts/validate-private-beta-package.mjs
- node scripts/validate-ops-readiness.mjs
- node scripts/validate-release-gates.mjs
- node scripts/validate-deployment-configs.mjs (Docker/Helm unavailable locally; static checks passed)
- node scripts/lint.mjs
- python3 -m mkdocs build --strict
- node scripts/run-node-tests.mjs
- git diff --check