### PR TITLE
Restart runtime before setup connection test

### DIFF
--- a/apps/desktop/src/renderer/components/SetupScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.test.tsx
@@ -258,10 +258,16 @@ describe('SetupScreen', () => {
     expect(apiKeyInput).toHaveValue('sk-or-user-edit')
   })
 
-  it('tests the connection, then persists the developer config bridge choice during first-run setup', async () => {
+  it('restarts with saved setup choices before testing the connection', async () => {
     const user = userEvent.setup()
     const set = vi.fn(async () => settings())
-    const restart = vi.fn(async () => ({ ready: true, error: null }))
+    const restart = vi.fn(async () => ({
+      phase: 'ready' as const,
+      message: 'Runtime is ready.',
+      ready: true,
+      error: null,
+      updatedAt: new Date().toISOString(),
+    }))
     const testConnection = vi.fn(async (providerId: string, modelId: string) => ({ ok: true, providerId, modelId }))
     const awaitInitialization = vi.fn(async () => ({
       phase: 'ready' as const,
@@ -307,9 +313,9 @@ describe('SetupScreen', () => {
     await user.click(screen.getByRole('button', { name: 'Get Started' }))
 
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
-    expect(awaitInitialization).toHaveBeenCalledTimes(1)
+    expect(awaitInitialization).not.toHaveBeenCalled()
     expect(testConnection).toHaveBeenCalledWith('openrouter', 'anthropic/claude-sonnet-4')
-    expect(restart).not.toHaveBeenCalled()
+    expect(restart).toHaveBeenCalledTimes(1)
     expect(set).toHaveBeenCalledWith(expect.objectContaining({
       selectedProviderId: 'openrouter',
       selectedModelId: 'anthropic/claude-sonnet-4',
@@ -318,6 +324,53 @@ describe('SetupScreen', () => {
         openrouter: expect.objectContaining({ apiKey: 'sk-or-scoped' }),
       },
     }))
+  })
+
+  it('blocks provider validation when saved setup choices fail to restart the runtime', async () => {
+    const user = userEvent.setup()
+    const restart = vi.fn(async () => ({
+      ready: false,
+      error: 'Runtime config rejected provider options',
+      updatedAt: new Date().toISOString(),
+    }))
+    const testConnection = vi.fn(async (providerId: string, modelId: string) => ({ ok: true, providerId, modelId }))
+    const onComplete = vi.fn()
+    installRendererTestCoworkApi({
+      settings: {
+        get: vi.fn(async () => settings()),
+        getProviderCredentials: vi.fn(async () => ({})),
+        set: vi.fn(async () => settings()),
+      },
+      runtime: {
+        restart,
+      },
+      provider: {
+        testConnection,
+      },
+    })
+
+    render(
+      <SetupScreen
+        brandName="Open Cowork"
+        providers={providers}
+        defaultProviderId="openrouter"
+        defaultModelId="anthropic/claude-sonnet-4"
+        onComplete={onComplete}
+      />,
+    )
+
+    const apiKeyInput = await screen.findByPlaceholderText('sk-or-...')
+    await user.type(apiKeyInput, 'runtime-config-placeholder')
+    const testButton = await screen.findByRole('button', { name: 'Test connection' })
+    await waitFor(() => expect(testButton).not.toBeDisabled())
+    await user.click(testButton)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Runtime config rejected provider options'))
+    expect(restart).toHaveBeenCalledTimes(1)
+    expect(testConnection).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().globalErrors[0]?.message).toBe('Runtime config rejected provider options')
+    expect(screen.getByRole('button', { name: 'Get Started' })).toBeDisabled()
+    expect(onComplete).not.toHaveBeenCalled()
   })
 
   it('keeps setup open and surfaces provider validation failures', async () => {
@@ -436,6 +489,6 @@ describe('SetupScreen', () => {
         'github-copilot': {},
       },
     }))
-    expect(restart).toHaveBeenCalledTimes(1)
+    expect(restart).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/renderer/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/components/SetupScreen.tsx
@@ -4,6 +4,7 @@ import {
   type ProviderDescriptor,
   type RuntimeLoadingPhase,
   type RuntimeLoadingStatus,
+  type RuntimeStatus,
   type SetupIntentId,
 } from '@open-cowork/shared'
 import { t } from '../helpers/i18n'
@@ -108,6 +109,19 @@ function runtimeProgressLabel(status: RuntimeLoadingStatus | null, fallback: str
   if (status?.phase === 'ready') return t('setup.progressReady', 'Model service is ready.')
   if (status?.phase === 'error') return t('setup.progressError', 'The model service could not start.')
   return fallback || t('setup.connectionIdle', 'Ready to test the connection.')
+}
+
+function runtimeStatusToLoadingStatus(
+  status: RuntimeStatus,
+  message: string,
+): RuntimeLoadingStatus {
+  return {
+    phase: status.ready ? 'ready' : 'error',
+    message,
+    ready: status.ready,
+    error: status.ready ? null : status.error || message,
+    updatedAt: status.updatedAt || new Date().toISOString(),
+  }
 }
 
 export function SetupScreen({
@@ -330,15 +344,19 @@ export function SetupScreen({
     })
     try {
       await saveSetupSelection()
-      const status = await window.coworkApi.runtime.awaitInitialization()
+      const status = await window.coworkApi.runtime.restart()
       if (!status.ready) {
         const message = status.error || t('setup.runtimeFailed', 'The model service could not start with these settings. Double-check your key and try again.')
+        setRuntimeProgress(runtimeStatusToLoadingStatus(status, message))
         setError(message)
         setConnectionTest({ status: 'error', signature: null, message })
         addGlobalError(message)
         return
       }
-      setRuntimeProgress(status)
+      setRuntimeProgress(runtimeStatusToLoadingStatus(
+        status,
+        t('setup.progressReady', 'Model service is ready.'),
+      ))
       await window.coworkApi.provider.testConnection(providerId, modelId.trim())
       const message = t('setup.connectionReady', 'Connection tested. You can start using {{brandName}}.', { brandName })
       setConnectionTest({


### PR DESCRIPTION
## Summary

- Restart the OpenCode runtime after first-run setup settings are saved and before provider/model validation runs.
- Adapt the returned runtime status into setup loading status so the setup progress UI stays stable.
- Add renderer coverage for the restart-before-validation flow and the failure branch where runtime config cannot start.

## Root Cause

First-run setup saved fresh provider credentials, but Test Connection only waited for the already-running runtime. Custom provider credentials are injected into generated runtime config at runtime startup, so validation could run against stale provider options.

## Validation

- `pnpm --dir apps/desktop exec vitest run --config vitest.renderer.config.ts src/renderer/components/SetupScreen.test.tsx`
- `pnpm test:renderer`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`

`pnpm test` result: 1809 passed, 20 expected Postgres skips, 0 failures.