### PR TITLE
Fail closed when workspace support is unavailable

### DIFF
--- a/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { useSessionStore } from '../../stores/session'
-import { WORKSPACE_SUPPORT_APIS, useWorkspaceSupportStore } from '../../stores/workspace-support'
+import { WORKSPACE_SUPPORT_APIS, unavailableWorkspaceSupport, useWorkspaceSupportStore } from '../../stores/workspace-support'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { ChatInput } from './ChatInput'
 
@@ -348,6 +348,26 @@ describe('ChatInput', () => {
       )
     })
     expect(api.session.setComposerPreferences).not.toHaveBeenCalled()
+  })
+
+  it('fails closed for cloud prompt submission when workspace support cannot load', async () => {
+    const api = installModelRuntime()
+    seedCloudSession()
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: { 'cloud:test': unavailableWorkspaceSupport('support failed') },
+      loadedByWorkspace: { 'cloud:test': true },
+      loadingByWorkspace: {},
+      errorByWorkspace: { 'cloud:test': 'support failed' },
+    })
+
+    render(<ChatInput />)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Continue in cloud' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(api.session.prompt).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('support failed')
   })
 
   it('does not let a stale failed composer save roll back the latest reasoning choice', async () => {

--- a/apps/desktop/src/renderer/components/chat/SessionArtifactList.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionArtifactList.tsx
@@ -26,12 +26,16 @@ export function SessionArtifactList({
   sessionId,
   artifacts,
   workspaceId,
+  canDownloadArtifact = true,
+  downloadDisabledReason = 'Artifact downloads are disabled by this workspace policy.',
   canRevealArtifact = true,
   revealDisabledReason = 'Cloud artifacts cannot be revealed in the local filesystem.',
 }: {
   sessionId: string
   artifacts: ReturnType<typeof listSessionArtifacts>
   workspaceId?: string
+  canDownloadArtifact?: boolean
+  downloadDisabledReason?: string
   canRevealArtifact?: boolean
   revealDisabledReason?: string
 }) {
@@ -65,6 +69,13 @@ export function SessionArtifactList({
 
   useEffect(() => {
     let cancelled = false
+
+    if (!canDownloadArtifact) {
+      setPreviewStates({})
+      return () => {
+        cancelled = true
+      }
+    }
 
     for (const artifact of artifacts) {
       if (!isPreviewableArtifact(artifact)) continue
@@ -103,7 +114,7 @@ export function SessionArtifactList({
     return () => {
       cancelled = true
     }
-  }, [artifacts, sessionId])
+  }, [artifacts, canDownloadArtifact, sessionId, workspaceId])
 
   if (artifacts.length === 0) {
     return (
@@ -118,6 +129,9 @@ export function SessionArtifactList({
       {artifacts.map((artifact) => {
         const previewState = previewStates[artifact.id]
         const showPreview = isPreviewableArtifact(artifact)
+        const bodyActionsBlocked = !canDownloadArtifact
+        const bodyActionTitle = bodyActionsBlocked ? downloadDisabledReason : undefined
+        const actionClassName = 'px-2.5 py-1.5 rounded-lg border border-border-subtle text-[11px] text-text-secondary hover:text-text hover:bg-surface-hover transition-colors cursor-pointer whitespace-nowrap disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-text-secondary'
 
         return (
           <div
@@ -135,7 +149,7 @@ export function SessionArtifactList({
                     />
                   ) : (
                     <div className="flex h-16 w-full items-center justify-center px-2 text-center text-[10px] font-medium text-text-muted">
-                      {previewState?.status === 'failed' ? 'Preview unavailable' : 'Loading preview…'}
+                      {bodyActionsBlocked ? 'Preview disabled' : previewState?.status === 'failed' ? 'Preview unavailable' : 'Loading preview…'}
                     </div>
                   )}
                 </div>
@@ -156,6 +170,7 @@ export function SessionArtifactList({
             <div className="mt-3 flex flex-wrap gap-2">
               <button
                 onClick={async () => {
+                  if (bodyActionsBlocked) return
                   try {
                     setComposerAction({ artifactId: artifact.id, mode: 'send' })
                     const payload = await window.coworkApi.artifact.readAttachment({
@@ -170,7 +185,9 @@ export function SessionArtifactList({
                     setComposerAction(null)
                   }
                 }}
-                className="px-2.5 py-1.5 rounded-lg border border-border-subtle text-[11px] text-text-secondary hover:text-text hover:bg-surface-hover transition-colors cursor-pointer whitespace-nowrap"
+                disabled={bodyActionsBlocked || composerAction !== null}
+                title={bodyActionTitle}
+                className={actionClassName}
               >
                 {composerAction?.artifactId === artifact.id && composerAction.mode === 'send' ? 'Sending…' : 'Send to thread'}
               </button>
@@ -178,6 +195,7 @@ export function SessionArtifactList({
               {artifact.chart ? (
                 <button
                   onClick={async () => {
+                    if (bodyActionsBlocked) return
                     try {
                       setComposerAction({ artifactId: artifact.id, mode: 'rerender' })
                       const payload = await window.coworkApi.artifact.readAttachment({
@@ -193,7 +211,9 @@ export function SessionArtifactList({
                       setComposerAction(null)
                     }
                   }}
-                  className="px-2.5 py-1.5 rounded-lg border border-border-subtle text-[11px] text-text-secondary hover:text-text hover:bg-surface-hover transition-colors cursor-pointer whitespace-nowrap"
+                  disabled={bodyActionsBlocked || composerAction !== null}
+                  title={bodyActionTitle}
+                  className={actionClassName}
                 >
                   {composerAction?.artifactId === artifact.id && composerAction.mode === 'rerender' ? 'Preparing…' : 'Rerender'}
                 </button>
@@ -220,6 +240,7 @@ export function SessionArtifactList({
 
               <button
                 onClick={async () => {
+                  if (bodyActionsBlocked) return
                   try {
                     setExportingId(artifact.id)
                     await window.coworkApi.artifact.export({
@@ -232,7 +253,9 @@ export function SessionArtifactList({
                     setExportingId(null)
                   }
                 }}
-                className="px-2.5 py-1.5 rounded-lg border border-border-subtle text-[11px] text-text-secondary hover:text-text hover:bg-surface-hover transition-colors cursor-pointer whitespace-nowrap"
+                disabled={bodyActionsBlocked || exportingId === artifact.id}
+                title={bodyActionTitle}
+                className={actionClassName}
               >
                 {exportingId === artifact.id ? 'Saving...' : 'Save As…'}
               </button>

--- a/apps/desktop/src/renderer/components/chat/SessionInspector.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionInspector.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SessionArtifact, SessionView, TaskRun } from '@open-cowork/shared'
 import { useSessionStore } from '../../stores/session'
+import { sessionWorkspaceKey } from '../../stores/session-workspace-keys'
+import { unavailableWorkspaceSupport, useWorkspaceSupportStore } from '../../stores/workspace-support'
 import { installRendererTestCoworkApi } from '../../test/setup'
 import { COMPOSER_COMPOSE_EVENT } from './composer-events'
 import { SessionInspector } from './SessionInspector'
@@ -103,6 +105,7 @@ function resetStore(options: {
   artifacts?: SessionArtifact[]
 } = {}) {
   useSessionStore.setState({
+    activeWorkspaceId: 'local',
     sessions: [
       {
         id: 'session-1',
@@ -179,6 +182,12 @@ function installInspectorApi() {
 beforeEach(() => {
   vi.clearAllMocks()
   resetStore()
+  useWorkspaceSupportStore.setState({
+    supportByWorkspace: {},
+    loadedByWorkspace: {},
+    loadingByWorkspace: {},
+    errorByWorkspace: {},
+  })
   installInspectorApi()
 })
 
@@ -301,5 +310,48 @@ describe('SessionInspector', () => {
       suggestedName: 'chart.png',
     })
     window.removeEventListener(COMPOSER_COMPOSE_EVENT, onComposerEvent)
+  })
+
+  it('fails closed for artifact actions when workspace support cannot load', async () => {
+    const user = userEvent.setup()
+    const chartArtifact: SessionArtifact = {
+      id: 'chart-artifact',
+      toolId: 'tool-chart',
+      toolName: 'chart',
+      filePath: '/tmp/chart.png',
+      filename: 'chart.png',
+      order: 10,
+      mime: 'image/png',
+      chart: {
+        format: 'vega-lite',
+        spec: { mark: 'bar' },
+        title: 'Revenue',
+      },
+    }
+    useSessionStore.setState({
+      activeWorkspaceId: 'cloud:test',
+      chartArtifactsBySession: {
+        [sessionWorkspaceKey('cloud:test', 'session-1')]: [chartArtifact],
+      },
+    })
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: { 'cloud:test': unavailableWorkspaceSupport('support failed') },
+      loadedByWorkspace: { 'cloud:test': true },
+      loadingByWorkspace: {},
+      errorByWorkspace: { 'cloud:test': 'support failed' },
+    })
+    const api = installInspectorApi()
+
+    render(<SessionInspector onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'Artifacts' }))
+    expect(await screen.findByText('chart.png')).toBeInTheDocument()
+    expect(screen.getByText('Preview disabled')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Send to thread' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Rerender' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save As…' })).toBeDisabled()
+    expect(screen.getByText('Reveal disabled')).toHaveAttribute('title', 'support failed')
+    expect(api.artifact.readAttachment).not.toHaveBeenCalled()
+    expect(api.artifact.export).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/components/chat/SessionInspector.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionInspector.tsx
@@ -394,6 +394,8 @@ export function SessionInspector({ onClose }: InspectorProps) {
                 sessionId={currentSessionId}
                 artifacts={artifacts}
                 workspaceId={activeWorkspaceIsLocal ? undefined : activeWorkspaceId}
+                canDownloadArtifact={workspaceSupport.flags.canDownloadArtifact}
+                downloadDisabledReason={workspaceSupport.flags.reasons.downloadArtifact}
                 canRevealArtifact={workspaceSupport.flags.canRevealArtifact}
                 revealDisabledReason={workspaceSupport.flags.reasons.revealArtifact}
               />

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CoworkAPI, EffectiveAppSettings, WorkflowListPayload } from '@open-cowork/shared'
 import { WorkflowsPage } from './WorkflowsPage'
 import { useSessionStore } from '../../stores/session'
-import { WORKSPACE_SUPPORT_APIS, useWorkspaceSupportStore } from '../../stores/workspace-support'
+import { WORKSPACE_SUPPORT_APIS, unavailableWorkspaceSupport, useWorkspaceSupportStore } from '../../stores/workspace-support'
 
 function payload(overrides: Partial<WorkflowListPayload> = {}): WorkflowListPayload {
   return {
@@ -182,6 +182,24 @@ describe('WorkflowsPage', () => {
 
     expect(api.workflows?.runNow).toHaveBeenCalledWith('workflow-1', { workspaceId: 'cloud:test' })
     await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith('ses_run'))
+  })
+
+  it('fails closed for cloud workflow access when workspace support cannot load', async () => {
+    useSessionStore.setState({ activeWorkspaceId: 'cloud:test' })
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: { 'cloud:test': unavailableWorkspaceSupport('support failed') },
+      loadedByWorkspace: { 'cloud:test': true },
+      loadingByWorkspace: {},
+      errorByWorkspace: { 'cloud:test': 'support failed' },
+    })
+    const { api } = installApi()
+
+    render(<WorkflowsPage onOpenThread={vi.fn()} />)
+
+    expect(await screen.findByText('No workflows yet')).toBeInTheDocument()
+    expect(screen.getByText('support failed')).toBeInTheDocument()
+    expect(api.workflows?.list).not.toHaveBeenCalled()
+    expect(api.workflows?.runNow).not.toHaveBeenCalled()
   })
 
   it('copies webhook invocation without putting the secret in the URL', async () => {

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
@@ -85,6 +85,8 @@ export function WorkflowsPage({ onOpenThread }: Props) {
   const workspaceSupport = useActiveWorkspaceSupport()
   const activeWorkspaceIsLocal = workspaceSupport.workspaceId === LOCAL_WORKSPACE_ID
   const workspaceOptions = activeWorkspaceIsLocal ? undefined : { workspaceId: workspaceSupport.workspaceId }
+  const workflowListBlocked = !workspaceSupport.flags.canListWorkflows
+  const workflowListReason = workflowListBlocked ? workspaceSupport.flags.reasons.listWorkflows : null
 
   const activeWorkflows = useMemo(
     () => payload.workflows.filter((workflow) => workflow.status !== 'archived'),
@@ -95,6 +97,10 @@ export function WorkflowsPage({ onOpenThread }: Props) {
   const refresh = async () => {
     setLoading(true)
     try {
+      if (workflowListBlocked) {
+        setPayload(EMPTY_PAYLOAD)
+        return
+      }
       setPayload(activeWorkspaceIsLocal
         ? await window.coworkApi.workflows.list()
         : await window.coworkApi.workflows.list(workspaceOptions))
@@ -116,7 +122,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
     return window.coworkApi.on.workflowUpdated(() => {
       void refresh()
     })
-  }, [workspaceOptions?.workspaceId])
+  }, [workflowListBlocked, workspaceOptions?.workspaceId])
   const workflowDraftBlocked = !activeWorkspaceIsLocal || runtimeConfigSource === 'machine'
   const workflowActionBlocked = !workspaceSupport.flags.canRunWorkflow
   const workflowActionReason = workflowActionBlocked ? workspaceSupport.flags.reasons.runWorkflow : null
@@ -211,7 +217,9 @@ export function WorkflowsPage({ onOpenThread }: Props) {
             <div>
               <h2 className="text-lg font-semibold text-primary">No workflows yet</h2>
               <p className="mt-2 max-w-md text-sm text-muted">
-                {workflowDraftBlocked
+                {workflowListBlocked && workflowListReason
+                  ? workflowListReason
+                  : workflowDraftBlocked
                   ? activeWorkspaceIsLocal
                     ? 'Workflow setup requires the in-app OpenCode config source because it uses Cowork’s Workflow Designer agent and Workflows tool.'
                     : 'Cloud workflow creation is managed by the cloud workspace. Existing workflows will appear here when available.'

--- a/apps/desktop/src/renderer/stores/workspace-support.test.ts
+++ b/apps/desktop/src/renderer/stores/workspace-support.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  WORKSPACE_SUPPORT_APIS,
+  deriveWorkspaceSupportFlags,
+  supportAllows,
+  unavailableWorkspaceSupport,
+  useWorkspaceSupportStore,
+} from './workspace-support'
+import { LOCAL_WORKSPACE_ID } from './session-workspace-keys'
+
+function resetWorkspaceSupportStore() {
+  useWorkspaceSupportStore.setState({
+    supportByWorkspace: {},
+    loadedByWorkspace: {},
+    loadingByWorkspace: {},
+    errorByWorkspace: {},
+  })
+}
+
+function installWorkspaceSupportLoader(support: (workspaceId: string) => Promise<unknown>) {
+  Object.defineProperty(window, 'coworkApi', {
+    value: {
+      workspace: {
+        support,
+      },
+    },
+    configurable: true,
+  })
+}
+
+describe('workspace support store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetWorkspaceSupportStore()
+  })
+
+  it('treats missing support entries as denied capabilities', () => {
+    const flags = deriveWorkspaceSupportFlags([])
+
+    expect(supportAllows(undefined)).toBe(false)
+    expect(flags.canCreateSession).toBe(false)
+    expect(flags.canPrompt).toBe(false)
+    expect(flags.canRunWorkflow).toBe(false)
+    expect(flags.canDownloadArtifact).toBe(false)
+    expect(flags.canRevealArtifact).toBe(false)
+  })
+
+  it('builds a complete fail-closed support payload when policy is unavailable', () => {
+    const support = unavailableWorkspaceSupport('support unavailable')
+    const flags = deriveWorkspaceSupportFlags(support)
+
+    expect(support.map((entry) => entry.api)).toEqual([...WORKSPACE_SUPPORT_APIS])
+    expect(support.every((entry) => entry.status === 'blocked_by_policy')).toBe(true)
+    expect(support.every((entry) => entry.verdict?.allowed === false)).toBe(true)
+    expect(flags.canPrompt).toBe(false)
+    expect(flags.canRunWorkflow).toBe(false)
+    expect(flags.canDownloadArtifact).toBe(false)
+    expect(flags.canRevealArtifact).toBe(false)
+    expect(flags.reasons.prompt).toBe('support unavailable')
+    expect(flags.reasons.runWorkflow).toBe('support unavailable')
+    expect(flags.reasons.downloadArtifact).toBe('support unavailable')
+  })
+
+  it('fails closed when a non-local support load rejects', async () => {
+    const supportLoader = vi.fn(async () => {
+      throw new Error('support service unavailable')
+    })
+    installWorkspaceSupportLoader(supportLoader)
+
+    const support = await useWorkspaceSupportStore.getState().loadWorkspaceSupport('cloud:test')
+    const flags = deriveWorkspaceSupportFlags(support)
+    const state = useWorkspaceSupportStore.getState()
+
+    expect(supportLoader).toHaveBeenCalledWith('cloud:test')
+    expect(support).toHaveLength(WORKSPACE_SUPPORT_APIS.length)
+    expect(support.every((entry) => entry.status === 'blocked_by_policy')).toBe(true)
+    expect(flags.canPrompt).toBe(false)
+    expect(flags.canRunWorkflow).toBe(false)
+    expect(flags.canDownloadArtifact).toBe(false)
+    expect(flags.canRevealArtifact).toBe(false)
+    expect(flags.reasons.prompt).toBe('support service unavailable')
+    expect(state.loadedByWorkspace['cloud:test']).toBe(true)
+    expect(state.loadingByWorkspace['cloud:test']).toBe(false)
+    expect(state.errorByWorkspace['cloud:test']).toBe('support service unavailable')
+  })
+
+  it('fails closed for an empty non-local support payload', async () => {
+    const supportLoader = vi.fn(async () => [])
+    installWorkspaceSupportLoader(supportLoader)
+
+    const support = await useWorkspaceSupportStore.getState().loadWorkspaceSupport('cloud:test')
+    const flags = deriveWorkspaceSupportFlags(support)
+    const state = useWorkspaceSupportStore.getState()
+
+    expect(supportLoader).toHaveBeenCalledWith('cloud:test')
+    expect(support).toHaveLength(WORKSPACE_SUPPORT_APIS.length)
+    expect(support.every((entry) => entry.status === 'blocked_by_policy')).toBe(true)
+    expect(flags.canPrompt).toBe(false)
+    expect(flags.canRunWorkflow).toBe(false)
+    expect(flags.canDownloadArtifact).toBe(false)
+    expect(flags.reasons.prompt).toContain('Workspace support could not be loaded')
+    expect(state.loadedByWorkspace['cloud:test']).toBe(true)
+    expect(state.errorByWorkspace['cloud:test']).toBeNull()
+  })
+
+  it('preserves the implied workspace authority when support is unavailable', async () => {
+    const supportLoader = vi.fn(async () => [])
+    installWorkspaceSupportLoader(supportLoader)
+
+    const gatewaySupport = await useWorkspaceSupportStore.getState().loadWorkspaceSupport('gateway:test')
+    const pairedSupport = await useWorkspaceSupportStore.getState().loadWorkspaceSupport('paired-desktop:device-1')
+
+    expect(deriveWorkspaceSupportFlags(gatewaySupport).authority).toBe('gateway_standalone')
+    expect(deriveWorkspaceSupportFlags(pairedSupport).authority).toBe('desktop_paired')
+  })
+
+  it('keeps local support allowed without calling the support API', async () => {
+    const supportLoader = vi.fn(async () => [])
+    installWorkspaceSupportLoader(supportLoader)
+
+    const support = await useWorkspaceSupportStore.getState().loadWorkspaceSupport(LOCAL_WORKSPACE_ID)
+    const flags = deriveWorkspaceSupportFlags(support)
+
+    expect(supportLoader).not.toHaveBeenCalled()
+    expect(flags.canCreateSession).toBe(true)
+    expect(flags.canPrompt).toBe(true)
+    expect(flags.canRunWorkflow).toBe(true)
+    expect(flags.canDownloadArtifact).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/stores/workspace-support.ts
+++ b/apps/desktop/src/renderer/stores/workspace-support.ts
@@ -37,12 +37,75 @@ function describeSupportError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
 }
 
+const WORKSPACE_SUPPORT_UNAVAILABLE_REASON = 'Workspace support could not be loaded. Mutating and file actions are disabled until policy is available.'
+
+function unavailableSupportAuthorityForWorkspace(workspaceId: string): WorkspaceExecutionAuthority {
+  if (workspaceId.startsWith('gateway:')) return 'gateway_standalone'
+  if (workspaceId.startsWith('paired-desktop:')) return 'desktop_paired'
+  return 'cloud_worker'
+}
+
+function unavailableSupportSurface(authority: WorkspaceExecutionAuthority) {
+  if (authority === 'gateway_standalone') return 'gateway_standalone'
+  if (authority === 'desktop_paired') return 'desktop_paired'
+  if (authority === 'cloud_channel_gateway') return 'cloud_channel_gateway'
+  return 'desktop_cloud'
+}
+
+export function unavailableWorkspaceSupport(
+  reason = WORKSPACE_SUPPORT_UNAVAILABLE_REASON,
+  options: { authority?: WorkspaceExecutionAuthority } = {},
+): WorkspaceApiSupport[] {
+  const authority = options.authority || 'cloud_worker'
+  return WORKSPACE_SUPPORT_APIS.map((api) => {
+    const verdict = {
+      allowed: false,
+      reason,
+      policyCode: 'workspace.policy_unavailable',
+    }
+    return {
+      api,
+      status: 'blocked_by_policy',
+      verdict,
+      context: workspaceApiSupportContextForAuthority(authority, {
+        status: 'blocked_by_policy',
+        surface: unavailableSupportSurface(authority),
+        onlineState: 'error',
+        pathExposure: 'not_exposed',
+        artifactBody: 'none',
+        artifactReveal: 'none',
+        workflows: 'blocked',
+        blockedReason: verdict,
+      }),
+    }
+  })
+}
+
+function supportForWorkspace(
+  workspaceId: string,
+  support: WorkspaceApiSupport[] | undefined,
+  options: { loaded?: boolean; error?: string | null } = {},
+) {
+  if (workspaceId === LOCAL_WORKSPACE_ID) {
+    return support && support.length > 0 ? support : LOCAL_SUPPORT
+  }
+  if (support && support.length > 0) {
+    return support
+  }
+  if (options.loaded || options.error) {
+    return unavailableWorkspaceSupport(options.error || undefined, {
+      authority: unavailableSupportAuthorityForWorkspace(workspaceId),
+    })
+  }
+  return []
+}
+
 export function supportEntry(support: WorkspaceApiSupport[] | undefined, api: string) {
   return (support || []).find((entry) => entry.api === api)
 }
 
 export function supportAllows(entry: WorkspaceApiSupport | undefined, options: { mutation?: boolean } = {}) {
-  if (!entry) return true
+  if (!entry) return false
   if (options.mutation && entry.status !== 'supported') return false
   return entry.status === 'supported' || entry.status === 'read_only' || entry.verdict?.allowed === true
 }
@@ -121,8 +184,9 @@ export const useWorkspaceSupportStore = create<WorkspaceSupportState>((set, get)
   errorByWorkspace: {},
   setWorkspaceSupport: (workspaceId, support) => set((state) => {
     const normalized = normalizeWorkspaceId(workspaceId)
+    const effectiveSupport = supportForWorkspace(normalized, support, { loaded: true })
     return {
-      supportByWorkspace: { ...state.supportByWorkspace, [normalized]: support },
+      supportByWorkspace: { ...state.supportByWorkspace, [normalized]: effectiveSupport },
       loadedByWorkspace: { ...state.loadedByWorkspace, [normalized]: true },
       loadingByWorkspace: { ...state.loadingByWorkspace, [normalized]: false },
       errorByWorkspace: { ...state.errorByWorkspace, [normalized]: null },
@@ -147,22 +211,26 @@ export const useWorkspaceSupportStore = create<WorkspaceSupportState>((set, get)
     }))
     try {
       const support = await window.coworkApi.workspace.support(normalized)
-      get().setWorkspaceSupport(normalized, support)
-      return support
+      const effectiveSupport = supportForWorkspace(normalized, support, { loaded: true })
+      get().setWorkspaceSupport(normalized, effectiveSupport)
+      return effectiveSupport
     } catch (error) {
+      const reason = describeSupportError(error)
+      const support = unavailableWorkspaceSupport(reason)
       set((current) => ({
+        supportByWorkspace: { ...current.supportByWorkspace, [normalized]: support },
         loadedByWorkspace: { ...current.loadedByWorkspace, [normalized]: true },
         loadingByWorkspace: { ...current.loadingByWorkspace, [normalized]: false },
-        errorByWorkspace: { ...current.errorByWorkspace, [normalized]: describeSupportError(error) },
+        errorByWorkspace: { ...current.errorByWorkspace, [normalized]: reason },
       }))
-      return []
+      return support
     }
   },
 }))
 
 export function useActiveWorkspaceSupport() {
   const activeWorkspaceId = useSessionStore((state) => normalizeWorkspaceId(state.activeWorkspaceId))
-  const support = useWorkspaceSupportStore((state) => state.supportByWorkspace[activeWorkspaceId])
+  const rawSupport = useWorkspaceSupportStore((state) => state.supportByWorkspace[activeWorkspaceId])
   const loaded = useWorkspaceSupportStore((state) => state.loadedByWorkspace[activeWorkspaceId] === true)
   const loading = useWorkspaceSupportStore((state) => state.loadingByWorkspace[activeWorkspaceId] === true)
   const error = useWorkspaceSupportStore((state) => state.errorByWorkspace[activeWorkspaceId] || null)
@@ -171,6 +239,11 @@ export function useActiveWorkspaceSupport() {
   useEffect(() => {
     void loadWorkspaceSupport(activeWorkspaceId)
   }, [activeWorkspaceId, loadWorkspaceSupport])
+
+  const support = useMemo(
+    () => supportForWorkspace(activeWorkspaceId, rawSupport, { loaded, error }),
+    [activeWorkspaceId, error, loaded, rawSupport],
+  )
 
   const flags = useMemo(() => {
     const next = deriveWorkspaceSupportFlags(support)
@@ -205,7 +278,7 @@ export function useActiveWorkspaceSupport() {
 
   return {
     workspaceId: activeWorkspaceId,
-    support: support || (activeWorkspaceId === LOCAL_WORKSPACE_ID ? LOCAL_SUPPORT : []),
+    support,
     loaded,
     loading,
     error,


### PR DESCRIPTION
## Summary
- Treat missing, failed, or empty non-local workspace support as an explicit blocked policy payload instead of optimistic allow-by-absence.
- Gate cloud workflow listing and artifact body actions on workspace support flags.
- Add regression coverage for store calculations, ChatInput, WorkflowsPage, and SessionInspector artifact actions.

Closes #655

## Validation
- pnpm --filter @open-cowork/desktop test:renderer -- src/renderer/stores/workspace-support.test.ts src/renderer/components/chat/ChatInput.test.tsx src/renderer/components/workflows/WorkflowsPage.test.tsx src/renderer/components/chat/SessionInspector.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check