### PR TITLE
Mark workspace client packages private

### DIFF
--- a/docs/cloud-client.md
+++ b/docs/cloud-client.md
@@ -16,8 +16,8 @@ this package instead of importing Cloud control-plane internals.
 - The client talks to Open Cowork Cloud product APIs over HTTP and SSE.
 - It does not import Electron, Desktop main-process modules, control-plane
   stores, Postgres modules, or `@opencode-ai/sdk`.
-- It may depend on `@open-cowork/shared`, which is the public package for
-  shared Open Cowork product and wire types.
+- It may depend on `@open-cowork/shared`, which is the shared workspace/source
+  package for Open Cowork product and wire types.
 - OpenCode still owns execution. The client only creates sessions, sends
   product commands, reads projections, subscribes to events, and manages
   product surfaces such as workflows, artifacts, BYOK metadata, and channel
@@ -206,13 +206,14 @@ parsing strings.
 ## Release Checklist
 
 - Build shared first: `pnpm --filter @open-cowork/shared build`.
-- Build the SDK: `pnpm --filter @open-cowork/cloud-client build`.
+- Build the client package: `pnpm --filter @open-cowork/cloud-client build`.
 - Run transport and package-boundary tests.
-- Confirm package exports only the documented public entry points.
+- Confirm package exports only the documented entry points.
 - Update README and this page when auth, timeout, SSE, or error behavior
   changes.
 - Keep examples free of private deployment URLs, org ids, tokens, provider keys,
   and project-specific values.
-- Pre-1.0 typed breaks must be called out in release notes. Do not present the
-  package as a standalone published SDK until package publication, versioning,
-  and support ownership are explicit.
+- Pre-1.0 typed breaks must be called out in release notes. Do not add
+  `publishConfig`, mark the package publishable, or present it as a standalone
+  published SDK until package publication, versioning, provenance, and support
+  ownership are explicit.

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -115,6 +115,11 @@ The remaining work is concentrated in two areas:
   worker heartbeat visibility, Cloud/Gateway operator metrics, Desktop/Gateway
   mutation coverage with token revocation rejection, and Continuation rich
   projection with ephemeral-token cleanup.
+- The `@open-cowork/cloud-client` and `@open-cowork/shared` manifests now
+  match their documented workspace/source-package status: both are private,
+  expose no `publishConfig`, and the Cloud client boundary test prevents an
+  accidental npm-publishable state before standalone SDK publication,
+  provenance, and support ownership exist.
 
 ## High Priority
 
@@ -153,10 +158,6 @@ No open high-priority findings remain after the current audit remediations.
 - The vendored docs Mermaid bundle is version-drifted from the locked runtime
   dependency. Add deterministic regeneration/hash checking or build the bundle
   from the locked dependency.
-- Public package metadata for `@open-cowork/cloud-client` and
-  `@open-cowork/shared` conflicts with docs that describe them as workspace
-  packages. Mark them private until npm publishing exists, or add explicit
-  npm release, provenance, and support docs.
 
 ## Low Priority
 

--- a/packages/cloud-client/README.md
+++ b/packages/cloud-client/README.md
@@ -31,7 +31,8 @@ APIs.
 
 The package must not import Electron, Desktop main-process modules,
 control-plane stores, or `@opencode-ai/sdk`. Its only Open Cowork package
-dependency is the public `@open-cowork/shared` wire-type package.
+dependency is the shared workspace/source `@open-cowork/shared` wire-type
+package.
 
 Modules outside the entry points above are internal implementation details.
 First-party clients and downstream deployers should not import source files,
@@ -201,7 +202,8 @@ Before publishing or treating a repo release as a cloud-client contract update:
 - Run `pnpm --filter @open-cowork/shared build`.
 - Run `pnpm --filter @open-cowork/cloud-client build`.
 - Run the cloud transport and boundary tests.
-- Confirm `packages/cloud-client/package.json` exports only public entry points.
+- Confirm `packages/cloud-client/package.json` exports only documented entry
+  points.
 - Confirm README and `docs/cloud-client.md` document new auth, timeout, SSE, and
   error behavior.
 - Do not include private deployment URLs, tokens, org ids, or provider keys in

--- a/packages/cloud-client/package.json
+++ b/packages/cloud-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-cowork/cloud-client",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "description": "Typed Open Cowork Cloud HTTP and SSE client",
   "author": "Joe Broadhead",
   "license": "MIT",
