### PR TITLE
Ratchet coverage source inventory

### DIFF
--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -24,7 +24,7 @@ The remaining work is concentrated in two areas:
 ## Verified Baseline
 
 - GitHub code scanning: 0 open alerts on `master` at
-  `9de8383f3eb945d715a731ecea93398b5ab7509a`.
+  `a7120994ea3cf00e1f5339813a8fbb5e1e715ffe`.
 - Dependabot alerts: 0 open alerts at the same point-in-time check.
 - GitHub Actions checks on that `master` SHA were green for deploy, CodeQL,
   build, coverage, validate, docs, cloud-gates, macos-build, and linux-package.
@@ -101,6 +101,11 @@ The remaining work is concentrated in two areas:
   directions. New benchmarks without checked-in baselines fail `perf:check`,
   and the downstream catalog relationship benchmark is represented in every
   committed baseline.
+- Coverage summary now has source-inventory ratchets for Node, Shared Package,
+  and Workspace Node coverage inputs. CI still enforces the existing line,
+  function, and branch thresholds, and now also fails if LCOV stops
+  representing at least 90% of the configured production/shipped source
+  inventory for those suites.
 
 ## High Priority
 
@@ -115,8 +120,9 @@ No open high-priority findings remain after the current audit remediations.
   revocation, runtime status, and worker heartbeat visibility.
 - Workspace coverage gates are too broad and low for deployable workspace code:
   `lines: 40`, `functions: 28`, and `branches: 68`. Split thresholds by
-  package/service, remove generated dist noise from source coverage, and fail
-  when workspace packages are not represented in coverage inputs.
+  package/service and remove generated dist noise from source coverage once the
+  deployable workspaces have enough direct source-level coverage to support
+  that stricter ratchet.
 - Recovery and failover drills are currently evidence wrappers for public CI.
   Add an executable local compose recovery drill and require private
   environment drill evidence for hosted promotion.
@@ -176,6 +182,8 @@ node scripts/lint.mjs
 node scripts/check-preload-channels.mjs
 node scripts/check-shared-dist.mjs
 node scripts/run-node-tests.mjs tests/package-scripts.test.ts
+node --no-warnings --experimental-strip-types --test tests/coverage-summary.test.ts tests/package-scripts.test.ts
+node scripts/coverage-summary.mjs --check --no-write
 ./apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
 ./apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.preload.json --noEmit
 git diff --check

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,10 +1,57 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 
-export const NODE_COVERAGE_INPUT = { name: 'Node', path: 'coverage/node/lcov.info', thresholds: { lines: 80, functions: 74, branches: 68 } }
+const NODE_SOURCE_INVENTORY = {
+  minimumPercent: 90,
+  roots: [
+    { path: 'apps/desktop/src/main', extensions: ['.ts', '.tsx'] },
+    { path: 'apps/desktop/src/lib', extensions: ['.ts', '.tsx'] },
+    { path: 'packages/shared/dist', extensions: ['.js', '.mjs'] },
+  ],
+}
+
+const SHARED_SOURCE_INVENTORY = {
+  minimumPercent: 90,
+  roots: [
+    { path: 'packages/shared/dist', extensions: ['.js', '.mjs'] },
+  ],
+}
+
+const WORKSPACE_SOURCE_INVENTORY = {
+  minimumPercent: 90,
+  roots: [
+    { path: 'apps/gateway/dist', extensions: ['.js', '.mjs'] },
+    { path: 'apps/standalone-gateway/dist', extensions: ['.js', '.mjs'] },
+    { path: 'apps/website/src', extensions: ['.ts', '.tsx'] },
+    { path: 'mcps/agents/dist', extensions: ['.js', '.mjs'] },
+    { path: 'mcps/charts/dist', extensions: ['.js', '.mjs'] },
+    { path: 'mcps/clock/dist', extensions: ['.js', '.mjs'] },
+    { path: 'mcps/skills/dist', extensions: ['.js', '.mjs'] },
+    { path: 'mcps/workflows/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-channel/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-cli/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-discord/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-email/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-signal/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-slack/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-telegram/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-webhook/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-provider-whatsapp/dist', extensions: ['.js', '.mjs'] },
+    { path: 'packages/gateway-testing/dist', extensions: ['.js', '.mjs'] },
+  ],
+}
+
+export const NODE_COVERAGE_INPUT = {
+  name: 'Node',
+  path: 'coverage/node/lcov.info',
+  sourceInventory: NODE_SOURCE_INVENTORY,
+  thresholds: { lines: 80, functions: 74, branches: 68 },
+}
 export const SHARED_COVERAGE_INPUT = {
   name: 'Shared Package',
   path: 'coverage/node/lcov.info',
   includePathPrefixes: ['packages/shared/'],
+  sourceInventory: SHARED_SOURCE_INVENTORY,
   thresholds: { lines: 90, functions: 90, branches: 75 },
 }
 export const WORKSPACE_NODE_COVERAGE_INPUT = {
@@ -30,6 +77,7 @@ export const WORKSPACE_NODE_COVERAGE_INPUT = {
     'packages/gateway-provider-whatsapp/dist/',
     'packages/gateway-testing/dist/',
   ],
+  sourceInventory: WORKSPACE_SOURCE_INVENTORY,
   thresholds: { lines: 40, functions: 28, branches: 68 },
 }
 export const RENDERER_COVERAGE_INPUT = { name: 'Renderer', path: 'coverage/renderer/lcov.info', thresholds: { lines: 65, functions: 62, branches: 58 } }
