### PR TITLE
Abort cloud worker commands on lease loss

### DIFF
--- a/apps/desktop/src/main/cloud/runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/runtime-adapter.ts
@@ -48,11 +48,13 @@ export type CloudRuntimeAdapter = {
     parts: CloudRuntimePromptPart[]
     agent: string
     context?: CloudRuntimeExecutionContext | null
+    messageId?: string
+    signal?: AbortSignal
   }): Promise<CloudPromptResult | void>
-  abortSession(input: { sessionId: string, context?: CloudRuntimeExecutionContext | null }): Promise<void>
-  replyToQuestion?(input: { requestId: string, answers: unknown[], context?: CloudRuntimeExecutionContext | null }): Promise<void>
-  rejectQuestion?(input: { requestId: string, context?: CloudRuntimeExecutionContext | null }): Promise<void>
-  respondToPermission?(input: { permissionId: string, allowed: boolean, context?: CloudRuntimeExecutionContext | null }): Promise<void>
+  abortSession(input: { sessionId: string, context?: CloudRuntimeExecutionContext | null, signal?: AbortSignal }): Promise<void>
+  replyToQuestion?(input: { requestId: string, answers: unknown[], context?: CloudRuntimeExecutionContext | null, signal?: AbortSignal }): Promise<void>
+  rejectQuestion?(input: { requestId: string, context?: CloudRuntimeExecutionContext | null, signal?: AbortSignal }): Promise<void>
+  respondToPermission?(input: { permissionId: string, allowed: boolean, context?: CloudRuntimeExecutionContext | null, signal?: AbortSignal }): Promise<void>
   subscribeEvents?: (
     listener: CloudRuntimeEventListener,
     options?: CloudRuntimeSubscribeOptions,
@@ -67,8 +69,9 @@ type SdkLikeClient = {
       sessionID: string
       parts: CloudRuntimePromptPart[]
       agent: string
-    }, options?: { throwOnError?: boolean }): Promise<unknown>
-    abort(input: { sessionID: string }): Promise<unknown>
+      messageID?: string
+    }, options?: { throwOnError?: boolean, signal?: AbortSignal }): Promise<unknown>
+    abort(input: { sessionID: string }, options?: { throwOnError?: boolean, signal?: AbortSignal }): Promise<unknown>
   }
   question?: {
     reply?: unknown
@@ -103,42 +106,43 @@ export function createSdkCloudRuntimeAdapter(client: SdkLikeClient): CloudRuntim
         sessionID: input.sessionId,
         parts: input.parts,
         agent: input.agent,
-      }, { throwOnError: true })
+        ...(input.messageId ? { messageID: input.messageId } : {}),
+      }, { throwOnError: true, signal: input.signal })
     },
     async abortSession(input) {
-      await client.session.abort({ sessionID: input.sessionId })
+      await client.session.abort({ sessionID: input.sessionId }, { throwOnError: true, signal: input.signal })
     },
     async replyToQuestion(input) {
       if (typeof client.question?.reply !== 'function') throw new Error('OpenCode question replies are not available.')
       const reply = client.question.reply as (
         request: { requestID: string, answers: unknown[] },
-        options?: { throwOnError?: boolean },
+        options?: { throwOnError?: boolean, signal?: AbortSignal },
       ) => Promise<unknown>
       await reply.call(client.question, {
         requestID: input.requestId,
         answers: input.answers,
-      }, { throwOnError: true })
+      }, { throwOnError: true, signal: input.signal })
     },
     async rejectQuestion(input) {
       if (typeof client.question?.reject !== 'function') throw new Error('OpenCode question rejection is not available.')
       const reject = client.question.reject as (
         request: { requestID: string },
-        options?: { throwOnError?: boolean },
+        options?: { throwOnError?: boolean, signal?: AbortSignal },
       ) => Promise<unknown>
       await reject.call(client.question, {
         requestID: input.requestId,
-      }, { throwOnError: true })
+      }, { throwOnError: true, signal: input.signal })
     },
     async respondToPermission(input) {
       if (typeof client.permission?.reply !== 'function') throw new Error('OpenCode permission responses are not available.')
       const reply = client.permission.reply as (
         request: { requestID: string, reply: 'once' | 'reject' },
-        options?: { throwOnError?: boolean },
+        options?: { throwOnError?: boolean, signal?: AbortSignal },
       ) => Promise<unknown>
       await reply.call(client.permission, {
         requestID: input.permissionId,
         reply: input.allowed ? 'once' : 'reject',
-      }, { throwOnError: true })
+      }, { throwOnError: true, signal: input.signal })
     },
   }
 }

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -602,6 +602,26 @@ function importAuditActor(principal: CloudPrincipal): { actorType: 'user' | 'api
   }
 }
 
