### PR TITLE
Add Cloud Web Channels Studio surface

### DIFF
--- a/apps/desktop/src/renderer/app-api.ts
+++ b/apps/desktop/src/renderer/app-api.ts
@@ -65,6 +65,11 @@ export function createDesktopAppApi(coworkApi: CoworkAPI = window.coworkApi): Ap
       validate: (input) => coworkApi.projectSource.validate(input as Parameters<CoworkAPI['projectSource']['validate']>[0]),
       uploadSnapshot: (input) => coworkApi.projectSource.uploadSnapshot(input as Parameters<CoworkAPI['projectSource']['uploadSnapshot']>[0]),
     },
+    channels: {
+      agents: unsupported('Cloud channel agents'),
+      bindings: unsupported('Cloud channel bindings'),
+      deliveries: unsupported('Cloud channel deliveries'),
+    },
     admin: {
       policy: unsupported('Cloud admin policy'),
       members: {

--- a/apps/website/src/app-api.ts
+++ b/apps/website/src/app-api.ts
@@ -163,6 +163,11 @@ export function createCloudWebAppApi(bootstrap: CloudWebClientBootstrap, options
       validate: (input) => request(endpoint('projectSourceValidate', '/api/project-sources/validate'), { method: 'POST', body: input }),
       uploadSnapshot: (input) => request(endpoint('projectSnapshots', '/api/project-sources/snapshots'), { method: 'POST', body: input }),
     },
+    channels: {
+      agents: () => request(endpoint('channelAgents', '/api/channels/agents?limit=100')),
+      bindings: () => request(endpoint('channelBindings', '/api/channels/bindings?limit=100')),
+      deliveries: () => request(endpoint('channelDeliveries', '/api/channels/deliveries?limit=50')),
+    },
     admin: {
       policy: () => request(endpoint('adminPolicy', '/api/admin/policy')),
       members: {

--- a/apps/website/src/app-shell.ts
+++ b/apps/website/src/app-shell.ts
@@ -9,6 +9,7 @@ export type CloudWebRouteId =
   | 'agents'
   | 'capabilities'
   | 'workflows'
+  | 'channels'
   | 'artifacts'
   | 'org'
   | 'members'
@@ -78,6 +79,14 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
     requiresAuth: true,
     requiresAdmin: false,
     summary: cloudWebWorkbenchRouteSummary('workflows', 'Saved playbooks, runs, and status.'),
+  },
+  {
+    id: 'channels',
+    label: 'Channels',
+    surface: 'workbench',
+    requiresAuth: true,
+    requiresAdmin: false,
+    summary: cloudWebWorkbenchRouteSummary('channels', 'Connected chat channels and delivery status.'),
   },
   {
     id: 'artifacts',

--- a/apps/website/src/browser-e2e.test.ts
+++ b/apps/website/src/browser-e2e.test.ts
@@ -239,6 +239,19 @@ test('cloud web browser exposes desktop parity boundaries and workbench state vo
       },
     }])
     await waitFor(() => assert.match(harness.document.querySelector('#status')?.textContent || '', /Playbook created/))
+
+    harness.clickText('[data-route-link]', 'Channels')
+    await waitFor(() => assert.equal(harness.document.body.dataset.route, 'channels'))
+    assert.match(harness.document.querySelector('[data-parity-route="channels"]')?.textContent || '', /Channel setup/)
+    assert.match(harness.document.querySelector('#channel-summary-list')?.textContent || '', /read-only/)
+    assert.ok(harness.document.querySelector('#channel-agent-list .row'))
+    assert.ok(harness.document.querySelector('#channel-binding-list .row'))
+    assert.ok(harness.document.querySelector('#channel-delivery-list .row'))
+    const userDeliveryText = harness.document.querySelector('#channel-delivery-list')?.textContent || ''
+    assert.doesNotMatch(userDeliveryText, /leaked-secret|signed\?token=|secret:\/\//)
+    assert.ok(harness.lastRequest((request) => request.path === '/api/channels/agents?limit=100'))
+    assert.ok(harness.lastRequest((request) => request.path === '/api/channels/bindings?limit=100'))
+    assert.ok(harness.lastRequest((request) => request.path === '/api/channels/deliveries?limit=50'))
   } finally {
     harness.close()
   }
@@ -408,6 +421,7 @@ test('cloud web browser bounds large admin surfaces and redacts unsafe operation
     assert.equal(harness.document.querySelectorAll('#member-list .member-row').length, 100)
     assert.equal(harness.document.querySelectorAll('#token-list > .row').length, 100)
     assert.equal(harness.document.querySelectorAll('#delivery-list > .row').length, 50)
+    assert.equal(harness.document.querySelectorAll('#channel-delivery-list > .row').length, 50)
     assert.equal(harness.document.querySelectorAll('#workflow-list [role="row"]').length, 100)
     assert.equal(harness.document.querySelectorAll('#audit-list > .row').length, 100)
     assert.equal(harness.document.querySelectorAll('#artifact-list .artifact-card').length, 100)
@@ -427,6 +441,8 @@ test('cloud web browser bounds large admin surfaces and redacts unsafe operation
 
     const deliveryText = harness.document.querySelector('#delivery-list')?.textContent || ''
     assert.doesNotMatch(deliveryText, /leaked-secret|signed\?token=/)
+    const channelDeliveryText = harness.document.querySelector('#channel-delivery-list')?.textContent || ''
+    assert.doesNotMatch(channelDeliveryText, /leaked-secret|signed\?token=|secret:\/\//)
 
     const artifactText = harness.document.querySelector('#artifact-list')?.textContent || ''
     assert.doesNotMatch(artifactText, /signed\?token=|objectKey/)

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -120,6 +120,12 @@ export type CloudWebClientStateContract = {
     runs: unknown[]
     error: string | null
   }
+  channels: {
+    agents: unknown[]
+    bindings: unknown[]
+    deliveries: unknown[]
+    error: string | null
+  }
   usageSummary: unknown | null
   deliveries: unknown[]
   diagnostics: unknown | null

--- a/apps/website/src/modularity.test.ts
+++ b/apps/website/src/modularity.test.ts
@@ -34,6 +34,7 @@ test('cloud web workbench production source stays split into bounded modules', (
     'react-client-asset.ts',
     'react-client.tsx',
     'react-project-source.ts',
+    'react-workbench-channels.tsx',
     'react-shell.ts',
     'react-shell-controller.tsx',
     'react-state.ts',

--- a/apps/website/src/performance.test.ts
+++ b/apps/website/src/performance.test.ts
@@ -159,7 +159,7 @@ test('cloud web browser keeps large admin surfaces bounded across route transiti
     budget('browser bootstrap with large admin fixtures', performance.now() - start, 8000)
 
     const routeStart = performance.now()
-    for (const label of ['Members', 'Connections', 'Gateway', 'Audit', 'Usage', 'Playbooks', 'Artifacts']) {
+    for (const label of ['Members', 'Connections', 'Gateway', 'Audit', 'Usage', 'Playbooks', 'Channels', 'Artifacts']) {
       harness.clickText('[data-route-link]', label)
     }
     budget('admin route transitions over large fixtures', performance.now() - routeStart, 1200)
@@ -167,6 +167,7 @@ test('cloud web browser keeps large admin surfaces bounded across route transiti
     assert.equal(harness.document.querySelectorAll('#member-list .member-row').length, 100)
     assert.equal(harness.document.querySelectorAll('#token-list > .row').length, 100)
     assert.equal(harness.document.querySelectorAll('#delivery-list > .row').length, 50)
+    assert.equal(harness.document.querySelectorAll('#channel-delivery-list > .row').length, 50)
     assert.equal(harness.document.querySelectorAll('#workflow-list [role="row"]').length, 100)
     assert.equal(harness.document.querySelectorAll('#audit-list > .row').length, 100)
     assert.equal(harness.document.querySelectorAll('#artifact-list .artifact-card').length, 100)

--- a/apps/website/src/performance.test.ts
+++ b/apps/website/src/performance.test.ts
@@ -158,11 +158,12 @@ test('cloud web browser keeps large admin surfaces bounded across route transiti
     await waitFor(() => assert.equal(harness.document.body.dataset.chatState, 'thread'))
     budget('browser bootstrap with large admin fixtures', performance.now() - start, 8000)
 
+    const largeSurfaceRoutes = ['Members', 'Connections', 'Gateway', 'Audit', 'Usage', 'Playbooks', 'Channels', 'Artifacts']
     const routeStart = performance.now()
-    for (const label of ['Members', 'Connections', 'Gateway', 'Audit', 'Usage', 'Playbooks', 'Channels', 'Artifacts']) {
+    for (const label of largeSurfaceRoutes) {
       harness.clickText('[data-route-link]', label)
     }
-    budget('admin route transitions over large fixtures', performance.now() - routeStart, 1200)
+    budget('admin route transitions over large fixtures', performance.now() - routeStart, largeSurfaceRoutes.length * 175)
 
     assert.equal(harness.document.querySelectorAll('#member-list .member-row').length, 100)
     assert.equal(harness.document.querySelectorAll('#token-list > .row').length, 100)

--- a/apps/website/src/react-state.ts
+++ b/apps/website/src/react-state.ts
@@ -54,6 +54,12 @@ export function initialCloudWebClientState(bootstrap: CloudWebClientBootstrap): 
       runs: [],
       error: null,
     },
+    channels: {
+      agents: [],
+      bindings: [],
+      deliveries: [],
+      error: null,
+    },
     usageSummary: null,
     deliveries: [],
     diagnostics: null,

--- a/apps/website/src/react-workbench-channels.tsx
+++ b/apps/website/src/react-workbench-channels.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useAppApi } from '@open-cowork/ui/app-api'
+import { asRecord, errorMessage, setRouteHash } from './react-workbench-controller.ts'
+
+type ChannelAgent = {
+  agentId?: string
+  name?: string
+  profileName?: string
+  status?: string
+  managed?: boolean
+}
+
+type ChannelBinding = {
+  bindingId?: string
+  agentId?: string
+  provider?: string
+  displayName?: string
+  status?: string
+  externalWorkspaceId?: string | null
+}
+
+type ChannelDelivery = {
+  deliveryId?: string
+  provider?: string
+  channelBindingId?: string
+  status?: string
+  eventType?: string
+  attemptCount?: number
+  nextAttemptAt?: string
+  sessionId?: string
+}
+
+function usePortalTarget(id: string) {
+  const [target, setTarget] = useState<HTMLElement | null>(null)
+  useEffect(() => {
+    const element = document.getElementById(id)
+    if (element) element.replaceChildren()
+    setTarget(element)
+  }, [id])
+  return target
+}
+
+function list<T = unknown>(value: unknown): T[] {
+  return Array.isArray(value) ? value as T[] : []
+}
+
+function text(value: unknown, fallback = '') {
+  return String(value ?? fallback)
+}
+
+function formatDate(value: unknown) {
+  if (!value) return 'never'
+  const date = new Date(String(value))
+  return Number.isNaN(date.getTime()) ? String(value) : date.toISOString()
+}
+
+function rowId(record: Record<string, unknown>, fallback: string) {
+  return text(record.id || record.agentId || record.bindingId || record.deliveryId || record.sessionId, fallback)
+}
+
+function channelPillKind(status: unknown) {
+  const value = String(status || '').toLowerCase()
+  if (value === 'active' || value === 'sent' || value === 'delivered' || value === 'completed') return 'ok'
+  if (value === 'pending' || value === 'queued' || value === 'auth_required' || value === 'retrying') return 'warn'
+  if (value === 'failed' || value === 'dead' || value === 'error' || value === 'disabled') return 'warn'
+  return ''
+}
+
+function channelAgentName(agents: ChannelAgent[], agentId: unknown) {
+  const id = text(agentId)
+  return agents.find((agent) => agent.agentId === id)?.name || id || 'unassigned coworker'
+}
+
+function channelBindingLabel(bindings: ChannelBinding[], bindingId: unknown) {
+  const id = text(bindingId)
+  const binding = bindings.find((entry) => entry.bindingId === id)
+  return binding?.displayName || id || 'unbound channel'
+}
+
+function channelHaystack(value: unknown) {
+  const record = asRecord(value)
+  return [
+    rowId(record, ''),
+    record.name,
+    record.profileName,
+    record.provider,
+    record.displayName,
+    record.status,
+    record.externalWorkspaceId,
+    record.eventType,
+    record.channelBindingId,
+    record.sessionId,
+  ].filter(Boolean).join(' ').toLowerCase()
+}
+
+function matchesChannelFilter(value: unknown, filter: string) {
+  const tokens = filter.toLowerCase().trim().split(/\s+/).filter(Boolean)
+  if (!tokens.length) return true
+  const haystack = channelHaystack(value)
+  return tokens.every((token) => haystack.includes(token))
+}
+
+function ChannelSummary({
+  agents,
+  bindings,
+  deliveries,
+  error,
+}: {
+  agents: ChannelAgent[]
+  bindings: ChannelBinding[]
+  deliveries: ChannelDelivery[]
+  error: string | null
+}) {
+  const activeBindings = bindings.filter((binding) => String(binding.status || '').toLowerCase() === 'active').length
+  const blockedDeliveries = deliveries.filter((delivery) => ['failed', 'dead', 'error'].includes(String(delivery.status || '').toLowerCase())).length
+  return (
+    <>
+      {error ? <p className="notice">{error}</p> : null}
+      <div className="row compact"><strong>Channel coworkers</strong><span>{agents.length}</span></div>
+      <div className="row compact"><strong>Connected channels</strong><span>{bindings.length}</span></div>
+      <div className="row compact"><strong>Active channels</strong><span>{activeBindings}</span></div>
+      <div className="row compact"><strong>Delivery backlog</strong><span>{deliveries.length}</span></div>
+      <div className="row compact"><strong>Needs attention</strong><span>{blockedDeliveries}</span></div>
+      <p className="empty">This user view is read-only. Channel setup, credentials, retries, and dead-letter actions stay in Admin Gateway controls.</p>
+    </>
+  )
+}
+
+function ChannelAgentRows({ agents }: { agents: ChannelAgent[] }) {
+  if (!agents.length) return <p className="empty">No channel coworkers loaded.</p>
+  return (
+    <>
+      {agents.map((agent, index) => (
+        <div className="row compact" key={agent.agentId || agent.name || index}>
+          <div>
+            <strong>{agent.name || agent.agentId || 'Channel coworker'}</strong>
+            <br />
+            <small>{[agent.profileName || 'default profile', agent.managed ? 'managed' : 'manual'].join(' - ')}</small>
+          </div>
+          <span className="pill" data-kind={channelPillKind(agent.status)}>{agent.status || 'unknown'}</span>
+        </div>
+      ))}
+    </>
+  )
+}
+
+function ChannelBindingRows({ bindings, agents }: { bindings: ChannelBinding[], agents: ChannelAgent[] }) {
+  if (!bindings.length) return <p className="empty">No connected channels loaded.</p>
+  return (
+    <>
+      {bindings.map((binding, index) => (
+        <div className="row compact" key={binding.bindingId || binding.displayName || index}>
+          <div>
+            <strong>{binding.displayName || binding.bindingId || 'Connected channel'}</strong>
+            <br />
+            <small>{[binding.provider || 'provider', binding.externalWorkspaceId || 'tenant-wide channel', channelAgentName(agents, binding.agentId)].join(' - ')}</small>
+          </div>
+          <span className="pill" data-kind={channelPillKind(binding.status)}>{binding.status || 'unknown'}</span>
+        </div>
+      ))}
+    </>
+  )
+}
+
+function ChannelDeliveryRows({
+  deliveries,
+  bindings,
+  onOpenThread,
+}: {
+  deliveries: ChannelDelivery[]
+  bindings: ChannelBinding[]
+  onOpenThread: (sessionId: string) => void
+}) {
+  if (!deliveries.length) return <p className="empty">No channel deliveries loaded.</p>
+  return (
+    <>
+      {deliveries.slice(0, 50).map((delivery, index) => {
+        const sessionId = text(delivery.sessionId)
+        return (
+          <div className="row compact" key={delivery.deliveryId || index}>
+            <div>
+              <strong>{delivery.eventType || delivery.deliveryId || 'Channel delivery'}</strong>
+              <br />
+              <small>{[
+                delivery.provider || 'provider',
+                channelBindingLabel(bindings, delivery.channelBindingId),
+                `attempts ${delivery.attemptCount || 0}`,
+                `next ${formatDate(delivery.nextAttemptAt)}`,
+              ].join(' - ')}</small>
+            </div>
+            <div className="row-actions">
+              <span className="pill" data-kind={channelPillKind(delivery.status)}>{delivery.status || 'unknown'}</span>
+              {sessionId ? <button type="button" onClick={() => onOpenThread(sessionId)}>Open chat</button> : null}
+            </div>
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export function CloudChannelSurfacePortals({ onSelectSession }: { onSelectSession: (sessionId: string) => Promise<void> }) {
+  const api = useAppApi()
+  const [agents, setAgents] = useState<ChannelAgent[]>([])
+  const [bindings, setBindings] = useState<ChannelBinding[]>([])
+  const [deliveries, setDeliveries] = useState<ChannelDelivery[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState('')
+  const summaryTarget = usePortalTarget('channel-summary-list')
+  const agentsTarget = usePortalTarget('channel-agent-list')
+  const bindingsTarget = usePortalTarget('channel-binding-list')
+  const deliveriesTarget = usePortalTarget('channel-delivery-list')
+
+  const loadChannels = useCallback(async () => {
+    setError(null)
+    try {
+      const [agentBody, bindingBody, deliveryBody] = await Promise.all([
+        api.channels.agents(),
+        api.channels.bindings(),
+        api.channels.deliveries(),
+      ])
+      setAgents(list<ChannelAgent>(asRecord(agentBody).agents))
+      setBindings(list<ChannelBinding>(asRecord(bindingBody).bindings))
+      setDeliveries(list<ChannelDelivery>(asRecord(deliveryBody).deliveries))
+    } catch (loadError) {
+      setError(errorMessage(loadError))
+      setAgents([])
+      setBindings([])
+      setDeliveries([])
+    }
+  }, [api])
+
+  useEffect(() => {
+    void loadChannels()
+  }, [loadChannels])
+
+  useEffect(() => {
+    const control = document.getElementById('channel-filter') as HTMLInputElement | null
+    const onInput = () => setFilter(control?.value || '')
+    control?.addEventListener('input', onInput)
+    setFilter(control?.value || '')
+    return () => control?.removeEventListener('input', onInput)
+  }, [])
+
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null
+      if (!target?.closest('#refresh-channels')) return
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      void loadChannels()
+    }
+    document.addEventListener('click', handler, true)
+    return () => document.removeEventListener('click', handler, true)
+  }, [loadChannels])
+
+  const filteredAgents = useMemo(() => agents.filter((agent) => matchesChannelFilter(agent, filter)), [agents, filter])
+  const filteredBindings = useMemo(() => bindings.filter((binding) => matchesChannelFilter(binding, filter)), [bindings, filter])
+  const filteredDeliveries = useMemo(() => deliveries.filter((delivery) => matchesChannelFilter(delivery, filter)), [deliveries, filter])
+  const openThread = useCallback((sessionId: string) => {
+    setRouteHash('chat')
+    void onSelectSession(sessionId)
+  }, [onSelectSession])
+  const portals = []
+
+  if (summaryTarget) portals.push(createPortal(<ChannelSummary agents={agents} bindings={bindings} deliveries={deliveries} error={error} />, summaryTarget))
+  if (agentsTarget) portals.push(createPortal(error ? <p className="notice">{error}</p> : <ChannelAgentRows agents={filteredAgents} />, agentsTarget))
+  if (bindingsTarget) portals.push(createPortal(error ? <p className="notice">{error}</p> : <ChannelBindingRows bindings={filteredBindings} agents={agents} />, bindingsTarget))
+  if (deliveriesTarget) portals.push(createPortal(error ? <p className="notice">{error}</p> : <ChannelDeliveryRows deliveries={filteredDeliveries} bindings={bindings} onOpenThread={openThread} />, deliveriesTarget))
+
+  return <>{portals}</>
+}

--- a/apps/website/src/react-workbench-surfaces.tsx
+++ b/apps/website/src/react-workbench-surfaces.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useAppApi } from '@open-cowork/ui/app-api'
 import type { CloudWebClientBootstrap } from './client-contract.ts'
+import { CloudChannelSurfacePortals } from './react-workbench-channels.tsx'
 import { CloudArtifactCards, type CloudRuntimeActionProps } from './react-workbench.ts'
 import { asRecord, errorMessage, setRouteHash } from './react-workbench-controller.ts'
 import type { CloudWebThreadView } from './thread-workbench.ts'
@@ -299,7 +300,6 @@ export function CloudWorkbenchSurfacePortals({ bootstrap, workspace, selectedVie
   const [workflowError, setWorkflowError] = useState<string | null>(null)
   const [workflowFilter, setWorkflowFilter] = useState('')
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null)
-
   const targets = {
     agents: usePortalTarget('workbench-agent-list'),
     agentPolicy: usePortalTarget('agent-policy-list'),
@@ -443,7 +443,6 @@ export function CloudWorkbenchSurfacePortals({ bootstrap, workspace, selectedVie
   }, [workflowFilter, workflows])
   const selectedWorkflow = visibleWorkflows.find((workflow) => workflow.id === selectedWorkflowId) || visibleWorkflows[0] || null
   const selectedRuns = selectedWorkflow ? runs.filter((run) => run.workflowId === selectedWorkflow.id) : []
-
   const runWorkflow = useCallback((workflow: Workflow) => {
     void (async () => {
       try {
@@ -497,7 +496,7 @@ export function CloudWorkbenchSurfacePortals({ bootstrap, workspace, selectedVie
         <div className="row compact"><strong>Profile</strong><span>{text(asRecord(workspace).profileName || bootstrap.profileName, 'default')}</span></div>
         <div className="row compact"><strong>Chat</strong><span>{bootstrap.features.chat === false ? 'disabled' : 'enabled'}</span></div>
         <div className="row compact"><strong>Playbooks</strong><span>{workflowDisabled ? 'disabled' : 'enabled'}</span></div>
-        <div className="row compact"><strong>Surfaces</strong><span>chat, coworkers, tools, playbooks, artifacts</span></div>
+        <div className="row compact"><strong>Surfaces</strong><span>chat, coworkers, tools, playbooks, channels, artifacts</span></div>
       </>,
       targets.agentPolicy,
     ))
@@ -544,5 +543,5 @@ export function CloudWorkbenchSurfacePortals({ bootstrap, workspace, selectedVie
   }
   if (targets.artifactList) portals.push(createPortal(<CloudArtifactCards view={selectedView} {...artifactActions} />, targets.artifactList))
   if (targets.artifactHistory) portals.push(createPortal(<CloudArtifactCards view={selectedView} {...artifactActions} />, targets.artifactHistory))
-  return <>{portals}</>
+  return <>{portals}<CloudChannelSurfacePortals onSelectSession={onSelectSession} /></>
 }

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -81,6 +81,7 @@ test('cloud website renders Studio and admin shell surfaces', () => {
   assert.match(html, /Home/)
   assert.match(html, /Coworkers/)
   assert.match(html, /Playbooks/)
+  assert.match(html, /Channels/)
   assert.match(html, /Tools &amp; Skills/)
   assert.match(html, /Artifacts/)
   assert.match(html, /Admin controls/)
@@ -94,6 +95,7 @@ test('cloud website renders Studio and admin shell surfaces', () => {
   assert.match(html, /Audit/)
   assert.match(html, /Diagnostics/)
   assert.match(html, /data-route-panel="threads"/)
+  assert.match(html, /data-route-panel="channels"/)
   assert.match(html, /data-route-panel="byok"/)
   assert.match(html, /data-route-panel="chat"(?=[^>]*data-requires-auth="false")(?![^>]* hidden)[^>]*>/)
   assert.match(html, /data-route-panel="org"(?=[^>]*data-requires-auth="false")(?=[^>]* hidden)[^>]*>/)
@@ -270,7 +272,7 @@ test('cloud website route/API matrix covers every route and real endpoint id', (
   assert.equal(CLOUD_WEB_ROUTE_API_MATRIX.find((entry) => entry.routeId === 'chat')?.requiredRole, 'public')
   assert.match(CLOUD_WEB_ROUTE_API_MATRIX.find((entry) => entry.routeId === 'chat')?.states.loading || '', /default public route/)
   assert.doesNotMatch(CLOUD_WEB_ROUTE_API_MATRIX.find((entry) => entry.routeId === 'org')?.states.loading || '', /fallback/)
-  for (const routeId of ['members', 'audit', 'usage', 'gateway', 'connections', 'policy', 'workflows', 'artifacts', 'diagnostics']) {
+  for (const routeId of ['members', 'audit', 'usage', 'gateway', 'connections', 'policy', 'workflows', 'channels', 'artifacts', 'diagnostics']) {
     const entry = CLOUD_WEB_ROUTE_API_MATRIX.find((candidate) => candidate.routeId === routeId)
     assert.ok(entry, `${routeId} has a route matrix entry`)
     assert.ok(entry.paginationContract.limit === null || entry.paginationContract.limit <= 100, `${routeId} is browser-bounded`)
@@ -320,6 +322,12 @@ test('cloud website bootstrap exposes typed client endpoint metadata', () => {
     workflows: {
       workflows: [],
       runs: [],
+      error: null,
+    },
+    channels: {
+      agents: [],
+      bindings: [],
+      deliveries: [],
       error: null,
     },
     usageSummary: null,

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -350,6 +350,46 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
           </div>
         </section>
 
+        <section ${routePanelAttrs('channels')}>
+          <div class="section-header">
+            <div>
+              <h2>Channels</h2>
+              <div class="meta">Connected chat channels and delivery status</div>
+            </div>
+            <div class="row-actions">
+              <label><span>Filter</span><input id="channel-filter" autocomplete="off" placeholder="provider, channel, status, coworker" data-channel-control="true"></label>
+              <button id="refresh-channels" type="button" data-channel-control="true">Refresh</button>
+            </div>
+          </div>
+          <div class="grid">
+            ${routeParityMarkup('channels')}
+            <div class="panel">
+              <h3>Channel summary</h3>
+              <div class="list" id="channel-summary-list">
+                <p class="empty">Channel status loads after sign-in.</p>
+              </div>
+            </div>
+            <div class="panel">
+              <h3>Connected channels</h3>
+              <div class="list" id="channel-binding-list">
+                <p class="empty">No connected channels loaded.</p>
+              </div>
+            </div>
+            <div class="panel">
+              <h3>Channel coworkers</h3>
+              <div class="list" id="channel-agent-list">
+                <p class="empty">No channel coworkers loaded.</p>
+              </div>
+            </div>
+            <div class="panel">
+              <h3>Delivery status</h3>
+              <div class="list" id="channel-delivery-list">
+                <p class="empty">No channel deliveries loaded.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section ${routePanelAttrs('artifacts')}>
           <div class="section-header">
             <div>

--- a/apps/website/src/route-api-matrix.ts
+++ b/apps/website/src/route-api-matrix.ts
@@ -140,6 +140,23 @@ export const CLOUD_WEB_ROUTE_API_MATRIX: CloudWebRouteApiMatrixEntry[] = [
     tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
+    routeId: 'channels',
+    surface: 'workbench',
+    requiredRole: 'member',
+    endpointIds: ['channelAgents', 'channelBindings', 'channelDeliveries'],
+    states: {
+      loading: 'Channel agent, binding, and delivery lists render empty cards until the Cloud channel endpoints return.',
+      empty: 'No connected channels or deliveries loaded.',
+      error: 'Gateway/channel API denial renders a read-only unavailable state and does not expose admin setup internals.',
+    },
+    disabledBehavior: 'The user-facing Channels route is read-only; setup, credential, retry, and dead-letter actions remain admin-only.',
+    pagination: 'Channel agents and bindings load the first 100 rows; delivery status loads the first 50 rows.',
+    paginationContract: paginationContract('bounded-page', 'deferred', 100),
+    redaction: 'Credential refs, payload secrets, signed URLs, tokens, object keys, and provider internals are stripped before rendering.',
+    redactionContract: redactionContract('safeOperationalMetadata'),
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
+  },
+  {
     routeId: 'artifacts',
     surface: 'workbench',
     requiredRole: 'member',

--- a/apps/website/src/workbench-parity.ts
+++ b/apps/website/src/workbench-parity.ts
@@ -15,6 +15,7 @@ export type CloudWebWorkbenchConceptId =
   | 'tools-skills'
   | 'artifacts'
   | 'workflows'
+  | 'channels'
   | 'cloud-project-sources'
   | 'local-filesystem'
   | 'local-stdio-mcps'
@@ -120,6 +121,17 @@ export const CLOUD_WEB_WORKBENCH_PARITY_MATRIX: CloudWebWorkbenchParityEntry[] =
     boundary: 'Cloud Web runs saved playbooks through Cloud workflow APIs; local launch-at-login and native notifications remain Desktop settings.',
     disabledReason: 'Playbook controls disable when org profile policy disables workflows or a playbook is archived.',
     tests: ['render.test.ts', 'browser-e2e.test.ts'],
+  },
+  {
+    conceptId: 'channels',
+    label: 'Channels',
+    availability: 'shared',
+    desktopSurface: 'Desktop Gateway/channel status and channel-backed chat context',
+    cloudRouteIds: ['channels', 'chat'],
+    cloudAffordance: 'Show connected channel agents, channel bindings, delivery status, and linked Cloud run chats without exposing setup credentials.',
+    boundary: 'Cloud Web reads channel state through tenant-scoped Cloud APIs; Gateway delivery, provider adapters, and OpenCode execution remain service-owned.',
+    disabledReason: 'Channel setup, retry, dead-letter, and credential rotation stay in Admin Gateway controls.',
+    tests: ['browser-e2e.test.ts', 'render.test.ts'],
   },
   {
     conceptId: 'cloud-project-sources',

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -27,6 +27,7 @@ loading/empty/error state contract.
 | `agents` | Studio | Member | `workspace`, `capabilitiesCatalog` | Capability filtering is local and performance-tested. | Coworker metadata is cloud profile metadata only; local stdio MCP commands and secrets are not rendered. |
 | `capabilities` | Studio | Member | `capabilitiesCatalog`, `capabilityTools`, `capabilitySkills` | Local capability filtering is bounded; API cursoring is deferred. | Machine-scoped MCPs are visible only as policy-limited metadata. |
 | `workflows` | Studio | Member | `workflows`, `workflow`, `workflowRun`, `workflowPause`, `workflowResume`, `workflowArchive` | Playbook summary rendering is bounded to 100 playbooks and 50 recent runs in the browser; run-history cursoring is deferred. | Playbook controls disable when profile policy blocks workflows. Rows never expose worker credentials or local paths. |
+| `channels` | Studio | Member | `channelAgents`, `channelBindings`, `channelDeliveries` | Channel coworkers and bindings request `limit=100`; delivery status requests and renders the first 50 rows. Delivery stream cursoring stays with Gateway/admin flows. | User route is read-only. Setup, credential rotation, retry, and dead-letter actions stay under Admin Gateway. Credential refs, payload secrets, signed URLs, tokens, and provider internals are stripped before rendering. |
 | `artifacts` | Studio | Member | `sessionArtifacts`, `sessionArtifact` | Selected-session artifact metadata rendering is bounded to 100 artifacts. Cross-session artifact browsing is deferred. | Artifact bodies fetch only after explicit action. Signed URLs, object keys, buckets, tokens, and object-store internals are stripped from metadata. |
 | `org` | Admin | Public | `authMe`, `config`, `workspace` | Not applicable. | Org is an explicit public org/profile surface, not the signed-out fallback. Bootstrap JSON carries public branding, route metadata, endpoint metadata, and feature metadata only. |
 | `members` | Admin | Admin | `adminMembers`, `adminMemberInvite`, `adminMemberUpdate` | Members endpoint supports `q` and `limit`; the browser requests `limit=100` and renders at most 100 rows. | Member rows expose identity, role, and status only. Invite and role controls disable for non-admins and non-invite signup modes. |
@@ -59,6 +60,7 @@ keeping Cloud Web honest about cloud-only and desktop-only boundaries.
 | Tools & Skills | Shared with Desktop | `capabilities` | Show allowed tools, skills, MCP metadata, linked coworkers, and policy verdicts. | Cloud Web renders cloud-safe capability metadata; runtime execution remains owned by OpenCode workers. |
 | Artifacts | Shared with Desktop | `artifacts`, `chat` | Show artifact cards, loaded-chat history, sanitized metadata, explicit view/download actions, and selected-chat previews. | Cloud Web fetches artifact bodies only after explicit user action and strips object-store internals from metadata. |
 | Playbooks | Shared with Desktop | `workflows`, `chat` | Create, list, run, pause, resume, archive, and inspect Cloud playbook definitions and run chats. | Cloud Web runs saved playbooks through Cloud workflow APIs; local launch-at-login and native notifications remain Desktop settings. |
+| Channels | Shared with Desktop | `channels`, `chat` | Show connected channel agents, channel bindings, delivery status, and linked Cloud run chats without exposing setup credentials. | Cloud Web reads channel state through tenant-scoped Cloud APIs; Gateway delivery, provider adapters, and OpenCode execution remain service-owned. |
 | Cloud Project Sources | Cloud-only | `threads` | Start project-backed Cloud chats from allowed git repositories or explicit browser-uploaded snapshots. | Cloud policy validates git and snapshot sources before execution. |
 | Local Filesystem | Unavailable in Cloud | `threads`, `artifacts` | Use git URLs, managed Cloud project sources, uploaded snapshots, and Cloud artifacts instead. | Browser sessions must not implicitly read or upload host paths from the user machine. |
 | Local Stdio MCPs | Unavailable in Cloud | `capabilities`, `agents` | Show only policy-safe MCP metadata that has been converted into the Cloud profile. | Cloud Web cannot spawn local stdio MCP processes or expose command lines, environment variables, or secret refs. |
@@ -98,6 +100,8 @@ Cloud Web must keep parity with Desktop Cloud for cloud workspaces:
 - reconnect SSE from durable projection cursors
 - browse artifact metadata and fetch bodies only on explicit action
 - run playbooks through the Cloud workflow API
+- review connected channel coworkers, bindings, and delivery status without
+  exposing setup credentials or delivery payloads
 - show custom coworker, skill, and MCP metadata with policy verdicts
 
 The browser must not create a second projection model. It consumes Cloud
@@ -134,8 +138,9 @@ branding, role, and feature metadata, and the HTTP server keeps the same CSP
 nonce boundary.
 
 There are no remaining vanilla feature scripts under `apps/website/src/client`.
-Projects, chat, coworkers, capabilities, playbooks, artifacts, admin/settings
-surfaces, and the browser theme switcher are React-owned in the browser bundle.
+Projects, chat, coworkers, capabilities, playbooks, channels, artifacts,
+admin/settings surfaces, and the browser theme switcher are React-owned in the
+browser bundle.
 New feature work must use the shared `AppAPI` contract from
 `packages/shared/src/app-api.ts`, `AppApiProvider` / `useAppApi()` from
 `@open-cowork/ui/app-api`, and the Cloud fetch/SSE adapter in
@@ -202,7 +207,8 @@ parity, not pixel-perfect screenshots.
 - Cards, panels, tables, rows, badges, notices, empty states, focus rings, and
   destructive/primary/secondary controls read like Desktop primitives.
 - Projects, chat, runtime status, approvals, questions, coworkers, tools,
-  skills, playbooks, and artifacts map to the Desktop/Cloud parity matrix.
+  skills, playbooks, channels, and artifacts map to the Desktop/Cloud parity
+  matrix.
 - Org, members, policy, BYOK, connections, gateway, billing, audit, usage, and
   diagnostics map to the admin/settings surface matrix.
 - `/assets/open-cowork-cloud-react.js` mounts the React controller for

--- a/packages/shared/src/app-api.ts
+++ b/packages/shared/src/app-api.ts
@@ -79,6 +79,11 @@ export type AppAPI = AppApiEndpointResolver & {
     validate: (input: unknown) => Promise<unknown>
     uploadSnapshot: (input: unknown) => Promise<unknown>
   }
+  channels: {
+    agents: () => Promise<unknown>
+    bindings: () => Promise<unknown>
+    deliveries: () => Promise<unknown>
+  }
   admin: {
     policy: () => Promise<unknown>
     members: {


### PR DESCRIPTION
## Summary
- Add a member-facing, read-only Cloud Web `Channels` Studio route for connected channel agents, bindings, delivery status, and linked run chats.
- Extend the shared `AppAPI` contract with read-only channel endpoints while keeping setup, retry, dead-letter, and credential mutation under Admin Gateway.
- Update route/API and Desktop parity contracts, docs, browser/perf/render coverage, and bounded module enforcement.

## OpenCode boundary
Cloud Web remains a Cloud API client. This route reads tenant-scoped channel state only and does not introduce browser-owned runtime state, local filesystem access, local provider keys, local stdio MCP execution, or Desktop runtime mutation.

## Verification
- `pnpm --filter @open-cowork/website test`
- `pnpm test:cloud-web`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm docs:build`
- `pnpm test`
- `pnpm test:coverage:node`
- `git diff --check`

## Review
- Manual diff review completed.
- Structured autoreview was attempted with `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local`, but the Codex review engine hit an account usage limit before returning structured findings.

Refs #779