### PR TITLE
Mask renderer credential reads

### DIFF
--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -317,15 +317,15 @@ export function registerAppHandlers(context: IpcHandlerContext) {
   })
 
   context.ipcMain.handle('settings:get-provider-credentials', async (event, providerId: unknown, options: unknown) => {
-    // Scoped opt-in for provider credential editor surfaces. Avoid
-    // returning every stored provider and integration secret to any
-    // renderer code that only needs one credential bag.
+    // Scoped opt-in for provider credential editor surfaces. Secret values
+    // are masked so the renderer can show configured state without receiving
+    // raw provider keys.
     if (!canReadLocalCredentialBag(context, event, options)) return {}
     return getProviderCredentials(normalizeCredentialScopeId(providerId, 'Provider'))
   })
 
   context.ipcMain.handle('settings:get-integration-credentials', async (event, integrationId: unknown, options: unknown) => {
-    // Same scoped read for integration/MCP credential editors.
+    // Same scoped, masked read for integration/MCP credential editors.
     if (!canReadLocalCredentialBag(context, event, options)) return {}
     return getIntegrationCredentials(normalizeCredentialScopeId(integrationId, 'Integration'))
   })

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -8,9 +8,11 @@ import {
   type EffectiveAppSettings,
   type RuntimePermissionPolicy,
 } from '@open-cowork/shared'
