### PR TITLE
Align Cloud Web admin surfaces with Desktop

### DIFF
--- a/apps/website/src/admin-surface-matrix.ts
+++ b/apps/website/src/admin-surface-matrix.ts
@@ -1,0 +1,112 @@
+import type { CloudWebRouteId } from './app-shell.ts'
+
+export type CloudWebAdminSurfaceEntry = {
+  routeId: CloudWebRouteId
+  label: string
+  desktopSurface: string
+  cloudAffordance: string
+  sensitiveBoundary: string
+  disabledReason: string
+  tests: string[]
+}
+
+export const CLOUD_WEB_ADMIN_SURFACE_MATRIX: CloudWebAdminSurfaceEntry[] = [
+  {
+    routeId: 'org',
+    label: 'Workspace Profile',
+    desktopSurface: 'Desktop account, workspace, and profile status surfaces',
+    cloudAffordance: 'Show signed-in org identity, role, profile, and public sign-in state.',
+    sensitiveBoundary: 'Bootstrap and signed-out state expose only public branding, route metadata, endpoint metadata, and feature flags.',
+    disabledReason: 'Signed-in workspace details require Cloud authentication.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'members',
+    label: 'Members',
+    desktopSurface: 'Desktop account/settings identity context',
+    cloudAffordance: 'Manage org member roles, invites, activation, suspension, and invite-mode state.',
+    sensitiveBoundary: 'Member rows expose identity, role, and status only; authorization remains server-side.',
+    disabledReason: 'Member administration requires an org owner or admin role.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'policy',
+    label: 'Profiles & Policy',
+    desktopSurface: 'Desktop runtime settings, capability policy, and Health Center',
+    cloudAffordance: 'Show Cloud profile features, project-source policy, runtime guardrails, gateway policy, and worker health.',
+    sensitiveBoundary: 'Cloud Web reports policy and health summaries without configuring local runtime, host paths, or stdio MCP processes.',
+    disabledReason: 'Policy is read-only in Cloud Web; privileged worker details may require operator access.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'byok',
+    label: 'BYOK',
+    desktopSurface: 'Desktop provider credential setup',
+    cloudAffordance: 'Add, rotate, validate, and disable provider credentials through write-only Cloud APIs.',
+    sensitiveBoundary: 'Provider keys are never rendered after submission; the browser receives metadata such as provider id, status, last4, and validation timestamps.',
+    disabledReason: 'BYOK management requires an org owner or admin role.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'connections',
+    label: 'Connections',
+    desktopSurface: 'Desktop Cloud connection and Gateway pairing surfaces',
+    cloudAffordance: 'Issue scoped Desktop, Gateway, and admin API tokens with one-time plaintext reveal.',
+    sensitiveBoundary: 'Token plaintext is shown once after creation and is not stored in persistent browser state.',
+    disabledReason: 'Connection token issuance requires an org owner or admin role.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'billing',
+    label: 'Billing',
+    desktopSurface: 'Desktop entitlement and setup status surfaces',
+    cloudAffordance: 'Show managed billing mode, plan state, checkout/portal actions, and resolved entitlements.',
+    sensitiveBoundary: 'Billing renders plan and entitlement metadata only; provider integration stays behind the Cloud API.',
+    disabledReason: 'Billing changes require an org owner or admin role and a managed billing deployment.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'gateway',
+    label: 'Headless Gateway',
+    desktopSurface: 'Desktop Gateway connection and workflow delivery status',
+    cloudAffordance: 'Configure headless agents, channel bindings, setup guidance, and delivery backlog controls.',
+    sensitiveBoundary: 'Channel credential refs, delivery targets, payloads, and errors are browser-sanitized before rendering.',
+    disabledReason: 'Gateway administration requires an org owner or admin role.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'audit',
+    label: 'Audit',
+    desktopSurface: 'Desktop diagnostics and sensitive-action history context',
+    cloudAffordance: 'Browse and export redacted administrative events for sensitive Cloud actions.',
+    sensitiveBoundary: 'Audit metadata must be server-redacted and is sanitized again before display or export.',
+    disabledReason: 'Audit access requires an org owner or admin role.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'usage',
+    label: 'Usage',
+    desktopSurface: 'Desktop chat cost, token, and runtime status summaries',
+    cloudAffordance: 'Show quota windows, recent metering totals, and bounded usage event samples.',
+    sensitiveBoundary: 'Usage events include metering dimensions only, never prompts, provider keys, or tokens.',
+    disabledReason: 'Usage is read-only and depends on the Cloud usage API being available.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    routeId: 'diagnostics',
+    label: 'Diagnostics',
+    desktopSurface: 'Desktop Health Center and support bundle surfaces',
+    cloudAffordance: 'Prepare redacted health summaries and support bundles for Cloud runtime, BYOK, gateway, and object-store state.',
+    sensitiveBoundary: 'Diagnostics are recursively redacted and array-capped before rendering or download.',
+    disabledReason: 'Diagnostics require admin or operator privileges and may be denied by the Cloud API.',
+    tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+]
+
+export function cloudWebAdminSurfaceForRoute(routeId: CloudWebRouteId) {
+  return CLOUD_WEB_ADMIN_SURFACE_MATRIX.find((entry) => entry.routeId === routeId) || null
+}
+
+export function cloudWebAdminRouteSummary(routeId: CloudWebRouteId, fallback: string) {
+  return cloudWebAdminSurfaceForRoute(routeId)?.cloudAffordance || fallback
+}

--- a/apps/website/src/app-shell.ts
+++ b/apps/website/src/app-shell.ts
@@ -1,3 +1,4 @@
+import { cloudWebAdminRouteSummary } from './admin-surface-matrix.ts'
 import { cloudWebWorkbenchRouteSummary } from './workbench-parity.ts'
 
 export type CloudWebSurface = 'workbench' | 'admin'
@@ -92,7 +93,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: false,
     requiresAdmin: false,
-    summary: 'Organization profile, role, and deployment policy.',
+    summary: cloudWebAdminRouteSummary('org', 'Organization profile, role, and deployment policy.'),
   },
   {
     id: 'members',
@@ -100,7 +101,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: true,
-    summary: 'Member, invite, and role administration.',
+    summary: cloudWebAdminRouteSummary('members', 'Member, invite, and role administration.'),
   },
   {
     id: 'policy',
@@ -108,7 +109,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Runtime profile and feature verdicts.',
+    summary: cloudWebAdminRouteSummary('policy', 'Runtime profile and feature verdicts.'),
   },
   {
     id: 'byok',
@@ -116,7 +117,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: true,
-    summary: 'Write-only provider key status and rotation.',
+    summary: cloudWebAdminRouteSummary('byok', 'Write-only provider key status and rotation.'),
   },
   {
     id: 'connections',
@@ -124,7 +125,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: true,
-    summary: 'Scoped API tokens for desktop and gateway clients.',
+    summary: cloudWebAdminRouteSummary('connections', 'Scoped API tokens for desktop and gateway clients.'),
   },
   {
     id: 'billing',
@@ -132,7 +133,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: true,
-    summary: 'Subscription and entitlement state.',
+    summary: cloudWebAdminRouteSummary('billing', 'Subscription and entitlement state.'),
   },
   {
     id: 'gateway',
@@ -140,7 +141,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: true,
-    summary: 'Headless agents and channel bindings.',
+    summary: cloudWebAdminRouteSummary('gateway', 'Headless agents and channel bindings.'),
   },
   {
     id: 'audit',
@@ -148,7 +149,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: true,
-    summary: 'Redacted audit events for sensitive actions.',
+    summary: cloudWebAdminRouteSummary('audit', 'Redacted audit events for sensitive actions.'),
   },
   {
     id: 'usage',
@@ -156,7 +157,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: false,
-    summary: 'Recent metering and quota events.',
+    summary: cloudWebAdminRouteSummary('usage', 'Recent metering and quota events.'),
   },
   {
     id: 'diagnostics',
@@ -164,7 +165,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     surface: 'admin',
     requiresAuth: true,
     requiresAdmin: true,
-    summary: 'Redacted health and support data.',
+    summary: cloudWebAdminRouteSummary('diagnostics', 'Redacted health and support data.'),
   },
 ]
 

