### PR TITLE
Harden cloud observability failures

### DIFF
--- a/apps/desktop/src/main/cloud/app.ts
+++ b/apps/desktop/src/main/cloud/app.ts
@@ -22,6 +22,8 @@ import {
 } from './http-server.ts'
 import {
   createCloudObservabilityFromEnv,
+  recordCloudLog,
+  recordCloudMetric,
   recordCloudSchedulerMetric,
   recordCloudWorkerMetric,
   type CloudObservabilityAdapter,
@@ -1176,7 +1178,7 @@ async function recordLoopError(
   error: unknown,
   attributes: Record<string, string | number | boolean | null | undefined> = {},
 ) {
-  await observability?.metric({
+  await recordCloudMetric(observability, {
     name: 'open_cowork_cloud_loop_errors_total',
     value: 1,
     unit: '1',
@@ -1186,7 +1188,7 @@ async function recordLoopError(
       error_name: error instanceof Error ? error.name : 'Error',
     },
   })
-  await observability?.log({
+  await recordCloudLog(observability, {
     level: 'error',
     name,
     message: error instanceof Error ? error.message : String(error),
@@ -1216,7 +1218,7 @@ async function waitForLoopDrain(
   ])
   if (timeout) clearTimeout(timeout)
   if (result === timeoutMarker) {
-    await observability?.log({
+    await recordCloudLog(observability, {
       level: 'warn',
       name: `cloud.${loopName}.shutdown_timeout`,
       message: `Cloud ${loopName} loop did not finish before shutdown grace elapsed.`,
@@ -1539,7 +1541,7 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
         ))
       }, {
         onDroppedEvent(event) {
-          void observability?.metric({
+          void recordCloudMetric(observability, {
             name: 'open_cowork_cloud_opencode_events_dropped_total',
             value: 1,
             unit: '1',
@@ -1635,7 +1637,11 @@ export async function startCloudApp(options: CloudAppOptions = {}): Promise<Clou
       ])
       runtimeUnsubscribe?.()
       await server?.close()
-      await observability?.close?.()
+      try {
+        await observability?.close?.()
+      } catch {
+        // Telemetry shutdown must not block runtime, object-store, or control-plane cleanup.
+      }
       await runtime.close?.()
       await objectStore.close?.()
       await store.close?.()

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -45,7 +45,7 @@ import type {
   SessionEventRecord,
   WorkspaceEventRecord,
 } from './control-plane-store.ts'
-import { recordCloudHttpRequest } from './observability.ts'
+import { recordCloudHttpRequest, recordCloudMetric } from './observability.ts'
 import type { CloudCookieSession, CloudSessionCookieManager } from './session-cookie-auth.ts'
 import {
   InMemoryWorkflowWebhookSecurityStore,
@@ -1720,7 +1720,7 @@ export class CloudHttpServer {
         ? 'open_cowork_cloud_auth_failures_total'
         : null
     if (!name) return
-    await this.options.observability?.metric({
+    await recordCloudMetric(this.options.observability, {
       name,
       value: 1,
       unit: '1',

--- a/apps/desktop/src/main/cloud/observability.ts
+++ b/apps/desktop/src/main/cloud/observability.ts
@@ -56,6 +56,8 @@ export type OtlpHttpCloudObservabilityOptions = {
   serviceVersion?: string | null
   headers?: Record<string, string>
   fetch?: typeof fetch
+  flushIntervalMs?: number
+  maxQueueSize?: number
 }
 
 export type CloudHttpRequestObservation = {
@@ -77,6 +79,8 @@ type CloudPrometheusMetricPoint = {
 }
 
 const DEFAULT_SERVICE_NAME = 'open-cowork-cloud'
+const DEFAULT_OTLP_FLUSH_INTERVAL_MS = 30_000
+const DEFAULT_OTLP_MAX_QUEUE_SIZE = 1_000
 const SENSITIVE_FIELD = /(authorization|cookie|token|secret|password|credential|key|ref|kmsref|ciphertext|envelope)$/i
 const MAX_STRING_LENGTH = 512
 const SIGNED_URL_QUERY_PATTERN = /\b(https?:\/\/[^\s"'<>?]+)\?[^"'<> \t\r\n]+/gi
@@ -225,27 +229,61 @@ export function createNoopCloudObservability(): CloudObservabilityAdapter {
   }
 }
 
+async function observeBestEffort(callback: () => void | Promise<void>) {
+  try {
+    await callback()
+  } catch {
+    // Telemetry must never become part of product correctness.
+  }
+}
+
+async function observeAllBestEffort(callbacks: Array<() => void | Promise<void>>) {
+  await Promise.allSettled(callbacks.map((callback) => Promise.resolve().then(callback)))
+}
+
+export async function recordCloudLog(
+  observability: CloudObservabilityAdapter | null | undefined,
+  record: CloudLogRecord,
+) {
+  if (!observability) return
+  await observeBestEffort(() => observability.log(record))
+}
+
+export async function recordCloudMetric(
+  observability: CloudObservabilityAdapter | null | undefined,
+  record: CloudMetricRecord,
+) {
+  if (!observability) return
+  await observeBestEffort(() => observability.metric(record))
+}
+
 export function createCompositeCloudObservability(adapters: Array<CloudObservabilityAdapter | null | undefined>): CloudObservabilityAdapter {
   const active = adapters.filter((adapter): adapter is CloudObservabilityAdapter => Boolean(adapter))
   if (active.length === 0) return createNoopCloudObservability()
   return {
     async log(record) {
-      await Promise.all(active.map((adapter) => adapter.log(record)))
+      await observeAllBestEffort(active.map((adapter) => () => adapter.log(record)))
     },
     async metric(record) {
-      await Promise.all(active.map((adapter) => adapter.metric(record)))
+      await observeAllBestEffort(active.map((adapter) => () => adapter.metric(record)))
     },
     async span(record) {
-      await Promise.all(active.map((adapter) => adapter.span(record)))
+      await observeAllBestEffort(active.map((adapter) => () => adapter.span(record)))
     },
     renderPrometheus() {
-      return active.map((adapter) => adapter.renderPrometheus?.()).filter(Boolean).join('\n')
+      return active.map((adapter) => {
+        try {
+          return adapter.renderPrometheus?.() || ''
+        } catch {
+          return ''
+        }
+      }).filter(Boolean).join('\n')
     },
     async flush() {
-      await Promise.all(active.map((adapter) => adapter.flush?.()))
+      await observeAllBestEffort(active.map((adapter) => () => adapter.flush?.()))
     },
     async close() {
-      await Promise.all(active.map((adapter) => adapter.close?.()))
+      await observeAllBestEffort(active.map((adapter) => () => adapter.close?.()))
     },
   }
 }
@@ -361,12 +399,25 @@ export function createOtlpHttpCloudObservability(options: OtlpHttpCloudObservabi
   const fetcher = options.fetch || globalThis.fetch
   const serviceName = options.serviceName || DEFAULT_SERVICE_NAME
   const serviceVersion = options.serviceVersion || null
+  const maxQueueSize = Math.max(1, Math.floor(options.maxQueueSize || DEFAULT_OTLP_MAX_QUEUE_SIZE))
+  const flushIntervalMs = Math.max(0, Math.floor(options.flushIntervalMs ?? DEFAULT_OTLP_FLUSH_INTERVAL_MS))
   const headers = {
     'content-type': 'application/json',
     ...(options.headers || {}),
   }
   const spans: CloudSpanRecord[] = []
   const metrics: CloudMetricRecord[] = []
+  let droppedSpansTotal = 0
+  let droppedMetricsTotal = 0
+  let flushing: Promise<void> | null = null
+
+  function enqueue<T>(queue: T[], record: T, onDrop: () => void) {
+    if (queue.length >= maxQueueSize) {
+      queue.shift()
+      onDrop()
+    }
+    queue.push(record)
+  }
 
   async function post(path: '/v1/traces' | '/v1/metrics', body: unknown) {
     const response = await fetcher(normalizeEndpoint(options.endpoint, path), {
@@ -406,8 +457,24 @@ export function createOtlpHttpCloudObservability(options: OtlpHttpCloudObservabi
   }
 
   async function flushMetrics() {
-    if (metrics.length === 0) return
+    if (metrics.length === 0 && droppedSpansTotal === 0 && droppedMetricsTotal === 0) return
     const pending = metrics.splice(0)
+    if (droppedSpansTotal > 0) {
+      pending.push({
+        name: 'open_cowork_cloud_otlp_dropped_records_total',
+        value: droppedSpansTotal,
+        unit: '1',
+        attributes: { kind: 'span' },
+      })
+    }
+    if (droppedMetricsTotal > 0) {
+      pending.push({
+        name: 'open_cowork_cloud_otlp_dropped_records_total',
+        value: droppedMetricsTotal,
+        unit: '1',
+        attributes: { kind: 'metric' },
+      })
+    }
     await post('/v1/metrics', {
       resourceMetrics: [{
         resource: {
@@ -420,7 +487,7 @@ export function createOtlpHttpCloudObservability(options: OtlpHttpCloudObservabi
             unit: metric.unit || '',
             sum: {
               aggregationTemporality: 2,
-              isMonotonic: false,
+              isMonotonic: metric.name.endsWith('_total'),
               dataPoints: [{
                 timeUnixNano: timeUnixNano(metric.timestamp || new Date()),
                 asDouble: metric.value,
@@ -433,21 +500,47 @@ export function createOtlpHttpCloudObservability(options: OtlpHttpCloudObservabi
     })
   }
 
+  async function flushAll() {
+    if (flushing) return flushing
+    flushing = (async () => {
+      await Promise.allSettled([
+        flushSpans(),
+        flushMetrics(),
+      ])
+    })()
+    try {
+      await flushing
+    } finally {
+      flushing = null
+    }
+  }
+
+  const flushTimer = flushIntervalMs > 0
+    ? setInterval(() => {
+        void flushAll()
+      }, flushIntervalMs)
+    : null
+  flushTimer?.unref?.()
+
   return {
     log() {},
     metric(record) {
-      metrics.push(record)
+      if (!Number.isFinite(record.value)) return
+      enqueue(metrics, record, () => {
+        droppedMetricsTotal += 1
+      })
     },
     span(record) {
-      spans.push(record)
+      enqueue(spans, record, () => {
+        droppedSpansTotal += 1
+      })
     },
     async flush() {
-      await flushSpans()
-      await flushMetrics()
+      await flushAll()
     },
     async close() {
-      await flushSpans()
-      await flushMetrics()
+      if (flushTimer) clearInterval(flushTimer)
+      await flushAll()
     },
   }
 }
@@ -467,7 +560,7 @@ export async function recordCloudHttpRequest(
     'cloud.role': input.role,
     'cloud.profile': input.profileName,
   }
-  await observability.log({
+  await observeBestEffort(() => observability.log({
     level: input.statusCode >= 500 ? 'error' : input.statusCode >= 400 ? 'warn' : 'info',
     name: 'cloud.http.request',
     message: `${input.method} ${input.path} ${input.statusCode}`,
@@ -476,15 +569,15 @@ export async function recordCloudHttpRequest(
       duration_ms: input.durationMs,
     },
     timestamp,
-  })
-  await observability.metric({
+  }))
+  await observeBestEffort(() => observability.metric({
     name: 'cloud.http.server.duration_ms',
     value: input.durationMs,
     unit: 'ms',
     attributes,
     timestamp,
-  })
-  await observability.metric({
+  }))
+  await observeBestEffort(() => observability.metric({
     name: 'open_cowork_cloud_http_requests_total',
     value: 1,
     unit: '1',
@@ -496,8 +589,8 @@ export async function recordCloudHttpRequest(
       'cloud.profile': input.profileName,
     },
     timestamp,
-  })
-  await observability.metric({
+  }))
+  await observeBestEffort(() => observability.metric({
     name: 'open_cowork_cloud_http_request_duration_ms',
     value: input.durationMs,
     unit: 'ms',
@@ -509,8 +602,8 @@ export async function recordCloudHttpRequest(
       'cloud.profile': input.profileName,
     },
     timestamp,
-  })
-  await observability.span({
+  }))
+  await observeBestEffort(() => observability.span({
     name: 'cloud.http.request',
     startTime: new Date(timestamp.getTime() - input.durationMs),
     endTime: timestamp,
@@ -519,7 +612,7 @@ export async function recordCloudHttpRequest(
       duration_ms: input.durationMs,
     },
     status,
-  })
+  }))
 }
 
 export async function recordCloudWorkerMetric(
@@ -537,7 +630,7 @@ export async function recordCloudWorkerMetric(
 ) {
   if (!observability) return
   const timestamp = input.timestamp || new Date()
-  await observability.metric({
+  await observeBestEffort(() => observability.metric({
     name: input.name,
     value: input.value ?? 1,
     unit: input.name.endsWith('_ms') ? 'ms' : '1',
@@ -548,7 +641,7 @@ export async function recordCloudWorkerMetric(
       status: input.status || undefined,
     },
     timestamp,
-  })
+  }))
 }
 
 export async function recordCloudSchedulerMetric(
@@ -564,7 +657,7 @@ export async function recordCloudSchedulerMetric(
 ) {
   if (!observability) return
   const timestamp = input.timestamp || new Date()
-  await observability.metric({
+  await observeBestEffort(() => observability.metric({
     name: input.name,
     value: input.value ?? 1,
     unit: input.name.endsWith('_ms') ? 'ms' : '1',
@@ -573,7 +666,7 @@ export async function recordCloudSchedulerMetric(
       status: input.status || undefined,
     },
     timestamp,
-  })
+  }))
 }
 
 function parseJsonHeaders(value: string | null) {
@@ -591,6 +684,26 @@ function parseJsonHeaders(value: string | null) {
 
 function envValue(env: Env, key: string) {
   return normalizeString(env[key])
+}
+
+function parseOptionalNonNegativeInteger(env: Env, key: string) {
+  const value = envValue(env, key)
+  if (!value) return undefined
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${key} must be a non-negative integer.`)
+  }
+  return parsed
+}
+
+function parseOptionalPositiveInteger(env: Env, key: string) {
+  const value = envValue(env, key)
+  if (!value) return undefined
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${key} must be a positive integer.`)
+  }
+  return parsed
 }
 
 export function createCloudObservabilityFromEnv(env: Env = process.env) {
@@ -616,6 +729,8 @@ export function createCloudObservabilityFromEnv(env: Env = process.env) {
       serviceName,
       serviceVersion,
       headers: parseJsonHeaders(envValue(env, 'OPEN_COWORK_CLOUD_OTLP_HEADERS')),
+      flushIntervalMs: parseOptionalNonNegativeInteger(env, 'OPEN_COWORK_CLOUD_OTLP_FLUSH_INTERVAL_MS'),
+      maxQueueSize: parseOptionalPositiveInteger(env, 'OPEN_COWORK_CLOUD_OTLP_MAX_QUEUE_SIZE'),
     }))
   }
 

--- a/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
+++ b/apps/desktop/src/main/cloud/worker-scoped-runtime-adapter.ts
@@ -6,7 +6,7 @@ import {
   type CloudByokRuntimeProviderPolicy,
 } from './byok-runtime-config.ts'
 import type { CloudRuntimePolicy } from './cloud-config.ts'
-import type { CloudObservabilityAdapter } from './observability.ts'
+import { recordCloudMetric, type CloudObservabilityAdapter } from './observability.ts'
 import type { PathProvider } from './path-provider.ts'
 import { createCloudSessionPathProvider } from './path-provider.ts'
 import type {
@@ -115,7 +115,7 @@ export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAda
     value: number,
     attributes: Record<string, string | number | boolean | undefined> = {},
   ) {
-    await options.observability?.metric({
+    await recordCloudMetric(options.observability, {
       name,
       value,
       unit: '1',
@@ -186,7 +186,7 @@ export function createWorkerScopedRuntimeAdapter(options: WorkerScopedRuntimeAda
       })
     } catch (error) {
       if (error instanceof CloudByokRuntimeConfigError) {
-        await options.observability?.metric({
+        await recordCloudMetric(options.observability, {
           name: 'open_cowork_cloud_byok_reveal_failures_total',
           value: 1,
           unit: '1',

--- a/docs/open-cowork-cloud.md
+++ b/docs/open-cowork-cloud.md
@@ -710,6 +710,8 @@ Set these environment variables in every role:
 | `OPEN_COWORK_CLOUD_LOG_FORMAT` | `json`, `pretty`, or `silent`; defaults to JSON for cloud logs. |
 | `OPEN_COWORK_CLOUD_OTLP_ENDPOINT` | Optional OpenTelemetry OTLP HTTP base endpoint; exports traces to `/v1/traces` and metrics to `/v1/metrics`. |
 | `OPEN_COWORK_CLOUD_OTLP_HEADERS` | Optional JSON object of OTLP HTTP headers, stored as a secret when it contains collector credentials. |
+| `OPEN_COWORK_CLOUD_OTLP_FLUSH_INTERVAL_MS` | Optional non-negative OTLP export interval in milliseconds; defaults to `30000`; `0` disables the timer and relies on explicit flush/close. |
+| `OPEN_COWORK_CLOUD_OTLP_MAX_QUEUE_SIZE` | Optional positive maximum queued spans and metrics per OTLP record type before oldest records are dropped and counted; defaults to `1000`. |
 | `OPEN_COWORK_CLOUD_CHECKPOINTS_ENABLED` | `true` enables worker runtime/workspace checkpoints in object storage. |
 
 Managed billing variables:
@@ -957,6 +959,10 @@ browser is not the only protection.
   profile, status, and duration. When `OPEN_COWORK_CLOUD_OTLP_ENDPOINT` is
   set, the same request observations are exported as OTLP HTTP traces and
   duration metrics without adding provider-specific code paths.
+- OTLP export is best-effort and bounded: collector failures do not block Cloud
+  requests or worker commands, overflow drops the oldest queued records, and
+  `open_cowork_cloud_otlp_dropped_records_total` reports queue drops by record
+  type.
 - Browser event streams use ordered durable events, so web replicas do not need
   sticky sessions for session replay.
 - Browser sessions use signed `HttpOnly`, `SameSite=Lax` cookies and require

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -1,6 +1,6 @@
 # Production Readiness Audit
 
-Last updated: 2026-06-01.
+Last updated: 2026-06-02.
 
 This audit records the current delta between the repository and a polished
 enterprise-production target. It is based on local source inspection, targeted
@@ -15,18 +15,17 @@ Cloud tenant boundaries are guarded, release supply-chain controls are mature,
 and deployment templates have explicit production gates. No critical issue was
 found in the current review.
 
-The remaining work is concentrated in four areas:
+The remaining work is concentrated in three areas:
 
-- high-value security hardening around renderer-accessible local secrets
-- Cloud worker lifecycle and operational correctness under failure
 - release/promotion proof for hosted production claims
 - maintainability guardrails for the largest Cloud compatibility facades and
   generated or vendored surfaces
+- shutdown and backpressure behavior for long-lived Cloud streams and queues
 
 ## Verified Baseline
 
 - GitHub code scanning: 0 open alerts on `master` at
-  `7fdbfb7203657b98a2b1d424404c9a3075152d29`.
+  `d904f74cb97e4697294966ec0cb1743f07706f77`.
 - Dependabot alerts: 0 open alerts at the same point-in-time check.
 - GitHub Actions checks on that `master` SHA were green for deploy, CodeQL,
   build, coverage, validate, docs, cloud-gates, macos-build, and linux-package.
@@ -52,42 +51,16 @@ The remaining work is concentrated in four areas:
   instead of raw provider or integration secrets. Non-secret descriptor fields
   can still be shown for editing, and echoed mask sentinels preserve the stored
   secret on save.
+- Cloud worker command execution now aborts on lease-renewal loss, propagates
+  `AbortSignal` through runtime command calls, uses stable OpenCode message IDs
+  for prompt retries, and has regressions for active and cached lease renewal
+  failure paths.
+- Cloud observability hot paths are best-effort: composite adapters isolate
+  failing sinks, worker/scheduler/HTTP record helpers suppress telemetry sink
+  failures, and OTLP export uses bounded queues, drop counters, and periodic
+  flush.
 
 ## High Priority
-
-### Worker Lease Renewal Loss Does Not Cancel Active Execution
-
-Evidence:
-
-- `apps/desktop/src/main/cloud/worker.ts` renews leases while executing
-  commands.
-- Renewal failures are caught and recorded, but the active command is not
-  aborted.
-
-Impact: after lease expiry, another worker can reclaim a command while the
-stale worker continues runtime or external side effects. Store writes are
-fenced, but side effects outside the store are not.
-
-Target state: propagate renewal loss through an `AbortSignal`, fail or cancel
-the active command, and add a regression where renewal fails and another worker
-attempts reclaim.
-
-### Telemetry Failure Can Affect Command Correctness
-
-Evidence:
-
-- Composite observability adapters use `Promise.all`.
-- Worker success-path metrics are awaited inside command execution.
-- OTLP spans and metrics are buffered in arrays and flushed only on explicit
-  flush or close.
-
-Impact: a telemetry sink failure can turn an already-executed command into a
-worker failure or retry. Long-running OTLP deployments can retain unbounded
-telemetry until shutdown.
-
-Target state: make hot-path telemetry best-effort, introduce bounded queues and
-drop counters, add periodic OTLP flush, and test a failing adapter during a
-successful command.
 
 ### Active SSE Streams Can Block Cloud Shutdown
 

--- a/helm/open-cowork-cloud/templates/configmap.yaml
+++ b/helm/open-cowork-cloud/templates/configmap.yaml
@@ -33,6 +33,8 @@ data:
   OPEN_COWORK_CLOUD_SERVICE_VERSION: {{ .Values.cloud.observability.serviceVersion | quote }}
   OPEN_COWORK_CLOUD_LOG_FORMAT: {{ .Values.cloud.observability.logFormat | quote }}
   OPEN_COWORK_CLOUD_OTLP_ENDPOINT: {{ .Values.cloud.observability.otlpEndpoint | quote }}
+  OPEN_COWORK_CLOUD_OTLP_FLUSH_INTERVAL_MS: {{ .Values.cloud.observability.otlpFlushIntervalMs | quote }}
+  OPEN_COWORK_CLOUD_OTLP_MAX_QUEUE_SIZE: {{ .Values.cloud.observability.otlpMaxQueueSize | quote }}
   OPEN_COWORK_CLOUD_OBJECT_STORE_KIND: {{ .Values.cloud.objectStore.kind | quote }}
   OPEN_COWORK_CLOUD_OBJECT_STORE_BUCKET: {{ .Values.cloud.objectStore.bucket | quote }}
   OPEN_COWORK_CLOUD_OBJECT_STORE_REGION: {{ .Values.cloud.objectStore.region | quote }}

--- a/helm/open-cowork-cloud/values.yaml
+++ b/helm/open-cowork-cloud/values.yaml
@@ -92,6 +92,8 @@ cloud:
     logFormat: json
     otlpEndpoint: ""
     otlpHeaders: ""
+    otlpFlushIntervalMs: 30000
+    otlpMaxQueueSize: 1000
   checkpoints:
     enabled: false
   objectStore:

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -3025,6 +3025,30 @@ test('cloud HTTP server emits auth and quota denial metrics', async () => {
   assert.equal(metrics.some((metric) => (metric as Record<string, unknown>).name === 'open_cowork_cloud_quota_rejections_total'), true)
 })
 
+test('cloud HTTP policy error responses ignore failing observability sinks', async () => {
+  const observability: CloudObservabilityAdapter = {
+    log() {},
+    metric() { throw new Error('metric sink unavailable') },
+    span() {},
+  }
+  const fixture = createFixture({
+    observability,
+    auth: () => {
+      throw new CloudHttpError(401, 'Cloud authentication is required.', { policyCode: 'auth.invalid_token' })
+    },
+  })
+  const baseUrl = await fixture.server.listen()
+  try {
+    const rejected = await fetch(`${baseUrl}/api/workspace`, {
+      signal: AbortSignal.timeout(1_000),
+    })
+    assert.equal(rejected.status, 401)
+    await rejected.text()
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP browser session cookies use secure flags and enforce CSRF on mutating routes', async () => {
   const sessionCookies = createCloudSessionCookieManager({
     secret: TEST_COOKIE_KEY,

--- a/tests/cloud-observability.test.ts
+++ b/tests/cloud-observability.test.ts
@@ -3,10 +3,14 @@ import assert from 'node:assert/strict'
 
 import {
   createCloudObservabilityFromEnv,
+  createCompositeCloudObservability,
   createConsoleCloudObservability,
   createOtlpHttpCloudObservability,
   createPrometheusCloudObservability,
   recordCloudHttpRequest,
+  recordCloudMetric,
+  recordCloudSchedulerMetric,
+  recordCloudWorkerMetric,
   sanitizeCloudObservabilityAttributes,
   type CloudObservabilityAdapter,
 } from '../apps/desktop/src/main/cloud/observability.ts'
@@ -98,6 +102,62 @@ test('cloud HTTP request observation emits log, metric, and span records', async
   assert.equal((spans[0] as Record<string, unknown>).status, 'ok')
 })
 
+test('cloud observability record helpers isolate telemetry sink failures', async () => {
+  const adapter: CloudObservabilityAdapter = {
+    log() { throw new Error('log sink unavailable') },
+    metric() { throw new Error('metric sink unavailable') },
+    span() { throw new Error('span sink unavailable') },
+  }
+
+  await assert.doesNotReject(() => recordCloudHttpRequest(adapter, {
+    requestId: 'req-1',
+    method: 'POST',
+    path: '/api/sessions',
+    statusCode: 201,
+    durationMs: 42,
+    role: 'web',
+    profileName: 'full',
+  }))
+  await assert.doesNotReject(() => recordCloudMetric(adapter, {
+    name: 'cloud.test.metric',
+    value: 1,
+  }))
+  await assert.doesNotReject(() => recordCloudWorkerMetric(adapter, {
+    name: 'open_cowork_cloud_worker_commands_processed_total',
+    workerId: 'worker-1',
+    status: 'ok',
+  }))
+  await assert.doesNotReject(() => recordCloudSchedulerMetric(adapter, {
+    name: 'open_cowork_cloud_scheduler_claims_total',
+    schedulerId: 'scheduler-1',
+    status: 'ok',
+  }))
+})
+
+test('cloud composite observability keeps healthy adapters active when one fails', async () => {
+  const metrics: unknown[] = []
+  const failing: CloudObservabilityAdapter = {
+    log() { throw new Error('log failed') },
+    metric() { throw new Error('metric failed') },
+    span() { throw new Error('span failed') },
+    flush() { throw new Error('flush failed') },
+    close() { throw new Error('close failed') },
+  }
+  const healthy: CloudObservabilityAdapter = {
+    log() {},
+    metric(record) { metrics.push(record) },
+    span() {},
+    flush() {},
+    close() {},
+  }
+  const composite = createCompositeCloudObservability([failing, healthy])
+
+  await assert.doesNotReject(() => composite.metric({ name: 'cloud.test', value: 1 }))
+  await assert.doesNotReject(() => composite.flush?.() ?? Promise.resolve())
+  await assert.doesNotReject(() => composite.close?.() ?? Promise.resolve())
+  assert.equal((metrics[0] as Record<string, unknown>).name, 'cloud.test')
+})
+
 test('cloud Prometheus observability renders low-cardinality product metrics', async () => {
   const adapter = createPrometheusCloudObservability()
   await adapter.metric({
@@ -179,14 +239,143 @@ test('cloud OTLP observability exports trace and metric payloads with headers', 
   assert.equal((metric[0] as Record<string, unknown>).name, 'cloud.http.server.duration_ms')
 })
 
+test('cloud OTLP observability bounds queues and exports drop counters', async () => {
+  const requests: Array<{ url: string, init?: { body?: string } }> = []
+  const adapter = createOtlpHttpCloudObservability({
+    endpoint: 'https://otel.example.test',
+    flushIntervalMs: 0,
+    maxQueueSize: 1,
+    fetch: async (url, init) => {
+      requests.push({ url: String(url), init: init as typeof requests[number]['init'] })
+      return new Response('{}', { status: 200 })
+    },
+  })
+
+  await adapter.metric({ name: 'cloud.first_metric', value: 1 })
+  await adapter.metric({ name: 'cloud.second_metric', value: 2 })
+  await adapter.span({
+    name: 'cloud.first_span',
+    startTime: new Date('2026-01-01T00:00:00.000Z'),
+    endTime: new Date('2026-01-01T00:00:00.001Z'),
+  })
+  await adapter.span({
+    name: 'cloud.second_span',
+    startTime: new Date('2026-01-01T00:00:00.002Z'),
+    endTime: new Date('2026-01-01T00:00:00.003Z'),
+  })
+  await adapter.flush?.()
+
+  function exportedMetricsFrom(request: { init?: { body?: string } }) {
+    const metricBody = JSON.parse(request.init?.body || '{}') as Record<string, unknown>
+    return ((((metricBody.resourceMetrics as unknown[])[0] as Record<string, unknown>)
+      .scopeMetrics as unknown[])[0] as Record<string, unknown>).metrics as Array<Record<string, unknown>>
+  }
+
+  const traceBody = JSON.parse(requests.find((request) => request.url.endsWith('/v1/traces'))?.init?.body || '{}') as Record<string, unknown>
+  const exportedSpans = ((((traceBody.resourceSpans as unknown[])[0] as Record<string, unknown>)
+    .scopeSpans as unknown[])[0] as Record<string, unknown>).spans as Array<Record<string, unknown>>
+  assert.deepEqual(exportedSpans.map((span) => span.name), ['cloud.second_span'])
+
+  const metricRequests = requests.filter((request) => request.url.endsWith('/v1/metrics'))
+  const exportedMetrics = exportedMetricsFrom(metricRequests[0] || {})
+  assert.deepEqual(exportedMetrics.map((metric) => metric.name), [
+    'cloud.second_metric',
+    'open_cowork_cloud_otlp_dropped_records_total',
+    'open_cowork_cloud_otlp_dropped_records_total',
+  ])
+  assert.equal((exportedMetrics[0]?.sum as Record<string, unknown>).isMonotonic, false)
+
+  const droppedMetrics = exportedMetrics.filter((metric) => metric.name === 'open_cowork_cloud_otlp_dropped_records_total')
+  const droppedMetricCounter = droppedMetrics.find((metric) => {
+    const dataPoint = (((metric.sum as Record<string, unknown>).dataPoints as Array<Record<string, unknown>>)[0])
+    const attributes = dataPoint.attributes as Array<{ key: string, value: Record<string, unknown> }>
+    return attributes.some((entry) => entry.key === 'kind' && entry.value.stringValue === 'metric')
+  })
+  assert.equal((droppedMetricCounter?.sum as Record<string, unknown>).isMonotonic, true)
+  assert.equal((((droppedMetricCounter?.sum as Record<string, unknown>).dataPoints as Array<Record<string, unknown>>)[0] || {}).asDouble, 1)
+
+  await adapter.metric({ name: 'cloud.third_metric', value: 3 })
+  await adapter.metric({ name: 'cloud.fourth_metric', value: 4 })
+  await adapter.flush?.()
+
+  const secondExportedMetrics = exportedMetricsFrom(requests.filter((request) => request.url.endsWith('/v1/metrics'))[1] || {})
+  const secondDroppedMetricCounter = secondExportedMetrics.find((metric) => {
+    const dataPoint = (((metric.sum as Record<string, unknown>).dataPoints as Array<Record<string, unknown>>)[0])
+    const attributes = dataPoint.attributes as Array<{ key: string, value: Record<string, unknown> }>
+    return metric.name === 'open_cowork_cloud_otlp_dropped_records_total'
+      && attributes.some((entry) => entry.key === 'kind' && entry.value.stringValue === 'metric')
+  })
+  assert.equal((((secondDroppedMetricCounter?.sum as Record<string, unknown>).dataPoints as Array<Record<string, unknown>>)[0] || {}).asDouble, 2)
+})
+
+test('cloud OTLP observability treats failed exports as best-effort loss', async () => {
+  const requests: Array<{ url: string, init?: { body?: string } }> = []
+  let failNextExport = true
+  const adapter = createOtlpHttpCloudObservability({
+    endpoint: 'https://otel.example.test',
+    flushIntervalMs: 0,
+    fetch: async (url, init) => {
+      requests.push({ url: String(url), init: init as typeof requests[number]['init'] })
+      if (failNextExport) {
+        failNextExport = false
+        return new Response('{}', { status: 503 })
+      }
+      return new Response('{}', { status: 200 })
+    },
+  })
+
+  await adapter.metric({ name: 'cloud.lost_metric', value: 1 })
+  await assert.doesNotReject(() => adapter.flush?.() ?? Promise.resolve())
+  assert.equal(requests.length, 1)
+
+  await adapter.flush?.()
+  assert.equal(requests.length, 1)
+
+  await adapter.metric({ name: 'cloud.next_metric', value: 2 })
+  await adapter.flush?.()
+  assert.equal(requests.length, 2)
+  const metricBody = JSON.parse(requests[1]?.init?.body || '{}') as Record<string, unknown>
+  const exportedMetrics = ((((metricBody.resourceMetrics as unknown[])[0] as Record<string, unknown>)
+    .scopeMetrics as unknown[])[0] as Record<string, unknown>).metrics as Array<Record<string, unknown>>
+  assert.deepEqual(exportedMetrics.map((metric) => metric.name), ['cloud.next_metric'])
+})
+
+test('cloud OTLP observability periodically flushes queued records', async () => {
+  const requests: string[] = []
+  const adapter = createOtlpHttpCloudObservability({
+    endpoint: 'https://otel.example.test',
+    flushIntervalMs: 10,
+    fetch: async (url) => {
+      requests.push(String(url))
+      return new Response('{}', { status: 200 })
+    },
+  })
+
+  await adapter.metric({ name: 'cloud.periodic_metric', value: 1 })
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  await adapter.close?.()
+
+  assert.equal(requests.some((url) => url.endsWith('/v1/metrics')), true)
+})
+
 test('cloud observability env factory parses OTLP settings and rejects invalid log formats', () => {
   assert.doesNotThrow(() => createCloudObservabilityFromEnv({
     OPEN_COWORK_CLOUD_LOG_FORMAT: 'silent',
     OPEN_COWORK_CLOUD_OTLP_ENDPOINT: 'https://otel.example.test',
     OPEN_COWORK_CLOUD_OTLP_HEADERS: '{"X-Api-Key":"test"}',
+    OPEN_COWORK_CLOUD_OTLP_FLUSH_INTERVAL_MS: '1000',
+    OPEN_COWORK_CLOUD_OTLP_MAX_QUEUE_SIZE: '250',
     OPEN_COWORK_CLOUD_SERVICE_NAME: 'open-cowork-cloud-test',
   }))
   assert.throws(() => createCloudObservabilityFromEnv({
     OPEN_COWORK_CLOUD_LOG_FORMAT: 'verbose',
   }), /Invalid cloud log format/)
+  assert.throws(() => createCloudObservabilityFromEnv({
+    OPEN_COWORK_CLOUD_OTLP_ENDPOINT: 'https://otel.example.test',
+    OPEN_COWORK_CLOUD_OTLP_FLUSH_INTERVAL_MS: '-1',
+  }), /OPEN_COWORK_CLOUD_OTLP_FLUSH_INTERVAL_MS/)
+  assert.throws(() => createCloudObservabilityFromEnv({
+    OPEN_COWORK_CLOUD_OTLP_ENDPOINT: 'https://otel.example.test',
+    OPEN_COWORK_CLOUD_OTLP_MAX_QUEUE_SIZE: '0',
+  }), /OPEN_COWORK_CLOUD_OTLP_MAX_QUEUE_SIZE/)
 })


### PR DESCRIPTION
## Summary
- make Cloud observability hot paths best-effort so failing telemetry sinks cannot block HTTP policy responses, worker metrics, scheduler metrics, or shutdown cleanup
- bound OTLP span/metric queues, add periodic flushing, cumulative drop counters, and env/Helm controls for flush interval and queue size
- document best-effort OTLP behavior and update the production readiness audit status

## Validation
- node scripts/run-node-tests.mjs tests/cloud-observability.test.ts tests/cloud-http-server.test.ts
- ./node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
- node scripts/lint.mjs
- .venv-docs/bin/mkdocs build --strict
- node scripts/validate-deployment-configs.mjs
- node scripts/validate-release-gates.mjs
- git diff --check
- node scripts/run-node-tests.mjs

## Review
- Kepler subagent reviewed the first patch, found remaining telemetry failure paths and OTLP counter/doc gaps; all were fixed
- Kepler re-reviewed the updated patch and found no remaining issues