### PR TITLE
Harden workflow creation validation

### DIFF
--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -2391,9 +2391,14 @@ export class CloudSessionService {
   async createWorkflow(principal: CloudPrincipal, draft: WorkflowDraft): Promise<WorkflowDetail> {
     await this.ensurePrincipal(principal)
     this.assertWorkflowsEnabled()
-    const normalized = this.normalizeWorkflowDraft(draft)
-    this.assertWorkflowDraftAllowed(normalized)
     const now = new Date()
+    let normalized: WorkflowDraft
+    try {
+      normalized = this.normalizeWorkflowDraft(draft, now)
+    } catch (error) {
+      throw new CloudServiceError(400, error instanceof Error ? error.message : 'Workflow draft is invalid.')
+    }
+    this.assertWorkflowDraftAllowed(normalized)
     const workflow = await this.store.createWorkflow({
       tenantId: principal.tenantId,
       userId: principal.userId,
@@ -3596,8 +3601,8 @@ export class CloudSessionService {
     }
   }
 
-  private normalizeWorkflowDraft(draft: WorkflowDraft): WorkflowDraft {
-    const triggers = this.normalizeWorkflowTriggers(draft.triggers)
+  private normalizeWorkflowDraft(draft: WorkflowDraft, now = new Date()): WorkflowDraft {
+    const triggers = this.normalizeWorkflowTriggers(draft.triggers, now)
     if (!triggers.some((trigger) => trigger.type === 'manual')) {
       triggers.unshift({ id: this.ids.randomUUID(), type: 'manual', enabled: true })
     }
@@ -3613,7 +3618,7 @@ export class CloudSessionService {
     }
   }
 
-  private normalizeWorkflowTriggers(value: unknown): WorkflowTrigger[] {
+  private normalizeWorkflowTriggers(value: unknown, now: Date): WorkflowTrigger[] {
     if (!Array.isArray(value) || value.length === 0) {
       throw new Error('Workflow requires at least one trigger.')
     }
@@ -3631,7 +3636,7 @@ export class CloudSessionService {
       if (type === 'schedule') {
         const schedule = asRecord(trigger.schedule) as unknown as WorkflowTrigger['schedule']
         if (!schedule) throw new Error('Scheduled workflow trigger requires a schedule.')
-        const scheduleError = validateWorkflowSchedule(schedule)
+        const scheduleError = validateWorkflowSchedule(schedule, now)
         if (scheduleError) throw new Error(scheduleError)
         normalized.schedule = schedule
       }

--- a/apps/desktop/src/main/workflow/workflow-service.ts
+++ b/apps/desktop/src/main/workflow/workflow-service.ts
@@ -73,8 +73,9 @@ function workflowDraftPrompt(sessionId: string) {
     '- what output should be produced',
     '',
     'When the workflow is clear, call mcp__workflows__preview_workflow and show the proposal to the user.',
-    'Only after the user explicitly confirms, call mcp__workflows__create_workflow.',
-    `Set draftSessionId to "${sessionId}" in both tool calls.`,
+    `Set draftSessionId to "${sessionId}" on the preview draft so the saved workflow links back to this setup thread.`,
+    'Only after the user explicitly confirms, call mcp__workflows__create_workflow with the previewToken returned by the preview tool.',
+    'Do not reconstruct or change the draft in create_workflow.',
   ].join('\n')
 }
 

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from 'node:sqlite'
-import { chmodSync, existsSync, mkdirSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import electron from 'electron'
 import type {
@@ -15,6 +15,7 @@ import type {
   WorkflowToolPreview,
   WorkflowTrigger,
   WorkflowTriggerType,
+  WorkflowValidationGap,
 } from '@open-cowork/shared'
 import {
   createCloudProjectionCheckpoint,
@@ -53,6 +54,16 @@ const ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION = 2
 type DbRow = Record<string, unknown>
 type WorkflowWriteOptions = {
   now?: Date
+  capabilities?: WorkflowCapabilityValidationContext
+}
+type WorkflowDraftOptions = {
+  now?: Date
+  capabilities?: WorkflowCapabilityValidationContext
+}
+export type WorkflowCapabilityValidationContext = {
+  agentNames?: readonly string[]
+  skillNames?: readonly string[]
+  toolIds?: readonly string[]
 }
 type WorkflowSecretStorageAdapter = {
   mode: SecretStorageMode
@@ -212,11 +223,82 @@ function writeNow(options?: WorkflowWriteOptions) {
   return options?.now ?? new Date()
 }
 
-export function normalizeWorkflowDraft(draft: WorkflowDraft): WorkflowDraft {
+function hasCapabilityReference(value: string, available?: readonly string[]) {
+  if (!available) return true
+  return available.includes(value)
+}
+
+function projectDirectoryExists(directory: string) {
+  try {
+    return statSync(directory).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export function validateWorkflowDraftCapabilities(
+  draft: WorkflowDraft,
+  capabilities?: WorkflowCapabilityValidationContext,
+): WorkflowValidationGap[] {
+  const gaps: WorkflowValidationGap[] = []
+
+  if (!hasCapabilityReference(draft.agentName, capabilities?.agentNames)) {
+    gaps.push({
+      severity: 'required',
+      field: 'agentName',
+      value: draft.agentName,
+      message: `Workflow agent "${draft.agentName}" is not available.`,
+    })
+  }
+
+  for (const skillName of draft.skillNames || []) {
+    if (hasCapabilityReference(skillName, capabilities?.skillNames)) continue
+    gaps.push({
+      severity: 'optional',
+      field: 'skillNames',
+      value: skillName,
+      message: `Workflow skill "${skillName}" is not available.`,
+    })
+  }
+
+  for (const toolId of draft.toolIds || []) {
+    if (hasCapabilityReference(toolId, capabilities?.toolIds)) continue
+    gaps.push({
+      severity: 'optional',
+      field: 'toolIds',
+      value: toolId,
+      message: `Workflow tool "${toolId}" is not available.`,
+    })
+  }
+
+  if (draft.projectDirectory && !projectDirectoryExists(draft.projectDirectory)) {
+    gaps.push({
+      severity: 'required',
+      field: 'projectDirectory',
+      value: draft.projectDirectory,
+      message: `Workflow project directory "${draft.projectDirectory}" is not available.`,
+    })
+  }
+
+  return gaps
+}
+
+function requiredWorkflowGaps(gaps: WorkflowValidationGap[]) {
+  return gaps.filter((gap) => gap.severity === 'required')
+}
+
+function assertWorkflowCapabilities(draft: WorkflowDraft, capabilities?: WorkflowCapabilityValidationContext) {
+  const gaps = validateWorkflowDraftCapabilities(draft, capabilities)
+  const required = requiredWorkflowGaps(gaps)
+  if (required.length > 0) throw new Error(required[0]!.message)
+  return gaps
+}
+
+export function normalizeWorkflowDraft(draft: WorkflowDraft, options?: WorkflowDraftOptions): WorkflowDraft {
   const title = boundedText(draft.title, 'Workflow title', 512)
   const instructions = boundedText(draft.instructions, 'Workflow instructions', MAX_TEXT)
   const agentName = boundedText(draft.agentName || 'build', 'Workflow agent', 256)
-  const triggers = normalizeWorkflowTriggers(draft.triggers)
+  const triggers = normalizeWorkflowTriggers(draft.triggers, options?.now ?? new Date())
   if (!triggers.some((trigger) => trigger.type === 'manual')) {
     triggers.unshift({ id: crypto.randomUUID(), type: 'manual', enabled: true })
   }
@@ -232,7 +314,7 @@ export function normalizeWorkflowDraft(draft: WorkflowDraft): WorkflowDraft {
   }
 }
 
-function normalizeWorkflowTriggers(value: unknown): WorkflowTrigger[] {
+function normalizeWorkflowTriggers(value: unknown, now: Date): WorkflowTrigger[] {
   if (!Array.isArray(value) || value.length === 0) {
     throw new Error('Workflow requires at least one trigger.')
   }
@@ -250,7 +332,7 @@ function normalizeWorkflowTriggers(value: unknown): WorkflowTrigger[] {
     }
     if (normalized.type === 'schedule') {
       if (!trigger.schedule) throw new Error('Scheduled workflow trigger requires a schedule.')
-      const scheduleError = validateWorkflowSchedule(trigger.schedule)
+      const scheduleError = validateWorkflowSchedule(trigger.schedule, now)
       if (scheduleError) throw new Error(scheduleError)
       normalized.schedule = trigger.schedule
     }
@@ -469,23 +551,33 @@ function listRunsForWorkflow(workflowId: string, limit = 25) {
   return rows.map(rowToRun)
 }
 
-export function previewWorkflowDraft(draft: WorkflowDraft): WorkflowToolPreview {
-  const missing: string[] = []
+export function previewWorkflowDraft(draft: WorkflowDraft, options?: WorkflowDraftOptions): WorkflowToolPreview {
   try {
-    const normalizedDraft = normalizeWorkflowDraft(draft)
+    const now = options?.now ?? new Date()
+    const normalizedDraft = normalizeWorkflowDraft(draft, { ...options, now })
+    const gaps = validateWorkflowDraftCapabilities(normalizedDraft, options?.capabilities)
+    const missing = requiredWorkflowGaps(gaps).map((gap) => gap.message)
     return {
       ok: missing.length === 0,
       title: normalizedDraft.title,
       summary: normalizedDraft.instructions.slice(0, 500),
       missing,
+      gaps,
       normalizedDraft,
     }
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Workflow draft is invalid.'
     return {
       ok: false,
       title: typeof draft.title === 'string' ? draft.title : 'Workflow draft',
-      summary: error instanceof Error ? error.message : 'Workflow draft is invalid.',
-      missing: [error instanceof Error ? error.message : 'Workflow draft is invalid.'],
+      summary: message,
+      missing: [message],
+      gaps: [{
+        severity: 'required',
+        field: 'draft',
+        value: '',
+        message,
+      }],
     }
   }
 }
@@ -508,8 +600,9 @@ export function getWorkflow(workflowId: string, webhookBaseUrl?: string | null):
 }
 
 export function createWorkflow(draft: WorkflowDraft, webhookBaseUrl?: string | null, options?: WorkflowWriteOptions): WorkflowDetail {
-  const normalized = normalizeWorkflowDraft(draft)
   const nowDate = writeNow(options)
+  const normalized = normalizeWorkflowDraft(draft, { ...options, now: nowDate })
+  assertWorkflowCapabilities(normalized, options?.capabilities)
   const now = nowDate.toISOString()
   const id = crypto.randomUUID()
   const nextRunAt = computeNextWorkflowRunAt(normalized.triggers, nowDate)

--- a/apps/desktop/src/main/workflow/workflow-tool-actions.ts
+++ b/apps/desktop/src/main/workflow/workflow-tool-actions.ts
@@ -1,22 +1,141 @@
-import type { WorkflowDraft, WorkflowToolCreateResult } from '@open-cowork/shared'
+import { randomBytes } from 'node:crypto'
+import type {
+  WorkflowDraft,
+  WorkflowToolCreateRequest,
+  WorkflowToolCreateResult,
+  WorkflowToolPreview,
+} from '@open-cowork/shared'
 import {
   createWorkflow,
   previewWorkflowDraft,
+  type WorkflowCapabilityValidationContext,
 } from './workflow-store.ts'
 import { getWorkflowWebhookBaseUrl } from './workflow-webhook-server.ts'
+import {
+  getConfiguredAgentsFromConfig,
+  getConfiguredSkillsFromConfig,
+  getConfiguredToolsFromConfig,
+} from '../config-loader.ts'
+import { getBuiltInAgentOverride } from '../built-in-agent-overrides.ts'
+import { getRuntimeCatalogSnapshot } from '../runtime-catalog-snapshot.ts'
+import { log } from '../logger.ts'
 
 let publishWorkflowUpdated: (() => void) | null = null
+const PREVIEW_TOKEN_TTL_MS = 30 * 60 * 1000
+const PREVIEW_TOKEN_MAX_ENTRIES = 256
+const BUILT_IN_AGENT_NAMES = ['build', 'plan', 'general', 'explore', 'executive-assistant', 'autoresearch'] as const
+const previewTokens = new Map<string, { normalizedDraft: WorkflowDraft; expiresAt: number }>()
+
+export class WorkflowToolActionError extends Error {}
 
 export function configureWorkflowToolActions(options: { publishWorkflowUpdated: () => void }) {
   publishWorkflowUpdated = options.publishWorkflowUpdated
 }
 
-export function previewWorkflowFromTool(draft: WorkflowDraft) {
-  return previewWorkflowDraft(draft)
+function cloneWorkflowDraft(draft: WorkflowDraft): WorkflowDraft {
+  return JSON.parse(JSON.stringify(draft)) as WorkflowDraft
 }
 
-export function createWorkflowFromTool(draft: WorkflowDraft): WorkflowToolCreateResult {
-  const workflow = createWorkflow(draft, getWorkflowWebhookBaseUrl())
-  publishWorkflowUpdated?.()
-  return { ok: true, workflow }
+function pruneExpiredPreviewTokens(now = Date.now()) {
+  for (const [token, preview] of previewTokens.entries()) {
+    if (preview.expiresAt <= now) previewTokens.delete(token)
+  }
+}
+
+function mintPreviewToken(normalizedDraft: WorkflowDraft) {
+  pruneExpiredPreviewTokens()
+  while (previewTokens.size >= PREVIEW_TOKEN_MAX_ENTRIES) {
+    const oldest = previewTokens.keys().next().value
+    if (typeof oldest !== 'string') break
+    previewTokens.delete(oldest)
+  }
+  const token = randomBytes(32).toString('base64url')
+  previewTokens.set(token, {
+    normalizedDraft: cloneWorkflowDraft(normalizedDraft),
+    expiresAt: Date.now() + PREVIEW_TOKEN_TTL_MS,
+  })
+  return token
+}
+
+function readPreviewToken(request: WorkflowToolCreateRequest) {
+  const record = request && typeof request === 'object' && !Array.isArray(request)
+    ? request as Partial<WorkflowToolCreateRequest>
+    : null
+  const previewToken = typeof record?.previewToken === 'string' ? record.previewToken.trim() : ''
+  if (!previewToken) {
+    throw new WorkflowToolActionError('Workflow create requires the previewToken returned by preview_workflow after the user confirms the preview.')
+  }
+  return previewToken
+}
+
+function sorted(values: Set<string>) {
+  return Array.from(values).filter(Boolean).sort((a, b) => a.localeCompare(b))
+}
+
+async function resolveWorkflowCapabilityContext(draft: WorkflowDraft): Promise<WorkflowCapabilityValidationContext> {
+  const agentNames = new Set<string>()
+  const fallbackSkillNames = getConfiguredSkillsFromConfig().map((skill) => skill.sourceName)
+  const skillNames = new Set<string>()
+  const toolIds = new Set(getConfiguredToolsFromConfig().map((tool) => tool.id))
+
+  for (const agentName of BUILT_IN_AGENT_NAMES) {
+    if (getBuiltInAgentOverride(agentName)?.disable === true) continue
+    agentNames.add(agentName)
+  }
+  for (const agent of getConfiguredAgentsFromConfig()) agentNames.add(agent.name)
+
+  try {
+    const projectDirectory = typeof draft.projectDirectory === 'string' && draft.projectDirectory.trim()
+      ? draft.projectDirectory
+      : undefined
+    const snapshot = await getRuntimeCatalogSnapshot(projectDirectory ? { directory: projectDirectory } : undefined)
+    for (const skill of snapshot.availableSkills) skillNames.add(skill.name)
+    for (const tool of snapshot.builtinTools) toolIds.add(tool.id)
+    for (const mcp of snapshot.customMcps) {
+      if (mcp.name) toolIds.add(mcp.name)
+    }
+    for (const tool of snapshot.runtimeTools) toolIds.add(tool.id)
+    for (const agent of snapshot.customAgentSummaries) {
+      if (agent.enabled && agent.valid) agentNames.add(agent.name)
+    }
+  } catch (error) {
+    for (const skillName of fallbackSkillNames) skillNames.add(skillName)
+    log('error', `Workflow capability validation catalog lookup failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  return {
+    agentNames: sorted(agentNames),
+    skillNames: sorted(skillNames),
+    toolIds: sorted(toolIds),
+  }
+}
+
+export async function previewWorkflowFromTool(draft: WorkflowDraft): Promise<WorkflowToolPreview> {
+  const capabilities = await resolveWorkflowCapabilityContext(draft)
+  const preview = previewWorkflowDraft(draft, { capabilities })
+  if (!preview.ok || !preview.normalizedDraft) return preview
+  return {
+    ...preview,
+    previewToken: mintPreviewToken(preview.normalizedDraft),
+  }
+}
+
+export async function createWorkflowFromTool(request: WorkflowToolCreateRequest): Promise<WorkflowToolCreateResult> {
+  const previewToken = readPreviewToken(request)
+  pruneExpiredPreviewTokens()
+  const preview = previewTokens.get(previewToken)
+  previewTokens.delete(previewToken)
+  if (!preview) {
+    throw new WorkflowToolActionError('Workflow create requires a valid confirmed preview token. Preview the workflow, ask the user to confirm it, then pass previewToken to create_workflow.')
+  }
+
+  try {
+    const normalizedDraft = cloneWorkflowDraft(preview.normalizedDraft)
+    const capabilities = await resolveWorkflowCapabilityContext(normalizedDraft)
+    const workflow = createWorkflow(normalizedDraft, getWorkflowWebhookBaseUrl(), { capabilities })
+    publishWorkflowUpdated?.()
+    return { ok: true, workflow }
+  } catch (error) {
+    throw new WorkflowToolActionError(error instanceof Error ? error.message : 'Workflow create failed.')
+  }
 }

--- a/apps/desktop/src/main/workflow/workflow-tool-bridge.ts
+++ b/apps/desktop/src/main/workflow/workflow-tool-bridge.ts
@@ -1,7 +1,11 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { randomBytes, timingSafeEqual } from 'node:crypto'
-import type { WorkflowDraft } from '@open-cowork/shared'
-import { createWorkflowFromTool, previewWorkflowFromTool } from './workflow-tool-actions.ts'
+import type { WorkflowDraft, WorkflowToolCreateRequest } from '@open-cowork/shared'
+import {
+  createWorkflowFromTool,
+  previewWorkflowFromTool,
+  WorkflowToolActionError,
+} from './workflow-tool-actions.ts'
 import { log } from '../logger.ts'
 
 const MAX_TOOL_BODY_BYTES = 256 * 1024
@@ -74,19 +78,24 @@ async function handleToolRequest(req: IncomingMessage, res: ServerResponse) {
     assertAuthorized(req)
     const body = await readJsonBody(req)
     if (req.url === '/preview') {
-      writeJson(res, 200, previewWorkflowFromTool(body as unknown as WorkflowDraft) as unknown as Record<string, unknown>)
+      const result = await previewWorkflowFromTool(body as unknown as WorkflowDraft)
+      writeJson(res, 200, result as unknown as Record<string, unknown>)
       return
     }
     if (req.url === '/create') {
-      const result = createWorkflowFromTool(body as unknown as WorkflowDraft)
+      const result = await createWorkflowFromTool(body as unknown as WorkflowToolCreateRequest)
       writeJson(res, 200, result as unknown as Record<string, unknown>)
       return
     }
     writeJson(res, 404, { ok: false, error: 'Workflow tool route not found.' })
   } catch (error) {
     const status = error instanceof ToolBridgeHttpError ? error.status : 400
-    const message = error instanceof ToolBridgeHttpError ? error.publicMessage : 'Workflow tool request failed.'
-    if (!(error instanceof ToolBridgeHttpError)) {
+    const message = error instanceof ToolBridgeHttpError
+      ? error.publicMessage
+      : error instanceof WorkflowToolActionError
+        ? error.message
+        : 'Workflow tool request failed.'
+    if (!(error instanceof ToolBridgeHttpError) && !(error instanceof WorkflowToolActionError)) {
       log('error', `Workflow tool request failed: ${error instanceof Error ? error.message : String(error)}`)
     }
     writeJson(res, status, { ok: false, error: message })

--- a/docs/skills-and-mcps.md
+++ b/docs/skills-and-mcps.md
@@ -78,7 +78,8 @@ short tool name such as `bar_chart`.
     Lets a Workflow Designer setup thread preview and save repeatable Open Cowork
     workflows with manual, scheduled, or webhook triggers. Runtime ids:
     `mcp__workflows__preview_workflow` and
-    `mcp__workflows__create_workflow`. Source:
+    `mcp__workflows__create_workflow`; create accepts the preview token returned
+    by the confirmed preview. Source:
     `mcps/workflows/src/index.ts`.
 
 -   :material-monitor-dashboard: **`semantic-ui` MCP** <span class="status-badge stable">stable</span>
@@ -388,8 +389,8 @@ create custom agents through the same validation path as the UI. The bundled
 that teaches the model how to use a paired MCP" pattern. The `clock` skill +
 `clock` MCP pair uses the same pattern for calendar reasoning. The
 `workflow-creator` + `workflows` MCP pair applies it to workflow setup: the
-skill teaches the conversational checklist, while the MCP previews and saves
-the confirmed workflow. The `autoresearch` skill extends the pattern by
+skill teaches the conversational checklist, while the MCP previews, validates,
+and saves only from a confirmed preview token. The `autoresearch` skill extends the pattern by
 composing `charts`, `skills`, and `agents`: charts show experiment progress,
 while the Skills and Agents MCPs can apply approved custom improvements.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -52,7 +52,8 @@ local project directory or host-path grant.
 6. Workflow Designer calls the bundled `mcp__workflows__preview_workflow`
    tool and shows the proposed workflow.
 7. After you explicitly confirm, Workflow Designer calls
-   `mcp__workflows__create_workflow`.
+   `mcp__workflows__create_workflow` with the preview token returned by the
+   preview tool.
 
 The saved workflow points back to that setup thread so you can reopen the
 conversation that created it.
@@ -120,7 +121,7 @@ stateDiagram-v2
     [*] --> SetupThread: Add workflow
     SetupThread --> Preview: Workflow Designer calls preview_workflow
     Preview --> SetupThread: user edits or answers questions
-    Preview --> Saved: user confirms and Workflow Designer calls create_workflow
+    Preview --> Saved: user confirms and Workflow Designer calls create_workflow with preview token
     Saved --> RunThread: manual, schedule, or webhook trigger
     RunThread --> Completed: assistant finishes
     RunThread --> Failed: runtime or session error

--- a/mcps/workflows/README.md
+++ b/mcps/workflows/README.md
@@ -16,7 +16,7 @@ The server talks only to the app-owned localhost bridge started by the Electron 
   the desktop bridge.
 - Saving a workflow remains approval-gated by the agent policy; the MCP tool
   description tells agents to call `create_workflow` only after explicit user
-  confirmation.
+  confirmation, using the `previewToken` returned by `preview_workflow`.
 
 ## Development
 

--- a/mcps/workflows/src/index.ts
+++ b/mcps/workflows/src/index.ts
@@ -41,6 +41,10 @@ const workflowDraftShape = {
 
 type WorkflowDraftInput = z.infer<z.ZodObject<typeof workflowDraftShape>>
 
+const workflowCreateShape = {
+  previewToken: z.string().min(1).describe('previewToken returned by preview_workflow after the user explicitly confirms the proposal.'),
+}
+
 function bridgeUrl() {
   const value = process.env.OPEN_COWORK_WORKFLOW_TOOL_URL?.trim()
   if (!value) throw new Error('OPEN_COWORK_WORKFLOW_TOOL_URL is not configured.')
@@ -72,7 +76,7 @@ function bridgeToken() {
   return value
 }
 
-async function postToBridge(path: '/preview' | '/create', draft: WorkflowDraftInput) {
+async function postToBridge(path: '/preview' | '/create', body: WorkflowDraftInput | z.infer<z.ZodObject<typeof workflowCreateShape>>) {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), BRIDGE_REQUEST_TIMEOUT_MS)
   let response: Response
@@ -83,7 +87,7 @@ async function postToBridge(path: '/preview' | '/create', draft: WorkflowDraftIn
         authorization: `Bearer ${bridgeToken()}`,
         'content-type': 'application/json',
       },
-      body: JSON.stringify(draft),
+      body: JSON.stringify(body),
       signal: controller.signal,
     })
   } catch (error) {
@@ -128,9 +132,9 @@ server.tool(
 
 server.tool(
   'create_workflow',
-  'Save a confirmed Open Cowork workflow. Call only after the user explicitly confirms the preview.',
-  workflowDraftShape,
-  async (draft) => textResult(await postToBridge('/create', draft)),
+  'Save a confirmed Open Cowork workflow. Call only after the user explicitly confirms the preview, passing the previewToken returned by preview_workflow.',
+  workflowCreateShape,
+  async (request) => textResult(await postToBridge('/create', request)),
 )
 
 process.stderr.write('[workflows-mcp] Server started\n')

--- a/mcps/workflows/tests/contract.test.ts
+++ b/mcps/workflows/tests/contract.test.ts
@@ -24,6 +24,7 @@ async function withBridge<T>(fn: (baseUrl: string, seen: Array<{ url: string; bo
         ok: true,
         route: req.url,
         title: body?.title,
+        previewToken: req.url === '/preview' ? 'preview-token-from-bridge' : undefined,
       }))
     })
   })
@@ -125,11 +126,16 @@ test('workflows MCP previews and creates through the app bridge', async () => {
       const listed = await client.listTools()
       assert.deepEqual(listed.tools.map((tool) => tool.name).sort(), ['create_workflow', 'preview_workflow'])
 
-      assert.equal(parseTextResult(await client.callTool({ name: 'preview_workflow', arguments: draft })).route, '/preview')
-      assert.equal(parseTextResult(await client.callTool({ name: 'create_workflow', arguments: draft })).route, '/create')
+      const preview = parseTextResult(await client.callTool({ name: 'preview_workflow', arguments: draft }))
+      assert.equal(preview.route, '/preview')
+      assert.equal(parseTextResult(await client.callTool({
+        name: 'create_workflow',
+        arguments: { previewToken: preview.previewToken },
+      })).route, '/create')
     })
     assert.deepEqual(seen.map((entry) => entry.url), ['/preview', '/create'])
     assert.equal((seen[0]?.body as { title?: string }).title, 'Inbox summary')
+    assert.deepEqual(seen[1]?.body, { previewToken: 'preview-token-from-bridge' })
   })
 })
 
@@ -147,7 +153,7 @@ test('workflows MCP rejects invalid drafts and surfaces bridge errors', async ()
     await withWorkflowsClient(baseUrl, async (client) => {
       await assertToolError(client, {
         name: 'create_workflow',
-        arguments: draft,
+        arguments: { previewToken: 'preview-token-from-bridge' },
       }, /workflow bridge exploded/)
     })
   })

--- a/packages/shared/src/workflow.ts
+++ b/packages/shared/src/workflow.ts
@@ -36,6 +36,15 @@ export interface WorkflowDraft {
   triggers: WorkflowTrigger[]
 }
 
+export type WorkflowValidationGapSeverity = 'required' | 'optional'
+
+export interface WorkflowValidationGap {
+  severity: WorkflowValidationGapSeverity
+  field: string
+  value: string
+  message: string
+}
+
 export interface WorkflowSummary {
   id: string
   title: string
@@ -88,7 +97,13 @@ export interface WorkflowToolPreview {
   title: string
   summary: string
   missing: string[]
+  gaps?: WorkflowValidationGap[]
   normalizedDraft?: WorkflowDraft
+  previewToken?: string
+}
+
+export interface WorkflowToolCreateRequest {
+  previewToken: string
 }
 
 export interface WorkflowToolCreateResult {
@@ -177,34 +192,60 @@ function isValidTimeZone(timeZone: string) {
   }
 }
 
-export function validateWorkflowSchedule(schedule: WorkflowSchedule) {
+function isIntegerInRange(value: unknown, min: number, max: number) {
+  return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max
+}
+
+function parseScheduleStartAt(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const parsed = new Date(value)
+  return Number.isFinite(parsed.getTime()) ? parsed : null
+}
+
+export function validateWorkflowSchedule(schedule: WorkflowSchedule, from?: Date) {
   if (!schedule?.type) return 'Schedule type is required.'
   if (!VALID_SCHEDULE_TYPES.has(schedule.type)) return 'Schedule type is invalid.'
   if (!schedule.timezone) return 'Schedule timezone is required.'
   if (!isValidTimeZone(schedule.timezone)) return 'Schedule timezone is invalid.'
-  if (schedule.type === 'weekly' && (typeof schedule.dayOfWeek !== 'number' || schedule.dayOfWeek < 0 || schedule.dayOfWeek > 6)) {
+  if (schedule.runAtHour !== null && schedule.runAtHour !== undefined && !isIntegerInRange(schedule.runAtHour, 0, 23)) {
+    return 'Schedule runAtHour must be an integer between 0 and 23.'
+  }
+  if (schedule.runAtMinute !== null && schedule.runAtMinute !== undefined && !isIntegerInRange(schedule.runAtMinute, 0, 59)) {
+    return 'Schedule runAtMinute must be an integer between 0 and 59.'
+  }
+  if (schedule.type === 'weekly' && !isIntegerInRange(schedule.dayOfWeek, 0, 6)) {
     return 'Weekly schedules require dayOfWeek between 0 and 6.'
   }
-  if (schedule.type === 'monthly' && (typeof schedule.dayOfMonth !== 'number' || schedule.dayOfMonth < 1 || schedule.dayOfMonth > 31)) {
+  if (schedule.type === 'monthly' && !isIntegerInRange(schedule.dayOfMonth, 1, 31)) {
     return 'Monthly schedules require dayOfMonth between 1 and 31.'
   }
   if (schedule.type === 'one_time' && !schedule.startAt) return 'One-time schedules require startAt.'
+  if (schedule.startAt) {
+    const startAt = parseScheduleStartAt(schedule.startAt)
+    if (!startAt) return 'Schedule startAt must be a valid ISO timestamp.'
+    if (from && startAt.getTime() <= from.getTime()) return 'Schedule startAt must be in the future.'
+  }
   return null
 }
 
 export function computeNextWorkflowScheduleRunAt(schedule: WorkflowSchedule, from = new Date()) {
   const runAtHour = schedule.runAtHour ?? 9
   const runAtMinute = schedule.runAtMinute ?? 0
-  const zonedNow = getZonedParts(from, schedule.timezone)
 
   if (schedule.type === 'one_time') {
     const at = schedule.startAt ? new Date(schedule.startAt) : null
     return at && !Number.isNaN(at.getTime()) && at.getTime() > from.getTime() ? at.toISOString() : null
   }
 
+  const startAt = parseScheduleStartAt(schedule.startAt)
+  const recurrenceFrom = startAt && startAt.getTime() > from.getTime()
+    ? new Date(startAt.getTime() - 1)
+    : from
+  const zonedNow = getZonedParts(recurrenceFrom, schedule.timezone)
+
   if (schedule.type === 'daily') {
     let candidate = zonedDateTimeToUtc(schedule.timezone, zonedNow.year, zonedNow.month, zonedNow.day, runAtHour, runAtMinute)
-    if (candidate.getTime() <= from.getTime()) {
+    if (candidate.getTime() <= recurrenceFrom.getTime()) {
       const tomorrow = addDays(zonedNow, 1)
       candidate = zonedDateTimeToUtc(schedule.timezone, tomorrow.year, tomorrow.month, tomorrow.day, runAtHour, runAtMinute)
     }
@@ -218,7 +259,7 @@ export function computeNextWorkflowScheduleRunAt(schedule: WorkflowSchedule, fro
     if (delta < 0) delta += 7
     let target = addDays(zonedNow, delta)
     let candidate = zonedDateTimeToUtc(schedule.timezone, target.year, target.month, target.day, runAtHour, runAtMinute)
-    if (candidate.getTime() <= from.getTime()) {
+    if (candidate.getTime() <= recurrenceFrom.getTime()) {
       target = addDays(target, 7)
       candidate = zonedDateTimeToUtc(schedule.timezone, target.year, target.month, target.day, runAtHour, runAtMinute)
     }
@@ -228,7 +269,7 @@ export function computeNextWorkflowScheduleRunAt(schedule: WorkflowSchedule, fro
   const requestedDay = schedule.dayOfMonth ?? 1
   const day = clampDayOfMonth(zonedNow.year, zonedNow.month, requestedDay)
   let candidate = zonedDateTimeToUtc(schedule.timezone, zonedNow.year, zonedNow.month, day, runAtHour, runAtMinute)
-  if (candidate.getTime() <= from.getTime()) {
+  if (candidate.getTime() <= recurrenceFrom.getTime()) {
     const nextMonth = zonedNow.month === 12
       ? { year: zonedNow.year + 1, month: 1 }
       : { year: zonedNow.year, month: zonedNow.month + 1 }

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -4439,6 +4439,66 @@ test('cloud HTTP exposes workflow create, manual run, and durable finalization',
   }
 })
 
+test('cloud HTTP validates workflow schedules at the create boundary', async () => {
+  const fixture = createFixture()
+  const baseUrl = await fixture.server.listen()
+  const postWorkflow = (triggers: unknown[]) => fetch(`${baseUrl}/api/workflows`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      title: 'Scheduled revenue',
+      instructions: 'Summarize scheduled revenue.',
+      agentName: 'data-analyst',
+      triggers,
+    }),
+  })
+
+  try {
+    const invalidHour = await postWorkflow([{
+      id: 'daily',
+      type: 'schedule',
+      enabled: true,
+      schedule: {
+        type: 'daily',
+        timezone: 'UTC',
+        runAtHour: 24,
+      },
+    }])
+    assert.equal(invalidHour.status, 400)
+    assert.match(String((await readJson(invalidHour)).error), /runAtHour/)
+
+    const pastOneTime = await postWorkflow([{
+      id: 'once',
+      type: 'schedule',
+      enabled: true,
+      schedule: {
+        type: 'one_time',
+        timezone: 'UTC',
+        startAt: '2000-01-01T00:00:00.000Z',
+      },
+    }])
+    assert.equal(pastOneTime.status, 400)
+    assert.match(String((await readJson(pastOneTime)).error), /future/)
+
+    const futureStartAt = '2099-01-01T00:00:00.000Z'
+    const valid = await postWorkflow([{
+      id: 'once',
+      type: 'schedule',
+      enabled: true,
+      schedule: {
+        type: 'one_time',
+        timezone: 'UTC',
+        startAt: futureStartAt,
+      },
+    }])
+    assert.equal(valid.status, 201)
+    const workflow = asRecord((await readJson(valid)).workflow)
+    assert.equal(workflow.nextRunAt, futureStartAt)
+  } finally {
+    await fixture.server.close()
+  }
+})
+
 test('cloud HTTP gates managed workflow runs by concurrency and hourly quotas', async () => {
   const createWorkflow = async (baseUrl: string, suffix: string) => {
     const response = await fetch(`${baseUrl}/api/workflows`, {

--- a/tests/shared-roadmap-dist-contracts.test.ts
+++ b/tests/shared-roadmap-dist-contracts.test.ts
@@ -417,6 +417,11 @@ test('dist workflow schedule helpers validate and compute next runs across trigg
   assert.equal(validateWorkflowSchedule({ type: 'monthly', timezone: 'UTC', dayOfMonth: 32 }), 'Monthly schedules require dayOfMonth between 1 and 31.')
   assert.equal(validateWorkflowSchedule({ type: 'one_time', timezone: 'UTC' }), 'One-time schedules require startAt.')
   assert.equal(validateWorkflowSchedule({ type: 'daily', timezone: 'Not/AZone' }), 'Schedule timezone is invalid.')
+  assert.equal(validateWorkflowSchedule({ type: 'daily', timezone: 'UTC', runAtHour: 24 }), 'Schedule runAtHour must be an integer between 0 and 23.')
+  assert.equal(validateWorkflowSchedule({ type: 'daily', timezone: 'UTC', runAtMinute: 60 }), 'Schedule runAtMinute must be an integer between 0 and 59.')
+  assert.equal(validateWorkflowSchedule({ type: 'one_time', timezone: 'UTC', startAt: 'not-a-date' }, from), 'Schedule startAt must be a valid ISO timestamp.')
+  assert.equal(validateWorkflowSchedule({ type: 'one_time', timezone: 'UTC', startAt: '2026-06-03T09:00:00.000Z' }, from), 'Schedule startAt must be in the future.')
+  assert.equal(validateWorkflowSchedule({ type: 'one_time', timezone: 'UTC', startAt: '2026-06-03T11:00:00.000Z' }, from), null)
 
   assert.equal(computeNextWorkflowScheduleRunAt({
     type: 'one_time',
@@ -434,6 +439,13 @@ test('dist workflow schedule helpers validate and compute next runs across trigg
     runAtHour: 9,
     runAtMinute: 15,
   }, from), '2026-06-04T09:15:00.000Z')
+  assert.equal(computeNextWorkflowScheduleRunAt({
+    type: 'daily',
+    timezone: 'UTC',
+    startAt: '2026-06-05T10:00:00.000Z',
+    runAtHour: 9,
+    runAtMinute: 15,
+  }, from), '2026-06-06T09:15:00.000Z')
   assert.equal(computeNextWorkflowScheduleRunAt({
     type: 'weekly',
     timezone: 'UTC',

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -451,7 +451,9 @@ test('workflow tool bridge requires bearer auth and creates workflows through th
       body: JSON.stringify(manualWorkflowDraft),
     })
     assert.equal(preview.status, 200)
-    assert.equal((await preview.json() as { ok: boolean }).ok, true)
+    const previewBody = await preview.json() as { ok: boolean; previewToken?: string }
+    assert.equal(previewBody.ok, true)
+    assert.equal(typeof previewBody.previewToken, 'string')
 
     const created = await fetch(`${baseUrl}/create`, {
       method: 'POST',
@@ -459,7 +461,7 @@ test('workflow tool bridge requires bearer auth and creates workflows through th
         authorization: `Bearer ${token}`,
         'content-type': 'application/json',
       },
-      body: JSON.stringify(manualWorkflowDraft),
+      body: JSON.stringify({ previewToken: previewBody.previewToken }),
     })
     assert.equal(created.status, 200)
     const createdBody = await created.json() as { ok: boolean; workflow: { id: string; title: string; webhookUrl: string | null } }

--- a/tests/workflow-schedule.test.ts
+++ b/tests/workflow-schedule.test.ts
@@ -24,11 +24,32 @@ test('workflow schedules compute the next enabled trigger', () => {
   assert.equal(next, '2026-05-15T09:00:00.000Z')
 })
 
+test('workflow recurring schedules honor future startAt boundaries', () => {
+  const from = new Date('2026-05-14T09:30:00.000Z')
+
+  assert.equal(computeNextWorkflowRunAt([
+    {
+      id: 'daily',
+      type: 'schedule',
+      enabled: true,
+      schedule: {
+        type: 'daily',
+        timezone: 'UTC',
+        startAt: '2026-05-16T10:00:00.000Z',
+        runAtHour: 9,
+        runAtMinute: 0,
+      },
+    },
+  ], from), '2026-05-17T09:00:00.000Z')
+})
+
 test('workflow schedule validation catches incomplete scheduled triggers', () => {
+  const now = new Date('2026-05-14T09:30:00.000Z')
+
   assert.equal(validateWorkflowSchedule({
     type: 'one_time',
     timezone: 'UTC',
-  }), 'One-time schedules require startAt.')
+  }, now), 'One-time schedules require startAt.')
   assert.equal(validateWorkflowSchedule({
     type: 'weekly',
     timezone: 'UTC',
@@ -41,6 +62,31 @@ test('workflow schedule validation catches incomplete scheduled triggers', () =>
     runAtHour: 9,
     runAtMinute: 0,
   }), 'Schedule timezone is invalid.')
+  assert.equal(validateWorkflowSchedule({
+    type: 'daily',
+    timezone: 'UTC',
+    runAtHour: 24,
+  }), 'Schedule runAtHour must be an integer between 0 and 23.')
+  assert.equal(validateWorkflowSchedule({
+    type: 'daily',
+    timezone: 'UTC',
+    runAtMinute: 60,
+  }), 'Schedule runAtMinute must be an integer between 0 and 59.')
+  assert.equal(validateWorkflowSchedule({
+    type: 'one_time',
+    timezone: 'UTC',
+    startAt: 'not-a-date',
+  }, now), 'Schedule startAt must be a valid ISO timestamp.')
+  assert.equal(validateWorkflowSchedule({
+    type: 'one_time',
+    timezone: 'UTC',
+    startAt: '2026-05-14T09:00:00.000Z',
+  }, now), 'Schedule startAt must be in the future.')
+  assert.equal(validateWorkflowSchedule({
+    type: 'one_time',
+    timezone: 'UTC',
+    startAt: '2026-05-14T10:00:00.000Z',
+  }, now), null)
 })
 
 test('desktop workflow schedule module re-exports the shared validator', async () => {

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -27,6 +27,10 @@ import {
   setWorkflowSecretStorageForTests,
   updateWorkflowStatus,
 } from '../apps/desktop/src/main/workflow/workflow-store.ts'
+import {
+  createWorkflowFromTool,
+  previewWorkflowFromTool,
+} from '../apps/desktop/src/main/workflow/workflow-tool-actions.ts'
 
 function uniqueUserDataDir(name: string) {
   return join(tmpdir(), `open-cowork-workflow-${name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
@@ -40,6 +44,24 @@ function withWorkflowStore(name: string, run: (userDataDir: string) => void) {
     clearConfigCaches()
     clearWorkflowStoreCache()
     run(userDataDir)
+  } finally {
+    setWorkflowSecretStorageForTests(null)
+    clearWorkflowStoreCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+async function withWorkflowStoreAsync(name: string, run: (userDataDir: string) => Promise<void>) {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir(name)
+  try {
+    process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+    clearConfigCaches()
+    clearWorkflowStoreCache()
+    await run(userDataDir)
   } finally {
     setWorkflowSecretStorageForTests(null)
     clearWorkflowStoreCache()
@@ -309,6 +331,84 @@ test('workflow preview accepts manual-only workflows', () => {
   assert.equal(preview.ok, true)
   assert.equal(preview.normalizedDraft?.triggers.length, 1)
   assert.equal(preview.normalizedDraft?.triggers[0]?.type, 'manual')
+})
+
+test('workflow preview blocks missing required agents and create enforces the same capability check', () => {
+  const missingAgentDraft = {
+    ...draft,
+    agentName: 'missing-agent',
+    skillNames: [],
+    toolIds: [],
+    triggers: [{ id: 'manual', type: 'manual' as const, enabled: true }],
+  }
+  const capabilities = { agentNames: ['build'], skillNames: [], toolIds: [] }
+  const preview = previewWorkflowDraft(missingAgentDraft, { capabilities })
+
+  assert.equal(preview.ok, false)
+  assert.deepEqual(preview.missing, ['Workflow agent "missing-agent" is not available.'])
+  assert.deepEqual(preview.gaps?.map((gap) => `${gap.severity}:${gap.field}:${gap.value}`), ['required:agentName:missing-agent'])
+
+  assert.throws(
+    () => createWorkflow(missingAgentDraft, null, { capabilities }),
+    /Workflow agent "missing-agent" is not available/,
+  )
+})
+
+test('workflow preview represents missing optional skill and tool references as gaps', () => {
+  const preview = previewWorkflowDraft({
+    ...draft,
+    skillNames: ['ghost-skill'],
+    toolIds: ['ghost-tool'],
+    triggers: [{ id: 'manual', type: 'manual' as const, enabled: true }],
+  }, { capabilities: { agentNames: ['build'], skillNames: [], toolIds: [] } })
+
+  assert.equal(preview.ok, true)
+  assert.deepEqual(preview.missing, [])
+  assert.deepEqual(preview.gaps?.map((gap) => `${gap.severity}:${gap.field}:${gap.value}`), [
+    'optional:skillNames:ghost-skill',
+    'optional:toolIds:ghost-tool',
+  ])
+})
+
+test('workflow preview blocks unavailable project directories', () => {
+  const projectDirectory = join(tmpdir(), `open-cowork-missing-workflow-project-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  const preview = previewWorkflowDraft({
+    ...draft,
+    skillNames: [],
+    toolIds: [],
+    projectDirectory,
+    triggers: [{ id: 'manual', type: 'manual' as const, enabled: true }],
+  }, { capabilities: { agentNames: ['build'], skillNames: [], toolIds: [] } })
+
+  assert.equal(preview.ok, false)
+  assert.deepEqual(preview.missing, [`Workflow project directory "${projectDirectory}" is not available.`])
+})
+
+test('workflow tool create requires and consumes a confirmed preview token', async () => {
+  await withWorkflowStoreAsync('tool-preview-token', async () => {
+    await assert.rejects(
+      () => createWorkflowFromTool({ previewToken: 'missing-token' }),
+      /valid confirmed preview token/,
+    )
+
+    const preview = await previewWorkflowFromTool({
+      ...draft,
+      skillNames: [],
+      toolIds: [],
+      triggers: [{ id: 'manual', type: 'manual' as const, enabled: true }],
+    })
+    assert.equal(preview.ok, true)
+    assert.equal(typeof preview.previewToken, 'string')
+
+    const result = await createWorkflowFromTool({ previewToken: preview.previewToken! })
+    assert.equal(result.ok, true)
+    assert.equal(result.workflow.title, 'Inbox summary')
+
+    await assert.rejects(
+      () => createWorkflowFromTool({ previewToken: preview.previewToken! }),
+      /valid confirmed preview token/,
+    )
+  })
 })
 
 test('workflow store pauses, resumes, archives, regenerates webhook secrets, and lists due workflows', () => withWorkflowStore('status', () => {


### PR DESCRIPTION
## Summary
- require workflow creation to use a single-use preview token minted from a normalized preview
- validate workflow agent, skill, tool, and project-directory references with typed required/optional gaps
- harden shared schedule validation for hour/minute bounds and startAt parsing/future constraints
- update workflows MCP/docs/tests for the preview-token create contract

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm docs:build
- git diff --check

Closes #670
Closes #671
Closes #672