### PR TITLE
Align workflow draft local contract

### DIFF
--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
@@ -120,6 +120,7 @@ describe('WorkflowsPage', () => {
     await userEvent.click(screen.getAllByRole('button', { name: 'Add workflow' })[0]!)
 
     expect(api.workflows?.startDraft).toHaveBeenCalledTimes(1)
+    expect(api.workflows?.startDraft).toHaveBeenCalledWith()
     await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith('ses_new'))
   })
 

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
@@ -155,9 +155,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
     setBusyId('new')
     setFeedback(null)
     try {
-      const session = activeWorkspaceIsLocal
-        ? await window.coworkApi.workflows.startDraft()
-        : await window.coworkApi.workflows.startDraft(null, workspaceOptions)
+      const session = await window.coworkApi.workflows.startDraft()
       onOpenThread(session.id)
       await refresh()
     } catch (error) {

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -120,6 +120,10 @@ The remaining work is concentrated in two areas:
   expose no `publishConfig`, and the Cloud client boundary test prevents an
   accidental npm-publishable state before standalone SDK publication,
   provenance, and support ownership exist.
+- Workflow draft creation is now explicitly local-only across the renderer and
+  shared preload contract: `workflows.startDraft` no longer advertises
+  workspace options that the IPC handler intentionally rejects for non-local
+  workspaces.
 
 ## High Priority
 
@@ -152,9 +156,6 @@ No open high-priority findings remain after the current audit remediations.
 - Workflow setup policy is duplicated across kickoff prompt, generated agent
   config, and skill text. Centralize policy in a typed source and generate
   downstream text from it.
-- `workflows.startDraft` exposes an options contract that the bridge ignores.
-  Either implement workspace-aware draft creation or remove the unused options
-  surface.
 - The vendored docs Mermaid bundle is version-drifted from the locked runtime
   dependency. Add deterministic regeneration/hash checking or build the bundle
   from the locked dependency.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -349,7 +349,7 @@ export interface CoworkAPI {
   workflows: {
     list: (options?: WorkspaceOptions) => Promise<WorkflowListPayload>
     get: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowDetail | null>
-    startDraft: (directory?: string | null, options?: WorkspaceOptions) => Promise<SessionInfo>
+    startDraft: (directory?: string | null) => Promise<SessionInfo>
     runNow: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowRun | null>
     pause: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowDetail | null>
     resume: (workflowId: string, options?: WorkspaceOptions) => Promise<WorkflowDetail | null>


### PR DESCRIPTION
## Summary

- remove the unused workspace options argument from workflows.startDraft in the shared preload contract
- keep workflow draft creation explicitly local-only in the renderer call site
- add a renderer regression asserting Add workflow calls startDraft without ignored workspace options
- move the audit finding from open medium priority to fixed evidence

## Verification

- PATH=/Users/joe/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/joe/.cargo/bin:/Users/joe/.codex/tmp/arg0/codex-arg0SCY5aa:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources node_modules/.bin/vitest run --config vitest.renderer.config.ts src/renderer/components/workflows/WorkflowsPage.test.tsx (from apps/desktop)
- node scripts/run-node-tests.mjs tests/ipc-handler-behavior.test.ts
- ./node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit
- ./node_modules/.bin/tsc -p apps/desktop/tsconfig.json --noEmit
- ./node_modules/.bin/tsc -p apps/desktop/tsconfig.preload.json --noEmit
- ./node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
- ./node_modules/.bin/eslint apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx apps/desktop/src/preload/index.ts packages/shared/src/index.ts --max-warnings 0
- node scripts/lint.mjs
- git diff --check