+function throwIfAborted(signal: AbortSignal | undefined) {
+  if (!signal?.aborted) return
+  const reason = signal.reason
+  if (reason instanceof Error) throw reason
+  throw new Error(typeof reason === 'string' && reason.trim() ? reason : 'Cloud worker command execution was aborted.')
+}
+
+function runOnAbort(signal: AbortSignal | undefined, callback: () => Promise<void> | void) {
+  if (!signal) return () => undefined
+  const abort = () => {
+    void Promise.resolve(callback()).catch(() => undefined)
+  }
+  if (signal.aborted) {
+    abort()
+    return () => undefined
+  }
+  signal.addEventListener('abort', abort, { once: true })
+  return () => signal.removeEventListener('abort', abort)
+}
+
 export class CloudSessionService {
   private readonly store: ControlPlaneStore
   private readonly runtime: CloudRuntimeAdapter
@@ -3054,31 +3074,38 @@ export class CloudSessionService {
     })
   }
 
-  async executeCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord): Promise<void> {
+  async executeCommand(
+    lease: WorkerLeaseRecord,
+    command: SessionCommandRecord,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<void> {
     try {
+      throwIfAborted(options.signal)
       switch (command.kind) {
         case 'prompt':
-          await this.executePromptCommand(lease, command)
+          await this.executePromptCommand(lease, command, options.signal)
           break
         case 'abort':
-          await this.executeAbortCommand(lease, command)
+          await this.executeAbortCommand(lease, command, options.signal)
           break
         case 'question.reply':
-          await this.executeQuestionReplyCommand(lease, command)
+          await this.executeQuestionReplyCommand(lease, command, options.signal)
           break
         case 'question.reject':
-          await this.executeQuestionRejectCommand(lease, command)
+          await this.executeQuestionRejectCommand(lease, command, options.signal)
           break
         case 'permission.respond':
-          await this.executePermissionCommand(lease, command)
+          await this.executePermissionCommand(lease, command, options.signal)
           break
         default: {
           const unsupported: never = command.kind
           throw new Error(`Unsupported command kind ${String(unsupported)}.`)
         }
       }
+      throwIfAborted(options.signal)
       await this.store.ackSessionCommand(lease, command.commandId)
     } catch (error) {
+      if (options.signal?.aborted) throw error
       const message = error instanceof Error ? error.message : String(error)
       await this.appendProjectedEvent({
         tenantId: command.tenantId,
@@ -3142,10 +3169,13 @@ export class CloudSessionService {
     })
   }
 
-  private async executePromptCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
+  private async executePromptCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord, signal?: AbortSignal) {
+    throwIfAborted(signal)
     const payload = normalizePromptPayload(command.payload)
     const session = await this.requireSessionRecord(command.tenantId, command.sessionId)
     const runtimeSessionId = await this.ensureRuntimeSessionBound(lease)
+    const context = this.runtimeContext(session)
+    throwIfAborted(signal)
     await this.store.updateSessionStatus({
       tenantId: command.tenantId,
       sessionId: command.sessionId,
@@ -3164,12 +3194,24 @@ export class CloudSessionService {
       },
       leaseToken: lease.leaseToken,
     })
-    const result = await this.runtime.promptSession({
+    const stopAbortHandler = runOnAbort(signal, () => this.runtime.abortSession({
       sessionId: runtimeSessionId,
-      parts: promptParts(payload.text),
-      agent: payload.agent,
-      context: this.runtimeContext(session),
-    })
+      context,
+    }))
+    let result: Awaited<ReturnType<CloudRuntimeAdapter['promptSession']>>
+    try {
+      result = await this.runtime.promptSession({
+        sessionId: runtimeSessionId,
+        parts: promptParts(payload.text),
+        agent: payload.agent,
+        context,
+        messageId: command.commandId,
+        signal,
+      })
+    } finally {
+      stopAbortHandler()
+    }
+    throwIfAborted(signal)
     for (const event of result?.events || []) {
       await this.applyRuntimeEvent(lease, command.sessionId, event)
     }
@@ -3181,14 +3223,17 @@ export class CloudSessionService {
     )
   }
 
-  private async executeAbortCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
+  private async executeAbortCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord, signal?: AbortSignal) {
+    throwIfAborted(signal)
     const session = await this.requireSessionRecord(command.tenantId, command.sessionId)
     if (session.opencodeSessionId) {
       await this.runtime.abortSession({
         sessionId: session.opencodeSessionId,
         context: this.runtimeContext(session),
+        signal,
       })
     }
+    throwIfAborted(signal)
     await this.store.updateSessionStatus({
       tenantId: command.tenantId,
       sessionId: command.sessionId,
@@ -3206,7 +3251,8 @@ export class CloudSessionService {
     })
   }
 
-  private async executeQuestionReplyCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
+  private async executeQuestionReplyCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord, signal?: AbortSignal) {
+    throwIfAborted(signal)
     const payload = normalizeQuestionReplyPayload(command.payload)
     if (!payload.requestId) throw new Error('Question reply requires a request id.')
     if (!this.runtime.replyToQuestion) throw new Error('OpenCode question replies are not available.')
@@ -3215,7 +3261,9 @@ export class CloudSessionService {
       requestId: payload.requestId,
       answers: payload.answers,
       context: this.runtimeContext(session),
+      signal,
     })
+    throwIfAborted(signal)
     await this.appendProjectedEvent({
       tenantId: command.tenantId,
       sessionId: command.sessionId,
@@ -3229,7 +3277,8 @@ export class CloudSessionService {
     })
   }
 
-  private async executeQuestionRejectCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
+  private async executeQuestionRejectCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord, signal?: AbortSignal) {
+    throwIfAborted(signal)
     const payload = normalizeQuestionRejectPayload(command.payload)
     if (!payload.requestId) throw new Error('Question rejection requires a request id.')
     if (!this.runtime.rejectQuestion) throw new Error('OpenCode question rejection is not available.')
@@ -3237,7 +3286,9 @@ export class CloudSessionService {
     await this.runtime.rejectQuestion({
       requestId: payload.requestId,
       context: this.runtimeContext(session),
+      signal,
     })
+    throwIfAborted(signal)
     await this.appendProjectedEvent({
       tenantId: command.tenantId,
       sessionId: command.sessionId,
@@ -3251,7 +3302,8 @@ export class CloudSessionService {
     })
   }
 
-  private async executePermissionCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord) {
+  private async executePermissionCommand(lease: WorkerLeaseRecord, command: SessionCommandRecord, signal?: AbortSignal) {
+    throwIfAborted(signal)
     const payload = normalizePermissionPayload(command.payload)
     if (!payload.permissionId) throw new Error('Permission response requires a permission id.')
     if (!this.runtime.respondToPermission) throw new Error('OpenCode permission responses are not available.')
@@ -3264,7 +3316,9 @@ export class CloudSessionService {
       permissionId: payload.permissionId,
       allowed,
       context: this.runtimeContext(session),
+      signal,
     })
+    throwIfAborted(signal)
     await this.appendProjectedEvent({
       tenantId: command.tenantId,
       sessionId: command.sessionId,

--- a/apps/desktop/src/main/cloud/worker.ts
+++ b/apps/desktop/src/main/cloud/worker.ts
@@ -10,6 +10,13 @@ export type CloudWorkerCheckpointHooks = {
   saveAfterCommand?: (lease: WorkerLeaseRecord) => Promise<void>
 }
 
+export class CloudWorkerLeaseLostError extends Error {
+  constructor() {
+    super('Cloud worker lost its session lease during command execution.')
+    this.name = 'CloudWorkerLeaseLostError'
+  }
+}
+
 export class CloudWorker {
   private readonly claimBatchSize = 100
   private readonly leases = new Map<string, WorkerLeaseRecord>()
@@ -74,7 +81,7 @@ export class CloudWorker {
       })
       try {
         const commandLease = lease
-        lease = await this.executeWithLeaseRenewal(commandLease, () => this.service.executeCommand(commandLease, command))
+        lease = await this.executeWithLeaseRenewal(commandLease, (signal) => this.service.executeCommand(commandLease, command, { signal }))
         await this.service.recordManagedExecutionEvent({
           tenantId,
           sessionId,
@@ -243,13 +250,7 @@ export class CloudWorker {
       try {
         const renewed = await this.store.renewSessionLease(existing, new Date(), this.leaseTtlMs)
         this.leases.set(leaseKey, renewed)
-        await recordCloudWorkerMetric(this.observability, {
-          name: 'open_cowork_cloud_worker_lease_renewals_total',
-          workerId: this.workerId,
-          tenantId,
-          sessionId,
-          status: 'ok',
-        })
+        void this.recordRenewalMetric(tenantId, sessionId, 'ok')
         return renewed
       } catch {
         this.leases.delete(leaseKey)
@@ -324,41 +325,42 @@ export class CloudWorker {
     })
   }
 
-  private async executeWithLeaseRenewal<T>(lease: WorkerLeaseRecord, work: () => Promise<T>): Promise<WorkerLeaseRecord> {
+  private async executeWithLeaseRenewal<T>(lease: WorkerLeaseRecord, work: (signal: AbortSignal) => Promise<T>): Promise<WorkerLeaseRecord> {
     let current = lease
     let renewing = false
+    let leaseLostError: CloudWorkerLeaseLostError | null = null
+    const controller = new AbortController()
     const intervalMs = Math.max(1_000, Math.floor(this.leaseTtlMs / 3))
+    const markLeaseLost = () => {
+      if (leaseLostError) return
+      leaseLostError = new CloudWorkerLeaseLostError()
+      this.leases.delete(this.leaseKey(lease.tenantId, lease.sessionId))
+      controller.abort(leaseLostError)
+    }
     const timer = setInterval(() => {
+      if (controller.signal.aborted) return
       if (renewing) return
       renewing = true
-      void Promise.resolve(this.store.renewSessionLease(current, new Date(), this.leaseTtlMs))
+      void Promise.resolve()
+        .then(() => this.store.renewSessionLease(current, new Date(), this.leaseTtlMs))
         .then((renewed) => {
+          if (controller.signal.aborted) return
           current = renewed
           this.leases.set(this.leaseKey(renewed.tenantId, renewed.sessionId), renewed)
-          return recordCloudWorkerMetric(this.observability, {
-            name: 'open_cowork_cloud_worker_lease_renewals_total',
-            workerId: this.workerId,
-            tenantId: renewed.tenantId,
-            sessionId: renewed.sessionId,
-            status: 'ok',
-          })
+          void this.recordRenewalMetric(renewed.tenantId, renewed.sessionId, 'ok')
         })
         .catch((error: unknown) => {
           void error
-          void recordCloudWorkerMetric(this.observability, {
-            name: 'open_cowork_cloud_worker_lease_renewals_total',
-            workerId: this.workerId,
-            tenantId: lease.tenantId,
-            sessionId: lease.sessionId,
-            status: 'failed',
-          })
+          markLeaseLost()
+          void this.recordRenewalMetric(lease.tenantId, lease.sessionId, 'failed')
         })
         .finally(() => {
           renewing = false
         })
     }, intervalMs)
     try {
-      await work()
+      await work(controller.signal)
+      if (leaseLostError) throw leaseLostError
       return current
     } finally {
       clearInterval(timer)
@@ -367,5 +369,19 @@ export class CloudWorker {
 
   private leaseKey(tenantId: string, sessionId: string) {
     return `${tenantId}\0${sessionId}`
+  }
+
+  private async recordRenewalMetric(tenantId: string, sessionId: string, status: 'ok' | 'failed') {
+    try {
+      await recordCloudWorkerMetric(this.observability, {
+        name: 'open_cowork_cloud_worker_lease_renewals_total',
+        workerId: this.workerId,
+        tenantId,
+        sessionId,
+        status,
+      })
+    } catch {
+      // Lease ownership is authoritative; telemetry failures must not change command execution.
+    }
   }
 }

--- a/tests/cloud-worker-lease-renewal.test.ts
+++ b/tests/cloud-worker-lease-renewal.test.ts
@@ -1,0 +1,251 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { DEFAULT_CONFIG } from '../apps/desktop/src/main/config-types.ts'
+import { resolveCloudRuntimePolicy } from '../apps/desktop/src/main/cloud/cloud-config.ts'
+import { InMemoryControlPlaneStore } from '../apps/desktop/src/main/cloud/in-memory-control-plane-store.ts'
+import type { CloudObservabilityAdapter } from '../apps/desktop/src/main/cloud/observability.ts'
+import { CloudSessionService } from '../apps/desktop/src/main/cloud/session-service.ts'
+import { CloudWorker, CloudWorkerLeaseLostError } from '../apps/desktop/src/main/cloud/worker.ts'
+import type {
+  CloudRuntimeAdapter,
+  CloudRuntimePromptPart,
+} from '../apps/desktop/src/main/cloud/runtime-adapter.ts'
+
+class AbortAwareRuntime implements CloudRuntimeAdapter {
+  readonly promptSignals: AbortSignal[] = []
+  readonly abortReasons: unknown[] = []
+  readonly messageIds: Array<string | undefined> = []
+  readonly abortedSessions: string[] = []
+
+  async createSession() {
+    return {
+      id: 'oc-session-created',
+      title: 'Created session',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }
+  }
+
+  async promptSession(input: {
+    sessionId: string
+    parts: CloudRuntimePromptPart[]
+    agent: string
+    messageId?: string
+    signal?: AbortSignal
+  }) {
+    assert.equal(input.sessionId, 'oc-session-1')
+    assert.equal(input.parts.find((part) => part.type === 'text')?.text, 'long running prompt')
+    assert.ok(input.signal)
+    this.promptSignals.push(input.signal)
+    this.messageIds.push(input.messageId)
+    await new Promise<void>((_resolve, reject) => {
+      const signal = input.signal
+      if (!signal) {
+        reject(new Error('Expected a worker abort signal.'))
+        return
+      }
+      if (signal.aborted) {
+        this.abortReasons.push(signal.reason)
+        reject(signal.reason)
+        return
+      }
+      signal.addEventListener('abort', () => {
+        this.abortReasons.push(signal.reason)
+        reject(signal.reason instanceof Error ? signal.reason : new Error('Worker command aborted.'))
+      }, { once: true })
+    })
+  }
+
+  async abortSession(input: { sessionId: string }) {
+    this.abortedSessions.push(input.sessionId)
+  }
+}
+
+class SlowSuccessfulRuntime implements CloudRuntimeAdapter {
+  readonly messageIds: Array<string | undefined> = []
+  private readonly delayMs: number
+
+  constructor(delayMs = 1_100) {
+    this.delayMs = delayMs
+  }
+
+  async createSession() {
+    return {
+      id: 'oc-session-created',
+      title: 'Created session',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }
+  }
+
+  async promptSession(input: {
+    sessionId: string
+    parts: CloudRuntimePromptPart[]
+    agent: string
+    messageId?: string
+    signal?: AbortSignal
+  }) {
+    this.messageIds.push(input.messageId)
+    if (this.delayMs > 0) await new Promise((resolve) => setTimeout(resolve, this.delayMs))
+    return {
+      events: [{
+        type: 'assistant.message',
+        payload: {
+          messageId: `${input.sessionId}:assistant`,
+          content: 'done',
+        },
+      }, {
+        type: 'session.idle',
+        payload: {
+          sessionId: input.sessionId,
+        },
+      }],
+    }
+  }
+
+  async abortSession() {}
+}
+
+class FailingRenewalMetricObservability implements CloudObservabilityAdapter {
+  metricNames: string[] = []
+
+  async log() {}
+
+  async metric(record: { name: string }) {
+    this.metricNames.push(record.name)
+    if (record.name === 'open_cowork_cloud_worker_lease_renewals_total') {
+      throw new Error('simulated renewal metric failure')
+    }
+  }
+
+  async span() {}
+}
+
+function seedStore() {
+  const store = new InMemoryControlPlaneStore()
+  store.createTenant({ tenantId: 'tenant-1', name: 'Acme' })
+  store.ensureUser({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    email: 'user@example.com',
+    role: 'owner',
+  })
+  store.createSession({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    opencodeSessionId: 'oc-session-1',
+    profileName: 'default',
+  })
+  store.enqueueSessionCommand({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    commandId: 'cmd-1',
+    kind: 'prompt',
+    payload: { text: 'long running prompt', agent: 'build' },
+  })
+  return store
+}
+
+test('cloud worker aborts active command when session lease renewal is lost', async () => {
+  const store = seedStore()
+  const runtime = new AbortAwareRuntime()
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+    undefined,
+    { randomUUID: () => 'test-id' },
+  )
+  const worker = new CloudWorker(store, service, 'worker-1', 3_000)
+
+  const originalRenewSessionLease = store.renewSessionLease.bind(store)
+  const originalCheckpointSession = store.checkpointSession.bind(store)
+  let renewAttempts = 0
+  let checkpointAttempts = 0
+  store.renewSessionLease = (lease, now, ttlMs) => {
+    renewAttempts += 1
+    throw new Error(`simulated renewal loss for ${lease.leaseToken}:${now?.toISOString()}:${ttlMs}`)
+  }
+  store.checkpointSession = (lease) => {
+    checkpointAttempts += 1
+    return originalCheckpointSession(lease)
+  }
+
+  await assert.rejects(
+    () => worker.processSessionCommands('tenant-1', 'session-1'),
+    CloudWorkerLeaseLostError,
+  )
+
+  assert.equal(renewAttempts, 1)
+  assert.equal(checkpointAttempts, 0)
+  assert.equal(runtime.promptSignals.length, 1)
+  assert.deepEqual(runtime.messageIds, ['cmd-1'])
+  assert.equal(runtime.promptSignals[0]?.aborted, true)
+  assert.equal(runtime.abortReasons[0] instanceof CloudWorkerLeaseLostError, true)
+  assert.deepEqual(runtime.abortedSessions, ['oc-session-1'])
+
+  store.renewSessionLease = originalRenewSessionLease
+  const recoveryNow = new Date(Date.now() + 60_000)
+  const reaped = store.reapExpiredSessionLeases({ now: recoveryNow })
+  assert.deepEqual(reaped.map((entry) => entry.retriedCommandIds), [['cmd-1']])
+
+  const nextLease = store.claimSessionLease('tenant-1', 'session-1', 'worker-2', recoveryNow)
+  assert.ok(nextLease)
+  const reclaimed = store.claimNextSessionCommand(nextLease, recoveryNow)
+  assert.equal(reclaimed?.commandId, 'cmd-1')
+  assert.equal(reclaimed?.status, 'running')
+  assert.equal(reclaimed?.attemptCount, 2)
+})
+
+test('cloud worker does not treat renewal metric failures as lease loss', async () => {
+  const store = seedStore()
+  const runtime = new SlowSuccessfulRuntime()
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+    undefined,
+    { randomUUID: () => 'test-id' },
+  )
+  const observability = new FailingRenewalMetricObservability()
+  const worker = new CloudWorker(store, service, 'worker-1', 3_000, {}, null, observability)
+
+  await assert.doesNotReject(() => worker.processSessionCommands('tenant-1', 'session-1'))
+  assert.deepEqual(runtime.messageIds, ['cmd-1'])
+  assert.equal(observability.metricNames.includes('open_cowork_cloud_worker_lease_renewals_total'), true)
+
+  const lease = store.claimSessionLease('tenant-1', 'session-1', 'worker-2', new Date(Date.now() + 60_000))
+  assert.ok(lease)
+  assert.equal(store.claimNextSessionCommand(lease, new Date(Date.now() + 60_000)), null)
+})
+
+test('cloud worker keeps a valid cached lease when cached renewal metrics fail', async () => {
+  const store = seedStore()
+  const runtime = new SlowSuccessfulRuntime(0)
+  const service = new CloudSessionService(
+    store,
+    runtime,
+    resolveCloudRuntimePolicy(DEFAULT_CONFIG),
+    undefined,
+    { randomUUID: () => 'test-id' },
+  )
+  const observability = new FailingRenewalMetricObservability()
+  const worker = new CloudWorker(store, service, 'worker-1', 3_000, {}, null, observability)
+
+  assert.equal(await worker.processSessionCommands('tenant-1', 'session-1'), 1)
+  store.enqueueSessionCommand({
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    commandId: 'cmd-2',
+    kind: 'prompt',
+    payload: { text: 'second prompt', agent: 'build' },
+  })
+
+  assert.equal(await worker.processSessionCommands('tenant-1', 'session-1'), 1)
+  assert.deepEqual(runtime.messageIds, ['cmd-1', 'cmd-2'])
+  assert.equal(observability.metricNames.includes('open_cowork_cloud_worker_lease_renewals_total'), true)
+})


### PR DESCRIPTION
## Summary\n- abort active cloud worker command execution when session lease renewal is lost\n- pass AbortSignal through cloud runtime prompt/abort/question/permission calls\n- use stable OpenCode message IDs for prompt command retries and abort the runtime session on prompt lease loss\n- isolate renewal telemetry failures from lease ownership decisions\n- add regressions for active lease loss, renewal metric failures, and cached lease renewal\n\n## Validation\n- node scripts/run-node-tests.mjs tests/cloud-worker-lease-renewal.test.ts\n- node scripts/run-node-tests.mjs tests/cloud-worker-lease-renewal.test.ts tests/cloud-http-server.test.ts tests/cloud-session-projection.test.ts tests/cloud-opencode-runtime-adapter.test.ts tests/desktop-cloud-sync-smoke.test.ts tests/cloud-continuation-e2e.test.ts\n- ./node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit\n- node scripts/lint.mjs\n- git diff --check\n- node scripts/run-node-tests.mjs