### PR TITLE
Add release promotion evidence gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,9 @@ jobs:
       - name: Run launch evidence manifest validator
         run: pnpm deploy:launch:evidence:validate
 
+      - name: Run release promotion contract validator
+        run: pnpm deploy:promotion:validate -- --tier local-self-host-beta
+
       - name: Run private beta launch package validator
         run: pnpm deploy:private-beta:validate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,11 +180,29 @@ jobs:
             > /tmp/open-cowork-gateway-release-rendered.yaml
           test -s /tmp/open-cowork-gateway-release-rendered.yaml
 
+      - name: Materialize hosted promotion evidence manifest
+        if: vars.OPEN_COWORK_RELEASE_CLAIM_TIER != '' && vars.OPEN_COWORK_RELEASE_CLAIM_TIER != 'local-self-host-beta'
+        env:
+          OPEN_COWORK_RELEASE_CLAIM_TIER: ${{ vars.OPEN_COWORK_RELEASE_CLAIM_TIER }}
+          OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64: ${{ secrets.OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64 }}
+        run: |
+          if [ -z "$OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64" ]; then
+            echo "::error::Set OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64 for hosted release claim tier ${OPEN_COWORK_RELEASE_CLAIM_TIER}."
+            exit 1
+          fi
+          manifest_path="${RUNNER_TEMP}/open-cowork-promotion-evidence.json"
+          printf '%s' "$OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64" | base64 --decode > "$manifest_path"
+          chmod 600 "$manifest_path"
+          echo "OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST=$manifest_path" >> "$GITHUB_ENV"
+
       - name: Deployment and launch readiness gates
+        env:
+          OPEN_COWORK_RELEASE_CLAIM_TIER: ${{ vars.OPEN_COWORK_RELEASE_CLAIM_TIER || 'local-self-host-beta' }}
         run: |
           pnpm deploy:validate -- --require-tools
           pnpm deploy:launch:validate
           pnpm deploy:launch:evidence:validate
+          pnpm deploy:promotion:validate -- --tier "${OPEN_COWORK_RELEASE_CLAIM_TIER}"
           pnpm deploy:private-beta:validate
           pnpm deploy:standalone-gateway:validate
           pnpm ops:validate

--- a/deploy/gcp/smoke/evidence.template.json
+++ b/deploy/gcp/smoke/evidence.template.json
@@ -74,7 +74,8 @@
     "quotaRateLimitBehavior": "PASS_OR_PENDING_PRIVATE_EVIDENCE",
     "billingEntitlementGating": "PASS_OR_PENDING_PRIVATE_EVIDENCE",
     "supportIncidentOwnershipEscalation": "PASS_OR_PENDING_PRIVATE_EVIDENCE",
-    "costSloNotes": "PASS_OR_PENDING_PRIVATE_EVIDENCE"
+    "costSloNotes": "PASS_OR_PENDING_PRIVATE_EVIDENCE",
+    "releaseRollback": "PASS_OR_PENDING_PRIVATE_EVIDENCE"
   },
   "notes": [
     "Do not replace placeholders with real project ids, account ids, domains, customer names, prices, tokens, signed URLs, or secret values in the public repo.",

--- a/deploy/load/launch-evidence-matrix.json
+++ b/deploy/load/launch-evidence-matrix.json
@@ -196,6 +196,7 @@
         "pnpm deploy:validate",
         "pnpm deploy:launch:validate",
         "pnpm deploy:launch:evidence:validate",
+        "pnpm deploy:promotion:validate -- --tier local-self-host-beta",
         "pnpm deploy:private-beta:validate",
         "pnpm ops:validate",
         "git diff --check"
@@ -418,6 +419,19 @@
           "pnpm deploy:soak:strict"
         ],
         "passCondition": "Private evidence records observed capacity limits, p95 latency/error targets, cost notes, and known scale boundaries for the target tier."
+      },
+      "releaseRollback": {
+        "requiredForPrivateBeta": true,
+        "category": "releasePackaging",
+        "publicArtifacts": [
+          "docs/release-checklist.md",
+          "docs/runbooks/launch-readiness-report.md"
+        ],
+        "requiredCommands": [
+          "pnpm deploy:launch:validate",
+          "pnpm deploy:private-beta:validate"
+        ],
+        "passCondition": "Private evidence records the exact rollback path for the promoted release, including artifact revoke/unpublish steps, worker drain or disablement, and customer communication owner."
       }
     }
   }

--- a/deploy/private-beta/README.md
+++ b/deploy/private-beta/README.md
@@ -17,7 +17,8 @@ Files:
   RPO/RTO, required launch evidence, and go/no-go placeholders.
 - `launch-evidence-record.template.json`: machine-readable evidence register
   for deployed continuation, load, soak, failover, restore, BYOK redaction,
-  gateway replay, quota/billing gates, support ownership, and cost/SLO notes.
+  gateway replay, quota/billing gates, support ownership, cost/SLO notes, and
+  release rollback evidence.
 - `managed-byok-readiness-contract.template.json`: machine-readable
   public/private boundary, onboarding status/reason-code, billing, BYOK,
   diagnostics, and validation contract.
@@ -58,7 +59,9 @@ The hosted path is for an operator-managed private beta:
    operations tracker and fill them with real evidence there, not in this repo.
 9. Validate the private evidence record with
    `pnpm deploy:launch:evidence:validate -- --manifest <private-record> --require-private-pass`
-   before changing the public decision summary.
+   and promote it with `pnpm deploy:promotion:validate -- --tier
+   private-hosted-beta --manifest <private-record>` before changing the public
+   decision summary.
 
 ## OSS Self-Host
 
