### PR TITLE
Complete onboarding and accessibility gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,11 @@ pnpm dev
   `eslint-plugin-no-unsanitized` for the renderer. Config lives in
   `eslint.config.mjs`. `pnpm lint` runs ESLint (`--max-warnings 0`)
   followed by `scripts/lint.mjs` for repo-specific checks (trailing
-  whitespace, tabs, final newlines).
+  whitespace, tabs, final newlines, design-system drift gates).
+- **Design system** primitives, tokens, accessibility gates, and motion
+  rules are documented in `docs/design-system.md`. Prefer the shared
+  renderer primitives before adding local button, input, badge, modal, or
+  icon-only control markup.
 - **Tests** run with Node's built-in runner via
   `--experimental-strip-types` for main/shared/runtime coverage.
   Renderer component tests run with Vitest + jsdom via

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -104,7 +104,10 @@ const {
   getAppIsQuitting: () => appIsQuitting,
   log,
 })
-configureRuntimeInitialization({ getLoadingWindow })
+configureRuntimeInitialization({
+  getLoadingWindow,
+  getStatusWindows: () => [getMainWindow()],
+})
 
 const eventSubscriptions = createRuntimeEventSubscriptionManager({
   getMainWindow,

--- a/apps/desktop/src/main/ipc/provider-handlers.ts
+++ b/apps/desktop/src/main/ipc/provider-handlers.ts
@@ -1,26 +1,102 @@
 import type { IpcHandlerContext } from './context.ts'
 import {
   mergeRuntimeProviderModels,
+  normalizeBoundedString,
   normalizeProviderAuthCode,
   normalizeProviderAuthorization,
   normalizeProviderAuthInputs,
   normalizeProviderAuthMethod,
   resolveKnownProviderId,
 } from './app-handler-support.ts'
-import { getProviderDynamicCatalog, getPublicAppConfig, invalidatePublicConfigCache } from '../config-loader.ts'
+import { getProviderDescriptor, getProviderDynamicCatalog, getPublicAppConfig, invalidatePublicConfigCache } from '../config-loader.ts'
 import { log } from '../logger.ts'
 import { refreshProviderCatalog } from '../provider-catalog.ts'
-import { normalizeProviderListResponse } from '../provider-utils.ts'
+import { modelInfoKeys } from '../model-info-utils.ts'
+import { normalizeProviderListResponse, type ProviderLike } from '../provider-utils.ts'
 import { getClient } from '../runtime.ts'
 import { sdkErrorMessage } from '../sdk-error.ts'
+import { getEffectiveSettings, getProviderCredentialValue } from '../settings.ts'
 
 type ElectronShell = typeof import('electron').shell
+const MAX_PROVIDER_MODEL_ID_LENGTH = 512
 
 async function listRuntimeProviders() {
   const client = getClient()
   if (!client) return []
   const result = await client.provider.list()
   return normalizeProviderListResponse(result.data)
+}
+
+function normalizeProviderModelId(value: unknown) {
+  const modelId = normalizeBoundedString(value, 'Provider model id', MAX_PROVIDER_MODEL_ID_LENGTH).trim()
+  if (!modelId) throw new Error('Provider model id is invalid.')
+  return modelId
+}
+
+function findApiKeyCredential(providerId: string) {
+  const descriptor = getProviderDescriptor(providerId)
+  return descriptor?.credentials.find((credential) => {
+    const runtimeKey = credential.runtimeKey || credential.key
+    return runtimeKey === 'apiKey' || /api.*key/i.test(`${credential.key} ${credential.label}`)
+  }) || null
+}
+
+async function syncApiCredentialForConnectionTest(providerId: string) {
+  const client = getClient()
+  if (!client) throw new Error('The model service is not ready yet. Try testing the connection again in a moment.')
+  const credential = findApiKeyCredential(providerId)
+  if (!credential) return false
+
+  const settings = getEffectiveSettings()
+  const key = getProviderCredentialValue(settings, providerId, credential.key)
+  if (!key) return false
+
+  await client.auth.set({
+    providerID: providerId,
+    auth: {
+      type: 'api',
+      key,
+      metadata: { source: 'open-cowork' },
+    },
+  }, { throwOnError: true })
+  return true
+}
+
+function providerMatches(provider: ProviderLike, providerId: string) {
+  return provider.id === providerId || provider.name === providerId
+}
+
+function providerHasModel(provider: ProviderLike, modelId: string) {
+  const models = provider.models || {}
+  const keys = Object.keys(models)
+  if (keys.length === 0) return true
+  const providerId = provider.id || provider.name
+  const wanted = new Set(modelInfoKeys(providerId, modelId))
+  return keys.some((key) => (
+    wanted.has(key) ||
+    modelInfoKeys(providerId, key).some((candidate) => candidate === modelId || wanted.has(candidate))
+  ))
+}
+
+async function testRuntimeProviderConnection(providerId: string, modelId: string) {
+  const client = getClient()
+  if (!client) throw new Error('The model service is not ready yet. Try testing the connection again in a moment.')
+  const providerName = getProviderDescriptor(providerId)?.name || providerId
+  const apiCredentialSynced = await syncApiCredentialForConnectionTest(providerId)
+  const providers = await listRuntimeProviders()
+  const provider = providers.find((entry) => providerMatches(entry, providerId))
+
+  if (!provider) {
+    throw new Error(`${providerName} is not available in the model service. Choose another provider or update setup settings.`)
+  }
+  if (!apiCredentialSynced && provider.connected === false) {
+    throw new Error(`${providerName} is not signed in yet. Sign in or enter an API key, then test again.`)
+  }
+  if (!providerHasModel(provider, modelId)) {
+    throw new Error(`${modelId} is not available from ${providerName}. Choose a listed model, then test again.`)
+  }
+
+  return { ok: true, providerId, modelId }
 }
 
 export async function getPublicAppConfigWithRuntimeModels() {
@@ -67,6 +143,19 @@ export function registerProviderHandlers(context: IpcHandlerContext, electronShe
     } catch (err) {
       context.logHandlerError('provider:auth-methods', err)
       return {}
+    }
+  })
+
+  context.ipcMain.handle('provider:test-connection', async (_event, providerIdInput: unknown, modelIdInput: unknown) => {
+    const providerId = resolveKnownProviderId(providerIdInput)
+    const modelId = normalizeProviderModelId(modelIdInput)
+    try {
+      const result = await testRuntimeProviderConnection(providerId, modelId)
+      log('provider', `Tested provider connection for ${providerId}/${modelId}`)
+      return result
+    } catch (err) {
+      context.logHandlerError(`provider:test-connection ${providerId}`, err)
+      throw err
     }
   })
 

--- a/apps/desktop/src/main/runtime-initialization.ts
+++ b/apps/desktop/src/main/runtime-initialization.ts
@@ -8,6 +8,7 @@ type Deferred = {
 }
 
 let getLoadingWindow: (() => BrowserWindow | null) | null = null
+let getStatusWindows: (() => Array<BrowserWindow | null>) | null = null
 let currentStatus: RuntimeLoadingStatus = createStatus('idle', 'Waiting to start runtime.', false, null)
 let deferred: Deferred = createDeferred()
 
@@ -35,8 +36,11 @@ function createDeferred(): Deferred {
 }
 
 function publish(status: RuntimeLoadingStatus) {
-  const win = getLoadingWindow?.()
-  if (win && !win.isDestroyed()) {
+  const windows = [getLoadingWindow?.(), ...(getStatusWindows?.() || [])]
+  const seen = new Set<number>()
+  for (const win of windows) {
+    if (!win || win.isDestroyed() || seen.has(win.id)) continue
+    seen.add(win.id)
     win.webContents.send('runtime:loading-status', status)
   }
 }
@@ -86,8 +90,10 @@ function startupFailureRemediation(phase: RuntimeLoadingPhase) {
 
 export function configureRuntimeInitialization(options: {
   getLoadingWindow: () => BrowserWindow | null
+  getStatusWindows?: () => Array<BrowserWindow | null>
 }) {
   getLoadingWindow = options.getLoadingWindow
+  getStatusWindows = options.getStatusWindows || null
 }
 
 export function getRuntimeInitializationStatus() {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -91,6 +91,7 @@ const PRELOAD_INVOKE_CHANNELS = [
   'model:info',
   'provider:list',
   'provider:auth-methods',
+  'provider:test-connection',
   'provider:oauth-authorize',
   'provider:oauth-callback',
   'provider:auth-remove',
@@ -333,6 +334,7 @@ const api: CoworkAPI = {
   provider: {
     list: () => invoke('provider:list'),
     authMethods: () => invoke('provider:auth-methods'),
+    testConnection: (providerId, modelId) => invoke('provider:test-connection', providerId, modelId),
     authorize: (providerId, method, inputs) => invoke('provider:oauth-authorize', providerId, method, inputs),
     callback: (providerId, method, code) => invoke('provider:oauth-callback', providerId, method, code),
     logout: (providerId) => invoke('provider:auth-remove', providerId),

--- a/apps/desktop/src/renderer/components/CommandPalette.test.tsx
+++ b/apps/desktop/src/renderer/components/CommandPalette.test.tsx
@@ -42,7 +42,7 @@ describe('CommandPalette', () => {
       />,
     )
 
-    const search = screen.getByRole('combobox', { name: 'Search command palette' })
+    const search = screen.getByRole('searchbox', { name: 'Search command palette' })
     expect(search).toHaveAttribute('aria-controls', 'command-palette-results')
     expect(screen.getByRole('listbox', { name: 'Command palette results' })).toBeTruthy()
 
@@ -76,7 +76,7 @@ describe('CommandPalette', () => {
       />,
     )
 
-    const search = screen.getByRole('combobox', { name: 'Search command palette' })
+    const search = screen.getByRole('searchbox', { name: 'Search command palette' })
     await user.type(search, 'governance')
 
     expect(screen.queryByRole('option', { name: /Governance/ })).not.toBeInTheDocument()

--- a/apps/desktop/src/renderer/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/components/CommandPalette.tsx
@@ -162,10 +162,9 @@ export function CommandPalette({
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             onKeyDown={handleKeyDown}
-            role="combobox"
+            type="search"
+            role="searchbox"
             aria-label={t('commandPalette.searchLabel', 'Search command palette')}
-            aria-autocomplete="list"
-            aria-expanded="true"
             aria-controls={listboxId}
             aria-activedescendant={activeOptionId}
             placeholder={t('commandPalette.search', 'Search actions, agents, and commands...')}

--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -99,7 +99,8 @@ beforeEach(() => {
 })
 
 describe('SetupScreen', () => {
-  it('shows topology choices before provider setup', async () => {
+  it('defaults to local setup and keeps deployment topology behind disclosure', async () => {
+    const user = userEvent.setup()
     installRendererTestCoworkApi({
       settings: {
         get: vi.fn(async () => settings()),
@@ -117,11 +118,22 @@ describe('SetupScreen', () => {
       />,
     )
 
-    expect(await screen.findByRole('button', { name: /Run Desktop locally/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Deploy Gateway/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Connect Cloud/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Pair Desktop/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Connect all surfaces/ })).toBeTruthy()
+    expect(await screen.findByText('Running on this Mac')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Deploy Gateway/ })).not.toBeInTheDocument()
+    expect(screen.queryByText(/Gateway/)).not.toBeInTheDocument()
+    expect(screen.queryByText('desktop-only')).not.toBeInTheDocument()
+    expect(screen.queryByText(/pnpm/)).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('https://github.com/joe-broadhead/open-cowork/blob/master/docs/desktop-app.md'),
+    )
+
+    await user.click(screen.getByRole('button', { name: /Set up a team or server deployment/ }))
+
+    expect(screen.getByRole('button', { name: /Deploy Gateway/ })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /Deploy Gateway/ }))
+    expect(screen.getByText('gateway-only')).toBeInTheDocument()
+    expect(screen.getByText('pnpm standalone-gateway:setup')).toBeInTheDocument()
   })
 
   it('loads selected-provider credentials through the scoped credential IPC', async () => {
@@ -246,10 +258,18 @@ describe('SetupScreen', () => {
     expect(apiKeyInput).toHaveValue('sk-or-user-edit')
   })
 
-  it('discloses and persists the developer config bridge choice during first-run setup', async () => {
+  it('tests the connection, then persists the developer config bridge choice during first-run setup', async () => {
     const user = userEvent.setup()
     const set = vi.fn(async () => settings())
     const restart = vi.fn(async () => ({ ready: true, error: null }))
+    const testConnection = vi.fn(async (providerId: string, modelId: string) => ({ ok: true, providerId, modelId }))
+    const awaitInitialization = vi.fn(async () => ({
+      phase: 'ready' as const,
+      message: 'Runtime is ready.',
+      ready: true,
+      error: null,
+      updatedAt: new Date().toISOString(),
+    }))
     const onComplete = vi.fn()
     installRendererTestCoworkApi({
       settings: {
@@ -258,7 +278,11 @@ describe('SetupScreen', () => {
         set,
       },
       runtime: {
+        awaitInitialization,
         restart,
+      },
+      provider: {
+        testConnection,
       },
     })
 
@@ -272,14 +296,20 @@ describe('SetupScreen', () => {
       />,
     )
 
-    const bridgeToggle = await screen.findByRole('checkbox', { name: /Developer config bridge/ })
+    await user.click(screen.getByRole('button', { name: /Set up a team or server deployment/ }))
+    const bridgeToggle = await screen.findByRole('checkbox', { name: /Reuse developer tools from this Mac/ })
     expect(bridgeToggle).toBeChecked()
 
     await user.click(bridgeToggle)
+    await user.click(screen.getByRole('button', { name: 'Test connection' }))
+    await waitFor(() => expect(screen.getByText(/Connection tested/)).toBeInTheDocument())
+    expect(screen.queryByText('Runtime is ready.')).not.toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Get Started' }))
 
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
-    expect(restart).toHaveBeenCalledTimes(1)
+    expect(awaitInitialization).toHaveBeenCalledTimes(1)
+    expect(testConnection).toHaveBeenCalledWith('openrouter', 'anthropic/claude-sonnet-4')
+    expect(restart).not.toHaveBeenCalled()
     expect(set).toHaveBeenCalledWith(expect.objectContaining({
       selectedProviderId: 'openrouter',
       selectedModelId: 'anthropic/claude-sonnet-4',
@@ -290,7 +320,46 @@ describe('SetupScreen', () => {
     }))
   })
 
-  it('uses OpenCode runtime catalog defaults after credentialless provider auth', async () => {
+  it('keeps setup open and surfaces provider validation failures', async () => {
+    const user = userEvent.setup()
+    const testConnection = vi.fn(async () => {
+      throw new Error('Provider rejected the API key')
+    })
+    const onComplete = vi.fn()
+    installRendererTestCoworkApi({
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(async () => ({})),
+        set: vi.fn(async () => settings()),
+      },
+      provider: {
+        testConnection,
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providers}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={onComplete}
+      />,
+    )
+
+    const apiKeyInput = await screen.findByPlaceholderText('sk-or-...')
+    await user.type(apiKeyInput, 'sk-or-bad')
+    const testButton = await screen.findByRole('button', { name: 'Test connection' })
+    await waitFor(() => expect(testButton).not.toBeDisabled())
+    await user.click(testButton)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Provider rejected the API key'))
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Provider rejected the API key')
+    expect(screen.getByRole('button', { name: 'Get Started' })).toBeDisabled()
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('uses model catalog defaults after credentialless provider auth', async () => {
     const user = userEvent.setup()
     const set = vi.fn(async (updates: Partial<EffectiveAppSettings>) => settings({
       ...updates,
@@ -317,6 +386,7 @@ describe('SetupScreen', () => {
           defaultModel: 'gpt-5.4',
           models: { 'gpt-5.4': {} },
         }]),
+        testConnection: vi.fn(async (providerId: string, modelId: string) => ({ ok: true, providerId, modelId })),
       },
       settings: {
         get: vi.fn(async () => settings({
@@ -355,6 +425,8 @@ describe('SetupScreen', () => {
     await user.click(screen.getByRole('button', { name: "I've finished signing in" }))
     await waitFor(() => expect(screen.getByPlaceholderText('Model ID')).toHaveValue('gpt-5.4'))
 
+    await user.click(screen.getByRole('button', { name: 'Test connection' }))
+    await waitFor(() => expect(screen.getByText(/Connection tested/)).toBeInTheDocument())
     await user.click(screen.getByRole('button', { name: 'Get Started' }))
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
     expect(set).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -364,6 +436,6 @@ describe('SetupScreen', () => {
         'github-copilot': {},
       },
     }))
-    expect(restart).toHaveBeenCalledTimes(2)
+    expect(restart).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -1,10 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { SETUP_INTENTS, type ProviderDescriptor, type SetupIntentId } from '@open-cowork/shared'
+import {
+  SETUP_INTENTS,
+  type ProviderDescriptor,
+  type RuntimeLoadingPhase,
+  type RuntimeLoadingStatus,
+  type SetupIntentId,
+} from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
 import { credentialFieldIsSecret, isCredentialMask, mergeFetchedProviderCredentials } from './provider/credential-merge'
 import { ProviderAuthControls } from './provider/ProviderAuthControls'
 import { useSessionStore } from '../stores/session'
 import { LOCAL_WORKSPACE_ID } from '../stores/session-workspace-keys'
+import { Badge, Button } from './ui'
 
 interface Props {
   brandName: string
@@ -13,6 +20,26 @@ interface Props {
   defaultProviderId: string | null
   defaultModelId: string | null
   onComplete: () => void
+}
+
+type ConnectionTestState =
+  | { status: 'idle'; signature: null; message: string | null }
+  | { status: 'testing'; signature: null; message: string | null }
+  | { status: 'success'; signature: string; message: string }
+  | { status: 'error'; signature: null; message: string }
+
+const localIntent = SETUP_INTENTS.find((intent) => intent.id === 'desktop-local') || SETUP_INTENTS[0]
+const advancedIntents = SETUP_INTENTS.filter((intent) => intent.id !== 'desktop-local')
+
+const phaseProgress: Record<RuntimeLoadingPhase, number> = {
+  idle: 6,
+  starting: 16,
+  config: 34,
+  'managed-server': 56,
+  'connecting-events': 72,
+  mcp: 86,
+  ready: 100,
+  error: 100,
 }
 
 function describeSetupLoadError(error: unknown) {
@@ -46,6 +73,43 @@ async function resolveRuntimeProviderDefaultModel(providerId: string | null) {
   return models[0] || ''
 }
 
+function buildConnectionSignature(input: {
+  providerId: string | null
+  modelId: string
+  credentials: Record<string, string>
+  runtimeToolingBridgeEnabled: boolean
+}) {
+  const credentials = Object.fromEntries(
+    Object.entries(input.credentials).sort(([left], [right]) => left.localeCompare(right)),
+  )
+  return JSON.stringify({
+    providerId: input.providerId,
+    modelId: input.modelId.trim(),
+    credentials,
+    runtimeToolingBridgeEnabled: input.runtimeToolingBridgeEnabled,
+  })
+}
+
+function docsLabel(path: string) {
+  return path.replace(/^docs\//, '').replace(/\.md$/, '').replace(/-/g, ' ')
+}
+
+function docsHref(path: string) {
+  if (/^https?:\/\//i.test(path)) return path
+  return `https://github.com/joe-broadhead/open-cowork/blob/master/${path.replace(/^\/+/, '')}`
+}
+
+function runtimeProgressLabel(status: RuntimeLoadingStatus | null, fallback: string | null) {
+  if (status?.phase === 'starting') return t('setup.progressStarting', 'Starting the model service...')
+  if (status?.phase === 'config') return t('setup.progressConfig', 'Applying setup choices...')
+  if (status?.phase === 'managed-server') return t('setup.progressManagedServer', 'Preparing the local model service...')
+  if (status?.phase === 'connecting-events') return t('setup.progressEvents', 'Connecting status updates...')
+  if (status?.phase === 'mcp') return t('setup.progressTools', 'Preparing agent tools...')
+  if (status?.phase === 'ready') return t('setup.progressReady', 'Model service is ready.')
+  if (status?.phase === 'error') return t('setup.progressError', 'The model service could not start.')
+  return fallback || t('setup.connectionIdle', 'Ready to test the connection.')
+}
+
 export function SetupScreen({
   brandName,
   email,
@@ -61,6 +125,13 @@ export function SetupScreen({
   const [selectedIntentId, setSelectedIntentId] = useState<SetupIntentId>('desktop-local')
   const [loadedCredentialProviders, setLoadedCredentialProviders] = useState<Set<string>>(() => new Set())
   const [saving, setSaving] = useState(false)
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  const [runtimeProgress, setRuntimeProgress] = useState<RuntimeLoadingStatus | null>(null)
+  const [connectionTest, setConnectionTest] = useState<ConnectionTestState>({
+    status: 'idle',
+    signature: null,
+    message: null,
+  })
   const [error, setError] = useState<string | null>(null)
   const addGlobalError = useSessionStore((s) => s.addGlobalError)
   const dirtyProviderCredentialKeys = useRef<Record<string, Set<string>>>({})
@@ -84,8 +155,12 @@ export function SetupScreen({
   }
 
   useEffect(() => {
-    // Settings are loaded masked by default. The setup form requests only
-    // the selected provider's descriptor-aware masked credential bag below.
+    return window.coworkApi.on.runtimeLoadingStatus((status) => {
+      setRuntimeProgress(status)
+    })
+  }, [])
+
+  useEffect(() => {
     let cancelled = false
     window.coworkApi.settings.get().then(async (settings) => {
       const initialProviderId = providers.some((provider) => provider.id === settings.selectedProviderId)
@@ -129,7 +204,7 @@ export function SetupScreen({
     [providers, providerId],
   )
   const selectedIntent = useMemo(
-    () => SETUP_INTENTS.find((intent) => intent.id === selectedIntentId) || SETUP_INTENTS[0],
+    () => SETUP_INTENTS.find((intent) => intent.id === selectedIntentId) || localIntent,
     [selectedIntentId],
   )
 
@@ -165,11 +240,26 @@ export function SetupScreen({
 
   const selectedCredentials = providerId ? (providerCredentials[providerId] || {}) : {}
   const requiredCredentials = selectedProvider?.credentials.filter((credential) => credential.required !== false) || []
-  const canContinue = Boolean(
-    providerId
-    && modelId.trim()
-    && requiredCredentials.every((credential) => (selectedCredentials[credential.key] || '').trim()),
-  )
+  const hasRequiredCredentials = requiredCredentials.every((credential) => (selectedCredentials[credential.key] || '').trim())
+  const canContinue = Boolean(providerId && modelId.trim() && hasRequiredCredentials)
+  const currentConnectionSignature = useMemo(() => buildConnectionSignature({
+    providerId,
+    modelId,
+    credentials: selectedCredentials,
+    runtimeToolingBridgeEnabled,
+  }), [modelId, providerId, runtimeToolingBridgeEnabled, selectedCredentials])
+  const connectionIsCurrent = connectionTest.status === 'success'
+    && connectionTest.signature === currentConnectionSignature
+  const connectionNeedsRetest = connectionTest.status === 'success' && !connectionIsCurrent
+  const setupProgress = connectionIsCurrent ? 3 : modelId.trim() ? 2 : providerId ? 1 : 0
+  const progressPercent = connectionTest.status === 'testing'
+    ? phaseProgress[runtimeProgress?.phase || 'starting']
+    : connectionIsCurrent
+      ? 100
+      : Math.max(12, setupProgress * 28)
+  const visibleRuntimeProgress = connectionTest.status === 'testing' || connectionIsCurrent
+    ? runtimeProgress
+    : null
 
   const updateCredential = (key: string, value: string) => {
     if (!providerId) return
@@ -183,31 +273,30 @@ export function SetupScreen({
     }))
   }
 
-  const persistSelectionAndRestart = async (modelOverride?: string, options: { allowMissingModel?: boolean } = {}) => {
+  const saveSetupSelection = async (modelOverride?: string, options: { allowMissingModel?: boolean } = {}) => {
     if (!providerId) return false
     const nextModelId = (modelOverride || modelId).trim()
-    const hasRequiredCredentials = requiredCredentials.every((credential) => (selectedCredentials[credential.key] || '').trim())
     if ((!nextModelId && !options.allowMissingModel) || !hasRequiredCredentials) return false
+    await window.coworkApi.settings.set({
+      selectedProviderId: providerId,
+      selectedModelId: nextModelId,
+      runtimeToolingBridgeEnabled,
+      providerCredentials: {
+        [providerId]: selectedCredentials,
+      },
+    })
+    return true
+  }
+
+  const prepareProviderAuthorization = async () => {
     setSaving(true)
     setError(null)
     try {
-      await window.coworkApi.settings.set({
-        selectedProviderId: providerId,
-        selectedModelId: nextModelId,
-        runtimeToolingBridgeEnabled,
-        providerCredentials: {
-          [providerId]: selectedCredentials,
-        },
-      })
-      // Reboot the runtime with the new credentials so a bad API key
-      // surfaces here instead of silently during the user's first
-      // prompt. If restart reports `ready: false`, show the actual
-      // runtime error (wrong key, unreachable provider, etc.) and
-      // leave the setup form open so the user can correct it.
+      const saved = await saveSetupSelection(undefined, { allowMissingModel: true })
+      if (!saved) return false
       const status = await window.coworkApi.runtime.restart()
       if (!status.ready) {
-        setError(status.error || t('setup.runtimeFailed', 'Runtime could not start with the provided credentials. Double-check your API key and try again.'))
-        setSaving(false)
+        setError(status.error || t('setup.runtimeFailed', 'The model service could not start with these settings. Double-check your key and try again.'))
         return false
       }
       return true
@@ -219,18 +308,67 @@ export function SetupScreen({
     }
   }
 
-  const handleContinue = async () => {
-    const ok = await persistSelectionAndRestart()
-    if (ok) {
-      onComplete()
+  const handleTestConnection = async () => {
+    if (!canContinue) {
+      setError(t('setup.connectionMissingFields', 'Choose a provider, enter the required key, and choose a model before testing.'))
+      return
+    }
+    if (!providerId) return
+    setSaving(true)
+    setError(null)
+    setRuntimeProgress({
+      phase: 'starting',
+      message: t('setup.connectionSaving', 'Saving setup choices...'),
+      ready: false,
+      error: null,
+      updatedAt: new Date().toISOString(),
+    })
+    setConnectionTest({
+      status: 'testing',
+      signature: null,
+      message: t('setup.connectionTesting', 'Testing the model connection...'),
+    })
+    try {
+      await saveSetupSelection()
+      const status = await window.coworkApi.runtime.awaitInitialization()
+      if (!status.ready) {
+        const message = status.error || t('setup.runtimeFailed', 'The model service could not start with these settings. Double-check your key and try again.')
+        setError(message)
+        setConnectionTest({ status: 'error', signature: null, message })
+        addGlobalError(message)
+        return
+      }
+      setRuntimeProgress(status)
+      await window.coworkApi.provider.testConnection(providerId, modelId.trim())
+      const message = t('setup.connectionReady', 'Connection tested. You can start using {{brandName}}.', { brandName })
+      setConnectionTest({
+        status: 'success',
+        signature: currentConnectionSignature,
+        message,
+      })
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : t('setup.saveFailed', 'Failed to save settings')
+      setError(message)
+      setConnectionTest({ status: 'error', signature: null, message })
+      addGlobalError(message)
+    } finally {
+      setSaving(false)
     }
   }
 
+  const handleContinue = () => {
+    if (!connectionIsCurrent) {
+      setError(t('setup.connectionRequired', 'Test this provider and model before continuing.'))
+      return
+    }
+    onComplete()
+  }
+
   return (
-    <div className="h-screen w-screen overflow-y-auto" style={{ background: 'var(--color-base)' }}>
-      <div className="mx-auto w-full max-w-2xl px-6 py-8">
-        <div className="flex flex-col items-center gap-2">
-          <div className="w-12 h-12 rounded-2xl bg-surface border border-border flex items-center justify-center">
+    <div className="h-screen w-screen overflow-y-auto bg-base">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8">
+        <header className="flex flex-col items-center gap-2 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border bg-surface">
             <span className="text-lg font-bold text-accent">O</span>
           </div>
           <h1 className="text-lg font-semibold text-text">
@@ -238,194 +376,311 @@ export function SetupScreen({
               ? t('setup.welcomeUser', 'Welcome, {{name}}', { name: email.split('@')[0] })
               : t('setup.welcomeGeneric', 'Welcome to {{brandName}}', { brandName })}
           </h1>
-          <p className="text-[13px] text-text-muted text-center max-w-2xl">
-            {t('setup.description', 'Choose the provider and model this {{brandName}} build should use by default.', { brandName })}
+          <p className="max-w-xl text-sm text-text-muted">
+            {t('setup.description', 'Connect an AI model, choose your default model, then start your first prompt.')}
           </p>
-        </div>
+        </header>
 
-        <div className="mt-6 w-full flex flex-col gap-3">
-          <div className="rounded-xl border border-border-subtle bg-elevated p-3">
-            <div className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
-              {t('setup.pathLabel', 'Setup path')}
+        <section aria-label={t('setup.progress', 'Setup progress')} className="rounded-2xl border border-border-subtle bg-elevated p-4">
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              { label: t('setup.stepConnect', 'Connect a model'), done: setupProgress >= 1 },
+              { label: t('setup.stepChoose', 'Choose model'), done: setupProgress >= 2 },
+              { label: t('setup.stepDone', 'Done'), done: setupProgress >= 3 },
+            ].map((step, index) => (
+              <div key={step.label} className="flex items-center gap-2 text-sm text-text-secondary">
+                <span className={`flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold ${step.done ? 'border-accent bg-accent text-accent-foreground' : 'border-border-subtle text-text-muted'}`}>
+                  {index + 1}
+                </span>
+                <span className={step.done ? 'text-text' : undefined}>{step.label}</span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 h-2 overflow-hidden rounded-full bg-surface">
+            <div className="h-full rounded-full bg-accent transition-[width]" style={{ width: `${progressPercent}%` }} />
+          </div>
+          <p className="mt-2 text-xs text-text-muted">
+            {runtimeProgressLabel(visibleRuntimeProgress, connectionTest.message)}
+          </p>
+        </section>
+
+        <section className="rounded-2xl border border-border-subtle bg-elevated p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2">
+                <h2 className="text-base font-semibold text-text">{t('setup.localTitle', 'Running on this Mac')}</h2>
+                <Badge tone="success">{t('setup.localReady', 'Ready')}</Badge>
+              </div>
+              <p className="mt-1 text-sm text-text-muted">
+                {t('setup.localDescription', 'Your projects and model credentials stay on this computer unless you choose a team or server option.')}
+              </p>
             </div>
-            <div className="mt-2 grid gap-2 sm:grid-cols-2">
-              {SETUP_INTENTS.map((intent) => (
+            <a
+              href={docsHref(localIntent.primaryDocs)}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm font-medium text-accent hover:underline"
+            >
+              {t('setup.learnMore', 'Learn more')}
+            </a>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3" aria-label={t('setup.providerSection', 'Model provider')}>
+          <div>
+            <h2 className="text-base font-semibold text-text">{t('setup.providerTitle', 'Model provider')}</h2>
+            <p className="text-sm text-text-muted">
+              {t('setup.providerDescription', 'Choose the account that will power your agents.')}
+            </p>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {providers.map((provider) => {
+              const active = providerId === provider.id
+              return (
                 <button
-                  key={intent.id}
+                  key={provider.id}
                   type="button"
-                  onClick={() => setSelectedIntentId(intent.id)}
-                  className="min-h-[86px] rounded-lg border px-3 py-2 text-start transition-colors"
-                  style={{
-                    background: selectedIntentId === intent.id ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : 'var(--color-base)',
-                    borderColor: selectedIntentId === intent.id ? 'var(--color-accent)' : 'var(--color-border-subtle)',
+                  onClick={() => {
+                    providerSelectionEdited.current = true
+                    setProviderId(provider.id)
+                    setModelId(provider.defaultModel || provider.models[0]?.id || '')
                   }}
+                  className={`rounded-2xl border px-4 py-3 text-start transition-colors ${active ? 'border-accent bg-accent/10' : 'border-border-subtle bg-elevated hover:bg-surface-hover'}`}
                 >
-                  <div className="text-[12px] font-semibold text-text">{intent.label}</div>
-                  <div className="mt-1 line-clamp-3 text-[10px] leading-relaxed text-text-muted">{intent.summary}</div>
+                  <div className={`text-sm font-semibold ${active ? 'text-accent' : 'text-text'}`}>{provider.name}</div>
+                  <div className="mt-1 text-xs text-text-muted">{t('setup.providerCardHint', 'Use this provider for new chats.')}</div>
                 </button>
-              ))}
+              )
+            })}
+          </div>
+        </section>
+
+        {selectedProvider ? (
+          <section className="flex flex-col gap-4 rounded-2xl border border-border-subtle bg-elevated p-4" aria-label={t('setup.connectionSection', 'Connection details')}>
+            <div>
+              <h2 className="text-base font-semibold text-text">{t('settings.models.authentication', 'Authentication')}</h2>
+              <p className="text-sm text-text-muted">
+                {t('setup.authenticationDescription', 'Use a browser sign-in if available, or enter the required API key.')}
+              </p>
             </div>
-            {selectedIntent ? (
-              <div className="mt-2 rounded-lg border border-border-subtle bg-base px-3 py-2 text-[11px] text-text-secondary">
-                <div className="font-medium text-text">{selectedIntent.topologyProfile}</div>
-                <div className="mt-1 text-text-muted">{selectedIntent.nextActions[0]}</div>
-                {selectedIntent.primaryCommand ? (
-                  <div className="mt-2 rounded border border-border-subtle px-2 py-1 font-mono text-[10px] text-text-muted">
-                    {selectedIntent.primaryCommand}
-                  </div>
-                ) : null}
+            <ProviderAuthControls
+              providerId={providerId}
+              providerName={selectedProvider.name}
+              connected={selectedProvider.connected}
+              disabled={!providerId || saving}
+              copyMode="setup"
+              onBeforeAuthorize={prepareProviderAuthorization}
+              onAuthUpdated={async () => {
+                const authModelId = selectedProvider.defaultModel
+                  || await resolveRuntimeProviderDefaultModel(providerId)
+                  || modelId
+                setModelId(authModelId)
+              }}
+            />
+            {selectedProvider.credentials.length > 0 ? (
+              <div className="flex flex-col gap-3">
+                {selectedProvider.credentials.map((credential) => {
+                  const credentialIsSecret = credentialFieldIsSecret(credential)
+                  return (
+                    <label key={credential.key} className="flex flex-col gap-1.5">
+                      <span className="text-sm font-medium text-text-secondary">{credential.label}</span>
+                      <input
+                        type={credentialIsSecret ? 'password' : 'text'}
+                        value={selectedCredentials[credential.key] || ''}
+                        onFocus={() => {
+                          if (credentialIsSecret && isCredentialMask(selectedCredentials[credential.key])) {
+                            updateCredential(credential.key, '')
+                          }
+                        }}
+                        onChange={(event) => updateCredential(credential.key, event.target.value)}
+                        placeholder={credential.placeholder}
+                        className="w-full rounded-lg border border-border-subtle bg-base px-3 py-2 text-sm text-text outline-none transition-colors placeholder:text-text-muted focus:border-accent/40"
+                      />
+                      <span className="text-xs text-text-muted">{credential.description}</span>
+                    </label>
+                  )
+                })}
+                <a
+                  href={docsHref(localIntent.primaryDocs)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs font-medium text-accent hover:underline"
+                >
+                  {t('setup.keyHelp', 'Where do I get a key?')}
+                </a>
               </div>
             ) : null}
-          </div>
+          </section>
+        ) : null}
 
-          {providers.map((provider) => (
-            <button
-              key={provider.id}
-              onClick={() => {
-                providerSelectionEdited.current = true
-                setProviderId(provider.id)
-                setModelId(provider.defaultModel || provider.models[0]?.id || '')
-              }}
-              className="w-full text-start px-4 py-3 rounded-xl border transition-all cursor-pointer"
-              style={{
-                background: providerId === provider.id ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : 'var(--color-elevated)',
-                borderColor: providerId === provider.id ? 'var(--color-accent)' : 'var(--color-border-subtle)',
-              }}
-            >
-              <div className="text-[13px] font-medium" style={{ color: providerId === provider.id ? 'var(--color-accent)' : 'var(--color-text)' }}>
-                {provider.name}
+        {selectedProvider ? (
+          <section className="flex flex-col gap-3 rounded-2xl border border-border-subtle bg-elevated p-4" aria-label={t('setup.model', 'Model')}>
+            <div>
+              <h2 className="text-base font-semibold text-text">{t('setup.model', 'Model')}</h2>
+              <p className="text-sm text-text-muted">{t('setup.modelDescription', 'Pick the model agents will use by default.')}</p>
+            </div>
+            {selectedProvider.models.length > 0 ? (
+              <div className="grid gap-2">
+                {selectedProvider.models.map((model) => {
+                  const active = modelId === model.id
+                  return (
+                    <button
+                      key={model.id}
+                      type="button"
+                      onClick={() => setModelId(model.id)}
+                      className={`rounded-xl border px-3.5 py-3 text-start transition-colors ${active ? 'border-accent bg-accent/10' : 'border-border-subtle hover:bg-surface-hover'}`}
+                    >
+                      <span className={`block text-sm font-medium ${active ? 'text-accent' : 'text-text-secondary'}`}>{model.name}</span>
+                      {model.description ? (
+                        <span className="mt-1 block line-clamp-2 text-xs leading-relaxed text-text-muted">
+                          {model.description}
+                        </span>
+                      ) : null}
+                    </button>
+                  )
+                })}
               </div>
-              <div className="text-[11px] text-text-muted mt-0.5">{provider.description}</div>
-            </button>
-          ))}
+            ) : (
+              <label className="flex flex-col gap-1.5">
+                <span className="text-sm font-medium text-text-secondary">{t('setup.modelIdLabel', 'Model ID')}</span>
+                <input
+                  type="text"
+                  value={modelId}
+                  onChange={(event) => setModelId(event.target.value)}
+                  placeholder={t('setup.modelIdPlaceholder', 'Model ID')}
+                  className="w-full rounded-lg border border-border-subtle bg-base px-3 py-2 text-sm text-text outline-none transition-colors placeholder:text-text-muted focus:border-accent/40"
+                />
+                <span className="text-xs text-text-muted">
+                  {t('setup.liveModelsHint', 'This provider fills its model list after sign-in.')}
+                </span>
+              </label>
+            )}
+          </section>
+        ) : null}
 
-          {selectedProvider && (
-            <>
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1 mt-3">{t('settings.models.authentication', 'Authentication')}</span>
-              <ProviderAuthControls
-                providerId={providerId}
-                providerName={selectedProvider.name}
-                connected={selectedProvider.connected}
-                disabled={!providerId || saving}
-                onBeforeAuthorize={async () => persistSelectionAndRestart(undefined, { allowMissingModel: true })}
-                onAuthUpdated={async () => {
-                  const authModelId = selectedProvider.defaultModel
-                    || await resolveRuntimeProviderDefaultModel(providerId)
-                    || modelId
-                  setModelId(authModelId)
-                }}
-              />
-              {selectedProvider.credentials.length > 0 ? (
-                <div className="flex flex-col gap-2.5 rounded-xl border border-border-subtle p-3.5" style={{ background: 'var(--color-elevated)' }}>
-                  {selectedProvider.credentials.map((credential) => {
-                    const credentialIsSecret = credentialFieldIsSecret(credential)
-                    return (
-                      <label key={credential.key} className="flex flex-col gap-1">
-                        <span className="text-[11px] text-text-muted font-medium">{credential.label}</span>
-                        <input
-                          type={credentialIsSecret ? 'password' : 'text'}
-                          value={selectedCredentials[credential.key] || ''}
-                          onFocus={() => {
-                            if (credentialIsSecret && isCredentialMask(selectedCredentials[credential.key])) {
-                              updateCredential(credential.key, '')
-                            }
-                          }}
-                          onChange={(event) => updateCredential(credential.key, event.target.value)}
-                          placeholder={credential.placeholder}
-                          className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
-                        />
-                        <span className="text-[10px] text-text-muted">{credential.description}</span>
-                      </label>
-                    )
-                  })}
+        <section className="rounded-2xl border border-border-subtle bg-elevated p-4">
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen((current) => !current)}
+            className="flex w-full items-center justify-between gap-3 text-start"
+            aria-expanded={advancedOpen}
+          >
+            <span>
+              <span className="block text-sm font-semibold text-text">
+                {t('setup.advancedTitle', 'Set up a team or server deployment')}
+              </span>
+              <span className="mt-1 block text-xs text-text-muted">
+                {t('setup.advancedDescription', 'Optional paths for shared work, remote access, or stricter local isolation.')}
+              </span>
+            </span>
+            <span className="text-sm text-accent">{advancedOpen ? t('common.hide', 'Hide') : t('common.show', 'Show')}</span>
+          </button>
+
+          {advancedOpen ? (
+            <div className="mt-4 flex flex-col gap-4">
+              <div className="grid gap-2 sm:grid-cols-2">
+                {advancedIntents.map((intent) => {
+                  const active = selectedIntentId === intent.id
+                  return (
+                    <button
+                      key={intent.id}
+                      type="button"
+                      onClick={() => setSelectedIntentId(intent.id)}
+                      className={`min-h-24 rounded-xl border px-3 py-3 text-start transition-colors ${active ? 'border-accent bg-accent/10' : 'border-border-subtle hover:bg-surface-hover'}`}
+                    >
+                      <div className="text-sm font-semibold text-text">{intent.label}</div>
+                      <div className="mt-1 line-clamp-3 text-xs leading-relaxed text-text-muted">{intent.summary}</div>
+                    </button>
+                  )
+                })}
+              </div>
+              {selectedIntent.id !== 'desktop-local' ? (
+                <div className="rounded-xl border border-border-subtle bg-base px-3 py-2 text-xs text-text-secondary">
+                  <div className="font-medium text-text">{selectedIntent.topologyProfile}</div>
+                  <div className="mt-1 text-text-muted">{selectedIntent.nextActions[0]}</div>
+                  {selectedIntent.primaryCommand ? (
+                    <div className="mt-2 rounded border border-border-subtle px-2 py-1 font-mono text-xs text-text-muted">
+                      {selectedIntent.primaryCommand}
+                    </div>
+                  ) : null}
+                  <a
+                    href={docsHref(selectedIntent.primaryDocs)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-2 inline-flex text-accent hover:underline"
+                  >
+                    {t('setup.readDocs', 'Read {{name}} docs', { name: docsLabel(selectedIntent.primaryDocs) })}
+                  </a>
                 </div>
               ) : null}
 
-              <div className="w-full flex flex-col gap-3 mt-2">
-                <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1">{t('setup.model', 'Model')}</span>
-                {selectedProvider.models.length > 0 ? (
-                  <div className="flex flex-col gap-1">
-                    {selectedProvider.models.map((model) => (
-                      <button
-                        key={model.id}
-                        onClick={() => setModelId(model.id)}
-                        className="flex flex-col items-start gap-1 px-3.5 py-2.5 rounded-lg text-start cursor-pointer transition-all border"
-                        style={{
-                          background: modelId === model.id ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : 'transparent',
-                          borderColor: modelId === model.id ? 'var(--color-accent)' : 'transparent',
-                        }}
-                      >
-                        <span
-                          className="text-[12px] font-medium leading-snug w-full"
-                          style={{ color: modelId === model.id ? 'var(--color-accent)' : 'var(--color-text-secondary)' }}
-                        >
-                          {model.name}
-                        </span>
-                        {model.description ? (
-                          <span className="text-[10px] text-text-muted leading-relaxed w-full line-clamp-2">
-                            {model.description}
-                          </span>
-                        ) : null}
-                      </button>
-                    ))}
-                  </div>
-                ) : (
-                  <input
-                    type="text"
-                    value={modelId}
-                    onChange={(event) => setModelId(event.target.value)}
-                    placeholder={t('setup.modelIdPlaceholder', 'Model ID')}
-                    className="w-full px-3 py-2 rounded-lg text-[12px] bg-base border border-border-subtle text-text placeholder:text-text-muted outline-none focus:border-accent/40 transition-colors"
-                  />
-                )}
-                {selectedProvider.models.length === 0 ? (
-                  <span className="text-[10px] text-text-muted px-1">
-                    {t('setup.runtimeModelsHint', 'This provider uses OpenCode\'s live model catalog after the runtime starts.')}
+              <div className="flex items-start gap-3 rounded-xl border border-border-subtle bg-base px-3.5 py-3">
+                <input
+                  id="setup-runtime-tooling-bridge"
+                  type="checkbox"
+                  checked={runtimeToolingBridgeEnabled}
+                  onChange={(event) => setRuntimeToolingBridgeEnabled(event.target.checked)}
+                  className="mt-0.5"
+                />
+                <label htmlFor="setup-runtime-tooling-bridge" className="flex min-w-0 cursor-pointer flex-col gap-1">
+                  <span id="setup-runtime-tooling-bridge-title" className="text-sm font-semibold text-text">
+                    {t('setup.toolingBridgeTitle', 'Reuse developer tools from this Mac')}
                   </span>
-                ) : null}
+                  <span className="text-xs leading-relaxed text-text-muted">
+                    {t(
+                      'setup.toolingBridgeDescription',
+                      'Allow agents to see standard Git, SSH, package-manager, cloud, Docker, and Kubernetes config from your home directory. Turn this off for stricter isolation; you can change it later in Settings.',
+                    )}
+                  </span>
+                </label>
               </div>
-            </>
-          )}
-
-          {error ? (
-            <p className="text-[12px] text-center" style={{ color: 'var(--color-red)' }}>{error}</p>
+            </div>
           ) : null}
+        </section>
 
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label htmlFor="setup-runtime-tooling-bridge" className="mt-1 flex items-start gap-3 rounded-xl border border-border-subtle bg-elevated px-3.5 py-3 cursor-pointer">
-            <input
-              id="setup-runtime-tooling-bridge"
-              type="checkbox"
-              checked={runtimeToolingBridgeEnabled}
-              onChange={(event) => setRuntimeToolingBridgeEnabled(event.target.checked)}
-              className="mt-0.5"
-            />
-            <span className="flex min-w-0 flex-col gap-1">
-              <span className="text-[12px] font-semibold text-text">
-                {t('setup.toolingBridgeTitle', 'Developer config bridge')}
-              </span>
-              <span className="text-[10px] leading-relaxed text-text-muted">
-                {t(
-                  'setup.toolingBridgeDescription',
-                  'Let the managed OpenCode runtime reuse standard Git, SSH, package-manager, cloud, Docker, and Kubernetes config from your home directory. Turn this off for a stricter isolated runtime HOME; you can change it later in Settings.',
-                )}
-              </span>
-            </span>
-          </label>
+        {connectionNeedsRetest ? (
+          <div role="status" className="rounded-xl border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+            {t('setup.connectionStale', 'The provider or model changed. Test the connection again before continuing.')}
+          </div>
+        ) : null}
+        {error ? (
+          <div role="alert" className="rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100">
+            <div>{error}</div>
+            <a href={docsHref(localIntent.primaryDocs)} target="_blank" rel="noreferrer" className="mt-1 inline-flex text-red-50 underline">
+              {t('setup.errorDocs', 'Open setup help')}
+            </a>
+          </div>
+        ) : null}
 
-          <button
-            onClick={handleContinue}
+        <footer className="flex flex-col gap-2 sm:flex-row">
+          <Button
+            variant="secondary"
+            fullWidth
+            onClick={() => void handleTestConnection()}
+            loading={connectionTest.status === 'testing'}
             disabled={!canContinue || saving}
-            className="w-full py-2.5 rounded-xl text-[13px] font-semibold cursor-pointer transition-all mt-2"
-            style={{
-              background: canContinue ? 'var(--color-accent)' : 'var(--color-surface-hover)',
-              color: canContinue ? 'var(--color-accent-foreground)' : 'var(--color-text-muted)',
-              opacity: saving ? 0.6 : 1,
-            }}
+            disabledReason={!canContinue ? t('setup.testDisabled', 'Choose a provider, enter required credentials, and choose a model first.') : null}
           >
-            {saving ? t('common.loading', 'Setting up...') : t('setup.continue', 'Get Started')}
-          </button>
-        </div>
+            {connectionTest.status === 'testing'
+              ? t('setup.testingConnection', 'Testing connection...')
+              : t('setup.testConnection', 'Test connection')}
+          </Button>
+          <Button
+            variant="primary"
+            fullWidth
+            onClick={handleContinue}
+            disabled={!connectionIsCurrent || saving}
+            disabledReason={!connectionIsCurrent ? t('setup.continueDisabled', 'Test this provider and model first.') : null}
+          >
+            {t('setup.continue', 'Get Started')}
+          </Button>
+        </footer>
+
+        {connectionTest.status === 'success' && connectionIsCurrent ? (
+          <div role="status" className="text-center text-sm text-text-muted">
+            {connectionTest.message}
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/components/accessibility-smoke.test.tsx
+++ b/apps/desktop/src/renderer/components/accessibility-smoke.test.tsx
@@ -8,7 +8,11 @@ import { SettingsPanel } from './sidebar/SettingsPanel'
 import { configureI18n } from '../helpers/i18n'
 
 async function expectNoA11yViolations(container: HTMLElement) {
-  const result = await axe(container)
+  const result = await axe(container, {
+    rules: {
+      'color-contrast': { enabled: true },
+    },
+  })
   expect(result.violations).toEqual([])
 }
 

--- a/apps/desktop/src/renderer/components/chat/SessionQuestionDock.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionQuestionDock.test.tsx
@@ -56,6 +56,7 @@ function resetSessionStore() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  document.body.replaceChildren()
   resetSessionStore()
   installQuestionApi()
 })
@@ -124,6 +125,40 @@ describe('SessionQuestionDock', () => {
     await user.click(screen.getByRole('button', { name: /About:/ }))
     expect(screen.getByText('Read file')).toBeInTheDocument()
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+  })
+
+  it('uses instant scoped-tool scrolling when reduced motion is enabled', async () => {
+    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    const user = userEvent.setup()
+    const scrollIntoView = vi.fn()
+    const target = document.createElement('div')
+    target.dataset.toolCallId = 'tool-call-1'
+    Object.defineProperty(target, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    })
+    document.body.append(target)
+    const request: PendingQuestion = {
+      ...baseRequest,
+      tool: {
+        messageId: 'message-1',
+        callId: 'tool-call-1',
+      },
+    }
+
+    render(<SessionQuestionDock request={request} />)
+
+    await user.click(screen.getByRole('button', { name: /About:/ }))
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'center' })
   })
 
   it('rejects the active question through the question IPC', async () => {

--- a/apps/desktop/src/renderer/components/chat/SessionQuestionDock.tsx
+++ b/apps/desktop/src/renderer/components/chat/SessionQuestionDock.tsx
@@ -29,7 +29,7 @@ export function SessionQuestionDock({ request, queueCount = 1 }: Props) {
     if (!callId) return
     const target = document.querySelector(`[data-tool-call-id="${CSS.escape(callId)}"]`)
     if (target instanceof HTMLElement) {
-      target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      target.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'center' })
     }
   }
 
@@ -259,4 +259,10 @@ export function SessionQuestionDock({ request, queueCount = 1 }: Props) {
       </div>
     </div>
   )
+}
+
+function preferredScrollBehavior(): ScrollBehavior {
+  const reduce = typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  return reduce ? 'auto' : 'smooth'
 }

--- a/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
+++ b/apps/desktop/src/renderer/components/provider/ProviderAuthControls.tsx
@@ -3,14 +3,25 @@ import type { ProviderAuthMethod, ProviderAuthPrompt } from '@open-cowork/shared
 import { t } from '../../helpers/i18n'
 import { writeTextToClipboard } from '../../helpers/clipboard'
 
-function suggestedAuthLabel(providerId: string | null | undefined, providerName?: string) {
+type CopyMode = 'settings' | 'setup'
+
+function suggestedAuthLabel(providerId: string | null | undefined, providerName?: string, copyMode: CopyMode = 'settings') {
   if (providerId === 'openai') return 'ChatGPT Plus/Pro'
-  return providerName || t('providerAuth.openCodeLogin', 'OpenCode login')
+  return providerName || (
+    copyMode === 'setup'
+      ? t('providerAuth.browserLogin', 'Browser login')
+      : t('providerAuth.openCodeLogin', 'OpenCode login')
+  )
 }
 
-function noBrowserMethodMessage(providerId: string | null | undefined, providerName?: string) {
+function noBrowserMethodMessage(providerId: string | null | undefined, providerName?: string, copyMode: CopyMode = 'settings') {
+  if (copyMode === 'setup') {
+    return t('providerAuth.noBrowserMethodSetup', 'Browser sign-in is not available for {{provider}} yet. Use the API key field.', {
+      provider: suggestedAuthLabel(providerId, providerName, copyMode),
+    })
+  }
   return t('providerAuth.noBrowserMethod', 'OpenCode does not currently expose browser login for {{provider}} in this runtime. Use the API key field, or update OpenCode when this provider adds subscription login support.', {
-    provider: suggestedAuthLabel(providerId, providerName),
+    provider: suggestedAuthLabel(providerId, providerName, copyMode),
   })
 }
 
@@ -27,6 +38,7 @@ interface Props {
   providerName?: string
   connected?: boolean
   disabled?: boolean
+  copyMode?: CopyMode
   onBeforeAuthorize?: () => Promise<boolean>
   onAuthUpdated?: () => void | Promise<void>
 }
@@ -74,6 +86,7 @@ export function ProviderAuthControls({
   providerName,
   connected,
   disabled,
+  copyMode = 'settings',
   onBeforeAuthorize,
   onAuthUpdated,
 }: Props) {
@@ -171,7 +184,9 @@ export function ProviderAuthControls({
       const selectedIndex = methodIndex ?? latestMethods.findIndex((method) => method.type === 'oauth')
       const selected = selectedIndex >= 0 ? latestMethods[selectedIndex] : null
       if (!selected || selected.type !== 'oauth') {
-        setStatus(t('providerAuth.noOauthMethod', 'OpenCode did not expose a subscription login method for this provider. Use the API key field or update the bundled OpenCode runtime.'))
+        setStatus(copyMode === 'setup'
+          ? t('providerAuth.noOauthMethodSetup', 'Browser sign-in is not available for this provider. Use the API key field.')
+          : t('providerAuth.noOauthMethod', 'OpenCode did not expose a subscription login method for this provider. Use the API key field or update the bundled OpenCode runtime.'))
         return
       }
 
@@ -181,7 +196,9 @@ export function ProviderAuthControls({
         methodInputs[selectedIndex] || {},
       )
       if (!authorization) {
-        setStatus(t('providerAuth.noAuthorization', 'OpenCode did not return a login URL. Its local callback server may already be running or blocked; close any stale OpenCode login flow and try again.'))
+        setStatus(copyMode === 'setup'
+          ? t('providerAuth.noAuthorizationSetup', 'The login URL was not returned. Close any stale browser login flow and try again.')
+          : t('providerAuth.noAuthorization', 'OpenCode did not return a login URL. Its local callback server may already be running or blocked; close any stale OpenCode login flow and try again.'))
         return
       }
       if (authorization.method === 'code') {
@@ -213,7 +230,9 @@ export function ProviderAuthControls({
         : t('providerAuth.callbackFailed', 'Provider login did not complete. Try the login flow again.'))
       if (ok) {
         if (!await verifyProviderConnected()) {
-          setStatus(t('providerAuth.notVerified', 'OpenCode still does not report this provider as signed in. Finish the browser login, then try confirming again.'))
+          setStatus(copyMode === 'setup'
+            ? t('providerAuth.notVerifiedSetup', 'This provider is not signed in yet. Finish the browser login, then try confirming again.')
+            : t('providerAuth.notVerified', 'OpenCode still does not report this provider as signed in. Finish the browser login, then try confirming again.'))
           return
         }
         setPendingAuth(null)
@@ -246,7 +265,9 @@ export function ProviderAuthControls({
     setStatus(t('providerAuth.verifying', 'Checking provider login status...'))
     if (await checkCurrentRuntime(5)) return true
 
-    setStatus(t('providerAuth.reloadingRuntime', 'Reloading OpenCode to pick up the provider login...'))
+    setStatus(copyMode === 'setup'
+      ? t('providerAuth.reloadingRuntimeSetup', 'Refreshing the model service to pick up the provider login...')
+      : t('providerAuth.reloadingRuntime', 'Reloading OpenCode to pick up the provider login...'))
     const runtimeStatus = await window.coworkApi.runtime.restart()
     if (!runtimeStatus.ready) return false
     return checkCurrentRuntime(5)
@@ -267,7 +288,9 @@ export function ProviderAuthControls({
       }
 
       if (!await verifyProviderConnected()) {
-        setStatus(t('providerAuth.notVerified', 'OpenCode still does not report this provider as signed in. Finish the browser login, then try confirming again.'))
+        setStatus(copyMode === 'setup'
+          ? t('providerAuth.notVerifiedSetup', 'This provider is not signed in yet. Finish the browser login, then try confirming again.')
+          : t('providerAuth.notVerified', 'OpenCode still does not report this provider as signed in. Finish the browser login, then try confirming again.'))
         return
       }
       await onAuthUpdated?.()
@@ -312,20 +335,30 @@ export function ProviderAuthControls({
   return (
     <div className="flex flex-col gap-3">
       <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted px-1">
-        {t('providerAuth.header', 'OpenCode login')}
+        {copyMode === 'setup'
+          ? t('providerAuth.headerSetup', 'Browser sign-in')
+          : t('providerAuth.header', 'OpenCode login')}
       </span>
       <div className="rounded-2xl border border-border-subtle p-4 flex flex-col gap-3">
         <div className="text-[11px] text-text-muted leading-relaxed">
-          {t('providerAuth.description', 'Use OpenCode-native provider auth for subscriptions/OAuth, or keep using the API key field above.')}
+          {copyMode === 'setup'
+            ? t('providerAuth.descriptionSetup', 'Use provider sign-in for subscriptions or OAuth, or keep using the API key field.')
+            : t('providerAuth.description', 'Use OpenCode-native provider auth for subscriptions/OAuth, or keep using the API key field above.')}
         </div>
         {connected === false ? (
           <div className="rounded-xl border border-border-subtle px-3 py-2 text-[11px] leading-relaxed" style={{ background: 'var(--color-surface)' }}>
-            {t('providerAuth.notConnected', 'OpenCode does not currently report this provider as signed in. Sign in below or enter an API key above, then save before chatting.')}
+            {copyMode === 'setup'
+              ? t('providerAuth.notConnectedSetup', 'This provider is not signed in yet. Sign in below or enter an API key.')
+              : t('providerAuth.notConnected', 'OpenCode does not currently report this provider as signed in. Sign in below or enter an API key above, then save before chatting.')}
           </div>
         ) : null}
         {connected === true ? (
           <div className="rounded-xl border border-border-subtle px-3 py-2 text-[11px] leading-relaxed flex items-center justify-between gap-3" style={{ color: 'var(--color-green)', background: 'var(--color-surface)' }}>
-            <span>{t('providerAuth.connectedStatus', 'OpenCode reports this provider is signed in.')}</span>
+            <span>
+              {copyMode === 'setup'
+                ? t('providerAuth.connectedStatusSetup', 'This provider is signed in.')
+                : t('providerAuth.connectedStatus', 'OpenCode reports this provider is signed in.')}
+            </span>
             <button
               type="button"
               onClick={forgetProviderLogin}
@@ -338,7 +371,7 @@ export function ProviderAuthControls({
         ) : null}
         {!loading && entries.length === 0 ? (
           <div className="rounded-xl border border-border-subtle px-3 py-2 text-[11px] leading-relaxed" style={{ background: 'var(--color-surface)' }}>
-            {noBrowserMethodMessage(providerId, providerName)}
+            {noBrowserMethodMessage(providerId, providerName, copyMode)}
           </div>
         ) : null}
         {entries.map(({ method, index }) => {

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -176,6 +176,16 @@
     --dur-2: 0ms;
     --dur-3: 0ms;
   }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-delay: 0ms !important;
+    transition-duration: 0ms !important;
+  }
 }
 
 html, body, #root {

--- a/apps/desktop/src/renderer/test/setup.ts
+++ b/apps/desktop/src/renderer/test/setup.ts
@@ -364,6 +364,7 @@ function installCoworkApi(overrides: TestCoworkApi = {}) {
       callback: vi.fn(async () => false),
       list: vi.fn(async () => []),
       logout: vi.fn(async () => true),
+      testConnection: vi.fn(async (providerId: string, modelId: string) => ({ ok: true, providerId, modelId })),
     },
     runtime: {
       awaitInitialization: vi.fn(async () => ({

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,32 @@
+# Design System
+
+Open Cowork uses a small, enforceable design system so UI work stays consistent across themes, downstream branding, and accessibility gates.
+
+## Tokens
+
+Structural tokens live in `apps/desktop/src/renderer/styles/globals.css` and are documented in [Design Tokens](design-tokens.md). Use the token-backed classes and CSS variables for type, spacing, radius, motion, elevation, and content measures. Theme color values stay inside the `BrandThemeTokens` contract so downstream themes can change color without forking layout.
+
+Avoid adding new Tailwind arbitrary font-size utilities such as `text-[13px]`. `pnpm lint` ratchets the existing renderer count and fails if the count increases.
+
+## Primitives
+
+Shared renderer primitives live in `apps/desktop/src/renderer/components/ui/`:
+
+- `Button` and `IconButton` for actions. `IconButton` requires a `label` prop; `pnpm lint` fails if a usage omits it.
+- `Input`, `Select`, and `SegmentedControl` for form controls.
+- `Dialog`, `Card`, `Badge`, `EmptyState`, `Skeleton`, `Tooltip`, and `Toaster` for common surfaces and feedback.
+- `Icon` wraps Lucide icons so stroke, sizing, and naming stay consistent.
+
+Prefer these primitives before adding component-local button, input, badge, skeleton, or modal markup.
+
+## Accessibility Gates
+
+CI runs `pnpm lint:a11y --max-warnings=0` and the focused renderer accessibility smoke tests. The smoke helper explicitly enables axe `color-contrast`, so contrast regressions are part of the required test gate.
+
+Command-style pickers should expose the result list as `role="listbox"` with `role="option"` rows. Search inputs should remain search/text inputs and point at the listbox with `aria-controls` and `aria-activedescendant`; do not model these as a combobox unless the input itself owns a popup value.
+
+## Motion
+
+Motion durations are tokenized as `--dur-1`, `--dur-2`, and `--dur-3`. Global CSS collapses transitions, animations, and smooth scrolling under `prefers-reduced-motion: reduce`, including inline transition styles. Renderer tests cover reduced-motion scrolling for chat source jumps.
+
+When adding JavaScript-driven motion, check `window.matchMedia('(prefers-reduced-motion: reduce)')` and provide an instant path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
       - Gateway Provider Readiness: gateway-provider-readiness.md
       - Downstream Customization: downstream.md
       - Downstream Contract: downstream-contract.md
+      - Design System: design-system.md
       - Design Tokens: design-tokens.md
       - Iconography: iconography.md
       - OpenCode SDK Boundary: opencode-sdk-v2-boundary.md

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -293,6 +293,7 @@ export interface CoworkAPI {
   provider: {
     list: () => Promise<RuntimeProviderDescriptor[]>
     authMethods: () => Promise<Record<string, ProviderAuthMethod[]>>
+    testConnection: (providerId: string, modelId: string) => Promise<{ ok: boolean; providerId: string; modelId: string }>
     authorize: (
       providerId: string,
       method: number,

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -89,6 +89,9 @@ const privateSdkAccessPatterns = [
     guidance: 'Use OAuth2ClientOptions.redirectUri or GetTokenOptions.redirect_uri instead.',
   },
 ]
+const rendererArbitraryFontSizeLimit = 833
+const arbitraryFontSizePattern = /\btext-\[\d+px\]/g
+let rendererArbitraryFontSizeCount = 0
 
 function visit(dir) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -146,6 +149,11 @@ function lintFile(fullPath) {
     }
   }
 
+  if (shouldLintStyle && relPath.startsWith('apps/desktop/src/renderer/')) {
+    rendererArbitraryFontSizeCount += content.match(arbitraryFontSizePattern)?.length || 0
+    if (ext === '.tsx') validateIconButtonLabels(relPath, content)
+  }
+
   if (/\b(?:opencowork|OpenCowork)\b/.test(content) && !isLegacyNamingAllowed(relPath)) {
     errors.push(`${relPath}: use "open-cowork" publicly; legacy "opencowork" is allowed only for documented back-compat namespaces`)
   }
@@ -160,6 +168,7 @@ function lintFile(fullPath) {
 }
 
 visit(root)
+validateRendererDesignSystemGates()
 validateArchitectureSdkVersionPolicy()
 
 if (errors.length) {
@@ -216,4 +225,58 @@ function validateArchitectureSdkVersionPolicy() {
     const message = err instanceof Error ? err.message : String(err)
     errors.push(`docs/architecture.md: unable to verify OpenCode SDK version policy: ${message}`)
   }
+}
+
+function validateRendererDesignSystemGates() {
+  if (rendererArbitraryFontSizeCount > rendererArbitraryFontSizeLimit) {
+    errors.push(
+      `apps/desktop/src/renderer: arbitrary font-size utility count is ${rendererArbitraryFontSizeCount}; `
+      + `limit is ${rendererArbitraryFontSizeLimit}. Use text tokens/classes or lower the ratchet intentionally.`,
+    )
+  }
+}
+
+function validateIconButtonLabels(relPath, content) {
+  const iconButtonPattern = /<IconButton\b/g
+  for (const match of content.matchAll(iconButtonPattern)) {
+    const start = match.index || 0
+    const tag = readJsxOpeningTag(content, start)
+    if (!tag) continue
+    if (/\blabel\s*=/.test(tag)) continue
+    const lineNo = content.slice(0, start).split('\n').length
+    errors.push(`${relPath}:${lineNo} IconButton must include a label prop`)
+  }
+}
+
+function readJsxOpeningTag(content, start) {
+  let quote = null
+  let expressionDepth = 0
+
+  for (let index = start; index < content.length; index += 1) {
+    const char = content[index]
+    const prev = content[index - 1]
+
+    if (quote) {
+      if (char === quote && prev !== '\\') quote = null
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '{') {
+      expressionDepth += 1
+      continue
+    }
+    if (char === '}') {
+      expressionDepth = Math.max(0, expressionDepth - 1)
+      continue
+    }
+    if (char === '>' && expressionDepth === 0) {
+      return content.slice(start, index)
+    }
+  }
+
+  return null
 }

--- a/scripts/validate-deployment-configs.mjs
+++ b/scripts/validate-deployment-configs.mjs
@@ -1111,8 +1111,16 @@ function validateSetupHealthCenter() {
   }
 
   const setupScreen = read(setupScreenPath)
-  if (!setupScreen.includes('SETUP_INTENTS') || !setupScreen.includes('Setup path')) {
-    throw new Error(`${setupScreenPath} must render shared setup intents`)
+  for (const phrase of [
+    'SETUP_INTENTS',
+    'advancedIntents.map',
+    'Set up a team or server deployment',
+    'selectedIntent.primaryCommand',
+    'selectedIntent.primaryDocs',
+  ]) {
+    if (!setupScreen.includes(phrase)) {
+      throw new Error(`${setupScreenPath} must render shared setup intents behind advanced setup disclosure`)
+    }
   }
 
   const healthCenter = read(healthCenterPath)

--- a/tests/ipc-handler-behavior.test.ts
+++ b/tests/ipc-handler-behavior.test.ts
@@ -26,6 +26,7 @@ import { sessionEngine } from '../apps/desktop/src/main/session-engine.ts'
 import { stopSessionStatusReconciliation } from '../apps/desktop/src/main/session-status-reconciler.ts'
 import { clearSessionRegistryCache, toSessionRecord, upsertSessionRecord } from '../apps/desktop/src/main/session-registry.ts'
 import { LOCAL_WORKSPACE_ID, createWorkspaceGateway } from '../apps/desktop/src/main/workspace-gateway.ts'
+import { runtimeState } from '../apps/desktop/src/main/runtime-state.ts'
 import type { CloudWorkspaceSessionAdapter } from '../apps/desktop/src/main/cloud-workspace-adapter.ts'
 
 function createBaseContext() {
@@ -2075,6 +2076,95 @@ test('local credential editor IPC masks secret fields and preserves them on save
   } finally {
     const { clearSettingsCache } = await import('../apps/desktop/src/main/settings.ts')
     clearSettingsCache()
+    if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
+    else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
+    if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR
+    else process.env.OPEN_COWORK_USER_DATA_DIR = previousUserDataDir
+    clearConfigCaches()
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('provider connection test IPC syncs saved API auth and validates live models', async () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'opencowork-ipc-provider-test-'))
+  const configDir = join(tempRoot, 'downstream')
+  const userDataDir = join(tempRoot, 'user-data')
+  const previousConfigDir = process.env.OPEN_COWORK_CONFIG_DIR
+  const previousUserDataDir = process.env.OPEN_COWORK_USER_DATA_DIR
+
+  writeCredentialDescriptorConfig(configDir)
+  process.env.OPEN_COWORK_CONFIG_DIR = configDir
+  process.env.OPEN_COWORK_USER_DATA_DIR = userDataDir
+  clearConfigCaches()
+
+  const authSetCalls: unknown[] = []
+  const fakeClient = {
+    auth: {
+      set: async (input: unknown, options: unknown) => {
+        authSetCalls.push({ input, options })
+      },
+    },
+    provider: {
+      list: async () => ({
+        data: {
+          all: [{
+            id: 'acme',
+            name: 'Acme',
+            models: {
+              'acme/model': {},
+            },
+          }],
+          connected: [],
+        },
+      }),
+    },
+  }
+
+  runtimeState.setClient(fakeClient as Parameters<typeof runtimeState.setClient>[0])
+  try {
+    const {
+      clearSettingsCache,
+      saveSettings,
+    } = await import('../apps/desktop/src/main/settings.ts')
+    clearSettingsCache()
+    saveSettings({
+      selectedProviderId: 'acme',
+      selectedModelId: 'acme/model',
+      providerCredentials: {
+        acme: { apiKey: 'provider-secret', projectId: 'project-visible' },
+      },
+    })
+
+    const { context, handlers } = createBaseContext()
+    registerAppHandlers(context)
+    const handler = handlers.get('provider:test-connection')
+    assert.ok(handler, 'expected provider:test-connection handler to be registered')
+
+    assert.deepEqual(await handler({}, 'acme', 'acme/model'), {
+      ok: true,
+      providerId: 'acme',
+      modelId: 'acme/model',
+    })
+    assert.deepEqual(authSetCalls, [{
+      input: {
+        providerID: 'acme',
+        auth: {
+          type: 'api',
+          key: 'provider-secret',
+          metadata: { source: 'open-cowork' },
+        },
+      },
+      options: { throwOnError: true },
+    }])
+
+    await assert.rejects(
+      () => handler({}, 'acme', 'missing-model'),
+      /missing-model is not available from Acme/,
+    )
+  } finally {
+    const { clearSettingsCache } = await import('../apps/desktop/src/main/settings.ts')
+    clearSettingsCache()
+    runtimeState.resetAfterStop()
     if (previousConfigDir === undefined) delete process.env.OPEN_COWORK_CONFIG_DIR
     else process.env.OPEN_COWORK_CONFIG_DIR = previousConfigDir
     if (previousUserDataDir === undefined) delete process.env.OPEN_COWORK_USER_DATA_DIR


### PR DESCRIPTION
## Summary
- make first-run setup local-first, hide team/server deployment paths behind disclosure, and require an explicit tested provider/model before Get Started
- add provider:test-connection through the typed bridge so setup syncs saved API auth through OpenCode and validates the live provider/model catalog
- add accessibility/design-system guardrails for command palette search semantics, reduced motion, color contrast, labelled icon buttons, font-size ratchets, and contributor docs

## Validation
- pnpm typecheck
- pnpm lint
- pnpm --dir apps/desktop test:renderer
- node --no-warnings --experimental-strip-types --test tests/ipc-handler-behavior.test.ts
- pnpm test
- pnpm lint:a11y --max-warnings=0
- uv run mkdocs build --strict
- node scripts/validate-deployment-configs.mjs
- git diff --check

Closes #710
Closes #711