--- a/apps/website/src/browser-e2e.test.ts
+++ b/apps/website/src/browser-e2e.test.ts
@@ -25,6 +25,8 @@ test('cloud web browser gates admin controls for member workspaces', async () =>
     assert.equal((harness.document.querySelector('[data-route-link="byok"]') as HTMLElement).hidden, true)
     assert.equal((harness.document.querySelector('#byok-form input[name="providerId"]') as HTMLInputElement).disabled, true)
     assert.equal((harness.document.querySelector('#desktop-token') as HTMLButtonElement).disabled, true)
+    assert.match((harness.document.querySelector('#desktop-token') as HTMLButtonElement).title, /Connection token issuance requires/)
+    assert.match((harness.document.querySelector('#prepare-diagnostics') as HTMLButtonElement).title, /Diagnostics require/)
     assert.equal(harness.lastRequest((request) => request.path === '/api/workspace')?.method, 'GET')
   } finally {
     harness.close()
@@ -35,6 +37,7 @@ test('cloud web browser exercises every route declared in the route API matrix',
   const harness = await createCloudWebBrowserHarness({ role: 'admin' }).start()
   try {
     await waitFor(() => assert.equal(harness.document.body.dataset.auth, 'signed-in'))
+    assert.ok(Array.isArray(harness.bootstrap.adminSurfaces))
 
     for (const entry of CLOUD_WEB_ROUTE_API_MATRIX) {
       const link = harness.document.querySelector(`[data-route-link="${entry.routeId}"]`) as HTMLElement | null
@@ -48,6 +51,10 @@ test('cloud web browser exercises every route declared in the route API matrix',
         assert.equal(harness.document.body.dataset.route, entry.routeId)
         assert.equal(panel.getAttribute('aria-hidden'), 'false')
       })
+      if (entry.surface === 'admin') {
+        const surface = panel.querySelector(`[data-admin-surface-route="${entry.routeId}"]`)
+        assert.ok(surface, `${entry.routeId} renders an admin surface contract card`)
+      }
     }
   } finally {
     harness.close()
@@ -282,6 +289,7 @@ test('cloud web browser exercises BYOK, gateway, billing, diagnostics, and quota
   const harness = await createCloudWebBrowserHarness({ role: 'admin' }).start()
   try {
     await waitFor(() => assert.equal(harness.document.body.dataset.auth, 'signed-in'))
+    assert.match(harness.document.querySelector('[data-admin-surface-route="byok"]')?.textContent || '', /Provider keys are never rendered/)
 
     ;(harness.document.querySelector('#byok-form input[name="providerId"]') as HTMLInputElement).value = 'openai'
     ;(harness.document.querySelector('#byok-form input[name="apiKey"]') as HTMLInputElement).value = 'sk-test-secret'
@@ -289,9 +297,17 @@ test('cloud web browser exercises BYOK, gateway, billing, diagnostics, and quota
     await waitFor(() => assert.ok(harness.lastRequest((request) => request.method === 'POST' && request.path === '/api/byok/openai')))
     assert.doesNotMatch(harness.document.querySelector('#byok-list')?.textContent || '', /sk-test-secret/)
 
+    harness.clickText('[data-route-link]', 'Connections')
+    await waitFor(() => assert.equal(harness.document.body.dataset.route, 'connections'))
+    assert.match(harness.document.querySelector('[data-admin-surface-route="connections"]')?.textContent || '', /one-time plaintext reveal/)
+
     ;(harness.document.querySelector('#agent-form input[name="name"]') as HTMLInputElement).value = 'Release helper'
     harness.submit('#agent-form')
     await waitFor(() => assert.ok(harness.lastRequest((request) => request.method === 'POST' && request.path === '/api/channels/agents')))
+
+    harness.clickText('[data-route-link]', 'Gateway')
+    await waitFor(() => assert.equal(harness.document.body.dataset.route, 'gateway'))
+    assert.match(harness.document.querySelector('[data-admin-surface-route="gateway"]')?.textContent || '', /delivery backlog/)
 
     ;(harness.document.querySelector('#binding-form input[name="displayName"]') as HTMLInputElement).value = 'Team Slack'
     ;(harness.document.querySelector('#binding-form input[name="credentialRef"]') as HTMLInputElement).value = 'secret://gateway/slack'
@@ -311,6 +327,9 @@ test('cloud web browser exercises BYOK, gateway, billing, diagnostics, and quota
     harness.clickText('#diagnostics button', 'Prepare bundle')
     await waitFor(() => assert.match(harness.document.querySelector('#diagnostics-bundle')?.textContent || '', /secrets-redacted/))
     assert.doesNotMatch(harness.document.querySelector('#diagnostics-bundle')?.textContent || '', /sk-test-secret|occ_created_token/)
+    harness.clickText('[data-route-link]', 'Diagnostics')
+    await waitFor(() => assert.equal(harness.document.body.dataset.route, 'diagnostics'))
+    assert.match(harness.document.querySelector('[data-admin-surface-route="diagnostics"]')?.textContent || '', /recursively redacted/)
   } finally {
     harness.close()
   }

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -1,4 +1,5 @@
 import type { PublicBrandingConfig } from '@open-cowork/shared'
+import type { CloudWebAdminSurfaceEntry } from './admin-surface-matrix.ts'
 import type { CloudWebRoute, CloudWebRouteId } from './app-shell.ts'
 import type { CloudWebRouteApiMatrixEntry } from './route-api-matrix.ts'
 import type { CloudWebWorkbenchParityEntry } from './workbench-parity.ts'
@@ -65,6 +66,7 @@ export type CloudWebClientBootstrap = {
   defaultRoute: string
   api: CloudWebEndpoint[]
   routeMatrix: CloudWebRouteApiMatrixEntry[]
+  adminSurfaces: CloudWebAdminSurfaceEntry[]
   workbenchParity: CloudWebWorkbenchParityEntry[]
   sessionEventTypes: string[]
 }

--- a/apps/website/src/client/admin-script.ts
+++ b/apps/website/src/client/admin-script.ts
@@ -10,9 +10,12 @@ export function cloudWebsiteClientAdminScript() {
   if (adminNotice) {
     adminNotice.hidden = !workspace || canManage(workspace.role);
   }
+  const locked = adminLocked();
   qsa('[data-admin-control="true"]').forEach((element) => {
-    element.disabled = adminLocked();
-    element.dataset.locked = adminLocked() ? 'true' : 'false';
+    element.disabled = locked;
+    element.dataset.locked = locked ? 'true' : 'false';
+    if (locked) element.title = adminControlReason(element, 'This action requires an org owner or admin role.');
+    else element.removeAttribute('title');
   });
   qsa('[data-chat-control="true"]').forEach((element) => {
     const locked = !workspace || bootstrap.features?.chat === false;
@@ -40,11 +43,15 @@ function renderMembers() {
   if (!list) return;
   const policy = state.admin.policy;
   const signup = policy?.signup || {};
+  const memberLocked = adminLocked();
+  const memberAdminReason = adminSurfaceText('members', 'disabledReason', 'Member administration requires an org owner or admin role.');
   if (inviteForm) {
     qsa('button, input, select', inviteForm).forEach((element) => {
-      const locked = adminLocked() || signup.mode !== 'invite';
+      const locked = memberLocked || signup.mode !== 'invite';
       element.disabled = locked;
       element.dataset.locked = locked ? 'true' : 'false';
+      if (locked) element.title = memberLocked ? memberAdminReason : 'Invite creation is disabled for the current signup mode.';
+      else element.removeAttribute('title');
     });
   }
   if (inviteNotice) {
@@ -97,13 +104,13 @@ function renderMembers() {
     const actions = document.createElement('span');
     actions.setAttribute('role', 'cell');
     actions.className = 'row-actions';
-    actions.appendChild(actionButton('Make admin', () => updateMember(member.accountId, { role: 'admin' }), 'secondary', adminLocked() || member.role === 'admin' || member.status === 'disabled'));
-    actions.appendChild(actionButton('Make member', () => updateMember(member.accountId, { role: 'member' }), 'secondary', adminLocked() || member.role === 'member' || member.status === 'disabled'));
+    actions.appendChild(actionButton('Make admin', () => updateMember(member.accountId, { role: 'admin' }), 'secondary', memberLocked || member.role === 'admin' || member.status === 'disabled', memberLocked ? memberAdminReason : ''));
+    actions.appendChild(actionButton('Make member', () => updateMember(member.accountId, { role: 'member' }), 'secondary', memberLocked || member.role === 'member' || member.status === 'disabled', memberLocked ? memberAdminReason : ''));
     if (member.status === 'invited') {
-      actions.appendChild(actionButton('Activate', () => updateMember(member.accountId, { status: 'active' }), 'primary', adminLocked()));
-      actions.appendChild(actionButton('Revoke', () => disableMember(member.accountId), 'danger', adminLocked()));
+      actions.appendChild(actionButton('Activate', () => updateMember(member.accountId, { status: 'active' }), 'primary', memberLocked, memberLocked ? memberAdminReason : ''));
+      actions.appendChild(actionButton('Revoke', () => disableMember(member.accountId), 'danger', memberLocked, memberLocked ? memberAdminReason : ''));
     } else if (member.status !== 'disabled') {
-      actions.appendChild(actionButton('Suspend', () => disableMember(member.accountId), 'danger', adminLocked()));
+      actions.appendChild(actionButton('Suspend', () => disableMember(member.accountId), 'danger', memberLocked, memberLocked ? memberAdminReason : ''));
     }
     row.appendChild(identity);
     row.appendChild(role);

--- a/apps/website/src/client/byok-script.ts
+++ b/apps/website/src/client/byok-script.ts
@@ -14,6 +14,8 @@ export function cloudWebsiteClientByokScript() {
     policyNote.textContent = parts.join(' - ');
   }
   removeChildren(list);
+  const byokLocked = adminLocked();
+  const byokAdminReason = adminSurfaceText('byok', 'disabledReason', 'BYOK management requires an org owner or admin role.');
   if (!state.byok.length) {
     const empty = document.createElement('p');
     empty.className = 'empty';
@@ -40,8 +42,8 @@ export function cloudWebsiteClientByokScript() {
     const actions = document.createElement('div');
     actions.className = 'row-actions';
     actions.appendChild(pill(secret.status, secret.status === 'active' ? 'ok' : 'warn'));
-    actions.appendChild(actionButton('Validate', () => validateByok(secret.providerId), 'secondary', adminLocked()));
-    actions.appendChild(actionButton('Disable', () => deleteByok(secret.providerId), 'danger', adminLocked()));
+    actions.appendChild(actionButton('Validate', () => validateByok(secret.providerId), 'secondary', byokLocked, byokLocked ? byokAdminReason : ''));
+    actions.appendChild(actionButton('Disable', () => deleteByok(secret.providerId), 'danger', byokLocked, byokLocked ? byokAdminReason : ''));
     row.appendChild(main);
     row.appendChild(actions);
     list.appendChild(row);
@@ -52,6 +54,8 @@ function renderTokens() {
   const list = qs('#token-list');
   if (!list) return;
   removeChildren(list);
+  const tokenLocked = adminLocked();
+  const tokenAdminReason = adminSurfaceText('connections', 'disabledReason', 'Connection token issuance requires an org owner or admin role.');
   if (state.revealToken) {
     const reveal = document.createElement('div');
     reveal.className = 'secret-reveal';
@@ -89,7 +93,7 @@ function renderTokens() {
     const actions = document.createElement('div');
     actions.className = 'row-actions';
     actions.appendChild(pill(token.revokedAt ? 'revoked' : 'active', token.revokedAt ? 'warn' : 'ok'));
-    if (!token.revokedAt) actions.appendChild(actionButton('Revoke', () => revokeToken(token.tokenId), 'danger', adminLocked()));
+    if (!token.revokedAt) actions.appendChild(actionButton('Revoke', () => revokeToken(token.tokenId), 'danger', tokenLocked, tokenLocked ? tokenAdminReason : ''));
     row.appendChild(main);
     row.appendChild(actions);
     list.appendChild(row);

--- a/apps/website/src/client/common-script.ts
+++ b/apps/website/src/client/common-script.ts
@@ -544,6 +544,16 @@ function parityText(conceptId, field, fallback) {
   return entry?.[field] || fallback;
 }
 
+function adminSurfaceText(routeId, field, fallback) {
+  const entry = normalizeList(state.config?.adminSurfaces || bootstrap.adminSurfaces)
+    .find((candidate) => candidate.routeId === routeId);
+  return entry?.[field] || fallback;
+}
+
+function adminControlReason(element, fallback) {
+  return adminSurfaceText(element.closest('[data-route-panel]')?.dataset.routePanel, 'disabledReason', fallback);
+}
+
 function capabilityPolicyNote(capability) {
   if (capability.kind === 'mcp' && capability.scope === 'machine') return parityText('local-stdio-mcps', 'disabledReason', 'Machine-scoped MCP metadata requires a cloud-safe profile capability.');
   if (capability.source === 'custom') return 'Synced custom metadata. Execution depends on org policy.';

--- a/apps/website/src/client/gateway-script.ts
+++ b/apps/website/src/client/gateway-script.ts
@@ -9,6 +9,8 @@ export function cloudWebsiteClientGatewayScript() {
   removeChildren(agents);
   removeChildren(bindings);
   removeChildren(select);
+  const gatewayLocked = adminLocked();
+  const gatewayAdminReason = adminSurfaceText('gateway', 'disabledReason', 'Gateway administration requires an org owner or admin role.');
   if (deliveries) removeChildren(deliveries);
   if (setup) {
     removeChildren(setup);
@@ -103,8 +105,8 @@ export function cloudWebsiteClientGatewayScript() {
       const actions = document.createElement('div');
       actions.className = 'row-actions';
       actions.appendChild(pill(delivery.status || 'unknown', deliveryPillKind(delivery.status)));
-      actions.appendChild(actionButton('Retry', () => retryDelivery(delivery.deliveryId), 'secondary', adminLocked() || !delivery.deliveryId || delivery.status === 'sent'));
-      actions.appendChild(actionButton('Dead-letter', () => deadLetterDelivery(delivery.deliveryId), 'danger', adminLocked() || !delivery.deliveryId || delivery.status === 'dead'));
+      actions.appendChild(actionButton('Retry', () => retryDelivery(delivery.deliveryId), 'secondary', gatewayLocked || !delivery.deliveryId || delivery.status === 'sent', gatewayLocked ? gatewayAdminReason : ''));
+      actions.appendChild(actionButton('Dead-letter', () => deadLetterDelivery(delivery.deliveryId), 'danger', gatewayLocked || !delivery.deliveryId || delivery.status === 'dead', gatewayLocked ? gatewayAdminReason : ''));
       row.appendChild(main);
       row.appendChild(actions);
       appendDetails(row, 'Redacted delivery payload', {

--- a/apps/website/src/client/ops-script.ts
+++ b/apps/website/src/client/ops-script.ts
@@ -7,6 +7,7 @@ export function cloudWebsiteClientOpsScript() {
   if (!panel) return;
   removeChildren(panel);
   if (entitlements) removeChildren(entitlements);
+  const billingReason = adminSurfaceText('billing', 'disabledReason', 'Billing changes require an org owner or admin role and a managed billing deployment.');
   if (!billing || !billing.enabled) {
     panel.appendChild(pill('billing disabled', 'warn'));
     const text = document.createElement('p');
@@ -14,10 +15,20 @@ export function cloudWebsiteClientOpsScript() {
     text.textContent = 'Self-host mode is active. BYOK, desktop tokens, gateway setup, and workbench features remain available without commercial billing.';
     panel.appendChild(text);
     if (entitlements) appendDetails(entitlements, 'Self-host entitlements', billing?.entitlements || {});
-    qsa('[data-billing-control="true"]').forEach((element) => { element.disabled = true; });
+    qsa('[data-billing-control="true"]').forEach((element) => {
+      element.disabled = true;
+      element.dataset.locked = 'true';
+      element.title = billingReason;
+    });
     return;
   }
-  qsa('[data-billing-control="true"]').forEach((element) => { element.disabled = adminLocked(); });
+  const billingLocked = adminLocked();
+  qsa('[data-billing-control="true"]').forEach((element) => {
+    element.disabled = billingLocked;
+    element.dataset.locked = billingLocked ? 'true' : 'false';
+    if (billingLocked) element.title = billingReason;
+    else element.removeAttribute('title');
+  });
   panel.appendChild(pill(billing.active ? 'active' : 'action required', billing.active ? 'ok' : 'warn'));
   panel.appendChild(pill(billing.mode || 'managed'));
   panel.appendChild(pill(billing.providerId || 'provider'));

--- a/apps/website/src/modularity.test.ts
+++ b/apps/website/src/modularity.test.ts
@@ -22,6 +22,7 @@ function lineCount(path: string) {
 test('cloud web workbench production source stays split into bounded modules', () => {
   const files = new Map(sourceFiles().map((path) => [relative(SRC_ROOT, path), lineCount(path)]))
   const requiredModules = [
+    'admin-surface-matrix.ts',
     'app-shell.ts',
     'branding.ts',
     'client-contract.ts',

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -2,6 +2,11 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import {
+  CLOUD_WEB_ADMIN_SURFACE_MATRIX,
+  cloudWebAdminRouteSummary,
+  cloudWebAdminSurfaceForRoute,
+} from './admin-surface-matrix.ts'
 import { CLOUD_WEB_ROUTES, CLOUD_WEB_ROUTE_GROUPS, DEFAULT_CLOUD_WEB_ROUTE, findCloudWebRoute } from './app-shell.ts'
 import { CLOUD_WEB_CLIENT_ENDPOINTS, type CloudWebClientStateContract } from './client-contract.ts'
 import { CLOUD_WEB_ROUTE_API_MATRIX } from './route-api-matrix.ts'
@@ -63,6 +68,10 @@ function parityDocRow(entry: (typeof CLOUD_WEB_WORKBENCH_PARITY_MATRIX)[number])
   return `| ${markdownTableCell(entry.label)} | ${parityAvailabilityDocLabels[entry.availability]} | ${routes} | ${markdownTableCell(entry.cloudAffordance)} | ${markdownTableCell(entry.boundary)} |`
 }
 
+function adminSurfaceDocRow(entry: (typeof CLOUD_WEB_ADMIN_SURFACE_MATRIX)[number]) {
+  return `| ${markdownTableCell(entry.label)} | \`${entry.routeId}\` | ${markdownTableCell(entry.desktopSurface)} | ${markdownTableCell(entry.cloudAffordance)} | ${markdownTableCell(entry.sensitiveBoundary)} |`
+}
+
 test('cloud website renders workbench and admin shell surfaces', () => {
   assert.match(html, /Open Cowork Cloud/)
   assert.match(html, /Workbench/)
@@ -99,8 +108,11 @@ test('cloud website renders workbench and admin shell surfaces', () => {
   assert.match(html, /--danger: #fc92b4;/)
   assert.match(html, /--ok: #7fcfa0;/)
   assert.match(html, /"workbenchParity":/)
+  assert.match(html, /"adminSurfaces":/)
   assert.match(html, /data-parity-route="threads"/)
   assert.match(html, /data-parity-route="chat"/)
+  assert.match(html, /data-admin-surface-route="byok"/)
+  assert.match(html, /Provider keys are never rendered after submission/)
   assert.match(html, /Local Filesystem/)
   assert.match(html, /Local Stdio MCPs/)
 })
@@ -148,6 +160,34 @@ test('cloud website desktop parity matrix covers every workbench route and docum
     }
     if (entry.availability === 'desktop-only' || entry.availability === 'intentionally-unavailable') {
       assert.ok(entry.disabledReason, `${entry.conceptId} explains why Cloud Web does not expose it`)
+    }
+  }
+})
+
+test('cloud website admin surface matrix covers every admin route and documented boundary', () => {
+  const adminRoutes = CLOUD_WEB_ROUTES.filter((route) => route.surface === 'admin')
+  const routeApiIds = new Set(CLOUD_WEB_ROUTE_API_MATRIX.map((entry) => entry.routeId))
+  const doc = readFileSync(fileURLToPath(new URL('../../../docs/cloud-web-workbench.md', import.meta.url)), 'utf8')
+
+  assert.match(doc, /Admin\/Settings Surface Matrix/)
+  assert.deepEqual(CLOUD_WEB_ADMIN_SURFACE_MATRIX.map((entry) => entry.routeId).sort(), adminRoutes.map((route) => route.id).sort())
+
+  for (const route of adminRoutes) {
+    const entry = cloudWebAdminSurfaceForRoute(route.id)
+    assert.ok(entry, `${route.id} has an admin surface entry`)
+    assert.equal(route.summary, entry.cloudAffordance, `${route.id} summary is admin-surface-derived`)
+    assert.equal(route.summary, cloudWebAdminRouteSummary(route.id, 'fallback'), `${route.id} helper returns the same summary`)
+    assert.ok(routeApiIds.has(route.id), `${route.id} is covered by route/API matrix`)
+  }
+
+  for (const entry of CLOUD_WEB_ADMIN_SURFACE_MATRIX) {
+    assert.ok(entry.desktopSurface, `${entry.routeId} names its Desktop analog`)
+    assert.ok(entry.cloudAffordance, `${entry.routeId} names its Cloud Web affordance`)
+    assert.ok(entry.sensitiveBoundary, `${entry.routeId} documents its sensitive boundary`)
+    assert.ok(entry.disabledReason, `${entry.routeId} documents disabled behavior`)
+    assert.ok(doc.includes(adminSurfaceDocRow(entry)), `docs list exact admin surface row for ${entry.label}`)
+    for (const filename of entry.tests) {
+      assert.ok(existsSync(fileURLToPath(routeMatrixTestUrl(filename))), `${entry.routeId} listed test file exists: ${filename}`)
     }
   }
 })
@@ -208,6 +248,7 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
   assert.equal(CLOUD_WEB_CLIENT_ENDPOINTS.find((endpoint) => endpoint.id === 'workspace')?.path, '/api/workspace')
   assert.match(html, /"api":/)
   assert.match(html, /"routeMatrix":/)
+  assert.match(html, /"adminSurfaces":/)
   assert.match(cloudWebsiteClientScript(), /endpoint\(id, fallback\)/)
   assert.match(cloudWebsiteClientScript(), /sessionSelectionGeneration/)
   assert.match(cloudWebsiteClientScript(), /isCurrentSessionSelection/)
@@ -734,8 +775,9 @@ test('cloud website thread helper handles status filters and thousands-sized lis
 
 test('cloud website disables dynamic admin actions for member roles', () => {
   const script = cloudWebsiteClientScript()
-  assert.match(script, /Validate', \(\) => validateByok\(secret\.providerId\), 'secondary', adminLocked\(\)\)/)
-  assert.match(script, /Revoke', \(\) => revokeToken\(token\.tokenId\), 'danger', adminLocked\(\)\)/)
+  assert.match(script, /adminSurfaceText\('byok', 'disabledReason'/)
+  assert.match(script, /Validate', \(\) => validateByok\(secret\.providerId\), 'secondary', byokLocked, byokLocked \? byokAdminReason : ''\)/)
+  assert.match(script, /Revoke', \(\) => revokeToken\(token\.tokenId\), 'danger', tokenLocked, tokenLocked \? tokenAdminReason : ''\)/)
   assert.match(html, /data-requires-admin="true"/)
 })
 

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -1,4 +1,5 @@
 import { canManageOrg, type WebsiteRole } from './roles.ts'
+import { CLOUD_WEB_ADMIN_SURFACE_MATRIX, cloudWebAdminSurfaceForRoute } from './admin-surface-matrix.ts'
 import { CLOUD_WEB_ROUTE_GROUPS, CLOUD_WEB_ROUTES, DEFAULT_CLOUD_WEB_ROUTE, type CloudWebRoute, type CloudWebRouteId } from './app-shell.ts'
 import { CLOUD_WEB_CLIENT_ENDPOINTS, type CloudWebClientBootstrap } from './client-contract.ts'
 import { DEFAULT_WEBSITE_PUBLIC_BRANDING, brandLinksMarkup, brandLogoMarkup, resolvePublicBranding } from './branding.ts'
@@ -66,6 +67,22 @@ function routeParityMarkup(routeId: CloudWebRouteId) {
           </div>`
 }
 
+function routeAdminSurfaceMarkup(routeId: CloudWebRouteId) {
+  const entry = cloudWebAdminSurfaceForRoute(routeId)
+  if (!entry) return ''
+  return `<div class="surface-grid" data-admin-surface-route="${escapeHtml(routeId)}" aria-label="Cloud Web admin surface contract for ${escapeHtml(routeId)}">
+            <article class="surface-card">
+              <div class="runtime-card-header">
+                <span class="pill" data-kind="info">Admin surface</span>
+                <strong>${escapeHtml(entry.label)}</strong>
+              </div>
+              <p>${escapeHtml(entry.cloudAffordance)}</p>
+              <small>${escapeHtml(entry.sensitiveBoundary)}</small>
+              <small>${escapeHtml(entry.disabledReason)}</small>
+            </article>
+          </div>`
+}
+
 export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?: PublicBrandingConfig | null, cspNonce = '') {
   const branding = resolvePublicBranding(publicBranding || policy.publicBranding)
   const copy = branding.dashboard || DEFAULT_WEBSITE_PUBLIC_BRANDING.dashboard || {}
@@ -79,6 +96,7 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
     defaultRoute: DEFAULT_CLOUD_WEB_ROUTE,
     api: CLOUD_WEB_CLIENT_ENDPOINTS,
     routeMatrix: CLOUD_WEB_ROUTE_API_MATRIX,
+    adminSurfaces: CLOUD_WEB_ADMIN_SURFACE_MATRIX,
     workbenchParity: CLOUD_WEB_WORKBENCH_PARITY_MATRIX,
     sessionEventTypes: [...CLOUD_SESSION_EVENT_TYPES],
   }
@@ -379,6 +397,7 @@ ${cloudWebsiteStyles(branding)}
               <div class="meta">${escapeHtml(copy.subtitle || 'Cloud control plane state for this signed-in org.')}</div>
             </div>
           </div>
+          ${routeAdminSurfaceMarkup('org')}
           <div class="grid">
             <div class="panel">
               <h3>Profile and policy</h3>
@@ -405,6 +424,7 @@ ${cloudWebsiteStyles(branding)}
               <button id="refresh-admin" type="button" data-admin-control="true">Refresh admin</button>
             </div>
           </div>
+          ${routeAdminSurfaceMarkup('members')}
           <div class="workbench-split">
             <div class="panel">
               <div class="section-header">
@@ -450,6 +470,7 @@ ${cloudWebsiteStyles(branding)}
               <div class="meta">Runtime profile and feature flags</div>
             </div>
           </div>
+          ${routeAdminSurfaceMarkup('policy')}
           <div class="grid">
             <div class="panel">
               <h3>Runtime profile</h3>
@@ -493,6 +514,7 @@ ${cloudWebsiteStyles(branding)}
               <div class="meta">${escapeHtml(copy.byokDescription || 'Provider keys are write-only. The dashboard stores status metadata only.')}</div>
             </div>
           </div>
+          ${routeAdminSurfaceMarkup('byok')}
           <div class="grid">
             <form class="panel" id="byok-form">
               <h3>Add or rotate key</h3>
@@ -518,6 +540,7 @@ ${cloudWebsiteStyles(branding)}
               <div class="meta">${escapeHtml(copy.connectionsDescription || 'Issue scoped tokens for desktop and gateway clients. Plaintext is shown once.')}</div>
             </div>
           </div>
+          ${routeAdminSurfaceMarkup('connections')}
           <div class="grid">
             <form class="panel" id="token-form">
               <h3>Create ${escapeHtml(labels.apiToken || 'API token')}</h3>
@@ -548,6 +571,7 @@ ${cloudWebsiteStyles(branding)}
             </div>
             <button id="refresh-gateway" type="button" data-admin-control="true">Refresh gateway</button>
           </div>
+          ${routeAdminSurfaceMarkup('gateway')}
           <div class="grid">
             <div class="panel">
               <h3>Setup guide</h3>
@@ -611,6 +635,7 @@ ${cloudWebsiteStyles(branding)}
               <div class="meta">${escapeHtml(copy.billingDescription || 'Manage hosted plan state and entitlements for this org.')}</div>
             </div>
           </div>
+          ${routeAdminSurfaceMarkup('billing')}
           <div class="grid">
             <form class="panel" id="billing-form">
               <h3>Plan</h3>
@@ -641,6 +666,7 @@ ${cloudWebsiteStyles(branding)}
               <button id="export-audit" type="button" data-admin-control="true">Export</button>
             </div>
           </div>
+          ${routeAdminSurfaceMarkup('audit')}
           <div class="panel">
             <div class="section-header">
               <h3>Events</h3>
@@ -660,6 +686,7 @@ ${cloudWebsiteStyles(branding)}
             </div>
             <button id="export-usage" type="button">Export usage</button>
           </div>
+          ${routeAdminSurfaceMarkup('usage')}
           <div class="grid">
             <div class="panel">
               <h3>Quota windows</h3>
@@ -684,6 +711,7 @@ ${cloudWebsiteStyles(branding)}
             </div>
             <button id="prepare-diagnostics" type="button" data-admin-control="true">Prepare bundle</button>
           </div>
+          ${routeAdminSurfaceMarkup('diagnostics')}
           <div class="grid">
             <div class="panel">
               <h3>Health</h3>

--- a/apps/website/src/style-components.ts
+++ b/apps/website/src/style-components.ts
@@ -135,14 +135,16 @@ export function cloudWebsiteComponentStyles() {
       font-size: var(--text-md);
       line-height: var(--lh-md);
     }
-    .parity-grid {
+    .parity-grid,
+    .surface-grid {
       grid-column: 1 / -1;
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: var(--space-2);
       min-width: 0;
     }
-    .parity-card {
+    .parity-card,
+    .surface-card {
       min-width: 0;
       display: grid;
       gap: var(--space-2);
@@ -156,7 +158,8 @@ export function cloudWebsiteComponentStyles() {
       background: color-mix(in srgb, var(--color-amber) 8%, var(--color-surface) 92%);
       border-color: var(--tone-warn-border);
     }
-    .parity-card p {
+    .parity-card p,
+    .surface-card p {
       margin: 0;
       color: var(--text);
       font-size: var(--text-sm);
@@ -366,7 +369,8 @@ export function cloudWebsiteComponentStyles() {
       .form-grid {
         grid-template-columns: 1fr;
       }
-      .parity-grid {
+      .parity-grid,
+      .surface-grid {
         grid-template-columns: 1fr;
       }
       .row {

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -64,6 +64,27 @@ keeping Cloud Web honest about cloud-only and desktop-only boundaries.
 | Local Stdio MCPs | Unavailable in Cloud | `capabilities`, `agents` | Show only policy-safe MCP metadata that has been converted into the Cloud profile. | Cloud Web cannot spawn local stdio MCP processes or expose command lines, environment variables, or secret refs. |
 | Machine Runtime Config | Desktop-only | `chat`, `agents`, `capabilities` | Show current Cloud profile, feature flags, and projected runtime state. | Cloud Web does not configure the local machine runtime, provider defaults, local approvals mode, or desktop notification settings. |
 
+## Admin/Settings Surface Matrix
+
+The typed source of truth is
+`apps/website/src/admin-surface-matrix.ts`. Cloud Web admin route summaries,
+browser bootstrap metadata, rendered admin surface cards, and locked-control
+copy consume this matrix. This document mirrors the same rows, and render tests
+assert every documented row against the typed source.
+
+| Surface | Route | Desktop analog | Cloud Web affordance | Sensitive boundary |
+|---|---|---|---|---|
+| Workspace Profile | `org` | Desktop account, workspace, and profile status surfaces | Show signed-in org identity, role, profile, and public sign-in state. | Bootstrap and signed-out state expose only public branding, route metadata, endpoint metadata, and feature flags. |
+| Members | `members` | Desktop account/settings identity context | Manage org member roles, invites, activation, suspension, and invite-mode state. | Member rows expose identity, role, and status only; authorization remains server-side. |
+| Profiles & Policy | `policy` | Desktop runtime settings, capability policy, and Health Center | Show Cloud profile features, project-source policy, runtime guardrails, gateway policy, and worker health. | Cloud Web reports policy and health summaries without configuring local runtime, host paths, or stdio MCP processes. |
+| BYOK | `byok` | Desktop provider credential setup | Add, rotate, validate, and disable provider credentials through write-only Cloud APIs. | Provider keys are never rendered after submission; the browser receives metadata such as provider id, status, last4, and validation timestamps. |
+| Connections | `connections` | Desktop Cloud connection and Gateway pairing surfaces | Issue scoped Desktop, Gateway, and admin API tokens with one-time plaintext reveal. | Token plaintext is shown once after creation and is not stored in persistent browser state. |
+| Billing | `billing` | Desktop entitlement and setup status surfaces | Show managed billing mode, plan state, checkout/portal actions, and resolved entitlements. | Billing renders plan and entitlement metadata only; provider integration stays behind the Cloud API. |
+| Headless Gateway | `gateway` | Desktop Gateway connection and workflow delivery status | Configure headless agents, channel bindings, setup guidance, and delivery backlog controls. | Channel credential refs, delivery targets, payloads, and errors are browser-sanitized before rendering. |
+| Audit | `audit` | Desktop diagnostics and sensitive-action history context | Browse and export redacted administrative events for sensitive Cloud actions. | Audit metadata must be server-redacted and is sanitized again before display or export. |
+| Usage | `usage` | Desktop chat cost, token, and runtime status summaries | Show quota windows, recent metering totals, and bounded usage event samples. | Usage events include metering dimensions only, never prompts, provider keys, or tokens. |
+| Diagnostics | `diagnostics` | Desktop Health Center and support bundle surfaces | Prepare redacted health summaries and support bundles for Cloud runtime, BYOK, gateway, and object-store state. | Diagnostics are recursively redacted and array-capped before rendering or download. |
+
 ## End-User Workbench Contract
 
 Cloud Web must keep parity with Desktop Cloud for cloud workspaces:


### PR DESCRIPTION
## Summary

- add a typed Cloud Web admin/settings surface matrix that covers org, members, policy, BYOK, connections, billing, gateway, audit, usage, and diagnostics
- render Desktop-aligned admin surface cards on every admin route and expose the matrix through bootstrap metadata
- derive admin route summaries and locked-control copy from the matrix so role/sensitive-state messaging stays consistent
- drift-gate the matrix against docs, route/API coverage, browser route transitions, and sensitive admin states

## Roadmap

Closes #728.
Refs #724 and #729.

## Validation

- `pnpm --filter @open-cowork/website test`
- `pnpm test:cloud-web`
- `pnpm docs:build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local`
- read-only subagent security review: no findings
- read-only subagent design/parity review: no findings
