### PR TITLE
Label synthetic session diff fallbacks

### DIFF
--- a/apps/desktop/src/main/session-diff-fallback.ts
+++ b/apps/desktop/src/main/session-diff-fallback.ts
@@ -40,6 +40,7 @@ function normalizeSessionFileDiff(value: unknown): SessionFileDiff | null {
     patch: typeof record.patch === 'string' ? record.patch : '',
     additions: normalizeSessionDiffNumber(record.additions),
     deletions: normalizeSessionDiffNumber(record.deletions),
+    source: 'sdk',
     ...(status ? { status } : {}),
   }
 }
@@ -116,6 +117,8 @@ function buildSyntheticDiff(rootDir: string, candidate: SessionArtifactCandidate
       additions: 0,
       deletions: 0,
       status: 'added',
+      source: 'synthetic',
+      synthetic: true,
     }
   }
 
@@ -126,6 +129,8 @@ function buildSyntheticDiff(rootDir: string, candidate: SessionArtifactCandidate
       additions: 0,
       deletions: 0,
       status: 'added',
+      source: 'synthetic',
+      synthetic: true,
     }
   }
 
@@ -136,6 +141,8 @@ function buildSyntheticDiff(rootDir: string, candidate: SessionArtifactCandidate
     additions,
     deletions: 0,
     status: 'added',
+    source: 'synthetic',
+    synthetic: true,
   }
 }
 
