### PR TITLE
Harden gateway webhook delivery safety

### DIFF
--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -586,10 +586,12 @@ function readProvidersFromEnv(env: GatewayEnv, gatewayPublicBaseUrl?: string | n
       credentials: cleanStringRecord({
         sharedSecret: readString(env.OPEN_COWORK_GATEWAY_WEBHOOK_SHARED_SECRET) || undefined,
       }),
-      settings: {
+      settings: cleanRecord({
         deliveryUrl: webhookDeliveryUrl,
+        deliveryUrlAllowedHosts: readString(env.OPEN_COWORK_GATEWAY_WEBHOOK_DELIVERY_ALLOWED_HOSTS) || undefined,
+        allowPrivateDelivery: readString(env.OPEN_COWORK_GATEWAY_WEBHOOK_ALLOW_PRIVATE_DELIVERY) || undefined,
         maxAttachmentBytes: readString(env.OPEN_COWORK_GATEWAY_WEBHOOK_MAX_ATTACHMENT_BYTES) || undefined,
-      },
+      }),
     })
   }
 
@@ -607,6 +609,8 @@ function readProvidersFromEnv(env: GatewayEnv, gatewayPublicBaseUrl?: string | n
       }),
       settings: cleanRecord({
         deliveryUrl,
+        deliveryUrlAllowedHosts: readString(env[`${prefix}_DELIVERY_ALLOWED_HOSTS`]) || undefined,
+        allowPrivateDelivery: readString(env[`${prefix}_ALLOW_PRIVATE_DELIVERY`]) || undefined,
         maxAttachmentBytes: readString(env[`${prefix}_MAX_ATTACHMENT_BYTES`]) || undefined,
       }),
     })

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -2,6 +2,10 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createHmac } from 'node:crypto'
 
+import {
+  WebhookCircuitOpenError,
+  WebhookDeliveryPolicyError,
+} from '@open-cowork/gateway-provider-webhook'
 import type { CloudGateway } from '../dist/index.js'
 import {
   createGatewayHttpServer,
@@ -965,6 +969,17 @@ test('gateway provider registry wires fake, first-party, bridge, and CLI provide
         deliveryUrl: 'https://bridge.example.test/outbound',
       },
     }, {
+      id: 'webhook-internal',
+      kind: 'webhook',
+      channelBindingId: 'webhook-internal-binding',
+      credentials: {
+        sharedSecret: 'webhook-internal-secret',
+      },
+      settings: {
+        deliveryUrl: 'https://10.1.2.3/outbound',
+        allowPrivateDelivery: true,
+      },
+    }, {
       id: 'discord',
       kind: 'discord',
       channelBindingId: 'discord-binding',
@@ -1036,6 +1051,11 @@ test('gateway provider registry wires fake, first-party, bridge, and CLI provide
     id: 'webhook',
     kind: 'webhook',
     provider: 'webhook',
+    providerKind: 'webhook',
+  }, {
+    id: 'webhook-internal',
+    kind: 'webhook',
+    provider: 'webhook-internal',
     providerKind: 'webhook',
   }, {
     id: 'discord',
@@ -1737,6 +1757,66 @@ test('gateway runtime retries transient deliveries and marks permanent failures 
     assert.equal(acks[1]?.input.status, 'dead')
     assert.equal(acks[1]?.input.nextAttemptAt, null)
     assert.doesNotMatch(String(acks[1]?.input.lastError), /super-secret-token/)
+  } finally {
+    await runtime.stop()
+  }
+})
+
+test('gateway runtime treats webhook circuit failures as retryable and URL policy failures as permanent', async () => {
+  let onDelivery: ((delivery: unknown) => void) | null = null
+  const acks: Array<{ deliveryId: string, input: Record<string, unknown> }> = []
+  const cloud = {
+    subscribeDeliveries(input: { onDelivery: (delivery: unknown) => void }) {
+      onDelivery = input.onDelivery
+      return { close() {} }
+    },
+    async ackDelivery(deliveryId: string, input: Record<string, unknown>) {
+      acks.push({ deliveryId, input })
+      return { deliveryId, ...input } as never
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    server: {
+      adminToken: 'admin-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud)
+  const provider = runtime.providers.get('fake')?.provider
+  assert.ok(provider)
+  const failures = [
+    new WebhookCircuitOpenError(5000),
+    new WebhookDeliveryPolicyError('Webhook delivery URL resolved to a private or reserved address'),
+  ]
+  provider.sendText = async () => {
+    const failure = failures.shift()
+    if (failure) throw failure
+    throw new Error('test exhausted failures')
+  }
+
+  await runtime.start()
+  try {
+    const beforeCircuitMs = Date.now()
+    onDelivery?.(deliveryRecord({ deliveryId: 'delivery-circuit', attemptCount: 1 }))
+    await waitFor(() => acks.length === 1)
+    assert.equal(acks[0]?.input.status, 'failed')
+    assert.equal(typeof acks[0]?.input.nextAttemptAt, 'string')
+    const nextAttemptMs = Date.parse(String(acks[0]?.input.nextAttemptAt))
+    assert.ok(nextAttemptMs - beforeCircuitMs >= 4900)
+    assert.match(String(acks[0]?.input.lastError), /circuit is open/)
+
+    onDelivery?.(deliveryRecord({ deliveryId: 'delivery-policy', attemptCount: 1 }))
+    await waitFor(() => acks.length === 2)
+    assert.equal(acks[1]?.input.status, 'dead')
+    assert.equal(acks[1]?.input.nextAttemptAt, null)
+    assert.match(String(acks[1]?.input.lastError), /private or reserved address/)
   } finally {
     await runtime.stop()
   }

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -98,7 +98,6 @@ async function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<
       promise,
       new Promise<null>((resolve) => {
         timeout = setTimeout(() => resolve(null), timeoutMs)
-        timeout.unref?.()
       }),
     ])
   } finally {
@@ -245,7 +244,7 @@ async function handleDelivery(
       status: shouldRetry ? 'failed' : 'dead',
       claimedBy: delivery.claimedBy,
       lastError: failure.message,
-      nextAttemptAt: shouldRetry ? new Date(Date.now() + deliveryRetryDelayMs(delivery.attemptCount)).toISOString() : null,
+      nextAttemptAt: shouldRetry ? new Date(Date.now() + deliveryRetryDelayMs(delivery.attemptCount, failure.retryAfterMs)).toISOString() : null,
     })
   }
 }
@@ -268,9 +267,12 @@ async function sendDelivery(provider: ChannelProvider, delivery: ChannelDelivery
   return sent
 }
 