@@ -77,9 +77,6 @@
     "README.md"
   ],
   "sideEffects": false,
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-cowork/shared",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "description": "Shared Open Cowork product and wire types",
   "author": "Joe Broadhead",
   "license": "MIT",
@@ -24,9 +24,6 @@
     "dist"
   ],
   "sideEffects": false,
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "node ../../scripts/clean-shared-dist.mjs && tsc && node ../../scripts/check-shared-dist.mjs",
     "typecheck": "tsc --noEmit"

--- a/tests/cloud-client-boundaries.test.ts
+++ b/tests/cloud-client-boundaries.test.ts
@@ -11,6 +11,7 @@ test('cloud client package boundary and desktop transport compatibility re-expor
     exports?: Record<string, unknown>
     files?: string[]
     sideEffects?: boolean
+    publishConfig?: unknown
     dependencies?: Record<string, string>
   }
   const sharedPackageJson = JSON.parse(readFileSync(join(root, 'packages/shared/package.json'), 'utf8')) as {
@@ -19,6 +20,7 @@ test('cloud client package boundary and desktop transport compatibility re-expor
     exports?: Record<string, unknown>
     files?: string[]
     sideEffects?: boolean
+    publishConfig?: unknown
   }
   const clientSource = clientSources(join(root, 'packages/cloud-client/src')).join('\n')
   const desktopTransport = readFileSync(join(root, 'apps/desktop/src/main/cloud/transport-adapter.ts'), 'utf8')
@@ -26,10 +28,11 @@ test('cloud client package boundary and desktop transport compatibility re-expor
   const docs = readFileSync(join(root, 'docs/cloud-client.md'), 'utf8')
 
   assert.equal(packageJson.name, '@open-cowork/cloud-client')
-  assert.equal(packageJson.private, false)
+  assert.equal(packageJson.private, true)
   assert.equal(packageJson.sideEffects, false)
+  assert.equal(packageJson.publishConfig, undefined)
   assert.deepEqual(packageJson.files, ['dist', 'README.md'])
-  const publicExports = [
+  const documentedExports = [
     '.',
     './adapter',
     './domains/artifacts',
@@ -46,16 +49,17 @@ test('cloud client package boundary and desktop transport compatibility re-expor
     './domains/workflows',
     './package.json',
   ].sort()
-  assert.deepEqual(Object.keys(packageJson.exports || {}).sort(), publicExports)
+  assert.deepEqual(Object.keys(packageJson.exports || {}).sort(), documentedExports)
   assert.equal(sharedPackageJson.name, '@open-cowork/shared')
-  assert.equal(sharedPackageJson.private, false)
+  assert.equal(sharedPackageJson.private, true)
+  assert.equal(sharedPackageJson.publishConfig, undefined)
   assert.deepEqual(Object.keys(sharedPackageJson.exports || {}).sort(), ['.', './package.json'])
   assert.deepEqual(sharedPackageJson.files, ['dist'])
   assert.equal(sharedPackageJson.sideEffects, false)
   for (const dependencyName of Object.keys(packageJson.dependencies || {})) {
     if (!dependencyName.startsWith('@open-cowork/')) continue
     const dependencyPackage = JSON.parse(readFileSync(join(root, `packages/${dependencyName.replace('@open-cowork/', '')}/package.json`), 'utf8')) as { private?: boolean }
-    assert.equal(dependencyPackage.private, false, `${dependencyName} must be publishable because cloud-client is public`)
+    assert.equal(dependencyPackage.private, true, `${dependencyName} must remain a private workspace package until standalone SDK publication is explicit`)
   }
   assert.doesNotMatch(clientSource, /apps\/desktop|control-plane-store|session-service|@opencode-ai\/sdk/)
   assert.equal(desktopTransport.trim(), "export * from '../../../../../packages/cloud-client/src/index.ts'")


### PR DESCRIPTION
## Summary

- mark @open-cowork/cloud-client and @open-cowork/shared as private workspace packages
- remove npm publishConfig from both manifests until standalone SDK publication is explicit
- update docs and the cloud-client boundary test to prevent accidental publishable metadata drift

## Verification

- node --no-warnings --experimental-strip-types --test tests/cloud-client-boundaries.test.ts
- node --no-warnings --experimental-strip-types --test tests/package-scripts.test.ts
- node scripts/lint.mjs
- node scripts/validate-release-gates.mjs
- ./node_modules/.bin/eslint tests/cloud-client-boundaries.test.ts --max-warnings 0
- git diff --check