### PR TITLE
Harden standalone gateway data plane

### DIFF
--- a/apps/standalone-gateway/src/config.test.ts
+++ b/apps/standalone-gateway/src/config.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { loadStandaloneGatewayConfig } from "../dist/config.js";
+import {
+  assertStandaloneGatewayProductionDatabaseSecurity,
+  loadStandaloneGatewayConfig,
+  standaloneGatewayProductionDatabaseSecurityIssue,
+} from "../dist/config.js";
 
 const baseEnv = {
   OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:5432/gateway",
@@ -16,6 +20,9 @@ test("standalone gateway config requires private OpenCode, Postgres, admin token
 
   assert.equal(config.productMode, "standalone");
   assert.equal(config.database.url, baseEnv.OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL);
+  assert.equal(config.database.ssl, false);
+  assert.equal(config.database.sslRejectUnauthorized, true);
+  assert.equal(config.retention.jobDays, 30);
   assert.equal(config.opencode.baseUrl, "http://127.0.0.1:4096");
   assert.deepEqual(config.providers.map((provider) => ({
     id: provider.id,
@@ -26,6 +33,55 @@ test("standalone gateway config requires private OpenCode, Postgres, admin token
     kind: "webhook",
     channelBindingId: "webhook",
   }]);
+});
+
+test("standalone gateway config resolves Postgres TLS and retention windows", () => {
+  const config = loadStandaloneGatewayConfig({
+    ...baseEnv,
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL: "true",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_REJECT_UNAUTHORIZED: "false",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_CA_PATH: "/certs/ca.pem",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_CERT_PATH: "/certs/client-cert.pem",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_KEY_PATH: "/certs/client-key.pem",
+    OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_JOB_DAYS: "14",
+  });
+
+  assert.equal(config.database.ssl, true);
+  assert.equal(config.database.sslRejectUnauthorized, false);
+  assert.equal(config.database.sslCaPath, "/certs/ca.pem");
+  assert.equal(config.database.sslCertPath, "/certs/client-cert.pem");
+  assert.equal(config.database.sslKeyPath, "/certs/client-key.pem");
+  assert.equal(config.retention.jobDays, 14);
+});
+
+test("standalone gateway production modes require verified Postgres TLS before serving", () => {
+  const solo = loadStandaloneGatewayConfig(baseEnv);
+  assert.doesNotThrow(() => assertStandaloneGatewayProductionDatabaseSecurity(solo));
+  assert.equal(standaloneGatewayProductionDatabaseSecurityIssue(solo), null);
+
+  const teamPlaintext = loadStandaloneGatewayConfig({
+    ...baseEnv,
+    OPEN_COWORK_STANDALONE_GATEWAY_DEPLOYMENT_MODE: "team",
+  });
+  assert.throws(
+    () => assertStandaloneGatewayProductionDatabaseSecurity(teamPlaintext),
+    /DATABASE_SSL=true/,
+  );
+  assert.match(
+    standaloneGatewayProductionDatabaseSecurityIssue(teamPlaintext) || "",
+    /DATABASE_SSL=true/,
+  );
+
+  const teamUnverified = loadStandaloneGatewayConfig({
+    ...baseEnv,
+    OPEN_COWORK_STANDALONE_GATEWAY_DEPLOYMENT_MODE: "team",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL: "true",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_REJECT_UNAUTHORIZED: "false",
+  });
+  assert.throws(
+    () => assertStandaloneGatewayProductionDatabaseSecurity(teamUnverified),
+    /verified Postgres TLS/,
+  );
 });
 
 test("standalone gateway config rejects public OpenCode and placeholder admin secrets", () => {

--- a/apps/standalone-gateway/src/config.ts
+++ b/apps/standalone-gateway/src/config.ts
@@ -30,6 +30,10 @@ export function loadStandaloneGatewayConfig(env: StandaloneGatewayEnv = process.
     database: {
       url: databaseUrl,
       ssl: readBoolean(env.OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL, false),
+      sslRejectUnauthorized: readBoolean(env.OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_REJECT_UNAUTHORIZED, true),
+      sslCaPath: readNullable(env.OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_CA_PATH),
+      sslCertPath: readNullable(env.OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_CERT_PATH),
+      sslKeyPath: readNullable(env.OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_KEY_PATH),
     },
     opencode: {
       baseUrl: assertPrivateOpenCodeEndpoint(opencodeBaseUrl, { allowPrivateDns }).toString().replace(/\/$/, ""),
@@ -40,6 +44,7 @@ export function loadStandaloneGatewayConfig(env: StandaloneGatewayEnv = process.
       sessionDays: readInteger(env.OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_SESSION_DAYS, 90, 1, 3650),
       artifactDays: readInteger(env.OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_ARTIFACT_DAYS, 30, 1, 3650),
       auditDays: readInteger(env.OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_AUDIT_DAYS, 365, 1, 3650),
+      jobDays: readInteger(env.OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_JOB_DAYS, 30, 1, 3650),
     },
     providers: readProviders(env),
   };
@@ -47,6 +52,22 @@ export function loadStandaloneGatewayConfig(env: StandaloneGatewayEnv = process.
   if (publicBaseUrl && !adminToken) throw new Error("Public Standalone Gateway installs require an admin token.");
   if (isPlaceholderSecret(adminToken)) throw new Error("Standalone Gateway admin token is still a placeholder.");
   return config;
+}
+
+export function assertStandaloneGatewayProductionDatabaseSecurity(config: StandaloneGatewayConfig): void {
+  const issue = standaloneGatewayProductionDatabaseSecurityIssue(config);
+  if (issue) throw new Error(issue);
+}
+
+export function standaloneGatewayProductionDatabaseSecurityIssue(config: StandaloneGatewayConfig): string | null {
+  if (config.deploymentMode === "solo") return null;
+  if (!config.database.ssl) {
+    return `Standalone Gateway ${config.deploymentMode} deployments require OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL=true.`;
+  }
+  if (!config.database.sslRejectUnauthorized) {
+    return `Standalone Gateway ${config.deploymentMode} deployments require verified Postgres TLS. Keep OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_REJECT_UNAUTHORIZED=true.`;
+  }
+  return null;
 }
 
 function readProviders(env: StandaloneGatewayEnv): StandaloneGatewayProviderConfig[] {

--- a/apps/standalone-gateway/src/doctor.test.ts
+++ b/apps/standalone-gateway/src/doctor.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 
 import { loadStandaloneGatewayConfig } from "../dist/config.js";
 import { runStandaloneGatewayDoctor } from "../dist/doctor.js";
@@ -28,19 +29,83 @@ test("standalone doctor checks product mode, repository, OpenCode, schema, and p
   });
 
   assert.equal(result.ok, true);
-  assert.deepEqual(result.checks.map((check) => check.name), ["product-mode", "postgres", "opencode-private", "schema", "providers", "identity-authorization"]);
+  assert.deepEqual(result.checks.map((check) => check.name), ["product-mode", "postgres", "postgres-tls", "opencode-private", "schema", "providers", "identity-authorization", "retention"]);
   assert.deepEqual(result.doctorChecks.map((check) => check.code), [
     "standalone_gateway.product_mode",
     "standalone_gateway.repository.readiness",
+    "standalone_gateway.repository.tls",
     "standalone_gateway.opencode.health",
     "standalone_gateway.schema.production_tables",
     "standalone_gateway.providers.configured",
     "standalone_gateway.identity_authorization",
+    "standalone_gateway.retention.policy",
   ]);
+  assert.equal(result.doctorChecks.find((check) => check.code === "standalone_gateway.repository.tls")?.status, "pass");
+  assert.equal(result.doctorChecks.find((check) => check.code === "standalone_gateway.retention.policy")?.status, "pass");
   assert.equal(result.readinessTimeline.at(-1)?.phase, "ready");
   assert.equal(result.runtimeStatus.authority, "standalone-gateway");
   assert.equal(result.workspaceAuthority.audit, "standalone_gateway_repository");
   assert.equal(result.redacted, true);
+});
+
+test("standalone doctor fails closed for team Postgres without verified TLS", async () => {
+  const config = loadStandaloneGatewayConfig({
+    OPEN_COWORK_STANDALONE_GATEWAY_DEPLOYMENT_MODE: "team",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@db.example.test:5432/gateway",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL: "true",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_REJECT_UNAUTHORIZED: "false",
+    OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_CA_PATH: "/certs/ca.pem",
+    OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN: "standalone-admin-token",
+    OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL: "http://127.0.0.1:4096",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
+    OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
+  });
+  const repository = new InMemoryStandaloneGatewayRepository();
+  await repository.upsertChannelIdentity({
+    provider: "webhook",
+    externalUserId: "user-1",
+    role: "admin",
+  });
+
+  const result = await runStandaloneGatewayDoctor({
+    config,
+    repository,
+    opencode: new FakeStandaloneOpenCodeAdapter(),
+  });
+
+  const tlsCheck = result.doctorChecks.find((check) => check.code === "standalone_gateway.repository.tls");
+  assert.equal(result.ok, false);
+  assert.equal(tlsCheck?.status, "fail");
+  assert.equal(tlsCheck?.evidence?.deploymentMode, "team");
+  assert.equal(tlsCheck?.evidence?.enabled, true);
+  assert.equal(tlsCheck?.evidence?.rejectUnauthorized, false);
+  assert.equal(tlsCheck?.evidence?.caConfigured, true);
+  assert.equal(JSON.stringify(tlsCheck).includes("/certs/ca.pem"), false);
+});
+
+test("standalone doctor reports production TLS failure without connecting to Postgres", () => {
+  const result = spawnSync(process.execPath, [new URL("../dist/main.js", import.meta.url).pathname, "doctor"], {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: "--no-warnings",
+      OPEN_COWORK_STANDALONE_GATEWAY_DEPLOYMENT_MODE: "team",
+      OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL: "postgres://gateway:gateway@127.0.0.1:1/gateway",
+      OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN: "standalone-admin-token",
+      OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL: "http://127.0.0.1:4096",
+      OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_SHARED_SECRET: "standalone-webhook-secret",
+      OPEN_COWORK_STANDALONE_GATEWAY_WEBHOOK_DELIVERY_URL: "https://bridge.example.test/deliver",
+    },
+    encoding: "utf8",
+  });
+  const report = JSON.parse(result.stdout) as Awaited<ReturnType<typeof runStandaloneGatewayDoctor>>;
+
+  assert.equal(result.status, 1);
+  assert.equal(report.doctorChecks.find((check) => check.code === "standalone_gateway.repository.tls")?.status, "fail");
+  assert.match(
+    report.doctorChecks.find((check) => check.code === "standalone_gateway.repository.readiness")?.message || "",
+    /Postgres readiness skipped/,
+  );
+  assert.equal(result.stderr, "");
 });
 
 test("standalone doctor fails closed when no prompt-capable identity is configured", async () => {

--- a/apps/standalone-gateway/src/doctor.ts
+++ b/apps/standalone-gateway/src/doctor.ts
@@ -92,6 +92,8 @@ export async function runStandaloneGatewayDoctor(input: {
   const opencode = await input.opencode.health();
   const configuredProviderIds = input.config.providers.filter((provider) => provider.enabled).map((provider) => provider.id);
   const identityAuthorization = await identityAuthorizationSummary(input.repository, repository.ok, configuredProviderIds);
+  const databaseTls = databaseTlsSummary(input.config);
+  const retention = retentionSummary(input.config);
   const schemaOk = standaloneGatewaySchemaContainsProductionTables();
   const productModeOk = input.config.productMode === "standalone";
   const providersOk = input.config.providers.length > 0;
@@ -99,10 +101,12 @@ export async function runStandaloneGatewayDoctor(input: {
   const checks: StandaloneDoctorCheck[] = [
     legacyCheck("product-mode", productModeOk, `mode=${input.config.productMode}`),
     legacyCheck("postgres", repository.ok, repository.detail),
+    legacyCheck("postgres-tls", databaseTls.ok, databaseTls.detail),
     legacyCheck("opencode-private", opencode.ok, opencode.detail),
     legacyCheck("schema", schemaOk, "standalone gateway schema covers sessions/events/jobs/leases/channel/artifact/team/audit tables"),
     legacyCheck("providers", providersOk, `${input.config.providers.length} provider(s) configured`),
     legacyCheck("identity-authorization", identitiesOk, identityAuthorization.detail),
+    legacyCheck("retention", retention.ok, retention.detail),
   ];
   const doctorChecks = [
     doctorCheck({
@@ -118,6 +122,13 @@ export async function runStandaloneGatewayDoctor(input: {
       message: repository.detail,
       remediation: "Verify Postgres connectivity, migrations, and Standalone Gateway database credentials.",
       evidence: { repository: "postgres" },
+    }),
+    doctorCheck({
+      code: "standalone_gateway.repository.tls",
+      status: databaseTls.ok ? "pass" : "fail",
+      message: databaseTls.detail,
+      remediation: "Enable OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL=true and keep certificate verification enabled for team or enterprise deployments.",
+      evidence: databaseTls.evidence,
     }),
     doctorCheck({
       code: "standalone_gateway.opencode.health",
@@ -150,6 +161,13 @@ export async function runStandaloneGatewayDoctor(input: {
         promptCapable: identityAuthorization.summary.promptCapable,
       },
     }),
+    doctorCheck({
+      code: "standalone_gateway.retention.policy",
+      status: retention.ok ? "pass" : "fail",
+      message: retention.detail,
+      remediation: "Set positive retention windows for sessions, artifacts, audit rows, and completed jobs.",
+      evidence: retention.evidence,
+    }),
   ];
   const ok = doctorChecks.every((check) => check.status === "pass" || check.status === "skipped");
   return {
@@ -180,6 +198,65 @@ export async function runStandaloneGatewayDoctor(input: {
       audit: "standalone_gateway_repository",
     },
     redacted: true,
+  };
+}
+
+function databaseTlsSummary(config: StandaloneGatewayConfig): {
+  ok: boolean;
+  detail: string;
+  evidence: RuntimeDoctorCheck["evidence"];
+} {
+  const productionMode = config.deploymentMode === "team" || config.deploymentMode === "enterprise";
+  const evidence = {
+    deploymentMode: config.deploymentMode,
+    enabled: config.database.ssl,
+    rejectUnauthorized: config.database.ssl ? config.database.sslRejectUnauthorized : null,
+    caConfigured: Boolean(config.database.sslCaPath),
+    certConfigured: Boolean(config.database.sslCertPath),
+    keyConfigured: Boolean(config.database.sslKeyPath),
+  };
+  if (!config.database.ssl) {
+    return {
+      ok: !productionMode,
+      detail: productionMode
+        ? `Postgres TLS is disabled for ${config.deploymentMode} deployment mode.`
+        : "Postgres TLS is disabled for solo/local deployment mode.",
+      evidence,
+    };
+  }
+  if (productionMode && !config.database.sslRejectUnauthorized) {
+    return {
+      ok: false,
+      detail: `Postgres TLS certificate verification is disabled for ${config.deploymentMode} deployment mode.`,
+      evidence,
+    };
+  }
+  return {
+    ok: true,
+    detail: config.database.sslRejectUnauthorized
+      ? "Postgres TLS is enabled with certificate verification."
+      : "Postgres TLS is enabled without certificate verification for solo/local deployment mode.",
+    evidence,
+  };
+}
+
+function retentionSummary(config: StandaloneGatewayConfig): {
+  ok: boolean;
+  detail: string;
+  evidence: RuntimeDoctorCheck["evidence"];
+} {
+  const windows = config.retention;
+  const ok = windows.sessionDays > 0 && windows.artifactDays > 0 && windows.auditDays > 0 && windows.jobDays > 0;
+  return {
+    ok,
+    detail: `Retention is lease-gated with sessions=${windows.sessionDays}d artifacts=${windows.artifactDays}d audit=${windows.auditDays}d jobs=${windows.jobDays}d.`,
+    evidence: {
+      leaseGated: true,
+      sessionDays: windows.sessionDays,
+      artifactDays: windows.artifactDays,
+      auditDays: windows.auditDays,
+      jobDays: windows.jobDays,
+    },
   };
 }
 

--- a/apps/standalone-gateway/src/main.ts
+++ b/apps/standalone-gateway/src/main.ts
@@ -1,32 +1,48 @@
 import { hostname } from "node:os";
 
-import { loadStandaloneGatewayConfig } from "./config.js";
+import {
+  assertStandaloneGatewayProductionDatabaseSecurity,
+  loadStandaloneGatewayConfig,
+  standaloneGatewayProductionDatabaseSecurityIssue,
+} from "./config.js";
 import { runStandaloneGatewayDoctor } from "./doctor.js";
 import { createSdkOpenCodeAdapter } from "./opencode.js";
 import { createStandaloneGatewayPostgresRepository } from "./postgres-repository.js";
 import { createStandaloneProviderRegistry } from "./provider-registry.js";
+import { runStandaloneGatewayRetention } from "./retention.js";
 import { normalizeIdentityRole, normalizeIdentityStatus } from "./repository.js";
 import { createStandaloneGatewayRuntime } from "./runtime.js";
 import { createStandaloneGatewayServer } from "./server.js";
 import { runStandaloneGatewaySmoke } from "./smoke.js";
+import type { StandaloneGatewayRepository } from "./repository.js";
 
 const command = process.argv[2] || "serve";
+const daemonLeaseId = "standalone-gateway:daemon";
+const daemonLeaseTtlMs = 30_000;
+const daemonLeaseRenewalMs = 10_000;
+const maintenanceIntervalMs = 5_000;
+const retentionIntervalMs = 60 * 60 * 1000;
 
 if (command === "smoke") {
   const result = await runStandaloneGatewaySmoke();
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 } else {
   const config = loadStandaloneGatewayConfig();
-  const repository = await createStandaloneGatewayPostgresRepository(config.database.url);
-  await repository.migrate();
   const opencode = createSdkOpenCodeAdapter({ baseUrl: config.opencode.baseUrl });
 
   if (command === "doctor") {
+    const databaseSecurityIssue = standaloneGatewayProductionDatabaseSecurityIssue(config);
+    const repository = databaseSecurityIssue
+      ? skippedDoctorRepository(databaseSecurityIssue)
+      : await createMigratedRepository(config.database);
     const result = await runStandaloneGatewayDoctor({ config, repository, opencode });
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     await repository.close?.();
     process.exitCode = result.ok ? 0 : 1;
   } else if (command === "identity") {
+    assertStandaloneGatewayProductionDatabaseSecurity(config);
+    const repository = await createStandaloneGatewayPostgresRepository(config.database);
+    await repository.migrate();
     const action = process.argv[3] || "";
     if (action !== "upsert") {
       throw new Error("Unknown standalone gateway identity command. Use: identity upsert --provider <id> --external-user-id <id> --role <owner|admin|member|approver|viewer> [--status <active|disabled>] [--provider-workspace-id <id>].");
@@ -46,11 +62,14 @@ if (command === "smoke") {
     process.stdout.write(`${JSON.stringify({ ok: true, identity }, null, 2)}\n`);
     await repository.close?.();
   } else if (command === "serve") {
+    assertStandaloneGatewayProductionDatabaseSecurity(config);
+    const repository = await createStandaloneGatewayPostgresRepository(config.database);
+    await repository.migrate();
     const ownerId = `${hostname()}:${process.pid}`;
     const lease = await repository.acquireDaemonLease({
-      leaseId: "standalone-gateway:daemon",
+      leaseId: daemonLeaseId,
       ownerId,
-      ttlMs: 30_000,
+      ttlMs: daemonLeaseTtlMs,
     });
     if (!lease) {
       throw new Error("Another Standalone Gateway daemon owns the active provider/runtime lease.");
@@ -58,10 +77,10 @@ if (command === "smoke") {
     let leaseToken = lease.leaseToken;
     const leaseRenewal = setInterval(() => {
       void repository.renewDaemonLease({
-        leaseId: "standalone-gateway:daemon",
+        leaseId: daemonLeaseId,
         ownerId,
         leaseToken,
-        ttlMs: 30_000,
+        ttlMs: daemonLeaseTtlMs,
       }).then((renewed) => {
         if (!renewed) throw new Error("Lost Standalone Gateway daemon lease.");
         leaseToken = renewed.leaseToken;
@@ -69,28 +88,47 @@ if (command === "smoke") {
         process.stderr.write(`Standalone Gateway lease renewal failed: ${error instanceof Error ? error.message : String(error)}\n`);
         process.exit(1);
       });
-    }, 10_000);
+    }, daemonLeaseRenewalMs);
 
     const runtime = createStandaloneGatewayRuntime({ repository, opencode });
     const providers = createStandaloneProviderRegistry(config);
     await providers.start((providerConfig, message) =>
       runtime.handleMessage(providers.get(providerConfig.id)!.provider, providerConfig, message)
     );
-    const jobRunner = setInterval(() => {
-      void runtime.runDueJobs(ownerId).catch((error: unknown) => {
-        process.stderr.write(`Standalone Gateway job runner failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    let maintenanceRunning = false;
+    let nextRetentionAt = 0;
+    const maintenanceRunner = setInterval(() => {
+      if (maintenanceRunning) return;
+      maintenanceRunning = true;
+      void (async () => {
+        await runtime.runDueJobs(ownerId);
+        const now = Date.now();
+        if (now < nextRetentionAt) return;
+        const result = await runStandaloneGatewayRetention({
+          repository,
+          config,
+          lease: { leaseId: daemonLeaseId, ownerId, leaseToken },
+        });
+        if (!result) {
+          throw new Error("Standalone Gateway retention skipped because the daemon lease is not active.");
+        }
+        nextRetentionAt = Date.now() + retentionIntervalMs;
+      })().catch((error: unknown) => {
+        process.stderr.write(`Standalone Gateway maintenance runner failed: ${error instanceof Error ? error.message : String(error)}\n`);
+      }).finally(() => {
+        maintenanceRunning = false;
       });
-    }, 5_000);
+    }, maintenanceIntervalMs);
     const server = createStandaloneGatewayServer({ config, repository, opencode, providers });
     await server.listen();
     process.stdout.write(`Open Cowork Standalone Gateway listening on ${server.url() || `${config.server.host}:${config.server.port}`}\n`);
     const shutdown = async () => {
       clearInterval(leaseRenewal);
-      clearInterval(jobRunner);
+      clearInterval(maintenanceRunner);
       await server.close().catch(() => undefined);
       await providers.stop().catch(() => undefined);
       await repository.releaseDaemonLease({
-        leaseId: "standalone-gateway:daemon",
+        leaseId: daemonLeaseId,
         ownerId,
         leaseToken,
       }).catch(() => undefined);
@@ -100,9 +138,28 @@ if (command === "smoke") {
     process.once("SIGTERM", () => void shutdown().then(() => process.exit(0)));
   } else {
     process.stderr.write(`Unknown standalone gateway command ${command}. Use serve, doctor, or smoke.\n`);
-    await repository.close?.();
     process.exitCode = 1;
   }
+}
+
+async function createMigratedRepository(
+  database: Parameters<typeof createStandaloneGatewayPostgresRepository>[0],
+): Promise<StandaloneGatewayRepository> {
+  const repository = await createStandaloneGatewayPostgresRepository(database);
+  await repository.migrate();
+  return repository;
+}
+
+function skippedDoctorRepository(
+  reason: string,
+): Pick<StandaloneGatewayRepository, "readiness"> & { close?: StandaloneGatewayRepository["close"] } {
+  return {
+    readiness: async () => ({
+      ok: false,
+      detail: `Postgres readiness skipped because ${reason}`,
+    }),
+    close: undefined,
+  };
 }
 
 function parseArgs(argv: string[]): Record<string, string> {

--- a/apps/standalone-gateway/src/postgres-repository.ts
+++ b/apps/standalone-gateway/src/postgres-repository.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 
+import { standaloneRetentionCutoffs } from "./retention.js";
 import { standaloneGatewayMigrations } from "./schema.js";
 import {
   canIdentityPrompt,
@@ -7,6 +9,8 @@ import {
   normalizeIdentityStatus,
   normalizeWorkspaceId,
   redactRecord,
+  retentionAuditMetadata,
+  retentionResult,
 } from "./repository.js";
 import { redactSecretText } from "./redaction.js";
 import type { StandaloneGatewayRepository } from "./repository.js";
@@ -22,8 +26,10 @@ import type {
   StandaloneGatewayIdentityAuthorizationSummary,
   StandaloneGatewayIdentityRole,
   StandaloneGatewayIdentityStatus,
+  StandaloneGatewayRetentionResult,
   StandaloneGatewaySessionRecord,
   StandalonePromptInput,
+  StandaloneGatewayConfig,
 } from "./types.js";
 
 export interface PgLikeClient {
@@ -36,9 +42,74 @@ export interface PgLikePool extends PgLikeClient {
   end?(): Promise<void>;
 }
 
-export async function createStandaloneGatewayPostgresRepository(databaseUrl: string): Promise<StandaloneGatewayRepository> {
-  const pg = await import("pg") as { Pool: new (options: { connectionString: string }) => PgLikePool };
-  return new PostgresStandaloneGatewayRepository(new pg.Pool({ connectionString: databaseUrl }));
+export interface StandalonePostgresPoolOptions {
+  connectionString: string;
+  ssl?: {
+    rejectUnauthorized: boolean;
+    ca?: string;
+    cert?: string;
+    key?: string;
+  };
+}
+
+export interface CreateStandaloneGatewayPostgresRepositoryOptions {
+  createPool?: (options: StandalonePostgresPoolOptions) => PgLikePool;
+  readFile?: (path: string) => string;
+}
+
+type StandaloneDatabaseConfig = StandaloneGatewayConfig["database"];
+
+export async function createStandaloneGatewayPostgresRepository(
+  database: string | StandaloneDatabaseConfig,
+  options: CreateStandaloneGatewayPostgresRepositoryOptions = {},
+): Promise<StandaloneGatewayRepository> {
+  const poolOptions = standalonePostgresPoolOptions(database, { readFile: options.readFile });
+  if (options.createPool) {
+    return new PostgresStandaloneGatewayRepository(options.createPool(poolOptions));
+  }
+  const pg = await import("pg") as {
+    Pool: new (options: StandalonePostgresPoolOptions) => PgLikePool;
+  };
+  return new PostgresStandaloneGatewayRepository(new pg.Pool(poolOptions));
+}
+
+export function standalonePostgresPoolOptions(
+  database: string | StandaloneDatabaseConfig,
+  options: { readFile?: (path: string) => string } = {},
+): StandalonePostgresPoolOptions {
+  if (typeof database === "string") {
+    return { connectionString: database };
+  }
+  const poolOptions: StandalonePostgresPoolOptions = {
+    connectionString: database.ssl ? stripPostgresSslConnectionOptions(database.url) : database.url,
+  };
+  if (!database.ssl) {
+    return poolOptions;
+  }
+  const readFile = options.readFile || ((path: string) => readFileSync(path, "utf8"));
+  poolOptions.ssl = {
+    rejectUnauthorized: database.sslRejectUnauthorized,
+    ...(database.sslCaPath ? { ca: readFile(database.sslCaPath) } : {}),
+    ...(database.sslCertPath ? { cert: readFile(database.sslCertPath) } : {}),
+    ...(database.sslKeyPath ? { key: readFile(database.sslKeyPath) } : {}),
+  };
+  return poolOptions;
+}
+
+function stripPostgresSslConnectionOptions(connectionString: string): string {
+  try {
+    const url = new URL(connectionString);
+    let stripped = false;
+    for (const key of [...url.searchParams.keys()]) {
+      if (key.toLowerCase().startsWith("ssl")) {
+        url.searchParams.delete(key);
+        stripped = true;
+      }
+    }
+    return stripped ? url.toString() : connectionString;
+  } catch {
+    return connectionString;
+  }
 }
 
 export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRepository {
@@ -126,7 +197,7 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
          )
          VALUES ($1, $2, 'idle', $3, $4, $5, $6, $7, $8, $9, $10, $10)
          ON CONFLICT (provider, provider_workspace_id, external_chat_id, external_thread_id) DO UPDATE
-         SET updated_at = standalone_gateway_sessions.updated_at
+         SET updated_at = EXCLUDED.updated_at
          RETURNING *`,
         [
           randomUUID(),
@@ -360,6 +431,74 @@ export class PostgresStandaloneGatewayRepository implements StandaloneGatewayRep
       [randomUUID(), action, actor, JSON.stringify(redactRecord(metadata)), now.toISOString()],
     );
     return auditFromRow(result.rows[0]!);
+  }
+
+  async pruneRetention(input: {
+    retention: { sessionDays: number; artifactDays: number; auditDays: number; jobDays: number };
+    leaseId: string;
+    ownerId: string;
+    leaseToken: string;
+    now?: Date;
+  }): Promise<StandaloneGatewayRetentionResult | null> {
+    const now = input.now || new Date();
+    const cutoffs = standaloneRetentionCutoffs(input.retention, now);
+    return this.withTransaction(async (client) => {
+      const lease = await client.query(
+        `SELECT lease_id
+         FROM standalone_gateway_daemon_leases
+         WHERE lease_id = $1
+           AND owner_id = $2
+           AND lease_token = $3
+           AND expires_at > $4
+         FOR UPDATE`,
+        [input.leaseId, input.ownerId, input.leaseToken, now.toISOString()],
+      );
+      if (lease.rows.length === 0) {
+        return null;
+      }
+      const artifacts = await client.query(
+        "DELETE FROM standalone_gateway_artifacts WHERE created_at < $1",
+        [cutoffs.artifactCutoff.toISOString()],
+      );
+      const sessions = await client.query(
+        `DELETE FROM standalone_gateway_sessions sessions
+         WHERE sessions.updated_at < $1
+           AND sessions.status IN ('idle', 'failed', 'completed')
+           AND NOT EXISTS (
+             SELECT 1
+             FROM standalone_gateway_jobs jobs
+             WHERE jobs.session_id = sessions.session_id
+               AND jobs.status IN ('pending', 'claimed', 'running')
+           )
+           AND NOT EXISTS (
+             SELECT 1
+             FROM standalone_gateway_artifacts artifacts
+             WHERE artifacts.session_id = sessions.session_id
+               AND artifacts.created_at >= $2
+           )`,
+        [cutoffs.sessionCutoff.toISOString(), cutoffs.artifactCutoff.toISOString()],
+      );
+      const jobs = await client.query(
+        "DELETE FROM standalone_gateway_jobs WHERE updated_at < $1 AND status IN ('completed', 'failed', 'dead')",
+        [cutoffs.jobCutoff.toISOString()],
+      );
+      const auditEvents = await client.query(
+        "DELETE FROM standalone_gateway_audit_events WHERE created_at < $1",
+        [cutoffs.auditCutoff.toISOString()],
+      );
+      const result = retentionResult(now, cutoffs, {
+        sessionsDeleted: sessions.rowCount || 0,
+        artifactsDeleted: artifacts.rowCount || 0,
+        auditEventsDeleted: auditEvents.rowCount || 0,
+        jobsDeleted: jobs.rowCount || 0,
+      });
+      await client.query(
+        `INSERT INTO standalone_gateway_audit_events (audit_id, action, actor, metadata, created_at)
+         VALUES ($1, 'standalone.retention.pruned', $2, $3::jsonb, $4)`,
+        [randomUUID(), input.ownerId, JSON.stringify(retentionAuditMetadata(result)), now.toISOString()],
+      );
+      return result;
+    });
   }
 
   async close(): Promise<void> {

--- a/apps/standalone-gateway/src/repository.test.ts
+++ b/apps/standalone-gateway/src/repository.test.ts
@@ -3,9 +3,13 @@ import assert from "node:assert/strict";
 
 import * as standaloneGateway from "../dist/index.js";
 import { exportStandaloneGatewayBackup } from "../dist/backup.js";
-import { PostgresStandaloneGatewayRepository } from "../dist/postgres-repository.js";
+import {
+  createStandaloneGatewayPostgresRepository,
+  PostgresStandaloneGatewayRepository,
+  standalonePostgresPoolOptions,
+} from "../dist/postgres-repository.js";
 import { InMemoryStandaloneGatewayRepository } from "../dist/repository.js";
-import { describeStandaloneRetention } from "../dist/retention.js";
+import { describeStandaloneRetention, runStandaloneGatewayRetention } from "../dist/retention.js";
 import { standaloneGatewayMigrations } from "../dist/schema.js";
 
 function fakeProviderKey(...parts: string[]) {
@@ -132,11 +136,182 @@ test("standalone package barrel exposes backup, retention, and repository adapte
   assert.deepEqual(backup.sessions, [{ sessionId: "session-1" }]);
   assert.deepEqual(backup.identities, [{ identityId: "identity-1" }]);
   assert.deepEqual(describeStandaloneRetention({
-    retention: { sessionDays: 30, artifactDays: 7, auditDays: 90 },
-  } as never), ["sessions:30d", "artifacts:7d", "audit:90d"]);
+    retention: { sessionDays: 30, artifactDays: 7, auditDays: 90, jobDays: 14 },
+  } as never), ["sessions:30d", "artifacts:7d", "audit:90d", "jobs:14d"]);
   assert.equal(standaloneGateway.exportStandaloneGatewayBackup, exportStandaloneGatewayBackup);
   assert.equal(standaloneGateway.describeStandaloneRetention, describeStandaloneRetention);
   assert.equal(typeof standaloneGateway.createStandaloneGatewayPostgresRepository, "function");
+});
+
+test("postgres repository factory builds explicit TLS pool options without a live database", async () => {
+  let capturedOptions: unknown;
+  let closed = false;
+  const repository = await createStandaloneGatewayPostgresRepository({
+    url: "postgres://gateway:gateway@db.example.test:5432/gateway",
+    ssl: true,
+    sslRejectUnauthorized: true,
+    sslCaPath: "/certs/ca.pem",
+    sslCertPath: "/certs/client-cert.pem",
+    sslKeyPath: "/certs/client-key.pem",
+  }, {
+    readFile: (path) => `file:${path}`,
+    createPool: (options) => {
+      capturedOptions = options;
+      return {
+        async query() {
+          return { rows: [], rowCount: 0 };
+        },
+        async end() {
+          closed = true;
+        },
+      };
+    },
+  });
+
+  assert.deepEqual(capturedOptions, {
+    connectionString: "postgres://gateway:gateway@db.example.test:5432/gateway",
+    ssl: {
+      rejectUnauthorized: true,
+      ca: "file:/certs/ca.pem",
+      cert: "file:/certs/client-cert.pem",
+      key: "file:/certs/client-key.pem",
+    },
+  });
+  assert.deepEqual(standalonePostgresPoolOptions("postgres://local"), {
+    connectionString: "postgres://local",
+  });
+  assert.deepEqual(standalonePostgresPoolOptions({
+    url: "postgres://gateway:gateway@db.example.test:5432/gateway?sslmode=require&application_name=open-cowork",
+    ssl: false,
+    sslRejectUnauthorized: true,
+    sslCaPath: null,
+    sslCertPath: null,
+    sslKeyPath: null,
+  }), {
+    connectionString: "postgres://gateway:gateway@db.example.test:5432/gateway?sslmode=require&application_name=open-cowork",
+  });
+  assert.deepEqual(standalonePostgresPoolOptions({
+    url: "postgres://gateway:gateway@db.example.test:5432/gateway?application_name=open-cowork&sslmode=disable&ssl=0&sslrootcert=/tmp/ca.pem",
+    ssl: true,
+    sslRejectUnauthorized: true,
+    sslCaPath: null,
+    sslCertPath: null,
+    sslKeyPath: null,
+  }), {
+    connectionString: "postgres://gateway:gateway@db.example.test:5432/gateway?application_name=open-cowork",
+    ssl: {
+      rejectUnauthorized: true,
+    },
+  });
+  await repository.close?.();
+  assert.equal(closed, true);
+});
+
+test("standalone retention is lease-gated and preserves active sessions and jobs", async () => {
+  const repository = new InMemoryStandaloneGatewayRepository();
+  const now = new Date("2026-06-05T00:00:00.000Z");
+  const old = new Date("2026-02-01T00:00:00.000Z");
+  const recent = new Date("2026-06-01T00:00:00.000Z");
+  const lease = await repository.acquireDaemonLease({ leaseId: "daemon", ownerId: "node-1", ttlMs: 30_000, now });
+  assert.ok(lease);
+  const expiredSession = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-expired", threadId: "thread-expired" },
+    externalUserId: "user-1",
+    text: "expired session",
+    now: old,
+  });
+  await repository.updateSessionRuntime({ sessionId: expiredSession.sessionId, opencodeSessionId: "oc-expired", status: "completed", now: old });
+  const expiredJob = await repository.enqueueJob({ kind: "prompt", sessionId: expiredSession.sessionId, payload: { text: "expired" }, now: old });
+  const expiredClaim = await repository.claimNextJob({ claimedBy: "node-1", ttlMs: 30_000, now: old });
+  assert.equal(expiredClaim?.jobId, expiredJob.jobId);
+  await repository.finishJob({ jobId: expiredJob.jobId, claimToken: expiredClaim!.claimToken!, status: "completed", now: old });
+
+  const activeSession = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-active", threadId: "thread-active" },
+    externalUserId: "user-1",
+    text: "active session",
+    now: old,
+  });
+  await repository.enqueueJob({ kind: "prompt", sessionId: activeSession.sessionId, payload: { text: "still pending" }, now: old });
+  const reopenedSession = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-reopened", threadId: "thread-reopened" },
+    externalUserId: "user-1",
+    text: "old reopened session",
+    now: old,
+  });
+  const touchedSession = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-reopened", threadId: "thread-reopened" },
+    externalUserId: "user-1",
+    text: "touch reopened session",
+    now: recent,
+  });
+  assert.equal(touchedSession.sessionId, reopenedSession.sessionId);
+  assert.equal(touchedSession.updatedAt, recent.toISOString());
+  const runningSession = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-running", threadId: "thread-running" },
+    externalUserId: "user-1",
+    text: "running session",
+    now: old,
+  });
+  await repository.updateSessionRuntime({ sessionId: runningSession.sessionId, opencodeSessionId: "oc-running", status: "running", now: old });
+  const recentSession = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-recent", threadId: "thread-recent" },
+    externalUserId: "user-1",
+    text: "recent session",
+    now: recent,
+  });
+  await repository.recordAudit("old.audit", "user-1", { token: "secret-token" }, old);
+  await repository.recordAudit("recent.audit", "user-1", { note: "keep" }, recent);
+
+  const config = {
+    retention: { sessionDays: 30, artifactDays: 30, auditDays: 30, jobDays: 30 },
+  } as never;
+  assert.equal(await runStandaloneGatewayRetention({
+    repository,
+    config,
+    lease: { leaseId: "daemon", ownerId: "node-1", leaseToken: "wrong-token" },
+    now,
+  }), null);
+
+  const result = await runStandaloneGatewayRetention({
+    repository,
+    config,
+    lease: { leaseId: "daemon", ownerId: "node-1", leaseToken: lease.leaseToken },
+    now,
+  });
+  assert.equal(result?.sessionsDeleted, 1);
+  assert.equal(result?.jobsDeleted, 1);
+  assert.equal(result?.auditEventsDeleted, 1);
+  const snapshot = await repository.dashboardSnapshot(20);
+  assert.equal(snapshot.sessions.some((session) => session.sessionId === expiredSession.sessionId), false);
+  assert.equal(snapshot.sessions.some((session) => session.sessionId === activeSession.sessionId), true);
+  assert.equal(snapshot.sessions.some((session) => session.sessionId === reopenedSession.sessionId), true);
+  assert.equal(snapshot.sessions.some((session) => session.sessionId === runningSession.sessionId), true);
+  assert.equal(snapshot.sessions.some((session) => session.sessionId === recentSession.sessionId), true);
+  assert.equal(snapshot.jobs.some((job) => job.jobId === expiredJob.jobId), false);
+  assert.equal(snapshot.audits.some((audit) => audit.action === "old.audit"), false);
+  assert.equal(snapshot.audits.some((audit) => audit.action === "recent.audit"), true);
+  const retentionAudit = snapshot.audits.find((audit) => audit.action === "standalone.retention.pruned");
+  assert.equal(retentionAudit?.metadata.sessionsDeleted, 1);
+  assert.equal(retentionAudit?.metadata.jobsDeleted, 1);
 });
 
 test("postgres repository adapter maps readiness and daemon lease rows without a live database", async () => {
@@ -316,6 +491,107 @@ test("postgres repository adapter maps readiness and daemon lease rows without a
   assert.ok(queries.some((query) => query.includes("RETURNING *")));
 });
 
+test("postgres repository retention is transactional and protected by the daemon lease", async () => {
+  const now = new Date("2026-06-05T00:00:00.000Z");
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  let released = false;
+  const client = {
+    async query(sql: string, params?: unknown[]) {
+      queries.push({ sql, params });
+      if (sql === "BEGIN" || sql === "COMMIT" || sql === "ROLLBACK") return { rows: [], rowCount: 0 };
+      if (sql.includes("SELECT lease_id")) return { rows: [{ lease_id: "daemon" }], rowCount: 1 };
+      if (sql.includes("DELETE FROM standalone_gateway_artifacts")) return { rows: [], rowCount: 2 };
+      if (sql.includes("DELETE FROM standalone_gateway_sessions")) return { rows: [], rowCount: 3 };
+      if (sql.includes("DELETE FROM standalone_gateway_jobs")) return { rows: [], rowCount: 4 };
+      if (sql.includes("DELETE FROM standalone_gateway_audit_events")) return { rows: [], rowCount: 5 };
+      if (sql.includes("INSERT INTO standalone_gateway_audit_events")) return { rows: [], rowCount: 1 };
+      throw new Error(`Unexpected retention query: ${sql}`);
+    },
+    release() {
+      released = true;
+    },
+  };
+  const repository = new PostgresStandaloneGatewayRepository({
+    async connect() {
+      return client;
+    },
+    async query() {
+      throw new Error("retention should use an explicit transaction client");
+    },
+  } as never);
+
+  const result = await repository.pruneRetention({
+    retention: { sessionDays: 30, artifactDays: 7, auditDays: 90, jobDays: 14 },
+    leaseId: "daemon",
+    ownerId: "node-1",
+    leaseToken: "lease-token",
+    now,
+  });
+
+  assert.equal(result?.sessionsDeleted, 3);
+  assert.equal(result?.artifactsDeleted, 2);
+  assert.equal(result?.auditEventsDeleted, 5);
+  assert.equal(result?.jobsDeleted, 4);
+  assert.equal(queries[0]?.sql, "BEGIN");
+  assert.equal(queries.at(-1)?.sql, "COMMIT");
+  assert.equal(released, true);
+  const retentionSql = queries.map((query) => query.sql).join("\n");
+  assert.match(retentionSql, /FOR UPDATE/);
+  assert.match(retentionSql, /NOT EXISTS/);
+  assert.match(retentionSql, /jobs.status IN \('pending', 'claimed', 'running'\)/);
+  assert.match(retentionSql, /FROM standalone_gateway_artifacts artifacts/);
+  assert.match(retentionSql, /artifacts.created_at >= \$2/);
+  assert.match(retentionSql, /status IN \('completed', 'failed', 'dead'\)/);
+});
+
+test("postgres repository touches existing sessions before appending new message events", async () => {
+  const now = new Date("2026-06-01T00:00:00.000Z");
+  const queries: string[] = [];
+  const repository = new PostgresStandaloneGatewayRepository({
+    async query(sql: string, params?: unknown[]) {
+      queries.push(sql);
+      if (sql === "BEGIN" || sql === "COMMIT" || sql === "ROLLBACK") return { rows: [], rowCount: 0 };
+      if (sql.includes("INSERT INTO standalone_gateway_sessions")) {
+        return {
+          rows: [{
+            session_id: "session-existing",
+            opencode_session_id: "oc-existing",
+            title: "Existing",
+            status: "idle",
+            provider: "webhook-ci",
+            provider_kind: "webhook",
+            provider_workspace_id: "",
+            channel_binding_id: "webhook",
+            external_user_id: "user-1",
+            external_chat_id: "chat-1",
+            external_thread_id: "thread-1",
+            last_event_sequence: 7,
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: params?.[9],
+          }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`Unexpected findOrCreate query: ${sql}`);
+    },
+  } as never);
+
+  const session = await repository.findOrCreateSession({
+    provider: "webhook-ci",
+    providerKind: "webhook",
+    channelBindingId: "webhook",
+    target: { provider: "webhook-ci", providerKind: "webhook", chatId: "chat-1", threadId: "thread-1" },
+    externalUserId: "user-1",
+    text: "hello",
+    now,
+  });
+
+  assert.equal(session.sessionId, "session-existing");
+  assert.equal(session.updatedAt, now.toISOString());
+  assert.match(queries.join("\n"), /updated_at = EXCLUDED\.updated_at/);
+  assert.equal(queries.at(-1), "COMMIT");
+});
+
 test("postgres repository migrations skip applied migration ids before replaying old indexes", async () => {
   const queries: Array<{ sql: string; params?: unknown[] }> = [];
   const pool = {
@@ -329,6 +605,7 @@ test("postgres repository migrations skip applied migration ids before replaying
       if (sql.includes("INSERT INTO standalone_gateway_schema_migrations")) return { rows: [], rowCount: 1 };
       if (sql.includes("0001_standalone_gateway_core")) throw new Error("migration id should not be embedded in SQL");
       if (sql.includes("standalone_gateway_sessions_provider_workspace_thread_unique")) return { rows: [], rowCount: 0 };
+      if (sql.includes("standalone_gateway_sessions_retention_idx")) return { rows: [], rowCount: 0 };
       throw new Error(`Unexpected migration query: ${sql}`);
     },
   };
@@ -339,6 +616,18 @@ test("postgres repository migrations skip applied migration ids before replaying
   const migrationSql = queries.map((query) => query.sql).join("\n");
   assert.equal(migrationSql.includes("CREATE UNIQUE INDEX IF NOT EXISTS standalone_gateway_sessions_provider_thread_unique"), false);
   assert.equal(migrationSql.includes("standalone_gateway_sessions_provider_workspace_thread_unique"), true);
+  assert.equal(migrationSql.includes("standalone_gateway_jobs_active_session_idx"), true);
+});
+
+test("standalone retention migration indexes prune and active-job lookups", () => {
+  const migration = standaloneGatewayMigrations.find((entry) => entry.id === "0003_standalone_gateway_retention_indexes");
+  assert.ok(migration);
+  assert.match(migration.sql, /standalone_gateway_sessions_retention_idx/);
+  assert.match(migration.sql, /WHERE status IN \('idle', 'failed', 'completed'\)/);
+  assert.match(migration.sql, /standalone_gateway_jobs_retention_idx/);
+  assert.match(migration.sql, /standalone_gateway_jobs_active_session_idx/);
+  assert.match(migration.sql, /standalone_gateway_artifacts_retention_idx/);
+  assert.match(migration.sql, /standalone_gateway_artifacts_session_retention_idx/);
 });
 
 test("standalone identity migration drops legacy provider-user uniqueness by catalog lookup", () => {

--- a/apps/standalone-gateway/src/repository.ts
+++ b/apps/standalone-gateway/src/repository.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { standaloneRetentionCutoffs } from "./retention.js";
 import { redactSecretRecord, redactSecretText } from "./redaction.js";
 import type {
   StandaloneGatewayAuditRecord,
@@ -13,6 +14,7 @@ import type {
   StandaloneGatewayIdentityAuthorizationSummary,
   StandaloneGatewayIdentityRole,
   StandaloneGatewayIdentityStatus,
+  StandaloneGatewayRetentionResult,
   StandaloneGatewaySessionRecord,
   StandalonePromptInput,
 } from "./types.js";
@@ -43,6 +45,13 @@ export interface StandaloneGatewayRepository {
   listSessions(limit?: number): Promise<StandaloneGatewaySessionRecord[]>;
   dashboardSnapshot(limit?: number): Promise<StandaloneGatewayDashboardSnapshot>;
   recordAudit(action: string, actor: string, metadata?: Record<string, unknown>, now?: Date): Promise<StandaloneGatewayAuditRecord>;
+  pruneRetention(input: {
+    retention: { sessionDays: number; artifactDays: number; auditDays: number; jobDays: number };
+    leaseId: string;
+    ownerId: string;
+    leaseToken: string;
+    now?: Date;
+  }): Promise<StandaloneGatewayRetentionResult | null>;
   close?(): Promise<void>;
 }
 
@@ -104,8 +113,12 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
       session.externalChatId === input.target.chatId &&
       session.externalThreadId === externalThreadId
     );
-    if (existing) return { ...existing };
     const now = (input.now || new Date()).toISOString();
+    if (existing) {
+      const touched = { ...existing, updatedAt: now };
+      this.sessions.set(touched.sessionId, touched);
+      return { ...touched };
+    }
     const session: StandaloneGatewaySessionRecord = {
       sessionId: randomUUID(),
       opencodeSessionId: null,
@@ -287,10 +300,71 @@ export class InMemoryStandaloneGatewayRepository implements StandaloneGatewayRep
     return { ...audit, metadata: { ...audit.metadata } };
   }
 
+  async pruneRetention(input: {
+    retention: { sessionDays: number; artifactDays: number; auditDays: number; jobDays: number };
+    leaseId: string;
+    ownerId: string;
+    leaseToken: string;
+    now?: Date;
+  }): Promise<StandaloneGatewayRetentionResult | null> {
+    const now = input.now || new Date();
+    const lease = this.leases.get(input.leaseId);
+    if (
+      !lease ||
+      lease.ownerId !== input.ownerId ||
+      lease.leaseToken !== input.leaseToken ||
+      new Date(lease.expiresAt).getTime() <= now.getTime()
+    ) {
+      return null;
+    }
+    const cutoffs = standaloneRetentionCutoffs(input.retention, now);
+    let sessionsDeleted = 0;
+    for (const session of [...this.sessions.values()]) {
+      if (
+        new Date(session.updatedAt).getTime() < cutoffs.sessionCutoff.getTime() &&
+        isRetainableSessionStatus(session.status) &&
+        !this.hasActiveJobForSession(session.sessionId)
+      ) {
+        this.sessions.delete(session.sessionId);
+        this.events.delete(session.sessionId);
+        sessionsDeleted += 1;
+      }
+    }
+    let jobsDeleted = 0;
+    for (const job of [...this.jobs.values()]) {
+      if (
+        new Date(job.updatedAt).getTime() < cutoffs.jobCutoff.getTime() &&
+        isTerminalJobStatus(job.status)
+      ) {
+        this.jobs.delete(job.jobId);
+        jobsDeleted += 1;
+      }
+    }
+    let auditEventsDeleted = 0;
+    for (let index = this.audits.length - 1; index >= 0; index -= 1) {
+      if (new Date(this.audits[index]!.createdAt).getTime() < cutoffs.auditCutoff.getTime()) {
+        this.audits.splice(index, 1);
+        auditEventsDeleted += 1;
+      }
+    }
+    const result = retentionResult(now, cutoffs, {
+      sessionsDeleted,
+      artifactsDeleted: 0,
+      auditEventsDeleted,
+      jobsDeleted,
+    });
+    await this.recordAudit("standalone.retention.pruned", input.ownerId, retentionAuditMetadata(result), now);
+    return result;
+  }
+
   private requireSession(sessionId: string): StandaloneGatewaySessionRecord {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Unknown standalone gateway session ${sessionId}.`);
     return session;
+  }
+
+  private hasActiveJobForSession(sessionId: string): boolean {
+    return [...this.jobs.values()].some((job) => job.sessionId === sessionId && !isTerminalJobStatus(job.status));
   }
 }
 
@@ -331,4 +405,50 @@ function identityKey(provider: string, providerWorkspaceId: string | null, exter
 
 function cloneIdentity(identity: StandaloneGatewayChannelIdentityRecord): StandaloneGatewayChannelIdentityRecord {
   return { ...identity };
+}
+
+export function retentionResult(
+  now: Date,
+  cutoffs: {
+    sessionCutoff: Date;
+    artifactCutoff: Date;
+    auditCutoff: Date;
+    jobCutoff: Date;
+  },
+  counts: {
+    sessionsDeleted: number;
+    artifactsDeleted: number;
+    auditEventsDeleted: number;
+    jobsDeleted: number;
+  },
+): StandaloneGatewayRetentionResult {
+  return {
+    ranAt: now.toISOString(),
+    sessionCutoff: cutoffs.sessionCutoff.toISOString(),
+    artifactCutoff: cutoffs.artifactCutoff.toISOString(),
+    auditCutoff: cutoffs.auditCutoff.toISOString(),
+    jobCutoff: cutoffs.jobCutoff.toISOString(),
+    ...counts,
+  };
+}
+
+export function retentionAuditMetadata(result: StandaloneGatewayRetentionResult): Record<string, unknown> {
+  return {
+    sessionCutoff: result.sessionCutoff,
+    artifactCutoff: result.artifactCutoff,
+    auditCutoff: result.auditCutoff,
+    jobCutoff: result.jobCutoff,
+    sessionsDeleted: result.sessionsDeleted,
+    artifactsDeleted: result.artifactsDeleted,
+    auditEventsDeleted: result.auditEventsDeleted,
+    jobsDeleted: result.jobsDeleted,
+  };
+}
+
+function isRetainableSessionStatus(status: StandaloneGatewaySessionRecord["status"]): boolean {
+  return status === "idle" || status === "failed" || status === "completed";
+}
+
+function isTerminalJobStatus(status: StandaloneGatewayJobRecord["status"]): boolean {
+  return status === "completed" || status === "failed" || status === "dead";
 }

--- a/apps/standalone-gateway/src/retention.ts
+++ b/apps/standalone-gateway/src/retention.ts
@@ -1,9 +1,55 @@
-import type { StandaloneGatewayConfig } from "./types.js";
+import type { StandaloneGatewayRepository } from "./repository.js";
+import type { StandaloneGatewayConfig, StandaloneGatewayRetentionResult } from "./types.js";
+
+export interface StandaloneGatewayRetentionCutoffs {
+  sessionCutoff: Date;
+  artifactCutoff: Date;
+  auditCutoff: Date;
+  jobCutoff: Date;
+}
+
+export interface StandaloneGatewayRetentionLease {
+  leaseId: string;
+  ownerId: string;
+  leaseToken: string;
+}
 
 export function describeStandaloneRetention(config: StandaloneGatewayConfig): string[] {
   return [
     `sessions:${config.retention.sessionDays}d`,
     `artifacts:${config.retention.artifactDays}d`,
     `audit:${config.retention.auditDays}d`,
+    `jobs:${config.retention.jobDays}d`,
   ];
+}
+
+export function standaloneRetentionCutoffs(
+  retention: StandaloneGatewayConfig["retention"],
+  now = new Date(),
+): StandaloneGatewayRetentionCutoffs {
+  return {
+    sessionCutoff: subtractDays(now, retention.sessionDays),
+    artifactCutoff: subtractDays(now, retention.artifactDays),
+    auditCutoff: subtractDays(now, retention.auditDays),
+    jobCutoff: subtractDays(now, retention.jobDays),
+  };
+}
+
+export async function runStandaloneGatewayRetention(input: {
+  repository: Pick<StandaloneGatewayRepository, "pruneRetention">;
+  config: StandaloneGatewayConfig;
+  lease: StandaloneGatewayRetentionLease;
+  now?: Date;
+}): Promise<StandaloneGatewayRetentionResult | null> {
+  return input.repository.pruneRetention({
+    retention: input.config.retention,
+    leaseId: input.lease.leaseId,
+    ownerId: input.lease.ownerId,
+    leaseToken: input.lease.leaseToken,
+    now: input.now,
+  });
+}
+
+function subtractDays(now: Date, days: number): Date {
+  return new Date(now.getTime() - Math.max(1, Math.floor(days)) * 24 * 60 * 60 * 1000);
 }

--- a/apps/standalone-gateway/src/schema.ts
+++ b/apps/standalone-gateway/src/schema.ts
@@ -1,4 +1,4 @@
-export const STANDALONE_GATEWAY_SCHEMA_VERSION = 2;
+export const STANDALONE_GATEWAY_SCHEMA_VERSION = 3;
 
 export const standaloneGatewayMigrations = [{
   id: "0001_standalone_gateway_core",
@@ -187,8 +187,29 @@ BEGIN
 EXCEPTION WHEN duplicate_object THEN
   NULL;
 END $$;
-`,
-}];
+  `,
+  }, {
+    id: "0003_standalone_gateway_retention_indexes",
+    sql: `
+CREATE INDEX IF NOT EXISTS standalone_gateway_sessions_retention_idx
+  ON standalone_gateway_sessions (updated_at)
+  WHERE status IN ('idle', 'failed', 'completed');
+
+CREATE INDEX IF NOT EXISTS standalone_gateway_jobs_retention_idx
+  ON standalone_gateway_jobs (updated_at)
+  WHERE status IN ('completed', 'failed', 'dead');
+
+CREATE INDEX IF NOT EXISTS standalone_gateway_jobs_active_session_idx
+  ON standalone_gateway_jobs (session_id, status)
+  WHERE status IN ('pending', 'claimed', 'running');
+
+CREATE INDEX IF NOT EXISTS standalone_gateway_artifacts_retention_idx
+  ON standalone_gateway_artifacts (created_at);
+
+CREATE INDEX IF NOT EXISTS standalone_gateway_artifacts_session_retention_idx
+  ON standalone_gateway_artifacts (session_id, created_at);
+  `,
+  }];
 
 export function standaloneGatewaySchemaContainsProductionTables(sql = standaloneGatewayMigrations.map((migration) => migration.sql).join("\n")): boolean {
   return [

--- a/apps/standalone-gateway/src/types.ts
+++ b/apps/standalone-gateway/src/types.ts
@@ -48,6 +48,10 @@ export interface StandaloneGatewayConfig {
   database: {
     url: string;
     ssl: boolean;
+    sslRejectUnauthorized: boolean;
+    sslCaPath: string | null;
+    sslCertPath: string | null;
+    sslKeyPath: string | null;
   };
   opencode: {
     baseUrl: string;
@@ -58,6 +62,7 @@ export interface StandaloneGatewayConfig {
     sessionDays: number;
     artifactDays: number;
     auditDays: number;
+    jobDays: number;
   };
   providers: StandaloneGatewayProviderConfig[];
 }
@@ -143,6 +148,18 @@ export interface StandaloneGatewayDashboardSnapshot {
   identities: StandaloneGatewayChannelIdentityRecord[];
   jobs: StandaloneGatewayJobRecord[];
   audits: StandaloneGatewayAuditRecord[];
+}
+
+export interface StandaloneGatewayRetentionResult {
+  ranAt: string;
+  sessionCutoff: string;
+  artifactCutoff: string;
+  auditCutoff: string;
+  jobCutoff: string;
+  sessionsDeleted: number;
+  artifactsDeleted: number;
+  auditEventsDeleted: number;
+  jobsDeleted: number;
 }
 
 export interface StandalonePromptInput {

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -329,6 +329,9 @@ provider control plane.
 ### Backups/Restore
 
 - Back up Postgres and object storage on the same retention policy.
+- For Standalone Gateway team and enterprise deployments, run Postgres with
+  verified TLS and enable the lease-gated retention daemon for sessions,
+  artifacts, audit events, and completed/dead jobs.
 - Restore Postgres first, then object-store artifacts/checkpoints for the same
   point in time.
 - Start web with workers at zero, verify projections and session lists, start

--- a/docs/standalone-gateway.md
+++ b/docs/standalone-gateway.md
@@ -51,6 +51,8 @@ Required environment:
 
 ```bash
 OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_URL=postgres://...
+OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL=true
+OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_REJECT_UNAUTHORIZED=true
 OPEN_COWORK_STANDALONE_GATEWAY_ADMIN_TOKEN=...
 OPEN_COWORK_STANDALONE_GATEWAY_OPENCODE_URL=http://127.0.0.1:4096
 OPEN_COWORK_STANDALONE_GATEWAY_TELEGRAM_BOT_TOKEN=...
@@ -70,6 +72,28 @@ The setup helper writes env files with mode `0600`, refuses public OpenCode
 URLs, and does not echo provided secrets to stdout when `--output` is used. Use
 `--print` only for placeholder examples unless you explicitly pass
 `--allow-secret-print` in a controlled terminal.
+
+### Postgres TLS
+
+Solo/local deployments may run against a local Postgres listener without TLS.
+Team and enterprise deployments must enable verified Postgres TLS:
+
+```bash
+OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL=true
+OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_REJECT_UNAUTHORIZED=true
+OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_CA_PATH=/run/secrets/postgres-ca.pem
+```
+
+Client certificates are optional and are passed directly to the Postgres pool
+when configured:
+
+```bash
+OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_CERT_PATH=/run/secrets/postgres-client.pem
+OPEN_COWORK_STANDALONE_GATEWAY_DATABASE_SSL_KEY_PATH=/run/secrets/postgres-client-key.pem
+```
+
+The doctor report exposes only booleans for TLS state and certificate presence.
+It does not print certificate file contents or connection string secrets.
 
 ## Run
 
@@ -174,6 +198,21 @@ Retention windows are explicit:
 - `OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_SESSION_DAYS`
 - `OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_ARTIFACT_DAYS`
 - `OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_AUDIT_DAYS`
+- `OPEN_COWORK_STANDALONE_GATEWAY_RETENTION_JOB_DAYS`
+
+The serving daemon runs retention under the active daemon lease. A standby
+process that cannot hold the lease cannot prune data. Retention deletes:
+
+- idle, failed, or completed sessions older than the session window, including
+  their event rows
+- artifact metadata older than the artifact window
+- audit events older than the audit window
+- completed, failed, or dead jobs older than the job window
+
+Retention preserves running sessions, blocked sessions, and any session with a
+pending, claimed, or running job. Each successful retention pass writes a
+`standalone.retention.pruned` audit event with cutoff times and deletion
+counts.
 
 Run a restore drill before public or enterprise rollout.
 


### PR DESCRIPTION
## Summary

Closes #764.

Hardens the Standalone Gateway data plane by making Postgres TLS and retention enforcement real production paths instead of documented/config-only behavior.

## Changes

- Pass the typed database config into the Standalone Gateway Postgres repository and build explicit `pg.Pool` SSL options.
- Add CA/client cert/client key support and preserve existing URL-based SSL behavior unless explicit env-owned SSL is enabled.
- Enforce verified Postgres TLS before `serve` and `identity` in team/enterprise mode.
- Make `doctor` report production TLS failures without connecting to Postgres or running migrations first.
- Add lease-gated retention pruning for sessions/events, artifact metadata, audit rows, and completed/dead jobs.
- Preserve active/running sessions, sessions with active jobs, and sessions with unexpired artifact metadata.
- Add retention indexes for scalable prune queries.
- Document Postgres TLS and lease-gated retention operations.

## Validation

- `pnpm --filter @open-cowork/standalone-gateway test`
- `pnpm typecheck:standalone-gateway`
- `pnpm exec eslint apps/standalone-gateway/src/config.ts apps/standalone-gateway/src/config.test.ts apps/standalone-gateway/src/doctor.test.ts apps/standalone-gateway/src/main.ts apps/standalone-gateway/src/postgres-repository.ts apps/standalone-gateway/src/repository.ts apps/standalone-gateway/src/repository.test.ts --max-warnings 0`
- `pnpm deploy:standalone-gateway:validate`
- `pnpm docs:build`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/master` clean

## Notes

The local worktree still has unrelated desktop packaging/prototype changes that are not part of this branch or PR.