### PR TITLE
Harden async timeline coordination

### DIFF
--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -548,23 +548,33 @@ async function processSessionCommandIfConfigured(
   return options.worker.processSessionCommands(tenantId, sessionId)
 }
 
-function sessionProjectionFenceForView(
+function sessionEventCommandId(event: SessionEventRecord) {
+  return readString(readRecord(event.payload)?.commandId)
+}
+
+async function sessionProjectionFenceForCommand(
+  options: CloudHttpServerOptions,
   principal: CloudPrincipal,
   command: SessionCommandRecord,
   view: CloudSessionView,
-  minimumProjectionSequence: number,
-): CloudProjectionFenceToken | null {
+  processed: number,
+  afterProjectionSequence: number,
+): Promise<CloudProjectionFenceToken | null> {
+  if (processed <= 0) return null
   const observedSequence = typeof view.projection?.sequence === 'number' && Number.isInteger(view.projection.sequence) && view.projection.sequence > 0
     ? view.projection.sequence
     : null
-  if (observedSequence === null || observedSequence < minimumProjectionSequence) return null
+  if (observedSequence === null || observedSequence <= afterProjectionSequence) return null
+  const events = await options.service.listEvents(principal, command.sessionId, afterProjectionSequence)
+  const commandEvent = events.find((event) => event.sequence <= observedSequence && sessionEventCommandId(event) === command.commandId)
+  if (!commandEvent) return null
   return createCloudProjectionFenceToken({
     scope: 'session',
     tenantId: principal.tenantId,
     sessionId: view.session.sessionId,
     commandId: command.commandId,
-    sequence: observedSequence,
-    projectionVersion: observedSequence,
+    sequence: commandEvent.sequence,
+    projectionVersion: commandEvent.sequence,
   })
 }
 
@@ -579,14 +589,20 @@ async function writeSessionCommandMutationResponse(
   extraBody: Record<string, unknown> = {},
 ) {
   const view = await options.service.getSessionView(principal, sessionId)
+  const projectionFence = await sessionProjectionFenceForCommand(
+    options,
+    principal,
+    command,
+    view,
+    processed,
+    beforeProjectionSequence,
+  )
   writeJson(res, 202, {
     ...extraBody,
     command,
     processed,
     view,
-    projectionFence: processed > 0
-      ? sessionProjectionFenceForView(principal, command, view, beforeProjectionSequence + 1)
-      : null,
+    projectionFence,
   }, options.corsOrigin)
 }
 

--- a/apps/desktop/src/main/cloud/sse-replay.ts
+++ b/apps/desktop/src/main/cloud/sse-replay.ts
@@ -14,6 +14,7 @@ type SseReplayTopic = {
   loadEvents: (afterSequence: number) => Promise<SequencedSseEvent[]>
   lastSequence: number
   polling: boolean
+  pollRequested: boolean
   timer: ReturnType<typeof setInterval>
 }
 
@@ -91,13 +92,12 @@ export class CloudSseReplayHub {
         loadEvents: input.loadEvents,
         lastSequence: input.afterSequence,
         polling: false,
+        pollRequested: false,
         timer: setInterval(() => {
-          void this.poll(input.key)
+          this.requestPoll(input.key)
         }, input.pollMs),
       }
       this.topics.set(input.key, topic)
-    } else if (input.afterSequence < topic.lastSequence) {
-      topic.lastSequence = input.afterSequence
     }
     const subscriber: SseReplaySubscriber = {
       lastSequence: input.afterSequence,
@@ -105,6 +105,7 @@ export class CloudSseReplayHub {
       onError: input.onError,
     }
     topic.subscribers.add(subscriber)
+    this.requestPoll(input.key)
     return () => {
       const current = this.topics.get(input.key)
       if (!current) return
@@ -128,18 +129,43 @@ export class CloudSseReplayHub {
     this.topics.clear()
   }
 
+  private requestPoll(key: string) {
+    if (this.closed) return
+    const topic = this.topics.get(key)
+    if (!topic) return
+    if (topic.polling) {
+      topic.pollRequested = true
+      return
+    }
+    void this.poll(key)
+  }
+
+  private replayAfterSequence(topic: SseReplayTopic) {
+    let afterSequence = topic.lastSequence
+    for (const subscriber of topic.subscribers) {
+      afterSequence = Math.min(afterSequence, subscriber.lastSequence)
+    }
+    return afterSequence
+  }
+
   private async poll(key: string) {
     if (this.closed) return
     const topic = this.topics.get(key)
     if (!topic || topic.polling) return
     topic.polling = true
+    topic.pollRequested = false
     try {
-      const events = await topic.loadEvents(topic.lastSequence)
+      const afterSequence = this.replayAfterSequence(topic)
+      const events = await topic.loadEvents(afterSequence)
       if (this.closed || this.topics.get(key) !== topic) return
       for (const event of events) {
-        if (event.sequence <= topic.lastSequence) continue
-        topic.lastSequence = event.sequence
+        if (event.sequence <= afterSequence) continue
+        topic.lastSequence = Math.max(topic.lastSequence, event.sequence)
         for (const subscriber of topic.subscribers) {
+          if (subscriber.lastSequence < afterSequence) {
+            topic.pollRequested = true
+            continue
+          }
           if (event.sequence <= subscriber.lastSequence) continue
           subscriber.listener(event)
           subscriber.lastSequence = event.sequence
@@ -148,7 +174,13 @@ export class CloudSseReplayHub {
     } catch (error) {
       for (const subscriber of topic.subscribers) subscriber.onError?.(error)
     } finally {
-      if (this.topics.get(key) === topic) topic.polling = false
+      if (this.topics.get(key) === topic) {
+        topic.polling = false
+        if (topic.pollRequested && topic.subscribers.size > 0) {
+          topic.pollRequested = false
+          this.requestPoll(key)
+        }
+      }
     }
   }
 }

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -547,12 +547,6 @@ export async function startRuntime(
 
     const config = await buildRuntimeConfigForStartup(plan, projectDirectory)
 
-    // Global CWD is part of the OpenCode runtime contract: the managed server
-    // discovers config relative to the same root it receives at spawn time.
-    // Keep unrelated app filesystem access on explicit paths; do not add new
-    // product-layer behavior that depends on process.cwd().
-    process.chdir(getRuntimeWorkingDirectoryForSource(plan.runtimeConfigSource))
-
     try {
       const result = await createManagedOpencode(
         buildManagedServerOptions(config),

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -58,7 +58,7 @@ export type RuntimeSessionEvent = {
 
 type PendingViewFlush = {
   win: BrowserWindow
-  sessions: Map<string, { sessionId: string; workspaceId?: string | null }>
+  sessions: Map<string, SessionFlushIdentity>
   queuedAt: number
   timer: ReturnType<typeof setTimeout> | null
 }
@@ -66,10 +66,15 @@ type PendingViewFlush = {
 type PendingPatchFlush = {
   win: BrowserWindow
   patches: SessionPatch[]
-  overflowSessionIds: Set<string>
+  overflowSessionIds: Map<string, SessionFlushIdentity>
   droppedPatches: number
   queuedAt: number
   timer: ReturnType<typeof setTimeout> | null
+}
+
+type SessionFlushIdentity = {
+  sessionId: string
+  workspaceId?: string | null
 }
 
 const SESSION_PATCH_FLUSH_INTERVAL_MS = 8
@@ -78,7 +83,7 @@ const MAX_SESSION_PATCHES_PER_FLUSH = 128
 
 const pendingViewFlushByWindowId = new Map<number, PendingViewFlush>()
 const pendingPatchFlushByWindowId = new Map<number, PendingPatchFlush>()
-const patchViewRecoverySessionIdsByWindowId = new Map<number, Set<string>>()
+const patchViewRecoverySessionIdsByWindowId = new Map<number, Map<string, SessionFlushIdentity>>()
 let sessionHistoryRefreshHandler: ((sessionId: string) => Promise<void>) | null = null
 const runtimeSessionEventObservers = new Set<(event: RuntimeSessionEvent) => void>()
 const historyRefreshQueue = new Map<string, {
@@ -87,8 +92,12 @@ const historyRefreshQueue = new Map<string, {
   promise: Promise<void>
 }>()
 
-function sessionFlushKey(sessionId: string, workspaceId?: string | null) {
-  return `${workspaceId || 'local'}:${sessionId}`
+function sessionFlushIdentity(sessionId: string, workspaceId?: string | null): SessionFlushIdentity {
+  return { sessionId, workspaceId }
+}
+
+function sessionFlushKey(identity: SessionFlushIdentity) {
+  return `${identity.workspaceId || 'local'}:${identity.sessionId}`
 }
 
 function getEventType(event: RuntimeSessionEvent) {
@@ -250,29 +259,30 @@ export function publishSessionPatch(
 
 function markSessionPatchViewRecovery(windowId: number, sessionId: string, workspaceId?: string | null) {
   const existing = patchViewRecoverySessionIdsByWindowId.get(windowId)
-  const key = sessionFlushKey(sessionId, workspaceId)
+  const identity = sessionFlushIdentity(sessionId, workspaceId)
+  const key = sessionFlushKey(identity)
   if (existing) {
-    existing.add(key)
+    existing.set(key, identity)
     return
   }
-  patchViewRecoverySessionIdsByWindowId.set(windowId, new Set([key]))
+  patchViewRecoverySessionIdsByWindowId.set(windowId, new Map([[key, identity]]))
 }
 
 function clearSessionPatchViewRecovery(windowId: number, sessionId: string, workspaceId?: string | null) {
   const existing = patchViewRecoverySessionIdsByWindowId.get(windowId)
   if (!existing) return
-  existing.delete(sessionFlushKey(sessionId, workspaceId))
+  existing.delete(sessionFlushKey(sessionFlushIdentity(sessionId, workspaceId)))
   if (existing.size === 0) patchViewRecoverySessionIdsByWindowId.delete(windowId)
 }
 
 function sessionNeedsPatchViewRecovery(windowId: number, sessionId: string, workspaceId?: string | null) {
-  return patchViewRecoverySessionIdsByWindowId.get(windowId)?.has(sessionFlushKey(sessionId, workspaceId)) === true
+  return patchViewRecoverySessionIdsByWindowId.get(windowId)?.has(sessionFlushKey(sessionFlushIdentity(sessionId, workspaceId))) === true
 }
 
 function dropQueuedSessionPatches(pending: PendingPatchFlush, sessionId: string, workspaceId?: string | null) {
-  const key = sessionFlushKey(sessionId, workspaceId)
+  const key = sessionFlushKey(sessionFlushIdentity(sessionId, workspaceId))
   const before = pending.patches.length
-  pending.patches = pending.patches.filter((queuedPatch) => sessionFlushKey(queuedPatch.sessionId, queuedPatch.workspaceId) !== key)
+  pending.patches = pending.patches.filter((queuedPatch) => sessionFlushKey(sessionFlushIdentity(queuedPatch.sessionId, queuedPatch.workspaceId)) !== key)
   return before - pending.patches.length
 }
 
@@ -281,11 +291,12 @@ function recoverSessionWithViewOnlyCatchUp(windowId: number, sessionId: string, 
   if (!pending) return
   const dropped = dropQueuedSessionPatches(pending, sessionId, workspaceId)
   if (dropped > 0) pending.droppedPatches += dropped
-  pending.overflowSessionIds.add(sessionFlushKey(sessionId, workspaceId))
+  const identity = sessionFlushIdentity(sessionId, workspaceId)
+  pending.overflowSessionIds.set(sessionFlushKey(identity), identity)
 }
 
 function sessionHasQueuedView(windowId: number, sessionId: string, workspaceId?: string | null) {
-  return pendingViewFlushByWindowId.get(windowId)?.sessions.has(sessionFlushKey(sessionId, workspaceId)) === true
+  return pendingViewFlushByWindowId.get(windowId)?.sessions.has(sessionFlushKey(sessionFlushIdentity(sessionId, workspaceId))) === true
 }
 
 function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: string, workspaceId?: string | null) {
@@ -296,9 +307,9 @@ function flushQueuedSessionPatchesBeforeView(win: BrowserWindow, sessionId: stri
   if (!pending || pending.patches.length === 0) return
 
   const queuedForSession: SessionPatch[] = []
-  const key = sessionFlushKey(sessionId, workspaceId)
+  const key = sessionFlushKey(sessionFlushIdentity(sessionId, workspaceId))
   pending.patches = pending.patches.filter((patch) => {
-    if (sessionFlushKey(patch.sessionId, patch.workspaceId) !== key) return true
+    if (sessionFlushKey(sessionFlushIdentity(patch.sessionId, patch.workspaceId)) !== key) return true
     queuedForSession.push(patch)
     return false
   })
@@ -360,7 +371,7 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
       pending = {
         win,
         patches: [],
-        overflowSessionIds: new Set(),
+        overflowSessionIds: new Map(),
         droppedPatches: 0,
         queuedAt: Date.now(),
         timer: null,
@@ -371,7 +382,8 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
       pendingPatchFlushByWindowId.set(windowId, pending)
     }
     pending.droppedPatches += 1
-    pending.overflowSessionIds.add(sessionFlushKey(patch.sessionId, patch.workspaceId))
+    const identity = sessionFlushIdentity(patch.sessionId, patch.workspaceId)
+    pending.overflowSessionIds.set(sessionFlushKey(identity), identity)
     return
   }
 
@@ -385,7 +397,7 @@ function queueSessionPatchPublish(win: BrowserWindow, patch: SessionPatch | null
     pending = {
       win,
       patches: [],
-      overflowSessionIds: new Set(),
+      overflowSessionIds: new Map(),
       droppedPatches: 0,
       queuedAt: Date.now(),
       timer: null,
@@ -441,16 +453,17 @@ function queueSessionViewPublish(win: BrowserWindow, sessionId: string, workspac
   if (!sessionNeedsPatchViewRecovery(windowId, sessionId, workspaceId)) {
     flushQueuedSessionPatchesBeforeView(win, sessionId, workspaceId)
   }
-  const key = sessionFlushKey(sessionId, workspaceId)
+  const identity = sessionFlushIdentity(sessionId, workspaceId)
+  const key = sessionFlushKey(identity)
   const existing = pendingViewFlushByWindowId.get(windowId)
   if (existing) {
-    existing.sessions.set(key, { sessionId, workspaceId })
+    existing.sessions.set(key, identity)
     return
   }
 
   const pending: PendingViewFlush = {
     win,
-    sessions: new Map([[key, { sessionId, workspaceId }]]),
+    sessions: new Map([[key, identity]]),
     queuedAt: Date.now(),
     timer: null,
   }
@@ -517,19 +530,25 @@ function queueSessionHistoryRefresh(win: BrowserWindow, sessionId: string) {
 export function dropSessionFromDispatcherQueues(sessionId: string) {
   historyRefreshQueue.delete(sessionId)
   for (const [windowId, recoverySessionIds] of patchViewRecoverySessionIdsByWindowId.entries()) {
-    recoverySessionIds.delete(sessionFlushKey(sessionId))
+    for (const [key, identity] of recoverySessionIds.entries()) {
+      if (identity.sessionId === sessionId) recoverySessionIds.delete(key)
+    }
     if (recoverySessionIds.size === 0) patchViewRecoverySessionIdsByWindowId.delete(windowId)
   }
   for (const [windowId, pending] of pendingPatchFlushByWindowId.entries()) {
-    dropQueuedSessionPatches(pending, sessionId)
-    pending.overflowSessionIds.delete(sessionFlushKey(sessionId))
+    pending.patches = pending.patches.filter((patch) => patch.sessionId !== sessionId)
+    for (const [key, identity] of pending.overflowSessionIds.entries()) {
+      if (identity.sessionId === sessionId) pending.overflowSessionIds.delete(key)
+    }
     if (pending.patches.length === 0 && pending.overflowSessionIds.size === 0) {
       if (pending.timer) clearTimeout(pending.timer)
       pendingPatchFlushByWindowId.delete(windowId)
     }
   }
   for (const [windowId, pending] of pendingViewFlushByWindowId.entries()) {
-    if (!pending.sessions.delete(sessionFlushKey(sessionId))) continue
+    for (const [key, identity] of pending.sessions.entries()) {
+      if (identity.sessionId === sessionId) pending.sessions.delete(key)
+    }
     if (pending.sessions.size === 0) {
       if (pending.timer) clearTimeout(pending.timer)
       pendingViewFlushByWindowId.delete(windowId)

--- a/apps/desktop/src/main/session-history-loader.ts
+++ b/apps/desktop/src/main/session-history-loader.ts
@@ -425,6 +425,7 @@ export function createSessionHistoryService(
         children,
         statuses,
         loadChildSnapshot: childSnapshotLoader.load,
+        fallbackTimestampMs: record ? Date.parse(record.createdAt) : 0,
       })
       const latestModeledItem = [...items]
         .reverse()

--- a/apps/desktop/src/main/session-history-projection-utils.ts
+++ b/apps/desktop/src/main/session-history-projection-utils.ts
@@ -4,7 +4,7 @@ import type {
   NormalizedSessionMessage,
 } from './opencode-adapter.ts'
 
-export const toHistorySortTime = (value?: number, fallback = Date.now()) => {
+export const toHistorySortTime = (value?: number, fallback = 0) => {
   const raw = typeof value === 'number' && Number.isFinite(value) ? value : fallback
   return raw < 1_000_000_000_000 ? raw * 1000 : raw
 }

--- a/apps/desktop/src/main/session-history-projector.ts
+++ b/apps/desktop/src/main/session-history-projector.ts
@@ -89,6 +89,7 @@ type ProjectSessionHistoryInput = {
   children: ChildSessionRecord[]
   statuses: Record<string, { type: string | null }>
   loadChildSnapshot: (childId: string) => Promise<{ messages: unknown[]; todos: unknown[] }>
+  fallbackTimestampMs?: number
   generateId?: () => string
 }
 
@@ -164,17 +165,18 @@ function isDelegationPart(part: NormalizedMessagePart) {
 
 function messageCreatedSortTime(msg: NonNullable<ReturnType<typeof normalizeSessionMessages>[number]>) {
   const created = msg.info.time.created || msg.time.created
-  return created ? toHistorySortTime(created) : null
+  return created ? toHistorySortTime(created, 0) : null
 }
 
 function childCreatedSortTime(child: ChildSessionRecord) {
   const created = child.time?.created
-  return created === null || created === undefined ? null : toHistorySortTime(created)
+  return created === null || created === undefined ? null : toHistorySortTime(created, 0)
 }
 
 export async function projectSessionHistory(input: ProjectSessionHistoryInput): Promise<ProjectedHistoryItem[]> {
   const { sessionId, cachedModelId, rootMessages, rootTodos, statuses, loadChildSnapshot } = input
   const generateId = input.generateId || crypto.randomUUID
+  const fallbackSortTime = toHistorySortTime(input.fallbackTimestampMs, 0)
   const normalizedRootMessages = rootMessages
     .map((rawMsg) => normalizeSessionMessages([rawMsg])[0])
     .filter((msg): msg is NonNullable<ReturnType<typeof normalizeSessionMessages>[number]> => Boolean(msg))
@@ -429,7 +431,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       if (parentSessionId && !childBelongsToParent(child, parentSessionId)) continue
       const taskId = `child:${child.id}`
       const agent = extractAgentName(child.title)
-      const sortTime = toHistorySortTime(child.time?.created || Date.now())
+      const sortTime = toHistorySortTime(child.time?.created, fallbackSortTime)
       const childStatus = getTaskStatus(child.id)
       const timing = timingFromChild(child, childStatus)
       addTaskRun({
@@ -485,7 +487,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     const info = msg.info
     const parts = msg.parts
     const childBindingAfter = messageCreatedSortTime(msg)
-    const tsMs = childBindingAfter ?? Date.now()
+    const tsMs = childBindingAfter ?? fallbackSortTime
     const ts = toIsoTimestamp(tsMs)
     const msgId = info.id || msg.id || generateId()
     const role = info.role || msg.role || 'assistant'
@@ -665,7 +667,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
   if (rootTodos.length > 0) {
     const todos = normalizeTodoItems(rootTodos)
     if (todos.length > 0) {
-      const todosTs = Date.now()
+      const todosTs = fallbackSortTime
       pushItem({
         type: 'todos',
         id: `todos:${sessionId}`,
@@ -700,7 +702,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
       if (!msg) continue
       const info = msg.info
       const parts = msg.parts
-      const tsMs = toHistorySortTime(info.time.created || msg.time.created || Date.now())
+      const tsMs = toHistorySortTime(info.time.created || msg.time.created, fallbackSortTime)
       const ts = toIsoTimestamp(tsMs)
       const role = info.role || msg.role || 'assistant'
       const modelMeta = getHistoryModelMeta(msg)
@@ -877,7 +879,7 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
     }
 
     if (normalizedChildTodos.length > 0) {
-      const todoSortTime = toHistorySortTime(child.time?.updated || child.time?.created || Date.now())
+      const todoSortTime = toHistorySortTime(child.time?.updated || child.time?.created, fallbackSortTime)
       pushItem({
         type: 'task_todos',
         id: `${taskId}:todos`,

--- a/apps/standalone-gateway/src/postgres-repository.ts
+++ b/apps/standalone-gateway/src/postgres-repository.ts
@@ -97,39 +97,52 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
   async findOrCreateSession(input: StandalonePromptInput & { title?: string; now?: Date }): Promise<StandaloneGatewaySessionRecord> {
     const now = (input.now || new Date()).toISOString();
     const externalThreadId = input.target.threadId || input.target.chatId;
-    const result = await this.pool.query<SessionRow>(
-      `INSERT INTO standalone_gateway_sessions (
-         session_id, title, status, provider, provider_kind, channel_binding_id,
-         external_user_id, external_chat_id, external_thread_id, created_at, updated_at
-       )
-       VALUES ($1, $2, 'idle', $3, $4, $5, $6, $7, $8, $9, $9)
-       ON CONFLICT (provider, external_chat_id, external_thread_id) DO UPDATE
-       SET updated_at = standalone_gateway_sessions.updated_at
-       RETURNING *`,
-      [
-        randomUUID(),
-        input.title || input.text.slice(0, 80) || "Standalone Gateway session",
-        input.provider,
-        input.providerKind,
-        input.channelBindingId,
-        input.externalUserId,
-        input.target.chatId,
-        externalThreadId,
-        now,
-      ],
-    );
-    const session = sessionFromRow(result.rows[0]!);
-    if (session.lastEventSequence === 0) {
-      await this.appendEvent({ sessionId: session.sessionId, type: "session.created", payload: { title: session.title }, now: input.now });
-      return await this.getSession(session.sessionId) || session;
-    }
-    return session;
+    return this.withTransaction(async (client) => {
+      const result = await client.query<SessionRow>(
+        `INSERT INTO standalone_gateway_sessions (
+           session_id, title, status, provider, provider_kind, channel_binding_id,
+           external_user_id, external_chat_id, external_thread_id, created_at, updated_at
+         )
+         VALUES ($1, $2, 'idle', $3, $4, $5, $6, $7, $8, $9, $9)
+         ON CONFLICT (provider, external_chat_id, external_thread_id) DO UPDATE
+         SET updated_at = standalone_gateway_sessions.updated_at
+         RETURNING *`,
+        [
+          randomUUID(),
+          input.title || input.text.slice(0, 80) || "Standalone Gateway session",
+          input.provider,
+          input.providerKind,
+          input.channelBindingId,
+          input.externalUserId,
+          input.target.chatId,
+          externalThreadId,
+          now,
+        ],
+      );
+      let session = sessionFromRow(result.rows[0]!);
+      if (session.lastEventSequence !== 0) return session;
+      await client.query<EventRow>(
+        `INSERT INTO standalone_gateway_events (event_id, session_id, sequence, type, payload, created_at)
+         VALUES ($1, $2, 1, 'session.created', $3::jsonb, $4)
+         ON CONFLICT (session_id, sequence) DO NOTHING`,
+        [randomUUID(), session.sessionId, JSON.stringify(redactRecord({ title: session.title })), now],
+      );
+      const updated = await client.query<SessionRow>(
+        `UPDATE standalone_gateway_sessions
+         SET last_event_sequence = 1, updated_at = $2
+         WHERE session_id = $1 AND last_event_sequence = 0
+         RETURNING *`,
+        [session.sessionId, now],
+      );
+      session = updated.rows[0] ? sessionFromRow(updated.rows[0]) : session;
+      return session;
+    });
   }
 
   async updateSessionRuntime(input: { sessionId: string; opencodeSessionId: string | null; status?: StandaloneGatewaySessionRecord["status"]; now?: Date }): Promise<StandaloneGatewaySessionRecord> {
     const result = await this.pool.query<SessionRow>(
       `UPDATE standalone_gateway_sessions
-       SET opencode_session_id = $2,
+       SET opencode_session_id = COALESCE(standalone_gateway_sessions.opencode_session_id, $2),
            status = COALESCE($3, status),
            updated_at = $4
        WHERE session_id = $1

--- a/apps/standalone-gateway/src/repository.test.ts
+++ b/apps/standalone-gateway/src/repository.test.ts
@@ -17,6 +17,20 @@ test("standalone repository persists sessions, events, jobs, leases, and redacte
     externalUserId: "user-1",
     text: "hello",
   });
+  const sameSession = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-1", threadId: "thread-1" },
+    externalUserId: "user-1",
+    text: "hello again",
+  });
+  assert.equal(sameSession.sessionId, session.sessionId);
+  assert.equal(sameSession.lastEventSequence, 1);
+  const firstBinding = await repository.updateSessionRuntime({ sessionId: session.sessionId, opencodeSessionId: "oc-1", status: "running" });
+  const secondBinding = await repository.updateSessionRuntime({ sessionId: session.sessionId, opencodeSessionId: "oc-2", status: "idle" });
+  assert.equal(firstBinding.opencodeSessionId, "oc-1");
+  assert.equal(secondBinding.opencodeSessionId, "oc-1");
   await repository.appendEvent({ sessionId: session.sessionId, type: "user.message", payload: { text: "hello", token: "secret-token" } });
   const job = await repository.enqueueJob({ kind: "prompt", sessionId: session.sessionId, payload: { token: "secret-token" } });
   const claimed = await repository.claimNextJob({ claimedBy: "worker-1", ttlMs: 30_000 });

--- a/apps/standalone-gateway/src/repository.ts
+++ b/apps/standalone-gateway/src/repository.ts
@@ -104,14 +104,14 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
     };
     this.sessions.set(session.sessionId, session);
     await this.appendEvent({ sessionId: session.sessionId, type: "session.created", payload: { title: session.title }, now: input.now });
-    return { ...session };
+    return { ...this.requireSession(session.sessionId) };
   }
 
   async updateSessionRuntime(input: { sessionId: string; opencodeSessionId: string | null; status?: StandaloneGatewaySessionRecord["status"]; now?: Date }): Promise<StandaloneGatewaySessionRecord> {
     const current = this.requireSession(input.sessionId);
     const updated = {
       ...current,
-      opencodeSessionId: input.opencodeSessionId,
+      opencodeSessionId: current.opencodeSessionId || input.opencodeSessionId,
       status: input.status || current.status,
       updatedAt: (input.now || new Date()).toISOString(),
     };

--- a/apps/standalone-gateway/src/runtime.test.ts
+++ b/apps/standalone-gateway/src/runtime.test.ts
@@ -2,10 +2,39 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { FakeChannelProvider } from "@open-cowork/gateway-testing";
+import type { IncomingChannelMessage } from "@open-cowork/gateway-channel";
 
-import { FakeStandaloneOpenCodeAdapter } from "../dist/opencode.js";
+import { FakeStandaloneOpenCodeAdapter, type StandaloneOpenCodeAdapter } from "../dist/opencode.js";
 import { InMemoryStandaloneGatewayRepository } from "../dist/repository.js";
 import { createStandaloneGatewayRuntime } from "../dist/runtime.js";
+
+function message(id: string, text: string): IncomingChannelMessage {
+  return {
+    id,
+    provider: "cli-standalone",
+    providerKind: "cli",
+    providerInstanceId: "cli-standalone",
+    providerEventId: `event-${id}`,
+    providerMessageId: id,
+    target: { provider: "cli-standalone", providerKind: "cli", chatId: "chat-1", threadId: "thread-1" },
+    sender: { providerUserId: "user-1" },
+    text,
+    rawText: text,
+    isCommand: false,
+    attachments: [],
+    receivedAt: new Date("2026-06-01T00:00:00.000Z"),
+    raw: {},
+  };
+}
+
+const providerConfig = {
+  id: "cli-standalone" as const,
+  kind: "cli" as const,
+  channelBindingId: "cli",
+  enabled: true,
+  credentials: {},
+  settings: {},
+};
 
 test("standalone runtime prompts private OpenCode and persists projected events", async () => {
   const repository = new InMemoryStandaloneGatewayRepository();
@@ -13,35 +42,56 @@ test("standalone runtime prompts private OpenCode and persists projected events"
   const runtime = createStandaloneGatewayRuntime({ repository, opencode });
   const provider = new FakeChannelProvider({ id: "cli-standalone" });
 
-  await runtime.handleMessage(provider, {
-    id: "cli-standalone",
-    kind: "cli",
-    channelBindingId: "cli",
-    enabled: true,
-    credentials: {},
-    settings: {},
-  }, {
-    id: "message-1",
-    provider: "cli-standalone",
-    providerKind: "cli",
-    providerInstanceId: "cli-standalone",
-    providerEventId: "event-1",
-    providerMessageId: "message-1",
-    target: { provider: "cli-standalone", providerKind: "cli", chatId: "chat-1", threadId: "thread-1" },
-    sender: { providerUserId: "user-1" },
-    text: "build the thing",
-    rawText: "build the thing",
-    isCommand: false,
-    attachments: [],
-    receivedAt: new Date("2026-06-01T00:00:00.000Z"),
-    raw: {},
-  });
+  await runtime.handleMessage(provider, providerConfig, message("message-1", "build the thing"));
 
   assert.equal(opencode.prompts.length, 1);
   assert.equal((await repository.listSessions())[0]?.status, "idle");
   const snapshot = await repository.dashboardSnapshot();
   assert.equal(snapshot.sessions[0]?.provider, "cli-standalone");
   assert.equal(snapshot.audits[0]?.action, "standalone.prompt");
+});
+
+test("standalone runtime serializes concurrent work for one channel session", async () => {
+  const repository = new InMemoryStandaloneGatewayRepository();
+  let createCount = 0;
+  let activePrompts = 0;
+  let maxActivePrompts = 0;
+  const prompts: Array<{ opencodeSessionId: string; text: string }> = [];
+  const opencode: StandaloneOpenCodeAdapter = {
+    async createSession() {
+      createCount += 1;
+      return { opencodeSessionId: `oc-${createCount}` };
+    },
+    async prompt(input) {
+      activePrompts += 1;
+      maxActivePrompts = Math.max(maxActivePrompts, activePrompts);
+      prompts.push({ opencodeSessionId: input.opencodeSessionId, text: input.text });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await input.onEvent({ type: "assistant.message", payload: { text: `done: ${input.text}` } });
+      activePrompts -= 1;
+    },
+    async health() {
+      return { ok: true, detail: "ready" };
+    },
+  };
+  const runtime = createStandaloneGatewayRuntime({ repository, opencode });
+  const provider = new FakeChannelProvider({ id: "cli-standalone" });
+
+  await Promise.all([
+    runtime.handleMessage(provider, providerConfig, message("message-1", "first")),
+    runtime.handleMessage(provider, providerConfig, message("message-2", "second")),
+  ]);
+
+  assert.equal(createCount, 1);
+  assert.equal(maxActivePrompts, 1);
+  assert.deepEqual(prompts, [
+    { opencodeSessionId: "oc-1", text: "first" },
+    { opencodeSessionId: "oc-1", text: "second" },
+  ]);
+  const sessions = await repository.listSessions();
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0]?.opencodeSessionId, "oc-1");
+  assert.equal(sessions[0]?.status, "idle");
 });
 
 test("standalone runtime records failed prompts durably", async () => {
@@ -62,31 +112,43 @@ test("standalone runtime records failed prompts durably", async () => {
   });
   const provider = new FakeChannelProvider({ id: "cli-standalone" });
 
-  await assert.rejects(() => runtime.handleMessage(provider, {
-    id: "cli-standalone",
-    kind: "cli",
-    channelBindingId: "cli",
-    enabled: true,
-    credentials: {},
-    settings: {},
-  }, {
-    id: "message-1",
-    provider: "cli-standalone",
-    providerKind: "cli",
-    providerInstanceId: "cli-standalone",
-    providerEventId: "event-1",
-    providerMessageId: "message-1",
+  await assert.rejects(() => runtime.handleMessage(provider, providerConfig, {
+    ...message("message-1", "fail the thing"),
     target: { provider: "cli-standalone", providerKind: "cli", chatId: "chat-2", threadId: "thread-2" },
-    sender: { providerUserId: "user-1" },
-    text: "fail the thing",
-    rawText: "fail the thing",
-    isCommand: false,
-    attachments: [],
-    receivedAt: new Date("2026-06-01T00:00:00.000Z"),
-    raw: {},
   }), /runtime unavailable/);
 
   const snapshot = await repository.dashboardSnapshot();
   assert.equal(snapshot.sessions[0]?.status, "failed");
+  assert.equal(snapshot.audits[0]?.action, "standalone.prompt.failed");
+});
+
+test("standalone runtime records failed session creation durably", async () => {
+  const repository = new InMemoryStandaloneGatewayRepository();
+  let promptCalled = false;
+  const runtime = createStandaloneGatewayRuntime({
+    repository,
+    opencode: {
+      async createSession() {
+        throw new Error("session bind unavailable");
+      },
+      async prompt() {
+        promptCalled = true;
+      },
+      async health() {
+        return { ok: true, detail: "ready" };
+      },
+    },
+  });
+  const provider = new FakeChannelProvider({ id: "cli-standalone" });
+
+  await assert.rejects(() => runtime.handleMessage(provider, providerConfig, {
+    ...message("message-1", "fail before prompt"),
+    target: { provider: "cli-standalone", providerKind: "cli", chatId: "chat-3", threadId: "thread-3" },
+  }), /session bind unavailable/);
+
+  const snapshot = await repository.dashboardSnapshot();
+  assert.equal(promptCalled, false);
+  assert.equal(snapshot.sessions[0]?.status, "failed");
+  assert.equal(snapshot.sessions[0]?.opencodeSessionId, null);
   assert.equal(snapshot.audits[0]?.action, "standalone.prompt.failed");
 });

--- a/apps/standalone-gateway/src/runtime.ts
+++ b/apps/standalone-gateway/src/runtime.ts
@@ -14,63 +14,81 @@ export function createStandaloneGatewayRuntime(input: {
   opencode: StandaloneOpenCodeAdapter;
 }): StandaloneGatewayRuntime {
   const { repository, opencode } = input;
+  const sessionQueues = new Map<string, Promise<void>>();
+
+  function runSerialized<T>(key: string, action: () => Promise<T>): Promise<T> {
+    const previous = sessionQueues.get(key) || Promise.resolve();
+    const run = previous.catch(() => undefined).then(action);
+    const tracked = run.then(() => undefined, () => undefined);
+    sessionQueues.set(key, tracked);
+    void tracked.finally(() => {
+      if (sessionQueues.get(key) === tracked) sessionQueues.delete(key);
+    });
+    return run;
+  }
+
   return {
     async handleMessage(provider, providerConfig, message) {
       const text = message.text.trim();
       if (!text) return;
-      const session = await repository.findOrCreateSession({
-        provider: provider.id,
-        providerKind: provider.kind,
-        channelBindingId: providerConfig.channelBindingId,
-        target: message.target,
-        externalUserId: message.sender.providerUserId,
-        text,
-      });
-      await repository.appendEvent({ sessionId: session.sessionId, type: "user.message", payload: { text, providerMessageId: message.providerMessageId } });
-      const runtimeSession = session.opencodeSessionId
-        ? session
-        : await repository.updateSessionRuntime({
-            sessionId: session.sessionId,
-            opencodeSessionId: (await opencode.createSession({ title: session.title })).opencodeSessionId,
-            status: "running",
-          });
-      try {
-        await opencode.prompt({
-          opencodeSessionId: runtimeSession.opencodeSessionId || session.sessionId,
+      const externalThreadId = message.target.threadId || message.target.chatId;
+      const sessionQueueKey = `${provider.id}\0${message.target.chatId}\0${externalThreadId}`;
+      await runSerialized(sessionQueueKey, async () => {
+        const session = await repository.findOrCreateSession({
+          provider: provider.id,
+          providerKind: provider.kind,
+          channelBindingId: providerConfig.channelBindingId,
+          target: message.target,
+          externalUserId: message.sender.providerUserId,
           text,
-          onEvent: (event) => appendRuntimeEvent(repository, session.sessionId, event),
         });
-        await repository.updateSessionRuntime({
-          sessionId: session.sessionId,
-          opencodeSessionId: runtimeSession.opencodeSessionId,
-          status: "idle",
-        });
-        await repository.recordAudit("standalone.prompt", message.sender.providerUserId, {
-          provider: provider.id,
-          providerKind: provider.kind,
-          channelBindingId: providerConfig.channelBindingId,
-          sessionId: session.sessionId,
-        });
-      } catch (error) {
-        await repository.appendEvent({
-          sessionId: session.sessionId,
-          type: "session.error",
-          payload: { message: error instanceof Error ? error.message : String(error) },
-        });
-        await repository.updateSessionRuntime({
-          sessionId: session.sessionId,
-          opencodeSessionId: runtimeSession.opencodeSessionId,
-          status: "failed",
-        });
-        await repository.recordAudit("standalone.prompt.failed", message.sender.providerUserId, {
-          provider: provider.id,
-          providerKind: provider.kind,
-          channelBindingId: providerConfig.channelBindingId,
-          sessionId: session.sessionId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      }
+        await repository.appendEvent({ sessionId: session.sessionId, type: "user.message", payload: { text, providerMessageId: message.providerMessageId } });
+        let runtimeSession = session;
+        try {
+          if (!runtimeSession.opencodeSessionId) {
+            runtimeSession = await repository.updateSessionRuntime({
+              sessionId: session.sessionId,
+              opencodeSessionId: (await opencode.createSession({ title: session.title })).opencodeSessionId,
+              status: "running",
+            });
+          }
+          await opencode.prompt({
+            opencodeSessionId: runtimeSession.opencodeSessionId || session.sessionId,
+            text,
+            onEvent: (event) => appendRuntimeEvent(repository, session.sessionId, event),
+          });
+          await repository.updateSessionRuntime({
+            sessionId: session.sessionId,
+            opencodeSessionId: runtimeSession.opencodeSessionId,
+            status: "idle",
+          });
+          await repository.recordAudit("standalone.prompt", message.sender.providerUserId, {
+            provider: provider.id,
+            providerKind: provider.kind,
+            channelBindingId: providerConfig.channelBindingId,
+            sessionId: session.sessionId,
+          });
+        } catch (error) {
+          await repository.appendEvent({
+            sessionId: session.sessionId,
+            type: "session.error",
+            payload: { message: error instanceof Error ? error.message : String(error) },
+          });
+          await repository.updateSessionRuntime({
+            sessionId: session.sessionId,
+            opencodeSessionId: runtimeSession.opencodeSessionId,
+            status: "failed",
+          });
+          await repository.recordAudit("standalone.prompt.failed", message.sender.providerUserId, {
+            provider: provider.id,
+            providerKind: provider.kind,
+            channelBindingId: providerConfig.channelBindingId,
+            sessionId: session.sessionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
+        }
+      });
     },
     async runDueJobs(claimedBy) {
       let processed = 0;

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -163,6 +163,19 @@ function createFixture(options: {
   return { runtime, store, objectStore, policy, service, artifacts, worker, server }
 }
 
+async function processOneSessionCommand(fixture: ReturnType<typeof createFixture>, tenantId: string, sessionId: string) {
+  const lease = await fixture.store.claimSessionLease(tenantId, sessionId, 'single-command-worker')
+  if (!lease) return 0
+  try {
+    const command = await fixture.store.claimNextSessionCommand(lease)
+    if (!command) return 0
+    await fixture.service.executeCommand(lease, command)
+    return 1
+  } finally {
+    await fixture.store.releaseSessionLease(lease)
+  }
+}
+
 async function readJson(response: Response) {
   const text = await response.text()
   return JSON.parse(text) as Record<string, unknown>
@@ -409,6 +422,53 @@ test('cloud HTTP server exposes health, config, session create/list/get, prompt,
     assert.equal(asRecord(abort.projectionFence).sequence, asRecord(asRecord(abort.view).projection).sequence)
     assert.deepEqual(fixture.runtime.aborted, ['oc-session-1'])
   } finally {
+    await fixture.server.close()
+  }
+})
+
+test('cloud HTTP command projection fences require the submitted command event', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  const originalProcessSessionCommands = fixture.worker.processSessionCommands.bind(fixture.worker)
+  try {
+    const created = await readJson(await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    }))
+    const sessionId = String(asRecord(created.session).sessionId)
+
+    fixture.worker.processSessionCommands = async () => 0
+    const oldPromptResponse = await fetch(`${baseUrl}/api/sessions/${sessionId}/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'older queued command' }),
+    })
+    assert.equal(oldPromptResponse.status, 202)
+    const oldPrompt = await readJson(oldPromptResponse)
+    assert.equal(oldPrompt.processed, 0)
+    assert.equal(oldPrompt.projectionFence, null)
+
+    fixture.worker.processSessionCommands = async (tenantId, targetSessionId) => {
+      return processOneSessionCommand(fixture, tenantId, targetSessionId)
+    }
+    const newPromptResponse = await fetch(`${baseUrl}/api/sessions/${sessionId}/prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'new command still pending' }),
+    })
+    assert.equal(newPromptResponse.status, 202)
+    const newPrompt = await readJson(newPromptResponse)
+    assert.equal(newPrompt.processed, 1)
+    assert.equal(newPrompt.projectionFence, null)
+    assert.notEqual(asRecord(oldPrompt.command).commandId, asRecord(newPrompt.command).commandId)
+
+    const projectedMessages = asArray(asRecord(asRecord(asRecord(newPrompt.view).projection).view).messages)
+    assert.equal(projectedMessages.some((message) => asRecord(message).content === 'older queued command'), true)
+    assert.equal(projectedMessages.some((message) => asRecord(message).content === 'new command still pending'), false)
+    assert.deepEqual(fixture.runtime.prompts.map((prompt) => (prompt.parts[0] as { text?: string } | undefined)?.text), ['older queued command'])
+  } finally {
+    fixture.worker.processSessionCommands = originalProcessSessionCommands
     await fixture.server.close()
   }
 })

--- a/tests/cloud-sse-replay.test.ts
+++ b/tests/cloud-sse-replay.test.ts
@@ -58,3 +58,54 @@ test('SSE replay hub replays from each subscriber cursor on an existing topic', 
     hub.close()
   }
 })
+
+test('SSE replay hub catches up a late subscriber that joins during an in-flight poll', async () => {
+  const hub = new CloudSseReplayHub()
+  const events = [
+    { sequence: 1 },
+    { sequence: 2 },
+    { sequence: 3 },
+  ]
+  const loadCalls: number[] = []
+  let releaseFirstLoad: (() => void) | null = null
+  const firstLoad = new Promise<void>((resolve) => {
+    releaseFirstLoad = resolve
+  })
+  const first: number[] = []
+  const second: number[] = []
+  const loadEvents = async (afterSequence: number) => {
+    loadCalls.push(afterSequence)
+    if (loadCalls.length === 1) await firstLoad
+    return events.filter((event) => event.sequence > afterSequence)
+  }
+
+  const unsubscribeFirst = hub.subscribe({
+    key: 'workspace:tenant:user:race',
+    afterSequence: 2,
+    pollMs: 50,
+    loadEvents,
+    listener: (event) => first.push(event.sequence),
+  })
+  try {
+    await waitFor(() => loadCalls.length === 1, 'first in-flight replay poll')
+    const unsubscribeSecond = hub.subscribe({
+      key: 'workspace:tenant:user:race',
+      afterSequence: 0,
+      pollMs: 50,
+      loadEvents,
+      listener: (event) => second.push(event.sequence),
+    })
+    try {
+      releaseFirstLoad?.()
+      await waitFor(() => second.length === 3, 'late subscriber race replay')
+      assert.deepEqual(loadCalls, [2, 0])
+      assert.deepEqual(first, [3])
+      assert.deepEqual(second, [1, 2, 3])
+    } finally {
+      unsubscribeSecond()
+    }
+  } finally {
+    unsubscribeFirst()
+    hub.close()
+  }
+})

--- a/tests/runtime-managed-server.test.ts
+++ b/tests/runtime-managed-server.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { fork, type ChildProcess } from 'node:child_process'
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, realpathSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -82,14 +82,19 @@ test('managed opencode server resolves from stdout and closes the child process'
   const pidFile = join(root, 'pid')
   const envFile = join(root, 'env')
   const argsFile = join(root, 'args')
+  const cwdFile = join(root, 'cwd')
+  const runtimeCwd = join(root, 'runtime-cwd')
+  mkdirSync(runtimeCwd, { recursive: true })
   const executable = writeExecutable(root, 'fake-opencode', `
 printf '%s' "$$" > ${JSON.stringify(pidFile)}
 printf '%s\\n' "$@" > ${JSON.stringify(argsFile)}
+pwd > ${JSON.stringify(cwdFile)}
 printf '%s\\n%s\\n%s\\n' "$OPENCODE_SERVER_USERNAME" "$OPENCODE_SERVER_PASSWORD" "$OPENCODE_DISABLE_EMBEDDED_WEB_UI" > ${JSON.stringify(envFile)}
 printf '%s\\n' 'opencode server listening on http://127.0.0.1:43210'
 while true; do sleep 1; done
 `)
 
+  const mainProcessCwd = process.cwd()
   const server = await createManagedOpencodeServer({
     env: {
       PATH: process.env.PATH || '',
@@ -101,6 +106,7 @@ while true; do sleep 1; done
     config: { logLevel: 'warn' },
     forkUtilityProcess: forkTestSupervisor,
     opencodeBinPath: executable,
+    cwd: runtimeCwd,
     port: 0,
     timeout: 5000,
   })
@@ -110,7 +116,9 @@ while true; do sleep 1; done
       assert.equal(server.url, 'http://127.0.0.1:43210')
       assert.equal(existsSync(pidFile), true)
       assert.match(readFileSync(argsFile, 'utf8'), /--log-level=WARN/)
+      assert.equal(readFileSync(cwdFile, 'utf8').trim(), realpathSync(runtimeCwd))
       assert.equal(readFileSync(envFile, 'utf8'), 'opencode\nruntime-password\ntrue\n')
+      assert.equal(process.cwd(), mainProcessCwd)
       const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10)
       assert.ok(childPid > 0)
       return childPid

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
   dispatchRuntimeSessionEvent,
+  dropSessionFromDispatcherQueues,
   getRuntimeNotification,
   getSessionPatch,
   publishSessionView,
@@ -128,6 +129,65 @@ test('dispatcher batches text patches in event order', async () => {
     sent.filter((entry) => entry.channel === 'session:patch').map((entry) => (entry.payload as { content?: string }).content),
     ['first', 'second'],
   )
+})
+
+test('dispatcher drops queued local and workspace-scoped session patches on deletion', async () => {
+  const { win, sent } = createWindowCollector(55)
+
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-delete-queued',
+    data: {
+      type: 'text',
+      messageId: 'message-delete-local',
+      partId: 'part-delete-local',
+      content: 'local stale',
+      mode: 'append',
+    },
+  })
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-delete-queued',
+    workspaceId: 'workspace-remote',
+    data: {
+      type: 'text',
+      messageId: 'message-delete-remote',
+      partId: 'part-delete-remote',
+      content: 'remote stale',
+      mode: 'append',
+    },
+  })
+  dispatchRuntimeSessionEvent(win as any, {
+    type: 'text',
+    sessionId: 'session-delete-neighbor',
+    workspaceId: 'workspace-remote',
+    data: {
+      type: 'text',
+      messageId: 'message-neighbor',
+      partId: 'part-neighbor',
+      content: 'neighbor stays',
+      mode: 'append',
+    },
+  })
+
+  dropSessionFromDispatcherQueues('session-delete-queued')
+  await wait(30)
+
+  const patchPayloads = sent
+    .filter((entry) => entry.channel === 'session:patch')
+    .map((entry) => {
+      const payload = entry.payload as { sessionId?: string; workspaceId?: string; content?: string }
+      return {
+        sessionId: payload.sessionId,
+        workspaceId: payload.workspaceId,
+        content: payload.content,
+      }
+    })
+  assert.deepEqual(patchPayloads, [{
+    sessionId: 'session-delete-neighbor',
+    workspaceId: 'workspace-remote',
+    content: 'neighbor stays',
+  }])
 })
 
 test('dispatcher bounds queued patches and schedules full-view catch-up on overflow', async () => {

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -44,6 +44,54 @@ test('history projector keeps child task running when the child is idle but has 
   assert.equal(taskRun.taskRun?.status, 'running')
 })
 
+test('history projector uses a stable fallback timestamp for incomplete history', async () => {
+  const fallbackTimestampMs = Date.parse('2026-02-03T04:05:06.000Z')
+  const input = {
+    sessionId: 'root-incomplete',
+    cachedModelId: 'databricks-claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-msg-incomplete', role: 'assistant', time: {} },
+        parts: [
+          { id: 'root-text-incomplete', type: 'text', text: 'Starting' },
+          { id: 'root-task-incomplete', type: 'subtask', agent: 'general', description: 'Check missing times' },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [{ id: 'child-incomplete', title: 'Missing child timestamps' }],
+    statuses: {
+      'root-incomplete': { type: 'busy' },
+      'child-incomplete': { type: 'idle' },
+    },
+    fallbackTimestampMs,
+    loadChildSnapshot: async () => ({
+      messages: [
+        {
+          info: { id: 'child-msg-incomplete', role: 'assistant', time: {} },
+          parts: [
+            { id: 'child-text-incomplete', type: 'text', text: 'Still missing times' },
+          ],
+        },
+      ],
+      todos: [],
+    }),
+  }
+
+  const first = await projectSessionHistory(input)
+  const originalDateNow = Date.now
+  Date.now = () => Date.parse('2036-02-03T04:05:06.000Z')
+  try {
+    assert.deepEqual(await projectSessionHistory(input), first)
+  } finally {
+    Date.now = originalDateNow
+  }
+
+  assert.equal(first.find((item) => item.type === 'message')?.timestamp, '2026-02-03T04:05:06.000Z')
+  assert.equal(first.find((item) => item.type === 'task_run')?.timestamp, '2026-02-03T04:05:06.000Z')
+  assert.equal(first.find((item) => item.type === 'task_text')?.timestamp, '2026-02-03T04:05:06.000Z')
+})
+
 test('history projector marks child task complete after a terminal step-finish stop', async () => {
   const created = 1_713_714_000
   const updated = created + 3


### PR DESCRIPTION
## Summary
- make session history projection deterministic by using stable fallback timestamps during hydration
- remove runtime startup process.chdir reliance and keep managed OpenCode cwd explicit
- harden async queue identity, command-specific projection fences, SSE replay catch-up, and standalone gateway per-session serialization

## Validation
- node --no-warnings --experimental-strip-types --test tests/session-history-projector.test.ts tests/session-event-dispatcher.test.ts tests/session-history-projection-utils.test.ts
- node --no-warnings --experimental-strip-types --test tests/runtime-managed-server.test.ts
- node --no-warnings --experimental-strip-types --test tests/cloud-sse-replay.test.ts tests/cloud-http-server.test.ts
- pnpm --filter @open-cowork/standalone-gateway test
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check

Closes #657
Closes #658
Closes #659
Closes #660
Closes #662
Closes #663