### PR TITLE
Harden cloud auth role checks

### DIFF
--- a/apps/desktop/src/main/cloud/http-routes/access-policy.ts
+++ b/apps/desktop/src/main/cloud/http-routes/access-policy.ts
@@ -1,4 +1,9 @@
 import type { CloudPrincipal } from '../session-service.ts'
+import {
+  principalHasOrgAdminRole,
+  principalHasPrivilegedTokenScope,
+  principalHasTokenScope,
+} from '../principal-access.ts'
 
 export type GatewayRouteAccessInput = {
   resource: string | undefined
@@ -11,15 +16,15 @@ export type GatewayRouteAccessInput = {
 export function principalHasGatewayAccess(principal: CloudPrincipal) {
   if (principal.authSource === 'local' || principal.authSource === 'header') return true
   if (principal.authSource === 'api_token') {
-    return principal.tokenScopes?.includes('gateway') || principal.tokenScopes?.includes('admin') || false
+    return principalHasPrivilegedTokenScope(principal, 'gateway')
   }
-  return principal.role === 'owner' || principal.role === 'admin'
+  return principalHasOrgAdminRole(principal)
 }
 
 export function principalHasDesktopApiAccess(principal: CloudPrincipal) {
   if (principal.authSource === 'worker') return false
   if (principal.authSource === 'api_token') {
-    return principal.tokenScopes?.includes('desktop') || principal.tokenScopes?.includes('admin') || false
+    return principalHasTokenScope(principal, 'desktop')
   }
   return true
 }
@@ -37,7 +42,8 @@ export function routeAllowsGatewayOnlyToken(input: GatewayRouteAccessInput) {
 
 export function routeAllowsOperationalToken(principal: CloudPrincipal, input: GatewayRouteAccessInput) {
   if (principal.authSource !== 'api_token') return false
-  const operational = principal.tokenScopes?.includes('operator') || principal.tokenScopes?.includes('worker-internal')
+  const operational = (principalHasOrgAdminRole(principal) && Boolean(principal.tokenScopes?.includes('operator')))
+    || Boolean(principal.tokenScopes?.includes('worker-internal'))
   if (!operational || input.method !== 'GET') return false
   if (input.resource === 'metrics' || input.resource === 'diagnostics') return true
   if (input.resource === 'workers' && input.sessionId === 'heartbeats' && !input.action) return true

--- a/apps/desktop/src/main/cloud/oidc-auth.ts
+++ b/apps/desktop/src/main/cloud/oidc-auth.ts
@@ -235,9 +235,9 @@ function validateClaims(
   if (input.nonce && claims.nonce !== input.nonce) {
     unauthorized('Cloud authentication token nonce is invalid.')
   }
-  const email = normalizeEmail(claims.email || claims.preferred_username)
+  const email = normalizeEmail(claims.email)
   if (!email) unauthorized('Cloud authentication token email is missing.')
-  if (claims.email_verified === false) unauthorized('Cloud authentication token email is not verified.')
+  if (claims.email_verified !== true) unauthorized('Cloud authentication token email is not verified.')
   const allowedDomains = input.allowedEmailDomains.map((domain) => domain.toLowerCase())
   if (allowedDomains.length > 0 && !allowedDomains.includes(emailDomain(email))) {
     unauthorized('Cloud authentication token email domain is not allowed.')

--- a/apps/desktop/src/main/cloud/principal-access.ts
+++ b/apps/desktop/src/main/cloud/principal-access.ts
@@ -1,0 +1,14 @@
+import type { ApiTokenScope } from './control-plane-store.ts'
+import type { CloudPrincipal } from './session-service.ts'
+
+export function principalHasOrgAdminRole(principal: CloudPrincipal) {
+  return principal.role === 'owner' || principal.role === 'admin'
+}
+
+export function principalHasTokenScope(principal: CloudPrincipal, scope: ApiTokenScope) {
+  return principal.tokenScopes?.includes(scope) || principal.tokenScopes?.includes('admin') || false
+}
+
+export function principalHasPrivilegedTokenScope(principal: CloudPrincipal, scope: ApiTokenScope) {
+  return principalHasOrgAdminRole(principal) && principalHasTokenScope(principal, scope)
+}

--- a/apps/desktop/src/main/cloud/services/byok-service.ts
+++ b/apps/desktop/src/main/cloud/services/byok-service.ts
@@ -4,6 +4,7 @@ import type {
   ByokSecretStore,
 } from '../byok-secret-store.ts'
 import { CloudServiceError } from '../cloud-service-error.ts'
+import { principalHasOrgAdminRole, principalHasPrivilegedTokenScope } from '../principal-access.ts'
 import type { CloudPrincipal } from '../session-service.ts'
 
 export type ByokEntitlementVerdict = {
@@ -56,14 +57,10 @@ export type CloudByokServiceOptions = {
   }) => Promise<void> | void
 }
 
-function hasAdminTokenScope(principal: CloudPrincipal) {
-  return principal.tokenScopes?.includes('admin') || false
-}
-
 function principalCanManageByok(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasAdminTokenScope(principal)
-  return principal.role === 'owner' || principal.role === 'admin'
+  if (principal.authSource === 'api_token') return principalHasPrivilegedTokenScope(principal, 'admin')
+  return principalHasOrgAdminRole(principal)
 }
 
 function normalizeByokProviderIdForPolicy(value: string) {

--- a/apps/desktop/src/main/cloud/services/managed-worker-service.ts
+++ b/apps/desktop/src/main/cloud/services/managed-worker-service.ts
@@ -1,6 +1,5 @@
 import type {
   ControlPlaneStore,
-  ApiTokenScope,
   ManagedWorkerCredentialRecord,
   ManagedWorkerHeartbeatRecord,
   ManagedWorkerPoolMode,
@@ -10,6 +9,7 @@ import type {
   ManagedWorkerStatus,
 } from '../control-plane-store.ts'
 import { CloudServiceError } from '../cloud-service-error.ts'
+import { principalHasOrgAdminRole, principalHasPrivilegedTokenScope } from '../principal-access.ts'
 import type { CloudPrincipal } from '../session-service.ts'
 
 export type PublicManagedWorkerCredentialRecord = Omit<ManagedWorkerCredentialRecord, 'tokenHash'>
@@ -301,14 +301,13 @@ export class CloudManagedWorkerService {
   }
 }
 
-function hasTokenScope(principal: CloudPrincipal, scope: ApiTokenScope) {
-  return principal.tokenScopes?.includes(scope) || principal.tokenScopes?.includes('admin') || false
-}
-
 function principalCanManageWorkers(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin') || hasTokenScope(principal, 'operator')
-  return principal.role === 'owner' || principal.role === 'admin'
+  if (principal.authSource === 'api_token') {
+    return principalHasPrivilegedTokenScope(principal, 'admin')
+      || principalHasPrivilegedTokenScope(principal, 'operator')
+  }
+  return principalHasOrgAdminRole(principal)
 }
 
 function principalCanHeartbeatWorker(principal: CloudPrincipal, workerId: string) {

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -135,6 +135,10 @@ import {
   type UpdateManagedWorkerPoolRequest,
 } from './services/managed-worker-service.ts'
 import { CloudUsageGovernanceService } from './services/usage-governance-service.ts'
+import {
+  principalHasOrgAdminRole,
+  principalHasPrivilegedTokenScope,
+} from './principal-access.ts'
 import { computeNextWorkflowRunAt, validateWorkflowSchedule } from '../workflow/workflow-schedule.ts'
 import {
   verifyWorkflowWebhookAuth,
@@ -457,36 +461,32 @@ function channelRoleCanApprove(role: ChannelIdentityRole) {
   return role === 'owner' || role === 'admin' || role === 'member' || role === 'approver'
 }
 
-function hasTokenScope(principal: CloudPrincipal, scope: ApiTokenScope) {
-  return principal.tokenScopes?.includes(scope) || principal.tokenScopes?.includes('admin') || false
-}
-
 function stableCloudId(prefix: string, ...parts: string[]) {
   return `${prefix}_${createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32)}`
 }
 
 function principalCanManageChannels(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
-  return principal.role === 'owner' || principal.role === 'admin'
+  if (principal.authSource === 'api_token') return principalHasPrivilegedTokenScope(principal, 'admin')
+  return principalHasOrgAdminRole(principal)
 }
 
 function principalCanManageBilling(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
-  return principal.role === 'owner' || principal.role === 'admin'
+  if (principal.authSource === 'api_token') return principalHasPrivilegedTokenScope(principal, 'admin')
+  return principalHasOrgAdminRole(principal)
 }
 
 function principalCanManageApiTokens(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
-  return principal.role === 'owner' || principal.role === 'admin'
+  if (principal.authSource === 'api_token') return principalHasPrivilegedTokenScope(principal, 'admin')
+  return principalHasOrgAdminRole(principal)
 }
 
 function principalCanManageOrg(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'admin')
-  return principal.role === 'owner' || principal.role === 'admin'
+  if (principal.authSource === 'api_token') return principalHasPrivilegedTokenScope(principal, 'admin')
+  return principalHasOrgAdminRole(principal)
 }
 
 function principalEmailDomain(email: string | null | undefined) {
@@ -497,21 +497,26 @@ function principalEmailDomain(email: string | null | undefined) {
 
 function principalCanUseGatewayRoutes(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return hasTokenScope(principal, 'gateway')
-  return principal.role === 'owner' || principal.role === 'admin'
+  if (principal.authSource === 'api_token') return principalHasPrivilegedTokenScope(principal, 'gateway')
+  return principalHasOrgAdminRole(principal)
 }
 
 function principalCanViewOperations(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
   if (principal.authSource === 'api_token') {
-    return Boolean(principal.tokenScopes?.includes('operator') || principal.tokenScopes?.includes('worker-internal'))
+    return Boolean(
+      principal.tokenScopes?.includes('worker-internal')
+      || (principalHasOrgAdminRole(principal) && principal.tokenScopes?.includes('operator'))
+    )
   }
   return false
 }
 
 function principalCanViewDiagnostics(principal: CloudPrincipal) {
   if (principal.authSource === 'local') return true
-  if (principal.authSource === 'api_token') return Boolean(principal.tokenScopes?.includes('operator'))
+  if (principal.authSource === 'api_token') {
+    return principalHasOrgAdminRole(principal) && Boolean(principal.tokenScopes?.includes('operator'))
+  }
   return false
 }
 
@@ -795,28 +800,39 @@ export class CloudSessionService {
       accountId: account.accountId,
       email: account.email,
     })
+    let effectiveRole: ControlPlaneRole
     if (!membership) {
       if (requiresExistingMembership) {
         throw new CloudServiceError(403, 'Cloud membership is not active.')
       }
-      await this.store.upsertMembership({
+      const createdMembership = await this.store.upsertMembership({
         orgId: org.orgId,
         accountId: account.accountId,
         role: principal.role || user.role,
         status: 'active',
         actor: { actorType: 'system', actorId: 'principal.bootstrap' },
       })
+      effectiveRole = createdMembership.role
     } else if (membership.membership.status === 'invited' && principal.authSource === 'user' && signupMode === 'invite') {
-      await this.store.upsertMembership({
+      const activatedMembership = await this.store.upsertMembership({
         orgId: org.orgId,
         accountId: account.accountId,
         role: membership.membership.role,
         status: 'active',
         actor: { actorType: 'system', actorId: 'membership.invite.accepted' },
       })
+      effectiveRole = activatedMembership.role
     } else if (membership.membership.status !== 'active') {
       throw new CloudServiceError(403, 'Cloud membership is not active.')
+    } else {
+      effectiveRole = membership.membership.role
     }
+    principal.tenantId = org.tenantId
+    principal.orgId = org.orgId
+    principal.tenantName = org.name
+    principal.accountId = account.accountId
+    principal.email = account.email
+    principal.role = effectiveRole
   }
 
   async getWorkspaceOverview(principal: CloudPrincipal): Promise<CloudWorkspaceOverview> {

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -1743,6 +1743,68 @@ test('cloud HTTP server authenticates bearer API tokens and rejects revoked toke
   }
 })
 
+test('cloud HTTP server rejects user-bound admin API token privileges after role demotion', async () => {
+  const store = new InMemoryControlPlaneStore()
+  store.createTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
+  const org = store.ensureOrgForTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
+  const account = store.createAccount({
+    accountId: 'account-1',
+    idpSubject: 'subject-1',
+    email: 'member@example.test',
+  })
+  store.ensureUser({ tenantId: 'tenant-1', userId: account.accountId, email: account.email })
+  store.upsertMembership({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    role: 'admin',
+    status: 'active',
+  })
+  const issued = store.issueApiToken({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    name: 'Admin token',
+    scopes: ['admin'],
+  })
+
+  const runtime = new FakeRuntimeAdapter()
+  const policy = resolveCloudRuntimePolicy(DEFAULT_CONFIG)
+  const service = new CloudSessionService(store, runtime, policy)
+  const server = createCloudHttpServer({
+    service,
+    policy,
+    auth: createApiTokenCloudAuthResolver(store),
+    autoProcessCommands: true,
+  })
+  const baseUrl = await server.listen()
+  const headers = { authorization: `Bearer ${issued.plaintext}` }
+  try {
+    const beforeDemotion = await fetch(`${baseUrl}/api/admin/members`, { headers })
+    assert.equal(beforeDemotion.status, 200)
+
+    store.upsertMembership({
+      orgId: org.orgId,
+      accountId: account.accountId,
+      role: 'member',
+      status: 'active',
+    })
+
+    const afterDemotion = await fetch(`${baseUrl}/api/admin/members`, { headers })
+    assert.equal(afterDemotion.status, 403)
+
+    const issueAfterDemotion = await fetch(`${baseUrl}/api/api-tokens`, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'Blocked admin token', scopes: ['desktop'] }),
+    })
+    assert.equal(issueAfterDemotion.status, 403)
+  } finally {
+    await server.close()
+  }
+})
+
 test('cloud HTTP server keeps gateway-scoped tokens out of desktop API routes', async () => {
   const store = new InMemoryControlPlaneStore()
   store.createTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
@@ -3166,6 +3228,67 @@ test('cloud HTTP browser session cookies use secure flags and enforce CSRF on mu
     })
     assert.equal(logout.status, 200)
     assert.equal(setCookieHeaders(logout).every((cookie) => /Max-Age=0/.test(cookie)), true)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP browser session cookies refresh membership role before admin authorization', async () => {
+  const sessionCookies = createCloudSessionCookieManager({
+    secret: TEST_COOKIE_KEY,
+    now: () => new Date('2026-05-26T12:00:00.000Z'),
+  })
+  const fixture = createFixture({
+    sessionCookies,
+    auth: () => {
+      throw new CloudHttpError(401, 'Fallback auth should not be used for cookie requests.')
+    },
+  })
+  fixture.store.createTenant({ tenantId: 'tenant-1', name: 'Tenant 1' })
+  const org = fixture.store.ensureOrgForTenant({ tenantId: 'tenant-1', orgId: 'tenant-1', name: 'Tenant 1' })
+  const account = fixture.store.createAccount({
+    accountId: 'admin-1',
+    idpSubject: 'subject-admin-1',
+    email: 'admin@example.test',
+  })
+  fixture.store.ensureUser({
+    tenantId: 'tenant-1',
+    userId: account.accountId,
+    email: account.email,
+    role: 'admin',
+  })
+  fixture.store.upsertMembership({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    role: 'admin',
+    status: 'active',
+  })
+  const staleAdminCookie = sessionCookies.issue({
+    tenantId: 'tenant-1',
+    orgId: org.orgId,
+    tenantName: 'Tenant 1',
+    userId: account.accountId,
+    accountId: account.accountId,
+    email: account.email,
+    role: 'admin',
+    authSource: 'user',
+  })
+  const headers = { cookie: cookieHeader(staleAdminCookie.setCookieHeaders) }
+  const baseUrl = await fixture.server.listen()
+
+  try {
+    const beforeDemotion = await fetch(`${baseUrl}/api/admin/members`, { headers })
+    assert.equal(beforeDemotion.status, 200)
+
+    fixture.store.upsertMembership({
+      orgId: org.orgId,
+      accountId: account.accountId,
+      role: 'member',
+      status: 'active',
+    })
+
+    const afterDemotion = await fetch(`${baseUrl}/api/admin/members`, { headers })
+    assert.equal(afterDemotion.status, 403)
   } finally {
     await fixture.server.close()
   }

--- a/tests/cloud-oidc-auth.test.ts
+++ b/tests/cloud-oidc-auth.test.ts
@@ -159,6 +159,30 @@ test('cloud OIDC auth rejects missing, invalid-audience, and disallowed-domain t
   )
 })
 
+test('cloud OIDC auth requires a verified email claim for account linking', async () => {
+  const fixture = createJwtFixture()
+  const resolver = createOidcCloudAuthResolver(oidcConfig().cloud.auth, {
+    fetch: oidcFetch(fixture.jwk),
+    now: () => new Date('2026-05-26T12:00:00.000Z'),
+  })
+
+  await assert.rejects(
+    () => resolver(requestWithBearer(fixture.token({ email_verified: false }))),
+    /not verified/,
+  )
+  await assert.rejects(
+    () => resolver(requestWithBearer(fixture.token({ email_verified: undefined }))),
+    /not verified/,
+  )
+  await assert.rejects(
+    () => resolver(requestWithBearer(fixture.token({
+      email: undefined,
+      preferred_username: 'analyst@example.test',
+    }))),
+    /email is missing/,
+  )
+})
+
 test('cloud OIDC auth fails closed for tampered signatures and expired tokens', async () => {
   const fixture = createJwtFixture()
   const resolver = createOidcCloudAuthResolver(oidcConfig().cloud.auth, {


### PR DESCRIPTION
## Summary
- Refresh cloud principals from current membership before authorization so stale API tokens and browser cookies lose admin/operator/gateway privileges after demotion.
- Centralize privileged token checks across channel, billing, API-token, org, BYOK, managed-worker, gateway, and operational routes.
- Require OIDC identity tokens to carry a verified email claim and stop falling back to preferred_username for account linking.

## Verification
- node --no-warnings --experimental-strip-types --test tests/cloud-http-server.test.ts
- node --no-warnings --experimental-strip-types --test tests/cloud-oidc-auth.test.ts tests/cloud-http-server.test.ts
- node --no-warnings --experimental-strip-types --test tests/cloud-domain-services.test.ts tests/gateway-cloud-smoke.test.ts tests/desktop-cloud-sync-smoke.test.ts tests/cloud-continuation-e2e.test.ts
- node --no-warnings --experimental-strip-types --test tests/cloud-app.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-control-plane-store-contracts.test.ts
- node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json
- node_modules/.bin/eslint . --max-warnings 0
- node scripts/lint.mjs
- node scripts/check-preload-channels.mjs
- node scripts/check-shared-dist.mjs
- git diff --check