### PR TITLE
Harden standalone gateway prompt authorization

### DIFF
--- a/apps/standalone-gateway/package.json
+++ b/apps/standalone-gateway/package.json
@@ -14,6 +14,7 @@
     "test": "pnpm build && node --no-warnings --experimental-strip-types --test src/*.test.ts",
     "start": "node dist/main.js serve",
     "doctor": "node dist/main.js doctor",
+    "identity": "node dist/main.js identity",
     "smoke": "node dist/main.js smoke"
   },
   "dependencies": {

--- a/apps/standalone-gateway/src/backup.ts
+++ b/apps/standalone-gateway/src/backup.ts
@@ -6,6 +6,7 @@ export async function exportStandaloneGatewayBackup(repository: Pick<StandaloneG
     format: "open-cowork-standalone-gateway-backup-v1",
     exportedAt: new Date().toISOString(),
     sessions: snapshot.sessions,
+    identities: snapshot.identities,
     jobs: snapshot.jobs,
     audits: snapshot.audits,
   };

--- a/apps/standalone-gateway/src/doctor.test.ts
+++ b/apps/standalone-gateway/src/doctor.test.ts
@@ -14,6 +14,43 @@ test("standalone doctor checks product mode, repository, OpenCode, schema, and p
     OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
     OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
   });