-function deliveryRetryDelayMs(attemptCount: number) {
+function deliveryRetryDelayMs(attemptCount: number, retryAfterMs?: number) {
+  if (retryAfterMs !== undefined) return Math.max(0, Math.floor(retryAfterMs))
   const retryIndex = Math.max(0, attemptCount - 1)
-  return Math.min(60_000, 1000 * 2 ** retryIndex)
+  const base = Math.min(60_000, 1000 * 2 ** retryIndex)
+  const spread = base * 0.2
+  return Math.max(0, Math.floor(base - spread + Math.random() * spread * 2))
 }
 
 function findDeliveryProvider(providers: GatewayProviderRegistry, delivery: ChannelDeliveryRecord): ProviderRegistration | null {

--- a/apps/gateway/src/provider-errors.ts
+++ b/apps/gateway/src/provider-errors.ts
@@ -1,8 +1,15 @@
+import {
+  isRetryableWebhookDeliveryError,
+  WebhookCircuitOpenError,
+  WebhookDeliveryBodyError,
+  WebhookDeliveryPolicyError,
+} from '@open-cowork/gateway-provider-webhook'
 import { sanitizeChannelText } from './render/sanitize.js'
 
 export type GatewayProviderFailure = {
   transient: boolean
   message: string
+  retryAfterMs?: number
 }
 
 const permanentPatterns = [
@@ -18,6 +25,19 @@ const permanentPatterns = [
 export function classifyProviderFailure(error: unknown): GatewayProviderFailure {
   const raw = error instanceof Error ? error.message : String(error)
   const message = sanitizeChannelText(raw || 'Provider delivery failed.', 320)
+  if (isRetryableWebhookDeliveryError(error)) {
+    return {
+      message,
+      transient: true,
+      retryAfterMs: error instanceof WebhookCircuitOpenError ? Math.max(0, error.retryAfterMs) : undefined,
+    }
+  }
+  if (error instanceof WebhookDeliveryPolicyError || error instanceof WebhookDeliveryBodyError) {
+    return {
+      message,
+      transient: false,
+    }
+  }
   return {
     message,
     transient: !permanentPatterns.some((pattern) => pattern.test(message)),

--- a/apps/gateway/src/provider-registry.ts
+++ b/apps/gateway/src/provider-registry.ts
@@ -164,9 +164,11 @@ function createProvider(config: GatewayProviderConfig, gateway: GatewayConfig): 
     return new WebhookProvider({
       providerId: channelProviderConfigId(config),
       deliveryUrl: requiredSetting(config, 'deliveryUrl'),
+      deliveryUrlAllowedHosts: optionalStringList(config.settings.deliveryUrlAllowedHosts),
       sharedSecret: config.credentials.sharedSecret,
       maxAttachmentBytes: optionalNumber(config.settings.maxAttachmentBytes) || optionalNumberString(config.settings.maxAttachmentBytes) || gateway.server.maxRequestBodyBytes,
       deliveryTimeoutMs: gateway.timeouts.webhookDeliveryMs,
+      allowPrivateDelivery: readBoolean(config.settings.allowPrivateDelivery, false),
     })
   }
 
@@ -235,9 +237,11 @@ function bridgeProviderConfig(config: GatewayProviderConfig, gateway: GatewayCon
   return {
     providerId: channelProviderConfigId(config),
     deliveryUrl: requiredSetting(config, 'deliveryUrl'),
+    deliveryUrlAllowedHosts: optionalStringList(config.settings.deliveryUrlAllowedHosts),
     sharedSecret: requiredCredential(config, 'sharedSecret'),
     maxAttachmentBytes: optionalNumber(config.settings.maxAttachmentBytes) || optionalNumberString(config.settings.maxAttachmentBytes) || gateway.server.maxRequestBodyBytes,
     deliveryTimeoutMs: gateway.timeouts.webhookDeliveryMs,
+    allowPrivateDelivery: readBoolean(config.settings.allowPrivateDelivery, false),
   }
 }
 
@@ -322,6 +326,18 @@ function optionalNumberString(value: unknown) {
   const text = typeof value === 'string' ? value.trim() : ''
   const parsed = text ? Number(text) : NaN
   return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function optionalStringList(value: unknown) {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === 'string' && entry.trim() !== '')
+      .map((entry) => entry.trim())
+  }
+  if (typeof value === 'string') {
+    return value.split(',').map((entry) => entry.trim()).filter(Boolean)
+  }
+  return undefined
 }
 
 function readBoolean(value: unknown, fallback: boolean) {

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -161,6 +161,11 @@ provider control plane.
   service mesh; internal pod/service traffic may remain private.
 - Do not send desktop bearer tokens, gateway service tokens, cookies, or BYOK
   setup requests over non-loopback HTTP.
+- For generic webhook/bridge providers, keep outbound delivery on the default
+  public policy: HTTPS only, no embedded credentials, host allowlists for
+  managed bridges, DNS/private-address rejection, and circuit health visible in
+  Gateway diagnostics. Enable private/internal delivery only in explicitly
+  risk-accepted deployments.
 
 ### Cloud Web Workbench
 

--- a/docs/gateway-appliance.md
+++ b/docs/gateway-appliance.md
@@ -243,6 +243,28 @@ the canonical downstream idempotency keys. Gateway passes the Cloud
 chunk ids in the form `<cloud-delivery-id>:chunk:<n>` so downstream bridges can
 dedupe each chunk without conflating it with the parent delivery.
 
+Webhook and bridge outbound delivery is fail-closed by default. Delivery URLs
+must use HTTPS except for loopback development, cannot contain embedded
+credentials, and cannot target private or reserved IP literals. Before every
+send, the provider resolves the configured host, rejects private/reserved
+answers, rejects localhost names that rebind to public addresses, and pins the
+HTTP/S request to the validated address. Use delivery host allowlists for
+managed bridge deployments. Private/internal bridge delivery requires an
+explicit `allowPrivateDelivery` deployment option and should be treated as a
+risk-bearing internal mode in downstream diagnostics and runbooks.
+For env-based appliance config, use
+`OPEN_COWORK_GATEWAY_WEBHOOK_ALLOW_PRIVATE_DELIVERY=true` or
+`OPEN_COWORK_GATEWAY_<BRIDGE>_ALLOW_PRIVATE_DELIVERY=true` for bridge providers,
+and scope public bridge hosts with `*_DELIVERY_ALLOWED_HOSTS`.
+
+Gateway delivery retries use bounded exponential backoff with jitter. Webhook
+providers retry HTTP 429/5xx, network, and timeout failures; HTTP 429 respects
+`Retry-After` within the configured maximum delay. Persistent transient
+failures open a provider delivery circuit, stop hot-looping the downstream
+bridge, and surface the circuit as degraded provider health in `/ready` and
+`/diagnostics`. URL/DNS policy failures and oversized delivery responses are
+permanent and should dead-letter instead of retrying.
+
 Session-event rendering is ordered by Cloud event sequence. If provider
 rendering fails transiently, Gateway reconnects from the last persisted cursor
 and prevents later queued events from jumping the failed event. If retry budget

--- a/packages/gateway-provider-discord/src/discord-provider.test.ts
+++ b/packages/gateway-provider-discord/src/discord-provider.test.ts
@@ -4,6 +4,10 @@ import { signWebhookDeliveryPayload } from "@open-cowork/gateway-provider-webhoo
 import { DiscordProvider } from "@open-cowork/gateway-provider-discord";
 
 describe("DiscordProvider", () => {
+  async function resolvePublicBridgeHostname() {
+    return [{ address: "93.184.216.34", family: 4 }];
+  }
+
   it("declares Discord bridge capabilities", () => {
     const provider = new DiscordProvider({
       deliveryUrl: "https://bridge.example.test/discord",
@@ -37,6 +41,7 @@ describe("DiscordProvider", () => {
     const provider = new DiscordProvider({
       deliveryUrl: "https://bridge.example.test/discord",
       sharedSecret: "secret",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       fetch: async (_input, init) => {
         const rawBody = String(init?.body);
         deliveries.push({

--- a/packages/gateway-provider-webhook/src/index.ts
+++ b/packages/gateway-provider-webhook/src/index.ts
@@ -4,15 +4,41 @@ export {
   signWebhookDeliveryPayload,
   signWebhookIngressPayload,
   validateWebhookButtons,
-  WebhookProvider,
-  webhookRetryDelayMs,
-  withWebhookRetry
+  WebhookProvider
 } from "./webhook-provider.js";
 export type {
   MapWebhookPayloadOptions,
   WebhookIncomingAttachment,
   WebhookIncomingPayload,
   WebhookIngressAuth,
-  WebhookProviderConfig,
-  WebhookRetryOptions
+  WebhookProviderConfig
 } from "./webhook-provider.js";
+export {
+  isPrivateOrReservedIpAddress,
+  resolveWebhookDeliveryAddresses,
+  validateWebhookDeliveryUrl
+} from "./webhook-url-policy.js";
+export type {
+  ResolvedWebhookAddress,
+  ResolveWebhookHostname,
+  WebhookDeliveryUrlPolicy
+} from "./webhook-url-policy.js";
+export {
+  defaultWebhookRetryAttempts,
+  defaultWebhookRetryInitialDelayMs,
+  defaultWebhookRetryJitterRatio,
+  defaultWebhookRetryMaxDelayMs,
+  isRetryableWebhookDeliveryError,
+  parseRetryAfterMs,
+  WebhookCircuitOpenError,
+  WebhookDeliveryBodyError,
+  WebhookDeliveryError,
+  WebhookDeliveryNetworkError,
+  WebhookDeliveryPolicyError,
+  WebhookDeliveryTimeoutError,
+  webhookRetryDelayMs,
+  withWebhookRetry
+} from "./webhook-retry.js";
+export type {
+  WebhookRetryOptions
+} from "./webhook-retry.js";

--- a/packages/gateway-provider-webhook/src/webhook-provider.test.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.test.ts
@@ -20,6 +20,14 @@ describe("WebhookProvider", () => {
     };
   }
 
+  async function resolvePublicBridgeHostname() {
+    return [{ address: "93.184.216.34", family: 4 }];
+  }
+
+  async function resolvePrivateBridgeHostname() {
+    return [{ address: "10.1.2.3", family: 4 }];
+  }
+
   it("advertises only the attachment capabilities implemented by the generic bridge", () => {
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway"
@@ -51,9 +59,135 @@ describe("WebhookProvider", () => {
     })).toThrow("Webhook delivery URL must not include embedded credentials");
 
     expect(() => new WebhookProvider({
+      deliveryUrl: "https://10.1.2.3/gateway"
+    })).toThrow("Webhook delivery URL must not target a private or reserved IP literal");
+
+    expect(() => new WebhookProvider({
+      deliveryUrl: "https://[::ffff:127.0.0.1]/gateway"
+    })).toThrow("Webhook delivery URL must not target a private or reserved IP literal");
+
+    expect(() => new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      deliveryUrlAllowedHosts: ["*.example.com"]
+    })).toThrow("Webhook delivery URL host is not allowed");
+
+    expect(() => new WebhookProvider({
+      deliveryUrl: "https://bridge.example.com/gateway",
+      deliveryUrlAllowedHosts: ["*.example.com"]
+    })).not.toThrow();
+
+    expect(() => new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
       sharedSecret: "secret\nvalue"
     })).toThrow("Webhook shared secret cannot contain control characters");
+  });
+
+  it("rejects private or rebound DNS resolutions before bridge delivery", async () => {
+    let calls = 0;
+    const privateProvider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePrivateBridgeHostname,
+      fetch: async () => {
+        calls += 1;
+        return new Response("", { status: 200 });
+      }
+    });
+
+    await expect(privateProvider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery URL resolved to a private or reserved address",
+    );
+    expect(calls).toBe(0);
+
+    const mixedProvider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: async () => [
+        { address: "93.184.216.34", family: 4 },
+        { address: "10.1.2.3", family: 4 }
+      ],
+      fetch: async () => {
+        calls += 1;
+        return new Response("", { status: 200 });
+      }
+    });
+    await expect(mixedProvider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery URL resolved to a private or reserved address",
+    );
+    expect(calls).toBe(0);
+
+    const reboundLocalhostProvider = new WebhookProvider({
+      deliveryUrl: "http://localhost:3000/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
+      fetch: async () => {
+        calls += 1;
+        return new Response("", { status: 200 });
+      }
+    });
+    await expect(reboundLocalhostProvider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery URL localhost resolved to a public address",
+    );
+    expect(calls).toBe(0);
+  });
+
+  it("treats transient DNS resolver failures as retryable network errors", async () => {
+    let calls = 0;
+    const error = new Error("temporary DNS failure") as Error & { code: string };
+    error.code = "EAI_AGAIN";
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      retryAttempts: 1,
+      resolveDeliveryHostname: async () => {
+        throw error;
+      },
+      fetch: async () => {
+        calls += 1;
+        return new Response("", { status: 200 });
+      }
+    });
+
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery network error",
+    );
+    expect(calls).toBe(0);
+  });
+
+  it("bounds DNS resolution by the delivery timeout", async () => {
+    let calls = 0;
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      deliveryTimeoutMs: 10,
+      retryAttempts: 1,
+      resolveDeliveryHostname: async () => new Promise(() => {}),
+      fetch: async () => {
+        calls += 1;
+        return new Response("", { status: 200 });
+      }
+    });
+
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery timed out after 100ms",
+    );
+    expect(calls).toBe(0);
+  });
+
+  it("allows explicit private delivery mode without weakening the default policy", async () => {
+    let calls = 0;
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.internal.example/gateway",
+      allowPrivateDelivery: true,
+      resolveDeliveryHostname: resolvePrivateBridgeHostname,
+      fetch: async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ messageId: "internal-message-id" }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    });
+
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).resolves.toMatchObject({
+      messageId: "internal-message-id"
+    });
+    expect(calls).toBe(1);
   });
 
   it("maps signed bridge payloads to provider-neutral messages", () => {
@@ -204,6 +338,7 @@ describe("WebhookProvider", () => {
       providerId: "whatsapp",
       deliveryUrl: "https://bridge.example.test/gateway",
       sharedSecret: "secret",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       fetch: async (input, init) => {
         const rawBody = String(init?.body);
         deliveries.push({
@@ -233,9 +368,10 @@ describe("WebhookProvider", () => {
     });
     expect(deliveries).toEqual([
       {
-        url: "https://bridge.example.test/gateway",
+        url: "https://93.184.216.34/gateway",
         headers: expect.objectContaining({
           "content-type": "application/json",
+          host: "bridge.example.test",
           "x-open-cowork-gateway-delivery-id": expect.any(String),
           "x-open-cowork-gateway-webhook-signature": expect.any(String),
           "x-open-cowork-gateway-webhook-timestamp": expect.any(String)
@@ -282,6 +418,7 @@ describe("WebhookProvider", () => {
       providerId: "webhook-support",
       deliveryUrl: "https://bridge.example.test/gateway",
       sharedSecret: "secret",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       fetch: async (_input, init) => {
         const rawBody = String(init?.body);
         deliveries.push({
@@ -330,6 +467,7 @@ describe("WebhookProvider", () => {
     const provider = new WebhookProvider({
       providerId: "slack",
       deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       fetch: async (_input, init) => {
         deliveries.push({
           body: JSON.parse(String(init?.body))
@@ -406,6 +544,7 @@ describe("WebhookProvider", () => {
     const provider = new WebhookProvider({
       providerId: "slack",
       deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       fetch: async (_input, init) => {
         deliveries.push({
           body: JSON.parse(String(init?.body))
@@ -456,6 +595,7 @@ describe("WebhookProvider", () => {
   it("rejects unsafe bridge delivery response ids before they enter gateway state", async () => {
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       fetch: async () => new Response(JSON.stringify({ messageId: "bridge\nmessage" }), {
         status: 200,
         headers: { "content-type": "application/json" }
@@ -473,6 +613,7 @@ describe("WebhookProvider", () => {
     let calls = 0;
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       sleep: async (ms) => {
         sleeps.push(ms);
       },
@@ -502,12 +643,97 @@ describe("WebhookProvider", () => {
     expect(deliveryIds[1]).toBe(deliveryIds[0]);
   });
 
+  it("pins the resolved bridge address for production HTTP delivery", async () => {
+    const lookups: Array<{ address?: string; family?: number; addresses?: Array<{ address: string; family: number }>; error?: Error | null }> = [];
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
+      deliveryRequestForTests: (_url, options, callback) => ({
+        on() {
+          return this;
+        },
+        end() {
+          const lookup = options.lookup as unknown as {
+            (
+              hostname: string,
+              options: unknown,
+              callback: (error: Error | null, address?: string, family?: number) => void,
+            ): void;
+            (
+              hostname: string,
+              options: unknown,
+              callback: (error: Error | null, addresses?: Array<{ address: string; family: number }>) => void,
+            ): void;
+          };
+          lookup("bridge.example.test", {}, (error, address, family) => {
+            lookups.push({ error, address, family });
+          });
+          lookup("bridge.example.test", { all: true }, (error, addresses) => {
+            lookups.push({ error, addresses });
+          });
+          callback({
+            statusCode: 200,
+            headers: { "content-type": "application/json" },
+            resume() {},
+            destroy() {},
+            async *[Symbol.asyncIterator]() {
+              yield Buffer.from(JSON.stringify({ messageId: "bridge-message-id" }));
+            }
+          } as never);
+        }
+      } as never)
+    });
+
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).resolves.toMatchObject({
+      messageId: "bridge-message-id"
+    });
+    expect(lookups).toEqual([
+      { error: null, address: "93.184.216.34", family: 4 },
+      { error: null, addresses: [{ address: "93.184.216.34", family: 4 }] }
+    ]);
+  });
+
+  it("retries network and timeout delivery failures with bounded jitter", async () => {
+    const sleeps: number[] = [];
+    let calls = 0;
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
+      retryInitialDelayMs: 1000,
+      retryJitterRatio: 0.2,
+      random: () => 0.75,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      fetch: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new TypeError("ECONNRESET");
+        }
+        if (calls === 2) {
+          throw { name: "AbortError" };
+        }
+        return new Response(JSON.stringify({ messageId: "bridge-message-id" }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    });
+
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).resolves.toMatchObject({
+      messageId: "bridge-message-id"
+    });
+    expect(calls).toBe(3);
+    expect(sleeps).toEqual([1100, 2200]);
+  });
+
   it("caps bridge retry attempts and retry-after delays", async () => {
     const sleeps: number[] = [];
     let calls = 0;
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
       retryAttempts: 99,
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       sleep: async (ms) => {
         sleeps.push(ms);
       },
@@ -532,6 +758,7 @@ describe("WebhookProvider", () => {
     let calls = 0;
     const provider = new WebhookProvider({
       deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
       sleep: async () => {
         throw new Error("sleep should not be called");
       },
@@ -545,6 +772,55 @@ describe("WebhookProvider", () => {
       "Webhook delivery failed: 400",
     );
     expect(calls).toBe(1);
+  });
+
+  it("opens and recovers a bridge circuit after repeated transient delivery failures", async () => {
+    let nowMs = 0;
+    let healthy = false;
+    let calls = 0;
+    const provider = new WebhookProvider({
+      deliveryUrl: "https://bridge.example.test/gateway",
+      resolveDeliveryHostname: resolvePublicBridgeHostname,
+      retryAttempts: 1,
+      circuitBreakerFailureThreshold: 2,
+      circuitBreakerCooldownMs: 5000,
+      now: () => new Date(nowMs),
+      fetch: async () => {
+        calls += 1;
+        return healthy
+          ? new Response(JSON.stringify({ messageId: "bridge-message-id" }), {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          })
+          : new Response("", { status: 500 });
+      }
+    });
+
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery failed: 500",
+    );
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery failed: 500",
+    );
+    expect(calls).toBe(2);
+    expect(provider.health()).toMatchObject({
+      ok: false,
+      state: "degraded",
+      error: "Webhook delivery circuit is open for 5000ms"
+    });
+
+    healthy = true;
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).rejects.toThrow(
+      "Webhook delivery circuit is open for 5000ms",
+    );
+    expect(calls).toBe(2);
+
+    nowMs = 6000;
+    await expect(provider.sendText({ provider: "webhook", chatId: "team-chat" }, "hello")).resolves.toMatchObject({
+      messageId: "bridge-message-id"
+    });
+    expect(calls).toBe(3);
+    expect(provider.health()).toMatchObject({ ok: true, state: "ready", error: null });
   });
 
   it("dispatches incoming payloads through the started handler", async () => {

--- a/packages/gateway-provider-webhook/src/webhook-provider.ts
+++ b/packages/gateway-provider-webhook/src/webhook-provider.ts
@@ -1,8 +1,12 @@
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
 import type {
   ChannelAttachment,
   ChannelButton,
   ChannelCapabilities,
+  ChannelProviderHealth,
   ChannelProviderKind,
   ChannelProviderId,
   ChannelProvider,
@@ -13,20 +17,55 @@ import type {
   SentMessage
 } from "@open-cowork/gateway-channel";
 import { channelProviderKindFromId, normalizeChannelCapabilities, normalizeChannelProviderIdentity } from "@open-cowork/gateway-channel";
+import {
+  boundedPositiveInt,
+  isAbortError,
+  isRetryableWebhookDeliveryError,
+  parseRetryAfterMs,
+  WebhookCircuitOpenError,
+  WebhookDeliveryBodyError,
+  WebhookDeliveryError,
+  WebhookDeliveryNetworkError,
+  WebhookDeliveryPolicyError,
+  WebhookDeliveryTimeoutError,
+  withWebhookRetry
+} from "./webhook-retry.js";
+import {
+  resolveWebhookDeliveryAddresses,
+  type ResolvedWebhookAddress,
+  type ResolveWebhookHostname,
+  validateWebhookDeliveryUrl
+} from "./webhook-url-policy.js";
+
+type NodeRequestFactory = (
+  url: URL,
+  options: RequestOptions,
+  callback: (response: IncomingMessage) => void,
+) => ClientRequest;
 
 export interface WebhookProviderConfig {
   providerId?: ChannelProviderId;
   providerKind?: ChannelProviderKind;
   deliveryUrl: string;
+  deliveryUrlAllowedHosts?: readonly string[];
   sharedSecret?: string;
   capabilities?: Partial<ChannelCapabilities>;
   maxSignatureAgeMs?: number;
   maxAttachmentBytes?: number;
   fetch?: typeof globalThis.fetch;
+  deliveryRequestForTests?: NodeRequestFactory;
+  resolveDeliveryHostname?: ResolveWebhookHostname;
+  allowPrivateDelivery?: boolean;
   now?: () => Date;
   retryAttempts?: number;
+  retryInitialDelayMs?: number;
+  retryMaxDelayMs?: number;
+  retryJitterRatio?: number;
+  random?: () => number;
   sleep?: (ms: number) => Promise<void>;
   deliveryTimeoutMs?: number;
+  circuitBreakerFailureThreshold?: number;
+  circuitBreakerCooldownMs?: number;
   legacySharedSecretHeader?: boolean;
   maxSeenIngressSignatures?: number;
   maxSeenIngressSignaturesPerScope?: number;
@@ -75,8 +114,9 @@ export interface WebhookIngressAuth {
 const maxWebhookAttachments = 20;
 const defaultMaxSignatureAgeMs = 5 * 60 * 1000;
 const defaultDeliveryTimeoutMs = 15_000;
-const maxWebhookRetryAttempts = 5;
-const maxWebhookRetryDelayMs = 10_000;
+const maxWebhookDeliveryResponseBytes = 64 * 1024;
+const defaultWebhookCircuitBreakerFailureThreshold = 5;
+const defaultWebhookCircuitBreakerCooldownMs = 30_000;
 const defaultMaxSeenIngressSignatures = 5_000;
 const defaultMaxSeenIngressSignaturesPerScope = 1_000;
 
@@ -90,6 +130,20 @@ type WebhookIngressReplayClaim = {
   entry: SeenWebhookSignature;
 };
 
+type WebhookCircuitState = {
+  failures: number;
+  openUntilMs: number;
+};
+
+type WebhookDeliveryRequest = {
+  deliveryId: string;
+  body: string;
+};
+
+type SignedWebhookDeliveryRequest = WebhookDeliveryRequest & {
+  headers: Record<string, string>;
+};
+
 export interface MapWebhookPayloadOptions {
   maxAttachmentBytes?: number;
 }
@@ -101,9 +155,17 @@ export class WebhookProvider implements ChannelProvider {
 
   private handler?: (message: IncomingChannelMessage) => Promise<void>;
   private readonly seenIngressSignatures = new Map<string, SeenWebhookSignature>();
+  private readonly deliveryUrl: URL;
+  private circuit: WebhookCircuitState = {
+    failures: 0,
+    openUntilMs: 0
+  };
 
   constructor(private readonly config: WebhookProviderConfig) {
-    validateWebhookDeliveryUrl(config.deliveryUrl);
+    this.deliveryUrl = validateWebhookDeliveryUrl(config.deliveryUrl, {
+      allowedHosts: config.deliveryUrlAllowedHosts,
+      allowPrivateDelivery: config.allowPrivateDelivery
+    });
     if (config.sharedSecret !== undefined) {
       validateHeaderValue(config.sharedSecret, "Webhook shared secret");
     }
@@ -132,6 +194,29 @@ export class WebhookProvider implements ChannelProvider {
 
   async stop(): Promise<void> {
     this.handler = undefined;
+  }
+
+  health(): ChannelProviderHealth {
+    if (this.circuit.openUntilMs <= 0) {
+      return {
+        ok: true,
+        state: "ready",
+        error: null
+      };
+    }
+    const nowMs = this.config.now?.().getTime() ?? Date.now();
+    if (nowMs >= this.circuit.openUntilMs) {
+      return {
+        ok: true,
+        state: "ready",
+        error: null
+      };
+    }
+    return {
+      ok: false,
+      state: "degraded",
+      error: `Webhook delivery circuit is open for ${Math.ceil(this.circuit.openUntilMs - nowMs)}ms`
+    };
   }
 
   async handleWebhookPayload(payload: unknown, auth: WebhookIngressAuth): Promise<void> {
@@ -236,7 +321,6 @@ export class WebhookProvider implements ChannelProvider {
     }
     const normalizedTarget = payload.target ? normalizeOutboundTarget(payload.target, this.id, this.kind) : undefined;
     const normalizedPayload = normalizedTarget ? { ...payload, target: normalizedTarget } : payload;
-    const fetchImpl = this.config.fetch ?? globalThis.fetch;
     const deliveryId = deliveryIdForPayload(normalizedPayload);
     const body = JSON.stringify({
       deliveryId,
@@ -246,42 +330,22 @@ export class WebhookProvider implements ChannelProvider {
       providerKind: this.kind,
       ...normalizedPayload
     });
-    const response = await withWebhookRetry(async () => {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), normalizeDeliveryTimeoutMs(this.config.deliveryTimeoutMs));
-      const timestamp = String(Math.floor((this.config.now?.().getTime() ?? Date.now()) / 1000));
-      const signature = this.config.sharedSecret
-        ? signWebhookDeliveryPayload(body, this.config.sharedSecret, timestamp)
-        : null;
-      try {
-        const attempt = await fetchImpl(this.config.deliveryUrl, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            "x-open-cowork-gateway-delivery-id": deliveryId,
-            ...(signature ? {
-              "x-open-cowork-gateway-webhook-timestamp": timestamp,
-              "x-open-cowork-gateway-webhook-signature": signature
-            } : {}),
-            ...(this.config.legacySharedSecretHeader && this.config.sharedSecret
-              ? { "x-open-cowork-gateway-webhook-secret": this.config.sharedSecret }
-              : {})
-          },
-          body,
-          signal: controller.signal
-        });
-        if (!attempt.ok) {
-          throw WebhookDeliveryError.fromResponse(attempt);
-        }
-        return attempt;
-      } finally {
-        clearTimeout(timeout);
-      }
+    const responseBody = await withWebhookRetry(async () => {
+      this.assertCircuitClosed();
+      const parsed = await this.fetchDelivery({ deliveryId, body });
+      this.recordCircuitSuccess();
+      return parsed;
     }, {
       attempts: this.config.retryAttempts,
-      sleep: this.config.sleep
+      initialDelayMs: this.config.retryInitialDelayMs,
+      maxDelayMs: this.config.retryMaxDelayMs,
+      jitterRatio: this.config.retryJitterRatio,
+      sleep: this.config.sleep,
+      random: this.config.random
+    }).catch((error) => {
+      this.recordCircuitFailure(error);
+      throw error;
     });
-    const responseBody = await responseJson(response);
     const target = normalizedTarget;
     const messageId = cleanOptionalString(responseBody.messageId, "Webhook delivery response.messageId", 512) ?? randomUUID();
     return {
@@ -292,6 +356,120 @@ export class WebhookProvider implements ChannelProvider {
       messageId,
       providerDeliveryId: deliveryId,
       sentAt: new Date()
+    };
+  }
+
+  private async fetchDelivery(input: WebhookDeliveryRequest): Promise<Record<string, unknown>> {
+    const timeoutMs = normalizeDeliveryTimeoutMs(this.config.deliveryTimeoutMs);
+    const controller = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        reject(new WebhookDeliveryTimeoutError(timeoutMs));
+      }, timeoutMs);
+    });
+    try {
+      const resolvedAddresses = await Promise.race([
+        resolveWebhookDeliveryAddresses(this.deliveryUrl, {
+          resolveHostname: this.config.resolveDeliveryHostname,
+          allowPrivateDelivery: this.config.allowPrivateDelivery
+        }),
+        timeoutPromise
+      ]);
+      const signed = {
+        ...input,
+        headers: this.deliveryHeaders(input)
+      };
+      if (this.config.fetch) {
+        const attempt = await this.config.fetch(pinnedDeliveryUrl(this.deliveryUrl, resolvedAddresses).toString(), {
+          method: "POST",
+          headers: {
+            ...signed.headers,
+            host: this.deliveryUrl.host
+          },
+          body: signed.body,
+          signal: controller.signal
+        });
+        if (!attempt.ok) {
+          throw WebhookDeliveryError.fromResponse(attempt);
+        }
+        return responseJson(attempt);
+      }
+      return postWebhookDeliveryWithPinnedAddress(this.deliveryUrl, resolvedAddresses, signed, {
+        signal: controller.signal,
+        request: this.config.deliveryRequestForTests
+      });
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw new WebhookDeliveryTimeoutError(timeoutMs);
+      }
+      if (
+        error instanceof WebhookDeliveryError ||
+        error instanceof WebhookDeliveryTimeoutError ||
+        error instanceof WebhookDeliveryBodyError ||
+        error instanceof WebhookDeliveryPolicyError
+      ) {
+        throw error;
+      }
+      throw new WebhookDeliveryNetworkError(error);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  private deliveryHeaders(input: WebhookDeliveryRequest): Record<string, string> {
+    const timestamp = String(Math.floor((this.config.now?.().getTime() ?? Date.now()) / 1000));
+    const signature = this.config.sharedSecret
+      ? signWebhookDeliveryPayload(input.body, this.config.sharedSecret, timestamp)
+      : null;
+    return {
+      "content-type": "application/json",
+      "x-open-cowork-gateway-delivery-id": input.deliveryId,
+      ...(signature ? {
+        "x-open-cowork-gateway-webhook-timestamp": timestamp,
+        "x-open-cowork-gateway-webhook-signature": signature
+      } : {}),
+      ...(this.config.legacySharedSecretHeader && this.config.sharedSecret
+        ? { "x-open-cowork-gateway-webhook-secret": this.config.sharedSecret }
+        : {})
+    };
+  }
+
+  private assertCircuitClosed(): void {
+    if (this.circuit.openUntilMs <= 0) {
+      return;
+    }
+    const nowMs = this.config.now?.().getTime() ?? Date.now();
+    if (nowMs < this.circuit.openUntilMs) {
+      throw new WebhookCircuitOpenError(this.circuit.openUntilMs - nowMs);
+    }
+    this.circuit = {
+      failures: 0,
+      openUntilMs: 0
+    };
+  }
+
+  private recordCircuitSuccess(): void {
+    if (this.circuit.failures === 0 && this.circuit.openUntilMs === 0) {
+      return;
+    }
+    this.circuit = {
+      failures: 0,
+      openUntilMs: 0
+    };
+  }
+
+  private recordCircuitFailure(error: unknown): void {
+    if (error instanceof WebhookCircuitOpenError || !isRetryableWebhookDeliveryError(error)) {
+      return;
+    }
+    const threshold = boundedPositiveInt(this.config.circuitBreakerFailureThreshold, defaultWebhookCircuitBreakerFailureThreshold);
+    const cooldownMs = boundedPositiveInt(this.config.circuitBreakerCooldownMs, defaultWebhookCircuitBreakerCooldownMs);
+    const failures = this.circuit.failures + 1;
+    this.circuit = {
+      failures,
+      openUntilMs: failures >= threshold ? (this.config.now?.().getTime() ?? Date.now()) + cooldownMs : 0
     };
   }
 
@@ -404,62 +582,6 @@ export function signWebhookIngressPayload(rawBody: string, sharedSecret: string,
 
 export function signWebhookDeliveryPayload(rawBody: string, sharedSecret: string, timestamp: string): string {
   return signWebhookIngressPayload(rawBody, sharedSecret, timestamp);
-}
-
-export interface WebhookRetryOptions {
-  attempts?: number;
-  sleep?: (ms: number) => Promise<void>;
-}
-
-export async function withWebhookRetry<T>(
-  operation: () => Promise<T>,
-  options: WebhookRetryOptions = {},
-): Promise<T> {
-  const attempts = Math.max(1, Math.min(maxWebhookRetryAttempts, options.attempts ?? 3));
-  const sleep = options.sleep ?? delay;
-  let attempt = 0;
-
-  while (true) {
-    try {
-      return await operation();
-    } catch (error) {
-      attempt += 1;
-      const delayMs = webhookRetryDelayMs(error, attempt);
-      if (attempt >= attempts || delayMs === null) {
-        throw error;
-      }
-      await sleep(delayMs);
-    }
-  }
-}
-
-export function webhookRetryDelayMs(error: unknown, attempt: number): number | null {
-  if (!(error instanceof WebhookDeliveryError)) {
-    return null;
-  }
-  if (error.status === 429) {
-    return Math.min(error.retryAfterMs ?? cappedBackoffMs(attempt), maxWebhookRetryDelayMs);
-  }
-  if (error.status >= 500 && error.status < 600) {
-    return cappedBackoffMs(attempt);
-  }
-  return null;
-}
-
-class WebhookDeliveryError extends Error {
-  private constructor(
-    readonly status: number,
-    readonly retryAfterMs: number | null,
-  ) {
-    super(`Webhook delivery failed: ${status}`);
-  }
-
-  static fromResponse(response: Response): WebhookDeliveryError {
-    return new WebhookDeliveryError(
-      response.status,
-      parseRetryAfterMs(response.headers.get("retry-after")),
-    );
-  }
 }
 
 export function mapWebhookPayload(
@@ -693,32 +815,6 @@ function validateInteractionToken(token: string, label: string): void {
   }
 }
 
-function validateWebhookDeliveryUrl(value: string): void {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new Error("Webhook delivery URL is not a valid URL");
-  }
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    throw new Error("Webhook delivery URL must use http or https");
-  }
-  if (url.protocol === "http:" && !isLocalHttpHost(url.hostname)) {
-    throw new Error("Webhook delivery URL must use https unless it targets localhost");
-  }
-  if (url.username || url.password) {
-    throw new Error("Webhook delivery URL must not include embedded credentials");
-  }
-}
-
-function isLocalHttpHost(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
-    normalized === "::1" ||
-    normalized === "[::1]";
-}
-
 function webhookReplayScopeFromRawBody(rawBody: string, providerId: ChannelProviderId): string {
   const fallback = replayScopeSegment(providerId);
   try {
@@ -849,31 +945,6 @@ function parseReceivedAt(value: unknown, fallback: Date): Date {
   return Number.isNaN(parsed.getTime()) ? fallback : parsed;
 }
 
-function parseRetryAfterMs(value: string | null): number | null {
-  if (!value) {
-    return null;
-  }
-  const seconds = Number(value);
-  if (Number.isFinite(seconds)) {
-    return Math.min(maxWebhookRetryDelayMs, Math.max(0, seconds * 1000));
-  }
-  const date = new Date(value);
-  if (!Number.isNaN(date.getTime())) {
-    return Math.min(maxWebhookRetryDelayMs, Math.max(0, date.getTime() - Date.now()));
-  }
-  return null;
-}
-
-function cappedBackoffMs(attempt: number): number {
-  return Math.min(maxWebhookRetryDelayMs, 1000 * 2 ** Math.max(0, attempt - 1));
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
 function serializeOutgoingFile(file: OutgoingFile): Record<string, unknown> {
   const filename = cleanRequiredString(file.filename, "Webhook outgoing file.filename", 255);
   if (!filename) {
@@ -893,8 +964,139 @@ function deliveryIdForPayload(payload: { options?: SendOptions }): string {
   return cleanOptionalString(payload.options?.deliveryId, "Webhook delivery options.deliveryId", 512) ?? randomUUID();
 }
 
+async function postWebhookDeliveryWithPinnedAddress(
+  url: URL,
+  resolvedAddresses: ResolvedWebhookAddress[],
+  input: SignedWebhookDeliveryRequest,
+  options: { signal: AbortSignal; request?: NodeRequestFactory },
+): Promise<Record<string, unknown>> {
+  const pinned = resolvedAddresses[0];
+  if (!pinned?.address || !pinned.family) {
+    throw new WebhookDeliveryPolicyError("Webhook delivery URL host cannot be resolved");
+  }
+  const requestFactory = options.request ?? (url.protocol === "http:" ? httpRequest : httpsRequest);
+  return new Promise((resolve, reject) => {
+    const requestOptions: RequestOptions = {
+      method: "POST",
+      agent: false,
+      signal: options.signal,
+      headers: {
+        ...input.headers,
+        "content-length": String(Buffer.byteLength(input.body, "utf8"))
+      },
+      lookup: pinnedLookup(url, pinned, "Webhook delivery URL") as unknown as RequestOptions["lookup"]
+    };
+    const request = requestFactory(url, requestOptions, (response) => {
+      const status = response.statusCode ?? 0;
+      if (status < 200 || status > 299) {
+        response.resume();
+        reject(new WebhookDeliveryError(status, parseRetryAfterMs(firstHeaderValue(response.headers["retry-after"]) ?? null)));
+        return;
+      }
+      nodeResponseJson(response).then(resolve, reject);
+    });
+    request.on("error", reject);
+    request.end(input.body);
+  });
+}
+
+function pinnedDeliveryUrl(url: URL, resolvedAddresses: ResolvedWebhookAddress[]): URL {
+  const pinned = resolvedAddresses[0];
+  if (!pinned?.address || !pinned.family) {
+    throw new WebhookDeliveryPolicyError("Webhook delivery URL host cannot be resolved");
+  }
+  const next = new URL(url.toString());
+  const host = pinned.family === 6 ? `[${pinned.address}]` : pinned.address;
+  next.host = url.port ? `${host}:${url.port}` : host;
+  return next;
+}
+
+function pinnedLookup(url: URL, pinned: ResolvedWebhookAddress, label: string) {
+  return (
+    hostname: string,
+    lookupOptions: unknown,
+    callback: PinnedLookupCallback,
+  ): void => {
+    if (normalizeHostnameForPolicy(hostname) !== normalizeHostnameForPolicy(url.hostname)) {
+      callback(new Error(`${label} host changed during request`));
+      return;
+    }
+    if (isRecord(lookupOptions) && lookupOptions.all === true) {
+      callback(null, [{ address: pinned.address, family: pinned.family }]);
+      return;
+    }
+    callback(null, pinned.address, pinned.family);
+  };
+}
+
+type PinnedLookupCallback = {
+  (error: Error | null, address?: string, family?: number): void;
+  (error: Error | null, addresses?: ResolvedWebhookAddress[]): void;
+};
+
+function normalizeHostnameForPolicy(value: unknown): string {
+  return String(value).trim().replace(/^\[/u, "").replace(/\]$/u, "").toLowerCase();
+}
+
+function firstHeaderValue(value: string | string[] | number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return String(Array.isArray(value) ? value[0] : value);
+}
+
+async function nodeResponseJson(response: IncomingMessage): Promise<Record<string, unknown>> {
+  const contentLength = firstHeaderValue(response.headers["content-length"]);
+  if (contentLength) {
+    const bytes = Number(contentLength);
+    if (Number.isFinite(bytes) && bytes > maxWebhookDeliveryResponseBytes) {
+      response.resume();
+      throw new WebhookDeliveryBodyError(`Webhook delivery response cannot exceed ${maxWebhookDeliveryResponseBytes} bytes`);
+    }
+  }
+  const bytes = await readBoundedNodeResponseBytes(response, maxWebhookDeliveryResponseBytes);
+  if (bytes.byteLength === 0) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(Buffer.from(bytes).toString("utf8")) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readBoundedNodeResponseBytes(response: IncomingMessage, maxBytes: number): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const chunk of response) {
+    const value = chunk instanceof Uint8Array ? chunk : Buffer.from(String(chunk));
+    total += value.byteLength;
+    if (total > maxBytes) {
+      response.destroy();
+      throw new WebhookDeliveryBodyError(`Webhook delivery response cannot exceed ${maxBytes} bytes`);
+    }
+    chunks.push(value);
+  }
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return buffer;
+}
+
 async function responseJson(response: Response): Promise<Record<string, unknown>> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const bytes = Number(contentLength);
+    if (Number.isFinite(bytes) && bytes > maxWebhookDeliveryResponseBytes) {
+      throw new WebhookDeliveryBodyError(`Webhook delivery response cannot exceed ${maxWebhookDeliveryResponseBytes} bytes`);
+    }
+  }
   const text = await response.text();
+  if (Buffer.byteLength(text, "utf8") > maxWebhookDeliveryResponseBytes) {
+    throw new WebhookDeliveryBodyError(`Webhook delivery response cannot exceed ${maxWebhookDeliveryResponseBytes} bytes`);
+  }
   if (!text) {
     return {};
   }

--- a/packages/gateway-provider-webhook/src/webhook-retry.ts
+++ b/packages/gateway-provider-webhook/src/webhook-retry.ts
@@ -1,0 +1,180 @@
+export const defaultWebhookRetryAttempts = 3;
+export const defaultWebhookRetryInitialDelayMs = 1000;
+export const defaultWebhookRetryMaxDelayMs = 10_000;
+export const defaultWebhookRetryJitterRatio = 0.2;
+const maxWebhookRetryAttempts = 5;
+
+export interface WebhookRetryOptions {
+  attempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  jitterRatio?: number;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+}
+
+export async function withWebhookRetry<T>(
+  operation: () => Promise<T>,
+  options: WebhookRetryOptions = {},
+): Promise<T> {
+  const attempts = Math.min(maxWebhookRetryAttempts, boundedPositiveInt(options.attempts, defaultWebhookRetryAttempts));
+  const sleep = options.sleep ?? delay;
+  const random = typeof options.random === "function" ? options.random : Math.random;
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      attempt += 1;
+      const delayMs = webhookRetryDelayMs(error, attempt, options);
+      if (attempt >= attempts || delayMs === null) {
+        throw error;
+      }
+      await sleep(jitteredDelayMs(
+        delayMs,
+        options.jitterRatio,
+        random,
+        shouldJitterWebhookDelay(error),
+        options.maxDelayMs,
+      ));
+    }
+  }
+}
+
+export function webhookRetryDelayMs(error: unknown, attempt: number, options: WebhookRetryOptions = {}): number | null {
+  if (error instanceof WebhookDeliveryTimeoutError || error instanceof WebhookDeliveryNetworkError) {
+    return cappedBackoffMs(attempt, options);
+  }
+  if (error instanceof WebhookCircuitOpenError) {
+    return null;
+  }
+  if (error instanceof WebhookDeliveryError) {
+    if (error.status === 429) {
+      return error.retryAfterMs === null
+        ? cappedBackoffMs(attempt, options)
+        : Math.min(error.retryAfterMs, boundedPositiveInt(options.maxDelayMs, defaultWebhookRetryMaxDelayMs));
+    }
+    if (error.status >= 500 && error.status < 600) {
+      return cappedBackoffMs(attempt, options);
+    }
+  }
+  return null;
+}
+
+export class WebhookDeliveryError extends Error {
+  constructor(
+    readonly status: number,
+    readonly retryAfterMs: number | null,
+  ) {
+    super(`Webhook delivery failed: ${status}`);
+  }
+
+  static fromResponse(response: Response): WebhookDeliveryError {
+    return new WebhookDeliveryError(
+      response.status,
+      parseRetryAfterMs(response.headers.get("retry-after")),
+    );
+  }
+}
+
+export class WebhookDeliveryTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Webhook delivery timed out after ${timeoutMs}ms`);
+  }
+}
+
+export class WebhookDeliveryNetworkError extends Error {
+  constructor(readonly cause: unknown) {
+    super("Webhook delivery network error");
+  }
+}
+
+export class WebhookDeliveryPolicyError extends Error {
+  constructor(readonly cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+  }
+}
+
+export class WebhookDeliveryBodyError extends Error {}
+
+export class WebhookCircuitOpenError extends Error {
+  constructor(readonly retryAfterMs: number) {
+    super(`Webhook delivery circuit is open for ${Math.ceil(retryAfterMs)}ms`);
+  }
+}
+
+export function isRetryableWebhookDeliveryError(error: unknown): boolean {
+  if (
+    error instanceof WebhookDeliveryTimeoutError ||
+    error instanceof WebhookDeliveryNetworkError ||
+    error instanceof WebhookCircuitOpenError
+  ) {
+    return true;
+  }
+  return error instanceof WebhookDeliveryError && (error.status === 429 || (error.status >= 500 && error.status < 600));
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const record = error as { name?: unknown; code?: unknown };
+  return record.name === "AbortError" || record.code === "ABORT_ERR";
+}
+
+export function parseRetryAfterMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+  const date = new Date(value);
+  if (!Number.isNaN(date.getTime())) {
+    return Math.max(0, date.getTime() - Date.now());
+  }
+  return null;
+}
+
+export function boundedPositiveInt(value: unknown, fallback: number): number {
+  return Number.isInteger(value) && Number(value) > 0 ? Math.floor(Number(value)) : fallback;
+}
+
+function cappedBackoffMs(attempt: number, options: WebhookRetryOptions = {}): number {
+  const initialDelayMs = boundedPositiveInt(options.initialDelayMs, defaultWebhookRetryInitialDelayMs);
+  const maxDelayMs = boundedPositiveInt(options.maxDelayMs, defaultWebhookRetryMaxDelayMs);
+  return Math.min(maxDelayMs, initialDelayMs * 2 ** Math.max(0, attempt - 1));
+}
+
+function jitteredDelayMs(
+  delayMs: number,
+  jitterRatio: number | undefined,
+  random: () => number,
+  enabled: boolean,
+  maxDelayMs: number | undefined,
+): number {
+  const maxMs = boundedPositiveInt(maxDelayMs, defaultWebhookRetryMaxDelayMs);
+  if (!enabled) {
+    return Math.min(delayMs, maxMs);
+  }
+  const ratio = boundedNonNegativeNumber(jitterRatio, defaultWebhookRetryJitterRatio);
+  if (ratio === 0 || delayMs === 0) {
+    return Math.min(delayMs, maxMs);
+  }
+  const spread = delayMs * ratio;
+  return Math.min(maxMs, Math.max(0, Math.floor(delayMs - spread + random() * spread * 2)));
+}
+
+function boundedNonNegativeNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function shouldJitterWebhookDelay(error: unknown): boolean {
+  return !(error instanceof WebhookDeliveryError && error.status === 429 && error.retryAfterMs !== null);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/gateway-provider-webhook/src/webhook-url-policy.ts
+++ b/packages/gateway-provider-webhook/src/webhook-url-policy.ts
@@ -1,0 +1,208 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import {
+  WebhookDeliveryNetworkError,
+  WebhookDeliveryPolicyError
+} from "./webhook-retry.js";
+
+export type ResolvedWebhookAddress = {
+  address: string;
+  family: number;
+};
+
+export type ResolveWebhookHostname = (
+  hostname: string,
+  options: { all: true; verbatim: true },
+) => Promise<Array<string | { address: string; family?: number }>>;
+
+export interface WebhookDeliveryUrlPolicy {
+  allowedHosts?: readonly string[];
+  allowPrivateDelivery?: boolean;
+}
+
+export function validateWebhookDeliveryUrl(value: string, policy: WebhookDeliveryUrlPolicy = {}): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Webhook delivery URL is not a valid URL");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Webhook delivery URL must use http or https");
+  }
+  if (url.protocol === "http:" && !isLocalHttpHost(url.hostname)) {
+    throw new Error("Webhook delivery URL must use https unless it targets localhost");
+  }
+  if (url.username || url.password) {
+    throw new Error("Webhook delivery URL must not include embedded credentials");
+  }
+
+  const hostname = normalizePolicyHostname(url.hostname);
+  const local = isLocalHttpHost(hostname);
+  if (!local && !isHostnameAllowed(hostname, policy.allowedHosts)) {
+    throw new Error("Webhook delivery URL host is not allowed");
+  }
+  if (!local && !policy.allowPrivateDelivery && isPrivateOrReservedIpAddress(hostname)) {
+    throw new Error("Webhook delivery URL must not target a private or reserved IP literal");
+  }
+  url.hash = "";
+  return url;
+}
+
+export async function resolveWebhookDeliveryAddresses(
+  url: URL,
+  input: {
+    resolveHostname?: ResolveWebhookHostname;
+    allowPrivateDelivery?: boolean;
+  } = {},
+): Promise<ResolvedWebhookAddress[]> {
+  try {
+    const hostname = normalizePolicyHostname(url.hostname);
+    const resolved = await resolveHostAddresses(
+      hostname,
+      input.resolveHostname ?? lookup,
+      "Webhook delivery URL",
+      { allowPrivate: input.allowPrivateDelivery === true || isLocalHttpHost(hostname) },
+    );
+    if (isLocalHttpHost(hostname) && resolved.some((record) => !isPrivateOrReservedIpAddress(record.address))) {
+      throw new Error("Webhook delivery URL localhost resolved to a public address");
+    }
+    return resolved;
+  } catch (error) {
+    if (error instanceof WebhookDeliveryPolicyError) throw error;
+    if (isTransientResolverError(error)) throw new WebhookDeliveryNetworkError(error);
+    throw new WebhookDeliveryPolicyError(error);
+  }
+}
+
+export function isLocalHttpHost(hostname: string): boolean {
+  const normalized = normalizePolicyHostname(hostname);
+  return normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1";
+}
+
+export function isHostnameAllowed(hostname: string, allowedHosts: readonly string[] | undefined): boolean {
+  const allowed = (allowedHosts || []).map(normalizePolicyHostname).filter(Boolean);
+  if (allowed.length === 0) return true;
+  const normalized = normalizePolicyHostname(hostname);
+  return allowed.some((entry) => {
+    if (entry.startsWith("*.")) {
+      const suffix = entry.slice(1);
+      return normalized.endsWith(suffix) && normalized.length > suffix.length;
+    }
+    return normalized === entry;
+  });
+}
+
+export function isPrivateOrReservedIpAddress(value: string): boolean {
+  const normalized = normalizePolicyHostname(value);
+  if (normalized.includes(":")) return isPrivateOrReservedIpv6(normalized);
+  return isPrivateOrReservedIpv4(normalized);
+}
+
+function normalizePolicyHostname(value: string): string {
+  return value.trim().replace(/^\[/u, "").replace(/\]$/u, "").toLowerCase();
+}
+
+async function resolveHostAddresses(
+  hostname: string,
+  resolveHostname: ResolveWebhookHostname,
+  label: string,
+  options: { allowPrivate?: boolean } = {},
+): Promise<ResolvedWebhookAddress[]> {
+  const literalFamily = isIP(hostname);
+  if (literalFamily) {
+    if (!options.allowPrivate && isPrivateOrReservedIpAddress(hostname)) {
+      throw new Error(`${label} resolved to a private or reserved address`);
+    }
+    return [{ address: hostname, family: literalFamily }];
+  }
+
+  let records: Array<string | { address: string; family?: number }>;
+  try {
+    records = await resolveHostname(hostname, { all: true, verbatim: true });
+  } catch (error) {
+    if (isTransientResolverError(error)) throw error;
+    throw new Error(`${label} host cannot be resolved`, { cause: error });
+  }
+  if (records.length === 0) {
+    throw new Error(`${label} host cannot be resolved`);
+  }
+
+  return records.map((record) => {
+    const address = typeof record === "string" ? record : record.address;
+    const family = typeof record === "string" ? isIP(record) : record.family ?? isIP(record.address);
+    if (!address || !family) throw new Error(`${label} host cannot be resolved`);
+    const normalizedAddress = normalizePolicyHostname(address);
+    if (!options.allowPrivate && isPrivateOrReservedIpAddress(normalizedAddress)) {
+      throw new Error(`${label} resolved to a private or reserved address`);
+    }
+    return { address: normalizedAddress, family };
+  });
+}
+
+function isTransientResolverError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  const code = typeof error.code === "string" ? error.code.toUpperCase() : "";
+  return code === "EAI_AGAIN" ||
+    code === "ETIMEOUT" ||
+    code === "ETIMEDOUT" ||
+    code === "ESERVFAIL" ||
+    code === "SERVFAIL";
+}
+
+function isPrivateOrReservedIpv4(value: string): boolean {
+  const parts = value.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  const [a, b] = parts as [number, number, number, number];
+  if (a === 0 || a === 10 || a === 127 || a >= 224) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 0 && (parts[2] === 0 || parts[2] === 2)) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a === 198 && b === 51 && parts[2] === 100) return true;
+  if (a === 203 && b === 0 && parts[2] === 113) return true;
+  return false;
+}
+
+function isPrivateOrReservedIpv6(value: string): boolean {
+  const normalized = value.toLowerCase();
+  if (normalized === "::" || normalized === "::1") return true;
+  const mappedIpv4 = ipv4FromMappedIpv6(normalized);
+  if (mappedIpv4) return isPrivateOrReservedIpv4(mappedIpv4);
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  if (normalized.startsWith("fe8") || normalized.startsWith("fe9") || normalized.startsWith("fea") || normalized.startsWith("feb")) return true;
+  if (normalized.startsWith("ff")) return true;
+  if (normalized.startsWith("2001:db8")) return true;
+  return false;
+}
+
+function ipv4FromMappedIpv6(value: string): string | null {
+  if (!value.startsWith("::ffff:")) return null;
+  const suffix = value.slice("::ffff:".length);
+  if (suffix.includes(".")) return suffix;
+  const parts = suffix.split(":");
+  if (parts.length !== 2) return null;
+  const high = parseIpv6MappedPart(parts[0]);
+  const low = parseIpv6MappedPart(parts[1]);
+  if (high === null || low === null) return null;
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff
+  ].join(".");
+}
+
+function parseIpv6MappedPart(value: string | undefined): number | null {
+  if (!value || !/^[0-9a-f]{1,4}$/u.test(value)) return null;
+  const parsed = Number.parseInt(value, 16);
+  return Number.isInteger(parsed) && parsed >= 0 && parsed <= 0xffff ? parsed : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

Closes #763.

This PR hardens Gateway webhook and bridge outbound delivery using the Open Gateway patterns called out in roadmap #758:

- Adds fail-closed delivery URL policy: HTTPS except loopback, no embedded credentials, host allowlists, private/reserved IP literal rejection, DNS preflight rejection for private/reserved answers, localhost rebinding rejection, and pinned HTTP/S delivery addresses.
- Adds typed webhook delivery failures, retry-after parsing, bounded exponential backoff with jitter, transient network/timeout classification, and provider circuit breaker health degradation.
- Preserves Cloud delivery ids as downstream idempotency keys while classifying circuit-open failures as retryable and URL/body policy failures as permanent.
- Wires `allowPrivateDelivery` and `deliveryUrlAllowedHosts` through Gateway config/env for generic webhook and bridge providers.
- Documents the default public policy and explicit private/internal escape hatch.

## Review fixes included

Autoreview found and this PR fixes:

- IPv4-mapped IPv6 private-address bypasses.
- Circuit cooldown being dropped when scheduling Cloud retries.
- Custom fetch delivery bypassing pinned DNS addresses.
- Node `lookup({ all: true })` pinned lookup callback compatibility.
- Transient DNS resolver errors being dead-lettered instead of retried.
- DNS resolution not being bounded by the delivery timeout.

A final autoreview rerun could not complete because the Codex review engine hit a temporary usage limit after the fixes were applied; all accepted findings from completed review runs are addressed in this commit.

## Verification

- `pnpm --filter @open-cowork/gateway-provider-webhook test`
- `pnpm --filter @open-cowork/gateway test`
- `pnpm typecheck`
- `pnpm test`
- `uv run mkdocs build --strict`
- `git diff --check`
- Targeted lint for PR-scoped files:
  - `pnpm exec eslint apps/gateway/src/config.ts apps/gateway/src/daemon.test.ts apps/gateway/src/gateway-runtime.ts apps/gateway/src/provider-errors.ts apps/gateway/src/provider-registry.ts packages/gateway-provider-webhook/src/webhook-provider.test.ts packages/gateway-provider-webhook/src/webhook-provider.ts packages/gateway-provider-webhook/src/webhook-url-policy.ts --max-warnings 0`
  - earlier full target set also covered provider export/Discord test files.

`pnpm lint` is locally blocked by unrelated unstaged work in `scripts/desktop-after-pack.mjs` (`@typescript-eslint/no-var-requires` rule definition not found). That file is not part of this branch diff; CI should run from the clean PR checkout.