### PR TITLE
Harden config workflow and spec boundaries

### DIFF
--- a/apps/desktop/src/lib/vega-spec.ts
+++ b/apps/desktop/src/lib/vega-spec.ts
@@ -22,6 +22,17 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>
 }
 
+function cloneSpecValue<T>(value: T): T {
+  if (!value || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map((entry) => cloneSpecValue(entry)) as T
+
+  const output: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    output[key] = cloneSpecValue(entry)
+  }
+  return output as T
+}
+
 const TEMPORAL_POSITION_CHANNELS = ['x', 'y'] as const
 const HUMAN_DATE_WORD_PATTERN = /\b(?:sun|sunday|mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\b/i
 const ISO_DATE_OR_DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2}(?:[Tt\s]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/
@@ -251,9 +262,11 @@ export function makeInteractiveVegaSpecResponsive(spec: Record<string, unknown>)
     return normalizedSpec
   }
 
+  const sourceEncoding = asRecord(normalizedSpec.encoding)
   const responsiveSpec: Record<string, unknown> = {
     ...normalizedSpec,
     width: 'container',
+    ...(sourceEncoding ? { encoding: cloneSpecValue(sourceEncoding) } : {}),
     autosize: {
       ...(typeof normalizedSpec.autosize === 'object' && normalizedSpec.autosize ? normalizedSpec.autosize : {}),
       type: 'fit-x',

--- a/apps/desktop/src/main/config-loader.ts
+++ b/apps/desktop/src/main/config-loader.ts
@@ -2,8 +2,7 @@ import electron from 'electron'
 import { cpSync, existsSync, mkdirSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join, resolve } from 'path'
-import type { ProviderModelDescriptor, PublicAppConfig, PublicBrandingConfig } from '@open-cowork/shared'
-import { normalizeCloudProjectSource } from '@open-cowork/shared'
+import type { ProviderModelDescriptor, PublicAppConfig } from '@open-cowork/shared'
 import {
   buildConfiguredModelFallbacks,
   buildProviderDescriptors,
@@ -15,6 +14,7 @@ import {
 import { validateConfigLayerInput, validateResolvedConfig } from './config-schema.ts'
 import { jsonConfigCandidates, readJsoncFile } from './jsonc.ts'
 import { DEFAULT_CONFIG } from './config-types.ts'
+import { normalizeAppConfig, normalizeConfigLayers } from './config-normalizer.ts'
 import {
   deepMerge,
   formatConfigError,
@@ -22,11 +22,6 @@ import {
   validateConfigSemantics,
 } from './config-layer-utils.ts'
 import type {
-  CloudConfig,
-  CloudDesktopConfig,
-  CloudFeatureConfig,
-  CloudProfileConfig,
-  CloudRole,
   ConfiguredTool,
   ModelFallbackInfo,
   OpenCoworkConfig,
@@ -59,14 +54,6 @@ export { normalizeProviderModelId } from './config-public.ts'
 export { resolveConfigEnvPlaceholders } from './config-layer-utils.ts'
 
 const electronApp = (electron as { app?: typeof import('electron').app }).app
-const CLOUD_ROLES = new Set<CloudRole>(['all-in-one', 'web', 'worker', 'scheduler'])
-const CLOUD_AUTH_MODES = new Set(['none', 'header', 'oidc'])
-const CLOUD_CONTROL_PLANE_KINDS = new Set(['local', 'postgres'])
-const CLOUD_OBJECT_STORE_KINDS = new Set(['filesystem', 's3', 'gcs', 'azure-blob', 'digitalocean-spaces', 'minio'])
-const PUBLIC_BRANDING_URL_KEYS = new Set(['logoUrl', 'supportUrl', 'privacyUrl', 'securityUrl', 'legalUrl'])
-const GATEWAY_MODES = new Set(['self-host', 'managed'])
-const GATEWAY_LOG_LEVELS = new Set(['debug', 'info', 'warn', 'error', 'silent'])
-const GATEWAY_PROVIDER_KINDS = new Set(['fake', 'telegram', 'slack', 'email', 'webhook', 'discord', 'whatsapp', 'signal', 'cli'])
 
 let configCache: OpenCoworkConfig | null = null
 let publicConfigCache: PublicAppConfig | null = null
@@ -119,15 +106,15 @@ function getBaseConfigForPathResolution() {
   let merged = DEFAULT_CONFIG
   const bundledPath = firstExistingConfigPath(getBundledConfigCandidates())
   if (bundledPath) {
-    merged = normalizeConfig(deepMerge(merged, readConfigFile(bundledPath, 'bundled config')))
+    merged = normalizeAppConfig(deepMerge(merged, readConfigFile(bundledPath, 'bundled config')))
   }
   const overridePath = firstExistingConfigPath(getOverrideConfigCandidates())
   if (overridePath) {
-    merged = normalizeConfig(deepMerge(merged, readConfigFile(overridePath, 'override config')))
+    merged = normalizeAppConfig(deepMerge(merged, readConfigFile(overridePath, 'override config')))
   }
   const customDirPath = firstExistingConfigPath(getCustomDirConfigCandidates())
   if (customDirPath) {
-    merged = normalizeConfig(deepMerge(merged, readConfigFile(customDirPath, 'config directory')))
+    merged = normalizeAppConfig(deepMerge(merged, readConfigFile(customDirPath, 'config directory')))
   }
   return merged
 }
@@ -209,504 +196,6 @@ function readConfigFile(path: string, source: string): Partial<OpenCoworkConfig>
   }
 }
 
-function stringArray(value: unknown, fallback: string[] = []) {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
-    : fallback
-}
-
-function normalizeCloudFeatures(raw: Partial<CloudFeatureConfig> | undefined): CloudFeatureConfig {
-  return {
-    ...DEFAULT_CONFIG.cloud.features,
-    ...(raw || {}),
-  }
-}
-
-function safePublicBrandingUrl(value: unknown, allowMailto = false) {
-  const text = typeof value === 'string' ? value.trim() : ''
-  if (!text) return ''
-  try {
-    const url = new URL(text)
-    if (url.protocol === 'https:') return url.toString()
-    if (allowMailto && url.protocol === 'mailto:') return url.toString()
-  } catch {
-    return ''
-  }
-  return ''
-}
-
-function cleanPublicBrandingStrings(value: unknown) {
-  const output: Record<string, string> = {}
-  if (!value || typeof value !== 'object') return output
-  for (const [key, entry] of Object.entries(value)) {
-    if (typeof entry !== 'string') continue
-    const text = entry.trim()
-    if (!text) continue
-    output[key] = text
-  }
-  return output
-}
-
-function normalizePublicBranding(raw: Partial<PublicBrandingConfig> | undefined): PublicBrandingConfig {
-  const defaults = DEFAULT_CONFIG.cloud.publicBranding
-  const source = raw || {}
-  const base: PublicBrandingConfig = {
-    ...defaults,
-    ...source,
-    productName: typeof source.productName === 'string' && source.productName.trim()
-      ? source.productName.trim()
-      : defaults.productName,
-    shortName: typeof source.shortName === 'string' && source.shortName.trim()
-      ? source.shortName.trim()
-      : defaults.shortName,
-    logoUrl: safePublicBrandingUrl(source.logoUrl),
-    supportUrl: safePublicBrandingUrl(source.supportUrl, true),
-    privacyUrl: safePublicBrandingUrl(source.privacyUrl),
-    securityUrl: safePublicBrandingUrl(source.securityUrl),
-    legalUrl: safePublicBrandingUrl(source.legalUrl),
-    theme: {
-      ...(defaults.theme || {}),
-      ...cleanPublicBrandingStrings(source.theme),
-    },
-    dashboard: {
-      ...(defaults.dashboard || {}),
-      ...cleanPublicBrandingStrings(source.dashboard),
-    },
-    managedOrgConnectionLabels: {
-      ...(defaults.managedOrgConnectionLabels || {}),
-      ...cleanPublicBrandingStrings(source.managedOrgConnectionLabels),
-    },
-  }
-  for (const key of PUBLIC_BRANDING_URL_KEYS) {
-    if (!base[key as keyof PublicBrandingConfig]) delete base[key as keyof PublicBrandingConfig]
-  }
-  return base
-}
-
-function normalizeCloudProjectSources(raw: CloudConfig['projectSources'] | undefined): CloudConfig['projectSources'] {
-  const defaults = DEFAULT_CONFIG.cloud.projectSources
-  const source = raw || defaults
-  return {
-    git: {
-      ...defaults.git,
-      ...(source.git || {}),
-      enabled: typeof source.git?.enabled === 'boolean' ? source.git.enabled : defaults.git.enabled,
-      allowedHosts: stringArray(source.git?.allowedHosts, defaults.git.allowedHosts),
-      allowedRepositories: stringArray(source.git?.allowedRepositories, defaults.git.allowedRepositories),
-      allowFileUrls: typeof source.git?.allowFileUrls === 'boolean' ? source.git.allowFileUrls : defaults.git.allowFileUrls,
-    },
-    uploadedSnapshots: {
-      ...defaults.uploadedSnapshots,
-      ...(source.uploadedSnapshots || {}),
-      enabled: typeof source.uploadedSnapshots?.enabled === 'boolean'
-        ? source.uploadedSnapshots.enabled
-        : defaults.uploadedSnapshots.enabled,
-      maxFiles: nullablePositiveNumber(source.uploadedSnapshots?.maxFiles, defaults.uploadedSnapshots.maxFiles)
-        || defaults.uploadedSnapshots.maxFiles,
-      maxBytes: nullablePositiveNumber(source.uploadedSnapshots?.maxBytes, defaults.uploadedSnapshots.maxBytes)
-        || defaults.uploadedSnapshots.maxBytes,
-    },
-    managedWorkspaces: {
-      ...defaults.managedWorkspaces,
-      ...(source.managedWorkspaces || {}),
-      enabled: typeof source.managedWorkspaces?.enabled === 'boolean'
-        ? source.managedWorkspaces.enabled
-        : defaults.managedWorkspaces.enabled,
-    },
-  }
-}
-
-function nullablePositiveNumber(value: unknown, fallback: number | null): number | null {
-  if (value === null) return null
-  const parsed = Number(value ?? fallback)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
-}
-
-function normalizeCloudAbuseConfig(raw: CloudConfig['abuse'] | undefined): CloudConfig['abuse'] {
-  const defaults = DEFAULT_CONFIG.cloud.abuse
-  return {
-    ...defaults,
-    ...(raw || {}),
-    enabled: typeof raw?.enabled === 'boolean' ? raw.enabled : defaults.enabled,
-    maxConcurrentSessionsPerOrg: nullablePositiveNumber(raw?.maxConcurrentSessionsPerOrg, defaults.maxConcurrentSessionsPerOrg),
-    maxConcurrentWorkflowRunsPerOrg: nullablePositiveNumber(raw?.maxConcurrentWorkflowRunsPerOrg, defaults.maxConcurrentWorkflowRunsPerOrg),
-    maxActiveWorkersPerOrg: nullablePositiveNumber(raw?.maxActiveWorkersPerOrg, defaults.maxActiveWorkersPerOrg),
-    maxQueuedCommandsPerOrg: nullablePositiveNumber(raw?.maxQueuedCommandsPerOrg, defaults.maxQueuedCommandsPerOrg),
-    maxQueueAgeMs: nullablePositiveNumber(raw?.maxQueueAgeMs, defaults.maxQueueAgeMs),
-    maxPromptsPerHour: nullablePositiveNumber(raw?.maxPromptsPerHour, defaults.maxPromptsPerHour),
-    maxWorkflowRunsPerHour: nullablePositiveNumber(raw?.maxWorkflowRunsPerHour, defaults.maxWorkflowRunsPerHour),
-    maxGatewayPromptsPerHour: nullablePositiveNumber(raw?.maxGatewayPromptsPerHour, defaults.maxGatewayPromptsPerHour),
-    maxWorkerMinutesPerHour: nullablePositiveNumber(raw?.maxWorkerMinutesPerHour, defaults.maxWorkerMinutesPerHour),
-    maxGatewayDeliveriesPerHour: nullablePositiveNumber(raw?.maxGatewayDeliveriesPerHour, defaults.maxGatewayDeliveriesPerHour),
-    maxGatewayChannelBindingsPerOrg: nullablePositiveNumber(raw?.maxGatewayChannelBindingsPerOrg, defaults.maxGatewayChannelBindingsPerOrg),
-    maxArtifactBytesPerDay: nullablePositiveNumber(raw?.maxArtifactBytesPerDay, defaults.maxArtifactBytesPerDay),
-    httpRateLimit: {
-      ...defaults.httpRateLimit,
-      ...(raw?.httpRateLimit || {}),
-      enabled: typeof raw?.httpRateLimit?.enabled === 'boolean'
-        ? raw.httpRateLimit.enabled
-        : defaults.httpRateLimit.enabled,
-      windowMs: nullablePositiveNumber(raw?.httpRateLimit?.windowMs, defaults.httpRateLimit.windowMs) || defaults.httpRateLimit.windowMs,
-      maxRequests: nullablePositiveNumber(raw?.httpRateLimit?.maxRequests, defaults.httpRateLimit.maxRequests) || defaults.httpRateLimit.maxRequests,
-    },
-    authBackoff: {
-      ...defaults.authBackoff,
-      ...(raw?.authBackoff || {}),
-      enabled: typeof raw?.authBackoff?.enabled === 'boolean'
-        ? raw.authBackoff.enabled
-        : defaults.authBackoff.enabled,
-      windowMs: nullablePositiveNumber(raw?.authBackoff?.windowMs, defaults.authBackoff.windowMs) || defaults.authBackoff.windowMs,
-      maxFailures: nullablePositiveNumber(raw?.authBackoff?.maxFailures, defaults.authBackoff.maxFailures) || defaults.authBackoff.maxFailures,
-      backoffMs: nullablePositiveNumber(raw?.authBackoff?.backoffMs, defaults.authBackoff.backoffMs) || defaults.authBackoff.backoffMs,
-    },
-  }
-}
-
-function normalizeBillingEntitlements(raw: CloudConfig['billing']['plans'][string]['entitlements'] | undefined): CloudConfig['billing']['plans'][string]['entitlements'] {
-  if (!raw) return undefined
-  return {
-    ...raw,
-    allowedProfiles: raw.allowedProfiles === null ? null : stringArray(raw.allowedProfiles),
-    allowedProviders: raw.allowedProviders === null ? null : stringArray(raw.allowedProviders),
-    maxConcurrentSessionsPerOrg: nullablePositiveNumber(raw.maxConcurrentSessionsPerOrg, null),
-    maxConcurrentWorkflowRunsPerOrg: nullablePositiveNumber(raw.maxConcurrentWorkflowRunsPerOrg, null),
-    maxActiveWorkersPerOrg: nullablePositiveNumber(raw.maxActiveWorkersPerOrg, null),
-    maxQueuedCommandsPerOrg: nullablePositiveNumber(raw.maxQueuedCommandsPerOrg, null),
-    maxQueueAgeMs: nullablePositiveNumber(raw.maxQueueAgeMs, null),
-    maxPromptsPerHour: nullablePositiveNumber(raw.maxPromptsPerHour, null),
-    maxWorkflowRunsPerHour: nullablePositiveNumber(raw.maxWorkflowRunsPerHour, null),
-    maxGatewayPromptsPerHour: nullablePositiveNumber(raw.maxGatewayPromptsPerHour, null),
-    maxWorkerMinutesPerHour: nullablePositiveNumber(raw.maxWorkerMinutesPerHour, null),
-    maxGatewayDeliveriesPerHour: nullablePositiveNumber(raw.maxGatewayDeliveriesPerHour, null),
-    maxGatewayChannelBindingsPerOrg: nullablePositiveNumber(raw.maxGatewayChannelBindingsPerOrg, null),
-    maxArtifactBytesPerDay: nullablePositiveNumber(raw.maxArtifactBytesPerDay, null),
-  }
-}
-
-function normalizeCloudBillingConfig(raw: CloudConfig['billing'] | undefined): CloudConfig['billing'] {
-  const defaults = DEFAULT_CONFIG.cloud.billing
-  const source = raw || defaults
-  const providers = new Set(['none', 'stub', 'stripe'])
-  const plans: CloudConfig['billing']['plans'] = {}
-  for (const [planKey, plan] of Object.entries(defaults.plans)) {
-    plans[planKey] = {
-      ...plan,
-      entitlements: normalizeBillingEntitlements(plan.entitlements),
-    }
-  }
-  for (const [planKey, plan] of Object.entries(source.plans || {})) {
-    if (!planKey.trim()) continue
-    plans[planKey] = {
-      ...(plans[planKey] || {}),
-      ...plan,
-      entitlements: normalizeBillingEntitlements({
-        ...(plans[planKey]?.entitlements || {}),
-        ...(plan.entitlements || {}),
-      }),
-    }
-  }
-  const defaultPlanKey = source.defaultPlanKey && plans[source.defaultPlanKey]
-    ? source.defaultPlanKey
-    : defaults.defaultPlanKey
-  return {
-    ...defaults,
-    ...source,
-    enabled: typeof source.enabled === 'boolean' ? source.enabled : defaults.enabled,
-    provider: providers.has(source.provider) ? source.provider : defaults.provider,
-    defaultPlanKey,
-    plans,
-    stripe: {
-      ...(defaults.stripe || {}),
-      ...(source.stripe || {}),
-    },
-  }
-}
-
-function normalizeCloudProfile(raw: CloudProfileConfig | undefined): CloudProfileConfig {
-  const defaultProjectSource = Object.prototype.hasOwnProperty.call(raw || {}, 'defaultProjectSource')
-    ? normalizeCloudProjectSource(raw?.defaultProjectSource)
-    : undefined
-  return {
-    ...(raw || {}),
-    agents: stringArray(raw?.agents),
-    tools: stringArray(raw?.tools),
-    mcps: stringArray(raw?.mcps),
-    features: raw?.features ? normalizeCloudFeatures(raw.features) : undefined,
-    ...(defaultProjectSource !== undefined ? { defaultProjectSource } : {}),
-    runtime: raw?.runtime
-      ? {
-          ...raw.runtime,
-          configSource: 'app',
-          launcher: 'node',
-          allowedLocalMcpNames: stringArray(raw.runtime.allowedLocalMcpNames),
-          allowedHostProjectDirectories: stringArray(raw.runtime.allowedHostProjectDirectories),
-        }
-      : undefined,
-  }
-}
-
-function normalizeCloudConfig(raw: CloudConfig | undefined): CloudConfig {
-  const source = raw || DEFAULT_CONFIG.cloud
-  const profiles: Record<string, CloudProfileConfig> = {}
-  for (const [name, profile] of Object.entries(DEFAULT_CONFIG.cloud.profiles)) {
-    profiles[name] = normalizeCloudProfile(profile)
-  }
-  for (const [name, profile] of Object.entries(source.profiles || {})) {
-    if (!name.trim()) continue
-    profiles[name] = normalizeCloudProfile({
-      ...(profiles[name] || {}),
-      ...profile,
-      features: {
-        ...(profiles[name]?.features || {}),
-        ...(profile.features || {}),
-      },
-      runtime: {
-        ...(profiles[name]?.runtime || {}),
-        ...(profile.runtime || {}),
-      },
-    })
-  }
-
-  const role = CLOUD_ROLES.has(source.role) ? source.role : DEFAULT_CONFIG.cloud.role
-  const defaultProfile = source.defaultProfile && profiles[source.defaultProfile]
-    ? source.defaultProfile
-    : DEFAULT_CONFIG.cloud.defaultProfile
-
-  return {
-    ...DEFAULT_CONFIG.cloud,
-    ...source,
-    role,
-    defaultProfile,
-    profiles,
-    publicBranding: normalizePublicBranding(source.publicBranding),
-    auth: {
-      ...DEFAULT_CONFIG.cloud.auth,
-      ...(source.auth || {}),
-      mode: CLOUD_AUTH_MODES.has(source.auth?.mode || '')
-        ? source.auth.mode
-        : DEFAULT_CONFIG.cloud.auth.mode,
-      signupMode: source.auth?.signupMode
-        ? source.auth.signupMode
-        : source.auth?.mode === 'oidc'
-          ? 'invite'
-          : DEFAULT_CONFIG.cloud.auth.signupMode,
-      headerSecret: typeof source.auth?.headerSecret === 'string' && source.auth.headerSecret.trim()
-        ? source.auth.headerSecret.trim()
-        : undefined,
-      headerSecretRef: typeof source.auth?.headerSecretRef === 'string' && source.auth.headerSecretRef.trim()
-        ? source.auth.headerSecretRef.trim()
-        : undefined,
-      headerAllowUnsigned: typeof source.auth?.headerAllowUnsigned === 'boolean'
-        ? source.auth.headerAllowUnsigned
-        : false,
-      headerMaxSignatureAgeMs: nullablePositiveNumber(source.auth?.headerMaxSignatureAgeMs, 5 * 60 * 1000) || 5 * 60 * 1000,
-      allowedEmailDomains: stringArray(source.auth?.allowedEmailDomains),
-      allowSelfServiceSignup: typeof source.auth?.allowSelfServiceSignup === 'boolean'
-        ? source.auth.allowSelfServiceSignup
-        : source.auth?.mode === 'oidc'
-          ? false
-          : DEFAULT_CONFIG.cloud.auth.allowSelfServiceSignup,
-      apiTokens: {
-        ...DEFAULT_CONFIG.cloud.auth.apiTokens,
-        ...(source.auth?.apiTokens || {}),
-        defaultTtlMs: nullablePositiveNumber(
-          source.auth?.apiTokens?.defaultTtlMs,
-          DEFAULT_CONFIG.cloud.auth.apiTokens?.defaultTtlMs || 90 * 24 * 60 * 60 * 1000,
-        ) || DEFAULT_CONFIG.cloud.auth.apiTokens?.defaultTtlMs,
-        maxTtlMs: nullablePositiveNumber(
-          source.auth?.apiTokens?.maxTtlMs,
-          DEFAULT_CONFIG.cloud.auth.apiTokens?.maxTtlMs || 365 * 24 * 60 * 60 * 1000,
-        ) || DEFAULT_CONFIG.cloud.auth.apiTokens?.maxTtlMs,
-        allowedScopes: stringArray(source.auth?.apiTokens?.allowedScopes).length > 0
-          ? stringArray(source.auth?.apiTokens?.allowedScopes)
-          : DEFAULT_CONFIG.cloud.auth.apiTokens?.allowedScopes,
-      },
-    },
-    storage: {
-      controlPlane: {
-        ...DEFAULT_CONFIG.cloud.storage.controlPlane,
-        ...(source.storage?.controlPlane || {}),
-        kind: CLOUD_CONTROL_PLANE_KINDS.has(source.storage?.controlPlane?.kind || '')
-          ? source.storage!.controlPlane.kind
-          : DEFAULT_CONFIG.cloud.storage.controlPlane.kind,
-      },
-      objectStore: {
-        ...DEFAULT_CONFIG.cloud.storage.objectStore,
-        ...(source.storage?.objectStore || {}),
-        kind: CLOUD_OBJECT_STORE_KINDS.has(source.storage?.objectStore?.kind || '')
-          ? source.storage!.objectStore.kind
-          : DEFAULT_CONFIG.cloud.storage.objectStore.kind,
-      },
-    },
-    runtime: {
-      ...DEFAULT_CONFIG.cloud.runtime,
-      ...(source.runtime || {}),
-      configSource: 'app',
-      launcher: 'node',
-      allowedLocalMcpNames: stringArray(source.runtime?.allowedLocalMcpNames),
-      allowedHostProjectDirectories: stringArray(source.runtime?.allowedHostProjectDirectories),
-    },
-    projectSources: normalizeCloudProjectSources(source.projectSources),
-    features: normalizeCloudFeatures(source.features),
-    abuse: normalizeCloudAbuseConfig(source.abuse),
-    billing: normalizeCloudBillingConfig(source.billing),
-  }
-}
-
-function normalizeCloudDesktopConfig(raw: CloudDesktopConfig | undefined): CloudDesktopConfig {
-  const source = raw || DEFAULT_CONFIG.cloudDesktop
-  const cacheModes = new Set(['full', 'metadata-only', 'disabled'])
-  const fallbackModes = new Set(['metadata-only', 'disabled', 'fail-startup'])
-  return {
-    ...DEFAULT_CONFIG.cloudDesktop,
-    ...source,
-    enabled: typeof source.enabled === 'boolean' ? source.enabled : DEFAULT_CONFIG.cloudDesktop.enabled,
-    allowUserAddedConnections: typeof source.allowUserAddedConnections === 'boolean'
-      ? source.allowUserAddedConnections
-      : DEFAULT_CONFIG.cloudDesktop.allowUserAddedConnections,
-    preconfiguredConnections: Array.isArray(source.preconfiguredConnections)
-      ? source.preconfiguredConnections
-        .filter((connection) => connection && typeof connection.baseUrl === 'string' && connection.baseUrl.trim())
-        .map((connection) => ({
-          baseUrl: connection.baseUrl.trim(),
-          ...(typeof connection.label === 'string' && connection.label.trim() ? { label: connection.label.trim() } : {}),
-        }))
-      : DEFAULT_CONFIG.cloudDesktop.preconfiguredConnections,
-    requireManagedOrg: typeof source.requireManagedOrg === 'boolean'
-      ? source.requireManagedOrg
-      : DEFAULT_CONFIG.cloudDesktop.requireManagedOrg,
-    cacheMode: cacheModes.has(source.cacheMode) ? source.cacheMode : DEFAULT_CONFIG.cloudDesktop.cacheMode,
-    cacheEncryptionFallback: fallbackModes.has(source.cacheEncryptionFallback)
-      ? source.cacheEncryptionFallback
-      : DEFAULT_CONFIG.cloudDesktop.cacheEncryptionFallback,
-  }
-}
-
-function normalizeGatewayConfig(raw: OpenCoworkConfig['gateway'] | undefined): OpenCoworkConfig['gateway'] {
-  const defaults = DEFAULT_CONFIG.gateway
-  const source = raw || defaults
-  const mode = GATEWAY_MODES.has(source.mode || '') ? source.mode : defaults.mode
-  const logLevel = GATEWAY_LOG_LEVELS.has(source.logging?.level || '') ? source.logging?.level : defaults.logging?.level
-  return {
-    ...defaults,
-    ...source,
-    branding: normalizePublicBranding(source.branding),
-    cloud: {
-      ...(defaults.cloud || {}),
-      ...(source.cloud || {}),
-      allowInsecureHttp: typeof source.cloud?.allowInsecureHttp === 'boolean'
-        ? source.cloud.allowInsecureHttp
-        : defaults.cloud?.allowInsecureHttp,
-    },
-    server: {
-      ...(defaults.server || {}),
-      ...(source.server || {}),
-      port: Number.isInteger(source.server?.port) && source.server!.port! >= 0 && source.server!.port! <= 65535
-        ? source.server!.port
-        : defaults.server?.port,
-    },
-    mode,
-    logging: {
-      ...(defaults.logging || {}),
-      ...(source.logging || {}),
-      level: logLevel,
-    },
-    metrics: {
-      ...(defaults.metrics || {}),
-      ...(source.metrics || {}),
-      enabled: typeof source.metrics?.enabled === 'boolean' ? source.metrics.enabled : defaults.metrics?.enabled,
-    },
-    diagnostics: {
-      ...(defaults.diagnostics || {}),
-      ...(source.diagnostics || {}),
-      enabled: typeof source.diagnostics?.enabled === 'boolean'
-        ? source.diagnostics.enabled
-        : defaults.diagnostics?.enabled,
-    },
-    providers: Array.isArray(source.providers)
-      ? source.providers
-        .filter((provider) => provider && GATEWAY_PROVIDER_KINDS.has(provider.kind))
-        .map((provider) => ({
-          ...provider,
-          id: typeof provider.id === 'string' && provider.id.trim() ? provider.id.trim() : undefined,
-          channelBindingId: typeof provider.channelBindingId === 'string' ? provider.channelBindingId.trim() : '',
-          externalWorkspaceId: typeof provider.externalWorkspaceId === 'string' && provider.externalWorkspaceId.trim()
-            ? provider.externalWorkspaceId.trim()
-            : null,
-          defaultAgent: typeof provider.defaultAgent === 'string' && provider.defaultAgent.trim()
-            ? provider.defaultAgent.trim()
-            : null,
-          credentials: provider.credentials && typeof provider.credentials === 'object' ? { ...provider.credentials } : {},
-          settings: provider.settings && typeof provider.settings === 'object' ? { ...provider.settings } : {},
-        }))
-      : defaults.providers,
-  }
-}
-
-function normalizeConfig(raw: OpenCoworkConfig): OpenCoworkConfig {
-  return {
-    ...raw,
-    allowedEnvPlaceholders: Array.isArray(raw.allowedEnvPlaceholders)
-      ? raw.allowedEnvPlaceholders.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
-      : DEFAULT_CONFIG.allowedEnvPlaceholders,
-    branding: {
-      ...DEFAULT_CONFIG.branding,
-      ...(raw.branding || {}),
-    },
-    auth: {
-      ...(raw.auth || {}),
-      mode: raw.auth?.mode === 'google-oauth' ? 'google-oauth' : 'none',
-    },
-    providers: {
-      ...DEFAULT_CONFIG.providers,
-      ...(raw.providers || {}),
-      available: Array.isArray(raw.providers?.available) && raw.providers?.available.length > 0
-        ? raw.providers.available
-        : DEFAULT_CONFIG.providers.available,
-      descriptors: raw.providers?.descriptors || DEFAULT_CONFIG.providers.descriptors,
-      modelInfo: raw.providers?.modelInfo || DEFAULT_CONFIG.providers.modelInfo,
-      custom: raw.providers?.custom || {},
-    },
-    updates: {
-      ...DEFAULT_CONFIG.updates,
-      ...(raw.updates || {}),
-      ...(raw.updates?.releaseSource ? { releaseSource: { ...raw.updates.releaseSource } } : {}),
-    },
-    tools: Array.isArray(raw.tools) ? raw.tools : [],
-    skills: Array.isArray(raw.skills) ? raw.skills : [],
-    mcps: Array.isArray(raw.mcps) ? raw.mcps : [],
-    agents: Array.isArray(raw.agents) ? raw.agents : [],
-    capabilityBundles: Array.isArray(raw.capabilityBundles) ? raw.capabilityBundles : [],
-    permissions: {
-      ...DEFAULT_CONFIG.permissions,
-      ...(raw.permissions || {}),
-      webSearch: typeof raw.permissions?.webSearch === 'boolean'
-        ? raw.permissions.webSearch
-        : DEFAULT_CONFIG.permissions.webSearch,
-    },
-    builtInAgents: raw.builtInAgents && typeof raw.builtInAgents === 'object'
-      ? { ...raw.builtInAgents }
-      : undefined,
-    agentStarterTemplates: Array.isArray(raw.agentStarterTemplates) ? raw.agentStarterTemplates : undefined,
-    toolTrace: {
-      rules: Array.isArray(raw.toolTrace?.rules)
-        ? raw.toolTrace.rules
-        : DEFAULT_CONFIG.toolTrace?.rules || [],
-      additionalRules: Array.isArray(raw.toolTrace?.additionalRules)
-        ? raw.toolTrace.additionalRules
-        : [],
-    },
-    compaction: {
-      ...DEFAULT_CONFIG.compaction,
-      ...(raw.compaction || {}),
-      ...(raw.compaction?.agent ? { agent: { ...raw.compaction.agent } } : {}),
-    },
-    cloud: normalizeCloudConfig(raw.cloud),
-    cloudDesktop: normalizeCloudDesktopConfig(raw.cloudDesktop),
-    gateway: normalizeGatewayConfig(raw.gateway),
-  }
-}
-
 export function getAppConfig(): OpenCoworkConfig {
   if (configCache) return configCache
   try {
@@ -719,16 +208,13 @@ export function getAppConfig(): OpenCoworkConfig {
       firstExistingConfigPath(getManagedConfigCandidates(baseForPaths.branding.dataDirName)),
     ])
 
-    const merged = layerPaths.reduce(
-      (current, path) => normalizeConfig(deepMerge(current, readConfigFile(path, path))),
-      DEFAULT_CONFIG,
-    )
+    const merged = normalizeConfigLayers(layerPaths.map((path) => readConfigFile(path, path)))
     validateResolvedConfig(merged, 'resolved config')
     validateConfigSemantics(merged, 'resolved config')
     configCache = merged
     configErrorCache = null
   } catch (err) {
-    configCache = normalizeConfig(DEFAULT_CONFIG)
+    configCache = normalizeAppConfig(DEFAULT_CONFIG)
     configErrorCache = err instanceof Error
       ? err.message
       : 'Invalid app config'

--- a/apps/desktop/src/main/config-normalizer.ts
+++ b/apps/desktop/src/main/config-normalizer.ts
@@ -1,0 +1,529 @@
+import type { PublicBrandingConfig } from '@open-cowork/shared'
+import { normalizeCloudProjectSource } from '@open-cowork/shared'
+import { deepMerge } from './config-layer-utils.ts'
+import { DEFAULT_CONFIG } from './config-types.ts'
+import type {
+  CloudConfig,
+  CloudDesktopConfig,
+  CloudFeatureConfig,
+  CloudProfileConfig,
+  CloudRole,
+  OpenCoworkConfig,
+} from './config-types.ts'
+
+const CLOUD_ROLES = new Set<CloudRole>(['all-in-one', 'web', 'worker', 'scheduler'])
+const CLOUD_AUTH_MODES = new Set(['none', 'header', 'oidc'])
+const CLOUD_CONTROL_PLANE_KINDS = new Set(['local', 'postgres'])
+const CLOUD_OBJECT_STORE_KINDS = new Set(['filesystem', 's3', 'gcs', 'azure-blob', 'digitalocean-spaces', 'minio'])
+const PUBLIC_BRANDING_URL_KEYS = new Set(['logoUrl', 'supportUrl', 'privacyUrl', 'securityUrl', 'legalUrl'])
+const GATEWAY_MODES = new Set(['self-host', 'managed'])
+const GATEWAY_LOG_LEVELS = new Set(['debug', 'info', 'warn', 'error', 'silent'])
+const GATEWAY_PROVIDER_KINDS = new Set(['fake', 'telegram', 'slack', 'email', 'webhook', 'discord', 'whatsapp', 'signal', 'cli'])
+
+function stringArray(value: unknown, fallback: string[] = []) {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    : fallback
+}
+
+function normalizeCloudFeatures(raw: Partial<CloudFeatureConfig> | undefined): CloudFeatureConfig {
+  return {
+    ...DEFAULT_CONFIG.cloud.features,
+    ...(raw || {}),
+  }
+}
+
+function safePublicBrandingUrl(value: unknown, allowMailto = false) {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (!text) return ''
+  try {
+    const url = new URL(text)
+    if (url.protocol === 'https:') return url.toString()
+    if (allowMailto && url.protocol === 'mailto:') return url.toString()
+  } catch {
+    return ''
+  }
+  return ''
+}
+
+function cleanPublicBrandingStrings(value: unknown) {
+  const output: Record<string, string> = {}
+  if (!value || typeof value !== 'object') return output
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== 'string') continue
+    const text = entry.trim()
+    if (!text) continue
+    output[key] = text
+  }
+  return output
+}
+
+function normalizePublicBranding(raw: Partial<PublicBrandingConfig> | undefined): PublicBrandingConfig {
+  const defaults = DEFAULT_CONFIG.cloud.publicBranding
+  const source = raw || {}
+  const base: PublicBrandingConfig = {
+    ...defaults,
+    ...source,
+    productName: typeof source.productName === 'string' && source.productName.trim()
+      ? source.productName.trim()
+      : defaults.productName,
+    shortName: typeof source.shortName === 'string' && source.shortName.trim()
+      ? source.shortName.trim()
+      : defaults.shortName,
+    logoUrl: safePublicBrandingUrl(source.logoUrl),
+    supportUrl: safePublicBrandingUrl(source.supportUrl, true),
+    privacyUrl: safePublicBrandingUrl(source.privacyUrl),
+    securityUrl: safePublicBrandingUrl(source.securityUrl),
+    legalUrl: safePublicBrandingUrl(source.legalUrl),
+    theme: {
+      ...(defaults.theme || {}),
+      ...cleanPublicBrandingStrings(source.theme),
+    },
+    dashboard: {
+      ...(defaults.dashboard || {}),
+      ...cleanPublicBrandingStrings(source.dashboard),
+    },
+    managedOrgConnectionLabels: {
+      ...(defaults.managedOrgConnectionLabels || {}),
+      ...cleanPublicBrandingStrings(source.managedOrgConnectionLabels),
+    },
+  }
+  for (const key of PUBLIC_BRANDING_URL_KEYS) {
+    if (!base[key as keyof PublicBrandingConfig]) delete base[key as keyof PublicBrandingConfig]
+  }
+  return base
+}
+
+function normalizeCloudProjectSources(raw: CloudConfig['projectSources'] | undefined): CloudConfig['projectSources'] {
+  const defaults = DEFAULT_CONFIG.cloud.projectSources
+  const source = raw || defaults
+  return {
+    git: {
+      ...defaults.git,
+      ...(source.git || {}),
+      enabled: typeof source.git?.enabled === 'boolean' ? source.git.enabled : defaults.git.enabled,
+      allowedHosts: stringArray(source.git?.allowedHosts, defaults.git.allowedHosts),
+      allowedRepositories: stringArray(source.git?.allowedRepositories, defaults.git.allowedRepositories),
+      allowFileUrls: typeof source.git?.allowFileUrls === 'boolean' ? source.git.allowFileUrls : defaults.git.allowFileUrls,
+    },
+    uploadedSnapshots: {
+      ...defaults.uploadedSnapshots,
+      ...(source.uploadedSnapshots || {}),
+      enabled: typeof source.uploadedSnapshots?.enabled === 'boolean'
+        ? source.uploadedSnapshots.enabled
+        : defaults.uploadedSnapshots.enabled,
+      maxFiles: nullablePositiveNumber(source.uploadedSnapshots?.maxFiles, defaults.uploadedSnapshots.maxFiles)
+        || defaults.uploadedSnapshots.maxFiles,
+      maxBytes: nullablePositiveNumber(source.uploadedSnapshots?.maxBytes, defaults.uploadedSnapshots.maxBytes)
+        || defaults.uploadedSnapshots.maxBytes,
+    },
+    managedWorkspaces: {
+      ...defaults.managedWorkspaces,
+      ...(source.managedWorkspaces || {}),
+      enabled: typeof source.managedWorkspaces?.enabled === 'boolean'
+        ? source.managedWorkspaces.enabled
+        : defaults.managedWorkspaces.enabled,
+    },
+  }
+}
+
+function nullablePositiveNumber(value: unknown, fallback: number | null): number | null {
+  if (value === null) return null
+  const parsed = Number(value ?? fallback)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function normalizeCloudAbuseConfig(raw: CloudConfig['abuse'] | undefined): CloudConfig['abuse'] {
+  const defaults = DEFAULT_CONFIG.cloud.abuse
+  return {
+    ...defaults,
+    ...(raw || {}),
+    enabled: typeof raw?.enabled === 'boolean' ? raw.enabled : defaults.enabled,
+    maxConcurrentSessionsPerOrg: nullablePositiveNumber(raw?.maxConcurrentSessionsPerOrg, defaults.maxConcurrentSessionsPerOrg),
+    maxConcurrentWorkflowRunsPerOrg: nullablePositiveNumber(raw?.maxConcurrentWorkflowRunsPerOrg, defaults.maxConcurrentWorkflowRunsPerOrg),
+    maxActiveWorkersPerOrg: nullablePositiveNumber(raw?.maxActiveWorkersPerOrg, defaults.maxActiveWorkersPerOrg),
+    maxQueuedCommandsPerOrg: nullablePositiveNumber(raw?.maxQueuedCommandsPerOrg, defaults.maxQueuedCommandsPerOrg),
+    maxQueueAgeMs: nullablePositiveNumber(raw?.maxQueueAgeMs, defaults.maxQueueAgeMs),
+    maxPromptsPerHour: nullablePositiveNumber(raw?.maxPromptsPerHour, defaults.maxPromptsPerHour),
+    maxWorkflowRunsPerHour: nullablePositiveNumber(raw?.maxWorkflowRunsPerHour, defaults.maxWorkflowRunsPerHour),
+    maxGatewayPromptsPerHour: nullablePositiveNumber(raw?.maxGatewayPromptsPerHour, defaults.maxGatewayPromptsPerHour),
+    maxWorkerMinutesPerHour: nullablePositiveNumber(raw?.maxWorkerMinutesPerHour, defaults.maxWorkerMinutesPerHour),
+    maxGatewayDeliveriesPerHour: nullablePositiveNumber(raw?.maxGatewayDeliveriesPerHour, defaults.maxGatewayDeliveriesPerHour),
+    maxGatewayChannelBindingsPerOrg: nullablePositiveNumber(raw?.maxGatewayChannelBindingsPerOrg, defaults.maxGatewayChannelBindingsPerOrg),
+    maxArtifactBytesPerDay: nullablePositiveNumber(raw?.maxArtifactBytesPerDay, defaults.maxArtifactBytesPerDay),
+    httpRateLimit: {
+      ...defaults.httpRateLimit,
+      ...(raw?.httpRateLimit || {}),
+      enabled: typeof raw?.httpRateLimit?.enabled === 'boolean'
+        ? raw.httpRateLimit.enabled
+        : defaults.httpRateLimit.enabled,
+      windowMs: nullablePositiveNumber(raw?.httpRateLimit?.windowMs, defaults.httpRateLimit.windowMs) || defaults.httpRateLimit.windowMs,
+      maxRequests: nullablePositiveNumber(raw?.httpRateLimit?.maxRequests, defaults.httpRateLimit.maxRequests) || defaults.httpRateLimit.maxRequests,
+    },
+    authBackoff: {
+      ...defaults.authBackoff,
+      ...(raw?.authBackoff || {}),
+      enabled: typeof raw?.authBackoff?.enabled === 'boolean'
+        ? raw.authBackoff.enabled
+        : defaults.authBackoff.enabled,
+      windowMs: nullablePositiveNumber(raw?.authBackoff?.windowMs, defaults.authBackoff.windowMs) || defaults.authBackoff.windowMs,
+      maxFailures: nullablePositiveNumber(raw?.authBackoff?.maxFailures, defaults.authBackoff.maxFailures) || defaults.authBackoff.maxFailures,
+      backoffMs: nullablePositiveNumber(raw?.authBackoff?.backoffMs, defaults.authBackoff.backoffMs) || defaults.authBackoff.backoffMs,
+    },
+  }
+}
+
+function normalizeBillingEntitlements(raw: CloudConfig['billing']['plans'][string]['entitlements'] | undefined): CloudConfig['billing']['plans'][string]['entitlements'] {
+  if (!raw) return undefined
+  return {
+    ...raw,
+    allowedProfiles: raw.allowedProfiles === null ? null : stringArray(raw.allowedProfiles),
+    allowedProviders: raw.allowedProviders === null ? null : stringArray(raw.allowedProviders),
+    maxConcurrentSessionsPerOrg: nullablePositiveNumber(raw.maxConcurrentSessionsPerOrg, null),
+    maxConcurrentWorkflowRunsPerOrg: nullablePositiveNumber(raw.maxConcurrentWorkflowRunsPerOrg, null),
+    maxActiveWorkersPerOrg: nullablePositiveNumber(raw.maxActiveWorkersPerOrg, null),
+    maxQueuedCommandsPerOrg: nullablePositiveNumber(raw.maxQueuedCommandsPerOrg, null),
+    maxQueueAgeMs: nullablePositiveNumber(raw.maxQueueAgeMs, null),
+    maxPromptsPerHour: nullablePositiveNumber(raw.maxPromptsPerHour, null),
+    maxWorkflowRunsPerHour: nullablePositiveNumber(raw.maxWorkflowRunsPerHour, null),
+    maxGatewayPromptsPerHour: nullablePositiveNumber(raw.maxGatewayPromptsPerHour, null),
+    maxWorkerMinutesPerHour: nullablePositiveNumber(raw.maxWorkerMinutesPerHour, null),
+    maxGatewayDeliveriesPerHour: nullablePositiveNumber(raw.maxGatewayDeliveriesPerHour, null),
+    maxGatewayChannelBindingsPerOrg: nullablePositiveNumber(raw.maxGatewayChannelBindingsPerOrg, null),
+    maxArtifactBytesPerDay: nullablePositiveNumber(raw.maxArtifactBytesPerDay, null),
+  }
+}
+
+function normalizeCloudBillingConfig(raw: CloudConfig['billing'] | undefined): CloudConfig['billing'] {
+  const defaults = DEFAULT_CONFIG.cloud.billing
+  const source = raw || defaults
+  const providers = new Set(['none', 'stub', 'stripe'])
+  const plans: CloudConfig['billing']['plans'] = {}
+  for (const [planKey, plan] of Object.entries(defaults.plans)) {
+    plans[planKey] = {
+      ...plan,
+      entitlements: normalizeBillingEntitlements(plan.entitlements),
+    }
+  }
+  for (const [planKey, plan] of Object.entries(source.plans || {})) {
+    if (!planKey.trim()) continue
+    plans[planKey] = {
+      ...(plans[planKey] || {}),
+      ...plan,
+      entitlements: normalizeBillingEntitlements({
+        ...(plans[planKey]?.entitlements || {}),
+        ...(plan.entitlements || {}),
+      }),
+    }
+  }
+  const defaultPlanKey = source.defaultPlanKey && plans[source.defaultPlanKey]
+    ? source.defaultPlanKey
+    : defaults.defaultPlanKey
+  return {
+    ...defaults,
+    ...source,
+    enabled: typeof source.enabled === 'boolean' ? source.enabled : defaults.enabled,
+    provider: providers.has(source.provider) ? source.provider : defaults.provider,
+    defaultPlanKey,
+    plans,
+    stripe: {
+      ...(defaults.stripe || {}),
+      ...(source.stripe || {}),
+    },
+  }
+}
+
+function normalizeCloudProfile(raw: CloudProfileConfig | undefined): CloudProfileConfig {
+  const defaultProjectSource = Object.prototype.hasOwnProperty.call(raw || {}, 'defaultProjectSource')
+    ? normalizeCloudProjectSource(raw?.defaultProjectSource)
+    : undefined
+  return {
+    ...(raw || {}),
+    agents: stringArray(raw?.agents),
+    tools: stringArray(raw?.tools),
+    mcps: stringArray(raw?.mcps),
+    features: raw?.features ? normalizeCloudFeatures(raw.features) : undefined,
+    ...(defaultProjectSource !== undefined ? { defaultProjectSource } : {}),
+    runtime: raw?.runtime
+      ? {
+          ...raw.runtime,
+          configSource: 'app',
+          launcher: 'node',
+          allowedLocalMcpNames: stringArray(raw.runtime.allowedLocalMcpNames),
+          allowedHostProjectDirectories: stringArray(raw.runtime.allowedHostProjectDirectories),
+        }
+      : undefined,
+  }
+}
+
+function normalizeCloudConfig(raw: CloudConfig | undefined): CloudConfig {
+  const source = raw || DEFAULT_CONFIG.cloud
+  const profiles: Record<string, CloudProfileConfig> = {}
+  for (const [name, profile] of Object.entries(DEFAULT_CONFIG.cloud.profiles)) {
+    profiles[name] = normalizeCloudProfile(profile)
+  }
+  for (const [name, profile] of Object.entries(source.profiles || {})) {
+    if (!name.trim()) continue
+    profiles[name] = normalizeCloudProfile({
+      ...(profiles[name] || {}),
+      ...profile,
+      features: {
+        ...(profiles[name]?.features || {}),
+        ...(profile.features || {}),
+      },
+      runtime: {
+        ...(profiles[name]?.runtime || {}),
+        ...(profile.runtime || {}),
+      },
+    })
+  }
+
+  const role = CLOUD_ROLES.has(source.role) ? source.role : DEFAULT_CONFIG.cloud.role
+  const defaultProfile = source.defaultProfile && profiles[source.defaultProfile]
+    ? source.defaultProfile
+    : DEFAULT_CONFIG.cloud.defaultProfile
+
+  return {
+    ...DEFAULT_CONFIG.cloud,
+    ...source,
+    role,
+    defaultProfile,
+    profiles,
+    publicBranding: normalizePublicBranding(source.publicBranding),
+    auth: {
+      ...DEFAULT_CONFIG.cloud.auth,
+      ...(source.auth || {}),
+      mode: CLOUD_AUTH_MODES.has(source.auth?.mode || '')
+        ? source.auth.mode
+        : DEFAULT_CONFIG.cloud.auth.mode,
+      signupMode: source.auth?.signupMode
+        ? source.auth.signupMode
+        : source.auth?.mode === 'oidc'
+          ? 'invite'
+          : DEFAULT_CONFIG.cloud.auth.signupMode,
+      headerSecret: typeof source.auth?.headerSecret === 'string' && source.auth.headerSecret.trim()
+        ? source.auth.headerSecret.trim()
+        : undefined,
+      headerSecretRef: typeof source.auth?.headerSecretRef === 'string' && source.auth.headerSecretRef.trim()
+        ? source.auth.headerSecretRef.trim()
+        : undefined,
+      headerAllowUnsigned: typeof source.auth?.headerAllowUnsigned === 'boolean'
+        ? source.auth.headerAllowUnsigned
+        : false,
+      headerMaxSignatureAgeMs: nullablePositiveNumber(source.auth?.headerMaxSignatureAgeMs, 5 * 60 * 1000) || 5 * 60 * 1000,
+      allowedEmailDomains: stringArray(source.auth?.allowedEmailDomains),
+      allowSelfServiceSignup: typeof source.auth?.allowSelfServiceSignup === 'boolean'
+        ? source.auth.allowSelfServiceSignup
+        : source.auth?.mode === 'oidc'
+          ? false
+          : DEFAULT_CONFIG.cloud.auth.allowSelfServiceSignup,
+      apiTokens: {
+        ...DEFAULT_CONFIG.cloud.auth.apiTokens,
+        ...(source.auth?.apiTokens || {}),
+        defaultTtlMs: nullablePositiveNumber(
+          source.auth?.apiTokens?.defaultTtlMs,
+          DEFAULT_CONFIG.cloud.auth.apiTokens?.defaultTtlMs || 90 * 24 * 60 * 60 * 1000,
+        ) || DEFAULT_CONFIG.cloud.auth.apiTokens?.defaultTtlMs,
+        maxTtlMs: nullablePositiveNumber(
+          source.auth?.apiTokens?.maxTtlMs,
+          DEFAULT_CONFIG.cloud.auth.apiTokens?.maxTtlMs || 365 * 24 * 60 * 60 * 1000,
+        ) || DEFAULT_CONFIG.cloud.auth.apiTokens?.maxTtlMs,
+        allowedScopes: stringArray(source.auth?.apiTokens?.allowedScopes).length > 0
+          ? stringArray(source.auth?.apiTokens?.allowedScopes)
+          : DEFAULT_CONFIG.cloud.auth.apiTokens?.allowedScopes,
+      },
+    },
+    storage: {
+      controlPlane: {
+        ...DEFAULT_CONFIG.cloud.storage.controlPlane,
+        ...(source.storage?.controlPlane || {}),
+        kind: CLOUD_CONTROL_PLANE_KINDS.has(source.storage?.controlPlane?.kind || '')
+          ? source.storage!.controlPlane.kind
+          : DEFAULT_CONFIG.cloud.storage.controlPlane.kind,
+      },
+      objectStore: {
+        ...DEFAULT_CONFIG.cloud.storage.objectStore,
+        ...(source.storage?.objectStore || {}),
+        kind: CLOUD_OBJECT_STORE_KINDS.has(source.storage?.objectStore?.kind || '')
+          ? source.storage!.objectStore.kind
+          : DEFAULT_CONFIG.cloud.storage.objectStore.kind,
+      },
+    },
+    runtime: {
+      ...DEFAULT_CONFIG.cloud.runtime,
+      ...(source.runtime || {}),
+      configSource: 'app',
+      launcher: 'node',
+      allowedLocalMcpNames: stringArray(source.runtime?.allowedLocalMcpNames),
+      allowedHostProjectDirectories: stringArray(source.runtime?.allowedHostProjectDirectories),
+    },
+    projectSources: normalizeCloudProjectSources(source.projectSources),
+    features: normalizeCloudFeatures(source.features),
+    abuse: normalizeCloudAbuseConfig(source.abuse),
+    billing: normalizeCloudBillingConfig(source.billing),
+  }
+}
+
+function normalizeCloudDesktopConfig(raw: CloudDesktopConfig | undefined): CloudDesktopConfig {
+  const source = raw || DEFAULT_CONFIG.cloudDesktop
+  const cacheModes = new Set(['full', 'metadata-only', 'disabled'])
+  const fallbackModes = new Set(['metadata-only', 'disabled', 'fail-startup'])
+  return {
+    ...DEFAULT_CONFIG.cloudDesktop,
+    ...source,
+    enabled: typeof source.enabled === 'boolean' ? source.enabled : DEFAULT_CONFIG.cloudDesktop.enabled,
+    allowUserAddedConnections: typeof source.allowUserAddedConnections === 'boolean'
+      ? source.allowUserAddedConnections
+      : DEFAULT_CONFIG.cloudDesktop.allowUserAddedConnections,
+    preconfiguredConnections: Array.isArray(source.preconfiguredConnections)
+      ? source.preconfiguredConnections
+        .filter((connection) => connection && typeof connection.baseUrl === 'string' && connection.baseUrl.trim())
+        .map((connection) => ({
+          baseUrl: connection.baseUrl.trim(),
+          ...(typeof connection.label === 'string' && connection.label.trim() ? { label: connection.label.trim() } : {}),
+        }))
+      : DEFAULT_CONFIG.cloudDesktop.preconfiguredConnections,
+    requireManagedOrg: typeof source.requireManagedOrg === 'boolean'
+      ? source.requireManagedOrg
+      : DEFAULT_CONFIG.cloudDesktop.requireManagedOrg,
+    cacheMode: cacheModes.has(source.cacheMode) ? source.cacheMode : DEFAULT_CONFIG.cloudDesktop.cacheMode,
+    cacheEncryptionFallback: fallbackModes.has(source.cacheEncryptionFallback)
+      ? source.cacheEncryptionFallback
+      : DEFAULT_CONFIG.cloudDesktop.cacheEncryptionFallback,
+  }
+}
+
+function normalizeGatewayConfig(raw: OpenCoworkConfig['gateway'] | undefined): OpenCoworkConfig['gateway'] {
+  const defaults = DEFAULT_CONFIG.gateway
+  const source = raw || defaults
+  const mode = GATEWAY_MODES.has(source.mode || '') ? source.mode : defaults.mode
+  const logLevel = GATEWAY_LOG_LEVELS.has(source.logging?.level || '') ? source.logging?.level : defaults.logging?.level
+  return {
+    ...defaults,
+    ...source,
+    branding: normalizePublicBranding(source.branding),
+    cloud: {
+      ...(defaults.cloud || {}),
+      ...(source.cloud || {}),
+      allowInsecureHttp: typeof source.cloud?.allowInsecureHttp === 'boolean'
+        ? source.cloud.allowInsecureHttp
+        : defaults.cloud?.allowInsecureHttp,
+    },
+    server: {
+      ...(defaults.server || {}),
+      ...(source.server || {}),
+      port: Number.isInteger(source.server?.port) && source.server!.port! >= 0 && source.server!.port! <= 65535
+        ? source.server!.port
+        : defaults.server?.port,
+    },
+    mode,
+    logging: {
+      ...(defaults.logging || {}),
+      ...(source.logging || {}),
+      level: logLevel,
+    },
+    metrics: {
+      ...(defaults.metrics || {}),
+      ...(source.metrics || {}),
+      enabled: typeof source.metrics?.enabled === 'boolean' ? source.metrics.enabled : defaults.metrics?.enabled,
+    },
+    diagnostics: {
+      ...(defaults.diagnostics || {}),
+      ...(source.diagnostics || {}),
+      enabled: typeof source.diagnostics?.enabled === 'boolean'
+        ? source.diagnostics.enabled
+        : defaults.diagnostics?.enabled,
+    },
+    providers: Array.isArray(source.providers)
+      ? source.providers
+        .filter((provider) => provider && GATEWAY_PROVIDER_KINDS.has(provider.kind))
+        .map((provider) => ({
+          ...provider,
+          id: typeof provider.id === 'string' && provider.id.trim() ? provider.id.trim() : undefined,
+          channelBindingId: typeof provider.channelBindingId === 'string' ? provider.channelBindingId.trim() : '',
+          externalWorkspaceId: typeof provider.externalWorkspaceId === 'string' && provider.externalWorkspaceId.trim()
+            ? provider.externalWorkspaceId.trim()
+            : null,
+          defaultAgent: typeof provider.defaultAgent === 'string' && provider.defaultAgent.trim()
+            ? provider.defaultAgent.trim()
+            : null,
+          credentials: provider.credentials && typeof provider.credentials === 'object' ? { ...provider.credentials } : {},
+          settings: provider.settings && typeof provider.settings === 'object' ? { ...provider.settings } : {},
+        }))
+      : defaults.providers,
+  }
+}
+
+export function normalizeAppConfig(raw: OpenCoworkConfig): OpenCoworkConfig {
+  return {
+    ...raw,
+    allowedEnvPlaceholders: Array.isArray(raw.allowedEnvPlaceholders)
+      ? raw.allowedEnvPlaceholders.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+      : DEFAULT_CONFIG.allowedEnvPlaceholders,
+    branding: {
+      ...DEFAULT_CONFIG.branding,
+      ...(raw.branding || {}),
+    },
+    auth: {
+      ...(raw.auth || {}),
+      mode: raw.auth?.mode === 'google-oauth' ? 'google-oauth' : 'none',
+    },
+    providers: {
+      ...DEFAULT_CONFIG.providers,
+      ...(raw.providers || {}),
+      available: Array.isArray(raw.providers?.available) && raw.providers?.available.length > 0
+        ? raw.providers.available
+        : DEFAULT_CONFIG.providers.available,
+      descriptors: raw.providers?.descriptors || DEFAULT_CONFIG.providers.descriptors,
+      modelInfo: raw.providers?.modelInfo || DEFAULT_CONFIG.providers.modelInfo,
+      custom: raw.providers?.custom || {},
+    },
+    updates: {
+      ...DEFAULT_CONFIG.updates,
+      ...(raw.updates || {}),
+      ...(raw.updates?.releaseSource ? { releaseSource: { ...raw.updates.releaseSource } } : {}),
+    },
+    tools: Array.isArray(raw.tools) ? raw.tools : [],
+    skills: Array.isArray(raw.skills) ? raw.skills : [],
+    mcps: Array.isArray(raw.mcps) ? raw.mcps : [],
+    agents: Array.isArray(raw.agents) ? raw.agents : [],
+    capabilityBundles: Array.isArray(raw.capabilityBundles) ? raw.capabilityBundles : [],
+    permissions: {
+      ...DEFAULT_CONFIG.permissions,
+      ...(raw.permissions || {}),
+      webSearch: typeof raw.permissions?.webSearch === 'boolean'
+        ? raw.permissions.webSearch
+        : DEFAULT_CONFIG.permissions.webSearch,
+    },
+    builtInAgents: raw.builtInAgents && typeof raw.builtInAgents === 'object'
+      ? { ...raw.builtInAgents }
+      : undefined,
+    agentStarterTemplates: Array.isArray(raw.agentStarterTemplates) ? raw.agentStarterTemplates : undefined,
+    toolTrace: {
+      rules: Array.isArray(raw.toolTrace?.rules)
+        ? raw.toolTrace.rules
+        : DEFAULT_CONFIG.toolTrace?.rules || [],
+      additionalRules: Array.isArray(raw.toolTrace?.additionalRules)
+        ? raw.toolTrace.additionalRules
+        : [],
+    },
+    compaction: {
+      ...DEFAULT_CONFIG.compaction,
+      ...(raw.compaction || {}),
+      ...(raw.compaction?.agent ? { agent: { ...raw.compaction.agent } } : {}),
+    },
+    cloud: normalizeCloudConfig(raw.cloud),
+    cloudDesktop: normalizeCloudDesktopConfig(raw.cloudDesktop),
+    gateway: normalizeGatewayConfig(raw.gateway),
+  }
+}
+
+export function normalizeConfigLayers(
+  layers: Array<Partial<OpenCoworkConfig>>,
+  base: OpenCoworkConfig = DEFAULT_CONFIG,
+): OpenCoworkConfig {
+  return layers.reduce<OpenCoworkConfig>(
+    (current, layer) => normalizeAppConfig(deepMerge<OpenCoworkConfig>(current, layer)),
+    normalizeAppConfig(base),
+  )
+}

--- a/apps/desktop/src/main/custom-mcp-store.ts
+++ b/apps/desktop/src/main/custom-mcp-store.ts
@@ -88,6 +88,27 @@ function writeManagedMcpMetadata(
   writeJsonFile(path, next as JsonRecord)
 }
 
+function repairStaleManagedMcpMetadata(
+  scope: NativeConfigScope,
+  directory: string | null | undefined,
+  metadata: Record<string, ManagedMcpMetadata>,
+  configuredNames: Set<string>,
+) {
+  const staleNames = Object.keys(metadata).filter((name) => !configuredNames.has(name))
+  if (staleNames.length === 0) return
+
+  log('warn', `Custom MCP metadata had stale entries without config: ${staleNames.join(', ')}. Repairing sidecar metadata.`)
+  try {
+    writeManagedMcpMetadata(scope, directory, (current) => {
+      const next = { ...current }
+      for (const name of staleNames) delete next[name]
+      return next
+    })
+  } catch (error) {
+    log('error', `Custom MCP metadata repair failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
 function serializeCustomMcp(mcp: CustomMcpConfig): JsonRecord {
   if (mcp.type === 'stdio') {
     if (!mcp.command?.trim()) {
@@ -163,11 +184,27 @@ export function readScopedMcps(scope: NativeConfigScope, directory?: string | nu
   const path = configPathForTarget(scope, directory)
   const config = readJsoncFile<JsonRecord>(path)
   const mcp = config.mcp
-  if (!mcp || typeof mcp !== 'object' || Array.isArray(mcp)) return []
   const metadata = readManagedMcpMetadata(scope, directory)
-  return Object.entries(mcp)
+  if (!mcp || typeof mcp !== 'object' || Array.isArray(mcp)) {
+    repairStaleManagedMcpMetadata(scope, directory, metadata, new Set())
+    return []
+  }
+  const entries = Object.entries(mcp)
+  repairStaleManagedMcpMetadata(scope, directory, metadata, new Set(entries.map(([name]) => name)))
+  return entries
     .map(([name, value]) => parseCustomMcpEntry(name, value, scope, metadata[name] || {}, directory))
     .filter((entry): entry is CustomMcpConfig => Boolean(entry))
+}
+
+function readScopedMcpConfig(
+  scope: NativeConfigScope,
+  directory: string | null | undefined,
+): Record<string, unknown> {
+  const path = configPathForTarget(scope, directory)
+  const config = readJsoncFile<JsonRecord>(path)
+  return config.mcp && typeof config.mcp === 'object' && !Array.isArray(config.mcp)
+    ? { ...(config.mcp as Record<string, unknown>) }
+    : {}
 }
 
 function updateScopedMcpConfig(
@@ -191,6 +228,26 @@ function updateScopedMcpConfig(
   writeTopLevelObjectPropertyFile(path, 'mcp', Object.keys(nextMcp).length === 0 ? null : nextMcp)
 }
 
+function restoreScopedMcpConfigAfterMetadataFailure(
+  scope: NativeConfigScope,
+  directory: string | null | undefined,
+  previousMcp: Record<string, unknown>,
+  error: unknown,
+) {
+  try {
+    updateScopedMcpConfig(scope, directory, () => ({ ...previousMcp }))
+  } catch (rollbackError) {
+    throw new Error(
+      `Custom MCP metadata write failed (${error instanceof Error ? error.message : String(error)}), and OpenCode MCP config rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+      { cause: rollbackError },
+    )
+  }
+  throw new Error(
+    `Custom MCP metadata write failed after OpenCode MCP config update; restored previous MCP config: ${error instanceof Error ? error.message : String(error)}`,
+    { cause: error },
+  )
+}
+
 export function listCustomMcps(context?: RuntimeContextOptions) {
   const projectDirectory = resolveProjectDirectory(context?.directory)
   const entries = [
@@ -202,43 +259,53 @@ export function listCustomMcps(context?: RuntimeContextOptions) {
 
 export function saveCustomMcp(mcp: CustomMcpConfig) {
   assertCustomMcpContentLimits(mcp)
+  const previousMcp = readScopedMcpConfig(mcp.scope, mcp.directory)
   updateScopedMcpConfig(mcp.scope, mcp.directory, (current) => ({
     ...current,
     [mcp.name]: serializeCustomMcp(mcp),
   }))
-  writeManagedMcpMetadata(mcp.scope, mcp.directory, (current) => {
-    const next = { ...current }
-    const label = mcp.label?.trim() || undefined
-    const description = mcp.description?.trim() || undefined
-    const metadata: ManagedMcpMetadata = {
-      label,
-      description,
-      googleAuth: mcp.googleAuth === true ? true : undefined,
-      allowPrivateNetwork: mcp.allowPrivateNetwork === true ? true : undefined,
-      permissionMode: mcp.permissionMode === 'allow' ? 'allow' : undefined,
-      traceLabel: mcp.traceLabel?.trim() || undefined,
-      tracePluralLabel: mcp.tracePluralLabel?.trim() || undefined,
-    }
-    if (!metadata.label && !metadata.description && !metadata.googleAuth && !metadata.allowPrivateNetwork && !metadata.permissionMode && !metadata.traceLabel && !metadata.tracePluralLabel) {
-      delete next[mcp.name]
+  try {
+    writeManagedMcpMetadata(mcp.scope, mcp.directory, (current) => {
+      const next = { ...current }
+      const label = mcp.label?.trim() || undefined
+      const description = mcp.description?.trim() || undefined
+      const metadata: ManagedMcpMetadata = {
+        label,
+        description,
+        googleAuth: mcp.googleAuth === true ? true : undefined,
+        allowPrivateNetwork: mcp.allowPrivateNetwork === true ? true : undefined,
+        permissionMode: mcp.permissionMode === 'allow' ? 'allow' : undefined,
+        traceLabel: mcp.traceLabel?.trim() || undefined,
+        tracePluralLabel: mcp.tracePluralLabel?.trim() || undefined,
+      }
+      if (!metadata.label && !metadata.description && !metadata.googleAuth && !metadata.allowPrivateNetwork && !metadata.permissionMode && !metadata.traceLabel && !metadata.tracePluralLabel) {
+        delete next[mcp.name]
+        return next
+      }
+      next[mcp.name] = metadata
       return next
-    }
-    next[mcp.name] = metadata
-    return next
-  })
+    })
+  } catch (error) {
+    restoreScopedMcpConfigAfterMetadataFailure(mcp.scope, mcp.directory, previousMcp, error)
+  }
   return true
 }
 
 export function removeCustomMcp(target: ScopedArtifactRef) {
+  const previousMcp = readScopedMcpConfig(target.scope, target.directory)
   updateScopedMcpConfig(target.scope, target.directory, (current) => {
     const next = { ...current }
     delete next[target.name]
     return next
   })
-  writeManagedMcpMetadata(target.scope, target.directory, (current) => {
-    const next = { ...current }
-    delete next[target.name]
-    return next
-  })
+  try {
+    writeManagedMcpMetadata(target.scope, target.directory, (current) => {
+      const next = { ...current }
+      delete next[target.name]
+      return next
+    })
+  } catch (error) {
+    restoreScopedMcpConfigAfterMetadataFailure(target.scope, target.directory, previousMcp, error)
+  }
   return true
 }

--- a/apps/desktop/src/main/workflow/workflow-normalization.ts
+++ b/apps/desktop/src/main/workflow/workflow-normalization.ts
@@ -1,0 +1,215 @@
+import type {
+  WorkflowDraft,
+  WorkflowToolPreview,
+  WorkflowTrigger,
+  WorkflowTriggerType,
+  WorkflowValidationGap,
+} from '@open-cowork/shared'
+import { validateWorkflowSchedule } from './workflow-schedule.ts'
+
+const MAX_TEXT = 32 * 1024
+export const MAX_WORKFLOW_LIST_ITEMS = 50
+const VALID_TRIGGER_TYPES = new Set<WorkflowTriggerType>(['manual', 'schedule', 'webhook'])
+
+export type WorkflowCapabilityValidationContext = {
+  agentNames?: readonly string[]
+  skillNames?: readonly string[]
+  toolIds?: readonly string[]
+}
+
+export type WorkflowDraftNormalizationOptions = {
+  now?: Date
+  capabilities?: WorkflowCapabilityValidationContext
+  idGenerator?: () => string
+  secretGenerator?: () => string
+  projectDirectoryExists?: (directory: string) => boolean
+}
+
+export function isWorkflowTriggerType(value: unknown): value is WorkflowTriggerType {
+  return typeof value === 'string' && VALID_TRIGGER_TYPES.has(value as WorkflowTriggerType)
+}
+
+function boundedText(value: unknown, label: string, max = MAX_TEXT) {
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  const trimmed = value.trim()
+  if (!trimmed) throw new Error(`${label} is required.`)
+  if (Buffer.byteLength(trimmed, 'utf8') > max) throw new Error(`${label} is too large.`)
+  return trimmed
+}
+
+function boundedOptionalText(value: unknown, label: string, max = MAX_TEXT) {
+  if (value === null || value === undefined) return null
+  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (Buffer.byteLength(trimmed, 'utf8') > max) throw new Error(`${label} is too large.`)
+  return trimmed
+}
+
+function normalizeStringList(value: unknown, label: string) {
+  if (value === null || value === undefined) return []
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array.`)
+  return Array.from(new Set(value.map((item) => boundedText(item, `${label} entry`, 256)))).slice(0, MAX_WORKFLOW_LIST_ITEMS)
+}
+
+function randomWorkflowSecret() {
+  return crypto.randomUUID().replace(/-/g, '') + crypto.randomUUID().replace(/-/g, '')
+}
+
+function hasCapabilityReference(value: string, available?: readonly string[]) {
+  if (!available) return true
+  return available.includes(value)
+}
+
+export function validateWorkflowDraftCapabilities(
+  draft: WorkflowDraft,
+  options?: Pick<WorkflowDraftNormalizationOptions, 'capabilities' | 'projectDirectoryExists'>,
+): WorkflowValidationGap[] {
+  const capabilities = options?.capabilities
+  const gaps: WorkflowValidationGap[] = []
+
+  if (!hasCapabilityReference(draft.agentName, capabilities?.agentNames)) {
+    gaps.push({
+      severity: 'required',
+      field: 'agentName',
+      value: draft.agentName,
+      message: `Workflow agent "${draft.agentName}" is not available.`,
+    })
+  }
+
+  for (const skillName of draft.skillNames || []) {
+    if (hasCapabilityReference(skillName, capabilities?.skillNames)) continue
+    gaps.push({
+      severity: 'optional',
+      field: 'skillNames',
+      value: skillName,
+      message: `Workflow skill "${skillName}" is not available.`,
+    })
+  }
+
+  for (const toolId of draft.toolIds || []) {
+    if (hasCapabilityReference(toolId, capabilities?.toolIds)) continue
+    gaps.push({
+      severity: 'optional',
+      field: 'toolIds',
+      value: toolId,
+      message: `Workflow tool "${toolId}" is not available.`,
+    })
+  }
+
+  if (draft.projectDirectory && options?.projectDirectoryExists && !options.projectDirectoryExists(draft.projectDirectory)) {
+    gaps.push({
+      severity: 'required',
+      field: 'projectDirectory',
+      value: draft.projectDirectory,
+      message: `Workflow project directory "${draft.projectDirectory}" is not available.`,
+    })
+  }
+
+  return gaps
+}
+
+export function requiredWorkflowGaps(gaps: WorkflowValidationGap[]) {
+  return gaps.filter((gap) => gap.severity === 'required')
+}
+
+export function assertWorkflowCapabilities(draft: WorkflowDraft, options?: Pick<WorkflowDraftNormalizationOptions, 'capabilities' | 'projectDirectoryExists'>) {
+  const gaps = validateWorkflowDraftCapabilities(draft, options)
+  const required = requiredWorkflowGaps(gaps)
+  if (required.length > 0) throw new Error(required[0]!.message)
+  return gaps
+}
+
+export function normalizeWorkflowDraft(draft: WorkflowDraft, options?: WorkflowDraftNormalizationOptions): WorkflowDraft {
+  const title = boundedText(draft.title, 'Workflow title', 512)
+  const instructions = boundedText(draft.instructions, 'Workflow instructions', MAX_TEXT)
+  const agentName = boundedText(draft.agentName || 'build', 'Workflow agent', 256)
+  const idGenerator = options?.idGenerator ?? (() => crypto.randomUUID())
+  const triggers = normalizeWorkflowTriggers(draft.triggers, {
+    now: options?.now ?? new Date(),
+    idGenerator,
+    secretGenerator: options?.secretGenerator ?? randomWorkflowSecret,
+  })
+  if (!triggers.some((trigger) => trigger.type === 'manual')) {
+    triggers.unshift({ id: idGenerator(), type: 'manual', enabled: true })
+  }
+  return {
+    title,
+    instructions,
+    agentName,
+    skillNames: normalizeStringList(draft.skillNames, 'Workflow skillNames'),
+    toolIds: normalizeStringList(draft.toolIds, 'Workflow toolIds'),
+    projectDirectory: boundedOptionalText(draft.projectDirectory, 'Workflow projectDirectory', 4096),
+    draftSessionId: boundedOptionalText(draft.draftSessionId, 'Workflow draftSessionId', 256),
+    triggers,
+  }
+}
+
+function normalizeWorkflowTriggers(
+  value: unknown,
+  options: {
+    now: Date
+    idGenerator: () => string
+    secretGenerator: () => string
+  },
+): WorkflowTrigger[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('Workflow requires at least one trigger.')
+  }
+  return value.slice(0, 8).map((raw) => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('Workflow trigger must be an object.')
+    const trigger = raw as Partial<WorkflowTrigger>
+    const type = String(trigger.type || '')
+    if (!isWorkflowTriggerType(type)) throw new Error('Workflow trigger type is invalid.')
+    const normalized: WorkflowTrigger = {
+      id: typeof trigger.id === 'string' && trigger.id.trim() ? trigger.id.trim() : options.idGenerator(),
+      type,
+      enabled: trigger.enabled !== false,
+      schedule: null,
+      webhookSecret: null,
+    }
+    if (normalized.type === 'schedule') {
+      if (!trigger.schedule) throw new Error('Scheduled workflow trigger requires a schedule.')
+      const scheduleError = validateWorkflowSchedule(trigger.schedule, options.now)
+      if (scheduleError) throw new Error(scheduleError)
+      normalized.schedule = trigger.schedule
+    }
+    if (normalized.type === 'webhook') {
+      normalized.webhookSecret = typeof trigger.webhookSecret === 'string' && trigger.webhookSecret.trim()
+        ? trigger.webhookSecret.trim()
+        : options.secretGenerator()
+    }
+    return normalized
+  })
+}
+
+export function previewWorkflowDraft(draft: WorkflowDraft, options?: WorkflowDraftNormalizationOptions): WorkflowToolPreview {
+  try {
+    const now = options?.now ?? new Date()
+    const normalizedDraft = normalizeWorkflowDraft(draft, { ...options, now })
+    const gaps = validateWorkflowDraftCapabilities(normalizedDraft, options)
+    const missing = requiredWorkflowGaps(gaps).map((gap) => gap.message)
+    return {
+      ok: missing.length === 0,
+      title: normalizedDraft.title,
+      summary: normalizedDraft.instructions.slice(0, 500),
+      missing,
+      gaps,
+      normalizedDraft,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Workflow draft is invalid.'
+    return {
+      ok: false,
+      title: typeof draft.title === 'string' ? draft.title : 'Workflow draft',
+      summary: message,
+      missing: [message],
+      gaps: [{
+        severity: 'required',
+        field: 'draft',
+        value: '',
+        message,
+      }],
+    }
+  }
+}

--- a/apps/desktop/src/main/workflow/workflow-secret-storage.ts
+++ b/apps/desktop/src/main/workflow/workflow-secret-storage.ts
@@ -1,0 +1,104 @@
+import type { WorkflowTrigger } from '@open-cowork/shared'
+import type { SecretStorageMode } from '../secure-storage-policy.ts'
+import { isWorkflowTriggerType } from './workflow-normalization.ts'
+
+const LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX = 'enc:v1:'
+const ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION = 2
+
+export type WorkflowSecretStorageAdapter = {
+  mode: SecretStorageMode
+  encryptString?: (value: string) => Buffer
+  decryptString?: (value: Buffer) => string
+}
+
+type EncryptedWebhookSecretRecord = {
+  __openCoworkEncryptedWebhookSecret: typeof ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION
+  value: string
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== 'string') return fallback
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+function isEncryptedWebhookSecretRecord(value: unknown): value is EncryptedWebhookSecretRecord {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && (value as Partial<EncryptedWebhookSecretRecord>).__openCoworkEncryptedWebhookSecret === ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION
+    && typeof (value as Partial<EncryptedWebhookSecretRecord>).value === 'string',
+  )
+}
+
+function encryptWebhookSecretValue(storage: WorkflowSecretStorageAdapter, secret: string): EncryptedWebhookSecretRecord {
+  if (!storage.encryptString) throw new Error('Electron safeStorage is unavailable')
+  return {
+    __openCoworkEncryptedWebhookSecret: ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION,
+    value: Buffer.from(storage.encryptString(secret)).toString('base64'),
+  }
+}
+
+function tryDecryptWebhookSecretPayload(storage: WorkflowSecretStorageAdapter, payload: string) {
+  if (!storage.decryptString) return null
+  try {
+    return storage.decryptString(Buffer.from(payload, 'base64'))
+  } catch {
+    return null
+  }
+}
+
+function encodeWebhookSecretForStorage(
+  secret: unknown,
+  storage: WorkflowSecretStorageAdapter,
+): string | EncryptedWebhookSecretRecord | null {
+  if (isEncryptedWebhookSecretRecord(secret)) return secret
+  if (typeof secret !== 'string' || !secret) return null
+  if (storage.mode === 'encrypted') {
+    return encryptWebhookSecretValue(storage, secret)
+  }
+  if (storage.mode === 'plaintext') return secret
+  throw new Error('Secure storage unavailable on this system. Open Cowork cannot persist workflow webhook secrets in production without OS-backed secret storage.')
+}
+
+function decodeWebhookSecretFromStorage(secret: unknown, storage: WorkflowSecretStorageAdapter) {
+  if (isEncryptedWebhookSecretRecord(secret)) {
+    return tryDecryptWebhookSecretPayload(storage, secret.value) ?? secret
+  }
+
+  if (typeof secret !== 'string' || !secret.trim()) return null
+  if (!secret.startsWith(LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX)) return secret
+
+  const legacyPayload = secret.slice(LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX.length)
+  const decrypted = tryDecryptWebhookSecretPayload(storage, legacyPayload)
+  return decrypted ?? secret
+}
+
+export function serializeWorkflowTriggersForStorageWithAdapter(
+  triggers: WorkflowTrigger[],
+  storage: WorkflowSecretStorageAdapter,
+) {
+  return JSON.stringify(triggers.map((trigger) => trigger.type === 'webhook'
+    ? { ...trigger, webhookSecret: encodeWebhookSecretForStorage(trigger.webhookSecret, storage) }
+    : trigger))
+}
+
+export function parseWorkflowTriggersFromStorageWithAdapter(
+  value: unknown,
+  storage: WorkflowSecretStorageAdapter,
+) {
+  const parsed = parseJson<unknown>(value, [])
+  if (!Array.isArray(parsed)) return []
+  return parsed.flatMap((raw): WorkflowTrigger[] => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return []
+    const trigger = raw as Partial<WorkflowTrigger>
+    if (!isWorkflowTriggerType(trigger.type)) return []
+    return [trigger.type === 'webhook'
+      ? { ...trigger, webhookSecret: decodeWebhookSecretFromStorage(trigger.webhookSecret, storage) } as WorkflowTrigger
+      : trigger as WorkflowTrigger]
+  })
+}

--- a/apps/desktop/src/main/workflow/workflow-store.ts
+++ b/apps/desktop/src/main/workflow/workflow-store.ts
@@ -12,10 +12,8 @@ import type {
   WorkflowRunStatus,
   WorkflowStatus,
   WorkflowSummary,
-  WorkflowToolPreview,
   WorkflowTrigger,
   WorkflowTriggerType,
-  WorkflowValidationGap,
 } from '@open-cowork/shared'
 import {
   createCloudProjectionCheckpoint,
@@ -25,21 +23,31 @@ import { getAppDataDir } from '../config-loader.ts'
 import {
   readSafeStorageBackendForPolicy,
   resolveSecretStorageMode,
-  type SecretStorageMode,
 } from '../secure-storage-policy.ts'
-import { computeNextWorkflowRunAt, validateWorkflowSchedule } from './workflow-schedule.ts'
+import { computeNextWorkflowRunAt } from './workflow-schedule.ts'
+import {
+  assertWorkflowCapabilities,
+  isWorkflowTriggerType,
+  MAX_WORKFLOW_LIST_ITEMS,
+  normalizeWorkflowDraft,
+  previewWorkflowDraft as previewWorkflowDraftCalculation,
+  type WorkflowDraftNormalizationOptions,
+} from './workflow-normalization.ts'
+import {
+  parseWorkflowTriggersFromStorageWithAdapter,
+  serializeWorkflowTriggersForStorageWithAdapter,
+  type WorkflowSecretStorageAdapter,
+} from './workflow-secret-storage.ts'
 
 const WORKFLOW_DB_SCHEMA_VERSION = 1
 const WORKFLOW_SCHEMA_VERSION_KEY = 'schema_version'
 const WORKFLOW_PROJECTION_VERSION_KEY = 'workflow_projection_version'
 const LOCAL_WORKFLOW_PROJECTION_TENANT_ID = 'desktop-local'
-const MAX_TEXT = 32 * 1024
-const MAX_LIST_ITEMS = 50
 const VALID_STATUS = new Set<WorkflowStatus>(['active', 'paused', 'running', 'failed', 'archived'])
 const VALID_RUN_STATUS = new Set<WorkflowRunStatus>(['queued', 'running', 'completed', 'failed', 'cancelled'])
-const VALID_TRIGGER_TYPES = new Set<WorkflowTriggerType>(['manual', 'schedule', 'webhook'])
 
 let workflowDb: DatabaseSync | null = null
+let workflowDbForTests: DatabaseSync | null = null
 let transactionCounter = 0
 let workflowSecretStorageForTests: WorkflowSecretStorageAdapter | null = null
 
@@ -48,32 +56,11 @@ const electronSafeStorage = (electron as { safeStorage?: typeof import('electron
 const electronSafeStorageBackend = electronSafeStorage as (typeof import('electron').safeStorage & {
   getSelectedStorageBackend?: () => string
 }) | undefined
-const LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX = 'enc:v1:'
-const ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION = 2
 
 type DbRow = Record<string, unknown>
-type WorkflowWriteOptions = {
-  now?: Date
-  capabilities?: WorkflowCapabilityValidationContext
-}
-type WorkflowDraftOptions = {
-  now?: Date
-  capabilities?: WorkflowCapabilityValidationContext
-}
-export type WorkflowCapabilityValidationContext = {
-  agentNames?: readonly string[]
-  skillNames?: readonly string[]
-  toolIds?: readonly string[]
-}
-type WorkflowSecretStorageAdapter = {
-  mode: SecretStorageMode
-  encryptString?: (value: string) => Buffer
-  decryptString?: (value: Buffer) => string
-}
-type EncryptedWebhookSecretRecord = {
-  __openCoworkEncryptedWebhookSecret: typeof ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION
-  value: string
-}
+type WorkflowWriteOptions = WorkflowDraftNormalizationOptions
+type WorkflowDraftOptions = WorkflowDraftNormalizationOptions
+export type { WorkflowCapabilityValidationContext } from './workflow-normalization.ts'
 
 function workflowDbPath() {
   const dir = getAppDataDir()
@@ -87,23 +74,6 @@ function ensureWorkflowDbFileModes(dbPath = workflowDbPath()) {
     if (!existsSync(path)) continue
     chmodSync(path, 0o600)
   }
-}
-
-function boundedText(value: unknown, label: string, max = MAX_TEXT) {
-  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
-  const trimmed = value.trim()
-  if (!trimmed) throw new Error(`${label} is required.`)
-  if (Buffer.byteLength(trimmed, 'utf8') > max) throw new Error(`${label} is too large.`)
-  return trimmed
-}
-
-function boundedOptionalText(value: unknown, label: string, max = MAX_TEXT) {
-  if (value === null || value === undefined) return null
-  if (typeof value !== 'string') throw new Error(`${label} must be a string.`)
-  const trimmed = value.trim()
-  if (!trimmed) return null
-  if (Buffer.byteLength(trimmed, 'utf8') > max) throw new Error(`${label} is too large.`)
-  return trimmed
 }
 
 function parseJson<T>(value: unknown, fallback: T): T {
@@ -131,101 +101,32 @@ function getWorkflowSecretStorage(): WorkflowSecretStorageAdapter {
   }
 }
 
-function isEncryptedWebhookSecretRecord(value: unknown): value is EncryptedWebhookSecretRecord {
-  return Boolean(
-    value
-    && typeof value === 'object'
-    && !Array.isArray(value)
-    && (value as Partial<EncryptedWebhookSecretRecord>).__openCoworkEncryptedWebhookSecret === ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION
-    && typeof (value as Partial<EncryptedWebhookSecretRecord>).value === 'string',
-  )
-}
-
-function encryptWebhookSecretValue(storage: WorkflowSecretStorageAdapter, secret: string): EncryptedWebhookSecretRecord {
-  if (!storage.encryptString) throw new Error('Electron safeStorage is unavailable')
-  return {
-    __openCoworkEncryptedWebhookSecret: ENCRYPTED_WEBHOOK_SECRET_RECORD_VERSION,
-    value: Buffer.from(storage.encryptString(secret)).toString('base64'),
-  }
-}
-
-function tryDecryptWebhookSecretPayload(storage: WorkflowSecretStorageAdapter, payload: string) {
-  if (!storage.decryptString) return null
-  try {
-    return storage.decryptString(Buffer.from(payload, 'base64'))
-  } catch {
-    return null
-  }
-}
-
-function encodeWebhookSecretForStorage(secret: unknown): string | EncryptedWebhookSecretRecord | null {
-  if (isEncryptedWebhookSecretRecord(secret)) return secret
-  if (typeof secret !== 'string' || !secret) return null
-  const storage = getWorkflowSecretStorage()
-  if (storage.mode === 'encrypted') {
-    return encryptWebhookSecretValue(storage, secret)
-  }
-  if (storage.mode === 'plaintext') return secret
-  throw new Error('Secure storage unavailable on this system. Open Cowork cannot persist workflow webhook secrets in production without OS-backed secret storage.')
-}
-
-function decodeWebhookSecretFromStorage(secret: unknown) {
-  const storage = getWorkflowSecretStorage()
-  if (isEncryptedWebhookSecretRecord(secret)) {
-    return tryDecryptWebhookSecretPayload(storage, secret.value) ?? secret
-  }
-
-  if (typeof secret !== 'string' || !secret.trim()) return null
-  if (!secret.startsWith(LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX)) return secret
-
-  const legacyPayload = secret.slice(LEGACY_ENCRYPTED_WEBHOOK_SECRET_PREFIX.length)
-  const decrypted = tryDecryptWebhookSecretPayload(storage, legacyPayload)
-  // Older builds stored encrypted webhook secrets as strings prefixed with
-  // enc:v1:. If decryption fails, preserve the original value so an imported
-  // plaintext secret with that literal prefix still round-trips.
-  return decrypted ?? secret
-}
-
 export function serializeWorkflowTriggersForStorage(triggers: WorkflowTrigger[]) {
-  return JSON.stringify(triggers.map((trigger) => trigger.type === 'webhook'
-    ? { ...trigger, webhookSecret: encodeWebhookSecretForStorage(trigger.webhookSecret) }
-    : trigger))
+  return serializeWorkflowTriggersForStorageWithAdapter(triggers, getWorkflowSecretStorage())
 }
 
 export function parseWorkflowTriggersFromStorage(value: unknown) {
-  const parsed = parseJson<unknown>(value, [])
-  if (!Array.isArray(parsed)) return []
-  return parsed.flatMap((raw): WorkflowTrigger[] => {
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return []
-    const trigger = raw as Partial<WorkflowTrigger>
-    if (!VALID_TRIGGER_TYPES.has(trigger.type as WorkflowTriggerType)) return []
-    return [trigger.type === 'webhook'
-      ? { ...trigger, webhookSecret: decodeWebhookSecretFromStorage(trigger.webhookSecret) } as WorkflowTrigger
-      : trigger as WorkflowTrigger]
-  })
+  return parseWorkflowTriggersFromStorageWithAdapter(value, getWorkflowSecretStorage())
 }
 
 export function setWorkflowSecretStorageForTests(adapter: WorkflowSecretStorageAdapter | null) {
   workflowSecretStorageForTests = adapter
 }
 
-function normalizeStringList(value: unknown, label: string) {
-  if (value === null || value === undefined) return []
-  if (!Array.isArray(value)) throw new Error(`${label} must be an array.`)
-  return Array.from(new Set(value.map((item) => boundedText(item, `${label} entry`, 256)))).slice(0, MAX_LIST_ITEMS)
-}
-
-function randomSecret() {
-  return crypto.randomUUID().replace(/-/g, '') + crypto.randomUUID().replace(/-/g, '')
+export function setWorkflowDatabaseForTests(db: DatabaseSync | null) {
+  workflowDb?.close()
+  workflowDb = null
+  workflowDbForTests = db
+  transactionCounter = 0
+  if (db) initDb(db)
 }
 
 function writeNow(options?: WorkflowWriteOptions) {
   return options?.now ?? new Date()
 }
 
-function hasCapabilityReference(value: string, available?: readonly string[]) {
-  if (!available) return true
-  return available.includes(value)
+function randomWebhookSecret() {
+  return crypto.randomUUID().replace(/-/g, '') + crypto.randomUUID().replace(/-/g, '')
 }
 
 function projectDirectoryExists(directory: string) {
@@ -236,113 +137,11 @@ function projectDirectoryExists(directory: string) {
   }
 }
 
-export function validateWorkflowDraftCapabilities(
-  draft: WorkflowDraft,
-  capabilities?: WorkflowCapabilityValidationContext,
-): WorkflowValidationGap[] {
-  const gaps: WorkflowValidationGap[] = []
-
-  if (!hasCapabilityReference(draft.agentName, capabilities?.agentNames)) {
-    gaps.push({
-      severity: 'required',
-      field: 'agentName',
-      value: draft.agentName,
-      message: `Workflow agent "${draft.agentName}" is not available.`,
-    })
-  }
-
-  for (const skillName of draft.skillNames || []) {
-    if (hasCapabilityReference(skillName, capabilities?.skillNames)) continue
-    gaps.push({
-      severity: 'optional',
-      field: 'skillNames',
-      value: skillName,
-      message: `Workflow skill "${skillName}" is not available.`,
-    })
-  }
-
-  for (const toolId of draft.toolIds || []) {
-    if (hasCapabilityReference(toolId, capabilities?.toolIds)) continue
-    gaps.push({
-      severity: 'optional',
-      field: 'toolIds',
-      value: toolId,
-      message: `Workflow tool "${toolId}" is not available.`,
-    })
-  }
-
-  if (draft.projectDirectory && !projectDirectoryExists(draft.projectDirectory)) {
-    gaps.push({
-      severity: 'required',
-      field: 'projectDirectory',
-      value: draft.projectDirectory,
-      message: `Workflow project directory "${draft.projectDirectory}" is not available.`,
-    })
-  }
-
-  return gaps
-}
-
-function requiredWorkflowGaps(gaps: WorkflowValidationGap[]) {
-  return gaps.filter((gap) => gap.severity === 'required')
-}
-
-function assertWorkflowCapabilities(draft: WorkflowDraft, capabilities?: WorkflowCapabilityValidationContext) {
-  const gaps = validateWorkflowDraftCapabilities(draft, capabilities)
-  const required = requiredWorkflowGaps(gaps)
-  if (required.length > 0) throw new Error(required[0]!.message)
-  return gaps
-}
-
-export function normalizeWorkflowDraft(draft: WorkflowDraft, options?: WorkflowDraftOptions): WorkflowDraft {
-  const title = boundedText(draft.title, 'Workflow title', 512)
-  const instructions = boundedText(draft.instructions, 'Workflow instructions', MAX_TEXT)
-  const agentName = boundedText(draft.agentName || 'build', 'Workflow agent', 256)
-  const triggers = normalizeWorkflowTriggers(draft.triggers, options?.now ?? new Date())
-  if (!triggers.some((trigger) => trigger.type === 'manual')) {
-    triggers.unshift({ id: crypto.randomUUID(), type: 'manual', enabled: true })
-  }
+function workflowDraftOptions(options?: WorkflowDraftOptions): WorkflowDraftNormalizationOptions {
   return {
-    title,
-    instructions,
-    agentName,
-    skillNames: normalizeStringList(draft.skillNames, 'Workflow skillNames'),
-    toolIds: normalizeStringList(draft.toolIds, 'Workflow toolIds'),
-    projectDirectory: boundedOptionalText(draft.projectDirectory, 'Workflow projectDirectory', 4096),
-    draftSessionId: boundedOptionalText(draft.draftSessionId, 'Workflow draftSessionId', 256),
-    triggers,
+    ...options,
+    projectDirectoryExists: options?.projectDirectoryExists ?? projectDirectoryExists,
   }
-}
-
-function normalizeWorkflowTriggers(value: unknown, now: Date): WorkflowTrigger[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error('Workflow requires at least one trigger.')
-  }
-  return value.slice(0, 8).map((raw) => {
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('Workflow trigger must be an object.')
-    const trigger = raw as Partial<WorkflowTrigger>
-    const type = String(trigger.type || '')
-    if (!VALID_TRIGGER_TYPES.has(type as WorkflowTriggerType)) throw new Error('Workflow trigger type is invalid.')
-    const normalized: WorkflowTrigger = {
-      id: typeof trigger.id === 'string' && trigger.id.trim() ? trigger.id.trim() : crypto.randomUUID(),
-      type: type as WorkflowTriggerType,
-      enabled: trigger.enabled !== false,
-      schedule: null,
-      webhookSecret: null,
-    }
-    if (normalized.type === 'schedule') {
-      if (!trigger.schedule) throw new Error('Scheduled workflow trigger requires a schedule.')
-      const scheduleError = validateWorkflowSchedule(trigger.schedule, now)
-      if (scheduleError) throw new Error(scheduleError)
-      normalized.schedule = trigger.schedule
-    }
-    if (normalized.type === 'webhook') {
-      normalized.webhookSecret = typeof trigger.webhookSecret === 'string' && trigger.webhookSecret.trim()
-        ? trigger.webhookSecret.trim()
-        : randomSecret()
-    }
-    return normalized
-  })
 }
 
 function initDb(db: DatabaseSync) {
@@ -396,6 +195,7 @@ function initDb(db: DatabaseSync) {
 }
 
 export function getWorkflowDb() {
+  if (workflowDbForTests) return workflowDbForTests
   if (workflowDb) return workflowDb
   const dbPath = workflowDbPath()
   const db = new DatabaseSync(dbPath)
@@ -418,14 +218,14 @@ function withTransaction<T>(callback: (db: DatabaseSync) => T): T {
   try {
     const result = callback(db)
     db.exec(`release savepoint ${savepoint}`)
-    ensureWorkflowDbFileModes()
+    if (!workflowDbForTests) ensureWorkflowDbFileModes()
     return result
   } catch (error) {
     try {
       db.exec(`rollback to savepoint ${savepoint}`)
     } finally {
       db.exec(`release savepoint ${savepoint}`)
-      ensureWorkflowDbFileModes()
+      if (!workflowDbForTests) ensureWorkflowDbFileModes()
     }
     throw error
   }
@@ -526,8 +326,9 @@ function rowToWorkflow(row: DbRow, webhookBaseUrl?: string | null): WorkflowSumm
 
 function rowToRun(row: DbRow): WorkflowRun {
   const status = VALID_RUN_STATUS.has(String(row.status) as WorkflowRunStatus) ? String(row.status) as WorkflowRunStatus : 'queued'
-  const triggerType = VALID_TRIGGER_TYPES.has(String(row.trigger_type) as WorkflowTriggerType)
-    ? String(row.trigger_type) as WorkflowTriggerType
+  const rawTriggerType = String(row.trigger_type)
+  const triggerType = isWorkflowTriggerType(rawTriggerType)
+    ? rawTriggerType
     : 'manual'
   return {
     id: String(row.id || ''),
@@ -551,35 +352,8 @@ function listRunsForWorkflow(workflowId: string, limit = 25) {
   return rows.map(rowToRun)
 }
 
-export function previewWorkflowDraft(draft: WorkflowDraft, options?: WorkflowDraftOptions): WorkflowToolPreview {
-  try {
-    const now = options?.now ?? new Date()
-    const normalizedDraft = normalizeWorkflowDraft(draft, { ...options, now })
-    const gaps = validateWorkflowDraftCapabilities(normalizedDraft, options?.capabilities)
-    const missing = requiredWorkflowGaps(gaps).map((gap) => gap.message)
-    return {
-      ok: missing.length === 0,
-      title: normalizedDraft.title,
-      summary: normalizedDraft.instructions.slice(0, 500),
-      missing,
-      gaps,
-      normalizedDraft,
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Workflow draft is invalid.'
-    return {
-      ok: false,
-      title: typeof draft.title === 'string' ? draft.title : 'Workflow draft',
-      summary: message,
-      missing: [message],
-      gaps: [{
-        severity: 'required',
-        field: 'draft',
-        value: '',
-        message,
-      }],
-    }
-  }
+export function previewWorkflowDraft(draft: WorkflowDraft, options?: WorkflowDraftOptions) {
+  return previewWorkflowDraftCalculation(draft, workflowDraftOptions(options))
 }
 
 export function listWorkflows(webhookBaseUrl?: string | null): WorkflowListPayload {
@@ -601,8 +375,8 @@ export function getWorkflow(workflowId: string, webhookBaseUrl?: string | null):
 
 export function createWorkflow(draft: WorkflowDraft, webhookBaseUrl?: string | null, options?: WorkflowWriteOptions): WorkflowDetail {
   const nowDate = writeNow(options)
-  const normalized = normalizeWorkflowDraft(draft, { ...options, now: nowDate })
-  assertWorkflowCapabilities(normalized, options?.capabilities)
+  const normalized = normalizeWorkflowDraft(draft, workflowDraftOptions({ ...options, now: nowDate }))
+  assertWorkflowCapabilities(normalized, workflowDraftOptions(options))
   const now = nowDate.toISOString()
   const id = crypto.randomUUID()
   const nextRunAt = computeNextWorkflowRunAt(normalized.triggers, nowDate)
@@ -652,7 +426,7 @@ export function regenerateWorkflowWebhookSecret(workflowId: string, webhookBaseU
   const detail = getWorkflow(workflowId, webhookBaseUrl)
   if (!detail) return null
   const triggers = detail.triggers.map((trigger) => trigger.type === 'webhook'
-    ? { ...trigger, webhookSecret: randomSecret() }
+    ? { ...trigger, webhookSecret: randomWebhookSecret() }
     : trigger)
   const now = new Date().toISOString()
   withTransaction((db) => {
@@ -703,7 +477,7 @@ export function createWorkflowRun(workflowId: string, triggerType: WorkflowTrigg
 export function claimDueWorkflowRun(now = new Date()) {
   const claimedAt = now.toISOString()
   return withTransaction((db) => {
-    for (let attempt = 0; attempt < MAX_LIST_ITEMS; attempt += 1) {
+    for (let attempt = 0; attempt < MAX_WORKFLOW_LIST_ITEMS; attempt += 1) {
       const row = db.prepare(`
         select * from workflows
         where status = 'active'
@@ -872,4 +646,6 @@ export function recoverInterruptedWorkflowRuns(error = 'Workflow run was interru
 export function clearWorkflowStoreCache() {
   workflowDb?.close()
   workflowDb = null
+  workflowDbForTests = null
+  transactionCounter = 0
 }

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -18,6 +18,7 @@ import {
   getPublicAppConfig,
   getProviderDescriptors,
 } from '../apps/desktop/src/main/config-loader.ts'
+import { normalizeConfigLayers } from '../apps/desktop/src/main/config-normalizer.ts'
 
 test('open core ships with built-in tools, skills, mcps, and agents configured by default', () => {
   const tools = getConfiguredToolsFromConfig()
@@ -405,6 +406,49 @@ test('config loader applies per-user config after downstream env layers', () => 
     clearConfigCaches()
     rmSync(tempRoot, { recursive: true, force: true })
   }
+})
+
+test('config normalization applies layer precedence without loader state', () => {
+  const config = normalizeConfigLayers([
+    {
+      branding: {
+        dataDirName: 'calculation-data',
+        helpUrl: 'https://downstream.example/help',
+      },
+      cloud: {
+        role: 'worker',
+        defaultProfile: 'focused-agent',
+        profiles: {
+          'focused-agent': {
+            agents: ['data-analyst'],
+            features: {
+              workflows: false,
+            },
+          },
+        },
+      },
+      permissions: {
+        webSearch: true,
+      },
+    },
+    {
+      branding: {
+        helpUrl: 'https://user.example/help',
+      },
+      permissions: {
+        webSearch: false,
+      },
+    },
+  ])
+
+  assert.equal(config.branding.dataDirName, 'calculation-data')
+  assert.equal(config.branding.helpUrl, 'https://user.example/help')
+  assert.equal(config.permissions.webSearch, false)
+  assert.equal(config.cloud.role, 'worker')
+  assert.equal(config.cloud.defaultProfile, 'focused-agent')
+  assert.equal(config.cloud.profiles['focused-agent']?.agents?.[0], 'data-analyst')
+  assert.equal(config.cloud.profiles['focused-agent']?.features?.workflows, false)
+  assert.equal(config.cloud.runtime.configSource, 'app')
 })
 
 test('public branding keeps logoDataUrl fallback when logoAsset cannot resolve', () => {

--- a/tests/custom-mcp-store.test.ts
+++ b/tests/custom-mcp-store.test.ts
@@ -1,10 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { clearConfigCaches } from '../apps/desktop/src/main/config-loader.ts'
 import { listCustomMcps, removeCustomMcp, saveCustomMcp } from '../apps/desktop/src/main/native-customizations.ts'
+import { getMachineOpencodeConfigPath, getMachineOpencodeDir } from '../apps/desktop/src/main/runtime-paths.ts'
 
 function withTempUserData<T>(fn: () => T): T {
   const root = mkdtempSync(join(tmpdir(), 'open-cowork-custom-mcp-store-'))
@@ -76,4 +77,35 @@ test('custom MCP store rejects incomplete MCP definitions before writing', () =>
     })
   }, /Remote MCPs require a URL/)
   assert.equal(listCustomMcps().some((entry) => entry.name === 'broken'), false)
+}))
+
+test('custom MCP store rolls back OpenCode config when metadata write fails', () => withTempUserData(() => {
+  const metadataPath = join(getMachineOpencodeDir(), 'mcp.open-cowork.json')
+  mkdirSync(metadataPath, { recursive: true })
+
+  assert.throws(() => {
+    saveCustomMcp({
+      scope: 'machine',
+      directory: null,
+      name: 'rollback-mcp',
+      label: 'Rollback MCP',
+      type: 'http',
+      url: 'https://example.com/rollback-mcp',
+    })
+  }, /metadata write failed.*restored previous MCP config/i)
+
+  assert.equal(listCustomMcps().some((entry) => entry.name === 'rollback-mcp'), false)
+  if (existsSync(getMachineOpencodeConfigPath())) {
+    const config = JSON.parse(readFileSync(getMachineOpencodeConfigPath(), 'utf8'))
+    assert.equal(Boolean(config.mcp?.['rollback-mcp']), false)
+  }
+}))
+
+test('custom MCP store repairs stale metadata sidecar entries during load', () => withTempUserData(() => {
+  const metadataPath = join(getMachineOpencodeDir(), 'mcp.open-cowork.json')
+  mkdirSync(getMachineOpencodeDir(), { recursive: true })
+  writeFileSync(metadataPath, `${JSON.stringify({ ghost: { label: 'Ghost MCP' } }, null, 2)}\n`)
+
+  assert.deepEqual(listCustomMcps(), [])
+  assert.equal(existsSync(metadataPath), false)
 }))

--- a/tests/vega-chart-utils.test.ts
+++ b/tests/vega-chart-utils.test.ts
@@ -228,6 +228,34 @@ test('makeInteractiveVegaSpecResponsive gives dense horizontal bar charts more v
   assert.equal(yAxis.labelPadding, 10)
 })
 
+test('makeInteractiveVegaSpecResponsive does not mutate nested encoding structures', () => {
+  const spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+    mark: 'bar',
+    data: {
+      values: [
+        { category: 'A', total: 2, region: 'North' },
+        { category: 'B', total: 4, region: 'South' },
+      ],
+    },
+    encoding: {
+      x: { field: 'total', type: 'quantitative', axis: { title: 'Total' } },
+      y: { field: 'category', type: 'nominal', axis: { title: 'Category' } },
+      color: { field: 'region', type: 'nominal', legend: { title: 'Region' } },
+    },
+  }
+  const original = JSON.parse(JSON.stringify(spec))
+
+  const responsive = makeInteractiveVegaSpecResponsive(spec)
+  const yAxis = (responsive.encoding as Record<string, any>).y.axis
+  const colorLegend = (responsive.encoding as Record<string, any>).color.legend
+
+  assert.deepEqual(spec, original)
+  assert.equal(yAxis.labelLimit, 320)
+  assert.equal(colorLegend.orient, 'right')
+  assert.equal(colorLegend.title, 'Region')
+})
+
 test('makeInteractiveVegaSpecResponsive keeps arc legends readable in chat layouts', () => {
   const spec = {
     $schema: 'https://vega.github.io/schema/vega-lite/v6.json',

--- a/tests/workflow-store.test.ts
+++ b/tests/workflow-store.test.ts
@@ -24,9 +24,14 @@ import {
   recoverInterruptedWorkflowRuns,
   parseWorkflowTriggersFromStorage,
   serializeWorkflowTriggersForStorage,
+  setWorkflowDatabaseForTests,
   setWorkflowSecretStorageForTests,
   updateWorkflowStatus,
 } from '../apps/desktop/src/main/workflow/workflow-store.ts'
+import {
+  normalizeWorkflowDraft,
+  previewWorkflowDraft as previewWorkflowDraftCalculation,
+} from '../apps/desktop/src/main/workflow/workflow-normalization.ts'
 import {
   createWorkflowFromTool,
   previewWorkflowFromTool,
@@ -196,6 +201,57 @@ test('workflow store preserves encrypted webhook secret records when decryption 
   const serialized = JSON.parse(serializeWorkflowTriggersForStorage(parsed)) as Array<{ webhookSecret?: unknown }>
   assert.deepEqual(serialized[0]?.webhookSecret, storedSecret)
 }))
+
+test('workflow normalization uses explicit calculation adapters', () => {
+  const normalized = normalizeWorkflowDraft({
+    ...draft,
+    projectDirectory: ' /tmp/project ',
+    triggers: [{ id: '', type: 'webhook', enabled: true }],
+  }, {
+    now: new Date('2026-05-15T08:00:00.000Z'),
+    idGenerator: () => 'generated-id',
+    secretGenerator: () => 'generated-secret',
+  })
+
+  assert.equal(normalized.projectDirectory, '/tmp/project')
+  assert.deepEqual(normalized.triggers.map((trigger) => `${trigger.id}:${trigger.type}`), [
+    'generated-id:manual',
+    'generated-id:webhook',
+  ])
+  assert.equal(normalized.triggers.find((trigger) => trigger.type === 'webhook')?.webhookSecret, 'generated-secret')
+
+  const preview = previewWorkflowDraftCalculation({
+    ...draft,
+    projectDirectory: '/missing/project',
+    triggers: [{ id: 'manual', type: 'manual', enabled: true }],
+  }, {
+    projectDirectoryExists: () => false,
+  })
+
+  assert.equal(preview.ok, false)
+  assert.deepEqual(preview.missing, ['Workflow project directory "/missing/project" is not available.'])
+})
+
+test('workflow store accepts explicit database and secret adapters in tests', () => {
+  const db = new DatabaseSync(':memory:')
+  try {
+    setWorkflowDatabaseForTests(db)
+    setWorkflowSecretStorageForTests({ mode: 'plaintext' })
+    const workflow = createWorkflow({
+      ...draft,
+      skillNames: [],
+      toolIds: [],
+      triggers: [{ id: 'manual', type: 'manual', enabled: true }],
+    }, null, { now: new Date('2026-05-15T08:00:00.000Z') })
+
+    assert.equal(workflow.title, 'Inbox summary')
+    assert.equal(listWorkflows().workflows[0]?.id, workflow.id)
+  } finally {
+    setWorkflowSecretStorageForTests(null)
+    clearWorkflowStoreCache()
+    db.close()
+  }
+})
 
 test('workflow store treats valid non-array trigger JSON as empty', () => withWorkflowStore('non-array-triggers', () => {
   assert.deepEqual(parseWorkflowTriggersFromStorage('{}'), [])


### PR DESCRIPTION
## Summary
- defensively clone nested Vega-Lite encoding structures before responsive transforms mutate chart settings
- make custom MCP config/metadata saves recoverable with rollback and stale metadata repair
- extract config normalization into pure calculation helpers while keeping file/env/Electron work in the loader
- extract workflow normalization and webhook secret storage from SQLite persistence, with explicit test adapters

Closes #681.
Closes #685.
Closes #687.
Closes #688.

## Validation
- node scripts/run-node-tests.mjs tests/vega-chart-utils.test.ts tests/custom-mcp-store.test.ts tests/config-elements.test.ts tests/workflow-store.test.ts
- pnpm typecheck
- pnpm --filter @open-cowork/desktop build:electron
- pnpm lint
- pnpm test
- pnpm test:e2e
- git diff --check