### PR TITLE
Sanitize standalone gateway error responses

### DIFF
--- a/apps/standalone-gateway/src/server.test.ts
+++ b/apps/standalone-gateway/src/server.test.ts
@@ -55,6 +55,83 @@ test("standalone server exposes health, readiness, and admin-gated dashboard", a
   }
 });
 
+test("standalone server hides unexpected webhook exception details", async (t) => {
+  const stderr = t.mock.method(process.stderr, "write", () => true);
+  const config = loadStandaloneGatewayConfig({
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:5432/gateway",
+    OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN: "standalone-admin-token",
+    OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL: "http://127.0.0.1:4096",
+    OPEN_COWORK_STANDALONE_GATEWAY_PORT: "0",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
+  });
+  const repository = new InMemoryStandaloneGatewayRepository();
+  const opencode = new FakeStandaloneOpenCodeAdapter();
+  const providers = {
+    async handleWebhook() {
+      const error = new Error("provider failed while reading /private/standalone-gateway-config");
+      error.stack = "Error: provider failed\n    at /private/standalone-gateway-config.ts:1:1";
+      throw error;
+    },
+  };
+  const server = createStandaloneGatewayServer({ config, repository, opencode, providers });
+  await server.listen();
+  try {
+    const url = server.url();
+    assert.ok(url);
+    const response = await fetch(`${url}/webhooks/webhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    assert.equal(response.status, 500);
+    const body = await response.json();
+    assert.deepEqual(body, { ok: false, error: "internal_server_error" });
+    assert.doesNotMatch(JSON.stringify(body), /private|standalone-gateway-config|provider failed/);
+    assert.equal(stderr.mock.callCount(), 1);
+  } finally {
+    await server.close();
+  }
+});
+
+test("standalone server sanitizes webhook verification failures", async () => {
+  const config = loadStandaloneGatewayConfig({
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:5432/gateway",
+    OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN: "standalone-admin-token",
+    OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL: "http://127.0.0.1:4096",
+    OPEN_COWORK_STANDALONE_GATEWAY_PORT: "0",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
+  });
+  const repository = new InMemoryStandaloneGatewayRepository();
+  const opencode = new FakeStandaloneOpenCodeAdapter();
+  const providers = {
+    async handleWebhook() {
+      throw new Error("Webhook signature verification failed for /private/provider-hook");
+    },
+  };
+  const server = createStandaloneGatewayServer({ config, repository, opencode, providers });
+  await server.listen();
+  try {
+    const url = server.url();
+    assert.ok(url);
+    const response = await fetch(`${url}/webhooks/webhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    assert.equal(response.status, 401);
+    const body = await response.json();
+    assert.deepEqual(body, {
+      ok: false,
+      error: "Standalone Gateway webhook verification failed.",
+    });
+    assert.doesNotMatch(JSON.stringify(body), /private|provider-hook|signature verification failed for/);
+  } finally {
+    await server.close();
+  }
+});
+
 test("standalone server rate-limits repeated webhook requests by source", async () => {
   const config = loadStandaloneGatewayConfig({
     OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:5432/gateway",

--- a/apps/standalone-gateway/src/server.ts
+++ b/apps/standalone-gateway/src/server.ts
@@ -15,11 +15,19 @@ const webhookAuthBackoffWindowMs = 60_000;
 const webhookAuthBackoffMaxFailures = 20;
 const webhookAuthBackoffMs = 60_000;
 const maxWebhookRateRecords = 10_000;
+const standaloneHttpErrorMarker = Symbol("standalone-http-error");
 
 interface WebhookRateRecord {
   count: number;
   resetAt: number;
   blockedUntil: number;
+}
+
+type StandaloneHttpError = Error & {
+  statusCode: number;
+  publicMessage: string;
+  retryAfterMs?: number;
+  [standaloneHttpErrorMarker]: true;
 }
 
 class WebhookRateLimiter {
@@ -86,9 +94,10 @@ export function createStandaloneGatewayServer(input: {
   const webhookLimiter = new WebhookRateLimiter();
   const server = createServer((req, res) => {
     void handleRequest(input, req, res, webhookLimiter).catch((error) => {
-      const retryAfterMs = typeof error.retryAfterMs === "number" ? error.retryAfterMs : null;
-      writeJson(res, error.statusCode || 500, { ok: false, error: error instanceof Error ? error.message : String(error) }, retryAfterMs ? {
-        "retry-after": retryAfterSeconds(retryAfterMs),
+      const responseError = publicErrorResponse(error);
+      if (responseError.statusCode >= 500) logInternalError(error);
+      writeJson(res, responseError.statusCode, { ok: false, error: responseError.message }, responseError.retryAfterMs ? {
+        "retry-after": retryAfterSeconds(responseError.retryAfterMs),
       } : {});
     });
   });
@@ -163,8 +172,9 @@ async function handleRequest(input: {
     try {
       await input.providers.handleWebhook(providerId, payload, req.headers, rawBody);
     } catch (error) {
-      if (/signature|secret|authorization|authorized|token|timestamp|replay/i.test(error instanceof Error ? error.message : String(error))) {
+      if (isWebhookAuthFailure(error)) {
         recordWebhookAuthFailure(webhookLimiter, `auth:${source}:${providerId}`);
+        throw httpError(401, "Standalone Gateway webhook verification failed.");
       }
       throw error;
     }
@@ -176,9 +186,7 @@ async function handleRequest(input: {
 
 function assertAdmin(config: StandaloneGatewayConfig, req: IncomingMessage): void {
   if (isAdminRequest(config, req)) return;
-  const error = new Error("Standalone Gateway admin token required.") as Error & { statusCode: number };
-  error.statusCode = 401;
-  throw error;
+  throw httpError(401, "Standalone Gateway admin token required.");
 }
 
 function isAdminRequest(config: StandaloneGatewayConfig, req: IncomingMessage): boolean {
@@ -248,11 +256,41 @@ function constantTimeEqual(left: string, right: string): boolean {
   return timingSafeEqual(leftHash, rightHash);
 }
 
-function httpError(statusCode: number, message: string, retryAfterMs?: number): Error & { statusCode: number; retryAfterMs?: number } {
-  const error = new Error(message) as Error & { statusCode: number; retryAfterMs?: number };
+function httpError(statusCode: number, message: string, retryAfterMs?: number): StandaloneHttpError {
+  const error = new Error(message) as StandaloneHttpError;
   error.statusCode = statusCode;
+  error.publicMessage = message;
   error.retryAfterMs = retryAfterMs;
+  error[standaloneHttpErrorMarker] = true;
   return error;
+}
+
+function publicErrorResponse(error: unknown): { statusCode: number; message: string; retryAfterMs: number | null } {
+  if (isStandaloneHttpError(error)) {
+    return {
+      statusCode: error.statusCode,
+      message: error.publicMessage,
+      retryAfterMs: typeof error.retryAfterMs === "number" ? error.retryAfterMs : null,
+    };
+  }
+  return { statusCode: 500, message: "internal_server_error", retryAfterMs: null };
+}
+
+function isStandaloneHttpError(error: unknown): error is StandaloneHttpError {
+  return error instanceof Error
+    && (error as { [standaloneHttpErrorMarker]?: unknown })[standaloneHttpErrorMarker] === true
+    && typeof (error as { statusCode?: unknown }).statusCode === "number"
+    && typeof (error as { publicMessage?: unknown }).publicMessage === "string";
+}
+
+function isWebhookAuthFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /signature|secret|authorization|authorized|token|timestamp|replay/i.test(message);
+}
+
+function logInternalError(error: unknown): void {
+  const detail = error instanceof Error ? (error.stack || error.message) : String(error);
+  process.stderr.write(`Standalone Gateway request failed: ${detail}\n`);
 }
 
 function writeJson(res: ServerResponse, status: number, body: unknown, headers: Record<string, string> = {}): void {


### PR DESCRIPTION
## Summary
- stop reflecting arbitrary standalone gateway exception messages in HTTP responses
- expose only module-created public HTTP errors via a private marker, and return a generic internal error for unexpected provider/runtime exceptions
- map webhook verification-style provider failures to a fixed 401 response while preserving auth backoff accounting

## Validation
- node_modules/.bin/eslint apps/standalone-gateway/src/server.ts apps/standalone-gateway/src/server.test.ts --max-warnings 0
- node_modules/.bin/tsc -p apps/standalone-gateway/tsconfig.json --noEmit
- node_modules/.bin/tsc -p apps/standalone-gateway/tsconfig.json && node --no-warnings --experimental-strip-types --test apps/standalone-gateway/src/*.test.ts
- node scripts/validate-standalone-gateway.mjs && node scripts/validate-release-gates.mjs
- node scripts/lint.mjs && node scripts/check-preload-channels.mjs && node scripts/check-shared-dist.mjs
- git diff --check