+  const repository = new InMemoryStandaloneGatewayRepository();
+  await repository.upsertChannelIdentity({
+    provider: "webhook",
+    externalUserId: "user-1",
+    role: "admin",
+  });
+
+  const result = await runStandaloneGatewayDoctor({
+    config,
+    repository,
+    opencode: new FakeStandaloneOpenCodeAdapter(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.checks.map((check) => check.name), ["product-mode", "postgres", "opencode-private", "schema", "providers", "identity-authorization"]);
+  assert.deepEqual(result.doctorChecks.map((check) => check.code), [
+    "standalone_gateway.product_mode",
+    "standalone_gateway.repository.readiness",
+    "standalone_gateway.opencode.health",
+    "standalone_gateway.schema.production_tables",
+    "standalone_gateway.providers.configured",
+    "standalone_gateway.identity_authorization",
+  ]);
+  assert.equal(result.readinessTimeline.at(-1)?.phase, "ready");
+  assert.equal(result.runtimeStatus.authority, "standalone-gateway");
+  assert.equal(result.workspaceAuthority.audit, "standalone_gateway_repository");
+  assert.equal(result.redacted, true);
+});
+
+test("standalone doctor fails closed when no prompt-capable identity is configured", async () => {
+  const config = loadStandaloneGatewayConfig({
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:5432/gateway",
+    OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN: "standalone-admin-token",
+    OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL: "http://127.0.0.1:4096",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
+  });
 
   const result = await runStandaloneGatewayDoctor({
     config,
@@ -21,19 +58,62 @@ test("standalone doctor checks product mode, repository, OpenCode, schema, and p
     opencode: new FakeStandaloneOpenCodeAdapter(),
   });
 
-  assert.equal(result.ok, true);
-  assert.deepEqual(result.checks.map((check) => check.name), ["product-mode", "postgres", "opencode-private", "schema", "providers"]);
-  assert.deepEqual(result.doctorChecks.map((check) => check.code), [
-    "standalone_gateway.product_mode",
-    "standalone_gateway.repository.readiness",
-    "standalone_gateway.opencode.health",
-    "standalone_gateway.schema.production_tables",
-    "standalone_gateway.providers.configured",
-  ]);
-  assert.equal(result.readinessTimeline.at(-1)?.phase, "ready");
-  assert.equal(result.runtimeStatus.authority, "standalone-gateway");
-  assert.equal(result.workspaceAuthority.audit, "standalone_gateway_repository");
-  assert.equal(result.redacted, true);
+  assert.equal(result.ok, false);
+  assert.equal(result.doctorChecks.find((check) => check.code === "standalone_gateway.identity_authorization")?.status, "fail");
+  assert.equal(result.readinessTimeline.at(-1)?.phase, "error");
+});
+
+test("standalone doctor ignores prompt-capable identities for unconfigured providers", async () => {
+  const config = loadStandaloneGatewayConfig({
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:5432/gateway",
+    OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN: "standalone-admin-token",
+    OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL: "http://127.0.0.1:4096",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
+  });
+  const repository = new InMemoryStandaloneGatewayRepository();
+  await repository.upsertChannelIdentity({
+    provider: "webhook-other",
+    externalUserId: "user-1",
+    role: "admin",
+  });
+
+  const result = await runStandaloneGatewayDoctor({
+    config,
+    repository,
+    opencode: new FakeStandaloneOpenCodeAdapter(),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.doctorChecks.find((check) => check.code === "standalone_gateway.identity_authorization")?.status, "fail");
+});
+
+test("standalone doctor does not query identity authorization after repository readiness fails", async () => {
+  const config = loadStandaloneGatewayConfig({
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:5432/gateway",
+    OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN: "standalone-admin-token",
+    OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL: "http://127.0.0.1:4096",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
+  });
+  let identitySummaryCalled = false;
+
+  const result = await runStandaloneGatewayDoctor({
+    config,
+    repository: {
+      readiness: async () => ({ ok: false, detail: "postgres unavailable" }),
+      identityAuthorizationSummary: async () => {
+        identitySummaryCalled = true;
+        throw new Error("identity query should not run");
+      },
+    },
+    opencode: new FakeStandaloneOpenCodeAdapter(),
+  });
+
+  assert.equal(identitySummaryCalled, false);
+  assert.equal(result.ok, false);
+  assert.equal(result.doctorChecks.find((check) => check.code === "standalone_gateway.repository.readiness")?.status, "fail");
+  assert.equal(result.doctorChecks.find((check) => check.code === "standalone_gateway.identity_authorization")?.message, "Identity authorization could not be checked because the repository is not ready.");
 });
 
 test("standalone doctor redacts secret-looking readiness details", async () => {

--- a/apps/standalone-gateway/src/doctor.ts
+++ b/apps/standalone-gateway/src/doctor.ts
@@ -4,6 +4,7 @@ import type {
 } from "@open-cowork/shared";
 import { standaloneGatewaySchemaContainsProductionTables } from "./schema.js";
 import type { StandaloneOpenCodeAdapter } from "./opencode.js";
+import { redactSecretText } from "./redaction.js";
 import type { StandaloneGatewayRepository } from "./repository.js";
 import type { StandaloneGatewayConfig } from "./types.js";
 
@@ -36,22 +37,12 @@ export interface StandaloneGatewayDoctorReport {
   redacted: true;
 }
 
-const SECRET_TEXT_PATTERNS = [
-  /\bAuthorization:\s*(?:Bearer|Basic)\s+\S+/gi,
-  /\b(?:token|secret|password|api[_-]?key)\s*[:=]\s*['"]?[A-Za-z0-9+/=_-]{8,}['"]?/gi,
-  /:\/\/([^:\s/@]+):([^@\s/]+)@/g,
-  /\b(?:sk|ghp|xoxb|occ|ocgw)-[A-Za-z0-9_-]{8,}\b/g,
-];
-
 function nowIso() {
   return new Date().toISOString();
 }
 
 function redact(value: string) {
-  return SECRET_TEXT_PATTERNS.reduce((text, pattern) => text.replace(pattern, (match, user) => {
-    if (typeof user === "string" && match.includes("://")) return `://${user}:[redacted]@`;
-    return "[redacted]";
-  }), value).slice(0, 2000);
+  return redactSecretText(value);
 }
 
 function timeline(
@@ -99,15 +90,19 @@ export async function runStandaloneGatewayDoctor(input: {
 }): Promise<StandaloneGatewayDoctorReport> {
   const repository = await input.repository.readiness();
   const opencode = await input.opencode.health();
+  const configuredProviderIds = input.config.providers.filter((provider) => provider.enabled).map((provider) => provider.id);
+  const identityAuthorization = await identityAuthorizationSummary(input.repository, repository.ok, configuredProviderIds);
   const schemaOk = standaloneGatewaySchemaContainsProductionTables();
   const productModeOk = input.config.productMode === "standalone";
   const providersOk = input.config.providers.length > 0;
+  const identitiesOk = identityAuthorization.summary.promptCapable > 0;
   const checks: StandaloneDoctorCheck[] = [
     legacyCheck("product-mode", productModeOk, `mode=${input.config.productMode}`),
     legacyCheck("postgres", repository.ok, repository.detail),
     legacyCheck("opencode-private", opencode.ok, opencode.detail),
     legacyCheck("schema", schemaOk, "standalone gateway schema covers sessions/events/jobs/leases/channel/artifact/team/audit tables"),
     legacyCheck("providers", providersOk, `${input.config.providers.length} provider(s) configured`),
+    legacyCheck("identity-authorization", identitiesOk, identityAuthorization.detail),
   ];
   const doctorChecks = [
     doctorCheck({
@@ -144,6 +139,17 @@ export async function runStandaloneGatewayDoctor(input: {
       remediation: "Configure at least one channel provider for Standalone Gateway traffic.",
       evidence: { providerCount: input.config.providers.length },
     }),
+    doctorCheck({
+      code: "standalone_gateway.identity_authorization",
+      status: identitiesOk ? "pass" : "fail",
+      message: identityAuthorization.detail,
+      remediation: "Bootstrap at least one owner, admin, or member identity before accepting Standalone Gateway channel traffic.",
+      evidence: {
+        total: identityAuthorization.summary.total,
+        active: identityAuthorization.summary.active,
+        promptCapable: identityAuthorization.summary.promptCapable,
+      },
+    }),
   ];
   const ok = doctorChecks.every((check) => check.status === "pass" || check.status === "skipped");
   return {
@@ -157,6 +163,7 @@ export async function runStandaloneGatewayDoctor(input: {
       timeline("storage-migration", repository.ok ? "passed" : "failed", "standalone_gateway.repository.readiness", repository.detail),
       timeline("health-auth", opencode.ok ? "passed" : "failed", "standalone_gateway.opencode.health", opencode.detail),
       timeline("cloud-gateway-connector", providersOk ? "passed" : "failed", "standalone_gateway.providers.configured", `${input.config.providers.length} provider(s) configured.`),
+      timeline("config-build", identitiesOk ? "passed" : "failed", "standalone_gateway.identity_authorization", identityAuthorization.detail),
       timeline(ok ? "ready" : "error", ok ? "passed" : "failed", ok ? "standalone_gateway.ready" : "standalone_gateway.not_ready", ok ? "Standalone Gateway doctor passed." : "Standalone Gateway doctor failed."),
     ],
     runtimeStatus: {
@@ -174,4 +181,39 @@ export async function runStandaloneGatewayDoctor(input: {
     },
     redacted: true,
   };
+}
+
+async function identityAuthorizationSummary(
+  repository: StandaloneGatewayRepository | Pick<StandaloneGatewayRepository, "readiness">,
+  repositoryOk: boolean,
+  providers: readonly string[],
+): Promise<{
+  summary: { total: number; active: number; promptCapable: number };
+  detail: string;
+}> {
+  const empty = { total: 0, active: 0, promptCapable: 0 };
+  if (!repositoryOk) {
+    return {
+      summary: empty,
+      detail: "Identity authorization could not be checked because the repository is not ready.",
+    };
+  }
+  if (!("identityAuthorizationSummary" in repository)) {
+    return {
+      summary: empty,
+      detail: "Identity authorization summary is unavailable for this repository.",
+    };
+  }
+  try {
+    const summary = await repository.identityAuthorizationSummary({ providers });
+    return {
+      summary,
+      detail: `${summary.promptCapable} prompt-capable active identity/identities configured`,
+    };
+  } catch (error) {
+    return {
+      summary: empty,
+      detail: `Identity authorization check failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
 }

--- a/apps/standalone-gateway/src/main.ts
+++ b/apps/standalone-gateway/src/main.ts
@@ -5,6 +5,7 @@ import { runStandaloneGatewayDoctor } from "./doctor.js";
 import { createSdkOpenCodeAdapter } from "./opencode.js";
 import { createStandaloneGatewayPostgresRepository } from "./postgres-repository.js";
 import { createStandaloneProviderRegistry } from "./provider-registry.js";
+import { normalizeIdentityRole, normalizeIdentityStatus } from "./repository.js";
 import { createStandaloneGatewayRuntime } from "./runtime.js";
 import { createStandaloneGatewayServer } from "./server.js";
 import { runStandaloneGatewaySmoke } from "./smoke.js";
@@ -25,6 +26,25 @@ if (command === "smoke") {
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     await repository.close?.();
     process.exitCode = result.ok ? 0 : 1;
+  } else if (command === "identity") {
+    const action = process.argv[3] || "";
+    if (action !== "upsert") {
+      throw new Error("Unknown standalone gateway identity command. Use: identity upsert --provider <id> --external-user-id <id> --role <owner|admin|member|approver|viewer> [--status <active|disabled>] [--provider-workspace-id <id>].");
+    }
+    const args = parseArgs(process.argv.slice(4));
+    const provider = requiredArg(args, "provider");
+    if (!config.providers.some((configuredProvider) => configuredProvider.enabled && configuredProvider.id === provider)) {
+      throw new Error(`Standalone Gateway provider ${provider} is not configured or enabled.`);
+    }
+    const identity = await repository.upsertChannelIdentity({
+      provider,
+      externalUserId: requiredArg(args, "external-user-id"),
+      providerWorkspaceId: args["provider-workspace-id"] || null,
+      role: normalizeIdentityRole(requiredArg(args, "role")),
+      status: normalizeIdentityStatus(args.status || "active"),
+    });
+    process.stdout.write(`${JSON.stringify({ ok: true, identity }, null, 2)}\n`);
+    await repository.close?.();
   } else if (command === "serve") {
     const ownerId = `${hostname()}:${process.pid}`;
     const lease = await repository.acquireDaemonLease({
@@ -83,4 +103,23 @@ if (command === "smoke") {
     await repository.close?.();
     process.exitCode = 1;
   }
+}
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key?.startsWith("--")) throw new Error(`Unexpected argument ${key || ""}.`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${key}.`);
+    parsed[key.slice(2)] = value;
+    index += 1;
+  }
+  return parsed;
+}
+
+function requiredArg(args: Record<string, string>, key: string): string {
+  const value = args[key]?.trim();
+  if (!value) throw new Error(`Missing required --${key}.`);
+  return value;
 }

--- a/apps/standalone-gateway/src/opencode.test.ts
+++ b/apps/standalone-gateway/src/opencode.test.ts
@@ -1,0 +1,189 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createSdkOpenCodeAdapter } from "../dist/opencode.js";
+
+test("standalone OpenCode adapter falls back to HTTP when SDK prompt shape is unavailable", async () => {
+  const events: unknown[] = [];
+  const requests: Array<{ url: string; body: string }> = [];
+  const adapter = createSdkOpenCodeAdapter({
+    baseUrl: "http://127.0.0.1:4096",
+    loadSdk: async () => ({
+      createOpencodeClient: () => ({
+        session: {
+          create: async () => ({ id: "oc-1" }),
+        },
+      }),
+    }),
+    fetch: async (url, init) => {
+      requests.push({ url: String(url), body: String(init?.body || "") });
+      return Response.json({ type: "message", text: "accepted" });
+    },
+  });
+
+  await adapter.prompt({
+    opencodeSessionId: "oc-1",
+    text: "hello",
+    onEvent: (event) => events.push(event),
+  });
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.url, "http://127.0.0.1:4096/session/oc-1/prompt");
+  assert.deepEqual(JSON.parse(requests[0]?.body || "{}"), { text: "hello" });
+  assert.deepEqual(events, [{ type: "assistant.message", payload: { text: "accepted" } }]);
+});
+
+test("standalone OpenCode adapter throws on HTTP prompt non-2xx without synthetic success", async () => {
+  const events: unknown[] = [];
+  const adapter = createSdkOpenCodeAdapter({
+    baseUrl: "http://127.0.0.1:4096",
+    loadSdk: async () => ({}),
+    fetch: async () => new Response("token=super-secret failure", { status: 503 }),
+  });
+
+  await assert.rejects(() => adapter.prompt({
+    opencodeSessionId: "oc-1",
+    text: "hello",
+    onEvent: (event) => events.push(event),
+  }), /OpenCode prompt request returned HTTP 503: token=\[redacted\] failure/);
+
+  assert.deepEqual(events, []);
+});
+
+test("standalone OpenCode adapter redacts provider secrets from upstream prompt failures", async () => {
+  const providerKey = ["sk", "proj", "verysecretvalue"].join("-");
+  const routerKey = ["sk", "or", "secretvalue"].join("-");
+  const jsonProviderKey = ["sk", "proj", "jsonsecret"].join("-");
+  const adapter = createSdkOpenCodeAdapter({
+    baseUrl: "http://127.0.0.1:4096",
+    loadSdk: async () => ({}),
+    fetch: async () => new Response(
+      `Incorrect API key provided: ${providerKey} api_key:"${routerKey}" {"password":"hunter2","apiKey":"${jsonProviderKey}"} authorization=Basic dXNlcjpzZWNyZXQ= postgres://gateway:super-secret-password@127.0.0.1/db`,
+      { status: 401 },
+    ),
+  });
+
+  await assert.rejects(async () => adapter.prompt({
+    opencodeSessionId: "oc-1",
+    text: "hello",
+    onEvent: () => undefined,
+  }), (error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    assert.match(message, /OpenCode prompt request returned HTTP 401/);
+    assert.equal(message.includes(providerKey), false);
+    assert.equal(message.includes(routerKey), false);
+    assert.equal(message.includes("hunter2"), false);
+    assert.equal(message.includes(jsonProviderKey), false);
+    assert.equal(message.includes("dXNlcjpzZWNyZXQ="), false);
+    assert.equal(message.includes("super-secret-password"), false);
+    assert.match(message, /\[redacted\]/);
+    return true;
+  });
+});
+
+test("standalone OpenCode adapter throws on prompt network failure", async () => {
+  const adapter = createSdkOpenCodeAdapter({
+    baseUrl: "http://127.0.0.1:4096",
+    loadSdk: async () => ({}),
+    fetch: async () => {
+      throw new Error("connect ECONNREFUSED authorization=Bearer abc123456789");
+    },
+  });
+
+  await assert.rejects(() => adapter.prompt({
+    opencodeSessionId: "oc-1",
+    text: "hello",
+    onEvent: () => undefined,
+  }), /OpenCode prompt request failed: connect ECONNREFUSED authorization=Bearer \[redacted\]/);
+});
+
+test("standalone OpenCode adapter projects SDK fields-response parts", async () => {
+  const events: unknown[] = [];
+  const adapter = createSdkOpenCodeAdapter({
+    baseUrl: "http://127.0.0.1:4096",
+    loadSdk: async () => ({
+      createOpencodeClient: () => ({
+        session: {
+          prompt: async () => ({
+            data: {
+              parts: [
+                { type: "reasoning", text: "hidden reasoning text" },
+                { type: "text", text: "sdk assistant content" },
+              ],
+            },
+            error: null,
+            response: { status: 200 },
+          }),
+        },
+      }),
+    }),
+    fetch: async () => {
+      throw new Error("fetch should not be used");
+    },
+  });
+
+  await adapter.prompt({
+    opencodeSessionId: "oc-1",
+    text: "hello",
+    onEvent: (event) => events.push(event),
+  });
+
+  assert.deepEqual(events, [{ type: "assistant.message", payload: { text: "sdk assistant content" } }]);
+  assert.equal(JSON.stringify(events).includes("hidden reasoning text"), false);
+});
+
+test("standalone OpenCode adapter throws on SDK fields-response errors", async () => {
+  let fetchCalled = false;
+  const adapter = createSdkOpenCodeAdapter({
+    baseUrl: "http://127.0.0.1:4096",
+    loadSdk: async () => ({
+      createOpencodeClient: () => ({
+        session: {
+          prompt: async () => ({
+            data: null,
+            error: { message: "provider rejected token=super-secret" },
+            response: { status: 503 },
+          }),
+        },
+      }),
+    }),
+    fetch: async () => {
+      fetchCalled = true;
+      return Response.json({});
+    },
+  });
+
+  await assert.rejects(() => adapter.prompt({
+    opencodeSessionId: "oc-1",
+    text: "hello",
+    onEvent: () => undefined,
+  }), /OpenCode SDK prompt failed: provider rejected token=\[redacted\]/);
+  assert.equal(fetchCalled, false);
+});
+
+test("standalone OpenCode adapter does not fall back when SDK prompt itself fails", async () => {
+  let fetchCalled = false;
+  const adapter = createSdkOpenCodeAdapter({
+    baseUrl: "http://127.0.0.1:4096",
+    loadSdk: async () => ({
+      createOpencodeClient: () => ({
+        session: {
+          prompt: async () => {
+            throw new Error("sdk transport failed Authorization: Bearer sdk-secret-token");
+          },
+        },
+      }),
+    }),
+    fetch: async () => {
+      fetchCalled = true;
+      return Response.json({});
+    },
+  });
+
+  await assert.rejects(() => adapter.prompt({
+    opencodeSessionId: "oc-1",
+    text: "hello",
+    onEvent: () => undefined,
+  }), /OpenCode SDK prompt failed: sdk transport failed Authorization: Bearer \[redacted\]/);
+  assert.equal(fetchCalled, false);
+});

--- a/apps/standalone-gateway/src/opencode.ts
+++ b/apps/standalone-gateway/src/opencode.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { assertPrivateOpenCodeEndpoint } from "./network-policy.js";
+import { redactSecretText } from "./redaction.js";
 import type { StandaloneRuntimeEvent } from "./types.js";
 
 export interface StandaloneOpenCodeAdapter {
@@ -33,16 +34,23 @@ export function normalizeOpenCodeEvent(event: unknown): StandaloneRuntimeEvent[]
   if (type.includes("tool") && type.includes("fail")) {
     return [{ type: "tool.failed", entityId: stringField(record, "id"), payload: publicPayload(record) }];
   }
+  if (type.includes("reasoning") || type.includes("thought")) return [];
   const text = stringField(record, "text") || stringField(record, "content") || stringField(record, "message");
   if (text) return [{ type: "assistant.message", payload: { text } }];
   return [];
 }
 
-export function createSdkOpenCodeAdapter(options: { baseUrl: string }): StandaloneOpenCodeAdapter {
+export function createSdkOpenCodeAdapter(options: {
+  baseUrl: string;
+  fetch?: typeof globalThis.fetch;
+  loadSdk?: () => Promise<SdkV2Module>;
+}): StandaloneOpenCodeAdapter {
   const baseUrl = assertPrivateOpenCodeEndpoint(options.baseUrl).toString().replace(/\/$/, "");
+  const fetchImpl = options.fetch || globalThis.fetch;
+  const loadSdk = options.loadSdk || (async () => await import("@opencode-ai/sdk/v2") as unknown as SdkV2Module);
   return {
     async createSession(input) {
-      const sdk = await import("@opencode-ai/sdk/v2") as unknown as SdkV2Module;
+      const sdk = await loadSdk();
       const clientFactory = sdk.createOpencodeClient;
       if (typeof clientFactory === "function") {
         const client = clientFactory({ baseUrl });
@@ -53,39 +61,32 @@ export function createSdkOpenCodeAdapter(options: { baseUrl: string }): Standalo
       return { opencodeSessionId: randomUUID() };
     },
     async prompt(input) {
-      try {
-        const sdk = await import("@opencode-ai/sdk/v2") as unknown as SdkV2Module;
-        const client = sdk.createOpencodeClient?.({ baseUrl });
-        const prompted = await client?.session?.prompt?.({
-          sessionID: input.opencodeSessionId,
-          parts: [{ type: "text", text: input.text }],
-        });
-        let emitted = false;
-        for (const event of normalizeOpenCodeEvent(prompted)) {
-          emitted = true;
-          await input.onEvent(event);
+      const sdk = await loadSdk();
+      const clientFactory = sdk.createOpencodeClient;
+      if (typeof clientFactory === "function") {
+        const client = clientFactory({ baseUrl });
+        if (typeof client?.session?.prompt === "function") {
+          let prompted: unknown;
+          try {
+            prompted = await client.session.prompt({
+              sessionID: input.opencodeSessionId,
+              parts: [{ type: "text", text: input.text }],
+            });
+          } catch (error) {
+            throw new Error(`OpenCode SDK prompt failed: ${redactOpenCodeError(error)}`, { cause: error });
+          }
+          const error = sdkPromptError(prompted);
+          if (error) throw error;
+          for (const event of normalizeOpenCodePromptResult(prompted)) {
+            await input.onEvent(event);
+          }
+          return;
         }
-        if (emitted) return;
-      } catch {
-        // Fall back to the HTTP compatibility path below; older SDK/runtime
-        // pairs may not expose the same prompt method shape.
       }
-      const response = await fetch(`${baseUrl}/session/${encodeURIComponent(input.opencodeSessionId)}/prompt`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ text: input.text }),
-      }).catch(() => null);
-      if (!response?.ok) {
-        await input.onEvent({ type: "assistant.message", payload: { text: "Prompt accepted by the standalone Gateway runtime." } });
-        return;
-      }
-      const payload = await response.json().catch(() => ({}));
-      for (const event of normalizeOpenCodeEvent(payload)) await input.onEvent(event);
+      await promptViaHttp(baseUrl, fetchImpl, input);
     },
     async health() {
-      const response = await fetch(`${baseUrl}/health`).catch((error: unknown) => error);
-      if (response instanceof Response) return { ok: response.ok, detail: `OpenCode HTTP ${response.status}` };
-      return { ok: false, detail: response instanceof Error ? response.message : String(response) };
+      return healthViaHttp(baseUrl, fetchImpl);
     },
   };
 }
@@ -98,6 +99,91 @@ type SdkV2Module = {
     };
   };
 };
+
+async function promptViaHttp(
+  baseUrl: string,
+  fetchImpl: typeof globalThis.fetch,
+  input: Parameters<StandaloneOpenCodeAdapter["prompt"]>[0],
+): Promise<void> {
+  const response = await fetchImpl(`${baseUrl}/session/${encodeURIComponent(input.opencodeSessionId)}/prompt`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text: input.text }),
+  }).catch((error: unknown) => {
+    throw new Error(`OpenCode prompt request failed: ${redactOpenCodeError(error)}`);
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`OpenCode prompt request returned HTTP ${response.status}${detail ? `: ${redactOpenCodeText(detail)}` : ""}`);
+  }
+  if (response.status === 204) return;
+  const payload = await response.json().catch(() => ({}));
+  for (const event of normalizeOpenCodeEvent(payload)) await input.onEvent(event);
+}
+
+async function healthViaHttp(baseUrl: string, fetchImpl: typeof globalThis.fetch): Promise<{ ok: boolean; detail: string }> {
+  const response = await fetchImpl(`${baseUrl}/health`).catch((error: unknown) => error);
+  if (response instanceof Response) return { ok: response.ok, detail: `OpenCode HTTP ${response.status}` };
+  return { ok: false, detail: response instanceof Error ? redactOpenCodeText(response.message) : redactOpenCodeText(String(response)) };
+}
+
+function redactOpenCodeError(error: unknown): string {
+  return redactOpenCodeText(error instanceof Error ? error.message : String(error));
+}
+
+function redactOpenCodeText(value: string): string {
+  return redactSecretText(value, 500);
+}
+
+function normalizeOpenCodePromptResult(result: unknown): StandaloneRuntimeEvent[] {
+  const events = [...normalizeOpenCodeEvent(result)];
+  const record = objectRecord(result);
+  const data = unwrapData(result);
+  if (data !== record) events.push(...normalizeOpenCodeEvent(data));
+  for (const value of arrayField(data, "parts")) events.push(...normalizeOpenCodePart(value));
+  for (const value of arrayField(data, "events")) events.push(...normalizeOpenCodeEvent(value));
+  for (const value of arrayField(data, "messages")) events.push(...normalizeOpenCodeEvent(value));
+  return events;
+}
+
+function normalizeOpenCodePart(value: unknown): StandaloneRuntimeEvent[] {
+  const record = objectRecord(value);
+  const type = String(record.type || "");
+  if (type && type !== "text") return [];
+  return normalizeOpenCodeEvent(record);
+}
+
+function sdkPromptError(result: unknown): Error | null {
+  const record = objectRecord(result);
+  const error = record.error;
+  if (error) {
+    return new Error(`OpenCode SDK prompt failed: ${redactOpenCodeText(errorMessage(error))}`);
+  }
+  const response = objectRecord(record.response);
+  const status = typeof response.status === "number" ? response.status : null;
+  if (status !== null && status >= 400) {
+    return new Error(`OpenCode SDK prompt returned HTTP ${status}.`);
+  }
+  return null;
+}
+
+function arrayField(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  const record = objectRecord(error);
+  return stringField(record, "message")
+    || stringField(record, "detail")
+    || JSON.stringify(record);
+}
 
 export class FakeStandaloneOpenCodeAdapter implements StandaloneOpenCodeAdapter {
   readonly prompts: Array<{ opencodeSessionId: string; text: string }> = [];

--- a/apps/standalone-gateway/src/postgres-repository.ts
+++ b/apps/standalone-gateway/src/postgres-repository.ts
@@ -1,16 +1,27 @@
 import { randomUUID } from "node:crypto";
 
 import { standaloneGatewayMigrations } from "./schema.js";
-import { redactRecord } from "./repository.js";
+import {
+  canIdentityPrompt,
+  normalizeIdentityRole,
+  normalizeIdentityStatus,
+  normalizeWorkspaceId,
+  redactRecord,
+} from "./repository.js";
+import { redactSecretText } from "./redaction.js";
 import type { StandaloneGatewayRepository } from "./repository.js";
 import type {
   StandaloneGatewayAuditRecord,
+  StandaloneGatewayChannelIdentityRecord,
   StandaloneGatewayDaemonLease,
   StandaloneGatewayDashboardSnapshot,
   StandaloneGatewayEventRecord,
   StandaloneGatewayEventType,
   StandaloneGatewayJobKind,
   StandaloneGatewayJobRecord,
+  StandaloneGatewayIdentityAuthorizationSummary,
+  StandaloneGatewayIdentityRole,
+  StandaloneGatewayIdentityStatus,
   StandaloneGatewaySessionRecord,
   StandalonePromptInput,
 } from "./types.js";
@@ -34,7 +45,16 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
   constructor(private readonly pool: PgLikePool) {}
 
   async migrate(): Promise<void> {
+    await this.pool.query(`CREATE TABLE IF NOT EXISTS standalone_gateway_schema_migrations (
+      id text PRIMARY KEY,
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )`);
     for (const migration of standaloneGatewayMigrations) {
+      const applied = await this.pool.query(
+        "SELECT id FROM standalone_gateway_schema_migrations WHERE id = $1",
+        [migration.id],
+      );
+      if (applied.rows.length > 0) continue;
       await this.withTransaction(async (client) => {
         await client.query(migration.sql);
         await client.query(
@@ -97,14 +117,15 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
   async findOrCreateSession(input: StandalonePromptInput & { title?: string; now?: Date }): Promise<StandaloneGatewaySessionRecord> {
     const now = (input.now || new Date()).toISOString();
     const externalThreadId = input.target.threadId || input.target.chatId;
+    const providerWorkspaceId = normalizeWorkspaceId(input.providerWorkspaceId) || "";
     return this.withTransaction(async (client) => {
       const result = await client.query<SessionRow>(
         `INSERT INTO standalone_gateway_sessions (
            session_id, title, status, provider, provider_kind, channel_binding_id,
-           external_user_id, external_chat_id, external_thread_id, created_at, updated_at
+           provider_workspace_id, external_user_id, external_chat_id, external_thread_id, created_at, updated_at
          )
-         VALUES ($1, $2, 'idle', $3, $4, $5, $6, $7, $8, $9, $9)
-         ON CONFLICT (provider, external_chat_id, external_thread_id) DO UPDATE
+         VALUES ($1, $2, 'idle', $3, $4, $5, $6, $7, $8, $9, $10, $10)
+         ON CONFLICT (provider, provider_workspace_id, external_chat_id, external_thread_id) DO UPDATE
          SET updated_at = standalone_gateway_sessions.updated_at
          RETURNING *`,
         [
@@ -113,6 +134,7 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
           input.provider,
           input.providerKind,
           input.channelBindingId,
+          providerWorkspaceId,
           input.externalUserId,
           input.target.chatId,
           externalThreadId,
@@ -236,10 +258,73 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
            updated_at = $5
        WHERE job_id = $1 AND claim_token = $2
        RETURNING *`,
-      [input.jobId, input.claimToken, input.status, input.lastError || null, (input.now || new Date()).toISOString()],
+      [input.jobId, input.claimToken, input.status, input.lastError ? redactSecretText(input.lastError) : null, (input.now || new Date()).toISOString()],
     );
     if (!result.rows[0]) throw new Error("Cannot finish standalone gateway job with a stale claim token.");
     return jobFromRow(result.rows[0]);
+  }
+
+  async findChannelIdentity(input: { provider: string; externalUserId: string; providerWorkspaceId?: string | null }): Promise<StandaloneGatewayChannelIdentityRecord | null> {
+    const providerWorkspaceId = normalizeWorkspaceId(input.providerWorkspaceId) || "";
+    const result = await this.pool.query<IdentityRow>(
+      `SELECT *
+       FROM standalone_gateway_channel_identities
+       WHERE provider = $1
+         AND external_user_id = $2
+         AND provider_workspace_id = $3
+       LIMIT 1`,
+      [input.provider, input.externalUserId, providerWorkspaceId],
+    );
+    return result.rows[0] ? identityFromRow(result.rows[0]) : null;
+  }
+
+  async upsertChannelIdentity(input: {
+    identityId?: string;
+    provider: string;
+    externalUserId: string;
+    providerWorkspaceId?: string | null;
+    role: StandaloneGatewayIdentityRole;
+    status?: StandaloneGatewayIdentityStatus;
+    now?: Date;
+  }): Promise<StandaloneGatewayChannelIdentityRecord> {
+    const now = (input.now || new Date()).toISOString();
+    const result = await this.pool.query<IdentityRow>(
+      `INSERT INTO standalone_gateway_channel_identities (
+         identity_id, provider, provider_workspace_id, external_user_id, role, status, created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+       ON CONFLICT (provider, provider_workspace_id, external_user_id) DO UPDATE
+       SET role = EXCLUDED.role,
+           status = EXCLUDED.status,
+           updated_at = EXCLUDED.updated_at
+       RETURNING *`,
+      [
+        input.identityId || randomUUID(),
+        input.provider,
+        normalizeWorkspaceId(input.providerWorkspaceId) || "",
+        input.externalUserId,
+        normalizeIdentityRole(input.role),
+        normalizeIdentityStatus(input.status || "active"),
+        now,
+      ],
+    );
+    return identityFromRow(result.rows[0]!);
+  }
+
+  async identityAuthorizationSummary(input: { providers?: readonly string[] } = {}): Promise<StandaloneGatewayIdentityAuthorizationSummary> {
+    const providers = input.providers?.length ? [...new Set(input.providers)] : null;
+    const result = await this.pool.query<IdentityRow>(
+      providers
+        ? "SELECT * FROM standalone_gateway_channel_identities WHERE provider = ANY($1::text[])"
+        : "SELECT * FROM standalone_gateway_channel_identities",
+      providers ? [providers] : undefined,
+    );
+    const identities = result.rows.map(identityFromRow);
+    return {
+      total: identities.length,
+      active: identities.filter((identity) => identity.status === "active").length,
+      promptCapable: identities.filter(canIdentityPrompt).length,
+    };
   }
 
   async listSessions(limit = 50): Promise<StandaloneGatewaySessionRecord[]> {
@@ -252,14 +337,16 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
 
   async dashboardSnapshot(limit = 50): Promise<StandaloneGatewayDashboardSnapshot> {
     const safeLimit = Math.max(1, Math.min(200, limit));
-    const [sessions, jobs, audits] = await Promise.all([
+    const [sessions, identities, jobs, audits] = await Promise.all([
       this.listSessions(safeLimit),
+      this.pool.query<IdentityRow>("SELECT * FROM standalone_gateway_channel_identities ORDER BY updated_at DESC LIMIT $1", [safeLimit]),
       this.pool.query<JobRow>("SELECT * FROM standalone_gateway_jobs ORDER BY updated_at DESC LIMIT $1", [safeLimit]),
       this.pool.query<AuditRow>("SELECT * FROM standalone_gateway_audit_events ORDER BY created_at DESC LIMIT $1", [safeLimit]),
     ]);
     return {
       generatedAt: new Date().toISOString(),
       sessions,
+      identities: identities.rows.map(identityFromRow),
       jobs: jobs.rows.map(jobFromRow),
       audits: audits.rows.map(auditFromRow),
     };
@@ -318,6 +405,7 @@ type SessionRow = {
   status: StandaloneGatewaySessionRecord["status"];
   provider: StandaloneGatewaySessionRecord["provider"];
   provider_kind: StandaloneGatewaySessionRecord["providerKind"];
+  provider_workspace_id?: string | null;
   channel_binding_id: string;
   external_user_id: string;
   external_chat_id: string;
@@ -352,6 +440,17 @@ type JobRow = {
   updated_at: string | Date;
 };
 
+type IdentityRow = {
+  identity_id: string;
+  provider: StandaloneGatewayChannelIdentityRecord["provider"];
+  provider_workspace_id?: string | null;
+  external_user_id: string;
+  role: StandaloneGatewayIdentityRole;
+  status?: StandaloneGatewayIdentityStatus;
+  created_at: string | Date;
+  updated_at: string | Date;
+};
+
 type AuditRow = {
   audit_id: string;
   action: string;
@@ -378,6 +477,7 @@ function sessionFromRow(row: SessionRow): StandaloneGatewaySessionRecord {
     status: row.status,
     provider: row.provider,
     providerKind: row.provider_kind,
+    providerWorkspaceId: normalizeWorkspaceId(row.provider_workspace_id),
     channelBindingId: row.channel_binding_id,
     externalUserId: row.external_user_id,
     externalChatId: row.external_chat_id,
@@ -412,6 +512,19 @@ function jobFromRow(row: JobRow): StandaloneGatewayJobRecord {
     attemptCount: Number(row.attempt_count),
     availableAt: iso(row.available_at),
     lastError: row.last_error,
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  };
+}
+
+function identityFromRow(row: IdentityRow): StandaloneGatewayChannelIdentityRecord {
+  return {
+    identityId: row.identity_id,
+    provider: row.provider,
+    externalUserId: row.external_user_id,
+    providerWorkspaceId: normalizeWorkspaceId(row.provider_workspace_id),
+    role: normalizeIdentityRole(row.role),
+    status: normalizeIdentityStatus(row.status || "active"),
     createdAt: iso(row.created_at),
     updatedAt: iso(row.updated_at),
   };

--- a/apps/standalone-gateway/src/redaction.ts
+++ b/apps/standalone-gateway/src/redaction.ts
@@ -1,0 +1,53 @@
+const SECRET_KEY_PATTERN = /token|secret|password|credential|authorization|api[_-]?key/i;
+
+const SECRET_TEXT_PATTERNS: Array<{
+  pattern: RegExp;
+  replacement: string | ((match: string, ...captures: string[]) => string);
+}> = [
+  {
+    pattern: /\b(Authorization:\s*(?:Bearer|Basic)\s+)\S+/gi,
+    replacement: "$1[redacted]",
+  },
+  {
+    pattern: /(["']?authorization["']?\s*[:=]\s*["']?(?:Bearer|Basic)\s+)[^'"\s&,;}]+/gi,
+    replacement: "$1[redacted]",
+  },
+  {
+    pattern: /\b((?:Bearer|Basic)\s+)[A-Za-z0-9._~+/=-]+/g,
+    replacement: "$1[redacted]",
+  },
+  {
+    pattern: /(["']?(?:token|secret|password|credential|api[_-]?key)["']?\s*[:=]\s*['"]?)[^'"\s&,;}]+/gi,
+    replacement: "$1[redacted]",
+  },
+  {
+    pattern: /:\/\/([^:\s/@]+):([^@\s/]+)@/g,
+    replacement: (match, user) => `://${user}:[redacted]@`,
+  },
+  {
+    pattern: /\b(?:sk|ghp|xoxb|occ|ocgw)-[A-Za-z0-9_-]{8,}\b/g,
+    replacement: "[redacted]",
+  },
+];
+
+export function redactSecretText(value: string, maxLength = 2000): string {
+  return SECRET_TEXT_PATTERNS.reduce((text, entry) => {
+    if (typeof entry.replacement === "string") return text.replace(entry.pattern, entry.replacement);
+    return text.replace(entry.pattern, entry.replacement);
+  }, value).slice(0, maxLength);
+}
+
+export function redactSecretRecord(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [
+    key,
+    redactSecretValue(key, value),
+  ]));
+}
+
+function redactSecretValue(key: string, value: unknown): unknown {
+  if (SECRET_KEY_PATTERN.test(key)) return "[redacted]";
+  if (typeof value === "string") return redactSecretText(value);
+  if (Array.isArray(value)) return value.map((entry) => redactSecretValue(key, entry));
+  if (value && typeof value === "object") return redactSecretRecord(value as Record<string, unknown>);
+  return value;
+}

--- a/apps/standalone-gateway/src/repository.test.ts
+++ b/apps/standalone-gateway/src/repository.test.ts
@@ -6,12 +6,57 @@ import { exportStandaloneGatewayBackup } from "../dist/backup.js";
 import { PostgresStandaloneGatewayRepository } from "../dist/postgres-repository.js";
 import { InMemoryStandaloneGatewayRepository } from "../dist/repository.js";
 import { describeStandaloneRetention } from "../dist/retention.js";
+import { standaloneGatewayMigrations } from "../dist/schema.js";
+
+function fakeProviderKey(...parts: string[]) {
+  return parts.join("-");
+}
 
 test("standalone repository persists sessions, events, jobs, leases, and redacted audit state", async () => {
   const repository = new InMemoryStandaloneGatewayRepository();
+  const providerKey = fakeProviderKey("sk", "proj", "verysecretvalue");
+  const routerKey = fakeProviderKey("sk", "or", "secretvalue");
+  const jsonProviderKey = fakeProviderKey("sk", "proj", "jsonsecret");
   const lease = await repository.acquireDaemonLease({ leaseId: "daemon", ownerId: "node-1", ttlMs: 30_000 });
   assert.ok(lease?.leaseToken);
   assert.equal(await repository.acquireDaemonLease({ leaseId: "daemon", ownerId: "node-2", ttlMs: 30_000 }), null);
+  const identity = await repository.upsertChannelIdentity({
+    provider: "webhook-ci",
+    externalUserId: "user-1",
+    role: "member",
+  });
+  assert.equal(identity.status, "active");
+  assert.equal((await repository.findChannelIdentity({
+    provider: "webhook-ci",
+    externalUserId: "user-1",
+  }))?.identityId, identity.identityId);
+  assert.equal(await repository.findChannelIdentity({
+    provider: "webhook-ci",
+    externalUserId: "user-1",
+    providerWorkspaceId: "workspace-1",
+  }), null);
+  await repository.upsertChannelIdentity({
+    provider: "webhook-ci",
+    externalUserId: "user-1",
+    providerWorkspaceId: "workspace-1",
+    role: "viewer",
+    status: "disabled",
+  });
+  await repository.upsertChannelIdentity({
+    provider: "webhook-other",
+    externalUserId: "user-1",
+    role: "admin",
+  });
+  assert.equal((await repository.findChannelIdentity({
+    provider: "webhook-ci",
+    externalUserId: "user-1",
+    providerWorkspaceId: "workspace-1",
+  }))?.role, "viewer");
+  assert.deepEqual(await repository.identityAuthorizationSummary({ providers: ["webhook-ci"] }), {
+    total: 2,
+    active: 1,
+    promptCapable: 1,
+  });
 
   const session = await repository.findOrCreateSession({
     provider: "webhook-ci",
@@ -40,11 +85,30 @@ test("standalone repository persists sessions, events, jobs, leases, and redacte
   const claimed = await repository.claimNextJob({ claimedBy: "worker-1", ttlMs: 30_000 });
   assert.equal(claimed?.jobId, job.jobId);
   await repository.finishJob({ jobId: job.jobId, claimToken: claimed!.claimToken!, status: "completed" });
+  const failedJob = await repository.enqueueJob({ kind: "prompt", sessionId: session.sessionId, payload: { note: "provider failure" } });
+  const failedClaim = await repository.claimNextJob({ claimedBy: "worker-1", ttlMs: 30_000 });
+  assert.equal(failedClaim?.jobId, failedJob.jobId);
+  await repository.finishJob({
+    jobId: failedJob.jobId,
+    claimToken: failedClaim!.claimToken!,
+    status: "failed",
+    lastError: `Incorrect API key provided: ${providerKey} api_key:"${routerKey}" {"password":"hunter2","apiKey":"${jsonProviderKey}"} upstream failed with Bearer bare-secret-token and Basic dXNlcjpzZWNyZXQ= postgres://gateway:super-secret-password@127.0.0.1/db`,
+  });
   await repository.recordAudit("test.audit", "user-1", { token: "secret-token", note: "ok" });
 
   const snapshot = await repository.dashboardSnapshot();
   assert.equal(snapshot.sessions.length, 1);
-  assert.equal(snapshot.jobs[0]?.status, "completed");
+  assert.equal(snapshot.identities.length, 3);
+  assert.equal(snapshot.jobs.find((entry) => entry.jobId === job.jobId)?.status, "completed");
+  const persistedFailure = snapshot.jobs.find((entry) => entry.jobId === failedJob.jobId)?.lastError || "";
+  assert.equal(persistedFailure.includes(providerKey), false);
+  assert.equal(persistedFailure.includes(routerKey), false);
+  assert.equal(persistedFailure.includes("hunter2"), false);
+  assert.equal(persistedFailure.includes(jsonProviderKey), false);
+  assert.equal(persistedFailure.includes("bare-secret-token"), false);
+  assert.equal(persistedFailure.includes("dXNlcjpzZWNyZXQ="), false);
+  assert.equal(persistedFailure.includes("super-secret-password"), false);
+  assert.match(persistedFailure, /\[redacted\]/);
   assert.equal(snapshot.audits[0]?.metadata.token, "[redacted]");
 });
 
@@ -56,6 +120,7 @@ test("standalone package barrel exposes backup, retention, and repository adapte
       return {
         generatedAt: "2026-06-05T00:00:00.000Z",
         sessions: [{ sessionId: "session-1" }],
+        identities: [{ identityId: "identity-1" }],
         jobs: [{ jobId: "job-1" }],
         audits: [{ auditId: "audit-1" }],
       };
@@ -65,6 +130,7 @@ test("standalone package barrel exposes backup, retention, and repository adapte
   assert.equal(requestedLimit, 500);
   assert.equal(backup.format, "open-cowork-standalone-gateway-backup-v1");
   assert.deepEqual(backup.sessions, [{ sessionId: "session-1" }]);
+  assert.deepEqual(backup.identities, [{ identityId: "identity-1" }]);
   assert.deepEqual(describeStandaloneRetention({
     retention: { sessionDays: 30, artifactDays: 7, auditDays: 90 },
   } as never), ["sessions:30d", "artifacts:7d", "audit:90d"]);
@@ -75,6 +141,8 @@ test("standalone package barrel exposes backup, retention, and repository adapte
 
 test("postgres repository adapter maps readiness and daemon lease rows without a live database", async () => {
   const now = new Date("2026-06-05T00:00:00.000Z");
+  const routerKey = fakeProviderKey("sk", "or", "secretvalue");
+  const jsonProviderKey = fakeProviderKey("sk", "proj", "jsonsecret");
   const queries: string[] = [];
   const pool = {
     async query(sql: string, params?: unknown[]) {
@@ -89,6 +157,118 @@ test("postgres repository adapter maps readiness and daemon lease rows without a
             expires_at: "2026-06-05T00:00:30.000Z",
             updated_at: now,
           }],
+        };
+      }
+      if (sql.includes("INSERT INTO standalone_gateway_channel_identities")) {
+        return {
+          rows: [{
+            identity_id: params?.[0],
+            provider: params?.[1],
+            provider_workspace_id: params?.[2],
+            external_user_id: params?.[3],
+            role: params?.[4],
+            status: params?.[5],
+            created_at: now,
+            updated_at: now,
+          }],
+        };
+      }
+      if (sql.includes("FROM standalone_gateway_sessions ORDER BY updated_at DESC")) {
+        return {
+          rows: [{
+            session_id: "session-1",
+            opencode_session_id: "oc-1",
+            title: "Session",
+            status: "idle",
+            provider: "webhook-ci",
+            provider_kind: "webhook",
+            provider_workspace_id: "workspace-1",
+            channel_binding_id: "webhook",
+            external_user_id: "user-1",
+            external_chat_id: "chat-1",
+            external_thread_id: "thread-1",
+            last_event_sequence: 0,
+            created_at: now,
+            updated_at: now,
+          }],
+        };
+      }
+      if (sql.includes("FROM standalone_gateway_channel_identities ORDER BY updated_at DESC")) {
+        return {
+          rows: [{
+            identity_id: "identity-1",
+            provider: "webhook-ci",
+            provider_workspace_id: "workspace-1",
+            external_user_id: "user-1",
+            role: "member",
+            status: "active",
+            created_at: now,
+            updated_at: now,
+          }],
+        };
+      }
+      if (sql.includes("FROM standalone_gateway_jobs ORDER BY updated_at DESC")) {
+        return {
+          rows: [{
+            job_id: "job-1",
+            kind: "prompt",
+            status: "completed",
+            session_id: "session-1",
+            payload: {},
+            claimed_by: null,
+            claim_token: null,
+            claim_expires_at: null,
+            attempt_count: 1,
+            available_at: now,
+            last_error: null,
+            created_at: now,
+            updated_at: now,
+          }],
+        };
+      }
+      if (sql.includes("FROM standalone_gateway_audit_events ORDER BY created_at DESC")) {
+        return {
+          rows: [{
+            audit_id: "audit-1",
+            action: "test.audit",
+            actor: "user-1",
+            metadata: {},
+            created_at: now,
+          }],
+        };
+      }
+      if (sql.includes("FROM standalone_gateway_channel_identities")) {
+        return {
+          rows: [{
+            identity_id: "identity-1",
+            provider: params?.[0] || "webhook-ci",
+            provider_workspace_id: params?.[2] || "",
+            external_user_id: params?.[1] || "user-1",
+            role: "member",
+            status: "active",
+            created_at: now,
+            updated_at: now,
+          }],
+        };
+      }
+      if (sql.includes("UPDATE standalone_gateway_jobs")) {
+        return {
+          rows: [{
+            job_id: params?.[0],
+            kind: "prompt",
+            status: params?.[2],
+            session_id: "session-1",
+            payload: {},
+            claimed_by: "worker-1",
+            claim_token: params?.[1],
+            claim_expires_at: null,
+            attempt_count: 1,
+            available_at: now,
+            last_error: params?.[3],
+            created_at: now,
+            updated_at: now,
+          }],
+          rowCount: 1,
         };
       }
       if (sql.includes("DELETE FROM standalone_gateway_daemon_leases")) return { rowCount: 1, rows: [] };
@@ -107,5 +287,64 @@ test("postgres repository adapter maps readiness and daemon lease rows without a
     updatedAt: "2026-06-05T00:00:00.000Z",
   });
   assert.equal(await repository.releaseDaemonLease({ leaseId: "daemon", ownerId: "node-1", leaseToken: "lease-token" }), true);
+  const identity = await repository.upsertChannelIdentity({
+    provider: "webhook-ci",
+    externalUserId: "user-1",
+    providerWorkspaceId: "workspace-1",
+    role: "admin",
+  });
+  assert.equal(identity.providerWorkspaceId, "workspace-1");
+  assert.equal((await repository.findChannelIdentity({
+    provider: "webhook-ci",
+    externalUserId: "user-1",
+    providerWorkspaceId: "workspace-1",
+  }))?.role, "member");
+  const failedJob = await repository.finishJob({
+    jobId: "job-1",
+    claimToken: "claim-token",
+    status: "failed",
+    lastError: `OpenCode failed with Bearer bare-secret-token {"password":"hunter2","apiKey":"${jsonProviderKey}"} api_key:"${routerKey}"`,
+    now,
+  });
+  assert.equal(failedJob.lastError?.includes("bare-secret-token"), false);
+  assert.equal(failedJob.lastError?.includes(routerKey), false);
+  assert.equal(failedJob.lastError?.includes("hunter2"), false);
+  assert.equal(failedJob.lastError?.includes(jsonProviderKey), false);
+  assert.match(failedJob.lastError || "", /\[redacted\]/);
+  const snapshot = await repository.dashboardSnapshot();
+  assert.equal(snapshot.identities[0]?.identityId, "identity-1");
   assert.ok(queries.some((query) => query.includes("RETURNING *")));
+});
+
+test("postgres repository migrations skip applied migration ids before replaying old indexes", async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const pool = {
+    async query(sql: string, params?: unknown[]) {
+      queries.push({ sql, params });
+      if (sql.includes("CREATE TABLE IF NOT EXISTS standalone_gateway_schema_migrations")) return { rows: [], rowCount: 0 };
+      if (sql.includes("SELECT id FROM standalone_gateway_schema_migrations")) {
+        return { rows: params?.[0] === "0001_standalone_gateway_core" ? [{ id: params[0] }] : [], rowCount: params?.[0] === "0001_standalone_gateway_core" ? 1 : 0 };
+      }
+      if (sql === "BEGIN" || sql === "COMMIT" || sql === "ROLLBACK") return { rows: [], rowCount: 0 };
+      if (sql.includes("INSERT INTO standalone_gateway_schema_migrations")) return { rows: [], rowCount: 1 };
+      if (sql.includes("0001_standalone_gateway_core")) throw new Error("migration id should not be embedded in SQL");
+      if (sql.includes("standalone_gateway_sessions_provider_workspace_thread_unique")) return { rows: [], rowCount: 0 };
+      throw new Error(`Unexpected migration query: ${sql}`);
+    },
+  };
+  const repository = new PostgresStandaloneGatewayRepository(pool as never);
+
+  await repository.migrate();
+
+  const migrationSql = queries.map((query) => query.sql).join("\n");
+  assert.equal(migrationSql.includes("CREATE UNIQUE INDEX IF NOT EXISTS standalone_gateway_sessions_provider_thread_unique"), false);
+  assert.equal(migrationSql.includes("standalone_gateway_sessions_provider_workspace_thread_unique"), true);
+});
+
+test("standalone identity migration drops legacy provider-user uniqueness by catalog lookup", () => {
+  const migration = standaloneGatewayMigrations.find((entry) => entry.id === "0002_standalone_gateway_identity_authorization");
+  assert.ok(migration);
+  assert.match(migration.sql, /pg_constraint/);
+  assert.match(migration.sql, /DROP CONSTRAINT %I/);
+  assert.match(migration.sql, /ARRAY\['provider', 'external_user_id'\]/);
 });

--- a/apps/standalone-gateway/src/repository.ts
+++ b/apps/standalone-gateway/src/repository.ts
@@ -1,13 +1,18 @@
 import { randomUUID } from "node:crypto";
 
+import { redactSecretRecord, redactSecretText } from "./redaction.js";
 import type {
   StandaloneGatewayAuditRecord,
+  StandaloneGatewayChannelIdentityRecord,
   StandaloneGatewayDaemonLease,
   StandaloneGatewayDashboardSnapshot,
   StandaloneGatewayEventRecord,
   StandaloneGatewayEventType,
   StandaloneGatewayJobKind,
   StandaloneGatewayJobRecord,
+  StandaloneGatewayIdentityAuthorizationSummary,
+  StandaloneGatewayIdentityRole,
+  StandaloneGatewayIdentityStatus,
   StandaloneGatewaySessionRecord,
   StandalonePromptInput,
 } from "./types.js";
@@ -24,6 +29,17 @@ export interface StandaloneGatewayRepository {
   enqueueJob(input: { kind: StandaloneGatewayJobKind; sessionId?: string | null; payload?: Record<string, unknown>; availableAt?: Date; now?: Date }): Promise<StandaloneGatewayJobRecord>;
   claimNextJob(input: { claimedBy: string; ttlMs: number; now?: Date }): Promise<StandaloneGatewayJobRecord | null>;
   finishJob(input: { jobId: string; claimToken: string; status: "completed" | "failed" | "dead"; lastError?: string | null; now?: Date }): Promise<StandaloneGatewayJobRecord>;
+  findChannelIdentity(input: { provider: string; externalUserId: string; providerWorkspaceId?: string | null }): Promise<StandaloneGatewayChannelIdentityRecord | null>;
+  upsertChannelIdentity(input: {
+    identityId?: string;
+    provider: string;
+    externalUserId: string;
+    providerWorkspaceId?: string | null;
+    role: StandaloneGatewayIdentityRole;
+    status?: StandaloneGatewayIdentityStatus;
+    now?: Date;
+  }): Promise<StandaloneGatewayChannelIdentityRecord>;
+  identityAuthorizationSummary(input?: { providers?: readonly string[] }): Promise<StandaloneGatewayIdentityAuthorizationSummary>;
   listSessions(limit?: number): Promise<StandaloneGatewaySessionRecord[]>;
   dashboardSnapshot(limit?: number): Promise<StandaloneGatewayDashboardSnapshot>;
   recordAudit(action: string, actor: string, metadata?: Record<string, unknown>, now?: Date): Promise<StandaloneGatewayAuditRecord>;
@@ -35,6 +51,7 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
   private readonly events = new Map<string, StandaloneGatewayEventRecord[]>();
   private readonly jobs = new Map<string, StandaloneGatewayJobRecord>();
   private readonly leases = new Map<string, StandaloneGatewayDaemonLease>();
+  private readonly identities = new Map<string, StandaloneGatewayChannelIdentityRecord>();
   private readonly audits: StandaloneGatewayAuditRecord[] = [];
 
   async migrate(): Promise<void> {}
@@ -80,8 +97,10 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
 
   async findOrCreateSession(input: StandalonePromptInput & { title?: string; now?: Date }): Promise<StandaloneGatewaySessionRecord> {
     const externalThreadId = input.target.threadId || input.target.chatId;
+    const providerWorkspaceId = normalizeWorkspaceId(input.providerWorkspaceId);
     const existing = [...this.sessions.values()].find((session) =>
       session.provider === input.provider &&
+      session.providerWorkspaceId === providerWorkspaceId &&
       session.externalChatId === input.target.chatId &&
       session.externalThreadId === externalThreadId
     );
@@ -94,6 +113,7 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
       status: "idle",
       provider: input.provider,
       providerKind: input.providerKind,
+      providerWorkspaceId,
       channelBindingId: input.channelBindingId,
       externalUserId: input.externalUserId,
       externalChatId: input.target.chatId,
@@ -192,6 +212,52 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
     return cloneJob(updated);
   }
 
+  async findChannelIdentity(input: { provider: string; externalUserId: string; providerWorkspaceId?: string | null }): Promise<StandaloneGatewayChannelIdentityRecord | null> {
+    const workspaceId = normalizeWorkspaceId(input.providerWorkspaceId);
+    const exact = this.identities.get(identityKey(input.provider, workspaceId, input.externalUserId));
+    if (exact) return cloneIdentity(exact);
+    return null;
+  }
+
+  async upsertChannelIdentity(input: {
+    identityId?: string;
+    provider: string;
+    externalUserId: string;
+    providerWorkspaceId?: string | null;
+    role: StandaloneGatewayIdentityRole;
+    status?: StandaloneGatewayIdentityStatus;
+    now?: Date;
+  }): Promise<StandaloneGatewayChannelIdentityRecord> {
+    const role = normalizeIdentityRole(input.role);
+    const status = normalizeIdentityStatus(input.status || "active");
+    const providerWorkspaceId = normalizeWorkspaceId(input.providerWorkspaceId);
+    const key = identityKey(input.provider, providerWorkspaceId, input.externalUserId);
+    const existing = this.identities.get(key);
+    const now = (input.now || new Date()).toISOString();
+    const identity: StandaloneGatewayChannelIdentityRecord = {
+      identityId: existing?.identityId || input.identityId || randomUUID(),
+      provider: input.provider as StandaloneGatewayChannelIdentityRecord["provider"],
+      externalUserId: input.externalUserId,
+      providerWorkspaceId,
+      role,
+      status,
+      createdAt: existing?.createdAt || now,
+      updatedAt: now,
+    };
+    this.identities.set(key, identity);
+    return cloneIdentity(identity);
+  }
+
+  async identityAuthorizationSummary(input: { providers?: readonly string[] } = {}): Promise<StandaloneGatewayIdentityAuthorizationSummary> {
+    const providers = input.providers?.length ? new Set(input.providers) : null;
+    const identities = [...this.identities.values()].filter((identity) => !providers || providers.has(identity.provider));
+    return {
+      total: identities.length,
+      active: identities.filter((identity) => identity.status === "active").length,
+      promptCapable: identities.filter((identity) => canIdentityPrompt(identity)).length,
+    };
+  }
+
   async listSessions(limit = 50): Promise<StandaloneGatewaySessionRecord[]> {
     return [...this.sessions.values()]
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
@@ -203,6 +269,7 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
     return {
       generatedAt: new Date().toISOString(),
       sessions: await this.listSessions(limit),
+      identities: [...this.identities.values()].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)).slice(0, limit).map(cloneIdentity),
       jobs: [...this.jobs.values()].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)).slice(0, limit).map(cloneJob),
       audits: this.audits.slice(-limit).reverse().map((audit) => ({ ...audit, metadata: { ...audit.metadata } })),
     };
@@ -228,26 +295,40 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
 }
 
 export function redactRecord(input: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(input).map(([key, value]) => [
-    key,
-    redactValue(key, value),
-  ]));
-}
-
-function redactValue(key: string, value: unknown): unknown {
-  if (/token|secret|password|credential|authorization|api[_-]?key/i.test(key)) return "[redacted]";
-  if (typeof value === "string") return redactText(value);
-  if (Array.isArray(value)) return value.map((entry) => redactValue(key, entry));
-  if (value && typeof value === "object") return redactRecord(value as Record<string, unknown>);
-  return value;
+  return redactSecretRecord(input);
 }
 
 function redactText(value: string): string {
-  return value
-    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, "Bearer [redacted]")
-    .replace(/(token|secret|password|api[_-]?key)=([^&\s]+)/gi, "$1=[redacted]");
+  return redactSecretText(value);
 }
 
 function cloneJob(job: StandaloneGatewayJobRecord): StandaloneGatewayJobRecord {
   return { ...job, payload: { ...job.payload } };
+}
+
+export function canIdentityPrompt(identity: Pick<StandaloneGatewayChannelIdentityRecord, "role" | "status">): boolean {
+  return identity.status === "active" && (identity.role === "owner" || identity.role === "admin" || identity.role === "member");
+}
+
+export function normalizeIdentityRole(value: string): StandaloneGatewayIdentityRole {
+  if (value === "owner" || value === "admin" || value === "member" || value === "approver" || value === "viewer") return value;
+  throw new Error(`Unsupported standalone gateway identity role ${value}.`);
+}
+
+export function normalizeIdentityStatus(value: string): StandaloneGatewayIdentityStatus {
+  if (value === "active" || value === "disabled") return value;
+  throw new Error(`Unsupported standalone gateway identity status ${value}.`);
+}
+
+export function normalizeWorkspaceId(value: string | null | undefined): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text || null;
+}
+
+function identityKey(provider: string, providerWorkspaceId: string | null, externalUserId: string): string {
+  return `${provider}\0${providerWorkspaceId || ""}\0${externalUserId}`;
+}
+
+function cloneIdentity(identity: StandaloneGatewayChannelIdentityRecord): StandaloneGatewayChannelIdentityRecord {
+  return { ...identity };
 }

--- a/apps/standalone-gateway/src/runtime.test.ts
+++ b/apps/standalone-gateway/src/runtime.test.ts
@@ -7,6 +7,7 @@ import type { IncomingChannelMessage } from "@open-cowork/gateway-channel";
 import { FakeStandaloneOpenCodeAdapter, type StandaloneOpenCodeAdapter } from "../dist/opencode.js";
 import { InMemoryStandaloneGatewayRepository } from "../dist/repository.js";
 import { createStandaloneGatewayRuntime } from "../dist/runtime.js";
+import type { StandaloneGatewayIdentityRole, StandaloneGatewayIdentityStatus } from "../dist/types.js";
 
 function message(id: string, text: string): IncomingChannelMessage {
   return {
@@ -36,8 +37,22 @@ const providerConfig = {
   settings: {},
 };
 
+async function authorize(
+  repository: InMemoryStandaloneGatewayRepository,
+  input: { role?: StandaloneGatewayIdentityRole; status?: StandaloneGatewayIdentityStatus; externalUserId?: string; providerWorkspaceId?: string } = {},
+) {
+  return repository.upsertChannelIdentity({
+    provider: "cli-standalone",
+    externalUserId: input.externalUserId || "user-1",
+    providerWorkspaceId: input.providerWorkspaceId,
+    role: input.role || "member",
+    status: input.status || "active",
+  });
+}
+
 test("standalone runtime prompts private OpenCode and persists projected events", async () => {
   const repository = new InMemoryStandaloneGatewayRepository();
+  await authorize(repository);
   const opencode = new FakeStandaloneOpenCodeAdapter();
   const runtime = createStandaloneGatewayRuntime({ repository, opencode });
   const provider = new FakeChannelProvider({ id: "cli-standalone" });
@@ -53,6 +68,7 @@ test("standalone runtime prompts private OpenCode and persists projected events"
 
 test("standalone runtime serializes concurrent work for one channel session", async () => {
   const repository = new InMemoryStandaloneGatewayRepository();
+  await authorize(repository);
   let createCount = 0;
   let activePrompts = 0;
   let maxActivePrompts = 0;
@@ -96,6 +112,7 @@ test("standalone runtime serializes concurrent work for one channel session", as
 
 test("standalone runtime records failed prompts durably", async () => {
   const repository = new InMemoryStandaloneGatewayRepository();
+  await authorize(repository);
   const runtime = createStandaloneGatewayRuntime({
     repository,
     opencode: {
@@ -124,6 +141,7 @@ test("standalone runtime records failed prompts durably", async () => {
 
 test("standalone runtime records failed session creation durably", async () => {
   const repository = new InMemoryStandaloneGatewayRepository();
+  await authorize(repository);
   let promptCalled = false;
   const runtime = createStandaloneGatewayRuntime({
     repository,
@@ -152,3 +170,92 @@ test("standalone runtime records failed session creation durably", async () => {
   assert.equal(snapshot.sessions[0]?.opencodeSessionId, null);
   assert.equal(snapshot.audits[0]?.action, "standalone.prompt.failed");
 });
+
+test("standalone runtime isolates sessions by provider workspace", async () => {
+  const repository = new InMemoryStandaloneGatewayRepository();
+  await authorize(repository, { providerWorkspaceId: "workspace-a" });
+  await authorize(repository, { providerWorkspaceId: "workspace-b" });
+  const opencode = new FakeStandaloneOpenCodeAdapter();
+  const runtime = createStandaloneGatewayRuntime({ repository, opencode });
+  const provider = new FakeChannelProvider({ id: "cli-standalone" });
+
+  await runtime.handleMessage(provider, providerConfig, {
+    ...message("message-a", "workspace a"),
+    raw: { workspace_id: "workspace-a" },
+  });
+  await runtime.handleMessage(provider, providerConfig, {
+    ...message("message-b", "workspace b"),
+    raw: { workspace_id: "workspace-b" },
+  });
+
+  const sessions = await repository.listSessions();
+  assert.equal(opencode.prompts.length, 2);
+  assert.equal(sessions.length, 2);
+  assert.deepEqual(new Set(sessions.map((session) => session.providerWorkspaceId)), new Set(["workspace-a", "workspace-b"]));
+});
+
+test("standalone runtime denies unknown identities before session creation", async () => {
+  const repository = new InMemoryStandaloneGatewayRepository();
+  const opencode = new FakeStandaloneOpenCodeAdapter();
+  const runtime = createStandaloneGatewayRuntime({ repository, opencode });
+  const provider = new FakeChannelProvider({ id: "cli-standalone" });
+
+  await runtime.handleMessage(provider, providerConfig, message("message-1", "do not prompt"));
+
+  const snapshot = await repository.dashboardSnapshot();
+  assert.equal(opencode.prompts.length, 0);
+  assert.equal(snapshot.sessions.length, 0);
+  assert.equal(snapshot.audits[0]?.action, "standalone.prompt.denied");
+  assert.equal(snapshot.audits[0]?.metadata.reason, "identity_not_found");
+});
+
+for (const role of ["viewer", "approver"] as const) {
+  test(`standalone runtime denies ${role} identities before prompting`, async () => {
+    const repository = new InMemoryStandaloneGatewayRepository();
+    await authorize(repository, { role });
+    const opencode = new FakeStandaloneOpenCodeAdapter();
+    const runtime = createStandaloneGatewayRuntime({ repository, opencode });
+    const provider = new FakeChannelProvider({ id: "cli-standalone" });
+
+    await runtime.handleMessage(provider, providerConfig, message(`message-${role}`, "do not prompt"));
+
+    const snapshot = await repository.dashboardSnapshot();
+    assert.equal(opencode.prompts.length, 0);
+    assert.equal(snapshot.sessions.length, 0);
+    assert.equal(snapshot.audits[0]?.metadata.reason, "role_not_allowed");
+    assert.equal(snapshot.audits[0]?.metadata.identityRole, role);
+  });
+}
+
+test("standalone runtime denies disabled identities before prompting", async () => {
+  const repository = new InMemoryStandaloneGatewayRepository();
+  await authorize(repository, { role: "member", status: "disabled" });
+  const opencode = new FakeStandaloneOpenCodeAdapter();
+  const runtime = createStandaloneGatewayRuntime({ repository, opencode });
+  const provider = new FakeChannelProvider({ id: "cli-standalone" });
+
+  await runtime.handleMessage(provider, providerConfig, message("message-disabled", "do not prompt"));
+
+  const snapshot = await repository.dashboardSnapshot();
+  assert.equal(opencode.prompts.length, 0);
+  assert.equal(snapshot.sessions.length, 0);
+  assert.equal(snapshot.audits[0]?.metadata.reason, "identity_disabled");
+  assert.equal(snapshot.audits[0]?.metadata.identityStatus, "disabled");
+});
+
+for (const role of ["member", "admin", "owner"] as const) {
+  test(`standalone runtime allows ${role} identities to prompt`, async () => {
+    const repository = new InMemoryStandaloneGatewayRepository();
+    await authorize(repository, { role });
+    const opencode = new FakeStandaloneOpenCodeAdapter();
+    const runtime = createStandaloneGatewayRuntime({ repository, opencode });
+    const provider = new FakeChannelProvider({ id: "cli-standalone" });
+
+    await runtime.handleMessage(provider, providerConfig, message(`message-${role}`, "prompt"));
+
+    const snapshot = await repository.dashboardSnapshot();
+    assert.equal(opencode.prompts.length, 1);
+    assert.equal(snapshot.sessions.length, 1);
+    assert.equal(snapshot.audits[0]?.action, "standalone.prompt");
+  });
+}

--- a/apps/standalone-gateway/src/runtime.ts
+++ b/apps/standalone-gateway/src/runtime.ts
@@ -1,6 +1,7 @@
 import type { ChannelProvider, IncomingChannelMessage } from "@open-cowork/gateway-channel";
 
 import type { StandaloneOpenCodeAdapter } from "./opencode.js";
+import { canIdentityPrompt } from "./repository.js";
 import type { StandaloneGatewayRepository } from "./repository.js";
 import type { StandaloneGatewayProviderConfig, StandaloneRuntimeEvent } from "./types.js";
 
@@ -31,12 +32,32 @@ export function createStandaloneGatewayRuntime(input: {
     async handleMessage(provider, providerConfig, message) {
       const text = message.text.trim();
       if (!text) return;
+      const providerWorkspaceId = providerWorkspaceIdFromMessage(message);
       const externalThreadId = message.target.threadId || message.target.chatId;
-      const sessionQueueKey = `${provider.id}\0${message.target.chatId}\0${externalThreadId}`;
+      const sessionQueueKey = `${provider.id}\0${providerWorkspaceId || ""}\0${message.target.chatId}\0${externalThreadId}`;
       await runSerialized(sessionQueueKey, async () => {
+        const identity = await repository.findChannelIdentity({
+          provider: provider.id,
+          externalUserId: message.sender.providerUserId,
+          providerWorkspaceId,
+        });
+        if (!identity || !canIdentityPrompt(identity)) {
+          await repository.recordAudit("standalone.prompt.denied", message.sender.providerUserId, {
+            provider: provider.id,
+            providerKind: provider.kind,
+            channelBindingId: providerConfig.channelBindingId,
+            providerWorkspaceId,
+            reason: identity ? promptDenyReason(identity) : "identity_not_found",
+            identityId: identity?.identityId,
+            identityRole: identity?.role,
+            identityStatus: identity?.status,
+          });
+          return;
+        }
         const session = await repository.findOrCreateSession({
           provider: provider.id,
           providerKind: provider.kind,
+          providerWorkspaceId,
           channelBindingId: providerConfig.channelBindingId,
           target: message.target,
           externalUserId: message.sender.providerUserId,
@@ -111,6 +132,31 @@ export function createStandaloneGatewayRuntime(input: {
       return processed;
     },
   };
+}
+
+function promptDenyReason(identity: { role: string; status: string }): string {
+  if (identity.status !== "active") return "identity_disabled";
+  return "role_not_allowed";
+}
+
+function providerWorkspaceIdFromMessage(message: IncomingChannelMessage): string | null {
+  const raw = objectRecord(message.raw);
+  return stringField(raw, "workspace_id")
+    || stringField(raw, "workspaceId")
+    || stringField(raw, "team_id")
+    || stringField(objectRecord(raw.team), "id")
+    || stringField(raw, "guild_id")
+    || stringField(raw, "server_id")
+    || null;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 async function appendRuntimeEvent(repository: StandaloneGatewayRepository, sessionId: string, event: StandaloneRuntimeEvent): Promise<void> {

--- a/apps/standalone-gateway/src/schema.ts
+++ b/apps/standalone-gateway/src/schema.ts
@@ -1,4 +1,4 @@
-export const STANDALONE_GATEWAY_SCHEMA_VERSION = 1;
+export const STANDALONE_GATEWAY_SCHEMA_VERSION = 2;
 
 export const standaloneGatewayMigrations = [{
   id: "0001_standalone_gateway_core",
@@ -117,6 +117,76 @@ CREATE INDEX IF NOT EXISTS standalone_gateway_jobs_claim_idx
   ON standalone_gateway_jobs (status, available_at, claim_expires_at);
 CREATE INDEX IF NOT EXISTS standalone_gateway_audit_created_idx
   ON standalone_gateway_audit_events (created_at DESC);
+`,
+}, {
+  id: "0002_standalone_gateway_identity_authorization",
+  sql: `
+ALTER TABLE standalone_gateway_channel_identities
+  ADD COLUMN IF NOT EXISTS provider_workspace_id text NOT NULL DEFAULT '';
+
+ALTER TABLE standalone_gateway_channel_identities
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'active';
+
+DO $$
+DECLARE
+  legacy_constraint_name text;
+BEGIN
+  FOR legacy_constraint_name IN
+    SELECT constraint_row.conname
+    FROM pg_constraint constraint_row
+    JOIN pg_class table_row ON table_row.oid = constraint_row.conrelid
+    WHERE table_row.relname = 'standalone_gateway_channel_identities'
+      AND constraint_row.contype = 'u'
+      AND (
+        SELECT array_agg(attribute_row.attname::text ORDER BY constraint_column.ordinality)
+        FROM unnest(constraint_row.conkey) WITH ORDINALITY AS constraint_column(attnum, ordinality)
+        JOIN pg_attribute attribute_row
+          ON attribute_row.attrelid = table_row.oid
+         AND attribute_row.attnum = constraint_column.attnum
+      ) = ARRAY['provider', 'external_user_id']
+  LOOP
+    EXECUTE format('ALTER TABLE standalone_gateway_channel_identities DROP CONSTRAINT %I', legacy_constraint_name);
+  END LOOP;
+END $$;
+
+ALTER TABLE standalone_gateway_sessions
+  ADD COLUMN IF NOT EXISTS provider_workspace_id text NOT NULL DEFAULT '';
+
+DROP INDEX IF EXISTS standalone_gateway_sessions_provider_thread_unique;
+DROP INDEX IF EXISTS standalone_gateway_sessions_provider_thread_idx;
+
+CREATE INDEX IF NOT EXISTS standalone_gateway_sessions_provider_workspace_thread_idx
+  ON standalone_gateway_sessions (provider, provider_workspace_id, external_chat_id, external_thread_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS standalone_gateway_sessions_provider_workspace_thread_unique
+  ON standalone_gateway_sessions (provider, provider_workspace_id, external_chat_id, external_thread_id);
+
+ALTER TABLE standalone_gateway_channel_identities
+  DROP CONSTRAINT IF EXISTS standalone_gateway_channel_identities_provider_external_user_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS standalone_gateway_channel_identities_provider_workspace_user_unique
+  ON standalone_gateway_channel_identities (provider, provider_workspace_id, external_user_id);
+
+CREATE INDEX IF NOT EXISTS standalone_gateway_channel_identities_prompt_auth_idx
+  ON standalone_gateway_channel_identities (provider, status, role);
+
+DO $$
+BEGIN
+  ALTER TABLE standalone_gateway_channel_identities
+    ADD CONSTRAINT standalone_gateway_channel_identities_role_check
+    CHECK (role IN ('owner', 'admin', 'member', 'approver', 'viewer'));
+EXCEPTION WHEN duplicate_object THEN
+  NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE standalone_gateway_channel_identities
+    ADD CONSTRAINT standalone_gateway_channel_identities_status_check
+    CHECK (status IN ('active', 'disabled'));
+EXCEPTION WHEN duplicate_object THEN
+  NULL;
+END $$;
 `,
 }];
 

--- a/apps/standalone-gateway/src/server.test.ts
+++ b/apps/standalone-gateway/src/server.test.ts
@@ -17,6 +17,11 @@ test("standalone server exposes health, readiness, and admin-gated dashboard", a
     OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
   });
   const repository = new InMemoryStandaloneGatewayRepository();
+  await repository.upsertChannelIdentity({
+    provider: "webhook",
+    externalUserId: "user-1",
+    role: "member",
+  });
   const opencode = new FakeStandaloneOpenCodeAdapter();
   const providers = createStandaloneProviderRegistry(config);
   const server = createStandaloneGatewayServer({ config, repository, opencode, providers });

--- a/apps/standalone-gateway/src/smoke.ts
+++ b/apps/standalone-gateway/src/smoke.ts
@@ -6,6 +6,11 @@ import { createStandaloneGatewayRuntime } from "./runtime.js";
 
 export async function runStandaloneGatewaySmoke(): Promise<{ ok: true; sessionCount: number; promptCount: number }> {
   const repository = new InMemoryStandaloneGatewayRepository();
+  await repository.upsertChannelIdentity({
+    provider: "cli-standalone",
+    externalUserId: "smoke-user",
+    role: "member",
+  });
   const opencode = new FakeStandaloneOpenCodeAdapter();
   const runtime = createStandaloneGatewayRuntime({ repository, opencode });
   const provider = new FakeChannelProvider({ id: "cli-standalone" });

--- a/apps/standalone-gateway/src/types.ts
+++ b/apps/standalone-gateway/src/types.ts
@@ -5,6 +5,8 @@ import type {
 } from "@open-cowork/gateway-channel";
 
 export type StandaloneGatewayStatus = "idle" | "running" | "blocked" | "failed" | "completed";
+export type StandaloneGatewayIdentityRole = "owner" | "admin" | "member" | "approver" | "viewer";
+export type StandaloneGatewayIdentityStatus = "active" | "disabled";
 export type StandaloneGatewayEventType =
   | "session.created"
   | "user.message"
@@ -67,6 +69,7 @@ export interface StandaloneGatewaySessionRecord {
   status: StandaloneGatewayStatus;
   provider: ChannelProviderId;
   providerKind: ChannelProviderKind;
+  providerWorkspaceId: string | null;
   channelBindingId: string;
   externalUserId: string;
   externalChatId: string;
@@ -117,9 +120,27 @@ export interface StandaloneGatewayAuditRecord {
   createdAt: string;
 }
 
+export interface StandaloneGatewayChannelIdentityRecord {
+  identityId: string;
+  provider: ChannelProviderId;
+  externalUserId: string;
+  providerWorkspaceId: string | null;
+  role: StandaloneGatewayIdentityRole;
+  status: StandaloneGatewayIdentityStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StandaloneGatewayIdentityAuthorizationSummary {
+  total: number;
+  active: number;
+  promptCapable: number;
+}
+
 export interface StandaloneGatewayDashboardSnapshot {
   generatedAt: string;
   sessions: StandaloneGatewaySessionRecord[];
+  identities: StandaloneGatewayChannelIdentityRecord[];
   jobs: StandaloneGatewayJobRecord[];
   audits: StandaloneGatewayAuditRecord[];
 }
@@ -127,6 +148,7 @@ export interface StandaloneGatewayDashboardSnapshot {
 export interface StandalonePromptInput {
   provider: ChannelProviderId;
   providerKind: ChannelProviderKind;
+  providerWorkspaceId?: string | null;
   channelBindingId: string;
   target: ChannelTarget;
   externalUserId: string;

--- a/docs/standalone-gateway.md
+++ b/docs/standalone-gateway.md
@@ -118,12 +118,55 @@ The signed webhook provider can bridge custom channels. It requires
 `OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET` and validates incoming
 provider payloads before they can prompt private OpenCode.
 
+Provider webhook verification authenticates the provider request, not the human
+or channel actor. Standalone Gateway denies every inbound prompt until the
+sender has an active prompt-capable identity in Gateway Postgres.
+
+Bootstrap the first identity before accepting traffic:
+
+```bash
+pnpm --filter @open-cowork/standalone-gateway identity -- \
+  upsert \
+  --provider webhook \
+  --external-user-id "$CHANNEL_USER_ID" \
+  --role admin
+```
+
+For provider workspaces such as Slack teams or Discord guilds, scope the
+identity when the provider supplies that workspace id:
+
+```bash
+pnpm --filter @open-cowork/standalone-gateway identity -- \
+  upsert \
+  --provider slack-prod \
+  --provider-workspace-id "$SLACK_TEAM_ID" \
+  --external-user-id "$SLACK_USER_ID" \
+  --role member
+```
+
+An unscoped identity only authorizes provider messages that do not include a
+provider workspace id. It is not a global fallback for every workspace on the
+same provider.
+
+Roles are deliberately small:
+
+- `owner` and `admin` can prompt, approve, and manage identities.
+- `member` can prompt from their channel identity.
+- `approver` can approve/respond when approval flows are wired, but cannot start
+  private OpenCode work.
+- `viewer` and disabled identities cannot prompt.
+
+The doctor check fails until at least one active `owner`, `admin`, or `member`
+identity exists. Denied prompt attempts are audited as
+`standalone.prompt.denied` without storing message text.
+
 ## Backup And Retention
 
 Backups must cover:
 
 - Postgres database
 - artifact storage path or bucket
+- exported standalone manifest rows for sessions, identities, jobs, and audits
 - private env/secret inventory, stored separately from the backup manifest
 
 Retention windows are explicit:


### PR DESCRIPTION
## Summary

Part of #758.

Closes #759.
Closes #760.

- Add fail-closed Standalone Gateway identity authorization before session creation or OpenCode prompting.
- Scope channel identities and sessions by provider workspace so tenant traffic cannot reuse another workspace's identity or session.
- Add schema migration v2 for workspace-aware sessions and identity role/status authorization metadata.
- Fix OpenCode prompt adapter error handling so SDK/HTTP prompt failures are not converted into synthetic assistant success.
- Add shared secret redaction for upstream errors, persisted job/session/audit state, doctor output, and Postgres `last_error` writes.
- Filter SDK reasoning parts so they are not projected as assistant messages.
- Add CLI/docs for bootstrapping Standalone Gateway identities.

## Verification

- `pnpm --filter @open-cowork/standalone-gateway typecheck`
- `pnpm --filter @open-cowork/standalone-gateway test` (42 tests)
- `uv run mkdocs build --strict`
- `git diff --check origin/master...HEAD`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/master` — clean: no accepted/actionable findings reported

## Notes

Unrelated local desktop packaging/prototype files were left unstaged and are not part of this PR.