### PR TITLE
Harden runtime session state boundaries

### DIFF
--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -28,6 +28,7 @@ import {
   normalizeAgentName,
 } from './task-run-utils.ts'
 import { log } from './logger.ts'
+import { nextSessionScopedFallbackId } from './runtime-fallback-ids.ts'
 
 const MAX_PENDING_TEXT_EVENTS_PER_SESSION = 500
 const MAX_TOTAL_PENDING_TEXT_EVENTS = 10_000
@@ -850,7 +851,7 @@ function handleUpdatedToolPart(ctx: MessagePartUpdatedContext) {
     sessionId: ctx.rootSessionId,
     data: {
       type: 'tool_call',
-      id: ctx.part.callId || ctx.part.id || `${ctx.rootSessionId}:tool:${Date.now()}`,
+      id: ctx.part.callId || ctx.part.id || nextSessionScopedFallbackId(ctx.rootSessionId, 'tool'),
       name: displayName,
       input: toolInput,
       status,

--- a/apps/desktop/src/main/runtime-fallback-ids.ts
+++ b/apps/desktop/src/main/runtime-fallback-ids.ts
@@ -1,0 +1,12 @@
+const fallbackCountersBySessionAndKind = new Map<string, number>()
+
+export function nextSessionScopedFallbackId(sessionId: string, kind: string) {
+  const key = `${sessionId}:${kind}`
+  const next = (fallbackCountersBySessionAndKind.get(key) || 0) + 1
+  fallbackCountersBySessionAndKind.set(key, next)
+  return `${sessionId}:${kind}:fallback:${next}`
+}
+
+export function resetSessionScopedFallbackIdsForTests() {
+  fallbackCountersBySessionAndKind.clear()
+}

--- a/apps/desktop/src/main/runtime-status.ts
+++ b/apps/desktop/src/main/runtime-status.ts
@@ -12,13 +12,45 @@ import { sanitizeLogMessage } from './log-sanitizer.ts'
 
 const MAX_TIMELINE_ENTRIES = 80
 
-let runtimeReady = false
-let runtimeError: string | null = null
-let runtimePhase: RuntimeReadinessPhase = 'environment'
-let updatedAt = new Date().toISOString()
-let timeline: RuntimeReadinessTimelineEntry[] = []
-const doctorChecks = new Map<string, RuntimeDoctorCheck>()
-let componentVerification: RuntimeComponentVerificationReport | null = null
+export type RuntimeDoctorCheckInput = {
+  code: string
+  severity?: RuntimeDoctorSeverity
+  status: RuntimeDoctorStatus
+  message: string
+  remediation?: string
+  evidence?: RuntimeDoctorCheck['evidence']
+}
+
+export type RuntimeStatusState = {
+  ready: boolean
+  error: string | null
+  phase: RuntimeReadinessPhase
+  updatedAt: string
+  timeline: RuntimeReadinessTimelineEntry[]
+  checks: RuntimeDoctorCheck[]
+  components: RuntimeComponentVerificationReport | null
+}
+
+export type RuntimeStatusAction =
+  | { type: 'reset'; timestamp: string }
+  | {
+    type: 'record-readiness-phase'
+    phase: RuntimeReadinessPhase
+    message: string
+    status?: RuntimeReadinessStatus
+    code?: string
+    timestamp: string
+  }
+  | { type: 'record-doctor-check'; input: RuntimeDoctorCheckInput; timestamp: string }
+  | { type: 'record-component-verification'; report: RuntimeComponentVerificationReport; timestamp: string }
+  | {
+    type: 'set-ready'
+    ready: boolean
+    error?: string | null
+    hasErrorArgument: boolean
+    timestamp: string
+  }
+  | { type: 'set-error'; error: string | null; timestamp: string }
 
 function now() {
   return new Date().toISOString()
@@ -33,35 +65,317 @@ function checkCodeForPhase(phase: RuntimeReadinessPhase) {
   return `runtime.${phase.replace(/-/g, '_')}`
 }
 
-function appendTimeline(entry: Omit<RuntimeReadinessTimelineEntry, 'timestamp'>) {
-  timeline = [
-    ...timeline,
-    {
-      ...entry,
-      message: sanitizeStatusText(entry.message) || '',
-      timestamp: now(),
-    },
-  ].slice(-MAX_TIMELINE_ENTRIES)
+function cloneRuntimeStatusValue<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value
+  try {
+    return structuredClone(value)
+  } catch {
+    if (Array.isArray(value)) return [...value] as T
+    return { ...(value as Record<string, unknown>) } as T
+  }
 }
 
-function setUpdatedAt() {
-  updatedAt = now()
+function createEmptyRuntimeStatusState(timestamp: string): RuntimeStatusState {
+  return {
+    ready: false,
+    error: null,
+    phase: 'environment',
+    updatedAt: timestamp,
+    timeline: [],
+    checks: [],
+    components: null,
+  }
 }
+
+function appendTimeline(
+  state: RuntimeStatusState,
+  entry: Omit<RuntimeReadinessTimelineEntry, 'timestamp'>,
+  timestamp: string,
+): RuntimeStatusState {
+  return {
+    ...state,
+    updatedAt: timestamp,
+    timeline: [
+      ...state.timeline,
+      {
+        ...entry,
+        message: sanitizeStatusText(entry.message) || '',
+        timestamp,
+      },
+    ].slice(-MAX_TIMELINE_ENTRIES),
+  }
+}
+
+function upsertDoctorCheck(
+  state: RuntimeStatusState,
+  input: RuntimeDoctorCheckInput,
+  timestamp: string,
+): RuntimeStatusState {
+  const check: RuntimeDoctorCheck = {
+    code: input.code,
+    severity: input.severity || (input.status === 'fail' ? 'error' : 'info'),
+    status: input.status,
+    message: sanitizeStatusText(input.message) || '',
+    remediation: sanitizeStatusText(input.remediation) || undefined,
+    evidence: input.evidence ? { ...input.evidence } : undefined,
+    updatedAt: timestamp,
+  }
+  return {
+    ...state,
+    updatedAt: timestamp,
+    checks: [
+      ...state.checks.filter((entry) => entry.code !== check.code),
+      check,
+    ],
+  }
+}
+
+export function reduceRuntimeStatus(
+  state: RuntimeStatusState,
+  action: RuntimeStatusAction,
+): RuntimeStatusState {
+  switch (action.type) {
+    case 'reset': {
+      return appendTimeline(createEmptyRuntimeStatusState(action.timestamp), {
+        phase: 'environment',
+        status: 'started',
+        message: 'Runtime status reset.',
+        code: checkCodeForPhase('environment'),
+      }, action.timestamp)
+    }
+    case 'record-readiness-phase': {
+      return appendTimeline({
+        ...state,
+        phase: action.phase,
+      }, {
+        phase: action.phase,
+        status: action.status || 'started',
+        message: action.message,
+        code: action.code || checkCodeForPhase(action.phase),
+      }, action.timestamp)
+    }
+    case 'record-doctor-check':
+      return upsertDoctorCheck(state, action.input, action.timestamp)
+    case 'record-component-verification': {
+      let next: RuntimeStatusState = {
+        ...state,
+        updatedAt: action.timestamp,
+        components: cloneRuntimeStatusValue(action.report),
+      }
+      next = upsertDoctorCheck(next, {
+        code: 'runtime.components',
+        status: action.report.ok ? 'pass' : 'fail',
+        severity: action.report.ok ? 'info' : 'error',
+        message: action.report.ok
+          ? 'Runtime component manifest verification passed.'
+          : 'Runtime component manifest verification failed.',
+        remediation: action.report.ok
+          ? undefined
+          : 'Review component hashes, signatures, compatibility status, and development override policy before release.',
+        evidence: {
+          componentCount: action.report.components.length,
+          issueCount: action.report.issues.length,
+          developmentOverride: action.report.developmentOverride,
+        },
+      }, action.timestamp)
+      for (const componentIssue of action.report.issues) {
+        next = upsertDoctorCheck(next, {
+          code: `runtime.component.${componentIssue.componentId || 'manifest'}.${componentIssue.code}`,
+          status: componentIssue.severity === 'error' ? 'fail' : 'pending',
+          severity: componentIssue.severity,
+          message: componentIssue.message,
+          evidence: {
+            componentId: componentIssue.componentId || null,
+            code: componentIssue.code,
+          },
+        }, action.timestamp)
+      }
+      return next
+    }
+    case 'set-ready': {
+      if (!action.ready && action.hasErrorArgument && action.error === null) {
+        return reduceRuntimeStatus(state, { type: 'reset', timestamp: action.timestamp })
+      }
+
+      const sanitizedError = action.hasErrorArgument ? sanitizeStatusText(action.error) : state.error
+      let next: RuntimeStatusState = {
+        ...state,
+        ready: action.ready,
+        error: action.ready ? null : sanitizedError,
+        updatedAt: action.timestamp,
+      }
+
+      if (action.ready) {
+        next = {
+          ...next,
+          phase: 'ready',
+        }
+        next = appendTimeline(next, {
+          phase: 'ready',
+          status: 'passed',
+          message: 'OpenCode runtime is ready.',
+          code: checkCodeForPhase('ready'),
+        }, action.timestamp)
+        return upsertDoctorCheck(next, {
+          code: 'runtime.ready',
+          status: 'pass',
+          message: 'Runtime reached ready state.',
+        }, action.timestamp)
+      }
+
+      const errorMessage = next.error
+      if (errorMessage) {
+        next = {
+          ...next,
+          phase: 'error',
+        }
+        return appendTimeline(next, {
+          phase: 'error',
+          status: 'failed',
+          message: errorMessage,
+          code: checkCodeForPhase('error'),
+        }, action.timestamp)
+      }
+
+      return {
+        ...next,
+        phase: 'environment',
+      }
+    }
+    case 'set-error': {
+      const error = sanitizeStatusText(action.error)
+      if (!error) {
+        return {
+          ...state,
+          error: null,
+          updatedAt: action.timestamp,
+        }
+      }
+
+      let next: RuntimeStatusState = {
+        ...state,
+        ready: false,
+        error,
+        phase: 'error',
+        updatedAt: action.timestamp,
+      }
+      next = appendTimeline(next, {
+        phase: 'error',
+        status: 'failed',
+        message: error,
+        code: checkCodeForPhase('error'),
+      }, action.timestamp)
+      return upsertDoctorCheck(next, {
+        code: 'runtime.startup',
+        status: 'fail',
+        severity: 'error',
+        message: error,
+        remediation: 'Review runtime input diagnostics, app configuration, and the managed OpenCode startup log.',
+      }, action.timestamp)
+    }
+  }
+}
+
+function toRuntimeStatus(state: RuntimeStatusState): RuntimeStatus {
+  return {
+    ready: state.ready,
+    error: state.error,
+    phase: state.phase,
+    updatedAt: state.updatedAt,
+    timeline: state.timeline.map((entry) => cloneRuntimeStatusValue(entry)),
+    checks: [...state.checks]
+      .sort((left, right) => left.code.localeCompare(right.code))
+      .map((check) => cloneRuntimeStatusValue(check)),
+    components: cloneRuntimeStatusValue(state.components),
+  }
+}
+
+export class RuntimeStatusStore {
+  private state: RuntimeStatusState
+  private readonly clock: () => string
+
+  constructor(clock: () => string = now) {
+    this.clock = clock
+    const timestamp = this.clock()
+    this.state = reduceRuntimeStatus(createEmptyRuntimeStatusState(timestamp), {
+      type: 'reset',
+      timestamp,
+    })
+  }
+
+  reset() {
+    this.dispatch({ type: 'reset', timestamp: this.clock() })
+  }
+
+  recordReadinessPhase(
+    phase: RuntimeReadinessPhase,
+    message: string,
+    options: {
+      status?: RuntimeReadinessStatus
+      code?: string
+    } = {},
+  ) {
+    this.dispatch({
+      type: 'record-readiness-phase',
+      phase,
+      message,
+      status: options.status,
+      code: options.code,
+      timestamp: this.clock(),
+    })
+  }
+
+  recordDoctorCheck(input: RuntimeDoctorCheckInput) {
+    this.dispatch({
+      type: 'record-doctor-check',
+      input,
+      timestamp: this.clock(),
+    })
+  }
+
+  recordComponentVerification(report: RuntimeComponentVerificationReport) {
+    this.dispatch({
+      type: 'record-component-verification',
+      report,
+      timestamp: this.clock(),
+    })
+  }
+
+  setReady(value: boolean, error: string | null | undefined, hasErrorArgument: boolean) {
+    this.dispatch({
+      type: 'set-ready',
+      ready: value,
+      error,
+      hasErrorArgument,
+      timestamp: this.clock(),
+    })
+  }
+
+  isReady() {
+    return this.state.ready
+  }
+
+  setError(error: string | null) {
+    this.dispatch({
+      type: 'set-error',
+      error,
+      timestamp: this.clock(),
+    })
+  }
+
+  getStatus(): RuntimeStatus {
+    return toRuntimeStatus(this.state)
+  }
+
+  private dispatch(action: RuntimeStatusAction) {
+    this.state = reduceRuntimeStatus(this.state, action)
+  }
+}
+
+const runtimeStatusStore = new RuntimeStatusStore()
 
 export function resetRuntimeStatus() {
-  runtimeReady = false
-  runtimeError = null
-  runtimePhase = 'environment'
-  timeline = []
-  doctorChecks.clear()
-  componentVerification = null
-  setUpdatedAt()
-  appendTimeline({
-    phase: 'environment',
-    status: 'started',
-    message: 'Runtime status reset.',
-    code: checkCodeForPhase('environment'),
-  })
+  runtimeStatusStore.reset()
 }
 
 export function recordRuntimeReadinessPhase(
@@ -72,129 +386,29 @@ export function recordRuntimeReadinessPhase(
     code?: string
   } = {},
 ) {
-  runtimePhase = phase
-  setUpdatedAt()
-  appendTimeline({
-    phase,
-    status: options.status || 'started',
-    message,
-    code: options.code || checkCodeForPhase(phase),
-  })
+  runtimeStatusStore.recordReadinessPhase(phase, message, options)
 }
 
-export function recordRuntimeDoctorCheck(input: {
-  code: string
-  severity?: RuntimeDoctorSeverity
-  status: RuntimeDoctorStatus
-  message: string
-  remediation?: string
-  evidence?: RuntimeDoctorCheck['evidence']
-}) {
-  const check: RuntimeDoctorCheck = {
-    code: input.code,
-    severity: input.severity || (input.status === 'fail' ? 'error' : 'info'),
-    status: input.status,
-    message: sanitizeStatusText(input.message) || '',
-    remediation: sanitizeStatusText(input.remediation) || undefined,
-    evidence: input.evidence,
-    updatedAt: now(),
-  }
-  doctorChecks.set(check.code, check)
-  setUpdatedAt()
+export function recordRuntimeDoctorCheck(input: RuntimeDoctorCheckInput) {
+  runtimeStatusStore.recordDoctorCheck(input)
 }
 
 export function recordRuntimeComponentVerification(report: RuntimeComponentVerificationReport) {
-  componentVerification = report
-  recordRuntimeDoctorCheck({
-    code: 'runtime.components',
-    status: report.ok ? 'pass' : 'fail',
-    severity: report.ok ? 'info' : 'error',
-    message: report.ok
-      ? 'Runtime component manifest verification passed.'
-      : 'Runtime component manifest verification failed.',
-    remediation: report.ok
-      ? undefined
-      : 'Review component hashes, signatures, compatibility status, and development override policy before release.',
-    evidence: {
-      componentCount: report.components.length,
-      issueCount: report.issues.length,
-      developmentOverride: report.developmentOverride,
-    },
-  })
-  for (const componentIssue of report.issues) {
-    recordRuntimeDoctorCheck({
-      code: `runtime.component.${componentIssue.componentId || 'manifest'}.${componentIssue.code}`,
-      status: componentIssue.severity === 'error' ? 'fail' : 'pending',
-      severity: componentIssue.severity,
-      message: componentIssue.message,
-      evidence: {
-        componentId: componentIssue.componentId || null,
-        code: componentIssue.code,
-      },
-    })
-  }
+  runtimeStatusStore.recordComponentVerification(report)
 }
 
 export function setRuntimeReady(value: boolean, error?: string | null) {
-  if (!value && error === null) {
-    resetRuntimeStatus()
-    return
-  }
-  runtimeReady = value
-  if (error !== undefined) {
-    runtimeError = sanitizeStatusText(error)
-  } else if (value) {
-    runtimeError = null
-  }
-  if (value) {
-    runtimePhase = 'ready'
-    recordRuntimeReadinessPhase('ready', 'OpenCode runtime is ready.', { status: 'passed' })
-    recordRuntimeDoctorCheck({
-      code: 'runtime.ready',
-      status: 'pass',
-      message: 'Runtime reached ready state.',
-    })
-  } else if (runtimeError) {
-    runtimePhase = 'error'
-    recordRuntimeReadinessPhase('error', runtimeError, { status: 'failed' })
-  } else {
-    runtimePhase = 'environment'
-    setUpdatedAt()
-  }
+  runtimeStatusStore.setReady(value, error, error !== undefined)
 }
 
 export function isRuntimeReady() {
-  return runtimeReady
+  return runtimeStatusStore.isReady()
 }
 
 export function setRuntimeError(error: string | null) {
-  runtimeError = sanitizeStatusText(error)
-  if (error) {
-    runtimeReady = false
-    runtimePhase = 'error'
-    recordRuntimeReadinessPhase('error', runtimeError || 'Runtime startup failed.', { status: 'failed' })
-    recordRuntimeDoctorCheck({
-      code: 'runtime.startup',
-      status: 'fail',
-      severity: 'error',
-      message: runtimeError || 'Runtime startup failed.',
-      remediation: 'Review runtime input diagnostics, app configuration, and the managed OpenCode startup log.',
-    })
-  } else {
-    setUpdatedAt()
-  }
+  runtimeStatusStore.setError(error)
 }
 
 export function getRuntimeStatus(): RuntimeStatus {
-  return {
-    ready: runtimeReady,
-    error: runtimeError,
-    phase: runtimePhase,
-    updatedAt,
-    timeline: [...timeline],
-    checks: [...doctorChecks.values()].sort((left, right) => left.code.localeCompare(right.code)),
-    components: componentVerification,
-  }
+  return runtimeStatusStore.getStatus()
 }
-
-resetRuntimeStatus()

--- a/apps/desktop/src/main/session-engine.ts
+++ b/apps/desktop/src/main/session-engine.ts
@@ -40,6 +40,7 @@ import {
   normalizeToolStatus,
 } from './session-engine-events.ts'
 import { createSessionViewSequence, type SessionViewSequence } from './session-view-sequence.ts'
+import { nextSessionScopedFallbackId } from './runtime-fallback-ids.ts'
 
 export { MAX_SEEN_COST_EVENT_IDS_PER_SESSION } from './session-cost-event-tracker.ts'
 
@@ -411,7 +412,7 @@ export class SessionEngine {
         break
       case 'tool_call':
         this.updateSessionState(sessionId, (current) => {
-          const toolId = typeof data.id === 'string' ? data.id : `${sessionId}:tool:${this.nowMs()}`
+          const toolId = typeof data.id === 'string' ? data.id : nextSessionScopedFallbackId(sessionId, 'tool')
           const toolStatus = normalizeToolStatus(data.status)
           const toolName = typeof data.name === 'string' ? data.name : undefined
           if (data.taskRunId) {

--- a/apps/desktop/src/main/session-registry.ts
+++ b/apps/desktop/src/main/session-registry.ts
@@ -58,6 +58,27 @@ export function toDisplayDirectory(opencodeDirectory: string) {
   return normalized === resolve(getRuntimeHomeDir()) || isSandboxWorkspaceDir(normalized) ? null : normalized
 }
 
+function cloneSessionRecord(record: SessionRecord): SessionRecord {
+  try {
+    return structuredClone(record)
+  } catch {
+    return {
+      ...record,
+      summary: record.summary
+        ? {
+            ...record.summary,
+            tokens: { ...record.summary.tokens },
+            agentBreakdown: record.summary.agentBreakdown?.map((entry) => ({
+              ...entry,
+              tokens: { ...entry.tokens },
+            })),
+          }
+        : null,
+      changeSummary: record.changeSummary ? { ...record.changeSummary } : null,
+    }
+  }
+}
+
 function getManagedSessionIdsFromLogs() {
   const logDir = getLogDir()
   if (!existsSync(logDir)) return new Set<string>()
@@ -167,13 +188,16 @@ function scheduleRegistrySave() {
 }
 
 export function listSessionRecords() {
-  return Array.from(loadRegistryMap().values()).sort((a, b) => {
-    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-  })
+  return Array.from(loadRegistryMap().values())
+    .map(cloneSessionRecord)
+    .sort((a, b) => {
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    })
 }
 
 export function getSessionRecord(id: string) {
-  return loadRegistryMap().get(id) || null
+  const record = loadRegistryMap().get(id)
+  return record ? cloneSessionRecord(record) : null
 }
 
 export function upsertSessionRecord(record: SessionRecord) {
@@ -187,7 +211,7 @@ export function upsertSessionRecord(record: SessionRecord) {
   } else {
     scheduleRegistrySave()
   }
-  return map.get(record.id) || null
+  return cloneSessionRecord(next)
 }
 
 export function updateSessionRecord(id: string, patch: Partial<Omit<SessionRecord, 'id'>>) {
@@ -202,9 +226,11 @@ export function updateSessionRecord(id: string, patch: Partial<Omit<SessionRecor
   if (!('directory' in patch) || patch.directory === undefined) {
     next.directory = toDisplayDirectory(next.opencodeDirectory)
   }
-  map.set(id, next)
+  const normalized = normalizeStoredSessionRecord(next, normalizeOpencodeDirectory, toDisplayDirectory)
+  if (!normalized) return null
+  map.set(id, normalized)
   scheduleRegistrySave()
-  return next
+  return cloneSessionRecord(normalized)
 }
 
 export function touchSessionRecord(id: string, updatedAt = new Date().toISOString()) {

--- a/apps/desktop/src/main/session-task-state-store.ts
+++ b/apps/desktop/src/main/session-task-state-store.ts
@@ -32,6 +32,10 @@ type QueuedChildSessionMeta = {
   id: string
 }
 
+function cloneTaskRunMeta(taskRun: TaskRunMeta): TaskRunMeta {
+  return { ...taskRun }
+}
+
 // Local cache fed by OpenCode session/task events. OpenCode remains the
 // source of truth; this store only keeps enough indexed state for synchronous
 // event projection without calling the SDK from every event handler.
@@ -115,7 +119,7 @@ export class SessionTaskStateStore {
         && (taskRun.status === 'queued' || taskRun.status === 'running')
     })
 
-    return candidates.length === 1 ? candidates[0] : null
+    return candidates.length === 1 ? cloneTaskRunMeta(candidates[0]) : null
   }
 
   bindTaskRunToChild(taskRunId: string, childSessionId: string) {
@@ -165,19 +169,23 @@ export class SessionTaskStateStore {
         if (resolvedTaskRunId !== taskRunId) this.taskRunAliases.set(resolvedTaskRunId, existingTaskRunId)
         this.removePendingTaskRun(resolvedTaskRunId)
         this.removeQueuedChildSession(childSessionId)
-        return mergedTaskRun
+        return cloneTaskRunMeta(mergedTaskRun)
       }
     }
 
     const taskRun = this.taskRuns.get(resolvedTaskRunId)
     if (!taskRun) return null
-    taskRun.childSessionId = childSessionId
-    taskRun.parentSessionId = childParentSessionId || taskRun.parentSessionId || taskRun.rootSessionId
+    const nextTaskRun: TaskRunMeta = {
+      ...taskRun,
+      childSessionId,
+      parentSessionId: childParentSessionId || taskRun.parentSessionId || taskRun.rootSessionId,
+    }
+    this.taskRuns.set(resolvedTaskRunId, nextTaskRun)
     this.childSessionToTaskRunId.set(childSessionId, resolvedTaskRunId)
     if (resolvedTaskRunId !== taskRunId) this.taskRunAliases.set(taskRunId, resolvedTaskRunId)
     this.removePendingTaskRun(resolvedTaskRunId)
     this.removeQueuedChildSession(childSessionId)
-    return taskRun
+    return cloneTaskRunMeta(nextTaskRun)
   }
 
   registerTaskRun(taskRun: TaskRunMeta) {
@@ -193,20 +201,20 @@ export class SessionTaskStateStore {
       this.childSessionToTaskRunId.set(normalizedTaskRun.childSessionId, normalizedTaskRun.id)
       this.removePendingTaskRun(normalizedTaskRun.id)
       this.removeQueuedChildSession(normalizedTaskRun.childSessionId)
-      return normalizedTaskRun
+      return cloneTaskRunMeta(normalizedTaskRun)
     }
 
     const queuedChild = this.takeQueuedChildSession(parentQueueKey)
     if (queuedChild) {
       const bound = this.bindTaskRunToChild(normalizedTaskRun.id, queuedChild.id)
-      return bound || this.taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun
+      return bound || cloneTaskRunMeta(this.taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun)
     }
 
     if (!normalizedTaskRun.childSessionId && !isTerminalTaskStatus(normalizedTaskRun.status)) {
       pushUniqueQueueValue(this.pendingTaskRunsByParent, parentQueueKey, normalizedTaskRun.id)
     }
 
-    return this.taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun
+    return cloneTaskRunMeta(this.taskRuns.get(normalizedTaskRun.id) || normalizedTaskRun)
   }
 
   queueOrBindChildSession(
@@ -219,7 +227,7 @@ export class SessionTaskStateStore {
       const existing = this.taskRuns.get(existingTaskRunId)
       if (existing) {
         this.removeQueuedChildSession(childSessionId)
-        return existing
+        return cloneTaskRunMeta(existing)
       }
       this.childSessionToTaskRunId.delete(childSessionId)
     }
@@ -246,7 +254,10 @@ export class SessionTaskStateStore {
     parentSessionId?: string | null,
   ) {
     const existingTaskRunId = this.childSessionToTaskRunId.get(childSessionId)
-    if (existingTaskRunId) return this.taskRuns.get(existingTaskRunId) || null
+    if (existingTaskRunId) {
+      const existing = this.taskRuns.get(existingTaskRunId)
+      return existing ? cloneTaskRunMeta(existing) : null
+    }
 
     const immediateParentSessionId = parentSessionId || this.getImmediateParentSession(childSessionId) || rootSessionId
     const fallback: TaskRunMeta = {
@@ -262,7 +273,7 @@ export class SessionTaskStateStore {
     }
     this.taskRuns.set(fallback.id, fallback)
     this.childSessionToTaskRunId.set(childSessionId, fallback.id)
-    return fallback
+    return cloneTaskRunMeta(fallback)
   }
 
   updateTaskRun(taskRunId: string, patch: Partial<TaskRunMeta>) {
@@ -276,12 +287,13 @@ export class SessionTaskStateStore {
     } else if (isTerminalTaskStatus(next.status)) {
       this.removePendingTaskRun(next.id)
     }
-    return next
+    return cloneTaskRunMeta(next)
   }
 
   getTaskRun(taskRunId: string | null | undefined) {
     if (!taskRunId) return null
-    return this.taskRuns.get(taskRunId) || null
+    const taskRun = this.taskRuns.get(taskRunId)
+    return taskRun ? cloneTaskRunMeta(taskRun) : null
   }
 
   getTaskRunIdForChild(sessionId: string | null | undefined) {

--- a/tests/event-runtime-handlers.test.ts
+++ b/tests/event-runtime-handlers.test.ts
@@ -18,6 +18,7 @@ import {
   resolveRootSession,
   trackParentSession,
 } from '../apps/desktop/src/main/event-task-state.ts'
+import { resetSessionScopedFallbackIdsForTests } from '../apps/desktop/src/main/runtime-fallback-ids.ts'
 
 function createDispatchCollector() {
   const events: unknown[] = []
@@ -46,6 +47,7 @@ function createWindowSendCollector(options?: { destroyed?: boolean; webContentsD
 test.afterEach(() => {
   resetEventTaskState()
   resetRuntimeEventStateForTests()
+  resetSessionScopedFallbackIdsForTests()
 })
 
 test('returns false for events outside the runtime side-effect handler scope', () => {
@@ -481,6 +483,62 @@ test('child tool errors do not terminalize a still-running subagent task', () =>
       sourceSessionId: 'child-session',
     },
   })
+})
+
+test('message.part.updated fallback tool ids do not collide within one session', () => {
+  const collector = createDispatchCollector()
+  const win = {
+    webContents: { send: () => undefined },
+    isDestroyed: () => false,
+  } as unknown as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+
+  trackParentSession('root-session')
+
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-1',
+      part: {
+        type: 'tool',
+        tool: 'read',
+        state: {
+          status: 'running',
+          input: { path: 'README.md' },
+        },
+      },
+    },
+    messageState,
+    'openai/gpt-5.5',
+  )
+  handleMessagePartUpdatedEvent(
+    win,
+    collector.dispatch,
+    {
+      sessionID: 'root-session',
+      messageID: 'message-2',
+      part: {
+        type: 'tool',
+        tool: 'write',
+        state: {
+          status: 'running',
+          input: { path: 'notes.md' },
+        },
+      },
+    },
+    messageState,
+    'openai/gpt-5.5',
+  )
+
+  const ids = collector.events.map((event) => {
+    return (event as { data?: { id?: string } }).data?.id
+  })
+  assert.deepEqual(ids, [
+    'root-session:tool:fallback:1',
+    'root-session:tool:fallback:2',
+  ])
 })
 
 test('message.part.updated reads SDK part-scoped ids for child transcript text', () => {

--- a/tests/event-task-state.test.ts
+++ b/tests/event-task-state.test.ts
@@ -286,6 +286,40 @@ test('SessionTaskStateStore keeps hierarchy indexes isolated per instance', () =
   assert.equal(first.consumePendingPromptEcho('child-session', 'pending echo'), 'pending echo')
 })
 
+test('SessionTaskStateStore returns task run snapshots at public boundaries', () => {
+  const store = new SessionTaskStateStore()
+  store.trackParentSession('root-session')
+  const registered = store.registerTaskRun({
+    id: 'task-copy',
+    rootSessionId: 'root-session',
+    parentSessionId: 'root-session',
+    title: 'Original title',
+    agent: 'research',
+    childSessionId: null,
+    status: 'queued',
+  })
+
+  registered.title = 'Mutated registration result'
+  registered.status = 'complete'
+  assert.equal(store.getTaskRun('task-copy')?.title, 'Original title')
+  assert.equal(store.getTaskRun('task-copy')?.status, 'queued')
+
+  const bound = store.queueOrBindChildSession('root-session', 'child-session')
+  assert.ok(bound)
+  bound.childSessionId = 'mutated-child'
+  assert.equal(store.getTaskRun('task-copy')?.childSessionId, 'child-session')
+
+  const updated = store.updateTaskRun('task-copy', { status: 'running' })
+  assert.ok(updated)
+  updated.status = 'error'
+  assert.equal(store.getTaskRun('task-copy')?.status, 'running')
+
+  const read = store.getTaskRun('task-copy')
+  assert.ok(read)
+  read.title = 'Mutated read result'
+  assert.equal(store.getTaskRun('task-copy')?.title, 'Original title')
+})
+
 test('consumes pending prompt echo incrementally', () => {
   rememberSubmittedPrompt('session-1', 'awesome')
 

--- a/tests/runtime-status.test.ts
+++ b/tests/runtime-status.test.ts
@@ -3,15 +3,58 @@ import assert from 'node:assert/strict'
 import {
   getRuntimeStatus,
   isRuntimeReady,
+  reduceRuntimeStatus,
   recordRuntimeComponentVerification,
   recordRuntimeDoctorCheck,
   recordRuntimeReadinessPhase,
   resetRuntimeStatus,
+  RuntimeStatusStore,
   setRuntimeError,
   setRuntimeReady,
+  type RuntimeStatusState,
 } from '../apps/desktop/src/main/runtime-status.ts'
 import { verifyRuntimeComponentManifest } from '../apps/desktop/src/main/runtime-component-manifest.ts'
 import { RUNTIME_COMPONENT_MANIFEST_FORMAT } from '../packages/shared/src/runtime.ts'
+
+test('runtime status reducer derives phase changes without mutating prior state', () => {
+  const initial: RuntimeStatusState = {
+    ready: false,
+    error: null,
+    phase: 'environment',
+    updatedAt: '2026-06-03T10:00:00.000Z',
+    timeline: [],
+    checks: [],
+    components: null,
+  }
+
+  const next = reduceRuntimeStatus(initial, {
+    type: 'record-readiness-phase',
+    phase: 'config-build',
+    message: 'Config ready',
+    timestamp: '2026-06-03T10:00:01.000Z',
+  })
+
+  assert.equal(initial.phase, 'environment')
+  assert.equal(initial.timeline.length, 0)
+  assert.equal(next.phase, 'config-build')
+  assert.equal(next.updatedAt, '2026-06-03T10:00:01.000Z')
+  assert.deepEqual(next.timeline.map((entry) => entry.code), ['runtime.config_build'])
+})
+
+test('runtime status store accepts an explicit clock dependency', () => {
+  const timestamps = [
+    '2026-06-03T10:00:00.000Z',
+    '2026-06-03T10:00:01.000Z',
+  ]
+  const store = new RuntimeStatusStore(() => timestamps.shift() || '2026-06-03T10:00:02.000Z')
+
+  store.recordReadinessPhase('event-stream', 'Connected')
+
+  const status = store.getStatus()
+  assert.equal(status.phase, 'event-stream')
+  assert.equal(status.updatedAt, '2026-06-03T10:00:01.000Z')
+  assert.equal(status.timeline?.at(-1)?.timestamp, '2026-06-03T10:00:01.000Z')
+})
 
 test('runtime status starts not ready with no error after reset', () => {
   resetRuntimeStatus()

--- a/tests/session-engine.test.ts
+++ b/tests/session-engine.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { MAX_SEEN_COST_EVENT_IDS_PER_SESSION, SessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { MAX_WARM_SESSION_DETAILS } from '../apps/desktop/src/lib/session-view-model.ts'
+import { resetSessionScopedFallbackIdsForTests } from '../apps/desktop/src/main/runtime-fallback-ids.ts'
 
 function apply(engine: SessionEngine, sessionId: string, data: Record<string, unknown>) {
   engine.applyStreamEvent({
@@ -274,6 +275,30 @@ test('session engine defensively copies SDK tool payloads', () => {
   const tool = engine.getSessionView(sessionId).toolCalls[0]
   assert.deepEqual(tool?.input, { nested: { path: 'before.md' } })
   assert.deepEqual(tool?.output, { result: { ok: true } })
+})
+
+test('session engine fallback tool ids do not collide within one session', () => {
+  resetSessionScopedFallbackIdsForTests()
+  const engine = new SessionEngine({ nowMs: () => 1_700_000_000_000 })
+  const sessionId = 'session-tool-fallback'
+
+  engine.activateSession(sessionId)
+  apply(engine, sessionId, {
+    type: 'tool_call',
+    name: 'read',
+    status: 'running',
+  })
+  apply(engine, sessionId, {
+    type: 'tool_call',
+    name: 'write',
+    status: 'running',
+  })
+
+  const ids = engine.getSessionView(sessionId).toolCalls.map((tool) => tool.id)
+  assert.deepEqual(ids, [
+    'session-tool-fallback:tool:fallback:1',
+    'session-tool-fallback:tool:fallback:2',
+  ])
 })
 
 test('session engine accepts deterministic id and clock dependencies for action-owned fields', () => {

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -8,6 +8,7 @@ import { closeLogger } from '../apps/desktop/src/main/logger.ts'
 import {
   clearSessionRegistryCache,
   flushSessionRegistryWrites,
+  getSessionRecord,
   listSessionRecords,
   removeSessionRecord,
   toSessionRecord,
@@ -113,6 +114,83 @@ test('session composer preferences persist separately from last-used model', () 
     assert.equal(record?.modelId, 'openrouter/model-last-used-after-prompt')
     assert.equal(record?.composerModelId, 'openrouter/model-composer')
     assert.equal(record?.composerReasoningVariant, 'xhigh')
+  } finally {
+    clearSessionRegistryCache()
+    clearConfigCaches()
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+})
+
+test('session registry returns defensive copies from public boundaries', () => {
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+  const userDataDir = uniqueUserDataDir('defensive-copy')
+  const sessionId = `session-copy-${Date.now()}`
+
+  try {
+    resetRegistryTestState(userDataDir)
+
+    const inserted = upsertSessionRecord(toSessionRecord({
+      id: sessionId,
+      title: 'Cached state',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      opencodeDirectory: userDataDir,
+      summary: {
+        messages: 1,
+        userMessages: 1,
+        assistantMessages: 0,
+        toolCalls: 0,
+        taskRuns: 1,
+        cost: 0.25,
+        tokens: {
+          input: 10,
+          output: 0,
+          reasoning: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        agentBreakdown: [{
+          agent: 'research',
+          taskRuns: 1,
+          cost: 0.25,
+          tokens: {
+            input: 10,
+            output: 0,
+            reasoning: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+        }],
+      },
+    }))
+    assert.ok(inserted)
+
+    inserted.title = 'Mutated insert result'
+    inserted.summary!.tokens.input = 999
+    inserted.summary!.agentBreakdown![0]!.tokens.input = 999
+
+    const listed = listSessionRecords().find((record) => record.id === sessionId)
+    assert.ok(listed)
+    listed.title = 'Mutated list result'
+    listed.summary!.tokens.input = 500
+
+    const updated = updateSessionRecord(sessionId, {
+      changeSummary: {
+        additions: 2,
+        deletions: 1,
+        files: 1,
+      },
+    })
+    assert.ok(updated)
+    updated.changeSummary!.additions = 999
+
+    const fresh = getSessionRecord(sessionId)
+    assert.equal(fresh?.title, 'Cached state')
+    assert.equal(fresh?.summary?.tokens.input, 10)
+    assert.equal(fresh?.summary?.agentBreakdown?.[0]?.tokens.input, 10)
+    assert.equal(fresh?.changeSummary?.additions, 2)
   } finally {
     clearSessionRegistryCache()
     clearConfigCaches()


### PR DESCRIPTION
## Summary

- Extract runtime status state into an explicit reducer and store while preserving existing runtime status APIs.
- Defensively copy session registry records and task run state at public boundaries.
- Replace timestamp-only fallback tool IDs with session-scoped monotonic fallback IDs.

Closes #677.
Closes #678.
Closes #679.
Closes #680.

## Validation

- node scripts/run-node-tests.mjs tests/runtime-status.test.ts tests/session-registry.test.ts tests/event-task-state.test.ts tests/session-engine.test.ts tests/event-runtime-handlers.test.ts tests/task-run-timing.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check