### PR TITLE
Harden renderer async coordination

### DIFF
--- a/apps/desktop/src/main/event-runtime-handlers.ts
+++ b/apps/desktop/src/main/event-runtime-handlers.ts
@@ -449,6 +449,7 @@ export function handleRuntimeSideEffectEvent(input: {
         const updated = updateSessionRecord(info.id, patch)
         win.webContents.send('session:updated', {
           id: info.id,
+          workspaceId: 'local',
           title: info.title || null,
           parentSessionId: info.parentID,
           changeSummary: info.summary,
@@ -471,7 +472,7 @@ export function handleRuntimeSideEffectEvent(input: {
       // client sharing the same OpenCode server, etc). Only broadcast for
       // top-level sessions — child / sub-agent deletions are internal.
       if (!info.parentID) {
-        win.webContents.send('session:deleted', { id: info.id })
+        win.webContents.send('session:deleted', { id: info.id, workspaceId: 'local' })
       }
       return true
     }

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -116,6 +116,7 @@ export function setupIpcHandlers(
     getThreadIndexService().refreshThreadMetadata(sessionId)
     win.webContents.send('session:updated', {
       id: record.id,
+      workspaceId: 'local',
       title: record.title || null,
       parentSessionId: record.parentSessionId,
       changeSummary: record.changeSummary,

--- a/apps/desktop/src/main/session-event-dispatcher.ts
+++ b/apps/desktop/src/main/session-event-dispatcher.ts
@@ -239,6 +239,7 @@ export function publishSessionMetadata(win: BrowserWindow | null | undefined, se
   if (!record) return
   win.webContents.send('session:updated', {
     id: record.id,
+    workspaceId: 'local',
     title: record.title || null,
     parentSessionId: record.parentSessionId,
     changeSummary: record.changeSummary,

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react'
+import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react'
 import type { AppMetadata, CustomAgentConfig, EffectiveAppSettings, PublicAppConfig, SessionInfo, SessionPromptOptions } from '@open-cowork/shared'
 import { Sidebar } from './components/layout/Sidebar'
 import { TitleBar } from './components/layout/TitleBar'
@@ -119,6 +119,7 @@ export function App() {
   useOpenCodeEvents()
   const [rendererErrorNotice, setRendererErrorNotice] = useRendererErrorNotice()
   const [bootstrapError, setBootstrapError] = useState<string | null>(null)
+  const workspaceActivationGenerationRef = useRef(0)
 
   const reportAppError = useCallback((notice: string, error: unknown, viewName = 'app') => {
     setRendererErrorNotice(notice)
@@ -209,12 +210,18 @@ export function App() {
   }, [ensureSidebarVisible])
 
   const activateExactWorkspace = useCallback(async (workspaceId: string) => {
+    const generation = workspaceActivationGenerationRef.current + 1
+    workspaceActivationGenerationRef.current = generation
+    const isCurrentActivation = () => workspaceActivationGenerationRef.current === generation
     const normalized = normalizeWorkspaceId(workspaceId)
     const activated = await window.coworkApi.workspace.activate(normalized)
+    if (!isCurrentActivation()) return null
     const activeId = normalizeWorkspaceId(activated?.id || normalized)
     setActiveWorkspace(activeId)
     await useWorkspaceSupportStore.getState().loadWorkspaceSupport(activeId, { force: true })
+    if (!isCurrentActivation()) return null
     await loadSessions()
+    if (!isCurrentActivation()) return null
     return activeId
   }, [loadSessions, setActiveWorkspace])
 
@@ -229,7 +236,8 @@ export function App() {
 
     const workspaceId = action.routeParams.workspaceId
     if (workspaceId) {
-      await activateExactWorkspace(workspaceId)
+      const activeId = await activateExactWorkspace(workspaceId)
+      if (!activeId) return
     }
 
     setResourceNavigationNotice(null)

--- a/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
@@ -235,10 +235,55 @@ describe('ChatInput', () => {
       'build',
     ))
     expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Could not send the prompt. Please try again.')
+    expect(textarea).toHaveValue('Summarize this')
     expect(api.diagnostics.reportRendererError).toHaveBeenCalledWith(expect.objectContaining({
       message: expect.stringContaining('provider offline'),
       view: 'chat',
     }))
+  })
+
+  it('serializes rapid prompt submissions while a send is in flight', async () => {
+    const pendingPrompt = createDeferred<null>()
+    const prompt = vi.fn(() => pendingPrompt.promise)
+    installRendererTestCoworkApi({
+      app: {
+        config: vi.fn(async () => ({
+          appId: 'com.opencowork.desktop',
+          name: 'Open Cowork',
+          helpUrl: 'https://github.com/joe-broadhead/open-cowork',
+          defaultModel: null,
+          providers: { available: [] },
+          auth: { mode: 'none' },
+        })),
+      },
+      on: {
+        runtimeReady: vi.fn(() => () => undefined),
+      },
+      session: {
+        prompt,
+      },
+    })
+    seedCurrentSession()
+
+    render(<ChatInput />)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Run the task' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => expect(prompt).toHaveBeenCalledTimes(1))
+    expect(prompt).toHaveBeenCalledWith(
+      'session-1',
+      'Run the task',
+      undefined,
+      'build',
+    )
+    expect(textarea).toHaveValue('Run the task')
+
+    pendingPrompt.resolve(null)
+
+    await waitFor(() => expect(textarea).toHaveValue(''))
   })
 
   it('surfaces chat settings load failures through the chat error channel and diagnostics', async () => {

--- a/apps/desktop/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.tsx
@@ -66,6 +66,7 @@ export function ChatInput() {
   const [input, setInput] = useState('')
   const [attachments, setAttachments] = useState<Attachment[]>([])
   const [dragOver, setDragOver] = useState(false)
+  const [submitInFlight, setSubmitInFlight] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const inputChromeRef = useRef<HTMLDivElement>(null)
   const inlinePickerRef = useRef<HTMLDivElement>(null)
@@ -73,6 +74,7 @@ export function ChatInput() {
   const focusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const modelBtnRef = useRef<HTMLButtonElement>(null)
   const reasoningBtnRef = useRef<HTMLButtonElement>(null)
+  const submitInFlightRef = useRef(false)
   const composerSaveVersionByKeyRef = useRef(new Map<string, number>())
   const currentSessionId = useSessionStore((s) => s.currentSessionId)
   const sessions = useSessionStore((s) => s.sessions)
@@ -168,6 +170,7 @@ export function ChatInput() {
   const handleSubmit = useCallback(async () => {
     const text = input.trim()
     if ((!text && attachments.length === 0) || !currentSessionId) return
+    if (submitInFlightRef.current) return
     if (!workspaceSupport.flags.canPrompt) {
       addGlobalError(workspaceSupport.flags.reasons.prompt)
       return
@@ -183,6 +186,8 @@ export function ChatInput() {
     recordPrompt(text)
 
     const currentAttachments = [...attachments]
+    submitInFlightRef.current = true
+    setSubmitInFlight(true)
     try {
       const files = currentAttachments.map(a => ({ mime: a.mime, url: a.url, filename: a.filename }))
       if (!promptText && files.length === 0) {
@@ -208,6 +213,9 @@ export function ChatInput() {
         err,
         addGlobalError,
       )
+    } finally {
+      submitInFlightRef.current = false
+      setSubmitInFlight(false)
     }
   }, [input, attachments, currentSessionId, workspaceSupport.flags, specialistAgents, recordPrompt, agentMode, runtimeControlsManaged, workspaceOptions, reasoningSelection.promptOptions, addGlobalError])
 
@@ -418,7 +426,7 @@ export function ChatInput() {
     : attachments.length > 0 && !workspaceSupport.flags.canAttachFiles
       ? workspaceSupport.flags.reasons.attachFiles
       : null
-  const canSend = (input.trim() || attachments.length > 0) && currentSessionId && !isGenerating && !isAwaitingPermission && !isAwaitingQuestion && !sendBlockedReason
+  const canSend = (input.trim() || attachments.length > 0) && currentSessionId && !submitInFlight && !isGenerating && !isAwaitingPermission && !isAwaitingQuestion && !sendBlockedReason
   const currentModelLabel = (availableModels[provider] || []).find((model) => model.id === currentModel)?.label || currentModel
   const inlineMenuWidth = 260
   // Anchor the menu to the outer input chrome (the whole composer block)

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -2,16 +2,118 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Sidebar } from './Sidebar'
 import { installRendererTestCoworkApi } from '../../test/setup'
+import { useSessionStore } from '../../stores/session'
 import { useWorkspaceSupportStore } from '../../stores/workspace-support'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
 
 describe('Sidebar', () => {
   beforeEach(() => {
+    useSessionStore.setState(useSessionStore.getInitialState(), true)
     useWorkspaceSupportStore.setState({
       supportByWorkspace: {},
       loadedByWorkspace: {},
       loadingByWorkspace: {},
       errorByWorkspace: {},
     })
+  })
+
+  it('ignores stale workspace activation responses', async () => {
+    const slowActivation = deferred<{
+      id: string
+      kind: 'cloud'
+      label: string
+      status: 'online'
+      active: boolean
+      baseUrl: string
+      lastSyncedAt: null
+    }>()
+    let activeWorkspaceId = 'local'
+    const workspace = (id: string) => ({
+      id,
+      kind: id === 'local' ? 'local' as const : 'cloud' as const,
+      label: id === 'local' ? 'Local' : id === 'cloud:slow' ? 'Slow Cloud' : 'Fast Cloud',
+      status: 'online' as const,
+      active: activeWorkspaceId === id,
+      ...(id === 'local' ? {} : { baseUrl: `https://${id.replace(':', '-')}.test` }),
+      lastSyncedAt: null,
+    })
+    const sessionList = vi.fn(async (options?: { workspaceId?: string }) => (
+      options?.workspaceId === 'cloud:fast'
+        ? [{
+            id: 'fast-session',
+            title: 'Fast session',
+            createdAt: '2026-05-27T10:00:00.000Z',
+            updatedAt: '2026-05-27T10:00:00.000Z',
+          }]
+        : [{
+            id: 'slow-session',
+            title: 'Slow session',
+            createdAt: '2026-05-27T10:00:00.000Z',
+            updatedAt: '2026-05-27T10:00:00.000Z',
+          }]
+    ))
+    const activate = vi.fn(async (workspaceId: string) => {
+      if (workspaceId === 'cloud:slow') {
+        const activated = await slowActivation.promise
+        activeWorkspaceId = workspaceId
+        return activated
+      }
+      activeWorkspaceId = workspaceId
+      return workspace(workspaceId)
+    })
+    installRendererTestCoworkApi({
+      workspace: {
+        list: vi.fn(async () => [workspace('local'), workspace('cloud:slow'), workspace('cloud:fast')]),
+        activate,
+        support: vi.fn(async () => [{
+          api: 'sessions.list',
+          status: 'supported',
+          verdict: { allowed: true, reason: null },
+        }]),
+      },
+      session: {
+        list: sessionList,
+      },
+    })
+
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace - private on this device/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Slow Cloud.*Online/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /Local.*Online.*Local workspace - private on this device/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Fast Cloud.*Online/i }))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().activeWorkspaceId).toBe('cloud:fast')
+      expect(useSessionStore.getState().sessions.map((session) => session.id)).toEqual(['fast-session'])
+    })
+
+    slowActivation.resolve({
+      id: 'cloud:slow',
+      kind: 'cloud',
+      label: 'Slow Cloud',
+      status: 'online',
+      active: true,
+      baseUrl: 'https://cloud-slow.test',
+      lastSyncedAt: null,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(useSessionStore.getState().activeWorkspaceId).toBe('cloud:fast')
+    expect(useSessionStore.getState().sessions.map((session) => session.id)).toEqual(['fast-session'])
+    expect(sessionList).not.toHaveBeenCalledWith({ workspaceId: 'cloud:slow' })
   })
 
   it('keeps the upstream sidebar layout when no branding config is provided', () => {

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState, type CSSProperties } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState, type CSSProperties } from 'react'
 import type {
   BrandingSidebarConfig,
   BrandingSidebarLowerConfig,
@@ -308,6 +308,7 @@ function WorkspaceSwitcher() {
   const [gatewayUrl, setGatewayUrl] = useState('')
   const [gatewayToken, setGatewayToken] = useState('')
   const [gatewayLabel, setGatewayLabel] = useState('')
+  const activationGenerationRef = useRef(0)
 
   const activeWorkspace = workspaces.find((workspace) => workspace.active) || workspaces[0] || LOCAL_WORKSPACE_FALLBACK
 
@@ -358,36 +359,51 @@ function WorkspaceSwitcher() {
   }, [loadWorkspaceSupport, setActiveWorkspace, setSessions])
 
   const activateWorkspace = async (workspace: WorkspaceInfo) => {
+    const generation = activationGenerationRef.current + 1
+    activationGenerationRef.current = generation
+    const isCurrentActivation = () => activationGenerationRef.current === generation
     const previousId = activeWorkspace.id
     setOpen(false)
     try {
       if (workspace.kind === 'cloud' && workspace.status === 'auth_required') {
         await window.coworkApi.workspace.login(workspace.id)
+        if (!isCurrentActivation()) return
       }
       let activated = await window.coworkApi.workspace.activate(workspace.id)
+      if (!isCurrentActivation()) return
       if (activated.kind === 'cloud' && activated.status === 'auth_required') {
         await window.coworkApi.workspace.login(activated.id)
+        if (!isCurrentActivation()) return
         activated = await window.coworkApi.workspace.activate(activated.id)
+        if (!isCurrentActivation()) return
       }
       const nextWorkspaces = await window.coworkApi.workspace.list()
+      if (!isCurrentActivation()) return
       setWorkspaces(nextWorkspaces.length > 0 ? nextWorkspaces : [activated])
-      const supportEntries = await refreshSupport(nextWorkspaces.length > 0 ? nextWorkspaces : [activated], () => false)
+      const supportEntries = await refreshSupport(nextWorkspaces.length > 0 ? nextWorkspaces : [activated], () => !isCurrentActivation())
+      if (!isCurrentActivation()) return
       const activeSupport = supportEntries?.find((entry) => entry.workspace.id === activated.id)?.support
       if (activated.id !== previousId) {
         setActiveWorkspace(activated.id)
         setCurrentSession(null)
       }
-      setSessions(await loadSessionsForWorkspace(activated, activeSupport))
+      const sessions = await loadSessionsForWorkspace(activated, activeSupport)
+      if (isCurrentActivation()) setSessions(sessions)
     } catch (error) {
+      if (!isCurrentActivation()) return
       const message = error instanceof Error ? error.message : String(error)
       try {
         const restored = await window.coworkApi.workspace.activate(previousId)
+        if (!isCurrentActivation()) return
         const restoredWorkspaces = await window.coworkApi.workspace.list()
+        if (!isCurrentActivation()) return
         setWorkspaces(restoredWorkspaces.length > 0 ? restoredWorkspaces : [restored])
-        const supportEntries = await refreshSupport(restoredWorkspaces.length > 0 ? restoredWorkspaces : [restored], () => false)
+        const supportEntries = await refreshSupport(restoredWorkspaces.length > 0 ? restoredWorkspaces : [restored], () => !isCurrentActivation())
+        if (!isCurrentActivation()) return
         const restoredSupport = supportEntries?.find((entry) => entry.workspace.id === restored.id)?.support
         setActiveWorkspace(restored.id)
-        setSessions(await loadSessionsForWorkspace(restored, restoredSupport))
+        const sessions = await loadSessionsForWorkspace(restored, restoredSupport)
+        if (isCurrentActivation()) setSessions(sessions)
       } catch {
         // Leave the visible workspace unchanged if rollback also fails; the
         // original login error is still the actionable user-facing failure.

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.test.tsx
@@ -100,6 +100,16 @@ function installApi(
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 describe('WorkflowsPage', () => {
   beforeEach(() => {
     useSessionStore.setState({ activeWorkspaceId: 'local' })
@@ -182,6 +192,78 @@ describe('WorkflowsPage', () => {
 
     expect(api.workflows?.runNow).toHaveBeenCalledWith('workflow-1', { workspaceId: 'cloud:test' })
     await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith('ses_run'))
+  })
+
+  it('ignores stale workflow list refreshes from a previous workspace', async () => {
+    const firstWorkspaceList = createDeferred<WorkflowListPayload>()
+    const secondWorkspaceList = createDeferred<WorkflowListPayload>()
+    useSessionStore.setState({ activeWorkspaceId: 'cloud:first' })
+    useWorkspaceSupportStore.setState({
+      supportByWorkspace: {
+        'cloud:first': WORKSPACE_SUPPORT_APIS.map((api) => ({
+          api,
+          status: api === 'workflows.list' || api === 'workflows.run' ? 'supported' : 'not_supported',
+          verdict: {
+            allowed: api === 'workflows.list' || api === 'workflows.run',
+            reason: api.startsWith('workflows') ? null : 'Blocked by cloud policy.',
+          },
+        })),
+        'cloud:second': WORKSPACE_SUPPORT_APIS.map((api) => ({
+          api,
+          status: api === 'workflows.list' || api === 'workflows.run' ? 'supported' : 'not_supported',
+          verdict: {
+            allowed: api === 'workflows.list' || api === 'workflows.run',
+            reason: api.startsWith('workflows') ? null : 'Blocked by cloud policy.',
+          },
+        })),
+      },
+      loadedByWorkspace: {
+        'cloud:first': true,
+        'cloud:second': true,
+      },
+      loadingByWorkspace: {},
+      errorByWorkspace: {},
+    })
+    const { api } = installApi(payload({ workflows: [] }))
+    vi.mocked(api.workflows!.list)
+      .mockImplementation((options?: { workspaceId?: string }) => {
+        if (options?.workspaceId === 'cloud:first') return firstWorkspaceList.promise
+        if (options?.workspaceId === 'cloud:second') return secondWorkspaceList.promise
+        return Promise.resolve(payload({ workflows: [] }))
+      })
+
+    render(<WorkflowsPage onOpenThread={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(api.workflows?.list).toHaveBeenCalledWith({ workspaceId: 'cloud:first' })
+    })
+
+    useSessionStore.setState({ activeWorkspaceId: 'cloud:second' })
+    await waitFor(() => {
+      expect(api.workflows?.list).toHaveBeenCalledWith({ workspaceId: 'cloud:second' })
+    })
+
+    secondWorkspaceList.resolve(payload({
+      workflows: [{
+        ...payload().workflows[0]!,
+        id: 'workflow-second',
+        title: 'Second workspace workflow',
+      }],
+    }))
+    expect(await screen.findByText('Second workspace workflow')).toBeInTheDocument()
+
+    firstWorkspaceList.resolve(payload({
+      workflows: [{
+        ...payload().workflows[0]!,
+        id: 'workflow-first',
+        title: 'First workspace workflow',
+      }],
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Second workspace workflow')).toBeInTheDocument()
+      expect(screen.queryByText('First workspace workflow')).not.toBeInTheDocument()
+    })
   })
 
   it('fails closed for cloud workflow access when workspace support cannot load', async () => {

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { EffectiveAppSettings, WorkflowListPayload, WorkflowRun, WorkflowSummary, WorkflowTrigger } from '@open-cowork/shared'
 import { formatDate as formatLocalizedDate } from '../../helpers/i18n'
 import { useActiveWorkspaceSupport } from '../../stores/workspace-support'
@@ -82,6 +82,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
   const [feedback, setFeedback] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [runtimeConfigSource, setRuntimeConfigSource] = useState<EffectiveAppSettings['runtimeConfigSource']>('app')
+  const refreshGenerationRef = useRef(0)
   const workspaceSupport = useActiveWorkspaceSupport()
   const activeWorkspaceIsLocal = workspaceSupport.workspaceId === LOCAL_WORKSPACE_ID
   const workspaceOptions = activeWorkspaceIsLocal ? undefined : { workspaceId: workspaceSupport.workspaceId }
@@ -94,34 +95,44 @@ export function WorkflowsPage({ onOpenThread }: Props) {
   )
   const archivedCount = payload.workflows.length - activeWorkflows.length
 
-  const refresh = async () => {
+  const refresh = async (generation = refreshGenerationRef.current + 1) => {
+    refreshGenerationRef.current = generation
+    const isCurrentRefresh = () => refreshGenerationRef.current === generation
     setLoading(true)
     try {
       if (workflowListBlocked) {
-        setPayload(EMPTY_PAYLOAD)
+        if (isCurrentRefresh()) setPayload(EMPTY_PAYLOAD)
         return
       }
-      setPayload(activeWorkspaceIsLocal
+      const nextPayload = activeWorkspaceIsLocal
         ? await window.coworkApi.workflows.list()
-        : await window.coworkApi.workflows.list(workspaceOptions))
+        : await window.coworkApi.workflows.list(workspaceOptions)
+      if (isCurrentRefresh()) setPayload(nextPayload)
     } finally {
-      setLoading(false)
+      if (isCurrentRefresh()) setLoading(false)
     }
   }
 
   useEffect(() => {
-    void refresh()
+    const generation = refreshGenerationRef.current + 1
+    refreshGenerationRef.current = generation
+    const isCurrentRefresh = () => refreshGenerationRef.current === generation
+    void refresh(generation)
     const settingsRequest = activeWorkspaceIsLocal
       ? window.coworkApi.settings.get()
       : window.coworkApi.settings.get(workspaceOptions)
     void settingsRequest.then((settings) => {
-      setRuntimeConfigSource(settings.runtimeConfigSource === 'machine' ? 'machine' : 'app')
+      if (isCurrentRefresh()) setRuntimeConfigSource(settings.runtimeConfigSource === 'machine' ? 'machine' : 'app')
     }).catch(() => {
-      setRuntimeConfigSource('app')
+      if (isCurrentRefresh()) setRuntimeConfigSource('app')
     })
-    return window.coworkApi.on.workflowUpdated(() => {
+    const unsubscribe = window.coworkApi.on.workflowUpdated(() => {
       void refresh()
     })
+    return () => {
+      refreshGenerationRef.current += 1
+      unsubscribe()
+    }
   }, [workflowListBlocked, workspaceOptions?.workspaceId])
   const workflowDraftBlocked = !activeWorkspaceIsLocal || runtimeConfigSource === 'machine'
   const workflowActionBlocked = !workspaceSupport.flags.canRunWorkflow

--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.test.tsx
@@ -14,6 +14,12 @@ describe('useOpenCodeEvents', () => {
   let notify: ((event: RuntimeNotification) => void) | null = null
   let sessionPatch: ((event: SessionPatch) => void) | null = null
   let sessionView: ((event: { sessionId: string; view: SessionView }) => void) | null = null
+  let sessionUpdated: ((event: {
+    id: string
+    workspaceId?: string | null
+    title: string | null
+  }) => void) | null = null
+  let sessionDeleted: ((event: { id: string; workspaceId?: string | null }) => void) | null = null
   let workspaceSessionsUpdated: ((event: WorkspaceSessionsUpdatedEvent) => void) | null = null
   let closeAudioContext: ReturnType<typeof vi.fn>
 
@@ -78,6 +84,8 @@ describe('useOpenCodeEvents', () => {
     notify = null
     sessionPatch = null
     sessionView = null
+    sessionUpdated = null
+    sessionDeleted = null
     workspaceSessionsUpdated = null
     closeAudioContext = vi.fn(async () => undefined)
     resetSessionStore()
@@ -129,12 +137,18 @@ describe('useOpenCodeEvents', () => {
           return vi.fn()
         }),
         permissionRequest: vi.fn(() => vi.fn()),
-        sessionDeleted: vi.fn(() => vi.fn()),
+        sessionDeleted: vi.fn((callback: (event: { id: string; workspaceId?: string | null }) => void) => {
+          sessionDeleted = callback
+          return vi.fn()
+        }),
         sessionPatch: vi.fn((callback: (event: SessionPatch) => void) => {
           sessionPatch = callback
           return vi.fn()
         }),
-        sessionUpdated: vi.fn(() => vi.fn()),
+        sessionUpdated: vi.fn((callback: (event: { id: string; workspaceId?: string | null; title: string | null }) => void) => {
+          sessionUpdated = callback
+          return vi.fn()
+        }),
         sessionView: vi.fn((callback: (event: { sessionId: string; view: SessionView }) => void) => {
           sessionView = callback
           return vi.fn()
@@ -265,6 +279,54 @@ describe('useOpenCodeEvents', () => {
     })
 
     expect(useSessionStore.getState().sessions.map((session) => session.id)).toEqual(['active-session'])
+  })
+
+  it('routes session metadata and delete events by workspace identity', () => {
+    render(<Harness />)
+    useSessionStore.getState().setSessions([{
+      id: 'shared-session',
+      title: 'Local title',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }])
+    useSessionStore.getState().setActiveWorkspace('cloud:active')
+    useSessionStore.getState().setSessions([{
+      id: 'shared-session',
+      title: 'Cloud title',
+      createdAt: '2026-05-27T10:00:00.000Z',
+      updatedAt: '2026-05-27T10:00:00.000Z',
+    }])
+
+    act(() => {
+      sessionUpdated?.({
+        id: 'shared-session',
+        workspaceId: 'local',
+        title: 'Local renamed',
+      })
+      sessionUpdated?.({
+        id: 'shared-session',
+        workspaceId: 'cloud:active',
+        title: 'Cloud renamed',
+      })
+    })
+
+    expect(useSessionStore.getState().sessions[0]?.title).toBe('Cloud renamed')
+    useSessionStore.getState().setActiveWorkspace('local')
+    expect(useSessionStore.getState().sessions[0]?.title).toBe('Local renamed')
+    useSessionStore.getState().setActiveWorkspace('cloud:active')
+
+    act(() => {
+      sessionDeleted?.({ id: 'shared-session', workspaceId: 'local' })
+    })
+    expect(useSessionStore.getState().sessions.map((session) => session.id)).toEqual(['shared-session'])
+    useSessionStore.getState().setActiveWorkspace('local')
+    expect(useSessionStore.getState().sessions).toEqual([])
+    useSessionStore.getState().setActiveWorkspace('cloud:active')
+
+    act(() => {
+      sessionDeleted?.({ id: 'shared-session', workspaceId: 'cloud:active' })
+    })
+    expect(useSessionStore.getState().sessions).toEqual([])
   })
 
   it('flushes older buffered text before immediately committing a newer task patch', () => {

--- a/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
+++ b/apps/desktop/src/renderer/hooks/useOpenCodeEvents.ts
@@ -194,7 +194,7 @@ export function useOpenCodeEvents() {
     })
 
     const unsubSessionUpdate = window.coworkApi.on.sessionUpdated((data) => {
-      useSessionStore.getState().applySessionMetadata(data)
+      useSessionStore.getState().applySessionMetadata(data, data.workspaceId)
     })
 
     // Externally-triggered session deletions (SDK cleanup, another client
@@ -203,7 +203,7 @@ export function useOpenCodeEvents() {
     // refreshed. The main handler only broadcasts for top-level sessions,
     // so this is safe to dispatch directly into `removeSession`.
     const unsubSessionDelete = window.coworkApi.on.sessionDeleted((data) => {
-      useSessionStore.getState().removeSession(data.id)
+      useSessionStore.getState().removeSession(data.id, data.workspaceId)
     })
 
     const unsubWorkspaceSessions = window.coworkApi.on.workspaceSessionsUpdated((data) => {

--- a/apps/desktop/src/renderer/stores/session.test.ts
+++ b/apps/desktop/src/renderer/stores/session.test.ts
@@ -138,6 +138,29 @@ describe('useSessionStore', () => {
     expect(localState.currentView.isAwaitingQuestion).toBe(false)
   })
 
+  it('routes metadata and deletes to exact workspace buckets', () => {
+    const store = useSessionStore.getState()
+
+    store.setSessions([session('shared', 'Local shared')])
+    useSessionStore.getState().setActiveWorkspace('cloud:acme')
+    useSessionStore.getState().setSessions([session('shared', 'Cloud shared')])
+
+    useSessionStore.getState().applySessionMetadata({
+      id: 'shared',
+      title: 'Local renamed',
+    }, 'local')
+    expect(useSessionStore.getState().sessions[0]?.title).toBe('Cloud shared')
+
+    useSessionStore.getState().setActiveWorkspace('local')
+    expect(useSessionStore.getState().sessions[0]?.title).toBe('Local renamed')
+
+    useSessionStore.getState().removeSession('shared', 'cloud:acme')
+    expect(useSessionStore.getState().sessions.map((entry) => entry.id)).toEqual(['shared'])
+
+    useSessionStore.getState().setActiveWorkspace('cloud:acme')
+    expect(useSessionStore.getState().sessions).toEqual([])
+  })
+
   it('applies message and task text patches to the visible session', () => {
     const store = useSessionStore.getState()
     store.setCurrentSession('ses_1')

--- a/apps/desktop/src/renderer/stores/session.ts
+++ b/apps/desktop/src/renderer/stores/session.ts
@@ -50,6 +50,30 @@ export type { HistoryItem, SessionViewState } from '../../lib/session-view-model
 
 export type Session = SessionInfo
 
+type SessionMetadataPatch = {
+  id: string
+  title: string | null
+  parentSessionId?: string | null
+  changeSummary?: SessionChangeSummary | null
+  revertedMessageId?: string | null
+  composerModelId?: string | null
+  composerReasoningVariant?: string | null
+}
+
+function applySessionMetadataPatch(session: Session, patch: SessionMetadataPatch): Session {
+  if (session.id !== patch.id) return session
+  const next: Session = { ...session }
+  if (patch.title !== null && patch.title !== undefined) next.title = patch.title
+  // parentSessionId is stable once set. SDK refresh events occasionally
+  // arrive with parentID=null; guard against erasing a real fork linkage.
+  if (patch.parentSessionId) next.parentSessionId = patch.parentSessionId
+  if (patch.changeSummary !== undefined) next.changeSummary = patch.changeSummary
+  if (patch.revertedMessageId !== undefined) next.revertedMessageId = patch.revertedMessageId
+  if (patch.composerModelId !== undefined) next.composerModelId = patch.composerModelId
+  if (patch.composerReasoningVariant !== undefined) next.composerReasoningVariant = patch.composerReasoningVariant
+  return next
+}
+
 export interface McpConnection {
   name: string
   connected: boolean
@@ -73,16 +97,8 @@ export interface SessionStore {
     modelId?: string | null
     reasoningVariant?: string | null
   }) => void
-  applySessionMetadata: (patch: {
-    id: string
-    title: string | null
-    parentSessionId?: string | null
-    changeSummary?: SessionChangeSummary | null
-    revertedMessageId?: string | null
-    composerModelId?: string | null
-    composerReasoningVariant?: string | null
-  }) => void
-  removeSession: (id: string) => void
+  applySessionMetadata: (patch: SessionMetadataPatch, workspaceId?: string | null) => void
+  removeSession: (id: string, workspaceId?: string | null) => void
   setSessionView: (sessionId: string, view: SessionView, workspaceId?: string | null) => void
   applySessionPatch: (patch: SessionPatch) => void
   applySessionPatches: (patches: SessionPatch[]) => void
@@ -234,37 +250,26 @@ export const useSessionStore = create<SessionStore>((set) => ({
       }),
     },
   })),
-  applySessionMetadata: (patch) => set((state) => ({
-    sessions: state.sessions.map((session) => {
-      if (session.id !== patch.id) return session
-      const next: Session = { ...session }
-      if (patch.title !== null && patch.title !== undefined) next.title = patch.title
-      // parentSessionId is stable once set. SDK refresh events occasionally
-      // arrive with parentID=null; guard against erasing a real fork linkage.
-      if (patch.parentSessionId) next.parentSessionId = patch.parentSessionId
-      if (patch.changeSummary !== undefined) next.changeSummary = patch.changeSummary
-      if (patch.revertedMessageId !== undefined) next.revertedMessageId = patch.revertedMessageId
-      if (patch.composerModelId !== undefined) next.composerModelId = patch.composerModelId
-      if (patch.composerReasoningVariant !== undefined) next.composerReasoningVariant = patch.composerReasoningVariant
-      return next
-    }),
-    sessionsByWorkspace: {
-      ...state.sessionsByWorkspace,
-      [normalizeWorkspaceId(state.activeWorkspaceId)]: state.sessions.map((session) => {
-        if (session.id !== patch.id) return session
-        const next: Session = { ...session }
-        if (patch.title !== null && patch.title !== undefined) next.title = patch.title
-        if (patch.parentSessionId) next.parentSessionId = patch.parentSessionId
-        if (patch.changeSummary !== undefined) next.changeSummary = patch.changeSummary
-        if (patch.revertedMessageId !== undefined) next.revertedMessageId = patch.revertedMessageId
-        if (patch.composerModelId !== undefined) next.composerModelId = patch.composerModelId
-        if (patch.composerReasoningVariant !== undefined) next.composerReasoningVariant = patch.composerReasoningVariant
-        return next
-      }),
-    },
-  })),
-  removeSession: (id) => set((state) => {
-    const sessionKey = activeSessionWorkspaceKey(state, id)
+  applySessionMetadata: (patch, workspaceId) => set((state) => {
+    const activeWorkspaceId = normalizeWorkspaceId(state.activeWorkspaceId)
+    const targetWorkspaceId = normalizeWorkspaceId(workspaceId ?? activeWorkspaceId)
+    const currentSessions = targetWorkspaceId === activeWorkspaceId
+      ? state.sessions
+      : state.sessionsByWorkspace[targetWorkspaceId] || []
+    const nextSessions = currentSessions.map((session) => applySessionMetadataPatch(session, patch))
+    return {
+      sessions: targetWorkspaceId === activeWorkspaceId ? nextSessions : state.sessions,
+      sessionsByWorkspace: {
+        ...state.sessionsByWorkspace,
+        [targetWorkspaceId]: nextSessions,
+      },
+    }
+  }),
+  removeSession: (id, workspaceId) => set((state) => {
+    const activeWorkspaceId = normalizeWorkspaceId(state.activeWorkspaceId)
+    const targetWorkspaceId = normalizeWorkspaceId(workspaceId ?? activeWorkspaceId)
+    const targetIsActive = targetWorkspaceId === activeWorkspaceId
+    const sessionKey = sessionWorkspaceKey(targetWorkspaceId, id)
     const sessionStateById = { ...state.sessionStateById }
     delete sessionStateById[sessionKey]
     const chartArtifactsBySession = { ...state.chartArtifactsBySession }
@@ -283,13 +288,16 @@ export const useSessionStore = create<SessionStore>((set) => ({
     const nextAwaitingQuestion = state.awaitingQuestionSessions.has(sessionKey)
       ? new Set(Array.from(state.awaitingQuestionSessions).filter((sid) => sid !== sessionKey))
       : state.awaitingQuestionSessions
-    const nextSessions = state.sessions.filter((session) => session.id !== id)
+    const currentSessions = targetIsActive
+      ? state.sessions
+      : state.sessionsByWorkspace[targetWorkspaceId] || []
+    const nextSessions = currentSessions.filter((session) => session.id !== id)
 
     const patch: Partial<SessionStore> = {
-      sessions: nextSessions,
+      sessions: targetIsActive ? nextSessions : state.sessions,
       sessionsByWorkspace: {
         ...state.sessionsByWorkspace,
-        [normalizeWorkspaceId(state.activeWorkspaceId)]: nextSessions,
+        [targetWorkspaceId]: nextSessions,
       },
       sessionStateById,
       totalCost: sumSessionCosts(sessionStateById),
@@ -299,7 +307,7 @@ export const useSessionStore = create<SessionStore>((set) => ({
       chartArtifactsBySession,
     }
 
-    if (state.currentSessionId === id) {
+    if (targetIsActive && state.currentSessionId === id) {
       Object.assign(patch, {
         currentSessionId: null,
         currentView: deriveVisibleSessionPatch(

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -76,6 +76,7 @@ export type CloudWebClientStateContract = {
   workspace: unknown | null
   csrfToken: string | null
   selectedSessionId: string | null
+  sessionSelectionGeneration: number
   sessions: unknown[]
   sessionList: {
     nextCursor: string | null

--- a/apps/website/src/client/common-script.ts
+++ b/apps/website/src/client/common-script.ts
@@ -29,6 +29,7 @@ const state = {
   },
   sessionViews: {},
   selectedSessionId: null,
+  sessionSelectionGeneration: 0,
   runtimeActions: {},
   threadLimit: ${CLOUD_WEB_THREAD_PAGE_SIZE},
   threadFilters: {
@@ -277,6 +278,7 @@ function renderSignedOut() {
   };
   state.sessionViews = {};
   state.selectedSessionId = null;
+  state.sessionSelectionGeneration += 1;
   state.runtimeActions = {};
   state.artifactPanel = {
     sessionId: null,

--- a/apps/website/src/client/workbench-script.ts
+++ b/apps/website/src/client/workbench-script.ts
@@ -658,10 +658,18 @@ function readSseEvent(event) {
 
 async function refreshSelectedSession() {
   if (!state.selectedSessionId) return;
-  await loadSessionView(state.selectedSessionId, { render: true });
+  await loadSessionView(state.selectedSessionId, {
+    render: true,
+    selectionGeneration: state.sessionSelectionGeneration,
+  });
 }
 
-function openSessionEvents(sessionId, afterSequence = 0) {
+function isCurrentSessionSelection(sessionId, selectionGeneration) {
+  return state.selectedSessionId === sessionId
+    && state.sessionSelectionGeneration === selectionGeneration;
+}
+
+function openSessionEvents(sessionId, afterSequence = 0, selectionGeneration = state.sessionSelectionGeneration) {
   closeEventSource(state.sessionEvents);
   state.sessionEvents = {
     source: null,
@@ -671,6 +679,7 @@ function openSessionEvents(sessionId, afterSequence = 0) {
     error: null,
   };
   if (!window.EventSource) {
+    if (!isCurrentSessionSelection(sessionId, selectionGeneration)) return;
     state.sessionEvents.status = 'closed';
     renderChat();
     return;
@@ -678,14 +687,17 @@ function openSessionEvents(sessionId, afterSequence = 0) {
   const source = new EventSource(sseUrl(endpointPath('sessionEvents', '/api/sessions/:sessionId/events', { sessionId }), afterSequence), { withCredentials: true });
   state.sessionEvents.source = source;
   source.onopen = () => {
+    if (!isCurrentSessionSelection(sessionId, selectionGeneration)) return;
     state.sessionEvents.status = 'open';
     renderChat();
   };
   source.onerror = () => {
+    if (!isCurrentSessionSelection(sessionId, selectionGeneration)) return;
     state.sessionEvents.status = 'retrying';
     renderChat();
   };
   bindCloudEventListeners(source, (event) => {
+    if (!isCurrentSessionSelection(sessionId, selectionGeneration)) return;
     const payload = readSseEvent(event);
     if (payload?.sequence) state.sessionEvents.cursor = Math.max(state.sessionEvents.cursor, payload.sequence);
     if (payload?.type === 'snapshot.required') {
@@ -724,6 +736,12 @@ function openWorkspaceEvents(afterSequence = 0) {
 
 async function loadSessionView(sessionId, options = {}) {
   const view = await api(endpointPath('sessionView', '/api/sessions/:sessionId/view', { sessionId }));
+  if (
+    typeof options.selectionGeneration === 'number'
+    && !isCurrentSessionSelection(sessionId, options.selectionGeneration)
+  ) {
+    return null;
+  }
   state.sessionViews[sessionId] = view;
   if (options.render !== false) {
     renderThreadList();
@@ -734,10 +752,24 @@ async function loadSessionView(sessionId, options = {}) {
 }
 
 async function selectSession(sessionId) {
+  const selectionGeneration = state.sessionSelectionGeneration + 1;
+  state.sessionSelectionGeneration = selectionGeneration;
   state.selectedSessionId = sessionId;
-  const view = await loadSessionView(sessionId, { render: false });
+  closeEventSource(state.sessionEvents);
+  state.sessionEvents = {
+    source: null,
+    sessionId,
+    cursor: 0,
+    status: 'connecting',
+    error: null,
+  };
+  renderThreadList();
+  renderChat();
+  renderArtifacts();
+  const view = await loadSessionView(sessionId, { render: false, selectionGeneration });
+  if (!view || !isCurrentSessionSelection(sessionId, selectionGeneration)) return;
   const afterSequence = typeof view?.projection?.sequence === 'number' ? view.projection.sequence : 0;
-  openSessionEvents(sessionId, afterSequence);
+  openSessionEvents(sessionId, afterSequence, selectionGeneration);
   setRoute('chat', true);
   renderThreadList();
   renderChat();

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -127,12 +127,16 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
   assert.match(html, /"api":/)
   assert.match(html, /"routeMatrix":/)
   assert.match(cloudWebsiteClientScript(), /endpoint\(id, fallback\)/)
+  assert.match(cloudWebsiteClientScript(), /sessionSelectionGeneration/)
+  assert.match(cloudWebsiteClientScript(), /isCurrentSessionSelection/)
+  assert.match(cloudWebsiteClientScript(), /selectionGeneration/)
   const stateContract: CloudWebClientStateContract = {
     authStatus: 'loading',
     activeRoute: DEFAULT_CLOUD_WEB_ROUTE,
     workspace: null,
     csrfToken: null,
     selectedSessionId: null,
+    sessionSelectionGeneration: 0,
     sessions: [],
     sessionList: {
       nextCursor: null,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -431,6 +431,7 @@ export interface CoworkAPI {
     runtimeLoadingStatus: (callback: (status: RuntimeLoadingStatus) => void) => () => void
     sessionUpdated: (callback: (data: {
       id: string
+      workspaceId?: string | null
       title: string | null
       parentSessionId?: string | null
       changeSummary?: SessionChangeSummary | null
@@ -438,7 +439,7 @@ export interface CoworkAPI {
       composerModelId?: string | null
       composerReasoningVariant?: string | null
     }) => void) => () => void
-    sessionDeleted: (callback: (data: { id: string }) => void) => () => void
+    sessionDeleted: (callback: (data: { id: string; workspaceId?: string | null }) => void) => () => void
     workspaceSessionsUpdated: (callback: (data: WorkspaceSessionsUpdatedEvent) => void) => () => void
     workflowUpdated: (callback: () => void) => () => void
   }

--- a/tests/session-event-dispatcher.test.ts
+++ b/tests/session-event-dispatcher.test.ts
@@ -534,6 +534,7 @@ test('history refresh publishes SDK-owned session metadata after registry sync',
       sent.find((entry) => entry.channel === 'session:updated')?.payload,
       {
         id: 'session-title-sync',
+        workspaceId: 'local',
         title: 'SDK generated title',
         parentSessionId: null,
         changeSummary: null,


### PR DESCRIPTION
## Summary

This groups the next roadmap async/client coordination batch into one PR:

- adds explicit workspace identity to local session metadata/delete renderer events and routes renderer session metadata/deletes into exact workspace buckets
- fences workspace activation, resource navigation activation, cloud web thread selection, and workflow list refreshes with request generations so stale responses cannot overwrite the active workspace/session view
- serializes chat composer prompt submissions locally while an IPC send is in flight, while preserving retry input on failures

Closes #665
Closes #666
Closes #667
Closes #668
Closes #669

## Validation

- `pnpm --filter @open-cowork/desktop test:renderer -- Sidebar.test.tsx ChatInput.test.tsx WorkflowsPage.test.tsx useOpenCodeEvents.test.tsx session.test.ts`
- `pnpm --filter @open-cowork/website test`
- `node --no-warnings --experimental-strip-types --test tests/session-event-dispatcher.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `pnpm test` (1,798 tests: 1,778 passed, 20 skipped)
- `pnpm test:renderer` (70 files, 353 tests)

Note: an earlier renderer run was intentionally discarded because it ran concurrently with `pnpm test`; the shared package rebuild cleaned `packages/shared/dist` while Vitest was importing it. The isolated renderer rerun passed.