### PR TITLE
Harden channel command contracts

### DIFF
--- a/apps/gateway/src/cloud-gateway.test.ts
+++ b/apps/gateway/src/cloud-gateway.test.ts
@@ -9,6 +9,14 @@ test('cloud gateway wraps all required channel and session operations', async ()
   const calls: string[] = []
   let sessionClosed = false
   let deliveriesClosed = false
+  const fence = (commandId: string, sessionId = 'session-1') => ({
+    version: 1,
+    scope: 'session',
+    tenantId: 'tenant-1',
+    sessionId,
+    commandId,
+    issuedAt: '2026-05-27T10:00:00.000Z',
+  })
   const adapter = {
     async resolveChannelIdentity(input: unknown) {
       calls.push(`identity:${JSON.stringify(input)}`)
@@ -28,27 +36,54 @@ test('cloud gateway wraps all required channel and session operations', async ()
     },
     async promptChannelSession(input: unknown) {
       calls.push(`prompt:${JSON.stringify(input)}`)
-      return { binding: { bindingId: 'binding-1' }, command: { commandId: 'cmd-1' }, processed: 1 }
+      return {
+        binding: { bindingId: 'binding-1' },
+        command: { commandId: 'cmd-1' },
+        processed: 1,
+        projectionFence: fence('cmd-1'),
+      }
     },
     async abortSession(sessionId: string) {
       calls.push(`abort:${sessionId}`)
-      return { command: { commandId: 'cmd-abort' }, processed: 1, view: { session: { sessionId }, projection: null } }
+      return {
+        command: { commandId: 'cmd-abort' },
+        processed: 1,
+        view: { session: { sessionId }, projection: null },
+        projectionFence: fence('cmd-abort', sessionId),
+      }
     },
     async respondToPermission(sessionId: string, input: unknown) {
       calls.push(`permission:${sessionId}:${JSON.stringify(input)}`)
-      return { command: { commandId: 'cmd-permission' }, processed: 1 }
+      return {
+        command: { commandId: 'cmd-permission' },
+        processed: 1,
+        projectionFence: fence('cmd-permission', sessionId),
+      }
     },
     async replyToQuestion(sessionId: string, input: unknown) {
       calls.push(`question-reply:${sessionId}:${JSON.stringify(input)}`)
-      return { command: { commandId: 'cmd-reply' }, processed: 1 }
+      return {
+        command: { commandId: 'cmd-reply' },
+        processed: 1,
+        projectionFence: fence('cmd-reply', sessionId),
+      }
     },
     async rejectQuestion(sessionId: string, input: unknown) {
       calls.push(`question-reject:${sessionId}:${JSON.stringify(input)}`)
-      return { command: { commandId: 'cmd-reject' }, processed: 1 }
+      return {
+        command: { commandId: 'cmd-reject' },
+        processed: 1,
+        projectionFence: fence('cmd-reject', sessionId),
+      }
     },
     async resolveChannelInteraction(input: unknown) {
       calls.push(`interaction:${JSON.stringify(input)}`)
-      return { interaction: { interactionId: 'interaction-1' }, command: { commandId: 'cmd-interaction' }, processed: 1 }
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        command: { commandId: 'cmd-interaction' },
+        processed: 1,
+        projectionFence: fence('cmd-interaction'),
+      }
     },
     async createChannelInteraction(input: unknown) {
       calls.push(`interaction-create:${JSON.stringify(input)}`)
@@ -90,12 +125,12 @@ test('cloud gateway wraps all required channel and session operations', async ()
   await gateway.bindSession({ channelBindingId: 'channel-1', provider: 'telegram', externalChatId: 'chat-1', externalThreadId: 'thread-1' })
   await gateway.findSessionByThread({ provider: 'telegram', externalChatId: 'chat-1', externalThreadId: 'thread-1' })
   await gateway.getSession('session-1')
-  await gateway.prompt({ bindingId: 'binding-1', text: 'hello' })
-  await gateway.abortSession('session-1')
-  await gateway.respondToPermission('session-1', { permissionId: 'permission-1', response: { allowed: true } })
-  await gateway.replyToQuestion('session-1', { requestId: 'question-1', answers: ['yes'] })
-  await gateway.rejectQuestion('session-1', { requestId: 'question-2' })
-  await gateway.resolveChannelInteraction({ token: 'token-1', response: { allowed: true } })
+  const prompt = await gateway.prompt({ bindingId: 'binding-1', text: 'hello' })
+  const abort = await gateway.abortSession('session-1')
+  const permission = await gateway.respondToPermission('session-1', { permissionId: 'permission-1', response: { allowed: true } })
+  const reply = await gateway.replyToQuestion('session-1', { requestId: 'question-1', answers: ['yes'] })
+  const reject = await gateway.rejectQuestion('session-1', { requestId: 'question-2' })
+  const interaction = await gateway.resolveChannelInteraction({ token: 'token-1', response: { allowed: true } })
   await gateway.createChannelInteraction({
     agentId: 'agent-1',
     sessionId: 'session-1',
@@ -114,6 +149,12 @@ test('cloud gateway wraps all required channel and session operations', async ()
 
   assert.equal(sessionClosed, true)
   assert.equal(deliveriesClosed, true)
+  assert.equal(prompt.projectionFence?.commandId, 'cmd-1')
+  assert.equal(abort.projectionFence?.commandId, 'cmd-abort')
+  assert.equal(permission.projectionFence?.commandId, 'cmd-permission')
+  assert.equal(reply.projectionFence?.commandId, 'cmd-reply')
+  assert.equal(reject.projectionFence?.commandId, 'cmd-reject')
+  assert.equal(interaction.projectionFence?.commandId, 'cmd-interaction')
   assert.deepEqual(calls.map((call) => call.split(':')[0]), [
     'identity',
     'bind',

--- a/apps/gateway/src/cloud-gateway.ts
+++ b/apps/gateway/src/cloud-gateway.ts
@@ -4,14 +4,17 @@ import {
   type ChannelDeliveryRecord,
   type ChannelIdentityRecord,
   type ChannelSessionBindingRecord,
+  type CloudChannelInteractionMutationResponse,
   type CloudChannelProviderId,
+  type CloudChannelPromptMutationResponse,
+  type CloudSessionCommandAckResponse,
+  type CloudSessionCommandMutationResponse,
   type SessionArtifactAttachment,
   type CloudSessionView,
   type CloudTransportAdapter,
   type CloudTransportSessionEvent,
   type CloudTransportSubscription,
   type IssuedChannelInteractionRecord,
-  type SessionCommandRecord,
 } from '@open-cowork/cloud-client'
 
 import type { GatewayCloudConnectionConfig } from './config.js'
@@ -42,14 +45,14 @@ export type CloudGateway = {
     bindingId: string
     text: string
     agent?: string | null
-  }): Promise<{ binding: ChannelSessionBindingRecord, command: SessionCommandRecord, processed: number }>
+  }): Promise<CloudChannelPromptMutationResponse>
   resolveChannelInteraction(input: ChannelActorInput & {
     token?: string | null
     externalInteractionId?: string | null
     response?: unknown
     answers?: unknown[]
     reject?: boolean
-  }): Promise<{ interaction: unknown, command: SessionCommandRecord, processed: number }>
+  }): Promise<CloudChannelInteractionMutationResponse>
   createChannelInteraction(input: {
     agentId: string
     sessionId: string
@@ -61,19 +64,10 @@ export type CloudGateway = {
     expiresAt?: string | null
     interactionId?: string | null
   }): Promise<IssuedChannelInteractionRecord>
-  abortSession(sessionId: string): Promise<{ command: SessionCommandRecord, processed: number, view: CloudSessionView }>
-  respondToPermission(sessionId: string, input: { permissionId: string, response: unknown }): Promise<{
-    command: SessionCommandRecord
-    processed: number
-  }>
-  replyToQuestion(sessionId: string, input: { requestId: string, answers: unknown[] }): Promise<{
-    command: SessionCommandRecord
-    processed: number
-  }>
-  rejectQuestion(sessionId: string, input: { requestId: string }): Promise<{
-    command: SessionCommandRecord
-    processed: number
-  }>
+  abortSession(sessionId: string): Promise<CloudSessionCommandMutationResponse>
+  respondToPermission(sessionId: string, input: { permissionId: string, response: unknown }): Promise<CloudSessionCommandAckResponse>
+  replyToQuestion(sessionId: string, input: { requestId: string, answers: unknown[] }): Promise<CloudSessionCommandAckResponse>
+  rejectQuestion(sessionId: string, input: { requestId: string }): Promise<CloudSessionCommandAckResponse>
   readArtifactAttachment?(sessionId: string, filePathOrArtifactId: string): Promise<SessionArtifactAttachment>
   artifactUrl(sessionId: string, artifactId: string): string
   subscribeSessionEvents(input: {

--- a/packages/cloud-client/src/adapter.ts
+++ b/packages/cloud-client/src/adapter.ts
@@ -7,6 +7,7 @@ import type {
   CloudProjectSnapshotUploadResult,
   CloudProjectSourceInput,
   CloudProjectSourcePolicyVerdict,
+  CloudProjectionFenceToken,
   CloudSessionProjectionRecord,
   CloudSessionEventType,
   CloudSessionViewRecord,
@@ -36,6 +37,7 @@ export type {
   CloudProjectSnapshotUploadResult,
   CloudProjectSourceInput,
   CloudProjectSourcePolicyVerdict,
+  CloudProjectionFenceToken,
   SessionArtifact,
   SessionArtifactAttachment,
   SessionArtifactUploadRequest,
@@ -552,6 +554,33 @@ export type CloudTransportSettingMetadata = {
   updatedAt: string
 }
 
+export type CloudSessionCommandMutationResponse = {
+  command: SessionCommandRecord
+  processed: number
+  view: CloudSessionView
+  projectionFence?: CloudProjectionFenceToken | null
+}
+
+export type CloudSessionCommandAckResponse = {
+  command: SessionCommandRecord
+  processed: number
+  projectionFence?: CloudProjectionFenceToken | null
+}
+
+export type CloudChannelPromptMutationResponse = {
+  binding: ChannelSessionBindingRecord
+  command: SessionCommandRecord
+  processed: number
+  projectionFence?: CloudProjectionFenceToken | null
+}
+
+export type CloudChannelInteractionMutationResponse = {
+  interaction: ChannelInteractionRecord
+  command: SessionCommandRecord
+  processed: number
+  projectionFence?: CloudProjectionFenceToken | null
+}
+
 export type CloudTransportAdapter = {
   getConfig(): Promise<CloudTransportConfig>
   getWorkspace(): Promise<CloudWorkspaceOverview>
@@ -563,24 +592,11 @@ export type CloudTransportAdapter = {
   uploadProjectSnapshot(input: CloudProjectSnapshotUploadInput): Promise<CloudProjectSnapshotUploadResult>
   importSession(input: SessionImportRequest): Promise<CloudSessionView>
   getSession(sessionId: string): Promise<CloudSessionView>
-  promptSession(sessionId: string, input: { text: string, agent?: string | null }): Promise<{
-    command: SessionCommandRecord
-    processed: number
-    view: CloudSessionView
-  }>
-  abortSession(sessionId: string): Promise<{ command: SessionCommandRecord, processed: number, view: CloudSessionView }>
-  replyToQuestion(sessionId: string, input: { requestId: string, answers: unknown[] }): Promise<{
-    command: SessionCommandRecord
-    processed: number
-  }>
-  rejectQuestion(sessionId: string, input: { requestId: string }): Promise<{
-    command: SessionCommandRecord
-    processed: number
-  }>
-  respondToPermission(sessionId: string, input: { permissionId: string, response: unknown }): Promise<{
-    command: SessionCommandRecord
-    processed: number
-  }>
+  promptSession(sessionId: string, input: { text: string, agent?: string | null }): Promise<CloudSessionCommandMutationResponse>
+  abortSession(sessionId: string): Promise<CloudSessionCommandMutationResponse>
+  replyToQuestion(sessionId: string, input: { requestId: string, answers: unknown[] }): Promise<CloudSessionCommandAckResponse>
+  rejectQuestion(sessionId: string, input: { requestId: string }): Promise<CloudSessionCommandAckResponse>
+  respondToPermission(sessionId: string, input: { permissionId: string, response: unknown }): Promise<CloudSessionCommandAckResponse>
   listWorkflows?(): Promise<WorkflowListPayload>
   getWorkflow?(workflowId: string): Promise<WorkflowDetail | null>
   runWorkflow?(workflowId: string, input?: { triggerType?: WorkflowTriggerType, triggerPayload?: Record<string, unknown> | null }): Promise<WorkflowRun | null>
@@ -695,7 +711,7 @@ export type CloudTransportAdapter = {
     bindingId: string
     text: string
     agent?: string | null
-  }): Promise<{ binding: ChannelSessionBindingRecord, command: SessionCommandRecord, processed: number }>
+  }): Promise<CloudChannelPromptMutationResponse>
   updateChannelCursor?(input: {
     bindingId: string
     lastEventSequence: number
@@ -719,7 +735,7 @@ export type CloudTransportAdapter = {
     response?: unknown
     answers?: unknown[]
     reject?: boolean
-  }): Promise<{ interaction: ChannelInteractionRecord, command: SessionCommandRecord, processed: number }>
+  }): Promise<CloudChannelInteractionMutationResponse>
   createChannelDelivery?(input: {
     agentId: string
     channelBindingId: string

--- a/packages/gateway-provider-slack/src/slack-provider.test.ts
+++ b/packages/gateway-provider-slack/src/slack-provider.test.ts
@@ -103,6 +103,71 @@ describe("SlackProvider", () => {
     expect(messages).toHaveLength(1);
   });
 
+  it("releases replay claims when message handler dispatch fails", async () => {
+    const messages: IncomingChannelMessage[] = [];
+    const provider = new SlackProvider({
+      botToken: "xoxb-test",
+      signingSecret,
+      now: () => fixedNow,
+    });
+    let attempts = 0;
+    await provider.start(async (message) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("store offline");
+      messages.push(message);
+    });
+    const payload = slackMessagePayload("T123", "C123", "1716984000.000200", "hello");
+    const rawBody = JSON.stringify(payload);
+    const headers = signedHeaders(rawBody);
+
+    await expect(provider.handleWebhookPayload(payload, { headers, rawBody })).rejects.toThrow("store offline");
+    await provider.handleWebhookPayload(payload, { headers, rawBody });
+    await expect(provider.handleWebhookPayload(payload, { headers, rawBody })).rejects.toThrow("replay");
+
+    expect(attempts).toBe(2);
+    expect(messages).toHaveLength(1);
+  });
+
+  it("does not release newer replay claims from older handler failures", async () => {
+    const messages: IncomingChannelMessage[] = [];
+    const provider = new SlackProvider({
+      botToken: "xoxb-test",
+      signingSecret,
+      now: () => fixedNow,
+      maxSeenWebhookSignatures: 1,
+    });
+    let firstAttempts = 0;
+    let failOriginalFirst: (error: Error) => void = () => {};
+    await provider.start(async (message) => {
+      if (message.text === "first") {
+        firstAttempts += 1;
+        if (firstAttempts === 1) {
+          await new Promise<void>((_, reject) => {
+            failOriginalFirst = reject;
+          });
+          return;
+        }
+      }
+      messages.push(message);
+    });
+    const firstPayload = slackMessagePayload("T123", "C123", "1716984000.000200", "first");
+    const secondPayload = slackMessagePayload("T123", "C123", "1716984000.000201", "second");
+    const firstRawBody = JSON.stringify(firstPayload);
+    const firstHeaders = signedHeaders(firstRawBody);
+
+    const originalFirst = provider.handleWebhookPayload(firstPayload, { headers: firstHeaders, rawBody: firstRawBody });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const secondRawBody = JSON.stringify(secondPayload);
+    await provider.handleWebhookPayload(secondPayload, { headers: signedHeaders(secondRawBody), rawBody: secondRawBody });
+    await provider.handleWebhookPayload(firstPayload, { headers: firstHeaders, rawBody: firstRawBody });
+    failOriginalFirst(new Error("store offline"));
+    await expect(originalFirst).rejects.toThrow("store offline");
+    await expect(provider.handleWebhookPayload(firstPayload, { headers: firstHeaders, rawBody: firstRawBody })).rejects.toThrow("replay");
+
+    expect(messages.map((message) => message.text)).toEqual(["second", "first"]);
+  });
+
   it("keeps replay eviction scoped by Slack team", async () => {
     const messages: IncomingChannelMessage[] = [];
     const provider = new SlackProvider({

--- a/packages/gateway-provider-slack/src/slack-provider.ts
+++ b/packages/gateway-provider-slack/src/slack-provider.ts
@@ -65,6 +65,11 @@ type SeenSlackWebhookSignature = {
   scope: string;
 };
 
+type SlackWebhookReplayClaim = {
+  key: string;
+  entry: SeenSlackWebhookSignature;
+};
+
 export class SlackProvider implements ChannelProvider {
   readonly kind: ChannelProviderKind = "slack";
   readonly id: ChannelProviderId;
@@ -111,17 +116,23 @@ export class SlackProvider implements ChannelProvider {
   }
 
   async handleWebhookPayload(payload: unknown, auth: SlackWebhookAuth): Promise<SlackWebhookResult | void> {
-    this.assertWebhookAuthorized(auth);
+    const replayClaim = this.assertWebhookAuthorized(auth);
     const record = objectRecord(payload);
     if (record.type === "url_verification") {
       const challenge = stringField(record, "challenge");
       return challenge ? { challenge } : undefined;
     }
 
-    if (!this.handler) throw new Error("Slack provider is not started.");
     const message = mapSlackPayload(record, this.config.now?.() ?? new Date(), this.id);
-    if (message) await this.handler(message);
-    return undefined;
+    if (!message) return undefined;
+    try {
+      if (!this.handler) throw new Error("Slack provider is not started.");
+      await this.handler(message);
+      return undefined;
+    } catch (error) {
+      if (replayClaim) this.releaseWebhookReplayClaim(replayClaim);
+      throw error;
+    }
   }
 
   async sendText(target: ChannelTarget, text: string, options?: SendOptions): Promise<SentMessage> {
@@ -209,8 +220,8 @@ export class SlackProvider implements ChannelProvider {
     return new Uint8Array(await response.arrayBuffer());
   }
 
-  private assertWebhookAuthorized(auth: SlackWebhookAuth): void {
-    if (auth.verified === true) return;
+  private assertWebhookAuthorized(auth: SlackWebhookAuth): SlackWebhookReplayClaim | null {
+    if (auth.verified === true) return null;
     const signingSecret = auth.signingSecret || this.config.signingSecret;
     const rawBody = auth.rawBody || "";
     const timestamp = headerValue(auth.headers, "x-slack-request-timestamp");
@@ -229,18 +240,26 @@ export class SlackProvider implements ChannelProvider {
     if (!constantTimeStringEqual(signature, expected)) {
       throw new Error("Slack webhook signature verification failed.");
     }
-    this.claimWebhookSignature(`${timestamp}:${signature}`, slackReplayScopeFromRawBody(rawBody, this.id), nowMs, maxAgeMs);
+    return this.claimWebhookSignature(`${timestamp}:${signature}`, slackReplayScopeFromRawBody(rawBody, this.id), nowMs, maxAgeMs);
   }
 
-  private claimWebhookSignature(replayKey: string, scope: string, nowMs: number, maxAgeMs: number): void {
+  private claimWebhookSignature(replayKey: string, scope: string, nowMs: number, maxAgeMs: number): SlackWebhookReplayClaim {
     this.purgeSeenWebhookSignatures(nowMs);
     const existing = this.seenWebhookSignatures.get(replayKey);
     if (existing && existing.expiresAt > nowMs) {
       throw new Error("Slack webhook signature replay rejected.");
     }
-    this.seenWebhookSignatures.set(replayKey, { expiresAt: nowMs + maxAgeMs, scope });
+    const entry = { expiresAt: nowMs + maxAgeMs, scope };
+    this.seenWebhookSignatures.set(replayKey, entry);
     this.enforceSeenWebhookSignatureScopeLimit(scope);
     this.enforceSeenWebhookSignatureGlobalLimit();
+    return { key: replayKey, entry };
+  }
+
+  private releaseWebhookReplayClaim(claim: SlackWebhookReplayClaim): void {
+    if (this.seenWebhookSignatures.get(claim.key) === claim.entry) {
+      this.seenWebhookSignatures.delete(claim.key);
+    }
   }
 
   private enforceSeenWebhookSignatureScopeLimit(scope: string): void {

--- a/packages/gateway-provider-webhook/src/webhook-provider.test.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.test.ts
@@ -572,6 +572,89 @@ describe("WebhookProvider", () => {
     await provider.stop();
   });
 
+  it("releases signed ingress replay claims when handler dispatch fails", async () => {
+    const payload = {
+      id: "retry-message",
+      target: { chatId: "team-chat" },
+      sender: { userId: "alice" },
+      text: "hello"
+    };
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      sharedSecret: "secret",
+      now: () => new Date("2026-02-28T12:00:00.000Z")
+    });
+    const seen: string[] = [];
+    let attempts = 0;
+    await provider.start(async (message) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("store offline");
+      seen.push(message.id);
+    });
+
+    const auth = signedAuth(payload);
+    await expect(provider.handleWebhookPayload(payload, auth)).rejects.toThrow("store offline");
+    await provider.handleWebhookPayload(payload, auth);
+    await expect(provider.handleWebhookPayload(payload, auth)).rejects.toThrow(
+      "Webhook signature replay rejected",
+    );
+
+    expect(attempts).toBe(2);
+    expect(seen).toEqual(["retry-message"]);
+    await provider.stop();
+  });
+
+  it("does not release newer signed ingress replay claims from older handler failures", async () => {
+    const firstPayload = {
+      id: "first-message",
+      target: { chatId: "team-chat" },
+      sender: { userId: "alice" },
+      text: "first"
+    };
+    const secondPayload = {
+      id: "second-message",
+      target: { chatId: "team-chat" },
+      sender: { userId: "alice" },
+      text: "second"
+    };
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      sharedSecret: "secret",
+      now: () => new Date("2026-02-28T12:00:00.000Z"),
+      maxSeenIngressSignatures: 1
+    });
+    const seen: string[] = [];
+    let firstAttempts = 0;
+    let failOriginalFirst: (error: Error) => void = () => {};
+    await provider.start(async (message) => {
+      if (message.id === "first-message") {
+        firstAttempts += 1;
+        if (firstAttempts === 1) {
+          await new Promise<void>((_, reject) => {
+            failOriginalFirst = reject;
+          });
+          return;
+        }
+      }
+      seen.push(message.id);
+    });
+
+    const firstAuth = signedAuth(firstPayload);
+    const originalFirst = provider.handleWebhookPayload(firstPayload, firstAuth);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await provider.handleWebhookPayload(secondPayload, signedAuth(secondPayload, "secret", "1772280001"));
+    await provider.handleWebhookPayload(firstPayload, firstAuth);
+    failOriginalFirst(new Error("store offline"));
+    await expect(originalFirst).rejects.toThrow("store offline");
+    await expect(provider.handleWebhookPayload(firstPayload, firstAuth)).rejects.toThrow(
+      "Webhook signature replay rejected",
+    );
+
+    expect(seen).toEqual(["second-message", "first-message"]);
+    await provider.stop();
+  });
+
   it("keeps signed ingress replay eviction scoped by bridge target", async () => {
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -85,6 +85,11 @@ type SeenWebhookSignature = {
   scope: string;
 };
 
+type WebhookIngressReplayClaim = {
+  key: string;
+  entry: SeenWebhookSignature;
+};
+
 export interface MapWebhookPayloadOptions {
   maxAttachmentBytes?: number;
 }
@@ -133,10 +138,16 @@ export class WebhookProvider implements ChannelProvider {
     if (!this.handler) {
       throw new Error("Webhook provider is not started");
     }
-    this.assertIngressAuthorized(auth);
-    await this.handler(mapWebhookPayload(payload, this.config.now?.() ?? new Date(), this.id, this.kind, {
+    const replayClaim = this.assertIngressAuthorized(auth);
+    const message = mapWebhookPayload(payload, this.config.now?.() ?? new Date(), this.id, this.kind, {
       maxAttachmentBytes: this.config.maxAttachmentBytes
-    }));
+    });
+    try {
+      await this.handler(message);
+    } catch (error) {
+      if (replayClaim) this.releaseIngressReplayClaim(replayClaim);
+      throw error;
+    }
   }
 
   async sendText(target: ChannelTarget, text: string, options?: SendOptions): Promise<SentMessage> {
@@ -276,10 +287,10 @@ export class WebhookProvider implements ChannelProvider {
     };
   }
 
-  private assertIngressAuthorized(auth: WebhookIngressAuth): void {
+  private assertIngressAuthorized(auth: WebhookIngressAuth): WebhookIngressReplayClaim | null {
     const expectedSecret = this.config.sharedSecret;
     if (auth.verified === true) {
-      return;
+      return null;
     }
     if (!expectedSecret) {
       throw new Error("Webhook shared secret is required for ingress");
@@ -313,9 +324,17 @@ export class WebhookProvider implements ChannelProvider {
       throw new Error("Webhook signature replay rejected");
     }
     const scope = webhookReplayScopeFromRawBody(rawBody, this.id);
-    this.seenIngressSignatures.set(replayKey, { expiresAt: nowMs + maxAgeMs, scope });
+    const entry = { expiresAt: nowMs + maxAgeMs, scope };
+    this.seenIngressSignatures.set(replayKey, entry);
     this.enforceSeenIngressSignatureScopeLimit(scope);
     this.enforceSeenIngressSignatureGlobalLimit();
+    return { key: replayKey, entry };
+  }
+
+  private releaseIngressReplayClaim(claim: WebhookIngressReplayClaim): void {
+    if (this.seenIngressSignatures.get(claim.key) === claim.entry) {
+      this.seenIngressSignatures.delete(claim.key);
+    }
   }
 
   private purgeSeenIngressSignatures(nowMs: number): void {

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -481,6 +481,119 @@ test('cloud HTTP direct question responses require explicit remote approval opt-
   }
 })
 
+test('cloud HTTP channel approval responses fail closed unless the profile opts in', async () => {
+  const fixture = createFixture({ autoProcessCommands: false })
+  const baseUrl = await fixture.server.listen()
+  const headers = { 'content-type': 'application/json' }
+  try {
+    const agentResponse = await fetch(`${baseUrl}/api/channels/agents`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        agentId: 'agent-1',
+        name: 'Gateway agent',
+      }),
+    })
+    assert.equal(agentResponse.status, 201)
+
+    const bindingResponse = await fetch(`${baseUrl}/api/channels/bindings`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        bindingId: 'telegram-binding',
+        agentId: 'agent-1',
+        provider: 'telegram',
+        displayName: 'Telegram',
+        externalWorkspaceId: 'bot-1',
+        credentialRef: 'secret/telegram',
+      }),
+    })
+    assert.equal(bindingResponse.status, 201)
+    const channelBinding = asRecord((await readJson(bindingResponse)).binding)
+
+    const identityResponse = await fetch(`${baseUrl}/api/channels/identities/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        provider: 'telegram',
+        externalWorkspaceId: 'bot-1',
+        externalUserId: 'tg-user-1',
+        accountId: 'user-1',
+        role: 'member',
+        status: 'active',
+      }),
+    })
+    assert.equal(identityResponse.status, 200)
+    const identity = asRecord((await readJson(identityResponse)).identity)
+
+    const bindResponse = await fetch(`${baseUrl}/api/channels/sessions/bind`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: identity.identityId,
+        channelBindingId: channelBinding.bindingId,
+        provider: 'telegram',
+        externalChatId: 'chat-1',
+        externalThreadId: 'thread-1',
+        title: 'Telegram thread',
+      }),
+    })
+    assert.equal(bindResponse.status, 200)
+    const bound = await readJson(bindResponse)
+    const cloudSession = asRecord(asRecord(bound.session).session)
+
+    const interactionResponse = await fetch(`${baseUrl}/api/channels/interactions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        interactionId: 'interaction-policy-denied',
+        agentId: 'agent-1',
+        sessionId: cloudSession.sessionId,
+        provider: 'telegram',
+        kind: 'permission',
+        targetId: 'permission-1',
+        tokenSecret: 'test-secret',
+      }),
+    })
+    assert.equal(interactionResponse.status, 201)
+    const issuedInteraction = await readJson(interactionResponse)
+
+    const denied = await fetch(`${baseUrl}/api/channels/interactions/resolve`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        identityId: identity.identityId,
+        token: issuedInteraction.plaintextToken,
+        response: { allowed: true },
+      }),
+    })
+    assert.equal(denied.status, 403)
+    const body = await readJson(denied)
+    assert.equal(asRecord(body.verdict).policyCode, 'gateway-remote-approval-disabled')
+
+    assert.equal(await fixture.worker.processAllSessionCommands(), 0)
+    assert.deepEqual(fixture.runtime.permissions, [])
+    const pending = fixture.store.findChannelInteraction({
+      orgId: 'tenant-1',
+      token: String(issuedInteraction.plaintextToken),
+      provider: 'telegram',
+    })
+    assert.equal(pending?.status, 'pending')
+
+    const auditEvents = await fixture.store.listAuditEvents('tenant-1')
+    const deniedAudit = auditEvents.find((event) => event.eventType === 'channel_interaction.remote_policy.denied')
+    assert.ok(deniedAudit)
+    assert.equal(deniedAudit.targetType, 'channel_interaction')
+    assert.equal(deniedAudit.targetId, 'interaction-policy-denied')
+    assert.equal(asRecord(deniedAudit.metadata).policyReasonCode, 'gateway-remote-approval-disabled')
+    assert.equal(asRecord(deniedAudit.metadata).interaction, 'permission-approval')
+    assert.equal(asRecord(deniedAudit.metadata).authority, 'cloud-channel-gateway')
+    assert.equal(asRecord(deniedAudit.metadata).actorWorkspaceMember, true)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP server paginates session lists with scoped cursors and filters', async () => {
   const fixture = createFixture()
   const baseUrl = await fixture.server.listen()

--- a/tests/cloud-transport-adapter.test.ts
+++ b/tests/cloud-transport-adapter.test.ts
@@ -40,7 +40,18 @@ function textResponse(text: string, status = 200, headers: Record<string, string
   }
 }
 
-test('cloud transport adapter maps session commands to HTTP routes with CSRF', async () => {
+function projectionFence(commandId: string, sessionId = 'session-1') {
+  return {
+    version: 1,
+    scope: 'session',
+    tenantId: 'tenant-1',
+    sessionId,
+    commandId,
+    issuedAt: '2026-05-27T10:00:00.000Z',
+  }
+}
+
+test('cloud transport adapter maps session and channel commands to HTTP routes with CSRF', async () => {
   const requests: Array<{ url: string, init?: Parameters<CloudTransportFetch>[1] }> = []
   const fetcher: CloudTransportFetch = async (url, init) => {
     requests.push({ url, init })
@@ -82,16 +93,49 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
       }, 201)
     }
     if (url.endsWith('/api/sessions/session-1/prompt')) {
-      return jsonResponse({ command: { commandId: 'cmd-1' }, processed: 0, view: { session: {}, projection: null } }, 202)
+      return jsonResponse({
+        command: { commandId: 'cmd-1' },
+        processed: 0,
+        view: { session: {}, projection: null },
+        projectionFence: projectionFence('cmd-1'),
+      }, 202)
     }
     if (url.endsWith('/api/sessions/session-1/question-reply')) {
-      return jsonResponse({ command: { commandId: 'cmd-2' }, processed: 0 }, 202)
+      return jsonResponse({
+        command: { commandId: 'cmd-2' },
+        processed: 0,
+        projectionFence: projectionFence('cmd-2'),
+      }, 202)
     }
     if (url.endsWith('/api/sessions/session-1/question-reject')) {
-      return jsonResponse({ command: { commandId: 'cmd-3' }, processed: 0 }, 202)
+      return jsonResponse({
+        command: { commandId: 'cmd-3' },
+        processed: 0,
+        projectionFence: projectionFence('cmd-3'),
+      }, 202)
     }
     if (url.endsWith('/api/sessions/session-1/permission-respond')) {
-      return jsonResponse({ command: { commandId: 'cmd-4' }, processed: 0 }, 202)
+      return jsonResponse({
+        command: { commandId: 'cmd-4' },
+        processed: 0,
+        projectionFence: projectionFence('cmd-4'),
+      }, 202)
+    }
+    if (url.endsWith('/api/channels/sessions/prompt')) {
+      return jsonResponse({
+        binding: { bindingId: 'binding-1' },
+        command: { commandId: 'cmd-channel-prompt' },
+        processed: 0,
+        projectionFence: projectionFence('cmd-channel-prompt'),
+      }, 202)
+    }
+    if (url.endsWith('/api/channels/interactions/resolve')) {
+      return jsonResponse({
+        interaction: { interactionId: 'interaction-1' },
+        command: { commandId: 'cmd-channel-interaction' },
+        processed: 0,
+        projectionFence: projectionFence('cmd-channel-interaction'),
+      }, 202)
     }
     if (url.endsWith('/api/sessions/session-1/artifacts')) {
       if (init?.method === 'POST') {
@@ -303,10 +347,24 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
     itemCounts: { messages: 1, artifacts: 0, attachments: 0, projectSource: 0, excluded: 1 },
     messages: [{ id: 'm1', role: 'user', content: 'imported', order: 1 }],
   })).session.sessionId, 'session-imported')
-  assert.equal((await transport.promptSession('session-1', { text: 'hello' })).processed, 0)
-  assert.equal((await transport.replyToQuestion('session-1', { requestId: 'q1', answers: ['A'] })).processed, 0)
-  assert.equal((await transport.rejectQuestion('session-1', { requestId: 'q2' })).processed, 0)
-  assert.equal((await transport.respondToPermission('session-1', { permissionId: 'p1', response: { allowed: true } })).processed, 0)
+  const prompt = await transport.promptSession('session-1', { text: 'hello' })
+  assert.equal(prompt.processed, 0)
+  assert.equal(prompt.projectionFence?.commandId, 'cmd-1')
+  const questionReply = await transport.replyToQuestion('session-1', { requestId: 'q1', answers: ['A'] })
+  assert.equal(questionReply.processed, 0)
+  assert.equal(questionReply.projectionFence?.commandId, 'cmd-2')
+  const questionReject = await transport.rejectQuestion('session-1', { requestId: 'q2' })
+  assert.equal(questionReject.processed, 0)
+  assert.equal(questionReject.projectionFence?.commandId, 'cmd-3')
+  const permissionResponse = await transport.respondToPermission('session-1', { permissionId: 'p1', response: { allowed: true } })
+  assert.equal(permissionResponse.processed, 0)
+  assert.equal(permissionResponse.projectionFence?.commandId, 'cmd-4')
+  const channelPrompt = await transport.promptChannelSession?.({ identityId: 'identity-1', bindingId: 'binding-1', text: 'hello channel' })
+  assert.equal(channelPrompt?.processed, 0)
+  assert.equal(channelPrompt?.projectionFence?.commandId, 'cmd-channel-prompt')
+  const channelInteraction = await transport.resolveChannelInteraction?.({ identityId: 'identity-1', token: 'token-1', response: { allowed: true } })
+  assert.equal(channelInteraction?.processed, 0)
+  assert.equal(channelInteraction?.projectionFence?.commandId, 'cmd-channel-interaction')
   assert.equal((await transport.listWorkflows?.())?.workflows[0]?.id, 'workflow-1')
   assert.equal((await transport.getWorkflow?.('workflow-1'))?.id, 'workflow-1')
   assert.equal((await transport.runWorkflow?.('workflow-1'))?.id, 'run-1')
@@ -358,6 +416,8 @@ test('cloud transport adapter maps session commands to HTTP routes with CSRF', a
       '/api/sessions/session-1/question-reply',
       '/api/sessions/session-1/question-reject',
       '/api/sessions/session-1/permission-respond',
+      '/api/channels/sessions/prompt',
+      '/api/channels/interactions/resolve',
       '/api/workflows/workflow-1/run',
       '/api/workflows/workflow-1/pause',
       '/api/threads/tags',


### PR DESCRIPTION
## Summary
- Preserve projectionFence in public cloud-client and gateway command response contracts.
- Add a fail-closed channel approval policy regression test that keeps denied interactions pending and audits policy metadata.
- Release signed Slack and webhook replay claims only when handler dispatch fails, so retries can complete after downstream failures while malformed signed payloads remain replay-protected.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check
- node scripts/run-node-tests.mjs tests/cloud-transport-adapter.test.ts tests/cloud-http-server.test.ts
- pnpm --filter @open-cowork/gateway-provider-webhook test
- pnpm --filter @open-cowork/gateway-provider-slack test
- pnpm --filter @open-cowork/gateway test
- pnpm --filter @open-cowork/cloud-client test

Closes #656
Closes #661
Closes #664