### PR TITLE
Scope webhook replay cache eviction

### DIFF
--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -24,7 +24,7 @@ The remaining work is concentrated in two areas:
 ## Verified Baseline
 
 - GitHub code scanning: 0 open alerts on `master` at
-  `075bb11f8c07710be93c5e6d9853ca40d5cc812d`.
+  `c5fbb5a2987f995390ede95cfd3596c5b011348e`.
 - Dependabot alerts: 0 open alerts at the same point-in-time check.
 - GitHub Actions checks on that `master` SHA were green for deploy, CodeQL,
   build, coverage, validate, docs, cloud-gates, macos-build, and linux-package.
@@ -128,6 +128,9 @@ The remaining work is concentrated in two areas:
   `mermaid@11.15.0` dependency, recorded in a version/hash manifest, and
   checked by lint so the self-hosted docs bundle cannot drift silently from the
   package lock.
+- Webhook and Slack replay caches now enforce both per-source and global caps.
+  A hot bridge target or Slack team cannot evict another source's replay claim
+  before the signature window expires.
 
 ## High Priority
 
@@ -163,8 +166,6 @@ No open high-priority findings remain after the current audit remediations.
 
 ## Low Priority
 
-- Webhook replay cache eviction is global, not source/org scoped. Add scoped
-  caps plus a global cap and test cross-source eviction.
 - Cloud compatibility facades remain near their documented budgets:
   `postgres-control-plane-store.ts`, `in-memory-control-plane-store.ts`, and
   `session-service.ts` should be decomposed further before adding major Cloud

--- a/packages/gateway-provider-slack/src/slack-provider.test.ts
+++ b/packages/gateway-provider-slack/src/slack-provider.test.ts
@@ -103,6 +103,104 @@ describe("SlackProvider", () => {
     expect(messages).toHaveLength(1);
   });
 
+  it("keeps replay eviction scoped by Slack team", async () => {
+    const messages: IncomingChannelMessage[] = [];
+    const provider = new SlackProvider({
+      botToken: "xoxb-test",
+      signingSecret,
+      now: () => fixedNow,
+      maxSeenWebhookSignatures: 10,
+      maxSeenWebhookSignaturesPerScope: 2,
+    });
+    await provider.start(async (message) => {
+      messages.push(message);
+    });
+    const preservedPayload = slackMessagePayload("T-B", "C-B", "1716984000.000100", "team b");
+    const preservedRawBody = JSON.stringify(preservedPayload);
+    const preservedHeaders = signedHeaders(preservedRawBody);
+
+    await provider.handleWebhookPayload(preservedPayload, {
+      headers: preservedHeaders,
+      rawBody: preservedRawBody,
+    });
+
+    let newestFloodPayload: ReturnType<typeof slackMessagePayload> | null = null;
+    let newestFloodRawBody: string | null = null;
+    let newestFloodHeaders: ReturnType<typeof signedHeaders> | null = null;
+    for (let index = 0; index < 3; index += 1) {
+      const payload = slackMessagePayload("T-A", "C-A", `171698400${index}.000100`, `team a ${index}`);
+      const rawBody = JSON.stringify(payload);
+      const headers = signedHeaders(rawBody);
+      await provider.handleWebhookPayload(payload, {
+        headers,
+        rawBody,
+      });
+      newestFloodPayload = payload;
+      newestFloodRawBody = rawBody;
+      newestFloodHeaders = headers;
+    }
+
+    if (!newestFloodPayload || !newestFloodRawBody || !newestFloodHeaders) throw new Error("missing newest flood request");
+    await expect(provider.handleWebhookPayload(newestFloodPayload, {
+      headers: newestFloodHeaders,
+      rawBody: newestFloodRawBody,
+    })).rejects.toThrow("replay");
+    await expect(provider.handleWebhookPayload(preservedPayload, {
+      headers: preservedHeaders,
+      rawBody: preservedRawBody,
+    })).rejects.toThrow("replay");
+    expect(messages).toHaveLength(4);
+  });
+
+  it("keeps form-encoded Slack interaction replay eviction scoped by team", async () => {
+    const messages: IncomingChannelMessage[] = [];
+    const provider = new SlackProvider({
+      botToken: "xoxb-test",
+      signingSecret,
+      now: () => fixedNow,
+      maxSeenWebhookSignatures: 10,
+      maxSeenWebhookSignaturesPerScope: 2,
+    });
+    await provider.start(async (message) => {
+      messages.push(message);
+    });
+    const preservedPayload = slackInteractionPayload("T-B", "C-B", "trigger-b", "1716984001.000100");
+    const preservedRawBody = slackFormBody(preservedPayload);
+    const preservedHeaders = signedHeaders(preservedRawBody);
+
+    await provider.handleWebhookPayload(preservedPayload, {
+      headers: preservedHeaders,
+      rawBody: preservedRawBody,
+    });
+
+    let newestFloodPayload: ReturnType<typeof slackInteractionPayload> | null = null;
+    let newestFloodRawBody: string | null = null;
+    let newestFloodHeaders: ReturnType<typeof signedHeaders> | null = null;
+    for (let index = 0; index < 3; index += 1) {
+      const payload = slackInteractionPayload("T-A", "C-A", `trigger-a-${index}`, `171698400${index}.000100`);
+      const rawBody = slackFormBody(payload);
+      const headers = signedHeaders(rawBody);
+      await provider.handleWebhookPayload(payload, {
+        headers,
+        rawBody,
+      });
+      newestFloodPayload = payload;
+      newestFloodRawBody = rawBody;
+      newestFloodHeaders = headers;
+    }
+
+    if (!newestFloodPayload || !newestFloodRawBody || !newestFloodHeaders) throw new Error("missing newest flood request");
+    await expect(provider.handleWebhookPayload(newestFloodPayload, {
+      headers: newestFloodHeaders,
+      rawBody: newestFloodRawBody,
+    })).rejects.toThrow("replay");
+    await expect(provider.handleWebhookPayload(preservedPayload, {
+      headers: preservedHeaders,
+      rawBody: preservedRawBody,
+    })).rejects.toThrow("replay");
+    expect(messages).toHaveLength(4);
+  });
+
   it("maps Slack button actions to provider-neutral interactions", async () => {
     const messages: IncomingChannelMessage[] = [];
     const provider = new SlackProvider({
@@ -171,6 +269,36 @@ describe("SlackProvider", () => {
     ]);
   });
 });
