### PR TITLE
Derive managed worker tenant ids

### DIFF
--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -1549,7 +1549,6 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly workspaceEvents = new Map<string, { nextSequence: number, events: WorkspaceEventRecord[] }>()
   private readonly managedWorkersDomain = new InMemoryManagedWorkersDomain({
     orgTenantId: (orgId) => this.orgs.get(orgId)?.tenantId || null,
-    hasTenant: (tenantId) => this.tenants.has(tenantId),
     recordAuditEvent: (input) => this.recordAuditEvent(input),
   })
   private readonly quotaDomain = new InMemoryQuotaDomain({

--- a/apps/desktop/src/main/cloud/in-memory-domains/workers.ts
+++ b/apps/desktop/src/main/cloud/in-memory-domains/workers.ts
@@ -26,7 +26,6 @@ const MANAGED_WORKER_SUPPORTED_POOL_MODES = new Set<ManagedWorkerPoolMode>(['saa
 
 type ManagedWorkersDomainHost = {
   orgTenantId(orgId: string): string | null
-  hasTenant(tenantId: string): boolean
   recordAuditEvent(input: RecordAuditEventInput): unknown
 }
 
@@ -44,12 +43,11 @@ export class InMemoryManagedWorkersDomain {
   createPool(input: CreateManagedWorkerPoolInput): ManagedWorkerPoolRecord {
     const orgTenantId = this.host.orgTenantId(input.orgId)
     if (!orgTenantId) throw new Error(`Unknown org ${input.orgId}.`)
-    if (input.tenantId && !this.host.hasTenant(input.tenantId)) throw new Error(`Unknown tenant ${input.tenantId}.`)
     const now = nowIso(input.createdAt)
     const record: ManagedWorkerPoolRecord = {
       poolId: input.poolId || stableId('mwp', input.orgId, input.name, now),
       orgId: input.orgId,
-      tenantId: input.tenantId === undefined ? orgTenantId : input.tenantId,
+      tenantId: orgTenantId,
       name: normalizeText(input.name, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool name'),
       mode: normalizePoolMode(input.mode),
       status: normalizePoolStatus(input.status),
@@ -135,7 +133,7 @@ export class InMemoryManagedWorkersDomain {
     const record: ManagedWorkerRecord = {
       workerId: input.workerId || stableId('mworker', input.orgId, input.poolId, input.displayName, now),
       orgId: input.orgId,
-      tenantId: input.tenantId === undefined ? pool.tenantId : input.tenantId,
+      tenantId: pool.tenantId,
       poolId: input.poolId,
       displayName: normalizeText(input.displayName, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker display name'),
       status: normalizeWorkerStatus(input.status),

--- a/apps/desktop/src/main/cloud/managed-worker-types.ts
+++ b/apps/desktop/src/main/cloud/managed-worker-types.ts
@@ -87,7 +87,6 @@ type ManagedWorkerActorInput = {
 export type CreateManagedWorkerPoolInput = {
   poolId?: string
   orgId: string
-  tenantId?: string | null
   name: string
   mode: ManagedWorkerPoolMode
   status?: ManagedWorkerPoolStatus
@@ -116,7 +115,6 @@ export type RegisterManagedWorkerInput = {
   workerId?: string
   orgId: string
   poolId: string
-  tenantId?: string | null
   displayName: string
   status?: ManagedWorkerStatus
   version?: string | null

--- a/apps/desktop/src/main/cloud/postgres-store-domains/workers.ts
+++ b/apps/desktop/src/main/cloud/postgres-store-domains/workers.ts
@@ -71,7 +71,7 @@ export class PostgresManagedWorkersRepository {
         [
           poolId,
           input.orgId,
-          input.tenantId === undefined ? org.tenant_id : input.tenantId,
+          String(org.tenant_id),
           normalizeText(input.name, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker pool name'),
           normalizePoolMode(input.mode),
           normalizePoolStatus(input.status),
@@ -179,7 +179,7 @@ export class PostgresManagedWorkersRepository {
         [
           workerId,
           input.orgId,
-          input.tenantId === undefined ? pool.tenantId : input.tenantId,
+          pool.tenantId,
           input.poolId,
           normalizeText(input.displayName, MANAGED_WORKER_TEXT_MAX_LENGTH, 'Managed worker display name'),
           normalizeWorkerStatus(input.status),

--- a/tests/cloud-control-plane-store-contracts.test.ts
+++ b/tests/cloud-control-plane-store-contracts.test.ts
@@ -154,22 +154,25 @@ function runControlPlaneDomainContracts(
       const workerPool = await store.createManagedWorkerPool({
         poolId: `${prefix}-pool`,
         orgId: org.orgId,
-        tenantId,
+        tenantId: `${prefix}-spoofed-pool-tenant`,
         name: 'Managed pool',
         mode: 'self_hosted',
         capabilities: { profiles: ['default'] },
         actor: { actorType: 'user', actorId: accountId, accountId },
-      })
+      } as Parameters<typeof store.createManagedWorkerPool>[0] & { tenantId: string })
       assert.equal(workerPool.status, 'active')
+      assert.equal(workerPool.tenantId, tenantId)
       const managedWorker = await store.registerManagedWorker({
         workerId: `${prefix}-managed-worker`,
         orgId: org.orgId,
         poolId: workerPool.poolId,
+        tenantId: `${prefix}-spoofed-worker-tenant`,
         displayName: 'Managed worker',
         capabilities: { runtime: 'opencode' },
         actor: { actorType: 'user', actorId: accountId, accountId },
-      })
+      } as Parameters<typeof store.registerManagedWorker>[0] & { tenantId: string })
       assert.equal(managedWorker.status, 'pending')
+      assert.equal(managedWorker.tenantId, tenantId)
       await store.updateManagedWorkerStatus({
         orgId: org.orgId,
         workerId: managedWorker.workerId,


### PR DESCRIPTION
## Summary
- remove managed-worker tenantId from lower store creation inputs
- derive worker pool tenant IDs from the owning org and worker tenant IDs from the selected pool
- add a store contract regression proving runtime-smuggled tenantId values are ignored

## Validation
- node scripts/run-node-tests.mjs tests/cloud-control-plane-store.test.ts tests/cloud-control-plane-store-contracts.test.ts
- node scripts/run-node-tests.mjs tests/cloud-http-server.test.ts
- ./apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
- git diff --check