### PR TITLE
Harden gateway operator observability

### DIFF
--- a/apps/desktop/src/main/cloud/channel-provider-types.ts
+++ b/apps/desktop/src/main/cloud/channel-provider-types.ts
@@ -34,6 +34,7 @@ export type ClaimChannelProviderEventInput = {
   orgId: string
   provider: ChannelProviderId
   providerInstanceId: string
+  channelBindingId?: string | null
   externalWorkspaceId?: string | null
   providerEventId: string
   eventType: ChannelProviderEventType
@@ -46,6 +47,7 @@ export type ClaimChannelProviderEventInput = {
 export type CompleteChannelProviderEventInput = {
   orgId: string
   eventId: string
+  channelBindingIds?: readonly string[] | null
   claimedBy: string
   status: Extract<ChannelProviderEventStatus, 'processed' | 'failed'>
   retryable?: boolean

--- a/apps/desktop/src/main/cloud/control-plane-domains/channels.ts
+++ b/apps/desktop/src/main/cloud/control-plane-domains/channels.ts
@@ -25,6 +25,7 @@ export type ChannelControlPlaneStore = Pick<ControlPlaneStore,
   | 'listChannelDeliveries'
   | 'claimNextChannelDelivery'
   | 'ackChannelDelivery'
+  | 'listApiTokenChannelBindingGrants'
   | 'claimChannelProviderEvent'
   | 'completeChannelProviderEvent'
   | 'getSession'

--- a/apps/desktop/src/main/cloud/http-routes/api-tokens.ts
+++ b/apps/desktop/src/main/cloud/http-routes/api-tokens.ts
@@ -20,12 +20,30 @@ export async function handleApiTokensApiRoute(input: CloudApiRouteInput): Promis
       tools.writeError(res, 400, 'API token requires a name and at least one valid scope.', options.corsOrigin)
       return true
     }
+    const channelBindingIds = readOptionalStringArray(body.channelBindingIds)
+    if (channelBindingIds === false) {
+      tools.writeError(res, 400, 'Channel binding grants must be an array of strings.', options.corsOrigin)
+      return true
+    }
     const issued = await options.service.issueApiToken(context.principal, {
       name,
       scopes,
       expiresAt: tools.readOptionalDate(body.expiresAt),
+      channelBindingIds,
     })
     tools.writeJson(res, 201, issued, options.corsOrigin)
+    return true
+  }
+
+  if (itemId && action === 'channel-bindings' && req.method === 'POST') {
+    const body = await tools.readJsonBody(req, options.maxBodyBytes || 1024 * 1024)
+    const channelBindingId = tools.readString(body.channelBindingId)
+    if (!channelBindingId) {
+      tools.writeError(res, 400, 'Channel binding id is required.', options.corsOrigin)
+      return true
+    }
+    const result = await options.service.grantApiTokenChannelBinding(context.principal, itemId, { channelBindingId })
+    tools.writeJson(res, 200, result, options.corsOrigin)
     return true
   }
 
@@ -41,4 +59,10 @@ export async function handleApiTokensApiRoute(input: CloudApiRouteInput): Promis
 
   tools.writeError(res, 404, 'Not found.', options.corsOrigin)
   return true
+}
+
+function readOptionalStringArray(value: unknown): string[] | null | false {
+  if (value === undefined || value === null) return null
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) return false
+  return [...new Set(value.map((entry) => entry.trim()).filter(Boolean))]
 }

--- a/apps/desktop/src/main/cloud/http-routes/channel-delivery-sse.ts
+++ b/apps/desktop/src/main/cloud/http-routes/channel-delivery-sse.ts
@@ -1,0 +1,99 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { principalHasGatewayAccess } from './access-policy.ts'
+import type { CloudHttpServerOptions } from '../http-server.ts'
+import { CloudServiceError, type CloudPrincipal } from '../session-service.ts'
+
+type RouteContext = {
+  principal: CloudPrincipal
+  url: URL
+}
+
+export type ChannelDeliverySseTools = {
+  writeCorsHeaders(res: ServerResponse, origin: string | null | undefined): void
+  writeError(res: ServerResponse, status: number, message: string, origin?: string | null): void
+  trackSseStream(
+    req: IncomingMessage,
+    res: ServerResponse,
+    options: CloudHttpServerOptions,
+    cleanup: () => void,
+  ): boolean
+  ssePollMs(options: CloudHttpServerOptions): number
+}
+
+const CHANNEL_DELIVERY_SSE_EVENT_TYPE = 'channel.delivery'
+
+function deliverySseId(delivery: unknown) {
+  if (!delivery || typeof delivery !== 'object' || Array.isArray(delivery)) return 'delivery'
+  const deliveryId = (delivery as { deliveryId?: unknown }).deliveryId
+  return typeof deliveryId === 'string' && deliveryId.trim() ? deliveryId : 'delivery'
+}
+
+function writeChannelDeliverySseEvent(res: ServerResponse, delivery: unknown) {
+  res.write(`id: ${deliverySseId(delivery)}\n`)
+  res.write(`event: ${CHANNEL_DELIVERY_SSE_EVENT_TYPE}\n`)
+  res.write(`data: ${JSON.stringify({ delivery })}\n\n`)
+}
+
+export async function handleChannelDeliveriesSse(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: CloudHttpServerOptions,
+  context: RouteContext,
+  tools: ChannelDeliverySseTools,
+) {
+  if (!principalHasGatewayAccess(context.principal)) {
+    tools.writeError(res, 403, 'Gateway channel access requires a gateway-scoped API token.', options.corsOrigin)
+    return
+  }
+  tools.writeCorsHeaders(res, options.corsOrigin)
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-store',
+    connection: 'keep-alive',
+  })
+  const requestedClaimedBy = context.url.searchParams.get('claimedBy')
+    || (context.principal.authSource === 'api_token' && context.principal.tokenId ? context.principal.tokenId : null)
+    || context.principal.userId
+    || 'gateway'
+  const channelBindingIds = context.url.searchParams.getAll('channelBindingId')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  const ttlMsRaw = Number(context.url.searchParams.get('ttlMs') || 30_000)
+  const ttlMs = Number.isInteger(ttlMsRaw) && ttlMsRaw > 0 ? ttlMsRaw : 30_000
+  let closed = false
+  let pollActive = false
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+  const cleanup = () => {
+    if (closed) return
+    closed = true
+    if (pollTimer) clearInterval(pollTimer)
+  }
+  if (!tools.trackSseStream(req, res, options, cleanup)) return
+  const poll = async () => {
+    if (pollActive || closed || res.destroyed) return
+    pollActive = true
+    try {
+      const requestedChannelBindingIds = channelBindingIds.length > 0 ? channelBindingIds : null
+      let claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy: requestedClaimedBy, ttlMs, channelBindingIds: requestedChannelBindingIds })
+      while (claimed && !closed && !res.destroyed) {
+        writeChannelDeliverySseEvent(res, claimed)
+        claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy: requestedClaimedBy, ttlMs, channelBindingIds: requestedChannelBindingIds })
+      }
+      if (!closed && !res.destroyed) res.write(': keep-alive\n\n')
+    } catch (error) {
+      if (!closed && !res.destroyed) {
+        const message = error instanceof CloudServiceError
+          ? error.publicMessage
+          : 'Channel delivery stream failed.'
+        res.write(`event: error\ndata: ${JSON.stringify({ error: message })}\n\n`)
+      }
+    } finally {
+      pollActive = false
+    }
+  }
+  await poll()
+  if (closed) return
+  pollTimer = setInterval(() => {
+    void poll()
+  }, tools.ssePollMs(options))
+}

--- a/apps/desktop/src/main/cloud/http-routes/channels.ts
+++ b/apps/desktop/src/main/cloud/http-routes/channels.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { handleChannelDeliveriesSse, type ChannelDeliverySseTools } from './channel-delivery-sse.ts'
 import type { ChannelProviderId, SessionCommandRecord } from '../control-plane-store.ts'
 import type { CloudHttpServerOptions } from '../http-server.ts'
 import type { CloudPrincipal } from '../session-service.ts'
@@ -8,7 +9,7 @@ type RouteContext = {
   url: URL
 }
 
