### PR TITLE
Harden cloud SSE shutdown

### DIFF
--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
-import type { AddressInfo } from 'node:net'
+import type { AddressInfo, Socket } from 'node:net'
 import {
   emptySessionImportItemCounts,
   isCloudSessionEventType,
@@ -99,6 +99,7 @@ export type CloudHttpServerOptions = {
   maxBodyBytes?: number
   ssePollMs?: number
   sseReplayHub?: CloudSseReplayHub
+  sseStreamRegistry?: CloudSseStreamRegistry
   trustProxyHeaders?: boolean
   readiness?: () => Promise<CloudReadinessReport> | CloudReadinessReport
 }
@@ -146,8 +147,61 @@ type SseReplayTopic = {
   timer: ReturnType<typeof setInterval>
 }
 
+type ActiveSseStream = {
+  res: ServerResponse
+  socket: Socket | null
+  close: () => void
+}
+
+export class CloudSseStreamRegistry {
+  private readonly streams = new Set<ActiveSseStream>()
+  private closing = false
+
+  track(req: IncomingMessage, res: ServerResponse, cleanup: () => void) {
+    if (this.closing) {
+      const socket = res.socket || req.socket || null
+      cleanup()
+      if (!res.writableEnded && !res.destroyed) res.end()
+      if (!res.destroyed) res.destroy()
+      if (socket && !socket.destroyed) socket.destroy()
+      return false
+    }
+
+    let closed = false
+    const stream: ActiveSseStream = {
+      res,
+      socket: res.socket || req.socket || null,
+      close: () => {
+        if (closed) return
+        closed = true
+        this.streams.delete(stream)
+        req.off('close', stream.close)
+        res.off('close', stream.close)
+        res.off('finish', stream.close)
+        cleanup()
+      },
+    }
+    this.streams.add(stream)
+    req.once('close', stream.close)
+    res.once('close', stream.close)
+    res.once('finish', stream.close)
+    return true
+  }
+
+  closeAll() {
+    this.closing = true
+    for (const stream of Array.from(this.streams)) {
+      stream.close()
+      if (!stream.res.writableEnded && !stream.res.destroyed) stream.res.end()
+      if (!stream.res.destroyed) stream.res.destroy()
+      if (stream.socket && !stream.socket.destroyed) stream.socket.destroy()
+    }
+  }
+}
+
 export class CloudSseReplayHub {
   private readonly topics = new Map<string, SseReplayTopic>()
+  private closed = false
 
   subscribe(
     input: {
@@ -159,6 +213,7 @@ export class CloudSseReplayHub {
       onError?: (error: unknown) => void
     },
   ) {
+    if (this.closed) return () => {}
     let topic = this.topics.get(input.key)
     if (!topic) {
       topic = {
@@ -193,16 +248,22 @@ export class CloudSseReplayHub {
   }
 
   close() {
-    for (const topic of this.topics.values()) clearInterval(topic.timer)
+    this.closed = true
+    for (const topic of this.topics.values()) {
+      clearInterval(topic.timer)
+      topic.subscribers.clear()
+    }
     this.topics.clear()
   }
 
   private async poll(key: string) {
+    if (this.closed) return
     const topic = this.topics.get(key)
     if (!topic || topic.polling) return
     topic.polling = true
     try {
       const events = await topic.loadEvents(topic.lastSequence)
+      if (this.closed || this.topics.get(key) !== topic) return
       for (const event of events) {
         if (event.sequence <= topic.lastSequence) continue
         topic.lastSequence = event.sequence
@@ -215,7 +276,7 @@ export class CloudSseReplayHub {
     } catch (error) {
       for (const subscriber of topic.subscribers) subscriber.onError?.(error)
     } finally {
-      topic.polling = false
+      if (this.topics.get(key) === topic) topic.polling = false
     }
   }
 }
@@ -776,6 +837,29 @@ async function handleBillingWebhook(
   }
 }
 
+function trackSseStream(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: CloudHttpServerOptions,
+  cleanup: () => void,
+) {
+  if (options.sseStreamRegistry) return options.sseStreamRegistry.track(req, res, cleanup)
+
+  let closed = false
+  const close = () => {
+    if (closed) return
+    closed = true
+    req.off('close', close)
+    res.off('close', close)
+    res.off('finish', close)
+    cleanup()
+  }
+  req.once('close', close)
+  res.once('close', close)
+  res.once('finish', close)
+  return true
+}
+
 async function handleSse(
   req: IncomingMessage,
   res: ServerResponse,
@@ -794,12 +878,25 @@ async function handleSse(
   })
   res.write(': connected\n\n')
   let lastSequence = afterSequence
+  let cleaned = false
+  let unsubscribe: (() => void) | null = null
+  let replayUnsubscribe: (() => void) | null = null
+  let keepAliveTimer: ReturnType<typeof setInterval> | null = null
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+    if (keepAliveTimer) clearInterval(keepAliveTimer)
+    replayUnsubscribe?.()
+    unsubscribe?.()
+  }
+  if (!trackSseStream(req, res, options, cleanup)) return
   const writeIfNew = (event: {
     sequence: number
     type: string
     eventId: string
     payload: Record<string, unknown>
   }) => {
+    if (cleaned || res.destroyed) return
     if (event.sequence <= lastSequence) return
     if (!isCloudSessionEventType(event.type)) {
       lastSequence = event.sequence
@@ -812,28 +909,25 @@ async function handleSse(
   for (const event of await options.service.listEvents(context.principal, sessionId, afterSequence)) {
     writeIfNew(event)
   }
-  const unsubscribe = options.service.eventBus.subscribe({
+  if (cleaned) return
+  unsubscribe = options.service.eventBus.subscribe({
     tenantId: context.principal.tenantId,
     sessionId,
     afterSequence,
   }, (event) => {
     writeIfNew(event)
   })
-  const replayUnsubscribe = options.sseReplayHub?.subscribe({
+  replayUnsubscribe = options.sseReplayHub?.subscribe({
     key: `session:${context.principal.tenantId}:${context.principal.userId}:${sessionId}`,
     afterSequence: lastSequence,
     pollMs: ssePollMs(options),
     loadEvents: (sequence) => options.service.listEvents(context.principal, sessionId, sequence),
     listener: (event) => writeIfNew(event as SessionEventRecord),
-  })
-  const keepAliveTimer = setInterval(() => {
+  }) ?? null
+  keepAliveTimer = setInterval(() => {
+    if (cleaned || res.destroyed) return
     res.write(': keep-alive\n\n')
   }, ssePollMs(options))
-  req.on('close', () => {
-    clearInterval(keepAliveTimer)
-    replayUnsubscribe?.()
-    unsubscribe()
-  })
 }
 
 async function handleWorkspaceSse(
@@ -852,6 +946,18 @@ async function handleWorkspaceSse(
   })
   res.write(': connected\n\n')
   let lastSequence = afterSequence
+  let cleaned = false
+  let unsubscribe: (() => void) | null = null
+  let replayUnsubscribe: (() => void) | null = null
+  let keepAliveTimer: ReturnType<typeof setInterval> | null = null
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+    if (keepAliveTimer) clearInterval(keepAliveTimer)
+    replayUnsubscribe?.()
+    unsubscribe?.()
+  }
+  if (!trackSseStream(req, res, options, cleanup)) return
   const writeIfNew = (event: {
     tenantId?: string
     userId?: string
@@ -866,6 +972,7 @@ async function handleWorkspaceSse(
     payload: Record<string, unknown>
     createdAt?: string
   }) => {
+    if (cleaned || res.destroyed) return
     if (event.sequence <= lastSequence) return
     if (!isCloudSessionEventType(event.type)) {
       lastSequence = event.sequence
@@ -877,6 +984,7 @@ async function handleWorkspaceSse(
   }
 
   const retainedEvents = await options.service.listWorkspaceEvents(context.principal, 0)
+  if (cleaned || res.destroyed) return
   const earliestSequence = retainedEvents[0]?.sequence
   const hasReplayGap = afterSequence > 0
     && earliestSequence !== undefined
@@ -895,28 +1003,25 @@ async function handleWorkspaceSse(
     for (const event of retainedEvents) writeIfNew(event)
   }
 
-  const unsubscribe = options.service.workspaceEventBus.subscribe({
+  if (cleaned) return
+  unsubscribe = options.service.workspaceEventBus.subscribe({
     tenantId: context.principal.tenantId,
     userId: context.principal.userId,
     afterSequence: lastSequence,
   }, (event) => {
     writeIfNew(event)
   })
-  const replayUnsubscribe = options.sseReplayHub?.subscribe({
+  replayUnsubscribe = options.sseReplayHub?.subscribe({
     key: `workspace:${context.principal.tenantId}:${context.principal.userId}`,
     afterSequence: lastSequence,
     pollMs: ssePollMs(options),
     loadEvents: (sequence) => options.service.listWorkspaceEvents(context.principal, sequence),
     listener: (event) => writeIfNew(event as WorkspaceEventRecord),
-  })
-  const keepAliveTimer = setInterval(() => {
+  }) ?? null
+  keepAliveTimer = setInterval(() => {
+    if (cleaned || res.destroyed) return
     res.write(': keep-alive\n\n')
   }, ssePollMs(options))
-  req.on('close', () => {
-    clearInterval(keepAliveTimer)
-    replayUnsubscribe?.()
-    unsubscribe()
-  })
 }
 
 async function handleChannelDeliveriesSse(
@@ -940,18 +1045,25 @@ async function handleChannelDeliveriesSse(
   const ttlMs = Number.isInteger(ttlMsRaw) && ttlMsRaw > 0 ? ttlMsRaw : 30_000
   let closed = false
   let pollActive = false
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+  const cleanup = () => {
+    if (closed) return
+    closed = true
+    if (pollTimer) clearInterval(pollTimer)
+  }
+  if (!trackSseStream(req, res, options, cleanup)) return
   const poll = async () => {
-    if (pollActive || closed) return
+    if (pollActive || closed || res.destroyed) return
     pollActive = true
     try {
       let claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy, ttlMs })
-      while (claimed && !closed) {
+      while (claimed && !closed && !res.destroyed) {
         writeChannelDeliverySseEvent(res, claimed)
         claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy, ttlMs })
       }
-      if (!closed) res.write(': keep-alive\n\n')
+      if (!closed && !res.destroyed) res.write(': keep-alive\n\n')
     } catch (error) {
-      if (!closed) {
+      if (!closed && !res.destroyed) {
         const message = error instanceof CloudServiceError
           ? error.publicMessage
           : 'Channel delivery stream failed.'
@@ -962,13 +1074,10 @@ async function handleChannelDeliveriesSse(
     }
   }
   await poll()
-  const pollTimer = setInterval(() => {
+  if (closed) return
+  pollTimer = setInterval(() => {
     void poll()
   }, ssePollMs(options))
-  req.on('close', () => {
-    closed = true
-    clearInterval(pollTimer)
-  })
 }
 
 async function handleApiRequest(
@@ -1627,12 +1736,15 @@ export class CloudHttpServer {
   private readonly server: Server
   private readonly options: CloudHttpServerOptions
   private readonly sseReplayHub: CloudSseReplayHub
+  private readonly sseStreamRegistry: CloudSseStreamRegistry
 
   constructor(options: CloudHttpServerOptions) {
     this.sseReplayHub = options.sseReplayHub || new CloudSseReplayHub()
+    this.sseStreamRegistry = options.sseStreamRegistry || new CloudSseStreamRegistry()
     this.options = {
       ...options,
       sseReplayHub: this.sseReplayHub,
+      sseStreamRegistry: this.sseStreamRegistry,
       webhookSecurity: options.webhookSecurity || new InMemoryWorkflowWebhookSecurityStore(),
     }
     this.server = createServer((req, res) => {
@@ -1658,13 +1770,15 @@ export class CloudHttpServer {
   }
 
   async close() {
+    this.sseReplayHub.close()
+    this.sseStreamRegistry.closeAll()
+    this.server.closeIdleConnections?.()
     await new Promise<void>((resolve, reject) => {
       this.server.close((error) => {
         if (error) reject(error)
         else resolve()
       })
     })
-    this.sseReplayHub.close()
   }
 
   private async enforceIpRateLimit(req: IncomingMessage) {

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -59,23 +59,11 @@ The remaining work is concentrated in three areas:
   failing sinks, worker/scheduler/HTTP record helpers suppress telemetry sink
   failures, and OTLP export uses bounded queues, drop counters, and periodic
   flush.
+- Cloud HTTP shutdown now closes replay polling and active SSE streams before
+  awaiting `server.close()`, with lifecycle regressions for open streams and
+  shutdown during replay loading.
 
 ## High Priority
-
-### Active SSE Streams Can Block Cloud Shutdown
-
-Evidence:
-
-- Cloud HTTP shutdown awaits `server.close()` before closing stream hubs.
-- SSE timers and subscriptions clean up on request `close`, but active streams
-  may keep the HTTP server open.
-
-Impact: deploys and restarts can hang while clients keep long-lived streams
-connected.
-
-Target state: track active SSE responses and sockets, close replay hubs before
-awaiting server close, end or destroy active streams on shutdown, and add a
-lifecycle test with an open stream.
 
 ### Release Gates Do Not Prove Hosted Production Readiness
 

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -270,6 +270,46 @@ async function readSseUntil(
   throw new Error('Timed out waiting for SSE event.')
 }
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string) {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs)
+        timer.unref()
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+async function readInitialStreamChunk(response: Response) {
+  const reader = response.body?.getReader()
+  assert.ok(reader)
+  const chunk = await withTimeout(reader.read(), 1000, 'Timed out waiting for initial SSE chunk.')
+  assert.equal(chunk.done, false)
+  return reader
+}
+
+async function waitForStreamReaderClosed(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 1000,
+) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const remaining = Math.max(1, deadline - Date.now())
+    try {
+      const chunk = await withTimeout(reader.read(), remaining, 'Timed out waiting for SSE reader to close.')
+      if (chunk.done) return
+    } catch {
+      return
+    }
+  }
+  throw new Error('Timed out waiting for SSE reader to close.')
+}
+
 test('cloud HTTP server exposes health, config, session create/list/get, prompt, and abort', async () => {
   const fixture = createFixture()
   const baseUrl = await fixture.server.listen()
@@ -3305,6 +3345,110 @@ test('cloud HTTP workspace event feed streams owned session deltas', async () =>
   } finally {
     controller.abort()
     await fixture.server.close()
+  }
+})
+
+test('cloud HTTP server close shuts down active SSE streams without client aborts', async () => {
+  const scenarios = [
+    {
+      name: 'session events',
+      setup: async (baseUrl: string) => {
+        await fetch(`${baseUrl}/api/sessions`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({}),
+        })
+      },
+      path: '/api/sessions/oc-session-1/events?after=0',
+    },
+    {
+      name: 'workspace events',
+      setup: async () => {},
+      path: '/api/events?after=0',
+    },
+    {
+      name: 'channel deliveries',
+      setup: async () => {},
+      path: '/api/channels/deliveries/stream?claimedBy=test-gateway',
+    },
+  ]
+
+  for (const scenario of scenarios) {
+    const fixture = createFixture({ ssePollMs: 10 })
+    const baseUrl = await fixture.server.listen()
+    const controller = new AbortController()
+    let closed = false
+    try {
+      await scenario.setup(baseUrl)
+      const stream = await fetch(`${baseUrl}${scenario.path}`, {
+        signal: controller.signal,
+      })
+      assert.equal(stream.status, 200, scenario.name)
+      const reader = await readInitialStreamChunk(stream)
+
+      await withTimeout(
+        fixture.server.close().then(() => {
+          closed = true
+        }),
+        1000,
+        `${scenario.name} stream blocked server shutdown.`,
+      )
+      await waitForStreamReaderClosed(reader)
+    } finally {
+      controller.abort()
+      if (!closed) await fixture.server.close().catch(() => {})
+    }
+  }
+})
+
+test('cloud HTTP server close handles workspace SSE shutdown during replay load', async () => {
+  const fixture = createFixture({ ssePollMs: 10 })
+  const originalListWorkspaceEvents = fixture.service.listWorkspaceEvents.bind(fixture.service)
+  let releaseList: (() => void) | null = null
+  const listStarted = new Promise<void>((resolve) => {
+    fixture.service.listWorkspaceEvents = async () => {
+      resolve()
+      await new Promise<void>((release) => {
+        releaseList = release
+      })
+      return [{
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        sessionId: 'oc-session-1',
+        sequence: 10,
+        entityType: 'session',
+        entityId: 'oc-session-1',
+        operation: 'update',
+        projectionVersion: 10,
+        type: 'assistant.message',
+        eventId: 'event-10',
+        payload: { content: 'retained event after a replay gap' },
+        createdAt: '2026-06-02T00:00:00.000Z',
+      }] satisfies Awaited<ReturnType<typeof originalListWorkspaceEvents>>
+    }
+  })
+  const baseUrl = await fixture.server.listen()
+  const controller = new AbortController()
+  let closed = false
+  try {
+    const stream = await fetch(`${baseUrl}/api/events?after=8`, {
+      signal: controller.signal,
+    })
+    assert.equal(stream.status, 200)
+    await listStarted
+
+    const closePromise = fixture.server.close().then(() => {
+      closed = true
+    })
+    releaseList?.()
+    await withTimeout(closePromise, 1000, 'Workspace SSE replay load blocked server shutdown.')
+    const reader = stream.body?.getReader()
+    if (reader) await waitForStreamReaderClosed(reader)
+  } finally {
+    controller.abort()
+    releaseList?.()
+    fixture.service.listWorkspaceEvents = originalListWorkspaceEvents
+    if (!closed) await fixture.server.close().catch(() => {})
   }
 })
 


### PR DESCRIPTION
## Summary
- track active Cloud SSE responses and sockets across session, workspace, and channel-delivery streams
- close replay polling and active SSE streams before awaiting HTTP server shutdown
- prevent in-flight replay polling and replay-gap snapshot writes from dispatching after shutdown
- add lifecycle regressions for open SSE shutdown and shutdown while workspace replay loading is suspended

## Validation
- node scripts/run-node-tests.mjs tests/cloud-http-server.test.ts
- ./node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
- node scripts/lint.mjs
- .venv-docs/bin/mkdocs build --strict
- git diff --check
- node scripts/validate-release-gates.mjs
- node scripts/run-node-tests.mjs

## Review
- Arendt subagent reviewed the first applied patch and found the workspace replay-gap shutdown race; fixed
- Arendt re-reviewed the final patch and found no remaining issues