### PR TITLE
Harden capability config contracts

### DIFF
--- a/apps/desktop/src/main/capability-tool-discovery.ts
+++ b/apps/desktop/src/main/capability-tool-discovery.ts
@@ -4,9 +4,9 @@ import type {
   CustomAgentConfig,
   RuntimeContextOptions,
 } from '@open-cowork/shared'
-import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index'
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp'
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { getEffectiveSettings } from './settings.ts'
 import { getCustomAgentCatalog } from './custom-agents.ts'
 import { buildCustomAgentPermissionFromCatalog } from './custom-agents-utils.ts'
@@ -24,6 +24,19 @@ type CapabilityToolDiscoveryDeps = {
   resolveContextDirectory: (options?: RuntimeContextOptions) => string | null
   logHandlerError: (handler: string, err: unknown) => void
   capabilityToolMethodCache: Map<string, { expiresAt: number; entries: CapabilityToolEntry[] }>
+}
+
+export const CAPABILITY_TOOL_DISCOVERY_TIMEOUT_MS = 5_000
+
+type CapabilityToolDiscoveryOptions = RuntimeContextOptions & {
+  deep?: boolean
+  discoveryTimeoutMs?: number
+  signal?: AbortSignal
+}
+
+export type ListToolsFromMcpEntryOptions = {
+  timeoutMs?: number
+  signal?: AbortSignal
 }
 
 export async function buildCustomAgentPermission(agent: CustomAgentConfig, options?: RuntimeContextOptions) {
@@ -56,7 +69,63 @@ function isMcpBackedCapability(tool: CapabilityTool) {
   return Boolean(tool.namespace) || tool.patterns.some((pattern) => pattern.startsWith('mcp__'))
 }
 
-export async function listToolsFromMcpEntry(entry: unknown, options: { timeoutMs?: number } = {}) {
+function capabilityDiscoveryTimeoutError(timeoutMs: number) {
+  const error = new Error(`MCP capability discovery timed out after ${timeoutMs}ms.`)
+  error.name = 'TimeoutError'
+  return error
+}
+
+function createDiscoveryAbortSignal(options: ListToolsFromMcpEntryOptions) {
+  const timeoutMs = options.timeoutMs ?? CAPABILITY_TOOL_DISCOVERY_TIMEOUT_MS
+  const controller = new AbortController()
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  const onCallerAbort = () => {
+    controller.abort(options.signal?.reason || new Error('MCP capability discovery was cancelled.'))
+  }
+
+  if (options.signal?.aborted) {
+    onCallerAbort()
+  } else {
+    options.signal?.addEventListener('abort', onCallerAbort, { once: true })
+  }
+
+  if (timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      controller.abort(capabilityDiscoveryTimeoutError(timeoutMs))
+    }, timeoutMs)
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      if (timeout) clearTimeout(timeout)
+      options.signal?.removeEventListener('abort', onCallerAbort)
+    },
+  }
+}
+
+function abortReason(signal: AbortSignal) {
+  const reason = signal.reason
+  return reason instanceof Error ? reason : new Error('MCP capability discovery was cancelled.')
+}
+
+async function withDiscoveryAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw abortReason(signal)
+  let cleanup = () => {}
+  const aborted = new Promise<never>((_resolve, reject) => {
+    const onAbort = () => reject(abortReason(signal))
+    cleanup = () => signal.removeEventListener('abort', onAbort)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
+  try {
+    return await Promise.race([operation, aborted])
+  } finally {
+    cleanup()
+  }
+}
+
+export async function listToolsFromMcpEntry(entry: unknown, options: ListToolsFromMcpEntryOptions = {}) {
   if (!entry) return []
 
   const runtimeEntry = entry as ResolvedRuntimeMcpEntry
@@ -65,12 +134,7 @@ export async function listToolsFromMcpEntry(entry: unknown, options: { timeoutMs
     { capabilities: {} },
   )
 
-  const abortController = runtimeEntry.type === 'remote' && options.timeoutMs
-    ? new AbortController()
-    : null
-  const timeout = abortController && options.timeoutMs
-    ? setTimeout(() => abortController.abort(), options.timeoutMs)
-    : null
+  const abort = createDiscoveryAbortSignal(options)
 
   try {
     if (runtimeEntry.type === 'local') {
@@ -82,25 +146,25 @@ export async function listToolsFromMcpEntry(entry: unknown, options: { timeoutMs
         env: runtimeEntry.environment,
         stderr: 'pipe',
       })
-      await client.connect(transport)
+      await withDiscoveryAbort(client.connect(transport), abort.signal)
     } else {
       const requestInit: RequestInit = {
         ...(runtimeEntry.headers ? { headers: runtimeEntry.headers } : {}),
-        ...(abortController ? { signal: abortController.signal } : {}),
+        signal: abort.signal,
       }
       const transport = new StreamableHTTPClientTransport(new URL(runtimeEntry.url), {
         requestInit,
       })
-      await client.connect(transport)
+      await withDiscoveryAbort(client.connect(transport), abort.signal)
     }
 
-    const result = await client.listTools()
+    const result = await withDiscoveryAbort(client.listTools(), abort.signal)
     return (result.tools || []).map((tool: { name: string; description?: string }) => ({
       id: tool.name,
       description: tool.description?.trim() || 'No description available for this MCP method.',
     }))
   } finally {
-    if (timeout) clearTimeout(timeout)
+    abort.cleanup()
     await client.close().catch(() => {})
   }
 }
@@ -112,7 +176,7 @@ export function isLikelyMcpAuthError(error: unknown) {
 
 async function discoverCapabilityToolEntries(
   tool: CapabilityTool,
-  options: RuntimeContextOptions | undefined,
+  options: CapabilityToolDiscoveryOptions | undefined,
   deps: CapabilityToolDiscoveryDeps,
 ) {
   if (!isMcpBackedCapability(tool)) return tool.availableTools || []
@@ -150,7 +214,10 @@ async function discoverCapabilityToolEntries(
   )
   if (shouldSkipDirectProbe) return []
 
-  const entries = await listToolsFromMcpEntry(builtinEntry || customEntry).catch((error) => {
+  const entries = await listToolsFromMcpEntry(builtinEntry || customEntry, {
+    timeoutMs: options?.discoveryTimeoutMs,
+    signal: options?.signal,
+  }).catch((error) => {
     deps.logHandlerError(`capability:mcp-tools ${tool.id}`, error)
     return []
   })
@@ -178,7 +245,7 @@ export function createCapabilityToolDiscovery(deps: CapabilityToolDiscoveryDeps)
     async withDiscoveredBuiltInTools(
       tools: CapabilityTool[],
       runtimeTools: unknown[],
-      options?: RuntimeContextOptions & { deep?: boolean },
+      options?: CapabilityToolDiscoveryOptions,
     ) {
       const builtInAgentDetails = listBuiltInAgentDetails()
       const nativeToolEntries = new Map<string, CapabilityTool>()

--- a/apps/desktop/src/main/ipc/context.ts
+++ b/apps/desktop/src/main/ipc/context.ts
@@ -50,9 +50,9 @@ export type IpcHandlerContext = {
   withDiscoveredBuiltInTools: (
     tools: CapabilityTool[],
     runtimeTools: unknown[],
-    options?: RuntimeContextOptions,
+    options?: RuntimeContextOptions & { deep?: boolean; discoveryTimeoutMs?: number; signal?: AbortSignal },
   ) => Promise<CapabilityTool[]>
-  listToolsFromMcpEntry: (entry: unknown, options?: { timeoutMs?: number }) => Promise<CapabilityToolEntry[]>
+  listToolsFromMcpEntry: (entry: unknown, options?: { timeoutMs?: number; signal?: AbortSignal }) => Promise<CapabilityToolEntry[]>
   isLikelyMcpAuthError: (error: unknown) => boolean
   authenticateNewRemoteMcpIfNeeded: (name: string) => Promise<void>
   approvedSkillImportDirectories: Map<string, string>

--- a/apps/desktop/src/main/jsonc.ts
+++ b/apps/desktop/src/main/jsonc.ts
@@ -1,124 +1,22 @@
 import { existsSync, mkdirSync } from 'fs'
-import { dirname, extname } from 'path'
+import { dirname } from 'path'
+import {
+  jsonConfigCandidates,
+  parseJsoncText,
+  stripJsonComments,
+  stripTrailingCommas,
+  type JsonObject,
+} from '@open-cowork/shared'
 import { writeFileAtomic } from './fs-atomic.ts'
 import { readTextFileCheckedSync } from './fs-read.ts'
 
-export type JsonObject = Record<string, unknown>
-
-export function stripJsonComments(input: string) {
-  let output = ''
-  let inString = false
-  let inLineComment = false
-  let inBlockComment = false
-  let escaped = false
-
-  for (let index = 0; index < input.length; index += 1) {
-    const current = input[index]
-    const next = input[index + 1]
-
-    if (inLineComment) {
-      if (current === '\n') {
-        inLineComment = false
-        output += current
-      }
-      continue
-    }
-
-    if (inBlockComment) {
-      if (current === '*' && next === '/') {
-        inBlockComment = false
-        index += 1
-      }
-      continue
-    }
-
-    if (inString) {
-      output += current
-      if (escaped) {
-        escaped = false
-      } else if (current === '\\') {
-        escaped = true
-      } else if (current === '"') {
-        inString = false
-      }
-      continue
-    }
-
-    if (current === '"') {
-      inString = true
-      output += current
-      continue
-    }
-
-    if (current === '/' && next === '/') {
-      inLineComment = true
-      index += 1
-      continue
-    }
-
-    if (current === '/' && next === '*') {
-      inBlockComment = true
-      index += 1
-      continue
-    }
-
-    output += current
-  }
-
-  return output
+export {
+  jsonConfigCandidates,
+  parseJsoncText,
+  stripJsonComments,
+  stripTrailingCommas,
 }
-
-export function stripTrailingCommas(input: string) {
-  let output = ''
-  let inString = false
-  let escaped = false
-
-  for (let index = 0; index < input.length; index += 1) {
-    const current = input[index]
-
-    if (inString) {
-      output += current
-      if (escaped) {
-        escaped = false
-      } else if (current === '\\') {
-        escaped = true
-      } else if (current === '"') {
-        inString = false
-      }
-      continue
-    }
-
-    if (current === '"') {
-      inString = true
-      output += current
-      continue
-    }
-
-    if (current === ',') {
-      let lookahead = index + 1
-      while (lookahead < input.length && /\s/.test(input[lookahead] || '')) {
-        lookahead += 1
-      }
-      const next = input[lookahead]
-      if (next === '}' || next === ']') {
-        continue
-      }
-    }
-
-    output += current
-  }
-
-  return output
-}
-
-export function parseJsoncText<T extends JsonObject = JsonObject>(raw: string): T {
-  const normalized = stripTrailingCommas(stripJsonComments(raw.trim()))
-  const parsed = JSON.parse(normalized)
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('Expected a top-level object')
-  }
-  return parsed as T
-}
+export type { JsonObject }
 
 export function readJsoncFile<T extends JsonObject = JsonObject>(path: string): T {
   let raw: string
@@ -136,14 +34,6 @@ export function readJsoncFile<T extends JsonObject = JsonObject>(path: string): 
 export function writeJsonFile(path: string, value: JsonObject) {
   mkdirSync(dirname(path), { recursive: true })
   writeFileAtomic(path, `${JSON.stringify(value, null, 2)}\n`)
-}
-
-export function jsonConfigCandidates(path: string) {
-  const extension = extname(path).toLowerCase()
-  const base = extension === '.json' || extension === '.jsonc'
-    ? path.slice(0, -extension.length)
-    : path
-  return [`${base}.jsonc`, `${base}.json`]
 }
 
 export function resolveExistingJsonConfigPath(path: string) {

--- a/apps/desktop/src/main/mcp-preflight.ts
+++ b/apps/desktop/src/main/mcp-preflight.ts
@@ -9,7 +9,7 @@ type FetchLike = typeof fetch
 
 type McpPreflightDeps = {
   fetchImpl?: FetchLike
-  listToolsFromMcpEntry: (entry: ResolvedRuntimeMcpEntry, options?: { timeoutMs?: number }) => Promise<CapabilityToolEntry[]>
+  listToolsFromMcpEntry: (entry: ResolvedRuntimeMcpEntry, options?: { timeoutMs?: number; signal?: AbortSignal }) => Promise<CapabilityToolEntry[]>
   resolveHostname?: McpDnsResolver
   timeoutMs?: number
 }

--- a/open-cowork.config.schema.json
+++ b/open-cowork.config.schema.json
@@ -1080,6 +1080,24 @@
       },
       "required": ["kind", "id"]
     },
+    "capabilityBundleResourceIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["opencode-plugin", "skill", "agent", "mcp", "provider", "workflow", "command", "native-helper"]
+        },
+        "id": { "$ref": "#/$defs/capabilityBundleId" }
+      },
+      "required": ["kind", "id"]
+    },
+    "capabilityBundleResourceSelector": {
+      "oneOf": [
+        { "$ref": "#/$defs/capabilityBundleId" },
+        { "$ref": "#/$defs/capabilityBundleResourceIdentity" }
+      ]
+    },
     "capabilityBundlePermission": {
       "type": "object",
       "additionalProperties": false,
@@ -1124,12 +1142,12 @@
           "properties": {
             "removes": {
               "type": "array",
-              "items": { "$ref": "#/$defs/capabilityBundleId" },
+              "items": { "$ref": "#/$defs/capabilityBundleResourceSelector" },
               "uniqueItems": true
             },
             "preserves": {
               "type": "array",
-              "items": { "$ref": "#/$defs/capabilityBundleId" },
+              "items": { "$ref": "#/$defs/capabilityBundleResourceSelector" },
               "uniqueItems": true
             }
           }

--- a/packages/shared/src/capabilities.ts
+++ b/packages/shared/src/capabilities.ts
@@ -169,6 +169,13 @@ export interface CapabilityBundleResource {
   command?: string
 }
 
+export interface CapabilityBundleResourceIdentity {
+  kind: CapabilityBundleResourceKind
+  id: string
+}
+
+export type CapabilityBundleResourceSelector = string | CapabilityBundleResourceIdentity
+
 export interface CapabilityBundlePermission {
   kind: CapabilityBundlePermissionKind
   id: string
@@ -188,8 +195,8 @@ export interface CapabilityBundleManifest {
   resources: CapabilityBundleResource[]
   permissions: CapabilityBundlePermission[]
   uninstall?: {
-    removes?: string[]
-    preserves?: string[]
+    removes?: CapabilityBundleResourceSelector[]
+    preserves?: CapabilityBundleResourceSelector[]
   }
 }
 
@@ -197,6 +204,15 @@ export interface CapabilityBundleIssue {
   code: string
   message: string
   resourceId?: string
+}
+
+export interface CapabilityBundleManifestNormalizeOptions {
+  /**
+   * Compatibility mode for legacy manifests written before the public schema
+   * required explicit resources/permissions arrays. Runtime callers should
+   * leave this false so normalization matches the schema contract.
+   */
+  allowMissingCollections?: boolean
 }
 
 export interface CapabilityBundleInstallPlanAction {
@@ -352,6 +368,81 @@ function readExactId(value: unknown) {
   return id && EXACT_BUNDLE_ID_PATTERN.test(id) ? id : null
 }
 
+function resourceIdentityKey(identity: Pick<CapabilityBundleResourceIdentity, 'kind' | 'id'>) {
+  return `${identity.kind}:${identity.id}`
+}
+
+function cloneResourceSelector(selector: CapabilityBundleResourceSelector): CapabilityBundleResourceSelector {
+  return typeof selector === 'string' ? selector : { ...selector }
+}
+
+function resourceIdentity(resource: CapabilityBundleResource | CapabilityBundleLifecycleResource): CapabilityBundleResourceIdentity {
+  return { kind: resource.kind, id: resource.id }
+}
+
+function isResourceKind(value: unknown): value is CapabilityBundleResourceKind {
+  return typeof value === 'string' && RESOURCE_KINDS.has(value as CapabilityBundleResourceKind)
+}
+
+type ResourceIdentitySet = {
+  exact: Set<string>
+  legacyIds: Set<string>
+}
+
+function createResourceIdentitySet(identities: CapabilityBundleResourceSelector[] = []): ResourceIdentitySet {
+  const exact = new Set<string>()
+  const legacyIds = new Set<string>()
+  for (const identity of identities) {
+    if (typeof identity === 'string') legacyIds.add(identity)
+    else exact.add(resourceIdentityKey(identity))
+  }
+  return { exact, legacyIds }
+}
+
+function resourceIdentitySetIsEmpty(set: ResourceIdentitySet) {
+  return set.exact.size === 0 && set.legacyIds.size === 0
+}
+
+function resourceIdentitySetHasResource(set: ResourceIdentitySet, resource: Pick<CapabilityBundleResourceIdentity, 'kind' | 'id'>) {
+  return set.exact.has(resourceIdentityKey(resource)) || set.legacyIds.has(resource.id)
+}
+
+type CapabilityBundleResourceCandidate = {
+  kind: CapabilityBundleResourceKind | 'bundle'
+  id: string
+  resource: CapabilityBundleResource | null
+}
+
+function candidateKey(candidate: CapabilityBundleResourceCandidate) {
+  return `${candidate.kind}:${candidate.id}`
+}
+
+function resourceCandidateFromSelector(
+  selector: CapabilityBundleResourceSelector,
+  resources: CapabilityBundleResource[],
+): CapabilityBundleResourceCandidate[] {
+  if (typeof selector !== 'string') {
+    const resource = resources.find((entry) => resourceIdentityKey(entry) === resourceIdentityKey(selector)) || null
+    return [{ kind: resource?.kind || selector.kind, id: selector.id, resource }]
+  }
+
+  const matches = resources.filter((resource) => resource.id === selector)
+  if (matches.length > 0) {
+    return matches.map((resource) => ({ kind: resource.kind, id: resource.id, resource }))
+  }
+  return [{ kind: 'bundle', id: selector, resource: null }]
+}
+
+function resourceIdentitySetHasCandidate(set: ResourceIdentitySet, candidate: CapabilityBundleResourceCandidate) {
+  if (candidate.resource) return resourceIdentitySetHasResource(set, candidate.resource)
+  if (candidate.kind !== 'bundle' && set.exact.has(resourceIdentityKey({ kind: candidate.kind, id: candidate.id }))) return true
+  return set.legacyIds.has(candidate.id)
+}
+
+function installActionResourceKey(action: CapabilityBundleInstallPlanAction) {
+  return isResourceKind(action.kind) ? resourceIdentityKey({ kind: action.kind, id: action.id }) : null
+}
+
 function maxRisk(left: CapabilityRiskLevel, right: CapabilityRiskLevel): CapabilityRiskLevel {
   return RISK_RANK[right] > RISK_RANK[left] ? right : left
 }
@@ -418,7 +509,41 @@ function normalizePermission(value: unknown, issues: CapabilityBundleIssue[], in
   }
 }
 
-export function normalizeCapabilityBundleManifest(input: unknown): { ok: true; manifest: CapabilityBundleManifest } | { ok: false; issues: CapabilityBundleIssue[] } {
+function normalizeResourceSelector(value: unknown, issues: CapabilityBundleIssue[], field: string, index: number): CapabilityBundleResourceSelector | null {
+  if (typeof value === 'string') {
+    const id = readExactId(value)
+    if (!id) {
+      pushIssue(issues, 'invalid_uninstall_resource_id', `Bundle uninstall ${field}[${index}] must use an exact canonical id.`)
+      return null
+    }
+    return id
+  }
+
+  const record = asRecord(value)
+  const kind = readNonEmptyString(record.kind)
+  const id = readExactId(record.id)
+  const label = id || `${field}[${index}]`
+  if (!kind || !RESOURCE_KINDS.has(kind as CapabilityBundleResourceKind)) {
+    pushIssue(issues, 'invalid_uninstall_resource_kind', `Bundle uninstall resource ${label} has an unsupported kind.`, id || undefined)
+    return null
+  }
+  if (!id) {
+    pushIssue(issues, 'invalid_uninstall_resource_id', `Bundle uninstall ${field}[${index}] must use an exact canonical id.`)
+    return null
+  }
+  return { kind: kind as CapabilityBundleResourceKind, id }
+}
+
+function normalizeResourceSelectors(value: unknown, issues: CapabilityBundleIssue[], field: string) {
+  return Array.isArray(value)
+    ? value.map((entry, index) => normalizeResourceSelector(entry, issues, field, index)).filter((entry): entry is CapabilityBundleResourceSelector => Boolean(entry))
+    : []
+}
+
+export function normalizeCapabilityBundleManifest(
+  input: unknown,
+  options: CapabilityBundleManifestNormalizeOptions = {},
+): { ok: true; manifest: CapabilityBundleManifest } | { ok: false; issues: CapabilityBundleIssue[] } {
   const issues: CapabilityBundleIssue[] = []
   const record = asRecord(input)
   if (Object.keys(record).length === 0) {
@@ -434,12 +559,23 @@ export function normalizeCapabilityBundleManifest(input: unknown): { ok: true; m
   if (!version) pushIssue(issues, 'version_required', 'Capability bundle version is required.')
   if (!owner) pushIssue(issues, 'owner_required', 'Capability bundle owner is required.')
 
-  const resources = Array.isArray(record.resources)
-    ? record.resources.map((entry, index) => normalizeResource(entry, issues, index)).filter((entry): entry is CapabilityBundleResource => Boolean(entry))
-    : []
-  const permissions = Array.isArray(record.permissions)
-    ? record.permissions.map((entry, index) => normalizePermission(entry, issues, index)).filter((entry): entry is CapabilityBundlePermission => Boolean(entry))
-    : []
+  let resources: CapabilityBundleResource[] = []
+  if (Array.isArray(record.resources)) {
+    resources = record.resources.map((entry, index) => normalizeResource(entry, issues, index)).filter((entry): entry is CapabilityBundleResource => Boolean(entry))
+  } else if (record.resources === undefined) {
+    if (!options.allowMissingCollections) pushIssue(issues, 'resources_required', 'Capability bundle resources must be declared as an array.')
+  } else {
+    pushIssue(issues, 'invalid_resources', 'Capability bundle resources must be an array.')
+  }
+
+  let permissions: CapabilityBundlePermission[] = []
+  if (Array.isArray(record.permissions)) {
+    permissions = record.permissions.map((entry, index) => normalizePermission(entry, issues, index)).filter((entry): entry is CapabilityBundlePermission => Boolean(entry))
+  } else if (record.permissions === undefined) {
+    if (!options.allowMissingCollections) pushIssue(issues, 'permissions_required', 'Capability bundle permissions must be declared as an array.')
+  } else {
+    pushIssue(issues, 'invalid_permissions', 'Capability bundle permissions must be an array.')
+  }
   const compatibilityRecord = asRecord(record.compatibility)
   const rawProductModes = asRecord(compatibilityRecord.productModes)
   const productModes = Object.fromEntries(Object.entries(rawProductModes).flatMap(([mode, tier]) => {
@@ -447,6 +583,8 @@ export function normalizeCapabilityBundleManifest(input: unknown): { ok: true; m
     return [[mode, tier]]
   })) as Partial<Record<CapabilityBundleProductMode, CapabilityBundleCompatibilityTier>>
   const uninstallRecord = asRecord(record.uninstall)
+  const uninstallRemoves = normalizeResourceSelectors(uninstallRecord.removes, issues, 'removes')
+  const uninstallPreserves = normalizeResourceSelectors(uninstallRecord.preserves, issues, 'preserves')
 
   if (issues.length > 0) return { ok: false, issues }
   return {
@@ -463,8 +601,8 @@ export function normalizeCapabilityBundleManifest(input: unknown): { ok: true; m
       resources,
       permissions,
       uninstall: {
-        removes: Array.isArray(uninstallRecord.removes) ? uninstallRecord.removes.filter((entry): entry is string => typeof entry === 'string') : [],
-        preserves: Array.isArray(uninstallRecord.preserves) ? uninstallRecord.preserves.filter((entry): entry is string => typeof entry === 'string') : [],
+        removes: uninstallRemoves,
+        preserves: uninstallPreserves,
       },
     },
   }
@@ -639,13 +777,13 @@ export function planCapabilityBundleInstall(
   manifest: CapabilityBundleManifest,
   options: {
     productMode: CapabilityBundleProductMode
-    existingResourceIds?: string[]
+    existingResourceIds?: CapabilityBundleResourceSelector[]
   },
 ): CapabilityBundleInstallPlan {
   const blockers: CapabilityBundleIssue[] = []
   const actions: CapabilityBundleInstallPlanAction[] = []
   const reasons: string[] = []
-  const existingResourceIds = new Set(options.existingResourceIds || [])
+  const existingResourceIds = createResourceIdentitySet(options.existingResourceIds)
   let level: CapabilityRiskLevel = 'low'
   const modeTier = manifest.compatibility?.productModes?.[options.productMode] || 'unsupported'
   if (modeTier === 'unsupported' || modeTier === 'blocked') {
@@ -664,7 +802,7 @@ export function planCapabilityBundleInstall(
       level = 'high'
       continue
     }
-    if (existingResourceIds.has(resource.id)) {
+    if (resourceIdentitySetHasResource(existingResourceIds, resource)) {
       actions.push({ action: 'preserve_user_resource', kind: resource.kind, id: resource.id, reason: 'Existing resource is preserved; bundle cannot overwrite it during install.' })
       level = maxRisk(level, 'medium')
       continue
@@ -737,48 +875,56 @@ export function planCapabilityBundleInstall(
 export function planCapabilityBundleUninstall(
   manifest: CapabilityBundleManifest,
   options: {
-    installedResourceIds?: string[]
-    userOwnedResourceIds?: string[]
+    installedResourceIds?: CapabilityBundleResourceSelector[]
+    userOwnedResourceIds?: CapabilityBundleResourceSelector[]
   } = {},
 ): CapabilityBundleUninstallPlan {
-  const resourceById = new Map(manifest.resources.map((resource) => [resource.id, resource]))
-  const installedResourceIds = new Set(options.installedResourceIds || [])
-  const userOwnedResourceIds = new Set(options.userOwnedResourceIds || [])
-  const explicitRemoves = new Set(manifest.uninstall?.removes || [])
-  const explicitPreserves = new Set(manifest.uninstall?.preserves || [])
-  const candidateIds = new Set([
-    ...manifest.resources.filter((resource) => resource.ownedByBundle).map((resource) => resource.id),
-    ...explicitRemoves,
-    ...explicitPreserves,
-    ...userOwnedResourceIds,
-  ])
+  const installedResourceIds = createResourceIdentitySet(options.installedResourceIds)
+  const userOwnedResourceIds = createResourceIdentitySet(options.userOwnedResourceIds)
+  const explicitPreserves = createResourceIdentitySet(manifest.uninstall?.preserves)
+  const candidates = new Map<string, CapabilityBundleResourceCandidate>()
+  const addCandidate = (candidate: CapabilityBundleResourceCandidate) => {
+    candidates.set(candidateKey(candidate), candidate)
+  }
+  for (const resource of manifest.resources.filter((entry) => entry.ownedByBundle)) {
+    addCandidate({ kind: resource.kind, id: resource.id, resource })
+  }
+  for (const selector of [
+    ...(manifest.uninstall?.removes || []),
+    ...(manifest.uninstall?.preserves || []),
+    ...(options.userOwnedResourceIds || []),
+  ]) {
+    for (const candidate of resourceCandidateFromSelector(selector, manifest.resources)) {
+      addCandidate(candidate)
+    }
+  }
   const actions: CapabilityBundleInstallPlanAction[] = []
   const reasons: string[] = []
   let level: CapabilityRiskLevel = 'low'
 
-  for (const id of Array.from(candidateIds).sort()) {
-    const resource = resourceById.get(id)
-    const kind = resource?.kind || 'bundle'
-    const installed = installedResourceIds.size === 0 || installedResourceIds.has(id)
-    const mustPreserve = explicitPreserves.has(id) || userOwnedResourceIds.has(id) || (resource ? !resource.ownedByBundle : false)
+  for (const candidate of Array.from(candidates.values()).sort((left, right) => `${left.id}:${left.kind}`.localeCompare(`${right.id}:${right.kind}`))) {
+    const resource = candidate.resource
+    const installed = resourceIdentitySetIsEmpty(installedResourceIds) || resourceIdentitySetHasCandidate(installedResourceIds, candidate)
+    const explicitPreserve = resourceIdentitySetHasCandidate(explicitPreserves, candidate)
+    const mustPreserve = explicitPreserve || resourceIdentitySetHasCandidate(userOwnedResourceIds, candidate) || (resource ? !resource.ownedByBundle : false)
     if (mustPreserve) {
       actions.push({
         action: 'preserve_user_resource',
-        kind,
-        id,
-        reason: explicitPreserves.has(id)
+        kind: candidate.kind,
+        id: candidate.id,
+        reason: explicitPreserve
           ? 'Manifest marks this resource as preserved during uninstall.'
           : 'User-owned resource is preserved during bundle uninstall.',
       })
-      reasons.push(`Resource ${id} is preserved during uninstall.`)
+      reasons.push(`Resource ${candidate.id} is preserved during uninstall.`)
       level = maxRisk(level, 'medium')
       continue
     }
     if (!installed) continue
     actions.push({
       action: 'remove_bundle_resource',
-      kind,
-      id,
+      kind: candidate.kind,
+      id: candidate.id,
       reason: 'Bundle-owned resource can be removed by bundle uninstall.',
     })
   }
@@ -803,9 +949,9 @@ export function planCapabilityBundleUpdate(
   next: CapabilityBundleManifest,
   options: {
     productMode: CapabilityBundleProductMode
-    existingResourceIds?: string[]
-    installedResourceIds?: string[]
-    userOwnedResourceIds?: string[]
+    existingResourceIds?: CapabilityBundleResourceSelector[]
+    installedResourceIds?: CapabilityBundleResourceSelector[]
+    userOwnedResourceIds?: CapabilityBundleResourceSelector[]
   },
 ): CapabilityBundleUpdatePlan {
   const blockers: CapabilityBundleIssue[] = []
@@ -819,16 +965,16 @@ export function planCapabilityBundleUpdate(
     level = 'high'
   }
 
-  const nextResourceIds = new Set(next.resources.map((resource) => resource.id))
-  const installedResourceIds = new Set(options.installedResourceIds || [])
-  const userOwnedResourceIds = new Set(options.userOwnedResourceIds || [])
-  const previousResourceById = new Map(previous.resources.map((resource) => [resource.id, resource]))
+  const nextResourceIds = new Set(next.resources.map((resource) => resourceIdentityKey(resource)))
+  const installedResourceIds = createResourceIdentitySet(options.installedResourceIds)
+  const userOwnedResourceIds = createResourceIdentitySet(options.userOwnedResourceIds)
+  const previousResourceByKey = new Map(previous.resources.map((resource) => [resourceIdentityKey(resource), resource]))
 
   for (const resource of [...previous.resources].sort((left, right) => `${left.kind}:${left.id}`.localeCompare(`${right.kind}:${right.id}`))) {
-    if (nextResourceIds.has(resource.id)) continue
-    const installed = installedResourceIds.size === 0 || installedResourceIds.has(resource.id)
+    if (nextResourceIds.has(resourceIdentityKey(resource))) continue
+    const installed = resourceIdentitySetIsEmpty(installedResourceIds) || resourceIdentitySetHasResource(installedResourceIds, resource)
     if (!installed) continue
-    if (!resource.ownedByBundle || userOwnedResourceIds.has(resource.id)) {
+    if (!resource.ownedByBundle || resourceIdentitySetHasResource(userOwnedResourceIds, resource)) {
       actions.push({
         action: 'preserve_user_resource',
         kind: resource.kind,
@@ -856,10 +1002,12 @@ export function planCapabilityBundleUpdate(
   level = maxRisk(level, installPlan.risk.level)
 
   for (const action of installPlan.actions) {
+    const actionResourceKey = installActionResourceKey(action)
     if (
       action.action === 'install'
-      && previousResourceById.has(action.id)
-      && !userOwnedResourceIds.has(action.id)
+      && actionResourceKey
+      && previousResourceByKey.has(actionResourceKey)
+      && !resourceIdentitySetHasResource(userOwnedResourceIds, { kind: action.kind as CapabilityBundleResourceKind, id: action.id })
     ) {
       actions.push({
         ...action,
@@ -900,8 +1048,8 @@ function cloneCapabilityBundleLifecycleState(
           resources: [...bundle.manifest.resources],
           permissions: [...bundle.manifest.permissions],
           uninstall: {
-            removes: [...(bundle.manifest.uninstall?.removes || [])],
-            preserves: [...(bundle.manifest.uninstall?.preserves || [])],
+            removes: (bundle.manifest.uninstall?.removes || []).map(cloneResourceSelector),
+            preserves: (bundle.manifest.uninstall?.preserves || []).map(cloneResourceSelector),
           },
         },
         resources: [...bundle.resources],
@@ -973,8 +1121,9 @@ function upsertLifecycleResource(
     now: string
   },
 ) {
-  const next = resources.filter((entry) => entry.id !== resource.id)
-  const previous = resources.find((entry) => entry.id === resource.id)
+  const key = resourceIdentityKey(resource)
+  const next = resources.filter((entry) => resourceIdentityKey(entry) !== key)
+  const previous = resources.find((entry) => resourceIdentityKey(entry) === key)
   next.push({
     kind: resource.kind,
     id: resource.id,
@@ -993,12 +1142,12 @@ function removeBundleOwnedLifecycleResources(
   ids: Set<string>,
 ) {
   return sortedLifecycleResources(resources.filter((resource) => {
-    if (!ids.has(resource.id)) return true
+    if (!ids.has(resourceIdentityKey(resource))) return true
     return resource.owner !== 'bundle' || resource.bundleName !== bundleName
   }))
 }
 
-function installActionsByResourceId(actions: CapabilityBundleInstallPlanAction[]) {
+function installActionsByResourceKey(actions: CapabilityBundleInstallPlanAction[]) {
   const map = new Map<string, CapabilityBundleInstallPlanAction>()
   for (const action of actions) {
     if (
@@ -1006,7 +1155,8 @@ function installActionsByResourceId(actions: CapabilityBundleInstallPlanAction[]
       || action.action === 'preserve_user_resource'
       || action.action === 'remove_bundle_resource'
     ) {
-      map.set(action.id, action)
+      const key = installActionResourceKey(action)
+      if (key) map.set(key, action)
     }
   }
   return map
@@ -1015,19 +1165,19 @@ function installActionsByResourceId(actions: CapabilityBundleInstallPlanAction[]
 function lifecycleResourceIdsExcludingBundle(state: CapabilityBundleLifecycleState, bundleName: string) {
   return state.resources
     .filter((resource) => resource.bundleName !== bundleName)
-    .map((resource) => resource.id)
+    .map(resourceIdentity)
 }
 
 function lifecycleUserOwnedResourceIds(state: CapabilityBundleLifecycleState) {
   return state.resources
     .filter((resource) => resource.owner === 'user')
-    .map((resource) => resource.id)
+    .map(resourceIdentity)
 }
 
 function lifecycleInstalledResourceIdsForBundle(state: CapabilityBundleLifecycleState, bundleName: string) {
   return state.resources
     .filter((resource) => resource.bundleName === bundleName || resource.owner === 'user')
-    .map((resource) => resource.id)
+    .map(resourceIdentity)
 }
 
 export function createEmptyCapabilityBundleLifecycleState(): CapabilityBundleLifecycleState {
@@ -1045,7 +1195,7 @@ export function applyCapabilityBundleInstall(
   const current = cloneCapabilityBundleLifecycleState(state)
   const plan = planCapabilityBundleInstall(manifest, {
     productMode: options.productMode,
-    existingResourceIds: current.resources.map((resource) => resource.id),
+    existingResourceIds: current.resources.map(resourceIdentity),
   })
 
   if (current.bundles.some((bundle) => bundle.name === manifest.name)) {
@@ -1068,12 +1218,12 @@ export function applyCapabilityBundleInstall(
   }
 
   const now = options.now || new Date().toISOString()
-  const actionById = installActionsByResourceId(plan.actions)
+  const actionByKey = installActionsByResourceKey(plan.actions)
   let resources = current.resources
   const bundleResources: CapabilityBundleLifecycleBundle['resources'] = []
 
   for (const resource of [...manifest.resources].sort((left, right) => `${left.kind}:${left.id}`.localeCompare(`${right.kind}:${right.id}`))) {
-    const action = actionById.get(resource.id)
+    const action = actionByKey.get(resourceIdentityKey(resource))
     if (action?.action === 'preserve_user_resource') continue
     if (action?.action !== 'install') continue
     const owner: CapabilityBundleLifecycleOwner = resource.ownedByBundle ? 'bundle' : 'user'
@@ -1147,15 +1297,17 @@ export function applyCapabilityBundleUninstall(
   })
   const removals = new Set(plan.actions
     .filter((action) => action.action === 'remove_bundle_resource')
-    .map((action) => action.id))
+    .map(installActionResourceKey)
+    .filter((key): key is string => Boolean(key)))
   const preserves = new Set(plan.actions
     .filter((action) => action.action === 'preserve_user_resource')
-    .map((action) => action.id))
+    .map(installActionResourceKey)
+    .filter((key): key is string => Boolean(key)))
   const resources = removeBundleOwnedLifecycleResources(current.resources, bundleName, removals)
   const next: CapabilityBundleLifecycleState = {
     bundles: sortedLifecycleBundles(current.bundles.filter((bundle) => bundle.name !== bundleName)),
     resources: sortedLifecycleResources(resources.map((resource) => {
-      if (preserves.has(resource.id) && resource.owner === 'bundle' && resource.bundleName === bundleName) {
+      if (preserves.has(resourceIdentityKey(resource)) && resource.owner === 'bundle' && resource.bundleName === bundleName) {
         return {
           ...resource,
           owner: 'user',
@@ -1227,13 +1379,14 @@ export function applyCapabilityBundleUpdate(
   const now = options.now || new Date().toISOString()
   const removals = new Set(plan.actions
     .filter((action) => action.action === 'remove_bundle_resource')
-    .map((action) => action.id))
-  const actionById = installActionsByResourceId(plan.actions)
+    .map(installActionResourceKey)
+    .filter((key): key is string => Boolean(key)))
+  const actionByKey = installActionsByResourceKey(plan.actions)
   let resources = removeBundleOwnedLifecycleResources(current.resources, manifest.name, removals)
   const bundleResources: CapabilityBundleLifecycleBundle['resources'] = []
 
   for (const resource of [...manifest.resources].sort((left, right) => `${left.kind}:${left.id}`.localeCompare(`${right.kind}:${right.id}`))) {
-    const action = actionById.get(resource.id)
+    const action = actionByKey.get(resourceIdentityKey(resource))
     if (action?.action === 'preserve_user_resource') continue
     if (action?.action !== 'install') continue
     const owner: CapabilityBundleLifecycleOwner = resource.ownedByBundle ? 'bundle' : 'user'

--- a/tests/capability-bundle-policy.test.ts
+++ b/tests/capability-bundle-policy.test.ts
@@ -87,6 +87,31 @@ test('capability bundle validation requires explicit plugin compatibility', () =
   assert.equal(result.issues.some((issue) => issue.code === 'plugin_compatibility_required'), true)
 })
 
+test('capability bundle validation aligns required collections with the public schema', () => {
+  const result = normalizeCapabilityBundleManifest({
+    format: CAPABILITY_BUNDLE_FORMAT,
+    name: 'schema-pack',
+    version: '1.0.0',
+    owner: 'open-cowork',
+  })
+
+  assert.equal(result.ok, false)
+  if (result.ok) return
+  assert.equal(result.issues.some((issue) => issue.code === 'resources_required'), true)
+  assert.equal(result.issues.some((issue) => issue.code === 'permissions_required'), true)
+
+  const legacy = normalizeCapabilityBundleManifest({
+    format: CAPABILITY_BUNDLE_FORMAT,
+    name: 'legacy-pack',
+    version: '1.0.0',
+    owner: 'open-cowork',
+  }, { allowMissingCollections: true })
+  assert.equal(legacy.ok, true)
+  if (!legacy.ok) return
+  assert.deepEqual(legacy.manifest.resources, [])
+  assert.deepEqual(legacy.manifest.permissions, [])
+})
+
 test('capability bundle plan fails closed for unsupported product modes and remote plugin tiers', () => {
   const localOnly = manifest({
     resources: [
@@ -139,6 +164,24 @@ test('capability bundle plan preserves existing user resources and orders action
   ])
   assert.equal(plan.risk.level, 'high')
   assert.equal(plan.risk.reasons.some((reason) => reason.includes('shell permission')), true)
+})
+
+test('capability bundle plan uses kind-qualified resource identity for existing resources', () => {
+  const plan = planCapabilityBundleInstall(manifest({
+    resources: [
+      { kind: 'skill', id: 'shared-id', ownedByBundle: true },
+      { kind: 'workflow', id: 'shared-id', ownedByBundle: true },
+    ],
+  }), {
+    productMode: 'desktop-local',
+    existingResourceIds: [{ kind: 'workflow', id: 'shared-id' }],
+  })
+
+  assert.equal(plan.blocked, false)
+  assert.deepEqual(plan.actions.map((action) => `${action.action}:${action.kind}:${action.id}`), [
+    'install:skill:shared-id',
+    'preserve_user_resource:workflow:shared-id',
+  ])
 })
 
 test('capability bundle uninstall plan removes only bundle-owned resources', () => {
@@ -355,6 +398,53 @@ test('capability bundle lifecycle uninstall removes bundle-owned resources and p
   assert.equal(uninstalled.audit.some((event) => event.outcome === 'removed' && event.id === 'review-skill'), true)
   assert.equal(uninstalled.audit.some((event) => event.outcome === 'preserved' && event.id === 'operator-command'), true)
   assert.equal(uninstalled.audit.some((event) => event.outcome === 'preserved' && event.id === 'operator-workflow'), true)
+})
+
+test('capability bundle lifecycle preserves mixed-kind resources with the same id', () => {
+  const installed = applyCapabilityBundleInstall(createEmptyCapabilityBundleLifecycleState(), manifest({
+    resources: [
+      { kind: 'skill', id: 'shared-id', ownedByBundle: true },
+      { kind: 'workflow', id: 'shared-id', ownedByBundle: true },
+    ],
+    uninstall: {
+      removes: [{ kind: 'skill', id: 'shared-id' }],
+      preserves: [{ kind: 'workflow', id: 'shared-id' }],
+    },
+  }), {
+    productMode: 'desktop-local',
+    now: '2026-06-03T10:00:00.000Z',
+  })
+  const uninstalled = applyCapabilityBundleUninstall(installed.state, 'review-pack')
+
+  assert.equal(uninstalled.applied, true)
+  assert.deepEqual(uninstalled.state.resources.map((resource) => `${resource.owner}:${resource.kind}:${resource.id}`), [
+    'user:workflow:shared-id',
+  ])
+
+  const reinstalled = applyCapabilityBundleInstall(createEmptyCapabilityBundleLifecycleState(), manifest({
+    resources: [
+      { kind: 'skill', id: 'shared-id', ownedByBundle: true },
+      { kind: 'workflow', id: 'shared-id', ownedByBundle: true },
+    ],
+  }), {
+    productMode: 'desktop-local',
+    now: '2026-06-03T11:00:00.000Z',
+  })
+  const updated = applyCapabilityBundleUpdate(reinstalled.state, manifest({
+    version: '1.1.0',
+    resources: [
+      { kind: 'workflow', id: 'shared-id', ownedByBundle: true },
+    ],
+  }), {
+    productMode: 'desktop-local',
+    now: '2026-06-03T12:00:00.000Z',
+  })
+
+  assert.equal(updated.applied, true)
+  assert.deepEqual(updated.state.resources.map((resource) => `${resource.owner}:${resource.kind}:${resource.id}`), [
+    'bundle:workflow:shared-id',
+  ])
+  assert.equal(updated.audit.some((event) => event.outcome === 'removed' && event.kind === 'skill' && event.id === 'shared-id'), true)
 })
 
 test('capability bundle lifecycle update preserves user resources and removes obsolete owned resources', () => {

--- a/tests/capability-tool-discovery-timeout.test.ts
+++ b/tests/capability-tool-discovery-timeout.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import test from 'node:test'
+
+import {
+  CAPABILITY_TOOL_DISCOVERY_TIMEOUT_MS,
+  listToolsFromMcpEntry,
+} from '../apps/desktop/src/main/capability-tool-discovery.ts'
+import type { ResolvedRuntimeMcpEntry } from '../apps/desktop/src/main/runtime-mcp.ts'
+
+async function waitForPid(path: string) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (existsSync(path)) return Number(readFileSync(path, 'utf8'))
+    await delay(25)
+  }
+  throw new Error('Timed out waiting for MCP child pid.')
+}
+
+function processIsAlive(pid: number) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false
+    throw error
+  }
+}
+
+async function waitForProcessExit(pid: number) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (!processIsAlive(pid)) return
+    await delay(25)
+  }
+  try {
+    process.kill(pid, 'SIGTERM')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
+  }
+  assert.fail(`MCP child process ${pid} was still running after discovery timeout cleanup.`)
+}
+
+test('capability MCP discovery documents a default timeout', () => {
+  assert.equal(CAPABILITY_TOOL_DISCOVERY_TIMEOUT_MS, 5_000)
+})
+
+test('capability MCP discovery times out hanging stdio probes and closes the transport', async () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'open-cowork-capability-discovery-'))
+  const pidPath = join(tempRoot, 'mcp.pid')
+  const script = [
+    'const fs = require("node:fs")',
+    `fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid))`,
+    'process.on("SIGTERM", () => process.exit(0))',
+    'process.on("SIGINT", () => process.exit(0))',
+    'setInterval(() => {}, 1000)',
+  ].join(';')
+  const entry: ResolvedRuntimeMcpEntry = {
+    type: 'local',
+    command: [process.execPath, '-e', script],
+  }
+
+  try {
+    const result = listToolsFromMcpEntry(entry, { timeoutMs: 100 }).then(
+      () => null,
+      (error: unknown) => error,
+    )
+    const pid = await waitForPid(pidPath)
+    const error = await result
+
+    assert.ok(error instanceof Error)
+    assert.equal(error.name, 'TimeoutError')
+    assert.match(error.message, /timed out after 100ms/)
+    await waitForProcessExit(pid)
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/tests/config-schema-validation.test.ts
+++ b/tests/config-schema-validation.test.ts
@@ -17,6 +17,46 @@ test('root open-cowork.config.json validates against the public schema', () => {
   assert.doesNotThrow(() => validateResolvedConfig(config, 'open-cowork.config.json'))
 })
 
+test('capability bundle schema requires collections and accepts kind-qualified uninstall selectors', () => {
+  const config = cloneConfig()
+  config.capabilityBundles = [{
+    format: 'open-cowork-capability-bundle-v1',
+    name: 'schema-pack',
+    version: '1.0.0',
+    owner: 'open-cowork',
+    resources: [
+      { kind: 'skill', id: 'shared-id', ownedByBundle: true },
+      { kind: 'workflow', id: 'shared-id', ownedByBundle: true },
+    ],
+    permissions: [],
+    uninstall: {
+      removes: [{ kind: 'skill', id: 'shared-id' }],
+      preserves: ['shared-id', { kind: 'workflow', id: 'shared-id' }],
+    },
+  }]
+  assert.doesNotThrow(() => validateResolvedConfig(config, 'capability bundle config'))
+
+  const missingResources = cloneConfig()
+  missingResources.capabilityBundles = [{
+    format: 'open-cowork-capability-bundle-v1',
+    name: 'schema-pack',
+    version: '1.0.0',
+    owner: 'open-cowork',
+    permissions: [],
+  }]
+  assert.throws(() => validateResolvedConfig(missingResources, 'capability bundle config'), /capabilityBundles/)
+
+  const missingPermissions = cloneConfig()
+  missingPermissions.capabilityBundles = [{
+    format: 'open-cowork-capability-bundle-v1',
+    name: 'schema-pack',
+    version: '1.0.0',
+    owner: 'open-cowork',
+    resources: [],
+  }]
+  assert.throws(() => validateResolvedConfig(missingPermissions, 'capability bundle config'), /capabilityBundles/)
+})
+
 test('downstream contract version is required and fixed for this schema', () => {
   const config = cloneConfig()
   assert.equal(config.contractVersion, 1)

--- a/tests/shared-roadmap-dist-contracts.test.ts
+++ b/tests/shared-roadmap-dist-contracts.test.ts
@@ -144,6 +144,31 @@ test('dist capability manifest normalization reports invalid object, resource, a
   ]))
 })
 
+test('dist capability manifest normalization requires schema collections unless legacy defaults are explicit', () => {
+  const result = normalizeCapabilityBundleManifest({
+    format: CAPABILITY_BUNDLE_FORMAT,
+    name: 'dist-schema-pack',
+    version: '1.0.0',
+    owner: 'open-cowork',
+  })
+
+  assert.equal(result.ok, false)
+  if (result.ok) return
+  assert.equal(result.issues.some((issue) => issue.code === 'resources_required'), true)
+  assert.equal(result.issues.some((issue) => issue.code === 'permissions_required'), true)
+
+  const legacy = normalizeCapabilityBundleManifest({
+    format: CAPABILITY_BUNDLE_FORMAT,
+    name: 'dist-legacy-pack',
+    version: '1.0.0',
+    owner: 'open-cowork',
+  }, { allowMissingCollections: true })
+  assert.equal(legacy.ok, true)
+  if (!legacy.ok) return
+  assert.deepEqual(legacy.manifest.resources, [])
+  assert.deepEqual(legacy.manifest.permissions, [])
+})
+
 test('dist capability planning blocks unsafe remote resources and reviews native helpers', () => {
   const installPlan = planCapabilityBundleInstall(bundle({
     resources: [
@@ -212,6 +237,42 @@ test('dist capability lifecycle applies install, update fallback, duplicate inst
   const missingUninstall = applyCapabilityBundleUninstall(createEmptyCapabilityBundleLifecycleState(), 'missing-pack')
   assert.equal(missingUninstall.applied, false)
   assert.equal(missingUninstall.plan.blockers[0]?.code, 'bundle_not_installed')
+})
+
+test('dist capability lifecycle uses kind-qualified resource identity', () => {
+  const installPlan = planCapabilityBundleInstall(bundle({
+    resources: [
+      { kind: 'skill', id: 'shared-id', ownedByBundle: true },
+      { kind: 'workflow', id: 'shared-id', ownedByBundle: true },
+    ],
+  }), {
+    productMode: 'desktop-local',
+    existingResourceIds: [{ kind: 'workflow', id: 'shared-id' }],
+  })
+
+  assert.deepEqual(installPlan.actions.map((action) => `${action.action}:${action.kind}:${action.id}`), [
+    'install:skill:shared-id',
+    'preserve_user_resource:workflow:shared-id',
+  ])
+
+  const installed = applyCapabilityBundleInstall(createEmptyCapabilityBundleLifecycleState(), bundle({
+    resources: [
+      { kind: 'skill', id: 'shared-id', ownedByBundle: true },
+      { kind: 'workflow', id: 'shared-id', ownedByBundle: true },
+    ],
+    uninstall: {
+      removes: [{ kind: 'skill', id: 'shared-id' }],
+      preserves: [{ kind: 'workflow', id: 'shared-id' }],
+    },
+  }), {
+    productMode: 'desktop-local',
+    now: '2026-06-03T00:00:00.000Z',
+  })
+  const uninstalled = applyCapabilityBundleUninstall(installed.state, 'dist-pack')
+
+  assert.deepEqual(uninstalled.state.resources.map((resource) => `${resource.owner}:${resource.kind}:${resource.id}`), [
+    'user:workflow:shared-id',
+  ])
 })
 
 test('dist capability lifecycle removes and preserves installed resources across uninstall and update', () => {


### PR DESCRIPTION
## Summary
- add a documented default timeout plus caller cancellation support for MCP capability tool discovery
- key capability bundle lifecycle comparisons by resource `{ kind, id }` while retaining legacy id-string selectors as compatibility input
- align capability bundle normalization with the public config schema for required `resources` and `permissions`
- delegate main-process JSONC parsing to the shared pure parser while keeping main file IO helpers at the edge

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm docs:build`
- `git diff --check`

Closes #673
Closes #674
Closes #684
Closes #686