### PR TITLE
Harden gateway provider event idempotency

### DIFF
--- a/apps/desktop/src/main/cloud/channel-provider-types.ts
+++ b/apps/desktop/src/main/cloud/channel-provider-types.ts
@@ -1,0 +1,54 @@
+export type ChannelProviderKind = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
+export type ChannelProviderId = ChannelProviderKind | `${ChannelProviderKind}-${string}` | `${string}-${string}`
+export type ChannelProviderEventType = 'message' | 'command' | 'interaction'
+export type ChannelProviderEventStatus = 'received' | 'processing' | 'processed' | 'failed'
+
+export type ChannelProviderEventRecord = {
+  eventId: string
+  orgId: string
+  provider: ChannelProviderId
+  providerInstanceId: string
+  externalWorkspaceId: string | null
+  providerEventId: string
+  eventType: ChannelProviderEventType
+  status: ChannelProviderEventStatus
+  claimedBy: string | null
+  claimExpiresAt: string | null
+  attemptCount: number
+  retryable: boolean
+  lastError: string | null
+  metadata: Record<string, unknown>
+  processedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelProviderEventClaimResult = {
+  event: ChannelProviderEventRecord
+  claimed: boolean
+  duplicate: boolean
+}
+
+export type ClaimChannelProviderEventInput = {
+  eventId?: string
+  orgId: string
+  provider: ChannelProviderId
+  providerInstanceId: string
+  externalWorkspaceId?: string | null
+  providerEventId: string
+  eventType: ChannelProviderEventType
+  claimedBy: string
+  ttlMs?: number
+  now?: Date
+  metadata?: Record<string, unknown>
+}
+
+export type CompleteChannelProviderEventInput = {
+  orgId: string
+  eventId: string
+  claimedBy: string
+  status: Extract<ChannelProviderEventStatus, 'processed' | 'failed'>
+  retryable?: boolean
+  lastError?: string | null
+  updatedAt?: Date
+}

--- a/apps/desktop/src/main/cloud/channel-provider-utils.ts
+++ b/apps/desktop/src/main/cloud/channel-provider-utils.ts
@@ -1,0 +1,33 @@
+import type { ChannelProviderId } from './channel-provider-types.ts'
+
+export function normalizeChannelProviderId(value: unknown): ChannelProviderId {
+  const provider = normalizeText(value, 64, 'Channel provider') as ChannelProviderId
+  if (isChannelProviderId(provider)) return provider
+  throw new Error(`Unsupported channel provider ${provider}.`)
+}
+
+export function channelScopeKey(provider: ChannelProviderId, externalWorkspaceId: string | null, externalId: string) {
+  return key(provider, externalWorkspaceId || '', externalId)
+}
+
+export function channelThreadKey(provider: ChannelProviderId, externalWorkspaceId: string | null, externalChatId: string, externalThreadId: string) {
+  return key(provider, externalWorkspaceId || '', externalChatId, externalThreadId)
+}
+
+function isChannelProviderId(value: string): value is ChannelProviderId {
+  return ['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(value)
+    || (/^[a-z][a-z0-9_-]{1,63}$/.test(value) && value.includes('-'))
+}
+
+function normalizeText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (normalized.length > maxLength) {
+    throw new Error(`${label} exceeds ${maxLength} characters.`)
+  }
+  return normalized
+}
+
+function key(...parts: string[]) {
+  return parts.join('\0')
+}

--- a/apps/desktop/src/main/cloud/control-plane-domains/channels.ts
+++ b/apps/desktop/src/main/cloud/control-plane-domains/channels.ts
@@ -25,6 +25,8 @@ export type ChannelControlPlaneStore = Pick<ControlPlaneStore,
   | 'listChannelDeliveries'
   | 'claimNextChannelDelivery'
   | 'ackChannelDelivery'
+  | 'claimChannelProviderEvent'
+  | 'completeChannelProviderEvent'
   | 'getSession'
   | 'getSessionProjection'
   | 'enqueueSessionCommand'

--- a/apps/desktop/src/main/cloud/control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/control-plane-store.ts
@@ -23,5 +23,6 @@ export {
   hashManagedWorkerCredential,
 } from './in-memory-domains/workers.ts'
 export type { WorkspaceEventCursorRecord } from './workspace-event-cursor.ts'
+export type * from './channel-provider-types.ts'
 export type * from './in-memory-control-plane-store.ts'
 export type * from './managed-worker-types.ts'

--- a/apps/desktop/src/main/cloud/http-routes/channels.ts
+++ b/apps/desktop/src/main/cloud/http-routes/channels.ts
@@ -233,6 +233,7 @@ export async function handleChannelsApiRoute(input: {
         bindingId,
         text,
         agent: tools.readString(body.agent),
+        commandId: tools.readString(body.commandId),
         identityId: tools.readString(body.identityId),
         provider: tools.readChannelProvider(body.provider),
         externalWorkspaceId: tools.readString(body.externalWorkspaceId),
@@ -337,6 +338,55 @@ export async function handleChannelsApiRoute(input: {
           ...(processingError ? { processingError } : {}),
         },
       )
+      return true
+    }
+  }
+
+  if (collection === 'provider-events') {
+    if (itemId === 'claim' && !itemAction && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const provider = tools.readChannelProvider(body.provider)
+      const providerInstanceId = tools.readString(body.providerInstanceId)
+      const providerEventId = tools.readString(body.providerEventId)
+      const eventType = tools.readEnum(body.eventType, ['message', 'command', 'interaction'] as const)
+      const claimedBy = tools.readString(body.claimedBy)
+      if (!provider || !providerInstanceId || !providerEventId || !eventType || !claimedBy) {
+        tools.writeError(res, 400, 'Provider event claim requires provider, providerInstanceId, providerEventId, eventType, and claimedBy.', options.corsOrigin)
+        return true
+      }
+      const result = await options.service.claimChannelProviderEvent(context.principal, {
+        provider,
+        providerInstanceId,
+        externalWorkspaceId: tools.readString(body.externalWorkspaceId),
+        providerEventId,
+        eventType,
+        claimedBy,
+        ttlMs: tools.readNonNegativeInteger(body.ttlMs),
+        metadata: tools.readRecord(body.metadata) || {},
+      })
+      tools.writeJson(res, 200, result, options.corsOrigin)
+      return true
+    }
+    if (itemId && itemAction === 'complete' && req.method === 'POST') {
+      const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+      const status = tools.readEnum(body.status, ['processed', 'failed'] as const)
+      const claimedBy = tools.readString(body.claimedBy)
+      if (!status || !claimedBy) {
+        tools.writeError(res, 400, 'Provider event completion requires claimedBy and status processed or failed.', options.corsOrigin)
+        return true
+      }
+      const event = await options.service.completeChannelProviderEvent(context.principal, {
+        eventId: itemId,
+        claimedBy,
+        status,
+        retryable: body.retryable === undefined ? undefined : body.retryable === true,
+        lastError: tools.readString(body.lastError),
+      })
+      if (!event) {
+        tools.writeError(res, 404, 'Provider event claim was not found.', options.corsOrigin)
+        return true
+      }
+      tools.writeJson(res, 200, { event }, options.corsOrigin)
       return true
     }
   }

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -28,6 +28,7 @@ import type {
 } from './managed-worker-types.ts'
 import { InMemoryManagedWorkersDomain } from './in-memory-domains/workers.ts'
 import { InMemoryQuotaDomain } from './in-memory-domains/quotas.ts'
+import { InMemoryChannelProviderEventsDomain } from './in-memory-domains/channel-provider-events.ts'
 import { redactAuditMetadata } from './audit-redaction.ts'
 import {
   generateChannelInteractionToken,
@@ -39,6 +40,8 @@ import {
 } from './control-plane-tokens.ts'
 import { decodeSessionPageCursor, encodeSessionPageCursor } from './session-page-cursor.ts'
 import { workspaceEventCursor, type WorkspaceEventCursorRecord } from './workspace-event-cursor.ts'
+import { channelScopeKey, channelThreadKey, normalizeChannelProviderId as normalizeProvider } from './channel-provider-utils.ts'
+import type { ChannelProviderEventClaimResult, ChannelProviderEventRecord, ChannelProviderId, ClaimChannelProviderEventInput, CompleteChannelProviderEventInput } from './channel-provider-types.ts'
 export { ControlPlaneQuotaExceededError, publicQuotaMessage } from './control-plane-errors.ts'
 export type { QuotaPolicyCode } from './control-plane-errors.ts'
 export type {
@@ -79,8 +82,6 @@ export type ControlPlaneCommandKind = 'prompt' | 'abort' | 'permission.respond' 
 export type ControlPlaneCommandStatus = 'pending' | 'running' | 'acked' | 'failed'
 export type WorkerRole = 'all-in-one' | 'web' | 'worker' | 'scheduler'
 export type WorkReaperAction = 'retried' | 'failed' | 'released'
-export type ChannelProviderKind = 'telegram' | 'slack' | 'email' | 'discord' | 'whatsapp' | 'signal' | 'webhook' | 'cli'
-export type ChannelProviderId = ChannelProviderKind | `${ChannelProviderKind}-${string}` | `${string}-${string}`
 export type HeadlessAgentStatus = 'active' | 'disabled'
 export type ChannelBindingStatus = 'active' | 'disabled' | 'auth_required' | 'error'
 export type ChannelIdentityRole = ControlPlaneRole | 'approver' | 'viewer'
@@ -1207,6 +1208,8 @@ export type ControlPlaneStore = {
   listChannelDeliveries(input: ListChannelDeliveriesInput): MaybePromise<ChannelDeliveryRecord[]>
   claimNextChannelDelivery(input: ClaimChannelDeliveryInput): MaybePromise<ChannelDeliveryRecord | null>
   ackChannelDelivery(input: AckChannelDeliveryInput): MaybePromise<ChannelDeliveryRecord | null>
+  claimChannelProviderEvent(input: ClaimChannelProviderEventInput): MaybePromise<ChannelProviderEventClaimResult>
+  completeChannelProviderEvent(input: CompleteChannelProviderEventInput): MaybePromise<ChannelProviderEventRecord | null>
   createSession(input: CreateSessionInput): MaybePromise<SessionRecord>
   getSession(tenantId: string, userId: string, sessionId: string): MaybePromise<SessionRecord | null>
   getSessionForTenant(tenantId: string, sessionId: string): MaybePromise<SessionRecord | null>
@@ -1463,16 +1466,6 @@ function quotaRetryAfterMs(nowMs: number, startedAtMs: number, windowMs: number)
   return Math.max(1, startedAtMs + windowMs - nowMs)
 }
 
-function normalizeProvider(value: unknown): ChannelProviderId {
-  const provider = normalizeText(value, 64, 'Channel provider') as ChannelProviderId
-  if (isChannelProviderId(provider)) return provider
-  throw new Error(`Unsupported channel provider ${provider}.`)
-}
-function isChannelProviderId(value: string): value is ChannelProviderId {
-  return ['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(value)
-    || (/^[a-z][a-z0-9_-]{1,63}$/.test(value) && value.includes('-'))
-}
-
 function normalizeBillingStatus(value: unknown): BillingSubscriptionStatus {
   const status = normalizeText(value || 'incomplete', 32, 'Billing subscription status') as BillingSubscriptionStatus
   return BILLING_SUBSCRIPTION_STATUSES.has(status) ? status : 'incomplete'
@@ -1499,14 +1492,6 @@ function normalizeChannelIdentityRole(value: unknown): ChannelIdentityRole {
     throw new Error(`Unsupported channel identity role ${role}.`)
   }
   return role
-}
-
-function channelScopeKey(provider: ChannelProviderId, externalWorkspaceId: string | null, externalId: string) {
-  return key(provider, externalWorkspaceId || '', externalId)
-}
-
-function channelThreadKey(provider: ChannelProviderId, externalWorkspaceId: string | null, externalChatId: string, externalThreadId: string) {
-  return key(provider, externalWorkspaceId || '', externalChatId, externalThreadId)
 }
 
 export class InMemoryControlPlaneStore implements ControlPlaneStore {
@@ -1558,6 +1543,9 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     sessions: () => this.sessions.values(),
     workflowRuns: () => this.workflowRuns.values(),
     consumeUsageQuota: (input) => this.consumeUsageQuota(input),
+  })
+  private readonly channelProviderEventsDomain = new InMemoryChannelProviderEventsDomain({
+    orgExists: (orgId) => this.orgs.has(orgId),
   })
 
   private orgIdForTenant(tenantId: string) {
@@ -2878,6 +2866,14 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     delivery.nextAttemptAt = (input.nextAttemptAt || input.updatedAt || new Date()).toISOString()
     delivery.updatedAt = updatedAt
     return clone(delivery)
+  }
+
+  claimChannelProviderEvent(input: ClaimChannelProviderEventInput): ChannelProviderEventClaimResult {
+    return this.channelProviderEventsDomain.claim(input)
+  }
+
+  completeChannelProviderEvent(input: CompleteChannelProviderEventInput): ChannelProviderEventRecord | null {
+    return this.channelProviderEventsDomain.complete(input)
   }
 
   createSession(input: CreateSessionInput): SessionRecord {

--- a/apps/desktop/src/main/cloud/in-memory-domains/channel-provider-events.ts
+++ b/apps/desktop/src/main/cloud/in-memory-domains/channel-provider-events.ts
@@ -1,0 +1,194 @@
+import { createHash } from 'node:crypto'
+import type {
+  ChannelProviderEventClaimResult,
+  ChannelProviderEventRecord,
+  ChannelProviderEventType,
+  ChannelProviderId,
+  ClaimChannelProviderEventInput,
+  CompleteChannelProviderEventInput,
+} from '../channel-provider-types.ts'
+import { normalizeChannelProviderId as normalizeProvider } from '../channel-provider-utils.ts'
+
+const CHANNEL_TEXT_MAX_LENGTH = 256
+const CHANNEL_METADATA_MAX_BYTES = 16_384
+const CHANNEL_PROVIDER_EVENT_ERROR_MAX_LENGTH = 1024
+
+type InMemoryChannelProviderEventsHost = {
+  orgExists(orgId: string): boolean
+}
+
+export class InMemoryChannelProviderEventsDomain {
+  private readonly events = new Map<string, ChannelProviderEventRecord>()
+  private readonly host: InMemoryChannelProviderEventsHost
+
+  constructor(host: InMemoryChannelProviderEventsHost) {
+    this.host = host
+  }
+
+  claim(input: ClaimChannelProviderEventInput): ChannelProviderEventClaimResult {
+    if (!this.host.orgExists(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    const now = input.now || new Date()
+    const nowIsoValue = now.toISOString()
+    const ttlMs = Math.max(1, Math.min(input.ttlMs || 5 * 60_000, 60 * 60_000))
+    const eventKey = channelProviderEventKey(input)
+    const existing = this.events.get(eventKey)
+    const provider = normalizeProvider(input.provider)
+    const eventType = normalizeChannelProviderEventType(input.eventType)
+    const canReclaim = existing && (
+      (existing.status === 'processing' && existing.claimExpiresAt && new Date(existing.claimExpiresAt).getTime() <= now.getTime())
+      || (existing.status === 'failed' && existing.retryable)
+      || existing.status === 'received'
+    )
+
+    if (!existing) {
+      const record: ChannelProviderEventRecord = {
+        eventId: normalizeText(
+          input.eventId || stableId('channel_provider_event', input.orgId, provider, input.providerInstanceId, input.externalWorkspaceId || '', eventType, input.providerEventId),
+          CHANNEL_TEXT_MAX_LENGTH,
+          'Channel provider event id',
+        ),
+        orgId: input.orgId,
+        provider,
+        providerInstanceId: normalizeText(input.providerInstanceId, CHANNEL_TEXT_MAX_LENGTH, 'Channel provider instance id'),
+        externalWorkspaceId: normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'Channel external workspace id'),
+        providerEventId: normalizeText(input.providerEventId, CHANNEL_TEXT_MAX_LENGTH, 'Provider event id'),
+        eventType,
+        status: 'processing',
+        claimedBy: normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant'),
+        claimExpiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+        attemptCount: 1,
+        retryable: true,
+        lastError: null,
+        metadata: normalizeRecord(input.metadata || {}, 'Channel provider event metadata'),
+        processedAt: null,
+        createdAt: nowIsoValue,
+        updatedAt: nowIsoValue,
+      }
+      this.events.set(eventKey, record)
+      return { event: clone(record), claimed: true, duplicate: false }
+    }
+
+    existing.updatedAt = nowIsoValue
+    if (canReclaim) {
+      existing.provider = provider
+      existing.eventType = eventType
+      existing.status = 'processing'
+      existing.claimedBy = normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant')
+      existing.claimExpiresAt = new Date(now.getTime() + ttlMs).toISOString()
+      existing.attemptCount += 1
+      existing.retryable = true
+      existing.lastError = null
+      existing.metadata = normalizeRecord(input.metadata || existing.metadata, 'Channel provider event metadata')
+      existing.processedAt = null
+      return { event: clone(existing), claimed: true, duplicate: false }
+    }
+
+    return { event: clone(existing), claimed: false, duplicate: true }
+  }
+
+  complete(input: CompleteChannelProviderEventInput): ChannelProviderEventRecord | null {
+    const event = Array.from(this.events.values())
+      .find((candidate) => candidate.orgId === input.orgId && candidate.eventId === input.eventId)
+    if (!event) return null
+    if (event.claimedBy !== normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant')) return null
+
+    const updatedAt = nowIso(input.updatedAt)
+    event.status = input.status
+    event.claimedBy = null
+    event.claimExpiresAt = null
+    event.retryable = input.status === 'failed' ? input.retryable !== false : false
+    event.lastError = input.status === 'failed' && input.lastError
+      ? redactOperationalText(input.lastError, CHANNEL_PROVIDER_EVENT_ERROR_MAX_LENGTH, 'Provider event error')
+      : null
+    event.processedAt = input.status === 'processed' ? updatedAt : event.processedAt
+    event.updatedAt = updatedAt
+    return clone(event)
+  }
+}
+
+function channelProviderEventKey(input: {
+  orgId: string
+  provider: ChannelProviderId
+  providerInstanceId: string
+  externalWorkspaceId?: string | null
+  eventType: ChannelProviderEventType
+  providerEventId: string
+}) {
+  return key(
+    input.orgId,
+    normalizeProvider(input.provider),
+    normalizeText(input.providerInstanceId, CHANNEL_TEXT_MAX_LENGTH, 'Channel provider instance id'),
+    normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'Channel external workspace id') || '',
+    normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel provider event type'),
+    normalizeText(input.providerEventId, CHANNEL_TEXT_MAX_LENGTH, 'Channel provider event id'),
+  )
+}
+
+function normalizeChannelProviderEventType(value: unknown): ChannelProviderEventType {
+  const eventType = normalizeText(value || 'message', 32, 'Channel provider event type') as ChannelProviderEventType
+  if (!['message', 'command', 'interaction'].includes(eventType)) throw new Error(`Unsupported channel provider event type ${eventType}.`)
+  return eventType
+}
+
+function nowIso(now: Date | undefined) {
+  return (now || new Date()).toISOString()
+}
+
+function stableId(prefix: string, ...parts: string[]) {
+  return `${prefix}_${createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32)}`
+}
+
+function key(...parts: string[]) {
+  return parts.join('\0')
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function normalizeText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (normalized.length > maxLength) {
+    throw new Error(`${label} exceeds ${maxLength} characters.`)
+  }
+  return normalized
+}
+
+function normalizeNullableText(value: unknown, maxLength: number, label: string): string | null {
+  if (value === undefined || value === null || value === '') return null
+  return normalizeText(value, maxLength, label)
+}
+
+function normalizeRecord(value: unknown, label: string, maxBytes = CHANNEL_METADATA_MAX_BYTES): Record<string, unknown> {
+  const record = value && typeof value === 'object' && !Array.isArray(value)
+    ? clone(value as Record<string, unknown>)
+    : {}
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([field, entry]) => `${JSON.stringify(field)}:${stableJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function redactOperationalText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const redacted = value.trim()
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password|authorization)=([^\s&]+)/gi, '$1=[redacted]')
+    .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
+    .replace(/\b(?:sk-[A-Za-z0-9._-]{6,}|oc[wc]_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
+  return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength <= 3 ? maxLength : maxLength - 3)}${maxLength <= 3 ? '' : '...'}`
+}

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -25,11 +25,13 @@ import type {
   ChannelProviderId,
   ClaimDueWorkflowRunInput,
   ClaimChannelDeliveryInput,
+  ClaimChannelProviderEventInput,
   ClaimRateLimitInput,
   ClaimedWorkflowRunRecord,
   CloudWorkflowRecord,
   CloudWorkflowRunRecord,
   CommandQueueQuota,
+  CompleteChannelProviderEventInput,
   ConsumeUsageQuotaInput,
   CompleteWorkflowRunInput,
   ControlPlaneRole,
@@ -108,16 +110,10 @@ import type {
 } from '../workflow/workflow-webhook-server.ts'
 import { runPostgresControlPlaneMigrations } from './postgres-migrations.ts'
 import { workspaceEventCursorFromRow } from './workspace-event-cursor.ts'
+import { normalizeChannelProviderId as normalizeProvider } from './channel-provider-utils.ts'
 import { usageEventFromRow, billingSubscriptionFromRow } from './postgres-domains/billing.ts'
 import { byokSecretFromRow } from './postgres-domains/byok.ts'
-import {
-  channelBindingFromRow,
-  channelDeliveryFromRow,
-  channelIdentityFromRow,
-  channelInteractionFromRow,
-  channelSessionBindingFromRow,
-  headlessAgentFromRow,
-} from './postgres-domains/channels.ts'
+import { channelBindingFromRow, channelDeliveryFromRow, channelIdentityFromRow, channelInteractionFromRow, channelSessionBindingFromRow, headlessAgentFromRow } from './postgres-domains/channels.ts'
 import {
   accountFromRow,
   apiTokenFromRow,
@@ -145,6 +141,7 @@ import { webhookAuthFailureFromRow } from './postgres-domains/webhooks.ts'
 import { workflowFromRow, workflowRunFromRow } from './postgres-domains/workflows.ts'
 import { assertPostgresCommandEnqueueQuotas, assertPostgresCommandQueueQuota, assertPostgresConcurrentSessionQuota, assertPostgresWorkflowRunQuota, checkPostgresActiveWorkerQuota, listPostgresRunnableSessions } from './postgres-store-domains/quotas.ts'
 import { PostgresManagedWorkersRepository } from './postgres-store-domains/workers.ts'
+import { PostgresChannelProviderEventsRepository } from './postgres-store-domains/channel-provider-events.ts'
 
 type PgExecutor = {
   query<Row extends QueryRow = QueryRow>(text: string, values?: unknown[]): Promise<QueryResult<Row>>
@@ -290,19 +287,6 @@ function retryAfterMs(nowMs: number, windowStartedAtMs: number, windowMs: number
   return Math.max(1, windowStartedAtMs + windowMs - nowMs)
 }
 
-function normalizeProvider(value: unknown): ChannelProviderId {
-  const provider = normalizeText(value, 64, 'Channel provider') as ChannelProviderId
-  if (!isChannelProviderId(provider)) {
-    throw new Error(`Unsupported channel provider ${provider}.`)
-  }
-  return provider
-}
-
-function isChannelProviderId(value: string): value is ChannelProviderId {
-  if (['telegram', 'slack', 'email', 'discord', 'whatsapp', 'signal', 'webhook', 'cli'].includes(value)) return true
-  return /^[a-z][a-z0-9_-]{1,63}$/.test(value) && value.includes('-')
-}
-
 function normalizeByokProviderId(value: unknown) {
   const providerId = normalizeText(value, BYOK_PROVIDER_ID_MAX_LENGTH, 'BYOK provider id').toLowerCase()
   if (!/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) throw new Error(`Unsupported BYOK provider id ${providerId}.`)
@@ -313,6 +297,7 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   private readonly pool: PgPool
   private readonly ownsPool: boolean
   private readonly managedWorkers: PostgresManagedWorkersRepository
+  private readonly channelProviderEvents: PostgresChannelProviderEventsRepository
   private readonly quotaDeps = {
     lockQuota: (executor: PgExecutor, orgId: string, quotaKey: string, now?: Date) => this.lockQuota(executor, orgId, quotaKey, now),
     consumeUsageQuota: (executor: PgExecutor, input: ConsumeUsageQuotaInput) => this.consumeUsageQuotaWithExecutor(executor, input),
@@ -325,6 +310,10 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       pool: this.pool,
       withTransaction: (fn) => this.withTransaction(fn),
       recordAuditEvent: (executor, input) => this.recordAuditEventWithExecutor(executor, input),
+    })
+    this.channelProviderEvents = new PostgresChannelProviderEventsRepository({
+      pool: this.pool,
+      withTransaction: (fn) => this.withTransaction(fn),
     })
   }
 
@@ -2029,6 +2018,14 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       ],
     )
     return result.rows[0] ? channelDeliveryFromRow(result.rows[0]) : null
+  }
+
+  async claimChannelProviderEvent(input: ClaimChannelProviderEventInput) {
+    return this.channelProviderEvents.claim(input)
+  }
+
+  async completeChannelProviderEvent(input: CompleteChannelProviderEventInput) {
+    return this.channelProviderEvents.complete(input)
   }
 
   async createSession(input: {

--- a/apps/desktop/src/main/cloud/postgres-domains/channels.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/channels.ts
@@ -3,6 +3,7 @@ import type {
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
   ChannelInteractionRecord,
+  ChannelProviderEventRecord,
   ChannelProviderId,
   ChannelSessionBindingRecord,
   HeadlessAgentRecord,
@@ -113,6 +114,28 @@ export function channelDeliveryFromRow(row: QueryRow): ChannelDeliveryRecord {
     claimExpiresAt: isoOrNull(row.claim_expires_at),
     nextAttemptAt: iso(row.next_attempt_at),
     lastError: stringOrNull(row.last_error),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  }
+}
+
+export function channelProviderEventFromRow(row: QueryRow): ChannelProviderEventRecord {
+  return {
+    eventId: String(row.event_id),
+    orgId: String(row.org_id),
+    provider: String(row.provider) as ChannelProviderId,
+    providerInstanceId: String(row.provider_instance_id),
+    externalWorkspaceId: stringOrNull(row.external_workspace_id),
+    providerEventId: String(row.provider_event_id),
+    eventType: String(row.event_type) as ChannelProviderEventRecord['eventType'],
+    status: String(row.status) as ChannelProviderEventRecord['status'],
+    claimedBy: stringOrNull(row.claimed_by),
+    claimExpiresAt: isoOrNull(row.claim_expires_at),
+    attemptCount: numberValue(row.attempt_count),
+    retryable: row.retryable === true,
+    lastError: stringOrNull(row.last_error),
+    metadata: jsonRecord(row.metadata),
+    processedAt: isoOrNull(row.processed_at),
     createdAt: iso(row.created_at),
     updatedAt: iso(row.updated_at),
   }

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -447,6 +447,29 @@ export const CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_STATEMENTS = [
   )`,
   `CREATE INDEX IF NOT EXISTS cloud_channel_deliveries_claim_idx
     ON cloud_channel_deliveries (org_id, status, next_attempt_at, created_at)`,
+  `CREATE TABLE IF NOT EXISTS cloud_channel_provider_events (
+    event_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    provider text NOT NULL,
+    provider_instance_id text NOT NULL,
+    external_workspace_id text,
+    provider_event_id text NOT NULL,
+    event_type text NOT NULL,
+    status text NOT NULL,
+    claimed_by text,
+    claim_expires_at timestamptz,
+    attempt_count integer NOT NULL DEFAULT 0,
+    retryable boolean NOT NULL DEFAULT true,
+    last_error text,
+    metadata jsonb NOT NULL,
+    processed_at timestamptz,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS cloud_channel_provider_events_dedupe_idx
+    ON cloud_channel_provider_events (org_id, provider, provider_instance_id, COALESCE(external_workspace_id, ''), event_type, provider_event_id)`,
+  `CREATE INDEX IF NOT EXISTS cloud_channel_provider_events_claim_idx
+    ON cloud_channel_provider_events (org_id, status, retryable, claim_expires_at, updated_at)`,
 ] as const
 
 export const CLOUD_CONTROL_PLANE_BYOK_SECRETS_MIGRATION_ID = '004_byok_secrets'
@@ -685,6 +708,34 @@ export const CLOUD_CONTROL_PLANE_MANAGED_WORK_REAPER_INDEXES_STATEMENTS = [
       AND status IN ('queued', 'running')`,
 ] as const
 
+export const CLOUD_CONTROL_PLANE_CHANNEL_PROVIDER_EVENTS_MIGRATION_ID = '011_channel_provider_events'
+
+export const CLOUD_CONTROL_PLANE_CHANNEL_PROVIDER_EVENTS_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS cloud_channel_provider_events (
+    event_id text PRIMARY KEY,
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    provider text NOT NULL,
+    provider_instance_id text NOT NULL,
+    external_workspace_id text,
+    provider_event_id text NOT NULL,
+    event_type text NOT NULL,
+    status text NOT NULL,
+    claimed_by text,
+    claim_expires_at timestamptz,
+    attempt_count integer NOT NULL DEFAULT 0,
+    retryable boolean NOT NULL DEFAULT true,
+    last_error text,
+    metadata jsonb NOT NULL,
+    processed_at timestamptz,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS cloud_channel_provider_events_dedupe_idx
+    ON cloud_channel_provider_events (org_id, provider, provider_instance_id, COALESCE(external_workspace_id, ''), event_type, provider_event_id)`,
+  `CREATE INDEX IF NOT EXISTS cloud_channel_provider_events_claim_idx
+    ON cloud_channel_provider_events (org_id, status, retryable, claim_expires_at, updated_at)`,
+] as const
+
 export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration[] = [
   {
     id: CLOUD_CONTROL_PLANE_MIGRATION_ID,
@@ -727,5 +778,9 @@ export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration
     statements: CLOUD_CONTROL_PLANE_MANAGED_WORK_REAPER_INDEXES_STATEMENTS,
     concurrentIndexes: ['cloud_worker_leases_reaper_idx', 'cloud_workflow_runs_reaper_idx'],
     transactional: false,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_CHANNEL_PROVIDER_EVENTS_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_CHANNEL_PROVIDER_EVENTS_STATEMENTS,
   },
 ] as const

--- a/apps/desktop/src/main/cloud/postgres-store-domains/channel-provider-events.ts
+++ b/apps/desktop/src/main/cloud/postgres-store-domains/channel-provider-events.ts
@@ -1,0 +1,221 @@
+import { createHash } from 'node:crypto'
+import type {
+  ClaimChannelProviderEventInput,
+  CompleteChannelProviderEventInput,
+} from '../control-plane-store.ts'
+import { normalizeChannelProviderId } from '../channel-provider-utils.ts'
+import { channelProviderEventFromRow } from '../postgres-domains/channels.ts'
+import { jsonRecord, type QueryResult, type QueryRow } from '../postgres-domains/shared.ts'
+
+type PgExecutor = {
+  query<Row extends QueryRow = QueryRow>(text: string, values?: unknown[]): Promise<QueryResult<Row>>
+}
+type PgClient = PgExecutor & { release: () => void }
+
+type PostgresChannelProviderEventsRepositoryOptions = {
+  pool: PgExecutor
+  withTransaction<T>(fn: (client: PgClient) => Promise<T>): Promise<T>
+}
+
+const CHANNEL_TEXT_MAX_LENGTH = 256
+const CHANNEL_METADATA_MAX_BYTES = 16_384
+const CHANNEL_PROVIDER_EVENT_ERROR_MAX_LENGTH = 1024
+
+export class PostgresChannelProviderEventsRepository {
+  private readonly options: PostgresChannelProviderEventsRepositoryOptions
+
+  constructor(options: PostgresChannelProviderEventsRepositoryOptions) {
+    this.options = options
+  }
+
+  async claim(input: ClaimChannelProviderEventInput) {
+    return this.options.withTransaction(async (client) => {
+      const now = input.now || new Date()
+      const nowIsoValue = now.toISOString()
+      const ttlMs = Math.max(1, Math.min(input.ttlMs || 5 * 60_000, 60 * 60_000))
+      const provider = normalizeChannelProviderId(input.provider)
+      const providerInstanceId = normalizeText(input.providerInstanceId, CHANNEL_TEXT_MAX_LENGTH, 'Channel provider instance id')
+      const externalWorkspaceId = normalizeNullableText(input.externalWorkspaceId, CHANNEL_TEXT_MAX_LENGTH, 'Channel external workspace id')
+      const providerEventId = normalizeText(input.providerEventId, CHANNEL_TEXT_MAX_LENGTH, 'Provider event id')
+      const eventType = normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel provider event type')
+      if (!['message', 'command', 'interaction'].includes(eventType)) throw new Error(`Unsupported channel provider event type ${eventType}.`)
+      const eventId = normalizeText(
+        input.eventId || stableId('channel_provider_event', input.orgId, provider, providerInstanceId, externalWorkspaceId || '', eventType, providerEventId),
+        CHANNEL_TEXT_MAX_LENGTH,
+        'Channel provider event id',
+      )
+      const metadata = JSON.stringify(normalizeRecord(input.metadata || {}, 'Channel provider event metadata'))
+      const insert = await client.query(
+        `INSERT INTO cloud_channel_provider_events (
+          event_id, org_id, provider, provider_instance_id, external_workspace_id,
+          provider_event_id, event_type, status, claimed_by, claim_expires_at,
+          attempt_count, retryable, last_error, metadata, processed_at, created_at, updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, 'processing', $8, $9, 1, true, NULL, $10::jsonb, NULL, $11, $11)
+        ON CONFLICT DO NOTHING
+        RETURNING *`,
+        [
+          eventId,
+          input.orgId,
+          provider,
+          providerInstanceId,
+          externalWorkspaceId,
+          providerEventId,
+          eventType,
+          normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant'),
+          new Date(now.getTime() + ttlMs).toISOString(),
+          metadata,
+          nowIsoValue,
+        ],
+      )
+      if (insert.rows[0]) {
+        return { event: channelProviderEventFromRow(insert.rows[0]), claimed: true, duplicate: false }
+      }
+
+      const existing = await one(
+        client,
+        `SELECT *
+         FROM cloud_channel_provider_events
+         WHERE org_id = $1
+           AND provider = $2
+           AND provider_instance_id = $3
+           AND COALESCE(external_workspace_id, '') = COALESCE($4::text, '')
+           AND event_type = $5
+           AND provider_event_id = $6
+         FOR UPDATE`,
+        [input.orgId, provider, providerInstanceId, externalWorkspaceId, eventType, providerEventId],
+      )
+      const current = channelProviderEventFromRow(existing)
+      const claimExpired = current.status === 'processing'
+        && current.claimExpiresAt !== null
+        && new Date(current.claimExpiresAt).getTime() <= now.getTime()
+      const canReclaim = current.status === 'received'
+        || (current.status === 'failed' && current.retryable)
+        || claimExpired
+      if (!canReclaim) {
+        const touched = await client.query(
+          `UPDATE cloud_channel_provider_events
+           SET updated_at = $2
+           WHERE event_id = $1
+           RETURNING *`,
+          [current.eventId, nowIsoValue],
+        )
+        return { event: channelProviderEventFromRow(touched.rows[0]), claimed: false, duplicate: true }
+      }
+
+      const reclaimed = await client.query(
+        `UPDATE cloud_channel_provider_events
+         SET provider = $3,
+             status = 'processing',
+             claimed_by = $4,
+             claim_expires_at = $5,
+             attempt_count = attempt_count + 1,
+             retryable = true,
+             last_error = NULL,
+             metadata = $6::jsonb,
+             processed_at = NULL,
+             updated_at = $7
+         WHERE event_id = $1
+           AND org_id = $2
+         RETURNING *`,
+        [
+          current.eventId,
+          input.orgId,
+          provider,
+          normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant'),
+          new Date(now.getTime() + ttlMs).toISOString(),
+          metadata,
+          nowIsoValue,
+        ],
+      )
+      return { event: channelProviderEventFromRow(reclaimed.rows[0]), claimed: true, duplicate: false }
+    })
+  }
+
+  async complete(input: CompleteChannelProviderEventInput) {
+    const updatedAt = nowIso(input.updatedAt)
+    const result = await this.options.pool.query(
+      `UPDATE cloud_channel_provider_events
+       SET status = $3,
+           claimed_by = NULL,
+           claim_expires_at = NULL,
+           retryable = CASE WHEN $3 = 'failed' THEN $4 ELSE false END,
+           last_error = CASE WHEN $3 = 'failed' THEN $5 ELSE NULL END,
+           processed_at = CASE WHEN $3 = 'processed' THEN $6::timestamptz ELSE processed_at END,
+           updated_at = $6
+       WHERE org_id = $1
+         AND event_id = $2
+         AND claimed_by = $7
+       RETURNING *`,
+      [
+        input.orgId,
+        input.eventId,
+        input.status,
+        input.status === 'failed' ? input.retryable !== false : false,
+        input.status === 'failed' && input.lastError
+          ? redactOperationalText(input.lastError, CHANNEL_PROVIDER_EVENT_ERROR_MAX_LENGTH, 'Provider event error')
+          : null,
+        updatedAt,
+        normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant'),
+      ],
+    )
+    return result.rows[0] ? channelProviderEventFromRow(result.rows[0]) : null
+  }
+}
+
+async function one<Row extends QueryRow = QueryRow>(executor: PgExecutor, text: string, values?: unknown[]) {
+  const result = await executor.query<Row>(text, values)
+  if (!result.rows[0]) throw new Error('Expected query to return a row.')
+  return result.rows[0]
+}
+
+function nowIso(now: Date | undefined) {
+  return (now || new Date()).toISOString()
+}
+
+function stableId(prefix: string, ...parts: string[]) {
+  return `${prefix}_${createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32)}`
+}
+
+function normalizeText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (normalized.length > maxLength) throw new Error(`${label} exceeds ${maxLength} characters.`)
+  return normalized
+}
+
+function redactOperationalText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const redacted = value.trim()
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password|authorization)=([^\s&]+)/gi, '$1=[redacted]')
+    .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
+    .replace(/\b(?:sk-[A-Za-z0-9._-]{6,}|oc[wc]_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
+  return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength <= 3 ? maxLength : maxLength - 3)}${maxLength <= 3 ? '' : '...'}`
+}
+
+function normalizeRecord(value: unknown, label: string, maxBytes = CHANNEL_METADATA_MAX_BYTES): Record<string, unknown> {
+  const record = jsonRecord(value)
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function normalizeNullableText(value: unknown, maxLength: number, label: string): string | null {
+  if (value === undefined || value === null || value === '') return null
+  return normalizeText(value, maxLength, label)
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([field, entry]) => `${JSON.stringify(field)}:${stableJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}

--- a/apps/desktop/src/main/cloud/services/channel-domain-service.ts
+++ b/apps/desktop/src/main/cloud/services/channel-domain-service.ts
@@ -4,6 +4,9 @@ import type {
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
   ChannelInteractionRecord,
+  ChannelProviderEventClaimResult,
+  ChannelProviderEventRecord,
+  ChannelProviderEventType,
   ChannelProviderId,
   ChannelSessionBindingRecord,
   HeadlessAgentRecord,
@@ -26,6 +29,7 @@ import {
 } from './channel-domain-context.ts'
 import * as deliveryActions from './channel-delivery-actions.ts'
 import * as interactionActions from './channel-interaction-actions.ts'
+import * as providerEventActions from './channel-provider-event-actions.ts'
 import * as sessionActions from './channel-session-actions.ts'
 
 export type {
@@ -171,6 +175,7 @@ export class CloudChannelDomainService {
       bindingId: string
       text: string
       agent?: string | null
+      commandId?: string | null
     },
   ): Promise<{ binding: ChannelSessionBindingRecord, command: SessionCommandRecord, beforeProjectionSequence: number }> {
     return sessionActions.enqueueChannelPrompt(this.options, principal, input)
@@ -259,5 +264,34 @@ export class CloudChannelDomainService {
     },
   ): Promise<PublicChannelDeliveryRecord | null> {
     return deliveryActions.ackChannelDelivery(this.options, principal, input)
+  }
+
+  claimChannelProviderEvent(
+    principal: CloudPrincipal,
+    input: {
+      provider: ChannelProviderId
+      providerInstanceId: string
+      externalWorkspaceId?: string | null
+      providerEventId: string
+      eventType: ChannelProviderEventType
+      claimedBy: string
+      ttlMs?: number | null
+      metadata?: Record<string, unknown>
+    },
+  ): Promise<ChannelProviderEventClaimResult> {
+    return providerEventActions.claimChannelProviderEvent(this.options, principal, input)
+  }
+
+  completeChannelProviderEvent(
+    principal: CloudPrincipal,
+    input: {
+      eventId: string
+      claimedBy: string
+      status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
+      retryable?: boolean
+      lastError?: string | null
+    },
+  ): Promise<ChannelProviderEventRecord | null> {
+    return providerEventActions.completeChannelProviderEvent(this.options, principal, input)
   }
 }

--- a/apps/desktop/src/main/cloud/services/channel-provider-event-actions.ts
+++ b/apps/desktop/src/main/cloud/services/channel-provider-event-actions.ts
@@ -1,0 +1,63 @@
+import type {
+  ChannelProviderEventClaimResult,
+  ChannelProviderEventRecord,
+  ChannelProviderEventType,
+  ChannelProviderId,
+} from '../control-plane-store.ts'
+import type { CloudPrincipal } from '../session-service.ts'
+import {
+  assertGatewayAccess,
+  type CloudChannelDomainServiceOptions,
+} from './channel-domain-context.ts'
+
+export async function claimChannelProviderEvent(
+  options: CloudChannelDomainServiceOptions,
+  principal: CloudPrincipal,
+  input: {
+    provider: ChannelProviderId
+    providerInstanceId: string
+    externalWorkspaceId?: string | null
+    providerEventId: string
+    eventType: ChannelProviderEventType
+    claimedBy: string
+    ttlMs?: number | null
+    metadata?: Record<string, unknown>
+  },
+): Promise<ChannelProviderEventClaimResult> {
+  await options.ensurePrincipal(principal)
+  assertGatewayAccess(principal)
+  return options.store.claimChannelProviderEvent({
+    orgId: options.principalOrgId(principal),
+    provider: input.provider,
+    providerInstanceId: input.providerInstanceId,
+    externalWorkspaceId: input.externalWorkspaceId,
+    providerEventId: input.providerEventId,
+    eventType: input.eventType,
+    claimedBy: input.claimedBy,
+    ttlMs: input.ttlMs || undefined,
+    metadata: input.metadata || {},
+  })
+}
+
+export async function completeChannelProviderEvent(
+  options: CloudChannelDomainServiceOptions,
+  principal: CloudPrincipal,
+  input: {
+    eventId: string
+    claimedBy: string
+    status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
+    retryable?: boolean
+    lastError?: string | null
+  },
+): Promise<ChannelProviderEventRecord | null> {
+  await options.ensurePrincipal(principal)
+  assertGatewayAccess(principal)
+  return options.store.completeChannelProviderEvent({
+    orgId: options.principalOrgId(principal),
+    eventId: input.eventId,
+    claimedBy: input.claimedBy,
+    status: input.status,
+    retryable: input.retryable,
+    lastError: input.lastError,
+  })
+}

--- a/apps/desktop/src/main/cloud/services/channel-service.ts
+++ b/apps/desktop/src/main/cloud/services/channel-service.ts
@@ -9,6 +9,9 @@ import type {
   ChannelIdentityRole,
   ChannelIdentityStatus,
   ChannelInteractionRecord,
+  ChannelProviderEventClaimResult,
+  ChannelProviderEventRecord,
+  ChannelProviderEventType,
   ChannelProviderId,
   ChannelSessionBindingRecord,
   HeadlessAgentRecord,
@@ -97,6 +100,7 @@ export type CloudChannelServiceDelegate = {
     bindingId: string
     text: string
     agent?: string | null
+    commandId?: string | null
   }): Promise<{
     binding: ChannelSessionBindingRecord
     command: SessionCommandRecord
@@ -146,6 +150,23 @@ export type CloudChannelServiceDelegate = {
     lastError?: string | null
     nextAttemptAt?: Date | null
   }): Promise<PublicChannelDeliveryRecord | null>
+  claimChannelProviderEvent(principal: CloudPrincipal, input: {
+    provider: ChannelProviderId
+    providerInstanceId: string
+    externalWorkspaceId?: string | null
+    providerEventId: string
+    eventType: ChannelProviderEventType
+    claimedBy: string
+    ttlMs?: number | null
+    metadata?: Record<string, unknown>
+  }): Promise<ChannelProviderEventClaimResult>
+  completeChannelProviderEvent(principal: CloudPrincipal, input: {
+    eventId: string
+    claimedBy: string
+    status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
+    retryable?: boolean
+    lastError?: string | null
+  }): Promise<ChannelProviderEventRecord | null>
 }
 
 export class CloudChannelService {
@@ -209,5 +230,11 @@ export class CloudChannelService {
   }
   ackDelivery(principal: CloudPrincipal, input: Parameters<CloudChannelServiceDelegate['ackChannelDelivery']>[1]) {
     return this.delegate.ackChannelDelivery(principal, input)
+  }
+  claimProviderEvent(principal: CloudPrincipal, input: Parameters<CloudChannelServiceDelegate['claimChannelProviderEvent']>[1]) {
+    return this.delegate.claimChannelProviderEvent(principal, input)
+  }
+  completeProviderEvent(principal: CloudPrincipal, input: Parameters<CloudChannelServiceDelegate['completeChannelProviderEvent']>[1]) {
+    return this.delegate.completeChannelProviderEvent(principal, input)
   }
 }

--- a/apps/desktop/src/main/cloud/services/channel-session-actions.ts
+++ b/apps/desktop/src/main/cloud/services/channel-session-actions.ts
@@ -189,6 +189,7 @@ export async function enqueueChannelPrompt(
     bindingId: string
     text: string
     agent?: string | null
+    commandId?: string | null
   },
 ): Promise<{ binding: ChannelSessionBindingRecord, command: SessionCommandRecord, beforeProjectionSequence: number }> {
   await options.ensurePrincipal(principal)
@@ -225,7 +226,7 @@ export async function enqueueChannelPrompt(
   let command: SessionCommandRecord
   try {
     command = await options.store.enqueueSessionCommand({
-      commandId: options.ids.randomUUID(),
+      commandId: input.commandId || options.ids.randomUUID(),
       tenantId: principal.tenantId,
       userId: session.userId,
       sessionId: binding.sessionId,

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -40,6 +40,9 @@ import type {
   ChannelIdentityRecord,
   ChannelInteractionRecord,
   ChannelCursorUpdateResult,
+  ChannelProviderEventClaimResult,
+  ChannelProviderEventRecord,
+  ChannelProviderEventType,
   ChannelProviderId,
   ChannelSessionBindingRecord,
   ClaimedWorkflowRunRecord,
@@ -1550,6 +1553,7 @@ export class CloudSessionService {
       bindingId: string
       text: string
       agent?: string | null
+      commandId?: string | null
     },
   ): Promise<{ binding: ChannelSessionBindingRecord, command: SessionCommandRecord, beforeProjectionSequence: number }> {
     return this.channelDomain.enqueueChannelPrompt(principal, input)
@@ -1641,6 +1645,35 @@ export class CloudSessionService {
     },
   ): Promise<PublicChannelDeliveryRecord | null> {
     return this.channelDomain.ackChannelDelivery(principal, input)
+  }
+
+  async claimChannelProviderEvent(
+    principal: CloudPrincipal,
+    input: {
+      provider: ChannelProviderId
+      providerInstanceId: string
+      externalWorkspaceId?: string | null
+      providerEventId: string
+      eventType: ChannelProviderEventType
+      claimedBy: string
+      ttlMs?: number | null
+      metadata?: Record<string, unknown>
+    },
+  ): Promise<ChannelProviderEventClaimResult> {
+    return this.channelDomain.claimChannelProviderEvent(principal, input)
+  }
+
+  async completeChannelProviderEvent(
+    principal: CloudPrincipal,
+    input: {
+      eventId: string
+      claimedBy: string
+      status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
+      retryable?: boolean
+      lastError?: string | null
+    },
+  ): Promise<ChannelProviderEventRecord | null> {
+    return this.channelDomain.completeChannelProviderEvent(principal, input)
   }
 
   async listSettingMetadata(principal: CloudPrincipal) {

--- a/apps/gateway/src/cloud-gateway.ts
+++ b/apps/gateway/src/cloud-gateway.ts
@@ -4,8 +4,12 @@ import {
   type ChannelCursorUpdateResult,
   type ChannelDeliveryRecord,
   type ChannelIdentityRecord,
+  type ChannelProviderEventClaimResult,
+  type ChannelProviderEventRecord,
   type ChannelSessionBindingRecord,
   type CloudChannelInteractionMutationResponse,
+  type CloudChannelProviderEventStatus,
+  type CloudChannelProviderEventType,
   type CloudChannelProviderId,
   type CloudChannelPromptMutationResponse,
   type CloudSessionCommandAckResponse,
@@ -46,7 +50,24 @@ export type CloudGateway = {
     bindingId: string
     text: string
     agent?: string | null
+    commandId?: string | null
   }): Promise<CloudChannelPromptMutationResponse>
+  claimProviderEvent(input: {
+    provider: CloudChannelProviderId
+    providerInstanceId: string
+    externalWorkspaceId?: string | null
+    providerEventId: string
+    eventType: CloudChannelProviderEventType
+    claimedBy: string
+    ttlMs?: number | null
+    metadata?: Record<string, unknown>
+  }): Promise<ChannelProviderEventClaimResult>
+  completeProviderEvent(eventId: string, input: {
+    claimedBy: string
+    status: Extract<CloudChannelProviderEventStatus, 'processed' | 'failed'>
+    retryable?: boolean
+    lastError?: string | null
+  }): Promise<ChannelProviderEventRecord | null>
   resolveChannelInteraction(input: ChannelActorInput & {
     token?: string | null
     externalInteractionId?: string | null
@@ -124,6 +145,14 @@ export function createCloudGateway(connection: GatewayCloudConnectionConfig, ada
     async prompt(input) {
       assertMethod(adapter.promptChannelSession, 'promptChannelSession')
       return adapter.promptChannelSession(input)
+    },
+    async claimProviderEvent(input) {
+      assertMethod(adapter.claimChannelProviderEvent, 'claimChannelProviderEvent')
+      return adapter.claimChannelProviderEvent(input)
+    },
+    async completeProviderEvent(eventId, input) {
+      assertMethod(adapter.completeChannelProviderEvent, 'completeChannelProviderEvent')
+      return adapter.completeChannelProviderEvent(eventId, input)
     },
     async resolveChannelInteraction(input) {
       assertMethod(adapter.resolveChannelInteraction, 'resolveChannelInteraction')

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -25,6 +25,44 @@ function resolveGatewayConfig(
   })
 }
 
+function signedWebhookHeaders(rawBody: string, sharedSecret: string, timestamp = String(Math.floor(Date.now() / 1000))) {
+  return {
+    'content-type': 'application/json',
+    'x-open-cowork-gateway-webhook-timestamp': timestamp,
+    'x-open-cowork-gateway-webhook-signature': `v1=${createHmac('sha256', sharedSecret).update(`v1:${timestamp}:${rawBody}`).digest('hex')}`,
+  }
+}
+
+function providerEventRecord(input: {
+  provider: string
+  providerInstanceId: string
+  externalWorkspaceId?: string | null
+  providerEventId: string
+  eventType: 'message' | 'command' | 'interaction'
+  claimedBy?: string | null
+  status?: 'processing' | 'processed' | 'failed'
+}) {
+  return {
+    eventId: `event-${input.providerInstanceId}-${input.providerEventId}-${input.eventType}`,
+    orgId: 'tenant-1',
+    provider: input.provider,
+    providerInstanceId: input.providerInstanceId,
+    externalWorkspaceId: input.externalWorkspaceId || null,
+    providerEventId: input.providerEventId,
+    eventType: input.eventType,
+    status: input.status || 'processing',
+    claimedBy: input.claimedBy || null,
+    claimExpiresAt: input.claimedBy ? new Date(Date.now() + 30_000).toISOString() : null,
+    attemptCount: 1,
+    retryable: true,
+    lastError: null,
+    metadata: {},
+    processedAt: input.status === 'processed' ? new Date().toISOString() : null,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  } as never
+}
+
 test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake webhook', async () => {
   const prompted: string[] = []
   const cloud: CloudGateway = {
@@ -83,6 +121,23 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     async prompt(input) {
       prompted.push(input.text)
       return { binding: { bindingId: input.bindingId } as never, command: { commandId: 'cmd-1' } as never, processed: 1 }
+    },
+    async claimProviderEvent(input) {
+      return {
+        event: providerEventRecord(input),
+        claimed: true,
+        duplicate: false,
+      }
+    },
+    async completeProviderEvent(eventId, input) {
+      return providerEventRecord({
+        provider: 'fake',
+        providerInstanceId: 'fake',
+        providerEventId: eventId,
+        eventType: 'message',
+        claimedBy: input.claimedBy,
+        status: input.status,
+      })
     },
     async abortSession() { return { command: { commandId: 'cmd-abort' } as never, processed: 1, view: {} as never } },
     async respondToPermission() { return { command: { commandId: 'cmd-permission' } as never, processed: 1 } },
@@ -166,6 +221,518 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     await http.close()
     await runtime.stop()
   }
+})
+
+test('gateway runtime claims provider events before prompting and skips duplicate claims', async () => {
+  const prompted: Array<{ text: string, commandId?: string | null }> = []
+  const claims: Array<{ providerEventId: string, providerInstanceId: string, eventType: string }> = []
+  const completed: Array<{ eventId: string, status: string }> = []
+  const seen = new Set<string>()
+  const cloud: CloudGateway = {
+    async resolveIdentity(input) {
+      return {
+        identityId: `identity-${input.externalUserId}`,
+        orgId: 'tenant-1',
+        provider: input.provider,
+        externalWorkspaceId: input.externalWorkspaceId || null,
+        externalUserId: input.externalUserId,
+        accountId: null,
+        role: 'member',
+        status: 'active',
+        metadata: {},
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+    async bindSession(input) {
+      return {
+        binding: {
+          bindingId: 'session-binding-1',
+          orgId: 'tenant-1',
+          agentId: 'agent-1',
+          channelBindingId: input.channelBindingId,
+          provider: input.provider,
+          externalWorkspaceId: input.externalWorkspaceId || null,
+          externalThreadId: input.externalThreadId,
+          externalChatId: input.externalChatId,
+          sessionId: 'session-1',
+          lastEventSequence: 0,
+          lastWorkspaceSequence: 0,
+          lastChatMessageId: null,
+          status: 'active',
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+        session: {
+          session: { sessionId: 'session-1' },
+          projection: null,
+        },
+      } as never
+    },
+    async findSessionByThread() { return null },
+    async getSession() { return { session: { sessionId: 'session-1' }, projection: null } as never },
+    async prompt(input) {
+      prompted.push({ text: input.text, commandId: input.commandId })
+      return { binding: { bindingId: input.bindingId } as never, command: { commandId: 'cmd-1' } as never, processed: 1 }
+    },
+    async claimProviderEvent(input) {
+      claims.push({
+        providerEventId: input.providerEventId,
+        providerInstanceId: input.providerInstanceId,
+        eventType: input.eventType,
+      })
+      const key = `${input.providerInstanceId}:${input.eventType}:${input.providerEventId}`
+      if (seen.has(key)) {
+        return {
+          event: providerEventRecord({ ...input, status: 'processed' }),
+          claimed: false,
+          duplicate: true,
+        }
+      }
+      seen.add(key)
+      return {
+        event: providerEventRecord(input),
+        claimed: true,
+        duplicate: false,
+      }
+    },
+    async completeProviderEvent(eventId, input) {
+      completed.push({ eventId, status: input.status })
+      return providerEventRecord({
+        provider: 'cli',
+        providerInstanceId: 'fake',
+        providerEventId: eventId,
+        eventType: 'message',
+        claimedBy: input.claimedBy,
+        status: input.status,
+      })
+    },
+    async abortSession() { return { command: { commandId: 'cmd-abort' } as never, processed: 1, view: {} as never } },
+    async respondToPermission() { return { command: { commandId: 'cmd-permission' } as never, processed: 1 } },
+    async replyToQuestion() { return { command: { commandId: 'cmd-question' } as never, processed: 1 } },
+    async rejectQuestion() { return { command: { commandId: 'cmd-reject' } as never, processed: 1 } },
+    async createChannelInteraction() { return { interaction: { interactionId: 'interaction-1' } as never, plaintextToken: 'token-1' } },
+    async resolveChannelInteraction() { return { interaction: {}, command: { commandId: 'cmd-interaction' } as never, processed: 1 } },
+    subscribeSessionEvents() { return { close() {} } },
+    subscribeDeliveries() { return { close() {} } },
+    async updateCursor() { return { ok: false, reason: 'not_found' } },
+    async ackDelivery() { return null },
+    artifactUrl() { return 'https://cloud.example.test/api/sessions/session-1/artifacts/artifact-1' },
+  }
+  const config = resolveGatewayConfig({
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+    OPEN_COWORK_GATEWAY_ADMIN_TOKEN: 'admin-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud, undefined, { subscribeDeliveries: false })
+
+  await runtime.start()
+  try {
+    await runtime.providers.emitFake('fake', { id: 'provider-event-1', text: 'ship it', chatId: 'chat-1', userId: 'user-1' })
+    await runtime.providers.emitFake('fake', { id: 'provider-event-1', text: 'ship it again', chatId: 'chat-1', userId: 'user-1' })
+
+    assert.deepEqual(prompted, [{ text: 'ship it', commandId: 'event-fake-provider-event-1-message' }])
+    assert.deepEqual(claims, [
+      { providerEventId: 'provider-event-1', providerInstanceId: 'fake', eventType: 'message' },
+      { providerEventId: 'provider-event-1', providerInstanceId: 'fake', eventType: 'message' },
+    ])
+    assert.deepEqual(completed, [
+      { eventId: 'event-fake-provider-event-1-message', status: 'processed' },
+    ])
+    assert.equal(runtime.metrics.incomingMessages, 2)
+    assert.equal(runtime.metrics.promptedMessages, 1)
+  } finally {
+    await runtime.stop()
+  }
+})
+
+test('gateway runtime does not make an already prompted provider event retryable when completion fails', async () => {
+  const prompted: Array<{ text: string, commandId?: string | null }> = []
+  const completed: Array<{ eventId: string, status: string }> = []
+  const seen = new Set<string>()
+  const cloud: CloudGateway = {
+    async resolveIdentity(input) {
+      return {
+        identityId: `identity-${input.externalUserId}`,
+        orgId: 'tenant-1',
+        provider: input.provider,
+        externalWorkspaceId: input.externalWorkspaceId || null,
+        externalUserId: input.externalUserId,
+        accountId: null,
+        role: 'member',
+        status: 'active',
+        metadata: {},
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+    async bindSession(input) {
+      return {
+        binding: {
+          bindingId: 'session-binding-1',
+          orgId: 'tenant-1',
+          agentId: 'agent-1',
+          channelBindingId: input.channelBindingId,
+          provider: input.provider,
+          externalWorkspaceId: input.externalWorkspaceId || null,
+          externalThreadId: input.externalThreadId,
+          externalChatId: input.externalChatId,
+          sessionId: 'session-1',
+          lastEventSequence: 0,
+          lastWorkspaceSequence: 0,
+          lastChatMessageId: null,
+          status: 'active',
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+        session: {
+          session: { sessionId: 'session-1' },
+          projection: null,
+        },
+      } as never
+    },
+    async findSessionByThread() { return null },
+    async getSession() { return { session: { sessionId: 'session-1' }, projection: null } as never },
+    async prompt(input) {
+      prompted.push({ text: input.text, commandId: input.commandId })
+      return { binding: { bindingId: input.bindingId } as never, command: { commandId: input.commandId || 'cmd-1' } as never, processed: 1 }
+    },
+    async claimProviderEvent(input) {
+      const key = `${input.providerInstanceId}:${input.eventType}:${input.providerEventId}`
+      if (seen.has(key)) {
+        return {
+          event: providerEventRecord({ ...input, status: 'processing' }),
+          claimed: false,
+          duplicate: true,
+        }
+      }
+      seen.add(key)
+      return {
+        event: providerEventRecord(input),
+        claimed: true,
+        duplicate: false,
+      }
+    },
+    async completeProviderEvent(eventId, input) {
+      completed.push({ eventId, status: input.status })
+      if (input.status === 'processed') throw new Error('provider event completion unavailable')
+      return providerEventRecord({
+        provider: 'fake',
+        providerInstanceId: 'fake',
+        providerEventId: eventId,
+        eventType: 'message',
+        claimedBy: input.claimedBy,
+        status: input.status,
+      })
+    },
+    async abortSession() { return { command: { commandId: 'cmd-abort' } as never, processed: 1, view: {} as never } },
+    async respondToPermission() { return { command: { commandId: 'cmd-permission' } as never, processed: 1 } },
+    async replyToQuestion() { return { command: { commandId: 'cmd-question' } as never, processed: 1 } },
+    async rejectQuestion() { return { command: { commandId: 'cmd-reject' } as never, processed: 1 } },
+    async createChannelInteraction() { return { interaction: { interactionId: 'interaction-1' } as never, plaintextToken: 'token-1' } },
+    async resolveChannelInteraction() { return { interaction: {}, command: { commandId: 'cmd-interaction' } as never, processed: 1 } },
+    subscribeSessionEvents() { return { close() {} } },
+    subscribeDeliveries() { return { close() {} } },
+    async updateCursor() { return { ok: false, reason: 'not_found' } },
+    async ackDelivery() { return null },
+    artifactUrl() { return 'https://cloud.example.test/api/sessions/session-1/artifacts/artifact-1' },
+  }
+  const config = resolveGatewayConfig({
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+    OPEN_COWORK_GATEWAY_ADMIN_TOKEN: 'admin-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud, undefined, { subscribeDeliveries: false })
+
+  await runtime.start()
+  try {
+    await assert.rejects(
+      () => runtime.providers.emitFake('fake', { id: 'provider-event-1', text: 'ship it', chatId: 'chat-1', userId: 'user-1' }),
+      /provider event completion unavailable/,
+    )
+    await runtime.providers.emitFake('fake', { id: 'provider-event-1', text: 'ship it again', chatId: 'chat-1', userId: 'user-1' })
+
+    assert.deepEqual(prompted, [{ text: 'ship it', commandId: 'event-fake-provider-event-1-message' }])
+    assert.deepEqual(completed, [
+      { eventId: 'event-fake-provider-event-1-message', status: 'processed' },
+    ])
+    assert.equal(runtime.metrics.promptedMessages, 1)
+  } finally {
+    await runtime.stop()
+  }
+})
+
+test('gateway runtime marks claimed provider events failed when prompting fails', async () => {
+  const completed: Array<{ status: string, retryable?: boolean, lastError?: string | null }> = []
+  const cloud: CloudGateway = {
+    async resolveIdentity(input) {
+      return {
+        identityId: `identity-${input.externalUserId}`,
+        orgId: 'tenant-1',
+        provider: input.provider,
+        externalWorkspaceId: input.externalWorkspaceId || null,
+        externalUserId: input.externalUserId,
+        accountId: null,
+        role: 'member',
+        status: 'active',
+        metadata: {},
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+    async bindSession(input) {
+      return {
+        binding: {
+          bindingId: 'session-binding-1',
+          orgId: 'tenant-1',
+          agentId: 'agent-1',
+          channelBindingId: input.channelBindingId,
+          provider: input.provider,
+          externalWorkspaceId: input.externalWorkspaceId || null,
+          externalThreadId: input.externalThreadId,
+          externalChatId: input.externalChatId,
+          sessionId: 'session-1',
+          lastEventSequence: 0,
+          lastWorkspaceSequence: 0,
+          lastChatMessageId: null,
+          status: 'active',
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+        session: {
+          session: { sessionId: 'session-1' },
+          projection: null,
+        },
+      } as never
+    },
+    async findSessionByThread() { return null },
+    async getSession() { return { session: { sessionId: 'session-1' }, projection: null } as never },
+    async prompt() {
+      throw new Error('OpenCode prompt unavailable')
+    },
+    async claimProviderEvent(input) {
+      return {
+        event: providerEventRecord(input),
+        claimed: true,
+        duplicate: false,
+      }
+    },
+    async completeProviderEvent(_eventId, input) {
+      completed.push({
+        status: input.status,
+        retryable: input.retryable,
+        lastError: input.lastError,
+      })
+      return providerEventRecord({
+        provider: 'cli',
+        providerInstanceId: 'fake',
+        providerEventId: 'provider-event-1',
+        eventType: 'message',
+        claimedBy: input.claimedBy,
+        status: input.status,
+      })
+    },
+    async abortSession() { return { command: { commandId: 'cmd-abort' } as never, processed: 1, view: {} as never } },
+    async respondToPermission() { return { command: { commandId: 'cmd-permission' } as never, processed: 1 } },
+    async replyToQuestion() { return { command: { commandId: 'cmd-question' } as never, processed: 1 } },
+    async rejectQuestion() { return { command: { commandId: 'cmd-reject' } as never, processed: 1 } },
+    async createChannelInteraction() { return { interaction: { interactionId: 'interaction-1' } as never, plaintextToken: 'token-1' } },
+    async resolveChannelInteraction() { return { interaction: {}, command: { commandId: 'cmd-interaction' } as never, processed: 1 } },
+    subscribeSessionEvents() { return { close() {} } },
+    subscribeDeliveries() { return { close() {} } },
+    async updateCursor() { return { ok: false, reason: 'not_found' } },
+    async ackDelivery() { return null },
+    artifactUrl() { return 'https://cloud.example.test/api/sessions/session-1/artifacts/artifact-1' },
+  }
+  const config = resolveGatewayConfig({
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+    OPEN_COWORK_GATEWAY_ADMIN_TOKEN: 'admin-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud, undefined, { subscribeDeliveries: false })
+
+  await runtime.start()
+  try {
+    await assert.rejects(
+      () => runtime.providers.emitFake('fake', { id: 'provider-event-1', text: 'ship it', chatId: 'chat-1', userId: 'user-1' }),
+      /OpenCode prompt unavailable/,
+    )
+    assert.deepEqual(completed, [{
+      status: 'failed',
+      retryable: false,
+      lastError: 'OpenCode prompt unavailable',
+    }])
+    assert.equal(runtime.metrics.promptedMessages, 0)
+    assert.equal(runtime.metrics.errors, 1)
+  } finally {
+    await runtime.stop()
+  }
+})
+
+test('gateway webhook replay stays durable across runtime restarts through Cloud provider event claims', async () => {
+  const prompted: string[] = []
+  const claims: Array<{ providerEventId: string, providerInstanceId: string, eventType: string }> = []
+  const seen = new Set<string>()
+  const cloud: CloudGateway = {
+    async resolveIdentity(input) {
+      return {
+        identityId: `identity-${input.externalUserId}`,
+        orgId: 'tenant-1',
+        provider: input.provider,
+        externalWorkspaceId: input.externalWorkspaceId || null,
+        externalUserId: input.externalUserId,
+        accountId: null,
+        role: 'member',
+        status: 'active',
+        metadata: {},
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }
+    },
+    async bindSession(input) {
+      return {
+        binding: {
+          bindingId: 'session-binding-1',
+          orgId: 'tenant-1',
+          agentId: 'agent-1',
+          channelBindingId: input.channelBindingId,
+          provider: input.provider,
+          externalWorkspaceId: input.externalWorkspaceId || null,
+          externalThreadId: input.externalThreadId,
+          externalChatId: input.externalChatId,
+          sessionId: 'session-1',
+          lastEventSequence: 0,
+          lastWorkspaceSequence: 0,
+          lastChatMessageId: null,
+          status: 'active',
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+        session: {
+          session: { sessionId: 'session-1' },
+          projection: null,
+        },
+      } as never
+    },
+    async findSessionByThread() { return null },
+    async getSession() { return { session: { sessionId: 'session-1' }, projection: null } as never },
+    async prompt(input) {
+      prompted.push(input.text)
+      return { binding: { bindingId: input.bindingId } as never, command: { commandId: 'cmd-1' } as never, processed: 1 }
+    },
+    async claimProviderEvent(input) {
+      claims.push({
+        providerEventId: input.providerEventId,
+        providerInstanceId: input.providerInstanceId,
+        eventType: input.eventType,
+      })
+      const key = `${input.providerInstanceId}:${input.eventType}:${input.providerEventId}`
+      if (seen.has(key)) {
+        return {
+          event: providerEventRecord({ ...input, status: 'processed' }),
+          claimed: false,
+          duplicate: true,
+        }
+      }
+      seen.add(key)
+      return {
+        event: providerEventRecord(input),
+        claimed: true,
+        duplicate: false,
+      }
+    },
+    async completeProviderEvent(eventId, input) {
+      return providerEventRecord({
+        provider: 'webhook',
+        providerInstanceId: 'webhook',
+        providerEventId: eventId,
+        eventType: 'message',
+        claimedBy: input.claimedBy,
+        status: input.status,
+      })
+    },
+    async abortSession() { return { command: { commandId: 'cmd-abort' } as never, processed: 1, view: {} as never } },
+    async respondToPermission() { return { command: { commandId: 'cmd-permission' } as never, processed: 1 } },
+    async replyToQuestion() { return { command: { commandId: 'cmd-question' } as never, processed: 1 } },
+    async rejectQuestion() { return { command: { commandId: 'cmd-reject' } as never, processed: 1 } },
+    async createChannelInteraction() { return { interaction: { interactionId: 'interaction-1' } as never, plaintextToken: 'token-1' } },
+    async resolveChannelInteraction() { return { interaction: {}, command: { commandId: 'cmd-interaction' } as never, processed: 1 } },
+    subscribeSessionEvents() { return { close() {} } },
+    subscribeDeliveries() { return { close() {} } },
+    async updateCursor() { return { ok: false, reason: 'not_found' } },
+    async ackDelivery() { return null },
+    artifactUrl() { return 'https://cloud.example.test/api/sessions/session-1/artifacts/artifact-1' },
+  }
+  const config = resolveGatewayConfig({
+    providers: [{
+      id: 'webhook',
+      kind: 'webhook',
+      channelBindingId: 'webhook-binding',
+      credentials: {
+        sharedSecret: 'webhook-secret',
+      },
+      settings: {
+        deliveryUrl: 'https://bridge.example.test/outbound',
+      },
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+    OPEN_COWORK_GATEWAY_PORT: '0',
+    OPEN_COWORK_GATEWAY_ADMIN_TOKEN: 'admin-token',
+  })
+  const body = JSON.stringify({
+    id: 'signed-provider-event-1',
+    target: { chatId: 'chat-1' },
+    sender: { userId: 'user-1' },
+    text: 'ship it',
+  })
+  const headers = signedWebhookHeaders(body, 'webhook-secret')
+
+  async function postThroughFreshRuntime() {
+    const runtime = createGatewayRuntime(config, cloud, undefined, { subscribeDeliveries: false })
+    await runtime.start()
+    const http = createGatewayHttpServer(config, runtime)
+    const url = await http.listen()
+    try {
+      const response = await fetch(`${url}/webhooks/webhook`, {
+        method: 'POST',
+        headers,
+        body,
+      })
+      assert.equal(response.status, 202)
+    } finally {
+      await http.close()
+      await runtime.stop()
+    }
+  }
+
+  await postThroughFreshRuntime()
+  await postThroughFreshRuntime()
+
+  assert.deepEqual(prompted, ['ship it'])
+  assert.deepEqual(claims, [
+    { providerEventId: 'signed-provider-event-1', providerInstanceId: 'webhook', eventType: 'message' },
+    { providerEventId: 'signed-provider-event-1', providerInstanceId: 'webhook', eventType: 'message' },
+  ])
 })
 
 test('gateway diagnostics redact provider health errors', async () => {
@@ -1062,6 +1629,61 @@ test('gateway daemon rejects delivery admin controls without the admin token', a
   }
 })
 
+test('gateway runtime propagates stable Cloud delivery ids to provider sends', async () => {
+  let onDelivery: ((delivery: unknown) => void) | null = null
+  const acks: Array<{ deliveryId: string, input: Record<string, unknown> }> = []
+  const cloud = {
+    subscribeDeliveries(input: { onDelivery: (delivery: unknown) => void }) {
+      onDelivery = input.onDelivery
+      return { close() {} }
+    },
+    async ackDelivery(deliveryId: string, input: Record<string, unknown>) {
+      acks.push({ deliveryId, input })
+      return { deliveryId, ...input } as never
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    server: {
+      adminToken: 'admin-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud)
+  const provider = runtime.providers.get('fake')?.provider as {
+    capabilities: { maxTextLength: number }
+    sent: Array<{ text?: string, options?: { deliveryId?: string } }>
+  } | undefined
+  assert.ok(provider)
+
+  await runtime.start()
+  try {
+    onDelivery?.(deliveryRecord({ deliveryId: 'delivery-single', payload: { text: 'short' } }))
+    await waitFor(() => acks.length === 1)
+    assert.equal(provider.sent[0]?.options?.deliveryId, 'delivery-single')
+    assert.equal(acks[0]?.input.status, 'sent')
+
+    provider.capabilities.maxTextLength = 100
+    onDelivery?.(deliveryRecord({ deliveryId: 'delivery-chunked', payload: { text: 'x'.repeat(205) } }))
+    await waitFor(() => acks.length === 2)
+    assert.deepEqual(provider.sent.slice(1).map((entry) => entry.options?.deliveryId), [
+      'delivery-chunked:chunk:1',
+      'delivery-chunked:chunk:2',
+      'delivery-chunked:chunk:3',
+    ])
+    assert.equal(provider.sent.slice(1).every((entry) => (entry.text?.length ?? 0) <= 100), true)
+    assert.equal(acks[1]?.input.status, 'sent')
+  } finally {
+    await runtime.stop()
+  }
+})
+
 test('gateway runtime retries transient deliveries and marks permanent failures dead', async () => {
   let onDelivery: ((delivery: unknown) => void) | null = null
   const acks: Array<{ deliveryId: string, input: Record<string, unknown> }> = []
@@ -1179,6 +1801,7 @@ test('gateway runtime drains in-flight deliveries before provider shutdown', asy
 function deliveryRecord(overrides: Partial<{
   deliveryId: string
   attemptCount: number
+  payload: Record<string, unknown>
 }> = {}) {
   return {
     deliveryId: overrides.deliveryId || 'delivery-1',
@@ -1192,7 +1815,7 @@ function deliveryRecord(overrides: Partial<{
       externalThreadId: 'thread-1',
     },
     eventType: 'workflow.completed',
-    payload: { text: 'delivery text' },
+    payload: overrides.payload ?? { text: 'delivery text' },
     status: 'claimed',
     attemptCount: overrides.attemptCount ?? 1,
     claimedBy: 'gateway:test',

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -5,7 +5,7 @@ import type {
   SentMessage,
 } from '@open-cowork/gateway-channel'
 import { chunkText } from '@open-cowork/gateway-channel'
-import type { ChannelDeliveryRecord, CloudChannelProviderId } from '@open-cowork/cloud-client'
+import { isCloudTransportError, type ChannelDeliveryRecord, type CloudChannelProviderId } from '@open-cowork/cloud-client'
 
 import type { CloudGateway } from './cloud-gateway.js'
 import type { GatewayConfig, GatewayProviderConfig } from './config.js'
@@ -16,6 +16,7 @@ import { createGatewayProviderRegistry, type GatewayProviderRegistry, type Provi
 import { createGatewaySessionStreamManager, type GatewaySessionStreamManager } from './session-stream-manager.js'
 
 const MAX_DELIVERY_ATTEMPTS = 5
+const PROVIDER_EVENT_CLAIM_TTL_MS = 5 * 60_000
 
 export type GatewayRuntime = {
   readonly metrics: GatewayMetrics
@@ -49,7 +50,7 @@ export function createGatewayRuntime(
     streams,
     async start() {
       if (started) return
-      await providers.start((providerConfig, message) => handleMessage(providerConfig, message, cloud, providers, streams, metrics))
+      await providers.start((providerConfig, message) => handleMessage(providerConfig, message, cloud, providers, streams, metrics, claimedBy))
       started = true
       if (options.subscribeDeliveries !== false) {
         deliverySubscriptions.push(cloud.subscribeDeliveries({
@@ -112,21 +113,48 @@ async function handleMessage(
   providers: GatewayProviderRegistry,
   streams: GatewaySessionStreamManager,
   metrics: GatewayMetrics,
+  claimedBy: string,
 ) {
   metrics.incomingMessages += 1
   const provider = message.provider as CloudChannelProviderId
   const externalWorkspaceId = providerConfig.externalWorkspaceId ?? null
   const externalUserId = message.sender.providerUserId
+  let claimedEvent: { eventId: string } | null = null
+  let sideEffectCommitted = false
 
   try {
     const registration = providers.get(providerConfig.id)
     if (!registration) throw new Error(`Unknown gateway provider ${providerConfig.id}.`)
+    const eventClaim = await cloud.claimProviderEvent({
+      provider,
+      providerInstanceId: providerConfig.id,
+      externalWorkspaceId,
+      providerEventId: providerEventIdForMessage(message),
+      eventType: providerEventTypeForMessage(message),
+      claimedBy,
+      ttlMs: PROVIDER_EVENT_CLAIM_TTL_MS,
+      metadata: providerEventMetadata(message, providerConfig),
+    })
+    if (!eventClaim.claimed) return
+    claimedEvent = { eventId: eventClaim.event.eventId }
+
     if (await routeGatewayInteraction({ cloud, provider: registration.provider, providerConfig, message, metrics })) {
+      sideEffectCommitted = true
+      await cloud.completeProviderEvent(claimedEvent.eventId, {
+        claimedBy,
+        status: 'processed',
+      })
       return
     }
 
     const text = message.text.trim()
-    if (!text) return
+    if (!text) {
+      await cloud.completeProviderEvent(claimedEvent.eventId, {
+        claimedBy,
+        status: 'processed',
+      })
+      return
+    }
 
     const identity = await cloud.resolveIdentity({
       provider,
@@ -152,13 +180,27 @@ async function handleMessage(
       bindingId: bound.binding.bindingId,
       text,
       agent: providerConfig.defaultAgent,
+      commandId: claimedEvent.eventId,
       identityId: identity.identityId,
       provider,
       externalWorkspaceId,
       externalUserId,
     })
+    sideEffectCommitted = true
     metrics.promptedMessages += 1
+    await cloud.completeProviderEvent(claimedEvent.eventId, {
+      claimedBy,
+      status: 'processed',
+    })
   } catch (error) {
+    if (claimedEvent && !sideEffectCommitted) {
+      await cloud.completeProviderEvent(claimedEvent.eventId, {
+        claimedBy,
+        status: 'failed',
+        retryable: providerEventFailureIsRetryable(error),
+        lastError: error instanceof Error ? error.message : String(error),
+      }).catch(() => {})
+    }
     metrics.errors += 1
     throw error
   }
@@ -216,8 +258,11 @@ async function sendDelivery(provider: ChannelProvider, delivery: ChannelDelivery
       ? delivery.payload.message
       : JSON.stringify(delivery.payload)
   let sent: SentMessage | null = null
-  for (const chunk of chunkText(text, provider.capabilities.maxTextLength)) {
-    sent = await provider.sendText(target, chunk)
+  const chunks = chunkText(text, provider.capabilities.maxTextLength)
+  for (const [index, chunk] of chunks.entries()) {
+    sent = await provider.sendText(target, chunk, {
+      deliveryId: chunks.length === 1 ? delivery.deliveryId : `${delivery.deliveryId}:chunk:${index + 1}`,
+    })
   }
   if (!sent) throw new Error('Channel delivery payload was empty.')
   return sent
@@ -246,4 +291,38 @@ function readDeliveryTarget(delivery: ChannelDeliveryRecord, provider: Pick<Chan
 
 function stringField(value: unknown) {
   return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function providerEventIdForMessage(message: IncomingChannelMessage) {
+  return stringField(message.providerEventId)
+    || stringField(message.providerMessageId)
+    || stringField(message.interaction?.id)
+    || message.id
+}
+
+function providerEventTypeForMessage(message: IncomingChannelMessage) {
+  if (message.interaction) return 'interaction'
+  if (message.isCommand) return 'command'
+  return 'message'
+}
+
+function providerEventMetadata(message: IncomingChannelMessage, providerConfig: GatewayProviderConfig) {
+  return {
+    providerKind: message.providerKind || providerConfig.kind,
+    providerMessageId: stringField(message.providerMessageId),
+    targetChatId: stringField(message.target.chatId),
+    targetThreadId: stringField(message.target.threadId),
+    senderUserId: stringField(message.sender.providerUserId),
+    command: stringField(message.command),
+    attachmentCount: message.attachments.length,
+    interactionKind: message.interaction?.kind || null,
+    receivedAt: message.receivedAt.toISOString(),
+  }
+}
+
+function providerEventFailureIsRetryable(error: unknown) {
+  if (isCloudTransportError(error)) {
+    return ['network', 'abort', 'timeout', 'server', 'http', 'rate_limited', 'sse', 'request'].includes(error.kind)
+  }
+  return false
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,11 @@ workspace authorities:
   In this mode Gateway never imports the OpenCode SDK, starts OpenCode, or owns
   control-plane Postgres state. The current `apps/gateway` daemon is this mode
   and must use `productMode=cloud_channel`.
+  Gateway-owned memory is only a fast path for provider SDK state, replay
+  caches, delivery drains, and stream subscriptions; durable idempotency lives
+  in Cloud. Inbound provider messages must claim a Cloud provider-event record
+  before any session bind or prompt, and outbound provider sends must carry the
+  Cloud delivery id as the downstream idempotency key.
 - **Standalone Team Gateway** is a Gateway-owned execution authority for
   private VPS/server/Kubernetes deployments. It may supervise a private
   OpenCode runtime and own Gateway Postgres/control-plane state, but it must

--- a/docs/gateway-appliance.md
+++ b/docs/gateway-appliance.md
@@ -220,6 +220,29 @@ Gateway closes new Cloud delivery subscriptions, drains in-flight delivery
 sends, acknowledges completed deliveries, then stops providers. A restart
 resumes from Cloud-owned cursors and delivery records.
 
+Inbound provider events are also Cloud-owned. Before Gateway binds a channel
+thread or sends a prompt to Cloud, it claims a durable provider event keyed by
+organization, provider, provider instance, external workspace, event type, and
+the provider event id. A duplicate or already processed event becomes a no-op
+even if the Gateway process restarted and lost its provider-local replay cache.
+A processing claim can be reclaimed only after its lease expires, and a failed
+claim can be retried only when it was marked retryable.
+
+Production providers must send stable inbound event ids. Telegram uses
+`update_id`; Slack uses the signed event or interaction id; email and generic
+webhook/bridge providers must provide a stable message, delivery, or webhook
+`id`. Generic webhook payloads that omit `id` are accepted for developer
+convenience but cannot receive durable duplicate suppression after a process
+restart because the provider must synthesize a new event id.
+
+Outbound delivery idempotency flows the other direction. Cloud delivery ids are
+the canonical downstream idempotency keys. Gateway passes the Cloud
+`deliveryId` to provider sends; webhook and bridge providers include it as
+`deliveryId`, `idempotencyKey`, and
+`x-open-cowork-gateway-delivery-id`. Multi-part text deliveries use stable
+chunk ids in the form `<cloud-delivery-id>:chunk:<n>` so downstream bridges can
+dedupe each chunk without conflating it with the parent delivery.
+
 Session-event rendering is ordered by Cloud event sequence. If provider
 rendering fails transiently, Gateway reconnects from the last persisted cursor
 and prevents later queued events from jumping the failed event. If retry budget

--- a/docs/gateway-provider-readiness.md
+++ b/docs/gateway-provider-readiness.md
@@ -104,6 +104,14 @@ the demo override.
   default; legacy shared-secret headers are local compatibility only.
 - Gateway service-token authority is separate from inbound actor authority.
   Cloud resolves the channel actor and enforces approval authority.
+- Production providers must map incoming messages, commands, and interactions
+  to stable provider event ids before Gateway prompts Cloud. Replaying the same
+  signed provider event after a Gateway restart must hit the Cloud
+  provider-event claim and produce no second prompt.
+- Provider sends must preserve the Cloud delivery id as the provider delivery
+  id when the provider API allows it. Webhook and bridge providers must also
+  send that value as `deliveryId`, `idempotencyKey`, and
+  `x-open-cowork-gateway-delivery-id`.
 - Diagnostics, logs, provider health, delivery summaries, and metrics must not
   expose raw provider tokens, webhook secrets, API tokens, local paths, or
   signed artifact URLs.

--- a/packages/cloud-client/src/contracts.ts
+++ b/packages/cloud-client/src/contracts.ts
@@ -63,6 +63,8 @@ export type CloudChannelProviderId = CloudChannelProviderKind | `${CloudChannelP
 export type CloudChannelIdentityRole = 'owner' | 'admin' | 'member' | 'approver' | 'viewer'
 export type CloudChannelIdentityStatus = 'active' | 'disabled' | 'pending'
 export type CloudChannelDeliveryStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead'
+export type CloudChannelProviderEventType = 'message' | 'command' | 'interaction'
+export type CloudChannelProviderEventStatus = 'received' | 'processing' | 'processed' | 'failed'
 export type CloudByokSecretStatus = 'pending_validation' | 'active' | 'disabled' | 'expired' | 'invalid' | 'unsupported'
 
 export type CloudByokSecretMetadata = {
@@ -189,6 +191,32 @@ export type ChannelDeliveryRecord = {
   lastError: string | null
   createdAt: string
   updatedAt: string
+}
+
+export type ChannelProviderEventRecord = {
+  eventId: string
+  orgId: string
+  provider: CloudChannelProviderId
+  providerInstanceId: string
+  externalWorkspaceId: string | null
+  providerEventId: string
+  eventType: CloudChannelProviderEventType
+  status: CloudChannelProviderEventStatus
+  claimedBy: string | null
+  claimExpiresAt: string | null
+  attemptCount: number
+  retryable: boolean
+  lastError: string | null
+  metadata: Record<string, unknown>
+  processedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChannelProviderEventClaimResult = {
+  event: ChannelProviderEventRecord
+  claimed: boolean
+  duplicate: boolean
 }
 
 export type ChannelActorInput = {
@@ -703,7 +731,24 @@ export type CloudTransportAdapter = {
     bindingId: string
     text: string
     agent?: string | null
+    commandId?: string | null
   }): Promise<CloudChannelPromptMutationResponse>
+  claimChannelProviderEvent?(input: {
+    provider: CloudChannelProviderId
+    providerInstanceId: string
+    externalWorkspaceId?: string | null
+    providerEventId: string
+    eventType: CloudChannelProviderEventType
+    claimedBy: string
+    ttlMs?: number | null
+    metadata?: Record<string, unknown>
+  }): Promise<ChannelProviderEventClaimResult>
+  completeChannelProviderEvent?(eventId: string, input: {
+    claimedBy: string
+    status: Extract<CloudChannelProviderEventStatus, 'processed' | 'failed'>
+    retryable?: boolean
+    lastError?: string | null
+  }): Promise<ChannelProviderEventRecord | null>
   updateChannelCursor?(input: {
     bindingId: string
     lastEventSequence: number

--- a/packages/cloud-client/src/domain-clients/channels.ts
+++ b/packages/cloud-client/src/domain-clients/channels.ts
@@ -5,10 +5,14 @@ export type {
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
   ChannelInteractionRecord,
+  ChannelProviderEventClaimResult,
+  ChannelProviderEventRecord,
   ChannelSessionBindingRecord,
   CloudChannelDeliveryStatus,
   CloudChannelIdentityRole,
   CloudChannelIdentityStatus,
+  CloudChannelProviderEventStatus,
+  CloudChannelProviderEventType,
   CloudChannelProviderId,
   CloudChannelProviderKind,
   HeadlessAgentRecord,
@@ -23,10 +27,14 @@ import type {
   ChannelDeliveryRecord,
   ChannelIdentityRecord,
   ChannelInteractionRecord,
+  ChannelProviderEventClaimResult,
+  ChannelProviderEventRecord,
   ChannelSessionBindingRecord,
   CloudChannelDeliveryStatus,
   CloudChannelIdentityRole as ChannelIdentityRole,
   CloudChannelIdentityStatus as ChannelIdentityStatus,
+  CloudChannelProviderEventStatus,
+  CloudChannelProviderEventType,
   CloudChannelPromptMutationResponse,
   CloudChannelInteractionMutationResponse,
   CloudChannelProviderId as ChannelProviderId,
@@ -98,7 +106,24 @@ export type CloudChannelsClient = {
     bindingId: string
     text: string
     agent?: string | null
+    commandId?: string | null
   }): Promise<CloudChannelPromptMutationResponse>
+  claimChannelProviderEvent(input: {
+    provider: ChannelProviderId
+    providerInstanceId: string
+    externalWorkspaceId?: string | null
+    providerEventId: string
+    eventType: CloudChannelProviderEventType
+    claimedBy: string
+    ttlMs?: number | null
+    metadata?: Record<string, unknown>
+  }): Promise<ChannelProviderEventClaimResult>
+  completeChannelProviderEvent(eventId: string, input: {
+    claimedBy: string
+    status: Extract<CloudChannelProviderEventStatus, 'processed' | 'failed'>
+    retryable?: boolean
+    lastError?: string | null
+  }): Promise<ChannelProviderEventRecord | null>
   updateChannelCursor(input: {
     bindingId: string
     lastEventSequence: number
@@ -213,6 +238,18 @@ export function createCloudChannelsClient(context: CloudChannelsClientContext): 
         method: 'POST',
         body: input,
       })
+    },
+    claimChannelProviderEvent(input) {
+      return request('/api/channels/provider-events/claim', {
+        method: 'POST',
+        body: input,
+      })
+    },
+    async completeChannelProviderEvent(eventId, input) {
+      return (await request<{ event: ChannelProviderEventRecord | null }>(`/api/channels/provider-events/${encodePath(eventId)}/complete`, {
+        method: 'POST',
+        body: input,
+      })).event
     },
     async updateChannelCursor(input) {
       try {

--- a/packages/gateway-channel/src/conformance.ts
+++ b/packages/gateway-channel/src/conformance.ts
@@ -103,10 +103,12 @@ export async function runChannelProviderConformance(
   }
 
   await check("send text", async () => {
+    const deliveryId = "provider-conformance-text";
     const sent = await provider.sendText(input.target, "provider conformance text", {
-      deliveryId: "provider-conformance-text",
+      deliveryId,
     });
     validateSentMessage(sent, input.target, provider);
+    validateProviderDeliveryId(sent, deliveryId);
   });
 
   if (provider.capabilities.messageEditing) {
@@ -117,13 +119,15 @@ export async function runChannelProviderConformance(
 
   if (provider.capabilities.inlineButtons) {
     await check("send buttons", async () => {
+      const deliveryId = "provider-conformance-buttons";
       const sent = await provider.sendButtons(input.target, "provider conformance buttons", [
         [{ label: "Approve", token: createProviderToken("p") }],
         [{ label: "Deny", token: createProviderToken("p"), style: "danger" }],
       ], {
-        deliveryId: "provider-conformance-buttons",
+        deliveryId,
       });
       validateSentMessage(sent, input.target, provider);
+      validateProviderDeliveryId(sent, deliveryId);
     });
   }
 
@@ -261,6 +265,12 @@ export function validateSentMessage(
     violations.push("sentAt must be a valid Date");
   }
   if (violations.length > 0) throw new Error(violations.join("; "));
+}
+
+function validateProviderDeliveryId(sent: SentMessage, expectedDeliveryId: string): void {
+  if (sent.providerDeliveryId !== undefined && sent.providerDeliveryId !== expectedDeliveryId) {
+    throw new Error(`sent providerDeliveryId ${sent.providerDeliveryId} does not match deliveryId ${expectedDeliveryId}`);
+  }
 }
 
 function validateProviderCapabilities(provider: ChannelProvider): void {

--- a/packages/gateway-provider-cli/src/cli-provider.ts
+++ b/packages/gateway-provider-cli/src/cli-provider.ts
@@ -146,10 +146,12 @@ export class CliProvider implements ChannelProvider {
   private async writeEvent(type: string, target: ChannelTarget, payload: Record<string, unknown>): Promise<SentMessage> {
     const messageId = randomUUID();
     const sentAt = this.now();
+    const providerDeliveryId = deliveryIdFromPayload(payload);
     this.writeJson({
       type,
       target: normalizeTarget(target),
       messageId,
+      providerDeliveryId,
       sentAt: sentAt.toISOString(),
       ...payload
     });
@@ -159,6 +161,7 @@ export class CliProvider implements ChannelProvider {
       chatId: target.chatId,
       threadId: target.threadId,
       messageId,
+      providerDeliveryId,
       sentAt
     };
   }
@@ -272,6 +275,11 @@ function cleanString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed || undefined;
+}
+
+function deliveryIdFromPayload(payload: Record<string, unknown>): string | undefined {
+  const options = payload.options;
+  return isRecord(options) ? cleanString(options.deliveryId) : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/gateway-provider-email/src/email-provider.ts
+++ b/packages/gateway-provider-email/src/email-provider.ts
@@ -151,7 +151,7 @@ export class EmailProvider implements ChannelProvider {
     }
   }
 
-  async sendText(target: ChannelTarget, text: string, _options?: SendOptions): Promise<SentMessage> {
+  async sendText(target: ChannelTarget, text: string, options?: SendOptions): Promise<SentMessage> {
     const messageId = emailMessageId();
     const result = await this.transport.send({
       from: this.config.from,
@@ -168,6 +168,7 @@ export class EmailProvider implements ChannelProvider {
       chatId: target.chatId,
       threadId: target.threadId || messageId,
       messageId: result?.messageId || messageId,
+      providerDeliveryId: options?.deliveryId,
       sentAt: new Date()
     };
   }

--- a/packages/gateway-provider-slack/src/slack-provider.ts
+++ b/packages/gateway-provider-slack/src/slack-provider.ts
@@ -144,7 +144,7 @@ export class SlackProvider implements ChannelProvider {
       unfurl_media: false,
       mrkdwn: options?.parseMode === "markdown"
     });
-    return sentMessage(target, stringField(result, "ts") || randomUUID());
+    return sentMessage(target, stringField(result, "ts") || randomUUID(), options?.deliveryId);
   }
 
   async editText(target: ChannelTarget, messageId: string, text: string, options?: SendOptions): Promise<void> {
@@ -173,7 +173,7 @@ export class SlackProvider implements ChannelProvider {
     return sentMessage(target, slackFileMessageTs(result) || stringField(result, "ts") || randomUUID());
   }
 
-  async sendButtons(target: ChannelTarget, text: string, buttons: ChannelButton[][]): Promise<SentMessage> {
+  async sendButtons(target: ChannelTarget, text: string, buttons: ChannelButton[][], options?: SendOptions): Promise<SentMessage> {
     validateSlackButtons(buttons);
     const result = await this.apiJson("chat.postMessage", {
       channel: target.chatId,
@@ -200,7 +200,7 @@ export class SlackProvider implements ChannelProvider {
         }))
       }))]
     });
-    return sentMessage(target, stringField(result, "ts") || randomUUID());
+    return sentMessage(target, stringField(result, "ts") || randomUUID(), options?.deliveryId);
   }
 
   async answerInteraction(_interactionId: string, _text?: string, _alert?: boolean): Promise<void> {
@@ -504,13 +504,14 @@ function validateSlackButtons(buttons: ChannelButton[][]): void {
   }
 }
 
-function sentMessage(target: ChannelTarget, messageId: string): SentMessage {
+function sentMessage(target: ChannelTarget, messageId: string, providerDeliveryId?: string): SentMessage {
   return {
     provider: target.provider,
     providerKind: target.providerKind ?? "slack",
     chatId: target.chatId,
     threadId: target.threadId || messageId,
     messageId,
+    providerDeliveryId,
     sentAt: new Date()
   };
 }

--- a/packages/gateway-provider-telegram/src/telegram-provider.ts
+++ b/packages/gateway-provider-telegram/src/telegram-provider.ts
@@ -185,7 +185,7 @@ export class TelegramProvider implements ChannelProvider {
       disable_notification: options?.disableNotification
     }));
 
-    return toSentMessage(target, sent.message_id);
+    return toSentMessage(target, sent.message_id, options?.deliveryId);
   }
 
   async editText(
@@ -212,6 +212,7 @@ export class TelegramProvider implements ChannelProvider {
     target: ChannelTarget,
     text: string,
     buttons: ChannelButton[][],
+    options?: SendOptions,
   ): Promise<SentMessage> {
     validateTelegramButtons(buttons);
     const keyboard = new InlineKeyboard();
@@ -227,7 +228,7 @@ export class TelegramProvider implements ChannelProvider {
       reply_markup: keyboard
     }));
 
-    return toSentMessage(target, sent.message_id);
+    return toSentMessage(target, sent.message_id, options?.deliveryId);
   }
 
   async answerInteraction(interactionId: string, text?: string, alert?: boolean): Promise<void> {
@@ -569,13 +570,14 @@ function toThreadId(threadId: string | null | undefined): number | undefined {
   return Number.isSafeInteger(numeric) ? numeric : undefined;
 }
 
-function toSentMessage(target: ChannelTarget, messageId: number): SentMessage {
+function toSentMessage(target: ChannelTarget, messageId: number, providerDeliveryId?: string): SentMessage {
   return {
     provider: target.provider,
     providerKind: target.providerKind ?? "telegram",
     chatId: target.chatId,
     threadId: target.threadId,
     messageId: String(messageId),
+    providerDeliveryId,
     sentAt: new Date()
   };
 }

--- a/packages/gateway-provider-webhook/src/webhook-provider.test.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.test.ts
@@ -242,7 +242,10 @@ describe("WebhookProvider", () => {
         }),
         body: expect.objectContaining({
           deliveryId: expect.any(String),
+          idempotencyKey: expect.any(String),
           provider: "whatsapp",
+          providerInstanceId: "whatsapp",
+          providerKind: "whatsapp",
           type: "buttons",
           target: {
             provider: "whatsapp",
@@ -260,7 +263,59 @@ describe("WebhookProvider", () => {
     expect((deliveries[0]?.body as { deliveryId?: string }).deliveryId).toBe(
       deliveries[0]?.headers["x-open-cowork-gateway-delivery-id"],
     );
+    expect((deliveries[0]?.body as { idempotencyKey?: string }).idempotencyKey).toBe(
+      deliveries[0]?.headers["x-open-cowork-gateway-delivery-id"],
+    );
     expect(deliveries[0]?.headers["x-open-cowork-gateway-webhook-secret"]).toBe(undefined);
+    expect(deliveries[0]?.headers["x-open-cowork-gateway-webhook-signature"]).toBe(
+      signWebhookDeliveryPayload(
+        deliveries[0]?.rawBody || "",
+        "secret",
+        deliveries[0]?.headers["x-open-cowork-gateway-webhook-timestamp"] || "",
+      ),
+    );
+  });
+
+  it("uses caller supplied delivery ids as downstream idempotency keys", async () => {
+    const deliveries: Array<{ headers: Record<string, string>; rawBody: string; body: unknown }> = [];
+    const provider = new WebhookProvider({
+      providerId: "webhook-support",
+      deliveryUrl: "https://bridge.example.test/gateway",
+      sharedSecret: "secret",
+      fetch: async (_input, init) => {
+        const rawBody = String(init?.body);
+        deliveries.push({
+          headers: Object.fromEntries(new Headers(init?.headers).entries()),
+          rawBody,
+          body: JSON.parse(rawBody)
+        });
+        return new Response(JSON.stringify({ messageId: "bridge-message-id" }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    });
+
+    const sent = await provider.sendText(
+      { provider: "webhook-support", chatId: "team-chat" },
+      "hello",
+      { deliveryId: "cloud-delivery-1" },
+    );
+
+    expect(sent).toMatchObject({
+      providerDeliveryId: "cloud-delivery-1",
+      messageId: "bridge-message-id"
+    });
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.headers["x-open-cowork-gateway-delivery-id"]).toBe("cloud-delivery-1");
+    expect(deliveries[0]?.body).toMatchObject({
+      deliveryId: "cloud-delivery-1",
+      idempotencyKey: "cloud-delivery-1",
+      provider: "webhook-support",
+      providerInstanceId: "webhook-support",
+      providerKind: "webhook",
+      type: "text"
+    });
     expect(deliveries[0]?.headers["x-open-cowork-gateway-webhook-signature"]).toBe(
       signWebhookDeliveryPayload(
         deliveries[0]?.rawBody || "",

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -192,7 +192,7 @@ export class WebhookProvider implements ChannelProvider {
     });
   }
 
-  async sendButtons(target: ChannelTarget, text: string, buttons: ChannelButton[][]): Promise<SentMessage> {
+  async sendButtons(target: ChannelTarget, text: string, buttons: ChannelButton[][], options?: SendOptions): Promise<SentMessage> {
     if (!this.capabilities.inlineButtons) {
       throw new Error(`${this.id} bridge does not support inline buttons`);
     }
@@ -202,7 +202,8 @@ export class WebhookProvider implements ChannelProvider {
       type: "buttons",
       target,
       text,
-      buttons
+      buttons,
+      options
     });
   }
 
@@ -229,15 +230,22 @@ export class WebhookProvider implements ChannelProvider {
     });
   }
 
-  private async deliver(payload: Record<string, unknown> & { target?: ChannelTarget }): Promise<SentMessage> {
+  private async deliver(payload: Record<string, unknown> & { target?: ChannelTarget; options?: SendOptions }): Promise<SentMessage> {
     if (payload.target && payload.target.provider !== this.id) {
       throw new Error(`Webhook bridge ${this.id} cannot deliver target for provider ${payload.target.provider}`);
     }
     const normalizedTarget = payload.target ? normalizeOutboundTarget(payload.target, this.id, this.kind) : undefined;
     const normalizedPayload = normalizedTarget ? { ...payload, target: normalizedTarget } : payload;
     const fetchImpl = this.config.fetch ?? globalThis.fetch;
-    const deliveryId = randomUUID();
-    const body = JSON.stringify({ deliveryId, provider: this.id, providerKind: this.kind, ...normalizedPayload });
+    const deliveryId = deliveryIdForPayload(normalizedPayload);
+    const body = JSON.stringify({
+      deliveryId,
+      idempotencyKey: deliveryId,
+      provider: this.id,
+      providerInstanceId: this.id,
+      providerKind: this.kind,
+      ...normalizedPayload
+    });
     const response = await withWebhookRetry(async () => {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), normalizeDeliveryTimeoutMs(this.config.deliveryTimeoutMs));
@@ -879,6 +887,10 @@ function serializeOutgoingFile(file: OutgoingFile): Record<string, unknown> {
     mimeType: cleanOptionalString(file.mimeType, "Webhook outgoing file.mimeType", 255),
     dataBase64: Buffer.from(file.data).toString("base64")
   };
+}
+
+function deliveryIdForPayload(payload: { options?: SendOptions }): string {
+  return cleanOptionalString(payload.options?.deliveryId, "Webhook delivery options.deliveryId", 512) ?? randomUUID();
 }
 
 async function responseJson(response: Response): Promise<Record<string, unknown>> {

--- a/packages/gateway-testing/src/fake-channel.test.ts
+++ b/packages/gateway-testing/src/fake-channel.test.ts
@@ -68,20 +68,27 @@ describe("FakeChannelProvider", () => {
       threadId: "thread-1"
     };
 
-    await expect(provider.sendText(target, "hello")).resolves.toMatchObject({
+    await expect(provider.sendText(target, "hello", { deliveryId: "delivery-text-1" })).resolves.toMatchObject({
       provider: "cli",
       chatId: "local-test",
       threadId: "thread-1",
-      messageId: "1"
+      messageId: "1",
+      providerDeliveryId: "delivery-text-1"
     });
-    await provider.sendButtons(target, "approve?", [[{ label: "Approve", token: "p:abc123" }]]);
+    await expect(provider.sendButtons(
+      target,
+      "approve?",
+      [[{ label: "Approve", token: "p:abc123" }]],
+      { deliveryId: "delivery-buttons-1" },
+    )).resolves.toMatchObject({ providerDeliveryId: "delivery-buttons-1" });
     await provider.answerInteraction("callback-1", "Approved");
     await provider.sendFile(target, { filename: "result.txt", data: new TextEncoder().encode("ok") });
 
     expect(provider.sent).toHaveLength(3);
     expect(provider.sent[1]).toMatchObject({
       text: "approve?",
-      buttons: [[{ label: "Approve", token: "p:abc123" }]]
+      buttons: [[{ label: "Approve", token: "p:abc123" }]],
+      options: { deliveryId: "delivery-buttons-1" }
     });
     expect(provider.sent[2]).toMatchObject({
       file: { filename: "result.txt" }

--- a/packages/gateway-testing/src/fake-channel.ts
+++ b/packages/gateway-testing/src/fake-channel.ts
@@ -92,7 +92,7 @@ export class FakeChannelProvider implements ChannelProvider {
   async sendText(target: ChannelTarget, text: string, _options?: SendOptions): Promise<SentMessage> {
     assertTextWithinLimit(text, this.capabilities.maxTextLength);
     this.sent.push({ kind: "text", target, text, options: _options });
-    return sent(target, this.sent.length, this.now());
+    return sent(target, this.sent.length, this.now(), _options?.deliveryId);
   }
 
   async editText(target: ChannelTarget, messageId: string, text: string): Promise<void> {
@@ -118,14 +118,15 @@ export class FakeChannelProvider implements ChannelProvider {
     target: ChannelTarget,
     text: string,
     buttons: ChannelButton[][],
+    options?: SendOptions,
   ): Promise<SentMessage> {
     if (!this.capabilities.inlineButtons) {
       throw new Error("Fake channel provider does not support inline buttons");
     }
     assertTextWithinLimit(text, this.capabilities.maxTextLength);
     assertButtonsWithinLimits(buttons, this.capabilities);
-    this.sent.push({ kind: "buttons", target, text, buttons });
-    return sent(target, this.sent.length, this.now());
+    this.sent.push({ kind: "buttons", target, text, buttons, options });
+    return sent(target, this.sent.length, this.now(), options?.deliveryId);
   }
 
   async answerInteraction(interactionId: string, text?: string, alert?: boolean): Promise<void> {
@@ -148,13 +149,14 @@ export class FakeChannelProvider implements ChannelProvider {
   }
 }
 
-function sent(target: ChannelTarget, id: number, sentAt: Date): SentMessage {
+function sent(target: ChannelTarget, id: number, sentAt: Date, providerDeliveryId?: string): SentMessage {
   return {
     provider: target.provider,
     providerKind: target.providerKind,
     chatId: target.chatId,
     threadId: target.threadId,
     messageId: String(id),
+    providerDeliveryId,
     sentAt
   };
 }

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -1289,6 +1289,124 @@ test('cloud control plane stores headless channel bindings, interactions, cursor
     updatedAt: new Date('2026-01-01T00:00:03.000Z'),
   })?.status, 'sent')
 
+  const firstProviderEvent = store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-1',
+    eventType: 'message',
+    claimedBy: 'gateway-1',
+    ttlMs: 30_000,
+    now: new Date('2026-01-01T00:00:00.000Z'),
+    metadata: { providerMessageId: 'message-1', attachmentCount: 0 },
+  })
+  assert.equal(firstProviderEvent.claimed, true)
+  assert.equal(firstProviderEvent.duplicate, false)
+  assert.equal(firstProviderEvent.event.status, 'processing')
+  assert.equal(firstProviderEvent.event.attemptCount, 1)
+  assert.equal(store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-1',
+    eventType: 'message',
+    claimedBy: 'gateway-2',
+    now: new Date('2026-01-01T00:00:01.000Z'),
+  }).claimed, false)
+  assert.equal(store.completeChannelProviderEvent({
+    orgId: org.orgId,
+    eventId: firstProviderEvent.event.eventId,
+    claimedBy: 'gateway-1',
+    status: 'processed',
+    updatedAt: new Date('2026-01-01T00:00:02.000Z'),
+  })?.status, 'processed')
+  assert.equal(store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-1',
+    eventType: 'message',
+    claimedBy: 'gateway-2',
+    now: new Date('2026-01-01T00:00:03.000Z'),
+  }).duplicate, true)
+
+  const expired = store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-expired',
+    eventType: 'message',
+    claimedBy: 'gateway-1',
+    ttlMs: 1_000,
+    now: new Date('2026-01-01T00:00:00.000Z'),
+  })
+  const reclaimed = store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-expired',
+    eventType: 'message',
+    claimedBy: 'gateway-2',
+    now: new Date('2026-01-01T00:00:02.000Z'),
+  })
+  assert.equal(reclaimed.claimed, true)
+  assert.equal(reclaimed.event.eventId, expired.event.eventId)
+  assert.equal(reclaimed.event.attemptCount, 2)
+
+  const failed = store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-failed',
+    eventType: 'command',
+    claimedBy: 'gateway-1',
+    now: new Date('2026-01-01T00:00:00.000Z'),
+  })
+  assert.equal(store.completeChannelProviderEvent({
+    orgId: org.orgId,
+    eventId: failed.event.eventId,
+    claimedBy: 'gateway-1',
+    status: 'failed',
+    retryable: true,
+    lastError: 'temporary outage token=secret',
+    updatedAt: new Date('2026-01-01T00:00:01.000Z'),
+  })?.retryable, true)
+  assert.equal(store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-failed',
+    eventType: 'command',
+    claimedBy: 'gateway-2',
+    now: new Date('2026-01-01T00:00:02.000Z'),
+  }).claimed, true)
+  assert.equal(store.completeChannelProviderEvent({
+    orgId: org.orgId,
+    eventId: failed.event.eventId,
+    claimedBy: 'gateway-2',
+    status: 'failed',
+    retryable: false,
+    lastError: 'forbidden',
+    updatedAt: new Date('2026-01-01T00:00:03.000Z'),
+  })?.retryable, false)
+  assert.equal(store.claimChannelProviderEvent({
+    orgId: org.orgId,
+    provider: 'telegram',
+    providerInstanceId: 'telegram-prod',
+    externalWorkspaceId: 'bot-1',
+    providerEventId: 'event-failed',
+    eventType: 'command',
+    claimedBy: 'gateway-3',
+    now: new Date('2026-01-01T00:00:04.000Z'),
+  }).claimed, false)
+
   const secondInteraction = store.createChannelInteraction({
     interactionId: 'interaction-2',
     orgId: org.orgId,

--- a/tests/cloud-domain-services.test.ts
+++ b/tests/cloud-domain-services.test.ts
@@ -87,6 +87,8 @@ function channelStore(overrides: Partial<ChannelControlPlaneStore> = {}): Channe
     listChannelDeliveries: unusedStoreAction,
     claimNextChannelDelivery: unusedStoreAction,
     ackChannelDelivery: unusedStoreAction,
+    claimChannelProviderEvent: unusedStoreAction,
+    completeChannelProviderEvent: unusedStoreAction,
     getSession: unusedStoreAction,
     getSessionProjection: unusedStoreAction,
     enqueueSessionCommand: unusedStoreAction,
@@ -219,6 +221,8 @@ test('cloud domain services expose testable seams without an HTTP server', async
     async deadLetterChannelDelivery() { return null },
     async claimNextChannelDelivery() { return null },
     async ackChannelDelivery() { return null },
+    async claimChannelProviderEvent() { throw new Error('not needed') },
+    async completeChannelProviderEvent() { return null },
   })
 
   const workflow = new CloudWorkflowService({

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -3297,6 +3297,84 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     assert.equal(auditPayload.includes(String(issuedInteraction.plaintextToken)), false)
     assert.equal(auditPayload.includes(String(issuedQuestion.plaintextToken)), false)
 
+    const providerEventClaimResponse = await fetch(`${baseUrl}/api/channels/provider-events/claim`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        providerInstanceId: 'telegram-prod',
+        externalWorkspaceId: 'bot-1',
+        providerEventId: 'provider-event-1',
+        eventType: 'message',
+        claimedBy: 'gateway-1',
+        ttlMs: 30_000,
+        metadata: {
+          providerMessageId: 'message-1',
+          attachmentCount: 0,
+        },
+      }),
+    })
+    assert.equal(providerEventClaimResponse.status, 200)
+    const providerEventClaim = await readJson(providerEventClaimResponse)
+    assert.equal(providerEventClaim.claimed, true)
+    assert.equal(providerEventClaim.duplicate, false)
+    const providerEvent = asRecord(providerEventClaim.event)
+    assert.equal(providerEvent.status, 'processing')
+
+    const duplicateBeforeComplete = await fetch(`${baseUrl}/api/channels/provider-events/claim`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        providerInstanceId: 'telegram-prod',
+        externalWorkspaceId: 'bot-1',
+        providerEventId: 'provider-event-1',
+        eventType: 'message',
+        claimedBy: 'gateway-2',
+      }),
+    })
+    assert.equal(duplicateBeforeComplete.status, 200)
+    assert.equal((await readJson(duplicateBeforeComplete)).claimed, false)
+
+    const wrongClaimantComplete = await fetch(`${baseUrl}/api/channels/provider-events/${providerEvent.eventId}/complete`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({ claimedBy: 'gateway-2', status: 'processed' }),
+    })
+    assert.equal(wrongClaimantComplete.status, 404)
+
+    const missingClaimantComplete = await fetch(`${baseUrl}/api/channels/provider-events/${providerEvent.eventId}/complete`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({ status: 'processed' }),
+    })
+    assert.equal(missingClaimantComplete.status, 400)
+
+    const providerEventComplete = await fetch(`${baseUrl}/api/channels/provider-events/${providerEvent.eventId}/complete`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({ claimedBy: 'gateway-1', status: 'processed' }),
+    })
+    assert.equal(providerEventComplete.status, 200)
+    assert.equal(asRecord((await readJson(providerEventComplete)).event).status, 'processed')
+
+    const duplicateAfterComplete = await fetch(`${baseUrl}/api/channels/provider-events/claim`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        providerInstanceId: 'telegram-prod',
+        externalWorkspaceId: 'bot-1',
+        providerEventId: 'provider-event-1',
+        eventType: 'message',
+        claimedBy: 'gateway-3',
+      }),
+    })
+    assert.equal(duplicateAfterComplete.status, 200)
+    const duplicateAfterCompleteBody = await readJson(duplicateAfterComplete)
+    assert.equal(duplicateAfterCompleteBody.claimed, false)
+    assert.equal(asRecord(duplicateAfterCompleteBody.event).status, 'processed')
+
     const deliveryResponse = await fetch(`${baseUrl}/api/channels/deliveries`, {
       method: 'POST',
       headers,

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -133,6 +133,7 @@ test('real Postgres cloud store serializes concurrent schema migrations', {
         '007_scale_foundation',
         '008_managed_workers',
         '009_managed_work_claims',
+        '011_channel_provider_events',
         '010_managed_work_reaper_indexes',
       ])
     } finally {
@@ -874,6 +875,52 @@ test('real Postgres cloud store keeps channel identities, cursors, and delivery 
       status: 'sent',
       updatedAt: new Date('2026-01-01T00:00:02.000Z'),
     }))?.status, 'sent')
+  })
+})
+
+test('real Postgres cloud store atomically claims one provider event across gateways', {
+  skip: POSTGRES_SKIP,
+}, async () => {
+  await withPostgresStore(async (store, ids) => {
+    const org = await store.ensureOrgForTenant({ tenantId: ids.tenantId, name: 'Provider events' })
+    const claims = await Promise.all(Array.from({ length: 8 }, (_, index) => (
+      store.claimChannelProviderEvent({
+        orgId: org.orgId,
+        provider: 'telegram',
+        providerInstanceId: 'telegram-prod',
+        externalWorkspaceId: 'bot-1',
+        providerEventId: `${ids.tenantId}-event`,
+        eventType: 'message',
+        claimedBy: `gateway-${index}`,
+        ttlMs: 30_000,
+        now: new Date('2026-01-01T00:00:00.000Z'),
+      })
+    )))
+    assert.equal(claims.filter((claim) => claim.claimed).length, 1)
+    assert.equal(claims.filter((claim) => claim.duplicate).length, 7)
+    const winner = claims.find((claim) => claim.claimed)
+    assert.ok(winner)
+    assert.equal(winner.event.status, 'processing')
+    assert.equal((await store.completeChannelProviderEvent({
+      orgId: org.orgId,
+      eventId: winner.event.eventId,
+      claimedBy: winner.event.claimedBy,
+      status: 'processed',
+      updatedAt: new Date('2026-01-01T00:00:01.000Z'),
+    }))?.status, 'processed')
+    const duplicate = await store.claimChannelProviderEvent({
+      orgId: org.orgId,
+      provider: 'telegram',
+      providerInstanceId: 'telegram-prod',
+      externalWorkspaceId: 'bot-1',
+      providerEventId: `${ids.tenantId}-event`,
+      eventType: 'message',
+      claimedBy: 'gateway-late',
+      now: new Date('2026-01-01T00:00:02.000Z'),
+    })
+    assert.equal(duplicate.claimed, false)
+    assert.equal(duplicate.duplicate, true)
+    assert.equal(duplicate.event.status, 'processed')
   })
 })
 