@@ -76,6 +79,7 @@ Run:
 ```bash
 pnpm deploy:private-beta:validate
 pnpm deploy:launch:evidence:validate
+pnpm deploy:promotion:validate -- --tier local-self-host-beta
 pnpm deploy:validate
 pnpm deploy:launch:validate
 pnpm ops:validate

--- a/deploy/private-beta/go-no-go-report.template.md
+++ b/deploy/private-beta/go-no-go-report.template.md
@@ -38,6 +38,7 @@ separate SHA256 value.
 | `pnpm deploy:validate` | | | | | |
 | `pnpm deploy:launch:validate` | | | | | |
 | `pnpm deploy:launch:evidence:validate` | | | | | |
+| `pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>` | | | | | |
 | `pnpm deploy:private-beta:validate` | | | | | |
 | `pnpm ops:validate` | | | | | |
 | `pnpm deploy:smoke` | | | | | |
@@ -78,6 +79,7 @@ checksum or immutable artifact id, owner, and timestamp.
 | `billingEntitlementGating` | | | | | | |
 | `supportIncidentOwnershipEscalation` | | | | | | |
 | `costSloNotes` | | | | | | |
+| `releaseRollback` | | | | | | |
 
 ## Immutable Release Artifacts
 

--- a/deploy/private-beta/launch-evidence-record.template.json
+++ b/deploy/private-beta/launch-evidence-record.template.json
@@ -39,6 +39,7 @@
   ],
   "requiredReportFields": [
     "command",
+    "evidenceCommands",
     "commitSha",
     "imageDigests",
     "sanitizedEnvironmentProfile",
@@ -196,6 +197,17 @@
       "blockingForPrivateBeta": true,
       "status": "pending-private-evidence",
       "command": "pnpm deploy:soak:strict",
+      "privateEvidenceRef": "{private-evidence-ref}",
+      "publicRedactedSummary": "{redacted-summary}",
+      "checksum": "{sha256-or-immutable-artifact-id}",
+      "owner": "{owner}",
+      "followUpIssue": "{issue-or-empty}"
+    },
+    {
+      "id": "releaseRollback",
+      "blockingForPrivateBeta": true,
+      "status": "pending-private-evidence",
+      "command": "pnpm deploy:launch:validate",
       "privateEvidenceRef": "{private-evidence-ref}",
       "publicRedactedSummary": "{redacted-summary}",
       "checksum": "{sha256-or-immutable-artifact-id}",

--- a/deploy/private-beta/managed-byok-readiness-contract.template.json
+++ b/deploy/private-beta/managed-byok-readiness-contract.template.json
@@ -189,6 +189,7 @@
       "pnpm deploy:validate -- --require-tools",
       "pnpm deploy:launch:validate",
       "pnpm deploy:launch:evidence:validate",
+      "pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>",
       "pnpm ops:validate",
       "pnpm test",
       "pnpm typecheck",

--- a/deploy/private-beta/private-beta-go-no-go.public.md
+++ b/deploy/private-beta/private-beta-go-no-go.public.md
@@ -50,6 +50,7 @@ Until that happens, the public repo must keep the accepted claim at
 | `billingEntitlementGating` | `pending-private-evidence` | Billing/entitlement gating evidence has not been publicly summarized. | `{private-checksum}` | `{issue-or-empty}` |
 | `supportIncidentOwnershipEscalation` | `pending-private-evidence` | Support ownership and escalation evidence has not been publicly summarized. | `{private-checksum}` | `{issue-or-empty}` |
 | `costSloNotes` | `pending-private-evidence` | Cost, capacity, and SLO evidence has not been publicly summarized. | `{private-checksum}` | `{issue-or-empty}` |
+| `releaseRollback` | `pending-private-evidence` | Release rollback and customer communication evidence has not been publicly summarized. | `{private-checksum}` | `{issue-or-empty}` |
 
 ## Public/Private Boundary
 
@@ -66,6 +67,7 @@ Run these before changing this public decision summary:
 pnpm deploy:launch:validate
 pnpm deploy:launch:evidence:validate
 pnpm deploy:launch:evidence:validate -- --manifest <private-record> --require-private-pass
+pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>
 pnpm deploy:private-beta:validate
 pnpm ops:validate
 pnpm deploy:continuation:smoke

--- a/deploy/private-beta/private-beta-launch-profile.template.json
+++ b/deploy/private-beta/private-beta-launch-profile.template.json
@@ -93,12 +93,14 @@
       "quotaRateLimitBehavior": true,
       "billingEntitlementGating": true,
       "supportIncidentOwnershipEscalation": true,
-      "costSloNotes": true
+      "costSloNotes": true,
+      "releaseRollback": true
     },
     "requiredSmokeCommands": [
       "pnpm deploy:private-beta:validate",
       "pnpm deploy:launch:validate",
       "pnpm deploy:launch:evidence:validate",
+      "pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>",
       "pnpm ops:validate",
       "pnpm deploy:smoke",
       "pnpm deploy:desktop:smoke",

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -83,8 +83,8 @@ The repository includes:
   - verifies the tag signature, allowed release actor, and required green CI
     checks before publishing
   - reruns Cloud Web, Desktop/Web/Gateway continuation, Docker/Compose,
-    Helm, deployment, launch, private-beta, and ops readiness gates before
-    publishing a tag
+    Helm, deployment, launch, promotion, private-beta, and ops readiness gates
+    before publishing a tag
   - creates GitHub Releases automatically for version tags
   - publishes Cloud and Gateway images to GHCR using immutable release tags
     and captures their registry digests
@@ -213,6 +213,16 @@ Recommended release flow:
 3. Let `release.yml` build platform artifacts
 4. Verify the resulting GitHub Release includes checksums and provenance
 5. Smoke-test at least one macOS build and one Linux build before announcing it
+
+The default tag workflow validates the public `local-self-host-beta` promotion
+claim with `pnpm deploy:promotion:validate -- --tier local-self-host-beta`.
+Stronger hosted claims require `OPEN_COWORK_RELEASE_CLAIM_TIER` plus a private
+evidence manifest. For tag releases, set repository variable
+`OPEN_COWORK_RELEASE_CLAIM_TIER` and provide the base64-encoded private
+manifest in secret `OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64`; the workflow
+materializes it into `OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST` before running
+the gate. Local operators can pass `--manifest <private-record>` directly.
+Without completed private-pass report evidence the promotion gate fails closed.
 
 ## Signing and notarization
 

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -15,9 +15,8 @@ Cloud tenant boundaries are guarded, release supply-chain controls are mature,
 and deployment templates have explicit production gates. No critical issue was
 found in the current review.
 
-The remaining work is concentrated in three areas:
+The remaining work is concentrated in two areas:
 
-- release/promotion proof for hosted production claims
 - maintainability guardrails for the largest Cloud compatibility facades and
   generated or vendored surfaces
 - shutdown and backpressure behavior for long-lived Cloud streams and queues
@@ -62,25 +61,16 @@ The remaining work is concentrated in three areas:
 - Cloud HTTP shutdown now closes replay polling and active SSE streams before
   awaiting `server.close()`, with lifecycle regressions for open streams and
   shutdown during replay loading.
+- Release promotion now has a separate tier-aware validator. CI and release
+  preflight prove the public `local-self-host-beta` claim, and hosted
+  promotion requires a private manifest with `private-pass` evidence plus
+  strict per-item report metadata for load, soak, failover, restore, BYOK,
+  support, rollback, commit SHA, image digests, and sanitized environment
+  profile.
 
 ## High Priority
 
-### Release Gates Do Not Prove Hosted Production Readiness
-
-Evidence:
-
-- CI and release validate the launch evidence manifest without the
-  `--require-private-pass` flag.
-- The public launch matrix honestly targets `local-self-host-beta`, not managed
-  SaaS, GA, or enterprise hosting.
-
-Impact: a release tag can pass while real load, soak, restore, failover, BYOK,
-support, and on-call evidence is absent. This is acceptable for the current
-public tier, but not for hosted production claims.
-
-Target state: add a separate promotion gate for private beta, public beta, and
-GA that runs the private-pass evidence validator plus strict environment
-evidence for load, soak, failover, restore, BYOK, support, and rollback.
+No open high-priority findings remain after the current audit remediations.
 
 ## Medium Priority
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -38,6 +38,7 @@ and linked from the release Go/No-Go report.
       evidence.
 - [ ] `pnpm deploy:launch:validate`
 - [ ] `pnpm deploy:launch:evidence:validate`
+- [ ] `pnpm deploy:promotion:validate -- --tier local-self-host-beta`
 - [ ] `pnpm deploy:private-beta:validate`
 - [ ] `pnpm ops:validate`
 - [ ] perf baseline environment is intentional; refresh
@@ -89,6 +90,10 @@ and linked from the release Go/No-Go report.
 - [ ] release workflows point at the correct package names and scripts
 - [ ] release notes state the accepted launch tier: `v0.x` preview, private
       hosted beta, public beta, stable, or enterprise-ready
+- [ ] if the release claim tier is stronger than `local-self-host-beta`,
+      repository variable `OPEN_COWORK_RELEASE_CLAIM_TIER` is set and secret
+      `OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64` contains the base64-encoded
+      private promotion manifest for the exact tag commit.
 - [ ] Cloud Channel Gateway and Standalone Gateway are not described as the
       same product mode in release notes, docs, or deployment assets
 - [ ] any `opencode-gateway` or `opencode-agent-gateway` compatibility alias
@@ -128,7 +133,8 @@ and linked from the release Go/No-Go report.
 - [ ] private-beta evidence has been completed from
       `deploy/private-beta/launch-evidence-record.template.json`, validated
       with `pnpm deploy:launch:evidence:validate -- --manifest <private-record>
-      --require-private-pass`, and summarized in
+      --require-private-pass`, promoted with `pnpm deploy:promotion:validate
+      -- --tier private-hosted-beta --manifest <private-record>`, and summarized in
       `deploy/private-beta/private-beta-go-no-go.public.md` without private
       values.
 - [ ] worker images are pinned by release tag or digest; no deployment uses
@@ -153,6 +159,9 @@ and linked from the release Go/No-Go report.
       failover evidence or recorded explicit private operator hook evidence.
       `pnpm deploy:failover:drill:dry-run` is only a local contract check and
       is not launch evidence.
+- [ ] release rollback evidence records artifact revoke/unpublish steps, worker
+      drain or disablement, support/customer communication owner, and checksum
+      or immutable private evidence reference.
 - [ ] load and soak JSON/Markdown reports are attached to the release or
       downstream operations evidence.
 - [ ] `docs/runbooks/launch-readiness-report.md` has a completed Go/No-Go

--- a/docs/runbooks/launch-readiness-report.md
+++ b/docs/runbooks/launch-readiness-report.md
@@ -66,6 +66,7 @@ follow-up issue id.
 | billingEntitlementGating | | | | | |
 | supportIncidentOwnershipEscalation | | | | | |
 | costSloNotes | | | | | |
+| releaseRollback | | | | | |
 
 ## Load Test Report
 

