### PR TITLE
Harden cloud boundary data contracts

### DIFF
--- a/apps/desktop/src/main/cloud/http-routes/channels.ts
+++ b/apps/desktop/src/main/cloud/http-routes/channels.ts
@@ -260,17 +260,17 @@ export async function handleChannelsApiRoute(input: {
       tools.writeError(res, 400, 'Channel cursor update requires bindingId.', options.corsOrigin)
       return true
     }
-    const binding = await options.service.updateChannelCursor(context.principal, {
+    const result = await options.service.updateChannelCursor(context.principal, {
       bindingId,
       lastEventSequence: tools.readNonNegativeInteger(body.lastEventSequence),
       lastWorkspaceSequence: tools.readNonNegativeInteger(body.lastWorkspaceSequence),
       lastChatMessageId: body.lastChatMessageId === undefined ? undefined : tools.readString(body.lastChatMessageId),
     })
-    if (!binding) {
+    if (!result.ok && result.reason === 'not_found') {
       tools.writeError(res, 404, 'Channel session binding was not found.', options.corsOrigin)
       return true
     }
-    tools.writeJson(res, 200, { binding }, options.corsOrigin)
+    tools.writeJson(res, 200, { binding: result.binding, result }, options.corsOrigin)
     return true
   }
 

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -861,6 +861,8 @@ export type UpdateChannelCursorInput = {
   updatedAt?: Date
 }
 
+export type ChannelCursorUpdateResult = { ok: true, binding: ChannelSessionBindingRecord } | { ok: false, reason: 'stale', binding: ChannelSessionBindingRecord } | { ok: false, reason: 'not_found' }
+
 export type CreateChannelInteractionInput = {
   interactionId: string
   orgId: string
@@ -1193,7 +1195,7 @@ export type ControlPlaneStore = {
     externalThreadId: string
   }): MaybePromise<ChannelSessionBindingRecord | null>
   listChannelSessionBindingsForSession(orgId: string, sessionId: string): MaybePromise<ChannelSessionBindingRecord[]>
-  updateChannelCursor(input: UpdateChannelCursorInput): MaybePromise<ChannelSessionBindingRecord | null>
+  updateChannelCursor(input: UpdateChannelCursorInput): MaybePromise<ChannelCursorUpdateResult>
   createChannelInteraction(input: CreateChannelInteractionInput): MaybePromise<IssuedChannelInteractionRecord>
   findChannelInteraction(input: FindChannelInteractionInput): MaybePromise<ChannelInteractionRecord | null>
   resolveChannelInteraction(input: ResolveChannelInteractionInput): MaybePromise<ChannelInteractionRecord | null>
@@ -2645,21 +2647,19 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       .map((binding) => clone(binding))
   }
 
-  updateChannelCursor(input: UpdateChannelCursorInput): ChannelSessionBindingRecord | null {
+  updateChannelCursor(input: UpdateChannelCursorInput): ChannelCursorUpdateResult {
     const existing = this.channelSessionBindings.get(input.bindingId)
-    if (!existing || existing.orgId !== input.orgId) return null
+    if (!existing || existing.orgId !== input.orgId) return { ok: false, reason: 'not_found' }
     const lastEventSequence = normalizeNonNegativeInteger(input.lastEventSequence, 'Last event sequence')
     const lastWorkspaceSequence = normalizeNonNegativeInteger(input.lastWorkspaceSequence, 'Last workspace sequence')
     if (lastEventSequence < existing.lastEventSequence || lastWorkspaceSequence < existing.lastWorkspaceSequence) {
-      throw new Error('Channel cursor updates must be monotonic.')
+      return { ok: false, reason: 'stale', binding: clone(existing) }
     }
     existing.lastEventSequence = lastEventSequence
     existing.lastWorkspaceSequence = lastWorkspaceSequence
-    if (input.lastChatMessageId !== undefined) {
-      existing.lastChatMessageId = normalizeNullableText(input.lastChatMessageId, CHANNEL_TEXT_MAX_LENGTH, 'Last chat message id')
-    }
+    if (input.lastChatMessageId !== undefined) existing.lastChatMessageId = normalizeNullableText(input.lastChatMessageId, CHANNEL_TEXT_MAX_LENGTH, 'Last chat message id')
     existing.updatedAt = nowIso(input.updatedAt)
-    return clone(existing)
+    return { ok: true, binding: clone(existing) }
   }
 
   createChannelInteraction(input: CreateChannelInteractionInput): IssuedChannelInteractionRecord {

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -1640,6 +1640,7 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   }
 
   async updateChannelCursor(input: UpdateChannelCursorInput) {
+    const lastEventSequence = normalizeNonNegativeInteger(input.lastEventSequence, 'Last event sequence'), lastWorkspaceSequence = normalizeNonNegativeInteger(input.lastWorkspaceSequence, 'Last workspace sequence')
     const result = await this.pool.query(
       `UPDATE cloud_channel_session_bindings
        SET last_event_sequence = $3,
@@ -1654,14 +1655,17 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       [
         input.orgId,
         input.bindingId,
-        normalizeNonNegativeInteger(input.lastEventSequence, 'Last event sequence'),
-        normalizeNonNegativeInteger(input.lastWorkspaceSequence, 'Last workspace sequence'),
+        lastEventSequence,
+        lastWorkspaceSequence,
         input.lastChatMessageId !== undefined,
         normalizeNullableText(input.lastChatMessageId, CHANNEL_TEXT_MAX_LENGTH, 'Last chat message id'),
         nowIso(input.updatedAt),
       ],
     )
-    return result.rows[0] ? channelSessionBindingFromRow(result.rows[0]) : null
+    if (result.rows[0]) return { ok: true as const, binding: channelSessionBindingFromRow(result.rows[0]) }
+    const existing = await this.maybeOne(`SELECT * FROM cloud_channel_session_bindings WHERE org_id = $1 AND binding_id = $2`, [input.orgId, input.bindingId])
+    if (!existing) return { ok: false as const, reason: 'not_found' as const }
+    return { ok: false as const, reason: 'stale' as const, binding: channelSessionBindingFromRow(existing) }
   }
 
   async createChannelInteraction(input: CreateChannelInteractionInput): Promise<IssuedChannelInteractionRecord> {

--- a/apps/desktop/src/main/cloud/services/channel-service.ts
+++ b/apps/desktop/src/main/cloud/services/channel-service.ts
@@ -1,4 +1,5 @@
 import type {
+  ChannelCursorUpdateResult,
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
   ChannelIdentityRole,
@@ -72,7 +73,7 @@ export type CloudChannelServiceDelegate = {
     lastEventSequence: number
     lastWorkspaceSequence: number
     lastChatMessageId?: string | null
-  }): Promise<ChannelSessionBindingRecord | null>
+  }): Promise<ChannelCursorUpdateResult>
   enqueueChannelPrompt(principal: CloudPrincipal, input: Record<string, unknown>): Promise<{
     binding: ChannelSessionBindingRecord
     command: SessionCommandRecord

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -41,6 +41,7 @@ import type {
   ChannelIdentityRecord,
   ChannelIdentityRole,
   ChannelInteractionRecord,
+  ChannelCursorUpdateResult,
   ChannelProviderId,
   ChannelSessionBindingRecord,
   ClaimedWorkflowRunRecord,
@@ -1763,7 +1764,7 @@ export class CloudSessionService {
       lastWorkspaceSequence: number
       lastChatMessageId?: string | null
     },
-  ): Promise<ChannelSessionBindingRecord | null> {
+  ): Promise<ChannelCursorUpdateResult> {
     await this.ensurePrincipal(principal)
     this.assertGatewayAccess(principal)
     return this.store.updateChannelCursor({

--- a/apps/gateway/src/cloud-gateway.test.ts
+++ b/apps/gateway/src/cloud-gateway.test.ts
@@ -105,7 +105,7 @@ test('cloud gateway wraps all required channel and session operations', async ()
     },
     async updateChannelCursor(input: unknown) {
       calls.push(`cursor:${JSON.stringify(input)}`)
-      return { bindingId: 'binding-1' }
+      return { ok: true, binding: { bindingId: 'binding-1' } }
     },
     async ackChannelDelivery(deliveryId: string, input: unknown) {
       calls.push(`ack:${deliveryId}:${JSON.stringify(input)}`)

--- a/apps/gateway/src/cloud-gateway.ts
+++ b/apps/gateway/src/cloud-gateway.ts
@@ -1,6 +1,7 @@
 import {
   createHttpSseCloudTransportAdapter,
   type ChannelActorInput,
+  type ChannelCursorUpdateResult,
   type ChannelDeliveryRecord,
   type ChannelIdentityRecord,
   type ChannelSessionBindingRecord,
@@ -87,7 +88,7 @@ export type CloudGateway = {
     lastEventSequence: number
     lastWorkspaceSequence: number
     lastChatMessageId?: string | null
-  }): Promise<ChannelSessionBindingRecord | null>
+  }): Promise<ChannelCursorUpdateResult>
   ackDelivery(deliveryId: string, input: {
     claimedBy?: string | null
     status: 'sent' | 'failed' | 'dead'

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -94,7 +94,7 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     async resolveChannelInteraction() { return { interaction: {}, command: { commandId: 'cmd-interaction' } as never, processed: 1 } },
     subscribeSessionEvents() { return { close() {} } },
     subscribeDeliveries() { return { close() {} } },
-    async updateCursor() { return null },
+    async updateCursor() { return { ok: false, reason: 'not_found' } },
     async ackDelivery() { return null },
   }
   const config = resolveGatewayConfig({
@@ -747,7 +747,7 @@ test('gateway rejects oversized webhook bodies before provider dispatch', async 
     async createChannelInteraction() { return { interaction: { interactionId: 'interaction-1' } as never, plaintextToken: 'token-1' } },
     subscribeSessionEvents() { return { close() {} } },
     subscribeDeliveries() { return { close() {} } },
-    async updateCursor() { return null },
+    async updateCursor() { return { ok: false, reason: 'not_found' } },
     async ackDelivery() { return null },
   } as CloudGateway
   const config = resolveGatewayConfig({

--- a/apps/gateway/src/session-stream-manager.test.ts
+++ b/apps/gateway/src/session-stream-manager.test.ts
@@ -6,6 +6,35 @@ import { FakeChannelProvider } from '@open-cowork/gateway-testing'
 import type { CloudGateway } from '../dist/index.js'
 import { createGatewayMetrics, createGatewaySessionStreamManager } from '../dist/index.js'
 
+function cursorBinding(input: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    bindingId: 'binding-1',
+    orgId: 'tenant-1',
+    agentId: 'agent-1',
+    channelBindingId: 'channel-binding-1',
+    provider: 'cli',
+    externalWorkspaceId: null,
+    externalThreadId: 'thread-1',
+    externalChatId: 'chat-1',
+    sessionId: 'session-1',
+    lastEventSequence: (input as { lastEventSequence?: number }).lastEventSequence ?? 0,
+    lastWorkspaceSequence: (input as { lastWorkspaceSequence?: number }).lastWorkspaceSequence ?? 0,
+    lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
+    status: 'active',
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  }
+}
+
+function cursorOk(input: unknown, overrides: Record<string, unknown> = {}) {
+  return { ok: true as const, binding: cursorBinding(input, overrides) }
+}
+
+function cursorNotFound() {
+  return { ok: false as const, reason: 'not_found' as const }
+}
+
 test('session stream manager renders session events once and persists cursor after provider send', async () => {
   const provider = new FakeChannelProvider()
   const subscriptions: Array<{
@@ -27,23 +56,7 @@ test('session stream manager renders session events once and persists cursor aft
     },
     async updateCursor(input: unknown) {
       cursorUpdates.push(input)
-      return {
-        bindingId: 'binding-1',
-        orgId: 'tenant-1',
-        agentId: 'agent-1',
-        channelBindingId: 'channel-binding-1',
-        provider: 'cli',
-        externalWorkspaceId: null,
-        externalThreadId: 'thread-1',
-        externalChatId: 'chat-1',
-        sessionId: 'session-1',
-        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
-        lastWorkspaceSequence: (input as { lastWorkspaceSequence: number }).lastWorkspaceSequence,
-        lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
-        status: 'active',
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      }
+      return cursorOk(input)
     },
     async createChannelInteraction() {
       return {
@@ -149,23 +162,7 @@ test('session stream manager renders permission requests as channel buttons', as
       }
     },
     async updateCursor(input: unknown) {
-      return {
-        bindingId: 'binding-1',
-        orgId: 'tenant-1',
-        agentId: 'agent-1',
-        channelBindingId: 'channel-binding-1',
-        provider: 'cli',
-        externalWorkspaceId: null,
-        externalThreadId: 'thread-1',
-        externalChatId: 'chat-1',
-        sessionId: 'session-1',
-        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
-        lastWorkspaceSequence: 0,
-        lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
-        status: 'active',
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      }
+      return cursorOk(input)
     },
   } as CloudGateway
   const manager = createGatewaySessionStreamManager(cloud, createGatewayMetrics())
@@ -237,7 +234,7 @@ test('session stream manager reconnects from the last persisted cursor', async (
       subscriptions.push(input)
       return { close() {} }
     },
-    async updateCursor() { return null },
+    async updateCursor() { return cursorNotFound() },
     async createChannelInteraction() {
       return {
         interaction: { interactionId: 'interaction-1' },
@@ -301,23 +298,7 @@ test('session stream manager hydrates snapshot-required retention gaps', async (
     },
     async updateCursor(input: unknown) {
       cursorUpdates.push(input)
-      return {
-        bindingId: 'binding-1',
-        orgId: 'tenant-1',
-        agentId: 'agent-1',
-        channelBindingId: 'channel-binding-1',
-        provider: 'cli',
-        externalWorkspaceId: null,
-        externalThreadId: 'thread-1',
-        externalChatId: 'chat-1',
-        sessionId: 'session-1',
-        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
-        lastWorkspaceSequence: 0,
-        lastChatMessageId: null,
-        status: 'active',
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      }
+      return cursorOk(input)
     },
     async createChannelInteraction() {
       return {
@@ -391,23 +372,7 @@ test('session stream manager leaves failed provider sends retryable', async () =
     },
     async updateCursor(input: unknown) {
       cursorUpdates.push(input)
-      return {
-        bindingId: 'binding-1',
-        orgId: 'tenant-1',
-        agentId: 'agent-1',
-        channelBindingId: 'channel-binding-1',
-        provider: 'cli',
-        externalWorkspaceId: null,
-        externalThreadId: 'thread-1',
-        externalChatId: 'chat-1',
-        sessionId: 'session-1',
-        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
-        lastWorkspaceSequence: 0,
-        lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
-        status: 'active',
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      }
+      return cursorOk(input)
     },
     async createChannelInteraction() {
       return {
@@ -472,23 +437,7 @@ test('session stream manager retries transient poison events before skipping the
     },
     async updateCursor(input: unknown) {
       cursorUpdates.push(input)
-      return {
-        bindingId: 'binding-1',
-        orgId: 'tenant-1',
-        agentId: 'agent-1',
-        channelBindingId: 'channel-binding-1',
-        provider: 'cli',
-        externalWorkspaceId: null,
-        externalThreadId: 'thread-1',
-        externalChatId: 'chat-1',
-        sessionId: 'session-1',
-        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
-        lastWorkspaceSequence: 0,
-        lastChatMessageId: null,
-        status: 'active',
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      }
+      return cursorOk(input)
     },
     async createChannelInteraction() {
       return {
@@ -572,23 +521,7 @@ test('session stream manager does not let queued later events jump a failed tran
     },
     async updateCursor(input: unknown) {
       cursorUpdates.push(input)
-      return {
-        bindingId: 'binding-1',
-        orgId: 'tenant-1',
-        agentId: 'agent-1',
-        channelBindingId: 'channel-binding-1',
-        provider: 'cli',
-        externalWorkspaceId: null,
-        externalThreadId: 'thread-1',
-        externalChatId: 'chat-1',
-        sessionId: 'session-1',
-        lastEventSequence: (input as { lastEventSequence: number }).lastEventSequence,
-        lastWorkspaceSequence: 0,
-        lastChatMessageId: (input as { lastChatMessageId?: string | null }).lastChatMessageId ?? null,
-        status: 'active',
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      }
+      return cursorOk(input)
     },
     async createChannelInteraction() {
       return {
@@ -659,6 +592,78 @@ test('session stream manager does not let queued later events jump a failed tran
   manager.closeAll()
 })
 
+test('session stream manager treats stale cursor updates as already persisted', async () => {
+  const provider = new FakeChannelProvider()
+  const metrics = createGatewayMetrics()
+  let onEvent: ((event: unknown) => void) | null = null
+  const cursorUpdates: unknown[] = []
+  const cloud = {
+    subscribeSessionEvents(input: { onEvent: (event: unknown) => void }) {
+      onEvent = input.onEvent
+      return { close() {} }
+    },
+    async updateCursor(input: unknown) {
+      cursorUpdates.push(input)
+      return {
+        ok: false as const,
+        reason: 'stale' as const,
+        binding: cursorBinding(input),
+      }
+    },
+    async createChannelInteraction() {
+      return {
+        interaction: { interactionId: 'interaction-1' },
+        plaintextToken: 'token-1',
+      }
+    },
+  } as CloudGateway
+  const manager = createGatewaySessionStreamManager(cloud, metrics, { retryDelayMs: 1 })
+
+  manager.ensure({
+    provider,
+    binding: {
+      bindingId: 'binding-1',
+      orgId: 'tenant-1',
+      agentId: 'agent-1',
+      channelBindingId: 'channel-binding-1',
+      provider: 'cli',
+      externalWorkspaceId: null,
+      externalThreadId: 'thread-1',
+      externalChatId: 'chat-1',
+      sessionId: 'session-1',
+      lastEventSequence: 0,
+      lastWorkspaceSequence: 0,
+      lastChatMessageId: null,
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+  })
+
+  onEvent?.({
+    eventId: 'event-1',
+    sequence: 1,
+    type: 'assistant.message',
+    payload: { content: 'already persisted' },
+  })
+  await waitFor(() => cursorUpdates.length === 1)
+
+  assert.deepEqual(provider.sent.map((entry) => entry.text), ['already persisted'])
+  assert.equal(metrics.cursorPersistenceFailures, 0)
+  assert.equal(metrics.streamReconnects, 0)
+
+  onEvent?.({
+    eventId: 'event-1-duplicate',
+    sequence: 1,
+    type: 'assistant.message',
+    payload: { content: 'duplicate' },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+
+  assert.deepEqual(provider.sent.map((entry) => entry.text), ['already persisted'])
+  manager.closeAll()
+})
+
 test('session stream manager reconnects without advancing when cursor persistence fails', async () => {
   const provider = new FakeChannelProvider()
   const metrics = createGatewayMetrics()
@@ -669,7 +674,7 @@ test('session stream manager reconnects without advancing when cursor persistenc
       return { close() {} }
     },
     async updateCursor() {
-      return null
+      return cursorNotFound()
     },
     async createChannelInteraction() {
       return {

--- a/apps/gateway/src/session-stream-manager.ts
+++ b/apps/gateway/src/session-stream-manager.ts
@@ -168,11 +168,11 @@ export function createGatewaySessionStreamManager(
         lastWorkspaceSequence: state.lastWorkspaceSequence,
         lastChatMessageId,
       })
-      state.lastEventSequence = updated?.lastEventSequence ?? event.sequence
-      state.lastWorkspaceSequence = updated?.lastWorkspaceSequence ?? state.lastWorkspaceSequence
-      state.lastChatMessageId = updated?.lastChatMessageId ?? lastChatMessageId
+      state.lastEventSequence = updated.lastEventSequence
+      state.lastWorkspaceSequence = updated.lastWorkspaceSequence
+      state.lastChatMessageId = updated.lastChatMessageId ?? lastChatMessageId
       state.renderFailures.delete(event.sequence)
-      if (updated) state.binding = updated
+      state.binding = updated
     } catch (error) {
       metrics.errors += 1
       const attempts = (state.renderFailures.get(event.sequence) ?? 0) + 1
@@ -203,11 +203,11 @@ export function createGatewaySessionStreamManager(
       lastWorkspaceSequence: state.lastWorkspaceSequence,
       lastChatMessageId: state.lastChatMessageId,
     })
-    state.lastEventSequence = updated?.lastEventSequence ?? event.sequence
-    state.lastWorkspaceSequence = updated?.lastWorkspaceSequence ?? state.lastWorkspaceSequence
-    state.lastChatMessageId = updated?.lastChatMessageId ?? state.lastChatMessageId
+    state.lastEventSequence = updated.lastEventSequence
+    state.lastWorkspaceSequence = updated.lastWorkspaceSequence
+    state.lastChatMessageId = updated.lastChatMessageId ?? state.lastChatMessageId
     state.renderFailures.delete(event.sequence)
-    if (updated) state.binding = updated
+    state.binding = updated
   }
 
   async function hydrateSnapshot(state: StreamState, event: CloudTransportSessionEvent) {
@@ -225,10 +225,10 @@ export function createGatewaySessionStreamManager(
       lastWorkspaceSequence: state.lastWorkspaceSequence,
       lastChatMessageId: state.lastChatMessageId,
     })
-    state.lastEventSequence = updated?.lastEventSequence ?? latestSequence
-    state.lastWorkspaceSequence = updated?.lastWorkspaceSequence ?? state.lastWorkspaceSequence
-    state.lastChatMessageId = updated?.lastChatMessageId ?? state.lastChatMessageId
-    if (updated) state.binding = updated
+    state.lastEventSequence = updated.lastEventSequence
+    state.lastWorkspaceSequence = updated.lastWorkspaceSequence
+    state.lastChatMessageId = updated.lastChatMessageId ?? state.lastChatMessageId
+    state.binding = updated
   }
 
   async function persistCursor(state: StreamState, input: {
@@ -237,12 +237,12 @@ export function createGatewaySessionStreamManager(
     lastWorkspaceSequence: number
     lastChatMessageId?: string | null
   }) {
-    const updated = await cloud.updateCursor(input)
-    if (!updated) {
+    const result = await cloud.updateCursor(input)
+    if (!result.ok && result.reason === 'not_found') {
       metrics.cursorPersistenceFailures += 1
       throw new Error(`Gateway cursor persistence failed for channel binding ${state.binding.bindingId}.`)
     }
-    return updated
+    return result.binding
   }
 
   return manager

--- a/packages/cloud-client/src/adapter.ts
+++ b/packages/cloud-client/src/adapter.ts
@@ -156,6 +156,8 @@ export type ChannelSessionBindingRecord = {
   updatedAt: string
 }
 
+export type ChannelCursorUpdateResult = { ok: true, binding: ChannelSessionBindingRecord } | { ok: false, reason: 'stale', binding: ChannelSessionBindingRecord } | { ok: false, reason: 'not_found' }
+
 export type ChannelInteractionRecord = {
   interactionId: string
   orgId: string
@@ -717,7 +719,7 @@ export type CloudTransportAdapter = {
     lastEventSequence: number
     lastWorkspaceSequence: number
     lastChatMessageId?: string | null
-  }): Promise<ChannelSessionBindingRecord | null>
+  }): Promise<ChannelCursorUpdateResult>
   createChannelInteraction?(input: {
     agentId: string
     sessionId: string
@@ -1863,10 +1865,19 @@ export function createHttpSseCloudTransportAdapter(
       })
     },
     async updateChannelCursor(input) {
-      return (await request<{ binding: ChannelSessionBindingRecord | null }>('/api/channels/cursor', {
-        method: 'POST',
-        body: input,
-      })).binding
+      try {
+        const response = await request<{ binding?: ChannelSessionBindingRecord | null, result?: ChannelCursorUpdateResult }>('/api/channels/cursor', {
+          method: 'POST',
+          body: input,
+        })
+        if (response.result) return response.result
+        return response.binding
+          ? { ok: true, binding: response.binding }
+          : { ok: false, reason: 'not_found' }
+      } catch (error) {
+        if (isCloudTransportError(error) && error.kind === 'not_found') return { ok: false, reason: 'not_found' }
+        throw error
+      }
     },
     createChannelInteraction(input) {
       return request('/api/channels/interactions', {

--- a/packages/cloud-client/src/domains/channels.ts
+++ b/packages/cloud-client/src/domains/channels.ts
@@ -1,6 +1,7 @@
 export type {
   ChannelActorInput,
   ChannelBindingRecord,
+  ChannelCursorUpdateResult,
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
   ChannelInteractionRecord,

--- a/packages/shared/src/cloud-session-projection.ts
+++ b/packages/shared/src/cloud-session-projection.ts
@@ -164,6 +164,17 @@ function asRecord(value: unknown): Record<string, unknown> {
     : {}
 }
 
+function cloneProjectionValue<T>(value: T): T {
+  if (Array.isArray(value)) return value.map((entry) => cloneProjectionValue(entry)) as T
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .map(([key, entry]) => [key, cloneProjectionValue(entry)]),
+    ) as T
+  }
+  return value
+}
+
 function readString(value: unknown, fallback = '') {
   return typeof value === 'string' && value.trim() ? value : fallback
 }
@@ -193,7 +204,7 @@ function toCloudSessionMessage(value: unknown): CloudSessionMessage | null {
     role,
     content: readString(record.content),
     createdAt: readString(record.createdAt, new Date().toISOString()),
-    ...(Array.isArray(record.attachments) ? { attachments: record.attachments as MessageAttachment[] } : {}),
+    ...(Array.isArray(record.attachments) ? { attachments: cloneProjectionValue(record.attachments as MessageAttachment[]) } : {}),
   }
 }
 
@@ -254,10 +265,10 @@ function normalizeToolCall(value: unknown): ToolCall | null {
   return {
     id,
     name: readString(record.name, 'tool'),
-    input: asRecord(record.input),
+    input: cloneProjectionValue(asRecord(record.input)),
     status: normalizeToolStatus(record.status),
-    ...(record.output !== undefined ? { output: record.output } : {}),
-    ...(Array.isArray(record.attachments) ? { attachments: record.attachments as ToolCall['attachments'] } : {}),
+    ...(record.output !== undefined ? { output: cloneProjectionValue(record.output) } : {}),
+    ...(Array.isArray(record.attachments) ? { attachments: cloneProjectionValue(record.attachments as ToolCall['attachments']) } : {}),
     agent: readNullableString(record.agent),
     sourceSessionId: readNullableString(record.sourceSessionId),
     order: readNumber(record.order),
@@ -276,12 +287,12 @@ function normalizeTaskRun(value: unknown): TaskRun | null {
     sourceSessionId: readNullableString(record.sourceSessionId),
     parentSessionId: readNullableString(record.parentSessionId),
     content: readString(record.content),
-    transcript: Array.isArray(record.transcript) ? record.transcript as TaskRun['transcript'] : [],
-    reasoning: Array.isArray(record.reasoning) ? record.reasoning as TaskRun['reasoning'] : undefined,
+    transcript: Array.isArray(record.transcript) ? cloneProjectionValue(record.transcript as TaskRun['transcript']) : [],
+    reasoning: Array.isArray(record.reasoning) ? cloneProjectionValue(record.reasoning as TaskRun['reasoning']) : undefined,
     toolCalls: Array.isArray(record.toolCalls)
       ? record.toolCalls.map(normalizeToolCall).filter((entry): entry is ToolCall => Boolean(entry))
       : [],
-    compactions: Array.isArray(record.compactions) ? record.compactions as TaskRun['compactions'] : [],
+    compactions: Array.isArray(record.compactions) ? cloneProjectionValue(record.compactions as TaskRun['compactions']) : [],
     todos: normalizeTodos(record.todos),
     error: readNullableString(record.error),
     sessionCost: readNumber(record.sessionCost),
@@ -347,7 +358,7 @@ function normalizePendingApproval(value: unknown): PendingApproval | null {
     sessionId,
     taskRunId: readNullableString(record.taskRunId),
     tool: readString(record.tool, 'permission'),
-    input: asRecord(record.input),
+    input: cloneProjectionValue(asRecord(record.input)),
     description: readString(record.description, 'Permission requested'),
     order: readNumber(record.order),
   }
@@ -382,7 +393,7 @@ function normalizeResolvedQuestion(value: unknown): CloudResolvedQuestion | null
     questions: Array.isArray(record.questions)
       ? record.questions.map(normalizeQuestionPrompt).filter((entry): entry is PendingQuestion['questions'][number] => Boolean(entry))
       : [],
-    answers: Array.isArray(record.answers) ? record.answers : [],
+    answers: Array.isArray(record.answers) ? cloneProjectionValue(record.answers) : [],
     rejected: record.rejected === true,
     order: readNumber(record.order),
     resolvedAt: readString(record.resolvedAt),
@@ -516,10 +527,10 @@ function toolCallFromPayload(
   return {
     id,
     name: readString(payload.name, readString(payload.tool, 'tool')),
-    input: asRecord(payload.input),
+    input: cloneProjectionValue(asRecord(payload.input)),
     status: normalizeToolStatus(payload.status),
-    ...(payload.output !== undefined ? { output: payload.output } : {}),
-    ...(Array.isArray(payload.attachments) ? { attachments: payload.attachments as ToolCall['attachments'] } : {}),
+    ...(payload.output !== undefined ? { output: cloneProjectionValue(payload.output) } : {}),
+    ...(Array.isArray(payload.attachments) ? { attachments: cloneProjectionValue(payload.attachments as ToolCall['attachments']) } : {}),
     agent: readNullableString(payload.agent),
     sourceSessionId: readNullableString(payload.sourceSessionId),
     order: event.sequence,
@@ -565,7 +576,7 @@ function pendingApprovalFromPayload(
     sessionId: session.sessionId,
     taskRunId: readNullableString(payload.taskRunId),
     tool: readString(payload.tool, 'permission'),
-    input: asRecord(payload.input),
+    input: cloneProjectionValue(asRecord(payload.input)),
     description: readString(payload.description, readString(payload.tool, 'Permission requested')),
     order: event.sequence,
   }
@@ -727,7 +738,7 @@ export function reduceCloudSessionProjectionEvent(
         role: 'user',
         content: readString(payload.text),
         createdAt: eventTime,
-        ...(Array.isArray(payload.attachments) ? { attachments: payload.attachments as MessageAttachment[] } : {}),
+        ...(Array.isArray(payload.attachments) ? { attachments: cloneProjectionValue(payload.attachments as MessageAttachment[]) } : {}),
       })
     case 'assistant.message':
       return addMessage({
@@ -741,7 +752,7 @@ export function reduceCloudSessionProjectionEvent(
         role: 'assistant',
         content: readString(payload.content),
         createdAt: eventTime,
-        ...(Array.isArray(payload.attachments) ? { attachments: payload.attachments as MessageAttachment[] } : {}),
+        ...(Array.isArray(payload.attachments) ? { attachments: cloneProjectionValue(payload.attachments as MessageAttachment[]) } : {}),
       })
     case 'tool.call': {
       const toolCall = toolCallFromPayload(session, payload, event)

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -1158,13 +1158,25 @@ test('cloud control plane stores headless channel bindings, interactions, cursor
     lastWorkspaceSequence: 3,
     lastChatMessageId: 'message-7',
   })
-  assert.equal(cursor?.lastEventSequence, 7)
-  assert.throws(() => store.updateChannelCursor({
+  assert.equal(cursor.ok, true)
+  if (!cursor.ok) assert.fail(`Expected cursor update to succeed, got ${cursor.reason}`)
+  assert.equal(cursor.binding.lastEventSequence, 7)
+  const staleCursor = store.updateChannelCursor({
     orgId: org.orgId,
     bindingId: sessionBinding.bindingId,
     lastEventSequence: 6,
     lastWorkspaceSequence: 3,
-  }), /monotonic/)
+  })
+  assert.equal(staleCursor.ok, false)
+  if (staleCursor.ok) assert.fail('Expected stale cursor update to be rejected.')
+  assert.equal(staleCursor.reason, 'stale')
+  assert.equal(staleCursor.binding.lastEventSequence, 7)
+  assert.deepEqual(store.updateChannelCursor({
+    orgId: org.orgId,
+    bindingId: 'missing-session-binding',
+    lastEventSequence: 1,
+    lastWorkspaceSequence: 1,
+  }), { ok: false, reason: 'not_found' })
 
   const issued = store.createChannelInteraction({
     interactionId: 'interaction-1',

--- a/tests/cloud-domain-services.test.ts
+++ b/tests/cloud-domain-services.test.ts
@@ -167,7 +167,7 @@ test('cloud domain services expose testable seams without an HTTP server', async
     async resolveChannelIdentity() { throw new Error('not needed') },
     async bindChannelSession() { throw new Error('not needed') },
     async getChannelSessionByThread() { return null },
-    async updateChannelCursor() { return null },
+    async updateChannelCursor() { return { ok: false, reason: 'not_found' } },
     async enqueueChannelPrompt() { throw new Error('not needed') },
     async createChannelInteraction() { throw new Error('not needed') },
     async resolveChannelInteraction() { throw new Error('not needed') },

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -817,18 +817,25 @@ test('real Postgres cloud store keeps channel identities, cursors, and delivery 
       externalThreadId: 'thread-1',
       sessionId: ids.sessionId,
     })
-    assert.equal((await store.updateChannelCursor({
+    const updatedCursor = await store.updateChannelCursor({
       orgId: org.orgId,
       bindingId: sessionBinding.bindingId,
       lastEventSequence: 10,
       lastWorkspaceSequence: 8,
-    }))?.lastEventSequence, 10)
-    assert.equal(await store.updateChannelCursor({
+    })
+    assert.equal(updatedCursor.ok, true)
+    if (!updatedCursor.ok) assert.fail(`Expected cursor update to succeed, got ${updatedCursor.reason}`)
+    assert.equal(updatedCursor.binding.lastEventSequence, 10)
+    const staleCursor = await store.updateChannelCursor({
       orgId: org.orgId,
       bindingId: sessionBinding.bindingId,
       lastEventSequence: 9,
       lastWorkspaceSequence: 8,
-    }), null)
+    })
+    assert.equal(staleCursor.ok, false)
+    if (staleCursor.ok) assert.fail('Expected stale cursor update to be rejected.')
+    assert.equal(staleCursor.reason, 'stale')
+    assert.equal(staleCursor.binding.lastEventSequence, 10)
 
     await store.createChannelDelivery({
       deliveryId: `${ids.tenantId}-delivery`,

--- a/tests/cloud-session-projection-contract.test.ts
+++ b/tests/cloud-session-projection-contract.test.ts
@@ -614,6 +614,89 @@ test('cloud projection normalization filters malformed cached fields', () => {
   assert.equal(normalized.updatedAt, session.updatedAt)
 })
 
+test('cloud projection normalization owns nested cached structures', () => {
+  const session = baseSession()
+  const messageAttachments = [{ mime: 'text/plain', url: 'https://example.test/a.txt', filename: 'before.txt' }]
+  const toolInput = { command: 'pwd', args: ['before'] }
+  const toolOutput = { chunks: [{ text: 'before' }] }
+  const toolAttachments = [{ mime: 'text/plain', url: 'https://example.test/tool.txt', filename: 'tool-before.txt' }]
+  const taskTranscript = [{ id: 'segment-1', content: 'before', order: 1 }]
+  const taskReasoning = [{ id: 'reasoning-1', content: 'before', order: 1 }]
+  const taskCompactions = [{ id: 'compaction-1', status: 'compacted', auto: true, overflow: false, order: 1 }]
+  const approvalInput = { command: 'rm', paths: ['before'] }
+  const questionAnswers = [{ value: { selected: ['before'] } }]
+  const raw = {
+    sessionId: 'session-1',
+    messages: [{
+      id: 'message-1',
+      role: 'assistant',
+      content: 'cached',
+      createdAt: '2026-05-28T10:00:00.000Z',
+      attachments: messageAttachments,
+    }],
+    toolCalls: [{
+      id: 'tool-1',
+      name: 'bash',
+      status: 'complete',
+      input: toolInput,
+      output: toolOutput,
+      attachments: toolAttachments,
+    }],
+    taskRuns: [{
+      id: 'task-1',
+      title: 'Task',
+      status: 'running',
+      transcript: taskTranscript,
+      reasoning: taskReasoning,
+      compactions: taskCompactions,
+    }],
+    pendingApprovals: [{
+      id: 'permission-1',
+      sessionId: 'session-1',
+      tool: 'bash',
+      input: approvalInput,
+      description: 'Approve',
+    }],
+    resolvedQuestions: [{
+      id: 'question-1',
+      sessionId: 'session-1',
+      questions: [{ question: 'Continue?' }],
+      answers: questionAnswers,
+      resolvedAt: '2026-05-28T10:00:00.000Z',
+    }],
+  }
+
+  const normalized = normalizeCloudSessionProjectionView(raw, session)
+
+  messageAttachments[0].filename = 'after.txt'
+  toolInput.args.push('after')
+  toolOutput.chunks[0].text = 'after'
+  toolAttachments[0].filename = 'tool-after.txt'
+  taskTranscript[0].content = 'after'
+  taskReasoning[0].content = 'after'
+  taskCompactions[0].overflow = true
+  approvalInput.paths.push('after')
+  questionAnswers[0].value.selected.push('after')
+
+  assert.deepEqual(normalized.messages[0]?.attachments, [{
+    mime: 'text/plain',
+    url: 'https://example.test/a.txt',
+    filename: 'before.txt',
+  }])
+  assert.deepEqual(normalized.toolCalls[0]?.input, { command: 'pwd', args: ['before'] })
+  assert.deepEqual(normalized.toolCalls[0]?.output, { chunks: [{ text: 'before' }] })
+  assert.deepEqual(normalized.toolCalls[0]?.attachments, [{
+    mime: 'text/plain',
+    url: 'https://example.test/tool.txt',
+    filename: 'tool-before.txt',
+  }])
+  assert.deepEqual(normalized.taskRuns[0]?.transcript, [{ id: 'segment-1', content: 'before', order: 1 }])
+  assert.deepEqual(normalized.taskRuns[0]?.reasoning, [{ id: 'reasoning-1', content: 'before', order: 1 }])
+  assert.deepEqual(normalized.taskRuns[0]?.compactions, [{ id: 'compaction-1', status: 'compacted', auto: true, overflow: false, order: 1 }])
+  assert.deepEqual(normalized.pendingApprovals[0]?.input, { command: 'rm', paths: ['before'] })
+  assert.deepEqual(normalized.resolvedQuestions[0]?.answers, [{ value: { selected: ['before'] } }])
+})
+
 test('cloud SessionView conversion handles empty and error-only projections', () => {
   const session = baseSession()
   assert.deepEqual(cloudSessionViewToSessionView({ session, projection: null }), emptySessionView())

--- a/tests/gateway-cloud-smoke.test.ts
+++ b/tests/gateway-cloud-smoke.test.ts
@@ -286,7 +286,9 @@ test('gateway daemon prompts an in-process cloud session through fake provider w
       lastWorkspaceSequence: 0,
       lastChatMessageId: 'chat-message-1',
     })
-    assert.equal(cursor?.lastChatMessageId, 'chat-message-1')
+    assert.equal(cursor.ok, true)
+    if (!cursor.ok) assert.fail(`Expected cursor update to succeed, got ${cursor.reason}`)
+    assert.equal(cursor.binding.lastChatMessageId, 'chat-message-1')
 
     await cloudGateway.respondToPermission(bound.session.session.sessionId, {
       permissionId: 'permission-wrapper',


### PR DESCRIPTION
## Summary
- add an explicit channel cursor update result across in-memory/Postgres stores, cloud services, HTTP, cloud-client, and gateway consumers
- treat stale cursor writes as already persisted in the gateway while preserving not_found as a persistence failure
- defensively clone nested cloud projection structures during normalization and event reduction
- keep cloud facade/client modularity budgets green while extending the channel domain contract

Closes #675
Closes #676
Closes #682
Closes #683

## Validation
- node scripts/run-node-tests.mjs tests/cloud-session-projection-contract.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-postgres-concurrency.test.ts apps/gateway/src/session-stream-manager.test.ts apps/gateway/src/cloud-gateway.test.ts apps/gateway/src/daemon.test.ts tests/cloud-domain-services.test.ts tests/gateway-cloud-smoke.test.ts tests/cloud-control-plane-modularity.test.ts tests/cloud-modularity-boundaries.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:e2e
- git diff --check