### PR TITLE
Bound workspace SSE replay cursors

### DIFF
--- a/apps/desktop/src/main/cloud/control-plane-domains/sessions.ts
+++ b/apps/desktop/src/main/cloud/control-plane-domains/sessions.ts
@@ -14,6 +14,7 @@ export type SessionControlPlaneStore = Pick<ControlPlaneStore,
   | 'appendSessionEvent'
   | 'listSessionEvents'
   | 'appendWorkspaceEvent'
+  | 'getWorkspaceEventCursor'
   | 'listWorkspaceEvents'
   | 'writeSessionProjection'
   | 'getSessionProjection'

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -22,5 +22,6 @@ export {
   generateManagedWorkerCredential,
   hashManagedWorkerCredential,
 } from './in-memory-domains/workers.ts'
+export type { WorkspaceEventCursorRecord } from './workspace-event-cursor.ts'
 export type * from './in-memory-control-plane-store.ts'
 export type * from './managed-worker-types.ts'

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -990,15 +990,15 @@ async function handleWorkspaceSse(
     lastSequence = event.sequence
   }
 
-  const retainedEvents = await options.service.listWorkspaceEvents(context.principal, 0)
+  const cursor = await options.service.getWorkspaceEventCursor(context.principal)
   if (cleaned || res.destroyed) return
-  const earliestSequence = retainedEvents[0]?.sequence
+  const earliestSequence = cursor.earliestSequence
   const hasReplayGap = afterSequence > 0