--- a/docs/runbooks/launch-readiness.md
+++ b/docs/runbooks/launch-readiness.md
@@ -239,8 +239,21 @@ Validate committed launch-readiness artifacts:
 
 ```bash
 pnpm deploy:launch:validate
+pnpm deploy:launch:evidence:validate
+pnpm deploy:promotion:validate -- --tier local-self-host-beta
 ```
 
 This checks target profiles, harness coverage, required runbook wording, the
 launch evidence matrix, report template, package scripts, and release-checklist
 links.
+
+Hosted promotion is a separate private-operations gate. For managed private
+beta, copy the launch evidence record into private ops, complete every
+`private-pass` item with strict report metadata, then run:
+
+```bash
+pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>
+```
+
+Higher hosted tiers fail closed until the launch evidence matrix records
+explicit private-ops promotion requirements for that tier.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "deploy:failover:drill:dry-run": "node scripts/launch-failover-drill.mjs --dry-run",
     "deploy:launch:validate": "node scripts/validate-launch-readiness.mjs",
     "deploy:launch:evidence:validate": "node scripts/validate-launch-evidence-manifest.mjs",
+    "deploy:promotion:validate": "node scripts/validate-release-promotion.mjs",
     "deploy:private-beta:validate": "node scripts/validate-private-beta-package.mjs",
     "ops:validate": "node scripts/validate-ops-readiness.mjs && node scripts/validate-release-gates.mjs",
     "release:gates:validate": "node scripts/validate-release-gates.mjs",

--- a/scripts/validate-launch-evidence-manifest.mjs
+++ b/scripts/validate-launch-evidence-manifest.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
 
 const matrixPath = 'deploy/load/launch-evidence-matrix.json'
 const defaultManifestPath = 'deploy/private-beta/launch-evidence-record.template.json'
 const publicSummaryPath = 'deploy/private-beta/private-beta-go-no-go.public.md'
 const packagePath = 'package.json'
 
