### PR TITLE
Align Cloud Web workbench parity with Desktop

### DIFF
--- a/apps/website/src/app-shell.ts
+++ b/apps/website/src/app-shell.ts
@@ -1,3 +1,5 @@
+import { cloudWebWorkbenchRouteSummary } from './workbench-parity.ts'
+
 export type CloudWebSurface = 'workbench' | 'admin'
 
 export type CloudWebRouteId =
@@ -42,7 +44,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'workbench',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Cloud threads from web, desktop, and gateway.',
+    summary: cloudWebWorkbenchRouteSummary('threads', 'Cloud threads from web, desktop, and gateway.'),
   },
   {
     id: 'chat',
@@ -50,7 +52,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'workbench',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Selected cloud session timeline and composer.',
+    summary: cloudWebWorkbenchRouteSummary('chat', 'Selected cloud session timeline and composer.'),
   },
   {
     id: 'agents',
@@ -58,7 +60,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'workbench',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Profile-allowed agents and runtime capability status.',
+    summary: cloudWebWorkbenchRouteSummary('agents', 'Profile-allowed agents and runtime capability status.'),
   },
   {
     id: 'capabilities',
@@ -66,7 +68,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'workbench',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Allowed tools, skills, and MCP capability verdicts.',
+    summary: cloudWebWorkbenchRouteSummary('capabilities', 'Allowed tools, skills, and MCP capability verdicts.'),
   },
   {
     id: 'workflows',
@@ -74,7 +76,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'workbench',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Workflow definitions, runs, and status.',
+    summary: cloudWebWorkbenchRouteSummary('workflows', 'Workflow definitions, runs, and status.'),
   },
   {
     id: 'artifacts',
@@ -82,7 +84,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'workbench',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Cloud artifact metadata and downloads.',
+    summary: cloudWebWorkbenchRouteSummary('artifacts', 'Cloud artifact metadata and downloads.'),
   },
   {
     id: 'org',

--- a/apps/website/src/browser-e2e.test.ts
+++ b/apps/website/src/browser-e2e.test.ts
@@ -54,6 +54,57 @@ test('cloud web browser exercises every route declared in the route API matrix',
   }
 })
 
