### PR TITLE
Document Cloud Web design parity gates

### DIFF
--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -150,3 +150,26 @@ smoke, accessibility/keyboard behavior, responsive layout expectations,
 performance budgets for large thread and admin lists, route/API matrix coverage,
 backend cursor validation, and package-boundary checks that keep the browser out
 of server-only modules.
+
+## Visual QA Checklist
+
+For visual or surface-organization changes, compare Cloud Web and Desktop
+side-by-side before merge. The expected match is product language and workflow
+parity, not pixel-perfect screenshots.
+
+- App shell, sidebar, topbar, active route, status text, and density use the
+  same dark product language.
+- Cards, panels, tables, rows, badges, notices, empty states, focus rings, and
+  destructive/primary/secondary controls read like Desktop primitives.
+- Threads, chat, runtime status, approvals, questions, tools, skills,
+  workflows, and artifacts map to the Desktop/Cloud parity matrix.
+- Org, members, policy, BYOK, connections, gateway, billing, audit, usage, and
+  diagnostics map to the admin/settings surface matrix.
+- Loading, empty, error, disabled, confirmation, and one-time reveal states stay
+  visible and consistent without exposing secrets.
+- Desktop-only boundaries remain explicit: no local host paths, local stdio MCP
+  process controls, machine runtime config, or browser-owned OpenCode runtime.
+- Responsive desktop and mobile views have no horizontal overflow, clipped
+  controls, or unreachable keyboard focus targets.
+- `/assets/fonts/*.woff2` requests return `200 font/woff2` and computed fonts
+  resolve to Mona Sans / Hubot Sans in the real-browser smoke.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,10 +135,13 @@ ship one desktop app that can connect to different cloud orgs.
       "securityUrl": "https://security.acme.example/cowork",
       "legalUrl": "https://legal.acme.example/terms",
       "theme": {
-        "background": "#f7f8f5",
-        "surface": "#ffffff",
-        "accent": "#0f6b4b",
-        "accentStrong": "#0a4c35"
+        "background": "#1b1b26",
+        "elevated": "#23232f",
+        "surface": "rgba(141, 164, 245, 0.04)",
+        "text": "#e8e9f3",
+        "accent": "#8da4f5",
+        "accentHover": "#a7b6f8",
+        "accentForeground": "#0f0f18"
       },
       "managedOrgConnectionLabels": {
         "desktopToken": "Acme Desktop token",
@@ -155,6 +158,16 @@ The cloud service exposes the same metadata from `GET /api/config`; the browser
 dashboard renders it directly, and the gateway returns it from health/readiness
 metadata for provider setup tooling. Helm deployments can set the equivalent
 `cloud.branding` and `gateway.branding` values.
+
+Cloud Web defaults to the shared Desktop dark palette, Mona Sans / Hubot Sans
+font stacks, and the structural token scale from
+`packages/shared/src/design-tokens.ts`. Public branding may override color and
+brand presentation keys such as `background`, `surface`, `elevated`, `text`,
+`mutedText`, `accent`, `accentHover`, `accentForeground`, semantic tones,
+`shadowCard`, `shadowElevated`, and `bgImage`. Do not use public branding to
+fork spacing, radius, control heights, typography scale, or runtime behavior.
+Legacy light partial theme overrides are still normalized for existing
+deployments.
 
 ## Environment placeholders
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -4,7 +4,19 @@ Open Cowork uses a small, enforceable design system so UI work stays consistent 
 
 ## Tokens
 
-Structural tokens live in `apps/desktop/src/renderer/styles/globals.css` and are documented in [Design Tokens](design-tokens.md). Use the token-backed classes and CSS variables for type, spacing, radius, motion, elevation, and content measures. Theme color values stay inside the `BrandThemeTokens` contract so downstream themes can change color without forking layout.
+Canonical structural tokens live in
+`packages/shared/src/design-tokens.ts` and are documented in
+[Design Tokens](design-tokens.md). Desktop keeps the matching CSS variables in
+`apps/desktop/src/renderer/styles/globals.css`; Cloud Web emits the same
+structural `:root` block from `emitRootTokensCss()` while staying a zero-build,
+inline HTML Cloud API client. `tests/design-tokens-sync.test.ts` drift-gates the
+shared module against Desktop globals, the default dark public branding theme,
+and the Cloud Web font package assumptions.
+
+Use the token-backed classes and CSS variables for type, spacing, radius,
+motion, elevation, and content measures. Theme color values stay inside the
+`BrandThemeTokens` / public branding contract so downstream themes can change
+color without forking layout.
 
 Avoid adding new Tailwind arbitrary font-size utilities such as `text-[13px]`. `pnpm lint` ratchets the existing renderer count and fails if the count increases.
 
@@ -18,6 +30,13 @@ Shared renderer primitives live in `apps/desktop/src/renderer/components/ui/`:
 - `Icon` wraps Lucide icons so stroke, sizing, and naming stay consistent.
 
 Prefer these primitives before adding component-local button, input, badge, skeleton, or modal markup.
+
+Cloud Web does not import the Desktop React primitive library, but it must match
+the same product vocabulary in CSS and markup: shell/sidebar/topbar, cards,
+buttons, icon-sized controls, inputs, badges, notices, empty states, tables,
+chat bubbles, runtime cards, and admin surface cards. The route/API,
+workbench-parity, admin-surface, browser, accessibility, and performance tests
+are the Cloud Web guardrail for that non-React implementation.
 
 ## Accessibility Gates
 

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -2,9 +2,18 @@
 
 Open Cowork separates color from structure.
 
-Color tokens stay in the runtime `BrandThemeTokens` contract so downstream
-themes can vary by brand and color scheme. Structural tokens are theme
-invariant and live in `apps/desktop/src/renderer/styles/globals.css`.
+The canonical typed token source is
+`packages/shared/src/design-tokens.ts`. It exports `DESIGN_TOKENS`,
+`DEFAULT_DARK_BRAND_THEME`, and `emitRootTokensCss()`. Desktop keeps the
+matching CSS variables in `apps/desktop/src/renderer/styles/globals.css`; Cloud
+Web emits the same structural variables from `emitRootTokensCss()` and layers
+public branding color tokens on top. `tests/design-tokens-sync.test.ts`
+drift-gates the shared module against Desktop globals and the default Cloud Web
+dark branding theme.
+
+Color tokens stay in the runtime `BrandThemeTokens` and public branding
+contracts so downstream themes can vary by brand and color scheme. Structural
+tokens are theme invariant and should not be forked by downstream deployments.
 
 ## Type
 
@@ -79,3 +88,32 @@ Z-index tokens reserve predictable stacking slots:
 
 Control heights are `--control-h-sm` at 28px, `--control-h-md` at 32px, and
 `--control-h-lg` at 40px.
+
+## Consumers
+
+| Surface | Source path | Contract |
+| --- | --- | --- |
+| Shared package | `packages/shared/src/design-tokens.ts` | Canonical typed token values, default dark brand theme, public branding bridge, and CSS emitter. |
+| Desktop | `apps/desktop/src/renderer/styles/globals.css` | Hand-authored CSS variables and font-face declarations that must match the shared token module. |
+| Cloud Web | `apps/website/src/styles.ts` | Zero-build inline CSS that imports `emitRootTokensCss()`, serves Mona Sans / Hubot Sans from `/assets/fonts/*.woff2`, and overlays public branding variables. |
+| Drift gate | `tests/design-tokens-sync.test.ts` | Fails when Desktop globals, shared tokens, font package assumptions, or default public branding drift. |
+
+## Public Branding Theme Keys
+
+`cloud.publicBranding.theme` may override color and visual-brand values only.
+The default theme is the Desktop-aligned dark palette from
+`DEFAULT_DARK_BRAND_THEME`; legacy light partial overrides remain supported for
+existing deployments.
+
+Supported keys are:
+
+`background`, `surface`, `mutedSurface`, `border`, `text`, `mutedText`,
+`accent`, `accentStrong`, `focus`, `warn`, `danger`, `ok`, `surfaceHover`,
+`surfaceActive`, `borderSubtle`, `elevated`, `textSecondary`, `accentHover`,
+`accentForeground`, `green`, `amber`, `red`, `info`, `shadowCard`,
+`shadowElevated`, and `bgImage`.
+
+Downstream builders should override only the color/brand keys they own and let
+the shared structural tokens continue to define layout density, control heights,
+radii, typography scale, and shadows. Do not reintroduce Cloud Web-only spacing
+or typography scales.

--- a/docs/downstream-contract.md
+++ b/docs/downstream-contract.md
@@ -96,6 +96,12 @@ Downstream branding must flow through config and assets:
 Back-compat names such as `com.opencowork.desktop` and `.opencowork/` are
 allowed only where docs identify them as migration or bundle-id compatibility.
 
+Cloud Web branding must stay on the shared token contract. Public theme
+overrides may change color, semantic tones, shadows, and background imagery, but
+the structural token source remains `packages/shared/src/design-tokens.ts`.
+Downstream builds should not patch `apps/website/src/styles.ts` to create a
+separate Cloud Web visual language or bypass the Desktop/Cloud Web drift gates.
+
 ## Extension Contracts
 
 Downstream extension work must start in the layer that owns the concept.

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -209,6 +209,15 @@ config overlays, billing adapters, object-store and secret refs, and operations
 evidence. That repo should not fork Open Cowork runtime behavior or require
 billing for the OSS self-host path.
 
+Cloud Web theming is intentionally narrow. Downstream overlays can change
+`cloud.publicBranding` names, logo/legal/support URLs, dashboard copy, token
+labels, and public theme colors, including the expanded dark-token keys
+documented in [Design Tokens](design-tokens.md). They should not fork Cloud Web
+layout CSS, add a separate build pipeline, replace Mona/Hubot font serving, or
+change the Cloud Web cloud-client-only architecture. The shared structural
+tokens in `packages/shared/src/design-tokens.ts` keep Desktop and Cloud Web
+aligned across spacing, radius, typography scale, shadows, and control density.
+
 Downstream deployment recipes must also preserve these production contracts:
 
 - images are pinned by immutable release tag or digest; `latest`, `stable`,

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -189,6 +189,10 @@ and linked from the release Go/No-Go report.
       decision, Accepted Launch Tier, Known limits, Cost and scaling notes,
       Final smoke status, and Findings Workflow.
 - [ ] final Cloud Web/Desktop/Gateway smoke gates passed after the soak run.
+- [ ] Cloud Web and Desktop visual parity checklist completed from
+      `docs/cloud-web-workbench.md`: shell/nav/topbar, cards/panels, controls,
+      chat/thread runtime surfaces, admin/settings surfaces, responsive layout,
+      loading/empty/error states, and `/assets/fonts/*.woff2` font loading.
 
 ## Tagged release
 

--- a/tests/design-tokens-sync.test.ts
+++ b/tests/design-tokens-sync.test.ts
@@ -123,6 +123,32 @@ test('desktop font package dependencies are present for cloud font serving', () 
   assert.ok(packageJson.dependencies?.['@fontsource-variable/hubot-sans'], 'Hubot Sans font package is a desktop dependency')
 })
 
