### PR TITLE
Add typography, icon, and primitive systems

### DIFF
--- a/THIRD_PARTY_LICENSES/@fontsource-variable__hubot-sans@5.2.8/LICENSE
+++ b/THIRD_PARTY_LICENSES/@fontsource-variable__hubot-sans@5.2.8/LICENSE
@@ -1,0 +1,93 @@
+Copyright 2021 The Hubot Sans Project Authors (https://github.com/github/hubot-sans), with Reserved Font Name "Hubot" HubotSans-Italic[wdth,wght].ttf: Copyright 2021 The Hubot Sans Project Authors (https://github.com/github/hubot-sans), with Reserved Font Name "Hubot"
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/THIRD_PARTY_LICENSES/@fontsource-variable__mona-sans@5.2.8/LICENSE
+++ b/THIRD_PARTY_LICENSES/@fontsource-variable__mona-sans@5.2.8/LICENSE
@@ -1,0 +1,93 @@
+Copyright 2022 The Mona Sans Project Authors (https://github.com/github/mona-sans), with Reserved Font Name "Mona" MonaSans-Italic[wdth,wght].ttf: Copyright 2022 The Mona Sans Project Authors (https://github.com/github/mona-sans), with Reserved Font Name "Mona"
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/THIRD_PARTY_LICENSES/lucide-react@1.17.0/LICENSE
+++ b/THIRD_PARTY_LICENSES/lucide-react@1.17.0/LICENSE
@@ -1,0 +1,43 @@
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following Lucide icons are derived from the Feather project:
+
+airplay, alert-circle, alert-octagon, alert-triangle, aperture, arrow-down-circle, arrow-down-left, arrow-down-right, arrow-down, arrow-left-circle, arrow-left, arrow-right-circle, arrow-right, arrow-up-circle, arrow-up-left, arrow-up-right, arrow-up, at-sign, calendar, cast, check, chevron-down, chevron-left, chevron-right, chevron-up, chevrons-down, chevrons-left, chevrons-right, chevrons-up, circle, clipboard, clock, code, columns, command, compass, corner-down-left, corner-down-right, corner-left-down, corner-left-up, corner-right-down, corner-right-up, corner-up-left, corner-up-right, crosshair, database, divide-circle, divide-square, dollar-sign, download, external-link, feather, frown, hash, headphones, help-circle, info, italic, key, layout, life-buoy, link-2, link, loader, lock, log-in, log-out, maximize, meh, minimize, minimize-2, minus-circle, minus-square, minus, monitor, moon, more-horizontal, more-vertical, move, music, navigation-2, navigation, octagon, pause-circle, percent, plus-circle, plus-square, plus, power, radio, rss, search, server, share, shopping-bag, sidebar, smartphone, smile, square, table-2, tablet, target, terminal, trash-2, trash, triangle, tv, type, upload, x-circle, x-octagon, x-square, x, zoom-in, zoom-out
+
+The MIT License (MIT) (for the icons listed above)
+
+Copyright (c) 2013-present Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,9 +3,9 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `3ee91209b38cfb0b6a94e518bb0a8335719487a78814d7e0202f5e6b861aadea`
-- Production package entries: 503
-- Bundled license directories: 460 (43 package entries have no standalone license file or are workspace links)
+- pnpm lockfile SHA-256: `c288e00c8bd6a6ca3fde39fa1426c76a8242feb3e55f55369b0eb3098a30116c`
+- Production package entries: 506
+- Bundled license directories: 463 (43 package entries have no standalone license file or are workspace links)
 
 Each package remains licensed under its own license terms. The table below is provided for attribution and review; bundled license files are emitted under `THIRD_PARTY_LICENSES/`.
 
@@ -45,6 +45,8 @@ Each package remains licensed under its own license terms. The table below is pr
 | @aws/lambda-invoke-store | 0.2.4 | Apache-2.0 | THIRD_PARTY_LICENSES/@aws__lambda-invoke-store@0.2.4/ | git+https://github.com/awslabs/aws-lambda-invoke-store.git |
 | @braintree/sanitize-url | 7.1.2 | MIT | THIRD_PARTY_LICENSES/@braintree__sanitize-url@7.1.2/ | git+https://github.com/braintree/sanitize-url.git |
 | @chevrotain/types | 11.1.2 | Apache-2.0 | THIRD_PARTY_LICENSES/@chevrotain__types@11.1.2/ | git://github.com/Chevrotain/chevrotain.git |
+| @fontsource-variable/hubot-sans | 5.2.8 | OFL-1.1 | THIRD_PARTY_LICENSES/@fontsource-variable__hubot-sans@5.2.8/ | git+https://github.com/fontsource/font-files.git |
+| @fontsource-variable/mona-sans | 5.2.8 | OFL-1.1 | THIRD_PARTY_LICENSES/@fontsource-variable__mona-sans@5.2.8/ | git+https://github.com/fontsource/font-files.git |
 | @grammyjs/types | 3.27.3 | MIT | THIRD_PARTY_LICENSES/@grammyjs__types@3.27.3/ | git+https://github.com/grammyjs/types.git |
 | @hono/node-server | 1.19.13 | MIT | THIRD_PARTY_LICENSES/@hono__node-server@1.19.13/ | https://github.com/honojs/node-server.git |
 | @iconify/types | 2.0.0 | MIT | THIRD_PARTY_LICENSES/@iconify__types@2.0.0/ | https://github.com/iconify/iconify.git |
@@ -297,6 +299,7 @@ Each package remains licensed under its own license terms. The table below is pr
 | lodash.escaperegexp | 4.1.2 | MIT | THIRD_PARTY_LICENSES/lodash.escaperegexp@4.1.2/ | lodash/lodash |
 | lodash.isequal | 4.5.0 | MIT | THIRD_PARTY_LICENSES/lodash.isequal@4.5.0/ | lodash/lodash |
 | longest-streak | 3.1.0 | MIT | THIRD_PARTY_LICENSES/longest-streak@3.1.0/ | wooorm/longest-streak |
+| lucide-react | 1.17.0 | ISC | THIRD_PARTY_LICENSES/lucide-react@1.17.0/ | https://github.com/lucide-icons/lucide.git |
 | markdown-table | 3.0.4 | MIT | THIRD_PARTY_LICENSES/markdown-table@3.0.4/ | wooorm/markdown-table |
 | marked | 16.4.2 | MIT | THIRD_PARTY_LICENSES/marked@16.4.2/ | git://github.com/markedjs/marked.git |
 | marked | 18.0.3 | MIT | THIRD_PARTY_LICENSES/marked@18.0.3/ | git://github.com/markedjs/marked.git |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1054.0",
+    "@fontsource-variable/hubot-sans": "^5.2.8",
+    "@fontsource-variable/mona-sans": "^5.2.8",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "1.15.5",
     "@tanstack/react-virtual": "^3.13.24",
@@ -40,6 +42,7 @@
     "dompurify": "^3.4.6",
     "electron-updater": "^6.8.3",
     "google-auth-library": "^10.6.2",
+    "lucide-react": "^1.17.0",
     "marked": "^18.0.3",
     "mermaid": "^11.15.0",
     "morphdom": "^2.7.8",

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -18,6 +18,7 @@ const WorkflowsPage = lazy(() => import('./components/workflows/WorkflowsPage').
 const AgentsPage = lazy(() => import('./components/agents/AgentsPage').then((m) => ({ default: m.AgentsPage })))
 const CapabilitiesPage = lazy(() => import('./components/capabilities/CapabilitiesPage').then((m) => ({ default: m.CapabilitiesPage })))
 const HealthCenterPage = lazy(() => import('./components/health/HealthCenterPage').then((m) => ({ default: m.HealthCenterPage })))
+const PrimitiveGallery = lazy(() => import('./components/ui/PrimitiveGallery').then((m) => ({ default: m.PrimitiveGallery })))
 const CommandPalette = lazy(() => import('./components/CommandPalette').then((m) => ({ default: m.CommandPalette })))
 import { useSessionStore } from './stores/session'
 import { useOpenCodeEvents } from './hooks/useOpenCodeEvents'
@@ -39,6 +40,13 @@ import {
 } from './resource-navigation'
 
 type AgentBuilderSeed = Partial<CustomAgentConfig> | null
+
+const UI_PRIMITIVES_HASH = '#/ui-primitives'
+
+function initialAppView(): AppView {
+  if (typeof window !== 'undefined' && window.location.hash === UI_PRIMITIVES_HASH) return 'ui-primitives'
+  return 'home'
+}
 
 type ResourceNavigationNotice = {
   status: ResourceNavigationAction['status'] | 'invalid'
@@ -103,7 +111,7 @@ export function App() {
   const [authenticated, setAuthenticated] = useState(false)
   const [needsSetup, setNeedsSetup] = useState(false)
   const [userEmail, setUserEmail] = useState('')
-  const [view, setView] = useState<AppView>('home')
+  const [view, setView] = useState<AppView>(initialAppView)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [agentBuilderSeed, setAgentBuilderSeed] = useState<AgentBuilderSeed>(null)
   const [pendingComposerInsert, setPendingComposerInsert] = useState<string | null>(null)
@@ -367,6 +375,14 @@ export function App() {
     window.addEventListener('open-cowork:open-resource', listener)
     return () => window.removeEventListener('open-cowork:open-resource', listener)
   }, [openResourceNavigationTarget])
+
+  useEffect(() => {
+    const listener = () => {
+      if (window.location.hash === UI_PRIMITIVES_HASH) setView('ui-primitives')
+    }
+    window.addEventListener('hashchange', listener)
+    return () => window.removeEventListener('hashchange', listener)
+  }, [])
 
   // If the current thread disappears while the chat view is active —
   // deleted from the sidebar, reset, or reverted to null by a runtime
@@ -661,6 +677,11 @@ export function App() {
             {view === 'health' && (
               <Suspense fallback={null}>
                 <HealthCenterPage />
+              </Suspense>
+            )}
+            {view === 'ui-primitives' && (
+              <Suspense fallback={null}>
+                <PrimitiveGallery />
               </Suspense>
             )}
           </ViewErrorBoundary>

--- a/apps/desktop/src/renderer/app-types.ts
+++ b/apps/desktop/src/renderer/app-types.ts
@@ -1,1 +1,1 @@
-export type AppView = 'home' | 'chat' | 'threads' | 'workflows' | 'agents' | 'capabilities' | 'health'
+export type AppView = 'home' | 'chat' | 'threads' | 'workflows' | 'agents' | 'capabilities' | 'health' | 'ui-primitives'

--- a/apps/desktop/src/renderer/components/HomePage.test.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.test.tsx
@@ -168,7 +168,7 @@ describe('HomePage', () => {
     )
 
     expect(await screen.findByRole('button', { name: /Claude Sonnet 4/ })).toBeTruthy()
-    expect(screen.getByTitle('Attach file')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Attach file' })).toBeTruthy()
     await user.click(screen.getByRole('button', { name: 'Build' }))
     expect(screen.getByRole('button', { name: 'Plan' })).toBeTruthy()
 

--- a/apps/desktop/src/renderer/components/HomePage.tsx
+++ b/apps/desktop/src/renderer/components/HomePage.tsx
@@ -684,7 +684,7 @@ export function HomePage({ brandName, homeBranding, onStartThread, onOpenThread 
       <HomeBackdrop />
       <div className="relative max-w-[760px] mx-auto px-6 pt-[clamp(72px,13vh,142px)] pb-16 flex flex-col items-center">
         <HomeEyebrow brandName={brandName} />
-        <h1 className="text-[30px] sm:text-[38px] leading-[1.08] font-semibold text-text text-center">
+        <h1 className="font-display text-role-hero font-bold text-text text-center">
           {greeting}
         </h1>
         <p className="mt-3 text-[13px] text-text-muted text-center">

--- a/apps/desktop/src/renderer/components/agents/AgentsPage.tsx
+++ b/apps/desktop/src/renderer/components/agents/AgentsPage.tsx
@@ -235,7 +235,7 @@ export function AgentsPage({
       <div className="max-w-[1200px] mx-auto px-8 py-8">
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h1 className="text-[18px] font-semibold text-text">{t('agentsPage.title', 'Agents')}</h1>
+            <h1 className="font-display text-role-page-title font-bold text-text">{t('agentsPage.title', 'Agents')}</h1>
             <p className="text-[13px] text-text-secondary mt-1">
               {t('agentsPage.subtitle', 'Compose specialists from skills, tools, and instructions. Click any card to open it in the builder.')}
             </p>
@@ -436,7 +436,7 @@ function ListSection({
   return (
     <section className="mb-8">
       <div className="mb-3">
-        <h2 className="text-[14px] font-semibold text-text">{label}</h2>
+        <h2 className="font-display text-role-section-title font-bold text-text">{label}</h2>
         <p className="text-[12px] text-text-muted mt-0.5">{sublabel}</p>
       </div>
       {empty ? (

--- a/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.tsx
+++ b/apps/desktop/src/renderer/components/capabilities/CapabilitiesPage.tsx
@@ -303,7 +303,7 @@ export function CapabilitiesPage({
       <div className="max-w-[1200px] mx-auto px-8 py-8">
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h1 className="text-[18px] font-semibold text-text">{t('capabilities.title', 'Tools & Skills')}</h1>
+            <h1 className="font-display text-role-page-title font-bold text-text">{t('capabilities.title', 'Tools & Skills')}</h1>
             <p className="text-[13px] text-text-secondary mt-1">
               {t('capabilities.subtitle', 'Inspect the tools and skill bundles available in the current OpenCode context, including bundled, machine, project, and custom additions.')}
             </p>
@@ -505,7 +505,7 @@ function CapabilitySectionHeading({
   return (
     <div className="flex flex-wrap items-end justify-between gap-2 px-0.5">
       <div>
-        <h2 className="text-[12px] font-semibold uppercase tracking-[0.08em] text-text-muted">{section.label}</h2>
+        <h2 className="font-display text-role-card-title font-bold text-text">{section.label}</h2>
         <p className="mt-0.5 text-[11px] text-text-muted">{section.description}</p>
       </div>
       <span className="text-[10px] text-text-muted">

--- a/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInput.test.tsx
@@ -377,7 +377,7 @@ describe('ChatInput', () => {
     render(<ChatInput />)
 
     expect(await screen.findByRole('button', { name: /Model A/ })).toBeDisabled()
-    expect(screen.getByTitle('Cloud workspaces do not implicitly upload local files.')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cloud workspaces do not implicitly upload local files.' })).toBeDisabled()
 
     const textarea = screen.getByRole('textbox')
     fireEvent.change(textarea, { target: { value: 'Continue in cloud' } })

--- a/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputToolbar.test.tsx
@@ -39,7 +39,7 @@ describe('ChatInputToolbar', () => {
     const clickSpy = vi.spyOn(input, 'click')
     const file = new File(['hello'], 'notes.txt', { type: 'text/plain' })
 
-    fireEvent.click(screen.getByTitle('Attach file'))
+    fireEvent.click(screen.getByRole('button', { name: 'Attach file' }))
     expect(clickSpy).toHaveBeenCalledTimes(1)
 
     Object.defineProperty(input, 'files', {
@@ -55,8 +55,8 @@ describe('ChatInputToolbar', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Claude Sonnet/i }))
     fireEvent.click(screen.getByRole('button', { name: /Build/i }))
-    fireEvent.click(screen.getByTitle('Fork thread'))
-    fireEvent.click(screen.getAllByRole('button').at(-1)!)
+    fireEvent.click(screen.getByRole('button', { name: 'Fork thread' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
 
     expect(props.onToggleModelMenu).toHaveBeenCalledTimes(1)
     expect(props.onToggleAgentMode).toHaveBeenCalledTimes(1)
@@ -83,8 +83,8 @@ describe('ChatInputToolbar', () => {
   it('routes stop actions while generating', () => {
     const { props } = renderToolbar({ isGenerating: true })
 
-    fireEvent.click(screen.getByTitle('Stop generating (Esc)'))
-    fireEvent.click(screen.getAllByRole('button').at(-1)!)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Stop generating (Esc)' })[0])
+    fireEvent.click(screen.getAllByRole('button', { name: 'Stop generating (Esc)' })[1])
 
     expect(props.onStop).toHaveBeenCalledTimes(2)
     expect(props.onSubmit).not.toHaveBeenCalled()

--- a/apps/desktop/src/renderer/components/chat/ChatInputToolbar.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatInputToolbar.tsx
@@ -1,5 +1,6 @@
 import type { RefObject } from 'react'
 import { t } from '../../helpers/i18n'
+import { Icon } from '../ui'
 
 type ChatInputToolbarProps = {
   fileInputRef: RefObject<HTMLInputElement | null>
@@ -62,18 +63,15 @@ export function ChatInputToolbar({
     <div className="flex items-center justify-between px-3 pb-2.5 pt-0.5">
       <div className="flex items-center gap-1">
         <button
+          aria-label={attachmentsAllowed ? t('chat.attachFile', 'Attach file') : attachmentsDisabledReason || t('chat.attachFileDisabled', 'File attachments are disabled by this workspace policy.')}
           onClick={() => {
             if (!attachmentsAllowed) return
             fileInputRef.current?.click()
           }}
           disabled={!attachmentsAllowed}
           className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-          title={attachmentsAllowed ? t('chat.attachFile', 'Attach file') : attachmentsDisabledReason || t('chat.attachFileDisabled', 'File attachments are disabled by this workspace policy.')}
         >
-          <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
-            <line x1="7.5" y1="3" x2="7.5" y2="12" />
-            <line x1="3" y1="7.5" x2="12" y2="7.5" />
-          </svg>
+          <Icon name="paperclip" size={16} />
         </button>
         <input
           ref={fileInputRef}
@@ -97,9 +95,7 @@ export function ChatInputToolbar({
             className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer flex items-center gap-1 disabled:opacity-60 disabled:cursor-not-allowed"
           >
             {modelLabel}
-            <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.2">
-              <polyline points="2,3 4,5.5 6,3" />
-            </svg>
+            <Icon name="chevron-down" size={16} />
           </button>
         </div>
 
@@ -112,9 +108,7 @@ export function ChatInputToolbar({
             title={reasoningControlsManaged ? modelControlsReason || t('chat.reasoningManagedByPolicy', 'This workspace manages reasoning settings.') : t('chat.reasoningDescription', 'Reasoning mode for models that expose OpenCode variants')}
           >
             {t('chat.reasoningChip', 'Think')} {reasoningLabel || t('chat.reasoningAuto', 'Auto')}
-            <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.2">
-              <polyline points="2,3 4,5.5 6,3" />
-            </svg>
+            <Icon name="chevron-down" size={16} />
           </button>
         ) : null}
 
@@ -124,9 +118,7 @@ export function ChatInputToolbar({
             style={{ maxWidth: 160 }}
             title={currentDirectory}
           >
-            <svg width="10" height="10" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" className="shrink-0">
-              <path d="M2 3.5C2 2.67 2.67 2 3.5 2H5.5L7 3.5H10.5C11.33 3.5 12 4.17 12 5V10.5C12 11.33 11.33 12 10.5 12H3.5C2.67 12 2 11.33 2 10.5V3.5Z" />
-            </svg>
+            <Icon name="folder" size={16} className="shrink-0" />
             {currentDirectory.split('/').pop()}
           </span>
         ) : null}
@@ -141,38 +133,30 @@ export function ChatInputToolbar({
           title={agentMode === 'plan' ? t('chat.planModeDescription', 'Plan mode: read-only analysis and audits') : t('chat.buildModeDescription', 'Build mode: full-access work and delegation')}
         >
           {agentMode === 'plan' ? t('chat.planMode', 'Plan') : t('chat.buildMode', 'Build')}
-          <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.2">
-            <polyline points="2,3 4,5.5 6,3" />
-          </svg>
+          <Icon name="chevron-down" size={16} />
         </button>
       </div>
 
       <div className="flex items-center gap-1.5">
         {currentSessionId && !isGenerating && !isAwaitingPermission && !isAwaitingQuestion ? (
           <button
+            aria-label={t('chat.forkThread', 'Fork thread')}
             onClick={() => void onFork()}
             className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-colors cursor-pointer"
             title={t('chat.forkThread', 'Fork thread')}
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
-              <line x1="7" y1="2" x2="7" y2="8" />
-              <line x1="4" y1="5" x2="7" y2="8" />
-              <line x1="10" y1="5" x2="7" y2="8" />
-              <line x1="4" y1="8" x2="4" y2="12" />
-              <line x1="10" y1="8" x2="10" y2="12" />
-            </svg>
+            <Icon name="git-fork" size={16} />
           </button>
         ) : null}
 
         {isGenerating ? (
           <button
+            aria-label={t('chat.stopGenerating', 'Stop generating (Esc)')}
             onClick={() => void onStop()}
             className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-red hover:bg-red/10 transition-colors cursor-pointer"
             title={t('chat.stopGenerating', 'Stop generating (Esc)')}
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
-              <rect x="3" y="3" width="8" height="8" rx="1.5" />
-            </svg>
+            <Icon name="square" size={16} />
           </button>
         ) : null}
 
@@ -203,6 +187,7 @@ export function ChatInputToolbar({
         ) : null}
 
         <button
+          aria-label={isGenerating ? t('chat.stopGenerating', 'Stop generating (Esc)') : t('chat.send', 'Send message')}
           onClick={() => void (isGenerating ? onStop() : onSubmit())}
           disabled={!canSend && !isGenerating}
           title={!canSend && !isGenerating ? sendDisabledReason || undefined : undefined}
@@ -217,10 +202,7 @@ export function ChatInputToolbar({
           {isGenerating ? (
             <span className="w-2 h-2 rounded-full bg-accent animate-pulse" />
           ) : (
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-              <line x1="7" y1="11" x2="7" y2="3" />
-              <polyline points="3.5,6 7,2.5 10.5,6" />
-            </svg>
+            <Icon name="arrow-up" size={16} />
           )}
         </button>
       </div>

--- a/apps/desktop/src/renderer/components/command-palette-items.ts
+++ b/apps/desktop/src/renderer/components/command-palette-items.ts
@@ -11,7 +11,7 @@ import type {
 import { formatAgentLabel } from '../helpers/agent-label.ts'
 import { compactDescription } from '../helpers/format.ts'
 
-export type View = 'home' | 'chat' | 'threads' | 'workflows' | 'agents' | 'capabilities' | 'health'
+export type View = 'home' | 'chat' | 'threads' | 'workflows' | 'agents' | 'capabilities' | 'health' | 'ui-primitives'
 export type PaletteSection = 'Go To' | 'Create' | 'Modes' | 'Commands' | 'Agents'
 const COMMAND_PALETTE_DESCRIPTION_MAX_LENGTH = 96
 
@@ -210,6 +210,18 @@ export function buildCommandPaletteItems(input: BuildPaletteItemsInput): Palette
       badge: 'Navigate',
       keywords: 'health setup onboarding readiness doctor smoke workspace authority',
       run: () => onNavigate('health'),
+    },
+    {
+      id: 'nav:ui-primitives',
+      title: 'UI Primitives',
+      subtitle: 'Open the internal design-system gallery for visual QA.',
+      section: 'Go To',
+      badge: 'QA',
+      keywords: 'ui primitives design system gallery components',
+      run: () => {
+        window.location.hash = '#/ui-primitives'
+        onNavigate('ui-primitives')
+      },
     },
     {
       id: 'nav:settings',

--- a/apps/desktop/src/renderer/components/health/HealthCenterPage.tsx
+++ b/apps/desktop/src/renderer/components/health/HealthCenterPage.tsx
@@ -230,7 +230,7 @@ export function HealthCenterPage() {
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-5 py-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h1 className="text-[20px] font-semibold text-text">Health Center</h1>
+            <h1 className="font-display text-role-page-title font-bold text-text">Health Center</h1>
             <p className="mt-1 max-w-3xl text-[12px] leading-relaxed text-text-muted">
               Setup paths, execution authority, sync state, and operator recovery checks for Desktop, Cloud, and Gateway.
             </p>
@@ -274,7 +274,7 @@ export function HealthCenterPage() {
             <Card>
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <h2 className="text-[14px] font-semibold text-text">Desktop Runtime</h2>
+                  <h2 className="font-display text-role-card-title font-bold text-text">Desktop Runtime</h2>
                   <p className="mt-1 text-[11px] text-text-muted">
                     Local execution authority and provider selection. No raw credential values are shown.
                   </p>
@@ -311,7 +311,7 @@ export function HealthCenterPage() {
             </Card>
 
             <Card>
-              <h2 className="text-[14px] font-semibold text-text">Runtime Capability Provenance</h2>
+              <h2 className="font-display text-role-card-title font-bold text-text">Runtime Capability Provenance</h2>
               <p className="mt-1 text-[11px] text-text-muted">Source, winner, and reason-code diagnostics for runtime inputs. Evidence is redacted before it reaches the renderer.</p>
               <div className="mt-3 flex flex-col gap-2">
                 {runtimeCapabilities.length === 0 ? (
@@ -368,7 +368,7 @@ export function HealthCenterPage() {
             </Card>
 
             <Card>
-              <h2 className="text-[14px] font-semibold text-text">Pairings</h2>
+              <h2 className="font-display text-role-card-title font-bold text-text">Pairings</h2>
               <p className="mt-1 text-[11px] text-text-muted">Outbound Desktop pairings stay local-authority unless remote policy explicitly allows more.</p>
               <div className="mt-3 flex flex-col gap-2">
                 {snapshot.pairings.length === 0 ? (
@@ -392,7 +392,7 @@ export function HealthCenterPage() {
 
           <div className="flex flex-col gap-4">
             <Card>
-              <h2 className="text-[14px] font-semibold text-text">Workspaces And Authorities</h2>
+              <h2 className="font-display text-role-card-title font-bold text-text">Workspaces And Authorities</h2>
               <p className="mt-1 text-[11px] text-text-muted">Each thread must belong to exactly one workspace and one execution authority.</p>
               <div className="mt-3 grid gap-2">
                 {snapshot.workspaces.length === 0 ? (
@@ -440,7 +440,7 @@ export function HealthCenterPage() {
             </Card>
 
             <Card>
-              <h2 className="text-[14px] font-semibold text-text">Operator Checks</h2>
+              <h2 className="font-display text-role-card-title font-bold text-text">Operator Checks</h2>
               <p className="mt-1 text-[11px] text-text-muted">Doctor, smoke, durability, and recovery checks before routing real users or public webhooks.</p>
               <div className="mt-3 grid gap-2 md:grid-cols-2">
                 {visibleChecks.map(({ check, status }) => (

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import { t } from '../../helpers/i18n'
 import type { AppView } from '../../app-types'
 import { useSessionStore } from '../../stores/session'
 import { supportAllows, supportEntry, useWorkspaceSupportStore } from '../../stores/workspace-support'
+import { Icon } from '../ui'
 
 interface Props {
   currentView: AppView
@@ -588,10 +589,7 @@ export function Sidebar({
               className={`w-9 h-9 flex items-center justify-center rounded-lg border border-border-subtle transition-colors cursor-pointer ${showSearch ? 'bg-surface-active text-text' : 'text-text-muted hover:bg-surface-hover hover:text-text-secondary'}`}
               title={t('sidebar.searchTitle', 'Search threads (⌘K)')}
             >
-              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
-                <circle cx="6" cy="6" r="4.5" />
-                <line x1="9.2" y1="9.2" x2="12" y2="12" />
-              </svg>
+              <Icon name="search" size={16} />
             </button>
           </div>
 
@@ -614,57 +612,31 @@ export function Sidebar({
             <button onClick={() => onViewChange('home')}
               aria-current={currentView === 'home' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'home' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M2 5.5 6.5 2 11 5.5V11a.75.75 0 0 1-.75.75H2.75A.75.75 0 0 1 2 11V5.5Z" />
-                <path d="M5 11.75V8h3v3.75" />
-              </svg>
+              <Icon name="home" size={16} />
               {t('sidebar.home', 'Home')}
             </button>
             <button onClick={() => onViewChange('agents')}
               aria-current={currentView === 'agents' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'agents' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="4" cy="4" r="1.5" />
-                <circle cx="9" cy="4" r="1.5" />
-                <path d="M1.8 10.8C2.2 9.4 3.3 8.5 4.6 8.5H5.3C6.7 8.5 7.8 9.4 8.2 10.8" />
-                <path d="M7.5 10.8C7.8 9.9 8.5 9.3 9.4 9.3H9.8C10.8 9.3 11.5 9.9 11.8 10.8" />
-              </svg>
+              <Icon name="bot" size={16} />
               {t('sidebar.agents', 'Agents')}
             </button>
             <button onClick={() => onViewChange('workflows')}
               aria-current={currentView === 'workflows' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'workflows' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="2" y="2" width="3" height="3" rx="0.6" />
-                <rect x="8" y="2" width="3" height="3" rx="0.6" />
-                <rect x="2" y="8" width="3" height="3" rx="0.6" />
-                <path d="M8 9.5H11" />
-                <path d="M9.5 8V11" />
-                <path d="M5 3.5H8" />
-                <path d="M3.5 5V8" />
-              </svg>
+              <Icon name="workflow" size={16} />
               {t('sidebar.workflows', 'Workflows')}
             </button>
             <button onClick={() => onViewChange('capabilities')}
               aria-current={currentView === 'capabilities' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'capabilities' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="3.25" cy="3.25" r="1.25" />
-                <circle cx="9.75" cy="3.25" r="1.25" />
-                <circle cx="6.5" cy="9.75" r="1.25" />
-                <path d="M4.5 3.25H8.5" />
-                <path d="M4 4.2 5.8 8.7" />
-                <path d="M9 4.2 7.2 8.7" />
-              </svg>
+              <Icon name="blocks" size={16} />
               {t('sidebar.toolsSkills', 'Tools & Skills')}
             </button>
             <button onClick={() => onViewChange('health')}
               aria-current={currentView === 'health' ? 'page' : undefined}
               className={`w-full flex items-center gap-2.5 px-3 py-[7px] rounded-md text-[13px] transition-colors cursor-pointer ${currentView === 'health' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M6.5 1.75 10.5 3.2v3.1c0 2.25-1.45 4.15-4 4.95-2.55-.8-4-2.7-4-4.95V3.2l4-1.45Z" />
-                <path d="M4.6 6.5 5.8 7.7 8.7 4.8" />
-              </svg>
+              <Icon name="heart-pulse" size={16} />
               {t('sidebar.healthCenter', 'Health Center')}
             </button>
           </div>
@@ -694,9 +666,7 @@ export function Sidebar({
           {/* Settings */}
           <button onClick={() => setShowSettings(true)}
             className="flex items-center gap-2.5 px-4 py-3 text-[13px] text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-colors cursor-pointer border-t border-border-subtle">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
-              <circle cx="7" cy="7" r="2.5" /><path d="M7 1.5V3M7 11V12.5M1.5 7H3M11 7H12.5M2.8 2.8L3.9 3.9M10.1 10.1L11.2 11.2M11.2 2.8L10.1 3.9M3.9 10.1L2.8 11.2" />
-            </svg>
+            <Icon name="settings-2" size={16} />
             {t('sidebar.settings', 'Settings')}
           </button>
         </>

--- a/apps/desktop/src/renderer/components/layout/StatusBar.tsx
+++ b/apps/desktop/src/renderer/components/layout/StatusBar.tsx
@@ -135,7 +135,7 @@ export function StatusBar() {
         <div className="flex items-center gap-3">
           <McpStatusBadge />
           {showContext && (
-            <div className="flex items-center gap-1.5 min-w-[96px]">
+            <div className="tabular flex items-center gap-1.5 min-w-[96px]">
               <span style={{ color: contextColor }}>{contextLabel}</span>
               <span
                 className="relative inline-flex w-12 h-1.5 rounded-full overflow-hidden"
@@ -159,7 +159,7 @@ export function StatusBar() {
           {totalTokens > 0 && (
             <button
               onClick={() => setShowDetail(!showDetail)}
-              className="flex items-center gap-1.5 cursor-pointer hover:text-text-secondary transition-colors"
+              className="tabular flex items-center gap-1.5 cursor-pointer hover:text-text-secondary transition-colors"
             >
               <span>{t('statusbar.tokensCount', '{{count}} tokens', { count: formatTokens(totalTokens) })}</span>
               <span className="text-border">|</span>
@@ -174,7 +174,7 @@ export function StatusBar() {
       {showDetail && totalTokens > 0 && (
         <>
           <ModalBackdrop onDismiss={() => setShowDetail(false)} className="fixed inset-0 z-40" />
-          <div className="absolute bottom-8 end-4 z-50 w-56 p-3 rounded-xl bg-elevated border border-border shadow-lg">
+          <div className="tabular absolute bottom-8 end-4 z-50 w-56 p-3 rounded-xl bg-elevated border border-border shadow-lg">
             <div className="text-[11px] font-semibold text-text mb-2">{t('statusbar.sessionUsage', 'Session Usage')}</div>
             <div className="flex flex-col gap-1.5 text-[11px]">
               <div className="flex justify-between">

--- a/apps/desktop/src/renderer/components/layout/TitleBar.tsx
+++ b/apps/desktop/src/renderer/components/layout/TitleBar.tsx
@@ -1,5 +1,6 @@
 import { useSessionStore } from '../../stores/session'
 import { t } from '../../helpers/i18n'
+import { IconButton } from '../ui'
 
 export function TitleBar() {
   const toggleSidebar = useSessionStore((s) => s.toggleSidebar)
@@ -7,16 +8,13 @@ export function TitleBar() {
   return (
     <div className="drag flex items-center h-[38px] shrink-0 select-none border-b border-border-subtle">
       <div className="flex items-center pl-[72px] gap-1.5">
-        <button
+        <IconButton
+          icon="panel-left"
+          label={t('titleBar.toggleSidebar', 'Toggle sidebar')}
           onClick={toggleSidebar}
-          aria-label={t('titleBar.toggleSidebar', 'Toggle sidebar')}
-          className="no-drag flex items-center justify-center w-6 h-6 rounded-md text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all cursor-pointer"
-        >
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
-            <rect x="2" y="3" width="10" height="8" rx="1.5" />
-            <line x1="5" y1="3" x2="5" y2="11" />
-          </svg>
-        </button>
+          size="sm"
+          className="no-drag"
+        />
       </div>
       <div className="flex-1" />
       <div className="w-[100px]" />

--- a/apps/desktop/src/renderer/components/threads/ThreadsPage.tsx
+++ b/apps/desktop/src/renderer/components/threads/ThreadsPage.tsx
@@ -165,7 +165,7 @@ function FacetButton({
     >
       {color ? <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: color }} /> : null}
       <span className="min-w-0 flex-1 truncate">{bucket.label}</span>
-      <span className="shrink-0 text-[10px] text-text-muted">{bucket.count}</span>
+      <span className="tabular shrink-0 text-[10px] text-text-muted">{bucket.count}</span>
     </button>
   )
 }

--- a/apps/desktop/src/renderer/components/ui/Badge.tsx
+++ b/apps/desktop/src/renderer/components/ui/Badge.tsx
@@ -1,0 +1,21 @@
+import { type ComponentPropsWithoutRef } from 'react'
+import { cn } from './utils'
+
+export type BadgeTone = 'neutral' | 'accent' | 'success' | 'warning' | 'danger'
+
+export type BadgeProps = ComponentPropsWithoutRef<'span'> & {
+  tone?: BadgeTone
+}
+
+export function Badge({
+  tone = 'neutral',
+  className,
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      {...props}
+      className={cn('ui-badge', `ui-badge--${tone}`, className)}
+    />
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/Button.tsx
+++ b/apps/desktop/src/renderer/components/ui/Button.tsx
@@ -1,0 +1,130 @@
+import { forwardRef, useId, type ButtonHTMLAttributes, type ReactNode } from 'react'
+import { DisabledHint } from './DisabledHint'
+import { Icon, type IconName } from './Icon'
+import { Tooltip } from './Tooltip'
+import { cn } from './utils'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+export type ButtonSize = 'sm' | 'md' | 'lg'
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+  leftIcon?: IconName
+  rightIcon?: IconName
+  fullWidth?: boolean
+  disabledReason?: string | null
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonPrimitive({
+  variant = 'secondary',
+  size = 'md',
+  loading = false,
+  leftIcon,
+  rightIcon,
+  fullWidth = false,
+  disabledReason,
+  disabled,
+  children,
+  className,
+  'aria-describedby': ariaDescribedBy,
+  ...props
+}, ref) {
+  const hintId = useId()
+  const isDisabled = disabled || loading || Boolean(disabledReason)
+  const disabledHintId = `${hintId}-disabled`
+  const describedBy = [ariaDescribedBy, disabledReason ? disabledHintId : undefined].filter(Boolean).join(' ') || undefined
+  const button = (
+    <button
+      {...props}
+      ref={ref}
+      className={cn(
+        'ui-button',
+        `ui-button--${variant}`,
+        `ui-button--${size}`,
+        fullWidth && 'ui-button--full',
+        className,
+      )}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      aria-describedby={describedBy}
+      type={props.type || 'button'}
+    >
+      {loading ? <Icon name="loader-circle" size={16} className="ui-spin" /> : leftIcon ? <Icon name={leftIcon} size={16} /> : null}
+      <span>{children}</span>
+      {rightIcon ? <Icon name={rightIcon} size={16} /> : null}
+    </button>
+  )
+
+  if (!disabledReason) return button
+
+  return (
+    <span className={cn('ui-control-stack', fullWidth && 'ui-button--full')}>
+      <Tooltip content={disabledReason} delay={0}>
+        <span>{button}</span>
+      </Tooltip>
+      <DisabledHint id={disabledHintId} reason={disabledReason} />
+    </span>
+  )
+})
+
+export type IconButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'aria-label'> & {
+  icon: IconName
+  label: string
+  size?: Exclude<ButtonSize, 'lg'>
+  variant?: Exclude<ButtonVariant, 'primary'>
+  badge?: ReactNode
+  loading?: boolean
+  disabledReason?: string | null
+}
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButtonPrimitive({
+  icon,
+  label,
+  size = 'md',
+  variant = 'ghost',
+  badge,
+  loading = false,
+  disabled,
+  disabledReason,
+  className,
+  'aria-describedby': ariaDescribedBy,
+  ...props
+}, ref) {
+  const hintId = useId()
+  const isDisabled = disabled || loading || Boolean(disabledReason)
+  const disabledHintId = `${hintId}-disabled`
+  const describedBy = [ariaDescribedBy, disabledReason ? disabledHintId : undefined].filter(Boolean).join(' ') || undefined
+  const button = (
+    <button
+      {...props}
+      ref={ref}
+      type={props.type || 'button'}
+      className={cn(
+        'ui-icon-button',
+        `ui-icon-button--${variant}`,
+        `ui-icon-button--${size}`,
+        className,
+      )}
+      aria-label={label}
+      aria-busy={loading || undefined}
+      aria-describedby={describedBy}
+      disabled={isDisabled}
+    >
+      {loading ? <Icon name="loader-circle" size={16} className="ui-spin" /> : <Icon name={icon} size={size === 'sm' ? 16 : 20} />}
+      {badge ? <span className="ui-icon-button__badge">{badge}</span> : null}
+    </button>
+  )
+
+  if (!disabledReason) return button
+
+  return (
+    <span className="ui-control-stack">
+      <Tooltip content={disabledReason} delay={0}>
+        <span>{button}</span>
+      </Tooltip>
+      <DisabledHint id={disabledHintId} reason={disabledReason} />
+    </span>
+  )
+})

--- a/apps/desktop/src/renderer/components/ui/Card.tsx
+++ b/apps/desktop/src/renderer/components/ui/Card.tsx
@@ -1,0 +1,44 @@
+import { type ButtonHTMLAttributes, type ComponentPropsWithoutRef } from 'react'
+import { cn } from './utils'
+
+type CardBaseProps = {
+  padding?: 'sm' | 'md' | 'lg'
+}
+
+type StaticCardProps = ComponentPropsWithoutRef<'div'> & CardBaseProps & {
+  interactive?: false
+}
+
+type InteractiveCardProps = ButtonHTMLAttributes<HTMLButtonElement> & CardBaseProps & {
+  interactive: true
+}
+
+export type CardProps = StaticCardProps | InteractiveCardProps
+
+export function Card(props: CardProps) {
+  const {
+    interactive = false,
+    padding = 'md',
+    className,
+    ...rest
+  } = props
+
+  if (interactive) {
+    const buttonProps = rest as ButtonHTMLAttributes<HTMLButtonElement>
+    return (
+      <button
+        {...buttonProps}
+        type={buttonProps.type || 'button'}
+        className={cn('ui-card', `ui-card--${padding}`, 'ui-card--interactive', className)}
+      />
+    )
+  }
+
+  const divProps = rest as ComponentPropsWithoutRef<'div'>
+  return (
+    <div
+      {...divProps}
+      className={cn('ui-card', `ui-card--${padding}`, className)}
+    />
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/Dialog.tsx
+++ b/apps/desktop/src/renderer/components/ui/Dialog.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { IconButton } from './Button'
+import { cn } from './utils'
+
+export type DialogProps = {
+  title: string
+  children: ReactNode
+  onClose: () => void
+  size?: 'sm' | 'md' | 'lg'
+  footer?: ReactNode
+}
+
+export function Dialog({
+  title,
+  children,
+  onClose,
+  size = 'md',
+  footer,
+}: DialogProps) {
+  const titleId = useId()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(dialogRef, { onEscape: onClose })
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'w') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', listener)
+    return () => document.removeEventListener('keydown', listener)
+  }, [onClose])
+
+  return (
+    <>
+      <div aria-hidden="true" className="ui-dialog-backdrop" onClick={onClose} />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className={cn('ui-dialog', `ui-dialog--${size}`)}
+      >
+        <div className="ui-dialog__header">
+          <h2 id={titleId} className="ui-dialog__title">{title}</h2>
+          <IconButton icon="x" label="Close dialog" onClick={onClose} />
+        </div>
+        <div className="ui-dialog__body">
+          {children}
+        </div>
+        {footer ? <div className="ui-dialog__footer">{footer}</div> : null}
+      </div>
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/DisabledHint.tsx
+++ b/apps/desktop/src/renderer/components/ui/DisabledHint.tsx
@@ -1,0 +1,19 @@
+import { Icon } from './Icon'
+import { Tooltip } from './Tooltip'
+
+export function DisabledHint({
+  id,
+  reason,
+}: {
+  id: string
+  reason: string
+}) {
+  return (
+    <Tooltip content={reason} side="bottom" delay={0}>
+      <span id={id} className="ui-disabled-reason">
+        <Icon name="info" size={16} />
+        <span>{reason}</span>
+      </span>
+    </Tooltip>
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/EmptyState.tsx
+++ b/apps/desktop/src/renderer/components/ui/EmptyState.tsx
@@ -1,0 +1,29 @@
+import { type ReactNode } from 'react'
+import { Icon, type IconName } from './Icon'
+
+export type EmptyStateProps = {
+  icon: IconName
+  title: string
+  body: string
+  action?: ReactNode
+}
+
+export function EmptyState({
+  icon,
+  title,
+  body,
+  action,
+}: EmptyStateProps) {
+  return (
+    <div className="ui-empty-state">
+      <div className="ui-empty-state__icon" aria-hidden="true">
+        <Icon name={icon} size={24} />
+      </div>
+      <div>
+        <div className="ui-empty-state__title">{title}</div>
+        <div className="ui-empty-state__body">{body}</div>
+      </div>
+      {action ? <div>{action}</div> : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/Icon.tsx
+++ b/apps/desktop/src/renderer/components/ui/Icon.tsx
@@ -1,0 +1,113 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import {
+  Activity,
+  AlertCircle,
+  ArrowUp,
+  BadgeCheck,
+  Bell,
+  Blocks,
+  Bot,
+  Brain,
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  CircleHelp,
+  CircleX,
+  Clipboard,
+  Copy,
+  ExternalLink,
+  File,
+  Folder,
+  GitFork,
+  HeartPulse,
+  Home,
+  Info,
+  LoaderCircle,
+  Menu,
+  Minus,
+  PanelLeft,
+  Paperclip,
+  Plus,
+  Search,
+  Settings2,
+  Sparkles,
+  Square,
+  Trash2,
+  Users,
+  Workflow,
+  Wrench,
+  X,
+  type LucideIcon,
+} from 'lucide-react'
+
+const ICONS = {
+  activity: Activity,
+  'alert-circle': AlertCircle,
+  'arrow-up': ArrowUp,
+  'badge-check': BadgeCheck,
+  bell: Bell,
+  blocks: Blocks,
+  bot: Bot,
+  brain: Brain,
+  check: Check,
+  'chevron-down': ChevronDown,
+  'chevron-left': ChevronLeft,
+  'chevron-right': ChevronRight,
+  'circle-help': CircleHelp,
+  'circle-x': CircleX,
+  clipboard: Clipboard,
+  copy: Copy,
+  'external-link': ExternalLink,
+  file: File,
+  folder: Folder,
+  'git-fork': GitFork,
+  'heart-pulse': HeartPulse,
+  home: Home,
+  info: Info,
+  'loader-circle': LoaderCircle,
+  menu: Menu,
+  minus: Minus,
+  'panel-left': PanelLeft,
+  paperclip: Paperclip,
+  plus: Plus,
+  search: Search,
+  'settings-2': Settings2,
+  sparkles: Sparkles,
+  square: Square,
+  'trash-2': Trash2,
+  users: Users,
+  workflow: Workflow,
+  wrench: Wrench,
+  x: X,
+} satisfies Record<string, LucideIcon>
+
+export type IconName = keyof typeof ICONS
+export type IconSize = 16 | 20 | 24
+
+export type IconProps = Omit<ComponentPropsWithoutRef<'svg'>, 'aria-hidden' | 'color' | 'name'> & {
+  name: IconName
+  size?: IconSize
+  strokeWidth?: number
+  'aria-hidden'?: boolean | 'true' | 'false'
+}
+
+export function Icon({
+  name,
+  size = 16,
+  strokeWidth = 1.5,
+  'aria-hidden': ariaHidden = true,
+  ...props
+}: IconProps) {
+  const Component = ICONS[name]
+  return (
+    <Component
+      {...props}
+      aria-hidden={ariaHidden}
+      color="currentColor"
+      focusable="false"
+      size={size}
+      strokeWidth={strokeWidth}
+    />
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/Input.tsx
+++ b/apps/desktop/src/renderer/components/ui/Input.tsx
@@ -1,0 +1,201 @@
+import {
+  useEffect,
+  forwardRef,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type InputEvent,
+  type Ref,
+  type TextareaHTMLAttributes,
+} from 'react'
+import { DisabledHint } from './DisabledHint'
+import { Icon, type IconName } from './Icon'
+import { IconButton } from './Button'
+import { cn } from './utils'
+
+type FieldSize = 'sm' | 'md' | 'lg'
+type TextareaMaxHeight = 'sm' | 'md' | 'lg' | number | string
+type TextareaStyle = CSSProperties & {
+  '--ui-textarea-max-height'?: string
+}
+
+const TEXTAREA_MAX_HEIGHTS = {
+  sm: 'calc(var(--space-12) * 2)',
+  md: 'calc(var(--space-12) * 3)',
+  lg: 'calc(var(--space-12) * 4)',
+} as const
+
+function resolveTextareaMaxHeight(maxHeight: TextareaMaxHeight | undefined) {
+  if (typeof maxHeight === 'number') return `${maxHeight}px`
+  if (!maxHeight) return undefined
+  return TEXTAREA_MAX_HEIGHTS[maxHeight as keyof typeof TEXTAREA_MAX_HEIGHTS] || maxHeight
+}
+
+function assignRefs<T>(node: T, ...refs: Array<Ref<T> | undefined>) {
+  for (const ref of refs) {
+    if (!ref) continue
+    if (typeof ref === 'function') {
+      ref(node)
+    } else {
+      ref.current = node
+    }
+  }
+}
+
+export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+  size?: FieldSize
+  leftIcon?: IconName
+  error?: string | null
+  clearable?: boolean
+  onClear?: () => void
+  disabledReason?: string | null
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function InputPrimitive({
+  size = 'md',
+  leftIcon,
+  error,
+  clearable = false,
+  onClear,
+  disabled,
+  disabledReason,
+  className,
+  value,
+  defaultValue,
+  onChange,
+  'aria-describedby': ariaDescribedBy,
+  ...props
+}, ref) {
+  const id = useId()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const errorId = error ? `${id}-error` : undefined
+  const disabledId = disabledReason ? `${id}-disabled` : undefined
+  const describedBy = [ariaDescribedBy, errorId, disabledId].filter(Boolean).join(' ') || undefined
+  const isDisabled = disabled || Boolean(disabledReason)
+  const isControlled = value !== undefined
+  const [uncontrolledValue, setUncontrolledValue] = useState(() => defaultValue === undefined ? '' : String(defaultValue))
+  const currentValue = isControlled ? value : uncontrolledValue
+  const hasValue = currentValue !== undefined && String(currentValue).length > 0
+
+  const clear = () => {
+    onClear?.()
+    const input = inputRef.current
+    if (!input) return
+    if (!isControlled) setUncontrolledValue('')
+    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    nativeSetter?.call(input, '')
+    const event = new Event('input', { bubbles: true })
+    input.dispatchEvent(event)
+  }
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!isControlled) setUncontrolledValue(event.currentTarget.value)
+    onChange?.(event)
+  }
+
+  return (
+    <label className="ui-field">
+      <span className="ui-field__chrome">
+        {leftIcon ? <span className="ui-field__left-icon"><Icon name={leftIcon} size={16} /></span> : null}
+        <input
+          {...props}
+          ref={(node) => {
+            inputRef.current = node
+            assignRefs(node, ref)
+          }}
+          value={value}
+          defaultValue={defaultValue}
+          onChange={handleChange}
+          disabled={isDisabled}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          className={cn(
+            'ui-input',
+            `ui-input--${size}`,
+            leftIcon && 'ui-input--with-left-icon',
+            clearable && 'ui-input--clearable',
+            className,
+          )}
+        />
+        {clearable && hasValue ? (
+          <span className="ui-input__clear">
+            <IconButton icon="x" label="Clear" size="sm" onClick={clear} disabled={isDisabled} />
+          </span>
+        ) : null}
+      </span>
+      {error ? <span id={errorId} className="ui-field__message ui-field__message--error">{error}</span> : null}
+      {disabledReason ? <DisabledHint id={disabledId!} reason={disabledReason} /> : null}
+    </label>
+  )
+})
+
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  autoGrow?: boolean
+  maxHeight?: TextareaMaxHeight
+  error?: string | null
+  disabledReason?: string | null
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function TextareaPrimitive({
+  autoGrow = false,
+  maxHeight,
+  error,
+  disabled,
+  disabledReason,
+  className,
+  onInput,
+  'aria-describedby': ariaDescribedBy,
+  ...props
+}, ref) {
+  const id = useId()
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const errorId = error ? `${id}-error` : undefined
+  const disabledId = disabledReason ? `${id}-disabled` : undefined
+  const describedBy = [ariaDescribedBy, errorId, disabledId].filter(Boolean).join(' ') || undefined
+  const isDisabled = disabled || Boolean(disabledReason)
+  const resolvedMaxHeight = resolveTextareaMaxHeight(maxHeight)
+  const textareaStyle: TextareaStyle | undefined = resolvedMaxHeight
+    ? { ...props.style, '--ui-textarea-max-height': resolvedMaxHeight }
+    : props.style
+
+  const resize = () => {
+    if (!autoGrow || !textareaRef.current) return
+    const element = textareaRef.current
+    element.style.height = 'auto'
+    const limit = typeof maxHeight === 'number' ? maxHeight : Number.POSITIVE_INFINITY
+    const next = Math.min(element.scrollHeight, limit)
+    element.style.height = `${next}px`
+  }
+
+  useEffect(() => {
+    resize()
+  })
+
+  const handleInput = (event: InputEvent<HTMLTextAreaElement>) => {
+    resize()
+    onInput?.(event)
+  }
+
+  return (
+    <label className="ui-field">
+      <textarea
+        {...props}
+        ref={(node) => {
+          textareaRef.current = node
+          assignRefs(node, ref)
+        }}
+        disabled={isDisabled}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
+        className={cn('ui-textarea', className)}
+        onInput={handleInput}
+        style={textareaStyle}
+      />
+      {error ? <span id={errorId} className="ui-field__message ui-field__message--error">{error}</span> : null}
+      {disabledReason ? <DisabledHint id={disabledId!} reason={disabledReason} /> : null}
+    </label>
+  )
+})

--- a/apps/desktop/src/renderer/components/ui/Kbd.tsx
+++ b/apps/desktop/src/renderer/components/ui/Kbd.tsx
@@ -1,0 +1,9 @@
+import { type ComponentPropsWithoutRef } from 'react'
+import { cn } from './utils'
+
+export function Kbd({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<'kbd'>) {
+  return <kbd {...props} className={cn('ui-kbd', className)} />
+}

--- a/apps/desktop/src/renderer/components/ui/PrimitiveGallery.tsx
+++ b/apps/desktop/src/renderer/components/ui/PrimitiveGallery.tsx
@@ -1,0 +1,209 @@
+import { useState, type ReactNode } from 'react'
+import { Badge } from './Badge'
+import { Button, IconButton, type ButtonSize, type ButtonVariant } from './Button'
+import { Card } from './Card'
+import { Dialog } from './Dialog'
+import { EmptyState } from './EmptyState'
+import { Icon } from './Icon'
+import { Input, Textarea } from './Input'
+import { Kbd } from './Kbd'
+import { Menu, Select } from './Select'
+import { SegmentedControl } from './SegmentedControl'
+import { Skeleton } from './Skeleton'
+import { Tooltip } from './Tooltip'
+import { toast } from './Toaster'
+
+const buttonVariants: ButtonVariant[] = ['primary', 'secondary', 'ghost', 'danger']
+const buttonSizes: ButtonSize[] = ['sm', 'md', 'lg']
+const iconVariants = ['secondary', 'ghost', 'danger'] as const
+const iconSizes = ['sm', 'md'] as const
+const tones = ['neutral', 'accent', 'success', 'warning', 'danger'] as const
+
+function GallerySection({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="font-display text-role-section-title font-bold text-text">{title}</h2>
+      <Card padding="lg" className="space-y-4">
+        {children}
+      </Card>
+    </section>
+  )
+}
+
+export function PrimitiveGallery() {
+  const [selectValue, setSelectValue] = useState('build')
+  const [segment, setSegment] = useState('plan')
+  const [dialogSize, setDialogSize] = useState<'sm' | 'md' | 'lg' | null>(null)
+  const [menuAction, setMenuAction] = useState('No action yet')
+  const [cardAction, setCardAction] = useState('No card action yet')
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto bg-base">
+      <div className="ui-primitive-gallery__shell mx-auto flex w-full flex-col gap-8 px-8 py-8">
+        <header className="space-y-2">
+          <Badge tone="accent">Design system QA</Badge>
+          <h1 className="font-display text-role-page-title font-bold text-text">UI primitives</h1>
+        </header>
+
+        <GallerySection title="Buttons">
+          <div className="grid gap-4">
+            {buttonVariants.map((variant) => (
+              <div key={variant} className="flex flex-wrap items-center gap-3">
+                {buttonSizes.map((size) => (
+                  <Button key={`${variant}-${size}`} variant={variant} size={size} leftIcon="sparkles">
+                    {variant} {size}
+                  </Button>
+                ))}
+                <Button variant={variant} loading>Loading</Button>
+                <Button variant={variant} disabledReason="Workspace policy disables this action.">Disabled</Button>
+              </div>
+            ))}
+          </div>
+        </GallerySection>
+
+        <GallerySection title="Icon Buttons">
+          <div className="flex flex-wrap items-start gap-4">
+            {iconVariants.map((variant) => (
+              <div key={variant} className="flex items-center gap-2">
+                {iconSizes.map((size) => (
+                  <IconButton key={`${variant}-${size}`} icon="search" label={`${variant} ${size} search`} variant={variant} size={size} />
+                ))}
+                <IconButton icon="bell" label="Unread notices" variant={variant} badge="3" />
+              </div>
+            ))}
+            <IconButton icon="loader-circle" label="Loading settings" loading />
+            <IconButton icon="settings-2" label="Disabled settings" disabledReason="Settings are managed by this workspace." />
+          </div>
+        </GallerySection>
+
+        <GallerySection title="Fields">
+          <div className="grid gap-4 md:grid-cols-3">
+            <Input aria-label="Small input" size="sm" leftIcon="search" placeholder="Small input" clearable defaultValue="Query" />
+            <Input aria-label="Medium input" size="md" placeholder="Medium input" error="Use a shorter name." />
+            <Input aria-label="Large input" size="lg" placeholder="Large input" disabledReason="This value is locked." />
+          </div>
+          <Textarea aria-label="Notes" autoGrow maxHeight="md" placeholder="Notes" defaultValue="Review notes" />
+        </GallerySection>
+
+        <GallerySection title="Select And Menu">
+          <div className="grid gap-4 md:grid-cols-3">
+            <Select
+              label="Mode"
+              value={selectValue}
+              onChange={setSelectValue}
+              options={[
+                { value: 'plan', label: 'Plan' },
+                { value: 'build', label: 'Build' },
+                { value: 'review', label: 'Review', disabled: true, disabledReason: 'Review is not enabled for this workspace.' },
+              ]}
+            />
+            <Menu
+              label="Thread actions"
+              triggerLabel="Thread actions"
+              onSelect={setMenuAction}
+              items={[
+                { id: 'copy', label: 'Copy link', icon: <Icon name="copy" size={16} /> },
+                { id: 'fork', label: 'Fork thread', icon: <Icon name="git-fork" size={16} /> },
+                { id: 'delete', label: 'Delete', icon: <Icon name="trash-2" size={16} />, disabled: true, disabledReason: 'Pinned threads cannot be deleted.' },
+              ]}
+            />
+            <div className="text-role-metadata text-text-muted tabular">{menuAction}</div>
+          </div>
+        </GallerySection>
+
+        <GallerySection title="Dialog">
+          <div className="flex flex-wrap gap-3">
+            {(['sm', 'md', 'lg'] as const).map((size) => (
+              <Button key={size} variant="secondary" onClick={() => setDialogSize(size)}>
+                Open {size}
+              </Button>
+            ))}
+          </div>
+          {dialogSize ? (
+            <Dialog
+              title={`${dialogSize.toUpperCase()} dialog`}
+              size={dialogSize}
+              onClose={() => setDialogSize(null)}
+              footer={<Button variant="primary" onClick={() => setDialogSize(null)}>Done</Button>}
+            >
+              <p className="text-role-body text-text-secondary">Review details</p>
+            </Dialog>
+          ) : null}
+        </GallerySection>
+
+        <GallerySection title="Content Primitives">
+          <div className="grid gap-4 md:grid-cols-2">
+            {(['sm', 'md', 'lg'] as const).map((padding) => (
+              <Card key={padding} padding={padding}>
+                <div className="ui-card-title font-display text-role-card-title font-bold">Card {padding}</div>
+                <p className="mt-2 text-role-body text-text-secondary">Workspace details</p>
+              </Card>
+            ))}
+            <Card interactive padding="lg" onClick={() => setCardAction('Card opened')}>
+              <div className="ui-card-title font-display text-role-card-title font-bold">Interactive card</div>
+              <p className="mt-2 text-role-body text-text-secondary">Open workspace details</p>
+            </Card>
+            <EmptyState
+              icon="blocks"
+              title="Nothing configured yet"
+              body="Create an item to continue."
+              action={<Button variant="primary" size="sm">Create item</Button>}
+            />
+            <div className="text-role-metadata text-text-muted tabular">{cardAction}</div>
+          </div>
+        </GallerySection>
+
+        <GallerySection title="Badges, Tooltip, Kbd, Skeleton, Toast">
+          <div className="flex flex-wrap items-center gap-2">
+            {tones.map((tone) => <Badge key={tone} tone={tone}>{tone}</Badge>)}
+            <Tooltip content="More detail">
+              <span><Button variant="secondary" size="sm">Hover or focus</Button></span>
+            </Tooltip>
+            <Kbd>Cmd</Kbd>
+            <Kbd>K</Kbd>
+            <Button
+              size="sm"
+              onClick={() => toast({ tone: 'success', message: 'Primitive toast preview.' })}
+            >
+              Toast
+            </Button>
+          </div>
+          <div className="grid gap-3 md:grid-cols-3">
+            <Skeleton variant="text" />
+            <Skeleton variant="block" />
+            <Skeleton variant="card" />
+          </div>
+        </GallerySection>
+
+        <GallerySection title="Segmented Control">
+          <SegmentedControl
+            label="Agent mode"
+            value={segment}
+            onChange={setSegment}
+            options={[
+              { value: 'plan', label: 'Plan' },
+              { value: 'build', label: 'Build' },
+              { value: 'observe', label: 'Observe', disabled: true, disabledReason: 'Observe is not available here.' },
+            ]}
+          />
+          <SegmentedControl
+            label="Disabled agent mode"
+            value="plan"
+            onChange={() => undefined}
+            disabledReason="Mode selection is managed by policy."
+            options={[
+              { value: 'plan', label: 'Plan' },
+              { value: 'build', label: 'Build' },
+            ]}
+          />
+        </GallerySection>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/SegmentedControl.tsx
+++ b/apps/desktop/src/renderer/components/ui/SegmentedControl.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { DisabledHint } from './DisabledHint'
+import { cn, nextEnabledIndex } from './utils'
+
+export type SegmentedControlOption = {
+  value: string
+  label: string
+  disabled?: boolean
+  disabledReason?: string
+}
+
+export type SegmentedControlProps = {
+  options: SegmentedControlOption[]
+  value: string
+  onChange: (value: string) => void
+  label: string
+  disabled?: boolean
+  disabledReason?: string | null
+  className?: string
+}
+
+export function SegmentedControl({
+  options,
+  value,
+  onChange,
+  label,
+  disabled = false,
+  disabledReason,
+  className,
+}: SegmentedControlProps) {
+  const id = useId()
+  const [activeIndex, setActiveIndex] = useState(Math.max(0, options.findIndex((option) => option.value === value)))
+  const refs = useRef<Array<HTMLButtonElement | null>>([])
+  const emptyReason = options.length === 0 ? 'No segments available.' : null
+  const isDisabled = disabled || Boolean(disabledReason) || Boolean(emptyReason)
+  const disabledId = disabledReason ? `${id}-disabled` : undefined
+  const emptyId = emptyReason ? `${id}-empty` : undefined
+  const describedBy = [disabledId, emptyId].filter(Boolean).join(' ') || undefined
+
+  useEffect(() => {
+    const selectedIndex = options.findIndex((option) => option.value === value)
+    if (selectedIndex >= 0) setActiveIndex(selectedIndex)
+  }, [options, value])
+
+  const move = (direction: 1 | -1) => {
+    const next = nextEnabledIndex(options, activeIndex, direction)
+    if (next < 0) return
+    setActiveIndex(next)
+    refs.current[next]?.focus()
+  }
+
+  return (
+    <span className={cn('ui-control-stack', className)}>
+      <span
+        role="tablist"
+        aria-label={label}
+        aria-describedby={describedBy}
+        className="ui-segmented-control"
+      >
+        {options.map((option, index) => {
+          const selected = option.value === value
+          return (
+            <button
+              key={option.value}
+              ref={(node) => { refs.current[index] = node }}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              tabIndex={selected ? 0 : -1}
+              disabled={isDisabled || option.disabled}
+              className="ui-segmented-option"
+              onClick={() => {
+                if (!option.disabled) onChange(option.value)
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                  event.preventDefault()
+                  move(1)
+                } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+                  event.preventDefault()
+                  move(-1)
+                } else if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  if (!option.disabled) onChange(option.value)
+                }
+              }}
+            >
+              {option.label}
+            </button>
+          )
+        })}
+      </span>
+      {disabledReason ? <DisabledHint id={disabledId!} reason={disabledReason} /> : null}
+      {emptyReason ? <DisabledHint id={emptyId!} reason={emptyReason} /> : null}
+    </span>
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/Select.tsx
+++ b/apps/desktop/src/renderer/components/ui/Select.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { DisabledHint } from './DisabledHint'
+import { Icon } from './Icon'
+import { cn, nextEnabledIndex } from './utils'
+
+export type SelectOption = {
+  value: string
+  label: string
+  disabled?: boolean
+  disabledReason?: string
+}
+
+export type SelectProps = {
+  options: SelectOption[]
+  value: string
+  onChange: (value: string) => void
+  label?: string
+  disabled?: boolean
+  disabledReason?: string | null
+  className?: string
+}
+
+export function Select({
+  options,
+  value,
+  onChange,
+  label = 'Select option',
+  disabled = false,
+  disabledReason,
+  className,
+}: SelectProps) {
+  const id = useId()
+  const listRef = useRef<HTMLDivElement>(null)
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const [open, setOpen] = useState(false)
+  const selectedIndex = Math.max(0, options.findIndex((option) => option.value === value))
+  const [activeIndex, setActiveIndex] = useState(selectedIndex)
+  const selectedOption = options[selectedIndex] || options[0]
+  const selectedEnabledIndex = options[selectedIndex]?.disabled ? nextEnabledIndex(options, selectedIndex, 1) : selectedIndex
+  const emptyReason = options.length === 0 ? 'No options available.' : null
+  const isDisabled = disabled || Boolean(disabledReason) || Boolean(emptyReason)
+  const disabledId = disabledReason ? `${id}-disabled` : undefined
+  const emptyId = emptyReason ? `${id}-empty` : undefined
+  const listboxId = `${id}-listbox`
+  const describedBy = [disabledId, emptyId].filter(Boolean).join(' ') || undefined
+
+  useFocusTrap(listRef, { active: open, onEscape: () => setOpen(false) })
+
+  useEffect(() => {
+    if (!open) return
+    optionRefs.current[activeIndex]?.focus()
+  }, [activeIndex, open])
+
+  const openList = () => {
+    if (isDisabled) return
+    setActiveIndex(selectedEnabledIndex >= 0 ? selectedEnabledIndex : selectedIndex)
+    setOpen(true)
+  }
+
+  const select = (option: SelectOption | undefined) => {
+    if (!option || option.disabled) return
+    onChange(option.value)
+    setOpen(false)
+  }
+
+  const onTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      openList()
+    }
+  }
+
+  const onListKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setOpen(false)
+      return
+    }
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const next = nextEnabledIndex(options, activeIndex, event.key === 'ArrowDown' ? 1 : -1)
+      if (next >= 0) setActiveIndex(next)
+      return
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      select(options[activeIndex])
+    }
+  }
+
+  return (
+    <span className={cn('ui-control-stack', className)}>
+      <span className="ui-popover-root">
+        <button
+          type="button"
+          className="ui-select-trigger"
+          aria-label={`${label}: ${selectedOption?.label || 'No selection'}`}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={open ? listboxId : undefined}
+          aria-describedby={describedBy}
+          disabled={isDisabled}
+          onClick={() => (open ? setOpen(false) : openList())}
+          onKeyDown={onTriggerKeyDown}
+        >
+          <span>{selectedOption?.label || label}</span>
+          <Icon name="chevron-down" size={16} />
+        </button>
+        {open ? (
+          <div
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            aria-label={label}
+            className="ui-popover"
+            onKeyDown={onListKeyDown}
+          >
+            {options.map((option, index) => (
+              <button
+                key={option.value}
+                ref={(node) => { optionRefs.current[index] = node }}
+                type="button"
+                role="option"
+                aria-selected={option.value === value}
+                data-active={index === activeIndex}
+                disabled={option.disabled}
+                className="ui-popover-item"
+                onClick={() => select(option)}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                <span className="ui-popover-item__content">
+                  <span>{option.label}</span>
+                  {option.disabled && option.disabledReason ? <span className="ui-popover-item__hint">{option.disabledReason}</span> : null}
+                </span>
+                {option.value === value ? <Icon name="check" size={16} /> : null}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </span>
+      {disabledReason ? <DisabledHint id={disabledId!} reason={disabledReason} /> : null}
+      {emptyReason ? <DisabledHint id={emptyId!} reason={emptyReason} /> : null}
+    </span>
+  )
+}
+
+export type MenuItem = {
+  id: string
+  label: string
+  icon?: ReactNode
+  disabled?: boolean
+  disabledReason?: string
+}
+
+export type MenuProps = {
+  label: string
+  triggerLabel?: string
+  items: MenuItem[]
+  onSelect: (id: string) => void
+  disabled?: boolean
+  disabledReason?: string | null
+  className?: string
+}
+
+export function Menu({
+  label,
+  triggerLabel = label,
+  items,
+  onSelect,
+  disabled = false,
+  disabledReason,
+  className,
+}: MenuProps) {
+  const id = useId()
+  const menuRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const emptyReason = items.length === 0 ? 'No actions available.' : null
+  const isDisabled = disabled || Boolean(disabledReason) || Boolean(emptyReason)
+  const disabledId = disabledReason ? `${id}-disabled` : undefined
+  const emptyId = emptyReason ? `${id}-empty` : undefined
+  const menuId = `${id}-menu`
+  const describedBy = [disabledId, emptyId].filter(Boolean).join(' ') || undefined
+
+  useFocusTrap(menuRef, { active: open, onEscape: () => setOpen(false) })
+
+  useEffect(() => {
+    if (!open) return
+    itemRefs.current[activeIndex]?.focus()
+  }, [activeIndex, open])
+
+  const openMenu = () => {
+    if (isDisabled) return
+    const first = items.findIndex((item) => !item.disabled)
+    setActiveIndex(Math.max(first, 0))
+    setOpen(true)
+  }
+
+  const choose = (item: MenuItem | undefined) => {
+    if (!item || item.disabled) return
+    onSelect(item.id)
+    setOpen(false)
+  }
+
+  const onMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setOpen(false)
+      return
+    }
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const next = nextEnabledIndex(items, activeIndex, event.key === 'ArrowDown' ? 1 : -1)
+      if (next >= 0) setActiveIndex(next)
+      return
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      choose(items[activeIndex])
+    }
+  }
+
+  return (
+    <span className={cn('ui-control-stack', className)}>
+      <span className="ui-popover-root">
+        <button
+          type="button"
+          className="ui-menu-trigger"
+          aria-label={label}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={open ? menuId : undefined}
+          aria-describedby={describedBy}
+          disabled={isDisabled}
+          onClick={() => (open ? setOpen(false) : openMenu())}
+          onKeyDown={(event) => {
+            if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              openMenu()
+            }
+          }}
+        >
+          <span>{triggerLabel}</span>
+          <Icon name="chevron-down" size={16} />
+        </button>
+        {open ? (
+          <div
+            ref={menuRef}
+            id={menuId}
+            role="menu"
+            aria-label={label}
+            className="ui-popover"
+            onKeyDown={onMenuKeyDown}
+          >
+            {items.map((item, index) => (
+              <button
+                key={item.id}
+                ref={(node) => { itemRefs.current[index] = node }}
+                type="button"
+                role="menuitem"
+                data-active={index === activeIndex}
+                disabled={item.disabled}
+                className="ui-popover-item"
+                onClick={() => choose(item)}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                <span className="ui-popover-item__content">
+                  <span className="ui-popover-item__label">
+                    {item.icon}
+                    {item.label}
+                  </span>
+                  {item.disabled && item.disabledReason ? <span className="ui-popover-item__hint">{item.disabledReason}</span> : null}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </span>
+      {disabledReason ? <DisabledHint id={disabledId!} reason={disabledReason} /> : null}
+      {emptyReason ? <DisabledHint id={emptyId!} reason={emptyReason} /> : null}
+    </span>
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/Skeleton.tsx
+++ b/apps/desktop/src/renderer/components/ui/Skeleton.tsx
@@ -1,0 +1,20 @@
+import { type ComponentPropsWithoutRef } from 'react'
+import { cn } from './utils'
+
+export type SkeletonProps = ComponentPropsWithoutRef<'span'> & {
+  variant?: 'text' | 'block' | 'card'
+}
+
+export function Skeleton({
+  variant = 'text',
+  className,
+  ...props
+}: SkeletonProps) {
+  return (
+    <span
+      {...props}
+      aria-hidden="true"
+      className={cn('ui-skeleton', `ui-skeleton--${variant}`, className)}
+    />
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/Toaster.tsx
+++ b/apps/desktop/src/renderer/components/ui/Toaster.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type FocusEvent } from 'react'
 import { useSessionStore, type SessionError } from '../../stores/session'
+import { Button, IconButton } from './Button'
 
 export type ToastTone = 'error' | 'warning' | 'success' | 'info'
 
@@ -144,28 +145,24 @@ function ToastCard({
       role={isError ? 'alert' : 'status'}
       aria-live={isError ? 'assertive' : 'polite'}
       aria-label={`${record.title}: ${record.message}`}
-      className="toast-enter pointer-events-auto w-[min(360px,calc(100vw-32px))] rounded-lg border px-3 py-3 shadow-card"
-      style={{
-        ...toneStyles[record.tone],
-        borderColor: 'var(--toast-border)',
-        background: 'var(--toast-bg)',
-      }}
+      className="ui-toast-card toast-enter pointer-events-auto"
+      style={toneStyles[record.tone]}
       onPointerEnter={() => setPaused(true)}
       onPointerLeave={() => setPaused(false)}
     >
       <div className="flex items-start gap-3">
         <div
           aria-hidden="true"
-          className="mt-1 h-2 w-2 shrink-0 rounded-full"
-          style={{ background: 'var(--toast-color)', boxShadow: '0 0 0 3px color-mix(in srgb, var(--toast-color) 18%, transparent)' }}
+          className="ui-toast-indicator shrink-0"
         />
         <div className="min-w-0 flex-1">
           <div className="text-sm font-semibold text-text">{record.title}</div>
           <div className="mt-1 text-xs text-text-secondary">{record.message}</div>
           {record.action ? (
-            <button
-              type="button"
-              className="mt-2 rounded-sm border border-border-subtle px-2 py-1 text-xs font-semibold text-text hover:bg-surface-hover focus-visible:shadow-[var(--ring-focus)]"
+            <Button
+              variant="secondary"
+              size="sm"
+              className="mt-2"
               onFocus={() => setPaused(true)}
               onBlur={onButtonBlur}
               onClick={() => {
@@ -174,21 +171,18 @@ function ToastCard({
               }}
             >
               {record.action.label}
-            </button>
+            </Button>
           ) : null}
         </div>
-        <button
-          type="button"
-          aria-label="Dismiss"
-          className="no-drag -mr-1 -mt-1 grid h-7 w-7 shrink-0 place-items-center rounded-sm text-xs font-semibold text-text-muted hover:bg-surface-hover hover:text-text focus-visible:shadow-[var(--ring-focus)]"
+        <IconButton
+          icon="x"
+          label="Dismiss"
+          size="sm"
+          className="no-drag -mr-1 -mt-1"
           onFocus={() => setPaused(true)}
           onBlur={onButtonBlur}
           onClick={() => onDismiss(record.id)}
-        >
-          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
-            <path d="M4 4l8 8M12 4l-8 8" />
-          </svg>
-        </button>
+        />
       </div>
     </section>
   )
@@ -240,8 +234,7 @@ export function Toaster() {
       role="status"
       aria-live="polite"
       aria-label="Notifications"
-      className="pointer-events-none fixed bottom-5 right-5 flex flex-col items-end gap-2"
-      style={{ zIndex: 'var(--z-toast)' }}
+      className="ui-toaster pointer-events-none flex flex-col items-end gap-2"
     >
       {hiddenCount > 0 ? (
         <div className="pointer-events-auto rounded-full border border-border-subtle bg-elevated px-3 py-1 text-xs font-semibold text-text-muted shadow-card">

--- a/apps/desktop/src/renderer/components/ui/Tooltip.tsx
+++ b/apps/desktop/src/renderer/components/ui/Tooltip.tsx
@@ -1,0 +1,114 @@
+import { cloneElement, isValidElement, useEffect, useId, useRef, useState, type ReactElement, type ReactNode } from 'react'
+
+type TooltipSide = 'top' | 'right' | 'bottom' | 'left'
+
+type DescribedChildProps = {
+  'aria-describedby'?: string
+}
+
+export type TooltipProps = {
+  content: ReactNode
+  children: ReactNode
+  side?: TooltipSide
+  delay?: number
+}
+
+function readTooltipGap() {
+  if (typeof window === 'undefined') return 8
+  const raw = window.getComputedStyle(document.documentElement).getPropertyValue('--space-2')
+  const parsed = Number.parseFloat(raw)
+  return Number.isFinite(parsed) ? parsed : 8
+}
+
+function positionFor(side: TooltipSide, rect: DOMRect) {
+  const gap = readTooltipGap()
+  switch (side) {
+    case 'right':
+      return { top: rect.top + (rect.height / 2), left: rect.right + gap, transform: 'translateY(-50%)' }
+    case 'bottom':
+      return { top: rect.bottom + gap, left: rect.left + (rect.width / 2), transform: 'translateX(-50%)' }
+    case 'left':
+      return { top: rect.top + (rect.height / 2), left: rect.left - gap, transform: 'translate(-100%, -50%)' }
+    case 'top':
+    default:
+      return { top: rect.top - gap, left: rect.left + (rect.width / 2), transform: 'translate(-50%, -100%)' }
+  }
+}
+
+export function Tooltip({
+  content,
+  children,
+  side = 'top',
+  delay = 250,
+}: TooltipProps) {
+  const id = useId()
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const timeoutRef = useRef<number | null>(null)
+  const [open, setOpen] = useState(false)
+  const [position, setPosition] = useState<ReturnType<typeof positionFor> | null>(null)
+
+  const show = () => {
+    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
+    timeoutRef.current = window.setTimeout(() => setOpen(true), delay)
+  }
+
+  const hide = () => {
+    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
+    timeoutRef.current = null
+    setOpen(false)
+  }
+
+  useEffect(() => {
+    if (!open || !anchorRef.current) return
+    const update = () => {
+      const rect = anchorRef.current?.getBoundingClientRect()
+      if (rect) setPosition(positionFor(side, rect))
+    }
+    update()
+    window.addEventListener('scroll', update, true)
+    window.addEventListener('resize', update)
+    return () => {
+      window.removeEventListener('scroll', update, true)
+      window.removeEventListener('resize', update)
+    }
+  }, [open, side])
+
+  useEffect(() => () => {
+    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
+  }, [])
+
+  const describedChild = isValidElement(children) && open
+    ? cloneElement(children as ReactElement<DescribedChildProps>, {
+        'aria-describedby': [
+          (children.props as DescribedChildProps)['aria-describedby'],
+          id,
+        ].filter(Boolean).join(' '),
+      })
+    : children
+
+  return (
+    // The wrapper only observes hover/focus to position descriptive text.
+    // The child keeps the actual interactive semantics and keyboard behavior.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <span
+      ref={anchorRef}
+      className="ui-tooltip-anchor"
+      onPointerEnter={show}
+      onPointerLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {describedChild}
+      {open && position ? (
+        <span
+          id={id}
+          role="tooltip"
+          className="ui-tooltip"
+          style={position}
+        >
+          {content}
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/apps/desktop/src/renderer/components/ui/index.ts
+++ b/apps/desktop/src/renderer/components/ui/index.ts
@@ -1,0 +1,20 @@
+export { Badge, type BadgeProps, type BadgeTone } from './Badge'
+export {
+  Button,
+  IconButton,
+  type ButtonProps,
+  type ButtonSize,
+  type ButtonVariant,
+  type IconButtonProps,
+} from './Button'
+export { Card, type CardProps } from './Card'
+export { Dialog, type DialogProps } from './Dialog'
+export { EmptyState, type EmptyStateProps } from './EmptyState'
+export { Icon, type IconName, type IconProps, type IconSize } from './Icon'
+export { Input, Textarea, type InputProps, type TextareaProps } from './Input'
+export { Kbd } from './Kbd'
+export { Menu, Select, type MenuItem, type MenuProps, type SelectOption, type SelectProps } from './Select'
+export { SegmentedControl, type SegmentedControlOption, type SegmentedControlProps } from './SegmentedControl'
+export { Skeleton, type SkeletonProps } from './Skeleton'
+export { Tooltip, type TooltipProps } from './Tooltip'
+export { Toaster, toast, type ToastOptions, type ToastTone } from './Toaster'

--- a/apps/desktop/src/renderer/components/ui/primitives.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/primitives.test.tsx
@@ -1,0 +1,363 @@
+import { useState } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  Badge,
+  Button,
+  Card,
+  Dialog,
+  EmptyState,
+  Icon,
+  IconButton,
+  Input,
+  Kbd,
+  Menu,
+  SegmentedControl,
+  Select,
+  Skeleton,
+  Textarea,
+  Tooltip,
+} from '.'
+import { PrimitiveGallery } from './PrimitiveGallery'
+
+describe('Icon', () => {
+  it('renders decorative Lucide icons by default', () => {
+    const { container } = render(<Icon name="search" />)
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+})
+
+describe('Button and IconButton', () => {
+  it('covers loading and disabled reason states', () => {
+    render(
+      <div>
+        <p id="run-context">Requires workspace access.</p>
+        <Button loading>Save</Button>
+        <Button aria-describedby="run-context" disabledReason="Workspace policy blocks this.">Run</Button>
+        <IconButton icon="search" label="Search threads" badge="2" />
+      </div>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save' })).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Run' }).getAttribute('aria-describedby')).toContain('run-context')
+    expect(screen.getByText('Workspace policy blocks this.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Search threads' })).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+})
+
+describe('Input and Textarea', () => {
+  it('supports clearable inputs, errors, and disabled reasons', async () => {
+    const user = userEvent.setup()
+    const onClear = vi.fn()
+    render(
+      <div>
+        <Input aria-label="Search" clearable value="threads" onClear={onClear} onChange={vi.fn()} error="Too broad." />
+        <Input aria-label="Locked" disabledReason="Managed by policy." />
+      </div>,
+    )
+
+    expect(screen.getByLabelText('Search')).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('Too broad.')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(onClear).toHaveBeenCalledTimes(1)
+    expect(screen.getByLabelText('Locked')).toBeDisabled()
+    expect(screen.getByText('Managed by policy.')).toBeInTheDocument()
+  })
+
+  it('tracks clearable uncontrolled input state', async () => {
+    const user = userEvent.setup()
+    render(<Input aria-label="Filter" clearable />)
+
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument()
+    await user.type(screen.getByLabelText('Filter'), 'agents')
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(screen.getByLabelText('Filter')).toHaveValue('')
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument()
+  })
+
+  it('renders textarea with error and disabled state semantics', () => {
+    render(<Textarea aria-label="Instructions" maxHeight="md" error="Required." disabledReason="Read-only workspace." />)
+
+    expect(screen.getByLabelText('Instructions')).toBeDisabled()
+    expect(screen.getByLabelText('Instructions')).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByLabelText('Instructions').style.getPropertyValue('--ui-textarea-max-height')).toBe('calc(var(--space-12) * 3)')
+    expect(screen.getByText('Required.')).toBeInTheDocument()
+    expect(screen.getByText('Read-only workspace.')).toBeInTheDocument()
+  })
+})
+
+describe('Select and Menu', () => {
+  it('selects options with roving keyboard focus', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <Select
+        label="Mode"
+        value="plan"
+        onChange={onChange}
+        options={[
+          { value: 'plan', label: 'Plan' },
+          { value: 'build', label: 'Build' },
+        ]}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Plan/ }))
+    expect(screen.getByRole('listbox', { name: 'Mode' })).toBeInTheDocument()
+    await user.keyboard('{ArrowDown}{Enter}')
+
+    expect(onChange).toHaveBeenCalledWith('build')
+  })
+
+  it('runs menu actions from the keyboard and exposes menu roles', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(
+      <Menu
+        label="Thread actions"
+        items={[
+          { id: 'copy', label: 'Copy link' },
+          { id: 'fork', label: 'Fork thread' },
+        ]}
+        onSelect={onSelect}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Thread actions/ }))
+    expect(screen.getByRole('menu', { name: 'Thread actions' })).toBeInTheDocument()
+    await user.keyboard('{ArrowDown}{Enter}')
+
+    expect(onSelect).toHaveBeenCalledWith('fork')
+  })
+
+  it('closes Select and Menu with Escape and renders disabled reasons', async () => {
+    const user = userEvent.setup()
+    render(
+      <div>
+        <Select
+          label="Locked mode"
+          value="plan"
+          onChange={vi.fn()}
+          disabledReason="Mode is managed."
+          options={[{ value: 'plan', label: 'Plan' }]}
+        />
+        <Menu
+          label="Locked actions"
+          disabledReason="Actions are managed."
+          items={[{ id: 'copy', label: 'Copy link' }]}
+          onSelect={vi.fn()}
+        />
+        <Select
+          label="Closable mode"
+          value="plan"
+          onChange={vi.fn()}
+          options={[{ value: 'plan', label: 'Plan' }]}
+        />
+        <Menu
+          label="Closable actions"
+          items={[{ id: 'copy', label: 'Copy link' }]}
+          onSelect={vi.fn()}
+        />
+      </div>,
+    )
+
+    expect(screen.getByRole('button', { name: /Locked mode/ })).toBeDisabled()
+    expect(screen.getByText('Mode is managed.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Locked actions' })).toBeDisabled()
+    expect(screen.getByText('Actions are managed.')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Closable mode/ }))
+    expect(screen.getByRole('listbox', { name: 'Closable mode' })).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('listbox', { name: 'Closable mode' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Closable actions/ }))
+    expect(screen.getByRole('menu', { name: 'Closable actions' })).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('menu', { name: 'Closable actions' })).not.toBeInTheDocument()
+  })
+
+  it('focuses an enabled Select option when the selected value is disabled', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <Select
+        label="Mode"
+        value="review"
+        onChange={onChange}
+        options={[
+          { value: 'review', label: 'Review', disabled: true, disabledReason: 'Unavailable.' },
+          { value: 'plan', label: 'Plan' },
+        ]}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Review/ }))
+    expect(screen.getByRole('option', { name: 'Plan' })).toHaveFocus()
+    await user.keyboard('{Enter}')
+
+    expect(onChange).toHaveBeenCalledWith('plan')
+  })
+
+  it('renders empty popovers as disabled described states', () => {
+    render(
+      <div>
+        <Select label="Empty mode" value="" onChange={vi.fn()} options={[]} />
+        <Menu label="Empty actions" items={[]} onSelect={vi.fn()} />
+      </div>,
+    )
+
+    expect(screen.getByRole('button', { name: /Empty mode/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Empty actions' })).toBeDisabled()
+    expect(screen.getByText('No options available.')).toBeInTheDocument()
+    expect(screen.getByText('No actions available.')).toBeInTheDocument()
+  })
+})
+
+describe('Dialog', () => {
+  it('renders a modal dialog and closes with Escape', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(
+      <Dialog title="Confirm" onClose={onClose}>
+        <Button>Keep working</Button>
+      </Dialog>,
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Confirm' })).toHaveAttribute('aria-modal', 'true')
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores focus and closes with Cmd/Ctrl+W', async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <Button onClick={() => setOpen(true)}>Open dialog</Button>
+          {open ? (
+            <Dialog title="Review" onClose={() => setOpen(false)}>
+              <Button>Inside dialog</Button>
+            </Dialog>
+          ) : null}
+        </>
+      )
+    }
+
+    render(<Harness />)
+
+    const opener = screen.getByRole('button', { name: 'Open dialog' })
+    await user.click(opener)
+    expect(screen.getByRole('dialog', { name: 'Review' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close dialog' })).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'w', metaKey: true })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Review' })).not.toBeInTheDocument()
+    })
+    expect(opener).toHaveFocus()
+  })
+})
+
+describe('Card', () => {
+  it('supports keyboard activation when interactive', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<Card interactive onClick={onClick}>Interactive card</Card>)
+
+    const card = screen.getByRole('button', { name: 'Interactive card' })
+    card.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Card, Badge, Tooltip, Kbd, EmptyState, Skeleton', () => {
+  it('renders static primitives with accessible semantics', async () => {
+    vi.useFakeTimers()
+    render(
+      <div>
+        <Card>Static card</Card>
+        <Badge tone="success">Ready</Badge>
+        <Tooltip content="Tooltip details" delay={10}>
+          <button type="button">Hover target</button>
+        </Tooltip>
+        <Kbd>Cmd</Kbd>
+        <EmptyState icon="blocks" title="Nothing here" body="Create something to continue." action={<Button>Create</Button>} />
+        <Skeleton variant="card" data-testid="skeleton" />
+      </div>,
+    )
+
+    expect(screen.getByText('Static card')).toBeInTheDocument()
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+    fireEvent.focus(screen.getByRole('button', { name: 'Hover target' }))
+    act(() => {
+      vi.advanceTimersByTime(10)
+    })
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Tooltip details')
+    expect(screen.getByRole('button', { name: 'Hover target' }).getAttribute('aria-describedby')).toBe(screen.getByRole('tooltip').id)
+    expect(screen.getByText('Cmd').tagName).toBe('KBD')
+    expect(screen.getByText('Nothing here')).toBeInTheDocument()
+    expect(screen.getByTestId('skeleton')).toHaveAttribute('aria-hidden', 'true')
+    vi.useRealTimers()
+  })
+})
+
+describe('SegmentedControl', () => {
+  it('uses tab roles and keyboard selection', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <SegmentedControl
+        label="Agent mode"
+        value="plan"
+        onChange={onChange}
+        options={[
+          { value: 'plan', label: 'Plan' },
+          { value: 'build', label: 'Build' },
+        ]}
+      />,
+    )
+
+    screen.getByRole('tab', { name: 'Plan' }).focus()
+    await user.keyboard('{ArrowRight}{Enter}')
+
+    expect(screen.getByRole('tablist', { name: 'Agent mode' })).toBeInTheDocument()
+    expect(onChange).toHaveBeenCalledWith('build')
+  })
+
+  it('renders an empty segmented control without invalid option state', () => {
+    render(<SegmentedControl label="Empty segments" value="" onChange={vi.fn()} options={[]} />)
+
+    expect(screen.getByRole('tablist', { name: 'Empty segments' })).toBeInTheDocument()
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+    expect(screen.getByText('No segments available.')).toBeInTheDocument()
+  })
+})
+
+describe('PrimitiveGallery', () => {
+  it('renders the primitive review matrix', () => {
+    render(<PrimitiveGallery />)
+
+    expect(screen.getByRole('heading', { name: 'UI primitives' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Buttons' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Icon Buttons' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Select And Menu' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Badges, Tooltip, Kbd, Skeleton, Toast' })).toBeInTheDocument()
+    expect(screen.getByText('primary sm')).toBeInTheDocument()
+    expect(screen.getByText('danger lg')).toBeInTheDocument()
+    expect(screen.getByText('Card sm')).toBeInTheDocument()
+    expect(screen.getByText('Card lg')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Loading settings' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Toast' })).toBeInTheDocument()
+    expect(screen.getByText('Mode selection is managed by policy.')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/components/ui/utils.ts
+++ b/apps/desktop/src/renderer/components/ui/utils.ts
@@ -1,0 +1,16 @@
+export function cn(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(' ')
+}
+
+export function nextEnabledIndex<T extends { disabled?: boolean }>(
+  items: T[],
+  current: number,
+  direction: 1 | -1,
+) {
+  if (items.length === 0) return -1
+  for (let offset = 1; offset <= items.length; offset += 1) {
+    const index = (current + (offset * direction) + items.length) % items.length
+    if (!items[index]?.disabled) return index
+  }
+  return -1
+}

--- a/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
+++ b/apps/desktop/src/renderer/components/workflows/WorkflowsPage.tsx
@@ -198,7 +198,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
       <div className="border-b border-border px-6 py-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0">
-            <h1 className="text-[22px] font-semibold tracking-normal text-primary">Workflows</h1>
+            <h1 className="font-display text-role-page-title font-bold text-primary">Workflows</h1>
             <p className="mt-1 max-w-2xl text-sm text-muted">
               Save repeatable work from a Workflow Designer setup thread, then run it manually, on a schedule, or from a webhook.
             </p>
@@ -226,7 +226,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
         ) : activeWorkflows.length === 0 ? (
           <div className="flex min-h-[360px] items-center justify-center rounded-lg border border-dashed border-border bg-surface/40 px-6 text-center">
             <div>
-              <h2 className="text-lg font-semibold text-primary">No workflows yet</h2>
+              <h2 className="font-display text-role-section-title font-bold text-primary">No workflows yet</h2>
               <p className="mt-2 max-w-md text-sm text-muted">
                 {workflowListBlocked && workflowListReason
                   ? workflowListReason
@@ -254,7 +254,7 @@ export function WorkflowsPage({ onOpenThread }: Props) {
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h2 className="min-w-0 text-base font-semibold text-primary">{workflow.title}</h2>
+                      <h2 className="min-w-0 font-display text-role-card-title font-bold text-primary">{workflow.title}</h2>
                       <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${statusTone(workflow.status)}`}>
                         {workflow.status}
                       </span>

--- a/apps/desktop/src/renderer/helpers/theme.test.ts
+++ b/apps/desktop/src/renderer/helpers/theme.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { applyAppearancePreferences, getAppearancePreferences, UI_FONT_OPTIONS } from './theme'
+
+describe('appearance typography defaults', () => {
+  it('defaults the interface font to Mona Sans and exposes the display font token', () => {
+    expect(getAppearancePreferences().uiFont).toBe('mona')
+    expect(UI_FONT_OPTIONS[0]).toEqual({ id: 'mona', label: 'Mona Sans' })
+
+    applyAppearancePreferences()
+
+    expect(document.documentElement.style.getPropertyValue('--font-ui')).toContain('Mona Sans')
+    expect(document.documentElement.style.getPropertyValue('--font-display')).toContain('Hubot Sans')
+  })
+
+  it('keeps existing interface font overrides available', () => {
+    window.localStorage.setItem('open-cowork-ui-font', 'rounded')
+
+    applyAppearancePreferences()
+
+    expect(getAppearancePreferences().uiFont).toBe('rounded')
+    expect(document.documentElement.style.getPropertyValue('--font-ui')).toContain('SF Pro Rounded')
+    expect(document.documentElement.style.getPropertyValue('--font-display')).toContain('Hubot Sans')
+  })
+})

--- a/apps/desktop/src/renderer/helpers/theme.ts
+++ b/apps/desktop/src/renderer/helpers/theme.ts
@@ -10,7 +10,7 @@ export { getThemeTokens, getUiThemeOptions, getDefaultThemeId }
 export type { UiTheme }
 
 export type ColorScheme = 'system' | 'dark' | 'light'
-export type UiFont = 'system' | 'rounded' | 'serif'
+export type UiFont = 'mona' | 'system' | 'rounded' | 'serif'
 export type MonoFont = 'sfmono' | 'jetbrains' | 'fira'
 
 export type AppearancePreferences = {
@@ -41,10 +41,13 @@ const LEGACY_THEME_MAP: Record<string, UiTheme> = {
 const SYSTEM_QUERY = '(prefers-color-scheme: light)'
 
 const UI_FONT_STACKS: Record<UiFont, string> = {
+  mona: "'Mona Sans Variable', 'Mona Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
   system: "-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', 'Segoe UI', sans-serif",
   rounded: "'SF Pro Rounded', 'Avenir Next Rounded', 'Nunito', -apple-system, BlinkMacSystemFont, sans-serif",
   serif: "'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif",
 }
+
+const DISPLAY_FONT_STACK = "'Hubot Sans Variable', 'Hubot Sans', var(--font-ui)"
 
 const MONO_FONT_STACKS: Record<MonoFont, string> = {
   sfmono: "'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace",
@@ -54,6 +57,7 @@ const MONO_FONT_STACKS: Record<MonoFont, string> = {
 
 
 export const UI_FONT_OPTIONS: Array<{ id: UiFont; label: string }> = [
+  { id: 'mona', label: 'Mona Sans' },
   { id: 'system', label: 'System' },
   { id: 'rounded', label: 'Rounded' },
   { id: 'serif', label: 'Serif' },
@@ -90,9 +94,9 @@ function readUiTheme(): UiTheme {
 
 function readUiFont(): UiFont {
   const stored = localStorage.getItem(STORAGE_KEYS.uiFont)
-  return stored === 'rounded' || stored === 'serif' || stored === 'system'
+  return stored === 'mona' || stored === 'rounded' || stored === 'serif' || stored === 'system'
     ? stored
-    : 'system'
+    : 'mona'
 }
 
 function readMonoFont(): MonoFont {
@@ -174,6 +178,7 @@ export function applyAppearancePreferences(preferences = getAppearancePreference
   const root = document.documentElement
   root.setAttribute('data-ui-theme', preferences.uiTheme)
   root.style.setProperty('--font-ui', UI_FONT_STACKS[preferences.uiFont])
+  root.style.setProperty('--font-display', DISPLAY_FONT_STACK)
   root.style.setProperty('--font-mono', MONO_FONT_STACKS[preferences.monoFont])
   applyResolvedColorScheme(preferences.colorScheme)
   applyThemeVariables(preferences.uiTheme, preferences.colorScheme)

--- a/apps/desktop/src/renderer/hooks/useFocusTrap.ts
+++ b/apps/desktop/src/renderer/hooks/useFocusTrap.ts
@@ -31,7 +31,17 @@ const FOCUSABLE_SELECTOR = [
 
 function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
-    .filter((el) => !el.hasAttribute('inert') && el.offsetParent !== null)
+    .filter((el) => !el.hasAttribute('inert') && isVisible(el))
+}
+
+function isVisible(element: HTMLElement) {
+  let current: HTMLElement | null = element
+  while (current && current !== document.body) {
+    const style = window.getComputedStyle(current)
+    if (style.display === 'none' || style.visibility === 'hidden') return false
+    current = current.parentElement
+  }
+  return true
 }
 
 export function useFocusTrap(

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -1,5 +1,41 @@
 @import "tailwindcss";
 
+@font-face {
+  font-family: 'Mona Sans Variable';
+  font-style: normal;
+  font-display: block;
+  font-weight: 200 900;
+  src: url('@fontsource-variable/mona-sans/files/mona-sans-latin-wght-normal.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+  font-family: 'Mona Sans Variable';
+  font-style: italic;
+  font-display: block;
+  font-weight: 200 900;
+  src: url('@fontsource-variable/mona-sans/files/mona-sans-latin-wght-italic.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+  font-family: 'Hubot Sans Variable';
+  font-style: normal;
+  font-display: block;
+  font-weight: 200 900;
+  src: url('@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-normal.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+  font-family: 'Hubot Sans Variable';
+  font-style: italic;
+  font-display: block;
+  font-weight: 200 900;
+  src: url('@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-italic.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
 @theme {
   --color-base: #1b1b26;
   --color-surface: rgba(141, 164, 245, 0.04);
@@ -62,7 +98,8 @@
 }
 
 :root {
-  --font-ui: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', 'Segoe UI', sans-serif;
+  --font-ui: 'Mona Sans Variable', 'Mona Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Hubot Sans Variable', 'Hubot Sans', var(--font-ui);
   --font-mono: 'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
   --text-2xs: 11px;
   --lh-2xs: 14px;
@@ -118,6 +155,17 @@
   --control-h-sm: 28px;
   --control-h-md: 32px;
   --control-h-lg: 40px;
+  --control-h-xl: 48px;
+  --border-width-1: 1px;
+  --icon-size-sm: 16px;
+  --icon-size-md: 20px;
+  --icon-size-lg: 24px;
+  --primitive-tooltip-max-w: calc((var(--space-12) * 5) + var(--space-5));
+  --primitive-popover-max-h: calc((var(--space-12) * 6) + var(--space-8));
+  --primitive-dialog-max-h: calc(var(--space-12) * 15);
+  --primitive-dialog-w-sm: calc((var(--space-10) * 10) + var(--space-5));
+  --primitive-dialog-w-md: calc((var(--space-12) * 11) + var(--space-8));
+  --primitive-dialog-w-lg: calc((var(--space-12) * 15) + var(--space-10));
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -134,8 +182,10 @@ html, body, #root {
   overflow: hidden;
   color: var(--color-text);
   font-family: var(--font-ui);
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--text-md);
+  line-height: var(--lh-md);
+  font-feature-settings: "tnum" 1, "cv01" 1;
+  font-variant-numeric: tabular-nums;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -152,6 +202,748 @@ body {
 }
 
 .shadow-card { box-shadow: var(--shadow-card); }
+
+.font-display {
+  font-family: var(--font-display);
+}
+
+.tabular {
+  font-feature-settings: "tnum" 1, "cv01" 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.text-role-hero {
+  font-size: var(--text-hero);
+  line-height: var(--lh-hero);
+}
+
+.text-role-page-title {
+  font-size: var(--text-2xl);
+  line-height: var(--lh-2xl);
+}
+
+.text-role-section-title {
+  font-size: var(--text-xl);
+  line-height: var(--lh-xl);
+}
+
+.text-role-card-title {
+  font-size: var(--text-lg);
+  line-height: var(--lh-lg);
+}
+
+.text-role-body {
+  font-size: var(--text-md);
+  line-height: var(--lh-md);
+}
+
+.text-role-dense {
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+}
+
+.text-role-metadata {
+  font-size: var(--text-xs);
+  line-height: var(--lh-xs);
+}
+
+.ui-control-stack {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.ui-disabled-reason {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  max-width: 100%;
+  color: var(--color-text-muted);
+  font-size: var(--text-2xs);
+  line-height: var(--lh-2xs);
+}
+
+.ui-tooltip-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.ui-tooltip {
+  position: fixed;
+  z-index: var(--z-tooltip);
+  max-width: min(var(--primitive-tooltip-max-w), calc(100vw - var(--space-8)));
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-elevated) 94%, var(--color-base) 6%);
+  box-shadow: var(--elevation-popover);
+  color: var(--color-text);
+  font-size: var(--text-xs);
+  line-height: var(--lh-xs);
+  padding: var(--space-2) var(--space-3);
+  pointer-events: none;
+}
+
+.ui-primitive-gallery__shell {
+  max-width: calc((var(--space-12) * 23) + var(--space-4));
+}
+
+.ui-toaster {
+  position: fixed;
+  inset-block-end: var(--space-5);
+  inset-inline-end: var(--space-5);
+  z-index: var(--z-toast);
+}
+
+.ui-toast-card {
+  width: min(calc((var(--space-12) * 7) + var(--space-6)), calc(100vw - var(--space-8)));
+  border: var(--border-width-1) solid var(--toast-border);
+  border-radius: var(--radius-lg);
+  background: var(--toast-bg);
+  box-shadow: var(--shadow-card);
+  padding: var(--space-3);
+}
+
+.ui-toast-indicator {
+  width: var(--space-2);
+  height: var(--space-2);
+  margin-block-start: var(--space-1);
+  border-radius: var(--radius-full);
+  background: var(--toast-color);
+  box-shadow: 0 0 0 var(--space-1) color-mix(in srgb, var(--toast-color) 18%, transparent);
+}
+
+.ui-button,
+.ui-icon-button,
+.ui-input,
+.ui-textarea,
+.ui-select-trigger,
+.ui-menu-trigger,
+.ui-segmented-option {
+  border: var(--border-width-1) solid transparent;
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--dur-1) var(--ease-out),
+    border-color var(--dur-1) var(--ease-out),
+    color var(--dur-1) var(--ease-out),
+    box-shadow var(--dur-1) var(--ease-out),
+    transform var(--dur-1) var(--ease-out);
+}
+
+.ui-button,
+.ui-icon-button,
+.ui-select-trigger,
+.ui-menu-trigger,
+.ui-segmented-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  font-weight: 650;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ui-button:focus-visible,
+.ui-icon-button:focus-visible,
+.ui-input:focus-visible,
+.ui-textarea:focus-visible,
+.ui-select-trigger:focus-visible,
+.ui-menu-trigger:focus-visible,
+.ui-segmented-option:focus-visible,
+.ui-popover-item:focus-visible,
+.ui-dialog:focus-visible {
+  outline: none;
+  box-shadow: var(--ring-focus);
+}
+
+.ui-button:active:not(:disabled),
+.ui-icon-button:active:not(:disabled),
+.ui-select-trigger:active:not(:disabled),
+.ui-menu-trigger:active:not(:disabled),
+.ui-segmented-option:active:not(:disabled) {
+  transform: translateY(var(--border-width-1));
+}
+
+.ui-button:disabled,
+.ui-icon-button:disabled,
+.ui-input:disabled,
+.ui-textarea:disabled,
+.ui-select-trigger:disabled,
+.ui-menu-trigger:disabled,
+.ui-segmented-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.ui-button--sm {
+  min-height: var(--control-h-sm);
+  padding: 0 var(--space-3);
+  font-size: var(--text-xs);
+  line-height: var(--lh-xs);
+}
+
+.ui-button--md {
+  min-height: var(--control-h-md);
+  padding: 0 var(--space-4);
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+}
+
+.ui-button--lg {
+  min-height: var(--control-h-lg);
+  padding: 0 var(--space-5);
+  font-size: var(--text-md);
+  line-height: var(--lh-md);
+}
+
+.ui-button--full {
+  width: 100%;
+}
+
+.ui-button--primary {
+  background: var(--color-accent);
+  color: var(--color-accent-foreground);
+  border-color: color-mix(in srgb, var(--color-accent) 82%, var(--color-text) 18%);
+}
+
+.ui-button--primary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.ui-button--secondary {
+  background: var(--color-elevated);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.ui-icon-button--secondary {
+  background: var(--color-elevated);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.ui-button--secondary:hover:not(:disabled),
+.ui-icon-button--secondary:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+}
+
+.ui-button--ghost,
+.ui-icon-button--ghost {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-color: transparent;
+}
+
+.ui-button--ghost:hover:not(:disabled),
+.ui-icon-button--ghost:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.ui-button--danger,
+.ui-icon-button--danger {
+  background: color-mix(in srgb, var(--color-red) 12%, transparent);
+  color: var(--color-red);
+  border-color: color-mix(in srgb, var(--color-red) 34%, transparent);
+}
+
+.ui-button--danger:hover:not(:disabled),
+.ui-icon-button--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-red) 18%, transparent);
+}
+
+.ui-icon-button {
+  flex: none;
+  padding: 0;
+  position: relative;
+}
+
+.ui-icon-button--sm {
+  width: var(--control-h-sm);
+  height: var(--control-h-sm);
+}
+
+.ui-icon-button--md {
+  width: var(--control-h-md);
+  height: var(--control-h-md);
+}
+
+.ui-icon-button__badge {
+  position: absolute;
+  inset-block-start: calc(-1 * var(--space-1));
+  inset-inline-end: calc(-1 * var(--space-1));
+  display: inline-flex;
+  min-width: var(--space-4);
+  height: var(--space-4);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  color: var(--color-accent-foreground);
+  font-size: var(--text-2xs);
+  line-height: var(--lh-2xs);
+}
+
+.ui-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.ui-field__chrome {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.ui-input,
+.ui-textarea {
+  width: 100%;
+  background: color-mix(in srgb, var(--color-base) 70%, var(--color-elevated) 30%);
+  border-color: var(--color-border-subtle);
+  color: var(--color-text);
+  font-family: var(--font-ui);
+}
+
+.ui-input::placeholder,
+.ui-textarea::placeholder {
+  color: var(--color-text-muted);
+}
+
+.ui-input:hover:not(:disabled),
+.ui-textarea:hover:not(:disabled) {
+  border-color: var(--color-border);
+}
+
+.ui-input[aria-invalid="true"],
+.ui-textarea[aria-invalid="true"] {
+  border-color: color-mix(in srgb, var(--color-red) 58%, var(--color-border));
+}
+
+.ui-input--sm {
+  min-height: var(--control-h-sm);
+  padding: 0 var(--space-3);
+  font-size: var(--text-xs);
+  line-height: var(--lh-xs);
+}
+
+.ui-input--md {
+  min-height: var(--control-h-md);
+  padding: 0 var(--space-3);
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+}
+
+.ui-input--lg {
+  min-height: var(--control-h-lg);
+  padding: 0 var(--space-4);
+  font-size: var(--text-md);
+  line-height: var(--lh-md);
+}
+
+.ui-field__left-icon {
+  position: absolute;
+  inset-inline-start: var(--space-3);
+  color: var(--color-text-muted);
+  pointer-events: none;
+}
+
+.ui-input--with-left-icon {
+  padding-inline-start: calc(var(--space-6) + var(--space-3));
+}
+
+.ui-input--clearable {
+  padding-inline-end: calc(var(--space-6) + var(--space-3));
+}
+
+.ui-input__clear {
+  position: absolute;
+  inset-inline-end: var(--space-1);
+  color: var(--color-text-muted);
+}
+
+.ui-field__message {
+  font-size: var(--text-2xs);
+  line-height: var(--lh-2xs);
+  color: var(--color-text-muted);
+}
+
+.ui-field__message--error {
+  color: var(--color-red);
+}
+
+.ui-textarea {
+  min-height: calc(var(--control-h-lg) + var(--space-4));
+  max-height: var(--ui-textarea-max-height, none);
+  resize: vertical;
+  padding: var(--space-3);
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+}
+
+.ui-popover-root {
+  position: relative;
+  display: inline-block;
+  min-width: 0;
+}
+
+.ui-select-trigger,
+.ui-menu-trigger {
+  width: 100%;
+  min-height: var(--control-h-md);
+  justify-content: space-between;
+  background: color-mix(in srgb, var(--color-base) 70%, var(--color-elevated) 30%);
+  border-color: var(--color-border-subtle);
+  color: var(--color-text);
+  padding: 0 var(--space-3);
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+}
+
+.ui-select-trigger:hover:not(:disabled),
+.ui-menu-trigger:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+  border-color: var(--color-border);
+}
+
+.ui-popover {
+  position: absolute;
+  inset-block-start: calc(100% + var(--space-1));
+  inset-inline-start: 0;
+  z-index: var(--z-dropdown);
+  min-width: 100%;
+  max-height: min(var(--primitive-popover-max-h), calc(100vh - var(--space-12)));
+  overflow: auto;
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-elevated) 94%, var(--color-base) 6%);
+  box-shadow: var(--elevation-popover);
+  padding: var(--space-1);
+}
+
+.ui-popover-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  min-height: var(--control-h-md);
+  padding: 0 var(--space-3);
+  text-align: start;
+}
+
+.ui-popover-item:hover:not(:disabled),
+.ui-popover-item[data-active="true"] {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.ui-popover-item[aria-selected="true"] {
+  color: var(--color-text);
+  box-shadow: var(--ring-selected);
+}
+
+.ui-popover-item__content {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.ui-popover-item__label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ui-popover-item__hint {
+  color: var(--color-text-muted);
+  font-size: var(--text-2xs);
+  line-height: var(--lh-2xs);
+}
+
+.ui-popover-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.ui-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal);
+  background: color-mix(in srgb, var(--color-base) 66%, transparent);
+}
+
+.ui-dialog {
+  position: fixed;
+  inset-block-start: 12vh;
+  inset-inline-start: 50%;
+  z-index: calc(var(--z-modal) + 1);
+  display: flex;
+  max-height: min(var(--primitive-dialog-max-h), calc(100vh - var(--space-12)));
+  max-width: calc(100vw - var(--space-8));
+  transform: translateX(-50%);
+  flex-direction: column;
+  overflow: hidden;
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--color-elevated) 92%, var(--color-base) 8%);
+  box-shadow: var(--shadow-elevated);
+  color: var(--color-text);
+}
+
+.ui-dialog--sm { width: min(var(--primitive-dialog-w-sm), calc(100vw - var(--space-8))); }
+.ui-dialog--md { width: min(var(--primitive-dialog-w-md), calc(100vw - var(--space-8))); }
+.ui-dialog--lg { width: min(var(--primitive-dialog-w-lg), calc(100vw - var(--space-8))); }
+
+.ui-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  border-bottom: var(--border-width-1) solid var(--color-border-subtle);
+  padding: var(--space-4);
+}
+
+.ui-dialog__title {
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: 700;
+  line-height: var(--lh-xl);
+}
+
+.ui-dialog__body {
+  overflow: auto;
+  padding: var(--space-4);
+}
+
+.ui-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  border-top: var(--border-width-1) solid var(--color-border-subtle);
+  padding: var(--space-4);
+}
+
+.ui-card {
+  border: var(--border-width-1) solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-elevated) 68%, transparent);
+  color: var(--color-text);
+}
+
+.ui-card--sm { padding: var(--space-3); }
+.ui-card--md { padding: var(--space-4); }
+.ui-card--lg { padding: var(--space-5); }
+
+.ui-card--interactive {
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  font: inherit;
+  text-align: start;
+  transition:
+    background var(--dur-1) var(--ease-out),
+    border-color var(--dur-1) var(--ease-out),
+    box-shadow var(--dur-1) var(--ease-out);
+}
+
+.ui-card--interactive:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-border);
+}
+
+.ui-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-height: var(--control-h-sm);
+  border: var(--border-width-1) solid transparent;
+  border-radius: var(--radius-full);
+  padding: 0 var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 650;
+  line-height: var(--lh-xs);
+}
+
+.ui-badge--neutral {
+  background: var(--color-surface);
+  border-color: var(--color-border-subtle);
+  color: var(--color-text-secondary);
+}
+
+.ui-badge--accent {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 34%, transparent);
+  color: var(--color-accent);
+}
+
+.ui-badge--success {
+  background: color-mix(in srgb, var(--color-green) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-green) 34%, transparent);
+  color: var(--color-green);
+}
+
+.ui-badge--warning {
+  background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-amber) 34%, transparent);
+  color: var(--color-amber);
+}
+
+.ui-badge--danger {
+  background: color-mix(in srgb, var(--color-red) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-red) 34%, transparent);
+  color: var(--color-red);
+}
+
+.ui-kbd {
+  display: inline-flex;
+  min-width: var(--control-h-sm);
+  min-height: var(--control-h-sm);
+  align-items: center;
+  justify-content: center;
+  border: var(--border-width-1) solid var(--color-border-subtle);
+  border-radius: var(--radius-xs);
+  background: color-mix(in srgb, var(--color-base) 78%, var(--color-elevated) 22%);
+  color: var(--color-text-secondary);
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  line-height: var(--lh-xs);
+  padding: 0 var(--space-2);
+}
+
+.ui-segmented-control {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  gap: var(--space-1);
+  border: var(--border-width-1) solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-base) 64%, var(--color-elevated) 36%);
+  padding: var(--space-1);
+}
+
+.ui-segmented-option {
+  min-height: var(--control-h-md);
+  background: transparent;
+  color: var(--color-text-muted);
+  padding: 0 var(--space-3);
+  font-size: var(--text-xs);
+  line-height: var(--lh-xs);
+}
+
+.ui-segmented-option:hover:not(:disabled) {
+  color: var(--color-text-secondary);
+}
+
+.ui-segmented-option[aria-selected="true"] {
+  background: var(--color-surface-active);
+  color: var(--color-text);
+  box-shadow: var(--ring-selected);
+}
+
+.ui-empty-state {
+  display: grid;
+  place-items: center;
+  gap: var(--space-3);
+  border: var(--border-width-1) dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-surface) 68%, transparent);
+  color: var(--color-text-secondary);
+  padding: var(--space-8);
+  text-align: center;
+}
+
+.ui-empty-state__icon {
+  display: grid;
+  place-items: center;
+  width: var(--control-h-xl);
+  height: var(--control-h-xl);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  color: var(--color-accent);
+}
+
+.ui-empty-state__title {
+  color: var(--color-text);
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  line-height: var(--lh-lg);
+}
+
+.ui-empty-state__body {
+  max-width: 42ch;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+}
+
+.ui-skeleton {
+  display: block;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-surface) 80%, transparent),
+    color-mix(in srgb, var(--color-surface-hover) 82%, transparent),
+    color-mix(in srgb, var(--color-surface) 80%, transparent)
+  );
+  background-size: 200% 100%;
+  animation: ui-skeleton-shimmer 1.2s var(--ease-out) infinite;
+}
+
+.ui-skeleton--text {
+  width: 100%;
+  height: var(--lh-sm);
+}
+
+.ui-skeleton--block {
+  width: 100%;
+  min-height: calc(var(--space-12) * 2);
+}
+
+.ui-skeleton--card {
+  width: 100%;
+  min-height: calc(var(--space-12) * 3);
+  border-radius: var(--radius-md);
+}
+
+@keyframes ui-skeleton-shimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+@keyframes ui-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ui-spin {
+  animation: ui-spin 820ms linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-skeleton {
+    animation: none;
+  }
+
+  .ui-spin {
+    animation: none;
+  }
+}
 
 .theme-popover {
   background: color-mix(in srgb, var(--color-elevated) 88%, var(--color-base) 12%);

--- a/docs/iconography.md
+++ b/docs/iconography.md
@@ -1,0 +1,68 @@
+# Iconography
+
+Open Cowork uses Lucide through the renderer `Icon` wrapper at
+`apps/desktop/src/renderer/components/ui/Icon.tsx`.
+
+Use the wrapper instead of bespoke inline SVGs for app chrome, navigation,
+toolbars, menus, and shared primitives:
+
+```tsx
+<Icon name="search" size={16} />
+<IconButton icon="settings-2" label="Open settings" />
+```
+
+The wrapper sets `currentColor`, a 24px Lucide grid, and a default
+`strokeWidth` of `1.5`. Icons are decorative by default with
+`aria-hidden="true"`; interactive labels belong on the button or menu item
+that contains the icon.
+
+## Inventory
+
+| Product meaning | Lucide wrapper name |
+| --- | --- |
+| Home | `home` |
+| Agents | `bot` |
+| People / collaborators | `users` |
+| Workflows | `workflow` |
+| Tools and skills | `blocks` |
+| Tools / actions | `wrench` |
+| Health / readiness | `heart-pulse` or `activity` |
+| Search | `search` |
+| Settings | `settings-2` |
+| Sidebar toggle | `panel-left` |
+| Send | `arrow-up` |
+| Attach file | `paperclip` |
+| Stop | `square` |
+| Model / intelligence | `sparkles` |
+| Reasoning | `brain` |
+| Folder / project | `folder` |
+| Fork thread | `git-fork` |
+| Confirm / selected | `check` |
+| Close / dismiss | `x` |
+| More options / select | `chevron-down` |
+| Empty state / building blocks | `blocks` |
+| Warnings | `alert-circle` |
+| Help / disabled reason | `circle-help` or `info` |
+
+## Rules
+
+- Add new icon names to `Icon.tsx` with named Lucide imports. Do not import the
+  full icon namespace.
+- Keep decorative icons hidden from assistive technology. Use `IconButton`
+  when the icon itself is the control; its `label` prop is required.
+- Use sizes `16`, `20`, or `24` unless a product surface has a documented
+  exception.
+- Do not use inline SVGs in chrome, navigation, toolbars, or shared primitives.
+- Brand logos and downstream-provided brand media remain outside this system.
+
+## Bundle Behavior
+
+`lucide-react` declares `sideEffects: false`; `Icon.tsx` imports named Lucide
+icons only for the product inventory above. The desktop Vite build verifies the
+icon set stays tree-shakeable because no `* as Icons` namespace import is used.
+
+## Licensing
+
+`lucide-react` is recorded in `THIRD_PARTY_NOTICES.md` from the package
+manifest. The bundled font packages for Mona Sans and Hubot Sans are also
+recorded there under OFL-1.1.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - Downstream Customization: downstream.md
       - Downstream Contract: downstream-contract.md
       - Design Tokens: design-tokens.md
+      - Iconography: iconography.md
       - OpenCode SDK Boundary: opencode-sdk-v2-boundary.md
       - Development Environment: development-environment.md
       - Performance: performance.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,12 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1054.0
         version: 3.1054.0
+      '@fontsource-variable/hubot-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/mona-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -76,6 +82,9 @@ importers:
       google-auth-library:
         specifier: ^10.6.2
         version: 10.6.2
+      lucide-react:
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.5)
       marked:
         specifier: ^18.0.3
         version: 18.0.3
@@ -1065,6 +1074,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fontsource-variable/hubot-sans@5.2.8':
+    resolution: {integrity: sha512-snt3rHAg6IrE0DKltYvjsIoeB+GSUpQHY3PAkMGUzxp8gN31kTl8yFuyuK6RcknIjtCVo7v0S6i31Oif3QxtjA==}
+
+  '@fontsource-variable/mona-sans@5.2.8':
+    resolution: {integrity: sha512-8OWdTcP8KvRxkU1Skkk+tX3D5XHN9buejxSDwrT7teRfGnpKBYxQUApV/+zS8TzeHiSU8H5Tc0HfBr57ahgcvA==}
 
   '@grammyjs/types@3.27.3':
     resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
@@ -3617,6 +3632,11 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -5835,6 +5855,10 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@fontsource-variable/hubot-sans@5.2.8': {}
+
+  '@fontsource-variable/mona-sans@5.2.8': {}
 
   '@grammyjs/types@3.27.3': {}
 
@@ -8646,6 +8670,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@1.17.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
Part of #712.

Closes #701.
Closes #702.
Closes #703.

## Summary

- Adds the Mona Sans / Hubot Sans typography pairing with local bundled font assets, display/body tokens, appearance override support, and tabular numeric treatment on status/facet surfaces.
- Adds the Lucide-backed `Icon` wrapper, replaces bespoke SVGs in the required chrome/nav/toolbar/ui surfaces, and documents the icon inventory in `docs/iconography.md`.
- Adds token-driven renderer primitives under `components/ui/`, including Button/IconButton, Input/Textarea, Select/Menu, Dialog, Card, Badge, Tooltip, Kbd, SegmentedControl, EmptyState, Skeleton, Toaster integration, and the `#/ui-primitives` QA gallery.
- Hardens primitive behavior from review: empty Select/Menu/SegmentedControl data, disabled selected-option handling, native interactive cards, tooltip child descriptions, uncontrolled clearable inputs, focus-trap visibility, disabled reasons, and expanded matrix tests.
- Keeps display typography on the Hubot face without negative letter spacing, matching the current renderer design constraints.

## Review Evidence

- Fonts are bundled by the production desktop build as four local WOFF2 assets: Mona Sans normal/italic and Hubot Sans normal/italic; `font-display: block` is used in the renderer CSS.
- Icon tree-shaking is kept to named `lucide-react` imports in `Icon.tsx`; the serial desktop build completed with no Lucide namespace chunk and emitted `main-oMa2kwDv.js` at 285.81 kB / 78.40 kB gzip plus a lazy `PrimitiveGallery` chunk at 6.21 kB / 1.98 kB gzip.
- `rg "<svg|</svg"` returned no matches for `TitleBar.tsx`, `Sidebar.tsx`, `StatusBar.tsx`, `ChatInputToolbar.tsx`, or `components/ui`.
- `rg "tracking-\\[-|letter-spacing:\\s*-" apps/desktop/src/renderer -n` returned no matches after the final typography review.
- `lucide-react@1.17.0` is recorded from its package manifest as ISC in `THIRD_PARTY_NOTICES.md`; Fontsource Mona/Hubot notices are OFL-1.1.

## Validation

- `pnpm --dir apps/desktop test:renderer src/renderer/components/ui/primitives.test.tsx src/renderer/helpers/theme.test.ts` — 2 files, 19 tests passed after the final typography review
- `pnpm --filter @open-cowork/desktop typecheck`
- `pnpm test:coverage:node`
- `pnpm --dir apps/desktop test:renderer src/renderer/components/ui/primitives.test.tsx` — 1 file, 17 tests passed after PR review fixes
- `pnpm --dir apps/desktop test:renderer src/renderer/components/ui/primitives.test.tsx src/renderer/components/ui/Toaster.test.tsx src/renderer/helpers/theme.test.ts src/renderer/components/chat/ChatInputToolbar.test.tsx src/renderer/components/layout/TitleBar.test.tsx src/renderer/components/layout/Sidebar.test.tsx src/renderer/components/layout/StatusBar.test.tsx` — 7 files, 50 tests passed before final review patch
- `pnpm lint`
- `pnpm typecheck`
- `uv run mkdocs build --strict`
- `git diff --check`
- `pnpm --filter @open-cowork/desktop build`
- `pnpm test:renderer` — 74 files, 380 tests passed
- `pnpm test` — 1808 passed, 20 skipped, 0 failed