@@ -37,13 +85,17 @@ export const DEFAULT_INPUTS = [NODE_COVERAGE_INPUT, SHARED_COVERAGE_INPUT, WORKS
 
 function normalizeCoveragePath(path, includePathPrefixes = []) {
   const normalized = path.replace(/\\/g, '/')
+  const cwdPrefix = `${process.cwd().replace(/\\/g, '/')}/`
+  const repoRelative = normalized.startsWith(cwdPrefix)
+    ? normalized.slice(cwdPrefix.length)
+    : normalized
   for (const prefix of includePathPrefixes) {
     const normalizedPrefix = prefix.replace(/\\/g, '/').replace(/^\/+/, '')
-    if (normalized.startsWith(normalizedPrefix)) return normalized
-    const prefixIndex = normalized.indexOf(`/${normalizedPrefix}`)
-    if (prefixIndex >= 0) return normalized.slice(prefixIndex + 1)
+    if (repoRelative.startsWith(normalizedPrefix)) return repoRelative
+    const prefixIndex = repoRelative.indexOf(`/${normalizedPrefix}`)
+    if (prefixIndex >= 0) return repoRelative.slice(prefixIndex + 1)
   }
-  return normalized
+  return repoRelative
 }
 
 export function parseLcovInfo(content, options = {}) {
@@ -161,6 +213,77 @@ export function parseLcovInfo(content, options = {}) {
   return totals
 }
 
+export function parseLcovFilePaths(content, options = {}) {
+  const files = new Set()
+  const includePathPrefixes = options.includePathPrefixes || []
+
+  function shouldIncludeFile(path) {
+    return includePathPrefixes.length === 0 || includePathPrefixes.some((prefix) => path.startsWith(prefix))
+  }
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    if (!rawLine.startsWith('SF:')) continue
+    const sourcePath = normalizeCoveragePath(rawLine.slice(3), includePathPrefixes)
+    if (shouldIncludeFile(sourcePath)) files.add(sourcePath)
+  }
+  return files
+}
+
+function collectInventoryFiles(inventory, suiteName) {
+  const files = new Set()
+  for (const root of inventory.roots || []) {
+    const rootPath = root.path
+    const extensions = root.extensions || ['.ts', '.tsx', '.js', '.mjs']
+    let rootStats
+    try {
+      rootStats = statSync(rootPath)
+    } catch {
+      throw new Error(`${suiteName} coverage inventory root is missing: ${rootPath}`)
+    }
+    if (!rootStats.isDirectory()) {
+      throw new Error(`${suiteName} coverage inventory root is not a directory: ${rootPath}`)
+    }
+    collectInventoryDirectory(rootPath, extensions, files)
+  }
+  return files
+}
+
+function collectInventoryDirectory(directory, extensions, files) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name).replace(/\\/g, '/')
+    if (entry.isDirectory()) {
+      if (['node_modules', 'coverage', 'test', 'tests', '__tests__'].includes(entry.name)) continue
+      collectInventoryDirectory(path, extensions, files)
+      continue
+    }
+    if (!entry.isFile()) continue
+    if (!extensions.some((extension) => entry.name.endsWith(extension))) continue
+    if (entry.name.endsWith('.d.ts') || /\.(test|spec)\.[cm]?[jt]sx?$/.test(entry.name)) continue
+    files.add(path)
+  }
+}
+
+function summarizeInventory(input, coveredFiles) {
+  if (!input.sourceInventory) return null
+  const inventoryFiles = collectInventoryFiles(input.sourceInventory, input.name)
+  if (inventoryFiles.size === 0) {
+    throw new Error(`${input.name} coverage inventory matched no source files.`)
+  }
+  let covered = 0
+  for (const file of inventoryFiles) {
+    if (coveredFiles.has(file)) covered += 1
+  }
+  const inventoryPercent = percent(covered, inventoryFiles.size)
+  const minimumPercent = input.sourceInventory.minimumPercent
+  return {
+    covered,
+    total: inventoryFiles.size,
+    percent: inventoryPercent,
+    threshold: minimumPercent,
+    status: status(inventoryPercent, minimumPercent),
+  }
+}
+
 function percent(covered, total) {
   if (total === 0) return 100
   return (covered / total) * 100
@@ -176,7 +299,9 @@ function status(value, threshold) {
 
 export function summarizeCoverage(inputs = DEFAULT_INPUTS) {
   return inputs.map((input) => {
-    const totals = parseLcovInfo(readFileSync(input.path, 'utf8'), input)
+    const lcov = readFileSync(input.path, 'utf8')
+    const totals = parseLcovInfo(lcov, input)
+    const coveredFiles = parseLcovFilePaths(lcov, input)
     if (input.includePathPrefixes && input.includePathPrefixes.length > 0 && totals.files === 0) {
       throw new Error(`${input.name} coverage matched no files for prefixes: ${input.includePathPrefixes.join(', ')}`)
     }
@@ -187,6 +312,7 @@ export function summarizeCoverage(inputs = DEFAULT_INPUTS) {
       name: input.name,
       path: input.path,
       files: totals.files,
+      inventory: summarizeInventory(input, coveredFiles),
       metrics: {
         lines: { ...totals.lines, percent: lines, threshold: input.thresholds.lines, status: status(lines, input.thresholds.lines) },
         functions: { ...totals.functions, percent: functions, threshold: input.thresholds.functions, status: status(functions, input.thresholds.functions) },
@@ -217,6 +343,13 @@ export function renderCoverageMarkdown(summary) {
   }
 
   lines.push('', '_Coverage is reported from the CI lcov artifacts for this commit._')
+  const inventoriedSuites = summary.filter((suite) => suite.inventory)
+  if (inventoriedSuites.length > 0) {
+    lines.push('', 'Source inventory ratchets:')
+    for (const suite of inventoriedSuites) {
+      lines.push(`- ${suite.name}: ${suite.inventory.covered}/${suite.inventory.total} files represented (${formatPercent(suite.inventory.percent)} / ${formatPercent(suite.inventory.threshold)})`)
+    }
+  }
   return lines.join('\n')
 }
 
@@ -233,6 +366,9 @@ function failingMetrics(summary) {
       .map(([metricName, metric]) => {
         return `${suite.name} ${metricName}: ${formatPercent(metric.percent)} < ${formatPercent(metric.threshold)}`
       })
+      .concat(suite.inventory?.status === 'fail'
+        ? [`${suite.name} source inventory: ${formatPercent(suite.inventory.percent)} < ${formatPercent(suite.inventory.threshold)} (${suite.inventory.covered}/${suite.inventory.total} files represented)`]
+        : [])
   })
 }
 

--- a/tests/coverage-summary.test.ts
+++ b/tests/coverage-summary.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { DEFAULT_INPUTS, SHARED_COVERAGE_INPUT, WORKSPACE_NODE_COVERAGE_INPUT, parseLcovInfo, renderCoverageMarkdown, summarizeCoverage } from '../scripts/coverage-summary.mjs'
+import { DEFAULT_INPUTS, NODE_COVERAGE_INPUT, SHARED_COVERAGE_INPUT, WORKSPACE_NODE_COVERAGE_INPUT, parseLcovFilePaths, parseLcovInfo, renderCoverageMarkdown, summarizeCoverage } from '../scripts/coverage-summary.mjs'
 
 test('coverage summary parses lcov totals and renders a PR-safe table', () => {
   const totals = parseLcovInfo([
@@ -136,6 +136,75 @@ test('coverage summary normalizes absolute and platform-specific scoped paths', 
   })
 })
 
+test('coverage summary normalizes lcov source file paths for inventory checks', () => {
+  const paths = parseLcovFilePaths([
+    'TN:',
+    `SF:${join(process.cwd(), 'apps/desktop/src/main/runtime.ts')}`,
+    'DA:1,1',
+    'end_of_record',
+    'SF:/home/runner/work/open-cowork/open-cowork/packages/shared/src/index.ts',
+    'DA:1,1',
+    'end_of_record',
+    String.raw`SF:C:\a\open-cowork\packages\shared\src\providers.ts`,
+    'DA:1,1',
+    'end_of_record',
+  ].join('\n'), { includePathPrefixes: ['packages/shared/'] })
+
+  assert.deepEqual([...paths].sort(), [
+    'packages/shared/src/index.ts',
+    'packages/shared/src/providers.ts',
+  ])
+
+  assert.deepEqual([...parseLcovFilePaths([
+    'TN:',
+    `SF:${join(process.cwd(), 'apps/desktop/src/main/runtime.ts')}`,
+    'DA:1,1',
+    'end_of_record',
+  ].join('\n'))], ['apps/desktop/src/main/runtime.ts'])
+})
+
+test('coverage summary reports source inventory representation ratchets', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'open-cowork-coverage-inventory-'))
+  const src = join(dir, 'src')
+  const lcovPath = join(dir, 'lcov.info')
+  try {
+    mkdirSync(src, { recursive: true })
+    writeFileSync(join(src, 'covered.ts'), 'export const covered = true\n')
+    writeFileSync(join(src, 'missing.ts'), 'export const missing = true\n')
+    writeFileSync(join(src, 'covered.test.ts'), 'test("ignored", () => {})\n')
+    writeFileSync(join(src, 'types.d.ts'), 'export type Ignored = string\n')
+    writeFileSync(lcovPath, [
+      'TN:',
+      `SF:${join(src, 'covered.ts')}`,
+      'FN:1,covered',
+      'FNDA:1,covered',
+      'DA:1,1',
+      'end_of_record',
+    ].join('\n'))
+
+    const [summary] = summarizeCoverage([{
+      name: 'Inventory',
+      path: lcovPath,
+      sourceInventory: {
+        minimumPercent: 75,
+        roots: [{ path: src, extensions: ['.ts'] }],
+      },
+      thresholds: { lines: 1, functions: 1, branches: 1 },
+    }])
+
+    assert.deepEqual(summary.inventory, {
+      covered: 1,
+      total: 2,
+      percent: 50,
+      threshold: 75,
+      status: 'fail',
+    })
+    assert.match(renderCoverageMarkdown([summary]), /Inventory: 1\/2 files represented \(50\.0% \/ 75\.0%\)/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('coverage summary refuses scoped input with zero matched files', () => {
   const dir = mkdtempSync(join(tmpdir(), 'open-cowork-coverage-summary-'))
   const lcovPath = join(dir, 'lcov.info')
@@ -189,6 +258,20 @@ test('coverage summary reports the enforced renderer ratchet', () => {
   })
 })
 
+test('coverage summary reports the enforced node source inventory ratchet', () => {
+  assert.equal(NODE_COVERAGE_INPUT.sourceInventory.minimumPercent, 90)
+  for (const expectedRoot of [
+    'apps/desktop/src/main',
+    'apps/desktop/src/lib',
+    'packages/shared/dist',
+  ]) {
+    assert.ok(
+      NODE_COVERAGE_INPUT.sourceInventory.roots.some((root) => root.path === expectedRoot),
+      `node coverage inventory includes ${expectedRoot}`,
+    )
+  }
+})
+
 test('coverage summary reports the enforced shared-package ratchet', () => {
   assert.deepEqual(SHARED_COVERAGE_INPUT.thresholds, {
     lines: 90,
@@ -196,6 +279,8 @@ test('coverage summary reports the enforced shared-package ratchet', () => {
     branches: 75,
   })
   assert.deepEqual(SHARED_COVERAGE_INPUT.includePathPrefixes, ['packages/shared/'])
+  assert.equal(SHARED_COVERAGE_INPUT.sourceInventory.minimumPercent, 90)
+  assert.deepEqual(SHARED_COVERAGE_INPUT.sourceInventory.roots.map((root) => root.path), ['packages/shared/dist'])
 })
 
 test('coverage summary reports the enforced shipped workspace ratchet', () => {
@@ -205,6 +290,7 @@ test('coverage summary reports the enforced shipped workspace ratchet', () => {
     branches: 68,
   })
   assert.ok(DEFAULT_INPUTS.includes(WORKSPACE_NODE_COVERAGE_INPUT))
+  assert.equal(WORKSPACE_NODE_COVERAGE_INPUT.sourceInventory.minimumPercent, 90)
   for (const expectedPrefix of [
     'apps/gateway/dist/',
     'apps/standalone-gateway/dist/',


### PR DESCRIPTION
## Summary
- Add source-inventory ratchets to the coverage summary for Node, Shared Package, and Workspace Node suites.
- Keep existing line/function/branch thresholds stable while failing CI if LCOV silently stops representing configured production or shipped source areas.
- Record the coverage-inventory gap as fixed in the production readiness audit ledger.

## Verification
- node --no-warnings --experimental-strip-types --test tests/coverage-summary.test.ts tests/package-scripts.test.ts
- node scripts/coverage-summary.mjs --check --no-write
- node_modules/.bin/eslint scripts/coverage-summary.mjs tests/coverage-summary.test.ts --max-warnings 0
- node scripts/lint.mjs
- git diff --check