+test('design docs describe the shared Cloud Web and Desktop token contract', () => {
+  const designSystem = readFileSync('docs/design-system.md', 'utf8')
+  const designTokens = readFileSync('docs/design-tokens.md', 'utf8')
+  const configuration = readFileSync('docs/configuration.md', 'utf8')
+  const downstream = readFileSync('docs/downstream.md', 'utf8')
+  const downstreamContract = readFileSync('docs/downstream-contract.md', 'utf8')
+  const cloudWeb = readFileSync('docs/cloud-web-workbench.md', 'utf8')
+  const releaseChecklist = readFileSync('docs/release-checklist.md', 'utf8')
+
+  for (const doc of [designSystem, designTokens, downstream, downstreamContract]) {
+    assert.match(doc, /packages\/shared\/src\/design-tokens\.ts/)
+  }
+  assert.match(designSystem, /emitRootTokensCss\(\)/)
+  assert.match(designTokens, /DEFAULT_DARK_BRAND_THEME/)
+  assert.match(designTokens, /Public Branding Theme Keys/)
+  assert.match(designTokens, /surfaceHover/)
+  assert.match(designTokens, /shadowElevated/)
+  assert.match(configuration, /Cloud Web defaults to the shared Desktop dark palette/)
+  assert.match(configuration, /Legacy light partial theme overrides/)
+  assert.match(downstream, /should not fork Cloud Web\s+layout CSS/)
+  assert.match(downstreamContract, /bypass the Desktop\/Cloud Web drift gates/)
+  assert.match(cloudWeb, /Visual QA Checklist/)
+  assert.match(cloudWeb, /\/assets\/fonts\/\*\.woff2/)
+  assert.match(releaseChecklist, /Cloud Web and Desktop visual parity checklist/)
+})
+
 test('shared public branding default uses the canonical dark theme', () => {
   assert.deepEqual(DEFAULT_PUBLIC_BRANDING.theme, DEFAULT_DARK_PUBLIC_BRANDING_THEME)
 })


### PR DESCRIPTION
## Summary

- document `packages/shared/src/design-tokens.ts` as the shared Cloud Web/Desktop token source and describe Desktop/Cloud Web consumers
- add downstream theming guidance for Cloud Web public branding without forking the zero-build Cloud Web architecture
- add a concrete Cloud Web/Desktop visual QA checklist to the workbench docs and release checklist
- drift-gate the docs so future changes keep naming the shared token source, public branding keys, and visual checklist

## Roadmap

Closes #729.
Closes #730.
Refs #724.

## Validation

- `pnpm build:shared && node scripts/run-node-tests.mjs tests/design-tokens-sync.test.ts`
- `pnpm docs:build`
- `pnpm --filter @open-cowork/website test`
- `pnpm test:cloud-web`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local`