+test('cloud web browser exposes desktop parity boundaries and workbench state vocabulary', async () => {
+  const harness = createCloudWebBrowserHarness({ role: 'admin' })
+  const firstView = harness.views[harness.sessions[0].sessionId]
+  firstView.projection.view.messages.push(
+    { id: 'system-note', role: 'system', content: 'Cloud policy loaded.', order: 8 },
+    { id: 'error-note', role: 'error', content: 'Provider warning projected from cloud.', order: 9 },
+  )
+  await harness.start()
+  try {
+    assert.ok(Array.isArray(harness.bootstrap.workbenchParity))
+    assert.match(harness.document.querySelector('[data-parity-route="threads"]')?.textContent || '', /Cloud Project Sources/)
+    assert.match(harness.document.querySelector('[data-parity-route="threads"]')?.textContent || '', /Local Filesystem/)
+
+    const chatLink = harness.document.querySelector('[data-route-link="chat"]') as HTMLAnchorElement
+    chatLink.focus()
+    assert.equal(harness.document.activeElement, chatLink)
+    chatLink.dispatchEvent(new harness.window.MouseEvent('click', { bubbles: true, cancelable: true }))
+    await waitFor(() => assert.equal(harness.document.body.dataset.route, 'chat'))
+    assert.match(harness.document.querySelector('[data-parity-route="chat"]')?.textContent || '', /Runtime Status/)
+    assert.match(harness.document.querySelector('[data-parity-route="chat"]')?.textContent || '', /Approvals & Questions/)
+    assert.match(harness.document.querySelector('.message-bubble[data-role="system"]')?.textContent || '', /Cloud policy loaded/)
+    assert.match(harness.document.querySelector('.message-bubble[data-role="error"]')?.textContent || '', /Provider warning/)
+
+    harness.clickText('[data-route-link]', 'Tools & Skills')
+    await waitFor(() => assert.equal(harness.document.body.dataset.route, 'capabilities'))
+    assert.match(harness.document.querySelector('[data-parity-route="capabilities"]')?.textContent || '', /Local Stdio MCPs/)
+    assert.match(harness.document.querySelector('#capability-policy-note')?.textContent || '', /Local stdio MCPs are Desktop-only/)
+
+    harness.clickText('[data-route-link]', 'Workflows')
+    await waitFor(() => assert.equal(harness.document.body.dataset.route, 'workflows'))
+    assert.match(harness.document.querySelector('#workflow-detail')?.textContent || '', /Latest run/)
+  } finally {
+    harness.close()
+  }
+
+  const locked = await createCloudWebBrowserHarness({
+    role: 'admin',
+    features: { chat: false, workflows: false, agents: false },
+  }).start()
+  try {
+    const startThread = locked.document.querySelector('#workbench-agent-list button.primary') as HTMLButtonElement
+    assert.equal(startThread.disabled, true)
+    assert.match(startThread.title, /Start thread disables/)
+    const runNow = locked.document.querySelector('#workflow-detail button.primary') as HTMLButtonElement
+    assert.equal(runNow.disabled, true)
+    assert.match(runNow.title, /Workflow controls disable/)
+  } finally {
+    locked.close()
+  }
+})
+
 test('cloud web browser creates, prompts, streams, reloads, and continues a cloud thread', async () => {
   const harness = await createCloudWebBrowserHarness({ role: 'admin' }).start()
   try {

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -1,6 +1,7 @@
 import type { PublicBrandingConfig } from '@open-cowork/shared'
 import type { CloudWebRoute, CloudWebRouteId } from './app-shell.ts'
 import type { CloudWebRouteApiMatrixEntry } from './route-api-matrix.ts'
+import type { CloudWebWorkbenchParityEntry } from './workbench-parity.ts'
 
 export type CloudWebEndpointId =
   | 'authMe'
@@ -64,6 +65,7 @@ export type CloudWebClientBootstrap = {
   defaultRoute: string
   api: CloudWebEndpoint[]
   routeMatrix: CloudWebRouteApiMatrixEntry[]
+  workbenchParity: CloudWebWorkbenchParityEntry[]
   sessionEventTypes: string[]
 }
 

--- a/apps/website/src/client/common-script.ts
+++ b/apps/website/src/client/common-script.ts
@@ -354,12 +354,16 @@ function pill(text, kind = '') {
   return node;
 }
 
-function actionButton(label, onClick, variant = '', disabled = false) {
+function actionButton(label, onClick, variant = '', disabled = false, disabledReason = '') {
   const button = document.createElement('button');
   button.type = 'button';
   button.textContent = label;
   button.disabled = disabled;
   if (variant) button.className = variant;
+  if (disabled && disabledReason) {
+    button.title = disabledReason;
+    button.setAttribute('aria-label', label + ' - ' + disabledReason);
+  }
   button.addEventListener('click', () => {
     try {
       const result = onClick();
@@ -530,8 +534,18 @@ function capabilityLabel(capability) {
   return capability.label || capability.name || capability.id || 'Capability';
 }
 
+function parityEntry(conceptId) {
+  return normalizeList(state.config?.workbenchParity || bootstrap.workbenchParity)
+    .find((entry) => entry.conceptId === conceptId) || null;
+}
+
+function parityText(conceptId, field, fallback) {
+  const entry = parityEntry(conceptId);
+  return entry?.[field] || fallback;
+}
+
 function capabilityPolicyNote(capability) {
-  if (capability.kind === 'mcp' && capability.scope === 'machine') return 'Machine-scoped MCP metadata requires a cloud-safe profile capability.';
+  if (capability.kind === 'mcp' && capability.scope === 'machine') return parityText('local-stdio-mcps', 'disabledReason', 'Machine-scoped MCP metadata requires a cloud-safe profile capability.');
   if (capability.source === 'custom') return 'Synced custom metadata. Execution depends on org policy.';
   return 'Allowed by current cloud profile.';
 }

--- a/apps/website/src/client/surfaces-script.ts
+++ b/apps/website/src/client/surfaces-script.ts
@@ -31,7 +31,14 @@ export function cloudWebsiteClientSurfacesScript() {
     const actions = document.createElement('div');
     actions.className = 'row-actions';
     actions.appendChild(pill(agent.custom ? 'custom' : 'profile', agent.custom ? 'warn' : 'ok'));
-    actions.appendChild(actionButton('Start thread', () => startAgentThread(agent.name), 'primary', bootstrap.features?.chat === false || bootstrap.features?.agents === false));
+    const agentStartLocked = bootstrap.features?.chat === false || bootstrap.features?.agents === false;
+    actions.appendChild(actionButton(
+      'Start thread',
+      () => startAgentThread(agent.name),
+      'primary',
+      agentStartLocked,
+      parityText('agents', 'disabledReason', 'Chat or agent browsing is disabled by this cloud profile.'),
+    ));
     row.appendChild(main);
     row.appendChild(actions);
     list.appendChild(row);
@@ -121,7 +128,8 @@ function renderCapabilities() {
     bootstrap.features?.customSkills === false ? 'Custom skill metadata may be synced but is disabled by this org profile.' : null,
     bootstrap.features?.customMcps === false ? 'Custom MCP metadata may be synced but is disabled by this org profile.' : null,
   ].filter(Boolean);
-  if (!rows.length) rows.push('The browser shows cloud-safe capability metadata and policy verdicts only.');
+  if (!rows.length) rows.push(parityText('tools-skills', 'boundary', 'The browser shows cloud-safe capability metadata and policy verdicts only.'));
+  rows.push(parityText('local-stdio-mcps', 'disabledReason', 'Local stdio MCPs are Desktop-only unless represented by a Cloud-safe capability profile.'));
   for (const text of rows) {
     const row = document.createElement('p');
     row.className = 'empty';
@@ -238,6 +246,30 @@ function renderWorkflows() {
   detail.appendChild(pill(workflow.status || 'unknown', workflowPillKind(workflow.status)));
   detail.appendChild(pill('trigger: ' + workflowTriggerSummary(workflow)));
   if (workflow.webhookUrl) detail.appendChild(pill('webhook configured', 'ok'));
+  if (workflow.latestRunStatus || workflow.latestRunSummary || workflow.latestRunSessionId) {
+    const latest = document.createElement('div');
+    latest.className = 'row compact';
+    const main = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = 'Latest run';
+    main.appendChild(title);
+    const meta = document.createElement('small');
+    meta.textContent = [
+      workflow.latestRunStatus || 'unknown',
+      workflow.latestRunSummary || null,
+      workflow.latestRunSessionId ? 'thread ' + workflow.latestRunSessionId : null,
+    ].filter(Boolean).join(' - ');
+    main.appendChild(document.createElement('br'));
+    main.appendChild(meta);
+    latest.appendChild(main);
+    if (workflow.latestRunSessionId) {
+      const actions = document.createElement('div');
+      actions.className = 'row-actions';
+      actions.appendChild(actionButton('Open run thread', () => selectSession(workflow.latestRunSessionId), 'secondary'));
+      latest.appendChild(actions);
+    }
+    detail.appendChild(latest);
+  }
   const text = document.createElement('p');
   text.className = 'empty';
   text.textContent = workflow.instructions || 'No instructions.';
@@ -255,10 +287,11 @@ function renderWorkflows() {
   });
   const actions = document.createElement('div');
   actions.className = 'row-actions';
-  actions.appendChild(actionButton('Run now', () => runWorkflow(workflow.id), 'primary', bootstrap.features?.workflows === false || workflow.status === 'archived'));
-  if (workflow.status === 'paused') actions.appendChild(actionButton('Resume', () => updateWorkflowStatus(workflow.id, 'resume'), 'secondary', bootstrap.features?.workflows === false));
-  else actions.appendChild(actionButton('Pause', () => updateWorkflowStatus(workflow.id, 'pause'), 'secondary', bootstrap.features?.workflows === false || workflow.status === 'archived'));
-  actions.appendChild(actionButton('Archive', () => updateWorkflowStatus(workflow.id, 'archive'), 'danger', bootstrap.features?.workflows === false || workflow.status === 'archived'));
+  const workflowLockedReason = parityText('workflows', 'disabledReason', 'Workflow controls are disabled by policy or workflow state.');
+  actions.appendChild(actionButton('Run now', () => runWorkflow(workflow.id), 'primary', bootstrap.features?.workflows === false || workflow.status === 'archived', workflowLockedReason));
+  if (workflow.status === 'paused') actions.appendChild(actionButton('Resume', () => updateWorkflowStatus(workflow.id, 'resume'), 'secondary', bootstrap.features?.workflows === false, workflowLockedReason));
+  else actions.appendChild(actionButton('Pause', () => updateWorkflowStatus(workflow.id, 'pause'), 'secondary', bootstrap.features?.workflows === false || workflow.status === 'archived', workflowLockedReason));
+  actions.appendChild(actionButton('Archive', () => updateWorkflowStatus(workflow.id, 'archive'), 'danger', bootstrap.features?.workflows === false || workflow.status === 'archived', workflowLockedReason));
   if (workflow.latestRunSessionId) actions.appendChild(actionButton('Open run thread', () => selectSession(workflow.latestRunSessionId), 'secondary'));
   detail.appendChild(actions);
 }`

--- a/apps/website/src/client/workbench-script.ts
+++ b/apps/website/src/client/workbench-script.ts
@@ -264,12 +264,13 @@ function renderResolvedCard(kind, item) {
 function renderMessageBubble(message) {
   const bubble = document.createElement('article');
   bubble.className = 'message-bubble';
-  bubble.dataset.role = message.role;
+  const role = String(message.role || 'assistant').toLowerCase();
+  bubble.dataset.role = ['assistant', 'user', 'system', 'error'].includes(role) ? role : 'assistant';
   const heading = document.createElement('div');
   heading.className = 'message-heading';
-  heading.textContent = message.role === 'user' ? 'You' : 'Assistant';
+  heading.textContent = role === 'user' ? 'You' : role === 'system' ? 'System' : role === 'error' ? 'Error' : 'Assistant';
   const body = document.createElement('p');
-  body.textContent = messageText(message);
+  body.textContent = messageText(message) || '(empty message)';
   bubble.appendChild(heading);
   bubble.appendChild(body);
   if (Array.isArray(message.attachments) && message.attachments.length) {
@@ -379,6 +380,7 @@ function renderTodoList(todos) {
 function renderRuntimeError(error) {
   const item = document.createElement('div');
   item.className = 'notice runtime-error';
+  item.dataset.kind = 'error';
   item.appendChild(pill(errorCategory(error.message), 'warn'));
   const text = document.createElement('span');
   text.textContent = error.message || 'Runtime error';

--- a/apps/website/src/modularity.test.ts
+++ b/apps/website/src/modularity.test.ts
@@ -45,6 +45,7 @@ test('cloud web workbench production source stays split into bounded modules', (
     'styles.ts',
     'surface-workbench.ts',
     'thread-workbench.ts',
+    'workbench-parity.ts',
   ]
   for (const module of requiredModules) {
     assert.ok(files.has(module), `${module} exists`)

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -25,6 +25,11 @@ import {
   deriveCloudWebWorkbenchAgents,
   filterCloudWebCapabilities,
 } from './surface-workbench.ts'
+import {
+  CLOUD_WEB_WORKBENCH_PARITY_MATRIX,
+  cloudWebWorkbenchParityForRoute,
+  cloudWebWorkbenchRouteSummary,
+} from './workbench-parity.ts'
 
 const html = cloudWebsiteHtml({
   role: 'web',
@@ -40,6 +45,22 @@ const repositoryTestsDir = new URL('../../../tests/', import.meta.url)
 function routeMatrixTestUrl(filename: string) {
   if (filename === 'cloud-continuation-e2e.test.ts') return new URL(filename, repositoryTestsDir)
   return new URL(filename, import.meta.url)
+}
+
+const parityAvailabilityDocLabels = {
+  shared: 'Shared with Desktop',
+  'cloud-only': 'Cloud-only',
+  'desktop-only': 'Desktop-only',
+  'intentionally-unavailable': 'Unavailable in Cloud',
+} as const
+
+function markdownTableCell(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
+}
+
+function parityDocRow(entry: (typeof CLOUD_WEB_WORKBENCH_PARITY_MATRIX)[number]) {
+  const routes = entry.cloudRouteIds.map((routeId) => `\`${routeId}\``).join(', ')
+  return `| ${markdownTableCell(entry.label)} | ${parityAvailabilityDocLabels[entry.availability]} | ${routes} | ${markdownTableCell(entry.cloudAffordance)} | ${markdownTableCell(entry.boundary)} |`
 }
 
 test('cloud website renders workbench and admin shell surfaces', () => {
@@ -71,10 +92,17 @@ test('cloud website renders workbench and admin shell surfaces', () => {
   assert.match(html, /\.panel \{[\s\S]*border-radius: var\(--radius-lg\);/)
   assert.match(html, /\.pill\[data-kind="info"\]/)
   assert.match(html, /\.message-bubble\[data-role="user"\]/)
+  assert.match(html, /\.message-bubble\[data-role="system"\]/)
+  assert.match(html, /\.message-bubble\[data-role="error"\]/)
   assert.match(html, /--focus: rgba\(141, 164, 245, 0\.55\);/)
   assert.match(html, /--warn: #fcb07a;/)
   assert.match(html, /--danger: #fc92b4;/)
   assert.match(html, /--ok: #7fcfa0;/)
+  assert.match(html, /"workbenchParity":/)
+  assert.match(html, /data-parity-route="threads"/)
+  assert.match(html, /data-parity-route="chat"/)
+  assert.match(html, /Local Filesystem/)
+  assert.match(html, /Local Stdio MCPs/)
 })
 
 test('cloud website app shell exposes typed route metadata', () => {
@@ -83,6 +111,45 @@ test('cloud website app shell exposes typed route metadata', () => {
   assert.equal(findCloudWebRoute('threads')?.surface, 'workbench')
   assert.equal(findCloudWebRoute('byok')?.requiresAdmin, true)
   assert.equal(findCloudWebRoute('usage')?.requiresAdmin, false)
+})
+
+test('cloud website desktop parity matrix covers every workbench route and documented boundary', () => {
+  const workbenchRoutes = CLOUD_WEB_ROUTES.filter((route) => route.surface === 'workbench')
+  const routeApiIds = new Set(CLOUD_WEB_ROUTE_API_MATRIX.map((entry) => entry.routeId))
+  const doc = readFileSync(fileURLToPath(new URL('../../../docs/cloud-web-workbench.md', import.meta.url)), 'utf8')
+
+  assert.match(doc, /Desktop\/Cloud Workbench Parity Matrix/)
+  assert.ok(CLOUD_WEB_WORKBENCH_PARITY_MATRIX.some((entry) => entry.availability === 'shared'))
+  assert.ok(CLOUD_WEB_WORKBENCH_PARITY_MATRIX.some((entry) => entry.availability === 'cloud-only'))
+  assert.ok(CLOUD_WEB_WORKBENCH_PARITY_MATRIX.some((entry) => entry.availability === 'desktop-only'))
+  assert.ok(CLOUD_WEB_WORKBENCH_PARITY_MATRIX.some((entry) => entry.availability === 'intentionally-unavailable'))
+
+  for (const route of workbenchRoutes) {
+    const entries = cloudWebWorkbenchParityForRoute(route.id)
+    const sharedEntry = entries.find((entry) => entry.availability === 'shared')
+    assert.ok(entries.length > 0, `${route.id} has Desktop/Cloud parity entries`)
+    assert.ok(sharedEntry, `${route.id} has at least one shared Desktop concept`)
+    assert.equal(route.summary, sharedEntry.cloudAffordance, `${route.id} summary is parity-derived`)
+    assert.equal(route.summary, cloudWebWorkbenchRouteSummary(route.id, 'fallback'), `${route.id} helper returns the same summary`)
+    assert.ok(routeApiIds.has(route.id), `${route.id} is covered by route/API matrix`)
+  }
+
+  for (const entry of CLOUD_WEB_WORKBENCH_PARITY_MATRIX) {
+    assert.ok(entry.desktopSurface, `${entry.conceptId} names its Desktop surface`)
+    assert.ok(entry.cloudAffordance, `${entry.conceptId} names its Cloud Web affordance`)
+    assert.ok(entry.boundary, `${entry.conceptId} documents its product boundary`)
+    assert.ok(entry.cloudRouteIds.length > 0, `${entry.conceptId} maps to at least one Cloud route`)
+    assert.ok(doc.includes(parityDocRow(entry)), `docs list exact parity row for ${entry.label}`)
+    for (const routeId of entry.cloudRouteIds) {
+      assert.ok(CLOUD_WEB_ROUTES.some((route) => route.id === routeId), `${entry.conceptId} references existing route ${routeId}`)
+    }
+    for (const filename of entry.tests) {
+      assert.ok(existsSync(fileURLToPath(routeMatrixTestUrl(filename))), `${entry.conceptId} listed test file exists: ${filename}`)
+    }
+    if (entry.availability === 'desktop-only' || entry.availability === 'intentionally-unavailable') {
+      assert.ok(entry.disabledReason, `${entry.conceptId} explains why Cloud Web does not expose it`)
+    }
+  }
 })
 
 test('cloud website route/API matrix covers every route and real endpoint id', () => {
@@ -520,7 +587,10 @@ test('cloud website renders cloud thread controls without local host path afford
   assert.match(html, /id="admin-project-policy"/)
   assert.match(html, /id="audit-list"/)
   assert.doesNotMatch(html, /\/Users\//)
-  assert.doesNotMatch(html, /local stdio MCP/i)
+  assert.doesNotMatch(html, /name="localPath"/)
+  assert.doesNotMatch(html, /name="stdioCommand"/)
+  assert.match(html, /Local Stdio MCPs/)
+  assert.match(html, /Cloud Web cannot spawn local stdio MCP processes/)
 })
 
 test('cloud website surface helper derives agents, filters capabilities, and summarizes workflow triggers', () => {

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -1,11 +1,12 @@
 import { canManageOrg, type WebsiteRole } from './roles.ts'
-import { CLOUD_WEB_ROUTE_GROUPS, CLOUD_WEB_ROUTES, DEFAULT_CLOUD_WEB_ROUTE, type CloudWebRoute } from './app-shell.ts'
+import { CLOUD_WEB_ROUTE_GROUPS, CLOUD_WEB_ROUTES, DEFAULT_CLOUD_WEB_ROUTE, type CloudWebRoute, type CloudWebRouteId } from './app-shell.ts'
 import { CLOUD_WEB_CLIENT_ENDPOINTS, type CloudWebClientBootstrap } from './client-contract.ts'
 import { DEFAULT_WEBSITE_PUBLIC_BRANDING, brandLinksMarkup, brandLogoMarkup, resolvePublicBranding } from './branding.ts'
 import { cloudWebsiteClientScript } from './client-script.ts'
 import { escapeHtml, jsonScript } from './html-utils.ts'
 import { cloudWebsiteStyles } from './styles.ts'
 import { CLOUD_WEB_ROUTE_API_MATRIX } from './route-api-matrix.ts'
+import { CLOUD_WEB_WORKBENCH_PARITY_MATRIX, cloudWebWorkbenchParityForRoute, type CloudWebWorkbenchParityAvailability } from './workbench-parity.ts'
 import { CLOUD_SESSION_EVENT_TYPES, type PublicBrandingConfig } from '@open-cowork/shared'
 
 export { cloudWebsiteClientScript } from './client-script.ts'
@@ -38,6 +39,33 @@ function routePanelAttrs(routeId: string, options: { signedIn?: boolean, admin?:
   return `class="${classes.join(' ')}" id="${escapeHtml(routeId)}" data-route-panel="${escapeHtml(routeId)}" data-route-surface="${escapeHtml(route?.surface || 'workbench')}" data-requires-auth="${options.signedIn === false ? 'false' : 'true'}" data-requires-admin="${options.admin ? 'true' : 'false'}"`
 }
 
+const parityAvailabilityLabels: Record<CloudWebWorkbenchParityAvailability, { label: string, kind: string }> = {
+  shared: { label: 'Shared with Desktop', kind: 'ok' },
+  'cloud-only': { label: 'Cloud-only', kind: 'info' },
+  'desktop-only': { label: 'Desktop-only', kind: 'warn' },
+  'intentionally-unavailable': { label: 'Unavailable in Cloud', kind: 'warn' },
+}
+
+function routeParityMarkup(routeId: CloudWebRouteId) {
+  const entries = cloudWebWorkbenchParityForRoute(routeId)
+  if (!entries.length) return ''
+  return `<div class="parity-grid" data-parity-route="${escapeHtml(routeId)}" aria-label="Desktop and Cloud Web parity for ${escapeHtml(routeId)}">
+            ${entries.map((entry) => {
+              const availability = parityAvailabilityLabels[entry.availability]
+              const reason = entry.disabledReason ? `<small>${escapeHtml(entry.disabledReason)}</small>` : ''
+              return `<article class="parity-card" data-parity-concept="${escapeHtml(entry.conceptId)}" data-parity-availability="${escapeHtml(entry.availability)}">
+                <div class="runtime-card-header">
+                  <span class="pill" data-kind="${escapeHtml(availability.kind)}">${escapeHtml(availability.label)}</span>
+                  <strong>${escapeHtml(entry.label)}</strong>
+                </div>
+                <p>${escapeHtml(entry.cloudAffordance)}</p>
+                <small>${escapeHtml(entry.boundary)}</small>
+                ${reason}
+              </article>`
+            }).join('')}
+          </div>`
+}
+
 export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?: PublicBrandingConfig | null, cspNonce = '') {
   const branding = resolvePublicBranding(publicBranding || policy.publicBranding)
   const copy = branding.dashboard || DEFAULT_WEBSITE_PUBLIC_BRANDING.dashboard || {}
@@ -51,6 +79,7 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
     defaultRoute: DEFAULT_CLOUD_WEB_ROUTE,
     api: CLOUD_WEB_CLIENT_ENDPOINTS,
     routeMatrix: CLOUD_WEB_ROUTE_API_MATRIX,
+    workbenchParity: CLOUD_WEB_WORKBENCH_PARITY_MATRIX,
     sessionEventTypes: [...CLOUD_SESSION_EVENT_TYPES],
   }
   const adminDefault = canManageOrg(policy.role as WebsiteRole)
@@ -108,6 +137,7 @@ ${cloudWebsiteStyles(branding)}
             <button class="primary" id="new-thread-shortcut" type="button" data-chat-control="true">New thread</button>
           </div>
           <div class="workbench-split">
+            ${routeParityMarkup('threads')}
             <div class="panel">
               <div class="toolbar" aria-label="Thread filters">
                 <label><span>Search</span><input id="thread-query" autocomplete="off" placeholder="title, profile, project, tag"></label>
@@ -170,6 +200,7 @@ ${cloudWebsiteStyles(branding)}
             <span class="pill" data-kind="${policy.features.chat ? 'ok' : 'warn'}">${policy.features.chat ? 'enabled' : 'disabled'}</span>
           </div>
           <div class="workbench-split">
+            ${routeParityMarkup('chat')}
             <div class="panel chat-shell">
               <div class="section-header">
                 <div>
@@ -202,6 +233,7 @@ ${cloudWebsiteStyles(branding)}
             <button id="refresh-capabilities" type="button" data-capability-control="true">Refresh</button>
           </div>
           <div class="grid">
+            ${routeParityMarkup('agents')}
             <div class="panel">
               <h3>Available agents</h3>
               <div class="list" id="workbench-agent-list">
@@ -227,6 +259,7 @@ ${cloudWebsiteStyles(branding)}
             <label><span>Filter</span><input id="capability-filter" autocomplete="off" placeholder="tool, skill, agent, source" data-capability-control="true"></label>
           </div>
           <div class="grid">
+            ${routeParityMarkup('capabilities')}
             <div class="panel">
               <h3>Tools</h3>
               <div class="list" id="tool-list">
@@ -261,6 +294,7 @@ ${cloudWebsiteStyles(branding)}
             </div>
           </div>
           <div class="workbench-split">
+            ${routeParityMarkup('workflows')}
             <div class="panel">
               <div class="table-shell" role="table" aria-label="Cloud workflows">
                 <div class="table-row table-head" role="row">
@@ -316,6 +350,7 @@ ${cloudWebsiteStyles(branding)}
             </div>
           </div>
           <div class="grid">
+            ${routeParityMarkup('artifacts')}
             <div class="panel">
               <h3>Selected thread artifacts</h3>
               <div class="list" id="artifact-list">

--- a/apps/website/src/style-chat.ts
+++ b/apps/website/src/style-chat.ts
@@ -115,6 +115,14 @@ export function cloudWebsiteChatStyles() {
       border-radius: var(--radius-xl) var(--radius-xl) var(--radius-xs) var(--radius-xl);
       background: var(--color-surface-active);
     }
+    .message-bubble[data-role="system"] {
+      border-style: dashed;
+      background: color-mix(in srgb, var(--color-info) 8%, var(--color-surface) 92%);
+    }
+    .message-bubble[data-role="error"] {
+      border-color: var(--tone-danger-border);
+      background: var(--tone-danger-bg);
+    }
     .message-heading {
       color: var(--muted);
       font-size: var(--text-xs);

--- a/apps/website/src/style-components.ts
+++ b/apps/website/src/style-components.ts
@@ -135,6 +135,33 @@ export function cloudWebsiteComponentStyles() {
       font-size: var(--text-md);
       line-height: var(--lh-md);
     }
+    .parity-grid {
+      grid-column: 1 / -1;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: var(--space-2);
+      min-width: 0;
+    }
+    .parity-card {
+      min-width: 0;
+      display: grid;
+      gap: var(--space-2);
+      border: var(--border-width-1) solid var(--color-border-subtle);
+      border-radius: var(--radius-sm);
+      background: color-mix(in srgb, var(--color-surface) 76%, transparent);
+      padding: var(--space-3);
+    }
+    .parity-card[data-parity-availability="intentionally-unavailable"],
+    .parity-card[data-parity-availability="desktop-only"] {
+      background: color-mix(in srgb, var(--color-amber) 8%, var(--color-surface) 92%);
+      border-color: var(--tone-warn-border);
+    }
+    .parity-card p {
+      margin: 0;
+      color: var(--text);
+      font-size: var(--text-sm);
+      line-height: var(--lh-sm);
+    }
     .form-grid {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -337,6 +364,9 @@ export function cloudWebsiteComponentStyles() {
         min-width: 620px;
       }
       .form-grid {
+        grid-template-columns: 1fr;
+      }
+      .parity-grid {
         grid-template-columns: 1fr;
       }
       .row {

--- a/apps/website/src/workbench-parity.ts
+++ b/apps/website/src/workbench-parity.ts
@@ -1,0 +1,176 @@
+import type { CloudWebRouteId } from './app-shell.ts'
+
+export type CloudWebWorkbenchParityAvailability =
+  | 'shared'
+  | 'cloud-only'
+  | 'desktop-only'
+  | 'intentionally-unavailable'
+
+export type CloudWebWorkbenchConceptId =
+  | 'threads'
+  | 'chat'
+  | 'runtime-status'
+  | 'approvals-questions'
+  | 'agents'
+  | 'tools-skills'
+  | 'artifacts'
+  | 'workflows'
+  | 'cloud-project-sources'
+  | 'local-filesystem'
+  | 'local-stdio-mcps'
+  | 'machine-runtime-config'
+
+export type CloudWebWorkbenchParityEntry = {
+  conceptId: CloudWebWorkbenchConceptId
+  label: string
+  availability: CloudWebWorkbenchParityAvailability
+  desktopSurface: string
+  cloudRouteIds: CloudWebRouteId[]
+  cloudAffordance: string
+  boundary: string
+  disabledReason: string | null
+  tests: string[]
+}
+
+export const CLOUD_WEB_WORKBENCH_PARITY_MATRIX: CloudWebWorkbenchParityEntry[] = [
+  {
+    conceptId: 'threads',
+    label: 'Threads',
+    availability: 'shared',
+    desktopSurface: 'Desktop Threads page and sidebar thread list',
+    cloudRouteIds: ['threads'],
+    cloudAffordance: 'List, filter, page, create, and reopen tenant-scoped Cloud threads.',
+    boundary: 'Cloud Web reads Cloud session records and projections through the Cloud API; Desktop may also show local sessions.',
+    disabledReason: null,
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'chat',
+    label: 'Chat',
+    availability: 'shared',
+    desktopSurface: 'Desktop Chat view',
+    cloudRouteIds: ['chat'],
+    cloudAffordance: 'Render the selected Cloud session timeline and send prompts through durable Cloud commands.',
+    boundary: 'Cloud Web never builds a browser-only projection model or invokes local OpenCode runtime commands.',
+    disabledReason: 'Composer controls disable until a Cloud thread is selected or when org policy disables chat.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'runtime-status',
+    label: 'Runtime Status',
+    availability: 'shared',
+    desktopSurface: 'Desktop status bar and chat inspector context cards',
+    cloudRouteIds: ['chat'],
+    cloudAffordance: 'Show status, streaming state, cost, token usage, context, compactions, tool calls, task runs, todos, and errors from Cloud projections.',
+    boundary: 'Cloud Web reports projected Cloud runtime state only; machine health and local model controls remain Desktop-owned.',
+    disabledReason: null,
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'approvals-questions',
+    label: 'Approvals & Questions',
+    availability: 'shared',
+    desktopSurface: 'Desktop chat approval and question queue',
+    cloudRouteIds: ['chat'],
+    cloudAffordance: 'Render pending and resolved approvals/questions and answer them through Cloud API endpoints.',
+    boundary: 'Approval and question semantics remain OpenCode-owned; Cloud Web only submits tenant-scoped responses.',
+    disabledReason: 'Response controls disable while a response is pending or when no Cloud thread is selected.',
+    tests: ['browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'agents',
+    label: 'Agents',
+    availability: 'shared',
+    desktopSurface: 'Desktop Agents page and chat agent picker',
+    cloudRouteIds: ['agents'],
+    cloudAffordance: 'Show profile-allowed agents, built-in/custom metadata, and a Start thread action.',
+    boundary: 'Cloud Web displays policy-safe agent metadata and cannot edit local custom agent files.',
+    disabledReason: 'Start thread disables when chat or agent browsing is disabled by profile policy.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'tools-skills',
+    label: 'Tools & Skills',
+    availability: 'shared',
+    desktopSurface: 'Desktop Tools & Skills capability map',
+    cloudRouteIds: ['capabilities'],
+    cloudAffordance: 'Show allowed tools, skills, MCP metadata, linked agents, and policy verdicts.',
+    boundary: 'Cloud Web renders cloud-safe capability metadata; runtime execution remains owned by OpenCode workers.',
+    disabledReason: 'Capability browsing explains policy-disabled agents, custom skills, or custom MCPs.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'artifacts',
+    label: 'Artifacts',
+    availability: 'shared',
+    desktopSurface: 'Desktop session inspector Artifacts tab',
+    cloudRouteIds: ['artifacts', 'chat'],
+    cloudAffordance: 'Show artifact cards, loaded-thread history, sanitized metadata, explicit view/download actions, and selected-thread previews.',
+    boundary: 'Cloud Web fetches artifact bodies only after explicit user action and strips object-store internals from metadata.',
+    disabledReason: 'Artifact actions disable when no artifact id or Cloud thread is available.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'workflows',
+    label: 'Workflows',
+    availability: 'shared',
+    desktopSurface: 'Desktop Workflows page',
+    cloudRouteIds: ['workflows', 'chat'],
+    cloudAffordance: 'Create, list, run, pause, resume, archive, and inspect Cloud workflow definitions and run threads.',
+    boundary: 'Cloud Web runs saved workflows through Cloud workflow APIs; local launch-at-login and native notifications remain Desktop settings.',
+    disabledReason: 'Workflow controls disable when org profile policy disables workflows or a workflow is archived.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'cloud-project-sources',
+    label: 'Cloud Project Sources',
+    availability: 'cloud-only',
+    desktopSurface: 'Desktop local workspace picker and cloud copy/upload flows',
+    cloudRouteIds: ['threads'],
+    cloudAffordance: 'Create Cloud threads from allowed git repositories or explicit browser-uploaded snapshots.',
+    boundary: 'Cloud policy validates git and snapshot sources before execution.',
+    disabledReason: 'Project source creation fails closed when policy denies the source.',
+    tests: ['browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'local-filesystem',
+    label: 'Local Filesystem',
+    availability: 'intentionally-unavailable',
+    desktopSurface: 'Desktop local project directories and sandbox artifacts',
+    cloudRouteIds: ['threads', 'artifacts'],
+    cloudAffordance: 'Use git URLs, managed Cloud project sources, uploaded snapshots, and Cloud artifacts instead.',
+    boundary: 'Browser sessions must not implicitly read or upload host paths from the user machine.',
+    disabledReason: 'Local paths are Desktop-only because they depend on local filesystem access and user consent inside the desktop shell.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'local-stdio-mcps',
+    label: 'Local Stdio MCPs',
+    availability: 'intentionally-unavailable',
+    desktopSurface: 'Desktop local MCP process configuration',
+    cloudRouteIds: ['capabilities', 'agents'],
+    cloudAffordance: 'Show only policy-safe MCP metadata that has been converted into the Cloud profile.',
+    boundary: 'Cloud Web cannot spawn local stdio MCP processes or expose command lines, environment variables, or secret refs.',
+    disabledReason: 'Local stdio MCPs are Desktop-only unless represented by a Cloud-safe capability profile.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'machine-runtime-config',
+    label: 'Machine Runtime Config',
+    availability: 'desktop-only',
+    desktopSurface: 'Desktop setup, model/provider controls, and runtime health center',
+    cloudRouteIds: ['chat', 'agents', 'capabilities'],
+    cloudAffordance: 'Show current Cloud profile, feature flags, and projected runtime state.',
+    boundary: 'Cloud Web does not configure the local machine runtime, provider defaults, local approvals mode, or desktop notification settings.',
+    disabledReason: 'Machine runtime configuration is Desktop-only because it depends on local app settings and host process control.',
+    tests: ['render.test.ts'],
+  },
+]
+
+export function cloudWebWorkbenchParityForRoute(routeId: CloudWebRouteId) {
+  return CLOUD_WEB_WORKBENCH_PARITY_MATRIX.filter((entry) => entry.cloudRouteIds.includes(routeId))
+}
+
+export function cloudWebWorkbenchRouteSummary(routeId: CloudWebRouteId, fallback: string) {
+  return cloudWebWorkbenchParityForRoute(routeId).find((entry) => entry.availability === 'shared')?.cloudAffordance || fallback
+}

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -39,6 +39,31 @@ loading/empty/error state contract.
 | `usage` | Admin | Member | `usageEvents`, `usageSummary` | Usage events load `limit=20`; summaries load `limit=100`. | Usage events include metering dimensions only, not prompts, provider keys, or tokens. |
 | `diagnostics` | Admin | Operator | `diagnostics`, `runtimeStatus`, `workerHeartbeats` | Diagnostics includes bounded worker heartbeat and gateway delivery samples. Browser diagnostics arrays are recursively capped before rendering. | Diagnostics are redacted recursively. Org admins may see the route, but the API may require operator-token privileges for global operational state. |
 
+## Desktop/Cloud Workbench Parity Matrix
+
+The typed source of truth is
+`apps/website/src/workbench-parity.ts`. Cloud Web route labels, summaries,
+browser bootstrap metadata, and rendered parity cards consume this matrix.
+This document mirrors the same rows, and render tests assert every documented
+row against the typed source so the product boundary cannot drift silently. The
+purpose is to make shared Desktop concepts feel like the same product while
+keeping Cloud Web honest about cloud-only and desktop-only boundaries.
+
+| Concept | Availability | Cloud route(s) | Cloud Web affordance | Product boundary |
+|---|---|---|---|---|
+| Threads | Shared with Desktop | `threads` | List, filter, page, create, and reopen tenant-scoped Cloud threads. | Cloud Web reads Cloud session records and projections through the Cloud API; Desktop may also show local sessions. |
+| Chat | Shared with Desktop | `chat` | Render the selected Cloud session timeline and send prompts through durable Cloud commands. | Cloud Web never builds a browser-only projection model or invokes local OpenCode runtime commands. |
+| Runtime Status | Shared with Desktop | `chat` | Show status, streaming state, cost, token usage, context, compactions, tool calls, task runs, todos, and errors from Cloud projections. | Cloud Web reports projected Cloud runtime state only; machine health and local model controls remain Desktop-owned. |
+| Approvals & Questions | Shared with Desktop | `chat` | Render pending and resolved approvals/questions and answer them through Cloud API endpoints. | Approval and question semantics remain OpenCode-owned; Cloud Web only submits tenant-scoped responses. |
+| Agents | Shared with Desktop | `agents` | Show profile-allowed agents, built-in/custom metadata, and a Start thread action. | Cloud Web displays policy-safe agent metadata and cannot edit local custom agent files. |
+| Tools & Skills | Shared with Desktop | `capabilities` | Show allowed tools, skills, MCP metadata, linked agents, and policy verdicts. | Cloud Web renders cloud-safe capability metadata; runtime execution remains owned by OpenCode workers. |
+| Artifacts | Shared with Desktop | `artifacts`, `chat` | Show artifact cards, loaded-thread history, sanitized metadata, explicit view/download actions, and selected-thread previews. | Cloud Web fetches artifact bodies only after explicit user action and strips object-store internals from metadata. |
+| Workflows | Shared with Desktop | `workflows`, `chat` | Create, list, run, pause, resume, archive, and inspect Cloud workflow definitions and run threads. | Cloud Web runs saved workflows through Cloud workflow APIs; local launch-at-login and native notifications remain Desktop settings. |
+| Cloud Project Sources | Cloud-only | `threads` | Create Cloud threads from allowed git repositories or explicit browser-uploaded snapshots. | Cloud policy validates git and snapshot sources before execution. |
+| Local Filesystem | Unavailable in Cloud | `threads`, `artifacts` | Use git URLs, managed Cloud project sources, uploaded snapshots, and Cloud artifacts instead. | Browser sessions must not implicitly read or upload host paths from the user machine. |
+| Local Stdio MCPs | Unavailable in Cloud | `capabilities`, `agents` | Show only policy-safe MCP metadata that has been converted into the Cloud profile. | Cloud Web cannot spawn local stdio MCP processes or expose command lines, environment variables, or secret refs. |
+| Machine Runtime Config | Desktop-only | `chat`, `agents`, `capabilities` | Show current Cloud profile, feature flags, and projected runtime state. | Cloud Web does not configure the local machine runtime, provider defaults, local approvals mode, or desktop notification settings. |
+
 ## End-User Workbench Contract
 
 Cloud Web must keep parity with Desktop Cloud for cloud workspaces:


### PR DESCRIPTION
## Summary

- Add a typed `CLOUD_WEB_WORKBENCH_PARITY_MATRIX` for Desktop/Cloud Web workbench concepts, including shared, cloud-only, desktop-only, and intentionally unavailable surfaces.
- Drive Cloud Web route summaries, bootstrap metadata, rendered parity cards, disabled-state explanations, and docs/tests from the parity contract.
- Tighten workbench presentation for chat roles, runtime errors, capability policy notes, workflow latest-run details, and browser-visible Desktop boundary copy.

## Scope

Closes #727.
Refs #724.
Refs #729 for the route/browser parity coverage included in this PR.

## Validation

- `pnpm --filter @open-cowork/website test`
- `pnpm test:cloud-web`
- `pnpm docs:build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`
- Live Chromium smoke against `pnpm cloud:dev`: verified parity cards on Threads/Chat/Tools & Skills, Mona/Hubot fonts loaded, and no body horizontal overflow on desktop/mobile.
- Subagent review: boundary/security clean; parity findings fixed.
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.