+
+function slackMessagePayload(teamId: string, channel: string, ts: string, text: string) {
+  return {
+    type: "event_callback",
+    team_id: teamId,
+    event: {
+      type: "message",
+      user: "U123",
+      channel,
+      text,
+      ts,
+    },
+  };
+}
+
+function slackInteractionPayload(teamId: string, channel: string, triggerId: string, actionTs: string) {
+  return {
+    type: "block_actions",
+    trigger_id: triggerId,
+    team: { id: teamId },
+    user: { id: "U123", username: "alice", name: "Alice" },
+    channel: { id: channel },
+    message: { ts: "1716984000.000100" },
+    actions: [{ action_ts: actionTs, value: "p:token-1" }],
+  };
+}
+
+function slackFormBody(payload: unknown) {
+  return `payload=${encodeURIComponent(JSON.stringify(payload))}`;
+}
 
 function signedHeaders(rawBody: string) {
   const timestamp = Math.floor(fixedNow.getTime() / 1000).toString();

--- a/packages/gateway-provider-slack/src/slack-provider.ts
+++ b/packages/gateway-provider-slack/src/slack-provider.ts
@@ -25,6 +25,8 @@ export interface SlackProviderConfig {
   now?: () => Date;
   maxSignatureAgeMs?: number;
   requestTimeoutMs?: number;
+  maxSeenWebhookSignatures?: number;
+  maxSeenWebhookSignaturesPerScope?: number;
 }
 
 export interface SlackWebhookAuth {
@@ -55,7 +57,13 @@ type SlackApiResponse = {
 const defaultSlackApiBaseUrl = "https://slack.com/api";
 const defaultMaxSignatureAgeMs = 5 * 60 * 1000;
 const defaultSlackRequestTimeoutMs = 15_000;
-const maxSeenSlackSignatures = 5_000;
+const defaultMaxSeenSlackSignatures = 5_000;
+const defaultMaxSeenSlackSignaturesPerScope = 1_000;
+
+type SeenSlackWebhookSignature = {
+  expiresAt: number;
+  scope: string;
+};
 
 export class SlackProvider implements ChannelProvider {
   readonly kind: ChannelProviderKind = "slack";
@@ -85,7 +93,7 @@ export class SlackProvider implements ChannelProvider {
   };
 
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
-  private readonly seenWebhookSignatures = new Map<string, number>();
+  private readonly seenWebhookSignatures = new Map<string, SeenSlackWebhookSignature>();
 
   constructor(private readonly config: SlackProviderConfig) {
     this.id = normalizeChannelProviderIdentity(this.kind, config.providerId).providerId;
@@ -221,24 +229,45 @@ export class SlackProvider implements ChannelProvider {
     if (!constantTimeStringEqual(signature, expected)) {
       throw new Error("Slack webhook signature verification failed.");
     }
-    this.claimWebhookSignature(`${timestamp}:${signature}`, nowMs, maxAgeMs);
+    this.claimWebhookSignature(`${timestamp}:${signature}`, slackReplayScopeFromRawBody(rawBody, this.id), nowMs, maxAgeMs);
   }
 
-  private claimWebhookSignature(replayKey: string, nowMs: number, maxAgeMs: number): void {
+  private claimWebhookSignature(replayKey: string, scope: string, nowMs: number, maxAgeMs: number): void {
     this.purgeSeenWebhookSignatures(nowMs);
-    const existingExpiresAt = this.seenWebhookSignatures.get(replayKey);
-    if (existingExpiresAt && existingExpiresAt > nowMs) {
+    const existing = this.seenWebhookSignatures.get(replayKey);
+    if (existing && existing.expiresAt > nowMs) {
       throw new Error("Slack webhook signature replay rejected.");
     }
-    this.seenWebhookSignatures.set(replayKey, nowMs + maxAgeMs);
-    if (this.seenWebhookSignatures.size > maxSeenSlackSignatures) {
+    this.seenWebhookSignatures.set(replayKey, { expiresAt: nowMs + maxAgeMs, scope });
+    this.enforceSeenWebhookSignatureScopeLimit(scope);
+    this.enforceSeenWebhookSignatureGlobalLimit();
+  }
+
+  private enforceSeenWebhookSignatureScopeLimit(scope: string): void {
+    const limit = normalizeReplayCacheLimit(this.config.maxSeenWebhookSignaturesPerScope, defaultMaxSeenSlackSignaturesPerScope);
+    const scopedKeys: string[] = [];
+    for (const [key, entry] of this.seenWebhookSignatures) {
+      if (entry.scope !== scope) continue;
+      scopedKeys.push(key);
+    }
+    while (scopedKeys.length > limit) {
+      const oldest = scopedKeys.shift();
+      if (!oldest) return;
+      this.seenWebhookSignatures.delete(oldest);
+    }
+  }
+
+  private enforceSeenWebhookSignatureGlobalLimit(): void {
+    const limit = normalizeReplayCacheLimit(this.config.maxSeenWebhookSignatures, defaultMaxSeenSlackSignatures);
+    while (this.seenWebhookSignatures.size > limit) {
       const oldest = this.seenWebhookSignatures.keys().next().value;
-      if (oldest) this.seenWebhookSignatures.delete(oldest);
+      if (!oldest) return;
+      this.seenWebhookSignatures.delete(oldest);
     }
   }
 
   private purgeSeenWebhookSignatures(nowMs: number): void {
-    for (const [key, expiresAt] of this.seenWebhookSignatures) {
+    for (const [key, { expiresAt }] of this.seenWebhookSignatures) {
       if (expiresAt <= nowMs) this.seenWebhookSignatures.delete(key);
     }
   }
@@ -293,6 +322,50 @@ function normalizeRequestTimeoutMs(value: number | undefined): number {
     return defaultSlackRequestTimeoutMs;
   }
   return Math.min(120_000, Math.max(100, Math.floor(value)));
+}
+
+function normalizeReplayCacheLimit(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function slackReplayScopeFromRawBody(rawBody: string, providerId: ChannelProviderId): string {
+  const fallback = replayScopeSegment(providerId);
+  try {
+    const value = parseSlackReplayScopeBody(rawBody);
+    if (!isRecord(value)) return fallback;
+    return replayScopeSegment(value.team_id)
+      || replayScopeSegment(isRecord(value.team) ? value.team.id : undefined)
+      || replayScopeSegment(value.enterprise_id)
+      || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function parseSlackReplayScopeBody(rawBody: string): unknown {
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    const params = new URLSearchParams(rawBody);
+    const payload = params.get("payload");
+    return payload ? JSON.parse(payload) as unknown : Object.fromEntries(params.entries());
+  }
+}
+
+function replayScopeSegment(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  let sanitized = "";
+  for (const character of trimmed) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    sanitized += codePoint < 32 || codePoint === 127 || character === ":" ? "_" : character;
+    if (sanitized.length >= 256) break;
+  }
+  return sanitized;
 }
 
 function mapSlackPayload(payload: Record<string, unknown>, now: Date, providerId: ChannelProviderId = "slack"): IncomingChannelMessage | null {
@@ -479,6 +552,10 @@ function constantTimeStringEqual(left: string | null | undefined, right: string 
 
 function objectRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function stringField(value: Record<string, unknown>, key: string): string | null {

--- a/packages/gateway-provider-webhook/src/webhook-provider.test.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.test.ts
@@ -572,6 +572,54 @@ describe("WebhookProvider", () => {
     await provider.stop();
   });
 
+  it("keeps signed ingress replay eviction scoped by bridge target", async () => {
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      sharedSecret: "secret",
+      now: () => new Date("2026-02-28T12:00:00.000Z"),
+      maxSeenIngressSignatures: 10,
+      maxSeenIngressSignaturesPerScope: 2
+    });
+    const seen: string[] = [];
+    await provider.start(async (message) => {
+      seen.push(message.id);
+    });
+
+    const preservedPayload = {
+      id: "team-b-first",
+      target: { chatId: "team-b" },
+      sender: { userId: "bob" },
+      text: "preserve replay claim"
+    };
+    const preservedAuth = signedAuth(preservedPayload, "secret", "1772280001");
+    await provider.handleWebhookPayload(preservedPayload, preservedAuth);
+
+    let newestFloodPayload: { id: string, target: { chatId: string }, sender: { userId: string }, text: string } | null = null;
+    let newestFloodAuth: ReturnType<typeof signedAuth> | null = null;
+    for (let index = 0; index < 3; index += 1) {
+      const payload = {
+        id: `team-a-${index}`,
+        target: { chatId: "team-a" },
+        sender: { userId: "alice" },
+        text: `flood ${index}`
+      };
+      const auth = signedAuth(payload, "secret", String(1772280002 + index));
+      await provider.handleWebhookPayload(payload, auth);
+      newestFloodPayload = payload;
+      newestFloodAuth = auth;
+    }
+
+    if (!newestFloodPayload || !newestFloodAuth) throw new Error("missing newest flood request");
+    await expect(provider.handleWebhookPayload(newestFloodPayload, newestFloodAuth)).rejects.toThrow(
+      "Webhook signature replay rejected",
+    );
+    await expect(provider.handleWebhookPayload(preservedPayload, preservedAuth)).rejects.toThrow(
+      "Webhook signature replay rejected",
+    );
+    expect(seen).toHaveLength(4);
+    await provider.stop();
+  });
+
   it("rejects ingress when no shared secret has been configured", async () => {
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway"

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -28,6 +28,8 @@ export interface WebhookProviderConfig {
   sleep?: (ms: number) => Promise<void>;
   deliveryTimeoutMs?: number;
   legacySharedSecretHeader?: boolean;
+  maxSeenIngressSignatures?: number;
+  maxSeenIngressSignaturesPerScope?: number;
 }
 
 export interface WebhookIncomingPayload {
@@ -75,6 +77,13 @@ const defaultMaxSignatureAgeMs = 5 * 60 * 1000;
 const defaultDeliveryTimeoutMs = 15_000;
 const maxWebhookRetryAttempts = 5;
 const maxWebhookRetryDelayMs = 10_000;
+const defaultMaxSeenIngressSignatures = 5_000;
+const defaultMaxSeenIngressSignaturesPerScope = 1_000;
+
+type SeenWebhookSignature = {
+  expiresAt: number;
+  scope: string;
+};
 
 export interface MapWebhookPayloadOptions {
   maxAttachmentBytes?: number;
@@ -86,7 +95,7 @@ export class WebhookProvider implements ChannelProvider {
   readonly capabilities: ChannelCapabilities;
 
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
-  private readonly seenIngressSignatures = new Map<string, number>();
+  private readonly seenIngressSignatures = new Map<string, SeenWebhookSignature>();
 
   constructor(private readonly config: WebhookProviderConfig) {
     validateWebhookDeliveryUrl(config.deliveryUrl);
@@ -299,16 +308,42 @@ export class WebhookProvider implements ChannelProvider {
     }
     this.purgeSeenIngressSignatures(nowMs);
     const replayKey = `${timestamp}:${signature}`;
-    const existingExpiresAt = this.seenIngressSignatures.get(replayKey);
-    if (existingExpiresAt && existingExpiresAt > nowMs) {
+    const existing = this.seenIngressSignatures.get(replayKey);
+    if (existing && existing.expiresAt > nowMs) {
       throw new Error("Webhook signature replay rejected");
     }
-    this.seenIngressSignatures.set(replayKey, nowMs + maxAgeMs);
+    const scope = webhookReplayScopeFromRawBody(rawBody, this.id);
+    this.seenIngressSignatures.set(replayKey, { expiresAt: nowMs + maxAgeMs, scope });
+    this.enforceSeenIngressSignatureScopeLimit(scope);
+    this.enforceSeenIngressSignatureGlobalLimit();
   }
 
   private purgeSeenIngressSignatures(nowMs: number): void {
-    for (const [key, expiresAt] of this.seenIngressSignatures) {
+    for (const [key, { expiresAt }] of this.seenIngressSignatures) {
       if (expiresAt <= nowMs) this.seenIngressSignatures.delete(key);
+    }
+  }
+
+  private enforceSeenIngressSignatureScopeLimit(scope: string): void {
+    const limit = normalizeReplayCacheLimit(this.config.maxSeenIngressSignaturesPerScope, defaultMaxSeenIngressSignaturesPerScope);
+    const scopedKeys: string[] = [];
+    for (const [key, entry] of this.seenIngressSignatures) {
+      if (entry.scope !== scope) continue;
+      scopedKeys.push(key);
+    }
+    while (scopedKeys.length > limit) {
+      const oldest = scopedKeys.shift();
+      if (!oldest) return;
+      this.seenIngressSignatures.delete(oldest);
+    }
+  }
+
+  private enforceSeenIngressSignatureGlobalLimit(): void {
+    const limit = normalizeReplayCacheLimit(this.config.maxSeenIngressSignatures, defaultMaxSeenIngressSignatures);
+    while (this.seenIngressSignatures.size > limit) {
+      const oldest = this.seenIngressSignatures.keys().next().value;
+      if (!oldest) return;
+      this.seenIngressSignatures.delete(oldest);
     }
   }
 }
@@ -604,6 +639,13 @@ function normalizeTimeoutOrByteLimit(value: number | undefined): number | undefi
   return Math.floor(value);
 }
 
+function normalizeReplayCacheLimit(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
 function normalizeDeliveryTimeoutMs(value: number | undefined): number {
   if (value === undefined) {
     return defaultDeliveryTimeoutMs;
@@ -648,6 +690,34 @@ function isLocalHttpHost(hostname: string): boolean {
     normalized === "127.0.0.1" ||
     normalized === "::1" ||
     normalized === "[::1]";
+}
+
+function webhookReplayScopeFromRawBody(rawBody: string, providerId: ChannelProviderId): string {
+  const fallback = replayScopeSegment(providerId);
+  try {
+    const value = JSON.parse(rawBody) as unknown;
+    if (!isRecord(value)) return fallback;
+    const target = isRecord(value.target) ? value.target : null;
+    const chatId = replayScopeSegment(optionalString(target?.chatId));
+    if (!chatId) return fallback;
+    const threadId = replayScopeSegment(optionalString(target?.threadId));
+    return threadId ? `${fallback}:${chatId}:${threadId}` : `${fallback}:${chatId}`;
+  } catch {
+    return fallback;
+  }
+}
+
+function replayScopeSegment(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  let sanitized = "";
+  for (const character of trimmed) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    sanitized += codePoint < 32 || codePoint === 127 || character === ":" ? "_" : character;
+    if (sanitized.length >= 256) break;
+  }
+  return sanitized;
 }
 
 function validateHeaderValue(value: string, label: string): void {


### PR DESCRIPTION
## Summary
- Add per-source replay-cache caps for generic webhook bridge ingress and Slack webhooks while preserving global caps.
- Scope generic webhook replay entries by provider/target and Slack replay entries by team, including form-encoded interaction payloads.
- Add regressions that prove a hot source cannot evict another source and that newest accepted requests remain replay-protected after scope trimming.

## Validation
- node --no-warnings --experimental-strip-types --test packages/gateway-provider-webhook/src/webhook-provider.test.ts packages/gateway-provider-slack/src/slack-provider.test.ts
- ./node_modules/.bin/tsc -p packages/gateway-provider-webhook/tsconfig.json --noEmit
- ./node_modules/.bin/tsc -p packages/gateway-provider-slack/tsconfig.json --noEmit
- ./node_modules/.bin/eslint . --max-warnings 0
- node scripts/lint.mjs
- node scripts/check-preload-channels.mjs
- git diff --check

## Review
- Sidecar review found and verified fixes for Slack form-encoded replay scoping and newest-request eviction behavior.