-    && earliestSequence !== undefined
+    && earliestSequence !== null
     && earliestSequence > afterSequence + 1
 
   if (hasReplayGap) {
-    const latestSequence = retainedEvents[retainedEvents.length - 1]?.sequence || afterSequence
+    const latestSequence = cursor.latestSequence || afterSequence
     writeSnapshotRequiredEvent(res, afterSequence, {
       reason: 'event_retention_gap',
       afterSequence,
@@ -1007,6 +1007,7 @@ async function handleWorkspaceSse(
     })
     lastSequence = Math.max(lastSequence, latestSequence)
   } else {
+    const retainedEvents = await options.service.listWorkspaceEvents(context.principal, afterSequence)
     for (const event of retainedEvents) writeIfNew(event)
   }
 

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -37,10 +37,8 @@ import {
   plaintextMatchesCloudApiTokenId,
   verifyCloudApiTokenHash,
 } from './control-plane-tokens.ts'
-import {
-  decodeSessionPageCursor,
-  encodeSessionPageCursor,
-} from './session-page-cursor.ts'
+import { decodeSessionPageCursor, encodeSessionPageCursor } from './session-page-cursor.ts'
+import { workspaceEventCursor, type WorkspaceEventCursorRecord } from './workspace-event-cursor.ts'
 export { ControlPlaneQuotaExceededError, publicQuotaMessage } from './control-plane-errors.ts'
 export type { QuotaPolicyCode } from './control-plane-errors.ts'
 export type {
@@ -436,7 +434,6 @@ export type WorkspaceEventRecord = {
   payload: Record<string, unknown>
   createdAt: string
 }
-
 export type SessionProjectionRecord = {
   tenantId: string
   sessionId: string
@@ -1236,6 +1233,7 @@ export type ControlPlaneStore = {
   appendSessionEvent(input: AppendEventInput): MaybePromise<SessionEventRecord>
   listSessionEvents(tenantId: string, sessionId: string, afterSequence?: number): MaybePromise<SessionEventRecord[]>
   appendWorkspaceEvent(input: AppendWorkspaceEventInput): MaybePromise<WorkspaceEventRecord>
+  getWorkspaceEventCursor(tenantId: string, userId: string): MaybePromise<WorkspaceEventCursorRecord>
   listWorkspaceEvents(tenantId: string, userId: string, afterSequence?: number): MaybePromise<WorkspaceEventRecord[]>
   writeSessionProjection(input: WriteProjectionInput): MaybePromise<SessionProjectionRecord>
   getSessionProjection(tenantId: string, sessionId: string): MaybePromise<SessionProjectionRecord | null>
@@ -3191,7 +3189,10 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       .filter((event) => event.sequence > afterSequence)
       .map((event) => clone(event))
   }
-
+  getWorkspaceEventCursor(tenantId: string, userId: string): WorkspaceEventCursorRecord {
+    this.requireTenantUser(tenantId, userId)
+    return workspaceEventCursor(this.workspaceEvents.get(`${tenantId}:${userId}`)?.events || [])
+  }
   writeSessionProjection(input: WriteProjectionInput): SessionProjectionRecord {
     const session = this.requireSession(input.tenantId, input.sessionId)
     if (session.lease && session.lease.leaseToken !== input.leaseToken) {

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -96,6 +96,7 @@ import type {
   UpsertMembershipInput,
   WorkerLeaseRecord,
   WorkerRole,
+  WorkspaceEventCursorRecord,
   WorkspaceEventRecord,
   CreateManagedWorkerPoolInput,
   RegisterManagedWorkerInput,
@@ -106,6 +107,7 @@ import type {
   WorkflowWebhookSecurityStore,
 } from '../workflow/workflow-webhook-server.ts'
 import { runPostgresControlPlaneMigrations } from './postgres-migrations.ts'
+import { workspaceEventCursorFromRow } from './workspace-event-cursor.ts'
 import { usageEventFromRow, billingSubscriptionFromRow } from './postgres-domains/billing.ts'
 import { byokSecretFromRow } from './postgres-domains/byok.ts'
 import {
@@ -2462,6 +2464,17 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       [tenantId, userId, afterSequence],
     )
     return result.rows.map(workspaceEventFromRow)
+  }
+
+  async getWorkspaceEventCursor(tenantId: string, userId: string): Promise<WorkspaceEventCursorRecord> {
+    await this.requireTenantUser(tenantId, userId)
+    const result = await this.pool.query(
+      `SELECT min(sequence) AS earliest_sequence, max(sequence) AS latest_sequence
+       FROM cloud_workspace_events
+       WHERE tenant_id = $1 AND user_id = $2`,
+      [tenantId, userId],
+    )
+    return workspaceEventCursorFromRow(result.rows[0])
   }
 
   async writeSessionProjection(input: {

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -1370,6 +1370,11 @@ export class CloudSessionService {
     return this.store.listWorkspaceEvents(principal.tenantId, principal.userId, afterSequence)
   }
 
+  async getWorkspaceEventCursor(principal: CloudPrincipal) {
+    await this.ensurePrincipal(principal)
+    return this.store.getWorkspaceEventCursor(principal.tenantId, principal.userId)
+  }
+
   async listWorkerHeartbeats(principal: CloudPrincipal) {
     await this.ensurePrincipal(principal)
     if (!principalCanViewOperations(principal)) {

--- a/apps/desktop/src/main/cloud/workspace-event-cursor.ts
+++ b/apps/desktop/src/main/cloud/workspace-event-cursor.ts
@@ -1,0 +1,20 @@
+type Sequenced = { sequence: number }
+
+export type WorkspaceEventCursorRecord = {
+  earliestSequence: number | null
+  latestSequence: number
+}
+
+export function workspaceEventCursor(events: readonly Sequenced[]): WorkspaceEventCursorRecord {
+  return {
+    earliestSequence: events[0]?.sequence ?? null,
+    latestSequence: events.at(-1)?.sequence || 0,
+  }
+}
+
+export function workspaceEventCursorFromRow(row: Record<string, unknown> | undefined): WorkspaceEventCursorRecord {
+  return {
+    earliestSequence: row?.earliest_sequence === null || row?.earliest_sequence === undefined ? null : Number(row.earliest_sequence),
+    latestSequence: row?.latest_sequence === null || row?.latest_sequence === undefined ? 0 : Number(row.latest_sequence),
+  }
+}

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -24,7 +24,7 @@ The remaining work is concentrated in two areas:
 ## Verified Baseline
 
 - GitHub code scanning: 0 open alerts on `master` at
-  `2389992f05c6852a2e04a9e2f2b15e19a5a92c45`.
+  `920d09dddf45311240a6438375208c65f4eb4aea`.
 - Dependabot alerts: 0 open alerts at the same point-in-time check.
 - GitHub Actions checks on that `master` SHA were green for deploy, CodeQL,
   build, coverage, validate, docs, cloud-gates, macos-build, and linux-package.
@@ -137,6 +137,9 @@ The remaining work is concentrated in two areas:
   transaction, drain only a capped number of batches per worker/scheduler tick,
   and emit drain-cap-hit metrics when a tick exhausts the configured recovery
   cap.
+- Workspace SSE reconnects now use retained-stream cursor metadata to detect
+  retention gaps and replay only events newer than the client cursor. Gap
+  detection no longer loads all retained workspace events from sequence `0`.
 
 ## High Priority
 
@@ -152,9 +155,6 @@ No open high-priority findings remain after the current audit remediations.
 - Recovery and failover drills are currently evidence wrappers for public CI.
   Add an executable local compose recovery drill and require private
   environment drill evidence for hosted promotion.
-- Workspace SSE reconnect replay loads retained events from sequence `0`.
-  Add paged replay and earliest/latest event metadata so gap detection does not
-  require loading all retained events.
 - Queue processing needs fairness and backpressure caps across hot sessions,
   gateway deliveries, providers, and bindings.
 - Product diff fallback infers OpenCode tool semantics for write/edit tools.

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -301,7 +301,15 @@ test('cloud control plane appends user-scoped workspace events across sessions',
     store.listWorkspaceEvents('tenant-1', 'user-1', 1).map((event) => [event.sequence, event.sessionId]),
     [[2, 'session-2']],
   )
+  assert.deepEqual(store.getWorkspaceEventCursor('tenant-1', 'user-1'), {
+    earliestSequence: 1,
+    latestSequence: 2,
+  })
   assert.deepEqual(store.listWorkspaceEvents('tenant-1', 'user-2', 0), [])
+  assert.deepEqual(store.getWorkspaceEventCursor('tenant-1', 'user-2'), {
+    earliestSequence: null,
+    latestSequence: 0,
+  })
   assert.throws(() => store.appendWorkspaceEvent({
     tenantId: 'tenant-1',
     userId: 'user-1',

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -3594,6 +3594,8 @@ test('cloud HTTP workspace event feed replays one ordered user stream across ses
     userId: 'user-1',
     email: 'user@example.test',
   }
+  const originalListWorkspaceEvents = fixture.service.listWorkspaceEvents.bind(fixture.service)
+  const replayListCalls: number[] = []
   try {
     await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
@@ -3628,6 +3630,10 @@ test('cloud HTTP workspace event feed replays one ordered user stream across ses
 
     const firstAssistant = events.find((event) => event.type === 'assistant.message' && event.sessionId === 'oc-session-1')
     assert.ok(firstAssistant)
+    fixture.service.listWorkspaceEvents = async (eventPrincipal, afterSequence = 0) => {
+      replayListCalls.push(afterSequence)
+      return originalListWorkspaceEvents(eventPrincipal, afterSequence)
+    }
     const stream = await fetch(`${baseUrl}/api/events?after=${firstAssistant.sequence}`, {
       signal: controller.signal,
     })
@@ -3636,8 +3642,11 @@ test('cloud HTTP workspace event feed replays one ordered user stream across ses
       entry.type === 'assistant.message' && entry.sessionId === 'oc-session-2'
     ))
     assert.equal(asRecord(replayed.payload).content, 'echo: second session')
+    assert.equal(replayListCalls.includes(0), false)
+    assert.equal(replayListCalls.includes(firstAssistant.sequence), true)
   } finally {
     controller.abort()
+    fixture.service.listWorkspaceEvents = originalListWorkspaceEvents
     await fixture.server.close()
   }
 })
@@ -3685,25 +3694,20 @@ test('cloud HTTP workspace event feed asks clients to refresh snapshots after re
   const baseUrl = await fixture.server.listen()
   const controller = new AbortController()
   const originalListWorkspaceEvents = fixture.service.listWorkspaceEvents.bind(fixture.service)
+  const originalGetWorkspaceEventCursor = fixture.service.getWorkspaceEventCursor.bind(fixture.service)
+  const replayListCalls: number[] = []
   try {
     await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({}),
     })
+    fixture.service.getWorkspaceEventCursor = async () => ({
+      earliestSequence: 10,
+      latestSequence: 10,
+    })
     fixture.service.listWorkspaceEvents = async (principal, afterSequence = 0) => {
-      if (afterSequence === 0) {
-        return [{
-          tenantId: 'tenant-1',
-          userId: 'user-1',
-          sessionId: 'oc-session-1',
-          eventId: 'oc-session-1:retained-event-10',
-          sequence: 10,
-          type: 'assistant.message',
-          payload: { content: 'retained only' },
-          createdAt: '2026-01-01T00:00:00.000Z',
-        }]
-      }
+      replayListCalls.push(afterSequence)
       return originalListWorkspaceEvents(principal, afterSequence)
     }
 
@@ -3717,8 +3721,11 @@ test('cloud HTTP workspace event feed asks clients to refresh snapshots after re
     assert.equal(asRecord(event.payload).afterSequence, 1)
     assert.equal(asRecord(event.payload).earliestSequence, 10)
     assert.equal(asRecord(event.payload).latestSequence, 10)
+    assert.equal(replayListCalls.includes(0), false)
   } finally {
     controller.abort()
+    fixture.service.getWorkspaceEventCursor = originalGetWorkspaceEventCursor
+    fixture.service.listWorkspaceEvents = originalListWorkspaceEvents
     await fixture.server.close()
   }
 })

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -613,6 +613,10 @@ test('real Postgres cloud store assigns one ordered workspace stream across sess
       (await store.listWorkspaceEvents(ids.tenantId, ids.userId, 0)).map((event) => event.sequence),
       [1, 2, 3],
     )
+    assert.deepEqual(await store.getWorkspaceEventCursor(ids.tenantId, ids.userId), {
+      earliestSequence: 1,
+      latestSequence: 3,
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- add workspace-event cursor metadata for earliest/latest retained sequence without loading retained rows
- make workspace SSE reconnects detect retention gaps from metadata and replay only events newer than the client cursor
- add in-memory, Postgres, HTTP reconnect, and audit-doc coverage

## Validation

- node --no-warnings --experimental-strip-types --test tests/cloud-modularity-boundaries.test.ts tests/cloud-http-server.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-postgres-concurrency.test.ts
- ./apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
- node scripts/lint.mjs
- ./node_modules/.bin/eslint . --max-warnings 0
- git diff --check