-const requiredEvidenceIds = [
+export const requiredLaunchEvidenceIds = [
   'deployedDesktopWebGatewayContinuation',
   'deployedLoadTest',
   'deployedSoakTest',
@@ -21,6 +22,7 @@ const requiredEvidenceIds = [
   'billingEntitlementGating',
   'supportIncidentOwnershipEscalation',
   'costSloNotes',
+  'releaseRollback',
 ]
 
 const statusValues = new Set([
@@ -32,6 +34,7 @@ const statusValues = new Set([
 
 const requiredReportFields = [
   'command',
+  'evidenceCommands',
   'commitSha',
   'imageDigests',
   'sanitizedEnvironmentProfile',
@@ -154,106 +157,122 @@ function assertArrayContainsAll(values, required, label) {
   }
 }
 
-const args = parseArgs(process.argv.slice(2))
-for (const path of [matrixPath, defaultManifestPath, publicSummaryPath, packagePath, args.manifest]) assertFile(path)
+export function validateLaunchEvidenceManifest(options = {}) {
+  const args = {
+    manifest: options.manifest ?? defaultManifestPath,
+    requirePrivatePass: options.requirePrivatePass === true,
+  }
+  for (const path of [matrixPath, defaultManifestPath, publicSummaryPath, packagePath, args.manifest]) assertFile(path)
 
-const packageJson = readJson(packagePath)
-const matrix = readJson(matrixPath)
-if (matrix.schemaVersion !== 1) throw new Error(`${matrixPath} must declare schemaVersion 1`)
-if (matrix.acceptedPublicTier !== 'local-self-host-beta') {
-  throw new Error(`${matrixPath} must keep local-self-host-beta as the public tier until private evidence is complete`)
-}
-if (matrix.privateBetaEvidenceItems?.requiredStatusForGo !== 'private-pass') {
-  throw new Error(`${matrixPath} must require private-pass for go decisions`)
-}
-if (matrix.privateBetaEvidenceItems?.storageRule?.includes('tokens') !== true) {
-  throw new Error(`${matrixPath} must document private evidence storage and token redaction`)
-}
+  const packageJson = readJson(packagePath)
+  const matrix = readJson(matrixPath)
+  if (matrix.schemaVersion !== 1) throw new Error(`${matrixPath} must declare schemaVersion 1`)
+  if (matrix.acceptedPublicTier !== 'local-self-host-beta') {
+    throw new Error(`${matrixPath} must keep local-self-host-beta as the public tier until private evidence is complete`)
+  }
+  if (matrix.privateBetaEvidenceItems?.requiredStatusForGo !== 'private-pass') {
+    throw new Error(`${matrixPath} must require private-pass for go decisions`)
+  }
+  if (matrix.privateBetaEvidenceItems?.storageRule?.includes('tokens') !== true) {
+    throw new Error(`${matrixPath} must document private evidence storage and token redaction`)
+  }
 
-const matrixItems = matrix.privateBetaEvidenceItems?.items ?? {}
-const matrixIds = Object.keys(matrixItems)
-for (const id of requiredEvidenceIds) {
-  const item = matrixItems[id]
-  if (!item) throw new Error(`${matrixPath} is missing private beta evidence item ${id}`)
-  if (item.requiredForPrivateBeta !== true) throw new Error(`${id} must be required for private beta`)
-  if (typeof item.passCondition !== 'string' || item.passCondition.length < 30) {
-    throw new Error(`${id} must define a concrete pass condition`)
-  }
-  if (!Array.isArray(item.publicArtifacts) || item.publicArtifacts.length === 0) {
-    throw new Error(`${id} must list public artifacts`)
-  }
-  for (const artifact of item.publicArtifacts) assertFile(artifact)
-  if (!Array.isArray(item.requiredCommands) || item.requiredCommands.length === 0) {
-    throw new Error(`${id} must list required commands`)
-  }
-  for (const command of item.requiredCommands) {
-    const script = commandScript(command)
-    if (script && typeof packageJson.scripts?.[script] !== 'string') {
-      throw new Error(`${id} references missing package script ${script}`)
+  const matrixItems = matrix.privateBetaEvidenceItems?.items ?? {}
+  const matrixIds = Object.keys(matrixItems)
+  for (const id of requiredLaunchEvidenceIds) {
+    const item = matrixItems[id]
+    if (!item) throw new Error(`${matrixPath} is missing private beta evidence item ${id}`)
+    if (item.requiredForPrivateBeta !== true) throw new Error(`${id} must be required for private beta`)
+    if (typeof item.passCondition !== 'string' || item.passCondition.length < 30) {
+      throw new Error(`${id} must define a concrete pass condition`)
+    }
+    if (!Array.isArray(item.publicArtifacts) || item.publicArtifacts.length === 0) {
+      throw new Error(`${id} must list public artifacts`)
+    }
+    for (const artifact of item.publicArtifacts) assertFile(artifact)
+    if (!Array.isArray(item.requiredCommands) || item.requiredCommands.length === 0) {
+      throw new Error(`${id} must list required commands`)
+    }
+    for (const command of item.requiredCommands) {
+      const script = commandScript(command)
+      if (script && typeof packageJson.scripts?.[script] !== 'string') {
+        throw new Error(`${id} references missing package script ${script}`)
+      }
     }
   }
-}
-for (const id of matrixIds) {
-  if (!requiredEvidenceIds.includes(id)) throw new Error(`${matrixPath} has unexpected private beta evidence item ${id}`)
-}
-
-const manifest = readJson(args.manifest)
-if (manifest.schemaVersion !== 1) throw new Error(`${args.manifest} must declare schemaVersion 1`)
-if (manifest.purpose !== 'managed-byok-private-beta-launch-evidence-record-template') {
-  throw new Error(`${args.manifest} must declare purpose managed-byok-private-beta-launch-evidence-record-template`)
-}
-if (manifest.targetTier !== 'private-beta') throw new Error(`${args.manifest} must target private-beta`)
-if (manifest.currentPublicTier !== 'local-self-host-beta') {
-  throw new Error(`${args.manifest} must keep currentPublicTier local-self-host-beta`)
-}
-if (manifest.publicPrivateBoundary?.publicSummaryStorage !== publicSummaryPath) {
-  throw new Error(`${args.manifest} must point to ${publicSummaryPath}`)
-}
-assertArrayContainsAll(
-  manifest.publicPrivateBoundary?.allowedPublicFields,
-  requiredPublicAllowedFields,
-  `${args.manifest}.publicPrivateBoundary.allowedPublicFields`,
-)
-assertArrayContainsAll(manifest.requiredReportFields, requiredReportFields, `${args.manifest}.requiredReportFields`)
-
-const manifestItems = manifest.requiredEvidence
-if (!Array.isArray(manifestItems)) throw new Error(`${args.manifest} must list requiredEvidence`)
-const seen = new Set()
-for (const item of manifestItems) {
-  if (!requiredEvidenceIds.includes(item.id)) throw new Error(`${args.manifest} has unexpected evidence id ${item.id}`)
-  if (seen.has(item.id)) throw new Error(`${args.manifest} has duplicate evidence id ${item.id}`)
-  seen.add(item.id)
-  if (item.blockingForPrivateBeta !== true) throw new Error(`${item.id} must block private beta`)
-  if (!statusValues.has(item.status)) throw new Error(`${item.id} has invalid status ${item.status}`)
-  if (typeof item.command !== 'string' || item.command.length === 0) throw new Error(`${item.id} must record command`)
-  const script = commandScript(item.command)
-  if (script && typeof packageJson.scripts?.[script] !== 'string') {
-    throw new Error(`${item.id} references missing package script ${script}`)
+  for (const id of matrixIds) {
+    if (!requiredLaunchEvidenceIds.includes(id)) throw new Error(`${matrixPath} has unexpected private beta evidence item ${id}`)
   }
-  if (args.requirePrivatePass) {
-    if (item.status !== 'private-pass') throw new Error(`${item.id} must be private-pass for private-beta go`)
-    assertCompletedValue(item, 'privateEvidenceRef', item.id)
-    assertCompletedValue(item, 'publicRedactedSummary', item.id)
-    assertCompletedValue(item, 'checksum', item.id)
-    assertCompletedValue(item, 'owner', item.id)
-    assertPublicSafeText(item.publicRedactedSummary, `${item.id}.publicRedactedSummary`)
-    assertChecksum(item.checksum, item.id)
+
+  const manifest = readJson(args.manifest)
+  if (manifest.schemaVersion !== 1) throw new Error(`${args.manifest} must declare schemaVersion 1`)
+  if (manifest.purpose !== 'managed-byok-private-beta-launch-evidence-record-template') {
+    throw new Error(`${args.manifest} must declare purpose managed-byok-private-beta-launch-evidence-record-template`)
   }
-}
-for (const id of requiredEvidenceIds) {
-  if (!seen.has(id)) throw new Error(`${args.manifest} is missing required evidence ${id}`)
+  const expectedTargetTier = options.expectedTargetTier ?? 'private-beta'
+  if (manifest.targetTier !== expectedTargetTier) throw new Error(`${args.manifest} must target ${expectedTargetTier}`)
+  if (manifest.currentPublicTier !== 'local-self-host-beta') {
+    throw new Error(`${args.manifest} must keep currentPublicTier local-self-host-beta`)
+  }
+  if (manifest.publicPrivateBoundary?.publicSummaryStorage !== publicSummaryPath) {
+    throw new Error(`${args.manifest} must point to ${publicSummaryPath}`)
+  }
+  assertArrayContainsAll(
+    manifest.publicPrivateBoundary?.allowedPublicFields,
+    requiredPublicAllowedFields,
+    `${args.manifest}.publicPrivateBoundary.allowedPublicFields`,
+  )
+  assertArrayContainsAll(manifest.requiredReportFields, requiredReportFields, `${args.manifest}.requiredReportFields`)
+
+  const manifestItems = manifest.requiredEvidence
+  if (!Array.isArray(manifestItems)) throw new Error(`${args.manifest} must list requiredEvidence`)
+  const seen = new Set()
+  for (const item of manifestItems) {
+    if (!requiredLaunchEvidenceIds.includes(item.id)) throw new Error(`${args.manifest} has unexpected evidence id ${item.id}`)
+    if (seen.has(item.id)) throw new Error(`${args.manifest} has duplicate evidence id ${item.id}`)
+    seen.add(item.id)
+    if (item.blockingForPrivateBeta !== true) throw new Error(`${item.id} must block private beta`)
+    if (!statusValues.has(item.status)) throw new Error(`${item.id} has invalid status ${item.status}`)
+    if (typeof item.command !== 'string' || item.command.length === 0) throw new Error(`${item.id} must record command`)
+    const script = commandScript(item.command)
+    if (script && typeof packageJson.scripts?.[script] !== 'string') {
+      throw new Error(`${item.id} references missing package script ${script}`)
+    }
+    if (args.requirePrivatePass) {
+      if (item.status !== 'private-pass') throw new Error(`${item.id} must be private-pass for private-beta go`)
+      assertCompletedValue(item, 'privateEvidenceRef', item.id)
+      assertCompletedValue(item, 'publicRedactedSummary', item.id)
+      assertCompletedValue(item, 'checksum', item.id)
+      assertCompletedValue(item, 'owner', item.id)
+      assertPublicSafeText(item.publicRedactedSummary, `${item.id}.publicRedactedSummary`)
+      assertChecksum(item.checksum, item.id)
+    }
+  }
+  for (const id of requiredLaunchEvidenceIds) {
+    if (!seen.has(id)) throw new Error(`${args.manifest} is missing required evidence ${id}`)
+  }
+
+  for (const path of [matrixPath, defaultManifestPath, publicSummaryPath]) {
+    assertPublicSafe(path)
+  }
+
+  for (const id of requiredLaunchEvidenceIds) {
+    assertIncludes(publicSummaryPath, id)
+  }
+  assertIncludes(publicSummaryPath, 'Decision: `no-go`')
+  assertIncludes(publicSummaryPath, 'Current public tier: `local-self-host-beta`')
+  assertIncludes(publicSummaryPath, 'pending-private-evidence')
+  assertIncludes(publicSummaryPath, 'no-go')
+
+  return { manifest, matrix, packageJson }
 }
 
-for (const path of [matrixPath, defaultManifestPath, publicSummaryPath]) {
-  assertPublicSafe(path)
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv)
+  validateLaunchEvidenceManifest(args)
+  process.stdout.write('[launch-evidence-validate] launch evidence manifest validated\n')
 }
 
-for (const id of requiredEvidenceIds) {
-  assertIncludes(publicSummaryPath, id)
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
 }
-assertIncludes(publicSummaryPath, 'Decision: `no-go`')
-assertIncludes(publicSummaryPath, 'Current public tier: `local-self-host-beta`')
-assertIncludes(publicSummaryPath, 'pending-private-evidence')
-assertIncludes(publicSummaryPath, 'no-go')
-
-process.stdout.write('[launch-evidence-validate] launch evidence manifest validated\n')

--- a/scripts/validate-launch-readiness.mjs
+++ b/scripts/validate-launch-readiness.mjs
@@ -188,6 +188,7 @@ const requiredPrivateBetaEvidenceIds = [
   'billingEntitlementGating',
   'supportIncidentOwnershipEscalation',
   'costSloNotes',
+  'releaseRollback',
 ]
 if (evidenceMatrix.privateBetaEvidenceItems?.requiredStatusForGo !== 'private-pass') {
   throw new Error(`${evidenceMatrixPath} must require private-pass before a private-beta go decision`)
@@ -234,6 +235,7 @@ for (const command of [
   'pnpm deploy:private-beta:validate',
   'pnpm deploy:launch:validate',
   'pnpm deploy:launch:evidence:validate',
+  'pnpm deploy:promotion:validate -- --tier local-self-host-beta',
   'pnpm ops:validate',
   'git diff --check',
 ]) {
@@ -274,6 +276,7 @@ for (const phrase of [
   'gatewayDeliveryReplayDeadLetter',
   'supportIncidentOwnershipEscalation',
   'costSloNotes',
+  'releaseRollback',
 ]) {
   assertIncludes(evidenceMatrixPath, phrase)
 }
@@ -381,6 +384,7 @@ for (const phrase of [
 for (const phrase of [
   'requiredReportFields',
   'commitSha',
+  'evidenceCommands',
   'imageDigests',
   'sanitizedEnvironmentProfile',
   'dates and duration',
@@ -398,7 +402,9 @@ for (const phrase of [
   'gatewayDeliveryReplayDeadLetter',
   'supportIncidentOwnershipEscalation',
   'costSloNotes',
+  'releaseRollback',
   'pnpm deploy:launch:evidence:validate -- --manifest <private-record> --require-private-pass',
+  'pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>',
 ]) {
   assertIncludes(publicGoNoGoPath, phrase)
 }
@@ -415,6 +421,7 @@ for (const phrase of [
   'pnpm deploy:failover:drill',
   'pnpm deploy:launch:validate',
   'pnpm deploy:launch:evidence:validate',
+  'pnpm deploy:promotion:validate',
 ]) {
   assertIncludes(releaseChecklistPath, phrase)
 }
@@ -428,6 +435,7 @@ for (const script of [
   'deploy:failover:drill',
   'deploy:launch:validate',
   'deploy:launch:evidence:validate',
+  'deploy:promotion:validate',
 ]) {
   if (typeof packageJson.scripts?.[script] !== 'string') {
     throw new Error(`${packagePath} is missing ${script}`)

--- a/scripts/validate-private-beta-package.mjs
+++ b/scripts/validate-private-beta-package.mjs
@@ -174,6 +174,9 @@ if (packageJson.scripts?.['deploy:private-beta:validate'] !== 'node scripts/vali
 if (packageJson.scripts?.['deploy:launch:evidence:validate'] !== 'node scripts/validate-launch-evidence-manifest.mjs') {
   throw new Error('package.json must expose deploy:launch:evidence:validate')
 }
+if (packageJson.scripts?.['deploy:promotion:validate'] !== 'node scripts/validate-release-promotion.mjs') {
+  throw new Error('package.json must expose deploy:promotion:validate')
+}
 if (packageJson.scripts?.['deploy:failover:drill'] !== 'node scripts/launch-failover-drill.mjs') {
   throw new Error('package.json must expose deploy:failover:drill')
 }
@@ -283,6 +286,15 @@ for (const evidence of [
   'desktopWebGatewayContinuation',
   'tokenRevocationProof',
   'diagnosticsRedactionProof',
+  'launchEvidenceRecord',
+  'schedulerReplicaFailover',
+  'secretAdapterResolution',
+  'byokRedactionNoPlaintext',
+  'quotaRateLimitBehavior',
+  'billingEntitlementGating',
+  'supportIncidentOwnershipEscalation',
+  'costSloNotes',
+  'releaseRollback',
 ]) {
   if (profile?.requiredEvidence?.[evidence] !== true) {
     throw new Error(`launch profile must require ${evidence}`)
@@ -292,6 +304,7 @@ for (const command of [
   'pnpm deploy:private-beta:validate',
   'pnpm deploy:launch:validate',
   'pnpm deploy:launch:evidence:validate',
+  'pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>',
   'pnpm ops:validate',
   'pnpm deploy:continuation:smoke',
   'pnpm deploy:load:strict',
@@ -333,6 +346,7 @@ for (const evidence of [
   'billingEntitlementGating',
   'supportIncidentOwnershipEscalation',
   'costSloNotes',
+  'releaseRollback',
 ]) {
   const record = launchEvidence.requiredEvidence.find((entry) => entry.id === evidence)
   if (!record) throw new Error(`launch evidence record must require ${evidence}`)
@@ -484,6 +498,7 @@ for (const command of [
   'pnpm deploy:validate -- --require-tools',
   'pnpm deploy:launch:validate',
   'pnpm deploy:launch:evidence:validate',
+  'pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>',
   'pnpm ops:validate',
   'pnpm test',
   'pnpm typecheck',
@@ -532,6 +547,8 @@ for (const phrase of [
   'Cloud Channel Gateway is a channel client and delivery adapter',
   'managed-byok-readiness-contract.template.json',
   'launch-evidence-record.template.json',
+  'pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>',
+  'releaseRollback',
   'Onboarding failures preserve machine-readable status and reason codes',
 ]) {
   assertIncludes('deploy/private-beta/go-no-go-report.template.md', phrase)
@@ -545,7 +562,9 @@ for (const phrase of [
   'gatewayDeliveryReplayDeadLetter',
   'supportIncidentOwnershipEscalation',
   'costSloNotes',
+  'releaseRollback',
   'pnpm deploy:launch:evidence:validate -- --manifest <private-record> --require-private-pass',
+  'pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>',
 ]) {
   assertIncludes('deploy/private-beta/private-beta-go-no-go.public.md', phrase)
 }

--- a/scripts/validate-release-gates.mjs
+++ b/scripts/validate-release-gates.mjs
@@ -288,6 +288,9 @@ function assertPackageScripts() {
   if (packageJson.scripts?.['deploy:launch:evidence:validate'] !== 'node scripts/validate-launch-evidence-manifest.mjs') {
     throw new Error('package.json must expose deploy:launch:evidence:validate')
   }
+  if (packageJson.scripts?.['deploy:promotion:validate'] !== 'node scripts/validate-release-promotion.mjs') {
+    throw new Error('package.json must expose deploy:promotion:validate')
+  }
 }
 
 function assertBranchProtectionContract() {
@@ -322,6 +325,7 @@ function assertCiContract() {
     'pnpm deploy:validate -- --require-tools',
     'pnpm deploy:launch:validate',
     'pnpm deploy:launch:evidence:validate',
+    'pnpm deploy:promotion:validate -- --tier local-self-host-beta',
     'pnpm deploy:private-beta:validate',
     'pnpm deploy:standalone-gateway:validate',
     'pnpm ops:validate',
@@ -344,6 +348,7 @@ function assertReleaseWorkflowContract() {
     'pnpm deploy:validate -- --require-tools',
     'pnpm deploy:launch:validate',
     'pnpm deploy:launch:evidence:validate',
+    'pnpm deploy:promotion:validate -- --tier "${OPEN_COWORK_RELEASE_CLAIM_TIER}"',
     'pnpm deploy:private-beta:validate',
     'pnpm deploy:standalone-gateway:validate',
     'pnpm ops:validate',
@@ -391,6 +396,10 @@ function assertReleaseWorkflowContract() {
 
   assertIncludes(releaseWorkflowPath, 'needs.release-policy.result == \'success\'')
   assertIncludes(releaseWorkflowPath, 'publish-oci-images')
+  assertIncludes(releaseWorkflowPath, 'Materialize hosted promotion evidence manifest')
+  assertIncludes(releaseWorkflowPath, 'OPEN_COWORK_RELEASE_CLAIM_TIER: ${{ vars.OPEN_COWORK_RELEASE_CLAIM_TIER || \'local-self-host-beta\' }}')
+  assertIncludes(releaseWorkflowPath, 'OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64: ${{ secrets.OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64 }}')
+  assertIncludes(releaseWorkflowPath, 'OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST=$manifest_path')
   assertIncludes(releaseWorkflowPath, 'OPEN_COWORK_PACKAGED_EXECUTABLE: ${{ steps.packaged-executable.outputs.path }}')
   assertNotIncludes(releaseWorkflowPath, 'test:e2e:packaged:optional')
 }
@@ -409,6 +418,9 @@ function assertReleaseChecklistContract() {
     'BYOK redaction',
     'Gateway replay/dead-letter recovery',
     'private-value scan',
+    'deploy:promotion:validate',
+    'OPEN_COWORK_RELEASE_CLAIM_TIER',
+    'OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST_B64',
     '--require-private-pass',
     'Go/No-Go',
   ]) {

--- a/scripts/validate-release-promotion.mjs
+++ b/scripts/validate-release-promotion.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import {
+  requiredLaunchEvidenceIds,
+  validateLaunchEvidenceManifest,
+} from './validate-launch-evidence-manifest.mjs'
+
+const matrixPath = 'deploy/load/launch-evidence-matrix.json'
+const publicTemplatePath = 'deploy/private-beta/launch-evidence-record.template.json'
+
+const tierConfigs = {
+  'local-self-host-beta': {
+    hosted: false,
+    matrixTier: 'local-self-host-beta',
+    evidenceTargetTier: null,
+    evidenceProfile: 'local-self-host-beta',
+  },
+  'private-hosted-beta': {
+    hosted: true,
+    matrixTier: 'private-beta',
+    evidenceTargetTier: 'private-beta',
+    evidenceProfile: 'private-beta',
+  },
+  'public-beta': {
+    hosted: true,
+    matrixTier: 'public-beta',
+    evidenceTargetTier: 'public-beta',
+    evidenceProfile: 'public-beta',
+  },
+  'general-availability': {
+    hosted: true,
+    matrixTier: 'general-availability',
+    evidenceTargetTier: 'general-availability',
+    evidenceProfile: 'enterprise-scale',
+  },
+  'enterprise-ready': {
+    hosted: true,
+    matrixTier: 'enterprise-scale',
+    evidenceTargetTier: 'enterprise-ready',
+    evidenceProfile: 'enterprise-scale',
+  },
+}
+
+const passStatuses = new Set(['go', 'pass', 'passed', 'private-pass', 'success'])
+const forbiddenProfileKeyPattern = /(secret|token|password|private[_-]?key|database[_-]?url|credential|cookie)/i
+const forbiddenValuePatterns = [
+  /(?:sk|ghp|xoxb)-[A-Za-z0-9_-]{8,}/,
+  /\bghp_[A-Za-z0-9_]{20,}\b/,
+  /\bxoxb-[A-Za-z0-9-]{20,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+  /\bAIza[0-9A-Za-z_-]{20,}\b/,
+  /\b(?:price|prod|acct|cus|sub)_[0-9A-Za-z]{8,}\b/,
+  /\b\d{12}\b/,
+  /postgres(?:ql)?:\/\//i,
+  /[?&](?:X-Amz-Signature|X-Amz-Credential|X-Goog-Signature|X-Goog-Credential|AWSAccessKeyId|sig|signature)=/i,
+  /BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY/,
+]
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function readJson(path) {
+  return JSON.parse(read(path))
+}
+
+function assertFile(path) {
+  if (!existsSync(path)) throw new Error(`${path} is required`)
+}
+
+function parseArgs(argv) {
+  const args = {
+    tier: process.env.OPEN_COWORK_RELEASE_CLAIM_TIER || 'local-self-host-beta',
+    manifest: process.env.OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST || '',
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') {
+      continue
+    } else if (arg === '--tier') {
+      args.tier = argv[index + 1]
+      index += 1
+    } else if (arg === '--manifest') {
+      args.manifest = argv[index + 1]
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      process.stdout.write(
+        `Usage: node scripts/validate-release-promotion.mjs --tier ${Object.keys(tierConfigs).join('|')} [--manifest path]\n`,
+      )
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+  if (!args.tier) throw new Error('--tier is required')
+  return args
+}
+
+function assertSha(value, label) {
+  if (typeof value !== 'string' || !/^[a-f0-9]{40}$/i.test(value)) {
+    throw new Error(`${label} must be a 40-character commit SHA`)
+  }
+}
+
+function assertDigest(value, label) {
+  if (typeof value !== 'string' || !/^sha256:[a-f0-9]{64}$/i.test(value)) {
+    throw new Error(`${label} must be sha256:<64 hex>`)
+  }
+}
+
+function assertIsoTimestamp(value, label) {
+  if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) {
+    throw new Error(`${label} must be an ISO timestamp`)
+  }
+}
+
+function assertPassStatus(value, label) {
+  if (typeof value !== 'string' || !passStatuses.has(value)) {
+    throw new Error(`${label} must record a passing status`)
+  }
+}
+
+function assertNoPrivateValues(value, label) {
+  if (typeof value === 'string') {
+    for (const pattern of forbiddenValuePatterns) {
+      if (pattern.test(value)) throw new Error(`${label} contains private-looking value ${pattern}`)
+    }
+    return
+  }
+  if (!value || typeof value !== 'object') return
+  for (const [key, nested] of Object.entries(value)) {
+    const isBooleanIndicator = typeof nested === 'boolean' && /(Provided|Configured|Enabled)$/i.test(key)
+    if (forbiddenProfileKeyPattern.test(key) && !isBooleanIndicator) {
+      throw new Error(`${label}.${key} must not expose secret-bearing metadata`)
+    }
+    assertNoPrivateValues(nested, `${label}.${key}`)
+  }
+}
+
+function assertEnvironmentProfile(profile, config, itemId) {
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new Error(`${itemId}.report.sanitizedEnvironmentProfile must be an object`)
+  }
+  assertNoPrivateValues(profile, `${itemId}.report.sanitizedEnvironmentProfile`)
+  const profileName = profile.profileName ?? profile.targetProfile ?? profile.launchProfile
+  const targetTier = profile.targetTier ?? profile.claimTier ?? profile.promotionTier
+  if (profileName !== config.evidenceProfile) {
+    throw new Error(`${itemId}.report.sanitizedEnvironmentProfile.profileName must be ${config.evidenceProfile}`)
+  }
+  if (targetTier !== config.evidenceTargetTier) {
+    throw new Error(`${itemId}.report.sanitizedEnvironmentProfile.targetTier must be ${config.evidenceTargetTier}`)
+  }
+}
+
+function assertNoDryRunEvidence(item, report) {
+  const values = [item.command, report.command, report.mode]
+  if (Array.isArray(report.flags)) values.push(...report.flags)
+  if (values.some((value) => typeof value === 'string' && /\bdry[-_ ]?run\b/i.test(value)) || report.dryRun === true) {
+    throw new Error(`${item.id} must use executed evidence, not dry-run evidence`)
+  }
+}
+
+function assertStrictCommandEvidence(item, report) {
+  const command = `${item.command} ${report.command}`
+  if ((item.id === 'deployedLoadTest' || item.id === 'quotaRateLimitBehavior') && !command.includes('deploy:load:strict')) {
+    throw new Error(`${item.id} must use deploy:load:strict evidence`)
+  }
+  if ((item.id === 'deployedSoakTest' || item.id === 'costSloNotes') && !command.includes('deploy:soak:strict')) {
+    throw new Error(`${item.id} must use deploy:soak:strict evidence`)
+  }
+}
+
+function assertRollbackEvidence(item, report) {
+  if (item.id !== 'releaseRollback') return
+  const text = `${item.publicRedactedSummary} ${JSON.stringify(report)}`
+  for (const phrase of ['rollback', 'revoke', 'drain', 'communication']) {
+    if (!new RegExp(phrase, 'i').test(text)) {
+      throw new Error(`releaseRollback evidence must mention ${phrase}`)
+    }
+  }
+}
+
+function assertReportFieldSet(manifest, report, itemId) {
+  for (const field of manifest.requiredReportFields) {
+    if (!(field in report)) throw new Error(`${itemId}.report.${field} is required`)
+  }
+}
+
+function assertEvidenceCommands(matrix, item, report) {
+  if (!Array.isArray(report.evidenceCommands) || report.evidenceCommands.length === 0) {
+    throw new Error(`${item.id}.report.evidenceCommands must list executed evidence commands`)
+  }
+  for (const command of report.evidenceCommands) {
+    if (typeof command !== 'string' || command.trim().length === 0) {
+      throw new Error(`${item.id}.report.evidenceCommands must contain non-empty strings`)
+    }
+  }
+  const requiredCommands = matrix.privateBetaEvidenceItems?.items?.[item.id]?.requiredCommands ?? []
+  for (const command of requiredCommands) {
+    if (!report.evidenceCommands.includes(command)) {
+      throw new Error(`${item.id}.report.evidenceCommands must include ${command}`)
+    }
+  }
+  if (!report.evidenceCommands.includes(item.command)) {
+    throw new Error(`${item.id}.report.evidenceCommands must include primary command ${item.command}`)
+  }
+}
+
+function validateHostedManifest(args, config) {
+  if (!args.manifest) {
+    throw new Error(`${args.tier} promotion requires --manifest or OPEN_COWORK_PROMOTION_EVIDENCE_MANIFEST`)
+  }
+  assertFile(args.manifest)
+  if (resolve(args.manifest) === resolve(publicTemplatePath)) {
+    throw new Error(`${args.tier} promotion must not use the committed public launch evidence template`)
+  }
+
+  const { manifest, matrix } = validateLaunchEvidenceManifest({
+    manifest: args.manifest,
+    requirePrivatePass: true,
+    expectedTargetTier: config.evidenceTargetTier,
+  })
+  if (manifest.scope === 'public-template-only') {
+    throw new Error(`${args.tier} promotion must use a private operations evidence record, not a public template`)
+  }
+
+  let commitSha = null
+  let cloudDigest = null
+  let gatewayDigest = null
+  for (const item of manifest.requiredEvidence) {
+    if (!requiredLaunchEvidenceIds.includes(item.id)) {
+      throw new Error(`${args.manifest} has unexpected promotion evidence item ${item.id}`)
+    }
+    const report = item.report
+    if (!report || typeof report !== 'object' || Array.isArray(report)) {
+      throw new Error(`${item.id}.report must attach strict environment evidence metadata`)
+    }
+    assertReportFieldSet(manifest, report, item.id)
+    assertNoPrivateValues(report, `${item.id}.report`)
+    if (report.command !== item.command) throw new Error(`${item.id}.report.command must match ${item.command}`)
+    assertEvidenceCommands(matrix, item, report)
+    assertSha(report.commitSha, `${item.id}.report.commitSha`)
+    assertDigest(report.imageDigests?.cloud, `${item.id}.report.imageDigests.cloud`)
+    assertDigest(report.imageDigests?.gateway, `${item.id}.report.imageDigests.gateway`)
+    assertEnvironmentProfile(report.sanitizedEnvironmentProfile, config, item.id)
+    assertIsoTimestamp(report.startedAt, `${item.id}.report.startedAt`)
+    assertIsoTimestamp(report.finishedAt, `${item.id}.report.finishedAt`)
+    if (Date.parse(report.finishedAt) < Date.parse(report.startedAt)) {
+      throw new Error(`${item.id}.report.finishedAt must be after startedAt`)
+    }
+    if (typeof report.durationMs !== 'number' || !Number.isFinite(report.durationMs) || report.durationMs <= 0) {
+      throw new Error(`${item.id}.report.durationMs must be a positive number`)
+    }
+    assertPassStatus(report.status, `${item.id}.report.status`)
+    assertNoDryRunEvidence(item, report)
+    assertStrictCommandEvidence(item, report)
+    assertRollbackEvidence(item, report)
+
+    commitSha ??= report.commitSha
+    cloudDigest ??= report.imageDigests.cloud
+    gatewayDigest ??= report.imageDigests.gateway
+    if (report.commitSha !== commitSha) throw new Error(`${item.id}.report.commitSha must match all promotion evidence`)
+    if (report.imageDigests.cloud !== cloudDigest) {
+      throw new Error(`${item.id}.report.imageDigests.cloud must match all promotion evidence`)
+    }
+    if (report.imageDigests.gateway !== gatewayDigest) {
+      throw new Error(`${item.id}.report.imageDigests.gateway must match all promotion evidence`)
+    }
+  }
+}
+
+function validateLocalTier(matrix) {
+  if (matrix.acceptedPublicTier !== 'local-self-host-beta') {
+    throw new Error(`${matrixPath} must keep acceptedPublicTier local-self-host-beta for the public release gate`)
+  }
+  for (const [tier, record] of Object.entries(matrix.tiers ?? {})) {
+    if (tier === 'local-self-host-beta') {
+      if (record.claimStatus !== 'accepted-public') throw new Error(`${tier} must remain accepted-public`)
+    } else if (record.claimStatus === 'accepted-public') {
+      throw new Error(`${tier} must not be accepted-public without hosted promotion evidence`)
+    }
+  }
+}
+
+export function validateReleasePromotion(options = {}) {
+  assertFile(matrixPath)
+  const args = {
+    ...parseArgs([]),
+    ...options,
+  }
+  const config = tierConfigs[args.tier]
+  if (!config) throw new Error(`Unknown promotion tier ${args.tier}`)
+  const matrix = readJson(matrixPath)
+  validateLocalTier(matrix)
+  if (!config.hosted) return { tier: args.tier, hosted: false }
+
+  const matrixTier = matrix.tiers?.[config.matrixTier]
+  if (!matrixTier) throw new Error(`${matrixPath} is missing ${config.matrixTier}`)
+  if (matrixTier.claimStatus === 'not-claimed') {
+    throw new Error(`${args.tier} is not claimable until ${matrixPath} records explicit private-ops promotion requirements`)
+  }
+  if (matrixTier.claimStatus !== 'requires-private-ops-evidence') {
+    throw new Error(`${args.tier} must require private operations evidence before promotion`)
+  }
+  validateHostedManifest(args, config)
+  return { tier: args.tier, hosted: true }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  validateReleasePromotion(args)
+  process.stdout.write(`[release-promotion-validate] ${args.tier} promotion gate validated\n`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+}

--- a/tests/launch-readiness.test.ts
+++ b/tests/launch-readiness.test.ts
@@ -286,6 +286,7 @@ test('launch evidence matrix states the current accepted tier and required gates
     'billingEntitlementGating',
     'supportIncidentOwnershipEscalation',
     'costSloNotes',
+    'releaseRollback',
   ]) {
     assert.equal(matrix.privateBetaEvidenceItems.items[item].requiredForPrivateBeta, true, item)
     assert.ok(matrix.privateBetaEvidenceItems.items[item].publicArtifacts.length > 0, item)
@@ -304,6 +305,7 @@ test('launch evidence manifest validator accepts template and completed private 
     const manifest = readJsonFile('deploy/private-beta/launch-evidence-record.template.json')
     assert.deepEqual(manifest.requiredReportFields, [
       'command',
+      'evidenceCommands',
       'commitSha',
       'imageDigests',
       'sanitizedEnvironmentProfile',

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -121,6 +121,7 @@ test('root deployment scripts expose provider smoke gates', () => {
   assert.equal(requireScript('deploy:soak'), 'node scripts/launch-readiness.mjs --mode soak')
   assert.equal(requireScript('deploy:launch:validate'), 'node scripts/validate-launch-readiness.mjs')
   assert.equal(requireScript('deploy:launch:evidence:validate'), 'node scripts/validate-launch-evidence-manifest.mjs')
+  assert.equal(requireScript('deploy:promotion:validate'), 'node scripts/validate-release-promotion.mjs')
   assert.equal(requireScript('deploy:private-beta:validate'), 'node scripts/validate-private-beta-package.mjs')
   assert.equal(requireScript('ops:validate'), 'node scripts/validate-ops-readiness.mjs && node scripts/validate-release-gates.mjs')
   assert.equal(requireScript('release:gates:validate'), 'node scripts/validate-release-gates.mjs')
@@ -197,6 +198,7 @@ test('ci and release workflows use canonical release gate scripts', () => {
     'pnpm deploy:validate -- --require-tools',
     'pnpm deploy:launch:validate',
     'pnpm deploy:launch:evidence:validate',
+    'pnpm deploy:promotion:validate -- --tier local-self-host-beta',
     'pnpm deploy:private-beta:validate',
     'pnpm deploy:standalone-gateway:validate',
     'pnpm ops:validate',
@@ -219,6 +221,7 @@ test('ci and release workflows use canonical release gate scripts', () => {
     'pnpm deploy:validate -- --require-tools',
     'pnpm deploy:launch:validate',
     'pnpm deploy:launch:evidence:validate',
+    'pnpm deploy:promotion:validate -- --tier "${OPEN_COWORK_RELEASE_CLAIM_TIER}"',
     'pnpm deploy:private-beta:validate',
     'pnpm deploy:standalone-gateway:validate',
     'pnpm ops:validate',

--- a/tests/private-beta-package.test.ts
+++ b/tests/private-beta-package.test.ts
@@ -121,6 +121,11 @@ test('managed BYOK readiness contract encodes public-private and support boundar
   assert.ok(contract.supportBundleContract.forbiddenFields.includes('Desktop, Gateway, API, cookie, internal, or operator tokens'))
   assert.ok(contract.launchPackageContract.requiredPublicArtifacts.includes('docs/runbooks/managed-byok-saas-boundary.md'))
   assert.ok(contract.launchPackageContract.requiredValidationCommands.includes('pnpm deploy:private-beta:validate'))
+  assert.ok(
+    contract.launchPackageContract.requiredValidationCommands.includes(
+      'pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>',
+    ),
+  )
 })
 
 test('private beta launch profile template captures launch decisions and evidence gates', () => {
@@ -167,6 +172,7 @@ test('private beta launch profile template captures launch decisions and evidenc
     'billingEntitlementGating',
     'supportIncidentOwnershipEscalation',
     'costSloNotes',
+    'releaseRollback',
   ]) {
     assert.equal(template.profile.requiredEvidence[evidence], true)
   }
@@ -174,6 +180,7 @@ test('private beta launch profile template captures launch decisions and evidenc
     'pnpm deploy:private-beta:validate',
     'pnpm deploy:launch:validate',
     'pnpm deploy:launch:evidence:validate',
+    'pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>',
     'pnpm ops:validate',
     'pnpm deploy:continuation:smoke',
     'pnpm deploy:load:strict',
@@ -208,6 +215,7 @@ test('private beta launch evidence record and public go/no-go summary remain con
     'billingEntitlementGating',
     'supportIncidentOwnershipEscalation',
     'costSloNotes',
+    'releaseRollback',
   ]) {
     const evidence = record.requiredEvidence.find((entry: { id: string }) => entry.id === item)
     assert.ok(evidence, item)
@@ -221,6 +229,8 @@ test('private beta launch evidence record and public go/no-go summary remain con
   assert.match(publicSummary, /pending-private-evidence/)
   assert.match(publicSummary, /deploy\/private-beta\/launch-evidence-record\.template\.json/)
   assert.match(publicSummary, /pnpm deploy:launch:evidence:validate -- --manifest <private-record> --require-private-pass/)
+  assert.match(publicSummary, /pnpm deploy:promotion:validate -- --tier private-hosted-beta --manifest <private-record>/)
+  assert.match(publicSummary, /releaseRollback/)
 })
 
 test('private beta onboarding and go/no-go templates force complete evidence records', () => {
@@ -326,6 +336,7 @@ test('private beta validator runs from the package script', () => {
   const packageJson = readJson('package.json')
   assert.equal(packageJson.scripts['deploy:private-beta:validate'], 'node scripts/validate-private-beta-package.mjs')
   assert.equal(packageJson.scripts['deploy:launch:evidence:validate'], 'node scripts/validate-launch-evidence-manifest.mjs')
+  assert.equal(packageJson.scripts['deploy:promotion:validate'], 'node scripts/validate-release-promotion.mjs')
   assert.equal(packageJson.scripts['deploy:failover:drill'], 'node scripts/launch-failover-drill.mjs')
   assert.equal(packageJson.scripts['deploy:failover:drill:dry-run'], 'node scripts/launch-failover-drill.mjs --dry-run')
   const output = execFileSync(process.execPath, ['scripts/validate-private-beta-package.mjs'], {

--- a/tests/release-promotion-gates.test.ts
+++ b/tests/release-promotion-gates.test.ts
@@ -1,0 +1,199 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const commitSha = 'abcdef1234567890abcdef1234567890abcdef12'
+const cloudDigest = `sha256:${'1'.repeat(64)}`
+const gatewayDigest = `sha256:${'2'.repeat(64)}`
+
+function readJsonFile(path: string) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function completedPromotionManifest() {
+  const manifest = readJsonFile('deploy/private-beta/launch-evidence-record.template.json')
+  const matrix = readJsonFile('deploy/load/launch-evidence-matrix.json')
+  manifest.scope = 'private-ops-record'
+  for (const item of manifest.requiredEvidence) {
+    item.status = 'private-pass'
+    item.privateEvidenceRef = `private://evidence/${item.id}`
+    item.publicRedactedSummary = item.id === 'releaseRollback'
+      ? 'Rollback evidence confirms revoke, drain, and communication owners without exposing private details.'
+      : `Redacted private evidence summary for ${item.id}.`
+    item.checksum = `sha256:${'a'.repeat(64)}`
+    item.owner = 'private-ops-owner'
+    item.report = {
+      command: item.command,
+      evidenceCommands: [
+        ...new Set([
+          item.command,
+          ...(matrix.privateBetaEvidenceItems.items[item.id]?.requiredCommands ?? []),
+        ]),
+      ],
+      commitSha,
+      imageDigests: {
+        cloud: cloudDigest,
+        gateway: gatewayDigest,
+      },
+      sanitizedEnvironmentProfile: {
+        profileName: 'private-beta',
+        targetTier: 'private-beta',
+        environmentKind: 'production-like',
+        cloudTokenProvided: true,
+        gatewayAdminTokenProvided: true,
+      },
+      startedAt: '2026-06-02T00:00:00.000Z',
+      finishedAt: '2026-06-02T00:05:00.000Z',
+      durationMs: 300_000,
+      status: 'go',
+      dryRun: false,
+    }
+    if (item.id === 'releaseRollback') {
+      item.report.rollback = {
+        revoke: 'redacted artifact revoke plan',
+        drain: 'redacted worker drain plan',
+        communication: 'redacted customer communication owner',
+      }
+    }
+  }
+  return manifest
+}
+
+async function writeCompletedManifest(outputDir: string) {
+  const path = join(outputDir, 'completed-promotion-evidence.json')
+  writeFileSync(path, `${JSON.stringify(completedPromotionManifest(), null, 2)}\n`)
+  return path
+}
+
+test('release promotion validator accepts the local self-host public tier', async () => {
+  const { stdout } = await execFileAsync(process.execPath, [
+    'scripts/validate-release-promotion.mjs',
+    '--tier',
+    'local-self-host-beta',
+  ], { encoding: 'utf8' })
+  assert.match(stdout, /local-self-host-beta promotion gate validated/)
+})
+
+test('release promotion validator rejects hosted promotion without private evidence', async () => {
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      'scripts/validate-release-promotion.mjs',
+      '--tier',
+      'private-hosted-beta',
+      '--manifest',
+      'deploy/private-beta/launch-evidence-record.template.json',
+    ], { encoding: 'utf8' }),
+    /must not use the committed public launch evidence template/,
+  )
+})
+
+test('release promotion validator accepts completed private hosted evidence', async () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'open-cowork-release-promotion-'))
+  try {
+    const manifestPath = await writeCompletedManifest(outputDir)
+    const { stdout } = await execFileAsync(process.execPath, [
+      'scripts/validate-release-promotion.mjs',
+      '--tier',
+      'private-hosted-beta',
+      '--manifest',
+      manifestPath,
+    ], { encoding: 'utf8' })
+    assert.match(stdout, /private-hosted-beta promotion gate validated/)
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('release promotion validator fails closed for unclaimed hosted tiers', async () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'open-cowork-release-promotion-'))
+  try {
+    const manifestPath = await writeCompletedManifest(outputDir)
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        'scripts/validate-release-promotion.mjs',
+        '--tier',
+        'public-beta',
+        '--manifest',
+        manifestPath,
+      ], { encoding: 'utf8' }),
+      /public-beta is not claimable/,
+    )
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('release promotion validator rejects mismatched environment profile tiers', async () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'open-cowork-release-promotion-'))
+  try {
+    const manifest = completedPromotionManifest()
+    manifest.requiredEvidence[0].report.sanitizedEnvironmentProfile.targetTier = 'public-beta'
+    const manifestPath = join(outputDir, 'mismatched-promotion-evidence.json')
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        'scripts/validate-release-promotion.mjs',
+        '--tier',
+        'private-hosted-beta',
+        '--manifest',
+        manifestPath,
+      ], { encoding: 'utf8' }),
+      /targetTier must be private-beta/,
+    )
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('release promotion validator rejects private-looking sanitized profile values', async () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'open-cowork-release-promotion-'))
+  try {
+    const manifest = completedPromotionManifest()
+    manifest.requiredEvidence[0].report.sanitizedEnvironmentProfile.redactedArtifact = [
+      'ghp',
+      'privatevalue123456789012345',
+    ].join('_')
+    const manifestPath = join(outputDir, 'unsafe-promotion-evidence.json')
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        'scripts/validate-release-promotion.mjs',
+        '--tier',
+        'private-hosted-beta',
+        '--manifest',
+        manifestPath,
+      ], { encoding: 'utf8' }),
+      /private-looking value/,
+    )
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('release promotion validator requires all matrix evidence commands', async () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'open-cowork-release-promotion-'))
+  try {
+    const manifest = completedPromotionManifest()
+    const item = manifest.requiredEvidence.find((entry: { id: string }) => entry.id === 'gatewayDeliveryReplayDeadLetter')
+    item.report.evidenceCommands = [item.command]
+    const manifestPath = join(outputDir, 'partial-command-promotion-evidence.json')
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        'scripts/validate-release-promotion.mjs',
+        '--tier',
+        'private-hosted-beta',
+        '--manifest',
+        manifestPath,
+      ], { encoding: 'utf8' }),
+      /evidenceCommands must include pnpm deploy:gateway:smoke/,
+    )
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add a tier-aware release promotion validator for local/self-host and hosted launch claims
- require private hosted promotion evidence to include private-pass records, sanitized report metadata, matching profile/tier, image digests, commit SHA, rollback proof, and matrix command coverage
- wire the local promotion contract into CI/release preflight and document hosted manifest secret wiring

## Validation
- node scripts/validate-launch-evidence-manifest.mjs
- node scripts/validate-release-promotion.mjs --tier local-self-host-beta
- node scripts/validate-launch-readiness.mjs
- node scripts/validate-private-beta-package.mjs
- node scripts/validate-release-gates.mjs
- node scripts/run-node-tests.mjs tests/release-promotion-gates.test.ts tests/launch-readiness.test.ts tests/private-beta-package.test.ts tests/package-scripts.test.ts tests/release-gates.test.ts
- node scripts/lint.mjs
- .venv-docs/bin/mkdocs build --strict
- git diff --check
- node scripts/run-node-tests.mjs

Subagent re-review found no issues after fixes.