-export type ChannelRouteTools = {
+export type ChannelRouteTools = ChannelDeliverySseTools & {
   readJsonBody(req: IncomingMessage, maxBodyBytes: number): Promise<Record<string, unknown>>
   readString(value: unknown): string | null
   readRecord(value: unknown): Record<string, unknown> | null
@@ -29,12 +30,6 @@ export type ChannelRouteTools = {
     processed: number,
     beforeProjectionSequence: number,
     extraBody?: Record<string, unknown>,
-  ): Promise<void>
-  handleChannelDeliveriesSse(
-    req: IncomingMessage,
-    res: ServerResponse,
-    options: CloudHttpServerOptions,
-    context: RouteContext,
   ): Promise<void>
 }
 
@@ -161,7 +156,8 @@ export async function handleChannelsApiRoute(input: {
     const identity = await options.service.resolveChannelIdentity(context.principal, {
       identityId: tools.readString(body.identityId),
       provider,
-      externalWorkspaceId: tools.readString(body.externalWorkspaceId),
+      channelBindingId: tools.readString(body.channelBindingId),
+      externalWorkspaceId: body.externalWorkspaceId === undefined ? undefined : tools.readString(body.externalWorkspaceId),
       externalUserId,
       accountId: tools.readString(body.accountId),
       role: tools.readEnum(body.role, ['owner', 'admin', 'member', 'approver', 'viewer'] as const),
@@ -357,7 +353,8 @@ export async function handleChannelsApiRoute(input: {
       const result = await options.service.claimChannelProviderEvent(context.principal, {
         provider,
         providerInstanceId,
-        externalWorkspaceId: tools.readString(body.externalWorkspaceId),
+        channelBindingId: tools.readString(body.channelBindingId),
+        externalWorkspaceId: body.externalWorkspaceId === undefined ? undefined : tools.readString(body.externalWorkspaceId),
         providerEventId,
         eventType,
         claimedBy,
@@ -377,6 +374,7 @@ export async function handleChannelsApiRoute(input: {
       }
       const event = await options.service.completeChannelProviderEvent(context.principal, {
         eventId: itemId,
+        channelBindingId: tools.readString(body.channelBindingId),
         claimedBy,
         status,
         retryable: body.retryable === undefined ? undefined : body.retryable === true,
@@ -393,12 +391,13 @@ export async function handleChannelsApiRoute(input: {
 
   if (collection === 'deliveries') {
     if (itemId === 'stream' && !itemAction && req.method === 'GET') {
-      await tools.handleChannelDeliveriesSse(req, res, options, context)
+      await handleChannelDeliveriesSse(req, res, options, context, tools)
       return true
     }
     if (!itemId && req.method === 'GET') {
       const status = tools.readEnum(context.url.searchParams.get('status'), ['pending', 'claimed', 'sent', 'failed', 'dead'] as const)
       const deliveries = await options.service.listChannelDeliveries(context.principal, {
+        deliveryId: tools.readString(context.url.searchParams.get('deliveryId')),
         status,
         channelBindingId: tools.readString(context.url.searchParams.get('channelBindingId')),
         limit: tools.readNonNegativeInteger(context.url.searchParams.get('limit'), 50),

--- a/apps/desktop/src/main/cloud/http-server.ts
+++ b/apps/desktop/src/main/cloud/http-server.ts
@@ -20,7 +20,6 @@ import type { CloudArtifactService } from './artifact-service.ts'
 import { cloudBrowserAppHtml } from './browser-app.ts'
 import {
   principalHasDesktopApiAccess,
-  principalHasGatewayAccess,
   routeAllowsGatewayOnlyToken,
   routeAllowsOperationalToken,
   routeAllowsWorkerCredential,
@@ -146,8 +145,6 @@ type RouteContext = {
   url: URL
   segments: string[]
 }
-
-const CHANNEL_DELIVERY_SSE_EVENT_TYPE = 'channel.delivery' satisfies CloudSessionEventType
 
 const DEFAULT_PRINCIPAL: CloudPrincipal = {
   tenantId: 'default',
@@ -514,14 +511,6 @@ function writeSseEvent(res: ServerResponse, event: {
   res.write(`id: ${event.sequence}\n`)
   res.write(`event: ${event.type}\n`)
   res.write(`data: ${JSON.stringify(event)}\n\n`)
-}
-
-function writeChannelDeliverySseEvent(res: ServerResponse, delivery: unknown) {
-  const record = readRecord(delivery) || {}
-  const deliveryId = readString(record.deliveryId) || 'delivery'
-  res.write(`id: ${deliveryId}\n`)
-  res.write(`event: ${CHANNEL_DELIVERY_SSE_EVENT_TYPE}\n`)
-  res.write(`data: ${JSON.stringify({ delivery })}\n\n`)
 }
 
 function publicChannelInteraction(value: unknown) {
@@ -976,62 +965,6 @@ async function handleWorkspaceSse(
   }, ssePollMs(options))
 }
 
-async function handleChannelDeliveriesSse(
-  req: IncomingMessage,
-  res: ServerResponse,
-  options: CloudHttpServerOptions,
-  context: RouteContext,
-) {
-  if (!principalHasGatewayAccess(context.principal)) {
-    writeError(res, 403, 'Gateway channel access requires a gateway-scoped API token.', options.corsOrigin)
-    return
-  }
-  writeCorsHeaders(res, options.corsOrigin)
-  res.writeHead(200, {
-    'content-type': 'text/event-stream',
-    'cache-control': 'no-store',
-    connection: 'keep-alive',
-  })
-  const claimedBy = context.url.searchParams.get('claimedBy') || context.principal.tokenId || context.principal.userId || 'gateway'
-  const ttlMsRaw = Number(context.url.searchParams.get('ttlMs') || 30_000)
-  const ttlMs = Number.isInteger(ttlMsRaw) && ttlMsRaw > 0 ? ttlMsRaw : 30_000
-  let closed = false
-  let pollActive = false
-  let pollTimer: ReturnType<typeof setInterval> | null = null
-  const cleanup = () => {
-    if (closed) return
-    closed = true
-    if (pollTimer) clearInterval(pollTimer)
-  }
-  if (!trackSseStream(req, res, options, cleanup)) return
-  const poll = async () => {
-    if (pollActive || closed || res.destroyed) return
-    pollActive = true
-    try {
-      let claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy, ttlMs })
-      while (claimed && !closed && !res.destroyed) {
-        writeChannelDeliverySseEvent(res, claimed)
-        claimed = await options.service.claimNextChannelDelivery(context.principal, { claimedBy, ttlMs })
-      }
-      if (!closed && !res.destroyed) res.write(': keep-alive\n\n')
-    } catch (error) {
-      if (!closed && !res.destroyed) {
-        const message = error instanceof CloudServiceError
-          ? error.publicMessage
-          : 'Channel delivery stream failed.'
-        res.write(`event: error\ndata: ${JSON.stringify({ error: message })}\n\n`)
-      }
-    } finally {
-      pollActive = false
-    }
-  }
-  await poll()
-  if (closed) return
-  pollTimer = setInterval(() => {
-    void poll()
-  }, ssePollMs(options))
-}
-
 async function handleApiRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -1245,9 +1178,11 @@ async function handleApiRequest(
         publicChannelInteraction,
         writeJson,
         writeError,
+        writeCorsHeaders,
+        trackSseStream,
+        ssePollMs,
         processSessionCommandIfConfigured,
         writeSessionCommandMutationResponse,
-        handleChannelDeliveriesSse,
       },
     })
     if (!handled) writeError(res, 404, 'Not found.', options.corsOrigin)

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -29,6 +29,7 @@ import type {
 import { InMemoryManagedWorkersDomain } from './in-memory-domains/workers.ts'
 import { InMemoryQuotaDomain } from './in-memory-domains/quotas.ts'
 import { InMemoryChannelProviderEventsDomain } from './in-memory-domains/channel-provider-events.ts'
+import { InMemoryChannelDeliveriesDomain } from './in-memory-domains/channel-deliveries.ts'
 import { redactAuditMetadata } from './audit-redaction.ts'
 import {
   generateChannelInteractionToken,
@@ -246,6 +247,13 @@ export type ApiTokenRecord = {
   updatedAt: string
 }
 
+export type ApiTokenChannelBindingGrantRecord = {
+  orgId: string
+  tokenId: string
+  channelBindingId: string
+  createdAt: string
+}
+
 export type IssuedApiTokenRecord = {
   token: ApiTokenRecord
   plaintext: string
@@ -376,6 +384,7 @@ export type ChannelDeliveryRecord = {
   status: ChannelDeliveryStatus
   attemptCount: number
   claimedBy: string | null
+  lastClaimedBy: string | null
   claimExpiresAt: string | null
   nextAttemptAt: string
   lastError: string | null
@@ -726,6 +735,19 @@ export type RevokeApiTokenInput = {
   actor?: AuditActorInput
 }
 
+export type GrantApiTokenChannelBindingInput = {
+  orgId: string
+  tokenId: string
+  channelBindingId: string
+  createdAt?: Date
+  actor?: AuditActorInput
+}
+
+export type ListApiTokenChannelBindingGrantsInput = {
+  orgId: string
+  tokenId: string
+}
+
 export type RecordAuditEventInput = {
   eventId?: string
   orgId: string
@@ -914,6 +936,8 @@ export type CreateChannelDeliveryInput = {
 export type ClaimChannelDeliveryInput = {
   orgId: string
   claimedBy: string
+  lastClaimedBy?: string | null
+  channelBindingIds?: readonly string[] | null
   now?: Date
   ttlMs?: number
   quota?: Omit<ConsumeUsageQuotaInput, 'orgId'> | null
@@ -922,7 +946,9 @@ export type ClaimChannelDeliveryInput = {
 export type AckChannelDeliveryInput = {
   orgId: string
   deliveryId: string
+  channelBindingIds?: readonly string[] | null
   claimedBy?: string | null
+  lastClaimedBy?: string | null
   status: Extract<ChannelDeliveryStatus, 'sent' | 'failed' | 'dead'>
   lastError?: string | null
   nextAttemptAt?: Date | null
@@ -931,8 +957,11 @@ export type AckChannelDeliveryInput = {
 
 export type ListChannelDeliveriesInput = {
   orgId: string
+  deliveryId?: string | null
   status?: ChannelDeliveryStatus | null
   channelBindingId?: string | null
+  channelBindingIds?: readonly string[] | null
+  lastClaimedBy?: string | null
   limit?: number | null
 }
 
@@ -1130,6 +1159,8 @@ export type ControlPlaneStore = {
   listApiTokens(orgId: string): MaybePromise<ApiTokenRecord[]>
   findApiTokenByPlaintext(plaintext: string, now?: Date): MaybePromise<ApiTokenRecord | null>
   revokeApiToken(input: RevokeApiTokenInput): MaybePromise<ApiTokenRecord | null>
+  grantApiTokenChannelBinding(input: GrantApiTokenChannelBindingInput): MaybePromise<ApiTokenChannelBindingGrantRecord>
+  listApiTokenChannelBindingGrants(input: ListApiTokenChannelBindingGrantsInput): MaybePromise<ApiTokenChannelBindingGrantRecord[]>
   createManagedWorkerPool(input: CreateManagedWorkerPoolInput): MaybePromise<ManagedWorkerPoolRecord>
   updateManagedWorkerPool(input: UpdateManagedWorkerPoolInput): MaybePromise<ManagedWorkerPoolRecord | null>
   getManagedWorkerPool(orgId: string, poolId: string): MaybePromise<ManagedWorkerPoolRecord | null>
@@ -1324,7 +1355,6 @@ const SMART_FILTER_QUERY_MAX_BYTES = 16_384
 const WORKFLOW_RUN_LIST_LIMIT = 100
 const CHANNEL_TEXT_MAX_LENGTH = 256
 const CHANNEL_METADATA_MAX_BYTES = 16_384
-const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
 const BYOK_PROVIDER_ID_MAX_LENGTH = 64
 const BYOK_SECRET_TEXT_MAX_LENGTH = 4096
 const BILLING_TEXT_MAX_LENGTH = 256
@@ -1504,6 +1534,7 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly accountsByEmail = new Map<string, string>()
   private readonly memberships = new Map<string, MembershipRecord>()
   private readonly apiTokens = new Map<string, ApiTokenRecord>()
+  private readonly apiTokenChannelBindingGrants = new Map<string, ApiTokenChannelBindingGrantRecord>()
   private readonly auditEvents = new Map<string, AuditEventRecord>()
   private readonly usageEvents = new Map<string, UsageEventRecord>()
   private readonly billingSubscriptions = new Map<string, BillingSubscriptionRecord>()
@@ -1523,7 +1554,6 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   private readonly channelInteractions = new Map<string, ChannelInteractionRecord>()
   private readonly channelInteractionsByTokenHash = new Map<string, string>()
   private readonly channelInteractionsByExternal = new Map<string, string>()
-  private readonly channelDeliveries = new Map<string, ChannelDeliveryRecord>()
   private readonly sessions = new Map<string, SessionState>()
   private readonly heartbeats = new Map<string, WorkerHeartbeatRecord>()
   private readonly settings = new Map<string, SettingMetadataRecord>()
@@ -1546,6 +1576,22 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   })
   private readonly channelProviderEventsDomain = new InMemoryChannelProviderEventsDomain({
     orgExists: (orgId) => this.orgs.has(orgId),
+  })
+  private readonly channelDeliveriesDomain = new InMemoryChannelDeliveriesDomain({
+    orgExists: (orgId) => this.orgs.has(orgId),
+    getHeadlessAgent: (orgId, agentId) => {
+      const agent = this.headlessAgents.get(agentId)
+      return agent?.orgId === orgId ? agent : null
+    },
+    getChannelBinding: (orgId, bindingId) => {
+      const binding = this.channelBindings.get(bindingId)
+      return binding?.orgId === orgId ? binding : null
+    },
+    getChannelSessionBinding: (orgId, bindingId) => {
+      const binding = this.channelSessionBindings.get(bindingId)
+      return binding?.orgId === orgId ? binding : null
+    },
+    consumeUsageQuota: (input) => this.consumeUsageQuota(input),
   })
 
   private orgIdForTenant(tenantId: string) {
@@ -1825,6 +1871,42 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
       createdAt: input.revokedAt,
     })
     return clone(existing)
+  }
+
+  grantApiTokenChannelBinding(input: GrantApiTokenChannelBindingInput): ApiTokenChannelBindingGrantRecord {
+    const token = this.apiTokens.get(input.tokenId)
+    if (!token || token.orgId !== input.orgId) throw new Error(`Unknown API token ${input.tokenId}.`)
+    const binding = this.channelBindings.get(input.channelBindingId)
+    if (!binding || binding.orgId !== input.orgId) throw new Error(`Unknown channel binding ${input.channelBindingId}.`)
+    const grantKey = key(input.orgId, input.tokenId, input.channelBindingId)
+    const existing = this.apiTokenChannelBindingGrants.get(grantKey)
+    if (existing) return clone(existing)
+    const record: ApiTokenChannelBindingGrantRecord = {
+      orgId: input.orgId,
+      tokenId: input.tokenId,
+      channelBindingId: input.channelBindingId,
+      createdAt: nowIso(input.createdAt),
+    }
+    this.apiTokenChannelBindingGrants.set(grantKey, record)
+    this.recordAuditEvent({
+      orgId: input.orgId,
+      accountId: input.actor?.accountId || token.accountId,
+      actorType: input.actor?.actorType || 'system',
+      actorId: input.actor?.actorId || null,
+      eventType: 'api_token.channel_binding_granted',
+      targetType: 'api_token',
+      targetId: input.tokenId,
+      metadata: { channelBindingId: input.channelBindingId },
+      createdAt: input.createdAt,
+    })
+    return clone(record)
+  }
+
+  listApiTokenChannelBindingGrants(input: ListApiTokenChannelBindingGrantsInput): ApiTokenChannelBindingGrantRecord[] {
+    return [...this.apiTokenChannelBindingGrants.values()]
+      .filter((grant) => grant.orgId === input.orgId && grant.tokenId === input.tokenId)
+      .sort((left, right) => left.channelBindingId.localeCompare(right.channelBindingId))
+      .map((grant) => clone(grant))
   }
 
   createManagedWorkerPool(input: CreateManagedWorkerPoolInput): ManagedWorkerPoolRecord {
@@ -2761,111 +2843,19 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
   }
 
   createChannelDelivery(input: CreateChannelDeliveryInput): ChannelDeliveryRecord {
-    if (!this.orgs.has(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
-    const agent = this.headlessAgents.get(input.agentId)
-    if (!agent || agent.orgId !== input.orgId) throw new Error(`Unknown headless agent ${input.agentId}.`)
-    const channelBinding = this.channelBindings.get(input.channelBindingId)
-    if (!channelBinding || channelBinding.orgId !== input.orgId) throw new Error(`Unknown channel binding ${input.channelBindingId}.`)
-    const provider = normalizeProvider(input.provider)
-    if (channelBinding.agentId !== agent.agentId) throw new Error('Channel delivery binding does not match headless agent.')
-    if (channelBinding.provider !== provider) throw new Error('Channel delivery provider does not match channel binding.')
-    if (input.sessionBindingId) {
-      const sessionBinding = this.channelSessionBindings.get(input.sessionBindingId)
-      if (!sessionBinding || sessionBinding.orgId !== input.orgId) throw new Error(`Unknown channel session binding ${input.sessionBindingId}.`)
-      if (
-        sessionBinding.agentId !== agent.agentId
-        || sessionBinding.channelBindingId !== channelBinding.bindingId
-        || sessionBinding.provider !== provider
-      ) {
-        throw new Error('Channel delivery session binding does not match channel binding.')
-      }
-    }
-    const existing = this.channelDeliveries.get(input.deliveryId)
-    if (existing) return clone(existing)
-    const now = nowIso(input.createdAt)
-    const record: ChannelDeliveryRecord = {
-      deliveryId: normalizeText(input.deliveryId, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery id'),
-      orgId: input.orgId,
-      agentId: normalizeText(input.agentId, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent id'),
-      channelBindingId: normalizeText(input.channelBindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding id'),
-      sessionBindingId: normalizeNullableText(input.sessionBindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel session binding id'),
-      provider,
-      target: normalizeRecord(input.target, 'Channel delivery target'),
-      eventType: normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery event type'),
-      payload: normalizeRecord(input.payload, 'Channel delivery payload'),
-      status: input.status || 'pending',
-      attemptCount: 0,
-      claimedBy: null,
-      claimExpiresAt: null,
-      nextAttemptAt: (input.nextAttemptAt || input.createdAt || new Date()).toISOString(),
-      lastError: null,
-      createdAt: now,
-      updatedAt: now,
-    }
-    this.channelDeliveries.set(record.deliveryId, record)
-    return clone(record)
+    return this.channelDeliveriesDomain.create(input)
   }
 
   listChannelDeliveries(input: ListChannelDeliveriesInput): ChannelDeliveryRecord[] {
-    const limit = Math.max(1, Math.min(200, input.limit || 50))
-    return Array.from(this.channelDeliveries.values())
-      .filter((delivery) => delivery.orgId === input.orgId)
-      .filter((delivery) => !input.status || delivery.status === input.status)
-      .filter((delivery) => !input.channelBindingId || delivery.channelBindingId === input.channelBindingId)
-      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || right.createdAt.localeCompare(left.createdAt))
-      .slice(0, limit)
-      .map(clone)
+    return this.channelDeliveriesDomain.list(input)
   }
 
   claimNextChannelDelivery(input: ClaimChannelDeliveryInput): ChannelDeliveryRecord | null {
-    const now = input.now || new Date()
-    const nowMs = now.getTime()
-    const candidate = Array.from(this.channelDeliveries.values())
-      .filter((delivery) => delivery.orgId === input.orgId)
-      .filter((delivery) => (
-        (delivery.status === 'pending' && new Date(delivery.nextAttemptAt).getTime() <= nowMs)
-        || (delivery.status === 'failed' && new Date(delivery.nextAttemptAt).getTime() <= nowMs)
-        || (delivery.status === 'claimed' && delivery.claimExpiresAt && new Date(delivery.claimExpiresAt).getTime() <= nowMs)
-      ))
-      .sort((left, right) => left.nextAttemptAt.localeCompare(right.nextAttemptAt) || left.createdAt.localeCompare(right.createdAt))[0]
-    if (!candidate) return null
-    if (input.quota) {
-      const quota = this.consumeUsageQuota({
-        ...input.quota,
-        orgId: input.orgId,
-        now,
-      })
-      if (!quota.allowed) {
-        quotaExceeded({
-          message: 'Gateway delivery quota exceeded.',
-          policyCode: quota.policyCode || 'quota.gateway_deliveries_per_hour_exceeded',
-          retryAfterMs: quota.retryAfterMs,
-          limit: quota.limit,
-          used: quota.used,
-          resetAt: quota.resetAt,
-        })
-      }
-    }
-    candidate.status = 'claimed'
-    candidate.claimedBy = normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery claimant')
-    candidate.claimExpiresAt = new Date(nowMs + (input.ttlMs || 30_000)).toISOString()
-    candidate.attemptCount += 1
-    candidate.updatedAt = now.toISOString()
-    return clone(candidate)
+    return this.channelDeliveriesDomain.claimNext(input)
   }
 
   ackChannelDelivery(input: AckChannelDeliveryInput): ChannelDeliveryRecord | null {
-    const delivery = this.channelDeliveries.get(input.deliveryId)
-    if (!delivery || delivery.orgId !== input.orgId) return null
-    if (input.claimedBy && delivery.claimedBy !== input.claimedBy) return null
-    const updatedAt = nowIso(input.updatedAt)
-    delivery.status = input.status
-    delivery.claimedBy = null
-    delivery.claimExpiresAt = null
-    delivery.lastError = input.lastError ? redactOperationalText(input.lastError, CHANNEL_DELIVERY_ERROR_MAX_LENGTH, 'Delivery error') : null
-    delivery.nextAttemptAt = (input.nextAttemptAt || input.updatedAt || new Date()).toISOString()
-    delivery.updatedAt = updatedAt
-    return clone(delivery)
+    return this.channelDeliveriesDomain.ack(input)
   }
 
   claimChannelProviderEvent(input: ClaimChannelProviderEventInput): ChannelProviderEventClaimResult {

--- a/apps/desktop/src/main/cloud/in-memory-domains/channel-deliveries.ts
+++ b/apps/desktop/src/main/cloud/in-memory-domains/channel-deliveries.ts
@@ -1,0 +1,210 @@
+import { quotaExceeded } from '../control-plane-errors.ts'
+import { normalizeChannelProviderId as normalizeProvider } from '../channel-provider-utils.ts'
+import type {
+  AckChannelDeliveryInput,
+  ChannelBindingRecord,
+  ChannelDeliveryRecord,
+  ChannelSessionBindingRecord,
+  ClaimChannelDeliveryInput,
+  CreateChannelDeliveryInput,
+  HeadlessAgentRecord,
+  ListChannelDeliveriesInput,
+  QuotaConsumptionRecord,
+} from '../in-memory-control-plane-store.ts'
+
+const CHANNEL_TEXT_MAX_LENGTH = 256
+const CHANNEL_METADATA_MAX_BYTES = 16_384
+const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
+
+type ChannelDeliveryQuotaInput = NonNullable<ClaimChannelDeliveryInput['quota']> & { orgId: string }
+
+type InMemoryChannelDeliveriesHost = {
+  orgExists(orgId: string): boolean
+  getHeadlessAgent(orgId: string, agentId: string): HeadlessAgentRecord | null
+  getChannelBinding(orgId: string, bindingId: string): ChannelBindingRecord | null
+  getChannelSessionBinding(orgId: string, bindingId: string): ChannelSessionBindingRecord | null
+  consumeUsageQuota(input: ChannelDeliveryQuotaInput): QuotaConsumptionRecord
+}
+
+export class InMemoryChannelDeliveriesDomain {
+  private readonly deliveries = new Map<string, ChannelDeliveryRecord>()
+  private readonly host: InMemoryChannelDeliveriesHost
+
+  constructor(host: InMemoryChannelDeliveriesHost) {
+    this.host = host
+  }
+
+  create(input: CreateChannelDeliveryInput): ChannelDeliveryRecord {
+    if (!this.host.orgExists(input.orgId)) throw new Error(`Unknown org ${input.orgId}.`)
+    const agent = this.host.getHeadlessAgent(input.orgId, input.agentId)
+    if (!agent) throw new Error(`Unknown headless agent ${input.agentId}.`)
+    const channelBinding = this.host.getChannelBinding(input.orgId, input.channelBindingId)
+    if (!channelBinding) throw new Error(`Unknown channel binding ${input.channelBindingId}.`)
+    const provider = normalizeProvider(input.provider)
+    if (channelBinding.agentId !== agent.agentId) throw new Error('Channel delivery binding does not match headless agent.')
+    if (channelBinding.provider !== provider) throw new Error('Channel delivery provider does not match channel binding.')
+    if (input.sessionBindingId) {
+      const sessionBinding = this.host.getChannelSessionBinding(input.orgId, input.sessionBindingId)
+      if (!sessionBinding) throw new Error(`Unknown channel session binding ${input.sessionBindingId}.`)
+      if (
+        sessionBinding.agentId !== agent.agentId
+        || sessionBinding.channelBindingId !== channelBinding.bindingId
+        || sessionBinding.provider !== provider
+      ) {
+        throw new Error('Channel delivery session binding does not match channel binding.')
+      }
+    }
+    const existing = this.deliveries.get(input.deliveryId)
+    if (existing) return clone(existing)
+    const now = nowIso(input.createdAt)
+    const record: ChannelDeliveryRecord = {
+      deliveryId: normalizeText(input.deliveryId, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery id'),
+      orgId: input.orgId,
+      agentId: normalizeText(input.agentId, CHANNEL_TEXT_MAX_LENGTH, 'Headless agent id'),
+      channelBindingId: normalizeText(input.channelBindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel binding id'),
+      sessionBindingId: normalizeNullableText(input.sessionBindingId, CHANNEL_TEXT_MAX_LENGTH, 'Channel session binding id'),
+      provider,
+      target: normalizeRecord(input.target, 'Channel delivery target'),
+      eventType: normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery event type'),
+      payload: normalizeRecord(input.payload, 'Channel delivery payload'),
+      status: input.status || 'pending',
+      attemptCount: 0,
+      claimedBy: null,
+      lastClaimedBy: null,
+      claimExpiresAt: null,
+      nextAttemptAt: (input.nextAttemptAt || input.createdAt || new Date()).toISOString(),
+      lastError: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.deliveries.set(record.deliveryId, record)
+    return clone(record)
+  }
+
+  list(input: ListChannelDeliveriesInput): ChannelDeliveryRecord[] {
+    if (input.channelBindingIds?.length === 0) return []
+    const limit = Math.max(1, Math.min(200, input.limit || 50))
+    return Array.from(this.deliveries.values())
+      .filter((delivery) => delivery.orgId === input.orgId)
+      .filter((delivery) => !input.deliveryId || delivery.deliveryId === input.deliveryId)
+      .filter((delivery) => !input.status || delivery.status === input.status)
+      .filter((delivery) => !input.channelBindingId || delivery.channelBindingId === input.channelBindingId)
+      .filter((delivery) => !input.channelBindingIds || input.channelBindingIds.includes(delivery.channelBindingId))
+      .filter((delivery) => !input.lastClaimedBy || delivery.lastClaimedBy === input.lastClaimedBy)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || right.createdAt.localeCompare(left.createdAt))
+      .slice(0, limit)
+      .map(clone)
+  }
+
+  claimNext(input: ClaimChannelDeliveryInput): ChannelDeliveryRecord | null {
+    if (input.channelBindingIds?.length === 0) return null
+    const now = input.now || new Date()
+    const nowMs = now.getTime()
+    const candidate = Array.from(this.deliveries.values())
+      .filter((delivery) => delivery.orgId === input.orgId)
+      .filter((delivery) => !input.channelBindingIds || input.channelBindingIds.includes(delivery.channelBindingId))
+      .filter((delivery) => (
+        (delivery.status === 'pending' && new Date(delivery.nextAttemptAt).getTime() <= nowMs)
+        || (delivery.status === 'failed' && new Date(delivery.nextAttemptAt).getTime() <= nowMs)
+        || (delivery.status === 'claimed' && delivery.claimExpiresAt && new Date(delivery.claimExpiresAt).getTime() <= nowMs)
+      ))
+      .sort((left, right) => left.nextAttemptAt.localeCompare(right.nextAttemptAt) || left.createdAt.localeCompare(right.createdAt))[0]
+    if (!candidate) return null
+    if (input.quota) {
+      const quota = this.host.consumeUsageQuota({ ...input.quota, orgId: input.orgId, now })
+      if (!quota.allowed) {
+        quotaExceeded({
+          message: 'Gateway delivery quota exceeded.',
+          policyCode: quota.policyCode || 'quota.gateway_deliveries_per_hour_exceeded',
+          retryAfterMs: quota.retryAfterMs,
+          limit: quota.limit,
+          used: quota.used,
+          resetAt: quota.resetAt,
+        })
+      }
+    }
+    candidate.status = 'claimed'
+    candidate.claimedBy = normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery claimant')
+    candidate.lastClaimedBy = normalizeText(input.lastClaimedBy || input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery owner')
+    candidate.claimExpiresAt = new Date(nowMs + (input.ttlMs || 30_000)).toISOString()
+    candidate.attemptCount += 1
+    candidate.updatedAt = now.toISOString()
+    return clone(candidate)
+  }
+
+  ack(input: AckChannelDeliveryInput): ChannelDeliveryRecord | null {
+    if (input.channelBindingIds?.length === 0) return null
+    const delivery = this.deliveries.get(input.deliveryId)
+    if (!delivery || delivery.orgId !== input.orgId) return null
+    if (input.channelBindingIds && !input.channelBindingIds.includes(delivery.channelBindingId)) return null
+    if (input.claimedBy && delivery.claimedBy !== input.claimedBy) return null
+    if (input.lastClaimedBy && delivery.lastClaimedBy !== input.lastClaimedBy) {
+      const legacyClaimMatches = delivery.lastClaimedBy === null && Boolean(input.claimedBy) && delivery.claimedBy === input.claimedBy
+      if (!legacyClaimMatches) return null
+      delivery.lastClaimedBy = input.lastClaimedBy
+    }
+    const updatedAt = nowIso(input.updatedAt)
+    delivery.status = input.status
+    delivery.claimedBy = null
+    delivery.claimExpiresAt = null
+    delivery.lastError = input.lastError ? redactOperationalText(input.lastError, CHANNEL_DELIVERY_ERROR_MAX_LENGTH, 'Delivery error') : null
+    delivery.nextAttemptAt = (input.nextAttemptAt || input.updatedAt || new Date()).toISOString()
+    delivery.updatedAt = updatedAt
+    return clone(delivery)
+  }
+}
+
+function nowIso(now: Date | undefined) {
+  return (now || new Date()).toISOString()
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function normalizeText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (normalized.length > maxLength) {
+    throw new Error(`${label} exceeds ${maxLength} characters.`)
+  }
+  return normalized
+}
+
+function normalizeNullableText(value: unknown, maxLength: number, label: string): string | null {
+  if (value === undefined || value === null || value === '') return null
+  return normalizeText(value, maxLength, label)
+}
+
+function normalizeRecord(value: unknown, label: string, maxBytes = CHANNEL_METADATA_MAX_BYTES): Record<string, unknown> {
+  const record = value && typeof value === 'object' && !Array.isArray(value)
+    ? clone(value as Record<string, unknown>)
+    : {}
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([field, entry]) => `${JSON.stringify(field)}:${stableJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function redactOperationalText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const redacted = value.trim()
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password|authorization)=([^\s&]+)/gi, '$1=[redacted]')
+    .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
+    .replace(/\b(?:sk-[A-Za-z0-9._-]{6,}|oc[wc]_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
+  return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength <= 3 ? maxLength : maxLength - 3)}${maxLength <= 3 ? '' : '...'}`
+}

--- a/apps/desktop/src/main/cloud/in-memory-domains/channel-provider-events.ts
+++ b/apps/desktop/src/main/cloud/in-memory-domains/channel-provider-events.ts
@@ -90,6 +90,7 @@ export class InMemoryChannelProviderEventsDomain {
     const event = Array.from(this.events.values())
       .find((candidate) => candidate.orgId === input.orgId && candidate.eventId === input.eventId)
     if (!event) return null
+    if (!providerEventMatchesChannelBindingScope(event, input.channelBindingIds)) return null
     if (event.claimedBy !== normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant')) return null
 
     const updatedAt = nowIso(input.updatedAt)
@@ -104,6 +105,16 @@ export class InMemoryChannelProviderEventsDomain {
     event.updatedAt = updatedAt
     return clone(event)
   }
+}
+
+function providerEventMatchesChannelBindingScope(
+  event: ChannelProviderEventRecord,
+  channelBindingIds: readonly string[] | null | undefined,
+) {
+  if (channelBindingIds === null || channelBindingIds === undefined) return true
+  if (!Object.prototype.hasOwnProperty.call(event.metadata, 'channelBindingId')) return true
+  const bindingId = typeof event.metadata.channelBindingId === 'string' ? event.metadata.channelBindingId : null
+  return bindingId !== null && channelBindingIds.includes(bindingId)
 }
 
 function channelProviderEventKey(input: {

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -51,10 +51,12 @@ import type {
   EnqueueCommandInput,
   FailWorkflowRunInput,
   FindChannelInteractionInput,
+  GrantApiTokenChannelBindingInput,
   IssuedApiTokenRecord,
   IssuedChannelInteractionRecord,
   IssuedManagedWorkerCredentialRecord,
   IssueApiTokenInput,
+  ListApiTokenChannelBindingGrantsInput,
   ListSessionsPageInput,
   ManagedWorkerCredentialRecord,
   ManagedWorkerHeartbeatRecord,
@@ -103,6 +105,7 @@ import type {
   CreateManagedWorkerPoolInput,
   RegisterManagedWorkerInput,
   IssueManagedWorkerCredentialInput,
+  ApiTokenChannelBindingGrantRecord,
 } from './control-plane-store.ts'
 import type {
   WorkflowWebhookReplayClaim,
@@ -113,9 +116,10 @@ import { workspaceEventCursorFromRow } from './workspace-event-cursor.ts'
 import { normalizeChannelProviderId as normalizeProvider } from './channel-provider-utils.ts'
 import { usageEventFromRow, billingSubscriptionFromRow } from './postgres-domains/billing.ts'
 import { byokSecretFromRow } from './postgres-domains/byok.ts'
-import { channelBindingFromRow, channelDeliveryFromRow, channelIdentityFromRow, channelInteractionFromRow, channelSessionBindingFromRow, headlessAgentFromRow } from './postgres-domains/channels.ts'
+import { channelBindingFromRow, channelIdentityFromRow, channelInteractionFromRow, channelSessionBindingFromRow, headlessAgentFromRow } from './postgres-domains/channels.ts'
 import {
   accountFromRow,
+  apiTokenChannelBindingGrantFromRow,
   apiTokenFromRow,
   auditEventFromRow,
   cloudAuthBackoffFromRow,
@@ -142,6 +146,7 @@ import { workflowFromRow, workflowRunFromRow } from './postgres-domains/workflow
 import { assertPostgresCommandEnqueueQuotas, assertPostgresCommandQueueQuota, assertPostgresConcurrentSessionQuota, assertPostgresWorkflowRunQuota, checkPostgresActiveWorkerQuota, listPostgresRunnableSessions } from './postgres-store-domains/quotas.ts'
 import { PostgresManagedWorkersRepository } from './postgres-store-domains/workers.ts'
 import { PostgresChannelProviderEventsRepository } from './postgres-store-domains/channel-provider-events.ts'
+import { PostgresChannelDeliveriesRepository } from './postgres-store-domains/channel-deliveries.ts'
 
 type PgExecutor = {
   query<Row extends QueryRow = QueryRow>(text: string, values?: unknown[]): Promise<QueryResult<Row>>
@@ -166,7 +171,6 @@ const SMART_FILTER_QUERY_MAX_BYTES = 16_384
 const WORKFLOW_RUN_LIST_LIMIT = 100
 const CHANNEL_TEXT_MAX_LENGTH = 256
 const CHANNEL_METADATA_MAX_BYTES = 16_384
-const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
 const BYOK_PROVIDER_ID_MAX_LENGTH = 64
 const BYOK_SECRET_TEXT_MAX_LENGTH = 4096
 function loadPgPool(connectionString: string): PgPool {
@@ -298,6 +302,7 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   private readonly ownsPool: boolean
   private readonly managedWorkers: PostgresManagedWorkersRepository
   private readonly channelProviderEvents: PostgresChannelProviderEventsRepository
+  private readonly channelDeliveries: PostgresChannelDeliveriesRepository
   private readonly quotaDeps = {
     lockQuota: (executor: PgExecutor, orgId: string, quotaKey: string, now?: Date) => this.lockQuota(executor, orgId, quotaKey, now),
     consumeUsageQuota: (executor: PgExecutor, input: ConsumeUsageQuotaInput) => this.consumeUsageQuotaWithExecutor(executor, input),
@@ -314,6 +319,11 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     this.channelProviderEvents = new PostgresChannelProviderEventsRepository({
       pool: this.pool,
       withTransaction: (fn) => this.withTransaction(fn),
+    })
+    this.channelDeliveries = new PostgresChannelDeliveriesRepository({
+      pool: this.pool,
+      withTransaction: (fn) => this.withTransaction(fn),
+      consumeUsageQuota: (executor, input) => this.consumeUsageQuotaWithExecutor(executor, input),
     })
   }
 
@@ -691,6 +701,64 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
       })
       return token
     })
+  }
+
+  async grantApiTokenChannelBinding(input: GrantApiTokenChannelBindingInput): Promise<ApiTokenChannelBindingGrantRecord> {
+    return this.withTransaction(async (client) => {
+      const tokenRow = await this.maybeOne(
+        `SELECT * FROM cloud_api_tokens WHERE org_id = $1 AND token_id = $2`,
+        [input.orgId, input.tokenId],
+        client,
+      )
+      if (!tokenRow) throw new Error(`Unknown API token ${input.tokenId}.`)
+      const bindingRow = await this.maybeOne(
+        `SELECT * FROM cloud_channel_bindings WHERE org_id = $1 AND binding_id = $2`,
+        [input.orgId, input.channelBindingId],
+        client,
+      )
+      if (!bindingRow) throw new Error(`Unknown channel binding ${input.channelBindingId}.`)
+      const createdAt = nowIso(input.createdAt)
+      const result = await client.query(
+        `INSERT INTO cloud_api_token_channel_binding_grants (
+          org_id, token_id, channel_binding_id, created_at
+         )
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (org_id, token_id, channel_binding_id) DO NOTHING
+         RETURNING *`,
+        [input.orgId, input.tokenId, input.channelBindingId, createdAt],
+      )
+      const row = result.rows[0] || await this.one(
+        `SELECT * FROM cloud_api_token_channel_binding_grants
+         WHERE org_id = $1 AND token_id = $2 AND channel_binding_id = $3`,
+        [input.orgId, input.tokenId, input.channelBindingId],
+        client,
+      )
+      if (result.rows[0]) {
+        const token = apiTokenFromRow(tokenRow)
+        await this.recordAuditEventWithExecutor(client, {
+          orgId: input.orgId,
+          accountId: input.actor?.accountId || token.accountId,
+          actorType: input.actor?.actorType || 'system',
+          actorId: input.actor?.actorId || null,
+          eventType: 'api_token.channel_binding_granted',
+          targetType: 'api_token',
+          targetId: input.tokenId,
+          metadata: { channelBindingId: input.channelBindingId },
+          createdAt: input.createdAt,
+        })
+      }
+      return apiTokenChannelBindingGrantFromRow(row)
+    })
+  }
+
+  async listApiTokenChannelBindingGrants(input: ListApiTokenChannelBindingGrantsInput): Promise<ApiTokenChannelBindingGrantRecord[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM cloud_api_token_channel_binding_grants
+       WHERE org_id = $1 AND token_id = $2
+       ORDER BY channel_binding_id`,
+      [input.orgId, input.tokenId],
+    )
+    return result.rows.map(apiTokenChannelBindingGrantFromRow)
   }
 
   async createManagedWorkerPool(input: CreateManagedWorkerPoolInput): Promise<ManagedWorkerPoolRecord> {
@@ -1862,162 +1930,19 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   }
 
   async createChannelDelivery(input: CreateChannelDeliveryInput) {
-    const now = nowIso(input.createdAt)
-    const provider = normalizeProvider(input.provider)
-    const relationship = await this.maybeOne(
-      `SELECT b.binding_id
-       FROM headless_agents a
-       JOIN cloud_channel_bindings b
-         ON b.binding_id = $3
-        AND b.org_id = $1
-        AND b.agent_id = a.agent_id
-        AND b.provider = $5
-       LEFT JOIN cloud_channel_session_bindings sb
-         ON sb.binding_id = $4
-       WHERE a.org_id = $1
-         AND a.agent_id = $2
-         AND ($4::text IS NULL OR (
-           sb.org_id = $1
-           AND sb.agent_id = a.agent_id
-           AND sb.channel_binding_id = b.binding_id
-           AND sb.provider = $5
-         ))`,
-      [input.orgId, input.agentId, input.channelBindingId, input.sessionBindingId || null, provider],
-    )
-    if (!relationship) throw new Error('Channel delivery references must belong to the same org, agent, provider, binding, and session binding.')
-    const result = await this.pool.query(
-      `INSERT INTO cloud_channel_deliveries (
-        delivery_id, org_id, agent_id, channel_binding_id, session_binding_id,
-        provider, target, event_type, payload, status, attempt_count,
-        claimed_by, claim_expires_at, next_attempt_at, last_error, created_at, updated_at
-       )
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9::jsonb, $10, 0, NULL, NULL, $11, NULL, $12, $12)
-       ON CONFLICT (delivery_id) DO NOTHING
-       RETURNING *`,
-      [
-        input.deliveryId,
-        input.orgId,
-        input.agentId,
-        input.channelBindingId,
-        input.sessionBindingId || null,
-        provider,
-        JSON.stringify(normalizeRecord(input.target, 'Channel delivery target')),
-        normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery event type'),
-        JSON.stringify(normalizeRecord(input.payload, 'Channel delivery payload')),
-        input.status || 'pending',
-        (input.nextAttemptAt || input.createdAt || new Date()).toISOString(),
-        now,
-      ],
-    )
-    const row = result.rows[0] || await this.one(
-      `SELECT * FROM cloud_channel_deliveries WHERE org_id = $1 AND delivery_id = $2`,
-      [input.orgId, input.deliveryId],
-    )
-    return channelDeliveryFromRow(row)
+    return this.channelDeliveries.create(input)
   }
 
   async listChannelDeliveries(input: ListChannelDeliveriesInput) {
-    const conditions = ['org_id = $1']
-    const values: unknown[] = [input.orgId]
-    if (input.status) {
-      values.push(input.status)
-      conditions.push(`status = $${values.length}`)
-    }
-    if (input.channelBindingId) {
-      values.push(input.channelBindingId)
-      conditions.push(`channel_binding_id = $${values.length}`)
-    }
-    values.push(Math.max(1, Math.min(200, input.limit || 50)))
-    const limitIndex = values.length
-    const result = await this.pool.query(
-      `SELECT * FROM cloud_channel_deliveries
-       WHERE ${conditions.join(' AND ')}
-       ORDER BY updated_at DESC, created_at DESC
-       LIMIT $${limitIndex}`,
-      values,
-    )
-    return result.rows.map(channelDeliveryFromRow)
+    return this.channelDeliveries.list(input)
   }
 
   async claimNextChannelDelivery(input: ClaimChannelDeliveryInput) {
-    return this.withTransaction(async (client) => {
-      const now = input.now || new Date()
-      const selected = await this.maybeOne(
-        `SELECT * FROM cloud_channel_deliveries
-         WHERE org_id = $1
-           AND (
-             (status = 'pending' AND next_attempt_at <= $2)
-             OR (status = 'failed' AND next_attempt_at <= $2)
-             OR (status = 'claimed' AND claim_expires_at <= $2)
-           )
-         ORDER BY next_attempt_at, created_at
-         FOR UPDATE SKIP LOCKED
-         LIMIT 1`,
-        [input.orgId, now.toISOString()],
-        client,
-      )
-      if (!selected) return null
-      if (input.quota) {
-        const quota = await this.consumeUsageQuotaWithExecutor(client, {
-          ...input.quota,
-          orgId: input.orgId,
-          now,
-        })
-        if (!quota.allowed) {
-          throw new ControlPlaneQuotaExceededError({
-            message: 'Gateway delivery quota exceeded.',
-            policyCode: quota.policyCode || 'quota.gateway_deliveries_per_hour_exceeded',
-            retryAfterMs: quota.retryAfterMs,
-            limit: quota.limit,
-            used: quota.used,
-            resetAt: quota.resetAt,
-          })
-        }
-      }
-      const result = await client.query(
-        `UPDATE cloud_channel_deliveries
-         SET status = 'claimed',
-             claimed_by = $2,
-             claim_expires_at = $3,
-             attempt_count = attempt_count + 1,
-             updated_at = $4
-         WHERE delivery_id = $1
-         RETURNING *`,
-        [
-          String(selected.delivery_id),
-          normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery claimant'),
-          new Date(now.getTime() + (input.ttlMs || 30_000)).toISOString(),
-          now.toISOString(),
-        ],
-      )
-      return channelDeliveryFromRow(result.rows[0])
-    })
+    return this.channelDeliveries.claimNext(input)
   }
 
   async ackChannelDelivery(input: AckChannelDeliveryInput) {
-    const result = await this.pool.query(
-      `UPDATE cloud_channel_deliveries
-       SET status = $3,
-           claimed_by = NULL,
-           claim_expires_at = NULL,
-           last_error = $4,
-           next_attempt_at = $5,
-           updated_at = $6
-       WHERE org_id = $1
-         AND delivery_id = $2
-         AND ($7::text IS NULL OR claimed_by = $7)
-       RETURNING *`,
-      [
-        input.orgId,
-        input.deliveryId,
-        input.status,
-        input.lastError ? redactOperationalText(input.lastError, CHANNEL_DELIVERY_ERROR_MAX_LENGTH, 'Delivery error') : null,
-        (input.nextAttemptAt || input.updatedAt || new Date()).toISOString(),
-        nowIso(input.updatedAt),
-        input.claimedBy || null,
-      ],
-    )
-    return result.rows[0] ? channelDeliveryFromRow(result.rows[0]) : null
+    return this.channelDeliveries.ack(input)
   }
 
   async claimChannelProviderEvent(input: ClaimChannelProviderEventInput) {

--- a/apps/desktop/src/main/cloud/postgres-domains/channels.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/channels.ts
@@ -111,6 +111,7 @@ export function channelDeliveryFromRow(row: QueryRow): ChannelDeliveryRecord {
     status: String(row.status) as ChannelDeliveryRecord['status'],
     attemptCount: numberValue(row.attempt_count),
     claimedBy: stringOrNull(row.claimed_by),
+    lastClaimedBy: stringOrNull(row.last_claimed_by),
     claimExpiresAt: isoOrNull(row.claim_expires_at),
     nextAttemptAt: iso(row.next_attempt_at),
     lastError: stringOrNull(row.last_error),

--- a/apps/desktop/src/main/cloud/postgres-domains/identity.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/identity.ts
@@ -1,5 +1,6 @@
 import type {
   AccountRecord,
+  ApiTokenChannelBindingGrantRecord,
   ApiTokenRecord,
   AuditEventRecord,
   CloudAuthBackoffRecord,
@@ -77,6 +78,15 @@ export function apiTokenFromRow(row: QueryRow): ApiTokenRecord {
     lastUsedAt: isoOrNull(row.last_used_at),
     createdAt: iso(row.created_at),
     updatedAt: iso(row.updated_at),
+  }
+}
+
+export function apiTokenChannelBindingGrantFromRow(row: QueryRow): ApiTokenChannelBindingGrantRecord {
+  return {
+    orgId: String(row.org_id),
+    tokenId: String(row.token_id),
+    channelBindingId: String(row.channel_binding_id),
+    createdAt: iso(row.created_at),
   }
 }
 

--- a/apps/desktop/src/main/cloud/postgres-schema.ts
+++ b/apps/desktop/src/main/cloud/postgres-schema.ts
@@ -439,6 +439,7 @@ export const CLOUD_CONTROL_PLANE_HEADLESS_CHANNELS_STATEMENTS = [
     status text NOT NULL,
     attempt_count integer NOT NULL DEFAULT 0,
     claimed_by text,
+    last_claimed_by text,
     claim_expires_at timestamptz,
     next_attempt_at timestamptz NOT NULL,
     last_error text,
@@ -736,6 +737,46 @@ export const CLOUD_CONTROL_PLANE_CHANNEL_PROVIDER_EVENTS_STATEMENTS = [
     ON cloud_channel_provider_events (org_id, status, retryable, claim_expires_at, updated_at)`,
 ] as const
 
+export const CLOUD_CONTROL_PLANE_DELIVERY_OWNER_MIGRATION_ID = '012_channel_delivery_owner'
+
+export const CLOUD_CONTROL_PLANE_DELIVERY_OWNER_STATEMENTS = [
+  `ALTER TABLE cloud_channel_deliveries
+    ADD COLUMN IF NOT EXISTS last_claimed_by text`,
+  `CREATE INDEX IF NOT EXISTS cloud_channel_deliveries_owner_idx
+    ON cloud_channel_deliveries (org_id, last_claimed_by, status, updated_at DESC)
+    WHERE last_claimed_by IS NOT NULL`,
+] as const
+
+export const CLOUD_CONTROL_PLANE_API_TOKEN_CHANNEL_BINDINGS_MIGRATION_ID = '013_api_token_channel_binding_grants'
+
+export const CLOUD_CONTROL_PLANE_API_TOKEN_CHANNEL_BINDINGS_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS cloud_api_token_channel_binding_grants (
+    org_id text NOT NULL REFERENCES cloud_orgs(org_id) ON DELETE CASCADE,
+    token_id text NOT NULL REFERENCES cloud_api_tokens(token_id) ON DELETE CASCADE,
+    channel_binding_id text NOT NULL REFERENCES cloud_channel_bindings(binding_id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (org_id, token_id, channel_binding_id)
+  )`,
+  `INSERT INTO cloud_api_token_channel_binding_grants (
+    org_id, token_id, channel_binding_id, created_at
+   )
+   SELECT tokens.org_id, tokens.token_id, bindings.binding_id, now()
+   FROM cloud_api_tokens tokens
+   JOIN cloud_channel_bindings bindings ON bindings.org_id = tokens.org_id
+   WHERE tokens.revoked_at IS NULL
+     AND tokens.scopes @> '["gateway"]'::jsonb
+     AND NOT EXISTS (
+       SELECT 1
+       FROM cloud_schema_migrations
+       WHERE id = '${CLOUD_CONTROL_PLANE_API_TOKEN_CHANNEL_BINDINGS_MIGRATION_ID}'
+     )
+   ON CONFLICT (org_id, token_id, channel_binding_id) DO NOTHING`,
+  `CREATE INDEX IF NOT EXISTS cloud_api_token_channel_binding_grants_token_idx
+    ON cloud_api_token_channel_binding_grants (org_id, token_id, channel_binding_id)`,
+  `CREATE INDEX IF NOT EXISTS cloud_api_token_channel_binding_grants_binding_idx
+    ON cloud_api_token_channel_binding_grants (org_id, channel_binding_id, token_id)`,
+] as const
+
 export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration[] = [
   {
     id: CLOUD_CONTROL_PLANE_MIGRATION_ID,
@@ -782,5 +823,13 @@ export const CLOUD_CONTROL_PLANE_MIGRATIONS: readonly CloudControlPlaneMigration
   {
     id: CLOUD_CONTROL_PLANE_CHANNEL_PROVIDER_EVENTS_MIGRATION_ID,
     statements: CLOUD_CONTROL_PLANE_CHANNEL_PROVIDER_EVENTS_STATEMENTS,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_DELIVERY_OWNER_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_DELIVERY_OWNER_STATEMENTS,
+  },
+  {
+    id: CLOUD_CONTROL_PLANE_API_TOKEN_CHANNEL_BINDINGS_MIGRATION_ID,
+    statements: CLOUD_CONTROL_PLANE_API_TOKEN_CHANNEL_BINDINGS_STATEMENTS,
   },
 ] as const

--- a/apps/desktop/src/main/cloud/postgres-store-domains/channel-deliveries.ts
+++ b/apps/desktop/src/main/cloud/postgres-store-domains/channel-deliveries.ts
@@ -1,0 +1,276 @@
+import {
+  ControlPlaneQuotaExceededError,
+  type AckChannelDeliveryInput,
+  type ClaimChannelDeliveryInput,
+  type ConsumeUsageQuotaInput,
+  type CreateChannelDeliveryInput,
+  type ListChannelDeliveriesInput,
+  type QuotaConsumptionRecord,
+} from '../control-plane-store.ts'
+import { normalizeChannelProviderId as normalizeProvider } from '../channel-provider-utils.ts'
+import { channelDeliveryFromRow } from '../postgres-domains/channels.ts'
+import { jsonRecord, type QueryResult, type QueryRow } from '../postgres-domains/shared.ts'
+
+type PgExecutor = {
+  query<Row extends QueryRow = QueryRow>(text: string, values?: unknown[]): Promise<QueryResult<Row>>
+}
+type PgClient = PgExecutor & { release: () => void }
+
+type PostgresChannelDeliveriesRepositoryOptions = {
+  pool: PgExecutor
+  withTransaction<T>(fn: (client: PgClient) => Promise<T>): Promise<T>
+  consumeUsageQuota(executor: PgExecutor, input: ConsumeUsageQuotaInput): Promise<QuotaConsumptionRecord>
+}
+
+const CHANNEL_TEXT_MAX_LENGTH = 256
+const CHANNEL_METADATA_MAX_BYTES = 16_384
+const CHANNEL_DELIVERY_ERROR_MAX_LENGTH = 1024
+
+export class PostgresChannelDeliveriesRepository {
+  private readonly options: PostgresChannelDeliveriesRepositoryOptions
+
+  constructor(options: PostgresChannelDeliveriesRepositoryOptions) {
+    this.options = options
+  }
+
+  async create(input: CreateChannelDeliveryInput) {
+    const now = nowIso(input.createdAt)
+    const provider = normalizeProvider(input.provider)
+    const relationship = await maybeOne(
+      this.options.pool,
+      `SELECT b.binding_id
+       FROM headless_agents a
+       JOIN cloud_channel_bindings b
+         ON b.binding_id = $3
+        AND b.org_id = $1
+        AND b.agent_id = a.agent_id
+        AND b.provider = $5
+       LEFT JOIN cloud_channel_session_bindings sb
+         ON sb.binding_id = $4
+       WHERE a.org_id = $1
+         AND a.agent_id = $2
+         AND ($4::text IS NULL OR (
+           sb.org_id = $1
+           AND sb.agent_id = a.agent_id
+           AND sb.channel_binding_id = b.binding_id
+           AND sb.provider = $5
+         ))`,
+      [input.orgId, input.agentId, input.channelBindingId, input.sessionBindingId || null, provider],
+    )
+    if (!relationship) throw new Error('Channel delivery references must belong to the same org, agent, provider, binding, and session binding.')
+    const result = await this.options.pool.query(
+      `INSERT INTO cloud_channel_deliveries (
+        delivery_id, org_id, agent_id, channel_binding_id, session_binding_id,
+        provider, target, event_type, payload, status, attempt_count,
+        claimed_by, last_claimed_by, claim_expires_at, next_attempt_at, last_error, created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9::jsonb, $10, 0, NULL, NULL, NULL, $11, NULL, $12, $12)
+       ON CONFLICT (delivery_id) DO NOTHING
+       RETURNING *`,
+      [
+        input.deliveryId,
+        input.orgId,
+        input.agentId,
+        input.channelBindingId,
+        input.sessionBindingId || null,
+        provider,
+        JSON.stringify(normalizeRecord(input.target, 'Channel delivery target')),
+        normalizeText(input.eventType, CHANNEL_TEXT_MAX_LENGTH, 'Channel delivery event type'),
+        JSON.stringify(normalizeRecord(input.payload, 'Channel delivery payload')),
+        input.status || 'pending',
+        (input.nextAttemptAt || input.createdAt || new Date()).toISOString(),
+        now,
+      ],
+    )
+    const row = result.rows[0] || await one(
+      this.options.pool,
+      `SELECT * FROM cloud_channel_deliveries WHERE org_id = $1 AND delivery_id = $2`,
+      [input.orgId, input.deliveryId],
+    )
+    return channelDeliveryFromRow(row)
+  }
+
+  async list(input: ListChannelDeliveriesInput) {
+    if (input.channelBindingIds?.length === 0) return []
+    const conditions = ['org_id = $1']
+    const values: unknown[] = [input.orgId]
+    if (input.deliveryId) {
+      values.push(input.deliveryId)
+      conditions.push(`delivery_id = $${values.length}`)
+    }
+    if (input.status) {
+      values.push(input.status)
+      conditions.push(`status = $${values.length}`)
+    }
+    if (input.channelBindingId) {
+      values.push(input.channelBindingId)
+      conditions.push(`channel_binding_id = $${values.length}`)
+    }
+    if (input.channelBindingIds) {
+      values.push([...input.channelBindingIds])
+      conditions.push(`channel_binding_id = ANY($${values.length}::text[])`)
+    }
+    if (input.lastClaimedBy) {
+      values.push(input.lastClaimedBy)
+      conditions.push(`last_claimed_by = $${values.length}`)
+    }
+    values.push(Math.max(1, Math.min(200, input.limit || 50)))
+    const limitIndex = values.length
+    const result = await this.options.pool.query(
+      `SELECT * FROM cloud_channel_deliveries
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY updated_at DESC, created_at DESC
+       LIMIT $${limitIndex}`,
+      values,
+    )
+    return result.rows.map(channelDeliveryFromRow)
+  }
+
+  async claimNext(input: ClaimChannelDeliveryInput) {
+    if (input.channelBindingIds?.length === 0) return null
+    return this.options.withTransaction(async (client) => {
+      const now = input.now || new Date()
+      const selected = await maybeOne(
+        client,
+        `SELECT * FROM cloud_channel_deliveries
+         WHERE org_id = $1
+           AND ($3::text[] IS NULL OR channel_binding_id = ANY($3::text[]))
+           AND (
+             (status = 'pending' AND next_attempt_at <= $2)
+             OR (status = 'failed' AND next_attempt_at <= $2)
+             OR (status = 'claimed' AND claim_expires_at <= $2)
+           )
+         ORDER BY next_attempt_at, created_at
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1`,
+        [input.orgId, now.toISOString(), input.channelBindingIds?.length ? [...input.channelBindingIds] : null],
+      )
+      if (!selected) return null
+      if (input.quota) {
+        const quota = await this.options.consumeUsageQuota(client, {
+          ...input.quota,
+          orgId: input.orgId,
+          now,
+        })
+        if (!quota.allowed) {
+          throw new ControlPlaneQuotaExceededError({
+            message: 'Gateway delivery quota exceeded.',
+            policyCode: quota.policyCode || 'quota.gateway_deliveries_per_hour_exceeded',
+            retryAfterMs: quota.retryAfterMs,
+            limit: quota.limit,
+            used: quota.used,
+            resetAt: quota.resetAt,
+          })
+        }
+      }
+      const result = await client.query(
+        `UPDATE cloud_channel_deliveries
+         SET status = 'claimed',
+             claimed_by = $2,
+             last_claimed_by = COALESCE($5::text, $2),
+             claim_expires_at = $3,
+             attempt_count = attempt_count + 1,
+             updated_at = $4
+         WHERE delivery_id = $1
+         RETURNING *`,
+        [
+          String(selected.delivery_id),
+          normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery claimant'),
+          new Date(now.getTime() + (input.ttlMs || 30_000)).toISOString(),
+          now.toISOString(),
+          input.lastClaimedBy ? normalizeText(input.lastClaimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Delivery owner') : null,
+        ],
+      )
+      return channelDeliveryFromRow(result.rows[0])
+    })
+  }
+
+  async ack(input: AckChannelDeliveryInput) {
+    if (input.channelBindingIds?.length === 0) return null
+    const result = await this.options.pool.query(
+      `UPDATE cloud_channel_deliveries
+       SET status = $3,
+           claimed_by = NULL,
+           last_claimed_by = COALESCE(last_claimed_by, $8),
+           claim_expires_at = NULL,
+           last_error = $4,
+           next_attempt_at = $5,
+           updated_at = $6
+       WHERE org_id = $1
+         AND delivery_id = $2
+         AND ($9::text[] IS NULL OR channel_binding_id = ANY($9::text[]))
+         AND ($7::text IS NULL OR claimed_by = $7)
+         AND (
+           $8::text IS NULL
+           OR last_claimed_by = $8
+           OR (last_claimed_by IS NULL AND $7::text IS NOT NULL AND claimed_by = $7)
+         )
+       RETURNING *`,
+      [
+        input.orgId,
+        input.deliveryId,
+        input.status,
+        input.lastError ? redactOperationalText(input.lastError, CHANNEL_DELIVERY_ERROR_MAX_LENGTH, 'Delivery error') : null,
+        (input.nextAttemptAt || input.updatedAt || new Date()).toISOString(),
+        nowIso(input.updatedAt),
+        input.claimedBy || null,
+        input.lastClaimedBy || null,
+        input.channelBindingIds?.length ? [...input.channelBindingIds] : null,
+      ],
+    )
+    return result.rows[0] ? channelDeliveryFromRow(result.rows[0]) : null
+  }
+}
+
+async function one<Row extends QueryRow = QueryRow>(executor: PgExecutor, text: string, values?: unknown[]) {
+  const result = await executor.query<Row>(text, values)
+  if (!result.rows[0]) throw new Error('Expected query to return a row.')
+  return result.rows[0]
+}
+
+async function maybeOne<Row extends QueryRow = QueryRow>(executor: PgExecutor, text: string, values?: unknown[]) {
+  const result = await executor.query<Row>(text, values)
+  return result.rows[0] || null
+}
+
+function nowIso(now: Date | undefined) {
+  return (now || new Date()).toISOString()
+}
+
+function normalizeText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const normalized = value.trim()
+  if (normalized.length > maxLength) throw new Error(`${label} exceeds ${maxLength} characters.`)
+  return normalized
+}
+
+function redactOperationalText(value: unknown, maxLength: number, label: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} is required.`)
+  const redacted = value.trim()
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[redacted]')
+    .replace(/\b(api[_-]?key|token|secret|password|authorization)=([^\s&]+)/gi, '$1=[redacted]')
+    .replace(/\b(gcp-sm|aws-sm|azure-kv|env):[^\s,)]+/gi, '$1:[redacted]')
+    .replace(/\b(?:sk-[A-Za-z0-9._-]{6,}|oc[wc]_[A-Za-z0-9._-]{8,})\b/g, '[redacted]')
+    .replace(/\b([A-Za-z0-9_-]{32,})\b/g, '[redacted]')
+  return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength <= 3 ? maxLength : maxLength - 3)}${maxLength <= 3 ? '' : '...'}`
+}
+
+function normalizeRecord(value: unknown, label: string, maxBytes = CHANNEL_METADATA_MAX_BYTES): Record<string, unknown> {
+  const record = jsonRecord(value)
+  const serialized = stableJson(record)
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} bytes.`)
+  }
+  return record
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([field, entry]) => `${JSON.stringify(field)}:${stableJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}

--- a/apps/desktop/src/main/cloud/postgres-store-domains/channel-provider-events.ts
+++ b/apps/desktop/src/main/cloud/postgres-store-domains/channel-provider-events.ts
@@ -146,6 +146,7 @@ export class PostgresChannelProviderEventsRepository {
        WHERE org_id = $1
          AND event_id = $2
          AND claimed_by = $7
+         AND ($8::text[] IS NULL OR metadata ->> 'channelBindingId' = ANY($8::text[]) OR NOT (metadata ? 'channelBindingId'))
        RETURNING *`,
       [
         input.orgId,
@@ -157,6 +158,7 @@ export class PostgresChannelProviderEventsRepository {
           : null,
         updatedAt,
         normalizeText(input.claimedBy, CHANNEL_TEXT_MAX_LENGTH, 'Provider event claimant'),
+        input.channelBindingIds === null || input.channelBindingIds === undefined ? null : [...input.channelBindingIds],
       ],
     )
     return result.rows[0] ? channelProviderEventFromRow(result.rows[0]) : null

--- a/apps/desktop/src/main/cloud/services/api-token-policy.ts
+++ b/apps/desktop/src/main/cloud/services/api-token-policy.ts
@@ -7,7 +7,9 @@ const DEFAULT_API_TOKEN_TTL_MS = 90 * DAY_MS
 const MAX_API_TOKEN_TTL_MS = 365 * DAY_MS
 const DEFAULT_API_TOKEN_ALLOWED_SCOPES = new Set<ApiTokenScope>(['desktop', 'gateway', 'admin', 'operator'])
 
-export type PublicApiTokenRecord = Omit<ApiTokenRecord, 'tokenHash'>
+export type PublicApiTokenRecord = Omit<ApiTokenRecord, 'tokenHash'> & {
+  channelBindingIds: string[]
+}
 
 export type CloudIdentityPolicy = {
   allowSelfServiceSignup: boolean
@@ -18,9 +20,12 @@ export type CloudIdentityPolicy = {
   apiTokenAllowedScopes?: readonly string[] | null
 }
 
-export function publicApiToken(token: ApiTokenRecord): PublicApiTokenRecord {
+export function publicApiToken(token: ApiTokenRecord, channelBindingIds: readonly string[] = []): PublicApiTokenRecord {
   const { tokenHash: _tokenHash, ...publicToken } = token
-  return publicToken
+  return {
+    ...publicToken,
+    channelBindingIds: [...new Set(channelBindingIds)].sort(),
+  }
 }
 
 export function resolvedSignupMode(policy: CloudIdentityPolicy): 'disabled' | 'closed' | 'invite' | 'domain' | 'open' {

--- a/apps/desktop/src/main/cloud/services/channel-admin-actions.ts
+++ b/apps/desktop/src/main/cloud/services/channel-admin-actions.ts
@@ -11,6 +11,10 @@ import {
 } from '../public-channel-records.ts'
 import type { CloudPrincipal } from '../session-service.ts'
 import {
+  resolveGatewayChannelBindingForProviderScope,
+  resolveGatewayChannelBindingScope,
+} from './channel-binding-scope.ts'
+import {
   assertChannelSetupAllowed,
   assertGatewayAccess,
   normalizedCloudListLimit,
@@ -181,6 +185,7 @@ export async function resolveChannelIdentity(
   principal: CloudPrincipal,
   input: {
     provider: ChannelProviderId
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     externalUserId: string
     identityId?: string | null
@@ -193,18 +198,24 @@ export async function resolveChannelIdentity(
   await options.ensurePrincipal(principal)
   assertGatewayAccess(principal)
   const orgId = options.principalOrgId(principal)
+  const setupAllowed = principalCanManageChannels(principal)
+  let externalWorkspaceId = input.externalWorkspaceId
+  if (!setupAllowed) {
+    const channelBinding = await resolveGatewayChannelBindingForProviderScope(options, principal, input, 'Channel identity resolution')
+    await resolveGatewayChannelBindingScope(options, principal, [channelBinding.bindingId])
+    externalWorkspaceId = input.externalWorkspaceId === undefined ? channelBinding.externalWorkspaceId : input.externalWorkspaceId
+  }
   const existing = await options.store.findChannelIdentity({
     orgId,
     provider: input.provider,
-    externalWorkspaceId: input.externalWorkspaceId,
+    externalWorkspaceId,
     externalUserId: input.externalUserId,
   })
-  const setupAllowed = principalCanManageChannels(principal)
   return options.store.upsertChannelIdentity({
     identityId: existing?.identityId || input.identityId || options.ids.randomUUID(),
     orgId,
     provider: input.provider,
-    externalWorkspaceId: input.externalWorkspaceId,
+    externalWorkspaceId,
     externalUserId: input.externalUserId,
     accountId: setupAllowed ? input.accountId : existing?.accountId,
     role: setupAllowed ? input.role || existing?.role || 'viewer' : existing?.role || 'viewer',

--- a/apps/desktop/src/main/cloud/services/channel-binding-scope.ts
+++ b/apps/desktop/src/main/cloud/services/channel-binding-scope.ts
@@ -1,0 +1,99 @@
+import { CloudServiceError } from '../cloud-service-error.ts'
+import type {
+  ChannelBindingRecord,
+  ChannelProviderId,
+} from '../control-plane-store.ts'
+import type { CloudPrincipal } from '../session-service.ts'
+import {
+  assertGatewayAccess,
+  principalCanManageChannels,
+  type CloudChannelDomainServiceOptions,
+} from './channel-domain-context.ts'
+
+export type GatewayChannelBindingScope = {
+  gatewayTokenId: string | null
+  channelBindingIds: readonly string[] | null
+}
+
+export async function resolveGatewayChannelBindingScope(
+  options: CloudChannelDomainServiceOptions,
+  principal: CloudPrincipal,
+  requestedChannelBindingIds?: readonly string[] | null,
+): Promise<GatewayChannelBindingScope> {
+  const requested = normalizeRequestedChannelBindingIds(requestedChannelBindingIds)
+  if (principalCanManageChannels(principal)) {
+    return {
+      gatewayTokenId: null,
+      channelBindingIds: requested.length > 0 ? requested : null,
+    }
+  }
+  assertGatewayAccess(principal)
+  if (principal.authSource !== 'api_token' || !principal.tokenId) {
+    throw new CloudServiceError(403, 'Gateway channel operations require a gateway API token.')
+  }
+  const grants = await options.store.listApiTokenChannelBindingGrants({
+    orgId: options.principalOrgId(principal),
+    tokenId: principal.tokenId,
+  })
+  const allowed = [...new Set(grants.map((grant) => grant.channelBindingId))].sort()
+  if (allowed.length === 0) {
+    throw new CloudServiceError(403, 'Gateway API token is not authorized for any channel bindings.')
+  }
+  if (requested.length > 0) {
+    const ungranted = requested.filter((channelBindingId) => !allowed.includes(channelBindingId))
+    if (ungranted.length > 0) {
+      throw new CloudServiceError(403, 'Gateway API token is not authorized for one or more requested channel bindings.')
+    }
+  }
+  return {
+    gatewayTokenId: principal.tokenId,
+    channelBindingIds: requested.length > 0 ? requested : allowed,
+  }
+}
+
+export async function resolveGatewayChannelBindingForProviderScope(
+  options: CloudChannelDomainServiceOptions,
+  principal: CloudPrincipal,
+  input: {
+    provider: ChannelProviderId
+    channelBindingId?: string | null
+    externalWorkspaceId?: string | null
+  },
+  operationLabel = 'Gateway channel operation',
+): Promise<ChannelBindingRecord> {
+  const orgId = options.principalOrgId(principal)
+  const requestedWorkspaceId = input.externalWorkspaceId === undefined ? undefined : input.externalWorkspaceId || null
+  if (input.channelBindingId) {
+    const binding = await options.store.getChannelBinding(orgId, input.channelBindingId)
+    if (!binding) throw new CloudServiceError(404, 'Channel binding was not found.')
+    assertProviderScopedBindingMatches(binding, input.provider, requestedWorkspaceId)
+    return binding
+  }
+  const candidates = (await options.store.listChannelBindings(orgId))
+    .filter((binding) => {
+      if (binding.status !== 'active') return false
+      if (binding.provider !== input.provider) return false
+      return binding.externalWorkspaceId === (requestedWorkspaceId || null)
+    })
+  if (candidates.length === 0) throw new CloudServiceError(404, 'Channel binding was not found for gateway operation.')
+  if (candidates.length > 1) {
+    throw new CloudServiceError(400, `${operationLabel} requires channelBindingId when multiple channel bindings match.`)
+  }
+  return candidates[0]!
+}
+
+function normalizeRequestedChannelBindingIds(input: readonly string[] | null | undefined) {
+  return [...new Set((input || []).map((value) => value.trim()).filter(Boolean))]
+}
+
+function assertProviderScopedBindingMatches(
+  binding: ChannelBindingRecord,
+  provider: ChannelProviderId,
+  requestedWorkspaceId: string | null | undefined,
+) {
+  if (binding.status !== 'active') throw new CloudServiceError(403, 'Channel binding is not active.')
+  if (binding.provider !== provider) throw new CloudServiceError(400, 'Channel provider does not match binding.')
+  if (requestedWorkspaceId !== undefined && binding.externalWorkspaceId !== requestedWorkspaceId) {
+    throw new CloudServiceError(403, 'Channel binding is not authorized for this provider workspace.')
+  }
+}

--- a/apps/desktop/src/main/cloud/services/channel-delivery-actions.ts
+++ b/apps/desktop/src/main/cloud/services/channel-delivery-actions.ts
@@ -8,8 +8,8 @@ import {
   type PublicChannelDeliveryRecord,
 } from '../public-channel-records.ts'
 import type { CloudPrincipal } from '../session-service.ts'
+import { resolveGatewayChannelBindingScope as deliveryOperatorScope } from './channel-binding-scope.ts'
 import {
-  assertChannelSetupAllowed,
   assertGatewayAccess,
   CHANNEL_HOUR_MS,
   type CloudChannelDomainServiceOptions,
@@ -44,6 +44,7 @@ export async function createChannelDelivery(
   if (channelBinding.provider !== input.provider) {
     throw new CloudServiceError(400, 'Channel delivery provider does not match the channel binding.')
   }
+  await deliveryOperatorScope(options, principal, [channelBinding.bindingId])
   if (input.sessionBindingId) {
     const sessionBinding = await options.store.getChannelSessionBinding(orgId, input.sessionBindingId)
     if (!sessionBinding) throw new CloudServiceError(404, 'Channel session binding was not found.')
@@ -75,17 +76,20 @@ export async function listChannelDeliveries(
   options: CloudChannelDomainServiceOptions,
   principal: CloudPrincipal,
   input: {
+    deliveryId?: string | null
     status?: ChannelDeliveryRecord['status'] | null
     channelBindingId?: string | null
     limit?: number | null
   } = {},
 ): Promise<PublicChannelDeliveryRecord[]> {
   await options.ensurePrincipal(principal)
-  assertGatewayAccess(principal)
+  const scope = await deliveryOperatorScope(options, principal, input.channelBindingId ? [input.channelBindingId] : null)
   return (await options.store.listChannelDeliveries({
     orgId: options.principalOrgId(principal),
+    deliveryId: input.deliveryId || null,
     status: input.status || null,
-    channelBindingId: input.channelBindingId || null,
+    channelBindingIds: scope.channelBindingIds,
+    lastClaimedBy: scope.gatewayTokenId,
     limit: input.limit || null,
   })).map(publicChannelDelivery)
 }
@@ -96,10 +100,12 @@ export async function retryChannelDelivery(
   deliveryId: string,
 ): Promise<PublicChannelDeliveryRecord | null> {
   await options.ensurePrincipal(principal)
-  assertChannelSetupAllowed(principal)
+  const scope = await deliveryOperatorScope(options, principal)
   const delivery = await options.store.ackChannelDelivery({
     orgId: options.principalOrgId(principal),
     deliveryId,
+    channelBindingIds: scope.channelBindingIds,
+    lastClaimedBy: scope.gatewayTokenId,
     status: 'failed',
     lastError: null,
     nextAttemptAt: new Date(),
@@ -113,10 +119,12 @@ export async function deadLetterChannelDelivery(
   input: { deliveryId: string, lastError?: string | null },
 ): Promise<PublicChannelDeliveryRecord | null> {
   await options.ensurePrincipal(principal)
-  assertChannelSetupAllowed(principal)
+  const scope = await deliveryOperatorScope(options, principal)
   const delivery = await options.store.ackChannelDelivery({
     orgId: options.principalOrgId(principal),
     deliveryId: input.deliveryId,
+    channelBindingIds: scope.channelBindingIds,
+    lastClaimedBy: scope.gatewayTokenId,
     status: 'dead',
     lastError: input.lastError || 'Manually dead-lettered by gateway operator.',
     nextAttemptAt: null,
@@ -127,10 +135,11 @@ export async function deadLetterChannelDelivery(
 export async function claimNextChannelDelivery(
   options: CloudChannelDomainServiceOptions,
   principal: CloudPrincipal,
-  input: { claimedBy: string, ttlMs?: number, now?: Date },
+  input: { claimedBy: string, ttlMs?: number, now?: Date, channelBindingIds?: readonly string[] | null },
 ): Promise<ChannelDeliveryRecord | null> {
   await options.ensurePrincipal(principal)
   assertGatewayAccess(principal)
+  const scope = await deliveryOperatorScope(options, principal, input.channelBindingIds)
   try {
     const gatewayDeliveryLimit = await options.usageGovernance.effectiveQuotaLimit(
       options.principalOrgId(principal),
@@ -140,6 +149,8 @@ export async function claimNextChannelDelivery(
     const delivery = await options.store.claimNextChannelDelivery({
       orgId: options.principalOrgId(principal),
       claimedBy: input.claimedBy,
+      lastClaimedBy: scope.gatewayTokenId,
+      channelBindingIds: scope.channelBindingIds,
       ttlMs: input.ttlMs,
       now: input.now,
       quota: options.usageGovernance.quotaLimit(gatewayDeliveryLimit)
@@ -183,9 +194,12 @@ export async function ackChannelDelivery(
 ): Promise<PublicChannelDeliveryRecord | null> {
   await options.ensurePrincipal(principal)
   assertGatewayAccess(principal)
+  const scope = await deliveryOperatorScope(options, principal)
   const delivery = await options.store.ackChannelDelivery({
     orgId: options.principalOrgId(principal),
     deliveryId: input.deliveryId,
+    channelBindingIds: scope.channelBindingIds,
+    lastClaimedBy: scope.gatewayTokenId,
     claimedBy: input.claimedBy,
     status: input.status,
     lastError: input.lastError,

--- a/apps/desktop/src/main/cloud/services/channel-domain-service.ts
+++ b/apps/desktop/src/main/cloud/services/channel-domain-service.ts
@@ -116,6 +116,7 @@ export class CloudChannelDomainService {
     principal: CloudPrincipal,
     input: {
       provider: ChannelProviderId
+      channelBindingId?: string | null
       externalWorkspaceId?: string | null
       externalUserId: string
       identityId?: string | null
@@ -227,6 +228,7 @@ export class CloudChannelDomainService {
   listChannelDeliveries(
     principal: CloudPrincipal,
     input: {
+      deliveryId?: string | null
       status?: ChannelDeliveryRecord['status'] | null
       channelBindingId?: string | null
       limit?: number | null
@@ -248,7 +250,7 @@ export class CloudChannelDomainService {
 
   claimNextChannelDelivery(
     principal: CloudPrincipal,
-    input: { claimedBy: string, ttlMs?: number, now?: Date },
+    input: { claimedBy: string, ttlMs?: number, now?: Date, channelBindingIds?: readonly string[] | null },
   ): Promise<ChannelDeliveryRecord | null> {
     return deliveryActions.claimNextChannelDelivery(this.options, principal, input)
   }
@@ -271,6 +273,7 @@ export class CloudChannelDomainService {
     input: {
       provider: ChannelProviderId
       providerInstanceId: string
+      channelBindingId?: string | null
       externalWorkspaceId?: string | null
       providerEventId: string
       eventType: ChannelProviderEventType
@@ -286,6 +289,7 @@ export class CloudChannelDomainService {
     principal: CloudPrincipal,
     input: {
       eventId: string
+      channelBindingId?: string | null
       claimedBy: string
       status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
       retryable?: boolean

--- a/apps/desktop/src/main/cloud/services/channel-provider-event-actions.ts
+++ b/apps/desktop/src/main/cloud/services/channel-provider-event-actions.ts
@@ -6,6 +6,10 @@ import type {
 } from '../control-plane-store.ts'
 import type { CloudPrincipal } from '../session-service.ts'
 import {
+  resolveGatewayChannelBindingForProviderScope,
+  resolveGatewayChannelBindingScope,
+} from './channel-binding-scope.ts'
+import {
   assertGatewayAccess,
   type CloudChannelDomainServiceOptions,
 } from './channel-domain-context.ts'
@@ -16,6 +20,7 @@ export async function claimChannelProviderEvent(
   input: {
     provider: ChannelProviderId
     providerInstanceId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     providerEventId: string
     eventType: ChannelProviderEventType
@@ -26,16 +31,19 @@ export async function claimChannelProviderEvent(
 ): Promise<ChannelProviderEventClaimResult> {
   await options.ensurePrincipal(principal)
   assertGatewayAccess(principal)
+  const channelBinding = await resolveGatewayChannelBindingForProviderScope(options, principal, input, 'Provider event claim')
+  await resolveGatewayChannelBindingScope(options, principal, [channelBinding.bindingId])
   return options.store.claimChannelProviderEvent({
     orgId: options.principalOrgId(principal),
     provider: input.provider,
     providerInstanceId: input.providerInstanceId,
-    externalWorkspaceId: input.externalWorkspaceId,
+    channelBindingId: channelBinding.bindingId,
+    externalWorkspaceId: input.externalWorkspaceId === undefined ? channelBinding.externalWorkspaceId : input.externalWorkspaceId,
     providerEventId: input.providerEventId,
     eventType: input.eventType,
     claimedBy: input.claimedBy,
     ttlMs: input.ttlMs || undefined,
-    metadata: input.metadata || {},
+    metadata: { ...(input.metadata || {}), channelBindingId: channelBinding.bindingId },
   })
 }
 
@@ -44,6 +52,7 @@ export async function completeChannelProviderEvent(
   principal: CloudPrincipal,
   input: {
     eventId: string
+    channelBindingId?: string | null
     claimedBy: string
     status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
     retryable?: boolean
@@ -52,9 +61,15 @@ export async function completeChannelProviderEvent(
 ): Promise<ChannelProviderEventRecord | null> {
   await options.ensurePrincipal(principal)
   assertGatewayAccess(principal)
+  const scope = await resolveGatewayChannelBindingScope(
+    options,
+    principal,
+    input.channelBindingId ? [input.channelBindingId] : null,
+  )
   return options.store.completeChannelProviderEvent({
     orgId: options.principalOrgId(principal),
     eventId: input.eventId,
+    channelBindingIds: scope.channelBindingIds,
     claimedBy: input.claimedBy,
     status: input.status,
     retryable: input.retryable,

--- a/apps/desktop/src/main/cloud/services/channel-service.ts
+++ b/apps/desktop/src/main/cloud/services/channel-service.ts
@@ -60,6 +60,7 @@ export type CloudChannelServiceDelegate = {
   resolveChannelIdentity(principal: CloudPrincipal, input: {
     identityId?: string | null
     provider: ChannelProviderId
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     externalUserId: string
     accountId?: string | null
@@ -136,13 +137,14 @@ export type CloudChannelServiceDelegate = {
     deliveryId?: string | null
   }): Promise<PublicChannelDeliveryRecord>
   listChannelDeliveries(principal: CloudPrincipal, input?: {
+    deliveryId?: string | null
     status?: ChannelDeliveryRecord['status'] | null
     channelBindingId?: string | null
     limit?: number | null
   }): Promise<PublicChannelDeliveryRecord[]>
   retryChannelDelivery(principal: CloudPrincipal, deliveryId: string): Promise<PublicChannelDeliveryRecord | null>
   deadLetterChannelDelivery(principal: CloudPrincipal, input: { deliveryId: string, lastError?: string | null }): Promise<PublicChannelDeliveryRecord | null>
-  claimNextChannelDelivery(principal: CloudPrincipal, input: { claimedBy: string, now?: Date, ttlMs?: number }): Promise<ChannelDeliveryRecord | null>
+  claimNextChannelDelivery(principal: CloudPrincipal, input: { claimedBy: string, now?: Date, ttlMs?: number, channelBindingIds?: readonly string[] | null }): Promise<ChannelDeliveryRecord | null>
   ackChannelDelivery(principal: CloudPrincipal, input: {
     deliveryId: string
     claimedBy?: string | null
@@ -153,6 +155,7 @@ export type CloudChannelServiceDelegate = {
   claimChannelProviderEvent(principal: CloudPrincipal, input: {
     provider: ChannelProviderId
     providerInstanceId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     providerEventId: string
     eventType: ChannelProviderEventType
@@ -162,6 +165,7 @@ export type CloudChannelServiceDelegate = {
   }): Promise<ChannelProviderEventClaimResult>
   completeChannelProviderEvent(principal: CloudPrincipal, input: {
     eventId: string
+    channelBindingId?: string | null
     claimedBy: string
     status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
     retryable?: boolean

--- a/apps/desktop/src/main/cloud/services/channel-session-actions.ts
+++ b/apps/desktop/src/main/cloud/services/channel-session-actions.ts
@@ -10,6 +10,7 @@ import type {
   CloudPrincipal,
   CloudSessionView,
 } from '../session-service.ts'
+import { resolveGatewayChannelBindingScope } from './channel-binding-scope.ts'
 import {
   assertGatewayAccess,
   CHANNEL_HOUR_MS,
@@ -40,6 +41,7 @@ export async function bindChannelSession(
   if (!channelBinding) throw new CloudServiceError(404, 'Channel binding was not found.')
   if (channelBinding.status !== 'active') throw new CloudServiceError(403, 'Channel binding is not active.')
   if (channelBinding.provider !== input.provider) throw new CloudServiceError(400, 'Channel provider does not match binding.')
+  await resolveGatewayChannelBindingScope(options, principal, [channelBinding.bindingId])
   const actor = await requireChannelActor(options, principal, input, 'prompt', {
     provider: channelBinding.provider,
     externalWorkspaceId: channelBinding.externalWorkspaceId,
@@ -142,14 +144,16 @@ export async function getChannelSessionByThread(
 ): Promise<{ binding: ChannelSessionBindingRecord, session: CloudSessionView } | null> {
   await options.ensurePrincipal(principal)
   assertGatewayAccess(principal)
+  const orgId = options.principalOrgId(principal)
   const binding = await options.store.findChannelSessionBindingByThread({
-    orgId: options.principalOrgId(principal),
+    orgId,
     provider: input.provider,
     externalWorkspaceId: input.externalWorkspaceId,
     externalChatId: input.externalChatId,
     externalThreadId: input.externalThreadId,
   })
   if (!binding) return null
+  await resolveGatewayChannelBindingScope(options, principal, [binding.channelBindingId])
   const session = await options.store.getSession(principal.tenantId, principal.userId, binding.sessionId)
   if (!session) throw new CloudServiceError(403, 'Channel thread lookup requires a session owned by the gateway principal.')
   return {
@@ -173,8 +177,12 @@ export async function updateChannelCursor(
 ): Promise<ChannelCursorUpdateResult> {
   await options.ensurePrincipal(principal)
   assertGatewayAccess(principal)
+  const orgId = options.principalOrgId(principal)
+  const binding = await options.store.getChannelSessionBinding(orgId, input.bindingId)
+  if (!binding) return { ok: false, reason: 'not_found' }
+  await resolveGatewayChannelBindingScope(options, principal, [binding.channelBindingId])
   return options.store.updateChannelCursor({
-    orgId: options.principalOrgId(principal),
+    orgId,
     bindingId: input.bindingId,
     lastEventSequence: input.lastEventSequence,
     lastWorkspaceSequence: input.lastWorkspaceSequence,
@@ -199,6 +207,7 @@ export async function enqueueChannelPrompt(
   if (!binding || binding.status !== 'active') throw new CloudServiceError(404, 'Channel session binding was not found.')
   const channelBinding = await options.store.getChannelBinding(orgId, binding.channelBindingId)
   if (!channelBinding) throw new CloudServiceError(404, 'Channel binding was not found.')
+  await resolveGatewayChannelBindingScope(options, principal, [channelBinding.bindingId])
   const actor = await requireChannelActor(options, principal, input, 'prompt', {
     provider: binding.provider,
     externalWorkspaceId: channelBinding.externalWorkspaceId,

--- a/apps/desktop/src/main/cloud/services/identity-service.ts
+++ b/apps/desktop/src/main/cloud/services/identity-service.ts
@@ -14,8 +14,12 @@ export type CloudIdentityServiceDelegate = {
     name: string
     scopes: ApiTokenScope[]
     expiresAt?: Date | null
+    channelBindingIds?: readonly string[] | null
   }): Promise<IssuedPublicApiTokenRecord>
   revokeApiToken(principal: CloudPrincipal, tokenId: string): Promise<PublicApiTokenRecord | null>
+  grantApiTokenChannelBinding(principal: CloudPrincipal, tokenId: string, input: {
+    channelBindingId: string
+  }): Promise<{ grant: { orgId: string, tokenId: string, channelBindingId: string, createdAt: string }, token: PublicApiTokenRecord }>
 }
 
 export class CloudIdentityService {
@@ -41,11 +45,16 @@ export class CloudIdentityService {
     name: string
     scopes: ApiTokenScope[]
     expiresAt?: Date | null
+    channelBindingIds?: readonly string[] | null
   }) {
     return this.delegate.issueApiToken(principal, input)
   }
 
   revokeApiToken(principal: CloudPrincipal, tokenId: string) {
     return this.delegate.revokeApiToken(principal, tokenId)
+  }
+
+  grantApiTokenChannelBinding(principal: CloudPrincipal, tokenId: string, input: { channelBindingId: string }) {
+    return this.delegate.grantApiTokenChannelBinding(principal, tokenId, input)
   }
 }

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -34,6 +34,7 @@ import {
 import { InvalidSessionPageCursorError } from './control-plane-store.ts'
 import type {
   ApiTokenScope,
+  ApiTokenRecord,
   BillingSubscriptionRecord,
   ChannelBindingRecord,
   ChannelDeliveryRecord,
@@ -1494,6 +1495,7 @@ export class CloudSessionService {
     principal: CloudPrincipal,
     input: {
       provider: ChannelProviderId
+      channelBindingId?: string | null
       externalWorkspaceId?: string | null
       externalUserId: string
       identityId?: string | null
@@ -1605,6 +1607,7 @@ export class CloudSessionService {
   async listChannelDeliveries(
     principal: CloudPrincipal,
     input: {
+      deliveryId?: string | null
       status?: ChannelDeliveryRecord['status'] | null
       channelBindingId?: string | null
       limit?: number | null
@@ -1629,7 +1632,7 @@ export class CloudSessionService {
 
   async claimNextChannelDelivery(
     principal: CloudPrincipal,
-    input: { claimedBy: string, ttlMs?: number, now?: Date },
+    input: { claimedBy: string, ttlMs?: number, now?: Date, channelBindingIds?: readonly string[] | null },
   ): Promise<ChannelDeliveryRecord | null> {
     return this.channelDomain.claimNextChannelDelivery(principal, input)
   }
@@ -1652,6 +1655,7 @@ export class CloudSessionService {
     input: {
       provider: ChannelProviderId
       providerInstanceId: string
+      channelBindingId?: string | null
       externalWorkspaceId?: string | null
       providerEventId: string
       eventType: ChannelProviderEventType
@@ -1667,6 +1671,7 @@ export class CloudSessionService {
     principal: CloudPrincipal,
     input: {
       eventId: string
+      channelBindingId?: string | null
       claimedBy: string
       status: Extract<ChannelProviderEventRecord['status'], 'processed' | 'failed'>
       retryable?: boolean
@@ -2290,7 +2295,7 @@ export class CloudSessionService {
     this.assertApiTokenAdmin(principal)
     const tokens = (await this.store.listApiTokens(this.principalOrgId(principal)))
       .slice(0, normalizedCloudListLimit(input.limit))
-    return tokens.map(publicApiToken)
+    return Promise.all(tokens.map((token) => this.publicApiTokenWithChannelBindings(token)))
   }
 
   async issueApiToken(
@@ -2299,11 +2304,13 @@ export class CloudSessionService {
       name: string
       scopes: ApiTokenScope[]
       expiresAt?: Date | null
+      channelBindingIds?: readonly string[] | null
     },
   ): Promise<IssuedPublicApiTokenRecord> {
     await this.ensurePrincipal(principal)
     this.assertApiTokenAdmin(principal)
     const scopes = enforceApiTokenScopePolicy(normalizeApiTokenScopes(input.scopes), this.identityPolicy)
+    const channelBindingIds = await this.normalizeApiTokenChannelBindingIds(principal, input.channelBindingIds, scopes)
     const issued = await this.store.issueApiToken({
       orgId: this.principalOrgId(principal),
       accountId: principal.accountId || principal.userId,
@@ -2316,8 +2323,20 @@ export class CloudSessionService {
         accountId: principal.accountId || principal.userId,
       },
     })
+    for (const channelBindingId of channelBindingIds) {
+      await this.store.grantApiTokenChannelBinding({
+        orgId: this.principalOrgId(principal),
+        tokenId: issued.token.tokenId,
+        channelBindingId,
+        actor: {
+          actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+          actorId: principal.tokenId || principal.userId,
+          accountId: principal.accountId || principal.userId,
+        },
+      })
+    }
     return {
-      token: publicApiToken(issued.token),
+      token: publicApiToken(issued.token, channelBindingIds),
       plaintext: issued.plaintext,
     }
   }
@@ -2334,7 +2353,37 @@ export class CloudSessionService {
         accountId: principal.accountId || principal.userId,
       },
     })
-    return revoked ? publicApiToken(revoked) : null
+    return revoked ? this.publicApiTokenWithChannelBindings(revoked) : null
+  }
+
+  async grantApiTokenChannelBinding(
+    principal: CloudPrincipal,
+    tokenId: string,
+    input: { channelBindingId: string },
+  ): Promise<{ grant: { orgId: string, tokenId: string, channelBindingId: string, createdAt: string }, token: PublicApiTokenRecord }> {
+    await this.ensurePrincipal(principal)
+    this.assertApiTokenAdmin(principal)
+    const orgId = this.principalOrgId(principal)
+    const token = (await this.store.listApiTokens(orgId)).find((candidate) => candidate.tokenId === tokenId)
+    if (!token) throw new CloudServiceError(404, 'API token was not found.')
+    if (!token.scopes.includes('gateway')) {
+      throw new CloudServiceError(400, 'Channel binding grants require a gateway-scoped API token.')
+    }
+    const channelBindingId = await this.normalizeSingleApiTokenChannelBindingId(principal, input.channelBindingId)
+    const grant = await this.store.grantApiTokenChannelBinding({
+      orgId,
+      tokenId,
+      channelBindingId,
+      actor: {
+        actorType: principal.authSource === 'api_token' ? 'api_token' : 'user',
+        actorId: principal.tokenId || principal.userId,
+        accountId: principal.accountId || principal.userId,
+      },
+    })
+    return {
+      grant,
+      token: await this.publicApiTokenWithChannelBindings(token),
+    }
   }
 
   async getBillingSubscription(principal: CloudPrincipal) {
@@ -3406,6 +3455,39 @@ export class CloudSessionService {
       input,
       resolveActorWorkspaceMember: () => this.principalIsActiveWorkspaceMember(principal),
     })
+  }
+
+  private async publicApiTokenWithChannelBindings(token: ApiTokenRecord): Promise<PublicApiTokenRecord> {
+    const grants = await this.store.listApiTokenChannelBindingGrants({
+      orgId: token.orgId,
+      tokenId: token.tokenId,
+    })
+    return publicApiToken(token, grants.map((grant) => grant.channelBindingId))
+  }
+
+  private async normalizeApiTokenChannelBindingIds(
+    principal: CloudPrincipal,
+    input: readonly string[] | null | undefined,
+    scopes: ApiTokenScope[],
+  ): Promise<string[]> {
+    const ids = [...new Set((input || []).map((value) => value.trim()).filter(Boolean))]
+    if (ids.length === 0) return []
+    if (!scopes.includes('gateway')) {
+      throw new CloudServiceError(400, 'Channel binding grants require a gateway-scoped API token.')
+    }
+    const normalized: string[] = []
+    for (const channelBindingId of ids) {
+      normalized.push(await this.normalizeSingleApiTokenChannelBindingId(principal, channelBindingId))
+    }
+    return normalized
+  }
+
+  private async normalizeSingleApiTokenChannelBindingId(principal: CloudPrincipal, input: string): Promise<string> {
+    const channelBindingId = input.trim()
+    if (!channelBindingId) throw new CloudServiceError(400, 'Channel binding id is required.')
+    const binding = await this.store.getChannelBinding(this.principalOrgId(principal), channelBindingId)
+    if (!binding) throw new CloudServiceError(404, 'Channel binding was not found.')
+    return binding.bindingId
   }
 
   private assertBillingAdmin(principal: CloudPrincipal) {

--- a/apps/gateway/src/cloud-gateway.test.ts
+++ b/apps/gateway/src/cloud-gateway.test.ts
@@ -98,8 +98,15 @@ test('cloud gateway wraps all required channel and session operations', async ()
       input.onEvent({ eventId: 'event-1', sequence: 1, type: 'assistant.message', payload: {} })
       return { close() { sessionClosed = true } }
     },
-    subscribeChannelDeliveries(input: { onDelivery: (delivery: unknown) => void }) {
-      calls.push('deliveries')
+    subscribeChannelDeliveries(input: {
+      claimedBy?: string
+      channelBindingIds?: readonly string[]
+      onDelivery: (delivery: unknown) => void
+    }) {
+      calls.push(`deliveries:${JSON.stringify({
+        claimedBy: input.claimedBy,
+        channelBindingIds: input.channelBindingIds,
+      })}`)
       input.onDelivery({ deliveryId: 'delivery-1' })
       return { close() { deliveriesClosed = true } }
     },
@@ -141,7 +148,11 @@ test('cloud gateway wraps all required channel and session operations', async ()
   await gateway.readArtifactAttachment?.('session-1', 'artifact-1')
   assert.equal(gateway.artifactUrl('session-1', 'artifact-1'), 'https://cloud.example.test/api/sessions/session-1/artifacts/artifact-1')
   const sessionEvents = gateway.subscribeSessionEvents({ sessionId: 'session-1', onEvent() {} })
-  const deliveries = gateway.subscribeDeliveries({ onDelivery() {} })
+  const deliveries = gateway.subscribeDeliveries({
+    claimedBy: 'gateway:test',
+    channelBindingIds: ['channel-binding-1'],
+    onDelivery() {},
+  })
   await gateway.updateCursor({ bindingId: 'binding-1', lastEventSequence: 5, lastWorkspaceSequence: 7 })
   await gateway.ackDelivery('delivery-1', { status: 'sent' })
   sessionEvents.close()
@@ -173,4 +184,5 @@ test('cloud gateway wraps all required channel and session operations', async ()
     'cursor',
     'ack',
   ])
+  assert.equal(calls.some((call) => call === 'deliveries:{"claimedBy":"gateway:test","channelBindingIds":["channel-binding-1"]}'), true)
 })

--- a/apps/gateway/src/cloud-gateway.ts
+++ b/apps/gateway/src/cloud-gateway.ts
@@ -28,6 +28,7 @@ export type CloudGateway = {
   resolveIdentity(input: {
     provider: CloudChannelProviderId
     externalUserId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     metadata?: Record<string, unknown>
   }): Promise<ChannelIdentityRecord>
@@ -55,6 +56,7 @@ export type CloudGateway = {
   claimProviderEvent(input: {
     provider: CloudChannelProviderId
     providerInstanceId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     providerEventId: string
     eventType: CloudChannelProviderEventType
@@ -63,6 +65,7 @@ export type CloudGateway = {
     metadata?: Record<string, unknown>
   }): Promise<ChannelProviderEventClaimResult>
   completeProviderEvent(eventId: string, input: {
+    channelBindingId?: string | null
     claimedBy: string
     status: Extract<CloudChannelProviderEventStatus, 'processed' | 'failed'>
     retryable?: boolean
@@ -101,6 +104,7 @@ export type CloudGateway = {
   subscribeDeliveries(input: {
     claimedBy?: string
     ttlMs?: number
+    channelBindingIds?: readonly string[]
     onDelivery: (delivery: ChannelDeliveryRecord) => void
     onError?: (error: unknown) => void
   }): CloudTransportSubscription
@@ -117,6 +121,7 @@ export type CloudGateway = {
     nextAttemptAt?: string | null
   }): Promise<ChannelDeliveryRecord | null>
   listDeliveries?(input?: {
+    deliveryId?: string | null
     status?: ChannelDeliveryRecord['status'] | null
     channelBindingId?: string | null
     limit?: number | null

--- a/apps/gateway/src/daemon.test.ts
+++ b/apps/gateway/src/daemon.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@open-cowork/gateway-provider-webhook'
 import type { CloudGateway } from '../dist/index.js'
 import {
+  createGatewayDaemon,
   createGatewayHttpServer,
   createGatewayProviderRegistry,
   createGatewayRuntime,
@@ -36,6 +37,37 @@ function signedWebhookHeaders(rawBody: string, sharedSecret: string, timestamp =
     'x-open-cowork-gateway-webhook-signature': `v1=${createHmac('sha256', sharedSecret).update(`v1:${timestamp}:${rawBody}`).digest('hex')}`,
   }
 }
+
+test('gateway daemon default cloud client uses the resolved config instead of process env', () => {
+  const previousBaseUrl = process.env.OPEN_COWORK_CLOUD_BASE_URL
+  const previousServiceToken = process.env.OPEN_COWORK_GATEWAY_SERVICE_TOKEN
+  const config = resolveGatewayConfigBase({
+    server: {
+      port: 0,
+      adminToken: 'admin-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://configured-cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'configured-service-token',
+  })
+  try {
+    delete process.env.OPEN_COWORK_CLOUD_BASE_URL
+    delete process.env.OPEN_COWORK_GATEWAY_SERVICE_TOKEN
+    const daemon = createGatewayDaemon(config)
+    assert.equal(daemon.config.cloud.baseUrl, 'https://configured-cloud.example.test')
+    assert.equal(daemon.config.cloud.serviceToken, 'configured-service-token')
+  } finally {
+    if (previousBaseUrl === undefined) delete process.env.OPEN_COWORK_CLOUD_BASE_URL
+    else process.env.OPEN_COWORK_CLOUD_BASE_URL = previousBaseUrl
+    if (previousServiceToken === undefined) delete process.env.OPEN_COWORK_GATEWAY_SERVICE_TOKEN
+    else process.env.OPEN_COWORK_GATEWAY_SERVICE_TOKEN = previousServiceToken
+  }
+})
 
 function providerEventRecord(input: {
   provider: string
@@ -221,6 +253,7 @@ test('gateway daemon exposes health, readiness, metrics, diagnostics, and fake w
     assert.equal(webhook.status, 202)
     assert.deepEqual(prompted, ['ship it'])
     assert.equal(runtime.metrics.webhookRequests, 1)
+    assert.equal(runtime.metrics.providerMetrics.fake?.webhookRequests, 1)
   } finally {
     await http.close()
     await runtime.stop()
@@ -773,6 +806,7 @@ test('gateway diagnostics redact provider health errors', async () => {
     assert.equal(text.includes('alice@example.test'), false)
     assert.equal(text.includes('/Users/alice'), false)
     assert.match(text, /Bearer \[redacted\]/)
+    assert.equal(((diagnostics.metrics as { providerMetrics: Record<string, { state: string }> }).providerMetrics.fake)?.state, 'unhealthy')
   } finally {
     await http.close()
     await runtime.stop()
@@ -903,6 +937,15 @@ test('gateway operator endpoints require the admin token when configured', async
       headers: { 'x-open-cowork-gateway-admin-token': 'admin-token' },
     })
     assert.equal(diagnostics.status, 200)
+    const diagnosticsBody = await readJson(diagnostics)
+    assert.deepEqual(diagnosticsBody.deliveryOperator, {
+      scope: 'configured-channel-bindings',
+      channelBindingIds: ['fake-binding'],
+      listAllowed: true,
+      retryAllowed: false,
+      deadLetterAllowed: false,
+      disabledReason: 'Cloud delivery retry is not available. Cloud delivery dead-letter is not available.',
+    })
     const deliveries = await fetch(`${url}/deliveries`, {
       headers: { authorization: 'Bearer admin-token' },
     })
@@ -1539,8 +1582,12 @@ test('gateway daemon exposes admin delivery backlog controls', async () => {
   const cloud = {
     subscribeDeliveries() { return { close() {} } },
     async listDeliveries(input) {
-      calls.push(`list:${input.status}`)
-      return [deliveryRecord({ deliveryId: 'delivery-1' })]
+      calls.push(`list:${input.deliveryId || ''}:${input.status || ''}:${input.channelBindingId}`)
+      if (input.deliveryId && input.deliveryId !== `delivery-${input.channelBindingId}`) return []
+      return [deliveryRecord({
+        deliveryId: `delivery-${input.channelBindingId}`,
+        channelBindingId: input.channelBindingId,
+      })]
     },
     async retryDelivery(deliveryId: string) {
       calls.push(`retry:${deliveryId}`)
@@ -1559,6 +1606,10 @@ test('gateway daemon exposes admin delivery backlog controls', async () => {
       id: 'fake',
       kind: 'fake',
       channelBindingId: 'fake-binding',
+    }, {
+      id: 'fake-secondary',
+      kind: 'fake',
+      channelBindingId: 'secondary-binding',
     }],
   }, {
     OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
@@ -1575,9 +1626,21 @@ test('gateway daemon exposes admin delivery backlog controls', async () => {
   try {
     const listed = await readJson(await fetch(`${url}/deliveries?status=failed`, { headers: auth }))
     assert.equal(Array.isArray(listed.deliveries), true)
-    const retried = await readJson(await fetch(`${url}/deliveries/delivery-1/retry`, { method: 'POST', headers: auth }))
-    assert.equal((retried.delivery as { deliveryId: string }).deliveryId, 'delivery-1')
-    const dead = await readJson(await fetch(`${url}/deliveries/delivery-1/dead-letter`, {
+    assert.deepEqual((listed.deliveries as Array<{ deliveryId: string }>).map((delivery) => delivery.deliveryId), [
+      'delivery-fake-binding',
+      'delivery-secondary-binding',
+    ])
+    const filtered = await readJson(await fetch(`${url}/deliveries?status=failed&channelBindingId=secondary-binding`, { headers: auth }))
+    assert.deepEqual((filtered.deliveries as Array<{ deliveryId: string }>).map((delivery) => delivery.deliveryId), [
+      'delivery-secondary-binding',
+    ])
+    const unrelated = await readJson(await fetch(`${url}/deliveries?status=failed&channelBindingId=unconfigured-binding`, { headers: auth }))
+    assert.deepEqual(unrelated.deliveries, [])
+    const blockedRetry = await fetch(`${url}/deliveries/delivery-unconfigured/retry`, { method: 'POST', headers: auth })
+    assert.equal(blockedRetry.status, 404)
+    const retried = await readJson(await fetch(`${url}/deliveries/delivery-fake-binding/retry`, { method: 'POST', headers: auth }))
+    assert.equal((retried.delivery as { deliveryId: string }).deliveryId, 'delivery-fake-binding')
+    const dead = await readJson(await fetch(`${url}/deliveries/delivery-fake-binding/dead-letter`, {
       method: 'POST',
       headers: {
         ...auth,
@@ -1585,8 +1648,20 @@ test('gateway daemon exposes admin delivery backlog controls', async () => {
       },
       body: JSON.stringify({ lastError: 'operator stop' }),
     }))
-    assert.equal((dead.delivery as { deliveryId: string }).deliveryId, 'delivery-1')
-    assert.deepEqual(calls, ['list:failed', 'retry:delivery-1', 'dead:delivery-1:operator stop'])
+    assert.equal((dead.delivery as { deliveryId: string }).deliveryId, 'delivery-fake-binding')
+    assert.deepEqual(calls, [
+      'list::failed:fake-binding',
+      'list::failed:secondary-binding',
+      'list::failed:secondary-binding',
+      'list:delivery-unconfigured::fake-binding',
+      'list:delivery-unconfigured::secondary-binding',
+      'list:delivery-fake-binding::fake-binding',
+      'list:delivery-fake-binding::secondary-binding',
+      'retry:delivery-fake-binding',
+      'list:delivery-fake-binding::fake-binding',
+      'list:delivery-fake-binding::secondary-binding',
+      'dead:delivery-fake-binding:operator stop',
+    ])
   } finally {
     await http.close()
     await runtime.stop()
@@ -1645,6 +1720,46 @@ test('gateway daemon rejects delivery admin controls without the admin token', a
     assert.deepEqual(calls, [])
   } finally {
     await http.close()
+    await runtime.stop()
+  }
+})
+
+test('gateway runtime subscribes only to enabled configured channel bindings', async () => {
+  let subscribed: { channelBindingIds?: readonly string[] } | null = null
+  const cloud = {
+    subscribeDeliveries(input: { channelBindingIds?: readonly string[] }) {
+      subscribed = input
+      return { close() {} }
+    },
+  } as CloudGateway
+  const config = resolveGatewayConfig({
+    server: {
+      adminToken: 'admin-token',
+    },
+    providers: [{
+      id: 'fake',
+      kind: 'fake',
+      channelBindingId: 'fake-binding',
+    }, {
+      id: 'fake-secondary',
+      kind: 'fake',
+      channelBindingId: 'secondary-binding',
+    }, {
+      id: 'fake-disabled',
+      kind: 'fake',
+      enabled: false,
+      channelBindingId: 'disabled-binding',
+    }],
+  }, {
+    OPEN_COWORK_CLOUD_BASE_URL: 'https://cloud.example.test',
+    OPEN_COWORK_GATEWAY_SERVICE_TOKEN: 'service-token',
+  })
+  const runtime = createGatewayRuntime(config, cloud)
+
+  await runtime.start()
+  try {
+    assert.deepEqual(subscribed?.channelBindingIds, ['fake-binding', 'secondary-binding'])
+  } finally {
     await runtime.stop()
   }
 })
@@ -1881,13 +1996,14 @@ test('gateway runtime drains in-flight deliveries before provider shutdown', asy
 function deliveryRecord(overrides: Partial<{
   deliveryId: string
   attemptCount: number
+  channelBindingId: string
   payload: Record<string, unknown>
 }> = {}) {
   return {
     deliveryId: overrides.deliveryId || 'delivery-1',
     orgId: 'tenant-1',
     agentId: 'agent-1',
-    channelBindingId: 'fake-binding',
+    channelBindingId: overrides.channelBindingId || 'fake-binding',
     sessionBindingId: null,
     provider: 'cli',
     target: {
@@ -1899,6 +2015,7 @@ function deliveryRecord(overrides: Partial<{
     status: 'claimed',
     attemptCount: overrides.attemptCount ?? 1,
     claimedBy: 'gateway:test',
+    lastClaimedBy: 'gateway:test',
     claimExpiresAt: new Date(Date.now() + 30_000).toISOString(),
     nextAttemptAt: new Date(0).toISOString(),
     lastError: null,

--- a/apps/gateway/src/daemon.ts
+++ b/apps/gateway/src/daemon.ts
@@ -1,11 +1,12 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { timingSafeEqual } from 'node:crypto'
+import type { ChannelDeliveryRecord } from '@open-cowork/cloud-client'
 import { resolveHttpClientSource } from '@open-cowork/shared'
 
 import { createCloudGateway, type CloudGateway } from './cloud-gateway.js'
-import { type GatewayConfig, redactGatewayConfig, redactGatewayDiagnosticText, resolveGatewayCloudConnection } from './config.js'
+import { type GatewayConfig, redactGatewayConfig, redactGatewayDiagnosticText } from './config.js'
 import { createGatewayRuntime, type GatewayRuntime } from './gateway-runtime.js'
-import { renderPrometheusMetrics } from './metrics.js'
+import { ensureGatewayProviderMetrics, renderPrometheusMetrics } from './metrics.js'
 
 class GatewayHttpError extends Error {
   constructor(readonly status: number, message: string, readonly retryAfterMs?: number) {
@@ -103,7 +104,13 @@ export type GatewayDaemon = {
   stop(): Promise<void>
 }
 
-export function createGatewayDaemon(config: GatewayConfig, cloud: CloudGateway = createCloudGateway(resolveGatewayCloudConnection())): GatewayDaemon {
+export function createGatewayDaemon(
+  config: GatewayConfig,
+  cloud: CloudGateway = createCloudGateway({
+    ...config.cloud,
+    requestTimeoutMs: config.timeouts.cloudRequestMs,
+  }),
+): GatewayDaemon {
   const runtime = createGatewayRuntime(config, cloud)
   const http = createGatewayHttpServer(config, runtime, cloud)
 
@@ -213,6 +220,7 @@ async function handleRequest(
       writeJson(res, 401, { ok: false, error: 'Gateway admin authorization is required.' })
       return
     }
+    runtime.refreshProviderHealth()
     const body = renderPrometheusMetrics(runtime.metrics, runtime.providers.registrations.length, runtime.streams.activeCount())
     res.writeHead(200, { 'content-type': 'text/plain; version=0.0.4; charset=utf-8' })
     res.end(body)
@@ -234,6 +242,7 @@ async function handleRequest(
       ready: runtime.ready(),
       providers: providerStatus(runtime),
       metrics: runtime.metrics,
+      deliveryOperator: deliveryOperatorStatus(config, cloud),
     })
     return
   }
@@ -247,7 +256,8 @@ async function handleRequest(
       writeJson(res, 503, { ok: false, error: 'Cloud delivery listing is not available.' })
       return
     }
-    const deliveries = await cloud.listDeliveries({
+    const deliveries = await listConfiguredDeliveries(config, cloud, {
+      deliveryId: null,
       status: readDeliveryStatus(url.searchParams.get('status')),
       channelBindingId: url.searchParams.get('channelBindingId'),
       limit: readLimit(url.searchParams.get('limit'), 50),
@@ -264,9 +274,18 @@ async function handleRequest(
     }
     const deliveryId = decodeURIComponent(deliveryActionMatch[1] || '')
     const action = deliveryActionMatch[2]
+    if (!cloud?.listDeliveries) {
+      writeJson(res, 503, { ok: false, error: 'Cloud delivery listing is not available.' })
+      return
+    }
     if (action === 'retry') {
       if (!cloud?.retryDelivery) {
         writeJson(res, 503, { ok: false, error: 'Cloud delivery retry is not available.' })
+        return
+      }
+      const scopedDelivery = await findConfiguredDelivery(config, cloud, deliveryId)
+      if (!scopedDelivery) {
+        writeJson(res, 404, { ok: false, error: 'Delivery not found.' })
         return
       }
       const delivery = await cloud.retryDelivery(deliveryId)
@@ -282,6 +301,11 @@ async function handleRequest(
     const lastError = payload && typeof payload === 'object' && !Array.isArray(payload)
       ? stringField((payload as Record<string, unknown>).lastError)
       : null
+    const scopedDelivery = await findConfiguredDelivery(config, cloud, deliveryId)
+    if (!scopedDelivery) {
+      writeJson(res, 404, { ok: false, error: 'Delivery not found.' })
+      return
+    }
     const delivery = await cloud.deadLetterDelivery(deliveryId, { lastError })
     writeJson(res, delivery ? 200 : 404, delivery ? { ok: true, delivery } : { ok: false, error: 'Delivery not found.' })
     return
@@ -291,6 +315,8 @@ async function handleRequest(
   if (req.method === 'POST' && webhookMatch) {
     runtime.metrics.webhookRequests += 1
     const providerId = decodeURIComponent(webhookMatch[1])
+    const providerConfig = configuredProvider(config, providerId)
+    if (providerConfig) ensureGatewayProviderMetrics(runtime.metrics, providerConfig).webhookRequests += 1
     const source = webhookSource(req, config.server.trustProxyHeaders, config.server.trustedProxyCidrs)
     enforceGatewayWebhookLimit(webhookLimiter, `request:${source}:${providerId}`)
     enforceGatewayWebhookAuthBackoff(webhookLimiter, `auth:${source}:${providerId}`)
@@ -395,6 +421,78 @@ function providerStatus(runtime: GatewayRuntime) {
     healthy: registration.healthy,
     error: registration.lastError ? redactGatewayDiagnosticText(registration.lastError) : null,
   }))
+}
+
+async function listConfiguredDeliveries(
+  config: GatewayConfig,
+  cloud: CloudGateway,
+  input: {
+    deliveryId: string | null
+    status: 'pending' | 'claimed' | 'sent' | 'failed' | 'dead' | null
+    channelBindingId: string | null
+    limit: number
+  },
+) {
+  if (!cloud.listDeliveries) return []
+  const configuredBindings = configuredChannelBindingIds(config)
+  const requestedBinding = input.channelBindingId?.trim() || null
+  const bindingIds = requestedBinding
+    ? configuredBindings.includes(requestedBinding) ? [requestedBinding] : []
+    : configuredBindings
+  if (bindingIds.length === 0) return []
+  const pages = await Promise.all(bindingIds.map((channelBindingId) => cloud.listDeliveries?.({
+    deliveryId: input.deliveryId,
+    status: input.status,
+    channelBindingId,
+    limit: input.limit,
+  }) || []))
+  const byId = new Map<string, ChannelDeliveryRecord>()
+  for (const delivery of pages.flat()) byId.set(delivery.deliveryId, delivery)
+  return [...byId.values()]
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || right.createdAt.localeCompare(left.createdAt))
+    .slice(0, input.limit)
+}
+
+async function findConfiguredDelivery(config: GatewayConfig, cloud: CloudGateway, deliveryId: string) {
+  const deliveries = await listConfiguredDeliveries(config, cloud, {
+    deliveryId,
+    status: null,
+    channelBindingId: null,
+    limit: 1,
+  })
+  return deliveries.find((delivery) => delivery.deliveryId === deliveryId) || null
+}
+
+function configuredChannelBindingIds(config: GatewayConfig) {
+  return [...new Set(config.providers.filter((provider) => provider.enabled).map((provider) => provider.channelBindingId))]
+}
+
+function configuredProvider(config: GatewayConfig, providerId: string) {
+  return config.providers.find((provider) => provider.enabled && provider.id === providerId) || null
+}
+
+function deliveryOperatorStatus(config: GatewayConfig, cloud?: CloudGateway) {
+  const channelBindingIds = configuredChannelBindingIds(config)
+  const hasBindings = channelBindingIds.length > 0
+  const listAvailable = Boolean(cloud?.listDeliveries)
+  const retryAvailable = Boolean(cloud?.retryDelivery)
+  const deadLetterAvailable = Boolean(cloud?.deadLetterDelivery)
+  const disabledReasons = [
+    cloud ? null : 'Cloud client is not attached to this gateway HTTP server.',
+    hasBindings ? null : 'No enabled provider channel bindings are configured.',
+    listAvailable ? null : 'Cloud delivery listing is not available.',
+    retryAvailable ? null : 'Cloud delivery retry is not available.',
+    deadLetterAvailable ? null : 'Cloud delivery dead-letter is not available.',
+  ].filter(Boolean)
+
+  return {
+    scope: 'configured-channel-bindings',
+    channelBindingIds,
+    listAllowed: hasBindings && listAvailable,
+    retryAllowed: hasBindings && listAvailable && retryAvailable,
+    deadLetterAllowed: hasBindings && listAvailable && deadLetterAvailable,
+    disabledReason: disabledReasons.length > 0 ? disabledReasons.join(' ') : null,
+  }
 }
 
 function isAdminRequest(config: GatewayConfig, req: IncomingMessage) {

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -10,7 +10,12 @@ import { isCloudTransportError, type ChannelDeliveryRecord, type CloudChannelPro
 import type { CloudGateway } from './cloud-gateway.js'
 import type { GatewayConfig, GatewayProviderConfig } from './config.js'
 import { routeGatewayInteraction } from './interaction-router.js'
-import { createGatewayMetrics, type GatewayMetrics } from './metrics.js'
+import {
+  createGatewayMetrics,
+  ensureGatewayProviderMetrics,
+  setGatewayProviderState,
+  type GatewayMetrics,
+} from './metrics.js'
 import { classifyProviderFailure } from './provider-errors.js'
 import { createGatewayProviderRegistry, type GatewayProviderRegistry, type ProviderRegistration } from './provider-registry.js'
 import { createGatewaySessionStreamManager, type GatewaySessionStreamManager } from './session-stream-manager.js'
@@ -25,6 +30,7 @@ export type GatewayRuntime = {
   start(): Promise<void>
   stop(): Promise<void>
   ready(): boolean
+  refreshProviderHealth(): void
 }
 
 export type GatewayRuntimeOptions = {
@@ -38,8 +44,12 @@ export function createGatewayRuntime(
   options: GatewayRuntimeOptions = {},
 ): GatewayRuntime {
   const metrics = createGatewayMetrics()
+  for (const provider of config.providers.filter((entry) => entry.enabled)) {
+    ensureGatewayProviderMetrics(metrics, provider)
+  }
   const streams = createGatewaySessionStreamManager(cloud, metrics)
   const claimedBy = `gateway:${config.instanceId}`
+  const channelBindingIds = [...new Set(config.providers.filter((provider) => provider.enabled).map((provider) => provider.channelBindingId))]
   const deliverySubscriptions: Array<{ close(): void }> = []
   const inFlightDeliveries = new Set<Promise<void>>()
   let started = false
@@ -50,11 +60,18 @@ export function createGatewayRuntime(
     streams,
     async start() {
       if (started) return
+      for (const provider of config.providers.filter((entry) => entry.enabled)) {
+        setGatewayProviderState(metrics, provider, 'starting')
+      }
       await providers.start((providerConfig, message) => handleMessage(providerConfig, message, cloud, providers, streams, metrics, claimedBy))
+      for (const registration of providers.registrations) {
+        setGatewayProviderState(metrics, registration.config, registration.healthy ? 'healthy' : 'unhealthy')
+      }
       started = true
       if (options.subscribeDeliveries !== false) {
         deliverySubscriptions.push(cloud.subscribeDeliveries({
           claimedBy,
+          channelBindingIds,
           onDelivery: (delivery) => {
             const task = handleDelivery(delivery, providers, cloud, metrics)
               .finally(() => {
@@ -76,19 +93,30 @@ export function createGatewayRuntime(
         await settleWithin(Promise.allSettled([...inFlightDeliveries]), config.timeouts.shutdownDrainMs)
       }
       await providers.stop()
+      for (const provider of config.providers.filter((entry) => entry.enabled)) {
+        setGatewayProviderState(metrics, provider, 'stopped')
+      }
       started = false
     },
     ready() {
-      return started && providers.registrations.every((registration) => {
-        const health = registration.provider.health?.()
-        registration.healthy = health?.ok ?? registration.healthy
-        registration.lastError = health?.error || null
-        return registration.started && registration.healthy
-      })
+      refreshProviderHealth(providers, metrics)
+      return started && providers.registrations.every((registration) => registration.started && registration.healthy)
+    },
+    refreshProviderHealth() {
+      refreshProviderHealth(providers, metrics)
     },
   }
 
   return runtime
+}
+
+function refreshProviderHealth(providers: GatewayProviderRegistry, metrics: GatewayMetrics) {
+  for (const registration of providers.registrations) {
+    const health = registration.provider.health?.()
+    registration.healthy = health?.ok ?? registration.healthy
+    registration.lastError = health?.error || null
+    setGatewayProviderState(metrics, registration.config, registration.healthy ? 'healthy' : 'unhealthy')
+  }
 }
 
 async function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
@@ -115,6 +143,8 @@ async function handleMessage(
   claimedBy: string,
 ) {
   metrics.incomingMessages += 1
+  const providerMetrics = ensureGatewayProviderMetrics(metrics, providerConfig)
+  providerMetrics.incomingMessages += 1
   const provider = message.provider as CloudChannelProviderId
   const externalWorkspaceId = providerConfig.externalWorkspaceId ?? null
   const externalUserId = message.sender.providerUserId
@@ -127,6 +157,7 @@ async function handleMessage(
     const eventClaim = await cloud.claimProviderEvent({
       provider,
       providerInstanceId: providerConfig.id,
+      channelBindingId: providerConfig.channelBindingId,
       externalWorkspaceId,
       providerEventId: providerEventIdForMessage(message),
       eventType: providerEventTypeForMessage(message),
@@ -134,12 +165,16 @@ async function handleMessage(
       ttlMs: PROVIDER_EVENT_CLAIM_TTL_MS,
       metadata: providerEventMetadata(message, providerConfig),
     })
-    if (!eventClaim.claimed) return
+    if (!eventClaim.claimed) {
+      providerMetrics.inboundDuplicates += 1
+      return
+    }
     claimedEvent = { eventId: eventClaim.event.eventId }
 
     if (await routeGatewayInteraction({ cloud, provider: registration.provider, providerConfig, message, metrics })) {
       sideEffectCommitted = true
       await cloud.completeProviderEvent(claimedEvent.eventId, {
+        channelBindingId: providerConfig.channelBindingId,
         claimedBy,
         status: 'processed',
       })
@@ -149,6 +184,7 @@ async function handleMessage(
     const text = message.text.trim()
     if (!text) {
       await cloud.completeProviderEvent(claimedEvent.eventId, {
+        channelBindingId: providerConfig.channelBindingId,
         claimedBy,
         status: 'processed',
       })
@@ -157,6 +193,7 @@ async function handleMessage(
 
     const identity = await cloud.resolveIdentity({
       provider,
+      channelBindingId: providerConfig.channelBindingId,
       externalWorkspaceId,
       externalUserId,
       metadata: {
@@ -187,13 +224,16 @@ async function handleMessage(
     })
     sideEffectCommitted = true
     metrics.promptedMessages += 1
+    providerMetrics.promptedMessages += 1
     await cloud.completeProviderEvent(claimedEvent.eventId, {
+      channelBindingId: providerConfig.channelBindingId,
       claimedBy,
       status: 'processed',
     })
   } catch (error) {
     if (claimedEvent && !sideEffectCommitted) {
       await cloud.completeProviderEvent(claimedEvent.eventId, {
+        channelBindingId: providerConfig.channelBindingId,
         claimedBy,
         status: 'failed',
         retryable: providerEventFailureIsRetryable(error),
@@ -201,6 +241,7 @@ async function handleMessage(
       }).catch(() => {})
     }
     metrics.errors += 1
+    providerMetrics.inboundFailures += 1
     throw error
   }
 }
@@ -224,6 +265,8 @@ async function handleDelivery(
     })
     return
   }
+  const providerMetrics = ensureGatewayProviderMetrics(metrics, registration.config)
+  providerMetrics.deliveriesReceived += 1
 
   try {
     await sendDelivery(registration.provider, delivery)
@@ -233,13 +276,19 @@ async function handleDelivery(
       lastError: null,
     })
     metrics.deliveriesSent += 1
+    providerMetrics.deliveriesSent += 1
     metrics.deliveryLatencyMsTotal += Math.max(0, Date.now() - startedAt)
   } catch (error) {
     metrics.errors += 1
     const failure = classifyProviderFailure(error)
     const shouldRetry = failure.transient && delivery.attemptCount < MAX_DELIVERY_ATTEMPTS
-    if (shouldRetry) metrics.deliveryRetries += 1
-    else metrics.deliveryDeadLetters += 1
+    if (shouldRetry) {
+      metrics.deliveryRetries += 1
+      providerMetrics.deliveryRetries += 1
+    } else {
+      metrics.deliveryDeadLetters += 1
+      providerMetrics.deliveryDeadLetters += 1
+    }
     await cloud.ackDelivery(delivery.deliveryId, {
       status: shouldRetry ? 'failed' : 'dead',
       claimedBy: delivery.claimedBy,

--- a/apps/gateway/src/interaction-router.test.ts
+++ b/apps/gateway/src/interaction-router.test.ts
@@ -91,6 +91,7 @@ test('interaction router resolves channel button tokens through cloud and acknow
     alert: undefined,
   }])
   assert.equal(metrics.interactionsResolved, 1)
+  assert.equal(metrics.providerMetrics.fake?.interactionsResolved, 1)
 })
 
 test('interaction router resolves deny, answer, and reject fallback commands through cloud', async () => {
@@ -154,6 +155,7 @@ test('interaction router resolves deny, answer, and reject fallback commands thr
     })
   }
   assert.equal(metrics.interactionsResolved, 3)
+  assert.equal(metrics.providerMetrics.fake?.interactionsResolved, 3)
 })
 
 test('interaction router ignores ordinary channel messages', async () => {

--- a/apps/gateway/src/interaction-router.ts
+++ b/apps/gateway/src/interaction-router.ts
@@ -3,7 +3,7 @@ import type { CloudChannelProviderId } from '@open-cowork/cloud-client'
 
 import type { CloudGateway } from './cloud-gateway.js'
 import type { GatewayProviderConfig } from './config.js'
-import type { GatewayMetrics } from './metrics.js'
+import { ensureGatewayProviderMetrics, type GatewayMetrics } from './metrics.js'
 import { parseGatewayInteractionToken } from './render/interaction-tokens.js'
 
 export type RouteGatewayInteractionInput = {
@@ -28,6 +28,7 @@ export async function routeGatewayInteraction(input: RouteGatewayInteractionInpu
     ...interaction.resolution,
   })
   input.metrics.interactionsResolved += 1
+  ensureGatewayProviderMetrics(input.metrics, input.providerConfig).interactionsResolved += 1
 
   if (input.provider.answerInteraction) {
     try {

--- a/apps/gateway/src/metrics.test.ts
+++ b/apps/gateway/src/metrics.test.ts
@@ -19,6 +19,21 @@ test('gateway Prometheus metrics include delivery, stream, and webhook operation
   metrics.cursorPersistenceFailures = 1
   metrics.cloudSubscriptionErrors = 1
   metrics.droppedSessionEvents = 1
+  metrics.providerMetrics.fake = {
+    id: 'fake',
+    kind: 'fake',
+    state: 'healthy',
+    incomingMessages: 2,
+    inboundDuplicates: 1,
+    inboundFailures: 1,
+    promptedMessages: 1,
+    interactionsResolved: 1,
+    deliveriesReceived: 3,
+    deliveriesSent: 2,
+    deliveryRetries: 1,
+    deliveryDeadLetters: 1,
+    webhookRequests: 4,
+  }
 
   const text = renderPrometheusMetrics(metrics, 2, 7, () => new Date('2026-01-01T00:01:00.000Z').getTime())
 
@@ -35,4 +50,7 @@ test('gateway Prometheus metrics include delivery, stream, and webhook operation
   assert.match(text, /open_cowork_gateway_session_render_dead_letters_total 1/)
   assert.match(text, /open_cowork_gateway_cursor_persistence_failures_total 1/)
   assert.match(text, /open_cowork_gateway_cloud_subscription_errors_total 1/)
+  assert.match(text, /open_cowork_gateway_provider_state\{provider_id="fake",provider_kind="fake",state="healthy"\} 1/)
+  assert.match(text, /open_cowork_gateway_provider_webhook_requests_total\{provider_id="fake",provider_kind="fake"\} 4/)
+  assert.match(text, /open_cowork_gateway_provider_interactions_resolved_total\{provider_id="fake",provider_kind="fake"\} 1/)
 })

--- a/apps/gateway/src/metrics.ts
+++ b/apps/gateway/src/metrics.ts
@@ -16,6 +16,25 @@ export type GatewayMetrics = {
   cloudSubscriptionErrors: number
   droppedSessionEvents: number
   errors: number
+  providerMetrics: Record<string, GatewayProviderMetrics>
+}
+
+export type GatewayProviderMetricState = 'configured' | 'starting' | 'healthy' | 'unhealthy' | 'stopped'
+
+export type GatewayProviderMetrics = {
+  id: string
+  kind: string
+  state: GatewayProviderMetricState
+  incomingMessages: number
+  inboundDuplicates: number
+  inboundFailures: number
+  promptedMessages: number
+  interactionsResolved: number
+  deliveriesReceived: number
+  deliveriesSent: number
+  deliveryRetries: number
+  deliveryDeadLetters: number
+  webhookRequests: number
 }
 
 export function createGatewayMetrics(now = Date.now): GatewayMetrics {
@@ -37,7 +56,44 @@ export function createGatewayMetrics(now = Date.now): GatewayMetrics {
     cloudSubscriptionErrors: 0,
     droppedSessionEvents: 0,
     errors: 0,
+    providerMetrics: {},
   }
+}
+
+export function ensureGatewayProviderMetrics(
+  metrics: GatewayMetrics,
+  provider: { id: string, kind: string },
+): GatewayProviderMetrics {
+  const existing = metrics.providerMetrics[provider.id]
+  if (existing) {
+    existing.kind = provider.kind
+    return existing
+  }
+  const record: GatewayProviderMetrics = {
+    id: provider.id,
+    kind: provider.kind,
+    state: 'configured',
+    incomingMessages: 0,
+    inboundDuplicates: 0,
+    inboundFailures: 0,
+    promptedMessages: 0,
+    interactionsResolved: 0,
+    deliveriesReceived: 0,
+    deliveriesSent: 0,
+    deliveryRetries: 0,
+    deliveryDeadLetters: 0,
+    webhookRequests: 0,
+  }
+  metrics.providerMetrics[provider.id] = record
+  return record
+}
+
+export function setGatewayProviderState(
+  metrics: GatewayMetrics,
+  provider: { id: string, kind: string },
+  state: GatewayProviderMetricState,
+) {
+  ensureGatewayProviderMetrics(metrics, provider).state = state
 }
 
 export function renderPrometheusMetrics(metrics: GatewayMetrics, providerCount: number, activeSessionStreams = 0, now = Date.now) {
@@ -100,6 +156,74 @@ export function renderPrometheusMetrics(metrics: GatewayMetrics, providerCount: 
     '# HELP open_cowork_gateway_dropped_session_events_total Session events skipped after non-retryable channel rendering failures.',
     '# TYPE open_cowork_gateway_dropped_session_events_total counter',
     `open_cowork_gateway_dropped_session_events_total ${metrics.droppedSessionEvents}`,
+    ...renderProviderMetrics(metrics),
     '',
   ].join('\n')
+}
+
+function renderProviderMetrics(metrics: GatewayMetrics) {
+  const providers = Object.values(metrics.providerMetrics)
+    .sort((left, right) => left.id.localeCompare(right.id))
+  if (providers.length === 0) return []
+  return [
+    '# HELP open_cowork_gateway_provider_state Provider lifecycle state by configured provider.',
+    '# TYPE open_cowork_gateway_provider_state gauge',
+    ...providers.flatMap((provider) => providerStateSeries(provider)),
+    '# HELP open_cowork_gateway_provider_incoming_messages_total Incoming channel messages accepted by provider.',
+    '# TYPE open_cowork_gateway_provider_incoming_messages_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_incoming_messages_total', provider, provider.incomingMessages)),
+    '# HELP open_cowork_gateway_provider_inbound_duplicates_total Duplicate inbound provider events skipped by durable claims.',
+    '# TYPE open_cowork_gateway_provider_inbound_duplicates_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_inbound_duplicates_total', provider, provider.inboundDuplicates)),
+    '# HELP open_cowork_gateway_provider_inbound_failures_total Inbound provider messages that failed before completion.',
+    '# TYPE open_cowork_gateway_provider_inbound_failures_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_inbound_failures_total', provider, provider.inboundFailures)),
+    '# HELP open_cowork_gateway_provider_prompted_messages_total Channel messages prompted into cloud sessions by provider.',
+    '# TYPE open_cowork_gateway_provider_prompted_messages_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_prompted_messages_total', provider, provider.promptedMessages)),
+    '# HELP open_cowork_gateway_provider_interactions_resolved_total Channel approval/question interactions resolved by provider.',
+    '# TYPE open_cowork_gateway_provider_interactions_resolved_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_interactions_resolved_total', provider, provider.interactionsResolved)),
+    '# HELP open_cowork_gateway_provider_deliveries_received_total Cloud deliveries received by provider binding.',
+    '# TYPE open_cowork_gateway_provider_deliveries_received_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_deliveries_received_total', provider, provider.deliveriesReceived)),
+    '# HELP open_cowork_gateway_provider_deliveries_sent_total Channel deliveries successfully sent by provider.',
+    '# TYPE open_cowork_gateway_provider_deliveries_sent_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_deliveries_sent_total', provider, provider.deliveriesSent)),
+    '# HELP open_cowork_gateway_provider_delivery_retries_total Channel deliveries marked for retry by provider.',
+    '# TYPE open_cowork_gateway_provider_delivery_retries_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_delivery_retries_total', provider, provider.deliveryRetries)),
+    '# HELP open_cowork_gateway_provider_delivery_dead_letters_total Channel deliveries dead-lettered by provider.',
+    '# TYPE open_cowork_gateway_provider_delivery_dead_letters_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_delivery_dead_letters_total', provider, provider.deliveryDeadLetters)),
+    '# HELP open_cowork_gateway_provider_webhook_requests_total Webhook requests received by provider.',
+    '# TYPE open_cowork_gateway_provider_webhook_requests_total counter',
+    ...providers.map((provider) => providerCounterLine('open_cowork_gateway_provider_webhook_requests_total', provider, provider.webhookRequests)),
+  ]
+}
+
+function providerStateSeries(provider: GatewayProviderMetrics) {
+  const states: GatewayProviderMetricState[] = ['configured', 'starting', 'healthy', 'unhealthy', 'stopped']
+  return states.map((state) => (
+    `open_cowork_gateway_provider_state${providerLabels(provider, { state })} ${provider.state === state ? 1 : 0}`
+  ))
+}
+
+function providerCounterLine(name: string, provider: GatewayProviderMetrics, value: number) {
+  return `${name}${providerLabels(provider)} ${value}`
+}
+
+function providerLabels(provider: GatewayProviderMetrics, extra: Record<string, string> = {}) {
+  const labels = {
+    provider_id: provider.id,
+    provider_kind: provider.kind,
+    ...extra,
+  }
+  return `{${Object.entries(labels)
+    .map(([key, value]) => `${key}="${escapePrometheusLabel(value)}"`)
+    .join(',')}}`
+}
+
+function escapePrometheusLabel(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"')
 }

--- a/apps/website/src/browser-e2e.test.ts
+++ b/apps/website/src/browser-e2e.test.ts
@@ -519,6 +519,13 @@ test('cloud web browser exercises BYOK, gateway, billing, diagnostics, and quota
     await waitFor(() => assert.equal(harness.document.body.dataset.route, 'connections'))
     assert.match(harness.document.querySelector('[data-admin-surface-route="connections"]')?.textContent || '', /one-time plaintext reveal/)
 
+    harness.clickText('#gateway-token', 'Gateway token')
+    await waitFor(() => {
+      const request = harness.lastRequest((entry) => entry.method === 'POST' && entry.path === '/api/api-tokens')
+      assert.ok(request)
+      assert.deepEqual((request.body as Record<string, unknown>).channelBindingIds, ['binding-1'])
+    })
+
     ;(harness.document.querySelector('#agent-form input[name="name"]') as HTMLInputElement).value = 'Release helper'
     harness.submit('#agent-form')
     await waitFor(() => assert.ok(harness.lastRequest((request) => request.method === 'POST' && request.path === '/api/channels/agents')))

--- a/apps/website/src/browser-test-harness.ts
+++ b/apps/website/src/browser-test-harness.ts
@@ -271,10 +271,13 @@ export function createCloudWebBrowserHarness(options: BrowserHarnessOptions = {}
     }
     if (request.method === 'GET' && request.pathname === '/api/api-tokens') return jsonResponse({ tokens: state.tokens.slice(0, limitFromRequest(request, 100)) })
     if (request.method === 'POST' && request.pathname === '/api/api-tokens') {
+      const body = request.body as Record<string, unknown>
+      const channelBindingIds = Array.isArray(body?.channelBindingIds) ? body.channelBindingIds : []
       const token = {
         tokenId: `token-${state.tokens.length + 1}`,
-        name: (request.body as Record<string, unknown>)?.name || 'API token',
-        scopes: (request.body as Record<string, unknown>)?.scopes || ['desktop'],
+        name: body?.name || 'API token',
+        scopes: body?.scopes || ['desktop'],
+        channelBindingIds,
         last4: 'wxyz',
         lastUsedAt: null,
         revokedAt: null,

--- a/apps/website/src/react-admin-surfaces.tsx
+++ b/apps/website/src/react-admin-surfaces.tsx
@@ -82,6 +82,13 @@ function pillKind(value: unknown) {
   return ''
 }
 
+function grantableChannelBindingIds(bindings: Record<string, unknown>[]) {
+  return [...new Set(bindings
+    .filter((binding) => text(binding.status, 'active') !== 'disabled')
+    .map((binding) => text(binding.bindingId || binding.id).trim())
+    .filter(Boolean))]
+}
+
 function formatDate(value: unknown) {
   if (!value) return 'never'
   const date = new Date(String(value))
@@ -316,7 +323,12 @@ export function CloudAdminSurfacePortals({ bootstrap, workspace }: Props) {
       } else if (target.closest('#desktop-token')) {
         event.preventDefault(); event.stopImmediatePropagation(); void mutate('Desktop token issued', async () => { const issued = asRecord(await api.admin.apiTokens.create({ name: 'Desktop connection', scopes: ['desktop'] })); setState((current) => ({ ...current, revealToken: text(issued.plaintext) })) })
       } else if (target.closest('#gateway-token')) {
-        event.preventDefault(); event.stopImmediatePropagation(); void mutate('Gateway token issued', async () => { const issued = asRecord(await api.admin.apiTokens.create({ name: 'Gateway service token', scopes: ['gateway'] })); setState((current) => ({ ...current, revealToken: text(issued.plaintext) })) })
+        event.preventDefault(); event.stopImmediatePropagation(); void mutate('Gateway token issued', async () => {
+          const channelBindingIds = grantableChannelBindingIds(state.bindings)
+          if (channelBindingIds.length === 0) throw new Error('Create a channel binding before issuing a Gateway token.')
+          const issued = asRecord(await api.admin.apiTokens.create({ name: 'Gateway service token', scopes: ['gateway'], channelBindingIds }))
+          setState((current) => ({ ...current, revealToken: text(issued.plaintext) }))
+        })
       } else if (target.closest('#billing-portal')) {
         event.preventDefault(); event.stopImmediatePropagation(); if (billingActionDisabled) status(billingDisabledReason, 'warn'); else void mutate('Billing portal opened', async () => { const result = asRecord(await api.admin.billing.portal()); if (result.url) window.location.href = text(result.url) })
       } else if (target.closest('#export-audit')) {
@@ -329,7 +341,7 @@ export function CloudAdminSurfacePortals({ bootstrap, workspace }: Props) {
     }
     document.addEventListener('click', click, true)
     return () => { disposers.forEach((dispose) => dispose()); document.removeEventListener('click', click, true) }
-  }, [api, auditFilter, billingActionDisabled, billingDisabledReason, bootstrap.profileName, filteredAudit, inviteDisabled, inviteDisabledReason, locked, lockTitle, mutate, reload, state.usage, state.usageSummary, workspace])
+  }, [api, auditFilter, billingActionDisabled, billingDisabledReason, bootstrap.profileName, filteredAudit, inviteDisabled, inviteDisabledReason, locked, lockTitle, mutate, reload, state.bindings, state.usage, state.usageSummary, workspace])
 
   const portals = []
   if (targets.memberCount) portals.push(createPortal(<>{filteredMembers.length}</>, targets.memberCount))

--- a/deploy/observability/grafana-open-cowork-overview.json
+++ b/deploy/observability/grafana-open-cowork-overview.json
@@ -97,6 +97,17 @@
       ]
     },
     {
+      "type": "timeseries",
+      "title": "Gateway provider health",
+      "targets": [
+        { "expr": "sum(open_cowork_gateway_provider_state{state=~\"healthy|unhealthy\"}) by (provider_id, provider_kind, state)" },
+        { "expr": "sum(rate(open_cowork_gateway_provider_inbound_failures_total[5m])) by (provider_id, provider_kind)" },
+        { "expr": "sum(rate(open_cowork_gateway_provider_delivery_retries_total[5m])) by (provider_id, provider_kind)" },
+        { "expr": "sum(rate(open_cowork_gateway_provider_delivery_dead_letters_total[5m])) by (provider_id, provider_kind)" },
+        { "expr": "sum(rate(open_cowork_gateway_provider_webhook_requests_total[5m])) by (provider_id, provider_kind)" }
+      ]
+    },
+    {
       "type": "stat",
       "title": "Gateway active providers and streams",
       "targets": [

--- a/deploy/observability/metrics-catalog.json
+++ b/deploy/observability/metrics-catalog.json
@@ -235,6 +235,36 @@
       "type": "counter",
       "owner": "gateway",
       "description": "Gateway stream reconnects after cloud SSE or render failures."
+    },
+    {
+      "name": "open_cowork_gateway_provider_state",
+      "type": "gauge",
+      "owner": "gateway",
+      "description": "Provider lifecycle state by configured provider id, provider kind, and state."
+    },
+    {
+      "name": "open_cowork_gateway_provider_inbound_failures_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Inbound provider messages that failed before completion by configured provider id and kind."
+    },
+    {
+      "name": "open_cowork_gateway_provider_delivery_retries_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Channel deliveries marked for retry by configured provider id and kind."
+    },
+    {
+      "name": "open_cowork_gateway_provider_delivery_dead_letters_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Channel deliveries dead-lettered by configured provider id and kind."
+    },
+    {
+      "name": "open_cowork_gateway_provider_webhook_requests_total",
+      "type": "counter",
+      "owner": "gateway",
+      "description": "Webhook requests received by configured provider id and kind."
     }
   ]
 }

--- a/deploy/observability/prometheus-alerts.yaml
+++ b/deploy/observability/prometheus-alerts.yaml
@@ -129,6 +129,33 @@ groups:
         annotations:
           summary: Gateway deliveries are retrying or dead-lettering.
           runbook: docs/runbooks/cloud-managed-operations.md#gateway-provider-outage
+      - alert: OpenCoworkGatewayProviderUnhealthy
+        expr: sum by (provider_id, provider_kind) (open_cowork_gateway_provider_state{state="unhealthy"}) > 0
+        for: 5m
+        labels:
+          severity: page
+          surface: gateway
+        annotations:
+          summary: A configured Gateway provider is unhealthy.
+          runbook: docs/runbooks/cloud-managed-operations.md#gateway-provider-outage
+      - alert: OpenCoworkGatewayProviderDeliveryFailures
+        expr: sum by (provider_id, provider_kind) (rate(open_cowork_gateway_provider_delivery_retries_total[10m])) > 1 or sum by (provider_id, provider_kind) (rate(open_cowork_gateway_provider_delivery_dead_letters_total[10m])) > 0
+        for: 10m
+        labels:
+          severity: page
+          surface: gateway
+        annotations:
+          summary: A configured Gateway provider is retrying or dead-lettering deliveries.
+          runbook: docs/runbooks/cloud-managed-operations.md#gateway-provider-outage
+      - alert: OpenCoworkGatewayProviderInboundFailures
+        expr: sum by (provider_id, provider_kind) (rate(open_cowork_gateway_provider_inbound_failures_total[10m])) > 0
+        for: 10m
+        labels:
+          severity: ticket
+          surface: gateway
+        annotations:
+          summary: A configured Gateway provider is failing inbound message handling.
+          runbook: docs/runbooks/cloud-managed-operations.md#gateway-provider-outage
       - alert: OpenCoworkGatewayStreamReconnects
         expr: sum(rate(open_cowork_gateway_stream_reconnects_total[5m])) > 5
         for: 10m

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,10 +175,14 @@ Cloud source files should stay below 2,000 lines. Current documented
 exceptions have explicit budgets and are implementation backlogs, not target
 architecture:
 
-- `in-memory-control-plane-store.ts` (budget 4,200 lines): compatibility
+- `in-memory-control-plane-store.ts` (budget 4,300 lines): compatibility
   implementation for the full domain store contract, including managed work
   claim fencing until the store contract is split further.
-- `postgres-control-plane-store.ts` (budget 4,400 lines): compatibility
+- `http-server.ts` (budget 2,100 lines): compatibility Cloud HTTP/SSE entry
+  point that wires shared route modules, HTML/CSP serving, pre-auth health,
+  and streaming lifecycles while route handlers continue moving into
+  `http-routes/`.
+- `postgres-control-plane-store.ts` (budget 4,500 lines): compatibility
   implementation for the full Postgres-backed store plus webhook security
   store and managed work claim fencing. Domain row mappers belong in
   `postgres-domains/`.

--- a/docs/deployment-readiness.md
+++ b/docs/deployment-readiness.md
@@ -277,6 +277,11 @@ provider control plane.
   restarting the gateway, then revoking the old token.
 - The gateway token authenticates the gateway process only; inbound channel
   actor identity and approval authority are resolved separately by cloud.
+- Cloud records the API-token id that last claimed each channel delivery. A
+  gateway-scoped token can list, retry, or dead-letter only deliveries last
+  claimed by that same token; channel admins retain broader Cloud recovery
+  access. Run one gateway token per provider shard or deployment instance so
+  retry/dead-letter ownership is auditable.
 
 ### Provider Webhook Signing
 
@@ -533,6 +538,14 @@ channels or mint tokens, runs a loopback fake-provider Gateway against the
 deployed Cloud URL, verifies inbound prompt routing, session SSE rendering,
 approval interaction routing, async delivery, retry/dead-letter controls, and
 ephemeral token revocation.
+
+The Gateway smoke should also confirm `/diagnostics.deliveryOperator` reports
+the enabled `channelBindingIds`, and that `/deliveries` is scoped to those local
+bindings. Provider-level dashboard and alert assets must include
+`open_cowork_gateway_provider_state`,
+`open_cowork_gateway_provider_delivery_retries_total`, and
+`open_cowork_gateway_provider_delivery_dead_letters_total` before public
+provider traffic is enabled.
 
 For the full Web/Desktop/Gateway continuation parity gate:
 

--- a/docs/gateway-appliance.md
+++ b/docs/gateway-appliance.md
@@ -167,6 +167,11 @@ macOS and Mac mini:
 - Configure `OPEN_COWORK_GATEWAY_ADMIN_TOKEN` before exposing operator
   endpoints: `/metrics`, `/diagnostics`, `/deliveries`, and delivery retry or
   dead-letter actions.
+- Gateway `/deliveries` lists only enabled provider `channelBindingId` values
+  from the local daemon config. Retry and dead-letter actions are protected by
+  the Gateway admin token locally and by the Cloud service-token owner of the
+  last delivery claim in Cloud, so one gateway token cannot operate on another
+  gateway shard's backlog.
 - Public reverse proxies must strip untrusted
   `x-open-cowork-gateway-admin-token` headers and either block operator
   endpoints or require the Gateway admin bearer token.
@@ -264,6 +269,16 @@ failures open a provider delivery circuit, stop hot-looping the downstream
 bridge, and surface the circuit as degraded provider health in `/ready` and
 `/diagnostics`. URL/DNS policy failures and oversized delivery responses are
 permanent and should dead-letter instead of retrying.
+
+Operator delivery controls are intentionally shard-aware. The Gateway daemon
+subscribes to Cloud deliveries with its enabled `channelBindingId` list, so it
+does not claim unrelated provider backlog. Cloud records the API-token id that
+last claimed each delivery. A gateway-scoped token can list, retry, or
+dead-letter only deliveries last claimed by that same token; channel admins can
+perform broader channel-management recovery from Cloud. Gateway `/diagnostics`
+exposes a redacted `deliveryOperator` block with `listAllowed`, `retryAllowed`,
+`deadLetterAllowed`, the scoped `channelBindingIds`, and a reason when a control
+is unavailable.
 
 Session-event rendering is ordered by Cloud event sequence. If provider
 rendering fails transiently, Gateway reconnects from the last persisted cursor

--- a/docs/runbooks/cloud-managed-operations.md
+++ b/docs/runbooks/cloud-managed-operations.md
@@ -18,8 +18,9 @@ Before routing traffic to a new deployment:
 3. Confirm `GET /api/workers/heartbeats` shows at least one fresh worker and
    one fresh scheduler heartbeat when those roles are enabled.
 4. Confirm the gateway returns `200` from `GET /health` and `GET /ready`.
-5. Confirm gateway `/metrics` includes provider count, delivery counters, and
-   error counters when metrics are enabled.
+5. Confirm gateway `/metrics` includes provider count, aggregate delivery
+   counters, provider-labeled counters, and error counters when metrics are
+   enabled.
 6. Confirm object-store writes work by creating a small artifact or running a
    checkpoint-enabled smoke session.
 7. Confirm BYOK status reads return metadata only and no plaintext keys.
@@ -186,13 +187,16 @@ Use this when stale-owner rejections or expired lease reaping spikes.
 Gateway delivery lag is operationally separate from cloud execution lag.
 
 1. Check gateway `/ready` for provider startup state.
-2. Check `/metrics` for `open_cowork_gateway_deliveries_received_total` and
-   `open_cowork_gateway_errors_total`.
-3. Inspect pending `cloud_channel_deliveries` rows by status and
-   `next_attempt_at`.
-4. For channel-provider outages, keep cloud sessions running and let deliveries
+2. Check `/metrics` for `open_cowork_gateway_deliveries_received_total`,
+   `open_cowork_gateway_errors_total`, and provider-labeled retry/dead-letter
+   counters by `provider_id` and `provider_kind`.
+3. Inspect gateway `/diagnostics.deliveryOperator` and confirm listing, retry,
+   dead-letter, and `channelBindingIds` match the affected provider shard.
+4. Inspect pending `cloud_channel_deliveries` rows by status, `next_attempt_at`,
+   `channel_binding_id`, and `last_claimed_by`.
+5. For channel-provider outages, keep cloud sessions running and let deliveries
    retry with backoff.
-5. For bad provider credentials, rotate the channel secret and restart only the
+6. For bad provider credentials, rotate the channel secret and restart only the
    affected gateway deployment.
 
 If gateway lag is caused by worker backlog, do not scale Gateway first. Fix
@@ -321,14 +325,20 @@ Use this when sign-in, token refresh, or browser callback handling fails.
 Use this when Telegram, Slack, email, webhook, or another channel provider
 fails while cloud sessions still execute.
 
-1. Check gateway `/ready` provider status and
-   `open_cowork_gateway_delivery_retries_total`.
+1. Check gateway `/ready` provider status,
+   `open_cowork_gateway_provider_state`, and provider-labeled retry/dead-letter
+   counters.
 2. Keep cloud workers running; failed channel delivery should retry or
    dead-letter without blocking execution.
 3. Rotate only the affected channel credential if provider auth failed.
-4. Use `/deliveries?status=failed` and retry/dead-letter controls after the
-   provider recovers.
-5. Notify users that desktop and web remain authoritative while chat delivery is
+4. Use `/deliveries?status=failed&channelBindingId=<binding>` from the affected
+   gateway. Retry/dead-letter controls are valid only for deliveries last
+   claimed by that gateway token unless an org channel admin performs broader
+   Cloud-side recovery.
+5. If `/diagnostics.deliveryOperator.disabledReason` is non-null, fix the
+   missing Cloud client capability, admin token, or provider binding before
+   replaying deliveries.
+6. Notify users that desktop and web remain authoritative while chat delivery is
    degraded.
 
 ## Webhook Abuse

--- a/docs/runbooks/private-beta-support.md
+++ b/docs/runbooks/private-beta-support.md
@@ -59,8 +59,8 @@ Do not request:
    and gateway delivery id.
 4. Check Cloud metrics first: command age, projection lag, worker heartbeats,
    quota rejections, BYOK failures, and HTTP error rate.
-5. Check Gateway metrics next: stream reconnects, delivery retries, dead
-   letters, provider status, and session-stream count.
+5. Check Gateway metrics next: stream reconnects, aggregate and provider-labeled
+   delivery retries/dead letters, provider status, and session-stream count.
 6. Check object-store and Postgres health for artifact, checkpoint, or replay
    issues.
 7. Record outcome, mitigation, owner, and follow-up test.
@@ -156,9 +156,12 @@ For channel issues:
 3. Confirm webhook signatures or shared-secret/HMAC headers are present.
 4. Confirm the channel binding maps to the expected org, headless agent, and
    cloud profile.
-5. Check the durable delivery cursor and dead-letter queue.
-6. Retry dead-lettered deliveries only after reviewing the event body and
-   provider error.
+5. Check `/diagnostics.deliveryOperator` for enabled controls and scoped
+   `channelBindingIds`.
+6. Check the durable delivery cursor and dead-letter queue.
+7. Retry dead-lettered deliveries only after reviewing the event body and
+   provider error, and use the gateway token that last claimed the delivery
+   unless a channel admin is performing broader Cloud-side recovery.
 
 ## Desktop Sync Issue Handling
 

--- a/packages/cloud-client/src/contracts.ts
+++ b/packages/cloud-client/src/contracts.ts
@@ -186,6 +186,7 @@ export type ChannelDeliveryRecord = {
   status: CloudChannelDeliveryStatus
   attemptCount: number
   claimedBy: string | null
+  lastClaimedBy: string | null
   claimExpiresAt: string | null
   nextAttemptAt: string
   lastError: string | null
@@ -352,6 +353,7 @@ export type CloudApiTokenRecord = {
   accountId: string | null
   name: string
   scopes: CloudApiTokenScope[]
+  channelBindingIds: string[]
   last4: string
   expiresAt: string | null
   revokedAt: string | null
@@ -363,6 +365,13 @@ export type CloudApiTokenRecord = {
 export type CloudIssuedApiTokenRecord = {
   token: CloudApiTokenRecord
   plaintext: string
+}
+
+export type CloudApiTokenChannelBindingGrantRecord = {
+  orgId: string
+  tokenId: string
+  channelBindingId: string
+  createdAt: string
 }
 
 export type CloudOrgMemberRecord = {
@@ -660,8 +669,12 @@ export type CloudTransportAdapter = {
     name: string
     scopes: CloudApiTokenScope[]
     expiresAt?: string | null
+    channelBindingIds?: readonly string[] | null
   }): Promise<CloudIssuedApiTokenRecord>
   revokeApiToken?(tokenId: string): Promise<CloudApiTokenRecord | null>
+  grantApiTokenChannelBinding?(tokenId: string, input: {
+    channelBindingId: string
+  }): Promise<{ grant: CloudApiTokenChannelBindingGrantRecord, token: CloudApiTokenRecord }>
   getAdminPolicy?(): Promise<CloudAdminPolicyOverview>
   listOrgMembers?(input?: { query?: string | null, limit?: number | null }): Promise<CloudOrgMemberRecord[]>
   inviteOrgMember?(input: { email: string, role?: 'owner' | 'admin' | 'member' | null }): Promise<CloudOrgMemberRecord>
@@ -706,6 +719,7 @@ export type CloudTransportAdapter = {
   resolveChannelIdentity?(input: {
     provider: CloudChannelProviderId
     externalUserId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     identityId?: string | null
     accountId?: string | null
@@ -736,6 +750,7 @@ export type CloudTransportAdapter = {
   claimChannelProviderEvent?(input: {
     provider: CloudChannelProviderId
     providerInstanceId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     providerEventId: string
     eventType: CloudChannelProviderEventType
@@ -744,6 +759,7 @@ export type CloudTransportAdapter = {
     metadata?: Record<string, unknown>
   }): Promise<ChannelProviderEventClaimResult>
   completeChannelProviderEvent?(eventId: string, input: {
+    channelBindingId?: string | null
     claimedBy: string
     status: Extract<CloudChannelProviderEventStatus, 'processed' | 'failed'>
     retryable?: boolean
@@ -791,16 +807,18 @@ export type CloudTransportAdapter = {
     nextAttemptAt?: string | null
   }): Promise<ChannelDeliveryRecord | null>
   listChannelDeliveries?(input?: {
+    deliveryId?: string | null
     status?: CloudChannelDeliveryStatus | null
     channelBindingId?: string | null
     limit?: number | null
   }): Promise<ChannelDeliveryRecord[]>
   retryChannelDelivery?(deliveryId: string): Promise<ChannelDeliveryRecord | null>
   deadLetterChannelDelivery?(deliveryId: string, input?: { lastError?: string | null }): Promise<ChannelDeliveryRecord | null>
-  channelDeliveriesUrl?(input?: { claimedBy?: string, ttlMs?: number }): string
+  channelDeliveriesUrl?(input?: { claimedBy?: string, ttlMs?: number, channelBindingIds?: readonly string[] }): string
   subscribeChannelDeliveries?(input: {
     claimedBy?: string
     ttlMs?: number
+    channelBindingIds?: readonly string[]
     onDelivery: (delivery: ChannelDeliveryRecord) => void
     onError?: (error: unknown) => void
   }): CloudTransportSubscription

--- a/packages/cloud-client/src/domain-clients/channels.ts
+++ b/packages/cloud-client/src/domain-clients/channels.ts
@@ -81,6 +81,7 @@ export type CloudChannelsClient = {
   resolveChannelIdentity(input: {
     provider: ChannelProviderId
     externalUserId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     identityId?: string | null
     accountId?: string | null
@@ -111,6 +112,7 @@ export type CloudChannelsClient = {
   claimChannelProviderEvent(input: {
     provider: ChannelProviderId
     providerInstanceId: string
+    channelBindingId?: string | null
     externalWorkspaceId?: string | null
     providerEventId: string
     eventType: CloudChannelProviderEventType
@@ -119,6 +121,7 @@ export type CloudChannelsClient = {
     metadata?: Record<string, unknown>
   }): Promise<ChannelProviderEventClaimResult>
   completeChannelProviderEvent(eventId: string, input: {
+    channelBindingId?: string | null
     claimedBy: string
     status: Extract<CloudChannelProviderEventStatus, 'processed' | 'failed'>
     retryable?: boolean
@@ -166,23 +169,29 @@ export type CloudChannelsClient = {
     nextAttemptAt?: string | null
   }): Promise<ChannelDeliveryRecord | null>
   listChannelDeliveries(input?: {
+    deliveryId?: string | null
     status?: CloudChannelDeliveryStatus | null
     channelBindingId?: string | null
     limit?: number | null
   }): Promise<ChannelDeliveryRecord[]>
   retryChannelDelivery(deliveryId: string): Promise<ChannelDeliveryRecord | null>
   deadLetterChannelDelivery(deliveryId: string, input?: { lastError?: string | null }): Promise<ChannelDeliveryRecord | null>
-  channelDeliveriesUrl(input?: { claimedBy?: string, ttlMs?: number }): string
+  channelDeliveriesUrl(input?: { claimedBy?: string, ttlMs?: number, channelBindingIds?: readonly string[] }): string
   subscribeChannelDeliveries(input: {
     claimedBy?: string
     ttlMs?: number
+    channelBindingIds?: readonly string[]
     onDelivery: (delivery: ChannelDeliveryRecord) => void
     onError?: (error: unknown) => void
   }): CloudTransportSubscription
 }
 
-function channelDeliveriesUrl(baseUrl: string, input: { claimedBy?: string, ttlMs?: number } = {}) {
-  return `${baseUrl}/api/channels/deliveries/stream${queryString(input)}`
+function channelDeliveriesUrl(baseUrl: string, input: { claimedBy?: string, ttlMs?: number, channelBindingIds?: readonly string[] } = {}) {
+  return `${baseUrl}/api/channels/deliveries/stream${queryString({
+    claimedBy: input.claimedBy,
+    ttlMs: input.ttlMs,
+    channelBindingId: input.channelBindingIds,
+  })}`
 }
 
 export function createCloudChannelsClient(context: CloudChannelsClientContext): CloudChannelsClient {
@@ -312,9 +321,14 @@ export function createCloudChannelsClient(context: CloudChannelsClientContext): 
       const url = channelDeliveriesUrl(context.baseUrl, {
         claimedBy: input.claimedBy,
         ttlMs: input.ttlMs,
+        channelBindingIds: input.channelBindingIds,
       })
       const onEvent = (event: unknown) => {
         const record = asRecord(event)
+        if ('error' in record) {
+          input.onError?.(new Error(typeof record.error === 'string' ? record.error : 'Channel delivery stream failed.'))
+          return
+        }
         const delivery = record.delivery
         if (delivery && typeof delivery === 'object') input.onDelivery(delivery as ChannelDeliveryRecord)
       }

--- a/packages/cloud-client/src/domains/identity.ts
+++ b/packages/cloud-client/src/domains/identity.ts
@@ -1,5 +1,6 @@
 export type {
   CloudAdminPolicyOverview,
+  CloudApiTokenChannelBindingGrantRecord,
   CloudApiTokenRecord,
   CloudApiTokenScope,
   CloudAuditEventRecord,
@@ -9,6 +10,7 @@ export type {
 
 import type {
   CloudAdminPolicyOverview,
+  CloudApiTokenChannelBindingGrantRecord,
   CloudApiTokenRecord,
   CloudApiTokenScope,
   CloudAuditEventRecord,
@@ -24,8 +26,12 @@ export type CloudIdentityClient = {
     name: string
     scopes: CloudApiTokenScope[]
     expiresAt?: string | null
+    channelBindingIds?: readonly string[] | null
   }): Promise<CloudIssuedApiTokenRecord>
   revokeApiToken(tokenId: string): Promise<CloudApiTokenRecord | null>
+  grantApiTokenChannelBinding(tokenId: string, input: {
+    channelBindingId: string
+  }): Promise<{ grant: CloudApiTokenChannelBindingGrantRecord, token: CloudApiTokenRecord }>
   getAdminPolicy(): Promise<CloudAdminPolicyOverview>
   listOrgMembers(input?: { query?: string | null, limit?: number | null }): Promise<CloudOrgMemberRecord[]>
   inviteOrgMember(input: { email: string, role?: 'owner' | 'admin' | 'member' | null }): Promise<CloudOrgMemberRecord>
@@ -52,6 +58,15 @@ export function createCloudIdentityClient({ request }: CloudDomainClientContext)
       return (await request<{ token: CloudApiTokenRecord | null }>(`/api/api-tokens/${encodePath(tokenId)}`, {
         method: 'DELETE',
       })).token
+    },
+    grantApiTokenChannelBinding(tokenId, input) {
+      return request<{ grant: CloudApiTokenChannelBindingGrantRecord, token: CloudApiTokenRecord }>(
+        `/api/api-tokens/${encodePath(tokenId)}/channel-bindings`,
+        {
+          method: 'POST',
+          body: input,
+        },
+      )
     },
     async getAdminPolicy() {
       return (await request<{ policy: CloudAdminPolicyOverview }>('/api/admin/policy')).policy

--- a/scripts/cloud-continuation-smoke.mjs
+++ b/scripts/cloud-continuation-smoke.mjs
@@ -383,7 +383,7 @@ function assertDesktopParity(rawView, desktopView, label) {
   return { raw, desktop }
 }
 
-async function setupGateway({ baseUrl, token, adminClient, runId }) {
+async function setupGateway({ baseUrl, token, tokenId, adminClient, runId }) {
   const createHeadlessAgent = requireMethod(adminClient, 'createHeadlessAgent')
   const createChannelBinding = requireMethod(adminClient, 'createChannelBinding')
   const resolveChannelIdentity = requireMethod(adminClient, 'resolveChannelIdentity')
@@ -405,6 +405,11 @@ async function setupGateway({ baseUrl, token, adminClient, runId }) {
     status: 'active',
     settings: { smoke: true },
   })
+  const grantApiTokenChannelBinding = requireMethod(adminClient, 'grantApiTokenChannelBinding')
+  const grant = await grantApiTokenChannelBinding(tokenId, { channelBindingId: bindingId })
+  if (!grant?.token?.channelBindingIds?.includes(bindingId)) {
+    throw new Error('Continuation smoke gateway token was not granted to the channel binding.')
+  }
   const identity = await resolveChannelIdentity({
     provider: 'cli',
     externalUserId,
@@ -814,6 +819,7 @@ async function runSmoke() {
     gatewaySetup = await setupGateway({
       baseUrl,
       token: tokenState.tokens.gateway,
+      tokenId: tokenState.issued.gateway.tokenId,
       adminClient: tokenState.adminClient,
       runId,
     })

--- a/scripts/gateway-cloud-smoke.mjs
+++ b/scripts/gateway-cloud-smoke.mjs
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 
 import { createHttpSseCloudTransportAdapter } from '../packages/cloud-client/dist/index.js'
 import { createCloudGateway, createGatewayDaemon, resolveGatewayCloudConnection, resolveGatewayConfig } from '../apps/gateway/dist/index.js'
+import { WebhookCircuitOpenError } from '../packages/gateway-provider-webhook/dist/index.js'
 
 const args = parseArgs(process.argv.slice(2))
 const debugEnabled = process.env.OPEN_COWORK_GATEWAY_SMOKE_DEBUG === 'true'
@@ -406,6 +407,15 @@ async function setupCloudChannelState({ baseUrl, adminToken, adminClient, servic
   }
 }
 
+async function grantGatewayTokenChannelBinding(adminClient, issuedToken, channelBindingId) {
+  const grantApiTokenChannelBinding = requireMethod(adminClient, 'grantApiTokenChannelBinding')
+  const result = await grantApiTokenChannelBinding(issuedToken.tokenId, { channelBindingId })
+  if (!result?.token?.channelBindingIds?.includes(channelBindingId)) {
+    throw new Error('Gateway token channel binding grant was not applied.')
+  }
+  return result
+}
+
 async function runSelfHostGatewaySmoke({ baseUrl, serviceToken, adminToken, adminClient, setup, timeoutMs, runId }) {
   const gatewayAdminToken = `gateway-admin-${runId}`
   const gatewayEnv = {
@@ -433,6 +443,18 @@ async function runSelfHostGatewaySmoke({ baseUrl, serviceToken, adminToken, admi
   const fakeProvider = gateway.runtime.providers.get('fake')?.provider
   if (!fakeProvider || !Array.isArray(fakeProvider.sent)) {
     throw new Error('Gateway smoke fake provider was not available.')
+  }
+  const originalSendText = fakeProvider.sendText.bind(fakeProvider)
+  const forcedDeliveryFailures = new Map()
+  fakeProvider.sendText = async (...sendArgs) => {
+    const options = sendArgs[2] && typeof sendArgs[2] === 'object' ? sendArgs[2] : {}
+    const deliveryId = typeof options.deliveryId === 'string' ? options.deliveryId : ''
+    const retryAfterMs = forcedDeliveryFailures.get(deliveryId)
+    if (retryAfterMs !== undefined) {
+      forcedDeliveryFailures.delete(deliveryId)
+      throw new WebhookCircuitOpenError(retryAfterMs)
+    }
+    return originalSendText(...sendArgs)
   }
 
   try {
@@ -566,8 +588,7 @@ async function runSelfHostGatewaySmoke({ baseUrl, serviceToken, adminToken, admi
     )
 
     const failedRetryId = `gw-smoke-retry-${runId}`
-    const retryChannelDelivery = requireMethod(adminClient, 'retryChannelDelivery')
-    const deadLetterChannelDelivery = requireMethod(adminClient, 'deadLetterChannelDelivery')
+    forcedDeliveryFailures.set(failedRetryId, 60_000)
     await createDelivery(baseUrl, adminToken, {
       deliveryId: failedRetryId,
       agentId: setup.ids.agentId,
@@ -576,24 +597,24 @@ async function runSelfHostGatewaySmoke({ baseUrl, serviceToken, adminToken, admi
       target: { externalChatId: setup.ids.externalChatId, externalThreadId: setup.ids.externalThreadId },
       eventType: 'workflow.completed',
       payload: { text: 'retry later' },
-      status: 'failed',
-      nextAttemptAt: new Date(Date.now() + 60_000).toISOString(),
     })
-    const backlog = await expectOkJson(`${gatewayUrl}/deliveries?status=failed&channelBindingId=${encodeURIComponent(setup.ids.bindingId)}`, {
-      token: gatewayAdminToken,
-    })
-    if (!Array.isArray(backlog.deliveries) || !backlog.deliveries.some((delivery) => delivery.deliveryId === failedRetryId)) {
-      throw new Error('Gateway admin delivery backlog did not include the failed smoke delivery.')
-    }
+    await waitFor(
+      () => expectOkJson(`${gatewayUrl}/deliveries?status=failed&channelBindingId=${encodeURIComponent(setup.ids.bindingId)}`, {
+        token: gatewayAdminToken,
+      }),
+      (backlog) => Array.isArray(backlog.deliveries) && backlog.deliveries.some((delivery) => delivery.deliveryId === failedRetryId),
+      'gateway-owned failed smoke retry delivery',
+      timeoutMs,
+    )
     const gatewayRetry = await requestJson(`${gatewayUrl}/deliveries/${encodeURIComponent(failedRetryId)}/retry`, {
       method: 'POST',
       token: gatewayAdminToken,
     })
-    if (gatewayRetry.status >= 200 && gatewayRetry.status < 300) {
-      throw new Error('Gateway admin delivery retry unexpectedly succeeded with a gateway-scoped cloud token.')
+    if (gatewayRetry.status < 200 || gatewayRetry.status >= 300) {
+      throw new Error(`Gateway admin delivery retry returned ${gatewayRetry.status}: ${String(gatewayRetry.text).slice(0, 240)}`)
     }
-    const retried = await retryChannelDelivery(failedRetryId)
-    if (retried?.status !== 'failed') throw new Error('Cloud admin delivery retry did not move the failed delivery back into retry eligibility.')
+    const retried = gatewayRetry.body?.delivery
+    if (retried?.status !== 'failed') throw new Error('Gateway admin delivery retry did not move the failed delivery back into retry eligibility.')
     await waitFor(
       () => fakeProvider.sent,
       (sent) => sent.some((entry) => entry.text === 'retry later'),
@@ -609,6 +630,7 @@ async function runSelfHostGatewaySmoke({ baseUrl, serviceToken, adminToken, admi
     )
 
     const failedDeadId = `gw-smoke-dead-${runId}`
+    forcedDeliveryFailures.set(failedDeadId, 60_000)
     await createDelivery(baseUrl, adminToken, {
       deliveryId: failedDeadId,
       agentId: setup.ids.agentId,
@@ -617,19 +639,25 @@ async function runSelfHostGatewaySmoke({ baseUrl, serviceToken, adminToken, admi
       target: { externalChatId: setup.ids.externalChatId, externalThreadId: setup.ids.externalThreadId },
       eventType: 'workflow.completed',
       payload: { text: 'dead letter me' },
-      status: 'failed',
-      nextAttemptAt: new Date(Date.now() + 60_000).toISOString(),
     })
+    await waitFor(
+      () => expectOkJson(`${gatewayUrl}/deliveries?status=failed&channelBindingId=${encodeURIComponent(setup.ids.bindingId)}`, {
+        token: gatewayAdminToken,
+      }),
+      (backlog) => Array.isArray(backlog.deliveries) && backlog.deliveries.some((delivery) => delivery.deliveryId === failedDeadId),
+      'gateway-owned failed smoke dead-letter delivery',
+      timeoutMs,
+    )
     const gatewayDeadLetter = await requestJson(`${gatewayUrl}/deliveries/${encodeURIComponent(failedDeadId)}/dead-letter`, {
       method: 'POST',
       token: gatewayAdminToken,
       body: { lastError: 'gateway smoke operator dead-letter' },
     })
-    if (gatewayDeadLetter.status >= 200 && gatewayDeadLetter.status < 300) {
-      throw new Error('Gateway admin delivery dead-letter unexpectedly succeeded with a gateway-scoped cloud token.')
+    if (gatewayDeadLetter.status < 200 || gatewayDeadLetter.status >= 300) {
+      throw new Error(`Gateway admin delivery dead-letter returned ${gatewayDeadLetter.status}: ${String(gatewayDeadLetter.text).slice(0, 240)}`)
     }
-    const dead = await deadLetterChannelDelivery(failedDeadId, { lastError: 'gateway smoke operator dead-letter' })
-    if (dead?.status !== 'dead') throw new Error('Cloud admin delivery dead-letter did not return a dead delivery.')
+    const dead = gatewayDeadLetter.body?.delivery
+    if (dead?.status !== 'dead') throw new Error('Gateway admin delivery dead-letter did not return a dead delivery.')
 
     return {
       gatewayUrl,
@@ -681,6 +709,7 @@ async function runSmoke() {
       serviceToken: tokenState.serviceToken,
       runId,
     })
+    await grantGatewayTokenChannelBinding(tokenState.adminClient, tokenState.issuedToken, setup.ids.bindingId)
     const managed = await checkManagedGateway(managedGatewayUrl)
     const selfHost = await runSelfHostGatewaySmoke({
       baseUrl,

--- a/scripts/validate-ops-readiness.mjs
+++ b/scripts/validate-ops-readiness.mjs
@@ -181,6 +181,11 @@ const requiredMetrics = [
   'open_cowork_gateway_delivery_dead_letters_total',
   'open_cowork_gateway_session_streams',
   'open_cowork_gateway_stream_reconnects_total',
+  'open_cowork_gateway_provider_state',
+  'open_cowork_gateway_provider_inbound_failures_total',
+  'open_cowork_gateway_provider_delivery_retries_total',
+  'open_cowork_gateway_provider_delivery_dead_letters_total',
+  'open_cowork_gateway_provider_webhook_requests_total',
 ]
 
 const requiredAlertMetrics = [
@@ -202,6 +207,10 @@ const requiredAlertMetrics = [
   'pg_settings_max_connections',
   'open_cowork_gateway_delivery_retries_total',
   'open_cowork_gateway_delivery_dead_letters_total',
+  'open_cowork_gateway_provider_state',
+  'open_cowork_gateway_provider_inbound_failures_total',
+  'open_cowork_gateway_provider_delivery_retries_total',
+  'open_cowork_gateway_provider_delivery_dead_letters_total',
   'open_cowork_gateway_stream_reconnects_total',
 ]
 

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -1262,13 +1262,30 @@ test('cloud control plane stores headless channel bindings, interactions, cursor
     claimedBy: 'gateway-early',
     now: new Date('2026-01-01T00:00:01.000Z'),
   }), null)
+  assert.equal(store.claimNextChannelDelivery({
+    orgId: org.orgId,
+    claimedBy: 'gateway-wrong-binding',
+    channelBindingIds: ['other-binding'],
+    now: new Date('2026-01-01T00:00:10.000Z'),
+  }), null)
   const claimed = store.claimNextChannelDelivery({
     orgId: org.orgId,
-    claimedBy: 'gateway-1',
+    claimedBy: 'gateway-instance-1',
+    lastClaimedBy: 'gateway-token-1',
     now: new Date('2026-01-01T00:00:10.000Z'),
     ttlMs: 30_000,
   })
   assert.equal(claimed?.deliveryId, delivery.deliveryId)
+  assert.equal(claimed?.claimedBy, 'gateway-instance-1')
+  assert.equal(claimed?.lastClaimedBy, 'gateway-token-1')
+  assert.equal(store.listChannelDeliveries({
+    orgId: org.orgId,
+    lastClaimedBy: 'gateway-token-1',
+  })[0]?.deliveryId, delivery.deliveryId)
+  assert.equal(store.listChannelDeliveries({
+    orgId: org.orgId,
+    lastClaimedBy: 'gateway-token-2',
+  }).length, 0)
   assert.equal(store.claimNextChannelDelivery({
     orgId: org.orgId,
     claimedBy: 'gateway-2',
@@ -1284,10 +1301,27 @@ test('cloud control plane stores headless channel bindings, interactions, cursor
   assert.equal(store.ackChannelDelivery({
     orgId: org.orgId,
     deliveryId: delivery.deliveryId,
-    claimedBy: 'gateway-1',
+    lastClaimedBy: 'gateway-token-2',
+    status: 'dead',
+    updatedAt: new Date('2026-01-01T00:00:03.000Z'),
+  }), null)
+  const legacyDeliveryRecord = (store as unknown as {
+    channelDeliveriesDomain: {
+      deliveries: Map<string, { lastClaimedBy: string | null }>
+    }
+  }).channelDeliveriesDomain.deliveries.get(delivery.deliveryId)
+  assert.ok(legacyDeliveryRecord)
+  legacyDeliveryRecord.lastClaimedBy = null
+  const legacyAck = store.ackChannelDelivery({
+    orgId: org.orgId,
+    deliveryId: delivery.deliveryId,
+    claimedBy: 'gateway-instance-1',
+    lastClaimedBy: 'gateway-token-1',
     status: 'sent',
     updatedAt: new Date('2026-01-01T00:00:03.000Z'),
-  })?.status, 'sent')
+  })
+  assert.equal(legacyAck?.status, 'sent')
+  assert.equal(legacyAck?.lastClaimedBy, 'gateway-token-1')
 
   const firstProviderEvent = store.claimChannelProviderEvent({
     orgId: org.orgId,

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -2235,7 +2235,7 @@ test('cloud HTTP server keeps gateway-scoped tokens out of desktop API routes', 
     const channelDeliveries = await fetch(`${baseUrl}/api/channels/deliveries`, {
       headers: { authorization: `Bearer ${issued.plaintext}` },
     })
-    assert.notEqual(channelDeliveries.status, 403)
+    assert.equal(channelDeliveries.status, 403)
 
     store.createSession({
       tenantId: 'tenant-1',
@@ -2964,6 +2964,12 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     name: 'Gateway-only token',
     scopes: ['gateway'],
   })
+  const otherGatewayOnlyIssued = store.issueApiToken({
+    orgId: org.orgId,
+    accountId: account.accountId,
+    name: 'Other gateway-only token',
+    scopes: ['gateway'],
+  })
   store.createTenant({ tenantId: 'tenant-2', name: 'Tenant 2' })
   const org2 = store.ensureOrgForTenant({ tenantId: 'tenant-2', name: 'Tenant 2' })
   const account2 = store.createAccount({
@@ -3007,6 +3013,10 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
   }
   const gatewayOnlyHeaders = {
     authorization: `Bearer ${gatewayOnlyIssued.plaintext}`,
+    'content-type': 'application/json',
+  }
+  const otherGatewayOnlyHeaders = {
+    authorization: `Bearer ${otherGatewayOnlyIssued.plaintext}`,
     'content-type': 'application/json',
   }
   const tenant2Headers = {
@@ -3114,6 +3124,22 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     const secondChannelBinding = asRecord((await readJson(secondBindingResponse)).binding)
     assert.equal(secondChannelBinding.credentialRef, undefined)
 
+    store.grantApiTokenChannelBinding({
+      orgId: org.orgId,
+      tokenId: gatewayOnlyIssued.token.tokenId,
+      channelBindingId: String(channelBinding.bindingId),
+    })
+    store.grantApiTokenChannelBinding({
+      orgId: org.orgId,
+      tokenId: otherGatewayOnlyIssued.token.tokenId,
+      channelBindingId: String(secondChannelBinding.bindingId),
+    })
+    store.grantApiTokenChannelBinding({
+      orgId: org.orgId,
+      tokenId: otherGatewayOnlyIssued.token.tokenId,
+      channelBindingId: String(channelBinding.bindingId),
+    })
+
     store.ensureUser({ tenantId: 'tenant-1', userId: 'other-user', email: 'other@example.test' })
     store.createSession({
       tenantId: 'tenant-1',
@@ -3171,6 +3197,180 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     const secondWorkspaceSessionBinding = asRecord((await readJson(secondWorkspaceBindResponse)).binding)
     assert.equal(secondWorkspaceSessionBinding.externalWorkspaceId, 'bot-2')
     assert.notEqual(secondWorkspaceSessionBinding.bindingId, sessionBinding.bindingId)
+
+    const ungrantedGatewayBind = await fetch(`${baseUrl}/api/channels/sessions/bind`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        identityId: wrongWorkspaceIdentity.identityId,
+        channelBindingId: secondChannelBinding.bindingId,
+        provider: 'telegram',
+        externalChatId: 'chat-ungranted',
+        externalThreadId: 'thread-ungranted',
+        title: 'Ungrantable second workspace thread',
+      }),
+    })
+    assert.equal(ungrantedGatewayBind.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedGatewayBind)).error), /not authorized/)
+
+    const ungrantedGatewayThreadLookup = await fetch(
+      `${baseUrl}/api/channels/sessions/by-thread?provider=telegram&externalWorkspaceId=bot-2&externalChatId=chat-1&externalThreadId=thread-1`,
+      { headers: gatewayOnlyHeaders },
+    )
+    assert.equal(ungrantedGatewayThreadLookup.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedGatewayThreadLookup)).error), /not authorized/)
+
+    const ungrantedGatewayPrompt = await fetch(`${baseUrl}/api/channels/sessions/prompt`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        identityId: wrongWorkspaceIdentity.identityId,
+        bindingId: secondWorkspaceSessionBinding.bindingId,
+        text: 'should not reach prompt queue',
+      }),
+    })
+    assert.equal(ungrantedGatewayPrompt.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedGatewayPrompt)).error), /not authorized/)
+
+    const ungrantedGatewayCursor = await fetch(`${baseUrl}/api/channels/cursor`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        bindingId: secondWorkspaceSessionBinding.bindingId,
+        lastEventSequence: 1,
+        lastWorkspaceSequence: 1,
+        lastChatMessageId: 'message-ungranted',
+      }),
+    })
+    assert.equal(ungrantedGatewayCursor.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedGatewayCursor)).error), /not authorized/)
+
+    const ungrantedGatewayIdentity = await fetch(`${baseUrl}/api/channels/identities/resolve`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        channelBindingId: secondChannelBinding.bindingId,
+        externalUserId: 'tg-user-ungranted-explicit',
+      }),
+    })
+    assert.equal(ungrantedGatewayIdentity.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedGatewayIdentity)).error), /not authorized/)
+
+    const ungrantedGatewayIdentityFallback = await fetch(`${baseUrl}/api/channels/identities/resolve`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        externalWorkspaceId: 'bot-2',
+        externalUserId: 'tg-user-ungranted-fallback',
+      }),
+    })
+    assert.equal(ungrantedGatewayIdentityFallback.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedGatewayIdentityFallback)).error), /not authorized/)
+
+    const grantedGatewayIdentity = await fetch(`${baseUrl}/api/channels/identities/resolve`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        channelBindingId: channelBinding.bindingId,
+        externalUserId: 'tg-user-granted',
+      }),
+    })
+    assert.equal(grantedGatewayIdentity.status, 200)
+    const grantedGatewayIdentityBody = asRecord((await readJson(grantedGatewayIdentity)).identity)
+    assert.equal(grantedGatewayIdentityBody.externalWorkspaceId, 'bot-1')
+    assert.equal(grantedGatewayIdentityBody.status, 'pending')
+
+    const ungrantedProviderEventClaim = await fetch(`${baseUrl}/api/channels/provider-events/claim`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        providerInstanceId: 'telegram-prod-2',
+        channelBindingId: secondChannelBinding.bindingId,
+        externalWorkspaceId: 'bot-2',
+        providerEventId: 'provider-event-ungranted-explicit',
+        eventType: 'message',
+        claimedBy: 'gateway-1',
+      }),
+    })
+    assert.equal(ungrantedProviderEventClaim.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedProviderEventClaim)).error), /not authorized/)
+
+    const ungrantedProviderEventFallbackClaim = await fetch(`${baseUrl}/api/channels/provider-events/claim`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        provider: 'telegram',
+        providerInstanceId: 'telegram-prod-2',
+        externalWorkspaceId: 'bot-2',
+        providerEventId: 'provider-event-ungranted-fallback',
+        eventType: 'message',
+        claimedBy: 'gateway-1',
+      }),
+    })
+    assert.equal(ungrantedProviderEventFallbackClaim.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedProviderEventFallbackClaim)).error), /not authorized/)
+
+    const secondProviderEventClaim = await fetch(`${baseUrl}/api/channels/provider-events/claim`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        provider: 'telegram',
+        providerInstanceId: 'telegram-prod-2',
+        channelBindingId: secondChannelBinding.bindingId,
+        providerEventId: 'provider-event-second-complete',
+        eventType: 'message',
+        claimedBy: 'gateway-2',
+      }),
+    })
+    assert.equal(secondProviderEventClaim.status, 200)
+    const secondProviderEvent = asRecord(asRecord(await readJson(secondProviderEventClaim)).event)
+
+    const ungrantedProviderEventComplete = await fetch(`${baseUrl}/api/channels/provider-events/${secondProviderEvent.eventId}/complete`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        channelBindingId: secondChannelBinding.bindingId,
+        claimedBy: 'gateway-2',
+        status: 'processed',
+      }),
+    })
+    assert.equal(ungrantedProviderEventComplete.status, 403)
+    assert.match(String(asRecord(await readJson(ungrantedProviderEventComplete)).error), /not authorized/)
+
+    const ungrantedProviderEventCompleteByRecordedBinding = await fetch(`${baseUrl}/api/channels/provider-events/${secondProviderEvent.eventId}/complete`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        claimedBy: 'gateway-2',
+        status: 'processed',
+      }),
+    })
+    assert.equal(ungrantedProviderEventCompleteByRecordedBinding.status, 404)
+
+    const legacyProviderEventClaim = store.claimChannelProviderEvent({
+      orgId: org.orgId,
+      provider: 'telegram',
+      providerInstanceId: 'telegram-prod',
+      externalWorkspaceId: 'bot-1',
+      providerEventId: 'provider-event-legacy-complete',
+      eventType: 'message',
+      claimedBy: 'gateway-legacy',
+      ttlMs: 30_000,
+      metadata: { providerMessageId: 'legacy-message' },
+    })
+    const legacyProviderEventComplete = await fetch(`${baseUrl}/api/channels/provider-events/${legacyProviderEventClaim.event.eventId}/complete`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        claimedBy: 'gateway-legacy',
+        status: 'processed',
+      }),
+    })
+    assert.equal(legacyProviderEventComplete.status, 200)
 
     const wrongWorkspacePrompt = await fetch(`${baseUrl}/api/channels/sessions/prompt`, {
       method: 'POST',
@@ -3303,6 +3503,7 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
       body: JSON.stringify({
         provider: 'telegram',
         providerInstanceId: 'telegram-prod',
+        channelBindingId: channelBinding.bindingId,
         externalWorkspaceId: 'bot-1',
         providerEventId: 'provider-event-1',
         eventType: 'message',
@@ -3327,6 +3528,7 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
       body: JSON.stringify({
         provider: 'telegram',
         providerInstanceId: 'telegram-prod',
+        channelBindingId: channelBinding.bindingId,
         externalWorkspaceId: 'bot-1',
         providerEventId: 'provider-event-1',
         eventType: 'message',
@@ -3339,21 +3541,21 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     const wrongClaimantComplete = await fetch(`${baseUrl}/api/channels/provider-events/${providerEvent.eventId}/complete`, {
       method: 'POST',
       headers: gatewayOnlyHeaders,
-      body: JSON.stringify({ claimedBy: 'gateway-2', status: 'processed' }),
+      body: JSON.stringify({ channelBindingId: channelBinding.bindingId, claimedBy: 'gateway-2', status: 'processed' }),
     })
     assert.equal(wrongClaimantComplete.status, 404)
 
     const missingClaimantComplete = await fetch(`${baseUrl}/api/channels/provider-events/${providerEvent.eventId}/complete`, {
       method: 'POST',
       headers: gatewayOnlyHeaders,
-      body: JSON.stringify({ status: 'processed' }),
+      body: JSON.stringify({ channelBindingId: channelBinding.bindingId, status: 'processed' }),
     })
     assert.equal(missingClaimantComplete.status, 400)
 
     const providerEventComplete = await fetch(`${baseUrl}/api/channels/provider-events/${providerEvent.eventId}/complete`, {
       method: 'POST',
       headers: gatewayOnlyHeaders,
-      body: JSON.stringify({ claimedBy: 'gateway-1', status: 'processed' }),
+      body: JSON.stringify({ channelBindingId: channelBinding.bindingId, claimedBy: 'gateway-1', status: 'processed' }),
     })
     assert.equal(providerEventComplete.status, 200)
     assert.equal(asRecord((await readJson(providerEventComplete)).event).status, 'processed')
@@ -3364,6 +3566,7 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
       body: JSON.stringify({
         provider: 'telegram',
         providerInstanceId: 'telegram-prod',
+        channelBindingId: channelBinding.bindingId,
         externalWorkspaceId: 'bot-1',
         providerEventId: 'provider-event-1',
         eventType: 'message',
@@ -3390,6 +3593,22 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
       }),
     })
     assert.equal(deliveryResponse.status, 201)
+
+    const ungrantedDeliveryCreate = await fetch(`${baseUrl}/api/channels/deliveries`, {
+      method: 'POST',
+      headers: gatewayOnlyHeaders,
+      body: JSON.stringify({
+        deliveryId: 'delivery-ungranted-create',
+        agentId: 'agent-1',
+        channelBindingId: secondChannelBinding.bindingId,
+        sessionBindingId: secondWorkspaceSessionBinding.bindingId,
+        provider: 'telegram',
+        target: { externalChatId: 'chat-1', externalThreadId: 'thread-1' },
+        eventType: 'workflow.completed',
+        payload: { runId: 'run-ungranted-create' },
+      }),
+    })
+    assert.equal(ungrantedDeliveryCreate.status, 403)
 
     const mismatchedDelivery = await fetch(`${baseUrl}/api/channels/deliveries`, {
       method: 'POST',
@@ -3423,9 +3642,27 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     })
     assert.equal(crossOrgDelivery.status, 404)
 
+    const ungrantedListResponse = await fetch(
+      `${baseUrl}/api/channels/deliveries?channelBindingId=${encodeURIComponent(String(secondChannelBinding.bindingId))}&limit=10`,
+      { headers: gatewayOnlyHeaders },
+    )
+    assert.equal(ungrantedListResponse.status, 403)
+    const ungrantedController = new AbortController()
+    const ungrantedStream = await fetch(
+      `${baseUrl}/api/channels/deliveries/stream?claimedBy=test-gateway&channelBindingId=${encodeURIComponent(String(secondChannelBinding.bindingId))}`,
+      {
+        headers: gatewayOnlyHeaders,
+        signal: ungrantedController.signal,
+      },
+    )
+    assert.equal(ungrantedStream.status, 200)
+    const ungrantedEvent = await readSseUntil(ungrantedStream, (event) => typeof event.error === 'string')
+    ungrantedController.abort()
+    assert.match(String(ungrantedEvent.error), /not authorized/)
+
     const controller = new AbortController()
     const stream = await fetch(`${baseUrl}/api/channels/deliveries/stream?claimedBy=test-gateway`, {
-      headers: { authorization: `Bearer ${issued.plaintext}` },
+      headers: gatewayOnlyHeaders,
       signal: controller.signal,
     })
     assert.equal(stream.status, 200)
@@ -3434,28 +3671,68 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     ))
     controller.abort()
     assert.equal(asRecord(deliveryEvent.delivery).status, 'claimed')
+    assert.equal(asRecord(deliveryEvent.delivery).claimedBy, 'test-gateway')
+    assert.equal(asRecord(deliveryEvent.delivery).lastClaimedBy, gatewayOnlyIssued.token.tokenId)
 
     const ackResponse = await fetch(`${baseUrl}/api/channels/deliveries/delivery-1/ack`, {
       method: 'POST',
-      headers,
+      headers: gatewayOnlyHeaders,
       body: JSON.stringify({ status: 'sent', claimedBy: 'test-gateway' }),
     })
     assert.equal(ackResponse.status, 200)
     assert.equal(asRecord((await readJson(ackResponse)).delivery).status, 'sent')
 
-    const listedDeliveries = await readJson(await fetch(`${baseUrl}/api/channels/deliveries?limit=10`, { headers }))
-    assert.equal(asArray(listedDeliveries.deliveries).some((delivery) => asRecord(delivery).deliveryId === 'delivery-1'), true)
-
-    const gatewayOnlyRetry = await fetch(`${baseUrl}/api/channels/deliveries/delivery-1/retry`, {
+    const defaultClaimantDeliveryResponse = await fetch(`${baseUrl}/api/channels/deliveries`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        deliveryId: 'delivery-default-claimant',
+        agentId: 'agent-1',
+        channelBindingId: channelBinding.bindingId,
+        sessionBindingId: sessionBinding.bindingId,
+        provider: 'telegram',
+        target: { externalChatId: 'chat-1', externalThreadId: 'thread-1' },
+        eventType: 'workflow.completed',
+        payload: { runId: 'run-default-claimant' },
+      }),
+    })
+    assert.equal(defaultClaimantDeliveryResponse.status, 201)
+    const defaultController = new AbortController()
+    const defaultStream = await fetch(`${baseUrl}/api/channels/deliveries/stream`, {
+      headers: gatewayOnlyHeaders,
+      signal: defaultController.signal,
+    })
+    assert.equal(defaultStream.status, 200)
+    const defaultClaimantEvent = await readSseUntil(defaultStream, (event) => (
+      asRecord(event.delivery).deliveryId === 'delivery-default-claimant'
+    ))
+    defaultController.abort()
+    assert.equal(asRecord(defaultClaimantEvent.delivery).claimedBy, gatewayOnlyIssued.token.tokenId)
+    assert.equal(asRecord(defaultClaimantEvent.delivery).lastClaimedBy, gatewayOnlyIssued.token.tokenId)
+    const defaultClaimantAck = await fetch(`${baseUrl}/api/channels/deliveries/delivery-default-claimant/ack`, {
       method: 'POST',
       headers: gatewayOnlyHeaders,
+      body: JSON.stringify({ status: 'sent' }),
+    })
+    assert.equal(defaultClaimantAck.status, 200)
+
+    const listedDeliveries = await readJson(await fetch(`${baseUrl}/api/channels/deliveries?limit=10`, { headers }))
+    assert.equal(asArray(listedDeliveries.deliveries).some((delivery) => asRecord(delivery).deliveryId === 'delivery-1'), true)
+    const gatewayListedDeliveries = await readJson(await fetch(`${baseUrl}/api/channels/deliveries?limit=10`, { headers: gatewayOnlyHeaders }))
+    assert.equal(asArray(gatewayListedDeliveries.deliveries).some((delivery) => asRecord(delivery).deliveryId === 'delivery-1'), true)
+    const otherGatewayListedDeliveries = await readJson(await fetch(`${baseUrl}/api/channels/deliveries?limit=10`, { headers: otherGatewayOnlyHeaders }))
+    assert.equal(asArray(otherGatewayListedDeliveries.deliveries).some((delivery) => asRecord(delivery).deliveryId === 'delivery-1'), false)
+
+    const otherGatewayRetry = await fetch(`${baseUrl}/api/channels/deliveries/delivery-1/retry`, {
+      method: 'POST',
+      headers: otherGatewayOnlyHeaders,
       body: JSON.stringify({}),
     })
-    assert.equal(gatewayOnlyRetry.status, 403)
+    assert.equal(otherGatewayRetry.status, 404)
 
     const retryDelivery = await fetch(`${baseUrl}/api/channels/deliveries/delivery-1/retry`, {
       method: 'POST',
-      headers,
+      headers: gatewayOnlyHeaders,
       body: JSON.stringify({}),
     })
     assert.equal(retryDelivery.status, 200)
@@ -3464,7 +3741,7 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     const tokenLikeErrorText = ['sk', 'production', 'secret', '1234567890'].join('-')
     const deadLetterDelivery = await fetch(`${baseUrl}/api/channels/deliveries/delivery-1/dead-letter`, {
       method: 'POST',
-      headers,
+      headers: gatewayOnlyHeaders,
       body: JSON.stringify({ lastError: `poison event token=${tokenLikeErrorText}` }),
     })
     assert.equal(deadLetterDelivery.status, 200)
@@ -3484,6 +3761,7 @@ test('cloud HTTP server exposes gateway channel identity, binding, interaction, 
     assert.equal(diagnosticsText.includes(issued.plaintext), false)
     assert.equal(diagnosticsText.includes(operatorIssued.plaintext), false)
     assert.equal(diagnosticsText.includes(gatewayOnlyIssued.plaintext), false)
+    assert.equal(diagnosticsText.includes(otherGatewayOnlyIssued.plaintext), false)
     assert.equal(diagnosticsText.includes(tokenLikeErrorText), false)
     assert.equal(diagnosticsText.includes('secret/telegram'), false)
   } finally {

--- a/tests/cloud-modularity-boundaries.test.ts
+++ b/tests/cloud-modularity-boundaries.test.ts
@@ -12,13 +12,15 @@ const dockerIgnore = readFileSync(join(root, '.dockerignore'), 'utf8')
 const postgresSchema = readFileSync(join(cloudRoot, 'postgres-schema.ts'), 'utf8')
 const postgresMigrations = readFileSync(join(cloudRoot, 'postgres-migrations.ts'), 'utf8')
 const postgresStore = readFileSync(join(cloudRoot, 'postgres-control-plane-store.ts'), 'utf8')
+const postgresChannelDeliveriesDomain = readFileSync(join(cloudRoot, 'postgres-store-domains/channel-deliveries.ts'), 'utf8')
 const postgresQuotaDomain = readFileSync(join(cloudRoot, 'postgres-store-domains/quotas.ts'), 'utf8')
 const performanceDoc = readFileSync(join(root, 'docs/performance.md'), 'utf8')
 
 const lineThreshold = 2_000
 const documentedLargeFileBudgets = new Map([
-  ['apps/desktop/src/main/cloud/in-memory-control-plane-store.ts', 4_200],
-  ['apps/desktop/src/main/cloud/postgres-control-plane-store.ts', 4_400],
+  ['apps/desktop/src/main/cloud/http-server.ts', 2_100],
+  ['apps/desktop/src/main/cloud/in-memory-control-plane-store.ts', 4_300],
+  ['apps/desktop/src/main/cloud/postgres-control-plane-store.ts', 4_500],
   ['apps/desktop/src/main/cloud/session-service.ts', 4_200],
 ])
 
@@ -140,6 +142,24 @@ test('large cloud source files are documented exceptions', () => {
   }
 })
 
+test('gateway token delivery-owner migrations preserve upgrade compatibility', () => {
+  assert.match(
+    postgresSchema,
+    /INSERT INTO cloud_api_token_channel_binding_grants[\s\S]+tokens\.scopes @> '\["gateway"\]'::jsonb[\s\S]+NOT EXISTS \([\s\S]+cloud_schema_migrations[\s\S]+CLOUD_CONTROL_PLANE_API_TOKEN_CHANNEL_BINDINGS_MIGRATION_ID/,
+    'gateway API token binding migration must backfill active legacy gateway tokens',
+  )
+  assert.match(
+    postgresChannelDeliveriesDomain,
+    /last_claimed_by = COALESCE\(last_claimed_by, \$8\)/,
+    'legacy delivery ACKs must backfill last_claimed_by when the gateway token owner is known',
+  )
+  assert.match(
+    postgresChannelDeliveriesDomain,
+    /last_claimed_by IS NULL AND \$7::text IS NOT NULL AND claimed_by = \$7/,
+    'legacy claimed deliveries must remain ACKable when claimed_by still matches',
+  )
+})
+
 test('cloud route, service, and client modules stay within ownership budgets', () => {
   assertSourceBudget('cloud HTTP route module', join(cloudRoot, 'http-routes'), 500)
   assertSourceBudget('cloud service module', join(cloudRoot, 'services'), 450)
@@ -250,7 +270,7 @@ test('high-volume cloud tables keep indexed and bounded query shapes', () => {
   assert.match(postgresStore, /async claimRunnableSessions[\s\S]*FOR UPDATE OF sessions SKIP LOCKED/)
   assert.doesNotMatch(extractMethodSource(postgresStore, 'claimRunnableSessions'), /count\(\*\)[\s\S]*cloud_session_commands/)
   assert.match(postgresStore, /async claimNextSessionCommand[\s\S]*ORDER BY created_sequence[\s\S]*FOR UPDATE SKIP LOCKED[\s\S]*LIMIT 1/)
-  assert.match(postgresStore, /async claimNextChannelDelivery[\s\S]*ORDER BY next_attempt_at, created_at[\s\S]*FOR UPDATE SKIP LOCKED[\s\S]*LIMIT 1/)
+  assert.match(postgresChannelDeliveriesDomain, /async claimNext[\s\S]*ORDER BY next_attempt_at, created_at[\s\S]*FOR UPDATE SKIP LOCKED[\s\S]*LIMIT 1/)
   assert.match(postgresStore, /async claimDueWorkflowRun[\s\S]*ORDER BY runs\.created_at ASC, runs\.run_id[\s\S]*FOR UPDATE OF runs, workflows SKIP LOCKED[\s\S]*LIMIT 1/)
 })
 

--- a/tests/cloud-postgres-concurrency.test.ts
+++ b/tests/cloud-postgres-concurrency.test.ts
@@ -134,6 +134,8 @@ test('real Postgres cloud store serializes concurrent schema migrations', {
         '008_managed_workers',
         '009_managed_work_claims',
         '011_channel_provider_events',
+        '012_channel_delivery_owner',
+        '013_api_token_channel_binding_grants',
         '010_managed_work_reaper_indexes',
       ])
     } finally {

--- a/tests/cloud-transport-adapter.test.ts
+++ b/tests/cloud-transport-adapter.test.ts
@@ -713,6 +713,45 @@ test('cloud transport adapter reports typed fetch SSE failures', async () => {
   assert.equal((parseErrors[0] as CloudTransportError).kind, 'parse')
 })
 
+test('cloud transport adapter surfaces channel delivery SSE error payloads', async () => {
+  const deliveries: unknown[] = []
+  const errors: unknown[] = []
+  const transport = createHttpSseCloudTransportAdapter({
+    baseUrl: 'https://cloud.example.test',
+    headers: { authorization: 'Bearer cloud-token' },
+    fetch: async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      async text() {
+        return ''
+      },
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('event: error\ndata: {"error":"Gateway API token is not authorized for one or more requested channel bindings."}\n\n'))
+          controller.close()
+        },
+      }),
+    }),
+  })
+
+  transport.subscribeChannelDeliveries?.({
+    claimedBy: 'gateway:test',
+    channelBindingIds: ['binding-2'],
+    onDelivery(delivery) {
+      deliveries.push(delivery)
+    },
+    onError(error) {
+      errors.push(error)
+    },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.deepEqual(deliveries, [])
+  assert.equal(errors.length, 1)
+  assert.match(errors[0] instanceof Error ? errors[0].message : String(errors[0]), /not authorized/)
+})
+
 test('cloud transport adapter applies request timeout and caller cancellation signals', async () => {
   const timeoutTransport = createHttpSseCloudTransportAdapter({
     baseUrl: 'https://cloud.example.test',

--- a/tests/gateway-cloud-smoke.test.ts
+++ b/tests/gateway-cloud-smoke.test.ts
@@ -337,7 +337,7 @@ test('gateway daemon prompts an in-process cloud session through fake provider w
     })
     assert.deepEqual(runtime.permissions.at(-1), { permissionId: 'permission-interaction-wrapper', allowed: false })
 
-    const deliveryEvent = waitFor<{ deliveryId: string }>((resolve, reject) => cloudGateway.subscribeDeliveries({
+    const deliveryEvent = waitFor<{ deliveryId: string, claimedBy: string | null }>((resolve, reject) => cloudGateway.subscribeDeliveries({
       claimedBy: 'gateway-wrapper-smoke',
       ttlMs: 5_000,
       onDelivery: resolve,
@@ -361,8 +361,9 @@ test('gateway daemon prompts an in-process cloud session through fake provider w
     const delivery = await deliveryEvent.promise
     deliveryEvent.close()
     assert.equal(delivery.deliveryId, 'delivery-wrapper')
+    assert.equal(typeof delivery.claimedBy, 'string')
     assert.equal((await cloudGateway.ackDelivery(delivery.deliveryId, {
-      claimedBy: 'gateway-wrapper-smoke',
+      claimedBy: String(delivery.claimedBy),
       status: 'sent',
     }))?.status, 'sent')
 
@@ -527,8 +528,8 @@ test('gateway cloud smoke script validates self-host gateway against deployed cl
     assert.equal(payload.results.selfHost.delivery.retryInitialStatus, 'failed')
     assert.equal(payload.results.selfHost.delivery.retryStatus, 'sent')
     assert.equal(payload.results.selfHost.delivery.deadLetterStatus, 'dead')
-    assert.equal(payload.results.selfHost.delivery.gatewayOperatorRetryStatus >= 400, true)
-    assert.equal(payload.results.selfHost.delivery.gatewayOperatorDeadLetterStatus >= 400, true)
+    assert.equal(payload.results.selfHost.delivery.gatewayOperatorRetryStatus, 200)
+    assert.equal(payload.results.selfHost.delivery.gatewayOperatorDeadLetterStatus, 200)
     assert.deepEqual(payload.results.selfHost.operatorEndpoints, {
       metrics: 'admin_only',
       diagnostics: 'admin_only',


### PR DESCRIPTION
## Summary
- Enforce gateway API token channel-binding grants across delivery, session, provider-event, and identity gateway mutations.
- Preserve per-instance delivery claim fencing while recording token ownership for scoped list/retry/dead-letter/ack operations.
- Add provider-level gateway metrics, alerts, dashboards, runbooks, and ops readiness validation for production operation.
- Issue Cloud Web gateway tokens with explicit channel-binding grants and surface SSE authorization errors to subscribers.

## Validation
- `node scripts/run-node-tests.mjs tests/cloud-http-server.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-transport-adapter.test.ts tests/gateway-cloud-smoke.test.ts tests/cloud-modularity-boundaries.test.ts`
- `pnpm exec eslint apps/desktop/src/main/cloud/services/channel-binding-scope.ts apps/desktop/src/main/cloud/services/channel-delivery-actions.ts apps/desktop/src/main/cloud/services/channel-session-actions.ts apps/desktop/src/main/cloud/services/channel-provider-event-actions.ts apps/desktop/src/main/cloud/services/channel-admin-actions.ts apps/desktop/src/main/cloud/channel-provider-types.ts apps/desktop/src/main/cloud/in-memory-domains/channel-provider-events.ts apps/desktop/src/main/cloud/postgres-store-domains/channel-provider-events.ts apps/desktop/src/main/cloud/http-routes/channels.ts apps/gateway/src/cloud-gateway.ts apps/gateway/src/gateway-runtime.ts packages/cloud-client/src/domain-clients/channels.ts packages/cloud-client/src/contracts.ts tests/cloud-http-server.test.ts --max-warnings 0`
- `pnpm --filter @open-cowork/shared build && pnpm --filter @open-cowork/gateway test && pnpm typecheck`
- `node scripts/validate-ops-readiness.mjs`
- `uv run mkdocs build --strict`
- `git diff --check`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

Fixes #765
Fixes #766
Refs #758