### PR DESCRIPTION
## Summary
- Add Cloud-owned durable provider-event claim/complete APIs for inbound gateway messages, backed by in-memory and Postgres stores.
- Teach the gateway runtime to claim provider events before prompting, skip duplicates, preserve stable Cloud command IDs, and avoid retryable failure state after side effects have committed.
- Propagate Cloud delivery IDs through providers as downstream idempotency keys, with conformance/test coverage and gateway docs updated.

Closes #761.
Closes #762.

## Validation
- `pnpm --filter @open-cowork/gateway test`
- `node scripts/run-node-tests.mjs tests/cloud-control-plane-store.test.ts tests/cloud-domain-services.test.ts tests/cloud-http-server.test.ts tests/cloud-postgres-concurrency.test.ts`
- `pnpm --filter @open-cowork/gateway-provider-webhook test`
- `pnpm --filter @open-cowork/gateway-testing test`
- `node --no-warnings --experimental-strip-types --test tests/cloud-control-plane-modularity.test.ts tests/cloud-modularity-boundaries.test.ts`
- `pnpm typecheck`
- `pnpm test`
- Targeted `pnpm exec eslint ...` on PR-scope files
- `git diff --check`
- `uv run mkdocs build --strict`
- Autoreview clean: no accepted/actionable findings