@@ -164,14 +171,22 @@ export function mergeSessionDiffsWithSynthetic(
 
 export function summarizeSessionDiffs(diffs: SessionFileDiff[]): SessionChangeSummary | null {
   if (diffs.length === 0) return null
+  const syntheticFiles = diffs.filter((diff) => diff.synthetic || diff.source === 'synthetic').length
 
-  return diffs.reduce<SessionChangeSummary>((summary, diff) => ({
-    additions: summary.additions + diff.additions,
-    deletions: summary.deletions + diff.deletions,
-    files: summary.files + 1,
+  const summary = diffs.reduce<SessionChangeSummary>((current, diff) => ({
+    additions: current.additions + diff.additions,
+    deletions: current.deletions + diff.deletions,
+    files: current.files + 1,
   }), {
     additions: 0,
     deletions: 0,
     files: 0,
   })
+  return syntheticFiles > 0
+    ? {
+        ...summary,
+        source: syntheticFiles === diffs.length ? 'synthetic' : 'mixed',
+        synthetic: true,
+      }
+    : summary
 }

--- a/apps/desktop/src/main/session-registry-utils.ts
+++ b/apps/desktop/src/main/session-registry-utils.ts
@@ -117,6 +117,9 @@ export function normalizeStoredSessionRecord(
           additions: typeof item.changeSummary.additions === 'number' ? item.changeSummary.additions : 0,
           deletions: typeof item.changeSummary.deletions === 'number' ? item.changeSummary.deletions : 0,
           files: typeof item.changeSummary.files === 'number' ? item.changeSummary.files : 0,
+          ...(item.changeSummary.source === 'synthetic' || item.changeSummary.source === 'mixed'
+            ? { source: item.changeSummary.source, synthetic: true }
+            : {}),
         }
       : null,
     revertedMessageId: typeof item.revertedMessageId === 'string' ? item.revertedMessageId : null,

--- a/apps/desktop/src/main/thread-index/thread-index-schema.ts
+++ b/apps/desktop/src/main/thread-index/thread-index-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite'
 
-export const THREAD_INDEX_SCHEMA_VERSION = 1
+export const THREAD_INDEX_SCHEMA_VERSION = 2
 
 const THREAD_INDEX_SCHEMA_VERSION_KEY = 'schema_version'
 
@@ -64,6 +64,7 @@ export function migrateThreadIndexDb(db: DatabaseSync) {
       change_files integer not null default 0,
       change_additions integer not null default 0,
       change_deletions integer not null default 0,
+      change_source text,
       indexed_at text not null,
       metadata_version integer not null
     );
@@ -128,5 +129,6 @@ export function migrateThreadIndexDb(db: DatabaseSync) {
     create index if not exists idx_thread_suggestions_session on thread_category_suggestions(session_id, status);
   `)
   ensureColumn(db, 'thread_index', 'workflow_id', 'text')
+  ensureColumn(db, 'thread_index', 'change_source', 'text')
   recordThreadIndexSchemaVersion(db)
 }

--- a/apps/desktop/src/main/thread-index/thread-index-service.ts
+++ b/apps/desktop/src/main/thread-index/thread-index-service.ts
@@ -165,6 +165,9 @@ function changeCounts(changeSummary?: SessionChangeSummary | null) {
     changeFiles: changeSummary?.files || 0,
     changeAdditions: changeSummary?.additions || 0,
     changeDeletions: changeSummary?.deletions || 0,
+    changeSource: changeSummary?.source === 'synthetic' || changeSummary?.source === 'mixed'
+      ? changeSummary.source
+      : null,
   }
 }
 

--- a/apps/desktop/src/main/thread-index/thread-index-store.ts
+++ b/apps/desktop/src/main/thread-index/thread-index-store.ts
@@ -97,7 +97,16 @@ function changeSummaryFromRow(row: Row) {
   const files = asNumber(row.change_files)
   const additions = asNumber(row.change_additions)
   const deletions = asNumber(row.change_deletions)
-  return files > 0 || additions > 0 || deletions > 0 ? { files, additions, deletions } : null
+  if (files <= 0 && additions <= 0 && deletions <= 0) return null
+  const source: 'synthetic' | 'mixed' | null = row.change_source === 'synthetic' || row.change_source === 'mixed'
+    ? row.change_source
+    : null
+  return {
+    files,
+    additions,
+    deletions,
+    ...(source ? { source, synthetic: true } : {}),
+  }
 }
 
 export class ThreadIndexStore {
@@ -188,8 +197,8 @@ export class ThreadIndexStore {
           created_at, updated_at, parent_session_id, workflow_id, run_id, reverted_message_id,
           message_count, tool_call_count, task_run_count, cost,
           input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_write_tokens,
-          change_files, change_additions, change_deletions, indexed_at, metadata_version
-        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          change_files, change_additions, change_deletions, change_source, indexed_at, metadata_version
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         on conflict(session_id) do update set
           title = excluded.title,
           kind = excluded.kind,
@@ -216,6 +225,7 @@ export class ThreadIndexStore {
           change_files = excluded.change_files,
           change_additions = excluded.change_additions,
           change_deletions = excluded.change_deletions,
+          change_source = excluded.change_source,
           indexed_at = excluded.indexed_at,
           metadata_version = excluded.metadata_version
       `).run(
@@ -245,6 +255,7 @@ export class ThreadIndexStore {
         input.changeFiles || 0,
         input.changeAdditions || 0,
         input.changeDeletions || 0,
+        input.changeSource === 'synthetic' || input.changeSource === 'mixed' ? input.changeSource : null,
         indexedAt,
         input.metadataVersion || THREAD_INDEX_METADATA_VERSION,
       )

--- a/apps/desktop/src/renderer/components/chat/ChatThreadHeader.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatThreadHeader.tsx
@@ -49,7 +49,9 @@ export function ChatThreadHeader({
           )}
           {currentSession?.changeSummary && currentSession.changeSummary.files > 0 && (
             <span
-              title={`${currentSession.changeSummary.files} file${currentSession.changeSummary.files === 1 ? '' : 's'} changed`}
+              title={currentSession.changeSummary.synthetic
+                ? `${currentSession.changeSummary.files} file${currentSession.changeSummary.files === 1 ? '' : 's'} changed (estimated from projection data)`
+                : `${currentSession.changeSummary.files} file${currentSession.changeSummary.files === 1 ? '' : 's'} changed`}
               className="inline-flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded-full border border-border-subtle"
             >
               <span style={{ color: 'var(--color-green)' }}>+{currentSession.changeSummary.additions}</span>
@@ -57,6 +59,7 @@ export function ChatThreadHeader({
               <span className="text-text-muted">
                 · {currentSession.changeSummary.files} file{currentSession.changeSummary.files === 1 ? '' : 's'}
               </span>
+              {currentSession.changeSummary.synthetic && <span className="text-text-muted">est</span>}
             </span>
           )}
           {currentSession?.revertedMessageId && (

--- a/apps/desktop/src/renderer/components/chat/DiffViewer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/DiffViewer.test.tsx
@@ -132,6 +132,25 @@ describe('DiffViewer', () => {
     expect(await screen.findByText('No file changes in this session')).toBeInTheDocument()
   })
 
+  it('labels synthetic fallback diffs as estimated', async () => {
+    installDiffApi({
+      diffResult: [{
+        file: 'generated/report.md',
+        status: 'added',
+        additions: 2,
+        deletions: 0,
+        patch: '@@ -0,0 +1,2 @@\n+# Report\n+Hello',
+        source: 'synthetic',
+        synthetic: true,
+      }],
+    })
+
+    render(<DiffViewer sessionId="session-synthetic" onClose={vi.fn()} />)
+
+    expect(await screen.findByText('estimated')).toBeInTheDocument()
+    expect(screen.getByTitle('Estimated from projected tool output; not an authoritative OpenCode snapshot diff')).toBeInTheDocument()
+  })
+
   it('shows snippet failures inline so collapsed context can be retried', async () => {
     const user = userEvent.setup()
     installDiffApi({ snippetRejects: true })

--- a/apps/desktop/src/renderer/components/chat/DiffViewerRows.tsx
+++ b/apps/desktop/src/renderer/components/chat/DiffViewerRows.tsx
@@ -62,6 +62,7 @@ export const DiffFileRow = memo(function DiffFileRowComponent({
   const hunks = useMemo(() => parseUnifiedPatch(diff.patch), [diff.patch])
   const status = inferStatus(hunks, diff.status)
   const handleClick = useCallback(() => { onToggle(filePath) }, [onToggle, filePath])
+  const isSynthetic = diff.synthetic || diff.source === 'synthetic'
 
   return (
     <div className="border-b" style={{ borderColor: 'var(--color-border-subtle)' }}>
@@ -72,6 +73,14 @@ export const DiffFileRow = memo(function DiffFileRowComponent({
         <div className="flex items-center gap-2 min-w-0">
           <StatusBadge status={status} />
           <span className="text-[12px] font-mono text-text truncate">{diff.file}</span>
+          {isSynthetic && (
+            <span
+              title={t('diff.syntheticTitle', 'Estimated from projected tool output; not an authoritative OpenCode snapshot diff')}
+              className="text-[9px] uppercase tracking-[0.04em] text-text-muted border border-border-subtle rounded px-1 py-px"
+            >
+              {t('diff.estimated', 'estimated')}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2 text-[11px] shrink-0">
           {diff.additions > 0 && <span style={{ color: 'var(--color-green)' }}>+{diff.additions}</span>}

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -342,9 +342,12 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
                     )}
                     {session.changeSummary && session.changeSummary.files > 0 && (
                       <span
-                        title={t('diff.filesChanged', '{{count}} file(s) changed', { count: String(session.changeSummary.files) })}
+                        title={session.changeSummary.synthetic
+                          ? t('diff.estimatedFilesChanged', '{{count}} estimated file(s) changed from projection data', { count: String(session.changeSummary.files) })
+                          : t('diff.filesChanged', '{{count}} file(s) changed', { count: String(session.changeSummary.files) })}
                         className="shrink-0 inline-flex items-center gap-1 text-[9px] leading-none"
                       >
+                        {session.changeSummary.synthetic && <span className="text-text-muted">est</span>}
                         <span style={{ color: 'var(--color-green)' }}>+{session.changeSummary.additions}</span>
                         <span style={{ color: 'var(--color-red)' }}>−{session.changeSummary.deletions}</span>
                       </span>

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -24,7 +24,7 @@ The remaining work is concentrated in two areas:
 ## Verified Baseline
 
 - GitHub code scanning: 0 open alerts on `master` at
-  `920d09dddf45311240a6438375208c65f4eb4aea`.
+  `854fbd0eeaf02cfd3ac5c71836b279cf605c2280`.
 - Dependabot alerts: 0 open alerts at the same point-in-time check.
 - GitHub Actions checks on that `master` SHA were green for deploy, CodeQL,
   build, coverage, validate, docs, cloud-gates, macos-build, and linux-package.
@@ -140,6 +140,10 @@ The remaining work is concentrated in two areas:
 - Workspace SSE reconnects now use retained-stream cursor metadata to detect
   retention gaps and replay only events newer than the client cursor. Gap
   detection no longer loads all retained workspace events from sequence `0`.
+- Product diff fallback rows and aggregate summaries now carry explicit
+  synthetic/mixed provenance when they are inferred from projected tool output
+  instead of OpenCode SDK snapshot diffs, and the diff dialog plus thread
+  summaries label those values as estimated.
 
 ## High Priority
 
@@ -157,9 +161,6 @@ No open high-priority findings remain after the current audit remediations.
   environment drill evidence for hosted promotion.
 - Queue processing needs fairness and backpressure caps across hot sessions,
   gateway deliveries, providers, and bindings.
-- Product diff fallback infers OpenCode tool semantics for write/edit tools.
-  Prefer SDK `session.diff`; if fallback remains, label synthetic summaries as
-  untrusted projection data.
 - History replay still has a large heuristic child-task binding path. Persist
   live binding decisions or require explicit child session ids, keeping
   heuristic replay quarantined as fallback.

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -7,6 +7,8 @@ export interface SessionChangeSummary {
   additions: number
   deletions: number
   files: number
+  source?: 'synthetic' | 'mixed'
+  synthetic?: boolean
 }
 
 // Per-file diff entry, mirroring SDK SnapshotFileDiff. `patch` is a unified
@@ -17,6 +19,10 @@ export interface SessionFileDiff {
   additions: number
   deletions: number
   status?: 'added' | 'deleted' | 'modified'
+  // Synthetic entries are inferred by Open Cowork from projected tool outputs
+  // when SDK snapshot diffs are unavailable for a written file.
+  source?: 'sdk' | 'synthetic'
+  synthetic?: boolean
 }
 
 export interface SessionInfo {

--- a/packages/shared/src/threads.ts
+++ b/packages/shared/src/threads.ts
@@ -156,6 +156,7 @@ export interface ThreadIndexUpsertInput {
   changeFiles?: number
   changeAdditions?: number
   changeDeletions?: number
+  changeSource?: 'synthetic' | 'mixed' | null
   /**
    * Omit actual metadata arrays when an update is record-only and should
    * preserve the existing sidecar metadata. Pass an empty array only when the

--- a/tests/session-diff-fallback.test.ts
+++ b/tests/session-diff-fallback.test.ts
@@ -62,6 +62,8 @@ test('buildSyntheticSessionDiffs turns write artifacts into added-file diffs', (
     assert.equal(diffs.length, 1)
     assert.equal(diffs[0]?.file, 'report.md')
     assert.equal(diffs[0]?.status, 'added')
+    assert.equal(diffs[0]?.source, 'synthetic')
+    assert.equal(diffs[0]?.synthetic, true)
     assert.equal(diffs[0]?.deletions, 0)
     assert.equal(diffs[0]?.additions, 3)
     assert.match(diffs[0]?.patch || '', /^@@ -0,0 \+1,3 @@/)
@@ -128,6 +130,8 @@ test('mergeSessionDiffsWithSynthetic appends write-only files without duplicatin
 
     assert.equal(merged.length, 2)
     assert.deepEqual(merged.map((diff) => diff.file), ['existing.md', 'report.md'])
+    assert.equal(merged[0]?.source, undefined)
+    assert.equal(merged[1]?.source, undefined)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -158,12 +162,13 @@ test('normalizeSessionFileDiffs drops SDK entries without file paths', () => {
       patch: '@@ -1,1 +1,1 @@',
       additions: 1,
       deletions: 0,
+      source: 'sdk',
       status: 'modified',
     },
   ])
 })
 
-test('summarizeSessionDiffs returns aggregate sidebar stats', () => {
+test('summarizeSessionDiffs returns authoritative aggregate sidebar stats', () => {
   assert.deepEqual(summarizeSessionDiffs([
     {
       file: 'a.md',
@@ -185,4 +190,50 @@ test('summarizeSessionDiffs returns aggregate sidebar stats', () => {
     files: 2,
   })
   assert.equal(summarizeSessionDiffs([]), null)
+})
+
+test('summarizeSessionDiffs labels synthetic and mixed projection fallback stats', () => {
+  assert.deepEqual(summarizeSessionDiffs([
+    {
+      file: 'generated.md',
+      patch: '',
+      additions: 2,
+      deletions: 0,
+      status: 'added',
+      source: 'synthetic',
+      synthetic: true,
+    },
+  ]), {
+    additions: 2,
+    deletions: 0,
+    files: 1,
+    source: 'synthetic',
+    synthetic: true,
+  })
+
+  assert.deepEqual(summarizeSessionDiffs([
+    {
+      file: 'real.md',
+      patch: '',
+      additions: 1,
+      deletions: 1,
+      status: 'modified',
+      source: 'sdk',
+    },
+    {
+      file: 'generated.md',
+      patch: '',
+      additions: 2,
+      deletions: 0,
+      status: 'added',
+      source: 'synthetic',
+      synthetic: true,
+    },
+  ]), {
+    additions: 3,
+    deletions: 1,
+    files: 2,
+    source: 'mixed',
+    synthetic: true,
+  })
 })

--- a/tests/session-history-loader.test.ts
+++ b/tests/session-history-loader.test.ts
@@ -930,6 +930,8 @@ test('createSessionHistoryService synthesizes changeSummary for write-only sessi
         additions: 3,
         deletions: 0,
         files: 1,
+        source: 'synthetic',
+        synthetic: true,
       },
     })
   } finally {

--- a/tests/session-registry-utils.test.ts
+++ b/tests/session-registry-utils.test.ts
@@ -86,3 +86,28 @@ test('normalizeStoredSessionRecord preserves session usage agent breakdowns', ()
     tokens: { input: 10, output: 20, reasoning: 3, cacheRead: 4, cacheWrite: 5 },
   }])
 })
+
+test('normalizeStoredSessionRecord preserves synthetic diff summary provenance', () => {
+  const record = normalizeStoredSessionRecord({
+    id: 'ses_changes',
+    opencodeDirectory: '/runtime-home',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:01.000Z',
+    managedByCowork: true,
+    changeSummary: {
+      files: 2,
+      additions: 10,
+      deletions: 1,
+      source: 'mixed',
+      synthetic: true,
+    },
+  }, (value) => value, () => null)
+
+  assert.deepEqual(record?.changeSummary, {
+    files: 2,
+    additions: 10,
+    deletions: 1,
+    source: 'mixed',
+    synthetic: true,
+  })
+})

--- a/tests/thread-index-service.test.ts
+++ b/tests/thread-index-service.test.ts
@@ -67,7 +67,7 @@ test('thread index service reconciles registry rows and removes orphans', () => 
     opencodeDirectory: '/workspace/revenue',
     providerId: 'openrouter',
     modelId: 'openrouter/sonnet',
-    changeSummary: { files: 2, additions: 10, deletions: 1 },
+    changeSummary: { files: 2, additions: 10, deletions: 1, source: 'mixed', synthetic: true },
   }))
   const second = upsertSessionRecord(toSessionRecord({
     id: 'session-b',
@@ -86,6 +86,8 @@ test('thread index service reconciles registry rows and removes orphans', () => 
   assert.equal(result.threads.length, 2)
   assert.equal(result.threads[0]!.providerId, 'codex')
   assert.equal(result.threads[1]!.changeSummary?.files, 2)
+  assert.equal(result.threads[1]!.changeSummary?.source, 'mixed')
+  assert.equal(result.threads[1]!.changeSummary?.synthetic, true)
 
   const renamed = updateSessionRecord('session-a', { title: 'Renamed revenue', updatedAt: '2026-01-05T00:00:00.000Z' })
   assert.ok(renamed)

--- a/tests/thread-index-store.test.ts
+++ b/tests/thread-index-store.test.ts
@@ -64,7 +64,7 @@ test('thread index store searches, facets, and cursor-pages 5k seeded threads', 
       }
     }
   }
-  assert.equal(THREAD_INDEX_SCHEMA_VERSION, 1)
+  assert.equal(THREAD_INDEX_SCHEMA_VERSION, 2)
 }))
 
 test('thread index store keeps user tags, smart filters, and suggestions separate', () => withStore('tags', (store) => {
@@ -78,6 +78,10 @@ test('thread index store keeps user tags, smart filters, and suggestions separat
     status: 'idle',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-02T00:00:00.000Z',
+    changeFiles: 1,
+    changeAdditions: 2,
+    changeDeletions: 0,
+    changeSource: 'synthetic',
     actualAgents: [{ name: 'research', count: 1 }],
     actualTools: [{ name: 'charts.create', mcpName: 'charts', count: 1 }],
   })
@@ -103,6 +107,13 @@ test('thread index store keeps user tags, smart filters, and suggestions separat
   const tagged = store.searchThreads({ tagIds: [tag.id] })
   assert.equal(tagged.threads.length, 1)
   assert.equal(tagged.threads[0]!.tags[0]!.name, 'Revenue')
+  assert.deepEqual(tagged.threads[0]!.changeSummary, {
+    files: 1,
+    additions: 2,
+    deletions: 0,
+    source: 'synthetic',
+    synthetic: true,
+  })
   assert.equal(tagged.threads[0]!.actualTools[0]!.name, 'charts.create')
   assert.equal(tagged.threads[0]!.suggestions[0]!.label, 'reporting')
 


### PR DESCRIPTION
## Summary
- mark SDK and synthetic session diff rows with explicit provenance
- persist aggregate synthetic/mixed summary provenance through the session registry and thread index
- label estimated projection-derived changes in the diff dialog, thread header, and sidebar
- update the production-readiness audit to close the diff fallback provenance item

## Validation
- node --no-warnings --experimental-strip-types --test tests/session-diff-fallback.test.ts tests/session-registry-utils.test.ts tests/thread-index-store.test.ts tests/thread-index-service.test.ts
- PATH=/Users/joe/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/vitest run --config vitest.renderer.config.ts src/renderer/components/chat/DiffViewer.test.tsx (from apps/desktop)
- apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.main.json --noEmit
- apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.json --noEmit
- node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit
- node scripts/lint.mjs
- node_modules/.bin/eslint . --max-warnings 0
- node scripts/build-docs-mermaid-vendor.mjs --check
- node scripts/check-preload-channels.mjs
- node scripts/check-shared-dist.mjs
- git diff --check

## Review
- Focused sidecar review found no actionable production issues in the provenance tagging changes.
