### PR TITLE
Add Studio production QA contract

### DIFF
--- a/apps/website/src/modularity.test.ts
+++ b/apps/website/src/modularity.test.ts
@@ -54,6 +54,7 @@ test('cloud web workbench production source stays split into bounded modules', (
     'style-primitives.ts',
     'style-shared-ui.ts',
     'styles.ts',
+    'studio-production-qa.ts',
     'surface-workbench.ts',
     'thread-workbench.ts',
     'workbench-parity.ts',

--- a/apps/website/src/studio-production-qa.test.ts
+++ b/apps/website/src/studio-production-qa.test.ts
@@ -1,0 +1,132 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { CLOUD_WEB_ROUTES } from './app-shell.ts'
+import { cloudWebsiteHtml } from './render.ts'
+import {
+  OPENWIKI_DEFERRAL_CONTRACT,
+  STUDIO_PRODUCTION_AUDIT_CHECKLIST,
+  STUDIO_VISUAL_QA_MATRIX,
+  type StudioProductionAuditEntry,
+  type StudioQaState,
+  type StudioVisualQaEntry,
+} from './studio-production-qa.ts'
+
+const workbenchDocPath = new URL('../../../docs/cloud-web-workbench.md', import.meta.url)
+const releaseChecklistPath = new URL('../../../docs/release-checklist.md', import.meta.url)
+const repoRoot = new URL('../../../', import.meta.url)
+
+function markdownTableCell(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
+}
+
+function studioVisualQaDocRow(entry: StudioVisualQaEntry) {
+  const routes = entry.routeIds.map((routeId) => `\`${routeId}\``).join(', ')
+  const states = entry.states.map((state) => `\`${state}\``).join(', ')
+  return `| ${markdownTableCell(entry.label)} | ${routes} | ${markdownTableCell(entry.desktopSurface)} | ${markdownTableCell(entry.cloudCheck)} | ${states} | ${markdownTableCell(entry.boundary)} |`
+}
+
+function studioProductionAuditDocRow(entry: StudioProductionAuditEntry) {
+  const evidence = entry.evidence.map((item) => `\`${item}\``).join(', ')
+  return `| \`${entry.id}\` | ${markdownTableCell(entry.requirement)} | ${evidence} |`
+}
+
+function repoEvidenceExists(path: string) {
+  return existsSync(fileURLToPath(new URL(path, repoRoot)))
+}
+
+test('studio production QA matrix covers every Cloud Web route, state class, and documented row', () => {
+  const doc = readFileSync(fileURLToPath(workbenchDocPath), 'utf8')
+  const routeIds = new Set(CLOUD_WEB_ROUTES.map((route) => route.id))
+  const coveredRouteIds = new Set(STUDIO_VISUAL_QA_MATRIX.flatMap((entry) => entry.routeIds))
+  const coveredStates = new Set(STUDIO_VISUAL_QA_MATRIX.flatMap((entry) => entry.states))
+  const requiredStates: StudioQaState[] = [
+    'loading',
+    'empty',
+    'error',
+    'disabled',
+    'permission-gated',
+    'offline-disconnected',
+    'retry',
+    'destructive-confirmation',
+    'one-time-reveal',
+  ]
+
+  assert.match(doc, /Studio Production Visual QA Matrix/)
+  assert.match(doc, /Production Audit Checklist/)
+  assert.equal(STUDIO_VISUAL_QA_MATRIX.length, 8)
+
+  for (const routeId of routeIds) {
+    assert.ok(coveredRouteIds.has(routeId), `${routeId} has a Studio visual QA entry`)
+  }
+  for (const routeId of coveredRouteIds) {
+    assert.ok(routeIds.has(routeId), `${routeId} is an existing Cloud Web route`)
+  }
+  for (const state of requiredStates) {
+    assert.ok(coveredStates.has(state), `${state} state is part of production visual QA`)
+  }
+
+  for (const entry of STUDIO_VISUAL_QA_MATRIX) {
+    assert.deepEqual(entry.viewports, ['desktop', 'tablet', 'mobile'], `${entry.id} covers all release viewports`)
+    assert.ok(entry.desktopSurface, `${entry.id} names the Desktop surface`)
+    assert.ok(entry.cloudCheck, `${entry.id} names the Cloud Web check`)
+    assert.ok(entry.boundary, `${entry.id} documents the product/runtime boundary`)
+    assert.ok(entry.evidence.length > 0, `${entry.id} lists automated evidence`)
+    assert.ok(doc.includes(studioVisualQaDocRow(entry)), `docs list exact Studio visual QA row for ${entry.id}`)
+    for (const evidence of entry.evidence) {
+      assert.ok(repoEvidenceExists(evidence), `${entry.id} evidence exists: ${evidence}`)
+    }
+  }
+})
+
+test('studio production audit checklist is documented and points at real evidence', () => {
+  const doc = readFileSync(fileURLToPath(workbenchDocPath), 'utf8')
+  const checklistIds = new Set(STUDIO_PRODUCTION_AUDIT_CHECKLIST.map((entry) => entry.id))
+  const requiredIds = [
+    'canonical-shared-tokens',
+    'shared-primitives-first',
+    'shared-product-vocabulary',
+    'cloud-api-client-only',
+    'admin-not-default-path',
+    'safe-redaction',
+    'honest-performance-budgets',
+    'docs-match-shipped-behavior',
+  ]
+
+  assert.deepEqual([...checklistIds].sort(), requiredIds.sort())
+  for (const entry of STUDIO_PRODUCTION_AUDIT_CHECKLIST) {
+    assert.ok(doc.includes(studioProductionAuditDocRow(entry)), `docs list exact production audit row for ${entry.id}`)
+    for (const evidence of entry.evidence) {
+      assert.ok(repoEvidenceExists(evidence), `${entry.id} evidence exists: ${evidence}`)
+    }
+  }
+})
+
+test('OpenWiki Knowledge is explicitly deferred without route, CTA, or runtime coupling', () => {
+  const doc = readFileSync(fileURLToPath(workbenchDocPath), 'utf8')
+  const releaseChecklist = readFileSync(fileURLToPath(releaseChecklistPath), 'utf8')
+  const html = cloudWebsiteHtml({
+    role: 'web',
+    profileName: 'default',
+    features: {
+      chat: true,
+      workflows: true,
+    },
+  })
+
+  assert.equal(OPENWIKI_DEFERRAL_CONTRACT.status, 'deferred')
+  assert.deepEqual(OPENWIKI_DEFERRAL_CONTRACT.routeIds, [])
+  assert.deepEqual(OPENWIKI_DEFERRAL_CONTRACT.visibleCtas, [])
+  assert.deepEqual(OPENWIKI_DEFERRAL_CONTRACT.runtimeDependencies, [])
+  assert.match(doc, /OpenWiki\/Knowledge Deferral/)
+  assert.match(doc, /Knowledge\/OpenWiki is intentionally deferred/)
+  assert.match(doc, /no Cloud Web route,\s+no visible CTA, no runtime dependency, and no data-sync claim/)
+  assert.match(releaseChecklist, /OpenWiki\/Knowledge deferral/)
+  assert.doesNotMatch(html, /OpenWiki|Knowledge/)
+  assert.doesNotMatch(html, /data-route-panel="(?:knowledge|openwiki|wiki)"/i)
+  for (const route of CLOUD_WEB_ROUTES) {
+    assert.doesNotMatch(route.id, /knowledge|openwiki|wiki/i)
+    assert.doesNotMatch(route.label, /Knowledge|OpenWiki|Wiki/)
+  }
+})

--- a/apps/website/src/studio-production-qa.ts
+++ b/apps/website/src/studio-production-qa.ts
@@ -1,0 +1,188 @@
+import type { CloudWebRouteId } from './app-shell.ts'
+
+export type StudioQaViewport = 'desktop' | 'tablet' | 'mobile'
+
+export type StudioQaState =
+  | 'loading'
+  | 'empty'
+  | 'error'
+  | 'disabled'
+  | 'permission-gated'
+  | 'offline-disconnected'
+  | 'retry'
+  | 'destructive-confirmation'
+  | 'one-time-reveal'
+
+export type StudioVisualQaEntry = {
+  id: string
+  label: string
+  routeIds: CloudWebRouteId[]
+  desktopSurface: string
+  cloudCheck: string
+  states: StudioQaState[]
+  boundary: string
+  evidence: string[]
+  viewports: StudioQaViewport[]
+}
+
+export type StudioProductionAuditEntry = {
+  id: string
+  requirement: string
+  evidence: string[]
+}
+
+export type OpenWikiDeferralContract = {
+  id: 'openwiki-knowledge'
+  status: 'deferred'
+  routeIds: CloudWebRouteId[]
+  visibleCtas: string[]
+  runtimeDependencies: string[]
+  contract: string
+  releaseRequirement: string
+}
+
+const allViewports: StudioQaViewport[] = ['desktop', 'tablet', 'mobile']
+
+export const STUDIO_VISUAL_QA_MATRIX: StudioVisualQaEntry[] = [
+  {
+    id: 'home-chat-composer',
+    label: 'Home, Chat, and composer',
+    routeIds: ['chat'],
+    desktopSurface: 'Home and Chat composer-first runtime surface',
+    cloudCheck: 'Default route opens to chat, shows coworker selection, disables signed-out send controls, and submits prompts through Cloud commands after auth.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'offline-disconnected', 'retry'],
+    boundary: 'Cloud Web consumes Cloud session projections and commands only; OpenCode owns session execution and event semantics.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/browser-e2e.test.ts', 'apps/website/src/browser-real-e2e.spec.ts'],
+    viewports: allViewports,
+  },
+  {
+    id: 'projects-and-thread-history',
+    label: 'Projects and thread history',
+    routeIds: ['threads'],
+    desktopSurface: 'Projects with recent chats, project context, filters, and reopen actions',
+    cloudCheck: 'Thread list, filters, selected objective, project-source status, bounded loading, and Load more behavior match the Desktop Studio vocabulary.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'offline-disconnected', 'retry'],
+    boundary: 'Browser project sources stay cloud-safe; local host paths are never inferred, uploaded, or rendered as available Cloud context.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/browser-e2e.test.ts', 'tests/cloud-http-server.test.ts'],
+    viewports: allViewports,
+  },
+  {
+    id: 'runtime-review-and-approvals',
+    label: 'Runtime review, approvals, and questions',
+    routeIds: ['chat', 'artifacts'],
+    desktopSurface: 'Chat transcript, task lanes, approvals, questions, todos, runtime status, cost, tokens, and review panel',
+    cloudCheck: 'Messages, delegated specialist lanes, running/completed/error task states, approval/question cards, deliverables, todos, artifacts, cost, token usage, and follow-up actions are visible from Cloud projections.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'offline-disconnected', 'retry', 'destructive-confirmation'],
+    boundary: 'Approval and question semantics remain OpenCode-owned; Cloud Web only submits tenant-scoped responses through Cloud API endpoints.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/react-workbench.test.ts', 'tests/cloud-session-projection-contract.test.ts'],
+    viewports: allViewports,
+  },
+  {
+    id: 'coworkers-tools-and-skills',
+    label: 'Coworkers, tools, and skills',
+    routeIds: ['agents', 'capabilities'],
+    desktopSurface: 'Team and Tools & Skills capability catalog',
+    cloudCheck: 'Coworker cards, picker states, linked skills, linked tools, MCP policy verdicts, and Start chat actions use the shared Studio primitive language.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'retry'],
+    boundary: 'Cloud Web renders policy-safe metadata only and cannot edit local custom agent files or spawn local stdio MCPs.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/react-workbench.test.ts', 'apps/website/src/accessibility.test.ts'],
+    viewports: allViewports,
+  },
+  {
+    id: 'playbooks-and-runs',
+    label: 'Playbooks and runs',
+    routeIds: ['workflows'],
+    desktopSurface: 'Playbooks list, saved workflow setup chats, run controls, and run history',
+    cloudCheck: 'Playbook cards, run rows, pause/resume/archive actions, empty states, and blocked policy copy behave like Desktop workflows while staying browser-bounded.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'offline-disconnected', 'retry', 'destructive-confirmation'],
+    boundary: 'Cloud Web runs saved playbooks through Cloud workflow APIs; OpenCode-native agents still execute the work.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/browser-e2e.test.ts', 'tests/cloud-http-server.test.ts'],
+    viewports: allViewports,
+  },
+  {
+    id: 'channels-and-artifacts',
+    label: 'Channels and artifacts',
+    routeIds: ['channels', 'artifacts', 'chat'],
+    desktopSurface: 'Channel status, linked run chats, artifact cards, and review-first artifact previews',
+    cloudCheck: 'Connected channel coworkers, bindings, delivery status, sanitized artifact metadata, explicit view/download actions, and selected-chat previews stay reachable without admin controls.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'offline-disconnected', 'retry'],
+    boundary: 'Provider payloads, signed URLs, object-store internals, channel secrets, and delivery targets are stripped before rendering.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/react-workbench.test.ts', 'apps/website/src/browser-real-e2e.spec.ts'],
+    viewports: allViewports,
+  },
+  {
+    id: 'team-and-member-admin-boundary',
+    label: 'Team and member admin boundary',
+    routeIds: ['org', 'members', 'policy', 'usage'],
+    desktopSurface: 'Desktop account, Team context, Settings policy, Health Center, and usage summaries',
+    cloudCheck: 'Org profile, member rows, invite/role controls, policy summaries, usage quotas, and worker health are visually grouped under Admin without dominating the default Studio path.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'retry', 'destructive-confirmation'],
+    boundary: 'Browser disabled controls are ergonomic only; Cloud API authorization remains server-side and tenant-scoped.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/react-integration.test.ts', 'apps/website/src/app-api.test.ts'],
+    viewports: allViewports,
+  },
+  {
+    id: 'secrets-gateway-audit-diagnostics',
+    label: 'Secrets, Gateway, audit, and diagnostics',
+    routeIds: ['byok', 'connections', 'billing', 'gateway', 'audit', 'diagnostics'],
+    desktopSurface: 'Desktop Cloud connection setup, Gateway pairing, provider credentials, billing, audit, and Health Center support bundle surfaces',
+    cloudCheck: 'BYOK write-only rotation, one-time token reveal, gateway delivery controls, billing portal actions, audit export, diagnostics redaction, confirmations, and settled disabled states are visible and keyboard-reachable.',
+    states: ['loading', 'empty', 'error', 'disabled', 'permission-gated', 'offline-disconnected', 'retry', 'destructive-confirmation', 'one-time-reveal'],
+    boundary: 'Raw secrets, provider keys, auth headers, signed URLs, object-store internals, local paths, command lines, and environment variables must not render outside intentional safe reveal flows.',
+    evidence: ['apps/website/src/render.test.ts', 'apps/website/src/react-integration.test.ts', 'tests/cloud-http-server.test.ts'],
+    viewports: allViewports,
+  },
+]
+
+export const STUDIO_PRODUCTION_AUDIT_CHECKLIST: StudioProductionAuditEntry[] = [
+  {
+    id: 'canonical-shared-tokens',
+    requirement: 'Shared design tokens are the only canonical Studio token source for Desktop and Cloud Web.',
+    evidence: ['packages/shared/src/design-tokens.ts', 'tests/design-tokens-sync.test.ts', 'docs/design-tokens.md'],
+  },
+  {
+    id: 'shared-primitives-first',
+    requirement: 'Shared Studio primitives are preferred before app-local component duplication.',
+    evidence: ['packages/ui/src/', 'docs/design-system.md', 'apps/website/src/modularity.test.ts'],
+  },
+  {
+    id: 'shared-product-vocabulary',
+    requirement: 'Desktop and Cloud Web use the same user-facing vocabulary for shared concepts.',
+    evidence: ['docs/desktop-app.md', 'docs/cloud-web-workbench.md', 'apps/website/src/workbench-parity.ts'],
+  },
+  {
+    id: 'cloud-api-client-only',
+    requirement: 'Cloud Web remains a Cloud API client and does not own execution, projection semantics, or OpenCode runtime behavior.',
+    evidence: ['apps/website/src/app-api.ts', 'apps/website/src/modularity.test.ts', 'docs/architecture.md'],
+  },
+  {
+    id: 'admin-not-default-path',
+    requirement: 'Admin/setup controls are explicit secondary surfaces and do not dominate the default user path.',
+    evidence: ['apps/website/src/app-shell.ts', 'apps/website/src/admin-surface-matrix.ts', 'docs/cloud-web-workbench.md'],
+  },
+  {
+    id: 'safe-redaction',
+    requirement: 'No raw secrets, signed URLs, object-store internals, local paths, command lines, environment variables, or provider payloads render outside intentional safe reveal flows.',
+    evidence: ['apps/website/src/route-api-matrix.ts', 'apps/website/src/render.test.ts', 'tests/cloud-http-server.test.ts'],
+  },
+  {
+    id: 'honest-performance-budgets',
+    requirement: 'Performance budgets stay honest for added routes, surfaces, large fixtures, and responsive layouts.',
+    evidence: ['apps/website/src/performance.test.ts', 'apps/website/src/modularity.test.ts', 'docs/cloud-web-workbench.md'],
+  },
+  {
+    id: 'docs-match-shipped-behavior',
+    requirement: 'Docs describe shipped behavior and explicit boundaries, not aspirational runtime behavior.',
+    evidence: ['docs/cloud-web-workbench.md', 'docs/release-checklist.md', 'apps/website/src/studio-production-qa.test.ts'],
+  },
+]
+
+export const OPENWIKI_DEFERRAL_CONTRACT: OpenWikiDeferralContract = {
+  id: 'openwiki-knowledge',
+  status: 'deferred',
+  routeIds: [],
+  visibleCtas: [],
+  runtimeDependencies: [],
+  contract: 'Knowledge/OpenWiki is intentionally deferred and ships with no Cloud Web route, no visible CTA, no runtime dependency, and no data-sync claim in this roadmap.',
+  releaseRequirement: 'Create a separate future roadmap before adding a Knowledge route, CTA, sync contract, local OpenWiki checkout dependency, or runtime integration.',
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,6 +139,13 @@ workspace authorities:
   runtime still executes; remote Gateway/mobile/Cloud callers only reach it
   through explicit, revocable pairing without public Desktop or OpenCode ports.
 
+Cloud Web's browser contract is documented in
+[Cloud Web Studio](cloud-web-workbench.md). Its route/API matrix, admin matrix,
+and production QA contract are product-surface gates only: they require Desktop
+and Cloud Web to share Studio vocabulary, design tokens, primitives, and visible
+state coverage while keeping OpenCode as the execution authority and the Cloud
+API as the browser boundary.
+
 A thread belongs to exactly one workspace. Local threads do not become cloud
 threads unless a user intentionally creates or imports cloud-safe content
 through an explicit product flow. Normal sync is product-state sync, not

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -203,6 +203,24 @@ For visual or surface-organization changes, compare Cloud Web and Desktop
 side-by-side before merge. The expected match is product language and workflow
 parity, not pixel-perfect screenshots.
 
+The typed source of truth for release visual QA is
+`apps/website/src/studio-production-qa.ts`. The matrix below must cover every
+Cloud Web route at desktop, tablet, and mobile widths. Tests assert every row so
+the checklist cannot drift from the source contract.
+
+## Studio Production Visual QA Matrix
+
+| Surface | Cloud route(s) | Desktop surface | Cloud Web check | Required states | Product boundary |
+|---|---|---|---|---|---|
+| Home, Chat, and composer | `chat` | Home and Chat composer-first runtime surface | Default route opens to chat, shows coworker selection, disables signed-out send controls, and submits prompts through Cloud commands after auth. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `offline-disconnected`, `retry` | Cloud Web consumes Cloud session projections and commands only; OpenCode owns session execution and event semantics. |
+| Projects and thread history | `threads` | Projects with recent chats, project context, filters, and reopen actions | Thread list, filters, selected objective, project-source status, bounded loading, and Load more behavior match the Desktop Studio vocabulary. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `offline-disconnected`, `retry` | Browser project sources stay cloud-safe; local host paths are never inferred, uploaded, or rendered as available Cloud context. |
+| Runtime review, approvals, and questions | `chat`, `artifacts` | Chat transcript, task lanes, approvals, questions, todos, runtime status, cost, tokens, and review panel | Messages, delegated specialist lanes, running/completed/error task states, approval/question cards, deliverables, todos, artifacts, cost, token usage, and follow-up actions are visible from Cloud projections. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `offline-disconnected`, `retry`, `destructive-confirmation` | Approval and question semantics remain OpenCode-owned; Cloud Web only submits tenant-scoped responses through Cloud API endpoints. |
+| Coworkers, tools, and skills | `agents`, `capabilities` | Team and Tools & Skills capability catalog | Coworker cards, picker states, linked skills, linked tools, MCP policy verdicts, and Start chat actions use the shared Studio primitive language. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `retry` | Cloud Web renders policy-safe metadata only and cannot edit local custom agent files or spawn local stdio MCPs. |
+| Playbooks and runs | `workflows` | Playbooks list, saved workflow setup chats, run controls, and run history | Playbook cards, run rows, pause/resume/archive actions, empty states, and blocked policy copy behave like Desktop workflows while staying browser-bounded. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `offline-disconnected`, `retry`, `destructive-confirmation` | Cloud Web runs saved playbooks through Cloud workflow APIs; OpenCode-native agents still execute the work. |
+| Channels and artifacts | `channels`, `artifacts`, `chat` | Channel status, linked run chats, artifact cards, and review-first artifact previews | Connected channel coworkers, bindings, delivery status, sanitized artifact metadata, explicit view/download actions, and selected-chat previews stay reachable without admin controls. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `offline-disconnected`, `retry` | Provider payloads, signed URLs, object-store internals, channel secrets, and delivery targets are stripped before rendering. |
+| Team and member admin boundary | `org`, `members`, `policy`, `usage` | Desktop account, Team context, Settings policy, Health Center, and usage summaries | Org profile, member rows, invite/role controls, policy summaries, usage quotas, and worker health are visually grouped under Admin without dominating the default Studio path. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `retry`, `destructive-confirmation` | Browser disabled controls are ergonomic only; Cloud API authorization remains server-side and tenant-scoped. |
+| Secrets, Gateway, audit, and diagnostics | `byok`, `connections`, `billing`, `gateway`, `audit`, `diagnostics` | Desktop Cloud connection setup, Gateway pairing, provider credentials, billing, audit, and Health Center support bundle surfaces | BYOK write-only rotation, one-time token reveal, gateway delivery controls, billing portal actions, audit export, diagnostics redaction, confirmations, and settled disabled states are visible and keyboard-reachable. | `loading`, `empty`, `error`, `disabled`, `permission-gated`, `offline-disconnected`, `retry`, `destructive-confirmation`, `one-time-reveal` | Raw secrets, provider keys, auth headers, signed URLs, object-store internals, local paths, command lines, and environment variables must not render outside intentional safe reveal flows. |
+
 - App shell, sidebar, topbar, active route, status text, and density use the
   same dark product language.
 - Cards, panels, tables, rows, badges, notices, empty states, focus rings, and
@@ -226,3 +244,31 @@ parity, not pixel-perfect screenshots.
 - `/assets/open-cowork-cloud-react.js` returns the Vite-built React client
   asset, and the real-browser smoke verifies that the nonce'd module route is
   requested and can mount the controller for `#open-cowork-cloud-react-root`.
+
+## Production Audit Checklist
+
+The typed source of truth is `apps/website/src/studio-production-qa.ts`. This
+checklist is the closeout audit for Studio parity work before the roadmap can
+be considered complete.
+
+| Check id | Requirement | Evidence |
+|---|---|---|
+| `canonical-shared-tokens` | Shared design tokens are the only canonical Studio token source for Desktop and Cloud Web. | `packages/shared/src/design-tokens.ts`, `tests/design-tokens-sync.test.ts`, `docs/design-tokens.md` |
+| `shared-primitives-first` | Shared Studio primitives are preferred before app-local component duplication. | `packages/ui/src/`, `docs/design-system.md`, `apps/website/src/modularity.test.ts` |
+| `shared-product-vocabulary` | Desktop and Cloud Web use the same user-facing vocabulary for shared concepts. | `docs/desktop-app.md`, `docs/cloud-web-workbench.md`, `apps/website/src/workbench-parity.ts` |
+| `cloud-api-client-only` | Cloud Web remains a Cloud API client and does not own execution, projection semantics, or OpenCode runtime behavior. | `apps/website/src/app-api.ts`, `apps/website/src/modularity.test.ts`, `docs/architecture.md` |
+| `admin-not-default-path` | Admin/setup controls are explicit secondary surfaces and do not dominate the default user path. | `apps/website/src/app-shell.ts`, `apps/website/src/admin-surface-matrix.ts`, `docs/cloud-web-workbench.md` |
+| `safe-redaction` | No raw secrets, signed URLs, object-store internals, local paths, command lines, environment variables, or provider payloads render outside intentional safe reveal flows. | `apps/website/src/route-api-matrix.ts`, `apps/website/src/render.test.ts`, `tests/cloud-http-server.test.ts` |
+| `honest-performance-budgets` | Performance budgets stay honest for added routes, surfaces, large fixtures, and responsive layouts. | `apps/website/src/performance.test.ts`, `apps/website/src/modularity.test.ts`, `docs/cloud-web-workbench.md` |
+| `docs-match-shipped-behavior` | Docs describe shipped behavior and explicit boundaries, not aspirational runtime behavior. | `docs/cloud-web-workbench.md`, `docs/release-checklist.md`, `apps/website/src/studio-production-qa.test.ts` |
+
+## OpenWiki/Knowledge Deferral
+
+Knowledge/OpenWiki is intentionally deferred and ships with no Cloud Web route,
+no visible CTA, no runtime dependency, and no data-sync claim in this roadmap.
+Do not add a placeholder that implies wiki content is synced, indexed, or
+available to OpenCode. Do not couple Cloud Web, Desktop, Gateway, or the Cloud
+API to a local OpenWiki checkout while this contract is in force.
+
+Create a separate future roadmap before adding a Knowledge route, CTA, sync
+contract, local OpenWiki checkout dependency, or runtime integration.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -89,6 +89,13 @@ React-owned; the old vanilla feature-script directory has been retired. New
 React feature code should use `useAppApi()` instead of direct `fetch`,
 `EventSource`, or `window.coworkApi` access.
 
+The production visual QA contract for shared Studio surfaces lives in
+`apps/website/src/studio-production-qa.ts` and is documented in
+[Cloud Web Studio](cloud-web-workbench.md). It is a parity gate, not a new
+runtime contract: OpenCode still owns execution, while Desktop and Cloud Web
+must share the same visual language, product vocabulary, primitive usage, and
+state coverage.
+
 ## Accessibility Gates
 
 CI runs `pnpm lint:a11y --max-warnings=0` and the focused renderer accessibility smoke tests. The smoke helper explicitly enables axe `color-contrast`, so contrast regressions are part of the required test gate.

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -207,3 +207,10 @@ Settings holds lower-frequency configuration:
 
 Settings should configure the core surfaces without introducing separate
 product concepts.
+
+Cloud Web shares this Studio vocabulary and visual language for Cloud
+workspaces. The route/API matrix, Desktop/Cloud parity matrix, admin/settings
+surface matrix, and production visual QA checklist live in
+[Cloud Web Studio](cloud-web-workbench.md). Those contracts keep Cloud Web
+chat-first and Desktop-aligned while preserving the OpenCode boundary:
+Cloud Web remains a Cloud API client, not an execution runtime.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -189,10 +189,24 @@ and linked from the release Go/No-Go report.
       decision, Accepted Launch Tier, Known limits, Cost and scaling notes,
       Final smoke status, and Findings Workflow.
 - [ ] final Cloud Web/Desktop/Gateway smoke gates passed after the soak run.
-- [ ] Cloud Web and Desktop visual parity checklist completed from
-      `docs/cloud-web-workbench.md`: shell/nav/topbar, cards/panels, controls,
-      chat/thread runtime surfaces, admin/settings surfaces, responsive layout,
-      loading/empty/error states, and `/assets/fonts/*.woff2` font loading.
+- [ ] Cloud Web and Desktop visual parity checklist completed from the Studio
+      Production Visual QA Matrix in `docs/cloud-web-workbench.md`: Home/Chat
+      and composer, Projects/thread history, runtime review, approvals,
+      questions, coworker picker/cards, delegated specialist lanes, Team,
+      Playbooks, Tools & Skills, Channels, Artifacts, Settings/Admin,
+      BYOK/token/Gateway/audit/diagnostics, responsive desktop/tablet/mobile
+      layout, loading/empty/error/disabled/permission/offline/retry states,
+      destructive confirmations, one-time reveal flows, and
+      `/assets/fonts/*.woff2` font loading.
+- [ ] Studio production audit checklist completed from
+      `docs/cloud-web-workbench.md`: canonical shared tokens, shared Studio
+      primitives, shared product vocabulary, Cloud API client-only browser
+      boundary, secondary Admin path, safe redaction, honest performance
+      budgets, and docs that describe shipped behavior only.
+- [ ] OpenWiki/Knowledge deferral verified: no Cloud Web route, no visible CTA,
+      no runtime dependency, no data-sync claim, no local OpenWiki checkout
+      coupling, and a separate future roadmap exists before any Knowledge work
+      starts.
 
 ## Tagged release
 


### PR DESCRIPTION
## Summary

- Add a typed Studio production QA contract for Cloud Web route/state coverage, production audit checks, and OpenWiki/Knowledge deferral.
- Add doc-backed tests that keep the visual QA matrix, audit checklist, and deferred Knowledge boundary synchronized with source.
- Expand Cloud Web, design system, desktop, architecture, and release checklist docs with the production QA and OpenCode boundary language.

## Validation

- pnpm --filter @open-cowork/website test
- pnpm test:cloud-web
- pnpm lint
- pnpm typecheck
- uv run mkdocs build --strict
- git diff --check
- pnpm test
- python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local

Closes #781