+import type { CredentialField } from '@open-cowork/shared/providers'
 import {
   getAppConfig,
   getAppDataDir,
+  getConfiguredMcpsFromConfig,
   getProviderDescriptor,
   getPublicAppConfig,
   normalizeProviderModelId,
@@ -438,6 +440,21 @@ function decryptLegacyDevelopmentSecret(raw: Buffer) {
 // masked value back can't overwrite the real key with the mask string.
 export const CREDENTIAL_MASK = '••••••••'
 
+function maskCredentialBag(
+  value: Record<string, string>,
+  fields: readonly CredentialField[] | undefined,
+) {
+  const fieldByKey = new Map((fields || []).map((field) => [field.key, field] as const))
+  const masked: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    const field = fieldByKey.get(key)
+    masked[key] = field && field.secret === false
+      ? entry
+      : entry && entry.length > 0 ? CREDENTIAL_MASK : ''
+  }
+  return masked
+}
+
 function maskNestedStringMap(value: Record<string, Record<string, string>>) {
   const masked: Record<string, Record<string, string>> = {}
   for (const [outer, inner] of Object.entries(value)) {
@@ -553,10 +570,8 @@ export function clearSettingsCache() {
 export function saveSettings(settings: Partial<AppSettings>) {
   const current = settingsCache || loadSettings()
   const updates = normalizeSettingsUpdate(settings)
-  // Strip mask sentinels so a caller that round-tripped `settings:get`
-  // (which returns masked credentials) can't accidentally overwrite
-  // real keys with the mask string. Safe because the real value can
-  // only have been preserved through the scoped credential IPCs.
+  // Strip mask sentinels so a caller that round-tripped masked credential
+  // state can't accidentally overwrite real keys with the mask string.
   const merged: AppSettings = {
     ...current,
     ...updates,
@@ -600,12 +615,13 @@ export function getIntegrationCredentialValue(settings: AppSettings, integration
 
 export function getProviderCredentials(providerId: string) {
   const credentials = loadSettings().providerCredentials[providerId] || {}
-  return { ...credentials }
+  return maskCredentialBag(credentials, getProviderDescriptor(providerId)?.credentials)
 }
 
 export function getIntegrationCredentials(integrationId: string) {
   const credentials = loadSettings().integrationCredentials[integrationId] || {}
-  return { ...credentials }
+  const configuredMcp = getConfiguredMcpsFromConfig().find((entry) => entry.name === integrationId)
+  return maskCredentialBag(credentials, configuredMcp?.credentials)
 }
 
 export function isSetupComplete(settings = loadSettings()) {

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { SETUP_INTENTS, type ProviderDescriptor, type SetupIntentId } from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
-import { mergeFetchedProviderCredentials } from './provider/credential-merge'
+import { credentialFieldIsSecret, isCredentialMask, mergeFetchedProviderCredentials } from './provider/credential-merge'
 import { ProviderAuthControls } from './provider/ProviderAuthControls'
 import { useSessionStore } from '../stores/session'
 import { LOCAL_WORKSPACE_ID } from '../stores/session-workspace-keys'
@@ -85,7 +85,7 @@ export function SetupScreen({
 
   useEffect(() => {
     // Settings are loaded masked by default. The setup form requests only
-    // the selected provider's credential bag below.
+    // the selected provider's descriptor-aware masked credential bag below.
     let cancelled = false
     window.coworkApi.settings.get().then(async (settings) => {
       const initialProviderId = providers.some((provider) => provider.id === settings.selectedProviderId)
@@ -317,19 +317,27 @@ export function SetupScreen({
               />
               {selectedProvider.credentials.length > 0 ? (
                 <div className="flex flex-col gap-2.5 rounded-xl border border-border-subtle p-3.5" style={{ background: 'var(--color-elevated)' }}>
-                  {selectedProvider.credentials.map((credential) => (
-                    <label key={credential.key} className="flex flex-col gap-1">
-                      <span className="text-[11px] text-text-muted font-medium">{credential.label}</span>
-                      <input
-                        type={credential.secret ? 'password' : 'text'}
-                        value={selectedCredentials[credential.key] || ''}
-                        onChange={(event) => updateCredential(credential.key, event.target.value)}
-                        placeholder={credential.placeholder}
-                        className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
-                      />
-                      <span className="text-[10px] text-text-muted">{credential.description}</span>
-                    </label>
-                  ))}
+                  {selectedProvider.credentials.map((credential) => {
+                    const credentialIsSecret = credentialFieldIsSecret(credential)
+                    return (
+                      <label key={credential.key} className="flex flex-col gap-1">
+                        <span className="text-[11px] text-text-muted font-medium">{credential.label}</span>
+                        <input
+                          type={credentialIsSecret ? 'password' : 'text'}
+                          value={selectedCredentials[credential.key] || ''}
+                          onFocus={() => {
+                            if (credentialIsSecret && isCredentialMask(selectedCredentials[credential.key])) {
+                              updateCredential(credential.key, '')
+                            }
+                          }}
+                          onChange={(event) => updateCredential(credential.key, event.target.value)}
+                          placeholder={credential.placeholder}
+                          className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
+                        />
+                        <span className="text-[10px] text-text-muted">{credential.description}</span>
+                      </label>
+                    )
+                  })}
                 </div>
               ) : null}
 

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.test.tsx
@@ -481,6 +481,7 @@ describe('CapabilitiesPage', () => {
           label: 'Account region',
           description: 'Region slug used by the chart API.',
           placeholder: 'us',
+          secret: false,
         },
       ],
     }
@@ -527,6 +528,7 @@ describe('CapabilitiesPage', () => {
             { label: 'API key', value: 'api_key', hint: 'Static API credentials' },
             { label: 'SSO', value: 'sso', hint: 'Browser-based sign in' },
           ],
+          secret: false,
           required: true,
         },
         {
@@ -541,6 +543,7 @@ describe('CapabilitiesPage', () => {
           key: 'ssoUser',
           label: 'SSO email',
           description: 'Email address for single sign-on.',
+          secret: false,
           required: true,
           when: { key: 'authMethod', op: 'eq', value: 'sso' },
         },

--- a/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/capabilities-page-components.tsx
@@ -6,6 +6,7 @@ import type { CapabilityTool, RuntimeContextOptions } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
 import { useSessionStore } from '../../stores/session'
 import { LOCAL_WORKSPACE_ID } from '../../stores/session-workspace-keys'
+import { credentialFieldIsSecret } from '../provider/credential-merge'
 
 function describeCapabilityError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
@@ -268,9 +269,10 @@ export function ToolCredentialsCard({
           const draft = drafts[credential.key]
           const options = credential.options || []
           const isChoiceField = (credential.type === 'select' || credential.type === 'radio') && options.length > 0
+          const credentialIsSecret = credentialFieldIsSecret(credential)
           const value = draft !== undefined
             ? draft
-            : credential.secret && !isChoiceField
+            : credentialIsSecret && !isChoiceField
               ? (hasStored ? '••••••••' : '')
               : storedValue
           const selectedOption = options.find((option) => option.value === value)
@@ -346,11 +348,11 @@ export function ToolCredentialsCard({
                 {credential.label}{credential.required ? <span className="text-red ms-1">*</span> : null}
               </span>
               <input
-                type={credential.secret ? 'password' : 'text'}
+                type={credentialIsSecret ? 'password' : 'text'}
                 value={value}
                 placeholder={credential.placeholder || ''}
                 onFocus={(event) => {
-                  if (credential.secret && draft === undefined && hasStored) {
+                  if (credentialIsSecret && draft === undefined && hasStored) {
                     setDrafts((current) => ({ ...current, [credential.key]: '' }))
                     event.currentTarget.value = ''
                   }

--- a/apps/desktop/src/renderer/components/provider/credential-merge.ts
+++ b/apps/desktop/src/renderer/components/provider/credential-merge.ts
@@ -1,6 +1,14 @@
 type ProviderCredentialBag = Record<string, string>
 
-const CREDENTIAL_MASK = '••••••••'
+export const CREDENTIAL_MASK = '••••••••'
+
+export function isCredentialMask(value: string | null | undefined) {
+  return value === CREDENTIAL_MASK
+}
+
+export function credentialFieldIsSecret(credential: { secret?: boolean }) {
+  return credential.secret !== false
+}
 
 export function mergeFetchedProviderCredentials(
   current: ProviderCredentialBag | undefined,

--- a/apps/desktop/src/renderer/components/sidebar/SettingsModelsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsModelsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { SMALL_MODEL_USE_MAIN, type EffectiveAppSettings, type PublicAppConfig } from '@open-cowork/shared'
 import { t } from '../../helpers/i18n'
+import { credentialFieldIsSecret, isCredentialMask } from '../provider/credential-merge'
 import { ProviderAuthControls } from '../provider/ProviderAuthControls'
 import {
   fieldLabelCls,
@@ -195,19 +196,27 @@ export function ModelsPanel({
 
           {provider.credentials.length ? (
             <div className={panelCardCls}>
-              {provider.credentials.map((credential) => (
-                <label key={credential.key} className="flex flex-col gap-1.5">
-                  <span className={fieldLabelCls}>{credential.label}</span>
-                  <input
-                    type={credential.secret ? 'password' : 'text'}
-                    value={providerCredentials[credential.key] || ''}
-                    onChange={(event) => updateProviderCredential(provider.id, credential.key, event.target.value)}
-                    placeholder={credential.placeholder}
-                    className={inputCls}
-                  />
-                  <span className="text-[10px] text-text-muted">{credential.description}</span>
-                </label>
-              ))}
+              {provider.credentials.map((credential) => {
+                const credentialIsSecret = credentialFieldIsSecret(credential)
+                return (
+                  <label key={credential.key} className="flex flex-col gap-1.5">
+                    <span className={fieldLabelCls}>{credential.label}</span>
+                    <input
+                      type={credentialIsSecret ? 'password' : 'text'}
+                      value={providerCredentials[credential.key] || ''}
+                      onFocus={() => {
+                        if (credentialIsSecret && isCredentialMask(providerCredentials[credential.key])) {
+                          updateProviderCredential(provider.id, credential.key, '')
+                        }
+                      }}
+                      onChange={(event) => updateProviderCredential(provider.id, credential.key, event.target.value)}
+                      placeholder={credential.placeholder}
+                      className={inputCls}
+                    />
+                    <span className="text-[10px] text-text-muted">{credential.description}</span>
+                  </label>
+                )
+              })}
             </div>
           ) : null}
         </div>

--- a/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsPanel.tsx
@@ -117,8 +117,8 @@ export function SettingsPanel({
   useEffect(() => {
     // Fast close-reopen cycles can land these resolves into an unmounted
     // component; guard with a cancelled flag so we don't setState on a
-    // disposed instance. The default settings load is masked; the Models
-    // tab fetches only the active provider's real credential bag below.
+    // disposed instance. The default settings load is masked; the Models tab
+    // fetches only the active provider's descriptor-aware masked bag below.
     let cancelled = false
     Promise.all([
       activeWorkspaceIsLocal ? window.coworkApi.settings.get() : window.coworkApi.settings.get(workspaceOptions),

--- a/apps/desktop/tests/settings-round-trip.smoke.test.ts
+++ b/apps/desktop/tests/settings-round-trip.smoke.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { launchSmokeApp, waitForAppShell } from './smoke-helpers.ts'
 
 // Smoke: settings are the primary persistence surface for downstream
@@ -15,7 +17,7 @@ import { launchSmokeApp, waitForAppShell } from './smoke-helpers.ts'
 //   - locale persistence regressing from `setLocale`
 
 test('settings round-trip survives a full reload through safeStorage + disk', async () => {
-  const { app, page, cleanup } = await launchSmokeApp()
+  const { app, page, paths, cleanup } = await launchSmokeApp()
   try {
     await waitForAppShell(page)
 
@@ -53,16 +55,36 @@ test('settings round-trip survives a full reload through safeStorage + disk', as
     assert.equal(afterReload.selectedProviderId, 'openrouter')
     assert.equal(afterReload.selectedModelId, 'anthropic/claude-opus-4')
 
-    // Credentials come back through a separate IPC so the plain
-    // settings:get doesn't leak them to every renderer consumer.
+    // Credential-editor IPC returns descriptor-aware masks, while the
+    // encrypted settings file still stores the plaintext for runtime use.
     const providerCredentials = await page.evaluate(async () => window.coworkApi.settings.getProviderCredentials('openrouter', {
       workspaceId: 'local',
       purpose: 'credential_editor',
     }))
     assert.equal(
       providerCredentials.apiKey,
+      '••••••••',
+      'credential editor IPC must not expose the stored provider credential plaintext',
+    )
+
+    const encryptedSettingsPath = join(paths.dataRoot, 'settings.enc')
+    const plaintextSettingsPath = join(paths.dataRoot, 'settings.json')
+    const persistedSettingsJson = existsSync(encryptedSettingsPath)
+      ? await app.evaluate(({ safeStorage }, bytes: number[]) => {
+          if (!safeStorage?.decryptString) throw new Error('safeStorage.decryptString is unavailable')
+          return safeStorage.decryptString(Buffer.from(bytes))
+        }, Array.from(readFileSync(encryptedSettingsPath)))
+      : existsSync(plaintextSettingsPath)
+        ? readFileSync(plaintextSettingsPath, 'utf8')
+        : null
+    if (persistedSettingsJson === null) assert.fail('settings must be persisted to disk')
+    const persisted = JSON.parse(persistedSettingsJson) as {
+      providerCredentials?: Record<string, Record<string, string>>
+    }
+    assert.equal(
+      persisted.providerCredentials?.openrouter?.apiKey,
       'roundtrip-key',
-      'safeStorage-encrypted credential must decrypt back to the original value',
+      'stored credential must read back to the original value from persisted settings',
     )
   } finally {
     await cleanup()

--- a/apps/desktop/tests/smoke-helpers.ts
+++ b/apps/desktop/tests/smoke-helpers.ts
@@ -38,6 +38,7 @@ export async function acceptNextNativeConfirmation(app: ElectronApplication) {
 export interface SmokeHarness {
   app: ElectronApplication
   page: Page
+  paths: SmokePaths
   cleanup: () => Promise<void>
 }
 
@@ -808,6 +809,7 @@ export async function launchSmokeApp(options?: LaunchSmokeAppOptions): Promise<S
   return {
     app: session.app,
     page: session.page,
+    paths,
     async cleanup() {
       await session.close()
       cleanupSmokePaths(paths)

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -48,32 +48,12 @@ The remaining work is concentrated in four areas:
 - The Workflow tool bridge now verifies bearer tokens with
   `timingSafeEqual`, matching the Agent tool bridge, with a same-length
   wrong-token regression test.
+- Local credential editor IPC now returns descriptor-aware masked secret fields
+  instead of raw provider or integration secrets. Non-secret descriptor fields
+  can still be shown for editing, and echoed mask sentinels preserve the stored
+  secret on save.
 
 ## High Priority
-
-### Renderer IPC Can Read Raw Local Credentials
-
-Evidence:
-
-- `apps/desktop/src/preload/index.ts` exposes
-  `settings:get-provider-credentials` and
-  `settings:get-integration-credentials`.
-- `apps/desktop/src/main/ipc/app-handlers.ts` allows reads when the renderer
-  supplies `{ purpose: "credential_editor" }` for the local workspace.
-- `apps/desktop/src/main/settings.ts` returns raw provider and integration
-  credential bags.
-
-Impact: any renderer script execution in the trusted app can exfiltrate local
-provider keys and integration secrets. Existing Electron isolation, navigation
-guards, IPC sender validation, masked default settings, and encrypted-at-rest
-storage reduce exposure, but renderer compromise still becomes full local
-credential compromise.
-
-Target state: make credentials write-only from the renderer by default. Use
-masked placeholders plus replace-secret flows. If reveal is necessary, require
-a short-lived main-process reveal grant tied to a specific provider/key and a
-native or OS-backed confirmation. Add regression tests proving ordinary
-renderer code cannot retrieve raw secrets.
 
 ### Worker Lease Renewal Loss Does Not Cancel Active Execution
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -230,8 +230,9 @@ export interface CoworkAPI {
     // Returns credentials masked ('••••••••' for set values). Safe default
     // for any consumer that only needs non-secret fields.
     get: (options?: WorkspaceOptions) => Promise<EffectiveAppSettings>
-    // Scoped unmasked reads for credential editor surfaces. The renderer
-    // never receives the full effective settings object with every secret.
+    // Scoped masked reads for credential editor surfaces. Secret fields return
+    // the mask sentinel for configured values; raw secrets stay in the main
+    // process and are preserved when the mask is echoed through settings.set.
     getProviderCredentials: (providerId: string, options: WorkspaceOptions & { purpose: 'credential_editor' }) => Promise<Record<string, string>>
     getIntegrationCredentials: (integrationId: string, options: WorkspaceOptions & { purpose: 'credential_editor' }) => Promise<Record<string, string>>
     set: (updates: WorkspaceScoped<Partial<AppSettings>>) => Promise<EffectiveAppSettings>

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { CustomMcpConfig, DesktopPairingPublicRecord } from '@open-cowork/shared'
@@ -84,6 +84,41 @@ function createBaseContext() {
   }
 
   return { context, handlers, errors }
+}
+
+function writeCredentialDescriptorConfig(configDir: string) {
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({
+    providers: {
+      available: ['acme'],
+      defaultProvider: 'acme',
+      defaultModel: 'acme/model',
+      descriptors: {
+        acme: {
+          runtime: 'builtin',
+          name: 'Acme',
+          description: 'Acme provider',
+          defaultModel: 'acme/model',
+          credentials: [
+            { key: 'apiKey', label: 'API key', description: 'Secret API key', secret: true },
+            { key: 'projectId', label: 'Project', description: 'Visible project id', secret: false },
+          ],
+          models: [{ id: 'acme/model', name: 'Acme Model' }],
+        },
+      },
+    },
+    mcps: [{
+      name: 'github',
+      type: 'remote',
+      description: 'GitHub',
+      authMode: 'api_token',
+      url: 'https://mcp.example.test/github',
+      credentials: [
+        { key: 'token', label: 'Token', description: 'Secret token', secret: true },
+        { key: 'host', label: 'Host', description: 'Visible host', secret: false },
+      ],
+    }],
+  }))
 }
 
 function desktopPairingRecord(overrides: Partial<DesktopPairingPublicRecord> = {}): DesktopPairingPublicRecord {
@@ -1976,7 +2011,80 @@ test('settings handlers sync only portable settings for cloud workspaces', async
   ])
 })
 
-test('raw credential IPC is unavailable from Gateway and Paired Desktop workspaces', async () => {
+test('local credential editor IPC masks secret fields and preserves them on save', async () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-ipc-masked-credentials-'))
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeCredentialDescriptorConfig(configDir)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  try {
+    const {
+      CREDENTIAL_MASK,
+      clearSettingsCache,
+      loadSettings,
+      saveSettings,
+    } = await import('../apps/desktop/src/main/settings.ts')
+    clearSettingsCache()
+    saveSettings({
+      providerCredentials: {
+        acme: { apiKey: 'provider-secret', projectId: 'project-visible' },
+      },
+      integrationCredentials: {
+        github: { token: 'integration-secret', host: 'github.example.test' },
+      },
+    })
+
+    const { context, handlers } = createBaseContext()
+    registerAppHandlers(context)
+    const localEvent = { sender: { id: 901 } } as never
+
+    assert.deepEqual(await handlers.get('settings:get-provider-credentials')?.(localEvent, 'acme', {
+      workspaceId: LOCAL_WORKSPACE_ID,
+      purpose: 'credential_editor',
+    }), {
+      apiKey: CREDENTIAL_MASK,
+      projectId: 'project-visible',
+    })
+    assert.deepEqual(await handlers.get('settings:get-integration-credentials')?.(localEvent, 'github', {
+      workspaceId: LOCAL_WORKSPACE_ID,
+      purpose: 'credential_editor',
+    }), {
+      token: CREDENTIAL_MASK,
+      host: 'github.example.test',
+    })
+
+    saveSettings({
+      providerCredentials: {
+        acme: { apiKey: CREDENTIAL_MASK, projectId: 'project-updated' },
+      },
+      integrationCredentials: {
+        github: { token: CREDENTIAL_MASK, host: 'github-updated.example.test' },
+      },
+    })
+    const persisted = loadSettings()
+    assert.equal(persisted.providerCredentials.acme.apiKey, 'provider-secret')
+    assert.equal(persisted.providerCredentials.acme.projectId, 'project-updated')
+    assert.equal(persisted.integrationCredentials.github.token, 'integration-secret')
+    assert.equal(persisted.integrationCredentials.github.host, 'github-updated.example.test')
+  } finally {
+    const { clearSettingsCache } = await import('../apps/desktop/src/main/settings.ts')
+    clearSettingsCache()
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('credential editor IPC is unavailable from Gateway and Paired Desktop workspaces', async () => {
   const { context, handlers } = createBaseContext()
   const pairing: DesktopPairingPublicRecord = {
     id: 'pairing-credentials',

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -66,6 +66,41 @@ function writeProviderDefaultConfig(configDir: string, internalDefaultModel = 'i
   }))
 }
 
+function writeCredentialDescriptorConfig(configDir: string) {
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, 'config.jsonc'), JSON.stringify({
+    providers: {
+      available: ['acme'],
+      defaultProvider: 'acme',
+      defaultModel: 'acme/model',
+      descriptors: {
+        acme: {
+          runtime: 'builtin',
+          name: 'Acme',
+          description: 'Acme provider',
+          defaultModel: 'acme/model',
+          credentials: [
+            { key: 'apiKey', label: 'API key', description: 'Secret API key', secret: true },
+            { key: 'projectId', label: 'Project', description: 'Visible project id', secret: false },
+          ],
+          models: [{ id: 'acme/model', name: 'Acme Model' }],
+        },
+      },
+    },
+    mcps: [{
+      name: 'github',
+      type: 'remote',
+      description: 'GitHub',
+      authMode: 'api_token',
+      url: 'https://mcp.example.test/github',
+      credentials: [
+        { key: 'token', label: 'Token', description: 'Secret token', secret: true },
+        { key: 'host', label: 'Host', description: 'Visible host', secret: false },
+      ],
+    }],
+  }))
+}
+
 async function importFreshSettingsModule(label: string) {
   return import(`../apps/desktop/src/main/settings.ts?${label}-${Date.now()}`)
 }
@@ -321,14 +356,14 @@ test('loadSettings migrates legacy encrypted development settings to plaintext',
   }
 })
 
-test('credential reads are scoped while default effective settings can be masked', async () => {
+test('credential reads return descriptor-aware masks while default effective settings can be masked', async () => {
   const tempRoot = testTempDir('opencowork-settings-scoped-credentials-')
   const configDir = join(tempRoot, 'downstream')
   const userDataDir = join(tempRoot, 'user-data')
   const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
   const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
 
-  writeEmptyConfig(configDir)
+  writeCredentialDescriptorConfig(configDir)
   process.env.OPEN_COWORK_CONFIG_DIR = configDir
   process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
   clearConfigCaches()
@@ -342,21 +377,29 @@ test('credential reads are scoped while default effective settings can be masked
       maskEffectiveSettingsCredentials,
       saveSettings,
     } = await importFreshSettingsModule('scoped-credentials')
-    saveSettings({
-      providerCredentials: {
-        openrouter: { apiKey: 'provider-secret' },
-        databricks: { token: 'other-provider-secret' },
-      },
-      integrationCredentials: {
-        github: { token: 'integration-secret' },
-      },
-    })
+      saveSettings({
+        providerCredentials: {
+          acme: { apiKey: 'provider-secret', projectId: 'project-visible' },
+          databricks: { token: 'other-provider-secret' },
+        },
+        integrationCredentials: {
+          github: { token: 'integration-secret', host: 'github.example.test' },
+        },
+      })
 
     const masked = maskEffectiveSettingsCredentials(getEffectiveSettings())
-    assert.equal(masked.providerCredentials.openrouter.apiKey, CREDENTIAL_MASK)
+    assert.equal(masked.providerCredentials.acme.apiKey, CREDENTIAL_MASK)
+    assert.equal(masked.providerCredentials.acme.projectId, CREDENTIAL_MASK)
     assert.equal(masked.integrationCredentials.github.token, CREDENTIAL_MASK)
-    assert.deepEqual(getProviderCredentials('openrouter'), { apiKey: 'provider-secret' })
-    assert.deepEqual(getIntegrationCredentials('github'), { token: 'integration-secret' })
+    assert.equal(masked.integrationCredentials.github.host, CREDENTIAL_MASK)
+    assert.deepEqual(getProviderCredentials('acme'), {
+      apiKey: CREDENTIAL_MASK,
+      projectId: 'project-visible',
+    })
+    assert.deepEqual(getIntegrationCredentials('github'), {
+      token: CREDENTIAL_MASK,
+      host: 'github.example.test',
+    })
   } finally {
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir


### PR DESCRIPTION
## Summary
- return descriptor-aware masked secret values from provider/integration credential editor IPCs
- preserve non-secret credential metadata for editing while keeping raw secrets in the main process
- clear masked provider secret fields on focus so users replace rather than edit the mask sentinel
- add settings and IPC regression coverage, and update the production-readiness audit status

## Validation
- node scripts/run-node-tests.mjs tests/settings.test.ts
- node scripts/run-node-tests.mjs tests/ipc-handler-behavior.test.ts
- ./apps/desktop/node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json
- ./apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
- ./apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.preload.json --noEmit
- ./node_modules/.bin/vitest run --config vitest.renderer.config.ts src/renderer/components/SetupScreen.test.tsx src/renderer/components/sidebar/SettingsPanel.test.tsx
- node scripts/lint.mjs
- node scripts/check-preload-channels.mjs && node scripts/check-shared-dist.mjs
- node scripts/validate-deployment-configs.mjs
- .venv-docs/bin/mkdocs build --strict
- git diff --check

Note: the local CapabilitiesPage renderer suite could not start in this workspace because local node_modules is missing @ungap/structured-clone; CI will run from a clean install.