### PR TITLE
Harden release finalization gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -646,24 +646,10 @@ jobs:
           sbom-path: dist-oci/open-cowork-gateway.image.sbom.cdx.json
           push-to-registry: true
 
-      - name: Publish final OCI release tags
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          docker buildx imagetools create --prefer-index=false \
-            -t "${{ steps.cloud-meta.outputs.image }}:${GITHUB_REF_NAME}" \
-            -t "${{ steps.cloud-meta.outputs.image }}:${version}" \
-            "${{ steps.cloud-meta.outputs.digest_ref }}"
-          docker buildx imagetools create --prefer-index=false \
-            -t "${{ steps.gateway-meta.outputs.image }}:${GITHUB_REF_NAME}" \
-            -t "${{ steps.gateway-meta.outputs.image }}:${version}" \
-            "${{ steps.gateway-meta.outputs.digest_ref }}"
-
       - name: Verify OCI supply-chain evidence
         run: |
-          cloud_tag_digest="$(docker buildx imagetools inspect "${{ steps.cloud-meta.outputs.image }}:${GITHUB_REF_NAME}" --format '{{.Manifest.Digest}}')"
-          gateway_tag_digest="$(docker buildx imagetools inspect "${{ steps.gateway-meta.outputs.image }}:${GITHUB_REF_NAME}" --format '{{.Manifest.Digest}}')"
-          test "$cloud_tag_digest" = "${{ steps.cloud-meta.outputs.digest }}"
-          test "$gateway_tag_digest" = "${{ steps.gateway-meta.outputs.digest }}"
+          docker buildx imagetools inspect "${{ steps.cloud-meta.outputs.digest_ref }}" > /dev/null
+          docker buildx imagetools inspect "${{ steps.gateway-meta.outputs.digest_ref }}" > /dev/null
           jq empty dist-oci/open-cowork-cloud.image.json
           jq empty dist-oci/open-cowork-gateway.image.json
           jq empty dist-oci/open-cowork-cloud.image.sbom.cdx.json
@@ -694,6 +680,7 @@ jobs:
       name: release-publish
     permissions:
       contents: write
+      packages: write
       attestations: write
       id-token: write
     steps:
@@ -850,6 +837,35 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist-artifacts/release-macos/latest-mac.yml
+
+      - name: Log in to GHCR for final OCI tag promotion
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Publish final OCI release tags
+        run: |
+          for component in open-cowork-cloud open-cowork-gateway; do
+            image_json="dist-artifacts/release-oci-supply-chain/${component}.image.json"
+            image="$(jq -er '.image' "$image_json")"
+            tag="$(jq -er '.tag' "$image_json")"
+            version_tag="$(jq -er '.versionTag' "$image_json")"
+            digest="$(jq -er '.digest' "$image_json")"
+            digest_ref="$(jq -er '.digestRef' "$image_json")"
+            test -n "$image"
+            test -n "$tag"
+            test -n "$version_tag"
+            test -n "$digest"
+            test -n "$digest_ref"
+            docker buildx imagetools create --prefer-index=false \
+              -t "$tag" \
+              -t "$version_tag" \
+              "$digest_ref"
+            tag_digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
+            version_tag_digest="$(docker buildx imagetools inspect "$version_tag" --format '{{.Manifest.Digest}}')"
+            test "$tag_digest" = "$digest"
+            test "$version_tag_digest" = "$digest"
+          done
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/benchmarks/perf-baseline.darwin-arm64-node25.json
+++ b/benchmarks/perf-baseline.darwin-arm64-node25.json
@@ -77,6 +77,15 @@
       "p95Ms": 0.54
     },
     {
+      "name": "catalog.relationship.downstreamCatalog",
+      "iterations": 30,
+      "minMs": 0.08,
+      "maxMs": 0.4,
+      "avgMs": 0.11,
+      "p50Ms": 0.1,
+      "p95Ms": 0.2
+    },
+    {
       "name": "agents.preview.downstreamCatalog",
       "iterations": 30,
       "minMs": 0,

--- a/benchmarks/perf-baseline.json
+++ b/benchmarks/perf-baseline.json
@@ -77,6 +77,15 @@
       "p95Ms": 0.81
     },
     {
+      "name": "catalog.relationship.downstreamCatalog",
+      "iterations": 30,
+      "minMs": 0.08,
+      "maxMs": 0.4,
+      "avgMs": 0.11,
+      "p50Ms": 0.1,
+      "p95Ms": 0.2
+    },
+    {
       "name": "agents.preview.downstreamCatalog",
       "iterations": 30,
       "minMs": 0,

--- a/benchmarks/perf-baseline.linux-x64-node22.json
+++ b/benchmarks/perf-baseline.linux-x64-node22.json
@@ -77,6 +77,15 @@
       "p95Ms": 2.43
     },
     {
+      "name": "catalog.relationship.downstreamCatalog",
+      "iterations": 30,
+      "minMs": 0.45,
+      "maxMs": 1.4,
+      "avgMs": 0.6,
+      "p50Ms": 0.58,
+      "p95Ms": 0.9
+    },
+    {
       "name": "agents.preview.downstreamCatalog",
       "iterations": 30,
       "minMs": 0,

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -92,6 +92,15 @@ The remaining work is concentrated in two areas:
   `x64` `.AppImage` and `.deb`, plus signed-only `latest-mac.yml` feed
   metadata. Fixture tests reject missing formats, missing architectures, and
   unexpected installer artifacts.
+- OCI images now remain on release-candidate tags until the protected final
+  publish job has downloaded and validated desktop artifacts, OCI evidence,
+  SBOMs, checksums, and attestations. Final `v*` and unprefixed version tags
+  are promoted immediately before GitHub Release creation, and both tags are
+  verified back to the signed/scanned digest.
+- Performance regression checks now require benchmark-name parity in both
+  directions. New benchmarks without checked-in baselines fail `perf:check`,
+  and the downstream catalog relationship benchmark is represented in every
+  committed baseline.
 
 ## High Priority
 
@@ -143,8 +152,6 @@ No open high-priority findings remain after the current audit remediations.
 
 - Webhook replay cache eviction is global, not source/org scoped. Add scoped
   caps plus a global cap and test cross-source eviction.
-- OCI release verification checks the `v*` image tags but should also verify
-  the unprefixed version tags it publishes.
 - Cloud compatibility facades remain near their documented budgets:
   `postgres-control-plane-store.ts`, `in-memory-control-plane-store.ts`, and
   `session-service.ts` should be decomposed further before adding major Cloud

--- a/scripts/perf/compare.ts
+++ b/scripts/perf/compare.ts
@@ -42,7 +42,10 @@ export function compareReports(current: BenchmarkReport, baseline: BenchmarkRepo
 
   for (const currentEntry of current.benchmarks) {
     const baselineEntry = baselineByName.get(currentEntry.name)
-    if (!baselineEntry) continue
+    if (!baselineEntry) {
+      failures.push(`${currentEntry.name} is present in the current report but missing from the baseline`)
+      continue
+    }
 
     const avgLimit = round(Math.max(
       baselineEntry.avgMs * avgMultiplier,

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -2024,6 +2024,8 @@ function validateReleaseSupplyChain() {
     'dist-artifacts/release-oci-supply-chain/*',
     'open-cowork-cloud.image.sbom.cdx.json',
     'open-cowork-gateway.image.scan.grype.json',
+    "jq -er '.versionTag'",
+    'version_tag_digest',
   ]) {
     assertIncludes('.github/workflows/release.yml', phrase)
   }
@@ -2031,8 +2033,13 @@ function validateReleaseSupplyChain() {
   const scanIndex = releaseWorkflow.indexOf('name: Scan cloud image vulnerabilities')
   const attestIndex = releaseWorkflow.indexOf('name: Attest cloud image provenance')
   const finalTagIndex = releaseWorkflow.indexOf('name: Publish final OCI release tags')
+  const publishJobIndex = releaseWorkflow.indexOf('\n  publish:')
+  const verifyReleaseArtifactsIndex = releaseWorkflow.indexOf('name: Verify OCI supply-chain release artifacts')
   if (scanIndex < 0 || attestIndex < 0 || finalTagIndex < 0 || finalTagIndex < attestIndex || finalTagIndex < scanIndex) {
     throw new Error('release workflow must publish final OCI tags only after image scan and attestation steps')
+  }
+  if (publishJobIndex < 0 || verifyReleaseArtifactsIndex < 0 || finalTagIndex < publishJobIndex || finalTagIndex < verifyReleaseArtifactsIndex) {
+    throw new Error('release workflow must publish final OCI tags from the final publish job after release artifact validation')
   }
   if (releaseWorkflow.includes('docker push "${image}:${GITHUB_REF_NAME}"')) {
     throw new Error('release workflow must not push final OCI release tags before supply-chain evidence succeeds')

--- a/scripts/validate-release-gates.mjs
+++ b/scripts/validate-release-gates.mjs
@@ -377,10 +377,36 @@ function assertReleaseWorkflowContract() {
     'Attest gateway image provenance',
     'Attest cloud image SBOM',
     'Attest gateway image SBOM',
-    'Publish final OCI release tags',
     'Verify OCI supply-chain evidence',
     'Upload OCI supply-chain artifacts',
   ])
+
+  assertOrder(releaseWorkflowPath, [
+    'Verify OCI supply-chain release artifacts',
+    'Generate CycloneDX SBOM',
+    'Validate SBOMs',
+    'Re-generate checksums with SBOMs included',
+    'Sign checksums',
+    'Attest build provenance',
+    'Log in to GHCR for final OCI tag promotion',
+    'Publish final OCI release tags',
+    'Publish GitHub Release',
+  ])
+
+  const releaseWorkflow = read(releaseWorkflowPath)
+  const publishOciIndex = releaseWorkflow.indexOf('\n  publish-oci-images:')
+  const publishJobIndex = releaseWorkflow.indexOf('\n  publish:')
+  const finalTagIndex = releaseWorkflow.indexOf('name: Publish final OCI release tags')
+  const githubReleaseIndex = releaseWorkflow.indexOf('name: Publish GitHub Release')
+  if (publishOciIndex < 0 || publishJobIndex < 0 || finalTagIndex < 0 || githubReleaseIndex < 0) {
+    throw new Error('release workflow must include publish-oci-images, publish, final OCI tag promotion, and GitHub Release jobs')
+  }
+  if (finalTagIndex < publishJobIndex || finalTagIndex < publishOciIndex) {
+    throw new Error('release workflow must keep final OCI tag promotion in the final publish job')
+  }
+  if (finalTagIndex > githubReleaseIndex) {
+    throw new Error('release workflow must publish final OCI tags before creating the GitHub Release')
+  }
 
   for (const evidence of [
     'open-cowork-cloud.image.json',
@@ -397,6 +423,8 @@ function assertReleaseWorkflowContract() {
     'dist-artifacts/SHA256SUMS.txt',
     'dist-artifacts/SHA256SUMS.txt.asc',
     'actions/attest-build-provenance',
+    "jq -er '.versionTag'",
+    'version_tag_digest',
   ]) {
     assertIncludes(releaseWorkflowPath, evidence)
   }

--- a/tests/cloud-deployment-artifacts.test.ts
+++ b/tests/cloud-deployment-artifacts.test.ts
@@ -1045,4 +1045,12 @@ test('release workflow publishes versioned cloud and gateway OCI images', () => 
   assert.match(workflow, /Publish final OCI release tags/)
   assert.match(workflow, /docker buildx imagetools create --prefer-index=false/)
   assert.match(workflow, /dist-artifacts\/release-oci-supply-chain\/\*/)
+
+  const publishJobIndex = workflow.indexOf('\n  publish:')
+  const finalTagIndex = workflow.indexOf('name: Publish final OCI release tags')
+  const releaseArtifactValidationIndex = workflow.indexOf('name: Verify OCI supply-chain release artifacts')
+  const githubReleaseIndex = workflow.indexOf('name: Publish GitHub Release')
+  assert.ok(finalTagIndex > publishJobIndex, 'final OCI tags must be promoted by the final publish job')
+  assert.ok(finalTagIndex > releaseArtifactValidationIndex, 'release artifact validation must precede final OCI tag promotion')
+  assert.ok(finalTagIndex < githubReleaseIndex, 'final OCI tag promotion must precede GitHub Release creation')
 })

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -301,6 +301,8 @@ test('ci and release workflows use canonical release gate scripts', () => {
     'open-cowork-gateway.image.scan.grype.json',
     'open-cowork-gateway.image.cosign-verify.json',
     'release-oci-supply-chain',
+    "jq -er '.versionTag'",
+    'version_tag_digest',
   ]) {
     assert.match(releaseWorkflow, new RegExp(evidence.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `release workflow must preserve ${evidence}`)
   }
@@ -310,6 +312,15 @@ test('ci and release workflows use canonical release gate scripts', () => {
     / {2}release-policy:\n[\s\S]*? {4}steps:\n {6}- uses: actions\/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd[\s\S]*? {6}- name: Verify release artifacts\n[\s\S]*?node scripts\/verify-release-artifact-matrix\.mjs/,
     'release-policy must checkout source before running the repository release artifact matrix script',
   )
+
+  const publishJobIndex = releaseWorkflow.indexOf('\n  publish:')
+  const finalTagIndex = releaseWorkflow.indexOf('name: Publish final OCI release tags')
+  const releaseArtifactValidationIndex = releaseWorkflow.indexOf('name: Verify OCI supply-chain release artifacts')
+  const githubReleaseIndex = releaseWorkflow.indexOf('name: Publish GitHub Release')
+  assert.ok(publishJobIndex > 0, 'release workflow must define a final publish job')
+  assert.ok(finalTagIndex > publishJobIndex, 'release workflow must publish final OCI tags from the final publish job')
+  assert.ok(finalTagIndex > releaseArtifactValidationIndex, 'release workflow must validate release artifacts before final OCI tag promotion')
+  assert.ok(finalTagIndex < githubReleaseIndex, 'release workflow must promote final OCI tags before GitHub Release creation')
 
   assert.match(packagingDocs, /gh attestation verify "oci:\/\/\$\{digest_ref\}"/)
   assert.match(packagingDocs, /--predicate-type https:\/\/cyclonedx\.org\/bom/)

--- a/tests/perf-compare.test.ts
+++ b/tests/perf-compare.test.ts
@@ -61,3 +61,15 @@ test('compareReports fails when a baseline benchmark disappears from the current
     'engine.stream.mixed is present in the baseline but missing from the current report',
   ])
 })
+
+test('compareReports fails when a current benchmark is missing from the baseline', () => {
+  const baseline = {
+    ...makeReport(1.5, 0.94),
+    benchmarks: [],
+  }
+  const current = makeReport(1.5, 0.94)
+
+  assert.deepEqual(compareReports(current, baseline), [
+    'engine.stream.mixed is present in the current report but missing from the baseline',
+  ])
+})


### PR DESCRIPTION
## Summary
- keep OCI images on release-candidate tags until the protected final publish job validates release artifacts, SBOMs, checksums, attestations, and OCI evidence
- promote and verify both v* and unprefixed version GHCR tags immediately before GitHub Release creation
- make perf checks fail when a current benchmark is missing from checked-in baselines, and add the missing downstream catalog relationship baseline entries

## Verification
- node scripts/validate-release-gates.mjs
- node scripts/validate-deployment-configs.mjs
- node --no-warnings --experimental-strip-types --test tests/package-scripts.test.ts tests/cloud-deployment-artifacts.test.ts
- node --no-warnings --experimental-strip-types --test tests/release-gates.test.ts tests/release-artifact-matrix.test.ts
- node --no-warnings --experimental-strip-types --test tests/perf-compare.test.ts
- node --no-warnings --experimental-sqlite --experimental-strip-types scripts/perf-benchmark.ts --check
- node scripts/lint.mjs
- git diff --check

actionlint is not installed in this local shell; release workflow syntax is covered here by repository static validators.